### PR TITLE
docs(xray): xray spec stale/moot sweep (rf2-iold6b)

### DIFF
--- a/tools/xray/spec/016-Auxiliary-Panels.md
+++ b/tools/xray/spec/016-Auxiliary-Panels.md
@@ -592,10 +592,10 @@ The Filters tab was retired per rf2-wknb3 — full pill management lives in the 
 
 The Theme tab was retired per rf2-ou3pn — the top-ribbon sun/moon icon (`ribbon-theme-toggle` in `shell.cljs`) is now the canonical light/dark affordance. Both surfaces dispatched the identical `[:rf.xray/settings-update :theme nil <kw>]` event; the popup copy was pure redundancy. The `:use-system-colors?` HCM-override toggle relocated to **General → Power user** — the setting slot has always been `:general :use-system-colors?`; only its cosmetic home in the Theme section is gone with the tab.
 
-**v1 ships:** the General tab visible above, plus Keybindings, Buffer, and Diff (catalogued in [`018-Event-Spine.md`](./018-Event-Spine.md) §9). The Theme tab was retired per rf2-ou3pn and the Filters tab per rf2-wknb3 — see the notes immediately under the table. The fuller
-[`018-Event-Spine.md`](./018-Event-Spine.md) §9 catalogue
-(Keybindings, Buffer, Popout, Actions) is deferred to follow-on
-beads. A Telemetry tab shipped briefly in the initial popup landing
+**v1 ships:** the General tab visible above, plus Keybindings, Buffer, and Diff (catalogued in [`018-Event-Spine.md`](./018-Event-Spine.md) §9). The Theme tab was retired per rf2-ou3pn and the Filters tab per rf2-wknb3 — see the notes immediately under the table. Nothing further is deferred: per
+[`018-Event-Spine.md`](./018-Event-Spine.md) §9, **Popout** folded
+into General's Panel-position radio (no own tab) and **Actions** was
+dropped (factory-reset stays code-only). A Telemetry tab shipped briefly in the initial popup landing
 (rf2-9poxq) but was removed (rf2-jh9ws) — Xray transmits no
 telemetry, and a toggle pretending to control a non-existent
 endpoint was a broken affordance per the text audit (rf2-yn86j).
@@ -679,8 +679,10 @@ a corporate fork that wants light theme as the factory default).
 
 `config/reset-settings-to-defaults!` clears the localStorage payload
 and resets the in-memory atom to `default-settings`. No popup
-affordance ships in v1 (deferred to the §018 §9 "Actions" tab
-follow-on).
+affordance ships in v1 — factory-reset stays **code-only**. The
+"Actions" tab that would have hosted a reset button was dropped per
+[`018-Event-Spine.md`](./018-Event-Spine.md) §9; the only destructive
+op with a UI affordance is "Clear buffer now" under the Buffer tab.
 
 ### Cross-references
 

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -3917,9 +3917,15 @@ the renderer, not separate chrome wrappers:
 
 - `:rf/redacted` (bare keyword) — magenta chip with `●` indicator;
   never expandable.
-- `{:rf.size/large-elided {:path [...] :bytes N :type <kw> :reason :schema :hint s :handle [:rf.elision/at <path>]}}` — yellow chip showing bytes;
-  click-to-reveal is deferred (was in the now-deleted
-  `theme.data-inspector` ns; the popup phase D6=a returns it).
+- `{:rf.size/large-elided {:path [...] :bytes N :type <kw> :reason :schema :hint s :handle [:rf.elision/at <path>]}}` — yellow chip showing bytes.
+  The chip is a **static, non-interactive** display in v1 (the `:handle`
+  is carried for a future drill-in affordance). The popup overlay infra
+  the reveal would ride on has since landed (rf2-s0x6x, D6=a — the
+  `edn-inspector-popup` stack + the opt-in "open in popup" affordance,
+  rf2-l4625), but the large-elided chip is **not yet wired** to open it;
+  the click-to-reveal path (originally in the now-deleted
+  `theme.data-inspector` ns) awaits a follow-on that wires the chip's
+  `:handle` through to the popup.
 - `{:rf/redacted {:bytes N}}` — combined sensitive+size; magenta
   chip with size annotation.
 

--- a/tools/xray/spec/README.md
+++ b/tools/xray/spec/README.md
@@ -42,7 +42,7 @@ main read**.
   cancellation-cascade visualiser, per-instance "why am I stuck" trace.
   UC1 Sim + UC2 Mode A/B/C dynamic-instance UI preserved as Static
   re-host reference below the §STATIC RE-HOST REFERENCE divider
