### PR TITLE
docs: reg-view authoring lane + todomvc sub-view rewrite (rf2-xoafxf)

### DIFF
--- a/docs/core/concepts/views.md
+++ b/docs/core/concepts/views.md
@@ -213,6 +213,46 @@ That isn't an oversight — it's [frame identity is carried, not found](../gloss
 
     That pairing is how a tool panel or story canvas hosts a view it doesn't know at the call site, how a code-gen pipeline emits views from a manifest, and how Reagent class components (`create-class`) register. If you're building screens, you won't reach for either — they're the host/tooling entry points, not the app-facing one. The full split is in the API reference's [Views section](../../api/re-frame.core.md#views).
 
+### Which style for which view: the authoring lane
+
+`reg-view` and plain `defn` both produce a valid view, so a real app quickly faces a choice at every component: which one? There's a single rule, and holding to it is what keeps a codebase readable — every view announces its kind by its form:
+
+> **A view that touches state — that `subscribe`s or `dispatch`es — is a `reg-view`. A plain `defn` is for a helper that takes *data + callbacks* only and reaches for no state of its own. Never thread `dispatch`/`subscribe` down as arguments.**
+
+The pull toward the anti-pattern is real, because it *works*. You register the root view, and then it feels natural to hand its injected `dispatch` and `subscribe` down to each child as ordinary function arguments — `[todo-item dispatch subscribe todo]` — so the children can stay plain `defn`s. The tree renders correctly. But now every child is an unregistered fn: it has no id, so it renders under the fallback trace key `[:rf.view/anonymous nil]` (see [When something renders wrong](#when-something-renders-wrong)), and a reader can't tell at a glance which components are the app's real, addressable views and which are throwaway helpers. The house rule disappears into the argument lists.
+
+Register the state-touching child instead, and it subscribes to exactly the slice it needs:
+
+```clojure
+;; Anti-pattern — dispatch/subscribe drilled down as args. The child is an
+;; unregistered fn: no trace name, and the "which style?" rule is invisible.
+(rf/reg-view todo-list []
+  [:ul
+   (for [todo @(subscribe [:todos/visible])]
+     ^{:key (:id todo)} [todo-item dispatch subscribe todo])])   ; drilled
+
+(defn todo-item [dispatch subscribe {:keys [id title]}]          ; plain fn, but touches state
+  [:li {:on-click #(dispatch [:todo/toggle id])} title])
+
+;; House rule — the state-touching child is a reg-view. It subscribes to what it
+;; needs by its own id; the parent hands it only data. Named in the trace.
+(rf/reg-view todo-list []
+  [:ul
+   (for [todo @(subscribe [:todos/visible])]
+     ^{:key (:id todo)} [todo-item todo])])                      ; data only
+
+(rf/reg-view todo-item [{:keys [id title]}]
+  (let [editing? @(subscribe [:todo/editing? id])]               ; asks for its own state
+    [:li {:class (when editing? "editing")
+          :on-click #(dispatch [:todo/toggle id])} title]))
+```
+
+The plain-`defn` lane is not a lesser option — it's the right lane for a *genuine helper*: a controlled input that takes its `:value` and `on-change` as props, a formatting fn that turns a data map into hiccup, a presentational wrapper. What marks a helper is that everything it depends on is in its signature and it touches no state. The moment a component reaches for `subscribe` or `dispatch`, it has state to touch, and that's the `reg-view` lane. The [TodoMVC example](../../../examples/core/todomvc) is written to this rule: its state-touching views (`task-entry`, `task-list`, `todo-item`, `footer-controls`) are each a `reg-view`; only `todo-input` (data + callbacks) and `filter-link` (pure data → hiccup) stay plain fns.
+
+!!! note "On the hooks substrates"
+
+    UIx and Helix don't have the `reg-view` macro; a component reaches for the frame through the adapter's hooks (`use-subscribe`, `use-current-frame`) instead — see the *"`reg-view` is the Reagent surface"* note under [`reg-view`: registering a view for project code](#reg-view-registering-a-view-for-project-code) above. The *lane rule still holds*: a component that reads state reads it through those hooks itself, rather than receiving a `dispatch`/`subscribe` (or their hook results) drilled down as props. Reach for state where you need it; don't thread it.
+
 ## The one rule: views compute hiccup only
 
 Now the single discipline that keeps views fast, correct, and easy to debug. It pays for itself within a day of writing real screens:

--- a/examples/core/todomvc/views.cljs
+++ b/examples/core/todomvc/views.cljs
@@ -1,13 +1,20 @@
 (ns todomvc.views
   "The TodoMVC markup, written as hiccup.
 
-  A few things on show. `reg-view` for the root view — inside its body
-  `subscribe` and `dispatch` are simply in scope, no ceremony. Plain helper fns
-  for the sub-views, which take `dispatch`/`subscribe` as explicit args, because
-  that's the honest shape for an ordinary function. And hiccup throughout, which
-  is really just markup-as-data. The job of a view is small and strict: read
-  derived state, dispatch events when the user does something. No business logic
-  sneaks in here. See docs/core/glossary.md (view)."
+  One authoring rule runs through this file, and it's the re-frame2 house rule:
+  a view that touches state — that `subscribe`s or `dispatch`es — is a
+  `reg-view`, so the frame-bound `dispatch`/`subscribe` arrive in scope and the
+  view gets a name in the trace. A plain `defn` is for a genuine helper that
+  takes *data + callbacks* only and never reaches for state itself. So the
+  sub-views here (`task-entry`, `task-list`, `todo-item`, `footer-controls`) are
+  each a `reg-view` that reads exactly the slice it needs; the two true helpers
+  (`todo-input`, `filter-link`) stay plain fns. No `dispatch`/`subscribe` is
+  threaded down as an argument — a view that needs state subscribes to it.
+
+  And hiccup throughout, which is really just markup-as-data. The job of a view
+  is small and strict: read derived state, dispatch events when the user does
+  something. No business logic sneaks in here.
+  See docs/core/concepts/views.md (the reg-view authoring lane)."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]))
 
@@ -21,17 +28,20 @@
   {:all :todo/all, :active :todo/active, :completed :todo/completed})
 
 ;; A CONTROLLED text input — the workhorse behind both the header box and the
-;; edit-in-place box. `:value` comes from a draft sub, and every keystroke
-;; dispatches `on-change` to write that draft into app-db. The input itself
-;; never holds the text; app-db does. Enter commits (`on-commit`), Escape
-;; cancels (`on-cancel`), and losing focus commits too. There's a subtle bit
-;; here: cancelling unmounts the input, so the blur that follows finds nothing
-;; left to save. Tidy by accident, and on purpose.
+;; edit-in-place box. It's a plain `defn` on purpose: it touches no state of its
+;; own. Everything it needs arrives as data + callbacks in its props map, which
+;; is the honest shape for a reusable helper — what it depends on is right there
+;; in the signature. `:value` comes from a draft its caller subscribed to, and
+;; every keystroke calls `on-change` so the caller can write that draft into
+;; app-db. The input itself never holds the text; app-db does. Enter commits
+;; (`on-commit`), Escape cancels (`on-cancel`), and losing focus commits too.
+;; There's a subtle bit here: cancelling unmounts the input, so the blur that
+;; follows finds nothing left to save. Tidy by accident, and on purpose.
 ;;
 ;; `:autofocus?` drops the cursor into the input the moment it mounts — exactly
 ;; what the edit box wants, since the row just flipped into edit mode. A `:ref`
 ;; callback calls `.focus()` on the real DOM node. It touches focus and nothing
-;; else; `:value` stays bound to the sub.
+;; else; `:value` stays bound to the draft.
 (defn todo-input [{:keys [draft on-change on-commit on-cancel autofocus?] :as props}]
   (let [handle-keydown
         (fn [event]
@@ -51,9 +61,10 @@
          ;; Focus-only ref: nudge the cursor into the just-mounted input.
          {:ref (fn [node] (when node (.focus node)))}))]))
 
-(defn todo-item [dispatch subscribe {:keys [id title completed]}]
-  ;; A plain form-1 fn — nothing fancy. The per-row editing flag lives in app-db,
-  ;; so each row just asks a sub keyed by its own id: "am I the one being edited?"
+(rf/reg-view todo-item [{:keys [id title completed]}]
+  ;; A state-touching view, so a `reg-view`. It subscribes to what it needs by
+  ;; the row's own id — "am I the one being edited?" — rather than being handed
+  ;; the editing state from above. The per-row editing flag lives in app-db.
   (let [editing? @(subscribe [:todo.ui/editing? id])]
     [:li {:class (str/join " " (cond-> []
                                  completed (conj "completed")
@@ -74,6 +85,8 @@
       [:button.destroy
        {:on-click #(dispatch [:todo/delete id])}]]
      (when editing?
+       ;; `todo-input` is a plain helper, so this view subscribes to the draft
+       ;; and hands it down as data, with dispatching callbacks alongside.
        [todo-input
         {:class       "edit"
          :draft       @(subscribe [:todo.ui/draft :edit])
@@ -82,9 +95,11 @@
          :on-commit   #(dispatch [:todo.ui/commit-edit])
          :on-cancel   #(dispatch [:todo.ui/stop-edit])}])]))
 
-(defn task-entry [dispatch subscribe]
+(rf/reg-view task-entry []
   [:header.header
    [:h1 "todos"]
+   ;; Same pattern as the edit box: subscribe to the draft here, hand it to the
+   ;; plain `todo-input` helper as data with dispatching callbacks.
    [todo-input
     {:id          "new-todo"
      :class       "new-todo"
@@ -96,7 +111,7 @@
      ;; Escape just empties the draft.
      :on-cancel   #(dispatch [:todo.ui/edit-field :new ""])}]])
 
-(defn task-list [dispatch subscribe]
+(rf/reg-view task-list []
   [:section.main {:id "main"}
    [:input#toggle-all.toggle-all
     {:type "checkbox"
@@ -107,17 +122,21 @@
    [:ul.todo-list {:id "todo-list"}
     (for [{:keys [id] :as todo} @(subscribe [:todo/visible-todos])]
       ^{:key id}
-      [todo-item dispatch subscribe todo])]])
+      ;; `todo-item` is itself a `reg-view` — it subscribes to its own editing
+      ;; state — so all it needs from here is the todo map to render.
+      [todo-item todo])]])
 
 (defn- filter-link [showing filter-kw label]
-  ;; `route-link` renders the `<a>` and owns the click: the href is the route's
-  ;; URL (encoded to `#/active` by the frame's hash strategy), and a plain click
-  ;; navigates through `:rf/url-requested`. The `:class` marks the active filter.
+  ;; A plain `defn`: it touches no state, it's a pure function from data
+  ;; (`showing`, the filter it stands for) to hiccup. `route-link` renders the
+  ;; `<a>` and owns the click: the href is the route's URL (encoded to `#/active`
+  ;; by the frame's hash strategy), and a plain click navigates through
+  ;; `:rf/url-requested`. The `:class` marks the active filter.
   [rf/route-link {:to    (filter->route filter-kw)
                   :class (when (= showing filter-kw) "selected")}
    label])
 
-(defn footer-controls [dispatch subscribe]
+(rf/reg-view footer-controls []
   (let [[active completed] @(subscribe [:todo/footer-counts])
         showing @(subscribe [:todo/showing])]
     [:footer.footer {:id "footer"}
@@ -136,22 +155,21 @@
          :on-click #(dispatch [:todo/clear-completed])}
         "Clear completed"])]))
 
-;; The sub-views above (task-entry, task-list, todo-item, footer-controls) are
-;; plain Reagent helper fns. They take `dispatch` / `subscribe` as explicit args
-;; because that's the clearest shape for an internal helper — what it needs is
-;; right there in the signature. `reg-view` is reserved for the root: inside its
-;; body `dispatch` and `subscribe` arrive in scope for free, which is exactly why
-;; the root is the one threading them down to the helpers below.
+;; The root view. Like every state-touching view in this file it's a `reg-view`,
+;; and because its children subscribe to what they need, all it does is decide
+;; which sub-views to show — no `dispatch`/`subscribe` gets threaded down. That's
+;; the reg-view authoring lane at work: a view that needs state asks for it,
+;; rather than receiving it prop-drilled from above.
 ;; See docs/core/concepts/views.md.
 (rf/reg-view root-view []
   (let [todos @(subscribe [:todo/todos])]
     [:<>
      [:section.todoapp
-      [task-entry dispatch subscribe]
+      [task-entry]
       (when (seq todos)
-        [task-list dispatch subscribe])
+        [task-list])
       (when (seq todos)
-        [footer-controls dispatch subscribe])]
+        [footer-controls])]
      [:footer.info
       [:p "Double-click to edit a todo"]
       [:p

--- a/spec/004-Views.md
+++ b/spec/004-Views.md
@@ -182,6 +182,20 @@ View registration sorts into two lanes that should be documented separately beca
 
 Both lanes write into the same view registry; the split is about *who registers and how they address the view*, not about two registries. App-facing docs should teach the `reg-view` lane without the tooling internals (host panel components, by-id hosting) mixed in; tooling and adapter authors get the `reg-view*` / `view` lane documented on its own. The remainder of this section specifies both surfaces.
 
+### The authoring-lane rule (which lane an author picks per view)
+
+The two lanes above answer *who registers a view and how they address it*. A separate, more frequent question faces the application author at every component in a tree: `reg-view` or plain `defn`? This spec fixes a single rule, and **this spec ([004](004-Views.md)) is its owner** — the guide's [Views concept page](../docs/core/concepts/views.md) teaches it and the [TodoMVC example](../examples/core/todomvc/views.cljs) models it, both deferring here for the rule itself.
+
+> **A view that touches state — that `subscribe`s or `dispatch`es — MUST be authored as a `reg-view`. A plain `defn` view is reserved for a helper that takes *data + callbacks* only and reaches for no state of its own. `dispatch` / `subscribe` MUST NOT be threaded down to a sub-view as arguments.**
+
+The rationale is threefold, and each leg is a property the framework otherwise guarantees:
+
+- **Trace identity.** A `reg-view` renders under its registered id; an unregistered `defn` renders under the fallback key `[:rf.view/anonymous nil]` (see [009 §render trace](009-Instrumentation.md)). Threading `dispatch`/`subscribe` into a plain `defn` so it can touch state produces a component that *has* a name it could carry but doesn't — every such sub-view collapses into `:rf.view/anonymous`, and the trace can no longer distinguish them.
+- **Frame carriage.** The injected `dispatch`/`subscribe` a `reg-view` gets are already frame-bound at render time (see [§`reg-view` is the multi-frame contract](#reg-view-is-the-multi-frame-contract)). A view that subscribes to its own state gets that carriage for free; drilling the ops down as arguments is a hand-rolled substitute for a binding the macro already provides correctly.
+- **Legibility.** When state-touching views are `reg-view`s and helpers are plain fns, a component's *form* announces its kind — a reader tells the app's addressable views from throwaway presentational helpers at a glance. Drilling erases that signal: a plain `defn` that receives `dispatch`/`subscribe` is a state-touching view wearing a helper's clothes.
+
+The plain-`defn` lane remains first-class for a *genuine* helper: a controlled input taking `:value` + `on-change` as props, a formatter mapping a data record to hiccup, a presentational wrapper. The discriminant is single: **does the component reach for `subscribe` or `dispatch`?** If yes, it is a state-touching view and belongs in the `reg-view` lane; if everything it depends on is in its signature, it is a helper and stays a plain `defn`. On the hooks substrates (UIx / Helix) the same rule holds with the substrate's own idiom: a state-touching component reads state through the adapter hooks (`use-subscribe`, `use-current-frame`) itself rather than receiving those results as drilled props (see the [Views concept page](../docs/core/concepts/views.md)).
+
 ## `reg-view` is the multi-frame contract
 
 `reg-view` is a **defn-shape macro**. It registers a render function under an auto-derived id, defs the symbol you supply to the wrapped (frame-aware) fn, and auto-injects two lexical bindings — `dispatch` and `subscribe` — at every call to the rendered fn. It is the **app-facing lane**.


### PR DESCRIPTION
Implements **rf2-xoafxf** (design-review gap 6 / day-one-dx finding 3, P3).

Two parts, tied together by one rule.

## The rule stated

TodoMVC threaded `dispatch`/`subscribe` positionally through its sub-views (prop-drilling), so every sub-view traced as `:rf.view/anonymous` — while spec 004 calls `reg-view` the 80% lane. A day-one reader couldn't tell which style was the house rule. This states it once:

> **A view that touches state — that `subscribe`s or `dispatch`es — MUST be authored as a `reg-view`. A plain `defn` view is reserved for a helper that takes *data + callbacks* only and reaches for no state of its own. `dispatch`/`subscribe` MUST NOT be threaded down to a sub-view as arguments.**

- **`spec/004-Views.md`** — new `### The authoring-lane rule` subsection, added *alongside* (not disturbing) u9pkoz's view-state-placement section. Spec 004 is named the rule's owner; rationale is threefold (trace identity, frame carriage, legibility). The hooks-substrate variant (UIx/Helix read through adapter hooks, not drilled props) is noted.
- **`docs/core/concepts/views.md`** — new `### Which style for which view: the authoring lane` subsection under the `reg-view` section, with a before/after code contrast and a pointer to TodoMVC as the canonical model.

## The todomvc rewrite

The four prop-drilled sub-views move onto the reg-view lane; the two genuine helpers stay plain fns:

- `task-entry`, `task-list`, `todo-item`, `footer-controls` → each now a `reg-view` that subscribes to exactly the slice it needs. `dispatch`/`subscribe` dropped from every signature (they arrive injected); call sites updated (`[todo-item todo]`, not `[todo-item dispatch subscribe todo]`); `root-view` no longer threads them down.
- `todo-input` (data + callbacks) and `filter-link` (pure data → hiccup) stay plain `defn`s.

Behaviour-preserving: the rendered hiccup is identical. The only observable change is that every sub-view now traces by name instead of `:rf.view/anonymous`. Comments rewritten to teach the rule at each site.

## Quality gates

- **`mkdocs build --strict`** — PASS (exit 0). No warnings on `views.md`/`004-Views.md`; the new intra-doc anchors and the `../../../examples/core/todomvc` relative link resolve. (Fixed two link targets that pointed at an admonition title rather than a heading before they could ship broken.)
- **Standalone-example compile gate** (`shadow-cljs compile examples/todomvc`) — PASS: 173 files, **0 warnings**, exit 0. This is the exact gate class (`test:examples-compile`) that catches ns/require/form regressions in the changed file.
- **CLJS test suite** (`npm run test:cljs`, node runtime) — PASS: **8039 tests, 36945 assertions, 0 failures, 0 errors** — including `todomvc-cljs-test` (cold-boot + id-allocation integration test that drives the example's events/subs/cofx).
- **Reagent adapter smoke** — the todomvc-specific coverage is `todomvc_cljs_test.cljs` (in the node-test bundle above, green). The 3 adapter-level browser smokes don't cover todomvc per the test-free-examples policy (rf2-8cevm), so the CLJS test is the relevant gate.
- **`check_doc_slugs.py`** — PASS (exit 0).
