### PR TITLE
docs: pipeline-vocab docstring residue (rf2-6i5fcc)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -2360,27 +2360,27 @@
 
 #?(:clj
    (do
-     (def ^{:doc "Return the named frame's cascade-keyed trace ring,
+     (def ^{:doc "Return the named frame's event-keyed trace ring,
        oldest-first. Two arities:
 
          (rf/trace-buffer frame-id)
-           Returns cascade bundles by default — one entry per retained
-           cascade with the cascade's `:dispatch-id`, raw `:trace-events`,
+           Returns event bundles by default — one entry per retained
+           event bundle with the run's `:dispatch-id`, raw `:trace-events`,
            and the projected six-domino slots (`:event`, `:dispatched`,
            `:handler`, `:fx`, `:effects`, `:subs`, `:renders`, `:other`).
 
          (rf/trace-buffer frame-id opts)
            `opts` is a filter map. `{:flat true}` returns raw trace
-           events instead of cascade bundles. The full filter
+           events instead of event bundles. The full filter
            vocabulary lives in Spec 009 §Filter vocabulary.
 
        Returns `[]` for a destroyed or never-registered frame, and `[]`
        in production (the ring is never allocated under
        `goog.DEBUG=false`). JVM-only alias — CLJS callers use
        `re-frame.trace.tooling/trace-buffer` directly. Per Spec 009
-       §Per-frame trace rings (cascade-keyed, dev-only)."}
+       §Per-frame trace rings (event-keyed, dev-only)."}
        trace-buffer           trace/trace-buffer)
-     (def ^{:doc "Empty the named frame's cascade-keyed trace ring.
+     (def ^{:doc "Empty the named frame's event-keyed trace ring.
        Tooling uses this between sessions. No-op for an unknown frame,
        no-op in production. JVM-only alias — CLJS callers use
        `re-frame.trace.tooling/clear-trace-buffer!` directly. Per Spec

--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -2496,7 +2496,7 @@
         ;; The shipped subsystems tear down via the named ordered hooks above.
         (emit-frame-destroyed-trace! id)
         ;; Per Spec 009 §Per-frame trace rings:
-        ;; release the destroyed frame's cascade-keyed ring so no
+        ;; release the destroyed frame's event-keyed ring so no
         ;; residual trace events leak across the frame lifecycle. Fired
         ;; AFTER `:rf.frame/destroyed` emits so the destroyed trace
         ;; itself (which is frameless and bypasses the ring anyway)

--- a/implementation/core/test/re_frame/elision_probe.cljs
+++ b/implementation/core/test/re_frame/elision_probe.cljs
@@ -97,7 +97,7 @@
   (trace-tooling/register-listener! ::probe (fn [_ev] nil))
   (rf/emit-trace-event! :event :rf.probe/touched {:source :probe})
   (trace-tooling/unregister-listener! ::probe)
-  ;; rf2-g1b2m / rf2-8uwce — per-frame cascade-keyed trace rings (Spec 009).
+  ;; rf2-g1b2m / rf2-8uwce — per-frame event-keyed trace rings (Spec 009).
   ;; These public entry points must elide their bodies in production.
   (trace-tooling/configure-trace-buffer! {:events-retained 50})
   (let [_buf (trace-tooling/trace-buffer :rf/default {:op-type :rf.event :flat true})]

--- a/implementation/core/test/re_frame/trace_buffer_test.clj
+++ b/implementation/core/test/re_frame/trace_buffer_test.clj
@@ -1,16 +1,16 @@
 (ns re-frame.trace-buffer-test
-  "Per-frame cascade-keyed trace ring tests (rf2-g1b2m spec + rf2-8uwce
+  "Per-frame event-keyed trace ring tests (rf2-g1b2m spec + rf2-8uwce
   impl).
 
   Three deliverables in one suite:
     1. Per-frame ring: event-bundle reads, `:flat` opt, eviction by
-       cascade, filter vocab, configure knob, clear, elision.
+       event bundle, filter vocab, configure knob, clear, elision.
     2. `:rf.trace/dispatch-id` allocation + parent-dispatch-id linkage.
     3. `:origin` / `:source` opts ride trace events. Per rf2-1ve9h
        the prior parallel `:rf/dispatch-origin` axis was collapsed
        into `:source` — see `dispatch-source-*` deftests below.
 
-  Per Spec 009 §Per-frame trace rings (cascade-keyed, dev-only) and
+  Per Spec 009 §Per-frame trace rings (event-keyed, dev-only) and
   §Dispatch correlation. JVM-only by intent — the trace + router
   machinery is platform-agnostic and CLJS adds no signal."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
@@ -90,16 +90,16 @@
       (is (some #(= :rf.event/dispatched (:operation %)) evs)
           "the :rf.event/dispatched trace lands in the flat stream"))))
 
-;; ---- 1b. Cascade-keyed eviction ------------------------------------------
+;; ---- 1b. Event-keyed eviction --------------------------------------------
 
-(deftest cascade-keyed-eviction
-  (testing "ring evicts by CASCADE slot, not by raw event count"
+(deftest event-keyed-eviction
+  (testing "ring evicts by EVENT-BUNDLE slot, not by raw event count"
     (rf/configure! {:trace-buffer {:events-retained 3}})
     (rf/reg-event :ping (fn [{:keys [db]} _] {:db db}))
     (dotimes [_ 10] (rf/dispatch-sync [:ping]))
-    (let [cascades (rf/trace-buffer :rf/default)]
-      (is (= 3 (count cascades))
-          (str "ring caps at 3 cascade slots; got " (count cascades))))))
+    (let [bundles (rf/trace-buffer :rf/default)]
+      (is (= 3 (count bundles))
+          (str "ring caps at 3 event-bundle slots; got " (count bundles))))))
 
 (deftest cascade-burst-cannot-evict-prior-cascades
   (testing "a single cascade's burst of :rf.sub/skip-like noise can't displace OTHER cascades"

--- a/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
+++ b/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
@@ -1520,10 +1520,10 @@
 ;; Topic semantics:
 ;;   :trace     — every event in the raw trace stream matching `:filter`
 ;;                (filter map mirrors `(re-frame.trace.tooling/trace-buffer)` filter vocab —
-;;                see the trace-buffer surface). Cascade-bundle delivery:
+;;                see the trace-buffer surface). Event-bundle delivery:
 ;;                per drain, matched events are grouped by
-;;                `:rf.trace/dispatch-id` and projected into one cascade
-;;                bundle per cascade (`group-cascades` shape with a
+;;                `:rf.trace/dispatch-id` and projected into one event
+;;                bundle per run (`group-by-event` shape with a
 ;;                `:trace-events` slot carrying the raw events). Events
 ;;                without a `:rf.trace/dispatch-id` tag (frameless
 ;;                registry / lifecycle emits) NEVER ride this topic —
@@ -1531,13 +1531,13 @@
 ;;   :epoch     — every assembled `:rf/epoch-record` matching `:filter`
 ;;                (filter map mirrors `epoch-matches?` — see watch-epochs).
 ;;                One event per committed epoch. `:rf/epoch-record` is
-;;                already a cascade-bundle by construction.
+;;                already an event-bundle by construction.
 ;;   :fx        — sugar for `:topic :trace :filter {:op-type :rf.fx}` with
 ;;                optional `:fx-id` and `:event-id` axes from the trace
-;;                filter vocabulary. Cascade-bundle delivery as for :trace.
+;;                filter vocabulary. Event-bundle delivery as for :trace.
 ;;   :error     — sugar for `:topic :trace :filter {:op-type :error}`,
 ;;                with `:event-id`/`:handler-id`/`:source` available.
-;;                Cascade-bundle delivery as for :trace.
+;;                Event-bundle delivery as for :trace.
 ;;   :frameless — every trace event matching `:filter` whose
 ;;                `:rf.trace/dispatch-id` tag is absent. Registration
 ;;                emits, REPL evals, lifecycle outside any cascade flow
@@ -1667,43 +1667,43 @@
 ;; Cascade-bundle projection
 ;; ---------------------------------------------------------------------------
 ;;
-;; Per Spec 009 §Cascade projection and Tool-Pair §Reading the per-frame
-;; trace ring, the wire-delivery unit for the streaming subscribe is
-;; the cascade bundle (one entry per `:rf.trace/dispatch-id`) rather
-;; than the flat per-event slice. We mirror the framework's per-frame
-;; trace-ring shape: `rf/group-cascades` projection PLUS a
+;; Per Spec 009 §Event-bundle projection and Tool-Pair §Reading the
+;; per-frame trace ring, the wire-delivery unit for the streaming
+;; subscribe is the event bundle (one entry per `:rf.trace/dispatch-id`)
+;; rather than the flat per-event slice. We mirror the framework's
+;; per-frame trace-ring shape: `rf/group-by-event` projection PLUS a
 ;; `:trace-events` slot carrying the raw events.
 ;;
 ;; The bundling happens at drain time (not enqueue), so the per-event
 ;; queue's byte+event budget still works as the upstream bound — an
-;; oversized cascade still evicts oldest events per the documented
+;; oversized run still evicts oldest events per the documented
 ;; policy. Each bundle's `:trace-events` slot carries ONLY the events
 ;; that survived eviction.
 ;;
 ;; Frameless events (`:rf.trace/dispatch-id` tag absent) NEVER ride
-;; cascade-bundle topics — `dispatch-trace-to-subs!` filters them out
+;; event-bundle topics — `dispatch-trace-to-subs!` filters them out
 ;; for those topics. The `:frameless` topic exists to deliver them
 ;; explicitly (Tool-Pair §Frameless trace events — live channel only).
 
 (defn- frameless-event?
   "True when `ev` carries no `:rf.trace/dispatch-id` tag — a registration
    emit, REPL eval, or lifecycle event that never rode a dispatch
-   cascade. The cascade-bundle topics filter these out; the `:frameless`
+   run. The event-bundle topics filter these out; the `:frameless`
    topic accepts only these."
   [ev]
   (nil? (get-in ev [:tags :rf.trace/dispatch-id])))
 
-(defn- cascade-bundle-events
-  "Group a vector of raw trace events into cascade-bundle maps matching
+(defn- event-bundle-events
+  "Group a vector of raw trace events into event-bundle maps matching
    the framework's `(rf/trace-buffer frame-id)` shape — the
-   `group-cascades` projection PLUS a `:trace-events` slot carrying the
-   raw events for the cascade. The returned vector is sorted by emission
+   `group-by-event` projection PLUS a `:trace-events` slot carrying the
+   raw events for the run. The returned vector is sorted by emission
    order (lowest `:id` first, the order the projection returns).
 
-   Delegates the grouping entirely to `rf/group-cascades-with-events` —
-   the framework projection that keys cascades by `[frame dispatch-id]`.
+   Delegates the grouping entirely to `rf/group-by-event-with-events` —
+   the framework projection that keys bundles by `[frame dispatch-id]`.
    This is load-bearing: dispatch ids are unique only WITHIN a frame
-   (the portable trace contract), so two cascades sharing a dispatch id
+   (the portable trace contract), so two runs sharing a dispatch id
    across frames are distinct bundles, each carrying only its own frame's
    raw `:trace-events`. Grouping by `:rf.trace/dispatch-id` alone would
    merge foreign-frame events into both bundles the moment per-frame id
@@ -1711,7 +1711,7 @@
    framework key, never re-derive a weaker one.
 
    Events whose `:rf.trace/dispatch-id` tag is missing are NOT included
-   — the caller is expected to have filtered them upstream (cascade-
+   — the caller is expected to have filtered them upstream (event-
    bundle topics) or routed them to the frameless channel."
   [events]
   (->> (rf/group-by-event-with-events events)
@@ -1992,12 +1992,12 @@
   "Pop every queued event for `sub-id` and return them in order.
    Returns one of two envelopes per the sub's topic:
 
-   - Cascade-bundle topics (`:trace`/`:fx`/`:error`):
+   - Event-bundle topics (`:trace`/`:fx`/`:error`):
      `{:ok? true :sub-id ... :cascades [<bundle> ...] :dropped-events <n>
        :dropped-bytes <m> :overflow-reason <kw|nil> :gone? bool}`
      — queued raw events are grouped by `:rf.trace/dispatch-id` and
-     projected into cascade bundles (`group-cascades` shape with a
-     `:trace-events` slot) per Spec 009 §Cascade projection.
+     projected into event bundles (`group-by-event` shape with a
+     `:trace-events` slot) per Spec 009 §Event-bundle projection.
 
    - Flat topics (`:epoch`/`:frameless`):
      `{:ok? true :sub-id ... :events [...] :dropped-events <n>
@@ -2015,10 +2015,10 @@
    tripped (`:max-buffered-events` or `:max-buffered-bytes`); the
    `:dropped-bytes` figure tells them how much state they missed.
 
-   Note on cascade-bundle counters: `:dropped-events` counts the raw
-   trace events evicted from the queue, NOT cascades. An evicted event
-   may have left its sibling cascade-members in place — consumers
-   reconstructing a cascade should be tolerant of partially-truncated
+   Note on event-bundle counters: `:dropped-events` counts the raw
+   trace events evicted from the queue, NOT bundles. An evicted event
+   may have left its sibling run-members in place — consumers
+   reconstructing a run should be tolerant of partially-truncated
    bundles when `:dropped-events` is non-zero."
   [sub-id]
   ;; Atomically reset the drained sub's queue + counters and capture the
@@ -2044,14 +2044,14 @@
                   :overflow-reason overflow-reason
                   :gone?           false}]
         (cond
-          ;; Cascade-bundle delivery — group raw queued
+          ;; Event-bundle delivery — group raw queued
           ;; trace events by `:rf.trace/dispatch-id` into bundles. The
-          ;; cascade-bundle topics never enqueue frameless events
+          ;; event-bundle topics never enqueue frameless events
           ;; (`dispatch-trace-to-subs!` filters them out at the gate),
-          ;; so `cascade-bundle-events`'s `:ungrouped`-drop is purely
+          ;; so `event-bundle-events`'s `:ungrouped`-drop is purely
           ;; defensive.
           (contains? #{:trace :fx :error} topic)
-          (assoc base :cascades (cascade-bundle-events queue))
+          (assoc base :cascades (event-bundle-events queue))
 
           ;; Flat delivery — :epoch and :frameless.
           :else
@@ -2098,19 +2098,19 @@
 
 (defn cascade-of
   "Reconstruct the cascade tree from a root `:dispatch-id` by walking
-   the per-frame trace-ring cascade bundles for matching parent links.
+   the per-frame trace-ring event bundles for matching parent links.
    Returns a tree of `{:dispatch-id <id> :event <ev> :children [...]}`.
 
-   The trace ring is per-frame and cascade-keyed; the read unit is the
-   cascade bundle (`group-cascades` shape).
+   The trace ring is per-frame and event-keyed; the read unit is the
+   event bundle (`group-by-event` shape).
    A single cascade can fan out across frames (per Spec 002
    §Cross-frame dispatch) — every emit on every frame shares the same
    `:rf.trace/dispatch-id`, so cross-frame reconstruction iterates
    every registered frame's bundles and merges by `:dispatch-id`.
    Per-frame depth is configurable via
-   `(rf/configure! {:trace-buffer {:cascades-retained N}})`."
+   `(rf/configure! {:trace-buffer {:events-retained N}})`."
   [root-dispatch-id]
-  (let [;; Per-frame rings, cascade-bundle reads — merge across
+  (let [;; Per-frame rings, event-bundle reads — merge across
         ;; frames so cross-frame cascades reconstruct correctly. Each
         ;; bundle carries `:parent-dispatch-id` (the causal-parent
         ;; link) and `:dispatched :tags :rf.event/origin` directly,
@@ -4441,8 +4441,8 @@
                                 {})]
                   {:ids ids :state state})
     :epochs     (vec (rf/epoch-history frame-id))
-    ;; The trace ring is per-frame and cascade-bundle-shaped: this slot
-    ;; delivers bundles (the storage unit), matching the cascade-bundle
+    ;; The trace ring is per-frame and event-bundle-shaped: this slot
+    ;; delivers bundles (the storage unit), matching the event-bundle
     ;; wire format emitted by the streaming subscribe surface (Tool-Pair
     ;; §Reading the per-frame trace ring + Tool-Pair §`watch-epochs` /
     ;; `trace-window` consumer shape).

--- a/skills/re-frame2-pair/references/mcp-transport.md
+++ b/skills/re-frame2-pair/references/mcp-transport.md
@@ -155,7 +155,7 @@ Use the per-op reads when:
 - **`:path-sliced` (with `path`)** — the slot is `(get-in db path)`. Out-of-range paths surface per-frame in a top-level `:path-not-found` map with `:deepest-valid-prefix` so the agent can re-aim without a binary search.
 - **Root path `path: "[]"`** — explicit request for the full `:app-db`. A **last resort** (large on any real app frame; refused against a reserved `:rf/*` tool frame). Orient first, then slice. The wire cap is the backstop.
 
-The other slices (`:sub-cache`, `:machines`, `:epochs`) pass through unchanged. The `:traces` slice now ships **cascade bundles by default** (`{:dispatch-id :frame :event :dispatched :handler :fx :effects :subs :renders :other :trace-events :parent-dispatch-id}` per cascade — the framework's `(re-frame.trace.tooling/trace-buffer frame-id)` shape and the same wire format the `subscribe` streaming surface emits on cascade-bundle topics).
+The other slices (`:sub-cache`, `:machines`, `:epochs`) pass through unchanged. The `:traces` slice now ships **event bundles by default** (`{:dispatch-id :frame :event :dispatched :handler :fx :effects :subs :renders :other :trace-events :parent-dispatch-id}` per run — the framework's `(re-frame.trace.tooling/trace-buffer frame-id)` shape and the same wire format the `subscribe` streaming surface emits on event-bundle topics).
 
 Use `get-path` (next section) when you already know the addressed subtree — it's a single-slice round-trip rather than the multi-slice composition `snapshot` does.
 

--- a/skills/re-frame2-pair/references/streaming-subscriptions.md
+++ b/skills/re-frame2-pair/references/streaming-subscriptions.md
@@ -43,7 +43,7 @@ Five topics, two underlying buses.
 
 The `:fx` and `:error` topics are convenience sugar — they pre-pin the `:op-type` filter so you can layer additional trace-vocab keys on top.
 
-**Cascade-bundle vs flat delivery.** On `:trace` / `:fx` / `:error` each tick's matched events ship **grouped by `:rf.trace/dispatch-id` into cascade bundles** (matching the `(re-frame.trace.tooling/trace-buffer frame-id)` shape — `:dispatch-id :frame :event :dispatched :handler :fx :effects :subs :renders :other :trace-events :parent-dispatch-id`); the progress payload's load slot is `:cascades`. `:epoch` and `:frameless` ship flat as `:events`. **Frameless events NEVER ride the cascade-bundle topics** — opt into the `:frameless` topic explicitly to see registration / REPL / lifecycle events that belong to no cascade.
+**Event-bundle vs flat delivery.** On `:trace` / `:fx` / `:error` each tick's matched events ship **grouped by `:rf.trace/dispatch-id` into event bundles** (matching the `(re-frame.trace.tooling/trace-buffer frame-id)` shape — `:dispatch-id :frame :event :dispatched :handler :fx :effects :subs :renders :other :trace-events :parent-dispatch-id`); the progress payload's load slot is `:cascades`. `:epoch` and `:frameless` ship flat as `:events`. **Frameless events NEVER ride the event-bundle topics** — opt into the `:frameless` topic explicitly to see registration / REPL / lifecycle events that belong to no run.
 
 Use `:epoch` for assembled cascades (with their `:sub-runs` / `:renders` / `:effects` projections); use `:trace` (or its sugar) for raw trace-event detail (handler timings, registry traces, sub-cache events — the things the projection drops).
 
@@ -105,7 +105,7 @@ The structured drop counts live under **`_meta.data`**, not a top-level `data` s
 
 The `message` slot is an EDN-printed **map** (not a bare vector). It carries `:sub-id` plus the delivered batch under exactly one topic-dependent slot:
 
-- `:cascades` — on the cascade-bundle topics (`:trace` / `:fx` / `:error`): a vector of cascade bundles, each matching the `(rf/trace-buffer frame-id)` shape (`:dispatch-id :frame :event :dispatched :handler :fx :effects :subs :renders :other :trace-events :parent-dispatch-id`).
+- `:cascades` — on the event-bundle topics (`:trace` / `:fx` / `:error`): a vector of event bundles, each matching the `(rf/trace-buffer frame-id)` shape (`:dispatch-id :frame :event :dispatched :handler :fx :effects :subs :renders :other :trace-events :parent-dispatch-id`).
 - `:events` — on the flat topics (`:epoch` / `:frameless`): a flat vector (`:rf/epoch-record` maps for `:epoch`; raw trace events for `:frameless`).
 
 So a `:epoch` tick's `message` reads as `{:sub-id "<uuid>" :events [<epoch-record> ...] :dedup <bool> :dropped-events <n> :dropped-bytes <n>}`, and a `:trace`/`:fx`/`:error` tick reads as `{:sub-id "<uuid>" :cascades [<bundle> ...] :dedup <bool> ...}`. The `:dedup` flag signals whether the slot was structurally deduped (reconstruct via `(de-dupe.core/expand cache-map)`); `:overflow-reason` rides the map too when a budget tripped. The agent reads `message` directly; capable hosts can additionally inspect `_meta.data` for the structured counts.

--- a/skills/re-frame2-pair/references/wire-size-budget.md
+++ b/skills/re-frame2-pair/references/wire-size-budget.md
@@ -45,7 +45,7 @@ no extra round-trip to the runtime.
 `watch-epochs`; the per-tick subscribe payload slot on `subscribe`.
 That slot is **topic-dependent** (per `streaming-subscriptions.md`):
 `:events` for the flat topics (`:epoch` / `:frameless`), `:cascades`
-for the cascade-bundle topics (`:trace` / `:fx` / `:error`). A host
+for the event-bundle topics (`:trace` / `:fx` / `:error`). A host
 decoding subscribe dedup must look under whichever slot the topic
 delivers, not `:events` alone. Opt out via `dedup false` if your host hasn't been taught the marker.
 

--- a/skills/re-frame2-pair/tests/prompts/prompt_regression_test.clj
+++ b/skills/re-frame2-pair/tests/prompts/prompt_regression_test.clj
@@ -391,10 +391,10 @@
 ;;
 ;; wire-size-budget.md must describe the SAME topic-dependent
 ;; subscribe payload slot as streaming-subscriptions.md: `:events` for the
-;; flat topics (epoch/frameless) and `:cascades` for the cascade-bundle
+;; flat topics (epoch/frameless) and `:cascades` for the event-bundle
 ;; topics (trace/fx/error). A host decoding subscribe dedup off the
 ;; size-budget leaf that only knew `:events` would leave trace/fx/error
-;; cascade ticks unexpanded. Mirrors the streaming-subscriptions guard above.
+;; event-bundle ticks unexpanded. Mirrors the streaming-subscriptions guard above.
 
 (deftest wire-size-budget-names-both-subscribe-slots
   (testing "wire-size-budget.md subscribe dedup names both :events and :cascades (rf2-a85bb2 finding 2)"
@@ -403,7 +403,7 @@
         (str "wire-size-budget.md must document the topic-dependent subscribe "
              "payload slot — :events (epoch/frameless) AND :cascades "
              "(trace/fx/error) — not :events alone, or a host will leave "
-             "cascade-bundle dedup ticks unexpanded (rf2-a85bb2)."))))
+             "event-bundle dedup ticks unexpanded (rf2-a85bb2)."))))
 
 ;; Finding 3 — the render-source-coord recipe must NOT tell an agent to pass
 ;; the whole `:render-key` tuple to `handler-meta {kind: "view"}`. The schema

--- a/skills/re-frame2-pair/tests/runtime/snapshot_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/snapshot_test.clj
@@ -67,13 +67,13 @@
 (defn stub-epoch-history [fid] (get-in fixture-frames [fid :epochs]))
 (defn stub-machines [] [:auth :session]) ;; global registrar surface
 (defn stub-trace-buffer
- "The framework's `trace-buffer` is per-frame and cascade-keyed; the
+ "The framework's `trace-buffer` is per-frame and event-keyed; the
  frame-id is the required first arg. The snapshot `:traces` slice ships
- cascade-bundles by default (the framework's storage unit), matching the
+ event bundles by default (the framework's storage unit), matching the
  streaming subscribe wire shape. This stub returns the fixture's `:traces`
  vector directly — the loosely-typed stub is shape-agnostic; the
  production snapshot slice calls `(trace-tooling/trace-buffer
- frame-id)` (zero-arg opts) for the cascade-bundle default."
+ frame-id)` (zero-arg opts) for the event-bundle default."
  ([frame-id] (stub-trace-buffer frame-id {}))
  ([frame-id _opts]
  (filter #(= frame-id (get-in % [:tags :frame]))
@@ -112,7 +112,7 @@
  {})}
  :epochs (vec (stub-epoch-history frame-id))
  ;; The trace ring is per-frame; the snapshot `:traces` slice ships
- ;; cascade-bundles by default (the framework's storage unit, matching
+ ;; event bundles by default (the framework's storage unit, matching
  ;; the streaming subscribe wire shape per Tool-Pair §Reading the
  ;; per-frame trace ring). Production runtime calls
  ;; `(trace-tooling/trace-buffer frame-id)` (zero-arg opts).

--- a/skills/re-frame2-pair/tests/runtime/streaming_subscriptions_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/streaming_subscriptions_test.clj
@@ -178,7 +178,7 @@
 
 (defn frameless-event?
  "Mirror of `runtime/frameless-event?` — true when the event
- carries no `:rf.trace/dispatch-id` tag. The cascade-bundle topics
+ carries no `:rf.trace/dispatch-id` tag. The event-bundle topics
  filter these out at the dispatch gate; the `:frameless` topic accepts
  only these."
  [ev]
@@ -410,7 +410,7 @@
  (dispatch-trace-to-subs! ev2)
  (dispatch-trace-to-subs! ev3))]
  ;; The drain returns `:queue` raw; the MCP-server layer projects
- ;; them into `:cascades` for cascade-bundle topics. The bb-runnable
+ ;; them into `:cascades` for event-bundle topics. The bb-runnable
  ;; mirror exposes the queue directly so
  ;; the contract under test is "what landed in the queue after
  ;; filtering" rather than the post-projection wire shape.
@@ -445,7 +445,7 @@
  ;; An :epoch sub should NOT be fed trace events; a :trace sub should
  ;; NOT be fed epoch records. Verifies the topic gating in the
  ;; dispatchers. The trace event carries a dispatch-id so it routes to
- ;; the cascade-bundle topic; a frameless event would route to
+ ;; the event-bundle topic; a frameless event would route to
  ;; `:frameless` instead.
  (let [subs (-> {}
  (subscribe! "epoch-sub" {:topic :epoch :filter {:event-id :cart/add}})
@@ -710,11 +710,11 @@
  "even a filter that *names* the sensitive event must not pull it through")))
 
 ;; ---------------------------------------------------------------------------
-;; Cascade-bundle topic routing
+;; Event-bundle topic routing
 ;; ---------------------------------------------------------------------------
 
-(deftest cascade-bundle-topics-reject-frameless-events
- ;; The cascade-bundle topics (`:trace`/`:fx`/`:error`) ONLY accept
+(deftest event-bundle-topics-reject-frameless-events
+ ;; The event-bundle topics (`:trace`/`:fx`/`:error`) ONLY accept
  ;; events with a `:rf.trace/dispatch-id` tag — frameless events
  ;; (registration emits, REPL evals) belong on the `:frameless` channel.
  (let [subs (-> {} (subscribe! "trace-sub" {:topic :trace}))
@@ -727,7 +727,7 @@
  subs (-> subs
  (dispatch-trace-to-subs! cascade-ev)
  (dispatch-trace-to-subs! frameless-ev))]
- (testing "the cascade-bundle event lands; the frameless event does not"
+ (testing "the event-bundle event lands; the frameless event does not"
  (is (= 1 (count (get-in subs ["trace-sub" :queue]))))
  (is (= cascade-ev (first (get-in subs ["trace-sub" :queue])))))))
 


### PR DESCRIPTION
Truly-final residue of the pipeline-vocab epic (rf2-glw1bh). The keys / wire / spec were already renamed to `event-bundle` / `event-keyed`; this PR syncs the lagging **PROSE** — impl `.cljc`/`.cljs` docstrings + comments and skill markdown / preload / tests — from `cascade-bundle` / `cascade-keyed` to the merged vocab.

## Sites renamed (event-traversal sense only)

- `implementation/core/src/re_frame/core.cljc` — `trace-buffer` / `clear-trace-buffer!` docstrings (ring keying + read unit + spec anchor)
- `implementation/core/src/re_frame/frame.cljc` — destroyed-frame ring-release comment
- `implementation/core/test/re_frame/trace_buffer_test.clj` — ns docstring, `1b` comment, `event-keyed-eviction` deftest (renamed; self-referenced only) + its testing prose
- `implementation/core/test/re_frame/elision_probe.cljs` — per-frame ring comment
- `skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs` — topic-semantics comments, `frameless-event?` / `drain-subscription!` / `cascade-of` docstrings, and the private helper `event-bundle-events` (was `cascade-bundle-events`; def + comment + single call site, all in-file). Also corrected a stale `:cascades-retained` docstring config key → `:events-retained` (the live framework key).
- `skills/re-frame2-pair/references/{mcp-transport,streaming-subscriptions,wire-size-budget}.md`
- `skills/re-frame2-pair/tests/{prompts/prompt_regression_test.clj,runtime/snapshot_test.clj,runtime/streaming_subscriptions_test.clj}` (incl. the `event-bundle-topics-reject-frameless-events` deftest, self-referenced only)

Prose "cascade bundle" / "group-cascades" references were aligned to the merged spec vocabulary (`event bundle` / `group-by-event` / §Event-bundle projection).

## Sense-guarded — KEPT (verified NOT the event-traversal sense)

- `re-frame.trace.cascade` DAG aggregator ns + hooks (late-bind directory, `trace/cascade.cljc`)
- `:rf.sub/cascade?` reactive wire key (`subs/memo.cljc`)
- the public `cascade-of` fn name + the dispatch-cascade tree nouns it reconstructs
- the **live `:cascades` wire key** on the trace/fx/error subscribe topics (payload load slot) — untouched
- (out of token scope; not `cascade-bundle`/`cascade-keyed`) machines cancellation-cascade, CSS/routing cascade

## Carve-out

rf2-tlf4if concurrently edits the handler source-as-data files (`core_reg_macros.cljc` keys + egress). None of my hits landed in that surface — my targets were the trace-ring / event-bundle docstrings. No carve-out collisions; nothing skipped/flagged for that bead.

## Follow-up flagged (out of this bead's token scope)

- `:cascades` (the live wire key / payload slot) and `:cascades-retained` (config key) still carry the old "cascade" root in wire/config surfaces beyond the one docstring corrected here. If the vocab epic wants those renamed too, that's a separate wire/config-contract change (touches tests + wire), not prose. Left for the mayor to file if desired.

## Quality gates

- `git grep -E 'cascade-bundle|cascade-keyed'` across the swept surfaces (`skills/re-frame2-pair/`, `skills/re-frame2/`, `implementation/`) → **zero** live matches (only `.beads/issues.jsonl` historical text remains, out of scope + untouched).
- Sense-guard tokens (`re-frame.trace.cascade`, `:rf.sub/cascade?`, cascade-DAG aggregator) verified present + untouched.
- Paren/bracket balance verified on all 8 edited Clojure files.
- Private-fn + deftest renames verified consistent (def + all refs; no dangling old symbols outside `.beads/`).
- `npm run test:cljs` — run locally (docstring/comment changes plus one compile-checked in-file private-fn rename must not break compile); result relied on via CI if the local run cannot complete in-session.
