### PR TITLE
docs(routing): correctness + clarity review pass

### DIFF
--- a/docs/api/re-frame.routing.md
+++ b/docs/api/re-frame.routing.md
@@ -177,6 +177,22 @@ The read-side surface over the route registry and the live route slice — the s
   ```
 - **Description**: The layer-1 sub fn behind `:rf/route` — reads the route slice from `[:rf.runtime/routing :current]`. Exposed publicly so external callers (smoke tests, tooling) read the slice without re-deriving the path.
 
+### `sub-route`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (re-frame.routing/sub-route)        ;; → reaction over the route slice, or nil
+  (re-frame.routing/sub-route opts)   ;; opts {:frame <id-or-frame>}
+  ```
+- **Description**: Named read sugar over `[:rf/route]`. Returns a reaction over the route slice `{:route-id :params :query :fragment :transition :error :nav-token}`, or `nil` before the first navigation. Zero-arity is the primary form (the route is a per-frame singleton); the 1-arity `opts` carries `{:frame …}` to target an explicit (e.g. non-default url-bound) frame. The vector form remains the canonical registered sub. Lives on `re-frame.routing` (not `re-frame.core`) so a non-routing app's production bundle carries no route keyword strings.
+
+```clojure
+(require '[re-frame.routing :as routing])
+
+(:route-id @(routing/sub-route))   ;; the active route id, or nil pre-navigation
+```
+
 ### `sub-pending-navigation`
 
 - **Kind**: function
@@ -348,12 +364,12 @@ These are the standard events the runtime dispatches (or you dispatch) around ro
 
 ### Subscriptions
 
-The full `:rf/route` slice is `{:id :params :query :transition :error}`. The standard subs are projections of that slice plus a couple of conveniences.
+The full `:rf/route` slice is `{:route-id :params :query :fragment :transition :error :nav-token}`. The standard subs are projections of that slice plus a couple of conveniences.
 
 | Sub | Returns |
 |---|---|
