### PR TITLE
docs(machines): rewrite the landing page, sharpen the tutorial/concepts boundary, reorder the nav

### DIFF
--- a/docs/machines/index.md
+++ b/docs/machines/index.md
@@ -1,23 +1,57 @@
-# Machines
+# Hierarchical State Machines
 
-Finite state machines are hiding in plain sight, everywhere in your app. Your app's **boot** is one — load config, hydrate, check the session, go ready. So is **auth**: a user is logged out, or logged in; and if logged in, an admin or not. So is a single **HTTP request** (`idle → loading → loaded | failed`), a **websocket** (`connecting → open → reconnecting → closed`), and even a humble **dropdown** (`closed → open → selecting`). Keep looking and you'll see them at every scale. It's finite state machines all the way down.
+## They are everywhere
 
-Model one of those lifecycles with scattered boolean flags — `:loading?`, `:submitting?`, `:error?` — and it drifts out of sync and sprouts impossible states ("submitting *and* error" at once). A **machine** makes the lifecycle explicit: named states, named transitions, exactly one state at a time. The illegal combinations simply can't be represented.
+Finite state machines (FSMs) hide in plain sight all over your app:
 
-re-frame2 has first-class, **hierarchical** state machines — nested states, parallel regions, spawned children, guards, delayed transitions. And they're wired right into the re-frame2 substrate, **not bolted on as a side-car**. A machine *is* an event handler. Its live value is a [snapshot](glossary.md#snapshot) you read with an ordinary subscription and move with an ordinary dispatched event — same cascade, same `app-db`, same Xray, same tests. There's no second runtime to learn.
+- Your app's boot — load config, hydrate, check the session, then go ready.
+- Auth — logged out, or logged in; and if logged in, an admin or not.
+- A single HTTP request — `idle → loading → loaded | failed`.
+- A websocket — `connecting → open → reconnecting → closed`.
+- A humble dropdown — `closed → open → selecting`.
+
+Keep looking and you'll see them at every scale — usually tangled up in a cluster of enums and boolean flags. Formally modelling them makes your code more explicit, robust, and easier to understand.
+
+## First-class support
+
+re-frame2 has first-class, **hierarchical** state machines — nested states, parallel regions, spawned children, guards, and delayed transitions. They cover much the same ground as the 500-pound gorilla in this space, [XState v6](coming-from-xstate.md) — a wonderful library from which we have learned a lot.
+
+## Deeply integrated
+
+They're wired right into the **core** of re-frame2 — not bolted on as a side-car, and infused with the re-frame2 ethos. A machine *is* an event handler: its state lives in the [frame](../core/concepts/frames.md) alongside your `app-db`, it moves on the same cascade, and the same Xray and tests work on it — no second runtime to learn.
+
+They're **expressed** as a data-oriented DSL — the whole machine is just a value, so you can `def` it. Read `:states` as a transition table: in each state, `:on` maps an incoming event to the next state.
 
 ```clojure
-(rf/reg-machine :auth/login
+(def auth-login-machine
   {:initial :idle
-   :states  {:idle       {:on {:submit :submitting}}
-             :submitting {:on {:ok   :authed
-                               :fail :error}}
+   :states  {:idle       {:on {:submit :submitting}}   ;; :submit → :submitting
+             :submitting {:on {:ok   :authed            ;; :ok     → :authed
+                               :fail :error}}           ;; :fail   → :error
              :authed     {}
              :error      {:on {:submit :submitting}}}})
-
-@(rf/sub-machine :auth/login)   ;; => {:state :idle :data {}}
 ```
 
-Dispatch an event, the snapshot moves, and the views reading it follow.
+They're **integrated** as an event handler — `reg-machine` is just a machine-specific `reg-event`:
 
-New to machines? The [tutorial](tutorial.md) builds one step by step. To take in the whole model at once, read [Concepts](concepts.md).
+```clojure
+(rf/reg-machine :auth-login auth-login-machine)
+```
+
+They're **triggered** by normal events, dispatched the normal way, so you drive a machine straight from an ordinary handler. Dispatching `[:auth-login [:submit …]]` fires the machine's `:submit` arrow:
+
+```clojure
+(rf/reg-event :login/submit
+  (fn [_ [_ credentials]]
+    {:fx [[:dispatch [:auth-login [:submit credentials]]]]}))
+
+(rf/dispatch [:login/submit credentials])   ;; fire it the normal way
+```
+
+And they're **read** through an ordinary subscription — you get back a [snapshot](glossary.md#snapshot), `{:state … :data …}`:
+
+```clojure
+@(rf/sub-machine :auth-login)   ;; => {:state :submitting :data {}}
+```
+
+The snapshot moves, and the views that read it follow.

