### PR TITLE
feat(story): per-assertion granularity adapter (rf2-2yrb91)

### DIFF
--- a/tools/story/spec/004-Assertions.md
+++ b/tools/story/spec/004-Assertions.md
@@ -325,14 +325,52 @@ a variant with no `:play-script` still "passes"). The result map's
 `:assert-dom` step records (rf2-ee38b.3 closed the false-green gap where
 rich-DSL assert failures landed only in the runner's `run-state` atom).
 
-> **Per-assertion `is` granularity (deferred — rf2-ee38b.3).** A
-> higher-fidelity `run-variant-as-test` adapter that iterates the
-> `:assertions` list and calls `cljs.test/is` per record (one failing
-> assertion → one `is` failure, with `:source-coord`-driven file/line
-> reporting + a generic kaocha-reporter shape) is a planned enhancement.
-> It is NOT yet shipped — `assertions-passing?` is the canonical surface
-> today. The adapter needs async-cljs.test plumbing (`run-variant`
-> returns a Promise) and is tracked separately.
+### Per-assertion `cljs.test/is` granularity — shipped via `story/is` (rf2-2yrb91)
+
+The higher-fidelity per-assertion adapter this section once deferred is
+**shipped** as the `story/is` verb of the spec/017 execution trilogy
+([`017-Testing-Story.md` §Public execution API — the three verbs](017-Testing-Story.md#public-execution-api--the-three-verbs)).
+`(story/is target opts)` runs the target, then reports each assertion
+record to `clojure.test` / `cljs.test` at **per-assertion granularity** —
+one `do-report` (`:pass` / `:fail` / `:error`) per record — so a script
+with N assertions lands N separate results in the active test run's tally,
+NOT one lumped outcome per variant. The pure projection
+`re-frame.story.result/result->reports` (re-exported as
+`story/result->reports`) turns the unified run-result into that ordered
+vector of report maps; the impure `do-report` emission is the `story/is`
+side. Details:
+
+- **One report per record.** `result->reports` maps every unified
+  assertion record through `assertion->report`, then appends ONE run-level
+  report only when the run verdict is not carried by any single assertion
+  (a tape-floor `:fail`, a run-level `:cannot-run`, or a vacuous-green
+  `:pass` so a zero-assertion run still emits one positive signal). A
+  `:cannot-run` assertion reports `:fail` (the runner proved nothing —
+  never a silent pass).
+- **`:source-coord`-driven reporting.** Each report's `:message` names the
+  failing `:assertion` id + payload. The per-record source slot
+  (`:source-coord` on the raw record, normalized to `:source` on the
+  unified record — §Record slot name) rides the unified `:assertions`
+  vector `result->reports` projects, so IDE / reporter surfaces resolve
+  file/line off the record without a second lookup.
+- **Async plumbing done.** `run-variant` / `story/run` return a Promise
+  (CLJS) / `CompletableFuture` (JVM); `story/is` BLOCKS on the JVM (the
+  canonical headless gate, firing reports synchronously and returning the
+  unified result) and hands the promise back on CLJS — chain `then`, or use
+  the `cljs.test` `(async done …)` form and call `story/report-result!`
+  when it resolves. `report-result!` is the pure-report seam both runtimes
+  share.
+
+Coverage: the JVM bridge is exercised by
+`re-frame.story.story-is-test` (`story-is-reports-per-assertion-pass`
+proves two `:assert-db` steps in one `:script` fire **two** separate
+reports); the pure CLJS projection by
+`re-frame.story.result-test/result->reports-one-per-assertion`.
+
+`story/assertions-passing?` remains the one-line boolean predicate for the
+`(is (story/assertions-passing? result))` pattern above; `story/is` is the
+richer per-assertion surface. Both consume the same unified `:assertions`
+vector.
 
 ## Cross-references
 

--- a/tools/story/test/re_frame/story/story_is_test.clj
+++ b/tools/story/test/re_frame/story/story_is_test.clj
@@ -76,6 +76,29 @@
       (is (re-find #":rf.assert/path-equals" (:message (first reports)))
           "the report names the failing assertion id"))))
 
+(deftest story-is-two-is-in-one-script-report-as-two-results
+  (testing "per-assertion cljs.test/is granularity (rf2-2yrb91): TWO
+            assertions in ONE :script emit TWO independent reports — one
+            failing assertion does not collapse or suppress the other, and
+            the pass/fail verdict is tracked separately per :assert step"
+    (story/reg-variant :story.is/two-mixed
+      {:tags        #{:test}
+       :play-script {:script [[:dispatch-sync [:is/set-status :loaded]]
+                              ;; assertion 1 — passes
+                              [:assert-db [:status] :loaded]
+                              ;; assertion 2 — fails (status is :loaded, not :idle)
+                              [:assert-db [:status] :idle]]}})
+    (let [[result reports] (capture-reports #(story/is :story.is/two-mixed))]
+      (is (= :fail (:status result)) "the aggregate verdict is :fail")
+      (is (= 2 (count reports))
+          "two :assert steps → two separate reports, not one lumped result")
+      (is (= [:pass :fail] (mapv :type reports))
+          "each assertion is tracked separately: first passes, second fails")
+      (is (= :loaded (:actual (second reports)))
+          "the failing report carries its own per-assertion :actual")
+      (is (= :idle (:expected (second reports)))
+          "and its own per-assertion :expected — granularity, not aggregation"))))
+
 (deftest story-is-zero-assertion-emits-one-pass
   (testing "a variant with no assertions is vacuously green — story/is emits
             ONE run-level :pass so the test sees a positive signal"


### PR DESCRIPTION
## Summary

Implements bead **rf2-2yrb91** — the per-assertion `cljs.test/is` granularity adapter that `tools/story/spec/004-Assertions.md:328` deferred (citing only the closed `rf2-ee38b.3`, naming no successor).

**Key finding:** the adapter is *already shipped*. The spec/017 execution trilogy landed `story/is`, whose `re-frame.story.result/result->reports` + `assertion->report` projection fires one `clojure.test` / `cljs.test` `do-report` (`:pass` / `:fail` / `:error`) **per assertion record** — exactly the "one failing assertion → one `is` failure, `:source-coord`-driven, async-Promise plumbing" enhancement the 004-Assertions deferred note described as "NOT yet shipped". That note predates the spec/017 verbs and was never reconciled.

So this change:

1. **Reconciles the stale deferred note** in `004-Assertions.md` — replaces the "deferred / not yet shipped" block with a "shipped via `story/is`" section recording the granularity as delivered, cross-linked to `017-Testing-Story.md` §Public execution API. (The bead's Surface instruction: "record the granularity as delivered".)
2. **Adds a mixed pass/fail acceptance test** (`story-is-two-is-in-one-script-report-as-two-results`) proving two `:assert` steps in one `:script` report as **two independent results** — one passing, one failing, each with its own `:expected` / `:actual` — i.e. granularity, not aggregation. (The existing `story-is-reports-per-assertion-pass` proved the two-passing case; this sharpens it with a mixed outcome.)

No `src/` change was needed — duplicating the working adapter would violate the elegance/no-over-engineering posture. The right delta is the spec reconciliation + the sharper test.

## Quality gates

- Story artefact `clojure -M:test` — **PASS** (1709 tests / 6338 assertions, 0 failures, 0 errors), including the new `story-is-two-is-in-one-script-report-as-two-results`.
- `npm run test:cljs` — **not run**: change touches only `tools/story/spec/` (not built/shipped) + `tools/story/test/` (JVM `.clj`); no shared `implementation/` source. The pure CLJS projection is already covered by `re-frame.story.result-test/result->reports-one-per-assertion`. Relying on CI.
- Test delta: **+1 test** (`story-is-two-is-in-one-script-report-as-two-results`), proving two `is` in one script report as two results (bead requirement).
- `mkdocs build --strict` — **not applicable**: `tools/story/spec/` is outside the mkdocs `docs_dir: docs` tree; no `docs/` file touched.