### PR TITLE
docs(routing): docs-internal routing, section map, house nav order

### DIFF
--- a/docs/routing/concepts.md
+++ b/docs/routing/concepts.md
@@ -120,9 +120,9 @@ You've now met the keys you'll reach for daily. The metadata map has thirteen re
 
 When two patterns could both match one URL, a structural ranking breaks the tie: more static segments win, and named params beat splats. The ranking is computed at *registration* time from the patterns alone — so the winner is decided before a single URL ever arrives, and there's no runtime ambiguity to debug.
 
-??? note "The full grammar and ranking rules"
+??? note "The full ranking cascade"
 
-    The full path grammar, the six-rule ranking cascade, and the per-boundary validation failure modes live in [Spec 012 — Routing](../../spec/012-Routing.md). You won't need them for everyday routes. Worth knowing the shape of the cascade, though: (1) more static segments win; (2) the *bare* catch-all `/*` is demoted below everything; (3) longer paths win; (4) named params beat splats; (5) exact routes beat optional-group routes; (6) registration order is the final, discouraged tiebreak — and the runtime warns (`:rf.warning/route-shadowed-by-equal-score`) at registration if two routes tie all the way down.
+    The five path elements above are the whole grammar; the ranking cascade, when two patterns compete, runs six rules deep: (1) more static segments win; (2) the *bare* catch-all `/*` is demoted below everything; (3) longer paths win; (4) named params beat splats; (5) exact routes beat optional-group routes; (6) registration order is the final, discouraged tiebreak — and the runtime warns (`:rf.warning/route-shadowed-by-equal-score`) at registration if two routes tie all the way down. You won't need past rule (1) for everyday routes.
 
 ## Move 2: navigation is an event
 
@@ -430,7 +430,7 @@ A route slice can hold secrets — an OAuth `?token=`, a `?code=` callback param
 
 > **Gotcha — classify the query key the route promotes.** A `[:query :token]` classification path names the *keyword* `:token`, but the slice only keys a query value as a keyword when the route declares it (in `:query`, `:query-defaults`, or `:query-retain`). Classify a query key the route doesn't promote and the path silently fails open — so `reg-route` emits a `:rf.warning/route-classification-query-key-unpromoted` advisory pointing at the fix: name the key in the `:query` schema. Path params are immune (path captures are always keyword-keyed). And a structurally malformed declaration (a non-vector axis, a bad path segment) fails *loud* at registration with `:rf.error/invalid-route-classification`.
 
-Routing's classification is the [data-classification](../../spec/015-Data-Classification.md) model applied to the singleton current-route. The full classification, privacy, and observability story lives in the spec; routes just declare the paths.
+Routing's classification is the framework-wide [data-classification](../core/glossary.md#data-classification) model applied to the singleton current-route — [Keep secrets out of traces](../core/how-to/keep-secrets-out-of-traces.md) is the full story; routes just declare the paths.
 
 ## The browser is just another event source
 

--- a/docs/routing/examples.md
+++ b/docs/routing/examples.md
@@ -2,7 +2,7 @@
 
 Worked routing apps you can read end to end in the repo's example tree.
 
-- **routing** — the smallest app that exercises the full Spec 012 surface: a route table via `reg-route`, navigation-as-event (`:rf.route/navigate`), route reads as plain subs (`:rf.route/id` / `:rf.route/params`), and a root view that switches on the route id. Start here. [→ source](../../examples/capabilities/routing/routing)
-- **realworld** — routing folded into a full Conduit clone: path params and `?page=N` query params, auth-gated routes via an `auth-guard` interceptor (Spec 012 redirects and guards), route-driven data loads, and navigation blocking for the unsaved-editor form. See routing working under real load. [→ source](../../examples/real-apps/realworld_http)
+- **routing** — the smallest app that exercises the whole routing surface: a route table via `reg-route`, navigation-as-event (`:rf.route/navigate`), route reads as plain subs (`:rf.route/id` / `:rf.route/params`), and a root view that switches on the route id. Start here. [→ source](../../examples/capabilities/routing/routing)
+- **realworld** — routing folded into a full Conduit clone: path params and `?page=N` query params, auth-gated routes via an `auth-guard` interceptor, route-driven data loads, and navigation blocking for the unsaved-editor form. See routing working under real load. [→ source](../../examples/real-apps/realworld_http)
 
 For the underlying ideas, see [Concepts](concepts.md).

