### PR TITLE
Correctness fixes from /implementation review (6 fixes + findings ledger)

### DIFF
--- a/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
@@ -293,9 +293,20 @@
         (set! (.-cljsRenderFn c) inner)
         (apply inner args))
 
-      ;; Compile-time-tagged Form-1: skip the classification cond.
+      ;; Compile-time-tagged Form-1: skip the full classification cond, but keep
+      ;; the runtime fn? fallback. `classify-form-body` tags a body Form-1
+      ;; whenever its LAST form is not a literal `(fn …)` — which includes the
+      ;; idiomatic stateful Form-2 shape `(let [s (r/atom 0)] (fn [] …))` (last
+      ;; form is a `let`). Such a body returns the inner render CLOSURE, so
+      ;; without this fn? check `wrap-render` would return a function as hiccup
+      ;; and React errors ("Functions are not valid as a React child"). Treat a
+      ;; returned fn as Form-2 — cache and recall — exactly as the :else path.
       (= :reagent2/form-1 (form-tag render-fn))
-      (apply render-fn args)
+      (let [out (apply render-fn args)]
+        (if (fn? out)
+          (do (set! (.-cljsRenderFn c) out)
+              (apply out args))
+          out))
 
       :else
       (let [out (apply render-fn args)]

--- a/implementation/adapters/reagent-slim/test/reagent2/impl/component_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/impl/component_cljs_test.cljs
@@ -204,6 +204,34 @@
           c         (fake-instance [render-fn 42])]
       (is (= [:tag/form-1 42] (component/wrap-render c render-fn))))))
 
