### PR TITLE
fix(perf): stop production perf-channel leak (rf2-2yv859)

### DIFF
--- a/docs/core/how-to/fix-a-slow-view.md
+++ b/docs/core/how-to/fix-a-slow-view.md
@@ -226,20 +226,11 @@ The channel is off by default. It is gated on its own compile-time flag, indepen
         :compiler-options {:closure-defines {re-frame.performance/enabled? true}}}}}
 ```
 
-A build that doesn't flip the flag carries **zero** User-Timing bytes, because dead-code elimination elides every bracket. CI proves this both ways: `npm run test:perf-bundle` builds the same example twice — flag off and flag on — and asserts the off bundle contains no `performance.mark`, `performance.measure`, or `rf:` fragment while the on bundle contains all three. So keeping the channel on in production is a deliberate, cheap choice ([Configure dev and production builds](configure-dev-and-prod.md)).
+A build that doesn't flip the flag carries **zero** User-Timing bytes, because dead-code elimination elides every bracket. CI proves this both ways: `npm run test:perf-bundle` builds the same example twice — flag off and flag on — and asserts the off bundle contains no `performance.measure`, `clearMeasures`, or `rf:` fragment while the on bundle contains all three. (The bracket allocates no `performance.mark` at all — it uses the options-bag `measure` form — so that string is absent from both bundles.) So keeping the channel on in production is a deliberate, cheap choice ([Configure dev and production builds](configure-dev-and-prod.md)).
 
-To read it, open the Chrome DevTools **Performance** panel, where the `rf:` measures appear as named bars beside React renders, paint, and layout. Or ask the console for the worst offenders:
+To read it, open the Chrome DevTools **Performance** panel, where the `rf:` measures appear as named bars beside React renders, paint, and layout (the panel captures entries as they are emitted, so it sees them regardless of the buffer-retention flag below).
 
-```javascript
-performance.getEntriesByType('measure')
-  .filter(e => e.name.startsWith('rf:'))
-  .sort((a, b) => b.duration - a.duration)
-  .slice(0, 20);
-```
-
-The diagnosis reads the same as rung 1. One wide `rf:render:` or `rf:sub:` bar is misplaced work (rung 2); a cloud of identical narrow `rf:render:` bars per interaction is a storm (rung 3).
-
-For continuous telemetry, don't lean on the entry buffer — the host bounds it (Chrome keeps only the last 10,000 `measure` entries), so a long-running page silently drops the oldest. Instead attach a `PerformanceObserver`, which fires per entry as it lands, and forward `rf:`-prefixed measures to your APM:
+The channel is **observer-first**: each bracket emits its measure, hands it to any live `PerformanceObserver`, then clears it from the retained buffer so a long-running page doesn't accumulate entries forever. That means `performance.getEntriesByType('measure')` returns `[]` in a normal build — the entries were delivered, not retained. For continuous telemetry, attach a `PerformanceObserver`, which fires per entry as it lands, and forward `rf:`-prefixed measures to your APM:
 
 ```javascript
 new PerformanceObserver((list) => {
@@ -250,6 +241,20 @@ new PerformanceObserver((list) => {
   }
 }).observe({ type: 'measure', buffered: true });   // buffered: replay entries from before this observer attached
 ```
+
+The diagnosis reads the same as rung 1. One wide `rf:render:` or `rf:sub:` bar (in the panel, or in an observer's stream) is misplaced work (rung 2); a cloud of identical narrow `rf:render:` bars per interaction is a storm (rung 3).
+
+For a quick one-shot console snapshot instead of an observer, build with `:closure-defines {re-frame.performance/retain-entries? true}` — that skips the per-emit clear so entries persist in the buffer for `getEntriesByType`:
+
+```javascript
+// only populated when retain-entries? is on
+performance.getEntriesByType('measure')
+  .filter(e => e.name.startsWith('rf:'))
+  .sort((a, b) => b.duration - a.duration)
+  .slice(0, 20);
+```
+
+Leave `retain-entries?` off in production: the [W3C User-Timing buffer is unbounded](https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure) (`maxBufferSize` is Infinite for measure entries), so retaining every entry across a multi-hour session leaks memory. re-frame2 clears after emit precisely so it doesn't.
 
 The channel is off by default and rides its own compile-time flag, distinct from the dev-trace gate — [Observability](../concepts/observability.md#production-the-wire-disappears--errors-dont) covers what ships and what doesn't.
 

--- a/implementation/core/src/re_frame/performance.cljc
+++ b/implementation/core/src/re_frame/performance.cljc
@@ -16,17 +16,39 @@
       `(if enabled? <gated-bracket> (do ~@body))`. With the flag false
       at compile time, Closure constant-folds the gate; the gated
       branch DCEs and every helper string (the entry name, the
-      `performance.mark` / `performance.measure` call sites, the helper
-      ns code) elides. The macro shape — rather than a fn — is what
-      keeps the entry-name construction inside the gate too: a
-      function-shaped helper would force its arg expressions to evaluate
-      regardless, which would leave the `\"rf:\"` prefix string surviving
-      DCE in the off bundle.
+      `performance.measure` call site, the helper ns code) elides. The
+      macro shape — rather than a fn — is what keeps the entry-name
+      construction inside the gate too: a function-shaped helper would
+      force its arg expressions to evaluate regardless, which would leave
+      the `\"rf:\"` prefix string surviving DCE in the off bundle.
     - The runtime call sites (event dispatch, sub recompute, fx
       execution, render) wrap their hot-path work via `mark-and-measure`
