### PR TITLE
refactor: Tier-3 internal identifiers (rf2-7dod25)

### DIFF
--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -430,7 +430,7 @@
 
   Per rf2-j20a7 / Spec 005 §Level 4: when the parent envelope is tagged
   `:rf.machine/internal? true` (the router stamps it in
-  `run-handler-cascade!` whenever the emitting handler is a machine),
+  `run-handler-pipeline!` whenever the emitting handler is a machine),
   the child is a machine-internal continuation event and inherits the
   flag. `re-frame.router/dispatch!` reads it to insert the child at the
   FRONT of the queue so the machine settles its macrostep to quiescence
@@ -1167,7 +1167,7 @@
   `:rf.event/coeffects` as 'no user-injected coeffects', distinct from
   an empty map which would itself be a 'stamped but empty' signal).
 
-  Called from `re-frame.router/emit-cascade-trailers!` to stamp the
+  Called from `re-frame.router/emit-pipeline-trailers!` to stamp the
   per-event user-cofx subset onto `:rf.event/run-end` (rf2-9dk9y — the
   stamp moved here from `:rf.fx/do-fx` so events that return only `:db`
   — no `:fx` — still get a COEFFECTS row in the Xray Event lens)."

--- a/implementation/core/src/re_frame/privacy.cljc
+++ b/implementation/core/src/re_frame/privacy.cljc
@@ -186,7 +186,7 @@
 ;;
 ;; The interceptor carries its `:paths` on the interceptor map itself so
 ;; the router can collect them at chain-assembly time and fold them into
-;; the pre-chain `:run-start` / `emit-cascade-trailers` event projection
+;; the pre-chain `:run-start` / `emit-pipeline-trailers` event projection
 ;; (which fires BEFORE any chain `:before` runs). The `:before` here remains
 ;; load-bearing for the in-chain composition with `:rf/schema-redaction`:
 ;; when both interceptors are present, this `:before` extends the already-
@@ -274,7 +274,7 @@
   of every `redact-interceptor` interceptor it contains.
 
   Read by the router at chain-assembly time so the pre-chain trace events
-  (`:run-start`, `emit-cascade-trailers`'s `:run-end`) and the frame-
+  (`:run-start`, `emit-pipeline-trailers`'s `:run-end`) and the frame-
   classification emit-event projection both honour user-declared payload
   paths."
   [interceptors]

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -1773,7 +1773,7 @@
 
   Per rf2-9dk9y: the user-injected coeffects projection moved OFF the
   `:rf.fx/do-fx` marker and ONTO `:rf.event/run-end` (see
-  `emit-cascade-trailers!`). The prior placement silently dropped the
+  `emit-pipeline-trailers!`). The prior placement silently dropped the
   COEFFECTS row whenever a handler returned only `:db` (no `:fx`) — the
   fx walk was short-circuited so the marker never emitted. Pinning the
   cofx stamp to the always-fires run-end emit makes the COEFFECTS
@@ -1809,7 +1809,7 @@
 ;; ---- process-event* phases ------------------------------------------------
 ;;
 ;; `process-event*` decomposes into named phases per audit RT1 (rf2-mccjv).
-;; Each phase owns one piece of the per-event cascade; the outer
+;; Each phase owns one piece of the per-event pipeline run; the outer
 ;; `process-event*` is a thin driver that sequences them.
 ;;
 ;;   handle-frame-destroyed!     early-exit: emit :rf.error/frame-destroyed
@@ -1836,8 +1836,8 @@
 ;;                               order; returns the dispatch outcome keyword
 ;;                               (:ok / :error / :rolled-back / :flow-error)
 ;;                               for the event-emit record
-;;   emit-cascade-trailers!      :run-end trace + always-on event-emit fan-out
-;;   run-handler-cascade!        sequence prepare → run → commit → trailers
+;;   emit-pipeline-trailers!      :run-end trace + always-on event-emit fan-out
+;;   run-handler-pipeline!        sequence prepare → run → commit → trailers
 ;;                               under `trace/with-handler-scope`
 
 (defn- emit-frame-destroyed!
@@ -1933,7 +1933,7 @@
         ;; SAME `base-chain`, replacing the prior two independent chain
         ;; walks. Per rf2-461sp — user-installed redact interceptors expose
         ;; their paths on the interceptor map so the pre-chain trace
-        ;; projection (`:run-start`, `emit-cascade-trailers`) honours them
+        ;; projection (`:run-start`, `emit-pipeline-trailers`) honours them
         ;; too. Each user `:before` ALSO runs during chain execution and
         ;; extends `:rf/redacted-event` in-chain, which is what the schema-
         ;; redaction interceptor (when also installed) composes with. The
@@ -2199,8 +2199,8 @@
         (run-fx-effects! effects frame frame-record fx-overrides envelope)
         :ok))))
 
-(defn- emit-cascade-trailers!
-  "Cascade-tail emissions: the dev-only `:run-end` trace then the
+(defn- emit-pipeline-trailers!
+  "Pipeline-run-tail emissions: the dev-only `:run-end` trace then the
   always-on event-emit fan-out.
 
   Per rf2-rirbq: the event-emit substrate is ALWAYS-ON — it survives
@@ -2308,8 +2308,8 @@
                               effects
                               correlation))))))))
 
