### PR TITLE
docs: resolve rename-policy contradiction (rf2-xfueas)

### DIFF
--- a/spec/Conventions.md
+++ b/spec/Conventions.md
@@ -1212,13 +1212,13 @@ Tears down something with **identity and a creation moment** — a frame, an ada
 - `destroy-frame!`
 - `destroy-adapter!`
 
-### Renamed under this axis (one-cycle deprecation aliases)
+### Renamed under this axis (hard rename — no alias)
 
 The prior surface had `dispose-adapter!` for the adapter teardown. It collapses onto `destroy-` because adapter installation is a lifecycle boundary, symmetric with `destroy-frame!`:
 
 - `dispose-adapter!` → `destroy-adapter!` (lifecycle boundary)
 
-The old name ships as a deprecated alias pointing at the same Var for one deprecation cycle; tooling that introspects `:deprecated` metadata will flag it. Per the [Migration corpus M-53](../migration/from-re-frame-v1/README.md#m-53-tear-down-verb-rename--dispose-adapter--destroy-adapter) for the v1→v2 mapping.
+Per the pre-alpha posture (no back-compat shims), the old `re-frame.core/dispose-adapter!` Var is **removed** — the rename is hard. There is no deprecated alias and no deprecation cycle; stale call sites raise an unresolved-symbol at compile time. Per the [Migration corpus M-53](../migration/from-re-frame-v1/README.md#m-53-tear-down-verb-rename--dispose-adapter--destroy-adapter) for the v1→v2 mapping. (The adapter-spec map key `:dispose-adapter!` is an internal contract slot and is unchanged — only the public wrapper name moves.)
 
 ### Carve-out: `unsubscribe`
 


### PR DESCRIPTION
Resolves **rf2-xfueas** (P3 bug — design-review gap 9 / self-consistency finding 5).

## Problem
Two normative docs contradicted on rename policy:

- **`migration/from-re-frame-v1/README.md` M-53** (L2177): "**No alias.** Per pre-alpha posture (no back-compat shims), the public `re-frame.core/dispose-adapter!` Var is **removed**... There is no deprecation cycle; the rename is hard."
- **`spec/Conventions.md` §Renamed under this axis** (L1215–1221): heading read "one-cycle deprecation aliases"; body said the old name "ships as a deprecated alias pointing at the same Var for one deprecation cycle."

Conventions was the outlier. M-53, the sibling M-54 (schema rename, which explicitly references stripping "the M-53 `dispose-adapter!` alias"), the api-manifest, and the `re-frame-migration` breaking-changes skill (`The old name is **removed**`) all agree on the hard-rename disposition.

## Fix
Rewrote the Conventions `§Renamed under this axis` section to the M-53 hard-rename disposition (pre-alpha: no aliases, no deprecation cycles). No inbound anchor cited the old heading text, so retitling is safe.

**Before** (`spec/Conventions.md`):
> ### Renamed under this axis (one-cycle deprecation aliases)
> … The old name ships as a deprecated alias pointing at the same Var for one deprecation cycle; tooling that introspects `:deprecated` metadata will flag it.

**After**:
> ### Renamed under this axis (hard rename — no alias)
> … Per the pre-alpha posture (no back-compat shims), the old `re-frame.core/dispose-adapter!` Var is **removed** — the rename is hard. There is no deprecated alias and no deprecation cycle; stale call sites raise an unresolved-symbol at compile time. … (The adapter-spec map key `:dispose-adapter!` is an internal contract slot and is unchanged — only the public wrapper name moves.)

Contradiction was a clean alias-policy conflict (not a deeper fork — same scenario, same Var), so the default no-alias resolution applied.

## Quality gates
- `mkdocs build --strict` — PASS (exit 0, no warnings; INFO-only)
- `scripts/check_doc_slugs.py` — PASS (exit 0)
- No rename-policy/residue check present in the tree.