### PR TITLE
docs(core): close the testing gaps — Test-a-view recipe + flow/interceptor/reg-fx testing sections

### DIFF
--- a/docs/core/concepts/flows.md
+++ b/docs/core/concepts/flows.md
@@ -261,6 +261,26 @@ Call `reg-flow` again with an already-registered id (on the same frame) and you 
 
 One subtlety worth a callout: if the replacement also **moves the `:output-path`** to a new slot, the framework vacates the *old* slot — the same `dissoc-in` cleanup `clear-flow` does — so a stale value from the previous definition never lingers at the abandoned path. Keep the same `:output-path` and nothing is vacated; the next recompute simply overwrites it in place.
 
+## Testing a flow
+
+A flow splits into the two layers you'd expect, and each tests like everything else on this shelf:
+
+- **The `:derive` is a pure function.** It's usually worth lifting into a named `defn` so a test can call it with literal inputs and assert on the return — no runtime anywhere, the same move as [testing a handler](../how-to/test-an-event-handler.md).
+- **The wiring** — inputs watched, output written, same-commit timing — tests through a real frame: register the flow, dispatch an event that writes an input, and read the output path off the committed state:
+
+```clojure
+(deftest parity-materialises-with-the-write
+  (rf/with-new-frame [f (rf/make-frame {})]
+    (rf/reg-flow {:id     :counter/parity          ;; frame comes from the surrounding scope
+                  :inputs [[:counter/value]]
+                  :derive (fn [n] (if (odd? n) :odd :even))
+                  :output-path [:counter/parity]})
+    (rf/dispatch-sync [:rf/set-db {:counter/value 3}])
+    (is (= :odd (get-in (rf/app-db-value f) [:counter/parity])))))
+```
+
+`with-new-frame` pins the frame for the body, so `reg-flow` seats the flow there without an explicit `{:frame …}` — and tears the frame down on exit, so nothing leaks into the next test. Note the one-event lag doesn't bite here: it applies to a flow registered *mid-event* via the fx; a flow registered before the dispatch (as above) computes with that first event's commit.
+
 ## When the framework refuses: the registration-time errors
 
 Flows [fail loud](../glossary.md#fail-loud-not-silent) and early. Almost everything that can go wrong is caught at registration time — when you call `reg-flow` (or its fx), before any state changes — so a bad flow definition never silently corrupts your app-db. They split into two groups: **shape** errors (the map itself is malformed) and **semantic / lifecycle** errors (the map is well-formed but can't be seated). The semantic ones are the ones worth memorising:

--- a/docs/core/concepts/interceptors.md
+++ b/docs/core/concepts/interceptors.md
@@ -323,6 +323,28 @@ And reading an *event's* metadata gives you the chain as authored — a vector o
 
 The two compose: a tool reads the refs off the event, then resolves each ref's source and `:doc` via `handler-meta :interceptor`. That's exactly how [Xray](../glossary.md#xray) draws a chain with jump-to-source links on every stage. (In a real app the [trace stream](observability.md) already records every event with timings — the logger up top is the teaching shape.)
 
+## Testing an interceptor
+
+Both slots are pure functions `ctx → ctx`, and the context is a plain map — so an interceptor unit-tests the way [a handler does](../how-to/test-an-event-handler.md): call the function with a literal context, assert on the one it returns. Give the slots named `defn`s and reference them from the descriptor, so a test can reach them without any registry:
+
+```clojure
+(defn stamp-audit [ctx]
+  (assoc-in ctx [:effects :db :audit/last-event]
+            (first (get-in ctx [:coeffects :event]))))
+
+(rf/reg-interceptor :my-app/audit
+  {:doc "Stamp the triggering event's id onto the handler's :db write."}
+  {:after stamp-audit})
+
+(deftest audit-stamps-the-event-id
+  (let [ctx {:coeffects {:event [:cart.item/add {:sku "a"}]}
+             :effects   {:db {}}}]
+    (is (= :cart.item/add
+           (get-in (stamp-audit ctx) [:effects :db :audit/last-event])))))
+```
+
+Build the literal ctx from the [two-key shape above](#the-context-map-two-keys): a `:before` test supplies only `:coeffects`; an `:after` test supplies both halves — including the error-path shape where the handler never populated `[:effects :db]`, which is exactly the case [When the chain throws](#when-the-chain-throws) warns your `:after` must survive. The *wiring* — that the reference actually wraps the handler — is one notch up, the same move as [a handler's runtime check](../how-to/test-an-event-handler.md#3-when-you-want-the-runtime-a-fresh-frame-per-test): dispatch through a test frame and assert on the committed state. And when someone *else's* interceptor is in the way of the thing you're testing, [`:interceptor-overrides`](#removing-or-swapping-a-reference-interceptor-overrides) is the seam that takes it out of play for one dispatch.
+
 ## When a reference is wrong
 
 Because a chain is just data, the runtime can check it *eagerly* — and it does. The single most common mistake, a misspelled id, dies at the earliest possible moment:

--- a/docs/core/how-to/index.md
+++ b/docs/core/how-to/index.md
@@ -23,12 +23,16 @@ This is where most of your time goes: turning a feature request into stages of t
 
 ## Test it
 
-re-frame2's payoff at test time is that the interesting parts of your app are pure functions, so you test them *as* functions — no browser, no DOM, no mocking framework standing between you and the assertion. An [event handler](../glossary.md#event-handler) is a pure `(coeffects, event) → effect map`; you hand it a map and check the map it returns. The two recipes climb one rung at a time: first the smallest unit (a single handler), then the *whole cascade* — the new state, the effects, and any follow-up events that one dispatch sets off — all checked together.
+re-frame2's payoff at test time is that the interesting parts of your app are pure functions, so you test them *as* functions — no browser, no DOM, no mocking framework standing between you and the assertion. An [event handler](../glossary.md#event-handler) is a pure `(coeffects, event) → effect map`; you hand it a map and check the map it returns. The recipes climb one rung at a time: the smallest unit (a single handler), then the *whole cascade* — the new state, the effects, and any follow-up events that one dispatch sets off — then the view layer, as a tree walk over the hiccup a view returns.
 
 | I want to… | Recipe |
 |---|---|
 | unit-test an event handler as the pure function it is | [Test an event handler](test-an-event-handler.md) |
 | test a whole dispatch — state, effects, follow-ups | [Test a full cascade](test-a-cascade.md) |
+| assert a view's structure, text, and wiring — no browser | [Test a view](test-a-view.md) |
+| unit-test a subscription's computation | [Testing a subscription](../concepts/subscriptions.md#testing-a-subscription-without-a-browser) |
+
+Two neighbours complete the picture: a [machine](../../machines/glossary.md#machine)'s transition table tests as a pure function call too — that recipe lives with the machines material, in [Inspecting and testing machines](../../machines/inspecting-machines.md) — and setting up the runner itself (the `deps.edn` `:test` alias, and the `.cljc` discipline that lets your registration namespaces load on the JVM) is walked in [the tutorial's Part 5: test it, ship it](../../resources/tutorial/05-test-and-ship.md).
 
 ## Debug it
 

--- a/docs/core/how-to/test-a-cascade.md
+++ b/docs/core/how-to/test-a-cascade.md
@@ -184,6 +184,8 @@ This is redirect-not-mock in a single frame. The override receives the **exact a
 
 > **The override fn takes two args.** An `:fx-overrides` value is either another registered fx-id (a keyword) or a function `(fn [frame-ctx args] ...)`. The first arg is the frame context; the second is the **effect's args map** — for `:rf.http/managed` that's `{:request {...} :on-success [...] :on-failure [...]}`. Returning a value is fine but ignored; the override runs for its capture or its (stubbed) effect, exactly like an ordinary `reg-fx` handler. The `_` prefixes above are just "I'm not reading this arg."
 
+> **Testing your own `reg-fx`.** The same two-arg shape means an effect handler you wrote is directly callable — hand it a stub frame context and a literal args map when its body has logic worth pinning. But keep that body thin on purpose: the more of an effect's behaviour lives in the *args your handlers build*, the more of it the capture test above already covers, and the less lives in the one function only a real host can prove.
+
 > **Gotcha — frames isolate `app-db`, not registrations.** A fresh frame gets its own state and its own queue, but handlers live in a *process-global* [registrar](../glossary.md#registrar) — registering `:session/login` registers it for everyone. If your tests `(rf/reg-event ...)` in their bodies rather than requiring app namespaces, add `(use-fixtures :each (ts/make-reset-runtime-fixture))` — from `re-frame.test-support` — once per file, so one test's registrations can't leak into the next. Requiring `my-app.session` (as the tests above do) sidesteps the issue entirely: those registrations are stable for the whole run.
 
 ### The `:test` preset — deterministic defaults in one key

--- a/docs/core/how-to/test-a-view.md
+++ b/docs/core/how-to/test-a-view.md
@@ -1,0 +1,89 @@
+# Test a view
+
+You've tested the [handler](test-an-event-handler.md) and the [cascade](test-a-cascade.md), and now you want the same confidence about a view: the right structure comes out, the right text shows for a given state, and the right handler is wired to the right button. Like the rest of the suite, this needs no browser. A [view](../glossary.md#view) is a pure function that returns [hiccup](../glossary.md#hiccup) — plain data — so a view test is a function call and a tree walk, and it runs on the JVM in milliseconds.
+
+> **A view test calls the function and walks the returned data — no DOM, no JSDOM, no `act()`.**
+
+One honest framing before the recipe: **most "view bugs" are data bugs.** A view holds no state and decides nothing, so when the screen is wrong the cause is nearly always the [subscription](../concepts/subscriptions.md#testing-a-subscription-without-a-browser) or [handler](test-an-event-handler.md) upstream — pure functions with cheaper tests ([Views](../concepts/views.md#when-something-renders-wrong) makes the case). Reach for a view test for what a view genuinely *owns*: its structure, its text, and its wiring.
+
+The toolkit is `re-frame.test-helpers` — pure walks over hiccup, [catalogued in the API reference](../../api/re-frame.test-helpers.md) — alongside the `re-frame.test-support` fixtures you already use:
+
+```clojure
+(ns my-app.views-test
+  (:require [clojure.test :refer [deftest is use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.test-support :as ts]
+            [re-frame.test-helpers :as th]
+            [my-app.counter :as counter]))   ;; the app namespace under test
+
+(use-fixtures :each (ts/make-reset-runtime-fixture {}))
+```
+
+## 1. Call it, walk it
+
+Give the nodes you'll assert on a stable address at the view site — `th/testid` builds an attrs map carrying `:data-testid` — then call the view like any function and read the tree it returns:
+
+```clojure
+;; The view under test — a plain function of its arguments.
+(defn price-row [{:keys [label price]}]
+  [:tr (th/testid "price-row")
+   [:td label]
+   [:td (th/testid "price-cell") "$" price]])
+
+(deftest price-row-shows-the-price
+  (let [tree (price-row {:label "Widget" :price "12.50"})]
+    (is (= "$12.50" (th/text-content (th/find-by-testid tree "price-cell"))))))
+```
+
+`find-by-testid` returns the first node carrying that `:data-testid`; `text-content` collects the string leaves under it. Their generic siblings — `find-by-attr`, `find-all-by-testid`, `find-by-testid-prefix`, `attrs`, `children` — cover lists and custom attributes ("every node whose testid starts with `row-`").
+
+> **Gotcha — a tree that nests other views needs expanding.** A view that renders another view returns it as a *component reference* — `[cart-line item]`, a vector whose head is a function, not a tag. `th/expand-tree` recursively expands those references so your walk sees the real tags underneath. Run it first whenever you assert *through* a child view.
+
+> **Coming from React Testing Library?** `find-by-testid` / `text-content` are `getByTestId` / `textContent` — except the "render" was a plain function call, so there's no JSDOM to stand up and nothing to clean up. The query API is deliberately smaller: you're walking a value, not a live document.
+
+## 2. Views that subscribe: the app fixture
+
+A presentational view takes data as arguments. A *connected* view subscribes and dispatches, so it needs a [frame](../glossary.md#frame) in scope. `th/with-app-fixture` brackets a test with exactly that: it creates a fresh frame, runs your `:install` hook (the registrations the test relies on), stashes a `:root-view`, runs the body, and destroys the frame on the way out — success or throw:
+
+```clojure
+(deftest counter-increments-in-the-view
+  (th/with-app-fixture {:install   counter/install!     ;; zero-arg fn: reg-event / reg-sub / views
+                        :root-view counter/main}
+                       :test-app
+    (rf/dispatch-sync [:counter/inc])
+    (rf/dispatch-sync [:counter/inc])
+    (th/expect-text :counter-display "2")))
+```
+
+`expect-text` renders the stashed root view, finds the testid, and asserts its text through `clojure.test/is` — the view-side sibling of `ts/assert-path-equals`. (A 3-arity form takes an explicit tree when you're not using the fixture.)
+
+> **Gotcha — `:install` registrations land in the process-global registrar.** The fixture destroys its *frame*, but registrations are global, exactly as [Test an event handler](test-an-event-handler.md#4-the-trap-frames-dont-isolate-registrations) warns. Pair `with-app-fixture` with the `make-reset-runtime-fixture` shown at the top so one test's registrations can't leak into the next.
+
+## 3. Drive the wiring
+
+The last thing a view owns is the connection from a node to its dispatch. `th/invoke-handler` finds the handler attached at an event attribute and calls it — so the test proves the button is wired, not just present:
+
+```clojure
+(deftest inc-button-is-wired
+  (th/with-app-fixture {:install   counter/install!
+                        :root-view counter/main}
+                       :test-app
+    (let [tree (th/expand-tree (counter/main))
+          btn  (th/find-by-testid tree "counter-inc")]
+      (th/invoke-handler btn :on-click))       ;; runs the attached fn — the dispatch fires
+    (th/wait-until :counter-display "1" {:label "counter reached 1"})))
+```
+
+Two details carry this test. `invoke-handler` **throws** when the node has no handler under that key — a missing handler is almost always the bug you're hunting, so it refuses to pass silently. And the assertion is `th/wait-until`, not `expect-text`: the invoked `:on-click` fires a plain `dispatch`, which queues rather than draining synchronously, so the test polls the rendered view against a bounded deadline (the view-side sibling of `ts/poll-until` — same defaults, same loud timeout carrying `:rf.error/wait-until-timeout`). The same form covers any async settle whose outcome is *visible in the view* — an HTTP reply, a machine `:after` transition, a scheduled event. For a synchronous cascade, `expect-text` after `dispatch-sync` is enough.
+
+## When you want more than hiccup
+
+Three neighbouring tools pick up where the tree walk stops:
+
+- **Rendered markup** — when the assertion is about the HTML *string* a view produces (attribute serialisation, SSR output), `render-to-string` is the complementary path; see [`re-frame.ssr`](../../api/re-frame.ssr.md).
+- **A real DOM** — when you genuinely need React in the loop (a ref, a portal, an imperative child), mount under your adapter and settle updates with its `flush-views!` test helper; [Use UIx, Helix, or reagent-slim](use-uix-helix-or-slim.md#what-carries-over-what-doesnt) covers the shape. This is the rare case, not the default.
+- **A view's *states*** — "show this view empty, loading, error, and loaded" is not a tree-walk job; it's [Story](../concepts/observability.md#the-tools-four-presentations-zero-second-truths)'s whole purpose: named variants in isolated frames, promotable into tests.
+
+## When not to test a view
+
+Don't re-prove upstream logic through the view. If the assertion is really "the sort order is right" or "the total is correct", that's a [subscription test](../concepts/subscriptions.md#testing-a-subscription-without-a-browser) — cheaper, and it fails at the function that owns the logic. If it's "the state changed correctly", that's a [handler test](test-an-event-handler.md). A view test earns its keep only when the thing under test is the view's own contribution: structure, text, wiring. Most views are boring enough — deliberately — that they need no test at all.

--- a/docs/core/how-to/test-an-event-handler.md
+++ b/docs/core/how-to/test-an-event-handler.md
@@ -32,7 +32,7 @@ To get that function back in a test, ask the registrar for it. `handler-meta` re
 
 That's the entire pattern. No [frame](../glossary.md#frame), no [dispatch](../glossary.md#dispatch), no runtime — just a function call. Which means these tests run wherever your test runner runs, including the JVM, where most re-frame2 suites live, because nothing in them touches a browser.
 
-One setup detail makes it work. Your test namespace needs three requires — `clojure.test`, `re-frame.core`, and the app namespace whose *load* performs the registrations. That last one is the easy one to forget, because requiring the namespace is what runs the `reg-event` calls and puts your handler in the registrar in the first place.
+One setup detail makes it work. Your test namespace needs three requires — `clojure.test`, `re-frame.core`, and the app namespace whose *load* performs the registrations. That last one is the easy one to forget, because requiring the namespace is what runs the `reg-event` calls and puts your handler in the registrar in the first place. (Setting up the runner itself — the `deps.edn` `:test` alias, and the `.cljc` discipline that lets your registration namespaces load on the JVM at all — is walked in [the tutorial's Part 5: test it, ship it](../../resources/tutorial/05-test-and-ship.md).)
 
 ```clojure
 (ns my-app.articles-test

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -190,6 +190,7 @@ nav:
       - "Validate with schemas": core/how-to/validate-with-schemas.md
       - "Test an event handler": core/how-to/test-an-event-handler.md
       - "Test a cascade": core/how-to/test-a-cascade.md
+      - "Test a view": core/how-to/test-a-view.md
       - "Debug with Xray": core/how-to/debug-with-xray.md
       - "Fix a slow view": core/how-to/fix-a-slow-view.md
       - "Keep secrets out of traces": core/how-to/keep-secrets-out-of-traces.md


### PR DESCRIPTION
Scoped follow-up to the core review: the testing-gap findings, as agreed.

## What was missing, and what closes it

| Gap | Fix |
|---|---|
| Views/DOM testing had no home — and it turns out re-frame2 ships a full headless view-testing toolkit (re-frame.test-helpers: hiccup walks, testid queries, invoke-handler, the with-app-fixture/expect-text/wait-until trio) that core never mentioned | **New page: Test a view** — position-first (most view bugs are data bugs), then the tree-walk recipe, the connected-view fixture, wiring checks, and the three neighbours (render-to-string, adapter flush-views!, Story) for everything past hiccup |
| Sub + machine testing invisible from the how-to Test-it group | Index rows route to subscriptions.md's testing section and machines/inspecting-machines.md |
| flows.md had no testing section | 'Testing a flow': pure :derive + through-a-frame wiring test |
| interceptors.md had no testing section | 'Testing an interceptor': named defns + literal ctx, error-path :after shape, runtime notch, :interceptor-overrides seam |
| Testing your own reg-fx unstated | A note in test-a-cascade's :fx-overrides section |
| Runner setup / .cljc discipline unreferenced from core | Checked first, as agreed: the resources tutorial Part 5 already owns it (deps.edn :test alias, .cljc renames) — core now cross-links it from the Test-it index and test-an-event-handler |

Every taught symbol verified against implementation/core/src/re_frame/test_helpers.cljc (a .cljc file, so the JVM-runnable claim holds) and the api-manifest classification.

## Gates
- mkdocs build --strict — green
- check_doc_slugs.py — exit 0