### PR TITLE
docs(xray): 021 trigger-records + OQ sweep (rf2-4wwf7p)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1199,9 +1199,16 @@ Layout direction: **top-to-bottom by default** (elk's `elk.direction
 DOWN`, the `MachineChart` default Xray does not override). The original
 sketch called for a left-to-right `rankdir: 'LR'` default; the elkjs
 backend that shipped (`MachineChart`, 2026-05-19 ELK lock) maps `:lr` →
-elk `RIGHT` / `:tb` → elk `DOWN` and defaults to `DOWN`. Operator-facing
-direction flip (Settings → View → Machines layout direction) is deferred
-to a follow-on bead. Default framing: fit-on-mount via xyflow's
+elk `RIGHT` / `:tb` → elk `DOWN` and defaults to `DOWN`. An operator-facing
+direction flip (Settings → View → Machines layout direction) is a
+**post-v1, untracked note** — no bead filed yet; the trigger files one
+when it fires. **Reconsideration trigger (falsifiable).** A corpus or
+consumer machine renders wide enough that the `DOWN` default forces
+horizontal scrolling the operator cannot resolve by resizing the panel,
+and a per-render `:lr` flip would recover legibility — at which point the
+Settings toggle is wired against the `:lr`/`:tb` → elk `RIGHT`/`DOWN`
+mapping the `MachineChart` backend already exposes. Default framing:
+fit-on-mount via xyflow's
 `:fitViewOptions {:padding 0.1}` (a fractional viewport padding, not a
 fixed pixel inset); Xray re-frames on panel-entry by bumping the
 `:fit-signal` nonce (rf2-6tw7t).
@@ -4335,7 +4342,8 @@ as precise when the eye actually wants the ISO date. Both
 directions are symmetric — past (`Nm ago`) and future (`in Nm`) —
 so scheduled-event timestamps read naturally.
 
-**URI heuristic — deliberately deferred.** CLJS has no built-in
+**URI heuristic — rejected (with an extend-type escape hatch).** This is
+a rejection, not a deferral: CLJS has no built-in
 `uri?` predicate, and extending `js/String` so non-URL strings can
 return `nil` from the protocol path would route every string in
 every render through the seam — invasive on a fundamental type
@@ -4848,9 +4856,17 @@ to `:rf.xray.edn-inspector/expansion {<path>}` so the operator's
 disclosure choices survive epoch navigation. **No right-click reset**
 (per §10.5 — right-click context menus are explicitly out). Reset by
 navigating to a new focused epoch (the sticky override is per-epoch +
-path, so a new epoch's tree starts from the default heuristic) or via
-the panel-local "Reset expansion" affordance in the Settings menu
-(deferred follow-on).
+path, so a new epoch's tree starts from the default heuristic). The
+panel-local "Reset expansion" affordance in the Settings menu — a button
+that dispatches the already-shipped `:rf.xray.edn-inspector/reset-expansion`
+event to clear the whole `:rf.xray.edn-inspector/expansion` slice at once
+— is a **post-v1, untracked note** — no bead filed yet; the trigger files
+one when it fires. (The reset *mechanism* ships today; only the operator-
+facing Settings button is deferred.) **Reconsideration trigger
+(falsifiable).** An operator reports that per-epoch reset plus per-node
+collapse is not enough to escape an accumulated expansion state — they
+want a single "collapse everything back to the heuristic" control — at
+which point the Settings button is wired to the existing reset event.
 
 ### §10.5 Interaction model
 
@@ -4962,7 +4978,18 @@ What the panel design needs from the substrate (per §1.4 captured-not-replayed)
 | Meta-epoch section ordering | **Fixed order: Event > App-db > Reactive > Trace > Machines > Routing > Issues** | Matches the L3 tab order. Predictable beats dynamic. (rf2-4v67l — Chrome A11y removed in favour of Story's shipped panel.) |
 | Epoch panel section default-expansion | **All cascade steps expanded by default; collapsible per-step via header click; collapse-all keyboard `[`** | The Epoch panel IS the handling-pipeline view — collapsing by default would hide the punch. |
 | Dispatch-origin display on L2 rows | **Short text label prefix** (`user · :checkout/submit`) | No icon-only or coloured chip — keeps L2 row scannable. Matches the existing L1 ribbon density. |
-| Pattern view (4th lens) | **Defer to follow-up bead** | Per super-prompt. The 3-lens model (handling / reactive / state) is sufficient for MVP. |
+| Pattern view (4th lens) | **Post-v1, untracked note** (see trigger below) | The 3-lens model (handling / reactive / state) is sufficient for MVP. |
+
+A **Pattern view** — a fourth lens over the epoch that groups recurring
+cascade shapes rather than the per-epoch handling / reactive / state
+slices the three shipped lenses show — is a **post-v1, untracked note** —
+no bead filed yet; the trigger files one when it fires.
+**Reconsideration trigger (falsifiable).** An operator working a real
+debugging session finds the 3-lens model (handling / reactive / state)
+cannot surface a repeated cross-epoch pattern they need to see (e.g. "the
+same sub re-runs every third epoch"), and a Pattern lens would answer it
+where the existing three cannot — at which point the fourth lens is
+designed against the shipped epoch projection.
 
 ### §11.5 Views → Reactive → Views label history
 

--- a/tools/xray/spec/findings/re-frame-10x-v2-design.md
+++ b/tools/xray/spec/findings/re-frame-10x-v2-design.md
@@ -536,7 +536,7 @@ a curated Xray-MCP — was killed.
 
 ### §10.8 re-frame2-pair delegation in co-pilot
 
-**Open.** With co-pilot back (§10.2), this is on the table again. Recommendation: defer to v2 — the co-pilot has its own chat via direct LLM API; re-frame2-pair delegation is an "if a re-frame2-pair nREPL session is running, route through it" optimisation, not blocking for v1. Awaiting Mike's call.
+**Resolved 2026-05-17 — moot (co-pilot dropped; two-doors architecture).** This question is dissolved rather than answered on its merits: the in-Xray AI co-pilot was removed entirely (Mike, rf2-s3vx5 — see `DESIGN-RATIONALE.md` Lock #2 and [`../000-Vision.md`](../000-Vision.md) §"two doors"). With no co-pilot in Xray there is nothing to delegate *from* — the AI door is the sibling `tools/re-frame2-pair-mcp/` tool directly (raw nREPL over MCP), not an Xray co-pilot that proxies to re-frame2-pair. The false middle was killed. _(Historical draft note; the co-pilot framing this depended on is superseded.)_
 
 ### §10.9 Mobile / phone form factor
 

--- a/tools/xray/spec/findings/xray-ux-design.md
+++ b/tools/xray/spec/findings/xray-ux-design.md
@@ -787,19 +787,21 @@ Temptations rejected:
 
 ## §12 — Open questions for Mike
 
-Decisions that require Mike's call, not a designer's:
+Decisions that required Mike's call, not a designer's. **All six have
+since landed** — this section is a historical record; each item below
+carries its resolution and a pointer into the current numbered spec.
 
-**§12.1 Detail-panel-as-hero (§4).** This design demotes the causality graph from hero to peer. The bet: habit beats demo. The risk: the graph is the screenshot people love; demoting it costs marketing. If you'd rather flip it (graph as default canvas, detail as side popover), the design rearranges cleanly.
+**§12.1 Detail-panel-as-hero (§4). RESOLVED 2026-05-19 — went further than demotion: the causality graph was dropped entirely.** The bet (habit beats demo) was taken and then some. The ELK+SVG causality graph, its popover, and the `c` key binding are all gone (Mike, rf2-y0z5b — `DESIGN-RATIONALE.md` Lock #7). The current hero / default-landing surface is the **Epoch panel** (leftmost tab, mnemonic `e`, `:order -1`; superseded the Event-detail panel per rf2-5gl5r) — see [`../000-Vision.md`](../000-Vision.md) §"What it is" and [`../007-UX-IA.md`](../007-UX-IA.md). (A derivation/process **Graph** tab survives as an ordinary L4 peer tab per EP-0014, not the hero.)
 
-**§12.2 Co-pilot default state.** **Locked 2026-05-11: open by default.** The marquee-pull argument wins — Xray's pitch hinges on the AI co-pilot being immediately visible, not hidden behind a shortcut. User can close the rail (it remembers the choice across the session).
+**§12.2 Co-pilot default state.** ~~Locked 2026-05-11: open by default.~~ **SUPERSEDED 2026-05-17 — moot (co-pilot dropped).** The AI co-pilot rail was removed entirely (Mike, rf2-s3vx5; `DESIGN-RATIONALE.md` Lock #2) — there is no rail to default open or closed. AI integration lives in `tools/re-frame2-pair-mcp/`.
 
-**§12.3 The launch button (§10).** A 48×48px floating button in the bottom-right when Xray is closed. Discoverable secondary to `Ctrl+Shift+X`. Some JS devtools don't ship one (Redux, Vue). Keep, drop, or default-hidden-with-settings-toggle?
+**§12.3 The launch button (§10). RESOLVED — dropped as an Xray default; hosts MAY add their own.** No Xray-owned floating launcher ships. The canonical launch path is the keychord (`Ctrl+Shift+C`); the only Xray-shipped ribbon button is pop-out (`⛶`). Hosts MAY add their own launcher affordance, but that is host chrome, not Xray's launch contract — see [`../011-Launch-Modes.md`](../011-Launch-Modes.md) §"Closed state". (The 48×48 button survives only in this historical draft.)
 
-**§12.4 Source-coord click-through fallback.** Editors with URL handlers (`vscode://`, `idea://`) work out of the box. Editors without (Vim, Emacs, Sublime) fall back to "copy coord to clipboard." Is clipboard enough, or do we ship per-editor preset configurations in Settings?
+**§12.4 Source-coord click-through fallback. RESOLVED — full editor-URI matrix + unconfigured-host DX hint (not the clipboard fallback).** The current spec ships a per-editor URI-template matrix (`:vscode` default, `:cursor`, `:windsurf`, `:zed`, `:idea`, plus a `{:custom <template>}` escape with `{path}/{file}/{line}/{column}` placeholders), configured via `:rf.xray/editor` with resolution order `[end-user-override → host default → :vscode]` — see [`../007-UX-IA.md`](../007-UX-IA.md) §"Editor protocol matrix" and [`../015-Configuration.md`](../015-Configuration.md). The unconfigured-host case surfaces a DX-hint toast rather than a silent `vscode:` no-op (rf2-4s08ov); the clipboard-fallback idea was not carried (source-coords remain copyable `file:line` chips independently).
 
-**§12.5 Conversation persistence default.** Per-session (cleared on reload) in this design — opt-in to localStorage. Privacy bet vs. utility bet. Per-session or persistent-with-opt-out?
+**§12.5 Conversation persistence default. RESOLVED — moot (co-pilot dropped).** With the AI co-pilot rail removed entirely (Mike 2026-05-17, rf2-s3vx5; `DESIGN-RATIONALE.md` Lock #2 + Lock #12) there is no conversation to persist. AI integration lives in `tools/re-frame2-pair-mcp/` instead — see [`../000-Vision.md`](../000-Vision.md) §"What it isn't".
 
-**§12.6 Voice STT at v1.** Fully implementable (browser-local, no service dependency) but niche. Ship at v1 or defer to v1.1 to reduce launch surface?
+**§12.6 Voice STT at v1. RESOLVED — moot (dropped with the co-pilot).** Voice/STT was a co-pilot input affordance; the co-pilot rail is gone (`DESIGN-RATIONALE.md` Lock #13, superseded by the Lock #2 reversal). No voice/STT surface appears anywhere in the current numbered spec.
 
 ---
 


### PR DESCRIPTION
Implements **rf2-4wwf7p** (P4 — VAGUE cluster 7). Spec-only doc hygiene, no behavioural change. All xray vocab renames already merged; this only records/sweeps.

## What changed

### `tools/xray/spec/021-Dynamic-Panel-Designs.md` — 4 edits
1. **§6.2 Machines layout-direction flip** (was "deferred to a follow-on bead") → SA-4 **untracked note + falsifiable reconsideration trigger** (fires when a machine renders wide enough that the `DOWN` default forces unrecoverable horizontal scroll and a `:lr` flip recovers legibility).
2. **§10.4 panel-local "Reset expansion" affordance** (was "deferred follow-on") → untracked note + trigger. Records the nuance verified in code: the `:rf.xray.edn-inspector/reset-expansion` **event already ships + is tested**; only the operator-facing **Settings-menu button** is deferred.
3. **§11.4 4th "Pattern" lens** (was "Defer to follow-up bead") → untracked note + trigger; table cell + a following paragraph describing what a Pattern lens would add over the shipped 3-lens (handling/reactive/state) model.
4. **§9.x URI heuristic** — reworded "**deliberately deferred**" → "**rejected (with an extend-type escape hatch)**". It is a rejection with a project-owned opt-in seam, not a deferral (per bead).

### Historical-findings open-question sweep (verified against current numbered spec + closed beads)
- **`findings/re-frame-10x-v2-design.md` §10.8** re-frame2-pair delegation in co-pilot — was "Open. Awaiting Mike's call" → **RESOLVED, moot**: the in-Xray co-pilot was dropped (rf2-s3vx5, two-doors architecture); nothing to delegate from.
- **`findings/xray-ux-design.md` §12** — header reframed as historical; all six items resolved:
  - **§12.1** graph-as-hero → **RESOLVED**: causality graph dropped entirely (rf2-y0z5b); Epoch panel is the hero/landing.
  - **§12.2** co-pilot default state → **SUPERSEDED (moot)**: co-pilot dropped.
  - **§12.3** launch button → **RESOLVED**: no Xray-default launcher; keychord + optional host chrome (011 §Closed state).
  - **§12.4** source-coord click-through → **RESOLVED**: editor-URI matrix + unconfigured-host DX hint (007/015); clipboard fallback not carried.
  - **§12.5** conversation persistence → **RESOLVED (moot)**: co-pilot dropped.
  - **§12.6** voice STT → **RESOLVED (moot)**: dropped with the co-pilot.

## 3 beads for the mayor to file

These are the three promised-but-unfiled follow-ons the bead named. Each is now recorded in 021 as an honest untracked note with a falsifiable fires-when trigger (no `bd create` done per brief). File when its trigger fires:

1. **Machines panel: operator-facing layout-direction flip** (Settings → View → Machines layout direction). Wire a `:lr`/`:tb` toggle against the `MachineChart` ELK mapping (`:lr`→`RIGHT`, `:tb`→`DOWN`) that already exists. Fires-when: a machine renders wide enough that the `DOWN` default forces horizontal scroll the operator can't resolve by resizing. (021 §6.2)
2. **EDN inspector: "Reset expansion" Settings-menu button.** Wire a Settings-menu control to the already-shipped `:rf.xray.edn-inspector/reset-expansion` event (clears the `:rf.xray.edn-inspector/expansion` slice). Mechanism ships today; only the button is missing. Fires-when: an operator needs a single "collapse all back to heuristic" control beyond per-epoch/per-node reset. (021 §10.4)
3. **Epoch panel: 4th "Pattern" lens.** A lens grouping recurring cross-epoch cascade shapes, beyond the 3-lens handling/reactive/state model. Fires-when: an operator hits a repeated cross-epoch pattern the 3 lenses can't surface. (021 §11.4)

## Quality gates
- `python scripts/check_doc_slugs.py` → **exit 0** (no broken targets/anchors; new cross-links into `../000-Vision.md`, `../007-UX-IA.md`, `../011-Launch-Modes.md`, `../015-Configuration.md` all resolve). No headings were changed, so no inbound anchors into 021 were broken.
- No dedicated xray spec-drift script exists in `scripts/` (only skill-drift checks); relying on CI for any additional lint. No xray src or other spec touched — surface is `tools/xray/spec` only.
