### PR TITLE
fix(examples/ssr): drop redundant :doctype? — handler already writes the document envelope (rf2-o0tspx)

### DIFF
--- a/examples/capabilities/ssr/ssr/core.cljc
+++ b/examples/capabilities/ssr/ssr/core.cljc
@@ -286,9 +286,15 @@
                  ;; recomputes the hash after its first render, and if the two
                  ;; don't match, the runtime raises :rf.ssr/hydration-mismatch
                  ;; instead of quietly serving a subtly-broken page.
+                 ;; No `:doctype?` here — this handler wraps a *fragment*
+                 ;; (`<div id='app'>…</div>`) inside its own hand-written
+                 ;; document envelope below, which already opens with
+                 ;; `<!DOCTYPE html>`. `:doctype?` is for a root view that
+                 ;; renders the whole `[:html …]` document; asking for it here
+                 ;; would prefix a *second* doctype onto the fragment and nest
+                 ;; it inside `<div id='app'>`.
                  html     (rf/render-to-string hiccup
-                                               {:doctype?    true
-                                                :emit-hash?  true})
+                                               {:emit-hash? true})
                  ;; The same hash also rides in the payload, so something
                  ;; without a DOM to parse — a server log line, a CDN cache key
                  ;; — can read it straight.


### PR DESCRIPTION
## What

`examples/capabilities/ssr/ssr/core.cljc` `handle-request` passed `{:doctype? true :emit-hash? true}` to `rf/render-to-string` **and** separately hand-wrote `<!DOCTYPE html>` at the start of its response envelope.

Per `re-frame.ssr.emit` (`emit.cljc` lines 543-544), `:doctype? true` prefixes `<!DOCTYPE html>` onto the emitted string:

```clojure
(if (:doctype? opts)
  (str "<!DOCTYPE html>" body)
  body)
```

So the real output nested a **second** doctype *inside* `<div id='app'>`. Browsers tolerate it, so nothing visibly broke, and the hand-authored `index.html` snapshot never showed it (it was written by hand, not generated).

## Change

One-line fix in `handle-request`: drop `:doctype? true`, keep `:emit-hash? true`. The handler wraps a *fragment* in its own document envelope, so it should not ask the renderer to also emit a doctype. `:doctype?` is for a root view that renders the whole `[:html …]` document. Added a short explanatory comment on the call site.

No change to `re-frame.ssr.emit` or any other code.

## Test

`re-frame.examples-test` / `ssr-example-runs-end-to-end` does **not** pin the buggy string: it never invokes `handle-request` and calls `(rf/render-to-string hiccup {:emit-hash? true})` itself (already without `:doctype?`), asserting article titles, `<h1>`, and `data-rf-render-hash` — never a doctype. So it needed **no** update. It already asserts the correct shape.

Verified concretely by evaluating `handle-request`: output now contains exactly **one** `<!DOCTYPE html>` (at the document head), and **none** inside `<div id='app'>`.

## Quality gates

- `re-frame.examples-test/ssr-example-runs-end-to-end` (`clojure -M:test -v …`, `implementation/core`) — **PASS** (1 test, 6 assertions, 0 failures/errors).
- Full `re-frame.examples-test` namespace (`clojure -M:test -n re-frame.examples-test`) — **PASS** (14 tests, 65 assertions, 0 failures/errors). The `…-tears-down-per-request-frame` / `…-tears-down-on-throw` tests do invoke `handle-request`.
- Full core JVM `:test` alias sweep — **PASS** (1726 tests, 7501 assertions, 0 failures/errors).
- Concrete output check on `handle-request`: `DOCTYPE_COUNT = 1`, `DOCTYPE_INSIDE_APP_DIV = false`.

Note: the SSR example test is JVM (`examples_test.clj`) because `handle-request` is `#?(:clj …)`-only, so it was run via the core `:test` alias rather than `npm run test:cljs`.
