### PR TITLE
feat(adapters): resource-lease mount-lifecycle helper (rf2-cxozh4)

### DIFF
--- a/docs/EP/EP-0020-active-owner-polling.md
+++ b/docs/EP/EP-0020-active-owner-polling.md
@@ -457,6 +457,20 @@ they are kept verbatim as the record of what was ruled.
    component-observer model legitimately re-enters). This keeps EP-0020's runtime
    contract clean while acknowledging the real ergonomic gap.
 
+   **DELIVERED (rf2-cxozh4).** The mount-lifecycle helper shipped in the adapter
+   layer, exactly as recommended — the runtime contract is untouched. Two
+   substrate-shaped surfaces over the ONE shared implementation
+   (`re-frame.adapter.resource-lease`, core/CLJS): `use-resource-lease`
+   (`re-frame.adapter.uix` / `re-frame.adapter.helix` — a React hook) and
+   `with-resource-lease` (`re-frame.adapter.reagent` — a Form-3 component). Each
+   mints a unique `[:lease …]` owner on mount (dispatching `:rf.resource/ensure`)
+   and releases it on unmount (`:rf.resource/release-owner`), carrying the
+   surrounding `frame-provider`'s frame. It is DATA-only — it `:require`s no
+   resources artefact (the two events are dispatched by keyword id), so it is
+   inert in an app without `day8/re-frame2-resources`; under SSR the lifecycle
+   never fires (a natural no-op); and the per-instance lease token is idempotent
+   under a StrictMode / hot-reload re-mount.
+
 2. **Hidden-tab polling opt-in: ship in v1 or reserve?** TanStack
    (`refetchIntervalInBackground`), SWR (`refreshWhenHidden`), and RTK
    (`skipPollingIfUnfocused`) all expose a hidden-tab toggle. Default-pause-when-hidden

--- a/implementation/adapters/helix/src/re_frame/adapter/helix.cljs
+++ b/implementation/adapters/helix/src/re_frame/adapter/helix.cljs
@@ -17,6 +17,7 @@
             [helix.hooks         :as helix-hooks]
             [re-frame.frame             :as frame]
             [re-frame.substrate.spine   :as spine]
+            [re-frame.adapter.resource-lease :as resource-lease]
             [re-frame.views.owned-frame :as owned-frame]))
 
 ;; ---- shared spine wiring --------------------------------------------------
@@ -149,6 +150,25 @@
   `(rf/subscribe ...)` deref shape, asymmetric naming (hooks live in
   hook-named space)."
   (:use-subscribe spine-fns))