--- a/docs/machines/tutorial.md
+++ b/docs/machines/tutorial.md
@@ -58,7 +58,7 @@ Now drive it. A machine is addressed by its id, and the event rides *inside* a w
 
 Dispatch `[:auth.login/flow [:auth.login/success]]` and the snapshot reads `{:state :authed …}`. Dispatch an event the current state has no transition for — `[:auth.login/flow [:auth.login/dismiss]]` while `:submitting` — and nothing happens: an unhandled event is a silent no-op, not a crash.
 
-**Why this works.** A machine *is* an [event handler](../core/glossary.md#event-handler). `reg-machine` is sugar over `reg-event` whose body reads the snapshot, computes the transition from the table, and writes the new snapshot back. So the snapshot rides the [frame](../core/concepts/frames.md) like everything else, and you read it with the ordinary `[:rf/machine <id>]` subscription — same `dispatch`, same `subscribe`, no second runtime to learn.
+**Why it works:** `reg-machine` is sugar over `reg-event`, so the snapshot rides the [frame](../core/concepts/frames.md) and you read it with an ordinary subscription — same `dispatch`, same `subscribe`. [Concepts → Registering and running it](concepts.md#registering-and-running-it) walks the machinery.
 
 ## Step 2 — a guard: refuse an invalid submit
 
@@ -96,14 +96,11 @@ You name the guard once in `:guards`, then point at it by id — `:guard :form-v
 @(rf/sub-machine :auth.login/flow)     ;; => {:state :submitting …}
 ```
 
-**Notice what the guard read.** It pulled the credentials out of `:event`, not out of [app-db](../core/concepts/app-db.md). A machine callback can't see app-db at all — only its own `:data` plus the event that woke it. A fact from the outside world arrives *in the event*; the view that has the form hands it over in the dispatch. That boundary is load-bearing — [Concepts](concepts.md) has the why.
+**Notice:** the guard read the credentials from `:event`, not [app-db](../core/concepts/app-db.md) — a machine callback sees only its own `:data` and the event that woke it. [Concepts → Strict encapsulation](concepts.md#strict-encapsulation--a-machine-sees-only-its-own-data) explains why that boundary matters.
 
 ## Step 3 — an action, and the `{:data :fx}` it returns
 
-A guard decides *whether*; an **action** does the *work* a transition performs. But an action never performs a side-effect itself — it **returns a description**, the same `{:data :fx}` shape a `reg-event` handler returns:
-
-- `:data` — updates *merged* into the machine's own `:data`, key by key (mention only what changes).
-- `:fx` — the ordinary effects vector (`:dispatch`, HTTP, your own effects).
+A guard decides *whether*; an **action** does the *work*. But it never performs a side-effect itself — it **returns** the same `{:data :fx}` map a `reg-event` does: `:data` is merged into the machine's own data, `:fx` is the ordinary effects vector. [Concepts → The action effect map](concepts.md#the-action-effect-map--data-fx) has the full shape.
 
 Add three actions and a second guard, and wire them in. `:clear-error` wipes the last error on submit; `:record-error` counts a failure into `:data`; `:store-session` fires an effect on success:
 
@@ -155,7 +152,7 @@ Add three actions and a second guard, and wire them in. `:clear-error` wipes the
     :locked-out {:meta {:terminal? true}}}})   ;; NOT :final? (which would auto-destroy the machine)
 ```
 
-Two things arrived with the actions. The `:auth.login/failure` arrow is now a **list of candidates** — the runtime tries them top to bottom and takes the first whose guard passes. While under the retry limit, a failure records the error and shows it; once `:under-retry-limit` says no, the next candidate (no guard) wins and the machine locks out. And `:store-session` returns an `:fx` rather than calling `localStorage` itself — effects are data the runtime actions, exactly like in an event handler.
+The `:auth.login/failure` arrow is now a **list of candidates** — the runtime takes the first whose guard passes. Under the retry limit, a failure records the error and shows it; past it, the unguarded candidate wins and the machine locks out.
 
 **What you see:** drive a failure and watch `:data` change.
 
@@ -168,7 +165,7 @@ Two things arrived with the actions. The `:auth.login/failure` arrow is now a **
 
 Keep submitting and failing. The first three failures each land in `:error-shown` with `:attempts` climbing `1 → 2 → 3`. On the fourth, `:under-retry-limit` returns false, the guarded candidate is skipped, and the machine settles in `:locked-out`.
 
-> **`:data` is a merge, not a replace.** `:clear-error` returns `{:data {:error nil}}` and only `:error` changes — `:attempts` is left alone. [Concepts](concepts.md) covers the sharp edges: an explicit `nil` *sets* a key (the merge never removes keys), and an action's `:fx` can't read the `:data` it's writing in the same breath.
+> **`:data` is a merge, not a replace** — `:clear-error` changes only `:error`, leaving `:attempts` alone. [Concepts → The action effect map](concepts.md#the-action-effect-map--data-fx) has the sharp edges.
 
 ## Step 4 — talk to a real server
 
@@ -277,4 +274,4 @@ Here's the payoff. A transition is a pure function of *(table, snapshot, event)*
     (is (= :locked-out (:state snap)))))
 ```
 
