### PR TITLE
docs: fix slim how-to vs rename-contract contradiction (rf2-xzmovc)

### DIFF
--- a/docs/api/re-frame.adapter.reagent.md
+++ b/docs/api/re-frame.adapter.reagent.md
@@ -26,14 +26,14 @@
   (rf/init! reagent-adapter/adapter)   ;; install the substrate once, at boot
   ```
 
-Reagent ships in two variants. The full adapter lives here; the slim adapter is a sibling artefact that drops React's server-rendering tax for browser-only bundles:
+Reagent ships in two variants. The full adapter lives here; the slim adapter is a sibling artefact that drops React's server-rendering tax for browser-only bundles. Both publish their adapter at the **same** canonical ns — `re-frame.adapter.reagent` — so the require and `init!` line are identical; what differs is the Maven coordinate you depend on:
 
-| Variant | Namespace | Includes | Use when |
-|---|---|---|---|
-| Full | `re-frame.adapter.reagent` | stock Reagent (`reagent.core`, `reagent.dom`, `reagent.dom.server`) | client apps that may also render to a string on the JVM |
-| Slim | `re-frame.adapter.reagent-slim` | Reagent without `reagent.dom.server` | browser-only bundles; drops ~30 KB by excluding `react-dom/server` |
+| Variant | Maven coordinate | Adapter ns (require) | Includes | Use when |
+|---|---|---|---|---|
+| Full | `day8/re-frame2-reagent` | `re-frame.adapter.reagent` | stock Reagent (`reagent.core`, `reagent.dom`, `reagent.dom.server`) | client apps that may also render to a string on the JVM |
+| Slim | `day8/reagent-slim` | `re-frame.adapter.reagent` (renamed from the in-tree `-slim` ns at publication) | Reagent without `reagent.dom.server` | browser-only bundles; drops ~30 KB by excluding `react-dom/server` |
 
-The two artefacts sit side by side; you choose between them by which `adapter` you pass to `init!`. The slim variant is bundle-isolated — a dedicated isolation gate verifies that stock Reagent / `react-dom/server` don't leak into builds that select it. The full migration (a four-line swap) is in [Use UIx, Helix, or reagent-slim](../core/how-to/use-uix-helix-or-slim.md).
+The two artefacts sit side by side; a build depends on exactly one of them, so the adapter ns is single-source per app and you select slim vs full through your `deps.edn` coordinate, not through the boot line. (In-repo `:git/sha` consumers require `re-frame.adapter.reagent-slim` directly, because the monorepo carries both adapters on one classpath — the publication step renames it to `re-frame.adapter.reagent` before packaging the jar.) The slim variant is bundle-isolated — a dedicated isolation gate verifies that stock Reagent / `react-dom/server` don't leak into builds that select it. The full migration (a four-line swap) is in [Use UIx, Helix, or reagent-slim](../core/how-to/use-uix-helix-or-slim.md).
 
 ## Test helpers
 

--- a/docs/core/how-to/use-uix-helix-or-slim.md
+++ b/docs/core/how-to/use-uix-helix-or-slim.md
@@ -44,15 +44,19 @@ That's it. To switch substrates, you change that one argument. Each adapter live
 (rf/init! helix-adapter/adapter)
 ```
 
-reagent-slim follows the same explicit shape — it ships its own adapter binding at `re-frame.adapter.reagent-slim`, and you name it at `init!` exactly like the others:
+reagent-slim follows the same explicit shape — but here the published artefact deliberately ships its adapter at the *canonical* `re-frame.adapter.reagent` ns, the very same require and `init!` line as stock Reagent. The `day8/reagent-slim` package renames its adapter namespace to `re-frame.adapter.reagent` at publication, so a consumer's boot line is identical whichever of the two Reagent coordinates they depend on:
 
 ```clojure
-;; reagent-slim
-(require '[re-frame.adapter.reagent-slim :as reagent-slim])
-(rf/init! reagent-slim/adapter)
+;; reagent-slim — the require and init! line are the SAME as stock Reagent
+(require '[re-frame.adapter.reagent :as reagent-adapter])
+(rf/init! reagent-adapter/adapter)
 ```
 
