### PR TITLE
docs(impl): correct stale docstrings + guide-doc ripples from the docs/api audit (rf2-v324jh)

### DIFF
--- a/docs/routing/concepts.md
+++ b/docs/routing/concepts.md
@@ -109,12 +109,12 @@ Because routes are registry entries, the route table is *queryable data* — and
 
 ### The metadata map, in full
 
-You've now met the keys you'll reach for daily. The metadata map has thirteen reserved keys in total — the largest registration shape in re-frame2 — but you never learn them as a flat list. They cluster into four groups by *what they control*; pick the group first, then the key. The rest of this page introduces the remaining keys in context, so treat this table as a map of where you're going — and the [API reference](../api/re-frame.routing.md#reg-route) for the canonical, per-key spec.
+You've now met the keys you'll reach for daily. The metadata map has fourteen reserved keys in total — the largest registration shape in re-frame2 — but you never learn them as a flat list. They cluster into four groups by *what they control*; pick the group first, then the key. The rest of this page introduces the remaining keys in context, so treat this table as a map of where you're going — and the [API reference](../api/re-frame.routing.md#reg-route) for the canonical, per-key spec.
 
 | Group | Keys | What it controls |
 |---|---|---|
 | **Shape** — URL ↔ params | `:params`, `:query`, `:query-defaults`, `:query-retain` | Which URLs match, and how their parts coerce into maps. The contract `match-url` and `route-url` agree on. |