-(defn- run-handler-cascade!
-  "Sequence the four cascade phases under the handler's
+(defn- run-handler-pipeline!
+  "Sequence the four pipeline-run phases under the handler's
   `trace/*handler-scope*` binding.
 
   Per rf2-ryri7: publish the event handler's HandlerScope —
@@ -2426,12 +2426,13 @@
             ;; failures, not just the chain exception.
             outcome   (commit-and-flow! final-ctx event-id event frame
                                         frame-record fx-overrides envelope start-ms)]
-        (emit-cascade-trailers! event-id event emit-event frame outcome
+        (emit-pipeline-trailers! event-id event emit-event frame outcome
                                 start-ms handler-elapsed-ms final-ctx)))))
 
 (defn- process-event*
-  "Per-event drain body. Resolve handler, then sequence the four cascade
-  phases under the handler-scope binding (see `run-handler-cascade!`).
+  "Per-event drain body. Resolve handler, then sequence the four
+  pipeline-run phases under the handler-scope binding (see
+  `run-handler-pipeline!`).
   Per Spec 002 §Drain-loop pseudocode.
 
   This is the inner of `process-event!`; the outer wraps it in a
@@ -2478,7 +2479,7 @@
                              (resolve-unhandled event frame))]
         (if (nil? handler-meta)
           (diag/handle-no-handler! event-id event frame)
-          (run-handler-cascade! envelope event-id event frame
+          (run-handler-pipeline! envelope event-id event frame
                                 frame-record handler-meta))))))
 
 (defn- process-event!

--- a/implementation/core/src/re_frame/trace.cljc
+++ b/implementation/core/src/re_frame/trace.cljc
@@ -350,15 +350,15 @@
       (some? tag-sensitive?) (true? tag-sensitive?)
       :else                  (true? (some-> scope :sensitive?)))))
 
