### PR TITLE
feat(routing): :rf.route/self + :query-merge navigate-in-place (rf2-ue2d4t)

### DIFF
--- a/docs/routing/concepts.md
+++ b/docs/routing/concepts.md
@@ -145,16 +145,33 @@ You navigate with the same verb you use for everything else, which is the whole 
 (rf/dispatch [:rf.route/navigate :app/article {:id "intro"} {:fragment "section-2"}])
 ```
 
-The opts map (third slot) is open; the runtime recognises four keys:
+The opts map (third slot) is open; the runtime recognises these keys (the canonical enumeration lives in [Spec 012 §The `navigate` opts](../../spec/012-Routing.md), which this table mirrors):
 
 | Opt | Effect |
 |---|---|
 | `:replace?` | Use `replaceState` instead of `pushState` — for redirects, login-flow returns, and search-as-you-type, where the back button should *not* land on the intermediate URL. |
-| `:query` | The query-string params for the new URL — coerced and emitted as `?key=value`. |
+| `:query` | The query-string params for the new URL — coerced and emitted as `?key=value`. Replaces the query wholesale. |
+| `:query-merge` | Fold these deltas into the **current** query instead of replacing it — the "stay here, change these params" move for search, pagination, and tabs. A `nil` value **removes** a key. Pairs with the `:rf.route/self` target (see [Navigate-in-place](#navigate-in-place) below). |
+| `:scroll` | Per-call override of the route's `:scroll` strategy (`:top` / `:restore` / `:preserve`; see [Fragments and scrolling](#fragments-and-scrolling)). |
 | `:fragment` | The target `#fragment` for the new URL. |
 | `:bypass-leave-guard?` | Skip the current route's `:can-leave` guard for this one navigation (see [Blocking a navigation](#blocking-a-navigation) below). |
 
 Hosts and apps may add their own opts under a namespace.
+
+<a id="navigate-in-place"></a>
+#### Navigate-in-place: change the query, stay on the route
+
+Changing `?page=`, a search term, or a tab means *stay on this route, change these query params* — the most common URL operation there is. Reach for the reserved `:rf.route/self` target and `:query-merge`:
+
+```clojure
+;; On /search?q=clojure&page=1  →  /search?q=clojure&page=2
+(rf/dispatch [:rf.route/navigate :rf.route/self {} {:query-merge {:page 2}}])
+
+;; Clear a filter: a nil value removes the key  →  /search?q=clojure
+(rf/dispatch [:rf.route/navigate :rf.route/self {} {:query-merge {:page nil}}])
+```
+
+`:rf.route/self` resolves to the route you're already on (id + path params, read from the current slice), so you never hand-roll a "read the route, branch on the id, rebuild the query" helper. `:query-merge` folds your deltas onto the current query — caller values win, a `nil` drops a key. It works with any target, but `:rf.route/self` is its natural partner. (`:query` *replaces* the whole query; `:query-merge` *edits* it — pick by whether you're building a fresh query or nudging the current one.)
 
 > **From re-frame v1.** `useNavigate`-style imperative calls and `secretary`'s `(set! js/window.location ...)` both become an ordinary `dispatch`. That means navigation is now *interceptable* and *replayable* like any other event — a navigate shows up in [Xray](../core/glossary.md#xray) on the same wire as your business events, and time-travel rewinds it for free, because it was never a side-channel. And this holds for **hash-URL apps too** — the shape most secretary-era apps have. Declare `:url-strategy rf/hash-url-strategy` on your URL-owning frame and the router speaks `#/…` at the edges (link hrefs, history, the URL-change listener) while `route-url` / `match-url` stay path-form; you use `:rf.route/navigate` and `route-link` exactly as a path-URL app does. There is no `(set! js/window.location.hash …)` side-channel left to write. See [URL strategies](#url-strategies) below.
 

