### PR TITLE
docs(mayor-method): retire the dashboard — decisions.md is the operator index

### DIFF
--- a/docs/the-mayor-method/README.md
+++ b/docs/the-mayor-method/README.md
@@ -24,7 +24,7 @@ Prompt engineering and context management are still the keys.
 - [Beads](https://github.com/gastownhall/beads) are used to work.
 - Prompts are treated very seriously.
 - Git worktrees isolate workers.
-- `/ai/dashboard.md` keeps me oriented.
+- `/ai/decisions.md` tracks the calls waiting on me.
 - I make the important calls.
 
 The rest is good discipline.
@@ -110,7 +110,7 @@ Keep AI working material out of the product tree:
   spec, or docs.
 - `/ai/extended-context/` — durable project context not obvious from code.
   The mayor consults it on bootstrap and contributes on retrospectives.
-- `/ai/dashboard.md` — my dashboard.
+- `/ai/decisions.md` — the index of holds awaiting the operator (review gates, operator-run actions, held beads).
 
 ## Beads are the work queue
 
@@ -166,8 +166,7 @@ Before merging, the mayor checks:
 - tests or CI are green;
 - bead state will be updated after merge.
 
-After merge, the mayor pulls main, closes the bead with a concrete reason,
-and updates `/ai/dashboard.md`.
+After merge, the mayor pulls main and closes the bead with a concrete reason.
 
 This is the difference between "a lot of agents did things" and "the
 project advanced."
@@ -229,8 +228,8 @@ Different lenses find different issues.
 ## Standing prompts
 
 The cron prompts I register with the scheduler are defined in
-[`bootstrap.md`](bootstrap.md). Five `/loop` blocks: bead dispatch,
-clustering review, worktree hygiene, PR merge, and dashboard.md upkeep. Each
+[`bootstrap.md`](bootstrap.md). Four `/loop` blocks: bead dispatch,
+clustering review, worktree hygiene, and PR merge. Each
 carries its own operating manual inline (short-circuit rules,
 phase-transition behaviour, `--admin` discipline, the Windows-worktree
 merge trap recovery sequence). Register them once with your local

--- a/docs/the-mayor-method/bootstrap.md
+++ b/docs/the-mayor-method/bootstrap.md
@@ -18,11 +18,10 @@ git-history record.
 prompts; paste the worktree-boundary block verbatim into every editing
 dispatch), then `README.md` (the longer "why"; refer back to sections as needed).
 
-**Dashboard.** Maintain `ai/dashboard.md` for the operator: timestamp, one-line
-resume command, then "what needs the operator now" (decisions, blockers, files
-they are editing), then in-flight work, open PRs, recent merges. Short enough
-that a returning operator re-orients in 30 seconds. Update on every signal —
-don't batch.
+**Decisions.** Keep `ai/decisions.md` current: every hold awaiting the
+operator — review gates, operator-run actions, held beads — goes in it the
+moment it arises, and comes out when resolved. Everything else operator-facing
+goes in chat; there is no dashboard to maintain.
 
 **Findings vs extended-context.** `ai/findings/` is gitignored exploratory work
 (audits, drafts, alternatives); always write the finding doc BEFORE filing the
@@ -44,8 +43,8 @@ convention — if already landed, close as `verified-duplicate of #NNNN`.
 pending check is structurally irrelevant to the diff — name the gate, name why
 the diff cannot affect it, then merge; a failing test on the touched surface is
 never an --admin candidate). Post-merge: `git pull --ff-only`, verify worker
-closed the bead (close it if not), update `ai/dashboard.md`, mention follow-on
-beads filed by the worker.
+closed the bead (close it if not), mention follow-on beads filed by the
+worker.
 
 **Operator decisions.** Surface design / product / security / taste decisions
 explicitly. Explain options + trade-offs; recommend when useful; let the
@@ -82,8 +81,8 @@ of a drain; the binding rule is hot-zone parallelism, not strict same-surface.
   project's stance deliberately excludes (e.g. egress the threat model doesn't
   cover). Hold it as an operator decision; surface, don't auto-fix. Don't gold-plate.
 - *Quiescent is a valid state.* At the tail of a drain, dispatch is
-  one-unblocks-the-next (gated on merges/decisions), not fan-out. Hold, keep the
-  dashboard honest, surface what needs the operator — don't manufacture work.
+  one-unblocks-the-next (gated on merges/decisions), not fan-out. Hold, keep
+  `ai/decisions.md` honest, surface what needs the operator — don't manufacture work.
 - *Checkpoint tracker state on the heartbeat.* Many trackers auto-stage but never
   commit; commit + push the tracker file each cycle so a long session's state
   isn't stranded locally.
@@ -94,7 +93,6 @@ of a drain; the binding rule is hot-zone parallelism, not strict same-surface.
 - 30m — cluster review (3+ same-surface beads → one PR; 8–12 sweet spot)
 - 30m — merge PRs (green or structurally-irrelevant `--admin`)
 - 15m — bead dispatch pass (filter out decisions/EPICs/release-coupled/v1.x/hot-zone)
-- 10m — dashboard refresh
 
 Codify the loop bodies as commands (this repo: `.claude/commands/mayor-*.md`)
 so each is a single invocation and one source of truth, rather than re-pasted prose.


### PR DESCRIPTION
Follow-up to #5201, which refreshed CLAUDE.md's dashboard rules: this sweeps the same 2026-06-20 retirement through the mayor-method docs. All eight `ai/dashboard.md` references removed — the principles bullet and ai/-tree row now point at `ai/decisions.md` (the index of holds awaiting the operator), the post-merge step and PR-merge loop drop their dashboard-update clauses, bootstrap's **Dashboard** paragraph becomes a **Decisions** paragraph, the quiescent-state guidance keeps decisions.md honest instead, and the 10m dashboard-refresh loop leaves the roster (README's loop count updated to match). No `mayor-dashboard` command file existed, so `.claude/commands/` needed no change.

Gates: mkdocs strict pass; check_doc_slugs exit 0.