### PR TITLE
docs(machines): correctness + clarity review pass

### DIFF
--- a/docs/machines/concepts.md
+++ b/docs/machines/concepts.md
@@ -97,7 +97,7 @@ So every event reaches the machine through the same `dispatch` and the same [eve
 (rf/dispatch [:auth.login/flow [:auth.login/submit credentials]])
 
 @(rf/sub-machine :auth.login/flow)
-;; => {:state :submitting :data {:attempts 1 :error nil}}   (nil before the first event)
+;; => {:state :submitting :data {:attempts 0 :error nil}}   (nil before the first event)
 ```
 
 `[:rf/machine <id>]` is an ordinary [query vector](../core/glossary.md#query-vector), so it's traceable like the rest of your [derivation graph](../core/glossary.md#the-derivation-graph), and named projections chain off it — `(rf/reg-sub :auth.login/error :<- [:rf/machine :auth.login/flow] ...)` — like any other [subscription](../core/concepts/subscriptions.md).

--- a/docs/machines/index.md
+++ b/docs/machines/index.md
@@ -42,7 +42,7 @@ And a singleton machine (based on this specification value) can be defined as an
 (rf/reg-machine :auth-login auth-login-machine)
 ```
 
-The state for all machines lives in a [frame](../core/concepts/frames.md) alongside your `app-db`, it moves on the same cascade, can be "undone" the same way, and be debugged using the same tools (like Xray) and be tested the same way — **there's no second runtime to learn**.
+The state for all machines lives in a [frame](../core/concepts/frames.md) alongside your `app-db`. It moves on the same cascade, can be "undone" the same way, debugged with the same tools (like Xray), and tested the same way — **there's no second runtime to learn**.
 
 Triggers are sent to machines by normal events, dispatched the normal way, so you drive a machine straight from an ordinary handler. Dispatching `[:auth-login [:submit …]]` fires the machine's `:submit` arrow:
 

--- a/docs/machines/tutorial.md
+++ b/docs/machines/tutorial.md
@@ -34,7 +34,7 @@ A machine is a data structure which defines a set of named states, and for each 
     :authed      {}}})                    ;; a resting state — no outgoing transitions
 ```
 
-Except, instead of triggers, we'll call them events. 
+Those triggers — the `:on` keys, `:auth.login/submit` and friends — are ordinary event ids. You'll see how one reaches the machine in a moment.
 
 Register it — one line to create a singleton machine:
 
@@ -50,7 +50,7 @@ And that means, to drive this machine, we dispatch events. The event id is that 
 (rf/dispatch [:auth.login/flow [:auth.login/submit]])
 ```
 
-In a similar way, if a view needs to see what state the machine is in, it reads that snapshot through a subscription (a specialised subscription called sub-machine)
+And when a view needs to know what state the machine is in, it reads the machine's [snapshot](glossary.md#snapshot) — its live `{:state … :data …}` value — through a specialised subscription, `rf/sub-machine`:
 
 ```clojure
 @(rf/sub-machine :auth.login/flow)


### PR DESCRIPTION
A full review of `docs/machines` (all 13 files) for correctness and completeness, then clarity.

## Verified clean

30+ checkable claims tested against the implementation and Spec 005 — **all held**: the lazy snapshot init (`nil` before the first event), the machine-wrapped reply mechanics (`route-inner-event` folds the appended reply into the inner trigger — exactly as the tutorial teaches), `:meta {:terminal? true}`, every cited `:rf.error/*` / `:rf.machine.*` id, `sub-machine` on the `rf/` facade, `machine-has-tag?`, `handler-meta :machine-guard`, the `Result` accessors (`result/ok?`/`fail?`/`snap`/`fx`/`info`), the actors' `:rf/self-id`/`:rf/parent-id`/`:rf/spawned` stamps, and the `:rf/history` slot. No completeness gaps — the corpus (fresh from #5075–#5097) is in excellent shape, so no churn beyond the genuine findings.

## Fixed — correctness (1)

- **concepts.md**: the "Registering and running it" snippet dispatches a single submit from a *fresh* machine and showed `:data {:attempts 1 …}` — the submit arrow runs `:clear-error` only; `:attempts` increments on **failure**, so it reads `0`. (The tutorial's identical sequence correctly shows `0`.)

## Fixed — clarity (3)

- **tutorial.md**: the orphaned *"Except, instead of triggers, we'll call them events."* announced a renaming the page then ignored ("the trigger rides *inside* an event wrapper" two paragraphs later). Replaced with a sentence that does the actual job: the `:on` keys are ordinary event ids; delivery is shown next.
- **tutorial.md**: *"it reads that snapshot through a subscription (a specialised subscription called sub-machine)"* — "that snapshot" was never introduced, "subscription" repeated, no terminal period. Now introduces the snapshot (glossary-linked) and names `rf/sub-machine`.
- **index.md**: comma-splice / broken parallelism in the "Deeply integrated" paragraph → one clean parallel series.

Three files, small surgical diff. Verified: `mkdocs build --strict` (exit 0), check_doc_slugs / check_readme_links / check_readme_inventories (exit 0). (`docs/api` untouched, so the api-manifest gate is unaffected.)