### PR TITLE
docs(code): stale docstring/comment sweep (rf2-k269mi)

### DIFF
--- a/examples/capabilities/machines/state_machine_walkthrough/core.cljc
+++ b/examples/capabilities/machines/state_machine_walkthrough/core.cljc
@@ -35,7 +35,7 @@
             [re-frame.registrar :as registrar]))
 
 ;; ============================================================================
-;; THE TRANSITION TABLE — guide §The same flow as a transition table
+;; THE TRANSITION TABLE — guide §A machine at a glance
 ;; ============================================================================
 ;;
 ;; It's all just data. The `:guards` and `:actions` sit right here in the table,
@@ -140,7 +140,7 @@
      :meta {:terminal? true}}}})
 
 ;; ============================================================================
-;; FX — guide §Composing with async effects
+;; FX — guide §An action returns effects
 ;; ============================================================================
 ;;
 ;; `:auth.session/store` is a stub — it shows you the SHAPE of the effect without

--- a/examples/capabilities/resources/infinite_feed/core.cljs
+++ b/examples/capabilities/resources/infinite_feed/core.cljs
@@ -38,7 +38,7 @@
    The view reads one combined view-model, `[:rf.resource/infinite-state …]`:
    `:items` (the merged flat list — the read you care about most),
    `:has-next-page?`, `:fetching-next?`, `:page-error`, `:loading?`,
-   `:has-data?`. Then it dispatches one causal event. Scope is the leak
+   `:error`. Then it dispatches one causal event. Scope is the leak
    boundary, and it fails closed: this feed is public — the same for every
    viewer — so it makes the explicit `:rf.scope/global` claim. A per-user feed
    would carry a scope resolver instead. See docs/resources/glossary.md#scope.
@@ -54,9 +54,10 @@
    There's no backend here, so the example overrides `:rf.http/managed` with a
    per-cursor canned stub that hands off to the framework's
    `:rf.http/managed-canned-success` — the same reply shape a live server would
-   send. So every page fetch still runs the real thing: a real fetch, in-flight
-   dedupe, stale-reply suppression, the passive status flow. A small reply delay
-   gives the load-more spinner a moment on screen before each page lands."
+   send. The transport is canned, but everything above it is the real thing:
+   in-flight dedupe, stale-reply suppression, the passive status flow all run
+   exactly as they would over a live network. A small reply delay gives the
+   load-more spinner a moment on screen before each page lands."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.registrar :as registrar]

--- a/examples/capabilities/ssr/ssr/core.cljc
+++ b/examples/capabilities/ssr/ssr/core.cljc
@@ -34,8 +34,11 @@
      ../../../docs/ssr/glossary.md#hydration-mismatch.
 
    Want to see it live? The hand-written `index.html` beside this file is a
-   frozen snapshot of exactly what `handle-request` below produces: the
-   pre-rendered markup sits in `<div id='app'>`, and the baked
+   runnable stand-in for what `handle-request` below would emit if a real
+   Clojure server sat in front — close in shape, but hand-authored, not
+   byte-exact (it deliberately omits the render-hash attribute + payload key
+   a genuine server stamps; see the comment in index.html). The pre-rendered
+   markup sits in `<div id='app'>`, and the baked
    `<script id='__rf_payload'>` carries the state. The browser-side `run`
    reads that payload, hydrates, verifies, and renders on top of the seeded
    state — no flash, no re-fetch."

