### PR TITLE
docs(xray): trim spec-007 keyboard to shipped set (rf2-f7748x)

### DIFF
--- a/tools/xray/spec/007-UX-IA.md
+++ b/tools/xray/spec/007-UX-IA.md
@@ -155,14 +155,13 @@ itself indicates LIVE / RETRO via the head-row pulse / pinned-row
 glyph; the dedicated Mode pill widget was dropped). Classification
 totals live in per-row + per-panel renderings.
 
-Below 1200px viewport: pop-out detaches if user opens it; chrome stays
-within the inline host.
-
-Below 900px viewport: Xray takes 100% of viewport width.
-
-Below 600px viewport (phones): **Xray refuses to mount** (per lock
-#5). The DOM root creates but the visible UI is a single message
-explaining desktop-only.
+The panel width is driven by the drag handle and the
+`--rf-xray-inline-width` host variable, clamped to `[320px, 90vw]`
+(§Resize affordance). There is **no responsive-viewport behaviour** —
+no small-viewport 100%-width takeover and no sub-900px mount guard.
+(See §Trimmed pending demand — the spec once described a 1200px pop-out
+detach, a sub-900px full-width takeover, and a sub-600px "refuses to
+mount" desktop-only guard; none shipped, so all three were trimmed.)
 
 ### Inline host CSS variables
 
@@ -264,7 +263,7 @@ width). Bindings:
 | `Enter` / `Space` | Reset to default (matches double-click) |
 
 Unrecognised keys bubble normally so the surrounding chrome's
-`Ctrl+Shift+C` / `?` / `Esc` shortcuts remain reachable from the
+`Ctrl+Shift+C` / `Esc` shortcuts remain reachable from the
 handle's focus position.
 
 ### Splitter affordance — the L2/L3 seam (rf2-t2dsh)
@@ -328,7 +327,7 @@ height). Bindings:
 | `Enter` / `Space` | Reset to default (matches double-click) |
 
 Unrecognised keys bubble normally — the surrounding chrome's
-`Ctrl+Shift+C` / `?` / `Esc` shortcuts remain reachable from the
+`Ctrl+Shift+C` / `Esc` shortcuts remain reachable from the
 handle's focus position.
 
 #### Rendering
@@ -382,7 +381,7 @@ the filter pills. The nav cluster moved UP to the chrome ribbon; the focus chip 
 | Cluster | Side | Content | Keys |
 |---|---|---|---|
 | **Label** | left | `↳ filters:` (muted) | — |
-| **Filter pills** | left | a `+` add-filter icon + active filter pills (each a removable `<key> ×` chip). Click any pill → edit popup; each pill's `✕` removes it. | `/` focus add-pill |
+| **Filter pills** | left | a `+` add-filter icon + active filter pills (each a removable `<key> ×` chip). Click any pill → edit popup; each pill's `✕` removes it. | — (mouse; the `/` focus-add-pill key was trimmed — see §Trimmed pending demand) |
 | **Hidden** | far right | `N events filtered out` count, only when N > 0. | — |
 
 Full anatomy + filter-pill edit popup in
@@ -529,7 +528,6 @@ functional semantic colours):
 | Issue tint / trailing `⚠` | the row's epoch carries an error/warning issue | a subtle row tint + small trailing marker (not a new column); navigates to Issues for that epoch |
 | `[● REDACTED N]` | event arg-map carries `:rf/redacted` | magenta trailing marker |
 | `[● ELIDED N]` | event arg-map carries `:rf.size/large-elided` | yellow trailing marker |
-| pin marker `↺` | pinned cascade | small trailing modifier on the row |
 
 These are right-anchored, subordinate to the four data columns — they reinforce, never replace,
 the table.
@@ -1184,73 +1182,51 @@ the rule now applies to the spine's head-row cue.
 
 ## Keyboard
 
