### PR TITLE
docs: MkDocs-rendering rationale in the contract; prune 29 low-value v1 callouts (61 → 32)

### DIFF
--- a/docs/async/continuations-are-data.md
+++ b/docs/async/continuations-are-data.md
@@ -36,10 +36,6 @@ Under `async/await`, the continuation is a **closure**. Write `const quote = awa
 
 That event vector — `[:article/loaded]` — has none of those properties. It *has* a name (it *is* a name). It serializes. It survives a reload. And, as we're about to see, it never reads a stale world.
 
-??? info "From re-frame v1"
-
-    re-frame v1 already pointed this direction — effectful handlers returned `{:dispatch [:some-event]}` rather than calling code inline, and the original `:http-xhrio` effect took `:on-success` / `:on-failure` event vectors. v2 keeps that spelling and makes it the *whole framework's* spine: every [managed](../resources/glossary.md#managed-http) async surface — HTTP, [resources](../resources/concepts.md), mutations, [machines](../machines/concepts.md) — addresses its reply by a named event. The bare `(rf/dispatch …)` inside a `.then` callback that v1 tolerated now fails loud (see the trap below) — there's a sanctioned managed effect for every async job.
-
 ## The bug this kills: the stale-world trap
 
 The fourth closure property — "closes over the world as it was" — isn't an inconvenience. It's a correctness trap, and it's the part that actually bites people. Here's the shape someone writes in their first week, adapted from real migration code:

--- a/docs/core/AUTHORING.md
+++ b/docs/core/AUTHORING.md
@@ -16,7 +16,7 @@ Every guide page commits to all five:
 2. **One load-bearing takeaway** a reader could quote from memory a week later, set as the page's single bold pull-quote blockquote (`> **…**` — this page's is above, and it's the only blockquote form left in the corpus). One per page; a page with three slogans has none.
 3. **Reader-first ordering.** Goal → working code → explanation. Result before mechanism, mechanism before theory. Never open with internals.
 4. **Adjacency.** Examples sit beside the explanation they serve; warnings sit beside the risky step; the common mistake appears where the reader is about to make it — not in a pitfalls appendix.
-5. **No ceremony footer.** No "You can now" / "what you learned" checklist, no "In this section" preamble, no "What's next" paragraph — navigation is the left nav plus Material's prev/next buttons, and a genuinely useful cross-link belongs inline in the prose where it's relevant, not parked at the bottom.
+5. **No navigation ceremony — MkDocs already provides it.** Every page renders through MkDocs Material, which supplies the left-hand navigation and prev/next buttons at the foot of every page. So: no "What's next" / "Where next" sections at the bottom, no "You can now" / "what you learned" checklists — and on **index and introduction pages** specifically, no "In this section" enumeration that mirrors the LHS menu the reader is already looking at. An index page routes by adding *judgment* (which door for which reader, and why), never by restating the nav. A genuinely useful cross-link belongs inline in the prose where it's relevant, not parked at the bottom.
 
 Mode rules, stated as what each mode *forbids*: a **tutorial** page never catalogues alternatives ("you could also…" is a how-to's job); a **how-to** page assumes competence and never teaches a concept beyond a link; an **explanation** page carries no task steps; an **index** page routes and never teaches. Quality bar for foundational pages: a concrete reader problem, a complete listing, a walkthrough, a common mistake, and a checkpoint the reader can run or reason through.
 
@@ -140,7 +140,7 @@ Per-persona callouts are collapsed `??? info` admonitions (see [Callouts](#callo
     are caused by routes and events, never by render.
 ```
 
-The **v1 delta callout** (`??? info "From re-frame v1"`) is the standing instance of this device: what moved, linking to [From re-frame v1](25-from-re-frame-v1.md) for the full delta. Retired v1 surfaces (`inject-cofx`, `:rf.world/inputs`) appear *only* on that migration page, marked superseded — never in teaching prose elsewhere.
+The **v1 delta callout** (`??? info "From re-frame v1"`) is the standing instance of this device — but it is earned **only where the v1 instinct would actively mislead**: a retired surface that now errors (`inject-cofx`, `reg-event-db`, `:initial-db`), a behaviour that genuinely changed underfoot (run-to-completion timing), a reflex that now fails loud. "Same as v1 in spirit" and "v1 didn't have this" deliver nothing — a v1 veteran already knows what v1 lacked — and get cut. Most pages need **zero**; the [migration page](25-from-re-frame-v1.md) is the complete delta that audience will actually read. When one is earned: what moved, one link, done. Retired v1 surfaces (`inject-cofx`, `:rf.world/inputs`) appear *only* on that migration page, marked superseded — never in teaching prose elsewhere.
 
 ## Snippets are production code
 

--- a/docs/core/concepts/effects-and-coeffects.md
+++ b/docs/core/concepts/effects-and-coeffects.md
@@ -55,10 +55,6 @@ A state change, an HTTP POST, a storage write, and a follow-up dispatch — stil
 
     `:fx` is what thunks, sagas, and middleware do — minus the machinery. No middleware ordering, no generator runtime. The handler returns data and one interpreter loop executes it.
 
