### PR TITLE
docs(spec): reconcile 008 test-primitive ownership (rf2-pk14u2)

### DIFF
--- a/spec/008-Testing.md
+++ b/spec/008-Testing.md
@@ -757,20 +757,26 @@ A test fixture is a story-variant minus the rendering — the story library's `r
 
 > Forward-reference normative section (NewTestStory EPIC). The
 > Story-as-test work introduces a variant-plan execution model and a set
-> of low-level evidence tools. The tools below live **at the testing-
-> substrate level**, below Story, and run without the Story UI; Story
-> consumes them but does not own them. The full Story-facing contract —
-> variant plans, the three execution verbs (`run` / `is` / `explain`),
-> `:cannot-run`, composition, the schema floor, and the run-result shape
-> — is normative in
-> [`tools/story/spec/017-Testing-Story.md`](../tools/story/spec/017-Testing-Story.md).
-> This section states the substrate primitives that contract depends on,
-> kept consistent with the existing 008 surfaces (`re-frame.test-support`
-> / `re-frame.test-helpers` / `compute-sub`). These primitives have
-> landed — `settled-boundary`, the invariant sentinels / `first-bad-epoch`,
-> the run-artifact replay / determinism utilities, and `canonicalize` are
-> all shipped and build on the always-on substrate seams (`dispatch-sync`,
-> the epoch-listener seam, the one epoch tape) named below.
+> of evidence tools. **These tools are Story-owned** — they ship in the
+> `re-frame.story.*` namespaces under `tools/story/src` and their full
+> contract is normative in
+> [`tools/story/spec/017-Testing-Story.md`](../tools/story/spec/017-Testing-Story.md)
+> (variant plans, the three execution verbs `run` / `is` / `explain`,
+> `:cannot-run`, composition, the schema floor, and the run-result shape).
+> They run headless, without the Story UI, so a plain `clojure.test` /
+> `cljs.test` suite reaches them without mounting a Story — but the code
+> lives in, and is owned by, the Story tool. What lives **below** Story,
+> in `re-frame.core`, is the set of always-on **substrate seams** these
+> tools build on: `dispatch-sync`'s run-to-fixed-point drain, the
+> epoch-listener seam, and the one epoch tape. This section documents that
+> Story-facing surface from the 008 side because it is the general
+> testing-substrate counterpart of the 008 helpers
+> (`re-frame.test-support` / `re-frame.test-helpers` / `compute-sub`) — it
+> describes the tools, it does not relocate their ownership. These
+> primitives have landed — `settled-boundary`, the invariant sentinels /
+> `first-bad-epoch`, the run-artifact replay / determinism utilities, and
+> `canonicalize` are all shipped in `re-frame.story.*` and build on the
+> substrate seams named above.
 
 ### `settled-boundary`
 
@@ -819,12 +825,13 @@ below).
 
 ### Invariant sentinels and first-bad-epoch
 
-The testing substrate SHOULD add two evidence utilities over committed
-epochs:
+Story adds two evidence utilities over committed epochs (shipped in
+`re-frame.story.invariants`, building on the epoch-listener seam this
+Spec provides):
 
 ```clojure
-(test/with-invariants [invariant-spec ...] body...)
-(test/first-bad-epoch epoch-tape invariant)
+(with-invariants [invariant-spec ...] body...)
+(first-bad-epoch epoch-tape invariant)
 ```
 
 Invariants run after each committed epoch (via the existing epoch-listener
@@ -836,12 +843,15 @@ event, db-diff, and trace events), or `nil`.
 
 ### Run-artifact replay and determinism gate
 
-The testing substrate SHOULD add three pure-over-evidence utilities:
+Story adds three pure-over-evidence utilities (shipped across
+`re-frame.story.artifact` / `re-frame.story.determinism` /
+`re-frame.story.diff`, consuming the Story play-runner and the one epoch
+tape):
 
 ```clojure
-(test/replay-run-artifact   artifact opts)
-(test/assert-deterministic  plan-or-artifact opts)   ; N fresh runs, compared via canonicalize
-(test/diff-run-artifacts    baseline current opts)
+(replay-run-artifact   artifact opts)
+(assert-deterministic  plan-or-artifact opts)   ; N fresh runs, compared via canonicalize
+(diff-run-artifacts    baseline current opts)
 ```
 
 A **run artifact** is the low-level evidence emitted by generated tests,

