### PR TITLE
refactor(reagent-slim): remove dead before-flush queue from batching (rf2-offa0e)

### DIFF
--- a/implementation/adapters/reagent-slim/IMPL-SPEC.md
+++ b/implementation/adapters/reagent-slim/IMPL-SPEC.md
@@ -345,7 +345,7 @@ Internal Vars:
 - `queue-render!` `[component]` — enqueue a component for re-render; schedules a microtask if not already scheduled.
 - `flush!` `[]` — synchronous drain of the dirty set + cooperation with React commit. The implementation hook for `reagent2.dom.client/flush-views!`.
 - `after-render` `[f]` — schedule `f` after the next render. Kept as the public ABI for `reagent2.core/after-render`.
-- `do-after-render`, `before-flush` — internal lifecycle hooks.
+- `do-after-render` — internal lifecycle hook.
 
 See §4 for the scheduler's full design.
 

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/batching.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/batching.cljs
@@ -23,7 +23,6 @@
 
     queue-render!   ;; component → enqueue + schedule microtask
     do-after-render ;; fn → run after the next render
-    do-before-flush ;; fn → run before each flush turn
     schedule        ;; force a microtask schedule (no-op if already scheduled)
     flush!          ;; synchronous drain (test primitive's worker)
     mark-rendered   ;; clear a component's dirty flag (called by render)
@@ -74,10 +73,9 @@
 ;; ---------------------------------------------------------------------------
 ;; The render queue
 ;;
-;; A single `RenderQueue` instance holds three sub-queues:
+;; A single `RenderQueue` instance holds two sub-queues:
 ;;
 ;;   - components       — JS array of component instances to forceUpdate
-;;   - before-flush     — fns run at the start of each flush turn
 ;;   - after-render     — fns run at the end of each flush turn
 ;;
 ;; Per IMPL-SPEC §4.4 components flow through three pathways:
@@ -93,7 +91,6 @@
 
 (deftype RenderQueue [^:mutable ^boolean scheduled?
                       ^:mutable component-queue
-                      ^:mutable before-flush-queue
                       ^:mutable after-render-queue]
   Object
   (schedule [this]
@@ -107,12 +104,6 @@
     (.push component-queue c)
     (.schedule this))
 
-  (add-before-flush [this f]
-    (when (nil? before-flush-queue)
-      (set! before-flush-queue #js []))
-    (.push before-flush-queue f)
-    (.schedule this))
-
   (add-after-render [this f]
     (when (nil? after-render-queue)
       (set! after-render-queue #js []))
@@ -121,12 +112,6 @@
   (run-queues [this]
     (set! scheduled? false)
     (.flush-queues this))
-
-  (flush-before-flush [_this]
-    (when-some [fs before-flush-queue]
-      (set! before-flush-queue nil)
-      (dotimes [i (alength fs)]
-        ((aget fs i)))))
 
   (flush-render [_this]
     (when-some [fs component-queue]
@@ -146,7 +131,6 @@
         ((aget fs i)))))
 
   (flush-queues [this]
-    (.flush-before-flush this)
     ;; Drain the reactive queue first — Reaction recomputes may enqueue
     ;; further component renders into component-queue, which we then
     ;; pick up in flush-render below.
@@ -155,7 +139,7 @@
     (.flush-after-render this)))
 
 (defonce ^:private render-queue
-  (->RenderQueue false nil nil nil))
+  (->RenderQueue false nil nil))
 
 ;; ---------------------------------------------------------------------------
 ;; Public API
@@ -176,12 +160,6 @@
   first entry — see ns docstring."
   []
   (.schedule render-queue))
-
-(defn do-before-flush
-  "Register `f` to run at the start of the next flush turn. Used by
-  internal lifecycle plumbing; users prefer `do-after-render`."
-  [f]
-  (.add-before-flush render-queue f))
 
 (defn do-after-render
   "Register `f` to run at the end of the next flush turn — i.e. after

--- a/implementation/adapters/reagent-slim/test/reagent2/impl/batching_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/impl/batching_cljs_test.cljs
@@ -7,7 +7,7 @@
       microtask body drains the queue.
     - Deduplication: same component enqueued multiple times before
       drain runs only once (cljsIsDirty flag).
-    - Ordering: before-flush -> rea-flush -> render -> after-render.
+    - Ordering: rea-flush -> render -> after-render.
     - flush! synchronous drain: callable from test code, identical
       contract to the microtask body.
     - do-after-render: callbacks fire after the render phase.
@@ -124,21 +124,20 @@
                      (done))))))))
 
 ;; ---------------------------------------------------------------------------