--- a/examples/core/counter/core.cljs
+++ b/examples/core/counter/core.cljs
@@ -1,6 +1,6 @@
 (ns counter.core
   "The smallest possible re-frame2 app: a number and two buttons. One slice
-   of app-db, three event handlers, one subscription, one view, one frame.
+   of app-db, three event handlers, one subscription, two views, one frame.
 
    Small on purpose. With nothing else in the way, you can watch a single
    click make the whole loop turn. The click dispatches an event, a handler

--- a/examples/core/flows/core.cljs
+++ b/examples/core/flows/core.cljs
@@ -161,8 +161,9 @@
 
 (rf/reg-event :cart/remove-discount
   {:doc "Disengage the feature gate. `:rf.fx/clear-flow` removes the flow and
-         resets its [:cart :discount-rate] output to nil, so :cart/total
-         climbs back to full price on the next walk."}
+         `dissoc-in`s its [:cart :discount-rate] output path (per spec 013 —
+         the key is removed, not set to nil), so :cart/total climbs back to
+         full price on the next walk."}
   (fn handler-cart-remove-discount [_ _]
     {:fx [[:rf.fx/clear-flow :cart/discount-rate]
           [:dispatch [:cart/touch]]]}))

--- a/examples/core/seven_guis/cells/core.cljs
+++ b/examples/core/seven_guis/cells/core.cljs
@@ -28,7 +28,7 @@
    - Cycles (A1 → B1 → A1) caught by a visited-set walk, not a stack overflow
    - Bad arithmetic turned into typed error markers — the evaluator never throws
    - A sparse cell registry: only edited cells take up space
-   - A pure parser + evaluator — no `eval`, no host I/O, runs anywhere
+   - A pure parser + evaluator — no `eval`, no DOM, easy to unit-test
 
    The formula language is a tiny parenthesised calculator: numbers, cell refs
    (A1..Z100), and `+ - * /`, all written prefix inside `()`."
@@ -105,8 +105,9 @@
 ;; A formula is a string like '=(+ A1 (* B2 3))'. Turning that into an answer
 ;; is two steps: parse the text into an AST, then walk the AST computing a
 ;; number. Everything here is a pure function — no `eval`, no DOM, no surprises
-;; — so it runs just as happily on the JVM in a unit test as it does in the
-;; browser.
+;; — so it's trivial to unit-test in isolation. (The numeric parse leans on
+;; `js/parseFloat` / `js/isNaN`, so this particular file is CLJS-only; the
+;; parse/eval shape itself is host-agnostic.)
 
 (def num-re
   "Matches a string that is *entirely* a number: optional sign, an integer

--- a/examples/patterns/long_running_work/worker.cljs
+++ b/examples/patterns/long_running_work/worker.cljs
@@ -290,8 +290,9 @@
     ;; The heart of it — the state that carries :spawn-all. Entering it,
     ;; the runtime seeds the join-state map and spawns a child for each
     ;; entry below. Leaving it — by ANY route, :cancel or :work/all-done
-    ;; alike — fires a single :rf.machine/destroy that reads the join
-    ;; state and clears away every child still standing.
+    ;; alike — runs the exit cascade, which (because :spawn-all is sugar
+    ;; over N :spawns, per spec 005) fires a :rf.machine/destroy per
+    ;; surviving child and clears every one still standing.
     ;;
     ;; The :progress event is just a child checking in. It's an internal
     ;; self-transition that updates :data :progress — and because
@@ -328,8 +329,8 @@
              :work/all-done   {:target :complete  :action :stamp-outcome}
              :work/any-failed {:target :error     :action :stamp-outcome}
              ;; The user pulling the plug. Leaving :working is the part
-             ;; that matters: that exit fires the one :rf.machine/destroy
-             ;; that takes every surviving child with it.
+             ;; that matters: that exit fires a :rf.machine/destroy per
+             ;; surviving child, taking every one of them with it.
              :cancel          {:target :cancelled :action :stamp-outcome}}}
 
     :complete

--- a/examples/patterns/nine_states/core.cljs
+++ b/examples/patterns/nine_states/core.cljs
@@ -556,7 +556,7 @@
    ;; form region — the transient Correct / Incorrect acknowledgements
    {:tag :form/success    :render :correct}
    {:tag :form/invalid    :render :incorrect}
-   ;; data region — error first (also transient), then loading, then the
+   ;; data region — loading first, then error (both transient), then the
    ;; resting cardinality buckets
    {:tag :data/loading    :render :loading}
    {:tag :data/error      :render :error}

--- a/examples/real-apps/realworld_resources/http.cljs
+++ b/examples/real-apps/realworld_resources/http.cljs
@@ -9,12 +9,15 @@
    `js/setTimeout`) so the runtime's `:loading` state is actually observable and
    the replies stay time-travel-safe.
 
-   Two helpers live here:
+   What lives here:
    - `failure->message` — turn a `:rf.http/*` failure envelope (the shape a
      resource `:error` / `:refresh-error` and a mutation `:error` carry) into a
      human-readable string.
