### PR TITLE
feat(template): wire :css :tailwind (rf2-nxqcov)

### DIFF
--- a/tools/template/README.md
+++ b/tools/template/README.md
@@ -96,19 +96,34 @@ checkout (and, pre-split, cloning a repo that doesn't exist yet).
 `:rf.error/template-include-story-reagent-only`. UIx + Helix Story
 variants follow once those adapters' Story coverage matches Reagent's.
 
-### Deferred flags
+### `:css :tailwind`
 
-`:css` (e.g. `:tailwind`) and `:include-ssr?` are reserved in the v1
-flag set but **not yet implemented** — they are gated on rf2-gthro
-(Tailwind v4 verification) and rf2-0m5ea (SSR validation)
-respectively. Passing one today **fails closed** with
-`:rf.error/template-unsupported-flag` (naming the flag and its gating
-bead) rather than silently scaffolding a vanilla app that lacks the
-feature. Any other unrecognised template flag — including a typo such
-as `:include-story` (missing the `?`) — fails closed with
+`:css :tailwind` swaps the default plain-CSS scaffold for Tailwind v4:
+`resources/public/css/app.css` becomes a CSS-first
+`@import "tailwindcss";` entry (Tailwind v4 has no
+`tailwind.config.js` — design tokens go in `@theme { … }`), and
+`index.html` loads the `@tailwindcss/browser@4` dev CDN compiler so
+utilities work with zero build step. Omit `:css` (or pass nothing) for
+the plain-CSS default. The flag is substrate-invariant. A bogus value
+(e.g. `:css :tailwnd`) **fails closed** with
+`:rf.error/template-bad-css-flag`. Before shipping, swap the dev CDN
+for the compiled `@tailwindcss/cli` build (see the generated README's
+"Production hardening").
+
+```bash
+# Reagent, with Tailwind v4
+clojure -Sdeps '{:deps {day8/re-frame2-template
+                        {:local/root "tools/template"}}}' \
+        -Tnew create :template day8/re-frame2-template \
+        :name acme/my-app \
+        :css :tailwind
+```
+
+Any unrecognised template flag — including a typo such as
+`:include-story` (missing the `?`) — fails closed with
 `:rf.error/template-unknown-flag`. See
-[`spec/API.md`](./spec/API.md#args-reference) for the flag-set status
-and the error table.
+[`spec/API.md`](./spec/API.md#args-reference) for the full flag-set
+status and the error table.
 
 ### Post-split (future)
 

--- a/tools/template/resources/day8/re_frame2_template/_css_tailwind/app.css
+++ b/tools/template/resources/day8/re_frame2_template/_css_tailwind/app.css
@@ -1,0 +1,42 @@
+/* {{name}} — Tailwind v4 stylesheet (:css :tailwind).
+ *
+ * Tailwind v4 is CSS-first: there is NO `tailwind.config.js`. The single
+ * `@import "tailwindcss";` below pulls in Tailwind's preflight + utilities,
+ * and design tokens are declared inline via `@theme { … }`. In dev, the
+ * `@tailwindcss/browser` CDN script in index.html compiles the utilities
+ * at runtime — zero build step. For production, swap the CDN for the
+ * `@tailwindcss/cli` build (see README "Production hardening") and emit a
+ * compiled stylesheet.
+ *
+ * The layout / Xray-host rules below are plain CSS on purpose: they size
+ * the app shell + the devtools column and must survive whether or not
+ * Tailwind's utilities are in play. */
+@import "tailwindcss";
+
+body { font: 16px/1.4 system-ui, sans-serif; margin: 0; }
+.rf2-app-shell { display: flex; min-height: 100vh; }
+/* The Xray host reserves a RIGHT-side column (the aside follows
+ * `<main id="app">` in the DOM, so flex flow lays it to the right).
+ * It only takes up space once Xray has populated it. In dev, the
+ * `day8.re-frame2-xray.preload` mounts Xray into the
+ * `[data-rf-xray-host]` aside, making it non-empty and sizing it here.
+ * Release builds drop the preload, so the aside stays empty and
+ * `:empty` collapses it — `#app` then spans the full viewport instead
+ * of shipping a blank gutter.
+ *
+ * `flex-basis` reads `--rf-xray-inline-width` (Xray's host-owned resize
+ * knob, default 560px) so a persisted drag-resize width and
+ * cascade-level overrides (`:root`, per-route) take effect — a literal
+ * width ignores them. `box-sizing: border-box` keeps the 1px
+ * `border-left` inside the documented width. See the Xray §Layout host
+ * contract (tools/xray/spec/011-Launch-Modes.md). */
+.rf2-xray-host {
+  flex: 0 0 var(--rf-xray-inline-width, 560px);
+  min-width: 320px;
+  box-sizing: border-box;
+  border-left: 1px solid #2a2a2a;
+}
+.rf2-xray-host:empty { display: none; }
+#app { flex: 1; min-width: 0; padding: 2em; }
+button { padding: 0.4em 0.8em; }
+h1 { margin: 0 0 1em; }

--- a/tools/template/resources/day8/re_frame2_template/_css_tailwind/index.html
+++ b/tools/template/resources/day8/re_frame2_template/_css_tailwind/index.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <!-- Development-flavoured Content Security Policy. This meta tag is
+         the dev fall-back when no server-side header is set; it is tuned
+         to the RUNTIME the scaffold actually produces, not an aspirational
+         strict baseline.
+
+         - `style-src 'self' 'unsafe-inline'` — the generated views use
+           inline `:style` props, the default-on Xray devtools surface
+           injects `<style>` blocks and inline styles, AND the
+           @tailwindcss/browser CDN compiler injects a runtime `<style>`
+           block of utilities. Without `'unsafe-inline'` the first page
+           would emit CSP violations and both Xray's styling and Tailwind's
+           utilities would be blocked. (To run with a strict
+           `style-src 'self'`, move to the `@tailwindcss/cli` compiled
+           build + external CSS / a nonce and drop Xray — see README
+           "Production hardening".)
+         - `script-src 'self' https://cdn.jsdelivr.net` — the dev Tailwind
+           compiler loads from the jsdelivr CDN. Production drops the CDN
+           for a compiled stylesheet, so `script-src 'self'` alone
+           suffices there (see README "Production hardening").
+         - `connect-src` admits the same origin plus ws:/wss: so
+           shadow-cljs's hot-reload websocket connects in dev (it can
+           route to a different port than the page, which 'self' alone
+           would block).
+         - NO `frame-ancestors` here: browsers IGNORE `frame-ancestors`
+           delivered via a `<meta>` tag — it only takes effect from a
+           response header. Putting it here would imply anti-clickjacking
+           protection the scaffold does not actually have. The
+           anti-clickjacking contract lives in the README's response-header
+           snippets ("Production hardening").
+
+         For production, serve a Content-Security-Policy RESPONSE HEADER
+         (see README "Production hardening"): drop `'unsafe-inline'` and
+         the jsdelivr origin once you've compiled Tailwind with
+         `@tailwindcss/cli` and externalised styles, drop `ws: wss:` (no
+         dev hot-reload), tighten `connect-src` to your real API
+         origin(s), and add `frame-ancestors 'none'` THERE (where it
+         works). -->
+    <meta http-equiv="Content-Security-Policy"
+          content="default-src 'self'; script-src 'self' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' ws: wss:; object-src 'none'; base-uri 'none'">
+    <title>{{name}} — re-frame2</title>
+    <!-- Tailwind v4, dev-only CDN compiler (@tailwindcss/browser@4,
+         Q6 lock / rf2-gthro). Compiles the utilities used on the page at
+         runtime — zero build step. Swap for a compiled stylesheet from
+         `@tailwindcss/cli` before shipping (README "Production
+         hardening"). -->
+    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+    <link rel="stylesheet" href="/css/app.css">
+  </head>
+  <body>
+    <div class="rf2-app-shell">
+      <main id="app"></main>
+      <aside class="rf2-xray-host" data-rf-xray-host></aside>
+    </div>
+    <script src="/js/main.js"></script>
+  </body>
+</html>

--- a/tools/template/spec/000-Vision.md
+++ b/tools/template/spec/000-Vision.md
@@ -102,9 +102,11 @@ and recognises the shape. That continuity is deliberate.
   - `:include-story?` (rf2-t009p, shipped today) — emits a
     `counter_with_stories`-shaped story scaffold alongside the
     live app. Reagent-only in v1.
-  - `:css :tailwind` (rf2-gthro, deferred until gating bead
-    flips) — Tailwind v4 in place of the default plain-CSS
-    `app.css`.
+  - `:css :tailwind` (rf2-gthro verification; wiring rf2-nxqcov,
+    shipped) — Tailwind v4 in place of the default plain-CSS
+    `app.css`: a CSS-first `@import "tailwindcss";` stylesheet (no
+    `tailwind.config.js`) plus an `index.html` that loads the
+    `@tailwindcss/browser@4` dev CDN compiler. Substrate-invariant.
   - `:include-ssr?` (rf2-675qdb, shipped) — SSR scaffolding per
     Spec 011: a shared `core.cljc` (JVM render + CLJS hydration),
     a `server.clj` Ring host, and a headless `ssr_test.clj`.

--- a/tools/template/spec/API.md
+++ b/tools/template/spec/API.md
@@ -106,15 +106,19 @@ throws. The branching exception is justified in
 are permitted when they enable optional shared scaffolding whose
 absence would force the user into hand-wiring known idioms.
 
-Future toggles (`:css`, `:include-ssr?`) slot in here. The v1 set
-is locked at three flags total (`:include-story?`, `:css`,
-`:include-ssr?`); the latter two are gated on rf2-gthro (Tailwind
-v4 verification) and rf2-0m5ea (SSR validation) respectively. Until
-those gates clear, passing `:css` or `:include-ssr?` **fails closed**
-with `:rf.error/template-unsupported-flag` (the flag and its gating
-bead are named in the message) — it is not silently dropped. Any
-other unrecognised template key, including a typo of a live flag
-(e.g. `:include-story` for `:include-story?`), fails closed with
+The v1 set is locked at three flags total (`:include-story?`,
+`:css`, `:include-ssr?`) — all now live. `:css` (rf2-gthro
+verification; wiring rf2-nxqcov) accepts `:tailwind` (Tailwind v4
+scaffold) or nil (plain-CSS default); a bogus value fails closed
+with `:rf.error/template-bad-css-flag`. `:include-ssr?` (rf2-0m5ea
+validation; wiring rf2-675qdb) accepts `true` / `false` / `nil`.
+There are no reserved-but-unimplemented flags today; the fail-closed
+`reserved-flag-gates` list (empty) stays as the home for any future
+one — passing a reserved flag would throw
+`:rf.error/template-unsupported-flag` (the flag and its gating bead
+named in the message). Any other unrecognised template key,
+including a typo of a live flag (e.g. `:include-story` for
+`:include-story?`), fails closed with
 `:rf.error/template-unknown-flag`. The gate distinguishes template
 keys from deps-new's own harness keys via a pinned allowlist (the
 deps-new coord is pinned in the template's `deps.edn`).
@@ -178,7 +182,8 @@ mirror the chosen `:substrate` + `:include-story?` flags.
 | `:substrate` not one of `#{:reagent :uix :helix}` | `:rf.error/template-substrate-must-be-one-of` (keyword arg outside the valid set) / `:rf.error/template-substrate-must-be-keyword` (non-keyword shape — string, symbol, number, …) | `ex-info` thrown; message names the valid set; `ex-data` carries `{:substrate <bad-value> :valid #{...}}`. |
 | `:include-story?` not `true` / `false` / `nil` | `:rf.error/template-bad-include-story-flag` | `ex-info` thrown; message gives the offending value. |
 | `:include-story? true` with non-Reagent substrate | `:rf.error/template-include-story-reagent-only` | `ex-info` thrown; message says "Reagent-only in v1" and names the chosen substrate. |
-| Reserved-but-unimplemented flag passed (`:css`, `:include-ssr?`) | `:rf.error/template-unsupported-flag` | `ex-info` thrown; message names the flag and its gating bead (rf2-gthro / rf2-0m5ea). Fails closed — does **not** silently scaffold a vanilla app. |
+| `:css` not `:tailwind` / `nil` | `:rf.error/template-bad-css-flag` | `ex-info` thrown; message names the valid set (`#{:tailwind}`, or omit for the plain-CSS default) and the offending value. Fails closed. |
+| Reserved-but-unimplemented flag passed (none today) | `:rf.error/template-unsupported-flag` | `ex-info` thrown; message names the flag and its gating bead. Fails closed — does **not** silently scaffold a vanilla app. The v1 flags (`:include-story?` / `:css` / `:include-ssr?`) are all live; `reserved-flag-gates` (empty) is the home for any future reserved flag. |
 | Unknown template flag (incl. typos like `:include-story`, `:include-stories?`) | `:rf.error/template-unknown-flag` | `ex-info` thrown; message lists the unknown key(s) and the accepted flag set. Distinguished from deps-new harness keys via a pinned allowlist. |
 | `:name` missing | n/a (deps-new) | deps-new's harness rejects before template is invoked. |
 | `:name` not group-qualified | n/a (deps-new) | **Not rejected.** deps-new doubles a bare name (`my-app` → the symbol `my-app/my-app`), so the generated namespace is `my-app.my-app` and the source nests under `src/my_app/my_app/`. Always pass a group-qualified `:name` (`acme/my-app`); an unqualified one scaffolds, but with a doubled, almost-certainly-unintended namespace. |

--- a/tools/template/src/day8/re_frame2_template/hooks.clj
+++ b/tools/template/src/day8/re_frame2_template/hooks.clj
@@ -21,9 +21,13 @@
        `:rf.error/ssr-and-story-mutually-exclusive` (the file-naming
        convention would blow up combinatorially on `_with_X_and_Y`
        sources; see 004-SSR-Validation-Report §2.1).
-     - Pending flags (reserved, gated to later stages): `:css`. Passing it
-       today fails closed with `:rf.error/template-unsupported-flag` (it is
-       NOT silently dropped) — see `gate-arg-keys!`.
+     - `:css` — `:tailwind` swaps the plain-CSS scaffold for a Tailwind
+       v4 one (Q6 lock / rf2-gthro verification; wiring rf2-nxqcov).
+       Omitted / nil ⇒ the plain-CSS default. Substrate-invariant.
+     - No pending (reserved-but-unimplemented) flags today.
+       `reserved-flag-gates` (empty) stays as the fail-closed home for any
+       future one — passing a reserved flag throws
+       `:rf.error/template-unsupported-flag` (see `gate-arg-keys!`).
 
    ## Substitution engine note
 
@@ -46,8 +50,9 @@
    second `package_with_story.json` source exists.
 
    The steady-state shape (see tools/template/spec/003-DepsNew-Rebuild-Plan.md
-   §1) is the same matrix; additional flags (`:css`, `:include-ssr?`)
-   slot in here once their upstream gates clear."
+   §1) is the same matrix; the v1 flag set (`:include-story?`,
+   `:include-ssr?`, `:css`) is fully wired — further flags slot in here
+   once justified in DESIGN-RATIONALE."
   (:require [clojure.set :as set]
             [clojure.string :as string]))
 
@@ -115,15 +120,15 @@
 ;;
 ;; deps-new hands `data-fn` a single map that merges its own harness keys
 ;; (the project-name derivations + run metadata) with whatever top-level
-;; k/v args the caller passed. We accept exactly three template-specific
-;; flags today (`:substrate`, `:include-story?`, `:include-ssr?`); the
-;; `:css` flag is reserved-but-unimplemented (gated on its upstream
-;; verification).
+;; k/v args the caller passed. We accept exactly four template-specific
+;; flags today (`:substrate`, `:include-story?`, `:include-ssr?`, `:css`).
+;; `reserved-flag-gates` is the fail-closed home for any future
+;; reserved-but-unimplemented flag (empty today — `:css` shipped under
+;; rf2-nxqcov once its rf2-gthro gate closed).
 ;;
 ;; The substrate posture already fails closed on bad values; this gate
 ;; extends that strictness to the *key set* so a flag typo
-;; (`:include-story`) or a documented-future flag (`:css :tailwind`) can't
-;; fail open into a misleading vanilla scaffold.
+;; (`:include-story`) can't fail open into a misleading vanilla scaffold.
 ;;
 ;; HOW WE DISTINGUISH HARNESS KEYS FROM TEMPLATE KEYS: deps-new's
 ;; `preprocess-options` (org.corfield.new.impl) populates a fixed, known
@@ -149,18 +154,23 @@
 
 (def ^:private template-flag-keys
   "The template-specific flags we accept today."
-  #{:substrate :include-story? :include-ssr?})
+  #{:substrate :include-story? :include-ssr? :css})
 
 (def ^:private reserved-flag-gates
   "Reserved-but-unimplemented flags → the gating bead that must clear
    before they go live. Passing one today fails closed rather than
-   scaffolding a vanilla app that silently lacks the feature."
-  {:css "rf2-gthro (Tailwind v4 verification)"})
+   scaffolding a vanilla app that silently lacks the feature.
+
+   Empty today: the last reserved flag (`:css`, gated on rf2-gthro)
+   shipped once the Tailwind-major verification closed (rf2-nxqcov).
+   Kept as the fail-closed home for any future reserved-but-unimplemented
+   flag."
+  {})
 
 (defn- gate-arg-keys!
   "Fail closed on reserved or unknown template arguments.
 
-   - A reserved flag (`:css`) throws
+   - A reserved flag (see `reserved-flag-gates`; empty today) throws
      `:rf.error/template-unsupported-flag`, naming the flag and its
      gating bead — it is not silently dropped.
    - Any key that is neither a deps-new harness key nor a live
@@ -231,6 +241,37 @@
                      :reason    (str ":include-ssr? must be true or false (got "
                                      (pr-str raw) ")")
                      :include-ssr? raw}))))
