### PR TITLE
docs(testing): seed test frames via :initial-events, not dispatch-sync stacks

### DIFF
--- a/docs/core/testing/cascades.md
+++ b/docs/core/testing/cascades.md
@@ -280,8 +280,7 @@ If [Xray](../glossary.md#xray) — the dev inspector — was open when the bug h
             [my-app.articles]))
 
 (deftest issue-217-unfavorite-leaves-count-stale
-  (rf/with-new-frame [f (rf/make-frame {})]
-    (rf/dispatch-sync [:app/init])   ;; seed via a setup dispatch (or :initial-events on make-frame)
+  (rf/with-new-frame [f (rf/make-frame {:initial-events [[:app/init]]})]
     (ts/dispatch-sequence [[:article/loaded {:slug "ten-tips" :favorites-count 0}]
                            [:article/favorite "ten-tips"]
                            [:article/unfavorite "ten-tips"]])
@@ -290,7 +289,7 @@ If [Xray](../glossary.md#xray) — the dev inspector — was open when the bug h
                      [:articles "ten-tips" :favorites-count])))))
 ```
 
-`ts/dispatch-sequence` runs the rows through `dispatch-sync` in order and returns the final `app-db`. A row whose handler declares facts gets its own `dispatch-sync` with the recorded `:rf.cofx` supplied — replay means recorded inputs, never fresh ones. Today the replay reproduces the bug (red); fix the handler and the same replay proves the fix (green). The report has become a permanent regression guard that can't flake, because every input is pinned.
+`ts/dispatch-sequence` runs the rows through `dispatch-sync` in order and returns the final `app-db`. This is the one place a multi-event run belongs in the test *body* rather than in `:initial-events`: the sequence itself is the subject — it *is* the bug — not setup for something else. (App boot, by contrast, is setup, which is why `[:app/init]` rides the frame's construction above.) Note the rows are bare event vectors: when a replayed event's handler declares facts, give that row its own `dispatch-sync` carrying the recorded `:rf.cofx` — replay means recorded inputs, never fresh ones. Today the replay reproduces the bug (red); fix the handler and the same replay proves the fix (green). The report has become a permanent regression guard that can't flake, because every input is pinned.
 
 !!! note "Capturing intermediate state on the way through"
 
@@ -326,15 +325,15 @@ Every assertion so far has read a path straight out of `app-db`. But the cascade
   (fn [db _] (filterv :favorited? (vals (:articles db)))))
 
 (deftest favorited-derives-correctly
-  (rf/with-new-frame [f (rf/make-frame {})]
-    (ts/dispatch-sequence [[:article/loaded {:slug "a" :favorited? true}]
-                           [:article/loaded {:slug "b" :favorited? false}]])
+  (rf/with-new-frame [f (rf/make-frame
+                          {:initial-events [[:article/loaded {:slug "a" :favorited? true}]
+                                            [:article/loaded {:slug "b" :favorited? false}]]})]
     ;; assert the SUB's output, not the raw :articles map
     (is (= 1 (count (rf/compute-sub [:articles/favorited]
                                     (rf/app-db-value f)))))))
 ```
 
-`(rf/compute-sub query-v db)` runs the subscription's body against an `app-db` *value* and returns what it computes — no reactive cache, no Reagent, no adapter. `query-v` is the exact vector you'd hand `subscribe` (`[:sub-id arg1 arg2]`), so a parameterized sub passes its args the same way. Layered subs resolve transitively: a sub built on other subs computes its inputs first, depth-first, then itself — the whole derivation graph, evaluated as a pure function. The recommended shape is the one above: **drive `db` with `dispatch-sync` (or `dispatch-sequence`), then `compute-sub` against the result**, so the sub is tested against state the real code paths produced. (You *can* pass a hand-rolled literal map as `db` for a trivial reader, but that decouples the test from how the state is actually built and rots silently when the shape moves — keep it for the rare case where the dispatch path adds nothing.)
+`(rf/compute-sub query-v db)` runs the subscription's body against an `app-db` *value* and returns what it computes — no reactive cache, no Reagent, no adapter. `query-v` is the exact vector you'd hand `subscribe` (`[:sub-id arg1 arg2]`), so a parameterized sub passes its args the same way. Layered subs resolve transitively: a sub built on other subs computes its inputs first, depth-first, then itself — the whole derivation graph, evaluated as a pure function. The recommended shape is the one above: **build `db` with real events — `:initial-events` at construction, or a `dispatch-sync` in the body when the dispatch is itself under test — then `compute-sub` against the result**, so the sub is tested against state the real code paths produced. (You *can* pass a hand-rolled literal map as `db` for a trivial reader, but that decouples the test from how the state is actually built and rots silently when the shape moves — keep it for the rare case where the dispatch path adds nothing.)
 
 !!! warning "Gotcha"
 

