### PR TITLE
docs(template): re-record skill-install trigger + declarative deliverable (rf2-tqrprb)

### DIFF
--- a/tools/template/resources/day8/re_frame2_template/root/README.md
+++ b/tools/template/resources/day8/re_frame2_template/root/README.md
@@ -648,10 +648,13 @@ shape changes mechanically.
 
 re-frame2 ships first-class Claude Code skills (under [`skills/`](https://github.com/day8/re-frame2/tree/main/skills))
 that pair-program against a running app, drive scaffolds, and walk
-the v1→v2 migration. Once those publish to the Claude Code skills
-marketplace this template will install them into your project on
-scaffold; until then, clone the `re-frame2` repo and copy the
-relevant skill directory into your `.claude/skills/`.
+the v1→v2 migration. Once those publish as an installable Claude Code
+plugin, this template will wire them in declaratively (an emitted
+`.claude/settings.json` marketplace + plugin entry, or a `/plugin
+install` one-liner) on scaffold; until then, clone the `re-frame2`
+repo and **symlink** (never copy) the relevant skill directory into
+your `.claude/skills/` — see [`skills/README.md`](https://github.com/day8/re-frame2/blob/main/skills/README.md#installing-link-never-copy)
+for why a copy drifts stale.
 
 ## License
 

--- a/tools/template/spec/003-DepsNew-Rebuild-Plan.md
+++ b/tools/template/spec/003-DepsNew-Rebuild-Plan.md
@@ -516,7 +516,7 @@ The locks below are inherited from the template walkthrough (Mike,
 | SSR opt-in: `:include-ssr?` | Q7 lock; shipped (rf2-675qdb; gate rf2-0m5ea cleared) | `template-fn` branch on `:include-ssr?` — Reagent-only, mutually exclusive with `:include-story?`; emits `core.cljc` + `server.clj` + `ssr_test.clj` |
 | Story opt-in: `:include-story?` | Q3/Q4 era | `template-fn` branch on `:include-story?` |
 | Xray preload (always-on) | Q9 lock | `_shared/shadow-cljs.edn` :preloads |
-| Skill install stub: `install-skills.sh` | Q9 lean A | Deferred — README mention only today (`_shared/README.md` §Future: skill install); placeholder script lands when the Claude Code skill marketplace publishes. |
+| Skill install: declarative plugin wiring | Q9 lean A, re-recorded (rf2-tqrprb, RULED B) | Deferred — README mention only today (`root/README.md:647-654` §Future: skill install); lands when day8 publishes its first marketplace-listed/installable re-frame2 plugin (requires `.claude-plugin/marketplace.json` + a release tag + skills out of pre-alpha). Deliverable is DECLARATIVE plugin wiring — emitted `.claude/settings.json` `extraKnownMarketplaces` + `enabledPlugins`, or a README `/plugin install` one-liner — NOT a copy-in `install-skills.sh` (that shape is now the anti-pattern; see `skills/README.md` link-never-copy doctrine). |
 | Layout: `src/` + `test/` + `dev/scratch.cljs` + `dev/user.clj` | Q8 lock | Unconditional under `_shared/` |
 
 Three flags total (`:include-story?`, `:css`, `:include-ssr?`). Resist


### PR DESCRIPTION
## Summary

Mike-ruled disposition (rf2-tqrprb, Option B) for deferred-decision audit F9. Doc-only, no code changes, no install-skills.sh landed.

The Q9-era stub's trigger ("placeholder script lands when the Claude Code skill marketplace publishes") was too coarse: Anthropic-side plugin marketplaces are GA, but day8 has no `.claude-plugin/marketplace.json`, no release tag, and skills are still pre-alpha — so the trigger as worded would have already looked "fired" when it hasn't.

**Slice 1** — `tools/template/spec/003-DepsNew-Rebuild-Plan.md` §5 row:
- New trigger: fires on day8's first marketplace-listed/installable re-frame2 plugin (requires `.claude-plugin/marketplace.json` + a release tag + skills out of pre-alpha).
- New deliverable shape: DECLARATIVE plugin wiring — emitted `.claude/settings.json` `extraKnownMarketplaces` + `enabledPlugins`, or a README `/plugin install` one-liner — explicitly NOT a copy-in `install-skills.sh` (that shape is now the anti-pattern per `skills/README.md`'s link-never-copy doctrine; a copy-in installer script would reintroduce the exact drift failure mode the repo already paid to eliminate).
- Fixed the stale pointer: the README section lives at `root/README.md:647-654`, not `_shared/README.md`.

**Slice 2** (rider) — reworded the emitted `root/README.md` "Future: skill install" section: kept the future-declarative-wiring promise, but changed the interim advice from "clone and copy the skill directory" to "clone and symlink (never copy)", with a link to `skills/README.md`'s link-never-copy doctrine. The previous copy-in advice directly contradicted that doctrine.

Slice 3 (publish the day8 marketplace) is explicitly out of scope — a future bead per the ruling.

## Quality gates

- `python -m mkdocs build --strict` — clean, exit 0, no WARNING/ERROR lines (spot-checked with `grep -iE "warn|error"` on the full output — no hits).
- `clojure -M:test` in `tools/template/` — 45 tests, 613 assertions, 0 failures, 0 errors. No fixture pins the old README wording (`grep` across `tools/template` for the old phrasing found no other occurrences besides the two edited files).

## Risk

Doc-only change to a deferred/non-normative spec row and a template-emitted README section; no runtime code touched. Low risk.