### PR TITLE
docs(routing): clarity pass from adversarial review — runnable tutorial, honest key table, friendlier prose

### DIFF
--- a/docs/api/re-frame.routing.md
+++ b/docs/api/re-frame.routing.md
@@ -44,6 +44,10 @@ The third positional arg is the URL shape — colon-prefixed segments capture in
 | `:on-error` | Event vector dispatched if any `:on-match` event errors. |
 | `:can-leave` | Guard sub-query run before leaving the route. **Closed boolean contract**: `true` allows the navigation, `false` blocks it; any non-boolean value blocks and emits `:rf.error/can-leave-non-boolean`. The sub name reads positively (`:can-leave`), so `false` means "can NOT leave". See [Routing → Blocking a navigation](../routing/concepts.md#blocking-a-navigation). |
 | `:scroll` | Scroll-restoration behaviour for this route. |
+| `:sensitive` | Slice paths (projection-relative, e.g. `[:query :token]`) redacted at egress while the route is active. See [Routing → Keeping tokens off the wire](../routing/concepts.md#keeping-tokens-off-the-wire). |
+| `:large` | Slice paths kept off the wire at egress (a size marker ships instead of the value). |
+
+Two cross-feature bare keys are also accepted when their owning artefact is loaded: `:resources` (the resources artefact's route integration) and `:head` (SSR's head-metadata contract). In an app without the owning artefact they are rejected like any other unknown bare key.
 
 Canonical detail in [The metadata map, in full](../routing/concepts.md#the-metadata-map-in-full) in the routing concept guide.
 

--- a/docs/routing/concepts.md
+++ b/docs/routing/concepts.md
@@ -118,6 +118,8 @@ You've now met the keys you'll reach for daily. The metadata map has thirteen re
 | **Layout** — how the route fits with neighbours | `:doc`, `:parent`, `:tags`, `:scroll` | How the route is described, nested (`:parent`), grouped for interceptors (`:tags`), and scrolled on entry (`:scroll`). |
 | **Classification** — data hygiene | `:sensitive`, `:large` | Which slice values are redacted or kept off the wire at egress while the route is active (see [Data classification](#keeping-tokens-off-the-wire) below). |
 
+Two more bare keys are on loan from other parts of the framework, accepted when their owning artefact is loaded: `:resources` (declared server state — [below](#declaring-resources-instead), owned by the resources artefact) and `:head` (the server-rendered page's [head metadata](../ssr/concepts.md#head-metadata----opengraph-json-ld), owned by SSR). In an app that doesn't load the owning artefact, they're rejected like any other unknown bare key — so a `:resources` declaration can't silently do nothing.
+
 > **Gotcha — typos fail loud, at registration.** Because the shape is large, a typo like `:on-matched` or `:querey` would otherwise be silently accepted and then quietly do nothing forever. So `reg-route` validates its metadata *at the authoring boundary*: a **bare** (unqualified) key outside the reserved set throws `:rf.error/invalid-route-metadata` the instant you register, naming the offending key and the valid vocabulary. Your own extension keys are fine — just namespace them (`:myapp/layout`, `:analytics/id`); namespaced keys are the open-extension surface, bare keys are the framework's reserved vocabulary. And note `:path` belongs in the *third slot*, not the map — leaving it inside the metadata is the same loud error.
 
 When two patterns could both match one URL, a structural ranking breaks the tie: more static segments win, and named params beat splats. The ranking is computed at *registration* time from the patterns alone — so the winner is decided before a single URL ever arrives, and there's no runtime ambiguity to debug.
@@ -149,7 +151,7 @@ The opts map (third slot) is open; the runtime recognises four keys:
 |---|---|
 | `:replace?` | Use `replaceState` instead of `pushState` — for redirects, login-flow returns, and search-as-you-type, where the back button should *not* land on the intermediate URL. |
 | `:query` | The query-string params for the new URL — coerced and emitted as `?key=value`. |
-| `:fragment` | The target `#fragment` (also accepted on the target map). |
+| `:fragment` | The target `#fragment` for the new URL. |
 | `:bypass-leave-guard?` | Skip the current route's `:can-leave` guard for this one navigation (see [Blocking a navigation](#blocking-a-navigation) below). |
 
 Hosts and apps may add their own opts under a namespace.
@@ -182,7 +184,7 @@ For links *in views*, use `route-link`. It renders a real `<a href>` (good for a
 
 Plain `[:a {:href "..."}]` anchors are **not** intercepted; they do a native full-page navigation. Site-wide anchor interception is a host-adapter concern, not framework magic, so you opt in per link (or install your own document-level click handler that dispatches `:rf/url-requested` — the same decision-point event `route-link` uses).
 
-> **`:rf/url-requested` is the policy seam.** Every `route-link` click dispatches `:rf/url-requested`, and *that* event is the single decision point for "in-app or external?", "is the leave-guard satisfied?", and any per-frame policy (auth, modifier keys). It's enumerable and testable with zero DOM: dispatch `[:rf/url-requested {:url "/cart"}]` from a test and assert the result — an in-app request pushes the URL and synthesises the transition; an external one (anything not provably same-origin) emits a `:rf.route/external-url-requested` trace and pushes nothing. Re-registering `:rf/url-requested` is how you install app-wide navigation policy.
+> **`:rf/url-requested` is the policy seam.** Every `route-link` click dispatches `:rf/url-requested`, and *that* event is the single decision point for "in-app or external?", "is the leave-guard satisfied?", and any policy of your own (auth, modifier keys). Because it's an ordinary event, you can drive it from a test with zero DOM: dispatch `[:rf/url-requested {:url "/cart"}]` and assert what happened. An in-app request pushes the URL and runs the route transition. Anything not provably same-origin is treated as external — it emits a `:rf.route/external-url-requested` trace and pushes nothing. Re-registering `:rf/url-requested` is how you install app-wide navigation policy.
 
 ### Navigating to a raw URL string
 
@@ -219,7 +221,7 @@ The current route lives in **runtime-db** — the framework-owned partition besi
 
 Nine subscriptions, every one a plain read — no special routing API in views. `:rf/route` is the whole slice; the rest are projections of it you'll reach for far more often. The [API reference](../api/re-frame.routing.md#subscriptions) lists each with its return shape.
 
-Two of those reads are per-frame singletons, so `re-frame.routing` also ships named read sugar for them: `(routing/sub-route)` over `[:rf/route]` and `(routing/sub-pending-navigation)` over `[:rf/pending-navigation]` — the same reaction, fewer brackets. The vector forms stay canonical; the sugar just tidies the two reads every app makes.
+Two of those you'll read constantly — the whole slice, and the pending navigation — so `re-frame.routing` ships small named helpers for them: `(routing/sub-route)` over `[:rf/route]` and `(routing/sub-pending-navigation)` over `[:rf/pending-navigation]`. Same reaction, fewer brackets. The vector forms stay canonical; the sugar just tidies the two most common reads.
 
 `:transition` is a tiny state machine the runtime drives for you: `:loading` while a route's loaders drain, `:error` if one fails, `:idle` otherwise. So a global progress bar is just a view over `:rf.route/transition`, and an error banner is a view over `:rf.route/error`. You never wire per-page loading state again — it's a property of the slice, the same on every page:
 
@@ -344,7 +346,7 @@ If the page's data is [server state managed as resources](../resources/concepts.
 
 Here's the bug this design quietly kills. On route entry, the runtime marks each listed resource active, owned by the route, keyed by *this navigation's* **nav-token**. On route leave — or the moment a newer navigation supersedes this one — ownership is released by token, and any stale reply that lands late is *suppressed* rather than written. That's the classic race where you click away, an old fetch resolves a beat too late, and clobbers the page you're now looking at. Fixed once, in the substrate, instead of in every page you'll ever write.
 
-> **Going deeper.** The nav-token is a monotonically-allocated identity stamped on each navigation — think of it as a generation counter for "which navigation am I?". Suppression is the *correctness* boundary: a result is written only if its token still matches the live one; otherwise it's dropped. That's the same shape as a compare-and-swap guard, and it's not a `:resources` trick. Any async loader can capture the live nav-token (declare the `:rf.route/nav-token` cofx) and either compare it on receipt or thread it through the `:rf.route/with-nav-token` effect wrapper, which suppresses a result whose token has been superseded. Resources do this for you; hand-rolled loaders opt in. Aborting the in-flight fetch (where the host supports it) is an optional bandwidth optimisation *on top of* suppression — never a substitute for it, because abort isn't guaranteed to win the race.
+> **Going deeper.** The nav-token is just a counter. Every navigation gets the next number, and that number answers "which navigation am I?". Suppression uses it as a receipt check: a result is written only if its token still matches the live navigation's; otherwise it's quietly dropped. And it isn't a `:resources`-only trick. A hand-rolled async loader can capture the live token (declare the `:rf.route/nav-token` cofx) and either compare it when the reply lands, or route the reply through the `:rf.route/with-nav-token` effect wrapper, which does the check for you. Resources do all of this automatically; hand-rolled loaders opt in. If the host can also abort the in-flight fetch, great — that saves bandwidth — but abort is an optimisation *on top of* suppression, never a substitute, because an abort isn't guaranteed to win the race.
 
 When a resource is per-user, scope it with a **named scope resolver**. Register the resolver once, then reference it everywhere as `{:from-db ...}` — so the "who is this for?" logic lives in exactly one place:
 
@@ -363,7 +365,7 @@ When a resource is per-user, scope it with a **named scope resolver**. Register 
  :blocking? false}
 ```
 
-The runtime resolves `{:from-db :realworld/session}` against [app-db](../core/concepts/app-db.md) at route entry. Resolution **fails closed**: logged out, the resolver returns `nil` and the feed is simply *not planned* (surfacing as a route plan error rather than a silent fallback). It never silently falls back to a shared cache, so one user's feed can never leak into another's session. Security by construction, not by remembering to check.
+The runtime resolves `{:from-db :realworld/session}` against [app-db](../core/concepts/app-db.md) at route entry, and the resolution **fails closed**. Logged out, the resolver returns `nil` and the feed simply isn't loaded — that surfaces as a visible route error, never a quiet fall-back to a shared cache. So one user's feed can never leak into another's session. Security by construction, not by remembering to check.
 
 ## Blocking a navigation
 
@@ -432,7 +434,7 @@ A route slice can hold secrets — an OAuth `?token=`, a `?code=` callback param
 
 `:sensitive` redacts a value's content; `:large` keeps a bulky value off the wire (emitting only a size marker). A path declared both lowers as `:sensitive` only. Classification is applied atomically when the route activates and dropped when it changes — so a route declaring none (including `:rf.route/not-found`) clears the previous route's classification cleanly. Crucially, it's *egress-only*: `@(routing/sub-route)` in your running app always returns the real values; only the copies that leave the box are redacted.
 
-> **Gotcha — classify the query key the route promotes.** A `[:query :token]` classification path names the *keyword* `:token`, but the slice only keys a query value as a keyword when the route declares it (in `:query`, `:query-defaults`, or `:query-retain`). Classify a query key the route doesn't promote and the path silently fails open — so `reg-route` emits a `:rf.warning/route-classification-query-key-unpromoted` advisory pointing at the fix: name the key in the `:query` schema. Path params are immune (path captures are always keyword-keyed). And a structurally malformed declaration (a non-vector axis, a bad path segment) fails *loud* at registration with `:rf.error/invalid-route-classification`.
+> **Gotcha — classify only query keys the route declares.** A classification path like `[:query :token]` names the keyword `:token`, and the slice only holds a query value under a keyword when the route declares that key — in `:query`, `:query-defaults`, or `:query-retain`. Classify a key the route never declares and there'd be nothing at that path to redact, so `reg-route` warns (`:rf.warning/route-classification-query-key-unpromoted`) and points at the fix: add the key to the `:query` schema. Path params can't have this problem — captures are always keyword-keyed. And a structurally malformed declaration (a non-vector axis, a bad path segment) fails loud at registration with `:rf.error/invalid-route-classification`.
 
 Routing's classification is the framework-wide [data-classification](../core/glossary.md#data-classification) model applied to the singleton current-route — [Keep secrets out of traces](../core/how-to/keep-secrets-out-of-traces.md) is the full story; routes just declare the paths.
 
@@ -446,7 +448,11 @@ Back/forward, deep links, and the initial page load are all, underneath, URL cha
 (rf/install-history-listener!)
 ```
 
-`:url-bound? true` declares which [frame](../core/concepts/frames.md) — an isolated instance of your app's state (frames isolate state, not registrations) — owns the browser URL. Ownership is always *explicit*, never inferred, and only one frame may hold it (a second frame claiming `:url-bound? true` is a loud `:rf.error/duplicate-url-binding`). Non-owning frames still route internally: a [Story](../core/concepts/observability.md) variant can sit on `/article/intro` without touching your address bar, and a test frame never calls `pushState`. With no declared owner, URL pushes and the popstate listener simply no-op. `install-history-listener!` installs the `popstate` listener (targeted at the owner) and does the initial URL-to-state sync; it's idempotent, so hot-reload is safe, and `rf/remove-history-listener!` tears it down.
+`:url-bound? true` declares which [frame](../core/concepts/frames.md) owns the browser URL. Ownership is always explicit, never inferred. Only one frame may hold it — a second claimant is a loud `:rf.error/duplicate-url-binding` — and having *no* owner is legal too: URL pushes and the popstate listener simply no-op.
+
+Frames without the flag still route internally, in memory. That's a feature, not a gap: a [Story](../core/concepts/observability.md) variant can sit on `/article/intro` without touching your address bar, and a test frame never calls `pushState`.
+
+`install-history-listener!` installs the `popstate` listener (aimed at whichever frame owns the URL) and syncs the URL into state once at startup, so deep links and refreshes land on the right page. It's idempotent — hot-reload can call it again — and `rf/remove-history-listener!` tears it down.
 
 > **From re-frame v1.** This is where the inversion lands hardest. In v1 the browser URL was the source of truth and your router *reacted* to it. Here the frame's state is the source of truth and the URL is a *print-out* of it. So a back-button press is, literally, a dispatch: popstate fires, the URL-change handler runs, the slice updates, the views re-derive. And [time-travel](../core/how-to/debug-with-xray.md) falls out for free — rewind the frame and the URL rewinds with it, because the URL was never truth, only a projection.
 
@@ -486,7 +492,3 @@ This is the payoff of routing having no runtime of its own. During [server-side 
 !!! note "What is client-only"
 
     The URL-push and scroll effects are no-ops on the server, where there's no address bar, and `install-history-listener!` does nothing server-side because there's no popstate to listen to. Everything else — your route table, handlers, loaders, and guards — runs unchanged on both sides. `route-url` and `match-url` are pure and run identically on the JVM, which is exactly why SSR can build links and parse the request URL with the same code.
-
-!!! note "Honest edges, pre-alpha"
-
-    [Nested layouts](#nested-layouts) are data — a `:parent` link plus the `:rf.route/chain` sub — with no React-Router-style `<Outlet/>` render slot; you compose the layout shells in the root view yourself (worked out in the section above). And if your app has exactly one page with no shareable URLs, skip the artefact entirely: it's separately packaged precisely so a non-routing app ships zero routing bytes.

--- a/docs/routing/examples.md
+++ b/docs/routing/examples.md
@@ -4,5 +4,6 @@ Worked routing apps you can read end to end in the repo's example tree.
 
 - **routing** — the smallest app that exercises the whole routing surface: a route table via `reg-route`, navigation-as-event (`:rf.route/navigate`), route reads as plain subs (`:rf.route/id` / `:rf.route/params`), and a root view that switches on the route id. Start here. [→ source](../../examples/capabilities/routing/routing)
 - **realworld** — routing folded into a full Conduit clone: path params and `?page=N` query params, auth-gated routes via an `auth-guard` interceptor, route-driven data loads, and navigation blocking for the unsaved-editor form. See routing working under real load. [→ source](../../examples/real-apps/realworld_http)
+- **realworld_resources** — the same Conduit clone with its server state declared as *resources*: routes plan blocking and background fetches with the `:resources` key, scope the personalised feed per user with a named scope resolver, and guard the editor with `:can-leave`. The route-integration side of [resources](../resources/concepts.md), under the same real load. [→ source](../../examples/real-apps/realworld_resources)
 
 For the underlying ideas, see [Concepts](concepts.md).

--- a/docs/routing/glossary.md
+++ b/docs/routing/glossary.md
@@ -24,6 +24,18 @@ The active URL surfaced as state: read `:rf.route/id`, `:rf.route/params`, and `
 
 What a [route](#route) declares it needs on entry — `:on-match` [events](../core/glossary.md#event) the runtime dispatches, and `:resources` it ensures are loaded — so a page's data requirement lives next to its URL. Loaders run on the server too, so there's no separate SSR data-fetch to keep in sync.
 
+### **route chain**
+
+The active route's ancestry. A route names a `:parent`, and `@(subscribe [:rf.route/chain])` returns the lineage root-most first — on `/articles/intro`, `[:app/articles :app/article]`. It's how shared layouts work without an `<Outlet/>`: the leaf is the page, and each ancestor wraps a shell around it. See [Nested layouts](concepts.md#nested-layouts).
+
+### **transition**
+
+The route slice's loading state — `:idle`, `:loading` (a [loader](#loader) is still running), or `:error` (one failed) — read via `:rf.route/transition`. One global fact instead of per-page loading flags: a progress bar or an error banner is a single view over it.
+
+### **nav-token**
+
+The counter that identifies one navigation. Route-declared resources are owned by the token that planned them, so a reply that lands after a newer navigation is quietly dropped instead of overwriting the page you're now on — the classic click-away race, fixed in the substrate. Hand-rolled loaders opt in via the `:rf.route/nav-token` coeffect.
+
 ### **route guard**
 
 A `:can-leave` guard subscription (strict boolean: `true` means leaving is fine) consulted before leaving a [route](#route); a `false` parks the navigation as *pending* so your [view](../core/glossary.md#view) can render a "discard changes?" prompt, resolved by dispatching `:rf.route/continue` or `:rf.route/cancel`. The idiomatic home for unsaved-changes prompts — gating *entry* (an auth redirect) is an ordinary interceptor over the navigation events instead ([Require sign-in on a route](how-to/require-sign-in-on-a-route.md)).

--- a/docs/routing/index.md
+++ b/docs/routing/index.md
@@ -22,6 +22,7 @@ Because a route's [loader](glossary.md#loader) runs on the server too, routing a
 - **[Tutorial: build a routed app](tutorial.md)** — a three-page app grown one step at a time: routes, links, dynamic segments, loaders, the 404, the Back button, and a shared layout. Start here.
 - **[Concepts](concepts.md)** — the whole model in three moves, then the refinements: query strings, loaders and resources, blocking a navigation, not-found, classification, and running the same handler on the server.
 - **How-to** — [Guard against unsaved changes](how-to/guard-unsaved-changes.md) and [Require sign-in on a route](how-to/require-sign-in-on-a-route.md): one task each, complete code.
+- **[Testing](testing.md)** — the URL codec as pure function calls, navigation through a test frame, deep links and the 404, and the leave guard — all with zero DOM.
 - **[Examples](examples.md)** — runnable routing apps, small and under real load.
 - **[Glossary](glossary.md)** — the section's vocabulary, one definition each.
 - **[Coming from React Router](coming-from-react-router.md)** — the mapping table and the deliberate divergences.

--- a/docs/routing/tutorial.md
+++ b/docs/routing/tutorial.md
@@ -1,6 +1,6 @@
 # Tutorial: build a routed app
 
-The fastest way to understand re-frame2 routing is to build something small and watch each piece arrive on its own. We'll make a three-page app — a **home** page, a **list of articles**, and a **detail** page for one article — then add the touches that make it real: a 404, the Back button, and a shared layout.
+The fastest way to understand re-frame2 routing is to build something small and watch each piece arrive on its own. We'll make a three-page app — a **home** page, a **list of articles**, and a **detail** page for one article — then add the touches that make it real: page data, a 404, the Back button, and a shared layout.
 
 You'll meet every part of routing you reach for daily, one at a time. This page assumes you've done the [core Quickstart](../core/quickstart.md) — you know what an [event](../core/concepts/events-and-the-cascade.md), a [subscription](../core/concepts/subscriptions.md), and a [view](../core/concepts/views.md) are. If you'd rather see the whole model at once, read [Concepts](concepts.md); if you're arriving from React Router, [the mapping](coming-from-react-router.md) may be the faster door.
 
@@ -18,9 +18,9 @@ Routing ships as its own package, `day8/re-frame2-routing`, so an app with no sh
 
 That bare `[re-frame.routing]` require has a side effect: it wires up `reg-route`, the route subscriptions, and `route-link`. Forget it and your first `reg-route` throws `:rf.error/routing-artefact-missing` — a loud error that names exactly what to require, not a silent no-op.
 
-## Step 1 — your first route
+## Step 1 — your first route, on screen
 
-A route is one row in a table: an **id**, a **metadata map**, and a **path**. Register the home page, then render it.
+A route is one row in a table: an **id**, a **metadata map**, and a **path**. Register the home page, give the root view a `case` to pick pages with, and mount the app so you can watch every step from here on:
 
 ```clojure
 ;; 1. Register the route: id, metadata, path.
@@ -33,12 +33,24 @@ A route is one row in a table: an **id**, a **metadata map**, and a **path**. Re
 (rf/reg-view root-view []
   (case @(subscribe [:rf.route/id])
     :app/home [:h1 "Home"]
-    [:h1 "…"]))
+    [:h1 "Nothing here yet"]))   ;; any URL we haven't routed — Step 5 retires this
+
+;; 3. Mount it — the standard mount from the Quickstart, plus two routing
+;;    lines that Step 6 explains properly. (Also requires:
+;;    [reagent.dom.client :as rdc] [re-frame.adapter.reagent :as reagent-adapter])
+(defn run []
+  (rf/init! reagent-adapter/adapter)
+  (rf/install-history-listener!)          ;; ← URL ↔ app wiring — Step 6's subject
+  (rdc/render (rdc/create-root (js/document.getElementById "app"))
+              [rf/frame-provider {:id :rf/default :url-bound? true}  ;; ← and this flag
+               [root-view]]))
 ```
 
 `@(subscribe [:rf.route/id])` reads the id of the route that matches the current URL. The root view is a plain `case` over that id — pick a page, render it. That's the entire "router": no `<Routes>`, no `<Switch>`, no nesting.
 
-**What you see:** at `/`, the page shows **Home**.
+The two routing lines in the mount are `install-history-listener!`, which connects the address bar to the app, and `:url-bound? true`, which says this frame is the one that owns it. Take both on faith for now — Step 6 comes back to them when we wire the Back button.
+
+**What you see:** at `/`, the page shows **Home**. Any other URL shows the placeholder — for now.
 
 ## Step 2 — a second page, and a link between them
 
@@ -60,7 +72,7 @@ Add an articles page, and a link to reach it. Links use `route-link`, which rend
   (case @(subscribe [:rf.route/id])
     :app/home     [home-page]
     :app/articles [articles-page]
-    [:h1 "…"]))
+    [:h1 "Nothing here yet"]))
 ```
 
 `route-link` builds the URL from the route id, so you never hand-write `href="/articles"`. Change the route's path later and every link follows — there's one place the URL is synthesised.
@@ -93,7 +105,7 @@ Link to it by passing `:params`:
 [rf/route-link {:to :app/article :params {:id "intro"}} "Read intro"]
 ```
 
-**What you see:** clicking the link lands on `/articles/intro`, and the page reads **Article intro**.
+**What you see:** clicking the link lands on `/articles/intro`, and the page reads **Article intro**. (Add `:app/article [article-page]` to the root view's `case` — each new page gets its row.)
 
 > **Path params vs query params.** `:params` are the `/segments/` of the path. Query-string values (`?page=2`) are a *separate* map you declare with `:query` and read with `@(subscribe [:rf.route/query])` — the two never merge into one bag. [Concepts → Move 1](concepts.md#move-1-a-route-is-a-registry-entry) covers `:query`, defaults, and carrying global state like `?theme=dark` across pages.
 
@@ -106,21 +118,38 @@ Most pages need data when they open. Declare it next to the route with `:on-matc
   {:params   [:map [:id :string]]
    :on-match [[:app/load-article]]}   ;; dispatched on entry, and on every :id change
   "/articles/:id")
-
-;; A normal event handler. It reads the active id, kicks off a fetch, and
-;; writes into app-db — the same app-db your view already reads.
-(rf/reg-event :app/load-article
-  (fn [{:keys [db]} _]
-    ;; Read the active :id (via a sub, or the :rf.route/params coeffect), start a
-    ;; fetch, and mark the page loading; a later event writes the article to db.
-    {:db (assoc db :article/loading? true)}))
 ```
 
-The view reads the loaded data with an ordinary subscription — there's no special "loader data" hook, because the loader just wrote to [app-db](../core/concepts/app-db.md) like every other event. `:on-match` re-fires when the `:id` changes but *not* when you navigate to the same route with identical params, so you never get an accidental double-load.
+Now the loader itself. It's a normal event handler, with one new thing to learn: it needs the article's `:id`, and that lives in the **route slice**, which the framework keeps in [runtime-db](../core/glossary.md#runtime-db) — its own partition beside your app-db. Handlers receive that partition under the `:rf.db/runtime` key, right next to `:db`:
 
-**What you see:** open one article, then navigate to another — `:app/load-article` fires once per article. Re-navigate to the *same* one and it doesn't fire again. Open [Xray](../core/how-to/debug-with-xray.md) and you'll see exactly those dispatches on the wire.
+```clojure
+(def sample-articles                            ;; stand-in for your server
+  {"intro" {:title "Intro to re-frame2"}
+   "ssr"   {:title "Server rendering"}})
 
-> **This is the loader — as data.** Because `:on-match` is a vector of event vectors rather than a function, you can read it, test it, and draw a route's data-dependency graph from it without running it: `(rf/handler-meta :route :app/article)` hands you the list. And the same events run on the server during [SSR](../ssr/concepts.md) — there's no separate server loader to keep in sync. For server *state* (cached, deduplicated fetches with a built-in click-away race fix), declare `:resources` instead — see [Concepts → Loaders](concepts.md#loaders-declaring-a-pages-data).
+(rf/reg-event :app/load-article
+  (fn [{:keys [db] rt :rf.db/runtime} _]
+    (let [{:keys [id]} (get-in rt [:rf.runtime/routing :current :params])]
+      ;; A real app starts an HTTP fetch here and lets a later event write the
+      ;; reply — see Managed HTTP (../async/http.md). We'll "load" locally.
+      {:db (assoc db :article/current (get sample-articles id))})))
+
+(rf/reg-sub :article/current (fn [db _] (:article/current db)))
+```
+
+And the detail page from Step 3 now reads the loaded article, like any other state:
+
+```clojure
+(rf/reg-view article-page []
+  (let [article @(subscribe [:article/current])]
+    [:h1 (or (:title article) "Loading…")]))
+```
+
+There's no special "loader data" hook, because the loader just wrote to [app-db](../core/concepts/app-db.md) like every other event. And `:on-match` re-fires when the `:id` changes but *not* when you navigate to the same route with identical params, so you never get an accidental double-load.
+
+**What you see:** click through to `/articles/intro` and the title appears. Navigate to another article and the loader fires again with the new id; re-navigate to the *same* one and it doesn't. Open [Xray](../core/how-to/debug-with-xray.md) and you'll see exactly those dispatches on the wire.
+
+> **This is the loader — as data.** Because `:on-match` is a vector of event vectors rather than a function, you can read it, test it, and draw a route's data-dependency graph from it without running it: `(rf/handler-meta :route :app/article)` hands you the list. The same events run on the server during [SSR](../ssr/concepts.md) — there's no separate server loader to keep in sync. For server *state* (cached, deduplicated fetches with a built-in click-away race fix), declare `:resources` instead — see [Concepts → Loaders](concepts.md#loaders-declaring-a-pages-data).
 
 ## Step 5 — when nothing matches: the 404
 
@@ -144,17 +173,17 @@ When no route matches a URL, the runtime activates a reserved id, `:rf.route/not
     :rf.route/not-found [not-found-page]))
 ```
 
+The "Nothing here yet" placeholder arm is gone — and that's the point. Now that `:rf.route/not-found` is registered, every URL lands on a real route id, so the `case` always has a page to pick.
+
 **What you see:** visit `/nonsense` and your own 404 renders, with `/nonsense` shown back to the reader.
 
 > Register it. Skip it and unmatched URLs fall to a bare built-in placeholder (plus a warning) — something renders, but not your design. The not-found params also carry a `:reason` so you can tell a plain miss from a malformed URL from a failed schema; see [Concepts → Not found](concepts.md#not-found-is-a-route-you-register).
 
-## Step 6 — boot it, and wire the Back button
+## Step 6 — the Back button and deep links
 
-Two things are still missing: we haven't actually *started* the app, and the browser's Back button doesn't yet talk to it. Both happen at boot. Routing adds just two things to the standard mount from the [Quickstart](../core/quickstart.md) — the owning [frame](../core/concepts/frames.md) declares `:url-bound? true`, and you call `install-history-listener!`:
+Back in Step 1, the mount had two routing lines you took on faith. Time to cash that in — they're what make the Back button, refreshes, and shared links work:
 
 ```clojure
-;; The mount also needs the standard adapter requires:
-;;   [reagent.dom.client :as rdc] [re-frame.adapter.reagent :as reagent-adapter]
 (defn run []
   (rf/init! reagent-adapter/adapter)
   (rf/install-history-listener!)                     ;; ← Back/Forward + first-load URL sync
@@ -164,9 +193,13 @@ Two things are still missing: we haven't actually *started* the app, and the bro
                [root-view]]))
 ```
 
-`:url-bound? true` says *this* frame owns the URL. `install-history-listener!` does two jobs: it syncs the current URL into state at first load (so a deep link or a refresh lands on the right page), and from then on every Back/Forward press dispatches into the owning frame. It's idempotent, so hot-reload is safe.
+`:url-bound? true` says *this* [frame](../core/concepts/frames.md) owns the browser URL. When it navigates, the address bar updates; a frame without the flag routes purely in memory, which is exactly what a test frame wants.
 
-**What you see:** the app mounts on the route for the current URL. Now navigate Home → Articles → an article, then press Back twice — each press steps the page back, because a Back press is now, literally, a dispatch.
+`install-history-listener!` does two jobs. At startup, it syncs the current URL into state — so a deep link or a refresh lands on the right page instead of always starting at home. From then on, every Back/Forward press is delivered to the owning frame as an ordinary dispatch. It's idempotent, so hot-reload is safe.
+
+**What you see:** paste `/articles/intro` straight into the address bar and the app boots onto that article. Then navigate Home → Articles → an article and press Back twice — each press steps the page back, because a Back press is now, literally, a dispatch.
+
+> **One mount shape, two spellings.** `frame-provider` with `:id` *creates* the frame if it doesn't exist — handy for a small app that boots everything in one spot. Elsewhere you'll see the two-step spelling: `reg-frame` first, then `frame-provider {:frame …}` to scope it. Same frame, same result; the second form just makes the registration explicit.
 
 > **The inversion.** In most routers the URL is the source of truth and your app reacts to it. Here your frame's state is the truth and the URL is a *print-out* of it — which is why [time-travel](../core/how-to/debug-with-xray.md) rewinds the URL for free. [Concepts → The browser is just another event source](concepts.md#the-browser-is-just-another-event-source) goes deeper.
 
@@ -209,6 +242,15 @@ Now `@(subscribe [:rf.route/chain])` returns the active route's ancestry, **root
              (page-for (last chain))         ;; start: the leaf page
              (reverse (butlast chain))))])   ;; wrap: ancestors, innermost first
 ```
+
+If the fold feels abstract, trace it once. On `/articles/intro` the chain is `[:app/articles :app/article]`, so the `reduce` computes:
+
+```clojure
+(ancestor-shell :app/articles (page-for :app/article))
+;; ⇒ [:div.articles-section [:nav "← All articles"] [article-page]]
+```
+
+One wrap, from the inside out. A deeper chain just wraps more times.
 
 **What you see:** on `/articles/intro`, the article renders inside the `← All articles` section nav, under the site header — and every article detail page shares that frame with no copy-paste. Plain `/articles` (no parent above it) shows the bare list; `/` shows the home page. Note the split: truly *global* chrome (the `My Site` header) is just rendered in the root view — you only reach for the chain when a shell wraps a *subtree*.
 


### PR DESCRIPTION
The routing counterpart of the SSR clarity pass (#5100), from an adversarial re-read of all nine routing pages, verified against `spec/012-Routing.md`, `implementation/routing/src/`, the API references, and `examples/capabilities/routing/routing/core.cljs`. Per the brief, the fixes also lean the prose toward a friendlier, less compressed voice.

## Progressiveness (the tutorial didn't run until Step 6)

- **The app now mounts in Step 1.** Previously Steps 1–5 made "What you see" claims while nothing was mounted — Step 6 even opened with "we haven't actually *started* the app". The boot (adapted from the canonical example, same order: `init!` → `install-history-listener!` → render) arrives in Step 1 with the two routing lines explicitly taken on faith, and Step 6 becomes the payoff: deep links, refreshes, and the Back button, explained against code you've been running all along.
- The mystery `[:h1 "…"]` default case-arm (which silently vanished by Step 5) is now an honest placeholder, and Step 5 says out loud why it can go once `:rf.route/not-found` is registered.
- Step 7's `reduce` — the hardest code on the page — now traces its one concrete unfolding for `/articles/intro`.

## Accuracy

- **Step 4's loader was a stub whose comment named a coeffect that doesn't exist.** There is no `:rf.route/params` cofx (the registered route cofx are `:rf.route/nav-token` and `:rf.route/route-id`). The step now shows a complete, runnable handler reading the route slice via `:rf.db/runtime` — the same documented shape concepts' `:on-error` example uses — plus the sub and view that make its "What you see" checkable.
- **Concepts' "The metadata map, in full" omitted two accepted bare keys** — `:resources` and `:head`, the cross-feature reserved keys of spec 012 — despite teaching `:resources` at length later on the same page. A short note after the table now covers them, including that they're rejected when the owning artefact isn't loaded.
- **The API reference's reserved-key table had drifted further** (11 rows): `:sensitive` and `:large` were missing entirely. Added, with the same cross-feature note.
- The unverifiable "`:fragment` (also accepted on the target map)" parenthetical is gone.
- Tutorial and concepts now acknowledge `frame-provider`'s two documented shapes (`:id` creates-or-reuses, `:frame` scopes) instead of each silently using a different one.

## Voice (the explicit brief: not dense, not terse, friendly)

Rewrote the densest passages in plainer sentences, keeping the facts: the nav-token "Going deeper" (was "monotonically-allocated identity… compare-and-swap guard"; now a counter and a receipt check), the `:rf/url-requested` policy seam, the `:url-bound?` ownership paragraph (one 6-clause sentence → three short paragraphs), the scope-resolver fail-closed paragraph, the classification gotcha, and "per-frame singletons" (now just: two reads you'll make constantly, so there's shorthand). The "Honest edges, pre-alpha" endnote was pure repetition of §Nested layouts and Step 0's packaging note — dropped.

## Corpus shape

- **index.md** gains the Testing entry its section map was missing (the page has been in the nav since #5094).
- **examples.md** gains `realworld_resources`, which concepts already pointed readers at twice.
- **glossary** grows route chain, transition, and nav-token (7 → 10 entries), matching the vocabulary the concepts page actually leans on.

Verdict on the page set: right set, no splits or merges — the failures were in-page. `coming-from-react-router.md`, `testing.md`, and both how-tos came through the adversarial read clean and are untouched.

Gates: `mkdocs build --strict` clean; `check_doc_slugs.py` — 506 files, no broken links. The only externally-linked tutorial anchor (`#step-7--a-shared-layout`) is preserved.