-Every layer is keyboard-reachable. Chrome tab order: ribbon (L1) →
-event list (L2) → tab bar (L3) → detail panel (L4 — focus enters the
-active panel). `Esc` always returns focus to the event list.
+Every layer is keyboard-reachable via ordinary Tab focus order: ribbon
+(L1) → event list (L2) → tab bar (L3) → detail panel (L4 — focus enters
+the active panel).
 
-### Global shortcuts
+The shipped key set is deliberately **small** and lives in two scopes,
+matching the global keydown listener in
+`tools/xray/src/day8/re_frame2_xray/keybinding.cljs` (the code is the
+contract for this section — trim any spec drift back to it):
 
-| Key | Action |
-|---|---|
-| `Ctrl+Shift+C` | Toggle Xray visibility |
-| `Ctrl+Shift+M` / `Cmd+Shift+M` | Toggle Dynamic ↔ Static mode (`keybinding/mode-toggle-key?`, rf2-o5f5f.1) |
-| `?` | Keyboard cheat-sheet |
-| `,` or `s` | Settings popup |
-| `Esc` | Close modal / collapse popover / focus event list |
-| `Ctrl+K` / `Cmd-K` | Command palette |
-| `Ctrl+F` | Find within active tab |
-| `o` | Popout (`window.open` whole shell) |
+- **Global chords** fire anywhere on the page (capture-phase listener).
+- **Shell spine keys** are bare unmodified keys that fire **only** when
+  the Xray shell is visible AND the keydown target is inside the shell
+  DOM tree AND the target is not an editable element (`<input>` /
+  `<textarea>` / `<select>` / contenteditable) AND not inside a modal
+  (Settings / palette). Those guards keep the bare letters from
+  stealing keystrokes from the host app, from text fields, and from a
+  modal's own inner mnemonics (per spec/018 §3 + §6 and rf2-ttnst).
 
-### Ribbon nav cluster
+### Global chords
 
-| Key | Action |
-|---|---|
-| `j` | Back one event (= `◀`) |
-| `k` | Forward one event (= `▶`) |
-| `G` | Fast-forward to latest (= `⏭`, snap LIVE) |
-| `Space` | Pause/resume LIVE feed |
-| `L` | Snap to LIVE (jump to head) |
+| Key | Action | Predicate |
+|---|---|---|
+| `Ctrl+Shift+C` | Toggle Xray shell visibility (CSS display flip) | `keybinding/xray-toggle-key?` |
+| `Ctrl+Shift+M` / `Cmd+Shift+M` | Toggle Dynamic ↔ Static mode (rf2-o5f5f.1) | `keybinding/mode-toggle-key?` |
+| `Ctrl+K` / `Cmd+K` | Command palette (opens the shell first if hidden) | `keybinding/palette-toggle-key?` |
+| `Esc` | Dismiss the open-in-editor hint toast when it is open (rf2-wpvy6f). Every modal (Settings, command palette, filter edit-popup, …) closes on its own `Esc` handler, not this global listener. | `keybinding/escape-key?` |
 
-### Event list (L2)
+### Shell spine keys
 
-| Key | Action |
-|---|---|
-| `j` / `k` | Next / previous (alias of ribbon nav) |
-| `J` / `K` | Cascade-root skip |
-| `g g` / `G` | Top / bottom |
-| `Enter` | Activate (= click row) |
-| `[` / `]` | Previous / next (10x parity = `j`/`k`) |
-| `*` | Pin a cascade (session-scoped) |
-| `r` | Rewind to before this event (calls `restore-epoch`) |
-| `R` | Re-dispatch this event |
-| `o` | Open source in editor |
-| `/` | Focus filter add-pill |
-| `Ctrl+click` | Copy cascade-id |
+Bare, unmodified keys — only inside the visible shell, never on an
+editable or modal target (see the scope guards above). Per spec/018 §3
++ §6.
 
