### PR TITLE
refactor(xray): rename preview-cascade public event-id (rf2-ear8mg)

### DIFF
--- a/tools/xray/spec/018-Event-Spine.md
+++ b/tools/xray/spec/018-Event-Spine.md
@@ -1091,7 +1091,7 @@ The single-axis selection that every layer reads from.
 | `:rf.xray/follow-head` | `⏭` button · `L` key | Sets `:mode :live`, clears pinned id, snaps `:dispatch-id` to head |
 | `:rf.xray/toggle-live-pause` | `Space` key | Pauses/resumes LIVE buffer-to-list flow; buffer continues collecting; mode stays LIVE (paused) |
 | `:rf.xray/select-frame <frame-id>` → `:rf.xray/set-frame <frame-id>` | Frame picker selection | **`:rf.xray/select-frame`** is the canonical write surface (event-fx; dispatched by the frame-switcher view + the palette + `core/set-target-frame!`). It writes the dedicated `:view-scope-frame` slot (the VIEW SCOPE the L2 list scopes by — rf2-4vp5j) AND dispatches the spine primitive **`:rf.xray/set-frame`**, which writes `:focus :frame` + clears `:dispatch-id` to head of the new frame. Per the multi-frame panel-focus fix wave (rf2-fvplw / rf2-y8bik / rf2-ug1r6 / rf2-thodq) the `set-frame` write ALSO re-seeds `:rf.xray/target-frame` (the per-frame projection axis the App-db diff + Views composites read) AND `:rf.xray/epoch-history` (the cached snapshot of `(rf/epoch-history target)`) so every per-frame panel follows the picker as one atomic move — see [§Multi-frame panel-focus invariant (P) — v1 ships](#multi-frame-panel-focus-invariant-p--v1-ships) below. |
-| `:rf.xray/preview-cascade <id> [<frame>]` | Row hover (before click commits) | Sets `:previewing? true`, `:dispatch-id` / `:epoch-id` `<id>` transiently. A non-destructive overlay: it snapshots the committed selection into `[:focus :pre-preview]` on the first hover of a gesture and RESTORES it on hover-out (nil `<id>`), and resolves the previewed epoch against the previewed frame's ring DIRECTLY without persisting a cross-frame `:target-frame` / `:epoch-history` re-key (rf2-uo0rc.5). The optional `<frame>` hint disambiguates a dispatch-id present in two frames (rf2-bz7flo) — the L2 row knows its frame; when omitted the lookup degrades to an id-only match. |
+| `:rf.xray/preview-event <id> [<frame>]` | Row hover (before click commits) | Sets `:previewing? true`, `:dispatch-id` / `:epoch-id` `<id>` transiently. A non-destructive overlay: it snapshots the committed selection into `[:focus :pre-preview]` on the first hover of a gesture and RESTORES it on hover-out (nil `<id>`), and resolves the previewed epoch against the previewed frame's ring DIRECTLY without persisting a cross-frame `:target-frame` / `:epoch-history` re-key (rf2-uo0rc.5). The optional `<frame>` hint disambiguates a dispatch-id present in two frames (rf2-bz7flo) — the L2 row knows its frame; when omitted the lookup degrades to an id-only match. |
 
 ### Per-layer rebind table
 
@@ -1472,7 +1472,7 @@ not just a same-frame one: pre-fix the clicked cascade's epoch
 resolved to nil and the epoch-keyed panels (App-DB diff, Views'
 focused-cascade-pair, Machine Inspector) rendered empty/stale.
 
-**`:rf.xray/preview-cascade` resolves WITHOUT committing the re-key
+**`:rf.xray/preview-event` resolves WITHOUT committing the re-key
 (rf2-uo0rc.5).** A preview is a transient hover, not a commit, so it
 must NOT persist a cross-frame `:target-frame` / `:epoch-history`
 re-key. The preview handler resolves the previewed cascade's epoch
@@ -1498,7 +1498,7 @@ resolution (multi-frame, picker untouched); the
 suites pin the panel render bodies post-reseed. For the preview path
 (rf2-uo0rc.5) `spine_cljs_test.cljs` additionally pins that
 preview-clear RESTORES the committed `:dispatch-id` / `:epoch-id` (RETRO
-hover-then-leave) and that the `:rf.xray/preview-cascade` handler does
+hover-then-leave) and that the `:rf.xray/preview-event` handler does
 NOT persist a cross-frame `:target-frame` / `:epoch-history` re-key.
 
 **Frame-strict cascade lookup (rf2-bz7flo).** Dispatch ids are unique

