### PR TITLE
docs(machines): consolidate XState into coming-from-xstate.md; strip the scattered asides

### DIFF
--- a/docs/machines/actors.md
+++ b/docs/machines/actors.md
@@ -4,7 +4,7 @@ A machine doesn't have to be a singleton. When a state needs to run some self-co
 
 The pattern earns its keep when an activity has a *lifetime that should match a state's lifetime*: start it when you enter the state, and — this is the part that's easy to get wrong by hand — tear it down on **every** way out of the state, including the ones you forgot about. Declare the binding once and the runtime enforces it.
 
-> **Coming from XState?** This is `invoke` (a state-bound child) and `spawn` (a dynamically-created actor) — re-frame2 spells both as **`:spawn`**. The deeper shift: in XState an actor is a living object you `createActor(machine).start()` and hold a reference to, then `.send()` messages. In re-frame2 there is **no actor object**. A spawned actor's *liveness is its snapshot* — a plain value at `[:rf.runtime/machines :snapshots <actor-id>]` in the [frame's runtime-db](glossary.md#snapshot). You address it by `dispatch`-ing to its id, exactly like any other handler, and it reverts with the frame on time-travel. See [Coming from XState](coming-from-xstate.md) for the full delta.
+A spawned child can be **state-bound** — alive for exactly as long as a state is active — or **dynamically created**; re-frame2 spells both as **`:spawn`**. There is **no actor object**: a spawned actor's *liveness is its snapshot* — a plain value at `[:rf.runtime/machines :snapshots <actor-id>]` in the [frame's runtime-db](glossary.md#snapshot). You address it by `dispatch`-ing to its id, exactly like any other handler, and it reverts with the frame on time-travel.
 
 This page assumes you've met the [transition table, guards, actions, tags, and `:after`](concepts.md#guards-and-actions). If not, read [Concepts](concepts.md) first.
 
@@ -39,8 +39,6 @@ Here's the heart of the [websocket example](../../examples/patterns/websocket/):
 
 Enter `:active` → the runtime spawns a `:websocket/socket` actor. Leave `:active` by *any* door — `:ws/closed`, `:ws/fatal`, a frame teardown — and the runtime destroys it. The parent never wrote "spawn" or "destroy"; `:spawn` is **registration-time sugar** that rewrites the state's `:entry`/`:exit` into the imperative spawn/destroy effects you'll meet below. From the outside it's indistinguishable from a machine that wired those slots by hand.
 
-> **Mental model.** `:spawn` is XState's `invoke`. The child's lifetime is the state's lifetime. Renamed because "invoke" reads like a synchronous call, when what you create is a child actor with its own lifecycle.
-
 ### The spawn-spec keys
 
 The map under `:spawn` accepts:
@@ -59,7 +57,7 @@ The map under `:spawn` accepts:
 
 `:on-done` / `:on-error` are the completion story — they pair with the child declaring a `:final?` leaf. That's covered under [Final states](concepts.md#final-states-when-a-machine-is-done); the [API reference](../api/re-frame.machines.md) lists the exact shapes. Here we focus on the lifecycle: spawn, address, message, and tear down.
 
-> **Divergence to know.** XState lets `invoke` take a vector of children per state; re-frame2 allows **one `:spawn` per state** (use a compound state with one actor per substate, or [`:spawn-all`](#fan-out-and-join-with-spawn-all) for parallelism). XState's `autoForward` is omitted — forward events explicitly with `:fx [[:dispatch [child-id ev]]]`. And there's no `:onSnapshot` — read the child with the `[:rf/machine actor-id]` subscription.
+> **One `:spawn` per state.** A state node carries at most one `:spawn` — for multiple children, use a compound state with one actor per substate, or [`:spawn-all`](#fan-out-and-join-with-spawn-all) for parallelism. Events aren't auto-forwarded to children — forward them explicitly with `:fx [[:dispatch [child-id ev]]]`. To observe a child's snapshot, read it with the `[:rf/machine actor-id]` subscription.
 
 ---
 
@@ -94,7 +92,7 @@ The child reads these as ordinary `:data` lookups inside its actions. Here's the
     :open    {:on {:send {:action :send-via-socket}}}}})
 ```
 
-> **This is XState's `sendParent`.** In XState a child can address its parent without being told who it is; here the runtime stamps `:rf/parent-id` and the child reads it. **Caveat:** the stamp is written **only on the declarative `:spawn` / `:spawn-all` path**. A *hand-emitted* `[:rf.machine/spawn …]` (next section) records only `:rf/self-id` — there's no structural parent — so a hand-spawned child must be handed a correspondent address through its `:data`.
+> **Addressing the parent.** A child can address its parent without being told who it is — the runtime stamps `:rf/parent-id` and the child reads it. **Caveat:** the stamp is written **only on the declarative `:spawn` / `:spawn-all` path**. A *hand-emitted* `[:rf.machine/spawn …]` (next section) records only `:rf/self-id` — there's no structural parent — so a hand-spawned child must be handed a correspondent address through its `:data`.
 
 ---
 
@@ -123,7 +121,7 @@ You will reach for `:on-spawn` to "capture the child's id into `:data`" — and 
 When you *do* need the id addressable by name, the first-class mechanisms (in order of preference):
 
 1. **`:system-id`** — give the spawn a stable name; resolve and message it by that name (see [below](#cross-machine-messaging)). Best when you want a *role* rather than a gensym.
-2. **The `:rf/spawned` `:data` slot** — on every declarative `:spawn`, the runtime binds the new id into the *spawning* machine's own `:data` under `{:rf/spawned {<invoke-id> <actor-id>}}`. A later action reads it: `(get-in data [:rf/spawned [:active]])`. This is the re-frame2 spelling of XState's `const ref = spawn(child)` captured into `context` — except the id rides the revertible snapshot, not a live object.
+2. **The `:rf/spawned` `:data` slot** — on every declarative `:spawn`, the runtime binds the new id into the *spawning* machine's own `:data` under `{:rf/spawned {<invoke-id> <actor-id>}}`. A later action reads it: `(get-in data [:rf/spawned [:active]])`. The id rides the revertible snapshot, not a live object reference.
 3. **Self-dispatch from `:on-spawn`** — since `:on-spawn` *can* fire a side-effecting dispatch (just not return data), have it dispatch a self-event whose ordinary `:action` writes the id. This is the verified [websocket](../../examples/patterns/websocket/) pattern:
 
 ```clojure
@@ -153,8 +151,6 @@ There is **one** mechanism: `dispatch` by id. A spawned actor's id is a handler 
 ;; parent → child, or child → parent: same primitive.
 {:fx [[:dispatch [some-machine-id [:some-event payload]]]]}
 ```
-
-> **XState splits this into four primitives** — `sendTo(ref, ev)`, `sendParent(ev)`, the implicit reply via the returned child ref, and `system.get(id)`. re-frame2 subsumes all four under `dispatch`-by-id, with `:system-id` supplying the `system.get` analog.
 
 ### Addressing by name with `:system-id`
 
@@ -226,7 +222,7 @@ The runtime knows how to release exactly **three** framework-managed resource ki
 - **Armed `:after` timers** the actor scheduled — cancelled, so a killed worker won't wake up later.
 - **`:rf.resource/*` owner leases** the actor holds.
 
-> **Divergence from XState.** XState's stop-on-exit is total and substrate-agnostic — it cancels *whatever* the actor was doing. re-frame2's auto-cancel is narrower: the three kinds above, the ones the framework manages and so knows how to release. **Anything else** the child holds — a raw `setInterval`, a `js/WebSocket`, a Web Worker, a third-party SDK subscription — you release yourself, in the child's **`:exit` action**. It runs on every destroy cascade, so one line covers all five triggers:
+> **Auto-cancel covers three resource kinds.** re-frame2 auto-cancels exactly the three kinds above — the ones the framework manages, and so knows how to release. **Anything else** the child holds — a raw `setInterval`, a `js/WebSocket`, a Web Worker, a third-party SDK subscription — you release yourself, in the child's **`:exit` action**. It runs on every destroy cascade, so one line covers all five triggers:
 
 ```clojure
 {:connected
@@ -256,7 +252,7 @@ The [long-running-work example](../../examples/patterns/long_running_work/) show
 
 The timer is anchored to `:authenticating`'s **entry**, so it bounds the child's whole lifetime no matter how many times the child retries internally. When it fires, the state exits and the standard cancellation cascade destroys the in-flight child (aborting its HTTP). Three independent triggers — the user cancels, 30s elapses, or the frame is torn down — all route through the *same* teardown.
 
-> The same guard has a named-intent spelling, `:timeout "PT30S"` + `:on-timeout {:target :auth-failed}` (ISO-8601 durations), which **lowers onto the same `:after` timer**. Use whichever reads better; they're one mechanism. (XState's `"5s"` shorthand isn't accepted — ISO-8601 or integer milliseconds.)
+> The same guard has a named-intent spelling, `:timeout "PT30S"` + `:on-timeout {:target :auth-failed}` (ISO-8601 durations), which **lowers onto the same `:after` timer**. Use whichever reads better; they're one mechanism. (Durations are ISO-8601 or integer milliseconds; a bare `"5s"` shorthand isn't accepted.)
 
 ---
 
@@ -314,6 +310,6 @@ A few rules worth knowing:
 - **An unregistered child type fails the whole join closed** before any join-state is seeded — a child that can never run can never deadlock an `:all` join.
 - **Wall-clock timeout:** same as single `:spawn` — an `:after` on the `:spawn-all`-bearing state. When it fires, the exit cascade cancels every surviving child.
 
-> **Coming from XState:** there's no single XState primitive for this — you'd `invoke` several actors and coordinate `onDone` by hand, or model an explicit parallel region. `:spawn-all` packages the fan-out, the join condition, and the cancel-on-resolution cascade into one declaration.
+`:spawn-all` packages the fan-out, the join condition, and the cancel-on-resolution cascade into one declaration.
 
 ---

--- a/docs/machines/automatic-transitions.md
+++ b/docs/machines/automatic-transitions.md
@@ -6,12 +6,12 @@ These are the statechart features that let a machine *drive itself*: a form that
 
 There are four authoring grammars, and underneath them just **two engines**:
 
-| You want… | Reach for | Fires when | In XState |
-|---|---|---|---|
-| "the instant condition X holds, go to Y" | `:always` | a guard turns true, re-checked after every transition into the state | `always` (SCXML calls it *transient*) |
-| "a decision node that routes on entry and never lingers" | `:type :choice` | entry — first guard-passing candidate wins | a *choice* / transient state |
-| "after N ms in this state, do Z" | `:after` | a wall-clock delay measured from state entry elapses | `after` (delayed transitions) |
-| "this state (or its child) must finish in time" | `:timeout` / `:on-timeout` | a fixed deadline from entry passes | an `after` transition, named |
+| You want… | Reach for | Fires when |
+|---|---|---|
+| "the instant condition X holds, go to Y" | `:always` | a guard turns true, re-checked after every transition into the state |
+| "a decision node that routes on entry and never lingers" | `:type :choice` | entry — first guard-passing candidate wins |
+| "after N ms in this state, do Z" | `:after` | a wall-clock delay measured from state entry elapses |
+| "this state (or its child) must finish in time" | `:timeout` / `:on-timeout` | a fixed deadline from entry passes |
 
 > **Four grammars, two engines.** `:type :choice` is sugar that **desugars to `:always`**; `:timeout` / `:on-timeout` is sugar that **desugars to `:after`**. So everything on this page runs on one of two mechanisms: the **guard-driven microstep loop** (`:always`, `:choice`) and the **wall-clock timer** (`:after`, `:timeout`). One fact, one mechanism — the extra grammars exist only to *name the author's intent* so tools and diagrams can read it.
 
@@ -57,7 +57,7 @@ This is classic statechart **macrostep** semantics: the externally-observable tr
 
 A few rules keep the loop well-behaved — and keep your typos loud at registration time, not on the unlucky dispatch:
 
-- **`:always` settles before the next raised event.** If an action both `:raise`s an event `R` and lands in a state whose `:always` is enabled, the `:always` is taken **first**; `R` is then handled in the post-`:always` state. Raised events otherwise drain FIFO. (This matches XState v5/SCXML exactly.)
+- **`:always` settles before the next raised event.** If an action both `:raise`s an event `R` and lands in a state whose `:always` is enabled, the `:always` is taken **first**; `R` is then handled in the post-`:always` state. Raised events otherwise drain FIFO. (This matches SCXML exactly.)
 - **Bounded depth.** The loop is capped (default **16** microsteps, configurable per machine via `:always-depth-limit`). A non-converging cycle trips `:rf.error/machine-always-depth-exceeded` and **fails the whole macrostep** — the snapshot is never written, so the transition rolls back atomically. It is a failure, not a silent no-op, so a runaway cycle is distinguishable from an ordinary guard-blocked decline.
 - **No self-target.** An `:always` whose `:target` resolves to its own declaring state is **rejected at `reg-machine` time** (`:rf.error/machine-always-self-loop`) — guarded or not. An eventless transition back into the state you just entered either loops to the depth limit or is a no-op; either way the author meant something else.
 
@@ -81,7 +81,7 @@ The [WebSocket example](../../examples/patterns/websocket/README.md) uses `:alwa
 
 `:reconnecting` carries **both** `:always` and `:after` — they're independent state-node slots and coexist freely. And `:connected`'s `:always` is the targetless-action form: its `:flush-queue` action clears the queue, the guard goes false, and the microstep loop settles — no extra state needed.
 
-> **Coming from XState.** XState calls these `always` transitions (SCXML's *transient* transitions); re-frame2 keeps the name `:always`. Same idea, same first-match-wins ordering. `:always` is **not** a substitute for `:after`: `:always` fires on guard *truth*, `:after` fires on elapsed *time*.
+`:always` is **not** a substitute for `:after`: `:always` fires on guard *truth*, `:after` fires on elapsed *time*.
 
 ## `:type :choice` — a decision node that never lingers
 
@@ -107,7 +107,7 @@ Under the hood, `:type :choice` / `:choice` **desugars to an ordinary state with
 
 ### Divergence: a declarative array, not a `choice` function
 
-> **This is a deliberate departure from XState.** XState lets a choice/transient state's routing be expressed as a `choice` **function**. re-frame2 **rejects that**: a function may never be the edge. `:choice` is a **declarative guarded-candidate array** `[{:guard … :target …}]` — the edge topology stays *data*, so diagrams, model tests, conformance fixtures, and AI tools can read the routing without executing it. A function-valued `:choice` fails loud at registration with `:rf.error/machine-bad-choice`. This is behavioural parity (an immediate routing node) without API-mimicry (the JS function form) — see [Where it diverges](coming-from-xstate.md#where-it-diverges--and-why).
+re-frame2 requires a choice node's routing to be a **declarative guarded-candidate array** `[{:guard … :target …}]`, never a function — a function may never be the edge. The edge topology stays *data*, so diagrams, model tests, conformance fixtures, and AI tools can read the routing without executing it. A function-valued `:choice` fails loud at registration with `:rf.error/machine-bad-choice`.
 
 ### What the runtime checks
 
@@ -167,7 +167,7 @@ Every `:after` timer counts independently from the moment the machine **enters t
 
 A state can have several triggers racing at once — multiple `:after` timers, the state's `:on` events, an `:always`, a [spawned](glossary.md#spawn) child completing. **Whichever fires first wins**; the resulting state exit cancels the rest as part of the normal exit cascade.
 
-> **A same-tick tie diverges from XState.** When two `:after` timers with different delays happen to fire in the same scheduler tick, the order they reach the router is the *host scheduler's* order — not document order. XState/SCXML resolve simultaneously-enabled transitions by document order; re-frame2 `:after` timers are real host-clock deferred events, so it's "first valid timer to arrive wins; the transition makes the rest stale." Don't rely on declaration order to break a same-tick `:after` tie.
+> **A same-tick tie has no document-order guarantee.** When two `:after` timers with different delays happen to fire in the same scheduler tick, the order they reach the router is the *host scheduler's* order — not document order. SCXML resolves simultaneously-enabled transitions by document order; re-frame2 `:after` timers are real host-clock deferred events, so it's "first valid timer to arrive wins; the transition makes the rest stale." Don't rely on declaration order to break a same-tick `:after` tie.
 
 ### No cancel flag: epoch-based staleness
 
@@ -210,8 +210,6 @@ Each visit to `:reconnecting` reads the *current* `:retries` and waits longer th
 
 `:after` deliberately does **not** include: recurring timers (re-enter the state to re-arm), calendar/wall-clock-time scheduling (it's relative to *entry*, not "9 AM tomorrow"), or pause/resume (transition out and back in).
 
-> **Coming from XState.** XState calls these `after` (delayed) transitions; re-frame2 keeps the name. XState also accepts named-delay maps and a `"5s"` shorthand string — re-frame2's `:after` keys are integer-ms / subscription-vector / fn instead (see the duration note below).
-
 ## `:timeout` / `:on-timeout` — a named deadline
 
 A state — or a [`:spawn`](glossary.md#spawn) spec — may declare a `:timeout` duration plus an `:on-timeout` transition. It names a single fact: "this state (or its spawned child) must finish before this time." It reads more clearly than a bare `:after` entry when the intent really is a deadline.
@@ -223,7 +221,7 @@ A state — or a [`:spawn`](glossary.md#spawn) spec — may declare a `:timeout`
    :on-timeout {:target :timed-out}}
 
   :loading
-  {:spawn {:machine-id :fetch-user          ;; XState's `invoke` is re-frame2's `:spawn`
+  {:spawn {:machine-id :fetch-user          ;; spawn a child machine
            :timeout    "PT10S"              ;; the child must finish within 10 s…
            :on-timeout {:target :timed-out}}}}}  ;; …or we bail
 ```
@@ -239,4 +237,4 @@ A `:timeout` duration is **exactly one of**:
 - a **positive integer** — literal milliseconds (`5000`); or
 - an **ISO-8601 duration string** — `"PT5S"`, `"PT2M"`, `"PT1H30M"`, `"PT0.5S"`, `"P1D"`, … (the `PnYnMnWnDTnHnMnS` form; case-insensitive; fractional seconds allowed).
 
-> **Divergence from XState.** XState v6 also accepts a readable shorthand like `"10ms"` / `"5s"`. re-frame2 **rejects** it: a `"5s"` / `"10ms"` string — or any other malformed duration (a non-positive integer, a fn, a vector, the bare `"P"`) — fails **loud** at registration with `:rf.error/machine-bad-timeout-duration`. And unlike `:after`, a `:timeout` admits **no** subscription-vector or fn dynamic delays — a timeout is a fixed wall-clock deadline. The integer-ms-or-ISO-8601 rule is the single duration grammar; the shorthand string is gone on purpose.
+A readable shorthand like `"5s"` / `"10ms"` is **not** accepted: such a string — or any other malformed duration (a non-positive integer, a fn, a vector, the bare `"P"`) — fails **loud** at registration with `:rf.error/machine-bad-timeout-duration`. And unlike `:after`, a `:timeout` admits **no** subscription-vector or fn dynamic delays — a timeout is a fixed wall-clock deadline. The integer-ms-or-ISO-8601 rule is the single duration grammar; the shorthand string is rejected on purpose.

--- a/docs/machines/coming-from-xstate.md
+++ b/docs/machines/coming-from-xstate.md
@@ -49,7 +49,7 @@ Skim this, then read the worked build-up in [The grammar, concept by concept](#t
 | **`createActor(m).start()` → `actor.send(ev)`** | **the machine is an event handler → `(rf/dispatch [machine-id [event]])`** | **The big one.** No actor object; one [`dispatch`](../core/glossary.md#dispatch), one [cascade](../core/glossary.md#event-cascade). |
 | `actor.getSnapshot()` | [`@(rf/subscribe [:rf/machine id])`](#reading-the-snapshot) | The [snapshot](glossary.md#snapshot) is a value in [runtime-db](../core/glossary.md#runtime-db), read like any other derived state. |
 
-A condensed five-row version of this lives at the foot of the [machines concepts page](concepts.md#coming-from-xstate-the-five-row-delta); this one is the long form, and the two sections below — the worked build-up and the *why* essays — are the part worth your attention.
+This table is the long form; the worked build-up and the *why* essays below are the part worth your attention.
 
 ## The grammar, concept by concept
 
@@ -210,7 +210,7 @@ loading: { after: { 5000: 'timeout', 30000: { guard: 'stillLoading', target: 'ha
           :on    {:loaded :ready :failed :error}}
 ```
 
-`:after`'s value uses the same transition grammar as an `:on` clause, and the delay can be a literal `pos-int?` ms, a subscription vector (app-state-derived), or `(fn [{:keys [snapshot]}] ms)` (computed from this machine's `:data`). XState's named/delayed-actor `timeout` maps to `:timeout` + `:on-timeout`, a named deadline that lowers onto the same `:after` machinery. **Divergence:** durations are integer ms **or** an ISO-8601 string (`"PT5S"`); XState's readable `"5s"` / `"10ms"` shorthand is **rejected** at registration. (Recurring timers and pause/resume are out of scope for v1.)
+`:after`'s value uses the same transition grammar as an `:on` clause, and the delay can be a literal `pos-int?` ms, a subscription vector (app-state-derived), or `(fn [{:keys [snapshot]}] ms)` (computed from this machine's `:data`). XState's named/delayed-actor `timeout` maps to `:timeout` + `:on-timeout`, a named deadline that lowers onto the same `:after` machinery. **Divergence:** durations are integer ms **or** an ISO-8601 string (`"PT5S"`); XState's readable `"5s"` / `"10ms"` shorthand is **rejected** at registration. And when two `:after` timers fire in the same scheduler tick, ordering follows host-clock arrival, not XState/SCXML document order — re-frame2 timers are real deferred events (first valid timer to arrive wins; the rest go stale), so don't lean on declaration order to break a same-tick tie. (Recurring timers and pause/resume are out of scope for v1.)
 
 ### Compound (nested) states
 
@@ -317,7 +317,7 @@ Starting a child actor on state entry and tearing it down on exit is XState's `i
  :on    {:auth/cancelled :idle}}
 ```
 
-The job is identical; the **name diverges on purpose** — "invoke" reads like a synchronous call, whereas the thing created is a spawned child actor's worth of lifecycle, so the declarative key aligns with the imperative fx `[:rf.machine/spawn …]`. **Divergences to know:** one `:spawn` per state (fan-out is the separate `:spawn-all`, with named children, a `:join` condition, and a `:cancel-on-decision?` policy); no `:onSnapshot` (subscribe to `[:rf/machine <child-id>]` instead); no per-actor mailbox (events route through the one queue); no `autoForward` (forward explicitly via `:fx [[:dispatch [child-id ev]]]`). To address a spawned child from a machine action, emit `[:rf.machine/dispatch-to-system [:auth-actor [:event]]]` — see the [API reference](../api/re-frame.machines.md).
+The job is identical; the **name diverges on purpose** — "invoke" reads like a synchronous call, whereas the thing created is a spawned child actor's worth of lifecycle, so the declarative key aligns with the imperative fx `[:rf.machine/spawn …]`. **Divergences to know:** one `:spawn` per state (fan-out is the separate `:spawn-all`, with named children, a `:join` condition, and a `:cancel-on-decision?` policy); no `:onSnapshot` (subscribe to `[:rf/machine <child-id>]` instead); no per-actor mailbox (events route through the one queue); no `autoForward` (forward explicitly via `:fx [[:dispatch [child-id ev]]]`). To address a spawned child from a machine action, emit `[:rf.machine/dispatch-to-system [:auth-actor [:event]]]`. Where XState splits child/parent messaging into four primitives (`sendTo`, `sendParent`, the returned child ref, `system.get`), re-frame2 folds them into `dispatch`-by-id: `:rf.machine/dispatch-to-system` resolves a `:system-id`-named child (the `system.get` analog), and a child reaches its parent through the runtime-stamped `:rf/parent-id` (XState's `sendParent`). See the [API reference](../api/re-frame.machines.md).
 
 ### Choice states
 

--- a/docs/machines/concepts.md
+++ b/docs/machines/concepts.md
@@ -79,8 +79,6 @@ Both are referenced from the table *by id*; their implementations sit once, up t
 
 > **Build it by hand.** The [tutorial](tutorial.md) constructs exactly this machine step by step — turn machines on, add a guard, an action, a real server call, a view per state, and a pure-function test — one idea at a time.
 
-> **Coming from XState?** This table will look familiar — re-frame2's machine grammar borrows XState's vocabulary: transition tables, guards, actions, tags, `:after`, run-to-completion. The big shift: a machine isn't an actor you `send` to — it's an [event handler](../core/glossary.md#event-handler). re-frame2 tracks the direction of **XState v6**; where the two differ this page flags it, and there's a full delta table [at the end](#coming-from-xstate-the-five-row-delta).
-
 ## Registering and running it
 
 Registering the table is one line — and there's no new runtime concept under it. **A machine *is* an event handler.** [`reg-machine`](../core/glossary.md#registration) is sugar over a `reg-event` whose body interprets the table: look up the current **[snapshot](glossary.md#snapshot)** (its live `{:state :data}` value), compute the transition, write the new snapshot back, return the action's [effects](../core/glossary.md#effect).
@@ -149,7 +147,7 @@ Here's a turnstile with two states and a counter riding in `:data`, live in your
 
 If the current state has no transition for an event, it's a **silent no-op** — nothing throws, the snapshot doesn't move. Try it in the turnstile: dispatch `[:turnstile/flow [:wat]]`, an event no state handles, and the machine simply ignores it. (This is different from the `:push`-while-`:locked` case earlier: that state *does* declare a `:push` transition, so its action ran — here there's no transition at all.) The runtime still emits a benign `:rf.machine.event/unhandled-no-op` trace, so a debugger can show the event arrived and was dropped.
 
-> **Coming from XState?** This matches XState, which dropped strict mode in v5 and keeps it dropped in the v6 direction: an unknown event is a no-op, not a crash. Almost everything *else* that's wrong (a guard referencing an undefined name, a target naming a missing state) [fails loud](../core/glossary.md#fail-loud-not-silent) — but at *registration* time, not on the unlucky dispatch. More on that fail-loud / silent-no-op split below.
+> **Fail-loud is the rule elsewhere.** The unhandled event is the one silent no-op. Almost everything *else* that's wrong (a guard referencing an undefined name, a target naming a missing state) [fails loud](../core/glossary.md#fail-loud-not-silent) — but at *registration* time, not on the unlucky dispatch. More on that fail-loud / silent-no-op split below.
 
 ## Guards and actions
 
@@ -165,8 +163,6 @@ The arrows in the table named two kinds of helper — `:under-retry-limit` (a gu
 ```
 
 Pull out the keys you want and ignore the rest. `data` is already the `:data` slot — you read `(:attempts data)`, never `(get-in snapshot [:data :attempts])`. Note what is *not* in that map: there is no `:db`. A machine callback cannot see [app-db](../core/glossary.md#app-db) at all — only its own data plus the event that woke it. That boundary is load-bearing; **Strict encapsulation** below is the why.
-
-> **Coming from XState?** This is XState's action/guard argument — `context`, `event` — under re-frame2 spellings: `context` is `:data` (the name "context" is already taken twice over here, by the interceptor context and React context). One uniform map across every slot means there's no positional `(data event)`-vs-`(data id)` shape to mix up — the keys say what they carry.
 
 ### A guard is a yes/no gate
 
@@ -186,8 +182,6 @@ You reference it from an arrow by id — `:guard :under-retry-limit` — and the
  (fn [{:keys [data]}]
    (and (email-valid? data) (under-quota? data)))}
 ```
-
-> **Coming from XState?** XState ships `and` / `or` / `not` / `stateIn` guard combinators (`guard: and(['isAuthed', 'hasQuota'])`). re-frame2 has none — you write the boolean in a fn, and the fn's *name* is what a visualiser or an AI reads off the arrow. This is where XState v6 is heading anyway: it drops the helper creators in favour of plain functions. For `stateIn` specifically, the guard already gets `:state` in its context map (your own machine's active state); the cross-region case is covered in [parallel-states.md](parallel-states.md).
 
 ### An action returns effects
 
@@ -257,8 +251,6 @@ One sharp edge: an explicit `nil` **sets** a key to `nil` (the key stays present
 
 When several slots fire in one transition (`:exit` → the transition's `:action` → `:entry`), their `:data` updates merge in that order — a later slot sees the earlier writes — and the `:fx` vectors concatenate left to right.
 
-> **Coming from XState?** A `:data` write *is* XState's `assign` — there's no separate `assign` primitive to call and no array of actions to order. Because an action returns one atomic `{:data :fx}` map, XState v5's "assigns run in declared order, not hoisted ahead" correctness rule is automatic here rather than something the engine must enforce. (v6 removes the `assign` helper creator outright — re-frame2 never had it.)
-
 ## Strict encapsulation — a machine sees only its own `:data`
 
 This is the rule hovering over that context map: a guard or action gets `{:data :event :state :meta}` and **never app-db**. It cannot read app-db, and it cannot write it.
@@ -284,7 +276,7 @@ So how does a machine read or write things outside itself? Two disciplined moves
 Two guard-rails enforce the boundary:
 
 - **Returning `:db` is a hard error.** A `:db` key in an action's effect map surfaces `:rf.error/machine-action-wrote-db` and the `:db` key is dropped (the rest of the effects still flow). Fail loud, don't silently let a machine scribble on app-db.
-- **The next state isn't in the return shape either.** An action returns `:data` and `:fx` — never a state keyword. Only the transition's `:target` moves the machine. Callbacks update working memory; they can't nudge the machine into a state the table didn't declare. (This is exactly XState's `assign` invariant.)
+- **The next state isn't in the return shape either.** An action returns `:data` and `:fx` — never a state keyword. Only the transition's `:target` moves the machine. Callbacks update working memory; they can't nudge the machine into a state the table didn't declare.
 
 > **Gotcha — facts from the world are *declared*, not grabbed.** A guard or action that needs the time (or a random draw) must not call `(js/Date.now)` or `(rand)`: that buries nondeterminism where replay can't reach it, and replay is what makes time-travel and SSR hydration work. Instead, declare the fact as a [coeffect](../core/glossary.md#coeffect) on a *named* entry with `:rf.cofx/requires`, and the framework threads it into the context map:
 >
@@ -325,8 +317,6 @@ You read the snapshot through the framework's `[:rf/machine <id>]` [subscription
 
 Because the snapshot is *just a value* — no functions, no atoms, nothing unprintable in `:data` — it `pr-str` / `read-string` round-trips; and because it lives in [runtime-db](../core/glossary.md#runtime-db) it inherits [time-travel](../core/glossary.md#time-travel), undo, persistence, and SSR hydration for free, exactly as app-db does. That is the quiet dividend of "a machine is just an event handler whose state rides the frame."
 
-> **Coming from XState?** This is `actor.getSnapshot()` — but a *value in your store that you subscribe to*, not a field you pull off a live actor object. There's no actor instance to hold a reference to; the id plus the subscription is the whole handle.
-
 ## Tags and timers
 
 Two keys round out the everyday kit, and each has earned a page of its own rather than a paragraph here:
@@ -352,7 +342,7 @@ Look again at the turnstile. Pushing while `:locked` is a *self-transition* — 
 
 Here the `:after` self-transition is **external** (`:reenter? true`), so re-entering `:polling` re-runs `:start-fetch` and rearms the 30-second timer — a self-rescheduling poll in two keys. The `:got-data` transition is **internal** (no target), so a reply landing mid-window merges into `:data` without resetting the clock. Picking internal vs external per transition is exactly the control this rule buys you.
 
-> **Coming from XState v4 / SCXML?** re-frame2's internal-by-default matches XState v5+ (and the v6 direction), where `:reenter? true` is XState's `reenter: true` spelled with a Clojure `?`. But if you trained on XState v4 or hand-wrote SCXML, you expect a *targeted* self-transition to re-enter by default — re-frame2 does **not**. A self-target you *meant* to re-fire `:entry` on needs `:reenter? true`; without it, only the transition `:action` runs. Full mechanics, including ancestor restarts and the one `:always` restriction (an eventless `:always` may never self-target), are in [Spec 005 §Self-transitions](../../spec/005-StateMachines.md#self-transitions--internal-default-vs-external-reenter).
+> **The self-target subtlety.** A *targeted* self-transition does **not** re-enter by default. A self-target you *meant* to re-fire `:entry` on needs `:reenter? true`; without it, only the transition `:action` runs. Full mechanics, including ancestor restarts and the one `:always` restriction (an eventless `:always` may never self-target), are in [Spec 005 §Self-transitions](../../spec/005-StateMachines.md#self-transitions--internal-default-vs-external-reenter).
 
 ## Wildcard transitions: handle a whole class of events
 
@@ -371,7 +361,7 @@ Sometimes a state should react to *any* event in a family rather than enumerate 
 
 One subtlety worth knowing: a guard-**blocked** exact match falls through to the coarser tiers (it wasn't *handled*), but a deliberate **forbidden block** — `{:on {:E {}}}` or `{:on {:E nil}}` — is itself a handler that *consumes* the event and stops the search. That distinction is how a child state opts out of an event its parent would otherwise handle. Full precedence rules in [Spec 005 §Wildcard transitions](../../spec/005-StateMachines.md#wildcard-transitions).
 
-> **Coming from XState?** The namespace tier is re-frame2's idiom for XState v5's prefix descriptor (`mouse.*`) — same behaviour (one prefix level between exact and catch-all), expressed on the keyword's `/` boundary instead of a dotted string. A bare, non-namespaced id like `:go` has no `:ns/*` tier; only its exact key or `:*` can catch it.
+> **A non-namespaced id has no wildcard tier.** A bare id like `:go` has no `:ns/*` tier — only its exact key or `:*` can catch it. The `:ns/*` tier lives on the keyword's `/` boundary: one prefix level between the exact id and the catch-all `:*`.
 
 ## Final states: when a machine is *done*
 
@@ -436,7 +426,7 @@ To *also* validate the inbound event vector, use the three-argument `reg-machine
 
 The `:schemas` map's sub-keys are a closed set. Two of them — `:data` and `:output` — are wired up to actually run a check (you've now seen both). The other three — `:events`, `:tags`, and `:meta` — are accepted so you can declare them today, but they don't validate anything yet; they're reserved for future wiring. Either way, a sub-key *outside* the set (a typo, or one you hoped was live but isn't) fails loud at registration rather than silently validating nothing.
 
-> **Coming from TypeScript?** The `:schemas` map follows the XState v6 direction, which replaces v5's `types` with a broader `schemas` section. But there's a runtime guarantee TypeScript's typed context *can't* give you: TS types are erased before the machine ever runs, whereas `[:schemas :data]` is an *actually-running* validation in dev that rolls a bad transition back. Same declaration, plus the runtime check the type-erased layer leaves out.
+> **Coming from TypeScript?** There's a runtime guarantee TypeScript's typed context *can't* give you: TS types are erased before the machine ever runs, whereas `[:schemas :data]` is an *actually-running* validation in dev that rolls a bad transition back. Same declaration, plus the runtime check the type-erased layer leaves out.
 
 > **Fail-loud guard.** Because the schema only does its job through `reg-machine`'s registration stamp, hand-rolling `(reg-event id meta (machines/make-machine-handler spec))` around a `[:schemas :data]`-bearing spec is rejected with `:rf.error/machine-schema-requires-reg-machine` — the framework refuses to let your schema sit there validating nothing. A schema-less spec is fine through either path.
 
@@ -492,35 +482,19 @@ The return value is a result map. Destructure `::result/snap` and `::result/fx`,
 
 The flat grammar above carries most machines. When a flow gets richer, the grammar grows *without changing the model* — each of these is the same transition-table data, one more key. You only need to recognise them here; the contracts live in [Spec 005](../../spec/005-StateMachines.md):
 
-- **`:raise` loops an event back into this machine.** An action can return `:fx [[:raise [:some-event …]]]` to fire an event *at its own machine*, atomically, before the transition commits — useful when one transition's outcome should immediately drive another (a wizard step that completes and re-asks "is the whole form done?"). It's the in-machine equivalent of XState's `raise`. `:raise` is a reserved fx-id, alongside `[:rf.machine/spawn …]` and `[:rf.machine/destroy …]`, the actor-lifecycle pair behind the `:spawn` sugar. Everything else in `:fx` — `:dispatch`, `:rf.http/managed`, your own effects — flows to the ordinary effects machinery untouched.
-- **`:internal-events` makes an event private.** Some events are machine *plumbing* — a `:check-complete` the machine raises at itself, not for a view or test to dispatch. Declare those in a top-level `:internal-events` **set** (`#{:check-complete}`); an internal `:raise` is handled normally, but an *external* dispatch is **refused** at the machine's boundary (no transition; a `:rf.error/machine-internal-event-external-dispatch` trace fires). It's XState v6's `internalEvents`, spelled as a Clojure set because membership is what you're declaring, not order. [§Public / private `:internal-events`](../../spec/005-StateMachines.md#public--private-internal-events).
-- **`:type :choice` is a decision node.** A choice state is a *transient* routing node: enter it and it resolves immediately — same step, no event — to the first guarded candidate whose `:guard` passes. It's `:always`'s decision pattern with a name, so diagrams render an explicit fork. The `:choice` value is a **declarative candidate array** (re-frame2 keeps the routing as *data*, rejecting XState v6's `choice`-*function* form); it must include an unguarded default and must not declare ordinary state keys. [§`:type :choice`](../../spec/005-StateMachines.md#type-choice-transient--choice-states).
-- **`:timeout` / `:on-timeout` names a deadline.** Where `:after` is the general timer table, `:timeout` is the named-intent spelling of "this state — or its spawned child — must finish before this time," pairing a duration with an `:on-timeout` transition (it lowers onto the same `:after` timer). A duration is a positive-integer millisecond count (`5000`) or an ISO-8601 string (`"PT5S"`, `"PT1H30M"`) — re-frame2 rejects XState's `"5s"` shorthand, failing loud at registration. [§`:timeout` / `:on-timeout`](../../spec/005-StateMachines.md#timeout--on-timeout-state--spawn).
+- **`:raise` loops an event back into this machine.** An action can return `:fx [[:raise [:some-event …]]]` to fire an event *at its own machine*, atomically, before the transition commits — useful when one transition's outcome should immediately drive another (a wizard step that completes and re-asks "is the whole form done?"). `:raise` is a reserved fx-id, alongside `[:rf.machine/spawn …]` and `[:rf.machine/destroy …]`, the actor-lifecycle pair behind the `:spawn` sugar. Everything else in `:fx` — `:dispatch`, `:rf.http/managed`, your own effects — flows to the ordinary effects machinery untouched.
+- **`:internal-events` makes an event private.** Some events are machine *plumbing* — a `:check-complete` the machine raises at itself, not for a view or test to dispatch. Declare those in a top-level `:internal-events` **set** (`#{:check-complete}`); an internal `:raise` is handled normally, but an *external* dispatch is **refused** at the machine's boundary (no transition; a `:rf.error/machine-internal-event-external-dispatch` trace fires). It's a set because membership is what you're declaring, not order. [§Public / private `:internal-events`](../../spec/005-StateMachines.md#public--private-internal-events).
+- **`:type :choice` is a decision node.** A choice state is a *transient* routing node: enter it and it resolves immediately — same step, no event — to the first guarded candidate whose `:guard` passes. It's `:always`'s decision pattern with a name, so diagrams render an explicit fork. The `:choice` value is a **declarative candidate array** — the routing stays *data*, not a function — and it must include an unguarded default and must not declare ordinary state keys. [§`:type :choice`](../../spec/005-StateMachines.md#type-choice-transient--choice-states).
+- **`:timeout` / `:on-timeout` names a deadline.** Where `:after` is the general timer table, `:timeout` is the named-intent spelling of "this state — or its spawned child — must finish before this time," pairing a duration with an `:on-timeout` transition (it lowers onto the same `:after` timer). A duration is a positive-integer millisecond count (`5000`) or an ISO-8601 string (`"PT5S"`, `"PT1H30M"`) — a `"5s"`-style shorthand is rejected, failing loud at registration. [§`:timeout` / `:on-timeout`](../../spec/005-StateMachines.md#timeout--on-timeout-state--spawn).
 - **Hierarchical states** — a compound state contains sub-states; entering the parent cascades to its `:initial` child (an `:authenticated` super-state over `:browsing` / `:checkout`). [§Hierarchical compound states](../../spec/005-StateMachines.md#hierarchical-compound-states).
 - **Eventless `:always`** — fires when a guard becomes true, no event needed. [§Eventless `:always` transitions](../../spec/005-StateMachines.md#eventless-always-transitions).
 - **Parallel regions** — one machine, several orthogonal axes active at once (`:type :parallel` + `:regions`) sharing one `:data`; the snapshot's `:state` becomes a map of region → state, tags union across regions. Three axes of 3 states each is 3 regions, not 27 cross-product states. [§Parallel regions](../../spec/005-StateMachines.md#parallel-regions); when the axes *don't* share data, prefer N separate machines — the trade-off is worked in the [CP-5 guide](../../spec/CP-5-MachineGuide.md).
 - **History states** — re-enter a compound at the substate it was in when you left (a paused player resumes mid-track), via a `:type :history` pseudo-state. The recording rides the snapshot, so it survives undo and hydration for free. [§History states](../../spec/005-StateMachines.md#history-states-type-history--shallow--deep--default-target).
-- **Spawned actors** — machines that aren't long-lived singletons: a per-request protocol machine, a wizard's per-step subprocess. The declarative [`:spawn`](glossary.md#spawn) key starts a child on state entry and destroys it on exit (XState's `invoke`). [§Declarative `:spawn`](../../spec/005-StateMachines.md#declarative-spawn).
+- **Spawned actors** — machines that aren't long-lived singletons: a per-request protocol machine, a wizard's per-step subprocess. The declarative [`:spawn`](glossary.md#spawn) key starts a child on state entry and destroys it on exit. [§Declarative `:spawn`](../../spec/005-StateMachines.md#declarative-spawn).
 
-> **Gotcha — a runaway `:always` / `:raise` cycle is a *failed* macrostep, not a hang.** Eventless transitions and `:raise` both re-enter the transition machinery within the same macrostep, so a non-converging loop (`:a` `:always`-targets `:b`, `:b` `:always`-targets `:a`, both guards true) could spin forever. It can't: each is bounded by a depth limit (default **16**, set per-frame via `:always-depth-limit` / `:raise-depth-limit`). Trip it and the macrostep **aborts atomically** — the snapshot stays at its pre-event value, no observer sees the partial path — and a single `:rf.error/machine-always-depth-exceeded` (or `:rf.error/machine-raise-depth-exceeded`) [error record](../core/glossary.md#error-record) fires. This matches XState (which *throws* on such a cycle), and it is **distinct** from the silent no-op of an unhandled event: a runaway loop is a bug you want surfaced, not swallowed. There's no automatic recovery.
+> **Gotcha — a runaway `:always` / `:raise` cycle is a *failed* macrostep, not a hang.** Eventless transitions and `:raise` both re-enter the transition machinery within the same macrostep, so a non-converging loop (`:a` `:always`-targets `:b`, `:b` `:always`-targets `:a`, both guards true) could spin forever. It can't: each is bounded by a depth limit (default **16**, set per-frame via `:always-depth-limit` / `:raise-depth-limit`). Trip it and the macrostep **aborts atomically** — the snapshot stays at its pre-event value, no observer sees the partial path — and a single `:rf.error/machine-always-depth-exceeded` (or `:rf.error/machine-raise-depth-exceeded`) [error record](../core/glossary.md#error-record) fires. It is **distinct** from the silent no-op of an unhandled event: a runaway loop is a bug you want surfaced, not swallowed. There's no automatic recovery.
 
 > **Gotcha — an `:always` may not target itself.** `{:checking {:always {:target :checking}}}` is rejected at *registration* with `:rf.error/machine-always-self-loop`: re-entering a state to re-test the same guard either spins to the depth limit (guard stays true) or no-ops (guard flips) — neither is what you meant. The fixed-point loop you actually want is a **targetless** guarded `:always` with an `:action` that flips the guard — `{:always {:guard :more? :action :bump}}` — which runs and settles; or an intermediate distinct state if you genuinely need entry/exit to re-fire.
-
-## Coming from XState? The five-row delta
-
-XState's *behaviour* is the reference re-frame2 matches; the *expression* is re-frame-native. The rows below hold across XState versions, and several are exactly where the **v6 direction** is heading anyway — v6 removes the `assign` helper and the `setup()` implementation registry, leaning toward plain functions, which is the shape re-frame2 already has:
-
-| XState | re-frame2 | The difference, and why |
-|---|---|---|
-| `context` (extended state) | `:data` | Same idea; "context" is already overloaded in re-frame2 (interceptor context, React context). |
-| `createActor(machine).start()`, then `actor.send({type: ...})` | the machine **is an event handler**; `(rf/dispatch [machine-id [event]])` | **The big one.** No actor object, no separate send mechanism — one router queue, one cascade. (v6 replaces v5's `interpret` with `createActor`; re-frame2 has neither — machines are event handlers.) |
-| actions that imperatively `assign(...)` / fire effects | actions **return** `{:data ... :fx ...}` | The same data-shaped return as any `reg-event` handler; effects are data, actioned by the runtime. v6 removes the `assign` helper creator — re-frame2 never had it. |
-| state lives in the actor; `actor.getSnapshot()` | the snapshot is a value in runtime-db, read via `@(rf/subscribe [:rf/machine id])` | Time-travel, undo, persistence, and SSR hydration extend to machines for free. |
-| `setup({guards, actions})` | machine-local `:guards` / `:actions` maps inside the spec | Each machine carries its own, validated at registration; cross-machine reuse is ordinary Clojure vars, not a string registry. v6 already simplifies `setup()` away from implementation registration. |
-
-The matches go deeper than the renames: run-to-completion, transition tables as data, tags, delayed transitions, final states, and internal-by-default self-transitions. An XState author ports their intuitions directly. The full divergence ledger is in the [machine construction guide](../../spec/CP-5-MachineGuide.md).
-
-> **Where re-frame2 diverges on purpose.** re-frame2 tracks the v6 *direction*, not a JavaScript runtime. Three divergences are worth holding in mind: (1) **function-valued transitions are rejected** — guards and actions are functions, but the transition *topology* (targets, `:always`, `:after`) stays declarative data so diagrams, tools, and AI can read the graph; (2) **frame dispatch + runtime-db snapshots instead of actor objects** — no `createActor`, no actor refs, no mailboxes; (3) **completion is event-shaped** — a child's final-state output flows to the parent's `:on-done` callback as `result`, not a long-lived `snapshot.output` slot. Several v6-direction features that motivate new grammar have already landed: the broader `:schemas` map, explicit `:timeout` / `:on-timeout`, `:type :choice` transient states, and private `:internal-events`.
 
 ## When to reach for a machine — and when not
 

--- a/docs/machines/glossary.md
+++ b/docs/machines/glossary.md
@@ -1,6 +1,6 @@
 # Machines glossary
 
-re-frame2's optional state-machine capability — modelling a feature's lifecycle as an explicit statechart rather than a scatter of boolean flags. Every term below lives within a [machine](#machine), and each entry links to the page that teaches it in depth — usually [the Machines guide](concepts.md). Where a term maps from XState (the behavioural parity reference — re-frame2 matches the *behaviour*, not the API), the entry flags it inline (*XState: …*) and calls out any deliberate divergence; [Coming from XState](coming-from-xstate.md) is the full delta.
+re-frame2's optional state-machine capability — modelling a feature's lifecycle as an explicit statechart rather than a scatter of boolean flags. Every term below lives within a [machine](#machine), and each entry links to the page that teaches it in depth — usually [the Machines guide](concepts.md).
 
 Grouped by role: [the core loop](#the-core-loop), [state structure](#state-structure), [transitions and timing](#transitions-and-timing), [actors and composition](#actors-and-composition), [tags](#tags), and [the runtime model](#the-runtime-model).
 
@@ -31,7 +31,7 @@ The data a machine *is*: a map with `:initial`, the starting [`:data`](#data), t
            :submitting {...}}}
 ```
 
-*XState:* the object you pass to `createMachine` — re-frame2 keeps it as plain Clojure data, with no builder or fluent API. See [The same flow as a transition table](concepts.md#the-same-flow-as-a-transition-table).
+See [The same flow as a transition table](concepts.md#the-same-flow-as-a-transition-table).
 
 ### **snapshot**
 
@@ -49,7 +49,7 @@ Related: [Machines](concepts.md); the [`[:rf/machine machine-id]` sub](../api/re
 
 A machine's private working memory — the *extended state* that rides alongside the named [state](#state) in every [snapshot](#snapshot). Counters, the in-flight error string, captured credentials: anything that isn't itself a named mode. [Guards](#guard) and [actions](#action) read it from their context map (`{:data …}`); an action *updates* it by returning `{:data …}` (see [action effect map](#action-effect-map)). It must be a printable value so the snapshot round-trips through persistence and time-travel, and a machine sees **only its own** `:data` — never [app-db](../core/glossary.md#app-db).
 
-*XState:* this is XState's **`context`**. re-frame2 renames it because "context" is already overloaded (interceptor context, React context). Taught in [The same flow as a transition table](concepts.md#the-same-flow-as-a-transition-table).
+Taught in [The same flow as a transition table](concepts.md#the-same-flow-as-a-transition-table).
 
 ### **state**
 
@@ -78,7 +78,7 @@ What an [action](#action) returns: the same `{:data … :fx …}` map a [`reg-ev
                   (assoc :error (:message failure)))})
 ```
 
-*XState:* replaces both `assign({...})` (now the `:data` return) and effectful actions (now the `:fx` return). v6 is removing `assign`'s special status, moving toward the plain-function shape re-frame2 started from. See [Guards, actions, tags, and `:after`](concepts.md#guards-and-actions).
+See [Guards, actions, tags, and `:after`](concepts.md#guards-and-actions).
 
 ## State structure
 
@@ -86,31 +86,29 @@ What an [action](#action) returns: the same `{:data … :fx …}` map a [`reg-ev
 
 A [state](#state) that nests its own `:states` map plus a required `:initial` substate — a parent mode with child modes (`:authenticated` over `:browsing` / `:checkout`). Entering it cascades down the `:initial` chain to a leaf, and the snapshot's `:state` becomes a **vector path** like `[:authenticated :cart :browsing]`. The runtime resolves an event by walking from the active leaf up to the root — **deepest-wins with parent fallthrough** — so a parent can factor out a transition (`:logout`) that every descendant inherits, while a child can [opt out](#forbidden-transition) or override.
 
-*XState:* a hierarchical / nested state; same `initial`-cascade and bubbling. Listed under [When the machine grows](concepts.md#when-the-machine-grows).
+Listed under [When the machine grows](concepts.md#when-the-machine-grows).
 
 ### **parallel state**
 
 A machine declared `:type :parallel` at its root, holding a **`:regions`** map (not `:states`) — the [regions](#region) are **all active at once** rather than one-at-a-time. Three orthogonal axes of three states each is three regions, not twenty-seven cross-product states. The snapshot's `:state` becomes a **map** of region-name → that region's state (`{:data :loading :form :neutral :mode :active}`); all regions share one [`:data`](#data) and their [tags](#state-tag) union across regions. When the axes *don't* share data, prefer N separate machines instead.
 
-*XState:* `type: 'parallel'`. See the [nine_states example](../../examples/patterns/nine_states/) and [When the machine grows](concepts.md#when-the-machine-grows).
+See the [nine_states example](../../examples/patterns/nine_states/) and [When the machine grows](concepts.md#when-the-machine-grows).
 
 ### **region**
 
 One orthogonal axis of a [parallel state](#parallel-state) — its own independent sub-state-tree, running concurrently with its sibling regions and sharing the machine's single [`:data`](#data). A dispatched [event](../core/glossary.md#event) broadcasts to every region, and each resolves it independently; a region's slice of the snapshot is keyed by its region-name. Cross-region coordination reads another region's [tags](#state-tag) — never reaching into its state directly.
 
-*XState:* the child states of a `parallel` node.
-
 ### **final state**
 
 A leaf marked **`:final? true`**: entering it **terminates the machine** — the runtime auto-destroys it, *even a top-level singleton*. It's for "this run is over," not "this is the last screen" — for a state the machine rests in indefinitely (like `:authed`), use an ordinary leaf and **omit** `:final?`. A final leaf can name an [`:output-key`](#on-done-and-output-key) to report a result, and can be flagged `:error? true` as a designated failure terminal.
 
-*XState:* `final: true` (+ `output`). See [Final states](concepts.md#final-states-when-a-machine-is-done).
+See [Final states](concepts.md#final-states-when-a-machine-is-done).
 
 ### **history state**
 
 A `:type :history` **pseudo-state** you target to re-enter a [compound state](#compound-state) at whichever substate was active when you last left it — a paused player resuming mid-track. **Shallow** restores the immediate child; **deep** restores the full nested path; a `:default-target` covers the never-visited-yet case. The recording rides the [snapshot](#snapshot), so it survives undo and SSR hydration for free.
 
-*XState:* `type: 'history'` (`history: 'shallow' | 'deep'`). Listed under [When the machine grows](concepts.md#when-the-machine-grows).
+Listed under [When the machine grows](concepts.md#when-the-machine-grows).
 
 ## Transitions and timing
 
@@ -122,7 +120,7 @@ A [transition](#transition) back into the state you're already in. re-frame2 fol
 - **Explicit self-target, no `:reenter?`** — your own `:exit` / `:entry` still don't fire, but a compound **re-resolves its descendants** to `:initial`.
 - **External (`:reenter? true`)** — genuinely exits and re-enters: `:exit` → `:action` → `:entry`, and on a compound the whole subtree restarts (`:after` timers reset, `:spawn` children respawn).
 
-*XState:* `:reenter? true` is XState's `reenter: true`. Watch the divergence from XState v4 / SCXML, where a *targeted* self-transition re-enters by default — re-frame2 does not. See [Self-transitions](concepts.md#self-transitions-internal-by-default-external-on-demand).
+See [Self-transitions](concepts.md#self-transitions-internal-by-default-external-on-demand).
 
 ### **wildcard transition**
 
@@ -134,13 +132,13 @@ An `:on` entry that matches a *class* of events instead of one id. `:on` resolve
                 :*          {:action :log-unknown}}}  ;; anything else
 ```
 
-*XState:* `:ns/*` is re-frame2's idiom for v5's prefix descriptor (`mouse.*`), expressed on the keyword's `/` boundary. See [Wildcard transitions](concepts.md#wildcard-transitions-handle-a-whole-class-of-events).
+See [Wildcard transitions](concepts.md#wildcard-transitions-handle-a-whole-class-of-events).
 
 ### **forbidden transition**
 
 A present `:on` key whose value is the **empty map** (`{:on {:E {}}}`) or **`nil`** — a handler that *consumes* an event and stops the deepest-wins search without changing state. It's how a child [compound state](#compound-state) **opts out** of a transition its parent would otherwise inherit to it. Distinct from an *unhandled* event (which falls through to coarser tiers and up to ancestors): a forbidden block is itself a match, so the search stops there.
 
-*XState:* `on: { LOGOUT: undefined }`. Covered with [wildcards](concepts.md#wildcard-transitions-handle-a-whole-class-of-events).
+Covered with [wildcards](concepts.md#wildcard-transitions-handle-a-whole-class-of-events).
 
 ### **eventless transition (`:always`)**
 
@@ -151,7 +149,7 @@ A state-node key holding a vector of guarded transitions that fire **with no eve
                          {:guard :form-invalid? :target :show-errors}]}
 ```
 
-*XState:* `always` (transient transitions); same firing rule. Settled inside the [microstep](#microstep) loop. See [When the machine grows](concepts.md#when-the-machine-grows).
+Settled inside the [microstep](#microstep) loop. See [When the machine grows](concepts.md#when-the-machine-grows).
 
 ### **delayed transition (`:after`)**
 
@@ -162,45 +160,45 @@ The declarative timer: a state-node key mapping a delay to a transition. Enter t
                :on    {:net/give-up :failed}}
 ```
 
-*XState:* `after: { 5000: 'next' }`; same auto-cancel-on-exit. (ISO-8601 durations and the `"5s"`-shorthand rejection belong to [`:timeout`](#timeout), not `:after` — an `:after` key is an ms int, a sub vector, or a fn.) See [Guards, actions, tags, and `:after`](concepts.md#guards-and-actions).
+(ISO-8601 durations and the `"5s"`-shorthand rejection belong to [`:timeout`](#timeout), not `:after` — an `:after` key is an ms int, a sub vector, or a fn.) See [Guards, actions, tags, and `:after`](concepts.md#guards-and-actions).
 
 ### **timeout**
 
 The named-intent spelling of "this state — or its spawned child — must finish before this deadline": a `:timeout` duration paired with an `:on-timeout` transition. It *lowers onto* the same [`:after`](#delayed-transition-after) timer machinery; it just reads as a deadline rather than a general delay. A duration is integer-ms (`5000`) or an ISO-8601 string (`"PT5S"`, `"PT1H30M"`) — `"5s"` is rejected, failing loud at registration.
 
-*XState:* the deadline idiom you'd build by hand from `after`; re-frame2 gives it a name. Listed under [When the machine grows](concepts.md#when-the-machine-grows).
+Listed under [When the machine grows](concepts.md#when-the-machine-grows).
 
 ### **choice state**
 
 A `:type :choice` **transient** routing node: enter it and it resolves *immediately* — same step, no event — to the first candidate whose `:guard` passes. It's [`:always`](#eventless-transition-always)'s decision pattern with a name, so a diagram renders an explicit fork. The candidate list is a **declarative array** that must include an unguarded default and must not declare ordinary state keys.
 
-*XState:* a `choice` node — but re-frame2 keeps the routing as **data**, deliberately rejecting v6's `choice`-*function* form so the graph stays readable by tools. See [When the machine grows](concepts.md#when-the-machine-grows).
+See [When the machine grows](concepts.md#when-the-machine-grows).
 
 ### **run-to-completion**
 
 The guarantee that a machine processes one event **to a settled, stable configuration before the next event is seen** — every [`:always`](#eventless-transition-always) microstep and every [`:raise`](#raise)d event drains, then the snapshot [commits](#commit) once. External observers (subs, other machines, tools) only ever see the settled state, never a mid-cascade intermediate. A non-converging `:always` / `:raise` loop can't hang the runtime: it's bounded (default depth 16) and aborts atomically with the snapshot unchanged.
 
-*XState:* RTC / SCXML macrostep semantics — matched deliberately. See [microstep](#microstep) and [macrostep](#macrostep).
+See [microstep](#microstep) and [macrostep](#macrostep).
 
 ## Actors and composition
 
 ### **spawn**
 
-A declarative key that starts a *child* machine on entering a [state](#state) and tears it down on leaving; the child reports a result back through [`:on-done`](#on-done-and-output-key). (`:spawn-all` starts several in parallel and joins on completion — re-frame2's spelling of XState's `invoke`.) Under the hood it's the reserved [`[:rf.machine/spawn …]`](../api/re-frame.machines.md#rfmachinespawn-spawn-spec) [effect](../core/glossary.md#effect); emit that directly from any handler when you need a dynamic count rather than one-child-per-state. The running instance it creates is an [actor](#actor).
+A declarative key that starts a *child* machine on entering a [state](#state) and tears it down on leaving; the child reports a result back through [`:on-done`](#on-done-and-output-key). (`:spawn-all` starts several in parallel and joins on completion.) Under the hood it's the reserved [`[:rf.machine/spawn …]`](../api/re-frame.machines.md#rfmachinespawn-spawn-spec) [effect](../core/glossary.md#effect); emit that directly from any handler when you need a dynamic count rather than one-child-per-state. The running instance it creates is an [actor](#actor).
 
-*XState:* `invoke: { src: childMachine }`, renamed because the thing created is a spawned child's worth of lifecycle, not a synchronous call. See [When the machine grows](concepts.md#when-the-machine-grows).
+See [When the machine grows](concepts.md#when-the-machine-grows).
 
 ### **actor**
 
 A *live machine instance* — a [snapshot](#snapshot) sitting at `[:rf.runtime/machines :snapshots <id>]` in [runtime-db](../core/glossary.md#runtime-db). Two kinds: a long-lived **singleton** (one per `reg-machine` id) and a dynamically **[spawned](#spawn)** child (a per-request protocol machine, a wizard's per-step subprocess). An actor's *liveness IS its snapshot's presence* — there's no parallel registry; destroying it removes the snapshot. Address a spawned actor by its gensym'd id, or by role via a [system-id](#system-id).
 
-*XState:* an actor — but re-frame2 has no `createActor` / actor-ref object; the instance is just a value in the frame, which is why time-travel and SSR extend to it for free. See [Coming from XState](coming-from-xstate.md).
+The live instance is just a value in the frame, so time-travel and SSR extend to it for free.
 
 ### **spawn-all**
 
 The fan-out sibling of [`:spawn`](#spawn): on entering a state it starts **N children in parallel** and **joins** on their completion, resolving when they've all finished (or on the first failure, with a cooperative cancellation cascade). Used for "spawn a worker per chunk and continue when all return."
 
-*XState:* invoking multiple actors and awaiting them. See the [long_running_work example](../../examples/patterns/long_running_work/) and [When the machine grows](concepts.md#when-the-machine-grows).
+See the [long_running_work example](../../examples/patterns/long_running_work/) and [When the machine grows](concepts.md#when-the-machine-grows).
 
 ### **:on-done and :output-key**
 
@@ -214,7 +212,7 @@ How a finishing child reports back. A [final state](#final-state) names an **`:o
                                     (assoc data :token result))}}
 ```
 
-*XState:* `final` `output` + `onDone`; re-frame2 keeps it event-shaped, not a long-lived `snapshot.output`. See [Final states](concepts.md#final-states-when-a-machine-is-done).
+See [Final states](concepts.md#final-states-when-a-machine-is-done).
 
 ### **system-id**
 
@@ -234,7 +232,7 @@ A reserved, **machine-only** fx-id. Inside an [action](#action)'s `:fx`, `[:rais
 {:actions {:kick (fn [_] {:fx [[:raise [:tick]]]})}}
 ```
 
-*XState:* `raise({type: …})`. See [`[:raise event-vec]`](../api/re-frame.machines.md#raise-event-vec) and [When the machine grows](concepts.md#when-the-machine-grows).
+See [`[:raise event-vec]`](../api/re-frame.machines.md#raise-event-vec) and [When the machine grows](concepts.md#when-the-machine-grows).
 
 ### **:internal-events**
 
@@ -245,7 +243,7 @@ A top-level **set** of event ids that are machine *plumbing* — events the mach
  :states {...}}
 ```
 
-*XState:* v6's `internalEvents` — spelled as a Clojure **set** (membership is what you're declaring, not order). See [When the machine grows](concepts.md#when-the-machine-grows).
+See [When the machine grows](concepts.md#when-the-machine-grows).
 
 ## Tags
 
@@ -258,7 +256,7 @@ A label like `:auth/busy` attached to several [machine](#machine) [states](#stat
   [spinner])
 ```
 
-*XState:* `tags: ['busy']` + `state.hasTag('busy')`; the membership question is a [subscription](../core/glossary.md#subscription). See [Guards, actions, tags, and `:after`](concepts.md#guards-and-actions).
+See [Guards, actions, tags, and `:after`](concepts.md#guards-and-actions).
 
 ## The runtime model
 
@@ -272,13 +270,9 @@ The deterministic ordering rules by which a machine's effects compose at four ne
 
 One iteration of the settle loop *inside* a single machine event: after the resolving transition, the runtime **prefers an enabled [`:always`](#eventless-transition-always)** transition; only when none is enabled does it **dequeue one [`:raise`](#raise)d event** (FIFO). It loops until no `:always` is enabled *and* the raise-queue is empty — the fixed point. Microsteps are **not** separately observable; they're the internal steps that compose one [macrostep](#macrostep). Bounded at depth 16 (`:always-depth-limit` / `:raise-depth-limit`).
 
-*XState:* SCXML §3.13 microstep / `selectEventlessTransitions` — matched deliberately.
-
 ### **macrostep**
 
 The whole machine event — the resolving transition plus every [`:always`](#eventless-transition-always) [microstep](#microstep) and every [`:raise`](#raise)d sub-event — seen as **one logical step** from outside: one [commit](#commit), one trace row, one [epoch](../core/glossary.md#epoch). External observers only ever see the post-commit settled [snapshot](#snapshot), never an intermediate. This is what makes a machine [run-to-completion](#run-to-completion).
-
-*XState:* the SCXML macrostep / run-to-completion boundary.
 
 ### **commit**
 
@@ -287,5 +281,3 @@ The single, deferred [runtime-db](../core/glossary.md#runtime-db) write that lan
 ### **LCCA (least common compound ancestor)**
 
 Also written **LCA**. For a [transition](#transition) from source path A to target path B inside a [compound state](#compound-state), the LCCA is the deepest state that stays active across the move — it neither exits nor enters. The exit cascade runs `:exit` from A's leaf *up to (not including)* the LCCA (deepest-first); the entry cascade runs `:entry` from just below the LCCA *down to* B's leaf (shallowest-first); the transition `:action` fires once at the boundary. For the common case it's just the longest common prefix of A and B — *except* when B is on A's active path or a descendant the declaring compound names, where it pulls up to a **proper** ancestor so the targeted subtree actually re-resolves. For a flat machine the LCCA is the root, and the rule collapses to plain `:exit` → `:action` → `:entry`.
-
-*XState:* the same LCCA the SCXML algorithm uses to compute exit/entry sets.

--- a/docs/machines/hierarchical-states.md
+++ b/docs/machines/hierarchical-states.md
@@ -27,12 +27,6 @@ The grammar recurses and stays additive: a substate is either a **leaf** (no
 `:initial`). Flat machines stay flat — you only pay for hierarchy where you use
 it.
 
-> **In XState** this is a [compound (nested) state](https://stately.ai/docs/parent-states);
-> the behaviour re-frame2 matches is XState v6's, expressed as Clojure data
-> rather than a `createMachine` object. `:data` is XState's `context`; `:spawn`
-> is XState's `invoke`/`spawn`; the snapshot's `{:state :data :tags}` is XState's
-> `snapshot.value` / `.context` / `.tags`.
-
 The canonical worked example is the connection machine in
 [`../../examples/patterns/websocket/`](../../examples/patterns/websocket) — its
 `:active` state parents the three happy-path leaves. The snippets on this page
@@ -166,7 +160,7 @@ A compound state *without* `:initial` is a registration error
 > life — a singleton on its first dispatched event, or a spawned actor — the
 > whole `:initial` chain's `:entry` actions fire once, shallowest-first, as part
 > of bringing it into existence — *every* level along the chain, not just the
-> leaf. (In XState this is `xstate.init` entering the initial state cascade.)
+> leaf.
 
 ---
 
@@ -203,11 +197,6 @@ Flat-machine targets you've already written (`{:target :editing}`) are keyword
 form, root-relative — unchanged, because in a flat machine the declaring state's
 parent *is* the root.
 
-> **In XState** an absolute target is written by id —
-> `target: '#connection.failed'`; re-frame2's `[:failed]` vector is the same
-> "absolute from the root" idea. A relative XState target like `target: 'authenticating'`
-> maps to re-frame2's keyword `:authenticating`.
-
 ---
 
 ## Transition resolution: deepest-wins with parent fallthrough
@@ -236,12 +225,6 @@ Two consequences make hierarchy pay off:
 ;; Dispatching :ws/send instead resolves at :connected (override → :send-now).
 ```
 
-> **In XState** this is the v5/v6 transition-selection order: a descendant state
-> handles an event in preference to its ancestors, and an ancestor handles what
-> the descendant doesn't. The descriptor tiers (exact, `mouse.*` prefix,
-> catch-all `*`) are XState's too — re-frame2 spells the prefix tier on the
-> keyword's `/` boundary (`:mouse/*`) instead of a dotted string.
-
 ### Opting a child OUT of an inherited transition
 
 Sometimes a child needs the *inverse* of inheritance — to **block** a
@@ -264,21 +247,13 @@ The block turns entirely on the key being **present**. A child with *no*
 `:logout` entry keeps falling through (absence means "I don't handle this");
 a deliberately-`nil` key blocks (presence means "I consume this here").
 
-> **In XState** this is `on: { LOGOUT: undefined }` — a forbidden transition.
-> `nil` is the natural Clojure analogue of `undefined`.
-
 ### Unhandled events are a benign no-op
 
 If *no* level enables a transition for an unknown event, the snapshot is
 unchanged and the runtime emits a benign `:rf.machine.event/unhandled-no-op`
-trace. Nothing throws.
-
-> **In XState** an unhandled event is silently ignored (v5 dropped `strict`
-> mode, and the v6 direction keeps it dropped). re-frame2 matches that runtime
-> behaviour — but **deliberately diverges** on one point: where XState emits
-> *nothing*, re-frame2 keeps the observability trace so a debugger can report
-> that an event arrived and was ignored. Benign is not invisible. To "fail loud
-> on unknown," declare a `:*` wildcard whose action throws.
+trace. Nothing throws — but benign is not invisible: the trace lets a debugger
+report that an event arrived and was ignored. To "fail loud on unknown," declare
+a `:*` wildcard whose action throws.
 
 ---
 
@@ -334,10 +309,8 @@ Take this auth-flow machine (a compound `:authenticated` over a `:dashboard` /
 | `:checkout` | `[:authenticated :cart :browsing]` | `[:authenticated :cart :paying]` | Sibling hop inside `:cart`. LCA `:cart`: exit `:browsing`; enter `:paying`. |
 | `:logout` | `[:authenticated :cart :paying]` | `[:unauthenticated]` | Deepest-wins walks `:paying` (no match), `:cart` (no), `:authenticated` (match). LCA is the root: exit `:paying → :cart → :authenticated` (deepest-first); enter `:unauthenticated`. |
 
-> **In XState/SCXML** this is the LCCA / `findLCCA` rule (re-frame2 keeps the
-> historical "LCA" name for the section). The generalisation of the flat
-> `exit → action → entry` rule: in a flat machine the path length is 1 and the
-> LCA is always the root.
+> This generalises the flat `exit → action → entry` rule: in a flat machine the
+> path length is 1 and the LCA is always the root.
 
 Actions are **pure returns**, not imperative writes: an `:entry` /
 `:exit` / transition `:action` is `(fn [{:keys [data event state]}] effects)`
@@ -376,12 +349,9 @@ a vector path, or a full `{:target :guard :action}` / candidate vector), and a
 keyword target resolves as a **sibling of the compound** — the natural "advance
 the outer flow" placement.
 
-> **In XState** `:on-done` on a compound is `onDone`, and re-frame2's
-> `[:rf.machine/done <path>]` is XState's `done.state.<id>` / SCXML's
-> `done.state.id` — the node id rides as the event's single argument so the
-> `:on` table stays keyed on one reserved keyword. The raise lands in the same
-> internal FIFO queue an action's `[:raise …]` uses, drained before the
-> macrostep settles.
+> The node id rides as the raised event's single argument so the `:on` table
+> stays keyed on one reserved keyword. The raise lands in the same internal FIFO
+> queue an action's `[:raise …]` uses, drained before the macrostep settles.
 
 There's also a lower-level escape hatch: if the done node declares no `:on-done`,
 the raised `[:rf.machine/done <path>]` walks the active path leaf→root like any
@@ -403,12 +373,11 @@ So you do **not** have to *avoid* `:final?` to keep a machine alive after a
 sub-flow completes — you put the final leaf *inside* the compound. A final leaf
 at the root, by contrast, ends the actor.
 
-> **Deliberate divergence — "final means final."** A *singleton* (top-level,
-> un-spawned) machine that reaches a **root-level** `:final?` leaf
-> auto-destroys. If you want a state the machine rests in indefinitely (an
-> `:authed` end-screen), use an ordinary leaf and **omit `:final?`**. `:final?`
-> is for "this run is over," not "this is the last screen." (XState's top-level
-> final simply stops the actor; re-frame2 tears it down — the snapshot is gone.)
+> **Final means final.** A *singleton* (top-level, un-spawned) machine that
+> reaches a **root-level** `:final?` leaf auto-destroys — the snapshot is gone.
+> If you want a state the machine rests in indefinitely (an `:authed`
+> end-screen), use an ordinary leaf and **omit `:final?`**. `:final?` is for
+> "this run is over," not "this is the last screen."
 
 ### Reporting a result to a spawning parent: `:output-key`
 
@@ -450,11 +419,9 @@ the same idea at two scopes:
   `(fn [{:keys [data result]}] new-data)` a parent gets when a spawned child
   reaches a root-level `:final?` and is then destroyed.
 
-> **In XState** `:final?` is `type: 'final'` and `:output-key` is the final
-> state's `output`. re-frame2 keeps exactly **one** output primitive — there's
-> no `:output-fn` escape hatch. Want a *computed* output? Write a transition
-> `:action` *into* the final state that stashes the computed value at the
-> `:output-key` slot.
+> re-frame2 keeps exactly **one** output primitive — there's no `:output-fn`
+> escape hatch. Want a *computed* output? Write a transition `:action` *into* the
+> final state that stashes the computed value at the `:output-key` slot.
 
 ### `:final?` constraints
 

--- a/docs/machines/history.md
+++ b/docs/machines/history.md
@@ -2,7 +2,7 @@
 
 Some compound states have a memory. A media player you stop and restart should resume *mid-track*, not jump back to the first second. A wizard you step away from and return to should land on the step you left, not step one. A tabbed settings panel should remember which tab — and how far down each tab was scrolled — across a close/reopen. That "resume where I last was" behaviour is what a **history state** gives you, declaratively, for any [compound state](concepts.md#when-the-machine-grows).
 
-Without it you reach for the obvious workaround — stash the last substate in `:data` on the way out, read it back on the way in, and write the wiring to restore it. History states make that pattern a single node in the transition table, and (because the record/restore lives *inside the snapshot*) they ride undo, time-travel, persistence, and SSR for free. This is xstate's history-state concept, shipped first-class in re-frame2 as a `:type :history` node — same idea, idiomatic spelling.
+Without it you reach for the obvious workaround — stash the last substate in `:data` on the way out, read it back on the way in, and write the wiring to restore it. History states make that pattern a single node in the transition table — a first-class `:type :history` node — and (because the record/restore lives *inside the snapshot*) they ride undo, time-travel, persistence, and SSR for free.
 
 > History only applies to a **compound** state — a state with its own `:states` and `:initial`. If "which tab" or "which step" is a single flat value, just keep it in [`:data`](concepts.md#the-same-flow-as-a-transition-table) like any other state; that is ordinary modelling, not a feature you need to name. History earns its keep when a *non-trivial nested* configuration is worth remembering across a leave/return.
 
@@ -42,7 +42,7 @@ Here is a player with a `:tray` (no disc) and a `:player` compound (disc inserte
       :paused  {:on {:resume [:player :playing]}}}}}})
 ```
 
-A machine **is an event handler** ([this is the load-bearing difference from xstate](coming-from-xstate.md) — there is no actor to `send` to), so you drive it with ordinary dispatched events and read it with an ordinary subscription:
+A machine **is an event handler** — there is no actor to `send` to — so you drive it with ordinary dispatched events and read it with an ordinary subscription:
 
 ```clojure
 (rf/dispatch [:media-player [:insert]])  ;; :tray → nothing recorded yet → :default-target → [:player :stopped]
@@ -95,7 +95,7 @@ Reach for **deep** when the precise nested position matters (resume the exact tr
 
 Recording is automatic and happens on the way **out**: whenever the exit cascade *leaves* a compound that owns a history pseudo-state, the runtime writes that compound's last-active configuration into the snapshot. You never write capture code.
 
-The owning compound must be **genuinely exited** to record. This is the [W3C SCXML](https://www.w3.org/TR/scxml/#history) / xstate exit-set rule: a `<history>` value is written only for states in the exit set. A transition that merely moves *between two children* of the compound keeps the compound as the [least-common ancestor](concepts.md#when-the-machine-grows) — the compound **survives**, was never left, and so records nothing (there is no "last config" to remember; it is still in one).
+The owning compound must be **genuinely exited** to record. This is the [W3C SCXML](https://www.w3.org/TR/scxml/#history) exit-set rule: a `<history>` value is written only for states in the exit set. A transition that merely moves *between two children* of the compound keeps the compound as the [least-common ancestor](concepts.md#when-the-machine-grows) — the compound **survives**, was never left, and so records nothing (there is no "last config" to remember; it is still in one).
 
 That is exactly why `:eject` targets `:tray` (a *sibling of* `:player`, outside it) rather than some inner state: only leaving `:player` puts it in the exit set. A common first mistake is to put the history node on a compound that nothing ever exits — then it silently never records and "restore" always falls to the default. If your history isn't sticking, check that *something leaves the owning compound.*
 
@@ -143,28 +143,14 @@ Under a [parallel](concepts.md#when-the-machine-grows) machine each region runs 
 
 Restoring history in one region leaves the others untouched — the same per-region scoping that `:spawn`, `:after`, and `:always` follow under parallel.
 
-## Coming from XState
-
-If you've drawn history states in xstate, the concepts port one-for-one; only the spelling changes (re-frame2 prefers `?`-suffixed booleans and keyword targets). re-frame2 tracks **behavioural parity** with [xstate v6](coming-from-xstate.md), not API mimicry:
-
-| XState (v5 / v6) | re-frame2 | Note |
-|---|---|---|
-| `{ type: 'history' }` | `{:type :history}` | Same pseudo-state. |
-| `history: 'deep'` (default `'shallow'`) | `:deep? true` (default shallow) | A boolean rather than a string; default is shallow in both. |
-| `target: 'someState'` (default when no history) | `:default-target :some-state` | Where the first entry lands before anything is recorded; absent ⇒ the compound's `:initial`. |
-| internal `historyValue` on the actor | the `:rf/history` slot **inside the snapshot** | **The deliberate divergence.** xstate keeps history as internal actor state; re-frame2 keeps it as a revertible value in the frame, which is why undo / time-travel / SSR get history for free. |
-| records on `statesToExit` (SCXML Appendix D) | records only when the owning compound is in the **exit set** | Identical semantic — history means "where this compound was when we *left* it," so the compound must actually be left. |
-
-The one thing to unlearn is *where the memory lives*: there is no actor object holding `historyValue`. The memory is a value in the snapshot, and the snapshot is just data on the frame.
-
 ## Why history is first-class, not a snapshot you stash yourself
 
 You *could* hand-roll the equivalent: an `:exit` action that copies the current sub-path into `:data`, an entry that reads it back, plus the bookkeeping to know *which* compound (and, under parallel, *which region*). re-frame2 ships the declarative node instead, for four reasons:
 
 - **Declarative beats hand-rolled.** `{:type :history :deep? true}` is one node an AI agent (or a teammate) reads and writes confidently; the stash-and-restore version is bespoke per machine.
 - **Composition you'd otherwise re-derive.** Per-region history under parallel, deep nesting, and shallow-vs-deep depth all fall out of the grammar plus the existing cascade machinery — the hand-rolled form has to re-implement each, correctly, every time.
-- **Tooling legibility.** A `:type :history` node is visible to the machine inspector, the diagram exporter, and the SCXML / xstate corpus; hand-rolled `:data` shuffling is invisible to all of them.
-- **Parity.** Both SCXML (`<history>`) and xstate (`{type:'history'}`) ship first-class history; matching the shape keeps the conformance corpus and the AI-trained-on-xstate path aligned.
+- **Tooling legibility.** A `:type :history` node is visible to the machine inspector, the diagram exporter, and the SCXML corpus; hand-rolled `:data` shuffling is invisible to all of them.
+- **Parity.** SCXML (`<history>`) ships first-class history; matching that shape keeps the conformance corpus aligned.
 
 Revertibility is what makes history *cheap* (the recording rides the snapshot), but it's the foundation history is built on, not a reason to skip the feature.
 

--- a/docs/machines/index.md
+++ b/docs/machines/index.md
@@ -4,7 +4,7 @@ Finite state machines are hiding in plain sight, everywhere in your app. Your ap
 
 Model one of those lifecycles with scattered boolean flags — `:loading?`, `:submitting?`, `:error?` — and it drifts out of sync and sprouts impossible states ("submitting *and* error" at once). A **machine** makes the lifecycle explicit: named states, named transitions, exactly one state at a time. The illegal combinations simply can't be represented.
 
-re-frame2 has first-class, **hierarchical** state machines — nested states, parallel regions, spawned children, guards, delayed transitions: the full XState v6 feature set. And they're wired right into the re-frame2 substrate, **not bolted on as a side-car**. A machine *is* an event handler. Its live value is a [snapshot](glossary.md#snapshot) you read with an ordinary subscription and move with an ordinary dispatched event — same cascade, same `app-db`, same Xray, same tests. There's no second runtime to learn.
+re-frame2 has first-class, **hierarchical** state machines — nested states, parallel regions, spawned children, guards, delayed transitions. And they're wired right into the re-frame2 substrate, **not bolted on as a side-car**. A machine *is* an event handler. Its live value is a [snapshot](glossary.md#snapshot) you read with an ordinary subscription and move with an ordinary dispatched event — same cascade, same `app-db`, same Xray, same tests. There's no second runtime to learn.
 
 ```clojure
 (rf/reg-machine :auth/login

--- a/docs/machines/inspecting-machines.md
+++ b/docs/machines/inspecting-machines.md
@@ -33,8 +33,8 @@ The canonical window onto a machine is the framework-registered subscription `[:
 
 The three keys are the whole user-facing shape:
 
-- **`:state`** — the discrete FSM keyword (`:idle`, `:submitting`, …). For a hierarchical machine it's a path vector (`[:authenticated :cart :browsing]`); for a parallel machine, a region map. This is what XState calls `state.value`.
-- **`:data`** — the machine's extended state: a plain map, distinct from app-db. XState calls this slot `context`; re-frame2 calls it `:data` to avoid the already-overloaded word "context". Read the fields a view needs by destructuring (above) or through a named projection sub (below).
+- **`:state`** — the discrete FSM keyword (`:idle`, `:submitting`, …). For a hierarchical machine it's a path vector (`[:authenticated :cart :browsing]`); for a parallel machine, a region map.
+- **`:data`** — the machine's extended state: a plain map, distinct from app-db; it's named `:data` to avoid the already-overloaded word "context". Read the fields a view needs by destructuring (above) or through a named projection sub (below).
 - **`:tags`** — the runtime-projected union of every active state's `:tags`. Ask membership questions against it rather than hard-coding state names (see below).
 
 > **The snapshot is `nil` until the first event.** A machine bootstraps itself on the first event addressed to it, so `[:rf/machine id]` reads `nil` before then. A view that renders pre-bootstrap should fall back to the definition's `:initial`:
@@ -72,7 +72,7 @@ Once a machine has several "loading-ish" states, views stop asking *which exact 
 
 This sub re-renders only when *this* tag's membership bit flips, so adding a fifth busy state later is one `:tags` entry on the new node — zero view changes.
 
-> **Coming from XState.** There you'd call `actor.getSnapshot()` on a live actor object. In re-frame2 there is no actor object — the snapshot is a value living at `[:rf.runtime/machines :snapshots :auth.login/flow]` in runtime-db, read through the ordinary subscription graph. The payoff is that time-travel, undo, persistence, and SSR hydration all extend to machines *for free*, because the snapshot rides the frame like any other state.
+> **The snapshot is a value, not a live object.** It lives at `[:rf.runtime/machines :snapshots :auth.login/flow]` in runtime-db and is read through the ordinary subscription graph. The payoff is that time-travel, undo, persistence, and SSR hydration all extend to machines *for free*, because the snapshot rides the frame like any other state.
 
 See [`[:rf/machine machine-id]`](../api/re-frame.machines.md#rfmachine-machine-id) and [`machine-has-tag?`](../api/re-frame.machines.md) in the API reference.
 
@@ -96,7 +96,7 @@ A reliable machine-debugging loop:
 
 That loop keeps you out of the commonest machine trap: staring at the *current* state while forgetting the *event* that moved it there. Because a machine has a small, named state space, Xray can say something a generic logger never could — not "something updated a map" but "this event moved `:door/main` from `:closed` to `:opening`, ran this guard, scheduled this timer, and cancelled that prior branch." That's the difference between seeing state and seeing behavior.
 
-> **Coming from XState.** Stately's inspector and `@statelyai/inspect` attach an observer to a running actor. Xray's Machine Inspector is the re-frame2 counterpart — but it reads the **same trace bus every event handler already uses**, not a machine-special channel. (A note on scope: there is *no* framework-level `machine->xstate-json` or Mermaid export — visualisation exporters live in the separate `re-frame2-machines-viz` library, not the framework.)
+> **Xray's Machine Inspector reads the same trace bus every event handler already uses**, not a machine-special channel. (A note on scope: there is *no* framework-level chart or JSON export — visualisation exporters live in the separate `re-frame2-machines-viz` library, not the framework.)
 
 The full tour is in [Xray — Machine Inspector](../xray/08-machine-inspector.md).
 
@@ -163,7 +163,7 @@ When you've found the guard that blocked a transition and want to *read it*, ask
 
 This is the surface Xray's focused-transition lens and the re-frame2 pair MCP use to render guard/action source inline under their declared id. (`reg-machine` captures that source at macro-expansion time; the `:source`-bearing slots are dev-only and elide under `:advanced` + `goog.DEBUG=false`.) See [`handler-meta`](../api/re-frame.core.md#handler-meta) for the general contract.
 
-> **Divergence the spec calls out — a guard that throws aborts the macrostep.** This matches XState (which throws on a guard exception): re-frame2 emits one `:rf.machine/guard-evaluated` with `:outcome :threw`, then aborts transition selection — no candidate falls through to a sibling, no transition fires, and the snapshot rolls back **atomically** (nothing reaches runtime-db). A thrown *action* and a runaway `:always`/`:raise` depth-abort converge on the same failed-macrostep semantics. The runtime does not silently demote a thrown guard to a lower-priority candidate — and neither does XState.
+> **A guard that throws aborts the macrostep — the spec calls this out.** re-frame2 emits one `:rf.machine/guard-evaluated` with `:outcome :threw`, then aborts transition selection — no candidate falls through to a sibling, no transition fires, and the snapshot rolls back **atomically** (nothing reaches runtime-db). A thrown *action* and a runaway `:always`/`:raise` depth-abort converge on the same failed-macrostep semantics. The runtime does not silently demote a thrown guard to a lower-priority candidate.
 
 ---
 
@@ -225,7 +225,7 @@ The `login-flow` table above is plain data, so the very same value that renders 
 
 Most logic lives at Level 1. Reach for Level 3 only for spawned-actor patterns, where the whole point is that a handler gets registered dynamically and the parent can `dispatch` to it. The contracts for all three are in [Spec 005 §Testing](../../spec/005-StateMachines.md).
 
-> **Coming from XState.** Driving an XState machine in a test means standing up the interpreter (`createActor(machine).start()`, then `actor.send(…)`) or reaching for `@xstate/test`'s model-based harness. re-frame2's `machine-transition` needs neither — it's a bare pure function, so the unit test *is* `(fn definition snapshot event)`. The behavioural contract is identical: *(state, event) → next state + effects*; only the actor object disappears.
+> **The test *is* the transition function.** A `machine-transition` test is literally `(fn definition snapshot event)` — nothing to instantiate, you assert the behavioural contract *(state, event) → next state + effects* directly.
 
 See [`machine-transition`](../api/re-frame.machines.md#re-framemachinesmachine-transition) and [`machine-meta`](../api/re-frame.machines.md#re-framemachinesmachine-meta) in the API reference, and the narrative in [Concepts §Testing](concepts.md#testing-transitions-are-pure-function-calls).
 

--- a/docs/machines/parallel-states.md
+++ b/docs/machines/parallel-states.md
@@ -4,8 +4,6 @@ Some lifecycles aren't *one* question — they're several, all live at once. A t
 
 Model that as one flat machine and the states multiply — three axes of three states each is `3 × 3 × 3 = 27` cross-product states, most of them named things like `:loading-and-invalid-and-active`. **Parallel regions** keep the axes apart. One machine declares `:type :parallel` and a `:regions` map; each region is a full little state-tree minding one axis; all regions are active simultaneously. Three axes of three states becomes **nine states across three regions**, not twenty-seven flat ones.
 
-> **Coming from XState?** This is XState's `type: 'parallel'` state (and SCXML's `<parallel>`). Same concept, idiomatic spelling: `:type :parallel` plus a `:regions` map keyed by region name. The behaviour is the contract re-frame2 tracks — see [Coming from XState](coming-from-xstate.md) for the full delta, and [the machines guide](concepts.md#when-the-machine-grows) for where this sits among the other grammar extensions.
-
 ## When to reach for parallel regions
 
 Reach for them when you have **multiple orthogonal axes of one feature** that share a domain: one form with data / validity / display-mode axes, one connection with auth + lifecycle + request-queue, one widget with display + interaction state. The giveaway is a single conceptual thing whose state is naturally a *tuple* of independent sub-states.
@@ -76,7 +74,7 @@ Three things to read off that snapshot:
 - **`:data`** is **shared** — one map, seen and written by every region. There is no per-region `:data` slot, on the region body or in the snapshot.
 - **`:tags`** is the **union** of every active state's tags across every region (covered [below](#tags-compose-across-regions)).
 
-> **Coming from XState?** XState's parallel state value is a nested object, `{ data: 'loading', form: 'neutral', mode: 'active' }`. re-frame2's `:state` map is the same idea in Clojure data, and you read it through one ordinary subscription — `@(rf/subscribe [:rf/machine :ui/nine-states])` — not an `actor.getSnapshot()`. The [`[:rf/machine machine-id]`](../api/re-frame.machines.md#rfmachine-machine-id) sub returns the whole snapshot; named projections chain off it like any other [subscription](../core/concepts/subscriptions.md).
+You read the `:state` map through one ordinary subscription — `@(rf/subscribe [:rf/machine :ui/nine-states])`. The [`[:rf/machine machine-id]`](../api/re-frame.machines.md#rfmachine-machine-id) sub returns the whole snapshot; named projections chain off it like any other [subscription](../core/concepts/subscriptions.md).
 
 ## Each region has its own `:initial`
 
@@ -139,7 +137,7 @@ When *several* regions handle the same event, each one's action runs against the
 
 If you wanted that event to count *once*, you'd register the coordinating action at the parent-machine level, or shape the regions so only one handles it.
 
-> **A subtle, load-bearing rule — selection is order-independent.** The broadcast is **select-then-apply**: every region's enabled transition is *selected* against **one frozen pre-broadcast snapshot** of the configuration, and only *then* are the selected transitions *applied* in declaration order. Declaration order governs only the apply order (action / `:fx` order, `:data` accumulation) — **never** which transitions are selected. Reorder the regions and you get the *same* selected set, and the new configuration is computed **atomically** old→new: no region ever observes an intermediate state where some siblings have moved and others haven't. This matches XState v5 / SCXML, where a parallel macrostep selects against the pre-event configuration. (It matters most for the next section.)
+> **A subtle, load-bearing rule — selection is order-independent.** The broadcast is **select-then-apply**: every region's enabled transition is *selected* against **one frozen pre-broadcast snapshot** of the configuration, and only *then* are the selected transitions *applied* in declaration order. Declaration order governs only the apply order (action / `:fx` order, `:data` accumulation) — **never** which transitions are selected. Reorder the regions and you get the *same* selected set, and the new configuration is computed **atomically** old→new: no region ever observes an intermediate state where some siblings have moved and others haven't. This matches SCXML, where a parallel macrostep selects against the pre-event configuration. (It matters most for the next section.)
 
 ## The root `:on`: an ancestor fallback
 
@@ -187,22 +185,20 @@ That last result is the **non-decomposable** case. A naive broadcast decompositi
 
 A `:type :parallel` root may also declare its own **`:after`** — the timer-driven twin of the root `:on`. It's scheduled at machine birth, owned by the root (alive for the machine's whole life rather than tied to any one region's lifecycle), and uses the very same region-qualified target grammar.
 
-> **Coming from XState?** This is XState's "[multiple transitions in parallel states](https://stately.ai/docs/state-machines-and-statecharts)" — a transition on the `<parallel>` node targeting one or several regions, `target: ['.a.x', '.b.y']`, which re-frame2 spells `:target [[:a :x] [:b :y]]`. The atomic suppression-when-a-region-competes is XState v5 / SCXML behaviour.
-
 ## Coordinating regions: tags as `stateIn`
 
 Orthogonal regions are independent — but sometimes one region's transition should depend on *where a sibling is*. The classic case: a `:checkout` region's `:submit` should only fire when the `:form` region is `:valid`.
 
-In XState you'd write a `stateIn({ form: 'valid' })` guard (SCXML's `In()` predicate). re-frame2 ships the same **behaviour** without a separate combinator (behavioural parity, not API mimicry). When a guard or action runs **inside a region** of a parallel machine, its context map carries two extra cross-region keys alongside the usual `:data` / `:event` / `:state` / `:meta`:
+re-frame2 lets one region's guard or action read where a sibling sits — no separate combinator needed. When a guard or action runs **inside a region** of a parallel machine, its context map carries two extra cross-region keys alongside the usual `:data` / `:event` / `:state` / `:meta`:
 
 | ctx key | value | use |
 |---|---|---|
 | **`:tags`** | the machine-wide active-configuration tag union | the **coarse** read — a sibling advertises a tag, you ask `(contains? tags :form/valid)`. The idiomatic choice: a tag is a *named* render-state that survives a sibling renaming its internal states. |
-| **`:all-state`** | the full region → active-state map, e.g. `{:form :valid :checkout :idle}` | the **precise** read — `(= :valid (:form all-state))` matches a sibling's discrete state value directly, the literal analog of `stateIn({form: 'valid'})`. |
+| **`:all-state`** | the full region → active-state map, e.g. `{:form :valid :checkout :idle}` | the **precise** read — `(= :valid (:form all-state))` matches a sibling's discrete state value directly. |
 
 ```clojure
-;; xstate stateIn({form: 'valid'}), as re-frame2's tag substitute: :checkout's
-;; :submit fires only while the :form region advertises :form/valid.
+;; :checkout's :submit fires only while the :form region
+;; advertises :form/valid — read via the cross-region :tags key.
 (rf/reg-machine :ui/checkout
   {:type   :parallel
    :data   {}
@@ -234,7 +230,7 @@ The precise variant reads the sibling's state value directly:
 
 Prefer the **tag** query: a tag is a named, tool-legible render-state, and it holds up when a sibling region refactors its internal state names.
 
-> **Both keys are frozen.** `:tags` and `:all-state` reflect the **frozen pre-broadcast snapshot** — the sibling configuration as of the *start* of the macrostep. A region's guard never sees a sibling's *same-event* move during selection (regions are genuinely simultaneous), which is exactly why selection is declaration-order-independent. A region reading its *own* state uses `:state` (which does evolve through its own `:always` loop); `:tags` / `:all-state` are the mechanism for reading *siblings*, and they're frozen. These two keys appear **only** for region guards/actions — a flat / compound machine's ctx stays exactly `{:data :event :state :meta}`, because its own `:state` is its `stateIn` substitute.
+> **Both keys are frozen.** `:tags` and `:all-state` reflect the **frozen pre-broadcast snapshot** — the sibling configuration as of the *start* of the macrostep. A region's guard never sees a sibling's *same-event* move during selection (regions are genuinely simultaneous), which is exactly why selection is declaration-order-independent. A region reading its *own* state uses `:state` (which does evolve through its own `:always` loop); `:tags` / `:all-state` are the mechanism for reading *siblings*, and they're frozen. These two keys appear **only** for region guards/actions — a flat / compound machine's ctx stays exactly `{:data :event :state :meta}`, because it has no siblings to read; its own `:state` already answers *where am I?*.
 
 The two `dispatch-sync` calls above are **separate events**, which is why each `:submit` reads the prior committed config. If you need a *single* event to flip `:form` to `:valid` **and** advance `:checkout` in the same breath, two statechart-idiomatic paths re-couple them — they differ in *when* convergence lands:
 
@@ -252,7 +248,7 @@ Each region's state-node keys are **scoped to that region**:
 - **`:spawn`** — a region's [`:spawn`](glossary.md#spawn)-bearing state starts and tears down child actors bound to *that region's* state; siblings never see the spawn / destroy cascade.
 - **`:entry` / `:exit`** — fire on the region's own transitions, never on a sibling's.
 
-> **`:raise` is the exception — it BROADCASTS.** A `[:raise [:event]]` emitted by any region's action does **not** stay local. It re-enters the parallel machine's single internal-event queue and re-broadcasts across **every** region — exactly as XState / SCXML deliver a `raise`d internal event to the whole machine, every active parallel state included. Each re-broadcast is its own microstep (a fresh frozen sibling view that already reflects the prior microstep's moves, while the in-flight `:data` flows through), the queue drains FIFO, and the whole macrostep — external event + every raised event + every region's `:always` settling — commits **once, atomically**, bounded by the `:raise-depth-limit`.
+> **`:raise` is the exception — it BROADCASTS.** A `[:raise [:event]]` emitted by any region's action does **not** stay local. It re-enters the parallel machine's single internal-event queue and re-broadcasts across **every** region — exactly as SCXML delivers a `raise`d internal event to the whole machine, every active parallel state included. Each re-broadcast is its own microstep (a fresh frozen sibling view that already reflects the prior microstep's moves, while the in-flight `:data` flows through), the queue drains FIFO, and the whole macrostep — external event + every raised event + every region's `:always` settling — commits **once, atomically**, bounded by the `:raise-depth-limit`.
 
 ## Tags compose across regions
 
@@ -285,4 +281,4 @@ The root view then branches with a single `case` over `@(rf/subscribe [:ui/rende
 
 ## A divergence to know: no nested parallel regions
 
-**Nested parallel regions are not supported in v1.** A region whose own tree declares `:type :parallel` is rejected at registration with `:rf.error/machine-parallel-nested-not-supported`. XState permits arbitrary nesting; re-frame2 does not (yet). Model a would-be two-level cross-product as a flatter set of regions, or — more idiomatically — as multiple top-level parallel-region machines. A region *may* still be a compound (hierarchical) state-tree; it just can't itself be parallel.
+**Nested parallel regions are not supported in v1.** A region whose own tree declares `:type :parallel` is rejected at registration with `:rf.error/machine-parallel-nested-not-supported`. Model a would-be two-level cross-product as a flatter set of regions, or — more idiomatically — as multiple top-level parallel-region machines. A region *may* still be a compound (hierarchical) state-tree; it just can't itself be parallel.

--- a/docs/machines/tags.md
+++ b/docs/machines/tags.md
@@ -10,7 +10,7 @@ Reach for tags when:
 
 If a label would only ever match exactly one state, skip it — query the state directly with `(= :loading (:state snap))`. Tags earn their keep by matching *many* states with one shared intent.
 
-> **Coming from XState.** re-frame2's `:tags` *are* XState's state `tags` — same name, same concept, a clean convergence. `tags: ['busy']` becomes `:tags #{:busy}` (a Clojure set, not a JS array), and the union rule is identical: any active state carrying the tag puts it in the snapshot's tag set. The one shift to learn is the *query* side. XState reads `state.hasTag('busy')` off a living actor; in re-frame2 a machine is an [event handler](../core/glossary.md#event-handler) with no actor object, so the membership question is a **[subscription](../core/concepts/subscriptions.md)** — `@(rf/machine-has-tag? id :busy)`. The full row-by-row map is in [Coming from XState](coming-from-xstate.md#the-mapping). This page assumes the [machine grammar](concepts.md) — `reg-machine`, the transition table, the `{:state :data}` snapshot — from the concepts chapter.
+This page assumes the [machine grammar](concepts.md) — `reg-machine`, the transition table, the `{:state :data}` snapshot — from the concepts chapter.
 
 ## Declaring tags on a state
 
@@ -154,13 +154,13 @@ And the controls disable themselves the same ask-don't-tell way — they ask for
 
 Notice what the form *doesn't* ask: "is the `:mode` region in `:done`?" It asks "is this read-only?" Move `:mode/read-only` onto a different state tomorrow and this view doesn't change a line.
 
-## Tags as a cross-region signal (`stateIn`)
+## Tags as a cross-region signal
 
-In a parallel machine the tag union spans *all* regions, which makes it the channel one region uses to read what a sibling is doing. This is the classic statechart coordination primitive: a guard in region A predicates on region B's state. XState spells it `stateIn({ form: 'valid' })` (and W3C SCXML has `In(...)`); re-frame2 ships the *behaviour* without a separate `stateIn` operator — a deliberate divergence for behavioural parity, not API mimicry. **A sibling region advertises a tag, and any region's guard reads the tag union off its context map.**
+In a parallel machine the tag union spans *all* regions, which makes it the channel one region uses to read what a sibling is doing. This is the classic statechart coordination primitive: a guard in region A predicates on region B's state. re-frame2 ships this without a dedicated operator: **a sibling region advertises a tag, and any region's guard reads the tag union off its context map.**
 
 A guard or action running *inside a parallel region* gets two extra keys in its context map, alongside the usual `:data` / `:event` / `:state` / `:meta`:
 
-- **`:tags`** — the machine-wide tag union (the **coarse**, idiomatic `stateIn` substitute);
+- **`:tags`** — the machine-wide tag union (the **coarse**, idiomatic read);
 - **`:all-state`** — the full `{region → active-state}` map (the **precise** read).
 
 ```clojure
@@ -190,7 +190,7 @@ Prefer the **tag** form: a tag is a named, tool-legible render-state, and it sur
 Two things to hold onto:
 
 - **A tag is a guard *input*, not a *trigger*.** A tag flipping on does not *fire* anything — there is no "on this tag appearing" transition. The dependent region still moves on its next event (or an eventless `:always`); the guard merely *reads* the sibling's advertised tag when it runs.
-- **These keys are parallel-only, and frozen.** A flat or compound machine's guard/action context is exactly `{:data :event :state :meta}` — no `:tags` / `:all-state`, because a flat machine has no sibling to coordinate with (its own `:state` is its `stateIn`). In a parallel machine both keys reflect the configuration *as of the start of the macrostep*, so every region selects against the same frozen sibling view, independent of region declaration order. The exact same-event convergence paths — `:raise` for same-macrostep coupling, a guarded `:always` for next-event coupling — are spelled out in the spec.
+- **These keys are parallel-only, and frozen.** A flat or compound machine's guard/action context is exactly `{:data :event :state :meta}` — no `:tags` / `:all-state`, because a flat machine has no sibling to coordinate with (its own `:state` is all there is to read). In a parallel machine both keys reflect the configuration *as of the start of the macrostep*, so every region selects against the same frozen sibling view, independent of region declaration order. The exact same-event convergence paths — `:raise` for same-macrostep coupling, a guarded `:always` for next-event coupling — are spelled out in the spec.
 
 ## What tags are *not*
 

--- a/docs/machines/tutorial.md
+++ b/docs/machines/tutorial.md
@@ -2,7 +2,7 @@
 
 The fastest way to understand a re-frame2 state machine is to build one and watch each piece arrive on its own. We'll make a **login flow** — idle, then submitting, then either signed-in or showing an error, and locked out after too many tries — adding one idea at a time: a guard, an action, a real server call, a view, and a test.
 
-This page assumes you've done the [core Quickstart](../core/quickstart.md) — you know what an [event](../core/concepts/events-and-the-cascade.md), a [subscription](../core/concepts/subscriptions.md), and a [view](../core/concepts/views.md) are. If you'd rather see the whole model at once, read [Concepts](concepts.md); if you're arriving from XState, [the mapping](coming-from-xstate.md) may be the faster door.
+This page assumes you've done the [core Quickstart](../core/quickstart.md) — you know what an [event](../core/concepts/events-and-the-cascade.md), a [subscription](../core/concepts/subscriptions.md), and a [view](../core/concepts/views.md) are. If you'd rather see the whole model at once, read [Concepts](concepts.md).
 
 > **One idea to carry through.** A machine is just an event handler. You *read* its current state — a small map called the [snapshot](glossary.md#snapshot) — through a subscription, and you *move* it by dispatching an event. There's no actor object to hold and no second runtime to learn. Keep that in mind and every step below is a small variation on the `dispatch` / `subscribe` loop you already know.
 


### PR DESCRIPTION
The machine pages were littered with XState micro-mentions — inline parentheticals, "> Coming from XState?" callouts, two whole "Coming from XState" sections, the "full XState v6 feature set" phrasing. Distracting on pages that should read as pure re-frame2.

- **Stripped all XState/Stately mentions from the 11 other machine pages** (~109 occurrences), repairing the prose so each reads cleanly. The re-frame2 facts and examples are unchanged — only the XState framing is gone.
- **`coming-from-xstate.md` is now the single home** for XState / v6-parity material. It already held the comprehensive mapping + divergences; I harvested the two finer parity facts that weren't yet there (the four-primitive actor-messaging consolidation → `:rf.machine/dispatch-to-system` + `:rf/parent-id`; the same-tick `:after` tie ordering) and fixed its self-link to the now-deleted concepts "five-row delta" section.

## Verification (local)
Zero XState mentions remain outside `coming-from-xstate.md`; `check_doc_slugs` (0 broken), `check_readme_links`, the 3 residue checkers, and the api-manifest JVM gate (671 refs reconcile). `mkdocs --strict` runs in CI.