### PR TITLE
docs(spec): 011 host-seam + SSR-slot trigger-records (rf2-uf56ad, rf2-axfo4s)

### DIFF
--- a/spec/011-SSR.md
+++ b/spec/011-SSR.md
@@ -394,12 +394,30 @@ Other-language ports may pick a different hash *as long as the canonical-EDN tra
                 :client-hash "def456"
                 :frame       :app/main             ;; the app's carried frame-id (placeholder; the runtime stamps the active frame)
                 :failing-id  :rf/hydrate           ;; the only value the bundled v1 runtime emits (see §Mismatch detection — head)
-                :first-diff-path [...]}            ;; optional: path into the render tree where divergence first occurs
+                :first-diff-path [...]}            ;; optional, host-supplied: path into the render tree where divergence first occurs (see §The `:first-diff-path` tag below)
  :start        (...)
  :end          (...)}
 ```
 
 The `:failing-id` tag is a **generic host-supplied attribution seam**, not a runtime-toggled enum. The mismatch-detection entry point (`verify-hydration!`) accepts a host-supplied `:failing-id` override and, when none is supplied, defaults it to `:rf/hydrate`. **The bundled v1 runtime never supplies an override**, so under one `:operation` it emits exactly one shape: `:failing-id :rf/hydrate`. A host that runs its own head-only diffing MAY attribute a mismatch with any value of its choosing — e.g. `:rf.ssr/head-mismatch` (per [§Mismatch detection — head](#mismatch-detection--head)) — and that value flows through to the trace; the v1 runtime itself does not. Consumers branch on `:failing-id` rather than maintaining a parallel category keyword per case, and the seam keeps that branch open for hosts (and the post-v1 head-only-hash channel) without a runtime change.
+
+#### The `:first-diff-path` tag
+
+The `:first-diff-path` tag is the **same shape of host-supplied seam** as `:failing-id` above — a value the host produces and the runtime carries verbatim, not a value the bundled runtime computes.
+
+**Producer — the host, not the runtime.** `verify-hydration!` accepts a host-supplied `:first-diff-path` opt and, when supplied, `assoc`es it verbatim onto the emitted trace's `:tags`; **the bundled v1 runtime never supplies one**. This is deliberate: the runtime compares two `render-tree` hashes, and a hash proves *that* the trees diverged — it does not locate *which node* diverged. Locating the divergent node is a full tree-diff, which the hash channel does not do and v1 does not ship. A host (or a tool) that runs its own structural tree-diff between the server and client render-trees MAY compute the divergence path and pass it through the seam; it then rides the trace for consumers. (Same producer contract as the [`docs/ssr/concepts.md` debugging surface](../docs/ssr/concepts.md), which names the empty-slot default.)
+
+**Absence — the default.** Unlike `:failing-id` (which defaults to `:rf/hydrate`), `:first-diff-path` has **no default**: when the host supplies none, the key is simply **absent** from the trace `:tags` (the `assoc` is guarded on the opt being present). An absent `:first-diff-path` therefore means "no host diff ran," never "divergence at the root" — consumers MUST treat the key as optional and branch on its presence, not read an absent value as a path.
+
+**Segment vocabulary.** A `:first-diff-path` is a vector of segments naming the descent from the render-tree root to the first divergent node, in the same spirit as a `get-in` path over the hiccup tree. Each segment is one of three kinds:
+
+| Segment kind | Shape | Meaning |
+|---|---|---|
+| **index** | integer (`0`, `1`, …) | the ordinal position of a child within its parent's child sequence — descend into the Nth child. |
+| **tag** | element-head keyword (`:head`, `:title`, `:div`) | the hiccup head (DOM tag or fragment/registered-view head) of the node being descended into — a by-tag step rather than a by-ordinal step. |
+| **key** | map/attribute keyword (`:children`, `:class`) | a key into a node's attribute or structured-children map — descend into the value at that key. |
+
+A path mixes the three freely as the descent alternates between ordered child sequences (index), tag-addressed nodes (tag), and structured sub-maps (key) — e.g. `[:head :title]` (two tag steps) or `[:body 0 :children 0]` (tag → index → key → index). The runtime does not validate the segment shape — the seam is host-owned; the host's diff and the host's consumer agree on the path convention, and the runtime only carries it. Other-language ports mirror the **seam** (host-supplied, absent-by-default, carried verbatim), not any one path spelling.
 
 Recovery is implementation-policy: the CLJS reference defaults to **warn-and-replace** — log the trace event, then re-render client-side, replacing the server's HTML. Strict mode (the frame's `:ssr {:on-mismatch :hard-error}` config — see [§Mismatch recovery and configuration](#mismatch-recovery-and-configuration)) escalates to a hard error for dev/CI builds that want to fail fast on misalignment.
 
@@ -1100,9 +1118,20 @@ Verification: the load test at `implementation/ssr/test/re_frame/ssr_teardown_lo
 
 ## Open questions
 