-(defn- stamp-cascade-id
-  "Merge the cascade's `:rf.trace/dispatch-id` into `base-tags` so
-  consumers can group raw trace events by cascade without inferring
+(defn- stamp-dispatch-id
+  "Merge the run's `:rf.trace/dispatch-id` into `base-tags` so
+  consumers can group raw trace events by run without inferring
   from sequence. Caller-supplied `:rf.trace/dispatch-id` wins. Per
   Spec 009 §Dispatch correlation — the cross-cutting correlation spine
   lives under `:rf.trace/*` (Conventions §`:rf.trace/*`)."
-  [base-tags cascade-id]
-  (if (and cascade-id (not (contains? base-tags :rf.trace/dispatch-id)))
-    (assoc base-tags :rf.trace/dispatch-id cascade-id)
+  [base-tags dispatch-id]
+  (if (and dispatch-id (not (contains? base-tags :rf.trace/dispatch-id)))
+    (assoc base-tags :rf.trace/dispatch-id dispatch-id)
     base-tags))
 
 (defn- build-event
@@ -378,7 +378,7 @@
   [op-type operation tags]
   (let [scope       *handler-scope*
         trigger     (some-> scope :trigger-handler)
-        cascade-id  (some-> scope :dispatch-id)
+        dispatch-id (some-> scope :dispatch-id)
         sensitive?  (compute-sensitive? tags scope)
         error?      (= op-type :error)
         source      (:source tags)
@@ -396,7 +396,7 @@
         base-tags   (cond-> (dissoc tags :recovery :sensitive?)
                       (not error?) (dissoc :source)
                       error?       (->> (merge {:category operation})))
-        tags+       (stamp-cascade-id base-tags cascade-id)]
+        tags+       (stamp-dispatch-id base-tags dispatch-id)]
     (cond-> {:operation operation
              :op-type   op-type
              :id        (next-event-id)

--- a/implementation/core/src/re_frame/trace/projection.cljc
+++ b/implementation/core/src/re_frame/trace/projection.cljc
@@ -15,11 +15,11 @@
   consumers need above the raw stream for the common 'render this
   cascade as six dominoes' use case.
 
-  The cascade-wide `:rf.trace/dispatch-id` makes the projection robust
+  The run-wide `:rf.trace/dispatch-id` makes the projection robust
   against events the framework emits *inside* a drain even though they
   aren't `:rf.event/dispatched` — fx invocations, sub-runs, renders,
   errors. Every such event carries `:tags :rf.trace/dispatch-id` so the
-  group-by below assembles a complete cascade record.
+  group-by below assembles a complete event bundle.
 
   ## Bucketing (per Spec 009 §`:op-type` vocabulary)
 
@@ -42,7 +42,7 @@
     6. `:render`   — `:op-type :rf.view` + `:operation :rf.view/render`
 
   Events whose op-type/operation pair doesn't fit any bucket flow
-  through `:other` so the cascade-record shape is fully accountable to
+  through `:other` so the event-bundle shape is fully accountable to
   the input — `(reduce + 0 (map #(+ (count (:effects %)) ...) ...))`
   equals the input event count when every event is grouped.
 
@@ -104,10 +104,10 @@
 
     :else :other))
 
-;; ---- cascade record -------------------------------------------------------
+;; ---- event bundle ---------------------------------------------------------
 
-(def ^:no-doc empty-cascade
-  "Slot template for a cascade record. Per-cascade reduction starts here;
+(def ^:no-doc empty-event-bundle
+  "Slot template for an event bundle. Per-run reduction starts here;
   every key the consumer can rely on lives in the template.
 
   `^:no-doc` public so `re-frame.trace.tooling/event-bundle` folds the
@@ -139,26 +139,26 @@
 
 (defn- dispatch-id
   "Return an event's concrete dispatch id, or nil when the event was
-  emitted outside a dispatch cascade."
+  emitted outside a dispatch run."
   [ev]
   (get-in ev [:tags :rf.trace/dispatch-id]))
 
-(defn- cascade-id
-  "Extract the cascade identifier from an event. Per Spec 009 §Dispatch
-  correlation, `:rf.trace/dispatch-id` is cascade-wide. For
-  `:rf.event/dispatched` events, `:rf.trace/parent-dispatch-id` documents
-  inter-cascade lineage; for pair-shaped tools assembling 'the cascade
-  caused by THAT dispatch', the event's own `:rf.trace/dispatch-id` is
-  the right key (the `:rf.event/dispatched` event rides under its own
-  cascade's id). Events outside any drain (registry-time, frame-creation)
-  carry no `:rf.trace/dispatch-id` — they land in the `:ungrouped`
-  bucket."
+(defn- bundle-id
+  "Extract the event-bundle grouping identifier from an event. Per Spec
+  009 §Dispatch correlation, `:rf.trace/dispatch-id` is run-wide (shared
+  by every trace event of one pipeline run). For `:rf.event/dispatched`
+  events, `:rf.trace/parent-dispatch-id` documents inter-run lineage; for
+  pair-shaped tools assembling 'the run caused by THAT dispatch', the
+  event's own `:rf.trace/dispatch-id` is the right key (the
+  `:rf.event/dispatched` event rides under its own run's id). Events
+  outside any drain (registry-time, frame-creation) carry no
+  `:rf.trace/dispatch-id` — they land in the `:ungrouped` bucket."
   [ev]
   (or (dispatch-id ev) :ungrouped))
 
 (defn- frame-index
   "Map dispatch ids to the frames explicitly seen for that dispatch.
-  Frame-less events inside a cascade can then join the only known frame
+  Frame-less events inside a run can then join the only known frame
   deterministically without merging ambiguous multi-frame dispatch ids."
   [events]
   (reduce (fn [acc ev]
@@ -170,11 +170,11 @@
           {}
           events))
 
-(defn- cascade-frame
+(defn- bundle-frame
   "Extract the host frame from an event. nil means the event is not
   frame-qualified (registry-time, boot-time, or older traces). Older
   dispatch-scoped traces that predate explicit frame tags are treated as
-  default-frame traces so errors/warnings still ride with their cascade."
+  default-frame traces so errors/warnings still ride with their run."
   [frame-index ev]
   (or (get-in ev [:tags :frame])
       (:frame ev)
@@ -185,20 +185,20 @@
       (when (dispatch-id ev)
         default-frame)))
 
-(defn- cascade-key
-  "The stable grouping key for a cascade. Dispatch ids are only unique
-  inside a frame in the portable contract, so frame-qualified traces
-  group by `[frame dispatch-id]`. Traces without a dispatch-id are not
-  cascades and share the historical ungrouped bucket regardless of
+(defn- bundle-key
+  "The stable grouping key for an event bundle. Dispatch ids are only
+  unique inside a frame in the portable contract, so frame-qualified
+  traces group by `[frame dispatch-id]`. Traces without a dispatch-id are
+  not runs and share the historical ungrouped bucket regardless of
   frame lifecycle metadata."
   [frame-index ev]
-  (let [id (cascade-id ev)]
+  (let [id (bundle-id ev)]
     (if (= :ungrouped id)
       [nil :ungrouped]
-      [(cascade-frame frame-index ev) id])))
+      [(bundle-frame frame-index ev) id])))
 
 (defn ^:no-doc absorb
-  "Fold one trace event into the per-cascade accumulator.
+  "Fold one trace event into the per-run event-bundle accumulator.
 
   The `:event` bucket lands the event VECTOR on `:event` (slim,
   consumers' common case) AND the full trace event on `:dispatched`
@@ -206,7 +206,7 @@
   rf2-twt7m Change 1).
 
   `^:no-doc` public so `re-frame.trace.tooling/event-bundle` reuses
-  this same fold (over `empty-cascade`) rather than re-inlining the
+  this same fold (over `empty-event-bundle`) rather than re-inlining the
   six-domino classification cond a third time (rf2-ih437c). Any extra
   keys the caller seeds the accumulator with (e.g. tooling's
   `:trace-events`) are preserved untouched — `absorb` only writes the
@@ -219,15 +219,15 @@
                        ;; projection (Spec 009 §Dispatch correlation /
                        ;; rf2-ryri7): the `:rf.event/dispatched` trace
                        ;; carries `:rf.trace/parent-dispatch-id` (the
-                       ;; in-flight cascade that emitted this dispatch —
+                       ;; in-flight run that emitted this dispatch —
                        ;; an `:fx :dispatch` parent, a machine-internal
                        ;; dispatch, etc.). Under epoch-per-event every
-                       ;; child event is its own cascade; this slot is
-                       ;; the only edge linking a cascade to its spawning
-                       ;; cascade. Consumers (Xray typed pills, the
+                       ;; child event is its own run; this slot is
+                       ;; the only edge linking a run to its spawning
+                       ;; run. Consumers (Xray typed pills, the
                        ;; causality breadcrumb) walk it to relate a
-                       ;; cascade to its causal ancestors. nil for a
-                       ;; root cascade (a user / external dispatch).
+                       ;; run to its causal ancestors. nil for a
+                       ;; root run (a user / external dispatch).
                        :parent-dispatch-id (get-in ev [:tags :rf.trace/parent-dispatch-id]))
     :handler (assoc acc :handler ev)
     :fx      (assoc acc :fx ev)
@@ -237,8 +237,8 @@
     :other   (update acc :other conj ev)))
 
 (defn- first-id
-  "Lowest `:id` among the cascade's events, or `##Inf` when no event
-  carries an id. Used for sorting cascades into emission order."
+  "Lowest `:id` among the event bundle's events, or `##Inf` when no event
+  carries an id. Used for sorting event bundles into emission order."
   [{:keys [event handler fx effects subs renders other]}]
   (let [all (concat (when handler [handler])
                     (when fx [fx])
@@ -246,32 +246,32 @@
         ids (keep :id all)]
     (if (seq ids)
       (apply min ids)
-      ;; Sentinel for cascades with no event carrying an id — sort to
+      ;; Sentinel for event bundles with no event carrying an id — sort to
       ;; the end. Use a number-shaped value larger than any practical
       ;; per-process trace id; CLJS-portable (no Long/MAX_VALUE).
       #?(:clj  Long/MAX_VALUE
          :cljs js/Number.MAX_SAFE_INTEGER))))
 
-(defn- grouped-cascades
+(defn- grouped-event-bundles
   "The single grouping pass shared by `group-by-event` and
   `group-by-event-with-events`. Groups `events` by the stable
-  `[frame dispatch-id]` `cascade-key` (dispatch ids are unique only
-  within a frame — see `cascade-key`), reduces each group into a cascade
-  record, and returns a vector of `[[frame dispatch-id] evs record]`
-  triples sorted into emission order (lowest `:id` per cascade first).
+  `[frame dispatch-id]` `bundle-key` (dispatch ids are unique only
+  within a frame — see `bundle-key`), reduces each group into an event
+  bundle, and returns a vector of `[[frame dispatch-id] evs record]`
+  triples sorted into emission order (lowest `:id` per run first).
 
   Both public projections consume this so the grouping key never drifts
   between them: `group-by-event` keeps the slim record; the
   `-with-events` sibling additionally attaches `evs` as `:trace-events`."
   [events]
   (let [index  (frame-index events)
-        groups (group-by #(cascade-key index %) events)]
+        groups (group-by #(bundle-key index %) events)]
     (->> groups
          (map (fn [[[frame dispatch-id :as key] evs]]
                 [key
                  evs
                  (reduce absorb
-                         (assoc empty-cascade
+                         (assoc empty-event-bundle
                                 :dispatch-id dispatch-id
                                 :frame frame)
                          evs)]))
@@ -285,10 +285,10 @@
 
   Returns a vector of maps shaped:
 
-      {:dispatch-id <cascade-id-or-:ungrouped>
-       :parent-dispatch-id <cascade-id or nil> ;; causal-parent link from
+      {:dispatch-id <dispatch-id-or-:ungrouped>
+       :parent-dispatch-id <dispatch-id or nil> ;; causal-parent link from
                                               ;;   :rf.trace/parent-dispatch-id
-                                              ;;   (the cascade that emitted
+                                              ;;   (the run that emitted
                                               ;;   this dispatch); nil for a
                                               ;;   root / external dispatch
        :frame       <frame-id-or-nil>
@@ -312,7 +312,7 @@
   Events without a `:rf.trace/dispatch-id` tag (registry-time emits,
   frame lifecycle outside a drain, REPL evals) collect under the
   projection's `:dispatch-id :ungrouped` slot. The returned vector is
-  sorted by the lowest `:id` in each cascade, so cascades render in
+  sorted by the lowest `:id` in each run, so runs render in
   emission order.
 
   Stable / additive: future framework op-types that don't fit a
@@ -320,7 +320,7 @@
   want richer projections of `:other` can call `domino-bucket`
   directly on each event."
   [events]
-  (->> (grouped-cascades events)
+  (->> (grouped-event-bundles events)
        (mapv (fn [[_key _evs record]] record))))
 
 (defn group-by-event-with-events
@@ -337,7 +337,7 @@
   whose wire shape mirrors `(re-frame.trace.tooling/trace-buffer frame)`.
   Such consumers MUST NOT re-derive the grouping with a weaker key
   (`:rf.trace/dispatch-id` alone): dispatch ids are unique only WITHIN a
-  frame (see `cascade-key`), so a dispatch-id-only group-by merges two
+  frame (see `bundle-key`), so a dispatch-id-only group-by merges two
   same-id runs from different frames and attaches each the UNION of
   both frames' raw events. Keying by `[frame dispatch-id]` here keeps
   every record's `:trace-events` scoped to its own frame.
@@ -347,6 +347,6 @@
   slot for the consumers that need it. Returns a vector sorted by
   emission order, identical to `group-by-event`."
   [events]
-  (->> (grouped-cascades events)
+  (->> (grouped-event-bundles events)
        (mapv (fn [[_key evs record]]
                (assoc record :trace-events (vec evs))))))

--- a/implementation/core/src/re_frame/trace/tooling.cljc
+++ b/implementation/core/src/re_frame/trace/tooling.cljc
@@ -3,7 +3,7 @@
   dev-tooling surface (`register-listener!` / `unregister-listener!` /
   `clear-listeners!` / `trace-buffer` / `clear-trace-buffer!` /
   `configure-trace-buffer!`) and the per-frame
-  cascade-keyed trace rings + listener state.
+  run-keyed trace rings + listener state.
 
   ## Per-frame trace rings (rf2-g1b2m / rf2-8uwce)
 
@@ -12,8 +12,8 @@
       {:events-retained N               ;; the per-frame ring depth (cap)
        :override?         <boolean>     ;; true iff N came from an explicit
                                         ;; per-frame `:rf.trace/events-retained`
-       :cascade-order [<dispatch-id> ...]  ;; oldest-first per-event slots
-       :cascades {<dispatch-id> [<event> ...]}}
+       :run-order [<dispatch-id> ...]  ;; oldest-first per-event slots
+       :runs {<dispatch-id> [<event> ...]}}
 
   - The unit of retention is the EVENT — one dequeued event / pipeline
     run (one `:rf.trace/dispatch-id`) = one slot, regardless of how many
@@ -64,7 +64,7 @@
   (:require [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             ;; rf2-ih437c: `event-bundle` reuses the six-domino fold
-            ;; (`absorb` over `empty-cascade`) from the projection ns
+            ;; (`absorb` over `empty-event-bundle`) from the projection ns
             ;; rather than re-inlining the classification cond. Both nss
             ;; are dev-side and bundle-isolated from production CLJS (the
             ;; `trace-tooling` bundle-isolation entry pins tooling's
@@ -102,18 +102,18 @@
   (clear-dedup-table!)
   nil)
 
-;; ---- per-frame cascade-keyed trace rings (dev-only) ---------------------
+;; ---- per-frame run-keyed trace rings (dev-only) ---------------------
 ;;
 ;; Storage shape (per Spec 009 §Per-frame trace rings):
 ;;
 ;;   trace-rings  = {<frame-id> {:events-retained N
 ;;                               :override?         <boolean>
-;;                               :cascade-order [<dispatch-id> ...]
-;;                               :cascades       {<dispatch-id> [<event>...]}}}
+;;                               :run-order [<dispatch-id> ...]
+;;                               :runs       {<dispatch-id> [<event>...]}}}
 ;;
-;; - `:cascade-order` is the oldest-first vector of `:dispatch-id`s
+;; - `:run-order` is the oldest-first vector of `:dispatch-id`s
 ;;   currently held in this frame's ring; eviction pops the head.
-;; - `:cascades` is a flat map from `:dispatch-id` → trace events
+;; - `:runs` is a flat map from `:dispatch-id` → trace events
 ;;   emitted under that dispatch, in arrival order.
 ;; - The slot count is bounded by `:events-retained` (default 50) — one
 ;;   slot per EVENT (one dequeued event / pipeline run), regardless of how
@@ -147,8 +147,8 @@
   ([retained override?]
    {:events-retained retained
     :override?         override?
-    :cascade-order     []
-    :cascades          {}}))
+    :run-order     []
+    :runs          {}}))
 
 (defn- effective-retained
   "Return the live events-retained cap for `frame-id`. Honours the
@@ -168,11 +168,11 @@
   existing slots if the new value is lower than current occupancy;
   raising keeps existing slots and grows the slot cap.
 
-  Always writes a COMPLETE ring (`:cascade-order` + `:cascades` present)
+  Always writes a COMPLETE ring (`:run-order` + `:runs` present)
   and stamps `:override? true`. Registering a per-frame cap BEFORE the
   frame's first emit therefore leaves a valid (empty) ring rather than a
   partial `{:events-retained N}` map — a partial map would later make
-  `push-to-ring!` start `:cascade-order` from nil, `conj` a list, and
+  `push-to-ring!` start `:run-order` from nil, `conj` a list, and
   crash `subvec` once the cap was exceeded (rf2-va65k finding 2).
 
   Per Spec 009 §Lowering events-retained on a populated ring."
@@ -181,8 +181,8 @@
     (swap! trace-rings
            (fn [rings]
              (let [existing (get rings frame-id)
-                   order    (or (:cascade-order existing) [])
-                   cascades (or (:cascades existing) {})]
+                   order    (or (:run-order existing) [])
+                   runs (or (:runs existing) {})]
                (cond
                  ;; retained = 0: drop everything; slot persists with depth 0
                  ;; so reads return [] cleanly.
@@ -198,8 +198,8 @@
                    (assoc rings frame-id
                           {:events-retained retained
                            :override?         true
-                           :cascade-order     kept-order
-                           :cascades          (apply dissoc cascades evicted)}))
+                           :run-order     kept-order
+                           :runs          (apply dissoc runs evicted)}))
 
                  ;; New cap fits the current occupancy: keep the slots,
                  ;; write a full ring (a never-emitted frame gets a valid
@@ -208,8 +208,8 @@
                  (assoc rings frame-id
                         {:events-retained retained
                          :override?         true
-                         :cascade-order     order
-                         :cascades          cascades}))))))
+                         :run-order     order
+                         :runs          runs}))))))
   nil)
 
 (defn release-frame-ring!
@@ -223,18 +223,18 @@
   nil)
 
 (defn- push-to-ring!
-  "Append `ev` to its frame's cascade-keyed ring. Frameless emits (no
+  "Append `ev` to its frame's run-keyed ring. Frameless emits (no
   `:rf.trace/dispatch-id` in scope) bypass the ring entirely per the
   B3 ruling — they stream live to listeners only and are never retained.
 
   Routing chain for the destination frame-id:
-    1. `:frame` under `:tags` (the router stamps it on most in-cascade
+    1. `:frame` under `:tags` (the router stamps it on most in-run
        emits).
     2. Top-level `:frame` on the envelope.
     3. The late-bound `:frame/current-frame-id` hook (published by
        `re-frame.frame` at ns-load) — covers sub recompute / view
        render emits where the call site doesn't stamp `:frame` but the
-       in-flight cascade's `frame/*current-frame*` is bound.
+       in-flight run's `frame/*current-frame*` is bound.
 
   No-op in production (production never reaches the emit site)."
   [ev]
@@ -245,7 +245,7 @@
                           (when-let [current-frame
                                      (late-bind/get-fn-cached :frame/current-frame-id)]
                             (current-frame)))]
-      ;; Frameless emits (no in-flight cascade) skip the ring. The B3
+      ;; Frameless emits (no in-flight run) skip the ring. The B3
       ;; ruling is that frameless events stream live to listeners only
       ;; and are never retained. A `:dispatch-id` without a resolvable
       ;; frame-id (extremely rare — would require a manual emit from
@@ -269,15 +269,15 @@
                            ;; ring), but coerce anyway so any future partial
                            ;; ring can't make `conj` build a list / `subvec`
                            ;; throw (rf2-va65k finding 2).
-                           order    (or (:cascade-order existing) [])
-                           cascades (or (:cascades existing) {})
-                           known?   (contains? cascades dispatch-id)
+                           order    (or (:run-order existing) [])
+                           runs (or (:runs existing) {})
+                           known?   (contains? runs dispatch-id)
                            order'   (if known? order (conj order dispatch-id))
-                           cascades' (update cascades dispatch-id
+                           runs' (update runs dispatch-id
                                              (fnil conj []) ev)