+
+;; -- :css coercion ---------------------------------------------------------
+
+(def ^:private valid-css
+  "Accepted `:css` values. `nil` ⇒ the plain-CSS default; `:tailwind`
+   swaps in the Tailwind v4 scaffold (Q6 lock / rf2-gthro; wiring
+   rf2-nxqcov). Additional CSS opt-ins would grow this set."
+  #{:tailwind})
+
+(defn- coerce-css
+  "Coerce the `:css` arg to a keyword or nil. `nil` selects the default
+   plain-CSS scaffold; `:tailwind` selects the Tailwind v4 variant.
+   Anything else (a string, a bogus keyword like `:tailwnid`) fails
+   closed with a clear message naming the valid set — matching the
+   fail-closed posture the substrate + flag coercions already carry."
+  [raw]
+  (cond
+    (nil? raw)          nil
+    (valid-css raw)     raw
+    :else
+    (throw (ex-info ":rf.error/template-bad-css-flag"
+                    {:rf.error/id :rf.error/template-bad-css-flag
+                     :where    'template/coerce-css
+                     :recovery :fix-registration
+                     :reason   (str ":css must be one of "
+                                    (pr-str valid-css)
+                                    " (or omitted for the plain-CSS "
+                                    "default). Got "
+                                    (pr-str raw) ".")
+                     :css      raw
+                     :valid    valid-css}))))
 
 ;; -- name derivations ------------------------------------------------------
 ;;
@@ -304,7 +345,9 @@
 
    Substrate + include-story? are also stored under `:substrate-kw` and
    `:include-story?` for `template-fn`'s switch (`->subst-map` would
-   otherwise coerce the keyword to a string)."
+   otherwise coerce the keyword to a string). `:css-kw` (nil or
+   `:tailwind`) is likewise stored for `template-fn`'s CSS overlay
+   branch (rf2-nxqcov)."
   [data]
   ;; Fail closed on reserved + unknown arguments BEFORE any coercion, so a
   ;; flag typo or a documented-future flag never produces a misleading