+
+(def use-resource-lease
+  "Helix hook that takes a resource liveness LEASE for the calling
+  component's mounted lifetime (rf2-cxozh4, EP-0020 §Open Issue #1). On
+  mount it dispatches `:rf.resource/ensure` with an app-minted `[:lease …]`
+  owner; on unmount it releases that lease via `:rf.resource/release-owner`.
+  Use it so a view declaratively OWNS a polled / cached resource for as long
+  as it is on screen — the mount-lifecycle half of resource ownership that
+  otherwise needs a hand-wired `use-effect`.
+
+      (use-resource-lease {:resource :my/feed :scope :rf.scope/global
+                           :params {:page 0}})
+
+  Pair it with `use-subscribe` on a `[:rf.resource/*]` query to READ the
+  data; this hook manages liveness only (returns nil). Frame resolution +
+  the `:cause` / `:frame` opts mirror `use-subscribe`; the shared
+  substrate-agnostic implementation lives in
+  `re-frame.adapter.resource-lease`."
+  resource-lease/use-resource-lease)
 
 (def flush-views!
   "Flush pending Helix renders synchronously. Wraps React's act() —

--- a/implementation/adapters/helix/test/re_frame/adapter/helix_use_resource_lease_dom_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_use_resource_lease_dom_cljs_test.cljs
@@ -1,0 +1,146 @@
+(ns re-frame.adapter.helix-use-resource-lease-dom-cljs-test
+  "Helix DOM/browser coverage for `use-resource-lease` (rf2-cxozh4, EP-0020
+  §Open Issue #1) — the mount-lifecycle resource-lease hook. Twin of the UIx
+  suite (`uix_use_resource_lease_dom_cljs_test`); both drive the ONE shared
+  hook in `re-frame.adapter.resource-lease` through their substrate's
+  re-export, so a gap on one substrate is a gap on both.
+
+  The acceptance property: MOUNT dispatches `:rf.resource/ensure` with an
+  app-minted `[:lease …]` owner + the descriptor; UNMOUNT dispatches
+  `:rf.resource/release-owner` for that SAME lease. Spy event handlers under
+  the two public resource event ids record the payloads.
+
+  ASYNC (queued-dispatch drain) + MAP-form fixture, per the UIx twin's note.
+
+  ns ends in `-dom-cljs-test` for `:browser-test` discovery; `:node-test`
+  matches too, where each test self-gates on `(browser?)` and no-ops."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            ["react" :as React]
+            ["react-dom/client" :as react-dom-client]
+            [helix.core :refer-macros [$ defnc]]
+            [helix.dom  :as d]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.adapter.helix :as helix-adapter]
+            [re-frame.substrate.adapter :as substrate-adapter]
+            [re-frame.test-support :as test-support]))
+
+;; ---- MAP-form fixture (async-safe) -----------------------------------------
+
+(def ^:private registrar-snapshot (atom nil))
+
+(defn- before! []
+  (reset! registrar-snapshot (test-support/snapshot-registrar))
+  (reset! frame/frames {})
+  (substrate-adapter/dispose-adapter!)
+  (substrate-adapter/install-adapter! helix-adapter/adapter)
+  (frame/ensure-default-frame!))
+
+(defn- after! []
+  (when-let [snap @registrar-snapshot]
+    (test-support/restore-registrar! snap)
+    (reset! registrar-snapshot nil))
+  (reset! frame/frames {}))
+
+(use-fixtures :each {:before before! :after after!})
+
+;; ---- spy channels ----------------------------------------------------------
+
+(def ^:private ensures  (atom []))
+(def ^:private releases (atom []))
+
+(def ^:private lease-frame :rf.helix-resource-lease/frame)
+(def ^:private descriptor
+  {:resource :rf.helix-resource-lease/feed
+   :scope    :rf.scope/global
+   :params   {:page 0}})
+
+(defnc ProbeLease []
+  (helix-adapter/use-resource-lease descriptor)
+  (d/div "leased"))
+
+(defnc ProbeLeaseExplicitFrame []
+  ;; No surrounding frame-provider — the :frame opt supplies the target.
+  (helix-adapter/use-resource-lease descriptor {:frame lease-frame :cause :dashboard})
+  (d/div "leased"))
+
+(defn- browser? []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+(defn- get-act []
+  (or (when (exists? (.-act React)) (.-act React))
+      (try (.-act (js/require "react-dom/test-utils")) (catch :default _ nil))))
+
+(defn- install-spies! []
+  (reset! ensures [])
+  (reset! releases [])
+  (rf/reg-frame lease-frame {:doc "use-resource-lease spy frame"})
+  (rf/reg-event :rf.resource/ensure
+                (fn [_cofx [_ payload]] (swap! ensures conj payload) {}))
+  (rf/reg-event :rf.resource/release-owner
+                (fn [_cofx [_ payload]] (swap! releases conj payload) {})))
+
+;; Wait two macrotasks so the router's next-tick drain has run.
+(defn- after-drain [k] (js/setTimeout (fn [] (js/setTimeout k 0)) 0))
+
+(deftest use-resource-lease-mount-acquires-unmount-releases
+  (testing "Helix — mount ensures with a [:lease …] owner; unmount releases it"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — :browser-test runner exercises the assertion")
+      (let [act-fn (get-act)]
+        (if (nil? act-fn)
+          (is true "act() not reachable from this runner; skipping")
+          (async done
+            (binding [frame/*current-frame* nil]
+              (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+              (install-spies!)
+              (let [mount-node (.createElement js/document "div")
+                    root       (react-dom-client/createRoot mount-node)]
+                (act-fn
+                  (fn []
+                    (.render root
+                      ($ helix-adapter/frame-provider {:frame lease-frame}
+                         ($ ProbeLease)))))
+                (after-drain
+                  (fn []
+                    (is (= 1 (count @ensures)) "exactly one ensure on mount")
+                    (let [p (first @ensures)]
+                      (is (= (:resource descriptor) (:resource p)) "ensure carried the resource")
+                      (is (= (:scope descriptor)    (:scope p))    "ensure carried the scope")
+                      (is (= (:params descriptor)   (:params p))   "ensure carried the params")
+                      (is (vector? (:owner p)) "owner is a vector")
+                      (is (= :lease (first (:owner p))) "owner is an app-minted [:lease …]")
+                      (is (some? (:cause p)) "ensure carried a cause"))
+                    (is (empty? @releases) "no release before unmount")
+                    (act-fn (fn [] (.unmount root)))
+                    (after-drain
+                      (fn []
+                        (is (= 1 (count @releases)) "exactly one release on unmount")
+                        (is (= (:owner (first @ensures)) (:owner (first @releases)))
+                            "release drops the SAME lease that was acquired")
+                        (done)))))))))))))
+
+(deftest use-resource-lease-explicit-frame-pins-lease
+  (testing "Helix — :frame opt pins the lease into an explicit frame (no provider needed)"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — :browser-test runner exercises the assertion")
+      (let [act-fn (get-act)]
+        (if (nil? act-fn)
+          (is true "act() not reachable from this runner; skipping")
+          (async done
+            (binding [frame/*current-frame* nil]
+              (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+              (install-spies!)
+              (let [mount-node (.createElement js/document "div")
+                    root       (react-dom-client/createRoot mount-node)]
+                (act-fn (fn [] (.render root ($ ProbeLeaseExplicitFrame))))
+                (after-drain
+                  (fn []
+                    (is (= 1 (count @ensures)) "ensure fired via the :frame opt")
+                    (is (= :dashboard (:cause (first @ensures))) "explicit :cause recorded")
+                    (act-fn (fn [] (.unmount root)))
+                    (after-drain
+                      (fn []
+                        (is (= 1 (count @releases)) "release fired on unmount")
+                        (done)))))))))))))

--- a/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
+++ b/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
@@ -6,6 +6,9 @@
   (:require [reagent.core :as r]
             [reagent.ratom :as ratom]
             [reagent.dom.client :as rdc]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.adapter.context :as adapter-context]
             [re-frame.substrate.spine :as spine]
             [re-frame.views :as views]))
 
@@ -78,6 +81,123 @@
   init! Var. Previously stock Reagent surfaced no adapter-level flush-views!
   and tests reached for reagent.core/flush or react/act directly."
   (:flush-views! spine-fns))
+
+;; ---- resource-lease mount-lifecycle helper (rf2-cxozh4, EP-0020 §Open Issue #1) --
+
+(defonce ^:private lease-token-counter
+  ;; Monotone per-runtime counter minting a UNIQUE lease token per mounted
+  ;; `with-resource-lease` instance, so two components leasing the same
+  ;; resource+scope hold INDEPENDENT leases (releasing one never drops the
+  ;; other). The Reagent twin of the React-hook helper's counter.
+  (atom 0))
+
+(defn- lease-args
+  "Normalise `with-resource-lease` call args `[descriptor & args]` into
+  `{:descriptor :cause :frame :body}`. The optional `opts` map may sit
+  between the descriptor and the body thunk; a leading fn is the body."
+  [[descriptor & args]]
+  (let [[opts body] (if (fn? (first args))
+                      [nil (first args)]
+                      [(first args) (second args)])]
+    {:descriptor descriptor
+     :cause      (get opts :cause [:lease :mount])
+     :frame      (get opts :frame)
+     :body       body}))
+
+(defn- lease-frame-from-context
+  "Resolve the frame this instance should lease into: an explicit `:frame`
+  opt wins; else the frame-provider's keyword read off the instance's React
+  context (`:contextType` = the shared frame-context; the no-provider
+  sentinel coerces to nil); else the dynamic-var tier; else a loud
+  `:rf.error/no-frame-context`. Mirrors the React-hook helper's resolution
+  contract, in the Reagent (class-context) idiom."
+  [^js this explicit-frame]
+  (or explicit-frame
+      (let [ctx (.-context this)]
+        (when-not (= ctx adapter-context/no-provider-sentinel)
+          (adapter-context/coerce-context-value ctx)))
+      frame/*current-frame*
+      (frame/require-current-frame!
+        :with-resource-lease
+        {:where 're-frame.adapter.reagent/with-resource-lease})))
+
+(def with-resource-lease
+  "Reagent component that takes a resource liveness LEASE for its mounted
+  lifetime (rf2-cxozh4, EP-0020 §Open Issue #1) — the Reagent (Form-3)
+  counterpart of the UIx / Helix `use-resource-lease` hook. On mount it
+  dispatches `:rf.resource/ensure` with an app-minted `[:lease …]` owner; on
+  unmount it releases that lease via `:rf.resource/release-owner`. Use it so
+  a view declaratively OWNS a polled / cached resource for as long as it is
+  mounted — the mount-lifecycle half of resource ownership that otherwise
+  needs a hand-wired Form-3.
+
+  Call it as a Reagent component with the resource descriptor and a body
+  thunk (a 0-arg fn returning hiccup — the children rendered while the lease
+  is held):
+
+      [reagent/with-resource-lease
+       {:resource :my/feed :scope :rf.scope/global :params {:page 0}}
+       (fn [] [feed-view])]
+
+  Or with opts (a map between the descriptor and the body thunk):
+
+      [reagent/with-resource-lease
+       {:resource :my/feed :scope … :params …}
+       {:cause :dashboard-widget :frame :some-frame}
+       (fn [] [feed-view])]
+
+  `descriptor` is the resource-instance identity `{:resource :scope
+  :params}` (the ensure payload's read keys, Spec 016 §Events). `opts`:
+    :cause  — recorded on the ensure (observability; free-form data value).
+              Defaults to `[:lease :mount]`.
+    :frame  — pin the lease to an explicit frame id, bypassing ambient
+              frame-provider / dynamic-var resolution.
+
+  A single Form-3 `create-class` (NOT a Form-2 returning one — that would
+  mint a fresh component type per render and remount). It declares
+  `:context-type` = the shared frame-context (via
+  `re-frame.adapter.context/frame-context`) so the instance receives the
+  surrounding `frame-provider`'s frame — the same wiring `reg-view` uses —
+  and resolves the lease frame in `:component-did-mount` (explicit `:frame`
+  opt → React-context → dynamic-var → loud `:rf.error/no-frame-context`),
+  stashing it so `:component-will-unmount` releases into the SAME frame even
+  though it runs after the render scope has unwound.
+
+  Idempotency: the lease token is minted ONCE per instance (stashed on the
+  instance in `did-mount`), so a hot-reload re-mount settles to exactly one
+  held lease (ensure re-attaches the same lease; Spec 016 §Active owners).
+  Under SSR (`render-to-string`) lifecycle methods do not run, so the
+  acquire/release is a natural no-op — the lease is a client-lifetime
+  concern."
+  (r/create-class
+    {:display-name "re-frame.adapter.reagent/with-resource-lease"
+     ;; Reagent's create-class copies `:context-type` (camelCased to the
+     ;; React static `contextType`) onto the class, so `(.-context this)`
+     ;; carries the enclosing frame-provider's value — the class-component
+     ;; parity of the reg-view `{:contextType frame-context}` wiring.
+     :context-type adapter-context/frame-context
+     :component-did-mount
+     (fn [^js this]
+       (let [{:keys [descriptor cause frame]} (lease-args (rest (r/argv this)))
+             {:keys [resource scope params]}  descriptor
+             frame-id (lease-frame-from-context this frame)
+             token    (swap! lease-token-counter inc)
+             lease    [:lease token]]
+         ;; Stash the per-instance lease + frame so unmount releases exactly
+         ;; this instance's lease into the same frame.
+         (set! (.-rf2ResourceLease this) #js {:frame frame-id :lease lease})
+         (rf/dispatch* [:rf.resource/ensure
+                        {:resource resource :scope scope :params params
+                         :owner lease :cause cause}]
+                       {:frame frame-id})))
+     :component-will-unmount
+     (fn [^js this]
+       (when-let [held (.-rf2ResourceLease this)]
+         (rf/dispatch* [:rf.resource/release-owner {:owner (.-lease held)}]
+                       {:frame (.-frame held)})))
+     :reagent-render
+     (fn [_descriptor & args]
+       ((:body (lease-args (cons _descriptor args)))))}))
 
 (def adapter
   "The Reagent adapter map. Pass to `(rf/init! ...)` to install:

--- a/implementation/adapters/reagent/test/re_frame/adapter/with_resource_lease_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/adapter/with_resource_lease_dom_cljs_test.cljs
@@ -1,0 +1,147 @@
+(ns re-frame.adapter.with-resource-lease-dom-cljs-test
+  "Reagent DOM/browser coverage for `with-resource-lease` (rf2-cxozh4,
+  EP-0020 §Open Issue #1) — the mount-lifecycle resource-lease component,
+  the Reagent (Form-3) counterpart of the UIx / Helix `use-resource-lease`
+  hook.
+
+  The acceptance property: MOUNT dispatches `:rf.resource/ensure` with an
+  app-minted `[:lease …]` owner + the descriptor; UNMOUNT dispatches
+  `:rf.resource/release-owner` for that SAME lease. Spy event handlers under
+  the two public resource event ids record the payloads.
+
+  ASYNC (queued-dispatch drain) + MAP-form fixture, per the UIx twin.
+
+  Browser-only — the lifecycle methods only fire under a real React mount.
+  `-dom-cljs-test$` opts it into `:browser-test`; `:node-test` loads it too
+  and the DOM branch gates on `(browser?)`."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            [reagent.dom.client :as rdc]
+            ["react" :as React]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.substrate.adapter :as substrate-adapter]
+            [re-frame.test-support :as test-support]))
+
+;; ---- MAP-form fixture (async-safe); pins the React-context tier ------------
+;; No ambient `*current-frame*` scope — the with-resource-lease under test
+;; must resolve the frame-provider's frame via the class React-context tier,
+;; which an ambient :rf/default would shadow.
+
+(def ^:private registrar-snapshot (atom nil))
+
+(defn- before! []
+  (reset! registrar-snapshot (test-support/snapshot-registrar))
+  (reset! frame/frames {})
+  (substrate-adapter/dispose-adapter!)
+  (substrate-adapter/install-adapter! reagent-adapter/adapter)
+  (frame/ensure-default-frame!))
+
+(defn- after! []
+  (when-let [snap @registrar-snapshot]
+    (test-support/restore-registrar! snap)
+    (reset! registrar-snapshot nil))
+  (reset! frame/frames {}))
+
+(use-fixtures :each {:before before! :after after!})
+
+;; ---- spy channels ----------------------------------------------------------
+
+(def ^:private ensures  (atom []))
+(def ^:private releases (atom []))
+
+(def ^:private lease-frame :rf.reagent-resource-lease/frame)
+(def ^:private descriptor
+  {:resource :rf.reagent-resource-lease/feed
+   :scope    :rf.scope/global
+   :params   {:page 0}})
+
+(defn- browser? []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+(defn- get-act []
+  (or (when (exists? (.-act React)) (.-act React))
+      (try (.-act (js/require "react-dom/test-utils")) (catch :default _ nil))))
+
+(defn- install-spies! []
+  (reset! ensures [])
+  (reset! releases [])
+  (rf/reg-frame lease-frame {:doc "with-resource-lease spy frame"})
+  (rf/reg-event :rf.resource/ensure
+                (fn [_cofx [_ payload]] (swap! ensures conj payload) {}))
+  (rf/reg-event :rf.resource/release-owner
+                (fn [_cofx [_ payload]] (swap! releases conj payload) {})))
+
+;; Wait two macrotasks so the router's next-tick drain has run.
+(defn- after-drain [k] (js/setTimeout (fn [] (js/setTimeout k 0)) 0))
+
+(deftest with-resource-lease-mount-acquires-unmount-releases
+  (testing "Reagent — mount ensures with a [:lease …] owner; unmount releases it"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — :browser-test runner exercises the assertion")
+      (let [act-fn (get-act)]
+        (if (nil? act-fn)
+          (is true "act() not reachable from this runner; skipping")
+          (async done
+            (binding [frame/*current-frame* nil]
+              (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+              (install-spies!)
+              (let [mount-node (.createElement js/document "div")
+                    root       (rdc/create-root mount-node)]
+                (act-fn
+                  (fn []
+                    (rdc/render root
+                      [rf/frame-provider {:frame lease-frame}
+                       [reagent-adapter/with-resource-lease
+                        descriptor
+                        (fn [] [:div "leased"])]])))
+                (after-drain
+                  (fn []
+                    (is (= 1 (count @ensures)) "exactly one ensure on mount")
+                    (let [p (first @ensures)]
+                      (is (= (:resource descriptor) (:resource p)) "ensure carried the resource")
+                      (is (= (:scope descriptor)    (:scope p))    "ensure carried the scope")
+                      (is (= (:params descriptor)   (:params p))   "ensure carried the params")
+                      (is (vector? (:owner p)) "owner is a vector")
+                      (is (= :lease (first (:owner p))) "owner is an app-minted [:lease …]")
+                      (is (some? (:cause p)) "ensure carried a cause"))
+                    (is (empty? @releases) "no release before unmount")
+                    (act-fn (fn [] (rdc/unmount root)))
+                    (after-drain
+                      (fn []
+                        (is (= 1 (count @releases)) "exactly one release on unmount")
+                        (is (= (:owner (first @ensures)) (:owner (first @releases)))
+                            "release drops the SAME lease that was acquired")
+                        (done)))))))))))))
+
+(deftest with-resource-lease-explicit-frame-and-cause
+  (testing "Reagent — :frame opt pins the lease + :cause is recorded (no provider needed)"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — :browser-test runner exercises the assertion")
+      (let [act-fn (get-act)]
+        (if (nil? act-fn)
+          (is true "act() not reachable from this runner; skipping")
+          (async done
+            (binding [frame/*current-frame* nil]
+              (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+              (install-spies!)
+              (let [mount-node (.createElement js/document "div")
+                    root       (rdc/create-root mount-node)]
+                ;; No frame-provider — the :frame opt supplies the target.
+                (act-fn
+                  (fn []
+                    (rdc/render root
+                      [reagent-adapter/with-resource-lease
+                       descriptor
+                       {:frame lease-frame :cause :dashboard}
+                       (fn [] [:div "leased"])])))
+                (after-drain
+                  (fn []
+                    (is (= 1 (count @ensures)) "ensure fired via the :frame opt")
+                    (is (= :dashboard (:cause (first @ensures))) "explicit :cause recorded")
+                    (act-fn (fn [] (rdc/unmount root)))
+                    (after-drain
+                      (fn []
+                        (is (= 1 (count @releases)) "release fired on unmount")
+                        (done)))))))))))))

--- a/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
+++ b/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
@@ -15,6 +15,7 @@
             [uix.hooks.alpha   :as uix-hooks]
             [re-frame.frame             :as frame]
             [re-frame.substrate.spine   :as spine]
+            [re-frame.adapter.resource-lease :as resource-lease]
             [re-frame.views.owned-frame :as owned-frame]))
 
 ;; ---- shared spine wiring --------------------------------------------------
@@ -148,6 +149,25 @@
   `(rf/subscribe ...)` deref shape, asymmetric naming (hooks live in
   hook-named space)."
   (:use-subscribe spine-fns))
+
+(def use-resource-lease
+  "UIx hook that takes a resource liveness LEASE for the calling
+  component's mounted lifetime (rf2-cxozh4, EP-0020 §Open Issue #1). On
+  mount it dispatches `:rf.resource/ensure` with an app-minted `[:lease …]`
+  owner; on unmount it releases that lease via `:rf.resource/release-owner`.
+  Use it so a view declaratively OWNS a polled / cached resource for as long
+  as it is on screen — the mount-lifecycle half of resource ownership that
+  otherwise needs a hand-wired `use-effect`.
+
+      (use-resource-lease {:resource :my/feed :scope :rf.scope/global
+                           :params {:page 0}})
+
+  Pair it with `use-subscribe` on a `[:rf.resource/*]` query to READ the
+  data; this hook manages liveness only (returns nil). Frame resolution +
+  the `:cause` / `:frame` opts mirror `use-subscribe`; the shared
+  substrate-agnostic implementation lives in
+  `re-frame.adapter.resource-lease`."
+  resource-lease/use-resource-lease)
 
 (def flush-views!
   "Flush pending UIx renders synchronously. Wraps React's act() —

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_use_resource_lease_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_use_resource_lease_dom_cljs_test.cljs
@@ -1,0 +1,155 @@
+(ns re-frame.adapter.uix-use-resource-lease-dom-cljs-test
+  "UIx DOM/browser coverage for `use-resource-lease` (rf2-cxozh4, EP-0020
+  §Open Issue #1) — the mount-lifecycle resource-lease hook.
+
+  The acceptance property: MOUNT dispatches `:rf.resource/ensure` with an
+  app-minted `[:lease …]` owner + the descriptor; UNMOUNT dispatches
+  `:rf.resource/release-owner` for that SAME lease. We do not load the
+  resources runtime's real handlers' behaviour here — instead we register
+  SPY event handlers under the two public resource event ids and assert on
+  the payloads they record. The shared substrate-agnostic hook lives in
+  `re-frame.adapter.resource-lease`; the Helix twin
+  (`helix_use_resource_lease_dom_cljs_test`) exercises the same fn through
+  the Helix re-export, so a gap on one substrate is a gap on both.
+
+  ASYNC: the hook dispatches through the QUEUED path (`dispatch*` — the
+  correct choice for a lifecycle effect), which drains on the router's
+  next-tick. Each test mounts / unmounts under `act`, then awaits a
+  macrotask so the enqueued ensure / release has drained before asserting.
+  A MAP-form fixture (not the fn-form `make-reset-runtime-fixture`) is
+  required because cljs.test fn-form fixtures do not suspend across an async
+  body — mirrors the frame-provider-context async-DOM idiom.
+
+  ns ends in `-dom-cljs-test` so shadow-cljs's `:browser-test` discovers it;
+  `:node-test`'s `cljs-test$` regex also matches, where each test self-gates
+  on `(browser?)` and no-ops cleanly."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            ["react" :as React]
+            ["react-dom/client" :as react-dom-client]
+            [uix.core :as uix :refer-macros [defui $]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.substrate.adapter :as substrate-adapter]
+            [re-frame.test-support :as test-support]))
+
+;; ---- MAP-form fixture (async-safe) -----------------------------------------
+
+(def ^:private registrar-snapshot (atom nil))
+
+(defn- before! []
+  (reset! registrar-snapshot (test-support/snapshot-registrar))
+  (reset! frame/frames {})
+  (substrate-adapter/dispose-adapter!)
+  (substrate-adapter/install-adapter! uix-adapter/adapter)
+  (frame/ensure-default-frame!))
+
+(defn- after! []
+  (when-let [snap @registrar-snapshot]
+    (test-support/restore-registrar! snap)
+    (reset! registrar-snapshot nil))
+  (reset! frame/frames {}))
+
+(use-fixtures :each {:before before! :after after!})
+
+;; ---- spy channels ----------------------------------------------------------
+
+(def ^:private ensures  (atom []))
+(def ^:private releases (atom []))
+
+(def ^:private lease-frame :rf.uix-resource-lease/frame)
+(def ^:private descriptor
+  {:resource :rf.uix-resource-lease/feed
+   :scope    :rf.scope/global
+   :params   {:page 0}})
+
+(defui ProbeLease []
+  (uix-adapter/use-resource-lease descriptor)
+  ($ :div "leased"))
+
+(defui ProbeLeaseExplicitFrame []
+  ;; No surrounding frame-provider — the :frame opt supplies the target.
+  (uix-adapter/use-resource-lease descriptor {:frame lease-frame :cause :dashboard})
+  ($ :div "leased"))
+
+(defn- browser? []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+(defn- get-act []
+  (or (when (exists? (.-act React)) (.-act React))
+      (try (.-act (js/require "react-dom/test-utils")) (catch :default _ nil))))
+
+(defn- install-spies! []
+  (reset! ensures [])
+  (reset! releases [])
+  (rf/reg-frame lease-frame {:doc "use-resource-lease spy frame"})
+  (rf/reg-event :rf.resource/ensure
+                (fn [_cofx [_ payload]] (swap! ensures conj payload) {}))
+  (rf/reg-event :rf.resource/release-owner
+                (fn [_cofx [_ payload]] (swap! releases conj payload) {})))
+
+;; Wait two macrotasks so the router's next-tick drain has run.
+(defn- after-drain [k] (js/setTimeout (fn [] (js/setTimeout k 0)) 0))
+
+(deftest use-resource-lease-mount-acquires-unmount-releases
+  (testing "UIx — mount ensures with a [:lease …] owner; unmount releases it"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — :browser-test runner exercises the assertion")
+      (let [act-fn (get-act)]
+        (if (nil? act-fn)
+          (is true "act() not reachable from this runner; skipping")
+          (async done
+            (binding [frame/*current-frame* nil]
+              (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+              (install-spies!)
+              (let [mount-node (.createElement js/document "div")
+                    root       (react-dom-client/createRoot mount-node)]
+                (act-fn
+                  (fn []
+                    (.render root
+                      ($ uix-adapter/frame-provider {:frame lease-frame}
+                         ($ ProbeLease)))))
+                (after-drain
+                  (fn []
+                    (is (= 1 (count @ensures)) "exactly one ensure on mount")
+                    (let [p (first @ensures)]
+                      (is (= (:resource descriptor) (:resource p)) "ensure carried the resource")
+                      (is (= (:scope descriptor)    (:scope p))    "ensure carried the scope")
+                      (is (= (:params descriptor)   (:params p))   "ensure carried the params")
+                      (is (vector? (:owner p)) "owner is a vector")
+                      (is (= :lease (first (:owner p))) "owner is an app-minted [:lease …]")
+                      (is (some? (:cause p)) "ensure carried a cause"))
+                    (is (empty? @releases) "no release before unmount")
+                    (act-fn (fn [] (.unmount root)))
+                    (after-drain
+                      (fn []
+                        (is (= 1 (count @releases)) "exactly one release on unmount")
+                        (is (= (:owner (first @ensures)) (:owner (first @releases)))
+                            "release drops the SAME lease that was acquired")
+                        (done)))))))))))))
+
+(deftest use-resource-lease-explicit-frame-pins-lease
+  (testing "UIx — :frame opt pins the lease into an explicit frame (no provider needed)"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — :browser-test runner exercises the assertion")
+      (let [act-fn (get-act)]
+        (if (nil? act-fn)
+          (is true "act() not reachable from this runner; skipping")
+          (async done
+            (binding [frame/*current-frame* nil]
+              (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+              (install-spies!)
+              (let [mount-node (.createElement js/document "div")
+                    root       (react-dom-client/createRoot mount-node)]
+                ;; No frame-provider — the :frame opt supplies the target.
+                (act-fn (fn [] (.render root ($ ProbeLeaseExplicitFrame))))
+                (after-drain
+                  (fn []
+                    (is (= 1 (count @ensures)) "ensure fired via the :frame opt")
+                    (is (= :dashboard (:cause (first @ensures))) "explicit :cause recorded")
+                    (act-fn (fn [] (.unmount root)))
+                    (after-drain
+                      (fn []
+                        (is (= 1 (count @releases)) "release fired on unmount")
+                        (done)))))))))))))

--- a/implementation/core/src/re_frame/adapter/resource_lease.cljs
+++ b/implementation/core/src/re_frame/adapter/resource_lease.cljs
@@ -1,0 +1,149 @@
+(ns re-frame.adapter.resource-lease
+  "Shared React-hook resource-lease helper for the React-shaped adapters
+  (UIx / Helix). Delivers the adapter-ergonomics helper EP-0020 §Open Issue #1
+  promised (rf2-cxozh4): a view-layer wrapper that mints a resource
+  liveness LEASE on mount and RELEASES it on unmount, so a view can
+  declaratively own a polled / cached resource for its lifetime without
+  hand-wiring a Form-3 / `useEffect` per app.
+
+  ## Why here (core, CLJS-only)
+
+  The React-hook body is substrate-agnostic — it uses `React/useRef` /
+  `React/useEffect` directly (exactly like the spine's unmount sentinel),
+  not any UIx- or Helix-specific hook — so the UIx and Helix
+  `use-resource-lease` surfaces re-export this ONE implementation with zero
+  drift (mirroring how `use-subscribe` lives once in the spine). It lives in
+  the core artefact because core already `:require`s React (via
+  `re-frame.views` / `re-frame.adapter.context`), so this file adds no new
+  transitive dep, and both adapters depend on core.
+
+  ## Bundle isolation
+
+  This ns does NOT `:require` the resources artefact — resource ownership
+  is expressed purely as DATA (the two public resource events dispatched by
+  keyword id, `:rf.resource/ensure` and `:rf.resource/release-owner`). An
+  app that omits `day8/re-frame2-resources` simply never registers those
+  events, so the helper is inert there — matching the EP framing that this
+  is an adapter concern, not a runtime-contract concern.
+
+  ## The lease contract (Spec 016 §The scoped-cache lease lifecycle)
+
+  ACQUIRE — `[:rf.resource/ensure {:resource … :scope … :params …
+             :owner [:lease …] :cause …}]` attaches the lease owner to the
+             resolved scoped entry (+ owner-index), keeping it alive and, if
+             the resource declares `:poll-interval-ms`, polling for the
+             view's lifetime.
+  RELEASE — `[:rf.resource/release-owner {:owner [:lease …]}]` drops that
+             lease. When it was the last owner the entry becomes GC-eligible
+             and (per EP-0020) polling stops immediately.
+
+  ## Frame resolution + carry
+
+  The frame is resolved at RENDER time through the same carried-invariant
+  chain `use-subscribe` uses (`frame/require-current-frame!`: dynamic-var →
+  React-context → loud `:rf.error/no-frame-context`), or pinned explicitly
+  via the `:frame` opt. Because the `useEffect` acquire/release runs AFTER
+  the render scope has unwound (an async boundary), the resolved frame is
+  CLOSED OVER and both dispatches carry it as an explicit `{:frame …}` opt —
+  the standard `capture-frame` carry (Spec 002 §capture-frame).
+
+  ## Idempotency (SSR / React StrictMode double-mount)
+
+  - SSR / JVM has no `useEffect` execution (effects never run on the
+    server), so the acquire/release is a natural no-op under
+    `render-to-string` — the lease is a client-lifetime concern.
+  - React 18 StrictMode dev double-invokes an effect (mount → cleanup →
+    mount). The lease token is minted ONCE per instance (via `useRef`,
+    stable across the double-invoke), and ensure is idempotent for a
+    re-attached owner (a second ensure of an already-owned entry re-attaches
+    the SAME lease — no duplicate durable owner; Spec 016 §Active owners).
+    release-owner drops that one lease. So the mount→cleanup→mount cycle
+    settles to exactly one held lease, matching the committed instance."
+  (:require ["react" :as React]
+            [re-frame.core  :as rf]
+            [re-frame.frame :as frame]))
+
+(defonce ^:private lease-token-counter
+  ;; Monotone per-runtime counter minting a UNIQUE lease token per mounted
+  ;; helper instance, so two components leasing the same resource+scope hold
+  ;; INDEPENDENT leases (releasing one never drops the other). Mirrors the
+  ;; spine's `unmount-instance-counter`.
+  (atom 0))
+
+(defn use-resource-lease
+  "React hook (UIx / Helix): take a resource liveness LEASE for the calling
+  component's mounted lifetime. On mount it dispatches `:rf.resource/ensure`
+  with an app-minted `[:lease …]` owner; on unmount it dispatches
+  `:rf.resource/release-owner` for that same lease. Returns nil (a lifecycle
+  hook, not a read — pair it with `use-subscribe` on a `[:rf.resource/*]`
+  query to read the data).
+
+  Call shapes:
+
+      (use-resource-lease {:resource :my/feed
+                           :scope    :rf.scope/global
+                           :params   {:page 0}})
+
+      (use-resource-lease {:resource :my/feed :scope … :params …}
+                          {:cause :dashboard-widget   ;; recorded on the ensure
+                           :frame :some-frame})       ;; explicit-frame pin
+
+  `descriptor` is the resource-instance identity — `{:resource :scope
+  :params}` — exactly the ensure payload's read keys (Spec 016 §Events).
+
+  `opts`:
+    :cause  — the `:cause` recorded on the ensure (observability; a
+              free-form data value). Defaults to `[:lease :mount]`.
+    :frame  — pin the lease to an explicit frame id, bypassing the ambient
+              frame-provider / dynamic-var resolution.
+
+  Frame resolution (1-arg / no `:frame`): the surrounding `frame-provider`'s
+  keyword via the carried-invariant chain (`frame/require-current-frame!`),
+  raising `:rf.error/no-frame-context` when no frame is in scope — the same
+  contract as `use-subscribe`.
+
+  Re-lease semantics: changing the resolved frame, the descriptor, or the
+  cause tears down the old lease (release-owner) and takes a fresh one
+  (ensure) — the effect is keyed on those values. A stable descriptor across
+  re-renders holds ONE lease with no churn."
+  ([descriptor] (use-resource-lease descriptor nil))
+  ([descriptor {:keys [cause frame] :as _opts}]
+   ;; Resolve the frame through the full carried-invariant chain at RENDER
+   ;; time — an explicit `:frame` opt wins; otherwise dynamic-var →
+   ;; React-context → loud `:rf.error/no-frame-context`. Resolving here (not
+   ;; inside the effect) captures the render-time frame to close over, since
+   ;; the effect runs after the render scope unwinds.
+   (let [frame-id (or frame
+                      (frame/require-current-frame!
+                        :use-resource-lease
+                        {:where 're-frame.adapter.resource-lease/use-resource-lease}))
+         ;; One stable lease token per mounted instance (survives re-renders
+         ;; AND React StrictMode's mount→cleanup→mount double-invoke).
+         token-ref (React/useRef nil)
+         token     (or (.-current token-ref)
+                       (let [t (swap! lease-token-counter inc)]
+                         (set! (.-current token-ref) t)
+                         t))
+         lease     [:lease token]
+         cause     (or cause [:lease :mount])
+         {:keys [resource scope params]} descriptor
+         ;; Stable primitive deps for React's `Object.is` comparison: the
+         ;; descriptor / cause are value-equal but fresh JS objects per
+         ;; render, so key the effect on a printed digest rather than the
+         ;; live objects (the same stable-key discipline the spine's
+         ;; use-subscribe uses for its query vector).
+         deps-key  (pr-str [frame-id token resource scope params cause])]
+     (React/useEffect
+       (fn arm-lease []
+         (rf/dispatch* [:rf.resource/ensure
+                        {:resource resource
+                         :scope    scope
+                         :params   params
+                         :owner    lease
+                         :cause    cause}]
+                       {:frame frame-id})
+         (fn release-lease []
+           (rf/dispatch* [:rf.resource/release-owner {:owner lease}]
+                         {:frame frame-id})))
+       #js [deps-key])
+     nil)))

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -71,10 +71,12 @@
   ;; --- Reagent adapter (day8/re-frame2-reagent) — probe fully-rowed ---
   {:namespace "re-frame.adapter.reagent" :var "adapter"             :kind :var :facade? false :tier :adapter :owner "006" :status "v1" :runtime-verified? true}
   {:namespace "re-frame.adapter.reagent" :var "flush-views!"        :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1" :runtime-verified? true}
+  {:namespace "re-frame.adapter.reagent" :var "with-resource-lease" :kind :var :facade? false :tier :adapter :owner "006" :status "v1" :runtime-verified? true}
   {:namespace "re-frame.adapter.reagent" :var "set-hiccup-emitter!" :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1" :runtime-verified? true}
   ;; --- UIx adapter (day8/re-frame2-uix) — probe fully-rowed ---
   {:namespace "re-frame.adapter.uix" :var "adapter"             :kind :var :facade? false :tier :adapter :owner "006" :status "v1" :runtime-verified? true}
   {:namespace "re-frame.adapter.uix" :var "use-subscribe"       :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1" :runtime-verified? true}
+  {:namespace "re-frame.adapter.uix" :var "use-resource-lease"  :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1" :runtime-verified? true}
   {:namespace "re-frame.adapter.uix" :var "use-current-frame"   :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1" :runtime-verified? true}
   {:namespace "re-frame.adapter.uix" :var "frame-provider"      :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1" :runtime-verified? true}
   {:namespace "re-frame.adapter.uix" :var "wrap-view"           :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1" :runtime-verified? true}
@@ -83,6 +85,7 @@
   ;; --- Helix adapter (day8/re-frame2-helix) — probe fully-rowed ---
   {:namespace "re-frame.adapter.helix" :var "adapter"             :kind :var :facade? false :tier :adapter :owner "006" :status "v1" :runtime-verified? true}
   {:namespace "re-frame.adapter.helix" :var "use-subscribe"       :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1" :runtime-verified? true}
+  {:namespace "re-frame.adapter.helix" :var "use-resource-lease"  :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1" :runtime-verified? true}
   {:namespace "re-frame.adapter.helix" :var "use-current-frame"   :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1" :runtime-verified? true}
   {:namespace "re-frame.adapter.helix" :var "frame-provider"      :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1" :runtime-verified? true}
   {:namespace "re-frame.adapter.helix" :var "wrap-view"           :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1" :runtime-verified? true}

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -6,7 +6,7 @@
  {:doc
  "GENERATED public-API manifest — do NOT hand-edit the :vars list. Regenerate with: clojure -M -m re-frame.api-manifest.gen (run from implementation/scripts/api-manifest/). The tier/owner/status axes are curated in spec/api-manifest-metadata.edn; existence + kind + facade? are derived from live public vars. See that generator ns for the design.",
  :keystone "rf2-3nbl5.2",
- :var-count 493,
+ :var-count 496,
  :tier-vocab
  [:front-porch
   :advanced
@@ -59,16 +59,19 @@
   {:namespace "re-frame.adapter.helix", :var "frame-provider", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.adapter.helix", :var "set-hiccup-emitter!", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.adapter.helix", :var "use-current-frame", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.adapter.helix", :var "use-resource-lease", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.adapter.helix", :var "use-subscribe", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.adapter.helix", :var "wrap-view", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.adapter.reagent", :var "adapter", :tier :adapter, :kind :var, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.adapter.reagent", :var "flush-views!", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.adapter.reagent", :var "set-hiccup-emitter!", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.adapter.reagent", :var "with-resource-lease", :tier :adapter, :kind :var, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.adapter.uix", :var "adapter", :tier :adapter, :kind :var, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.adapter.uix", :var "flush-views!", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.adapter.uix", :var "frame-provider", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.adapter.uix", :var "set-hiccup-emitter!", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.adapter.uix", :var "use-current-frame", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.adapter.uix", :var "use-resource-lease", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.adapter.uix", :var "use-subscribe", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.adapter.uix", :var "wrap-view", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.core", :var "->interceptor", :tier :implementation, :kind :macro, :owner "002", :status "EP-0022 (internal lowering only)", :facade? true, :runtime-verified? true}


### PR DESCRIPTION
Delivers the adapter-ergonomics helper **EP-0020 §Open Issue #1** promised (rf2-cxozh4): a view-layer wrapper that mints a resource liveness `[:lease …]` owner on **mount** and releases it on **unmount**, so a view can declaratively own a polled / cached resource for its lifetime without hand-wiring a Form-3 / `use-effect` per app. Runtime contract untouched — this is purely an adapter-layer concern, exactly as the EP recommended.

## Helper shape

Two substrate-shaped surfaces over **one** shared implementation:

- **`use-resource-lease`** (React hook) — re-exported from `re-frame.adapter.uix` and `re-frame.adapter.helix`; the shared impl lives in `re-frame.adapter.resource-lease` (core, CLJS).
  ```clojure
  (use-resource-lease {:resource :my/feed :scope :rf.scope/global :params {:page 0}})
  (use-resource-lease descriptor {:cause :dashboard :frame :some-frame})  ;; opts
  ```
- **`with-resource-lease`** (Reagent Form-3 component) — in `re-frame.adapter.reagent`.
  ```clojure
  [reagent/with-resource-lease
   {:resource :my/feed :scope :rf.scope/global :params {:page 0}}
   (fn [] [feed-view])]
  ```

Both acquire via `[:rf.resource/ensure {… :owner [:lease …] :cause …}]` and release via `[:rf.resource/release-owner {:owner [:lease …]}]`, carrying the surrounding `frame-provider`'s frame (React-context tier; explicit `:frame` opt wins). Pair with `use-subscribe` on a `[:rf.resource/*]` query to read the data — the helper manages liveness only.

Design properties:
- **Data-only / bundle-isolated** — no `:require` of the resources artefact (the two events are dispatched by keyword id), so the helper is inert in an app without `day8/re-frame2-resources`.
- **SSR-safe** — the mount/unmount lifecycle never fires under `render-to-string` (a natural no-op).
- **Idempotent** — the `[:lease …]` token is minted once per instance (`useRef` / stashed on the Reagent instance), so a StrictMode / hot-reload re-mount settles to exactly one held lease.

## Test deltas

New adapter DOM tests (async, exercising the queued-dispatch drain; spy handlers under the two resource event ids record payloads), one file per substrate:
- `uix_use_resource_lease_dom_cljs_test.cljs`
- `helix_use_resource_lease_dom_cljs_test.cljs`
- `with_resource_lease_dom_cljs_test.cljs` (Reagent)

Each asserts **mount → one ensure with a `[:lease …]` owner + descriptor + cause**, **unmount → one release of the SAME lease**, plus an explicit-`:frame` + `:cause` case. Public-API manifest gained three rows (`spec/api-manifest-metadata.edn`) + regenerated `spec/api-manifest.edn`. EP-0020 marked delivered.

## Quality gates

- `npm run test:cljs` (node CLJS gate incl. the CLJS manifest probe) — **8048 tests, 36969 assertions, 0 failures, 0 errors**.
- `npm run test:browser` — **230 tests, 757 assertions, 0 failures, 0 errors** (the real mount-acquire / unmount-release acceptance across UIx / Helix / Reagent); 0 compile warnings.
- JVM Public-API manifest drift-check (`clojure -M -m re-frame.api-manifest.gen --check`) — **in sync (496 public vars)** after regenerating for the three new adapter exports.
- `mkdocs build --strict` — passes (EP-0020 delivery note).
- `sh scripts/assert-worker-worktree.sh` — passed (worktree boundary honoured; no `.beads/`, no `spec/016-*` touched).