### PR TITLE
docs: trim the landing page — sectioned, first-person, with status

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,70 +1,76 @@
-# re-frame2
+# re-frame2 — The User Guide
 
-re-frame2 is an architectural pattern for building single-page applications. It targets a virtual-DOM substrate — in practice, React. 
+**This is the user guide for the ClojureScript reference implementation of re-frame2.**
 
-It is functional, which means, of course, there will be much talk of pure functions and values, and brief excursions into category theory (very brief, I promise).
+## On re-frame2
 
-It is the second generation of re-frame. The original shipped in 2014 with a design that has held up very well. This second version (with a `2`) is the refinement pass the author has wanted to make for ten years. Thank you AI for letting me scratch the itch.
+re-frame2 is an architectural pattern for building single-page applications which target a virtual-DOM substrate — in practice, React.
 
-Talking of AI, the pattern is specification-first: the [spec](https://github.com/day8/re-frame2/tree/main/spec) is the primary artefact, and implementations follow from it. The [project README](https://github.com/day8/re-frame2#readme) tells the story behind that inversion.
+This pattern is specification-first: the [spec](https://github.com/day8/re-frame2/tree/main/spec) is the primary artefact, and any implementation (including this one) is downstream from it. The [project README](https://github.com/day8/re-frame2#readme) tells the story behind that inversion.
 
-**This site is the user guide for the ClojureScript reference implementation.** 
+## Why the 2?
 
-## A familiar shape
+This is the second generation of [re-frame](https://github.com/day8/re-frame). The original shipped in 2014 with a novel design that has stood the test of time pretty well. This second version is a refinement pass I've wanted to make for ten years. AI has provided the horsepower to scratch the itch.
 
-To quickly orient you, I'll start by saying that re-frame2 is Redux-like:
+If you are coming from v1, you'll notice that v2 is a library, not a framework. v2 will be very familiar initially, and then you'll realise how much more v2 does for you and how much further it refines the key concepts.
+
+If you are interested, there is a [migration skill](skills/re-frame-migration.md) provided to help you transition your projects.
+
+## Status
+
+Alpha for the moment. I'm still enjoying the refining process.
+
+But it's the kind of alpha where the changes are now minimal. I'd be interested in your feedback.
+
+If you do want to try it: nothing is published to Clojars or npm yet, so point `deps.edn` at this repo directly — a `:git/sha` coordinate, or `:local/root` on a local clone.
+
+## The shape
+
+It is functional, which means, of course, there's talk of pure functions and values, and brief excursions into category theory.
+
+To orient you, I could say that re-frame2 is Redux-like:
 
 - application state is held in one place;
 - it changes only through a single, pure, reducer-like step; and
 - data flows in one direction — from events, through state changes, toward the UI.
 
-And now I'll immediately yank that rug of familiarity out from under you, and tell you that re-frame2 is quite different to Redux. I claim the differences run much deeper than vocabulary — deep enough to change what's possible.
+Unfortunately, that orientation would undersell re-frame2 considerably. But at least it might communicate that re-frame2 does not place views at the causal center of the architecture (unlike so many modern React frameworks). Views stay a reactive, derivative projection of state.
 
-To give you a flavour for the differences:
+If you want re-frame2 expressed in pseudo-code:
 
-- Redux talks about `actions` and re-frame2 talks about `events`. Hmm. Not much of a difference?
-- Even basic things differ: handlers are registered by id into a queryable registry — not composed into one reducer tree — so tools can list them, and hot reload is a semantics rather than a trick.
-- Redux models its fold with a reducer, `(state, action) → state'`, and lets the annoying impure stuff happen in middleware and thunk closures. re-frame2's fold is `(world, event) → world'`. Facts from the world come *in* as data. Changes to the world go *out* as data. The hard edges live inside the model and, oh my, what a difference that makes.
-- And that's just the **write side**. On the **read side** — between the store and the screen — Redux has no model at all: a change notification, plus whatever selector wiring you build by hand. re-frame2 models the read side too. The two sides together are the **event pipeline**, and it is the spine of everything in this guide.
+1. It is event-driven: `event1 → event2 → event3 → …`
+2. Each event is fully processed end to end, in one go, by an **event pipeline** (an *ep*, for short). So computation is: `ep1 → ep2 → ep3 → …`
+3. Each individual pipeline is three phases:
+    1. **write side**: `(world, event) → world'` (world is a set of facts; world' is a set of effects, including new state)
+    2. **commit** `world'` — the impure part, including updating app state
+    3. **read side**: `v = f(state)` — via a reactive DAG. The way React used to be before it got hooked-to-death.
 
-(In automata terms: Redux is a Moore machine — its only output is a projection of state. re-frame2 is a Mealy machine — every step can also emit effects — plus a structured Moore channel for the read side.)
+When writing an app, your job is to register various kinds of handlers (usually pure functions) which slot into the event pipeline.
 
-## Where it gets interesting
+(In automata terms: Redux is a Moore machine — its only output is a projection of state. re-frame2 is a Mealy machine — every step can also emit effects — plus re-frame2 has a structured Moore channel for the read side.)
+
+## Why re-frame2 is interesting
 
 It comes down to how re-frame2 is designed, and what it makes explicit.
 
-**1. It is deeply data-oriented.** Data-oriented *state* is table stakes — everyone claims that. Here, everything else is data too. Effects are values. Facts from the world — the clock, a storage read, the reply that just landed — arrive as declared values, recorded with the event when replay will need them. State machines are values. Routes are values. Error reports are values. Even continuations are a value. And so too Time. At the limit, the re-frame2 pattern itself is a value — a spec complete enough to fork and regenerate.
+**1. It is deeply data-oriented.** Of course *state* is a value. But effects are values too. So too facts from the world — the clock, a read of local storage, etc. State machines are values. Routes are values. Error reports are values. Even continuations are a value. And, surprisingly, so too is Time. At the limit, the re-frame2 pattern itself is a value — a spec complete enough to fork and regenerate.
 
-Why care? Because once a thing is a value you can print it, diff it, store it, replay it — and *check* it. A declared thing is an enforceable thing, so failure here is loud and early, never a quiet leak in production.
+**2. It rejects Turing-completeness everywhere, all the time. It embraces weak computational models.** A weak machine can be reasoned about. A strong one can only be run.
 
-**2. It prefers weak computational models over Turing-completeness everywhere, all the time.** Handling an event is one pure step in a fold: `(world, event) → world'`. The world arrives as a map of declared facts, and app state is just one entry in that map — always present, but not otherwise special. The next world leaves as data too: the new value of your state, plus descriptions of the changes you want made elsewhere. Declared on the way in, described on the way out. In between: just a function. That is the pipeline's write side.
+**3. It is deeply instrumented — made possible by 1 and 2.** It narrates itself by putting detailed trace data on the wire. Every tool — Xray, Story, the AI pairing on your live app — is a thin reader over that one wire. And in production, the whole wire dead-code-eliminates to zero bytes.
 
-(That's the concept. Mechanically the step is assembled — interceptors decorate the way in and the way out, flows derive last — but every part has the same pure shape, so the assembly keeps the signature.)
-
-The read side runs the same discipline in a second shape. The UI is derived through a DAG of registered subscriptions: pure functions of the folded state, recomputing only where a value actually changed, with views at the leaves. One weak machine writes. Another weak machine reads. The committed value is the only door between them.
-
-The rest of the framework holds the same line: no async/await, statechart topologies as data, a closed effect grammar. Turing-completeness is confined to small pure functions sitting in named slots; everything between the slots is structure, not code. A weak machine can be reasoned about. A strong one can only be run.
-
-**3. It is deeply instrumented — made possible by 1 and 2.** Everything is a value crossing one fixed event pipeline, so there is a single place to stand and watch the entire app go by. Every tool — Xray, Story, the AI pairing on your live app — is a thin reader over that one wire. And in production, the whole wire dead-code-eliminates to zero bytes.
-
-**4. It is deterministic — also a consequence of 1 and 2.** Durable state changes only through recorded facts. That's the contract. So history is a fold you can re-run: same event log, same state, every time. Replay is a theorem, not a devtools demo. Time-travel and undo fall out as corollaries. And a bug report becomes a replayable event list — which is to say, a regression test.
-
-Because a world is a value, worlds are plural. re-frame2 calls a running world a **frame**: two apps side by side on one page, a frame per server request, per test, per Story variant. Old worlds keep, too — because history is a value.
-
-A system made of values (1), computed by weak machines (2), narrating on one wire (3), with replayable history (4) — is a system an AI can read, drive, debug, and regenerate. That isn't a fifth feature. It's the compound interest on the other four.
+**4. It is deterministic — also a consequence of 1 and 2.** Durable state changes only through recorded facts. Time-travel and undo fall out as corollaries. And a bug report becomes a replayable event list — which is to say, a regression test.
 
 ## Batteries included
 
-Beyond the core loop, most real apps end up needing the same four hard things — feature lifecycles, URLs, server rendering, server state. re-frame2 ships each as a first-class capability rather than an ecosystem bolt-on: registered the same way, riding the same pipeline, visible on the same wire.
+Beyond the core, most real apps end up needing feature lifecycles, URLs, server rendering, and server state. re-frame2 ships each as a first-class capability rather than an ecosystem bolt-on: registered the same way, event oriented, riding the same event pipeline, and visible on the same wire.
 
-- **Machines** — statecharts at near-parity with XState, but integrated rather than sidecar. A machine is an event handler, and its snapshots are values: you can scrub them, restore them, and hydrate them through SSR. Hierarchical states, parallel regions, history states, delayed and automatic transitions, and a declarative spawn/actor model.
+- **Machines** — statecharts at near-parity with [XState](https://stately.ai/), but integrated rather than sidecar. Undoable, traceable, effects as data, etc. They inherit all of the re-frame2 ethos.
 - **Routing** — the URL as ordinary application state. Routes are registry rows. Navigation is an event. The active route is a subscription. So the Back button is literally a dispatch, and time-travel rewinds the address bar along with everything else. A route declares its data needs beside its URL — the same declaration serves client and server — and the classic click-away race is fixed once, in the framework.
 - **SSR** — one app, run twice. The same events, subscriptions, and views run on the JVM against a per-request frame: pure hiccup to HTML, no React on the server, no second app to keep in sync. What ships to the client is a fail-closed allowlist. And hydration is *verified* — a structural hash catches server/client divergence, instead of leaving it as a console warning nobody reads.
-- **Resources** — declarative, cached server state (the TanStack-Query-shaped capability). Declare what a page needs, and the framework owns fetching, caching, deduplication, and freshness. Resources ride the SSR payload, so a server-rendered page hydrates without re-fetching. Stale replies from abandoned navigations are suppressed, never written.
+- **Resources** — declarative, cached server state (the [TanStack Query](https://tanstack.com/query)-shaped capability). Declare what a page needs, and the framework owns fetching, caching, deduplication, and freshness. Resources ride the SSR payload, so a server-rendered page hydrates without re-fetching. Stale replies from abandoned navigations are suppressed, never written.
 
 ## Tools included
 
-Because every tool is a thin reader over the one wire (point 3 above), the tooling ships *with* the framework and knows everything the framework knows.
-
-- **Xray** — the in-app devtools panel, preloaded into dev builds. Thirteen tightly-integrated panels — the event ledger, app-db diffs, a causality graph, a machine inspector, a time-travel scrubber, an AI co-pilot rail, and more — with click-to-source from any row.
-- **Story** — a Storybook-class playground: render your views in every state, in isolation. Parity with Storybook 9 on the chrome, plus what the architecture makes easy — EDN-first variants, controls derived from your schemas, a frame per variant so scenarios can't leak into each other, machine-state visualisation, and a scrubber to walk each variant's history.
+- **Xray** — the in-app devtools panel for narrating your app's trace data.
+- **Story** — a [Storybook](https://storybook.js.org/)-class playground for enumerating visual states (via isolated execution contexts called **frames**).


### PR DESCRIPTION
Supersedes the #5129 page with the trimmed rework: front-loaded site scope, **On re-frame2** / **Why the 2?** / **Status** (alpha; install via `:git/sha` or `:local/root` — nothing on Clojars/npm yet) / **The shape** (the Redux orientation, the event-pipeline pseudo-code with write side → commit → read side, the Moore/Mealy aside) / the four interesting-points compressed to near-aphorisms / batteries / tools. First-person voice; all reference links filled (re-frame v1, XState, TanStack Query, Storybook, the migration skill).

Gates: mkdocs strict pass; check_doc_slugs exit 0.