### PR TITLE
refactor: one-require form sweep (rf2-qe2eoh)

### DIFF
--- a/docs/core/quickstart.md
+++ b/docs/core/quickstart.md
@@ -14,8 +14,7 @@ Here's the entire app. Read it once top to bottom, then we'll walk through what 
 
 ```clojure
 (ns quickstart.counter
-  (:require [re-frame.core :as rf])
-  (:require-macros [re-frame.core :refer [reg-view]]))
+  (:require [re-frame.core :as rf]))
 
 ;; STATE TRANSITIONS — pure functions of state, easy to read and to test.
 (defn inc-value [db] (update db :counter/value inc))
@@ -40,7 +39,7 @@ Here's the entire app. Read it once top to bottom, then we'll walk through what 
 
 ;; VIEW — reg-view hands the view a ready-to-use `dispatch` and
 ;; `subscribe`, so you don't import or wire them yourself.
-(reg-view counter-app []
+(rf/reg-view counter-app []
   [:div
    [:button {:on-click #(dispatch [:counter/dec])} "−"]
    [:span @(subscribe [:counter/value])]
@@ -54,7 +53,7 @@ A few words on the moving parts — five nouns and one verb, and they're the who
 - An [**event handler**](glossary.md#event-handler) (a "handler") is the pure function that receives an event and returns a map describing what should happen next: `{:db next-state}` here, where `:db` is the new value of app-db. Read that map as *"the next state, and anything else to do."* For the counter there's nothing else, so it's just `:db` — but the same shape grows to carry an HTTP request or a follow-up event without changing the handler's signature.
 - A [**subscription**](glossary.md#subscription) is a named, derived read of app-db, and a [**view**](glossary.md#view) renders from subscriptions and dispatches events back.
 
-(That last line — `reg-view` — needs the `:require-macros` form at the top because `reg-view` is a macro; a plain `:require` covers everything else. Don't sweat the distinction; it's the one piece of Clojure boilerplate on the page.)
+(One `require` and you're done: `[re-frame.core :as rf]` is the whole import — events, subscriptions, and `reg-view` all come through it, no second `:require-macros` line to remember.)
 
 That returned map is the handler's [**effect map**](glossary.md#effect-map), and its keys are a small, closed set: for application handlers, just `:db` (replace app-db) and `:fx` (an ordered vector of further [effects](glossary.md#effect) to run — dispatch another event, fire an HTTP request, write to local storage). Anything else in that set is reserved for the framework. Returning a key the framework doesn't recognise is a loud error rather than a silent no-op — there's no "I'll quietly ignore the typo" mode; this is the framework's standing [fail-loud](glossary.md#fail-loud-not-silent) posture, which you'll see again and again. (`:fx` is the subject of [Effects and coeffects](concepts/effects-and-coeffects.md); for the counter, `:db` alone is the whole story.)
 

--- a/examples/capabilities/machines/state_machine_walkthrough/views.cljs
+++ b/examples/capabilities/machines/state_machine_walkthrough/views.cljs
@@ -14,14 +14,13 @@
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.adapter.reagent :as reagent-adapter]
-            [state-machine-walkthrough.core])
-  (:require-macros [re-frame.core :refer [reg-view]]))
+            [state-machine-walkthrough.core]))
 
 ;; ============================================================================
 ;; VIEWS
 ;; ============================================================================
 
-(reg-view ^{:doc "The login form. Two threads of state run through it, and the
+(rf/reg-view ^{:doc "The login form. Two threads of state run through it, and the
                   whole view is easier to read once you separate them.
 
                   Thread one is the DRAFT — the email and password being typed.
@@ -77,7 +76,7 @@
                                          [:auth.login/dismiss]])}
          "Dismiss"]])]))
 
-(reg-view ^{:doc "A little banner up top that names the machine's current state —
+(rf/reg-view ^{:doc "A little banner up top that names the machine's current state —
                   handy for watching the transitions happen live. The
                   `data-state` attribute mirrors the state keyword into the DOM
                   so a test can assert the lockout transition without squinting
@@ -90,13 +89,13 @@
                      :data-state (when state (name state))}
       (if state (name state) "(uninitialised)")]]))
 
-(reg-view ^{:doc "The end of the road: what you see once the account locks out."}
+(rf/reg-view ^{:doc "The end of the road: what you see once the account locks out."}
           locked-panel []
   [:div.locked {:data-testid "locked-panel"}
    [:h2 "Account locked"]
    [:p "Three failed attempts. Contact support to unlock."]])
 
-(reg-view root-view []
+(rf/reg-view root-view []
   (let [locked? @(rf/machine-has-tag? :auth.login/flow :auth/locked)]
     [:div.app
      [:h1 "State-machines walkthrough — login lockout"]

--- a/examples/capabilities/resources/infinite_feed/core.cljs
+++ b/examples/capabilities/resources/infinite_feed/core.cljs
@@ -60,7 +60,6 @@
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.registrar :as registrar]
-            [re-frame.views]
             ;; Managed HTTP — the built-in transport resources fetch over.
             ;; Loading it registers the `:rf.http/managed` fx that every page
             ;; fetch runs on. See docs/resources/glossary.md#managed-http.
@@ -79,8 +78,7 @@
             ;; declare its resources. On entry a route ensures page 0 of an
             ;; infinite feed — just the first page, not the whole pile.
             [re-frame.routing]
-            [re-frame.adapter.reagent :as reagent-adapter])
-  (:require-macros [re-frame.core :refer [reg-view]]))
+            [re-frame.adapter.reagent :as reagent-adapter]))
 
 ;; ============================================================================
 ;; THE INFINITE RESOURCE — one growing feed, its pages held as the value
@@ -246,7 +244,7 @@
 (def ^:private feed-query
   {:resource :feed/timeline :scope :rf.scope/global :params {}})
 
-(reg-view home-page []
+(rf/reg-view home-page []
   [:div
    [:h1 "Infinite feed demo"]
    [:p "A load-more / infinite-scroll timeline as a first-class re-frame2
@@ -258,10 +256,10 @@
                        :data-testid "route-link-timeline"}
         "Open the timeline →"]]])
 
-(reg-view feed-row [{:keys [title]}]
+(rf/reg-view feed-row [{:keys [title]}]
   [:li {:data-testid "feed-row"} title])
 
-(reg-view timeline-page []
+(rf/reg-view timeline-page []
   ;; The route's `:resources` already ensured page 0 on the way in. All the view
   ;; does is read the whole feed view-model, passively, through
   ;; `[:rf.resource/infinite-state …]`.
@@ -319,12 +317,12 @@
           :else
           [:p {:data-testid "feed-end"} "— you're all caught up —"])])]))
 
-(reg-view not-found-page []
+(rf/reg-view not-found-page []
   [:div
    [:h1 "Not found"]
    [:p [rf/route-link {:to :infinite-feed.app/home :data-testid "route-link-home"} "Home"]]])
 
-(reg-view root-view []
+(rf/reg-view root-view []
   (case @(subscribe [:rf.route/id])
     :infinite-feed.app/home     [home-page]
     :infinite-feed.app/timeline [timeline-page]

--- a/examples/capabilities/resources/linearlite/core.cljs
+++ b/examples/capabilities/resources/linearlite/core.cljs
@@ -67,7 +67,6 @@
             [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.registrar :as registrar]
-            [re-frame.views]
             ;; Managed HTTP — the one transport every resource and mutation
             ;; lowers its read/write onto. Loading the ns registers the
             ;; `:rf.http/managed` fx. Guide:
@@ -85,8 +84,7 @@
             ;; `:resources` key — that's how the board route ensures the board on
             ;; entry.
             [re-frame.routing]
-            [re-frame.adapter.reagent :as reagent-adapter])
-  (:require-macros [re-frame.core :refer [reg-view reg-event reg-sub]]))
+            [re-frame.adapter.reagent :as reagent-adapter]))
 
 ;; ============================================================================
 ;; THE DOMAIN — issues + statuses
@@ -388,24 +386,24 @@
 ;; ordinary slices in the usual loop: an event writes, a sub reads, the view
 ;; reads the sub.
 
-(reg-event :linearlite/set-fail-next-write
+(rf/reg-event :linearlite/set-fail-next-write
   (fn [db [_ on?]] (assoc db :fail-next-write? on?)))
 
-(reg-event :linearlite/set-new-issue-draft
+(rf/reg-event :linearlite/set-new-issue-draft
   (fn [db [_ text]] (assoc db :new-issue-draft text)))
 
-(reg-event :linearlite/begin-edit
+(rf/reg-event :linearlite/begin-edit
   (fn [db [_ id title]] (assoc db :editing {:id id :title title})))
 
-(reg-event :linearlite/set-edit-draft
+(rf/reg-event :linearlite/set-edit-draft
   (fn [db [_ text]] (assoc-in db [:editing :title] text)))
 
-(reg-event :linearlite/cancel-edit
+(rf/reg-event :linearlite/cancel-edit
   (fn [db _] (dissoc db :editing)))
 
-(reg-sub :linearlite/fail-next-write? (fn [db _] (boolean (:fail-next-write? db))))
-(reg-sub :linearlite/new-issue-draft  (fn [db _] (or (:new-issue-draft db) "")))
-(reg-sub :linearlite/editing          (fn [db _] (:editing db)))
+(rf/reg-sub :linearlite/fail-next-write? (fn [db _] (boolean (:fail-next-write? db))))
+(rf/reg-sub :linearlite/new-issue-draft  (fn [db _] (or (:new-issue-draft db) "")))
+(rf/reg-sub :linearlite/editing          (fn [db _] (:editing db)))
 
 ;; --- the write events (fire the mutation, then get out of the way) ----------
 ;;
@@ -415,7 +413,7 @@
 ;; the board passively; the runtime does the real work — apply the optimistic
 ;; patch, send the request, commit or roll back on the reply.
 
-(reg-event :linearlite/create-issue
+(rf/reg-event :linearlite/create-issue
   (fn [{:keys [db]} [_ title]]
     (let [tmp-id (next-issue-id)]
       {:db (assoc db :new-issue-draft "")
@@ -425,7 +423,7 @@
                          :instance [:create tmp-id]
                          :cause    [:user :linearlite/create-issue]}]]]})))
 
-(reg-event :linearlite/commit-edit
+(rf/reg-event :linearlite/commit-edit
   (fn [{:keys [db]} [_ id title]]
     {:db (dissoc db :editing)
      :fx [[:dispatch [:rf.mutation/execute
@@ -434,7 +432,7 @@
                        :instance [:edit id]
                        :cause    [:user :linearlite/edit-title]}]]]}))
 
-(reg-event :linearlite/change-status
+(rf/reg-event :linearlite/change-status
   (fn [_ [_ id status]]
     {:fx [[:dispatch [:rf.mutation/execute
                       {:mutation :linearlite/change-status
@@ -461,7 +459,7 @@
 ;; VIEWS — passive board read + watched mutation instances
 ;; ============================================================================
 
-(reg-view fail-toggle []
+(rf/reg-view fail-toggle []
   (let [armed? @(subscribe [:linearlite/fail-next-write?])]
     [:label.fail-toggle {:data-testid "fail-toggle"}
      [:input {:type      "checkbox"
@@ -470,7 +468,7 @@
                                      (.. % -target -checked)])}]
      [:span "Fail the next write (simulate a server failure → rollback)"]]))
 
-(reg-view new-issue-form []
+(rf/reg-view new-issue-form []
   (let [draft @(subscribe [:linearlite/new-issue-draft])]
     [:form.new-issue {:data-testid "new-issue-form"
                       :on-submit   (fn [e]
@@ -484,7 +482,7 @@
               :on-change   #(dispatch [:linearlite/set-new-issue-draft (.. % -target -value)])}]
      [:button {:type :submit :data-testid "new-issue-submit"} "Add issue"]]))
 
-(reg-view status-picker [{:keys [id status]}]
+(rf/reg-view status-picker [{:keys [id status]}]
   ;; Pick a new column. This fires the optimistic change-status mutation: the
   ;; card jumps right away, then commits or rolls back when the reply lands.
   [:select {:data-testid (str "status-" id)
@@ -494,7 +492,7 @@
    (for [{s-id :id s-label :label} statuses]
      ^{:key s-id} [:option {:value (name s-id)} s-label])])
 
-(reg-view issue-card [{:keys [issue editing]}]
+(rf/reg-view issue-card [{:keys [issue editing]}]
   (let [{:keys [id title status optimistic?]} issue
         editing-this? (= id (:id editing))
         ;; Watch this card's in-flight writes, passively. `:optimistic?` stays
@@ -532,14 +530,14 @@
      [:div.issue-actions
       [status-picker {:id id :status status}]]]))
 
-(reg-view board-column [{:keys [status issues editing]}]
+(rf/reg-view board-column [{:keys [status issues editing]}]
   [:div.column {:data-testid (str "column-" (:id status))}
    [:h2 (:label status)]
    (into [:ul.issue-list]
          (for [issue issues]
            ^{:key (:id issue)} [issue-card {:issue issue :editing editing}]))])
 
-(reg-view board-page []
+(rf/reg-view board-page []
   ;; The route already ensured the board on entry (via its `:resources`
   ;; metadata), so this view just reads the whole thing passively through
   ;; `[:rf.resource/data …]`. Every write patches the cache, so the view
@@ -577,12 +575,12 @@
                               :issues  (filterv #(= (:id status) (:status %)) issues)
                               :editing editing}])))]))
 
-(reg-view not-found-page []
+(rf/reg-view not-found-page []
   [:div
    [:h1 "Not found"]
    [:p [rf/route-link {:to :linearlite.app/board :data-testid "route-link-board"} "Back to the board"]]])
 
-(reg-view root-view []
+(rf/reg-view root-view []
   (case @(subscribe [:rf.route/id])
     :linearlite.app/board [board-page]
     :rf.route/not-found   [not-found-page]

--- a/examples/capabilities/resources/resources/core.cljs
+++ b/examples/capabilities/resources/resources/core.cljs
@@ -47,7 +47,6 @@
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.registrar :as registrar]
-            [re-frame.views]
             ;; Managed HTTP is the transport a resource fetch rides on.
             ;; Requiring it registers the `:rf.http/managed` effect that every
             ;; ensure ultimately runs onto. See the managed-HTTP glossary entry:
@@ -67,8 +66,7 @@
             ;; route key, so it's loading *both* that makes a route allowed to
             ;; declare `:resources`.
             [re-frame.routing]
-            [re-frame.adapter.reagent :as reagent-adapter])
-  (:require-macros [re-frame.core :refer [reg-view]]))
+            [re-frame.adapter.reagent :as reagent-adapter]))
 
 ;; ============================================================================
 ;; RESOURCES — named, cached server-state reads
@@ -347,7 +345,7 @@
 ;; PAGES — passive reads; the runtime owns the state
 ;; ============================================================================
 
-(reg-view home-page []
+(rf/reg-view home-page []
   [:div
    [:h1 "Resources demo"]
    [:p "Server-state as named, cached reads. Views are passive; route entry,
@@ -360,7 +358,7 @@
 ;; open. The detail it shows was ensured under an app lease over in
 ;; `:resources.app/preview-opened`, and will be released by
 ;; `:resources.app/preview-closed`. The panel's whole job is to read and render.
-(reg-view preview-panel [slug]
+(rf/reg-view preview-panel [slug]
   (let [state @(subscribe [:rf.resource/state {:resource :article/by-slug
                                                :params  {:slug slug}}])]
     [:div.preview {:data-testid "preview-panel"}
@@ -380,7 +378,7 @@
 ;; The MACHINE-OWNED reader panel. Here the live reader actor owns this detail
 ;; for its whole lifetime; the panel just reads it passively. Hit stop and the
 ;; actor is destroyed, which is what releases the owner.
-(reg-view reader-panel [slug]
+(rf/reg-view reader-panel [slug]
   (let [state @(subscribe [:rf.resource/state {:resource :article/by-slug
                                                :params  {:slug slug}}])]
     [:div.reader {:data-testid "reader-panel"}
@@ -398,7 +396,7 @@
                :on-click    #(dispatch [:resources.app/stop-reader])}
       "Stop reader"]]))
 
-(reg-view articles-page []
+(rf/reg-view articles-page []
   ;; Getting here already ensured the list — that's what this route's
   ;; `:resources` metadata bought us. All the view has to do now is read the
   ;; resource's full state, passively.
@@ -457,7 +455,7 @@
         (when reader
           [reader-panel (:slug reader)])])]))
 
-(reg-view article-detail-page []
+(rf/reg-view article-detail-page []
   ;; Same deal as the list page: arriving here already ensured :article/by-slug
   ;; for the slug in the URL. The view just reads the result.
   (let [slug  (:slug @(subscribe [:rf.route/params]))
@@ -482,12 +480,12 @@
                          :data-testid "route-link-back"}
           "← Back"]]]))
 
-(reg-view not-found-page []
+(rf/reg-view not-found-page []
   [:div
    [:h1 "Not found"]
    [:p [rf/route-link {:to :resources.app/home :data-testid "route-link-home"} "Home"]]])
 
-(reg-view root-view []
+(rf/reg-view root-view []
   (case @(subscribe [:rf.route/id])
     :resources.app/home           [home-page]
     :resources.app/articles       [articles-page]

--- a/examples/capabilities/routing/routing/core.cljs
+++ b/examples/capabilities/routing/routing/core.cljs
@@ -22,7 +22,6 @@
      agreement"
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
-            [re-frame.views]
             ;; Routing lives in its own artefact (day8/re-frame2-routing), so
             ;; you opt into it with a require. The require has a side effect:
             ;; it registers the route subs that the `rf/reg-route` calls below
@@ -30,8 +29,7 @@
             ;; :rf.error/routing-artefact-missing — which is the runtime's
             ;; polite way of saying "you asked for routing but never packed it".
             [re-frame.routing]
-            [re-frame.adapter.reagent :as reagent-adapter])
-  (:require-macros [re-frame.core :refer [reg-view]]))
+            [re-frame.adapter.reagent :as reagent-adapter]))
 
 ;; ============================================================================
 ;; ROUTES
@@ -102,14 +100,14 @@
 ;; See the routing guide, "Linking from views":
 ;; ../../../docs/routing/concepts.md#linking-from-views
 
-(reg-view home-page []
+(rf/reg-view home-page []
   [:div
    [:h1 "Welcome"]
    [:p [rf/route-link {:to :routing.app/articles
                        :data-testid "route-link-articles"}
         "See the articles →"]]])
 
-(reg-view articles-page []
+(rf/reg-view articles-page []
   [:div
    [:h1 "Articles"]
    [:ul
@@ -120,7 +118,7 @@
                            :data-testid (str "route-link-article-" id)}
             title]])]])
 
-(reg-view article-detail-page []
+(rf/reg-view article-detail-page []
   (let [id      (:id @(subscribe [:rf.route/params]))
         article @(subscribe [:routing.app/article-by-id id])]
     ;; The "← Back" link is the same in both cases — found or not — so it's
@@ -136,7 +134,7 @@
                          :data-testid "route-link-back-to-articles"}
           "← Back"]]]))
 
-(reg-view not-found-page []
+(rf/reg-view not-found-page []
   (let [url (:url @(subscribe [:rf.route/params]))]
     [:div
      [:h1 "Not found"]
@@ -150,7 +148,7 @@
 ;; <Switch>, no nesting. The URL changes, the sub updates, this re-renders the
 ;; new page. If you were expecting more machinery, that's the whole trick:
 ;; routing is just another sub feeding just another view.
-(reg-view root-view []
+(rf/reg-view root-view []
   (case @(subscribe [:rf.route/id])
     :routing.app/home           [home-page]
     :routing.app/articles       [articles-page]

--- a/examples/core/counter/core.cljs
+++ b/examples/core/counter/core.cljs
@@ -16,9 +16,7 @@
    `dispatch`/`subscribe`."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core    :as rf]
-            [re-frame.views]
-            [re-frame.adapter.reagent :as reagent-adapter])
-  (:require-macros [re-frame.core :refer [reg-view]]))
+            [re-frame.adapter.reagent :as reagent-adapter]))
 
 ;; -- Events / subs -----------------------------------------------------------
 ;;
@@ -59,7 +57,7 @@
 ;; Var named for the symbol, which is how `counter-app` can name
 ;; `counter-buttons` just below. See `docs/core/concepts/views.md`.
 
-(reg-view counter-buttons []
+(rf/reg-view counter-buttons []
   [:div
    [:button {:on-click #(dispatch [:counter/dec])} "-"]
    [:span {:style {:margin "0 1em"} :data-testid "counter-value"} @(subscribe [:counter/value])]
@@ -69,7 +67,7 @@
 ;; ceremonial for one child, but it gives `run` a single tree to wrap in
 ;; the `frame-provider` that stands up the frame.
 
-(reg-view counter-app []
+(rf/reg-view counter-app []
   [counter-buttons])
 
 ;; -- Mount -------------------------------------------------------------------

--- a/examples/core/flows/core.cljs
+++ b/examples/core/flows/core.cljs
@@ -39,9 +39,7 @@
             ;; re-frame.flows once wires up the flow API; leave it out and the
             ;; reg-flow calls below raise :rf.error/flows-artefact-missing.
             [re-frame.flows]
-            [re-frame.views]
-            [re-frame.adapter.reagent :as reagent-adapter])
-  (:require-macros [re-frame.core :refer [reg-view with-frame]]))
+            [re-frame.adapter.reagent :as reagent-adapter]))
 
 ;; ============================================================================
 ;; FLOWS
@@ -63,7 +61,7 @@
 ;; :rf.fx/reg-flow from inside a handler — that route carries the dispatching
 ;; frame along for you, no naming required.)
 ;; See docs/core/glossary.md#frame-identity-is-carried-not-found.
-(with-frame :rf/default
+(rf/with-frame :rf/default
 
 (rf/reg-flow
   {:id     :cart/subtotal
@@ -233,7 +231,7 @@
 (defn- money [cents]
   (str "$" (.toFixed (/ cents 100) 2)))
 
-(reg-view cart-line [{:keys [sku name price qty]}]
+(rf/reg-view cart-line [{:keys [sku name price qty]}]
   [:tr {:data-testid (str "cart-line-" sku)}
    [:td name]
    [:td (money price)]
@@ -243,7 +241,7 @@
     [:button {:on-click #(dispatch [:cart/inc-qty sku])} "+"]]
    [:td (money (* price qty))]])
 
-(reg-view cart-app []
+(rf/reg-view cart-app []
   (let [items            @(subscribe [:cart/items])
         subtotal         @(subscribe [:cart/subtotal])
         total            @(subscribe [:cart/total])

--- a/examples/core/login/core.cljs
+++ b/examples/core/login/core.cljs
@@ -67,8 +67,7 @@
             ;; Turns on the canned-success / canned-failure stub fxs our
             ;; demo stub leans on (docs/core/how-to/test-a-cascade.md).
             [re-frame.http.test-support]
-            [re-frame.adapter.reagent :as reagent-adapter])
-  (:require-macros [re-frame.core :refer [reg-view]]))
+            [re-frame.adapter.reagent :as reagent-adapter]))
 
 ;; ============================================================================
 ;; SCHEMAS
@@ -546,7 +545,7 @@
 ;; the machine. And "are we busy?" / "what went wrong?" are answered by the
 ;; machine — the `:auth/busy` tag and the `:auth.login/error` sub. Slice
 ;; owns the draft; machine owns the status; the view just renders them.
-(reg-view ^{:doc "The login form view: email + password + submit button + error display."}
+(rf/reg-view ^{:doc "The login form view: email + password + submit button + error display."}
           login-form []
   (let [draft @(subscribe [:auth.login/draft])
         busy? @(rf/machine-has-tag? :auth.login/flow :auth/busy)
@@ -577,7 +576,7 @@
 ;; What you see once the flow hits :locked-out (tagged :auth/locked). That
 ;; state has no way out, so we replace the form wholesale instead of leaving
 ;; a zombie form on screen that takes input and ignores it.
-(reg-view ^{:doc "Locked-account panel shown when the login flow reaches :locked-out."}
+(rf/reg-view ^{:doc "Locked-account panel shown when the login flow reaches :locked-out."}
           locked-panel []
   [:div.locked {:data-testid "locked-panel"}
    [:h2 "Account locked"]
@@ -586,7 +585,7 @@
 ;; The top-level switch. It reads two tags off the machine and shows one of
 ;; three faces: a welcome when authed, the locked panel when locked, and the
 ;; form the rest of the time.
-(reg-view ^{:doc "Picks what to show by login state: welcome / locked panel / the form."}
+(rf/reg-view ^{:doc "Picks what to show by login state: welcome / locked panel / the form."}
           login-banner []
   (let [authed? @(rf/machine-has-tag? :auth.login/flow :auth/authenticated)
         locked? @(rf/machine-has-tag? :auth.login/flow :auth/locked)]
@@ -596,7 +595,7 @@
        locked? [locked-panel]
        :else   [login-form])]))
 
-(reg-view root-view []
+(rf/reg-view root-view []
   [:div.app
    [:h1 "Sign in"]
    [login-banner]])

--- a/examples/core/login/stories_host.cljs
+++ b/examples/core/login/stories_host.cljs
@@ -51,8 +51,7 @@
             [login.stories]
             ;; The shared Story-host helper, which owns the fiddly bits: the
             ;; live-app↔Story-shell hash router and the React-root handle.
-            [re-frame.testbed.story-host :as story-host])
-  (:require-macros [re-frame.core :refer [reg-view]]))
+            [re-frame.testbed.story-host :as story-host]))
 
 ;; -- The live-app frame ----------------------------------------------------
 ;;
@@ -68,7 +67,7 @@
     {:doc          "Login showcase live-app frame."
      :fx-overrides {:rf.http/managed :auth.login.demo/managed-stub}}))
 
-(reg-view login-app []
+(rf/reg-view login-app []
   [:div {:style {:padding "1.5em" :font-family "system-ui, sans-serif"}}
    [:p {:style {:font-size "13px" :color "#666" :margin "0 0 1em 0"}}
     "Open "

--- a/examples/core/managed_http_counter/core.cljs
+++ b/examples/core/managed_http_counter/core.cljs
@@ -40,7 +40,6 @@
   fx and the same reply shape, end to end, through Reagent and Fetch."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
-            [re-frame.views]
             ;; Managed HTTP ships in its own artefact (day8/re-frame2-http).
             ;; Requiring this once at boot is what registers `:rf.http/managed`
             ;; and its family — skip it and the first fx dispatch fails loud
@@ -59,8 +58,7 @@
             ;; head / options). Each builds the canonical
             ;; [:rf.http/managed args-map] vector so the call site stays a line.
             [re-frame.http :as rf.http]
-            [re-frame.adapter.reagent :as reagent-adapter])
-  (:require-macros [re-frame.core :refer [reg-view]]))
+            [re-frame.adapter.reagent :as reagent-adapter]))
 
 ;; ============================================================================
 ;; APP-DB SHAPE
@@ -302,7 +300,7 @@
 ;; sneaks in here. A view reads derived state and fires events; that's the
 ;; whole contract, and keeping it that thin is what keeps it predictable.
 
-(reg-view counter-view []
+(rf/reg-view counter-view []
   (let [count  @(subscribe [:counter/count])
         status @(subscribe [:counter/status])
         error  @(subscribe [:counter/error])]
@@ -321,7 +319,7 @@
       [:button {:on-click #(dispatch [:counter/start-long])}      "Start long"]
       [:button {:on-click #(dispatch [:counter/cancel])}          "Cancel"]]]))
 
-(reg-view counter-app []
+(rf/reg-view counter-app []
   [counter-view])
 
 ;; ============================================================================

--- a/examples/core/notebook/README.md
+++ b/examples/core/notebook/README.md
@@ -30,7 +30,7 @@ UI is just those Vars composed. (The document rows inside the sidebar
 are plain inline hiccup, not their own registration.)
 
 ```clojure