-                           ;; Evict oldest cascade slots while over cap.
-                           [order'' cascades'']
-                           (loop [o order' c cascades']
+                           ;; Evict oldest run slots while over cap.
+                           [order'' runs'']
+                           (loop [o order' c runs']
                              (if (> (count o) retained)
                                (let [oldest (first o)]
                                  (recur (subvec o 1) (dissoc c oldest)))
@@ -285,8 +285,8 @@
                        (assoc rings frame-id
                               {:events-retained retained
                                :override?         override?
-                               :cascade-order     order''
-                               :cascades          cascades''}))))))))))
+                               :run-order     order''
+                               :runs          runs''}))))))))))
 
 ;; ---- B4 hot-reload dedup-by-shape (process-scoped) ----------------------
 ;;
@@ -400,7 +400,7 @@
   (the `group-by-event` shape, per run / dequeued event).
 
   rf2-ih437c: folds with `re-frame.trace.projection/absorb` over
-  `projection/empty-cascade` — the canonical six-domino classification
+  `projection/empty-event-bundle` — the canonical six-domino classification
   + slot set — rather than re-inlining the bucketing cond + the six
   `*-bucket?`/`*-marker?` predicates a second time. The seed map carries
   the extra `:trace-events` slot the event-bundle wire shape needs;