--- a/implementation/routing/src/re_frame/routing/navigate.cljc
+++ b/implementation/routing/src/re_frame/routing/navigate.cljc
@@ -157,9 +157,35 @@
                   {:where 'rf.route/navigate-handler})
           opts (or opts {})
           rdb  (or rdb-raw {})
+          ;; The current route slice (durable framework runtime-db fact).
+          ;; Read once here so the `:rf.route/self` identity-on-route target
+          ;; and the `:query-merge` opt both resolve against it (rf2-ue2d4t).
+          current (get-in rdb [:rf.runtime/routing :current])
           {:keys [route-id path-params query-params matched-fragment unmatched-url
                   throw-reason requested-url external-url-target?]}
           (cond
+            ;; rf2-ue2d4t — Spec 012 §Navigation is an event §Reserved
+            ;; targets §:rf.route/self. `:rf.route/self` is a reserved
+            ;; navigate target that means "stay on the CURRENT route,
+            ;; change only these query params" — the single most common URL
+            ;; operation (search, pagination, tabs). It is a documented,
+            ;; semantically-honest exception to enumerable route-id targets:
+            ;; identity-on-route. It resolves `:route-id` + `:path-params`
+            ;; from the current slice (the path is held fixed — self-nav
+            ;; never re-threads path params; the 2nd `params` arg is ignored
+            ;; for a self target, so the classic `{}` placeholder is
+            ;; correct). Query starts from `(:query opts)` exactly like a
+            ;; route-id target — the `:query-merge` opt below then folds the
+            ;; caller's deltas into the CURRENT query. Before the first
+            ;; navigation there is no current route; `:route-id` is nil and
+            ;; the `route-url` build fails closed to a rejected navigation
+            ;; (`:rf.error/no-such-route`), the same as any unresolvable
+            ;; target.
+            (= :rf.route/self target)
+            {:route-id     (:route-id current)
+             :path-params  (or (:params current) {})
+             :query-params (:query opts {})}
+
             (keyword? target)
             {:route-id     target
              :path-params  (or params {})
@@ -289,6 +315,31 @@
                                       retain-keys))
           query-params (if (seq retained)
                          (merge retained query-params)
+                         query-params)
+          ;; rf2-ue2d4t — Spec 012 §Navigation is an event §The :query-merge
+          ;; opt. `:query-merge` folds the caller's deltas into the CURRENT
+          ;; route's `:query` slice — the "stay here, change these query
+          ;; params" primitive (search, pagination, tabs). It REUSES the
+          ;; same read-and-merge machinery `:query-retain` uses above:
+          ;; the current query is read from the durable slice
+          ;; (`[:rf.runtime/routing :current :query]`, i.e. `current`),
+          ;; not built afresh. Precedence, low→high: current query → any
+          ;; already-resolved `query-params` (`:query` opt + retained
+          ;; keys) → the `:query-merge` deltas — so an explicit delta wins.
+          ;; A `nil` value REMOVES a key from the result (both the pushed
+          ;; URL and the written slice), matching `route-url`'s query
+          ;; nil-elision policy (rf2-w3qgc): eliding here keeps the slice
+          ;; clean rather than carrying a `{:page nil}` the URL omits. A
+          ;; present-but-FALSY value (`false`, `0`, `""`) is a legitimate
+          ;; value and survives, same as `route-url`. `:query-merge` is
+          ;; target-agnostic — it works with any target — but its natural
+          ;; pairing is `:rf.route/self`, where the current route IS the
+          ;; target. When `:query-merge` is absent the query resolves
+          ;; exactly as before (no current-query base is folded in).
+          query-params (if-let [merge-in (:query-merge opts)]
+                         (into {}
+                               (remove (comp nil? val))
+                               (merge (:query current) query-params merge-in))
                          query-params)
           ;; Per Spec 012 §Param validation at the call site: the
           ;; event-boundary path `[:rf.route/navigate ...]` runs the

--- a/implementation/routing/test/re_frame/routing_navigation_test.clj
+++ b/implementation/routing/test/re_frame/routing_navigation_test.clj
@@ -1320,3 +1320,191 @@
           "control: :rf.route/activated DOES fire from an emitting frame")
       (is (some #(= :rf.route/deactivated (:operation %)) @app-traces)
           "control: :rf.route/deactivated DOES fire from an emitting frame"))))