@@ -312,7 +355,8 @@
   (gate-arg-keys! data)
   (let [substrate       (coerce-substrate (:substrate data))
         include-story?  (coerce-include-story? (:include-story? data))
-        include-ssr?    (coerce-include-ssr? (:include-ssr? data))]
+        include-ssr?    (coerce-include-ssr? (:include-ssr? data))
+        css             (coerce-css (:css data))]
     ;; Guards — all hoisted above the name-derivation `let` so the data
     ;; map build below has no side-effecting binding.
 
@@ -377,6 +421,10 @@
        :substrate-label     label
        :include-story?      include-story?
        :include-ssr?        include-ssr?
+       ;; nil (plain-CSS default) or :tailwind (Tailwind v4 scaffold).
+       ;; `template-fn` reads this to overlay the Tailwind app.css +
+       ;; index.html over the plain defaults emitted from `root/`.
+       :css-kw              css
        ;; package.json `description` suffix — the single per-flag delta
        ;; between the default and with-Story descriptions. Emitting it as
        ;; a subst var lets one `_shared/package.json` source serve both
@@ -451,7 +499,7 @@
 (defn template-fn
   "Build the `:transform` vector and merge it into the template EDN.
 
-   Three transform groups:
+   Transform groups:
 
      - Shared (from `_shared/`): dotfile rename (e.g. `gitignore` →
        `.gitignore`) + namespace-path rename for src/test source files
@@ -476,6 +524,13 @@
        (`events.cljs` / `subs.cljs` / `schema.cljs` / `events_test.cljs` /
        `views.cljs`) are NOT emitted; the shared file-map instead emits a
        headless JVM `ssr_test.clj`. See 004-SSR-Validation-Report §3.
+     - CSS overlay (substrate-invariant, under `:css :tailwind`; Q6 lock /
+       rf2-gthro, wiring rf2-nxqcov): overwrites the plain-CSS `app.css` +
+       `index.html` (emitted by the `root/` bulk-copy) with the Tailwind v4
+       variants from `_css_tailwind/` — an `@import \"tailwindcss\";`
+       stylesheet (v4 is CSS-first; no `tailwind.config.js`) and an
+       `index.html` that loads the `@tailwindcss/browser@4` dev CDN
+       compiler. Runs last so it lands on top of the root copy.
 
    All groups use `:only` so only files explicitly listed in the
    file-map emit (the implicit bulk-copy of `<src-dir>/*` is skipped).
@@ -491,6 +546,7 @@
         substrate      (:substrate data)
         include-story? (:include-story? data)
         include-ssr?   (:include-ssr? data)
+        css            (:css-kw data)
         ;; The build configs are substrate-invariant — the React
         ;; substrate is chosen in deps.edn + core.cljs, never here — so
         ;; they live in `_shared/` and emit once. package.json's only
@@ -585,8 +641,28 @@
             {"deps.edn"        "deps.edn"
              "core.cljs"       (str "src/" nested "/core.cljs")
              "views.cljs"      (str "src/" nested "/views.cljs")}
+            :only]])
+
+        ;; CSS overlay (Q6 lock / rf2-gthro; wiring rf2-nxqcov). The
+        ;; default plain-CSS `app.css` + `index.html` are emitted by the
+        ;; `root/` bulk-copy above. When `:css :tailwind` is passed, this
+        ;; transform runs AFTER the root copy and overwrites those two
+        ;; files with the Tailwind v4 variants from `_css_tailwind/`: an
+        ;; `app.css` whose entry is `@import "tailwindcss";` (v4 is
+        ;; CSS-first — no `tailwind.config.js`) and an `index.html` that
+        ;; loads the `@tailwindcss/browser@4` dev CDN compiler (zero build
+        ;; step) with a CSP tuned to admit it. deps-new runs the `:root`
+        ;; copy first, then each `:transform` entry in order (see
+        ;; org.corfield.new/create), and tools.build's `copy-dir`
+        ;; overwrites, so the overlay is deterministic. Substrate-invariant
+        ;; — the CSS scaffold is the same across Reagent / UIx / Helix.
+        css-overlay
+        (when (= css :tailwind)
+          [["_css_tailwind" "."
+            {"app.css"    "resources/public/css/app.css"
+             "index.html" "resources/public/index.html"}
             :only]])]