-??? info "From re-frame v1"
-
-    There's now exactly one event form — `reg-event` — and a db update is just the `:db` effect in the map every handler returns. No separate db-only registration: "I only touch state" is `{:db …}` and nothing else, the *same map shape* as a handler that also fires three effects. The top-level `:dispatch` / `:dispatch-later` / `:dispatch-n` effect keys are gone too — everything rides in `:fx` as ordinary rows, so you learn one grammar instead of two.
-
 !!! warning "Gotcha — `:db` and `:fx` are the whole top level"
 
     Application handlers return exactly those two keys; anything else at the top level is a malformed effect map. The runtime doesn't throw — it [fails closed](../glossary.md#fail-loud-not-silent): it emits `:rf.error/effect-map-shape` naming the offending key, **drops** that key, and applies the legal ones (so your `:db` still lands). This is the safety net under a typo (`:dn` for `:db`) and under the old v1 reflex of returning a top-level `[:dispatch …]` — the error message points you at wrapping it as an `:fx` row.
@@ -337,6 +333,3 @@ You stub effects with the symmetric move on the output side: **`:fx-overrides`**
 
 Overrides can also be pinned per frame at construction — `(rf/make-frame {:fx-overrides {…}})` — so an entire test frame, Story canvas, or SSR render runs against stubbed effects without touching any dispatch site. Ambient coeffects are the one place you re-register a *supplier* (legal precisely because ambient facts never feed durable state); recordable facts you supply as data, never by swapping a mechanism.
 
-??? info "From re-frame v1"
-
-    The v1 escape hatches are gone, loudly. Calling `rf/inject-cofx` is a hard error (`:rf.error/inject-cofx-removed`) that names `:rf.cofx/requires` as the replacement, and supplying a `:dispatched-at` dispatch opt is a hard error (`:rf.error/dispatched-at-retired`) that points you at `:rf/time-ms` on the `:rf.cofx` envelope. Both fire in production too — they're correctness contracts, not dev-only nags — so an old habit can't silently no-op.

