### PR TITLE
docs(spec): pin :rf/handler-context + reconcile inventories (rf2-lmflny)

### DIFF
--- a/spec/000-Vision.md
+++ b/spec/000-Vision.md
@@ -37,7 +37,7 @@ A claim to be "this pattern" requires an implementation to supply this minimal c
 
 - **Identity primitive** with the required properties (stable, namespaceable, value-equal, cheap to compare, serialisable, human-readable, reflective). Clojure keywords play this role in the CLJS reference; other hosts need an equivalent. See [§The identity primitive](#the-identity-primitive--required-properties) below.
 - **Registry** keyed by `(kind, id)` carrying per-entry metadata (`:doc`, source coords, tags, and *optionally* schema references if the implementation provides a schema layer).
-- **Event handler contract**: `(state, event) → effects-map`.
+- **Event handler contract**: `(coeffects, event) → effects-map` — the handler's first argument is the coeffects map (app-db under `:db`, the frame stamp under `:rf.frame/id`, declared coeffects, per [002 §The event handler contract](002-Frames.md#the-event-handler-contract), EP-0018 D4), not a bare state value. The v1 `(state, event)` shape is the `:db`-only specialisation of this.
 - **Registered-fx resolver**: an effects map is interpreted by looking up its keys against the registry.
 - **Subscription / derivation system**: `query → value-from-state`, with stable composition.
 - **Frame**: an isolated runtime boundary `{state, queue, sub-cache, id}`. Multi-instance, per-test, per-request, per-session — all the same shape.
@@ -109,7 +109,7 @@ The capabilities below are partitioned by what every conformant implementation m
 | Identity primitive (per [§The identity primitive](#the-identity-primitive--required-properties)) | yes | keywords | per host (branded strings, Id wrapper, sealed classes, …) | — |
 | Persistent data structures with structural sharing for `app-db` and frame state (in service of [§Frame state revertibility](#frame-state-revertibility)) | yes | yes (Clojure persistent collections) | per host — TS / Squint: Immer or Immutable.js (native JS without a library has prohibitive deep-copy cost); Kotlin/JS: im.kt or kotlinx.collections.immutable; Fable / Scala.js / PureScript / Melange / ReScript / Reason: native PDS from the source language (zero ceremony) | — |
 | Registry by `(kind, id)` with metadata | yes | yes | — | — |
-| Event handler contract `(state, event) → effects-map` | yes | yes | — | — |
+| Event handler contract `(coeffects, event) → effects-map` (the first arg is the coeffects map; `(state, event)` is its `:db`-only specialisation) | yes | yes | — | — |
 | Closed effect-map shape (`:db` and `:fx` only at top level) | yes | yes | — | — |
 | Subscription / derivation system | yes | yes (Reagent ratoms) | — | — |
 | Frame as isolated runtime boundary | yes | yes | — | — |
@@ -533,11 +533,13 @@ Plain fns continue to work inside an established frame scope; a plain fn carries
 
 ### Event shape and dispatch envelope
 
-The user-facing event shape is a vector. The internal dispatch envelope adds `:frame`, `:trace-id`, `:source` alongside the user-facing `:event` vector; handlers see these as additional keys in their `m`. Detailed in [002-Frames.md §Routing: the dispatch envelope](002-Frames.md).
+The user-facing event shape is a vector. The internal dispatch envelope adds `:frame`, `:trace-id`, `:source` alongside the user-facing `:event` vector. Event handlers see the frame stamp under `:rf.frame/id`, and `:trace-id` / `:source` when threaded, as keys in their coeffects `m` (see §Handler context map below and [Spec-Schemas §`:rf/handler-context`](Spec-Schemas.md#rfhandler-context-the-map-handlers-receive--event-context-and-fx-handler-ctx)). Detailed in [002-Frames.md §Routing: the dispatch envelope](002-Frames.md).
 
 ### Handler context map
 
-`reg-event` handlers receive `m`, the coeffects map, which carries `:frame` (always present), `:trace-id` (optional), `:source` (optional) alongside `:db` / `:event` / the declared coeffects. The handler is **two-arg** `(fn [m event-vec] ...)` (EP-0018 D4) and returns the closed effects map (`{:db … :fx …}`) or `nil`; `event-vec` is `(:event m)`. There is one event form — `reg-event-db` / `reg-event-fx` are removed and `reg-event-ctx` is framework-internal (per [EP-0018](../docs/EP/EP-0018-one-event-registration.md)).
+`reg-event` handlers receive `m`, the coeffects map, which carries `:db`, `:event`, `:rf.db/runtime`, the frame stamp under **`:rf.frame/id`** (the event-context spelling — there is no bare `:frame` coeffect, per [002 §One carrier, one name](002-Frames.md#one-carrier-one-name--the-frame-stamp)), the recordable-coeffect record under `:rf.cofx`, and the handler's declared coeffects flat, plus `:source` / `:trace-id` when threaded. The handler is **two-arg** `(fn [m event-vec] ...)` (EP-0018 D4) and returns the closed effects map (`{:db … :fx …}`) or `nil`; `event-vec` is `(:event m)`. There is one event form — `reg-event-db` / `reg-event-fx` are removed and `reg-event-ctx` is framework-internal (per [EP-0018](../docs/EP/EP-0018-one-event-registration.md)).
+
+A `reg-fx` handler receives a **separate, smaller** map (`:frame` — the frame *id*, not the record — plus `:event`, and a runtime-internal `:envelope`); it is not the event-handler coeffects map. Both maps carry the frame value as an **id keyword, never the live record**. The canonical shape of both is pinned in [Spec-Schemas §`:rf/handler-context`](Spec-Schemas.md#rfhandler-context-the-map-handlers-receive--event-context-and-fx-handler-ctx).
 
 ### `reg-frame` and `make-frame`
 

--- a/spec/002-Frames.md
+++ b/spec/002-Frames.md
@@ -388,7 +388,7 @@ The effects-map and coeffects model are as elsewhere in this spec; the rest of t
 
 #### Event context threads both partitions
 
-A standard event context threads both partitions plus the frame id and the handler's declared recordable coeffects:
+A standard event context threads both partitions plus the frame id and the handler's declared recordable coeffects (the canonical shape is pinned in [Spec-Schemas §`:rf/handler-context`](Spec-Schemas.md#rfhandler-context-the-map-handlers-receive--event-context-and-fx-handler-ctx) — this is the event-context half; the fx-handler ctx is a separate, smaller map):
 
 ```clojure
 {:coeffects
@@ -584,7 +584,7 @@ If the frame's initialisation needs to fire multiple events, list them as separa
 
 `:on-destroy` remains a **single** event dispatched before teardown.
 
-The framework stamps each setup dispatch with the frame's id automatically — the user doesn't write `dispatch` or specify `:frame`. If a setup handler needs the frame-id at runtime, it reads `(:frame m)` from its context. Each setup step carries construction provenance (`:source :frame-init` plus its step index) so the trace and tools can tell frame-init events apart from ordinary runtime events.
+The framework stamps each setup dispatch with the frame's id automatically — the user doesn't write `dispatch` or specify `:frame`. If a setup handler needs the frame-id at runtime, it reads `(:rf.frame/id m)` from its context — a setup handler is an ordinary event handler, so it reads the event-context spelling of the frame stamp, not a bare `:frame` coeffect (per [§One carrier, one name](#one-carrier-one-name--the-frame-stamp)). Each setup step carries construction provenance (`:source :frame-init` plus its step index) so the trace and tools can tell frame-init events apart from ordinary runtime events.
 
 [Spec 007 — Stories](007-Stories.md) keeps its own richer setup grammar (loaders, `:rf.story/*`) and neither desugars to nor couples to `:initial-events` (per [EP-0027 §Out of scope](../docs/EP/EP-0027-frame-initial-events.md)).
 
@@ -1406,7 +1406,7 @@ The trickiest correctness question. Consider:
 
 When `:load-todo` is dispatched in frame `:todo`, the `:my-app/http` effect fires (`:my-app/http` here is a placeholder for a user-supplied fx; the framework ships `:rf.http/managed` — see [014-HTTPRequests](014-HTTPRequests.md)). Some time later, the HTTP machinery dispatches `[:todo-loaded ...]`. **It must dispatch into `:todo`, not `:rf/default`** — otherwise the response lands in the wrong app-db.
 
-The mechanism is symmetric with how event handlers receive their context: **fx handlers receive the same `m` that the originating event handler received**, including `:frame`. Routing follows from explicit data, not implicit state.
+The mechanism is symmetric with how event handlers receive their context: **an fx handler receives the frame id in its ctx `m` under `:frame`** — the same frame the originating event ran in, carried as explicit data. Routing follows from explicit data, not implicit state. (The fx ctx is a small map distinct from the event handler's coeffects map — see [§The binary fx-handler signature](#the-binary-fx-handler-signature).)
 
 #### The binary fx-handler signature
 
@@ -1424,11 +1424,11 @@ The mechanism is symmetric with how event handlers receive their context: **fx h
 ;;         [:dispatch [:event-2]]]}
 ```
 
-`m` is the same map the originating event handler received — same `:db`, `:event`, `:frame`, `:trace-id`, `:source`, plus any cofx. fx handlers ignore the keys they don't care about.
+`m` is the fx-handler ctx — a **small map distinct from the event handler's coeffects map**: it carries `:frame` (the active frame **id** — a keyword, never the live record), `:event` (the originating event vector), and a runtime-internal `:envelope` (the parent dispatch envelope). It does **not** carry the event handler's `:db` / `:rf.cofx` / declared-flat coeffects — an fx reaches app-db only through a dispatched event. Through `(:envelope m)` a user fx MAY observe the envelope's `:trace-id` / `:origin` / `:source`, but SHOULD NOT depend on the slot. The canonical shape of both maps is pinned in [Spec-Schemas §`:rf/handler-context`](Spec-Schemas.md#rfhandler-context-the-map-handlers-receive--event-context-and-fx-handler-ctx). fx handlers ignore the keys they don't care about.
 
-For sync fx that dispatch (or otherwise need to know the frame), the pattern is `(rf/dispatch event {:frame (:frame m)})`.
+For sync fx that dispatch (or otherwise need to know the frame), the pattern is `(rf/dispatch event {:frame (:frame m)})` — `(:frame m)` is the frame **id**, fed straight into the public `:frame` opt (schema `:keyword`, per [§`:rf/dispatch-opts`](Spec-Schemas.md#rfdispatch-opts)).
 
-The runtime needs to resolve fx-handlers against the frame record (for `:fx-overrides`) and to thread the originating envelope through to reserved fxs that queue children (`:dispatch`, `:dispatch-later`, per [§Cascade propagation](#cascade-propagation)). Both reach the fx-handler as fields of `m` (`:frame` is already documented above; the parent envelope is available at `(:envelope m)` for reserved-fx implementations). User fxs typically read only `(:frame m)`; the `(:envelope m)` slot is a runtime-internal handle that the four reserved fx defmethods consume — see [§Drain-loop pseudocode](#drain-loop-pseudocode).
+The runtime needs to resolve the frame **record** (for `:fx-overrides`, and so reserved fxs can queue children — `:dispatch`, `:dispatch-later`, per [§Cascade propagation](#cascade-propagation)) and to thread the originating envelope through to those reserved fxs. It resolves the record **from the id** at the do-fx choke point (an O(1) registry lookup — the registry is the source of truth for live frames); the record itself never rides in `m`. The parent envelope is available at `(:envelope m)` for reserved-fx implementations. User fxs typically read only `(:frame m)`; the `(:envelope m)` slot is a runtime-internal handle that the four reserved fx defmethods consume — see [§Drain-loop pseudocode](#drain-loop-pseudocode).
 
 #### Async fx capture the frame in a closure
 
@@ -1918,13 +1918,18 @@ The loop has two layers — an **outer drain** (Level 4 in [005's terms](005-Sta
       ;;    synchronously before the next begins. Errors trace and continue.
       ;;    The fx-handler is invoked with the binary `(m args)` contract
       ;;    documented in [§The binary fx-handler signature](#the-binary-fx-handler-signature):
-      ;;    `m` is the same context map the originating event handler received,
-      ;;    carrying `:frame`, `:envelope`, `:event`, plus cofx. The runtime
-      ;;    needs the frame record (to resolve `:fx-overrides`) and the parent
-      ;;    envelope (so reserved fxs that queue children — `:dispatch`,
-      ;;    `:dispatch-later` — can copy envelope fields onto the child envelope,
-      ;;    per [§Cascade propagation](#cascade-propagation)); both reach the
-      ;;    fx-handler as fields of `m`, not as separate positional arguments.
+      ;;    `m` is the fx-handler ctx — a SMALL map DISTINCT from the event
+      ;;    handler's coeffects map, carrying `:frame` (the frame ID, never the
+      ;;    record), `:event`, and the runtime-internal `:envelope`. It does NOT
+      ;;    carry `:db` / cofx. The runtime needs the frame RECORD (to resolve
+      ;;    `:fx-overrides`) and the parent envelope (so reserved fxs that queue
+      ;;    children — `:dispatch`, `:dispatch-later` — can copy envelope fields
+      ;;    onto the child envelope, per [§Cascade propagation](#cascade-propagation));
+      ;;    the record is resolved FROM `(:frame m)` at the do-fx choke point
+      ;;    (registry lookup), and the envelope reaches the reserved fx as
+      ;;    `(:envelope m)` — neither rides as a separate positional argument,
+      ;;    and neither puts the live record into the handler-visible map.
+      ;;    Per Spec-Schemas §`:rf/handler-context`.
       ;;    Skipped on a pre-install throw — the chain context records the
       ;;    throw under `:rf/interceptor-error` (handler / interceptor) or
       ;;    `:rf/flow-error` (flow transform); either suppresses the walk.
@@ -1938,7 +1943,9 @@ The loop has two layers — an **outer drain** (Level 4 in [005's terms](005-Sta
       ;;    `(:rf/interceptor-error final-ctx)` / `(:rf/flow-error final-ctx)`.
       ;;    A literal port MUST read these off the chain context, not effects.
       (when-not (or (:rf/interceptor-error effects) (:rf/flow-error effects))
-       (let [m (handler-context frame envelope)]      ;; same `m` the event handler saw
+       (let [m (fx-handler-context frame envelope)]   ;; the SMALL fx ctx: {:frame <id> :event <ev> :envelope <envelope>}
+                                                      ;; — NOT the event handler's coeffects map; `:frame` is the id, resolved
+                                                      ;; from `(:id frame)`, never the record (Spec-Schemas §`:rf/handler-context`)
         (doseq [[fx-id args] (:fx effects)]
           (try
             (let [fx-handler (lookup-fx frame fx-id)]  ;; honors :fx-overrides
@@ -1984,13 +1991,17 @@ The loop has two layers — an **outer drain** (Level 4 in [005's terms](005-Sta
       (assoc :event event)))
 
 ;; Reserved-fx defmethods follow the same binary `(m args)` contract as
-;; user fxs. They reach the frame record and the parent envelope through
-;; `m` — `(:frame m)` and `(:envelope m)` — rather than as separate
-;; positional arguments. This keeps reserved and user fxs uniform: they
-;; are all `(fn [m args] ...)` to the resolver.
+;; user fxs. They read the frame ID and the parent envelope off `m` —
+;; `(:frame m)` (the id keyword, NOT the record) and `(:envelope m)` —
+;; rather than as separate positional arguments. Where the reserved fx
+;; needs the live frame RECORD (the router queue / state container), it
+;; RESOLVES it from the id via the registry (`resolve-frame`, O(1)) at
+;; this choke point — the record never rides in `m`. This keeps reserved
+;; and user fxs uniform: they are all `(fn [m args] ...)` to the resolver,
+;; and every handler-visible map stays portable (Spec-Schemas §`:rf/handler-context`).
 
 (defmethod do-fx :dispatch [m ev]
-  (let [frame           (:frame m)
+  (let [frame           (resolve-frame (:frame m))  ;; record ← id (registry lookup)
         parent-envelope (:envelope m)
         ;; Queue position is the dispatch's ORIGIN, not its target: a
         ;; child emitted from a MACHINE handler's own processing
@@ -2009,7 +2020,7 @@ The loop has two layers — an **outer drain** (Level 4 in [005's terms](005-Sta
     (dispatch frame child)))
 
 (defmethod do-fx :dispatch-later [m {:keys [ms event]}]
-  (let [frame           (:frame m)
+  (let [frame           (resolve-frame (:frame m))  ;; record ← id (registry lookup)
         parent-envelope (:envelope m)
         child           (child-envelope parent-envelope event)]
     (interop/set-timeout!

--- a/spec/Construction-Prompts.md
+++ b/spec/Construction-Prompts.md
@@ -208,7 +208,9 @@ Each entry below is one CP:
                [:on-success   {:optional true} [:vector :any]]
                [:on-error     {:optional true} [:vector :any]]]}
   (fn fx-http [m args]
-    ;; m: the dispatch envelope (the active frame, trace id, etc.)
+    ;; m: the fx-handler ctx — a small map with `:frame` (the frame ID, a
+    ;;    keyword, NOT the live record), `:event` (origin event vector), and a
+    ;;    runtime-internal `:envelope`. See Spec-Schemas §:rf/handler-context.
     ;; args: the value the user put under :http in their effect map
     (let [{:keys [method url body on-success on-error]} args
           frame-id (:frame m)]
@@ -219,7 +221,7 @@ Each entry below is one CP:
 
 **Pattern-level discipline:**
 
-- The handler is `(envelope-map, args) → side-effect`. The args are *data*; the side-effect is performed at the boundary.
+- The handler is `(fx-ctx, args) → side-effect`, where `fx-ctx` is the small fx-handler map (`:frame` = frame id, `:event`, runtime-internal `:envelope` — [Spec-Schemas §`:rf/handler-context`](Spec-Schemas.md#rfhandler-context-the-map-handlers-receive--event-context-and-fx-handler-ctx)), not the event handler's coeffects map. The args are *data*; the side-effect is performed at the boundary.
 - The handler is responsible for dispatching follow-up events (`:on-success`/`:on-error`) on the originating frame so the state-change cascade resumes.
 - The handler **may not modify `app-db` directly** — only via dispatched events.
 - Server-only effects (`:platforms #{:server}`) are skipped on the client; client-only on the server. The runtime emits `:rf.fx/skipped-on-platform` traces so it's visible.

--- a/spec/Pattern-AsyncEffect.md
+++ b/spec/Pattern-AsyncEffect.md
@@ -30,7 +30,7 @@ Three architectural properties make the shape work:
 
 - **Effects are deferred function calls described as data.** `:fx` returns a vector of `[fx-id args]` pairs; `do-fx` walks them after the handler returns. Nothing in the handler synchronously touches the outside world, so handlers stay pure (per [Principles.md](Principles.md)).
 - **Async results re-enter the runtime as named, dispatched events.** They do not mutate `app-db` directly; they cross the dispatch boundary like any other event. This is the same property that makes Pattern-StaleDetection's epoch idiom possible — the reply event is a place to attach context.
-- **Frame-aware fx handlers carry `:frame` into the closure that fires later** (per [002 §Async fx capture the frame in a closure](002-Frames.md#async-fx-capture-the-frame-in-a-closure)). The reply lands in the originating frame, not `:rf/default`.
+- **Frame-aware fx handlers carry `:frame` into the closure that fires later** (per [002 §Async fx capture the frame in a closure](002-Frames.md#async-fx-capture-the-frame-in-a-closure)). `(:frame m)` is the frame **id** (a keyword, never the live frame record — the fx ctx is portable data; see [Spec-Schemas §`:rf/handler-context`](Spec-Schemas.md#rfhandler-context-the-map-handlers-receive--event-context-and-fx-handler-ctx)), fed straight into the `{:frame …}` dispatch opt. The reply lands in the originating frame, not `:rf/default`.
 
 ## Worked example — HTTP
 

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -8,7 +8,7 @@
 The Malli forms below are the **canonical** shape descriptions for the CLJS reference. For a different in-scope host:
 
 - **Schema-bearing dynamic host** (CLJS+Malli; Squint+Zod): translate each Malli form into the host's schema language. The shape is identical; the syntax differs.
-- **Statically typed host** (TypeScript, Melange / ReScript / Reason, Fable, Scala.js, PureScript, Kotlin/JS): translate each Malli form into a type definition. The shape is identical; runtime validation is unnecessary if the type system enforces correctness throughout. A boundary validator (e.g., Zod for incoming JSON) may still be useful at system edges.
+- **Statically typed host** (TypeScript, Melange / ReScript / Reason, Fable, Scala.js, PureScript, Kotlin/JS): translate each Malli form into a type definition. The shape is identical; runtime validation *of user-declared schemas* is unnecessary if the type system enforces correctness throughout. A boundary validator (e.g., Zod for incoming JSON) may still be useful at system edges. **This applies to the user-schema plane only** — the type system covers the shapes a user declares. It does **not** discharge the *runtime shape policing at framework boundaries* the `:core/*` conformance fixtures require (closed effect-map rejection, classification-effect payloads, `input-fn` returns, interceptor refs, dispatch opts): those shapes reach the runtime after types erase (through function boundaries, the wire, or hot-swapped handlers), so a conformant static-host port still ships that policing layer regardless of its type system.
 
 A port can translate the Malli forms below mechanically. The CLJS canonical and TypeScript transcription:
 
@@ -176,6 +176,50 @@ The registration-metadata value declaring a handler's (or machine named-entry's)
 ```
 
 A malformed value (a non-vector, or an entry that is neither a keyword nor an `[id arg]` tuple) is `:rf.error/cofx-request-invalid` at registration; a referenced id with no `reg-cofx` registration is `:rf.error/unregistered-cofx`; declaring the same id twice (any args) in one consumer scope is `:rf.error/cofx-name-collision`. The key lives uniformly on `reg-event` — with the one event form (EP-0018) there is no db-only handler exempt from coeffect declaration (per [001 §`:rf.cofx/requires`](001-Registration.md#rfcofxrequires--the-declaration-key)).
+
+### `:rf/handler-context` (the map handlers receive — event-context and fx-handler-ctx)
+
+> **Layer:** Runtime
+> **Owner:** [002-Frames §Event context threads both partitions](002-Frames.md#event-context-threads-both-partitions) (event-context) + [002-Frames §The binary fx-handler signature](002-Frames.md#the-binary-fx-handler-signature) (fx-handler-ctx)
+> **Status:** v1-required
+> **Conformance:** `implementation/core/test/re_frame/event_context_coeffect_keys_test.clj` (event-context key set) + `spec/conformance/fixtures/cofx-*.edn` (event-context) + `implementation/core/test/re_frame/fx_test.cljc` (fx-handler-ctx `:frame`)
+
+The single most-touched runtime shape in application code: the map a handler receives as its first argument. **There are two related-but-distinct shapes**, and conflating them is the historical corpus bug this entry retires. Both share one invariant: **the frame value they carry is the frame *id* (a keyword), NEVER the live frame record** — handler-visible maps are portable data (replay-, SSR-, and headless-safe per [002 §Recordable coeffects](002-Frames.md#recordable-coeffects)); the do-fx layer resolves record-from-id at its own choke point (an O(1) registry lookup — the registry is the source of truth for live frames), so no host object ever rides in a map an application handler sees.
+
+**1. The event-context (coeffects) map** — what an **event handler** (`reg-event`, including machine handlers and `:initial-events` setup handlers) receives. The frame id appears under **`:rf.frame/id`** — the *event-context spelling* of the frame stamp; there is **no bare `:frame` coeffect** (retired per [002 §One carrier, one name](002-Frames.md#one-carrier-one-name--the-frame-stamp), EP-0002 R3):
+
+```clojure
+(def HandlerContextEventCoeffects
+  [:map
+   [:db                                    :any]                      ;; the app-db partition value (the inherited bare key)
+   [:event                                 [:vector :any]]            ;; the event vector — `(:event m)`, the fold's own arg
+   [:rf.db/runtime                         :any]                      ;; the runtime-db partition value (by reference)
+   [:rf.frame/id                           :keyword]                  ;; the running frame's ID — the event-context spelling; NOT the record, NOT a bare `:frame`
+   [:rf.cofx                #'Cofx]                                   ;; the envelope's recordable-coeffect map (always staged — a framework context key, reachable how `:event` is)
+   [:rf.cofx/mint-policy    {:optional true} :keyword]                ;; framework-internal: the resolved effective mint policy (not for app bodies)
+   [:source                 {:optional true} :keyword]                ;; the envelope's trigger kind, when threaded (see `:rf/dispatch-envelope` `:source`)
+   [:trace-id               {:optional true} :any]]                   ;; the envelope's trace id, when threaded
+   ;; open: declared recordable/ambient coeffects arrive FLAT under their own
+   ;;   owner-qualified ids (per `:rf.cofx/requires` — 002 §Recordable coeffects);
+   ;;   a leaf on the token but undeclared by this handler is NOT delivered flat.
+  )
+```
+
+The exact framework-default key set (no declarations, no threaded `:trace-id`) is `#{:db :event :rf.db/runtime :rf.frame/id :rf.cofx :rf.cofx/mint-policy :source}`, pinned by `event_context_coeffect_keys_test.clj`. Threading a `:trace-id` adds `:trace-id`; declared coeffects add their own flat ids; the bare `:frame` coeffect never reappears.
+
+**2. The fx-handler ctx (`m`)** — what a **binary fx-handler** (`reg-fx`) and the four reserved fx defmethods receive as their first argument. It is a **small, distinct map** — NOT the event-context map above. The frame id appears under **`:frame`** (a *sanctioned `:frame` survivor* per [002 §One carrier, one name](002-Frames.md#one-carrier-one-name--the-frame-stamp)):
+
+```clojure
+(def HandlerContextFx
+  [:map
+   [:frame                                 :keyword]                  ;; the active frame's ID — a sanctioned `:frame` survivor; NOT the record
+   [:event    {:optional true}             [:vector :any]]            ;; the originating event vector (present when there is an origin event) — 014 §Reply addressing
+   [:envelope {:optional true}             #'DispatchEnvelope]])      ;; the parent dispatch envelope — a runtime-internal handle the FOUR reserved fx consume; user fxs MAY observe `:trace-id` / `:origin` / `:source` through it, but SHOULD NOT depend on the slot's presence
+```
+
+A user fx reads only `(:frame m)` (and optionally `(:event m)`); the `(:envelope m)` slot is a runtime-internal handle for the reserved child-queueing fx (`:dispatch`, `:dispatch-later`) — see [002 §Cascade propagation](002-Frames.md#cascade-propagation). The fx ctx does **not** carry `:db` / `:rf.cofx` / declared-flat coeffects: an fx that needs app-db reads it through a dispatched event, not off `m` (fx handlers may not modify app-db directly).
+
+> **Why the record never rides.** If the live record rode in either map, handler contexts would be non-serialisable and host-object-bearing, colliding with recordable-coeffect replay ([002 §Recordable coeffects](002-Frames.md#recordable-coeffects)) and headless / JVM handler evaluation ([000 §Capability vs mechanism](000-Vision.md#capability-vs-mechanism-host-discretion-items)). Id-only keeps both maps portable; the do-fx layer resolves the record from the id at the point it actually needs the router/state container (registry lookup), and the public `dispatch` / `subscribe` API takes a frame **id OR value** and resolves internally.
 
 ### `:rf/interceptor-ref` (the interceptor reference, EP-0022)
 


### PR DESCRIPTION
Pins the single canonical `:rf/handler-context` schema and reconciles the four contradictory handler-context inventories the porting design-review (rf2-lmflny / porting finding 3) flagged. Ruling followed: **the frame value in every handler-visible map is the frame id (a keyword), never the live frame record.**

## What changed

**Canonical entry (`spec/Spec-Schemas.md`).** New `### :rf/handler-context` Runtime schema pinning the TWO genuinely distinct shapes the corpus was conflating, both id-only:
- **event-context (coeffects) map** — event handlers (`reg-event`, machines, `:initial-events`): frame id under **`:rf.frame/id`**, no bare `:frame`; exact key set `#{:db :event :rf.db/runtime :rf.frame/id :rf.cofx :rf.cofx/mint-policy :source}` (+ `:trace-id` threaded, + declared cofx flat).
- **fx-handler ctx (`m`)** — `reg-fx` + the four reserved fx: a small map `{:frame <id> :event <ev> :envelope <runtime-internal>}`; NOT the event coeffects map; no `:db`/`:rf.cofx`.

Shape verified against the implementation (`fx.cljc` L1077 fx-ctx build; `router.cljc` `assemble-initial-ctx`) and the authoritative test `event_context_coeffect_keys_test.clj`, not just prose.

**Four inventories reconciled to it:**
1. `spec/000-Vision.md` — fixed the stale `(state, event) → effects-map` minimal-core row (+ table) to `(coeffects, event)`; rewrote §Handler context map (was wrongly listing `:frame`/`:trace-id`/`:source` as what handlers see) and §Event shape to `:rf.frame/id` + the two-map split, cross-linked to the schema.
2. `spec/002-Frames.md` — fixed the §binary-fx-handler "m is the same map ... same :frame" claim and the "resolve fx-handlers against the frame **record** ... `(:frame m)`" record language (now: id in `m`, record resolved from id at the do-fx choke point); fixed the §Async-fx intro; fixed the drain-loop pseudocode (`fx-handler-context`, `resolve-frame (:frame m)` in both reserved defmethods, comment block); fixed setup-handler `(:frame m)` → `(:rf.frame/id m)`; cross-linked from §Event context.
3. `spec/Pattern-AsyncEffect.md` — code already correct (`frame-id (:frame m)`); added the id-not-record cross-reference.
4. `spec/Construction-Prompts.md` — fixed the loose "m: the dispatch envelope" and "`(envelope-map, args)`" descriptions to the accurate small fx-ctx.

**Folded in (rf2-u9f17x):** the `spec/Spec-Schemas.md` §Scope qualifier — "runtime validation *of user-declared schemas* is unnecessary…" (types cover the user-schema plane, not the framework-boundary runtime-policing plane the `:core/*` fixtures require).

No `api-manifest.edn` change: `:rf/handler-context` is a spec-internal Runtime schema, no new public var; the manifest tracks public vars only.

## Quality gates
- `scripts/check_doc_slugs.py --repo-root .` — PASS (exit 0); all new cross-reference anchors resolve.
- `mkdocs build --strict` (spec/ staged into docs/spec/ per docs.yml) — PASS (exit 0); no new warnings.
- Public-API manifest drift-check — N/A (manifest untouched; no public-var change).

## Contradiction left for review
None unresolved. The one internal contradiction — 002's drain pseudocode passing `(:frame m)` to an internal `dispatch` that takes the record — is resolved per the ruling by resolving the record from the id at the do-fx choke point (matching the implementation, where the reserved `:dispatch` fx holds `frame-id` and routes through the public `router/dispatch!`).