-  (rf2-r4nao — deferred). ELK+SVG primitive Xray-internal. **The bug
+  (rf2-r4nao — landed). ELK+SVG primitive Xray-internal. **The bug
   catalogue at the bottom (M.1–M.10) is the per-feature motivation.**
 - **[004-App-DB-Diff.md](004-App-DB-Diff.md)** — Slice-centric (not
   tree-centric) app-db panel. Future: branch-aware diff (for Story

--- a/tools/xray/spec/findings/re-frame-10x-v2-design.md
+++ b/tools/xray/spec/findings/re-frame-10x-v2-design.md
@@ -526,7 +526,13 @@ Each as a §X.Y with my recommendation + the alternative.
 
 ### §10.7 MCP shipping at v1.0 vs v1.1
 
-**Deferred 2026-05-11.** Decision punted to a later read.
+**Deferred 2026-05-11; resolved by the two-doors architecture.** The
+punt (whether to ship an Xray-MCP server at v1.0 or v1.1) is now moot:
+there is **no Xray-MCP server** at all. The AI/MCP surface lives in the
+sibling `tools/re-frame2-pair-mcp/` tool (raw nREPL over MCP); Xray is
+the human GUI door. See [`000-Vision.md`](../000-Vision.md) §"two doors"
+and [`DESIGN-RATIONALE.md`](../DESIGN-RATIONALE.md). The false middle —
+a curated Xray-MCP — was killed.
 
 ### §10.8 re-frame2-pair delegation in co-pilot
 


### PR DESCRIPTION
Doc-hygiene sweep of stale/moot references in `tools/xray/spec/` (rf2-iold6b). No behavioural change. Each ref verified against current xray code + closed beads before flipping.

## What changed

- **016-Auxiliary-Panels.md (2 moot deferrals fixed).**
  - The "fuller 018 §9 catalogue (Keybindings, Buffer, Popout, Actions) is deferred to follow-on beads" claim is moot. Per 018 §9, **Popout** folded into General's Panel-position radio (no own tab) and **Actions** was dropped (factory-reset stays code-only). Rewrote to "nothing further is deferred" and cite the 018 dispositions.
  - The reset-to-defaults note deferred a popup affordance "to the §018 §9 Actions tab follow-on" — a tab that was **dropped**. Rewrote to say factory-reset stays code-only; "Clear buffer now" (Buffer tab) is the only destructive op with a UI affordance.
- **README.md.** The Machines-tab Static re-host annotation read `(rf2-r4nao — deferred)`, but rf2-r4nao is **CLOSED** (PR #1583; Sim machinery rehosted into `static/machines/sim.cljs`) and 003-Machine-Inspector §Sim re-host reference already says "landed". Flipped `deferred → landed`.
- **021-Dynamic-Panel-Designs.md §10.0.3.** The large-elided click-to-reveal passage said the path "is deferred … the popup phase D6=a returns it" (promissory, pinned to a closed phase). rf2-s0x6x (D6=a) **CLOSED**, but verification of the current code (`views/edn_inspector.cljs` L852–877) shows the large-elided chip is still a **static, non-interactive** chip — the `:handle` is carried for a future drill-in; its close reason deferred "mount/registry wire-up to follow-on". The popup infra landed (rf2-s0x6x + the opt-in "open in popup" affordance rf2-l4625) but the large-elided chip is **not yet wired** to it. Updated the passage to that current reality rather than flipping it to "landed" (which would have been inaccurate).
- **findings/re-frame-10x-v2-design.md §10.7 (optional, per bead).** Annotated the MCP v1.0-vs-v1.1 punt as resolved by the two-doors architecture — no Xray-MCP server; the AI/MCP surface is the sibling `tools/re-frame2-pair-mcp/` per 000-Vision + DESIGN-RATIONALE.

## Quality gates

- **`test:xray-feature-gate`** — this is a Playwright browser feature-matrix gate against the running Xray UI (serve-and-run), NOT a spec-markdown validator. It does not exercise the touched doc prose and requires a full browser build; not run here — CI covers the UI. No behavioural change in this PR.
- **`check_doc_slugs.py`** — scoped to the mkdocs docs build (`docs/`, excluding auto-staged `docs/spec/`); `tools/xray/spec/` is a separate curated tree not in the mkdocs nav, so this gate does not cover these files.
- **`tools/xray/test/.../panel_enum_spec_refs.clj`** — the one xray test that references spec files; grep confirms it asserts on none of the strings changed here.

Doc-only, no automated gate covers the touched prose; relying on CI. Verified manually against xray source + closed bead states.