--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -2455,12 +2455,18 @@ slot is what makes the round-trip succeed (§Run artifact and replay).
 
 ## Unit and integration testing adjustments
 
-The general testing-substrate counterpart of these additions
-(inline-plan execution surface, invariant sentinels, first-bad-epoch,
-run-artifact replay/determinism, and the cookbook) is owned by
+These additions (inline-plan execution surface, invariant sentinels,
+first-bad-epoch, run-artifact replay/determinism, and the cookbook) are
+**Story-owned** — they ship in the `re-frame.story.*` namespaces and are
+normative here in 017.
 [`spec/008-Testing.md`](../../../spec/008-Testing.md) §Story plan
-execution surface and evidence tools — those tools live **below** Story
-and run without the Story UI. Story consumes them; it does not own them.
+execution surface and evidence tools documents them from the general
+testing-substrate side, as the counterpart of the 008 helpers, and
+cross-links back here for the owning contract. What lives **below** Story
+is the set of always-on substrate seams these tools build on
+(`dispatch-sync`'s drain, the epoch-listener seam, the one epoch tape);
+the tools themselves run headless — without the Story UI — but the code
+is owned by the Story tool.
 
 Equivalent inline plans and registered variants SHOULD be testable as a
 **metamorphic relation**: when they describe the same behaviour and


### PR DESCRIPTION
Reconciles a spec-vs-reality contradiction flagged by rf2-9zr7s6: `spec/008-Testing.md` framed the P1 test primitives as living "below Story ... Story consumes them but does not own them," but all four shipped inside `tools/story/src` under `re-frame.story.*` and are specced in Story's own spec (017). This is **direction (a)** — fix the stale prose to match shipped reality; no code relocation.

## What was reconciled

**`spec/008-Testing.md`**
- The `## Story plan execution surface and evidence tools` forward-reference block: replaced "The tools below live at the testing-substrate level, below Story ... Story consumes them but does not own them" with an accurate framing — the tools **are Story-owned** (`re-frame.story.*` under `tools/story/src`, normative in 017); what lives **below** Story in `re-frame.core` is the always-on **substrate seams** they build on (`dispatch-sync`'s drain, the epoch-listener seam, the one epoch tape). 008 documents them from the substrate side as the counterpart of the 008 helpers; it does not relocate ownership.
- `### Invariant sentinels and first-bad-epoch`: "The testing substrate SHOULD add ..." → "Story adds ... (shipped in `re-frame.story.invariants`)". Dropped the aspirational `test/` alias from the code samples (bare `with-invariants` / `first-bad-epoch`, matching the shipped def names).
- `### Run-artifact replay and determinism gate`: same treatment — "Story adds ... (shipped across `re-frame.story.artifact` / `re-frame.story.determinism` / `re-frame.story.diff`)".

**`tools/story/spec/017-Testing-Story.md`**
- `## Unit and integration testing adjustments`: this passage self-contradicted — it said the tools "live below Story ... it does not own them" while, ~15 lines later, stating `with-invariants` / `first-bad-epoch` "both live in `re-frame.story.invariants`." Rewrote it to say the additions are **Story-owned** and normative in 017; 008 documents them from the substrate side and cross-links back here for the owning contract.

## Why direction (a), not (b)

Verified before rewriting:
- All four primitives are `re-frame.story.*` namespaces under `tools/story/src` (`settled_boundary.cljc`, `invariants.cljc`, `artifact.cljc`, `determinism.cljc`, `fingerprint.cljc`).
- `artifact` and `determinism` **depend on Story internals** (`re-frame.story.play.runner`, `re-frame.story.play.evidence`, `re-frame.story.fingerprint`) — they structurally cannot live below Story without dragging the play-runner down. Relocating them (direction b) would mean relocating the whole runner: clearly wrong.
- **No consumer outside `tools/story`** requires any of them — there is no lower layer that needs them, so "below Story" served no one.
- The def names in the reconciled code samples match the shipped functions exactly.

No behavioural claim was weakened; the substrate seams that genuinely live below Story (dispatch-sync drain, epoch-listener seam, one epoch tape) are still named as the foundation these Story-owned tools build on.

## Quality gates
- `mkdocs build --strict` — **not run locally** (mkdocs not installed on this machine); relying on CI. Edits are prose-only within existing markdown structure — no new links, no heading/slug changes.
- `check_doc_slugs.py` — **PASS** (exit 0) on the edited tree; pymdownx slugifier available locally.
