### PR TITLE
chore: tail vestigial cleanup — uix test .keep + flows deps.edn header (rf2-pxzk2x, rf2-kfrmm9)

### DIFF
--- a/implementation/adapters/uix/test/.keep
+++ b/implementation/adapters/uix/test/.keep
@@ -1,1 +1,0 @@
-UIx adapter is CLJS-only — JVM-runnable tests live in core/test (substrate-agnostic) and the browser smoke trio per Decision 7 lives under examples/substrates/uix/counter and examples/substrates/uix/login. This dir is kept so the :test alias has a valid :extra-paths entry.

--- a/implementation/flows/deps.edn
+++ b/implementation/flows/deps.edn
@@ -17,10 +17,15 @@
 ;; And require `re-frame.flows` in any namespace that calls
 ;; `rf/reg-flow` / `rf/clear-flow` or relies on the `:rf.fx/reg-flow`
 ;; / `:rf.fx/clear-flow` runtime fxs — loading the namespace registers
-;; its late-bind hooks (`:flows/reg-flow`, `:flows/clear-flow`,
-;; `:flows/run-flows-on-db`, `:flows/reset-last-inputs!`, `:flows/reset-flows!`)
-;; and installs the registrar replacement-hook for hot-reload
-;; `last-inputs` invalidation.
+;; its late-bind hooks and wires `reg-flow` to clear the affected
+;; frame's `last-inputs` row directly on a same-frame hot-reload
+;; replacement, so a hot-reloaded flow re-evaluates on its next drain.
+;;
+;; The authoritative, always-current hook list is the `late-bind/set-fn!`
+;; calls in `re-frame.flows` (cross-referenced against the
+;; `re-frame.late-bind.directory/hooks` `:flows/*` rows, pinned in sync by
+;; the `re-frame.late-bind-drift-test` gate) — this comment intentionally
+;; does NOT maintain a parallel list that would silently drift.
 ;;
 ;; Per Spec 006 §Adapter shipping convention (and the
 ;; rf2-p7va extension to per-feature splits): this artefact depends on


### PR DESCRIPTION
## Summary

Two tiny, verified, comment/placeholder-only vestigial-removal beads on disjoint surfaces.

**rf2-pxzk2x** — `git rm implementation/adapters/uix/test/.keep`. The placeholder's stated condition (empty dir needing a stub so the `:test` alias `:extra-paths` entry stays valid) has passed: `test/re_frame/adapter/` now carries 6 tracked test files. `git grep -n "\.keep"` repo-wide finds no build/test wiring reference — only the bead's own `.beads/issues.jsonl` record and two unrelated `:div.keep` hiccup literals in `tools/story` tests. No spec touch; nothing reads it.

**rf2-kfrmm9** — comment-only fix in `implementation/flows/deps.edn` (~lines 17-28). The header claimed loading `re-frame.flows` "installs the registrar replacement-hook for hot-reload last-inputs invalidation" — that mechanism was deleted by rf2-en00bk (single-store flows, d8bc29e2e): `invalidate-flow-on-replace!` and the replacement-hook wiring are gone; hot-reload invalidation now runs directly inside `reg-flow` on a same-frame replacement (see `registry.cljc`'s "hot-reload invalidation" section, ~1479-1494). Rewrote the sentence to describe the direct mechanism, and de-enumerated the stale partial hook list, adopting the `epoch/deps.edn` convention of pointing at the `late-bind/set-fn!` calls in `re-frame.flows` + the `late-bind-drift-test` gate instead of hand-maintaining a parallel copy. `git grep invalidate-flow-on-replace` confirmed zero live source hits (only historical-removal-note comments and test names asserting the mechanism is gone). Comment-only; no code, no spec touch.

## Quality gates

- `npm run test:cljs` (from `implementation/`) — **PASS**: 8058 tests, 37000 assertions, 0 failures, 0 errors. This node-runtime suite covers the flows artefact and all adapter unit tests (including uix).
- `clojure -Stree -A:test` and `clojure -M:test` (from `implementation/adapters/uix/`) — **PASS**: classpath resolves cleanly post-`.keep`-deletion; alias runs and reports "Ran 0 tests containing 0 assertions. 0 failures, 0 errors." (expected — the uix `:test` alias is a classpath-probe alias per `TESTING.md`; real coverage is the CLJS unit tests captured above).
- `clojure -e '(clojure.edn/read-string (slurp "implementation/flows/deps.edn"))'` — **PASS**: file parses as valid EDN after the edit.
- Not run locally (rely on CI): `npm run test:browser`, `npm run test:elision`, `npm run test:perf-bundle`, `npm run test:bundle-isolation`, `npm run test:adapter-smokes`, `mkdocs build --strict`. None of these surfaces are touched by a comment-only deps.edn edit or a `.keep` file deletion; CI will confirm no regression.

## Test plan

- [x] `git grep` verification before each edit (both beads) confirmed no live references to the removed/described machinery
- [x] `npm run test:cljs` green (8058/8058)
- [x] uix `:test` alias classpath probe green
- [x] `flows/deps.edn` parses as EDN
- [x] `git diff --stat origin/main..HEAD` shows only the two intended files changed