### PR TITLE
docs(spec): AI-Audit graduation 013/014/015/016 (rf2-mqtafh)

### DIFF
--- a/spec/AI-Audit.md
+++ b/spec/AI-Audit.md
@@ -1,18 +1,18 @@
 # AI-First Audit
 
 > **Type:** Audit
-> Applies the nine AI-first properties as a checklist against the re-frame2 corpus — the numbered Specs (000–016) plus the companion documents that participate in the AI-implementable goal (Spec-Schemas, Construction-Prompts, conformance/README). Surfaces gaps for the next round of design work. Per §Coverage policy the audit lags the live numbered set by design: Specs without a stand-alone Per-Spec table (incl. 013–016) are graded indirectly through the cross-cutting sections until a later pass adds them.
+> Applies the nine AI-first properties as a checklist against the re-frame2 corpus — the numbered Specs (000–016) plus the companion documents that participate in the AI-implementable goal (Spec-Schemas, Construction-Prompts, conformance/README). Surfaces gaps for the next round of design work. Per §Coverage policy the audit lags the live numbered set by design: a Spec earns a stand-alone Per-Spec table once its surface has stabilised enough to grade against all nine properties without thrash, and is graded indirectly through the cross-cutting sections until then. Specs 013–016 graduated to stand-alone tables in the 2026-07-04 pass (their surfaces stabilised — 016 declares first-public-beta complete, 013/014 pinned in conformance, 015 landed corpus-wide); Specs 001, 006, 007 remain graded indirectly.
 
 ## Scope
 
 This audit grades every artefact in `spec/` that contributes to the **pattern's contract** or to its **AI-implementability**. Specifically:
 