--- a/tools/xray/src/day8/re_frame2_xray/spine.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/spine.cljs
@@ -793,7 +793,7 @@
   `:target-frame` — a same-frame click is a no-op (the slot already
   holds that frame's ring, kept fresh by `epoch-recorded`).
 
-  `:rf.xray/preview-cascade` deliberately DOES NOT call this (rf2-uo0rc.5):
+  `:rf.xray/preview-event` deliberately DOES NOT call this (rf2-uo0rc.5):
   a transient hover must not persist a cross-frame re-key. The preview
   handler instead resolves the previewed event-bundle's epoch against that
   frame's ring DIRECTLY (a read), leaving the committed `:target-frame`
@@ -847,8 +847,8 @@
              :target-frame  frame-id
              :epoch-history (vec epoch-history-for-frame)))))
 
-(defn preview-cascade-reducer
-  "Pure reducer for `:rf.xray/preview-cascade <id>`. A preview is a
+(defn preview-event-reducer
+  "Pure reducer for `:rf.xray/preview-event <id>`. A preview is a
   TRANSIENT hover overlay: it sets `:previewing? true` and writes the
   previewed `:dispatch-id` / `:epoch-id`, but it must NOT leave the
   committed selection perturbed once the hover ends. nil `id` clears the
@@ -883,7 +883,7 @@
   untouched — back-compat for the pure-shape callers; the 2-arity
   (resolved `epoch-id`) is the production path the event handler
   drives."
-  ([db dispatch-id] (preview-cascade-reducer db dispatch-id nil))
+  ([db dispatch-id] (preview-event-reducer db dispatch-id nil))
   ([db dispatch-id epoch-id]
    (if (nil? dispatch-id)
      ;; preview-clear: restore the committed selection captured at the
@@ -1096,7 +1096,7 @@
       ;; docstring for the shared root cause.
       {:db (set-frame-reducer db frame-id (rf/epoch-history frame-id))}))
 
-  (rf/reg-event :rf.xray/preview-cascade
+  (rf/reg-event :rf.xray/preview-event
     (fn [{:keys [db]} [_ dispatch-id frame-hint]]
       ;; rf2-yng0y — resolve the previewed event-bundle's settling epoch-id
       ;; from the per-frame ring and write it in lockstep with
@@ -1133,6 +1133,6 @@
       {:db (let [frame-id      (:frame (event-bundle-by-id (db->event-bundles db) dispatch-id frame-hint))
             frame-history (when frame-id (rf/epoch-history frame-id))
             epoch-id      (epoch-id-for-event-bundle frame-history dispatch-id)]
-        (preview-cascade-reducer db dispatch-id epoch-id))}))
+        (preview-event-reducer db dispatch-id epoch-id))}))
 
   nil)

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -640,7 +640,7 @@
    ;; rf2-czcg5 — chrome `⛶` pop-out button → lowers to mount/popout!
    ;; via the :rf.xray.fx/popout-shell effect.
    :rf.xray/popout-shell
-   :rf.xray/preview-cascade
+   :rf.xray/preview-event
    :rf.xray/remove-filter
    ;; rf2-6ni62 — L2 event-list column-divider double-click reset.
    :rf.xray/reset-event-list-col-width