-| **Lifecycle** — events at navigation boundaries | `:on-match`, `:on-error`, `:can-leave` | What the runtime dispatches when the route activates (`:on-match`), when a loader errors (`:on-error`), and a guard sub consulted before you leave (`:can-leave`). |
+| **Lifecycle** — events at navigation boundaries | `:on-match`, `:on-error`, `:can-leave`, `:can-enter` | What the runtime dispatches when the route activates (`:on-match`), when a loader errors (`:on-error`), a guard sub consulted before you leave (`:can-leave`), and a guard sub consulted before you enter (`:can-enter`). |
 | **Layout** — how the route fits with neighbours | `:doc`, `:parent`, `:tags`, `:scroll` | How the route is described, nested (`:parent`), grouped for interceptors (`:tags`), and scrolled on entry (`:scroll`). |
 | **Classification** — data hygiene | `:sensitive`, `:large` | Which slice values are redacted or kept off the wire at egress while the route is active (see [Data classification](#keeping-tokens-off-the-wire) below). |
 

--- a/docs/ssr/index.md
+++ b/docs/ssr/index.md
@@ -5,8 +5,9 @@ Ship HTML before the JavaScript loads, then let the client take over — without
 On the server, [`render-to-string`](glossary.md#render-to-string) runs your real views in a per-request [frame](../core/glossary.md#frame) and emits HTML plus a serialized state payload. On the client, [hydration](glossary.md#hydration) adopts that HTML and installs the state instead of re-rendering from scratch — and a [hydration mismatch](glossary.md#hydration-mismatch) is *detected and traced*, never silently patched.
 
 ```clojure
-;; server (JVM): your real views, rendered against a frame — no DOM anywhere
-(ssr/render-to-string [(rf/view :app/root)] {:frame f})
+;; server (JVM): your real views, rendered inside a per-request frame — no DOM anywhere
+(rf/with-frame f
+  (ssr/render-to-string [(rf/view :app/root)] {}))
 
 ;; client: adopt the server's HTML and its state instead of re-rendering
 (ssr/hydrate! {:frame :app :render-tree-fn (fn [] ((rf/view :app/root)))})

--- a/docs/ssr/testing.md
+++ b/docs/ssr/testing.md
@@ -24,7 +24,7 @@ Here's the pleasant surprise: **your server tests are just JVM tests.** The whol
                           {:initial-events
                            [[:rf/set-db {:articles {"intro" {:title "Welcome"}}}]
                             [:rf.route/handle-url-change "/articles/intro"]]})]
-    (let [html (ssr/render-to-string [app-root] {:frame f})]
+    (let [html (ssr/render-to-string [app-root] {})]   ;; renders against the with-new-frame scope
       (is (clojure.string/includes? html "Welcome")))))
 ```
 

--- a/docs/ssr/tutorial.md
+++ b/docs/ssr/tutorial.md
@@ -54,7 +54,7 @@ Now install the headless SSR adapter, stand up a frame, seed it, render:
 
 (rf/with-new-frame [f (rf/make-frame {})]
   (rf/dispatch-sync [:articles/seed [{:id "1" :title "Hello, server"}]] {:frame f})
-  (ssr/render-to-string [(rf/view :app/root)] {:frame f}))
+  (ssr/render-to-string [(rf/view :app/root)] {}))   ;; renders against the with-new-frame scope
 ;; => "<div class=\"page\"><h1>Recent articles</h1><ul><li><h3>Hello, server</h3></li></ul></div>"
 ```
 

--- a/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
+++ b/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
@@ -72,7 +72,9 @@
   "Flush pending Reagent renders synchronously. Wraps React's act() —
   intended for test code only. Calls (act (fn [] (reagent.core/flush)));
   with `f`, runs `f` then the synchronous render drain inside act. Returns
-  nil. No-op when act() is unreachable in the current React build.
+  nil. When act() is unreachable in the current React build it degrades to
+  a plain synchronous flush (still runs `f` and drains the render queue),
+  so a `:node-test` runner with no real React render path still flushes.
 
   Per rf2-3yij Decision 6 / rf2-b6nm5: the canonical test-flush hook,
   surfaced identically (same name, same adapter-ns location, same

--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -384,7 +384,7 @@
        `day8/re-frame2-flows` (rf2-tfw3); apps must add the artefact and require
        `re-frame.flows` at boot. See `re-frame.core-flows/reg-flow` for the full
        signature."
-       {:arglists '([flow-id metadata derive-fn] [flow-id derive-fn])})
+       {:arglists '([flow-id metadata derive-fn])})
 
      (rm/defreg-macro reg-route rf-routing/reg-route
        "Register a route under `id`. Per rf2-wvh95f F1 the canonical
@@ -497,7 +497,7 @@
    (defmacro reg-machine
      "Register a machine as an event handler. Captures source-coords
      (Spec 001) at this call site plus co-located per-element source on
-     each `:guards` / `:actions` / `:on-spawn-action` entry (`{:fn ..
+     each `:guards` / `:actions` / `:on-spawn-actions` entry (`{:fn ..
      :source-coords .. :source-code ..}`) and a reference-site
      `:source-coords` co-located onto each `:states`-tree map node
      (state-node / transition map) at its spec-path (Spec 005 §Source-coord
@@ -536,7 +536,7 @@
 ;; compile-time literal-walk captures nothing (the spec form is not a map
 ;; literal). `defmachine` is the `def`-replacement that walks the inline
 ;; literal AT THE DEFINITION SITE and co-locates per-element source onto each
-;; `:guards` / `:actions` / `:on-spawn-action` entry (plus a reference-site
+;; `:guards` / `:actions` / `:on-spawn-actions` entry (plus a reference-site
 ;; `:source-coords` on each `:states`-tree map node), so the per-element
 ;; source travels WITH the value into `reg-machine`. Per Spec 005
 ;; §Source-coord stamping (value-registered machines; rf2-npvsx / rf2-vqja2).
@@ -2496,10 +2496,12 @@
   Spec 009 §Trace projection."}
   group-by-event-with-events  trace-projection/group-by-event-with-events)
 
-(def ^{:doc "Classify a trace event into one of the six domino buckets
-  (`:event` / `:event-handler` / `:fx` / `:db` / `:sub` / `:view`).
-  Pure fn used by trace projections and event-bundle views. Per Spec 009
-  §Trace projection."}
+(def ^{:doc "Classify a trace event into one of the domino buckets —
+  one of `#{:event :handler :fx :effect :sub :render :other}`. `:other`
+  covers every event that isn't part of the six-domino cascade (errors,
+  warnings, machine transitions, frame lifecycle, flows). The
+  classification is total. Pure fn used by trace projections and
+  event-bundle views. Per Spec 009 §Trace projection."}
   domino-bucket   trace-projection/domino-bucket)
 
 ;; ---- epoch history (Tool-Pair §Time-travel) ------------------------------
@@ -2666,12 +2668,16 @@
 (def ^{:doc "Clear an HTTP interceptor by `id` from a frame's
   `:rf.http/managed` middleware chain. EP-0002 context-required
   frame-local: the single-arity `(clear-http-interceptor id)` resolves
-  the frame through the carried-invariant scope chain; the two-arity
-  `(clear-http-interceptor frame id)` names the frame explicitly (the
-  *override*). Under no scope and no explicit frame the call raises
-  `:rf.error/no-frame-context` — it does NOT synthesise a `:rf/default`
-  target. Implementation ships in `day8/re-frame2-http`. Per Spec 014
-  §Middleware. Late-bound via `:http/clear-http-interceptor`."}
+  the frame through the carried-invariant scope chain; pass the public
+  opts form `(clear-http-interceptor id {:frame target})` to name the
+  frame explicitly (the *override*) — `target` is a frame-id keyword or a
+  live frame value. Per rf2-f28bno the 2-arity is SHAPE-DISCRIMINATED on
+  the second arg (mirroring `reg-http-interceptor`'s `:frame` opt): an
+  opts map ⇒ the public form; a bare frame target ⇒ the internal
+  frame-first plumbing. Under no scope and no explicit frame the call
+  raises `:rf.error/no-frame-context` — it does NOT synthesise a
+  `:rf/default` target. Implementation ships in `day8/re-frame2-http`.
+  Per Spec 014 §Middleware. Late-bound via `:http/clear-http-interceptor`."}
   clear-http-interceptor           rf-http/clear-http-interceptor)
 
 ;; reg-http-interceptor is a macro (per the defreg-macro form above) so
@@ -2752,8 +2758,11 @@
   destroy-adapter!     adapter/dispose-adapter!)
 
 (def ^{:doc "Return the discriminator keyword identifying the installed
-  adapter, or `nil` if none. One of `:reagent` / `:plain-atom` /
-  `:uix` / `:helix` per Spec 006 §Adapter introspection."}
+  adapter, or `nil` if none. One of `:rf.adapter/reagent`,
+  `:rf.adapter/reagent-slim`, `:rf.adapter/uix`, `:rf.adapter/helix`,
+  `:rf.adapter/plain-atom`, `:rf.adapter/ssr`, or `:custom` for
+  user-supplied adapters that didn't pick a canonical kind. Per Spec 006
+  §Adapter introspection."}
   current-adapter      adapter/current-adapter)
 
 (def ^{:doc "Return the installed adapter spec map, or `nil` if none.

--- a/implementation/core/src/re_frame/core_flows.cljc
+++ b/implementation/core/src/re_frame/core_flows.cljc
@@ -30,10 +30,9 @@
   flow-id metadata derive-fn)` — the pure `:derive` fn is the THIRD slot,
   the middle slot is the reflection-config metadata map (`:inputs`,
   `:output-path`, `:doc`, `:schema`, EP-0025 classification keys, and the
-  `:frame` mounting key). The 2-arg `(reg-flow flow-id derive-fn)` recurses
-  with an empty metadata map (which then fails validation for the required
-  `:inputs` / `:output-path`)."
+  `:frame` mounting key). A single 3-slot arity only — `:inputs` /
+  `:output-path` are mandatory, so (like `reg-route` / `reg-resource`)
+  there is no 2-arity."
   {:hook :flows/reg-flow :artefact flows-artefact :on-absent :throw
-   :arglists '([flow-id metadata derive-fn] [flow-id derive-fn])}
-  ([flow-id derive-fn]          [flow-id {} derive-fn])
+   :arglists '([flow-id metadata derive-fn])}
   ([flow-id metadata derive-fn] :delegate))

--- a/implementation/core/src/re_frame/core_resources.cljc
+++ b/implementation/core/src/re_frame/core_resources.cljc
@@ -149,10 +149,11 @@
 (defwrapper mutations
   "Per Spec 016 §Deferred slices / EP-0003 §Mutations. Return mutation
   introspection for a frame target `{:frame …}` — the registered mutation
-  ids and the live per-frame mutation-instance table (keyed by instance id;
-  Xray groups instances under their registered mutation id). Without
-  `:frame` only the static registry is returned. Late-bound via
-  `:resources/mutations`."
+  ids and the live per-frame mutation-instance table (keyed on each
+  instance id's CEDN-1 byte `key-id` per rf2-8iciw8, not the raw instance
+  id; each instance carries its id under `:instance/id`. Xray groups
+  instances under their registered mutation id). Without `:frame` only the
+  static registry is returned. Late-bound via `:resources/mutations`."
   {:hook :resources/mutations :artefact resources-artefact :on-absent :throw
    :arglists '([] [opts])}
   ([]     :delegate)

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -2245,8 +2245,10 @@
         ;; render drain (the injected `:rdc/flush-render!` op — stock
         ;; `reagent.core/flush` / slim's `reagent2.*` flush) so dirty
         ;; components forceUpdate and Reactions recompute before `act`
-        ;; returns. No-op when act() is unreachable in the current React
-        ;; build (mirrors the React-hook spine `flush-views!`).
+        ;; returns. When act() is unreachable in the current React build it
+        ;; degrades to a plain synchronous flush — the ratom family has a
+        ;; real synchronous render drain even without act (unlike the
+        ;; React-hook spine `flush-views!`, which no-ops).
         flush-views!
         (fn flush-views!
           ([] (flush-views! (fn [] nil)))

--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -64,9 +64,11 @@
 ;;
 ;; Design provenance (kept out of the public `configure!` docstring per the
 ;; rf2-ee38b clarity review):
-;;   * `:trace-events-keep` defaults to a FINITE value equal to `:depth`
-;;     (50 — see `re-frame.epoch.state/default-trace-events-keep`; rf2-mrsck /
-;;     Security.md §Epoch privacy posture). With the default the most-recent
+;;   * `:trace-events-keep` defaults to a FINITE fixed 50 — chosen to equal
+;;     the shipped `:depth` DEFAULT (see
+;;     `re-frame.epoch.state/default-trace-events-keep`; rf2-mrsck /
+;;     Security.md §Epoch privacy posture). It does NOT track a configured
+;;     `:depth` — the two are independent slots. With the default the most-recent
 ;;     `:depth` records per frame retain raw `:trace-events`; when an epoch
 ;;     evicts from the ring its raw trace evicts with it, so trace + epoch
 ;;     stay atomic (Mike pair-debug 2026-05-27 — the prior finite-5 default
@@ -97,9 +99,12 @@
                         `:trace-events` vector. Older records keep the cheap
                         structured projections (`:sub-runs` / `:renders` /
                         `:effects`) but drop `:trace-events` to bound memory.
-                        Defaults to the `:depth` value (50) so trace + epoch
-                        evict atomically; pass a smaller value (e.g. 5) to
-                        bound dev-session heap more aggressively.
+                        Defaults to a fixed 50 — chosen to equal the shipped
+                        `:depth` default so trace + epoch evict atomically. It
+                        is a fixed default, NOT one that tracks a configured
+                        `:depth`: set `{:depth 100}` and `:trace-events-keep`
+                        stays 50 unless you also set it. Pass a smaller value
+                        (e.g. 5) to bound dev-session heap more aggressively.
     :redact-fn          fn? or nil. The ADVANCED PROJECTION-SIDE override
                         (EP-0015 §15 + open-issue 6, RULED). When non-nil the
                         framework invokes the fn ONCE per record at the

--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -160,8 +160,11 @@
   `frame/require-current-frame!`. Called under no scope and no explicit
   `:frame`, it raises `:rf.error/no-frame-context` rather than defaulting to
   `:rf/default`. The override is a frame TARGET (keyword id or frame value),
-  normalized to its frame-id via `frame/frame-target->id` — the same shape the
-  `reg-flow` / `clear-flow` `:frame` opt accepts."
+  normalized to its frame-id via `frame/frame-target->id`. NOTE: the READ
+  path (this fn, `flow-meta-at`) normalizes and so accepts a frame VALUE;
+  the `reg-flow` / `clear-flow` `:frame` opt is used RAW (no
+  `frame-target->id`), so those writes expect a frame-id keyword — a frame
+  value would not resolve there."
   [opts]
   (let [override (:frame opts)]
     (if (some? override)
@@ -922,8 +925,11 @@
   namespace-load time is not a reason to synthesise a default frame.
 
   Returns the flow's id per the `reg-*` return-value convention
-  ([Conventions §reg-* return-value convention])."
-  ([flow-id derive-fn] (reg-flow flow-id {} derive-fn))
+  ([Conventions §reg-* return-value convention]).
+
+  A single 3-slot arity only — like its required-metadata siblings
+  `reg-route` / `reg-resource`, there is no 2-arity: `:inputs` /
+  `:output-path` are mandatory, so a metadata slot is always required."
   ([flow-id metadata derive-fn]
    (let [[flow frame] (reconstruct-flow flow-id metadata derive-fn)]
    (validate-flow flow)

--- a/implementation/resources/src/re_frame/resources.cljc
+++ b/implementation/resources/src/re_frame/resources.cljc
@@ -244,10 +244,13 @@
   "Return mutation introspection for a frame target (EP-0003 §Mutations /
   Xray). Returns `{:mutation-ids [...] :instances {…}}` — the static
   registry (every registered mutation id) plus, when `:frame` is supplied,
-  the live per-frame mutation-INSTANCE map (`{<instance-id> <instance>}`).
-  Xray groups instances under their registered `:mutation/id` while showing
-  each separately. Without `:frame` only the static registry is returned
-  (no ambient frame fallback, EP-0002)."
+  the live per-frame mutation-INSTANCE map. That map is keyed on each
+  instance id's CEDN-1 byte `key-id` (`{<key-id> <instance>}`, per
+  rf2-8iciw8), NOT the raw instance id — each instance carries its
+  kind-preserving id alongside under `:instance/id`. Xray groups instances
+  under their registered `:mutation/id` while showing each separately.
+  Without `:frame` only the static registry is returned (no ambient frame
+  fallback, EP-0002)."
   ([] {:mutation-ids (mutation-ids) :instances {}})
   ([{:keys [frame]}]
    {:mutation-ids (mutation-ids)

--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -6,7 +6,7 @@
   vectors):
 
     [:rf.resource/ensure          {:resource … :scope … :params … :owner … :cause …}]
-    [:rf.resource/refetch         {:resource … :scope … :params … :cause …}]
+    [:rf.resource/refetch         {:resource … :scope … :params … :owner … :cause …}]
     [:rf.resource/invalidate-tags {:scope … :tags … :cause …}]
     [:rf.resource/release-owner   {:owner …}]
     [:rf.resource/clear-scope     {:scope … :cause …}]
@@ -646,7 +646,9 @@
   "`:rf.resource/refetch` — force a refresh of a resource instance (forces
   a new generation; supersede + suppress any in-flight prior request by
   generation). Per Spec 016 §Events and §Race and in-flight semantics.
-  Payload: `{:resource :scope :params :cause}`."
+  Payload: `{:resource :scope :params :owner :cause}` — like `ensure`, a
+  supplied `:owner` is attached as a lease (both route through the shared
+  `ensure-load` core)."
   [cofx [_event-id payload]]
   (ensure-load cofx payload {:force-new? true :where 'rf.resource/refetch}))
 

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/cookie.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/cookie.clj
@@ -137,9 +137,10 @@
 
 (defn cookie->set-cookie-header
   "Serialise one re-frame.ssr cookie map to a Set-Cookie header value
-  per RFC 6265 §4.1. Per Spec 011 §Cookie shape — the cookie's :name /
-  :value are required; everything else is an attribute appended after
-  semicolons. The :value is URL-encoded.
+  per RFC 6265 §4.1. Per Spec 011 §Cookie shape — the cookie's :name is
+  required; :value is optional (a missing :value serialises as an empty
+  string). Everything else is an attribute appended after semicolons. The
+  :value is URL-encoded.
 
   Public surface so tests, alt host adapters (Pedestal, HttpKit), and
   user code that needs a one-off serialisation can call it directly.

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
@@ -723,9 +723,12 @@
   Opts mirror `re-frame.ssr.ring/ssr-handler` — same `:initial-events` /
   `:root-view` / `:payload` / `:on-error` /
   `:error-view` / `:emit-hash?` / `:version` / `:schema-digest` /
-  `:content-type` plus the four trusted shell-hook opts (`:head` /
-  `:body-end` / `:script-src` / `:app-element-id`, honoured by
-  `default-streaming-prefix` / `default-streaming-suffix`). `:initial-events`
+  `:content-type` / `:fx-overrides` / `:ssr` (the last two are threaded
+  through the shared `pipeline/setup-request-frame!` into the per-request
+  `(rf/make-frame …)`, exactly as `ssr-handler` does) plus the four trusted
+  shell-hook opts (`:head` / `:body-end` / `:script-src` /
+  `:app-element-id`, honoured by `default-streaming-prefix` /
+  `default-streaming-suffix`). `:initial-events`
   accepts BOTH forms `ssr-handler` does — an `:initial-events` vector OR a
   `(fn [request] -> initial-events-vector)` deriving the setup vector from
   the Ring request (rf2-kzns7l; both flow through the shared

--- a/implementation/ssr/src/re_frame/ssr/error_listener.cljc
+++ b/implementation/ssr/src/re_frame/ssr/error_listener.cljc
@@ -194,7 +194,9 @@
   "Project an error trace event via the active projector for frame-id
   and stamp the public-error's :status onto the response accumulator.
   Returns the public-error map on success, nil on no-op (frame missing
-  / not server / no pending trace / redirect set on the response).
+  / not server / no pending trace). When a redirect is already set on the
+  response the projected map is STILL returned — only the :status stamp is
+  suppressed (per Spec 011 §Redirect precedence, below).
 
   Two arities:
 


### PR DESCRIPTION
Follow-up to the docs/api completeness audit (PR #5214). Corrects stale **implementation docstrings** and **human guide-doc ripples** that #5214 surfaced but left to their owners. Implementation behaviour is truth: every edit corrects PROSE to match what the code actually does. One flagged code defect (an always-throwing `reg-flow` 2-arity) is removed per the bead's explicit authorization — see below.

Scope excludes `docs/api/*` (fixed in #5214) and `spec/API.md` + `spec/012-Routing.md` (owned by the parallel worker on **rf2-1oqupd**).

## Per-finding disposition

### Implementation docstrings (comment-only, no runtime change)
1. **FIXED** `core.cljc` `domino-bucket` — was `:event/:event-handler/:fx/:db/:sub/:view`; now `#{:event :handler :fx :effect :sub :render :other}` (matches `trace/projection.cljc` `domino-bucket`).
2. **FIXED** `core.cljc` `current-adapter` — was `:reagent/:plain-atom/:uix/:helix`; now the `:rf.adapter/*` kinds + `:custom` (matches `substrate/adapter.cljc`).
3. **FIXED** `core.cljc` `clear-http-interceptor` — dropped the retired frame-first public 2-arity; now describes the shape-discriminated public opts form `(clear-http-interceptor id {:frame target})` (matches `http/middleware.cljc` + `core_http.cljc`).
4. **FIXED** `core.cljc` `reg-machine` / `defmachine` — `:on-spawn-action` → `:on-spawn-actions` (plural; the real key, used everywhere in `core_reg_macros.cljc` / `source_coords.cljc`). Two occurrences.
5. **FIXED** `adapters/reagent/.../reagent.cljs` `flush-views!` (+ the mirror comment in `substrate/spine.cljs`) — was "No-op when act() unreachable"; the ratom spine actually degrades to a plain synchronous flush (`spine.cljs` ratom `flush-views!`). Also corrected the "mirrors the React-hook spine" phrasing: the React-hook spine genuinely no-ops, so they differ on this path.
6. **FIXED** `ssr/error_listener.cljc` `apply-error-projection!` — redirect was listed as a nil-returning no-op; the code still returns the public-error map on redirect and only suppresses the `:status` stamp.
7. **FIXED** `ssr-ring/cookie.clj` `cookie->set-cookie-header` — was ":name / :value required"; only `:name` is enforced (`:value` defaults to `""` when omitted).
8. **FIXED** `epoch.cljc` `configure!` docstring + design-provenance comment — `:trace-events-keep` was described as tracking the `:depth` value; it is a fixed default of 50 (chosen to equal the *default* depth) and does NOT follow a configured `:depth` (`epoch/state.cljc`).
9. **FIXED** `flows/registry.cljc` `resolve-read-frame` — claimed `reg-flow`/`clear-flow` accept the same normalized frame-value shape; the read path normalizes via `frame-target->id` (accepts frame values) but `reg-flow`/`clear-flow` use the `:frame` opt RAW (frame-id keyword only).
10. **FIXED** resources:
    - `resources/events.cljc` `refetch-handler` (+ the ns-header event index) — payload was missing `:owner`; refetch honours `:owner` via the shared `ensure-load` core.
    - `resources.cljc` `mutations` + `core_resources.cljc` `mutations` facade — the instances map was described as `{<instance-id> <instance>}` / "keyed by instance id"; it is keyed on each instance id's CEDN-1 byte `key-id` (per rf2-8iciw8), with the raw id carried under `:instance/id`.

### Flagged code defect
- **FIXED (removed)** `reg-flow` 2-arity `(reg-flow flow-id derive-fn)`. Verified it delegated with `{}` metadata and so ALWAYS threw the misleading `:rf.error/flow-bad-inputs` (`:inputs` mandatory) — genuinely unusable, no callers, no tests. The bead authorized "remove or make it a loud arity error." Removed it (across `flows/registry.cljc`, `core_flows.cljc` facade, and the `core.cljc` macro `:arglists`) to bring `reg-flow` in line with its required-metadata siblings `reg-route` / `reg-resource`, which have no 2-arity. This is the one code-behaviour change; it changes no valid call path (the 2-arity only ever threw). The `:rf.fx/reg-flow` effect and every internal caller already pass 3 args.

### Guide-doc ripples
- (a) **FIXED** `docs/ssr/{index,tutorial,testing}.md` — stripped the phantom `{:frame f}` opt to `render-to-string` (verified `ssr/emit.cljc` reads only `:doctype?`/`:emit-hash?`/`:render-hash`; the frame resolves via the enclosing `with-new-frame`/`with-frame` scope, matching the canonical `{}` idiom the same tutorial already uses).
- (b) **FIXED** `docs/routing/concepts.md` — "thirteen reserved keys" → "fourteen", and added `:can-enter` to the Lifecycle group (impl `reserved-route-keys` carries it per rf2-p69yaz). `spec/012:247` shares this staleness but is **DEFERRED to rf2-1oqupd** (out of scope).
- (c) **FIXED** `ssr-ring/streaming.clj` `stream-handler` — added `:fx-overrides` / `:ssr` to the mirrored-opts list (both are real `ssr-handler` opts threaded through the shared `pipeline/setup-request-frame!`, which `stream-handler` passes full opts to).

### Skipped / deferred
- `spec/API.md`, `docs/api/*`, `spec/012-Routing.md` — out of scope (owned by #5214 / rf2-1oqupd).

## Quality gates
- `mkdocs build --strict` — **PASS** (exit 0; touched `docs/routing/`, `docs/ssr/`).
- Reader syntax-check (babashka, reader-conditional aware) on all 12 touched `.clj(c/s)` files — **PASS** (all forms read cleanly).
- `check_retired_spellings.py`, `check_skill_re_frame2_drift.py`, `check_doc_slugs.py` — **PASS** (exit 0). No `skills/`/`migration/` echoes of the changed content.
- Fast CLJS gate (`npm run test:cljs`) **not run locally** — fresh worktree has no `node_modules` (heavy install + shadow-cljs compile, not cheap). Changes are docstring/comment-only except the `reg-flow` 2-arity removal, which is verified structurally (single well-formed 3-arity; no 2-arg callers/tests) and relies on CI for the runtime gate.
