### PR TITLE
docs(api): standalone posture — drop the last reader-facing /spec links (api README + nav row)

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -31,4 +31,4 @@ The dependency direction is one-way: adapters and feature artefacts depend on co
 
 Every entry carries a **Kind** (`function` / `macro` / `fx` / `sub` / `event`), a **Signature**, a **Description**, and — where one exists — an **Example** drawn from real usage. A facade re-export (e.g. `reg-machine` on `rf/`) appears briefly in [`re-frame.core`](re-frame.core.md) with the full contract in its feature namespace doc.
 
-The dense, normative single-page contract lives in [the spec API](../../spec/API.md); this reference is the same surface walked through by namespace.
+This reference is the complete public surface, walked through by namespace — every callable an application may reach for is here.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -228,7 +228,6 @@ nav:
       - "re-frame.adapter.helix": api/re-frame.adapter.helix.md
       - "re-frame.test-support": api/re-frame.test-support.md
       - "re-frame.test-helpers": api/re-frame.test-helpers.md
-      - "Normative reference": spec/API.md
 
   - Machines:
     - machines/index.md


### PR DESCRIPTION
Completes the reader-facing side of the no-/spec-links policy (#5086 flagged this follow-up). Surveyed the whole tracked docs tree with git grep; the reader-facing remainder was exactly two sites:

- **docs/api/README.md** — the one sentence routing readers down to spec/API.md; the page now presents the namespace walk-through as the complete public surface.
- **mkdocs.yml nav** — the 'Normative reference: spec/API.md' row in the API group (the last /spec link in the guide's nav). The staged spec tree stays published and reachable by URL/search; it just no longer rides the guide's navigation. **Easy to veto — say the word and I'll restore the row.**

## Deliberately not swept (recommend keeping their spec links)

| Corpus | Links | Why keep |
|---|---|---|
| docs/EP/** (22 files) | ~145 | Engineering proposals — design documents whose job is to cite spec sections normatively; they're the decision trail, not reader docs |
| docs/skills/re-frame2-implementor.md | 6 | Implementor-facing: implementors implement the spec |
| docs/release-process.md | 4 | Maintainer ops doc |

## Open call for you (not in this PR)

The **migration corpus** (repo-root migration/, staged into docs and nav'd under Core → From re-frame v1) carries ~190 spec links. It's reader-facing but is also the normative migration-rules catalogue — sweeping it is a real editorial decision, not a mechanical one.

Also verified: **mkdocs_hooks.py is NOT dead** after these sweeps — besides core/* rewrites it handles the staged spec tree's own internal links (SPEC-AUTHORING → conformance/ etc.), so it stays.

## Gates
- mkdocs build --strict — green
- check_doc_slugs.py — exit 0