### PR TITLE
docs(api): document the read-sugar trio (sub-resource / sub-mutation / sub-pending-navigation)

### DIFF
--- a/docs/api/re-frame.resources.md
+++ b/docs/api/re-frame.resources.md
@@ -584,6 +584,46 @@ A failure settles `:error` — there is **no `:refresh-error` analogue** (a writ
 
 > **Internal replies — do not dispatch.** The `:rf.mutation.internal/*` replies (and the `:rf.mutation/*` trace family — `started` / `succeeded` / `failed` / `cleared` / `stale-suppressed`, carrying the instance id) are framework-internal; user code MUST NOT dispatch them.
 
+## Read sugar
+
+`sub-resource` and `sub-mutation` are named reactive-read fns — thin sugar over the `[:rf.resource/state …]` / `[:rf.mutation/state …]` subscription vectors above. They live on the **`re-frame.resources` façade, not `re-frame.core`**, so a non-resources app's production bundle carries no resource/mutation keyword strings. The vector forms remain the canonical registered subs; these layer over them.
+
+### `sub-resource`
+
+- **Kind**: function (post-v1 lib)
+- **Signature**:
+  ```clojure
+  (re-frame.resources/sub-resource query)        ;; → reaction over the :rf.resource/state view-model
+  (re-frame.resources/sub-resource query opts)   ;; opts {:frame <id-or-frame>}
+  ```
+- **Description**: Sugar over `[:rf.resource/state query]`. `query` is the same `{:resource :params :scope}` map the vector takes, passed through unchanged — identical fail-closed scope resolution (`:rf.error/resource-sub-unresolved-scope`). The 2-arity `opts` carries `{:frame …}` to read from an explicit frame. A sub never fetches.
+
+```clojure
+(require '[re-frame.resources :as resources])
+
+;; a view reads passively — never fetches
+@(resources/sub-resource {:resource :article :params {:slug "hello"}})
+;; => {:status :loading}  …then  {:status :loaded :data {…}}
+```
+
+### `sub-mutation`
+
+- **Kind**: function (post-v1 lib)
+- **Signature**:
+  ```clojure
+  (re-frame.resources/sub-mutation instance)        ;; → reaction over the :rf.mutation/state view-model
+  (re-frame.resources/sub-mutation instance opts)   ;; opts {:frame <id-or-frame>}
+  ```
+- **Description**: Sugar over `[:rf.mutation/state {:instance instance}]` — the `{:instance …}` wrapping lives inside the sugar, so you pass just the instance id. The 2-arity `opts` carries `{:frame …}`. Idle empty-state until the instance's first `:rf.mutation/execute`.
+
+```clojure
+(require '[re-frame.resources :as resources])
+
+;; a form reads its own submission's state, keyed by instance
+@(resources/sub-mutation :form/save-1)
+;; => {:status :idle …}  …then  {:pending? true …}  …then  {:success? true …}
+```
+
 ## Cache home
 
 Resource cache lives **only** at `:rf.runtime/resources` inside the runtime-db partition (`:rf.db/runtime`); the frame work ledger at `:rf.runtime/work-ledger`. Both are reserved runtime-db keys, framework-owned, per-frame isolated, allocated lazily. App code reads through the subs and accessors and never hand-edits the slice. Cache *entries* (durable facts) and work-ledger *attempts* (in-flight records) are separate; host handles (AbortControllers, timers, promises) live in side tables and are never serialized. The correctness rule: **cancellation is opportunistic; stale-reply suppression (by work-id + generation) is mandatory.** See [Guide ch.27 §Cache home and the work ledger](../resources/concepts.md).

--- a/docs/api/re-frame.routing.md
+++ b/docs/api/re-frame.routing.md
@@ -177,6 +177,24 @@ The read-side surface over the route registry and the live route slice — the s
   ```
 - **Description**: The layer-1 sub fn behind `:rf/route` — reads the route slice from `[:rf.runtime/routing :current]`. Exposed publicly so external callers (smoke tests, tooling) read the slice without re-deriving the path.
 
+### `sub-pending-navigation`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (re-frame.routing/sub-pending-navigation)        ;; → reaction over the pending-nav map, or nil
+  (re-frame.routing/sub-pending-navigation opts)   ;; opts {:frame <id-or-frame>}
+  ```
+- **Description**: Named read sugar over `[:rf/pending-navigation]`. Returns a reaction over the pending-navigation map `{:requested-url :requested-by-event :rejecting-route :rejecting-guard …}`, or `nil` in the steady state — the slot is non-nil only while a `:can-leave` guard holds a blocked navigation awaiting `:rf.route/continue` / `:rf.route/cancel`. Zero-arity is the primary form (the slot is a per-frame singleton); the 1-arity `opts` carries `{:frame …}` to target an explicit (e.g. non-default url-bound) frame. The vector form remains the canonical registered sub.
+
+```clojure
+(require '[re-frame.routing :as routing])
+
+;; show an "unsaved changes?" prompt only while a navigation is blocked
+(when-let [pending @(routing/sub-pending-navigation)]
+  [confirm-leave-dialog pending])
+```
+
 ## Scroll restoration
 
 Saved scroll positions are a **host-side, per-frame transient LRU cache** keyed by frame-id — NOT runtime-db state. They are host-derived (read from `window.scrollX/Y`), meaningless server-side, and not needed to reconstitute a coherent frame on restore / SSR-hydration / time-travel, so they never ride the trace / epoch / SSR egress wire and cannot rewind on an epoch restore. The pure helpers operate on a plain per-frame cache map `{:positions {url [x y]} :order [url ...]}`; the `!`-suffixed wrappers read/write the host cache.
@@ -342,7 +360,7 @@ The full `:rf/route` slice is `{:id :params :query :transition :error}`. The sta
 | `:rf.route/error` | Current error map (when `:transition = :error`) |
 | `:rf.route/fragment` | Current URL fragment (string or `nil`) |
 | `:rf.route/chain` | Vector of route ids from parent-most to current (per `:parent` links) |
-| `:rf/pending-navigation` | The pending-nav slot (per `:rf/pending-navigation` schema) when a navigation is blocked; `nil` otherwise |
+| `:rf/pending-navigation` | The pending-nav slot (per `:rf/pending-navigation` schema) when a navigation is blocked; `nil` otherwise. Named read sugar: [`sub-pending-navigation`](#sub-pending-navigation). |
 
 ### Effects (`fx`)
 


### PR DESCRIPTION
**#5065** added the read-sugar fns to the implementation + manifest but didn't document them in `/docs`. This fills that gap in the API reference (now that #5065 has merged, this is clean on `main`).

- **`re-frame.resources.md`** — a new **"Read sugar"** section: `sub-resource` (sugar over `[:rf.resource/state query]`) and `sub-mutation` (sugar over `[:rf.mutation/state {:instance …}]` — the `{:instance …}` wrapping lives inside the sugar). Both noted as on the **`re-frame.resources` façade, not `re-frame.core`** (the bundle-isolation point), with the `{:frame …}` opts arity.
- **`re-frame.routing.md`** — a `sub-pending-navigation` entry (sugar over `[:rf/pending-navigation]`, zero-arity primary + `{:frame …}` opts), plus a pointer from the `:rf/pending-navigation` subscriptions row.

Signatures match the shipped #5065 docstrings. **Vector forms remain canonical**; these are additive ergonomic sugar. The spec-side is tracked separately by **rf2-i83t98** (`spec/*`); this is the `/docs`-guide half.

## Not in this pass (flagged)
The resources/routing **concept / how-to / tutorial** read-examples still show the canonical vector form — adopting the sugar there is an optional follow-up.

## Verification (local)
`check_doc_slugs` (incl. the new `#sub-pending-navigation` anchor) + the api-manifest JVM gate (271 refs; the 3 new fns resolve).