### PR TITLE
docs: AUTHORING — one voice/four registers, reference as a first-class track, review lenses

### DIFF
--- a/docs/core/AUTHORING.md
+++ b/docs/core/AUTHORING.md
@@ -1,8 +1,8 @@
 # Guide authoring contract
 
-> **Who this is for.** Contributors writing or revising any page under `/docs` — the core guide (`docs/core/`) and the machines, async, resources, routing, and ssr corpora alike. They all hold to the same standards now: a simple, direct voice; a standalone corpus with no spec links; no ceremony footers; delta teaching; the live-cell rules. This page is excluded from the site nav — readers never land here. If you came to *learn* re-frame2, start at [the guide](README.md). This page's one job: state the contract every docs page is held to, and the gates that enforce it.
+> **Who this is for.** Contributors writing or revising any page under `/docs` — the core guide (`docs/core/`) and the machines, async, resources, routing, and ssr corpora alike. They all hold to the same standards now: a simple, direct voice; a standalone corpus with no spec links; no ceremony footers; delta teaching; the live-cell rules. This page is excluded from the site nav — readers never land here. If you came to *learn* re-frame2, start at [the guide](README.md). This page's one job: state the contract every docs page — **teaching material and reference material alike** — is held to, and the gates that enforce it.
 
-The guide is organised by **Diátaxis** — tutorial / how-to / explanation / reference — with two deliberate divergences. First, **reference is thin and separate**: the exact API shape lives in the [API reference](../api/README.md) (`docs/api/`) and the vocabulary in the [glossary](glossary.md). A guide page that starts accumulating option tables and precedence rules is absorbing reference weight — move it to the API reference, don't polish it. Second, the mode discipline is enforced **per page**, not per section: a page is one mode all the way down.
+The corpus is organised by **Diátaxis** — tutorial / how-to / explanation / reference — with two deliberate refinements. First, **reference is separated, never slighted**: the exact API shape lives in the [API reference](../api/README.md) (`docs/api/`) and the vocabulary in the [glossaries](glossary.md), and both are authored to their own best-practice bar ([Reference pages](#reference-pages--glossaries-and-the-api)). A guide page that starts accumulating option tables and precedence rules is absorbing reference weight — move it there, don't polish it. Second, the mode discipline is enforced **per page**, not per section: a page is one mode all the way down.
 
 Which yields the rule everything else here serves:
 
@@ -13,7 +13,7 @@ Which yields the rule everything else here serves:
 Every guide page commits to all five:
 
 1. **One job, one mode.** The page is exactly one of *start / tutorial / how-to / explanation / index*, and its opening states the reader's problem — what brought them here, what they can do afterward — in a sentence or two.
-2. **One load-bearing takeaway** a reader could quote from memory a week later (this page's is the blockquote above). One per page; a page with three slogans has none.
+2. **One load-bearing takeaway** a reader could quote from memory a week later, set as the page's single bold pull-quote blockquote (`> **…**` — this page's is above, and it's the only blockquote form left in the corpus). One per page; a page with three slogans has none.
 3. **Reader-first ordering.** Goal → working code → explanation. Result before mechanism, mechanism before theory. Never open with internals.
 4. **Adjacency.** Examples sit beside the explanation they serve; warnings sit beside the risky step; the common mistake appears where the reader is about to make it — not in a pitfalls appendix.
 5. **No ceremony footer.** No "You can now" / "what you learned" checklist, no "In this section" preamble, no "What's next" paragraph — navigation is the left nav plus Material's prev/next buttons, and a genuinely useful cross-link belongs inline in the prose where it's relevant, not parked at the bottom.
@@ -22,17 +22,28 @@ Mode rules, stated as what each mode *forbids*: a **tutorial** page never catalo
 
 ## Voice
 
-**Use a simple, direct, and clear voice.** That is the rule; everything below is how to hit it.
+**One voice, four registers.** The whole corpus — tutorials and reference alike — speaks as a single author: **a friendly senior developer, good at writing technical documentation, in a simple, clear, direct voice.** What varies by document kind is the *register*, never the persona:
 
-Write like **a friendly senior developer who's good at explaining things** — one who knows the material well enough not to show off. The reader knows React or Redux but is new to re-frame2; meet them as a knowledgeable colleague explaining over coffee, not as a terse README and not as an essay. The test: would it sound natural said aloud, and could a tired engineer follow it at 11pm?
+| Register | Where | Sounds like |
+|---|---|---|
+| **Warm teaching** | quickstart, tutorials, concepts | The most explanatory and conversational — the reader is learning. This is where the occasional flash of humor lives (below). |
+| **Tight recipe** | how-to, testing | The reader is competent and in a hurry; warmth is a sentence, not a paragraph. |
+| **Argument** | the explanation shelf | Makes a case and defends it — the essay voice, trimmed of excess. |
+| **Terse reference** | glossaries, `docs/api/` | Exact, exhaustive within its surface, boring on purpose. No humor, no persona callouts, no narrative. |
+
+The test in every register: would it sound natural said aloud, and could a tired engineer follow it at 11pm? The reader knows React or Redux but is new to re-frame2 — meet them as a knowledgeable colleague, not as a terse README and not as an essay.
 
 - **Explain the why, not just the what.** After an instruction, a short *because* / *which means* / *so that* clause earns its keep. A senior dev tells you why a thing works, briefly.
 - **Vary your rhythm and connect your ideas.** Mix sentence lengths; carry the reader with transitions ("Now that X works…", "Here's the catch…", "The reason this matters…"). Stacks of clipped four-word sentences read cold — that's the failure mode to avoid.
 - **Be warm, and on the reader's side.** Acknowledge what trips people up, what they might expect, what they can ignore for now. That small gesture is most of what reads as friendly.
 - **Trust the reader with the obvious.** Calm seniority, not anxious over-hedging: spend the words on what's genuinely hard, not on what they already know.
-- **Never show off.** This is the guardrail against the old essayist voice — no aphorism-per-paragraph, no flourish, no deep-cut analogies, no jokes. Anchor to one tool the reader knows. One bolded takeaway per page, not one per paragraph.
+- **Humor is seasoning, Yegge-calibrated.** An occasional flash of conversational candor or a vivid concrete image in the *teaching* registers is welcome — the absurdity of a bug class, the honest confession of what everyone gets wrong the first time. The guardrails that keep it from rotting back into the essayist voice: the humor rises out of the material, never bolted on; the sentence must survive the joke's deletion; never in reference mode, never inside a gotcha; about one moment per page. When in doubt, cut it.
+- **Never show off.** Still the standing guardrail: no aphorism-per-paragraph, no flourish for its own sake, no deep-cut analogies. Anchor to one tool the reader knows. One bolded takeaway per page, not one per paragraph.
 
-Voice modulates by tier. **Tutorial and concepts** are the warmest and most explanatory — the reader is learning. **How-to** pages stay tighter, because the reader is competent and in a hurry; warmth is a sentence, not a paragraph. The **explanation shelf** (`explanation/`, `derivations-and-algebra-views.md`) keeps the argument voice — just trim the excess.
+**Two standing lens-callouts run terser than their page.** A callout is dense by design, so both families drop the warmth and compress:
+
+- **The JS lens** — the persona deltas (`??? info "Coming from React?"`, `??? info "For JavaScript developers"`): a lens for seeing re-frame2 *through* a tool the reader already holds — one tight mapping plus the one deliberate divergence, never a second tutorial. (Form and budget: [Callouts](#callouts) and [Delta teaching](#delta-teaching).)
+- **The FP / category-theory lens** — the `??? note "Going deeper"` asides and the "For the categorically curious" blocks: where the functional or categorical frame genuinely illuminates (a fold, an algebra, effects-as-data), state it tersely, gloss every term in the same breath, keep it skippable. It's a design tool, not teaching vocabulary.
 
 ## Define before use
 
@@ -50,6 +61,8 @@ Callouts are **MkDocs admonitions** — never bold-lead blockquotes — and the 
 
 Give each admonition a title (what used to be the bold lead — trimmed to a line; when the lead is too long for a title, use the bare type and keep the lead bolded in the body). Bodies are indented four spaces with a blank line after the marker — mis-indentation breaks the build. The **one exception** that stays a plain `> **…**` blockquote is the page's single quotable takeaway: that's a pull quote, not a callout.
 
+**Density budget.** Admonitions are seasoning, and they're cheap to mint — so budget them. A gotcha sits beside the one step it guards; two boxes may touch; **three in a row means the prose is hiding structure** — promote the content into the section body or split the section. A page that is more box than prose has inverted itself: the boxes have become the content, and the contract above no longer describes the page.
+
 ## Tiers and modes
 
 Paths below are relative to `docs/`. This table maps the **core guide**; the domain corpora (`machines/`, `async/`, `resources/`) mirror the same concepts → tutorial → how-to → reference shape inside their own tab.
@@ -64,9 +77,28 @@ Paths below are relative to `docs/`. This table maps the **core guide**; the dom
 | `core/testing/` | how-to | how-to | One test target, complete code, done |
 | `core/explanation/`, `core/derivations-and-algebra-views.md` | explanation | explanation | The why — for the curious, not the blocked |
 | `core/25-from-re-frame-v1.md` | migration | migration | v1 deltas, not basics |
+| `core/glossary.md`, per-tab glossaries | reference | reference | One term, one standalone definition, one route |
+| `docs/api/` | reference | reference | Every public callable: Kind / Signature / Description / Example |
 | `core/AUTHORING.md` | meta | index | This contract |
 
 A new page must name its tier and mode before drafting starts. If it doesn't fit one row, it's two pages.
+
+## Reference pages — glossaries and the API
+
+Reference is a **first-class authoring track** with its own best-practice bar, not an annex the guide points at. It runs in the terse-reference register — exact, exhaustive within its surface, no persona callouts, no humor, no narrative — and its quality test is the reader who arrives mid-task from a link or a search: land, read one entry, leave unblocked in under a minute.
+
+**Glossary entries** (`core/glossary.md` and the per-tab glossaries):
+
+- One term per entry under a bolded heading; group entries by role when the vocabulary has structure, never alphabetically for its own sake.
+- Open with a one-to-two-sentence definition that **stands alone** — the reader may never scroll past it.
+- Cross-link every load-bearing term the definition uses; include a short code sample when the term has a canonical spelling.
+- End with a *See / Related* line to the page that teaches the term in depth. A glossary entry defines and routes; it never teaches.
+
+**API pages** (`docs/api/`):
+
+- One entry per public callable, with four fixed fields in order: **Kind** (function / macro / fx / sub / event), **Signature**, **Description**, **Example** (drawn from real usage).
+- Exhaustive within the namespace: every public symbol appears, including the ones the guide never mentions.
+- The description states the **contract** — arguments, return shape, the `:rf.error/*` ids it can raise — never the motivation. Motivation lives in the guide page that teaches the surface, linked once per page, not once per entry.
 
 ## Progressive structure
 
@@ -116,13 +148,14 @@ Readers copy-paste; nobody reads the disclaimer. So every snippet is complete, i
 
 - **Source by inclusion.** Prefer adapting snippets from `examples/` files, citing the source in a first-line comment: `;; cf. examples/real-apps/realworld_http/articles.cljs`. The named file is the compile gate's anchor (see [Gates](#the-gates)); an uncited hand-written snippet is a snippet CI can't defend.
 - **Verify every API symbol** against `spec/API.md` and `implementation/core/src/re_frame/core.cljc` (`git grep` both) before teaching it. Not found there → not taught.
+- **Verify every error and warning id the same way.** A page asserting "fails loud with `:rf.error/x`" has made a machine-checkable claim — `git grep` the id in `implementation/` before teaching it. The `:rf.error/*` catalogue is the corpus's most-cited machine contract; an invented or stale id burns more trust than a broken link.
 - **Async snippets carry the frame.** Never a bare `rf/dispatch` from a `js/setTimeout` / promise callback — that raises `:rf.error/no-frame-context`. Use the frame-carrying idiom from the examples.
 
 ## Live cells
 
 Pages may embed editable, in-browser code via two fences (the info string is the only difference from a static block): ` ```cljs ` evaluates forms and prints the last value — pure ClojureScript teaching only, no re-frame; ` ```cljs-rf2 ` **mounts the last form as a live component** against re-frame2's real public API. For guide pages you almost always want `cljs-rf2`.
 
-Reach for a live cell **wherever editing teaches more than reading** — the counter and its small variations, a subscription graph pruning, a run-to-completion drain, a single derivation. A concepts page that never lets the reader poke its idea is leaving teaching on the table; most loop and concept pages should carry at least one cell. The limits are real, though: keep each cell small and self-contained, stick to surfaces the playground bundle actually provides (the `reg-event` / `reg-sub` / `dispatch` / `subscribe` core — the optional artefacts, flows and machines aside, may not be loaded), and keep a full app like RealWorld static with a link to the worked example. Section shape: a sentence of *why* → the cell → a `!!! tip "Try it"` naming an edit and its expected outcome. A live cell with no suggested experiment is a slow screenshot.
+Reach for a live cell **wherever editing teaches more than reading** — the counter and its small variations, a subscription graph pruning, a run-to-completion drain, a single derivation. A concepts page that never lets the reader poke its idea is leaving teaching on the table; most loop and concept pages should carry at least one cell. The limits are real, though: keep each cell small and self-contained, stay on the proven cell surface (below), and keep a full app like RealWorld static with a link to the worked example. Section shape: a sentence of *why* → the cell → a `!!! tip "Try it"` naming an edit and its expected outcome. A live cell with no suggested experiment is a slow screenshot.
 
 The `cljs-rf2` rules, each of which bites the first time:
 
@@ -133,6 +166,7 @@ The `cljs-rf2` rules, each of which bites the first time:
 - **Cell dialect is plain `defn` views with explicit `rf/dispatch` / `rf/subscribe`** — the cell environment is functions-only, so macro sugar like `reg-view` is unavailable. Don't re-explain this; the reader-facing statement is the plain-`defn` section in [Views: pure functions of data](concepts/views.md#plain-defn-views-and-when-they-break) — link it when a cell and a static listing differ.
 - **One shared registry and app-db per page**, across all cells. Write each cell self-contained (require, registrations, seed, view) and namespace ids (`:demo-a/inc`) when cells must be independent.
 - **Name the eval shortcut once per page** — `Ctrl-Enter` (`Cmd-Enter` on macOS) — the first time you ask for an evaluation; after that, "re-evaluate".
+- **Stay on the proven cell surface** — what shipped cells already exercise: `reg-event`, `reg-sub` (including `:<-` chains), `dispatch` / `dispatch-sync` / `subscribe`, plain `defn` views, and `reg-machine` / `sub-machine`. Flows, interceptors, and routing are **unproven** in the cell environment — a cell reaching for a new surface is exactly the cell you must click in a browser before merging, and the first one that works earns its surface a place on this list.
 - The rf2 bundle loads on demand, so a page's first cell may take a moment to come alive. After authoring, build and click every cell in a browser — a cell that compiles but doesn't mount is worse than a static block.
 
 ## Standing per-page devices
@@ -143,6 +177,16 @@ The `cljs-rf2` rules, each of which bites the first time:
 - **Asides, footguns, and persona deltas are admonitions** — see [Callouts](#callouts) for the expanded-vs-collapsed split. The only bold-lead blockquote left on a page is its single pull-quote takeaway.
 - **No bead references in prose.** Pages state current truth, not the decision trail; tracker-id citations belong in the tracker, not in the page. Unlinked normative ids are fine — a migration-rule id, or a spec section id cited as *text* — because those are normative, not historical; but never a *hyperlink* into `spec/`, which the standalone-corpus rule forbids.
 - **Honesty.** Say when *not* to use a feature; mark deferred things (timed polling, infinite feeds) and CLIENT-ONLY paths; no marketing voice. The test for every paragraph: could a tired engineer act on it at 11pm mid-incident?
+
+## Reviewing the corpus
+
+The writing contract keeps a *page* good; these five lenses keep the *corpus* good. Each runs on a trigger, not a calendar — and on a big sweep they run in this order, because the first two produce defects with repros, the next two produce prioritised gaps, and the last produces taste calls that are only valid once the defects are fixed:
+
+1. **The cold-reader walkthrough** — *when the quickstart or a tutorial changes materially.* Follow a README door for real: a fresh agent (or contributor) gets only the quickstart + tutorial and an empty project and must produce a working app. Every stall, cold term, or wrong turn is a doc bug with a repro. (This is [gate 2](#the-gates), given its trigger.)
+2. **Executable truth** — *when a page's cells, snippets, or error-id claims change.* Click every live cell in a browser; run the changed snippets; check newly-asserted `:rf.error/*` behaviour against the implementation.
+3. **The rendered-site read** — *after any bulk form change* (a callout conversion, a nav restructure). Read the built site, not the markdown: vertical rhythm, box density against the [budget](#callouts), nav weight, page-length outliers, whether collapsed blocks hide anything a reader actually needs.
+4. **Task arrival** — *periodically.* Probe the site search with realistic task and error-string queries ("debounce a search box", the text of `:rf.error/no-frame-context`). Every dead search is a routing or coverage gap.
+5. **Compression** — *only once content is stable.* Per page: what no longer earns its place? Going-deeper asides and stacked callouts first. Run this after the defect lenses, never before.
 
 ## The gates
 
@@ -155,5 +199,17 @@ The contract's own honesty rule applies to this list too. What CI actually enfor
 
 ## Mechanics
 
-Write Markdown for MkDocs Material. Pages live under `/docs` — the core guide (`docs/core/`) and the domain corpora (`docs/machines/`, `docs/async/`, `docs/resources/`, `docs/routing/`, `docs/ssr/`); the nav is explicit in `mkdocs.yml` and a new page must be added there by hand, next to its siblings (this page stays out of the nav). Build locally with `mkdocs build --strict` before opening a PR; if the page has live cells, load it and click them.
+Write Markdown for MkDocs Material. Pages live under `/docs` — the core guide (`docs/core/`) and the domain corpora (`docs/machines/`, `docs/async/`, `docs/resources/`, `docs/routing/`, `docs/ssr/`); the nav is explicit in `mkdocs.yml` and a new page must be added there by hand, next to its siblings (this page stays out of the nav). Renaming a heading changes its anchor, so sweep inbound links when you rename one — the slug gate catches stragglers at build time, but knowing why saves the debugging round. Build locally with `mkdocs build --strict` before opening a PR; if the page has live cells, load it and click them.
+
+## Before you open a PR
+
+The contract, made actionable at the moment it matters:
+
+- [ ] The page states its one job in its opening, and carries exactly one pull-quote takeaway
+- [ ] No links into `spec/`; sideways links go to the page that owns the idea
+- [ ] Every callout is an admonition in its contract form, within the density budget
+- [ ] Every load-bearing term is glossed at first use
+- [ ] Every API symbol **and** every `:rf.error/*` / `:rf.warning/*` id verified against the implementation
+- [ ] Live cells clicked in a browser; new cells stay on the proven surface (or extend it deliberately)
+- [ ] Nav row added beside its siblings; `mkdocs build --strict` and `python scripts/check_doc_slugs.py` both green
 


### PR DESCRIPTION
The agreed voice scheme plus the five AUTHORING improvements.

> **Note:** a second commit (the MkDocs-rendering rationale + the v1-callout prune) was pushed to this branch *after* the merge and never landed here — it ships separately as #5097.

## The voice ruling, as landed

**One voice, four registers** — a single author (the friendly senior developer: simple, clear, direct) whose *register* varies by document kind:

| Register | Where |
|---|---|
| Warm teaching (+ the occasional humor) | quickstart, tutorials, concepts |
| Tight recipe | how-to, testing |
| Argument | explanation shelf |
| Terse reference — no humor, no personas | glossaries, docs/api |

The FP/category-theory lens and the JS lens are named as the two standing lens-callouts, pinned to a slightly-terse register. The old flat 'no jokes' becomes **Yegge-calibrated permission with guardrails**: humor rises out of the material, the sentence survives the joke's deletion, never in reference mode or inside a gotcha, ~one moment per page.

## Reference as a first-class track

New §Reference pages codifies both shapes from actual practice: **glossary entries** (standalone 1–2 sentence definition → cross-linked terms → canonical-spelling sample → See/Related route; 'defines and routes, never teaches') and **API entries** (Kind/Signature/Description/Example, exhaustive per namespace, description states the *contract* incl. error ids). Tiers table gains both rows.

## The five improvements

1. **§Reviewing the corpus** — the five lenses with triggers and the defects-before-taste ordering.
2. **Callout density budget** — three boxes in a row = the prose is hiding structure.
3. **Error-id verification** — 'fails loud with :rf.error/x' is a machine-checkable claim; grep the implementation first.
4. **Proven cell-surface list** — shipped-cell surfaces vs the unproven artefacts; a new-surface cell must be clicked before merging.
5. **§Before you open a PR** — the contract as seven checkboxes.

## Gates
- mkdocs build --strict — green
- check_doc_slugs.py — exit 0