### PR TITLE
docs(spec): bracket 'per-session frames' (rf2-fuq4wn)

### DIFF
--- a/spec/000-Vision.md
+++ b/spec/000-Vision.md
@@ -19,7 +19,7 @@ The rationale that justifies the pattern's shape lives across re-frame's existin
 
 The headline shape:
 
-- **Frames** are isolated runtime boundaries — `{state, queue, sub-cache, id}` (multi-instance, per-test, per-request, per-session) (Spec 002).
+- **Frames** are isolated runtime boundaries — `{state, queue, sub-cache, id}` (multi-instance, per-test, per-request) (Spec 002).
 - **Registration** carries rich metadata; every registered entity is queryable (Spec 001 / 010).
 - **Views** are pure functions of `(state, props) → render-tree`; the render-tree is serialisable data (Spec 004).
 - The **CLJS reference** makes concrete bindings (atom, Malli, Reagent, hiccup, ...) without committing the pattern to them.
@@ -40,7 +40,7 @@ A claim to be "this pattern" requires an implementation to supply this minimal c
 - **Event handler contract**: `(coeffects, event) → effects-map` — the handler's first argument is the coeffects map (app-db under `:db`, the frame stamp under `:rf.frame/id`, declared coeffects, per [002 §The event handler contract](002-Frames.md#the-event-handler-contract), EP-0018 D4), not a bare state value. The v1 `(state, event)` shape is the `:db`-only specialisation of this.
 - **Registered-fx resolver**: an effects map is interpreted by looking up its keys against the registry.
 - **Subscription / derivation system**: `query → value-from-state`, with stable composition.
-- **Frame**: an isolated runtime boundary `{state, queue, sub-cache, id}`. Multi-instance, per-test, per-request, per-session — all the same shape.
+- **Frame**: an isolated runtime boundary `{state, queue, sub-cache, id}`. Multi-instance, per-test, per-request — all the same shape.
 - **Dispatch envelope**: `{event, frame, overrides, trace-id, source}` — an *open map*; consumers tolerate unknown keys.
 - **Run-to-completion drain semantics** (per frame): an event's cascade settles before the next event is processed.
 - **View contract**: `(state, props) → render-tree`. Pure. The render-tree is a serialisable data structure.
@@ -425,7 +425,7 @@ Per [011-SSR.md](011-SSR.md): `:fx-overrides` and `:interceptor-overrides` move 
 
 ### "Frame" vocabulary
 
-`Frame` in the original re-frame meant "an instance of an app." In re-frame2, `frame` is redefined explicitly: **a frame is an isolated runtime boundary**. Multi-instance widget, per-test fixture, per-request server-side render, per-session — all the same shape. See [002-Frames.md](002-Frames.md).
+`Frame` in the original re-frame meant "an instance of an app." In re-frame2, `frame` is redefined explicitly: **a frame is an isolated runtime boundary**. Multi-instance widget, per-test fixture, per-request server-side render — all the same shape. See [002-Frames.md](002-Frames.md).
 
 ## Pointers to per-area Specs
 

--- a/spec/002-Frames.md
+++ b/spec/002-Frames.md
@@ -1,14 +1,16 @@
 # Spec 002 — Frames
 
-> **What this Spec is about.** A *frame* is an isolated runtime boundary — multi-instance widget, per-test fixture, per-request server-side render, per-session — all the same shape. The pattern's contract is **explicit-frame addressing**: every dispatch and subscribe targets a specific frame at the call site. The CLJS reference's React-context-driven view injection (in §View ergonomics) is an *ergonomic optimisation* atop that contract, not a pattern-level commitment.
+> **What this Spec is about.** A *frame* is an isolated runtime boundary — multi-instance widget, per-test fixture, per-request server-side render — all the same shape. The pattern's contract is **explicit-frame addressing**: every dispatch and subscribe targets a specific frame at the call site. The CLJS reference's React-context-driven view injection (in §View ergonomics) is an *ergonomic optimisation* atop that contract, not a pattern-level commitment.
 >
 > For the bird's-eye view of where the frame container, router, drain loop, and `do-fx` sit in relation to the registrar, sub-cache, substrate adapter, and trace bus, see [Runtime-Architecture](Runtime-Architecture.md).
 
 ## Abstract
 