-- **Numbered Specs** (000, 002, 004, 005, 008, 009, 010, 011, 012) — the per-area normative specifications with stand-alone Per-Spec scoring tables below. Specs 001 (Registration), 006 (ReactiveSubstrate), 007 (Stories), 013 (Flows), 014 (HTTP Requests), 015 (Data Classification), and 016 (Resources) are graded indirectly through the cross-cutting goal sections below; they do not yet have stand-alone Per-Spec scoring tables.
+- **Numbered Specs** (000, 002, 004, 005, 008, 009, 010, 011, 012, 013, 014, 015, 016) — the per-area normative specifications with stand-alone Per-Spec scoring tables below. Specs 001 (Registration), 006 (ReactiveSubstrate), and 007 (Stories) are graded indirectly through the cross-cutting goal sections below; they do not yet have stand-alone Per-Spec scoring tables. (Specs 013–016 graduated to stand-alone tables in the 2026-07-04 pass per [§Coverage policy](#scope) — their surfaces stabilised enough to grade against all nine properties without thrash.)
 - **Spec-Schemas** — the spec's own runtime-shape catalogue.
 - **Construction-Prompts** — the AI-scaffolding catalogue.
 - **conformance/README** — the fixture format and capability-tagging convention.
 
-**Coverage policy.** Per-Spec scoring is intentionally selective: a Spec earns a stand-alone table once its surface has stabilised enough to grade against all nine properties without thrash. New Specs land in the cross-cutting sections first and graduate to a Per-Spec table when the next audit pass adds them. The audit therefore lags the live numbered set by design; absence from the Per-Spec list does not mean the Spec is out of scope, only that it is being graded indirectly until the next pass.
+**Coverage policy.** Per-Spec scoring is intentionally selective: a Spec earns a stand-alone table once its surface has stabilised enough to grade against all nine properties without thrash. New Specs land in the cross-cutting sections first and graduate to a Per-Spec table when the next audit pass adds them — the 2026-07-04 pass graduated Specs 013–016 once that condition fired (016 declares its first-public-beta surface complete; 013/014 are pinned in conformance; 015 landed corpus-wide). The audit therefore lags the live numbered set by design; absence from the Per-Spec list does not mean the Spec is out of scope, only that it is being graded indirectly until the next pass.
 
 Other companion documents (Principles, Conventions, Patterns, MIGRATION, Tool-Pair, Implementor-Checklist, README) are out of scope: they are rationale, conventions, or migration artefacts, not contracts an implementation conforms to.
 
@@ -87,16 +87,16 @@ _As-of 2026-07-04._
 | P4 Public query surfaces | ✓ | `registrations`, `frame-meta`, `frame-ids`, `app-db-value`, `snapshot-of`, `sub-topology` all in. |
 | P5 Schemas | ◐ | `:schema` in registration metadata is documented for handlers/subs/fx but the *frame's `:initial-events`* and *override map shape* aren't schema-described. |
 | P6 Deterministic execution | ✓ | Run-to-completion drain, depth limit, no-cross-frame-drain — all locked. |
-| P7 Machine-readable errors | ◐ | "Errors are maps with documented keys" stated as an aspiration but the actual error shapes aren't enumerated. Needs a §Error contract subsection. |
+| P7 Machine-readable errors | ✓ | Error shapes are enumerated in [009 §Error event catalogue](009-Instrumentation.md#error-event-catalogue) (the single normative catalogue) and the thrown-error `:rf.error/id` ex-data contract; 002's own error ids (`:rf.error/no-frame-context`, `:rf.error/unknown-preset`, drain-depth) carry catalogue rows (per **G-A**, RESOLVED). |
 | P8 Low hidden context | ◐ | **The biggest gap.** React-context-driven `dispatch`/`subscribe` injection is hidden context by definition. The pattern contract is explicit-frame addressing with React context positioned as a CLJS optimisation, but 002's body still leans on the React-context machinery as primary. A full rewrite of the View Ergonomics section would close this. |
 | Constrained model | ✓ | Frame-as-actor-boundary, event-as-FSM-step, drain-as-RtC. |
 | Data is code | ✓ | Events, effects, frames, registrations all data interpreted by the runtime. |
 
 **Gaps:**
-1. Override seam still presents function-valued as default; pattern-level id-valued should lead the §Per-frame and per-call overrides section. (Tracked as **G-C**.)
-2. Error contract is gestured at but not specified. (Tracked as **G-A**.)
+1. ~~Override seam still presents function-valued as default.~~ **Resolved** — the override seam is id-based and canonical-reference-matched, id-valued leading (see **G-C** below, RESOLVED).
+2. ~~Error contract is gestured at but not specified.~~ **Resolved** — [009 §Error event catalogue](009-Instrumentation.md#error-event-catalogue) is the single normative catalogue (see **G-A** below, RESOLVED).
 3. View ergonomics section's narrative still reads CLJS-context-primary; needs a top-down rewrite to lead with explicit-frame.
-4. View invocation has three forms — pick a canonical and document the others as alternatives. (Tracked as **G-E**.)
+4. View invocation has two forms — Var canonical, `(view :id)` for late-binding. (Tracked as **G-E**; the `h` macro draft was dropped, so two forms is the v1 surface.)
 
 **`:preset` audit row.** Frames declare a `:preset` (`:default`, `:test`, `:story`, `:ssr-server`); the runtime expands and `(frame-meta <id>)` records the applied preset. AI-amenable scaffolding should:
 
@@ -124,7 +124,7 @@ _As-of 2026-07-04._
 **Gaps:**
 1. Pick a canonical hiccup-invocation form and document the others as alternatives — three forms is a P1 hit. (Tracked as **G-E**.)
 2. ~~Make the plain-Reagent-fn-routes-to-default footgun loud.~~ **Resolved by EP-0002** (see **G-D** below): there is no ambient `:rf/default`, so a plain fn that can't read the provider's frame raises `:rf.error/no-frame-context` — a structured runtime error, not a warning.
-3. Consider whether Form-1/2/3 are all needed or whether Form-2's outer-fn-side-effects should be discouraged in favour of Form-1 + an explicit setup event. (Tracked as **G-F**.)
+3. ~~Consider whether Form-2's outer-fn-side-effects should be discouraged.~~ **Resolved** — Form-1 is canonical, Form-2 stays supported but Form-1 + an explicit setup event is preferred (see **G-F** below, RESOLVED).
 
 ### Spec 005 — State Machines
 
@@ -177,12 +177,12 @@ _As-of 2026-07-04._
 | P4 Public query surfaces | ✓ | The trace stream IS the query surface for runtime behaviour. |
 | P5 Schemas | ✓ | Trace event shape has stable required keys and a registered Malli schema — [Spec-Schemas §`:rf/trace-event`](Spec-Schemas.md) — one of the five load-bearing schemas carrying Owner/Status/Conformance metadata (see §SA-3 below). The schema is a spec-catalogue entry, **not** `reg-app-schema`: the trace stream is not app-db data (`reg-app-schema` validates app-db paths only), so it is not registered through the app-schema surface. |
 | P6 Deterministic execution | ✓ | Per-trace events for every drain step. |
-| P7 Machine-readable errors | ◐ | Errors emit trace events but the *error event shape* isn't formally defined alongside the others. |
+| P7 Machine-readable errors | ✓ | The error event shape is formally defined — [009 §The error event shape](009-Instrumentation.md#the-error-event-shape) + [§Error event catalogue](009-Instrumentation.md#error-event-catalogue) enumerate every category with its `:tags`; `:rf/error-event` + per-category `:tags` schemas registered (per **G-A**, RESOLVED). |
 | P8 Low hidden context | ✓ | All emit sites are visible in source. |
 
 **Gaps:**
 1. ~~Register a Malli schema for the trace event shape.~~ **Resolved** — [Spec-Schemas §`:rf/trace-event`](Spec-Schemas.md) registers it (one of the five load-bearing schemas per §SA-3).
-2. Define error trace events as a first-class subset. (Tracked as **G-A**.)
+2. ~~Define error trace events as a first-class subset.~~ **Resolved** — [009 §Error event catalogue](009-Instrumentation.md#error-event-catalogue) defines them as the single normative subset (per **G-A**, RESOLVED).
 
 ### Spec 010 — Schemas
 
@@ -196,10 +196,10 @@ _As-of 2026-07-04._
 | P4 Public query surfaces | ✓ | `(app-schemas)`, `(app-schema-at path)`. |
 | P5 Schemas | ✓ | (Self-referential, of course.) |
 | P6 Deterministic execution | ✓ | Validation runs at deterministic boundaries. |
-| P7 Machine-readable errors | ◐ | Validation errors include the failing path and value but the explicit error envelope isn't defined as a structured map alongside other errors. |
+| P7 Machine-readable errors | ✓ | The validation-error envelope is a structured shape alongside the other errors — `:rf.error/schema-validation-failure` carries the failing path, value, and explainer output per [009 §Error event catalogue](009-Instrumentation.md#error-event-catalogue) (per **G-A**, RESOLVED). |
 | P8 Low hidden context | ✓ | Every validation point is explicit. |
 
-**Gaps:** validation-error envelope as a structured shape (alongside other errors). (Tracked as **G-A**.)
+**Gaps:** none outstanding. The validation-error envelope is now a structured shape alongside the other errors (per **G-A**, RESOLVED).
 
 ### Spec 011 — SSR
 
@@ -218,6 +218,90 @@ _As-of 2026-07-04._
 
 **Gaps:** schema for the hydration payload format.
 
+### Spec 013 — Flows
+
+_As-of 2026-07-04._
+
+| Property | Score | Notes |
+|---|---|---|
+| P1 Regularity | ✓ | One `reg-flow` map shape; one flow-transform position (outermost `:after`); one dirty-check rule; one topsort per drain. `:rf.fx/reg-flow` / `:rf.fx/clear-flow` are the toggle pair — no second lifecycle surface. |
+| P2 Named things | ✓ | Flows, inputs, `:output-path`, `:derive` all id'd; the `:flow` registrar kind is reserved. Registration is frame-scoped, so `(frame-id, flow-id)` is the stable address. |
+| P3 Data before magic | ◐ | The flow map, `:inputs` paths, and `:output-path` are data; the dependency graph is statically derivable from them. `:derive` is a fn slot (per the data-DSL-vs-fn rule) — the references and structure are data, the compute step is a host fn. |
+| P4 Public query surfaces | ✓ | `(registrations :flow)` (which flows exist), `re-frame.flows/flow-meta-at` and `flows-snapshot` (the frame-scoped `{frame-id {flow-id flow-map}}` view), plus `(sub-cache-consumers-of-path …)` for output consumers. The single-store per-frame registry is the sole authoritative surface — a frame-blind `handler-meta :flow` deliberately returns nil. |
+| P5 Schemas | ✓ | `:rf/flow-meta` registers the `reg-flow` map in [Spec-Schemas](Spec-Schemas.md#rfflow-meta); the optional `:schema` key declares a Malli schema for the flow output, validated on every recompute in dev ([§Flow output validation](013-Flows.md#flow-output-validation)). |
+| P6 Deterministic execution | ✓ | Pure `:derive`; deterministic topological order each drain; single-pass evaluation (cycles rejected at registration); `=`-equality dirty-check; exactly one `app-db` install per event. |
+| P7 Machine-readable errors | ✓ | `:rf.error/flow-cycle` (with `:cycle` closing-repeat vector), `:rf.error/flow-path-overlap`, `:rf.error/flow-frame-not-live`, `:rf.error/flow-bad-marks`, and the run-level `:rf.error/flow-eval-exception` on the always-on error substrate; `:rf.flow/*` trace taxonomy per [009 §Flow trace events](009-Instrumentation.md#flow-trace-events). Registered `:tags` schemas (`FlowCycleTags`, `FlowEvalExceptionTags`). |
+| P8 Low hidden context | ✓ | Flow output lives at a known `app-db` path — visible to the inspector, downstream handlers, schemas, and SSR. Input partition is explicit (bare = app-db, `[:rf.db/runtime …]` = runtime-db). The one-event lag on `:rf.fx/reg-flow` is a structural consequence loudly signposted, not hidden. |
+| P9 Name over place | ◐ | `:inputs` is a **positional** vector matching `on-changes` and destructured by position in `:derive` — a place-based binding. A map-keyed alternative (name-over-place) is a documented, untracked post-v1 note (falsifiable trigger: N≥3 corpus/consumer flows at 4+ inputs bitten by positional fragility). Ships positional for v1 migration ergonomics. |
+| Constrained model | ✓ | One pure function + one output path + a static dependency graph; no parallel scheduler, no side effects, no per-flow `:fx` (all v1-alpha carry-overs dropped). |
+| Data is code | ✓ | A flow is a materialised `:after-event` derivation (per [Derivations](013-Flows.md#cross-references)) — the same whole-value function as the equivalent subscription, differing only in storage/evaluation/lifecycle policy. |
+
+**Gaps:**
+1. P3/P9 — `:derive` is a host fn (data-DSL-vs-fn rule) and `:inputs` is positional. The map-keyed `:inputs` reconsideration is an untracked post-v1 note with a falsifiable trigger ([013 §Open questions](013-Flows.md#open-questions)); not a v1 blocker.
+2. None blocking. The v1 design (vector `:inputs`, pending-`:db`-effect transform as the outermost `:after`, atomic-commit-on-throw, always-on error substrate) is settled in [§Resolved decisions](013-Flows.md#resolved-decisions).
+
+### Spec 014 — HTTP requests
+
+_As-of 2026-07-04._
+
+| Property | Score | Notes |
+|---|---|---|
+| P1 Regularity | ✓ | One fx-id (`:rf.http/managed`), one args map, **one** canonical reply envelope (the framework-wide uniform reply envelope; no second `{:kind :success/:failure}` dialect — the compat reshape is retired). Two reply-addressing forms (two explicit handlers / co-located `:rf/reply` branch) are the documented pair; per-verb call-site helpers (`rf.http/get` …) synthesise the same envelope. |
+| P2 Named things | ✓ | The fx, the failure categories (closed `:rf.http/*` set), the `:work/id` `[:rf.work/http …]` head, `:request-id`, and the reply-target spelling `:rf/reply-to` are all stable ids. |
+| P3 Data before magic | ✓ | Request envelope, `:retry` policy, `:decode` (schema / keyword / fn), reply envelope, and failure maps are all data; `:accept` / custom `:decode` are the fn slots. |
+| P4 Public query surfaces | ✓ | `(handler-meta :event …)` surfaces `:rf.http/decode-schemas` reflection; the in-flight request registry and `:rf.http.interceptor/*` traces are enumerable; every completion rides the trace stream (`:rf.http/replied`). |
+| P5 Schemas | ✓ | `:rf/http-managed-meta` (the `reg-fx` metadata incl. `:carriers`), `:rf/reply-map` / `:rf/reply-target` (the uniform envelope, EP-0011), and the `:decode` schema surface are registered in [Spec-Schemas](Spec-Schemas.md#rfhttp-managed-meta); the args map, failure categories, and reply shape are schema-described. |
+| P6 Deterministic execution | ◐ | Classification order (status-before-decode), retry/backoff, abort precedence, and the once-only finalisation CAS are deterministic and conformance-pinned. HTTP is inherently a side-effecting external boundary (transport, wall-clock timeouts, host CORS) — the *managed* surface is deterministic given a fixed transport; the transport itself is not. Stub-mode (`with-managed-request-stubs`) makes tests deterministic. |
+| P7 Machine-readable errors | ✓ | Eight-category closed `:rf.http/*` failure taxonomy, each failure map self-identifying (request echo + `:request-id` + `:attempt` + `:work/id`); dispatch-time guards (`:rf.error/http-bad-request`, `:rf.error/http-bad-retry-on`, `:rf.error/http-bad-reply-target`) per [009 §Error event catalogue](009-Instrumentation.md#error-event-catalogue). |
+| P8 Low hidden context | ✓ | The args map is the whole contract at the call site; per-frame `reg-http-interceptor` is the one seam for cross-cutting request/response transforms (auth headers, base-URL) and is itself id'd and trace-visible. CLJS-only keys emit a `:rf.http/cljs-only-key-ignored-on-jvm` warning rather than silently diverging. |
+| P9 Name over place | ✓ | The reply envelope is a named map (`:status` / `:value` / `:error` / `:work/id` / `:correlation`); the request envelope and failure maps are map-keyed. No positional payloads. |
+| Constrained model | ✓ | Effect-as-data via the args map; framework-owned lifecycle (retry / abort / teardown); a managed external effect satisfying the nine [Managed-Effects](Managed-Effects.md) properties. |
+| Data is code | ✓ | The request, retry policy, and reply are data the runtime interprets; `:decode` as a Malli schema is the canonical data-driven form. |
+
+**Gaps:**
+1. P6 — the managed surface is deterministic; the underlying transport is not (inherent to HTTP). Stub-mode covers the test path.
+2. None blocking. The v1 contract (closed failure set, one uniform reply envelope, CORS heuristic emission, frame-aware reply dispatch, `:sensitive?` privacy) is settled in [§Resolved decisions](014-HTTPRequests.md#resolved-decisions). Streaming / pluggable backoff are post-v1 open questions.
+
+### Spec 015 — Data Classification
+
+_As-of 2026-07-04._
+
+| Property | Score | Notes |
+|---|---|---|
+| P1 Regularity | ✓ | **One axis vocabulary** (`:sensitive` / `:large`) over `:rf/path` vectors, in three lowering shapes (commit-plane effects / registration metadata / subsystem projection-relative declarations). One projection primitive (`project-egress` over `elide-wire-value`); one clear-mirrors-set rule per axis. |
+| P2 Named things | ✓ | The four commit-plane effects, the `:rf.egress/*` profile enum, the `:rf.observe/*` record kinds, the `:rf.size/*` walker flags, and the sentinels (`:rf/redacted`, `:rf.size/large-elided`) are all reserved, named values. |
+| P3 Data before magic | ✓ | Classification is declared data (effect payloads / registration metadata / subsystem declarations) recorded in the per-frame elision registry at `[:rf.runtime/elision …]`; projection is a pure record-level transform. No imperative `add-marks` / `set-marks` API. |
+| P4 Public query surfaces | ✓ | The elision registry is runtime-db data (reverts with the frame); `project-egress` and the `:rf.egress/*` profile enum are the enumerable egress surface; every profile is exercised by a real consumer surface. |
+| P5 Schemas | ✓ | `:rf/elision-marker` (the `:rf.size/large-elided` shape) and `:rf/project-egress-opts` are registered in [Spec-Schemas](Spec-Schemas.md#rfelision-marker); the `:sensitive` / `:large` axis is `:rf/path` vectors (the shared path algebra, EP-0012). |
+| P6 Deterministic execution | ✓ | Projection is pure and value-independent; **sensitive wins over large** is a fixed precedence; fail-closed on unknown frame / profile is deterministic; classification-as-no-op over absent data is well-defined. |
+| P7 Machine-readable errors | ✓ | `:rf.error/unknown-egress-profile` (fail-closed on a bad profile), `:rf.error/bad-frame-classification` (a rejected `reg-frame` `:sensitive`/`:large` block), `:rf.error/flow-bad-marks` / malformed-path rejection at registration — structured, not stringy. |
+| P8 Low hidden context | ✓ | Classification lives at the fact's **definition site** (the writing handler / the registration / the subsystem definition) — visible where the data's meaning is authored. **No propagation, no taint**: a classification never silently flows input→output; a derived secret is a new path the author classifies directly. On-box reveal is a per-(tool, frame) trace-visible operator act, not a hidden global toggle. |
+| P9 Name over place | ✓ | Classifications are `:rf/path` vectors (named-key paths into shapes); the egress choice is a named profile (`:rf.egress/off-box-tool` …), not a remembered boolean combination. |
+| Constrained model | ✓ | A declarative leak-prevention overlay on observability — record the path, redact at egress. No runtime cost on the happy path; real values flow through the app unchanged. |
+| Data is code | ✓ | Classifications and egress profiles are data the projector interprets at the boundary; the model ships no host-code hooks. |
+
+**Gaps:** none significant. Posture is explicitly **hygiene, not security** ([§The north star](015-Data-Classification.md#the-north-star--a-helper-not-a-contract)); fail-open by design (an unclassified path ships raw). The removed EP-0015 surfaces (frame annotation, schema-prop durable classification, imperative marks, propagation) are catalogued in [§What is removed](015-Data-Classification.md#what-is-removed-and-what-is-kept).
+
+### Spec 016 — Resources
+
+_As-of 2026-07-04._
+
+| Property | Score | Notes |
+|---|---|---|
+| P1 Regularity | ✓ | One `reg-resource` shape; one scoped resource key `[cache-scope resource-id canonical-params]`; one built-in transport (managed HTTP); one lifecycle transition fn; one canonical reply map (the uniform reply envelope). `reg-mutation` mirrors the `reg-resource` registration gate. |
+| P2 Named things | ✓ | Resources, mutations, scope policies, the work ledger, and the `:rf.resource/*` / `:rf.scope/*` / `:rf.work/*` surfaces are all id'd. **One name per fact** (EP-0007): `:resource/key` is the single spelling of the scoped key on data shapes, distinct from `:resource/id`. |
+| P3 Data before magic | ✓ | The scoped resource key, cache entries, the work ledger, scope policies, and route `:resources` plans are all serializable EDN data an AI/devtool enumerates; host values (functions, promises, AbortControllers) are rejected from params/scope. |
+| P4 Public query surfaces | ✓ | Views read resources through passive subscriptions; the cache lives in the known runtime partition `:rf.runtime/resources`; Xray and SSR enumerate the same scoped-key shapes; the `:rf.runtime/resources` / `:rf.runtime/work-ledger` runtime subsystems each answer the five Runtime-Subsystems clauses (subtree / write authority / read API / projection / teardown). |
+| P5 Schemas | ✓ | `:rf/scoped-resource-key`, `:rf/resource-entry`, `:rf/resource-work-record`, `:rf/scope-policy`, `:rf/resource-scope-resolver`, `:rf/invalidation-descriptor`, and `:rf/infinite-resource-args` are all registered in [Spec-Schemas](Spec-Schemas.md#rfscoped-resource-key-rfresource-entry-rfresource-work-record-resources-spec-016); params conform to `:params-schema`. |
+| P6 Deterministic execution | ✓ | Canonicalization is a pure function over EDN (key order irrelevant to identity); the mutation attempt order and optimistic-rollback disposal are normative and keyed on recorded facts (work-id + generation verdict + `:revision`) — **no wall-clock race**; the generation allocator is monotonic and host-side, never rewinding across restore. |
+| P7 Machine-readable errors | ✓ | Fail-closed registration and use-time errors: `:rf.error/resource-missing-scope-policy`, `:rf.error/resource-bad-spec`, `:rf.error/resource-scope-required-from-caller`, `:rf.error/resource-sub-unresolved-scope`, `:rf.error/resource-invalidate-scope-required`, `:rf.error/infinite-missing-next-page-param` — structured, each pointing at its fix. |
+| P8 Low hidden context | ✓ | **No silent default scope** — every resource declares an explicit, auditable scope policy at registration; a user-scoped read can never be silently global. Sub-side scope resolution fails closed (`:rf.error/resource-sub-unresolved-scope`) rather than reading `:idle` or global — the read-side counterpart of the write-side gate. Every resource carries its explicit frame (EP-0002 carried invariant). |
+| P9 Name over place | ✓ | The scoped key is `[scope resource-id params]` with map-form scope/params (canonicalized so key order is irrelevant); the resource entry, work record, and reply are map-keyed. The storage tuple vs map-form authoring input is an input-vs-storage distinction (EP-0007 rule 3), not two spellings. |
+| Constrained model | ✓ | A runtime-managed read model over a frame work ledger with a compact lifecycle FSM; views are passive, events are causal, server state lives in the framework-owned runtime partition — the re-frame2 answer to TanStack Query / RTK Query / SWR re-expressed in the model. |
+| Data is code | ✓ | Resource registrations, scope policies, invalidation descriptors, and route `:resources` plans are data the resource runtime interprets. |
+
+**Gaps:** none blocking for the first-public-beta surface ([§Implementation status](016-Resources.md#implementation-status) — read MVP, mutations, focus/reconnect, optimistic rollback, polling all complete). Post-v1 open questions: the work-ledger multi-writer authority for out-of-artefact writers (`:post-v1 tracked` for v1) and warm-mode route-plan prefetch (`:post-v1 tracked`). GraphQL is a deferred later slice, explicitly out of this contract.
+
 ## Cross-cutting goal: AI-implementable from the spec alone
 
 [000-Vision §AI-implementable from the spec alone](000-Vision.md#ai-implementable-from-the-spec-alone) (Goal 2) is the meta-property that grades the spec corpus's *completeness* — can an AI build v1 from `/spec/` alone? Audit dimension: **spec self-containedness** — every spec must be readable without consulting re-frame v1 source, and every shape on the wire must be schema'd.
@@ -228,17 +312,17 @@ _As-of 2026-07-04._
 |---|---|---|
 | 000-Vision | ✓ | Names the goal; explains rationale, what-this-implies, connection-to-other-goals, and failure mode. Capability matrix entries (FSM-richness + actor-model rows) added to the host-profile matrix. |
 | 001-Registration | ◐ | Metadata-map shape is well-specced; the *exact* set of metadata keys per `reg-*` kind needs a single canonical table. |
-| 002-Frames | ◐ | Drain semantics, envelope shape, view ergonomics all specced; error contract is gestured at but not enumerated (G-A in §Cross-cutting gaps). |
+| 002-Frames | ✓ | Drain semantics, envelope shape, view ergonomics all specced; the error contract is now enumerated in [009 §Error event catalogue](009-Instrumentation.md#error-event-catalogue) (G-A RESOLVED). |
 | 005-StateMachines | ◐ | Foundation specced in detail; capability matrix in place; hierarchical / eventless / delayed / declarative-`:spawn` capabilities are claimed but drain-rule extensions for compound entry/exit are still being elaborated. |
 | 008-Testing | ✓ | Three test levels, fixture lifecycle, framework adapters all specced. |
-| 009-Instrumentation | ◐ | Trace event shape stable; error event shape not formally enumerated. Closes alongside G-A. |
+| 009-Instrumentation | ✓ | Trace event shape stable; error event shape formally enumerated in [§Error event catalogue](009-Instrumentation.md#error-event-catalogue) (G-A RESOLVED). |
 | 010-Schemas | ✓ | Self-referential — schemas are specced via examples in re-frame2's own conventions. |
 | 011-SSR | ◐ | Hydration payload schema missing (existing gap). |
 | 012-Routing | ✓ | URL ↔ params grammar, route metadata shape, fx ids all specced. |
-| Spec-Schemas | ◐ | Most shapes covered; declarative-`:spawn` schema additions remain to be written; hydration payload schema and trace-event schema (G-A) are tracked elsewhere. |
+| Spec-Schemas | ◐ | Most shapes covered; declarative-`:spawn` schema additions remain to be written. The trace-event, error-event (G-A RESOLVED), and hydration payload schemas are now registered; the remaining gap is the residual declarative-`:spawn` additions. |
 | conformance/README | ✓ | Cross-references the goal; capability-tagging convention added to fixture metadata. |
 
-**Gaps:** G-A (error envelope), G-B (CP depth), and schema-on-the-spec's-own-shapes coverage.
+**Gaps:** ~~G-A (error envelope)~~ RESOLVED; ~~G-B (CP depth)~~ RESOLVED. Remaining: schema-on-the-spec's-own-shapes coverage (the declarative-`:spawn` additions).
 
 ## Cross-cutting goal: Capability-conformance clarity
 
@@ -279,17 +363,17 @@ _As-of 2026-07-04._
 
 ## Cross-cutting gaps (across multiple Specs)
 
-### G-A. Error envelope is gestured at but not standardised
+### G-A. Error envelope standardised — RESOLVED
 
-Errors are mentioned in 002, 009, 010 but no single doc defines the canonical structured-error shape. Proposal: a small section in 009 enumerating error event shapes (validation failure, handler exception, hydration mismatch, drain depth exceeded, override fallthrough), each with a registered Malli schema and a unique `:op-type`. This closes P7 in three Specs simultaneously.
+Errors used to be gestured at in 002, 009, 010 with no single doc defining the canonical structured-error shape. **[009 §Error event catalogue](009-Instrumentation.md#error-event-catalogue) closes this**: it is the single normative catalogue of every error / warning / advisory event, enumerating each category (validation failure `:rf.error/schema-validation-failure`, handler exception `:rf.error/handler-exception`, hydration mismatch, drain depth exceeded `:rf.error/drain-depth-exceeded`, override fallthrough, …) with its `:op-type`, channel, default `:recovery`, and `:tags` payload. The canonical structured shapes are defined at [009 §The error event shape](009-Instrumentation.md#the-error-event-shape) (the trace shape) and [009 §The thrown-error shape — the `:rf.error/id` ex-data contract](009-Instrumentation.md#the-thrown-error-shape--the-rferrorid-ex-data-contract) (the thrown contract; `:rf.error/id` is the single normative discriminator). Registered Malli schemas: `:rf/error-event` plus per-category `:tags` schemas in [Spec-Schemas](Spec-Schemas.md#rferror-event). P7 closed in three Specs simultaneously, as the proposal intended.
 
-### G-B. Construction prompts not yet wired into pre-flight tooling
+### G-B. Construction prompts wired into pre-flight tooling — RESOLVED
 
-Construction-Prompts.md describes how an AI uses the prompts but doesn't specify what API calls satisfy the "verify the id is unused" / "consult registered schemas" pre-flight checks. Each prompt should reference the exact registry-query API (e.g., `(rf/registrations :event)`). CP-1 / CP-4 / CP-6 do this; CP-2/3/5/7/8/9 still need filling in.
+Construction-Prompts.md used to describe how an AI uses the prompts without specifying the API calls that satisfy the "verify the id is unused" / "consult registered schemas" pre-flight checks. **[Construction-Prompts §Shared pre-flight (applies to every CP)](Construction-Prompts.md) closes this**: a single shared pre-flight preamble gives *every* CP the exact registry-query API — `(rf/registrations :event)` / `:sub` / `:fx` / `:view` / `:route` for the id-uniqueness check, and `(rf/app-schemas)` / `(rf/app-schema-at <path>)` for the schema-consult check. Each CP now carries only a "Pre-flight delta" over the shared preamble, so the earlier per-CP gap (CP-2/3/5/7/8/9 missing the API) is closed structurally by hoisting it into the shared block.
 
-### G-C. The override seam is still mixed function/id
+### G-C. The override seam is id-based and canonical-reference-matched — RESOLVED
 
-Pattern contract is id-based (per recent edits), but the CLJS reference accepts function values. The two forms should be clearly separated — id-valued for portable testing, function-valued for one-off CLJS lambdas — and the documentation should lead with id-valued in the pattern's primary examples.
+The pattern contract was id-based while the CLJS reference also accepted function values, with no clear separation. **[008-Testing §Disabling a logging interceptor in tests](008-Testing.md#disabling-a-logging-interceptor-in-tests) closes this**: `:interceptor-overrides` is **reference-based** (a bare keyword matches the registered interceptor; a parameterized `[id arg]` 2-vector matches the full reference), matched by the canonical (CEDN-1) reference — the id-valued (portable) form leads the primary examples, and function values appear only as the one-off `:fx-overrides` HTTP-stub lambdas. [Conventions §Reserved fx-id override tiering](Conventions.md#reserved-fx-id-override-tiering) adds the complementary tiering (reserved fx tiered OVERRIDABLE vs REJECT by the state-installation criterion, with a dedicated `Override tier` column in the reserved-fx table).
 
 ### G-D. The plain-Reagent-fn footgun — RESOLVED (EP-0002)
 
@@ -299,13 +383,13 @@ Plain Reagent fns rendered inside a `frame-provider` used to silently route to `
 
 The Var reference (`[counter "Hello"]`) is the canonical call-site form: `reg-view` defs the symbol, hiccup picks it up directly. `(view :id)` is the documented escape hatch for late-binding by id (cross-module reference, runtime-computed ids, hot-reload-sensitive call sites). The earlier `h` macro draft has been dropped; two forms is the v1 surface.
 
-### G-F. Form-1 / Form-2 / Form-3 component shapes
+### G-F. Form-1 / Form-2 / Form-3 component shapes — RESOLVED
 
-Three component shapes inherit from Reagent. Form-2's outer-fn-side-effects pattern violates P8 (the side-effect is invisible from the call site). Consider deprecating Form-2 in favour of Form-1 + an explicit setup event.
+Three component shapes inherit from Reagent, and Form-2's outer-fn-side-effects pattern violates P8 (the mount-time side-effect is invisible from the call site). **[004-Views §Form-1, Form-2, Form-3 components](004-Views.md#form-1-form-2-form-3-components) closes this** with a "supported, prefer Form-1" resolution rather than deprecation: Form-1 is canonical; Form-2 stays **supported** for Reagent compatibility but is used only when the setup work genuinely depends on per-mount props, with the [Form-2 (closure — supported, prefer Form-1 + explicit setup event)](004-Views.md#form-2-closure--supported-prefer-form-1--explicit-setup-event) subsection steering stable setup to Form-1 + an explicit setup event / the frame's `:initial-events`. The P8 concern is addressed by preferring the visible form, keeping Form-2 available where it earns its keep.
 
 ## Headline finding
 
-The Specs score uniformly well on P1–P3 (regularity, naming, data-orientation) and P6 (determinism). The recurring weak points are P7 (machine-readable errors), P8 (low hidden context), and P5 (schemas applied to the spec's own shapes). The cross-cutting gaps section above enumerates the specific findings.
+The Specs score uniformly well on P1–P3 (regularity, naming, data-orientation) and P6 (determinism). The historically-weak P7 (machine-readable errors) and P8 (low hidden context) closed materially in the 2026-07-04 pass: **G-A** (the [009 §Error event catalogue](009-Instrumentation.md#error-event-catalogue) standardises the structured-error shape across 002/009/010), **G-D** (the plain-Reagent-fn footgun is now a loud `:rf.error/no-frame-context`), and **G-F** (Form-1 preferred over Form-2's hidden mount-time side-effect) all landed. All six cross-cutting gaps (G-A through G-F) are now RESOLVED. The remaining weak point is P5 (schemas applied to the spec's own shapes) — the residual declarative-`:spawn` schema additions and the SA-3 sweep tracked below. The cross-cutting gaps section above enumerates the specific findings.
 
 ## SA-3 schema-coverage report
 
@@ -313,16 +397,18 @@ The Specs score uniformly well on P1–P3 (regularity, naming, data-orientation)
 
 _As-of 2026-07-04._
 
-**Current state.** The shape catalogue carries 37 schema sections; the per-section Owner / Status / Conformance metadata that makes the projection auditable was demonstrated on 5 load-bearing schemas (`:rf/dispatch-envelope`, `:rf/effect-map`, `:rf/trace-event`, `:rf/epoch-record`, `:rf/hydration-payload`). The full sweep across the remaining ~32 schema sections is still pending.
+**Current state.** The shape catalogue carries **52 schema sections** (`###` headings), of which **50 are schema-bearing** (the other two are prose sub-headings). The per-section Owner / Status projection metadata that makes the projection auditable — required per [Spec-Schemas §Traceability metadata](Spec-Schemas.md#traceability-metadata) — is now present on **all 50 schema-bearing sections** (the full sweep has landed, superseding the earlier five-schema demonstration on `:rf/dispatch-envelope`, `:rf/effect-map`, `:rf/trace-event`, `:rf/epoch-record`, `:rf/hydration-payload`). Of those, **9 also carry the optional Conformance pointer** (present when a fixture / per-artefact test asserts the schema directly; the SA-3 header spec marks Conformance "when fixture/test exists", not universally required).
 
 **Audit cadence.** This report is regenerated per AI-Audit run. Per-section completeness gates on SA-3:
 
 | Section count | SA-3 status |
 |---|---|
-| 5 / 37 | Demonstration (Owner + Status + Conformance present) |
-| 32 / 37 | Pending sweep (Owner / Status / Conformance still to add) |
+| 50 / 50 | Owner + Status present (the required projection metadata — full sweep landed) |
+| 9 / 50 | Conformance pointer also present (optional — where a fixture/test asserts the schema directly) |
 
-**SA-3 violation rule.** A spec example or wire payload that does NOT map to either a schema entry or an explicit host-type exemption is an SA-3 violation. The fix is to add the missing entry to Spec-Schemas.md (not to add an exemption). Per-cycle the audit names any newly-surfaced violations under this section.
+The Owner + Status sweep obligation from the prior pass is **discharged**: every schema-bearing section now names its canonical owning spec and its API-status tier, so a reader maps any schema row to its owner and status without consulting the source docs. The residual work is additive Conformance pointers as fixture coverage grows, not a pending Owner/Status sweep.
+
+**SA-3 violation rule.** A spec example or wire payload that does NOT map to either a schema entry or an explicit host-type exemption is an SA-3 violation. The fix is to add the missing entry to Spec-Schemas.md (not to add an exemption). Per-cycle the audit names any newly-surfaced violations under this section. **No new violations surfaced in the 2026-07-04 pass** — the 013/014/015/016 shapes referenced by the newly-graduated Per-Spec tables (`:rf/flow-meta`, `:rf/http-managed-meta`, `:rf/reply-map`, `:rf/scoped-resource-key` / `:rf/resource-entry` / `:rf/resource-work-record` / `:rf/scope-policy` / `:rf/infinite-resource-args`, `:rf/elision-marker` / `:rf/project-egress-opts`) all already carry catalogue entries.
 
 **Scope clarification.** This report covers shapes that flow *between* implementation surfaces (wire payloads, returned shapes, registration metadata). It does NOT cover host-primitive shapes (a CLJS map, a TypeScript object type) — those are local to the host's type system and need no cross-host schema. Per [§Scope](#scope), per-Spec scoring is selective; the SA-3 report is corpus-wide and is the SA-3 enforcement surface.
 

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -61,7 +61,7 @@ This catalogue is a **projection** of shapes that originate in the owning per-Sp
 
 **SA-3 audit pointer.** [AI-Audit.md §SA-3 schema-coverage report](AI-Audit.md) carries the corpus-wide cross-reference table: every shape referenced in the numbered specs (as an example block, a wire payload, a returned-shape) MUST map to either a `:rf/<id>` schema entry in this catalogue OR an explicit host-type exemption (the per-host primitives that don't need cross-host schemas). The report is generated rather than hand-maintained per SA-3's enforcement obligation.
 
-**Migration scope.** This rule applies to five load-bearing schemas (`:rf/dispatch-envelope`, `:rf/effect-map`, `:rf/trace-event`, `:rf/epoch-record`, `:rf/hydration-payload`), with the full sweep across the remaining ~32 schema sections tracked separately.
+**Migration scope.** The Owner + Status sweep is **complete** — every schema-bearing `###` section now carries the required `> **Owner:**` and `> **Status:**` headers (the earlier five-schema demonstration — `:rf/dispatch-envelope`, `:rf/effect-map`, `:rf/trace-event`, `:rf/epoch-record`, `:rf/hydration-payload` — has been extended corpus-wide). The optional `> **Conformance:**` pointer is present where a fixture / per-artefact test asserts the schema directly; see [AI-Audit.md §SA-3 schema-coverage report](AI-Audit.md) for the current per-section counts.
 
 ## Schema layers
 
@@ -289,6 +289,7 @@ A descriptor matching none of the four shapes (a non-map, an `:id`-only map, a `
 
 > **Layer:** Public (input forms)
 > **Owner:** [002-Frames §Standard `:rf.interceptor/path`](002-Frames.md#standard-rfinterceptorpath)
+> **Status:** v1-required
 
 The argument carried by the one standard framework interceptor reference, `[:rf.interceptor/path <path-vector>]` (the canonical `:factory` consumer, [EP-0022](../docs/EP/EP-0022-registered-interceptors.md), [002 §Standard `:rf.interceptor/path`](002-Frames.md#standard-rfinterceptorpath)). The single factory arg is an [`:rf/path`](#rfpath-rfpath-template-the-path-algebra-ep-0012) (EP-0012) — the app-db sub-slice the handler is focused onto.
 
@@ -877,6 +878,8 @@ The canonical category vocabulary is fixed-and-additive (Spec-ulation): existing
 ### Per-category `:tags` schemas
 
 > **Layer:** Runtime
+> **Owner:** [009-Instrumentation §Error event catalogue](009-Instrumentation.md#error-event-catalogue)
+> **Status:** v1-required
 
 Each error / warning category enumerated in [009 §Error event catalogue](009-Instrumentation.md#error-event-catalogue) has a registered Malli schema describing its `:tags` payload, so consumers can validate without ad-hoc parsing. The schemas below are the canonical CLJS-reference shapes; ports translate them mechanically into the host's schema language (per [§Scope](#scope)).
 
@@ -3497,6 +3500,8 @@ The map is **closed** — production must not silently leak unknown keys. The `:
 ### Standard fx args schemas
 
 > **Layer:** Runtime
+> **Owner:** [002-Frames §`:fx` ordering and atomicity guarantees](002-Frames.md#fx-ordering-and-atomicity-guarantees)
+> **Status:** v1-required
 
 The `:rf/effect-map`'s `:fx` is `[[fx-id args] ...]`. Each *standard* `fx-id` (the ones the runtime / standard libraries register) has a known args shape; this section registers them so the conformance corpus and AI scaffolding can validate fx-args at the call site. User-registered fx attach their own args schema via the `:schema` metadata on `reg-fx` (per [010 §Where schemas attach](010-Schemas.md#where-schemas-attach)).
 


### PR DESCRIPTION
AI-Audit follow-on to the CLOSED **rf2-sry8qk** (which fixed five false rows + installed the freshness watermark). Deferred-decision audit **F14** (clear-fix; re-verified). Three parts:

## Table graduation

The AI-Audit §Coverage-policy graduation condition — *"a Spec earns a stand-alone table once its surface has stabilised enough to grade against all nine properties without thrash"* — has **fired** for four Specs that had no table:

- **016** declares its first-public-beta surface complete (read MVP, mutations, focus/reconnect, optimistic rollback, polling).
- **013** / **014** are pinned in conformance.
- **015** landed corpus-wide.

Authored their stand-alone **Per-Spec scoring tables** (P1–P9 + the two cross-cutting rows + the `_As-of 2026-07-04._` freshness watermark), each grounded against the current corpus. Updated the top-blurb / §Scope / §Coverage-policy prose that asserted 013–016 had no tables; **001 / 006 / 007** remain graded indirectly.

## G-rows flipped to RESOLVED

Four resolved-stale cross-cutting gaps flipped to RESOLVED (matching the existing **G-D** format), each **verified against the current corpus** (subject landed) before flipping:

| G-row | Resolution | Load-bearing prose |
|---|---|---|
| **G-A** | Error envelope standardised — the single normative catalogue enumerates every error shape (+ `:rf/error-event` + per-category `:tags` schemas). Closes P7 in 002/009/010. | 009 §Error event catalogue; §The thrown-error shape |
| **G-B** | Construction-Prompts §Shared pre-flight gives *every* CP the registry-query API (`registrations` / `app-schemas`); per-CP is now delta-only. | Construction-Prompts §Shared pre-flight |
| **G-C** | Override seam is id-based + canonical-reference (CEDN-1) matched, id-valued leading; reserved-fx override tiering (OVERRIDABLE vs REJECT). | 008-Testing §Disabling a logging interceptor; Conventions §Reserved fx-id override tiering |
| **G-F** | Form-1 canonical; Form-2 **supported but prefer Form-1** + explicit setup event (not deprecation). | 004-Views §Form-2 (closure — supported, prefer Form-1) |

Also updated the 002/004/009/010 per-Spec gap lists, the AI-implementable goal-table rows, and the Headline finding to match (SA-9 same-PR co-edit invariant). All six cross-cutting gaps (G-A through G-F) are now RESOLVED.

## SA-3 regen

The report claimed **37 sections / 5 stamped / 32 pending**; the live `Spec-Schemas.md` has **52 `###` sections (50 schema-bearing)** and the Owner+Status projection sweep has **landed on all 50** (9 also carry the optional Conformance pointer). Regenerated the SA-3 report to the real state, stamped the 3 remaining Layer-only grouping sections (`:rf.interceptor/path`, Per-category `:tags`, Standard fx args) with Owner+Status, and updated the `Spec-Schemas §Traceability` migration-scope line (sweep complete, not five-schema demonstration).

## Quality gates

- `python scripts/check_doc_slugs.py --repo-root .` → **exit 0** (all new cross-links + anchors resolve, including the 013/014/015/016/009/008/004/Conventions/Construction-Prompts/Spec-Schemas anchors).
- `mkdocs build --strict` → **exit 0**, no WARNING/ERROR, after staging `spec/` + `migration/` into `docs/` per the `.github/workflows/docs.yml` CI step (`rm -rf docs/spec && cp -r spec docs/spec`). Staged copies are gitignored and were removed after the build.

Surface: `spec/AI-Audit.md` + `spec/Spec-Schemas.md` only. Predecessor: rf2-sry8qk. Ledger F14 (local-only).
