### PR TITLE
docs(spec): fix retired fused reg-flow examples in Derivations to 3-slot grammar (rf2-3nlouf)

### DIFF
--- a/spec/Derivations.md
+++ b/spec/Derivations.md
@@ -438,11 +438,10 @@ The clearest illustration of the algebra: the *same* whole-value function, expre
   (fn [[items discounts] _] (sum-cart items discounts)))
 
 ;; Source form B — a flow, same function
-(rf/reg-flow
-  {:id :cart/materialized-total
-   :inputs [[:cart :items] [:pricing :discounts]]
-   :derive (fn [items discounts] (sum-cart items discounts))
-   :output-path [:cart :total]})
+(rf/reg-flow :cart/materialized-total
+  {:inputs [[:cart :items] [:pricing :discounts]]
+   :output-path [:cart :total]}
+  (fn [items discounts] (sum-cart items discounts)))
 ```
 
 Their algebra views differ only in output, storage, evaluation, and lifecycle:
@@ -535,13 +534,13 @@ The same ephemeral-derivation classifications as an ordinary subscription; the o
 
 ```clojure
 ;; SOURCE FORM                              ;; ALGEBRA VIEW
-(rf/reg-flow                                 {:id          :cart/materialized-total
-  {:id     :cart/materialized-total           :kind        :derivation
-   :inputs [[:cart :items]                    :source-form {:kind :reg-flow
-            [:pricing :discounts]]                          :id   :cart/materialized-total}
-   :derive (fn [items discounts]              :inputs      [[:db [:cart :items]]
-             (sum-cart items discounts))                    [:db [:pricing :discounts]]]
-   :output-path [:cart :total]})              :output      [:db [:cart :total]]
+(rf/reg-flow :cart/materialized-total        {:id          :cart/materialized-total
+  {:inputs [[:cart :items]                    :kind        :derivation
+            [:pricing :discounts]]            :source-form {:kind :reg-flow
+   :output-path [:cart :total]}                             :id   :cart/materialized-total}
+  (fn [items discounts]                       :inputs      [[:db [:cart :items]]
+    (sum-cart items discounts)))                            [:db [:pricing :discounts]]]
+                                              :output      [:db [:cart :total]]
                                               :storage     :app-db
                                               :evaluation  :after-event
                                               :lifecycle   :frame


### PR DESCRIPTION
## Summary

`spec/Derivations.md` carried two worked `reg-flow` examples in the retired fused single-map shape (`(rf/reg-flow {:id ... :inputs ... :derive ... :output-path ...})`). The 3-slot registration grammar (rf2-bqstzr / rf2-wvh95f F1) rejects a `:derive` left inside the metadata map with `:rf.error/invalid-flow-metadata` — an AI copying either example would produce code that throws at registration. Rewrites both to the current 3-slot form `(reg-flow flow-id metadata derive-fn)`, matching `spec/013-Flows.md:47`/`:78`, `spec/API.md:108`, and the `reg-resource` example already in the same file (~line 557).

- "Worked equivalence — one function, two policies" (Source form B), ~lines 440-446
- "Side-by-side catalogue → Flow → materialized derivation", ~lines 537-550 — re-padded the side-by-side SOURCE FORM / ALGEBRA VIEW column alignment to match the shorter 3-slot left column; the ALGEBRA VIEW (right column) content is unchanged.

The surrounding algebra-view prose is registration-shape-agnostic (unaffected) and was left untouched, per the bead.

Closes rf2-3nlouf.

## Quality gates

- `python -m mkdocs build --strict` (config `mkdocs.yml`, run from repo root) — **PASS** (exit 0, no warnings/errors; only benign INFO lines for pre-existing unrelated relative-link notices).
- Grepped the tree for test pins on the two example blocks (`materialized-total`, `Derivations.md` references in test dirs) — **PASS / no risk**: all hits are either tests already using the correct 3-slot `reg-flow` call shape (unrelated to the doc prose) or spec-citation comments (`;; against [Derivations.md] §...`); nothing literal-pins the changed example text.