@@ -408,20 +408,20 @@
   pre-seeded `:dispatch-id` / `:frame`) survive the fold untouched."
   [frame-id dispatch-id events]
   (reduce projection/absorb
-          (assoc projection/empty-cascade
+          (assoc projection/empty-event-bundle
                  :dispatch-id  dispatch-id
                  :frame        frame-id
                  :trace-events events)
           events))
 
-(defn- match-cascade?
+(defn- match-event-bundle?
   "Filter an event bundle against the bundle-level filter keys."
   [bundle {:keys [event-id origin dispatch-id since-ms between pred]}]
   (let [[t0 t1] (when (and (sequential? between)
                            (= 2 (count between)))
                   between)
         events  (:trace-events bundle)
-        ;; A cascade's "time" is its earliest event's time (where present)
+        ;; An event bundle's "time" is its earliest event's time (where present)
         first-time (some :time events)]
     (and (or (nil? event-id)
              (= event-id (first (:event bundle))))
@@ -468,17 +468,17 @@
              (= (true? sensitive?) (true? (:sensitive? ev))))
          (or (nil? pred) (pred ev)))))
 
-(defn- frame-ring-cascades
+(defn- frame-ring-event-bundles
   "Materialise `frame-id`'s ring as an oldest-first vector of event
   bundles. Returns an empty vector when the frame has no recorded
   events (including the destroyed-frame / unknown-frame case per
   Spec 009 §Reads against a destroyed / missing frame)."
   [rings frame-id]
   (if-let [ring (get rings frame-id)]
-    (let [order    (:cascade-order ring)
-          cascades (:cascades ring)]
+    (let [order    (:run-order ring)
+          runs (:runs ring)]
       (mapv (fn [dispatch-id]
-              (event-bundle frame-id dispatch-id (get cascades dispatch-id)))
+              (event-bundle frame-id dispatch-id (get runs dispatch-id)))
             order))
     []))
 
@@ -487,9 +487,9 @@
   events (the `:flat true` opt-in shape)."
   [rings frame-id]
   (if-let [ring (get rings frame-id)]
-    (let [order    (:cascade-order ring)
-          cascades (:cascades ring)]
-      (into [] (mapcat (fn [did] (get cascades did))) order))
+    (let [order    (:run-order ring)
+          runs (:runs ring)]
+      (into [] (mapcat (fn [did] (get runs did))) order))
     []))
 
 (defn trace-buffer
@@ -547,10 +547,10 @@
      (let [rings @trace-rings]
        (if (:flat opts)
          (filterv #(match-event? % opts) (frame-ring-flat-events rings frame-id))
-         (filterv #(match-cascade? % opts) (frame-ring-cascades rings frame-id)))))))
+         (filterv #(match-event-bundle? % opts) (frame-ring-event-bundles rings frame-id)))))))
 
 (defn clear-trace-buffer!
-  "Empty the named frame's cascade-keyed ring. Tooling uses this between
+  "Empty the named frame's run-keyed ring. Tooling uses this between
   sessions. No-op for an unknown frame, no-op in production. Per Spec
   009 §`trace-buffer` API."
   [frame-id]
@@ -640,8 +640,8 @@
               (fn [acc frame-id ring]
                 (if (true? (:override? ring))
                   acc
-                  (let [order    (or (:cascade-order ring) [])
-                        cascades (or (:cascades ring) {})]
+                  (let [order    (or (:run-order ring) [])
+                        runs (or (:runs ring) {})]
                     (cond
                       (zero? events-retained)
                       (assoc acc frame-id (empty-ring 0))
@@ -653,15 +653,15 @@
                         (assoc acc frame-id
                                {:events-retained events-retained
                                 :override?         false
-                                :cascade-order     kept-order
-                                :cascades          (apply dissoc cascades evicted)}))
+                                :run-order     kept-order
+                                :runs          (apply dissoc runs evicted)}))
 
                       :else
                       (assoc acc frame-id
                              {:events-retained events-retained
                               :override?         false
-                              :cascade-order     order
-                              :cascades          cascades})))))
+                              :run-order     order
+                              :runs          runs})))))
               rings
               rings))))
   nil)