-    (assoc edn :transform (into [] (concat shared per-substrate)))))
+    (assoc edn :transform (into [] (concat shared per-substrate css-overlay)))))
 
 ;; -- post-process-fn --------------------------------------------------------
 
@@ -597,12 +673,14 @@
   (let [substrate      (:substrate data)
         include-story? (:include-story? data)
         include-ssr?   (:include-ssr? data)
+        css            (:css-kw data)
         feature-tag    (cond
                          include-story? " (with Story playground)"
                          include-ssr?   " (with SSR)"
-                         :else          "")]
+                         :else          "")
+        css-tag        (if (= css :tailwind) " (Tailwind CSS)" "")]
     (println (str "Generated a re-frame2 application " (:name data)
-                  " (" substrate " substrate" feature-tag ")."))
+                  " (" substrate " substrate" feature-tag css-tag ")."))
     (println "Next steps:")
     ;; `:target-dir` is preprocess-options' computed output dir
     ;; (defaults to `(:main data)` when no `:target-dir` arg is given).

--- a/tools/template/test/day8/re_frame2_template/template_emission_test.clj
+++ b/tools/template/test/day8/re_frame2_template/template_emission_test.clj
@@ -36,7 +36,8 @@
             [clojure.tools.reader :as tr]
             [clojure.tools.reader.reader-types :as rt]
             [day8.re-frame2-template.test-support
-             :refer [tmp-dir delete-recursively run-template! repo-root]]))
+             :refer [tmp-dir delete-recursively run-template!
+                     run-template-opts! repo-root]]))
 
 ;; --- Helpers ---------------------------------------------------------------
 ;;