-;; Ordering invariant: before-flush -> ratom/flush! -> render -> after-render
+;; Ordering invariant: ratom/flush! -> render -> after-render
 ;; ---------------------------------------------------------------------------
 
-(deftest ordering-before-render-after
-  (testing "queues drain in spec order: before-flush, render, after-render"
+(deftest ordering-render-after
+  (testing "queues drain in spec order: render, after-render"
     (async done
       (let [order (atom [])
             c     #js {}]
         (set! (.-forceUpdate c) (fn [] (swap! order conj :render)))
-        (batching/do-before-flush (fn [] (swap! order conj :before)))
         (batching/queue-render! c)
         (batching/do-after-render (fn [] (swap! order conj :after)))
         (-> (next-microtask)
             (.then (fn [_]
-                     (is (= [:before :render :after] @order)
+                     (is (= [:render :after] @order)
                          "drain order matches IMPL-SPEC §4.1 step 1-4")
                      (done))))))))
 


### PR DESCRIPTION
## Summary

`reagent2.impl.batching` carried a complete before-flush sub-queue with zero production consumers: `do-before-flush`, the `RenderQueue` `before-flush-queue` field, methods `add-before-flush`/`flush-before-flush`, and the drain step in `flush-queues`. Stock Reagent's only consumer of this mechanism was `next-tick`, which the slim rewrite audit-dropped (IMPL-SPEC §2.2); the queue machinery was carried over in Stage 4-B (commit 1d621015b) with no consumer ever added, so `flush-before-flush` was a guaranteed no-op in production.

- Removed `do-before-flush`, the `before-flush-queue` field, `add-before-flush`/`flush-before-flush` methods, and the drain step in `flush-queues` from `implementation/adapters/reagent-slim/src/reagent2/impl/batching.cljs`.
- Updated the ns docstring "Public surface" list and the three-queue comment block to drop the before-flush references.
- Retargeted `implementation/adapters/reagent-slim/test/reagent2/impl/batching_cljs_test.cljs`: renamed `ordering-before-render-after` → `ordering-render-after` and dropped its `:before` leg — IMPL-SPEC §4.1's microtask body never specced a before-flush step, so the old test's citation was inaccurate.
- Dropped `before-flush` from `implementation/adapters/reagent-slim/IMPL-SPEC.md:348`. The §4.1/§4.6 drain contracts never included before-flush and are untouched.

No behaviour change — this is dead-code removal only.

## Quality gates

Run from `implementation/` in a fresh worktree (`npm install` first):

- `npm run test:cljs` — PASS. 8058 tests, 37000 assertions, 0 failures, 0 errors. (Includes `reagent2.impl.batching-cljs-test`, which is part of the consolidated `:node-test` build.)
- `npx shadow-cljs compile node-test` — PASS (compiles cleanly; only pre-existing unrelated warnings in other namespaces).
- `npm run test:reagent-slim:bundle-isolation` — PASS. `reagent-slim-bundle-isolation: 6 contracts passed; 25 sentinel checks`.

## Verification

`git grep -n "before-flush"` and `git grep -n "do-before-flush"` across the tracked tree (excluding `.beads/issues.jsonl`, which only carries historical bead-description text) now return zero hits — confirmed before editing that the only hits were `batching.cljs` itself, its own unit test, and `IMPL-SPEC.md:348`.

Closes rf2-offa0e.