-A **frame** is an **isolated runtime boundary**, identified by keyword, that owns the runtime state of a re-frame application: its `app-db`, its event router/queue, and its subscription cache. Multiple frames can coexist — multi-instance on a page (devcards, isolated widgets, serial test instances), per server-side request, per session — and live independently.
+A **frame** is an **isolated runtime boundary**, identified by keyword, that owns the runtime state of a re-frame application: its `app-db`, its event router/queue, and its subscription cache. Multiple frames can coexist — multi-instance on a page (devcards, isolated widgets, serial test instances), per server-side request — and live independently.
 
 > **Terminology:** "isolated runtime boundary" is the canonical definition. Other Specs sometimes describe a frame in terms of a particular role it plays — *actor-system boundary* (Spec 005, when describing message-passing semantics), *frame contract* (Spec 006, when describing what the substrate-agnostic core requires from an adapter), *per-request runtime* (Spec 011, when describing SSR). All refer to the same thing under different aspects.
+
+> **Not designed: long-lived server-side *session* frames.** The backed frame use cases are all short-lived or client-local: multi-instance widgets on a page, per-test fixtures, and per-request SSR frames (created, rendered, and destroyed within one request — see [Spec 011](011-SSR.md)). A frame held open across many requests to back a *server-side user session* is **out of scope and undesigned**: its lifetime (when does it end?), eviction (what bounds memory across N concurrent sessions?), and JVM concurrency (frames are single-threaded drain loops — a session frame touched by concurrent request threads has no defined contract) are all open questions with no ruling here. Do **not** build a port or a consumer on a session-scoped frame as though it were an advertised capability; it has no contract. Server-side session *state* belongs in the request/response cycle (per-request frame seeded from session storage), not in a resident frame.
 
 All frames share **one global handler registrar**. Multi-frame means "multiple instances of the same app's handlers" — devcards, isolated widgets, story variants, test fixtures — not "multiple different apps with different handler sets on one page." The latter use case (micro-frontends, embedded white-label widgets) is out of scope; iframes already serve it.
 

--- a/spec/011-SSR.md
+++ b/spec/011-SSR.md
@@ -30,7 +30,7 @@ The output of a view is a nested data structure (hiccup, JSX-as-data, virtual-DO
 
 ### Frames are per-request
 
-A server-side request creates a frame, runs setup events (the frame's `:initial-events`, computed per request from the request), renders, serialises the resulting state, destroys the frame. The frame contract is unchanged from Spec 002 — frames are isolated runtime boundaries; "per-request" is just one more use case alongside multi-instance / per-test / per-session.
+A server-side request creates a frame, runs setup events (the frame's `:initial-events`, computed per request from the request), renders, serialises the resulting state, destroys the frame. The frame contract is unchanged from Spec 002 — frames are isolated runtime boundaries; "per-request" is just one more use case alongside multi-instance / per-test.
 
 ### The override seam is id-based
 


### PR DESCRIPTION
Implements **rf2-fuq4wn** (P3) — cut or bracket the unbacked 'per-session frames' litany.

## Problem
'Per-session' frames were advertised **six times** in the Foundation/SSR litany (000:22/43/428, 002:3/9, 011:33), but **no lifetime, teardown, or JVM-concurrency ruling** backs a session-scoped frame. Per-REQUEST frames have the full story (create → render → destroy within one request, Spec 011); per-SESSION was an unbacked word — a port or consumer could build on an advertised capability that has no contract.

## Fix (text-only)
**Six one-word cuts.** Each enumeration already contains the *backed* use cases (multi-instance / per-test / per-request), so the clean floor fix is to drop the unbacked word rather than substitute a duplicate:

| Site | Before → After |
|------|----------------|
| `000-Vision.md:22` | `(multi-instance, per-test, per-request, per-session)` → `(multi-instance, per-test, per-request)` |
| `000-Vision.md:43` | `Multi-instance, per-test, per-request, per-session — all the same shape.` → drops `per-session` |
| `000-Vision.md:428` | `... per-request server-side render, per-session — all the same shape.` → drops `per-session` |
| `002-Frames.md:3` | `... per-request server-side render, per-session — all the same shape.` → drops `per-session` |
| `002-Frames.md:9` | `... per server-side request, per session — and live independently.` → drops `per session` |
| `011-SSR.md:33` | `... alongside multi-instance / per-test / per-session.` → drops `per-session` |

**One bracket paragraph** added to `spec/002-Frames.md` (Abstract, right after the terminology note): states that long-lived server-side *session* frames are out of scope and undesigned — lifetime, eviction, and JVM concurrency are all open questions with no ruling — and directs server-side session *state* to the per-request cycle instead of a resident frame.

The glw1bh terminology note is preserved untouched. The other repo uses of 'per-session' (MCP session caches, CSRF tokens, build-time posture gates in 009/Tool-Pair/Security/Pattern-FormAction) are unrelated and left alone.

## Quality gates
- `python scripts/check_doc_slugs.py` — **exit 0**
- `python -m mkdocs build --strict` (000/002/011 staged) — **exit 0, no warnings** ("Documentation built in 27.90 seconds")

Do NOT merge — worker PR.