### PR TITLE
docs: repo-wide README link sweep (rf2-iwe88b)

### DIFF
--- a/skills/re-frame-migration/README.md
+++ b/skills/re-frame-migration/README.md
@@ -45,7 +45,7 @@ It does **not** duplicate `migration/from-re-frame-v1/README.md` content. Each r
 
 ## Status
 
-Pre-alpha. The skill is authored; it has not yet been exercised end-to-end against a real v1 codebase migration. The structure mirrors the `re-frame2-setup` skill in this same repo. The content is grounded against `migration/from-re-frame-v1/README.md`, `docs/core/25-from-re-frame-v1.md`, and `docs/the-mayor-method.md`'s paste-prompt pattern.
+Pre-alpha. The skill is authored; it has not yet been exercised end-to-end against a real v1 codebase migration. The structure mirrors the `re-frame2-setup` skill in this same repo. The content is grounded against `migration/from-re-frame-v1/README.md`, `docs/core/25-from-re-frame-v1.md`, and `docs/the-mayor-method/`'s paste-prompt pattern.
 
 ## Layout
 


### PR DESCRIPTION
Repo-wide README link + cross-reference hygiene sweep (rf2-iwe88b). Verified every relative link + anchor in all 117 tracked `README.md` files resolves to an existing file/anchor; repointed stale references left by recent renames/moves.

## What changed

One surgical fix — the only genuine stale reference found:

- `skills/re-frame-migration/README.md` — grounding-sources note pointed at `docs/the-mayor-method.md` (now a redirect stub) → repointed to the current directory `docs/the-mayor-method/`. (`scripts/git-hooks/README.md` already referenced the new dir correctly; no change needed there.)

The bead's other flagged renames were verified clean:
- pipeline-vocab file renames (`events-and-the-cascade.md`, `testing/cascades.md`, `pipeline-runs.md`) — **not referenced in any README** (already updated or never present).
- The word "cascade" appearing in prose (state-machine / dispatch / reconnect cascades) is **live domain vocabulary**, not a stale file reference — left untouched per the "no prose rewriting" scope.
- `reg-flow` references — all point at the current live API; valid.

## Counts

- **READMEs scanned:** 117 (all tracked `README.md`)
- **READMEs with fixes:** 1
- **Total links/references repaired:** 1
- **Relative + external links inspected:** ~2,124

## Quality gates

- `scripts/check_readme_links.py --ci` — **PASS** (exit 0). Authoritative README link+anchor gate; covers source-tree READMEs (adapters/, examples/, tools/, etc.) with mkdocs `_N` slug rules.
- `scripts/check_readme_links.py --self-test` — **PASS** (exit 0).
- `scripts/check_doc_slugs.py` — **PASS** (exit 0). Covers the published-docs corpus (docs/, spec/, migration/, skills/, tools/*/spec/) — where the edited README lives.
- `scripts/check_readme_inventories.py` — **PASS** (exit 0).
- `mkdocs build --strict` — **PASS** (exit 0). (Remaining INFO lines are pre-existing GitHub-vs-site relative-link notes, unrelated to this change.)
- Final scripted resolver pass (custom, handles em-dash `--` slugs + duplicate-heading `_N` disambiguation) — every relative link in every edited README resolves. The 9 residual "misses" it reports are all deliberately-excluded content that the repo gate also skips: inline-code prose examples (`` `[click me](javascript:alert(1))` ``), the intentionally-broken `scripts/_test_fixtures/check_*` cases, and mustache `{{...}}` template placeholders.

## Flagged / uncertain

- No external URLs were chased/verified (per scope). None were obviously dead or a known-moved path, so none were changed.

Do not merge — worker PR for review.