@@ -675,8 +675,8 @@
 ;; production build that never `:requires` this ns DCEs the whole body.
 
 (defn- deliver-to-tooling!
-  "Push `event` onto its in-flight frame's cascade-keyed ring (when the
-  cascade has a `:dispatch-id` and a `:frame`; frameless emits skip the
+  "Push `event` onto its in-flight frame's run-keyed ring (when the
+  run has a `:dispatch-id` and a `:frame`; frameless emits skip the
   ring per the B3 ruling), then fan out to every registered listener.
   Listener throws are isolated. No-op in production."
   [event]

--- a/implementation/core/test/re_frame/trace_buffer_test.clj
+++ b/implementation/core/test/re_frame/trace_buffer_test.clj
@@ -266,8 +266,8 @@
 (deftest per-frame-override-before-first-emit-does-not-crash
   (testing "reg-frame with a low cap BEFORE first dispatch survives a cap-exceeding burst"
     ;; Pre-fix: set-frame-events-retained! wrote a partial
-    ;; {:events-retained N} map (no :cascade-order). push-to-ring!
-    ;; started :cascade-order from nil → conj built a PersistentList →
+    ;; {:events-retained N} map (no :run-order). push-to-ring!
+    ;; started :run-order from nil → conj built a PersistentList →
     ;; subvec threw ClassCastException once the cap was exceeded.
     (rf/reg-frame :tb/early {:rf.trace/events-retained 3
                              :doc "cap registered before first emit"})

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -3515,8 +3515,8 @@
         (is (= #{:category :frame :rf.epoch/id :history-size}
                (set (keys (:tags unknown))))
             "restore-unknown-epoch tag key-set == Spec-Schemas RestoreUnknownEpochTags")
-        ;; restore-during-drain fires from INSIDE a live cascade, so the
-        ;; envelope's `stamp-cascade-id` adds `:rf.trace/dispatch-id` for
+        ;; restore-during-drain fires from INSIDE a live run, so the
+        ;; envelope's `stamp-dispatch-id` adds `:rf.trace/dispatch-id` for
         ;; correlation — that's an envelope concern, not part of the
         ;; Spec-Schemas RestoreDuringDrainTags shape. Assert the contract
         ;; keys are present and the alias is absent (the adversarial scan

--- a/implementation/flows/test/re_frame/flows_trace_test.clj
+++ b/implementation/flows/test/re_frame/flows_trace_test.clj
@@ -1296,7 +1296,7 @@
 ;; classification-derived (EP-0015 §8): a handler scoped (`rf/path`) over a
 ;; frame-owned `:sensitive {:app-db …}` slot makes the router bind
 ;; `:rf/sensitive? true` into the handler scope. Flows run inside that scope
-;; (`commit-and-flow!` sits inside `run-handler-cascade!`'s
+;; (`commit-and-flow!` sits inside `run-handler-pipeline!`'s
 ;; `with-handler-scope`), so `trace/build-event`'s `compute-sensitive?`
 ;; hoists the stamp onto the flow trace automatically — the same handler-
 ;; scope inheritance every other in-cascade trace uses.
@@ -1584,7 +1584,7 @@
 ;;     Spec 009 §Canonical per-event trace sequence diagram against the impl.
 ;;
 ;; The load-bearing fact the 009 diagram encodes: `:rf.event/run-end` is a
-;; CASCADE-TAIL trace — the router emits it in `emit-cascade-trailers!`
+;; PIPELINE-RUN-TAIL trace — the router emits it in `emit-pipeline-trailers!`
 ;; AFTER `commit-and-flow!` has installed the deferred (flow-augmented)
 ;; `:db` and walked `:fx`. So a clean cascade orders:
 ;;

--- a/implementation/machines/test/re_frame/machine_front_of_queue_test.cljc
+++ b/implementation/machines/test/re_frame/machine_front_of_queue_test.cljc
@@ -6,7 +6,7 @@
 
   The router-level queue-insertion mechanism is pinned in
   `re-frame.router-front-of-queue-test` (core). Here we exercise the
-  marking SEAM: `re-frame.router/run-handler-cascade!` tags the in-flight
+  marking SEAM: `re-frame.router/run-handler-pipeline!` tags the in-flight
   envelope `:rf.machine/internal? true` when the handler's registration
   meta carries `:rf/machine? true` (stamped by `reg-machine*`); that flag
   rides the parent envelope into `do-fx`, and `child-dispatch-opts`

--- a/implementation/schemas/test/re_frame/schemas_cljs_test.cljs
+++ b/implementation/schemas/test/re_frame/schemas_cljs_test.cljs
@@ -280,7 +280,7 @@
 ;; queue exactly as a live button-click would, then (b) drive the drain to
 ;; fixed point synchronously by seeding a no-op via `dispatch-sync`. The
 ;; sync drain dequeues the already-queued bad event through the identical
-;; `process-event! -> run-handler-cascade!` path the async nextTick drain
+;; `process-event! -> run-handler-pipeline!` path the async nextTick drain
 ;; uses — so this faithfully reproduces "a queued (async-dispatched) event
 ;; drains" while staying deterministic in the node fixture.
 ;;

--- a/implementation/scripts/check-elision.cjs
+++ b/implementation/scripts/check-elision.cjs
@@ -122,7 +122,7 @@ const DEV_ONLY_SENTINELS = [
   // cleanly, so it is the load-bearing grep for the whole-emit DCE.) The
   // trailing `"` pins the op keyword exactly and avoids matching any
   // longer superstring.
-  { source: 're-frame.router/run-handler-cascade! (rf.event/run-start)',
+  { source: 're-frame.router/run-handler-pipeline! (rf.event/run-start)',
     sentinel: 'rf.event/run-start"' },
   // re-frame.http.managed — :rf.http/retry-attempt trace op (Spec 014
   // §Retry and backoff). Emitted from `(when interop/debug-enabled? ...)`


### PR DESCRIPTION
Renames the INTERNAL (private, non-public-surface) event-traversal identifiers that rf2-9v6j83 (Tier-2 public rename) deliberately left as Tier-3, per the glw1bh event-* terminology ruling. No public surface, no wire vocab (those were 9v6j83 / fsqlgz / eewbec). Ruling authoritative + merged.

## What changed

**core internals**
- `trace/tooling.cljc` — private per-frame ring storage keys `:cascade-order` -> `:run-order`, `:cascades` -> `:runs`; helpers `frame-ring-cascades` -> `frame-ring-event-bundles`, `match-cascade?` -> `match-event-bundle?`; local `cascades` -> `runs`; `cascade-keyed` / `in-cascade` prose onto run vocab.
- `trace/projection.cljc` — `empty-cascade` -> `empty-event-bundle` (`^:no-doc`, folded by tooling); private `grouped-cascades` -> `grouped-event-bundles`, `cascade-id` -> `bundle-id`, `cascade-frame` -> `bundle-frame`, `cascade-key` -> `bundle-key`; "cascade record" prose -> event bundle / run.
- `router.cljc` — private locals `run-handler-cascade!` -> `run-handler-pipeline!`, `emit-cascade-trailers!` -> `emit-pipeline-trailers!` (+ cross-file prose refs in `fx.cljc`, `privacy.cljc`, and the flows / machines / schemas test narratives + `check-elision.cjs` source label).
- `trace.cljc` — `stamp-cascade-id` -> `stamp-dispatch-id` (+ local `cascade-id` -> `dispatch-id`); the fn stamps `:rf.trace/dispatch-id`, so the name now matches the concrete field.

**tools/story** — NO private internal event-traversal identifiers exist to rename. Every story `cascade` is either the PUBLIC `:rf.assert/no-cascade-rerender` assertion vocab (+ its `id-no-cascade-rerender` const alias) — public wire, out of scope — or docstring prose (Tier-1). Left untouched.

## Sense guard

**Kept (not the event-traversal sense):** machines cancellation cascade + transition `cascade` locals (`transition.cljc`, `registration.cljc`, `classification.cljc` `:cascade` / `project-cascade`); the `re-frame.trace.cascade` focused-event cascade-DAG aggregator ns + `:trace.cascade/*` late-bind keys + sentinel + tests.

**Left + noted** (event-run sense but broader/ambiguous blast radius — outside the named Tier-3 targets, flagged for a follow-up bead):
- `frame.cljc` `*cascade-frame-state-before*` / `*cascade-time-ms*` dynamic vars — event-run sense, but span frame / router / epoch / tests.
- `:cascade?` sub-metadata keyword + `:epoch/cascade-cause` late-bind hook + `capture/cascade-cause` — reactive-propagation vs event-traversal sense is ambiguous; lives in the epoch artefact.
- `re-frame.live-cascade-frame-resolution-cljs-test` ns name.

## Quality gates

- Core `clojure -M:test` — 1733 tests, 7598 assertions, 0 failures, 0 errors.
- `npm run test:cljs` — 8039 tests, 36945 assertions, 0 failures, 0 errors.
- Story artefact `clojure -M:test` — 1708 tests, 6333 assertions, 0 failures, 0 errors.
- `npm run test:elision` — PASS (production 45/45 absent, control 45/45 present).
- `git grep` of the renamed internal spellings: old names zero live in scope, except the sense-guarded kept meanings and the explicitly-left `*cascade-frame-state-before*` / test-ns above.