-Feed in a snapshot and an event; assert on the snapshot that comes back. The result is a value — destructure `::result/snap` and `::result/fx`, or discriminate with `result/ok?` / `result/fail?` (a throwing action surfaces as a *failure value*, not an exception out of your test). These run on the JVM in microseconds, which is exactly the testing experience you want for the flows where testing usually gets hard.
+Feed in a snapshot and an event; assert on what comes back. The result is a value — `::result/snap` / `::result/fx`, or `result/ok?` / `result/fail?` (a throwing action is a *failure value*, not an exception out of your test). It runs on the JVM in microseconds — exactly the testing experience you want for the flows where testing usually gets hard. [Concepts → Testing](concepts.md#testing-transitions-are-pure-function-calls) goes deeper.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -235,14 +235,14 @@ nav:
     - "Concepts": machines/concepts.md
     - "Hierarchical states": machines/hierarchical-states.md
     - "Parallel states": machines/parallel-states.md
-    - "Automatic transitions": machines/automatic-transitions.md
-    - "Actors": machines/actors.md
-    - "Tags": machines/tags.md
     - "History": machines/history.md
+    - "Automatic transitions": machines/automatic-transitions.md
+    - "Tags": machines/tags.md
+    - "Actors": machines/actors.md
     - "Inspecting and testing": machines/inspecting-machines.md
-    - "Coming from XState": machines/coming-from-xstate.md
-    - "Glossary": machines/glossary.md
     - "Examples": machines/examples.md
+    - "Glossary": machines/glossary.md
+    - "Coming from XState": machines/coming-from-xstate.md
 
   - Resources:
     - resources/index.md


### PR DESCRIPTION
Polish pass over the machines guide — landing page, the tutorial↔concepts boundary, and the section nav. Done interactively against a live mkdocs preview.

## Landing page (`index.md`)
Restructured into three signposted sections:
- **They are everywhere** — the FSM examples as a scannable bulleted list.
- **First-class support** — the feature set, and "covers much the same ground as the 500-pound gorilla in this space, XState v6" (deliberately *not* "expressive parity" — v1 rejects nested parallel states, so the softer claim is the accurate one).
- **Deeply integrated** — "a machine *is* an event handler," shown as four parallel beats: a `def`'d data value → `reg-machine` (= a machine-specific `reg-event`) → `dispatch` a normal event → `sub-machine` to read.

Added a transition-table gloss (`:on` maps an event to the next state) and tied the dispatched event back to the `:submit` arrow. Simple, direct voice throughout.

## Tutorial (`tutorial.md`)
Sharpened the **tutorial ↔ concepts boundary**. The tutorial had been re-explaining the *model* (the `reg-machine`=`reg-event` mechanism, strict encapsulation, the full `{:data :fx}` shape, the test-result model) — all of which Concepts owns. Each is now a one-line gloss + a deep-link to the matching Concepts section, keeping every build step and "what you see." Nothing was lost — each trimmed idea already has a complete home in Concepts (verified before trimming).

## Nav (`mkdocs.yml`)
Reordered the machines section by reader journey: **learn** (Overview → Tutorial → Concepts) → **extend** (feature pages, foundation→advanced; History moved up next to the compound-state pages, Actors last) → **operate** (Inspecting) → **reference** (Examples, Glossary, Coming from XState last).

## Verification
`check_doc_slugs` green (all deep-links resolve); full `mkdocs build` clean locally; `mkdocs --strict` runs in CI.