-      with a stable `rf:<bucket>:<id>` name. Consumers read entries via
-      `(.getEntriesByType js/performance \"measure\")` and filter by
-      the `rf:` prefix.
+      with a stable `rf:<bucket>:<id>` name.
+
+  Observer-first contract — entries are **delivered, not retained**:
+
+    - The bracket emits **one** `performance.measure` per invocation
+      using the **options-bag** form
+      `performance.measure(name, {start, end})` with numeric
+      `performance.now()` timestamps. No `performance.mark` entries are
+      allocated — the two marks per bracket were pure buffer growth with
+      no documented consumer (nothing reads the `:start` / `:end` marks),
+      so the options-bag form drops two-thirds of the entry churn.
+    - After emitting, the bracket **clears the measure by name**
+      (`performance.clearMeasures(name)`) so the host's User-Timing entry
+      buffer does NOT accumulate. A live `PerformanceObserver` still
+      receives the entry — observer callbacks fire at `measure()` time,
+      before the clear — so timing is delivered to any attached observer
+      / APM; the buffer just doesn't grow. This is the real bound: the
+      framework clears after emit, NOT the (factually unbounded — W3C
+      `maxBufferSize` is Infinite for measure entries) host buffer.
+    - `retain-entries?` is a second `goog-define`d boolean, default
+      `false`. Flip it (`:closure-defines {re-frame.performance/retain-entries? true}`)
+      for one-shot DevTools / console workflows that read the retained
+      buffer via `(.getEntriesByType js/performance \"measure\")` — with
+      it on the per-emit clear is skipped so entries persist for
+      `getEntriesByType` readers. Long-running (RUM) sessions leave it
+      off and read via a `PerformanceObserver`.
 
   Naming convention (per Spec 009 §Performance instrumentation):
     rf:event:<event-id>     — event handler invocation
@@ -46,7 +68,7 @@
 
 #?(:clj (set! *warn-on-reflection* true))
 
-;; ---- the compile-time flag -------------------------------------------------
+;; ---- the compile-time flags ------------------------------------------------
 
 #?(:cljs
    (goog-define ^boolean enabled? false))
@@ -64,6 +86,18 @@
    ;;      below treat the JVM as a permanent no-op — the Performance API
    ;;      is browser-only — so the JVM expansion is just `(do body...)`.
    (def ^:const enabled? false))
+
+;; When true, the per-emit `performance.clearMeasures(name)` is skipped so
+;; entries persist in the host's User-Timing buffer for one-shot
+;; `getEntriesByType('measure')` readers (DevTools / console workflows).
+;; Default false: entries are delivered to observers then cleared, so the
+;; buffer does not grow across a long-running session. See the ns docstring
+;; §Observer-first contract.
+#?(:cljs
+   (goog-define ^boolean retain-entries? false))
+
+#?(:clj
+   (def ^:const retain-entries? false))
 
 ;; ---- name builder (used by the macro expansion at the call site) ----------
 
@@ -119,9 +153,19 @@
      last body form's value. JVM expansion is `(do body...)` — the
      Performance API is browser-only.
 
+     Entry shape (when the flag is on): one `performance.measure` via the
+     options-bag form `performance.measure(name, {start, end})` with
+     numeric `performance.now()` timestamps — **no** `performance.mark`
+     entries are allocated. Unless `retain-entries?` is on, the measure is
+     cleared by name (`performance.clearMeasures(name)`) immediately after
+     emit so the host's User-Timing buffer does not grow; a live
+     `PerformanceObserver` still receives the entry (its callback fires at
+     `measure()` time, before the clear). See the ns docstring
+     §Observer-first contract.
+
      Exception isolation: when the flag is on, the bracket is wrapped in
