### PR TITLE
docs(spec): stale-note sweep 000/002/005 (rf2-ytzak0)

### DIFF
--- a/spec/000-Vision.md
+++ b/spec/000-Vision.md
@@ -464,10 +464,12 @@ The above sections (Abstract, Constraints and goals, Pattern, Hard constraints, 
 
 - **Spec 014 — HTTP requests.** Implementations MAY ship `:rf.http/managed`; when they do, the contract in [014-HTTPRequests.md](014-HTTPRequests.md) is fixed. The CLJS reference ships it. Other-language ports decide independently.
 
-### Post-v1 (foundation hooks ship in v1; ergonomic libraries land later)
+### Shipped (foundation hooks in 002; ergonomic libraries land on top)
 
-- **Spec 005 — State Machines.** Builds on foundation hooks in 002 (machines as event handlers, pure factory `make-machine-handler`, pure `machine-transition`, the `:raise` reserved fx-id (machine-internal), and the `:rf.machine/spawn` / `:rf.machine/destroy` canonical actor-lifecycle fx-ids). Pattern adopted from xstate.
-- **Spec 007 — Stories, Variants, Workspaces.** Storybook-class tooling. Layered on Specs 002 and 008.
+The foundation hooks ship in 002; the two ergonomic libraries below both landed in-tree.
+
+- **Spec 005 — State Machines.** Builds on foundation hooks in 002 (machines as event handlers, pure factory `make-machine-handler`, pure `machine-transition`, the `:raise` reserved fx-id (machine-internal), and the `:rf.machine/spawn` / `:rf.machine/destroy` canonical actor-lifecycle fx-ids). Pattern adopted from xstate. Shipped: `implementation/machines/`, conformance-pinned.
+- **Spec 007 — Stories, Variants, Workspaces.** Storybook-class tooling. Layered on Specs 002 and 008. Shipped: the `re-frame.story` library in `tools/story/`.
 
 ### New / deferred
 
@@ -486,7 +488,6 @@ The above sections (Abstract, Constraints and goals, Pattern, Hard constraints, 
 ### Out of Scope for v1
 
 - **Multiple different apps on one page** (different handler sets sharing a single page). Out of scope, full stop — iframes serve this case. Multi-frame in re-frame2 is "multiple instances of the *same* app's handlers" (devcards, widgets, story variants, test fixtures).
-- **State machines as a shipped library** — Spec 005 is post-v1; the foundation hooks ship in v1 inside [002-Frames.md](002-Frames.md).
 - **Persistence / offline** — see Goal #10 dispositions above.
 - **Authentication / sessions library** — see Goal #10 dispositions above.
 
@@ -504,13 +505,9 @@ Layers 2 and 3 are tooling, not specification, but are first-class deliverables 
 
 ## Open questions
 
-These remain open at 000. Per-Spec documents track narrower open questions in their own appendices.
+None open at 000. Per-Spec documents track narrower open questions in their own appendices.
 
-> **SA-4 classification.** Per [SPEC-AUTHORING §SA-4](SPEC-AUTHORING.md): "Event-id re-registration warnings" classifies as **`:still-blocking`** for design polish at the 000-Vision tier — the load-bearing prose lives at [002 §Open questions — Event-id collisions on re-registration](002-Frames.md#event-id-collisions-on-re-registration), where the same item is classified the same way. The `~~Audit the re-frame.alpha namespace~~` entry that previously lived here as a strike-through pointer has been migrated to `## Resolved decisions` per SA-4's migration rule.
-
-### Event-id re-registration warnings
-
-Hot-reloading the same handler under the same id is normal and expected (figwheel/shadow-cljs save). But re-registering with a *different* function — accidentally, e.g. two namespaces colliding on `:save` — is silent last-write-wins. Open: how loud should re-frame2 warn at registration time, and is the warning on by default? Linked: [002 §Open questions — Event-id collisions on re-registration](002-Frames.md#event-id-collisions-on-re-registration).
+> **SA-4 note.** The "Event-id re-registration warnings" entry that previously lived here (`:still-blocking`) has been migrated to `## Resolved decisions` per SA-4's migration rule — the decision landed at [001 §Re-registration of a different function — collision warning](001-Registration.md#re-registration-of-a-different-function--collision-warning). The `~~Audit the re-frame.alpha namespace~~` strike-through pointer was migrated to `## Resolved decisions` by the same rule.
 
 ## Resolved decisions
 
@@ -526,6 +523,10 @@ The `re-frame.alpha` namespace is **not part of v2**. The alpha experiment was a
 - `reg-flow`, `flow<-`, `clear-flow`, `get-flow`, the `:flow` and `:live?` registered subs — **promoted to `re-frame.core`** under the `flow` family per [Spec 013](013-Flows.md). The migration is a namespace switch.
 
 Migration entries land at [MIGRATION §M-23](../migration/from-re-frame-v1/README.md#m-23-re-framealpha-is-removed).
+
+### Event-id re-registration warnings
+
+Hot-reloading the same handler under the same id is normal and expected (figwheel/shadow-cljs save); re-registering the same id from a *different* source location — accidentally, e.g. two namespaces colliding on `:save` — does **not** silently clobber. The decision landed at 001: a provenance-preserving registration source store (per [EP-0023 §Namespace-Selected Images](../docs/EP/EP-0023-image-loaded-frames.md)) keyed by `[kind id provenance-namespace]` retains both descriptors, so a cross-namespace duplicate fails image assembly rather than being masked, and the dev-time `:rf.warning/registration-collision` source-coord warning (recommended on in dev) is the early signal. Load-bearing prose: [001 §Re-registration of a different function — collision warning](001-Registration.md#re-registration-of-a-different-function--collision-warning); the 002 half of the sub-cache/hot-reload story lives at [002 §Resolved decisions](002-Frames.md#resolved-decisions).
 
 ### Plain Reagent fns under non-default frames
 

--- a/spec/002-Frames.md
+++ b/spec/002-Frames.md
@@ -746,7 +746,7 @@ Use case: per-test fixture frames (per [008-Testing](008-Testing.md)).
 | `:fx-overrides` | `{:rf.http/managed :rf.http/managed-canned-success}` | Network stubbed via the canonical Spec 014 redirect. **Time-based fxs are NOT stubbed** — stories animate in real time. Story-specific stubs (navigation no-op, etc.) are user-supplied; not shipped in the v1 closed set. |
 | `:drain-depth` | `16` | Tighter bound than the framework default (100). Stories are interactive demos; a runaway dispatch drain should fail fast under a story rather than spinning up to the production limit. |
 
-Use case: story / variant frames (per the post-v1 [007-Stories](007-Stories.md) library).
+Use case: story / variant frames (per the [007-Stories](007-Stories.md) library, shipped in `tools/story/`).
 
 #### `:ssr-server`
 
@@ -2448,23 +2448,11 @@ See [MIGRATION.md](../migration/from-re-frame-v1/README.md) for the migration ru
 
 ## Open questions
 
-> **SA-4 classification.** Per [SPEC-AUTHORING §SA-4](SPEC-AUTHORING.md): "Event-id collisions on re-registration", "Sub-cache invalidation across frames", "Concurrent React rendering", "Sub-cache disposal on frame destroy" classify as **`:still-blocking`** for design polish (file a bead to drive each decision); "Transducer-shaped event processing" classifies as **`:post-v1 tracked`** (already tracked at). The Frame-presets `(RESOLVED)` entry that previously lived here was migrated to `## Resolved decisions` per SA-4's migration rule.
-
-### Event-id collisions on re-registration
-
-Hot-reloading the same handler under the same id is normal and expected. But re-registering the same id with a *different* handler function — accidentally, e.g. two namespaces colliding — is silent last-write-wins. Should re-frame2 warn at registration time when an id is being re-registered with a function whose source coords don't match the previous registration? Probably yes, with a configurable threshold.
-
-### Sub-cache invalidation across frames
-
-If two frames depend on a shared piece of *registry* state (handler definitions), and a sub is hot-reloaded, both frames' caches need invalidation for any cached reactives derived from that sub. Mechanism: registry change fires a notification that frame sub-caches subscribe to. Detail-level design; flagged here so it is not forgotten.
+> **SA-4 classification.** Per [SPEC-AUTHORING §SA-4](SPEC-AUTHORING.md): "Concurrent React rendering" classifies as **`:still-blocking`** for design polish (file a bead to drive the decision); "Transducer-shaped event processing" classifies as **`:post-v1 tracked`** (already tracked at). Three entries that previously lived here have been migrated to `## Resolved decisions` per SA-4's migration rule — "Event-id collisions on re-registration" (landed at [001 §Re-registration of a different function — collision warning](001-Registration.md#re-registration-of-a-different-function--collision-warning)), "Sub-cache invalidation across frames" (landed at [001 §The hot-reload contract](001-Registration.md#the-hot-reload-contract)), and "Sub-cache disposal on frame destroy" (landed at [006 §Reference counting and disposal](006-ReactiveSubstrate.md#reference-counting-and-disposal) + the `destroy-frame!` teardown-ownership decision below). The Frame-presets `(RESOLVED)` entry that previously lived here was migrated to `## Resolved decisions` by the same rule.
 
 ### Concurrent React rendering
 
 React 19's concurrent rendering can render the same component multiple times before committing. `reg-view`'s injected `dispatch` is a value, so it survives this fine. But any `dispatch` *executed during render* (Form-2's outer fn, render-time setup patterns) may run more than once. Confirm with the substrate (Reagent today; possibly UIx tomorrow) and document.
-
-### Sub-cache disposal on frame destroy
-
-When `destroy-frame!` runs, every cached reactive needs its `dispose!`-equivalent called. With Reagent reactions today, this is direct. With a future substrate-agnostic substrate, the disposal contract becomes part of the adapter API. Flagged so the adapter-layer design includes it.
 
 ### Transducer-shaped event processing (substrate-agnostic router)
 
@@ -2494,3 +2482,6 @@ A pointer-only index of decisions taken in this Spec. Each entry's load-bearing 
 | Registered interceptors (EP-0022): event/frame `:interceptors` carry serializable interceptor **refs** (bare keyword or `[id arg]`), not inline values; `:interceptor-overrides` matches by exact canonical reference (replace with another ref, or `nil` to remove); effective ordering frame-refs → event-refs → handler-wrapper → subsystem dispatch-time interceptors; refs resolve at chain assembly (registration-time + app-value validation; dispatch-time defensive guard); one standard interceptor `[:rf.interceptor/path path-vector]` (the canonical `:factory` consumer) preserving the frame-commit `identical?` no-op; no standard `unwrap` | [§Registered interceptors and the chain grammar](#registered-interceptors-and-the-chain-grammar), [001 §Interceptors](001-Registration.md#interceptors--reg-interceptor-the-interceptor-registrar) |
 | `destroy-frame!` is the single normative teardown boundary every per-feature artefact (flows, machines, schemas, SSR, epoch) hangs its frame-scoped cleanup off; each artefact publishes a teardown hook the core invokes during destroy | [§Destroy](#destroy), [013 §Frame-destroy teardown](013-Flows.md#frame-destroy-teardown) |
 | Per-frame trace rings, event-keyed retention — each frame owns an independent ring sized by event count (`:rf.trace/events-retained`, default 50); trace events route to the in-flight frame; frameless events bypass rings and stream live only; hot-reload re-emits dedup by shape | [§What lives in a frame](#what-lives-in-a-frame), [009 §Per-frame trace rings](009-Instrumentation.md#per-frame-trace-rings-cascade-keyed-dev-only) |
+| Event-id collisions on re-registration — re-registering an id from a *different* source location does not silently clobber; a provenance-preserving registration source store (keyed by `[kind id provenance-namespace]`, EP-0023) retains both descriptors, cross-namespace duplicates fail image assembly, and the dev-time `:rf.warning/registration-collision` source-coord warning is the early signal (same-source re-eval is the ordinary hot-reload replacement) | [001 §Re-registration of a different function — collision warning](001-Registration.md#re-registration-of-a-different-function--collision-warning) |
+| Sub-cache invalidation across frames — re-registering a `:sub` disposes that sub's cache slot in **every** frame; the next subscribe rebuilds. Other kinds have no caches, so no invalidation is needed | [001 §The hot-reload contract](001-Registration.md#the-hot-reload-contract) |
+| Sub-cache disposal on frame destroy — `destroy-frame!` disposes every cached reactive via the single teardown-ownership path above; the disposal contract is the adapter API's synchronous ref-counting (`dispose` on ref-count → 0), not a frame-local ad-hoc walk | [§Destroy](#destroy), [006 §Reference counting and disposal](006-ReactiveSubstrate.md#reference-counting-and-disposal) |

--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -1,6 +1,6 @@
 # Spec 005 — State Machines
 
-> Status: Drafting. Post-v1 per [000 §Scope and roadmap](000-Vision.md#scope-and-roadmap). Builds on the foundation hooks in [002-Frames.md §State machines are just event handlers](002-Frames.md).
+> Status: Drafting. **Ergonomic library layered on the v1 foundation hooks — shipped and conformance-pinned.** The CLJS reference ships it as `implementation/machines/` (the capability matrix below is graded against the conformance corpus). Builds on the foundation hooks in [002-Frames.md §State machines are just event handlers](002-Frames.md); the foundation-vs-library split is per [000 §Scope and roadmap](000-Vision.md#scope-and-roadmap).
 >
 > **Why this Spec exists:** state machines and actors are in the pattern because **constrained execution models are easier to reason about than Turing-complete control flow.** A finite state machine has an enumerable state space and a discrete transition relation; an actor system bounds concurrency to message-passing across well-defined boundaries with run-to-completion semantics. This is disproportionately valuable for AI use — an AI can fully simulate a finite machine; it cannot fully simulate a free-form imperative program. The cost is some expressiveness; the benefit is an execution model that survives mechanical reasoning.
 >
@@ -3524,7 +3524,7 @@ The abort surfaces as a normal `:rf.http/aborted` failure on the request's reply
 
 A request is "in-flight inside actor `<spawned-id>`" if and only if its originating event vector's first element was `<spawned-id>`. The originating event vector flows to the `:rf.http/managed` fx through the standard fx 5-arity (`:event` on the fx ctx, per [Spec 002 §Routing the dispatch envelope](002-Frames.md#routing-the-dispatch-envelope)), and the http fx records the (`request-id`, `actor-id`) tuple in its in-flight registry alongside the abort-handle.
 
-The actor-id is **the spawned actor's own machine address** (e.g., `:http/post#1`), not the parent's address. A request that the parent (`:auth/main`) issued directly is NOT in-flight inside any spawned actor — it is in-flight inside the parent's event-handler context, which has no spawn-registry slot. The parent's request is unaffected by any child-actor destroy. See [§Open question — direct dispatches from event handlers](#open-question--direct-dispatches-from-event-handlers).
+The actor-id is **the spawned actor's own machine address** (e.g., `:http/post#1`), not the parent's address. A request that the parent (`:auth/main`) issued directly is NOT in-flight inside any spawned actor — it is in-flight inside the parent's event-handler context, which has no spawn-registry slot. The parent's request is unaffected by any child-actor destroy. See [§Direct dispatches from event handlers — NOT covered](#direct-dispatches-from-event-handlers--not-covered).
 
 ### What about the request's own `:request-id`?
 
@@ -3532,9 +3532,9 @@ The `:request-id` (per [Spec 014 §Aborts](014-HTTPRequests.md#aborts)) is **ort
 
 If a request was issued without `:request-id` from inside a spawned actor, it is still tracked by actor-id and is still aborted on actor-destroy. The `:request-id` is for app-level addressability; actor-id tracking is for runtime cleanup.
 
-### Open question — direct dispatches from event handlers
+### Direct dispatches from event handlers — NOT covered
 
-Events dispatched directly from ordinary `reg-event` handlers — i.e. the originating event vector is for an event-id that is NOT a spawned actor's address — issue `:rf.http/managed` requests that are NOT subject to the actor-destroy cancellation cascade. There is no actor-id to correlate against.
+Events dispatched directly from ordinary `reg-event` handlers — i.e. the originating event vector is for an event-id that is NOT a spawned actor's address — issue `:rf.http/managed` requests that are NOT subject to the actor-destroy cancellation cascade. There is no actor-id to correlate against. This is a resolved scope decision, not an open question — the paragraphs below record why actor-lifetime is the right cancellation scope and what an app does when it wants HTTP tied to a state's lifetime (spawn a child machine). Mirrors [014 §Direct dispatches from event handlers — NOT covered](014-HTTPRequests.md#direct-dispatches-from-event-handlers--not-covered).
 
 Cancellation tied to actor lifetime is semantically the right scope: the child actor exists to run until the parent says "we no longer care"; the parent saying so kills the actor and the actor's outstanding work. An ordinary event handler has no analogous lifecycle peg — its work is launched as a side effect and outlives the handler that fired it; the only way to abort it is via an explicit `:rf.http/managed-abort` keyed on the user-supplied `:request-id`.
 
@@ -4312,7 +4312,7 @@ Per [000-Vision §Hierarchical FSM substrate](000-Vision.md#hierarchical-fsm-sub
 | **Spawn-and-join via `:spawn-all`** — first-class parallel-region state-machines: a state node declares N child actors and a join condition (a closed two-member enum: `:all` / `:any`), the runtime fires one of three parent events when the join resolves and unconditionally cancels surviving siblings | Prose: [§Spawn-and-join via `:spawn-all`](#spawn-and-join-via-spawn-all); Schema: `:rf/state-node` extended for `:spawn-all` (per [Spec-Schemas §`:rf/transition-table`](Spec-Schemas.md#rftransition-table)); Fixtures: `spawn-all-join-all-completes`, `spawn-all-join-any-fails-cancels` | ✓ claimed (specified) | Sugar over N parallel `:spawn`s plus a runtime-owned join-state at `[:rf.runtime/machines :spawned <parent> <invoke-id>]` (the direct map shape — `:children` / `:done` / `:failed` / `:resolved?` / `:spec` co-mingle at the root). Sibling cancellation on the join decision is unconditional (matches Dash8/rf8 boot-page-reload semantics). |
 | **`:system-id` named-machine addressing** — a `:rf.machine/spawn` whose args carry `:system-id` binds the actor in the per-frame `[:rf.runtime/machines :system-ids]` reverse index; `(rf/machine-by-system-id sid)` resolves the binding | Prose: [§Named addressing via `:system-id`](#named-addressing-via-system-id), [§Cross-machine messaging by name](#cross-machine-messaging-by-name); Schema: `:rf.fx/spawn-args` extended for `:system-id`; Fixtures: `spawn-with-system-id-then-lookup-resolves`, `spawn-without-system-id-leaves-index-empty`, `destroy-machine-clears-system-id-index`, `system-id-collision-warns-and-rebinds` | ✓ claimed (specified) | Opt-in. The reverse index lives in runtime-db so it inherits frame revertibility. Collisions emit `:rf.error/system-id-collision` and rebind (last-write-wins). |
 | ~~**Wall-clock `:timeout-ms` on `:spawn` / `:spawn-all`**~~ | DROPPED in favour of state-level `:after`. See [§Wall-clock timeouts on `:spawn` — use parent state's `:after`](#wall-clock-timeouts-on-spawn--use-parent-states-after) and [MIGRATION §M-44](../migration/from-re-frame-v1/README.md#m-44-timeout-ms-removed-from-spawn--spawn-all--use-parent-states-after). | n/a | The `:after` capability subsumes this; one canonical primitive, not two. The `:fsm/delayed-after` capability above covers wall-clock-on-state semantics for both pure timed-transition states and `:spawn`-bearing states. |
-| **SCXML / Stately / XState JSON interop** — bidirectional schema parity or paste-and-render compatibility | Out of v1 scope | ✗ not claimed | Deferred to v1.1+; tracked alongside (SCXML) as the v1.1+ interop family. |
+| **SCXML / Stately / XState JSON interop** — bidirectional schema parity or paste-and-render compatibility | SCXML: shipped tool-side; XState JSON / Stately: deferred | ◑ partial (tool-side) | The **SCXML** half shipped as a pure-data round-trip in the machines-viz tool (`day8.re-frame2-machines-viz.scxml` — `spec->scxml` / `scxml->spec`, exact round-trip over the supported topology subset, rf2-6urjd), not in the runtime `machines` artefact. The **XState-JSON** (`machine->xstate-json`) and **Stately Inspector wire-format** halves remain deferred to v1.1+; tracked alongside as the interop family. |
 
 ### How conformance is graded
 
@@ -4433,12 +4433,12 @@ Post-v1 work that is in scope conceptually but does not ship in v1.
 
 ### Diagram export from transition tables
 
-The transition table is data; rendering it as a diagram is straightforward. v1 ships no exporter; post-v1 candidates:
+The transition table is data; rendering it as a diagram is straightforward. The runtime `machines` artefact ships **no** exporter (diagram export is a tool-side code-gen concern, so the runtime stays pure-engine — Mike-ruled (b), rf2-sqhqu); a `(rf/machine->…)` runtime surface is intentionally not shipped. Status of the candidates:
 
-- `(rf/machine->mermaid definition)` — emit Mermaid `stateDiagram-v2`. Renders inline in GitHub markdown, VS Code preview, AI-agent prompts.
-- `(rf/machine->d2 definition)` — emit D2.
+- **Mermaid — shipped tool-side.** `day8.re-frame2-machines-viz.mermaid/emit` (in the machines-viz tool) emits a fenced Mermaid `stateDiagram-v2` block from a normalised machine definition, with the ergonomic `chart-as-mermaid` / `copy-mermaid-to-clipboard!` wrappers in `…machines-viz.export`. Lossy by design (`:after` rings + `:spawn-all` rows omitted; flagged inline). Renders inline in GitHub markdown, VS Code preview, AI-agent prompts. Apps that want Mermaid require the machines-viz jar; apps that don't pay nothing.
+- **D2 — not yet shipped.** A `machine->d2` emitter (parallel to the Mermaid lane) remains a post-v1 candidate.
 
-XState/Stately JSON export (`machine->xstate-json`) is part of the v1.1+ interop family, not a v1 deliverable; tracked alongside (SCXML).
+XState/Stately JSON export (`machine->xstate-json`) is part of the v1.1+ interop family, not a v1 deliverable; tracked alongside (SCXML — whose tool-side round-trip has shipped in machines-viz, per the capability matrix above).
 
 Mermaid/D2 are AI-fluent — LLMs read and write them confidently — which makes diagram export the cheapest way to extend AI-amenability of machine code.
 
@@ -4512,7 +4512,7 @@ The v1 ship-list and the post-v1 follow-up are itemised below.
 Richer scaffolding on top of the v1 foundation. None of the items below add a new substrate — each desugars into the v1 surface:
 
 - **Sugar in transition tables:** `:child-machine` declarative state-scoped child binding (desugars to entry/exit `:rf.machine/spawn` / `:rf.machine/destroy`). (Hierarchical state nodes, `:always`, `:after`, `:spawn`, parallel state nodes, **final states with `:on-done`**, and **history states** are all v1; see the v1 ship list above.)
-- **XState/Stately/SCXML interop (v1.1+):** `machine->xstate-json` converter, paste-and-render parity, Stately-Inspector wire-format mapping. Tracked alongside (SCXML) as the v1.1+ interop family.
-- **Visualisation tooling:** `machine->mermaid`, `machine->d2` exporters.
+- **XState/Stately JSON interop (v1.1+):** `machine->xstate-json` converter, paste-and-render parity, Stately-Inspector wire-format mapping — still deferred. (The **SCXML** half of this family has already shipped tool-side as a pure-data round-trip in machines-viz, per the capability matrix above.)
+- **Visualisation tooling:** the **Mermaid** exporter has shipped tool-side (`machines-viz.mermaid/emit`, rf2-sqhqu); a `machine->d2` exporter remains a post-v1 candidate.
 - **Model-based testing harness:** `@xstate/test`-style graph traversal over the transition table.
 - **Recurring timers, wall-clock delays, pause/resume on `:after`** — explicitly out of scope for v1; see [§What `:after` does *not* include](#what-after-does-not-include).


### PR DESCRIPTION
Stale-note sweep across the three spec core docs — refresh notes whose subjects have LANDED. Each flip verified against the current corpus/impl before flipping. Prose/label hygiene only; no behavioural or key changes.

## What changed

**000-Vision.md**
- Flipped the `Post-v1 (… ergonomic libraries land later)` heading to `Shipped` — Spec 005 (`implementation/machines/`, conformance-pinned) and Spec 007 (`re-frame.story` in `tools/story/`) both landed in-tree.
- Dropped the stale Out-of-scope line `State machines as a shipped library — Spec 005 is post-v1` (005 now *is* a shipped library).
- Migrated the `Event-id re-registration warnings` open question to `## Resolved decisions` — the decision landed at [001 §Re-registration of a different function — collision warning] (`:rf.warning/registration-collision` + the EP-0023 registration source store). Open-questions section now records none open, per SA-4.

**002-Frames.md**
- Migrated three answered OQs to `## Resolved decisions`: **Event-id collisions on re-registration** (→ 001 collision warning), **Sub-cache invalidation across frames** (→ 001 hot-reload contract, line 278), **Sub-cache disposal on frame destroy** (→ 006 §Reference counting and disposal + the existing `destroy-frame!` teardown-ownership row). Kept **Concurrent React rendering** (`:still-blocking`) and **Transducer-shaped event processing** (`:post-v1 tracked`) open. Updated the SA-4 classification note.
- Flipped the `:post-v1 007-Stories` aside on the `:story` preset — 007 shipped in `tools/story/`.

**005-StateMachines.md**
- Fixed the false `Status: Drafting. Post-v1` header → shipped and conformance-pinned; framed as the ergonomic library layered on the v1 foundation hooks (aligns with the 016 "post-v1 artefact … CLJS reference ships it" convention).
- Retitled `Open question — direct dispatches from event handlers` → `Direct dispatches from event handlers — NOT covered` (the section records a decision, not a question — per SA-4; mirrors the 014 sibling heading). Updated the one intra-doc link to the new anchor.
- **SCXML interop capability row:** recorded the SCXML half as shipped tool-side (`day8.re-frame2-machines-viz.scxml` `spec->scxml` / `scxml->spec` round-trip, rf2-6urjd) — `◑ partial (tool-side)`; XState-JSON / Stately still deferred.
- **Future §Diagram export:** recorded Mermaid as shipped tool-side (`machines-viz.mermaid/emit`, rf2-sqhqu); d2 remaining. Kept the note that the runtime `rf/machine->…` surface is intentionally NOT shipped (Mike-ruled (b), rf2-sqhqu — diagram export is a tool-side concern). Same nuance applied to the `re-frame.machines` library post-v1 bullets.

Did not disturb the glw1bh terminology edits or the pipeline-vocab sweeps.

## Quality gates
- `mkdocs build --strict` — **PASS** (replicated the CI staging: `cp -r spec docs/spec && cp -r migration docs/migration` before the strict build; 0 warnings/errors; none of the three edited files flagged).
- `scripts/check_doc_slugs.py` — **PASS** (506 files scanned, no broken links; the retitled 005 heading's new anchor and all migrated cross-links resolve).
