### PR TITLE
docs(core): the voice pass — a person talks you through the core guide

### DIFF
--- a/docs/core/AUTHORING.md
+++ b/docs/core/AUTHORING.md
@@ -33,12 +33,16 @@ Mode rules, stated as what each mode *forbids*: a **tutorial** page never catalo
 
 The test in every register: would it sound natural said aloud, and could a tired engineer follow it at 11pm? The reader knows React or Redux but is new to re-frame2 — meet them as a knowledgeable colleague, not as a terse README and not as an essay.
 
+- **A person is talking.** The corpus speaks in first person where an opinion is being offered, and the opinions are owned, not hedged ("two copies of one truth is two chances to disagree"). First-person *conviction* must restate something the project actually holds (the specs, READMEs, and existing docs are full of them); first-person *biography* is off-limits — never invent personal history.
 - **Explain the why, not just the what.** After an instruction, a short *because* / *which means* / *so that* clause earns its keep. A senior dev tells you why a thing works, briefly.
-- **Vary your rhythm and connect your ideas.** Mix sentence lengths; carry the reader with transitions ("Now that X works…", "Here's the catch…", "The reason this matters…"). Stacks of clipped four-word sentences read cold — that's the failure mode to avoid.
+- **Rhythm is the instrument.** Short paragraphs — one sentence is fine, one word occasionally ("Don't.") — alternating with a longer roller that carries the payload. The failure mode isn't short sentences; it's *uniform* ones. Read it aloud: if every sentence is the same length, rewrite.
+- **Ask the reader's next question, then answer it.** Socratic headers ("Why Bother Naming Something So Trivial?") and self-answered questions in prose ("Fine. But what data?") are house devices in the teaching registers. Use them where they genuinely track the reader's thinking, not as decoration.
+- **One committed metaphor per concept, promoted to vocabulary.** The spreadsheet for derivations, the circuit breaker for extractors, the sandwich for interceptors. Pick one, use it for the whole page (and corpus), never mix two images in one explanation.
+- **Flag the load-bearing sentence.** Every teaching page has one sentence the rest hangs off. Say so, out loud: "I'll pause while you read that again." One per page.
 - **Be warm, and on the reader's side.** Acknowledge what trips people up, what they might expect, what they can ignore for now. That small gesture is most of what reads as friendly.
 - **Trust the reader with the obvious.** Calm seniority, not anxious over-hedging: spend the words on what's genuinely hard, not on what they already know.
-- **Humor is seasoning, Yegge-calibrated.** An occasional flash of conversational candor or a vivid concrete image in the *teaching* registers is welcome — the absurdity of a bug class, the honest confession of what everyone gets wrong the first time. The guardrails that keep it from rotting back into the essayist voice: the humor rises out of the material, never bolted on; the sentence must survive the joke's deletion; never in reference mode, never inside a gotcha; about one moment per page. When in doubt, cut it.
-- **Never show off.** Still the standing guardrail: no aphorism-per-paragraph, no flourish for its own sake, no deep-cut analogies. Anchor to one tool the reader knows. One bolded takeaway per page, not one per paragraph.
+- **Humor is seasoning — about one moment per screenful** in the teaching registers, straight prose between. The riff form is escalate-then-deflate (ride a true idea past reasonableness, then pull back: "Too much? Okay, fine.") — at most one riff per page, and the deflation is mandatory. Honest hedging is part of the register: a made-up number is flagged made-up in the same breath. Never in reference mode; the sentence must survive the joke's deletion. When in doubt, cut it.
+- **Never trade precision for charm.** The discipline that makes the rest work: every error id, signature, and semantic claim stays exact, and the jokes sit *beside* the contract statements, never instead of them. No aphorism-per-paragraph, no deep-cut analogies; anchor to one tool the reader knows.
 
 **Two standing lens-callouts run terser than their page.** A callout is dense by design, so both families drop the warmth and compress:
 
@@ -51,7 +55,7 @@ A reader goes top to bottom. The first time a page uses a core term — `app-db`
 
 ## Callouts
 
-Callouts are **MkDocs admonitions** — never bold-lead blockquotes — and the expanded-vs-collapsed choice turns on how skippable the content is:
+Callouts are **MkDocs admonitions** — never bold-lead blockquotes — and the expanded-vs-collapsed choice turns on how skippable the content is. One carve-out first: a *single-beat* warning may skip the box entirely and be said in plain prose at the point of need ("One rookie mistake will quietly defeat this, so hear it now: …") — that's the voice doing the callout's job. Box the warning when it needs a title to be scannable, carries multiple paragraphs, or must survive a skim; say it in prose when it's one sentence the reader is already mid-flow past. For the boxed kind:
 
 - **Footguns and gotchas** → `!!! warning "Gotcha — …"`, expanded, inline beside the risky step. A footgun the reader scrolls past unread has failed at its one job.
 - **Notes, heads-ups, "why this matters", "when not to"** → `!!! note "…"`, expanded.

--- a/docs/core/concepts/app-db.md
+++ b/docs/core/concepts/app-db.md
@@ -1,12 +1,18 @@
 # app-db: the one place
 
-Your application's state — all of it — lives in one place: a single immutable map called [**app-db**](../glossary.md#app-db). That is the whole answer, and almost everything else in re-frame2 stays simple *because* of it.
+Your application's state — all of it — lives in one place: a single immutable map called [**app-db**](../glossary.md#app-db).
 
-This page builds that idea up one step at a time: first the map and the one thing allowed to change it, then where the first value comes from, then the handful of properties you get for free, and finally the framework's own bookkeeping that lives next door and the surgical lane that tests and tools use.
+That is the whole answer. Almost everything else in re-frame2 stays simple *because* of it.
+
+If you have a background in OO, that first sentence is a hard one to swallow. You've spent your career breaking systems into pieces, organising them around behaviour, hiding state where nothing can touch it — and here is a framework asking you to lay every fact your app knows in one big map, exposed and passive. I still wake up in a sweat some nights thinking about all that Clojure data just lying around.
+
+The cure for the sweats is knowing exactly what the exposure buys, and that is this page's job. One step at a time: first the map and the one thing allowed to change it; then where the first value comes from; then the handful of properties you get for free; and finally the framework's own bookkeeping that lives next door, and the surgical lane that tests and tools use.
 
 ## The counter grows a second fact
 
-[Our first app](../first-app.md)'s counter knows one fact: its value. Give it a second — an adjustable step size — and you've hit the first real design question of any growing app: *where does the new fact live?* In re-frame2 the answer never changes. It goes in the same map:
+[Our first app](../first-app.md)'s counter knows one fact: its value. Give it a second — an adjustable step size — and you've hit the first real design question of any growing app: *where does the new fact live?*
+
+In re-frame2 the answer never changes. It goes in the same map:
 
 ```cljs-rf2
 (require '[re-frame.core :as rf])
@@ -42,7 +48,9 @@ This page builds that idea up one step at a time: first the map and the one thin
  [stepping-counter]]
 ```
 
-No second atom, no context, no module-level variable holding the step. app-db grew from the first app's one-fact shape to `{:value 0 :step 1}`, the `:inc` handler reads both facts from the one map it was already handed, and everything you learned about the first fact — how it changes, who may write it, how views watch it — is automatically true of the second. That scaling move is this page's whole subject.
+No second atom. No context. No module-level variable holding the step. app-db grew from the first app's one-fact shape to `{:value 0 :step 1}`, the `:inc` handler reads both facts from the one map it was already handed, and everything you learned about the first fact — how it changes, who may write it, how views watch it — is automatically true of the second.
+
+That scaling move is this page's whole subject.
 
 ## One map, one writer
 
@@ -62,11 +70,13 @@ Nested maps, vectors, sets, keywords. Ordinary data, no imposed schema. And exac
     {:db (update-in db [:cart :items] conj item)}))
 ```
 
-Read that carefully, because it is the whole immutability story in four lines. The handler receives the current map as `db` (pulled out of the argument map by `{:keys [db]}`, Clojure's way of saying "bind the `:db` key to a local named `db`"). It does not *change* that map: `update-in` returns a *new* map with one nested spot updated — here, `conj` (add an element) appends the item onto the items vector. The handler hands that new map back as its `:db` effect.
+Those four lines are the whole immutability story, so walk them slowly. The handler receives the current map as `db` — pulled out of the argument map by `{:keys [db]}`, Clojure's way of saying "bind the `:db` key to a local named `db`". It does not *change* that map: `update-in` returns a *new* map with one nested spot updated — here, `conj` (add an element) appends the item onto the items vector. The handler hands that new map back as its `:db` effect.
 
-Then the runtime does the only mutable step in the whole story. The map itself is immutable, but the name `app-db` is a mutable reference that *points* at a map, and the runtime swaps which map it points at — old value out, new value in, one atomic move. The old value still exists, untouched. The new one shares almost all of its structure with the old one — Clojure's persistent data structures don't copy, so the new map just points at the unchanged parts of the old one. Nobody ever observes anything halfway.
+Then the runtime does the only mutable step in the whole story. The map itself is immutable, but the name `app-db` is a mutable reference that *points* at a map, and the runtime swaps which map it points at — old value out, new value in, one atomic move. (This is also why the docs say `app-db` for the place and `db` for the value currently in it — worth keeping straight as you read code.) The old value still exists, untouched. The new one shares almost all of its structure with the old one — Clojure's persistent data structures don't copy; the new map just points at the unchanged parts of the old one. Nobody ever observes anything halfway.
 
-That is the entire shape of state in re-frame2: **structured data in one map; events in, new map out.** You can hold that and start writing apps. The rest of this page is what follows from it.
+That is the entire shape of state in re-frame2: **structured data in one map; events in, new map out.**
+
+I'll pause while you read that again. Hold it and you can start writing apps — the rest of this page is what follows from it.
 
 ??? info "Coming from Redux?"
 
@@ -78,9 +88,7 @@ That is the entire shape of state in re-frame2: **structured data in one map; ev
 
 Not every event has to return a new map, though. A handler that returns no `:db` key — or returns the *same* `db` object it was handed — changes nothing, on purpose. An event that only fires effects (a `:fx` with no `:db`) leaves app-db exactly as it was; so does the common short-circuit `{:db (if changed? (assoc db …) db)}`, whose `else` arm hands back the unchanged object. The runtime notices that object is the one it already holds (an `identical?` check, cheaper than comparing values) and skips the write entirely — no commit, no subscription recompute, nothing downstream re-renders. "Events in, new map out" is the shape; "no new map" is a legitimate special case of it.
 
-!!! warning "Gotcha — `{:db nil}` wipes app-db; it doesn't error"
-
-    app-db is *always* a map, never `nil`. So a handler that accidentally computes `{:db nil}` — a `get-in` that missed, a threading macro that fell off the end — doesn't throw: the runtime coerces the `nil` to `{}` and emits a dev-mode `:rf.warning/db-nil-coerced` diagnostic, because that pattern is almost always a bug quietly erasing your state. If you *mean* to clear app-db, say so explicitly with `{:db {}}` (which fires no warning). the symptom is "my whole app went blank after that event," and the warning in the console is the thread to pull.
+One gotcha will bite you exactly once, so hear it now: **`{:db nil}` wipes app-db, and it doesn't error.** app-db is *always* a map, never `nil`. So a handler that accidentally computes `{:db nil}` — a `get-in` that missed, a threading macro that fell off the end — doesn't throw: the runtime coerces the `nil` to `{}` and emits a dev-mode `:rf.warning/db-nil-coerced` diagnostic, because that pattern is almost always a bug quietly erasing your state. If you *mean* to clear app-db, say so explicitly with `{:db {}}`, which fires no warning. The symptom is "my whole app went blank after that event"; the warning in the console is the thread to pull.
 
 Here's the "one map" claim, live. Two views below share one value — the input edits it, the badge reads it — and neither owns a copy, so there is nothing to drift out of sync. Click into the cell, press **`Ctrl-Enter`** (**`Cmd-Enter`** on macOS) to evaluate, then type into the input that appears — the badge follows every keystroke:
 
@@ -113,13 +121,13 @@ Here's the "one map" claim, live. Two views below share one value — the input 
  [:div [name-editor] [name-badge]]]
 ```
 
-!!! tip "Try it"
-
-    Add a third view reading the same subscription — `(defn greeter [] [:p "Welcome back, " @(rf/subscribe [:appdb.demo/name])])`, mounted beside the others — and re-evaluate. Three windows, still one value, and you wrote no synchronisation code to keep them agreeing.
+Want a third witness? Add another view reading the same subscription — `(defn greeter [] [:p "Welcome back, " @(rf/subscribe [:appdb.demo/name])])`, mounted beside the others — and re-evaluate. Three windows, still one value, and you wrote no synchronisation code to keep them agreeing.
 
 ### Where the first value comes from
 
-If a handler only ever *transforms* app-db, what hands it the very first one? Every [frame](../glossary.md#frame) — the isolated, independently-running instance of your app that app-db belongs to — starts with `app-db` equal to the empty map `{}`. There is no `:db` config slot to seed it with. Seeding the initial state is itself an event, so it runs through the same [event pipeline](../glossary.md#event-pipeline) as every later change. You list the setup events when you register the frame, as `:initial-events`, and the conventional first step seeds app-db with the built-in `:rf/set-db` event:
+If a handler only ever *transforms* app-db, what hands it the very first one?
+
+Every [frame](../glossary.md#frame) — the isolated, independently-running instance of your app that app-db belongs to — starts with `app-db` equal to the empty map `{}`. There is no `:db` config slot to seed it with. Seeding the initial state is itself an event, so it runs through the same [event pipeline](../glossary.md#event-pipeline) as every later change. You list the setup events when you register the frame, as `:initial-events`, and the conventional first step seeds app-db with the built-in `:rf/set-db` event:
 
 ```clojure
 (rf/reg-frame :app
@@ -132,7 +140,13 @@ If a handler only ever *transforms* app-db, what hands it the very first one? Ev
 
 The steps dispatch synchronously, in order, each one run to completion before the next, so by the time `reg-frame` returns app-db is in whatever state they produced. The point is consistency: the first value of app-db is built by the same dispatch you use for the millionth. [Frames](frames.md) covers `:initial-events` and the rest of the registration grammar in full.
 
-`:rf/set-db` is an ordinary event in every respect: it commits a `:db`, rides schema validation once you add one (next section), and shows up in the trace — the framework's per-event record, which tools like Xray read. One thing is worth knowing: it *replaces* the whole of app-db with the map you give it, rather than merging into what's there. That is exactly what you want for a fresh `{}` frame, and it is the right tool for a test fixture that wants a clean known state. For an ordinary in-place change you still write your own event; `:rf/set-db` is the wholesale-replace one. (It takes exactly one map argument — a non-map, or extra arguments, raise `:rf.error/set-db-bad-value`; and because the `:rf/*` namespace is the framework's, re-registering `:rf/set-db` in your own code is a loud `:rf.error/reserved-event-id` collision.)
+`:rf/set-db` is an ordinary event in every respect: it commits a `:db`, rides schema validation once you add one (next section), and shows up in the trace — the framework's per-event record, which tools like Xray read.
+
+Notes:
+
+1. It **replaces** the whole of app-db with the map you give it, rather than merging into what's there. That is exactly what you want for a fresh `{}` frame, and it is the right tool for a test fixture that wants a clean known state. For an ordinary in-place change you still write your own event; `:rf/set-db` is the wholesale-replace one.
+2. It takes exactly one map argument — a non-map, or extra arguments, raise `:rf.error/set-db-bad-value`.
+3. The `:rf/*` namespace is the framework's, so re-registering `:rf/set-db` in your own code is a loud `:rf.error/reserved-event-id` collision.
 
 ??? info "From re-frame v1"
 
@@ -140,21 +154,31 @@ The steps dispatch synchronously, in order, each one run to completion before th
 
 ## A database, on purpose
 
-The name is `app-db`, not `app-state`, and the `db` carries weight. Not in the storage sense — it is all in memory, and nothing survives a reload unless you make it. The weight is in the mindset. Think how much care you give data in PostgreSQL: a schema, invariants, deliberate queries, atomic transactions, and no random function scribbling on a row as a side effect. Now think how much care the average frontend gives data scattered across thirty `useState`s. app-db asks you to treat your in-memory state with that same database care: structured data in, reads out through [subscriptions](../glossary.md#subscription) (named, cached, pure derivations of the map), and changes only through events. The name is a discipline disguised as a noun.
+The name is `app-db`, not `app-state`, and the `db` carries weight. `app-state` would arguably be the more accurate name; `app-db` is the more useful one, because it tells you how to *treat* the thing.
+
+Treat it as an in-memory database. Not in the storage sense — it is all in memory, and nothing survives a reload unless you make it — but in the working sense: it holds structured data; you query it, through [subscriptions](../glossary.md#subscription) (named, cached, pure derivations of the map); you transact on it atomically, through events. Nothing scribbles on a row as a side effect.
+
+None of this is remotely controversial for *real* databases. You'd happily give PostgreSQL every well-formed fact you own — behind a schema, with invariants, deliberate queries, atomic transactions. Then the same team hands its in-memory state — often the very same rows, freshly fetched — a `useState` here, a `useState` there, a context for the theme, a ref for the scroll position, a module-level singleton somebody swore was temporary, and a bolted-on store for whatever got embarrassing. Six homes. No schema. Nothing you can print.
+
+Too harsh? A little. But distributing state like that, then writing code to keep the copies agreeing, all while trying to *hide* it — that is, when you think about it, quite crazy. And I did it for years.
+
+app-db asks you to give your in-memory data the PostgreSQL kind of care. The name is a discipline disguised as a noun.
 
 You can [add a schema](../how-to/validate-with-schemas.md) when you want the app to scream the instant the shape goes wrong — but you never have to, and nothing forces one on you.
 
-> *Well-formed data at rest is as close to perfection in programming as it gets.* — [Fogus](https://twitter.com/fogus/status/454582953067438080)
+> *Well-formed data at rest is as close to perfection in programming as it gets. All the crap that had to happen to put it there however...* — [Fogus](https://twitter.com/fogus/status/454582953067438080)
+
+He's right on both counts, and this framework is organised around both sentences. The data at rest is app-db. The crap that has to happen to put it there is exactly what the event pipeline exists to manage.
 
 ## Why one place pays for itself
 
-Most frameworks let state live anywhere: any component's `useState`, a context, a ref, an external store. Every one of those is a place state can hide, and a way two copies can quietly disagree. re-frame2 makes the opposite bet, and you get four properties that are genuinely hard to buy any other way:
+Most frameworks let state live anywhere: any component's `useState`, a context, a ref, an external store. Every one of those is a place state can hide, and a way two copies can quietly disagree. re-frame2 makes the opposite bet, and you get four properties that are genuinely hard to buy any other way.
 
-1. **No synchronisation code.** When a piece of data has exactly one home, no code copies it to a second home and keeps the two in step. The "these two parts of the screen disagree" bug can't occur, because there are no copies to drift. You don't write the sync code, you don't debug it — you just have less app.
+1. **No synchronisation code.** This is the big one. When a piece of data has exactly one home, no code copies it to a second home and keeps the two in step. The "these two parts of the screen disagree" bug can't occur, because there are no copies to drift. I cannot stress enough how significant this is: you don't write the sync code, you don't debug it — you just have less app.
 
 2. **State changes are transactional.** Each event handler returns one new app-db, and the runtime [commits](../glossary.md#commit) it atomically. There is no instant where the cart total has updated but the items haven't, so there's no intermediate inconsistency for a subscription to read and render. Either the whole transition happened or none of it did.
 
-3. **One schema validates the whole app.** All state is one map, so a single [schema](../glossary.md#schema) can describe the entire application and run in one place: after every event, in dev. Because it spans the *whole* map, that schema can state relationships *between* values ("if logged in, a token must be present") — something thirty scattered state cells never could. [Validate with schemas](../how-to/validate-with-schemas.md) shows how.
+3. **One schema validates the whole app.** All state is one map, so a single [schema](../glossary.md#schema) can describe the entire application and run in one place: after every event, in dev. **All of it.** And because it spans the *whole* map, that schema can state relationships *between* values ("if logged in, a token must be present") — something thirty scattered state cells never could. [Validate with schemas](../how-to/validate-with-schemas.md) shows how.
 
 4. **Undo and time-travel come for almost nothing.** Snapshotting an immutable map takes a *reference*, not a copy, so structural sharing makes a ring buffer of hundreds of past values nearly free. Undo is "swap the reference back". [Xray](../glossary.md#xray)'s [epoch](../glossary.md#epoch) history — the thing that lets you scrub a running app backwards — is literally this. You don't build undo; you discover you already have it.
 
@@ -173,11 +197,9 @@ One small distinction matters everywhere in re-frame2, so meet it here. A key th
 (get-in {:page nil} [:page])   ;; => nil — the key is there, holding nil
 ```
 
-A bare `get` can't tell them apart, and the framework preserves the difference wherever it matters. Did the server send `null`, or send nothing? Is this form field cleared, or never touched? Those are different questions, and the answers shouldn't collapse into one.
+A bare `get` can't tell them apart, and the framework preserves the difference wherever it matters. Did the server send `null`, or send nothing? Is this form field cleared, or never touched? Different questions. The answers shouldn't collapse into one.
 
-!!! warning "Gotcha — some surfaces drop `nil` on purpose"
-
-    A few surfaces treat `nil` as absence on purpose — routing drops a `nil` query parameter from the URL, for example. That is always a declared, local policy, never an accidental erasure.
+One caveat, said plainly: a few surfaces treat `nil` as absence *on purpose* — routing drops a `nil` query parameter from the URL, for example. That is always a declared, local policy, never an accidental erasure.
 
 ## Paths, in four lines
 
@@ -273,9 +295,7 @@ Call these **state surgery**. They don't run a handler, fire no effects, and car
 - **Tooling.** [Xray](observability.md) time-travel — and the pair MCP, the tooling server an AI pair-programmer drives a live app through — rewind a running frame with `restore-epoch!`; an inspector may install a captured state to reproduce a bug.
 - **Framework internals.** Restore, SSR hydration, and frame reset replace whole partitions — privileged runtime code, never your handlers.
 
-!!! warning "Gotcha — never reach for state surgery in application code"
-
-    These are not a faster `assoc`. Calling `replace-app-db!` from a handler or a view forges a value with no event behind it: nothing appears in the [trace](observability.md), the [epoch](../glossary.md#epoch) ledger has no run to show, none of the per-event commit machinery runs, and any subscription or machine that assumed an event caused the change is now looking at a state nobody can explain. The very inspectability you bought by putting state in one place evaporates the moment a write skips the pipeline. If app code wants to change state, it dispatches an event — full stop.
+Now the warning, plainly, because it is the whole point of the two-lane design: **never reach for state surgery in application code.** These are not a faster `assoc`. Calling `replace-app-db!` from a handler or a view forges a value with no event behind it: nothing appears in the [trace](observability.md), the [epoch](../glossary.md#epoch) ledger has no run to show, none of the per-event commit machinery runs, and any subscription or machine that assumed an event caused the change is now looking at a state nobody can explain. The very inspectability you bought by putting state in one place evaporates the moment a write skips the pipeline. If app code wants to change state, it dispatches an event — full stop.
 
 ??? warning "Gotcha — surgery is elided from release builds"
 
@@ -306,7 +326,7 @@ Don't take the "one inspectable value" claim on faith. It is the most useful pro
 (pprint (rf/app-db-value :app))         ;; read the app partition — your data
 ```
 
-Your entire application state, printed top to bottom, readable as a map. `app-db-value` is the non-reactive snapshot read — the one for tools, tests, and the REPL, distinct from the front-door `subscribe`. Two sibling readers complete the set when you want to see the framework's side too:
+Your entire application state, printed top to bottom, readable as a map. The in-memory database, answering a query. `app-db-value` is the non-reactive snapshot read — the one for tools, tests, and the REPL, distinct from the front-door `subscribe`. Two sibling readers complete the set when you want to see the framework's side too:
 
 ```clojure
 (pprint (rf/runtime-db-value :app))     ;; the framework partition — routes, machines, …

--- a/docs/core/concepts/coeffects.md
+++ b/docs/core/concepts/coeffects.md
@@ -1,10 +1,12 @@
 # Coeffects: the way in
 
-[Effects](effects.md) covered impurity going *out*: a handler returns descriptions and the runtime performs them. This page is the other direction — the facts a handler *reads*. The current time, a `localStorage` value, a fresh id: reaching out and grabbing them would cost the handler its purity, so re-frame2 delivers them instead, as declared, **recorded** inputs called [coeffects](../glossary.md#coeffect). The recording is the point, and by the end of the page you'll see why it's non-negotiable.
+[Effects](effects.md) covered impurity going *out*: a handler returns descriptions and the runtime performs them. This page is the other direction — the facts a handler *reads*.
+
+The current time. A `localStorage` value. A fresh id. Reaching out and grabbing them would cost the handler its purity, so re-frame2 delivers them instead, as declared, **recorded** inputs called [coeffects](../glossary.md#coeffect). A coeffect is the state of the world, as data, as presented to your handler. The recording is the point, and by the end of the page you'll see why it's non-negotiable.
 
 ## The counter learns the time
 
-Let's give [our first app](../first-app.md) one more feature: show when the button was last clicked. It looks like throwaway decoration, but it's quietly one of the most important ideas in the framework, so it's worth slowing down for.
+Let's give [our first app](../first-app.md) one more feature: show when the button was last clicked. It looks like throwaway decoration. It's quietly one of the most important ideas in the framework, so it's worth slowing down for.
 
 Here's the constraint. A pure handler must not read the clock — if it did, replaying the same event tomorrow would compute different state, and the history the dev tools show you — a re-run of recorded events — would be a lie. So re-frame2 reads the time once, as the event enters the queue, and stamps it **onto the event**. A handler that wants the time *declares* it — one line of metadata — and receives it as a plain value:
 
@@ -38,7 +40,11 @@ Here's the constraint. A pure handler must not read the clock — if it did, rep
  [stamped-counter]]
 ```
 
-Notice what *didn't* change: the handler is still a `reg-event`, same shape as ever. All we added is `:rf.cofx/requires [:rf/time-ms]` in the metadata map, and the fact arrives flat in the handler's first argument — the `world` map, whose formal name is the [**coeffects**](../glossary.md#coeffect) map. The value was read at the instant the click entered the system and frozen onto the event's record, so the durable result depends on a *recorded* value: replay this event next week and `clicked-at` comes out byte-for-byte identical. (And notice the recorded fact is raw milliseconds — formatting belongs in the view, because pretty-printing is presentation, not state.)
+Notes:
+
+1. Notice what *didn't* change. The handler is still a `reg-event`, same shape as ever. All we added is `:rf.cofx/requires [:rf/time-ms]` in the metadata map, and the fact arrives flat in the handler's first argument — the `world` map, whose formal name is the [**coeffects**](../glossary.md#coeffect) map.
+2. The value was read at the instant the click entered the system and frozen onto the event's record, so the durable result depends on a *recorded* value. Replay this event next week and `clicked-at` comes out byte-for-byte identical.
+3. The recorded fact is raw milliseconds. Formatting belongs in the view — pretty-printing is presentation, not state.
 
 That recorded-ness is what the dev tools cash in. Open [Xray](../glossary.md#xray) on an app like this and every click is a row — the event, app-db before and after, and the recorded time; restore an older row and the counter returns to that exact moment. It falls out of three rules you're already following: state changes only through events, handlers stay pure, and world facts arrive recorded. Given those three, history *is* a list of `(event, recorded-facts)` pairs, and re-running any prefix reconstructs the exact state — there's nothing else for state to depend on. (The [Xray docs](../../xray/index.md) are the tour.)
 
@@ -55,7 +61,7 @@ Your handler needs the current time, a `localStorage` value, a fresh id — and 
     {:db (assoc-in db [:orders id] {:id id :items items :placed-at (js/Date.)})}))
 ```
 
-Now the handler isn't pure: same inputs, a different output every call. No test can pin it down without monkey-patching the global clock — and, worse, replay breaks (the [replay-pair section below](#why-this-is-non-negotiable-the-replay-pair) makes the reason precise).
+Now the handler isn't pure: same inputs, a different output every call. No test can pin it down without monkey-patching the global clock. And impure functions cause well-documented paper cuts, which have a way of accumulating non-linearly — except this one skips the accumulating and goes straight to the wound: replay breaks (the [replay-pair section below](#why-this-is-non-negotiable-the-replay-pair) makes the reason precise).
 
 These inputs-from-the-world are [**coeffects**](../glossary.md#coeffect). The symmetry, stated plainly: an effect is data the handler *outputs* for the runtime to perform; a coeffect is data the runtime *delivers* for the handler to read.
 
@@ -66,11 +72,13 @@ These inputs-from-the-world are [**coeffects**](../glossary.md#coeffect). The sy
 | **You opt in per handler with** | `:rf.cofx/requires` | (returned in the effect map) |
 | **The impure work happens in** | the cofx supplier | the [fx handler](../glossary.md#effect-handler) |
 
-That `{:keys [db]}` you destructure in every handler *is* the coeffects map. `:db` and `:event` are staged automatically; every other world fact is opt-in, through one declaration key.
+And here's the reveal: that `{:keys [db]}` you destructure in every handler *is* the coeffects map. You've been reading coeffects since your first handler. `:db` and `:event` are staged automatically; every other world fact is opt-in, through one declaration key.
+
+Sit with that map for a second, because it's grander than it looks. It is the handler's *entire observable universe*. Your app's state? In the map. The event being handled? In the map. The time, the storage read, the minted id? In the map — if declared. Everything your handler will ever know about anything arrives in its first argument, and as far as the handler is concerned, nothing else exists. (Too cosmic? Fine. It's a function argument. But it is the *only* place a handler may look, and holding that line is what the rest of this page is about.)
 
 ### Declare what you read: `:rf.cofx/requires`
 
-Nothing reaches a handler implicitly — **not even the time**. A handler declares the facts it consumes as registration metadata, and the runtime hands it exactly those, flat in the coeffects map beside `:db`:
+Nothing reaches a handler implicitly — **not even the time**. No abracadabra. A handler declares the facts it consumes as registration metadata, and the runtime hands it exactly those, flat in the coeffects map beside `:db`:
 
 ```clojure
 (rf/reg-event :checkout/place-order
@@ -143,9 +151,7 @@ One rule, no exceptions: a cofx supplier must return its value **synchronously**
 
     Same boundary, another name. A synchronous coeffect is a fact already in hand at dispatch time — like a value you read straight out of the query cache. An async read (a fetch that might be pending) can't be a coeffect for the same reason it can't be read inline in a React render: it isn't a value yet. It becomes one when it resolves — and in re-frame2 that resolution arrives as a reply event, not as a coeffect.
 
-!!! warning "Never record a secret"
-
-    Recordable values are copied into every recording, fixture, and exported trace. So crypto-grade randomness, tokens, nonces, and key material must not ride `:rf.cofx`. See [keeping secrets out of traces](../how-to/keep-secrets-out-of-traces.md).
+One warning before you register anything clever, and it's absolute: **never record a secret**. Recordable values are copied into every recording, fixture, and exported trace, so crypto-grade randomness, tokens, nonces, and key material must not ride `:rf.cofx`. See [keeping secrets out of traces](../how-to/keep-secrets-out-of-traces.md).
 
 ??? note "What about generated recordable facts?"
 
@@ -153,7 +159,7 @@ One rule, no exceptions: a cofx supplier must return its value **synchronously**
 
 ### When a declaration goes wrong
 
-Because every consumed fact is declared, the failure modes are precise and named — and the framework distinguishes a *typo* from a *genuinely-absent* value. (As always, [branch on the `:rf.error/*` category](../glossary.md#error-record), never on the human-readable reason.)
+Because every consumed fact is declared, the failure modes are precise and named — the framework can tell a *typo* from a *genuinely-absent* value, and says which one it saw. (As always, [branch on the `:rf.error/*` category](../glossary.md#error-record), never on the human-readable reason.)
 
 - **Required id that was never registered** → `:rf.error/unregistered-cofx`. Caught at registration where statically checkable, otherwise at first processing — typos die before the handler ever runs.
 - **Declared, registered, but `:provided?` and absent from the event** → `:rf.error/missing-required-cofx`, in *every* mint mode (the mint policies from the generated-facts box above). This is the case `:provided?` exists to make legible: the fact has a home and a `:schema`, so a missing supply reads as "you didn't stamp this," not "no such coeffect." (`:rf/time-ms` is the exception — the enqueue stamp guarantees it is always present.)
@@ -173,15 +179,19 @@ Recorded coeffects are the last rung, not the default. The `:checkout/place-orde
 
 ## The ledger
 
-Here's a reframing that, once it clicks, reorganises how you think about the whole app. The reflex picture of state is a whiteboard: there's a current drawing, each event erases a bit and draws something new, and the old drawing is gone. The right picture is a **ledger**: each event is a line appended to the lines before it, and the app-db you see at any moment is the running total — the result of starting from the initial state and applying every event since, in order. The handler's transform of app-db isn't "erase and redraw." It's "add the next line and re-total."
+Here's a reframing that, once it clicks, reorganises how you think about the whole app.
 
-That picture comes with a promise precise enough to test:
+The reflex picture of state is a whiteboard: there's a current drawing, each event erases a bit and draws something new, and the old drawing is gone. The right picture is a **ledger**: each event is a line appended to the lines before it, and the app-db you see at any moment is the running total — the result of starting from the initial state and applying every event since, in order.
 
-!!! note "The replay promise"
+The handler's transform of app-db isn't "erase and redraw." It's "add the next line and re-total."
 
-    **Two fresh apps, fed the same sequence of events, finish in identical states.** Start two copies from the same initial app-db, replay the same event log into each, and they land on the same value. The events *are* the state; the current app-db carries no information the log didn't put there.
+That picture comes with a promise precise enough to test — the **replay promise**:
 
-The promise has one precondition: handlers must be honest about their inputs. A handler that secretly reads the clock or mints a random id mid-fold smuggles in a value the ledger never recorded, and replay diverges. re-frame2 closes that hole structurally. World facts enter handlers as [recordable coeffects](../glossary.md#recordable-vs-ambient-coeffects), declared at registration and recorded with the event, so replay re-presents the very values the original run consumed. The rule of thumb is: *durable state folds facts, never reads.*
+> **Two fresh apps, fed the same sequence of events, finish in identical states.** Start two copies from the same initial app-db, replay the same event log into each, and they land on the same value. The events *are* the state; the current app-db carries no information the log didn't put there.
+
+I'll pause while you read that again. Everything else on this page — the grades, the strict declarations, the minting ladder — exists to keep that sentence true.
+
+Because the promise has one precondition: handlers must be honest about their inputs. A handler that secretly reads the clock or mints a random id mid-fold smuggles in a value the ledger never recorded, and replay diverges. re-frame2 closes that hole structurally. World facts enter handlers as [recordable coeffects](../glossary.md#recordable-vs-ambient-coeffects), declared at registration and recorded with the event, so replay re-presents the very values the original run consumed. The rule of thumb is: *durable state folds facts, never reads.*
 
 Hold the promise and a cluster of features stops looking like separate tricks:
 
@@ -262,3 +272,13 @@ Notice that `:demo.order/place` never calls `js/Date.` or `random-uuid`. The onl
 ## Supplying facts in tests
 
 The dispatch-opts key `:rf.cofx` hands the runtime exact facts — supplied values win, and the runtime fills only what you leave out. That two-line move (and its `:fx-overrides` sibling for stubbing effects) is [Testing event handlers](../testing/event-handlers.md)' subject.
+
+---
+
+The whole page, in note form:
+
+1. A handler computes from its arguments and nothing else. Its first argument — the coeffects map — is the state of the world, as data.
+2. `:db` and `:event` arrive free; every other world fact is declared, per handler, with `:rf.cofx/requires`.
+3. Suppliers are registered with `reg-cofx`. Recordable facts are stamped onto the event, so replay re-presents the exact values the original run consumed; ambient facts simply run again.
+4. Prefer deriving a fact from state, then minting it at the dispatch site; a recorded coeffect is the ladder's last rung.
+5. If the world can only answer asynchronously, it was never a coeffect — it's a managed effect whose answer comes back as an event.

--- a/docs/core/concepts/effects.md
+++ b/docs/core/concepts/effects.md
@@ -1,8 +1,12 @@
 # Effects: the way out
 
-Say your [event handler](../glossary.md#event-handler) needs to fire an HTTP request. It also has to stay a pure function — same inputs, same output, every time — because purity is what makes testing, replay, and time-travel work.
+This page shows you how to write pure event handlers that side-effect.
 
-The move re-frame2 makes is the one you've been leaning on since [our first app](../first-app.md): a handler never *does* anything — it returns a **description** of what should happen, and the runtime does the dirty work. This page is that output story in full: the [effect](../glossary.md#effect) grammar, effects you register yourself, and the guarantees you can build on.
+Yes. A surprising claim.
+
+Say your [event handler](../glossary.md#event-handler) needs to fire an HTTP request. It also has to stay a pure function — same inputs, same output, every time — because purity is what makes testing, replay, and time-travel work. Both demands are real. Neither bends.
+
+The way out is the move you've been leaning on since [our first app](../first-app.md): a handler never *does* anything. It returns a **to-do list** — a description of what should happen, in plain data — and the runtime does the dirty work. Hold onto that list — the whole page runs on it. What follows is the output story in full: the [effect](../glossary.md#effect) grammar, effects you register yourself, and the guarantees you can build on.
 
 ## The counter learns to act
 
@@ -44,7 +48,7 @@ One new feature for the counter: every fifth click deserves a little celebration
 
 (Reading the `cond->`: it starts from the `{:db …}` map and applies each following step only when its test is true — so the `:fx` key is added only on multiples of five.)
 
-Click to five. The `:inc` handler didn't *dispatch* anything — it returned one more key, `:fx`, holding a row that *describes* a dispatch, and the runtime performed it after committing `:db`. That's the entire idea of an effect, at counter scale.
+Click to five. Now look hard at the `:inc` handler: it didn't *dispatch* anything. It returned one more key, `:fx`, holding a row that *describes* a dispatch — one item on the list — and the runtime performed it after committing `:db`. That's the entire idea of an effect, at counter scale.
 
 ## The temptation to do it inline
 
@@ -62,15 +66,15 @@ Real apps reach outside themselves: servers, storage, timers. The counter never 
     {:db (assoc db :article/loading? true)}))
 ```
 
-This fails three ways, and the failures *are* the reasons for the architecture — not style points:
+A muddy monster truck has just parked in our field of white tulips.
 
-- **The handler isn't pure anymore.** It calls `js/fetch`. Testing it now means mocking the network. You took the most testable function in the codebase and made it the least.
+The inline fetch fails three ways, and the failures *are* the reasons for the architecture — not style points:
+
+- **The handler isn't pure anymore.** It calls `js/fetch`. Testing it now means mocking the network — and mocking should be mocked; it is a bad omen. You took the most testable function in the codebase and made it the least.
 - **The async path is a trap.** The `.then` callback fires *after* the handler returned. The `db` it closed over is the previous state, and the callback has no legal way to produce a new one. You've written a function that is half pure, half effectful, by accident.
 - **The history goes dark.** The fetch never appears in the event record. Reading the handler no longer tells you what the app will look like when the response lands. Replaying the app's events no longer reproduces its state. The inline fetch is a hole in the [ledger](coeffects.md#the-ledger) — the replayable record of everything that ever entered the app, and the asset this framework most refuses to give up.
 
-!!! warning "Gotcha — never call `js/fetch` (or any I/O) from a handler body"
-
-    A handler that performs I/O directly stops being pure, captures a stale `db` in its async callback, and vanishes from the event record. The rule is one line: *describe the effect, don't perform it.*
+So the rule is one line, and it is the load-bearing sentence of this page: **describe the effect, don't perform it.** Never call `js/fetch` — or any I/O — from a handler body; a handler that performs I/O directly stops being pure, captures a stale `db` in its async callback, and vanishes from the event record. Read the bolded sentence once more before moving on. Everything else on this page is that sentence wearing different clothes.
 
 ## Effects are data
 
@@ -106,11 +110,13 @@ Here is the same load, written so the handler stays pure. An [effect](../glossar
 
 (One more piece of syntax in those last two handlers: `(-> db (assoc :a 1) (assoc :b 2))` is the *thread-first* macro. It reads top-to-bottom — take `db`, hand it to the first `assoc`, hand *that* result to the next — so it's a pipeline of "return a copy of the map with this key set." Same purity rule as before: every `assoc` produces a new map; nothing is mutated.)
 
-The handler still returns nothing but a Clojure map: strings, keywords, vectors. No promise, no callback, no `js/fetch`. The map describes everything that should happen: "set app-db to this, fire a [managed HTTP request](../../resources/glossary.md#managed-http), on success dispatch `[:article/loaded ...]`, on failure dispatch `[:article/load-failed ...]`." The runtime reads the `:fx` row, looks up the `:rf.http/managed` [effect handler](../glossary.md#effect-handler), and performs the request. When the reply arrives, it enters the system the only way anything enters the system: as a fresh event on the queue, with its own trip through the pipeline and its own row in [Xray](../glossary.md#xray), re-frame2's inspection tool.
+The inline version **did** a fetch. This version **describes** one. The handler still returns nothing but a Clojure map: strings, keywords, vectors. No promise, no callback, no `js/fetch`. The map describes everything that should happen — the to-do list in full: "set app-db to this, fire a [managed HTTP request](../../resources/glossary.md#managed-http), on success dispatch `[:article/loaded ...]`, on failure dispatch `[:article/load-failed ...]`." The runtime reads the `:fx` row, looks up the `:rf.http/managed` [effect handler](../glossary.md#effect-handler), and performs the request. When the reply arrives, it enters the system the only way anything enters the system: as a fresh event on the queue, with its own trip through the pipeline and its own row in [Xray](../glossary.md#xray), re-frame2's inspection tool.
 
 That reply rides as the event's last argument in [the uniform reply](../glossary.md#the-uniform-reply) shape — success carries `:value`, failure carries `:error` — and every managed async surface answers the same way.
 
 Read what that bought you. The entire fetch flow is three pure handlers you read top to bottom. No `.then` chains, no stale-`db` trap, and the failure path has a *name* instead of being a branch you forgot to write. Each handler tests as a plain function. The request tests as data: assert on the map, no network required.
+
+And this pattern should feel familiar, because you already program in it all day. A [view](views.md) is a pure function that returns hiccup — a *description* of DOM — and the framework does the mutating, efficiently and discreetly. Effects are the same trick pointed at everything else the app touches.
 
 ??? info "Coming from Redux?"
 
@@ -122,10 +128,10 @@ Read what that bought you. The entire fetch flow is three pure handlers you read
 
 The `:rf.http/managed` args map carries far more than the four keys above — `:retry`, dropping a reply with `:on-failure nil`, the co-located single-handler form, the closed set of failure categories — but all of that is [Managed HTTP](../../async/http.md)'s subject.
 
-Two notes before moving on:
+Notes:
 
-- **The first argument is the coeffects map** — a [coeffect](../glossary.md#coeffect) being an input fact the handler needs from the world, gathered with everything else into one value. `:db` and `:event` arrive for free. A handler that needs more (the current time, a storage read) declares those facts at registration with `:rf.cofx/requires` and receives them as plain values in that map — no change to the handler's shape, just a line of metadata. That declaration is [Coeffects](coeffects.md)' subject.
-- **Follow-up events from inside a handler are effects too.** Never call `dispatch` from a handler body. Return `:fx [[:dispatch [:next-thing]]]` and the runtime queues it. Same rule, same reason: *describe, don't do.*
+1. **The first argument is the coeffects map** — a [coeffect](../glossary.md#coeffect) being an input fact the handler needs from the world, gathered with everything else into one value. `:db` and `:event` arrive for free. A handler that needs more (the current time, a storage read) declares those facts at registration with `:rf.cofx/requires` and receives them as plain values in that map — no change to the handler's shape, just a line of metadata. That declaration is [Coeffects](coeffects.md)' subject.
+2. **Follow-up events from inside a handler are effects too.** Never call `dispatch` from a handler body. Return `:fx [[:dispatch [:next-thing]]]` and the runtime queues it. Same rule, same reason: *describe, don't do.*
 
 ## The grammar: the effect map
 
@@ -136,7 +142,7 @@ One move covers *every* side-effect, not just state: a handler returns an [**eff
 | `:db` | Replace `app-db` with this value. |
 | `:fx` | A vector of `[fx-id args]` rows — each row names a registered [effect](../glossary.md#effect) by id and hands it one argument. *Every* other effect rides here: a dispatch, an HTTP request, a navigation, a storage write, one you wrote yourself. |
 
-Because `:fx` is just a vector, you keep adding rows. A richer checkout reads like a to-do list of side-effects:
+Because `:fx` is just a vector, you keep adding rows. A richer checkout is simply a longer to-do list:
 
 ```clojure
 (rf/reg-event :checkout/place-order
@@ -152,14 +158,16 @@ Because `:fx` is just a vector, you keep adding rows. A richer checkout reads li
           [:dispatch [:notification/show "Order placed!"]]]}))
 ```
 
-A state change, an HTTP POST, a storage write, and a follow-up dispatch — still one pure map.
+A state change, an HTTP POST, a storage write, and a follow-up dispatch — still one pure map. Push that thought as far as it will go: every request your app will ever send, every byte it will ever store, every place it will ever navigate — its entire worldly conduct — is rows of plain data, returned from pure functions, sitting still and legible before anything happens. Your app never *does* anything. It writes lists, and the runtime works down them.
+
+Too far? A little. One handler, one map. But "the app's conduct, as data" is not a slogan — it is exactly what the [trace stream](../glossary.md#trace-stream) records and [Xray](../glossary.md#xray) shows you when something goes weird at 4:45 on a Friday.
 
 ### Ordering and atomicity — what you can rely on
 
-When a handler returns `{:db new-db :fx [[a 1] [b 2] [c 3]]}`, four rules hold:
+When a handler returns `{:db new-db :fx [[a 1] [b 2] [c 3]]}`, four rules hold. They are contract, not habit — build on them:
 
 1. **`:db` commits first, atomically.** The whole swap lands in one step, before any `:fx` row runs. No observer — no subscription, no concurrent reader — ever sees a half-written app-db.
-2. **`:fx` rows run in source order.** `[a 1]` before `[b 2]` before `[c 3]`. The order you wrote them is the order they fire.
+2. **`:fx` rows run in source order.** `[a 1]` before `[b 2]` before `[c 3]`. The runtime works down the list top to bottom; the order you wrote is the order it fires.
 3. **Each row runs to (synchronous) completion before the next.** No interleaving. *Async* work a row kicks off — an outbound request, a `dispatch-later` timer — isn't awaited; "complete" means the effect handler returned.
 4. **Effects see the post-`:db` state.** Because `:db` committed first, a `[:dispatch [:react-to-new-state]]` row dispatches an event whose handler reads the *new* app-db. This is the legitimate way to chain: write state, then dispatch the event that builds on it.
 
@@ -174,7 +182,7 @@ When a handler returns `{:db new-db :fx [[a 1] [b 2] [c 3]]}`, four rules hold:
 
 ### Your own effects: `reg-fx`
 
-You aren't limited to the shipped effect set. When you need a new one, register it with [`reg-fx`](../glossary.md#effect-handler):
+You aren't limited to the shipped effect set — you couldn't be, because the set of possible effects is open-ended. Maybe you need to write `window.location`, or save a cookie, or ship metrics to DataDog. Everyone's list is different, so the grammar stays closed at the top (`:db` and `:fx`, always) and opens at the rows: when you need a new effect, register it with [`reg-fx`](../glossary.md#effect-handler):
 
 ```clojure
 (rf/reg-fx :localstorage/set
@@ -186,11 +194,11 @@ You aren't limited to the shipped effect set. When you need a new one, register 
 
 That `reg-fx` is now the *only* place in your codebase that writes to `js/localStorage`, so side-effects don't scatter across handlers. Each effect is named, registered, and addressable by id — which is exactly what lets a test redirect it, the [trace stream](../glossary.md#trace-stream) record it, and [Xray](../glossary.md#xray) display it.
 
+Two pieces of advice for writing one. First: make an effect handler as simple as possible, then simplify it further. It's side-effecty, which makes it the hardest kind of function to test rigorously, and fancy logic plus limited testing always ends in tears — if not now, later. Second: the args map you accept is a nano-DSL you are designing, so resist terse and smart; favour slightly verbose and obvious. Your future self will thank you. (Yes, this advice comes from a framework that named the key `:fx`. Oh, the hypocrisy.)
+
 The `:platforms #{:client}` declaration says where the effect may run. During [server-side rendering](../../ssr/concepts.md) the runtime skips a `:client`-only effect and emits a `:rf.fx/skipped-on-platform` trace event, so handlers never branch on platform. A `:platforms` set with more than one member runs on each listed platform; omit the key and the effect runs everywhere.
 
-!!! warning "Gotcha — register before you use it"
-
-    An `:fx` row naming an effect-id that was never `reg-fx`'d [fails loud](../glossary.md#fail-loud-not-silent) with `:rf.error/no-such-fx`, surfaced through the always-on error listener rather than silently dropped. A typo in an fx-id fails the same way. Registration *ordering* across files doesn't matter — the lookup happens when the row runs, not when the handler is defined.
+And if a row names an effect nobody registered? An `:fx` row naming an effect-id that was never `reg-fx`'d [fails loud](../glossary.md#fail-loud-not-silent) with `:rf.error/no-such-fx`, surfaced through the always-on error listener rather than silently dropped. A typo in an fx-id fails the same way. Registration *ordering* across files doesn't matter, though — the lookup happens when the row runs, not when the handler is defined. "Register before you use it" means registered by the time the row *runs*; nothing more.
 
 #### The effect handler's two arguments
 
@@ -219,6 +227,6 @@ Periodic and delayed work goes through that same door. An auto-dismissing notifi
 
 ## Stubbing effects in tests
 
-A registered effect is addressable by id, so a test can redirect it without touching the handler: pass `:fx-overrides` in the dispatch opts (or pin them per frame at construction). The recipe, with the symmetric fact-supplying move for coeffects, lives in [Testing event handlers](../testing/event-handlers.md).
+Because a registered effect is addressable by id, a test can redirect the world without touching the handler under test: pass `:fx-overrides` in the dispatch opts (or pin them per frame at construction). The recipe, with the symmetric fact-supplying move for coeffects, lives in [Testing event handlers](../testing/event-handlers.md).
 
 Effects are the world crossing the boundary *outward*. The way *in* — the facts a pure handler is allowed to read, and why they're recorded — is the next page: [Coeffects](coeffects.md).

--- a/docs/core/concepts/errors.md
+++ b/docs/core/concepts/errors.md
@@ -2,13 +2,15 @@
 
 You know the pipeline, [effects](effects.md), and [coeffects](coeffects.md). Now: what happens when one of them breaks?
 
-You've caught a hundred errors with `console.error("something broke", e)`. It kept the message and the stack — and threw away the important half: *which [event](../glossary.md#event) was in flight, which [frame](../glossary.md#frame) owned it, which [handler](../glossary.md#event-handler) was on the hook, what the [pipeline run](../glossary.md#run) had already done*. All of that existed in the runtime microseconds before the catch, and then you spent the next hour rebuilding it by hand.
+You've caught a hundred errors with `console.error("something broke", e)`. It kept the message and the stack — and threw away the important half: *which [event](../glossary.md#event) was in flight, which [frame](../glossary.md#frame) owned it, which [handler](../glossary.md#event-handler) was on the hook, what the [pipeline run](../glossary.md#run) had already done*. Every one of those facts existed in the runtime, microseconds before the catch. Then the catch fired, kept two of them, and you spent the next hour rebuilding the rest by hand.
 
-re-frame2's rule is simple: **if the runtime knows it, the [error record](../glossary.md#error-record) carries it.** Every error the framework detects becomes a structured map — fat on purpose — with the causal context already attached. This page teaches you to read that map, predict how your app degrades after each kind of failure, fix the error you'll hit first, and test the structure instead of the string.
+re-frame2's rule is one sentence: **if the runtime knows it, the [error record](../glossary.md#error-record) carries it.**
+
+Read that again — it's the whole model, and the rest of this page is that sentence unpacked. Every error the framework detects becomes a structured map — fat on purpose — with the causal context already attached. This page teaches you to read that map, predict how your app degrades after each kind of failure, fix the error you'll hit first, and test the structure instead of the string.
 
 ## The dossier
 
-When something breaks, the runtime already has an [event](../glossary.md#event), its [event handler](../glossary.md#event-handler), and the owning [frame](../glossary.md#frame) in scope. It keeps all of it. Here's the shape:
+When something breaks, the runtime is standing right there. It has the [event](../glossary.md#event) in hand, the [event handler](../glossary.md#event-handler) on the hook, the owning [frame](../glossary.md#frame) in scope. It keeps all of it. Here's the shape:
 
 ```clojure
 {:id        42                              ;; unique trace id
@@ -33,11 +35,11 @@ When something breaks, the runtime already has an [event](../glossary.md#event),
              :exception-message "Cannot read properties of undefined (reading 'price')"}}
 ```
 
-That's not a log line. That's a dossier.
+That's not a log line. That's a dossier. The offence, categorised. The severity, stamped. The suspect's registered address, an eyewitness placing the `dispatch` at the scene, and what the authorities did next — all filed before the stack trace hit your console. Too much? Okay, fine: it's a map. A plain map with a fixed shape, which is better than a dossier, because you can filter it.
 
 Three fields do the heavy lifting, and once you know them you've learned most of the surface:
 
-- **`:op-type`** is severity. `:error` for genuine failures, `:warning` for misuse the runtime recovers from. To ask "show me everything that failed", filter on `:op-type :error` — and you don't need to know a single category name to do it.
+- **`:op-type`** is severity. `:error` for genuine failures, `:warning` for misuse the runtime recovers from. Want "show me everything that failed"? Filter on `:op-type :error` — you don't need to know a single category name to ask that question.
 - **`:operation`** is the category — a namespaced keyword like `:rf.error/handler-exception` or `:rf.error/no-such-fx`. To narrow to "only handler exceptions", filter on it exactly.
 - **`:recovery`** is what the framework did *after* the error. This is the field that tells you whether your app is still standing — usually the first thing you want to know.
 
@@ -51,13 +53,11 @@ Two more slots turn a debugging session into a click. `:rf.trace/trigger-handler
 
     The dossier is a single product type with a closed tag set per category — a *sum type* keyed on `:operation`, where each variant carries a statically-known `:tags` payload. That's why a consumer can pattern-match on `:operation` and trust the shape of what follows: the catalogue *is* the type definition. The `:op-type`/`:operation` pair is a coarse-then-fine discriminator — severity first (for the "did anything fail?" fold), category second (for per-variant handling) — so you consume at whichever granularity your tool needs.
 
-!!! note "The dossier is a development surface"
-
-    Production builds [*elide*](../glossary.md#elide) the [trace stream](../glossary.md#trace-stream) — not disable it, elide it: dead-code elimination compiles the code clean out of the release bundle, dossiers and all. Errors that must still reach a monitor in production travel a separate always-on channel carrying a tight, unredacted record — covered at the end of this page.
+One expectation to set before you get attached: the dossier is a development surface. Production builds [*elide*](../glossary.md#elide) the [trace stream](../glossary.md#trace-stream) — not disable it, *elide* it: dead-code elimination compiles the code clean out of the release bundle, dossiers and all. Errors that must still reach a monitor in production travel a separate always-on channel carrying a tight, unredacted record — covered at the end of this page.
 
 ## A catalogue you consult, not memorise
 
-The framework emits errors from a fixed set of categories — dozens of them, covering handlers, subscriptions, effects, coeffects, schemas, frames, routing, machines, SSR. The set grows but never breaks, so you don't memorise the list — you learn its grammar.
+How many categories are there? Dozens — covering handlers, subscriptions, effects, coeffects, schemas, frames, routing, machines, SSR. Don't memorise them. The set grows but never breaks, and it has a grammar you can learn in the time it takes to read three bullets.
 
 The prefix names the owning subsystem:
 
@@ -67,14 +67,13 @@ The prefix names the owning subsystem:
 
 Existing categories are never renamed or repurposed: pin a test to `:rf.error/no-such-fx` and it still means that next year.
 
-The catalogue itself — every category, its trigger, its `:tags` payload, its recovery default — is a closed reference table ([Spec 009 §Error event catalogue](../../../spec/009-Instrumentation.md#error-event-catalogue), kept in CI lockstep with this page's examples), and every dossier names its own category. Treat it like HTTP status codes: look a category up when you meet it.
-
+The catalogue itself — every category, its trigger, its `:tags` payload, its recovery default — is a closed reference table ([Spec 009 §Error event catalogue](../../../spec/009-Instrumentation.md#error-event-catalogue), kept in CI lockstep with this page's examples), and every dossier names its own category. Treat it like HTTP status codes: nobody memorises the table; you look a category up when you meet it, and after a while you just know the ones you've met.
 
 ## Recovery is typed — and it isn't yours
 
-When an error fires, the runtime applies a typed, per-category default. That's the whole story. There's no app-steering error policy here: no global error handler, no hook that swallows an exception or substitutes a result.
+When an error fires, the runtime applies a typed, per-category default. That's the whole story. There is no app-steering error policy: no global error handler, no hook that swallows an exception or substitutes a result.
 
-Swallowing an exception masks a bug, and fabricating a replacement result invents something the thrown handler could not have produced. Genuine recovery belongs at the source, for *expected* failures, where "recovery" actually means something: [managed HTTP's](../../async/http.md) `:retry` for a flaky network, or a defensive default at a read. And the framework never re-runs a failing handler behind your back — when you want to try again, you [dispatch](../glossary.md#dispatch) a fresh event.
+Why so rigid? Because the two things such a hook gets used for are both mistakes. Swallowing an exception masks a bug. Fabricating a replacement result invents something the thrown handler could not have produced. Genuine recovery belongs at the source, for *expected* failures, where "recovery" actually means something: [managed HTTP's](../../async/http.md) `:retry` for a flaky network, or a defensive default at a read. And the framework never re-runs a failing handler behind your back — when you want to try again, you [dispatch](../glossary.md#dispatch) a fresh event.
 
 The `:recovery` vocabulary is small and readable on sight:
 
@@ -96,7 +95,7 @@ Four of those defaults shape how your app degrades, so they're worth knowing by 
 
 !!! note "No app-policy error hook"
 
-    There is no `reg-event-error-handler`. Observation lives on a [listener](../glossary.md#listener) on the error channel — the `:errors` stream covered at the end of this page. Coming from a v1 app that installed an error hook, the [migration guide](../25-from-re-frame-v1.md) maps the translation.
+    There is no `reg-event-error-handler` — on purpose, and this section just argued why. Observation lives on a [listener](../glossary.md#listener) on the error channel — the `:errors` stream covered at the end of this page. Coming from a v1 app that installed an error hook, the [migration guide](../25-from-re-frame-v1.md) maps the translation.
 
 ??? note "One category, three modes"
 
@@ -106,9 +105,7 @@ Four of those defaults shape how your app degrades, so they're worth knowing by 
 
     If you guard an [app-db](../glossary.md#app-db) path, an event, or an HTTP `:decode` step with a [schema](../glossary.md#schema), a value that fails it emits `:rf.error/schema-validation-failure` to surface the bug *early*, where the bad value was produced. Recovery is **not uniform** — it follows the boundary named in the `:where` tag: an `:event` failure **skips the handler**; an `:app-db` or `:machine-data` failure **rolls the cascade back** (no commit); an `:fx-args` failure **skips just the offending fx** (siblings run); a `:sub-return` or `:sub-override` failure **surfaces `nil` and renders on**; `:flow-output` / `:machine-output` are **observational** — the value still commits. The [per-`:where` recovery table](../../../spec/009-Instrumentation.md#schema-validation-failure-per-where-recovery) in Spec 009 is the full map, and `:explain` carries the Malli explanation. The surprise is the asymmetry: production builds [*elide*](../glossary.md#elide) the check entirely, so this category fires **only in dev**. Treat schema checks as a development assertion that hardens your data at its source, not a runtime gate you can lean on in production. (A structurally broken Malli form is the separate `:rf.error/malformed-schema`, which fails closed and rolls the commit back.)
 
-    One boundary is **not** on that list on purpose: a *recordable coeffect* (`:rf.cofx/requires`) whose value fails its `reg-cofx` `:schema` raises the separate, halting `:rf.error/cofx-value-invalid` — a **production hard error** that throws (`:recovery :no-recovery`) in prod as well as dev, because a recordable coeffect rides the durable causal record and a bad one silently corrupts replay, SSR, and [Xray](../glossary.md#xray). See [coeffects](coeffects.md) for why a coeffect value must stay recordable.
-
-    One boundary is **not** on that list on purpose: a *recordable coeffect* (`:rf.cofx/requires`) whose supplied, replayed, or generated value fails its `reg-cofx` `:schema` is **not** a `:where :cofx` schema-validation trace. It is the separate, halting `:rf.error/cofx-value-invalid` — a **production hard error** that throws (`:recovery :no-recovery`), because a recordable coeffect rides the durable causal record and a bad one silently corrupts replay, SSR, and [Xray](../glossary.md#xray) (the dev inspector). It fires in production too, not just dev — look the `:rf.error/cofx-value-invalid` row up in the catalogue when you meet it, and see [effects and coeffects](coeffects.md) for why a coeffect value must stay recordable.
+    One boundary is **not** on that list on purpose. A *recordable coeffect* (`:rf.cofx/requires`) whose supplied, replayed, or generated value fails its `reg-cofx` `:schema` is **not** a `:where :cofx` schema-validation trace. It is the separate, halting `:rf.error/cofx-value-invalid` — a **production hard error** that throws (`:recovery :no-recovery`) in prod as well as dev, because a recordable coeffect rides the durable causal record and a bad one silently corrupts replay, SSR, and [Xray](../glossary.md#xray) (the dev inspector). Look the `:rf.error/cofx-value-invalid` row up in the catalogue when you meet it, and see [coeffects](coeffects.md) for why a coeffect value must stay recordable.
 
 ## The failures you'll actually meet
 
@@ -140,9 +137,7 @@ The runtime catches it and emits `:rf.error/handler-exception` with `:recovery :
     {:db (update-in db [:cart :items] (fnil conj []) item)}))
 ```
 
-!!! note "Do this once, then you'll trust it"
-
-    Make a handler throw on purpose in dev with [Xray](../glossary.md#xray) open. The error lands *inside the run that produced it*. The dispatch that caused it sits right above. The category and recovery read straight off the error row. One click lands on the handler's registration site. Nothing about the failure is out-of-band — and that's the whole pitch.
+Do this once, deliberately, and you'll trust the machinery afterwards: make a handler throw on purpose in dev with [Xray](../glossary.md#xray) open. The error lands *inside the run that produced it*. The dispatch that caused it sits right above. The category and recovery read straight off the error row. One click lands on the handler's registration site. Nothing about the failure is out-of-band — and that's the whole pitch.
 
 ??? note "Going deeper — the failure is attributed, not lumped"
 
@@ -204,7 +199,7 @@ Errors are data, so asserting them is as boring as asserting anything else. Regi
           (is (= :checkout/never-registered (get-in t [:tags :rf.fx/id]))))))))
 ```
 
-Three things in that test generalise to every category:
+Notes — three of them, and each one generalises to every category:
 
 1. **The assertions are structural.** They pin `:operation`, `:op-type`, and the schema-checked `:tags` keys — the contract. They never touch `:reason`, the human-facing headline sentence, because its wording is allowed to change. String-shaped error tests rot; structural ones don't.
 2. **The listener is scoped to the test** and detached in `finally` — and detached with the *same* stream you registered on (`:trace` here), so a failing assertion can't leak it into the next test. `rf/clear-listeners! :trace` is the blunter test-isolation hammer when you'd rather drop every listener on a stream at once; production code never calls it.
@@ -214,7 +209,7 @@ The same move covers every category: `dispatch-sync` for event errors, a [sub](.
 
 !!! note "One verb, four streams"
 
-    That first argument to `register-listener!` is a stream selector. `:trace` is the dev tap you just used — [elided](../glossary.md#elide) out of production builds, the firehose [Xray](../glossary.md#xray) drinks from. `:errors` is the **always-on error channel** the dossier note promised: the same structured records, but it survives production, fans across every frame, and is not filtered by any frame's egress policy. That's why wiring Sentry in production is just `(rf/register-listener! :errors ::sentry report!)`. Mind one thing: nothing arrives redacted except the event vector, so scrubbing before shipping is on you — the [how-to](../how-to/report-errors-in-production.md) walks it. The other two — `:events` (an always-on per-event integration hook) and `:epoch` ([epoch](../glossary.md#epoch) records for time-travel tooling) — are [observability](observability.md)'s territory. One closed vocabulary; pass an unknown stream and you get a loud `:rf.error/unknown-listener-stream`, no silent default.
+    That first argument to `register-listener!` is a stream selector. `:trace` is the dev tap you just used — [elided](../glossary.md#elide) out of production builds, the firehose [Xray](../glossary.md#xray) drinks from. `:errors` is the **always-on error channel** promised earlier: the same structured records, but it survives production, fans across every frame, and is not filtered by any frame's egress policy. That's why wiring Sentry in production is just `(rf/register-listener! :errors ::sentry report!)`. Mind one thing: nothing arrives redacted except the event vector, so scrubbing before shipping is on you — the [how-to](../how-to/report-errors-in-production.md) walks it. The other two — `:events` (an always-on per-event integration hook) and `:epoch` ([epoch](../glossary.md#epoch) records for time-travel tooling) — are [observability](observability.md)'s territory. One closed vocabulary; pass an unknown stream and you get a loud `:rf.error/unknown-listener-stream`, no silent default.
 
 ## Advanced
 

--- a/docs/core/concepts/flows.md
+++ b/docs/core/concepts/flows.md
@@ -2,9 +2,9 @@
 
 You already know one way to derive a value: a [subscription](../glossary.md#subscription) — a named, pure derivation that reads [app-db](../glossary.md#app-db) (your app's single state map) and hands the result to a [view](../glossary.md#view). Keep that as your reflex. Most derived values are subscriptions, and a typical app has dozens of them.
 
-But there's a catch in *where* a subscription keeps its answer. It lives in a view-facing cache — built for views to read on the way to rendering, and only views. An [event handler](../glossary.md#event-handler) — the pure function that runs when an [event](../glossary.md#event) is dispatched and returns the next app-db — can't reach into that cache. Neither can an app-db validation [schema](../glossary.md#schema) (they check state, not caches), another derivation, or anything else that wants the answer as plain data rather than as something a view will render.
+But there's a catch in *where* a subscription keeps its answer. It lives in a view-facing cache — built for views to read on the way to rendering, and only views. An [event handler](../glossary.md#event-handler) — the pure function that runs when an [event](../glossary.md#event) is dispatched and returns the next app-db — can't reach into that cache. Neither can an app-db validation [schema](../glossary.md#schema) (they check state, not caches). Neither can another derivation, or anything else that wants the answer as plain data rather than as something a view will render.
 
-Sometimes a derived value needs to be *state*: plain data sitting in app-db that the rest of your program reads. For that you want a **[flow](../glossary.md#flow)** — a registered rule that says *"when these paths change, run this pure function and write the result into app-db."* The framework keeps the answer fresh, so you never write it by hand.
+Sometimes a derived value needs to be *state*: plain data sitting in app-db that the rest of your program reads. For that you want a **[flow](../glossary.md#flow)** — a registered rule that says *"when these paths change, run this pure function and write the result into app-db."* You declare the rule once. From then on the framework holds the pen for that path: it keeps the answer fresh, and you never write it by hand.
 
 This page builds flows up one step at a time: first the smallest possible flow, then the registration map key by key, then a value that genuinely earns its place in app-db, and finally the runtime tricks — toggling, validating, and classifying a flow's output.
 
@@ -66,20 +66,19 @@ Here it is running — note the view reads parity with an ordinary app-db subscr
  [flow-counter]]
 ```
 
-
 From now on, every event that changes `:value` also recomputes `:parity`. And here's the part worth pausing on: the recompute is part of the *same write*. An [event pipeline](../glossary.md#event-pipeline) run in re-frame2 doesn't dribble out a sequence of little app-db mutations; it gathers up everything it wants to change and installs it as one all-or-nothing write — the [**commit**](../glossary.md#commit) you've met on every page since the introduction. A flow runs after the event's handler (and after any cross-cutting [interceptors](../glossary.md#interceptor) — a later page — have finished shaping `:db`) and *before* that commit, so the handler's change and the fresh flow output land together. Views never see a half-updated state where the counter ticked but the label hasn't caught up.
 
 The flow also skips recomputing when its inputs didn't actually change value — write the same `:value` back and the flow stays quiet, which keeps the cost honest. (This input-changed test is the flow's **dirty-check** — the name comes back later.)
 
-!!! note "A flow is a derivation whose answer your handlers can read"
-
-    Same pure function as a subscription; the only difference is *where the answer lives*.
+So what did we actually build? Here it is in one sentence: **a flow is the same pure function as a subscription; the only difference is where the answer lives — and because the answer lives in app-db, your handlers can read it.** Read that sentence again. It's the key concept on this page; everything below — the registration keys, the errors, the toggling — is that one idea, worked out.
 
 ### What changed, and what didn't
 
 - **The view doesn't change.** It still reads `@(rf/subscribe [:parity])`. Only the sub's body changes, from *computing* the answer to *reading* it: `(rf/reg-sub :parity (fn [db _query] (:parity db)))`. Flows publish no special subscription ids — the output path *is* the contract, and anything that reads app-db can read it.
 - **Handlers can now read it.** Any event handler can ask `(:parity db)` as plain data. With the sub version that answer was stranded in the view-cache — visible to views, invisible to handlers. A handler always sees the output as of the last completed event; if the handler itself changes an input, the recompute happens right after it, inside that same event's single commit.
 - **You never write the output path.** You keep writing `:value` through ordinary handlers. The runtime is the sole author of `[:parity]`.
+
+That last bullet is a trade, so let's name it honestly. Design is all tradeoffs: a flow buys you *"this value simply derives from these inputs; it simply changes when they do"* at the cost of a little spooky action at a distance — no particular handler is responsible for `[:parity]` any more. re-frame2 takes that trade with its eyes open, and then spends tooling on the spooky part: every flow write is attributed to the flow that made it, as you're about to see.
 
 ??? info "From re-frame v1"
 
@@ -91,7 +90,7 @@ The flow also skips recomputing when its inputs didn't actually change value —
 
 ??? info "Coming from Redux?"
 
-    The style guide's "never store derived state" rule guards against someone forgetting to update it in one reducer. A flow is the *sanctioned* exception, because the framework owns the updating — that whole staleness failure mode is gone.
+    The style guide's "never store derived state" rule guards against someone forgetting to update it in one reducer — and someone always forgets, in exactly one reducer, discovered months later. A flow is the *sanctioned* exception, because the framework owns the updating: that whole staleness failure mode is gone.
 
 ### A flow belongs to a frame
 
@@ -99,7 +98,7 @@ One thing to know before you copy this, because it trips people up: a flow belon
 
 Outside any scope, `reg-flow` refuses with `:rf.error/no-frame-context` rather than guessing which frame you meant.
 
-Now dispatch `[:inc]` and open [Xray](../glossary.md#xray). The event's row records the handler's change and, in the same commit, the flow's recompute — the write to `[:parity]` attributed to the flow that made it. Restore an older [epoch](../glossary.md#epoch) — one of the per-event snapshots the runtime keeps — and parity travels back with the rest of app-db. Because a materialised value is ordinary state, [time-travel](../glossary.md#time-travel) and the inspector get it for free.
+Now dispatch `[:inc]` and open [Xray](../glossary.md#xray). The event's row records the handler's change and, in the same commit, the flow's recompute — the write to `[:parity]` attributed to the flow that made it. There's the promised paper trail for the spooky action. Restore an older [epoch](../glossary.md#epoch) — one of the per-event snapshots the runtime keeps — and parity travels back with the rest of app-db. Because a materialised value is ordinary state, [time-travel](../glossary.md#time-travel) and the inspector get it for free.
 
 The honest part: the counter's parity should *stay* a subscription. Nothing but the view reads it, so materialising it buys nothing and costs an app-db write per click. We re-expressed it only to learn the shape with familiar material. Next, a value that genuinely *earns* a flow.
 
@@ -130,7 +129,7 @@ Reach for a flow only when **all** of these hold:
 - It should **survive** [SSR hydration](../../ssr/concepts.md), time-travel restore, and app-db serialisation — a sub-cache does not survive the wire.
 - The derivation is **stable enough to be worth registering** — not a one-off computation inside a single handler.
 
-The RealWorld editor's submit gate is the canonical case. "Can the user submit?" means *the draft is valid AND differs from the loaded baseline*. The **submit handler** needs that answer, not just the button — and that single requirement is what tips the value from view-input to state:
+Notice the shape those four bullets describe. Nearly every value that passes the test is doing *synchronisation* — maintaining an invariant inside a changing data structure. The RealWorld editor's submit gate is the canonical case. "Can the user submit?" means *the draft is valid AND differs from the loaded baseline*. The **submit handler** needs that answer, not just the button — and that single requirement is what tips the value from view-input to state:
 
 ```clojure
 ;; Condensed from examples/real-apps/realworld_resources/article_editor.cljs
@@ -171,13 +170,15 @@ Trace one keystroke through this. The keystroke event writes the draft; the flow
 
 One validation rule, one source of truth, two readers — the handler and the button — both pointed at the same materialised slot. That is the whole reason the value earned its place in app-db.
 
-!!! note "Flows may read each other's outputs"
-
-    The runtime orders dependent flows topologically — and rejects cycles and overlapping output paths loudly at registration time (see [When the framework refuses](#when-the-framework-refuses-the-registration-time-errors)).
+And yes, flows may read each other's outputs — the runtime orders dependent flows topologically, and rejects cycles and overlapping output paths loudly at registration time (see [When the framework refuses](#when-the-framework-refuses-the-registration-time-errors)).
 
 ## When *not* to: the default is still a subscription
 
-Flows are a convenience for a small number of small use-cases. They are not a new dataflow paradigm, and not where derived values live by default. Here's the wrong-tool list:
+Flows are a convenience for a small number of small use-cases. They are not a new dataflow paradigm, and not where derived values live by default.
+
+I want that said plainly, because I can hear what the last section started in your head. A derivation that writes itself into app-db, rides the commit, survives time-travel, feeds your handlers *and* your schemas? Materialise everything! The totals! The labels! The filtered, sorted, grouped lists! An app-db so thick with precomputed answers that the views just point at it and coast!
+
+No. Put the keyboard down. That way lies an app-db full of copies, a write on every event, and a registry you carry around in your head. Here's the wrong-tool list:
 
 - **Only views consume it** → a [subscription](subscriptions.md). Lighter, cached per input, no app-db write.
 - **It has discrete states or a lifecycle** (entry/exit, transitions, timers) → a [state machine](../../machines/concepts.md).
@@ -204,9 +205,7 @@ Most flows read app-db with bare paths. But a flow's `:inputs` can also reach in
 
 Two things stay true no matter how many runtime inputs a flow reads. First, **the output is still app-db** — a flow never writes runtime-db, so `:rf.db/runtime`-led paths are an input-only privilege. Second, the dirty-check watches *both* partitions: a pure route transition that changes runtime-db but touches no app-db still re-fires this flow, because the resolved route-id is part of the flow's cached input vector. You get a materialised, time-travelling, handler-readable mirror of route state without writing a single sync handler.
 
-!!! warning "Gotcha — there is no `[:rf.db/app …]` form, and no bare runtime path"
-
-    The *only* way to read runtime-db is the partition-qualified `[:rf.db/runtime …]` input above — there is no explicit-app spelling, and no bare `[:rf.runtime/…]` path. A bare path is *always* app-db: one prefix means runtime, everything else means app-db, no third case to remember.
+One spelling rule before you go looking for symmetry: there is no `[:rf.db/app …]` form, and no bare runtime path. The *only* way to read runtime-db is the partition-qualified `[:rf.db/runtime …]` input above — a bare path is *always* app-db. One prefix means runtime, everything else means app-db, no third case to remember.
 
 ## Validating a flow's output
 
@@ -243,13 +242,9 @@ A flow's output rides the [trace stream](../glossary.md#trace-stream) to Xray an
 
 Each of `:sensitive` and `:large` is a **vector of subpaths** *into the output shape* — each subpath itself a vector of keys. `[[]]` (a single empty subpath) classifies the whole output. `:large? true` is the whole-output shorthand for `:large`. These mark *which slices* of the output get redacted (sensitive) or elided (large) when the flow's trace event and the `:output-path` write cross a trust boundary.
 
-!!! warning "Gotcha — `:sensitive` is a list of paths, not a boolean"
+Two spellings look like cousins here, and one is a mistake, so hear this plainly: at this layer `:sensitive` means *a collection of sensitive paths*, and the boolean spelling `:sensitive true` is wrong. A malformed declaration — a non-vector axis, a non-path entry, the boolean spelling — is rejected fail-closed at registration with `:rf.error/flow-bad-marks`: loud, rather than silently shipping the secret. (The boolean `:sensitive?` an event *handler* carries is a separate device — see [keeping secrets out of traces](../how-to/keep-secrets-out-of-traces.md); a *flow's* classification is the plural path-list.)
 
-    At this layer `:sensitive` means "a collection of sensitive paths", so the boolean spelling `:sensitive true` is a *mistake*. A malformed declaration — a non-vector axis, a non-path entry, the boolean spelling — is rejected fail-closed at registration with `:rf.error/flow-bad-marks`: loud, rather than silently shipping the secret. The boolean `:sensitive?` an event *handler* carries is a separate device — see [keeping secrets out of traces](../how-to/keep-secrets-out-of-traces.md); a *flow's* classification is the plural path-list.
-
-!!! warning "Gotcha — classification does not flow from input to output"
-
-    A flow that *reads* a sensitive app-db slice does **not** auto-classify its output — a derived secret is just a new path, and you classify it directly with the flow's own `:sensitive` / `:large`. There is no taint propagation to rely on (or fight). Separately: when a flow recomputes inside the settling pass of a handler that carries `:sensitive? true`, the *whole* flow trace event inherits that coarse, whole-event marker from the handler.
+And classification does not flow from input to output. A flow that *reads* a sensitive app-db slice does **not** auto-classify its output — a derived secret is just a new path, and you classify it directly with the flow's own `:sensitive` / `:large`. There is no taint propagation to rely on, or to fight. One separate wrinkle: when a flow recomputes inside the settling pass of a handler that carries `:sensitive? true`, the *whole* flow trace event inherits that coarse, whole-event marker from the handler.
 
 ## What happens when a derive throws
 
@@ -291,7 +286,10 @@ Here's the trick a materialised view in a database can't do: you can switch a fl
   (fn [{:keys [db]} _event] {:db db}))              ;; no-op; exists only to trigger a recompute pass
 ```
 
-`:rf.fx/clear-flow` removes the registration **and vacates the value at `:output-path`**, so no stale derived state is left behind for downstream readers to trust by mistake. (If you need the last value, copy it somewhere else before clearing.)
+Notes:
+
+1. `:rf.fx/clear-flow` removes the registration **and vacates the value at `:output-path`**, so no stale derived state is left behind for downstream readers to trust by mistake. The framework put the value there; the framework takes it away. (If you need the last value, copy it somewhere else before clearing.)
+2. The lag note the code promised: a flow registered mid-event does **not** compute during *that* event. Effects run after the event's flow pass has already happened, so the new flow's first output appears on the **next** event. Usually that's invisible — register on page entry and the user's first interaction materialises it (the editor above starts invalid-and-clean, so the lag carries no wrong value). When you need the initial value *now*, dispatch a follow-up no-op event, as `:cart/touch` does above: by the time it drains, the flow is registered and computes.
 
 The fx variant is the common one because most toggling happens *inside* event handling, where the dispatching frame is carried automatically. But the same two operations also exist as plain functions — the registration macro `rf/reg-flow`, and `re-frame.flows/clear-flow` — for use outside a handler (boot code, a test, a per-tenant setup):
 
@@ -309,19 +307,13 @@ The fx variant is the common one because most toggling happens *inside* event ha
 (flows/clear-flow :editor/can-submit? {:frame :scratch})  ;; clear lives on re-frame.flows
 ```
 
-!!! warning "Gotcha — `clear-flow` is not on the `rf/` facade"
-
-    `reg-flow` stays on `re-frame.core` because registration must stay central (it captures the call-site source coordinates). The lifecycle helper `clear-flow` lives on its owning namespace, `re-frame.flows` — reach it as `flows/clear-flow`, not `rf/clear-flow`. (Most code never needs it directly anyway: prefer the `:rf.fx/clear-flow` effect from inside a handler.)
-
-!!! note "The one-event lag"
-
-    A flow registered mid-event does **not** compute during *that* event: effects run after the event's flow pass has already happened, so the new flow's first output appears on the **next** event. Usually that's invisible — register on page entry and the user's first interaction materialises it (the editor above starts invalid-and-clean, so the lag carries no wrong value). When you need the initial value *now*, dispatch a follow-up no-op event, as `:cart/touch` does above: by the time it drains, the flow is registered and computes.
+Notice which function lives where, because it catches people: `reg-flow` stays on `re-frame.core`, since registration must stay central (it captures the call-site source coordinates), but the lifecycle helper `clear-flow` lives on its owning namespace, `re-frame.flows` — reach it as `flows/clear-flow`, not `rf/clear-flow`. Most code never needs it directly anyway: prefer the `:rf.fx/clear-flow` effect from inside a handler.
 
 ## Re-registering a flow (and hot reload)
 
-Call `reg-flow` again with an already-registered id (on the same frame) and you get a **surgical update**, the same as re-registering any event or sub. The new definition replaces the old; the dirty-check resets so the flow re-evaluates on the next event regardless of input change; the next pass's dependency sort picks up any changed edges automatically. This is what makes hot-reload-on-save work: edit a flow's `:derive`, save, and the running app swaps it in.
+Call `reg-flow` again with an already-registered id (on the same frame) and you get a **surgical update**, the same as re-registering any event or sub. The new definition replaces the old; the dirty-check resets, so the flow re-evaluates on the next event regardless of input change; the next pass's dependency sort picks up any changed edges automatically. This is what makes hot-reload-on-save work: edit a flow's `:derive`, save, and the running app swaps it in.
 
-One subtlety worth a callout: if the replacement also **moves the `:output-path`** to a new slot, the framework vacates the *old* slot — the same `dissoc-in` cleanup `clear-flow` does — so a stale value from the previous definition never lingers at the abandoned path. Keep the same `:output-path` and nothing is vacated; the next recompute simply overwrites it in place.
+One subtlety, and it's the pen again: if the replacement also **moves the `:output-path`** to a new slot, the framework vacates the *old* slot — the same `dissoc-in` cleanup `clear-flow` does — so a stale value from the previous definition never lingers at the abandoned path. Keep the same `:output-path` and nothing is vacated; the next recompute simply overwrites it in place.
 
 ## Testing a flow
 
@@ -369,8 +361,8 @@ Flows [fail loud](../glossary.md#fail-loud-not-silent) and early. Almost everyth
 
 The **shape** errors are the ones you meet while you're still typing the call — each names the offending slot in its `ex-data` so you can fix it without a stack-trace dig. First, the 3-slot grammar itself is enforced: `:rf.error/invalid-flow-metadata` fires when the middle slot isn't a map, or when a `:derive` is left inside the metadata map. Then the reconstructed flow is checked in order, most-fundamental-first: `:rf.error/flow-missing-id` (a nil `flow-id`), `:rf.error/flow-bad-id` (a `flow-id` that isn't a keyword), `:rf.error/flow-bad-inputs` (`:inputs` isn't a vector of non-empty paths), `:rf.error/flow-bad-output` (the `derive-fn` isn't a function — a historical name: it guards the derive slot, not `:output-path`), and `:rf.error/flow-bad-path` (`:output-path` isn't a non-empty vector of path segments). You'll mostly hit these once, the first time you write a flow; they're listed here so a thrown `:rf.error/*` keyword is self-explaining when it lands.
 
-!!! warning "Gotcha — forgot the artefact? `:rf.error/flows-artefact-missing`"
-
-    Flows ship in their own optional artefact, `day8/re-frame2-flows`, and the whole flow API (`reg-flow`, `clear-flow`, `:rf.fx/reg-flow`, `:rf.fx/clear-flow`) is published through a late-bind seam rather than baked into the core. If that artefact isn't on the classpath — or you forgot the one-time `(:require [re-frame.flows])` that loads its registration hooks — the *first* flow call throws `:rf.error/flows-artefact-missing` (a thrown ex-info naming the calling fn, not a trace) rather than silently no-opping. Add `day8/re-frame2-flows` to your deps and require it once, somewhere in your app. (Same require-to-register convention the schemas / machines / routing artefacts use.)
+There's one more refusal, and if you meet it at all you'll meet it first. Flows ship in their own optional artefact, `day8/re-frame2-flows`, and the whole flow API (`reg-flow`, `clear-flow`, `:rf.fx/reg-flow`, `:rf.fx/clear-flow`) is published through a late-bind seam rather than baked into the core. If that artefact isn't on the classpath — or you forgot the one-time `(:require [re-frame.flows])` that loads its registration hooks — the *first* flow call throws `:rf.error/flows-artefact-missing` (a thrown ex-info naming the calling fn, not a trace) rather than silently no-opping. Add `day8/re-frame2-flows` to your deps and require it once, somewhere in your app. (Same require-to-register convention the schemas / machines / routing artefacts use.)
 
 The one error that surfaces at *runtime* rather than registration is `:rf.error/flow-eval-exception` — a `:derive` function throwing — which aborts the event as described in [What happens when a derive throws](#what-happens-when-a-derive-throws). (A flow's `:schema` failing is *not* an error of this kind: it's the observational `:rf.error/schema-validation-failure` diagnostic — the value still commits; see [Validating a flow's output](#validating-a-flows-output).)
+
+And that's flows, whole: the derivation you already knew how to write, its answer moved into app-db — with the framework holding the pen.

--- a/docs/core/concepts/frames.md
+++ b/docs/core/concepts/frames.md
@@ -1,8 +1,12 @@
 # Frames: isolated worlds
 
-Sooner or later you want two independent copies of your app on one screen. A split pane showing the same widget against different data. A [Story](../glossary.md#story) canvas — the view workbench — rendering one view in three states side by side. A server handling a hundred render requests at once. Or you've hit `:rf.error/no-frame-context` from a `setTimeout` callback and want to know what it means. All those roads lead to one idea: the **[frame](../glossary.md#frame)** — re-frame2's isolation boundary.
+Sooner or later, you want two of your app.
 
-The good news is you can ignore frames almost entirely. Most apps establish exactly one frame at boot and never name it again. So we'll start there — the simplest working thing — and add a second frame only once the first one is solid. By the end you'll know the one rule everything else falls out of: *frame identity is carried, not found.*
+A split pane showing the same widget against different data. A [Story](../glossary.md#story) canvas — the view workbench — rendering one view in three states side by side. A server handling a hundred render requests at once. Or the less cheerful road: a `setTimeout` callback just raised `:rf.error/no-frame-context` and you'd like to know why.
+
+All those roads lead to one idea: the **[frame](../glossary.md#frame)** — re-frame2's isolation boundary. A frame is a **world**: one complete, running copy of your app, sealed off from every other copy.
+
+Now the good news: you can ignore frames almost entirely. Most apps establish exactly one world at boot and never say its name again. So we'll start there — the simplest working thing — and add a second world only once the first one is solid. By the end you'll know the one rule everything else falls out of: *frame identity is carried, not found.*
 
 ## The counter, twice
 
@@ -34,15 +38,15 @@ Click one. The other doesn't move. Nothing in `counter` names a frame — its in
 
 ## What a frame is
 
-A frame is one running instance of your app. It owns the runtime state of that instance:
+One running instance of your app. That's the definition; the rest is inventory. A frame owns the runtime state of its instance:
 
 - its **[app-db](../glossary.md#app-db)** — the single map this instance's events read and write; the whole of this instance's state,
 - its **event queue** — the [dispatches](../glossary.md#dispatch) waiting to run against this instance,
 - its **[subscription](../glossary.md#subscription) cache** — the memoised graph of derived values computed over this instance's state.
 
-A frame deliberately does *not* own the handlers — the functions you register with `reg-event` / `reg-sub` / `reg-view`. Those are shared. By default every `reg-*` in your program writes into one common table — the [**registrar**](../glossary.md#registrar) — that all frames draw from, so two frames both running `[:counter/inc]` run the *same handler function* against *different app-dbs*. That's the whole trick: shared code, separate state.
+Now notice what's missing from that list: the handlers. A frame deliberately does *not* own the functions you register with `reg-event` / `reg-sub` / `reg-view`. Those are shared. By default every `reg-*` in your program writes into one common table — the [**registrar**](../glossary.md#registrar) — that all frames draw from, so two frames both running `[:counter/inc]` run the *same handler function* against *different app-dbs*.
 
-A frame isolates **state, not behaviour**. That division is why "show two of them side by side" never forces a rewrite: you mount the same app twice, each mount in its own frame, and isolation is total.
+That's the whole trick. **Shared code, separate state.** A frame isolates state, not behaviour — which is why "show two of them side by side" never forces a rewrite. You mount the same app twice, each mount in its own world, and isolation is total.
 
 (The selected set of registrations a frame resolves against has a name — the [**image**](../glossary.md#image) — but you can park that word for now. It only earns its keep in the rare case where you want two frames to run *different* handlers, which we get to at the very end. Until then, "the handlers are shared" is the whole story.)
 
@@ -53,9 +57,9 @@ A frame isolates **state, not behaviour**. That division is why "show two of the
 
 ## The normal case: one app, one frame
 
-Almost every app is a one-frame app, and stays one. You register a frame at boot, establish it at the root of your view tree, and never name it again.
+Almost every app is a one-world app, and stays one. You register a frame at boot, establish it at the root of your view tree, and never name it again.
 
-One piece of syntax recurs on this page: inside a `reg-view`, `dispatch` and `subscribe` arrive as injected functions — `dispatch` sends an [event](../glossary.md#event) into the queue, `subscribe` reads a derived value (both detailed on the [views](views.md) page). And `@` is Clojure's deref — `@(subscribe [:screen])` reads the *current value* out of the reactive subscription. Both quietly target whichever frame this view is rendering under; you'll see how in a moment.
+One piece of syntax recurs on this page, so let's settle it once. Inside a `reg-view`, `dispatch` and `subscribe` arrive as injected functions — `dispatch` sends an [event](../glossary.md#event) into the queue, `subscribe` reads a derived value (both detailed on the [views](views.md) page). And `@` is Clojure's deref — `@(subscribe [:screen])` reads the *current value* out of the reactive subscription. Both quietly target whichever frame this view is rendering under; you'll see how in a moment.
 
 ```clojure
 (ns my-app.core
@@ -109,7 +113,7 @@ Notice there's no place to hand `reg-frame` an initial app-db. That's on purpose
 
     Keeping initialisation on the dispatch path means the same pipeline that handles every later state change also builds the first one — one mechanism, no special "initial state" channel that drifts from the rest of your app.
 
-`:initial-events` is an *ordered vector of setup steps*. Each step is a bare event vector (`[:cart/restore-session]`) or, when it needs dispatch opts, a map (`{:event [:cart/add "milk"] :opts {…}}`). Each step is dispatched synchronously and run to completion before the next one starts — "to completion" meaning that if a setup event dispatches further events, those all finish too. So by the time `reg-frame` returns, the entire setup drain is done and the frame is fully booted.
+`:initial-events` is an *ordered vector of setup steps*. Each step is a bare event vector (`[:cart/restore-session]`) or, when it needs dispatch opts, a map (`{:event [:cart/add "milk"] :opts {…}}`). Each step is dispatched synchronously and run to completion before the next one starts — and "to completion" means all the way down: if a setup event dispatches further events, those finish too. By the time `reg-frame` returns, the entire setup drain is done and the world is fully booted.
 
 ### The rest of `reg-frame`'s config
 
@@ -127,17 +131,17 @@ Day to day, `:initial-events` is the key you reach for. But `reg-frame` mirrors 
    :preset         :test})                         ;; capability bundle — :default / :test / :story / :ssr-server
 ```
 
-- **`:on-destroy`** is a *single* event fired once, just before teardown.
-- **`:fx-overrides`** swaps registered [effect handlers](../glossary.md#effect-handler) by id — the test-double mechanism (stub `:my-app/http` so a frame never hits the network).
-- **`:interceptors`** prepends [interceptor](../glossary.md#interceptor) *refs* (registered ids, never inline interceptor values) to every event in the frame — "global within this frame." (Interceptors get [their own page](interceptors.md) later.)
-- **`:drain-depth`** caps the run-to-completion drain.
-- **`:preset`** expands into a named bundle of frame-config defaults (`:test`, `:story`, `:ssr-server` — what each sets is in the [API reference](../../api/re-frame.core.md)) so a frame's *intent* is visible at the call site and machine-readable from `(rf/frame-meta :cart)`.
+Notes:
+
+1. **`:on-destroy`** is a *single* event fired once, just before teardown.
+2. **`:fx-overrides`** swaps registered [effect handlers](../glossary.md#effect-handler) by id — the test-double mechanism (stub `:my-app/http` so a frame never hits the network).
+3. **`:interceptors`** prepends [interceptor](../glossary.md#interceptor) *refs* (registered ids, never inline interceptor values) to every event in the frame — "global within this frame." (Interceptors get [their own page](interceptors.md) later.)
+4. **`:drain-depth`** caps the run-to-completion drain.
+5. **`:preset`** expands into a named bundle of frame-config defaults (`:test`, `:story`, `:ssr-server` — what each sets is in the [API reference](../../api/re-frame.core.md)) so a frame's *intent* is visible at the call site and machine-readable from `(rf/frame-meta :cart)`.
 
 The `:observability` sink policy — the production-telemetry key not shown above — is covered in [Observability](observability.md#consuming-production-telemetry-declare-a-sink); the full `reg-frame` grammar is in the [API reference](../../api/re-frame.core.md).
 
-!!! warning "Gotcha"
-
-    Hand `reg-frame` a `:sensitive` or `:large` key (those belong on handler effects, not frame config — see [data classification](../glossary.md#data-classification)) or a malformed `:observability` entry, and registration throws `:rf.error/bad-frame-classification` *before* any setup event runs, so you never get a half-registered frame. A top-level shape mistake is caught the same way: `{:initial-events [:cart/init]}` — a bare event, not a *vector of* steps — is rejected with a diagnostic that names the fix (wrap it as `[[:cart/init]]`).
+One class of mistake is caught before it can hurt you, so know what the catch looks like. Hand `reg-frame` a `:sensitive` or `:large` key (those belong on handler effects, not frame config — see [data classification](../glossary.md#data-classification)) or a malformed `:observability` entry, and registration throws `:rf.error/bad-frame-classification` *before* any setup event runs — you never get a half-registered frame. A top-level shape mistake is caught the same way: `{:initial-events [:cart/init]}` — a bare event, not a *vector of* steps — is rejected with a diagnostic that names the fix (wrap it as `[[:cart/init]]`).
 
 ??? note "Going deeper — three lanes meet at startup; keep them apart"
 
@@ -152,7 +156,7 @@ Now the reason frames exist. The genuine multi-frame cases, roughly in the order
 - **A fresh frame per test.** Each test gets its own frame, torn down after, so no test can leak state into the next — see [Test a pipeline run](../testing/pipeline-runs.md).
 - **A frame per server request.** [Server-side rendering](../../ssr/concepts.md) creates a frame per HTTP request, runs the app in it, serialises, destroys it. A hundred concurrent requests are a hundred isolated app-dbs.
 
-The shape is the same every time: **one app, mounted N times, each mount fully isolated.** Multi-frame is never "N half-apps stitched together" — each frame is a complete, self-sufficient world.
+The shape is the same every time: **one app, mounted N times, each mount fully isolated.** Multi-frame is never "N half-apps stitched together" — each frame is a complete, self-sufficient world. Two panes: two worlds. Three Story variants: three. A hundred SSR requests: a hundred worlds, each with its own state, its own queue, its own private history, blinking in and out of existence as requests come and go — you're not running an app anymore, you're administering a multiverse. Too much? Fine: N hash maps and N event queues, rigorously fenced. But that fence is the entire point of this page.
 
 Here's the split pane, end to end. Watch how little changes from the one-frame case:
 
@@ -189,13 +193,11 @@ Notice what *isn't* there: no pane id threaded through the view, no atom per pan
 
 Click `+` on the left and only the left number moves. Open [Xray](../glossary.md#xray), pick the left frame, and you see only that frame's events and app-db; the right frame's ledger never heard about the click. Frames are how every inspection tool partitions the world.
 
-!!! note "Borderline case? Ask one question"
-
-    This is where people hesitate. The discriminator: *would these two things ever sensibly share a piece of state?* If yes, they are two views over slices of *one* frame's app-db — views on a page compose by sharing app-db, and that's the point of [having one place](app-db.md). If no — if they're genuinely two separate runs of the app — they're two frames. The two panes never want to share a counter, and that "no" is the signal.
+Borderline case? This is where people hesitate, so here's the one question that settles it: *would these two things ever sensibly share a piece of state?* If yes, they are two views over slices of *one* frame's app-db — views on a page compose by sharing app-db, and that's the point of [having one place](app-db.md). If no — if they're genuinely two separate runs of the app — they're two frames. The two panes never want to share a counter. That "no" is the signal.
 
 ### Two config shapes: scope an existing frame, or ensure a named one?
 
-`frame-provider` is one component with two config shapes, chosen by the prop map you hand it. The split pane used the **scope** shape, `{:frame …}` It **scopes** an *already-registered* frame into a React subtree; it creates nothing and destroys nothing. You registered `:pane/left` with `reg-frame` at boot, and the provider just establishes its scope for descendants. Pass it a `:frame` keyword; scoping a frame that was never created (or has been destroyed) fails loud with `:rf.error/frame-provider-frame-absent`, because a silent mis-scope is a debugging nightmare.
+`frame-provider` is one component with two config shapes, chosen by the prop map you hand it. The split pane used the **scope** shape, `{:frame …}`. It **scopes** an *already-registered* frame into a React subtree — creates nothing, destroys nothing. You registered `:pane/left` with `reg-frame` at boot; the provider just establishes its scope for descendants. Pass it a `:frame` keyword. Scoping a frame that was never created (or has been destroyed) fails loud with `:rf.error/frame-provider-frame-absent`, because a silent mis-scope is a debugging nightmare.
 
 Its other shape, `{:id …}`, **ensures** a named frame. It creates the frame the first time the view mounts (running `:initial-events`), and on every later mount/remount under the same id it *reuses* the live frame without re-seeding — there is **no destroy-on-unmount**. You give it the frame's recipe inline rather than a pre-registered id:
 
@@ -222,17 +224,15 @@ So the choice is "do I already have this frame, or do I want the provider to ens
 
     Neither shape destroys the frame on unmount. When a component should own a frame's whole lifetime (a modal that wants a throwaway world torn down on close), make that explicit: `rf/make-frame` + `rf/destroy-frame!` (both [below](#ending-and-resetting-a-frame)), tied to the component's mount/unmount lifecycle — e.g. inside a `create-class`, where the component declares it owns the birth *and* the death.
 
-!!! warning "Gotcha — re-mounting the `{:id …}` shape is idempotent"
-
-    If the view re-mounts (a hot reload, a Story re-evaluation, a key change), the existing frame's durable state is *preserved*, not blown away — re-mount updates the frame's config without resetting `app-db` or replaying `:initial-events`. That's what makes hot reload not blink. If you genuinely want a fresh start, that's `reset-frame!` (below), not a re-mount.
+One behaviour to internalise before it surprises you: re-mounting the `{:id …}` shape is idempotent. If the view re-mounts — a hot reload, a Story re-evaluation, a key change — the existing frame's durable state is *preserved*, not blown away. Re-mount updates the frame's config without resetting `app-db` or replaying `:initial-events`; that's what makes hot reload not blink. If you genuinely want a fresh start, that's `reset-frame!` (below), not a re-mount.
 
 ## The one rule: frame identity is carried, not found
 
 Everything above rests on a single invariant — the rule that makes isolation *trustworthy*:
 
-!!! note
+> **[Frame identity is a value that travels with the work](../glossary.md#frame-identity-is-carried-not-found).** A dispatch, a subscription, a captured callback — each reads its frame from the context it was *given*: the provider above it, the handler it's running in, the frame api that carried it (the captured operations bundle you'll meet below). An operation never goes looking for a frame in the ambient world, and the runtime never invents one from absence.
 
-    **[Frame identity is a value that travels with the work](../glossary.md#frame-identity-is-carried-not-found).** A dispatch, a subscription, a captured callback — each reads its frame from the context it was *given*: the provider above it, the handler it's running in, the frame api that carried it (the captured operations bundle you'll meet below). An operation never goes looking for a frame in the ambient world, and the runtime never invents one from absence.
+I'll pause while you read that sentence again. Everything below — the loud errors, the capture tool, the test macros — is that sentence, enforced.
 
 So a bare `(rf/dispatch [:counter/inc])` works when — and only when — something above it established a frame: the root provider, the event handler it's firing from, a `with-frame` block in a test or at the REPL. With no established scope and no carried frame, the operation fails loud:
 
@@ -264,9 +264,7 @@ From outside any scope — a test, a tool, the REPL — you name the frame expli
 
 There is no `dispatch-to` / `subscribe-to` sugar — the two-argument opts form is the one mechanism. It's also the right shape from non-Reagent contexts: server-side rendering, headless JVM tests, and tooling agents all address frames this way.
 
-!!! warning "Gotcha"
-
-    `:rf.error/no-frame-context` is reserved for **absence** — you carried no frame at all. The moment you *do* carry one (`{:frame :ghost}`), you've supplied an explicit target, and a bad target — a typo, or a frame already torn down — is the registry-lookup case instead: `dispatch` quietly no-ops, `subscribe` returns `nil`, and a `:rf.error/frame-destroyed` record lands on the always-on [error stream](../glossary.md#error-record). (Same recovery as a [destroyed frame](#ending-and-resetting-a-frame) — the runtime can't tell a typo from a teardown race.) Branch on the category, not the absence: a missing scope and a bad target are two distinct failures.
+One distinction will save you a confused half-hour, so hear it now. `:rf.error/no-frame-context` is reserved for **absence** — you carried no frame at all. The moment you *do* carry one (`{:frame :ghost}`), you've supplied an explicit target, and a bad target — a typo, or a frame already torn down — is the registry-lookup case instead: `dispatch` quietly no-ops, `subscribe` returns `nil`, and a `:rf.error/frame-destroyed` record lands on the always-on [error stream](../glossary.md#error-record). (Same recovery as a [destroyed frame](#ending-and-resetting-a-frame) — the runtime can't tell a typo from a teardown race.) A missing scope and a bad target are two distinct failures. Branch on the category, not the absence.
 
 ## The async boundary: capture the frame
 
@@ -310,19 +308,15 @@ And there's one case where you need none of this: scheduling from inside an even
 
 `:dispatch` and `:dispatch-later` effects are stamped with the in-flight frame before any timer or microtask boundary — zero ceremony. If the deferred work is just a dispatch, this is the shape.
 
-!!! warning "Gotcha — when `capture-frame` is still needed inside an effect handler"
-
-    Reach for `capture-frame` only for callbacks the effect system doesn't mediate — the socket's `onmessage` above, SDK callbacks, `window` listeners — even when the function that wires them up runs inside an effect handler. The effect system carries the frame for the dispatches *it* schedules, not for callbacks you register with the outside world.
+Don't over-learn that, though. `capture-frame` is still needed for callbacks the effect system doesn't mediate — the socket's `onmessage` above, SDK callbacks, `window` listeners — even when the function that wires them up runs inside an effect handler. The effect system carries the frame for the dispatches *it* schedules, not for callbacks you register with the outside world.
 
 This page is the canonical home of the capture pattern. When the [views](views.md) and [subscriptions](subscriptions.md) pages warn "don't dispatch bare from async callbacks," this is the full story they're pointing at.
 
 ## The hard rule: subscriptions never reach across frames
 
-A [subscription](../glossary.md#subscription) — a derived, cached read over app-db — belongs to one frame. It computes from that frame's app-db and from other subscriptions *in that frame*, never from another frame's state. There is no "read frame B from a sub in frame A" affordance, and you must not build one by sneaking a cross-frame read into a sub's computation function. That's the anti-pattern, full stop.
+A [subscription](../glossary.md#subscription) — a derived, cached read over app-db — belongs to one frame. It computes from that frame's app-db and from other subscriptions *in that frame*, never from another frame's state. There is no window between worlds: no "read frame B from a sub in frame A" affordance exists, and you must not build one by sneaking a cross-frame read into a sub's computation function. That's the anti-pattern, full stop.
 
-!!! note
-
-    **Why this matters — one cross-frame subscription breaks every per-frame guarantee.** The reasoning is the same as the carried rule's: isolation is only worth having if it's total. Story variants are reproducible because nothing outside a frame can influence them. SSR requests can run concurrently because no request can observe another. A test frame is hermetic because *nothing* reaches in. One cross-frame sub quietly breaks all three — frame A's derived values now change when frame B does, and every tool that reasons per-frame (the [epoch](../glossary.md#epoch) ledger, [time-travel](../glossary.md#time-travel), replay) is lying to you about A.
+Why so hard a line? Because one cross-frame subscription breaks every per-frame guarantee at once. The reasoning is the same as the carried rule's: isolation is only worth having if it's total. Story variants are reproducible because nothing outside a frame can influence them. SSR requests can run concurrently because no request can observe another. A test frame is hermetic because *nothing* reaches in. One cross-frame sub quietly breaks all three — frame A's derived values now change when frame B does, and every tool that reasons per-frame (the [epoch](../glossary.md#epoch) ledger, [time-travel](../glossary.md#time-travel), replay) is lying to you about A.
 
 If you feel the need for one, you've answered the discriminator question wrongly: two things that need to share derived state are one frame. Restructure — don't reach across.
 
@@ -339,9 +333,7 @@ Most frames live for the whole program and you never tear them down — a UI-own
 
 **`reset-frame!`** is "I want this back to how it started." It's equivalent to a destroy followed by a fresh `reg-frame` with the same config: `app-db` resets to `{}`, the sub-cache and router queue clear, and the recorded `:initial-events` re-run synchronously. Tests use it between cases; Story "reset" buttons use it. (For an `app-db`-only reset that *keeps* live runtime state, there's a lighter `reset-app-db!` — but `reset-frame!` is the whole-world one.)
 
-!!! warning "Gotcha"
-
-    Constructing a frame inside an event handler fails loud with `:rf.error/frame-construction-in-handler`. The division is the same one this whole page rests on: a *handler* changes app-db; a *view* (or boot, or an SSR-per-request top level) materialises frames. A handler that wants a child frame to exist writes app-db to say so, and the view tree creates the frame in response (via `frame-provider`). There is no mid-run frame-creation path.
+And one construction rule, said plainly: constructing a frame inside an event handler fails loud with `:rf.error/frame-construction-in-handler`. The division is the same one this whole page rests on — a *handler* changes app-db; a *view* (or boot, or an SSR-per-request top level) materialises frames. A handler that wants a child frame to exist writes app-db to say so, and the view tree creates the frame in response (via `frame-provider`). There is no mid-run frame-creation path.
 
 ### Scoping a frame in a test or at the REPL
 
@@ -363,9 +355,7 @@ A test or REPL session is *outside* any provider, so there's no ambient scope �
 
 Note `dispatch-sync` rather than `dispatch`: from outside a running drain it runs the event to completion *before returning*, which is what a test wants to assert against. (Calling `dispatch-sync` from *inside* a handler is an error — `:rf.error/dispatch-sync-in-handler` — because the drain is already running synchronously; the in-handler shape is `:fx [[:dispatch …]]`.) The test-fixture idiom in full — seeding, stubs, and the two macros' argument-shape guards — is [Test a pipeline run](../testing/pipeline-runs.md)'s territory.
 
-!!! warning "Gotcha"
-
-    `with-frame` establishes the frame via a dynamic var, which evaporates the instant control crosses an async boundary. An async callback created inside a `with-frame` body that fires *after* the body returns is back in frameless territory — and `with-new-frame` has already destroyed its frame by then. That's the same async cliff as the WebSocket above; the same fix applies — capture a frame api with `capture-frame` (or pass an explicit `{:frame …}`) before the boundary.
+One cliff edge, before you walk off it: `with-frame` establishes the frame via a dynamic var, which evaporates the instant control crosses an async boundary. An async callback created inside a `with-frame` body that fires *after* the body returns is back in frameless territory — and `with-new-frame` has already destroyed its frame by then. It's the same async cliff as the WebSocket above, and the same fix applies: capture a frame api with `capture-frame` (or pass an explicit `{:frame …}`) before the boundary.
 
 ## Advanced
 
@@ -392,3 +382,5 @@ It's almost never what you meant, though, so the runtime emits `:rf.warning/cros
 ??? note "Going deeper — when two frames resolve the same id differently"
 
     Everything on this page assumed the default: all frames draw their handlers from one shared registrar, so every frame runs the same handlers against different app-dbs. The selected slice a frame resolves against has a name — the [**image**](../glossary.md#image) — and 99% of the time you never need to think about it. The 1% is when you want two frames to resolve `[:counter/inc]` to *different* handlers: two examples on one page, or an inspection tool sitting beside the app it inspects. Then you give those frames *different* images, and which image a frame points at is what decides its behaviour. That's the [Images](images.md) story; ignore it until you hit a case that needs it.
+
+One app. N worlds. And one rule keeping them honest: frame identity is carried, not found.

--- a/docs/core/concepts/images.md
+++ b/docs/core/concepts/images.md
@@ -1,14 +1,20 @@
 # Images: which registrations a frame runs
 
-You've registered a dozen [events](../glossary.md#event) and [subscriptions](../glossary.md#subscription) and your app works — and you've never once thought about *which* of them a given [frame](../glossary.md#frame) can see. That's the default path, and it's deliberately invisible. You can stay productive for a long time without learning the word on this page.
+You've registered a dozen [events](../glossary.md#event) and [subscriptions](../glossary.md#subscription). Your app works. And you have never once wondered *which* of them a given [frame](../glossary.md#frame) can see.
 
-This page is for the day the default stops being enough. The day you want two examples on one page that both call their event `:counter/inc`. Or an inspection tool mounted right beside the app it inspects. Or a test that needs a *fake* HTTP effect instead of the real one. Each of those is the same question — *which registrations does this frame resolve against?* — and the answer is the [**image**](../glossary.md#image).
+Good. That's the design working. The default path is deliberately invisible, and you can stay productive on it for a long time without learning the word on this page.
 
-If you quote one sentence from this page, quote this one:
+This page is for the day the default stops being enough. The day you want two examples on one page that both call their event `:counter/inc`. Or an inspection tool mounted right beside the app it inspects. Or a test that needs a *fake* HTTP effect instead of the real one. Three different wishes; one question underneath — *which registrations does this frame resolve against?*
+
+The answer is the [**image**](../glossary.md#image):
 
 > **An image is which registrations are loaded; a frame is the live run that resolves against them.**
 
-We'll build that up one step at a time, starting from code you've already written without realising an image was there at all.
+I'll pause while you read that again. It's the load-bearing sentence of this page — everything below is that one line wearing different clothes.
+
+If you want something concrete to hold, hold a theatre. The image is the script: which characters exist, what their lines are. The frame is tonight's performance: live, on stage, with its own history of everything that has already happened. One script can play on two stages at once. Two different scripts can both contain a character called the King. Keep the theatre; the rest of the page will use it.
+
+We'll build the idea up one step at a time, starting from code you've already written without realising an image was there at all.
 
 ## You already use an image — the default one
 
@@ -23,13 +29,13 @@ Here is ordinary re-frame2. No image in sight:
   (fn [db _] (:count db 0)))
 ```
 
-Those `reg-*` forms don't *run* anything. They write entries into the [**registrar**](../glossary.md#registrar) — the process-global table holding every [registration](../glossary.md#registration) you've authored, each tagged with the namespace it was written in (its registration source, `:rf.provenance/*`). Nothing has executed yet; you've just filled the registrar.
+Those `reg-*` forms don't *run* anything. They write entries into the [**registrar**](../glossary.md#registrar) — the process-global table holding every [registration](../glossary.md#registration) you've authored, each tagged with the namespace it was written in (its registration source, `:rf.provenance/*`). Nothing has executed yet. You've just filled the registrar.
 
-When you then create a frame *without* naming an image, that frame just resolves every lookup straight against the whole registrar — "everything I've registered." That implicit "all of it" selection is the **default image**: the conceptual zero-config selection you get for free. So an image, at its simplest, is just a *selection from the registrar* — and the default selects all of it.
+When you then create a frame *without* naming an image, that frame resolves every lookup straight against the whole registrar — "everything I've registered." That implicit all-of-it selection is the **default image**: the conceptual zero-config selection you get for free. So an image, at its simplest, is just a *selection from the registrar*. The default selects all of it.
 
 !!! note "Heads-up — the default image is a real sealed generation"
 
-    Conceptually the default image is "the whole registrar sealed into one set" — and mechanically that is exactly what you get. `make-frame` with no `:images` key resolves a sealed **default generation** over the whole active store (framework standards included): the implicit selector over everything. It runs the same assembly gate as an explicit selection, so even the default path fails loud on a cross-namespace `[kind id]` collision (`:rf.error/image-duplicate-id`) rather than letting load order silently pick a survivor. The one frame that carries *no* generation is one declared with bare `reg-frame` — it resolves each lookup live against the shared registrar, which is why the read-side accessors below want a `make-frame`-built frame.
+    "The whole registrar sealed into one set" is not just the concept — mechanically it is exactly what you get. `make-frame` with no `:images` key resolves a sealed **default generation** over the whole active store (framework standards included): the implicit selector over everything. It runs the same assembly gate as an explicit selection, so even the default path fails loud on a cross-namespace `[kind id]` collision (`:rf.error/image-duplicate-id`) rather than letting load order silently pick a survivor. The one frame that carries *no* generation is one declared with bare `reg-frame` — it resolves each lookup live against the shared registrar, which is why the read-side accessors below want a `make-frame`-built frame.
 
 The common case stays boring, on purpose. You never name an image. New registrations show up the moment you write them. Hot reload keeps working. You meet the image concept *explicitly* only when "everything that's loaded, ids assumed globally unique" stops being the boundary you want.
 
@@ -37,15 +43,13 @@ The common case stays boring, on purpose. You never name an image. New registrat
 
     Think of the registrar as your full set of module exports, and the default image as `import * from` everything. You don't normally think about it — until two modules export the same name and you need to be explicit about which one a particular consumer gets.
 
-!!! note "Heads-up"
-
-    "Default image" is the runtime's zero-config behaviour, not a value you author. Don't reach for `rf/image` to get the default — plain `reg-*` already gives it to you. In code, the default image is simply *a frame created with no `:images` key*. You never write the word "image" to get it.
+One clarification before we move on, because the name invites the mistake: "default image" is the runtime's zero-config behaviour, not a value you author. Don't reach for `rf/image` to get the default — plain `reg-*` already gives it to you. In code, the default image is simply *a frame created with no `:images` key*. You never write the word "image" to get the default image.
 
 ## When two registrations collide, it fails loud
 
 The default image works only while ids are globally unique across everything that's loaded. The moment two loaded namespaces register the same `(kind, id)` with *different* implementations — two surfaces that both define `:counter/inc`, say — the default image refuses to assemble. The error names the colliding kind/id and both source namespaces.
 
-That refusal is a feature. The registrar kept *both* descriptors, and assembly won't guess which one wins. You have three explicit ways out, and we'll meet each below: rename one id, narrow each frame to its own slice with an explicit image, or compose a later image that declares an exact replacement winner. The one thing the framework won't do is silently pick one and move on.
+That refusal is a feature. Read it as one. The registrar kept *both* descriptors, and assembly won't guess which one wins. You have three explicit ways out, and we'll meet each below: rename one id; narrow each frame to its own slice with an explicit image; or compose a later image that declares an exact replacement winner. The one thing the framework will not do is silently pick a survivor and move on.
 
 ??? info "From re-frame v1"
 
@@ -53,7 +57,7 @@ That refusal is a feature. The registrar kept *both* descriptors, and assembly w
 
 ## Naming an image: `rf/image`
 
-When you do need to be explicit, `rf/image` builds an image *value*. Building one registers nothing and runs nothing — it just produces a plain data description of "which registrations to select" — and you hand it to a frame through `:images`:
+When you do need to be explicit, `rf/image` builds an image *value*, and you hand it to a frame through `:images`:
 
 ```clojure
 (def counter-image
@@ -63,9 +67,12 @@ When you do need to be explicit, `rf/image` builds an image *value*. Building on
                 :images [counter-image]})
 ```
 
-`:select-ns` is the everyday move: *select existing registrations by the namespace they were authored in.* The frame now resolves against only the registrations written in `docs.quickstart.counter.basic` — not the whole registrar.
+`:select-ns` is the everyday move: *select existing registrations by the namespace they were authored in.* The frame now resolves against only the registrations written in `docs.quickstart.counter.basic` — not the whole registrar. Just that slice.
 
-One thing to notice, because it trips people up: the selection chooses by **provenance** — *where a registration was written* — not by the keyword namespace of its id. A registration with id `:counter/inc` authored in `docs.quickstart.counter.basic` is selected because of the *file it lives in*, not because the keyword starts with `counter`.
+Notes:
+
+1. Building an image registers nothing and runs nothing. `rf/image` produces a plain data description of "which registrations to select" — inert until a frame composes it.
+2. The selection chooses by **provenance** — *where a registration was written* — not by the keyword namespace of its id. A registration with id `:counter/inc` authored in `docs.quickstart.counter.basic` is selected because of the *file it lives in*, not because the keyword starts with `counter`. This one trips people up, so file it away now.
 
 ??? info "Coming from a bundler's globs?"
 
@@ -83,9 +90,7 @@ An `rf/image` value carries **exactly three** public source keys, and nothing el
 
 An image with neither `:select-ns` nor `:registrations` is valid but empty — useful as a deliberate "no app registrations" image: `(rf/image {:id :test/empty})`.
 
-!!! warning "Gotcha — the image surface is *closed*, not open"
-
-    An unknown top-level key fails loud (`:rf.error/invalid-image`) rather than being silently ignored — so a typo'd key is a loud error you hear at construction, not a mystery you debug at runtime.
+And "nothing else" is enforced, not aspirational: the image surface is *closed*, not open. An unknown top-level key fails loud (`:rf.error/invalid-image`) rather than being silently ignored — a typo'd key is a loud error you hear at construction, not a mystery you debug at runtime.
 
 ### Narrowing the glob: `:include` and `:exclude`
 
@@ -141,7 +146,7 @@ Most human-authored code should stay with ordinary `reg-*` forms and select by p
 
 ??? note "Going deeper"
 
-    Inline `:registrations` covers **exactly four** registrar kinds: `:reg-event`, `:reg-sub`, `:reg-fx`, `:reg-cofx` — the kinds a test double or generated slice realistically needs without a namespace. Every other section key (`:reg-interceptor`, `:reg-view`, `:reg-frame`, `:reg-route`, `:reg-flow`, …) fails loud with an unsupported-inline-kind diagnostic; those stay namespace-authored and come in via `:select-ns`. Inline `:reg-sub` accepts only the layer-1 db-reader shape `(fn [db query] …)`; signal-graph subs stay in source. Each entry lowers through its kind's own registrar parser, so a malformed inline descriptor fails exactly the way the corresponding `reg-*` call would. These are *descriptions* of registrations, never `reg-*` calls smuggled into a map.
+    Inline `:registrations` covers **exactly four** registrar kinds: `:reg-event`, `:reg-sub`, `:reg-fx`, `:reg-cofx` — the kinds a test double or generated slice realistically needs without a namespace. Every other section key (`:reg-interceptor`, `:reg-view`, `:reg-frame`, `:reg-route`, `:reg-flow`, …) fails loud with an unsupported-inline-kind diagnostic; those stay namespace-authored and come in via `:select-ns`. Inline `:reg-sub` accepts only the layer-1 db-reader shape `(fn [db query] …)`; subs with declared inputs (the `:<-` and input-function forms) stay in source. Each entry lowers through its kind's own registrar parser, so a malformed inline descriptor fails exactly the way the corresponding `reg-*` call would. These are *descriptions* of registrations, never `reg-*` calls smuggled into a map.
 
 !!! warning "Gotcha — `:select-ns` and `:registrations` must be disjoint"
 
@@ -156,7 +161,7 @@ Here is the rule that makes two examples on one page possible, and it's worth st
 | **Registration ids** | `:counter/inc`, `:counter/value` | the resolved image | reusable across images; must be unambiguous *within* one sealed image |
 | **Frame ids** | `:counter/left`, `:counter/right` | the process-local frame registry | must be unique among live frames |
 
-Two images may both contain a `:counter/inc` event. Two live frames may *not* both register as `:counter/main`. So a docs page can reuse one teaching vocabulary across every example, while each mounted example still gets a distinct frame id:
+Two images may both contain a `:counter/inc` event. Two live frames may *not* both register as `:counter/main`. In theatre terms: every script is allowed a character called the King, but the building has exactly one Stage 3. So a docs page can reuse one teaching vocabulary across every example, while each mounted example still gets a distinct frame id:
 
 ```clojure
 (def counter-basic  (rf/image {:select-ns {:include ["docs.quickstart.counter.basic"]}}))
@@ -176,7 +181,11 @@ The reader sees one small vocabulary evolve across lessons instead of `:counter-
 
 ## The shape of every image decision
 
-Every situation on this page reduces to one decision. An image holds *behaviour* (the registrations); a frame holds *state and history* (its own [app-db](../glossary.md#app-db), evolving as events run). So: **different behaviour means a different image; the same behaviour with a different lived history means the same image, just a different frame.** Watch that one rule produce every shape:
+Every situation on this page — every single one — reduces to one decision. An image holds *behaviour*: the registrations. A frame holds *state and history*: its own [app-db](../glossary.md#app-db), evolving as events run. So:
+
+**Different behaviour means a different image; the same behaviour with a different lived history means the same image, just a different frame.**
+
+Two surfaces on one page? That rule. A tool inspecting a live app? That rule. Test doubles, library packaging, story canvases, progressive lessons, the thing you're building right now that isn't on this list? The rule, the rule, the rule, probably the rule. ...All right. One rule doesn't need a chant. Watch it produce every shape instead:
 
 - **Two surfaces on one page.** A cart surface and a counter surface that both want simple local ids (`:boot/init`, `:item/add`). Give each its own image with disjoint `:select-ns` selectors; each frame resolves only its own.
 - **An inspection tool beside its target.** [Xray](../glossary.md#xray) is itself a running surface with its own events, subs, and app-db paths. Run it in its own image and frame, and let it inspect the target frame *as data* — the tool never has to coordinate ids with the thing it inspects.
@@ -246,7 +255,7 @@ An empty vector means nothing was overridden — so `(empty? (rf/frame-shadows f
 
 ## Tests and stories: behaviour is the image, state is the frame
 
-Tests and stories want controlled behaviour *and* controlled state. The image gives you the behaviour side; the frame gives you the state side. To swap in a fake HTTP [effect handler](../glossary.md#effect-handler), you don't mutate a process-global registrar under a running frame — you build a different image:
+Tests and stories want two things pinned down: behaviour *and* state. The image gives you the behaviour half; the frame gives you the state half. So to swap in a fake HTTP [effect handler](../glossary.md#effect-handler), you don't mutate a process-global registrar underneath a running frame — you build a different image:
 
 ```clojure
 (def checkout-test-image
@@ -259,7 +268,7 @@ Tests and stories want controlled behaviour *and* controlled state. The image gi
   @(rf/subscribe [:cart/items] {:frame frame}))
 ```
 
-State setup is a *frame* concern — `:initial-events` (e.g. a leading `[:rf/set-db {…}]`), a restored frame-state value, or setup events. Behaviour setup is an *image* concern — select or override registrations before the frame runs. The two stay separate, which is exactly why a test can fix behaviour and history independently.
+State setup is a *frame* concern — `:initial-events` (e.g. a leading `[:rf/set-db {…}]`), a restored frame-state value, or setup events. Behaviour setup is an *image* concern — select or override registrations before the frame runs. The two never tangle, which is exactly why a test can fix behaviour and history independently.
 
 ??? info "Coming from Jest mocks or MSW?"
 
@@ -288,17 +297,15 @@ To override an existing `(kind, id)`, define the winning registration in a *late
 ;; => [{:registration [:fx :checkout.http/post] :image :app/main :shadowed-by :test/doubles}]
 ```
 
-An override is always a *separate* image, never a second key in the same one. A cross-image shadow resolves (later wins) and is reported; you read the report and apply whatever policy you want.
+The stub is an understudy: same part — `:checkout.http/post` — different actor, and the stage manager's log (the shadow report) says exactly who went on. An override is always a *separate* image, never a second key in the same one. A cross-image shadow resolves (later wins) and is reported; you read the report and apply whatever policy you want.
 
-!!! warning "Gotcha — you cannot override a framework standard"
-
-    The one cross-image collision that still fails assembly is an app registration colliding with a framework **standard**. If it's application-owned, define the winner in a later image and read the shadow report. But if it's *how the frame executes registered entries* — queue ordering, the interceptor algorithm, app-db commit semantics — that's a protected standard (`:rf.error/image-standard-replacement-forbidden`), and no app image may shadow it. A standard encodes an execution invariant, not an app policy choice.
+One boundary is absolute, so hear it plainly: **you cannot override a framework standard.** The one cross-image collision that still fails assembly is an app registration colliding with a framework standard. If it's application-owned, define the winner in a later image and read the shadow report. But if it's *how the frame executes registered entries* — queue ordering, the interceptor algorithm, app-db commit semantics — that's a protected standard (`:rf.error/image-standard-replacement-forbidden`), and no app image may shadow it. A standard encodes an execution invariant, not an app policy choice.
 
 ## Hot reload swaps the image, keeps the memory
 
 During development the registrar changes every time you save a file. A `reg-*` re-eval doesn't mutate any running sealed generation — it marks every image that selects the changed namespace *dirty*, resolves fresh sealed generations, and swaps them into the affected frames. The existing app-db, [runtime-db](../glossary.md#runtime-db), queues, and still-valid subscription caches continue. The code changed; the VM kept its memory.
 
-That automatic path is the one you lean on day to day: you save a file and the live frames pick up the change without losing their state. You don't call anything.
+That automatic path is the one you lean on day to day. You save a file. The live frames pick up the change without losing their state. You call nothing.
 
 When you want to change a frame's image *composition* outright — swap one whole `:images` vector for another — that's an explicit, frame-targeted reload via **`rf/reload-images!`**:
 
@@ -324,4 +331,6 @@ You hand it a frame (id or value) and a new `:images` vector — exactly the sha
 
     `reload-images!` is the explicit knob; the automatic `reg-*` re-eval path is what you actually lean on. Save a file and the affected frames pick up the change with no call from you. Reach for `reload-images!` only when you want to swap a frame's *whole composition* deliberately — a test that re-points a running frame at a different image stack, a tool driving a frame through several configurations, a story canvas trading one deck of registrations for another.
 
-And that's the whole shape. The same boundary that lets two examples on one page each own `:counter/inc` is the boundary that survives a file save: the image is a *value*, the runtime can diff two of them, and a frame can trade one for another without forgetting what it has lived through. Behaviour is the image; state is the frame; the events are the program — and once those three are separate things, every situation above is one move in different clothes: *different behaviour means a different image; same behaviour with a different history means the same image with a different frame.*
+And that's the whole shape. The same boundary that lets two examples on one page each own `:counter/inc` is the boundary that survives a file save: the image is a *value*, the runtime can diff two of them, and a frame can trade one for another without forgetting what it has lived through. The script can be revised mid-run; the performance keeps its memory.
+
+Behaviour is the image. State is the frame. The events are the program. Once those three are separate things, every situation above is one move in different clothes: *different behaviour means a different image; the same behaviour with a different history means the same image with a different frame.*

--- a/docs/core/concepts/interceptors.md
+++ b/docs/core/concepts/interceptors.md
@@ -1,6 +1,12 @@
 # Interceptors
 
-Say you have three hundred [event handlers](../glossary.md#event-handler), and three chores that apply to all of them: log every event, snapshot state for undo, validate input at the boundary. Nobody wants to write those chores into three hundred handlers — that's nine hundred copies of code that isn't the handler's job.
+Say you have three hundred [event handlers](../glossary.md#event-handler), and three chores that apply to all of them: log every event, snapshot state for undo, validate input at the boundary.
+
+Where do the chores go?
+
+Not into the handlers. Do that and you have nine hundred copies of code that isn't any handler's job. Nine hundred copies drifting quietly apart. Three hundred edits the day the logging format changes — and it will change — three hundred chances to miss one, and a bug filed weeks later against the one you missed. And the undo chore isn't even stateless: it's a snapshot stack, smeared across every mutating handler you own.
+
+Okay. Deep breath. The diagnosis stands, though: these chores *cut across* handlers, so they can't live *inside* handlers.
 
 An **interceptor** is where a cross-cutting chore lives instead. You write the chore *once*, register it under a name, and wrap it around any handler — or around every handler in a [frame](../glossary.md#frame) — just by referencing that name. The handler stays focused on its one job: turning [coeffects](../glossary.md#coeffect) into an [effect map](../glossary.md#effect-map).
 
@@ -32,11 +38,11 @@ You register an interceptor the same way you register an event or a sub: give it
 
 Each function takes one argument, `ctx` — the **context** — and returns it (possibly modified). That single value is the only channel an interceptor has: `:before` here stashes the start time on the context, and its own `:after` reads it back. (That `::started-at` key, with the double colon, is just Clojure shorthand for a keyword namespaced to the current file — a safe place to park scratch data without colliding with anyone else's keys.) No closures, no side atoms.
 
-Three small things trip people up the first time:
+Notes — the three things that trip people up the first time:
 
-- **Each dispatch gets a fresh context.** Scratch like `::started-at` can never leak from one dispatch into the next — one registration is safe on any number of handlers and frames.
-- **The id is the handle.** Once registered, `:my-app/logger` *is* the interceptor everywhere — chains reference it by id, the [trace stream](../glossary.md#trace-stream) and [Xray](../glossary.md#xray) name it by id, overrides find it by id. There is no anonymous interceptor to lose track of.
-- **Both slots must return the context.** ("Slot" is just a handy name for one of the two functions — the `:before` or the `:after`.) A slot that returns `nil` reads as "unchanged". That works by accident in a log-only slot — right up until you also `assoc` something and the accident becomes a heisenbug. Always end with `ctx`.
+1. **Each dispatch gets a fresh context.** Scratch like `::started-at` can never leak from one dispatch into the next — one registration is safe on any number of handlers and frames.
+2. **The id is the handle.** Once registered, `:my-app/logger` *is* the interceptor everywhere — chains reference it by id, the [trace stream](../glossary.md#trace-stream) and [Xray](../glossary.md#xray) name it by id, overrides find it by id. There is no anonymous interceptor to lose track of.
+3. **Both slots must return the context.** ("Slot" is just a handy name for one of the two functions — the `:before` or the `:after`.) A slot that returns `nil` reads as "unchanged". That works by accident in a log-only slot — right up until you also `assoc` something and the accident becomes a heisenbug. Always end with `ctx`.
 
 ??? info "Coming from Express / Koa middleware?"
 
@@ -64,9 +70,7 @@ That bare keyword `:my-app/logger` *names* the registered interceptor; the runti
 
 This register-once-reference-everywhere split is the whole shape, and it has a quiet payoff: the chain is **plain data** — a vector of keywords you can serialize, diff, and carry in an [image](../glossary.md#image) (the portable registration set a later page covers). And because the chain stores a *reference*, re-registering `:my-app/logger` with new behaviour takes effect on the very next dispatch; you don't re-register the event just because an interceptor's implementation changed.
 
-!!! warning "Gotcha — an inline interceptor map in a chain is rejected"
-
-    Drop an interceptor *map* straight into a public chain — `{:interceptors [{:before ...}]}` — and the runtime refuses it (`:rf.error/inline-interceptor-removed`). A chain holds references only. The fix is always the same: register the behaviour under a name, and reference that name.
+Tempted to skip the registration step and drop an interceptor *map* straight into a public chain — `{:interceptors [{:before ...}]}`? The runtime refuses it (`:rf.error/inline-interceptor-removed`). A chain holds references only. The fix is always the same: register the behaviour under a name, and reference that name.
 
 ## The context map: two keys
 
@@ -92,6 +96,8 @@ This is the same `:coeffects` / `:effects` pair you met in [effects](effects.md)
 - a **`:before`** sees only `:coeffects` — the outputs don't exist yet;
 - an **`:after`** sees both `:coeffects` *and* `:effects`.
 
+I'll pause while you read those two lines again. That's the key concept, right there: the way in is about the handler's inputs, the way out is about its outputs, and everything an interceptor will ever do for you happens on one of those two trips.
+
 That's why our logger's `:before` could read `:event` but our undo example (later) needs `:after` to compare the before-`:db` against the after-`:db`.
 
 ??? note "Going deeper"
@@ -100,7 +106,13 @@ That's why our logger's `:before` could read `:event` but our undo example (late
 
 ## The sandwich: how a chain runs
 
-A single interceptor is a `:before`/`:after` pair wrapped around the handler. Stack three of them — `A`, `B`, `C` — around a handler `H` and the runtime makes two sweeps over one shared context:
+A single interceptor is a `:before`/`:after` pair wrapped around the handler. So what happens when you stack several?
+
+They wrap.
+
+Each one wraps *everything inside it*. Picture your event handler as a piece of ham. One interceptor is the bread on either side — its `:before` on the way in, its `:after` on the way out — and now you have a sandwich. A second interceptor doesn't line up *beside* the first; it goes *around* it, another pair of slices outside the existing sandwich. A sandwich of the sandwich. Three interceptors, and it is a very thick sandwich.
+
+Stack three of them — `A`, `B`, `C` — around a handler `H` and the runtime makes two sweeps over one shared context:
 
 ```text
 declared:  [A B C]  + handler H
@@ -122,13 +134,11 @@ If you'd rather see that as code, here it is — the whole execution is one thre
 
 (Morally, anyway — the runtime resolves the references and guards each call, but this is the shape. There's no machinery hiding under the machinery.)
 
-Two details carry weight. First, **the handler runs as the last `:before`.** The runtime wraps it as an interceptor too, so there's exactly one kind of thing to execute, all the way down. Second, **the trip out mirrors the trip in.** Whatever `B:before` set up, `B:after` tears down — and teardown happens *after* everything that ran inside the setup. Think of a sandwich: the outer slice goes on first and comes off last. Every cleanup interceptor you write leans on this symmetry.
+Two details carry weight. First, **the handler runs as the last `:before`.** The runtime wraps it as an interceptor too — even the ham gets wrapped — so there's exactly one kind of thing to execute, all the way down. Second, **the trip out mirrors the trip in.** Whatever `B:before` set up, `B:after` tears down — and teardown happens *after* everything that ran inside the setup, because the outer slice goes on first and comes off last. Every cleanup interceptor you write leans on this symmetry.
 
 The handler doesn't know it's wrapped, and an interceptor doesn't know what it wraps. That mutual ignorance is exactly why the pattern scales: any interceptor can decorate any handler, because they only ever talk through one shared value. They never reach into each other.
 
-!!! note "One discipline"
-
-    Never depend on chain position. An interceptor that only works when another one happens to wrap it has encoded an ordering as a hidden precondition — a trap for whoever reorders the chain next.
+One discipline, said plainly: never depend on chain position. An interceptor that only works when another one happens to wrap it has encoded an ordering as a hidden precondition — a trap for whoever reorders the chain next.
 
 ??? info "From re-frame v1 — the chain no longer rewrites itself"
 
@@ -221,7 +231,7 @@ Per-handler attachment, as above, fires for that event only — the right scope 
   {:interceptors [:my-app/logger]})   ;; a reference; wraps EVERY event handled in this frame
 ```
 
-Per-frame interceptors are **prepended** to each event's own chain. Frame-wide concerns sit outermost, event-specific ones inside them, the handler in the middle, and the same forward-then-reverse sweep runs across all of it. This is the answer to the three hundred handlers from the top of the page: the boring chores become two or three frame interceptors, registered once, referenced by id, touching no handler code.
+Per-frame interceptors are **prepended** to each event's own chain — the frame's slices go on the outside of every sandwich it serves. Frame-wide concerns sit outermost, event-specific ones inside them, the handler in the middle, and the same forward-then-reverse sweep runs across all of it. This is the answer to the three hundred handlers from the top of the page: the boring chores become two or three frame interceptors, registered once, referenced by id, touching no handler code.
 
 ??? info "From re-frame v1 — `reg-global-interceptor` is gone"
 
@@ -248,11 +258,9 @@ When both a frame and a dispatch supply overrides, they **merge, and on any key 
 
 ## Contribute, don't perform
 
-Here's the rule from the top of the page, made precise. The chain is part of the *step function* — the pure fold that replay, time-travel, and deterministic tests re-run against recorded inputs. So this is where discipline pays off:
+Here's the rule from the top of the page, made precise. The chain is part of the *step function* — the pure fold that replay, time-travel, and deterministic tests re-run against recorded inputs. So this is where discipline pays off.
 
-!!! warning "Gotcha — work done in an interceptor body re-fires on replay"
-
-    Don't do real work directly in an interceptor body. It re-fires on every replay, and it escapes every seam: `:fx-overrides` (the effects-side sibling of the `:interceptor-overrides` you just met) redirects *registered effects*, not a stray `localStorage` write buried in an `:after`. The sanctioned pattern is **contribute, don't perform** — append [effect](../glossary.md#effect) rows and let the [effect handler](../glossary.md#effect-handler) execute them.
+Don't do real work directly in an interceptor body. Not because it won't run — it will — but because it re-fires on every replay, and it escapes every seam: `:fx-overrides` (the effects-side sibling of the `:interceptor-overrides` you just met) redirects *registered effects*, not a stray `localStorage` write buried in an `:after`. The sanctioned pattern is **contribute, don't perform** — append [effect](../glossary.md#effect) rows and let the [effect handler](../glossary.md#effect-handler) execute them.
 
 ```clojure
 ;; ❌ performs — re-fires on replay, invisible to :fx-overrides and the trace
@@ -393,11 +401,7 @@ Testing the *wiring* — that the reference actually wraps the handler — is on
 
 ## When a reference is wrong
 
-Because a chain is just data, the runtime can check it *eagerly* — and it does. The single most common mistake, a misspelled id, dies at the earliest possible moment:
-
-!!! warning "Gotcha — a misspelled id fails at registration, not at dispatch"
-
-    Register an event whose `:interceptors` names an id that nobody has registered, and `reg-event` (or `reg-frame`) throws `:rf.error/unregistered-interceptor` right there at the registration site — naming the missing id. You find out when you load the namespace, not when an unlucky user trips the chain.
+Because a chain is just data, the runtime can check it *eagerly* — and it does. The single most common mistake, a misspelled id, dies at the earliest possible moment: register an event whose `:interceptors` names an id that nobody has registered, and `reg-event` (or `reg-frame`) throws `:rf.error/unregistered-interceptor` right there at the registration site — naming the missing id. You find out when you load the namespace, not when an unlucky user trips the chain.
 
 A handful of sibling errors cover the other ways a reference can be malformed. They all [fail loud](../glossary.md#fail-loud-not-silent) — re-frame2 never silently drops a chain entry it can't make sense of:
 

--- a/docs/core/concepts/observability.md
+++ b/docs/core/concepts/observability.md
@@ -1,20 +1,22 @@
 # Observability: one wire, every tool
 
-You clicked a button and the app is now subtly wrong. You want to know one thing: what did that click actually *do*? Which handler ran, what changed in [app-db](../glossary.md#app-db), which subscriptions recomputed, which views re-rendered, what effects escaped. In most frontends that question has no clean answer, because causality is smeared across a hundred components, each mutating its own little corner of state. You end up bisecting `console.log` statements like it's 2009.
+You clicked a button and the app is now subtly wrong.
 
-re-frame2 has a clean answer, and it falls out of the architecture rather than being bolted on. Every event traverses the same fixed [event pipeline](../glossary.md#event-pipeline) — the ordered run from a dispatched [event](../glossary.md#event) through its [event handler](../glossary.md#event-handler), the [commit](../glossary.md#commit), and the [effects](../glossary.md#effect) — so there's a single place to stand and watch the runtime go past. As it runs, the framework narrates: it emits a small data record at every moment worth noticing. That stream of records is the **trace stream**, and it's the whole foundation. The fancy panels you'll meet at the end — [Xray](../glossary.md#xray) (the dev inspector), Story (a view workbench), the pair MCP (a bridge that lets an AI inspect the running app) — are all just *readers* of it.
+You want to know one thing: what did that click actually *do*? Which handler ran, what changed in [app-db](../glossary.md#app-db), which subscriptions recomputed, which views re-rendered, what effects escaped. In most frontends that question has no clean answer, because causality is smeared across a hundred components, each mutating its own little corner of state. So you end up bisecting `console.log` statements like it's 2009.
+
+re-frame2 has a clean answer, and it isn't bolted on — it falls out of the architecture. Every event traverses the same fixed [event pipeline](../glossary.md#event-pipeline) — the ordered run from a dispatched [event](../glossary.md#event) through its [event handler](../glossary.md#event-handler), the [commit](../glossary.md#commit), and the [effects](../glossary.md#effect) — so there is a single place to stand and watch the runtime go past. And as it runs, the framework narrates: it emits a small data record at every moment worth noticing. That stream of records is the **trace stream** — the **wire**, from here on — and it's the whole foundation. The fancy panels you'll meet at the end — [Xray](../glossary.md#xray) (the dev inspector), Story (a view workbench), the pair MCP (a bridge that lets an AI inspect the running app) — are not the observability system. They are *readers* of it.
 
 This page builds up from the smallest piece. First the shape of a single trace event. Then the buffer that remembers recent ones. Then a listener you can write in eight lines. Then what survives into production. Then the tools sitting on top.
 
-If you take one idea away, take this one:
+If you take one idea away, take this one: **every tool is a thin presentation over the same runtime facts.** Xray, Story, the pair MCP, machines-viz, and any listener you write all read one trace stream and one [epoch](../glossary.md#epoch) history. If two of them ever disagree about a run, one of them is broken — there is no second truth.
 
-!!! note "Every tool is a thin presentation over the same runtime facts"
-
-    Xray, Story, the pair MCP, machines-viz, and any listener you write all read one trace stream and one [epoch](../glossary.md#epoch) history. If two of them ever disagree about a run, one of them is broken — there is no second truth.
+Read that last sentence again; it's the load-bearing one. The rest of this page is just me showing you the machinery that makes it true.
 
 ## One wire: the trace stream
 
-A [trace event](../glossary.md#trace-event) is just a map. The runtime emits one every time something worth noticing happens: an event dispatched, a handler run, app-db changed, a subscription recomputed, a view rendered, an effect fired, a [machine](../../machines/glossary.md#machine) transitioned, an error caught. Here's the shape:
+A [trace event](../glossary.md#trace-event) is just a map.
+
+The runtime emits one every time something worth noticing happens: an event dispatched, a handler run, app-db changed, a subscription recomputed, a view rendered, an effect fired, a [machine](../../machines/glossary.md#machine) transitioned, an error caught. Here's the shape:
 
 ```clojure
 {:id        18342                       ;; auto-incrementing, unique per process
@@ -27,7 +29,7 @@ A [trace event](../glossary.md#trace-event) is just a map. The runtime emits one
              ,,,}}                      ;; the open bag of specifics
 ```
 
-You never construct these — the runtime emits them, and your job (more often a tool's job) is just to read them. Two fields carry the routing, and it helps to know which is which.
+You never construct these. The runtime emits them; your job (more often a tool's job) is to read them. Two fields carry the routing, and it helps to know which is which.
 
 `:op-type` is the coarse one: a small closed vocabulary you branch on to grab a slice of the stream. The families you'll meet most:
 
@@ -46,7 +48,7 @@ You never construct these — the runtime emits them, and your job (more often a
 
 `:operation` is the fine-grained identity within that slice — the specific emit site, like `:rf.event/dispatched`, `:rf.sub/skip`, or `:rf.machine/transition`. Everything else rides in `:tags`, an open map.
 
-Both of these are designed to grow without breaking anyone. New `:op-type` values get added over time, so a tool simply ignores what it doesn't recognise; new tag keys can arrive later without disturbing a tool that only reads the old ones.
+Both fields are designed to grow without breaking anyone. New `:op-type` values get added over time, so a tool simply ignores what it doesn't recognise; new tag keys can arrive later without disturbing a tool that only reads the old ones.
 
 ??? info "Coming from OpenTelemetry?"
 
@@ -54,17 +56,19 @@ Both of these are designed to grow without breaking anyone. New `:op-type` value
 
 ### Two properties that shape everything downstream
 
-**Delivery is synchronous.** When the runtime emits, every registered listener runs *right then*, mid-run, on the same call stack — no queue, no batching, no reordering. That gives you perfect fidelity, which comes with an obligation: a listener has to be cheap. Grab the event, stash it, and return; defer anything expensive to a timer you own, so you never stretch out the run you're watching.
+**Delivery is synchronous.** When the runtime emits, every registered listener runs *right then*, mid-run, on the same call stack — no queue, no batching, no reordering.
+
+"Hang on," you say. "I see a problem. Synchronous listeners, on the hot path?" What you see is a trade, and it's a deliberate one: perfect fidelity is the gift, and cheapness is the price. A listener has to be cheap. Grab the event, stash it, and return; defer anything expensive to a timer you own, so you never stretch out the run you're watching.
 
 **Runs are correlated, not inferred.** Every trace event emitted inside one event's run carries the same `:rf.trace/dispatch-id` in its tags. So "everything that click did" is a filter, not a guess. When a handler's effects dispatch a child event, the child run's opening `:rf.event/dispatched` carries `:rf.trace/parent-dispatch-id` pointing back at its cause. Walk those links and you have the causal tree: *this* dispatch happened because *that* one did. One dispatch = one run = one [epoch](../glossary.md#epoch) — three names for the same unit of work, seen from three vantage points. (*Epoch* is just the name for the before-and-after state record one run leaves behind; we get to it [below](#the-epoch-history-what-the-app-was).)
 
-!!! note "You can put your own events on the wire"
-
-    If a tool you're writing wants its own milestones in the same stream the framework emits to, call `(rf/emit-trace-event! op-type operation tags)`. The runtime stamps `:id` and `:time`, routes it into the in-flight frame's history, and fans it out to every listener — exactly like a framework emit. Stay in your own namespace for `:op-type` and the tag keys — the `:rf.*` namespaces are framework-owned. Like every other trace emit, the call is elided in production.
+And the wire isn't framework-only. If a tool you're writing wants its own milestones in the same stream the framework emits to, call `(rf/emit-trace-event! op-type operation tags)`. The runtime stamps `:id` and `:time`, routes it into the in-flight frame's history, and fans it out to every listener — exactly like a framework emit. Stay in your own namespace for `:op-type` and the tag keys — the `:rf.*` namespaces are framework-owned. Like every other trace emit, the call is elided in production.
 
 ## The buffer: the last fifty things your app did
 
-Synchronous delivery has a catch. If you weren't listening when an event fired, you missed it — which is fatal for any tool that attaches *after* the interesting thing happened: the devtools panel you opened three clicks too late, or the AI you summoned precisely because the app is already broken.
+Synchronous delivery has a catch. If you weren't listening when an event fired, you missed it. Forever.
+
+That's fatal for any tool that attaches *after* the interesting thing happened: the devtools panel you opened three clicks too late, or the AI you summoned precisely because the app is already broken.
 
 So each [frame](../glossary.md#frame) also keeps a ring buffer of recent history beside its own [app-db](../glossary.md#app-db). The read surface is tool-facing, so it lives in its own namespace — `[re-frame.trace.tooling :as tooling]` — rather than on the app facade (on the JVM, `rf/trace-buffer` exists as a test-convenience alias). One read gets you the recent past:
 
@@ -93,9 +97,7 @@ That sets the process default. A frame that wants its own retention sets `:rf.tr
 
     This ring is the action log you scroll back through after something looks wrong — except it isn't a browser-extension bolt-on snooping on dispatches. It's a buffer the framework keeps natively, per isolated frame, and (the next section) it diffs state and time-travels too.
 
-!!! note "Why event bundles, not raw events?"
-
-    The default `trace-buffer` return is already grouped into per-event maps — the raw trace events folded into `:handler` / `:fx` / `:subs` / `:renders` slots — because that's the shape a tool actually wants to render. If you need the pre-grouped raw stream (you're re-folding it yourself, or chasing one specific emit), pass `{:flat true}` and you'll get plain trace events back instead. The storage is genuinely event-keyed either way; `:flat` just flattens the slots on the way out.
+Why hand back bundles instead of raw events? Because a per-event map — the raw trace events already folded into `:handler` / `:fx` / `:subs` / `:renders` slots — is the shape a tool actually wants to render. If you need the pre-grouped raw stream (you're re-folding it yourself, or chasing one specific emit), pass `{:flat true}` and you'll get plain trace events back instead. The storage is genuinely event-keyed either way; `:flat` just flattens the slots on the way out.
 
 ### Reading a slice, not the whole ring
 
@@ -118,9 +120,7 @@ That sets the process default. A frame that wants its own retention sets `:rf.tr
 
 The full vocabulary is small: `:event-id`, `:origin`, `:dispatch-id`, `:between [t0 t1]`, `:since-ms`, `:pred`, and the `:flat`-only `:operation` / `:op-type` / `:severity` / `:since` / `:source` / `:handler-id` / `:sensitive?` keys. The event-level keys (`:event-id`, `:origin`, `:dispatch-id`, `:between`, `:since-ms`, `:pred`) work on bundle reads; the per-trace-event keys require `:flat true`.
 
-!!! note "The corner cases are forgiving by design"
-
-    Reading a frame that doesn't exist — or was already destroyed — returns `[]`, not an error, mirroring how `(rf/app-db-value <unknown>)` returns `nil`. And `{:events-retained 0}` turns the ring *off* without turning the surface off: `trace-buffer` returns `[]`, but live listeners keep firing. That's the right setting when you only ever consume the live stream and don't want to pay for retention.
+The corner cases are forgiving by design. Reading a frame that doesn't exist — or was already destroyed — returns `[]`, not an error, mirroring how `(rf/app-db-value <unknown>)` returns `nil`. And `{:events-retained 0}` turns the ring *off* without turning the surface off: `trace-buffer` returns `[]`, but live listeners keep firing. That's the right setting when you only ever consume the live stream and don't want to pay for retention.
 
 ### The epoch history: what the app *was*
 
@@ -132,7 +132,9 @@ Next to the trace ring (what the app *did*) sits the **epoch history** (what the
                                 :redact-fn        my-fn}});; runs at off-box egress, never at storage
 ```
 
-`:depth` is the obvious one — how far back time-travel reaches. `:trace-events-keep` caps how many of the most-recent records keep their raw trace events alongside the cheap structured projections; older records drop the raw events to bound memory. It defaults to the `:depth` value (so trace detail and epoch evict together); set it smaller — `5`, say — to bound a long dev session's heap more aggressively. `:redact-fn` is the advanced safety valve, and where it runs matters: it is **projection-side, not storage-side**. The ring always stores the *raw* record, because an epoch record is causal replay material and mutating it at rest would corrupt `restore-epoch!`. The fn runs once per record at the **off-box egress boundary** — after the frame's normal `:sensitive` / `:large` classification has already projected the record — as a last scrub for something the declaration-driven projection can't prove (a sensitive slot no schema or classification covers). It is the rare escape hatch; ordinary redaction wants the [data classification](../glossary.md#data-classification) model, not this. A throwing `redact-fn` falls back to the already-projected record rather than leaking.
+`:depth` is the obvious one — how far back time-travel reaches. `:trace-events-keep` caps how many of the most-recent records keep their raw trace events alongside the cheap structured projections; older records drop the raw events to bound memory. It defaults to the `:depth` value (so trace detail and epoch evict together); set it smaller — `5`, say — to bound a long dev session's heap more aggressively.
+
+`:redact-fn` is the advanced safety valve, and where it runs matters: it is **projection-side, not storage-side**. The ring always stores the *raw* record, because an epoch record is causal replay material and mutating it at rest would corrupt `restore-epoch!`. The fn runs once per record at the **off-box egress boundary** — after the frame's normal `:sensitive` / `:large` classification has already projected the record — as a last scrub for something the declaration-driven projection can't prove (a sensitive slot no schema or classification covers). It is the rare escape hatch; ordinary redaction wants the [data classification](../glossary.md#data-classification) model, not this. A throwing `redact-fn` falls back to the already-projected record rather than leaking.
 
 Because each record holds real before-and-after state, [time travel](../glossary.md#time-travel) falls out for free: `(rf/restore-epoch! frame-id epoch-id)` rewinds a frame to exactly the state it held then — both partitions, [app-db](../glossary.md#app-db) and [runtime-db](../glossary.md#runtime-db) (machine snapshots, the route slice), in one atomic write. This isn't a special debug build; it's the direct consequence of state being one immutable value per frame.
 
@@ -140,9 +142,7 @@ Because each record holds real before-and-after state, [time travel](../glossary
 
     This is the state-diff-and-time-travel feature — but it's not a wrapper that re-runs reducers from a recorded action log. Each epoch record *holds the actual immutable db value*, before and after, so a rewind is one assignment, not a replay. That's the payoff of [app-db](app-db.md) being a single immutable value per frame.
 
-!!! note "Time travel only lands on clean states"
-
-    `restore-epoch!` refuses any epoch whose run didn't settle cleanly — a halted or rolled-back run has no coherent "after" to rewind to, so the runtime declines rather than restore a half-applied state. (Epoch records carry an `:outcome` field that says how the run ended; more on that below.)
+One refusal to know about, plainly: `restore-epoch!` declines any epoch whose run didn't settle cleanly — a halted or rolled-back run has no coherent "after" to rewind to, so the runtime refuses rather than restore a half-applied state. (Epoch records carry an `:outcome` field that says how the run ended; more on that below.)
 
 ## Your listener in eight lines
 
@@ -158,17 +158,15 @@ Everything the fancy panels do starts with this one API, and the nice part is th
                (-> trace-event :tags :reason)))))
 ```
 
-That's a working error logger. It receives *every* trace event and prints the errors; `(rf/unregister-listener! :trace :my-app/error-logger)` removes it again. The `:sensitive?` guard there isn't decoration — and it earns its own callout.
+That's a working error logger. It receives *every* trace event and prints the errors; `(rf/unregister-listener! :trace :my-app/error-logger)` removes it again.
 
-!!! warning "Gotcha — gate before anything leaves the box"
+That `:sensitive?` guard isn't decoration, so hear this now, plainly: a listener sees sensitive payloads in the clear — the runtime does not redact what it hands you. The moment your listener forwards data off-box (a network call, a third-party logger, even a console that gets captured into a log), check `:sensitive?` and drop or scrub the marked events. [Keep secrets out of traces](../how-to/keep-secrets-out-of-traces.md) is the full story.
 
-    A listener sees sensitive payloads in the clear — the runtime does not redact what it hands you. The moment your listener forwards data off-box (a network call, a third-party logger, even a console that gets captured into a log), check `:sensitive?` and drop or scrub the marked events. [Keep secrets out of traces](../how-to/keep-secrets-out-of-traces.md) is the full story.
+Notes — three contract details that start to matter once tools stack up:
 
-Three contract details start to matter once tools stack up:
-
-- **Same key replaces, atomically.** Re-registering under an existing key on the same stream swaps the callback between two emits, never mid-emit — which is exactly what hot reload needs.
-- **Exceptions are isolated.** A throwing listener is caught; the app and the other listeners keep going. So you can attach a flaky experimental tool to a live app and the worst it can do is fail quietly.
-- **Sibling order is unspecified.** Every listener sees every event, but never assume yours runs before another one.
+1. **Same key replaces, atomically.** Re-registering under an existing key on the same stream swaps the callback between two emits, never mid-emit — which is exactly what hot reload needs.
+2. **Exceptions are isolated.** A throwing listener is caught; the app and the other listeners keep going. So you can attach a flaky experimental tool to a live app and the worst it can do is fail quietly.
+3. **Sibling order is unspecified.** Every listener sees every event, but never assume yours runs before another one.
 
 There's also a test-time helper, `(rf/clear-listeners! :trace)`, which drops *every* listener on a stream atomically — the framework's own test fixtures use it to hand each test a clean registry. Ordinary application code unregisters its own listeners by key; reach for `clear-listeners!` only from test setup.
 
@@ -198,23 +196,19 @@ The same verb drives three more streams, distinguished by that leading keyword. 
 
 One subtlety the run-shaped view buys you: the `:epoch` callback fires once per *dequeued event*, not once per drain. If a handler's `:fx` dispatched a child event, the parent and the child are two separate epochs, and your callback fires twice — once each. The exception is work a [state machine](../../machines/concepts.md) does to itself: when a transition fires its own follow-up steps (an internal event it raises, or an automatic transition it takes immediately), those ride *inside* the triggering event's epoch rather than firing the callback again. So one user event stays one epoch, however much internal machinery it kicked off.
 
-!!! note "Halted runs show up here too"
+Halted runs show up here too. The `:epoch` stream is the devtools surface for *failed* runs, not just clean ones — the callback fires for halted drains as well, and each record's `:outcome` field tells you how it ended: `:ok` for a clean settle, `:halted-depth` if the run hit the re-entrancy depth guard, `:halted-destroy` if the frame was torn down mid-run. A partial record still carries whatever the runtime captured up to the halt, plus a `:halt-reason` descriptor. Consumers that only care about successful drains filter on `(= :ok (:outcome record))` at the top of the callback — and remember `restore-epoch!` refuses anything that isn't `:ok`.
 
-    The `:epoch` stream is the devtools surface for *failed* runs, not just clean ones — so the callback fires for halted drains as well, and each record's `:outcome` field tells you how it ended: `:ok` for a clean settle, `:halted-depth` if the run hit the re-entrancy depth guard, `:halted-destroy` if the frame was torn down mid-run. A partial record still carries whatever the runtime captured up to the halt, plus a `:halt-reason` descriptor. Consumers that only care about successful drains filter on `(= :ok (:outcome record))` at the top of the callback — and remember `restore-epoch!` refuses anything that isn't `:ok`.
-
-!!! note "Tool-Pair alias"
-
-    If you've read the Tool-Pair spec or the pair MCP code you'll also see `register-epoch-listener!` / `unregister-epoch-listener!`. Those are just named aliases for the `:epoch` stream of `register-listener!` — same machinery, same semantics. Use whichever reads better at the call site; the stream-keyword form keeps the four observation feeds under one verb.
+(If you've read the Tool-Pair spec or the pair MCP code you'll also have met `register-epoch-listener!` / `unregister-epoch-listener!`. Those are just named aliases for the `:epoch` stream of `register-listener!` — same machinery, same semantics. Use whichever reads better at the call site; the stream-keyword form keeps the four observation feeds under one verb.)
 
 The remaining two streams — `:events` and `:errors` — are different in kind: they're the **always-on** integration hooks that survive into production. That's the whole story of what ships and what doesn't, so it gets its own section.
 
 ## Production: the wire disappears — errors don't
 
-Everything above is development machinery, and none of it ships — the whole dev wire is [**elided**](../glossary.md#elide) from production builds. The entire dev trace surface — the `:trace` and `:epoch` streams, the rings, the epoch history, the listener registries behind them — sits behind one compile-time flag (`goog.DEBUG`, a constant the ClojureScript toolchain sets to `false` for production). In an `:advanced` production build, the Closure compiler — the optimising compiler ClojureScript ships through — sees the flag is constantly `false`, so dead-code elimination (DCE) removes every branch guarded by it. The emit calls don't just become no-ops; they're elided entirely, so production bundles carry zero trace code and zero trace cost.
+Everything above is development machinery, and none of it ships. The whole dev wire is [**elided**](../glossary.md#elide) from production builds — the `:trace` and `:epoch` streams, the rings, the epoch history, the listener registries behind them — all of it sitting behind one compile-time flag (`goog.DEBUG`, a constant the ClojureScript toolchain sets to `false` for production).
 
-!!! warning "Gotcha — JVM builds default the gate on"
+In an `:advanced` production build, the Closure compiler — the optimising compiler ClojureScript ships through — sees the flag is constantly `false`, so dead-code elimination (DCE) removes every branch guarded by it. The emit calls don't just become no-ops; they're elided entirely, so production bundles carry zero trace code and zero trace cost.
 
-    There's no Closure compiler on the JVM, so the same gate defaults *on* there — which is right for tests and the REPL, but means a production JVM process, an SSR host especially, must set `-Dre-frame.debug=false` explicitly. The flag also reads the `RE_FRAME_DEBUG` environment variable, and accepts the usual false-y vocabulary (`false`, `0`, `no`, `off`, empty) case-insensitively. See [configure dev and production builds](../how-to/configure-dev-and-prod.md).
+One deployment gotcha before we go on: there's no Closure compiler on the JVM, so the same gate defaults *on* there — which is right for tests and the REPL, but means a production JVM process, an SSR host especially, must set `-Dre-frame.debug=false` explicitly. The flag also reads the `RE_FRAME_DEBUG` environment variable, and accepts the usual false-y vocabulary (`false`, `0`, `no`, `off`, empty) case-insensitively. See [configure dev and production builds](../how-to/configure-dev-and-prod.md).
 
 What survives is deliberately narrow: an **always-on error substrate**, kept separate from the dev trace wire. It fires one tight structured [error record](../glossary.md#error-record) per production-reachable runtime failure — the error's id, the event and frame context, but never raw values. This is how a handler exception in production reaches Sentry or Datadog *knowing what the user was doing*, instead of arriving as a bare `window.onerror`. (A sibling substrate emits one record per processed event, for throughput-and-latency dashboards.)
 
@@ -272,17 +266,17 @@ The wiring recipe is [report errors in production](../how-to/report-errors-in-pr
 
     The mental split is: the dev trace wire is rich and elided, while the production error substrate is narrow and always-on. Don't reach for `register-listener!`'s `:trace` stream to feed a hosted monitor — it works in dev and hears *nothing* in production, because the emit sites it would listen to no longer exist. **For production telemetry, you want a sink, not a trace listener.** The sink is also the one that redacts for you, which a raw stream listener never does.
 
-!!! note "Sink for production, listener for an advanced cross-frame hook"
+Which route, then — sink or raw `:errors` stream? The frame-owned `:observability :errors` sink is the normal production error route, and it's the safe one — projected per-frame before you see it. The raw `:errors` stream of `register-listener!` is the advanced corpus-wide alternative: one fan-out across *every* frame, delivering an *unprojected* record (the `:event` is elided but the `:exception` rides raw and no frame egress policy applies). Reach for it only when you genuinely need a single cross-frame hook or a record the sink route can't carry — and accept that you're then responsible for the trust boundary yourself.
 
-    The frame-owned `:observability :errors` sink is the normal production error route, and it's the safe one — projected per-frame before you see it. The raw `:errors` stream of `register-listener!` is the advanced corpus-wide alternative: one fan-out across *every* frame, delivering an *unprojected* record (the `:event` is elided but the `:exception` rides raw and no frame egress policy applies). Reach for it only when you genuinely need a single cross-frame hook or a record the sink route can't carry — and accept that you're then responsible for the trust boundary yourself.
-
-!!! note "Want timing in production, too?"
-
-    There's a third production-survivable surface besides `:events` and `:errors`: a Performance API channel, off by default, that brackets the four hot paths (event dispatch, sub recompute, fx walk, render) in `performance.mark` / `performance.measure` calls. Flip it on at build time with `:closure-defines {re-frame.performance/enabled? true}` and any `PerformanceObserver` — including your APM's — reads the User-Timing entries. It's a compile-time flag distinct from `goog.DEBUG`, so you can ship timing without shipping the whole dev wire. [Find and fix a slow view](../how-to/fix-a-slow-view.md) shows the entries in use.
+Want timing in production, too? There's a third production-survivable surface besides `:events` and `:errors`: a Performance API channel, off by default, that brackets the four hot paths (event dispatch, sub recompute, fx walk, render) in `performance.mark` / `performance.measure` calls. Flip it on at build time with `:closure-defines {re-frame.performance/enabled? true}` and any `PerformanceObserver` — including your APM's — reads the User-Timing entries. It's a compile-time flag distinct from `goog.DEBUG`, so you can ship timing without shipping the whole dev wire. [Find and fix a slow view](../how-to/fix-a-slow-view.md) shows the entries in use.
 
 ## The tools: four presentations, zero second truths
 
-Now the payoff. The point isn't that re-frame2 has tools — every framework has tools, and most ecosystems have three that disagree with each other. The point is that these are thin presentations over the wire you just met. None has a private back-channel; none patches the framework or instruments your handlers. They bootstrap from the buffer, listen to the stream, and read the epoch history — and because they read the same facts, they tell consistent stories.
+Now the payoff.
+
+The point isn't that re-frame2 has tools — every framework has tools. Most ecosystems have three, and they disagree with each other: the state tool keeps its own action log, the profiler keeps its own timeline, the error reporter keeps its own breadcrumbs, and when something breaks you sit there cross-examining three witnesses who never met, each with its own clock, each telling a slightly different story about the same afternoon. Too grim? Okay, fine. But notice exactly what makes it grim: more than one source of truth.
+
+These tools are different in kind, not just in polish: they are thin presentations over the wire you just met. None has a private back-channel; none patches the framework or instruments your handlers. They bootstrap from the buffer, listen to the stream, and read the epoch history — and because they read the same facts, they tell consistent stories.
 
 ```mermaid
 flowchart LR

--- a/docs/core/concepts/run-to-completion.md
+++ b/docs/core/concepts/run-to-completion.md
@@ -1,10 +1,14 @@
 # Run to completion
 
-Every dispatch you've made so far queued an event and walked away, and the pipeline caught up moments later. The scheduling rule that governs that catch-up is the one guarantee about *when* things run that the whole rendering story leans on.
+Every dispatch you've made so far queued an event and walked away, and the pipeline caught up moments later. "Moments later" has been doing quiet work all along: hiding inside it is the one guarantee about *when* things run, and the whole rendering story leans on it. This page pins it down.
 
-Most frameworks let renders interleave with event processing, which is why this rule deserves a hard stop. When the runtime starts processing events, it [**drains the queue to completion**](../glossary.md#drain--run-to-completion) before any view re-renders. The dequeued event runs its full write side. Then any events its handler `:fx`-dispatched run theirs. And so on until the queue is empty. Only then does the read side run — once — and the render boundary arrives: the single point in the cycle where the settled state reaches the screen. So the write side runs *per event*; the read side runs *once per drain*, at settle. This is the dispatch semantics, not a mode; there is no opt-out.
+Most frameworks let renders interleave with event processing, which is why this rule deserves a hard stop. When the runtime starts processing events, it [**drains the queue to completion**](../glossary.md#drain--run-to-completion) before any view re-renders. The dequeued event runs its full write side. Then any events its handler `:fx`-dispatched run theirs. Boom, boom, boom, until the queue is empty. Only then does the read side run — once — and the render boundary arrives: the single point in the cycle where the settled state reaches the screen.
 
-What it buys is coherence. If submitting a form dispatches three follow-up events, the view does not glimpse the state after each one. It sees one settled state, once. Either the form is submitting or it's failed, never both in one paint. The flicker-of-intermediate-state bug is structurally absent.
+So the write side runs *per event*; the read side runs *once per drain*, at settle. Read that again — the rest of this page is that sentence, illustrated. And it is the dispatch semantics, not a mode; there is no opt-out.
+
+Here's the picture to keep: the render boundary is a **theatre curtain**. Every event in a drain is a stagehand shifting scenery behind it, and the curtain does not go up until the last stagehand steps off. What that buys is coherence. If submitting a form dispatches three follow-up events, the view does not glimpse the state after each one. It sees one settled state, once. Either the form is submitting or it's failed, never both in one paint.
+
+No half-updated spinner. No screenshot in the support inbox of a state that cannot exist. No ticket closed "cannot reproduce" because the guilty render lived for one animation frame last Tuesday. Too much? Fine, the sober version: the flicker-of-intermediate-state bug is structurally absent, because there is no moment in the cycle for it to happen in.
 
 Watch it happen. The counter's `:inc` already dispatched a follow-up on [Effects](effects.md), but a form submit is the fan-out you'll actually meet. One click below dispatches a single `:drain.demo/submit` whose handler fans out three follow-up events — four pipeline runs in one drain. Click into the cell and press **`Ctrl-Enter`** (**`Cmd-Enter`** on macOS) to evaluate, then click **submit**:
 
@@ -43,18 +47,18 @@ Watch it happen. The counter's `:inc` already dispatched a follow-up on [Effects
  [drain-demo]]
 ```
 
-All four steps appear **together**. The view never shows `[:submitted]` alone — by the time the render boundary arrives, the whole drain has settled.
+All four steps appear **together**. The view never shows `[:submitted]` alone — by the time the curtain rises, the whole drain has settled.
 
 !!! tip "Try it"
 
     Make `:drain.demo/validate` fan out its *own* follow-up — add `:fx [[:dispatch [:drain.demo/notify]]]` to its handler — re-evaluate, then click **submit** again. Five more steps settle in one drain, still one paint. (The earlier four stay — the cell's frame, and its app-db, survive a re-eval.) However deep the chain goes, the screen only ever sees the end of it.
 
-Two precise details, both visible in Xray:
+Notes, both visible in Xray:
 
-- **Each dequeued event is its own [epoch](../glossary.md#epoch).** A parent event and the child it `:fx`-dispatched are *two* rows in the record, each with its own handler run and its own before/after state — even though they settled inside one drain and produced one paint. The record stays per-event; the rendering stays per-drain.
-- **Async effects are not drained.** An HTTP request fired during the drain doesn't hold anything open; its reply arrives later as a fresh event and starts a fresh drain. "Run to completion" bounds the synchronous run, not the outside world.
+1. **Each dequeued event is its own [epoch](../glossary.md#epoch).** A parent event and the child it `:fx`-dispatched are *two* rows in the record, each with its own handler run and its own before/after state — even though they settled inside one drain and produced one paint. The record stays per-event; the rendering stays per-drain.
+2. **Async effects are not drained.** An HTTP request fired during the drain doesn't hold anything open; its reply arrives later as a fresh event and starts a fresh drain. "Run to completion" bounds the synchronous run, not the outside world.
 
-Strictly, the drain is per [**frame**](../glossary.md#frame) — a running [world](../glossary.md#world) with its own app-db and its own queue — and an app can run several ([Frames](frames.md)). But with one frame, which is every app until it isn't, "per frame" and "per app" say the same thing.
+Now, a confession — I haven't been entirely straight with you. I've been saying *the* queue all page, as if there's exactly one. Strictly, the drain is per [**frame**](../glossary.md#frame) — a running [world](../glossary.md#world) with its own app-db and its own queue — and an app can run several ([Frames](frames.md)). But with one frame, which is every app until it isn't, "per frame" and "per app" say the same thing.
 
 ??? info "For JavaScript developers"
 
@@ -66,7 +70,7 @@ Strictly, the drain is per [**frame**](../glossary.md#frame) — a running [worl
 
 ### When the drain won't stop
 
-Run-to-completion is unconditional, which raises an obvious question: what if a handler dispatches an event whose handler dispatches the first one again? An infinite drain would spin forever. The runtime won't let it. Each frame carries a **`:drain-depth`** — the maximum number of events one drain may process (default `100`). When a drain reaches it, the runtime stops with a loud, machine-readable [error record](../glossary.md#error-record):
+Run-to-completion is unconditional, which raises the question you're already asking: what if a handler dispatches an event whose handler dispatches the first one again? Stagehands queueing up stagehands, forever — a curtain that never rises. The runtime won't let it. Each frame carries a **`:drain-depth`** — the maximum number of events one drain may process (default `100`). When a drain reaches it, the runtime stops with a loud, machine-readable [error record](../glossary.md#error-record):
 
 ```clojure
 {:operation :rf.error/drain-depth-exceeded
@@ -84,7 +88,7 @@ The important part is what survives. Atomicity in re-frame2 is per [**event**](.
 
 ### Dispatching from outside the drain
 
-One more entry point completes the picture. Inside a handler, you never call `dispatch` directly — you return `:fx [[:dispatch ...]]` and let the runtime queue it. But *outside* any handler there's nothing to return effects to, so you call directly — every `:on-click` so far has called `dispatch`, fire-and-forget. When the caller also needs the drain settled before its next line — app startup, a test, the REPL — that's what [**`dispatch-sync`**](../glossary.md#dispatch-sync) is for:
+One more entry point completes the picture. Inside a handler, you never call `dispatch` directly — you return `:fx [[:dispatch ...]]` and let the runtime queue it. But *outside* any handler there's nothing to return effects to, so you call directly — every `:on-click` so far has done exactly that, fire-and-forget. Sometimes, though, the caller needs the drain settled before its next line runs. App startup. A test fixture. The REPL. That's what [**`dispatch-sync`**](../glossary.md#dispatch-sync) is for:
 
 ```clojure
 ;; App bootstrap, or a test fixture: run the drain to completion, synchronously.
@@ -94,12 +98,10 @@ One more entry point completes the picture. Inside a handler, you never call `di
 
 `dispatch-sync` runs the event through the same run-to-completion drain as `dispatch`, but it *blocks* until the drain settles, instead of scheduling the drain asynchronously (a later tick) and returning immediately.
 
-!!! warning "Gotcha — `dispatch-sync` is an *outside* call only"
-
-    Calling it from inside a handler raises `:rf.error/dispatch-sync-in-handler`. Under run-to-completion the drain is *already* running synchronously, so "sync" would mean nothing there — the in-handler shape for a follow-up is always `:fx [[:dispatch event]]`.
+One gotcha, and the runtime enforces it: `dispatch-sync` is an *outside* call only. Call it from inside a handler and you'll be handed `:rf.error/dispatch-sync-in-handler` — under run-to-completion the drain is *already* running synchronously, so "sync" would mean nothing there. The in-handler shape for a follow-up is always `:fx [[:dispatch event]]`.
 
 !!! warning "Gotcha — a dispatch needs a frame in scope"
 
     Both `dispatch` and `dispatch-sync` resolve [which frame](../glossary.md#frame) to target from the scope they're called in — a [provider](../glossary.md#frame-provider), a running handler, or a [capture-frame](../glossary.md#capture-frame). The runtime never invents one. A call from a *rootless* async callback — a stray `setTimeout`, a WebSocket `onmessage`, a bare promise `.then` that escaped the view tree — has no frame in scope and raises `:rf.error/no-frame-context` (an error that survives into production builds). The fix is to grab a `capture-frame` while the frame *is* in scope and dispatch through it, or to pass `{:frame <id>}` explicitly in the dispatch opts. (This is the everyday face of [frame identity is carried, not found](../glossary.md#frame-identity-is-carried-not-found); [Frames](frames.md) is the full story.)
 
-The trade is the framework's signature move, made again here. Give up a little flexibility — interleaved renders, inline effects, ambient reads — and get back inspectability: a recorded, replayable, coherent history.
+The trade is the framework's signature move, made again here. Give up a little flexibility — interleaved renders, inline effects, ambient reads — and get back inspectability: a recorded, replayable, coherent history. Behind the curtain, any amount of work. In front of it, only finished scenes.

--- a/docs/core/concepts/subscriptions.md
+++ b/docs/core/concepts/subscriptions.md
@@ -1,12 +1,38 @@
-# Subscriptions: the derivation graph
+# Subscriptions
 
-**[App-db](../glossary.md#app-db) stores facts; subscriptions derive conclusions.** App-db is your app's single state map, and your [views](../glossary.md#view) never read it directly. Instead they ask, by name, for a conclusion — "the visible articles", "can this form submit?", "the current user's initials" — and a [subscription](../glossary.md#subscription) is that question answered: a named, cached derivation that turns state into the value a view wants. Those derivations form a graph rooted at app-db, with your views hanging off the leaves. The nice part is that re-frame2 recomputes only along the paths where values actually changed.
 
-This page builds that graph one concept at a time: a single named derivation first, then chaining derivations into a graph, then the one rule that makes it fast, then parametric inputs, metadata, testing, and lifecycle. By the end you'll read a subscription's registration and know exactly when it recomputes.
+A UI is just derived data.
 
-## The counter learns a trick
+[App-db](../glossary.md#app-db) holds your **facts**. Your
+[views](../glossary.md#view) want **conclusions** — "the visible articles", "can
+this form submit?", "the current user's initials". A
+[subscription](../glossary.md#subscription) is the thing in between: a named,
+cached derivation that turns facts into a conclusion, and re-runs only when it
+must.
 
-[Our first app](../first-app.md)'s counter shows its value; suppose we also want to show whether that value is odd or even. The tempting move is to store a parity flag in app-db and keep it updated alongside the value. Don't — odd-or-even isn't a *new* fact, it's a *consequence* of one you already have, and two copies of the same truth is two chances to disagree. Derive it instead, live:
+A re-frame2 app is about 75% derived data. I just made that number up, but you get
+the idea: there's quite a bit of it. And the deriving doesn't even stop at the
+views. Hiccup becomes DOM — more derived data. The browser turns DOM into pixels —
+more data. The monitor turns pixels into photons (data; don't fight me here, I'm
+on a roll), your retina turns photons into nerve signals (still data), and
+somewhere behind your eyes a brain derives a conclusion from the lot. Derived data
+all the way down, and you are the last node on the graph.
+
+Too much? Okay, fine. Just the part between app-db and your views, then. That part
+is this page.
+
+## Don't Store What You Can Derive
+
+Here's the discipline the whole page hangs off.
+
+[Our first app](../first-app.md)'s counter shows a number. Suppose we also want to
+show whether that number is odd or even. The tempting move: store a parity flag in
+app-db and keep it updated alongside the value.
+
+Don't.
+
+Odd-or-even isn't a new *fact*. It's a *consequence* of a fact you already have,
+and two copies of one truth is two chances to disagree. Derive it, live:
 
 ```cljs-rf2
 (require '[re-frame.core :as rf])
@@ -40,11 +66,16 @@ This page builds that graph one concept at a time: a single named derivation fir
  [parity-counter]]
 ```
 
-The `:<-` line is the one new idea: it declares `:value` as the *input*, so `:parity` reads the other subscription rather than reaching into app-db. You've built a two-node spreadsheet — `:value` is a cell, `:parity` is a formula over it — and because the framework knows that dependency, `:parity` recomputes only when its declared input changes, and anything watching it re-renders only when the *answer* changes. (With a step of one, parity flips on every click, so this tiny example never actually skips work. The payoff comes when many input values give one answer, and the equality gate below delivers it.) The rest of this page builds the machinery under that little `:<-`.
+You just built a two-cell spreadsheet. `:value` is a cell. `:parity` is a formula
+over it. That `:<-` line declares the dependency, and because the framework *knows*
+the dependency, `:parity` recomputes only when `:value` changes, and anything
+watching `:parity` re-renders only when the *answer* changes.
 
-## A subscription is a named derivation
+Hold onto the spreadsheet. It's the metaphor for the rest of the page.
 
-At bottom, a subscription is just a function from app-db to a value some view wants. That's the whole idea. You register it under a keyword id:
+## What Is a Subscription, Exactly?
+
+A function from app-db to a value some view wants, registered under a name:
 
 ```clojure
 (rf/reg-sub :cart/category-filter
@@ -52,14 +83,15 @@ At bottom, a subscription is just a function from app-db to a value some view wa
     (:cart/category-filter db)))
 ```
 
-A view reads the current value by deref-ing the subscription:
+A view reads it by deref:
 
 ```clojure
 @(rf/subscribe [:cart/category-filter])
 ```
 
-
-The vector `[:cart/category-filter]` is the [**query vector**](../glossary.md#query-vector): the id plus any arguments. `[:cart/line-item "sku-1"]` carries one argument. The whole vector arrives as the computation function's second argument — named `_query` above, where the leading underscore is the Clojure convention for "a parameter I'm deliberately ignoring." This sub takes no arguments, so it ignores the query vector entirely. When a sub does take an argument, it destructures it from that same vector:
+The vector `[:cart/category-filter]` is the [**query vector**](../glossary.md#query-vector) —
+the id, plus any arguments. `[:cart/line-item "sku-1"]` carries one argument, and
+the sub destructures it from the same vector it was called with:
 
 ```clojure
 (rf/reg-sub :cart/line-item
@@ -67,40 +99,70 @@ The vector `[:cart/category-filter]` is the [**query vector**](../glossary.md#qu
     (get-in db [:cart/items sku])))
 ```
 
-`@(rf/subscribe [:cart/line-item "sku-1"])` binds `sku` to `"sku-1"`.
+Now, that little `@`. It is doing two jobs, and the second one is the entire trick
+of reactive programming, so let's not rush past it. Job one: unwrap the reactive
+reference to a plain value. Job two: register the deref-ing view as a *dependent*,
+so the view re-renders when — and only when — that value changes.
 
-That little `@` is doing two jobs at once. It unwraps the reactive reference to a plain value, and it registers the deref-ing view as a dependent, so the view re-renders when — and only when — that value changes. The view declared a dependency and walked away. It never polls, and it never listens to a store-wide "something changed" firehose.
+The view declared a dependency and walked away. It never polls. It never listens
+to a store-wide "something changed" firehose. It said what it wanted, once, and
+the graph does the rest.
 
-!!! warning "Gotcha — a wrong sub-id fails loud, not silent"
+Subscribe to an id nobody registered — a typo, a namespace that hasn't loaded —
+and re-frame2 does not quietly hand you `nil` and let you guess. It emits
+`:rf.error/no-such-sub` (an always-on [error record](../glossary.md#error-record)
+that survives into production, carrying the offending `:rf.sub/id`) and then
+recovers the subscription to `nil` so the view still renders. Loud, then graceful.
+And the failed lookup leaves no cache entry behind, so registering the sub later —
+boot order, a lazy load — lets the next subscribe build cleanly.
 
-    Subscribe to an id that was never registered — a typo, a not-yet-loaded namespace — and re-frame2 doesn't quietly hand back `nil` and leave you guessing. It emits `:rf.error/no-such-sub` (an always-on [error record](../glossary.md#error-record) that survives production, carrying the offending `:rf.sub/id`) and recovers the subscription to `nil` so the view still renders. The same id appearing as a `:<-` input of another sub reports the same way. The failed lookup leaves no cache entry behind, so registering the sub later — boot order, a lazy load — lets the next subscribe build cleanly against the real body.
+## Why Bother Naming Something So Trivial?
 
-So why name a derivation this trivial instead of just writing `(:cart/category-filter db)` in the view? Two reasons, and they recur everywhere in this framework:
+Fair question. `(:cart/category-filter db)` in the view would be shorter. Two
+reasons, and they recur all through this framework:
 
-- **Decoupling.** Where the value lives in app-db is the subscription's secret. Move it tomorrow and you change one registration, not forty views.
-- **Sharing.** Every view asking for `[:cart/category-filter]` reads the *same* cached node. The subscription cache is keyed by query vector (per [frame](../glossary.md#frame) — for now, read that as "per app"), so a computation runs once per change no matter how many views consume it. Adding the forty-first reader costs nothing.
+1. **Decoupling.** Where the value lives in app-db is the subscription's secret.
+   Move it tomorrow and you change one registration, not forty views.
+2. **Sharing.** Every view asking for `[:cart/category-filter]` reads the *same*
+   cached node. The cache is keyed by query vector (per
+   [frame](../glossary.md#frame) — for now, read that as "per app"), so the
+   computation runs once per change no matter how many views consume it. The
+   forty-first reader costs nothing.
 
-Both reasons get stronger the moment derivations start feeding each other, which is the actual design.
+One rookie mistake will quietly defeat reason 2, so hear it now: **don't build a
+non-primitive argument inline on every render.** `[:article/by-id "BK-1"]` from a
+hundred views is one cache node, because keywords and strings are value-stable. But
+`@(subscribe [:report/rows {:cols cols}])` with `{:cols cols}` assembled right
+there in the render body mints a *fresh* cache entry every time that map isn't `=`
+to the last one — unbounded cache growth, zero hit-rate, and the sub still computes
+the right answer, so nothing *looks* wrong. The dev build catches it with a
+one-shot `:rf.warning/sub-arg-cache-fragmentation` per sub-id. The fix: hoist the
+argument to a value-stable reference — `let`-bound, subscribed, or memoised — so
+repeated subscribes share one slot.
 
-!!! warning "Gotcha — don't rebuild a non-primitive argument inline every render"
+Coming from Redux? A subscription is a selector — Reselect's `createSelector` with
+the memoisation built in. From Solid or Jotai? A derived signal. Three deliberate
+differences, all in your favour: subscriptions are *named* in a registry, so tools
+can draw the whole graph without running your app; change detection is deep value
+equality (`=`), never reference identity; and dependencies are declared as data,
+not discovered by watching a function run.
 
-    Sharing works because the cache keys on the query vector. An id plus keyword/string/number args is value-stable, so `[:article/by-id "BK-1"]` from a hundred views is one cache node. But pass a *fresh* map, set, or collection assembled in the render body — `@(subscribe [:report/rows {:cols cols}])`, with `{:cols cols}` built right there — and anything that doesn't stay `=` across renders (a reordered `cols`, an embedded fn, a value rebuilt from changing props) mints a new cache entry per distinct value instead of reusing one: unbounded growth, zero hit-rate, and the sub still computes the right value so nothing looks wrong. The dev build catches this with a one-shot `:rf.warning/sub-arg-cache-fragmentation` per sub-id. The fix is to hoist the argument to a value-stable reference — a `let`-bound, subscribed, or memoised value — so repeated subscribes share one slot.
+## Three Layers, One Graph
 
-??? info "Coming from Redux, Solid, or Jotai?"
+A subscription's input doesn't have to be app-db. It can be another subscription —
+you saw that with `:parity`. Once derivations feed derivations, you have a directed
+acyclic graph, and re-frame2 walks it for you.
 
-    A subscription is a selector — Reselect's `createSelector` with the memoisation built in. **Coming from Solid or Jotai?** It's a derived signal / derived atom. Three deliberate divergences from both: subscriptions are named by keyword in a registry, so tools can draw the whole graph without running your app; change detection is deep value equality (`=`), never reference identity, so there is no "don't allocate a new object or you'll bust the memo" dance; and dependencies are declared as data, not discovered by tracking a function run.
+The graph has layers, and a sub's layer is decided entirely by what it reads:
 
-## Three layers, one graph
+- **Layer 1 — extractors.** Read app-db directly. Their one job: pluck out a raw
+  slice. No computation. They re-run on every app-db change (to check whether
+  their slice moved — the next section explains why that's cheap).
+- **Layer 2 — derivations.** Read other subs, via `:<-`. Sort, filter, join,
+  shape. They re-run when an input's value changes by `=`.
+- **Layer 3 and up — compositions.** Subs over subs over subs. Same rule.
 
-A subscription's input doesn't have to be app-db. It can be **another subscription**. Once derivations feed derivations you have a directed acyclic graph, and re-frame2 walks it for you. That graph has layers, and a subscription's layer is decided entirely by what it reads:
-
-| Layer | What it reads | Its one job | Recomputes when |
-|---|---|---|---|
-| **Layer 1 — extractors** | app-db directly | Pluck out a raw slice. No computation. | Every app-db change (to re-check whether their slice moved — see [The equality gate](#the-equality-gate)). |
-| **Layer 2 — derivations** | Other subs, via `:<-` | Sort, filter, join, shape. | An input sub's value changes by `=`. |
-| **Layer 3+ — compositions** | Other subs, some of them layer 2 | Compose derivations of derivations. | An input sub's value changes by `=`. |
-
-Layer 1 reaches into the map. Everybody else reaches into layer 1, or into each other. Here is a three-layer chain from a shopping cart:
+Here's a three-layer chain from a shopping cart:
 
 ```clojure
 ;; Layer 1 — extractors: read app-db, pluck a slice, nothing else.
@@ -126,41 +188,81 @@ Layer 1 reaches into the map. Everybody else reaches into layer 1, or into each 
       items)))
 ```
 
-The `:<-` arrow reads as "this sub's input comes from". Notice what changed between layers. `:cart/by-price` does **not** take `db`. It takes the already-extracted value that `:cart/items` produced. One arrow delivers that input as a bare value; two or more deliver a vector, destructured above as `[items category]`. That's the only wrinkle in the syntax, and once you've seen it you've seen it.
+Read `:<-` as "this sub's input comes from". Notice what changed between layers:
+`:cart/by-price` does **not** take `db`. It takes the already-extracted value that
+`:cart/items` produced. One arrow delivers its input as a bare value; two or more
+deliver a vector, destructured above as `[items category]`. That's the only
+wrinkle in the syntax. Once you've seen it, you've seen it.
 
-Here's the part worth pausing on: the shape of the registration *is* the topology. `(fn [db _] ...)` makes an extractor by construction; `:<-` makes a composer by construction. The framework reads the registry and knows the whole graph as data. That is how [Xray](../glossary.md#xray) can draw your subscription topology without executing a single computation function — its static-graph projection, `re-frame.subs.tooling/sub-topology`, is a literal read of the registry.
+And notice something quieter: the *shape of the registration* is the *shape of the
+graph*. `(fn [db _] ...)` is an extractor by construction. `:<-` is a composer by
+construction. The framework can read the registry and know your entire topology as
+data — which is exactly how [Xray](../glossary.md#xray) draws your subscription
+graph without executing a single computation function (`re-frame.subs.tooling/sub-topology`
+is a literal read of the registry). Declared dependencies, not discovered ones.
+This will be a theme.
 
-??? note "Going deeper"
+## The Equality Gate
 
-    That "the registration *is* the topology" property is what lets the whole subscription layer be treated as data rather than as opaque closures. Each `:<-` edge is a static arrow in a DAG; the layer of a node is just the longest path back to app-db. Because the edges are declared rather than discovered at run time, the graph is a *value* you can analyse, draw, diff, and reason about without evaluation — the same move that makes [flows, resources, route facts, and machine selectors](../glossary.md#the-derivation-graph) compose on one shared graph with one shared algebra.
+I said the graph is fast without tuning. Here is the entire mechanism. One rule:
 
-## The equality gate
+> **A subscription's cached value is invalidated only when one of its inputs
+> actually changes value — checked with `=`, deep value equality.**
 
-I said the graph is fast without tuning. Here is the entire mechanism, one rule:
+I'll pause while you read that again. It's the load-bearing sentence of this page.
 
-> **A subscription's cached value is invalidated only when one of its inputs actually changes value — checked with `=`, deep value equality.**
+Walk it through. App-db changes. The layer-1 extractors re-run — all of them, every
+time, because app-db is their input. Each one's new output is compared with its
+previous output by `=`. If the slice didn't change, the cached value stands and
+**propagation stops right there**. Downstream subs don't re-run. Views don't
+re-render. Nothing past the unchanged extractor even learns an
+[event](../glossary.md#event) happened.
 
-When app-db changes, the layer-1 extractors re-run. They read app-db, so every change makes them re-check. Then each extractor's new output is compared with its previous output by `=`. If the slice didn't change, the cached value stands and **propagation stops right there**. Downstream layer-2 subs don't re-run, views don't re-render, and nothing past the unchanged extractor even learns that an [event](../glossary.md#event) happened.
+That makes layer 1 a **circuit breaker** for everything behind it. Change
+`:cart/category-filter` and the `:cart/items` extractor re-runs, sees its slice is
+`=` to last time, and shuts the gate: the sort in `:cart/by-price` never executes.
+And the same gate sits at *every* node — a layer-2 sub that recomputes but produces
+an `=` result stops propagation to its dependents too.
 
-That makes layer 1 a **circuit breaker** for everything behind it. Change `:cart/category-filter` and the `:cart/items` extractor re-runs, sees its slice is `=` to last time, and shuts the gate — so the sort in `:cart/by-price` never executes. The same gate sits at every node: a layer-2 sub that recomputes but produces an `=` result stops propagation to *its* dependents too. You wrote zero `memo` and zero dependency arrays; you declared what each sub reads and got memoisation at every node for free. The same gate guards the root, too. A no-op write — a handler that assocs a key to the value it already holds — produces an app-db that is `=` to the old one, so *nothing* recomputes anywhere. You cannot cause a render storm by writing state that didn't change.
+You wrote zero `memo`. Zero dependency arrays. You declared what each sub reads,
+and got memoisation at every node of the graph for free.
 
-??? info "Coming from Redux?"
+The gate even guards the root. A no-op write — a handler that assocs a key to the
+value it already holds — produces an app-db that is `=` to the old one, so
+*nothing* recomputes anywhere. You cannot cause a render storm by writing state
+that didn't change. Try. You can't.
 
-    In Reselect you carry the memoisation discipline yourself: a selector memoises on *reference* identity, so the moment a reducer returns a freshly-allocated array that's element-wise identical to the old one, every downstream selector and component recomputes anyway. The fix is to never allocate unless something changed — a rule you must hold in your head at every reducer. re-frame2 compares by value (`=`), so that whole category of "I accidentally busted the memo" bug doesn't exist. Equal values are equal, however they were allocated.
+(Redux veterans: in Reselect, you carry the memoisation discipline yourself — a
+selector memoises on *reference* identity, so the moment a reducer returns a
+freshly-allocated array that's element-wise identical to the old one, everything
+downstream recomputes anyway, and "never allocate unless something changed" becomes
+a rule you hold in your head at every reducer, forever. Here, equal values are
+equal, however they were allocated. That entire category of bug does not exist.)
 
-One practical rule falls out of all this, and it's the one to carry away:
+One practical rule falls out of the gate, and it's the one to carry away: **keep
+extractors tiny — put the work in layer 2.** An extractor fires on every app-db
+change; it must be cheap. A `get`, a `get-in`, nothing more. Put a `sort-by` inside
+an extractor and that sort runs on every keystroke in every unrelated form — you've
+placed expensive work *in front of* the gate instead of behind it. Move it into a
+`:<-` sub and it runs only when its slice actually changes. Same code, dramatically
+less work. When a view is mysteriously slow, "is there computation in a layer-1
+sub?" is the first question [Find and fix a slow view](../how-to/fix-a-slow-view.md)
+asks — because the answer is so often yes.
 
-!!! note "Keep extractors tiny — put the work in layer 2"
+Does the gate scale? The [Cells spreadsheet example](../../../examples/core/seven_guis/cells)
+derives 2,600 mounted cell values from one shared input sub, and the `=` check on
+each result means only cells whose displayed value genuinely changed re-render. A
+literal spreadsheet, running on the metaphor.
 
-    An extractor must fire on every app-db change to decide whether to propagate, so it has to be cheap: a `get`, a `get-in`, nothing more. Put a `sort-by` inside one and that sort runs on every keystroke in every unrelated form — you've placed expensive work *before* the gate instead of behind it. Move it into a `:<-` sub and it runs only when the extracted slice actually changes. Same code, dramatically less work. And when a view is mysteriously slow, "is there computation in a layer-1 sub?" is the first question [Find and fix a slow view](../how-to/fix-a-slow-view.md) asks.
+## Watch It Prune
 
-The gate scales further than you'd guess. The [Cells spreadsheet example](../../../examples/core/seven_guis/cells) derives 2,600 mounted cell values from one shared input sub. The `=` check on each result means only cells whose displayed value genuinely changed re-render: correct propagation with no hand-maintained dependency edges at all.
+Reading about a circuit breaker is one thing. Watching one branch stay silent while
+its neighbour fires is better.
 
-## Watch it prune
-
-Reading about a circuit breaker is one thing; watching one branch stay silent while its neighbour fires is better. The cell below is self-contained: two independent app-db slices, one extractor and one derivation per branch, one view reading both. The `reg-event` / `dispatch` scaffolding is the same you've used since [Our First App](../first-app.md) — it's here to let you watch the gate work, not as the subject of the page.
-
-Click into the cell, press **`Ctrl-Enter`** (**`Cmd-Enter`** on macOS) to evaluate, then click **add item** a few times:
+The cell below is self-contained: two independent app-db slices, one extractor and
+one derivation per branch, one view reading both. Click into it, press
+**`Ctrl-Enter`** (**`Cmd-Enter`** on macOS) to evaluate, then click **add item** a
+few times:
 
 ```cljs-rf2
 (require '[re-frame.core :as rf])
@@ -199,19 +301,34 @@ Click into the cell, press **`Ctrl-Enter`** (**`Cmd-Enter`** on macOS) to evalua
  [cart-summary]]
 ```
 
-Every add builds a brand-new app-db value, and *both* branches are attached to it — yet only the count line moves. The currency extractor `:cart/currency` *ran* on every add, but it produced an `=` value each time, so the gate closed and the currency branch never woke up: `:cart/currency-label` never recomputed. Change flows exactly as far as values actually move, and not one node further.
+Every add builds a brand-new app-db value, and *both* branches hang off it — yet
+only the count line moves. The `:cart/currency` extractor *ran* on every click, but
+it produced an `=` value each time, so the gate closed, and `:cart/currency-label`
+never recomputed. Change flows exactly as far as values actually move. Not one
+node further.
 
-!!! tip "Try it"
+Want a stronger dose? Add a deliberate no-op to the cell —
+`(rf/reg-event :cart/restate-currency (fn [{:keys [db]} _] {:db (assoc db :cart/currency "USD")}))`
+plus a button that dispatches it — and re-evaluate. Clicking it does nothing,
+anywhere. The new app-db is `=` to the old one, so the graph proves nothing changed
+and goes back to sleep.
 
-    Add a deliberate no-op to the cell — `(rf/reg-event :cart/restate-currency (fn [{:keys [db]} _] {:db (assoc db :cart/currency "USD")}))`, plus a button that dispatches it — and re-evaluate. Clicking it does nothing anywhere: the new app-db is `=` to the old one, so *nothing* recomputes and nothing re-renders. The graph proved nothing changed and went back to sleep.
+To see the gate's decisions rather than infer them, run this shape in your own app
+with [Xray](../glossary.md#xray) attached (one-line setup:
+[Debug with Xray](../../xray/index.md)), click **add item**, select the newest
+event row, and open the **Views** tab: `:cart/count-label` is marked as the
+re-render's trigger while `:cart/currency-label` sits beside it, unmarked.
 
-To see the gate's decisions rather than infer them, run the same shape in your own app with [Xray](../glossary.md#xray) attached (the one-line setup is in [Debug with Xray](../../xray/index.md)): click **add item**, select the newest event row, and open the **Views** tab — `:cart/count-label` is marked as the re-render's trigger while `:cart/currency-label` sits beside it unmarked.
+## When the Inputs Depend on the Arguments
 
-## Parametric inputs: the two-function form
+Subscriptions take arguments — `@(rf/subscribe [:article/page article-id])` — and
+sometimes the *arguments* decide which upstream subs you need. An article page
+needs *that* article, *that* article's comments, and the current viewer. `:<-`
+can't express this: it lists query vectors literally at registration time, and
+`article-id` doesn't exist yet.
 
-Subscriptions take arguments — `@(rf/subscribe [:article/page article-id])` — and sometimes the *arguments* decide which upstream subs you need. An article page needs *that* article, *that* article's comments, and the current viewer. `:<-` can't express this, because it lists query vectors literally at registration time, and `article-id` doesn't exist yet.
-
-For that case `reg-sub` takes **two functions**: an *input function* and the computation function.
+For that case, `reg-sub` takes **two functions** — an *input function* and the
+computation function:
 
 ```clojure
 (rf/reg-sub
@@ -229,20 +346,33 @@ For that case `reg-sub` takes **two functions**: an *input function* and the com
      :can-edit? (:edit? viewer)}))
 ```
 
-The input function answers *what does this sub depend on?* Here, three subscriptions, two of them parameterised by the `article-id` plucked from the query vector. The computation function answers *what does it compute?* It receives the resolved input values as a vector, in the order the input function listed them. (Always a vector in this form, even for a single input.)
+The input function answers *what does this sub depend on?* The computation function
+answers *what does it compute?* The resolved input values arrive as a vector, in
+the order the input function listed them — always a vector in this form, even for
+a single input.
 
-The choice between the two forms is sharp: **use `:<-` for static inputs; reach for an input function only when the upstream query vectors need values from the outer query vector.** `:<-` is exactly a constant input function with the boilerplate removed, and its edges are statically drawable. The two-function form trades that for parametricity.
+The choice between the two forms is sharp. **Use `:<-` for static inputs; reach for
+an input function only when the upstream query vectors need values from the outer
+query vector.** `:<-` is exactly a constant input function with the boilerplate
+removed — and its edges are statically drawable, which the tooling repays.
 
-A few things keep this form predictable. The first trips people up, so it leads:
+Notes, in descending order of how often each one bites:
 
-!!! warning "Gotcha — the input function returns *data*, not live subs"
-
-    It returns query vectors, never `subscribe` calls. It must be pure over the query vector: no deref of app-db, no `subscribe`, no dispatch, no IO. The runtime does the subscribing. And a single input is still a *vector of one query vector* — `[[:item/by-id id]]`, not `[:item/by-id id]`. The scalar shape is rejected because `[:x :y]` is ambiguous: one query with an argument, or two inputs? A wrong shape fails loud rather than guessing — the next section has the whole grammar.
-
-The other two predictability rules are gentler:
-
-- **It is not on the hot path.** It runs once, when a concrete query vector like `[:article/page :a1]` is first materialised. From then on that entry is an ordinary cached node, and `[:article/page :a2]` is a separate entry with its own inputs.
-- **Dependencies cannot come from app-db.** A sub whose edges changed with state would break disposal (see Lifecycle, below), hot reload, and Xray's topology view. So when the parameter you need lives in app-db, read it at the call site and thread it through the query vector:
+1. **The input function returns *data*, not live subs.** Query vectors, never
+   `subscribe` calls. Pure over the query vector: no app-db deref, no dispatch, no
+   IO. The runtime does the subscribing. And a single input is still a *vector of
+   one query vector* — `[[:item/by-id id]]`, not `[:item/by-id id]`. The scalar
+   shape is rejected because `[:x :y]` is ambiguous: one query with an argument, or
+   two inputs? re-frame2 refuses to guess.
+2. **It is not on the hot path.** It runs once, when a concrete query vector like
+   `[:article/page :a1]` is first materialised. From then on that entry is an
+   ordinary cached node; `[:article/page :a2]` is a separate entry with its own
+   inputs.
+3. **Dependencies cannot come from app-db.** A sub whose edges changed with state
+   would break disposal, hot reload, and Xray's topology view. When the parameter
+   you need lives in app-db, read it at the call site and thread it through the
+   query vector — the dynamism lives at the view boundary, where mount/unmount
+   already manages lifecycle:
 
 ```clojure
 (rf/reg-view article-pane []
@@ -251,15 +381,11 @@ The other two predictability rules are gentler:
     ...))
 ```
 
-The dynamism lives at the view boundary, where view mount and unmount already manage subscription lifecycle. Each concrete cache entry keeps the same edges for its whole life.
+### The Exact Return Grammar
 
-??? info "From re-frame v1"
-
-    Your signal functions returned live `(rf/subscribe ...)` calls — v2 input functions return query vectors as plain data instead, and the single-input and map-returning v1 shapes need rewriting. [From re-frame v1](../25-from-re-frame-v1.md) has the mechanical recipes.
-
-### The exact return grammar — what's accepted, what's rejected
-
-This is the one corner of `reg-sub` with a strict shape, so it's worth seeing the whole grammar in one place. An input function **must** return a vector, and **every element** must itself be a query vector (a vector whose head is a keyword):
+This is the one corner of `reg-sub` with a strict shape, so here it is in one
+place. An input function **must** return a vector, and **every element** must
+itself be a query vector — a vector whose head is a keyword:
 
 ```clojure
 ;; Accepted
@@ -274,17 +400,20 @@ This is the one corner of `reg-sub` with a strict shape, so it's worth seeing th
 {:article [:article/by-id id]}             ;; a map
 ```
 
-These aren't silent coercions — they [fail loud](../glossary.md#fail-loud-not-silent) so a typo can't quietly produce the wrong dependency edges:
+None of these are silently coerced — they
+[fail loud](../glossary.md#fail-loud-not-silent), because a typo that quietly
+produced the wrong dependency edges would cost you an afternoon. Three distinct
+errors keep three distinct mistakes apart: a malformed registration shape signals
+`:rf.error/reg-sub-bad-args` at `reg-sub` time; a bad return value signals
+`:rf.error/sub-input-fn-bad-return` when the concrete subscription is first
+materialised; a throw inside the input function signals
+`:rf.error/sub-input-fn-exception`. All three are catalogued in
+[Errors and recovery](errors.md).
 
-- A **malformed registration shape** (e.g. a stray non-fn in the tail) is caught at `reg-sub` time and signals `:rf.error/reg-sub-bad-args`. It's a programming error to fix.
-- A **bad return value** from the input function signals `:rf.error/sub-input-fn-bad-return` when the concrete subscription is first materialised.
-- A **throw inside the input function** signals `:rf.error/sub-input-fn-exception`.
+## Saying Things About a Sub: Metadata
 
-All three are catalogued in [Errors and recovery](errors.md). When something computes the wrong thing, that's where to look first.
-
-## Registration metadata: docs, schema, and classification
-
-Any `reg-sub` may carry an optional **metadata map** immediately after the id, before the `:<-` chain or the body. It's where you put declarations *about* the subscription rather than its computation:
+Any `reg-sub` may carry an optional metadata map right after the id — declarations
+*about* the subscription, as opposed to its computation:
 
 ```clojure
 (rf/reg-sub :user/initials
@@ -300,14 +429,21 @@ Any `reg-sub` may carry an optional **metadata map** immediately after the id, b
 
 The keys you'll reach for:
 
-- **`:doc`** — a human-readable description. It's structurally optional, but the dev build *warns* when a registration omits it, because tools (Xray's sub list, the topology view) surface it. Treat it as a SHOULD.
-- **`:schema`** — a [Malli](https://github.com/metosin/malli) [schema](../glossary.md#schema) (or your implementation's equivalent) describing the sub's **output**. When present, the dev build validates the computed value against it at the `:sub-return` validation boundary — a fail-loud guard, [elided](../glossary.md#elide) from production like every schema check. The full schema-everywhere story is in [Validate with schemas](../how-to/validate-with-schemas.md).
-- **`:tags`** — a set of keywords for your own grouping and tooling.
+1. **`:doc`** — a human-readable description. Structurally optional, but the dev
+   build warns when you omit it, because tools (Xray's sub list, the topology
+   view) surface it. Treat it as a SHOULD.
+2. **`:schema`** — a [Malli](https://github.com/metosin/malli)
+   [schema](../glossary.md#schema) for the sub's **output**. When present, the dev
+   build validates the computed value at the `:sub-return` boundary — a fail-loud
+   guard, [elided](../glossary.md#elide) from production like every schema check.
+   The full story: [Validate with schemas](../how-to/validate-with-schemas.md).
+3. **`:tags`** — a set of keywords for your own grouping and tooling.
 
-Two metadata keys are specific to subscriptions, both from the [data-classification](../glossary.md#data-classification) model. They classify the sub's **own output** so the observability pipeline knows what to redact or summarise when it captures a value into a trace:
-
-- **`:sensitive`** — a vector of paths into the output shape that hold sensitive data (`[[]]` marks the whole output). A sub deriving a token, a card number, or a session secret should classify it so it's elided from traces and recordings.
-- **`:large`** — a vector of paths into the output that are big enough to summarise rather than capture verbatim (a 5,000-row table, a decoded blob).
+Two more keys come from the [data-classification](../glossary.md#data-classification)
+model, and they exist because the observability pipeline captures sub outputs into
+traces. **`:sensitive`** marks paths in the output that hold secrets (`[[]]` marks
+the whole output); **`:large`** marks paths big enough to summarise rather than
+capture verbatim (a 5,000-row table, a decoded blob):
 
 ```clojure
 (rf/reg-sub :auth/session-token
@@ -316,68 +452,136 @@ Two metadata keys are specific to subscriptions, both from the [data-classificat
   (fn [db _] (:auth/token db)))
 ```
 
-!!! warning "Gotcha — classification doesn't propagate"
+One thing to hear plainly: **classification does not propagate.** A sub does *not*
+inherit its inputs' `:sensitive`/`:large` declarations. If a derived value is
+sensitive, classify it at the sub that produces it. (The narrative:
+[Keep secrets out of traces](../how-to/keep-secrets-out-of-traces.md).) A malformed
+declaration is rejected at registration with `:rf.error/bad-classification`.
 
-    A sub does **not** inherit its inputs' `:sensitive`/`:large` declarations. If a derived value is sensitive, classify it *at the sub that produces it*. The narrative and the keep-it-out-of-traces recipe live in [Keep secrets out of traces](../how-to/keep-secrets-out-of-traces.md).
+## Testing, Briefly
 
-A malformed `:sensitive`/`:large` value is rejected at registration with `:rf.error/bad-classification`.
+A layer-1/2/3 computation is a pure function of `(inputs, query-v)`. So you don't
+need a reactive runtime — or a DOM, or a browser — to test what a subscription
+*computes*. `rf/compute-sub` runs a sub's body against an app-db **value**,
+resolving the whole `:<-` chain for you, JVM-runnable, no live cache. The recipe,
+both styles, gotchas included: [Test a subscription](../testing/subscriptions.md).
 
-## Testing a subscription without a browser
+## Lifecycle: a Sub Exists Only While Something Watches
 
-Because a layer-1/2/3 computation is just a pure function of `(inputs, query-v)`, you don't need a reactive runtime — or a DOM, or a browser — to test what a subscription *computes*: `rf/compute-sub` runs a sub's body against an app-db **value**, resolving the whole `:<-` chain for you, and it's JVM-runnable with no live cache. The recipe — both styles, and the gotchas — is [Test a subscription](../testing/subscriptions.md).
+A subscription node is not a permanent fixture. It's reference-counted. A view
+derefs `[:cart/visible]`; the cache materialises the node (computing the whole
+input chain) and bumps a ref-count. A second view sharing the query vector bumps it
+again and reads the same cached value. A view unmounts; its reference is released.
+And on the **last** release — ref-count hits zero — the slot is disposed
+**synchronously, in the same tick**: reaction torn down, input ref-counts released
+(which can cascade disposal up the chain), slot removed. A `:rf.sub/dispose`
+[trace event](../glossary.md#trace-event) marks the eviction.
 
-## Lifecycle: a sub exists only while something watches it
+Why should you care? Two everyday ways:
 
-A subscription node isn't a permanent fixture in the cache — it's reference-counted. When a view derefs `[:cart/visible]`, the cache materialises the node (computing the whole input chain) and bumps a ref-count. A second view sharing the same query vector bumps it again and reads the same cached value. When a view unmounts, its dependency is released, and on the **last** release — ref-count hits zero — the cache slot is disposed **synchronously, in the same tick**: the reaction is torn down, its input ref-counts are released (which can cascade disposal up the chain), and the slot is removed. A `:rf.sub/dispose` [trace event](../glossary.md#trace-event) marks the eviction.
+1. **No grace-period timer.** Disposal is immediate on the 1 → 0 edge, so a sub
+   can't linger, recomputing pointlessly, after its last reader has gone. And
+   re-subscribing after disposal is just a fresh cache miss that rebuilds against
+   the registered body — same body, same db, so the value is `=` to what was
+   disposed, and a remount observes no flicker.
+2. **Hot-reload and teardown are clean.** Re-registering a sub disposes every
+   cached slot for that query, regardless of ref-count — the next subscribe builds
+   against the new body. Destroying a [frame](../glossary.md#frame) disposes every
+   slot it owns. Correct behaviour across a `shadow-cljs` reload, no thought
+   required.
 
-This matters in two everyday ways:
+Two functions step outside the deref-driven lifecycle on purpose:
 
-- **There's no grace-period timer.** Disposal is immediate on the 1 → 0 edge, so a sub can't be kept alive — recomputing pointlessly — across a state change that lands after its last reader has gone. (Equally: re-subscribing after disposal is a fresh cache miss that rebuilds against the registered body — same body, same db, so the value `=` what was disposed and a remount observes no flicker.)
-- **Hot-reload and frame teardown are clean.** Re-registering a sub disposes every cached slot for that query, regardless of ref-count — the next subscribe builds against the new body. Destroying a [frame](../glossary.md#frame) disposes every cached slot it owns. You get correct behaviour across a `shadow-cljs` reload without thinking about it.
+- **`rf/subscribe-once`** — subscribe, deref once, immediately unsubscribe, return
+  the plain value. A **non-reactive** read: you get the value as of now, and you
+  are *not* registered for changes. Right for a one-shot read in a REPL, or a
+  handler that genuinely needs a derived value once. (Takes the same
+  `{:frame f}` opts as `subscribe` for reading a named frame from outside any
+  scope.) If you reach for it *routinely* from handlers, the value probably wants
+  to be a [flow](../glossary.md#flow) instead — see below.
+- **`rf/unsubscribe`** — decrement the ref-count by hand, for the rare case where
+  you took a reference programmatically. Views never call this; mount/unmount does
+  it for them.
 
-Two functions let you step outside the deref-driven lifecycle deliberately:
+## The Framework's Own Subs
 
-- **`rf/subscribe-once`** — `(subscribe-once query-v)` (or `(subscribe-once query-v {:frame f})` to read a named frame from outside any scope) subscribes, derefs once, and immediately unsubscribes, returning the plain value. It's a **non-reactive** read: you get the value as of right now and you are *not* registered for change notification. It's the right tool for a one-shot read inside a REPL session, or a handler body that genuinely needs a derived value once. The `{:frame f}` opts form mirrors `subscribe`'s — `f` a frame-id keyword or a live frame value — so the two calls share one shape. If you reach for it routinely from a handler, the value probably wants to be a [flow](../glossary.md#flow) instead (see below).
-- **`rf/unsubscribe`** — `(unsubscribe query-v)` decrements the ref-count by hand, for the rare case where you took a reference programmatically and need to release it. Views never call this; their mount/unmount lifecycle does it for you.
+The framework registers a handful of subscriptions for you, and you read subsystem
+state through them exactly as you read your own:
 
-## Standard registered subscriptions
+- **`[:rf/machine <machine-id>]`** — a [state machine](../../machines/glossary.md#machine)'s
+  [snapshot](../../machines/glossary.md#snapshot) `{:state :data}`, or `nil` before
+  it's initialised. The canonical way to drive a view off a machine.
+- The router publishes a family — **`:rf/route`**, **`:rf.route/id`**,
+  **`:rf.route/params`**, **`:rf.route/query`**, **`:rf.route/transition`**,
+  **`:rf.route/chain`**, and more — covered in [Routing](../../routing/concepts.md).
 
-The framework registers a handful of subscriptions for you — you read subsystem state through them exactly as you'd read your own:
+Anything under `:rf/…` or `:rf.<subsystem>/…` is framework-owned, per the reserved-
+namespace convention. Keep your subs out of that namespace and the two never collide.
 
-- **`[:rf/machine <machine-id>]`** returns a [state machine](../../machines/glossary.md#machine)'s [snapshot](../../machines/glossary.md#snapshot) `{:state :data}` (or `nil` before it's initialised). It's the canonical way to drive a view off a machine.
-- The router publishes a family — **`:rf/route`** (the whole route slice), **`:rf.route/id`**, **`:rf.route/params`**, **`:rf.route/query`**, **`:rf.route/transition`**, **`:rf.route/chain`**, and more — covered in [Routing](../../routing/concepts.md).
+## When a Subscription Is the Wrong Tool
 
-These follow the reserved-namespace convention: anything under `:rf/…` or `:rf.<subsystem>/…` is framework-owned. Keep your own subs out of that namespace and the two never collide.
+Subscriptions are view-facing and pull-based: a node exists only while a view
+watches it. That boundary tells you when to reach for something else.
 
-## When a subscription is the wrong tool
+- **An event handler needs the derived value.** Handlers don't subscribe. That's
+  what [flows](../glossary.md#flow) are for — derived values materialised *into*
+  app-db, where a handler reads them as plain state.
+- **The value comes from a server.** Subscriptions never fetch; computation
+  functions are pure, no IO. Server-owned data belongs to
+  [resources](../../resources/glossary.md#resource); subscriptions derive *over*
+  the cached resource state.
+- **The value crosses frames.** A subscription must not reach into another
+  [frame](../glossary.md#frame)'s state. Frames are isolated worlds; that's the
+  point of them.
+- **Not sure where a value belongs at all?**
+  [Where should this value live?](../where-state-lives.md) sorts it into a sub,
+  flow, resource, or machine with four questions.
 
-Subscriptions are view-facing and pull-based: a node exists in the cache only while some view is watching it. That boundary is what tells you when to reach for something else — here are the edges where a sub is the wrong answer:
+(TanStack Query folks: `useQuery` is one hook doing two jobs — fetching server
+state *and* deriving over it. re-frame2 splits those. Resources own
+fetch-cache-invalidate; subscriptions are the pure derivation layer over whatever
+is already in app-db, resource state included.)
 
-!!! note "Reach past a subscription when…"
+## When Things Go Wrong
 
-    - **An event handler needs the derived value.** Handlers don't subscribe — that's what [flows](../glossary.md#flow) are for: derived values materialised *into* app-db, where a handler can read them as plain state.
-    - **The value comes from a server.** Subscriptions never fetch — computation functions are pure, no IO. Server-owned data belongs to [resources](../../resources/glossary.md#resource); subscriptions derive *over* the cached resource state.
-    - **The value crosses frames.** A subscription must not reach into another [frame](../glossary.md#frame)'s state; frames are isolated worlds by design.
-    - **Unsure where a value belongs at all?** [Where should this value live?](../where-state-lives.md) sorts a value into a sub, flow, resource, or machine with four questions.
+Three corners you won't need on day one. You'll want them the day something goes
+sideways, so here they are.
 
-??? info "Coming from TanStack Query?"
+**A computation throws.** A `nil` where you assumed a map; a divide-by-zero in a
+derived total. re-frame2 treats it as a [fail-loud](../glossary.md#fail-loud-not-silent)
+event, not a crash: it emits `:rf.error/sub-exception` and recovers the sub to
+`nil`, so the throw can't take down the render. The record is always-on — it
+reaches your production error listeners — and its `:where` tag names the path that
+threw: `:reactive` for the live cache path, `:compute-sub` for the pure test/SSR
+path. SSR runs on that same pure path, so a sub that throws during a server render
+lets the server fail closed with a real error response instead of shipping HTML
+built from `nil`s. Catalogue entry: [Errors and recovery](errors.md).
 
-    Note the split: TanStack Query gives you *one* hook (`useQuery`) that both fetches server state and derives over it. re-frame2 keeps those concerns apart — [resources](../../resources/glossary.md#resource) own the fetch-cache-invalidate lifecycle for server-owned data, and subscriptions are the pure derivation layer that computes *over* whatever's already in app-db (resource state included). When you want to fetch, that's a resource; when you want to shape what's already there, that's a sub.
+**A schema'd sub computes the wrong shape.** The runtime validates *after* the
+body runs, at the `:sub-return` boundary. On a mismatch it emits
+`:rf.error/schema-validation-failure` with `:where :sub-return` and surfaces `nil`
+to the consumer — the same recover-to-`nil` posture as a throw — so a derivation
+producing the wrong shape is caught at the sub that produced it, not three layers
+downstream where some view chokes on it. A strict mode re-raises, for CI. Like
+every schema check, the whole boundary is [elided](../glossary.md#elide) from
+production.
 
-## Advanced
+**Subscribing during teardown.** A stray async callback fires after its
+`frame-provider` unmounted; a hot-reload race. The subscribe returns `nil` —
+fail-safe — while emitting a production-survivable `:rf.error/frame-destroyed`
+carrying the frame id and the attempted query vector, so a genuine
+use-after-destroy bug stays visible on the stream you actually watch. (A
+*rootless* subscribe — issued under no frame scope at all — is the different
+`:rf.error/no-frame-context`; see
+[frame identity is carried, not found](../glossary.md#frame-identity-is-carried-not-found).)
 
-Three corners you won't need on day one, but will want when something goes sideways — what the graph does when a computation throws, how a schema'd sub recovers from a bad value, and what subscribing during teardown reports.
+---
 
-### When a computation throws
+One last widening of the lens. Subscriptions are one face of a larger family:
+flows, resources, route facts, and machine selectors all live on
+[one derivation graph](../glossary.md#the-derivation-graph), with one shared
+algebra. The essay-length tour is
+[One graph: derivations and their algebra views](../derivations-and-algebra-views.md).
 
-A computation function is just code, and code can throw — a `nil` where you assumed a map, a divide-by-zero in a derived total. re-frame2 treats that as a [fail-loud](../glossary.md#fail-loud-not-silent) event, not a crash: it emits `:rf.error/sub-exception` and **recovers the sub to `nil`**, so the throw can't take down the render. The record is always-on (it reaches your production error listeners — Sentry, Datadog), and its `:where` tag tells you which path threw: `:reactive` for the live cache path a view drives, `:compute-sub` for the pure test/SSR path. Both surface the same way, so when a sub throws during a server-side render (SSR runs on the same pure `:compute-sub` path), the server can fail closed with a real error response rather than silently shipping HTML built from `nil`s. There's no per-frame recovery policy to configure. The full catalogue entry is in [Errors and recovery](errors.md).
-
-### When a schema'd sub computes the wrong shape
-
-If a sub carries a `:schema` (see [Registration metadata](#registration-metadata-docs-schema-and-classification)), the runtime validates the computed value *after* the body runs, at the `:sub-return` boundary. On a mismatch it emits `:rf.error/schema-validation-failure` with `:where :sub-return` and, by default, **surfaces `nil`** to the consumer (the same recover-to-`nil` posture as a throw) — so a derivation quietly producing the wrong shape is caught at the sub that produced it, not three layers downstream where a view chokes on it. A strict mode re-raises instead, for CI. Like every schema check, this whole boundary is [elided](../glossary.md#elide) in production builds — it's a development guard, not a runtime tax.
-
-!!! warning "Gotcha — subscribing during teardown returns `nil`, loudly"
-
-    Subscribe against a [frame](../glossary.md#frame) that's already been destroyed — a stray async callback firing after a `frame-provider` unmounted, a hot-reload race — and re-frame2 recovers (the subscribe returns `nil`) while emitting a production-survivable `:rf.error/frame-destroyed` carrying the frame id and the attempted query vector. So a teardown race fails safe, but a genuine use-after-destroy bug stays visible on the stream you watch in production. (A *rootless* subscribe — one issued under no frame scope at all — is the different `:rf.error/no-frame-context`; see [frame identity is carried, not found](../glossary.md#frame-identity-is-carried-not-found).)
-
-Subscriptions are also one face of a larger family — flows, resources, route facts, and machine selectors all live on [one derivation graph](../glossary.md#the-derivation-graph); [One graph: derivations and their algebra views](../derivations-and-algebra-views.md) is the essay-length tour.
+Derived data, all the way down — and now you can read any registration on the
+graph and say exactly when it recomputes.

--- a/docs/core/concepts/views.md
+++ b/docs/core/concepts/views.md
@@ -1,18 +1,26 @@
 # Views: pure functions of data
 
-A [view](../glossary.md#view)'s whole job is to turn data into a description of the screen: it reads some application state, returns the picture for that state, and that's it — no stored state of its own, no side effects, no lifecycle to manage. When the state changes, the framework re-runs the view and updates the DOM to match. So the entire contract fits in one sentence, and it's worth holding onto as you read the rest of this page:
+A [view](../glossary.md#view) has one job: turn data into a picture of the screen.
+
+Not "manage local state" — a view stores nothing. Not "fetch what it needs" — a view never touches the world. Not "coordinate a lifecycle" — there's nothing to coordinate. It reads some application state, returns the description of the screen for that state, and it's finished. State changes; the framework re-runs the view; the DOM catches up.
+
+So the entire contract fits in one sentence:
 
 > **A view is a pure function from subscription values to hiccup.**
 
-This page builds that sentence up one piece at a time. We'll start with the output — [*hiccup*](../glossary.md#hiccup), the data a view returns — then add the two ways a view talks to the rest of the app, then look at a complete view running live, and finally cover the one discipline that keeps views fast and the handful of escape hatches you'll occasionally reach for.
+I'll pause while you read that again, because every heading below is that sentence being unpacked. That's the whole page, right there.
+
+Behind it sits a conviction, and I'd rather own it out loud than have you discover it sideways: **views are derivative, not causal.** For about ten years the React world has organised itself around one gravitational centre — the component. Components own state. Components fetch data. Components route. Components subscribe to stores through whatever `useFoo` hook this year's library plumbed in. Effects colocate with the view tree because the view tree is what the framework can see, so the view tree is where *everything* ends up living — state, IO, navigation, the lot, bolted onto render functions. Too grumpy? Maybe; those tools ship real products. But re-frame2 makes the opposite bet. [Events](../glossary.md#event) update centralised state. [Subscriptions](subscriptions.md) derive values from it. Views sit at the very end of the flow and render whatever arrives. A view is a **window** onto your application's state: it shows you the room. It doesn't get to be the room.
+
+Hold onto the window; we'll be looking through it for the rest of the page. The route: first the output — [*hiccup*](../glossary.md#hiccup), the data a view returns — then the two ways a view talks to the rest of the app, then a complete view running live, and finally the one discipline that keeps views fast, plus the handful of escape hatches you'll occasionally reach for.
 
 ??? info "For JavaScript developers"
 
-    A re-frame2 view is a React function component with everything except rendering removed. There's no `useState`, because state lives in [app-db](app-db.md) — your app's single state map — and arrives through [subscriptions](subscriptions.md). There's no `useEffect`, because anything that touches the world is an [effect](effects.md), produced as data by an [event handler](../glossary.md#event-handler) and never run from a component. And there's no JSX, because a view returns plain Clojure data. The design here is in what got *subtracted*, not in anything added.
+    A re-frame2 view is a React function component with everything except rendering removed. No `useState` — state lives in [app-db](app-db.md), your app's single state map, and arrives through [subscriptions](subscriptions.md). No `useEffect` — anything that touches the world is an [effect](effects.md), produced as data by an [event handler](../glossary.md#event-handler) and never run from a component. No JSX — a view returns plain Clojure data. The design here is in what got *subtracted*, not in anything added.
 
 ## The counter gets components
 
-[Our first app](../first-app.md) rendered the whole counter in one view. Real screens are built from *pieces* — and views compose exactly the way the hiccup they return does. Here's the counter split into three registered views: a display, a reusable button, and a parent that assembles them:
+[Our first app](../first-app.md) rendered the whole counter in one view. Real screens are built from *pieces*, and views compose exactly the way the hiccup they return does — one vector inside another. Here's the counter split into three registered views: a display, a reusable button, and a parent that assembles them:
 
 ```cljs-rf2
 (require '[re-frame.core :as rf])
@@ -41,7 +49,13 @@ This page builds that sentence up one piece at a time. We'll start with the outp
  [counter]]
 ```
 
-Three things to notice, each of which the rest of this page unpacks. A child view is used *as data* — `[counter-button "−" [:dec]]` is just a vector whose tail is the child's arguments, so `counter-button` renders twice with different args and never knows it. The display subscribes for itself — the parent doesn't fetch the value and pass it down, so only `counter-display` re-renders when the value changes. And the button takes the *event to announce* as an argument — passing events as data is how a piece stays reusable without knowing what its click means.
+Notes:
+
+1. A child view is used *as data*. `[counter-button "−" [:dec]]` is just a vector whose tail is the child's arguments, so `counter-button` renders twice with different args and never knows it.
+2. The display subscribes for itself. The parent doesn't fetch the value and hand it down — so when the value changes, only `counter-display` re-renders.
+3. The button takes the *event to announce* as an argument. Passing events as data is how a piece stays reusable without knowing what its click means.
+
+The rest of this page unpacks all three.
 
 ## Hiccup: the screen is data
 
@@ -60,13 +74,13 @@ The rules are quick to learn:
 - Everything after that is **children**. Strings become text; nested vectors become nested elements.
 - A vector whose first element is a **view** (not a keyword) renders that view, with the rest of the vector as its arguments — `[counter-button "−" [:dec]]` above. That's the composition rule the counter used.
 
-The important word is *data*. Not "data-like" — these are actual vectors, maps, and keywords, the same structures you manipulate everywhere else in the program. So you build screens with ordinary code and no template syntax:
+The important word is *data*. Not "data-like". Actual vectors, maps, and keywords — the same structures you manipulate everywhere else in the program. So you build screens with ordinary code and no template syntax:
 
 ```clojure
 (into [:ul] (for [item items] [:li (:name item)]))
 ```
 
-Because hiccup is just data, views compose like any other values: a function can take hiccup and return hiccup, you can `pprint` a view's output and read it, and a pure function that walks hiccup and emits an HTML string can run on the server — which is how [server-side rendering](../../ssr/concepts.md) renders the *same* views without a browser.
+And because hiccup is just data, everything you already know how to do with data works on screens. A function can take hiccup and return hiccup. You can `pprint` a view's output and *read* it. A pure function that walks hiccup and emits an HTML string can run on the server — which is how [server-side rendering](../../ssr/concepts.md) renders the *same* views without a browser in the building.
 
 ??? info "For JavaScript developers"
 
@@ -78,7 +92,7 @@ Because hiccup is just data, views compose like any other values: a function can
 
 ## Subscribe in, dispatch out
 
-A static screen isn't much use. A view needs to read live application state, and it needs to react to clicks and typing. It does both through exactly two openings — and both are one-way.
+A static screen isn't much use. A view needs to read live application state, and it needs to react to clicks and typing. Two jobs, exactly two openings — and both are one-way.
 
 **Reading state in: the view derefs a [subscription](../glossary.md#subscription).**
 
@@ -96,7 +110,7 @@ This declares "I depend on this derived value. Re-run me when it changes." That'
 
 A dispatch *announces that something happened* by handing the framework an [event](../glossary.md#event) — a plain vector naming what occurred — and returns immediately. It does not change state. It does not know or care what the handler will do with it. The [event pipeline](../glossary.md#event-pipeline) takes it from there: the handler runs, `app-db` moves, subscriptions repropagate, and at the very end this view re-renders to match. (The whole traversal is the [Introduction](../introduction.md)'s subject.)
 
-Notice the shape of the round trip, because it's the whole idea. A click never mutates the number it sits next to. It dispatches an event that produces a *new* `app-db`, which flows back through a subscription. The view can't short-circuit that path, because it holds no state to short-circuit with.
+Notice the shape of the round trip, because it's the whole idea. A click never mutates the number it sits next to. It dispatches an event that produces a *new* `app-db`, which flows back through a subscription. The view can't short-circuit that path, because it holds no state to short-circuit with. In window terms: you can see into the room, and you can knock. What happens after the knock is the room's business, not the window's.
 
 ??? info "Coming from Redux?"
 
@@ -136,9 +150,7 @@ Here is a view doing its whole job: subscribe in, dispatch out, hiccup between. 
 
 That's a complete view. You use it by referencing it inside other hiccup — `[qty-stepper]` — and a view that takes arguments takes them like any function: `[labelled-stepper "Apples"]`.
 
-!!! note "Try it"
-
-    Change the last form to `[:div [qty-stepper] [qty-stepper]]` and re-evaluate. Click either stepper: both move, because neither owns the number — each is a window onto the same `app-db` value. There is no local copy to fall out of sync.
+Now try something. Change the last form to `[:div [qty-stepper] [qty-stepper]]` and re-evaluate. Click either stepper: both move, because neither owns the number — each is a window onto the same `app-db` value, and two windows onto one room show the same furniture. There is no local copy to fall out of sync. There is no local copy at all.
 
 ## `reg-view`: registering a view for project code
 
@@ -193,9 +205,7 @@ So to *read* a `reg-view` body as a `defn`, map `dispatch` → `rf/dispatch` and
 
 In all three the symbol `cart-line` is `def`-ed, so you write `[cart-line item]` from sibling code regardless.
 
-!!! warning "Gotcha"
-
-    Get the *shape* wrong — pass a render fn instead of an args vector, or hand it a pre-built component object (`reagent.core/create-class …` — a legacy Reagent shape covered under *From re-frame v1* below) — and the macro refuses at compile time with a stable error pointing you at `re-frame.core/reg-view*` (the plain-fn surface described under *Tooling and library registration* below). The macro is the defn-shaped 80% lane; those cases have a different door.
+One warning before moving on. Get the *shape* wrong — pass a render fn instead of an args vector, or hand it a pre-built component object (`reagent.core/create-class …` — a legacy Reagent shape covered under *From re-frame v1* below) — and the macro refuses at compile time with a stable error pointing you at `re-frame.core/reg-view*` (the plain-fn surface described under *Tooling and library registration* below). The macro is the defn-shaped 80% lane; those cases have a different door.
 
 ??? info "From re-frame v1"
 
@@ -320,9 +330,7 @@ And the *after*, with the derivation pushed up into a [subscription](subscriptio
 
 Ask the "after" view what it does: all it does is walk the list and emit `<li>`s. That's a view that knows what it's for.
 
-!!! note "Why this matters"
-
-    A view re-runs whenever any value it derefs changes, and whenever a re-rendering parent hands it changed arguments. A `sort-by` in the view re-runs on every one of those. The same `sort-by` in a sub re-runs *only when `:cart/items` changes*, sits in the subscription cache, and is shared by every view that wants the sorted list. Compute once, read many. This is the single most common way re-frame2 apps get accidentally slow; the hunt and the fix are in [Find and fix a slow view](../how-to/fix-a-slow-view.md).
+Why so strict? Because a view re-runs whenever any value it derefs changes, and whenever a re-rendering parent hands it changed arguments — and a `sort-by` in the view re-runs on every single one of those. The same `sort-by` in a sub re-runs *only when `:cart/items` changes*, sits in the subscription cache, and is shared by every view that wants the sorted list. Compute once, read many. This is the single most common way re-frame2 apps get accidentally slow; the hunt and the fix are in [Find and fix a slow view](../how-to/fix-a-slow-view.md).
 
 ??? note "Need the derived value in an *event handler*, not just a view?"
 
@@ -357,9 +365,7 @@ Hiccup's event attrs — `:on-click`, `:on-change`, `:on-animation-end`, the who
 
 Rule of thumb: if an `:on-*` attr exists for what you need, use it. If one doesn't — a `js/setTimeout`, a `fetch`, an `IntersectionObserver`, a WebSocket — that work was never a view's job. It belongs in a registered [effect](effects.md), which captures the frame for you. The loud failure is deliberate: the runtime refuses to guess which world a frameless dispatch belongs to.
 
-!!! warning "It's still wrong inside a `reg-view`"
-
-    Inside a `reg-view` body the injected `dispatch` happens to survive, because it captured its frame at render time. But the imperative attach is wrong there too: render bodies re-run, each run adds another listener, and nothing ever removes them. Attach through the attrs map either way.
+And don't let a `reg-view` lull you. Inside a `reg-view` body the injected `dispatch` happens to survive, because it captured its frame at render time — but the imperative attach is wrong there too: render bodies re-run, each run adds another listener, and nothing ever removes them. Attach through the attrs map either way.
 
 ??? note "Going deeper"
 
@@ -388,10 +394,10 @@ Step back and notice what all this buys you at debugging time. A view holds no s
 
 > **When something renders wrong, the bug is almost never in the view — it's in the data the view was handed.**
 
-So don't debug views. Inspect data. Follow the value upstream: the [subscription](subscriptions.md) that computed it, then the [event handler](../glossary.md#event-handler) that wrote it. Both are pure functions you can test without a browser. With [Xray](../glossary.md#xray) open, find the [event](../glossary.md#event) row that preceded the bad render and look at the data it produced. The wrong value is usually sitting there, visibly wrong, before the view ever ran ([Debug with Xray](../../xray/index.md)).
+So don't debug views. Inspect data. When the room looks wrong, you don't repaint the window — you go and look at the room. Follow the value upstream: the [subscription](subscriptions.md) that computed it, then the [event handler](../glossary.md#event-handler) that wrote it. Both are pure functions you can test without a browser. With [Xray](../glossary.md#xray) open, find the [event](../glossary.md#event) row that preceded the bad render and look at the data it produced. The wrong value is usually sitting there, visibly wrong, before the view ever ran ([Debug with Xray](../../xray/index.md)).
 
 The render itself is observable too, which helps with the *other* failure mode — not "wrong value" but "why did this re-render at all?" Each render emits a [trace event](../glossary.md#trace-event) keyed by a `:render-key` — the tuple `[view-id instance-token]`, where the token disambiguates two mounted instances of the same view (`[:cart/row 1473]` vs `[:cart/row 1474]`). The entry also carries what *triggered* the render (the sub or props that changed) and the view's render args, so an over-rendering view shows its cause rather than leaving you to guess.
 
-!!! note "Why register the views you care about"
+This is also the practical reason to register the views you care about: plain unregistered fns render under the fallback key `[:rf.view/anonymous nil]` — a registered `reg-view` is what gives a render a *name* in the trace. All of this sits behind the dev-build gate and [elides](../glossary.md#elide) completely in production.
 
-    Plain unregistered fns render under the fallback key `[:rf.view/anonymous nil]` — a registered `reg-view` is what gives a render a *name* in the trace. All of this sits behind the dev-build gate and [elides](../glossary.md#elide) completely in production.
+A view is a pure function from subscription values to hiccup. That's the whole job: show the room, pass along the knocks, keep nothing. Everything interesting happens on the other side of the glass — and the rest of this guide is about that side.

--- a/docs/core/derivations-and-algebra-views.md
+++ b/docs/core/derivations-and-algebra-views.md
@@ -1,16 +1,16 @@
 # One graph: derivations and their algebra views
 
-You're reading a re-frame2 app you didn't write. A tool has just drawn its dependency graph — subscriptions, a flow, a resource cache, a machine — as one picture, and you want to know what you're looking at. This page is the model that makes the picture legible. It fits in one sentence:
+Everything flows; nothing stands still. Heraclitus said that, around 500 BC — a man who, being Greek, had never seen a frozen river — and it is still the best one-line description of a re-frame2 app.
 
-!!! note
+Here's the scene this page exists for. You're reading a re-frame2 app you didn't write. A tool has just drawn its dependency graph — subscriptions, a flow, a resource cache, a machine — as one picture, and you want to know what you're looking at. This page is the model that makes the picture legible, and the model fits in one sentence:
 
-    **A subscription, a flow, a resource, and a machine are the same thing seen four ways** — one node in one dependency graph rooted at your state, distinguished only by *where its value is kept* and *when it's recomputed*.
+**A subscription, a flow, a resource, and a machine are the same thing seen four ways** — one node in one dependency graph rooted at your state, distinguished only by *where its value is kept* and *when it's recomputed*.
 
-You don't need this page to *write* an app. [Where should this value live?](where-state-lives.md) routes any value to the right home with four questions and no theory. This page is for *reading* apps — yours six months from now, or somebody else's tomorrow — when the graph a tool draws has to make sense without opening every source file.
+One thing before we start, so nobody sits through theory they don't need: you don't need this page to *write* an app. [Where should this value live?](where-state-lives.md) routes any value to the right home with four questions and no theory. This page is for *reading* apps — yours six months from now, or somebody else's tomorrow — when the graph a tool draws has to make sense without opening every source file.
 
 ## Start with a spreadsheet
 
-The anchor here is a spreadsheet. Every cell is either an entered value or a formula over other cells, and the engine recalculates exactly the cells downstream of an edit. That's the whole idea: a value declares its inputs, and it recomputes when those inputs move.
+The anchor here is a spreadsheet — the same one the [subscriptions](concepts/subscriptions.md) page told you to hold onto, now asked to carry the whole framework. Every cell is either an entered value or a formula over other cells, and the engine recalculates exactly the cells downstream of an edit. That's the whole idea. A value declares its inputs, and it recomputes when those inputs move.
 
 re-frame2's [subscriptions](concepts/subscriptions.md) are exactly spreadsheet cells. (A subscription is the read side of your app: a *derivation* — a value computed from other values by a pure function, which is all "derivation" means anywhere on this page.) You write a formula; the framework recomputes it when its inputs change; you never recompute it by hand.
 
@@ -18,9 +18,9 @@ re-frame2's [subscriptions](concepts/subscriptions.md) are exactly spreadsheet c
 
     The JS world rediscovered the spreadsheet as the **signals graph** — `createMemo`, `computed`, signals — where a derived value declares its inputs and recomputes when those inputs move. A re-frame2 subscription is one of those derived signals. If you've reached for `useMemo` to avoid recomputing a value on every render, you already have the intuition: declare the inputs, let the framework decide when to recompute.
 
-This page adds one bigger claim, and it's the deliberate divergence from the signals world: **flows, resources, route state, and machines are nodes in the same graph.** A flow is a cell that writes its result back into the sheet. A resource is a cell whose authoritative value lives on a server — locally you hold a copy that can go stale. A machine is a cell with memory, where its next value depends on its current one. The signals ecosystem never wrote that unification down as one model; re-frame2 does.
+This page adds one bigger claim, and it's the deliberate divergence from the signals world: **flows, resources, route state, and machines are nodes in the same graph.** A flow is a cell that writes its result back into the sheet. A resource is a cell whose authoritative value lives on a server — locally you hold a copy that can go stale. A machine is a cell with memory, where its next value depends on its current one. The signals ecosystem never wrote that unification down as one model. re-frame2 does.
 
-re-frame2 calls this model the **derivation/process algebra**. Don't let "algebra" summon high-school equations — here it just means *a small fixed set of node kinds plus rules for how they combine into a graph*, the same sense in which "relational algebra" is the handful of operations you compose into a SQL query. The payoff is that one vocabulary describes every node; this page is the tour.
+re-frame2 calls this model the **derivation/process algebra**. Don't let "algebra" summon high-school equations — here it just means *a small fixed set of node kinds plus rules for how they combine into a graph*, the same sense in which "relational algebra" is the handful of operations you compose into a SQL query. The payoff is that one vocabulary describes every node. This page is the tour.
 
 ## The keystone: one function, two policies
 
@@ -49,15 +49,19 @@ Here's the example that makes the whole idea click — a cart total, expressed t
 | When it recomputes | when something reads it | after each event, in that event's commit |
 | Who keeps it alive | a subscription-cache entry | the frame |
 
-The subscription stores nothing and recomputes on demand. The [flow](concepts/flows.md) stores its answer into [app-db](glossary.md#app-db) (your app's single immutable state map) and recomputes after each event. The math is identical; the *policy over the graph* is what differs.
+The subscription stores nothing and recomputes on demand — a formula cell. The [flow](concepts/flows.md) stores its answer into [app-db](glossary.md#app-db) (your app's single immutable state map) and recomputes after each event — a cell that writes its result back into the sheet. The math is identical; the *policy over the graph* is what differs.
 
-That's the entire reason the algebra exists. Hold onto this one sentence and the rest of the page is just extending it across the other homes:
+That's the entire reason the algebra exists:
 
 > The difference between a subscription and a flow is **not the function; it is policy over the same dependency graph.**
 
+I'll pause while you read that sentence again. That's the whole page, right there — everything below is that sentence, visiting the other homes.
+
 ## The five questions every node answers
 
-Every declared fact in re-frame2 — subscription, flow, resource read, route fact, machine selector — answers the *same five questions*. Learn to ask these five of any node and you can read any graph:
+Every declared fact in re-frame2 — subscription, flow, resource read, route fact, machine selector — answers the *same five questions*. Not five per family. Five, total, across every node kind a tool will ever draw for you: a plain sub, a flow writing back into the sheet, a resource mid-fetch, a machine mid-transition, the route sitting in your user's address bar. Learn to ask these five of any node and you can read any graph in any re-frame2 app — yours, your team's, the ones that haven't been written yet. **Any of them.**
+
+Too much? Only slightly. Further down you'll meet *refinements* and some diagnostic dressing, but they only ever add colour to a node — never a sixth question. Here are the five:
 
 | Question | Field | Example answers |
 |---|---|---|
@@ -83,7 +87,7 @@ That's the whole vocabulary. The five source forms you actually write — `reg-s
 
 ## One node, opened up
 
-Here's the complete algebra view of that cart subscription — the shape every node in an inspected graph has. Don't memorize it; just see that it's the five questions plus some labelling and diagnostics:
+Here's the complete algebra view of that cart subscription — the shape every node in an inspected graph has. Don't memorize it. Just see that it's the five questions plus some labelling and diagnostics:
 
 ```clojure
 {:id          :cart/total
@@ -103,17 +107,17 @@ Here's the complete algebra view of that cart subscription — the shape every n
  :source      {:ns "app.cart" :file "src/app/cart.cljs" :line 42}}
 ```
 
-Three fields earn a comment:
+Notes:
 
-- **`:kind`** is one of exactly two closed superkinds — `:derivation` or `:process`. A tool that understands only those two can still classify every node.
-- **`:refinement`** carries the finer labels you'll meet below (`:resource-process`, `:route-fact`, `:machine-process`, `:machine-selector`). They never live in `:kind`, so a refinement always refines its node's superkind and never invents a third one.
-- **`:derive`** is an opaque token. (`#'app.cart/sum-cart` is Clojure's var-quote — a reference *to* the function named `sum-cart`, not the function's source code.) The graph contract is about dependencies, storage, evaluation, and ownership; it never requires serializing your functions.
+1. **`:kind`** is one of exactly two closed superkinds — `:derivation` or `:process`. A tool that understands only those two can still classify every node.
+2. **`:refinement`** carries the finer labels you'll meet below (`:resource-process`, `:route-fact`, `:machine-process`, `:machine-selector`). They never live in `:kind`, so a refinement always refines its node's superkind and never invents a third one.
+3. **`:derive`** is an opaque token. (`#'app.cart/sum-cart` is Clojure's var-quote — a reference *to* the function named `sum-cart`, not the function's source code.) The graph contract is about dependencies, storage, evaluation, and ownership; it never requires serializing your functions.
 
 The trailing fields — `:schema` (the output's Malli [schema](glossary.md#schema)), `:source` (namespace / file / line), plus a doc string — are the **diagnostic dressing**. They're optional; a node with none of them is still a complete node. But a good graph carries them, because "where is this defined and what shape does it produce?" is exactly the question a reader of an unfamiliar app asks first.
 
 ### Parametric nodes and the don't-execute rule
 
-So far the subscription's inputs were fixed. But some subscriptions compute their inputs from the [query vector](glossary.md#query-vector) — `[:article/page "welcome"]` reads a different article than `[:article/page "intro"]`. The static graph can't know those edges before a concrete query exists, **and it must not guess**. So it reports `:parametric` and names the producer; the live graph reports the realized edges once a real query is in play:
+Now, I haven't been entirely straight with you. So far the subscription's inputs were fixed, and I've let you believe they always are. But some subscriptions compute their inputs from the [query vector](glossary.md#query-vector) — `[:article/page "welcome"]` reads a different article than `[:article/page "intro"]`. The static graph can't know those edges before a concrete query exists, **and it must not guess**. So it reports `:parametric` and names the producer; the live graph reports the realized edges once a real query is in play:
 
 ```clojure
 ;; STATIC — derived from registrations alone
@@ -140,7 +144,7 @@ This is the **don't-execute rule**: static inspection never runs your input, par
 
 Subscriptions and flows are derivations — pure formulas. Now we cross into **processes**: nodes that carry state, have a lifecycle, and run commands over time. The first one is the **resource**.
 
-A resource is a fact whose authoritative value lives on a server, with a local cached copy ([Server state: resources](../resources/concepts.md)). Here's the wrinkle that makes resources more than a fancy subscription: one `reg-resource` declaration lowers to *more than one* node — a process node for the cache entry, plus its read selectors (`:rf.resource/state`, `:rf.resource/data`, `:rf.resource/loading?`, …), each an ordinary on-demand derivation over that entry. Reading a selector never starts work; it just reads the cache.
+A resource is a fact whose authoritative value lives on a server, with a local cached copy ([Server state: resources](../resources/concepts.md)). Here's the wrinkle that makes resources more than a fancy subscription: one `reg-resource` declaration lowers to *more than one* node — a process node for the cache entry, plus its read selectors (`:rf.resource/state`, `:rf.resource/data`, `:rf.resource/loading?`, …), each an ordinary on-demand derivation over that entry. Reading a selector never starts work. It just reads the cache.
 
 ```clojure
 ;; STATIC ALGEBRA VIEW of (rf/reg-resource :article/by-slug {…})
@@ -159,11 +163,7 @@ A resource is a fact whose authoritative value lives on a server, with a local c
                :rf.resource/loading? :rf.resource/error :rf.resource/has-data?]}
 ```
 
-The view makes a split explicit that folklore usually muddles. **`:storage` always names the local home** — here, the runtime-db cache entry. **`:authority` names whose fact it really is** — an external server.
-
-!!! warning "Gotcha — 'remote' is not a storage class"
-
-    This is the one place people reliably tie themselves in knots. Locally you *always* hold a representation; the truth living on a server doesn't move it out of your `:storage`. So `:storage` is `:runtime-db` (where your copy sits) and `:authority` is the remote server (whose fact it is) — two separate axes, never collapsed into one. A graph that printed "storage: remote" would be telling you nothing about where the bytes actually are.
+The view makes a split explicit that folklore usually muddles — and it's the one place people reliably tie themselves in knots, so hear it plainly. **`:storage` always names the local home** — here, the runtime-db cache entry. **`:authority` names whose fact it really is** — an external server. "Remote" is not a storage class. Locally you *always* hold a representation; the truth living on a server doesn't move it out of your `:storage`. So `:storage` is `:runtime-db` (where your copy sits) and `:authority` is the remote server (whose fact it is) — two separate axes, never collapsed into one. A graph that printed "storage: remote" would be telling you nothing about where the bytes actually are.
 
 ??? info "Coming from TanStack Query?"
 
@@ -175,7 +175,7 @@ The view makes a split explicit that folklore usually muddles. **`:storage` alwa
 
 ### Buying back static visibility: named resolvers
 
-The don't-execute rule says static inspection won't *run* your scope function — so a resource scoped by an inline `(fn [route ctx] …)` reports the opaque marker `[:scope :rf.scope/resolver]` and nothing more. But there's an escape hatch that buys back static visibility: a **named scope resolver**. Declare the scope as a data reference — `{:from-db :session/current-tenant}` instead of an inline function — and the resolver's *declared inputs* are themselves declarations, so the static graph can read them without running anything:
+The don't-execute rule has a price. Static inspection won't *run* your scope function — so a resource scoped by an inline `(fn [route ctx] …)` reports the opaque marker `[:scope :rf.scope/resolver]` and nothing more. Fair enough. But there's an escape hatch that buys back static visibility: a **named scope resolver**. Declare the scope as a data reference — `{:from-db :session/current-tenant}` instead of an inline function — and the resolver's *declared inputs* are themselves declarations, so the static graph can read them without running anything:
 
 ```clojure
 ;; STATIC ALGEBRA VIEW — named-resolver scope
@@ -189,15 +189,11 @@ The don't-execute rule says static inspection won't *run* your scope function �
  :params      :parametric}
 ```
 
-The lesson generalizes, and it's the trade the whole algebra makes:
-
-!!! note
-
-    **Declaring a dependency as *data*, rather than burying it in a function body, is what lets a tool see it before the app runs.** An inline function is opaque to static analysis on purpose; a named, data-described resolver hands the same information to the graph for free. The more you say in data, the more a tool can answer without executing you.
+The lesson generalizes, and it's the trade the whole algebra makes: **declaring a dependency as *data*, rather than burying it in a function body, is what lets a tool see it before the app runs.** An inline function is opaque to static analysis on purpose; a named, data-described resolver hands the same information to the graph for free. The more you say in data, the more a tool can answer without executing you.
 
 ### Machines: a node with memory
 
-A [machine](../machines/glossary.md#machine) is the algebra's canonical process — a stateful node whose *next* value depends on its *current* one. It's the feature that motivates the `:process` superkind in the first place: a pure derivation can't depend on its own previous value, so a machine simply isn't expressible as one. Its [snapshot](../machines/glossary.md#snapshot) is durable runtime-db state, written only by its own transitions.
+A [machine](../machines/glossary.md#machine) is the algebra's canonical process — a cell with memory, a stateful node whose *next* value depends on its *current* one. It's the feature that motivates the `:process` superkind in the first place: a pure derivation can't depend on its own previous value, so a machine simply isn't expressible as one. Its [snapshot](../machines/glossary.md#snapshot) is durable runtime-db state, written only by its own transitions.
 
 The view, side by side with one of its selectors:
 
@@ -229,7 +225,9 @@ That `:checkout/progress` selector's algebra view is an `:ephemeral`, `:on-deman
 
 ### Routes: the same fact, every route
 
-A route lowers the same way, with a twist worth pausing on: every route materializes the *same* route fact — `:rf/route`, the one consumer-facing name for the route slice in runtime-db — with the per-route id recorded in `:source-form` and evaluation `:on-route`. Its `:inputs` are the framework route-transition events (`:rf.route/navigate`, `:rf.route/transitioned`, `:rf.route/handle-url-change`), the same across every route, because the same events materialize the slice no matter which route matched. Forty routes, one fact.
+A route lowers the same way, with a twist worth pausing on: every route materializes the *same* route fact — `:rf/route`, the one consumer-facing name for the route slice in runtime-db — with the per-route id recorded in `:source-form` and evaluation `:on-route`. Its `:inputs` are the framework route-transition events (`:rf.route/navigate`, `:rf.route/transitioned`, `:rf.route/handle-url-change`), the same across every route, because the same events materialize the slice no matter which route matched.
+
+Forty routes. One fact.
 
 A route's `:resources` declaration becomes a route-owned **activation edge** into the resource it ensures ([Routing: the URL is a sub](../routing/concepts.md)):
 
@@ -284,7 +282,7 @@ To see one live, open [Xray](glossary.md#xray) on a running app. The panel that 
 
 ## When the graph is wrong: errors as graph facts
 
-Reading a healthy graph is the common case. But the algebra also shapes how the framework reports an *unhealthy* one — and because errors are attributed to **graph identities** rather than to low-level functions, the diagnostics line up with the same node vocabulary you've been reading. When something goes wrong, the framework tells you *which node* and *which axis*, not just which function threw. The cases worth recognizing:
+Reading a healthy graph is the common case. But the algebra also shapes how the framework reports an *unhealthy* one — and because errors are attributed to **graph identities** rather than to low-level functions, the diagnostics speak the same node vocabulary you've been reading all page. When something goes wrong, the framework tells you *which node* and *which axis*, not just which function threw. The cases worth recognizing:
 
 - **Unknown input fact** — a derivation declares an input (`[:sub …]`, `[:db …]`, `[:resource …]`) that names a fact nothing produces. The graph has a dangling edge; the framework [fails loud](glossary.md#fail-loud-not-silent) rather than silently feeding `nil`.
 - **Cycle in an acyclic graph** — a flow whose inputs depend, transitively, on its own output. Flows are topologically sorted before they drain, so a cycle is a registration-time error (`:rf.error/flow-cycle`, thrown by `reg-flow` *before* any snapshot is created), not a hang at runtime. The error even carries the offending chain — a `:cycle` vector with a closing repeat, `[:a :b :a]` for `:a → :b → :a` — which a tool like Xray renders verbatim. (Subscriptions tolerate some shapes flows can't, because a flow must reach a fixed point inside one commit; the subscription graph stays dynamic at the view boundary and has no registration-time cycle gate.)
@@ -330,3 +328,5 @@ You don't memorize the tables. You carry the sentence the keystone example prove
 > A subscription, a flow, a resource, a route fact, and a machine are the same dependency-graph node under different **storage** and **evaluation** policies. The source forms differ for good ergonomic reasons; the algebra view is what they share.
 
 When you just want to pick a home for a value, ask the four questions in [Where should this value live?](where-state-lives.md). This page is what sits underneath that router: *why* the four homes are four faces of one idea.
+
+Everything flows; nothing stands still — and now you can read the picture. Derived data, flowing.

--- a/docs/core/explanation/inside-out.md
+++ b/docs/core/explanation/inside-out.md
@@ -1,6 +1,6 @@
 # Inside out: why views come last
 
-This page is the argument, not the instructions. You don't need it to build with re-frame2 — the working mental model lives in [The model: the event pipeline](../introduction.md), and you can ship without ever reading this essay. But re-frame2 asks something of you up front. It costs ceremony a `useState` user never pays, and it forbids things React happily allows. You deserve the case for that trade, made once, in full. Every concepts page that touches it links back here rather than re-arguing it.
+This page is the argument, not the instructions. The working mental model lives in [The model: the event pipeline](../introduction.md), and you can ship without ever reading this essay. But re-frame2 asks something of you up front — it costs ceremony a `useState` user never pays, and it forbids things React happily allows — and I'd rather make the case for that trade once, in full, than have you take it on faith. Every concepts page that touches it links back here rather than re-arguing it.
 
 The whole essay compresses to one sentence:
 
@@ -8,17 +8,19 @@ The whole essay compresses to one sentence:
 
 The first half is uncontroversial — of course the language you compute in should be able to express anything. The surprising half is the second: deliberately *withholding* that full power from the shape your app's behaviour flows through, and getting something valuable back in return. That trade is the whole argument, and we'll earn it slowly rather than assert it.
 
-The rest of this page unpacks it — one idea at a time, each building on the last. We start with the problem the inversion solves, state the inversion itself, then cash out what it buys and what it honestly costs.
+The route: the problem the inversion solves, then the inversion itself, then what it buys, then what it honestly costs.
 
 ## The gravity well: ten years of React state management
 
-For about a decade, the React world has organised itself around one centre: the component. State lives in the component, in a `useState`. Data fetching lives in the component, in a `useEffect`. Store subscriptions are a `useSelector`, another hook in the component. Everything orbits the component.
+For about a decade, the React world has organised itself around one centre of mass: the component. State lives in the component, in a `useState`. Data fetching lives in the component, in a `useEffect`. Store subscriptions are a `useSelector` — another hook, in the component. Everything orbits the component.
 
-Here's the part worth dwelling on. Most people already sense this is a problem. The history of React state management is a long run of attempts to get state *out* of the component tree. Redux arrived in 2015 and said: one store, off to the side, pure reducers. That was the right instinct. Then the ecosystem spent five years migrating the Redux bits back into hooks — `useReducer`, `useContext`, "co-location." MobX, Zustand, Recoil, Jotai, signals, server components: each one is, in the end, another way to bolt state back onto the component tree.
+Here's the part worth dwelling on: most people already sense this is a problem. The history of React state management is a long run of escape attempts — attempt after attempt to get state *out* of the component tree. Redux reached escape velocity in 2015: one store, off to the side, pure reducers. That was the right instinct. Then the ecosystem spent five years hauling the Redux bits back down into hooks — `useReducer`, `useContext`, "co-location." MobX, Zustand, Recoil, Jotai, signals, server components: each one a fresh trajectory, and each one, in the end, another way to bolt state back onto the component tree. At this rate the flagship 2030 state library will be a hook that keeps your state in the component but feels bad about it.
 
-This isn't carelessness, and it isn't a failure of taste. The component tree is the thing the framework can see, so the component tree is where everything ends up living. But in a mature app the consequence is real, and you've probably felt it. "Where does this piece of state live?" gets answered "somewhere in a tree of three hundred components, possibly four of them, possibly out of sync between two of them." "What changed it?" is a shrug and a debugger session.
+Too glib? A little. Because this isn't carelessness, and it isn't a failure of taste — the people building these libraries are excellent engineers. The component tree is the thing the framework can see, so the component tree is where everything ends up living. The pull is structural. That's why this section is called what it's called: the component is a **gravity well**, and no amount of discipline beats gravity indefinitely.
 
-re-frame — the 2015 original this framework is the sequel to — looked at that pull and declined to follow it inward.
+In a mature app the consequence is real, and you've probably felt it. "Where does this piece of state live?" gets answered "somewhere in a tree of three hundred components. Possibly four of them. Possibly out of sync between two of them." "What changed it?" is a shrug and a debugger session.
+
+re-frame — the 2015 original this framework is the sequel to — looked at that pull and declined to fall in.
 
 ## The inversion: state in one place, views last
 
@@ -30,6 +32,8 @@ There is exactly one container of application state: [**app-db**](../glossary.md
 
 Notice what dissolves. There is no "lifting state up," because state was never down in the components in the first place — there is nothing to lift. A view is a render function from subscription values to [**hiccup**](../glossary.md#hiccup), and that is its entire job. It doesn't start anything. It doesn't fetch. It doesn't own anything. Nothing *originates* in a view — it's derived from state, not the home of it.
 
+That's the climb out of the well. The component stops being the centre of mass and becomes the last stop on a pipeline that starts somewhere else.
+
 ??? info "For JavaScript developers"
 
     Map the pipeline onto what you already run in your head. The **event** is your action object. The **event handler** is your reducer — but with effects pulled out of it. The **subscription** is your selector. The **view** is your component, minus everything except the `return`. The unfamiliar move isn't any one of those pieces; it's that re-frame2 takes the pieces that normally live *inside* the component — the dispatch wiring, the selectors, the data-fetching effect — and lifts every one of them *out*, so the component is left with nothing to do but render. The callout below makes the analogy precise for Redux users.
@@ -40,11 +44,11 @@ Notice what dissolves. There is no "lifting state up," because state was never d
 
 ## Boring views are the point
 
-This is the part that surprises every React-shaped brain on first contact, so don't be thrown by it. Your views are going to be boring. Structurally boring. Can't-get-into-a-weird-state boring. That isn't a limitation the framework apologises for — it's the design objective. The most bug-prone real estate in a typical frontend is where state, effects, and rendering tangle together inside components, and re-frame2 simply evicts all of it. Views render, and that's the whole story.
+This is the part that surprises every React-shaped brain on first contact, so don't be thrown by it. Your views are going to be boring. Structurally boring. Can't-get-into-a-weird-state boring. That isn't a limitation the framework apologises for — it's the design objective. The most bug-prone real estate in a typical frontend is where state, effects, and rendering tangle together inside components, and re-frame2 simply evicts the lot. Views render. That's the whole story.
 
-The reason this matters: a boring view can't be the source of a state bug, because it's downstream of everything and decides nothing. So when the screen is wrong, the cause is in an event handler or a subscription — and those are pure functions you can test with plain data, no DOM required.
+Why does that matter? A boring view can't be the source of a state bug, because it's downstream of everything and decides nothing. So when the screen is wrong, the cause is in an event handler or a subscription — and those are pure functions you can test with plain data, no DOM required.
 
-That last sentence is the whole payoff, so it's worth making concrete rather than leaving as a promise. Here is the entire causal machinery behind a counter that increments. Two pieces of vocabulary it leans on, defined once so the code reads clean: a handler receives a [**coeffects**](../glossary.md#coeffect) map — the facts it's allowed to see, with the current app-db under `:db` — and returns an [**effect map**](../glossary.md#effect-map), a description of what should change, with the next app-db under `:db`. In short: data in, data out, and the runtime does the actual mutating.
+That's worth cashing out rather than leaving as a promise. Here is the entire causal machinery behind a counter that increments. Two pieces of vocabulary it leans on, defined once so the code reads clean: a handler receives a [**coeffects**](../glossary.md#coeffect) map — the facts it's allowed to see, with the current app-db under `:db` — and returns an [**effect map**](../glossary.md#effect-map), a description of what should change, with the next app-db under `:db`. In short: data in, data out, and the runtime does the actual mutating.
 
 ```clojure
 ;; The event handler: (coeffects, event) → effect map. Pure.
@@ -75,19 +79,16 @@ Neither of those touches the DOM, a clock, the network, or a component. So neith
     (is (= 6 (handler {:counter/value 6} [:counter/value])))))
 ```
 
-That's the boring-view dividend cashed out. The two functions that *decide* anything are testable with maps and vectors; the view that *decides nothing* doesn't need a test of its own at all. [Test an event handler](../testing/event-handlers.md) walks the pattern in full; [the pipeline](../introduction.md) shows the same two functions in their runtime habitat.
+That's the boring-view dividend, cashed out. The two functions that *decide* anything are testable with maps and vectors; the view that *decides nothing* doesn't need a test of its own at all. [Test an event handler](../testing/event-handlers.md) walks the pattern in full; [the pipeline](../introduction.md) shows the same two functions in their runtime habitat.
 
 ??? info "For JavaScript developers"
 
     Compare the React version, where the increment, the state it lives in, and the render are the same component — to test the increment logic you must mount the component and simulate a click, because the logic has no existence apart from the component. Here the logic *is* a plain function with a name in a registry, so the test is a function call with two literals. That's the difference between testing behaviour and testing a rendering of behaviour.
 
-!!! note "Where does `handler-meta` come from?"
+Notes:
 
-    It reads the registry back — given a kind (`:event`, `:sub`, …) and an id, it hands back the registration map, whose `:handler-fn` is your function. You rarely reach for it outside tests, because in an app the runtime looks handlers up for you; its reason to be public is that "test it as a plain function" is a first-class promise, not a hack.
-
-!!! warning "Gotcha — a typo'd id returns `nil`, not a clean error"
-
-    `handler-meta` returns `nil` for an id it doesn't know, so `(:handler-fn nil)` is also `nil`, and the *next* line blows up with "nil is not a function" rather than "no such handler." If a handler you *know* you registered comes back `nil`, suspect the id spelling or a missing `:require`.
+1. Where does `handler-meta` come from? It reads the registry back — given a kind (`:event`, `:sub`, …) and an id, it hands back the registration map, whose `:handler-fn` is your function, exactly as you wrote it. You'll rarely reach for it outside tests, because in an app the runtime looks handlers up for you; it's public because "test it as a plain function" is a first-class promise, not a hack.
+2. One gotcha, and it bites everyone exactly once: `handler-meta` returns `nil` for an id it doesn't know, so `(:handler-fn nil)` is also `nil`, and the *next* line blows up with "nil is not a function" rather than "no such handler." If a handler you *know* you registered comes back `nil`, suspect the id spelling or a missing `:require`.
 
 ## Why your architecture shouldn't be Turing complete
 
@@ -119,21 +120,19 @@ Now the honest part, because it's only fair to put it plainly. A counter in plai
 
     Inside a re-frame2 app, though, "does *this* value go in app-db or stay a `useState`?" is a real per-value judgment, and this page argues only the default (app-db, for the reasons above). The full placement rule — the default, the tightly-worded render-mechanical exception (uncommitted IME composition, transient focus/hover, animation interpolation), and the forbidden tier (anything a handler, sub, schema, or tool reads) — lives in [Spec 004 §Where ephemeral view-state lives](https://github.com/day8/re-frame2/blob/main/spec/004-Views.md), which owns it.
 
-The ceremony is a fixed cost per feature. The claim is that it amortises: the same shape that feels like bureaucracy at thirty lines is the only thing keeping you sane at thirty thousand. That claim needs to be specific to be believable, so here it is.
+The ceremony is a fixed cost per feature — the price of keeping state out of the well. The claim is that it amortises: the same shape that feels like bureaucracy at thirty lines is the only thing keeping you sane at thirty thousand. A claim like that needs to be specific to be believable, so here it is, made specific.
 
 ## The bounded-cost claim
 
 **The cost of adding a feature is bounded by the size of the feature, not the size of the app.**
 
-Sit with that, because it's the opposite of how most codebases age. In a normally-shaped app, adding a feature means first reading a large fraction of the existing code: which components own the relevant state, which effects might fire, what will break. The marginal cost of a feature grows with the app — that's the slow death every large frontend eventually circles. In a re-frame2 app you read the events, the subscriptions, and the one view that touches the area you're changing. That is *enough*, because there's nowhere else for the relevant logic to hide. State is in one place. Changes happen in one place. Effects are described as data in one place. The architecture can't sprout new kinds of place, because it isn't Turing complete.
+I'll pause while you read that again. It's the sentence this essay exists to earn, and it's the opposite of how most codebases age. In a normally-shaped app, adding a feature means first reading a large fraction of the existing code: which components own the relevant state, which effects might fire, what will break. The marginal cost of a feature grows with the app — that's the slow death every large frontend eventually circles. In a re-frame2 app you read the events, the subscriptions, and the one view that touches the area you're changing. That is *enough*, because there's nowhere else for the relevant logic to hide. State is in one place. Changes happen in one place. Effects are described as data in one place. The architecture can't sprout new kinds of place, because it isn't Turing complete.
 
 The boundedness isn't a vibe; it's structural, and you can name the reason. Because state lives only in [app-db](../concepts/app-db.md) and changes only through registered event handlers, the set of things that can mutate your feature's slice is *enumerable* — it's exactly the handlers that write that path, and a grep finds all of them. There is no fifth component three screens away quietly reaching into the same `useState` through a context provider, because there is no such mechanism to reach with. The question "what can change this?" has a finite, searchable answer. In a component-tree app it does not.
 
 That's what the ceremony buys. Not elegance — boundedness.
 
-!!! warning "Gotcha"
-
-    "A grep finds all of them" only holds if a *miss* is loud. So re-frame2 [fails loud, not silent](../glossary.md#fail-loud-not-silent): when it recognises a value as input but can't honour it, it raises a structured [error record](../glossary.md#error-record) keyed by a reserved `:rf.error/*` category — never a `nil` or a no-op. Dispatch an id nobody registered and you get `:rf.error/no-such-handler` (the trace names the exact id), not a button that silently does nothing. Return an effect for an fx-id nobody registered and you get `:rf.error/no-such-fx`. Declare a coeffect with no supplier and the requirement fails with `:rf.error/unregistered-cofx` *before* the handler runs. Return an effect map with a stray top-level key beyond `:db`/`:fx` and you get `:rf.error/effect-map-shape` — the bad key is named and dropped, your `:db` still lands. The point isn't the catalogue — it's that a typo can't smuggle in a new "place" where state hides; it surfaces as a named failure at the boundary. [Errors](../concepts/errors.md) is the full catalogue and the branch-on-category discipline.
+One thing has to hold for "a grep finds all of them" to be true, so hear it now: a *miss* must be loud. re-frame2 therefore [fails loud, not silent](../glossary.md#fail-loud-not-silent): when it recognises a value as input but can't honour it, it raises a structured [error record](../glossary.md#error-record) keyed by a reserved `:rf.error/*` category — never a `nil` or a no-op. Dispatch an id nobody registered and you get `:rf.error/no-such-handler` (the trace names the exact id), not a button that silently does nothing. Return an effect for an fx-id nobody registered and you get `:rf.error/no-such-fx`. Declare a coeffect with no supplier and the requirement fails with `:rf.error/unregistered-cofx` *before* the handler runs. Return an effect map with a stray top-level key beyond `:db`/`:fx` and you get `:rf.error/effect-map-shape` — the bad key is named and dropped, your `:db` still lands. The point isn't the catalogue — it's that a typo can't smuggle in a new "place" where state hides; it surfaces as a named failure at the boundary. [Errors](../concepts/errors.md) is the full catalogue and the branch-on-category discipline.
 
 ??? note "Going deeper"
 
@@ -149,12 +148,15 @@ Circle back to the React question this essay opened on — *"what changed this p
 
 [Observability: one wire, every tool](../concepts/observability.md) is the full tour.
 
-!!! note "Two honest limits on the wire"
+Notes — two honest limits on the wire:
 
-    First, the rich trace wire is production-[elided](../glossary.md#elide): the whole emit substrate sits behind a `goog.DEBUG` gate (the JVM mirror is `-Dre-frame.debug`) that the Closure compiler dead-code-eliminates in `:advanced` builds. What you ship to users keeps a separate, deliberately smaller channel — two always-on streams (`:events` and `:errors`) that survive elision — so production tells you *that* an event ran and *whether* it failed, without the rich per-stage detail (db snapshots, render args, derivation values) the dev trace carries. Build your monitoring on the always-on streams. Second, revertibility ends at the effect boundary: the framework can rewind its own state perfectly, but it cannot un-send an HTTP request. The world is compensated, never reversed.
+1. The rich trace wire is production-[elided](../glossary.md#elide): the whole emit substrate sits behind a `goog.DEBUG` gate (the JVM mirror is `-Dre-frame.debug`) that the Closure compiler dead-code-eliminates in `:advanced` builds. What you ship to users keeps a separate, deliberately smaller channel — two always-on streams (`:events` and `:errors`) that survive elision — so production tells you *that* an event ran and *whether* it failed, without the rich per-stage detail (db snapshots, render args, derivation values) the dev trace carries. Build your monitoring on the always-on streams.
+2. Revertibility ends at the effect boundary. The framework can rewind its own state perfectly, but it cannot un-send an HTTP request. The world is compensated, never reversed.
 
 ## When not to use it
 
-!!! note "Pre-alpha, and there's a floor below which this doesn't pay"
+Honest to the last, then.
 
-    re-frame2's contracts are still settling, and this guide says so wherever it matters. Beyond that, the architecture has a floor. A static content site, a single embedded widget, a weekend prototype you'll throw away — the loop pays for itself only when the app outgrows the loop, and those don't. And if your team is committed to component-local state as a philosophy, this framework will feel like swimming upstream the entire time, because it is. The current flows the other way here, on purpose.
+re-frame2 is pre-alpha. Its contracts are still settling, and this guide says so wherever it matters.
+
+Beyond that, the architecture has a floor. A static content site, a single embedded widget, a weekend prototype you'll throw away — the loop pays for itself only when the app outgrows the loop, and those don't. And if your team is committed to component-local state as a philosophy, this framework will feel like swimming upstream the entire time, because it is. The current flows the other way here, on purpose.

--- a/docs/core/how-to/add-auth.md
+++ b/docs/core/how-to/add-auth.md
@@ -45,11 +45,7 @@ A page reload throws away app-db, so to stay logged in across refreshes the toke
         (.removeItem ls "auth-token")))))
 ```
 
-One [effect handler](../glossary.md#effect-handler), two behaviours, called from exactly one place each. That `:platforms #{:client}` is doing real work — see the next callout.
-
-!!! warning "Gotcha — this effect is client-only"
-
-    Under [SSR](../../ssr/glossary.md#ssr) there is no `localStorage`, so a session rides an http-only cookie instead. The effect is declared `:platforms #{:client}` for exactly this reason — the registration exists everywhere, but on a server drain the runtime *skips* the row, leaving a `:rf.fx/skipped-on-platform` trace instead of crashing on a missing `localStorage`.
+One [effect handler](../glossary.md#effect-handler), two behaviours, called from exactly one place each. And that `:platforms #{:client}` is doing real work. Under [SSR](../../ssr/glossary.md#ssr) there is no `localStorage` — a session rides an http-only cookie instead — so the effect is declared client-only: the registration exists everywhere, but on a server drain the runtime *skips* the row, leaving a `:rf.fx/skipped-on-platform` trace instead of crashing on a missing `localStorage`.
 
 !!! note
 
@@ -59,7 +55,7 @@ One [effect handler](../glossary.md#effect-handler), two behaviours, called from
 
 Persisting is half the seam; reading the value *back* when the app reboots is the other half. Skip the boot read and every refresh silently logs the user out.
 
-But there's a rule in the way. An [event handler](../glossary.md#event-handler) is pure, and reading `localStorage` is reaching out to the world — so the handler can't do it directly. The escape hatch is a [coeffect](../glossary.md#coeffect): a declared input the framework supplies *before* the handler runs, so the handler stays pure ([Coeffects](../concepts/coeffects.md) owns the full story). A handler that wants the saved token declares it under `:rf.cofx/requires`.
+But there's a rule in the way. An [event handler](../glossary.md#event-handler) is pure, and reading `localStorage` is reaching out to the world. Handlers that reach out to the world are like a well salted paper cut — we try hard to avoid them. The escape hatch is a [coeffect](../glossary.md#coeffect): a declared input the framework supplies *before* the handler runs, so the handler stays pure ([Coeffects](../concepts/coeffects.md) owns the full story). A handler that wants the saved token declares it under `:rf.cofx/requires`.
 
 Now the auth-specific wrinkle: *which kind* of coeffect this is. Coeffects come in [two grades](../glossary.md#recordable-vs-ambient-coeffects). An *ambient* one is read live and re-read on every replay — fine for a display hint, fatal here. The saved token folds into durable `[:auth :token]`, and anything that feeds a durable write must arrive as **recorded data**: captured once, re-presented verbatim under replay. An ambient read would let an epoch-restore land *whatever `localStorage` holds now*, not the token recorded with the boot.
 
@@ -130,7 +126,7 @@ Upgrade the form's `:form.login/submit-success` to an fx handler that stores the
 
 One token, one home. The classified `[:auth :token]` path holds it; the user map ships with `:token` stripped, so the JWT isn't *also* sitting unclassified at `[:auth :user :token]`, ready to leak to every off-box record. The decorator in step 3 always reads from `[:auth :token]`, never from the user.
 
-The failure handler is unchanged from the form recipe. Notice login does **not** retry — one submission per click. That's the [managed-HTTP](../../resources/glossary.md#managed-http) default (`:max-attempts 1`); the rule here is *don't add* a `:retry` block to a credential submission, even though you would to a public GET. A transient 5xx (`:rf.http/http-5xx`) or network drop (`:rf.http/transport`) surfaces as a failure reply and the user clicks again, which is the behaviour you want; silently re-firing a credential submission is a fine way to lock an account or double-charge a flow. (`:rf.http/managed` retry is entirely opt-in — nothing retries unless the request carries a `:retry` block, and the retryable categories are a closed set; the convention is retry policies on idempotent reads, never on writes.) Register is the same wiring with a different URL and draft.
+The failure handler is unchanged from the form recipe. Notice login does **not** retry — one submission per click. That's the [managed-HTTP](../../resources/glossary.md#managed-http) default (`:max-attempts 1`); the rule here is *don't add* a `:retry` block to a credential submission, even though you would to a public GET. A transient 5xx (`:rf.http/http-5xx`) or network drop (`:rf.http/transport`) surfaces as a failure reply and the user clicks again, which is the behaviour you want; silently re-firing a credential submission is a fine way to lock an account or double-charge a flow. (`:rf.http/managed` retry is entirely opt-in — nothing retries unless the request carries a `:retry` block, and the retryable categories are a closed set; the convention is retry policies on idempotent reads, never on writes.) Register is the same wiring with a different URL and draft — left as an exercise.
 
 !!! warning "Gotcha — keep the credential out of the trace on the way *in*, too"
 
@@ -209,9 +205,7 @@ An interceptor map carries **`:before`**, **`:after`**, or both — supply at le
 
     Re-evaluating `reg-http-interceptor` with the same id replaces the slot **in place** — its position in the chain is preserved, which is exactly what you want on a file save. `clear-http-interceptor` removes the slot entirely; a later re-registration then **appends to the end** of the chain. So don't clear-then-reg in hot-reload paths unless you genuinely want a fresh end-of-chain slot.
 
-!!! note "One write site, not many"
-
-    The frame seam is the single write site for this decoration, so there's no per-request call site to forget — one forgotten wrapper around an `http-xhrio` map is one unauthenticated request, and there are no wrappers here. It's the same shift you make moving from passing an `axios` config object around everywhere to registering one request interceptor: the decoration becomes structural, not something each caller has to remember.
+One write site, not many. The frame seam is the single write site for this decoration, so there's no per-request call site to forget — one forgotten wrapper around an `http-xhrio` map is one unauthenticated request, and there are no wrappers here. It's the same shift you make moving from passing an `axios` config object around everywhere to registering one request interceptor: the decoration becomes structural, not something each caller has to remember.
 
 ## 4. Guard the protected routes
 
@@ -340,9 +334,7 @@ A guard's headline feature is returning the user to exactly where they were head
                          [:rf.route/navigate :app/home])]]})))
 ```
 
-!!! note "Why this matters — read-and-clear, not just read"
-
-    A stash that lingers is a footgun. The user logs in directly from `/login` an hour later, and a `:return-to` left over from this morning silently teleports them somewhere they never asked to go. Consuming the stash in the same handler that reads it means the bounce target lives exactly as long as one login round-trip — no longer.
+Why read *and clear*? Because a stash that lingers is a footgun. The user logs in directly from `/login` an hour later, and a `:return-to` left over from this morning silently teleports them somewhere they never asked to go. Consume the stash in the same handler that reads it and the bounce target lives exactly as long as one login round-trip — no longer.
 
 ## 6. Logout is a teardown
 
@@ -400,3 +392,5 @@ With all six steps wired, watch the whole flow in [Xray](../../xray/index.md):
 - Logged in, find an authenticated request: the live request carried `Authorization`, the captured trace shows it redacted — as is `[:auth :token]` in the app-db view.
 - Reload the page while signed in: the `:auth/init` row shows the saved token folded in from the coeffect, and the slice comes back classified — no re-login.
 - Dispatch `:auth/logout`: one clear-scope row lists what was removed, what was aborted, and what was left alone.
+
+And that's auth. A slice, a guard, and a teardown — no subsystem, no new machinery, just the loop you already know doing one more job.

--- a/docs/core/how-to/boot-and-mount-an-app.md
+++ b/docs/core/how-to/boot-and-mount-an-app.md
@@ -1,6 +1,6 @@
 # Boot and mount an app
 
-An app's entry/boot namespace has three jobs:
+An app's entry/boot namespace has three jobs. Only three, and always the same three:
 
 - require the namespaces that register the app's behaviour;
 - install the reactive adapter for the process;
@@ -8,18 +8,19 @@ An app's entry/boot namespace has three jobs:
 
 A [frame](../glossary.md#frame) is one isolated running instance of your app: its own
 [app-db](../glossary.md#app-db), event queue, runtime state, and subscription cache.
+One division of labour catches nearly everyone, so hear it before the code:
 `rf/init!` does not create a frame. It only installs the
 [adapter](../glossary.md#adapter) for your React substrate, such as Reagent, UIx,
 or Helix. The frame is created later by the rendered
 [frame-provider](../glossary.md#frame-provider).
 
-The goal is simple: first page load should create and seed the app; hot reload
-should re-render changed views without losing app-db.
+The whole recipe serves two moments. First page load should create and seed the
+app. Hot reload should re-render changed views without losing app-db.
 
 ## The small shape
 
-For an app with no browser listeners, there is no need for a separate `boot!`
-function. Keep the process setup inline in `run`, and put DOM work in `mount!`.
+For an app with no browser listeners, you don't need a separate `boot!`
+function. Keep the process setup inline in `run`, and put the DOM work in `mount!`.
 
 ```clojure
 (ns counter.core
@@ -51,19 +52,20 @@ function. Keep the process setup inline in `run`, and put DOM work in `mount!`.
   (mount!))
 ```
 
-Wire `run` as the build's `:init-fn`, for example
+Wire `run` as the build's `:init-fn` — for example
 `:init-fn counter.core/run` in `shadow-cljs.edn`.
 
-`rf/init!` is process setup. `mount!` is browser setup. Keeping the DOM touch
-inside `mount!` lets the namespace load in tests or Node hosts where
-`js/document` is not present.
+`rf/init!` is process setup. `mount!` is browser setup. The split is not
+ceremony: keeping the DOM touch inside `mount!` lets the namespace load in tests
+or Node hosts where `js/document` is not present.
 
-The `ns` form is also part of boot. `counter.events` and `counter.subs` may look
-unused in this namespace, but requiring them loads their `reg-event` and
-`reg-sub` forms. A real app's entry/boot namespace usually requires every
-namespace whose top-level registrations must exist before the app runs: events,
-effects, coeffects, subscriptions, views, routes, resources, machines, and
-schemas.
+The `ns` form is also part of boot. `counter.events` and `counter.subs` look
+unused in this namespace — nothing in the file names them again — but requiring
+them loads their `reg-event` and `reg-sub` forms. Registration happens as a
+direct result of loading the code; there is no manifest and no wiring step. A
+real app's entry/boot namespace usually requires every namespace whose
+top-level registrations must exist before the app runs: events, effects,
+coeffects, subscriptions, views, routes, resources, machines, and schemas.
 
 ## What the provider does
 
@@ -84,12 +86,18 @@ On the first mount it:
 - runs the `:initial-events` once, in order, to seed app-db;
 - scopes descendant views, subscriptions, and dispatches to that frame.
 
-On a later remount under the same `:id`, such as a hot reload, it reuses the
-live frame. It does not replay `:initial-events`, and it does not destroy the
-frame on unmount. That is why app-db survives reload.
+Notice how the seeding happens. `:initial-events` are ordinary events, handled
+by ordinary handlers — even the initial values arrive by event. Those are the
+rules.
 
-If you edit the setup event itself and want the new setup to run, reset the
-frame or reload the page. Hot reload preserves state by design.
+On a later remount under the same `:id` — a hot reload, say — it reuses the
+live frame. It does not replay `:initial-events`, and it does not destroy the
+frame on unmount. That sentence is the whole hot-reload story: it is why app-db
+survives a reload.
+
+Which cuts both ways. If you edit the setup event itself and want the new setup
+to run, reset the frame or reload the page. Hot reload preserves state by
+design, and it will preserve it right past your edited setup event.
 
 ## Hot reload
 
@@ -114,10 +122,13 @@ It does not re-run `run`.
 Some apps also install browser listeners: `hashchange`, `popstate`, `storage`,
 or similar. Those listeners are process/browser wiring, not frame creation.
 
-When listener code can change during development, reinstall the listener from a
-hot-reload hook as well as from `run`. The browser removes listeners by exact
-function object identity, so keep the installed listener in a `defonce` cell and
-remove that stored value before adding the new one.
+Here's the trap. The browser removes listeners by exact function object
+identity, and after a hot reload your namespace holds *new* function objects —
+so removing "the listener" by name removes nothing, and each reload stacks
+another copy. The cure: keep the installed listener in a `defonce` cell, and
+remove that stored value before adding the new one. When listener code can
+change during development, reinstall the listener from a hot-reload hook as
+well as from `run`.
 
 ```clojure
 (defonce hash-listener (atom nil))
@@ -148,21 +159,23 @@ remove that stored value before adding the new one.
   (mount!))
 ```
 
-The separate `install-host-listeners!` function earns its name because it runs in
-two situations: first page load and hot reload. A separate `boot!` wrapper is
+`install-host-listeners!` earns its own name because it runs in two
+situations: first page load and hot reload. A separate `boot!` wrapper is
 optional; use one only if it makes your app's entry point clearer.
 
-In this shape, put `^:dev/after-load` on `reload!`, not on `mount!`, so a reload
-reinstalls listeners and renders once.
+In this shape, put `^:dev/after-load` on `reload!`, not on `mount!`, so a
+reload reinstalls listeners and renders once.
 
-For history routing, prefer the routing helper where it fits. It already owns the
-same hot-reload-safe listener pattern.
+For history routing, prefer the routing helper where it fits. It already owns
+this same hot-reload-safe listener pattern.
 
 ## Two frame shapes
 
-`frame-provider` has two useful shapes.
+`frame-provider` has two useful shapes, and the difference fits in one
+question: does the subtree *bring* its frame, or *borrow* it?
 
-Use `{:id ...}` when the rendered subtree should ensure its own frame exists:
+Use `{:id ...}` when the rendered subtree should ensure its own frame exists —
+it brings one:
 
 ```clojure
 [rf/frame-provider {:id             :counter/widget
@@ -173,7 +186,8 @@ Use `{:id ...}` when the rendered subtree should ensure its own frame exists:
 This creates the frame if absent, reuses it if present, and scopes descendants to
 it.
 
-Use `{:frame ...}` when the frame was already created somewhere else:
+Use `{:frame ...}` when the frame was already created somewhere else — it
+borrows:
 
 ```clojure
 (rf/reg-frame :checkout {:initial-events [[:checkout/initialise]]})
@@ -187,6 +201,8 @@ nothing and destroys nothing. Use it when boot, tests, SSR/request setup, or a
 tooling harness needs to create the frame before rendering.
 
 ## The boot lifecycle
+
+The whole recipe, one moment per row:
 
 | Moment | What should happen |
 | --- | --- |
@@ -216,25 +232,37 @@ Top-level DOM work is not:
 (defonce root (rdc/create-root (js/document.getElementById "app")))
 ```
 
-The namespace may be loaded by a test host, a Story tool, or another namespace
-that wants the registrations without mounting the app. Lazy DOM work keeps that
-safe.
+Why so strict? The namespace may be loaded by a test host, a Story tool, or
+another namespace that wants the registrations without mounting the app. Lazy
+DOM work keeps all of those safe.
 
 ## When boot goes wrong
 
-Boot is where the "did you wire it up?" mistakes surface, and each one [fails loud](../glossary.md#fail-loud-not-silent) with a named [error](../concepts/errors.md) rather than a blank page.
+Boot is where the "did you wire it up?" mistakes surface, and each one [fails loud](../glossary.md#fail-loud-not-silent) with a named [error](../concepts/errors.md) rather than a blank page. Three, in the order you're likely to meet them.
 
-!!! warning "Gotcha — touching the substrate before `init!`"
+**You touched the substrate before `init!`.** `rf/init!` installs the
+[adapter](../glossary.md#adapter); until it runs there is nothing to render
+through. A `render` or `mount!` that beats `(rf/init! …)` throws
+`:rf.error/no-adapter-installed`, naming the call; a `dispatch` or `subscribe`
+fired from a bare top-level form fails on its missing frame scope first
+(`:rf.error/no-frame-context`). Either way the cure is the same: boot before
+anything runs — in the shapes above, `run` installs the adapter on its first
+line.
 
-    `rf/init!` installs the [adapter](../glossary.md#adapter); until it runs there is nothing to render through. A `render` or `mount!` that beats `(rf/init! …)` throws `:rf.error/no-adapter-installed`, naming the call; a `dispatch` or `subscribe` fired from a bare top-level form fails on its missing frame scope first (`:rf.error/no-frame-context`). Either way the cure is the same: boot before anything runs — in the shapes above, `run` installs the adapter on its first line.
+**You pointed `{:frame …}` at a frame that doesn't exist.** The scope shape
+only *scopes* a frame someone else created; it creates nothing. Point
+`[rf/frame-provider {:frame :checkout} …]` at a frame that was never
+`reg-frame`'d (nor ensured by an `{:id}` provider) and it throws
+`:rf.error/frame-provider-frame-absent`. When the subtree should bring its own
+frame into being, use the **ensure** shape `{:id …}` instead — that's the whole
+difference between [the two shapes](#two-frame-shapes).
 
-!!! warning "Gotcha — `{:frame …}` needs a frame that already exists"
-
-    The scope shape only *scopes* a frame someone else created; it creates nothing. Point `[rf/frame-provider {:frame :checkout} …]` at a frame that was never `reg-frame`'d (nor ensured by an `{:id}` provider) and it throws `:rf.error/frame-provider-frame-absent`. When the subtree should bring its own frame into being, use the **ensure** shape `{:id …}` instead — that's the whole difference between [the two shapes](#two-frame-shapes).
-
-!!! warning "Gotcha — a registration namespace you forgot to require"
-
-    A `reg-event` or `reg-sub` runs only when its namespace loads, so a missing `require` means the registration never happened. Drop `counter.events` from the entry `ns` and the first `[:counter/inc]` dispatch — or `[:counter/value]` subscribe — is a loud `:rf.error/no-such-handler` / `:rf.error/no-such-sub` naming the missing id, not a silent dead button. The fix is the require list in the `ns` form above.
+**You forgot to require a registration namespace.** A `reg-event` or `reg-sub`
+runs only when its namespace loads, so a missing `require` means the
+registration never happened. Drop `counter.events` from the entry `ns` and the
+first `[:counter/inc]` dispatch — or `[:counter/value]` subscribe — is a loud
+`:rf.error/no-such-handler` / `:rf.error/no-such-sub` naming the missing id,
+not a silent dead button. The fix is the require list in the `ns` form above.
 
 ## Worked examples
 
@@ -248,9 +276,11 @@ creation, and render calls change.
 
 ??? info "From re-frame v1"
 
-    The old `mount-root` pattern rendered again after a hot
-    reload while global app-db survived as a top-level value. In re-frame2, the
-    state container is explicit: a frame. The provider ensures or scopes that
-    frame, and `:initial-events` seed it through the normal event pipeline.
+    The old `mount-root` pattern rendered again after a hot reload while a
+    global app-db survived as a top-level value — the state container was
+    ambient. In re-frame2 it is explicit: a frame. The provider ensures or
+    scopes that frame, and `:initial-events` seed it through the normal event
+    pipeline.
 
-The full frame lifecycle is covered in [Frames](../concepts/frames.md).
+That's the recipe. The full frame lifecycle is covered in
+[Frames](../concepts/frames.md).

--- a/docs/core/how-to/build-a-form.md
+++ b/docs/core/how-to/build-a-form.md
@@ -1,12 +1,14 @@
 # Build a form
 
-You're adding a form — a login, a signup, a settings panel, an editor. What you want is a draft the user types into, validation, a submit round-trip, and server rejections shown next to the right fields. This page is the recipe for that whole lifecycle, so you don't have to reinvent it every time: one state shape, seven [events](../glossary.md#event), and one rule for when errors become visible.
+You're adding a form. A login, a signup, a settings panel, an editor. Different chrome, same lifecycle underneath: a draft the user types into, validation, a submit round-trip, and server rejections shown next to the right fields. This page is the recipe for that lifecycle, so you don't have to reinvent it every time: one state shape, seven [events](../glossary.md#event), and one rule for when errors become visible.
 
 One page-specific word carries the rest: a **slice** is the corner of [app-db](../glossary.md#app-db) a feature claims (this form's lives under `[:auth :login]`). Everything in it changes the usual way — you [dispatch](../glossary.md#dispatch) an [event](../glossary.md#event) (a keystroke, a blur, a submit) and an [event handler](../glossary.md#event-handler) writes new state.
 
-Here's the thing about forms: they look trivial and turn out to be one of the buggier corners of any UI. When does an error appear — on the first keystroke, on blur, on submit? Where do *server* validation failures show up versus client ones? What makes the submit button live? Get these wrong and you ship a form that yells "required!" at a user who hasn't typed a single character. So before any code, one rule carries the whole page, and everything else is plumbing around it:
+Here's the thing about forms: they look trivial and turn out to be one of the buggier corners of any UI. When does an error appear — on the first keystroke, on blur, on submit? Where do *server* validation failures show up versus client ones? What makes the submit button live? Get these wrong and you ship a form that yells "required!" at a user who hasn't typed a single character. So before any code, the one rule that carries the whole page:
 
 > **A field's errors show when the field is touched OR a submit was attempted — one rule, one one-way latch, encoded in exactly one [subscription](../glossary.md#subscription).**
+
+Read it twice — everything below is plumbing around that one sentence.
 
 We'll build the simplest thing that works first — a login form that validates the whole draft on submit — and only then layer on the trimmings (cross-field rules, per-field and async validation, server rejections). The running example lives at `[:auth :login]`; that vector is a *path* into app-db, the same way `["auth"]["login"]` would be in a nested object. A form's slice always lives under its feature's key like this, which keeps the whole feature's state in one inspectable place.
 
@@ -37,7 +39,7 @@ Each key earns its place — drop one and the user notices. Three of them carry 
 
 !!! note "Why two error slots and not one?"
 
-    It's tempting to dump every failure into `:errors` and be done. But field errors and transport errors render in completely different places — one sits under an input, the other is a banner that says "couldn't reach the server, try again." Conflating them means the view has to *guess* which kind it's holding. Two slots, two render sites, zero guessing. We'll lean on this split hard in step 2.
+    It's tempting to dump every failure into `:errors` and be done. Resist. Field errors and transport errors render in completely different places — one sits under an input, the other is a banner that says "couldn't reach the server, try again." Conflating them means the view has to *guess* which kind it's holding. Two slots, two render sites, zero guessing. We'll lean on this split hard in step 2.
 
 Now bind two [schemas](../glossary.md#schema), one for the slice's shape and one for the value you're actually collecting. (A schema is a data description of a valid shape; here it guards what may be written into app-db.)
 
@@ -95,7 +97,7 @@ Everything that can happen to a form is one of seven events. That's not arbitrar
 | `:form.login/submit-error` | Route structured rejections to `:errors`, transport failures to `:submit-error`. |
 | `:form.login/reset` | Re-dispatch `:initialise`. |
 
-We'll wire up the three that carry the form's spine — the keystroke, the submit, and the two replies — then mop up the mechanical ones.
+We'll wire up the spine first — the keystroke, the submit, and the two replies — then mop up the mechanical ones.
 
 ### The keystroke
 
@@ -157,9 +159,7 @@ The [effect map](../glossary.md#effect-map) this handler returns has two keys wo
 
 Read the latch line carefully: `:submit-attempted?` flips to `true` on the way into *both* branches, valid or not. That's the whole trick behind the visibility rule in step 3 — the moment the user first presses submit, every invalid field is allowed to speak, whether or not they ever visited it.
 
-!!! warning "Gotcha — a malformed request is caught at dispatch, not at the server"
-
-    Two slots on the `:rf.http/managed` map are validated the instant the effect runs, before any packet leaves: `:on-success` / `:on-failure` must each be an event vector (or `nil`) — anything else throws `:rf.error/http-bad-reply-target` — and the final `:url` must be a non-blank string, or you get `:rf.error/http-bad-request`. Both fail loud at the call site rather than surfacing as a baffling `:rf.http/transport` failure three handlers downstream. So a fat-fingered reply target (`:on-success :form.login/submit-success` — a bare keyword, not `[:form.login/submit-success]`) is a named error you fix in seconds, not a submit that silently never replies.
+One gotcha to hear now: a malformed request is caught at dispatch, not at the server. Two slots on the `:rf.http/managed` map are validated the instant the effect runs, before any packet leaves: `:on-success` / `:on-failure` must each be an event vector (or `nil`) — anything else throws `:rf.error/http-bad-reply-target` — and the final `:url` must be a non-blank string, or you get `:rf.error/http-bad-request`. Both fail loud at the call site rather than surfacing as a baffling `:rf.http/transport` failure three handlers downstream. So a fat-fingered reply target (`:on-success :form.login/submit-success` — a bare keyword, not `[:form.login/submit-success]`) is a named error you fix in seconds, not a submit that silently never replies.
 
 ### The success reply
 

--- a/docs/core/how-to/configure-dev-and-prod.md
+++ b/docs/core/how-to/configure-dev-and-prod.md
@@ -1,6 +1,6 @@
 # Configure dev and production builds
 
-You're about to ship, and you want to know two things: what's actually in your production bundle, and which knobs you need to touch. For that second question the answer is *almost none*, because the defaults are already correct. **This page is the pre-ship pass.** We'll build it up one piece at a time: first the single flag that makes a build "production", then how to gate your *own* dev code so it disappears alongside the framework's, then the JVM/SSR variant, then the dev knobs, and finally the always-on guardrails.
+You're about to ship. Two questions matter: what's actually in your production bundle, and which knobs do you need to touch? Take the second one first: *almost none*. The defaults are already correct. **This page is the pre-ship pass.** One piece at a time: the single flag that makes a build "production", then gating your *own* dev code so it disappears alongside the framework's, then the JVM/SSR variant, then the dev knobs, and finally the guardrails you can't turn off.
 
 ??? info "Coming from React?"
 
@@ -19,7 +19,7 @@ Here is the whole production story — one line in your release build:
 
 That's it. Most production CLJS builds already set `goog.DEBUG false`, so re-frame2 reuses the canonical flag rather than inventing its own — odds are you have this line already.
 
-Under that `:advanced` build with `goog.DEBUG=false`, the framework's *surfaces* — the distinct things you can attach to or read from, like the [trace stream](../glossary.md#trace-stream) or [schema](../glossary.md#schema) validation — sort into three piles. It's worth knowing which is which before you ship.
+Under that `:advanced` build with `goog.DEBUG=false`, the framework's *surfaces* — the distinct things you can attach to or read from, like the [trace stream](../glossary.md#trace-stream) or [schema](../glossary.md#schema) validation — sort into three piles. Know which is which before you ship.
 
 **Elided — gone from the bundle, zero cost:**
 
@@ -61,9 +61,7 @@ The framework elides its own dev surface; yours needs the same gate so it disapp
 
 In production, `debug-enabled?` is the constant `false`, so the `when` body is dead code and the whole registration disappears with everything else.
 
-!!! warning "Gotcha — the gate must be outermost"
-
-    `(when (and something debug-enabled?) ...)` does **not** constant-fold. Closure can't rule out `something`, so it can't prove the branch is dead, and the code ships in your bundle. Keep `debug-enabled?` as the outermost test, on its own. The same applies to every dev-only call you write — a `register-epoch-listener!`, a `trace-buffer` read, a `(rf/configure! {:trace-buffer …})` — each belongs under its own `when ^boolean re-frame.interop/debug-enabled?` guard.
+One rookie mistake quietly defeats this gate: `(when (and something debug-enabled?) ...)` does **not** constant-fold. Closure can't rule out `something`, so it can't prove the branch is dead, and the code ships in your bundle. Keep `debug-enabled?` as the outermost test, on its own. The same applies to every dev-only call you write — a `register-epoch-listener!`, a `trace-buffer` read, a `(rf/configure! {:trace-buffer …})` — each belongs under its own `when ^boolean re-frame.interop/debug-enabled?` guard.
 
 ## 3. Shipping a JVM/SSR tier? One system property
 
@@ -111,9 +109,7 @@ One term in the table below: a [**frame**](../glossary.md#frame) is one isolated
 
 A missing top-level key leaves that subsystem untouched, so you can pass just the one knob you want — `(rf/configure! {:trace-buffer {:events-retained 200}})` — or compose all three in one value. An unknown top-level key is a silent no-op, which is what lets a wrapper hand `configure!` a composed config without first filtering it.
 
-!!! note "One thing fails loud"
-
-    The *argument* must be a map. `(rf/configure! [:trace-buffer …])` — a vector, say, because you mistyped — doesn't quietly do nothing; it throws. The silent no-op is reserved for *unknown keys inside* a well-formed map (that's the property that lets a wrapper pass a composed config straight through); a malformed argument is a programming error and surfaces as one.
+One thing fails loud, though: the *argument* must be a map. `(rf/configure! [:trace-buffer …])` — a vector, say, because you mistyped — doesn't quietly do nothing; it throws. The silent no-op is reserved for *unknown keys inside* a well-formed map; a malformed argument is a programming error and surfaces as one.
 
 The three keys, in detail:
 
@@ -182,3 +178,5 @@ The elision mechanism itself — what disappears from a production build, and th
 4. Handlers receiving untrusted payloads reference the `:rf.schema/at-boundary` interceptor in their `:interceptors` chain.
 5. A JVM/SSR tier ships with `-Dre-frame.debug=false`.
 6. No Xray preload or pair-server artefact on the release classpath.
+
+Six checks. If every one holds, ship.

--- a/docs/core/how-to/fix-a-slow-view.md
+++ b/docs/core/how-to/fix-a-slow-view.md
@@ -1,10 +1,14 @@
 # Find and fix a slow view
 
-A click hitches. Typing stutters. Some [view](../glossary.md#view) — the pure function that turns your data into [hiccup](../glossary.md#hiccup) — is doing too much work, and you want to find it and stop it, without sprinkling memoisation everywhere and hoping.
+A click hitches. Typing stutters. Some [view](../glossary.md#view) — the pure function that turns your data into [hiccup](../glossary.md#hiccup) — is doing too much work, and you want to find it and stop it. Without sprinkling memoisation everywhere and hoping.
 
-Here is the good news up front, and it's the whole reason this page is short. Your views read from [subscriptions](../glossary.md#subscription) — named, cached, read-only derivations of state — and those subscriptions chain into each other, each one feeding the next. That chain is the [derivation graph](../glossary.md#the-derivation-graph), and the framework already memoises every node of it for you: a subscription recomputes only when an input it actually reads produces a *new* value, compared by `=`. So nearly every slow view is the *same* mistake wearing a different costume: expensive work on the wrong side of that `=` check. You don't add caching — you move the work to the side of the cache that already exists.
+Here is the good news up front, and it's the whole reason this page is short. Your views read from [subscriptions](../glossary.md#subscription) — named, cached, read-only derivations of state — and those subscriptions chain into each other, each one feeding the next. That chain is the [derivation graph](../glossary.md#the-derivation-graph), and the framework already memoises every node of it for you: a subscription recomputes only when an input it actually reads produces a *new* value, compared by `=`.
+
+Which means nearly every slow view is the *same* mistake wearing a different costume: expensive work on the wrong side of that `=` check. You don't add caching. You move the work to the side of the cache that already exists.
 
 > **Put expensive work after the circuit breaker, not before it.**
+
+That sentence is the whole page. The four rungs below just find the work and pick the side.
 
 The hunt is a ladder, and you climb it in order of *how cheaply you can spot the problem* — easiest-to-see first, not most-impactful first. Most hunts end on the first two rungs, so don't brace for all four:
 
@@ -23,9 +27,9 @@ We'll take them one at a time.
 
 ## 1 — Observe: name the shape of the slow
 
-Your usual first move still works: open the React DevTools profiler, record, do the slow thing, read the flame graph. But it tells you *which components rendered*, not *why the data changed* — and the why is what you need. Every re-render here traces back through a subscription to an [event](../glossary.md#event), the inert data vector recording that something happened. [Xray](../glossary.md#xray), the dev inspector, shows that chain directly.
+Your usual first move still works: open the React DevTools profiler, record, do the slow thing, read the flame graph. But a flame graph tells you *which components rendered*, not *why the data changed* — and the why is what you need. Every re-render here traces back through a subscription to an [event](../glossary.md#event), the inert data vector recording that something happened. That chain is exactly what [Xray](../glossary.md#xray), the dev inspector, shows you. Use the trace, Luke.
 
-Attach Xray with one line ([Debug with Xray](../../xray/index.md)). Reproduce the slow interaction once, select the newest event row, and open the **Views** tab. It lists every view that re-rendered in that [pipeline run](../glossary.md#run), with its render time, and nests under each view the subscriptions it read. Each sub carries a drill that answers "why did this sub re-run", tracing back to the event that caused it. Mounted, re-rendered, and unmounted views appear in their own groups, and a re-rendered row names its cause — `← :sub-id` when a subscription's value moved, `← props` when the parent handed it different arguments.
+Attach Xray with one line ([Debug with Xray](../../xray/index.md)). Reproduce the slow interaction once, select the newest event row, and open the **Views** tab. It lists every view that re-rendered in that [pipeline run](../glossary.md#run), with its render time, and nests under each view the subscriptions it read. Each sub carries a drill that answers "why did this sub re-run", tracing back to the event that caused it. Mounted, re-rendered, and unmounted views appear in their own groups, and a re-rendered row names its cause — `← :sub-id` when a subscription's value moved, `← props` when the parent handed it different arguments. You may be surprised by what you see.
 
 You are looking for one of two shapes:
 
@@ -34,9 +38,7 @@ You are looking for one of two shapes:
 
 If the dev build feels fine and only production is slow, jump straight to rung 4.
 
-!!! warning "Gotcha — those render times are best-effort"
-
-    The dev Views tab's per-view millisecond numbers are the framework's own wall-clock read around each registered view's render function — and, like any dev-build number, they're inflated by the trace surface itself. Use them to *rank rows within one capture*, not as ground truth. The numbers that match what your users feel come from rung 4's production channel.
+One caution before you lean on those per-view milliseconds: they are best-effort. Each number is the framework's own wall-clock read around a registered view's render function — and, like any dev-build number, it's inflated by the trace surface itself. Use them to *rank rows within one capture*, not as ground truth. The numbers that match what your users feel come from rung 4's production channel.
 
 ---
 
@@ -72,15 +74,15 @@ Split it. A tiny extractor decides *whether* anything changed, and a layer-2 sub
          (mapv :slug))))
 ```
 
-The `:<-` arrow reads as "this sub's input comes from"; `:feed/slugs` now derives from the *value* `:articles/all` extracted, not from `db`. When some other key in app-db changes, `:articles/all` re-runs, returns an `=` map, the gate closes, and `:feed/slugs` never wakes — the sort doesn't run.
+The `:<-` arrow reads as "this sub's input comes from": `:feed/slugs` now derives from the *value* `:articles/all` extracted, not from `db`. When some other key in app-db changes, `:articles/all` re-runs, returns an `=` map, the gate closes, and `:feed/slugs` never wakes. The sort doesn't run. You didn't make anything faster — you stopped doing it.
 
 !!! warning "Gotcha — a mistyped `:<-` input fails quiet, not loud"
 
     When you split a sub, the new `:<-` edge points at another sub *by id*. Get that id wrong — a typo, a sub you haven't registered yet — and re-frame2 doesn't throw. It [fails loud as data](../glossary.md#error-record): it emits a `:rf.error/no-such-sub` [error record](../glossary.md#error-record) (recovery `:replaced-with-default`) to your always-on error listeners and feeds your derivation `nil` for that input. So a bad split doesn't look *slow* — it looks *wrong* (the feed renders empty, or a downstream `nil` throws somewhere unrelated). If a sub you just refactored returns nothing, check its `:<-` ids against your `reg-sub` names before you suspect the gate. The parametric input-function form has its own two named modes: an input fn that throws surfaces `:rf.error/sub-input-fn-exception`, and one that returns something other than a query vector (or vector of them) surfaces `:rf.error/sub-input-fn-bad-return`.
 
-The same misplacement happens one level up, and it trips people up. Computation in a **view body** runs on every render of that view, including renders caused by ancestors. Sorting, filtering, and formatting belong in a layer-2 sub; there they run once per input change and are shared by every consumer. Views just walk data and emit hiccup — the `[:div ...]` vector form re-frame2 uses to describe markup ([Views](../concepts/views.md)).
+The same misplacement happens one level up, and it trips people constantly. Computation in a **view body** runs on every render of that view, including renders caused by ancestors. Sorting, filtering, and formatting belong in a layer-2 sub; there they run once per input change and are shared by every consumer. Views just walk data and emit hiccup — the `[:div ...]` vector form re-frame2 uses to describe markup ([Views](../concepts/views.md)).
 
-Now observe the fix. Dispatch the same event with the Views tab open, and the sub's drill shows it returning its cached value: the gate closed, and the sort never ran. Unrelated typing no longer wakes the feed at all.
+Now watch the fix land. Dispatch the same event with the Views tab open, and the sub's drill shows it returning its cached value: gate closed, sort never ran. Unrelated typing no longer wakes the feed at all.
 
 ??? note "Going deeper"
 
@@ -92,7 +94,7 @@ Now observe the fix. Dispatch the same event with the Views tab open, and the su
 
 !!! note "When placement isn't enough"
 
-    Some work is genuinely huge even when ideally placed — parsing megabytes, running a simulation step, diffing two trees. No side of the gate saves you there, because the cost is in the computation itself, not in how often it fires. Chunk it through a [machine](../../machines/concepts.md) or move it to a Web Worker. But this is rare: reach for it only after you've confirmed the work is correctly placed and *still* slow.
+    Some work is genuinely huge even when ideally placed — parsing megabytes, running a simulation step, diffing two trees. No side of the gate saves you there, because the cost is in the computation itself, not in how often it fires. And the browser gives you exactly one thread: while that work runs, nothing else does — no repaints, no clicks, no spinner. Chunk it through a [machine](../../machines/concepts.md) or move it to a Web Worker. But this is rare: reach for it only after you've confirmed the work is correctly placed and *still* slow.
 
 ---
 
@@ -108,9 +110,9 @@ A cloud of rows in the Views tab almost always means a parent handed each child 
      ^{:key (:slug article)} [article-row article])])
 ```
 
-Favorite one article in a 200-row feed and `:feed/articles` is a new vector, because one map inside it changed. So `feed` re-renders and all 200 `article-row`s are re-invoked. The 199 untouched rows pass their deep `=` prop checks and keep their DOM — but the checks still run, on full maps, on every click. That's the hitch.
+Favorite one article in a 200-row feed and `:feed/articles` is a new vector, because one map inside it changed. So `feed` re-renders and all 200 `article-row`s are re-invoked. The 199 untouched rows pass their deep `=` prop checks and keep their DOM — but the checks still run, on full maps, on every click. Lots of hiccup, `=` checks on big props: that's the anatomy of every storm, and that's your hitch.
 
-The cure: **hand each row an id, and let the row subscribe to its own slice.**
+The cure is to not do the unnecessary work. (Duh.) Concretely: **hand each row an id, and let the row subscribe to its own slice.**
 
 ```clojure
 ;; Calm — rows get a slug; each fetches exactly what it renders.
@@ -148,7 +150,7 @@ Second, the inline `#(dispatch …)` on the button is correct as written: on a D
 
 !!! note "'But now I have 200 subscriptions — won't they leak?'"
 
-    No. A subscription's cache key is its whole query vector, so `[:article/by-slug "abc"]` and `[:article/by-slug "xyz"]` are distinct cached entries, and equal subscriptions from multiple readers share one entry. Each entry is ref-counted: when the last reader of a query vector goes away — a row unmounts, the feed shrinks — the entry is evicted *in the same tick*, its reaction disposed, and a `:rf.sub/dispose` trace fires. Scroll a virtualised feed and the per-slug subs come and go with the rows; nothing accumulates. (The mechanics are in [Subscriptions → Lifecycle](../concepts/subscriptions.md#lifecycle-a-sub-exists-only-while-something-watches-it).)
+    No. A subscription's cache key is its whole query vector, so `[:article/by-slug "abc"]` and `[:article/by-slug "xyz"]` are distinct cached entries, and equal subscriptions from multiple readers share one entry. Each entry is ref-counted: when the last reader of a query vector goes away — a row unmounts, the feed shrinks — the entry is evicted *in the same tick*, its reaction disposed, and a `:rf.sub/dispose` trace fires. Scroll a virtualised feed and the per-slug subs come and go with the rows; nothing accumulates. (The mechanics are in [Subscriptions → Lifecycle](../concepts/subscriptions.md#lifecycle-a-sub-exists-only-while-something-watches).)
 
 ### Stable callbacks — only with a measurement
 
@@ -194,9 +196,7 @@ The trick is to split those two concerns. Build, once per row, a single long-liv
 
     `useCallback(fn, [slug])` exists to hand a child a stable function identity so it can `memo` past a no-op prop change. The factory-factory does the same job, but it sidesteps the stale-closure trap that bites `useCallback` when the dependency array is wrong: the callback object is stable *and* always sees current args, because the args live in an atom the factory refreshes, not in a captured closure. Same payoff (skip the expensive child's re-render), no dependency array to get wrong.
 
-!!! note "Reach for this rung last"
-
-    Use the factory pattern with a measurement in hand, not "on spec" across every list in the app. It trades a little reading clarity for a saved re-render, and that trade only pays off when the saved re-render is expensive. Most lists never need it; a button is not a chart.
+And don't be too paranoid about any of this. Use the factory pattern with a measurement in hand, not "on spec" across every list in the app: it trades a little reading clarity for a saved re-render, and that trade only pays off when the saved re-render is expensive. Most lists never need it. A button is not a chart.
 
 ---
 
@@ -256,15 +256,13 @@ performance.getEntriesByType('measure')
 
 Leave `retain-entries?` off in production: the [W3C User-Timing buffer is unbounded](https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure) (`maxBufferSize` is Infinite for measure entries), so retaining every entry across a multi-hour session leaks memory. re-frame2 clears after emit precisely so it doesn't.
 
-The channel is off by default and rides its own compile-time flag, distinct from the dev-trace gate — [Observability](../concepts/observability.md#production-the-wire-disappears--errors-dont) covers what ships and what doesn't.
+Once more, because it decides what ships: the channel is off by default, and it rides its own compile-time flag, distinct from the dev-trace gate. [Observability](../concepts/observability.md#production-the-wire-disappears--errors-dont) covers what ships and what doesn't.
 
 ??? info "For JavaScript developers"
 
     `rf:` measures are plain [User Timing API](https://developer.mozilla.org/en-US/docs/Web/API/Performance_API/User_timing) `measure` entries — the same ones React emits, the same ones your APM (Datadog RUM, Sentry, New Relic) already ingests. There's no re-frame2-specific tooling to install on the production side: it's `performance.getEntriesByType('measure')` and a `PerformanceObserver`, exactly as you'd instrument any web app. The framework just gives every event, sub, fx, and render a stable, namespaced entry name for free.
 
-!!! warning "Gotcha — never profile the dev build"
-
-    The dev build carries the whole trace surface, so the profile ends up measuring the measurement apparatus — you'll chase phantom costs that vanish in production. Build `:advanced` with the perf flag on, serve *that*, and profile that. The numbers you get are the numbers your users get.
+One warning, said plainly because it undoes everything above: **never profile the dev build.** The dev build carries the whole trace surface, so the profile ends up measuring the measurement apparatus — you'll chase phantom costs that vanish in production. Build `:advanced` with the perf flag on, serve *that*, and profile that. The numbers you get are the numbers your users get.
 
 !!! note "JVM and SSR"
 

--- a/docs/core/how-to/keep-secrets-out-of-traces.md
+++ b/docs/core/how-to/keep-secrets-out-of-traces.md
@@ -1,10 +1,12 @@
 # Keep secrets and large things out of traces
 
-Your login form just dispatched `[:auth/sign-in {:password "hunter2"}]`. In re-frame2 an [event](../glossary.md#event) is *just data* — an inert vector recording that something happened — so that password is now plain data sitting in your system. And re-frame2 is unusually observable: events, snapshots of [app-db](../glossary.md#app-db), and HTTP records all flow down one in-process feed — the [trace stream](../glossary.md#trace-stream) — and every tool drinks from that one feed ([one wire, every tool](../concepts/observability.md)). [Xray](../glossary.md#xray) (the dev inspector) reads it live; the [epoch](../glossary.md#epoch) history (the before/after record each event leaves behind, for [time-travel](../glossary.md#time-travel) debugging) keeps it; and any **shipper** — a [listener](../glossary.md#listener) you register to forward records to a hosted monitor like Datadog or Sentry — can carry it off-box.
+Your login form just dispatched `[:auth/sign-in {:password "hunter2"}]`.
+
+In re-frame2 an [event](../glossary.md#event) is *just data* — an inert vector recording that something happened — so that password is now plain data sitting in your system. And re-frame2 is unusually observable. Events, snapshots of [app-db](../glossary.md#app-db), and HTTP records all flow down one in-process feed — the [trace stream](../glossary.md#trace-stream) — and every tool drinks from that one feed ([one wire, every tool](../concepts/observability.md)). [Xray](../glossary.md#xray), the dev inspector, reads it live. The [epoch](../glossary.md#epoch) history — the before/after record each event leaves behind, for [time-travel](../glossary.md#time-travel) debugging — keeps it. And any **shipper** — a [listener](../glossary.md#listener) you register to forward records to a hosted monitor like Datadog or Sentry — can carry it off-box.
 
 That's a feature most of the time and a problem exactly once: when the data on the wire is a password, a token, or a 5MB upload. This page is the short list of declarations that keep those off the wire — **without ever hiding them from your own handler code**.
 
-Whenever a value leaves the wire for somewhere it can be *observed* — a dev panel, the saved epoch history, an off-box monitor — it crosses what we'll call an **observation boundary** (or just *egress*, the point where data exits the runtime to be looked at). The whole idea of this page fits in one sentence: **you name a *path* as sensitive once, where the data is defined, and the framework redacts whatever lives at that path everywhere it crosses an observation boundary.** That's it. This is the framework's [data classification](../glossary.md#data-classification) capability, and we'll build it up one declaration at a time.
+Whenever a value leaves the wire for somewhere it can be *observed* — a dev panel, the saved epoch history, an off-box monitor — it crosses what we'll call an **observation boundary** (or just *egress*: the point where data exits the runtime to be looked at). And the whole page fits in one sentence: **you name a *path* as sensitive once, where the data is defined, and the framework redacts whatever lives at that path everywhere it crosses an observation boundary.** That's it. That's the framework's [data classification](../glossary.md#data-classification) capability, and the rest of this page is that sentence applied to each kind of owner, one declaration at a time.
 
 !!! note "This is hygiene, not a security boundary — and it is fail-open"
 
@@ -25,7 +27,7 @@ Start with the most common case: a token that *lives* in app-db at a path you ow
      :sensitive [[:auth :token] [:auth :refresh-token]]}))
 ```
 
-What just happened: `:sensitive` takes a vector of paths and marks each one. From now on, whatever value comes to rest at `[:auth :token]` is redacted to `:rf/redacted` everywhere it would cross an observation boundary — the App-DB panel in Xray, the saved epoch history, your off-box shipper. Your handlers still read the real token. What gets redacted is only the *observable shadow* of your data: the copy the framework projects onto the wire for tools to look at, which is separate from the live value your code actually runs on.
+What just happened: `:sensitive` takes a vector of paths and marks each one. From now on, whatever value comes to rest at `[:auth :token]` is redacted to `:rf/redacted` everywhere it would cross an observation boundary — the App-DB panel in Xray, the saved epoch history, your off-box shipper. Your handlers still read the real token. What gets redacted is only the **observable shadow** of your data: the copy the framework projects onto the wire for tools to look at, separate from the live value your code actually runs on. That term does a lot of work on this page — hold onto it.
 
 Notice we classified the path **before any token exists there** — `:auth/init` just seeds an empty map. That's the safe, common pattern: a classification over an absent path is a harmless no-op that quietly redacts whatever later occupies the path. You don't re-classify on every write.
 
@@ -76,9 +78,7 @@ You reach for `:clear-*` rarely — when a value disappears its redaction effect
      :clear-sensitive [[:docs doc-id :body]]}))
 ```
 
-!!! warning "Gotcha — `:sensitive` is a *path collection*, never `:sensitive false`"
-
-    You *clear* the sensitive axis with `:clear-sensitive`; you never set `:sensitive false`. (Don't confuse it with `:sensitive?`, the yes/no schema prop — that's a different axis, covered later.)
+One rookie mistake, so hear it now: `:sensitive` is a *path collection*, never a flag. You *clear* the sensitive axis with `:clear-sensitive`; you never set `:sensitive false`. (And don't confuse it with `:sensitive?`, the yes/no schema prop — that's a different axis, covered later.)
 
 ??? note "Going deeper"
 
@@ -124,15 +124,13 @@ The same `:sensitive` metadata key works on **every** registration that introduc
 (rf/reg-fx :rf.ws/send {:sensitive [[:auth]]} ws-send-handler)
 ```
 
-!!! warning "Gotcha"
+!!! warning "Gotcha — a positional secret ships raw"
 
     A path like `[:password]` reaches into the event's **arg-map** (`[:auth/sign-in {:password "…"}]`), so the mark can name it. A positionally-passed secret (`[:auth/sign-in "alice" "hunter2"]`) has **no** stable named path — a positional index isn't addressable, so there's nothing for `:sensitive` to classify. Under fail-open that means it ships RAW into every trace and error sink. This is a structural limitation, not a bug: redaction is path-based, and only the arg-map (`(second event)`) is reachable. **So when an event carries a secret, pass a map payload and classify the key.** (The glossary [recommends a map payload over positional args](../glossary.md#event) anyway — this is one more reason.) The positional form is fine for data you wouldn't mind seeing in a trace.
 
 Note the `:decode` schema in the sign-in example: `[:token {:sensitive? true} :string]` classifies the *response body*. That's a second, separate declaration for the same secret — the **HTTP reply** is redacted by its `:decode` schema, and the **durable copy** that `:auth/signed-in` later stores at `[:auth :token]` is redacted by the path classification from the first section. There's no propagation carrying one to the other. **Classify each surface the secret crosses** — the wire it arrives on, *and* the slot it comes to rest in.
 
-!!! note "A malformed mark is the loud case"
-
-    A non-vector path is rejected at *registration* with `:rf.error/bad-classification` (a [flow](../glossary.md#flow)'s bad output marks raise `:rf.error/flow-bad-marks`), so the typo surfaces when you reload — not in a production log six weeks later.
+And while a mark at a *missing* slot is a silent no-op, a *malformed* mark is loud: a non-vector path is rejected at *registration* with `:rf.error/bad-classification` (a [flow](../glossary.md#flow)'s bad output marks raise `:rf.error/flow-bad-marks`), so the typo surfaces when you reload — not in a production log six weeks later.
 
 ### HTTP carriers: redact by header and query-param name
 

--- a/docs/core/how-to/report-errors-in-production.md
+++ b/docs/core/how-to/report-errors-in-production.md
@@ -1,14 +1,16 @@
 # Report errors in production
 
-Ship a re-frame2 app with an optimised production build and the compiler **[elides](../glossary.md#elide)** the whole dev-time *trace surface* — the rich "here's everything that just happened" feed that powers tools like [Xray](../glossary.md#xray). No [trace stream](../glossary.md#trace-stream), no per-frame [epoch](../glossary.md#epoch) rings, none of it. That keeps the bundle lean (you're not shipping a debugger to every user), but it leaves a gap: an [event handler](../glossary.md#event-handler) can still throw at 3am, and when it does you want that failure to land in your monitor with real context attached — not a bare stack trace stripped of *what the app was doing*.
+Ship a re-frame2 app as an optimised production build and the compiler **[elides](../glossary.md#elide)** the whole dev-time *trace surface* — the rich "here's everything that just happened" feed that powers tools like [Xray](../glossary.md#xray). No [trace stream](../glossary.md#trace-stream), no per-frame [epoch](../glossary.md#epoch) rings, none of it. Good. You're not shipping a debugger to every user.
 
-re-frame2 closes that gap with an **always-on error substrate**: a small slice of runtime that survives elision *on purpose*. On every production-reachable failure it fans one structured **[error record](../glossary.md#error-record)** out to every error [listener](../glossary.md#listener) you've registered. Each record carries three things worth having at 3am:
+But it leaves a gap. An [event handler](../glossary.md#event-handler) can still throw at 3am, and when it does you want that failure to land in your monitor with real context attached — not a bare stack trace stripped of *what the app was doing*.
+
+re-frame2 closes the gap with an **always-on error substrate**: a small slice of runtime that survives elision *on purpose*. On every production-reachable failure it fans one structured **[error record](../glossary.md#error-record)** out to every error [listener](../glossary.md#listener) you've registered. Each record carries three things worth having at 3am:
 
 - **the [event](../glossary.md#event) that was in flight** — the data vector describing what the user asked for;
 - **the [frame](../glossary.md#frame) it ran in** — the isolated app instance, with its own [app-db](../glossary.md#app-db); and
 - **the raw host exception** — the actual throwable, stack and all.
 
-This guide builds a production bridge to Sentry one step at a time: register the listener, gate it so it can't leak dev data, then branch correctly on every record shape the substrate hands you. We start with the smallest thing that works and add safety as we go.
+This guide builds a production bridge to Sentry, one step at a time: register the listener, gate it so it can't leak dev data, then branch correctly on every record shape the substrate hands you. Smallest thing that works first. Safety as we go.
 
 ??? info "Coming from plain JavaScript?"
 
@@ -34,9 +36,7 @@ One verb, `register-listener!`. Its leading `:errors` keyword names the **stream
 
 That's a working bridge — but it's naive in three ways we'll fix in turn: it fires in dev too, it assumes every record carries an `:exception` (some don't), and it ships nothing useful about *what* the app was doing. The rest of this page is those three fixes.
 
-!!! warning "Gotcha — the `:trace` stream is not a production wire"
-
-    There's a *different* stream, `register-listener! :trace`, and it's tempting because it carries everything. Don't reach for it here: it's dev-only and gets **elided** in a production build (`:advanced` + `goog.DEBUG=false`). A monitor built on `:trace` works beautifully on your laptop and ships *nothing* in production — and you discover the gap mid-incident, which is the worst possible time. The `:errors` stream is the always-on substrate that survives elision. That's the one.
+One trap to disarm before you go further. There's a *different* stream, `register-listener! :trace`, and it's tempting because it carries everything. Don't reach for it here. It's dev-only and gets **elided** in a production build (`:advanced` + `goog.DEBUG=false`), so a monitor built on `:trace` works beautifully on your laptop and ships *nothing* in production — and you discover the gap mid-incident, which is the worst possible time. The `:errors` stream is the always-on substrate that survives elision. That's the one.
 
 ??? info "From re-frame v1"
 
@@ -141,9 +141,7 @@ For exactly these two, the record **also** carries `:failing-id` (the broken int
 
 You don't have to redact the event vector by hand to keep secrets out of Sentry. The substrate runs it through `re-frame.elision/elide-wire-value` once before fan-out, with the off-box defaults. Paths your app classified as sensitive arrive as `:rf/redacted`, and oversized payloads arrive as the `:rf.size/large-elided` marker rather than the full thing. That's [data classification](../glossary.md#data-classification) doing its job at the egress boundary ([Keep secrets out of traces](keep-secrets-out-of-traces.md)).
 
-!!! warning "Gotcha — the raw `:exception` is *not* scrubbed"
-
-    The `:event` vector is wire-elided, but the host throwable rides **raw** — deliberately, because a post-mortem shipper needs the stack to be useful. The consequence: a value that landed in an exception message or `ex-data` is *not* redacted on this surface. This is the documented exception to the always-on substrate's "structured data only" rule. If that worries you for a given frame, the projected frame sink (§8) drops the `:exception` for you under its `:rf.egress/public-error` profile.
+Now the flip side, said plainly: the raw `:exception` is **not** scrubbed. The `:event` vector is wire-elided, but the host throwable rides raw — deliberately, because a post-mortem shipper needs the stack to be useful. The consequence: a value that landed in an exception message or `ex-data` is *not* redacted on this surface. This is the documented exception to the always-on substrate's "structured data only" rule. If that worries you for a given frame, the projected frame sink (§8) drops the `:exception` for you under its `:rf.egress/public-error` profile.
 
 ## 4. Handle the frame-teardown report {#handle-the-frame-teardown-report}
 
@@ -301,6 +299,4 @@ The `:rf.egress/profile` on each entry is load-bearing, and it's the one slot th
 
 The mental split: the corpus-wide `:errors` listener is the global black-box recorder (raw exceptions, one fan-out per process, *unprojected*); the frame `:observability` sink is the per-frame, policy-aware egress for metrics and projected diagnostics. Crash reporting that needs the host stack wants the former; dashboards and privacy-policy-bound error egress want the latter.
 
-!!! warning "Gotcha — frameless records reach only the corpus-wide listener"
-
-    One record type the sink *can't* carry is a **frameless** (`:frame nil`) record — the pre-frame SSR hydration-parse path and `:rf.error/no-frame-context` — because there's no owning frame to supply a policy. Those reach the corpus-wide `:errors` listener only. It's the other reason a black-box `:errors` listener stays useful even when you've gone all-in on frame sinks.
+One boundary to carry away. A **frameless** (`:frame nil`) record — the pre-frame SSR hydration-parse path and `:rf.error/no-frame-context` — can't reach a frame sink at all: there's no owning frame to supply a policy. Those records reach the corpus-wide `:errors` listener only. Which is the other reason the black-box `:errors` listener stays useful even after you've gone all-in on frame sinks — it's the seat that sees everything, including the failures that belong to nobody.

--- a/docs/core/how-to/use-uix-helix-or-slim.md
+++ b/docs/core/how-to/use-uix-helix-or-slim.md
@@ -1,10 +1,10 @@
 # Use UIx, Helix, or reagent-slim
 
-You're adopting re-frame2, but your team writes React function components in UIx or Helix, not Reagent's [hiccup](../glossary.md#hiccup). Or you're already on Reagent and the shipped bundle has grown a little too round for comfort. Either way, this page shows you how to run the *same* app on a different [substrate](../glossary.md#substrate) — the React-rendering layer underneath your [views](../glossary.md#view) — without touching a single [event](../glossary.md#event), [subscription](../glossary.md#subscription), [effect](../glossary.md#effect), or your [app-db](../glossary.md#app-db).
+You're adopting re-frame2, but your team writes React function components — UIx or Helix — and Reagent's [hiccup](../glossary.md#hiccup) isn't going to happen. Or you're already on Reagent, and the shipped bundle has grown a little too round for comfort. Both problems have the same fix: swap the [substrate](../glossary.md#substrate) — the React-rendering layer underneath your [views](../glossary.md#view) — and leave every [event](../glossary.md#event), [subscription](../glossary.md#subscription), [effect](../glossary.md#effect), and your [app-db](../glossary.md#app-db) untouched. This page shows you how.
 
-A word on the term *substrate*, since the rest of the page leans on it. A re-frame2 app is two layers stacked. On top sits your dataflow — events, subscriptions, effects, and the app-db map they all read and write — and it's plain Clojure data and functions, with no idea React exists. Underneath sits the [substrate](../glossary.md#substrate): the thin layer that actually drives a React renderer, turning your views into pixels. Reagent is one such substrate; UIx, Helix, and reagent-slim are three more. The whole trick of this page is that you can swap the bottom layer and the top layer never notices.
+A word on *substrate*, since the rest of the page leans on it. A re-frame2 app is two layers stacked. On top: your dataflow — events, subscriptions, effects, and the app-db map they all read and write — plain Clojure data and functions, with no idea React exists. Underneath: the [substrate](../glossary.md#substrate), the thin layer that actually drives a React renderer and turns your views into pixels. Reagent is one substrate. UIx, Helix, and reagent-slim are three more. The whole trick of this page: you can swap the bottom layer, and the top layer never notices.
 
-We'll build it up one step at a time: first the single line that picks a substrate, then a working UIx view, then how its callbacks [dispatch](../glossary.md#dispatch), then how you mount and scope it, and finally how Helix and reagent-slim fit the same mould. By the end you'll be able to boot one app on any of four substrates, write UIx/Helix views that read subs and dispatch correctly, and recognise the handful of errors the framework throws when you get the boundary wrong.
+We'll take it one step at a time: the single line that picks a substrate, then a working UIx view, then how its callbacks [dispatch](../glossary.md#dispatch), then how you mount and scope it, and finally how Helix and reagent-slim fit the same mould. By the end you'll be able to boot one app on any of four substrates, write UIx/Helix views that read subs and dispatch correctly, and recognise the handful of errors the framework throws when you get the boundary wrong.
 
 !!! note "Same app, four substrates — the only line that changes is `init!`"
 
@@ -58,7 +58,7 @@ That's the point: swapping stock Reagent for slim touches your `deps.edn` coordi
 
     In-tree the slim adapter lives at `re-frame.adapter.reagent-slim` — it has to, because the monorepo puts both it and the bridge adapter on one classpath and two namespaces can't share a name. The publication step (the `Rename adapter ns at publication` job in `.github/workflows/release.yml`) renames it to `re-frame.adapter.reagent` before packaging the jar. So a `:git/sha` consumer requires `re-frame.adapter.reagent-slim`, while a published-artefact consumer requires `re-frame.adapter.reagent`. Everything below assumes the published shape.
 
-There's deliberately no registry and no auto-install here, because the project holds boot to one rule: it must name its substrate in plain sight. Open any app's boot function and you can read its substrate straight off the page — no spelunking required. The framework enforces this strictly:
+There's deliberately no registry and no auto-install here, because boot is held to one rule: name your substrate in plain sight. Open any app's boot function and its substrate reads straight off the page — no spelunking. The framework enforces this strictly:
 
 - `(rf/init!)` with no argument is an arity error — `init!` has exactly one arity (it takes the adapter spec map), so there's no zero-arg form to fall through to.
 - A keyword, a `nil`, or anything that isn't the adapter spec map raises `:rf.error/no-adapter-specified`, whose message says it plainly: *"rf/init! takes the adapter spec map directly — there is no keyword form, no nil form, and no default-adapter registry."*
@@ -169,7 +169,7 @@ So the last move is to mount the root inside it. The scope shape takes a `:frame
   react-root)
 ```
 
-Children ride the native `$` trailing-args channel — `($ frame-provider {:frame :f} ($ a) ($ b))` — exactly the shape every other UIx/Helix component uses. There's no `:children` prop-map key to remember — the subtree rides the trailing-args channel, so there's no key to forget.
+Children ride the native `$` trailing-args channel — `($ frame-provider {:frame :f} ($ a) ($ b))` — exactly the shape every other UIx/Helix component uses. No `:children` prop-map key to remember, so no key to forget.
 
 ??? info "For JavaScript developers"
 
@@ -197,9 +197,7 @@ The `{:frame …}` scope shape from Step 4 scopes a frame that already exists. T
    ($ checkout-app))
 ```
 
-!!! warning "Gotcha — the prop map selects the shape"
-
-    A `:frame` key selects scope; *anything else* selects ensure, which **requires** a keyword `:id`. So if you mean to ensure a frame but forget `:id` (or pass an empty `{}`), the provider reads it as an ensure shape with no id and raises `:rf.error/ensure-frame-provider-missing-id`. The fix is in the message: pass `:id` to ensure a frame, or `:frame` to scope an existing one.
+And here is that stumble, said plainly: **the prop map selects the shape.** A `:frame` key selects scope; *anything else* selects ensure, which **requires** a keyword `:id`. So if you mean to ensure a frame but forget `:id` (or pass an empty `{}`), the provider reads it as an ensure shape with no id and raises `:rf.error/ensure-frame-provider-missing-id`. The fix is in the message: pass `:id` to ensure a frame, or `:frame` to scope an existing one.
 
 !!! note "Idempotent re-mount is safe"
 

--- a/docs/core/how-to/validate-with-schemas.md
+++ b/docs/core/how-to/validate-with-schemas.md
@@ -4,7 +4,7 @@ Picture an [event handler](../glossary.md#event-handler) — the pure function a
 
 A [schema](../glossary.md#schema) turns that silent corruption into a loud, named, instant failure. You describe the shape of a slice once, register it, and from then on the runtime checks every write against it. When a write doesn't conform you get the handler's name, the offending value, and the exact path it landed on — at the moment it happens, not six weeks later in a bug report. And it costs production nothing: validation is **dev-only by default** and is elided entirely from a release build.
 
-This page builds up one idea at a time, starting from the simplest useful thing — a schema on one app-db path — then schemas on events, the handful of shapes you'll actually write, the other surfaces you can validate, how to read a failure, and how to decide whether a schema is even worth writing.
+This page builds up one idea at a time. The simplest useful thing first — a schema on one app-db path — then schemas on events, the handful of shapes you'll actually write, the other surfaces you can validate, how to read a failure, and how to decide whether a schema is worth writing at all.
 
 ??? info "Coming from Zod?"
 
@@ -28,7 +28,7 @@ Start with the most common case — pin the shape of one slice of app-db. `reg-a
   (rf/reg-app-schema [:auth] {:schema AuthSlice}))
 ```
 
-Two pieces of that snippet are new and worth naming up front, because they recur on every example below.
+Two pieces of that snippet are new. Both recur on every example below, so let's name them now.
 
 The schema itself — `AuthSlice` — is just a **vector of plain data**: `[:map [:user ...] [:token ...]]`. No builder chain, no class to instantiate. That's [Malli](https://github.com/metosin/malli), the default schema language; we'll learn its handful of shapes in a moment.
 
@@ -104,9 +104,7 @@ The piece to watch is the `[:int {:min 0}]` on the `[:howto.schema/article]` sli
 
 Click `unfavorite` down to `0` and keep clicking: nothing happens, because the `pos?` guard stands. Now simulate the bug the schema exists to catch. **Delete the guard** — replace `(if (pos? n) (-> db …) db)` with just the `(-> db …)` threading — re-evaluate, and click `unfavorite` past zero. The handler writes `-1`, and `[:int {:min 0}]` rejects it. The browser console shows the `:rf.error/schema-validation-failure`, and the count on screen stays `0`: the write was rolled back, so app-db never held the bad value. Put the guard back when you're done.
 
-!!! warning "Gotcha — the rollback is a debugging aid, not app behaviour"
-
-    Validation, rollback included, is elided from production builds. In production that unguarded handler happily ships `-1`. So the handler keeps its real guard, *always*; the schema's job is to catch the day the guard gets deleted, refactored wrong, or bypassed by some *other* handler writing the same slice — in dev, the moment it happens.
+One thing to hear plainly before you move on: **the rollback is a debugging aid, not app behaviour.** Validation, rollback included, is elided from production builds — in production that unguarded handler happily ships `-1`. So the handler keeps its real guard, *always*. The schema is the tripwire that catches the day the guard gets deleted, refactored wrong, or bypassed by some *other* handler writing the same slice — in dev, the moment it happens.
 
 ## The shapes you'll actually write
 
@@ -151,9 +149,9 @@ Paths nest and overlap freely, which is more useful than it first sounds: a writ
 
 These paths address *your* data only. The framework's [runtime-db partition next door](../concepts/app-db.md) validates through its own machinery, and reaching into it is an error (see the callout below).
 
-!!! warning "Gotcha — two ways to get a registration wrong"
+!!! warning "Gotcha — three ways to get a registration wrong"
 
-    Both fail closed, because a malformed path or schema could otherwise install a validator that silently never checks anything — the worst outcome, a false sense of safety.
+    All three fail closed, because a malformed path or schema could otherwise install a validator that silently never checks anything — the worst outcome, a false sense of safety.
 
     - **A non-sequential path is rejected at registration.** The path must be a `get-in`-shaped sequential collection of keys (or `[]` for the root). Pass a bare keyword, string, or map and `reg-app-schema` throws `:rf.error/app-schema-bad-path` *before* anything registers. `reg-app-schemas` validates every key up front and rejects the whole batch atomically (`:rf.error/app-schemas-bad-batch` for a non-map argument). This check is always-on, not dev-only.
     - **A path that reaches into runtime-db is a hard error.** App-db schemas validate the [app-db](../glossary.md#app-db) partition only. Register one whose first segment is a reserved `:rf.runtime/*` key (or the retired `:rf/runtime` root) and you get `:rf.error/app-schema-runtime-path` at registration — [runtime-db](../glossary.md#runtime-db) is framework-owned, with no public schema surface; the remedy is to drop the runtime path. (See [app-db's two partitions](../concepts/app-db.md) for why the boundary is structural.)
@@ -238,9 +236,7 @@ Two tags reward a closer look. `:path` is the **failing leaf** — the registere
 
 In **Xray**, these don't pile up in a footnote: the four runtime boundaries (`:event` / `:app-db` / `:fx-args` / `:sub-return`) attach to the matching DISPATCH / HANDLER / FX / SUBSCRIPTIONS step of the event row, and an `:app-db` rollback mutes every downstream step with a "run rolled back" banner so you read the blast radius at a glance. [Debug with Xray](../../xray/index.md) walks the panel.
 
-!!! note "Why this matters"
-
-    A structured trace is the one thing that keeps documentation honest: the schema *is* the slice's description, and the runtime would catch any lie. A schema can't drift from reality, because the moment it does, a dispatch fails.
+One quiet consequence is worth saying plainly: the schema *is* the slice's description, and the runtime would catch any lie. A schema can't drift from reality, because the moment it does, a dispatch fails.
 
 !!! warning "Gotcha — editing a schema mid-session can flag a value no handler wrote"
 
@@ -346,3 +342,5 @@ One question decides it: *could this schema catch something no test of yours wou
 **Skip it** when the slice is a single scalar — `{:nav/open? true}` doesn't need `[:map [:open? :boolean]]`. And never register `:any` as a placeholder: it implies a constraint that isn't there, which is worse than silence.
 
 Three conventions are worth adopting from day one. Use `[:enum …]` for fixed value sets, never bare `:keyword` — the enum is where the leverage lives. Keep maps open, closing only at boundaries. And keep each schema in the same namespace as the handlers that write its slice, because the schema is the slice's documentation, and documentation lives next to the thing it describes.
+
+And when a slice clears the bar, promise me you'll write the schema. Promise me. Okay, good.

--- a/docs/core/testing/event-handlers.md
+++ b/docs/core/testing/event-handlers.md
@@ -1,8 +1,8 @@
 # Test an event handler
 
-You wrote an [**event handler**](../glossary.md#event-handler) — the pure function that runs in response to a dispatched [event](../glossary.md#event) and computes how your app's state should change — and now you want a unit test for it. The good news: this test runs in a millisecond, with no browser, no DOM, and no test double for the network or the clock. The recipe is short — pull the handler out of the [registrar](../glossary.md#registrar), call it with literal values, assert on what it returns.
+You wrote an [**event handler**](../glossary.md#event-handler) — the pure function that runs in response to a dispatched [event](../glossary.md#event) and computes how your app's state should change — and now you want a unit test for it. Good instinct: this is where most of your testing effort should go, because this is where most of the logic lives. It's also the cheapest test you'll write — a millisecond, no browser, no DOM, no test double for the network or the clock. The recipe is short: pull the handler out of the [registrar](../glossary.md#registrar), call it with literal values, assert on what it returns.
 
-Hold on to one sentence as you read this page, because it's the whole trick:
+One sentence is the whole trick. Hold on to it as you read this page:
 
 > **The handler returned a map. You checked the map.**
 
@@ -46,13 +46,9 @@ One setup detail makes it work. Your test namespace needs three requires — `cl
 
     This is the reducer test — call the function, check the return — except it never hits the ceiling where you'd reach for `vi.mock` or fake timers. A handler's world arrives as declared data and its side effects leave as data, so the plain function call covers the ground that mocks cover in JS. If you're coming from Vitest or Jest, notice what's *absent*: no mock module, no spy, no `beforeEach` wiring up a fake clock.
 
-!!! warning "Gotcha — `handler-meta` returns `nil` for an unregistered id"
+One gotcha before we add anything, because it produces a misleading error. `handler-meta` returns `nil` for an unregistered id. Typo the id, or forget the app-namespace require so the registration never ran, and `(rf/handler-meta :event :articels/page-changed)` returns `nil` — then `(:handler-fn nil)` is `nil`, so the next line tries to *call* `nil` and you get a "nil is not a function" blow-up rather than a clear "no such handler". The two usual causes are a misspelled id and a missing `:require`. If a handler you *know* you registered comes back `nil`, check the require list first.
 
-    Typo the id, or forget the app-namespace require so the registration never ran, and `(rf/handler-meta :event :articels/page-changed)` returns `nil` — then `(:handler-fn nil)` is `nil`, so the next line tries to *call* `nil` and you get a "nil is not a function" blow-up rather than a clear "no such handler". The two usual causes are a misspelled id and a missing `:require`. If a handler you *know* you registered comes back `nil`, check the require list first.
-
-!!! note "A handler may legitimately return `nil`"
-
-    A handler that performs only side effects — say it dispatches a follow-up but changes no state — returns `nil`, or an effect map with no `:db`, and that's valid (see [Effects](../concepts/effects.md)). Test it by asserting on `:fx` rather than `:db`; don't read `nil` as a failure.
+The mirror case is legitimate. A handler that performs only side effects — say it dispatches a follow-up but changes no state — returns `nil`, or an effect map with no `:db`, and that's valid (see [Effects](../concepts/effects.md)). Test it by asserting on `:fx` rather than `:db`; don't read `nil` as a failure.
 
 ## 2. A handler that needs the world
 
@@ -166,7 +162,7 @@ This is exactly the trap you want sprung. A silently-minted random value would m
 
 ### Seeding state: the frame boots it, the body tests it
 
-When a test needs state built up *before* the dispatch it's actually about, don't stack setup `dispatch-sync` calls above the action — hand the setup to `make-frame` as `:initial-events`, the same ordered event script a production [`reg-frame`](../concepts/frames.md#seeding-initial-state) boots with. Each step dispatches synchronously and drains to completion, in order, while the frame is constructed. The frame arrives already in the state the test needs, and the body holds exactly one dispatch — the one under test:
+When a test needs state built up *before* the dispatch it's actually about, don't stack setup `dispatch-sync` calls above the action — that buries the dispatch under test. Events are the language of the system, and setup can speak it too, just not in the test body: hand the setup to `make-frame` as `:initial-events`, the same ordered event script a production [`reg-frame`](../concepts/frames.md#seeding-initial-state) boots with. Each step dispatches synchronously and drains to completion, in order, while the frame is constructed. The frame arrives already in the state the test needs, and the body holds exactly one dispatch — the one under test:
 
 ```clojure
 (deftest page-change-from-a-seeded-feed
@@ -207,9 +203,7 @@ For the assertion itself, `test-support` ships two `clojure.test`-aware helpers 
 
 There's a footgun here worth slowing down for. `with-new-frame` gives each test its own app-db, but it does **not** give each test its own registrar. `reg-event` and its siblings register into a process-global [registrar](../glossary.md#registrar) — one table shared across the whole test run. (This is the rule in action: a frame isolates **state, not registrations** — see [Frames](../concepts/frames.md).)
 
-!!! warning "Gotcha — same id, last load wins"
-
-    If two test namespaces register different handlers under the same id, the later load silently wins. That's how you get the classic flake-hunt horror: every test passes alone, the suite fails together, and the failure jumps around as test order changes. It's maddening to chase, so guard against it before it bites.
+So: if two test namespaces register different handlers under the same id, the later load silently wins. That's how you get the classic flake-hunt horror — every test passes alone, the suite fails together, and the failure jumps around as test order changes. Maddening to chase. Cheap to prevent.
 
 If your tests — or any helpers they load — register anything themselves, bracket each test with a registrar snapshot/restore so the table is put back the way it was:
 
@@ -236,9 +230,7 @@ If your tests — or any helpers they load — register anything themselves, bra
 
 `make-reset-runtime-fixture` is the right default because its resets are no-ops when an artefact is absent — a plain JVM event-handler suite that never pulls in flows or schemas doesn't pay for resetting them.
 
-!!! warning "Gotcha — the two fixtures have different call shapes"
-
-    `with-fresh-registrar` *takes a thunk and runs it* (`(ts/with-fresh-registrar test-fn)`), while `make-reset-runtime-fixture` *returns a fixture fn* you hand to `use-fixtures` (`(ts/make-reset-runtime-fixture {})`). Mixing the two shapes up is the usual stumble — if `use-fixtures` complains, check which side of this line you're on.
+One last stumble, and it's a common one: the two fixtures have different call shapes. `with-fresh-registrar` *takes a thunk and runs it* (`(ts/with-fresh-registrar test-fn)`), while `make-reset-runtime-fixture` *returns a fixture fn* you hand to `use-fixtures` (`(ts/make-reset-runtime-fixture {})`). If `use-fixtures` complains, check which side of this line you're on.
 
 ??? info "For JavaScript developers"
 

--- a/docs/core/testing/pipeline-runs.md
+++ b/docs/core/testing/pipeline-runs.md
@@ -4,7 +4,7 @@ You have an [event handler](../glossary.md#event-handler) that does real work. I
 
 What you want to test is that journey end to end: an event goes in, the queue [drains to a fixed point](../glossary.md#drain--run-to-completion), and the final committed [`app-db`](../glossary.md#app-db) comes out the other side. This recipe tests exactly that, on the JVM. No browser, no mock library, milliseconds per test.
 
-The trick that makes it fast is one idea: **you don't mock, you redirect.** The handler under test runs unmodified and produces the same [effect](../glossary.md#effect) data it produces in production — an effect is just a *description* of work, returned as data. The test changes only *who answers* that effect. No service worker, no patched `fetch`, no module-mock hoisting.
+One idea makes it that fast, and the whole recipe hangs off it: **you don't mock, you redirect.** The handler under test runs unmodified and produces the same [effect](../glossary.md#effect) data it produces in production — an effect is just a *description* of work, returned as data. The test changes only *who answers* that effect. No service worker, no patched `fetch`, no module-mock hoisting.
 
 ??? info "Coming from MSW?"
 
@@ -12,7 +12,7 @@ The trick that makes it fast is one idea: **you don't mock, you redirect.** The 
 
 ## The shape of every pipeline-run test
 
-Start with the simplest possible version. Every pipeline-run test is the same three moves: a fresh [frame](../glossary.md#frame), a [`dispatch-sync`](../glossary.md#dispatch-sync), an assertion against the frame's `app-db`. (A frame is one isolated, running instance of your app — its own `app-db`, its own event queue.)
+Start with the simplest possible version. Every test has three steps — setup, execute, verify — and a pipeline-run test spends them the same way every time: a fresh [frame](../glossary.md#frame), a [`dispatch-sync`](../glossary.md#dispatch-sync), an assertion against the frame's `app-db`. (A frame is one isolated, running instance of your app — its own `app-db`, its own event queue.)
 
 ```clojure
 (rf/reg-event :counter/inc
@@ -71,7 +71,7 @@ The counter was a warm-up. Now a real chain — a RealWorld-style login that sta
                    :session/error  (:kind error))}))
 ```
 
-Two *seams* are already visible in that code — a "seam" being a spot where the test can step in and substitute a value without editing the handler. First, the handler **declares** the clock with `:rf.cofx/requires [:rf/time-ms]` and reads it as a delivered fact — a [coeffect](../glossary.md#coeffect), a declared input the framework injects — instead of calling the host clock directly. That's the seam that lets a test hand it an exact value. Second, the HTTP request is an **effect** in the returned effect map — a described side-effect, data, not a live connection — which is the seam that lets a test answer it without a network. Both seams are the same idea: the world arrives as data (coeffects) and leaves as data (effects), the model owned by [Effects and coeffects](../concepts/coeffects.md).
+Now look at that code for the *seams* — a "seam" being a spot where the test can step in and substitute a value without editing the handler. There are two. First, the clock: the handler **declares** it with `:rf.cofx/requires [:rf/time-ms]` and reads it as a delivered fact — a [coeffect](../glossary.md#coeffect), a declared input the framework injects — instead of calling the host clock directly. That seam lets a test hand it an exact value. Second, the HTTP request: it's an **effect** in the returned effect map — a described side-effect, data, not a live connection. That seam lets a test answer it without a network. Both seams are the same idea: the world arrives as data (coeffects) and leaves as data (effects), the model owned by [Effects and coeffects](../concepts/coeffects.md).
 
 !!! note "Where do `:value` and `:error` come from?"
 
@@ -170,9 +170,7 @@ Both tests above assert the *settled* state — the reply has already folded in 
 
 That last test reaches for `ts/poll-until` — `ts` is the conventional alias for `re-frame.test-support`, the test-only helper namespace already in this page's require block. `poll-until` is the **settle** primitive: it polls a predicate against a bounded deadline (defaults `:timeout-ms 2000`, `:interval-ms 5`) and fails fast if the condition never holds, so a genuinely stuck drain surfaces as a timeout rather than a hang. On the JVM it's synchronous and returns the truthy value (and on timeout throws an `ex-info` carrying `:rf.error/poll-until-timeout`, so you can branch on the discriminator); on CLJS it returns a `js/Promise` you compose under `cljs.test/async` — resolving with the value, rejecting on timeout. The optional `:label` rides into the timeout message, so a failing poll names *what* it was waiting for instead of a bare deadline. Reach for it whenever a reply or a scheduled event drains *past* `dispatch-sync` — a deferred reply, a machine `:after` transition, a `:dispatch-later`.
 
-!!! warning "Gotcha — `poll-until` is for *settles*, not *windows*"
-
-    Don't reach for it to wait out a timer window (a grace period, a debounce). That's a `Thread/sleep` whose duration *is* the contract — annotate it `;; Timer-semantics sleep: ...` so audits leave it alone. `poll-until` waits for a state change to *appear*; a timer sleep proves something does or doesn't happen *within* a fixed window. Different jobs.
+One misuse to head off now, because it looks so plausible: `poll-until` is for *settles*, not *windows*. Don't reach for it to wait out a timer window (a grace period, a debounce) — that's a `Thread/sleep` whose duration *is* the contract, annotated `;; Timer-semantics sleep: ...` so audits leave it alone. `poll-until` waits for a state change to *appear*; a timer sleep proves something does or doesn't happen *within* a fixed window. Different jobs.
 
 ### Redirect anything: `:fx-overrides`
 
@@ -276,7 +274,7 @@ Keys are interceptor *references* — a bare keyword matches that registered int
 
 ## Replay a bug as a regression test
 
-A user reports: "I favorited an article, then unfavorited it, and the count stuck." Here's the thing — that description is really just a *list of events in order*: favorite, then unfavorite. And in re-frame2 the current `app-db` is nothing more than what you get by starting from the initial state and applying each event in turn — so replaying that exact list rebuilds the exact state, bug and all. A bug report **is a replayable event sequence in disguise.**
+A user reports: "I favorited an article, then unfavorited it, and the count stuck." Read that report again — it isn't prose, it's a *list of events in order*: favorite, then unfavorite. Events are the language of the system, and the user has just dictated a program in it. And in re-frame2 the current `app-db` is nothing more than what you get by starting from the initial state and applying each event in turn — so replaying that exact list rebuilds the exact state, bug and all. A bug report **is a replayable event sequence in disguise.**
 
 If [Xray](../glossary.md#xray) — the dev inspector — was open when the bug happened, don't even reconstruct the sequence from prose: read the exact event rows (and each one's `:rf.cofx` facts) straight off its recorded [epoch](../glossary.md#epoch) ledger and paste them in. The test is just that sequence replayed with the right answer pinned:
 

--- a/docs/core/testing/subscriptions.md
+++ b/docs/core/testing/subscriptions.md
@@ -1,8 +1,12 @@
 # Test a subscription
 
-A [subscription](../concepts/subscriptions.md)'s computation is a pure function of `(inputs, query-v)` — so you don't need a reactive runtime, a DOM, or a browser to test what it *computes*. `rf/compute-sub` runs a sub's body against an app-db **value** and returns the result. It's JVM-runnable: no Reagent, no React, no installed [adapter](../glossary.md#adapter), no live cache.
+A [subscription](../concepts/subscriptions.md) is a formula over facts. You test a formula the spreadsheet way: hand it the cells, look at the answer.
+
+That works because a subscription's computation is a pure function of `(inputs, query-v)` — so you need no reactive runtime, no DOM, and no browser to test what it *computes*. `rf/compute-sub` runs a sub's body against an app-db **value** and returns the result. It runs on the JVM: no Reagent, no React, no installed [adapter](../glossary.md#adapter), no live cache.
 
 > **A subscription test is `compute-sub` against a db value — the whole `:<-` chain resolves for you.**
+
+That's the whole recipe. The rest of this page is choosing where the db value comes from — and knowing the one thing a sub test doesn't prove.
 
 The sub under test here is the three-layer cart chain from [Subscriptions](../concepts/subscriptions.md#three-layers-one-graph): `:cart/items` and `:cart/category-filter` extract, `:cart/by-price` sorts, `:cart/visible` filters.
 
@@ -25,11 +29,13 @@ The sub under test here is the three-layer cart chain from [Subscriptions](../co
            (mapv :sku (rf/compute-sub [:cart/visible] db))))))
 ```
 
-`compute-sub` resolves the entire input chain for you — pass it the outer query vector and a `db`, and it computes `:cart/items`, then `:cart/by-price`, then `:cart/visible`, in dependency order. It's **pure**: the same `(query-v, db)` always returns the same value, with no cache carried between calls. That's what makes it the workhorse for sub tests. A parametric sub tests the same way — the arguments ride the query vector: `(rf/compute-sub [:article/page "welcome"] db)`.
+Notice what you didn't write: nothing in the test computes `:cart/items` or `:cart/by-price`. Pass `compute-sub` the outer query vector and a `db`, and it resolves the entire input chain for you, in dependency order. It's **pure** — the same `(query-v, db)` always returns the same value, with no cache carried between calls — and that's what makes it the workhorse for sub tests. A parametric sub tests the same way, the arguments riding the query vector: `(rf/compute-sub [:article/page "welcome"] db)`.
 
 ## The sharper variant: drive real events first
 
-Hand-rolling a literal `db` is the escape hatch for very simple readers. For anything that depends on the *shape* your events actually produce, it silently rots the day a handler changes that shape — the test keeps passing against a db your app no longer builds. So the more robust style is to boot a test [frame](../glossary.md#frame) through real events — `:initial-events` on `make-frame`, each step an ordinary dispatch drained in order at construction — and read the sub against the db that produces. The events aren't the subject here; they're setup, so they ride the frame's construction rather than the test body:
+A hand-rolled literal `db` has a hidden cost: the test now knows the internal structure of app-db. For a very simple reader, fine — that's the escape hatch. But for anything that depends on the *shape* your events actually produce, it rots silently: the day a handler changes that shape, the test keeps passing against a db your app no longer builds. Green, and wrong.
+
+The fix is to build the db the way your app builds it — through events. Boot a test [frame](../glossary.md#frame) through real events — `:initial-events` on `make-frame`, each step an ordinary dispatch drained in order at construction — and read the sub against the db that produces. The events aren't the subject here; they're setup, so they ride the frame's construction rather than the test body:
 
 ```clojure
 (deftest cart-count-after-events
@@ -40,16 +46,14 @@ Hand-rolling a literal `db` is the escape hatch for very simple readers. For any
 
 !!! note "Two styles, one rule of thumb"
 
-    `compute-sub` against a literal `db` when the reader is trivial and the shape is obvious; seed with real events and read `(rf/app-db-value f)` when the db shape matters — your test then exercises the same db your handlers actually build, so it can't drift from reality. Avoid `subscribe` + deref in tests altogether: the reactive runtime is pure overhead for a value assertion, and it needs a live cache and an installed adapter.
+    `compute-sub` against a literal `db` when the reader is trivial and the shape is obvious. Seed with real events and read `(rf/app-db-value f)` when the db shape matters — that test exercises the same db your handlers actually build, so it can't drift from reality. And skip `subscribe` + deref in tests altogether: the reactive runtime is pure overhead for a value assertion, and it needs a live cache and an installed adapter.
 
-!!! warning "Gotcha — what a sub test can't see"
-
-    `compute-sub` runs the *computation*, not the *reactive machinery* — it proves the value is right, not that a view re-renders when it changes. That's by design: change propagation (the equality gate, ref-counting, disposal) is the framework's contract, not your code, so you don't re-test it per sub. When the thing under test genuinely is "the view updated", that's a [view test](views.md) with the app fixture, or a [pipeline-run test](pipeline-runs.md) asserting on committed state.
+Now the boundary, said plainly, because it spares you a whole category of useless test: `compute-sub` runs the *computation*, not the *reactive machinery*. It proves the value is right — not that a view re-renders when it changes. That's by design. Change propagation (the equality gate, ref-counting, disposal) is the framework's contract, not your code, so you don't re-test it per sub. When the thing under test genuinely is "the view updated", that's a [view test](views.md) with the app fixture, or a [pipeline-run test](pipeline-runs.md) asserting on committed state.
 
 ## When the sub carries a `:schema`
 
-A sub registered with output [`:schema`](../concepts/subscriptions.md#registration-metadata-docs-schema-and-classification) metadata validates its computed value at the `:sub-return` boundary in dev. Your value assertions don't change — but a shape bug in the computation surfaces as a structured `:rf.error/schema-validation-failure` rather than a downstream view choking, and [asserting on that record](../concepts/errors.md#test-the-structure-not-the-string) is itself an ordinary listener-based test.
+Nothing about your assertions changes. A sub registered with output [`:schema`](../concepts/subscriptions.md#saying-things-about-a-sub-metadata) metadata validates its computed value at the `:sub-return` boundary in dev — so a shape bug in the computation surfaces as a structured `:rf.error/schema-validation-failure` rather than a downstream view choking on it. And [asserting on that record](../concepts/errors.md#test-the-structure-not-the-string) is itself an ordinary listener-based test.
 
 ??? info "For JavaScript developers"
 
-    This is the payoff of computation functions being pure. There is no React Testing Library, no `renderHook`, no jsdom, no provider wrapper to set up — a subscription test is a plain function call asserting on a plain value, and it runs on the JVM at unit-test speed. The reactive runtime exists only to *cache and notify* in a live app; the *logic* is just data in, data out, testable in isolation.
+    Pause on what's *absent* from this page. No React Testing Library, no `renderHook`, no jsdom, no provider wrapper to set up — a subscription test is a plain function call asserting on a plain value, and it runs on the JVM at unit-test speed. That's the payoff of computation functions being pure: the reactive runtime exists only to *cache and notify* in a live app; the *logic* is just data in, data out, testable in isolation.

--- a/docs/core/testing/views.md
+++ b/docs/core/testing/views.md
@@ -1,10 +1,12 @@
 # Test a view
 
-You've tested the [handler](event-handlers.md) and the [pipeline run](pipeline-runs.md), and now you want the same confidence about a view: the right structure comes out, the right text shows for a given state, and the right handler is wired to the right button. Like the rest of the suite, this needs no browser. A [view](../glossary.md#view) is a pure function that returns [hiccup](../glossary.md#hiccup) — plain data — so a view test is a function call and a tree walk, and it runs on the JVM in milliseconds.
+You've tested the [handler](event-handlers.md) and the [pipeline run](pipeline-runs.md). Now the view: the right structure comes out, the right text shows for a given state, and the right handler is wired to the right button.
+
+No browser for this one either. A [view](../glossary.md#view) is a pure function that returns [hiccup](../glossary.md#hiccup) — plain data — so a view test is a function call and a tree walk, and it runs on the JVM in milliseconds.
 
 > **A view test calls the function and walks the returned data — no DOM, no JSDOM, no `act()`.**
 
-One honest framing before the recipe: **most "view bugs" are data bugs.** A view holds no state and decides nothing, so when the screen is wrong the cause is nearly always the [subscription](subscriptions.md) or [handler](event-handlers.md) upstream — pure functions with cheaper tests ([Views](../concepts/views.md#when-something-renders-wrong) makes the case). Reach for a view test for what a view genuinely *owns*: its structure, its text, and its wiring.
+One honest framing before the recipe: **most "view bugs" are data bugs.** A view holds no state and decides nothing, so when the screen is wrong, the culprit is nearly always the [subscription](subscriptions.md) or [handler](event-handlers.md) upstream — pure functions with cheaper tests ([Views](../concepts/views.md#when-something-renders-wrong) makes the case). A view test is for what a view genuinely *owns*: its structure, its text, and its wiring. That's the whole list.
 
 The toolkit is `re-frame.test-helpers` — pure walks over hiccup, [catalogued in the API reference](../../api/re-frame.test-helpers.md) — alongside the `re-frame.test-support` fixtures you already use:
 
@@ -37,9 +39,7 @@ Give the nodes you'll assert on a stable address at the view site — `th/testid
 
 `find-by-testid` returns the first node carrying that `:data-testid`; `text-content` collects the string leaves under it. Their generic siblings — `find-by-attr`, `find-all-by-testid`, `find-by-testid-prefix`, `attrs`, `children` — cover lists and custom attributes ("every node whose testid starts with `row-`").
 
-!!! note "Nested views expand for you"
-
-    A view that renders another view returns it as a *component reference* — `[cart-line item]`, a vector whose head is a function, not a tag. The finders and `text-content` expand those references as they walk, so asserting *through* a child view just works. `th/expand-tree` is the same expansion as a standalone step — reach for it when you want the fully-expanded tree as a value (to `let`-bind once for several assertions, or to walk by hand).
+What about a view that renders *another* view? It comes back as a *component reference* — `[cart-line item]`, a vector whose head is a function, not a tag. The finders and `text-content` expand those references as they walk, so asserting *through* a child view just works. And when you want the fully-expanded tree as a value — to `let`-bind once for several assertions, or to walk by hand — `th/expand-tree` is the same expansion as a standalone step.
 
 ??? info "Coming from React Testing Library?"
 
@@ -63,9 +63,7 @@ A presentational view takes data as arguments. A *connected* view subscribes and
 
 The two dispatches in that body are the *action under test* — the counter incrementing is the point. When a view instead needs state built *before* the action (a populated cart, a signed-in user), seed it in the fixture opts rather than the body: `:frame-config` merges into the fixture frame's config map, so `:frame-config {:initial-events [[:cart/seed-items …]]}` boots the frame through the same [construction script](../concepts/frames.md#seeding-initial-state) `make-frame` takes. The body then holds only the interaction being tested.
 
-!!! warning "Gotcha — `:install` registrations land in the process-global registrar"
-
-    The fixture destroys its *frame*, but registrations are global, exactly as [Test an event handler](event-handlers.md#4-the-trap-frames-dont-isolate-registrations) warns. Pair `with-app-fixture` with the `make-reset-runtime-fixture` shown at the top so one test's registrations can't leak into the next.
+One trap here, and it's the same one [Test an event handler](event-handlers.md#4-the-trap-frames-dont-isolate-registrations) warns about: the fixture destroys its *frame*, but **`:install` registrations land in the process-global registrar**. Pair `with-app-fixture` with the `make-reset-runtime-fixture` shown at the top, so one test's registrations can't leak into the next.
 
 ## 3. Drive the wiring
 
@@ -82,7 +80,11 @@ The last thing a view owns is the connection from a node to its dispatch. `th/in
     (th/wait-until :counter-display "1" {:label "counter reached 1"})))
 ```
 
-Two details carry this test. `invoke-handler` **throws** when the node has no handler under that key — a missing handler is almost always the bug you're hunting, so it refuses to pass silently. And the assertion is `th/wait-until`, not `expect-text`: the invoked `:on-click` fires a plain `dispatch`, which queues rather than draining synchronously, so the test polls the rendered view against a bounded deadline (the view-side sibling of `ts/poll-until` — same defaults, same loud timeout carrying `:rf.error/wait-until-timeout`). The same form covers any async settle whose outcome is *visible in the view* — an HTTP reply, a machine `:after` transition, a scheduled event. For a synchronous run, `expect-text` after `dispatch-sync` is enough.
+Two details carry this test.
+
+First, `invoke-handler` **throws** when the node has no handler under that key. A missing handler is almost always the bug you're hunting, so it refuses to pass silently.
+
+Second, the assertion is `th/wait-until`, not `expect-text`. The invoked `:on-click` fires a plain `dispatch`, which queues rather than draining synchronously, so the test polls the rendered view against a bounded deadline (the view-side sibling of `ts/poll-until` — same defaults, same loud timeout carrying `:rf.error/wait-until-timeout`). The same form covers any async settle whose outcome is *visible in the view* — an HTTP reply, a machine `:after` transition, a scheduled event. For a synchronous run, `expect-text` after `dispatch-sync` is enough.
 
 ## When you want more than hiccup
 
@@ -94,4 +96,8 @@ Three neighbouring tools pick up where the tree walk stops:
 
 ## When not to test a view
 
-Don't re-prove upstream logic through the view. If the assertion is really "the sort order is right" or "the total is correct", that's a [subscription test](subscriptions.md) — cheaper, and it fails at the function that owns the logic. If it's "the state changed correctly", that's a [handler test](event-handlers.md). A view test earns its keep only when the thing under test is the view's own contribution: structure, text, wiring. Most views are boring enough — deliberately — that they need no test at all.
+A confession to close on: I don't write many view tests. There, I said it.
+
+Every test you write is a ball and chain you must forevermore drag about, so each one has to pay its way — and a view test that re-proves upstream logic doesn't. If the assertion is really "the sort order is right" or "the total is correct", that's a [subscription test](subscriptions.md) — cheaper, and it fails at the function that owns the logic. If it's "the state changed correctly", that's a [handler test](event-handlers.md). A view test earns its keep only when the thing under test is the view's own contribution: structure, text, wiring.
+
+Most views are boring enough — deliberately — that they need no test at all. Boring is the goal.

--- a/docs/core/where-state-lives.md
+++ b/docs/core/where-state-lives.md
@@ -1,8 +1,12 @@
 # Where should this value live?
 
-You have a value — a cart total, an article you fetched, the step a checkout is sitting in — and re-frame2 hands it four possible homes: a [**subscription**](glossary.md#subscription) (a derived value computed on demand), a [**flow**](glossary.md#flow) (a derived value written into your state), a [**resource**](../resources/glossary.md#resource) (a cached copy of server data), or a [**machine**](../machines/glossary.md#machine) (a process with named states). Pick the wrong one and the value fights you: it goes stale, it lies to your handlers, it scatters across booleans nobody keeps in sync. Pick the right one and it just behaves — because each home is shaped for a different job.
+You have a value.
 
-This is the page every other concept page links back to instead of answering the question a fifth time. The whole decision comes down to **four questions, asked in order — the first *yes* is your answer.** Read on and we'll grow one value — a shopping cart — until it has lived in all four homes and you can feel why each one exists.
+A cart total. An article you fetched. The step a checkout is sitting in. And re-frame2 hands it four possible homes: a [**subscription**](glossary.md#subscription) (a derived value computed on demand), a [**flow**](glossary.md#flow) (a derived value written into your state), a [**resource**](../resources/glossary.md#resource) (a cached copy of server data), or a [**machine**](../machines/glossary.md#machine) (a process with named states).
+
+Pick the wrong home and the value fights you. It goes stale. It lies to your handlers. It scatters across booleans nobody keeps in sync. Pick the right home and it just behaves — because each home is shaped for a different job.
+
+This is the page every other concept page links back to instead of answering the question a fifth time. And the whole decision comes down to **four questions, asked in order — the first *yes* is your answer.** We'll grow one value — a shopping cart — until it has lived in all four homes, and you can feel why each one exists.
 
 ## The four questions
 
@@ -14,6 +18,8 @@ Ask them top to bottom. Stop at the first *yes*.
 4. **Does it have a lifecycle of its own — named states, timers, retries, cancellation?** → It's a **machine**. ([State machines](../machines/concepts.md))
 
 The order sorts by cost, cheapest first. A subscription costs nothing to declare and stores nothing. A flow pays an `app-db` write. A resource brings a whole cache. A machine brings a whole transition table. So you reach for a heavier home only when the value genuinely needs what it buys. **The cheapest home that fits is the right one.**
+
+Read that again — it's the load-bearing sentence of this page. Everything below is that one rule, unpacked four times.
 
 !!! note "Why ask in order?"
 
@@ -29,7 +35,9 @@ The order sorts by cost, cheapest first. A subscription costs nothing to declare
 
 ## One value, four homes: the cart
 
-The fastest way to feel the four questions is to follow a single value as a feature grows up. We'll take a shopping cart and let it pick up obligations until it has needed all four homes in turn.
+The fastest way to feel the four questions is to follow a single value as a feature grows up — because a value moves house the way people do. It starts out owning nothing, recomputed fresh whenever anyone asks. Then it needs a fixed address other code can find it at. Then it's dealing with a landlord on another continent who can change the place while you're out. And eventually it has house rules, a timer on the porch light, and a homeowners' association with opinions about which room may follow which.
+
+Too much? Fine. Watch a shopping cart do it instead.
 
 ### Question 1 — can you recompute it? Then it's a subscription
 
@@ -42,19 +50,17 @@ The cart total is the sum of the line items' prices, and the items already live 
     (reduce + (map :price items))))
 ```
 
-The total is never wrong, because there's no second copy to drift out of sync. It recomputes from the items whenever they change — and only while something is actually subscribed to it, so when no view is looking it costs nothing. You never write an "update the total" handler. A view reads `@(rf/subscribe [:cart/total])` and stays in lockstep for free. This is the default home, and most derived values in your app land here.
+The total is never wrong. There's no second copy, so there is nothing to drift. It recomputes from the items whenever they change — and only while something is actually subscribed to it, so when no view is looking it costs nothing. You never write an "update the total" handler. A view reads `@(rf/subscribe [:cart/total])` and stays in lockstep for free. This is the default home, and most derived values in your app land here.
 
 ??? info "Coming from Redux?"
 
     This is a reselect selector — a memoised derivation over store state — and `:<- [:cart/items]` is its input-signal vector, the moral equivalent of the selectors you'd thread into `createSelector`. The difference: in re-frame2 the dependency wiring is explicit *data*, not a closure you assemble by hand, so the framework can draw the [derivation graph](glossary.md#the-derivation-graph) for you.
 
-!!! warning "Gotcha — a subscription must stay pure"
-
-    A subscription is a *read*: same inputs, same output, no reaching into the world. The moment it fetches, writes `localStorage`, or reads the clock, it has stopped being a derivation and become a question the wrong home is trying to answer. (That smell — and where the value should go instead — is the first row of [the wrong-home table](#signs-you-picked-the-wrong-home) below.)
+One rule keeps this home standing, so hear it now: **a subscription must stay pure.** It is a *read* — same inputs, same output, no reaching into the world. The moment it fetches, writes `localStorage`, or reads the clock, it has stopped being a derivation and become a question the wrong home is trying to answer. (That smell — and where the value should go instead — is the first row of [the wrong-home table](#signs-you-picked-the-wrong-home) below.)
 
 ### Question 2 — must a handler read it? Then promote it to a flow
 
-Now a new requirement lands. When the total crosses $50 the user gets free shipping, and the *checkout event handler* — the function that runs in response to a dispatched event — needs to know that while building its order payload. Here's the wall you hit: **handlers can't read subscriptions.** A subscription lives view-side, not in `app-db`, and a handler reads state as the plain `db` value handed to it — so it has no way to ask for a subscription. Recomputing the total inside the handler would put the formula in two places, and they'll drift the first time pricing changes.
+Now a new requirement lands. When the total crosses $50 the user gets free shipping, and the *checkout event handler* — the function that runs in response to a dispatched event — needs to know that while building its order payload. Here's the wall you hit, and everyone hits it: **handlers can't read subscriptions.** A subscription lives view-side, not in `app-db`, and a handler reads state as the plain `db` value handed to it — so it has no way to ask for a subscription. You could recompute the total inside the handler, sure. Now the formula lives in two places, and they'll drift the first time pricing changes.
 
 This is the moment the value wants to be *part of the application's state*. That's a [flow](glossary.md#flow): "when these `app-db` paths change, recompute this and write the result to *this* `app-db` path."
 
@@ -77,7 +83,7 @@ The formula is identical. What changed is *where the value lives*. Your checkout
 
 Those four keys are the whole core of a flow: `:id` names it, `:inputs` is the ordered vector of paths to watch (each value arrives positionally to `:derive`), `:derive` is the pure recompute, and `:output-path` is the `app-db` path written for you.
 
-The cost is an `app-db` write on every recompute, plus a piece of registered runtime. You pay it *because a handler needs the value as data*, and not before. Rule of thumb: a typical app has dozens of subscriptions and a *handful* of flows. If no handler reads a flow's output, you've over-paid — go back to a sub.
+The rent is real: an `app-db` write on every recompute, plus a piece of registered runtime. You pay it *because a handler needs the value as data*, and not before. Rule of thumb: a typical app has dozens of subscriptions and a *handful* of flows. If no handler reads a flow's output, you're over-paying — go back to a sub.
 
 !!! note "You write the inputs, never the output"
 
@@ -101,7 +107,7 @@ The cost is an `app-db` write on every recompute, plus a piece of registered run
 
 ### Question 3 — does it come from a server and go stale? Then it's a resource
 
-The cart so far is *local*. The user built it, so it's true by construction. But the checkout page must show the article being bought — title, price, stock — and that data isn't yours. It lives on a server, and you hold a *cache* of it that's stale the instant you read it. A value like that — remote origin, an identity naming *which* thing you fetched, staleness, refetch, invalidation — is a [resource](../resources/glossary.md#resource).
+The cart so far is *local*. The user built it, so it's true by construction. But the checkout page must show the article being bought — title, price, stock — and that data isn't yours. It never was. It lives on a server, and what you hold is a *cache* of it, stale the instant you read it. A value like that — remote origin, an identity naming *which* thing you fetched, staleness, refetch, invalidation — is a [resource](../resources/glossary.md#resource).
 
 A resource splits cleanly into two halves: a **read** and a **cause**. The read is an ordinary subscription a view pulls passively — it never reaches out to the network. The fetch happens separately, set off by a **cause**: some named thing in your app that says "go get this now" — a route opening, an event firing, a machine entering a state. So the slogan is *a sub you read and a cause you fire*. Keeping the fetch off the render path is the whole point: a view that fetched while rendering would re-fetch on every re-render, and two views showing the same article would race to fetch it twice. A cause fires once, for a reason you can name and see in the trace.
 
@@ -161,7 +167,7 @@ Staleness and invalidation come built in too: ensuring a stale entry refetches i
 
 ### Question 4 — does it have its own lifecycle? Then it's a machine
 
-The user clicks **Checkout**. Now you're not modelling a value anymore — you're modelling a *process*: idle, then validating, then awaiting payment, then done, or failed-and-retrying. There are rules about which state may follow which, a timeout, and cancellation. The load-bearing question has shifted to "**what state are we in, and what moves us to the next one?**" That's a [machine](../machines/glossary.md#machine). You can usually spot the smell that precedes one:
+The user clicks **Checkout**. Now you're not modelling a value anymore — you're modelling a *process*: idle, then validating, then awaiting payment, then done, or failed-and-retrying. There are rules about which state may follow which, a timeout, and cancellation. The question itself has changed shape: "**what state are we in, and what moves us to the next one?**" That's a [machine](../machines/glossary.md#machine). You can usually spot the smell that precedes one:
 
 ```clojure
 ;; THE SMELL — three booleans pretending to be one state.
@@ -222,4 +228,4 @@ Each wrong home is a value asked to do a job its home isn't shaped for. Move it,
 
     → subscription. **Must a handler read it as `app-db` data?** → flow. **Remote, cached, can go stale?** → resource. **A process with states and timers?** → machine.
 
-A value graduates to a heavier home only when it *earns* the upgrade — a handler that needs it, a server it answers to, a lifecycle of its own. Pick the right home and the value just behaves.
+A value graduates to a heavier home only when it *earns* the upgrade — a handler that needs it, a server it answers to, a lifecycle of its own. Ask the four questions, top to bottom. Stop at the first *yes*. Move in.


### PR DESCRIPTION
Applies the house voice across `docs/core` — the register defined by studying re-frame v1's documentation (the analysis and voice definition live in `ai/findings/voice.md`): a person with owned convictions talks you through the material; Socratic rhythm; one committed metaphor per concept, promoted to vocabulary; the load-bearing sentence explicitly flagged; at most one escalate-then-deflate riff per page; warnings said plainly in prose at the point of need. Precision is never traded for charm — every error id, signature, code block, and semantic claim is unchanged, and all `cljs-rf2` live cells are byte-identical.

**Scope.** 28 pages re-voiced: FULL treatment on the twelve concepts pages and three essays (`where-state-lives`, `derivations-and-algebra-views`, `explanation/inside-out`); LIGHT treatment on the nine how-to and four testing recipes, which stay brisk and task-first. Untouched per the brief: `introduction.md`, `first-app.md` — plus `glossary.md`, `25-from-re-frame-v1.md`, and the index pages, where the persona stays out by design.

**v1 material, imported fully and owned (no attributions).** The ham sandwich, performed in the interceptors body at last. The Fogus data-at-rest tweet (now in full) and the in-memory-database framing in app-db, with the OO confession. The muddy monster truck in the field of white tulips, in effects. Heraclitus, the truth-interlude, and "Derived Data, flowing." closing the derivations essay. "Use the trace, Luke." The photons riff and the flagged-as-made-up 75% in subscriptions. "Promise me you'll write the schema. Promise me. Okay, good." The view-testing confession ("There, I said it"). Conflicting v1 vocabulary was excluded by rule: no dominoes imports, no ratom, no Signal Graph, no v1 layer numbering (v1's "Layer 2" extractors are re-frame2's Layer 1).

**The contract keeps up.** `AUTHORING.md` §Voice now codifies the register (rhythm-as-instrument, Socratic headers, metaphor discipline, riff rules, first-person conviction with **no invented autobiography**, never-trade-precision-for-charm), and §Callouts gains the single-beat carve-out: a one-sentence gotcha may be said in plain prose at the point of need; multi-paragraph asides stay boxed. In practice ~40 single-beat warning boxes across the corpus became prose warnings, while every "Coming from X" / "From re-frame v1" / "Going deeper" collapsible stays an admonition.

**Structure discipline.** Headings are verbatim corpus-wide with one deliberate exception — `concepts/subscriptions.md` took Socratic renames (its rewrite was the calibration sample for the whole pass); both inbound anchors were repaired. Incidental fixes found along the way: a duplicated paragraph merged in errors.md's schema gotcha, two miscounts corrected (build-a-form's "three" that were four; validate-with-schemas' "two ways" that were three), a "signal-graph subs" vocabulary slip in images.md, and a punctuation slip in frames.md.

Gates: `mkdocs build --strict` clean; `check_doc_slugs.py` — 504 files, no broken links.

Diff: 29 files, +1014/−746.