-(reg-view notebook []
+(rf/reg-view notebook []
   [:div.nb-shell
    [sidebar]
    [editor]

--- a/examples/core/notebook/core.cljs
+++ b/examples/core/notebook/core.cljs
@@ -37,9 +37,7 @@
   (:require [reagent.dom.client :as rdc]
             [clojure.string     :as str]
             [re-frame.core      :as rf]
-            [re-frame.views]
-            [re-frame.adapter.reagent :as reagent-adapter])
-  (:require-macros [re-frame.core :refer [reg-view]]))
+            [re-frame.adapter.reagent :as reagent-adapter]))
 
 ;; ============================================================================
 ;; SEED DATA
@@ -300,7 +298,7 @@
 ;; what it needs and dispatches on interaction — pure functions of state,
 ;; nothing reaching out to mutate. See docs/core/concepts/views.md.
 
-(reg-view sidebar []
+(rf/reg-view sidebar []
   (let [docs        @(subscribe [:notebook/documents])
         selected-id @(subscribe [:notebook/selected-id])]
     [:nav.nb-sidebar
@@ -323,7 +321,7 @@
      [:footer.nb-sidebar-footer
       [:span "Reagent substrate"]]]))
 
-(reg-view editor []
+(rf/reg-view editor []
   (let [body @(subscribe [:notebook/selected-body])
         sel  @(subscribe [:notebook/selected])]
     [:section.nb-editor
@@ -336,7 +334,7 @@
        :spellCheck  "false"
        :on-change   #(dispatch [:notebook/edit-body (.. % -target -value)])}]]))
 
-(reg-view preview []
+(rf/reg-view preview []
   (let [blocks @(subscribe [:notebook/selected-hiccup])]
     [:section.nb-preview
      [:header.nb-pane-header
@@ -345,7 +343,7 @@
      (into [:article.nb-rendered {:data-testid "notebook-preview"}]
            (or blocks []))]))
 
-(reg-view notebook []
+(rf/reg-view notebook []
   [:div.nb-shell
    [sidebar]
    [editor]

--- a/examples/core/seven_guis/cells/core.cljs
+++ b/examples/core/seven_guis/cells/core.cljs
@@ -37,11 +37,9 @@
             ;; Pulled in for its side effect: loading it wires up the hooks that
             ;; make `rf/reg-app-schema` actually do something.
             [re-frame.schemas]
-            [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter]
             [clojure.set]
-            [clojure.string :as str])
-  (:require-macros [re-frame.core :refer [reg-view with-frame]]))
+            [clojure.string :as str]))
 
 (def cols
   "Number of spreadsheet columns (A..Z)."
@@ -97,7 +95,7 @@
 ;; — `:rf/default`, the same name `run` mounts down below. The id is all that's
 ;; needed: we can register the schema here at load time, before the frame
 ;; actually exists, and it snaps into place once the frame is created.
-(with-frame :rf/default
+(rf/with-frame :rf/default
   (rf/reg-app-schema [:cells] {:schema CellsState}))
 
 ;; ============================================================================
@@ -385,7 +383,7 @@
 ;; One cell. It has two faces: while you're editing it shows an <input> holding
 ;; the raw text; otherwise it shows the computed value. Which face we wear comes
 ;; straight from subscriptions, so any edit anywhere just flows back in.
-(reg-view cell-view [id]
+(rf/reg-view cell-view [id]
   (let [editing-id @(subscribe [:cells/editing-id])
         editing?   (= editing-id id)
         raw        @(subscribe [:cells/raw   id])
@@ -427,7 +425,7 @@
                                 (dispatch [:cells/commit id (.. % -target -value)]))}]
        display)]))
 
-(reg-view cells-grid []
+(rf/reg-view cells-grid []
   [:table.cells-grid
    [:thead [:tr [:th] (for [c (range cols)] ^{:key c} [:th (char (+ 65 c))])]]
    [:tbody

--- a/examples/core/seven_guis/circle_drawer/core.cljs
+++ b/examples/core/seven_guis/circle_drawer/core.cljs
@@ -26,9 +26,7 @@
             ;; Pulling in `re-frame.schemas` wires up the hooks that teach
             ;; `rf/reg-app-schema` how to do its job. Require it, then use it.
             [re-frame.schemas]
-            [re-frame.views]
-            [re-frame.adapter.reagent :as reagent-adapter])
-  (:require-macros [re-frame.core :refer [reg-view with-frame]]))
+            [re-frame.adapter.reagent :as reagent-adapter]))
 
 ;; ============================================================================
 ;; SCHEMA
@@ -69,7 +67,7 @@
 ;; provider has mounted, so there's no frame "in scope" to pick up implicitly.
 ;; We just say which one out loud with `with-frame`. The `:rf/default` here is
 ;; the same frame the render root's `frame-provider` names below.
-(with-frame :rf/default
+(rf/with-frame :rf/default
   (rf/reg-app-schema [:drawer] {:schema DrawerState}))
 
 ;; ============================================================================
@@ -229,7 +227,7 @@
 ;; VIEW
 ;; ============================================================================
 
-(reg-view drawer-view []
+(rf/reg-view drawer-view []
   (let [circles    @(subscribe [:drawer/circles])
         dialog     @(subscribe [:drawer/dialog])
         can-undo?  @(subscribe [:drawer/can-undo?])

--- a/examples/core/seven_guis/crud/core.cljs
+++ b/examples/core/seven_guis/crud/core.cljs
@@ -29,9 +29,7 @@
             ;; is what makes `rf/reg-app-schema` below mean anything. Guide:
             ;; docs/core/how-to/validate-with-schemas.md.
             [re-frame.schemas]
-            [re-frame.views]
-            [re-frame.adapter.reagent :as reagent-adapter])
-  (:require-macros [re-frame.core :refer [reg-view with-frame]]))
+            [re-frame.adapter.reagent :as reagent-adapter]))
 
 ;; ============================================================================
 ;; SCHEMA
@@ -67,7 +65,7 @@
 ;; checks. Note we register against the frame before it exists — the name is all
 ;; the machinery needs to hang the schema on.
 ;; See docs/core/how-to/validate-with-schemas.md.
-(with-frame :rf/default
+(rf/with-frame :rf/default
   (rf/reg-app-schema [:crud] {:schema CrudState}))
 
 ;; ============================================================================
@@ -180,7 +178,7 @@
 ;; VIEW
 ;; ============================================================================
 
-(reg-view crud-view []
+(rf/reg-view crud-view []
   (let [people      @(subscribe [:crud/filtered-people])
         filter-text @(subscribe [:crud/filter-text])
         selected-id @(subscribe [:crud/selected-id])

--- a/examples/core/seven_guis/flight_booker/core.cljs
+++ b/examples/core/seven_guis/flight_booker/core.cljs
@@ -26,9 +26,7 @@
             ;; Loading re-frame.schemas registers its late-bind hooks, which
             ;; is what makes rf/reg-app-schema resolve below.
             [re-frame.schemas]
-            [re-frame.views]
-            [re-frame.adapter.reagent :as reagent-adapter])
-  (:require-macros [re-frame.core :refer [reg-view with-frame]]))
+            [re-frame.adapter.reagent :as reagent-adapter]))
 
 ;; ============================================================================
 ;; SCHEMA
@@ -51,7 +49,7 @@
 ;; name that frame here. Binding is by id, which is why this works even though
 ;; it runs at ns-load — before the provider has actually created the frame.
 ;; From here on, every commit to the `[:flight]` slice is validated.
-(with-frame :rf/default
+(rf/with-frame :rf/default
   (rf/reg-app-schema [:flight] {:schema FlightState}))
 
 ;; ============================================================================
@@ -196,7 +194,7 @@
 ;; VIEW
 ;; ============================================================================
 
-(reg-view flight-booker []
+(rf/reg-view flight-booker []
   (let [trip-type        @(subscribe [:flight/trip-type])
         start-text       @(subscribe [:flight/start-text])
         return-text      @(subscribe [:flight/return-text])

--- a/examples/core/seven_guis/temperature/core.cljs
+++ b/examples/core/seven_guis/temperature/core.cljs
@@ -27,9 +27,7 @@
             ;; hooks that make `rf/reg-app-schema` resolve. No var from it is
             ;; used directly — it just has to be on the page.
             [re-frame.schemas]
-            [re-frame.views]
-            [re-frame.adapter.reagent :as reagent-adapter])
-  (:require-macros [re-frame.core :refer [reg-view with-frame]]))
+            [re-frame.adapter.reagent :as reagent-adapter]))
 
 ;; ============================================================================
 ;; SCHEMA
@@ -54,7 +52,7 @@
 ;; `frame-provider` at the render root runs this app in `:rf/default`, so we
 ;; name that same frame here and bind the schema to it. From then on, every
 ;; commit to the `[:temp]` slice is checked against `TempState`.
-(with-frame :rf/default
+(rf/with-frame :rf/default
   (rf/reg-app-schema [:temp] {:schema TempState}))
 
 ;; ============================================================================
@@ -167,7 +165,7 @@
 ;; bidirectional "trap" the 7GUIs page warns about never even comes up, because
 ;; the fields don't know each other exists.
 
-(reg-view ^{:doc "Two text inputs, °C and °F, kept in sync through app-db."}
+(rf/reg-view ^{:doc "Two text inputs, °C and °F, kept in sync through app-db."}
           temperature-converter []
   (let [c-text @(subscribe [:temp/celsius-text])
         f-text @(subscribe [:temp/fahrenheit-text])]

--- a/examples/core/seven_guis/timer/core.cljs
+++ b/examples/core/seven_guis/timer/core.cljs
@@ -27,9 +27,7 @@
             ;; Pulling this in registers the hooks that teach the frame how to
             ;; validate against a schema — that's what makes `rf/reg-app-schema` work.
             [re-frame.schemas]
-            [re-frame.views]
-            [re-frame.adapter.reagent :as reagent-adapter])
-  (:require-macros [re-frame.core :refer [reg-view with-frame]]))
+            [re-frame.adapter.reagent :as reagent-adapter]))
 
 (def tick-ms
   "Wall-clock delay, in milliseconds, between one tick and the next. 100ms is
@@ -55,7 +53,7 @@
 ;; `frame-provider` picks (see `run`) — so the schema guards the very frame
 ;; whose commits it's meant to validate. If you want the why and the how of
 ;; schemas, that's docs/core/how-to/validate-with-schemas.md.
-(with-frame :rf/default
+(rf/with-frame :rf/default
   (rf/reg-app-schema [:timer] {:schema TimerState}))
 
 ;; ============================================================================
@@ -171,7 +169,7 @@
 ;; VIEW
 ;; ============================================================================
 
-(reg-view timer-view []
+(rf/reg-view timer-view []
   (let [progress @(subscribe [:timer/progress-pct])
         seconds  @(subscribe [:timer/elapsed-seconds])
         duration @(subscribe [:timer/duration-ms])]

--- a/examples/core/todomvc/views.cljs
+++ b/examples/core/todomvc/views.cljs
@@ -9,9 +9,7 @@
   derived state, dispatch events when the user does something. No business logic
   sneaks in here. See docs/core/glossary.md (view)."
   (:require [clojure.string :as str]
-            [re-frame.core :as rf]
-            [re-frame.views])
-  (:require-macros [re-frame.core :refer [reg-view]]))
+            [re-frame.core :as rf]))
 
 ;; Each filter is a ROUTE, so its link is a `route-link` naming the route id —
 ;; never a hand-built `#/active` string. The router's hash strategy (declared on
@@ -145,7 +143,7 @@
 ;; body `dispatch` and `subscribe` arrive in scope for free, which is exactly why
 ;; the root is the one threading them down to the helpers below.
 ;; See docs/core/concepts/views.md.
-(reg-view root-view []
+(rf/reg-view root-view []
   (let [todos @(subscribe [:todo/todos])]
     [:<>
      [:section.todoapp

--- a/examples/patterns/boot/schema.cljs
+++ b/examples/patterns/boot/schema.cljs
@@ -29,8 +29,7 @@
             ;; publishes the default validator, and requiring it is the CLJS
             ;; opt-in — skip it and the validator soft-passes, so a malformed
             ;; slice slides through with no failure trace.
-            [re-frame.schemas.malli])
-  (:require-macros [re-frame.core :refer [with-frame]]))
+            [re-frame.schemas.malli]))
 
 ;; ============================================================================
 ;; WIRE SHAPES — what the mocked endpoints return
@@ -156,7 +155,7 @@
 ;; This app lives in the `:rf/default` frame (see `core/run`), so we name that
 ;; frame explicitly with `with-frame`. The registrations then carry a frame
 ;; stamp even though they run at module-load, before `init!`.
-(with-frame :rf/default
+(rf/with-frame :rf/default
   ;; The :spawn-all children stage their payloads into [:boot/staging] before
   ;; signalling done, and :enter-hydrating reads them back out. We register
   ;; the slot so those staging writes get schema-checked like everything else.

--- a/examples/patterns/boot/views.cljs
+++ b/examples/patterns/boot/views.cljs
@@ -29,10 +29,9 @@
    The views are deliberately bare. The point is the boot shape, not a
    pretty UI."
   (:require [re-frame.core :as rf]
-            [boot.boot])
-  (:require-macros [re-frame.core :refer [reg-view]]))
+            [boot.boot]))
 
-(reg-view ^{:doc "The waiting screen — what you see while the boot
+(rf/reg-view ^{:doc "The waiting screen — what you see while the boot
                   machine is still working through its phases."}
           boot-progress []
   (let [state @(subscribe [:app.boot/state])]
@@ -51,7 +50,7 @@
       ". The main app view does not mount until the boot reaches "
       [:code ":ready"] "."]]))
 
-(reg-view ^{:doc "The :failed screen — shows what went wrong and offers
+(rf/reg-view ^{:doc "The :failed screen — shows what went wrong and offers
                   a retry that re-runs the boot from the top."}
           boot-failed []
   (let [err @(subscribe [:app.boot/error])]
@@ -67,7 +66,7 @@
                :on-click    #(dispatch [:app/boot [:boot/restart]])}
       "Retry boot"]]))
 
-(reg-view ^{:doc "The main app — the screen the boot was clearing the
+(rf/reg-view ^{:doc "The main app — the screen the boot was clearing the
                   way for. By the time it renders, all four loaded slices
                   are sitting in app-db, populated and stable."}
           main-app []
@@ -97,7 +96,7 @@
        (for [{:keys [id path]} routes]
          ^{:key id} [:li (str id " → " path)])]]]))
 
-(reg-view ^{:doc "The fork in the road. Reads the boot machine's state
+(rf/reg-view ^{:doc "The fork in the road. Reads the boot machine's state
                   and picks one of three screens — and it's the only
                   place in the app that makes that call."}
           root-view []

--- a/examples/patterns/long_running_work/views.cljs
+++ b/examples/patterns/long_running_work/views.cljs
@@ -19,14 +19,13 @@
    dispatch is the only seam where React's lifecycle reaches them."
   (:require [reagent.core :as r]
             [re-frame.core :as rf]
-            [long-running-work.worker])
-  (:require-macros [re-frame.core :refer [reg-view]]))
+            [long-running-work.worker]))
 
 ;; ============================================================================
 ;; SUB-COMPONENTS
 ;; ============================================================================
 
-(reg-view ^{:doc "The overall progress bar. Reads :work/progress-fraction
+(rf/reg-view ^{:doc "The overall progress bar. Reads :work/progress-fraction
                   (a number from 0.0 to 1.0) and grows a div's width to
                   match."}
           progress-bar []
@@ -55,7 +54,7 @@
                                    "#9e9e9e")
                      :transition "width 60ms linear"}}]]]))
 
-(reg-view ^{:doc "The per-shard breakdown. One little bar per worker, so
+(rf/reg-view ^{:doc "The per-shard breakdown. One little bar per worker, so
                   you can watch the parallel children making their own
                   independent progress."}
           shard-breakdown []
@@ -82,7 +81,7 @@
                 :data-testid (str "shard-counter-" (name shard-id))}
          (str processed " / " total)]])]))
 
-(reg-view ^{:doc "The status line — the parent machine's current :state,
+(rf/reg-view ^{:doc "The status line — the parent machine's current :state,
                   plus its recorded :outcome once it lands in a terminal
                   state (the little badge at the end)."}
           status-line []
@@ -96,7 +95,7 @@
         [:strong "Outcome: "]
         [:span {:data-testid "outcome-value"} (name outcome)]])]))
 
-(reg-view ^{:doc "The control panel. Three buttons, three events into
+(rf/reg-view ^{:doc "The control panel. Three buttons, three events into
                   the parent machine:
 
                   - Start  → [:work/flow [:start]]. The parent goes
@@ -132,7 +131,7 @@
 ;; WORK-BENCH WRAPPER — where unmount becomes cancellation
 ;; ============================================================================
 
-(reg-view ^{:doc "The work-bench — the widget that holds the whole demo,
+(rf/reg-view ^{:doc "The work-bench — the widget that holds the whole demo,
                   and the one that vanishes when you click 'Hide'. Watch
                   its `r/with-let` cleanup: on unmount it dispatches
                   [:work/flow [:cancel]] into the parent. The parent's
@@ -180,7 +179,7 @@
 (rf/reg-sub :ui/show-bench?
   (fn [db _] (get-in db [:ui :show-bench?] true)))
 
-(reg-view ^{:doc "The top-level root: a Show/Hide button and the
+(rf/reg-view ^{:doc "The top-level root: a Show/Hide button and the
                   work-bench, rendered only when shown. Hiding the bench
                   unmounts it, and that's what kicks off the cascade —
                   see work-bench above."}

--- a/examples/patterns/nine_states/core.cljs
+++ b/examples/patterns/nine_states/core.cljs
@@ -92,9 +92,7 @@
             ;; (`:rf.http/managed-canned-success` / `-failure`). Our little
             ;; per-app demo stub below just delegates to these.
             [re-frame.http.test-support]
-            [re-frame.views]
-            [re-frame.adapter.reagent :as reagent-adapter])
-  (:require-macros [re-frame.core :refer [reg-view with-frame]]))
+            [re-frame.adapter.reagent :as reagent-adapter]))
 
 ;; ============================================================================
 ;; CONSTANTS
@@ -140,7 +138,7 @@
 ;; same id `run`'s `frame-provider {:id …}` sets up), so we name it here.
 ;; Frame identity is carried, not magically found; see the frames glossary:
 ;; ../../../docs/core/glossary.md#frame-identity-is-carried-not-found
-(with-frame :rf/default
+(rf/with-frame :rf/default
   (rf/reg-app-schema [:new-todo] {:schema NewTodoSlice}))
 
 ;; ============================================================================
@@ -582,46 +580,46 @@
 ;; VIEWS — one per render-model keyword
 ;; ============================================================================
 
-(reg-view ^{:doc "State 1 — Nothing: a blank slate with a 'Get started' nudge."}
+(rf/reg-view ^{:doc "State 1 — Nothing: a blank slate with a 'Get started' nudge."}
           view-nothing []
   [:div.state.state-nothing
    [:h2 "Welcome"]
    [:p "You haven't loaded any todos yet."]
    [:button {:on-click #(dispatch [:nine-states.demo/load {:n 0}])} "Get started"]])
 
-(reg-view ^{:doc "State 2 — Loading: spinner / skeleton."}
+(rf/reg-view ^{:doc "State 2 — Loading: spinner / skeleton."}
           view-loading []
   [:div.state.state-loading
    [:p "Loading todos…"]])
 
-(reg-view ^{:doc "Error branch — the fetch failed; apologise and offer a retry."}
+(rf/reg-view ^{:doc "Error branch — the fetch failed; apologise and offer a retry."}
           view-error []
   (let [err @(subscribe [:todos/error])]
     [:div.state.state-error
      [:p.error (str "Couldn't load: " (:message err))]
      [:button {:on-click #(dispatch [:nine-states.demo/load {:n 4}])} "Retry"]]))
 
-(reg-view ^{:doc "State 3 — Empty: 'No todos yet' + CTA to add one."}
+(rf/reg-view ^{:doc "State 3 — Empty: 'No todos yet' + CTA to add one."}
           view-empty []
   [:div.state.state-empty
    [:h2 "No todos yet"]
    [:p "Add your first todo using the form below."]])
 
-(reg-view ^{:doc "State 4 — One: focused single-item layout."}
+(rf/reg-view ^{:doc "State 4 — One: focused single-item layout."}
           view-one []
   (let [todo (first @(subscribe [:todos/items]))]
     [:div.state.state-one
      [:h2 "Your todo"]
      [:p.title (:title todo)]]))
 
-(reg-view ^{:doc "State 5 — Some: standard list."}
+(rf/reg-view ^{:doc "State 5 — Some: standard list."}
           view-some []
   (let [todos @(subscribe [:todos/items])]
     [:div.state.state-some
      [:h2 (str (count todos) " todos")]
      [:ul (for [t todos] ^{:key (:id t)} [:li (:title t)])]]))
 
-(reg-view ^{:doc "State 6 — Too Many: more than anyone wants to scroll, so
+(rf/reg-view ^{:doc "State 6 — Too Many: more than anyone wants to scroll, so
                   show a search box and truncate the rest."}
           view-too-many []
   (let [todos    @(subscribe [:todos/items])
@@ -634,19 +632,19 @@
      (when (pos? overflow)
        [:p.overflow (str "…and " overflow " more.")])]))
 
-(reg-view ^{:doc "State 7 — Incorrect: per-field validation error + recovery path."}
+(rf/reg-view ^{:doc "State 7 — Incorrect: per-field validation error + recovery path."}
           view-incorrect []
   (let [err @(subscribe [:new-todo/field-error :title])]
     [:div.state.state-incorrect
      [:p.error (str "We can't add that todo: " err)]
      [:p "Please fix the title field below and submit again."]]))
 
-(reg-view ^{:doc "State 8 — Correct: success feedback (toast / checkmark)."}
+(rf/reg-view ^{:doc "State 8 — Correct: success feedback (toast / checkmark)."}
           view-correct []
   [:div.state.state-correct
    [:p.success "✓ Todo added."]])
 
-(reg-view ^{:doc "State 9 — Done/Frozen: archived list. Read-only."}
+(rf/reg-view ^{:doc "State 9 — Done/Frozen: archived list. Read-only."}
           view-done []
   (let [todos @(subscribe [:todos/items])]
     [:div.state.state-done
@@ -666,7 +664,7 @@
 ;; ask, don't tell. Move that tag to another state tomorrow and these views
 ;; don't change a line.
 
-(reg-view ^{:doc "The add-a-todo form — the thing that drives the form
+(rf/reg-view ^{:doc "The add-a-todo form — the thing that drives the form
                   region through states 7 (Incorrect) and 8 (Correct)."}
           new-todo-form []
   (let [draft       @(subscribe [:new-todo/draft])
@@ -685,7 +683,7 @@
      [:button {:type "submit" :disabled read-only?} "Add"]
      (when field-err [:p.error field-err])]))
 
-(reg-view ^{:doc "Your remote control: one button per state, so you can
+(rf/reg-view ^{:doc "Your remote control: one button per state, so you can
                   jump the demo straight to any of the nine."}
           control-panel []
   (let [read-only? @(rf/machine-has-tag? :ui/nine-states :mode/read-only)]
@@ -713,7 +711,7 @@
                :data-testid "ns-button-archive"
                :disabled read-only?} "9. Archive (Done)"]]))
 
-(reg-view ^{:doc "The root view, and the punchline of the whole example: a
+(rf/reg-view ^{:doc "The root view, and the punchline of the whole example: a
                   single `case` over :ui/render picks exactly one per-state
                   view. The control panel and form sit alongside it,
                   always on. Nine states, one branch."}

--- a/examples/patterns/nine_states/stories_host.cljs
+++ b/examples/patterns/nine_states/stories_host.cljs
@@ -57,8 +57,7 @@
             ;; The shared Story-host helper — it owns the
             ;; live-app↔Story-shell hash router and the React-root handle,
             ;; so we don't have to.
-            [re-frame.testbed.story-host :as story-host])
-  (:require-macros [re-frame.core :refer [reg-view]]))
+            [re-frame.testbed.story-host :as story-host]))
 
 ;; -- The live-app frame ----------------------------------------------------
 ;;
@@ -78,7 +77,7 @@
   (rf/with-frame :rf/default
     (rf/dispatch-sync [:nine-states.app/initialise])))
 
-(reg-view nine-states-app []
+(rf/reg-view nine-states-app []
   [:div {:style {:padding "1.5em" :font-family "system-ui, sans-serif"}}
    [:p {:style {:font-size "13px" :color "#666" :margin "0 0 1em 0"}}
     "Open "

--- a/examples/patterns/websocket/schema.cljs
+++ b/examples/patterns/websocket/schema.cljs
@@ -19,8 +19,7 @@
             ;; `re-frame.schemas` ships in day8/re-frame2-schemas.
             ;; Requiring it wires up the hooks that make `rf/reg-app-schema`
             ;; resolve at the call site below — no require, no schema.
-            [re-frame.schemas])
-  (:require-macros [re-frame.core :refer [with-frame]]))
+            [re-frame.schemas]))
 
 ;; ============================================================================
 ;; CONNECTION MACHINE :data SHAPE
@@ -106,5 +105,5 @@
 ;; scope. Call it bare at ns-load and you get :rf.error/no-frame-context.
 ;; This example lives in the :rf/default frame, so we name that frame
 ;; explicitly. See docs/core/glossary.md#capture-frame.
-(with-frame :rf/default
+(rf/with-frame :rf/default
   (rf/reg-app-schema [:messages]                   {:schema MessagesSlice}))

--- a/examples/patterns/websocket/views.cljs
+++ b/examples/patterns/websocket/views.cljs
@@ -21,16 +21,14 @@
       `cond` picking apart the raw `:state` vector. Same answer, far nicer
       to read."
   (:require [re-frame.core :as rf]
-            [re-frame.views]
             [websocket.messages]
-            [websocket.connection])
-  (:require-macros [re-frame.core :refer [reg-view]]))
+            [websocket.connection]))
 
 ;; ============================================================================
 ;; STATUS — the machine's connection state, rendered
 ;; ============================================================================
 
-(reg-view ^{:doc "Reads the machine's tag union (via this example's per-tag
+(rf/reg-view ^{:doc "Reads the machine's tag union (via this example's per-tag
                   subs) and boils it down to one status word. A state can
                   carry several tags at once, so a priority order —
                   failed > reconnecting > connected > connecting >
@@ -70,7 +68,7 @@
 ;; LIFECYCLE BUTTONS
 ;; ============================================================================
 
-(reg-view ^{:doc "The three lifecycle buttons: Connect, Drop (fake a
+(rf/reg-view ^{:doc "The three lifecycle buttons: Connect, Drop (fake a
                   transport error), and Disconnect (a clean goodbye). Drop
                   is the fun one — it reaches into the mock-server seam to
                   kill the socket, then sit back and watch the pill walk
@@ -109,7 +107,7 @@
 ;; SEND FORM
 ;; ============================================================================
 
-(reg-view ^{:doc "The message form. Connected? Your message goes straight
+(rf/reg-view ^{:doc "The message form. Connected? Your message goes straight
                   out. Not yet — disconnected, reconnecting, connecting?
                   It's queued instead, to be flushed the moment you next
                   reach :connected. The `Queued: N` text on the right is
@@ -139,7 +137,7 @@
 ;; SUBSCRIBE + REQUEST + SERVER-PUSH DEMO
 ;; ============================================================================
 
-(reg-view ^{:doc "Three buttons for the three trickier paths: subscribe
+(rf/reg-view ^{:doc "Three buttons for the three trickier paths: subscribe
                   (the topic survives reconnects, and the mock acks with a
                   synthetic push), request-reply (fire a request, watch the
                   correlated reply come back), and 'trigger server push'
@@ -177,7 +175,7 @@
 ;; INBOX
 ;; ============================================================================
 
-(reg-view ^{:doc "The inbox: everything that's arrived, newest at the top.
+(rf/reg-view ^{:doc "The inbox: everything that's arrived, newest at the top.
                   Server pushes and correlated replies alike all flow
                   through :ws/handle-message into [:messages :received],
                   and land here."}
@@ -195,7 +193,7 @@
 ;; ROOT
 ;; ============================================================================
 
-(reg-view ^{:doc "Root view of the websocket example app."}
+(rf/reg-view ^{:doc "Root view of the websocket example app."}
           root-view []
   [:div.app
    [:h1 "WebSocket — connection machine"]

--- a/examples/real-apps/realworld_resources/core.cljs
+++ b/examples/real-apps/realworld_resources/core.cljs
@@ -53,8 +53,7 @@
             [realworld-resources.auth :as auth]
             [realworld-resources.settings :as settings]
             [realworld-resources.article-editor :as editor]
-            [realworld-resources.views :as views])
-  (:require-macros [re-frame.core :refer [reg-view]]))
+            [realworld-resources.views :as views]))
 
 ;; ============================================================================
 ;; INITIALISATION
@@ -88,7 +87,7 @@
 ;; APP-SHELL VIEWS
 ;; ============================================================================
 
-(reg-view header []
+(rf/reg-view header []
   (let [authed? @(subscribe [:auth/authenticated?])
         user    @(subscribe [:auth/user])]
     [:nav.navbar.navbar-light
@@ -115,13 +114,13 @@
           [:li.nav-item [rf/route-link {:to :realworld.auth/login :class "nav-link" :data-testid "nav-signin"} "Sign in"]]
           [:li.nav-item [rf/route-link {:to :realworld.auth/register :class "nav-link" :data-testid "nav-signup"} "Sign up"]]])]]]))
 
-(reg-view footer []
+(rf/reg-view footer []
   [:footer [:div.container
             [rf/route-link {:to :realworld/home :class "logo-font"} "conduit"]
             [:span.attribution "An interactive learning project from Thinkster."
              " Code & design licensed under MIT."]]])
 
-(reg-view ^{:doc "The 'you have unsaved changes' dialog. It appears when a
+(rf/reg-view ^{:doc "The 'you have unsaved changes' dialog. It appears when a
                    `:can-leave` guard blocks a navigation — typically the editor
                    refusing to throw away a dirty draft. It reads the blocked
                    navigation off the `:rf/pending-navigation` sub; the buttons
@@ -139,10 +138,10 @@
                 :on-click #(dispatch [:rf.route/cancel (:id pending)])}
        "Stay"]]]))
 
-(reg-view not-found-page []
+(rf/reg-view not-found-page []
   [:div.not-found-page [:h1 "Page not found"] [rf/route-link {:to :realworld/home} "Home"]])
 
-(reg-view root-view []
+(rf/reg-view root-view []
   [:div.app
    [header]
    [pending-nav-dialog]

--- a/examples/real-apps/realworld_resources/schema.cljs
+++ b/examples/real-apps/realworld_resources/schema.cljs
@@ -18,8 +18,7 @@
   (:require [re-frame.core :as rf]
             ;; The schemas runtime. Loading it registers the hooks, so
             ;; rf/reg-app-schemas has something to resolve at the call site below.
-            [re-frame.schemas])
-  (:require-macros [re-frame.core :refer [with-frame]]))
+            [re-frame.schemas]))
 
 ;; ============================================================================
 ;; WIRE SHAPES — what the RealWorld API returns
@@ -144,7 +143,7 @@
 ;; a frame creation or seed. It binds the id at ns-load; the frame itself doesn't
 ;; exist until the provider first renders.
 
-(with-frame :rf/default
+(rf/with-frame :rf/default
   (rf/reg-app-schemas
     {[:auth]                 AuthSlice
      [:auth :login-form]     FormSlice

--- a/examples/substrates/reagent_slim/counter/core.cljs
+++ b/examples/substrates/reagent_slim/counter/core.cljs
@@ -22,11 +22,9 @@
    that exercises the pure-CLJS SSR path the gate inspects. Read past them."
   (:require [reagent2.dom.client                :as rdc]
             [re-frame.core                      :as rf]
-            [re-frame.views]
             ;; Monorepo-only spelling (see the ns docstring). Your app picks
             ;; slim by its deps coordinate, not by naming this namespace.
-            [re-frame.adapter.reagent-slim      :as reagent-slim-adapter])
-  (:require-macros [re-frame.core :refer [reg-view]]))
+            [re-frame.adapter.reagent-slim      :as reagent-slim-adapter]))
 
 ;; -- Events / subs (the handler registry is app-global) ----------------------
 ;;
@@ -56,13 +54,13 @@
 ;; at render time rather than baking one in. Here it finds slim (see `boot!`).
 ;; See docs/core/concepts/views.md.
 
-(reg-view counter-buttons []
+(rf/reg-view counter-buttons []
   [:div
    [:button {:on-click #(dispatch [:counter/dec])} "-"]
    [:span {:style {:margin "0 1em"} :data-testid "counter-value"} @(subscribe [:counter/value])]
    [:button {:on-click #(dispatch [:counter/inc])} "+"]])
 
-(reg-view counter-app []
+(rf/reg-view counter-app []
   [counter-buttons])
 
 ;; -- Mount -------------------------------------------------------------------

--- a/tools/template/resources/day8/re_frame2_template/_reagent/views.cljs
+++ b/tools/template/resources/day8/re_frame2_template/_reagent/views.cljs
@@ -4,7 +4,7 @@
    subscriptions deliver values, dispatches send events, and the runtime
    schedules re-renders when inputs change.
 
-   `reg-view` (the Reagent macro) defines the view symbol *and* registers
+   `rf/reg-view` defines the view symbol *and* registers
    it under (keyword *ns* sym), and auto-injects `dispatch` /
    `subscribe` as lexical bindings resolved to the frame in scope at
    render time.
@@ -20,16 +20,14 @@
      - shape subscriptions so each row subscribes to *its* slice, not
        the whole collection — collection-level subscriptions cause every
        row to re-render on every cell change."
-  (:require [re-frame.core]
-            [re-frame.views])
-  (:require-macros [re-frame.core :refer [reg-view]]))
+  (:require [re-frame.core :as rf]))
 
-(reg-view counter-buttons []
+(rf/reg-view counter-buttons []
   [:div
    [:button {:on-click #(dispatch [:counter/increment])} "+1"]
    [:span {:style {:margin "0 1em"}} @(subscribe [:counter/value])]])
 
-(reg-view counter-app []
+(rf/reg-view counter-app []
   [:div
    [:h1 "{{name}}"]
    [counter-buttons]])

--- a/tools/template/test/day8/re_frame2_template/template_emission_test.clj
+++ b/tools/template/test/day8/re_frame2_template/template_emission_test.clj
@@ -81,10 +81,12 @@
   load-order assertion below.
 
   Both `:require` and `:require-macros` are walked: the Reagent scaffold
-  brings `reg-view` in via `:require-macros [re-frame.core :refer
-  [reg-view]]` and calls it bare, so walking `:require-macros` too keeps
-  that central macro visible to the surface-drift audit. `:refer`-ed
-  symbols from either clause feed the bare-symbol audit below."
+  brings `re-frame.core` in via the one-require form
+  `[re-frame.core :as rf]` and calls `rf/reg-view` qualified, so the
+  qualified-symbol audit sees that central macro. Walking `:require-macros`
+  too keeps any `:refer`-ed symbols visible to the surface-drift audit,
+  and `:refer`-ed symbols from either clause feed the bare-symbol audit
+  below."
   [ns-form]
   (let [clauses    (drop 2 ns-form) ;; skip `ns` + ns-sym
         require?   #(and (sequential? %)
@@ -404,12 +406,13 @@
   shapes are audited:
 
     1. `<alias>/<sym>` qualified references whose alias resolves to a
-       `re-frame.*` ns (e.g. `rf/dispatch`).
+       `re-frame.*` ns (e.g. `rf/dispatch`, `rf/reg-view` — the Reagent
+       scaffold uses the one-require form `[re-frame.core :as rf]` and
+       calls `rf/reg-view` qualified). Without this, a rename of
+       `reg-view` would ship the Reagent scaffold broken-but-green.
     2. Bare, `:refer`-ed framework symbols whose source ns
-       is `re-frame.*` (e.g. the Reagent scaffold's `(reg-view …)`,
-       brought in via `:require-macros [re-frame.core :refer [reg-view]]`
-       and called unqualified). Without this, a rename of `reg-view`
-       would ship the Reagent scaffold broken-but-green."
+       is `re-frame.*` (none in the current scaffolds, but the audit
+       still covers the shape so a future `:refer` stays honest)."
   [substrate ^java.io.File file root]
   (when (.isFile file)
     (let [forms      (read-cljs-forms file)


### PR DESCRIPTION
Converts the multi-require import ceremony to the blessed **one-require form** across the quickstart docs, the example apps, and the Reagent template scaffold (bead **rf2-qe2eoh**, design-review day-one-dx gap 4).

## What changed

The canonical form, verified against `implementation/core/src/re_frame/core.cljc` (~L151-169: `re-frame.views` is required transitively by `re-frame.core`, and `reg-view`/`with-frame`/`reg-event`/`reg-sub` are all self-`:require-macros`-exposed under `rf/`):

```clojure
(:require [re-frame.core :as rf])   ; call rf/reg-view, rf/with-frame, …
```

Mechanically, per file:
- dropped the redundant bare `[re-frame.views]` require,
- dropped the `(:require-macros [re-frame.core :refer [...]])` clause,
- prefixed the previously-bare macro calls (`reg-view`, `with-frame`, `with-new-frame`, `reg-event`, `reg-sub`) with `rf/`.

Docs:
- `docs/core/quickstart.md` — Beat 1 code block to the one-require form; the `:require-macros` apology parenthetical replaced with a one-line "one require and you're done" note.
- `examples/core/notebook/README.md` — snippet `reg-view` → `rf/reg-view` to match its swept source.

Template:
- `_reagent/views.cljs` scaffold to `[re-frame.core :as rf]` + `rf/reg-view`; refreshed the two stale ceremony descriptions in `template_emission_test.clj` docstrings/comments (the surface-drift audit logic is generic and unchanged).

No behaviour or non-require code changed.

## Scope / skipped (concurrent-worker carve-outs)
- `examples/real-apps/realworld_http/**` — flagship owned by a concurrent worker (untouched).
- `examples/real-apps/realworld_resources/auth.cljs`, `article_editor.cljs` — explicit carve-outs; a concurrent worker is rewriting reply-handling bodies. The require change here forces body edits (`reg-view` → `rf/reg-view`), so these were **skipped** to keep a clean 3-way merge.
- `examples/real-apps/realworld_resources/settings.cljs`, `views.cljs` — dense reply-handling (13/15 sites); **skipped** for the same collision-avoidance reason.
- `examples/substrates/reagent_slim/counter/bundle_isolation_entry.cljs` — a bundle-isolation fixture with a lone `[re-frame.views]` (no `re-frame.core`), not the ceremony; left as-is.

## Quality gates
- **`mkdocs build --strict`** — PASS locally (exit 0, no warnings; quickstart clean).
- **Static validation** — all 29 swept ns forms verified paren-balanced with zero stale bare macro calls; no `rf/rf/` double-prefixes; no ceremony false-positives inside docstrings/comments.
- **Standalone-example compile gate** (`npm run test:examples-compile`) — NOT run locally (needs a full `npm install` + shadow-cljs JVM compile; skipped to avoid Windows worktree file-locks and time cost). Relying on CI. The change is transitivity-safe per core.cljc and matches the already-shipping uix/helix one-require form.
- **Template tests** (`template_emission_test`, `version_lockstep_test`) — NOT run locally (JVM); relying on CI. The emission test's surface-drift audit resolves `rf/reg-view` via the `:as rf` alias, so the qualified form is covered.
