### PR TITLE
docs(api): fix re-frame.http.md reply shape for explicit targets (rf2-48k66t)

### DIFF
--- a/docs/api/re-frame.http.md
+++ b/docs/api/re-frame.http.md
@@ -39,8 +39,8 @@ The verb helpers live in `re-frame.http`; the `:rf.http/managed` fx is keyword-a
             :on-failure [:cart/load-failed]}]]}))
 
 (rf/reg-event :cart/loaded
-  (fn [{:keys [db]} [_ {:keys [rf/reply]}]]
-    {:db (assoc-in db [:cart :items] (:value reply))}))
+  (fn [{:keys [db]} [_ {:keys [value]}]]
+    {:db (assoc-in db [:cart :items] value)}))
 
 (rf/reg-sub :cart/items
   (fn [db _] (get-in db [:cart :items])))
@@ -50,19 +50,19 @@ That's enough to issue a request, decode the JSON reply, and dispatch the result
 
 ## Reply addressing
 
-Every reply lands under `:rf/reply` in the dispatched event's payload map. Two shapes:
+Every reply is one of two plain payload maps:
 
 ```clojure
 ;; Success
-{:rf/reply {:kind :success :value decoded-body}}
+{:kind :success :value decoded-body}
 
 ;; Failure
-{:rf/reply {:kind    :failure
-            :failure {:kind  :rf.http/<category>
-                      :tags  {...}}}}
+{:kind    :failure
+ :failure {:kind :rf.http/<category>
+           :tags {...}}}
 ```
 
-**Default reply addressing** dispatches `[<originating-event-id> (assoc original-msg :rf/reply ...)]` back to the same handler — your `:cart/load` handler sees the reply at `:rf/reply`. **Explicit `:on-success` / `:on-failure`** targets append the reply payload as the last event-vector arg — your `:cart/loaded` handler sees `[:cart/loaded {:rf/reply ...}]`. Both shapes detailed in [Managed HTTP — Handling the reply](../async/http.md#handling-the-reply).
+Where that payload lands depends on how you addressed the reply. **Explicit `:on-success` / `:on-failure`** targets receive the **bare payload** appended as the last event-vector arg — your `:cart/loaded` handler sees `[:cart/loaded {:kind :success :value decoded-body}]` and destructures it directly (`[_ {:keys [value]}]` / `[_ {:keys [failure]}]`). **Default (co-located) addressing** — omit both targets — instead merges the same payload under `:rf/reply` into the originating message and re-dispatches `[<originating-event-id> (assoc original-msg :rf/reply ...)]` back to the same handler, which reads it at `:rf/reply`. The `:rf/reply` wrapper is the co-located form only; explicit targets get the bare `{:kind ...}` map. Both shapes detailed in [Managed HTTP — Handling the reply](../async/http.md#handling-the-reply).
 
 ## Failure categories (closed set)
 


### PR DESCRIPTION
Fixes **rf2-48k66t** — a docs bug in `docs/api/re-frame.http.md`. The §Reply addressing prose and the "A minimal request" example wrongly claimed that **explicit** `:on-success` / `:on-failure` targets receive `{:rf/reply …}` appended as the last event arg. That is the co-located **default** form's behaviour, not the explicit-target behaviour.

## What changed

Scope: `docs/api/re-frame.http.md` only.

1. **"A minimal request" example** — `:cart/loaded` is an explicit `:on-success` target, so its receive handler now destructures the **bare payload** (`[_ {:keys [value]}]` and reads `value` directly), instead of `[_ {:keys [rf/reply]}]` / `(:value reply)`.
2. **§Reply addressing** — the two-shapes code block now shows the bare `{:kind :success :value …}` / `{:kind :failure :failure …}` payload maps (not `:rf/reply`-wrapped). The prose now states: explicit targets receive the **bare** payload as the last event-vector arg (`[:cart/loaded {:kind :success :value decoded-body}]`, destructure `[_ {:keys [value]}]` / `[_ {:keys [failure]}]`); the `:rf/reply` merge is the **co-located default form only**.

## Correct contract (confirmed against source-of-truth)

- **spec/014-HTTPRequests.md §Reply addressing** — "The `:rf/reply` payload is appended as the last argument to the dispatched event vector: `[:article/loaded {:kind :success :value v}]` / `[:article/load-error {:kind :failure :failure failure-map}]`". The default (omitted) form dispatches `[<originating-event-id> (assoc original-msg :rf/reply {:kind :success :value v})]`.
- **docs/async/http.md §Handling the reply** — "Separate handlers" (explicit) get `[:article/loaded {:kind :success :value <decoded>}]`, destructured `[_ {:keys [value]}]` / `[_ {:keys [failure]}]`; the "One handler" (default) form merges the reply under `:rf/reply`.

The two sources agree; this PR makes the API doc match them. spec/014 and async/http.md are unchanged (source of truth).

## Quality gates

- `python -m mkdocs build --strict` (from worktree root) — **exit 0** (INFO messages only; strict raised no errors). `mkdocs` was not on PATH, so the `python -m mkdocs` form was used.