### PR TITLE
docs: remove the 'In this section' nav lists from the capability index pages

### DIFF
--- a/docs/async/index.md
+++ b/docs/async/index.md
@@ -15,9 +15,4 @@ That pattern is a **managed effect**: you *describe* the side effect, the runtim
 
 > **Separate artefact.** Managed HTTP ships as `day8/re-frame2-http`, so apps that never issue a request build clean of it. Require `re-frame.http.managed` once at boot and the `:rf.http/managed` effect is wired up.
 
-## In this section
-
-- **[Managed HTTP](http.md)** — the `:rf.http/managed` effect end to end: the smallest request that works, reading the reply, the closed set of failure categories, retries, decoding, and curing the search-box race for free.
-- **[API reference](../api/re-frame.http.md)** — the `:rf.http/managed` args map, the reply contract, request interceptors, and failure categories, with signatures.
-
 For the *cache* over server reads — staleness, invalidation, scope — that's [Resources](../resources/index.md), which rides on managed HTTP underneath.

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -15,9 +15,3 @@ re-frame2's **resources** capability makes server state declarative. You registe
 ```
 
 Underneath sits [**managed HTTP**](../async/index.md) (`:rf.http/managed`) — you describe a request as data and the runtime drives its whole lifecycle, dispatching the result back as an ordinary event. Resources are the high-level cache; managed HTTP — now its own section, [Async (HTTP)](../async/index.md) — is the transport they ride on, and it's there for the requests that aren't cached reads.
-
-## In this section
-
-- **[Concepts](concepts.md)** — resources, mutations, the cache, scope, invalidation, optimistic updates: how server state works.- **[Tutorial: Build RealWorld](tutorial/index.md)** — build a real, server-backed app (Conduit) end to end. This is the capability's worked example.
-- **[How-to](how-to/paginate-a-feed.md)** — task recipes: paginate a feed, invalidate after a mutation.
-- **[API](../api/re-frame.resources.md)** — `reg-resource`, `reg-mutation`, the `:rf/resource` subscription, the cache/invalidation surface.- **[Glossary](glossary.md)** — the server-state vocabulary in one place.

--- a/docs/routing/index.md
+++ b/docs/routing/index.md
@@ -17,28 +17,4 @@ You register routes (`reg-route`) as a table mapping URL patterns to what they n
 
 Because a route's [loader](glossary.md#loader) runs on the server too, routing and [SSR](../ssr/index.md) share one data-fetch story — there's no separate server fetch to keep in sync.
 
-## In this section
-
-These pages are the **guide** — read top to bottom to learn routing, or dip in to understand one part. Every signature, event, subscription, and keyword has its canonical home in the separate **[API reference](../api/re-frame.routing.md)**: the guide teaches, the reference is where you look things up.
-
-**Start here**
-
-- **[Tutorial: build a routed app](tutorial.md)** — build a small three-page app one piece at a time: routes, links, dynamic segments, loaders, the 404, the Back button, and a shared layout.
-
-**Understand the model**
-
-- **[Concepts](concepts.md)** — the whole model in three moves, then everything a growing app reaches for: query strings, the loading/error transition, nested layouts, navigation blocking, data classification, and routing on the server.
-- **[Coming from React Router](coming-from-react-router.md)** — the mapping from `createBrowserRouter`, loaders, and the hooks, and where re-frame2 deliberately diverges.
-
-**Do a task**
-
-- **[Guard against unsaved changes](how-to/guard-unsaved-changes.md)** and **[Require sign-in on a route](how-to/require-sign-in-on-a-route.md)** — focused recipes for the two common navigation-control jobs.
-
-**Look it up**
-
-- **[API reference](../api/re-frame.routing.md)** — `reg-route`, every `:rf.route/*` event and subscription, the URL helpers, and the guard contract, with signatures.
-- **[Glossary](glossary.md)** — the routing vocabulary in one place.
-
-**See it running**
-
-- **[Examples](examples.md)** — worked routing apps you can read end to end.
+The routing docs are a **guide** — read top to bottom to learn routing, or dip in to understand one part. Every signature, event, subscription, and keyword has its canonical home in the separate **[API reference](../api/re-frame.routing.md)**: the guide teaches, the reference is where you look things up.

--- a/docs/ssr/index.md
+++ b/docs/ssr/index.md
@@ -11,9 +11,3 @@ On the server, [`render-to-string`](glossary.md#render-to-string) runs your real
 ;; client: adopt the server's HTML instead of re-rendering it
 (rf/dispatch [:rf/hydrate payload])
 ```
-
-## In this section
-
-- **[Concepts](concepts.md)** — one app runs twice, `:platforms`, render-to-string, hydration, and locating mismatches.
-- **[API](../api/re-frame.ssr.md)** — `render-to-string`, the hydration payload contract, `:rf/hydrate`, strict-mode config.
-- **[Glossary](glossary.md)** — the SSR vocabulary in one place.


### PR DESCRIPTION
Removes the redundant in-body **"In this section"** page enumerations from the 4 capability index pages — `async`, `resources`, `routing`, `ssr`. The left nav already lists each section's pages (same reasoning as the machines index landing rewrite, and the earlier "Where to go next" / "Further reading" removals).

**Surgical, not blind truncation** — kept the non-nav prose that happened to sit under the heading:
- **async** — kept the managed-HTTP-vs-Resources distinction sentence.
- **routing** — kept the guide-vs-reference framing (reworded to stand alone), dropped the categorized page lists.
- **ssr / resources** — pure nav lists, removed wholesale.

Each index now ends on its pitch.

`check_doc_slugs` + `check_readme_links` green; `mkdocs --strict` runs in CI.