-| `:rf/route` | The full `:rf/route` slice `{:id :params :query :transition :error}` |
-| `:rf.route/id` | Current route id |
+| `:rf/route` | The full `:rf/route` slice `{:route-id :params :query :fragment :transition :error :nav-token}`. Named read sugar: [`sub-route`](#sub-route). |
+| `:rf.route/id` | Current route id (the slice's `:route-id`) |
 | `:rf.route/params` | Current path params |
 | `:rf.route/query` | Current query params |
 | `:rf.route/transition` | `:idle` / `:loading` / `:error` |

--- a/docs/routing/concepts.md
+++ b/docs/routing/concepts.md
@@ -18,8 +18,10 @@ Read these three moves and you've read the whole framework's idea of routing. Ev
 ;; Adapted from examples/capabilities/routing/routing/core.cljs
 (ns app.core
   (:require [re-frame.core :as rf]
-            [re-frame.routing]))   ;; ships in day8/re-frame2-routing; requiring it
-                                   ;; at boot is what makes reg-route available
+            ;; Ships in day8/re-frame2-routing. Requiring it at boot is what makes
+            ;; reg-route available; the alias serves the routing-namespace helpers
+            ;; you'll meet below (sub-route, route-url, match-url).
+            [re-frame.routing :as routing]))
 
 ;; 1. A route is data in the registry.
 (rf/reg-route :app/home
@@ -216,6 +218,8 @@ The current route lives in **runtime-db** — the framework-owned partition besi
 ```
 
 Nine subscriptions, every one a plain read — no special routing API in views. `:rf/route` is the whole slice; the rest are projections of it you'll reach for far more often. The [API reference](../api/re-frame.routing.md#subscriptions) lists each with its return shape.
+
+Two of those reads are per-frame singletons, so `re-frame.routing` also ships named read sugar for them: `(routing/sub-route)` over `[:rf/route]` and `(routing/sub-pending-navigation)` over `[:rf/pending-navigation]` — the same reaction, fewer brackets. The vector forms stay canonical; the sugar just tidies the two reads every app makes.
 
 `:transition` is a tiny state machine the runtime drives for you: `:loading` while a route's loaders drain, `:error` if one fails, `:idle` otherwise. So a global progress bar is just a view over `:rf.route/transition`, and an error banner is a view over `:rf.route/error`. You never wire per-page loading state again — it's a property of the slice, the same on every page:
 

--- a/docs/routing/glossary.md
+++ b/docs/routing/glossary.md
@@ -26,7 +26,7 @@ What a [route](#route) declares it needs on entry — `:on-match` [events](../co
 
 ### **route guard**
 
-A `:can-leave` predicate consulted before leaving a [route](#route); a `false` parks the navigation as *pending* so your [view](../core/glossary.md#view) can render a "discard changes?" prompt, resolved by dispatching `:rf.route/continue` or `:rf.route/cancel`. The idiomatic home for unsaved-changes and auth-redirect logic.
+A `:can-leave` guard subscription (strict boolean: `true` means leaving is fine) consulted before leaving a [route](#route); a `false` parks the navigation as *pending* so your [view](../core/glossary.md#view) can render a "discard changes?" prompt, resolved by dispatching `:rf.route/continue` or `:rf.route/cancel`. The idiomatic home for unsaved-changes prompts — gating *entry* (an auth redirect) is an ordinary interceptor over the navigation events instead ([Require sign-in on a route](how-to/require-sign-in-on-a-route.md)).
 
 ### **not-found**
 
@@ -34,4 +34,4 @@ The reserved [route](#route) (`:rf.route/not-found`) the runtime activates when 
 
 ### **url-bound?**
 
-The flag declaring that *this* [frame](../core/glossary.md#frame) owns the browser address bar. Exactly one frame is url-bound; its navigations write the URL and back/forward (popstate) dispatch to it, while other frames route in-memory only — which is how a sidecar like [Xray](../core/glossary.md#xray) coexists without fighting over the URL.
+The flag declaring that *this* [frame](../core/glossary.md#frame) owns the browser address bar. At most one frame is url-bound at a time (none is legal — URL pushes then no-op); its navigations write the URL and back/forward (popstate) dispatch to it, while other frames route in-memory only — which is how a sidecar like [Xray](../core/glossary.md#xray) coexists without fighting over the URL.

--- a/docs/routing/how-to/guard-unsaved-changes.md
+++ b/docs/routing/how-to/guard-unsaved-changes.md
@@ -45,6 +45,8 @@ The blocked navigation lands in `:rf/pending-navigation`. Subscribe to it: when 
      [:button {:on-click #(dispatch [:rf.route/continue])} "Discard & leave"]]))
 ```
 
+(`routing/sub-pending-navigation` is read sugar from the routing namespace — add `[re-frame.routing :as routing]` to your ns. The vector form `@(subscribe [:rf/pending-navigation])` reads the same slot.)
+
 The reader's choice is itself a dispatch:
 
 - `:rf.route/continue` — proceed with the parked navigation (it commits now).

--- a/docs/routing/how-to/require-sign-in-on-a-route.md
+++ b/docs/routing/how-to/require-sign-in-on-a-route.md
@@ -48,7 +48,7 @@ Guard `:rf.route/navigate` alone and the third row defeats you: a logged-out rea
     nil))
 ```
 
-`routing/match-url` is pure (it lives in `re-frame.routing`, not on the `rf/` facade) — it turns a URL string into a match map, or `nil` when nothing resolves, so a garbage URL short-circuits the guard rather than crashing it.
+`routing/match-url` is pure (it lives in `re-frame.routing`, not on the `rf/` facade — add `[re-frame.routing :as routing]` to your ns) — it turns a URL string into a match map, or `nil` when nothing resolves, so a garbage URL short-circuits the guard rather than crashing it.
 
 ## 3. Redirect with skip-and-dispatch
 

--- a/docs/routing/testing.md
+++ b/docs/routing/testing.md
@@ -38,7 +38,7 @@ The setup is the same as the [core testing pages](../core/testing/index.md): a J
 
 !!! warning "Gotcha — the nil-policy asymmetry is worth a test of its own"
 
-    A `nil` **path** param throws `:rf.error/route-url-validation` territory (`:rf.error/missing-route-param` — there's no URL without the segment); a `nil` **query** param is *silently elided* (`{:page nil}` just omits the key). If your app leans on the elision — "only add `?sort=` when chosen" — pin it: `(is (= "/search?q=x" (routing/route-url :app/search {} {:q "x" :sort nil})))`.
+    A `nil` **path** param is a hard error — `route-url` throws `:rf.error/missing-route-param`, because there's no URL to build without the segment; a `nil` **query** param is *silently elided* (`{:page nil}` just omits the key). If your app leans on the elision — "only add `?sort=` when chosen" — pin it: `(is (= "/search?q=x" (routing/route-url :app/search {} {:q "x" :sort nil})))`.
 
 ## 2. Navigation through a test frame
 


### PR DESCRIPTION
## What this is

A fresh correctness + completeness + clarity review of `docs/routing`, covering everything that landed since the last pass: the new `testing.md` (#5094/#5098), the section-map rework (#5087), and the read-sugar threading (rf2-7ux1w2).

## Verified clean (no change)

`tutorial.md`, `index.md`, `examples.md`, `coming-from-react-router.md`; `testing.md`'s structure — all its cross-links resolve (`core/testing/*`, `resources/testing`, `ssr/testing`), `sub-pending-navigation` is real (`routing.cljc:145`, matches its own test file's usage), the fixture opts-map arity is valid, and driving `:rf.route/handle-url-change` directly is the spec'd user-audience surface.

## Fixed — correctness

- **API reference: wrong slice shape.** The subs table said the `:rf/route` slice is `{:id :params :query :transition :error}`. The real slice is `{:route-id :params :query :fragment :transition :error :nav-token}` — verified twice against the implementation (the `sub-route` docstring, and the `:rf.route/id` sub which reads `:route-id`, rf2-3a5nk7).
- **glossary: `:can-leave` is not the auth-guard home.** "The idiomatic home for unsaved-changes **and auth-redirect** logic" contradicted the how-to: auth-gating guards *entry* via an interceptor over the navigation events, not `:can-leave`. Repointed. Also "predicate" → guard *subscription* (strict boolean), matching the documented contract.
- **glossary: "Exactly one frame is url-bound"** → "At most one" — zero owners is legal (URL pushes then no-op), per concepts and the spec.
- **testing.md: garbled error claim.** "A `nil` path param throws `:rf.error/route-url-validation` *territory* (`:rf.error/missing-route-param` …)" → `route-url` throws `:rf.error/missing-route-param`, plainly.

## Fixed — completeness

- **API reference: `sub-route` was undocumented.** Its sibling `sub-pending-navigation` has an entry; `sub-route` had none despite the guide using it. Added the entry (mirroring the sibling's shape, incl. the bundle-isolation note) and the "Named read sugar" cross-ref on the `:rf/route` table row.

## Fixed — clarity

- **The sugar was uncompilable as shown.** rf2-7ux1w2 threaded `routing/sub-route` / `routing/sub-pending-navigation` into the guide, but `concepts.md`'s only ns form required `[re-frame.routing]` with **no alias**, and neither how-to established one — a reader copying the leave-guard dialog gets a compile error. Fixed: the three-moves ns form now requires `:as routing` (with a comment naming what the alias serves), Move 3 introduces the two sugar reads in one short paragraph, and both how-tos name the require at first use.

Six files, +31/−9.

## Verification

- `python -m mkdocs build --strict` → exit 0 (the new `#sub-route` anchor and glossary link resolve)
- `check_doc_slugs` / `check_readme_links` / `check_readme_inventories` → exit 0
- api-manifest `doc-api-check` → 271 refs in sync, exit 0