--- a/docs/core/testing/event-handlers.md
+++ b/docs/core/testing/event-handlers.md
@@ -163,27 +163,37 @@ This is exactly the trap you want sprung. A silently-minted random value would m
 
     Rather than spell out each test-friendly setting on every frame, ask for the bundle: `(rf/reg-frame :my-test {:preset :test})` — or `:preset :test` on the advanced `re-frame.frame/make-frame` — expands to three fixed entries. It redirects `:rf.http/managed` to a canned-success stub, so a test frame never reaches the network; it sets `:rf.cofx/mint-policy :strict`, the strict-mint behaviour above; and it carries `:drain-depth 100`, the framework default, surfaced so tooling can read "this is a test frame" off the frame's metadata. Reach for the preset when you want those defaults without naming them one by one.
 
-### Seeding multiple events, and ergonomic state assertions
+### Seeding state: the frame boots it, the body tests it
 
-When a test needs several setup dispatches before the one under test, `re-frame.test-support/dispatch-sequence` fires a vector of events in order and returns the final committed app-db — tidier than a stack of `dispatch-sync` calls:
+When a test needs state built up *before* the dispatch it's actually about, don't stack setup `dispatch-sync` calls above the action — hand the setup to `make-frame` as `:initial-events`, the same ordered event script a production [`reg-frame`](../concepts/frames.md#seeding-initial-state) boots with. Each step dispatches synchronously and drains to completion, in order, while the frame is constructed. The frame arrives already in the state the test needs, and the body holds exactly one dispatch — the one under test:
 
 ```clojure
-(deftest feed-after-a-sequence
-  (rf/with-new-frame [f (rf/make-frame {})]
-    (let [final (ts/dispatch-sequence [[:articles/init]
-                                       [:articles/page-changed 2]
-                                       [:articles/page-changed 3]])]
-      (is (= 3 (get-in final [:articles :page]))))))
+(deftest page-change-from-a-seeded-feed
+  (rf/with-new-frame [f (rf/make-frame {:initial-events [[:articles/init]
+                                                         [:articles/page-changed 2]]})]
+    (rf/dispatch-sync [:articles/page-changed 3])
+    (is (= 3 (get-in (rf/app-db-value f) [:articles :page])))))
 ```
 
-`dispatch-sequence` takes an optional opts map: `:frame` (dispatch into a named frame instead of the current one) and `:after-each` (a `(fn [db event] …)` called once per event with the state committed after it — handy for asserting on each intermediate step, not just the final state).
+A setup step that needs pinned facts takes the map form — `:opts` is the ordinary `dispatch-sync` opts map, so a seed can carry `:rf.cofx` and `:fx-overrides` just like the action can:
+
+```clojure
+(rf/make-frame
+  {:initial-events [[:articles/init]
+                    {:event [:articles/refresh]
+                     :opts  {:rf.cofx      {:rf/time-ms 1781078400123}
+                             :fx-overrides {:rf.http/managed (fn [_ _] nil)}}}]})
+```
+
+And construction is strict: a setup step that fails — a thrown handler, a missing required cofx — tears the partial frame down and the constructor throws `:rf.error/initial-events-step-failed` naming the step. A broken seed is a red test at the `make-frame` line, never a half-seeded frame that fails three asserts later.
+
+### Ergonomic state assertions
 
 For the assertion itself, `test-support` ships two `clojure.test`-aware helpers that read the *current* (or a named) frame's app-db, so you don't have to thread `app-db-value` through `get-in` by hand: `(ts/assert-path-equals path expected)` checks one path, and `(ts/assert-db-equals expected-db)` checks the whole map. Both take an optional `{:frame …}` opt and report a `:pass` / `:fail` through `clojure.test`, so they slot straight into a `deftest`:
 
 ```clojure
 (deftest page-committed
-  (rf/with-new-frame [_ (rf/make-frame {})]
-    (rf/dispatch-sync [:articles/init])
+  (rf/with-new-frame [_ (rf/make-frame {:initial-events [[:articles/init]]})]
     (rf/dispatch-sync [:articles/page-changed 3])
     (ts/assert-path-equals [:articles :page] 3)))
 ```

--- a/docs/core/testing/index.md
+++ b/docs/core/testing/index.md
@@ -13,6 +13,8 @@ The pages here climb one rung at a time, and each stands alone — start whereve
 | a **view** | call it, walk the returned hiccup with `re-frame.test-helpers` | [Views](views.md) |
 | a **whole cascade** | `dispatch-sync` into a fresh frame with supplied facts and canned replies | [Cascades](cascades.md) |
 
+One habit runs through every page: **setup rides the frame's construction; the body dispatches only the action under test.** `make-frame` takes `:initial-events` — the same ordered event script a production [`reg-frame`](../concepts/frames.md#seeding-initial-state) boots with — so the state a test needs *before* its action is declared where the frame is made, not stacked up as `dispatch-sync` calls above the assertion. A setup step that needs pinned facts takes the map form, `{:event [...] :opts {:rf.cofx {...}}}`, and a failing step tears the frame down loudly instead of leaving the test half-seeded. When you see a `dispatch-sync` in a test body on these pages, it's the event being tested.
+
 ## What about `reg-fx` and `reg-cofx`?
 
 They don't get pages here, and that's deliberate: they are the app's **designed impure edges** — a `reg-fx` body touches the host, a `reg-cofx` supplier reads it — so "unit-test it as a pure function" doesn't apply. What you test instead is everything *around* them, at the seams the framework gives you:

--- a/docs/core/testing/subscriptions.md
+++ b/docs/core/testing/subscriptions.md
@@ -29,21 +29,18 @@ The sub under test here is the three-layer cart chain from [Subscriptions](../co
 
 ## The sharper variant: drive real events first
 
-Hand-rolling a literal `db` is the escape hatch for very simple readers. For anything that depends on the *shape* your events actually produce, it silently rots the day a handler changes that shape — the test keeps passing against a db your app no longer builds. So the more robust style is to dispatch real events through a test [frame](../glossary.md#frame) and read the sub against the resulting db:
+Hand-rolling a literal `db` is the escape hatch for very simple readers. For anything that depends on the *shape* your events actually produce, it silently rots the day a handler changes that shape — the test keeps passing against a db your app no longer builds. So the more robust style is to boot a test [frame](../glossary.md#frame) through real events — `:initial-events` on `make-frame`, each step an ordinary dispatch drained in order at construction — and read the sub against the db that produces. The events aren't the subject here; they're setup, so they ride the frame's construction rather than the test body:
 
 ```clojure
 (deftest cart-count-after-events
-  (rf/with-new-frame [f (rf/make-frame {})]
-    ;; with-new-frame pins f as the current frame for the body, so the
-    ;; dispatches below land in f without naming it each time.
-    (rf/dispatch-sync [:cart/add-item {:sku "BK-1"}])
-    (rf/dispatch-sync [:cart/add-item {:sku "BK-2"}])
+  (rf/with-new-frame [f (rf/make-frame {:initial-events [[:cart/add-item {:sku "BK-1"}]
+                                                         [:cart/add-item {:sku "BK-2"}]]})]
     (is (= 2 (count (rf/compute-sub [:cart/items] (rf/app-db-value f)))))))
 ```
 
 !!! note "Two styles, one rule of thumb"
 
-    `compute-sub` against a literal `db` when the reader is trivial and the shape is obvious; dispatch real events and read `(rf/app-db-value f)` when the db shape matters — your test then exercises the same db your handlers actually build, so it can't drift from reality. Avoid `subscribe` + deref in tests altogether: the reactive runtime is pure overhead for a value assertion, and it needs a live cache and an installed adapter.
+    `compute-sub` against a literal `db` when the reader is trivial and the shape is obvious; seed with real events and read `(rf/app-db-value f)` when the db shape matters — your test then exercises the same db your handlers actually build, so it can't drift from reality. Avoid `subscribe` + deref in tests altogether: the reactive runtime is pure overhead for a value assertion, and it needs a live cache and an installed adapter.
 
 !!! warning "Gotcha — what a sub test can't see"
 

--- a/docs/core/testing/views.md
+++ b/docs/core/testing/views.md
@@ -61,6 +61,8 @@ A presentational view takes data as arguments. A *connected* view subscribes and
 
 `expect-text` renders the stashed root view, finds the testid, and asserts its text through `clojure.test/is` — the view-side sibling of `ts/assert-path-equals`. (A 3-arity form takes an explicit tree when you're not using the fixture.)
 
+The two dispatches in that body are the *action under test* — the counter incrementing is the point. When a view instead needs state built *before* the action (a populated cart, a signed-in user), seed it in the fixture opts rather than the body: `:frame-config` merges into the fixture frame's config map, so `:frame-config {:initial-events [[:cart/seed-items …]]}` boots the frame through the same [construction script](../concepts/frames.md#seeding-initial-state) `make-frame` takes. The body then holds only the interaction being tested.
+
 !!! warning "Gotcha — `:install` registrations land in the process-global registrar"
 
     The fixture destroys its *frame*, but registrations are global, exactly as [Test an event handler](event-handlers.md#4-the-trap-frames-dont-isolate-registrations) warns. Pair `with-app-fixture` with the `make-reset-runtime-fixture` shown at the top so one test's registrations can't leak into the next.

--- a/docs/resources/testing.md
+++ b/docs/resources/testing.md
@@ -62,19 +62,20 @@ That second assertion is the one that matters: `nil` is the *fail-closed* answer
 
 ## 3. Invalidation and mutations
 
-A write's cache consequences are declared (`:invalidates`, `:populates`), so the test drives the write and asserts the consequence. Staleness is the observable: an entry with no live owner is *marked stale* by an invalidation rather than refetched, which makes `:stale?` the clean assertion:
+A write's cache consequences are declared (`:invalidates`, `:populates`), so the test drives the write and asserts the consequence. The read it invalidates is *setup*, not the subject — so it rides the frame's `:initial-events`, with the stub table wrapped around frame creation (stubs bind for their dynamic extent, and the seed fetches as the frame boots). Staleness is the observable: an entry with no live owner is *marked stale* by an invalidation rather than refetched, which makes `:stale?` the clean assertion:
 
 ```clojure
 (deftest favorite-invalidates-the-article
-  (rf/with-new-frame [f (rf/make-frame {})]
-    (rf/with-managed-request-stubs
-      {[:get  "/api/articles/intro"]          {:reply {:ok {:article {:slug "intro"}}}}
-       [:post "/api/articles/intro/favorite"] {:reply {:ok {:article {:slug "intro" :favorited true}}}}}
-      ;; seed the read…
-      (rf/dispatch-sync [:rf.resource/ensure {:resource :realworld/article
-                                              :params   {:slug "intro"}
-                                              :cause    [:manual :test/setup]}])
-      ;; …run the write…
+  (rf/with-managed-request-stubs
+    {[:get  "/api/articles/intro"]          {:reply {:ok {:article {:slug "intro"}}}}
+     [:post "/api/articles/intro/favorite"] {:reply {:ok {:article {:slug "intro" :favorited true}}}}}
+    ;; the frame boots with the article already loaded — through the canned reply
+    (rf/with-new-frame [f (rf/make-frame
+                            {:initial-events
+                             [[:rf.resource/ensure {:resource :realworld/article
+                                                    :params   {:slug "intro"}
+                                                    :cause    [:manual :test/setup]}]]})]
+      ;; run the write…
       (rf/dispatch-sync [:rf.mutation/execute {:mutation :realworld/favorite
                                                :params   {:slug "intro"}
                                                :instance [:favorite "intro"]

--- a/docs/routing/testing.md
+++ b/docs/routing/testing.md
@@ -80,11 +80,12 @@ The `:can-leave` flow is deliberately testable without a browser: the guard is a
 
 ```clojure
 (deftest leave-guard-parks-and-continues
-  (rf/with-new-frame [f (rf/make-frame {})]
-    ;; land on the guarded editor with unsaved changes (the guard sub reads app state)
-    (rf/dispatch-sync [:rf.route/navigate :app/article-editor {:id "intro"}])
-    (rf/dispatch-sync [:editor/typed "draft text"])
-
+  ;; the frame BOOTS on the guarded editor with unsaved changes — that's setup,
+  ;; so it rides :initial-events; the body dispatches only the moves under test
+  (rf/with-new-frame [f (rf/make-frame
+                          {:initial-events
+                           [[:rf.route/navigate :app/article-editor {:id "intro"}]
+                            [:editor/typed "draft text"]]})]
     ;; try to leave: the navigation parks, the slice doesn't move
     (rf/dispatch-sync [:rf.route/navigate :app/home])
     (is (some? @(routing/sub-pending-navigation)))

--- a/docs/ssr/testing.md
+++ b/docs/ssr/testing.md
@@ -6,7 +6,7 @@ Here's the pleasant surprise: **your server tests are just JVM tests.** The whol
 
 ## 1. Render a request to a string
 
-`render-to-string` is a pure function — hiccup in, HTML string out — and the test shape is the request lifecycle in miniature: fresh frame, setup dispatch, render, assert on the markup:
+`render-to-string` is a pure function — hiccup in, HTML string out — and the test shape is the request lifecycle in miniature: a fresh frame booted through `:initial-events`, render, assert on the markup. That's not just tidiness — `:initial-events` is the *same key* `ssr-handler` uses to seed every per-request frame, so a test frame built this way boots through exactly the path a production request's frame does:
 
 ```clojure
 (ns my-app.ssr-test
@@ -20,9 +20,10 @@ Here's the pleasant surprise: **your server tests are just JVM tests.** The whol
 (use-fixtures :each (ts/make-reset-runtime-fixture {}))
 
 (deftest article-page-renders-its-title
-  (rf/with-new-frame [f (rf/make-frame {})]
-    (rf/dispatch-sync [:rf/set-db {:articles {"intro" {:title "Welcome"}}}])
-    (rf/dispatch-sync [:rf.route/handle-url-change "/articles/intro"])
+  (rf/with-new-frame [f (rf/make-frame
+                          {:initial-events
+                           [[:rf/set-db {:articles {"intro" {:title "Welcome"}}}]
+                            [:rf.route/handle-url-change "/articles/intro"]]})]
     (let [html (ssr/render-to-string [app-root] {:frame f})]
       (is (clojure.string/includes? html "Welcome")))))
 ```


### PR DESCRIPTION
Operator feedback: the testing docs under-used `:initial-events` on frames, falling back to `dispatch-sync` stacks (and `ts/dispatch-sequence`) for plain seeding.

## The principle (now stated once, in the testing index)

**Setup rides the frame's construction; the body dispatches only the action under test.** `:initial-events` is the designed seeding surface (EP-0027): an ordered event script dispatched synchronously at construction, with a `{:event … :opts …}` map-step form carrying full dispatch-sync opts (pinned cofx, fx-overrides), and strict fail-and-teardown on a bad step. The testing pages never taught any of that — `docs/core/concepts/frames.md` did, but every test example seeded imperatively.

## Per-page changes

- **testing/index.md** — the principle, the map-step form, strict construction, and the reading rule: a `dispatch-sync` in a test body on these pages is the event being tested.
- **testing/event-handlers.md** — the "Seeding multiple events" section (which taught `dispatch-sequence` as the seeding tool) rewritten around `:initial-events`, including the map-step form and `:rf.error/initial-events-step-failed`. `dispatch-sequence` no longer taught here.
- **testing/subscriptions.md** — the "drive real events first" example seeds via `:initial-events`; both dispatches were setup.
- **testing/cascades.md** — regression-replay seeds `[:app/init]` at construction; `dispatch-sequence` kept for the replay rows and scoped to its honest niche (the sequence *is* the subject). **Fixes an overclaim**: the page said a replay row "gets its own dispatch-sync with the recorded `:rf.cofx` supplied" — `dispatch-sequence` rows are bare event vectors with no per-row opts; the text now says so and routes pinned-fact rows to individual `dispatch-sync` calls. `favorited-derives-correctly` also seeds via construction.
- **testing/views.md** — surfaces `with-app-fixture`'s `:frame-config {:initial-events …}` (documented in its docstring, absent from the page).
- **routing/testing.md** — the leave-guard test boots on the guarded editor via `:initial-events`; the body keeps only the park/continue moves under test.
- **resources/testing.md** — the mutation test's seed-read rides `:initial-events`, with the stub table wrapped *around* frame creation (stubs bind for their dynamic extent, so the boot-time ensure fetches through the canned reply — verified against `with-managed-request-stubs*`, which binds `router/*fx-overrides*`).
- **ssr/testing.md** — the render test boots via `:initial-events`, with the symmetry made explicit: it's the same key `ssr-handler` uses to seed every per-request frame.

Kept as `dispatch-sync`: every dispatch that is itself the subject (the cascade primer, navigation under test, the ensure in the resources read test, the counter increments in the view test).

## Gates

- `python -m mkdocs build --strict` — exit 0
- `python scripts/check_doc_slugs.py` — exit 0
