### PR TITLE
docs(machines): restructure corpus — one owner per topic, standalone (no /spec links), everyday-first nav

### DIFF
--- a/docs/machines/actors.md
+++ b/docs/machines/actors.md
@@ -6,7 +6,7 @@ The pattern earns its keep when an activity has a *lifetime that should match a 
 
 A spawned child can be **state-bound** — alive for exactly as long as a state is active — or **dynamically created**; re-frame2 spells both as **`:spawn`**. There is **no actor object**: a spawned actor's *liveness is its snapshot* — a plain value at `[:rf.runtime/machines :snapshots <actor-id>]` in the [frame's runtime-db](glossary.md#snapshot). You address it by `dispatch`-ing to its id, exactly like any other handler, and it reverts with the frame on time-travel.
 
-This page assumes you've met the [transition table, guards, actions, tags, and `:after`](concepts.md#guards-and-actions). If not, read [Concepts](concepts.md) first.
+This page assumes you've met the transition table and [guards and actions](concepts.md#guards-and-actions) from [Concepts](concepts.md), plus [`:after` timers](automatic-transitions.md) — they carry the timeout story below.
 
 ---
 
@@ -55,7 +55,7 @@ The map under `:spawn` accepts:
 | `:on-error` | an `:on`-shaped **transition** — fires when the child fails (an `:error?` final leaf, or a thrown action). The parent changes state. |
 | `:fixed-actor-id` | an explicit actor id instead of a gensym, for a per-state singleton actor. |
 
-`:on-done` / `:on-error` are the completion story — they pair with the child declaring a `:final?` leaf. That's covered under [Final states](concepts.md#final-states-when-a-machine-is-done); the [API reference](../api/re-frame.machines.md) lists the exact shapes. Here we focus on the lifecycle: spawn, address, message, and tear down.
+`:on-done` / `:on-error` are the completion story — they pair with the child declaring a `:final?` leaf, and they get [their own section below](#when-a-child-finishes). The [API reference](../api/re-frame.machines.md) lists the exact shapes.
 
 > **One `:spawn` per state.** A state node carries at most one `:spawn` — for multiple children, use a compound state with one actor per substate, or [`:spawn-all`](#fan-out-and-join-with-spawn-all) for parallelism. Events aren't auto-forwarded to children — forward them explicitly with `:fx [[:dispatch [child-id ev]]]`. To observe a child's snapshot, read it with the `[:rf/machine actor-id]` subscription.
 
@@ -174,6 +174,41 @@ There's no `sender`/`sendTo`-reply special form. Put the reply event *in the req
 
 ---
 
+## When a child finishes
+
+A spawned child that genuinely *completes* — a one-shot protocol, a finished handshake — declares a **`:final?` leaf**. Entering it terminates the child: the runtime reads the child's result, notifies the parent, then destroys the actor. The child names its result with **`:output-key`** — the slot of its final `:data` to hand up — and the parent's `:spawn` declares **`:on-done`**, which receives that value as `result`:
+
+```clojure
+;; Child — a one-shot auth handshake that reports its token, then ends.
+(rf/reg-machine :auth-flow
+  {:initial :running
+   :data    {}
+   :states
+   {:running {:on {:server-ok {:target :done
+                               :action (fn [{data :data ev :event}]
+                                         {:data (assoc data :token (second ev))})}}}
+    :done    {:final?     true
+              :output-key :token}}})       ;; report :data's :token back to the parent
+
+;; Parent — :on-done folds the child's result into its own :data.
+:authenticating
+{:spawn {:machine-id :auth-flow
+         :on-done    (fn [{data :data result :result}]   ;; result = the child's :token
+                       (assoc data :token result))
+         :on-error   :idle}                               ;; child failed → a transition
+ :on    {:auth/cancelled :idle}}
+```
+
+When `:auth-flow` enters `:done`, the runtime reads its `:token`, hands it to the parent's `:on-done` as `result`, then tears the child down — no stale id left behind. The details worth internalising:
+
+- **`:on-done` is a data-fold, not a transition.** It's `(fn [{:keys [data result]}] new-data)` — it returns the parent's next `:data`; the parent's state doesn't move.
+- **`:on-error` IS a transition.** A child that fails — it reaches a `:final?` leaf flagged `:error? true`, or one of its actions throws — routes the parent through the `:on`-shaped `:on-error` spec. Failure is control flow, not just observability.
+- **Completion is event-shaped.** The `:output-key` value flows to `:on-done` at the moment of completion, then the child is gone — there is no long-lived output slot to read later. Want a *computed* output? Write it into the final state's `:data` with a transition `:action`; there's no `:output-fn`.
+- **Final means final — even for a singleton.** A root-level `:final?` leaf auto-destroys *any* machine, spawned or not. A state a machine rests in indefinitely (an `:authed` end-screen) is an ordinary leaf with `:final?` omitted.
+- **Nested finals are different.** A `:final?` leaf *inside a compound state* doesn't end the machine — it signals "this sub-flow is done" to the enclosing compound's own `:on-done`, and the machine keeps running. That's the hierarchical pattern; see [Hierarchical states → When a sub-flow finishes](hierarchical-states.md#when-a-sub-flow-finishes-nested-final-states).
+
+---
+
 ## Imperative spawn and destroy
 
 `:spawn` desugars to two reserved effects you can also emit by hand from any `:fx` vector. They are **fx-ids inside `:fx`**, not top-level effect keys:
@@ -239,7 +274,7 @@ The [long-running-work example](../../examples/patterns/long_running_work/) show
 
 ## Wall-clock timeouts — use the parent state's `:after`
 
-"The whole activity must finish within N seconds, spanning any internal retries." There is **no `:timeout-ms` slot** on `:spawn` (it's rejected at registration). The answer is the [`:after`](concepts.md#guards-and-actions) primitive on the `:spawn`-bearing state — one timer mechanism, not two:
+"The whole activity must finish within N seconds, spanning any internal retries." There is **no `:timeout-ms` slot** on `:spawn` (it's rejected at registration). The answer is the [`:after`](automatic-transitions.md) primitive on the `:spawn`-bearing state — one timer mechanism, not two:
 
 ```clojure
 {:authenticating

--- a/docs/machines/automatic-transitions.md
+++ b/docs/machines/automatic-transitions.md
@@ -15,7 +15,7 @@ There are four authoring grammars, and underneath them just **two engines**:
 
 > **Four grammars, two engines.** `:type :choice` is sugar that **desugars to `:always`**; `:timeout` / `:on-timeout` is sugar that **desugars to `:after`**. So everything on this page runs on one of two mechanisms: the **guard-driven microstep loop** (`:always`, `:choice`) and the **wall-clock timer** (`:after`, `:timeout`). One fact, one mechanism — the extra grammars exist only to *name the author's intent* so tools and diagrams can read it.
 
-Everything below assumes the core loop from the [concepts guide](concepts.md#registering-and-running-it): a machine is registered with `reg-machine`, its transition table is data, a [guard](glossary.md#guard) returns a boolean, an [action](glossary.md#action) returns the data-shaped effect map `{:data … :fx …}` (the `:data` is *merged* into the snapshot, key by key), and the live value is a snapshot `{:state … :data … :tags …}`. New to all that? Read [Guards, actions, tags, and `:after` — the recognition kit](concepts.md#guards-and-actions) first.
+Everything below assumes the core loop from the [concepts guide](concepts.md#registering-and-running-it): a machine is registered with `reg-machine`, its transition table is data, a [guard](glossary.md#guard) returns a boolean, an [action](glossary.md#action) returns the data-shaped effect map `{:data … :fx …}` (the `:data` is *merged* into the snapshot, key by key), and the live value is a snapshot `{:state … :data … :tags …}`. New to all that? Read [Concepts → Guards and actions](concepts.md#guards-and-actions) first.
 
 ## Eventless `:always` — fire the instant a condition holds
 

--- a/docs/machines/concepts.md
+++ b/docs/machines/concepts.md
@@ -321,8 +321,8 @@ Because the snapshot is *just a value* — no functions, no atoms, nothing unpri
 
 Two keys round out the everyday kit, and each has earned a page of its own rather than a paragraph here:
 
-- **Tags** — `:tags #{:auth/busy}` on a state node, read with `@(rf/machine-has-tag? :auth.login/flow :auth/busy)`. This is the *ask-don't-tell* pattern: a view tracks "is it busy?" across any number of states without hard-coding state names, and adding a sixth busy state later is one `:tags` entry with zero view changes. (See [state tag](glossary.md#state-tag).) The deep treatment is in [tags.md](tags.md).
-- **Automatic transitions** — `:after` (a declarative timer: arm on entry, cancel on exit, no `setTimeout` or cancel-flag to wire) and `:always` (an eventless transition that fires the moment a guard turns true). The machine's *automatic* moves — the ones no event drives. See [automatic-transitions.md](automatic-transitions.md).
+- **Tags** — `:tags #{:auth/busy}` on a state node, read with `@(rf/machine-has-tag? :auth.login/flow :auth/busy)`. This is the *ask-don't-tell* pattern: a view tracks "is it busy?" across any number of states without hard-coding state names, and adding a sixth busy state later is one `:tags` entry with zero view changes. (See [state tag](glossary.md#state-tag).) The deep treatment is in [Tags](tags.md).
+- **Automatic transitions** — `:after` (a declarative timer: arm on entry, cancel on exit, no `setTimeout` or cancel-flag to wire) and `:always` (an eventless transition that fires the moment a guard turns true). The machine's *automatic* moves — the ones no event drives. See [Automatic transitions](automatic-transitions.md).
 
 ## Self-transitions: internal by default, external on demand
 
@@ -342,7 +342,7 @@ Look again at the turnstile. Pushing while `:locked` is a *self-transition* — 
 
 Here the `:after` self-transition is **external** (`:reenter? true`), so re-entering `:polling` re-runs `:start-fetch` and rearms the 30-second timer — a self-rescheduling poll in two keys. The `:got-data` transition is **internal** (no target), so a reply landing mid-window merges into `:data` without resetting the clock. Picking internal vs external per transition is exactly the control this rule buys you.
 
-> **The self-target subtlety.** A *targeted* self-transition does **not** re-enter by default. A self-target you *meant* to re-fire `:entry` on needs `:reenter? true`; without it, only the transition `:action` runs. Full mechanics, including ancestor restarts and the one `:always` restriction (an eventless `:always` may never self-target), are in [Spec 005 §Self-transitions](../../spec/005-StateMachines.md#self-transitions--internal-default-vs-external-reenter).
+> **The self-target subtlety.** A *targeted* self-transition does **not** re-enter by default. A self-target you *meant* to re-fire `:entry` on needs `:reenter? true`; without it, only the transition `:action` runs. (One related restriction: an eventless `:always` may never self-target at all — it's rejected at registration. See [Automatic transitions](automatic-transitions.md).)
 
 ## Wildcard transitions: handle a whole class of events
 
@@ -359,7 +359,7 @@ Sometimes a state should react to *any* event in a family rather than enumerate 
       :*          {:action :log-unknown}}}  ;; anything else
 ```
 
-One subtlety worth knowing: a guard-**blocked** exact match falls through to the coarser tiers (it wasn't *handled*), but a deliberate **forbidden block** — `{:on {:E {}}}` or `{:on {:E nil}}` — is itself a handler that *consumes* the event and stops the search. That distinction is how a child state opts out of an event its parent would otherwise handle. Full precedence rules in [Spec 005 §Wildcard transitions](../../spec/005-StateMachines.md#wildcard-transitions).
+One subtlety worth knowing: a guard-**blocked** exact match falls through to the coarser tiers (it wasn't *handled*), but a deliberate **forbidden block** — `{:on {:E {}}}` or `{:on {:E nil}}` — is itself a handler that *consumes* the event and stops the search. That distinction is how a child state opts out of an event its parent would otherwise handle. In a hierarchical machine the same three tiers run at each level of the deepest-wins walk — see [Hierarchical states](hierarchical-states.md#transition-resolution-deepest-wins-with-parent-fallthrough).
 
 > **A non-namespaced id has no wildcard tier.** A bare id like `:go` has no `:ns/*` tier — only its exact key or `:*` can catch it. The `:ns/*` tier lives on the keyword's `/` boundary: one prefix level between the exact id and the catch-all `:*`.
 
@@ -369,33 +369,10 @@ The login flow above parks in `:authed` and `:locked-out` forever — ordinary l
 
 > **Gotcha — final means final.** A `:final? true` leaf auto-destroys *even a top-level singleton machine*. If you want a state the machine rests in indefinitely (like `:authed`), use an ordinary leaf and **omit `:final?`** — exactly what the login flow does. `:final?` is for "this run is over," not "this is the last screen."
 
-The payoff is composition. A spawned child names a result key with `:output-key`; its parent's `:spawn` declares `:on-done`, which fires the moment the child finishes and receives that value as `:result`:
+The payoff is composition, and it comes in two scopes:
 
-```clojure
-;; Child — a one-shot auth handshake that reports its token, then ends.
-(rf/reg-machine :auth-flow
-  {:initial :running
-   :data    {}
-   :states
-   {:running {:on {:server-ok {:target :done
-                               :action (fn [{data :data ev :event}]
-                                         {:data (assoc data :token (second ev))})}}}
-    :done    {:final?     true
-              :output-key :token}}})       ;; report :data's :token back to the parent
-
-;; Parent — :on-done reads the child's result and folds it into its own :data.
-(rf/reg-machine :login
-  {:initial :idle
-   :states
-   {:idle           {:on {:submit :authenticating}}
-    :authenticating {:spawn {:machine-id :auth-flow
-                             :on-done    (fn [{data :data result :result}]
-                                           (assoc data :token result))}
-                     :on    {:auth/cancelled :idle}}
-    :authenticated  {}}})
-```
-
-When `:auth-flow` enters `:done`, the runtime reads its `:token`, hands it to the parent's `:on-done` as `result`, then tears the child down — no stale id left behind. A `:final?` leaf can also be flagged `:error? true` (a designated *error* terminal); if the parent's `:spawn` declares an `:on-error` transition, a failing child routes there instead. Full grammar, the singleton-symmetry rule, and the `[:rf.machine/done …]` signal that lets a *compound* state advance on its substates finishing are in [Spec 005 §Final states](../../spec/005-StateMachines.md#final-states-final--on-done--output-key).
+- **A spawned child reports back.** The child names a result key with `:output-key`; its parent's `:spawn` declares `:on-done`, which receives that value the moment the child finishes — then the runtime tears the child down. The full protocol, including the `:on-error` failure path, is in [Actors → When a child finishes](actors.md#when-a-child-finishes).
+- **A nested sub-flow advances the outer flow.** A `:final?` leaf *inside a compound state* doesn't end the machine — it signals "this sub-flow is done" to the enclosing compound's `:on-done`, and the machine keeps running. [Hierarchical states → When a sub-flow finishes](hierarchical-states.md#when-a-sub-flow-finishes-nested-final-states) owns that pattern.
 
 ## Validating a machine's `:data`
 
@@ -450,51 +427,30 @@ Unlike the `:data` boundary, output validation is **best-effort fail-loud**: the
 
 ## Testing: transitions are pure function calls
 
-This is where machines pay you back hardest. `machine-transition` runs one transition with no frame, no browser, no mocks. Table in, snapshot in, event in; result out:
+This is where machines pay you back hardest. A transition is a pure function of *(definition, snapshot, event)*, and `machine-transition` runs exactly one — no frame, no browser, no mocks. Table in, snapshot in, event in; result out:
 
 ```clojure
-(ns my-app.login-flow-test
-  (:require [clojure.test :refer [deftest is]]
-            [re-frame.machines :as machines]
-            [re-frame.machines.result :as result]
-            [my-app.login :refer [login-flow]]))
-
-(deftest login-flow-test
-  ;; happy path: :idle --submit--> :submitting (fires the request fx)
-  (let [s0 {:state :idle :data {:attempts 0 :error nil}}
-        {s1 ::result/snap fx1 ::result/fx}
-        (machines/machine-transition login-flow s0
-                                     [:auth.login/submit {:email "a@b.com" :password "secret"}])]
-    (is (= :submitting (:state s1)))
-    (is (= :rf.http/managed (ffirst fx1)))      ;; :entry ran :issue-request
-
-    ;; at the retry limit the guard rejects :error-shown; :locked-out wins
-    (let [{s2 ::result/snap}
-          (machines/machine-transition login-flow
-                                       {:state :submitting :data {:attempts 3 :error nil}}
-                                       [:auth.login/failure {:failure {:message "bad creds"}}])]
-      (is (= :locked-out (:state s2))))))
+(machines/machine-transition login-flow
+                             {:state :submitting :data {:attempts 3 :error nil}}
+                             [:auth.login/failure {:failure {:message "bad creds"}}])
+;; => a Result — ::result/snap holds {:state :locked-out …}, ::result/fx the emitted effects
 ```
 
-The return value is a result map. Destructure `::result/snap` and `::result/fx`, or discriminate with `result/ok?` / `result/fail?` — a throwing action surfaces as a *failure value*, not an exception out of your test, so one assertion style covers both paths. These run on the JVM in microseconds, which is exactly the testing experience you want for the flows where testing usually gets hard. The complete login flow with these tests lives at [`examples/capabilities/machines/state_machine_walkthrough/`](https://github.com/day8/re-frame2/tree/main/examples/capabilities/machines/state_machine_walkthrough) and runs on every CI pass.
+Feed in a snapshot and an event; assert on the value that comes back. These tests run on the JVM in microseconds — exactly the testing experience you want for the flows where testing usually gets hard. [Inspecting and testing machines](inspecting-machines.md) has the full treatment: the Result accessors, asserting effects as data, and the three test levels.
 
 ## When the machine grows
 
-The flat grammar above carries most machines. When a flow gets richer, the grammar grows *without changing the model* — each of these is the same transition-table data, one more key. You only need to recognise them here; the contracts live in [Spec 005](../../spec/005-StateMachines.md):
+The flat grammar above carries most machines. When a flow gets richer, the grammar grows *without changing the model* — each of these is the same transition-table data, one more key. Each has its own page in this guide:
 
+- **[Hierarchical states](hierarchical-states.md)** — a compound state contains sub-states; entering the parent cascades to its `:initial` child (an `:authenticated` super-state over `:browsing` / `:checkout`). A parent factors out transitions every descendant inherits, and a nested `:final?` leaf advances the outer flow when a sub-flow completes.
+- **[Parallel regions](parallel-states.md)** — one machine, several orthogonal axes active at once (`:type :parallel` + `:regions`) sharing one `:data`; the snapshot's `:state` becomes a map of region → state, tags union across regions. Three axes of 3 states each is 3 regions, not 27 cross-product states. When the axes *don't* share data, prefer N separate machines — that page works the trade-off.
+- **[History states](history.md)** — re-enter a compound at the substate it was in when you left (a paused player resumes mid-track), via a `:type :history` pseudo-state. The recording rides the snapshot, so it survives undo and hydration for free.
+- **[Automatic transitions](automatic-transitions.md)** — the moves no event drives, in depth: eventless `:always` (fires when a guard becomes true), `:type :choice` (a transient decision node that routes on entry), `:after` (the declarative timer), and `:timeout` / `:on-timeout` (a named deadline that lowers onto `:after`).
+- **[Spawned actors](actors.md)** — machines that aren't long-lived singletons: a per-request protocol machine, a wizard's per-step subprocess. The declarative [`:spawn`](glossary.md#spawn) key starts a child on state entry and destroys it on exit; `:spawn-all` fans out N children and joins on their completion.
 - **`:raise` loops an event back into this machine.** An action can return `:fx [[:raise [:some-event …]]]` to fire an event *at its own machine*, atomically, before the transition commits — useful when one transition's outcome should immediately drive another (a wizard step that completes and re-asks "is the whole form done?"). `:raise` is a reserved fx-id, alongside `[:rf.machine/spawn …]` and `[:rf.machine/destroy …]`, the actor-lifecycle pair behind the `:spawn` sugar. Everything else in `:fx` — `:dispatch`, `:rf.http/managed`, your own effects — flows to the ordinary effects machinery untouched.
-- **`:internal-events` makes an event private.** Some events are machine *plumbing* — a `:check-complete` the machine raises at itself, not for a view or test to dispatch. Declare those in a top-level `:internal-events` **set** (`#{:check-complete}`); an internal `:raise` is handled normally, but an *external* dispatch is **refused** at the machine's boundary (no transition; a `:rf.error/machine-internal-event-external-dispatch` trace fires). It's a set because membership is what you're declaring, not order. [§Public / private `:internal-events`](../../spec/005-StateMachines.md#public--private-internal-events).
-- **`:type :choice` is a decision node.** A choice state is a *transient* routing node: enter it and it resolves immediately — same step, no event — to the first guarded candidate whose `:guard` passes. It's `:always`'s decision pattern with a name, so diagrams render an explicit fork. The `:choice` value is a **declarative candidate array** — the routing stays *data*, not a function — and it must include an unguarded default and must not declare ordinary state keys. [§`:type :choice`](../../spec/005-StateMachines.md#type-choice-transient--choice-states).
-- **`:timeout` / `:on-timeout` names a deadline.** Where `:after` is the general timer table, `:timeout` is the named-intent spelling of "this state — or its spawned child — must finish before this time," pairing a duration with an `:on-timeout` transition (it lowers onto the same `:after` timer). A duration is a positive-integer millisecond count (`5000`) or an ISO-8601 string (`"PT5S"`, `"PT1H30M"`) — a `"5s"`-style shorthand is rejected, failing loud at registration. [§`:timeout` / `:on-timeout`](../../spec/005-StateMachines.md#timeout--on-timeout-state--spawn).
-- **Hierarchical states** — a compound state contains sub-states; entering the parent cascades to its `:initial` child (an `:authenticated` super-state over `:browsing` / `:checkout`). [§Hierarchical compound states](../../spec/005-StateMachines.md#hierarchical-compound-states).
-- **Eventless `:always`** — fires when a guard becomes true, no event needed. [§Eventless `:always` transitions](../../spec/005-StateMachines.md#eventless-always-transitions).
-- **Parallel regions** — one machine, several orthogonal axes active at once (`:type :parallel` + `:regions`) sharing one `:data`; the snapshot's `:state` becomes a map of region → state, tags union across regions. Three axes of 3 states each is 3 regions, not 27 cross-product states. [§Parallel regions](../../spec/005-StateMachines.md#parallel-regions); when the axes *don't* share data, prefer N separate machines — the trade-off is worked in the [CP-5 guide](../../spec/CP-5-MachineGuide.md).
-- **History states** — re-enter a compound at the substate it was in when you left (a paused player resumes mid-track), via a `:type :history` pseudo-state. The recording rides the snapshot, so it survives undo and hydration for free. [§History states](../../spec/005-StateMachines.md#history-states-type-history--shallow--deep--default-target).
-- **Spawned actors** — machines that aren't long-lived singletons: a per-request protocol machine, a wizard's per-step subprocess. The declarative [`:spawn`](glossary.md#spawn) key starts a child on state entry and destroys it on exit. [§Declarative `:spawn`](../../spec/005-StateMachines.md#declarative-spawn).
+- **`:internal-events` makes an event private.** Some events are machine *plumbing* — a `:check-complete` the machine raises at itself, not for a view or test to dispatch. Declare those in a top-level `:internal-events` **set** (`#{:check-complete}`); an internal `:raise` is handled normally, but an *external* dispatch is **refused** at the machine's boundary (no transition; a `:rf.error/machine-internal-event-external-dispatch` trace fires). It's a set because membership is what you're declaring, not order.
 
 > **Gotcha — a runaway `:always` / `:raise` cycle is a *failed* macrostep, not a hang.** Eventless transitions and `:raise` both re-enter the transition machinery within the same macrostep, so a non-converging loop (`:a` `:always`-targets `:b`, `:b` `:always`-targets `:a`, both guards true) could spin forever. It can't: each is bounded by a depth limit (default **16**, set per-frame via `:always-depth-limit` / `:raise-depth-limit`). Trip it and the macrostep **aborts atomically** — the snapshot stays at its pre-event value, no observer sees the partial path — and a single `:rf.error/machine-always-depth-exceeded` (or `:rf.error/machine-raise-depth-exceeded`) [error record](../core/glossary.md#error-record) fires. It is **distinct** from the silent no-op of an unhandled event: a runaway loop is a bug you want surfaced, not swallowed. There's no automatic recovery.
-
-> **Gotcha — an `:always` may not target itself.** `{:checking {:always {:target :checking}}}` is rejected at *registration* with `:rf.error/machine-always-self-loop`: re-entering a state to re-test the same guard either spins to the depth limit (guard stays true) or no-ops (guard flips) — neither is what you meant. The fixed-point loop you actually want is a **targetless** guarded `:always` with an `:action` that flips the guard — `{:always {:guard :more? :action :bump}}` — which runs and settles; or an intermediate distinct state if you genuinely need entry/exit to re-fire.
 
 ## When to reach for a machine — and when not
 

--- a/docs/machines/glossary.md
+++ b/docs/machines/glossary.md
@@ -1,6 +1,6 @@
 # Machines glossary
 
-re-frame2's optional state-machine capability — modelling a feature's lifecycle as an explicit statechart rather than a scatter of boolean flags. Every term below lives within a [machine](#machine), and each entry links to the page that teaches it in depth — usually [the Machines guide](concepts.md).
+re-frame2's optional state-machine capability — modelling a feature's lifecycle as an explicit statechart rather than a scatter of boolean flags. Every term below lives within a [machine](#machine), and each entry links to the page that teaches it in depth.
 
 Grouped by role: [the core loop](#the-core-loop), [state structure](#state-structure), [transitions and timing](#transitions-and-timing), [actors and composition](#actors-and-composition), [tags](#tags), and [the runtime model](#the-runtime-model).
 
@@ -78,7 +78,7 @@ What an [action](#action) returns: the same `{:data … :fx …}` map a [`reg-ev
                   (assoc :error (:message failure)))})
 ```
 
-See [Guards, actions, tags, and `:after`](concepts.md#guards-and-actions).
+See [The action effect map](concepts.md#the-action-effect-map--data-fx).
 
 ## State structure
 
@@ -86,13 +86,13 @@ See [Guards, actions, tags, and `:after`](concepts.md#guards-and-actions).
 
 A [state](#state) that nests its own `:states` map plus a required `:initial` substate — a parent mode with child modes (`:authenticated` over `:browsing` / `:checkout`). Entering it cascades down the `:initial` chain to a leaf, and the snapshot's `:state` becomes a **vector path** like `[:authenticated :cart :browsing]`. The runtime resolves an event by walking from the active leaf up to the root — **deepest-wins with parent fallthrough** — so a parent can factor out a transition (`:logout`) that every descendant inherits, while a child can [opt out](#forbidden-transition) or override.
 
-Listed under [When the machine grows](concepts.md#when-the-machine-grows).
+See [Hierarchical states](hierarchical-states.md).
 
 ### **parallel state**
 
 A machine declared `:type :parallel` at its root, holding a **`:regions`** map (not `:states`) — the [regions](#region) are **all active at once** rather than one-at-a-time. Three orthogonal axes of three states each is three regions, not twenty-seven cross-product states. The snapshot's `:state` becomes a **map** of region-name → that region's state (`{:data :loading :form :neutral :mode :active}`); all regions share one [`:data`](#data) and their [tags](#state-tag) union across regions. When the axes *don't* share data, prefer N separate machines instead.
 
-See the [nine_states example](../../examples/patterns/nine_states/) and [When the machine grows](concepts.md#when-the-machine-grows).
+See the [nine_states example](../../examples/patterns/nine_states/) and [Parallel states](parallel-states.md).
 
 ### **region**
 
@@ -100,15 +100,15 @@ One orthogonal axis of a [parallel state](#parallel-state) — its own independe
 
 ### **final state**
 
-A leaf marked **`:final? true`**: entering it **terminates the machine** — the runtime auto-destroys it, *even a top-level singleton*. It's for "this run is over," not "this is the last screen" — for a state the machine rests in indefinitely (like `:authed`), use an ordinary leaf and **omit** `:final?`. A final leaf can name an [`:output-key`](#on-done-and-output-key) to report a result, and can be flagged `:error? true` as a designated failure terminal.
+A leaf marked **`:final? true`**: entering it **terminates the machine** — the runtime auto-destroys it, *even a top-level singleton*. It's for "this run is over," not "this is the last screen" — for a state the machine rests in indefinitely (like `:authed`), use an ordinary leaf and **omit** `:final?`. A final leaf can name an [`:output-key`](#on-done-and-output-key) to report a result, and can be flagged `:error? true` as a designated failure terminal. A final leaf *nested inside a compound* is different: it ends the sub-flow, not the machine.
 
-See [Final states](concepts.md#final-states-when-a-machine-is-done).
+See [Actors → When a child finishes](actors.md#when-a-child-finishes) and [Hierarchical states → nested final states](hierarchical-states.md#when-a-sub-flow-finishes-nested-final-states).
 
 ### **history state**
 
 A `:type :history` **pseudo-state** you target to re-enter a [compound state](#compound-state) at whichever substate was active when you last left it — a paused player resuming mid-track. **Shallow** restores the immediate child; **deep** restores the full nested path; a `:default-target` covers the never-visited-yet case. The recording rides the [snapshot](#snapshot), so it survives undo and SSR hydration for free.
 
-Listed under [When the machine grows](concepts.md#when-the-machine-grows).
+See [History states](history.md).
 
 ## Transitions and timing
 
@@ -149,7 +149,7 @@ A state-node key holding a vector of guarded transitions that fire **with no eve
                          {:guard :form-invalid? :target :show-errors}]}
 ```
 
-Settled inside the [microstep](#microstep) loop. See [When the machine grows](concepts.md#when-the-machine-grows).
+Settled inside the [microstep](#microstep) loop. See [Automatic transitions](automatic-transitions.md).
 
 ### **delayed transition (`:after`)**
 
@@ -160,19 +160,19 @@ The declarative timer: a state-node key mapping a delay to a transition. Enter t
                :on    {:net/give-up :failed}}
 ```
 
-(ISO-8601 durations and the `"5s"`-shorthand rejection belong to [`:timeout`](#timeout), not `:after` — an `:after` key is an ms int, a sub vector, or a fn.) See [Guards, actions, tags, and `:after`](concepts.md#guards-and-actions).
+(ISO-8601 durations and the `"5s"`-shorthand rejection belong to [`:timeout`](#timeout), not `:after` — an `:after` key is an ms int, a sub vector, or a fn.) See [Automatic transitions](automatic-transitions.md).
 
 ### **timeout**
 
 The named-intent spelling of "this state — or its spawned child — must finish before this deadline": a `:timeout` duration paired with an `:on-timeout` transition. It *lowers onto* the same [`:after`](#delayed-transition-after) timer machinery; it just reads as a deadline rather than a general delay. A duration is integer-ms (`5000`) or an ISO-8601 string (`"PT5S"`, `"PT1H30M"`) — `"5s"` is rejected, failing loud at registration.
 
-Listed under [When the machine grows](concepts.md#when-the-machine-grows).
+See [Automatic transitions](automatic-transitions.md).
 
 ### **choice state**
 
 A `:type :choice` **transient** routing node: enter it and it resolves *immediately* — same step, no event — to the first candidate whose `:guard` passes. It's [`:always`](#eventless-transition-always)'s decision pattern with a name, so a diagram renders an explicit fork. The candidate list is a **declarative array** that must include an unguarded default and must not declare ordinary state keys.
 
-See [When the machine grows](concepts.md#when-the-machine-grows).
+See [Automatic transitions](automatic-transitions.md).
 
 ### **run-to-completion**
 
@@ -186,7 +186,7 @@ See [microstep](#microstep) and [macrostep](#macrostep).
 
 A declarative key that starts a *child* machine on entering a [state](#state) and tears it down on leaving; the child reports a result back through [`:on-done`](#on-done-and-output-key). (`:spawn-all` starts several in parallel and joins on completion.) Under the hood it's the reserved [`[:rf.machine/spawn …]`](../api/re-frame.machines.md#rfmachinespawn-spawn-spec) [effect](../core/glossary.md#effect); emit that directly from any handler when you need a dynamic count rather than one-child-per-state. The running instance it creates is an [actor](#actor).
 
-See [When the machine grows](concepts.md#when-the-machine-grows).
+See [Actors](actors.md).
 
 ### **actor**
 
@@ -198,7 +198,7 @@ The live instance is just a value in the frame, so time-travel and SSR extend to
 
 The fan-out sibling of [`:spawn`](#spawn): on entering a state it starts **N children in parallel** and **joins** on their completion, resolving when they've all finished (or on the first failure, with a cooperative cancellation cascade). Used for "spawn a worker per chunk and continue when all return."
 
-See the [long_running_work example](../../examples/patterns/long_running_work/) and [When the machine grows](concepts.md#when-the-machine-grows).
+See the [long_running_work example](../../examples/patterns/long_running_work/) and [Actors → Fan-out and join](actors.md#fan-out-and-join-with-spawn-all).
 
 ### **:on-done and :output-key**
 
@@ -212,7 +212,7 @@ How a finishing child reports back. A [final state](#final-state) names an **`:o
                                     (assoc data :token result))}}
 ```
 
-See [Final states](concepts.md#final-states-when-a-machine-is-done).
+See [Actors → When a child finishes](actors.md#when-a-child-finishes).
 
 ### **system-id**
 
@@ -256,7 +256,7 @@ A label like `:auth/busy` attached to several [machine](#machine) [states](#stat
   [spinner])
 ```
 
-See [Guards, actions, tags, and `:after`](concepts.md#guards-and-actions).
+See [Tags](tags.md).
 
 ## The runtime model
 

--- a/docs/machines/hierarchical-states.md
+++ b/docs/machines/hierarchical-states.md
@@ -381,34 +381,12 @@ at the root, by contrast, ends the actor.
 
 ### Reporting a result to a spawning parent: `:output-key`
 
-The *whole-machine* final case is how a **spawned child** reports back. The
+The *whole-machine* final case is how a **spawned child** reports back: the
 child marks its terminal leaf `:final?` and names the `:data` slot to hand up
 with `:output-key`; the parent's **`:spawn :on-done`** callback receives it as
-`result`:
-
-```clojure
-;; Child: declares its terminal state and what it outputs.
-(rf/reg-machine :auth-flow
-  {:initial :running
-   :data    {}
-   :states
-   {:running {:on {:server-ok {:target :done
-                               :action (fn [{data :data ev :event}]
-                                         {:data (assoc data :token (second ev))})}}}
-    :done    {:final?     true
-              :output-key :token}}})           ;; ← the :data slot reported back
-
-;; Parent: :spawn :on-done reads the child's result, then the child auto-destroys.
-(rf/reg-machine :login
-  {:initial :idle
-   :states
-   {:idle {:on {:submit :authenticating}}
-    :authenticating
-    {:spawn {:machine-id :auth-flow
-             :on-done    (fn [{data :data result :result}]   ;; result = child's :token
-                           (assoc data :token result))}
-     :on    {:auth/cancelled :idle}}}})
-```
+`result`, and the runtime then tears the child down. That protocol — including
+the `:on-error` failure path — is worked in
+[Actors → When a child finishes](actors.md#when-a-child-finishes).
 
 Two distinct `:on-done` hooks, then, named the same on purpose because they're
 the same idea at two scopes:
@@ -418,10 +396,6 @@ the same idea at two scopes:
 - **`:on-done` on a parent's `:spawn` map** — the *actor-teardown notification*
   `(fn [{:keys [data result]}] new-data)` a parent gets when a spawned child
   reaches a root-level `:final?` and is then destroyed.
-
-> re-frame2 keeps exactly **one** output primitive — there's no `:output-fn`
-> escape hatch. Want a *computed* output? Write a transition `:action` *into* the
-> final state that stashes the computed value at the `:output-key` slot.
 
 ### `:final?` constraints
 
@@ -440,6 +414,6 @@ A `:final?` state fails loud at registration if you break these:
 (Inside a parallel-region machine, a `:final?` leaf means "*this region* is
 done"; the machine as a whole is done only when *every* region is final.
 Parallel regions are a separate axis — they're for orthogonal concerns that
-*don't* share a sub-tree — covered in [Concepts](concepts.md).)
+*don't* share a sub-tree — covered in [Parallel states](parallel-states.md).)
 
 ---

--- a/docs/machines/history.md
+++ b/docs/machines/history.md
@@ -1,6 +1,6 @@
 # History states
 
-Some compound states have a memory. A media player you stop and restart should resume *mid-track*, not jump back to the first second. A wizard you step away from and return to should land on the step you left, not step one. A tabbed settings panel should remember which tab — and how far down each tab was scrolled — across a close/reopen. That "resume where I last was" behaviour is what a **history state** gives you, declaratively, for any [compound state](concepts.md#when-the-machine-grows).
+Some compound states have a memory. A media player you stop and restart should resume *mid-track*, not jump back to the first second. A wizard you step away from and return to should land on the step you left, not step one. A tabbed settings panel should remember which tab — and how far down each tab was scrolled — across a close/reopen. That "resume where I last was" behaviour is what a **history state** gives you, declaratively, for any [compound state](hierarchical-states.md).
 
 Without it you reach for the obvious workaround — stash the last substate in `:data` on the way out, read it back on the way in, and write the wiring to restore it. History states make that pattern a single node in the transition table — a first-class `:type :history` node — and (because the record/restore lives *inside the snapshot*) they ride undo, time-travel, persistence, and SSR for free.
 
@@ -95,7 +95,7 @@ Reach for **deep** when the precise nested position matters (resume the exact tr
 
 Recording is automatic and happens on the way **out**: whenever the exit cascade *leaves* a compound that owns a history pseudo-state, the runtime writes that compound's last-active configuration into the snapshot. You never write capture code.
 
-The owning compound must be **genuinely exited** to record. This is the [W3C SCXML](https://www.w3.org/TR/scxml/#history) exit-set rule: a `<history>` value is written only for states in the exit set. A transition that merely moves *between two children* of the compound keeps the compound as the [least-common ancestor](concepts.md#when-the-machine-grows) — the compound **survives**, was never left, and so records nothing (there is no "last config" to remember; it is still in one).
+The owning compound must be **genuinely exited** to record. This is the [W3C SCXML](https://www.w3.org/TR/scxml/#history) exit-set rule: a `<history>` value is written only for states in the exit set. A transition that merely moves *between two children* of the compound keeps the compound as the [least-common ancestor](hierarchical-states.md#entryexit-cascading-along-the-lca) — the compound **survives**, was never left, and so records nothing (there is no "last config" to remember; it is still in one).
 
 That is exactly why `:eject` targets `:tray` (a *sibling of* `:player`, outside it) rather than some inner state: only leaving `:player` puts it in the exit set. A common first mistake is to put the history node on a compound that nothing ever exits — then it silently never records and "restore" always falls to the default. If your history isn't sticking, check that *something leaves the owning compound.*
 
@@ -131,7 +131,7 @@ Because the recording is *part of the snapshot value* — not a side-table — r
 
 ## Per-region history under `:type :parallel`
 
-Under a [parallel](concepts.md#when-the-machine-grows) machine each region runs an independent state-tree, so **history is per-region**: a history node declared inside a region's compound records and restores *that region's* configuration on the region's own exit cascade, independently of its siblings. The `:rf/history` keys are **region-qualified** — the region name is the head segment of the declaration-path key — so two regions that each declare a history-bearing compound at structurally-identical paths never collide:
+Under a [parallel](parallel-states.md) machine each region runs an independent state-tree, so **history is per-region**: a history node declared inside a region's compound records and restores *that region's* configuration on the region's own exit cascade, independently of its siblings. The `:rf/history` keys are **region-qualified** — the region name is the head segment of the declaration-path key — so two regions that each declare a history-bearing compound at structurally-identical paths never collide:
 
 ```clojure
 ;; Two regions, each with a history-bearing :on compound at the same shape.

--- a/docs/machines/inspecting-machines.md
+++ b/docs/machines/inspecting-machines.md
@@ -223,10 +223,10 @@ The `login-flow` table above is plain data, so the very same value that renders 
 | **2 — unregistered handler fn** | handler-level wiring, `:data`-to-`:db` lowering | fast | dispatch pipeline, spawn lifecycle |
 | **3 — registered in a test frame** | full integration: trace events, drain, spawn/destroy, cross-actor messaging | slowest | nothing |
 
-Most logic lives at Level 1. Reach for Level 3 only for spawned-actor patterns, where the whole point is that a handler gets registered dynamically and the parent can `dispatch` to it. The contracts for all three are in [Spec 005 §Testing](../../spec/005-StateMachines.md).
+Most logic lives at Level 1. Reach for Level 3 only for spawned-actor patterns, where the whole point is that a handler gets registered dynamically and the parent can `dispatch` to it.
 
 > **The test *is* the transition function.** A `machine-transition` test is literally `(fn definition snapshot event)` — nothing to instantiate, you assert the behavioural contract *(state, event) → next state + effects* directly.
 
-See [`machine-transition`](../api/re-frame.machines.md#re-framemachinesmachine-transition) and [`machine-meta`](../api/re-frame.machines.md#re-framemachinesmachine-meta) in the API reference, and the narrative in [Concepts §Testing](concepts.md#testing-transitions-are-pure-function-calls).
+See [`machine-transition`](../api/re-frame.machines.md#re-framemachinesmachine-transition) and [`machine-meta`](../api/re-frame.machines.md#re-framemachinesmachine-meta) in the API reference.
 
 ---

--- a/docs/machines/parallel-states.md
+++ b/docs/machines/parallel-states.md
@@ -8,7 +8,7 @@ Model that as one flat machine and the states multiply — three axes of three s
 
 Reach for them when you have **multiple orthogonal axes of one feature** that share a domain: one form with data / validity / display-mode axes, one connection with auth + lifecycle + request-queue, one widget with display + interaction state. The giveaway is a single conceptual thing whose state is naturally a *tuple* of independent sub-states.
 
-The axes share a single [`:data`](concepts.md#the-same-flow-as-a-transition-table) map *because they're facets of one domain* — they read and write the *same* data, just sliced differently. If your axes are genuinely separate features that share nothing (a websocket connection plus an unrelated auth flow plus a route), that's not parallel regions — that's **N separate machines** colocated in [runtime-db](../core/glossary.md#runtime-db). Per-region `:data` is deliberately **not** supported; if your axes need encapsulated data, that's the substrate telling you to register N machines instead. (The full parallel-regions-versus-N-machines trade-off lives in the spec — see Further reading.)
+The axes share a single [`:data`](concepts.md#the-same-flow-as-a-transition-table) map *because they're facets of one domain* — they read and write the *same* data, just sliced differently. If your axes are genuinely separate features that share nothing (a websocket connection plus an unrelated auth flow plus a route), that's not parallel regions — that's **N separate machines** colocated in [runtime-db](../core/glossary.md#runtime-db). Per-region `:data` is deliberately **not** supported; if your axes need encapsulated data, that's the substrate telling you to register N machines instead.
 
 ## The shape: one machine, several regions
 
@@ -256,28 +256,7 @@ A parallel machine's `:tags` is the **union of every active state's tags across 
 
 The framework [`machine-has-tag?`](../api/re-frame.machines.md) sub works unchanged — it asks "does the union contain this tag?", and the answer is yes iff *any* active state in *any* region declared it. That's what lets a view disable itself with `@(rf/machine-has-tag? :ui/nine-states :mode/read-only)` without caring which region (or which state of it) carries the read-only intent — *ask, don't tell* ([state tag](glossary.md#state-tag)).
 
-The composed tag union also delivers the headline payoff: **collapsing N live axes down to one render decision**. Several tags are live at once, but the page draws one thing, so a plain-data priority table picks the winner:
-
-```clojure
-(def render-priority                       ;; read top to bottom; first match wins
-  [{:tag :mode/done    :render :done}      ;; an archived list trumps everything
-   {:tag :form/success :render :correct}   ;; transient form acknowledgements next
-   {:tag :form/invalid :render :incorrect}
-   {:tag :data/loading :render :loading}   ;; then the resting data axis
-   {:tag :data/nothing :render :nothing}
-   {:tag :data/empty   :render :empty}
-   {:tag :data/some    :render :some}
-   {:tag :data/too-many :render :too-many}])
-
-(rf/reg-sub :ui/render
-  :<- [:rf/machine :ui/nine-states]
-  (fn [snap _]
-    (let [tags (:tags snap)]
-      (some (fn [{:keys [tag render]}] (when (contains? tags tag) render))
-            render-priority))))
-```
-
-The root view then branches with a single `case` over `@(rf/subscribe [:ui/render])`. Three regions, nine states, **one** branch site — and the display priorities live in *one* readable table, not scattered across ten views.
+The composed tag union also delivers the headline payoff: **collapsing N live axes down to one render decision**. Several tags are live at once, but the page draws one thing, so a plain-data priority table picks the winner and the root view branches with a single `case`. Three regions, nine states, one branch site. That pattern — the priority table, the selector sub, the one-`case` root view — is worked in [Tags → Collapsing many states into one render decision](tags.md#collapsing-many-states-into-one-render-decision).
 
 ## A divergence to know: no nested parallel regions
 

--- a/docs/machines/tags.md
+++ b/docs/machines/tags.md
@@ -6,7 +6,7 @@ Reach for tags when:
 
 - several states share a meaning a view cares about ("any of these is loading-ish"), and you don't want a boolean sub per state;
 - a page's render decision slices across more than one axis (data cardinality × form validity × mode) and you want one decision table instead of an N-way `cond`;
-- a guard in one [parallel region](concepts.md#when-the-machine-grows) needs to know what a *sibling* region is doing without reaching into its private state.
+- a guard in one [parallel region](parallel-states.md) needs to know what a *sibling* region is doing without reaching into its private state.
 
 If a label would only ever match exactly one state, skip it — query the state directly with `(= :loading (:state snap))`. Tags earn their keep by matching *many* states with one shared intent.
 
@@ -53,8 +53,8 @@ At every transition the runtime walks the machine's active states, unions their 
 How the union is computed depends on the machine's shape:
 
 - **Flat machine** — the single active state's `:tags`.
-- **Compound (hierarchical) machine** — the union along the active path: root → every compound ancestor → leaf.
-- **Parallel machine** — the union across *every* active state in *every* region. (This is what makes tags the cross-region signal in the last section.)
+- **[Compound (hierarchical)](hierarchical-states.md) machine** — the union along the active path: root → every compound ancestor → leaf.
+- **[Parallel](parallel-states.md) machine** — the union across *every* active state in *every* region. (This is what makes tags the cross-region signal in the last section.)
 
 `:tags` is **read-only** for you. It's a pure projection of `:state` — set the state, the tags follow — so an action can't return `:tags` in its `{:data :fx}` effect map; the runtime owns the slot. And when the union is **empty** (no active state declares any tag), the runtime **elides** the key entirely: a tag-free machine carries no `:tags` slot at all, so `(contains? snap :tags)` can be `false` even after the machine has settled. Don't declare an empty `:tags #{}` to "have the slot" — just omit it.
 
@@ -95,7 +95,7 @@ Need the whole set rather than one bit? That's the ordinary snapshot read:
 
 ## Collapsing many states into one render decision
 
-This is where tags pay off hardest. The [Nine States example](../../examples/patterns/nine_states) models a page as one `:type :parallel` machine with three orthogonal regions — `:data` (request lifecycle + cardinality), `:form` (validation), `:mode` (active / archived). Every state wears a per-axis tag:
+This is where tags pay off hardest. The [Nine States example](../../examples/patterns/nine_states) models a page as one [`:type :parallel`](parallel-states.md) machine with three orthogonal regions — `:data` (request lifecycle + cardinality), `:form` (validation), `:mode` (active / archived). Every state wears a per-axis tag:
 
 ```clojure
 ;; (excerpt from the three regions) — each state announces its intent
@@ -156,41 +156,14 @@ Notice what the form *doesn't* ask: "is the `:mode` region in `:done`?" It asks 
 
 ## Tags as a cross-region signal
 
-In a parallel machine the tag union spans *all* regions, which makes it the channel one region uses to read what a sibling is doing. This is the classic statechart coordination primitive: a guard in region A predicates on region B's state. re-frame2 ships this without a dedicated operator: **a sibling region advertises a tag, and any region's guard reads the tag union off its context map.**
-
-A guard or action running *inside a parallel region* gets two extra keys in its context map, alongside the usual `:data` / `:event` / `:state` / `:meta`:
-
-- **`:tags`** — the machine-wide tag union (the **coarse**, idiomatic read);
-- **`:all-state`** — the full `{region → active-state}` map (the **precise** read).
-
-```clojure
-(rf/reg-machine :ui/checkout
-  {:type   :parallel
-   :data   {}
-   :guards {:form-valid? (fn [{:keys [tags]}]              ;; reads a SIBLING region's tag
-                           (contains? tags :form/valid))}
-   :regions
-   {:form     {:initial :editing
-               :states  {:editing {:tags #{:form/editing} :on {:complete :valid}}
-                         :valid   {:tags #{:form/valid}}}}
-    :checkout {:initial :idle
-               :states  {:idle       {:on {:submit {:target :submitting
-                                                    :guard  :form-valid?}}}
-                         :submitting {:tags #{:checkout/submitting}}}}}})
-```
-
-`:checkout`'s `:submit` fires only once the `:form` region has advertised `:form/valid`. The precise variant reads the sibling's state value directly instead:
-
-```clojure
-:guards {:form-valid? (fn [{:keys [all-state]}] (= :valid (:form all-state)))}
-```
-
-Prefer the **tag** form: a tag is a named, tool-legible render-state, and it survives the sibling region renaming its internal states as long as the tag stays put.
+In a [parallel machine](parallel-states.md) the tag union spans *all* regions, which makes it the channel one region uses to read what a sibling is doing — the classic statechart coordination primitive, shipped without a dedicated operator. A sibling region advertises a tag; any region's guard reads the machine-wide union off its context map and predicates on it — `(fn [{:keys [tags]}] (contains? tags :form/valid))`.
 
 Two things to hold onto:
 
 - **A tag is a guard *input*, not a *trigger*.** A tag flipping on does not *fire* anything — there is no "on this tag appearing" transition. The dependent region still moves on its next event (or an eventless `:always`); the guard merely *reads* the sibling's advertised tag when it runs.
-- **These keys are parallel-only, and frozen.** A flat or compound machine's guard/action context is exactly `{:data :event :state :meta}` — no `:tags` / `:all-state`, because a flat machine has no sibling to coordinate with (its own `:state` is all there is to read). In a parallel machine both keys reflect the configuration *as of the start of the macrostep*, so every region selects against the same frozen sibling view, independent of region declaration order. The exact same-event convergence paths — `:raise` for same-macrostep coupling, a guarded `:always` for next-event coupling — are spelled out in the spec.
+- **The cross-region keys are parallel-only.** A flat or compound machine's guard/action context stays exactly `{:data :event :state :meta}` — it has no sibling to coordinate with.
+
+The worked example — a `:checkout` region whose `:submit` waits for the `:form` region to advertise `:form/valid` — plus the precise `:all-state` variant and the frozen-snapshot selection rules are in [Parallel states → Coordinating regions](parallel-states.md#coordinating-regions-tags-as-statein).
 
 ## What tags are *not*
 

--- a/docs/machines/tutorial.md
+++ b/docs/machines/tutorial.md
@@ -276,4 +276,4 @@ Here's the payoff. A transition is a pure function of *(table, snapshot, event)*
     (is (= :locked-out (:state snap)))))
 ```
 
-Feed in a snapshot and an event; assert on what comes back. The result is a value — `::result/snap` / `::result/fx`, or `result/ok?` / `result/fail?` (a throwing action is a *failure value*, not an exception out of your test). It runs on the JVM in microseconds — exactly the testing experience you want for the flows where testing usually gets hard. [Concepts → Testing](concepts.md#testing-transitions-are-pure-function-calls) goes deeper.
+Feed in a snapshot and an event; assert on what comes back. The result is a value — `::result/snap` / `::result/fx`, or `result/ok?` / `result/fail?` (a throwing action is a *failure value*, not an exception out of your test). It runs on the JVM in microseconds — exactly the testing experience you want for the flows where testing usually gets hard. [Inspecting and testing machines](inspecting-machines.md) goes deeper: the Result accessors, asserting effects as data, and the three test levels.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -233,11 +233,11 @@ nav:
     - machines/index.md
     - "Tutorial: build a login machine": machines/tutorial.md
     - "Concepts": machines/concepts.md
+    - "Tags": machines/tags.md
+    - "Automatic transitions": machines/automatic-transitions.md
     - "Hierarchical states": machines/hierarchical-states.md
     - "Parallel states": machines/parallel-states.md
     - "History": machines/history.md
-    - "Automatic transitions": machines/automatic-transitions.md
-    - "Tags": machines/tags.md
     - "Actors": machines/actors.md
     - "Inspecting and testing": machines/inspecting-machines.md
     - "Examples": machines/examples.md


### PR DESCRIPTION
Full review + refactor of the `docs/machines` corpus (13 files, ~3.5K lines) for tutorial/reference quality, flow, and progressive disclosure.

## Verdict on the document set

The set itself is right — tutorial / concepts / six topic pages / inspecting-and-testing / examples / glossary / coming-from-xstate map cleanly onto tutorial–explanation–reference roles. **No pages added or removed.** The problems were duplication, ownership, and routing.

## What changed

**1. One owner per topic (duplications removed)**

| Topic | Was | Now owned by |
|---|---|---|
| Child completion (`:final?` / `:output-key` / `:on-done` / `:on-error`) | full code in concepts **and** hierarchical-states (actors deferred *out*) | **actors.md** — new "When a child finishes" section in the lifecycle where it belongs; concepts + hierarchical trimmed to pointers |
| Cross-region coordination (the `:ui/checkout` example) | verbatim in tags.md **and** parallel-states.md | **parallel-states.md**; tags keeps the idea + pointer |
| Render-priority collapse (the nine-states table) | verbatim in tags.md **and** parallel-states.md | **tags.md**; parallel keeps the union rule + pointer |
| Full testing treatment | near-identical code in concepts **and** inspecting-machines (plus the tutorial's) | **inspecting-machines.md**; concepts trimmed to a 6-line teaser; tutorial keeps its pedagogical Step 6 |

**2. Routing repair.** Concepts' "When the machine grows" and ~14 glossary entries pointed readers at `spec/005` — they predate the topic pages. All now route to the guide's own pages (hierarchical, parallel, history, automatic-transitions, actors, tags). history.md's three concepts-anchor links likewise now hit the owning pages.

**3. No `/spec` links (per direction).** The corpus now reads standalone: every spec pointer was either already covered inline or got its essential rule restated in place (self-target restriction, wildcard precedence, N-machines trade-off).

**4. Nav reordered — everyday kit first.** A reader finishing the tutorial has a flat machine; their next needs are tags and timers, not nesting. New order mirrors concepts' own structure ("the everyday kit" → "when the machine grows"):

Overview → Tutorial → Concepts → **Tags → Automatic transitions** → Hierarchical → Parallel → History → Actors → Inspecting and testing → Examples → Glossary → Coming from XState *(last, unchanged)*

**5. Small fixes.** Dangling "see Further reading" in parallel-states.md; stale link texts; duplicated `:always` self-target gotcha dropped from concepts (automatic-transitions owns it).

Net: −83 lines while *adding* the actors completion section. No "what you've learned" / "what's next" sections anywhere.

## Gates

- `python -m mkdocs build --strict` — green
- `python scripts/check_doc_slugs.py` — exit 0