+(deftest wrap-render-form-1-tag-returning-fn-recalls-as-form-2
+  (testing "a render-fn TAGGED :reagent2/form-1 whose body returns a FN (the
+  idiomatic `(let [s (r/atom 0)] (fn [] …))` stateful Form-2 shape that
+  classify-form-body mis-tags Form-1, since its last form is a `let`) is
+  recalled as Form-2 — wrap-render must return the inner fn's HICCUP, not the
+  bare function (React rejects a function as a child)"
+    (let [setup-calls  (atom 0)
+          render-calls (atom 0)
+          render-fn (with-meta
+                      (fn [n0]
+                        (swap! setup-calls inc)
+                        (let [local n0]
+                          (fn [n]
+                            (swap! render-calls inc)
+                            [:tag/form-1-fn (+ local n)])))
+                      {:reagent2/form :reagent2/form-1})
+          c (fake-instance [render-fn 10])]
+      (let [out (component/wrap-render c render-fn)]
+        (is (vector? out) "returns hiccup, not a bare function")
+        (is (not (fn? out)))
+        (is (= [:tag/form-1-fn 20] out))
+        (is (= 1 @setup-calls))
+        (is (= 1 @render-calls)))
+      ;; Inner fn now cached — a subsequent render hits the Form-2 hot path.
+      (set! (.-cljsArgv c) [render-fn 5])
+      (is (= [:tag/form-1-fn 15] (component/wrap-render c render-fn)))
+      (is (= 1 @setup-calls) "outer NOT re-run — inner cached like any Form-2"))))
+
 (deftest wrap-render-form-2-tag-fast-path
   (testing "render-fn with :reagent2/form-2 meta dispatches without classification"
     (let [setup-calls (atom 0)

--- a/implementation/core/src/re_frame/image.cljc
+++ b/implementation/core/src/re_frame/image.cljc
@@ -362,6 +362,25 @@
              "use the 3-tuple [id metadata body].")
         {:recovery :use-an-id-body-or-id-metadata-body-tuple
          :extra    {:image image-id :section section :entry entry}}))
+    ;; FAIL-LOUD on a non-MAP metadata slot in the 3-tuple form. The metadata
+    ;; slot of `[id metadata body]` is a Spec 001 registration metadata MAP
+    ;; (EP-0026 §Inline Registration Grammar). An unvalidated non-map slot
+    ;; otherwise either crashes raw at the `(seq metadata)` guard below (a
+    ;; non-seqable such as a number) or is silently accepted and passed on as
+    ;; junk `:metadata` to the lowering hook (a seqable non-map such as a
+    ;; string or vector) — both defeat the canonical `:rf.error/invalid-image`
+    ;; shape every sibling defect on this path gets.
+    (when (and has-meta (not (map? metadata)))
+      (error/throw-error!
+        :rf.error/invalid-image
+        'rf/image
+        (str "rf/image: inline " section " entry " (pr-str entry)
+             " has a non-map metadata slot — the middle slot of a 3-tuple "
+             "[id metadata body] MUST be a registration metadata MAP (EP-0026). "
+             "Got " (pr-str metadata) " (" (pr-str (type metadata)) "). For a "
+             "registration with no metadata use the 2-tuple [id body].")
+        {:recovery :use-an-id-body-or-id-metadata-body-tuple
+         :extra    {:image image-id :section section :entry entry}}))
     (cond-> {:kind                 kind
              :id                   id
              :impl                 body

--- a/implementation/core/src/re_frame/router/diagnostics.cljc
+++ b/implementation/core/src/re_frame/router/diagnostics.cljc
@@ -124,10 +124,15 @@
                             supplies `:explicit-live`. Absent ⇒ the frame
                             config's policy, else the router's `:live` default
     :rf.trace/call-site     macro-stamped invocation coord (dev-only)
-    :rf.machine/internal?   machine-internal continuation flag (front-queue)"
+    :rf.machine/internal?   machine-internal continuation flag (front-queue)
+    :step-index             frame-construction setup-step index, stamped by
+                            `frame.cljc`'s `run-setup-events!` onto each
+                            `:initial-events` dispatch (EP-0027); read by
+                            `build-envelope` and carried onto the dispatched
+                            trace as `:rf.frame/init-step-index`"
   #{:frame :fx-overrides :interceptor-overrides :trace-id :source
     :source-detail :origin :rf.cofx :rf.cofx/mint-policy :rf.trace/call-site
-    :rf.machine/internal?})
+    :rf.machine/internal? :step-index})
 
 (def ^:const retired-draft-opt-hints
   "Dispatch-opt keys that named a fact only ever spelled in the spec's own

--- a/implementation/core/src/re_frame/router_transducer.cljc
+++ b/implementation/core/src/re_frame/router_transducer.cljc
@@ -197,7 +197,7 @@
     ([] {:db nil :steps [] :fx-applied [] :errors []})
     ([acc] acc)                          ;; completing arity
     ([acc step]
-     (let [{:keys [rf/step db-after fx error]} step]
+     (let [{:keys [db-after fx error]} step]
        (cond-> acc
          true            (assoc :db db-after)
          true            (update :steps conj step)
@@ -220,7 +220,7 @@
          :fx-applied [] :errors []})
     ([acc] acc)
     ([acc step]
-     (let [{:keys [rf/step db-after fx error]} step
+     (let [{:keys [db-after fx error]} step
            [dispatches non-dispatches] ((juxt filter remove)
                                         (fn [[k _]] (= k :dispatch))
                                         (or fx []))]
@@ -250,7 +250,7 @@
          (assoc :committed? true
                 :staged-fx [])))
     ([acc step]
-     (let [{:keys [rf/step db-after fx error]} step]
+     (let [{:keys [db-after fx error]} step]
        (cond-> acc
          true            (assoc :db db-after)
          true            (update :steps conj step)

--- a/implementation/core/src/re_frame/source_coords.cljc
+++ b/implementation/core/src/re_frame/source_coords.cljc
@@ -714,14 +714,21 @@
   co-located coord — an inline-fn / keyword value at the same slot is
   skipped (there is no map to hang `:source-coords` on; a tool reads the
   enclosing map's coord). Inlines to the equivalent
-  `(when (and (map? form) ...) (assoc! acc path c))` so the imperative-
-  mutation shape `walk-states-tree` relies on for macro-expansion-time
-  performance is preserved.
+  `(when (and (map? form) ...) (vswap! acc assoc! path c))` so the
+  imperative-mutation shape `walk-states-tree` relies on for
+  macro-expansion-time performance is preserved.
 
-  Lexical-capture contract: callers must have `acc` (a transient map),
-  `ns-sym` (a symbol), and `file` (a string or nil) in scope. The macro
-  is private to this namespace and used only inside `walk-states-tree`
-  and `walk-machine-spec`, both of which bind those three locals.
+  Lexical-capture contract: callers must have `acc` (a VOLATILE holding a
+  transient map), `ns-sym` (a symbol), and `file` (a string or nil) in
+  scope. The macro is private to this namespace and used only inside
+  `walk-states-tree` and `walk-machine-spec`, both of which bind those
+  three locals.
+
+  `acc` is a `volatile!` around the transient, NOT a bare transient: a
+  transient array-map promotes to a transient hash-map on its 9th distinct
+  key and RETURNS A NEW OBJECT, so `assoc!`'s return value cannot be
+  discarded (in-place mutation is not guaranteed). `vswap!` captures the
+  (possibly promoted) return, so stamps past the 8th are not lost.
 
   Hides the repetitive shape behind a single two-arg call at every
   reference-site stamp."
@@ -729,7 +736,7 @@
   `(let [form# ~form]
      (when (map? form#)
        (when-let [c# (form-coords form# ~'ns-sym ~'file)]
-         (assoc! ~'acc ~path c#)))))
+         (vswap! ~'acc assoc! ~path c#)))))
 
 (defn- walk-states-tree
   "Recursively walk the literal `:states` map. `path` accumulates the
@@ -741,15 +748,19 @@
   so there is no node to co-locate `:source-coords` onto (a tool resolving
   such a slot reads the enclosing map's coord). Per rf2-vqja2.
 
-  Note on style: this walker is mutation-heavy (transient `acc` threaded
-  through nested `reduce-kv` / `doseq` with `assoc!` via the `stamp-map!`
-  macro) rather than the more functional shape of a visitor that returns
-  collected entries. The imperative shape is deliberate — this code runs
-  at macro-expansion time and gets called on every `reg-machine` form.
-  Transients avoid the per-state allocation cost of building intermediate
-  persistent maps during expansion. The result is materialised once at
-  the edge in `walk-machine-spec`. Refactoring to a fully declarative
-  visitor is feasible but would need to be benchmarked against current
+  Note on style: this walker is mutation-heavy (`acc` is a `volatile!`
+  around a transient, mutated via `vswap! acc assoc!` through nested
+  `reduce-kv` / `doseq`, stamped via the `stamp-map!` macro) rather than
+  the more functional shape of a visitor that returns collected entries.
+  The imperative shape is deliberate — this code runs at macro-expansion
+  time and gets called on every `reg-machine` form. Transients avoid the
+  per-state allocation cost of building intermediate persistent maps
+  during expansion. The `volatile!` wrapper is load-bearing: a bare
+  transient's `assoc!` return cannot be discarded (array-map→hash-map
+  promotion at the 9th key returns a NEW object), so the accumulator is
+  threaded through the volatile. The result is materialised once at the
+  edge in `walk-machine-spec`. Refactoring to a fully declarative visitor
+  is feasible but would need to be benchmarked against current
   compile-time numbers before adoption."
   [states-form path acc ns-sym file]
   (when (map? states-form)
@@ -837,10 +848,14 @@
   [spec-form ns-sym file]
   (if-not (map? spec-form)
     {}
-    (let [acc (transient {})]
+    ;; `acc` is a VOLATILE around the transient (not a bare transient): a
+    ;; transient array-map promotes to a hash-map on its 9th key and returns a
+    ;; NEW object, so `stamp-map!` threads the return via `vswap!` rather than
+    ;; relying on in-place mutation (which capped the index at 8 entries).
+    (let [acc (volatile! (transient {}))]
       ;; Reference-site stamping of MAP nodes under :states.
       (walk-states-tree (:states spec-form) [:states] acc ns-sym file)
-      (persistent! acc))))
+      (persistent! @acc))))
 
 ;; ---- inline-fn source-code co-location (rf2-se70xj) -----------------------
 ;;
@@ -916,8 +931,10 @@
    so the same `:on` / `:always` / `:after` / nested-`:states` shapes are
    covered, but collects fn-literal SOURCE rather than map-node coords.
 
-   `path` accumulates the spec-path from the spec's root. The mutable `acc`
-   transient is threaded through. Compile-time / JVM-only."
+   `path` accumulates the spec-path from the spec's root. `acc` is a
+   `volatile!` around a transient, mutated via `vswap! acc assoc!` (the
+   volatile threads the transient's possibly-promoted return so stamps past
+   the 8th key are not lost). Compile-time / JVM-only."
   [states-form path acc]
   (if-not (map? states-form)
     acc
@@ -927,7 +944,7 @@
           (when (map? node)
             ;; State-node inline `:entry` / `:exit`.
             (when-let [src (node-inline-source node)]
-              (assoc! acc node-path src))
+              (vswap! acc assoc! node-path src))
             ;; :on transitions — each transition MAP's inline `:guard` /
             ;; `:action`. Single-map and vector-of-candidates forms.
             (when-let [on-map (:on node)]
@@ -938,12 +955,12 @@
                       (cond
                         (map? t)
                         (when-let [src (node-inline-source t)]
-                          (assoc! acc tp src))
+                          (vswap! acc assoc! tp src))
                         (vector? t)
                         (doseq [[i tx] (map-indexed vector t)
                                 :when (map? tx)]
                           (when-let [src (node-inline-source tx)]
-                            (assoc! acc (conj tp i) src)))))
+                            (vswap! acc assoc! (conj tp i) src)))))
                     nil)
                   nil on-map)))
             ;; :always — single transition MAP or a vector of candidate maps
@@ -958,12 +975,12 @@
               (cond
                 (map? always)
                 (when-let [src (node-inline-source always)]
-                  (assoc! acc (conj node-path :always) src))
+                  (vswap! acc assoc! (conj node-path :always) src))
                 (vector? always)
                 (doseq [[i tx] (map-indexed vector always)
                         :when (map? tx)]
                   (when-let [src (node-inline-source tx)]
-                    (assoc! acc (conj node-path :always i) src)))))
+                    (vswap! acc assoc! (conj node-path :always i) src)))))
             ;; :after — map of delay → target-or-transition map.
             (when-let [after (:after node)]
               (when (map? after)
@@ -971,7 +988,7 @@
                   (fn [_ delay t]
                     (when (map? t)
                       (when-let [src (node-inline-source t)]
-                        (assoc! acc (conj node-path :after delay) src)))
+                        (vswap! acc assoc! (conj node-path :after delay) src)))
                     nil)
                   nil after)))
             ;; Recurse into nested :states.
@@ -1009,9 +1026,12 @@
   [spec-form]
   (if-not (map? spec-form)
     {}
-    (let [acc (transient {})]
+    ;; VOLATILE around the transient — `vswap! acc assoc!` threads the transient's
+    ;; (possibly promoted) return so stamps past the 8th key are not lost. See
+    ;; `walk-machine-spec` for the array-map-promotion rationale.
+    (let [acc (volatile! (transient {}))]
       (walk-states-inline-source (:states spec-form) [:states] acc)
-      (persistent! acc))))
+      (persistent! @acc))))
 
    )) ;; end #?(:clj (do ...)) for the inline-source walk
 

--- a/implementation/core/src/re_frame/test_support.cljc
+++ b/implementation/core/src/re_frame/test_support.cljc
@@ -956,7 +956,11 @@
             start    (System/currentTimeMillis)
             deadline (+ start timeout-ms)]
         (loop []
-          (let [v (pred)]
+          ;; A transient throw from `pred` (e.g. reading state mid-transition) is
+          ;; a falsy probe — keep polling until the deadline. Mirrors the CLJS arm
+          ;; below and the sibling `wait-until` (test_helpers), so the single
+          ;; cross-platform helper has uniform pred-exception semantics.
+          (let [v (try (pred) (catch Throwable _ false))]
             (cond
               v v
               (>= (System/currentTimeMillis) deadline)

--- a/implementation/core/test/re_frame/image_cljs_test.cljc
+++ b/implementation/core/test/re_frame/image_cljs_test.cljc
@@ -401,6 +401,40 @@
       (is (= :rf.error/invalid-image (:rf.error/id data)))
       (is (= entry (:entry data))))))
 
+(deftest inline-rejects-non-map-metadata-slot
+  ;; The middle slot of a 3-tuple [id metadata body] MUST be a registration
+  ;; metadata MAP (EP-0026). A non-seqable non-map (a number) previously crashed
+  ;; RAW at the `(seq metadata)` guard; a seqable non-map (a string / vector) was
+  ;; previously SILENTLY accepted and stamped as junk `:metadata`. Both must now
+  ;; fail loud with the canonical `:rf.error/invalid-image` shape.
+  (testing "a non-seqable metadata slot (a number) throws :rf.error/invalid-image, not a raw host crash"
+    (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                          #"\[:rf\.error/invalid-image\]"
+                          (image/image
+                            {:id :i
+                             :registrations {:reg-event [[:counter/inc 42 (fn [_ _] {})]]}}))))
+  (testing "a seqable non-map metadata slot (a string) throws rather than being silently accepted"
+    (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                          #"\[:rf\.error/invalid-image\]"
+                          (image/image
+                            {:id :i
+                             :registrations {:reg-event [[:counter/inc "doc" (fn [_ _] {})]]}}))))
+  (testing "a seqable non-map metadata slot (a vector) throws rather than being silently accepted"
+    (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                          #"\[:rf\.error/invalid-image\]"
+                          (image/image
+                            {:id :i
+                             :registrations {:reg-event [[:counter/inc [:x] (fn [_ _] {})]]}}))))
+  (testing "the diagnostic names the image, the section, and the offending entry"
+    (let [entry [:counter/inc "doc" (fn [_ _] {})]
+          data  (try (image/image {:id :my/image :registrations {:reg-event [entry]}})
+                     (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e
+                       (ex-data e)))]
+      (is (= :rf.error/invalid-image (:rf.error/id data)))
+      (is (= :my/image (:image data)))
+      (is (= :reg-event (:section data)))
+      (is (= entry (:entry data))))))
+
 (deftest anonymous-image-inline-omits-image-coordinate
   (testing "anonymous image inline descriptors omit :rf.provenance/image"
     (let [v (image/image {:registrations {:reg-event [[:x {} (fn [_ _] {})]]}})

--- a/implementation/core/test/re_frame/router_transducer_test.cljc
+++ b/implementation/core/test/re_frame/router_transducer_test.cljc
@@ -98,6 +98,12 @@
       (is (= {:n 1} (:db acc)))
       (is (= [[:log :did-inc]] (:fx-applied acc)))
       (is (= 1 (count (:steps acc))))
+      ;; `:steps` holds the step-result MAPS (a trace of every step), not the
+      ;; bare `:rf/step` status keyword — the reducing fn conjes the step map.
+      (let [s (first (:steps acc))]
+        (is (map? s) ":steps entries are step-result maps")
+        (is (= :ok (:rf/step s)))
+        (is (= {:n 1} (:db-after s))))
       (is (= [] (:errors acc))))))
 
 (deftest sync-rf-folds-multiple-envelopes

--- a/implementation/core/test/re_frame/test_support_test.clj
+++ b/implementation/core/test/re_frame/test_support_test.clj
@@ -480,3 +480,31 @@
         (finally
           (reset! late-bind/hooks snapshot))))))
 
+;; ---- poll-until pred-exception semantics (JVM ↔ CLJS parity) --------------
+
+(deftest poll-until-swallows-a-throwing-pred-jvm
+  (testing "a `pred` that throws transiently is a falsy probe — keep polling to
+  the deadline — matching the CLJS arm and the sibling `wait-until`. The JVM arm
+  previously propagated the throw out of poll-until on the first probe."
+    ;; Throws on the first two probes, then succeeds → must resolve, not surface
+    ;; the pred's exception.
+    (let [calls (atom 0)]
+      (is (= :ok
+             (ts/poll-until
+               (fn []
+                 (if (< (swap! calls inc) 3)
+                   (throw (ex-info "transient" {}))
+                   :ok))
+               {:timeout-ms 2000 :interval-ms 1}))
+          "throwing-then-succeeding pred resolves rather than propagating the throw")
+      (is (>= @calls 3)))
+    ;; An always-throwing pred hits the deadline and surfaces the
+    ;; poll-until-timeout discriminator — NOT the pred's own exception.
+    (let [e (try (ts/poll-until (fn [] (throw (ex-info "always" {:boom true})))
+                                {:timeout-ms 40 :interval-ms 5})
+                 nil
+                 (catch clojure.lang.ExceptionInfo ex ex))]
+      (is (some? e) "poll-until throws on the deadline")
+      (is (= :rf.error/poll-until-timeout (:rf.error/id (ex-data e)))
+          "the deadline surfaces poll-until-timeout, not the pred's own throw"))))
+

--- a/implementation/core/test/re_frame/unknown_dispatch_opts_warn_test.clj
+++ b/implementation/core/test/re_frame/unknown_dispatch_opts_warn_test.clj
@@ -137,6 +137,21 @@
       (is (= 1 (count (unknown-opt-warnings recorded)))
           "build-envelope is the single chokepoint — both dispatch paths funnel through it"))))
 
+(deftest no-warning-for-initial-events-step-index
+  (testing ":initial-events setup dispatches carry :step-index (a build-envelope-read internal opt) — no false unknown-opt warning"
+    (rf/reg-event :seed/set (fn [{:keys [db]} [_ v]] {:db (assoc db :seed v)}))
+    (let [recorded (record-traces! ::init-step)]
+      ;; `reg-frame` with `:initial-events` runs each setup step through
+      ;; `frame.cljc`'s `run-setup-events!`, which stamps `:step-index` into the
+      ;; dispatch opts. `build-envelope` READS `:step-index` (carrying it onto
+      ;; the dispatched trace as `:rf.frame/init-step-index`), so the key belongs
+      ;; in `known-dispatch-opts` and must NOT trip the unknown-dispatch-opt
+      ;; warning. Before the fix, each of the two setup steps emitted one false
+      ;; `:silently ignored` warning.
+      (rf/reg-frame :seeded/frame {:initial-events [[:seed/set 1] [:seed/set 2]]})
+      (is (empty? (unknown-opt-warnings recorded))
+          ":step-index is an honoured build-envelope opt, not an unknown key"))))
+
 (deftest known-set-matches-build-envelope-reads
   (testing "the published known-opts set documents exactly the keys build-envelope honours"
     ;; A guard against drift: if build-envelope grows/drops an opt the
@@ -150,5 +165,5 @@
     ;; so build-envelope no longer reads a realm dimension.)
     (is (= #{:frame :fx-overrides :interceptor-overrides :trace-id :source
              :source-detail :origin :rf.cofx :rf.cofx/mint-policy
-             :rf.trace/call-site :rf.machine/internal?}
+             :rf.trace/call-site :rf.machine/internal? :step-index}
            diag/known-dispatch-opts))))

--- a/implementation/machines/test/re_frame/machine_source_coord_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machine_source_coord_cljs_test.cljs
@@ -272,6 +272,40 @@
     (is (nil? (inline-source :rf2-se70xj/kw [:states :idle :on :submit] :guard)))
     (is (string? (get-in (machines/machine-meta :rf2-se70xj/kw) [:actions :do :source-code])))))
 
+;; ---- >8 stampable nodes: transient promotion must not drop stamps --------
+
+(deftest reg-machine-stamps-every-node-past-the-8th-cljs
+  (testing "a machine with MORE than 8 stampable map-nodes co-locates coords on
+  EVERY node, not just the first 8. The walkers accumulate into a transient; a
+  transient array-map promotes to a hash-map on its 9th distinct key and returns
+  a NEW object, so the accumulator is threaded through a volatile. Before that
+  fix the 9th+ stamps were silently dropped."
+    ;; 12 state-node maps (reference-site family, walk-states-tree) AND 12 inline
+    ;; :entry fns (inline-source family, walk-states-inline-source) — both exceed
+    ;; the 8-entry array-map cap.
+    (rf/reg-machine :rf2-src8cap/many
+      {:initial :s0
+       :states
+       {:s0  {:entry (fn [_] {}) :on {:next :s1}}
+        :s1  {:entry (fn [_] {}) :on {:next :s2}}
+        :s2  {:entry (fn [_] {}) :on {:next :s3}}
+        :s3  {:entry (fn [_] {}) :on {:next :s4}}
+        :s4  {:entry (fn [_] {}) :on {:next :s5}}
+        :s5  {:entry (fn [_] {}) :on {:next :s6}}
+        :s6  {:entry (fn [_] {}) :on {:next :s7}}
+        :s7  {:entry (fn [_] {}) :on {:next :s8}}
+        :s8  {:entry (fn [_] {}) :on {:next :s9}}
+        :s9  {:entry (fn [_] {}) :on {:next :s10}}
+        :s10 {:entry (fn [_] {}) :on {:next :s11}}
+        :s11 {:entry (fn [_] {}) :on {:next :s0}}}})
+    (doseq [s [:s0 :s1 :s2 :s3 :s4 :s5 :s6 :s7 :s8 :s9 :s10 :s11]]
+      ;; reference-site :source-coords on the state-node map.
+      (is (some? (node-coords :rf2-src8cap/many [:states s]))
+          (str "state-node " s " must carry co-located :source-coords"))
+      ;; inline-source :source-code on the state's :entry fn.
+      (is (string? (inline-source :rf2-src8cap/many [:states s] :entry))
+          (str "state-node " s " :entry must carry co-located :source-code")))))
+
 ;; ---- programmatic call (no walking) --------------------------------------
 
 (deftest reg-machine-skips-stamping-for-non-literal-spec-cljs


### PR DESCRIPTION
## What this is

A correctness review of `/implementation` (the CLJS reference), fanned out one reviewer per subsystem across all 16 core + artefact areas, every finding re-verified against the code (and spec where cited) before any edit. Baseline before edits: CLJS 8058 tests / 36998 assertions green; JVM all artefacts green.

The PR lands the **contained, testable, code-verified** fixes and documents the rest — findings that need a design/spec decision, sit in intricate multi-file subsystem invariants, or entangle with the 009 catalogue (SA-9) — as follow-ups below, each with a concrete fix direction for the owner.

## Fixes (each with a regression test)

1. **`router.diagnostics` — spurious `:rf.warning/unknown-dispatch-opt` on every `:initial-events` frame construction.** `build-envelope` reads `:step-index` (stamped by `run-setup-events!` onto each setup-step dispatch, EP-0027), but the key was absent from `known-dispatch-opts`, so each setup step tripped a dev warning that wrongly said the key "is silently ignored". Added `:step-index` to the set + docstring; updated the drift-guard test; new `no-warning-for-initial-events-step-index`.

2. **`router-transducer` — reducing fns collected status keywords instead of step maps.** `{:keys [rf/step db-after fx error]}` bound local `step` to the `:rf/step` STATUS keyword, shadowing the step-map parameter, so `:steps` accumulated `[:ok :ok …]` not the step-result maps its docstring promises. Dropped the dead binding; pinned the `:steps` entry shape. (Non-production design scaffold — the fix keeps the illustration faithful.)

3. **`image` — inline 3-tuple `[id metadata body]` never validated its metadata slot.** A non-seqable non-map (`[:id 42 f]`) raw-crashed at `(seq metadata)`; a seqable non-map (`[:id "doc" f]`) was silently accepted and passed junk `:metadata` to the lowering hook — while every sibling defect fails loud with `:rf.error/invalid-image`. Added a `map?` guard; regression test covers number / string / vector.

4. **`source-coords` — machine source-coord walkers silently dropped every stamp past the 8th (transient misuse).** `stamp-map!` / `walk-states-inline-source` discarded the `assoc!` return and relied on in-place transient mutation; a transient array-map promotes to a hash-map on its 9th key and returns a NEW object, so machines with >8 stampable map-nodes got `:source-coords` / `:source-code` on only 8 arbitrary nodes (Xray/pair jump-to-source incomplete for real machines). Wrapped the accumulator in a `volatile!` so `vswap! acc assoc!` threads the promoted return; both walker families fixed. New CLJS test with a 12-node machine asserts coords on every node.

5. **`test-support` — `poll-until` swallowed a throwing `pred` on CLJS but propagated it on the JVM.** The two arms of one public cross-platform helper disagreed; the sibling `wait-until` wraps its JVM `pred` in `try/catch`, confirming the swallow is intended. Wrapped the JVM arm to match; JVM regression test covers throwing-then-succeeding and always-throwing preds.

6. **`reagent-slim` adapter — compile-time Form-1 fold breaks stateful (let-wrapped) Form-2 views.** `classify-form-body` tags a body Form-1 unless its LAST form is a literal `(fn …)`, which mis-tags the idiomatic `(let [s (r/atom 0)] (fn [] …))`; `wrap-render`'s tagged-Form-1 branch returned the result verbatim with no `fn?` check, so the inner render closure leaked out as hiccup → React "Functions are not valid as a React child" → the view never mounts. Taught the tagged branch the same `fn?` fallback the untagged `:else` path already uses (purely additive). Regression test in `component_cljs_test`.

## One agent finding rejected on verification

- **`set-db-bad-value` ex-data `:event` slot** (router reviewer): the 009 catalogue row for `:rf.error/set-db-bad-value` explicitly documents `:event` as "the offending argument" (with the event vector under `:rf.event/v`), so the code matches its own spec row — renaming would have desynced code from spec (SA-9). No change.

## Follow-ups — verified findings deferred (fix direction noted; recommend beads)

**HIGH**

- **SSR hydration hash: server hashes the document wrapper, client hashes the bare body → spurious `:rf.ssr/hydration-mismatch` on every SSR page (hard-error under `:on-mismatch :hard-error`).** rf2-9fw2de moved the ssr-ring payload's `:rf/render-hash` to `render-document-hash` = `render-tree-hash [:rf/ssr-document body {head}]` (pipeline.clj:392,421), but the client `verify-hydration!` hashes `render-tree-hash(body)` from the documented `render-tree-fn #((rf/view :app/root))` (boot.cljc:342). The client side of the rf2-9fw2de change was never made. **Needs a Spec 011 decision:** reconstruct the head client-side (fold `rf/active-head` into the wrapper before hashing) vs. revert the payload hash to body-only and carry head divergence separately. Deferred because the fix drops a shipped feature or hand-reconstructs a fragile client-side head hash — a design call, not a mechanical fix.

- **`trace-buffer-unrecognised-opts` warning emitted on the `:error` op-type.** `configure-trace-buffer!` routes a `:rf.warning/*` id through `trace/emit-error!` (op-type `:error`), but the 009 row declares it `:warning`; a `{:severity :warning}` trace-buffer filter misses it. Fix: publish/consume a `:trace/emit!` hook and emit via the `:warning` path. (tooling.cljc:615)

**MEDIUM** (each verified; fix direction in parens)

- **routing — `pending-target` calls raw `match-url` in the nav-guard phase, bypassing `match-url-fail-closed`** → a hostile/throwing URL crashes the event drain instead of failing to `:rf.route/not-found` (can_leave.cljc:184). *(Route the guard-phase match through `match-url-fail-closed`, as `url-change-fx` already does.)*
- **routing — route-rank rule 5 uses the optional-group COUNT, not the spec's boolean bit** → two routes differing only in optional-group count rank differently where the spec ties them (cross-host divergence) (match.cljc:337). *(`(if (pos? optional) 0 1)`; likewise rule 4.)*
- **resources — aborted first-load leaves an owner-free `:idle` entry with no GC timer** (a per-frame cache leak; the `:error` twin arms GC via rf2-ar9pcx, the abort sibling was left unpatched) (events.cljc:2253). *(Emit `:rf.resource/schedule-timers` on the abort settle — after confirming `gc-fired-handler` reaps `:idle`.)*
- **flows — `clear-flow` from a handler body (in-drain) directly vacates the output path, then the deferred `:db` commit resurrects it** (`reg-flow` guards this via `record-abandoned-output-path!`; `clear-flow` does not) (registry.cljc:1367). Companion: **`run-flows-on-db` skips the abandoned-path drain when the flow-map is empty** (flows.cljc:546). *(Mirror `reg-flow`'s in-drain branch; drain abandoned paths before the empty-map early return.)*
- **subs — `clear-sub-cache!` / `dispose-all-for-frame-destroy!` double-emit `:rf.sub/dispose` (wrong reason) for layer-2 inputs** — the on-dispose ref-count cascade re-emits `:no-more-derefers` while the snapshot loop also emits `:cache-clear`; nondeterministic by hash-map order (cache.cljc:277). *(Dissoc each slot before `dispose!` so the cascade finds no entry.)*
- **instrumentation — frame trace-disable gate reads only `[:tags :frame]` but the ring resolves the frame 3 ways** → un-tagged emits under a disabled tool frame escape suppression (trace.cljc:242). *(Mirror `push-to-ring!`'s resolution, guarded by the empty-set short-circuit.)*
- **instrumentation — `first-id` destructures `:event` (the vector, no `:id`) instead of `:dispatched`** → `group-by-event` mis-orders bundles that contain only the dispatched root (projection.cljc:239). *(Destructure `:dispatched`, add to `all`.)*
- **machines — `:always <non-map>` (the keyword-target shorthand `:on`/`:after` accept) is neither normalized nor rejected** → raw `assoc`-on-non-map throw at the first macrostep (transition.cljc:3496). *(Needs a Spec 005 call: normalize the shorthand or reject it at validation.)*
- **frame identity — `canonical` normalizes an instant to a bare string, diverging from `canonical-bytes`** (`t:`/`s:` tags): `encode-map` accepts a heterogeneous instant+string-keyed map that `canonical-map` rejects; falsifies the fn's own docstring (identity.cljc:317). Near-zero practical severity; the obvious fix is platform-sensitive (CLJS `js/Date` has no value equality — the reason for the string) and likely needs a Conventions ruling on the canonical form of an instant.
- **frame — hot-reload reprojection re-resolves explicit-pool frames against the LIVE store** (live_frame.cljc:846); **deferred-flush swallows assembly failures with zero emission and aborts the sweep mid-way** (live_frame.cljc:988). Both dev-hot-reload-only; the first needs generation provenance, the second changes a deliberate swallow.
- **façade — `handler-meta` 1-arity `(contains? arg :frame)` with no `map?` guard** → `(handler-meta :event)` crashes on CLJ / mis-errors on CLJS (core.cljc:1946). Clean fix entangles with the 009 catalogue (the shared assert helper does `(keys arg)`), so deferred for a rare misuse.

**LOW / observational / spec-consistency**

- **`:rf.error/unknown-registry-kind` is emitted (registrar.cljc:536) but absent from the 009 catalogue** — a co-edit-invariant gap; add the row.
- **http — decode-failure DoS-cap discriminator sits at `:reason`, Spec 014 §Keyword-interning cap says `:cause`** — but the impl matches Spec **009**'s catalogue row (`:reason :too-many-keys`) and its own test + privacy layer; **009 and 014 disagree.** A spec-reconciliation call, not an impl bug (transport.cljc:1062).
- machines: `timer-cancel-reasons` omits `:on-restore` (taxonomy drift); singleton reconcile-reset mislabels `:rf.machine/started {:cause :spawned}` (observability only).
- frame — `destroy-frame!` in-flight guard is a non-atomic check-then-act; correct for the documented same-stack re-entrancy, outside re-frame's single-thread drain model for the concurrent case (`swap-vals!` would harden it).
- router-transducer manual-driver tick!/drain! completing-arity asymmetry (non-production scaffold, unstated intent).

**Clean subsystems (no findings):** event pipeline (interceptor/cofx/fx/path), substrate/views/elision, epoch.

## Verification

- CLJS suite green; JVM implementation suite green (both re-run after the fixes, with the new regression tests).
- Rebased onto current `origin/main` (advanced only in `.beads/issues.jsonl` — no code overlap).