-### Tab bar (L3)
+| Key | Action | Event dispatched |
+|---|---|---|
+| `Space` | Pause / resume the LIVE feed | `:rf.xray/toggle-live-pause` |
+| `l` | Snap to LIVE (follow the head) | `:rf.xray/follow-head` |
+| `Shift+G` | Fast-forward to head ("go to head") | `:rf.xray/follow-head` |
+| `j` | Step back one event (cascade-prev) | `:rf.xray/focus-cascade-prev` |
+| `k` | Step forward one event (cascade-next) | `:rf.xray/focus-cascade-next` |
+| `,` or `s` | Toggle the Settings popup | `:rf.xray/settings-toggle` |
 
-| Key | Tab |
-|---|---|
-| `1` | Epoch |
-| `2` | App-db |
-| `3` | Views |
-| `4` | Trace |
-| `5` | Machines |
-| `6` | Routes |
-| `e` | Epoch (mnemonic) |
-| `a` | App-db (mnemonic) |
-| `v` | Views (mnemonic — incl. subs nested under each view) |
-| `t` | Trace (mnemonic) |
-| `m` | Machines (mnemonic) |
-| `r` | Routes (mnemonic) |
-| `Ctrl+→` / `Ctrl+←` | Next / previous tab |
-
-### Detail panel (L4)
-
-| Key | Action |
-|---|---|
-| `Tab` / `Shift+Tab` | Cycle focusables |
-| `Esc` | Return focus to event list |
+Everything else — tab switching, rewind, re-dispatch, filter focus — is
+a click or a **command-palette** verb (`Cmd/Ctrl+K` finds any action by
+name). There is deliberately no dedicated key for those actions in v1.
 
 ### Machines canvas (rf2-y3l8z)
 
@@ -1261,6 +1237,38 @@ click-drag, and the xyflow `<Controls>` buttons only. The earlier
 host) was pre-xyflow SVG-renderer fiction and did not survive the
 rf2-gpzb4 migration (rf2-oc0fwy audit). A keyboard zoom/pan surface
 would be a new feature, not a documented-existing one.
+
+### Trimmed pending demand (rf2-f7748x — the POST-FREEZE upgrade path)
+
+Earlier drafts of this section specified a much larger keyboard model
+than the shipped listener implements. Mike RULED Option B (2026-07-03):
+**trim the spec to the shipped set** rather than build out the rest.
+The drift itself was the defect — it surfaced from a docs review, not
+from any missing-key complaint, so the shipped set is evidently
+sufficient. The following keys were specified here (and some in the
+Settings key-catalogue) but were **never implemented** and have been
+removed:
+
+| Trimmed key | Was going to | Why unimplemented / removed |
+|---|---|---|
+| `e` `a` `v` `t` `m` `r` (tab mnemonics) | Jump to Epoch / app-db / Views / Trace / Machines / Routes tab | No handler in `keybinding.cljs`; tab-jump is a palette verb. |
+| `1`–`6` (tab numbers) | Jump to the Nth L3 tab | Never wired. |
+| `Ctrl+→` / `Ctrl+←` | Cycle to next / previous tab | Never wired. |
+| `r` | Rewind to before this event (`restore-epoch`) | Never wired as a key. |
+| `R` | Re-dispatch this event | Never wired; no implementation at all. |
+| `*` | Pin a cascade (session-scoped) | Dead — the pin store was removed per spec/014. |
+| `/` | Focus the filter add-pill | Never wired. |
+| `?` | Keyboard cheat-sheet modal | The cheat-sheet modal itself was never built. |
+| `o` | Popout / open source in editor | Never wired as a key. |
+| `Ctrl+F` | Find within the active tab | Never wired. |
+| `J` `K` / `g g` / `[` `]` | Cascade-root skip / top-bottom / 10× step | Never wired; superseded by the `j`/`k` spine pair. |
+| sub-900px viewport takeover · sub-600px "refuses to mount" guard | Responsive-viewport behaviour (§Layout) | No breakpoint / `matchMedia` mount guard in the code. |
+
+**This is the documented Option-C upgrade path.** Any trimmed key is a
+small **feature bead** away from returning — file one with actual
+demand behind it, implement the handler in `keybinding.cljs`, and add
+the row back here in the same PR. Pre-alpha posture (avoid
+over-engineering, no demand today) is why none is being built now.
 
 ### Retired keys (from pre-rewrite spec)
 
