### PR TITLE
fix(examples): login lock off-by-one (rf2-18duuy)

### DIFF
--- a/examples/capabilities/machines/state_machine_walkthrough/views.cljs
+++ b/examples/capabilities/machines/state_machine_walkthrough/views.cljs
@@ -93,7 +93,7 @@
           locked-panel []
   [:div.locked {:data-testid "locked-panel"}
    [:h2 "Account locked"]
-   [:p "Three failed attempts. Contact support to unlock."]])
+   [:p "Too many failed attempts. Contact support to unlock."]])
 
 (rf/reg-view root-view []
   (let [locked? @(rf/machine-has-tag? :auth.login/flow :auth/locked)]

--- a/examples/core/login/core.cljs
+++ b/examples/core/login/core.cljs
@@ -581,7 +581,7 @@
           locked-panel []
   [:div.locked {:data-testid "locked-panel"}
    [:h2 "Account locked"]
-   [:p "Three failed attempts. Contact support to unlock."]])
+   [:p "Too many failed attempts. Contact support to unlock."]])
 
 ;; The top-level switch. It reads two tags off the machine and shows one of
 ;; three faces: a welcome when authed, the locked panel when locked, and the

--- a/examples/substrates/helix/login/core.cljs
+++ b/examples/substrates/helix/login/core.cljs
@@ -477,7 +477,7 @@
      {:class "locked"
       :data-testid "locked-panel"}
      (d/h2 "Account locked")
-     (d/p "Three failed attempts. Contact support to unlock.")))
+     (d/p "Too many failed attempts. Contact support to unlock.")))
 
 (defnc login-banner []
   (let [authed? (helix-adapter/use-subscribe [:rf/machine-has-tag?

--- a/examples/substrates/uix/login/core.cljs
+++ b/examples/substrates/uix/login/core.cljs
@@ -456,7 +456,7 @@
 (defui locked-panel []
   ($ :div.locked {:data-testid "locked-panel"}
      ($ :h2 "Account locked")
-     ($ :p "Three failed attempts. Contact support to unlock.")))
+     ($ :p "Too many failed attempts. Contact support to unlock.")))
 
 (defui login-banner []
   (let [authed? (uix-adapter/use-subscribe [:rf/machine-has-tag?


### PR DESCRIPTION
Fixes rf2-18duuy.

## What
The locked-account panel in all three login twins read **"Three failed attempts. Contact support to unlock."** — but the machine locks on the **fourth** failed submit. Off-by-one between the user-facing COPY and the BEHAVIOUR.

## Direction of fix: copy, not logic (as the bead rules)
The guard is `:under-retry-limit = (< (:attempts data) 3)`, evaluated on `:auth.login/failure` in `:submitting` **before** `:record-error` increments `:attempts`:

- failure 1 → attempts 0, `0<3` true → `:error-shown` (attempts→1)
- failure 2 → attempts 1, `1<3` true → `:error-shown` (attempts→2)
- failure 3 → attempts 2, `2<3` true → `:error-shown` (attempts→3)
- failure 4 → attempts 3, `3<3` **false** → falls through to `:locked-out`

So the intended shape is *three errors shown, lock on the fourth submit* — which the READMEs, ns docstrings, and stories all teach correctly ("the fourth wrong try trips the retry guard"). Only the panel copy disagreed. Per the bead, the guard is left untouched; the copy is corrected.

Chose to **reword to avoid the brittle count** rather than hard-code "Four": panels now read **"Too many failed attempts. Contact support to unlock."** This is accurate for the lock-on-4th behaviour, matches phrasing already used in the story doc ("Too many failed attempts"), and won't rot if the threshold ever changes.

## Sites fixed
- `examples/core/login/core.cljs` (locked-panel)
- `examples/substrates/uix/login/core.cljs` (verbatim copy)
- `examples/substrates/helix/login/core.cljs` (verbatim copy)
- `examples/capabilities/machines/state_machine_walkthrough/views.cljs` — the same login-lockout demo carried the identical wrong copy with the identical guard/increment order; fixed for consistency (beyond the bead's enumerated 3 sites, flagged here). Its ns docstring narrative ("three failed attempts ... then a fourth submit trips the guard") is already correct and was left as-is.

READMEs are **not** touched — PR #5204 owns those (disjoint files).

## Test delta
No test change. Examples are test-free by repo policy (no `*.spec.cjs` under `examples/`); the login examples have no machine/counter test to pin the threshold, and the `stories.cljs` artefacts already describe lock-on-fourth correctly.

## Quality gates
- `npm run test:cljs` (from `implementation/`, after `npm install` in the fresh worktree): **8058 tests / 37000 assertions — 0 failures, 0 errors.**
- Copy-only string edits in example view files; no logic, build, or API surface touched.