--- a/docs/core/concepts/events-and-the-cascade.md
+++ b/docs/core/concepts/events-and-the-cascade.md
@@ -172,10 +172,6 @@ Two notes before moving on:
 - **The first argument is the coeffects map** — a [coeffect](../glossary.md#coeffect) being an input fact the handler needs from the world, gathered with everything else into one value. `:db` and `:event` arrive for free. A handler that needs more (the current time, a storage read) declares those facts at registration with `:rf.cofx/requires` and receives them as plain values in that map — no change to the handler's shape, just a line of metadata. That declaration is [the coeffects page's](effects-and-coeffects.md) subject.
 - **Follow-up events from inside a handler are effects too.** Never call `dispatch` from a handler body. Return `:fx [[:dispatch [:next-thing]]]` and the runtime queues it. Same rule, same reason: *describe, don't do.*
 
-??? info "From re-frame v1"
-
-    The shape is the same — effect map out, `:fx` carries the side effects — but v1's hand-rolled `:http-xhrio` (cljs-ajax) is gone; the managed `:rf.http/managed` effect with its uniform reply map replaces it. The cross-cutting "wrap every handler" work you wrote as global interceptors now lives behind named, registered [interceptors](../glossary.md#interceptor) referenced by id (below). [From re-frame v1](../25-from-re-frame-v1.md) catalogues the deltas.
-
 !!! note "An optional middle slot"
 
     `reg-event` takes an optional metadata map between the id and the handler — `(rf/reg-event :id {:doc "..." :interceptors [:my-app/audit]} (fn [cofx ev] ...))`. It carries reflection metadata (`:doc`, `:schema`, `:tags`, …) and the reserved `:interceptors` key: a vector of registered [interceptors](../glossary.md#interceptor) (the cross-cutting "wrap every handler" work) referenced by id. The chain *must* live under that key — a bare interceptor or a loose positional vector in the slot is a loud registration error (`:rf.error/reg-event-bare-interceptor` / `:rf.error/reg-event-bad-interceptors`), because the runtime refuses to let a chain hide in a slot it reads as metadata. Authoring them is [Interceptors](interceptors.md)' subject.

--- a/docs/core/concepts/images.md
+++ b/docs/core/concepts/images.md
@@ -33,10 +33,6 @@ When you then create a frame *without* naming an image, that frame just resolves
 
 The common case stays boring, on purpose. You never name an image. New registrations show up the moment you write them. Hot reload keeps working. You meet the image concept *explicitly* only when "everything that's loaded, ids assumed globally unique" stops being the boundary you want.
 
-??? info "From re-frame v1"
-
-    In v1 there was exactly one global registry, and every `reg-*` wrote straight into it — last write wins, no provenance. v2 keeps the registrar process-global but adds a selection step: `reg-*` writes the registrar (now remembering the authoring namespace as provenance), and a *frame* resolves a selected slice of that registrar at creation. For everyday code you feel no difference — the default image gives you v1's "see everything" behaviour. The new power only shows up when you want more than one slice.
-
 ??? info "Coming from JavaScript modules?"
 
     Think of the registrar as your full set of module exports, and the default image as `import * from` everything. You don't normally think about it — until two modules export the same name and you need to be explicit about which one a particular consumer gets.

--- a/docs/core/concepts/index.md
+++ b/docs/core/concepts/index.md
@@ -133,10 +133,6 @@ All of this — the queue, app-db, the subscription cache — lives inside a [**
 
 But the frame is why a page can mount the same app several times without the copies sharing state, why every test gets a pristine world, and why a server can run one frame per request. A frame isolates *state*, not your code: the [**registrar**](../glossary.md#registrar) of handlers is process-global, so the same handlers and subscriptions run in every frame, each against that frame's own app-db. A frame always starts with `app-db = {}` and seeds itself by dispatching its `:initial-events` — the first dominoes that fall the moment it exists. So "load the app" is just the loop running on itself. [Frames: isolated worlds](frames.md) has the shape.
 
-??? info "From re-frame v1"
-
-    v1 had one implicit global `app-db` atom and one event queue. v2 names that world a *frame* and lets you have more than one. A frame seeds itself with `:initial-events` (the old `:on-create` / `:initial-db` boot keys are retired) — and because seeding is itself an event, there's no back door for "the first state": it's the same cascade, all the way down.
-
 ## A few deeper truths, once the loop clicks
 
 The loop above is the productive core — you can build real apps with exactly what's on this page. The callouts below are for the curious reader who wants to know *why* the design is shaped this way. Skip them freely; nothing downstream depends on them.

--- a/docs/core/concepts/interceptors.md
+++ b/docs/core/concepts/interceptors.md
@@ -222,10 +222,6 @@ Matching is by the *full* reference, so a parameterized entry is named in full �
 
 When both a frame and a dispatch supply overrides, they **merge, and on any key they both touch the per-call one wins** — the frame sets the default, the dispatch gets the last word. A frame might swap your auth guard for a permissive stub by default, and one test dispatch can still re-swap it for that single call. A malformed override — a key or replacement that isn't a valid reference — is rejected loudly with `:rf.error/interceptor-override-invalid`.
 
-??? info "From re-frame v1"
-
-    Per-dispatch *additive* `:interceptors` is gone. Authored behaviour has exactly two homes — event metadata and frame metadata — and per-call variation is expressed by *overriding a named reference*, not by appending an anonymous one. That keeps the per-call surface serializable too.
-
 ## Contribute, don't perform
 
 Here's the rule from the top of the page, made precise. The chain is part of the *step function* — the pure fold that replay, time-travel, and deterministic tests re-run against recorded inputs. So this is where discipline pays off:

--- a/docs/core/derivations-and-algebra-views.md
+++ b/docs/core/derivations-and-algebra-views.md
@@ -55,10 +55,6 @@ That's the entire reason the algebra exists. Hold onto this one sentence and the
 
 > The difference between a subscription and a flow is **not the function; it is policy over the same dependency graph.**
 
-??? info "From re-frame v1"
-
-    In v1 you had subscriptions and (later) flows, but they felt like two separate subsystems — a sub was a `reg-sub`, a flow was a thing you bolted on. re-frame2 says out loud what was always true: they are the *same* node under different storage-and-evaluation policy. You still write `reg-sub` and `reg-flow` for the same ergonomic reasons; what's new is that the framework — and any tool reading it — treats them as one graph.
-
 ## The five questions every node answers
 
 Every declared fact in re-frame2 — subscription, flow, resource read, route fact, machine selector — answers the *same five questions*. Learn to ask these five of any node and you can read any graph:

--- a/docs/core/explanation/inside-out.md
+++ b/docs/core/explanation/inside-out.md
@@ -38,10 +38,6 @@ Notice what dissolves. There is no "lifting state up," because state was never d
 
     You already believe most of this. Redux moved state into one store and made reducers pure — re-frame2 keeps that and finishes the job. The difference is what happens *around* the store. In Redux, `useSelector`, `useDispatch`, and your data-fetching middleware still live inside the component, so the component is still where state, effects, and rendering meet. re-frame2 pulls every one of those out: subscriptions, effects, and the [dispatch](../glossary.md#dispatch) path all live outside the view, and the view is left with nothing to do but render. Redux got the store right and stopped at the component door; the inversion walks through it.
 
-??? info "From re-frame v1"
-
-    This philosophy is unchanged from the original — the inversion *is* re-frame, and v1 already had it. What v2 adds sits on top of this foundation rather than altering it; the whole delta is laid out in [From re-frame v1](../25-from-re-frame-v1.md).
-
 ## Boring views are the point
 
 This is the part that surprises every React-shaped brain on first contact, so don't be thrown by it. Your views are going to be boring. Structurally boring. Can't-get-into-a-weird-state boring. That isn't a limitation the framework apologises for — it's the design objective. The most bug-prone real estate in a typical frontend is where state, effects, and rendering tangle together inside components, and re-frame2 simply evicts all of it. Views render, and that's the whole story.

--- a/docs/core/how-to/build-a-form.md
+++ b/docs/core/how-to/build-a-form.md
@@ -10,10 +10,6 @@ Here's the thing about forms: they look trivial and turn out to be one of the bu
 
 We'll build the simplest thing that works first — a login form that validates the whole draft on submit — and only then layer on the trimmings (cross-field rules, per-field and async validation, server rejections). The running example lives at `[:auth :login]`; that vector is a *path* into app-db, the same way `["auth"]["login"]` would be in a nested object. A form's slice always lives under its feature's key like this, which keeps the whole feature's state in one inspectable place.
 
-??? info "From re-frame v1"
-
-    v1 shipped no forms library, and neither does v2 — a form was, and still is, hand-rolled from the same primitives as everything else. What's new is that the hand-rolling now follows a *named convention* (this slice shape), the writes are [schema](../glossary.md#schema)-guarded so a malformed draft fails at the handler that wrote it, and handlers return an [effect map](../glossary.md#effect-map) — `(fn [{:keys [db]} _] {:db ...})` instead of v1's `reg-event-db` `(fn [db _] ...)`. If you wrote forms in v1, you already know the moves; this page just gives them a standard skeleton.
-
 ??? info "Coming from React Hook Form or Formik?"
 
     re-frame2 ships no `<Form>`, no `register()`, no `useForm`. A form is a *convention* built from the same events, subs, and schemas as everything else: state lives in [app-db](../glossary.md#app-db) (every keystroke is an inspectable event), the "validation resolver" is the Malli schema that guards the slice, and errors are subs.

--- a/docs/core/how-to/fix-a-slow-view.md
+++ b/docs/core/how-to/fix-a-slow-view.md
@@ -86,10 +86,6 @@ Now observe the fix. Dispatch the same event with the Views tab open, and the su
 
     The split-extractor trick is *function memoisation* applied compositionally. Layer 1 is a pure projection `app-db → slice`; the gate is `=` on its output, so the layer-1 sub is a memoised function whose cache invalidates exactly when its observable input changes. Stacking a layer-2 sub on top composes two memoised projections: `app-db → slice → derived`, and the composite recomputes the second stage only when the first stage's `=` check opens. The whole graph is a DAG of memoised pure functions, each gated independently — which is why "move the work behind the gate" is the *only* lever you ever need: you're choosing which arrow in the composition carries the cost, and the framework caches every arrow for free.
 
-??? info "From re-frame v1"
-
-    This is the same layered-subscription model you already know — `reg-sub` with `:<-` inputs, the `=`-based propagation cut. Nothing in the gate moved. What's new is the diagnostic surface: Xray's Views tab shows the cached-vs-recomputed verdict per sub per event, so "is this extractor doing work?" is now a thing you *read* rather than reason about. The fix is identical; the observability is better.
-
 !!! note "One derivation, read in many places?"
 
     A subscription is a *view-facing* reactive cache — a handler can take a one-shot `subscribe-once` read of its current value, but that read recomputes per call for the handler and shares nothing with the render side. So if the same expensive value is read by *both* views and handlers (or schemas, or other derivations), a layer-2 sub ends up computing it twice: once for the reactive view cache, once per handler that asks. Promote it to a [flow](../concepts/flows.md) and it's computed exactly once per app-db write, [materialised into app-db](../glossary.md#flow), and every reader — view and handler alike — shares that one result as plain state. A flow is the equality gate applied to *state* instead of to a view-facing cache.
@@ -197,10 +193,6 @@ The trick is to split those two concerns. Build, once per row, a single long-liv
 ??? info "For JavaScript developers"
 
     `useCallback(fn, [slug])` exists to hand a child a stable function identity so it can `memo` past a no-op prop change. The factory-factory does the same job, but it sidesteps the stale-closure trap that bites `useCallback` when the dependency array is wrong: the callback object is stable *and* always sees current args, because the args live in an atom the factory refreshes, not in a captured closure. Same payoff (skip the expensive child's re-render), no dependency array to get wrong.
-
-??? info "From re-frame v1"
-
-    This is v1's `callback-factory-factory`, unchanged — the prop-equality contract underneath didn't move. If you wrote this pattern in a v1 app, copy it across verbatim.
 
 !!! note "Reach for this rung last"
 

--- a/docs/core/how-to/index.md
+++ b/docs/core/how-to/index.md
@@ -47,10 +47,6 @@ When the app does something you didn't ask for, you don't reach for `println` �
 
     Treat this section the way you'd treat the "Recipes" or "Guides" part of any framework's docs — [React](https://react.dev)'s "you might not need an effect", the Rails guide's "how do I do file uploads". They're task-shaped, copy-pasteable, and deliberately opinionated: one good way, shown fully, rather than a tour of the option space. When you want every option on a surface, the [API reference](../../api/README.md) carries the exact shapes.
 
-??? info "From re-frame v1"
-
-    v1's recipes lived in a single flat wiki page — a long scroll you searched with Ctrl-F. Here they're one task per page, grouped by phase, each linking to the concept page that owns its why. The shape of an event handler hasn't changed; what's new is that several recipes have a live pairing counterpart (see the Tool-Pair note above) that v1 never offered.
-
 ## Can't find your task?
 
 A recipe answers "how do I do X." Some questions sit a step *before* that — they're design decisions, not tasks, and a recipe is the wrong shape for them. Those live elsewhere:

--- a/docs/core/how-to/use-uix-helix-or-slim.md
+++ b/docs/core/how-to/use-uix-helix-or-slim.md
@@ -209,10 +209,6 @@ The `{:frame …}` scope shape from Step 4 scopes a frame that already exists. T
 
     If you *do* take explicit ownership and `destroy-frame!` a frame, a handle you captured against it (a `capture-frame :that-id` you stashed at setup) can fire its `dispatch` or `subscribe` *after* the teardown — a slow HTTP reply, a `setTimeout`, a WebSocket message that lands late. The framework won't corrupt anything: a `dispatch` / `subscribe` against a frame that's been torn down raises `:rf.error/frame-destroyed`, and the deeper case where a scheduled commit reaches the container *after* it's already gone no-ops behind a guard and emits `:rf.error/write-after-destroy` (recovery `:ignored`). Both are **always-on** errors — they survive production and land in your error listeners, not just the dev trace. The fix is ownership-shaped: cancel the in-flight work when you destroy the frame, or hold the data in a longer-lived frame if it must outlast the widget.
 
-??? info "From re-frame v1"
-
-    There's no `:db` / `:initial-db` / `:on-create` here — a frame always starts `app-db = {}` and you seed it with `[:rf/set-db {…}]` as the first `:initial-events` step, as the `:checkout` example does. [Frames — Seeding initial state](../concepts/frames.md#seeding-initial-state) is the full init surface.
-
 ## Step 6 — Helix is the same moves, different notation
 
 Helix is the same decisions in Helix notation: `defnc` components built with `helix.dom`, the same `use-subscribe` (this time from `re-frame.adapter.helix`), the same `capture-frame` dispatch, and the same `($ helix-adapter/frame-provider {:frame ...} ...)` mount — here over `react-dom/client`'s `createRoot`. If you want to see it side by side, compare [`examples/substrates/helix/counter/`](../../../examples/substrates/helix/counter) line-for-line with [`examples/substrates/uix/counter/`](../../../examples/substrates/uix/counter); the diff is notation, nothing more.

--- a/docs/core/testing/event-handlers.md
+++ b/docs/core/testing/event-handlers.md
@@ -103,10 +103,6 @@ Look at what *didn't* happen here, because this is the part that trips people up
 
     **The coeffects map carries exactly what the handler declared — plus `:db` and `:event`.** A handler receives `:db`, the leaves it named in `:rf.cofx/requires`, and — if its destructuring reads it — the whole event vector under `:event`. (Most handlers destructure the event vector as the second argument, as above, and never need `:event`.) Nothing *undeclared* is ever delivered, which is the whole point: the coeffects map is a closed, hand-buildable input. If your handler reaches for a key you didn't supply, that's a clear signal the test's input map is incomplete — read the `:rf.cofx/requires` vector off the registry and supply each leaf.
 
-??? info "From re-frame v1"
-
-    Nothing is injected by interceptor anymore — the `:rf.cofx/requires` vector in the metadata is the whole mechanism, and the facts arrive flat in the coeffects map, not nested under `:coeffects`. The old "register a `:db` coeffect interceptor, chain it onto the handler" dance is gone. [From re-frame v1](../25-from-re-frame-v1.md) has the full delta.
-
 ??? note "Going deeper"
 
     Declaring the world up front makes the handler a *reader* in the functional sense: a function from an environment (the coeffects map) to a value (the effect map), `cofx -> fx`. The framework is the interpreter that builds the environment and runs the effects; your handler is pure description in between. That's why the test needs no mocks — you're calling a pure function with a literal environment, exactly the way you'd test any `(f input) => output`. The `:rf.cofx/requires` vector is, in effect, the function's *type signature* for its environment — and it's machine-readable, right off the registrar.

--- a/docs/core/where-state-lives.md
+++ b/docs/core/where-state-lives.md
@@ -159,10 +159,6 @@ Staleness and invalidation come built in too: ensuring a stale entry refetches i
 
     A subscription can't run a `(route, ctx)` resolver — it's pure — so a `:rf.scope/from-caller` resource that a route ensured under one scope, then a view subscribes to *without* passing the same `:scope`, fails closed. If the scope is unresolvable you get a loud `:rf.error/resource-sub-unresolved-scope`; if it resolves to a *different* key the view reads `:idle` forever (a permanent skeleton), and the framework emits a dev warning naming the active scope you probably meant. The fix is always the same: subscribe with the same `:scope` the owning route or event ensured under.
 
-??? info "From re-frame v1"
-
-    This is the biggest change from v1. There, server data was hand-rolled: a `:http-xhrio` effect, a success handler that `assoc`-ed the body into `app-db`, a failure handler that set `:error?`, and a `:loading?` boolean you flipped by hand — re-implemented per feature, races and all, with no shared cache, no dedupe, no leak boundary. A resource folds that entire recurring chore into one registration the runtime owns. Identity, staleness, dedupe, invalidation, and the cross-user scope boundary stop being your code.
-
 ### Question 4 — does it have its own lifecycle? Then it's a machine
 
 The user clicks **Checkout**. Now you're not modelling a value anymore — you're modelling a *process*: idle, then validating, then awaiting payment, then done, or failed-and-retrying. There are rules about which state may follow which, a timeout, and cancellation. The load-bearing question has shifted to "**what state are we in, and what moves us to the next one?**" That's a [machine](../machines/glossary.md#machine). You can usually spot the smell that precedes one:
@@ -200,10 +196,6 @@ Now checkout can only ever be in a state it can legally reach. The timeout belon
 !!! note "An event a state doesn't handle is a no-op, not a crash"
 
     Dispatch `:checkout/paid` while the machine is `:idle` and nothing happens — the snapshot is unchanged and the runtime emits one benign `:rf.machine.event/unhandled-no-op` trace (XState-parity: an unhandled event is a no-op). So you never have to guard every dispatch with "are we even in the right state?" — the machine simply ignores what it has no transition for, and you can still see the ignored event in the trace if you're hunting a missed wire. Two contrasts worth knowing: a transition is also *not selected* if its `:guard` predicate returns false (lower-priority transitions for the same event stay eligible), and a state with `{}` for a body (like `:complete`) is a legal terminal — it simply has no outgoing transitions.
-
-??? info "From re-frame v1"
-
-    v1 had no machines — a multi-step process was the boolean trio above, or a single `:checkout/step` keyword that every handler read and reassigned with no enforced transition table. A machine makes the transitions *data*, makes illegal states unrepresentable, and gives timers a home that cancels them for you. It's the same finite-state process you were already (badly) encoding, finally written somewhere the framework can check it.
 
 ??? note "Going deeper"
 

--- a/docs/machines/concepts.md
+++ b/docs/machines/concepts.md
@@ -114,10 +114,6 @@ So every event reaches the machine through the same `dispatch` and the same [eve
 
     `:issue-request` names its reply events machine-wrapped — `:on-success [:auth.login/flow [:auth.login/success]]`, written one element short on purpose. When the request returns, [managed HTTP](../async/http.md) *appends* its reply to that inner event, so it lands back *inside* the machine as `[:auth.login/success {:kind :success :value v}]` — exactly the event `:store-session` destructures. A machine and an async [effect](../core/glossary.md#effect) compose with no adapter layer.
 
-??? info "From re-frame v1"
-
-    Machines don't exist in v1 — the keyword-in-app-db + `cond` pattern *is* the v1 shape this replaces. There's nothing to unlearn; you're promoting an informal pattern to first-class data. See [From re-frame v1](../core/25-from-re-frame-v1.md).
-
 ## See one run
 
 Here's a turnstile with two states and a counter riding in `:data`, live in your browser. Click into the cell and press **`Ctrl-Enter`** (**`Cmd-Enter`** on macOS) to re-evaluate after edits. This is the real `rf/reg-machine` — the same call you'd write in your own app.

--- a/docs/resources/how-to/invalidate-after-a-mutation.md
+++ b/docs/resources/how-to/invalidate-after-a-mutation.md
@@ -393,6 +393,3 @@ Save an article with the list and detail pages mounted, then open [Xray](../../c
 
 The full read→write→invalidate→refetch loop runs live in [the RealWorld resources example](../../../examples/real-apps/realworld_resources).
 
-??? info "From re-frame v1"
-
-    None of this existed in v1. There was no managed server-state layer at all — you fetched in an [effect handler](../../core/glossary.md#effect-handler), hand-wrote the reply into [app-db](../../core/glossary.md#app-db) yourself, and there was no cache, so nothing ever went "stale." Invalidation was a phrase you didn't need because you owned every byte of the read path. The cost was that every screen reinvented loading flags, every write hand-coded which views to refresh, and a stale read was a bug you wrote, not a state the framework tracked. re-frame2's resources move that whole concern under the framework: the write *declares* what it breaks (`:invalidates`), and the read path refetches. The v1 instinct to reach for an effect that pokes `app-db` after a save is the exact thing this page replaces.

--- a/docs/resources/how-to/paginate-a-feed.md
+++ b/docs/resources/how-to/paginate-a-feed.md
@@ -62,10 +62,6 @@ That's the minimum. A real list usually tunes a few more optional keys:
 
     There's no implicit global default — a `reg-resource` with no `:scope` is a loud registration error (`:rf.error/resource-missing-scope-policy`), not a silent shared read. "I forgot this read is user-scoped" is made unrepresentable at the door. The articles list is the same for every viewer, so it states `:scope :rf.scope/global` outright. A *per-user* list — "my drafts", a tenant-scoped table — would carry a scope resolver instead, so page 2 of tenant A and page 2 of tenant B never collide in the cache. Pagination doesn't move that boundary.
 
-??? info "From re-frame v1"
-
-    The page-keyed cache map and the staleness clocks are framework state, not handler code. Your app-db holds none of it.
-
 ### 2. Let the URL carry the page
 
 Quick question: where should the *current page number* live? It's tempting to drop it into app-db — but the page number is really telling you *where the user is*, and "where the user is" is the URL's job. Put it in the URL and you get shareable links, working Back/Forward, and a reload that lands on the same page, all for free. (This is the [routing](../../routing/concepts.md) ethos in one move: the URL is an input, not a thing you sync.)
@@ -198,10 +194,6 @@ If you'd rather subscribe to one fact than the whole map, the family splits into
 !!! warning "Gotcha — two error channels, not one"
 
     This trips people the first time. `:error` is **first-load only**. Click back to a page you visited a while ago and its entry has gone stale: the framework revalidates in the background, the page stays `:loaded` with its old rows on screen, and the status moves to `:fetching` (not `:loading`). If *that* refresh fails, the failure lands on `:refresh-error` and the data **stays visible** — the list does *not* collapse to an error screen. So your full error branch (above) gates on `(:error state)` *and* `(not (:has-data? state))`, while a "couldn't refresh — showing cached" banner gates on `(:refresh-error state)`. Two channels, two affordances; conflate them and you either hide refresh failures or blank a perfectly good list.
-
-??? info "From re-frame v1"
-
-    The page-keyed cache map, the `:loading?` flags, the "don't blank the list while fetching" dance — all the framework's job. The whole handler-and-flags apparatus is four declarations and a `cond`.
 
 ??? note "Going deeper"
 
@@ -384,10 +376,6 @@ This is the load-bearing payoff. Itemised, here's what just disappeared from you
 - **The in-flight UI.** `:fetching-next?` is true while a load-more page is fetching; a second load-more while one is in flight dedupes (no double-fetch). You keep no `:loading-more?` flag.
 - **The terminal.** `:next-page-param` returning `nil` is the single end-of-feed signal; `:has-next-page?` reads it. A load-more past the end is a no-op — no request fires.
 - **The error.** A load-more failure keeps the feed and surfaces `:page-error` ("couldn't load more — retry"), a separate channel from a first-load failure.
-
-??? info "From re-frame v1"
-
-    Before infinite resources, you rolled all of the above by hand, and the parts list was long: a list slice in app-db, a `:loading-more?` flag, a cursor slice, an append handler on the success event, an "end of feed" flag, dedupe of a double-clicked button, reset-on-filter-change. The infinite resource owns all of it — and, because it's a real resource, it also rides scope clearing, tag invalidation, SSR, and time-travel restore, which a hand-rolled slice never gets for free.
 
 ### Refetch and reset
 

--- a/docs/resources/tutorial/01-pages-and-state.md
+++ b/docs/resources/tutorial/01-pages-and-state.md
@@ -336,10 +336,6 @@ To navigate from code — after a successful form submit, say — it's an event 
 
 One verb, `dispatch`, whether the user clicked a link, pressed Back, or your handler decided to move. Every path funnels into the same state change — which is why, when something goes wrong, there's only ever one place to look.
 
-??? info "From re-frame v1"
-
-    There was no routing in re-frame v1 — you reached for an external library (`reitit`, `secretary`, `bidi`) and hand-glued its match events into your event handlers. Routing now ships as a first-class re-frame2 artefact: the route table is a registry like events and subs, the current route is an ordinary subscription, and navigation is a dispatch. Nothing here is a foreign object you bridge into the loop — it *is* the loop.
-
 ??? note "URLs both ways — the pure helpers"
 
     The route table is bidirectional, and that fact is exposed as two **pure** functions you can call anywhere — in a handler, in a test, on the JVM during server rendering. They live in `re-frame.routing`, not on the `rf/` facade:
@@ -378,10 +374,6 @@ Reading it top to bottom:
 3. `dispatch-sync` runs the seed event *synchronously*, before the first render, so the feed never paints against an empty db. `with-frame` says which frame the dispatch targets. (Plain `dispatch` queues for the next tick — fine everywhere else, but at boot you want the state committed *now*.)
 4. `rf/install-history-listener!` does the initial URL→state sync, so deep links work from the very first paint. It also turns the browser's Back/Forward into the same kind of route-change event a link click produces — Back is not a special case, it's just another event.
 5. `frame-provider {:frame :rf/default}` scopes the mounted tree to the already-registered frame, so every `subscribe` and `dispatch` inside your views resolves to it. ([Frame identity is carried, not found](../../core/glossary.md#frame-identity-is-carried-not-found) — the scope hands the frame down through React; the runtime never guesses one.)
-
-??? info "From re-frame v1"
-
-    In re-frame v1 there was no frame: app-db was one global atom, and `re-frame.core/dispatch` always hit it. re-frame2 wraps app-db, the event queue, and the subscription cache into a [**frame**](../../core/glossary.md#frame) — a named, isolated instance — so you can run two independent apps on one page, or mount the same app twice without them sharing state. (Registrations stay process-global, shared across frames; it's the *state* that's isolated.) A single-app boot like this one declares one frame, names it `:rf/default`, and scopes the tree to it; for everyday code that mostly means an explicit `with-frame` at boot and a `frame-provider {:frame :rf/default}` around your root view. The everything-is-global model is gone, and with it the whole class of bugs where two parts of a page quietly clobbered each other's state.
 
 !!! note "An equivalent shape: `:initial-events`"
 

--- a/docs/resources/tutorial/02-server-data.md
+++ b/docs/resources/tutorial/02-server-data.md
@@ -14,10 +14,6 @@ That is the whole trick. The route *causes* the fetch, a subscription *reads* th
 
     A re-frame2 *[resource](../glossary.md#resource)* is `useQuery`'s keyed, cached, deduplicated read — same idea, with one structural difference you'll feel immediately: the component doesn't fetch on mount. There's no `useQuery(...)` call buried inside the view that quietly kicks off a request the first time React renders it. The *route* causes the fetch; the view only reads what's there. That inversion is the whole point of this part.
 
-??? info "From re-frame v1"
-
-    In v1 a server read was a hand-rolled chain of events: a `:get-articles` event firing an `:http-xhrio` effect, an `:articles-loaded` event to stash the response in app-db, an `:articles-failed` event for the error, and a flag in app-db you flipped to drive a spinner. Every read re-implemented loading, caching, and staleness by hand. re-frame2 makes a server read a *declared* thing — a **resource** — and the runtime owns the fetch/cache/staleness bookkeeping behind the same subscription shape you already know. The four-event boilerplate is gone.
-
 ## Step 1 — add the resources artefact and point at an API
 
 Resources ship as their own optional artefact, the way routing did in Part 1 — you only pay for the machinery you use. Add it, plus the managed-HTTP transport it sits on top of (the piece that actually talks to the network). Add both deps and restart `npm run dev`:

--- a/docs/resources/tutorial/03-auth-and-forms.md
+++ b/docs/resources/tutorial/03-auth-and-forms.md
@@ -387,10 +387,6 @@ The read happens at boot. Reading the world is a [coeffect](../../core/glossary.
 
 Delivery is declared-only: a handler receives exactly the facts in `:rf.cofx/requires`, and nothing it didn't ask for. Even the framework clock works this way — `:rf/time-ms` (wall-clock epoch ms, the one built-in coeffect, itself a *provided* fact stamped at enqueue) rides every dispatch, but a handler must declare it to read it. Declaring `:rf.cofx/requires` is just a line of metadata on an ordinary `reg-event`, so reaching for a world fact never changes the handler's shape. Dispatch `[:auth/initialise]` from boot, after Part 1's `[:app/initialise]`, stamping the saved token onto that dispatch (the boot wiring below shows exactly how).
 
-??? info "From re-frame v1"
-
-    The `inject-cofx` interceptor is gone — declare `:rf.cofx/requires` on the registration and the runtime assembles the value before the handler runs. No interceptor to thread, no order to get right: the dependency is data on the registration, and the runtime reads it.
-
 ??? note "Going deeper — why the token gets these two flags"
 
     [Coeffects come in two grades](../../core/glossary.md#recordable-vs-ambient-coeffects), recordable and ambient ([Effects and coeffects](../../core/concepts/effects-and-coeffects.md) is the full treatment). The token folds into durable state, so it registers `:recordable? true` — a [time-travel](../../core/glossary.md#time-travel) replay re-presents the *recorded* value rather than re-reading the world. And because the boot boundary stamps it rather than a supplier generating it, it's `:provided? true` — a registration with no generator function, there only to give the boundary fact docs, schema, and an owner (so a typo'd requirement is distinguishable from a missing value). An *ambient* coeffect — the default — would be wrong here: re-read live, never recorded, fine for a display preference but never for anything that feeds a durable write.

--- a/docs/resources/tutorial/05-test-and-ship.md
+++ b/docs/resources/tutorial/05-test-and-ship.md
@@ -111,10 +111,6 @@ Whatever appears there is what your literal map (or your dispatch, below) suppli
 
     Time is a declared fact like any other; there is no implicit clock. A handler that stamps a timestamp declares `:rf.cofx/requires [:rf/time-ms]` and reads it flat. A test supplies `{:rf/time-ms 1781078400123}` in the literal map, and the answer is identical at 14:00 and at 23:59:59. There's no `js/Date` to monkey-patch, because the handler never reads one. (Every `reg-event` may declare requires — there's no second-class form that needing the world forces you to convert away from.)
 
-??? info "From re-frame v1"
-
-    The interceptor-based coeffect injection is gone. Declaration moved into registration metadata (`:rf.cofx/requires`), and tests supply values on the dispatch instead of stubbing handlers or registering test cofx-injectors. The full delta is in [From re-frame v1](../../core/25-from-re-frame-v1.md).
-
 ??? note "Going deeper"
 
     The input map (coeffects) and the output map (effects) are both *plain data*, and the handler is a pure function between them. That makes a handler a morphism in the most boring, most useful sense: testing it is exactly testing `f(input) = output`, with no observation of effects on the side. The runtime's job is to *interpret* the returned effect data — your test skips the interpreter and inspects the description. It's the same separation a free monad buys you — build a program as a value, run it later — arrived at without a gram of type machinery: the effect map *is* the program, and `dispatch` *is* the interpreter.
@@ -201,10 +197,6 @@ There's a [partition](../../core/glossary.md#the-two-partitions) wrinkle the cas
 ??? note "Going deeper — layered subs come along for free"
 
     That `:auth.login-form/can-submit?` sub is **layered** — defined `:<- [:auth.login-form/slice]`, so it reads through another sub. `compute-sub` resolves the chain transitively: it computes the input sub against `db` first, depth-first, then runs the outer body against that value — all without spinning up the cache. Same for a parametric `input-fn` sub. You test the top sub and the whole [derivation graph](../../core/glossary.md#the-derivation-graph) underneath it comes along, exactly as the running app composes it. The cache the live app uses is an *optimisation* layered over this pure composition, not part of its meaning — which is precisely why you can drop it on the JVM and still get the right answer.
-
-??? info "From re-frame v1"
-
-    You never call `@(rf/subscribe …)` in these tests. `subscribe` needs a live reactive cache and an installed adapter — overhead for an assertion against a value. `compute-sub` is the pure, headless form. (If you genuinely want "what would the running frame see *right now*, cache and all", there's `rf/subscribe-once` — current value, synchronously, no live ratom left dangling — but for unit tests `compute-sub` is the right tool.)
 
 ## 5. Test the view, not just the state
 

--- a/docs/resources/tutorial/index.md
+++ b/docs/resources/tutorial/index.md
@@ -209,10 +209,6 @@ That's the whole boot. Four moves: install the substrate, register the frame, se
 
     Move 1 (`init!`) is roughly `applyMiddleware` — it wires the runtime to a substrate. Move 2 (`reg-frame`) is `createStore`. Move 3 is your initial-state argument to `createStore`, except expressed as an event rather than a literal. Move 4 is `<Provider store={...}>`. The big difference: re-frame2 makes you name the store (the frame) explicitly, because a re-frame2 app can run several stores side by side, fully isolated.
 
-??? info "From re-frame v1"
-
-    Moves 2–4 are the new part: there's no implicit global frame any more, so the app says — once, at the root — which frame it runs in. v1 dispatched into an ambient singleton you never named; v2 makes that frame explicit, which is exactly what later lets the *same* views run in two isolated frames side by side. The events, subs, and views in this file should look familiar; only the boot has changed.
-
 ### A more idiomatic seed: `:initial-events`
 
 The manual Move 3 (`with-frame` + `dispatch-sync`) is worth meeting first because it makes the seeding visible. But there's a second, more idiomatic way: hand `reg-frame` an `:initial-events` vector and let it run the boot events *for* you, synchronously, as part of registration.


### PR DESCRIPTION
Recovery PR: this commit was pushed to the #5096 branch *after* that PR merged, so it never reached main — cherry-picked here onto current main, gates re-run.

## What it contains (the follow-up direction from #5096's thread)

- **MkDocs rationale stated in the contract**: pages render via MkDocs Material (LHS nav + prev/next buttons), so no 'Where next' sections at the bottom — and on index/introduction pages specifically, no 'In this section' framing that mirrors the menu. An index routes by adding *judgment*, never by restating the nav.
- **v1→v2 callouts budgeted**: earned only where the v1 instinct *actively misleads* (a retired surface that errors, changed behaviour, a reflex that fails loud); 'same as v1' / 'v1 didn't have this' get cut; most pages need zero.
- **The rule applied corpus-wide: 61 → 32.** The 29 cuts are the colour ('philosophy unchanged'), the didn't-have-this notes (v1 had no machines/resources/routing/SSR), and the repeats (the frame story on four pages, inject-cofx on four). The 32 keeps each name a retired surface or changed behaviour on its owning page: reg-event collapse at first contact, inject-cofx, :initial-db/:on-create, ^:flush-dom drain timing, the silent-failure signal-fn reg-sub change, reg-global-interceptor, registrar collision hardening, http-xhrio → managed, 10x → Xray, form-1 → reg-view, wait-for retirement, resources/frames owning-page deltas.

## Gates
- mkdocs build --strict — green
- check_doc_slugs.py — exit 0