@@ -1564,14 +1572,14 @@ active `:rf.xray/mode`. Items missing `:modes` fall through to
 both modes (the legacy contract — every item used to be visible
 always).
 
-The L4 tab-jump items are mode-aware so the **same mnemonic
-letter** dispatches the active mode's tab. `m` in Dynamic jumps to
-the Machines instance-inspector; `m` in Static jumps to the
-Machines registry browse. The mnemonic chord — `e` (Events) · `m`
-(Machines) · `r` (Routes/Routing) · `c` (Schemas — Static only) ·
-`v` (Views) — works inside the palette and bare on the spine
-because both consult the active mode (see §Static mode for the
-mnemonics inventory).
+The L4 tab-jump items are mode-aware so the **same palette entry**
+dispatches the active mode's tab. Searching `machines` in the palette
+jumps to the Machines instance-inspector in Dynamic and to the Machines
+registry browse in Static, because the aggregator consults the active
+`:rf.xray/mode`. (The tab-jump verbs live only in the command palette —
+the bare-letter tab mnemonics `e`/`a`/`v`/`t`/`m`/`r` that earlier
+drafts also fired directly on the spine were trimmed; they are not
+wired in `keybinding.cljs`. See §Trimmed pending demand.)
 
 ### Command verbs (rf2-ybjkx)
 
@@ -1648,12 +1656,14 @@ to localStorage alongside the other Xray settings.
 
 ## Modal layers
 
-Three modal surfaces float over the chrome:
+Two modal surfaces float over the chrome:
 
 1. **Command palette** — 560px centred.
-2. **Keyboard cheat-sheet** (`?`) — 480px modal listing every
-   shortcut.
-3. **Settings** (`,` or `s` or `⚙`) — 560×640px modal with 6 sections.
+2. **Settings** (`,` or `s` or `⚙`) — 560×640px modal.
+
+(The `?` keyboard cheat-sheet modal was trimmed — it was specified but
+never built; the command palette is the discoverability surface. See
+§Trimmed pending demand.)
 
 ### Shared modal-chrome scaffold (rf2-7oxvd)
 
@@ -1689,13 +1699,14 @@ untouched.
 
 ## Discoverability
 
-Three layers, no onboarding tour:
+Two layers, no onboarding tour:
 
-1. **The `?` cheat-sheet.** Modal showing every shortcut.
-2. **Empty-state hints.** Each empty state shows a contextual keyboard
+1. **Empty-state hints.** Each empty state shows a contextual keyboard
    hint.
-3. **The command palette itself.** Typing `?` in the palette filters
-   to commands and shows their shortcuts.
+2. **The command palette (`Cmd/Ctrl+K`) itself.** Fuzzy-find any action
+   by name — the palette is the primary discoverability surface now
+   that the standalone `?` cheat-sheet modal is trimmed (§Trimmed
+   pending demand).
 
 ## Bundle splitting
 

--- a/tools/xray/spec/018-Event-Spine.md
+++ b/tools/xray/spec/018-Event-Spine.md
@@ -460,7 +460,7 @@ The single-line row drops detail the round-1 two-line row used to carry. Every r
 │ src/cart/events.cljs:213                                            │
 │ args  {:order-id 92 :attempt 2}                                     │
 │ ────                                                                │
