### PR TITLE
docs(spec): add missing route-metadata reserved keys to Spec-Schemas (rf2-i8sbwg)

### DIFF
--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -3315,9 +3315,12 @@ The shape of the **stored / effective** route-meta. Reserved keys per [012 §Res
    [:on-match        {:optional true} [:vector [:vector :any]]]            ;; events to dispatch when this route becomes active
    [:on-error        {:optional true} [:vector :any]]                      ;; event to dispatch if any :on-match event errors
    [:can-leave       {:optional true} :keyword]                            ;; sub-id; (subscribe [<sub-id>]) returns boolean — true means "OK to leave". Per [012 §Navigation blocking](012-Routing.md#navigation-blocking--pending-nav-protocol).
+   [:can-enter       {:optional true} :keyword]                            ;; sub-id; enter-gate mirror of :can-leave (rf2-p69yaz). Block dispatches :rf.route/entry-blocked. Per [012 §Navigation blocking](012-Routing.md#navigation-blocking--pending-nav-protocol).
    [:scroll          {:optional true} [:or
                                        [:enum :top :restore :preserve]
-                                       :map]]])                            ;; map form is post-v1 / host-extensible
+                                       :map]]                              ;; map form is post-v1 / host-extensible
+   [:sensitive       {:optional true} [:vector Path]]                      ;; projection-relative :rf/paths redacted at egress while the route is active (EP-0025). Per [012 §Route data classification](012-Routing.md#route-data-classification).
+   [:large           {:optional true} [:vector Path]]])                    ;; projection-relative :rf/paths kept off the wire at egress while active (EP-0025); sensitive wins at same path. Per [012 §Route data classification](012-Routing.md#route-data-classification).
 ```
 
 Per-host extension keys (`:myapp/...`, `:rf.tooling/...`) are tolerated — RouteMetadata composes with `:rf/registration-metadata`'s open shape.


### PR DESCRIPTION
Reconciles the `:rf/route-metadata` (RouteMetadata) schema in `spec/Spec-Schemas.md` with the implementation and `spec/012-Routing.md`'s reserved-keys table. Spotted during the spec/API.md reconciliation (PR #5216). **Implementation = truth.**

The RouteMetadata `[:map ...]` was missing three reserved route keys that both the impl and 012-Routing's 14-key table carry.

## Keys added
All three added as `{:optional true}`, positioned by axis (lifecycle keys grouped with `:can-leave`; classification keys after `:scroll`), matching the impl's value-types:

- **`:can-enter`** → `:keyword` (sub-id) — the first-class enter-gate mirror of `:can-leave` (rf2-p69yaz Option A). Placed immediately after `:can-leave`.
- **`:sensitive`** → `[:vector Path]` (a vector of projection-relative `:rf/path`s) — redacted at egress while the route is active.
- **`:large`** → `[:vector Path]` (a vector of projection-relative `:rf/path`s) — kept off the wire at egress while active.

`Path` (`:rf/path` = `[:vector PathSegment]`) is the existing named schema defined earlier in this file; referencing it is idiomatic here (e.g. `NamedPathDeclaration` already references `PathTemplate`) and precisely matches the impl's `normalize-axis-paths` contract (each declaration is a vector of paths, each normalised to a canonical `:rf/path`).

None of the three was already present — all genuinely missing; nothing skipped.

## Impl confirmation (implementation = truth)
- `implementation/routing/src/re_frame/routing/registry.cljc:146-156` — `reserved-route-keys` set enumerates `:can-enter`, `:sensitive`, `:large` (all bare, optional metadata keys).
- `implementation/routing/src/re_frame/routing/classification.cljc:114-203` — `normalize-axis-paths`: `:sensitive`/`:large` are each a **vector** of projection-relative paths, each a concrete `:rf/path` (empty path `[]` legal); a non-vector declaration fails closed.
- `spec/012-Routing.md:274-288` — per-key table: `:can-enter` typed "sub-id"; `:sensitive`/`:large` typed "vector of projection-relative paths"; "All metadata keys are optional."

## Cross-check (no edit to 012-Routing.md)
`spec/012-Routing.md`'s reserved-keys table (14 metadata keys + `:path` value slot) now agrees with the Spec-Schemas entry: doc, params, query, query-defaults, query-retain, tags, parent, on-match, on-error, can-leave, can-enter, scroll, sensitive, large (14) plus the `:path` value slot. 012-Routing was already reconciled in the earlier audit and is left untouched.

## Quality gates
- `mkdocs build --strict` from repo root — **PASS** (exit 0, no warnings/errors; spec/ is in the docs build).
- No dedicated Spec-Schemas/route-metadata drift-check script exists under `scripts/` or `.github/` that greps this schema (verified); no new drift introduced.
- Comment column alignment preserved (`;;` at col 75 across all new rows); delimiters balanced.

Scope: `spec/Spec-Schemas.md` only (+4/-1). Hot-zone file, solo sequential.