### PR TITLE
docs(core): boot-and-mount review — add unhappy path, align house style

### DIFF
--- a/docs/core/how-to/boot-and-mount-an-app.md
+++ b/docs/core/how-to/boot-and-mount-an-app.md
@@ -16,7 +16,7 @@ or Helix. The frame is created later by the rendered
 The goal is simple: first page load should create and seed the app; hot reload
 should re-render changed views without losing app-db.
 
-## The Small Shape
+## The small shape
 
 For an app with no browser listeners, there is no need for a separate `boot!`
 function. Keep the process setup inline in `run`, and put DOM work in `mount!`.
@@ -65,7 +65,7 @@ namespace whose top-level registrations must exist before the app runs: events,
 effects, coeffects, subscriptions, views, routes, resources, machines, and
 schemas.
 
-## What the Provider Does
+## What the provider does
 
 This form:
 
@@ -91,7 +91,7 @@ frame on unmount. That is why app-db survives reload.
 If you edit the setup event itself and want the new setup to run, reset the
 frame or reload the page. Hot reload preserves state by design.
 
-## Hot Reload
+## Hot reload
 
 Two pieces make hot reload work:
 
@@ -109,7 +109,7 @@ second `create-root` call for a live DOM node.
 reload. That re-renders the edited views into the same root and the same frame.
 It does not re-run `run`.
 
-## Host Listeners
+## Host listeners
 
 Some apps also install browser listeners: `hashchange`, `popstate`, `storage`,
 or similar. Those listeners are process/browser wiring, not frame creation.
@@ -155,7 +155,7 @@ reinstalls listeners and renders once.
 For history routing, prefer the routing helper where it fits. It already owns the
 same hot-reload-safe listener pattern.
 
-## Two Frame Shapes
+## Two frame shapes
 
 `frame-provider` has two useful shapes.
 
@@ -183,7 +183,7 @@ This shape only scopes an existing frame into the React subtree. It creates
 nothing and destroys nothing. Use it when boot, tests, SSR/request setup, or a
 tooling harness needs to create the frame before rendering.
 
-## Lifecycle Summary
+## The boot lifecycle
 
 | Moment | What should happen |
 | --- | --- |
@@ -194,7 +194,7 @@ tooling harness needs to create the frame before rendering.
 | Host listener edit | Reinstall the stored listener so the browser calls the current code. |
 | Fresh setup wanted | Reset the frame or reload the page; remounting does not replay setup. |
 
-## No DOM Work at Namespace Load
+## No DOM work at namespace load
 
 Keep `create-root`, `render`, and browser listener installation out of top-level
 namespace code. Requiring registration namespaces is fine; browser work is not.
@@ -217,7 +217,17 @@ The namespace may be loaded by a test host, a Story tool, or another namespace
 that wants the registrations without mounting the app. Lazy DOM work keeps that
 safe.
 
-## Worked Examples
+## When boot goes wrong
+
+Boot is where the "did you wire it up?" mistakes surface, and each one [fails loud](../glossary.md#fail-loud-not-silent) with a named [error](../concepts/errors.md) rather than a blank page.
+
+> **Gotcha — touching the substrate before `init!`.** `rf/init!` installs the [adapter](../glossary.md#adapter); until it runs there is nothing to render or dispatch through. A `render`, `dispatch`, or `subscribe` that beats `(rf/init! …)` — an event fired from a top-level form, a `mount!` that ran before `run` — throws `:rf.error/no-adapter-installed`, naming the call. Install the adapter first; in the shapes above, `run` does it on its first line.
+
+> **Gotcha — `{:frame …}` needs a frame that already exists.** The scope shape only *scopes* a frame someone else created; it creates nothing. Point `[rf/frame-provider {:frame :checkout} …]` at a frame that was never `reg-frame`'d (nor ensured by an `{:id}` provider) and it throws `:rf.error/frame-provider-frame-absent`. When the subtree should bring its own frame into being, use the **ensure** shape `{:id …}` instead — that's the whole difference between [the two shapes](#two-frame-shapes).
+
+> **Gotcha — a registration namespace you forgot to require.** A `reg-event` or `reg-sub` runs only when its namespace loads, so a missing `require` means the registration never happened. Drop `counter.events` from the entry `ns` and the first `[:counter/inc]` dispatch — or `[:counter/value]` subscribe — is a loud `:rf.error/no-such-handler` / `:rf.error/no-such-sub` naming the missing id, not a silent dead button. The fix is the require list in the `ns` form above.
+
+## Worked examples
 
 - [`examples/core/counter/core.cljs`](../../../examples/core/counter/core.cljs)
   shows the smallest app shape.


### PR DESCRIPTION
## The review

A full pass over `docs/core` (all 33 files). I deep-read the on-ramp (README, quickstart, the loop overview, how-to index), the **entire loop** (events-and-the-cascade, app-db, subscriptions, views, effects-and-coeffects), and `errors.md`, then structurally verified the rest.

**Verdict: `docs/core` is in excellent shape.** Complete, correct, and a genuinely cohesive tutorial-plus-reference:

- **Cohesive whole.** The README "shape of the guide" maps the tiers (quickstart → loop → tutorial → more-concepts → how-to → explanation → migration → reference), the loop arc is taught once on the counter and every page zooms into one piece, and two habits run throughout — "do, observe, explain" and "link down, never duplicate". Reorg isn't needed; the structure already delivers the purpose.
- **Progressive disclosure** is strong everywhere — each page starts at the smallest working thing, says "you can stop here and be productive", and pushes depth into `Going deeper` / `Advanced` tails.
- **The unhappy path is thoroughly covered** — a whole `errors.md` (the dossier, the catalogue, typed recovery, the failures-you'll-meet, thrown-vs-traced), plus `Gotcha`/error-record content in all 12 concept docs and 11 of 12 how-tos (149 + 102 occurrences).
- **Hygiene clean** — no stale links (the removed `reference.md` and the `http.md` move are fully propagated), no "What's next / Summary / In this section" sections, no TODO/placeholder/incomplete content.

## The one outlier — and this PR

`boot-and-mount-an-app.md` was the lone exception on two counts, both fixed here:

1. **No unhappy-path coverage** — the only how-to with zero gotchas, despite boot being a classic failure site. Added a **"When boot goes wrong"** section covering the three you'll actually hit, with verified keywords:
   - substrate work before `init!` → `:rf.error/no-adapter-installed`
   - a `{:frame …}` provider pointed at a frame that doesn't exist → `:rf.error/frame-provider-frame-absent` (use the `{:id}` ensure shape)
   - a forgotten registration `require` → `:rf.error/no-such-handler` / `:rf.error/no-such-sub` at first use
2. **Off the house style** — Title Case headings against a sentence-case corpus. Lower-cased all eight; renamed "Lifecycle Summary" → "The boot lifecycle" (sentence case, and drops the "Summary" label).

Keywords verified against `implementation/core/test/boot_test.clj` and the adapter sources. One file, +18/−8.

## Verification

- `python -m mkdocs build --strict` → exit 0, no warnings (the heading rename broke no inbound anchor; the new internal link resolves)
- `check_doc_slugs` / `check_readme_links` / `check_readme_inventories` → exit 0

## One thing I left for you

`boot-and-mount`'s *prose* is also terser than the corpus (it skips the "Coming from JS" framing and the warm cross-linking the rest leans on). I fixed the objective gaps (headings + unhappy path) but didn't rewrite the voice wholesale — that's a taste call. Say the word if you'd like it warmed to match.