--- a/tools/xray/test/day8/re_frame2_xray/spine_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/spine_cljs_test.cljs
@@ -8,7 +8,7 @@
 
   1. The pure reducers (`focus-event-bundle-reducer`, `follow-head-reducer`,
      `toggle-live-pause-reducer`, `set-frame-reducer`, `focus-step-
-     reducer`, `preview-cascade-reducer`) — JVM-runnable shape, no
+     reducer`, `preview-event-reducer`) — JVM-runnable shape, no
      re-frame machinery needed.
   2. `compose-focus` derives `:head?` + the effective `:dispatch-id`
      correctly across LIVE / RETRO / paused / evicted-cascade states.
@@ -448,7 +448,7 @@
       (is (= db r) "db unchanged"))))
 
 ;; -------------------------------------------------------------------------
-;; (7) set-frame-reducer + preview-cascade-reducer
+;; (7) set-frame-reducer + preview-event-reducer
 ;; -------------------------------------------------------------------------
 
 (deftest set-frame-reducer-clears-dispatch-id
@@ -508,20 +508,20 @@
           "no resolved history → slot cleared, never left stale")
       (is (= :cart-frame (:target-frame r))))))
 
-(deftest preview-cascade-reducer-sets-previewing-true
+(deftest preview-event-reducer-sets-previewing-true
   (let [db {}
-        r  (spine/preview-cascade-reducer db :c2)]
+        r  (spine/preview-event-reducer db :c2)]
     (is (true? (get-in r [:focus :previewing?])))
     (is (= :c2 (get-in r [:focus :dispatch-id])))))
 
-(deftest preview-cascade-reducer-nil-clears-preview
+(deftest preview-event-reducer-nil-clears-preview
   (let [db {:focus {:dispatch-id :c1 :previewing? true :mode :retro}}
-        r  (spine/preview-cascade-reducer db nil)]
+        r  (spine/preview-event-reducer db nil)]
     (is (false? (get-in r [:focus :previewing?])))
     (is (= :c1 (get-in r [:focus :dispatch-id]))
         "committed selection survives preview-clear")))
 
-(deftest preview-cascade-reducer-writes-epoch-id-rf2-yng0y
+(deftest preview-event-reducer-writes-epoch-id-rf2-yng0y
   (testing "rf2-yng0y — the 3-arity preview reducer writes :epoch-id in
             lockstep with :dispatch-id so the spine's two focus axes
             never desync mid-preview (the App-DB before-image follows
@@ -529,7 +529,7 @@
             leaving :epoch-id pinned to the committed epoch — a latent
             LIVE-mode correctness bug."
     (let [db {:focus {:dispatch-id :c1 :epoch-id :e1 :mode :live}}
-          r  (spine/preview-cascade-reducer db :c2 :e2)]
+          r  (spine/preview-event-reducer db :c2 :e2)]
       (is (true? (get-in r [:focus :previewing?])))
       (is (= :c2 (get-in r [:focus :dispatch-id]))
           ":dispatch-id moved to the previewed cascade")
@@ -540,18 +540,18 @@
             clobbering it to nil; the before-image stays on the last
             resolved epoch until a real epoch resolves."
     (let [db {:focus {:dispatch-id :c1 :epoch-id :e1 :mode :live}}
-          r  (spine/preview-cascade-reducer db :c2 nil)]
+          r  (spine/preview-event-reducer db :c2 nil)]
       (is (= :c2 (get-in r [:focus :dispatch-id])))
       (is (= :e1 (get-in r [:focus :epoch-id]))
           "unresolved preview epoch-id is non-destructive")))
   (testing "rf2-yng0y — the 2-arity arity is preserved (back-compat) and
             leaves :epoch-id untouched."
     (let [db {:focus {:epoch-id :e1}}
-          r  (spine/preview-cascade-reducer db :c2)]
+          r  (spine/preview-event-reducer db :c2)]
       (is (= :c2 (get-in r [:focus :dispatch-id])))
       (is (= :e1 (get-in r [:focus :epoch-id]))))))
 
-(deftest preview-cascade-reducer-clear-restores-committed-selection-rf2-uo0rc5
+(deftest preview-event-reducer-clear-restores-committed-selection-rf2-uo0rc5
   (testing "rf2-uo0rc.5 — a hover-then-leave gesture in RETRO restores the
             COMMITTED selection. Pre-fix the nil-arm cleared only
             :previewing?, leaving :dispatch-id / :epoch-id pinned at the
@@ -561,8 +561,8 @@
     (let [committed {:dispatch-id :c1 :epoch-id :e1 :mode :retro}
           ;; 1) user has :c1 committed; 2) hovers :c2 (preview-start);
           ;; 3) leaves (preview-clear).
-          previewed (spine/preview-cascade-reducer {:focus committed} :c2 :e2)
-          cleared   (spine/preview-cascade-reducer previewed nil)]
+          previewed (spine/preview-event-reducer {:focus committed} :c2 :e2)
+          cleared   (spine/preview-event-reducer previewed nil)]
       (testing "the preview moved focus transiently"
         (is (= :c2 (get-in previewed [:focus :dispatch-id])))
         (is (= :e2 (get-in previewed [:focus :epoch-id])))
@@ -576,33 +576,33 @@
         (is (nil? (get-in cleared [:focus :pre-preview]))
             "the backup slot is dropped after restore — no residue")))))
 
-(deftest preview-cascade-reducer-move-keeps-original-backup-rf2-uo0rc5
+(deftest preview-event-reducer-move-keeps-original-backup-rf2-uo0rc5
   (testing "rf2-uo0rc.5 — moving the hover across rows within one gesture
             keeps the ORIGINAL committed backup (not a previously-previewed
             value), so leaving still lands on the committed selection."
     (let [committed {:dispatch-id :c1 :epoch-id :e1 :mode :retro}
-          hover-c2  (spine/preview-cascade-reducer {:focus committed} :c2 :e2)
-          hover-c3  (spine/preview-cascade-reducer hover-c2 :c3 :e3)
-          cleared   (spine/preview-cascade-reducer hover-c3 nil)]
+          hover-c2  (spine/preview-event-reducer {:focus committed} :c2 :e2)
+          hover-c3  (spine/preview-event-reducer hover-c2 :c3 :e3)
+          cleared   (spine/preview-event-reducer hover-c3 nil)]
       (is (= :c3 (get-in hover-c3 [:focus :dispatch-id]))
           "the latest hover wins while previewing")
       (is (= :c1 (get-in cleared [:focus :dispatch-id]))
           "leaving restores the ORIGINAL committed :c1, never the intermediate :c2")
       (is (= :e1 (get-in cleared [:focus :epoch-id]))))))
 
-(deftest preview-cascade-reducer-no-backup-when-nothing-committed-rf2-uo0rc5
+(deftest preview-event-reducer-no-backup-when-nothing-committed-rf2-uo0rc5
   (testing "rf2-uo0rc.5 — preview-clear with no prior gesture (no backup)
             is a safe no-op on the committed slot (back-compat with the
             pre-fix `nil-clears-preview` contract)."
     (let [db {:focus {:dispatch-id :c1 :previewing? true :mode :retro}}
-          r  (spine/preview-cascade-reducer db nil)]
+          r  (spine/preview-event-reducer db nil)]
       (is (false? (get-in r [:focus :previewing?])))
       (is (= :c1 (get-in r [:focus :dispatch-id]))
           "committed selection survives when there is no backup to restore"))))
 
 ;; The handler-level cross-frame regression for rf2-uo0rc.5 lives in
 ;; section (9) alongside the other `seed-cascades!`-driven handler tests
-;; (`preview-cascade-handler-does-not-persist-cross-frame-rekey-rf2-uo0rc5`).
+;; (`preview-event-handler-does-not-persist-cross-frame-rekey-rf2-uo0rc5`).
 
 ;; -------------------------------------------------------------------------
 ;; (8) Registered :rf.xray/focus sub — reactive composition
@@ -936,8 +936,8 @@
           "paused LIVE pins focus through arrivals")
       (is (true? (:paused? r))))))
 
-(deftest preview-cascade-handler-does-not-persist-cross-frame-rekey-rf2-uo0rc5
-  (testing "rf2-uo0rc.5 — the :rf.xray/preview-cascade HANDLER must not
+(deftest preview-event-handler-does-not-persist-cross-frame-rekey-rf2-uo0rc5
+  (testing "rf2-uo0rc.5 — the :rf.xray/preview-event HANDLER must not
             persist a cross-frame :target-frame / :epoch-history re-key
             from a transient hover. Pre-fix it called
             reseed-epoch-history-for-frame, which re-keys those slots onto
@@ -959,7 +959,7 @@
       (let [before (rf/app-db-value :rf/xray)]
         ;; Hover the cross-frame :c2 row, then leave (preview-clear).
         (rf/with-frame :rf/xray
-          (rf/dispatch-sync [:rf.xray/preview-cascade :c2]))
+          (rf/dispatch-sync [:rf.xray/preview-event :c2]))
         (let [during (rf/app-db-value :rf/xray)]
           (testing "the preview did NOT re-key the committed cross-frame axis"
             (is (= (:target-frame before) (:target-frame during))
@@ -967,7 +967,7 @@
             (is (= (:epoch-history before) (:epoch-history during))
                 ":epoch-history is untouched by the transient hover")))
         (rf/with-frame :rf/xray
-          (rf/dispatch-sync [:rf.xray/preview-cascade nil]))
+          (rf/dispatch-sync [:rf.xray/preview-event nil]))
         (let [after (rf/app-db-value :rf/xray)]
           (testing "after hover-then-leave the committed axis is intact"
             (is (= (:target-frame before) (:target-frame after))


### PR DESCRIPTION
Renames the dispatchable PUBLIC event-id `:rf.xray/preview-cascade` → `:rf.xray/preview-event` (and the reducer `preview-cascade-reducer` → `preview-event-reducer`), completing the pipeline-vocab epic's event-*/pipeline-run migration. zj9cbj (#5153) correctly left this token because the public event-id was fsqlgz's domain; rf2-ear8mg finishes it now.

The new spelling matches the already-renamed `:rf.xray/focus-event` family (`:rf.xray/focus-event`, `focus-event-bundle-reducer`), keeping the public surface internally consistent.

## Rename
- `:rf.xray/preview-cascade` → `:rf.xray/preview-event` (public dispatchable event-id)
- `preview-cascade-reducer` → `preview-event-reducer` (pure reducer fn)

## Sites updated (all under `tools/xray/`)
- `tools/xray/src/day8/re_frame2_xray/spine.cljs` — `reg-event` id, `defn` + both call sites, docstring/comment refs
- `tools/xray/spec/018-Event-Spine.md` — the public event-id table row + 2 prose refs to the id
- `tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs` — registry-catalogue id
- `tools/xray/test/day8/re_frame2_xray/spine_cljs_test.cljs` — reducer/handler deftests + `dispatch-sync` id tokens

SENSE-GUARD honoured: only the literal `preview-cascade` token was touched. No machines cancellation-cascade or CSS-cascade names changed. The broader "cascade" prose noun (still 89 uses in spec/018) is out of scope — it belongs to the wider vocab migration, not this public-id rename. `git grep` of the old id/fn across all tracked files (excl `.beads/`) → zero live.

## Quality gates
- Xray `clojure -M:test` — **PASS** (1217 tests, 5643 assertions, 0 failures)
- `npm run test:xray-feature-gate` — **PASS** (0 failures, 16 scenarios / 13 matrix rows). First run flaked on the browser-driven `static mode chrome and chord` scenario (`http-server exited unexpectedly`); clean on re-run. That scenario never references `preview` and nothing in `implementation/` references the renamed id — the flake is unrelated to this rename.
- `npm run test:cljs` — **PASS** (8042 tests, 36963 assertions, 0 failures)