### PR TITLE
docs(ssr): standalone corpus — no spec links, section map, house nav order

### DIFF
--- a/docs/ssr/coming-from-nextjs.md
+++ b/docs/ssr/coming-from-nextjs.md
@@ -14,9 +14,9 @@ So read this page as a translation table, not a feature comparison. The capabili
 | Client Component (`"use client"`) | The same view, after [hydration](glossary.md#hydration). There's no second flavour; browser-only *effects* are gated with `:platforms #{:client}`. |
 | `"use server"` / `"use client"` directives | [`:platforms`](concepts.md#platforms--one-handler-gated-per-runtime) on an effect or coeffect — declared once on the *capability*, not at every import site. |
 | `getServerSideProps` / a route loader | Your ordinary events firing in the per-request frame's `:initial-events`. The "loader" is just dispatch + [drain](../core/glossary.md#drain--run-to-completion). |
-| `Promise.all` of N fetches in a loader | [Pattern-SSR-Loaders](../../spec/Pattern-SSR-Loaders.md) — a [machine](../machines/glossary.md#machine) fans fetches out with `:spawn-all`, joins on complete. Same site drives client-nav fetch. |
+| `Promise.all` of N fetches in a loader | [The SSR loader pattern](concepts.md#two-patterns-in-brief) — a [machine](../machines/glossary.md#machine) fans fetches out with `:spawn-all`, joins on complete. Same site drives client-nav fetch. |
 | A route's `loader` (App Router) | A re-frame2 route [loader](../routing/glossary.md#loader), which compiles to those `:initial-events` server-side. |
-| Server Action (form `action={fn}`) | [Pattern-FormAction](../../spec/Pattern-FormAction.md) — a real `method="POST"` form routes to the *same* [event](../core/glossary.md#event) the client's `:on-submit` dispatches. |
+| Server Action (form `action={fn}`) | [The form-action pattern](concepts.md#two-patterns-in-brief) — a real `method="POST"` form routes to the *same* [event](../core/glossary.md#event) the client's `:on-submit` dispatches. |
 | `hydrateRoot` (React 18) | [`ssr/hydrate!`](glossary.md#hydration) — but the server's *state* rides along explicitly in the payload, installed by `:rf/hydrate` before the first render. |
 | Reading `cookies()` / `headers()` | A declared [coeffect](../core/glossary.md#coeffect): `:rf.cofx/requires [:rf.server/request]`, value flat in the handler's coeffects. |
 | `redirect()` / `notFound()` | The data effects `:rf.server/redirect` / a routing miss your [error projector](concepts.md#when-the-server-throws) maps to `404`. |
@@ -43,7 +43,7 @@ re-frame2 doesn't have that boundary because it doesn't have that entanglement. 
 
 Next.js gives data-fetching its own ceremony: `getServerSideProps`, or an App Router `loader`, a function with a privileged signature that runs only on the server and hands props down. It's a distinct concept you learn, with its own caching rules and its own relationship to the component tree.
 
-In re-frame2 the [loader](../routing/glossary.md#loader) is not a special function. The per-request [frame](../core/glossary.md#frame) fires its `:initial-events`, the runtime [drains](../core/glossary.md#drain--run-to-completion) — runs every event those events trigger, to a fixed point — and *then* renders. The "loader" is your ordinary [events](../core/glossary.md#event) and [effects](../core/glossary.md#effect), the same ones the client dispatches on navigation. The payoff is that there's no second code path to keep in sync: server fetch and client-nav fetch are the *identical* machine (see [Pattern-SSR-Loaders](../../spec/Pattern-SSR-Loaders.md)), only the spawn site moves. You don't maintain a server-flavoured fetch and a client-flavoured one and pray they agree.
+In re-frame2 the [loader](../routing/glossary.md#loader) is not a special function. The per-request [frame](../core/glossary.md#frame) fires its `:initial-events`, the runtime [drains](../core/glossary.md#drain--run-to-completion) — runs every event those events trigger, to a fixed point — and *then* renders. The "loader" is your ordinary [events](../core/glossary.md#event) and [effects](../core/glossary.md#effect), the same ones the client dispatches on navigation. The payoff is that there's no second code path to keep in sync: server fetch and client-nav fetch are the *identical* machine (the [SSR loader pattern](concepts.md#two-patterns-in-brief)), only the spawn site moves. You don't maintain a server-flavoured fetch and a client-flavoured one and pray they agree.
 
 ### Hydration is verified, not hoped-for
 
@@ -71,4 +71,4 @@ re-frame2's [`:rf/suspense-boundary`](concepts.md#streaming-rfsuspense-boundary)
 
 ---
 
-The honest summary: if you liked Next.js's *goals*, you'll be at home. If you spent real time wrestling its *boundary* — the Server/Client seam, the "why won't this import," the silent prop that leaked — that wrestling is the part that's gone. The full contract lives in [Spec 011 — SSR & Hydration](../../spec/011-SSR.md).
+The honest summary: if you liked Next.js's *goals*, you'll be at home. If you spent real time wrestling its *boundary* — the Server/Client seam, the "why won't this import," the silent prop that leaked — that wrestling is the part that's gone.

--- a/docs/ssr/concepts.md
+++ b/docs/ssr/concepts.md
@@ -343,12 +343,12 @@ The wiring mirrors what you've already seen, with streaming counterparts: `strea
 
     A page without independently-slow regions gains nothing over plain `ssr-handler`. And a `:rf/suspense-boundary` that reaches the non-streaming emitter fails loudly rather than rendering a phantom element.
 
-## Two patterns, linked
+## Two patterns, in brief
 
-Two compositions of these primitives are common enough to have canonical write-ups. They're conventions over what you already know, not new machinery:
+Two compositions of these primitives are common enough to deserve names. They're conventions over what you already know, not new machinery:
 
-- **[Pattern-SSR-Loaders](../../spec/Pattern-SSR-Loaders.md)** — N parallel data fetches before render, the `Promise.all` of a Next.js loader. A [state machine](../machines/glossary.md#machine) spawned from the frame's `:initial-events` fans out HTTP-fetching children with `:spawn-all`, joins on all-complete, writes the slices. Wall-clock cost drops from the sum of the fetches to the max. The same machine drives client-side navigation fetch; only the spawn site moves. (This is what a route's [loader](../routing/glossary.md#loader) compiles down to when it runs server-side.)
-- **[Pattern-FormAction](../../spec/Pattern-FormAction.md)** — form POSTs that work before JS loads. The form renders with a real `method="POST"` and `action`. The server routes POST to the same domain event the client's `:on-submit` dispatches after hydration. Validation runs server-side via the event's schema, and success answers with `[:rf.server/redirect {:status 303 ...}]`. One handler tree, both entry points. Where the pattern reads the request, the spelling is the one you saw above: `:rf.cofx/requires [:rf.server/request]` on the registration, the value flat in the coeffects map.
+- **The SSR loader** — N parallel data fetches before render, the `Promise.all` of a Next.js loader. A [state machine](../machines/glossary.md#machine) spawned from the frame's `:initial-events` fans out HTTP-fetching children with `:spawn-all`, joins on all-complete, writes the slices. Wall-clock cost drops from the sum of the fetches to the max. The same machine drives client-side navigation fetch; only the spawn site moves. (This is what a route's [loader](../routing/glossary.md#loader) compiles down to when it runs server-side.)
+- **The form action** — form POSTs that work before JS loads. The form renders with a real `method="POST"` and `action`. The server routes POST to the same domain event the client's `:on-submit` dispatches after hydration. Validation runs server-side via the event's schema, and success answers with `[:rf.server/redirect {:status 303 ...}]`. One handler tree, both entry points. Where the pattern reads the request, the spelling is the one you saw above: `:rf.cofx/requires [:rf.server/request]` on the registration, the value flat in the coeffects map.
 
 ## What you give up
 
@@ -360,4 +360,4 @@ SSR isn't free of rules, and pretending otherwise would just move the surprise d
 
 Good React developers follow these by instinct. Here they're architecture: enforced by the platform gate and caught by the hash.
 
-The full contract — the complete `:rf.server/*` schema set, the payload scope, and the hydration protocol — lives in [Spec 011 — SSR & Hydration](../../spec/011-SSR.md).
+The API-level surface — every `:rf.server/*` effect with its args schema, the handler constructor options, and the hydration functions — is catalogued in [re-frame.ssr](../api/re-frame.ssr.md) and [re-frame.ssr.ring](../api/re-frame.ssr.ring.md).

--- a/docs/ssr/index.md
+++ b/docs/ssr/index.md
@@ -4,6 +4,15 @@ Ship HTML before the JavaScript loads, then let the client take over — without
 
 On the server, [`render-to-string`](glossary.md#render-to-string) runs your real views in a per-request [frame](../core/glossary.md#frame) and emits HTML plus a serialized state payload. On the client, [hydration](glossary.md#hydration) adopts that HTML and installs the state instead of re-rendering from scratch — and a [hydration mismatch](glossary.md#hydration-mismatch) is *located and traced*, not silently patched.
 
+## In this section
+
+- **[Concepts](concepts.md)** — the whole story, built to read straight down: why the same code runs on a JVM, the smallest server, the client that hydrates it, then the richer pieces — the payload allowlist, response control, head metadata, error projection, and streaming.
+- **[Examples](examples.md)** — runnable end-to-end SSR apps in the repo.
+- **[Glossary](glossary.md)** — the section's vocabulary, one definition each.
+- **[Coming from Next.js](coming-from-nextjs.md)** — the translation table and the deliberate divergences.
+
+The API-level surface lives in [re-frame.ssr](../api/re-frame.ssr.md) and [re-frame.ssr.ring](../api/re-frame.ssr.ring.md): the guide teaches, the reference is where you look things up.
+
 ```clojure
 ;; server (JVM): your real views, in a per-request frame, no DOM
 (rf.ssr/render-to-string [app-view] {:db initial-db})

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -289,11 +289,14 @@ nav:
     - "Coming from React Router": routing/coming-from-react-router.md
 
   - SSR:
+    # Concepts is the read-straight-down guide (no separate tutorial yet —
+    # rf2-v7nkg6 tracks that gap); Examples before Glossary; the Next.js
+    # translation last, like the other coming-from pages.
     - ssr/index.md
     - "Concepts": ssr/concepts.md
-    - "Coming from Next.js": ssr/coming-from-nextjs.md
-    - "Glossary": ssr/glossary.md
     - "Examples": ssr/examples.md
+    - "Glossary": ssr/glossary.md
+    - "Coming from Next.js": ssr/coming-from-nextjs.md
 
   - Story:
     # Section label IS the Story welcome page (navigation.indexes, rf2-qgpkm).


### PR DESCRIPTION
## Why

Same process as machines (#5082), async (#5083), resources (#5085), core (#5086), and routing (#5087), applied to `docs/ssr` — the last guide section carrying `/spec` links.

## What changed

- **No `/spec` links** (7 removed):
  - `concepts.md`'s "Two patterns, linked" section already restated Pattern-SSR-Loaders and Pattern-FormAction inline — the bullets keep every fact and lose the spec pointers; the section is retitled "Two patterns, in brief" (nothing linked to the old anchor).
  - Its closing "the full contract lives in Spec 011" now points at the docs-internal owners: the [re-frame.ssr](../api/re-frame.ssr.md) and [re-frame.ssr.ring](../api/re-frame.ssr.ring.md) API pages.
  - `coming-from-nextjs.md`'s three pattern links redirect to that concepts section; its trailing Spec-011 citation is dropped.
- **`ssr/index.md`** gains an "In this section" map matching the other landing pages, plus the guide-vs-API-reference pointer.
- **Nav** reordered to the house shape: index → Concepts → Examples → Glossary → **Coming from Next.js** (last, like the other coming-from pages).

## Deliberately unchanged

- `concepts.md`'s body is untouched beyond the two edits above — it's explicitly written as a read-straight-down guide and does the job well. Both externally-linked anchors (`#the-client-side-hydrate-then-verify`, `#when-the-server-throws`) are preserved.
- No factual changes anywhere.

## Gap noted, not filled

SSR is now the only guide section with **no hands-on tutorial and no how-tos**. Writing one (Step 0 dep → smallest `ssr-handler` → read the request → payload allowlist → hydrate → see it run, against `examples/capabilities/ssr/`) is real authoring work with fact-risk, so it's filed as **rf2-v7nkg6** rather than bundled here.

## Verification

- `mkdocs build --strict` passes (spec/migration staged per the CI recipe).
- `scripts/check_doc_slugs.py` passes — no broken links/anchors across 499 files.