### PR TITLE
refactor(epoch): drop unused substrate.adapter require + superseded JVM malli fallback in tool_pair (rf2-319zkf)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
+++ b/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
@@ -60,7 +60,6 @@
             [re-frame.classification :as classification]
             [re-frame.projection :as projection]
             [re-frame.registrar :as registrar]
-            [re-frame.substrate.adapter :as adapter]
             [re-frame.trace :as trace]))
 
 ;; ---- restore failure-mode predicates --------------------------------------

--- a/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
+++ b/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
@@ -67,21 +67,17 @@
 (defn- malli-validate-fn
   "Return the malli validate fn or nil.
 
-  Per rf2-t0hq — CLJS has no runtime `resolve`, so the lookup order on
-  CLJS is: late-bind hook then nil. Returning nil is treated as
-  soft-pass by callers ('cannot disprove, treat as valid').
+  Looks up the late-bind hook `:schemas/malli-validate`, published by
+  `re-frame.schemas.malli` when loaded — the only lookup step, on both
+  CLJ and CLJS. Per rf2-qyfie, `re-frame.schemas.validator` dropped its
+  JVM-only `(requiring-resolve 'malli.core/validate)` fallback for
+  contract symmetry between runtimes; this fn mirrors that shape rather
+  than the pre-rf2-qyfie two-step lookup.
 
-  Lookup order matches `re-frame.schemas/default-malli-validate`:
-    1. Late-bind hook `:schemas/malli-validate` (published by
-       `re-frame.schemas.malli` when loaded).
-    2. JVM only — fall back to `(requiring-resolve 'malli.core/validate)`.
-    3. Return nil (soft-pass — the schema-validate-ok? caller treats
-       a nil validate fn as 'cannot disprove, treat as valid')."
+  Returning nil (hook unbound) is treated as soft-pass by callers —
+  'cannot disprove, treat as valid' — unchanged from before rf2-qyfie."
   []
-  (or (late-bind/get-fn :schemas/malli-validate)
-      #?(:clj  (try (requiring-resolve 'malli.core/validate)
-                    (catch Throwable _ nil))
-         :cljs nil)))
+  (late-bind/get-fn :schemas/malli-validate))
 
 (defn- registered-app-schemas
   "Return the {path → schema-meta} map registered against the named


### PR DESCRIPTION
## Summary

Two verified vestiges removed from `implementation/epoch/src/re_frame/epoch/tool_pair.cljc` (rf2-319zkf):

- **Item 1** — dropped the unused `[re-frame.substrate.adapter :as adapter]` require. The `adapter` alias had zero code call sites in the file; the only `adapter/` occurrence is prose inside the write-boundary design comment (~line 505), which stays unchanged. Residue of the pre-rf2-adwcv6 write path: `cc41e5399` (physical frame-state container) moved every partition write to `frame/replace-app-db!`/`replace-runtime-db!`/`replace-frame-state!`, so the direct adapter write this ns once performed is gone.

- **Item 2** — reduced `malli-validate-fn` to a hook-only lookup (`(late-bind/get-fn :schemas/malli-validate)`), dropping the JVM-only `(requiring-resolve 'malli.core/validate)` fallback branch, and rewrote the docstring. The old docstring claimed lookup-order parity with `re-frame.schemas.validator/default-malli-validate`, but that's been false since rf2-qyfie (`b79eed703`, 2026-05-14), which dropped the equivalent fallback from the schemas-side default for CLJ/CLJS contract symmetry. The Tool-Pair restore-precondition soft-pass contract (nil validate fn = "cannot disprove, treat as valid") is **unchanged** — `failing-schema-paths` still short-circuits to `[]` when `malli-validate-fn` returns nil.

No spec touch for either item (per the bead). Single file changed, isolated surface (`implementation/epoch/src/re_frame/epoch/tool_pair.cljc`), no hot-zone files.

## Quality gates

- `npm run test:cljs` (from `implementation/`): **PASS** — 8058 tests, 37000 assertions, 0 failures, 0 errors.
- `clojure -M:test` (from `implementation/epoch/`): **PASS** — 376 tests, 1506 assertions, 0 failures, 0 errors.
- Verified premises against current HEAD before editing: `git grep -n 'adapter/' implementation/epoch/src/re_frame/epoch/tool_pair.cljc` → only the prose comment hit; `git grep -rn 'requiring-resolve' implementation/epoch/test/` → 0 hits (no test pins the old fallback branch).

## Test plan

- [x] `git grep` confirmed both premises before editing
- [x] `npm run test:cljs` green
- [x] `clojure -M:test` (epoch) green
- [x] Manual diff review confirms comment mention of `adapter/replace-container!` at ~line 505 is untouched