### PR TITLE
feat(machines): :rf/spawned clear-on-exit + websocket rewrite (rf2-yh21ah)

### DIFF
--- a/docs/machines/actors.md
+++ b/docs/machines/actors.md
@@ -19,7 +19,7 @@ Here's the heart of the [websocket example](../../examples/patterns/websocket/):
 ```clojure
 (rf/reg-machine :ws/connection
   {:initial :disconnected
-   :data    {:url nil :auth-token nil :socket-id nil}
+   :data    {:url nil :auth-token nil}
    :states
    {:disconnected
     {:on {:ws/connect {:target :active :action :record-opts}}}
@@ -120,30 +120,38 @@ A freshly-spawned actor needs a first nudge. Two ways:
 
 ## Recording the spawned id
 
-You will reach for `:on-spawn` to "capture the child's id into `:data`" — and it won't work. `:on-spawn` is an **advisory observation hook**: the runtime calls it with `{:data <parent-data> :id <new-id>}` and **drops its return value**. Writing `(assoc data :pending id)` records nothing (and emits a `:rf.warning/on-spawn-return-ignored` in dev). The runtime already tracks the id for you; you don't need `:on-spawn` for destroy to work.
+You will reach for `:on-spawn` to "capture the child's id into `:data`" — and it won't work. `:on-spawn` is an **advisory observation hook**: the runtime calls it with `{:data <parent-data> :id <new-id>}` and **drops its return value**. Writing `(assoc data :pending id)` records nothing (and emits a `:rf.warning/on-spawn-return-ignored` in dev). The runtime already tracks the id for you — so there's no self-dispatch dance to write, and no side-channel atom either.
 
-When you *do* need the id addressable by name, the first-class mechanisms (in order of preference):
+There are **two** first-class mechanisms; reach for whichever fits.
 
-1. **`:system-id`** — give the spawn a stable name; resolve and message it by that name (see [below](#cross-machine-messaging)). Best when you want a *role* rather than a gensym.
-2. **The `:rf/spawned` `:data` slot** — on every declarative `:spawn`, the runtime binds the new id into the *spawning* machine's own `:data` under `{:rf/spawned {<invoke-id> <actor-id>}}`. A later action reads it: `(get-in data [:rf/spawned [:active]])`. The id rides the revertible snapshot, not a live object reference.
-3. **Self-dispatch from `:on-spawn`** — since `:on-spawn` *can* fire a side-effecting dispatch (just not return data), have it dispatch a self-event whose ordinary `:action` writes the id. This is the verified [websocket](../../examples/patterns/websocket/) pattern:
+### 1. The `:rf/spawned` `:data` slot (read the id in-snapshot)
+
+On every declarative `:spawn` / `:spawn-all`, the pure transition reducer binds the new actor's id into the *spawning* machine's own `:data` under the reserved per-invoke map `:rf/spawned` — `{:rf/spawned {<invoke-id> <actor-id>}}`, keyed by the absolute path of the `:spawn`-bearing state. A later action reads it straight off its own `:data`:
 
 ```clojure
 :active
 {:spawn {:machine-id :websocket/socket
-         :data       (fn [{snap :snapshot}] {:url (-> snap :data :url)})
-         ;; :on-spawn can't write :data (return dropped), but it CAN
-         ;; fire an event whose transition records the id the normal way.
-         :on-spawn   (fn [{id :id}]
-                       (when-let [dispatch! (re-frame.late-bind/get-fn :router/dispatch!)]
-                         (dispatch! [:ws/connection [:ws/-socket-spawned id]]
-                                    {:source :websocket})))}
- :on {:ws/-socket-spawned {:action :record-socket-id}}}
-
-;; ... and the ordinary action that does the assoc:
-:record-socket-id (fn [{data :data [_ id] :event}]
-                    {:data (assoc data :socket-id id)})
+         :data       (fn [{snap :snapshot}] {:url (-> snap :data :url)})}
+ ;; ... nested leaves; a leaf action reads the spawned socket's id:
+ :states
+ {:authenticating
+  {:entry (fn [{data :data}]
+            ;; the socket actor's id — no :on-spawn, no atom
+            (let [socket (get-in data [:rf/spawned [:active]])]
+              {:fx [[:dispatch [socket [:send {:type :auth}]]]]}))}}}
 ```
+
+This is re-frame2's spelling of XState v5's `spawn(...)`-into-`context` capture, except the id rides the **revertible, SSR-survivable snapshot** rather than a live object reference. It's keyed by `<invoke-id>` (the same path the child records under `:rf/invoke-id`), so multiple `:spawn`-bearing states don't collide.
+
+**The slot clears itself on teardown.** When the actor is destroyed — leaving the state by any door, a completing `:final?`, a frame teardown — the runtime dissocs `[:rf/spawned <invoke-id>]` from the parent's `:data`, so it mirrors the runtime registry exactly. A read after the child is gone returns `nil`, never a dead id. That's what makes the [websocket example](../../examples/patterns/websocket/) treat the slot as its *connection clock*: the live socket's id **is** the epoch, and it goes `nil` the instant the socket dies — no `:exit` action nulling anything.
+
+### 2. `:system-id` (address the actor by a stable name)
+
+Give the spawn a `:system-id` and message it by that *role name* instead of the gensym'd id — best when you want a stable correspondent rather than to hold the id yourself. See [Addressing by name with `:system-id`](#addressing-by-name-with-system-id) below.
+
+!!! note "The runtime registry, for outside-the-machine reads"
+
+    The id is *also* always at `[:rf.runtime/machines :spawned <parent-id> <invoke-id>]` in the frame's runtime-db — the same value the `:rf/spawned` `:data` slot mirrors. Read it there when you're *outside* the machine's own action context (mechanism 1 needs the action's `:data`); inside an action, prefer the `:rf/spawned` slot.
 
 ---
 

--- a/examples/patterns/websocket/connection.cljs
+++ b/examples/patterns/websocket/connection.cljs
@@ -14,17 +14,17 @@
    Why nest the three happy-path leaves inside `:active` instead of laying
    everything out flat? Because they share one thing they can't live
    without: the live socket. The subscription set, the in-flight requests,
-   the offline queue, the socket id — all of it belongs to *one*
-   connection and rides a single `:data` map. A compound state is how you
-   say 'these share a lifecycle'. (Parallel regions are the opposite tool,
-   for axes that don't share data.)
+   the offline queue — all of it belongs to *one* connection and rides a
+   single `:data` map. A compound state is how you say 'these share a
+   lifecycle'. (Parallel regions are the opposite tool, for axes that don't
+   share data.)
    See docs/machines/concepts.md#when-the-machine-grows.
 
    The view never matches on state names. Each state carries tags, and the
    view asks tag-shaped questions — `:ws/connected?`, `:ws/reconnecting?`
-   (the per-tag subs below, each a `contains?` over the snapshot's `:tags`
-   union). It doesn't care which leaf carries the `:connected` intent, only
-   that the tag is present. Ask, don't tell.
+   (the per-tag subs below, each chaining off the framework
+   `rf/machine-has-tag?` sub). It doesn't care which leaf carries the
+   `:connected` intent, only that the tag is present. Ask, don't tell.
    See docs/machines/glossary.md#state-tag.
 
    Reconnects bring two ways to be fooled by something stale, and we guard
@@ -35,15 +35,31 @@
         fire after we've moved on.
         See docs/machines/concepts.md#guards-actions-tags-and-after--the-recognition-kit.
 
-     2. A late message. The live `:socket-id` *is* the connection's clock:
-        every inbound event names the socket it came from, and the
+     2. A late message. The live socket-actor id *is* the connection's
+        clock: every inbound event names the socket it came from, and the
         `:current-socket?` guard drops anything from a socket we've since
         replaced — the slow message that lands just after a reconnect.
 
    The thing that actually owns the JS WebSocket is the `:websocket/socket`
    actor, over in `websocket.messages`. We spawn it on the `:active`
    *parent*, so one socket spans `:connecting` -> `:authenticating` ->
-   `:connected` without re-spawning on every leaf transition."
+   `:connected` without re-spawning on every leaf transition.
+
+   Where does the parent learn the spawned actor's id? It doesn't have to
+   ask. Every declarative `:spawn` binds the newborn's id into the SPAWNING
+   machine's own `:data` under the reserved `:rf/spawned` map, keyed by the
+   `:spawn`-bearing state's path — here `[:active]`. So the id is simply
+   `(get-in data [:rf/spawned [:active]])`, and `socket-id` (below) reads it.
+   This is re-frame2's spelling of XState v5's `spawn(...)`-into-`context`
+   capture — no `:on-spawn` self-dispatch, no side-channel atom.
+   See docs/machines/actors.md#recording-the-spawned-id and
+   docs/machines/glossary.md#spawn.
+
+   And because the runtime CLEARS that slot the instant the actor is torn
+   down (leaving `:active` by any door), a stale read is impossible: the
+   moment the socket dies, `(socket-id data)` goes `nil` on its own. That is
+   what makes it a safe connection clock — no `:exit` action nulling
+   anything, nothing to remember to clean up."
   (:require [re-frame.core :as rf]
             ;; `re-frame.machines` ships in day8/re-frame2-machines.
             ;; Requiring it is what wires up the machine vocabulary: the
@@ -51,7 +67,6 @@
             ;; `:rf.machine/spawn` / `:rf.machine/destroy` fx, and the
             ;; `:rf/machine` / `:rf/machine-has-tag?` subs you'll see used
             ;; below. Skip the require and they simply aren't there.
-            [re-frame.late-bind]
             [re-frame.machines]
             [re-frame.fx]
             [websocket.schema :as schema]))
@@ -59,6 +74,20 @@
 ;; ============================================================================
 ;; CONNECTION MACHINE — :ws/connection
 ;; ============================================================================
+
+;; The socket actor is spawned on the `:active` parent state, so the id the
+;; runtime binds into our `:data :rf/spawned` map is keyed by that state's
+;; path. Naming the key once keeps the reads below honest.
+(def ^:private socket-invoke-id [:active])
+
+(defn- socket-id
+  "The live socket-actor id, read straight from the parent's own `:data`
+   under the framework-maintained `:rf/spawned` slot. Returns nil whenever
+   no socket is spawned — before the first `:active` entry, and (crucially)
+   the moment the actor is torn down, because the runtime clears the slot on
+   teardown. That auto-clear is why this doubles as the connection's clock."
+  [data]
+  (get-in data [:rf/spawned socket-invoke-id]))
 
 (def connection-machine
   "The `:ws/connection` machine spec, kept in its own `def` so we can hand
@@ -72,14 +101,16 @@
      :schemas {:data schema/ConnectionData}
 
      ;; `:data` is the connection's memory — everything that has to survive
-     ;; a reconnect, from the URL down to the in-flight requests.
+     ;; a reconnect, from the URL down to the in-flight requests. Note
+     ;; there's no `:socket-id` here: the live socket's id lives in the
+     ;; framework's `:rf/spawned` slot (read via `socket-id`), which the
+     ;; runtime keeps current for us.
      :data    {:url            nil
                :auth-token     nil
                :retries        0
                :max-retries    8
                :base-ms        100
                :max-backoff-ms 5000
-               :socket-id      nil
                :subscriptions  #{}
                :queue          []
                :in-flight      {}
@@ -100,10 +131,13 @@
       ;; the socket it came from (`:source-socket-id`, the actor's
       ;; `:rf/self-id`). We let it through only if that matches the live
       ;; socket — otherwise it's a straggler from a connection we've
-      ;; already replaced, and we drop it.
+      ;; already replaced, and we drop it. `socket-id` reads the live id
+      ;; from `:rf/spawned`, so a torn-down socket compares as nil and every
+      ;; straggler is dropped for free.
       (fn guard-current-socket? [{data :data [_ {:keys [source-socket-id]}] :event}]
-        (and (some? (:socket-id data))
-             (= source-socket-id (:socket-id data))))}
+        (let [live (socket-id data)]
+          (and (some? live)
+               (= source-socket-id live))))}
 
      :actions
      {:record-connection-opts
@@ -141,22 +175,12 @@
       (fn action-record-error [{data :data [_ {:keys [error]}] :event}]
         {:data (assoc data :error error)})
 
-      :record-socket-id
-      ;; Stash the spawned actor's id in `:data`. Why a whole action for an
-      ;; assoc? Because `:on-spawn` is advisory — its return value is
-      ;; thrown away, so it can't write `:data` directly. So it does the
-      ;; next best thing: it fires a `[:ws/-socket-spawned <id>]` event
-      ;; back at us, and that transition runs this action, which records
-      ;; the id the ordinary way.
-      (fn action-record-socket-id [{data :data [_ id] :event}]
-        {:data (assoc data :socket-id id)})
-
       :send-auth
       ;; We've just entered `:authenticating`, so send the credentials:
       ;; route an `:auth` message into the live socket actor and wait for
       ;; the server to bless us.
       (fn action-send-auth [{data :data}]
-        {:fx [[:dispatch [(:socket-id data)
+        {:fx [[:dispatch [(socket-id data)
                           [:send {:type  :auth
                                   :token (:auth-token data)}]]]]})
 
@@ -170,7 +194,7 @@
       (fn action-on-connected [{data :data}]
         {:data (assoc data :retries 0)
          :fx   (mapv (fn [topic]
-                       [:dispatch [(:socket-id data)
+                       [:dispatch [(socket-id data)
                                    [:send {:type :subscribe :topic topic}]]])
                      (:subscriptions data))})
 
@@ -182,7 +206,7 @@
         (let [q (:queue data)]
           {:data (assoc data :queue [])
            :fx   (mapv (fn [msg]
-                         [:dispatch [(:socket-id data) [:send msg]]])
+                         [:dispatch [(socket-id data) [:send msg]]])
                        q)}))
 
       :enqueue-message
@@ -194,12 +218,12 @@
       ;; queue. This is the leaf overriding the parent's `:ws/send` (which
       ;; enqueues) — same event, different answer depending on where we are.
       (fn action-send-now [{data :data [_ msg] :event}]
-        {:fx [[:dispatch [(:socket-id data) [:send msg]]]]})
+        {:fx [[:dispatch [(socket-id data) [:send msg]]]]})
 
       :register-subscription
       (fn action-register-subscription [{data :data [_ topic] :event}]
         {:data (update data :subscriptions conj topic)
-         :fx   [[:dispatch [(:socket-id data)
+         :fx   [[:dispatch [(socket-id data)
                             [:send {:type :subscribe :topic topic}]]]]})
 
       :register-request
@@ -214,7 +238,7 @@
                                             :or   {timeout-ms 30000}}] :event}]
         {:data (assoc-in data [:in-flight request-id]
                          {:reply-event reply :timeout-ms timeout-ms})
-         :fx   [[:dispatch [(:socket-id data)
+         :fx   [[:dispatch [(socket-id data)
                             [:send (assoc body :request-id request-id)]]]
                 ;; The timeout event carries the live socket-id too, so the
                 ;; same `:current-socket?` guard quietly discards a timeout
@@ -224,7 +248,7 @@
                   :event [:ws/connection
                           [:ws/request-timeout
                            {:request-id       request-id
-                            :source-socket-id (:socket-id data)}]]}]]})
+                            :source-socket-id (socket-id data)}]]}]]})
 
       :clear-request
       (fn action-clear-request [{data :data [_ {:keys [request-id]}] :event}]
@@ -255,7 +279,8 @@
       :active
       {;; Spawn the socket actor here, on the parent, so one socket lives
        ;; across :connecting -> :authenticating -> :connected. The instant
-       ;; we leave :active — by any door — the runtime tears it down.
+       ;; we leave :active — by any door — the runtime tears it down (and
+       ;; clears its id from our :rf/spawned slot, so `socket-id` reads nil).
        ;; See docs/machines/concepts.md#when-the-machine-grows.
        :spawn {:machine-id :websocket/socket
                 ;; Hand the child the URL and token from our `:data` as it's
@@ -264,29 +289,7 @@
                 ;; into the next socket, no extra plumbing.
                 :data       (fn [{snap :snapshot}]
                               {:url        (-> snap :data :url)
-                               :auth-token (-> snap :data :auth-token)})
-                ;; `:on-spawn` is advisory — its return value goes nowhere,
-                ;; so it can't write the parent's `:data` itself. It knows
-                ;; the new actor's id, though, and we need that recorded.
-                ;; The trick: fire a `:ws/-socket-spawned` event at
-                ;; ourselves, whose transition runs `:record-socket-id` and
-                ;; writes `:socket-id` the ordinary way.
-                :on-spawn (fn [{id :id}]
-                            (when-let [dispatch! (re-frame.late-bind/get-fn :router/dispatch!)]
-                              (dispatch!
-                                [:ws/connection [:ws/-socket-spawned id]]
-                                ;; Tag where this dispatch came from:
-                                ;; `:source :websocket` is the reserved
-                                ;; functional-origin slot for events that
-                                ;; originate at the socket.
-                                {:source :websocket})))}
-
-       ;; On the way out, null the :socket-id. The runtime already destroys
-       ;; the actor for us; this just clears the stale id behind it, so
-       ;; :current-socket? has a clean nil to compare against rather than
-       ;; the id of a socket that no longer exists.
-       :exit (fn action-clear-socket-id [{data :data}]
-               {:data (assoc data :socket-id nil)})
+                               :auth-token (-> snap :data :auth-token)})}
 
        ;; Transitions every leaf inherits. A leaf can override any of these
        ;; (deepest state wins); anything it doesn't handle falls through to
@@ -303,11 +306,7 @@
                ;; topic down; the next :connected entry will actually send
                ;; the subscribe.
                :ws/subscribe {:action (fn [{data :data [_ topic] :event}]
-                                        {:data (update data :subscriptions conj topic)})}
-               ;; Internal plumbing: the spawn's `:on-spawn` callback fires
-               ;; this so we can record the new socket id through a normal
-               ;; action (see `:record-socket-id`).
-               :ws/-socket-spawned {:action :record-socket-id}}
+                                        {:data (update data :subscriptions conj topic)})}}
 
        :initial :connecting
 
@@ -394,29 +393,31 @@
   :<- [:ws/snapshot]
   (fn [snap _] (:state snap)))
 
-;; One little yes/no sub per tag. Each is a `contains?` over the
-;; snapshot's `:tags` union, so a view can ask "connected?" and get a
-;; boolean — no unpacking the hierarchical `:state` vector to find out.
+;; One little yes/no sub per tag. Each chains off the FRAMEWORK sub
+;; `:rf/machine-has-tag?` (sugar: `(rf/machine-has-tag? :ws/connection
+;; tag)`), which returns the snapshot's tag-containment bit directly — so a
+;; view can ask "connected?" and get a boolean without unpacking the
+;; hierarchical `:state` vector or re-reading the snapshot itself.
 ;; See docs/machines/glossary.md#state-tag.
 (rf/reg-sub :ws/connecting?
-  :<- [:ws/snapshot]
-  (fn [snap _] (contains? (:tags snap) :websocket/connecting)))
+  :<- [:rf/machine-has-tag? :ws/connection :websocket/connecting]
+  (fn [has-tag? _] has-tag?))
 
 (rf/reg-sub :ws/authenticating?
-  :<- [:ws/snapshot]
-  (fn [snap _] (contains? (:tags snap) :websocket/authenticating)))
+  :<- [:rf/machine-has-tag? :ws/connection :websocket/authenticating]
+  (fn [has-tag? _] has-tag?))
 
 (rf/reg-sub :ws/connected?
-  :<- [:ws/snapshot]
-  (fn [snap _] (contains? (:tags snap) :websocket/connected)))
+  :<- [:rf/machine-has-tag? :ws/connection :websocket/connected]
+  (fn [has-tag? _] has-tag?))
 
 (rf/reg-sub :ws/reconnecting?
-  :<- [:ws/snapshot]
-  (fn [snap _] (contains? (:tags snap) :websocket/reconnecting)))
+  :<- [:rf/machine-has-tag? :ws/connection :websocket/reconnecting]
+  (fn [has-tag? _] has-tag?))
 
 (rf/reg-sub :ws/failed?
-  :<- [:ws/snapshot]
-  (fn [snap _] (contains? (:tags snap) :websocket/failed)))
+  :<- [:rf/machine-has-tag? :ws/connection :websocket/failed]
+  (fn [has-tag? _] has-tag?))
 
 (rf/reg-sub :ws/queue-depth
   :<- [:ws/snapshot]
@@ -434,10 +435,10 @@
 (rf/reg-event :ws.connection/initialise
   {:doc "Wake the connection machine up in its `:disconnected` start
          state. A machine's first snapshot only materialises when it first
-         receives an event, so this gives it a harmless nudge."}
+         receives an event, so this gives it the canonical eager kick."}
   (fn handler-ws-connection-initialise [_ _]
-    ;; `:ws/noop` is a do-nothing event with no transition. Dispatching it
-    ;; is just enough to make the machine materialise its `:disconnected`
-    ;; snapshot, so tests (and the UI) can read the state before anyone
-    ;; clicks Connect.
-    {:fx [[:dispatch [:ws/connection [:ws/noop]]]]}))
+    ;; `[:rf.machine/start]` is re-frame2's spelling of XState v5's
+    ;; `createActor(machine).start()`: it runs the initial-entry cascade
+    ;; and then stops, materialising the `:disconnected` snapshot so tests
+    ;; (and the UI) can read the state before anyone clicks Connect.
+    {:fx [[:dispatch [:ws/connection [:rf.machine/start]]]]}))

--- a/examples/patterns/websocket/core.cljs
+++ b/examples/patterns/websocket/core.cljs
@@ -35,15 +35,20 @@
 
    - **Two staleness defences** — the backoff timer (runtime-cancelled on
      exit) and the connection-epoch (`:current-socket?` guard against the
-     live `:socket-id`).
+     live socket id read from `:rf/spawned`).
+
+   - **`:rf/spawned` capture** — the parent reads the spawned socket
+     actor's id straight from its own `:data :rf/spawned [:active]` slot (no
+     `:on-spawn` self-dispatch), and the runtime clears that slot on
+     teardown, so the id is never stale.
 
    - **Request/reply correlation** — `:in-flight` map, request-id stamp,
      timeout via `:dispatch-later`, reply-event dispatch on the correlated
      `:ws/received`.
 
-   - **Reconnect cascade** — exit-from-`:active` clears the `:socket-id`;
-     the runtime destroys the socket actor; the `:reconnecting` `:after`
-     re-enters `:active`, which spawns a fresh one.
+   - **Reconnect cascade** — the runtime destroys the socket actor on
+     exit-from-`:active` (clearing its `:rf/spawned` id for us); the
+     `:reconnecting` `:after` re-enters `:active`, which spawns a fresh one.
 
    For the grammar the machine leans on, see docs/machines/concepts.md;
    for where this example sits among the others, docs/machines/examples.md.

--- a/examples/patterns/websocket/schema.cljs
+++ b/examples/patterns/websocket/schema.cljs
@@ -4,10 +4,11 @@
    Two slices get described here:
 
    - The `:ws/connection` machine's `:data` map: the URL and token, the
-     retry counters, `:socket-id` (who the live socket actor is),
-     `:subscriptions`, the offline `:queue`, and the `:in-flight` map of
-     awaited replies. It hangs off the machine as `[:schemas :data]` (see
-     `connection.cljs`), because a machine validates its own `:data` —
+     retry counters, `:subscriptions`, the offline `:queue`, and the
+     `:in-flight` map of awaited replies. The live socket actor's id isn't a
+     field here — it lives in the framework-maintained `:rf/spawned` slot
+     (see `connection.cljs`'s `socket-id`). This map hangs off the machine
+     as `[:schemas :data]`, because a machine validates its own `:data` —
      there's no app-schema involved.
      See docs/machines/concepts.md#validating-a-machines-data.
 
@@ -41,14 +42,17 @@
    [:max-retries    :int]
    [:base-ms        :int]
    [:max-backoff-ms :int]
-   ;; Who the live socket actor is right now. The runtime hands us this id
-   ;; at :spawn time and we null it on exit from :active. It doubles as the
-   ;; connection's clock — the live socket-id *is* the epoch.
-   [:socket-id      [:maybe :any]]
    [:subscriptions  [:set :any]]
    [:queue          [:vector :any]]
    [:in-flight      [:map-of :any InFlightEntry]]
    [:error          [:maybe :any]]
+   ;; The runtime binds a declaratively-spawned actor's id into the SPAWNING
+   ;; machine's own :data here, keyed by the :spawn-bearing state's path
+   ;; (`{[:active] <socket-actor-id>}`). It doubles as the connection's
+   ;; clock — the live socket id *is* the epoch — and the runtime clears the
+   ;; entry on teardown, so it's never stale. Optional, because it's absent
+   ;; until the first :active entry. See connection.cljs's `socket-id`.
+   [:rf/spawned     {:optional true} [:map-of :any :any]]
    ;; Framework keys the runtime stamps into a *spawned* actor's :data.
    ;; Optional, because the parent machine never gets them — only the
    ;; children the runtime spawns do.

--- a/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
@@ -132,17 +132,19 @@
   (rf/reg-machine :ws/connection ws.connection/connection-machine)
   (subs/reg-runtime-sub :ws/snapshot (fn [rt _] (get-in rt [:rf.runtime/machines :snapshots :ws/connection])))
   (rf/reg-sub :ws/state          :<- [:ws/snapshot] (fn [snap _] (:state snap)))
-  (rf/reg-sub :ws/connecting?    :<- [:ws/snapshot] (fn [snap _] (contains? (:tags snap) :websocket/connecting)))
-  (rf/reg-sub :ws/authenticating? :<- [:ws/snapshot] (fn [snap _] (contains? (:tags snap) :websocket/authenticating)))
-  (rf/reg-sub :ws/connected?     :<- [:ws/snapshot] (fn [snap _] (contains? (:tags snap) :websocket/connected)))
-  (rf/reg-sub :ws/reconnecting?  :<- [:ws/snapshot] (fn [snap _] (contains? (:tags snap) :websocket/reconnecting)))
-  (rf/reg-sub :ws/failed?        :<- [:ws/snapshot] (fn [snap _] (contains? (:tags snap) :websocket/failed)))
+  ;; The per-tag subs mirror the example: each chains off the framework
+  ;; `:rf/machine-has-tag?` sub rather than re-reading the snapshot's :tags.
+  (rf/reg-sub :ws/connecting?     :<- [:rf/machine-has-tag? :ws/connection :websocket/connecting]     (fn [has-tag? _] has-tag?))
+  (rf/reg-sub :ws/authenticating? :<- [:rf/machine-has-tag? :ws/connection :websocket/authenticating] (fn [has-tag? _] has-tag?))
+  (rf/reg-sub :ws/connected?      :<- [:rf/machine-has-tag? :ws/connection :websocket/connected]      (fn [has-tag? _] has-tag?))
+  (rf/reg-sub :ws/reconnecting?   :<- [:rf/machine-has-tag? :ws/connection :websocket/reconnecting]   (fn [has-tag? _] has-tag?))
+  (rf/reg-sub :ws/failed?         :<- [:rf/machine-has-tag? :ws/connection :websocket/failed]         (fn [has-tag? _] has-tag?))
   (rf/reg-sub :ws/queue-depth    :<- [:ws/snapshot] (fn [snap _] (count (get-in snap [:data :queue]))))
   (rf/reg-sub :ws/retries        :<- [:ws/snapshot] (fn [snap _] (get-in snap [:data :retries])))
   (rf/reg-sub :ws/error          :<- [:ws/snapshot] (fn [snap _] (get-in snap [:data :error])))
   (rf/reg-event :ws.connection/initialise
     (fn handler-ws-connection-initialise [_ _]
-      {:fx [[:dispatch [:ws/connection [:ws/noop]]]]}))
+      {:fx [[:dispatch [:ws/connection [:rf.machine/start]]]]}))
 
   ;; --- websocket.messages -------------------------------------------------
   (rf/reg-machine :websocket/socket messages/socket-actor-machine)
@@ -233,6 +235,13 @@
 (defn- snapshot [runtime-db]
   (get-in runtime-db [:rf.runtime/machines :snapshots :ws/connection]))
 
+;; The live socket-actor id now lives in the framework-maintained
+;; `:rf/spawned` slot on the parent's own :data, keyed by the :spawn-bearing
+;; state's path (`[:active]`) — the rf2-yh21ah rewrite dropped the bespoke
+;; `:socket-id` :data field. Mirrors `websocket.connection/socket-id`.
+(defn- socket-id-of [snap]
+  (get-in snap [:data :rf/spawned [:active]]))
+
 (defn- machine-has-tag?
   "Read the machine's :tags union against a frame's runtime-db (machine
   snapshots are runtime-db state — rf2-vzld77)."
@@ -263,7 +272,7 @@
 
 (defn- initial-state-test []
   (with-new-frame [f (new-frame)]
-    (rf/dispatch-sync [:ws/connection [:ws/noop]] {:frame f})
+    (rf/dispatch-sync [:ws/connection [:rf.machine/start]] {:frame f})
     (let [s (snapshot (rf/runtime-db-value f))]
       (is (= :disconnected (:state s))
           (str "expected :disconnected got " (pr-str (:state s))))
@@ -271,7 +280,8 @@
       (is (= {} (get-in s [:data :in-flight])))
       (is (= #{} (get-in s [:data :subscriptions])))
       (is (= 0 (get-in s [:data :retries])))
-      (is (nil? (get-in s [:data :socket-id]))))))
+      ;; No socket spawned yet, so the :rf/spawned slot has no [:active] entry.
+      (is (nil? (socket-id-of s))))))
 
 (defn- connect-happy-path-test []
   (with-sync-mock!
@@ -290,7 +300,7 @@
           (is (false? (machine-has-tag? f :websocket/reconnecting)))
           (is (false? (machine-has-tag? f :websocket/failed)))
           (is (= 0    (get-in s [:data :retries])))
-          (is (some?  (get-in s [:data :socket-id])))
+          (is (some?  (socket-id-of s)))
           ;; URL + token were recorded in :data — they survive across
           ;; reconnects.
           (is (= "ws://mock" (get-in s [:data :url])))
@@ -336,7 +346,7 @@
                           {:frame f})
         (is (true? (machine-has-tag? f :websocket/connected)))
         (let [pre-snap   (snapshot (rf/runtime-db-value f))
-              pre-socket (get-in pre-snap [:data :socket-id])]
+              pre-socket (socket-id-of pre-snap)]
           (is (some? pre-socket))
           ;; Simulate a transport-level drop. The mock fires :ws/closed
           ;; (with the source-socket-id) into the actor, which forwards
@@ -348,8 +358,10 @@
                 (str "expected :reconnecting got " (:state s)))
             (is (true?  (machine-has-tag? f :websocket/reconnecting)))
             (is (false? (machine-has-tag? f :websocket/connected)))
-            ;; :exit on :active cleared the stale socket-id.
-            (is (nil?   (get-in s [:data :socket-id])))
+            ;; Leaving :active tore the socket actor down; the runtime
+            ;; cleared its id from the :rf/spawned slot for us — no :exit
+            ;; null-out needed. So the connection clock reads nil.
+            (is (nil?   (socket-id-of s)))
             ;; :bump-retry ran.
             (is (= 1 (get-in s [:data :retries]))))
           ;; Fire the :after timer to re-enter :active. The :after key
@@ -388,8 +400,9 @@
             ;; staleness test.
             (when (= [:active :connected] (:state s))
               (is (true? (machine-has-tag? f :websocket/connected)))
-              ;; A NEW socket-id is in :data (different from pre-socket).
-              (is (not= pre-socket (get-in s [:data :socket-id]))
+              ;; A NEW socket id is in the :rf/spawned slot (a fresh actor,
+              ;; so a different id from pre-socket).
+              (is (not= pre-socket (socket-id-of s))
                   "reconnect spawned a fresh socket"))))))))
 
 (defn- max-retries-failed-test []
@@ -422,7 +435,7 @@
         ;; and immediately into :failed via :always-cascade.
         (let [snap-before (snapshot (rf/runtime-db-value f))]
           (rf/dispatch-sync [:ws/connection
-                             [:ws/closed {:source-socket-id (get-in snap-before [:data :socket-id])
+                             [:ws/closed {:source-socket-id (socket-id-of snap-before)
                                           :code 1006}]]
                             {:frame f}))
         (let [s (snapshot (rf/runtime-db-value f))]
@@ -439,8 +452,7 @@
                            [:ws/connect {:url "ws://mock"
                                          :auth-token "demo"}]]
                           {:frame f})
-        (let [live-socket-id (get-in (snapshot (rf/runtime-db-value f))
-                                     [:data :socket-id])
+        (let [live-socket-id (socket-id-of (snapshot (rf/runtime-db-value f)))
               stale-id       (str "stale-" (random-uuid))]
           ;; A :ws/received event with a stale source-socket-id is
           ;; dropped by :current-socket?. The :messages slice doesn't
@@ -500,7 +512,7 @@
           (is (false? (machine-has-tag? f :websocket/connected)))
           (is (false? (machine-has-tag? f :websocket/reconnecting)))
           (is (false? (machine-has-tag? f :websocket/failed)))
-          (is (nil? (get-in s [:data :socket-id]))))))))
+          (is (nil? (socket-id-of s))))))))
 
 ;; ============================================================================
 ;; REQUEST/REPLY + SERVER PUSH + SUBSCRIPTIONS

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/teardown.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/teardown.cljc
@@ -4,18 +4,27 @@
   Per Spec 005 §Cancellation cascade — when a spawned actor is destroyed
   (final-state auto-destroy, exit-cascade declarative-`:spawn` destroy,
   iterated `:spawn-all` children-destroy, or keyword/imperative
-  destroy) the runtime applies a four-step app-db projection:
+  destroy) the runtime applies a five-step app-db projection:
 
     1. dissoc snapshot at `[:rf.runtime/machines :snapshots actor-id]`
     2. release `[:rf.runtime/machines :system-ids <sid>]` reverse-index
        entry (if bound)
     3. clear `[:rf.runtime/machines :spawned parent-id invoke-id]` slot
        (declarative form)
-    4. prune the per-parent `[:rf.runtime/machines :spawned parent-id]`
-       map and the `[:rf.runtime/machines :spawned]` slot if they just
-       emptied (lazy-allocation invariant: spawn ALLOCATES the maps
-       lazily, so destroy mirrors that by pruning when emptied — see
-       Spec 005 §Spawning §Lazy allocation).
+    4. clear the PARENT snapshot's own `:rf/spawned` data slot at
+       `[:rf.runtime/machines :snapshots parent-id :data :rf/spawned
+       invoke-id]` (declarative form) so the parent-side data slot
+       (mechanism 1 — XState-context parity) mirrors the runtime registry
+       (step 3) EXACTLY, per Spec 005:2938 (\"the `:rf/spawned` `:data`
+       slot mirrors this registry slot exactly, in-snapshot\"). Without
+       this an action reading `[:data :rf/spawned <invoke-id>]` AFTER the
+       child completed would get a DEAD id — the stale-id footgun.
+    5. prune the per-parent `[:rf.runtime/machines :spawned parent-id]`
+       map, the `[:rf.runtime/machines :spawned]` slot, and the emptied
+       parent-side `:rf/spawned` data map if they just emptied
+       (lazy-allocation invariant: spawn ALLOCATES the maps lazily, so
+       destroy mirrors that by pruning when emptied — see Spec 005
+       §Spawning §Lazy allocation).
 
   The `[:rf.runtime/machines :snapshots]` and
   `[:rf.runtime/machines :system-ids]` maps are NOT pruned when
@@ -65,10 +74,14 @@
 
   When `:parent-id` and `:invoke-id` are both supplied, the
   `[:rf.runtime/machines :spawned <parent-id> <invoke-id>]` slot is
-  cleared and the parent map / `:spawned` root are pruned under the
-  lazy-allocation invariant (matching how spawn ALLOCATES the maps
-  lazily — see Spec 005 §Spawning §Lazy allocation). The
-  `[:rf.runtime/machines :snapshots]` and
+  cleared AND the parent snapshot's own `:rf/spawned` data slot at
+  `[:rf.runtime/machines :snapshots <parent-id> :data :rf/spawned
+  <invoke-id>]` is cleared, so the parent-side data slot mirrors the
+  runtime registry EXACTLY (Spec 005:2938). Both the parent map /
+  `:spawned` root AND the emptied parent-side `:rf/spawned` data map are
+  pruned under the lazy-allocation invariant (matching how spawn
+  ALLOCATES the maps lazily — see Spec 005 §Spawning §Lazy allocation).
+  The `[:rf.runtime/machines :snapshots]` and
   `[:rf.runtime/machines :system-ids]` maps are NOT pruned when
   emptied (see ns docstring).
 
@@ -78,25 +91,50 @@
   [db {:keys [actor-id parent-id invoke-id]}]
   (let [released-sid (find-system-id-for-actor db actor-id)
         track?       (and parent-id invoke-id)
-        ;; (1)+(2)+(3): the three primary slot mutations.
+        ;; The parent's own `:rf/spawned` data slot is cleared (step 4)
+        ;; ONLY when the parent snapshot is still present. A parent already
+        ;; torn down (its snapshot dissoc'd) has nothing to mirror, and
+        ;; touching it would materialise a phantom `{:data {:rf/spawned {}}}`
+        ;; on a dead parent — so guard the parent-side clear on presence.
+        clear-parent-data? (and track?
+                                (contains? (get-in db (paths/snapshot-path))
+                                           parent-id))
+        ;; (1)+(2)+(3)+(4): the primary slot mutations. (4) clears the
+        ;; PARENT snapshot's own `[:data :rf/spawned <invoke-id>]` slot so
+        ;; the parent-side data slot (mechanism 1) mirrors the runtime
+        ;; registry (step 3) EXACTLY — see ns docstring + Spec 005:2938.
         new-db       (cond-> db
                        actor-id     (update-in (paths/snapshot-path)
                                                dissoc actor-id)
                        released-sid (update-in (paths/system-id-path)
                                                dissoc released-sid)
                        track?       (update-in (paths/spawned-path parent-id)
-                                                dissoc invoke-id))
-        ;; (4a): prune the per-parent `:spawned` map if empty.
+                                                dissoc invoke-id)
+                       clear-parent-data?
+                       (update-in (paths/snapshot-path parent-id :data :rf/spawned)
+                                  dissoc invoke-id))
+        ;; (5a): prune the per-parent `:spawned` map if empty.
         new-db       (cond-> new-db
                        (and track?
                             (empty? (get-in new-db (paths/spawned-path parent-id))))
                        (update-in (paths/spawned-path) dissoc parent-id))
-        ;; (4b): prune the `[:rf.runtime/machines :spawned]` slot if
+        ;; (5b): prune the `[:rf.runtime/machines :spawned]` slot if
         ;; empty (lazy-allocation mirror — :snapshots and :system-ids
         ;; stay present per fixture contract).
         new-db       (cond-> new-db
                        (and (contains? (get-in new-db [:rf.runtime/machines])
                                        :spawned)
                             (empty? (get-in new-db (paths/spawned-path))))
-                       (update-in [:rf.runtime/machines] dissoc :spawned))]
+                       (update-in [:rf.runtime/machines] dissoc :spawned))
+        ;; (5c): prune the parent snapshot's now-empty `:rf/spawned` data
+        ;; map (lazy-allocation mirror of the registry prune above) so a
+        ;; parent that spawned exactly one child leaves NO empty
+        ;; `{:rf/spawned {}}` residue in its `:data` after the child dies.
+        ;; Only touch a still-present parent snapshot.
+        new-db       (cond-> new-db
+                       (and clear-parent-data?
+                            (empty? (get-in new-db (paths/snapshot-path parent-id
+                                                                        :data :rf/spawned))))
+                       (update-in (paths/snapshot-path parent-id :data)
+                                  dissoc :rf/spawned))]
     [new-db released-sid]))

--- a/implementation/machines/test/re_frame/spawn_registry_test.clj
+++ b/implementation/machines/test/re_frame/spawn_registry_test.clj
@@ -118,6 +118,107 @@
         (is (not (contains? (get-in db [:rf.runtime/machines]) :spawned))
             "the empty :spawned slot under [:rf.runtime/machines] is pruned to absent")))))
 
+;; ---- (2b) ADVERSARIAL: the parent's own :rf/spawned DATA slot is cleared ---
+;; on teardown too, so the in-snapshot data slot (mechanism 1 — XState-context
+;; parity) mirrors the runtime registry EXACTLY (Spec 005:2938). This is the
+;; stale-id footgun the rf2-yh21ah Option-A cleanup closes: BEFORE the fix, an
+;; action reading `[:data :rf/spawned <invoke-id>]` AFTER the child completed
+;; got a DEAD id (the data slot outlived the actor). AFTER the fix, the read
+;; returns nil — the actor is gone AND its capture is gone, together.
+
+(deftest destroy-clears-parent-data-rf-spawned-slot-no-dead-id
+  (testing "an action reading [:data :rf/spawned <invoke-id>] AFTER exit-cascade teardown sees NO dead id"
+    (let [;; The child sits LIVE in :running until the PARENT leaves :working —
+          ;; the declarative-:spawn exit cascade then tears it down
+          ;; (teardown-live-actor! → teardown-actor with parent-id/invoke-id).
+          child  {:initial :running
+                  :data    {}
+                  :states  {:running {}}}
+          ;; The parent's :inspect action reads its OWN :data under
+          ;; [:rf/spawned <invoke-id>] — the no-atom, in-snapshot idiom — and
+          ;; stashes whatever it finds so the test can assert the
+          ;; post-teardown read returns nil, not a stale id.
+          seen   (atom :unset)
+          parent {:initial :idle
+                  :actions
+                  {:inspect (fn [{data :data}]
+                              (reset! seen (get-in data [:rf/spawned [:working]]))
+                              nil)}
+                  :states
+                  ;; :done leaves :working → the exit cascade destroys the
+                  ;; child; :probe (fired from :idle AFTER) runs :inspect, which
+                  ;; reads the parent's own :data :rf/spawned slot post-teardown.
+                  {:idle    {:on {:start :working
+                                  :probe {:target :idle :action :inspect}}}
+                   :working {:spawn {:machine-id :kid/proc}
+                             :on    {:done :idle}}}}]
+      (rf/reg-machine :kid/proc child)
+      (rf/reg-machine :sup/data-clear parent)
+      (rf/dispatch-sync [:sup/data-clear [:start]])
+      ;; Precondition: the child is LIVE and the parent captured its id in
+      ;; BOTH the runtime registry AND its own :data slot (the two mirror).
+      (let [db (frame-db)]
+        (is (= :kid/proc#1 (get-in db [:rf.runtime/machines :spawned :sup/data-clear [:working]]))
+            "(precondition) registry slot bound")
+        (is (= :kid/proc#1 (get-in (snapshot :sup/data-clear) [:data :rf/spawned [:working]]))
+            "(precondition) parent :data slot bound — the two mirror on spawn")
+        (is (some? (get-in db [:rf.runtime/machines :snapshots :kid/proc#1]))
+            "(precondition) the child actor is alive"))
+      ;; Leave :working → the exit cascade tears the child down.
+      (rf/dispatch-sync [:sup/data-clear [:done]])
+      (let [db (frame-db)]
+        (is (nil? (get-in db [:rf.runtime/machines :snapshots :kid/proc#1]))
+            "the child actor's snapshot was cleared on exit-cascade teardown")
+        ;; THE ADVERSARIAL ASSERTION: the parent's own :data :rf/spawned slot
+        ;; for this invoke-id was ALSO cleared — no dead id lingers.
+        (is (nil? (get-in (snapshot :sup/data-clear) [:data :rf/spawned [:working]]))
+            "parent's :data :rf/spawned slot cleared on child teardown — NO dead id (footgun gone)")
+        ;; The now-empty :rf/spawned data map is pruned (lazy-allocation mirror):
+        ;; a parent that spawned exactly one child leaves NO {:rf/spawned {}}
+        ;; residue in its :data after the child dies.
+        (is (not (contains? (:data (snapshot :sup/data-clear)) :rf/spawned))
+            "the emptied :rf/spawned data map is pruned from the parent's :data")
+        ;; The two views still MIRROR each other post-teardown: both absent.
+        (is (= (get-in db [:rf.runtime/machines :spawned :sup/data-clear [:working]])
+               (get-in (snapshot :sup/data-clear) [:data :rf/spawned [:working]]))
+            "registry slot and :data slot still mirror exactly after teardown — both absent"))
+      ;; An action reading its own :data AFTER teardown sees nil, not a dead id
+      ;; — the reader's-eye-view of the same invariant.
+      (rf/dispatch-sync [:sup/data-clear [:probe]])
+      (is (nil? @seen)
+          "an action reading [:data :rf/spawned <invoke-id>] after teardown sees nil, not a stale id"))))
+
+(deftest finalize-auto-destroy-clears-parent-data-rf-spawned-slot
+  (testing "a child self-completing to :final? auto-destroys AND clears the parent's :data :rf/spawned slot"
+    (let [;; The child drives straight to a :final? state on its :start, so the
+          ;; runtime auto-destroys it via the finalize path (NOT the parent's
+          ;; exit cascade) — the OTHER teardown route through teardown-actor.
+          child  {:initial :running
+                  :data    {}
+                  :states  {:running {:on {:go :done}}
+                            :done    {:final? true}}}
+          parent {:initial :idle
+                  :states  {:idle    {:on {:start :working}}
+                            :working {:spawn {:machine-id :fin/kid
+                                              :start      [:go]}
+                                      :on    {:next :working}}}}]
+      (rf/reg-machine :fin/kid child)
+      (rf/reg-machine :sup/finalize parent)
+      ;; The child self-completes DURING this dispatch (its :start [:go] reaches
+      ;; :done/:final? synchronously), so by the time it returns the child is
+      ;; already auto-destroyed. We assert the parent's :data slot is clean.
+      (rf/dispatch-sync [:sup/finalize [:start]])
+      (let [db (frame-db)]
+        (is (nil? (get-in db [:rf.runtime/machines :snapshots :fin/kid#1]))
+            "(precondition) the child auto-destroyed on reaching its :final? state")
+        ;; ADVERSARIAL: the finalize auto-destroy path ALSO clears the parent's
+        ;; own :data :rf/spawned capture — no dead id survives the finalize.
+        (is (nil? (get-in (snapshot :sup/finalize) [:data :rf/spawned [:working]]))
+            "parent's :data :rf/spawned slot cleared on finalize auto-destroy — NO dead id")
+        (is (= (get-in db [:rf.runtime/machines :spawned :sup/finalize [:working]])
+               (get-in (snapshot :sup/finalize) [:data :rf/spawned [:working]]))
+            "registry slot and :data slot mirror exactly after finalize — both absent")))))
+
 ;; ---- (3) auth-flow scenario WITHOUT user-side :on-spawn bookkeeping -------
 ;;
 ;; A :spawn whose user-supplied :on-spawn doesn't write the id under any
@@ -276,8 +377,8 @@
       (is (nil? (get-in (frame-db) [:rf.runtime/machines :snapshots :worker/proc#1]))
           "the actor was torn down via an id read from the parent's own :data — no external atom involved"))))
 
-(deftest multi-spawn-parent-data-no-clobber
-  (testing "multiple :spawn-bearing states + a :spawn-all each record under their own invoke-id key — no lossy clobber"
+(deftest multi-spawn-parent-data-per-invoke-id-key
+  (testing "multiple :spawn-bearing states + a :spawn-all each record under their own invoke-id key — keyed-map shape, cleared on exit"
     (let [child-a {:initial :running :data {} :states {:running {}}}
           child-b {:initial :running :data {} :states {:running {}}}
           gc-x    {:initial :running :data {} :states {:running {}}}
@@ -310,22 +411,31 @@
       (let [d (:data (snapshot :sup/many))]
         (is (= :child/a#1 (get-in d [:rf/spawned [:a-running]]))
             "A's id recorded under its own invoke-id key"))
-      ;; Tear A, spawn B — distinct invoke-id, A's slot does not collide.
+      ;; Tear A (leaving :a-running exits the :spawn-bearing state), spawn B.
       (rf/dispatch-sync [:sup/many [:back]])
       (rf/dispatch-sync [:sup/many [:fork-b]])
       (let [d (:data (snapshot :sup/many))]
         (is (= :child/b#1 (get-in d [:rf/spawned [:b-running]]))
-            "B's id recorded under its own distinct invoke-id key — no clobber")
-        ;; A's earlier binding is still present in the :data map (the parent
-        ;; never clears its own :data captures — they accumulate per invoke-id,
-        ;; which is exactly why a single 'last-spawned' slot would be lossy).
-        (is (= :child/a#1 (get-in d [:rf/spawned [:a-running]]))
-            "A's earlier :data binding survived the B spawn — keyed-map shape is non-lossy"))
+            "B's id recorded under its own distinct invoke-id key — no collision with A's key")
+        ;; A's earlier binding was CLEARED when A was torn down on :a-running
+        ;; exit — the :data slot mirrors the runtime registry exactly
+        ;; (rf2-yh21ah Option A), so no dead id lingers. The keyed-map shape
+        ;; is what keeps B's live capture and A's absence INDEPENDENT (a single
+        ;; 'last-spawned' slot would have been overwritten, not cleared).
+        (is (nil? (get-in d [:rf/spawned [:a-running]]))
+            "A's :data binding cleared on A's teardown — mirrors the registry, no dead id")
+        (is (= :child/b#1 (get-in (frame-db) [:rf.runtime/machines :spawned :sup/many [:b-running]]))
+            "B's registry slot is bound; A's registry slot is gone — data mirrors registry")
+        (is (nil? (get-in (frame-db) [:rf.runtime/machines :spawned :sup/many [:a-running]]))
+            "A's registry slot cleared too — both views agree A is gone"))
       ;; :spawn-all records the WHOLE {<child-id> <spawned-id>} map under the
       ;; one shared invoke-id — both children, no clobber under the single key.
+      ;; Leaving :b-running first tears B down (clearing B's :data slot).
       (rf/dispatch-sync [:sup/many [:back]])
       (rf/dispatch-sync [:sup/many [:fork-all]])
       (let [d (:data (snapshot :sup/many))]
+        (is (nil? (get-in d [:rf/spawned [:b-running]]))
+            "B's :data binding cleared on B's teardown — clear-on-exit holds for :spawn-all's siblings too")
         (is (= {:x :gc/x#1 :y :gc/y#1} (get-in d [:rf/spawned [:forking]]))
             ":spawn-all records the full children id-map under the shared invoke-id — both children, no clobber")))))
 


### PR DESCRIPTION
Implements bead **rf2-yh21ah** — Mike-ruled **Part 1 = Option A**; parts 2-3 unconditional.

## Part 1 (Option A) — impl-only, no spec/005 edit
At actor teardown, `teardown/teardown-actor` now also dissocs the PARENT snapshot's own `:rf/spawned` data slot at `[:rf.runtime/machines :snapshots <parent-id> :data :rf/spawned <invoke-id>]`, so the in-snapshot data slot (mechanism 1 — XState-context parity) mirrors the runtime registry (`[:rf.runtime/machines :spawned <parent-id> <invoke-id>]`) EXACTLY — keeping Spec 005:2938 true as written. The parent-side clear is guarded on the parent snapshot still being present (no phantom `{:data {:rf/spawned {}}}` on a dead parent) and the now-empty `:rf/spawned` map is lazily pruned, mirroring the registry prune. This removes the stale-id footgun: an action reading `[:data :rf/spawned <invoke-id>]` after the child completes now sees `nil`, never a dead id. All three destroy paths route through `teardown-actor` (explicit/exit-cascade `destroy-single!` + `destroy-single-actor!`, and the finalize auto-destroy on `:final?`), so the clear applies uniformly. No spec/005/009/002/Conventions edits; only `validation`/`transition`/`join` were left untouched (sibling lanes).

## Part 2 — websocket flagship rewritten onto `:rf/spawned` + `[:rf.machine/start]` + `rf/machine-has-tag?`
`examples/patterns/websocket/connection.cljs` no longer carries a `:socket-id` `:data` field or the late-bind self-dispatch workaround. Deleted: the `:record-socket-id` action, the `:ws/-socket-spawned` internal transition, the `:on-spawn` self-dispatch callback, and the `:exit` null-out action. The live socket-actor id is now read straight off `[:data :rf/spawned [:active]]` (via a small `socket-id` helper) — and because Part 1 clears that slot on teardown, it doubles as the connection clock for free (`:current-socket?` compares against it; a torn-down socket reads `nil`). The silent-drop failure mode of the old workaround (a dispatch fired before `:router/dispatch!` was late-bound) is gone. The init event now uses the `[:rf.machine/start]` eager kick (XState `createActor(m).start()`) instead of the `:ws/noop` hack, and the per-tag subs chain off the framework `:rf/machine-has-tag?` sub. Schema + core-doc updated to match.

## Part 3 — docs/machines/actors.md drops the pattern-3 blessing
The "Recording the spawned id" section now teaches **two** first-class mechanisms — the `:rf/spawned` `:data` slot (with the clear-on-exit / connection-clock property) and `:system-id` — and no longer blesses the `:on-spawn` self-dispatch workaround. `:on-spawn` itself is kept (locked design rf2-grw4i/v0rrr); only the blessing of the workaround changed. Added a note that the runtime registry is the read for outside-the-machine callers.

## Quality gates
- **Machines `clojure -M:test`**: 852 tests, 2777 assertions, 0 failures, 0 errors. Includes the pre-existing suite plus the changes below.
- **`npm run test:cljs`**: 8031 tests, 36927 assertions, 0 failures, 0 errors. Includes the fully-rewritten `re-frame.websocket-cljs-test` (13 deftests) reading the socket id from `:rf/spawned`, using `[:rf.machine/start]`, and asserting through `rf/machine-has-tag?`-chained subs.
- **Standalone-example compile gate**: `shadow-cljs compile examples/websocket` → Build completed, 204 files, 0 warnings.
- **`mkdocs build --strict`** (docs/machines): passed — no warnings/errors on actors.md (only pre-existing INFO messages elsewhere).
- **`npm run test:elision`**: PASS — production 45/45 absent, EP-0023 provenance + assembly-DCE, control 45/45 present. (Two pre-existing `unreachable-code` warnings in `frame_classification.cljc`, untouched by this PR.)

**Adversarial tests added** (`spawn_registry_test.clj`):
- `destroy-clears-parent-data-rf-spawned-slot-no-dead-id` — child live in `:running`; on parent `:active` exit the exit-cascade tears it down; asserts the parent's `[:data :rf/spawned [:active]]` slot is cleared (no dead id), the emptied `:rf/spawned` map is pruned, the data slot and registry slot still mirror, and an action reading its own `:data` after teardown sees `nil`.
- `finalize-auto-destroy-clears-parent-data-rf-spawned-slot` — child self-completes to `:final?` (the finalize auto-destroy path); asserts the parent's `:rf/spawned` slot is cleared there too.
- Updated the pre-existing `multi-spawn-parent-data-no-clobber` → `...per-invoke-id-key`: its old assertion "A's earlier `:data` binding survived" was asserting the stale-id footgun; it now asserts clear-on-exit (A's slot cleared on A's teardown, B's independent) — the mirror of the registry.

Do NOT merge (per dispatch instructions).