-   - `install-demo-backend!` — register the stub fx and wire it as the
-     `:rf.http/managed` override on the demo frame.
+   - the demo-backend stub fx, `:realworld-resources.demo/http-stub`,
+     registered at namespace load. It routes by URL + method to canned
+     Conduit-shaped replies. `core.cljs` wires it as the `:rf.http/managed`
+     override on the demo frame via `:fx-overrides` — there is no explicit
+     install call to make.
 
    Three ways to point the app at a backend (see the README §Running against a
    real backend):

--- a/examples/substrates/helix/process_monitor/core.cljs
+++ b/examples/substrates/helix/process_monitor/core.cljs
@@ -1,9 +1,10 @@
 (ns helix.process-monitor.core
   "A terminal-style process monitor, built on Helix. Two panes — a
-   filterable process list on the left, a live log feed on the right — with
-   status tiles across the top. The log pane gains a fresh line every couple
-   of seconds with nobody touching it, which is the fun part: it proves this
-   is a real reactive loop, not a screenshot.
+   selectable process list on the left (click a process to filter the logs
+   to it), a live log feed on the right — with status tiles across the top.
+   The log pane gains a fresh line every couple of seconds with nobody
+   touching it, which is the fun part: it proves this is a real reactive
+   loop, not a screenshot.
 
    Four things worth watching:
 

--- a/implementation/routing/src/re_frame/routing/history.cljc
+++ b/implementation/routing/src/re_frame/routing/history.cljc
@@ -9,15 +9,18 @@
     (.addEventListener js/window \"popstate\"
       (fn [_] (rf/dispatch [:rf.route/handle-url-change (current-url)])))
 
-  which dispatches the URL-change event WITHOUT a `:frame`, so it lands
-  on `:rf/default`. That is correct only while `:rf/default` owns the
-  URL. When a non-default frame opts into URL binding
+  which dispatches the URL-change event WITHOUT a `:frame`. Under Spec
+  002's no-fallback ladder there is no `:rf/default` floor: a frameless
+  ambient dispatch fails with `:rf.error/no-frame-context` — the runtime
+  never synthesises or selects a default frame. So a hand-rolled listener
+  has to name its target explicitly, and it must name the RIGHT one. When
+  a non-default frame opts into URL binding
   (`(reg-frame :my-frame {:url-bound? true})`, with `:rf/default`
   releasing ownership via `{:url-bound? false}` — the single-non-default
   owner case, rf2-6qgbs.3), the PUSH side correctly routes through that
-  frame (`url-owner-frame-id` gates `:rf.nav/push-url`), but a
-  default-targeted popstate dispatch would update `:rf/default`'s
-  (frozen) slice instead of the owner's — so Back/Forward never restored
+  frame (`url-owner-frame-id` gates `:rf.nav/push-url`), but a popstate
+  dispatch targeted at the wrong (or defaulted) frame would update that
+  frame's slice instead of the owner's — so Back/Forward never restored
   the visible route (rf2-6qgbs.4).
 
   `install-history-listener!` resolves the URL owner AT POP TIME via

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -883,8 +883,8 @@
   ;; CI job is `cljs-reagent-slim-bundle-isolation` in .github/workflows/test.yml.
   ;;
   ;; The `:init-fn` is the gate-owned entrypoint
-  ;; `counter-slim-and-fast.bundle-isolation-entry/run` — NOT the teaching
-  ;; `counter-slim-and-fast.core/run`. The entry boots the same app and
+  ;; `reagent-slim.counter.bundle-isolation-entry/run` — NOT the teaching
+  ;; `reagent-slim.counter.core/run`. The entry boots the same app and
   ;; additionally exercises the pure-CLJS `render-to-static-markup` path so
   ;; Contract 4 (S3-005 non-vacuity) has signal; keeping the fixture behind
   ;; this entry leaves the teaching `core` namespace free of harness plumbing
@@ -1454,9 +1454,10 @@
   ;; core.cljc's :clj-side `handle-request` would stream chunk-by-
   ;; chunk via `re-frame.ssr.ring/stream-handler`. The CLJS branch
   ;; reads the inline __rf_payload and dispatches :rf/hydrate against
-  ;; the seeded app-db (the streaming-runtime client shim is a
-  ;; future host-opt-in; the worked example demonstrates the JVM-
-  ;; side primitive shape).
+  ;; the seeded app-db, then installs the streaming-runtime client
+  ;; shim (`ssr/streaming-install!`, called in `run`) — the shim ships
+  ;; and the example wires it up, so both the JVM-side primitive shape
+  ;; and the client-side reveal path are exercised end-to-end.
   :examples/ssr-streaming
   {:target     :browser
    :output-dir "out/examples/ssr-streaming"


### PR DESCRIPTION
Fixes the 12 stale docstring/comment sites in `examples/` + `implementation/` flagged by the examples-README accuracy sweep (#5204 fixed the READMEs; the same drift lived in code prose, left untouched per that review's constraints). Each site was verified against the current code/spec before editing. No code logic changed — prose only.

## Sites fixed (12)

1. **examples/capabilities/ssr/ssr/core.cljc** — ns docstring claimed `index.html` is "a frozen snapshot of exactly what `handle-request` produces". It's hand-authored and not byte-exact (deliberately omits the render-hash attr + payload key a real server stamps). Reworded to "runnable stand-in … not byte-exact".
2. **examples/capabilities/resources/infinite_feed/core.cljs** — view-model list named `:has-data?` (not read) and omitted `:error` (read); fixed. Also "a real fetch" → the transport is canned but the resource machinery above it is real.
3. **examples/real-apps/realworld_resources/http.cljs** — docstring named a nonexistent `install-demo-backend!` helper; the stub fx `:realworld-resources.demo/http-stub` is registered at ns load and wired via `:fx-overrides` in core.cljs. Corrected.
4. **implementation/routing/src/re_frame/routing/history.cljc** — docstring said a frameless popstate dispatch "lands on `:rf/default`"; contradicts Spec 002's no-fallback ladder (`:rf.error/no-frame-context`, runtime never synthesises a default). Rewritten.
5. **implementation/shadow-cljs.edn** — (a) `:examples/ssr-streaming` comment called the client shim "a future host-opt-in"; `ssr/streaming-install!` ships and the example calls it in `run`. (b) `:examples/counter-slim-and-fast` comment named old ns `counter-slim-and-fast.{bundle-isolation-entry,core}`; actual is `reagent-slim.counter.{bundle-isolation-entry,core}`.
6. **examples/core/seven_guis/cells/core.cljs** — PARSER comment claimed the parser "runs just as happily on the JVM"; file is `.cljs` and uses `js/parseFloat`/`js/isNaN` (CLJS-only). Reworded; matching ns-docstring bullet ("no host I/O, runs anywhere") corrected too.
7. **examples/core/counter/core.cljs** — docstring said "one view"; registers two (`counter-buttons`, `counter-app`).
8. **examples/substrates/helix/process_monitor/core.cljs** — "filterable process list"; clicking a process filters the LOG feed, not the list. Reworded to "selectable … click to filter the logs".
9. **examples/patterns/long_running_work/worker.cljs** — two comments said exit fires "the one `:rf.machine/destroy`"; `:spawn-all` is sugar over N `:spawn`s (Spec 005), so exit fires one destroy fx per surviving child.
10. **examples/core/flows/core.cljs** — `:cart/remove-discount` docstring said `clear-flow` "resets its output to nil"; Spec 013 specifies `dissoc-in` removal (key removed, not nil).
11. **examples/patterns/nine_states/core.cljs** — render-priority comment said "error first, then loading"; the table below it is loading first, then error. Comment corrected to match the table.
12. **examples/capabilities/machines/state_machine_walkthrough/core.cljc** — two section-heading citations pointed at headings that no longer exist in docs/machines/concepts.md (`§The same flow as a transition table`, `§Composing with async effects`); repointed to live headings (`§A machine at a glance`, `§An action returns effects`).

Out of scope (bead-noted but explicitly "not comments" + do-not-change-behaviour): realworld_http auth-form write-only `:status` field and unused `:articles/cancel`/`:feed/cancel` events.

## Quality gates

- `npm run test:cljs` — PASS (8058 tests, 37000 assertions, 0 failures, 0 errors).
- `npm run test:elision` — PASS (production 46/46 absent, control 46/46 present; EP-0023 provenance + assembly-DCE green). The two "unreachable code" warnings are pre-existing in `frame_classification.cljc`, a file this PR does not touch.