### PR TITLE
feat(routing,resources): add sub-pending-navigation + sub-mutation + sub-resource read sugar (rf2-kqfzu3)

### DIFF
--- a/implementation/resources/src/re_frame/resources.cljc
+++ b/implementation/resources/src/re_frame/resources.cljc
@@ -68,6 +68,7 @@
             [re-frame.resources.state :as state]
             [re-frame.resources.subs :as resource-subs]
             [re-frame.resources.timers :as timers]
+            [re-frame.subs :as subs]
             ;; rf2-8x0gfa (EP-0015): the OFF-BOX trace-row egress projector for
             ;; the resource/mutation trace family's scoped-key slots. A
             ;; production-reachable ns (NOT the bundle-isolated tooling sibling)
@@ -287,6 +288,73 @@
        :extra    {:opts (dissoc opts :frame)}}))
   (let [runtime-db (frame/frame-runtime-db-value frame)]
     (get-in runtime-db (mstate/instance-path instance))))
+
+;; ---- named reactive-read sugar --------------------------------------------
+;; Thin read sugar over the canonical `[:rf.mutation/state …]` /
+;; `[:rf.resource/state …]` subscription vectors. Defined + exported HERE on
+;; the `re-frame.resources` façade (NOT `re-frame.core`) so a non-resources
+;; app's production-elision bundle carries no resource/mutation keyword
+;; strings — the resources bundle-isolation invariant, the peer of routing's
+;; `sub-route`. The vector forms remain the registered subs; these layer over
+;; them. Each is a single thin fn (NOT a per-projection family).
+
+(defn sub-mutation
+  "Subscribe to a mutation INSTANCE's state. Sugar over
+  `(subscribe [:rf.mutation/state {:instance <instance>}])`. Returns a
+  reaction over the mutation view-model `{:status :result :error
+  :affected-keys :pending? :success? :error? :settled? :optimistic?}` — the
+  idle empty-state shape until the instance's first `:rf.mutation/execute`.
+
+  `instance` is the INSTANCE id a view scopes one form submission's state to
+  (so a view reading one submission never sees another concurrent submission
+  of the same mutation); the `{:instance …}` wrapping lives INSIDE the sugar,
+  so callers pass just the instance.
+
+  The 2-arity `opts` map carries the same `{:frame <target>}` capability the
+  underlying subscription vector accepts — `<target>` is a frame-id keyword
+  or a live frame object — so a read can target an explicit frame from
+  outside an established scope. Without `:frame` the read resolves the
+  ambient frame through the carried scope/hold chain, exactly like the bare
+  `(subscribe [:rf.mutation/state {:instance instance}])`.
+
+  The `[:rf.mutation/state {:instance …}]` vector form remains the canonical
+  registered sub; this is ergonomic read sugar over it. Per EP-0003
+  §Mutations."
+  ([instance] (subs/subscribe [:rf.mutation/state {:instance instance}]))
+  ([instance opts]
+   (if-let [frame (:frame opts)]
+     (subs/subscribe frame [:rf.mutation/state {:instance instance}])
+     (subs/subscribe [:rf.mutation/state {:instance instance}]))))
+
+(defn sub-resource
+  "Subscribe to a resource instance's state. Sugar over
+  `(subscribe [:rf.resource/state <query>])`. Returns a reaction over the
+  resource view-model `{:status :data :error :refresh-error :loading?
+  :fetching? :stale? :has-data?}` (plus the `:keep-previous?` projection) —
+  the idle empty-state shape until a route / event / machine CAUSES the
+  fetch (a sub never fetches).
+
+  `query` is the `{:resource :params}` map (with the optional `:scope` the
+  sub-side scope resolution reads) the canonical vector form takes; the sugar
+  passes it through unchanged, so it resolves the SAME scoped key as
+  `(subscribe [:rf.resource/state query])` — including the fail-closed
+  `:rf.error/resource-sub-unresolved-scope` boundary.
+
+  The 2-arity `opts` map carries the same `{:frame <target>}` capability the
+  underlying subscription vector accepts — `<target>` is a frame-id keyword
+  or a live frame object — so a read can target an explicit frame from
+  outside an established scope. Without `:frame` the read resolves the
+  ambient frame through the carried scope/hold chain, exactly like the bare
+  `(subscribe [:rf.resource/state query])`.
+
+  The `[:rf.resource/state <query>]` vector form remains the canonical
+  registered sub; this is ergonomic read sugar over it. Per Spec 016
+  §Subscriptions."
+  ([query] (subs/subscribe [:rf.resource/state query]))
+  ([query opts]
+   (if-let [frame (:frame opts)]
+     (subs/subscribe frame [:rf.resource/state query])
+     (subs/subscribe [:rf.resource/state query]))))
 
 ;; ---- event / sub / hook registrations -------------------------------------
 ;; Keeping the registrations in this façade means a `(require

--- a/implementation/resources/test/re_frame/sub_mutation_cljs_test.cljs
+++ b/implementation/resources/test/re_frame/sub_mutation_cljs_test.cljs
@@ -1,0 +1,95 @@
+(ns re-frame.sub-mutation-cljs-test
+  "CLJS coverage for the `sub-mutation` reactive-read sugar — a thin fn over
+  `(subscribe [:rf.mutation/state {:instance <instance>}])` returning a
+  reaction over a mutation instance's view-model. It lives on the
+  `re-frame.resources` façade (NOT `re-frame.core`) per the resources
+  bundle-isolation invariant, so the test reaches it as
+  `resources/sub-mutation`.
+
+  Concerns covered:
+    - happy path: the sugar reads the post-execute (`:pending`) instance state
+      and is value-equal to the canonical `[:rf.mutation/state {:instance …}]`
+      subscription vector form; the `{:instance …}` wrapping lives inside the
+      sugar (callers pass just the instance);
+    - adversarial: an unknown instance id yields the idle empty-state shape
+      (the sub never errors / fetches);
+    - adversarial: the `{:frame f}` opts passthrough resolves the instance from
+      the named frame, isolated from the ambient default frame.
+
+  ns ends in `-cljs-test` so shadow-cljs's `:node-test` build picks it up.
+  Per EP-0003 §Mutations."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            ;; load-bearing side-effecting require: the façade registers the
+            ;; :rf.mutation/* events + subs (and `sub-mutation` itself).
+            [re-frame.resources :as resources]
+            ;; production HTTP fx surface (so the transport feature probe
+            ;; resolves); the actual fetch is overridden by the no-op below.
+            [re-frame.http.managed]
+            [re-frame.schemas]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]))
+
+(defn- capturing-transport-fixture
+  "Override the real :rf.http/managed fx with a no-op so `:rf.mutation/execute`
+  mints a `:pending` instance deterministically without a live fetch. Composed
+  INSIDE the reset-runtime fixture (one `use-fixtures` call)."
+  [f]
+  (rf/reg-fx :rf.http/managed (fn [_ctx _args] nil))
+  (f))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-adapter/adapter})
+  capturing-transport-fixture)
+
+(defn- save-article-request
+  [{:keys [slug]} _ctx]
+  {:request {:method :put :url (str "/api/articles/" slug) :body {:slug slug}}})
+
+(defn- reg-save-mutation! []
+  (rf/reg-mutation :m/save {:params-schema [:map [:slug :string]]} save-article-request))
+
+(deftest sub-mutation-returns-instance-reaction
+  (testing "sub-mutation reads the post-execute :pending instance state,
+            value-equal to [:rf.mutation/state {:instance …}]"
+    (reg-save-mutation!)
+    (rf/dispatch-sync [:rf.mutation/execute
+                       {:mutation :m/save :params {:slug "w"} :instance :form/save-1}])
+    (let [state @(resources/sub-mutation :form/save-1)]
+      (is (= :pending (:status state)) "the sugar reads the post-execute :status")
+      (is (true? (:pending? state)) "the derived :pending? boolean is projected")
+      ;; the sugar wraps the bare instance in {:instance …} and resolves
+      ;; through the SAME framework sub as the vector form.
+      (is (= @(rf/subscribe [:rf.mutation/state {:instance :form/save-1}])
+             @(resources/sub-mutation :form/save-1))
+          "sub-mutation value == [:rf.mutation/state {:instance …}] value"))))
+
+(deftest sub-mutation-unknown-instance-idle-state
+  (testing "sub-mutation yields the idle empty-state for an unknown instance id
+            (adversarial — a sub never errors / fetches)"
+    (let [state @(resources/sub-mutation :form/never)]
+      (is (= :idle (:status state)) "unknown instance → idle status")
+      (is (false? (:pending? state)) "idle is not pending")
+      (is (= @(rf/subscribe [:rf.mutation/state {:instance :form/never}])
+             @(resources/sub-mutation :form/never))
+          "idle empty-state value == the vector form"))))
+
+(deftest sub-mutation-frame-opts-passthrough
+  (testing "the {:frame f} opts passthrough resolves the instance from the
+            named frame, isolated from the ambient default frame (adversarial)"
+    (reg-save-mutation!)
+    (rf/reg-frame :sub-mutation/f2 {:doc "second frame for the passthrough test"})
+    ;; execute the mutation ONLY in :sub-mutation/f2 — the default frame never
+    ;; runs it, so its instance row stays idle.
+    (rf/dispatch-sync [:rf.mutation/execute
+                       {:mutation :m/save :params {:slug "w"} :instance :form/save-2}]
+                      {:frame :sub-mutation/f2})
+    (is (= :pending (:status @(resources/sub-mutation :form/save-2
+                                                      {:frame :sub-mutation/f2})))
+        "{:frame f2} reads the instance that ran in f2")
+    (is (= @(rf/subscribe :sub-mutation/f2 [:rf.mutation/state {:instance :form/save-2}])
+           @(resources/sub-mutation :form/save-2 {:frame :sub-mutation/f2}))
+        "opts passthrough == the 2-arity frame-targeted vector subscription")
+    (is (= :idle (:status @(resources/sub-mutation :form/save-2)))
+        "the ambient default frame has no such instance — frame isolation holds")))

--- a/implementation/resources/test/re_frame/sub_resource_cljs_test.cljs
+++ b/implementation/resources/test/re_frame/sub_resource_cljs_test.cljs
@@ -1,0 +1,106 @@
+(ns re-frame.sub-resource-cljs-test
+  "CLJS coverage for the `sub-resource` reactive-read sugar — a thin fn over
+  `(subscribe [:rf.resource/state <query>])` returning a reaction over a
+  resource instance's view-model. It lives on the `re-frame.resources` façade
+  (NOT `re-frame.core`) per the resources bundle-isolation invariant, so the
+  test reaches it as `resources/sub-resource`.
+
+  Concerns covered:
+    - happy path: the sugar reads the post-ensure (`:loading`) resource state
+      and is value-equal to the canonical `[:rf.resource/state <query>]`
+      subscription vector form; `query` (the `{:resource :scope :params}` map)
+      passes straight through;
+    - adversarial: an un-ensured query yields the idle empty-state shape (a sub
+      never fetches);
+    - adversarial: the `{:frame f}` opts passthrough resolves the entry from the
+      named frame, isolated from the ambient default frame.
+
+  ns ends in `-cljs-test` so shadow-cljs's `:node-test` build picks it up.
+  Per Spec 016 §Subscriptions."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            ;; load-bearing side-effecting require: the façade registers the
+            ;; :rf.resource/* events + subs (and `sub-resource` itself).
+            [re-frame.resources :as resources]
+            ;; production HTTP fx surface (so the transport feature probe
+            ;; resolves); the actual fetch is overridden by the no-op below.
+            [re-frame.http.managed]
+            [re-frame.schemas]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]))
+
+(defn- capturing-transport-fixture
+  "Override the real :rf.http/managed fx with a no-op so `:rf.resource/ensure`
+  writes its `:loading` entry deterministically without a live fetch. Composed
+  INSIDE the reset-runtime fixture (one `use-fixtures` call)."
+  [f]
+  (rf/reg-fx :rf.http/managed (fn [_ctx _args] nil))
+  (f))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-adapter/adapter})
+  capturing-transport-fixture)
+
+(defn- article-spec []
+  {:scope         :rf.scope/global
+   :params-schema [:map [:slug :string]]
+   :tags          (fn [{:keys [slug]} _data] #{[:article slug]})})
+
+(defn- article-request [{:keys [slug]} _ctx]
+  {:request {:method :get :url (str "/api/articles/" slug)}})
+
+(def ^:private query
+  {:resource :sub/article :scope :rf.scope/global :params {:slug "w"}})
+
+(defn- ensure!
+  "Ensure the article resource (→ `:loading`) under an explicit lease owner, in
+  the frame named by `opts` (default the ambient frame)."
+  ([] (ensure! {}))
+  ([opts]
+   (rf/dispatch-sync [:rf.resource/ensure
+                      {:resource :sub/article :scope :rf.scope/global
+                       :params {:slug "w"} :owner [:lease :s 1]}]
+                     opts)))
+
+(deftest sub-resource-returns-state-reaction
+  (testing "sub-resource reads the post-ensure :loading state, value-equal to
+            [:rf.resource/state <query>]"
+    (rf/reg-resource :sub/article (article-spec) article-request)
+    (ensure!)
+    (let [state @(resources/sub-resource query)]
+      (is (= :loading (:status state)) "the sugar reads the post-ensure :status")
+      (is (true? (:loading? state)) "the derived :loading? boolean is projected")
+      ;; the sugar passes the query straight through to the SAME framework sub
+      ;; as the vector form.
+      (is (= @(rf/subscribe [:rf.resource/state query])
+             @(resources/sub-resource query))
+          "sub-resource value == [:rf.resource/state <query>] value"))))
+
+(deftest sub-resource-un-ensured-idle-state
+  (testing "sub-resource yields the idle empty-state for an un-ensured query
+            (adversarial — a sub never fetches)"
+    (rf/reg-resource :sub/article (article-spec) article-request)
+    (let [state @(resources/sub-resource query)]
+      (is (= :idle (:status state)) "un-ensured query → idle status")
+      (is (false? (:loading? state)) "idle is not loading")
+      (is (false? (:has-data? state)) "idle has no data")
+      (is (= @(rf/subscribe [:rf.resource/state query])
+             @(resources/sub-resource query))
+          "idle empty-state value == the vector form"))))
+
+(deftest sub-resource-frame-opts-passthrough
+  (testing "the {:frame f} opts passthrough resolves the entry from the named
+            frame, isolated from the ambient default frame (adversarial)"
+    (rf/reg-resource :sub/article (article-spec) article-request)
+    (rf/reg-frame :sub-resource/f2 {:doc "second frame for the passthrough test"})
+    ;; ensure the resource ONLY in :sub-resource/f2 — the default frame never
+    ;; ensures it, so its entry stays idle.
+    (ensure! {:frame :sub-resource/f2})
+    (is (= :loading (:status @(resources/sub-resource query {:frame :sub-resource/f2})))
+        "{:frame f2} reads the entry ensured in f2")
+    (is (= @(rf/subscribe :sub-resource/f2 [:rf.resource/state query])
+           @(resources/sub-resource query {:frame :sub-resource/f2}))
+        "opts passthrough == the 2-arity frame-targeted vector subscription")
+    (is (= :idle (:status @(resources/sub-resource query)))
+        "the ambient default frame has no such entry — frame isolation holds")))

--- a/implementation/routing/src/re_frame/routing.cljc
+++ b/implementation/routing/src/re_frame/routing.cljc
@@ -142,6 +142,32 @@
      (subs/subscribe frame [:rf/route])
      (subs/subscribe [:rf/route]))))
 
+(defn sub-pending-navigation
+  "Subscribe to the pending-navigation slot. Sugar over
+  `(subscribe [:rf/pending-navigation])`. Returns a reaction over the
+  pending-navigation map `{:requested-url :requested-by-event
+  :rejecting-route :rejecting-guard …}`, or nil in the steady state (no
+  navigation pending) — the slot is non-nil only while a `:can-leave` guard
+  holds a blocked navigation awaiting `:rf.route/continue` /
+  `:rf.route/cancel`. The slot is a per-frame singleton, so the primary
+  form is zero-arity.
+
+  The 1-arity `opts` map carries the same `{:frame <target>}` capability the
+  underlying subscription vector accepts — `<target>` is a frame-id keyword
+  or a live frame object — so a read can target an explicit frame (e.g. a
+  non-default url-bound frame) from outside an established scope. Without
+  `:frame` the read resolves the ambient frame through the carried scope/hold
+  chain, exactly like the bare `(subscribe [:rf/pending-navigation])`.
+
+  The `[:rf/pending-navigation]` vector form remains the canonical registered
+  sub; this is ergonomic read sugar over it. Per Spec 012 §Navigation
+  blocking — pending-nav protocol."
+  ([] (subs/subscribe [:rf/pending-navigation]))
+  ([opts]
+   (if-let [frame (:frame opts)]
+     (subs/subscribe frame [:rf/pending-navigation])
+     (subs/subscribe [:rf/pending-navigation]))))
+
 ;; EP-0014 slice-5 (rf2-eiiifu): the derivation/process algebra view of
 ;; registered routes (`route-algebra-view`, static) and a frame's live route
 ;; slice (`route-slice-algebra-view`, live). JVM-runnable (the route

--- a/implementation/routing/test/re_frame/sub_pending_navigation_cljs_test.cljs
+++ b/implementation/routing/test/re_frame/sub_pending_navigation_cljs_test.cljs
@@ -1,0 +1,100 @@
+(ns re-frame.sub-pending-navigation-cljs-test
+  "CLJS coverage for the `sub-pending-navigation` reactive-read sugar — a thin
+  fn over `(subscribe [:rf/pending-navigation])` returning a reaction over the
+  pending-navigation slot. It lives on the `re-frame.routing` façade (NOT
+  `re-frame.core`) per the routing bundle-isolation invariant, so the test
+  reaches it as `routing/sub-pending-navigation`.
+
+  Concerns covered:
+    - happy path: the sugar reads the populated pending-nav slot (a blocked
+      navigation) and is value-equal to the canonical `[:rf/pending-navigation]`
+      subscription vector form;
+    - adversarial: nil in the steady state (no navigation pending);
+    - adversarial: the `{:frame f}` opts passthrough resolves the slot from the
+      named frame, isolated from the ambient default frame.
+
+  ns ends in `-cljs-test` so shadow-cljs's `:node-test` build picks it up.
+  Per Spec 012 §Navigation blocking — pending-nav protocol."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            ;; load the routing artefact so its `:rf/pending-navigation`
+            ;; reg-sub, the `:can-leave` / pending-nav events, and
+            ;; `sub-pending-navigation` itself are available.
+            [re-frame.routing :as routing]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-adapter/adapter
+     :init-fn routing/reset-counters!}))
+
+(defn- stub-push-url!
+  "No-op `:rf.nav/push-url` — the real handler touches browser history, which
+  the node-test runtime has no `window` for. Mirrors sub_route_cljs_test."
+  []
+  (rf/reg-fx :rf.nav/push-url {:platforms #{:server :client}} (fn [_ _] nil)))
+
+(defn- block-a-navigation!
+  "Register an editor route whose `:can-leave?` guard rejects while the form is
+  dirty, land on it, dirty it, then request a different URL — leaving a
+  populated `:rf/pending-navigation` slot (Spec 012 §Navigation blocking).
+  `opts` (e.g. `{:frame :f2}`) targets the frame the whole flow runs in."
+  ([] (block-a-navigation! {}))
+  ([opts]
+   (rf/dispatch-sync [:rf.route/transitioned "/editor/articles/A"] opts)
+   (rf/dispatch-sync [:editor/dirty true] opts)
+   (rf/dispatch-sync [:rf/url-requested {:url "/cart"}] opts)))
+
+(defn- register-blocking-routes!
+  "Process-global registrations the block flow needs (routes + guard sub +
+  dirty event). Registrations are process-global; the slice/db they read are
+  per-frame."
+  []
+  (stub-push-url!)
+  (rf/reg-route :editor/article
+                {:params    [:map [:id :string]]
+                 :can-leave :editor/can-leave?} "/editor/articles/:id")
+  (rf/reg-route :route/cart {} "/cart")
+  (rf/reg-event :editor/dirty
+                (fn [{:keys [db]} [_ v]] {:db (assoc-in db [:editor :dirty?] v)}))
+  (rf/reg-sub :editor/can-leave?
+              (fn [db _] (not (get-in db [:editor :dirty?])))))
+
+(deftest sub-pending-navigation-returns-slot-reaction
+  (testing "sub-pending-navigation reads the populated pending-nav slot,
+            value-equal to [:rf/pending-navigation]"
+    (register-blocking-routes!)
+    (block-a-navigation!)
+    (let [pending @(routing/sub-pending-navigation)]
+      (is (some? pending) "the sugar reads the populated pending-nav slot")
+      (is (= "/cart" (:requested-url pending))
+          "the blocked target URL is carried on the slot")
+      ;; the sugar resolves through the SAME framework sub as the vector form.
+      (is (= @(rf/subscribe [:rf/pending-navigation])
+             @(routing/sub-pending-navigation))
+          "sub-pending-navigation value == [:rf/pending-navigation] value"))))
+
+(deftest sub-pending-navigation-nil-in-steady-state
+  (testing "sub-pending-navigation yields nil when no navigation is pending
+            (adversarial — the steady state)"
+    (rf/reg-frame :sub-pending/fresh {:doc "frame with no pending navigation"})
+    (is (nil? @(routing/sub-pending-navigation {:frame :sub-pending/fresh}))
+        "no pending-nav slot in the steady state")))
+
+(deftest sub-pending-navigation-frame-opts-passthrough
+  (testing "the {:frame f} opts passthrough resolves the slot from the named
+            frame, isolated from the ambient default frame (adversarial)"
+    (register-blocking-routes!)
+    (rf/reg-frame :sub-pending/f2 {:doc "second frame for the passthrough test"})
+    ;; block a navigation ONLY in :sub-pending/f2 — the default frame never
+    ;; navigates, so its pending-nav slot stays nil.
+    (block-a-navigation! {:frame :sub-pending/f2})
+    (is (= "/cart" (:requested-url @(routing/sub-pending-navigation
+                                      {:frame :sub-pending/f2})))
+        "{:frame f2} reads f2's pending-nav slot")
+    (is (= @(rf/subscribe :sub-pending/f2 [:rf/pending-navigation])
+           @(routing/sub-pending-navigation {:frame :sub-pending/f2}))
+        "opts passthrough == the 2-arity frame-targeted vector subscription")
+    (is (nil? @(routing/sub-pending-navigation))
+        "the ambient default frame has no pending nav — frame isolation holds")))

--- a/implementation/scripts/api-manifest/deps.edn
+++ b/implementation/scripts/api-manifest/deps.edn
@@ -28,6 +28,7 @@
          day8/re-frame2-schemas  {:local/root "../../schemas"}
          day8/re-frame2-machines {:local/root "../../machines"}
          day8/re-frame2-routing  {:local/root "../../routing"}
+         day8/re-frame2-resources {:local/root "../../resources"}
          day8/re-frame2-flows    {:local/root "../../flows"}
          day8/re-frame2-http     {:local/root "../../http"}
          day8/re-frame2-ssr      {:local/root "../../ssr"}

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/gen.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/gen.clj
@@ -121,7 +121,16 @@
     ;; namespaces (re-frame.interop / re-frame.performance) are otherwise
     ;; internal plumbing.
     [re-frame.interop     debug-enabled?]
-    [re-frame.performance enabled?]])
+    [re-frame.performance enabled?]
+    ;; The resources façade's named reactive-read sugar (sub-mutation /
+    ;; sub-resource). The `re-frame.resources` home namespace is not
+    ;; whole-namespace introspected here (its public surface is rowed via the
+    ;; re-frame.core late-bind wrappers — see the resources rows in the
+    ;; sidecar), so these two façade-only read-sugar fns are named
+    ;; individually, mirroring the routing `sub-route` precedent on a scanned
+    ;; namespace. The Owner-016 classification lives in the sidecar.
+    [re-frame.resources   sub-mutation]
+    [re-frame.resources   sub-resource]])
 
 ;; ---------------------------------------------------------------------------
 ;; Derivation from live vars.

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -530,6 +530,15 @@
   ["re-frame.core" "mutation-meta"]       {:tier :advanced :owner "016" :status "v1 (optional capability)"}
   ["re-frame.core" "mutation-state"]      {:tier :advanced :owner "016" :status "v1 (optional capability)"}
   ["re-frame.core" "mutations"]           {:tier :advanced :owner "016" :status "v1 (optional capability)"}
+  ;; Named reactive-read sugar over the canonical `[:rf.mutation/state …]` /
+  ;; `[:rf.resource/state …]` subscription vectors. Unlike the wrappers above
+  ;; these live ONLY on the `re-frame.resources` façade (NOT re-frame.core),
+  ;; the resources peer of routing's `sub-route`, so a non-resources app's
+  ;; production bundle carries no resource/mutation keyword strings. The home
+  ;; ns is not whole-namespace introspected, so the generator names them via
+  ;; `extra-vars`; advanced tier like `sub-route` + the resources read surfaces.
+  ["re-frame.resources" "sub-mutation"]   {:tier :advanced :owner "016" :status "v1 (optional capability)"}
+  ["re-frame.resources" "sub-resource"]   {:tier :advanced :owner "016" :status "v1 (optional capability)"}
   ;; Named resource-scope resolvers — the third resources kind (rf2-hls77w,
   ;; Spec 016 §Named resource-scope resolvers / EP-0016 D3 slice 2). The
   ;; inverse of slice-1's spec-ahead reservation: these now ship as live
@@ -1038,6 +1047,11 @@
   ;; bundle — the routing bundle-isolation invariant. Advanced tier like its
   ;; sibling read surfaces (`match-url` / `route-url`).
   ["re-frame.routing" "sub-route"]              {:tier :advanced :owner "012" :status "v1"}
+  ;; Named pending-navigation read sugar over the canonical
+  ;; `[:rf/pending-navigation]` subscription vector — the pending-nav peer of
+  ;; `sub-route`. Routing-façade home (NOT re-frame.core) for the same
+  ;; bundle-isolation reason; advanced tier like its sibling read surfaces.
+  ["re-frame.routing" "sub-pending-navigation"] {:tier :advanced :owner "012" :status "v1"}
   ["re-frame.routing" "reg-route"]              {:tier :implementation :owner "012" :status "v1"}
   ["re-frame.routing" "clear-route"]            {:tier :tooling :owner "012" :status "v1"}
   ["re-frame.routing" "malformed-url?"]         {:tier :implementation :owner "012" :status "v1"}

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -6,7 +6,7 @@
  {:doc
  "GENERATED public-API manifest — do NOT hand-edit the :vars list. Regenerate with: clojure -M -m re-frame.api-manifest.gen (run from implementation/scripts/api-manifest/). The tier/owner/status axes are curated in spec/api-manifest-metadata.edn; existence + kind + facade? are derived from live public vars. See that generator ns for the design.",
  :keystone "rf2-3nbl5.2",
- :var-count 486,
+ :var-count 489,
  :tier-vocab
  [:front-porch
   :advanced
@@ -260,6 +260,8 @@
   {:namespace "re-frame.mcp-base.sensitive", :var "sensitive-stamp?", :tier :tooling, :kind :fn, :owner "Tool-Pair", :status "post-v1 lib", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.mcp-base.sensitive", :var "strip-sensitive", :tier :tooling, :kind :fn, :owner "Tool-Pair", :status "post-v1 lib", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.performance", :var "enabled?", :tier :tooling, :kind :var, :owner "009", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.resources", :var "sub-mutation", :tier :advanced, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.resources", :var "sub-resource", :tier :advanced, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.routing", :var "clear-route", :tier :tooling, :kind :fn, :owner "012", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.routing", :var "counter-snapshot", :tier :implementation, :kind :fn, :owner "012", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.routing", :var "current-url", :tier :advanced, :kind :fn, :owner "012", :status "v1", :facade? false, :runtime-verified? true}
@@ -283,6 +285,7 @@
   {:namespace "re-frame.routing", :var "save-scroll-position", :tier :implementation, :kind :fn, :owner "012", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.routing", :var "save-scroll-position!", :tier :implementation, :kind :fn, :owner "012", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.routing", :var "scroll-positions-cap", :tier :implementation, :kind :var, :owner "012", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.routing", :var "sub-pending-navigation", :tier :advanced, :kind :fn, :owner "012", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.routing", :var "sub-route", :tier :advanced, :kind :fn, :owner "012", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.routing", :var "url-owner-frame-id", :tier :implementation, :kind :fn, :owner "012", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.schemas", :var "app-schema-at", :tier :tooling, :kind :fn, :owner "010", :status "v1", :facade? false, :runtime-verified? true}


### PR DESCRIPTION
Completes the runtime-db reactive-read sugar set (rf2-kqfzu3), mirroring the just-landed sub-route / sub-machine. Each new fn is a thin one-liner over the existing subscription vector form, returning a state map (NOT a per-projection family). The vector forms remain the registered canonical subs; the sugar coexists. subscribe is unchanged (rf2-r7tzz0 owns that).

## What landed

- sub-pending-navigation -- on the re-frame.routing facade, alongside sub-route. Zero-arg primary + (opts) over (subscribe [:rf/pending-navigation]). Per Spec 012 Navigation blocking.
- sub-mutation -- on the re-frame.resources facade. (sub-mutation instance) / (sub-mutation instance opts) over (subscribe [:rf.mutation/state {:instance instance}]); the {:instance ...} wrapping lives inside the sugar so callers pass just the instance. Returns the mutation view-model {:status :result :error :affected-keys :pending? :success? :error? :settled? :optimistic?}. Per EP-0003 Mutations.
- sub-resource -- on the re-frame.resources facade. (sub-resource query) / (sub-resource query opts) where query is the {:resource :params (:scope)} map, over (subscribe [:rf.resource/state query]). Returns the resource view-model {:status :data :error :refresh-error :loading? :fetching? :stale? :has-data?} (+ :previous?). Per Spec 016 Subscriptions.

Each lives on its feature facade (NOT re-frame.core) so a non-routing / non-resources production-elision bundle carries no route/resource/mutation keyword strings -- the bundle-isolation invariant, the peer of sub-route. The {:frame f} opt is lowered to subscribe's frame-first 2-arity verbatim per the sub-route template.

## Manifest

Sidecar classifications added: routing/sub-pending-navigation (owner 012, advanced); resources/sub-mutation + resources/sub-resource (owner 016, advanced -- the resources owner, matching the existing resources facade rows).

re-frame.resources is not whole-namespace introspected by the generator (its public surface is rowed via the re-frame.core late-bind wrappers), so the two resources facade-only sugar fns are named individually via the generator's purpose-built extra-vars mechanism, and day8/re-frame2-resources was added to the generator's own deps.edn classpath so it can resolve them. This mirrors how sub-route is a real row on the scanned routing namespace, without ballooning into whole-ns introspection of resources. Regenerated spec/api-manifest.edn: 486 -> 489 vars; the diff is exactly the three new rows.

## Tests

Focused node-test coverage beside the existing routing/resources sub tests, each: happy path value-equal to the vector form (populated state -- blocked nav / :pending mutation / :loading resource), >=1 adversarial (nil steady-state / idle empty-state), and the {:frame f} passthrough resolving the right frame with isolation from the ambient default frame.

## Quality gates

Run locally (all green):
- clojure -M -m re-frame.api-manifest.gen --check -- OK (489 public vars)
- api-md-check + all projection checks (Privacy / docs / skills) -- OK
- api-manifest projection unit tests -- 53 tests, 0 failures
- routing JVM slice (clojure -M:test) -- 339 tests, 0 failures
- resources JVM slice (clojure -M:test) -- 599 tests, 0 failures
- npm run test:cljs -- 8021 tests, 36886 assertions, 0 failures / 0 errors

Relying on CI for the full matrix (browser smokes, elision, bundle-isolation, perf-bundle, mcp-conformance).