-> **SA-4 classification.** Per [SPEC-AUTHORING §SA-4](SPEC-AUTHORING.md): no items outstanding at the 011-SSR tier. The streaming surface formerly listed here was classified **`:resolved`** when [§Streaming SSR](#streaming-ssr) landed; the resolved entry lives at `## Resolved decisions` below.
+> **SA-4 classification.** Per [SPEC-AUTHORING §SA-4](SPEC-AUTHORING.md): no *blocking* items outstanding at the 011-SSR tier. The streaming surface formerly listed here was classified **`:resolved`** when [§Streaming SSR](#streaming-ssr) landed; the resolved entry lives at `## Resolved decisions` below. The four items below are **additive forward slots** — each has a locked emit contract already documented in the body, and the deferred work is only the *consumer flip* that turns the slot on. They are **demand-triggered `:post-v1`** deferrals, not `:still-blocking` questions; per SA-4 a `:post-v1 tracked` item needs a `rf2-<id>` tracking bead, and each item below is honestly marked **untracked note** because no dedicated tracking bead exists yet — the record is the concrete *fires-when* trigger that would justify filing one.
 
-(None outstanding — add new open questions inline as decisions land or are deferred.)
+### Additive SSR forward slots — demand triggers (SA-4 `:post-v1`, untracked notes)
+
+Each slot's on-wire / emit contract is locked in the body; the flip is cheap once demanded. The trigger is the concrete condition under which the deferred work earns a tracking bead.
+
+| Slot | Where the contract lives | Classification | Fires-when trigger |
+|---|---|---|---|
+| **Head-only-hash channel** (`data-rf-head-hash` wire attr + `:rf/head-hash` payload key) | [§Head/meta contract — Status](#headmeta-contract) (596), [§Default flow step 6](#default-flow) (652), [§Mismatch detection — head](#mismatch-detection--head) (677) | `:post-v1` — **untracked note** (no dedicated build bead; the re-anchor rf2-9747xc is closed and only re-anchored the *reservation* off shipped `reg-head`, it did not schedule the channel) | A host actually attributing head mismatches through the `:failing-id` seam ([§Mismatch detection — head](#mismatch-detection--head)) in practice, **or** SEO/link-unfurl tooling needing head-vs-body divergence discrimination the unified `:rf/render-hash` channel cannot give. Either turns the head-only hash from a nicety into a demanded capability. (Pairs with rf2-9747xc, same 011 passages.) |
+| **Streaming per-boundary `:on-error` hiccup override** (`:on-error [:hiccup-vec]` on `:rf/suspense-boundary`) | [§Failure semantics — inline fallback](#failure-semantics--inline-fallback) (rationale at ~1004) | `:post-v1` — **untracked note** (no dedicated bead; the inline-fallback default is `:resolved` and shipped) | An app needing **error-distinct fallback UI** — a boundary whose hard-failure surface must differ from its loading fallback (e.g. "comments unavailable" vs the loading skeleton). The v1 default reuses the loading fallback on failure; a demanded error-distinct surface is the trigger. |
+| **`:writer-thread-factory` opt-in** (host-supplied virtual-thread / bounded-executor factory) | [§Writer concurrency model — Forward path](#writer-concurrency-model--one-daemon-thread-per-in-flight-stream) (1069, non-normative) | `:post-v1` — **untracked note** (no dedicated bead; the raw-daemon-thread-per-request baseline is `:resolved` and locked) | **Operator demand** — a host requiring bounded executors or JDK 21+ virtual threads for its streaming-concurrency posture (the raw-`java.lang.Thread`-per-request model is the locked baseline; the factory is purely additive and must not disturb the no-leak teardown contract). |
+| **`:rf/sub-warmups` payload key** (pre-computed sub values on the wire) | [§Payload scope](#payload-scope-canonical-boundary) (73), [§Resolved decisions — Sub-cache warmups out of scope](#sub-cache-warmups-out-of-scope-for-v1-rfhydration-payload) (1119), [Spec-Schemas `:rf/hydration-payload`](Spec-Schemas.md#rfhydration-payload) | `:post-v1` — **untracked note** (no dedicated bead; the slot is `:resolved` as *additive-and-absent-in-v1*) | A **measured first-read hydration-cost** — evidence that recomputing subs on the client's first read is a real latency cost worth the wire bytes + sub-graph-topology coupling. Absent that measurement the slot stays documented-but-empty ("the first read is the warmup"). |
+
+**No `bd create` performed** (per this cluster's brief). Each row above is the identification: any row whose trigger fires warrants filing a `rf2-<id>` bead at that time, converting the row from **untracked note** to `:post-v1 tracked` per SA-4's cross-link rule.
 
 ## Resolved decisions
 


### PR DESCRIPTION
Two same-surface `spec/011-SSR.md` beads in one PR (text-only; +32/−3).

## rf2-uf56ad — `:first-diff-path` is a host-supplied seam (P3)

`:first-diff-path` at 011's mismatch-trace shape was a bare `;; optional` with no producer statement and no segment vocabulary — while the adjacent `:failing-id` paragraph already models the host-supplied-seam treatment, and the repo's own tests use two incompatible path shapes for it (`[:head :title]` in `ssr_end_to_end_test.clj` vs `[:body 0 :children 0]` in `docs/ssr/concepts.md`).

Added a new `#### The `:first-diff-path` tag` subsection giving it the `:failing-id` treatment:
- **Producer** — the host, not the bundled runtime: `verify-hydration!` carries a host-supplied opt verbatim; the runtime hashes trees (proves *that* they diverged) but never computes *which node* diverged. Grounded in `implementation/ssr/src/re_frame/ssr/hydrate.cljc:570` (`:first-diff-path` is `assoc`ed only when supplied; no default — unlike `:failing-id`'s `(or failing-id :rf/hydrate)`).
- **Absence** — no default; the key is simply absent when no host diff ran (consumers branch on presence, never read absence as "root").
- **Segment vocabulary** — the three segment kinds the bead named: **index** (integer child position), **tag** (element-head keyword), **key** (map/attribute keyword), reconciling the two path shapes as free mixes of the three.
- Sharpened the inline trace-shape comment to point at the new subsection.

## rf2-axfo4s — SA-4 trigger-record cluster for 011's four additive SSR slots (P4)

The four forward slots (head-only-hash channel, streaming per-boundary `:on-error` override, `:writer-thread-factory` opt-in, `:rf/sub-warmups` payload key) had no consumer condition — their only "trigger" was self-referential. Applied the SA-4 record shape (per `spec/SPEC-AUTHORING.md §SA-4`): replaced the "None outstanding" `## Open questions` block with a classified trigger-record table. Each slot gets its contract cross-link, an honest `:post-v1` classification, and a **concrete fires-when trigger**; each is marked **untracked note** because no dedicated tracking bead exists.

### Beads that would be filed when a trigger fires (IDENTIFIED, not created)

Per the brief, **no `bd create` was performed**. No dedicated open tracking bead exists for any of the four deferred build-outs (verified against `.beads/issues.jsonl` — the head-only-hash bead rf2-9747xc is closed and only re-anchored the *reservation*; rf2-fzew1/bhk/99p are closed decisions, not build beads). A bead should be filed for a slot only *when its trigger fires*:
1. **Head-only-hash channel** — file when a host attributes head mismatches via the `:failing-id` seam in practice, or SEO tooling needs head-vs-body discrimination.
2. **Streaming `:on-error` override** — file when an app needs error-distinct fallback UI.
3. **`:writer-thread-factory`** — file on operator demand (bounded/virtual-thread executors).
4. **`:rf/sub-warmups`** — file on a measured first-read hydration-cost.

Did not disturb the recent 011 edits (57ehvw projector, 9747xc head-hash re-anchor, exfavp SSR note).

## Quality gates

- `python -m mkdocs build --strict` — PASS (exit 0; `spec/011-SSR.md` in built set, no 011/first-diff warnings; the INFO lines present are pre-existing and unrelated).
- `python scripts/check_doc_slugs.py` — PASS (exit 0).
- All referenced heading slugs verified present in 011.