+
+;; ---- rf2-ue2d4t — Spec 012 §:rf.route/self + §The :query-merge opt --------
+
+(defn- nav-slice
+  "The current route slice for the default frame."
+  []
+  (get-in (rf/runtime-db-value :rf/default) [:rf.runtime/routing :current]))
+
+(deftest routing-self-target-stays-on-current-route
+  (testing ":rf.route/self resolves to the CURRENT route's id + path-params"
+    ;; Per Spec 012 §:rf.route/self — navigate-in-place. A self-nav holds the
+    ;; route (path) fixed and changes only the query; the 2nd params slot is
+    ;; ignored.
+    (rf/reg-route :route/article
+                  {:params [:map [:id :string]]
+                   :query  [:map [:tab {:optional true} :string]]}
+                  "/articles/:id")
+    (let [pushed (atom [])]
+      (rf/reg-fx :rf.nav/push-url
+                 {:platforms #{:server :client}}
+                 (fn [_ url] (swap! pushed conj url)))
+      ;; Land on /articles/intro?tab=notes.
+      (rf/dispatch-sync [:rf.route/transitioned "/articles/intro?tab=notes"])
+      (is (= :route/article (:route-id (nav-slice))))
+      (is (= {:id "intro"} (:params (nav-slice))))
+      ;; Self-nav changing only the query; params slot is {}.
+      (reset! pushed [])
+      (rf/dispatch-sync [:rf.route/navigate :rf.route/self {} {:query {:tab "history"}}])
+      (is (= :route/article (:route-id (nav-slice)))
+          ":rf.route/self keeps the current route-id")
+      (is (= {:id "intro"} (:params (nav-slice)))
+          ":rf.route/self keeps the current path-params (path held fixed)")
+      (is (= {:tab "history"} (:query (nav-slice)))
+          "the query changed to the supplied :query")
+      (is (= ["/articles/intro?tab=history"] @pushed)
+          "the pushed URL keeps the path and carries the new query"))))
+
+(deftest routing-query-merge-folds-into-current-query
+  (testing ":query-merge folds deltas into the CURRENT query, keeping the rest"
+    (rf/reg-route :route/search
+                  {:query [:map [:q {:optional true} :string]
+                                [:page {:optional true} :int]
+                                [:sort {:optional true} :string]]}
+                  "/search")
+    (let [pushed (atom [])]
+      (rf/reg-fx :rf.nav/push-url
+                 {:platforms #{:server :client}}
+                 (fn [_ url] (swap! pushed conj url)))
+      ;; Land on /search?q=clojure&page=1&sort=recent.
+      (rf/dispatch-sync [:rf.route/transitioned "/search?q=clojure&page=1&sort=recent"])
+      (is (= {:q "clojure" :page 1 :sort "recent"} (:query (nav-slice))))
+      ;; Merge :page 2 — q + sort ride along.
+      (reset! pushed [])
+      (rf/dispatch-sync [:rf.route/navigate :rf.route/self {} {:query-merge {:page 2}}])
+      (is (= {:q "clojure" :page 2 :sort "recent"} (:query (nav-slice)))
+          ":query-merge changes :page, keeps :q + :sort from the current query")
+      (let [url (last @pushed)]
+        (is (re-find #"page=2" url) "the new :page is in the URL")
+        (is (re-find #"q=clojure" url) "the untouched :q rides along")
+        (is (re-find #"sort=recent" url) "the untouched :sort rides along")))))
+
+(deftest routing-query-merge-nil-removes-a-key
+  (testing "a nil :query-merge value REMOVES a key from the slice AND the URL"
+    ;; Per Spec 012 §The :query-merge opt: a nil value drops a key, matching
+    ;; route-url's query nil-elision. The slice must be clean too (no {:sort
+    ;; nil}) so a self-nav to the same query is a genuine no-op.
+    (rf/reg-route :route/search
+                  {:query [:map [:q {:optional true} :string]
+                                [:sort {:optional true} :string]]}
+                  "/search")
+    (let [pushed (atom [])]
+      (rf/reg-fx :rf.nav/push-url
+                 {:platforms #{:server :client}}
+                 (fn [_ url] (swap! pushed conj url)))
+      (rf/dispatch-sync [:rf.route/transitioned "/search?q=clojure&sort=recent"])
+      (reset! pushed [])
+      ;; Remove :sort via a nil value.
+      (rf/dispatch-sync [:rf.route/navigate :rf.route/self {} {:query-merge {:sort nil}}])
+      (is (= {:q "clojure"} (:query (nav-slice)))
+          ":sort is removed from the slice (no {:sort nil} residue)")
+      (is (not (contains? (:query (nav-slice)) :sort))
+          ":sort key is absent, not nil-valued")
+      (let [url (last @pushed)]
+        (is (re-find #"q=clojure" url) ":q survives")
+        (is (not (re-find #"sort" url)) ":sort is gone from the URL")))))
+
+(deftest routing-query-merge-preserves-falsy-values
+  (testing "a present-but-falsy :query-merge value survives (only nil removes)"
+    ;; false / 0 / "" are legitimate values, same as route-url.
+    (rf/reg-route :route/search
+                  {:query [:map [:page {:optional true} :int]
+                                [:flag {:optional true} :string]]}
+                  "/search")
+    (let [pushed (atom [])]
+      (rf/reg-fx :rf.nav/push-url
+                 {:platforms #{:server :client}}
+                 (fn [_ url] (swap! pushed conj url)))
+      (rf/dispatch-sync [:rf.route/transitioned "/search?page=1"])
+      (reset! pushed [])
+      ;; page 0 is falsy-but-legitimate; flag "" is an explicit empty value.
+      (rf/dispatch-sync [:rf.route/navigate :rf.route/self {} {:query-merge {:page 0 :flag ""}}])
+      (is (= 0 (:page (:query (nav-slice))))
+          "page=0 (falsy) survives the merge")
+      (is (= "" (:flag (:query (nav-slice))))
+          "flag=\"\" (empty string) survives the merge")
+      (is (re-find #"page=0" (last @pushed))
+          "page=0 is emitted in the URL"))))
+
+(deftest routing-query-merge-caller-delta-wins
+  (testing "an explicit :query-merge delta overrides the current query value"
+    (rf/reg-route :route/search
+                  {:query [:map [:page {:optional true} :int]]}
+                  "/search")
+    (let [pushed (atom [])]
+      (rf/reg-fx :rf.nav/push-url
+                 {:platforms #{:server :client}}
+                 (fn [_ url] (swap! pushed conj url)))
+      (rf/dispatch-sync [:rf.route/transitioned "/search?page=5"])
+      (reset! pushed [])
+      (rf/dispatch-sync [:rf.route/navigate :rf.route/self {} {:query-merge {:page 6}}])
+      (is (= 6 (:page (:query (nav-slice))))
+          "the :query-merge delta wins over the current :page=5"))))
+
+(deftest routing-query-merge-works-with-route-id-target
+  (testing ":query-merge is target-agnostic — folds current query into another route"
+    ;; Per Spec 012 §The :query-merge opt: :query-merge works with any target.
+    ;; Navigating to a DIFFERENT route folds the current query into that
+    ;; route's outgoing query (subject to the target's :query schema).
+    (rf/reg-route :route/a
+                  {:query [:map [:theme {:optional true} :string]]} "/a")
+    (rf/reg-route :route/b
+                  {:query [:map [:theme {:optional true} :string]
+                                [:page {:optional true} :int]]} "/b")
+    (let [pushed (atom [])]
+      (rf/reg-fx :rf.nav/push-url
+                 {:platforms #{:server :client}}
+                 (fn [_ url] (swap! pushed conj url)))
+      (rf/dispatch-sync [:rf.route/transitioned "/a?theme=dark"])
+      (reset! pushed [])
+      (rf/dispatch-sync [:rf.route/navigate :route/b {} {:query-merge {:page 3}}])
+      (is (= :route/b (:route-id (nav-slice))) "navigated to the other route")
+      (is (= {:theme "dark" :page 3} (:query (nav-slice)))
+          "current query (:theme) folded in, plus the :page delta"))))
+
+(deftest routing-self-before-first-nav-rejects
+  (testing ":rf.route/self before any navigation fails closed (no current route)"
+    ;; Per Spec 012 §:rf.route/self: before the first navigation there is no
+    ;; current route; route-id resolves to nil and the navigation is rejected
+    ;; (slice unchanged, no push), the same fail-closed reject as any
+    ;; unresolvable target.
+    (let [pushed  (atom [])
+          errors  (atom [])]
+      (rf/reg-fx :rf.nav/push-url
+                 {:platforms #{:server :client}}
+                 (fn [_ url] (swap! pushed conj url)))
+      (rf/register-listener! :trace ::self-reject
+                             (fn [ev] (when (= :error (:op-type ev))
+                                        (swap! errors conj ev))))
+      (rf/dispatch-sync [:rf.route/navigate :rf.route/self {} {:query-merge {:page 1}}])
+      (rf/unregister-listener! :trace ::self-reject)
+      (is (empty? @pushed)
+          "no URL is pushed for a self-nav with no current route")
+      (is (nil? (:route-id (nav-slice)))
+          "the route slice stays empty (unchanged)")
+      (is (some #(= :rf.error/schema-validation-failure (:operation %)) @errors)
+          "a rejection error is emitted (route-url could not resolve nil route-id)"))))
+
+(deftest routing-self-query-merge-no-op-when-unchanged
+  (testing "self + :query-merge to the SAME query is a rule-3 no-op"
+    ;; Per Spec 012 §Per-route data loading rule 3: a navigation whose
+    ;; resolved id/params/query/fragment match the current slice exactly is a
+    ;; no-op — no fresh nav-token, no push. Eliding nil-valued merge keys from
+    ;; the SLICE (not just the URL) is what makes this hold.
+    (rf/reg-route :route/search
+                  {:query [:map [:page {:optional true} :int]]} "/search")
+    (let [pushed (atom [])]
+      (rf/reg-fx :rf.nav/push-url
+                 {:platforms #{:server :client}}
+                 (fn [_ url] (swap! pushed conj url)))
+      (rf/dispatch-sync [:rf.route/transitioned "/search?page=2"])
+      (let [token-before (:nav-token (nav-slice))]
+        (reset! pushed [])
+        ;; Merge :page 2 while already on page 2 → no-op.
+        (rf/dispatch-sync [:rf.route/navigate :rf.route/self {} {:query-merge {:page 2}}])
+        (is (empty? @pushed)
+            "a self-nav to the identical query pushes no URL (rule-3 no-op)")
+        (is (= token-before (:nav-token (nav-slice)))
+            "the nav-token is unchanged (no fresh epoch)")))))

--- a/spec/012-Routing.md
+++ b/spec/012-Routing.md
@@ -360,6 +360,10 @@ A **malformed** declaration (a non-vector axis, a non-sequential path entry, a n
                                     [:? :map]      ;; params
                                     [:? :map]]}    ;; opts
   (fn handler-route-navigate [{rt :rf.db/runtime} [_ target params opts]]
+    ;; `resolve-target` is the pure target-resolution step — route-id /
+    ;; `:rf.route/self` / `{:url ...}` form dispatch + the query-shaping
+    ;; layers (`:query-retain`, `:query-merge`). Specified in
+    ;; §`resolve-target` below.
     (let [{:keys [route-id path-params query-params fragment]} (resolve-target target params opts rt)
           route-meta (rf/handler-meta :route route-id)
           url        (rf/route-url route-id path-params query-params fragment)
@@ -390,12 +394,21 @@ Three effect categories flow:
 
 The order is locked: state changes first, URL update second, then `:on-match` dispatches and scroll effect. If the URL update fails (browser denies, user is offline) the state is still consistent.
 
-The trailing `opts` map is open. The pattern recognises:
-- `:replace?` (use `replaceState` rather than `pushState` — for redirects, search-as-you-type filters, login-flow returns where the back button should not return to the intermediate URL).
-- `:scroll` (per-call override of the route's `:scroll` metadata; same enum/map shape, see "Scroll restoration").
-- `:fragment` (target `#fragment` for the new URL; see "Fragments" below). May also be supplied as `:fragment` on the target map.
-- `:bypass-leave-guard?` (skip the active route's `:can-leave` gate for this navigation; see [§Navigation blocking](#navigation-blocking--pending-nav-protocol)).
-- Hosts may add their own keys under a chosen namespace.
+<a id="the-navigate-opts--canonical-list"></a>
+##### The `navigate` opts — canonical list
+
+The trailing `opts` map (the **third** positional slot; see [§Arities](#arities--params-is-2nd-opts-is-3rd)) is open. This table is the **single canonical enumeration** of the keys the runtime recognises — the docs guide references it rather than re-listing, so the two never drift:
+
+| Opt | Effect |
+|---|---|
+| `:replace?` | Use `replaceState` rather than `pushState` — for redirects, search-as-you-type filters, and login-flow returns where the back button should not land on the intermediate URL. |
+| `:query` | The **query-string params** for the new URL — coerced against the target route's `:query` schema and emitted as `?key=value`. This is the query slot for the `[:rf.route/navigate target params opts]` form (path params ride the 2nd slot). |
+| `:query-merge` | Fold the given deltas into the **current** route's `:query` slice, rather than replacing it — the "stay here, change these query params" primitive (search, pagination, tabs). A `nil` value **removes** a key (matching `route-url`'s query nil-elision; see [§Bidirectional URL ↔ params](#bidirectional-url--params)). Its natural pairing is the [`:rf.route/self`](#rfrouteself--navigate-in-place) target. See [§The `:query-merge` opt](#the-query-merge-opt--navigate-in-place). |
+| `:scroll` | Per-call override of the route's `:scroll` metadata; same enum/map shape (see [§Scroll restoration](#scroll-restoration)). |
+| `:fragment` | Target `#fragment` for the new URL (see [§Fragments](#fragments)). May also be supplied as `:fragment` on the target map. |
+| `:bypass-leave-guard?` | Skip the active route's `:can-leave` gate for this navigation (see [§Navigation blocking](#navigation-blocking--pending-nav-protocol)). |
+
+Hosts and apps may add their own keys under a chosen namespace. Only `:replace?`, `:scroll`, `:fragment`, and `:bypass-leave-guard?` are treated as **opts-only** for the params/opts swap check (see [§Arities](#arities--params-is-2nd-opts-is-3rd)); `:query` and `:query-merge` are not, because a route may legitimately capture a path segment of that name.
 
 ##### Arities — params is 2nd, opts is 3rd
 
@@ -409,14 +422,64 @@ The event vector has two trailing **maps** in fixed positions — `params` secon
 
 At a call site `[:rf.route/navigate :route/x {...}]` the `{...}` is **path-params**, not opts. The classic mistake is dropping an opts-shaped map into the params slot — `[:rf.route/navigate :route/cart {:replace? true}]` *reads* like "navigate with these opts" but is parsed as "navigate with path-param `:replace?`". The runtime **rejects this swap**: when an opts-only key (`:replace?`, `:scroll`, `:fragment`, `:bypass-leave-guard?`) appears in the params slot and is **not** a declared path-param of the target route, navigation is rejected (slice unchanged, no URL push) and `:rf.error/navigate-arity-misuse` (`:where :event`) is emitted naming the misplaced key. A route that *legitimately* captures a path segment named `:fragment` (`"/anchor/:fragment"`) is not false-flagged — the key is a declared path-param, not a misplaced opt. To pass opts, use the explicit three-arity form with an empty (or real) params map: `[:rf.route/navigate :route/cart {} {:replace? true}]`.
 
-#### Target form — route-id vs URL-string
+The [`:rf.route/self`](#rfrouteself--navigate-in-place) reserved target uses the same three-arity form — `[:rf.route/navigate :rf.route/self {} {:query-merge {…}}]` — where the 2nd slot is an ignored `{}` placeholder (self-nav never re-threads path params) and the opts carry the query change.
 
-`:rf.route/navigate`'s second arg is one of two forms (per the schema's `[:or :keyword [:map [:url :string]]]`):
+#### Target form — route-id, URL-string, or reserved
+
+`:rf.route/navigate`'s second arg (`target`) is one of three forms (per the schema's `[:or :keyword [:map [:url :string]]]` — the reserved-target form is a distinguished keyword, so it fits the `:keyword` branch):
 
 - **Route-id (canonical):** `(rf/dispatch [:rf.route/navigate :route/cart {:cart-id 42}])`. The runtime resolves the route, builds the URL via `route-url`, and pushes. This is the form Construction-Prompts and well-formed app code use.
 - **URL-string (escape hatch):** `(rf/dispatch [:rf.route/navigate {:url "/some/path"}])`. For dynamic or user-supplied URLs the app didn't build itself — deep-link handlers, server-redirect targets, programmatic redirects from a string. The runtime calls `match-url` on the string; if it resolves to a registered route, navigation proceeds normally. URL-strings that don't match any registered route resolve to `:rf.route/not-found` with the URL in `params`, and the runtime pushes the **requested URL** to the address bar (not the not-found route's own `:path`) — the user keeps the URL they aimed at while the not-found view renders, exactly as the URL-driven not-found path leaves the requested URL in place. A miss with no `:rf.route/not-found` route registered still commits the not-found slice and emits the `:rf.warning/no-not-found-route` trace (per [§Route-not-found](#route-not-found--rfroutenot-found-canonical)); it is not rejected.
+- **Reserved `:rf.route/self` (navigate-in-place):** `(rf/dispatch [:rf.route/navigate :rf.route/self {} {:query-merge {:page 2}}])`. Stay on the current route, changing only the query (or fragment). See [§`:rf.route/self` — navigate-in-place](#rfrouteself--navigate-in-place) below.
 
 The route-id form is preferred everywhere it can be used because the route-id is enumerable, refactorable, and queryable through the registrar. URL-strings are stringly-typed escape-hatchy by nature; tooling can flag them as candidates for migration to a registered route-id when the URL pattern is known.
+
+<a id="rfrouteself--navigate-in-place"></a>
+##### `:rf.route/self` — navigate-in-place
+
+`:rf.route/self` is a **reserved navigate target** meaning *stay on the current route; change only these query params (or fragment)*. It is the single most common URL operation — search, pagination, tab switches, filter toggles — where the route (path) is unchanged and only the query string moves. Without it, an app hand-rolls a runtime-db-reading helper: read the current route-id and path-params out of the slice, branch on the id to re-thread the path params, and rebuild the query — all to change `?page=N`. React Router does this in one `setSearchParams` call; `:rf.route/self` is the re-frame2 equivalent, paired with the [`:query-merge` opt](#the-query-merge-opt--navigate-in-place).
+
+It is a **documented, semantically-honest exception** to the "targets are enumerable route-ids" rule: `:rf.route/self` is not a registered route, it is the reserved identity-on-route sentinel. Resolution:
+
+- **`:route-id` and path-`:params`** are read from the **current** route slice (`[:rf.runtime/routing :current]`). The path is held fixed — `:rf.route/self` never re-threads path params, so the **2nd `params` slot is ignored** (pass `{}`, the canonical placeholder). To change path params, navigate to the route-id form instead.
+- **Query** starts from `(:query opts)` (empty by default) exactly like a route-id target; the [`:query-merge` opt](#the-query-merge-opt--navigate-in-place) then folds the caller's deltas into the **current** query.
+- **Fragment** resolves as for any target (`:fragment` opt, else the current fragment is *not* carried — a self-nav that omits `:fragment` clears it, matching a route-id nav; supply `:fragment` to set one).
+- The resolved route-id's `:query` schema still validates the merged query at the call site (per [§Param validation at the call site](#param-validation-at-the-call-site)), and `:query-retain` on the resolved route still applies. Scroll, `:can-leave`, the rule-3 no-op short-circuit, and nav-token allocation all behave exactly as for the equivalent route-id nav.
+- **Before the first navigation** there is no current route: `:route-id` resolves to `nil` and the `route-url` build fails closed to a rejected navigation (`:rf.error/schema-validation-failure` wrapping `:rf.error/no-such-route`; slice unchanged, no push) — the same fail-closed reject as any unresolvable target.
+
+<a id="the-query-merge-opt--navigate-in-place"></a>
+##### The `:query-merge` opt — navigate-in-place
+
+`:query-merge` is a navigate **opt** (third slot) that folds the given deltas into the **current** route's `:query` slice, rather than replacing it. It is the "change these query params, keep the rest" primitive:
+
+```clojure
+;; On /search?q=clojure&page=1&sort=recent  →  /search?q=clojure&page=2&sort=recent
+(rf/dispatch [:rf.route/navigate :rf.route/self {} {:query-merge {:page 2}}])
+
+;; Remove a key: nil value drops it  →  /search?q=clojure&page=2
+(rf/dispatch [:rf.route/navigate :rf.route/self {} {:query-merge {:sort nil}}])
+```
+
+Semantics:
+
+- **Base is the current query.** The merge reads the current `:query` slice from the runtime-db (`[:rf.runtime/routing :current :query]`) — the **same read-and-merge machinery `:query-retain` uses** — and folds the deltas on top. Precedence, low→high: current query → any already-resolved query (`:query` opt + `:query-retain` keys) → the `:query-merge` deltas. An explicit delta wins.
+- **A `nil` value REMOVES a key** from the result — from both the pushed URL and the written slice — matching `route-url`'s query nil-elision (see [§Bidirectional URL ↔ params](#bidirectional-url--params)). Eliding here (rather than writing `{:sort nil}` into the slice and relying on `route-url` to drop it at emission) keeps the slice consistent with the URL: a self-nav to the same query is a genuine rule-3 no-op. A present-but-**falsy** value (`false`, `0`, `""`) is a legitimate value and survives, same as `route-url`.
+- **Target-agnostic.** `:query-merge` works with any target — its natural pairing is `:rf.route/self` (where the current route *is* the target), but `[:rf.route/navigate :route/other {} {:query-merge {…}}]` folds the current query into the *other* route's outgoing query too (subject to that route's `:query` schema). When `:query-merge` is absent the query resolves exactly as before — no current-query base is folded in.
+
+`:query-merge` is **not** treated as an opts-only key for the params/opts swap check (a route may legitimately capture a path segment named `:query-merge`), identical to `:query`.
+
+<a id="resolve-target"></a>
+##### `resolve-target` — the target-resolution contract
+
+The navigate handler resolves its `target`/`params`/`opts` triple into a `{:route-id :path-params :query-params :fragment}` shape through **`resolve-target`** (referenced in the handler sketch above). It is a **pure** function of the target triple plus the current route slice — no side effects, no dispatch. It dispatches on the `target` form:
+
+| `target` form | `:route-id` | `:path-params` | `:query-params` |
+|---|---|---|---|
+| **route-id** `:route/x` | the route-id | the 2nd `params` slot | `(:query opts)` |
+| **reserved** `:rf.route/self` | the **current** slice's `:route-id` | the **current** slice's `:params` (2nd slot ignored) | `(:query opts)` |
+| **URL-string** `{:url s}` | `match-url`'s route-id (or `:rf.route/not-found` on a miss / open-redirect / throw) | `match-url`'s params (or `{:url s}` on a miss) | `match-url`'s query |
+
+After the form dispatch, `resolve-target` applies the query-shaping layers uniformly: `:query-retain` on the resolved route (verbatim carry from the current slice — see [§`:query-retain` cross-route coercion class](#query-retain-cross-route-coercion-class)), then the [`:query-merge`](#the-query-merge-opt--navigate-in-place) fold (current-query base, nil removes a key). Fragment resolves from `:fragment` opt → target-map `:fragment` → URL-embedded fragment (`match-url`), normalised so an empty-string fragment collapses to nil. `resolve-target` performs **no** validation and **no** URL build — those happen downstream (`route-url` at the call site raises the structured caller-bug error, which the handler catches and rejects). This keeps `resolve-target` a pure planning step: given the same triple and slice it always yields the same resolved shape, on JVM and CLJS alike.
 
 ### URL changes are events
 


### PR DESCRIPTION
Implements bead **rf2-ue2d4t** — Mike ruled **OPTION A** (navigate-in-place) plus the unconditional doc fix.

## What ships

**1. Reserved `:rf.route/self` navigate target (navigate-in-place).**
`(dispatch [:rf.route/navigate :rf.route/self {} {:query-merge {:page 2}}])` stays on the current route and changes only the query/fragment — the single most common URL operation (search, pagination, tabs). It resolves `:route-id` + path-`:params` from the current slice (path held fixed; the 2nd `params` slot is ignored, so `{}` is the canonical placeholder). A documented, semantically-honest exception to enumerable route-id targets: identity-on-route. Before the first navigation there is no current route → `:route-id` is nil and the build fails closed to a rejected navigation (`:rf.error/schema-validation-failure` wrapping `:rf.error/no-such-route`; slice unchanged, no push), the same fail-closed reject as any unresolvable target.

**2. `:query-merge` opt.** Folds the caller's deltas into the **current** route's `:query` slice — REUSING the same read-and-merge machinery `:query-retain` already uses (`get-in rdb [:rf.runtime/routing :current :query]`), not a parallel mechanism. Precedence low→high: current query → resolved `:query`/`:query-retain` → `:query-merge` deltas (explicit delta wins). A **nil value REMOVES a key** — from both the pushed URL AND the written slice (eliding at the merge, not just relying on `route-url`'s emission-time nil-elision, so a self-nav to the same query is a genuine rule-3 no-op). A present-but-falsy value (`false`/`0`/`""`) survives, matching `route-url`. Target-agnostic; natural partner is `:rf.route/self`.

**3. Unconditional doc fix (ships regardless of the ruling).**
- The navigate opts list was duplicated and DISAGREEING (spec/012 had `:scroll` but not `:query`; docs/routing had `:query` but not `:scroll`). Now PINNED in ONE canonical place — **spec/012** (the normative artefact) — as a table including `:replace?`, `:query`, `:query-merge`, `:scroll`, `:fragment`, `:bypass-leave-guard?`. `docs/routing/concepts.md` mirrors it and cross-links to it, so the two can't drift.
- **`resolve-target`** — referenced in the handler sketch but never specified — is now SPECIFIED as the pure target-resolution contract (route-id / `:rf.route/self` / `{:url ...}` form dispatch table + the `:query-retain` and `:query-merge` query-shaping layers), with a pointer from the handler sketch.

## Public-API surface

No new facade symbols — `:rf.route/self` is a keyword sentinel and `:query-merge` an opt key, both interpreted inside the already-manifested `:rf.route/navigate` event. `git diff` on navigate.cljc confirms no new `def`/`defn`. **No manifest drift.** `:rf.route/self` lives in the already-reserved `:rf.route/*` namespace (Conventions.md).

## Quality gates

- **Routing `clojure -M:test` (full JVM suite):** 360 tests, 1551 assertions, **0 failures, 0 errors**.
- **`npm run test:cljs` (node CLJS gate):** 8040 tests, 36935 assertions, **0 failures, 0 errors** — confirms the `.cljc` navigate handler compiles + behaves under CLJS (cross-host).
- **`mkdocs build --strict`:** exit 0, no WARNING/ERROR on the changed files (spec/012 + docs/routing staged; new anchors + the docs→spec cross-link resolve).
- **Public-API manifest drift-check:** N/A — no new public symbol (see above).

**Adversarial/negative fixtures added** (`routing_navigation_test.clj`): `:query-merge` folds into the current query (untouched keys ride along); a **nil value REMOVES a key** from slice + URL (no `{:k nil}` residue); a falsy value survives; caller delta wins; `:rf.route/self` resolves to the current route id + path-params; `:query-merge` with a route-id target (target-agnostic); self-before-first-nav rejects; self+`:query-merge` to the same query is a rule-3 no-op (nav-token unchanged, no push).

Out of scope (per the bead): rewriting realworld's hand-rolled helper — this PR ships the mechanism + doc pin only.