-What makes slim *feel* like stock Reagent isn't the boot line — it's that the view layer is the same Reagent you already write. The two real differences are downstream: you depend on `day8/reagent-slim` in your `deps.edn` instead of `day8/re-frame2-reagent`, and your `reagent.*` view imports become `reagent2.*` (we'll get to both at the end).
+That's the point: swapping stock Reagent for slim touches your `deps.edn` coordinate and your `reagent.*` view imports, but *not* your boot call. What makes slim *feel* like stock Reagent isn't just the view layer being the same Reagent you already write — it's that the adapter binding is literally the same one. The two real differences are downstream: you depend on `day8/reagent-slim` in your `deps.edn` instead of `day8/re-frame2-reagent`, and your `reagent.*` view imports become `reagent2.*` (we'll get to both at the end).
+
+!!! note "Building from the repo, not the published jar?"
+
+    In-tree the slim adapter lives at `re-frame.adapter.reagent-slim` — it has to, because the monorepo puts both it and the bridge adapter on one classpath and two namespaces can't share a name. The publication step (the `Rename adapter ns at publication` job in `.github/workflows/release.yml`) renames it to `re-frame.adapter.reagent` before packaging the jar. So a `:git/sha` consumer requires `re-frame.adapter.reagent-slim`, while a published-artefact consumer requires `re-frame.adapter.reagent`. Everything below assumes the published shape.
 
 There's deliberately no registry and no auto-install here, because the project holds boot to one rule: it must name its substrate in plain sight. Open any app's boot function and you can read its substrate straight off the page — no spelunking required. The framework enforces this strictly:
 
@@ -226,9 +230,9 @@ Slim isn't a fourth view paradigm — that trips people up, so let's be clear up
 - **Payoff:** roughly 7–10 KB gzipped off a typical app (25–33% of the Reagent layer), and up to ~22–27 KB for apps using Reagent's HTML-export path. These are analytical estimates pending build-measured validation. Runtime speed is marginally better at best, so go slim for kilobytes, not frame rate — it's a download-size lever, not a performance one.
 - **Constraints:** React 19 only. No `react-dom/server` — HTML export is handled by a small pure-CLJS serializer in `reagent2.dom.server` instead. The class-component escape hatch is capped to seven `create-class` keys (more than most apps ever touch).
 
-Mechanically it's a small swap: your app depends on exactly one of `{day8/re-frame2-reagent, day8/reagent-slim}`, you boot the matching adapter (`reagent-adapter/adapter` vs `reagent-slim/adapter`), and you change your `reagent.*` requires to `reagent2.*` (for example, `reagent2.dom.client` for `reagent.dom.client`). Slim deliberately ships a *distinct* adapter namespace — `re-frame.adapter.reagent-slim`, the sibling of stock's `re-frame.adapter.reagent` — so the two artefacts can sit side by side and you choose between them by which `adapter` you pass to `init!`. Concretely, the migration is four line-edits:
+Mechanically it's a small swap: your app depends on exactly one of `{day8/re-frame2-reagent, day8/reagent-slim}`, and you change your `reagent.*` requires to `reagent2.*` (for example, `reagent2.dom.client` for `reagent.dom.client`). The one thing that *doesn't* change is the adapter you boot: the published `day8/reagent-slim` artefact ships its adapter at the canonical `re-frame.adapter.reagent` ns, so `(require '[re-frame.adapter.reagent :as reagent-adapter])` and `(rf/init! reagent-adapter/adapter)` are identical on both coordinates. You pick slim vs stock entirely through your `deps.edn` coordinate, not through the boot line. Concretely, the migration is four line-edits:
 