@@ -943,5 +944,37 @@
           (doseq [rel ["src/acme/my_app/core.cljs"
                        "src/acme/my_app/stories.cljs"]]
             (audit-framework-surface! :reagent (io/file proj rel) root)))
+        (finally
+          (delete-recursively tmp))))))
+
+;; --- :css :tailwind --------------------------------------------------------
+;;
+;; The Tailwind overlay overwrites the plain-CSS `app.css` + `index.html`
+;; with the `_css_tailwind/` variants (rf2-nxqcov). The Xray-host layout
+;; contract MUST survive that swap: the emitted index.html/app.css still
+;; have to satisfy `assert-xray-host-contract!` (right-side host DOM order,
+;; resizable flex-basis, :empty collapse) and `assert-no-stale-xray-wording!`
+;; (no stale left-column prose). Reusing those audits on the tailwind tree
+;; keeps the Tailwind variant honest against the same runtime shape the
+;; plain path is pinned to, and additionally pins the Tailwind-specific
+;; markers (the @import entry + the dev CDN script).
+
+(deftest css-tailwind-emission-static-parse-test
+  (testing ":css :tailwind swaps in the Tailwind v4 app.css + index.html
+            while preserving the Xray-host layout contract"
+    (let [tmp (tmp-dir "rf2-emission-tailwind-")]
+      (try
+        (let [proj    (run-template-opts! tmp "acme/my-app"
+                                          {:css :tailwind})
+              app-css (slurp (io/file proj "resources/public/css/app.css"))
+              index   (slurp (io/file proj "resources/public/index.html"))]
+          ;; The layout-host contract survives the overlay.
+          (assert-xray-host-contract! :tailwind proj)
+          (assert-no-stale-xray-wording! :tailwind proj)
+          ;; Tailwind-specific markers.
+          (is (re-find #"@import\s+\"tailwindcss\"" app-css)
+              "tailwind app.css imports tailwindcss (v4 CSS-first entry)")
+          (is (re-find #"@tailwindcss/browser@4" index)
+              "tailwind index.html loads the @tailwindcss/browser@4 dev CDN"))
         (finally
           (delete-recursively tmp))))))

--- a/tools/template/test/day8/re_frame2_template/template_test.clj
+++ b/tools/template/test/day8/re_frame2_template/template_test.clj
@@ -1265,16 +1265,56 @@
   (is (zero? (count (.listFiles (clojure.java.io/file (.toString tmp)))))
       "the gate fired before any scaffold was emitted (tmp dir is empty)"))
 
-(deftest reserved-css-flag-rejected-test
-  (testing ":css :tailwind is reserved (gated on rf2-gthro) and fails
-            closed — it does NOT silently emit the default scaffold"
-    (let [tmp (tmp-dir "rf2-template-css-")]
+(deftest css-tailwind-emits-tailwind-scaffold-test
+  (testing ":css :tailwind (rf2-gthro closed; wiring rf2-nxqcov) swaps the
+            plain-CSS scaffold for the Tailwind v4 variant — the app.css
+            imports Tailwind, index.html loads the dev CDN compiler, and
+            both keep the Xray-host layout contract"
+    (let [tmp (tmp-dir "rf2-template-css-tailwind-")]
+      (try
+        (let [proj    (run-template-opts! tmp "acme/my-app"
+                                          {:css :tailwind})
+              app-css (slurp (io/file proj "resources/public/css/app.css"))
+              index   (slurp (io/file proj "resources/public/index.html"))]
+          ;; -- app.css is the Tailwind v4 entry (CSS-first: @import, no
+          ;;    tailwind.config.js) --
+          (is (re-find #"@import\s+\"tailwindcss\"" app-css)
+              "tailwind app.css imports tailwindcss (v4 CSS-first entry)")
+          (is (not (re-find #"no Tailwind" app-css))
+              "the plain-CSS preamble (\"no Tailwind\") is gone — the
+               Tailwind variant overwrote the default app.css")
+          ;; -- the Xray-host layout contract SURVIVES the swap (the
+          ;;    emission test's assert-xray-host-contract! also pins this;
+          ;;    a lightweight cross-check here keeps the tailwind path
+          ;;    honest in the shape suite too) --
+          (is (re-find #"flex:\s*0\s+0\s+var\(--rf-xray-inline-width,\s*560px\)"
+                       app-css)
+              "tailwind app.css keeps the resizable Xray-host flex-basis")
+          (is (re-find #"\.rf2-xray-host:empty\s*\{[^}]*display:\s*none" app-css)
+              "tailwind app.css keeps the :empty host collapse")
+          ;; -- index.html loads the dev CDN compiler + admits it in the CSP --
+          (is (re-find #"@tailwindcss/browser@4" index)
+              "tailwind index.html loads the @tailwindcss/browser@4 dev CDN")
+          (is (re-find #"script-src[^;]*cdn\.jsdelivr\.net" index)
+              "tailwind index.html CSP script-src admits the jsdelivr CDN")
+          ;; -- the RIGHT-side Xray host DOM order survives the swap --
+          (is (< (.indexOf index "id=\"app\"")
+                 (.indexOf index "data-rf-xray-host"))
+              "tailwind index.html keeps `<main id=\"app\">` before the
+               Xray host aside (right-side host contract)"))
+        (finally
+          (delete-recursively tmp))))))
+
+(deftest css-bad-value-rejected-test
+  (testing "a bogus :css value fails closed with :rf.error/template-bad-css-flag
+            rather than silently emitting the plain-CSS scaffold"
+    (let [tmp (tmp-dir "rf2-template-css-bad-")]
       (try
         (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                              #":rf\.error/template-unsupported-flag"
+                              #":rf\.error/template-bad-css-flag"
                               (run-template-opts! tmp "acme/my-app"
-                                                  {:css :tailwind}))
-            ":css :tailwind is rejected as an unsupported reserved flag")
+                                                  {:css :tailwnid}))
+            ":css :tailwnid (typo) is rejected as an invalid css value")
         (assert-no-scaffold-emitted! tmp)
         (finally
           (delete-recursively tmp))))))


### PR DESCRIPTION
## What

Wires the template's `:css :tailwind` flag through for real. Its gating bead **rf2-gthro** closed (Tailwind v4.3 verified, coords locked) but the flag still failed closed as a reserved "Pending" flag. Now `:css :tailwind` emits the Tailwind-configured scaffold; `:css` omitted keeps the plain-CSS default.

### Wiring
- **`data-fn`** — `:css` is a live template flag now (moved from `reserved-flag-gates` into `template-flag-keys`). `coerce-css` accepts `nil` (plain default) or `:tailwind`; any other value fails closed with `:rf.error/template-bad-css-flag`. `reserved-flag-gates` is now empty (kept as the fail-closed home for any future reserved flag). `:css-kw` threaded to `template-fn`.
- **`template-fn`** — a substrate-invariant CSS **overlay** transform runs last and overwrites the plain-CSS `app.css` + `index.html` (emitted by the `root/` bulk-copy) with the Tailwind v4 variants when `:css :tailwind`. deps-new runs `:root` first then each `:transform` in order, and tools.build's `copy-dir` overwrites, so the overlay is deterministic.
- **`_css_tailwind/app.css`** — CSS-first `@import "tailwindcss";` entry (Tailwind v4 has no `tailwind.config.js`), keeping the Xray-host layout rules the emission tests audit.
- **`_css_tailwind/index.html`** — loads the `@tailwindcss/browser@4` dev CDN compiler (zero build step, matches the rf2-gthro-locked coord), with a CSP tuned to admit the jsdelivr script + Tailwind's runtime `<style>`; keeps the right-side Xray host DOM order.
- **Docs** — `spec/000-Vision.md`, `spec/API.md`, `README.md` flipped from deferred/gated to shipped (also corrected the now-stale `:include-ssr?` "reserved" wording, which had already shipped).

### Test delta
- `template_test.clj`: replaced `reserved-css-flag-rejected-test` with **`css-tailwind-emits-tailwind-scaffold-test`** (positive emission: `@import "tailwindcss"`, dev CDN, CSP, Xray host contract survives) + **`css-bad-value-rejected-test`** (bad `:css` value fails closed).
- `template_emission_test.clj`: added **`css-tailwind-emission-static-parse-test`** reusing `assert-xray-host-contract!` + `assert-no-stale-xray-wording!` on the tailwind tree, plus Tailwind-specific markers.

## Quality gates
- **Template `clojure -M:test`** (from `tools/template/`): **PASS** — `Ran 45 tests containing 613 assertions. 0 failures, 0 errors.` Includes the new positive `:css :tailwind` emission tests + the bad-value fail-closed test.
- **`mkdocs build --strict`**: not run — no `docs/` files touched (only `tools/template/spec/` + `tools/template/README.md`, which are outside the mkdocs tree). No coupling.