-│ click row to focus · `o` open source · ctrl+click copy id           │
+│ click row to focus · click the source coord to open in editor       │
 └─────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -1665,17 +1665,19 @@ Every Settings popup field maps to a `(xray-config/configure! {…})` key. See [
 
 ## §11 Keyboard map
 
-Complete map for the spine + chrome:
+Complete map for the spine + chrome. This mirrors the SHIPPED set in
+`tools/xray/src/day8/re_frame2_xray/keybinding.cljs`; the canonical
+narrative is [`007-UX-IA.md` §Keyboard](./007-UX-IA.md#keyboard)
+(including its §Trimmed pending demand log of the keys removed under
+rf2-f7748x — tab mnemonics, tab numbers, `Ctrl`+arrows, `r`/`R`, `*`,
+`/`, `?`, `o`, `Ctrl+F`, `J`/`K`/`g g`/`[`/`]`).
 
 | Region | Keys |
 |---|---|
-| **Ribbon nav cluster** | `j` back-one-event · `k` forward-one-event · `G` fast-forward-to-latest (= `⏭`, snap LIVE) |
-| **Event list (L2)** | `j` / `k` next/prev (alias of ribbon nav) · `J` / `K` cascade-root skip · `g g` / `G` top/bottom · `Enter` activate · `Space` pause auto-scroll · `[` / `]` (10x parity = `j`/`k`) · `*` pin · `r` rewind · `R` re-dispatch · `o` open source · `/` focus filter add-pill |
-| **Tab bar (L3)** | `1`–`6` jump to tab N · `Ctrl+→` / `Ctrl+←` next/prev tab · letter mnemonics: `e` Event · `a` App-db · `v` Views (incl. subs nested under each view) · `t` Trace · `m` Machines · `r` Routing. (`i` Issues was removed per rf2-gbz39 Option (c); `i` is released to the global namespace.) |
-| **Detail panel (L4)** | `Tab` / `Shift+Tab` cycle focusables · `Esc` returns focus to event list |
-| **Mode + scrubbing** | `Space` pause/resume LIVE · `L` snap to LIVE (jump to head) · `←` / `→` step one cascade (= `j`/`k`) · `Shift+←` / `Shift+→` step cascade root · `Home` / `End` oldest/newest. (The dedicated Mode pill widget was dropped — the L2 spine itself indicates LIVE / LIVE-paused / RETRO; only the widget is gone.) |
+| **Spine keys (inside the shell, non-editable, non-modal)** | `Space` pause/resume LIVE · `l` snap to LIVE (follow head) · `Shift+G` fast-forward to head · `j` step back one event · `k` step forward one event · `,` or `s` settings popup |
+| **Detail panel (L4)** | `Tab` / `Shift+Tab` cycle focusables (ordinary browser focus order) |
 | **Surface toggle** | `Cmd-Shift-M` (macOS) / `Ctrl+Shift+M` (every other host) toggles between **Dynamic** and **Static** surfaces (per Lock #14 in [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md) + §Static surface below). Dispatches `:rf.xray/toggle-mode` against the `:rf/xray` frame. Mode pill at ribbon-left mirrors the toggle (chord + pill share the handler). |
-| **Global** | `Ctrl+Shift+C` toggle Xray visibility · `Cmd-K` / `Ctrl+K` palette · `?` cheat-sheet · `,` or `s` settings popup (= `⚙`) · `o` popout (= `⛶`) · `Esc` close modal / return to canvas |
+| **Global** | `Ctrl+Shift+C` toggle Xray shell visibility · `Cmd-K` / `Ctrl+K` command palette · `Esc` dismiss the open-in-editor hint (modals close on their own Esc) |
 
 ### Retired keys (from pre-rewrite spec)
 
@@ -1684,7 +1686,7 @@ Complete map for the spine + chrome:
 - `c` (Causality tab) — Causality surface dropped entirely (rf2-y0z5b); `c` is unused.
 - `p` (Performance) — Performance panel dropped; `p` unused (available for future tab if added).
 - `w` (Flows) — Flows folded into Views; `w` unused.
-- ~~`r` (Routes panel) — Routes folded into App-db~~. **Restored** (rf2-nrbs9): Routing got promoted back to its own L3 tab (cohesive sub-domains earn their own lens tab). `r` is now the **Routing tab** mnemonic; the event-list `r` rewind binding stays on the L2 event list scope (the L2 list's key handler wins when focus is in the list; the tab-bar's letter mnemonic wins when focus is elsewhere).
+- `r` — neither the **Routing tab** mnemonic nor the event-list rewind binding is wired as a key (both were trimmed under rf2-f7748x — see §Complete map above + [`007-UX-IA.md` §Trimmed pending demand](./007-UX-IA.md#trimmed-pending-demand-rf2-f7748x--the-post-freeze-upgrade-path)). Routing is still its own L3 tab (rf2-nrbs9, reached by click or command palette); the rewind *feature* still ships as the Epoch-panel button + `:rf.xray/reset-to-epoch` — only the `r` key is gone.
 - `S` (Schemas) — schema violations surface inline in the Epoch panel's EFFECT HANDLERS step (rf2-kt6js); `S` unused.
 - `h` (Hydration) — hydration mismatches surface via the L2 event-row signal + the issues ribbon; `h` unused.
 - `i` (Issues) — the Issues tab was removed per rf2-gbz39 (Option (c)); issues surface inline in the Epoch panel + the L2 event-row pink-wash + the always-on issues ribbon signal; `i` unused.

--- a/tools/xray/spec/DESIGN-RATIONALE.md
+++ b/tools/xray/spec/DESIGN-RATIONALE.md
@@ -193,7 +193,16 @@ Does Xray support mobile / tablet / phone viewports?
 
 ### Pick
 
-**Desktop only.** Below 600px, Xray refuses to mount.
+**Desktop only** — no mobile / tablet / phone re-layout is built.
+
+> **Trimmed (rf2-f7748x, Mike ruled Option B 2026-07-03):** the
+> sub-900px full-width takeover and the sub-600px "refuses to mount"
+> guard described below were **never implemented** — there is no
+> `matchMedia` breakpoint or mount guard in the code. The desktop-only
+> stance is enforced simply by not building mobile support, not by an
+> active viewport guard. See [007-UX-IA.md §Layout](007-UX-IA.md) +
+> §Trimmed pending demand. The guard can return as a small feature bead
+> if a real narrow-viewport failure mode is observed.
 
 ### Why
 
@@ -206,8 +215,9 @@ Does Xray support mobile / tablet / phone viewports?
 - Mobile support adds significant UX surface (touch gestures,
   responsive layout, a separate compact density tier) for narrow
   benefit.
-- The 600px refusal is user-friendly: instead of cramping the panel,
-  Xray says "this is a desktop debugger" and gets out of the way.
+- A 600px refuse-to-mount message would be user-friendly if narrow
+  viewports were a real failure mode — but no such guard was built
+  (rf2-f7748x): the desktop-only decision holds without it.
 
 ### Date locked
 

--- a/tools/xray/spec/README.md
+++ b/tools/xray/spec/README.md
@@ -27,10 +27,12 @@ main read**.
 ### Per-tab content specs
 
 - **[002-Time-Travel.md](002-Time-Travel.md)** — Time-travel scrubber:
-  passive scrubbing rebases panels; explicit `r` rewinds the runtime; six
-  named restore failures surface as a modal. Pins survive ring-buffer
-  age-out. Future: branch-and-explore; "find me when path P last changed"
-  walker.
+  passive scrubbing rebases panels; explicit rewind (the Epoch-panel
+  button → `:rf.xray/reset-to-epoch`) rewinds the runtime; six named
+  restore failures surface as a modal. (The `r` rewind *key* was trimmed
+  under rf2-f7748x — see [007-UX-IA.md §Trimmed pending demand](007-UX-IA.md);
+  the rewind feature itself ships.) Future: branch-and-explore; "find me
+  when path P last changed" walker.
 - **[003-Machine-Inspector.md](003-Machine-Inspector.md)** — The Machines
   tab. **Event-driven Dynamic panel** (rf2-y9xmf): BLANK when the focused
   event has no machine activity; per-machine section when it did

--- a/tools/xray/src/day8/re_frame2_xray/settings/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/settings/view.cljs
@@ -745,43 +745,24 @@
 
 (def ^:private keybinding-rows
   "Static catalogue. Group key carries a section label; rows are
-  `[chord action]` pairs. Mirrors the tables in spec/007-UX-IA.md
-  §Keyboard."
-  [{:group "Global shortcuts"
-    :rows  [["Ctrl+Shift+C" "Toggle Xray visibility"]
-            ["?"            "Keyboard cheat-sheet"]
-            [", or s"       "Settings popup"]
-            ["Esc"          "Close modal / collapse popover / focus event list"]
-            ["Ctrl+K / ⌘K"  "Command palette"]
-            ["Ctrl+F"       "Find within active tab"]
-            ["o"            "Popout (window.open whole shell)"]]}
-   {:group "Ribbon nav cluster"
-    :rows  [["j"     "Back one event (◀)"]
-            ["k"     "Forward one event (▶)"]
-            ["G"     "Fast-forward to latest (⏭, snap LIVE)"]
-            ["Space" "Pause/resume LIVE feed"]
-            ["L"     "Snap to LIVE (jump to head)"]]}
-   {:group "Event list (L2)"
-    :rows  [["j / k"      "Next / previous"]
-            ["J / K"      "Cascade-root skip"]
-            ["g g / G"    "Top / bottom"]
-            ["Enter"      "Activate (= click row)"]
-            ["[ / ]"      "Previous / next (10x parity)"]
-            ["*"          "Pin a cascade (session-scoped)"]
-            ["r"          "Rewind to before this event"]
-            ["R"          "Re-dispatch this event"]
-            ["o"          "Open source in editor"]
-            ["/"          "Focus filter add-pill"]
-            ["Ctrl+click" "Copy cascade-id"]]}
-   {:group "Tab bar (L3)"
-    :rows  [["1-6"             "Switch tab by index"]
-            ["e"               "Epoch tab"]
-            ["a"               "App-db tab"]
-            ["v"               "Views tab"]
-            ["t"               "Trace tab"]
-            ["m"               "Machines tab"]
-            ["r"               "Routes tab"]
-            ["Ctrl+→ / Ctrl+←" "Next / previous tab"]]}
+  `[chord action]` pairs. Mirrors the SHIPPED set in
+  `keybinding.cljs` + the tables in spec/007-UX-IA.md §Keyboard —
+  trimmed to exactly what the global listener captures (rf2-f7748x,
+  Mike ruled Option B). Any trimmed key returns as a small feature
+  bead + a new row here; do NOT list keys the listener does not
+  actually bind."
+  [{:group "Global chords"
+    :rows  [["Ctrl+Shift+C"      "Toggle Xray shell visibility"]
+            ["Ctrl+Shift+M / ⌘⇧M" "Toggle Dynamic ↔ Static mode"]
+            ["Ctrl+K / ⌘K"       "Command palette"]
+            ["Esc"               "Dismiss the open-in-editor hint (modals close on their own Esc)"]]}
+   {:group "Shell spine keys (inside the shell, non-editable)"
+    :rows  [["Space"   "Pause / resume LIVE feed"]
+            ["l"       "Snap to LIVE (follow the head)"]
+            ["Shift+G" "Fast-forward to head"]
+            ["j"       "Step back one event"]
+            ["k"       "Step forward one event"]
+            [", or s"  "Settings popup"]]}
    {:group "Settings popup (modal-only)"
     :rows  [["g" "General tab"]
             ["k" "Keybindings tab"]


### PR DESCRIPTION
Implements **rf2-f7748x** — Mike ruled **Option B (trim)**: bring the Xray keyboard spec in line with what the shipped listener (`tools/xray/src/day8/re_frame2_xray/keybinding.cljs`) actually binds, rather than build out the larger spec'd model. The drift itself was the defect (it surfaced from a docs review, not from any missing-key complaint), so the shipped set is evidently sufficient.

## What ships (verified ground-truth from `keybinding.cljs`)

- **Global chords:** `Ctrl+Shift+C` (toggle shell), `Cmd/Ctrl+Shift+M` (Dynamic↔Static), `Cmd/Ctrl+K` (command palette), `Esc` (dismiss the open-in-editor hint; modals close on their own Esc).
- **Shell spine keys** (inside the shell, non-editable, non-modal): `Space`, `l`, `Shift+G`, `j`, `k`, `,`/`s`.
- **Settings modal-only inner mnemonics** (unchanged, genuinely shipped): `g`/`k`/`b`/`d`.

## Keys removed from spec + Settings catalogue (never wired)

tab mnemonics `e`/`a`/`v`/`t`/`m`/`r` · tab numbers `1`–`6` · `Ctrl+→`/`Ctrl+←` cycling · `r` rewind · `R` re-dispatch · `*` pin (dead — pin store removed per spec/014) · `/` filter-focus · `?` cheat-sheet (the modal was never built) · `o` popout/open-source · `Ctrl+F` find · `J`/`K`/`g g`/`[`/`]` navigation · the sub-900px full-width takeover + sub-600px "refuses to mount" guard (no `matchMedia`/breakpoint in the code).

**Features whose only KEY was trimmed still ship** via button / click / command palette: rewind (Epoch-panel button → `:rf.xray/reset-to-epoch`), open-in-editor (click the source coord), the Routing L3 tab. Only the key binding is gone.

## Trimmed pending demand (the Option-C upgrade path)

A new `### Trimmed pending demand` section in spec 007 records every removed key as the documented POST-FREEZE path: any key returns as a small feature bead with real demand behind it — implement the handler in `keybinding.cljs` and add the row back in the same PR.

## Files changed

- `tools/xray/spec/007-UX-IA.md` — trimmed the §Keyboard tables to the shipped set; added §Trimmed pending demand; removed the responsive-viewport prose (§Layout); dropped the `?` cheat-sheet from Modal layers + Discoverability; fixed the L2 pin-marker row, the resize/seam keyboard-contract prose, the L1.5 `/` ribbon cell, and the mode-aware palette-mnemonic "bare on the spine" claim.
- `tools/xray/src/day8/re_frame2_xray/settings/view.cljs` — rewrote the static `keybinding-rows` catalogue (the Settings → Keybindings read-only table data) to the shipped set. Catalogue data only; no `keybinding.cljs` behaviour change.
- `tools/xray/spec/018-Event-Spine.md` — trimmed the duplicate complete-key-map + the stale `r` retired-keys note; pointed at 007 §Keyboard as canonical.
- `tools/xray/spec/README.md` — fixed the 002-Time-Travel index summary (`r` rewind key → button).
- `tools/xray/spec/DESIGN-RATIONALE.md` — corrected the desktop-only lock so it no longer asserts a shipped 600px mount guard.

Isolated surface (tools/xray). No `keybinding.cljs` change — spec/catalogue trim only.

## Quality gates

- **Xray artefact JVM tests** (`clojure -M:test` in `tools/xray/`): **PASS** — 1217 tests, 5643 assertions, 0 failures, 0 errors.
- **Xray feature-matrix gate** (`npm run test:xray-feature-gate` from `implementation/`): **PASS** — 16 scenarios, 0 failures, 13 matrix rows covered; all 11 surfaces compiled with 0 warnings (incl. `panel-gallery`, which mounts the edited Settings popup).
- **Residue grep** over the tracked `tools/xray/` tree (src + test + spec, excluding the historical `spec/findings/` design notes): no remaining live references to the removed keys outside the intentional §Trimmed pending demand log. No tests assert on the removed catalogue rows or renamed group labels.