-1. swap the deps coordinate to `day8/reagent-slim`, and point `init!` at `re-frame.adapter.reagent-slim`'s `adapter`;
+1. swap the deps coordinate to `day8/reagent-slim` (the `re-frame.adapter.reagent` require and `init!` line stay exactly as they were);
 2. `react` / `react-dom` to 19.x in `package.json`;
 3. `reagent.dom/render` → `reagent2.dom.client/{create-root, render}`;
 4. `reagent.dom/unmount-component-at-node` → `reagent2.dom.client/unmount`.


### PR DESCRIPTION
Fixes **rf2-xzmovc** (P3 bug).

## The contradiction

`docs/core/how-to/use-uix-helix-or-slim.md` (Step 1 ~L47-55 and Step 7 ~L229-235) told adopters to `(:require [re-frame.adapter.reagent-slim …])` and `(rf/init! reagent-slim/adapter)`. But the shipped contract renames the adapter ns **at publication**: the `Rename adapter ns at publication (reagent-slim only)` step in `.github/workflows/release.yml` (via `.github/scripts/transform-reagent-slim-ns.sh`) `mv`s `reagent_slim.cljs → reagent.cljs` and rewrites the `(ns …)` form, so **published `day8/reagent-slim` consumers require the canonical `re-frame.adapter.reagent`** — the very same require and `init!` line as stock Reagent.

The how-to's guidance only worked for in-repo `:git/sha` consumers (where the in-tree `-slim` ns is real) and would break published-artefact adopters. Confirmed authoritative against:
- `implementation/adapters/reagent-slim/README.md` ("Published Maven artefact: `re-frame.adapter.reagent`")
- `implementation/adapters/reagent-slim/DESIGN-RATIONALE.md` §7 ("The adapter init line … does not change")
- `implementation/adapters/reagent-slim/IMPL-SPEC.md` §2.1 / §13.1 (adapter Var UNCHANGED at `re-frame.adapter.reagent`; the require line is unchanged on the bridge→slim swap)
- `implementation/adapters/reagent-slim/deps.edn` (in-tree `:main re-frame.adapter.reagent-slim`; published jar ships canonical `re-frame.adapter.reagent`)

## The fix (docs only — aligned to the shipped contract, no code touched)

- **how-to Step 1** — corrected the require/init to canonical `re-frame.adapter.reagent`; added an admonition noting the in-repo `:git/sha` caveat (in-tree ns is `-slim`, renamed at publication).
- **how-to Step 7** — corrected the "distinct adapter namespace" prose and migration step 1: you pick slim vs stock through your `deps.edn` **coordinate**, not the boot line; the require/`init!` stay identical.
- **`docs/api/re-frame.adapter.reagent.md`** — the same-contradiction table row ("Slim → `re-frame.adapter.reagent-slim`") reworked to show both variants publish the adapter at `re-frame.adapter.reagent` and differ only by Maven coordinate (with the in-repo caveat).

Left untouched (correctly in-repo builds off the monorepo classpath, so `-slim` ns is right): `docs/tools/playground/sci/*`. The generated `docs/cljs/playground-rf2.js` is a build artefact.

## Note for the mayor (not fixed here — contract-side, outside docs/ surface)

IMPL-SPEC §2.1 body prose describes the in-tree selection (`reagent-slim-adapter/adapter`) while its heading + §13.1 say canonical `re-frame.adapter.reagent`. It's internally coherent once you read it as "in-tree file, published-path renamed," but it never restates the rename inline, which reads as a wrinkle. It lives under `implementation/` (contract side), outside this bead's docs/ surface — surfacing rather than editing per the STOP-on-contract instruction.

## Quality gates

- `python -m mkdocs build --strict` — EXIT 0, no warnings (fixed a `--strict` link warning by referencing `release.yml` in prose rather than as an out-of-tree markdown link).
- `python scripts/check_doc_slugs.py` — EXIT 0.