### PR TITLE
docs(core): fix stale reply-key doc line (rf2-8om9kk)

### DIFF
--- a/docs/core/concepts/events-and-the-pipeline.md
+++ b/docs/core/concepts/events-and-the-pipeline.md
@@ -161,7 +161,7 @@ Here is the same load, written so the handler stays pure. An [effect](../glossar
 
 The handler still returns nothing but a Clojure map: strings, keywords, vectors. No promise, no callback, no `js/fetch`. The map describes everything that should happen: "set app-db to this, fire a [managed HTTP request](../../resources/glossary.md#managed-http), on success dispatch `[:article/loaded ...]`, on failure dispatch `[:article/load-failed ...]`." The runtime reads the `:fx` row, looks up the `:rf.http/managed` [effect handler](../glossary.md#effect-handler), and performs the request. When the reply arrives, it enters the system the only way anything enters the system: as a fresh event on the queue, with its own trip through the pipeline and its own row in Xray.
 
-That reply rides as the event's last argument in [the uniform reply](../glossary.md#the-uniform-reply) shape — success carries `:value`, failure carries `:failure` — and every managed async surface answers the same way. [Managed HTTP](../../async/http.md) is its home.
+That reply rides as the event's last argument in [the uniform reply](../glossary.md#the-uniform-reply) shape — success carries `:value`, failure carries `:error` — and every managed async surface answers the same way. [Managed HTTP](../../async/http.md) is its home.
 
 Read what that bought you. The entire fetch flow is three pure handlers you read top to bottom. No `.then` chains, no stale-`db` trap, and the failure path has a *name* instead of being a branch you forgot to write. Each handler tests as a plain function. The request tests as data: assert on the map, no network required.
 


### PR DESCRIPTION
Fixes stale reply-key prose in `docs/core/concepts/events-and-the-pipeline.md:164`. The line described the uniform-reply shape as "success carries \`:value\`, failure carries \`:failure\`" — but the canonical async-reply envelope (rf2-ibksxg, merged) puts the failure payload under **\`:error\`** with the \`:status :ok\`/\`:error\` discriminator, not \`:failure\`.

Verified against the canonical source before editing:
- `docs/core/glossary.md:651` — "\`:error\` (failure at \`:error\`)"
- `docs/async/http.md:98` — `{:status :error :error failure-map …}`

Surgical one-line fix. `git grep`'d the whole file — line 164 was the only stale \`:failure\`-as-reply-key occurrence.

**Before:** `success carries :value, failure carries :failure`
**After:** `success carries :value, failure carries :error`

## Quality gates
- `mkdocs build --strict` — passed (built in 21.4s, exit 0)
- `python scripts/check_doc_slugs.py` — passed (exit 0)