-     try/finally so the `:end` mark and the `measure` entry land even if
-     the body throws. The exception still propagates."
+     try/finally so the `measure` entry (and its clear) land even if the
+     body throws. The exception still propagates."
      [bucket id & body]
      (if (:ns &env)
        ;; CLJS expansion. Constant-fold-able shape:
@@ -129,16 +173,24 @@
        ;; Closure replaces `enabled?` with the goog-define value and
        ;; eliminates the dead branch under :advanced.
        `(if re-frame.performance/enabled?
-          (let [nm#         (re-frame.performance/build-name ~bucket ~id)
-                start-name# (str nm# ":start")
-                end-name#   (str nm# ":end")]
-            (.mark js/performance start-name#)
+          (let [nm#    (re-frame.performance/build-name ~bucket ~id)
+                start# (.now js/performance)]
             (try
               (do ~@body)
               (finally
-                (.mark js/performance end-name#)
                 (try
-                  (.measure js/performance nm# start-name# end-name#)
+                  ;; Options-bag measure: numeric start/end timestamps,
+                  ;; so no mark entries are ever allocated (two-thirds of
+                  ;; the old per-bracket buffer growth; nothing reads the
+                  ;; marks). The entry is delivered to any live
+                  ;; PerformanceObserver at this call, then — unless the
+                  ;; consumer opted into buffer retention — cleared so the
+                  ;; buffer does not accumulate across a long session.
+                  (.measure js/performance nm#
+                            (cljs.core/js-obj "start" start#
+                                              "end"   (.now js/performance)))
+                  (when-not re-frame.performance/retain-entries?
+                    (.clearMeasures js/performance nm#))
                   (catch :default _# nil)))))
           (do ~@body))
        ;; JVM expansion: pure pass-through. The Performance API is

--- a/implementation/core/test/re_frame/performance_cljs_test.cljs
+++ b/implementation/core/test/re_frame/performance_cljs_test.cljs
@@ -3,15 +3,18 @@
   round-trip (rf2-du3i).
 
   CLJS-only: the macro's only platform behaviour is the
-  `performance.mark` / `performance.measure` bracket; on JVM it expands
-  to `(do body...)` with no instrumentation overhead.
+  `performance.measure` (options-bag form) + per-emit `clearMeasures`
+  bracket; on JVM it expands to `(do body...)` with no instrumentation
+  overhead.
 
   This file covers:
 
    1. Naming convention (`build-name`).
    2. Helper round-trip with `enabled?` either branch — when false (the
       default :node-test build) no entry lands; when true (a bundle that
-      flips the goog-define) exactly one entry per call lands.
+      flips the goog-define) the entry is emitted then cleared after each
+      call (observer-first contract, rf2-2yv859) so the buffer does not
+      accumulate, and ZERO marks are allocated (options-bag form).
    3. Macro shape — body forms run, return value preserved.
 
   Bundle-isolation / bundle-presence under `:advanced` lives in
@@ -30,6 +33,15 @@
   [nm]
   (->> (.getEntriesByType js/performance "measure")
        (filter #(= nm (.-name %)))
+       count))
+
+(defn- count-rf-marks
+  "Count mark entries whose `.name` starts with `rf:`. The bracket must
+  allocate ZERO marks (options-bag measure form, rf2-2yv859)."
+  []
+  (->> (.getEntriesByType js/performance "mark")
+       (map #(.-name %))
+       (filter #(some-> % (.startsWith "rf:")))
        count))
 
 (defn- clear-measures!
@@ -63,16 +75,34 @@
                      (let [a 1 b 2]
                        [a b 3]))))))
 
-(deftest mark-and-measure-on-path-when-enabled
-  (testing "When `enabled?` is true at compile time, mark-and-measure
-            produces exactly one measure entry under the
-            `rf:<bucket>:<id>` name per call."
-    (when performance/enabled?
+(deftest mark-and-measure-clears-after-emit-when-enabled
+  (testing "Observer-first contract (rf2-2yv859): when `enabled?` is true
+            at compile time (and `retain-entries?` is off — the default),
+            each mark-and-measure call clears its measure by name right
+            after emit, so the host's User-Timing buffer does NOT
+            accumulate. A live PerformanceObserver still receives the
+            entry (callback fires at measure() time, before the clear);
+            the retained buffer that `getEntriesByType` reads stays empty."
+    (when (and performance/enabled? (not performance/retain-entries?))
       (clear-measures!)
       (let [nm "rf:test:roundtrip-on"]
-        (performance/mark-and-measure :test :roundtrip-on :ok)
-        (is (= 1 (count-measures nm))
-            "exactly one measure entry under the constructed name")))))
+        (dotimes [_ 25]
+          (performance/mark-and-measure :test :roundtrip-on :ok))
+        (is (zero? (count-measures nm))
+            "the measure buffer stays empty — cleared after each emit, no leak")))))
+
+(deftest mark-and-measure-allocates-no-marks-when-enabled
+  (testing "The options-bag measure form (rf2-2yv859) passes numeric
+            start/end timestamps, so ZERO `performance.mark` entries are
+            allocated — two-thirds of the old per-bracket buffer growth
+            is gone. No `rf:` mark entry lands regardless of the
+            retain-entries? flag."
+    (when performance/enabled?
+      (clear-measures!)
+      (dotimes [_ 25]
+        (performance/mark-and-measure :test :no-marks :ok))
+      (is (zero? (count-rf-marks))
+          "the bracket produces no rf: mark entries"))))
 
 (deftest mark-and-measure-off-path-when-disabled
   (testing "When `enabled?` is false at compile time, mark-and-measure is
@@ -88,8 +118,10 @@
 
 (deftest mark-and-measure-propagates-thrown-exceptions
   (testing "When the body throws, the exception propagates AFTER the
-            `:end` mark fires (the try/finally ensures a partial measure
-            entry still lands when the perf flag is on)."
+            `finally` emits (and clears) the measure — the try/finally
+            ensures the entry is delivered to observers on the partial
+            run even when the perf flag is on, then cleared per the
+            observer-first contract so the buffer does not retain it."
     (clear-measures!)
     (let [thrown (atom nil)]
       (try
@@ -98,6 +130,6 @@
         (catch :default e
           (reset! thrown e)))
       (is @thrown "the exception propagates")
-      (when performance/enabled?
-        (is (= 1 (count-measures "rf:test:throws"))
-            "the bracket still produced a measure entry on the partial run")))))
+      (when (and performance/enabled? (not performance/retain-entries?))
+        (is (zero? (count-measures "rf:test:throws"))
+            "the partial-run measure was emitted (delivered to observers) then cleared")))))

--- a/implementation/core/test/re_frame/performance_emit_nightly_test.cljs
+++ b/implementation/core/test/re_frame/performance_emit_nightly_test.cljs
@@ -62,6 +62,18 @@
   (test-support/make-reset-runtime-fixture
     {:adapter plain-atom/adapter}))
 
+;; Buffer retention for this runner (rf2-2yv859). The bracket now CLEARS
+;; each measure right after emit (`retain-entries?` default off), so a
+;; synchronous `getEntriesByType('measure')` snapshot taken after a drain
+;; finds an empty buffer — that's the leak fix working. This nightly
+;; runner sets `:closure-defines {re-frame.performance/retain-entries?
+;; true}` (alongside `enabled? true`) so the entries PERSIST in the
+;; retained buffer and these emission assertions can read them
+;; synchronously. The clear-after-emit (leak-fix) behaviour itself is
+;; unit-tested in `re-frame.performance-cljs-test` — a synchronous
+;; PerformanceObserver read is unreliable on the node runner (delivery is
+;; a microtask), so retention is the robust way to assert the entry
+;; NAMES / BUCKETS here.
 (defn- clear-measures!
   []
   (when (exists? js/performance.clearMeasures)
@@ -72,7 +84,8 @@
 (defn- rf-measures
   "Return the names of every `performance.getEntriesByType('measure')`
   entry whose name starts with `rf:`. Order preserved (insertion order
-  per the User-Timing API spec)."
+  per the User-Timing API spec). Reads the retained buffer, which this
+  runner keeps populated via `retain-entries? true` (see above)."
   []
   (->> (.getEntriesByType js/performance "measure")
        (map #(.-name %))
@@ -200,11 +213,16 @@
 
 (deftest enabled-flag-is-flipped-under-the-nightly-build
   (testing "The nightly runner (`:node-test-perf-nightly`) sets
-            `:closure-defines {re-frame.performance/enabled? true}` so
-            the call-site brackets actually fire. If this assertion
-            ever fails on the nightly runner, the build's closure-
-            defines map drifted — the integration assertions above
-            would silently no-op (their `when performance/enabled?`
-            guard short-circuits) so this canary catches it."
+            `:closure-defines {re-frame.performance/enabled? true
+                               re-frame.performance/retain-entries? true}`
+            so the call-site brackets actually fire AND the emitted
+            measures persist in the retained buffer for the synchronous
+            getEntriesByType reads above. If either assertion fails on the
+            nightly runner, the build's closure-defines map drifted — the
+            emission assertions would silently no-op (`enabled?` guard) or
+            read an empty buffer (`retain-entries?` off → cleared after
+            emit), so this canary catches both."
     (is (true? performance/enabled?)
-        "re-frame.performance/enabled? MUST be true under this build")))
+        "re-frame.performance/enabled? MUST be true under this build")
+    (is (true? performance/retain-entries?)
+        "re-frame.performance/retain-entries? MUST be true under this build")))

--- a/implementation/scripts/check-perf-bundle.cjs
+++ b/implementation/scripts/check-perf-bundle.cjs
@@ -20,10 +20,15 @@
  *      turn the negative grep into a false pass.
  *
  * Strategy: grep, not parse. The closure compiler may rename symbols
- * but does not rewrite string literals. Matching `performance.mark`
- * proves the JS-interop call site (from `(.mark js/performance ...)`)
- * survived; matching the bracketed entry-name shape `rf:` proves the
- * helper's name-building survived too.
+ * but does not rewrite string literals. Matching `performance.measure`
+ * proves the JS-interop emit site (from `(.measure js/performance ...)`)
+ * survived; matching `clearMeasures` proves the per-emit buffer clear
+ * survived (the leak fix, rf2-2yv859); matching the bracketed entry-name
+ * shape `rf:` proves the helper's name-building survived too.
+ *
+ * Note: `performance.mark` is intentionally NOT a sentinel — the bracket
+ * no longer allocates marks (options-bag measure with numeric
+ * timestamps), so it must be ABSENT from BOTH bundles.
  *
  * Exit 0 on PASS, 1 on FAIL.
  */
@@ -47,15 +52,15 @@ const report = createGateReporter();
 // is broken. If any are MISSING from the ON bundle, the strings have
 // moved and the negative assertion is now vacuous.
 //
-// The first three are the JS-interop strings the helper emits via
-// `(.mark js/performance ...)` / `(.measure js/performance ...)`; the
-// fourth is the namespace fragment (load-order proof — the ns is in the
-// bundle but every body-form should DCE on the OFF build).
+// The first two are the JS-interop strings the helper emits via
+// `(.measure js/performance ...)` / `(.clearMeasures js/performance ...)`;
+// the third is the entry-name prefix from `build-name`. Each appears ONLY
+// when the perf flag is on AND the call sites are reached.
 const PERF_SENTINELS = [
-  { source: 're-frame.performance/mark-and-measure (performance.mark)',
-    sentinel: 'performance.mark' },
   { source: 're-frame.performance/mark-and-measure (performance.measure)',
     sentinel: 'performance.measure' },
+  { source: 're-frame.performance/mark-and-measure (clearMeasures — per-emit buffer clear, rf2-2yv859)',
+    sentinel: 'clearMeasures' },
   { source: 're-frame.performance/build-name (rf: name prefix)',
     sentinel: '"rf:' },
 ];
@@ -105,7 +110,7 @@ function checkBundle(label, bundlePath, mustContain) {
   };
 }
 
-// Count `performance.mark|performance.measure|re-frame.performance` for
+// Count `performance.measure|clearMeasures|re-frame.performance` for
 // the report. The PR body wants the raw count number for both bundles,
 // per the bead's bundle-grep contract. The actual global-match count is
 // delegated to the shared `countMatches` (lib/read-release-bundle.cjs —
@@ -141,8 +146,8 @@ function main() {
   // the diagnostic report.
   const offBlob = classifyReleaseBundle(offDir).blob;
   const onBlob  = classifyReleaseBundle(onDir).blob;
-  const patterns = ['performance\\.mark',
-                    'performance\\.measure',
+  const patterns = ['performance\\.measure',
+                    'clearMeasures',
                     're-frame\\.performance'];
   const offCount = countOccurrences(offBlob, patterns);
   const onCount  = countOccurrences(onBlob,  patterns);

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -583,7 +583,7 @@
   ;;       node out/node-test-perf-nightly.js
   ;;
   ;; The migrated bundle-presence assertion (the `:advanced` bundle
-  ;; carries `performance.mark` / `performance.measure` symbols)
+  ;; carries `performance.measure` / `clearMeasures` symbols)
   ;; remains covered by `scripts/check-perf-bundle.cjs` via
   ;; `npm run test:perf-bundle`.
   :node-test-perf-nightly
@@ -597,8 +597,17 @@
     ;; Flip the perf-bracket gate on so the call-site emissions
     ;; actually land on the User-Timing stream. See
     ;; `implementation/core/src/re_frame/performance.cljc` for the
-    ;; goog-define declaration.
-    :closure-defines {re-frame.performance/enabled? true}}}
+    ;; goog-define declarations.
+    ;;
+    ;; `retain-entries? true` (rf2-2yv859): the bracket clears each
+    ;; measure by name right after emit by default, so the retained
+    ;; buffer stays empty and a synchronous getEntriesByType('measure')
+    ;; read finds nothing. This runner asserts the entry NAMES/BUCKETS,
+    ;; so it flips retention ON to keep the buffer populated for the
+    ;; synchronous read. The clear-after-emit (leak-fix) behaviour is
+    ;; unit-tested separately in re-frame.performance-cljs-test.
+    :closure-defines {re-frame.performance/enabled?        true
+                      re-frame.performance/retain-entries? true}}}
 
   ;; rf2-3cfvt — dedicated adversarial-property SECURITY tier runner.
   ;;
@@ -892,8 +901,8 @@
   ;; `:advanced` compilation, but with the `re-frame.performance/enabled?`
   ;; goog-define flipped to `true`. Its sole consumer is the
   ;; bundle-presence assertion in scripts/check-perf-bundle.cjs (`npm run
-  ;; test:perf-bundle`): with the flag on, the `performance.mark` /
-  ;; `performance.measure` / `"rf:` strings emitted by
+  ;; test:perf-bundle`): with the flag on, the `performance.measure` /
+  ;; `clearMeasures` / `"rf:` strings emitted by
   ;; `re-frame.performance` MUST survive `:advanced` DCE in this bundle —
   ;; the dual of the `:examples/counter` perf-off negative grep. Without
   ;; the perf-on bundle the negative assertion would be vacuous.

--- a/spec/009-Instrumentation.md
+++ b/spec/009-Instrumentation.md
@@ -1203,7 +1203,7 @@ The framework exposes **five observation surfaces**:
 2. **Assembled-epoch listener** — `register-epoch-listener!` / `unregister-epoch-listener!` ([§Assembled-epoch listener](#register-epoch-listener--assembled-epoch-listener), [Tool-Pair §Time-travel](Tool-Pair.md#time-travel-epoch-snapshots-and-undo)).
 3. **Event-emit listener** — `register-listener!` / `unregister-listener!` (the `:events` stream) ([API.md §Event-emit](API.md#event-emit-always-on-production-survivable)).
 4. **Error-emit listener** — `register-listener!` / `unregister-listener!` (the `:errors` stream) ([API.md §Error-emit](API.md#error-emit-always-on-production-survivable)).
-5. **Performance API channel** — `performance.mark` / `performance.measure` brackets ([§Performance instrumentation](#performance-instrumentation)).
+5. **Performance API channel** — `performance.measure` brackets (options-bag form, cleared after emit) ([§Performance instrumentation](#performance-instrumentation)).
 
 Each surface sits in exactly one of **three production postures**:
 
@@ -1256,7 +1256,8 @@ Each posture row has a small set of runtime knobs (orthogonal to the elision gat
 | dev-only DCE | `(rf/configure! {:epoch-history {:depth N :trace-events-keep N :redact-fn fn}})` | Epoch ring depth, per-record trace-event budget, per-record redaction hook for sensitive payloads | #2 |
 | dev-only DCE | `(rf/configure! {:elision {:rf.size/threshold-bytes N}})` | Per-payload size threshold for `:rf.size/large-elided` marker in trace records | #1, #2 (records ride post-elision) |
 | always-on | none — record shape is fixed by contract | Listeners receive identical record shapes in dev and prod | #3, #4 |
-| opt-in goog-define | `:closure-defines {re-frame.performance/enabled? true}` | Enables the four `performance.mark` / `performance.measure` bracket sites (`:event`, `:sub`, `:fx`, `:render`) | #5 |
+| opt-in goog-define | `:closure-defines {re-frame.performance/enabled? true}` | Enables the four `performance.measure` bracket sites (`:event`, `:sub`, `:fx`, `:render`) | #5 |
+| opt-in goog-define | `:closure-defines {re-frame.performance/retain-entries? true}` | Skips the per-emit `performance.clearMeasures` so entries persist in the retained buffer for one-shot `getEntriesByType('measure')` readers (DevTools / console); default off — entries are delivered to observers then cleared | #5 |
 
 The `goog.DEBUG` flag (CLJS) and the `-Dre-frame.debug` system property / `RE_FRAME_DEBUG` env var (JVM) are not user knobs — they're the build-time/process-start gates that select the **posture**. Apps DO NOT toggle them per-request or per-session; once the bundle is compiled (or the JVM is started), the posture is fixed.
 
@@ -1270,7 +1271,7 @@ Three of the five surfaces are designed to feed off-box (hosted) backends; the c
 | #2 epoch listener | NO — dev-only; epoch records carry full `:db-before` / `:db-after` snapshots and are not sized for hosted ingestion | Assembled `:rf/epoch-record` per [Tool-Pair §Time-travel](Tool-Pair.md#time-travel-epoch-snapshots-and-undo) | The listener delivers the **raw** record (causal replay material). The `:epoch-history` `:redact-fn` is a projection-side override applied only at off-box egress inside `projected-record` — never at ring-append / listener fan-out — so it does not redact what this listener receives. |
 | #3 event-emit listener | YES — tight record shape, post-elision, exception-isolated. Designed for direct hosted-backend forwarding | `{:event :event-id :frame :time :outcome :elapsed-ms}` | `:event` vector passed through `re-frame.elision/elide-wire-value` once before fan-out (large → `:rf.size/large-elided`; sensitive → `:rf/redacted`). |
 | #4 error-emit listener | YES — same posture and shape contract as #3 | `{:error :event :event-id :frame :time :exception :elapsed-ms}` | Same elision pre-fan-out as #3; `:exception` object is the JS / JVM throwable, not a serialised string. |
-| #5 Performance API channel | INDIRECT — User-Timing measure entries are consumed by host APMs through `PerformanceObserver`; the framework does not emit to a hosted backend directly | Browser-native `PerformanceMeasure` entries with `name` / `startTime` / `duration` / `detail` | No payload — measures carry only timing, not user data. |
+| #5 Performance API channel | INDIRECT — User-Timing measure entries are consumed by host APMs through `PerformanceObserver`; the framework does not emit to a hosted backend directly. Entries are delivered to observers then cleared from the retained buffer (observer-first; see [§Consumer access](#consumer-access)) | Browser-native `PerformanceMeasure` entries with `name` / `startTime` / `duration` (no `detail` is set — the options-bag `measure` call carries only `start` / `end` timestamps) | No payload — measures carry only timing, not user data. |
 
 The off-box egress contract above is the **only documented production wire**. Apps that need richer production observability than #3 / #4 / #5 provide must either (a) keep the dev-only trace surface in production via `:closure-defines {goog.DEBUG true}` (with the bundle-size cost — see [§Production-elision verification](#production-elision-verification)) or (b) implement custom emission from their own handlers / interceptors / fx handlers.
 
@@ -1319,7 +1320,7 @@ Dev iteration matters; you don't want trace machinery to slow ordinary feedback 
 
 The trace stream above is dev-only — too noisy for prod, gated on `re-frame.interop/debug-enabled?` (an alias of `goog.DEBUG`). Many apps still want a *separate*, default-off, prod-friendly timing channel: one that surfaces in Chrome DevTools' Performance panel alongside React renders, network, and paint, and that consumers (the host's APM, a custom `PerformanceObserver`, an in-app perf overlay) can read via the standard browser [User Timing](https://developer.mozilla.org/en-US/docs/Web/API/Performance_API/User_timing) surface.
 
-re-frame2 ships that channel through the browser's `performance.mark` / `performance.measure`, gated on a **second** compile-time constant — `re-frame.performance/enabled?` — that is independent of `goog.DEBUG`. The default is off; consumers opt in by flipping the `goog-define` via `:closure-defines`. Closure DCE then either keeps the bracket sites or elides them entirely; production binaries that don't ask for timing carry zero User-Timing instrumentation.
+re-frame2 ships that channel through the browser's `performance.measure` (options-bag form, no marks — see [§What gets bracketed](#what-gets-bracketed)), gated on a **second** compile-time constant — `re-frame.performance/enabled?` — that is independent of `goog.DEBUG`. The default is off; consumers opt in by flipping the `goog-define` via `:closure-defines`. Closure DCE then either keeps the bracket sites or elides them entirely; production binaries that don't ask for timing carry zero User-Timing instrumentation.
 
 This is **distinct from** the trace surface above:
 
@@ -1333,14 +1334,15 @@ This is **distinct from** the trace surface above:
 
 The two flags compose: a build that wants both flips both. A typical prod build has `goog.DEBUG=false` and either `re-frame.performance/enabled?` true (perf timing kept; trace elided) or false (everything elided).
 
-### The compile-time flag
+### The compile-time flags
 
 ```clojure
 ;; src/re_frame/performance.cljc
-(goog-define ^boolean enabled? false)
+(goog-define ^boolean enabled?        false)   ; the channel gate
+(goog-define ^boolean retain-entries? false)   ; keep entries in the retained buffer
 ```
 
-A consumer flips it in their shadow-cljs.edn / compiler-options:
+A consumer flips the channel gate in their shadow-cljs.edn / compiler-options:
 
 ```edn
 {:builds {:app {:target           :browser
@@ -1349,6 +1351,8 @@ A consumer flips it in their shadow-cljs.edn / compiler-options:
 ```
 
 Like `goog.DEBUG`, `:advanced` constant-folds the value, the gated branch DCEs, and the body collapses to its un-bracketed shape — for the perf surface that means each call site becomes a direct invocation of the body it brackets.
+
+`retain-entries?` is a second, independent `goog-define` (default `false`). Leave it off for production (RUM) — entries are delivered to observers then cleared so the buffer does not grow. Flip it on (`:closure-defines {re-frame.performance/retain-entries? true}`) only for one-shot DevTools / console workflows that read the retained buffer via `getEntriesByType('measure')`. See [§Consumer access](#consumer-access).
 
 ### What gets bracketed
 
@@ -1364,14 +1368,21 @@ The reference runtime brackets four hot-path call sites. Each runs inside a `(pe
 The bracket shape (when the flag is on at compile time):
 
 ```
-performance.mark(<name>:start)
+start = performance.now()
 try    <body>
 finally
-  performance.mark(<name>:end)
-  performance.measure(<name>, <name>:start, <name>:end)
+  performance.measure(<name>, { start, end: performance.now() })
+  if (!retain-entries?) performance.clearMeasures(<name>)
 ```
 
-The `try/finally` ensures a partial measure entry still lands when the body throws — observability does not become silent on the unhappy path. The thrown exception still propagates after the `:end` mark fires.
+Two design choices bound the entry buffer (per the observer-first contract, [§Consumer access](#consumer-access)):
+
+- **Options-bag `measure`, no marks.** The bracket uses the options-bag form `performance.measure(name, {start, end})` with numeric `performance.now()` timestamps rather than named marks. No `performance.mark` entries are ever allocated — the two marks per bracket were pure buffer growth with no documented consumer (nothing reads the `:start` / `:end` marks). This removes two-thirds of the per-bracket entry churn.
+- **Clear after emit.** Immediately after emitting the measure the bracket clears it by name (`performance.clearMeasures(name)`), unless the consumer flips the `re-frame.performance/retain-entries?` `goog-define` (default off). A live `PerformanceObserver` still receives the entry — observer callbacks fire at `measure()` time, before the clear — so timing is delivered to any attached observer / host APM; the retained buffer that `getEntriesByType('measure')` reads simply does not grow.
+
+The `try/finally` ensures the measure entry is emitted (and delivered to observers) even when the body throws — observability does not become silent on the unhappy path. The thrown exception still propagates after the `finally` runs.
+
+`retain-entries?` (a second `goog-define`, default `false`) is the escape hatch for one-shot **DevTools / console** workflows that read the retained buffer via `performance.getEntriesByType('measure')`: flip it on and the per-emit clear is skipped so entries persist. Long-running (RUM) sessions leave it off and read via a `PerformanceObserver` — see [§Consumer access](#consumer-access).
 
 ### Naming convention
 
@@ -1389,25 +1400,33 @@ Tools that want a per-bucket view split on the second `:`. The shape is **stable
 
 ### Consumer access
 
-```javascript
-// All re-frame entries from the most recent run.
-performance.getEntriesByType('measure')
-  .filter(e => e.name.startsWith('rf:'));
+The channel is **observer-first**: entries are *delivered, not retained*. Each bracket emits its measure and then clears it from the retained buffer (unless `retain-entries?` is on — see [§What gets bracketed](#what-gets-bracketed)), so the primary read is a `PerformanceObserver`, which receives the entry at emit time regardless of the clear:
 
-// Live: a PerformanceObserver fires per emitted entry.
+```javascript
+// Live: a PerformanceObserver fires per emitted entry — the production
+// (RUM) path. Delivery happens at measure() time, before the framework
+// clears the entry from the retained buffer, so the observer sees
+// every rf: measure even with buffer retention off (the default).
 new PerformanceObserver((list) => {
   for (const e of list.getEntriesByType('measure')) {
     if (e.name.startsWith('rf:')) {
-      // entry: { name, startTime, duration, ... }
+      // entry: { name, startTime, duration }
       sendToAPM(e);
     }
   }
 }).observe({ type: 'measure', buffered: true });
+
+// One-shot DevTools / console snapshot: only populated when the app was
+// built with :closure-defines {re-frame.performance/retain-entries? true}.
+// With retention off (the default) this returns [] — the entries were
+// delivered to observers then cleared.
+performance.getEntriesByType('measure')
+  .filter(e => e.name.startsWith('rf:'));
 ```
 
-Chrome DevTools' Performance panel renders the measures as named tracks alongside React renders, network, and paint — no custom UI required.
+Chrome DevTools' Performance panel renders the measures as named tracks alongside React renders, network, and paint — no custom UI required (the panel captures entries as they are emitted, so it too is unaffected by the post-emit clear).
 
-The `User Timing` entry buffer is bounded by the host (Chrome's default is 10000 entries); long-running pages that want every entry should attach a `PerformanceObserver` and offload to durable storage rather than rely on the buffer.
+**Why clear after emit.** The W3C User-Timing registry defines `maxBufferSize` as **Infinite** for `mark` and `measure` entries — the buffer is *not* bounded by the host. An always-on production channel that never cleared would grow the buffer without limit: a multi-hour RUM session would retain millions of entries and leak memory. re-frame2 therefore clears each measure after emit; the retained buffer is bounded by re-frame2, not the host. Long-running pages read via the `PerformanceObserver` above (which is unaffected by the clear) and offload to durable storage; they do not rely on the retained buffer. Consumers that genuinely want a retained buffer for one-shot inspection opt in via `retain-entries?`.
 
 ### Production-elision verification
 
@@ -1416,12 +1435,12 @@ The bundle-isolation contract is enforced in CI by `npm run test:perf-bundle` (t
 1. `:examples/counter` builds the standard counter example under `:advanced` with the perf flag off (the goog-define default).
 2. `:examples/counter-perf` builds the same source under `:advanced` with `:closure-defines {re-frame.performance/enabled? true}`.
 3. `scripts/check-perf-bundle.cjs` greps both bundles. The contract:
-   - **Off bundle** MUST NOT contain `performance.mark`, `performance.measure`, or any `"rf:` entry-name fragment.
-   - **On bundle** MUST contain all three.
+   - **Off bundle** MUST NOT contain `performance.measure`, `clearMeasures`, or any `"rf:` entry-name fragment (and — since the bracket allocates no marks — MUST NOT contain `performance.mark` either, in *both* bundles).
+   - **On bundle** MUST contain `performance.measure`, `clearMeasures`, and the `"rf:` fragment.
 
 Without the on bundle the off-bundle assertion would be vacuous — a refactor that *moved* the strings out of the gated branch would silently turn the negative grep into a false pass. The same dual-bundle methodology that gives the trace-surface elision contract its teeth (per [§Production-elision verification](#production-elision-verification)) extends to the perf surface here.
 
-The browser smoke at `tools/xray/testbeds/perf_counter/spec.cjs` complements the grep: it serves the perf-on bundle, drives a real dispatch through the +/- buttons, and reads `performance.getEntriesByType('measure')` to confirm at least one entry per bucket lands. A passing grep is necessary but not sufficient; the smoke proves the four call sites actually fire under a real cascade.
+A CLJS unit test (`re-frame.performance-cljs-test`) asserts the observer-first contract directly at the macro level: with the flag on and `retain-entries?` off, the retained buffer stays empty after repeated brackets (the clear-after-emit leak fix), and zero `rf:` mark entries are ever allocated (the options-bag form). The emission call-site coverage lives in the nightly `re-frame.performance-emit-nightly-test` (which flips `retain-entries? true` so it can read the entry names synchronously).
 
 ### JVM scope
 


### PR DESCRIPTION
## Summary

Stops the production Performance-API channel from leaking User-Timing entries (bead **rf2-2yv859**, P2 bug from the Run-2 design review, long-run-ops finding 2).

### The leak

`mark-and-measure` (performance.cljc) bracketed every event / sub / fx / render hot path with **2 `performance.mark` + 1 `performance.measure` per invocation and NEVER cleared them**. The W3C User-Timing registry defines `maxBufferSize` as **Infinite** for mark/measure entries, so the retained buffer grew without limit — an 8-hour RUM session retains millions of entries and leaks memory. Spec 009 falsely claimed the buffer was "bounded by the host (Chrome's default is 10000 entries)"; `docs/core/how-to/fix-a-slow-view.md` propagated the same false bound.

### The fix — observer-first, entries delivered not retained

- **Options-bag `measure`, zero marks.** The bracket now uses `performance.measure(name, {start, end})` with numeric `performance.now()` timestamps instead of named marks. No `performance.mark` entries are allocated at all — that removes two-thirds of the per-bracket churn (nothing documented ever read the `:start`/`:end` marks).
- **Clear after emit.** Immediately after emitting, the bracket calls `performance.clearMeasures(name)`, so the retained buffer does not accumulate. A live `PerformanceObserver` still receives the entry (its callback fires at `measure()` time, before the clear) — so timing is delivered to any attached observer / host APM; the buffer just doesn't grow. **This is the real bound: re-frame2 clears after emit, not the (unbounded) host buffer.**
- **`retain-entries?` goog-define (default false).** Escape hatch for one-shot DevTools / console workflows that read the retained buffer via `getEntriesByType('measure')`; flip it on to skip the per-emit clear. Long-running (RUM) sessions leave it off and read via a `PerformanceObserver`.

### Corrected false sentence (spec 009 §Consumer access)

Before: *"The `User Timing` entry buffer is bounded by the host (Chrome's default is 10000 entries)…"*

After: a **Why clear after emit** paragraph stating the W3C `maxBufferSize` is **Infinite** for measure entries — the buffer is *not* host-bounded; re-frame2 clears after emit so the retained buffer is bounded by re-frame2, and long-running pages read via a `PerformanceObserver` (unaffected by the clear). Also fixed the `:detail` drift in the off-box egress table (§ row #5 said entries carry `detail`; the options-bag call sets only `start`/`end`, so no `detail` is emitted).

### Test delta

- `performance_cljs_test.cljs`: replaced the "exactly one measure entry per call" assertion with **`mark-and-measure-clears-after-emit-when-enabled`** (25 brackets → retained buffer stays empty; the leak fix) and added **`mark-and-measure-allocates-no-marks-when-enabled`** (zero `rf:` mark entries; the options-bag form). Updated the throw-propagation test for the new clear-after-emit shape.
- `performance_emit_nightly_test.cljs`: the emission runner now flips `retain-entries? true` (added to the `:node-test-perf-nightly` closure-defines) so it can read entry names/buckets synchronously; canary now asserts both `enabled?` and `retain-entries?` are flipped.
- `check-perf-bundle.cjs` + shadow-cljs.edn comments: sentinels updated from `performance.mark` → `performance.measure` + `clearMeasures` (the OFF bundle must now contain *no* `performance.mark` in either build).

## Quality gates

- `npm run test:cljs` — **PASS** (8043 tests / 36964 assertions, 0 failures).
- `npx shadow-cljs compile node-test-perf-nightly && node out/node-test-perf-nightly.js` — **PASS** (5 tests / 14 assertions, 0 failures). This is the real browser-API exercise: it emits via the options-bag `measure`, retains entries, and verifies every `rf:event|sub|fx` bucket + entry name.
- `npm run test:perf-bundle` — **PASS** (`off-count=0; on-count=8` — OFF bundle carries zero perf instrumentation; ON bundle carries `performance.measure` / `clearMeasures` / `"rf:`).
- `npm run test:elision` — **PASS** (`production 45/45 absent`; perf stays dev-axis, no prod-bundle leak).
- `mkdocs build --strict` — **PASS** (009 + how-to touched; exit 0).
- `npm run test:browser` — not run: the perf path's only platform behaviour is the User-Timing emission, which is exercised headlessly by the nightly node runner above (Node `perf_hooks` implements the same options-bag `measure` + `clearMeasures`). Relying on CI for any browser-specific coverage.