--- a/docs/routing/index.md
+++ b/docs/routing/index.md
@@ -17,4 +17,13 @@ You register routes (`reg-route`) as a table mapping URL patterns to what they n
 
 Because a route's [loader](glossary.md#loader) runs on the server too, routing and [SSR](../ssr/index.md) share one data-fetch story — there's no separate server fetch to keep in sync.
 
+## In this section
+
+- **[Tutorial: build a routed app](tutorial.md)** — a three-page app grown one step at a time: routes, links, dynamic segments, loaders, the 404, the Back button, and a shared layout. Start here.
+- **[Concepts](concepts.md)** — the whole model in three moves, then the refinements: query strings, loaders and resources, blocking a navigation, not-found, classification, and running the same handler on the server.
+- **How-to** — [Guard against unsaved changes](how-to/guard-unsaved-changes.md) and [Require sign-in on a route](how-to/require-sign-in-on-a-route.md): one task each, complete code.
+- **[Examples](examples.md)** — runnable routing apps, small and under real load.
+- **[Glossary](glossary.md)** — the section's vocabulary, one definition each.
+- **[Coming from React Router](coming-from-react-router.md)** — the mapping table and the deliberate divergences.
+
 The routing docs are a **guide** — read top to bottom to learn routing, or dip in to understand one part. Every signature, event, subscription, and keyword has its canonical home in the separate **[API reference](../api/re-frame.routing.md)**: the guide teaches, the reference is where you look things up.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -276,15 +276,17 @@ nav:
     - "Examples": async/examples.md
 
   - Routing:
+    # Tutorial first, then the model, then task recipes; the React Router
+    # translation sits last, like XState in Machines and TanStack in Resources.
     - routing/index.md
     - "Tutorial: build a routed app": routing/tutorial.md
     - "Concepts": routing/concepts.md
-    - "Coming from React Router": routing/coming-from-react-router.md
     - "How-to":
       - "Guard against unsaved changes": routing/how-to/guard-unsaved-changes.md
       - "Require sign-in on a route": routing/how-to/require-sign-in-on-a-route.md
-    - "Glossary": routing/glossary.md
     - "Examples": routing/examples.md
+    - "Glossary": routing/glossary.md
+    - "Coming from React Router": routing/coming-from-react-router.md
 
   - SSR:
     - ssr/index.md


### PR DESCRIPTION
## Why

Same process as machines (#5082), async (#5083), resources (#5085), and core (#5086), applied to `docs/routing`. This corpus turned out to be the cleanest of the series — already tutorial-first, with an excellent stepwise tutorial, tight how-tos, and only two `/spec` links — so the delta is small.

## What changed

- **No `/spec` links** (2 removed, both in `concepts.md`):
  - The ranking-cascade collapsible already restated the six rules inline — the spec citation sentence is dropped and the collapsible retitled to what it actually contains.
  - The classification section's Spec-015 pointer now routes to the docs owners: the core glossary's data-classification entry and the keep-secrets-out-of-traces how-to.
- **Prose spec citations scrubbed**: `examples.md` said "the full Spec 012 surface" and "(Spec 012 redirects and guards)" — now plain language.
- **`routing/index.md`** gains an "In this section" map, matching the async and resources landing pages.
- **Nav** reordered to the house shape: index → Tutorial → Concepts → How-to → Examples → Glossary → **Coming from React Router** (last, like XState/TanStack in their sections).

## Deliberately unchanged

- `tutorial.md`, both how-tos, `glossary.md`, and `coming-from-react-router.md` were already the right shape — direct voice, clear steps, no footers, no spec links — and are untouched.
- Concepts/tutorial overlap on nested layouts and guards is cross-mode (reference version vs. stepwise build), already cross-linked in both directions; not duplication.
- All externally-linked anchors into `concepts.md` (`#blocking-a-navigation`, `#the-metadata-map-in-full`, `#loaders-declaring-a-pages-data`) and every glossary anchor are preserved.

## Verification

- `mkdocs build --strict` passes (spec/migration staged per the CI recipe).
- `scripts/check_doc_slugs.py` passes — no broken links/anchors across 499 files.