### PR TITLE
docs(api): rewrite the API reference for readability (density → scannability)

### DIFF
--- a/docs/api/re-frame.adapter.helix.md
+++ b/docs/api/re-frame.adapter.helix.md
@@ -1,6 +1,6 @@
 # re-frame.adapter.helix
 
-`re-frame.adapter.helix` binds re-frame2 to the Helix React substrate. It ships as its own artefact (`day8/re-frame2-helix`); the dependency direction is one-way — the adapter depends on `re-frame.core`, never the reverse — so a Helix app requires this namespace and passes its `adapter` Var into `(rf/init! ...)`. The surface is hooks-first and mirrors the [UIx adapter](re-frame.adapter.uix.md) one-for-one; the two are separate artefacts only because their underlying React-substrate libraries are, not because the re-frame2 contract differs. The substrate-agnostic carry and scoping primitives (`capture-frame`, `with-frame`, `with-new-frame`) live on [`re-frame.core`](re-frame.core.md) — this namespace carries the Helix-shaped hooks, the merged `frame-provider`, the view-wrapping seam, and the adapter spec. For choosing between substrates, see [Use UIx, Helix, or reagent-slim](../core/how-to/use-uix-helix-or-slim.md).
+`re-frame.adapter.helix` binds re-frame2 to the Helix React substrate. It ships as its own artefact (`day8/re-frame2-helix`) and depends on `re-frame.core`, never the reverse. A Helix app requires this namespace and passes its `adapter` Var into `(rf/init! ...)`. This namespace carries the Helix-shaped hooks, the merged `frame-provider`, the view-wrapping seam, and the adapter spec; the substrate-agnostic carry and scoping primitives (`capture-frame`, `with-frame`, `with-new-frame`) live on [`re-frame.core`](re-frame.core.md). The surface mirrors the [UIx adapter](re-frame.adapter.uix.md) one-for-one. For choosing between substrates, see [Use UIx, Helix, or reagent-slim](../core/how-to/use-uix-helix-or-slim.md).
 
 ```clojure
 (:require [re-frame.adapter.helix :as helix-adapter])
@@ -25,7 +25,7 @@
    :flush-render!             …
    :dispose-adapter!          …}
   ```
-- **Description**: The adapter spec passed to `(rf/init! ...)`. Implements the same adapter contract as the Reagent and UIx adapters; `:kind` is `:rf.adapter/helix`.
+- **Description**: The adapter spec passed to `(rf/init! ...)`. Implements the same adapter contract as the Reagent and UIx adapters. `:kind` is `:rf.adapter/helix`.
 
 ## Hooks
 
@@ -37,7 +37,9 @@
   (use-subscribe query-v) → current sub value
   (use-subscribe frame-kw query-v) → current sub value
   ```
-- **Description**: "Subscribe inside a Helix component." The hook-shaped equivalent of `subscribe` for Helix components. Re-renders the calling component when the sub value changes. The 1-arg form resolves the frame through the surrounding scope (dynamic-var, then React context) and raises `:rf.error/no-frame-context` when no frame is in scope; the 2-arg form pins an explicit frame id.
+- **Description**: Hook-shaped equivalent of `subscribe` for Helix components. Returns the current sub value and re-renders the calling component when it changes.
+  - 1-arg form resolves the frame through the surrounding scope (dynamic-var, then React context); raises `:rf.error/no-frame-context` when no frame is in scope.
+  - 2-arg form pins an explicit frame id.
 
 ### `use-resource-lease`
 
@@ -47,7 +49,11 @@
   (use-resource-lease descriptor) → nil
   (use-resource-lease descriptor opts) → nil
   ```
-- **Description**: Takes a resource liveness lease for the calling component's mounted lifetime: on mount dispatches `:rf.resource/ensure` with an app-minted `[:lease …]` owner; on unmount dispatches `:rf.resource/release-owner` for that lease. `descriptor` is the resource-instance identity `{:resource … :scope … :params …}`. `opts` keys: `:cause` (recorded on the ensure; defaults to `[:lease :mount]`) and `:frame` (pin to an explicit frame id, bypassing ambient resolution). Returns nil — the hook manages liveness only; read the data with `use-subscribe` on a `[:rf.resource/*]` query. Without a `:frame` opt the frame resolves through the same chain as `use-subscribe`, raising `:rf.error/no-frame-context` when no frame is in scope. Inert unless the resources artefact (`day8/re-frame2-resources`) is on the classpath to register the resource events.
+- **Description**: Holds a resource liveness lease for the calling component's mounted lifetime. On mount dispatches `:rf.resource/ensure` with an app-minted `[:lease …]` owner; on unmount dispatches `:rf.resource/release-owner` for that lease. Returns nil — manages liveness only; read the data with `use-subscribe` on a `[:rf.resource/*]` query.
+  - `descriptor` — resource-instance identity `{:resource … :scope … :params …}`.
+  - `opts` — `:cause` (recorded on the ensure; defaults to `[:lease :mount]`) and `:frame` (pin to an explicit frame id, bypassing ambient resolution).
+  - Without `:frame`, the frame resolves through the same chain as `use-subscribe`, raising `:rf.error/no-frame-context` when no frame is in scope.
+  - Inert unless the resources artefact (`day8/re-frame2-resources`) is on the classpath to register the resource events.
 - **Example**:
   ```clojure
   (use-resource-lease {:resource :my/feed :scope :rf.scope/global :params {:page 0}})
@@ -60,7 +66,7 @@
   ```clojure
   (use-current-frame) → frame-kw, or :rf.frame/no-provider when no provider is above
   ```
-- **Description**: "What frame am I in?" — the raw React-context read. Returns the surrounding `frame-provider`'s frame keyword, or the no-provider sentinel `:rf.frame/no-provider` when no frame-provider sits above (never a synthesised default). React-context tier only — it does not consult the dynamic-var tier; for the full resolution chain use `(rf/current-frame-id)`.
+- **Description**: Raw React-context read of the surrounding `frame-provider`'s frame keyword. Returns `:rf.frame/no-provider` when no frame-provider sits above (never a synthesised default). Consults the React-context tier only, not the dynamic-var tier; for the full resolution chain use `(rf/current-frame-id)`.
 
 > **NOT USED** — no call sites found in `implementation/`, `examples/`, or `tools/`.
 
@@ -74,7 +80,9 @@
   ($ helix-adapter/frame-provider {:frame :session} child…)                        ;; SCOPE an existing frame
   ($ helix-adapter/frame-provider {:id :session :images [session-image]} child…)   ;; ENSURE create-if-absent / reuse
   ```
-- **Description**: The Helix-shaped merged frame provider, dispatched on the prop map: `{:frame …}` scopes an already-created frame (fails loud if absent — `:rf.error/frame-provider-frame-absent`; a nil `:frame` raises `:rf.error/no-frame-context`, a non-keyword raises `:rf.error/bad-frame-provider-arg`), `{:id …}` ensures a named frame (create-if-absent / reuse-no-reseed, `make-frame` opts, no destroy-on-unmount; a missing / nil / non-keyword `:id` raises `:rf.error/ensure-frame-provider-missing-id`). Children ride the idiomatic `$` trailing-args channel — pass them after the prop map, exactly as for any other Helix component (no `:children` prop-map key).
+- **Description**: The Helix-shaped merged frame provider, dispatched on the prop map. Children ride the `$` trailing-args channel — pass them after the prop map, as for any Helix component (no `:children` prop-map key).
+  - `{:frame …}` scopes an already-created frame; fails loud if absent (`:rf.error/frame-provider-frame-absent`). A nil `:frame` raises `:rf.error/no-frame-context`; a non-keyword raises `:rf.error/bad-frame-provider-arg`.
+  - `{:id …}` ensures a named frame (create-if-absent / reuse-no-reseed, `make-frame` opts, no destroy-on-unmount). A missing / nil / non-keyword `:id` raises `:rf.error/ensure-frame-provider-missing-id`.
 - **Example**:
   ```clojure
   ;; ENSURE shape at the render root: create the frame on first mount, seed it
@@ -127,7 +135,7 @@
   ```clojure
   (set-hiccup-emitter! f)
   ```
-- **Description**: Install a render-tree → HTML fn. Parity with the Reagent and UIx adapters' late-bind seam.
+- **Description**: Installs a render-tree → HTML fn. Parity with the Reagent and UIx adapters' late-bind seam.
 - **Example**:
   ```clojure
   ;; SSR: install a render-tree → HTML emitter (normally wired for you by

--- a/docs/api/re-frame.adapter.reagent.md
+++ b/docs/api/re-frame.adapter.reagent.md
@@ -1,6 +1,10 @@
 # re-frame.adapter.reagent
 
-`re-frame.adapter.reagent` is the seam between re-frame2's substrate-agnostic core and Reagent, the browser-default reactive substrate. Requiring it gives you exactly four things: the `adapter` spec you pass to `(rf/init! ...)` at boot, the `with-resource-lease` mount-lifecycle component, plus two operational helpers — `flush-views!` for tests and `set-hiccup-emitter!` for the SSR render-to-string seam. There is deliberately no per-substrate hook surface here — Reagent's idiom is "views are plain functions returning hiccup", so the substrate-agnostic ergonomic surface (`capture-frame`, `with-frame`, `with-new-frame`, `frame-provider`) and the `reg-view` registry all live in [`re-frame.core`](re-frame.core.md) and compose across every substrate. The dependency direction is one-way: this adapter depends on `re-frame.core`; core never depends on it.
+`re-frame.adapter.reagent` binds re-frame2's substrate-agnostic core to Reagent, the browser-default reactive substrate. Requiring it gives you four things: the `adapter` spec you pass to `(rf/init! …)` at boot, the `with-resource-lease` mount-lifecycle component, and two operational helpers — `flush-views!` (tests) and `set-hiccup-emitter!` (the SSR render-to-string seam).
+
+There is no per-substrate hook surface here. The substrate-agnostic ergonomic surface (`capture-frame`, `with-frame`, `with-new-frame`, `frame-provider`) and the `reg-view` registry live in [`re-frame.core`](re-frame.core.md) and compose across every substrate. The dependency is one-way: this adapter depends on `re-frame.core`; core never depends on it.
+
+It ships in the `day8/re-frame2-reagent` (full) and `day8/reagent-slim` (slim) artefacts — see the variant table under [`adapter`](#adapter). For substrate choice see [Use UIx, Helix, or reagent-slim](../core/how-to/use-uix-helix-or-slim.md).
 
 ```clojure
 (:require [re-frame.adapter.reagent :as reagent-adapter])
@@ -17,7 +21,10 @@
    :render …
    :dispose-adapter! …}
   ```
-- **Description**: The Reagent adapter map — the substrate spec passed to `(rf/init! ...)` to install the browser-default Reagent substrate (stock `reagent.core` / `reagent.dom.client`). There is no default-adapter registry and no keyword form: require the adapter ns and pass its `adapter` Var explicitly at the call site. When this adapter is installed, `current-adapter` (in [`re-frame.core`](re-frame.core.md)) returns `:rf.adapter/reagent`. The Reagent `frame-provider` is the substrate-agnostic provider from [`re-frame.core`](re-frame.core.md), and keeps its children as trailing-positional hiccup (`[rf/frame-provider {:frame …} & children]`) — Reagent's idiomatic shape.
+- **Description**: The Reagent adapter map — the substrate spec passed to `(rf/init! ...)` to install the browser-default Reagent substrate (stock `reagent.core` / `reagent.dom.client`).
+  - No default-adapter registry and no keyword form: require the adapter ns and pass its `adapter` Var explicitly at the call site.
+  - When this adapter is installed, `current-adapter` (in [`re-frame.core`](re-frame.core.md)) returns `:rf.adapter/reagent`.
+  - The Reagent `frame-provider` is the substrate-agnostic provider from [`re-frame.core`](re-frame.core.md); children stay trailing-positional hiccup (`[rf/frame-provider {:frame …} & children]`).
 - **Example**:
   ```clojure
   (:require [re-frame.core :as rf]
@@ -26,14 +33,20 @@
   (rf/init! reagent-adapter/adapter)   ;; install the substrate once, at boot
   ```
 
-Reagent ships in two variants. The full adapter lives here; the slim adapter is a sibling artefact that drops React's server-rendering tax for browser-only bundles. Both publish their adapter at the **same** canonical ns — `re-frame.adapter.reagent` — so the require and `init!` line are identical; what differs is the Maven coordinate you depend on:
+Reagent ships in two variants, full and slim. Both publish their adapter at the same canonical ns — `re-frame.adapter.reagent` — so the require and `init!` line are identical. The variant is selected by the Maven coordinate you depend on, not by the boot line:
 
 | Variant | Maven coordinate | Adapter ns (require) | Includes | Use when |
 |---|---|---|---|---|
 | Full | `day8/re-frame2-reagent` | `re-frame.adapter.reagent` | stock Reagent (`reagent.core`, `reagent.dom.client`, `reagent.dom.server`) | client apps that may also render to a string on the JVM |
-| Slim | `day8/reagent-slim` | `re-frame.adapter.reagent` (renamed from the in-tree `-slim` ns at publication) | the `reagent2` Reagent rewrite; static HTML export via a pure-CLJS `reagent2.dom.server`, no `react-dom/server` | browser-only bundles; ~7–10 KB gzipped smaller (up to ~22–27 KB where Reagent's HTML-export path was in play) |
+| Slim | `day8/reagent-slim` | `re-frame.adapter.reagent` (renamed from the in-tree `-slim` ns at publication) | the `reagent2` rewrite; static HTML export via a pure-CLJS `reagent2.dom.server`, no `react-dom/server` | browser-only bundles; ~7–10 KB gzipped smaller (up to ~22–27 KB where the HTML-export path was in play) |
 
-The two artefacts sit side by side; a build depends on exactly one of them, so the adapter ns is single-source per app and you select slim vs full through your `deps.edn` coordinate, not through the boot line. (In-repo `:git/sha` consumers require `re-frame.adapter.reagent-slim` directly, because the monorepo carries both adapters on one classpath — the publication step renames it to `re-frame.adapter.reagent` before packaging the jar.) The slim variant is bundle-isolated — a dedicated isolation gate verifies that stock Reagent / `react-dom/server` don't leak into builds that select it. The full migration (a four-line swap) is in [Use UIx, Helix, or reagent-slim](../core/how-to/use-uix-helix-or-slim.md).
+A build depends on exactly one variant, so the adapter ns is single-source per app; you select slim vs full through your `deps.edn` coordinate.
+
+In-repo `:git/sha` consumers require `re-frame.adapter.reagent-slim` directly, because the monorepo carries both adapters on one classpath. The publication step renames it to `re-frame.adapter.reagent` before packaging the jar.
+
+The slim variant is bundle-isolated: a dedicated isolation gate verifies that stock Reagent / `react-dom/server` don't leak into builds that select it.
+
+The migration (a four-line swap) is in [Use UIx, Helix, or reagent-slim](../core/how-to/use-uix-helix-or-slim.md).
 
 ## Components
 
@@ -45,7 +58,18 @@ The two artefacts sit side by side; a build depends on exactly one of them, so t
   [with-resource-lease descriptor body-thunk]
   [with-resource-lease descriptor opts body-thunk]
   ```
-- **Description**: Reagent component that holds a resource liveness lease for its mounted lifetime — the Reagent counterpart of the UIx / Helix `use-resource-lease` hook. `descriptor` is the resource-instance identity `{:resource … :scope … :params …}`. `opts` (optional map between the descriptor and the body thunk) takes `:cause` — recorded on the ensure for observability, defaults to `[:lease :mount]` — and `:frame` — pin the lease to an explicit frame id, bypassing ambient resolution. `body-thunk` is a 0-arg fn returning the hiccup rendered while the lease is held. On mount it dispatches `:rf.resource/ensure` with a per-instance `[:lease token]` owner; on unmount it dispatches `:rf.resource/release-owner` for that owner into the same frame. Frame resolution: explicit `:frame` opt → surrounding `frame-provider` context → dynamic frame binding → raises `:rf.error/no-frame-context`. The lease token is minted once per mounted instance, so a hot-reload re-mount settles to exactly one held lease. Under `render-to-string` (SSR) lifecycle methods do not run, so the acquire/release is a no-op.
+- **Description**: Reagent component that holds a resource liveness lease for its mounted lifetime — the Reagent counterpart of the UIx / Helix `use-resource-lease` hook.
+
+  Arguments:
+  - `descriptor` — the resource-instance identity `{:resource … :scope … :params …}`.
+  - `opts` (optional map between the descriptor and the body thunk) — `:cause` recorded on the ensure for observability (defaults to `[:lease :mount]`); `:frame` pins the lease to an explicit frame id, bypassing ambient resolution.
+  - `body-thunk` — a 0-arg fn returning the hiccup rendered while the lease is held.
+
+  Behaviour:
+  - On mount, dispatches `:rf.resource/ensure` with a per-instance `[:lease token]` owner; on unmount, dispatches `:rf.resource/release-owner` for that owner into the same frame.
+  - Frame resolution: explicit `:frame` opt → surrounding `frame-provider` context → dynamic frame binding → raises `:rf.error/no-frame-context`.
+  - The lease token is minted once per mounted instance, so a hot-reload re-mount settles to exactly one held lease.
+  - Under `render-to-string` (SSR) lifecycle methods do not run, so the acquire/release is a no-op.
 - **Example**:
   ```clojure
   [reagent-adapter/with-resource-lease
@@ -69,7 +93,11 @@ The two artefacts sit side by side; a build depends on exactly one of them, so t
   (flush-views!)
   (flush-views! f)
   ```
-- **Description**: Wraps React's `act()` for tests. Flushes pending Reagent renders synchronously: the 0-arity form drains the queued renders and effects; the 1-arity form runs the thunk `f` and then the synchronous render drain inside `act()`. Returns nil. When `act()` is unreachable in the current React build, degrades to the plain synchronous flush — `f` still runs and the render queue still drains, without the `act()` wrapper. Surfaced identically across all substrates (same name, same adapter-ns location, same nil-return), so a test suite ports across substrates touching only the `init!` Var.
+- **Description**: Wraps React's `act()` for tests; flushes pending Reagent renders synchronously. Returns nil.
+  - 0-arity: drains the queued renders and effects.
+  - 1-arity: runs the thunk `f`, then the synchronous render drain, inside `act()`.
+  - When `act()` is unreachable in the current React build, degrades to the plain synchronous flush — `f` still runs and the render queue still drains, without the `act()` wrapper.
+  - Surfaced identically across all substrates: same name, same adapter-ns location, same nil-return.
 - **Example**:
   ```clojure
   ;; Test-only: flush pending renders synchronously, returns nil.
@@ -86,7 +114,10 @@ The two artefacts sit side by side; a build depends on exactly one of them, so t
   ```clojure
   (set-hiccup-emitter! f)
   ```
-- **Description**: Install a render-tree → HTML fn — the hiccup → HTML emitter used by render-to-string. Last call wins; pass `nil` to reset. You normally don't call this directly: requiring [`re-frame.ssr`](re-frame.ssr.md) resolves the late-bind hook and wires the emitter for you. It is the Reagent-side late-bind seam for SSR, matching the parallel seam on the UIx and Helix adapters.
+- **Description**: Install a render-tree → HTML fn — the hiccup → HTML emitter used by render-to-string.
+  - Last call wins; pass `nil` to reset.
+  - Normally you don't call this directly: requiring [`re-frame.ssr`](re-frame.ssr.md) resolves the late-bind hook and wires the emitter for you.
+  - It is the Reagent-side late-bind seam for SSR, matching the parallel seam on the UIx and Helix adapters.
 - **Example**:
   ```clojure
   ;; SSR: install a render-tree → HTML emitter (normally wired for you by

--- a/docs/api/re-frame.adapter.uix.md
+++ b/docs/api/re-frame.adapter.uix.md
@@ -1,12 +1,14 @@
 # re-frame.adapter.uix
 
-The UIx adapter is the seam between re-frame2's substrate-agnostic core and UIx, a hooks-first React substrate. It ships in its own artefact (`day8/re-frame2-uix`) and exposes a small surface that matches the React/hooks idiom: `use-subscribe` and `use-resource-lease` hooks, a `frame-provider` component, the `adapter` spec map you pass to `init!`, and a few adapter-side seams for tests, SSR, and code-gen. The dependency direction is one-way — the adapter depends on `re-frame.core`, never the reverse — which is why these surfaces live in `re-frame.adapter.uix` rather than being re-exported from core: an app requires the adapter it wants and passes its `adapter` Var into `(rf/init! …)`. There is no auto-injection — UIx components call `use-subscribe` and `(rf/capture-frame)` directly.
+The UIx adapter connects re-frame2's substrate-agnostic core to UIx, a hooks-first React substrate. It exposes hooks (`use-subscribe`, `use-resource-lease`, `use-current-frame`), the `frame-provider` component, the `adapter` spec map you pass to `init!`, and adapter seams for tests, SSR, and code-gen.
+
+Ships in the `day8/re-frame2-uix` artefact. The dependency direction is one-way: the adapter depends on `re-frame.core`, never the reverse. There is no auto-injection — UIx components call `use-subscribe` and `(rf/capture-frame)` directly.
 
 ```clojure
 (:require [re-frame.adapter.uix :as uix-adapter])
 ```
 
-UIx users register their views by Var (the React-component idiom) or with `rf/reg-view*` if they want registry-keyed view addressing — `reg-view` (the Reagent macro) does **not** cover UIx. A minimal app wires the adapter into `init!` and reads subscriptions through the hook:
+Register views by Var (the React-component idiom) or with `rf/reg-view*` for registry-keyed view addressing. `reg-view` (the Reagent macro) does not cover UIx. A minimal app wires the adapter into `init!` and reads subscriptions through the hook:
 
 ```clojure
 (:require [re-frame.core :as rf]
@@ -21,6 +23,8 @@ UIx users register their views by Var (the React-component idiom) or with `rf/re
        ($ :td (:name item))
        ($ :td count))))
 ```
+
+For narrative coverage and the substrate decision set, see [Use UIx, Helix, or reagent-slim](../core/how-to/use-uix-helix-or-slim.md).
 
 ## Adapter spec
 
@@ -41,7 +45,7 @@ UIx users register their views by Var (the React-component idiom) or with `rf/re
    :flush-render!             …
    :dispose-adapter!          …}
   ```
-- **Description**: The adapter spec passed to `(rf/init! ...)`. Implements the same substrate adapter contract as the Reagent and Helix adapters; `:kind` is `:rf.adapter/uix`.
+- **Description**: The adapter spec passed to `(rf/init! ...)`. Implements the same substrate adapter contract as the Reagent and Helix adapters. `:kind` is `:rf.adapter/uix`.
 - **Example**:
   ```clojure
   (rf/init! uix-adapter/adapter)
@@ -57,7 +61,12 @@ UIx users register their views by Var (the React-component idiom) or with `rf/re
   (use-subscribe query-v) → current sub value
   (use-subscribe frame-kw query-v) → current sub value
   ```
-- **Description**: "Subscribe inside a UIx component." The hook-shaped equivalent of `subscribe` for UIx components. Returns the current sub value; re-renders the calling component when the value changes. The 1-arg form resolves the frame through the standard chain — `with-frame` dynamic scope first, then the surrounding `frame-provider` — and raises `:rf.error/no-frame-context` when neither is in scope (no `:rf/default` floor). The 2-arg form pins to an explicit frame-id, bypassing the chain.
+- **Description**: Subscribe inside a UIx component; the hook-shaped equivalent of `subscribe`.
+
+  Returns the current sub value and re-renders the calling component when the value changes.
+
+  - 1-arg form resolves the frame through the standard chain — `with-frame` dynamic scope first, then the surrounding `frame-provider`. Raises `:rf.error/no-frame-context` when neither is in scope (there is no `:rf/default` floor).
+  - 2-arg form pins to an explicit frame-id, bypassing the chain.
 - **Example**:
   ```clojure
   (defui cart-total []
@@ -73,7 +82,15 @@ UIx users register their views by Var (the React-component idiom) or with `rf/re
   (use-resource-lease descriptor) → nil
   (use-resource-lease descriptor opts) → nil
   ```
-- **Description**: Takes a resource liveness lease for the calling component's mounted lifetime: on mount dispatches `:rf.resource/ensure` with an app-minted `[:lease …]` owner; on unmount dispatches `:rf.resource/release-owner` for that same lease. Returns nil — a lifecycle hook, not a read; pair with `use-subscribe` on a `[:rf.resource/*]` query to read the data. `descriptor` is the resource-instance identity `{:resource … :scope … :params …}`. `opts` keys: `:cause` (recorded on the ensure; defaults to `[:lease :mount]`) and `:frame` (pin to an explicit frame-id). Without `:frame`, frame resolution mirrors `use-subscribe`, raising `:rf.error/no-frame-context` when no frame is in scope. Changing the resolved frame, descriptor, or cause releases the old lease and takes a fresh one; the events are inert when the resources artefact is not loaded.
+- **Description**: Holds a resource liveness lease for the calling component's mounted lifetime. On mount, dispatches `:rf.resource/ensure` with an app-minted `[:lease …]` owner; on unmount, dispatches `:rf.resource/release-owner` for that same lease.
+
+  Returns nil — a lifecycle hook, not a read. Pair it with `use-subscribe` on a `[:rf.resource/*]` query to read the data.
+
+  - `descriptor` — the resource-instance identity `{:resource … :scope … :params …}`.
+  - `opts` keys: `:cause` (recorded on the ensure; defaults to `[:lease :mount]`) and `:frame` (pin to an explicit frame-id).
+  - Without `:frame`, frame resolution mirrors `use-subscribe`, raising `:rf.error/no-frame-context` when no frame is in scope.
+  - Changing the resolved frame, descriptor, or cause releases the old lease and takes a fresh one.
+  - The events are inert when the resources artefact is not loaded.
 - **Example**:
   ```clojure
   ;; Hold a liveness lease on a polled resource while the widget is mounted.
@@ -89,7 +106,9 @@ UIx users register their views by Var (the React-component idiom) or with `rf/re
   ```clojure
   (use-current-frame) → frame-kw, or :rf.frame/no-provider
   ```
-- **Description**: "What frame am I in?" — for components that need to thread the frame through hand-written child callbacks. React-context tier only: returns the surrounding `frame-provider`'s frame keyword, or the no-provider sentinel `:rf.frame/no-provider` when no provider sits above — never nil, never a synthesised default. Does not consult the `with-frame` dynamic var; for the full resolution chain use `rf/current-frame-id`.
+- **Description**: Returns the frame keyword of the surrounding `frame-provider`, for components that thread the frame through hand-written child callbacks.
+
+  React-context tier only. Returns the no-provider sentinel `:rf.frame/no-provider` when no provider sits above — never nil, never a synthesised default. Does not consult the `with-frame` dynamic var; for the full resolution chain use `rf/current-frame-id`.
 
 > **NOT USED** — no call sites found in `implementation/`, `examples/`, or `tools/`.
 
@@ -103,7 +122,16 @@ UIx users register their views by Var (the React-component idiom) or with `rf/re
   ($ uix-adapter/frame-provider {:frame :session} child…)                        ;; SCOPE an existing frame
   ($ uix-adapter/frame-provider {:id :session :images [session-image]} child…)   ;; ENSURE create-if-absent / reuse
   ```
-- **Description**: The UIx-shaped merged frame provider, dispatched on the prop map: `{:frame …}` scopes an already-created frame — raises `:rf.error/frame-provider-frame-absent` when the frame does not exist, `:rf.error/no-frame-context` on a nil `:frame`, and `:rf.error/bad-frame-provider-arg` on a non-keyword `:frame`; `{:id …}` ensures a named frame (create-if-absent / reuse-no-reseed, `make-frame` opts incl. `:images` / `:initial-events`, no destroy-on-unmount) — `:id` must be a keyword, and a missing / nil / non-keyword `:id` raises `:rf.error/ensure-frame-provider-missing-id`. Re-mounting the ENSURE shape under the same `:id` neither destroys durable state nor re-runs `:initial-events`. Children ride the idiomatic `$` trailing-args channel — pass them after the prop map, exactly as for any other UIx component (no `:children` prop-map key).
+- **Description**: The UIx-shaped merged frame provider, dispatched on the prop map.
+
+  `{:frame …}` — SCOPE an already-created frame. Raises:
+  - `:rf.error/frame-provider-frame-absent` when the frame does not exist
+  - `:rf.error/no-frame-context` on a nil `:frame`
+  - `:rf.error/bad-frame-provider-arg` on a non-keyword `:frame`
+
+  `{:id …}` — ENSURE a named frame (create-if-absent / reuse-no-reseed, `make-frame` opts incl. `:images` / `:initial-events`, no destroy-on-unmount). `:id` must be a keyword; a missing / nil / non-keyword `:id` raises `:rf.error/ensure-frame-provider-missing-id`. Re-mounting the ENSURE shape under the same `:id` neither destroys durable state nor re-runs `:initial-events`.
+
+  Children ride the idiomatic `$` trailing-args channel — pass them after the prop map, as for any other UIx component (no `:children` prop-map key).
 - **Example**:
   ```clojure
   ;; ENSURE shape at the render root: create the frame on first mount, seed it
@@ -165,8 +193,8 @@ UIx users register their views by Var (the React-component idiom) or with `rf/re
 
 ## Notes
 
-- **Shared React Context.** The `frame-provider` in all three adapters (Reagent, UIx, Helix) consumes the **same** `createContext` object, factored into `re-frame.adapter.context` (a CLJS-only file in core). There is exactly one Context, not three, so a mixed-substrate app composes — a UIx `frame-provider` can wrap a Reagent or Helix subtree, and a UIx subtree can be wrapped by a provider from either of the other substrates.
-- **DOM source-coord annotations.** Adapters inject `data-rf2-source-coord` on every registered view's root element, and `wrap-view` is the explicit seam for that injection. The attribute is gated on debug builds and elided from production `:advanced` builds via dead-code elimination, so it costs no shipped bytes; it powers click-to-source in Xray and re-frame2-pair. Full contract in the [Observability concept guide](../core/concepts/observability.md).
+- **Shared React Context.** The `frame-provider` in all three adapters (Reagent, UIx, Helix) consumes the same `createContext` object, factored into `re-frame.adapter.context` (a CLJS-only file in core). There is exactly one Context, not three, so a mixed-substrate app composes — a UIx `frame-provider` can wrap a Reagent or Helix subtree, and vice versa.
+- **DOM source-coord annotations.** Adapters inject `data-rf2-source-coord` on every registered view's root element; `wrap-view` is the explicit seam for that injection. The attribute is gated on debug builds and elided from production `:advanced` builds via dead-code elimination, so it costs no shipped bytes; it powers click-to-source in Xray and re-frame2-pair. Full contract in the [Observability concept guide](../core/concepts/observability.md).
 
 ## See also
 

--- a/docs/api/re-frame.core.md
+++ b/docs/api/re-frame.core.md
@@ -1,16 +1,18 @@
 # re-frame.core
 
-`re-frame.core` is the single namespace every re-frame2 app requires. It is the facade: the registration verbs (`reg-event`, `reg-sub`, `reg-fx`, `reg-cofx`), the two pipeline verbs (`dispatch`, `subscribe`), the view surface (`reg-view`, `frame-provider`, `capture-frame`), the effect/interceptor surface, the frame primitive, the boot/configure lane, the instrumentation and registrar-query reads, and single-import re-exports of every optional feature's registration macro. Genuine-core surfaces are documented in full below; feature surfaces (machines, routing, flows, schemas, SSR, HTTP, resources) are re-exported here for ergonomics and carry their deep contract in their own namespace doc — those entries are brief, with a pointer.
+`re-frame.core` is the single namespace every re-frame2 app requires — the facade. It re-exports the registration verbs, the pipeline verbs, the view surface, the effect/interceptor surface, the frame primitive, the boot/configure lane, the instrumentation and registrar-query reads, and every optional feature's registration macro.
 
 ```clojure
 (:require [re-frame.core :as rf])
 ```
 
+Core surfaces are documented in full below. Feature surfaces (machines, routing, flows, schemas, SSR, HTTP, resources) are re-exported here for single-import ergonomics; each has a brief entry with a pointer to its own namespace doc, which carries the deep contract. For the mental model, see the [Subscriptions](../core/concepts/subscriptions.md), [Frames](../core/concepts/frames.md), and [Effects](../core/concepts/effects.md) concept guides.
+
 ## Registration
 
-This is the surface every re-frame2 app touches. Every entry registers a named handler into the frame's registrar.
+Every entry here registers a named handler into the frame's registrar.
 
-**Return value.** Every `reg-*` returns its **primary id** — the keyword (or path, for `reg-app-schema`) you registered with — so you can thread the id through your code without retyping it.
+**Return value.** Every `reg-*` returns its primary id — the keyword (or path, for `reg-app-schema`) you registered with.
 
 ### `reg-event`
 
@@ -19,15 +21,15 @@ This is the surface every re-frame2 app touches. Every entry registers a named h
   ```clojure
   (reg-event id ?metadata handler)
   ```
-- **Description**: The **one** public event-registration form. The handler is two-arg `(fn [coeffects event-vec] effect-map)`: a coeffects map in, a **closed** effects map `{:db ... :fx [...]}` out (or `nil` for a no-op). The db write is an explicit `:db` effect — there is **no** db-only return shape. Use it for both the 80% of handlers that just update state and the richer handlers that dispatch follow-ups, fire HTTP, navigate, or read coeffects.
-- **Metadata-map — the extended form**: the optional middle slot is a metadata-map carrying reflection keys (`:doc`, `:schema`, `:tags`, …) **and** a reserved `:interceptors` vector — one superset shape for everything a registration declares:
+- **Description**: The one public event-registration form. The handler is `(fn [coeffects event-vec] effect-map)` — a coeffects map in, a **closed** effects map `{:db ... :fx [...]}` out (or `nil` for a no-op). The db write is an explicit `:db` effect; there is no db-only return shape.
+- **Metadata map (extended form)**: the optional middle slot carries reflection keys (`:doc`, `:schema`, `:tags`, …) and a reserved `:interceptors` vector:
   ```clojure
   (rf/reg-event :cart/add
     {:doc "Add an item." :interceptors [undoable]}
     (fn [{:keys [db]} [_ item]] {:db (update db :items conj item)}))
   ```
-  > **Migration note.** The historical bare/positional interceptor vector middle slot — `(reg-event :id [undoable] handler)` — has been removed. Put event interceptor chains in the metadata map: `(reg-event :id {:interceptors [undoable]} handler)`.
-- **Full interceptor-context work**: there is no separate registrar for raw-context handlers. When you need to read or rewrite the interceptor context itself, register a named interceptor with `(rf/reg-interceptor :my/audit {:before ... :after ...})` and reference it **by id** from the `:interceptors` vector above (`{:interceptors [:my/audit]}`). The `:before` / `:after` fns receive and return the context map directly. (`->interceptor` is the framework-internal lowering constructor, not the application-authoring form.)
+  > **Migration note.** The bare positional interceptor middle slot — `(reg-event :id [undoable] handler)` — has been removed. Put interceptor chains in the metadata map: `(reg-event :id {:interceptors [undoable]} handler)`.
+- **Raw-context handlers**: there is no separate registrar for them. To read or rewrite the interceptor context, register a named interceptor with `(rf/reg-interceptor :my/audit {:before ... :after ...})` and reference it by id from the `:interceptors` vector (`{:interceptors [:my/audit]}`). Its `:before` / `:after` fns receive and return the context map directly. (`->interceptor` is the framework-internal lowering constructor, not the authoring form.)
 - **Example** — a pure state update and an effectful handler:
   ```clojure
   ;; State-only: the db write is an explicit :db effect.
@@ -50,7 +52,11 @@ This is the surface every re-frame2 app touches. Every entry registers a named h
   ```clojure
   (reg-sub id ?metadata input-fn? computation-fn)
   ```
-- **Description**: "Computed view over `app-db` and other subs." `reg-sub` supports **three input-production modes** — every subscription has an *input query-vector producer*: a layer-1 app-db reader has no producer, `:<-` is the literal producer, and a parametric `input-fn` is the query-parametric producer. The optional first fn is a v2 **`input-fn`** — a *pure* function from the outer `query-v` to a **vector of query vectors**; it is **not** a v1 reaction-returning signal fn (it must not call `subscribe`, deref `app-db`, dispatch, or perform IO, and it must not return live reactions). The runtime resolves each returned query vector in the *same frame* as the outer subscription. This is the only sub-registration form in v2 — `reg-sub-raw` is gone (see the [migration reference](../../migration/from-re-frame-v1/README.md) for the replacement guidance). The full input grammar, the three input-production modes, and the error ids live in the [Subscriptions concept guide](../core/concepts/subscriptions.md).
+- **Description**: A computed view over `app-db` and other subs. Three input-production modes (see table): a layer-1 `app-db` reader has no input producer, `:<-` is a literal producer, and a parametric `input-fn` computes inputs from the outer `query-v`.
+
+  The optional first fn is the v2 **`input-fn`** — a *pure* function from the outer `query-v` to a **vector of query vectors**. It must not call `subscribe`, deref `app-db`, dispatch, or perform IO, and must not return live reactions (it is not a v1 reaction-returning signal fn). The runtime resolves each returned query vector in the *same frame* as the outer subscription.
+
+  This is the only sub-registration form in v2; `reg-sub-raw` is gone (see the [migration reference](../../migration/from-re-frame-v1/README.md)). Full input grammar and error ids: [Subscriptions concept guide](../core/concepts/subscriptions.md).
 
 | Mode | Form | Where the inputs come from |
 |---|---|---|
@@ -89,7 +95,10 @@ This is the surface every re-frame2 app touches. Every entry registers a named h
   ```clojure
   (reg-fx id ?metadata handler)
   ```
-- **Description**: "Define a named side effect." The handler is **binary**, context-first: `(fn [ctx args] ...)` — changed from v1's unary shape. `ctx` is a small map carrying `:frame` (the active frame id), `:event` (the originating event vector), and `:envelope` (the parent dispatch envelope); `args` is the value the event handler placed beside the fx-id in its `:fx` vector. `reg-fx` also accepts a `:platforms` metadata key (a set of `:server` / `:client`) that gates fx execution by active platform — see [re-frame.ssr.md](re-frame.ssr.md).
+- **Description**: Define a named side effect. The handler is **binary**, context-first: `(fn [ctx args] ...)` (changed from v1's unary shape).
+  - `ctx` is a small map carrying `:frame` (the active frame id), `:event` (the originating event vector), and `:envelope` (the parent dispatch envelope).
+  - `args` is the value the event handler placed beside the fx-id in its `:fx` vector.
+  - Accepts a `:platforms` metadata key (a set of `:server` / `:client`) that gates fx execution by active platform — see [re-frame.ssr.md](re-frame.ssr.md).
 - **Example**:
   ```clojure
   (rf/reg-fx :app/scroll-to-top
@@ -103,7 +112,11 @@ This is the surface every re-frame2 app touches. Every entry registers a named h
   ```clojure
   (reg-cofx id ?metadata supplier)
   ```
-- **Description**: "Register a named supplier for a world fact a handler can ask for." The supplier is a plain **value-returning** function — `(fn [] value)`, or `(fn [arg] value)` for ids parameterised at the call site — *not* a context-mutating fn. The runtime calls it and puts the result into the coeffects map under the cofx's id. A handler opts in with `:rf.cofx/requires` registration metadata; v2 has **no `inject-cofx` interceptor**. The middle slot carries the fact's grade: `{:recordable? true}` for a replayable fact, `{:recordable? true :provided? true}` for a recordable fact stamped by an owner boundary (no generator), a bare registration for an ambient (unrecorded) read. Reading a sub from a handler is done the same way — wrap `subscribe-once` in a cofx and declare it. Full model: [Effects](../core/concepts/effects.md), [Coeffects](../core/concepts/coeffects.md).
+- **Description**: Register a named supplier for a world fact a handler can ask for. The supplier is a plain **value-returning** function — `(fn [] value)`, or `(fn [arg] value)` for ids parameterised at the call site — not a context-mutating fn. The runtime calls it and puts the result into the coeffects map under the cofx's id.
+  - A handler opts in with `:rf.cofx/requires` registration metadata. v2 has no `inject-cofx` interceptor.
+  - The middle slot carries the fact's grade: `{:recordable? true}` for a replayable fact; `{:recordable? true :provided? true}` for a recordable fact stamped by an owner boundary (no generator); a bare registration for an ambient (unrecorded) read.
+  - Reading a sub from a handler is done the same way — wrap `subscribe-once` in a cofx and declare it.
+  - Full model: [Effects](../core/concepts/effects.md), [Coeffects](../core/concepts/coeffects.md).
 - **Example**:
   ```clojure
   ;; A value-returning supplier — quarantines an impure read behind a named id.
@@ -126,7 +139,10 @@ This is the surface every re-frame2 app touches. Every entry registers a named h
   ```clojure
   (reg-frame id metadata)
   ```
-- **Description**: Atomic create-and-register. A frame is the scoping unit — one `app-db`, one event queue, one pipeline — and `reg-frame` mints it with metadata you can later read via `frame-meta`. The frame owns the `:observability` sink policy. Durable `app-db` data classification is **not** a frame annotation: a `reg-frame` config carrying `:sensitive` / `:large` **fails loud at registration**. Classify durable `app-db` paths by returning the four commit-plane classification effects (`:sensitive` / `:large` / `:clear-sensitive` / `:clear-large`) from a `reg-event` alongside `:db`, wired to run at frame creation via `:initial-events`. See [re-frame.http.md](re-frame.http.md), [re-frame.schemas.md](re-frame.schemas.md) and [Keep secrets out of traces](../core/how-to/keep-secrets-out-of-traces.md).
+- **Description**: Atomic create-and-register. A frame is the scoping unit — one `app-db`, one event queue, one pipeline — minted with metadata you later read via `frame-meta`. The frame owns the `:observability` sink policy.
+  - Durable `app-db` data classification is **not** a frame annotation: a `reg-frame` config carrying `:sensitive` / `:large` **fails loud** at registration.
+  - Classify durable `app-db` paths by returning the four commit-plane classification effects (`:sensitive` / `:large` / `:clear-sensitive` / `:clear-large`) from a `reg-event` alongside `:db`, wired to run at frame creation via `:initial-events`.
+  - See [re-frame.http.md](re-frame.http.md), [re-frame.schemas.md](re-frame.schemas.md), and [Keep secrets out of traces](../core/how-to/keep-secrets-out-of-traces.md).
 - **Example**:
   ```clojure
   ;; User-defined fxs sit under a user-feature prefix per Conventions — never
@@ -148,7 +164,7 @@ This is the surface every re-frame2 app touches. Every entry registers a named h
 
 ### Clearing registrations
 
-Each `clear-*` removes an entry from the registrar; the no-arg form clears the whole kind. Use clearing in tests (the `with-fresh-registrar` fixture relies on these), in REPL workflows, and during teardown.
+Each `clear-*` removes an entry from the registrar; the no-arg form clears the whole kind. Used in tests (the `with-fresh-registrar` fixture relies on these), REPL workflows, and teardown.
 
 ### `clear-event`
 
@@ -158,7 +174,7 @@ Each `clear-*` removes an entry from the registrar; the no-arg form clears the w
   (clear-event)
   (clear-event id)
   ```
-- **Description**: "Forget this event-handler." No-arg clears the whole `:event` registry.
+- **Description**: Forget one event-handler. No-arg clears the whole `:event` registry.
 - **Example**:
   ```clojure
   (rf/clear-event :counter/inc)   ;; forget one handler
@@ -173,7 +189,7 @@ Each `clear-*` removes an entry from the registrar; the no-arg form clears the w
   (clear-sub)
   (clear-sub id)
   ```
-- **Description**: "Forget this sub." Note: this is the registrar-side clear (the inverse of `reg-sub`). The runtime cache decrement is `unsubscribe`.
+- **Description**: Forget one sub. This is the registrar-side clear (the inverse of `reg-sub`); the runtime cache decrement is `unsubscribe`.
 - **Example**:
   ```clojure
   (rf/clear-sub :counter/value)   ;; forget one sub registration
@@ -188,7 +204,7 @@ Each `clear-*` removes an entry from the registrar; the no-arg form clears the w
   (clear-fx)
   (clear-fx id)
   ```
-- **Description**: "Forget this fx."
+- **Description**: Forget one fx. No-arg clears the whole `:fx` registry.
 - **Example**:
   ```clojure
   (rf/clear-fx :app/scroll-to-top)   ;; forget one fx
@@ -197,11 +213,11 @@ Each `clear-*` removes an entry from the registrar; the no-arg form clears the w
 
 ## Dispatch and subscribe
 
-These are the two verbs that drive the pipeline. `dispatch` says "an event happened, run it through the pipeline"; `subscribe` says "give me a reactive handle on this query's value."
+These are the two verbs that drive the pipeline.
 
 `dispatch` and `dispatch-sync` come in macro + fn pairs. The **macro** form (`dispatch`, `dispatch-sync`, `subscribe`) captures the call-site source coords so tools like Xray can navigate from a trace event back to the originating expression. The **`*` fn** form (`dispatch*`, `dispatch-sync*`) skips the stamping — needed when you compose dispatch through a higher-order function (`(map dispatch* events)`) where a macro can't sit. Both route through the same dispatcher; only the trace stamping differs.
 
-**The `opts` map.** `dispatch` and `subscribe` accept a uniform opts map: `:frame`, `:fx-overrides`, `:interceptor-overrides`, `:trace-id`, `:source`. The most common pattern is `(rf/dispatch [::save x] {:frame :todo})` to target a non-default frame; the frame **id** is the public routing address.
+**The `opts` map.** `dispatch` and `subscribe` accept a uniform opts map: `:frame`, `:fx-overrides`, `:interceptor-overrides`, `:trace-id`, `:source`. Target a non-default frame via `(rf/dispatch [::save x] {:frame :todo})`; the frame **id** is the public routing address.
 
 ### `dispatch`
 
@@ -211,7 +227,7 @@ These are the two verbs that drive the pipeline. `dispatch` says "an event happe
   (dispatch event)
   (dispatch event opts)
   ```
-- **Description**: Async dispatch — drops the event onto the frame's queue, returns immediately. The default; use it for everything that isn't a synchronous test setup.
+- **Description**: Async dispatch — drops the event onto the frame's queue and returns immediately. The default.
 - **Example**:
   ```clojure
   [:button {:on-click #(rf/dispatch [:counter/inc])} "+"]
@@ -226,7 +242,7 @@ These are the two verbs that drive the pipeline. `dispatch` says "an event happe
   (dispatch* event opts)
   (dispatch* frame event)
   ```
-- **Description**: Fn variant of `dispatch`. Compose through `map` / `comp` / `partial`; skips call-site stamping. The 2-arity is shape-discriminated on the first arg: an event vector selects the event-first form; a frame target (a frame-id keyword or a live frame value — never a vector) selects the frame-first form, lowered to `{:frame frame}`. Returns `nil`.
+- **Description**: Fn variant of `dispatch`; skips call-site stamping, so it composes through `map` / `comp` / `partial`. The 2-arity is shape-discriminated on the first arg: an event vector selects the event-first form; a frame target (a frame-id keyword or a live frame value — never a vector) selects the frame-first form, lowered to `{:frame frame}`. Returns `nil`.
 - **Example**:
   ```clojure
   ;; A plain fn value — pass it through a HoF where the dispatch macro can't sit.
@@ -241,7 +257,7 @@ These are the two verbs that drive the pipeline. `dispatch` says "an event happe
   (dispatch-sync event)
   (dispatch-sync event opts)
   ```
-- **Description**: Synchronous dispatch — drains to completion before returning. Tests, REPL workflows, and one-shot app-boot events live here. Never call from inside a running event handler — that raises `:rf.error/dispatch-sync-in-handler`.
+- **Description**: Synchronous dispatch — drains to completion before returning. For tests, REPL workflows, and one-shot app-boot events. Never call from inside a running event handler — that raises `:rf.error/dispatch-sync-in-handler`.
 - **Example**:
   ```clojure
   (rf/dispatch-sync [:counter/initialise])   ;; one-shot app-boot event
@@ -272,7 +288,9 @@ These are the two verbs that drive the pipeline. `dispatch` says "an event happe
   (subscribe query-v)
   (subscribe query-v opts)
   ```
-- **Description**: The reactive handle. Returns a reaction whose value is the registered sub's current output; recomputes when upstreams change. Use inside views, inside other subs, and (carefully) inside event handlers via the cofx wrapper. Target a non-ambient frame via the `{:frame …}` opt — `(rf/subscribe [:counter/value] {:frame :other})`; the frame **id** is the public routing address. The frame-first `(subscribe frame-id query-v)` arity and the `subscribe*` fn form are **internal**, not app-facing.
+- **Description**: The reactive handle. Returns a reaction whose value is the registered sub's current output; recomputes when upstreams change. Valid inside views, inside other subs, and (via the cofx wrapper) inside event handlers.
+  - Target a non-ambient frame via the `{:frame …}` opt — `(rf/subscribe [:counter/value] {:frame :other})`; the frame **id** is the public routing address.
+  - The frame-first `(subscribe frame-id query-v)` arity and the `subscribe*` fn form are internal, not app-facing.
 - **Example**:
   ```clojure
   [:span @(rf/subscribe [:counter/value])]
@@ -296,7 +314,7 @@ These are the two verbs that drive the pipeline. `dispatch` says "an event happe
   (subscribe-once query-v) → value
   (subscribe-once query-v opts) → value
   ```
-- **Description**: One-shot read: subscribe, deref, immediately unsubscribe. Use in handler bodies, machine actions, REPL — anywhere you want the *current* value without the reactive plumbing. Not for views. Target a non-ambient frame via the `{:frame …}` opts form `(subscribe-once query-v {:frame f})`, mirroring `subscribe` — the same call shape carries over.
+- **Description**: One-shot read: subscribe, deref, immediately unsubscribe. Returns the *current* value with no reactive handle retained. For handler bodies, machine actions, and the REPL — not views. Target a non-ambient frame via `(subscribe-once query-v {:frame f})`, mirroring `subscribe`.
 - **Example**:
   ```clojure
   ;; One-shot read of the current value — no reactive handle retained.
@@ -312,7 +330,7 @@ These are the two verbs that drive the pipeline. `dispatch` says "an event happe
   (unsubscribe query-v) → nil
   (unsubscribe frame-id query-v) → nil
   ```
-- **Description**: Decrement the cache ref-count for a query. When the count hits zero, the entry is disposed **synchronously** — see [Subscriptions](../core/concepts/subscriptions.md). Most callers don't reach for this directly — Reagent / UIx / Helix adapters wire it on unmount. Target a non-ambient frame with the frame-first `(unsubscribe frame-id query-v)` form — unlike `subscribe` / `subscribe-once`, `unsubscribe` has no `{:frame …}` opts form (it's pure teardown, never a hot in-view call).
+- **Description**: Decrement the cache ref-count for a query. When the count hits zero, the entry is disposed **synchronously** — see [Subscriptions](../core/concepts/subscriptions.md). The Reagent / UIx / Helix adapters wire it on unmount; most callers never reach for it directly. Target a non-ambient frame with the frame-first `(unsubscribe frame-id query-v)` form — unlike `subscribe` / `subscribe-once`, `unsubscribe` has no `{:frame …}` opts form (it is pure teardown, never a hot in-view call).
 - **Example**:
   ```clojure
   ;; Manual ref-count pairing (tests / REPL) — balances an explicit subscribe.
@@ -329,7 +347,7 @@ These are the two verbs that drive the pipeline. `dispatch` says "an event happe
   (clear-sub-cache!)
   (clear-sub-cache! frame-id)
   ```
-- **Description**: Dispose every cached entry in a frame's runtime sub-cache and clear the cache; disposal is synchronous and unconditional. The no-arg form targets the **ambient** frame (under no established scope it raises `:rf.error/no-frame-context`); the one-arg form names the frame. Tests; rarely needed in app code.
+- **Description**: Dispose every cached entry in a frame's runtime sub-cache and clear the cache; disposal is synchronous and unconditional. The no-arg form targets the **ambient** frame (raising `:rf.error/no-frame-context` under no established scope); the one-arg form names the frame. Tests; rarely needed in app code.
 - **Example**:
   ```clojure
   (rf/clear-sub-cache! :app/main)   ;; evict one frame's cached subs
@@ -343,7 +361,9 @@ These are the two verbs that drive the pipeline. `dispatch` says "an event happe
   ```clojure
   (compute-sub query-v db) → value
   ```
-- **Description**: The test-friendly companion to `subscribe`. Runs the sub graph against a **value** of `app-db` — no cache, no reactivity, no frame — and returns the value. Query-vector first, db second. `db` may be a bare app-db map or a full frame-state value (`{:rf.db/app … :rf.db/runtime …}`) when the graph mixes app-db and runtime-db subs. JVM-runnable; the cache-bypassing pure sub evaluator that unit tests reach for to assert a sub's output without standing up a live frame.
+- **Description**: The test-friendly companion to `subscribe`. Runs the sub graph against a **value** of `app-db` — no cache, no reactivity, no frame — and returns the value. Query-vector first, db second.
+  - `db` may be a bare app-db map, or a full frame-state value (`{:rf.db/app … :rf.db/runtime …}`) when the graph mixes app-db and runtime-db subs.
+  - JVM-runnable.
 - **Example**:
   ```clojure
   ;; Evaluate :counter/doubled against a literal app-db value (no frame, no cache).
@@ -352,7 +372,7 @@ These are the two verbs that drive the pipeline. `dispatch` says "an event happe
 
 ### Standard events (keyword surface)
 
-The framework ships a small, fixed set of standard `:rf/*` events you can dispatch like any other. They are framework-owned: the `:rf/*` single-root namespace is reserved, so re-registering one with `reg-event` is a loud reserved-id collision (`:rf.error/reserved-event-id`).
+The framework ships a small, fixed set of standard `:rf/*` events you dispatch like any other. They are framework-owned: the `:rf/*` single-root namespace is reserved, so re-registering one with `reg-event` is a loud reserved-id collision (`:rf.error/reserved-event-id`).
 
 #### `:rf/set-db`
 
@@ -361,7 +381,7 @@ The framework ships a small, fixed set of standard `:rf/*` events you can dispat
   ```clojure
   [:rf/set-db new-db-map]
   ```
-- **Description**: The framework-standard `app-db` seeding event. `[:rf/set-db {…}]` **replaces** the whole `app-db` partition with the supplied map (it is a replace, not a merge) and rides the **normal** post-commit path — schema validation, rollback, trace emission, epoch recording — so seeding `app-db` is an ordinary, traceable event rather than a privileged direct write. It returns `{:db new-db}` from a pure handler, so it touches **only** the `app-db` partition and never runtime-db.
+- **Description**: The framework-standard `app-db` seeding event. **Replaces** the whole `app-db` partition with the supplied map (a replace, not a merge). Rides the normal post-commit path — schema validation, rollback, trace emission, epoch recording — so seeding is an ordinary traceable event, not a privileged direct write. Returns `{:db new-db}` from a pure handler, so it touches only the `app-db` partition, never runtime-db.
 - **Validation**: takes **exactly one map argument**. A missing / `nil` / non-map argument, or any extra trailing arg (`[:rf/set-db {} :junk]`), throws `:rf.error/set-db-bad-value`. Empty `app-db` is `[:rf/set-db {}]`.
 - **Example**:
   ```clojure
@@ -376,7 +396,7 @@ The framework ships a small, fixed set of standard `:rf/*` events you can dispat
 
 ## Views
 
-Views are where the pipeline ends and pixels begin. The view layer is **substrate-agnostic** — the shared dataflow (frames, subscriptions, dispatch, source metadata, registry ids) is uniform across Reagent, UIx, and Helix, and the same `capture-frame` carry primitive composes across all three. The substrate-specific hooks (`use-subscribe`, `wrap-view`, …) live in each adapter's namespace doc ([re-frame.adapter.reagent.md](re-frame.adapter.reagent.md) / [re-frame.adapter.uix.md](re-frame.adapter.uix.md) / [re-frame.adapter.helix.md](re-frame.adapter.helix.md)).
+The view layer is **substrate-agnostic** — the shared dataflow (frames, subscriptions, dispatch, source metadata, registry ids) is uniform across Reagent, UIx, and Helix, and the same `capture-frame` carry primitive composes across all three. The substrate-specific hooks (`use-subscribe`, `wrap-view`, …) live in each adapter's namespace doc ([re-frame.adapter.reagent.md](re-frame.adapter.reagent.md) / [re-frame.adapter.uix.md](re-frame.adapter.uix.md) / [re-frame.adapter.helix.md](re-frame.adapter.helix.md)).
 
 ### `reg-view`
 
@@ -387,7 +407,7 @@ Views are where the pipeline ends and pixels begin. The view layer is **substrat
   (reg-view sym docstring [args] body+)
   (reg-view ^{:rf/id :explicit/id} sym [args] body+)
   ```
-- **Description**: The `defn`-shape view registration — the app-facing lane. Auto-defs the symbol, auto-derives the id from `(keyword *ns* sym)`, auto-injects `dispatch` / `subscribe` as lexical bindings, and rejects non-defn-shape bodies at macroexpand. The 80% of registrations want this form. In all shapes the symbol is `def`-ed so you can write `[my-view item]` from sibling code; render an app-facing view by **Var reference** or `(rf/view id)` (bare keyword-tagged hiccup `[:my-view "args"]` is rejected — see [Spec 004 §Resolved decisions](../../spec/004-Views.md#bare-my-view-args-in-raw-hiccup-is-rejected)).
+- **Description**: The `defn`-shape view registration — the app-facing lane. It auto-defs the symbol, auto-derives the id from `(keyword *ns* sym)`, auto-injects `dispatch` / `subscribe` as lexical bindings, and rejects non-defn-shape bodies at macroexpand. In all shapes the symbol is `def`-ed, so sibling code can write `[my-view item]`. Render an app-facing view by **Var reference** or `(rf/view id)` — bare keyword-tagged hiccup `[:my-view "args"]` is rejected (see [Spec 004 §Resolved decisions](../../spec/004-Views.md#bare-my-view-args-in-raw-hiccup-is-rejected)).
 - **Example**:
   ```clojure
   (rf/reg-view counter-buttons []
@@ -405,7 +425,13 @@ Views are where the pipeline ends and pixels begin. The view layer is **substrat
   (reg-view* id render-fn)
   (reg-view* id metadata render-fn)
   ```
-- **Description**: The plain-fn surface beneath `reg-view` — the tooling / host lane. No auto-def (the caller manages the Var or computed id), no auto-inject, no compile check. Reach for it when the id is **computed** (code-gen pipelines, plugin systems, story scaffolding), when you **don't want a Var** (inside a `let` or closure), when writing a **Form-3 component** (`(rf/reg-view* :id (r/create-class {...}))` — the one app-facing reason to touch the starred form), or when writing **consumer-side library code** that registers without imposing a `def`. Inside a `reg-view*` body there's no auto-injected `dispatch` / `subscribe`; capture a `(rf/capture-frame)` at render and use its ops if the view needs frame-bound dispatch.
+- **Description**: The plain-fn surface beneath `reg-view` — the tooling / host lane. No auto-def, no auto-inject, no compile check. Reach for it when:
+  - the id is **computed** (code-gen pipelines, plugin systems, story scaffolding);
+  - you **don't want a Var** (inside a `let` or closure);
+  - you are writing a **Form-3 component** (`(rf/reg-view* :id (r/create-class {...}))` — the one app-facing reason to touch the starred form);
+  - you are writing **consumer-side library code** that registers without imposing a `def`.
+
+  There is no auto-injected `dispatch` / `subscribe` in a `reg-view*` body; capture a `(rf/capture-frame)` at render and use its ops if the view needs frame-bound dispatch.
 - **Example**:
   ```clojure
   ;; Computed id — the id isn't a literal symbol at the call site.
@@ -430,7 +456,7 @@ Views are where the pipeline ends and pixels begin. The view layer is **substrat
   ```clojure
   (view view-id) → render-fn
   ```
-- **Description**: Runtime lookup handle. Returns the **registered render-fn** (or `nil` when the id is not registered), not hiccup. Use in hiccup as `[(rf/view :id) args...]` when you need to late-bind a view by id — a host that resolves a stored view id, plugin-style dispatch, dynamic chrome. The Var form (`[my-view args]`) is the app-facing default; this lookup form is for the tooling/host case where the id, not the symbol, is what the caller holds.
+- **Description**: Runtime lookup handle. Returns the **registered render-fn** (or `nil` when the id is not registered), not hiccup. Use in hiccup as `[(rf/view :id) args...]` to late-bind a view by id — a host that resolves a stored view id, plugin-style dispatch, dynamic chrome. The Var form (`[my-view args]`) is the app-facing default; this lookup form is for the case where the caller holds the id, not the symbol.
 - **Example**:
   ```clojure
   [(rf/view :app/header) {:title "Cart"}]   ;; resolves the registered render-fn at render time
@@ -445,7 +471,7 @@ Views are where the pipeline ends and pixels begin. The view layer is **substrat
   [rf/frame-provider {:id :todo :images [todo-image]} & children]   ;; ENSURE: create-if-absent / reuse
   ```
 - **Description**: One component, two config shapes chosen by the prop map. See the [frame-provider glossary entry](../core/glossary.md#frame-provider).
-  - **`{:frame existing-id}` — SCOPE.** "Children inside this provider see `:todo` as their current frame." Scopes a React subtree to a frame that **already exists**; creates / refreshes / destroys nothing. **Fails loud** (`:rf.error/frame-provider-frame-absent`) when the named frame is absent. `:frame` must be a keyword. The scope-into-React counterpart to `with-frame`.
+  - **`{:frame existing-id}` — SCOPE.** Scopes a React subtree to a frame that **already exists**; creates / refreshes / destroys nothing. **Fails loud** (`:rf.error/frame-provider-frame-absent`) when the named frame is absent. `:frame` must be a keyword. The scope-into-React counterpart to `with-frame`.
   - **`{:id the-id …}` — ENSURE.** Creates the frame if absent (via `make-frame`, taking the same constructor opts: `:id` / `:images` / record-config incl. `:initial-events`), **reuses it without re-seeding** if present (an idempotent re-mount preserves durable state and does not replay `:initial-events`), and provides its id to descendants. There is **no destroy-on-unmount**. `:id` is required and must be a keyword. True ownership stays explicit: `make-frame` + `destroy-frame!` inside a `create-class`.
 - **Example**:
   ```clojure
@@ -469,7 +495,10 @@ Views are where the pipeline ends and pixels begin. The view layer is **substrat
   (capture-frame)          → {:frame :dispatch :dispatch-sync :subscribe}
   (capture-frame frame-id) → {:frame :dispatch :dispatch-sync :subscribe}
   ```
-- **Description**: The keystone affordance. Captures the active frame at CREATION time and returns an **operation bundle** whose `:dispatch` / `:dispatch-sync` / `:subscribe` ops always target the captured frame — they survive async boundaries (`Promise.then`, `setTimeout`, WebSocket `onmessage`, observer callbacks) where the ambient frame lookup would have unwound. The handle is *locked* to one frame: a per-call `:frame` opt MUST NOT override it. It's an operation bundle, not a container — read the frame's app-db value via `(rf/app-db-value (:frame handle))`, not the handle itself. The full async-boundary contract is in [Frames — the async boundary](../core/concepts/frames.md).
+- **Description**: Captures the active frame at CREATION time and returns an **operation bundle** whose `:dispatch` / `:dispatch-sync` / `:subscribe` ops always target the captured frame — they survive async boundaries (`Promise.then`, `setTimeout`, WebSocket `onmessage`, observer callbacks) where the ambient frame lookup would have unwound.
+  - The handle is *locked* to one frame: a per-call `:frame` opt MUST NOT override it.
+  - It is an operation bundle, not a container — read the frame's app-db value via `(rf/app-db-value (:frame handle))`, not the handle itself.
+  - Full async-boundary contract: [Frames — the async boundary](../core/concepts/frames.md).
 - **Example**:
   ```clojure
   (rf/reg-view stream-view []
@@ -496,7 +525,9 @@ Views are where the pipeline ends and pixels begin. The view layer is **substrat
   (with-frame :keyword body)        ;; pin *current-frame* to an existing frame-id
   (with-new-frame [sym expr] body)  ;; eval expr, bind id to sym, run, destroy on exit
   ```
-- **Description**: The two **lexical** (non-React) frame-scoping macros — the regions that aren't a view tree, chiefly tests, the REPL, and SSR. `with-frame` pins `*current-frame*` to an **existing** frame-id for the dynamic extent of `body`, creating and destroying nothing; it is the lexical counterpart to the `rf/frame-provider` `{:frame …}` SCOPE shape. `with-new-frame` evaluates `expr`, binds the resulting frame target to `sym` (a live frame value from `make-frame`, or a keyword id from `reg-frame` — either is accepted downstream), runs `body` in that frame's dynamic context, and **destroys the frame on exit** — the throwaway-frame form for one-off harnesses. Each rejects the other's argument shape at compile time.
+- **Description**: The two **lexical** (non-React) frame-scoping macros — for regions that aren't a view tree (tests, the REPL, SSR). Each rejects the other's argument shape at compile time.
+  - `with-frame` pins `*current-frame*` to an **existing** frame-id for the dynamic extent of `body`, creating and destroying nothing. The lexical counterpart to the `rf/frame-provider` `{:frame …}` SCOPE shape.
+  - `with-new-frame` evaluates `expr`, binds the resulting frame target to `sym` (a live frame value from `make-frame`, or a keyword id from `reg-frame` — either is accepted downstream), runs `body` in that frame's dynamic context, and **destroys the frame on exit**. The throwaway-frame form for one-off harnesses.
 - **Example**:
   ```clojure
   ;; Pin form — bind *current-frame* to an existing id for the body (most common)
@@ -512,9 +543,9 @@ Views are where the pipeline ends and pixels begin. The view layer is **substrat
 
 ## Effects and interceptors
 
-The effect map is what an event handler returns. The interceptor chain is what runs before and after the handler. Handlers stay pure (they return descriptions of effects, not the effects themselves), and the runtime actions those descriptions at exactly one point.
+The effect map is what an event handler returns; the interceptor chain runs before and after the handler. Handlers stay pure (they return descriptions of effects, not the effects themselves), and the runtime actions those descriptions at exactly one point.
 
-The effect map is **closed**: app handlers return `:db` + `:fx` only (a third reserved top-level key, `:rf.db/runtime`, exists for framework / runtime-extension authority — never for app handlers). `:db` is the new `app-db` value (replaced in the commit phase); `:fx` is a vector of `[fx-id args]` pairs (`[fx-id]` is the no-args shorthand), each run by the runtime's fx walker against the registered `reg-fx` handler. The [effect map](../core/glossary.md#effect-map) glossary entry covers both reserved keys.
+The effect map is **closed**: app handlers return `:db` + `:fx` only (a third reserved top-level key, `:rf.db/runtime`, exists for framework / runtime-extension authority — never for app handlers). `:db` is the new `app-db` value (replaced in the commit phase); `:fx` is a vector of `[fx-id args]` pairs (`[fx-id]` is the no-args shorthand), each run by the runtime's fx walker against the registered `reg-fx` handler. Both reserved keys are covered by the [effect map](../core/glossary.md#effect-map) glossary entry.
 
 ### `reg-interceptor`
 
@@ -523,7 +554,11 @@ The effect map is **closed**: app handlers return `:db` + `:fx` only (a third re
   ```clojure
   (reg-interceptor id {:keys [before after]})
   ```
-- **Description**: The public custom-interceptor authoring form. Register a named interceptor descriptor — `{:before f}` / `{:after f}` / `{:before f :after g}`, or `{:factory f}` for a parameterized family (`f` receives one arg and returns a descriptor; referenced as `[id arg]` — the standard `[:rf.interceptor/path …]` is the canonical factory consumer) — then **reference it by id** from a `reg-event` / `reg-frame` `:interceptors` vector. An optional middle slot carries the standard registration-metadata map (`:doc`, `:schema`, `:tags`, …). **Use this for any work not covered by the standard interceptors** — analytics, logging, validation, ad-hoc context manipulation. The interceptor is named, addressable, and queryable like any other artefact. (`->interceptor` is the framework-internal lowering constructor that turns a descriptor into an executable chain entry; it is not the application-authoring form and must not appear directly in a public chain.)
+- **Description**: The public custom-interceptor authoring form. Register a named interceptor descriptor, then **reference it by id** from a `reg-event` / `reg-frame` `:interceptors` vector. Descriptor shapes:
+  - `{:before f}` / `{:after f}` / `{:before f :after g}`;
+  - `{:factory f}` for a parameterized family (`f` receives one arg and returns a descriptor; referenced as `[id arg]` — the standard `[:rf.interceptor/path …]` is the canonical factory consumer).
+
+  An optional middle slot carries the standard registration-metadata map (`:doc`, `:schema`, `:tags`, …). Use this for any work not covered by the standard interceptors — analytics, logging, validation, ad-hoc context manipulation. (`->interceptor` is the framework-internal lowering constructor that turns a descriptor into an executable chain entry; it must not appear directly in a public chain.)
 - **Example**:
   ```clojure
   (rf/reg-interceptor :log-on-error
@@ -546,7 +581,7 @@ The effect map is **closed**: app handlers return `:db` + `:fx` only (a third re
   (reg-interceptor* id descriptor)
   (reg-interceptor* id metadata descriptor)
   ```
-- **Description**: The programmatic `*`-twin of `reg-interceptor` (EP-0022). Same registration, minus the macro's definition-site source-coord capture. Use from HoF / code-gen / REPL callers where a macro can't sit; the `reg-interceptor` macro is the ergonomic surface.
+- **Description**: The programmatic `*`-twin of `reg-interceptor` (EP-0022). Same registration, minus the macro's definition-site source-coord capture. Use from HoF / code-gen / REPL callers where a macro can't sit.
 
 ### `->interceptor`
 
@@ -555,7 +590,7 @@ The effect map is **closed**: app handlers return `:db` + `:fx` only (a third re
   ```clojure
   (->interceptor & {:keys [id before after]})
   ```
-- **Description**: **INTERNAL — not the public application-authoring form.** The framework-internal lowering constructor that turns a `{:before … :after …}` descriptor into an executable chain entry (capturing the definition-site `:source-coord` from `(meta &form)`). Application code registers interceptors with `reg-interceptor` and references them by id; `->interceptor` must not appear directly in a public `:interceptors` chain.
+- **Description**: **INTERNAL — not the public authoring form.** The framework-internal lowering constructor that turns a `{:before … :after …}` descriptor into an executable chain entry (capturing the definition-site `:source-coord` from `(meta &form)`). Application code registers interceptors with `reg-interceptor` and references them by id; `->interceptor` must not appear directly in a public `:interceptors` chain.
 
 ### `->interceptor*`
 
@@ -564,7 +599,7 @@ The effect map is **closed**: app handlers return `:db` + `:fx` only (a third re
   ```clojure
   (->interceptor* & {:keys [id before after]})
   ```
-- **Description**: **INTERNAL.** The plain, runtime-callable fn form of the `->interceptor` macro (per Conventions `*`-suffix naming). HoF / programmatic / REPL callers reach this directly; it captures no source-coord. Not an application-authoring surface — use `reg-interceptor`.
+- **Description**: **INTERNAL.** The plain, runtime-callable fn form of the `->interceptor` macro (per Conventions `*`-suffix naming). HoF / programmatic / REPL callers reach this directly; it captures no source-coord. Not an authoring surface — use `reg-interceptor`.
 
 ### `with-fx-overrides`
 
@@ -573,7 +608,9 @@ The effect map is **closed**: app handlers return `:db` + `:fx` only (a third re
   ```clojure
   (with-fx-overrides {fx-id -> override, …} body+)
   ```
-- **Description**: "For the duration of this body, every `dispatch` / `dispatch-sync` merges this fx-overrides map into its envelope." Lexical scope; composes with `with-frame`. The three override scopes compose with a clear precedence: **per-call** (`(rf/dispatch event {:fx-overrides {...}})`) wins, then **lexical** (`with-fx-overrides`), then **per-frame** (`(rf/reg-frame :todo {:fx-overrides {...}})`). At the pattern level the override value is an **id**; the CLJS reference implementation also accepts a **fn** value for ergonomic test wiring (the asymmetry is deliberate — ports that don't ship fn-valued overrides remain pattern-conformant).
+- **Description**: For the duration of `body`, every `dispatch` / `dispatch-sync` merges this fx-overrides map into its envelope. Lexical scope; composes with `with-frame`.
+  - The three override scopes compose with a clear precedence: **per-call** (`(rf/dispatch event {:fx-overrides {...}})`) wins, then **lexical** (`with-fx-overrides`), then **per-frame** (`(rf/reg-frame :todo {:fx-overrides {...}})`).
+  - At the pattern level the override value is an **id**; the CLJS reference implementation also accepts a **fn** value for test wiring (the asymmetry is deliberate — ports that don't ship fn-valued overrides remain pattern-conformant).
 - **Example**:
   ```clojure
   ;; Swap the real managed-HTTP fx for a canned-failure stub for the test body —
@@ -589,7 +626,10 @@ The effect map is **closed**: app handlers return `:db` + `:fx` only (a third re
   ```clojure
   validate-at-boundary-interceptor
   ```
-- **Description**: A **pre-built interceptor value**, not a fn, registered under the framework id `:rf.schema/at-boundary`. Reference it **by id** from a `reg-event` metadata map's `:interceptors` vector — `{:interceptors [:rf.schema/at-boundary]}`; chains are reference-only, so the Var itself never appears as an inline chain entry (it is the registration-boundary input). Use it for production-boundary validation (handlers that ingest data from outside the app's trust boundary — HTTP replies, websocket frames, postMessage): it forces `:schema` validation of the dispatched event vector even in production builds where dev-time validation is elided. **Do not call it as a fn** — invoking it raises `ArityException`. Full contract in [re-frame.schemas.md](re-frame.schemas.md).
+- **Description**: A **pre-built interceptor value**, not a fn, registered under the framework id `:rf.schema/at-boundary`. Reference it **by id** from a `reg-event` metadata map's `:interceptors` vector — `{:interceptors [:rf.schema/at-boundary]}`; chains are reference-only, so the Var itself never appears as an inline chain entry.
+  - It forces `:schema` validation of the dispatched event vector even in production builds where dev-time validation is elided — for handlers that ingest data from outside the app's trust boundary (HTTP replies, websocket frames, postMessage).
+  - **Do not call it as a fn** — invoking it raises `ArityException`.
+  - Full contract: [re-frame.schemas.md](re-frame.schemas.md).
 - **Example**:
   ```clojure
   (rf/reg-event ::receive-from-server
@@ -599,12 +639,12 @@ The effect map is **closed**: app handlers return `:db` + `:fx` only (a third re
 
 ### Standard fx and interceptor (keyword surface)
 
-The framework reserves a few `:fx` entries and one standard interceptor reference. User code registers its own fx-ids via `reg-fx`; the core-owned reserved entries are below. Feature-owned fx (`[:rf.http/managed …]`, `[:rf.nav/push-url …]`, `[:rf.machine/spawn …]`, `[:rf.fx/reg-flow …]`, `[:rf.server/* …]`, …) live in their feature namespace docs.
+The framework reserves a few `:fx` entries and one standard interceptor reference. User code registers its own fx-ids via `reg-fx`. Feature-owned fx (`[:rf.http/managed …]`, `[:rf.nav/push-url …]`, `[:rf.machine/spawn …]`, `[:rf.fx/reg-flow …]`, `[:rf.server/* …]`, …) live in their feature namespace docs.
 
 | `[fx-id args]` | Args | Status | Intuition |
 |---|---|---|---|
-| `[:dispatch event-vec]` | event vector | v1 | "Schedule this event on the same queue." Async — runs after the current run completes. |
-| `[:dispatch-later {:ms ms :event event-vec}]` | options map | v1 | "Schedule this event after N ms." |
+| `[:dispatch event-vec]` | event vector | v1 | Schedule this event on the same queue. Async — runs after the current run completes. |
+| `[:dispatch-later {:ms ms :event event-vec}]` | options map | v1 | Schedule this event after N ms. |
 
 #### `[:rf.interceptor/path <path-vector>]`
 
@@ -613,7 +653,10 @@ The framework reserves a few `:fx` entries and one standard interceptor referenc
   ```clojure
   {:interceptors [[:rf.interceptor/path [:cart :items]]]}
   ```
-- **Description**: Focus the handler on an `app-db` sub-slice. `:before` stages the focused slice as `:db` — `(get-in db path)`; `:after` widens the returned slice back into full app-db. The handler sees and returns a sub-tree, not the full db. Preserves the frame-commit `identical?` no-op (an unchanged focused slice widens back to the original app-db object, not an `assoc-in` allocation). A non-vector / malformed path arg raises `:rf.error/path-interceptor-bad-path`. It is a **reference**, not a constructed value — there is no public `path` fn (a stale `rf/path` call raises `:rf.error/path-removed`).
+- **Description**: Focus the handler on an `app-db` sub-slice. `:before` stages the focused slice as `:db` (`(get-in db path)`); `:after` widens the returned slice back into full app-db. The handler sees and returns a sub-tree, not the full db.
+  - Preserves the frame-commit `identical?` no-op (an unchanged focused slice widens back to the original app-db object, not an `assoc-in` allocation).
+  - A non-vector / malformed path arg raises `:rf.error/path-interceptor-bad-path`.
+  - It is a **reference**, not a constructed value — there is no public `path` fn (a stale `rf/path` call raises `:rf.error/path-removed`).
 
 ## Frames
 
@@ -627,7 +670,13 @@ A frame is the scoping unit for `app-db`, the event queue, and the pipeline. Mos
   (make-frame opts) ; → live frame value
   (make-frame opts descriptors) ; → live frame value (explicit descriptor pool — tests / harnesses)
   ```
-- **Description**: The **single public constructor** for a live frame. It accepts image-selection options *and* frame-configuration options in **one** call and **returns the live frame value** — one frame value backed by one registry. Useful for per-mount lifecycles — devcards, modal stacks, multiple live instances of a widget, dynamic tabs, tests, and the SSR per-request frame pattern. `opts` must be a map — a non-map (including `nil`) raises `:rf.error/make-frame-bad-opts`; a non-vector `:images` raises `:rf.error/make-frame-bad-images`. Opts: the image-selection keys `:images` (always a vector), `:id` (optional — registers the frame in the one process-local live-frame registry; a duplicate live id is **idempotent replacement** that preserves durable state on re-mount), `:adapter` — **and**, in the same call, the frame-configuration keys `:initial-events` (a vector of event vectors dispatched into the new frame at creation), `:fx-overrides`, `:platform`, `:ssr`, `:doc`, `:preset`, `:tags`. **Route by id, not by value:** read its id via `rf/frame-value->id` and pass the **id** to `dispatch` / `subscribe` / providers / tools. Lifecycle is the caller's responsibility — pair a direct `make-frame` with a `destroy-frame!`, or use the UI-owned `rf/frame-provider` boundary. See the [Frames concept guide](../core/concepts/frames.md) and [EP-0024](../EP/EP-0024-unified-frame-identity-and-lifecycle.md).
+- **Description**: The single public constructor for a live frame. It accepts image-selection *and* frame-configuration options in one call and **returns the live frame value** — one frame value backed by one registry. For per-mount lifecycles: devcards, modal stacks, multiple live widget instances, dynamic tabs, tests, and the SSR per-request frame pattern.
+  - `opts` must be a map — a non-map (including `nil`) raises `:rf.error/make-frame-bad-opts`; a non-vector `:images` raises `:rf.error/make-frame-bad-images`.
+  - Image-selection opts: `:images` (always a vector); `:id` (optional — registers the frame in the one process-local live-frame registry; a duplicate live id is **idempotent replacement** that preserves durable state on re-mount); `:adapter`.
+  - Frame-configuration opts (same call): `:initial-events` (a vector of event vectors dispatched into the new frame at creation), `:fx-overrides`, `:platform`, `:ssr`, `:doc`, `:preset`, `:tags`.
+  - **Route by id, not by value:** read the id via `rf/frame-value->id` and pass the id to `dispatch` / `subscribe` / providers / tools.
+  - Lifecycle is the caller's responsibility — pair a direct `make-frame` with a `destroy-frame!`, or use the UI-owned `rf/frame-provider` boundary.
+  - See the [Frames concept guide](../core/concepts/frames.md) and [EP-0024](../EP/EP-0024-unified-frame-identity-and-lifecycle.md).
 - **Example**:
   ```clojure
   ;; A component that OWNS a frame lifetime uses the UI-owned provider,
@@ -645,7 +694,9 @@ A frame is the scoping unit for `app-db`, the event queue, and the pipeline. Mos
   ```clojure
   (reset-frame! frame-id)
   ```
-- **Description**: Atomic `destroy-frame!` + `reg-frame` with the **same config** — a full frame replace (opt-in). It tears the frame down through the normative `destroy-frame!` boundary (running `:on-destroy`, releasing per-feature resources) and re-registers it fresh, so machine snapshots, the route slice, flows, and `app-db` are all rebuilt from the registered config. Use sparingly. To wipe just the `app-db` partition while keeping live runtime-db, reach for `reset-app-db!` instead. There is **no** `:initial-db` config key — seeding `app-db` is itself an ordinary, traceable event, `[:rf/set-db {…}]`.
+- **Description**: Atomic `destroy-frame!` + `reg-frame` with the **same config** — a full frame replace. It tears the frame down through the normative `destroy-frame!` boundary (running `:on-destroy`, releasing per-feature resources) and re-registers it fresh, so machine snapshots, the route slice, flows, and `app-db` are all rebuilt from the registered config.
+  - Use sparingly. To wipe just the `app-db` partition while keeping live runtime-db, use `reset-app-db!`.
+  - There is **no** `:initial-db` config key — seeding `app-db` is itself an ordinary, traceable event, `[:rf/set-db {…}]`.
 - **Example**:
   ```clojure
   ;; Full frame replace (destroy + re-reg with the SAME config).
@@ -677,7 +728,7 @@ A frame is the scoping unit for `app-db`, the event queue, and the pipeline. Mos
   ```clojure
   (current-frame-id) → keyword
   ```
-- **Description**: Return the active frame id the in-effect scope carries — the dynamic `*current-frame*` stamp or a React-context `frame-provider` scope (CLJS only). The context **reader** form; it is frame-scoped and requires a scope. There is **no `:rf/default` floor** — called under no established scope it raises `:rf.error/no-frame-context` rather than reporting an invented default (EP-0002).
+- **Description**: Return the active frame id the in-effect scope carries — the dynamic `*current-frame*` stamp or a React-context `frame-provider` scope (CLJS only). The context **reader** form; frame-scoped, requires a scope. There is **no `:rf/default` floor** — called under no established scope it raises `:rf.error/no-frame-context` (EP-0002).
 
 ### `frame-value->id`
 
@@ -695,7 +746,10 @@ A frame is the scoping unit for `app-db`, the event queue, and the pipeline. Mos
   ```clojure
   (frame-generation frame-target) → generation map
   ```
-- **Description**: Return the SEALED, resolved image **generation** a live frame is running — the inert image-assembly generation it resolves `(kind, id)` lookups through. The raw read over the EP-0023 frame→generation model, for tools (Pair MCP `describe-image`, Xray). `frame-target` is a registered frame id **or** a direct live frame object. Returns the generation map with stable public keys: `:rf.gen/resolver` (the sealed `[kind id]` map), `:rf.gen/images`, `:rf.gen/kinds`. **Fails loud** (`:rf.error/frame-no-generation`) when `frame-target` does not resolve to a live frame carrying a generation.
+- **Description**: Return the SEALED, resolved image **generation** a live frame is running — the inert image-assembly generation it resolves `(kind, id)` lookups through. The raw read over the EP-0023 frame→generation model, for tools (Pair MCP `describe-image`, Xray).
+  - `frame-target` is a registered frame id **or** a direct live frame object.
+  - Returns the generation map with stable public keys: `:rf.gen/resolver` (the sealed `[kind id]` map), `:rf.gen/images`, `:rf.gen/kinds`.
+  - **Fails loud** (`:rf.error/frame-no-generation`) when `frame-target` does not resolve to a live frame carrying a generation.
 
 ### `frame-shadows`
 
@@ -704,7 +758,9 @@ A frame is the scoping unit for `app-db`, the event queue, and the pipeline. Mos
   ```clojure
   (frame-shadows frame-target) → vector of shadow entries
   ```
-- **Description**: Return the cross-image **shadow report** for the image composition a live frame is running — the data you read to see exactly what a LATER image overrode in an EARLIER one. The public accessor for the report a frame's resolved generation carries at `:rf.gen/shadows`. `frame-target` is a registered frame id or a direct live frame value. Returns a flat vector, one entry per cross-image shadow (`{:registration [kind id] :image <defined-in> :shadowed-by <winner>}`); an **empty** vector when no later image shadowed an earlier one.
+- **Description**: Return the cross-image **shadow report** for the image composition a live frame is running — what a LATER image overrode in an EARLIER one. The public accessor for the report a frame's resolved generation carries at `:rf.gen/shadows`.
+  - `frame-target` is a registered frame id or a direct live frame value.
+  - Returns a flat vector, one entry per cross-image shadow (`{:registration [kind id] :image <defined-in> :shadowed-by <winner>}`); an **empty** vector when no later image shadowed an earlier one.
 
 ### `image`
 
@@ -713,7 +769,10 @@ A frame is the scoping unit for `app-db`, the event queue, and the pipeline. Mos
   ```clojure
   (image spec) → image value
   ```
-- **Description**: Construct an **image** value — a selected registration-set value, as inert data (EP-0023 / EP-0026). `spec` carries exactly three public keys: `:id` (optional), `:select-ns` (an `{:include [globs] :exclude [globs]}` selection map over registered descriptors' provenance namespaces), and `:registrations` (inline registrar-keyed sections). Pure — no registrar, no side effect. The result is the assembled registration set a frame resolves against (passed to `make-frame` / `frame-provider` under `:images`).
+- **Description**: Construct an **image** value — a selected registration-set value, as inert data (EP-0023 / EP-0026). Pure — no registrar, no side effect. The result is the assembled registration set a frame resolves against (passed to `make-frame` / `frame-provider` under `:images`). `spec` carries exactly three public keys:
+  - `:id` (optional);
+  - `:select-ns` (an `{:include [globs] :exclude [globs]}` selection map over registered descriptors' provenance namespaces);
+  - `:registrations` (inline registrar-keyed sections).
 
 ### `reload-images!`
 
@@ -722,7 +781,11 @@ A frame is the scoping unit for `app-db`, the event queue, and the pipeline. Mos
   ```clojure
   (reload-images! target opts) → reload report
   ```
-- **Description**: Hot-reload one frame's whole image composition, preserving frame memory — the seam that re-seals a frame's `(kind, id)` resolver after handler/sub/view source changes. `target` is a frame id **or** a frame value (`make-frame`'s return token); `opts` carries `:images`, a **vector** of image values forming the frame's new, complete composition (composition-replacing — it replaces the whole `:images` vector, not one member; a non-vector raises `:rf.error/make-frame-bad-images`). Only the frame's generation is swapped — app-db, runtime-db, caches, and lifecycle continue unchanged. Frame-targeted (reload affects only the named frame's generation, not siblings sharing an image). Returns the reload report `{:rf.frame/frame <frame value> :rf.reload/diff {:added … :changed … :removed … :retained …} :rf.reload/shadows [<shadow entry> …]}`.
+- **Description**: Hot-reload one frame's whole image composition, preserving frame memory — the seam that re-seals a frame's `(kind, id)` resolver after handler/sub/view source changes.
+  - `target` is a frame id **or** a frame value (`make-frame`'s return token).
+  - `opts` carries `:images`, a **vector** of image values forming the frame's new, complete composition (composition-replacing — it replaces the whole `:images` vector, not one member; a non-vector raises `:rf.error/make-frame-bad-images`).
+  - Only the frame's generation is swapped — app-db, runtime-db, caches, and lifecycle continue unchanged. Frame-targeted (affects only the named frame's generation, not siblings sharing an image).
+  - Returns the reload report `{:rf.frame/frame <frame value> :rf.reload/diff {:added … :changed … :removed … :retained …} :rf.reload/shadows [<shadow entry> …]}`.
 
 ### `frame-bound-fn`
 
@@ -731,7 +794,7 @@ A frame is the scoping unit for `app-db`, the event queue, and the pipeline. Mos
   ```clojure
   (frame-bound-fn fn-form)
   ```
-- **Description**: **INTERNAL — not app API.** A carry helper that binds a fn to the captured frame. Author async / tooling paths with `capture-frame` (or an explicit `{:frame …}` opt), which expresses the real use cases.
+- **Description**: **INTERNAL — not app API.** A carry helper that binds a fn to the captured frame. Author async / tooling paths with `capture-frame` (or an explicit `{:frame …}` opt).
 
 ### `frame-bound-fn*`
 
@@ -744,7 +807,7 @@ A frame is the scoping unit for `app-db`, the event queue, and the pipeline. Mos
 
 ## Lifecycle and configure
 
-The surfaces that bring a re-frame2 process up and take it down. An app author learns one boot sentence — **install an adapter with `init!`, then create your frame(s) explicitly** — and nothing else. The adapter-author surfaces (install / dispose / inspect) sit one layer down; an ordinary app never touches them.
+The surfaces that bring a re-frame2 process up and take it down. The one-line boot sentence: **install an adapter with `init!`, then create your frame(s) explicitly.** The adapter-author surfaces (install / dispose / inspect) sit one layer down; an ordinary app never touches them.
 
 ### `init!`
 
@@ -753,7 +816,9 @@ The surfaces that bring a re-frame2 process up and take it down. An app author l
   ```clojure
   (init! adapter-map)
   ```
-- **Description**: The idempotent boot. Required arg: the adapter spec map. Each adapter ns exports an `adapter` Var; consumers require the ns and pass the Var, e.g. `(rf/init! reagent-adapter/adapter)`. Calling `(init!)` with no args raises an `ArityException` at compile / load time; `(init! nil)` or `(init! :reagent)` raises `:rf.error/no-adapter-specified` at runtime. `init!` installs adapters and runtime capabilities only; it does **not** create or guarantee any frame — you register your app frame explicitly (`reg-frame`) and establish it at your root.
+- **Description**: The idempotent boot. Required arg: the adapter spec map. Each adapter ns exports an `adapter` Var; require the ns and pass the Var, e.g. `(rf/init! reagent-adapter/adapter)`.
+  - `(init!)` with no args raises `ArityException` at compile / load time; `(init! nil)` or `(init! :reagent)` raises `:rf.error/no-adapter-specified` at runtime.
+  - Installs adapters and runtime capabilities only; does **not** create or guarantee any frame — register your app frame explicitly (`reg-frame`) and establish it at your root.
 - **Example**:
   ```clojure
   (:require [re-frame.adapter.reagent :as reagent-adapter])
@@ -768,7 +833,10 @@ The surfaces that bring a re-frame2 process up and take it down. An app author l
   ```clojure
   (init-platform platform)   ;; :server | :client
   ```
-- **Description**: Set the host-wide active-platform marker. The runtime tracks the active platform so `reg-fx` / `reg-cofx` `:platforms` metadata can gate execution. CLJS hosts default to `:client`, JVM hosts to `:server`; call this at boot to override (e.g. a CLJS-on-Node SSR runtime sets `:server`; a JVM-runnable browser-simulating test sets `:client`). Anything other than `:server` / `:client` raises `:rf.error/invalid-platform`. Idempotent / re-callable. Per-frame `:config :platform` (set by the `:ssr-server` preset) is the finer-grained alternative and wins over the host-wide marker.
+- **Description**: Set the host-wide active-platform marker. The runtime tracks the active platform so `reg-fx` / `reg-cofx` `:platforms` metadata can gate execution.
+  - CLJS hosts default to `:client`, JVM hosts to `:server`; call this at boot to override (e.g. a CLJS-on-Node SSR runtime sets `:server`; a JVM-runnable browser-simulating test sets `:client`).
+  - Anything other than `:server` / `:client` raises `:rf.error/invalid-platform`. Idempotent / re-callable.
+  - Per-frame `:config :platform` (set by the `:ssr-server` preset) is the finer-grained alternative and wins over the host-wide marker.
 - **Example**:
   ```clojure
   (rf/init-platform :server)   ;; CLJS-on-Node SSR runtime
@@ -781,7 +849,7 @@ The surfaces that bring a re-frame2 process up and take it down. An app author l
   ```clojure
   (install-adapter! adapter-map)
   ```
-- **Description**: Must be called before any frame is created. **Lower-level than `init!`**; ordinary apps call `init!` instead. Installs once — a second call without an intervening `destroy-adapter!` raises `:rf.error/adapter-already-installed`. Use it when you're writing a custom boot pipeline that has additional steps between adapter-install and first-frame creation.
+- **Description**: Must be called before any frame is created. **Lower-level than `init!`**; ordinary apps call `init!` instead. Installs once — a second call without an intervening `destroy-adapter!` raises `:rf.error/adapter-already-installed`. Use it for a custom boot pipeline with steps between adapter-install and first-frame creation.
 - **Example**:
   ```clojure
   (rf/install-adapter! reagent-adapter/adapter)   ;; seat the substrate (lower-level than init!)
@@ -810,7 +878,7 @@ The surfaces that bring a re-frame2 process up and take it down. An app author l
   ```clojure
   (current-adapter) → discriminator keyword
   ```
-- **Description**: "What substrate am I on?" Answers `:rf.adapter/reagent` / `:rf.adapter/reagent-slim` / `:rf.adapter/uix` / `:rf.adapter/helix` / `:rf.adapter/plain-atom` / `:rf.adapter/ssr` / `:custom` — or `nil` when no adapter is installed. For predicate / branch code.
+- **Description**: Which substrate is installed. Answers `:rf.adapter/reagent` / `:rf.adapter/reagent-slim` / `:rf.adapter/uix` / `:rf.adapter/helix` / `:rf.adapter/plain-atom` / `:rf.adapter/ssr` / `:custom` — or `nil` when no adapter is installed. For predicate / branch code.
 - **Example**:
   ```clojure
   (rf/current-adapter)   ;; => :rf.adapter/reagent   (nil when no adapter is installed)
@@ -823,7 +891,7 @@ The surfaces that bring a re-frame2 process up and take it down. An app author l
   ```clojure
   (current-adapter-spec) → installed adapter spec map
   ```
-- **Description**: "Give me the adapter fns to call." The value passed to `(rf/init! ...)`, or `nil` when no adapter is installed. Use for tools / routing / identity checks across the install / dispose lifecycle. For the discriminator keyword, use `current-adapter`.
+- **Description**: The adapter spec map passed to `(rf/init! ...)`, or `nil` when no adapter is installed. For tools / routing / identity checks across the install / dispose lifecycle. For the discriminator keyword, use `current-adapter`.
 - **Example**:
   ```clojure
   (rf/current-adapter-spec)   ;; => the adapter spec map passed to (rf/init! …), or nil when none
@@ -836,7 +904,7 @@ The surfaces that bring a re-frame2 process up and take it down. An app author l
   ```clojure
   (adapter-disposed?) → boolean
   ```
-- **Description**: "Was the adapter torn down?" Returns `true` iff the most recent lifecycle event was a successful `destroy-adapter!` and no subsequent `install-adapter!` has fired. `false` for never-installed (fresh process) AND after a fresh install. Read-only. Use to distinguish `:rf.error/no-adapter-installed` (fresh process) from `:rf.error/adapter-disposed` (torn down).
+- **Description**: Returns `true` iff the most recent lifecycle event was a successful `destroy-adapter!` and no subsequent `install-adapter!` has fired. `false` for never-installed (fresh process) AND after a fresh install. Read-only. Use to distinguish `:rf.error/no-adapter-installed` (fresh process) from `:rf.error/adapter-disposed` (torn down).
 - **Example**:
   ```clojure
   (rf/adapter-disposed?)               ;; => false  (fresh process — never installed)
@@ -853,7 +921,7 @@ The surfaces that bring a re-frame2 process up and take it down. An app author l
   ```clojure
   (configure! config-map)
   ```
-- **Description**: Process-level data knobs you typically set once at boot. One of three orthogonal configuration surfaces — `configure!` for process-level data knobs; the `set-!` / `install-!` setters for adapter-pluggable hooks; per-frame metadata for frame-scoped overrides. The vocabulary of keys is closed-and-additive — existing keys cannot be renamed; new keys are added by extending the table. Three keys ship:
+- **Description**: Process-level data knobs, typically set once at boot. One of three orthogonal configuration surfaces — `configure!` for process-level data knobs; the `set-!` / `install-!` setters for adapter-pluggable hooks; per-frame metadata for frame-scoped overrides. The key vocabulary is closed-and-additive (existing keys cannot be renamed; new keys are added by extending the table). Three keys ship:
 
   | Key | Opts | Default | Status | What it tunes |
   |---|---|---|---|---|
@@ -861,7 +929,7 @@ The surfaces that bring a re-frame2 process up and take it down. An app author l
   | `:trace-buffer` | `{:events-retained N}` | `{:events-retained 50}` | v1 (dev-only) | The dev-only per-frame trace ring's event-slot count — one slot per event, regardless of how many trace events its run emitted. 0 disables retention (the surface stays live). |
   | `:elision` | `{:rf.size/threshold-bytes N}` | `{:rf.size/threshold-bytes 16384}` | v1 | The size threshold above which `elide-wire-value` substitutes a `:rf.size/large-elided` marker. 0 disables runtime auto-detect. |
 
-  There is **no `:sub-cache` knob** — sub-cache disposal is synchronous on derefer-count → 0. SSR error-projection policy (`:public-error-id`, `:dev-error-detail?`) is **not** a `configure!` key — it's per-frame metadata on the frame's `:ssr` map. Framework-owned semantic sub-keys use a namespaced keyword (`:rf.size/threshold-bytes`); ergonomic per-knob sub-keys are unqualified (`:depth`, `:trace-events-keep`, `:redact-fn`).
+  There is **no `:sub-cache` knob** — sub-cache disposal is synchronous on derefer-count → 0. SSR error-projection policy (`:public-error-id`, `:dev-error-detail?`) is **not** a `configure!` key — it is per-frame metadata on the frame's `:ssr` map. Framework-owned semantic sub-keys use a namespaced keyword (`:rf.size/threshold-bytes`); ergonomic per-knob sub-keys are unqualified (`:depth`, `:trace-events-keep`, `:redact-fn`).
 - **Example**:
   ```clojure
   (rf/configure! {:epoch-history {:depth 100}
@@ -876,7 +944,7 @@ The surfaces that bring a re-frame2 process up and take it down. An app author l
   ```clojure
   (feature-loaded? feature) → boolean
   ```
-- **Description**: Is the named optional feature's implementation artefact on the classpath? Detection is a pure keyword lookup in the always-loaded feature registry (no exception, no classpath probe). Code may legitimately probe `(feature-loaded? :routing)` before taking a feature-dependent path.
+- **Description**: Is the named optional feature's implementation artefact on the classpath? Detection is a pure keyword lookup in the always-loaded feature registry (no exception, no classpath probe). Probe `(feature-loaded? :routing)` before taking a feature-dependent path.
 - **Example**:
   ```clojure
   (rf/feature-loaded? :epoch)   ;; => true when day8/re-frame2-epoch is on the classpath
@@ -903,7 +971,7 @@ The surfaces that bring a re-frame2 process up and take it down. An app author l
   ```clojure
   (require-feature! feature) → true (or throws)
   ```
-- **Description**: Assert the optional feature is loaded. Returns `true` when its implementation artefact is on the classpath; throws a structured `:rf.error/feature-not-loaded` ex-info carrying the EXACT copy-pasteable Maven coordinate + require form when it is not; an unknown feature keyword throws `:rf.error/unknown-feature`. Use as an early, self-explaining guard at the top of code that depends on an optional feature.
+- **Description**: Assert the optional feature is loaded. Returns `true` when its implementation artefact is on the classpath. Throws a structured `:rf.error/feature-not-loaded` ex-info carrying the exact copy-pasteable Maven coordinate + require form when it is not; an unknown feature keyword throws `:rf.error/unknown-feature`. Use as an early guard at the top of code that depends on an optional feature.
 - **Example**:
   ```clojure
   (rf/require-feature! :epoch)   ;; absent => :rf.error/feature-not-loaded with copy-paste deps + require
@@ -911,7 +979,7 @@ The surfaces that bring a re-frame2 process up and take it down. An app author l
 
 ## Instrumentation and listeners
 
-Two surfaces stacked. The first is **dev-only**: a trace bus that emits one richly-tagged record per noteworthy event, buffered into a ring, fanned out to registered listeners synchronously, and elided entirely under `:advanced` + `goog.DEBUG=false`. The second is **always-on**: tight, production-survivable substrates (event-emit, error-emit) that deliver one record per processed event and one per `:rf.error/*` event. The epoch (time-travel) surfaces are dev-only and are also available natively as [re-frame.epoch.md](re-frame.epoch.md). The complete error catalogue is normative in Spec 009.
+Two surfaces stacked. The first is **dev-only**: a trace bus that emits one richly-tagged record per noteworthy event, buffered into a ring, fanned out to registered listeners synchronously, and elided entirely under `:advanced` + `goog.DEBUG=false`. The second is **always-on**: tight, production-survivable substrates (event-emit, error-emit) that deliver one record per processed event and one per `:rf.error/*` event. The epoch (time-travel) surfaces are dev-only and also available natively as [re-frame.epoch.md](re-frame.epoch.md). The complete error catalogue is normative in Spec 009.
 
 ### `register-listener!`
 
@@ -920,7 +988,9 @@ Two surfaces stacked. The first is **dev-only**: a trace bus that emits one rich
   ```clojure
   (register-listener! stream id callback-fn)
   ```
-- **Description**: Register `callback-fn` under `id` to receive every record the runtime emits on `stream`. **Stream-parameterized**: `:trace` (dev-only, DCE'd in production), `:events` and `:errors` (**always-on** — survive CLJS `:advanced` + `goog.DEBUG=false`), and `:epoch` (optional artefact). Synchronous delivery; the callback returns before the next record. Re-registering the same id on a stream replaces. Returns `id` (`nil` on the `:epoch` stream when the `day8/re-frame2-epoch` artefact is absent); an unknown `stream` throws `:rf.error/unknown-listener-stream`.
+- **Description**: Register `callback-fn` under `id` to receive every record the runtime emits on `stream`. Synchronous delivery — the callback returns before the next record. Re-registering the same id on a stream replaces.
+  - Streams: `:trace` (dev-only, DCE'd in production); `:events` and `:errors` (**always-on** — survive CLJS `:advanced` + `goog.DEBUG=false`); `:epoch` (optional artefact).
+  - Returns `id` (`nil` on the `:epoch` stream when the `day8/re-frame2-epoch` artefact is absent); an unknown `stream` throws `:rf.error/unknown-listener-stream`.
 - **Example**:
   ```clojure
   ;; Dev-only: tap every trace event the runtime emits (DCE'd in production).
@@ -971,7 +1041,7 @@ Two surfaces stacked. The first is **dev-only**: a trace bus that emits one rich
   ```clojure
   (emit-trace-event! op-type operation tags) → nil
   ```
-- **Description**: "Emit a custom trace event." Use sparingly — the framework emits the load-bearing events; custom emission is for app-specific cross-cutting concerns the framework can't know about.
+- **Description**: Emit a custom trace event. Use sparingly — the framework emits the load-bearing events; custom emission is for app-specific cross-cutting concerns the framework can't know about.
 - **Example**:
   ```clojure
   (rf/emit-trace-event! :event :rf.probe/touched {:source :probe})
@@ -985,7 +1055,10 @@ Two surfaces stacked. The first is **dev-only**: a trace bus that emits one rich
   (trace-buffer frame-id) → vector of event bundles, oldest-first
   (trace-buffer frame-id opts) → vector; {:flat true} yields raw trace events
   ```
-- **Description**: "What's in the ring right now?" Reads the named frame's dev-only, event-keyed ring non-destructively — one bundle per retained pipeline run by default; `{:flat true}` returns the raw trace events instead. Returns `[]` for a destroyed / never-registered frame, and `[]` in production (the ring is never allocated). On the `re-frame.core` facade this is a **JVM-only** alias — CLJS callers use `re-frame.trace.tooling/trace-buffer` directly. Pair tools and Xray use this for post-mortem inspection. The retained event-slot count is the `(rf/configure! {:trace-buffer {:events-retained N}})` knob.
+- **Description**: Read the named frame's dev-only, event-keyed ring non-destructively — one bundle per retained pipeline run by default; `{:flat true}` returns the raw trace events instead.
+  - Returns `[]` for a destroyed / never-registered frame, and `[]` in production (the ring is never allocated).
+  - On the `re-frame.core` facade this is a **JVM-only** alias — CLJS callers use `re-frame.trace.tooling/trace-buffer` directly.
+  - The retained event-slot count is the `(rf/configure! {:trace-buffer {:events-retained N}})` knob.
 - **Example**:
   ```clojure
   (rf/trace-buffer :app/main)               ;; event-keyed ring (oldest-first)
@@ -1048,7 +1121,10 @@ Two surfaces stacked. The first is **dev-only**: a trace bus that emits one rich
   (elide-wire-value v) → v or an elision-marker substitution
   (elide-wire-value v opts) → v or an elision-marker substitution
   ```
-- **Description**: The framework primitive that walks tree-shaped values at the wire boundary and substitutes elision markers for sensitive or large slots — the **single normative emission site** for the `:rf/redacted` sentinel and the `:rf.size/large-elided` marker. Walks `v` consulting the frame's runtime-db classification declarations; the frame resolves from the explicit `:frame` opt, else the carried scope. Redaction is strictly **path-based** — a secret re-keyed off its classified path ships raw (the **fail-open** default; to redact it, classify the destination path). A *live* frame that carries no declarations passes the value through unchanged; a frameless or unresolvable-frame call **fails closed** — the whole value is redacted to `:rf/redacted` (opt out with `:rf.size/include-sensitive? true`). This is the low-level *value* walker; the record-level boundary primitive is `project-egress`.
+- **Description**: The framework primitive that walks tree-shaped values at the wire boundary and substitutes elision markers for sensitive or large slots — the **single normative emission site** for the `:rf/redacted` sentinel and the `:rf.size/large-elided` marker. Walks `v` consulting the frame's runtime-db classification declarations; the frame resolves from the explicit `:frame` opt, else the carried scope.
+  - Redaction is strictly **path-based** — a secret re-keyed off its classified path ships raw (the **fail-open** default; to redact it, classify the destination path).
+  - A *live* frame carrying no declarations passes the value through unchanged; a frameless or unresolvable-frame call **fails closed** — the whole value is redacted to `:rf/redacted` (opt out with `:rf.size/include-sensitive? true`).
+  - This is the low-level *value* walker; the record-level boundary primitive is `project-egress`.
 - **Example**:
   ```clojure
   (rf/elide-wire-value slice {:frame :rf/default})
@@ -1063,7 +1139,11 @@ Two surfaces stacked. The first is **dev-only**: a trace bus that emits one rich
   ```clojure
   (project-egress record-or-value opts)
   ```
-- **Description**: The public, record-level boundary primitive — **the required step before any off-box sink**. Dispatches on a record's `:kind` (`:rf.observe/handled-event` / `:rf.observe/error`) to a per-kind projector, falling back to walking a kindless input as a tree-shaped value; each tree-shaped slot is delegated to `elide-wire-value` against the frame's classification. `opts` carries `:rf.egress/profile` (the closed six-member enum), `:frame`, `:path`, and advanced `:rf.size/*` overrides. An unknown profile throws `:rf.error/unknown-egress-profile`. **Fail-closed**: a tree slot projects only when the frame is known — no `:rf/default` synthesis. Full model: [Keep secrets out of traces](../core/how-to/keep-secrets-out-of-traces.md).
+- **Description**: The public, record-level boundary primitive — **the required step before any off-box sink**. Dispatches on a record's `:kind` (`:rf.observe/handled-event` / `:rf.observe/error`) to a per-kind projector, falling back to walking a kindless input as a tree-shaped value; each tree-shaped slot is delegated to `elide-wire-value` against the frame's classification.
+  - `opts` carries `:rf.egress/profile` (the closed six-member enum), `:frame`, `:path`, and advanced `:rf.size/*` overrides.
+  - An unknown profile throws `:rf.error/unknown-egress-profile`.
+  - **Fail-closed**: a tree slot projects only when the frame is known — no `:rf/default` synthesis.
+  - Full model: [Keep secrets out of traces](../core/how-to/keep-secrets-out-of-traces.md).
 - **Example**:
   ```clojure
   ;; Verify what an off-box sink will receive before wiring it.
@@ -1083,7 +1163,11 @@ Two surfaces stacked. The first is **dev-only**: a trace bus that emits one rich
   ```clojure
   (register-observability-sink! sink-id f)
   ```
-- **Description**: Register an observability sink fn `f` under the keyword `sink-id` — the id a frame's `:observability {:handled-events [{:sink <sink-id> :rf.egress/profile …}]}` entry names. `f` receives a single **already-projected** record (projected under the owning frame's classification and the entry's egress profile); it does **no** sink-local redaction. Re-registering the same id replaces. Returns `sink-id`. **Always-on** — survives CLJS `:advanced` + `goog.DEBUG=false`. This is the production-normal observability seam, parallel to the corpus-wide `register-listener!` surface (frame-scoped + profile-projected, where the corpus-wide listeners are cross-frame and raw).
+- **Description**: Register an observability sink fn `f` under the keyword `sink-id` — the id a frame's `:observability {:handled-events [{:sink <sink-id> :rf.egress/profile …}]}` entry names.
+  - `f` receives a single **already-projected** record (projected under the owning frame's classification and the entry's egress profile); it does **no** sink-local redaction.
+  - Re-registering the same id replaces. Returns `sink-id`.
+  - **Always-on** — survives CLJS `:advanced` + `goog.DEBUG=false`.
+  - The production-normal observability seam (frame-scoped + profile-projected), parallel to the corpus-wide `register-listener!` surface (cross-frame and raw).
 - **Example**:
   ```clojure
   (rf/reg-frame :app/main
@@ -1116,7 +1200,7 @@ Two surfaces stacked. The first is **dev-only**: a trace bus that emits one rich
   ```clojure
   (sensitive? trace-event) → boolean
   ```
-- **Description**: True iff `trace-event` is a map carrying `:sensitive? true` at the top level (not under `:tags`). The framework-published predicate every consumer composes against — replaces per-consumer reimplementations of the same check.
+- **Description**: True iff `trace-event` is a map carrying `:sensitive? true` at the top level (not under `:tags`). The framework-published predicate every consumer composes against.
 - **Example**:
   ```clojure
   (rf/sensitive? {:sensitive? true})   ;; => true
@@ -1239,11 +1323,11 @@ Two surfaces stacked. The first is **dev-only**: a trace bus that emits one rich
   (projected-history frame-id)
   (projected-history frame-id opts)
   ```
-- **Description**: Convenience: return the projected vector of records for a frame (each member projected as by `projected-record`). The off-box-safe companion to `epoch-history`.
+- **Description**: Return the projected vector of records for a frame (each member projected as by `projected-record`). The off-box-safe companion to `epoch-history`.
 
 ## Registrar queries
 
-The registrar is the data structure that holds every registered handler — events, subs, fx, cofx, flows, machines, views, schemas. Treating it as a queryable data structure is what makes the framework's tools possible. This is the read-side surface; the write-side is `reg-*` / `clear-*` above. Everything here is JVM-runnable.
+The registrar holds every registered handler — events, subs, fx, cofx, flows, machines, views, schemas — as a queryable data structure, which is what makes the framework's tools possible. This is the read-side surface; the write-side is `reg-*` / `clear-*` above. Everything here is JVM-runnable.
 
 ### `registrations`
 
@@ -1253,7 +1337,9 @@ The registrar is the data structure that holds every registered handler — even
   (registrations kind) → {id metadata-map}
   (registrations kind pred-fn) → {id metadata-map}
   ```
-- **Description**: **Use when you want metadata.** Walk the registrar with the full metadata map per id — source-coords, `:rf/sensitive`, `:rf/machine?`, `:platforms`, the doc string. Optional `pred-fn` filters by the metadata map. The frame-targeted form `(registrations {:frame :tenants/acme :kind :sub})` (an optional `:pred` filters as above) returns only the ids that frame's image carries, resolved through the frame's sealed image generation (EP-0023). A map argument is always a frame-targeted read: a map without `:frame` raises `:rf.error/registrar-query-needs-frame`; a `:frame` that does not resolve to a live frame carrying a generation raises `:rf.error/frame-no-generation`.
+- **Description**: Walk the registrar with the full metadata map per id — source-coords, `:rf/sensitive`, `:rf/machine?`, `:platforms`, the doc string. Use when you want metadata; optional `pred-fn` filters by the metadata map.
+  - Frame-targeted form `(registrations {:frame :tenants/acme :kind :sub})` (an optional `:pred` filters as above) returns only the ids that frame's image carries, resolved through the frame's sealed image generation (EP-0023).
+  - A map argument is always a frame-targeted read: a map without `:frame` raises `:rf.error/registrar-query-needs-frame`; a `:frame` that does not resolve to a live frame carrying a generation raises `:rf.error/frame-no-generation`.
 - **Example**:
   ```clojure
   (rf/registrations :event)
@@ -1268,7 +1354,7 @@ The registrar is the data structure that holds every registered handler — even
   ```clojure
   (handler-ids kind) → id set
   ```
-- **Description**: **Use when you only need to enumerate.** Canonical alias for `(-> (registrations kind) keys set)`. Saves both the metadata-map allocations and the `keys` walk — meaningful at scale (completion lists, existence checks, set-shaped intersections). The frame-targeted form `(handler-ids {:frame :blue/main :kind :event})` scopes to one frame's image; the same map-arity errors as `registrations` apply (`:rf.error/registrar-query-needs-frame`, `:rf.error/frame-no-generation`).
+- **Description**: Canonical alias for `(-> (registrations kind) keys set)`. Use when you only need to enumerate — it saves both the metadata-map allocations and the `keys` walk (meaningful at scale: completion lists, existence checks, set intersections). The frame-targeted form `(handler-ids {:frame :blue/main :kind :event})` scopes to one frame's image; the same map-arity errors as `registrations` apply (`:rf.error/registrar-query-needs-frame`, `:rf.error/frame-no-generation`).
 - **Example**:
   ```clojure
   (rf/handler-ids :event)                            ;; => #{:counter/inc :counter/reset}
@@ -1283,7 +1369,11 @@ The registrar is the data structure that holds every registered handler — even
   (handler-meta kind id) → registration-metadata map (or nil)
   (handler-meta {:frame f :kind k :id id}) → metadata resolved through frame f's image (or nil)
   ```
-- **Description**: "What did `reg-*` stamp at this id?" View registrations include source-coord keys (`:ns` / `:line` / `:column` / `:file`); pair tools resolve `data-rf2-source-coord` DOM annotations to `:file` via this lookup. The registrar kinds are `:event`, `:sub`, `:fx`, `:cofx`, `:interceptor`, `:view`, `:frame`, `:route`, `:head`, `:error-projector`, `:flow`, `:resource`. The two machine kinds `:machine-guard` / `:machine-action` are additionally accepted on the positional arity with a 2-vector id — `(handler-meta :machine-guard [machine-id guard-id])` — derived on demand from the machine's registration spec (dev-only source; not frame-targetable). The map arity is the frame-targeted read; the same map-arity errors as `registrations` apply (`:rf.error/registrar-query-needs-frame`, `:rf.error/frame-no-generation`). App-db schemas are **not** a registrar kind — look them up via `(app-schema-meta-at path)` in [re-frame.schemas.md](re-frame.schemas.md).
+- **Description**: What `reg-*` stamped at this id. View registrations include source-coord keys (`:ns` / `:line` / `:column` / `:file`); pair tools resolve `data-rf2-source-coord` DOM annotations to `:file` via this lookup.
+  - Registrar kinds: `:event`, `:sub`, `:fx`, `:cofx`, `:interceptor`, `:view`, `:frame`, `:route`, `:head`, `:error-projector`, `:flow`, `:resource`.
+  - The two machine kinds `:machine-guard` / `:machine-action` are additionally accepted on the positional arity with a 2-vector id — `(handler-meta :machine-guard [machine-id guard-id])` — derived on demand from the machine's registration spec (dev-only source; not frame-targetable).
+  - The map arity is the frame-targeted read; the same map-arity errors as `registrations` apply (`:rf.error/registrar-query-needs-frame`, `:rf.error/frame-no-generation`).
+  - App-db schemas are **not** a registrar kind — look them up via `(app-schema-meta-at path)` in [re-frame.schemas.md](re-frame.schemas.md).
 - **Example**:
   ```clojure
   (rf/handler-meta :sub :counter/value)
@@ -1298,7 +1388,7 @@ The registrar is the data structure that holds every registered handler — even
   (frame-ids)
   (frame-ids ns-prefix)
   ```
-- **Description**: "What frames exist?" Returns the set of all live (non-destroyed) frame ids. The optional prefix (a string) filters by namespace.
+- **Description**: Return the set of all live (non-destroyed) frame ids. The optional prefix (a string) filters by namespace.
 - **Example**:
   ```clojure
   (rf/frame-ids)              ;; => #{:rf/default :tenants/acme :tenants/globex}
@@ -1312,7 +1402,7 @@ The registrar is the data structure that holds every registered handler — even
   ```clojure
   (frame-meta frame-id)
   ```
-- **Description**: "What did `reg-frame` / `make-frame` stamp at this frame?" Returns the (post-preset-expansion) metadata map: `:fx-overrides`, `:interceptors`, `:ssr`, `:on-error`, schema bindings.
+- **Description**: What `reg-frame` / `make-frame` stamped at this frame. Returns the (post-preset-expansion) metadata map: `:fx-overrides`, `:interceptors`, `:ssr`, `:on-error`, schema bindings.
 - **Example**:
   ```clojure
   (rf/frame-meta :tenants/acme)
@@ -1327,7 +1417,7 @@ The registrar is the data structure that holds every registered handler — even
   ```clojure
   (app-db-value frame-id) → app-db value (plain map)
   ```
-- **Description**: "What's the current `app-db` value for this frame?" Returns the deref'd `app-db` map (a plain value, not the container) — `nil` for an unknown / destroyed frame. Accepts a frame-id keyword or a live frame object.
+- **Description**: Return the current `app-db` value for this frame — the deref'd `app-db` map (a plain value, not the container), or `nil` for an unknown / destroyed frame. Accepts a frame-id keyword or a live frame object.
 - **Example**:
   ```clojure
   (rf/app-db-value :rf/default)
@@ -1360,7 +1450,7 @@ The registrar is the data structure that holds every registered handler — even
   (snapshot-of path)
   (snapshot-of path opts)
   ```
-- **Description**: "What's at this path in `app-db` right now?" Convenience over `app-db-value` + `get-in`. Frame resolution: an explicit `(:frame opts)` override wins, else the scope/hold stamp.
+- **Description**: What is at this path in `app-db` right now. Convenience over `app-db-value` + `get-in`. Frame resolution: an explicit `(:frame opts)` override wins, else the scope/hold stamp.
 - **Example**:
   ```clojure
   (rf/snapshot-of [:user :id])          ;; => 7
@@ -1369,7 +1459,7 @@ The registrar is the data structure that holds every registered handler — even
 
 ## Feature registration (re-exports)
 
-These surfaces are re-exported on the `re-frame.core` facade for single-import ergonomics, but each is **defined in full — signature, metadata grammar, examples — in its feature namespace doc**. Each is a brief entry here; author against the linked doc. (Each feature's keyword surfaces — its `:fx` ids, standard events, and standard subs — also live in the feature doc.)
+These surfaces are re-exported on the `re-frame.core` facade for single-import ergonomics, but each is **defined in full — signature, metadata grammar, examples — in its feature namespace doc**. Entries here are brief; author against the linked doc. (Each feature's keyword surfaces — its `:fx` ids, standard events, and standard subs — also live in the feature doc.)
 
 ### Machines → [re-frame.machines.md](re-frame.machines.md)
 
@@ -1468,7 +1558,7 @@ Malli schemas attached to `app-db` paths; validated on writes in dev, elided in 
   (reg-app-schema path {:schema schema})
   (reg-app-schema path {:schema schema :frame frame})
   ```
-- "Attach this Malli schema to this `app-db` path." **Path is the registration id** — the only `reg-*` that is path-keyed rather than id-keyed. Full contract in [re-frame.schemas.md](re-frame.schemas.md).
+- Attach this Malli schema to this `app-db` path. **Path is the registration id** — the only `reg-*` that is path-keyed rather than id-keyed. Full contract in [re-frame.schemas.md](re-frame.schemas.md).
 
 #### `reg-app-schemas`
 
@@ -1580,7 +1670,7 @@ Managed HTTP is an optional capability: one fx-id (`[:rf.http/managed …]`), on
 
 ### Resources → [re-frame.resources.md](re-frame.resources.md)
 
-Resources are an optional, post-v1 capability (TanStack/RTK/SWR-style cached server-state reads, plus mutations) on the `re-frame.core` facade. The events and subscriptions are keyword-addressed (`[:rf.resource/ensure …]`, `[:rf.resource/refetch …]`, `[:rf.mutation/execute …]`, the passive `:rf.resource/*` / `:rf.mutation/*` subs, …) and live in the resources doc.
+Resources are an optional capability (cached server-state reads plus mutations) on the `re-frame.core` facade. The events and subscriptions are keyword-addressed (`[:rf.resource/ensure …]`, `[:rf.resource/refetch …]`, `[:rf.mutation/execute …]`, the passive `:rf.resource/*` / `:rf.mutation/*` subs, …) and live in the resources doc.
 
 #### `reg-resource`
 

--- a/docs/api/re-frame.epoch.md
+++ b/docs/api/re-frame.epoch.md
@@ -1,16 +1,16 @@
 # re-frame.epoch
 
-`re-frame.epoch` is the per-frame **epoch-history** surface — re-frame2's dev-only time-travel and post-mortem layer. The runtime records one `:rf/epoch-record` per dequeued event (at its run-to-completion boundary, not once per drain) into a per-frame ring buffer, capturing the before/after frame-state, the triggering event, and the harvested trace stream. Pair-shaped tools (Xray, re-frame2-pair, Story) read this history to time-travel (`restore-epoch!`), inject state directly (`replace-app-db!` and friends), observe assembled epochs (`register-epoch-listener!`), and project records safely across a process boundary (`projected-record`). The entire surface is gated on dev builds — production builds (`:advanced` + `goog.DEBUG=false`) elide it entirely, with no allocation, storage, or overhead.
+`re-frame.epoch` is the per-frame epoch-history surface: dev-only time-travel and post-mortem. On each dequeued event (at its run-to-completion boundary, not once per drain) the runtime records one `:rf/epoch-record` into a per-frame ring buffer, capturing before/after frame-state, the triggering event, and the harvested trace stream. Pair-shaped tools (Xray, re-frame2-pair, Story) read this history. Production builds (`:advanced` + `goog.DEBUG=false`) elide the whole surface — no allocation, storage, or overhead.
 
 ```clojure
 (:require [re-frame.epoch :as epoch])
 ```
 
-Most of this surface is also re-exported on the `re-frame.core` facade, so `rf/restore-epoch!` and `epoch/restore-epoch!` name the same function. The examples below use the `rf/` form for the re-exported names and the `epoch/` form for the epoch-only helpers (`clear-history!`, `current-config`, `clear-epoch-listeners!`, `configure!`). See [Observability](../core/concepts/observability.md) for how epochs fit the broader trace model.
+Most of this surface is re-exported on the `re-frame.core` facade, so `rf/restore-epoch!` and `epoch/restore-epoch!` name the same function. Examples below use the `rf/` form for re-exported names and the `epoch/` form for the epoch-only helpers (`clear-history!`, `current-config`, `clear-epoch-listeners!`, `configure!`). See [Observability](../core/concepts/observability.md) for how epochs fit the broader trace model.
 
 ## Epoch history
 
-Per-frame epoch snapshots, recorded on each dequeued event's run-to-completion in dev builds. Used by pair-shaped tools for time-travel and post-mortem analysis. **Production builds elide entirely.**
+Per-frame epoch snapshots, recorded on each dequeued event's run-to-completion in dev builds. Read by pair-shaped tools for time-travel and post-mortem. Production builds elide entirely.
 
 ### `epoch-history`
 
@@ -34,7 +34,7 @@ Per-frame epoch snapshots, recorded on each dequeued event's run-to-completion i
   ```clojure
   (clear-history!) → nil
   ```
-- **Description**: Drop every recorded epoch for every frame, and any in-flight per-frame capture buffer. Test fixtures use this so each fixture's drain observes a fresh capture state (a buffer left over from a previous fixture's mid-flight emit would otherwise be picked up by the next fixture's first run).
+- **Description**: Drops every recorded epoch for every frame, plus any in-flight per-frame capture buffer. Used by test fixtures so each fixture's drain starts from a fresh capture state (a leftover mid-flight buffer would otherwise be picked up by the next fixture's first run).
 
 ```clojure
 ;; Reset epoch state between test fixtures.
@@ -50,14 +50,16 @@ Per-frame epoch snapshots, recorded on each dequeued event's run-to-completion i
   ```clojure
   (restore-epoch! frame-id epoch-id) → boolean
   ```
-- **Description**: Restore the frame's whole **frame-state** — both the app-db and runtime-db partitions — to the named epoch's `:frame-state-after`, reinstalled in one atomic write (so machine snapshots, the route slice, and other runtime-db material rewind alongside app-db, not just the application slice). Emits `:rf.epoch/restored` on success. Returns `true` on success, `false` on any failure. Each failure is a no-op on the frame-state and emits a structured error trace:
-  - `:rf.error/no-such-handler` (kind `:frame`) — frame not registered / destroyed
-  - `:rf.epoch/restore-during-drain` — called while a drain is in flight
-  - `:rf.epoch/restore-unknown-epoch` — epoch-id not in the frame's current history
-  - `:rf.epoch/restore-non-ok-record` — target epoch's `:outcome` is not `:ok` (halted-cascade records carry partial state and are not valid restore targets)
-  - `:rf.epoch/restore-schema-mismatch` — the recorded app-db no longer validates against the frame's registered app-schemas
-  - `:rf.epoch/restore-missing-handler` — a machine / route referenced from the recorded runtime-db is no longer registered
-  - `:rf.epoch/restore-version-mismatch` — machine snapshot version drift against the current definition
+- **Description**: Restores the frame's whole frame-state — both app-db and runtime-db partitions — to the named epoch's `:frame-state-after`, in one atomic write. Machine snapshots, the route slice, and other runtime-db material rewind alongside app-db, not just the application slice.
+  - Returns `true` on success and emits `:rf.epoch/restored`.
+  - Returns `false` on any failure; each failure is a no-op on frame-state and emits a structured error trace:
+    - `:rf.error/no-such-handler` (kind `:frame`) — frame not registered / destroyed
+    - `:rf.epoch/restore-during-drain` — called while a drain is in flight
+    - `:rf.epoch/restore-unknown-epoch` — epoch-id not in the frame's current history
+    - `:rf.epoch/restore-non-ok-record` — target epoch's `:outcome` is not `:ok` (halted-cascade records carry partial state and are not valid restore targets)
+    - `:rf.epoch/restore-schema-mismatch` — the recorded app-db no longer validates against the frame's registered app-schemas
+    - `:rf.epoch/restore-missing-handler` — a machine / route referenced from the recorded runtime-db is no longer registered
+    - `:rf.epoch/restore-version-mismatch` — machine snapshot version drift against the current definition
 
 ```clojure
 ;; Time-travel: rewind a frame's whole frame-state to a recorded epoch.
@@ -67,7 +69,7 @@ Per-frame epoch snapshots, recorded on each dequeued event's run-to-completion i
 
 ## Pair-tool writes
 
-State-injection surfaces that replace a frame's partitions directly, bypassing the dispatch loop. Each records a synthetic `:rf/epoch-record` (so `restore-epoch!` can rewind past the injection) and emits `:rf.epoch/db-replaced` on success. All are dev-only — gated on dev builds; production builds elide them.
+State-injection surfaces that replace a frame's partitions directly, bypassing the dispatch loop. Each records a synthetic `:rf/epoch-record` (so `restore-epoch!` can rewind past the injection) and emits `:rf.epoch/db-replaced` on success. All are dev-only; production builds elide them.
 
 ### `replace-app-db!`
 
@@ -76,7 +78,11 @@ State-injection surfaces that replace a frame's partitions directly, bypassing t
   ```clojure
   (replace-app-db! frame-id new-db) → boolean
   ```
-- **Description**: Pair-tool write surface (state injection). Replace the frame's `app-db` partition with `new-db`, bypassing the dispatch loop; the runtime-db partition is preserved unchanged. No-ops returning `false` (each emitting a structured trace) on `:rf.error/no-such-handler` (frame not registered), `:rf.epoch/replace-during-drain`, `:rf.epoch/replace-schema-mismatch` (`new-db` fails the frame's registered app-schema set), and `:rf.epoch/replace-history-disabled` (ring disabled at depth 0, so the synthetic undo-anchor cannot land). Returns `true` on success.
+- **Description**: Replaces the frame's `app-db` partition with `new-db`, bypassing the dispatch loop. The runtime-db partition is preserved unchanged. Returns `true` on success. No-ops returning `false` (each emitting a structured trace) on:
+  - `:rf.error/no-such-handler` — frame not registered
+  - `:rf.epoch/replace-during-drain`
+  - `:rf.epoch/replace-schema-mismatch` — `new-db` fails the frame's registered app-schema set
+  - `:rf.epoch/replace-history-disabled` — ring disabled at depth 0, so the synthetic undo-anchor cannot land
 
 ```clojure
 ;; State injection — direct app-db write (bypasses the pipeline).
@@ -90,7 +96,7 @@ State-injection surfaces that replace a frame's partitions directly, bypassing t
   ```clojure
   (reset-app-db! frame-id) → boolean
   ```
-- **Description**: Reset the frame's `app-db` partition to `{}`, bypassing the dispatch loop, while preserving live runtime-db (machines / routes / elision / SSR survive). The app-db-only sibling of the whole-frame `reset-frame!`; a thin wrapper over `replace-app-db!` with the empty map, so it shares the same synthetic-epoch recording, gating, and failure modes. Returns `true` on success, `false` on any failure.
+- **Description**: Resets the frame's `app-db` partition to `{}`, bypassing the dispatch loop, preserving live runtime-db (machines / routes / elision / SSR survive). The app-db-only sibling of the whole-frame `reset-frame!`. A thin wrapper over `replace-app-db!` with the empty map, sharing its synthetic-epoch recording, gating, and failure modes. Returns `true` on success, `false` on any failure.
 
 ```clojure
 ;; Clear the application slice, keeping machines / routes alive.
@@ -104,7 +110,11 @@ State-injection surfaces that replace a frame's partitions directly, bypassing t
   ```clojure
   (replace-runtime-db! frame-id new-runtime-db) → boolean
   ```
-- **Description**: The runtime-db sibling of `replace-app-db!` — replace the frame's `runtime-db` partition (the framework-owned subsystem state: machine snapshots, route slice, elision declarations, SSR metadata), bypassing the dispatch loop; the app-db partition is preserved unchanged. No-ops returning `false` (each emitting a structured trace) on `:rf.error/no-such-handler` (frame not registered), `:rf.epoch/replace-during-drain`, `:rf.epoch/replace-schema-mismatch` (fails the framework-owned runtime-db validator), and `:rf.epoch/replace-history-disabled` (ring disabled at depth 0, so the synthetic undo-anchor cannot land). Returns `true` on success.
+- **Description**: The runtime-db sibling of `replace-app-db!`. Replaces the frame's `runtime-db` partition (framework-owned subsystem state: machine snapshots, route slice, elision declarations, SSR metadata), bypassing the dispatch loop. The app-db partition is preserved unchanged. Returns `true` on success. No-ops returning `false` (each emitting a structured trace) on:
+  - `:rf.error/no-such-handler` — frame not registered
+  - `:rf.epoch/replace-during-drain`
+  - `:rf.epoch/replace-schema-mismatch` — fails the framework-owned runtime-db validator
+  - `:rf.epoch/replace-history-disabled` — ring disabled at depth 0, so the synthetic undo-anchor cannot land
 
 ```clojure
 ;; Inject framework-owned subsystem state (runtime-db partition only).
@@ -118,7 +128,7 @@ State-injection surfaces that replace a frame's partitions directly, bypassing t
   ```clojure
   (replace-frame-state! frame-id new-frame-state) → boolean
   ```
-- **Description**: Replace **both** of the frame's partitions atomically with `new-frame-state` (`{:rf.db/app … :rf.db/runtime …}`), bypassing the dispatch loop — the full-frame install for tool-driven replay / fixture loading. A db-shaped name never silently replaces runtime-db, so this is the explicit whole-frame surface; a missing partition key installs `nil` for that partition (a full-frame replace is whole-value by contract). Same failure modes as `replace-runtime-db!` (`:rf.error/no-such-handler`, `:rf.epoch/replace-during-drain`, `:rf.epoch/replace-schema-mismatch`, `:rf.epoch/replace-history-disabled`). Returns `true` on success.
+- **Description**: Replaces both of the frame's partitions atomically with `new-frame-state` (`{:rf.db/app … :rf.db/runtime …}`), bypassing the dispatch loop — the full-frame install for tool-driven replay / fixture loading. This is the explicit whole-frame surface (a db-shaped name never silently replaces runtime-db). A missing partition key installs `nil` for that partition; a full-frame replace is whole-value by contract. Returns `true` on success. Same failure modes as `replace-runtime-db!`: `:rf.error/no-such-handler`, `:rf.epoch/replace-during-drain`, `:rf.epoch/replace-schema-mismatch`, `:rf.epoch/replace-history-disabled`.
 
 ```clojure
 ;; Full-frame install — both partitions at once.
@@ -134,7 +144,11 @@ State-injection surfaces that replace a frame's partitions directly, bypassing t
   ```clojure
   (register-epoch-listener! id callback-fn) → id
   ```
-- **Description**: Process-global assembled-epoch listener. `callback-fn` is invoked once per committed record with the fully-assembled **raw** `:rf/epoch-record`, after it lands in the frame's ring buffer; listeners receive every record regardless of `:outcome`. `id` may be any comparable value; registering the same `id` twice replaces. Listener exceptions are caught and isolated (emitting `:rf.epoch.cb/listener-exception`) — one broken listener cannot block others. When a frame a callback has observed is destroyed, a one-shot `:rf.epoch.cb/silenced-on-frame-destroy` trace is emitted for that callback. Returns the `id`.
+- **Description**: Registers a process-global assembled-epoch listener. Returns the `id`.
+  - `callback-fn` is invoked once per committed record with the fully-assembled raw `:rf/epoch-record`, after it lands in the frame's ring buffer. Listeners receive every record regardless of `:outcome`.
+  - `id` may be any comparable value; registering the same `id` twice replaces.
+  - Listener exceptions are caught and isolated (emitting `:rf.epoch.cb/listener-exception`) — one broken listener cannot block others.
+  - When a frame a callback has observed is destroyed, a one-shot `:rf.epoch.cb/silenced-on-frame-destroy` trace is emitted for that callback.
 
 ```clojure
 ;; Observe each assembled epoch as frames settle.
@@ -160,7 +174,7 @@ State-injection surfaces that replace a frame's partitions directly, bypassing t
   ```clojure
   (clear-epoch-listeners!) → nil
   ```
-- **Description**: Drop every registered epoch listener. Test fixtures use this to reset the process-global listener registry between runs.
+- **Description**: Drops every registered epoch listener. Used by test fixtures to reset the process-global listener registry between runs.
 
 ```clojure
 ;; Reset the listener registry between test fixtures.
@@ -169,7 +183,7 @@ State-injection surfaces that replace a frame's partitions directly, bypassing t
 
 ## Off-box egress projection
 
-Tools that forward epoch records across a process boundary (Xray-MCP `watch-epochs`, story / pair recorders, hosted post-mortem forwarders) **must** route through these helpers at the wire boundary. The on-box ring buffer and `register-epoch-listener!` fan-out always deliver the **raw** record so on-box devtools (Xray diff, REPL, `restore-epoch!`) can reason about exact state. See [keep secrets out of traces](../core/how-to/keep-secrets-out-of-traces.md) for the projection model.
+Tools that forward epoch records across a process boundary (Xray-MCP `watch-epochs`, story / pair recorders, hosted post-mortem forwarders) must route through these helpers at the wire boundary. The on-box ring buffer and `register-epoch-listener!` fan-out always deliver the raw record so on-box devtools (Xray diff, REPL, `restore-epoch!`) can reason about exact state. See [keep secrets out of traces](../core/how-to/keep-secrets-out-of-traces.md) for the projection model.
 
 ### `projected-record`
 
@@ -179,11 +193,11 @@ Tools that forward epoch records across a process boundary (Xray-MCP `watch-epoc
   (projected-record record)
   (projected-record record opts)
   ```
-- **Description**: Project an `:rf/epoch-record` for off-box egress — the single normative projection emission site for forwarding records across a process boundary. Routes the full-value payload slots (`:frame-state-before`, `:frame-state-after`, `:db-before`, `:db-after`, `:trace-events`) through the record-level egress boundary under a `:rf.egress/profile`, redacting sensitive paths to `:rf/redacted` and eliding large paths to `:rf.size/large-elided` markers. The frame-state `:rf.db/runtime` partition, the structured `:effects` `:args`, and the `:trigger-event` / trace-event args all fail closed (redacted) by default. `record` may be `nil` (returns `nil`). The 2-arity threads trusted-local egress `opts`; the **1-arity is the safe, fully-redacted off-box path**.
-  - **Profiles** (the primary `:rf.egress/profile` selector — answers *"which boundary is this?"*):
+- **Description**: Projects an `:rf/epoch-record` for off-box egress — the single normative projection emission site for forwarding records across a process boundary. Routes the full-value payload slots (`:frame-state-before`, `:frame-state-after`, `:db-before`, `:db-after`, `:trace-events`) through the record-level egress boundary under a `:rf.egress/profile`, redacting sensitive paths to `:rf/redacted` and eliding large paths to `:rf.size/large-elided` markers. The frame-state `:rf.db/runtime` partition, the structured `:effects` `:args`, and the `:trigger-event` / trace-event args all fail closed (redacted) by default. `record` may be `nil` (returns `nil`). The 2-arity threads trusted-local egress `opts`; the 1-arity is the safe, fully-redacted off-box path.
+  - **Profiles** (the primary `:rf.egress/profile` selector — *"which boundary is this?"*):
     - `:rf.egress/off-box-observability` (DEFAULT) — hosted monitoring / log shippers / Story / pair recorders (redact sensitive, elide large, omit structural digests).
     - `:rf.egress/off-box-tool` — the MCP / AI / tool wire. Same redact/elide defaults, but includes structural marker indicators (`:digest`) so a tool can reason about an elided large slot's shape. An unknown profile is rejected against the closed enum.
-  - The advanced per-call `:include-*` overrides (`:include-sensitive?` / `:include-large?` / `:include-runtime-db?` / `:include-fx-args?` / `:include-event-args?`, all default `false`) compose **over** the selected profile.
+  - The advanced per-call `:include-*` overrides (`:include-sensitive?` / `:include-large?` / `:include-runtime-db?` / `:include-fx-args?` / `:include-event-args?`, all default `false`) compose over the selected profile.
 
 ```clojure
 ;; Project an epoch record before forwarding it off-box (fully redacted).
@@ -200,7 +214,7 @@ Tools that forward epoch records across a process boundary (Xray-MCP `watch-epoc
   (projected-history frame-id)
   (projected-history frame-id opts)
   ```
-- **Description**: Convenience — return the projected vector of records for a frame. Equivalent to `(mapv #(projected-record % opts) (epoch-history frame-id))`. Tools that egress the whole ring (an MCP `watch-epochs` initial snapshot, a recorder dumping a full session) call this once rather than walking the raw ring and re-wrapping each record. The 2-arity threads the trusted-local egress `opts` to every record; the 1-arity is the safe, fully-redacted off-box path.
+- **Description**: Returns the projected vector of records for a frame. Equivalent to `(mapv #(projected-record % opts) (epoch-history frame-id))`. Tools that egress the whole ring (an MCP `watch-epochs` initial snapshot, a recorder dumping a full session) call this once rather than walking the raw ring and re-wrapping each record. The 2-arity threads the trusted-local egress `opts` to every record; the 1-arity is the safe, fully-redacted off-box path.
 
 ```clojure
 ;; Project the whole ring for off-box forwarding.
@@ -221,9 +235,10 @@ Tools that forward epoch records across a process boundary (Xray-MCP `watch-epoc
 - **Description**: Buffer-depth and redactor knobs for the epoch ring.
   - `:depth` — non-negative integer; per-frame ring-buffer depth (default 50). `0` disables recording.
   - `:trace-events-keep` — non-negative integer; caps how many of the most-recent records per frame retain their raw `:trace-events` vector (older records keep only the cheap structured `:sub-runs` / `:renders` / `:effects` projections). Defaults to 50 (matching the default `:depth`) so trace + epoch evict atomically; pass a smaller value to bound dev-session heap.
-  - `:redact-fn` — `fn?` or `nil`; the advanced projection-side override, invoked once per record at the off-box egress boundary inside `projected-record`, **never at storage time** (the ring buffer and every listener receive the raw record, since epoch records are causal replay material). A throwing fn emits `:rf.warning/epoch-redact-fn-exception` and falls back to the projected record. Passing `nil` clears any previously-installed fn.
+  - `:redact-fn` — `fn?` or `nil`; the advanced projection-side override, invoked once per record at the off-box egress boundary inside `projected-record`, never at storage time (the ring buffer and every listener receive the raw record, since epoch records are causal replay material). A throwing fn emits `:rf.warning/epoch-redact-fn-exception` and falls back to the projected record. `nil` clears any previously-installed fn.
+  - Invalid `:depth` / `:trace-events-keep` (not a non-negative integer) and a malformed `:redact-fn` (not `fn?` / `nil`) are silently dropped at the boundary.
 
-  Invalid `:depth` / `:trace-events-keep` (not a non-negative integer) and a malformed `:redact-fn` (not `fn?` / `nil`) are silently dropped at the boundary. Apps usually set this through `rf/configure!` with the `:epoch-history` key; see [re-frame.core.md](re-frame.core.md).
+  Apps usually set this through `rf/configure!` with the `:epoch-history` key; see [re-frame.core.md](re-frame.core.md).
 
 ```clojure
 ;; Shrink the ring and bound retained raw traces for a memory-conscious host.
@@ -237,7 +252,7 @@ Tools that forward epoch records across a process boundary (Xray-MCP `watch-epoc
   ```clojure
   (current-config) → config map
   ```
-- **Description**: Return the current epoch-history configuration map (`:depth` / `:trace-events-keep` / `:redact-fn`). Public for tests and tools that want to display the current depth.
+- **Description**: Returns the current epoch-history configuration map (`:depth` / `:trace-events-keep` / `:redact-fn`). Public for tests and tools that display the current depth.
 
 ```clojure
 ;; Inspect the live epoch-history configuration.
@@ -254,7 +269,14 @@ Tools that forward epoch records across a process boundary (Xray-MCP `watch-epoc
   (settle! frame-id frame-state-before frame-state-after committed-at)
   (settle! frame-id frame-state-before frame-state-after committed-at outcome halt-reason)
   ```
-- **Description**: The hook the router calls once per **dequeued event** — at each event's run-to-completion boundary, NOT once per drain. It harvests that event's trace buffer, assembles the `:rf/epoch-record` (deriving the `:db-before` / `:db-after` app-db projections from the whole-frame-state snapshots), appends it to the per-frame ring buffer, emits `:rf.epoch/snapshotted` with an `:outcome` tag plus its consumer-facing companion `:rf.epoch/outcome` (`:ok` / `:blocked` / `:error`), and fans out to every registered listener. A drain that processes a parent event and an `:fx [[:dispatch …]]` child it queued therefore commits **two** records (one per event); a machine macrostep stays one epoch. `committed-at` is the committing causal token's `:rf.cofx` `:rf/time-ms`, threaded down by the router (not an ambient assembly-time clock read), which keeps the record replayable. The 4-arity is the clean `:ok` settle (skipped when the captured buffer is empty); the 6-arity is the drain-boundary commit with an explicit outcome (`:ok` / `:halted-depth` / `:halted-destroy`). **Framework-internal** — the router invokes this; application and tool code never call it directly.
+- **Description**: The hook the router calls once per dequeued event — at each event's run-to-completion boundary, not once per drain. Framework-internal: the router invokes it; application and tool code never call it directly. Per call it:
+  - harvests that event's trace buffer;
+  - assembles the `:rf/epoch-record` (deriving the `:db-before` / `:db-after` app-db projections from the whole-frame-state snapshots);
+  - appends it to the per-frame ring buffer;
+  - emits `:rf.epoch/snapshotted` with an `:outcome` tag plus its consumer-facing companion `:rf.epoch/outcome` (`:ok` / `:blocked` / `:error`);
+  - fans out to every registered listener.
+
+  A drain that processes a parent event and an `:fx [[:dispatch …]]` child it queued commits two records (one per event); a machine macrostep stays one epoch. `committed-at` is the committing causal token's `:rf.cofx` `:rf/time-ms`, threaded down by the router (not an ambient assembly-time clock read), which keeps the record replayable. The 4-arity is the clean `:ok` settle (skipped when the captured buffer is empty); the 6-arity is the drain-boundary commit with an explicit outcome (`:ok` / `:halted-depth` / `:halted-destroy`).
 
 ```clojure
 ;; Framework-internal — the router invokes this through the :epoch/settle! late-bind hook.

--- a/docs/api/re-frame.flows.md
+++ b/docs/api/re-frame.flows.md
@@ -1,12 +1,21 @@
 # re-frame.flows
 
-A **flow** is a piece of *registered, named, observable, restorable* derived state. You declare its inputs (a vector of frame-state **paths** — not subs), a pure `:derive` computation over the values at those paths, and the `:output-path` in `app-db` it should write its output to; the runtime watches the input paths, recomputes the output whenever any of their values change, and writes the result. Inputs read either partition of the frame — a **bare** path reads `app-db` (the common case), and a path led by `:rf.db/runtime` reads `runtime-db` (route / machine state) — but outputs are always written to `app-db`. It is a sub-with-a-side-effect-on-`app-db`: useful exactly when you want derived state that other code reads via plain `get-in` (or a plain sub over the output path), without having to remember to recompute it manually. Flows replace v1's `on-changes` interceptor (same compute-on-input-change semantics, registered in the runtime rather than wired into individual events) and much of what `enrich` did — derived state is now a registered, observable thing, not a closure hidden behind an interceptor.
+A **flow** is registered, named, observable, restorable derived state materialised into `app-db`. You declare its `:inputs` (a vector of frame-state paths — not subs), a pure `:derive` computation over the values at those paths, and the `:output-path` in `app-db` to write to. The runtime watches the input paths, recomputes the output whenever any input value changes, and writes the result.
+
+Input paths read either partition of the frame:
+
+- A **bare** path reads `app-db` (the common case).
+- A path led by `:rf.db/runtime` reads `runtime-db` (route / machine state).
+
+Outputs are always written to `app-db`.
 
 ```clojure
 (:require [re-frame.flows :as flows])
 ```
 
-> **Note** — `reg-flow` is also exported from the `re-frame.core` facade, so the examples below register flows with `rf/reg-flow` (the conventional call site); `clear-flow`, the introspection accessors, and the test-support resets are called on the `flows` alias. The full `reg-flow` contract lives here.
+See [Flows: derived values your handlers can read](../core/concepts/flows.md) for the conceptual companion.
+
+> **Note** — `reg-flow` is also exported from the `re-frame.core` facade, so the examples below register with `rf/reg-flow` (the conventional call site). `clear-flow`, the introspection accessors, and the test-support resets are called on the `flows` alias. The full `reg-flow` contract lives here.
 
 ## Registering and clearing flows
 
@@ -17,7 +26,23 @@ A **flow** is a piece of *registered, named, observable, restorable* derived sta
   ```clojure
   (reg-flow flow-id metadata derive-fn)
   ```
-- **Description**: Register a flow, in the canonical 3-slot registration grammar: `flow-id` first, the pure `derive-fn` last, and `metadata` — the reflection-config map — in the middle carrying `:inputs`, `:output-path` (both required), plus optional `:doc` / `:schema` / the output-classification keys (`:sensitive` / `:large` / `:large?`) and the `:frame` mounting key (which selects the owning frame). Returns `flow-id` (per the `reg-*` return-value convention). Raises: `:rf.error/invalid-flow-metadata` (non-map metadata, or a `:derive` left inside the metadata map); `:rf.error/flow-missing-id` / `:rf.error/flow-bad-id` / `:rf.error/flow-bad-inputs` / `:rf.error/flow-bad-output` / `:rf.error/flow-bad-path` / `:rf.error/flow-bad-marks` (shape validation of the id, `:inputs`, `derive-fn`, `:output-path`, and classification keys); `:rf.error/no-frame-context` (no surrounding scope and no `:frame` key); `:rf.error/flow-frame-not-live` (the target frame is absent or destroyed); `:rf.error/flow-path-overlap` (the `:output-path` stands in a prefix relationship with a same-frame sibling's); `:rf.error/flow-cycle` (the registration would make the frame's dependency graph cyclic). A rejected registration mutates nothing — the prior definition, if any, survives.
+- **Description**: Register a flow. Returns `flow-id` (per the `reg-*` return-value convention). A rejected registration mutates nothing — the prior definition, if any, survives.
+
+  The 3-slot grammar is `flow-id` first, the pure `derive-fn` last, and `metadata` (the reflection-config map) in the middle. `metadata` carries:
+
+  - `:inputs` and `:output-path` — both **required**.
+  - `:doc` / `:schema` — optional.
+  - `:sensitive` / `:large` / `:large?` — optional output-classification keys.
+  - `:frame` — optional; selects the owning frame.
+
+  Raises:
+
+  - `:rf.error/invalid-flow-metadata` — non-map metadata, or a `:derive` left inside the metadata map.
+  - `:rf.error/flow-missing-id` / `:rf.error/flow-bad-id` / `:rf.error/flow-bad-inputs` / `:rf.error/flow-bad-output` / `:rf.error/flow-bad-path` / `:rf.error/flow-bad-marks` — shape validation of the id, `:inputs`, `derive-fn`, `:output-path`, and classification keys.
+  - `:rf.error/no-frame-context` — no surrounding scope and no `:frame` key.
+  - `:rf.error/flow-frame-not-live` — the target frame is absent or destroyed.
+  - `:rf.error/flow-path-overlap` — the `:output-path` stands in a prefix relationship with a same-frame sibling's.
+  - `:rf.error/flow-cycle` — the registration would make the frame's dependency graph cyclic.
 - **Example**:
   ```clojure
   (rf/reg-flow :cart/subtotal
@@ -35,7 +60,12 @@ A **flow** is a piece of *registered, named, observable, restorable* derived sta
   (clear-flow id)
   (clear-flow id opts)
   ```
-- **Description**: Deregister the flow from the named frame and `dissoc-in` its `:output-path` from that frame's `app-db` only (leaf-only removal — an emptied parent map is left in place). Sibling frames' state is preserved. The frame resolves from the `opts` `:frame` key (a frame-id keyword), else the surrounding scope; under no scope and no `:frame` it raises `:rf.error/no-frame-context`. A no-op when `id` is not registered against the frame. Returns `nil`.
+- **Description**: Deregister the flow from the named frame and `dissoc-in` its `:output-path` from that frame's `app-db` only. Returns `nil`.
+
+  - Leaf-only removal: an emptied parent map is left in place.
+  - Sibling frames' state is preserved.
+  - The frame resolves from the `opts` `:frame` key (a frame-id keyword), else the surrounding scope. Under no scope and no `:frame` it raises `:rf.error/no-frame-context`.
+  - A no-op when `id` is not registered against the frame.
 - **Example**:
   ```clojure
   ;; Deregister :cart/subtotal; clears [:cart :subtotal] in this frame's app-db.
@@ -70,7 +100,7 @@ read. Outputs stay `app-db`-only.
   (fn [route-id] (= route-id :checkout)))
 ```
 
-`:inputs` is a **positional vector** of frame-state paths; the values at those paths arrive as positional args to the `derive-fn` in the same order (a map-keyed `:inputs` form is a deferred design option, not v1). Each path reads against the pending frame-state's two partitions — a **bare** path reads `app-db`, and a path led by `:rf.db/runtime` reads `runtime-db`. The metadata slot is pure data — no fn registration with a separate id, no interceptor wiring, no closure capture. The conformance harness validates flows by walking the registered data and applying it to a synthesised frame-state.
+`:inputs` is a positional vector of frame-state paths; the values at those paths arrive as positional args to the `derive-fn` in the same order (a map-keyed `:inputs` form is a deferred design option, not v1). Each path reads against the pending frame-state's two partitions: a bare path reads `app-db`, a path led by `:rf.db/runtime` reads `runtime-db`. The metadata slot is pure data — no fn registration with a separate id, no interceptor wiring, no closure capture. The conformance harness validates flows by walking the registered data and applying it to a synthesised frame-state.
 
 | Slot / key | Required | Notes |
 |---|---|---|
@@ -80,14 +110,16 @@ read. Outputs stay `app-db`-only.
 | `:output-path` (metadata) | yes | Where to write the output in `app-db`. |
 | `:doc` (metadata) | no | One-sentence what-and-why; surfaces in tooling. |
 | `:frame` (metadata) | no | The frame the flow registers against (the override; else the surrounding `with-frame` scope). |
-| `:schema` (metadata) | no | Malli schema for the **output value**. Validated on every recompute in dev (and elided in production, like all schema validation). On failure the runtime emits `:rf.error/schema-validation-failure :where :flow-output` — **observational**: the output is still written (a flow output is materialised state downstream already reads), the trace surfaces the producer bug. Routes through the registered validator, so an app without the schemas artefact pays nothing. |
-| `:sensitive` (metadata) | no | Output data-classification: a vector of output subpaths (each a vector of scalar keys; `[]` marks the whole output) declared **sensitive**. Installed into the frame's elision registry rooted at `:output-path`, so trace and egress projections redact those slots. No input→output propagation — a flow classifies its own output only. Malformed values are rejected (`:rf.error/flow-bad-marks`); so are the retired `:sensitive?` boolean spelling and `:rf.egress/output-sensitivity`. |
-| `:large` (metadata) | no | Output data-classification: a vector of output subpaths (same shape as `:sensitive`) declared **large** for wire-size elision. Malformed values are rejected (`:rf.error/flow-bad-marks`). |
+| `:schema` (metadata) | no | Malli schema for the output value. Validated on every recompute in dev; elided in production, like all schema validation. On failure the runtime emits `:rf.error/schema-validation-failure :where :flow-output` — **observational**: the output is still written and the trace surfaces the producer bug. Routes through the registered validator, so an app without the schemas artefact pays nothing. |
+| `:sensitive` (metadata) | no | Output data-classification: a vector of output subpaths (each a vector of scalar keys; `[]` marks the whole output) declared sensitive. Installed into the frame's elision registry rooted at `:output-path`, so trace and egress projections redact those slots. No input→output propagation — a flow classifies its own output only. Malformed values are rejected (`:rf.error/flow-bad-marks`); so are the retired `:sensitive?` boolean spelling and `:rf.egress/output-sensitivity`. |
+| `:large` (metadata) | no | Output data-classification: a vector of output subpaths (same shape as `:sensitive`) declared large for wire-size elision. Malformed values are rejected (`:rf.error/flow-bad-marks`). |
 | `:large?` (metadata) | no | Boolean; `true` marks the whole output large. Non-boolean values are rejected (`:rf.error/flow-bad-marks`). |
 
 #### Frame-scoping
 
-Flows are **single-store**: the `:flow` registrar kind is RESERVED-but-empty (`reg-flow` does not write it). The same id can register against multiple frames with divergent definitions. For per-frame discovery read the encapsulated runtime registry via the public snapshot accessor `re-frame.flows/flows-snapshot` (it returns the `{frame-id {flow-id flow-map}}` shape) or the frame-scoped `re-frame.flows/flow-meta-at` — **not** the private registry atom, which is an implementation detail (in `re-frame.flows.registry`) behind the snapshot contract. The per-frame runtime registry is the source of truth for evaluation.
+Flows are single-store: the `:flow` registrar kind is reserved-but-empty (`reg-flow` does not write it). The same id can register against multiple frames with divergent definitions.
+
+For per-frame discovery, read the encapsulated runtime registry via the public snapshot accessor `re-frame.flows/flows-snapshot` (returns the `{frame-id {flow-id flow-map}}` shape) or the frame-scoped `re-frame.flows/flow-meta-at` — not the private registry atom (in `re-frame.flows.registry`), which is an implementation detail behind the snapshot contract. The per-frame runtime registry is the source of truth for evaluation.
 
 #### Frame-destroy teardown
 
@@ -95,14 +127,14 @@ Flows are **single-store**: the `:flow` registrar kind is RESERVED-but-empty (`r
 
 ## Keyword surfaces
 
-Sometimes you want to register or clear a flow from inside an event handler — feature-flag gates, demand-driven registration, the SSR per-request frame setting up flows for the request and tearing them down on response. Two reserved fx-ids cover that:
+Two reserved fx-ids register or clear a flow at runtime from inside an event handler:
 
 | `[fx-id args]` | Args | Status | Intuition |
 |---|---|---|---|
 | `[:rf.fx/reg-flow [flow-id metadata derive-fn]]` | the 3-slot triple (same shape as `reg-flow`) | v1 | Register a flow at runtime via `:fx`. The dispatching frame threads through as the `:frame` metadata key. |
 | `[:rf.fx/clear-flow id]` | flow id | v1 | Clear a registered flow at runtime via `:fx`. |
 
-The arguments mirror `reg-flow` / `clear-flow` exactly — the same 3-slot triple / flow id (an fx body's return value is not observable). When the flows artefact is not on the classpath both effects no-op. Use whichever surface matches your call site.
+The arguments mirror `reg-flow` / `clear-flow` exactly — the same 3-slot triple / flow id (an fx body's return value is not observable). When the flows artefact is not on the classpath both effects no-op.
 
 ```clojure
 ;; Clear a runtime-registered flow from inside a handler — e.g. disengaging a
@@ -116,9 +148,9 @@ The arguments mirror `reg-flow` / `clear-flow` exactly — the same 3-slot tripl
 
 > A flow registered with `:rf.fx/reg-flow` **does not compute its initial output during that event.** It first fires on the **next** drain on the same frame.
 
-This is the single least-obvious flow behaviour, so it is worth internalising before you reach for `:rf.fx/reg-flow`. The reason is structural: the `:fx` walk is the *last* drain stage, and it runs **after** the flow transform has already evaluated this event's flows. The newly-registered flow simply was not in the registry when the transform walked, so it has nothing to compute on *this* event. It computes on the next drain on that frame.
+The reason is structural: the `:fx` walk is the last drain stage, and it runs after the flow transform has already evaluated this event's flows. The newly-registered flow was not in the registry when the transform walked, so it has nothing to compute on this event. It computes on the next drain on that frame.
 
-In the common case the lag is invisible — you register a flow in an `:enter`-style handler and the user's next interaction materialises the output. When you genuinely need the initial value *now*, dispatch a follow-up no-op event from the same handler to re-trigger the drain (the flow is in the registry by the time that dispatched event drains):
+In the common case the lag is invisible — you register a flow in an `:enter`-style handler and the user's next interaction materialises the output. When you need the initial value now, dispatch a follow-up no-op event from the same handler to re-trigger the drain (the flow is in the registry by the time that dispatched event drains):
 
 ```clojure
 (rf/reg-event :wizard/enter-step-2
@@ -134,7 +166,7 @@ In the common case the lag is invisible — you register a flow in an `:enter`-s
 (rf/reg-event :wizard/settle (fn [{:keys [db]} _] {:db db}))   ;; no-op; exists only to drain
 ```
 
-This is an explicit step — not a hidden one — and most apps never need it. There is a one-event lag before a newly registered flow first computes, which preserves the one-install-per-event invariant.
+The one-event lag before a newly registered flow first computes preserves the one-install-per-event invariant.
 
 ## Introspection and tooling
 
@@ -147,7 +179,7 @@ Read-only views over the per-frame flow registry. They never touch the registrat
   ```clojure
   (flows-snapshot)
   ```
-- **Description**: Return the per-frame flow registry value: `{frame-id {flow-id flow-map}}`. This is the public seam for observing the registry shape — read it rather than dereferencing the private `flows` atom. Snapshot; observers must not mutate it.
+- **Description**: Return the per-frame flow registry value: `{frame-id {flow-id flow-map}}`. The public seam for observing the registry shape — read it rather than dereferencing the private `flows` atom. Snapshot; observers must not mutate it.
 - **Example**:
   ```clojure
   ;; Which flows are registered, and against which frames?
@@ -162,7 +194,12 @@ Read-only views over the per-frame flow registry. They never touch the registrat
   (flow-meta-at flow-id)
   (flow-meta-at flow-id opts)
   ```
-- **Description**: Return the registration metadata map for `flow-id` in a frame, or `nil` — the canonical per-frame flow introspection surface. Returns the full flow-map stamped at `reg-flow` (its source-coords `:ns` / `:line` / `:file`, `:inputs`, `:derive`, `:output-path`, and any output-classification keys). Frame-divergent by construction: the same `flow-id` registered against two frames returns each frame's own definition. The zero-`opts` arity resolves the frame from the carried-invariant scope (raising `:rf.error/no-frame-context` under no scope); `opts` is a map whose `:frame` names the frame target (a keyword id or frame value — the keyword sugar `(flow-meta-at flow-id frame-id)` is accepted).
+- **Description**: Return the registration metadata map for `flow-id` in a frame, or `nil` — the canonical per-frame flow introspection surface.
+
+  - Returns the full flow-map stamped at `reg-flow`: its source-coords `:ns` / `:line` / `:file`, `:inputs`, `:derive`, `:output-path`, and any output-classification keys.
+  - Frame-divergent by construction: the same `flow-id` registered against two frames returns each frame's own definition.
+  - The zero-`opts` arity resolves the frame from the carried-invariant scope (raising `:rf.error/no-frame-context` under no scope).
+  - `opts` is a map whose `:frame` names the frame target (a keyword id or frame value). The keyword sugar `(flow-meta-at flow-id frame-id)` is accepted.
 - **Example**:
   ```clojure
   ;; The :app frame's own definition of :cart/subtotal.
@@ -177,7 +214,11 @@ Read-only views over the per-frame flow registry. They never touch the registrat
   (flow-algebra-view)
   (flow-algebra-view frame-id)
   ```
-- **Description**: Return the static derivation-algebra view of every registered flow — each flow lowered into the normalized derivation-node shape so a tool can show subscriptions, flows, resources, route facts, and machine selectors as one family. Each node carries the flow's `:id`, `:kind` `:derivation`, `:source-form` `{:kind :reg-flow :id flow-id}`, declared `:inputs` (each lowered to `[:db path]` or `[:runtime …rest]`), `:output` `[:db <output-path>]`, the fixed `:storage` `:app-db` / `:evaluation` `:after-event` / `:lifecycle` `:frame` / `:materialized?` `true` classifications, `:owner` `[:frame frame-id]`, the opaque `:derive` token, and `:source` / `:schema` / `:doc` when present. Zero-arity returns `{frame-id {flow-id node}}`; the one-arity form returns `{flow-id node}` for a single frame. This is a JVM convenience alias; CLJS consumers call `re-frame.flows.tooling/flow-algebra-view` directly.
+- **Description**: Return the static derivation-algebra view of every registered flow — each flow lowered into the normalized derivation-node shape so a tool can show subscriptions, flows, resources, route facts, and machine selectors as one family.
+
+  Each node carries: the flow's `:id`; `:kind` `:derivation`; `:source-form` `{:kind :reg-flow :id flow-id}`; declared `:inputs` (each lowered to `[:db path]` or `[:runtime …rest]`); `:output` `[:db <output-path>]`; the fixed classifications `:storage` `:app-db` / `:evaluation` `:after-event` / `:lifecycle` `:frame` / `:materialized?` `true`; `:owner` `[:frame frame-id]`; the opaque `:derive` token; and `:source` / `:schema` / `:doc` when present.
+
+  Zero-arity returns `{frame-id {flow-id node}}`; the one-arity form returns `{flow-id node}` for a single frame. This is a JVM convenience alias; CLJS consumers call `re-frame.flows.tooling/flow-algebra-view` directly.
 
 ## Runtime and test-support internals
 
@@ -190,7 +231,12 @@ The flow-transform entry point the router installs, plus the test-fixture resets
   ```clojure
   (run-flows-on-db frame-id db runtime-db)
   ```
-- **Description**: The outermost-`:after` flow transform. Walks **this frame's** registered flows in topological order over the pending frame-state, dirty-checks each one, recomputes and `assoc-in`s the result into a transformed `app-db`, and returns the flow-augmented `app-db` value. `db` is the pending `app-db` partition; `runtime-db` the pending `runtime-db` partition (pass `nil` to resolve only bare `app-db` inputs). The router installs and calls this as the outermost `:after` interceptor — it fires last, against the chain's pending `:db` effect and before the `:db` install — so applications never call it. Flow outputs write `app-db` only. A flow `:derive` throw halts the walk (downstream flows do not run), rolls back the frame's dirty-check bookkeeping, and re-raises as `:rf.error/flow-eval-exception` (ex-data carries `:rf.flow/failed-id`); the router discards the pending `:db` effect, so the event aborts with no partial commit.
+- **Description**: The outermost-`:after` flow transform. Walks this frame's registered flows in topological order over the pending frame-state, dirty-checks each one, recomputes and `assoc-in`s the result into a transformed `app-db`, and returns the flow-augmented `app-db` value.
+
+  - `db` is the pending `app-db` partition; `runtime-db` the pending `runtime-db` partition (pass `nil` to resolve only bare `app-db` inputs).
+  - The router installs and calls this as the outermost `:after` interceptor — it fires last, against the chain's pending `:db` effect and before the `:db` install — so applications never call it.
+  - Flow outputs write `app-db` only.
+  - A flow `:derive` throw halts the walk (downstream flows do not run), rolls back the frame's dirty-check bookkeeping, and re-raises as `:rf.error/flow-eval-exception` (ex-data carries `:rf.flow/failed-id`). The router discards the pending `:db` effect, so the event aborts with no partial commit.
 
 ### `reset-flows!`
 
@@ -199,7 +245,7 @@ The flow-transform entry point the router installs, plus the test-fixture resets
   ```clojure
   (reset-flows!)
   ```
-- **Description**: Test-only. Clear the per-frame flow registry **and** the paired dirty-check `last-inputs` state (plus any pending abandoned-output-path moves), so a re-registration after a reset cannot silently no-op against a stale `=`-equal entry. Returns `nil`.
+- **Description**: Test-only. Clear the per-frame flow registry and the paired dirty-check `last-inputs` state (plus any pending abandoned-output-path moves), so a re-registration after a reset cannot silently no-op against a stale `=`-equal entry. Returns `nil`.
 
 ### `reset-last-inputs!`
 
@@ -208,18 +254,18 @@ The flow-transform entry point the router installs, plus the test-fixture resets
   ```clojure
   (reset-last-inputs!)
   ```
-- **Description**: Test-only. Clear **all** per-frame dirty-check `last-inputs` containers (dropping every frame's inner atom) while leaving the flow registry itself intact. Used by the reset-runtime fixture to drop stale per-flow input rows between tests. Returns `nil`.
+- **Description**: Test-only. Clear all per-frame dirty-check `last-inputs` containers (dropping every frame's inner atom) while leaving the flow registry itself intact. Used by the reset-runtime fixture to drop stale per-flow input rows between tests. Returns `nil`.
 
 ## Failure semantics
 
-**Production-survivable.** A throw inside a flow's `:derive` fn surfaces as `:rf.error/flow-eval-exception` on the **always-on error-emit substrate** — registered `register-error-listener!` callbacks fire under CLJS `:advanced` + `goog.DEBUG=false`. The error is *not* trace-only; production deployments catch it.
+**Production-survivable.** A throw inside a flow's `:derive` fn surfaces as `:rf.error/flow-eval-exception` on the always-on error-emit substrate — registered `register-error-listener!` callbacks fire under CLJS `:advanced` + `goog.DEBUG=false`. The error is not trace-only; production deployments catch it.
 
 See [Report errors in production](../core/how-to/report-errors-in-production.md) for wiring the always-on error listeners that catch these in a deployed app.
 
 ## Flow vs sub: when to reach for which
 
-- **Sub** when the value is computed *on read* and never written back to `app-db`. Cached; ref-counted; lazy.
-- **Flow** when the value should *live in `app-db`* — because other code reads it via path, other flows depend on it via path, or you want it captured by the epoch snapshot for time-travel.
+- **Sub** when the value is computed on read and never written back to `app-db`. Cached; ref-counted; lazy.
+- **Flow** when the value should live in `app-db` — because other code reads it via path, other flows depend on it via path, or you want it captured by the epoch snapshot for time-travel.
 
 A useful rule: if you find yourself writing `(reg-sub ::derived-total (fn [...]))` and immediately needing to read its value from a plain handler via `subscribe-once`, that's a flow. If you find yourself writing a flow that no path-shaped consumer ever reads (only sub-shaped ones do), it should probably be a sub.
 

--- a/docs/api/re-frame.http.md
+++ b/docs/api/re-frame.http.md
@@ -1,12 +1,16 @@
 # re-frame.http
 
-Managed HTTP is re-frame2's answer to "I want my app to talk to a server, but I don't want to write a custom fx-handler every time, and I want retries / cancellation / timeouts / decode / failure-classification to be the framework's problem, not mine." The `re-frame.http` namespace ships the verb-helper synthesis fns (`get`, `post`, `put`, `delete`, `patch`, `head`, `options`) that build the one canonical `[:rf.http/managed args-map]` fx; that fx, its abort/canned siblings, the request-interceptor middleware, and the test stubs are keyword-addressed or re-exported on the `re-frame.core` façade. Managed HTTP is an **optional capability** — implementations ship it (the CLJS reference does, on Fetch in the browser and `java.net.http.HttpClient` on the JVM); ports that omit it must not reuse the `:rf.http/*` namespace for anything else. If you're using the CLJS reference, you have it; if you're vendoring a port that doesn't, you're back to writing your own.
+Managed HTTP is an optional capability. An event dispatches the `[:rf.http/managed args-map]` fx and the implementation owns retries, cancellation, timeouts, decode, and failure classification. The `re-frame.http` namespace holds the verb-helper synthesis fns (`get`, `post`, `put`, `delete`, `patch`, `head`, `options`) that build that fx. The fx itself, its abort/canned siblings, the request-interceptor middleware, and the test stubs are keyword-addressed or re-exported on the `re-frame.core` façade.
+
+The CLJS reference ships managed HTTP (Fetch in the browser, `java.net.http.HttpClient` on the JVM). Ports that omit it must not reuse the `:rf.http/*` namespace for anything else.
+
+See [Managed HTTP — The request is a map](../async/http.md) for the teaching guide.
 
 ```clojure
 (:require [re-frame.http :as rf.http])
 ```
 
-The verb helpers live in `re-frame.http`; the `:rf.http/managed` fx is keyword-addressed (used in an event's `:fx`), and the interceptor + test-stub surfaces (`reg-http-interceptor`, `clear-http-interceptor`, `with-managed-request-stubs`) are re-exported on the `re-frame.core` façade — so the examples below also use `[re-frame.core :as rf]`. The namespace ships in `day8/re-frame2-http`, the same artefact as the fx itself, so loading the helpers and the fx is a single dep decision.
+The verb helpers live in `re-frame.http`. The `:rf.http/managed` fx is keyword-addressed (used in an event's `:fx`); the interceptor and test-stub fns (`reg-http-interceptor`, `clear-http-interceptor`, `with-managed-request-stubs`) are re-exported on the `re-frame.core` façade — so the examples below also `[re-frame.core :as rf]`. Everything ships in the `day8/re-frame2-http` artefact.
 
 ## Keyword surfaces — the managed-HTTP fx
 
@@ -14,7 +18,16 @@ The verb helpers live in `re-frame.http`; the `:rf.http/managed` fx is keyword-a
 
 - **Kind**: fx
 - **Args**: per [Managed HTTP — The request is a map](../async/http.md#the-request-is-a-map) and `:rf.fx/managed-args`
-- **Description**: The one fx-id. Args carry the request envelope (`:request` — `:url` required; a missing / nil / blank final URL raises `:rf.error/http-bad-request` at dispatch, after the `:before` chain runs), decode policy (`:decode`), accept fn (`:accept`), retry policy (`:retry {:on #{categories} :max-attempts N :backoff {:base-ms :factor :max-ms :jitter}}` — `:on` must be a set drawn from the retryable subset `#{:rf.http/transport :rf.http/cors :rf.http/timeout :rf.http/http-4xx :rf.http/http-5xx}`, else `:rf.error/http-bad-retry-on` at dispatch), per-attempt timeout (`:timeout-ms`, default 30000; explicit `nil` or `0` opts out), success / failure target events (`:on-success` / `:on-failure` — event vector or nil; any other value raises `:rf.error/http-bad-reply-target`), `:request-id` (for abort / supersede), optional `:abort-signal` (CLJS), and `:sensitive?` (see [Privacy and classification](#privacy-and-classification)).
+- **Description**: The one managed-HTTP fx-id. Keys in the args map:
+  - `:request` — the request envelope; `:url` is **required**. A missing / nil / blank final URL raises `:rf.error/http-bad-request` at dispatch, after the `:before` chain runs.
+  - `:decode` — decode policy.
+  - `:accept` — accept fn.
+  - `:retry` — `{:on #{categories} :max-attempts N :backoff {:base-ms :factor :max-ms :jitter}}`. `:on` must be a set drawn from the retryable subset `#{:rf.http/transport :rf.http/cors :rf.http/timeout :rf.http/http-4xx :rf.http/http-5xx}`, else `:rf.error/http-bad-retry-on` at dispatch.
+  - `:timeout-ms` — per-attempt timeout, default 30000; explicit `nil` or `0` opts out.
+  - `:on-success` / `:on-failure` — success / failure target events; event vector or nil. Any other value raises `:rf.error/http-bad-reply-target`.
+  - `:request-id` — for abort / supersede.
+  - `:abort-signal` — optional (CLJS).
+  - `:sensitive?` — see [Privacy and classification](#privacy-and-classification).
 
 ### `[:rf.http/managed-abort request-id]`
 
@@ -46,11 +59,11 @@ The verb helpers live in `re-frame.http`; the `:rf.http/managed` fx is keyword-a
   (fn [db _] (get-in db [:cart :items])))
 ```
 
-That's enough to issue a request, decode the JSON reply, and dispatch the result back. Retries, timeouts, schema validation, abort, decode customisation, accept-fn refinement — all of those are optional keys in the args map; you reach for them when the problem asks for them.
+Retries, timeouts, schema validation, abort, decode customisation, and accept-fn refinement are optional keys in the args map.
 
 ## Reply addressing
 
-Every reply is the one **canonical reply envelope** — a plain map keyed on a closed `:status`:
+Every reply is the one canonical reply envelope — a plain map keyed on a closed `:status`:
 
 ```clojure
 ;; Success
@@ -66,11 +79,18 @@ Every reply is the one **canonical reply envelope** — a plain map keyed on a c
  :error  {:kind :rf.http/aborted …}}
 ```
 
-Where that payload lands depends on how you addressed the reply. **`:on-success` / `:on-failure`** are pure routing sugar — both receive the **identical envelope** appended as the last event-vector arg; your `:cart/loaded` handler sees `[:cart/loaded {:status :ok :value decoded-body …}]` and destructures it directly (`[_ {:keys [value]}]` for success, `[_ {:keys [error]}]` for failure). **Default (co-located) addressing** — omit both targets — instead merges the same envelope under `:rf/reply` into the originating message and re-dispatches `[<originating-event-id> (assoc original-msg :rf/reply ...)]` back to the same handler, which reads it at `:rf/reply` and branches on `(:status reply)`. The `:rf/reply` wrapper is the co-located form only; explicit targets get the bare envelope. An explicit `:on-success nil` / `:on-failure nil` **silences** that side — no reply dispatch. Any other non-vector value for either key raises `:rf.error/http-bad-reply-target`. Both shapes detailed in [Managed HTTP — Handling the reply](../async/http.md#handling-the-reply).
+Where the payload lands depends on how the reply was addressed:
+
+- **Explicit `:on-success` / `:on-failure`** — pure routing sugar. Both receive the identical envelope appended as the last event-vector arg. A `:cart/loaded` handler sees `[:cart/loaded {:status :ok :value decoded-body …}]` and destructures it directly (`[_ {:keys [value]}]` for success, `[_ {:keys [error]}]` for failure).
+- **Default (co-located) addressing** — omit both targets. The same envelope is merged under `:rf/reply` into the originating message and re-dispatched as `[<originating-event-id> (assoc original-msg :rf/reply ...)]` back to the same handler, which reads it at `:rf/reply` and branches on `(:status reply)`. The `:rf/reply` wrapper is the co-located form only; explicit targets get the bare envelope.
+- **`:on-success nil` / `:on-failure nil`** — silences that side; no reply dispatch.
+- Any other non-vector value for either key raises `:rf.error/http-bad-reply-target`.
+
+Both shapes detailed in [Managed HTTP — Handling the reply](../async/http.md#handling-the-reply).
 
 ## Failure categories (closed set)
 
-Eight failure `:kind` values, all reserved under `:rf.http/*`. The set is closed — ports that ship managed HTTP deliver exactly these eight categories, and your handler's failure switch can be exhaustive.
+Eight failure `:kind` values, all reserved under `:rf.http/*`. The set is closed, so a handler's failure switch can be exhaustive.
 
 | `:kind` | Meaning |
 |---|---|
@@ -87,7 +107,7 @@ See [Managed HTTP — Failures are a closed set](../async/http.md#failures-are-a
 
 ## Verb helpers
 
-Call-site helpers for the common shapes. They're pure synthesis fns that produce the canonical `[:rf.http/managed args-map]` fx vector — no magic, no hidden state. The point is ergonomics: writing `(rf.http/get "/api/cart")` reads better at the call site than spelling out the full args map for a no-frills GET.
+Call-site helpers that synthesise the canonical `[:rf.http/managed args-map]` fx vector. Pure; no side effect — drop the result into `:fx`.
 
 ### `get`
 
@@ -97,7 +117,7 @@ Call-site helpers for the common shapes. They're pure synthesis fns that produce
   (rf.http/get url)
   (rf.http/get url args)
   ```
-- **Description**: "Synthesise a GET fx vector." Pure; no side effect — drop the result into `:fx`. `args` merges top-level into the canonical args map (caller wins) except `:request`, which merges with `{:method :get :url url}` — the helper's `:method` and `:url` overwrite caller-supplied ones. Same merge contract for all seven helpers.
+- **Description**: Synthesise a GET fx vector. `args` merges top-level into the canonical args map (caller wins) except `:request`, which merges with `{:method :get :url url}` — the helper's `:method` and `:url` overwrite caller-supplied ones. All seven helpers share this merge contract.
 
 ### `post`
 
@@ -194,7 +214,7 @@ Call-site helpers for the common shapes. They're pure synthesis fns that produce
   {:fx [(rf.http/options "/api/items")]}
   ```
 
-The verb helpers live in `re-frame.http` — users `(:require [re-frame.http :as rf.http])` alongside `re-frame.core`. The namespace ships in `day8/re-frame2-http`, the same artefact as the fx itself, so loading the helpers and the fx is a single dep decision.
+The verb helpers require `[re-frame.http :as rf.http]` alongside `re-frame.core`; the namespace ships in the `day8/re-frame2-http` artefact, the same one as the fx.
 
 ```clojure
 {:fx [(rf.http/get "/api/cart"
@@ -207,7 +227,7 @@ The verb helpers live in `re-frame.http` — users `(:require [re-frame.http :as
 
 ## Request-interceptor middleware
 
-Sometimes you want to inject behaviour into every request — adding an auth header, stamping a request ID, logging. Re-frame2's answer is a small middleware surface that mirrors the rest of the `reg-*` family. The fn forms (`reg-http-interceptor`, `clear-http-interceptor`) are re-exported on the `re-frame.core` façade — a façade call with `day8/re-frame2-http` absent raises `:rf.error/http-artefact-missing`; the data-shaped `:rf.fx/*` siblings below are keyword-addressed.
+A middleware surface that mirrors the rest of the `reg-*` family, for injecting behaviour into every request (auth header, request-id stamp, logging). The fn forms (`reg-http-interceptor`, `clear-http-interceptor`) are re-exported on the `re-frame.core` façade — a façade call with `day8/re-frame2-http` absent raises `:rf.error/http-artefact-missing`. The data-shaped `:rf.fx/*` siblings below are keyword-addressed.
 
 ### `reg-http-interceptor`
 
@@ -216,7 +236,12 @@ Sometimes you want to inject behaviour into every request — adding an auth hea
   ```clojure
   (reg-http-interceptor id interceptor-map)
   ```
-- **Description**: Register an HTTP interceptor on a frame's `:rf.http/managed` middleware chain. `interceptor-map` carries at least one of `:before (fn [ctx] ctx')` (request-side) and `:after (fn [ctx response] response')` (response-side), plus optional `:frame` (the explicit-frame *override*) and the standard `:rf/registration-metadata`. The target frame is the explicit `:frame`, else the carried scope it registers under (`with-frame` / an `:initial-events` step); registering under **no** scope raises `:rf.error/no-frame-context` — there is no `:rf/default` default. An invalid shape (non-keyword id, neither `:before` nor `:after`, a non-fn slot, a non-keyword `:frame`) raises `:rf.error/http-bad-interceptor`. Re-registering an existing id replaces the slot in place (position preserved); after a `clear-http-interceptor`, re-registering the same id appends to the end of the chain. Returns `id`. The `:before` chain runs in registration order; the `:after` chain runs in REVERSE registration order; `:after` sees the SAME ctx the `:before` chain produced (request-correlated handling).
+- **Description**: Register an HTTP interceptor on a frame's `:rf.http/managed` middleware chain. Returns `id`.
+  - `interceptor-map` carries at least one of `:before (fn [ctx] ctx')` (request-side) and `:after (fn [ctx response] response')` (response-side), plus optional `:frame` (explicit-frame override) and the standard `:rf/registration-metadata`.
+  - Target frame is the explicit `:frame`, else the carried scope it registers under (`with-frame` / an `:initial-events` step). Registering under **no** scope raises `:rf.error/no-frame-context` — there is no `:rf/default` default.
+  - An invalid shape (non-keyword id, neither `:before` nor `:after`, a non-fn slot, a non-keyword `:frame`) raises `:rf.error/http-bad-interceptor`.
+  - Re-registering an existing id replaces the slot in place (position preserved); after a `clear-http-interceptor`, re-registering the same id appends to the end of the chain.
+  - The `:before` chain runs in registration order; the `:after` chain runs in reverse registration order. `:after` sees the same ctx the `:before` chain produced (request-correlated handling).
 
 ### `clear-http-interceptor`
 
@@ -226,7 +251,11 @@ Sometimes you want to inject behaviour into every request — adding an auth hea
   (clear-http-interceptor id)
   (clear-http-interceptor id {:frame target})
   ```
-- **Description**: Unregister an interceptor by id. The single-arity `(clear-http-interceptor id)` resolves the frame from the carried scope it runs under; the opts form `(clear-http-interceptor id {:frame target})` names the frame explicitly — the trailing `{:frame …}` opts map, mirroring `reg-http-interceptor`'s `:frame` and the family's public-frame-targeting law (never a positional frame arg on a public surface). Either form raises `:rf.error/no-frame-context` when the frame is absent (single-arity under no scope, or opts `{:frame nil}`) — it never clears against a synthesised `:rf/default`. The 2-arity is shape-discriminated on the second arg: an opts map is the public form; a bare frame target first is the *internal* frame-first `(frame id)` plumbing.
+- **Description**: Unregister an interceptor by id.
+  - `(clear-http-interceptor id)` resolves the frame from the carried scope it runs under.
+  - `(clear-http-interceptor id {:frame target})` names the frame explicitly via the trailing opts map, mirroring `reg-http-interceptor`'s `:frame` and the family's public-frame-targeting law (never a positional frame arg on a public surface).
+  - Either form raises `:rf.error/no-frame-context` when the frame is absent (single-arity under no scope, or opts `{:frame nil}`); it never clears against a synthesised `:rf/default`.
+  - The 2-arity is shape-discriminated on the second arg: an opts map is the public form; a bare frame target first is the internal frame-first `(frame id)` plumbing.
 - **Example**:
   ```clojure
   (rf/clear-http-interceptor :auth-header)
@@ -236,7 +265,7 @@ Sometimes you want to inject behaviour into every request — adding an auth hea
 
 - **Kind**: fx
 - **Args**: `{:id <kw> :before <fn>? :after <fn>? :frame <id>? ...}` — `:id` plus the same interceptor-map slots as the fn form, including `:rf/registration-metadata`
-- **Description**: Data-shaped sibling of `reg-http-interceptor` for callers that drive registration through the dispatch surface (EDN conformance fixtures, boot event handlers). The fx body splits `:id` off and passes the remaining map to the fn form; when the args omit `:frame`, the fx-context frame (the cascade envelope stamp) is threaded in. Registered at load of `re-frame.http.managed`; dev+prod.
+- **Description**: Data-shaped sibling of `reg-http-interceptor` for callers driving registration through the dispatch surface (EDN conformance fixtures, boot event handlers). The fx body splits `:id` off and passes the remaining map to the fn form; when the args omit `:frame`, the fx-context frame (the cascade envelope stamp) is threaded in. Registered at load of `re-frame.http.managed`; dev+prod.
 - **Example**:
   ```clojure
   {:fx [[:rf.fx/reg-http-interceptor
@@ -267,16 +296,20 @@ Sometimes you want to inject behaviour into every request — adding an auth hea
              (assoc resp :elapsed-ms (- (js/Date.now) (::started ctx))))})
 ```
 
-The `:before` runs before the request is dispatched to the platform's HTTP client; the `:after` runs after the response is built and BEFORE `:on-success` / `:on-failure` fire. If either throws, the corresponding side is not delivered (request: not dispatched; response: reply suppressed) and `:rf.error/http-interceptor-failed` fires with `:frame`, `:interceptor-id`, `:url`, and `:cause` (`:phase :after` is stamped on the response side; absent for `:before`). See [Managed HTTP — Interceptors](../async/http-going-further.md#interceptors-stamp-every-request-once).
+`:before` runs before the request is dispatched to the platform's HTTP client; `:after` runs after the response is built and before `:on-success` / `:on-failure` fire. If either throws, the corresponding side is not delivered (request: not dispatched; response: reply suppressed) and `:rf.error/http-interceptor-failed` fires with `:frame`, `:interceptor-id`, `:url`, and `:cause` (`:phase :after` is stamped on the response side; absent for `:before`). See [Managed HTTP — Interceptors](../async/http-going-further.md#interceptors-stamp-every-request-once).
 
 ## Testing: stubbed responses
 
-Tests want to drive the pipeline without hitting the network. The test-support surface provides canned-reply fx and a stubbing macro that reroutes requests at the routes you name. The ergonomic `with-managed-request-stubs` macro is re-exported on the `re-frame.core` façade; the raw `install` / `uninstall` pair is reached only through the home namespace `re-frame.http.test-support`.
+Test-support surface for driving the pipeline without the network: canned-reply fx plus a stubbing macro that reroutes requests at named routes. The `with-managed-request-stubs` macro is re-exported on the `re-frame.core` façade; the raw `install` / `uninstall` pair is reached only through the home namespace `re-frame.http.test-support`.
 
 ### `[:rf.http/managed-canned-success {:value v}]`
 
 - **Kind**: fx
-- **Description**: Synthesise the canonical success reply (`{:status :ok :value v}`) directly into `:fx`. Useful for "stub THIS request inline" patterns. `:value` defaults to `{:stubbed true}` when absent. Optional `:after-ms` — a positive value defers the reply via a `:dispatch-later` tick; absent / `0` / non-positive delivers immediately. Runs the frame's `:before` and `:after` interceptor chains around the synthesised reply, exactly like the real transport path; reply addressing (`:on-success` / default co-located) applies as for `:rf.http/managed`. Registered at load of `re-frame.http.test-support`.
+- **Description**: Synthesise the canonical success reply (`{:status :ok :value v}`) directly into `:fx`, for inline "stub THIS request" patterns.
+  - `:value` defaults to `{:stubbed true}` when absent.
+  - `:after-ms` (optional) — a positive value defers the reply via a `:dispatch-later` tick; absent / `0` / non-positive delivers immediately.
+  - Runs the frame's `:before` and `:after` interceptor chains around the synthesised reply, exactly like the real transport path; reply addressing (`:on-success` / default co-located) applies as for `:rf.http/managed`.
+  - Registered at load of `re-frame.http.test-support`.
 - **Example**:
   ```clojure
   (rf/reg-event :counter/retry-recover
@@ -290,7 +323,11 @@ Tests want to drive the pipeline without hitting the network. The test-support s
 ### `[:rf.http/managed-canned-failure {:kind <:rf.http/*> :tags {...}}]`
 
 - **Kind**: fx
-- **Description**: Synthesise the canonical failure reply directly into `:fx`. `:kind` defaults to `:rf.http/transport`; `:tags` merge into the `:error` map. An `:rf.http/aborted` kind yields `:status :cancelled`; every other kind `:status :error`. Supports the same optional `:after-ms` deferral, interceptor-chain behaviour, and reply addressing (`:on-failure` / default co-located) as `:rf.http/managed-canned-success`. Registered at load of `re-frame.http.test-support`.
+- **Description**: Synthesise the canonical failure reply directly into `:fx`.
+  - `:kind` defaults to `:rf.http/transport`; `:tags` merge into the `:error` map.
+  - An `:rf.http/aborted` kind yields `:status :cancelled`; every other kind `:status :error`.
+  - Supports the same optional `:after-ms` deferral, interceptor-chain behaviour, and reply addressing (`:on-failure` / default co-located) as `:rf.http/managed-canned-success`.
+  - Registered at load of `re-frame.http.test-support`.
 - **Example**:
   ```clojure
   (rf/reg-event :flaky/load
@@ -308,7 +345,11 @@ Tests want to drive the pipeline without hitting the network. The test-support s
   ```clojure
   (with-managed-request-stubs route-map body+)
   ```
-- **Description**: Lexical-scope stubbing. `route-map` is `{[<method> <url>] {:reply {:ok <value>}}}` (success) or `{[<method> <url>] {:reply {:failure <failure-map>}}}` (failure). Inside the body, requests matching a stubbed route bypass the real client — the helper registers a per-scope stub fx (a process-unique `:rf.http/managed-test-stub-<n>` id, so nested scopes compose) and installs the matching `:rf.http/managed` override for the body's dynamic extent, so plain `dispatch-sync` calls auto-route by method + URL with NO manual `:fx-overrides`; a per-call `:fx-overrides` still wins. Routes are matched against the post-`:before` request (the method + URL the pipeline would actually issue); a request with no matching route receives a synthesised `:rf.http/transport` failure reply. The façade macro requires `re-frame.http.test-support` in the require closure — without it the call raises `:rf.error/http-artefact-missing`.
+- **Description**: Lexical-scope stubbing.
+  - `route-map` is `{[<method> <url>] {:reply {:ok <value>}}}` (success) or `{[<method> <url>] {:reply {:failure <failure-map>}}}` (failure).
+  - Inside the body, requests matching a stubbed route bypass the real client: the helper registers a per-scope stub fx (a process-unique `:rf.http/managed-test-stub-<n>` id, so nested scopes compose) and installs the matching `:rf.http/managed` override for the body's dynamic extent. Plain `dispatch-sync` calls auto-route by method + URL with no manual `:fx-overrides`; a per-call `:fx-overrides` still wins.
+  - Routes match against the post-`:before` request (the method + URL the pipeline would actually issue). A request with no matching route receives a synthesised `:rf.http/transport` failure reply.
+  - The façade macro requires `re-frame.http.test-support` in the require closure — without it the call raises `:rf.error/http-artefact-missing`.
 
 ### `with-managed-request-stubs*`
 
@@ -317,7 +358,7 @@ Tests want to drive the pipeline without hitting the network. The test-support s
   ```clojure
   (with-managed-request-stubs* route-map body-fn)
   ```
-- **Description**: Plain-fn surface beneath the macro. Use for computed route-maps or non-literal bodies. Like the macro, it installs the `:rf.http/managed` override for `body-fn`'s dynamic extent, so dispatches inside auto-route with no manual `:fx-overrides`.
+- **Description**: Plain-fn surface beneath the macro, for computed route-maps or non-literal bodies. Like the macro, it installs the `:rf.http/managed` override for `body-fn`'s dynamic extent, so dispatches inside auto-route with no manual `:fx-overrides`.
 - **Example**:
   ```clojure
   ;; Computed route-map / non-literal body — use the fn form.
@@ -335,7 +376,10 @@ Tests want to drive the pipeline without hitting the network. The test-support s
   ```clojure
   (install-managed-request-stubs! route-map)
   ```
-- **Description**: Lower-level than `with-managed-request-stubs`: registers the `:rf.http/managed-test-stub` fx (the stable, documented `:fx-overrides` target) that persists until `uninstall-managed-request-stubs!`. Use when stubs span multiple `deftest`s. Unlike the wrapper, this does NOT install the `:rf.http/managed` override — dispatch with `{:fx-overrides {:rf.http/managed :rf.http/managed-test-stub}}` (or wrap dispatches in `with-fx-overrides`) to route through it. Nested installs snapshot the prior handler and restore it on uninstall (LIFO). Returns the stub fx-id. **Not a `re-frame.core` façade export** — call it through its home namespace `re-frame.http.test-support`.
+- **Description**: Lower-level than `with-managed-request-stubs`; use when stubs span multiple `deftest`s. Registers the `:rf.http/managed-test-stub` fx (the stable, documented `:fx-overrides` target) that persists until `uninstall-managed-request-stubs!`. Returns the stub fx-id.
+  - Unlike the wrapper, this does **not** install the `:rf.http/managed` override — dispatch with `{:fx-overrides {:rf.http/managed :rf.http/managed-test-stub}}` (or wrap dispatches in `with-fx-overrides`) to route through it.
+  - Nested installs snapshot the prior handler and restore it on uninstall (LIFO).
+  - Not a `re-frame.core` façade export — call it through its home namespace `re-frame.http.test-support`.
 - **Example**:
   ```clojure
   ;; Stubs that span several deftests — install once, route via :fx-overrides.
@@ -353,13 +397,13 @@ Tests want to drive the pipeline without hitting the network. The test-support s
   ```clojure
   (uninstall-managed-request-stubs!)
   ```
-- **Description**: Tear down the most recent install: restores the previously installed stub handler when installs were nested (LIFO), else clears the stub fx and restores real-request routing. Idempotent — a teardown without a matching install is a safe no-op. **Not a `re-frame.core` façade export** — call it through its home namespace `re-frame.http.test-support`.
+- **Description**: Tear down the most recent install: restores the previously installed stub handler when installs were nested (LIFO), else clears the stub fx and restores real-request routing. Idempotent — a teardown without a matching install is a safe no-op. Not a `re-frame.core` façade export — call it through its home namespace `re-frame.http.test-support`.
 - **Example**:
   ```clojure
   (re-frame.http.test-support/uninstall-managed-request-stubs!)
   ```
 
-All the test-support surfaces live in `re-frame.http.test-support`. One namespace; same artefact (`day8/re-frame2-http`) as the production code.
+All test-support surfaces live in `re-frame.http.test-support` — one namespace, same artefact (`day8/re-frame2-http`) as the production code.
 
 ```clojure
 (deftest cart-loads
@@ -375,14 +419,14 @@ Handlers may declare `:rf.http/decode-schemas [<schema> ...]` in their `reg-even
 
 ## Privacy and classification
 
-HTTP is the canonical privacy surface in any app: passwords ride request bodies, auth tokens ride request headers, PII rides response bodies. The framework keeps these off its own observability wire — traces, off-box records, SSR payloads — without you writing a `beforeSend` scrub. Four declaration surfaces cooperate, none of them a process-global mutation. The conceptual walkthrough is [Managed HTTP — Keeping secrets out of the trace](../async/http-going-further.md#keeping-secrets-out-of-the-trace); the model end-to-end is [keep secrets out of traces](../core/how-to/keep-secrets-out-of-traces.md).
+HTTP carries secrets: passwords in request bodies, auth tokens in request headers, PII in response bodies. The framework keeps these off its own observability wire — traces, off-box records, SSR payloads. Four declaration surfaces cooperate, none of them a process-global mutation. See [Managed HTTP — Keeping secrets out of the trace](../async/http-going-further.md#keeping-secrets-out-of-the-trace) and [keep secrets out of traces](../core/how-to/keep-secrets-out-of-traces.md) for the model end-to-end.
 
 | Surface | What it covers | Where declared |
 |---|---|---|
-| **Built-in header denylist** | A closed, **immutable** set of always-sensitive header names (`Authorization`, `Cookie`, `Set-Cookie`, `X-API-Key`, `X-Auth-Token`, `X-CSRF-Token`, …). Redacted in every `:rf.http/*` trace's `:headers` slot regardless of any `:sensitive?` flag; case-insensitive. No frame can remove a name. | framework default |
-| **Built-in query-param denylist** | A closed, **immutable** set of always-sensitive query-param names (`api_key`, `access_token`, `token`, `secret`, `password`, `session`, `signature`, …). The **value** is redacted inline in `:url` slots (`?api_key=:rf/redacted&page=2`); name + position preserved. A hit also stamps `:sensitive? true` on the event — the name is the signal. | framework default |
-| **Managed-HTTP carriers** | App-specific sensitive header / query-param names, declared on the **`:rf.http/managed` `reg-fx` registration** (the transient-payload case). `:headers` is a vector of names (vector-only — header names always **union** onto the built-ins). `:query-params` is a vector of names (union) OR an `{:include […] :except […]}` policy map — effective policy `(defaults − except) ∪ include`; `:except` subtracts a built-in query-param default for this app's own dev trace. Names are case-insensitive; a malformed block fails loud. | `reg-fx :rf.http/managed` `:carriers {:headers […] :query-params […]}` |
-| **Per-request / per-call `:sensitive?`** | The coarse opt-in that redacts a single request's body / params / all URL param values wholesale. | the `:rf.http/managed` args map (`:sensitive?` at top level, or under `:request`) |
+| Built-in header denylist | A closed, **immutable** set of always-sensitive header names (`Authorization`, `Cookie`, `Set-Cookie`, `X-API-Key`, `X-Auth-Token`, `X-CSRF-Token`, …). Redacted in every `:rf.http/*` trace's `:headers` slot regardless of any `:sensitive?` flag; case-insensitive. No frame can remove a name. | framework default |
+| Built-in query-param denylist | A closed, **immutable** set of always-sensitive query-param names (`api_key`, `access_token`, `token`, `secret`, `password`, `session`, `signature`, …). The value is redacted inline in `:url` slots (`?api_key=:rf/redacted&page=2`); name + position preserved. A hit also stamps `:sensitive? true` on the event — the name is the signal. | framework default |
+| Managed-HTTP carriers | App-specific sensitive header / query-param names, declared on the `:rf.http/managed` `reg-fx` registration (the transient-payload case). `:headers` is a vector of names (vector-only — header names always union onto the built-ins). `:query-params` is a vector of names (union) OR an `{:include […] :except […]}` policy map — effective policy `(defaults − except) ∪ include`; `:except` subtracts a built-in query-param default for this app's own dev trace. Names are case-insensitive; a malformed block fails loud. | `reg-fx :rf.http/managed` `:carriers {:headers […] :query-params […]}` |
+| Per-request / per-call `:sensitive?` | The coarse opt-in that redacts a single request's body / params / all URL param values wholesale. | the `:rf.http/managed` args map (`:sensitive?` at top level, or under `:request`) |
 
 ```clojure
 ;; managed-HTTP carrier extensions (union onto the immutable built-ins)
@@ -406,11 +450,11 @@ HTTP is the canonical privacy surface in any app: passwords ride request bodies,
   ```clojure
   (managed-handler frame-ctx args-map)
   ```
-- **Description**: The `:rf.http/managed` fx handler body, re-exported so an app can RE-REGISTER `:rf.http/managed` to declare its `:carriers` block (as in the example above) without knowing the internal handler fn. Not called directly from app code — pass it to `reg-fx`.
+- **Description**: The `:rf.http/managed` fx handler body, re-exported so an app can re-register `:rf.http/managed` to declare its `:carriers` block (as in the example above) without knowing the internal handler fn. Not called directly from app code — pass it to `reg-fx`.
 
 ### Response-body classification — on the `:decode` schema
 
-The denylists and `:sensitive?` flag cover request carriers; the **response body** is a registration-owned transient payload, classified **per-slot via `:sensitive?` / `:large?` props on the request's `:decode` schema**. The `:decode` schema is the owner's natural declaration of the body shape, so per-slot props are the *one* route — there is no second route to classify it. These props fire **independently of** the per-call `:sensitive?` flag.
+The denylists and `:sensitive?` flag cover request carriers. The response body is a registration-owned transient payload, classified per-slot via `:sensitive?` / `:large?` props on the request's `:decode` schema. The `:decode` schema is the owner's natural declaration of the body shape, so per-slot props are the one route to classify it. These props fire independently of the per-call `:sensitive?` flag.
 
 ```clojure
 (rf/reg-event :auth/login
@@ -425,7 +469,7 @@ The denylists and `:sensitive?` flag cover request carriers; the **response body
 ```
 
 - **Per-slot.** A `:sensitive?` slot redacts to `:rf/redacted`; a `:large?` slot elides to the size marker; both → sensitive wins. A non-marked sibling rides verbatim. A root-level prop classifies the whole body (e.g. `[:string {:sensitive? true}]` for an opaque-token response).
-- **Off-box fail-closed.** Only an **introspectable** Malli schema (the raw EDN `[op props? …]` vector form) carries per-slot marks the walker can read. An **unschematized** body — the keyword decode modes (`:json` / `:text` / …), a custom decoder fn, a registry-keyword ref, or a compiled `m/schema` object — has an unknown shape, so it is **omitted entirely off-box** (fail-closed) rather than shipped raw.
+- **Off-box fail-closed.** Only an introspectable Malli schema (the raw EDN `[op props? …]` vector form) carries per-slot marks the walker can read. An unschematized body — the keyword decode modes (`:json` / `:text` / …), a custom decoder fn, a registry-keyword ref, or a compiled `m/schema` object — has an unknown shape, so it is omitted entirely off-box (**fail-closed**) rather than shipped raw.
 - **Raw error bodies are unconditionally omitted off-box.** A 4xx/5xx `:body` and a decode-failure `:body-text` are never decoded (status classification runs before decode), so they fail closed off-box irrespective of `:sensitive?` — error bodies frequently echo request context or tokens.
 
 !!! warning "Classification does not propagate — declare each surface a secret crosses"

--- a/docs/api/re-frame.machines.md
+++ b/docs/api/re-frame.machines.md
@@ -1,13 +1,18 @@
 # re-frame.machines
 
-State machines, per Spec 005. A machine in re-frame2 is registered with one macro (`reg-machine`) and *is* an event handler — the transition table is data (a map of `:states`, `:on`, `:entry`, `:exit`, `:after`) compiled into a `reg-event` handler at registration time. Dispatch an event at the machine's id and the table decides the transition; the resulting `:db` and `:fx` flow through the normal cascade. Because the machine is an event handler, the same trace bus, time-travel, and override surfaces that work for plain handlers work for machines — there is no parallel runtime to debug, no second store to inspect, no separate event log. The registration macros (`reg-machine` / `defmachine`) and the `machine-has-tag?` / `sub-machine` subscription sugar live on the `re-frame.core` facade; the engine, query, transition, and tooling surfaces live in this namespace, `re-frame.machines`, which is the `day8/re-frame2-machines` optional artefact.
+State machines, per Spec 005. A machine is registered with one macro (`reg-machine`) and *is* an event handler: the transition table — a map of `:states`, `:on`, `:entry`, `:exit`, `:after` — compiles into a `reg-event` handler at registration time. Dispatch an event at the machine's id and the table decides the transition; the resulting `:db` and `:fx` flow through the normal cascade. The same trace bus, time-travel, and override surfaces that work for plain handlers work for machines.
 
 ```clojure
 (:require [re-frame.core     :as rf]        ;; reg-machine / defmachine / machine-has-tag? / sub-machine — the facade macros + sub sugar
           [re-frame.machines :as machines]) ;; engine, query, transition, tooling, runtime helpers
 ```
 
-> **Facade surface.** Only `reg-machine` / `defmachine` and the `machine-has-tag?` / `sub-machine` subscription sugar are `re-frame.core` facade exports — reach them as `rf/…`. The plain-fn registration / engine / query helpers (`reg-machine*`, `make-machine-handler`, `machine-transition`, `machines`, `machine-meta`, `machine-by-system-id`) and the implementation-tier runtime helpers live in their owned namespace `re-frame.machines` — reach them as `re-frame.machines/<name>`, not `rf/<name>`. The canonical action-side cross-machine messaging surface is the reserved `[:rf.machine/dispatch-to-system [system-id event]]` fx tuple.
+Surfaces split two ways:
+
+- **`re-frame.core` facade exports** (reach as `rf/…`): the `reg-machine` / `defmachine` macros and the `machine-has-tag?` / `sub-machine` subscription sugar.
+- **Owned by `re-frame.machines`** (reach as `re-frame.machines/<name>`, not `rf/<name>`): the plain-fn registration / engine / query helpers (`reg-machine*`, `make-machine-handler`, `machine-transition`, `machines`, `machine-meta`, `machine-by-system-id`) and the implementation-tier runtime helpers. This namespace is the `day8/re-frame2-machines` optional artefact.
+
+The canonical action-side cross-machine messaging surface is the reserved `[:rf.machine/dispatch-to-system [system-id event]]` fx tuple.
 
 For the full treatment — the underlying model, the recognition kit, and the rationale behind the capability subset — see the [machines concept guide](../machines/concepts.md).
 
@@ -21,7 +26,12 @@ For the full treatment — the underlying model, the recognition kit, and the ra
   (reg-machine machine-id machine-spec)
   (reg-machine machine-id opts machine-spec)
   ```
-- **Description**: The canonical macro. Walks the literal spec form at expansion time and co-locates per-element source on each `:guards` / `:actions` / `:on-spawn-actions` entry (`{:fn .. :source-coords .. :source-code ..}`) plus a reference-site `:source-coords` on each `:states`-tree map node (state-node / transition map) — Xray uses these to navigate from a snapshot back to the guard/action definition or the state-node. Top-level call-site coords land on `handler-meta`. The optional `opts` registration-metadata map sits in the middle slot: its `:schema` key validates the dispatched outer event vector at the `:where :event` boundary; any other keys ride onto the registration metadata. The framework-owned `:rf/machine?` / `:rf/machine` keys are stamped by the registration home and must not appear in `opts`. Reached on the `re-frame.core` facade as `rf/reg-machine`.
+- **Description**: The canonical registration macro. Compiles the spec into a `reg-event` handler and captures per-element source for Xray.
+    - Walks the literal spec at expansion time; co-locates per-element source (`{:fn .. :source-coords .. :source-code ..}`) onto each `:guards` / `:actions` / `:on-spawn-actions` entry, plus a reference-site `:source-coords` onto each `:states`-tree map node (state-node / transition map). Xray uses these to navigate from a snapshot back to the guard/action definition or the state-node.
+    - Top-level call-site coords land on `handler-meta`.
+    - The optional `opts` registration-metadata map sits in the middle slot. Its `:schema` key validates the dispatched outer event vector at the `:where :event` boundary; any other keys ride onto the registration metadata.
+    - The framework-owned `:rf/machine?` / `:rf/machine` keys are stamped by the registration home and must **not** appear in `opts`.
+    - Reached on the `re-frame.core` facade as `rf/reg-machine`.
 
 A minimal machine:
 
@@ -70,7 +80,12 @@ The snapshot lives at `[:rf.runtime/machines :snapshots :session]` in the frame'
   (defmachine name machine-spec)
   (defmachine name docstring machine-spec)
   ```
-- **Description**: Define a machine-spec *value* with per-element source captured — a drop-in for `def` whose body is a literal machine-spec map. Walks the literal spec at expansion time and co-locates per-element source (`{:fn .. :source-coords .. :source-code ..}`) onto each `:guards` / `:actions` / `:on-spawn-actions` entry, plus a reference-site `:source-coords` onto each `:states`-tree map node. When that value is later passed to `reg-machine`, the source is already present on the stamped spec, so `(rf/handler-meta :machine-guard [machine-id guard-id])` (and the Xray machine-cascade source rendering) light up for value-registered machines exactly as for inline ones. The common app shape is `(def door-machine {…}) … (reg-machine :door/main door-machine)` — there `reg-machine` sees only the `door-machine` symbol and its compile-time literal-walk captures nothing, so `defmachine` is the `def`-replacement that captures the source at the definition site. The dev-only `:source-*` slots DCE under `:advanced + goog.DEBUG=false`. Reached on the `re-frame.core` facade as `rf/defmachine`.
+- **Description**: Defines a machine-spec *value* with per-element source captured — a drop-in for `def` whose body is a literal machine-spec map.
+    - Walks the literal spec at expansion time; co-locates per-element source (`{:fn .. :source-coords .. :source-code ..}`) onto each `:guards` / `:actions` / `:on-spawn-actions` entry, plus a reference-site `:source-coords` onto each `:states`-tree map node.
+    - The source is stamped on the value, so when it is later passed to `reg-machine`, `(rf/handler-meta :machine-guard [machine-id guard-id])` and the Xray machine-cascade source rendering light up for value-registered machines exactly as for inline ones.
+    - Needed because a plain `(def m {…})` + `(reg-machine :id m)` hands `reg-machine` only the symbol, so its literal-walk captures nothing. `defmachine` captures at the definition site.
+    - The dev-only `:source-*` slots DCE under `:advanced` + `goog.DEBUG=false`.
+    - Reached on the `re-frame.core` facade as `rf/defmachine`.
 - **Example**:
   ```clojure
   ;; Capture per-element source at the def site, then register the value.
@@ -93,7 +108,9 @@ The snapshot lives at `[:rf.runtime/machines :snapshots :session]` in the frame'
   (re-frame.machines/reg-machine* machine-id machine-spec)
   (re-frame.machines/reg-machine* machine-id opts machine-spec)
   ```
-- **Description**: Plain-fn surface beneath the macro. No source-coord walking. Use for code-gen pipelines, REPL workflows, or conformance harnesses that synthesise specs from data. The 3-arity takes the same middle-slot `opts` registration-metadata map as the macro (`:schema` validates the dispatched outer event vector at the `:where :event` boundary; the framework-owned `:rf/machine?` / `:rf/machine` keys must not appear in `opts`).
+- **Description**: Plain-fn surface beneath the macro. No source-coord walking.
+    - For code-gen pipelines, REPL workflows, or conformance harnesses that synthesise specs from data.
+    - The 3-arity takes the same middle-slot `opts` registration-metadata map as the macro: `:schema` validates the dispatched outer event vector at the `:where :event` boundary; the framework-owned `:rf/machine?` / `:rf/machine` keys must not appear in `opts`.
 - **Example**:
   ```clojure
   ;; Same effect as the macro, minus the source-coord walking.
@@ -110,7 +127,7 @@ The snapshot lives at `[:rf.runtime/machines :snapshots :session]` in the frame'
   ```clojure
   (re-frame.machines/make-machine-handler spec) → event-handler fn
   ```
-- **Description**: Compiles a transition table into the event-handler fn that `reg-machine` would register. Useful when you want to inspect the compiled fn or compose it manually.
+- **Description**: Compiles a transition table into the event-handler fn that `reg-machine` would register. Returns the fn; does not register it.
 - **Example**:
   ```clojure
   ;; Build the handler fn without registering it (e.g. to inspect or compose it).
@@ -128,7 +145,10 @@ The snapshot lives at `[:rf.runtime/machines :snapshots :session]` in the frame'
   ```clojure
   (re-frame.machines/machine-transition definition snapshot event) → result/Result
   ```
-- **Description**: The pure transition fn. Given a machine definition, a current snapshot, and an event, returns a `re-frame.machines.result/Result` — a map carrying the new snapshot under `::result/snap` and the effects vector under `::result/fx` (or a *failure* value if a guard / action / `:data`-fn threw). Discriminate with `result/ok?` / `result/fail?`; destructure `::result/snap` / `::result/fx`. JVM-runnable, no live frame needed — this is the primary surface for unit-testing machine behaviour.
+- **Description**: The pure transition fn. Given a machine definition, a current snapshot, and an event, returns a `re-frame.machines.result/Result`.
+    - The `Result` carries the new snapshot under `::result/snap` and the effects vector under `::result/fx`, or a *failure* value if a guard / action / `:data`-fn threw.
+    - Discriminate with `result/ok?` / `result/fail?`; destructure `::result/snap` / `::result/fx`.
+    - JVM-runnable; no live frame needed.
 - **Worked example** — drive a transition and assert on the snapshot:
   ```clojure
   (require '[re-frame.machines :as machines]
@@ -151,7 +171,7 @@ The snapshot lives at `[:rf.runtime/machines :snapshots :session]` in the frame'
   ```clojure
   (re-frame.machines/machines) → vector of machine-ids
   ```
-- **Description**: "What machines have been registered?" Derived view over `(registrations :event)` filtered by `:rf/machine? true`.
+- **Description**: Returns the vector of registered machine-ids. A derived view over `(registrations :event)` filtered by `:rf/machine? true`.
 - **Example**:
   ```clojure
   ;; Every registered machine-id (the registry, not a frame's live snapshots).
@@ -166,7 +186,7 @@ The snapshot lives at `[:rf.runtime/machines :snapshots :session]` in the frame'
   ```clojure
   (re-frame.machines/machine-meta machine-id) → registration-metadata map
   ```
-- **Description**: "What did `reg-machine` stamp at this machine's id?" Returns the registered machine's spec map — the transition table, doc, schemas, and the per-element source-coords — read from the `:rf/machine` slot of the `:event` registration metadata. Returns `nil` when `machine-id` does not name a registered machine.
+- **Description**: Returns the registered machine's spec map, or `nil` when `machine-id` does not name a registered machine. The spec map holds the transition table, doc, schemas, and per-element source-coords — read from the `:rf/machine` slot of the `:event` registration metadata.
 - **Example**:
   ```clojure
   ;; The registered spec back out — table, doc, schemas, source-coords.
@@ -183,7 +203,10 @@ The snapshot lives at `[:rf.runtime/machines :snapshots :session]` in the frame'
   (re-frame.machines/machine-by-system-id system-id)
   (re-frame.machines/machine-by-system-id system-id {:frame target})
   ```
-- **Description**: Reverse-lookup: given a `system-id`, what's the spawned machine bound to it? Returns the spawned-machine id or `nil`. The single-arity resolves the frame from the ambient scope (raising `:rf.error/no-frame-context` under no scope); the opts form `(machine-by-system-id system-id {:frame target})` names a frame explicitly — the trailing `{:frame …}` opts map, the same public-frame-targeting shape `sub-machine` takes. The 2-arity is shape-discriminated on the second arg: an opts map is the public form; a bare frame target is the *internal* frame-last plumbing.
+- **Description**: Reverse-lookup: given a `system-id`, returns the spawned-machine id bound to it, or `nil`.
+    - The single-arity resolves the frame from the ambient scope, raising `:rf.error/no-frame-context` under no scope.
+    - The opts form `(machine-by-system-id system-id {:frame target})` names a frame explicitly — the trailing `{:frame …}` opts map, the same public-frame-targeting shape `sub-machine` takes.
+    - The 2-arity is shape-discriminated on the second arg: an opts map is the public form; a bare frame target is the *internal* frame-last plumbing.
 - **Example**:
   ```clojure
   ;; Resolve a :system-id-bound actor, then address it directly.
@@ -198,7 +221,7 @@ The snapshot lives at `[:rf.runtime/machines :snapshots :session]` in the frame'
   ```clojure
   (machine-has-tag? machine-id tag) → reaction
   ```
-- **Description**: Sugar over `(subscribe [:rf/machine-has-tag? machine-id tag])`. Reactive predicate over the machine's snapshot's `:tags` set. Use in views to render conditionally on state-tag membership. Reached on the `re-frame.core` facade as `rf/machine-has-tag?`.
+- **Description**: Sugar over `(subscribe [:rf/machine-has-tag? machine-id tag])`. A reactive predicate over the machine's snapshot's `:tags` set. Reached on the `re-frame.core` facade as `rf/machine-has-tag?`.
 - **Example**:
   ```clojure
   ;; Ask by state-tag, not exact state name — disable inputs while a request is in flight.
@@ -214,7 +237,11 @@ The snapshot lives at `[:rf.runtime/machines :snapshots :session]` in the frame'
   (sub-machine machine-id) → reaction
   (sub-machine machine-id opts) → reaction
   ```
-- **Description**: Sugar over `(subscribe [:rf/machine machine-id])`. Returns a reaction whose value is the snapshot map `{:state :data :tags}`, or `nil` before the machine's first event. The 2-arity `opts` map carries the `{:frame target}` capability the underlying subscription vector accepts — `target` is a frame-id keyword or a live frame value. The `sub-` prefix is the subscription-family verb; it does not denote a child-machine relationship. The `[:rf/machine machine-id]` vector form remains the canonical registered sub. Reached on the `re-frame.core` facade as `rf/sub-machine`.
+- **Description**: Sugar over `(subscribe [:rf/machine machine-id])`. Returns a reaction whose value is the snapshot map `{:state :data :tags}`, or `nil` before the machine's first event.
+    - The 2-arity `opts` map carries the `{:frame target}` capability the underlying subscription vector accepts — `target` is a frame-id keyword or a live frame value.
+    - The `sub-` prefix is the subscription-family verb; it does not denote a child-machine relationship.
+    - The `[:rf/machine machine-id]` vector form remains the canonical registered sub.
+    - Reached on the `re-frame.core` facade as `rf/sub-machine`.
 - **Example**:
   ```clojure
   (let [{:keys [state]} @(rf/sub-machine :auth.login/flow)]
@@ -232,7 +259,7 @@ The framework-registered subscription vectors and reserved effect tuples that ad
   ```clojure
   [:rf/machine machine-id]
   ```
-- **Description**: The canonical machine read — subscribe to it the same way you subscribe to anything else. Returns a reaction whose value is the snapshot `{:state :data}` (plus framework-managed `:tags`), or `nil` if the machine is not yet initialised. The `re-frame.core` `sub-machine` fn is read sugar over this vector. The [machines concept guide](../machines/concepts.md#registering-and-running-it) walks through subscribing to a snapshot and chaining named projections off it.
+- **Description**: The canonical machine read. Returns a reaction whose value is the snapshot `{:state :data}` (plus framework-managed `:tags`), or `nil` if the machine is not yet initialised. The `re-frame.core` `sub-machine` fn is read sugar over this vector. The [machines concept guide](../machines/concepts.md#registering-and-running-it) walks through subscribing to a snapshot and chaining named projections off it.
 - **Example**:
   ```clojure
   (let [{:keys [state data]} @(rf/subscribe [:rf/machine :auth.login/flow])]
@@ -246,7 +273,7 @@ The framework-registered subscription vectors and reserved effect tuples that ad
   ```clojure
   [:rf/machine-has-tag? machine-id tag]
   ```
-- **Description**: Returns `true` iff the named machine's current snapshot's `:tags` set contains `tag`, `false` otherwise (including unknown / not-yet-initialised machines). A *derived* sub — it reads the snapshot's containment-bit directly rather than chaining off `:rf/machine`, so a view that only cares about one tag re-renders only when that bit flips. The `re-frame.core` `machine-has-tag?` sugar fn wraps this vector.
+- **Description**: Returns `true` iff the named machine's current snapshot's `:tags` set contains `tag`, `false` otherwise (including unknown / not-yet-initialised machines). A *derived* sub: it reads the snapshot's containment-bit directly rather than chaining off `:rf/machine`, so a view that only cares about one tag re-renders only when that bit flips. The `re-frame.core` `machine-has-tag?` sugar fn wraps this vector.
 - **Example**:
   ```clojure
   @(rf/subscribe [:rf/machine-has-tag? :auth.login/flow :auth/busy])  ;; => true / false
@@ -259,7 +286,15 @@ The framework-registered subscription vectors and reserved effect tuples that ad
   ```clojure
   [:rf.machine/spawn spawn-spec]
   ```
-- **Description**: "Spawn a dynamic actor instance." `spawn-spec` carries exactly one of `:machine-id` (the registered machine type to instantiate) or `:definition` (an inline spec map), plus optional `:data` (overrides the type's initial `:data`), `:id-prefix` (actor ids are the deterministic `<prefix>#<n>` from a per-type counter — the prefix defaults to `:machine-id`; ids are never gensym'd), `:fixed-actor-id` (an explicit actor address; skips allocation), `:system-id` (binds the actor in the frame's `[:rf.runtime/machines :system-ids]` reverse index; a collision emits `:rf.error/system-id-collision` and rebinds last-write-wins), `:start` (a single event vector dispatched to the new actor as `[<spawned-id> <start>]`; when absent the runtime dispatches the synthetic `[<spawned-id> [:rf.machine.spawn/spawned]]`), and `:on-spawn` (an *advisory* callback `(fn [{:keys [data id]}] …)` — the return value is dropped; a non-nil return emits the dev-only `:rf.warning/on-spawn-return-ignored`). Declarative `:spawn` state nodes accept the same keys plus `:on-done` / `:on-error` / `:timeout` / `:on-timeout`; on the declarative path the framework binds the child's allocated id into the parent's `:data` at `[:rf/spawned <invoke-id>]`. Emitted from any event handler's `:fx` (including machine actions and the declarative `:spawn` desugar). Fails closed when `:machine-id` names an unregistered type and no `:definition` is supplied (`:rf.error/machine-spawn-unregistered-type`). Backed by [`spawn-fx`](#re-framemachinesspawn-fx).
+- **Description**: Spawn a dynamic actor instance. Emitted from any event handler's `:fx` (including machine actions and the declarative `:spawn` desugar). `spawn-spec` carries exactly one of `:machine-id` (the registered machine type to instantiate) or `:definition` (an inline spec map), plus optional keys:
+    - `:data` — overrides the type's initial `:data`.
+    - `:id-prefix` — actor ids are the deterministic `<prefix>#<n>` from a per-type counter; the prefix defaults to `:machine-id`; ids are never gensym'd.
+    - `:fixed-actor-id` — an explicit actor address; skips allocation.
+    - `:system-id` — binds the actor in the frame's `[:rf.runtime/machines :system-ids]` reverse index; a collision emits `:rf.error/system-id-collision` and rebinds last-write-wins.
+    - `:start` — a single event vector dispatched to the new actor as `[<spawned-id> <start>]`; when absent the runtime dispatches the synthetic `[<spawned-id> [:rf.machine.spawn/spawned]]`.
+    - `:on-spawn` — an *advisory* callback `(fn [{:keys [data id]}] …)`; the return value is dropped; a non-nil return emits the dev-only `:rf.warning/on-spawn-return-ignored`.
+    - Declarative `:spawn` state nodes accept the same keys plus `:on-done` / `:on-error` / `:timeout` / `:on-timeout`; on the declarative path the framework binds the child's allocated id into the parent's `:data` at `[:rf/spawned <invoke-id>]`.
+    - Fails closed when `:machine-id` names an unregistered type and no `:definition` is supplied (`:rf.error/machine-spawn-unregistered-type`). Backed by [`spawn-fx`](#re-framemachinesspawn-fx).
 - **Example**:
   ```clojure
   (rf/reg-event :session/start-logger
@@ -284,7 +319,10 @@ The framework-registered subscription vectors and reserved effect tuples that ad
   ```clojure
   [:rf.machine/destroy actor-id]
   ```
-- **Description**: "Tear down this actor." Runs the actor's `:exit` cascade, cancels its armed `:after` timers, dissociates `[:rf.runtime/machines :snapshots <actor-id>]` (in runtime-db), releases its `:system-id` binding, and unregisters its event handler when one is registered (a spawned actor has no per-instance registration — its liveness is its snapshot's presence). Silent-idempotent: destroying an already-destroyed actor is a no-op. Symmetric counterpart to `:rf.machine/spawn`. Backed by [`destroy-machine-fx`](#re-framemachinesdestroy-machine-fx).
+- **Description**: Tear down an actor. Symmetric counterpart to `:rf.machine/spawn`; backed by [`destroy-machine-fx`](#re-framemachinesdestroy-machine-fx).
+    - Runs the actor's `:exit` cascade, cancels its armed `:after` timers, dissociates `[:rf.runtime/machines :snapshots <actor-id>]` (in runtime-db), releases its `:system-id` binding, and unregisters its event handler when one is registered.
+    - A spawned actor has no per-instance registration — its liveness is its snapshot's presence.
+    - Silent-idempotent: destroying an already-destroyed actor is a no-op.
 - **Example**:
   ```clojure
   (rf/reg-event :session/stop-logger
@@ -292,7 +330,7 @@ The framework-registered subscription vectors and reserved effect tuples that ad
       {:fx [[:rf.machine/destroy (machines/machine-by-system-id :logger)]]}))
   ```
 
-**Final states and `:on-done`.** Machines support **final states** — leaf states marked `:final?` that auto-destroy the machine on entry. The parent (if any) receives `:on-done` with the child's `:data` slot. No manual `:rf.machine/destroy` is needed: a spawn-shaped sub-process completes, the parent receives the result through `:on-done`, and the framework destroys the child.
+**Final states and `:on-done`.** Leaf states marked `:final?` auto-destroy the machine on entry; the parent (if any) receives `:on-done` with the child's `:data` slot. A spawn-shaped sub-process completes, the parent receives the result through `:on-done`, and the framework destroys the child — no manual `:rf.machine/destroy` needed.
 
 | State-node key | What it does |
 |---|---|
@@ -309,7 +347,11 @@ See [Final states: when a machine is done](../machines/concepts.md#final-states-
   ```clojure
   [:rf.machine/dispatch-to-system [system-id event]]
   ```
-- **Description**: The action-side way one machine addresses its spawned child actor by *role* (`:logger`, `:websocket`, `:retry-coordinator`) instead of by allocated id. Resolves `system-id` through the emitting frame's `[:rf.runtime/machines :system-ids]` reverse index (in runtime-db) and dispatches `event` to the bound actor; no-op when the `system-id` is unbound. This is the canonical surface — a **machine action** can't read app-db and its `:on-spawn` return is dropped, so the fx form is the way an action sends a message to a named actor. Args ride as a single 2-element pair (the fx contract is a `[fx-id args]` pair). Backed by [`dispatch-to-system-fx`](#re-framemachinesdispatch-to-system-fx); the call-site twin is the [`dispatch-to-system`](#re-framemachinesdispatch-to-system) fn.
+- **Description**: The action-side way one machine addresses its spawned child actor by *role* (`:logger`, `:websocket`, `:retry-coordinator`) instead of by allocated id.
+    - Resolves `system-id` through the emitting frame's `[:rf.runtime/machines :system-ids]` reverse index (in runtime-db) and dispatches `event` to the bound actor; no-op when the `system-id` is unbound.
+    - Canonical action-side surface: a machine action can't read app-db and its `:on-spawn` return is dropped, so the fx form is how an action messages a named actor.
+    - Args ride as a single 2-element pair (the fx contract is a `[fx-id args]` pair).
+    - Backed by [`dispatch-to-system-fx`](#re-framemachinesdispatch-to-system-fx); the call-site twin is the [`dispatch-to-system`](#re-framemachinesdispatch-to-system) fn.
 - **Example**:
   ```clojure
   {:fx [[:rf.machine/dispatch-to-system [:logger [:logger/flush]]]]}
@@ -354,7 +396,9 @@ When a child actor spawns declaratively under a parent, the framework binds the 
   (re-frame.machines/dispatch-to-system system-id event)
   (re-frame.machines/dispatch-to-system system-id event frame-id)
   ```
-- **Description**: The direct-call twin of the `:rf.machine/dispatch-to-system` fx — sugar over `(when-let [m (machine-by-system-id system-id)] (dispatch [m event]))`, no-op when the `system-id` is unbound. The two-arity form resolves the frame from the carried scope it runs under; the three-arity form names the frame explicitly — there is no `:rf/default` fallback, and looking up under no scope raises `:rf.error/no-frame-context`. This is an implementation-tier helper; new app code should emit the `[:rf.machine/dispatch-to-system [system-id event]]` fx instead.
+- **Description**: The direct-call twin of the `:rf.machine/dispatch-to-system` fx — sugar over `(when-let [m (machine-by-system-id system-id)] (dispatch [m event]))`, no-op when the `system-id` is unbound.
+    - The two-arity form resolves the frame from the carried scope it runs under; the three-arity form names the frame explicitly. There is no `:rf/default` fallback, and looking up under no scope raises `:rf.error/no-frame-context`.
+    - Implementation-tier helper; new app code should emit the `[:rf.machine/dispatch-to-system [system-id event]]` fx instead.
 - **Example**:
   ```clojure
   ;; Implementation-tier direct call (prefer the fx in app code); no-op when unbound.
@@ -368,11 +412,14 @@ When a child actor spawns declaratively under a parent, the framework binds the 
   ```clojure
   (re-frame.machines/dispatch-to-system-fx fx-ctx [system-id event])
   ```
-- **Description**: The fx handler behind `:rf.machine/dispatch-to-system`. Resolves `system-id` through the emitting frame's `[:rf.runtime/machines :system-ids]` reverse index and dispatches `event` to the bound actor; no-op when the `system-id` is unbound (symmetric with the `dispatch-to-system` fn's no-op fall-through). The cascade-envelope frame is the fx-context `:frame`; a nil stamp is an invariant failure (`:rf.error/no-frame-context`), never a synthesised `:rf/default`. App code emits the `[:rf.machine/dispatch-to-system [system-id event]]` fx rather than calling this fn.
+- **Description**: The fx handler behind `:rf.machine/dispatch-to-system`.
+    - Resolves `system-id` through the emitting frame's `[:rf.runtime/machines :system-ids]` reverse index and dispatches `event` to the bound actor; no-op when the `system-id` is unbound (symmetric with the `dispatch-to-system` fn's no-op fall-through).
+    - The cascade-envelope frame is the fx-context `:frame`; a nil stamp is an invariant failure (`:rf.error/no-frame-context`), never a synthesised `:rf/default`.
+    - App code emits the `[:rf.machine/dispatch-to-system [system-id event]]` fx rather than calling this fn.
 
 ## Machine-tooling exports (JVM)
 
-The shipped machine-tooling exports are `re-frame.machines` aliases over `re-frame.machines.tooling`; the aliases are JVM-only (no `re-frame.core` facade export). CLJS tool consumers call `re-frame.machines.tooling/<name>` directly — the CLJS facade deliberately omits the tooling require so an app that attaches no tool DCEs the tooling body. They render the machine *algebra view* that Xray / re-frame-pair navigate. There is **no** framework-level `machine->xstate-json`, `machine->mermaid`, or Stately bridge — those exporters are owned by the separate post-v1 `day8/re-frame2-machines-viz` library, not the framework. (A possible future declarative `:child-machine` binding would be pure sugar over the v1 `:spawn` / `:destroy` cycle; not yet shipped — use the imperative cycle today.)
+The shipped machine-tooling exports are `re-frame.machines` aliases over `re-frame.machines.tooling`; the aliases are JVM-only (no `re-frame.core` facade export). CLJS tool consumers call `re-frame.machines.tooling/<name>` directly — the CLJS facade deliberately omits the tooling require so an app that attaches no tool DCEs the tooling body. They render the machine *algebra view* that Xray / re-frame-pair navigate. There is **no** framework-level `machine->xstate-json`, `machine->mermaid`, or Stately bridge — those exporters are owned by the separate post-v1 `day8/re-frame2-machines-viz` library, not the framework.
 
 ### `re-frame.machines/machine-algebra-view`
 
@@ -412,7 +459,7 @@ The shipped machine-tooling exports are `re-frame.machines` aliases over `re-fra
   ```clojure
   (re-frame.machines/machine-selector? sub-id) → boolean
   ```
-- **Description**: True iff the subscription registered under `sub-id` is a MACHINE SELECTOR — an ordinary `reg-sub` whose static `:<-` inputs include a `[:rf/machine …]` (or `[:rf/machine-has-tag? …]`) query vector. Machine selectors are not a second subscription system — they stay ordinary ephemeral `:derivation` subscription nodes; this recognizer lets a graph tool flag the ones that read a machine. JVM-only.
+- **Description**: True iff the subscription registered under `sub-id` is a machine selector — an ordinary `reg-sub` whose static `:<-` inputs include a `[:rf/machine …]` (or `[:rf/machine-has-tag? …]`) query vector. Machine selectors stay ordinary ephemeral `:derivation` subscription nodes, not a second subscription system; this recognizer lets a graph tool flag the ones that read a machine. JVM-only.
 - **Example**:
   ```clojure
   (machines/machine-selector? :session/summary)  ;; => true / false
@@ -425,7 +472,7 @@ The shipped machine-tooling exports are `re-frame.machines` aliases over `re-fra
   ```clojure
   (re-frame.machines/machine-selector-targets sub-id) → #{machine-id …}
   ```
-- **Description**: The SET of machine ids the subscription registered under `sub-id` reads as a machine selector — the second element of each accepted `[:rf/machine machine-id …]` / `[:rf/machine-has-tag? machine-id …]` static `:<-` input. Where `machine-selector?` answers only the boolean "is this a selector?", this returns the actual target machine ids — what a graph tool needs to draw the edge. JVM-only.
+- **Description**: The set of machine ids the subscription registered under `sub-id` reads as a machine selector — the second element of each accepted `[:rf/machine machine-id …]` / `[:rf/machine-has-tag? machine-id …]` static `:<-` input. Where `machine-selector?` answers only the boolean, this returns the actual target machine ids a graph tool needs to draw the edge. JVM-only.
 - **Example**:
   ```clojure
   (machines/machine-selector-targets :session/summary)  ;; => #{:session}
@@ -491,7 +538,11 @@ The registration-time and `:data`-schema-boundary validators. The three `:data` 
   ```clojure
   (re-frame.machines/validate-machine! machine)
   ```
-- **Description**: Runs every registration-time check the machine grammar requires — history-state placement / closed key-set / at-most-one-per-compound / `:default-target` resolution, `:type :parallel` region shape, and top-level dispatch + guard/action ref resolution. Composed at the top of `make-machine-handler` so the registered handler fn's body is exclusively request processing. Throws the `:rf.error/machine-*` taxonomy on a grammar violation (e.g. `:rf.error/machine-history-misplaced` / `-history-extra-keys` / `-history-duplicate` / `-history-bad-default-target`, `:rf.error/machine-unknown-node-key`, `:rf.error/machine-unresolved-guard` / `-unresolved-action`). The conformance corpus's `:reg-machine` Mode-B op pins the registration-error taxonomy against this leaf fn.
+- **Description**: Runs every registration-time check the machine grammar requires.
+    - Covers history-state placement / closed key-set / at-most-one-per-compound / `:default-target` resolution, `:type :parallel` region shape, and top-level dispatch + guard/action ref resolution.
+    - Composed at the top of `make-machine-handler` so the registered handler fn's body is exclusively request processing.
+    - Throws the `:rf.error/machine-*` taxonomy on a grammar violation (e.g. `:rf.error/machine-history-misplaced` / `-history-extra-keys` / `-history-duplicate` / `-history-bad-default-target`, `:rf.error/machine-unknown-node-key`, `:rf.error/machine-unresolved-guard` / `-unresolved-action`).
+    - The conformance corpus's `:reg-machine` Mode-B op pins the registration-error taxonomy against this leaf fn.
 
 ### `re-frame.machines/validate-machine-data!`
 
@@ -500,7 +551,10 @@ The registration-time and `:data`-schema-boundary validators. The three `:data` 
   ```clojure
   (re-frame.machines/validate-machine-data! runtime-db event-id frame-id) → boolean
   ```
-- **Description**: Walks every snapshot under `[:rf.runtime/machines :snapshots]` in `runtime-db` and validates its `:data` against the resolved machine's `[:schemas :data]` schema. Returns `true` iff every snapshot conformed (or carried no schema / no validator); `false` on the first failure, with the per-snapshot trace already emitted — the router then rolls back the whole transition (same mechanism as the `:where :app-db` rollback). Schema resolution covers a SINGLETON (via `machine-meta`) AND a SPAWNED actor (via the snapshot's `:rf/machine-type`). The post-commit boundary the router AND-conjoins with `validate-app-schema!`.
+- **Description**: Walks every snapshot under `[:rf.runtime/machines :snapshots]` in `runtime-db` and validates its `:data` against the resolved machine's `[:schemas :data]` schema.
+    - Returns `true` iff every snapshot conformed (or carried no schema / no validator); `false` on the first failure, with the per-snapshot trace already emitted — the router then rolls back the whole transition (same mechanism as the `:where :app-db` rollback).
+    - Schema resolution covers a SINGLETON (via `machine-meta`) AND a SPAWNED actor (via the snapshot's `:rf/machine-type`).
+    - The post-commit boundary the router AND-conjoins with `validate-app-schema!`.
 
 ### `re-frame.machines/validate-spawn-data!`
 
@@ -529,7 +583,9 @@ The registration-time and `:data`-schema-boundary validators. The three `:data` 
   ```clojure
   (re-frame.machines/install-machine-runtime!)
   ```
-- **Description**: Re-registers the machine runtime effects + subs into BOTH the regular registrar AND the framework-standard registry (so an image-loaded frame resolves `[:rf.machine/spawn …]` / `[:rf/machine …]` through its sealed generation). Idempotent. Re-registers from descriptors captured at ns-load, so it works even after a `registrar/clear-all!` has wiped the registrar slots — the machine analogue of the `:rf/set-db` standard re-seed. Called at ns load, from the `:machines/install-runtime!` late-bind hook the reset fixture fires, and directly by tests that wipe the registrar.
+- **Description**: Re-registers the machine runtime effects + subs into BOTH the regular registrar AND the framework-standard registry (so an image-loaded frame resolves `[:rf.machine/spawn …]` / `[:rf/machine …]` through its sealed generation). Idempotent.
+    - Re-registers from descriptors captured at ns-load, so it works even after a `registrar/clear-all!` has wiped the registrar slots — the machine analogue of the `:rf/set-db` standard re-seed.
+    - Called at ns load, from the `:machines/install-runtime!` late-bind hook the reset fixture fires, and directly by tests that wipe the registrar.
 
 ### `re-frame.machines/reset-timers!`
 
@@ -539,7 +595,10 @@ The registration-time and `:data`-schema-boundary validators. The three `:data` 
   (re-frame.machines/reset-timers!)
   (re-frame.machines/reset-timers! frame-id)
   ```
-- **Description**: Cancel in-flight `:after` timers. The 0-arity form clears every frame's timers — the fixture-teardown shape used by `re-frame.test-support`'s `reset-runtime` and per-feature artefact test fixtures. The 1-arity form clears just the given frame's timers — the `frame/destroy-frame!` hook shape that releases a destroyed frame's host-clock handles and subscription watchers without touching siblings. Spawn-id counters reset automatically with the registrar snapshot/restore + frame reset, so this hook handles only the frame-scoped wall-clock timer table.
+- **Description**: Cancel in-flight `:after` timers.
+    - The 0-arity form clears every frame's timers — the fixture-teardown shape used by `re-frame.test-support`'s `reset-runtime` and per-feature artefact test fixtures.
+    - The 1-arity form clears just the given frame's timers — the `frame/destroy-frame!` hook shape that releases a destroyed frame's host-clock handles and subscription watchers without touching siblings.
+    - Spawn-id counters reset automatically with the registrar snapshot/restore + frame reset, so this hook handles only the frame-scoped wall-clock timer table.
 
 ### `re-frame.machines/owning-actor-id`
 
@@ -548,7 +607,10 @@ The registration-time and `:data`-schema-boundary validators. The three `:data` 
   ```clojure
   (re-frame.machines/owning-actor-id frame-id event-id) → actor-id (or nil)
   ```
-- **Description**: Resolve the spawned-actor-id that OWNS `event-id` in `frame-id`, or `nil`. Returns `event-id` (a keyword — the spawned actor's machine address) when a SPAWNED actor's snapshot is currently installed at `[:rf.runtime/machines :snapshots <event-id>]`, otherwise `nil` (the event came from an ordinary handler or a singleton machine). Set semantics are snapshot membership via the durable `:rf/machine-type`-at-root discriminator — declarative `:spawn` / `:spawn-all` AND imperative `[:rf.machine/spawn …]` actors. Published as the `:machines/owning-actor-id` late-bind hook so the http artefact can ask "who owns this request's originating event?" (to abort managed HTTP on actor-destroy) without statically requiring this artefact; http falls back to `nil` when machines is absent.
+- **Description**: Resolve the spawned-actor-id that OWNS `event-id` in `frame-id`, or `nil`.
+    - Returns `event-id` (a keyword — the spawned actor's machine address) when a SPAWNED actor's snapshot is currently installed at `[:rf.runtime/machines :snapshots <event-id>]`, otherwise `nil` (the event came from an ordinary handler or a singleton machine).
+    - Set semantics are snapshot membership via the durable `:rf/machine-type`-at-root discriminator — declarative `:spawn` / `:spawn-all` AND imperative `[:rf.machine/spawn …]` actors.
+    - Published as the `:machines/owning-actor-id` late-bind hook so the http artefact can ask "who owns this request's originating event?" (to abort managed HTTP on actor-destroy) without statically requiring this artefact; http falls back to `nil` when machines is absent.
 
 ## See also
 

--- a/docs/api/re-frame.performance.md
+++ b/docs/api/re-frame.performance.md
@@ -1,6 +1,11 @@
 # re-frame.performance
 
-`re-frame.performance` is re-frame2's **production timing** instrumentation surface. It is deliberately separate from the trace channel: trace runs in dev and is too noisy to keep on in production, whereas the Performance-API path here is built to survive production and is **off by default** behind a compile-time `goog-define`. When a consumer opts in at build time, re-frame2 brackets its four hot paths — event dispatch, subscription recompute, fx walk, and view render — in options-bag `performance.measure` calls (User-Timing measure entries named `rf:event:*`, `rf:sub:*`, `rf:fx:*`, `rf:render:*`; no `performance.mark` entries are allocated) that any `PerformanceObserver` — including an APM's — can read. Delivery is observer-first: each measure is cleared by name immediately after emit, so the retained buffer that `performance.getEntriesByType("measure")` reads stays empty unless the second flag, `retain-entries?`, is flipped on. With the flags left at their defaults, Closure DCE elides every call site under `:advanced`, so a shipped binary carries zero User-Timing instrumentation. The whole surface is two compile-time flags, `enabled?` and `retain-entries?`; the JVM is a no-op (the Performance API is browser-only).
+`re-frame.performance` is re-frame2's production timing instrumentation surface, separate from the dev-only trace channel. It brackets four hot paths — event dispatch, subscription recompute, fx walk, and view render — in options-bag `performance.measure` calls that any `PerformanceObserver` (including an APM's) can read.
+
+- Emits User-Timing measure entries named `rf:event:*`, `rf:sub:*`, `rf:fx:*`, `rf:render:*`. No `performance.mark` entries are allocated.
+- Delivery is observer-first: each measure is cleared by name immediately after emit, so the buffer read by `performance.getEntriesByType("measure")` stays empty unless `retain-entries?` is on.
+- The whole surface is two compile-time flags, `enabled?` and `retain-entries?`, both **off by default**. Under `:advanced` with the defaults, Closure DCE elides every call site, so a shipped binary carries zero User-Timing instrumentation.
+- CLJS-only: the JVM is a no-op (the Performance API is browser-only).
 
 ```clojure
 (:require [re-frame.performance :as perf])
@@ -8,12 +13,19 @@
 
 > **Note** — there is nothing to call from this namespace at runtime. You opt timing in by referencing the flags fully-qualified in your build's `:closure-defines` (see below); the `:as perf` alias is shown only for consistency with the other API docs.
 
+See [Find and fix a slow view](../core/how-to/fix-a-slow-view.md) for turning this channel on and reading the entries.
+
 ## Compile-time flags
 
 ### `enabled?`
 
 - **Kind**: Var (`^boolean`)
-- **Description**: `goog-define`d (CLJS) / `^:const false` (JVM). Set via `:closure-defines {re-frame.performance/enabled? true}` to bracket event dispatch / sub recompute / fx walk / view render in options-bag `performance.measure` calls — `performance.measure(name, {start, end})` with numeric `performance.now()` timestamps; no `performance.mark` entries are allocated (User-Timing measure entries `rf:event:*`, `rf:sub:*`, `rf:fx:*`, `rf:render:*`). The measure is emitted inside a `try/finally`, so the entry lands even when the bracketed body throws (the exception still propagates), and is cleared by name (`performance.clearMeasures`) immediately after emit unless `retain-entries?` is on — a live `PerformanceObserver` still receives it, since observer callbacks fire at `measure()` time, before the clear. **Compile-time only** — not a `(rf/configure! ...)` knob; runtime mutation has no effect. Default `false`; under `:advanced` + default the bracket DCEs and shipped binaries carry zero User-Timing instrumentation. CLJS-only — JVM is a no-op.
+- **Signature**: `goog-define`d (CLJS) / `^:const false` (JVM). Set via `:closure-defines {re-frame.performance/enabled? true}`.
+- **Description**: Gates the four `performance.measure` brackets (event dispatch / sub recompute / fx walk / view render).
+    - Emits `performance.measure(name, {start, end})` with numeric `performance.now()` timestamps; User-Timing measure entries `rf:event:*`, `rf:sub:*`, `rf:fx:*`, `rf:render:*`. No `performance.mark` entries are allocated.
+    - Each measure is emitted inside a `try/finally`, so the entry lands even when the bracketed body throws (the exception still propagates).
+    - The entry is cleared by name (`performance.clearMeasures`) immediately after emit unless `retain-entries?` is on. A live `PerformanceObserver` still receives it — observer callbacks fire at `measure()` time, before the clear.
+    - **Compile-time only** — not a `(rf/configure! ...)` knob; runtime mutation has no effect. Default `false`; under `:advanced` with the default, every bracket DCEs. CLJS-only; the JVM is a no-op.
 
 ```clojure
 ;; shadow-cljs.edn — flip the compile-time gate. Default off:
@@ -25,7 +37,12 @@
 ### `retain-entries?`
 
 - **Kind**: Var (`^boolean`)
-- **Description**: `goog-define`d (CLJS) / `^:const false` (JVM). Set via `:closure-defines {re-frame.performance/retain-entries? true}` to skip the per-emit `performance.clearMeasures(name)` so measure entries persist in the host's retained User-Timing buffer for one-shot `performance.getEntriesByType("measure")` readers (DevTools / console workflows). Default `false`: each entry is delivered to any live `PerformanceObserver` at `measure()` time, then cleared, so the buffer does not grow across a long-running (RUM) session — with the default, `getEntriesByType` returns no `rf:*` entries. No effect unless `enabled?` is also on. **Compile-time only** — not a `(rf/configure! ...)` knob; runtime mutation has no effect. CLJS-only — JVM is a no-op.
+- **Signature**: `goog-define`d (CLJS) / `^:const false` (JVM). Set via `:closure-defines {re-frame.performance/retain-entries? true}`.
+- **Description**: Skips the per-emit `performance.clearMeasures(name)` so measure entries persist in the host's retained User-Timing buffer.
+    - Enables one-shot `performance.getEntriesByType("measure")` readers (DevTools / console workflows).
+    - Default `false`: each entry is delivered to any live `PerformanceObserver` at `measure()` time, then cleared, so the buffer does not grow across a long-running (RUM) session — with the default, `getEntriesByType` returns no `rf:*` entries.
+    - No effect unless `enabled?` is also on.
+    - **Compile-time only** — not a `(rf/configure! ...)` knob; runtime mutation has no effect. CLJS-only; the JVM is a no-op.
 
 ```clojure
 ;; shadow-cljs.edn — retain entries for one-shot DevTools / console reads.

--- a/docs/api/re-frame.resources.md
+++ b/docs/api/re-frame.resources.md
@@ -1,12 +1,18 @@
 # re-frame.resources
 
-A resource is a named, cached read of remote state — re-frame2's answer to TanStack Query / RTK Query / SWR / `re-frame-query`, re-expressed in the model: **views read server state passively through subscriptions; route entry, events, and machines *cause* it to fetch; the cache lives in the framework-owned runtime partition, not `app-db`.** You register a resource once with a scope policy, a params schema, and a request; after that the runtime owns identity, cache scope, staleness, dedupe, invalidation, GC, in-flight ownership, SSR hydration, and the metadata Xray reads.
+A resource is a named, cached read of remote state. Views read server state passively through subscriptions; route entry, events, and machines *cause* it to fetch; the cache lives in the framework-owned runtime partition, not `app-db`. You register a resource once with a scope policy, a params schema, and a request; the runtime then owns identity, cache scope, staleness, dedupe, invalidation, GC, in-flight ownership, SSR hydration, and the metadata Xray reads.
 
-Resources are an **optional, post-v1 capability** — they ship in `day8/re-frame2-resources` (`re-frame.resources`), require `day8/re-frame2-http` for the transport, and are wired by one `(:require [re-frame.resources])` at app boot. An app that omits the artefact sees the `reg-resource` wrapper throw a clean `:rf.error/resources-artefact-missing`. This doc covers the registration shape, the events, the subs, and introspection. The tutorial is [Guide ch.27 — Server-state and resources](../resources/concepts.md).
+Resources are an optional, post-v1 capability. They ship in `day8/re-frame2-resources` (`re-frame.resources`), require `day8/re-frame2-http` for the transport, and are wired by one `(:require [re-frame.resources])` at app boot. An app that omits the artefact sees the `reg-resource` wrapper throw `:rf.error/resources-artefact-missing`. This page covers the registration shape, the events, the subs, and introspection. The tutorial is [Guide ch.27 — Server-state and resources](../resources/concepts.md).
 
-> **Scope is HTTP-only.** The first public-beta surface is **landed and complete**: the read-resource MVP, **mutations** (`reg-mutation` / `:rf.mutation/execute`, the causal-write counterpart — see [Mutation events](#mutation-events-map-payloads)), **focus/reconnect active-stale revalidation** (`:rf.resource/window-focused` / `:rf.resource/network-reconnected` + the `install-revalidation-listeners!` / `remove-revalidation-listeners!` host-listener fns — see [Revalidation listeners](#revalidation-listeners)), and **active-owner polling** (`:poll-interval-ms` — see [Polling](#polling)). **GraphQL is deferred** to a later slice. See [Guide ch.27 §What's deferred](../resources/concepts.md).
+Scope in this slice is HTTP-only:
 
-The resource surfaces are on the `re-frame.core` facade (`reg-resource` / `reg-mutation`); the events and subscriptions are keyword-addressed:
+- Read-resource MVP.
+- **Mutations** (`reg-mutation` / `:rf.mutation/execute`, the causal-write counterpart) — see [Mutation events](#mutation-events-map-payloads).
+- Focus/reconnect active-stale revalidation (`:rf.resource/window-focused` / `:rf.resource/network-reconnected`, plus the `install-revalidation-listeners!` / `remove-revalidation-listeners!` host-listener fns) — see [Revalidation listeners](#revalidation-listeners).
+- Active-owner polling (`:poll-interval-ms`) — see [Polling](#polling).
+- GraphQL is deferred to a later slice — see [Guide ch.27 §What's deferred](../resources/concepts.md).
+
+`reg-resource` / `reg-mutation` are on the `re-frame.core` facade; the events and subscriptions are keyword-addressed:
 
 ```clojure
 (:require [re-frame.core :as rf])
@@ -21,7 +27,11 @@ The resource surfaces are on the `re-frame.core` facade (`reg-resource` / `reg-m
   ```clojure
   (reg-resource resource-id metadata request-fn)
   ```
-- **Description**: Register a resource as data. The `metadata` is the MIDDLE registration-metadata map (the **required, fail-closed `:scope` policy**, `:params-schema`, `:doc`, …); the `request-fn` (which returns the [managed-HTTP args map](re-frame.http.md)) is the THIRD value slot. A non-map `metadata` is rejected loudly with `:rf.error/resource-bad-spec`. Validates the reconstructed spec — the **required, fail-closed `:scope` policy** first, then `:params-schema` — and writes a `:resource`-kind registrar entry. Returns `resource-id`. (The stored introspection spec from `resource-meta` reconstructs `:request` onto the metadata map.)
+- **Description**: Register a resource as data. Returns `resource-id`.
+  - `metadata` (middle slot): the registration-metadata map — the fail-closed `:scope` policy, `:params-schema`, `:doc`, and so on. A non-map `metadata` raises `:rf.error/resource-bad-spec`.
+  - `request-fn` (third slot): returns the [managed-HTTP args map](re-frame.http.md).
+  - Validates the reconstructed spec — `:scope` first, then `:params-schema` — then writes a `:resource`-kind registrar entry.
+  - The introspection spec stored for `resource-meta` reconstructs `:request` onto the metadata map.
 
 #### The resource spec
 
@@ -51,14 +61,14 @@ The resource surfaces are on the `re-frame.core` facade (`reg-resource` / `reg-m
 | Key | Notes |
 |---|---|
 | `:params-schema` | Validates and canonicalizes params (the resource's identity). |
-| `:scope` | The scope **policy** — `:rf.scope/global`, a resolver, or `:rf.scope/from-caller`. **Required, fail-closed** — no policy is a loud `:rf.error/resource-missing-scope-policy`. There is no implicit default; a user-scoped read must say so. |
+| `:scope` | The scope **policy** — `:rf.scope/global`, a resolver, or `:rf.scope/from-caller`. Fail-closed — no policy is a loud `:rf.error/resource-missing-scope-policy`. There is no implicit default; a user-scoped read must say so. |
 | request fn (3rd positional arg) | For `:transport :rf.http/managed`, returns a [managed-HTTP args map](re-frame.http.md). MUST NOT supply `:request-id` / `:on-success` / `:on-failure` — the runtime supplies those from the scoped key + generation (supplying one raises `:rf.error/resource-reserved-request-key`). |
 
-These three (`:params-schema`, `:scope`, request fn) are the registration gate — a `reg-resource` missing any of them throws. `:data-schema` is **not** part of the gate; it is optional — it validates successful data when present, but the registration gate does not enforce it.
+These three (`:params-schema`, `:scope`, request fn) are the registration gate — a `reg-resource` missing any of them throws. `:data-schema` is not part of the gate: it validates successful data when present, but the gate does not enforce it.
 
-**Optional keys**: `:doc`, `:data-schema` (validates successful data when present / transport decode supports it — not enforced by the registration gate), `:transport` (initial scope: `:rf.http/managed`), `:stale-after-ms`, `:gc-after-ms`, `:poll-interval-ms` (the active-owner poll interval — see [Polling](#polling)), `:infinite` + the infinite-only keys (`:next-page-param`, `:prev-page-param`, `:page->items`, `:initial-page-param`, `:page-data-schema`, `:refetch` — see [Infinite resources](#infinite-resources)), `:tags`, `:sensitive?` / `:large?` / schema-based classification.
+**Optional keys**: `:doc`, `:data-schema` (validates successful data when present / transport decode supports it — not enforced by the gate), `:transport` (initial scope: `:rf.http/managed`), `:stale-after-ms`, `:gc-after-ms`, `:poll-interval-ms` (the active-owner poll interval — see [Polling](#polling)), `:infinite` plus the infinite-only keys (`:next-page-param`, `:prev-page-param`, `:page->items`, `:initial-page-param`, `:page-data-schema`, `:refetch` — see [Infinite resources](#infinite-resources)), `:tags`, `:sensitive?` / `:large?` / schema-based classification.
 
-**Not in the v1 registration surface** (unused — the registration gate neither reads nor validates them): `:revalidate`, `:placeholder`, `:cache-key`, `:select`, transport extension protocols. (Interval polling is `:poll-interval-ms`; the `:infinite` load-more kind — see [Infinite resources](#infinite-resources).) The mutation-only keys (`:invalidates`, `:patches`, `:populates`, `:removes`, `:optimistic`, `:optimistic-tags`, `:on-conflict`) are **not resource-registration keys** — they live on `reg-mutation`.
+**Not in the v1 registration surface** (the gate neither reads nor validates them): `:revalidate`, `:placeholder`, `:cache-key`, `:select`, transport extension protocols. (Interval polling is `:poll-interval-ms`; the load-more kind is `:infinite` — see [Infinite resources](#infinite-resources).) The mutation-only keys (`:invalidates`, `:patches`, `:populates`, `:removes`, `:optimistic`, `:optimistic-tags`, `:on-conflict`) are not resource-registration keys — they live on `reg-mutation`.
 
 #### Scope policy
 
@@ -66,11 +76,16 @@ These three (`:params-schema`, `:scope`, request fn) are the registration gate �
 
 | Policy | Meaning |
 |---|---|
-| `:rf.scope/global` | The resource is **explicitly** global — a claim that the same params produce the same data for every user/tenant/permission/locale/impersonation state. Auditable, not a convenience default. |
+| `:rf.scope/global` | The resource is explicitly global — a claim that the same params produce the same data for every user/tenant/permission/locale/impersonation state. Auditable, not a convenience default. |
 | `<resolver>` | Derive the scope. A route-resource resolver is `(fn [route ctx] …)`; a sub-resolvable resolver is a pure data value or a fn-of-nothing. A reusable named resolver is registered with [`reg-resource-scope`](#reg-resource-scope) and referenced as `{:from-db <scope-id>}`. |
 | `:rf.scope/from-caller` | Scope required from the use site — every ensure / refetch / state call must supply `:scope` (or a route resolver must); reaching the resource without one raises `:rf.error/resource-scope-required-from-caller`. |
 
-There is no `[:rf.scope/global]` fallthrough. Event resolution precedence: payload `:scope` → route resolver → spec resolver. A `{:from-db <id>}` reference that resolves `nil` at an event/route site raises `:rf.error/resource-scope-unresolved-reference`. Subscription resolution: payload `:scope` → sub-resolvable spec policy → loud `:rf.error/resource-sub-unresolved-scope` (never a silent global read or `:idle`). See [Guide ch.27 §Scope](../resources/concepts.md).
+There is no `[:rf.scope/global]` fallthrough.
+
+- Event resolution precedence: payload `:scope` → route resolver → spec resolver. A `{:from-db <id>}` reference that resolves `nil` at an event/route site raises `:rf.error/resource-scope-unresolved-reference`.
+- Subscription resolution: payload `:scope` → sub-resolvable spec policy → loud `:rf.error/resource-sub-unresolved-scope` (never a silent global read or `:idle`).
+
+See [Guide ch.27 §Scope](../resources/concepts.md).
 
 ### `clear-resource`
 
@@ -79,14 +94,16 @@ There is no `[:rf.scope/global]` fallthrough. Event resolution precedence: paylo
   ```clojure
   (clear-resource resource-id)
   ```
-- **Description**: Remove a registered resource. A **registration-lifecycle** operation — NOT the normal cache-invalidation API (for data lifecycle use `:rf.resource/invalidate-tags` / `:rf.resource/remove` / `:rf.resource/clear-scope`). Also disposes the resource-runtime state for the id in each affected frame (release owner indexes, cancel timers/host handles, abort in-flight where possible, suppress late replies by generation, remove tag-index rows, emit a trace). Returns `resource-id`.
+- **Description**: Remove a registered resource. Returns `resource-id`.
+  - A **registration-lifecycle** operation, NOT cache invalidation. For data lifecycle use `:rf.resource/invalidate-tags` / `:rf.resource/remove` / `:rf.resource/clear-scope`.
+  - Also disposes the resource-runtime state for the id in each affected frame: releases owner indexes, cancels timers/host handles, aborts in-flight where possible, suppresses late replies by generation, removes tag-index rows, and emits a trace.
 
 ```clojure
 ;; deregister a resource (registration-lifecycle — e.g. on hot-reload / teardown)
 (rf/clear-resource :feed/timeline)
 ```
 
-A **mutation** is the causal-WRITE counterpart of a resource: a named write to remote state that, on success, invalidates / patches / populates cached resource reads. The write lowers through the **same** `:rf.http/managed` transport as resources, and the runtime owns reply addressing + stale-suppression (work-id + generation) exactly as for reads. Runtime state is keyed by mutation **instance** id, so concurrent submissions of the same mutation never clobber each other. The tutorial is [Guide ch.27 §Mutations](../resources/concepts.md).
+A mutation is the causal-WRITE counterpart of a resource: a named write to remote state that, on success, invalidates / patches / populates cached resource reads. The write lowers through the same `:rf.http/managed` transport as resources, and the runtime owns reply addressing + stale-suppression (work-id + generation) exactly as for reads. Runtime state is keyed by mutation **instance** id, so concurrent submissions of the same mutation never clobber each other. See [Guide ch.27 §Mutations](../resources/concepts.md).
 
 ### `reg-mutation`
 
@@ -95,7 +112,12 @@ A **mutation** is the causal-WRITE counterpart of a resource: a named write to r
   ```clojure
   (reg-mutation mutation-id metadata request-fn)
   ```
-- **Description**: Register a mutation as data under `mutation-id`. The `metadata` is the MIDDLE registration-metadata map (`:params-schema`, `:invalidates`, `:patches`, `:doc`, …); the `request-fn` (the [managed-HTTP write](re-frame.http.md)) is the THIRD value slot. A non-map `metadata` is rejected loudly with `:rf.error/mutation-bad-spec`. Validates the reconstructed spec and writes a `:mutation`-kind registrar entry (the causal-write counterpart of `:resource`). Returns `mutation-id`. An app that omits the resources artefact sees the wrapper throw `:rf.error/resources-artefact-missing`. (The stored introspection spec from `mutation-meta` reconstructs `:request` onto the metadata map.)
+- **Description**: Register a mutation as data under `mutation-id`. Returns `mutation-id`. The causal-write counterpart of `:resource`.
+  - `metadata` (middle slot): the registration-metadata map — `:params-schema`, `:invalidates`, `:patches`, `:doc`, and so on. A non-map `metadata` raises `:rf.error/mutation-bad-spec`.
+  - `request-fn` (third slot): the [managed-HTTP write](re-frame.http.md).
+  - Validates the reconstructed spec and writes a `:mutation`-kind registrar entry.
+  - An app that omits the resources artefact sees the wrapper throw `:rf.error/resources-artefact-missing`.
+  - The introspection spec stored for `mutation-meta` reconstructs `:request` onto the metadata map.
 
 ```clojure
 (rf/reg-mutation :article/save
@@ -123,15 +145,28 @@ A **mutation** is the causal-WRITE counterpart of a resource: a named write to r
 | Key | Notes |
 |---|---|
 | `:params-schema` | Validates and canonicalizes the write's params. |
-| request fn (3rd positional arg) | Returns a [managed-HTTP args map](re-frame.http.md) (the write). MUST NOT supply `:request-id` / `:on-success` / `:on-failure` — the runtime supplies those from the instance + generation (supplying one raises `:rf.error/resource-reserved-request-key`). **Write retries are OPT-IN** and live in this returned args map's own `:retry` (see the note below) — never a `reg-mutation` spec key. |
+| request fn (3rd positional arg) | Returns a [managed-HTTP args map](re-frame.http.md) (the write). MUST NOT supply `:request-id` / `:on-success` / `:on-failure` — the runtime supplies those from the instance + generation (supplying one raises `:rf.error/resource-reserved-request-key`). Write retries are **opt-in** and live in this returned args map's own `:retry` (see the note below) — never a `reg-mutation` spec key. |
 
-**Optional keys**: `:invalidates` (`(fn [params result] → #{tag …})` — the tags made stale on success, composed with `:rf.resource/invalidate-tags`, scoped), `:patches` / `:populates` (controlled resource-entry transforms / seeds applied on success **before** invalidation, keyed by scoped key, via the same durable entry shape + structural sharing the read path uses), `:removes` (`(fn [params result] → [target …])` — controlled resource-entry removals applied on success, same map-form exact targets `{:resource :params :scope}`; a removed key's in-flight attempt is best-effort aborted), `:scope` (the cache scope the invalidation / patch / populate targets), `:invalidate-timing` (`:after-success` (default) | `:before-request` | `:after-failure` | `:after-settle` — a value outside the closed enum is rejected with `:rf.error/mutation-bad-spec`), `:transport`, `:doc`.
+**Optional keys**:
 
-> **`:retry` is NOT a `reg-mutation` spec key.** Write retries are opt-in and ride the [managed-HTTP args](re-frame.http.md) your `:request` fn returns — put `:retry {…}` in *that* map. The runtime passes the `:request` args through to the transport unchanged and does **not** read or enforce a spec-level `:retry`; there is no `reg-mutation`-level retry to arm. (Reads inherit the same discipline — see [Managed HTTP reference §Retry](../async/http.md#retry-transport-retry-as-data): re-issuing a non-idempotent write because a reply was merely slow is the double-write bug, so retry stays explicit and per-request.)
+- `:invalidates` — `(fn [params result] → #{tag …})`, the tags made stale on success, composed with `:rf.resource/invalidate-tags`, scoped.
+- `:patches` / `:populates` — controlled resource-entry transforms / seeds applied on success **before** invalidation, keyed by scoped key, via the same durable entry shape + structural sharing the read path uses.
+- `:removes` — `(fn [params result] → [target …])`, controlled resource-entry removals applied on success; same map-form exact targets `{:resource :params :scope}`; a removed key's in-flight attempt is best-effort aborted.
+- `:scope` — the cache scope the invalidation / patch / populate targets.
+- `:invalidate-timing` — `:after-success` (default) | `:before-request` | `:after-failure` | `:after-settle`. A value outside the closed enum is rejected with `:rf.error/mutation-bad-spec`.
+- `:transport`, `:doc`.
 
-> **Mutation `:scope` is not fail-closed.** Unlike a resource read — whose `:scope` is **required** and fails closed — a mutation's `:scope` is optional and resolves payload `:scope` → spec `:scope` → `:rf.scope/global`. The scope decides which cache scope the success-time invalidate / patch / populate targets, so it **MUST match the scope of the resources the write changes**: a write against user/tenant/locale-scoped entries that omits `:scope` invalidates the `[:rf.scope/global]` cache instead and silently misses the scoped entries (stale reads, no error). Pass `:scope` on `[:rf.mutation/execute …]` when the principal is known only at the call site; the `:rf.scope/from-caller` *policy* is a resource-read concept, not a mutation one.
+> **`:retry` is NOT a `reg-mutation` spec key.** Write retries are opt-in and ride the [managed-HTTP args](re-frame.http.md) your `:request` fn returns — put `:retry {…}` in *that* map. The runtime passes the `:request` args through to the transport unchanged and does not read or enforce a spec-level `:retry`; there is no `reg-mutation`-level retry to arm. (Reads inherit the same discipline — see [Managed HTTP reference §Retry](../async/http.md#retry-transport-retry-as-data): re-issuing a non-idempotent write because a reply was merely slow is the double-write bug, so retry stays explicit and per-request.)
 
-**Optimistic keys** (see [EP-0019](../EP/EP-0019-optimistic-mutation-rollback.md) and [Guide ch.27 §Optimistic writes](../resources/concepts.md#optimistic-writes-commit-roll-back-or-reconcile)): `:optimistic` is a registration-level forward plan (the twin of `:patches`, signature `(fn [params] → {target patch-fn})` — no `result`; the reply does not exist yet) applied **before** the server confirms; `:optimistic-tags` is its tag-addressed twin for cross-view consistency; `:on-conflict` (`:invalidate` default | `:force`) decides the contested-rollback policy. The **inverse is runtime-recorded** — the author supplies no `:rollback` registration key; the runtime snapshots each touched entry (with its `:revision`) on the instance row's `:patch-summary` `:rollback` slot and settles via the commit/rollback/reconcile protocol. An optimistic plan combined with `:invalidate-timing :before-request` is contradictory and rejected at registration with `:rf.error/mutation-optimistic-before-request`.
+> **Mutation `:scope` is not fail-closed.** Unlike a resource read — whose `:scope` is required and fails closed — a mutation's `:scope` is optional and resolves payload `:scope` → spec `:scope` → `:rf.scope/global`. The scope decides which cache scope the success-time invalidate / patch / populate targets, so it MUST match the scope of the resources the write changes: a write against user/tenant/locale-scoped entries that omits `:scope` invalidates the `[:rf.scope/global]` cache instead and silently misses the scoped entries (stale reads, no error). Pass `:scope` on `[:rf.mutation/execute …]` when the principal is known only at the call site; the `:rf.scope/from-caller` *policy* is a resource-read concept, not a mutation one.
+
+**Optimistic keys** (see [EP-0019](../EP/EP-0019-optimistic-mutation-rollback.md) and [Guide ch.27 §Optimistic writes](../resources/concepts.md#optimistic-writes-commit-roll-back-or-reconcile)):
+
+- `:optimistic` — a registration-level forward plan (the twin of `:patches`, signature `(fn [params] → {target patch-fn})` — no `result`; the reply does not exist yet) applied **before** the server confirms.
+- `:optimistic-tags` — its tag-addressed twin for cross-view consistency.
+- `:on-conflict` — `:invalidate` (default) | `:force`, the contested-rollback policy.
+
+The inverse is runtime-recorded: the author supplies no `:rollback` registration key. The runtime snapshots each touched entry (with its `:revision`) on the instance row's `:patch-summary` `:rollback` slot and settles via the commit/rollback/reconcile protocol. An optimistic plan combined with `:invalidate-timing :before-request` is contradictory and rejected at registration with `:rf.error/mutation-optimistic-before-request`.
 
 ### `clear-mutation`
 
@@ -140,7 +175,7 @@ A **mutation** is the causal-WRITE counterpart of a resource: a named write to r
   ```clojure
   (clear-mutation mutation-id)
   ```
-- **Description**: Remove a registered mutation — a **registration-lifecycle** operation, NOT a form-error reset. For the causal runtime-instance reset use the `[:rf.mutation/clear …]` event. Returns `mutation-id`.
+- **Description**: Remove a registered mutation. Returns `mutation-id`. A **registration-lifecycle** operation, NOT a form-error reset. For the causal runtime-instance reset use the `[:rf.mutation/clear …]` event.
 
 ```clojure
 ;; deregister a mutation (registration-lifecycle — NOT the runtime-instance reset)
@@ -149,7 +184,7 @@ A **mutation** is the causal-WRITE counterpart of a resource: a named write to r
 
 ## Named scope resolvers
 
-A resource-scope resolver is the **third resources kind** (alongside resources and mutations) — a registrar entry under the `:resource-scope` kind that derives a **cache scope** from declared `app-db` inputs. It is the one scope-resolution currency the same named resolver carries to resource registration, route resources, event-side `ensure`, subscriptions, invalidation descriptors, populate/patch/remove targets, and `clear-scope`. A resource (or payload, or route) references a named resolver as `{:from-db <scope-id>}`; the reference is resolved at **use time** against the frame's `app-db`. A `nil` resolution is **fail-closed** at every scope-requiring site — never an implicit global read.
+A resource-scope resolver is the third resources kind (alongside resources and mutations): a registrar entry under the `:resource-scope` kind that derives a cache scope from declared `app-db` inputs. It is the one scope-resolution currency the same named resolver carries to resource registration, route resources, event-side `ensure`, subscriptions, invalidation descriptors, populate/patch/remove targets, and `clear-scope`. A resource (or payload, or route) references a named resolver as `{:from-db <scope-id>}`; the reference is resolved at **use time** against the frame's `app-db`. A `nil` resolution is **fail-closed** at every scope-requiring site — never an implicit global read.
 
 ### `reg-resource-scope`
 
@@ -159,7 +194,12 @@ A resource-scope resolver is the **third resources kind** (alongside resources a
   (reg-resource-scope scope-id metadata resolve-fn)
   (reg-resource-scope scope-id resolve-fn)           ;; whole-db sugar (no metadata)
   ```
-- **Description**: Register a PURE named scope resolver under `scope-id` in the canonical 3-slot grammar: the `:resolve` fn is the value (third) slot, and `metadata` — the middle slot — carries the declared `:inputs {name [:db <rf-path>]}` (plus optional `:doc`). The resolver's first arg is ALWAYS the resolved inputs map (the one stable Name-over-place meaning). **Omitting `:inputs`** (the 2-arg sugar, or a `:doc`-only metadata) selects the whole-db form — the resolver reads the whole db as its first arg (the one deliberate, documented exception). The only shipped input source is `[:db <rf-path>]` (a concrete `:rf/path`); `[:runtime …]` (route-derived scope) is **reserved** and rejected loudly with `:rf.error/resource-scope-source-reserved`. The resolver fn MUST be pure (it MUST NOT fetch, dispatch, mutate state, or read ambient host state); the `ctx` arg is reserved and invoked as literal `nil` in this slice. A `nil` resolve result is **fail-closed**. A non-map metadata, a malformed `:inputs` descriptor, a `:resolve` left inside the metadata map, or a non-fn value slot is rejected loudly with `:rf.error/invalid-resource-scope-spec`. Writes a `:resource-scope`-kind registrar entry carrying the canonical spec plus captured source coords; returns `scope-id`. Implementation ships in `day8/re-frame2-resources`; require `re-frame.resources` at boot — an app that omits the artefact sees the wrapper throw `:rf.error/resources-artefact-missing`.
+- **Description**: Register a **pure** named scope resolver under `scope-id` in the canonical 3-slot grammar. Returns `scope-id`. Ships in `day8/re-frame2-resources`; require `re-frame.resources` at boot — an app that omits the artefact sees the wrapper throw `:rf.error/resources-artefact-missing`.
+  - `resolve-fn` (value/third slot): the resolver. Its first arg is ALWAYS the resolved inputs map. It MUST be pure — it MUST NOT fetch, dispatch, mutate state, or read ambient host state. The `ctx` arg is reserved and invoked as literal `nil` in this slice. A `nil` resolve result is fail-closed.
+  - `metadata` (middle slot): carries the declared `:inputs {name [:db <rf-path>]}` plus optional `:doc`. The only shipped input source is `[:db <rf-path>]` (a concrete `:rf/path`); `[:runtime …]` (route-derived scope) is reserved and rejected with `:rf.error/resource-scope-source-reserved`.
+  - Whole-db form: omitting `:inputs` (the 2-arg sugar, or a `:doc`-only metadata) makes the resolver read the whole db as its first arg (the one deliberate, documented exception).
+  - A non-map metadata, a malformed `:inputs` descriptor, a `:resolve` left inside the metadata map, or a non-fn value slot is rejected with `:rf.error/invalid-resource-scope-spec`.
+  - Writes a `:resource-scope`-kind registrar entry carrying the canonical spec plus captured source coords.
 
 ```clojure
 (rf/reg-resource-scope :realworld/session
@@ -177,7 +217,7 @@ A resource-scope resolver is the **third resources kind** (alongside resources a
   ```clojure
   (clear-resource-scope scope-id)
   ```
-- **Description**: Remove a registered resource-scope resolver — a **registration-lifecycle** removal (the `clear-` decrement counterpart of `reg-resource-scope`). A resolver holds no per-frame runtime state of its own (it is a pure derivation consulted at use time), so there is nothing to dispose beyond the registrar entry. A no-op (returns `scope-id`) when the id is not registered.
+- **Description**: Remove a registered resource-scope resolver — a **registration-lifecycle** removal (the `clear-` counterpart of `reg-resource-scope`). A resolver holds no per-frame runtime state (it is a pure derivation consulted at use time), so nothing is disposed beyond the registrar entry. A no-op that returns `scope-id` when the id is not registered.
 
 ```clojure
 ;; deregister a named scope resolver (registration-lifecycle — e.g. on hot-reload / teardown)
@@ -191,7 +231,11 @@ A resource-scope resolver is the **third resources kind** (alongside resources a
   ```clojure
   (resolve-resource-scope db scope-id) → scope or nil
   ```
-- **Description**: Resolver **helper**: resolve the named resolver `scope-id` against the supplied `db` value, returning a canonical concrete scope or nil. A **pure** function over the resolver registry — NOT an effect: no app-state / dispatch side effects, and no observability side effect (it does NOT emit `:rf.resource/scope-resolved` trace; the causal `{:from-db …}` / route-entry / mutation-settle boundaries carry that evidence instead). The canonical use is the **logout / account-switch idiom**: resolve the concrete old scope from the handler's coeffect `db` (pre-transition by definition — the causal input) and pass it concretely to `[:rf.resource/clear-scope …]`. Throws `:rf.error/resource-scope-not-registered` when no resolver is registered under `scope-id` (the loud fail-closed boundary — a typo'd reference is never a silent nil). A resolver that returns nil for the supplied db yields nil (the fail-closed unresolved condition; the use site interprets it — never an implicit global).
+- **Description**: Resolver **helper**: resolve the named resolver `scope-id` against the supplied `db` value, returning a canonical concrete scope or nil.
+  - A pure function over the resolver registry, NOT an effect: no app-state / dispatch side effects, and no observability side effect (it does NOT emit a `:rf.resource/scope-resolved` trace; the causal `{:from-db …}` / route-entry / mutation-settle boundaries carry that evidence).
+  - Throws `:rf.error/resource-scope-not-registered` when no resolver is registered under `scope-id` (a typo'd reference is never a silent nil).
+  - A resolver that returns nil for the supplied db yields nil (the fail-closed unresolved condition; the use site interprets it — never an implicit global).
+  - Canonical use is the logout / account-switch idiom: resolve the concrete old scope from the handler's coeffect `db` (pre-transition by definition — the causal input) and pass it concretely to `[:rf.resource/clear-scope …]`.
 
 ```clojure
 ;; the logout idiom: resolve the concrete OLD scope off the coeffect db,
@@ -233,7 +277,7 @@ A resource-scope resolver is the **third resources kind** (alongside resources a
 
 ## Revalidation listeners
 
-Active-stale revalidation is expressed as **resource events** (see [`[:rf.resource/window-focused]` / `[:rf.resource/network-reconnected]`](#rfresourcewindow-focused--rfresourcenetwork-reconnected)), never subscription-driven fetching. On window focus / tab-return / network reconnect, the frame's active-owner **stale** entries are rescanned and refetched by policy — a stale entry with no active owner is left alone (revalidation creates no liveness). The host-listener install/remove fns below wire (and tear down) the `window` listeners that dispatch those events.
+Active-stale revalidation is expressed as **resource events** (see [`[:rf.resource/window-focused]` / `[:rf.resource/network-reconnected]`](#rfresourcewindow-focused--rfresourcenetwork-reconnected)), never subscription-driven fetching. On window focus / tab-return / network reconnect, the frame's active-owner **stale** entries are rescanned and refetched by policy — a stale entry with no active owner is left alone (revalidation creates no liveness). The host-listener install/remove fns below wire and tear down the `window` listeners that dispatch those events.
 
 ### `install-revalidation-listeners!` / `remove-revalidation-listeners!`
 
@@ -243,7 +287,11 @@ Active-stale revalidation is expressed as **resource events** (see [`[:rf.resour
   (install-revalidation-listeners! frame-id)   ;; → nil
   (remove-revalidation-listeners!  frame-id)   ;; → nil
   ```
-- **Description**: `install-revalidation-listeners!` wires three host listeners for `frame-id` — `focus` (on `window`) and `visibilitychange`-to-visible (on `document`, its only valid event target) → `[:rf.resource/window-focused]`, and `online` (on `window`) → `[:rf.resource/network-reconnected]` — each dispatched at `frame-id`. Idempotent (re-installing replaces, never stacks — hot-reload safe); CLJS-only (the JVM/SSR arm is a no-op). Listeners are recorded in a host side table and cancelled on frame destroy via the single `:resources/on-frame-destroyed!` hook. `remove-revalidation-listeners!` tears them down (useful for test isolation and single-page hosts that rotate which frame owns revalidation); a no-op when none is installed.
+- **Description**: `install-revalidation-listeners!` wires three host listeners for `frame-id`, each dispatched at `frame-id`:
+  - `focus` (on `window`) and `visibilitychange`-to-visible (on `document`, its only valid event target) → `[:rf.resource/window-focused]`.
+  - `online` (on `window`) → `[:rf.resource/network-reconnected]`.
+
+  Idempotent (re-installing replaces, never stacks — hot-reload safe); CLJS-only (the JVM/SSR arm is a no-op). Listeners are recorded in a host side table and cancelled on frame destroy via the single `:resources/on-frame-destroyed!` hook. `remove-revalidation-listeners!` tears them down (useful for test isolation and single-page hosts that rotate which frame owns revalidation); a no-op when none is installed.
 
 ```clojure
 ;; at boot, after the frame is live: wire focus / visibility / online revalidation
@@ -255,7 +303,7 @@ Active-stale revalidation is expressed as **resource events** (see [`[:rf.resour
 
 ## Polling
 
-A resource may declare an optional **`:poll-interval-ms`** policy: while an entry has at least one **active owner** and the document is **visible**, the runtime re-runs its load every N ms — without any component-side fetch call (re-frame2's counterpart of TanStack Query's `refetchInterval` / SWR's `refreshInterval` / RTK Query's `pollingInterval`). Polling is **owner-driven** (it tracks the active-owner lease, not a component observer), so a route / machine / app-minted lease keeps it alive and the instant the last owner releases polling stops.
+A resource may declare an optional `:poll-interval-ms` policy: while an entry has at least one **active owner** and the document is **visible**, the runtime re-runs its load every N ms, with no component-side fetch call. Polling is owner-driven — it tracks the active-owner lease, not a component observer — so a route / machine / app-minted lease keeps it alive and polling stops the instant the last owner releases.
 
 ```clojure
 (rf/reg-resource :notifications/unread-count
@@ -269,7 +317,7 @@ A resource may declare an optional **`:poll-interval-ms`** policy: while an entr
 Semantics (per [Guide ch.27 §Polling](../resources/concepts.md#polling-keep-this-fresh-every-n-ms)):
 
 - **Positive integer ms; non-positive / absent = no polling.** The poll timer is the third member of the freshness-timer family (beside `:stale-after-ms` / `:gc-after-ms`).
-- **Unconditional active-owner tick.** A tick refetches **by the interval**, not gated on `:stale?` — the consumer asked for "re-read every N ms". `:stale-after-ms` stays the orthogonal focus/route-entry knob. (Structural sharing keeps views quiet when an unchanged response comes back.)
+- **Unconditional active-owner tick.** A tick refetches by the interval, not gated on `:stale?`. `:stale-after-ms` stays the orthogonal focus/route-entry knob. (Structural sharing keeps views quiet when an unchanged response comes back.)
 - **Cause `:poll`, never an owner.** A poll refetch creates no liveness, extends no GC; generation + stale-reply suppression apply exactly as for any refetch.
 - **Default-pause-when-hidden.** Poll ticks are suppressed while the tab is hidden and resume on tab return (which also fires the focus scan). A `:poll-when-hidden?` opt-in for a true background monitor is reserved.
 - **Coalescing.** A tick that finds a live in-flight refetch skips (no overlap on a slow endpoint); focus + poll never double-fetch.
@@ -279,7 +327,7 @@ A "just polling" view with no natural route/machine owner needs an app-minted `[
 
 ## Infinite resources
 
-An **infinite resource** is the load-more / infinite-scroll feed counterpart of TanStack Query's `useInfiniteQuery` / SWR's `useSWRInfinite` (see [EP-0021](../EP/EP-0021-infinite-resources.md); tutorial in [Guide ch.27 §Infinite feeds](../resources/concepts.md#infinite-feeds-accumulate-pages-with-infinite)). It is a resource registered with `:infinite true` plus a pure `:next-page-param`; the user accumulates pages (1, then 1+2, then 1+2+3) rendered as one growing list, with the *next* page param derived from the last page's data. Numbered / cursor pagination (`:keep-previous?` + per-page entries) is untouched and orthogonal — an app picks per feed.
+An infinite resource is the load-more / infinite-scroll feed kind (see [EP-0021](../EP/EP-0021-infinite-resources.md); tutorial in [Guide ch.27 §Infinite feeds](../resources/concepts.md#infinite-feeds-accumulate-pages-with-infinite)). It is a resource registered with `:infinite true` plus a pure `:next-page-param`; the user accumulates pages (1, then 1+2, then 1+2+3) rendered as one growing list, with the *next* page param derived from the last page's data. Numbered / cursor pagination (`:keep-previous?` + per-page entries) is untouched and orthogonal — an app picks per feed.
 
 ```clojure
 (rf/reg-resource :feed/timeline
@@ -303,7 +351,7 @@ An **infinite resource** is the load-more / infinite-scroll feed counterpart of 
 Key semantics:
 
 - **`:infinite true` makes `:next-page-param` required** (a loud `:rf.error/infinite-missing-next-page-param` otherwise). It is pure `(last-page all-pages) → next-param-or-nil`; returning `nil` is the single canonical terminal, exposed as the derived `:has-next-page?`.
-- **One scoped entry per feed.** Pages accumulate as an ordered vector inside the one `:rf.runtime/resources` entry — **not** N per-page entries, **not** an app-db slice — so the feed has one owner set / freshness clock / GC clock / SSR-restore unit / Xray row. The per-page param is internal sequencing state, **never** part of the cache key; changing the identity params yields a different feed instance.
+- **One scoped entry per feed.** Pages accumulate as an ordered vector inside the one `:rf.runtime/resources` entry — not N per-page entries, not an app-db slice — so the feed has one owner set / freshness clock / GC clock / SSR-restore unit / Xray row. The per-page param is internal sequencing state, never part of the cache key; changing the identity params yields a different feed instance.
 - **`:page-data-schema` validates one page** and is the per-page egress/classification contract (applied per page on SSR/tool projection); `:data-schema` is not used for the accumulated vector.
 - **Other infinite-only keys**: `:prev-page-param` (the bidirectional derivation mirror — defined, but the `load-prev` prepend event is deferred; v1 ships next-direction load-more only), `:initial-page-param` (the first-page param, default `nil`), `:page->items` (required for non-vector pages), and `:refetch` (`{:refetch-all-pages? false}` by default — the conservative window-preserving refetch policy, with `:refetch-all-pages?` / `:refetch-window` opt-ins).
 
@@ -322,7 +370,12 @@ A view reads the merged list and dispatches the causal `[:rf.resource/load-more 
 
 ## Introspection and projection (tool/test lane)
 
-These direct functions are the **tool/test projection lane** — not an app-read API. `resource-meta` / `mutation-meta` project the **registration** (the registered spec); `resource-state` / `resources` / `mutation-state` / `mutations` project **runtime state** (the live entries) as a one-shot, non-reactive snapshot at an explicit frame. They serve Xray, unit tests, and SSR serialization — contexts with no reactive subscription. **App views read runtime state through the passive [`:rf.resource/*` / `:rf.mutation/*` subscriptions](#resource-subscriptions-passive)**, never through these functions, which do not re-render on change. Registering a handler, dispatching a cause, projecting a snapshot, and subscribing are four distinct jobs; see [Guide ch.27 §Three lanes](../resources/concepts.md#three-lanes--registering-causing-projecting).
+These direct functions are the tool/test projection lane, not an app-read API:
+
+- `resource-meta` / `mutation-meta` project the **registration** (the registered spec).
+- `resource-state` / `resources` / `mutation-state` / `mutations` project **runtime state** (the live entries) as a one-shot, non-reactive snapshot at an explicit frame.
+
+They serve Xray, unit tests, and SSR serialization — contexts with no reactive subscription. App views read runtime state through the passive [`:rf.resource/*` / `:rf.mutation/*` subscriptions](#resource-subscriptions-passive), never through these functions, which do not re-render on change. Registering a handler, dispatching a cause, projecting a snapshot, and subscribing are four distinct jobs; see [Guide ch.27 §Three lanes](../resources/concepts.md#three-lanes--registering-causing-projecting).
 
 `:frame` is an explicit, app-registered frame id ([EP-0002](../EP/EP-0002-frame-target-resolution.md) — no ambient `:rf/default` fallback; a frameless call with no resolvable context fails closed).
 
@@ -348,7 +401,10 @@ These direct functions are the **tool/test projection lane** — not an app-read
   ```clojure
   (resource-state {:resource … :scope … :params … :frame …}) → entry or nil
   ```
-- **Description**: A resource instance's durable runtime entry for an explicit-frame target, resolving the scoped key the same way a subscription does (a `{:from-db <id>}` scope resolves against the frame's app-db). nil when no entry exists. An absent / nil `:frame` raises `:rf.error/no-frame-context` (fail-closed — a nil pass-through would be indistinguishable from a genuinely absent entry); an explicit but unknown / destroyed `:frame` reads as nil.
+- **Description**: A resource instance's durable runtime entry for an explicit-frame target, resolving the scoped key the same way a subscription does (a `{:from-db <id>}` scope resolves against the frame's app-db).
+  - nil when no entry exists.
+  - An absent / nil `:frame` raises `:rf.error/no-frame-context` (fail-closed — a nil pass-through would be indistinguishable from a genuinely absent entry).
+  - An explicit but unknown / destroyed `:frame` reads as nil.
 
 ```clojure
 ;; the live durable entry for one scoped key, at an explicit frame
@@ -367,7 +423,9 @@ These direct functions are the **tool/test projection lane** — not an app-read
   (resources)            → {:resource-ids [...] :entries {}}
   (resources {:frame …}) → {:resource-ids [...] :entries {<key-id> <entry>}}
   ```
-- **Description**: Resource introspection for a frame target — the static registry (every registered id) plus, with `:frame`, the live per-frame resource-instance entries. The `:entries` map is keyed on the CEDN-1 byte `key-id` string (the same key the runtime storage / SSR wire use; it cannot collapse CEDN-distinct sequential-params entries the way an `=`-keyed scoped-key vector would). Each entry carries its kind-preserving scoped-resource-key `[scope resource-id params]` under `:resource/key` for destructure / scope-and-resource filtering.
+- **Description**: Resource introspection for a frame target — the static registry (every registered id) plus, with `:frame`, the live per-frame resource-instance entries.
+  - The `:entries` map is keyed on the CEDN-1 byte `key-id` string (the same key the runtime storage / SSR wire use; it cannot collapse CEDN-distinct sequential-params entries the way an `=`-keyed scoped-key vector would).
+  - Each entry carries its kind-preserving scoped-resource-key `[scope resource-id params]` under `:resource/key` for destructure / scope-and-resource filtering.
 
 ```clojure
 (rf/resources)                      ;; => {:resource-ids [...] :entries {}}  (static registry only)
@@ -409,7 +467,10 @@ These direct functions are the **tool/test projection lane** — not an app-read
   ```clojure
   (mutation-state {:instance … :frame …}) → row or nil
   ```
-- **Description**: A mutation **instance**'s durable runtime row (`{:status :result :error …}`) for an explicit-frame target, or nil. The frame is carried explicitly (see [EP-0002](../EP/EP-0002-frame-target-resolution.md)); an absent / nil `:frame` raises `:rf.error/no-frame-context` (fail-closed, symmetric with `resource-state`), and an explicit but unknown / destroyed `:frame` reads as nil.
+- **Description**: A mutation **instance**'s durable runtime row (`{:status :result :error …}`) for an explicit-frame target, or nil.
+  - The frame is carried explicitly (see [EP-0002](../EP/EP-0002-frame-target-resolution.md)).
+  - An absent / nil `:frame` raises `:rf.error/no-frame-context` (fail-closed, symmetric with `resource-state`).
+  - An explicit but unknown / destroyed `:frame` reads as nil.
 
 ```clojure
 ;; one mutation INSTANCE's runtime row, at an explicit frame
@@ -425,7 +486,9 @@ These direct functions are the **tool/test projection lane** — not an app-read
   (mutations)            → {:mutation-ids [...] :instances {}}
   (mutations {:frame …}) → {:mutation-ids [...] :instances {<instance-key-id> <row>}}
   ```
-- **Description**: Mutation introspection for a frame target — the registered mutation ids plus, with `:frame`, the live per-frame mutation-instance table. The `:instances` map is keyed on the CEDN-1 byte `key-id` of each instance id (the same identity discipline as `resources` `:entries`); each row carries its kind-preserving `:instance/id` and `:mutation/id` (Xray groups instances under the registered mutation id).
+- **Description**: Mutation introspection for a frame target — the registered mutation ids plus, with `:frame`, the live per-frame mutation-instance table.
+  - The `:instances` map is keyed on the CEDN-1 byte `key-id` of each instance id (the same identity discipline as `resources` `:entries`).
+  - Each row carries its kind-preserving `:instance/id` and `:mutation/id` (Xray groups instances under the registered mutation id).
 
 ```clojure
 (rf/mutations {:frame :rf/default})
@@ -446,21 +509,29 @@ These direct functions are the **tool/test projection lane** — not an app-read
 ;; => [:article/save]
 ```
 
-Xray exposes the same shapes plus the tool accessors (`list-resources`, `list-resource-instances`, `get-resource-state`, `get-resource-history`, `list-resource-invalidations`), the route/resource graph, the work-ledger table, and the **scope audit surface** (the standing enumeration of every `:rf.scope/global` resource). Tool accessors prefer summaries over raw values; params/scopes get the same privacy/size elision as data.
+Xray exposes the same shapes plus the tool accessors (`list-resources`, `list-resource-instances`, `get-resource-state`, `get-resource-history`, `list-resource-invalidations`), the route/resource graph, the work-ledger table, and the scope audit surface (the standing enumeration of every `:rf.scope/global` resource). Tool accessors prefer summaries over raw values; params/scopes get the same privacy/size elision as data.
 
 ## Keyword surfaces
 
-The resource and mutation runtime is **caused** and **read** entirely through keyword-addressed events and subscriptions — never by calling a function. Resources are caused to fetch by events and read passively by subscriptions; the same split applies to mutations.
+The resource and mutation runtime is caused and read entirely through keyword-addressed events and subscriptions — never by calling a function. Resources are caused to fetch by events and read passively by subscriptions; the same split applies to mutations.
 
 ### Resource events (map payloads)
 
-Resource events take a **map payload**, not a positional argument vector. The resource-addressed events validate their target: an unregistered `:resource` raises `:rf.error/resource-not-registered`, params that fail `:params-schema` raise `:rf.error/resource-invalid-params`, and scope resolution is fail-closed (`:rf.error/resource-scope-required-from-caller` / `:rf.error/resource-scope-unresolved-reference` — see [Scope policy](#scope-policy)).
+Resource events take a **map payload**, not a positional argument vector. The resource-addressed events validate their target:
+
+- An unregistered `:resource` raises `:rf.error/resource-not-registered`.
+- Params that fail `:params-schema` raise `:rf.error/resource-invalid-params`.
+- Scope resolution is fail-closed (`:rf.error/resource-scope-required-from-caller` / `:rf.error/resource-scope-unresolved-reference` — see [Scope policy](#scope-policy)).
 
 #### `[:rf.resource/ensure {…}]`
 
 - **Kind**: event
 - **Payload**: `{:resource :scope :params :owner :cause :keep-previous?}`
-- **Description**: Ensure the resource instance is loaded. `ensure` while the same scoped key is already in flight **joins** the existing work (attaches the owner, records the cause, emits a dedupe trace); an `ensure` of an already-`:loaded` entry still fresh-by-policy is a fresh-skip (serves the cached value, attaches the owner, emits `:rf.resource/cache-hit` — no fetch). `:owner` changes the active-owner set; `:cause` is recorded in trace/history. `:keep-previous?` on a first-loading key records a projection pointer to the prior loaded sibling key so `:rf.resource/previous-data` can show old data while the new key loads (never inserted into the new entry).
+- **Description**: Ensure the resource instance is loaded.
+  - `ensure` while the same scoped key is already in flight **joins** the existing work (attaches the owner, records the cause, emits a dedupe trace).
+  - `ensure` of an already-`:loaded` entry still fresh-by-policy is a fresh-skip: serves the cached value, attaches the owner, emits `:rf.resource/cache-hit`, no fetch.
+  - `:owner` changes the active-owner set; `:cause` is recorded in trace/history.
+  - `:keep-previous?` on a first-loading key records a projection pointer to the prior loaded sibling key so `:rf.resource/previous-data` can show old data while the new key loads (never inserted into the new entry).
 
 ```clojure
 [:rf.resource/ensure
@@ -489,7 +560,10 @@ Resource events take a **map payload**, not a positional argument vector. The re
 
 - **Kind**: event
 - **Payload**: `{:scope :tags :cause :cross-scope?}`
-- **Description**: Mark entries whose tags intersect `:tags` stale; refetch entries with active owners; leave inactive entries stale or GC-eligible. **Scoped by default** — a scoped invalidation with no `:scope` raises `:rf.error/resource-invalidate-scope-required` (never a silent nil-scope match). A cross-scope invalidation opts in explicitly with `:cross-scope? true` (ignores the scope filter, visible in Xray) and MUST carry `:cause` — a cross-scope invalidation without one raises `:rf.error/resource-cross-scope-cause-required`. On a successful load an entry's tags are *replaced* with the new data's tags.
+- **Description**: Mark entries whose tags intersect `:tags` stale; refetch entries with active owners; leave inactive entries stale or GC-eligible.
+  - **Scoped by default** — a scoped invalidation with no `:scope` raises `:rf.error/resource-invalidate-scope-required` (never a silent nil-scope match).
+  - A cross-scope invalidation opts in explicitly with `:cross-scope? true` (ignores the scope filter, visible in Xray) and MUST carry `:cause` — omitting one raises `:rf.error/resource-cross-scope-cause-required`.
+  - On a successful load an entry's tags are *replaced* with the new data's tags.
 
 ```clojure
 ;; after a write settles, stale the reads carrying these tags
@@ -543,7 +617,10 @@ Resource events take a **map payload**, not a positional argument vector. The re
 
 - **Kind**: event (infinite resources only — see [Infinite resources](#infinite-resources))
 - **Payload**: `{:resource :scope :params :cause}` — **ownerless** (carries a `:cause`, never an `:owner`)
-- **Description**: Extend an `:infinite` feed by one page. Computes the next page param from the entry's tail via `:next-page-param`, fetches that page through the same managed transport, and appends it to the feed's accumulated page vector (the feed stays `:loaded`; the pages stay visible — a load-more in flight is the derived `:fetching-next?` sub, distinct from a whole-feed `:fetching?` refresh). A load-more with no next page (`:next-page-param` → `nil`) is a no-op trace; a load-more while a page fetch is already in flight dedupes. A supplied `:owner` is warn-and-ignored — the route (or whatever first-loaded the feed) already owns the one feed entry, and load-more never changes the active-owner set.
+- **Description**: Extend an `:infinite` feed by one page. Computes the next page param from the entry's tail via `:next-page-param`, fetches that page through the same managed transport, and appends it to the feed's accumulated page vector (the feed stays `:loaded`; the pages stay visible — a load-more in flight is the derived `:fetching-next?` sub, distinct from a whole-feed `:fetching?` refresh).
+  - A load-more with no next page (`:next-page-param` → `nil`) is a no-op trace.
+  - A load-more while a page fetch is already in flight dedupes.
+  - A supplied `:owner` is warn-and-ignored — the route (or whatever first-loaded the feed) already owns the one feed entry, and load-more never changes the active-owner set.
 
 ```clojure
 ;; the "Load more" button — ownerless; carries a :cause, never an :owner
@@ -557,7 +634,7 @@ Resource events take a **map payload**, not a positional argument vector. The re
 #### `[:rf.resource/window-focused]` / `[:rf.resource/network-reconnected]`
 
 - **Kind**: event (no payload)
-- **Description**: Scan the frame's active-owner stale entries and refetch them by policy. The refetch carries cause `:focus` (window-focused) or `:reconnect` (network-reconnected) — **never an owner** (it creates no liveness); generation + stale-suppression protect any late reply. The host listeners ([Revalidation listeners](#revalidation-listeners)) dispatch these; user code MUST NOT dispatch them directly.
+- **Description**: Scan the frame's active-owner stale entries and refetch them by policy. The refetch carries cause `:focus` (window-focused) or `:reconnect` (network-reconnected) — never an owner (it creates no liveness); generation + stale-suppression protect any late reply. The host listeners ([Revalidation listeners](#revalidation-listeners)) dispatch these; user code MUST NOT dispatch them directly.
 
 ```clojure
 ;; no payload — dispatched by the host listeners (see Revalidation listeners);
@@ -570,7 +647,7 @@ Resource events take a **map payload**, not a positional argument vector. The re
 
 ### Resource subscriptions (passive)
 
-A subscription is a **pure passive read** — it never fetches. It resolves scope per the sub-side precedence and raises `:rf.error/resource-sub-unresolved-scope` rather than reading global or returning a silent `:idle`.
+A subscription is a pure passive read — it never fetches. It resolves scope per the sub-side precedence and raises `:rf.error/resource-sub-unresolved-scope` rather than reading global or returning a silent `:idle`.
 
 ```clojure
 [:rf.resource/state         {:resource … :scope … :params …}]   ;; the full view-model
@@ -596,9 +673,16 @@ The `:rf.resource/state` view-model — facts plus **derived** booleans:
                          ;; :previous-key + :previous-data (the prior key's data)
 ```
 
-Status invariants: `:loading` = first load, no usable data; `:fetching` = refresh in flight while prior data stays visible; `:error` = first load failed, no usable data; a failed *background* refresh stays `:loaded`, keeps prior `:data`, records `:refresh-error`. `:stale?` / `:loading?` / `:fetching?` / `:has-data?` are derived sub values, never stored. See [Guide ch.27 §Status](../resources/concepts.md).
+Status invariants:
 
-> **Lifecycle trace ops (observability, not events you dispatch).** The runtime emits `:rf.resource/cache-hit` when a fresh `ensure` is served from cache with **no fetch** (a fresh-skip: an already-`:loaded` entry still fresh-by-policy serves the cached value, attaches the owner lease, and — for a blocking route resource — drains the blocking slot immediately, with no `:fetching` transition), and `:rf.resource/stale-fired` when a stale timer ticks (arming the stale transition, not a fetch). These are trace surfaces Xray reads — they are not `:status` values and not events user code dispatches.
+- `:loading` = first load, no usable data.
+- `:fetching` = refresh in flight while prior data stays visible.
+- `:error` = first load failed, no usable data.
+- A failed *background* refresh stays `:loaded`, keeps prior `:data`, records `:refresh-error`.
+
+`:stale?` / `:loading?` / `:fetching?` / `:has-data?` are derived sub values, never stored. See [Guide ch.27 §Status](../resources/concepts.md).
+
+> **Lifecycle trace ops (observability, not events you dispatch).** The runtime emits `:rf.resource/cache-hit` when a fresh `ensure` is served from cache with no fetch (a fresh-skip: an already-`:loaded` entry still fresh-by-policy serves the cached value, attaches the owner lease, and — for a blocking route resource — drains the blocking slot immediately, with no `:fetching` transition), and `:rf.resource/stale-fired` when a stale timer ticks (arming the stale transition, not a fetch). These are trace surfaces Xray reads — they are not `:status` values and not events user code dispatches.
 
 ### Mutation events (map payloads)
 
@@ -606,7 +690,13 @@ Status invariants: `:loading` = first load, no usable data; `:fetching` = refres
 
 - **Kind**: event
 - **Payload**: `{:mutation :params :instance :scope :cause :reply-to :optimistic?}`
-- **Description**: Run a mutation. `:instance` is the caller-supplied (or generated) **instance** id all runtime state is keyed by — two concurrent submissions keep distinct rows. On success the runtime patches/populates/removes resource entries then invalidates tags (per `:invalidate-timing`). `:reply-to` is an optional data-only completion continuation target dispatched when the write settles; `:optimistic? false` is the per-call opt-out that forces a registered optimistic plan to run pessimistically. An unregistered `:mutation` raises `:rf.error/mutation-not-registered`; params that fail `:params-schema` raise `:rf.error/mutation-invalid-params`. A superseded reply (a re-execute under the same instance, or an `:rf.mutation/clear`) never overwrites a newer instance (work-id + generation suppression).
+- **Description**: Run a mutation.
+  - `:instance` is the caller-supplied (or generated) **instance** id all runtime state is keyed by — two concurrent submissions keep distinct rows.
+  - On success the runtime patches/populates/removes resource entries then invalidates tags (per `:invalidate-timing`).
+  - `:reply-to` is an optional data-only completion continuation target dispatched when the write settles.
+  - `:optimistic? false` is the per-call opt-out that forces a registered optimistic plan to run pessimistically.
+  - An unregistered `:mutation` raises `:rf.error/mutation-not-registered`; params that fail `:params-schema` raise `:rf.error/mutation-invalid-params`.
+  - A superseded reply (a re-execute under the same instance, or an `:rf.mutation/clear`) never overwrites a newer instance (work-id + generation suppression).
 
 ```clojure
 [:rf.mutation/execute
@@ -643,13 +733,13 @@ A `:rf.mutation/*` subscription is a pure passive read keyed by **instance** id 
 
 `:optimistic?` (derived) is true while a live optimistic apply is showing (applied, not yet settled); `:affected-keys` carries the scoped resource keys the settle touched.
 
-A failure settles `:error` — there is **no `:refresh-error` analogue** (a write has no last-known-good to keep).
+A failure settles `:error` — there is no `:refresh-error` analogue (a write has no last-known-good to keep).
 
 > **Internal replies — do not dispatch.** The `:rf.mutation.internal/*` replies (`succeeded` / `failed`), and the `:rf.mutation/*` trace family — `started` / `succeeded` / `failed` / `cleared` / `replied` / `stale-suppressed` plus the optimistic rows (`optimistic-applied` / `optimistic-reconciled` / `optimistic-rolled-back`), carrying the instance id — are framework-internal; user code MUST NOT dispatch them.
 
 ## Read sugar
 
-`sub-resource` and `sub-mutation` are named reactive-read fns — thin sugar over the `[:rf.resource/state …]` / `[:rf.mutation/state …]` subscription vectors above. They live on the **`re-frame.resources` façade, not `re-frame.core`**, so a non-resources app's production bundle carries no resource/mutation keyword strings. The vector forms remain the canonical registered subs; these layer over them.
+`sub-resource` and `sub-mutation` are named reactive-read fns — thin sugar over the `[:rf.resource/state …]` / `[:rf.mutation/state …]` subscription vectors above. They live on the `re-frame.resources` façade, not `re-frame.core`, so a non-resources app's production bundle carries no resource/mutation keyword strings. The vector forms remain the canonical registered subs; these layer over them.
 
 ### `sub-resource`
 
@@ -689,7 +779,9 @@ A failure settles `:error` — there is **no `:refresh-error` analogue** (a writ
 
 ## Cache home
 
-Resource cache lives **only** at `:rf.runtime/resources` inside the runtime-db partition (`:rf.db/runtime`); the frame work ledger at `:rf.runtime/work-ledger`; mutation instance rows at `:rf.runtime/mutations`. All three are reserved runtime-db keys, framework-owned, per-frame isolated, allocated lazily. App code reads through the subs and accessors and never hand-edits the slice. Cache *entries* (durable facts) and work-ledger *attempts* (in-flight records) are separate; host handles (AbortControllers, timers, promises) live in side tables and are never serialized. The correctness rule: **cancellation is opportunistic; stale-reply suppression (by work-id + generation) is mandatory.** See [Guide ch.27 §Cache home and the work ledger](../resources/concepts.md).
+Resource cache lives **only** at `:rf.runtime/resources` inside the runtime-db partition (`:rf.db/runtime`); the frame work ledger at `:rf.runtime/work-ledger`; mutation instance rows at `:rf.runtime/mutations`. All three are reserved runtime-db keys, framework-owned, per-frame isolated, allocated lazily. App code reads through the subs and accessors and never hand-edits the slice.
+
+Cache *entries* (durable facts) and work-ledger *attempts* (in-flight records) are separate; host handles (AbortControllers, timers, promises) live in side tables and are never serialized. The correctness rule: cancellation is opportunistic; stale-reply suppression (by work-id + generation) is **mandatory**. See [Guide ch.27 §Cache home and the work ledger](../resources/concepts.md).
 
 ## Examples and cross-references
 

--- a/docs/api/re-frame.routing.md
+++ b/docs/api/re-frame.routing.md
@@ -1,6 +1,8 @@
 # re-frame.routing
 
-Routes in re-frame2 are *data*. You register a route with a path and metadata — `:params`, `:query`, `:on-match`, `:on-error`, `:can-leave` — and the runtime turns URL changes into events the same way every other input source does. There's no parallel router state: the current route lives in the frame's runtime-db partition under `[:rf.runtime/routing :current]` (read it via the `:rf/route` sub), navigation is just dispatching an event, and in-flight navigation is just an event sequence the cascade is mid-way through. Because routing is state, the router is debuggable with the same tools that debug everything else — time-travel works, the trace bus sees navigation, and tests dispatch `:rf.route/navigate` like any other event. This namespace is the public boot point and façade for the routing artefact: apps load it with `(:require [re-frame.routing])`, which wires every routing event, fx, cofx, and sub. The `reg-route` macro is published on the `re-frame.core` facade; the rest of the surface — URL helpers, registry introspection, scroll restoration, URL strategies, the browser URL-listener boot seam, and the multi-frame URL-ownership resolver — lives here.
+Routes are data. A route is registered with a path and a metadata map (`:params`, `:query`, `:on-match`, `:on-error`, `:can-leave`, …), and URL changes become events. The current route lives in the frame's runtime-db at `[:rf.runtime/routing :current]`, read via the `:rf/route` sub; navigation is dispatching an event.
+
+This namespace is the public boot point and façade for the routing artefact. Requiring it wires every routing event, fx, cofx, and sub. The `reg-route` macro is published on the `re-frame.core` facade; the rest of the surface — URL helpers, registry introspection, scroll restoration, URL strategies, the browser URL-listener boot seam, and the multi-frame URL-ownership resolver — lives here. For motivation and narrative, see the [Routing guide](../routing/index.md).
 
 ```clojure
 (:require [re-frame.routing :as routing])
@@ -17,7 +19,13 @@ Throughout, `rf` denotes the `re-frame.core` facade alias (`[re-frame.core :as r
   ```clojure
   (reg-route id metadata path) → id
   ```
-- **Description**: Register a route as data. The id is a keyword you'll later dispatch against (`[:rf.route/navigate :route/cart]`); the path is the third positional arg (the URL shape); the metadata map carries the match events and the guards. Throws `:rf.error/route-bad-metadata` when `metadata` is not a map, when it carries `:path` (the pattern belongs in the third slot), or when it carries a bare (unqualified) key outside the reserved set below — namespaced keys (`:myapp/analytics-id`) always pass. Emits `:rf.warning/route-shadowed-by-equal-score` when an already-registered route has an equal structural rank, and the `:rf.route/registered` trace on first-time registration.
+- **Description**: Register a route as data.
+
+  - `id` — keyword dispatched against later (`[:rf.route/navigate :route/cart]`).
+  - `metadata` — map of match events and guards (keys below).
+  - `path` — the URL shape; colon-prefixed segments capture into `:params`.
+
+  Throws `:rf.error/route-bad-metadata` when `metadata` is not a map, carries `:path` (the pattern belongs in the third slot), or carries a bare (unqualified) key outside the reserved set below. Namespaced keys (`:myapp/analytics-id`) always pass. Emits `:rf.warning/route-shadowed-by-equal-score` when an already-registered route has an equal structural rank, and `:rf.route/registered` on first-time registration.
 
 #### A minimal route
 
@@ -27,7 +35,7 @@ Throughout, `rf` denotes the `re-frame.core` facade alias (`[re-frame.core :as r
   "/cart")
 ```
 
-The third positional arg is the URL shape — colon-prefixed segments capture into `:params`. `:on-match` is the event vector (or vector of event vectors) the runtime dispatches when the route activates. That's the whole minimal contract; everything else is optional.
+Colon-prefixed path segments capture into `:params`. `:on-match` is the event vector (or vector of event vectors) dispatched when the route activates. Everything else is optional.
 
 #### Reserved metadata keys
 
@@ -42,15 +50,18 @@ The third positional arg is the URL shape — colon-prefixed segments capture in
 | `:parent` | Another route id; builds a chain readable via `:rf.route/chain`. |
 | `:on-match` | Event vector(s) to dispatch when the route activates. |
 | `:on-error` | Event vector dispatched if any `:on-match` event errors. |
-| `:can-leave` | Guard sub-query run before leaving the route. **Closed boolean contract**: `true` allows the navigation, `false` blocks it; any non-boolean value blocks and emits `:rf.error/can-leave-non-boolean`. The sub name reads positively (`:can-leave`), so `false` means "can NOT leave". The sub receives the pending target as an argument. See [Routing → Blocking a navigation](../routing/concepts.md#blocking-a-navigation). |
-| `:can-enter` | Guard sub-query run before entering the route — the first-class mirror of `:can-leave` (the auth-gate shape). **Closed boolean contract**: `true` allows entry, `false` blocks it; any non-boolean value blocks and emits `:rf.error/can-enter-non-boolean`. On a block the runtime dispatches `:rf.route/entry-blocked`. See [Routing → Guarding entry](../routing/concepts.md#guarding-entry--can-enter). |
+| `:can-leave` | Guard sub-query run before leaving the route. Closed boolean contract: `true` allows, `false` blocks; any non-boolean blocks and emits `:rf.error/can-leave-non-boolean`. The name reads positively, so `false` means "can NOT leave". The sub receives the pending target as an argument. See [Routing → Blocking a navigation](../routing/concepts.md#blocking-a-navigation). |
+| `:can-enter` | Guard sub-query run before entering the route (the auth-gate mirror of `:can-leave`). Closed boolean contract: `true` allows entry, `false` blocks; any non-boolean blocks and emits `:rf.error/can-enter-non-boolean`. On a block the runtime dispatches `:rf.route/entry-blocked`. See [Routing → Guarding entry](../routing/concepts.md#guarding-entry--can-enter). |
 | `:scroll` | Scroll-restoration behaviour for this route. |
 | `:sensitive` | Slice paths (projection-relative, e.g. `[:query :token]`) redacted at egress while the route is active. See [Routing → Keeping tokens off the wire](../routing/concepts.md#keeping-tokens-off-the-wire). |
 | `:large` | Slice paths kept off the wire at egress (a size marker ships instead of the value). |
 
-Two cross-feature bare keys are also accepted: `:head` (SSR's head-metadata contract) is enumerated in the accepted set unconditionally, and `:resources` (the resources artefact's route integration) is late-bound — the Resources artefact publishes it through the `:routing/extra-route-keys` hook, so in an app without that artefact `:resources` is rejected like any other unknown bare key.
+Two cross-feature bare keys are also accepted:
 
-Canonical detail in [The metadata map, in full](../routing/concepts.md#the-metadata-map-in-full) in the routing concept guide.
+- `:head` — SSR's head-metadata contract; enumerated in the accepted set unconditionally.
+- `:resources` — the Resources artefact's route integration; late-bound via the `:routing/extra-route-keys` hook. In an app without the Resources artefact, `:resources` is rejected like any other unknown bare key.
+
+Canonical detail in [The metadata map, in full](../routing/concepts.md#the-metadata-map-in-full).
 
 ### `clear-route`
 
@@ -59,7 +70,7 @@ Canonical detail in [The metadata map, in full](../routing/concepts.md#the-metad
   ```clojure
   (clear-route id) → nil
   ```
-- **Description**: Remove a registered route. Emits `:rf.route/cleared` so tools subscribing to route lifecycle observe the removal (symmetric with `:rf.flow/cleared`). No-op when the route id was not registered.
+- **Description**: Remove a registered route. Emits `:rf.route/cleared` (symmetric with `:rf.flow/cleared`) so tools subscribing to route lifecycle observe the removal. No-op when `id` was not registered.
 
 ### `reset-counters!`
 
@@ -72,7 +83,7 @@ Canonical detail in [The metadata map, in full](../routing/concepts.md#the-metad
 
 ## URL and route matching
 
-The URL ↔ route mapping is a **prism**: `match-url` reads a URL to route data, `route-url` renders route data back to a URL, and `match-url(route-url(...))` round-trips the canonical route data. Both are pure and JVM-runnable.
+The URL ↔ route mapping is a prism: `match-url` reads a URL to route data, `route-url` renders route data back to a URL, and `match-url(route-url(...))` round-trips the canonical route data. Both are pure and JVM-runnable.
 
 ### `match-url`
 
@@ -81,7 +92,11 @@ The URL ↔ route mapping is a **prism**: `match-url` reads a URL to route data,
   ```clojure
   (match-url url) → {:route-id :params :query :fragment :validation-failed?} or nil
   ```
-- **Description**: "What route does this URL match?" Pure — JVM-runnable; useful for server-side rendering and tests. Returns `nil` when no route matches, and fails closed to `nil` on malformed percent-encoding anywhere in the URL. When the route declares `:params` / `:query` schemas and the parsed values fail them, `:validation-failed?` is `true` and the explanation rides under `:validation-error`. Query keys the route declares (via `:query` / `:query-defaults` / `:query-retain`) come back as keyword keys in deterministic canonical order; undeclared keys stay strings.
+- **Description**: Match a URL to route data. Pure; JVM-runnable.
+
+  - Returns `nil` when no route matches, and fails closed to `nil` on malformed percent-encoding anywhere in the URL.
+  - When the route declares `:params` / `:query` schemas and the parsed values fail them, `:validation-failed?` is `true` and the explanation rides under `:validation-error`.
+  - Query keys the route declares (via `:query` / `:query-defaults` / `:query-retain`) come back as keyword keys in deterministic canonical order; undeclared keys stay strings.
 - **Example**:
   ```clojure
   ;; with (rf/reg-route :user/show {} "/users/:id") registered:
@@ -102,7 +117,17 @@ The URL ↔ route mapping is a **prism**: `match-url` reads a URL to route data,
   (route-url route-id path-params query-params) → URL string
   (route-url route-id path-params query-params fragment) → URL string
   ```
-- **Description**: "Render this route to a URL." The inverse of `match-url`. Pure; JVM-runnable. The 4-arity appends `#fragment` when `fragment` is a non-empty string (`nil` / `""` append nothing). Nil-valued query keys are silently elided; a nil required path param is an error. Query keys are emitted percent-encoded in deterministic canonical order. Throws `:rf.error/no-such-route` when `route-id` is not registered, `:rf.error/missing-route-param` when a required path segment's param is nil or absent, `:rf.error/route-url-validation` when `path-params` / `query-params` fail the route's `:params` / `:query` schemas, and `:rf.error/route-url-non-edn-value` for non-EDN param/query values or a non-string fragment.
+- **Description**: Render a route to a URL — the inverse of `match-url`. Pure; JVM-runnable.
+
+  - The 4-arity appends `#fragment` when `fragment` is a non-empty string (`nil` / `""` append nothing).
+  - Nil-valued query keys are silently elided; a nil required path param is an error.
+  - Query keys are emitted percent-encoded in deterministic canonical order.
+
+  Throws:
+  - `:rf.error/no-such-route` — `route-id` not registered.
+  - `:rf.error/missing-route-param` — a required path segment's param is nil or absent.
+  - `:rf.error/route-url-validation` — `path-params` / `query-params` fail the route's `:params` / `:query` schemas.
+  - `:rf.error/route-url-non-edn-value` — non-EDN param/query values or a non-string fragment.
 - **Example**:
   ```clojure
   ;; with (rf/reg-route :user/show {} "/users/:id") registered:
@@ -119,7 +144,9 @@ The URL ↔ route mapping is a **prism**: `match-url` reads a URL to route data,
   ```clojure
   (malformed-url? url) → boolean
   ```
-- **Description**: Predicate: `true` when any percent-encoded portion of `url` (a non-empty path segment, a query key or value, or the `#fragment`) is malformed. The scan is purely lexical — no route table is consulted. The `:rf.route/transitioned` / `:rf.route/handle-url-change` handlers use it to discriminate the bare route-miss case (`{:url url}`) from the malformed-URL fail-closed case (`{:url url :reason :malformed-url}`); both end at `:rf.route/not-found`, but the structured `:reason` lets per-route error UIs and SSR projections branch on the cause.
+- **Description**: `true` when any percent-encoded portion of `url` (a non-empty path segment, a query key or value, or the `#fragment`) is malformed. Purely lexical — no route table is consulted.
+
+  The `:rf.route/transitioned` / `:rf.route/handle-url-change` handlers use it to discriminate the bare route-miss case (`{:url url}`) from the malformed-URL fail-closed case (`{:url url :reason :malformed-url}`). Both end at `:rf.route/not-found`; the structured `:reason` lets per-route error UIs and SSR projections branch on the cause.
 
 ### `current-url`
 
@@ -128,11 +155,11 @@ The URL ↔ route mapping is a **prism**: `match-url` reads a URL to route data,
   ```clojure
   (current-url) → app-relative URL string
   ```
-- **Description**: Read the current browser URL as an app-relative string (`pathname + search + hash`). Returns `"/"` when no `window.location` is available (JVM / SSR / Node). Public so apps that wire their own history listener can recover the same projection the framework's listener uses. This is the history strategy's `:decode`; a hash app's listener decodes through its own strategy and never calls this directly.
+- **Description**: Read the current browser URL as an app-relative string (`pathname + search + hash`). Returns `"/"` when no `window.location` is available (JVM / SSR / Node). This is the history strategy's `:decode`; a hash app's listener decodes through its own strategy and never calls this directly. Public so apps that wire their own history listener can recover the same projection the framework's listener uses.
 
 ## Introspection and slice access
 
-The read-side surface over the route registry and the live route slice — the static "which routes are registered, and what is route X's spec?" accessors plus the live per-frame slice readers. The `*-algebra-view` helpers lower routes into the shared derivation/process-algebra node shape so a tool can show subscriptions, flows, resources, route facts, and machine selectors as one family.
+The read-side surface over the route registry and the live route slice: static "which routes are registered, and what is route X's spec?" accessors plus live per-frame slice readers. The `*-algebra-view` helpers lower routes into the shared derivation/process-algebra node shape, so a tool can show subscriptions, flows, resources, route facts, and machine selectors as one family.
 
 ### `route-ids`
 
@@ -141,7 +168,7 @@ The read-side surface over the route registry and the live route slice — the s
   ```clojure
   (route-ids) → vector of route ids
   ```
-- **Description**: Return a vector of every registered route id — the static-registry "enumerate" half of routing introspection (the live per-frame route slice is read through the `:rf.route/*` subs). Mirrors the sibling `resource-ids` / machines `machines` accessors.
+- **Description**: Return a vector of every registered route id — the static-registry "enumerate" half of routing introspection (the live per-frame slice is read through the `:rf.route/*` subs). Mirrors the sibling `resource-ids` / machines `machines` accessors.
 - **Example**:
   ```clojure
   (routing/route-ids)  ;; => [:route/cart :user/show]
@@ -154,7 +181,7 @@ The read-side surface over the route registry and the live route slice — the s
   ```clojure
   (route-meta route-id) → metadata map or nil
   ```
-- **Description**: Return the registered route's metadata map (`:path` pattern, `:on-match`, `:params`, `:query`, `:scroll`, `:can-leave`, the computed `:rf.route/rank` / `:rf.route/compiled` / coercion tables, source coords) for `route-id`, or `nil` if no route is registered under that id. Mirrors the sibling `resource-meta` / machines `machine-meta` accessors.
+- **Description**: Return the registered route's metadata map for `route-id`, or `nil` if none is registered under that id. The map carries `:path` pattern, `:on-match`, `:params`, `:query`, `:scroll`, `:can-leave`, the computed `:rf.route/rank` / `:rf.route/compiled` / coercion tables, and source coords. Mirrors the sibling `resource-meta` / machines `machine-meta` accessors.
 
 ### `route-algebra-view`
 
@@ -164,7 +191,16 @@ The read-side surface over the route registry and the live route slice — the s
   (route-algebra-view) → {route-id route-fact-node}
   (route-algebra-view route-id) → route-fact-node or nil
   ```
-- **Description**: The STATIC derivation/process-algebra view of every registered route — pure data over the `:route` registrar kind (no app-db, no runtime-db, no live slice). Each route lowers to a normalized node carrying `:id` `:rf/route` (the route FACT identity — every route materializes the one route slice; the per-route registration id is under `:source-form`), `:kind` `:process`, `:refinement` `:route-fact`, `:source-form` `{:kind :reg-route :id <route-id>}`, the route-transition `:inputs` (`:rf.route/navigate` / `:rf.route/transitioned` / `:rf.route/handle-url-change`), `:output` `[:runtime [:rf.runtime/routing :current]]`, `:storage` `:runtime-db`, `:evaluation` `:on-route`, `:lifecycle` `:frame`, `:materialized?` `true`, and (only when the route declares `:resources`) `:resource-edges`. Zero-arity returns the map for every route (`{}` when none); one-arity returns one node or `nil`. JVM-runnable; consumed by Xray and the conformance fixtures. There is no `re-frame.core` facade export.
+- **Description**: The STATIC derivation/process-algebra view of every registered route — pure data over the `:route` registrar kind (no app-db, no runtime-db, no live slice). Zero-arity returns the map for every route (`{}` when none); one-arity returns one node or `nil`. JVM-runnable; consumed by Xray and the conformance fixtures. No `re-frame.core` facade export.
+
+  Each route lowers to a normalized node carrying:
+  - `:id` `:rf/route` — the route FACT identity (every route materializes the one route slice; the per-route registration id is under `:source-form`).
+  - `:kind` `:process`, `:refinement` `:route-fact`.
+  - `:source-form` `{:kind :reg-route :id <route-id>}`.
+  - `:inputs` — the route-transition inputs (`:rf.route/navigate` / `:rf.route/transitioned` / `:rf.route/handle-url-change`).
+  - `:output` `[:runtime [:rf.runtime/routing :current]]`, `:storage` `:runtime-db`.
+  - `:evaluation` `:on-route`, `:lifecycle` `:frame`, `:materialized?` `true`.
+  - `:resource-edges` — only when the route declares `:resources`.
 
 ### `route-slice-algebra-view`
 
@@ -173,7 +209,7 @@ The read-side surface over the route registry and the live route slice — the s
   ```clojure
   (route-slice-algebra-view frame-id) → route-fact-node or nil
   ```
-- **Description**: The LIVE counterpart to `route-algebra-view`: the route fact materialized in a frame's runtime-db at `[:rf.runtime/routing :current]` — the concrete matched route, its params, query, transition state, and nav-token (the live route owner). Returns a single `:route-fact` node, or `nil` for a missing / destroyed frame or when no route has been materialized yet (no navigation has committed). Adds `:route-id`, `:params`, `:query`, `:transition`, `:nav-token`, and `:owner` `[:route <route-id> <nav-token>]` to the same fixed classifications the static node carries. CLJS- and JVM-runnable (a single runtime-db container deref).
+- **Description**: The LIVE counterpart to `route-algebra-view`: the route fact materialized in a frame's runtime-db at `[:rf.runtime/routing :current]` (the concrete matched route — its params, query, transition state, and nav-token; the live route owner). Returns a single `:route-fact` node, or `nil` for a missing / destroyed frame or when no route has been materialized yet (no navigation has committed). Adds `:route-id`, `:params`, `:query`, `:transition`, `:nav-token`, and `:owner` `[:route <route-id> <nav-token>]` to the same fixed classifications the static node carries. CLJS- and JVM-runnable (a single runtime-db container deref).
 
 ### `route-sub-fn`
 
@@ -192,7 +228,13 @@ The read-side surface over the route registry and the live route slice — the s
   (re-frame.routing/sub-route)        ;; → reaction over the route slice, or nil
   (re-frame.routing/sub-route opts)   ;; opts {:frame <id-or-frame>}
   ```
-- **Description**: Named read sugar over `[:rf/route]`. Returns a reaction over the route slice `{:route-id :params :query :fragment :transition :error :nav-token}`, or `nil` before the first navigation. Zero-arity is the primary form (the route is a per-frame singleton); the 1-arity `opts` carries `{:frame …}` to target an explicit (e.g. non-default url-bound) frame. The vector form remains the canonical registered sub. Lives on `re-frame.routing` (not `re-frame.core`) so a non-routing app's production bundle carries no route keyword strings.
+- **Description**: Named read sugar over `[:rf/route]`. Returns a reaction over the route slice `{:route-id :params :query :fragment :transition :error :nav-token}`, or `nil` before the first navigation.
+
+  - Zero-arity is the primary form (the route is a per-frame singleton).
+  - The 1-arity `opts` carries `{:frame …}` to target an explicit (e.g. non-default url-bound) frame.
+  - The vector form remains the canonical registered sub.
+
+  Lives on `re-frame.routing` (not `re-frame.core`) so a non-routing app's production bundle carries no route keyword strings.
 
 ```clojure
 (require '[re-frame.routing :as routing])
@@ -208,7 +250,11 @@ The read-side surface over the route registry and the live route slice — the s
   (re-frame.routing/sub-pending-navigation)        ;; → reaction over the pending-nav map, or nil
   (re-frame.routing/sub-pending-navigation opts)   ;; opts {:frame <id-or-frame>}
   ```
-- **Description**: Named read sugar over `[:rf/pending-navigation]`. Returns a reaction over the pending-navigation map `{:requested-url :requested-by-event :rejecting-route :rejecting-guard …}`, or `nil` in the steady state — the slot is non-nil only while a `:can-leave` guard holds a blocked navigation awaiting `:rf.route/continue` / `:rf.route/cancel`. Zero-arity is the primary form (the slot is a per-frame singleton); the 1-arity `opts` carries `{:frame …}` to target an explicit (e.g. non-default url-bound) frame. The vector form remains the canonical registered sub.
+- **Description**: Named read sugar over `[:rf/pending-navigation]`. Returns a reaction over the pending-navigation map `{:requested-url :requested-by-event :rejecting-route :rejecting-guard …}`, or `nil` in the steady state. The slot is non-nil only while a `:can-leave` guard holds a blocked navigation awaiting `:rf.route/continue` / `:rf.route/cancel`.
+
+  - Zero-arity is the primary form (the slot is a per-frame singleton).
+  - The 1-arity `opts` carries `{:frame …}` to target an explicit (e.g. non-default url-bound) frame.
+  - The vector form remains the canonical registered sub.
 
 ```clojure
 (require '[re-frame.routing :as routing])
@@ -220,7 +266,7 @@ The read-side surface over the route registry and the live route slice — the s
 
 ## Scroll restoration
 
-Saved scroll positions are a **host-side, per-frame transient LRU cache** keyed by frame-id — NOT runtime-db state. They are host-derived (read from `window.scrollX/Y`), meaningless server-side, and not needed to reconstitute a coherent frame on restore / SSR-hydration / time-travel, so they never ride the trace / epoch / SSR egress wire and cannot rewind on an epoch restore. The pure helpers operate on a plain per-frame cache map `{:positions {url [x y]} :order [url ...]}`; the `!`-suffixed wrappers read/write the host cache.
+Saved scroll positions are a host-side, per-frame transient LRU cache keyed by frame-id — NOT runtime-db state. They are host-derived (read from `window.scrollX/Y`), meaningless server-side, and not needed to reconstitute a coherent frame on restore / SSR-hydration / time-travel, so they never ride the trace / epoch / SSR egress wire and cannot rewind on an epoch restore. The pure helpers operate on a plain per-frame cache map `{:positions {url [x y]} :order [url ...]}`; the `!`-suffixed wrappers read/write the host cache.
 
 ### `scroll-positions-cap`
 
@@ -229,7 +275,7 @@ Saved scroll positions are a **host-side, per-frame transient LRU cache** keyed 
   ```clojure
   scroll-positions-cap  ;; => 50
   ```
-- **Description**: Soft upper bound on tracked URLs in the per-frame scroll-positions cache. Sized for typical SPA navigation depth — large enough that real Back-button restoration hits saved positions, small enough that the per-frame host cache stays bounded over long sessions.
+- **Description**: Soft upper bound on tracked URLs in the per-frame scroll-positions cache. Large enough that real Back-button restoration hits saved positions, small enough that the per-frame host cache stays bounded over long sessions.
 
 ### `frame-scroll-cache`
 
@@ -278,7 +324,7 @@ Saved scroll positions are a **host-side, per-frame transient LRU cache** keyed 
 
 ## Navigation counters and state classification
 
-The nav-token and pending-nav allocators are **host-side, per-frame, monotonic high-water marks** (not runtime-db), so an epoch restore — which replaces the runtime-db partition wholesale — cannot rewind them and recycle a token still carried by a slow in-flight continuation. `counter-snapshot` reads them; `routing-state-classification` is the canonical durable/transient map that SSR, docs, and schemas key off.
+The nav-token and pending-nav allocators are host-side, per-frame, monotonic high-water marks (not runtime-db), so an epoch restore — which replaces the runtime-db partition wholesale — cannot rewind them and recycle a token still carried by a slow in-flight continuation. `counter-snapshot` reads them; `routing-state-classification` is the canonical durable/transient map that SSR, docs, and schemas key off.
 
 ### `counter-snapshot`
 
@@ -301,7 +347,11 @@ The nav-token and pending-nav allocators are **host-side, per-frame, monotonic h
   ;;                                             :nav-token-counter
   ;;                                             :pending-nav-counter] :doc "..."}}
   ```
-- **Description**: The canonical classification of every piece of per-frame routing state, by tier — `:durable-runtime-db` (serializable facts needed to reconstitute a coherent frame on restore / SSR-hydration; the route slice at `:current`), `:local-subscribable-runtime-db` (runtime-db state that stays subscribable and restores in local replay but is SSR-stripped fail-closed; the `:pending-navigation` slot), and `:host-transient` (host-derived caches never in runtime-db; saved scroll positions and the two allocator high-water marks). SSR, docs, and Spec-Schemas consume this so the durable/transient split has one home.
+- **Description**: The canonical classification of every piece of per-frame routing state, by tier. Consumed by SSR, docs, and Spec-Schemas so the durable/transient split has one home.
+
+  - `:durable-runtime-db` — serializable facts needed to reconstitute a coherent frame on restore / SSR-hydration; the route slice at `:current`.
+  - `:local-subscribable-runtime-db` — runtime-db state that stays subscribable and restores in local replay but is SSR-stripped fail-closed; the `:pending-navigation` slot.
+  - `:host-transient` — host-derived caches never in runtime-db; saved scroll positions and the two allocator high-water marks.
 
 ### `reset-nav-counters!`
 
@@ -323,7 +373,11 @@ At most one frame owns the browser URL at a time. A frame claims ownership by re
   ```clojure
   (url-owner-frame-id) → frame-id or nil
   ```
-- **Description**: Return the single frame that has EXPLICITLY declared browser-history ownership via `(rf/reg-frame :id {:url-bound? true})`, or `nil` when no frame has. URL ownership is an explicit host/bootstrap policy, not an absence repair — the runtime never infers `:rf/default` as the owner; `:rf/default` owns the URL only when it carries an explicit `{:url-bound? true}` like any other frame. Ownership resolves to the FIRST-CLAIMED still-live `:url-bound? true` frame (the incumbent), so a later duplicate cannot steal the URL. `nil` means no owner is declared — outbound history fxs no-op and the inbound popstate listener skips.
+- **Description**: Return the single frame that has explicitly declared browser-history ownership via `(rf/reg-frame :id {:url-bound? true})`, or `nil` when none has.
+
+  - URL ownership is an explicit host/bootstrap policy, not an absence repair — the runtime never infers `:rf/default` as the owner. `:rf/default` owns the URL only when it carries an explicit `{:url-bound? true}` like any other frame.
+  - Ownership resolves to the first-claimed still-live `:url-bound? true` frame (the incumbent), so a later duplicate cannot steal the URL.
+  - `nil` means no owner is declared — outbound history fxs no-op and the inbound popstate listener skips.
 - **Example**:
   ```clojure
   ;; one frame opts into URL ownership at boot:
@@ -351,7 +405,11 @@ A `:url-strategy` is a frame-level config map declared on the URL-owning frame �
   ```clojure
   history-url-strategy  ;; {:encode :decode :push! :replace! :install-listener!}
   ```
-- **Description**: The default URL strategy: HTML5 History, path-form. `:encode` / `:decode` are identity over the app-relative URL (`:decode` reads `pathname + search + hash`); `:push!` / `:replace!` drive `pushState` / `replaceState`; `:install-listener!` wires `popstate`. A frame that declares no `:url-strategy` uses this.
+- **Description**: The default URL strategy: HTML5 History, path-form. A frame that declares no `:url-strategy` uses this.
+
+  - `:encode` / `:decode` are identity over the app-relative URL (`:decode` reads `pathname + search + hash`).
+  - `:push!` / `:replace!` drive `pushState` / `replaceState`.
+  - `:install-listener!` wires `popstate`.
 
 ### `hash-url-strategy`
 
@@ -360,7 +418,11 @@ A `:url-strategy` is a frame-level config map declared on the URL-owning frame �
   ```clojure
   hash-url-strategy  ;; {:encode :decode :push! :replace! :install-listener!}
   ```
-- **Description**: The hash URL strategy: `#`-prefixed URLs (`#/active`) for no-server-rewrite static hosting and secretary-era v1 migrations. `route-url` still builds path-form `/active`; `:encode` maps it to `#/active` at the `route-link` href and the history fxs, `:decode` strips the leading `#` from `window.location.hash` (an empty hash decodes to `/`), and `:install-listener!` wires `hashchange`.
+- **Description**: The hash URL strategy: `#`-prefixed URLs (`#/active`) for no-server-rewrite static hosting and secretary-era v1 migrations. `route-url` still builds path-form `/active`.
+
+  - `:encode` maps it to `#/active` at the `route-link` href and the history fxs.
+  - `:decode` strips the leading `#` from `window.location.hash` (an empty hash decodes to `/`).
+  - `:install-listener!` wires `hashchange`.
 - **Example**:
   ```clojure
   (rf/reg-frame :app {:url-bound?   true
@@ -379,7 +441,11 @@ The CLJS-only boot seam that replaces hand-rolled `popstate` / `hashchange` wiri
   (install-url-listener!) → nil
   (install-url-listener! strategy) → nil
   ```
-- **Description**: Install the URL-owning frame's browser URL-change listener (`popstate` for the history strategy, `hashchange` for the hash strategy), then sync the current URL into the owner's route slice. Each browser-driven change is decoded to a path-form URL by the strategy's `:decode` and dispatched synchronously as `:rf.route/handle-url-change` to `(url-owner-frame-id)` resolved at fire time; when no frame declares `:url-bound? true` the dispatch is skipped. The 0-arity resolves the strategy from the current URL owner's `:url-strategy`; the 1-arity pins an explicit strategy map (for URL-owning frames registered asynchronously). Idempotent — re-installing tears down the prior listener.
+- **Description**: Install the URL-owning frame's browser URL-change listener (`popstate` for the history strategy, `hashchange` for the hash strategy), then sync the current URL into the owner's route slice.
+
+  - Each browser-driven change is decoded to a path-form URL by the strategy's `:decode` and dispatched synchronously as `:rf.route/handle-url-change` to `(url-owner-frame-id)` resolved at fire time; when no frame declares `:url-bound? true` the dispatch is skipped.
+  - The 0-arity resolves the strategy from the current URL owner's `:url-strategy`; the 1-arity pins an explicit strategy map (for URL-owning frames registered asynchronously).
+  - Idempotent — re-installing tears down the prior listener.
 
 ### `remove-url-listener!`
 
@@ -422,7 +488,14 @@ The `:route/link` registered view renders an `<a href=...>` from a route id and 
                :on-click f & html-attrs}
    & children]
   ```
-- **Description**: The registered `:route/link` view. `:to` is the only required key; `:params`, `:query`, and `:fragment` are forwarded to `route-url` for href synthesis, and every other props key passes through to the `<a>` element. A plain primary-button click (no modifier keys, `defaultPrevented` false) is intercepted: `preventDefault`, then dispatch `[:rf/url-requested {:url ... :to ...}]` targeted at the frame that rendered the link. Modifier-key / middle-button clicks, and anchors carrying native-handling attributes (`:target` other than `_self`, or `:download`), defer to the browser. A caller-supplied `:on-click` runs first; if it calls `preventDefault` the framework's interception is skipped. The rendered href is encoded through the rendering frame's `:url-strategy`. On the JVM the `:route/link` registration renders via [`route-link-render-ssr`](#route-link-render-ssr).
+- **Description**: The registered `:route/link` view.
+
+  - `:to` is the only required key; `:params`, `:query`, and `:fragment` are forwarded to `route-url` for href synthesis, and every other props key passes through to the `<a>` element.
+  - A plain primary-button click (no modifier keys, `defaultPrevented` false) is intercepted: `preventDefault`, then dispatch `[:rf/url-requested {:url ... :to ...}]` targeted at the frame that rendered the link.
+  - Modifier-key / middle-button clicks, and anchors carrying native-handling attributes (`:target` other than `_self`, or `:download`), defer to the browser.
+  - A caller-supplied `:on-click` runs first; if it calls `preventDefault` the framework's interception is skipped.
+  - The rendered href is encoded through the rendering frame's `:url-strategy`.
+  - On the JVM the `:route/link` registration renders via [`route-link-render-ssr`](#route-link-render-ssr).
 - **Example**:
   ```clojure
   [rf/route-link {:to :user/show :params {:id 42} :class "nav-item"}
@@ -447,15 +520,15 @@ The `:route/link` registered view renders an `<a href=...>` from a route id and 
   ```clojure
   (route-link-render-ssr props & children) → hiccup
   ```
-- **Description**: The JVM render fn for the `:route/link` view. Renders the `<a href=...>` shell without the click-interception logic — server-side rendering has no DOM events to intercept, so the anchor is emitted as-is and clicks on the hydrated page run the CLJS render fn's on-click path. The href is emitted path-form regardless of `:url-strategy` (SSR ignores strategies); the hydrated CLJS render re-encodes it. The authoring surface is [`route-link`](#route-link), also published on the `re-frame.core` facade.
+- **Description**: The JVM render fn for the `:route/link` view. Renders the `<a href=...>` shell without the click-interception logic — SSR has no DOM events to intercept, so the anchor is emitted as-is and clicks on the hydrated page run the CLJS render fn's on-click path. The href is emitted path-form regardless of `:url-strategy` (SSR ignores strategies); the hydrated CLJS render re-encodes it. The authoring surface is [`route-link`](#route-link), also published on the `re-frame.core` facade.
 
 ## Keyword surfaces
 
-The routing artefact registers a family of events, subscriptions, effects, and coeffects addressed by keyword. Loading `re-frame.routing` wires them all. It also registers internal machinery — the `:rf.route.internal/*` runtime events, the recordable allocation cofx (`:rf.route/nav-allocation`, `:rf.route/pending-nav-allocation`), and the `:rf.route/commit-nav-counter` fx — which apps and tools never dispatch or declare; those are omitted from the tables below.
+The routing artefact registers a family of events, subscriptions, effects, and coeffects addressed by keyword; loading `re-frame.routing` wires them all. It also registers internal machinery — the `:rf.route.internal/*` runtime events, the recordable allocation cofx (`:rf.route/nav-allocation`, `:rf.route/pending-nav-allocation`), and the `:rf.route/commit-nav-counter` fx — which apps and tools never dispatch or declare; those are omitted from the tables below.
 
 ### Events
 
-These are the standard events the runtime dispatches (or you dispatch) around routing.
+Standard events the runtime dispatches (or you dispatch) around routing.
 
 | Event | Notes |
 |---|---|
@@ -494,7 +567,7 @@ The full `:rf/route` slice is `{:route-id :params :query :fragment :transition :
 | `[:rf.nav/capture-scroll {:url url-string}]` | `{:url ...}` map | `:client` | Capture the current scroll position into the host-side per-frame scroll-position cache (keyed by `url`) before leaving a route. |
 | `[:rf.route/with-nav-token {:rf/reply-to <reply-target> :nav-token <token>}]` | see notes | universal | Name an async-completion continuation by its canonical `:rf/reply-to` reply target and guard it with a navigation token. On match the target is completed with the `:status :ok` reply map; if the token has been superseded by a later navigation, the completion is suppressed and `:rf.route.nav-token/stale-suppressed` fires. Optional args keys: `:route-id` (the captured route id, for the work-id), `:value` (rides the `:status :ok` reply map), `:completed-at`. |
 
-The nav-token wrapper is what makes "user navigates away mid-load" safe: the older load's reply carries the stale token, the runtime suppresses it, and you don't see the older page's data overwrite the newer page's state. Full semantics in [Routing → Loaders](../routing/concepts.md#loaders-declaring-a-pages-data) (the nav-token "going deeper").
+The nav-token wrapper guards "user navigates away mid-load": the older load's reply carries the stale token, the runtime suppresses it, and the older page's data does not overwrite the newer page's state. Full semantics in [Routing → Loaders](../routing/concepts.md#loaders-declaring-a-pages-data).
 
 ### Coeffects (`cofx`)
 

--- a/docs/api/re-frame.schemas.md
+++ b/docs/api/re-frame.schemas.md
@@ -1,12 +1,14 @@
 # re-frame.schemas
 
-`re-frame.schemas` is the **schema attachment, validation, and data-classification** axis of re-frame2. Schemas are [Malli](https://github.com/metosin/malli) schemas attached to `app-db` paths with `reg-app-schema`; in dev builds the runtime validates `app-db` writes (and event / fx / subscription values that carry a `:schema`) against the matching schemas and emits an `:rf.error/schema-validation-failure` trace on a mismatch, while production builds elide the validation at the call sites. This namespace owns the read-side introspection surface (`app-schemas` / `app-schema-at` / …), the pluggable validator / explainer / printer seams that let an app swap Malli for another validator, the per-slot `:sensitive?` / `:large?` schema walkers that drive failure-trace redaction, and the test-support snapshot / restore / clear hooks. The registration macros `reg-app-schema` / `reg-app-schemas` are surfaced through the `re-frame.core` facade (called as `rf/reg-app-schema`); their full contract is carried here.
+Schema attachment, validation, and data-classification. Schemas are [Malli](https://github.com/metosin/malli) schemas attached to `app-db` paths via `reg-app-schema`. In dev builds the runtime validates `app-db` writes (and event / fx / subscription values carrying a `:schema`) against the matching schemas, emitting an `:rf.error/schema-validation-failure` trace on mismatch; production builds elide validation at the call sites.
+
+This namespace owns the read-side introspection surface, the pluggable validator / explainer / printer seams, the per-slot `:sensitive?` / `:large?` schema walkers that drive failure-trace redaction, and the test-support snapshot / restore / clear hooks. The registration macros `reg-app-schema` / `reg-app-schemas` are surfaced through the `re-frame.core` facade (called as `rf/reg-app-schema`); their full contract is here.
 
 ```clojure
 (:require [re-frame.schemas :as schemas])
 ```
 
-Most app code touches only **Registration** and **Introspection**. The remaining sections — the validation entry points, the boundary / redaction seams, the validator-extension seams, the schema walkers, and the test-support hooks — are framework-integration and advanced surfaces; they are public and manifested, but everyday apps reach for them rarely (the validator-extension seams) or never (the dev-time `validate-*!` hooks the runtime calls for you).
+Ships in artefact `day8/re-frame2-schemas`. Most app code touches only **Registration** and **Introspection**; the remaining sections are framework-integration and advanced surfaces. See [Validate with schemas](../core/how-to/validate-with-schemas.md) for the working guide.
 
 ## Registration
 
@@ -20,7 +22,12 @@ The registration macros live in `re-frame.core` and route through the schemas ar
   (reg-app-schema path {:schema schema})
   (reg-app-schema path {:schema schema :frame frame})
   ```
-- **Description**: "Attach this Malli schema to this `app-db` path." The schema rides the metadata map under `:schema`; the optional frame target (a frame-id keyword or a frame value) rides `:frame` in the same map. **Path is the registration id** — app-db schemas are path-keyed (the schemas-at-paths grain matches `get-in` / `assoc-in`) and live in the schemas artefact's per-frame side-table (app-db schemas are NOT a registrar kind). `(app-schema-at [:user])` looks up by the same path vector. `path` is a sequential `get-in` path of concrete segments (`[]` registers a whole-`app-db` root schema) and is normalized to its canonical vector form; returns the normalized path. Raises `:rf.error/app-schema-bad-metadata` (non-map metadata, or no `:schema` key), `:rf.error/app-schema-bad-path` (non-sequential path or non-concrete segment), `:rf.error/app-schema-runtime-path` (first segment reaches the runtime-db partition — `:rf.runtime/*`, `:rf.db/runtime`, or the legacy `:rf/runtime` root), `:rf.error/app-schemas-bad-arg` (a `:frame` target that does not resolve to a keyword frame id), and `:rf.error/no-frame-context` (no `:frame` and no established frame scope). Dev builds add two diagnostics: a re-registration that changes the schema at a path whose live `app-db` value fails the new schema emits an `:rf.schema/violation` warning trace, and registering an opaque compiled schema the per-slot walker cannot introspect warns once per process with `:rf.warning/schema-walker-opaque`.
+- **Description**: Attach a Malli schema to an `app-db` path.
+  - The schema rides the metadata map under `:schema`; the optional frame target (a frame-id keyword or a frame value) rides `:frame` in the same map.
+  - The **path is the registration id** — app-db schemas are path-keyed, live in the schemas artefact's per-frame side-table, and are NOT a registrar kind. `(app-schema-at [:user])` looks up by the same path vector.
+  - `path` is a sequential `get-in` path of concrete segments (`[]` registers a whole-`app-db` root schema), normalized to canonical vector form. Returns the normalized path.
+  - Raises: `:rf.error/app-schema-bad-metadata` (non-map metadata, or no `:schema` key); `:rf.error/app-schema-bad-path` (non-sequential path or non-concrete segment); `:rf.error/app-schema-runtime-path` (first segment reaches the runtime-db partition — `:rf.runtime/*`, `:rf.db/runtime`, or the legacy `:rf/runtime` root); `:rf.error/app-schemas-bad-arg` (a `:frame` target that does not resolve to a keyword frame id); `:rf.error/no-frame-context` (no `:frame` and no established frame scope).
+  - Dev-only diagnostics: re-registering a schema at a path whose live `app-db` value fails the new schema emits an `:rf.schema/violation` warning trace; registering an opaque compiled schema the per-slot walker cannot introspect warns once per process with `:rf.warning/schema-walker-opaque`.
 - **Example**:
   ```clojure
   (rf/reg-app-schema [:cells]
@@ -35,7 +42,12 @@ The registration macros live in `re-frame.core` and route through the schemas ar
   (reg-app-schemas {path-1 schema-1, path-2 schema-2, ...})
   (reg-app-schemas {path-1 schema-1, ...} opts-or-frame-id)
   ```
-- **Description**: Bulk plural form. Feature-modular apps registering 5–20 paths against the same prefix reach for this. Each entry routes through the singular form and is stamped with this call's source coords. The optional second arg names the frame for every entry in the map — an opts map (`{:frame target}`), a bare frame-id keyword, or a frame value; one frame per call. Returns the vector of paths registered, in map-iteration order; `{}` is the documented empty no-op. A `nil` / non-map first arg raises `:rf.error/app-schemas-bad-batch`; every path in the batch is shape-checked before any store mutation, so a batch containing one invalid path (`:rf.error/app-schema-bad-path` / `:rf.error/app-schema-runtime-path`) registers nothing.
+- **Description**: Bulk plural form of `reg-app-schema`.
+  - Each entry routes through the singular form and is stamped with this call's source coords.
+  - The optional second arg names the frame for every entry — an opts map (`{:frame target}`), a bare frame-id keyword, or a frame value; one frame per call.
+  - Returns the vector of paths registered, in map-iteration order; `{}` is the documented empty no-op.
+  - Every path is shape-checked before any store mutation, so a batch containing one invalid path (`:rf.error/app-schema-bad-path` / `:rf.error/app-schema-runtime-path`) registers nothing.
+  - A `nil` / non-map first arg raises `:rf.error/app-schemas-bad-batch`.
 - **Example**:
   ```clojure
   (rf/reg-app-schemas
@@ -44,13 +56,11 @@ The registration macros live in `re-frame.core` and route through the schemas ar
      [:articles] ArticlesState})
   ```
 
-The path-keyed-not-id-keyed asymmetry is principled. Paths are first-class in `get-in` / `assoc-in` / `update-in`; schemas-at-paths matches the dataflow grain; the lookup site (`app-schema-at [:user]`) reads the same way the write site (`(assoc-in db [:user] ...)`) reads. Spelling it as `(reg-app-schema :user/schema {:schema schema})` would have shifted the registration's id away from the dataflow grain.
-
 See [re-frame.core.md](re-frame.core.md) for the `reg-*` return-value convention this registration participates in.
 
 ## Introspection
 
-The introspection surfaces live in `re-frame.schemas` (artefact `day8/re-frame2-schemas`). They are *not* re-exported from `re-frame.core` — the registration macros live in `re-frame.core` and route through the schemas artefact at registration time, but the read-side surface stays in its own namespace. Tools, 10x panels, and agents walk these to enumerate an app's schema surface. Every `opts-or-frame-id` argument below accepts an opts map (`{:frame target}`), a bare frame-id keyword, or a frame value (normalized to its frame id); a malformed argument raises `:rf.error/app-schemas-bad-arg`, and omitting the frame outside any frame scope raises `:rf.error/no-frame-context`.
+The introspection surfaces live in `re-frame.schemas` and are *not* re-exported from `re-frame.core`. Every `opts-or-frame-id` argument below accepts an opts map (`{:frame target}`), a bare frame-id keyword, or a frame value (normalized to its frame id). A malformed argument raises `:rf.error/app-schemas-bad-arg`; omitting the frame outside any frame scope raises `:rf.error/no-frame-context`.
 
 ### `app-schemas`
 
@@ -60,7 +70,7 @@ The introspection surfaces live in `re-frame.schemas` (artefact `day8/re-frame2-
   (app-schemas)
   (app-schemas opts-or-frame-id)
   ```
-- **Description**: "Hand me every registered schema-at-path for this frame." Returns `{path schema}`. Tools and agents walk this to enumerate the app's schema surface.
+- **Description**: Return every registered schema-at-path for the frame as `{path schema}`.
 - **Example**:
   ```clojure
   ;; every registered schema-at-path for the default frame
@@ -79,7 +89,7 @@ The introspection surfaces live in `re-frame.schemas` (artefact `day8/re-frame2-
   (app-schema-at path)
   (app-schema-at path opts-or-frame-id)
   ```
-- **Description**: "Schema for this exact path." Returns the schema value or `nil`.
+- **Description**: Return the schema registered at an exact path, or `nil`.
 - **Example**:
   ```clojure
   (schemas/app-schema-at [:user])
@@ -97,7 +107,9 @@ The introspection surfaces live in `re-frame.schemas` (artefact `day8/re-frame2-
   (app-schema-meta-at path)
   (app-schema-meta-at path opts-or-frame-id)
   ```
-- **Description**: "Full registration-metadata map for this path." Returns `:path`, `:schema`, `:frame`, plus source-coords (`:ns` / `:line` / `:file`) and the rest of `:rf/registration-metadata`; `nil` when nothing is registered at the path. Pair tools and 10x reach for this when they need the registration anchor for click-back-to-code. The lighter `app-schema-at` is the right call when only the schema value is needed.
+- **Description**: Return the full registration-metadata map for a path, or `nil` when nothing is registered.
+  - Contains `:path`, `:schema`, `:frame`, source-coords (`:ns` / `:line` / `:file`), and the rest of `:rf/registration-metadata`.
+  - Use `app-schema-at` when only the schema value is needed.
 - **Example**:
   ```clojure
   ;; the registration anchor — schema value plus source coords for click-back
@@ -114,7 +126,10 @@ The introspection surfaces live in `re-frame.schemas` (artefact `day8/re-frame2-
   (app-schemas-digest) → string
   (app-schemas-digest opts-or-frame-id) → string
   ```
-- **Description**: "Single hash over the frame's whole schema surface." Returns the canonical wire form — `"sha256:"` followed by the first 16 lowercase hex chars; byte-deterministic across runtimes, and the empty schema set produces a stable digest. Used by SSR hydration compatibility checks and by tools that want to know "has the schema corpus changed?" without diffing schema-by-schema.
+- **Description**: Return a single hash over the frame's whole schema surface.
+  - Canonical wire form: `"sha256:"` followed by the first 16 lowercase hex chars.
+  - Byte-deterministic across runtimes; the empty schema set produces a stable digest.
+  - Used by SSR hydration compatibility checks and by tools tracking whether the schema corpus changed without diffing schema-by-schema.
 - **Example**:
   ```clojure
   ;; one stable hash over the whole frame's schema surface
@@ -130,11 +145,13 @@ The introspection surfaces live in `re-frame.schemas` (artefact `day8/re-frame2-
   ```clojure
   (frame-schema-entries frame-id) → {path schema-meta}
   ```
-- **Description**: Return the full `{path schema-meta}` map for a frame, or `{}`. The lower-level cross-artefact read seam (consumed by `re-frame.elision` / `re-frame.epoch` and the `validate-app-schema!` loop): where `app-schemas` projects each entry down to its `{path schema}`, this returns the whole per-path metadata map (`:schema`, `:path`, `:frame`, source-coords).
+- **Description**: Return the full `{path schema-meta}` map for a frame, or `{}`.
+  - Lower-level cross-artefact read seam (consumed by `re-frame.elision` / `re-frame.epoch` and the `validate-app-schema!` loop).
+  - Where `app-schemas` projects each entry down to `{path schema}`, this returns the whole per-path metadata map (`:schema`, `:path`, `:frame`, source-coords).
 
 ## Validation entry points
 
-The four dev-time `validate-*!` functions are the locked validation sites the framework calls for you — pre-handler (event), pre-fx, post-commit (`app-db`), and post-recompute (subscription). They are public and manifested (tools and conformance tests call them directly), but ordinary app code does not: you register a `:schema` and the runtime invokes these. Every body lives inside an `interop/debug-enabled?` gate, so the whole surface is dead-code-eliminated in production builds (each fn then returns `true`). On every surface a structurally malformed registered schema — one that makes the registered validator throw — emits the distinct `:rf.error/malformed-schema` trace (structural locator slots only, no value-bearing slots) and returns `false` (fail closed), never a silent pass.
+The four dev-time `validate-*!` functions are the locked validation sites the framework calls for you — pre-handler (event), pre-fx, post-commit (`app-db`), and post-recompute (subscription). They are public and manifested (tools and conformance tests call them directly), but ordinary app code does not: you register a `:schema` and the runtime invokes these. Every body lives inside an `interop/debug-enabled?` gate, so the whole surface is dead-code-eliminated in production (each fn then returns `true`). On every surface a structurally malformed registered schema — one that makes the registered validator throw — emits the distinct `:rf.error/malformed-schema` trace (structural locator slots only, no value-bearing slots) and returns `false` (**fail closed**), never a silent pass.
 
 ### `validate-app-schema!`
 
@@ -145,7 +162,12 @@ The four dev-time `validate-*!` functions are the locked validation sites the fr
   (validate-app-schema! db event-id)           ;; current frame, named handler
   (validate-app-schema! db event-id frame-id)  ;; explicit frame
   ```
-- **Description**: After a handler commits `:db`, walk every registered app-schema for the named frame and validate the post-commit `app-db`. Failures emit `:rf.error/schema-validation-failure` (one trace per failing entry) with the registered explainer's output attached, and the value-bearing slots redacted when the failing slot is `:sensitive?`. A malformed entry (the validator throws) emits `:rf.error/malformed-schema` for that entry, contributes `false`, and does not stop the frame's sibling schemas from validating. Only the named frame's schemas are walked. `event-id` (optional) names the handler whose commit prompted the failure — surfaced as `:failing-id`. Returns `true` when every registered schema conformed (also when no validator is registered, no schemas are registered for the frame, or the build elided validation) and `false` when at least one failed — the router consumes a `false` to roll the `:db` effect back to the pre-handler value. A hard no-op for every schema when `set-schema-validator!` has been called with `nil`.
+- **Description**: After a handler commits `:db`, walk every registered app-schema for the named frame and validate the post-commit `app-db`. Only the named frame's schemas are walked.
+  - Failures emit `:rf.error/schema-validation-failure` (one trace per failing entry) with the registered explainer's output attached; value-bearing slots are redacted when the failing slot is `:sensitive?`.
+  - A malformed entry (the validator throws) emits `:rf.error/malformed-schema` for that entry, contributes `false`, and does not stop sibling schemas from validating.
+  - `event-id` (optional) names the handler whose commit prompted the failure — surfaced as `:failing-id`.
+  - Returns `true` when every registered schema conformed (also when no validator is registered, no schemas are registered for the frame, or the build elided validation), `false` when at least one failed. The router consumes a `false` to roll the `:db` effect back to the pre-handler value.
+  - A hard no-op for every schema when `set-schema-validator!` has been called with `nil`.
 
 ### `validate-event!`
 
@@ -155,7 +177,11 @@ The four dev-time `validate-*!` functions are the locked validation sites the fr
   (validate-event! event-id event handler-meta)
   (validate-event! event-id event handler-meta frame)
   ```
-- **Description**: Before an event handler runs, validate the event vector against any `:schema` on the handler's registration metadata. On failure emits `:rf.error/schema-validation-failure :where :event` and the caller skips the handler (recovery `:no-recovery`). A `:sensitive?` slot anywhere in the event schema — commonly the `:cat` / `:catn` payload (e.g. a `:password` slot in a login schema) — redacts the value-bearing trace slots. The optional `frame` arg stamps a `:frame` tag so the violation is captured into the in-flight epoch's `:trace-events` (the Xray Issues / Schema-timeline lens reads off that); the runtime passes it, direct callers may omit it. Returns `true`/`false`.
+- **Description**: Before an event handler runs, validate the event vector against any `:schema` on the handler's registration metadata.
+  - On failure emits `:rf.error/schema-validation-failure :where :event`; the caller skips the handler (recovery `:no-recovery`).
+  - A `:sensitive?` slot anywhere in the event schema — commonly the `:cat` / `:catn` payload (e.g. a `:password` slot in a login schema) — redacts the value-bearing trace slots.
+  - The optional `frame` arg stamps a `:frame` tag so the violation is captured into the in-flight epoch's `:trace-events` (read by the Xray Issues / Schema-timeline lens); the runtime passes it, direct callers may omit it.
+  - Returns `true`/`false`.
 
 ### `validate-fx!`
 
@@ -165,7 +191,10 @@ The four dev-time `validate-*!` functions are the locked validation sites the fr
   (validate-fx! fx-id event-id args fx-meta)
   (validate-fx! fx-id event-id args fx-meta frame)
   ```
-- **Description**: Before an fx handler runs, validate its args against any `:schema` on the fx's registration metadata. On failure emits `:rf.error/schema-validation-failure :where :fx-args`; only the offending fx is skipped (recovery `:skipped`) — sibling fx in the same `:fx` vector still run and downstream queued events still drain. The optional `frame` arg stamps a `:frame` tag for epoch capture. Returns `true`/`false`.
+- **Description**: Before an fx handler runs, validate its args against any `:schema` on the fx's registration metadata.
+  - On failure emits `:rf.error/schema-validation-failure :where :fx-args`; only the offending fx is skipped (recovery `:skipped`) — sibling fx in the same `:fx` vector still run and downstream queued events still drain.
+  - The optional `frame` arg stamps a `:frame` tag for epoch capture.
+  - Returns `true`/`false`.
 
 ### `validate-sub!`
 
@@ -175,7 +204,10 @@ The four dev-time `validate-*!` functions are the locked validation sites the fr
   (validate-sub! sub-id query-v value sub-meta)
   (validate-sub! sub-id query-v value sub-meta frame)
   ```
-- **Description**: After a subscription recomputes, validate its return value against any `:schema` on the sub's registration metadata. On failure emits `:rf.error/schema-validation-failure :where :sub-return` and the caller replaces the value with the default (recovery `:replaced-with-default`). The optional `frame` arg stamps a `:frame` tag for epoch capture. Returns `true`/`false`.
+- **Description**: After a subscription recomputes, validate its return value against any `:schema` on the sub's registration metadata.
+  - On failure emits `:rf.error/schema-validation-failure :where :sub-return`; the caller replaces the value with the default (recovery `:replaced-with-default`).
+  - The optional `frame` arg stamps a `:frame` tag for epoch capture.
+  - Returns `true`/`false`.
 
 ## Boundary validation and redaction seams
 
@@ -188,7 +220,9 @@ These three functions are the production-side and cross-artefact seams. `validat
   ```clojure
   (validate-with-registered-fn schema value) → boolean
   ```
-- **Description**: Apply the registered validator to `(schema, value)`. The public check seam the boundary-validation interceptor uses — it runs in production, outside the `debug-enabled?` gate the `validate-*!` hot path sits behind. Returns `true` on conform, `false` on fail (including a structurally malformed schema that makes the validator throw — fail closed), and `true` when no validator is registered (no-validator means no-validation, mirroring the hot path). Does NOT emit a trace (the interceptor owns the failure envelope) and does NOT consult `debug-enabled?`.
+- **Description**: Apply the registered validator to `(schema, value)`. The public check seam the boundary-validation interceptor uses — it runs in production, outside the `debug-enabled?` gate the `validate-*!` hot path sits behind.
+  - Returns `true` on conform; `false` on fail (including a structurally malformed schema that makes the validator throw — **fail closed**); `true` when no validator is registered (no-validator means no-validation, mirroring the hot path).
+  - Does NOT emit a trace (the interceptor owns the failure envelope) and does NOT consult `debug-enabled?`.
 
 ### `explain-with-registered-fn`
 
@@ -197,7 +231,9 @@ These three functions are the production-side and cross-artefact seams. `validat
   ```clojure
   (explain-with-registered-fn schema value) → explanation | nil
   ```
-- **Description**: Apply the registered explainer to `(schema, value)`. Companion to `validate-with-registered-fn` for the boundary interceptor. Returns the explanation map / data on fail; `nil` when the value conforms, no explainer is registered, or the explainer throws (a throwing explainer degrades to `nil` — diagnostics must never change the verdict).
+- **Description**: Apply the registered explainer to `(schema, value)`. Companion to `validate-with-registered-fn` for the boundary interceptor.
+  - Returns the explanation map / data on fail.
+  - Returns `nil` when the value conforms, no explainer is registered, or the explainer throws (a throwing explainer degrades to `nil` — diagnostics must never change the verdict).
 
 ### `redact-validation-tags`
 
@@ -206,11 +242,15 @@ These three functions are the production-side and cross-artefact seams. `validat
   ```clojure
   (redact-validation-tags schema tags) → tags
   ```
-- **Description**: The shared schema-aware redaction seam for every validation-failure trace emitted OUTSIDE this namespace (the production boundary interceptor, machine `:data` validation, the `:sub-override` path, flow-output validation, and the recordable-coeffect `:rf.error/cofx-value-invalid` emit). Given the `schema` the failing value was checked against and a failure-trace `tags` map, returns the tags with the value-bearing slots (`:value` / `:received` / `:explain` / `:explain-humanized` / `:rf.fx/args` / `:rf.sub/query-v`) scrubbed to `:rf/redacted` and `:sensitive? true` stamped when the schema declares any `:sensitive?` slot — failing closed on an opaque compiled schema the walker cannot introspect. A `:large?` (non-sensitive) schema instead elides those slots to the `:rf.size/large-elided` marker; otherwise the tags ride back verbatim. Off-namespace callers reach it through the `:schemas/redact-validation-tags` late-bind hook and fall through verbatim when the schemas artefact is absent. Idempotent.
+- **Description**: The shared schema-aware redaction seam for every validation-failure trace emitted OUTSIDE this namespace (the production boundary interceptor, machine `:data` validation, the `:sub-override` path, flow-output validation, and the recordable-coeffect `:rf.error/cofx-value-invalid` emit). Given the `schema` the failing value was checked against and a failure-trace `tags` map, returns the tags with:
+  - a `:sensitive?` schema → value-bearing slots (`:value` / `:received` / `:explain` / `:explain-humanized` / `:rf.fx/args` / `:rf.sub/query-v`) scrubbed to `:rf/redacted`, and `:sensitive? true` stamped. Fails closed on an opaque compiled schema the walker cannot introspect.
+  - a `:large?` (non-sensitive) schema → those slots elided to the `:rf.size/large-elided` marker.
+  - otherwise → the tags ride back verbatim.
+  - Off-namespace callers reach it through the `:schemas/redact-validation-tags` late-bind hook and fall through verbatim when the schemas artefact is absent. Idempotent.
 
 ## Validator extension seams
 
-The default validator ships Malli's `validate` / `explain` pair (plus an EDN canonical printer for the digest). These seams let apps swap in their own validator — typically to drop the Malli dependency entirely, or to add a custom explainer that formats failures for the app's domain. The three setters answer three different questions: validation correctness (`validator`), human-readable failure messages (`explainer`), and stable canonical printing for the digest (`printer`).
+The default validator ships Malli's `validate` / `explain` pair (plus an EDN canonical printer for the digest). These seams let an app swap in its own validator. The three setters answer three different questions: validation correctness (`validator`), human-readable failure messages (`explainer`), and stable canonical printing for the digest (`printer`).
 
 ### `set-schema-validator!`
 
@@ -219,7 +259,11 @@ The default validator ships Malli's `validate` / `explain` pair (plus an EDN can
   ```clojure
   (set-schema-validator! validate-fn)
   ```
-- **Description**: "Install the validator the framework uses at every dev-time schema-validation site." `validate-fn` is `(fn [schema value] truthy?)` — the `malli.core/validate` shape. Swaps ONLY the validator; `nil` disables validation entirely. Last-write-wins; returns the installed validator (may be `nil`). The default ships Malli's pair; this seam is for apps that want to swap to a different validator without forking the framework. To install the validator/explainer/printer together, use `set-schema-fns!`.
+- **Description**: Install the validator the framework uses at every dev-time schema-validation site.
+  - `validate-fn` is `(fn [schema value] truthy?)` — the `malli.core/validate` shape.
+  - `nil` disables validation entirely.
+  - Swaps ONLY the validator. Last-write-wins; returns the installed validator (may be `nil`).
+  - To install the validator/explainer/printer together, use `set-schema-fns!`.
 - **Example**:
   ```clojure
   ;; install an app's own validator (same shape as malli.core/validate:
@@ -237,7 +281,11 @@ The default validator ships Malli's `validate` / `explain` pair (plus an EDN can
   ```clojure
   (set-schema-fns! {:validate validate-fn :explain explain-fn :print print-fn})
   ```
-- **Description**: "Atomically install any subset of the validator / explainer / printer bundle from a single map." The honest bundle setter — named for what it sets, not just the validator. Each key is optional; an absent key leaves the existing registration in place, and a `nil` `:print` coerces to the default EDN canonicaliser (`:validate` / `:explain` `nil` disable that fn). Last-write-wins per key; returns the installed bundle map `{:validate … :explain … :print …}` reflecting the live state of all three fns after the call. The one-call substitute-Malli boot pattern, so the three fns never drift mid-boot.
+- **Description**: Atomically install any subset of the validator / explainer / printer bundle from a single map.
+  - Each key is optional; an absent key leaves the existing registration in place.
+  - A `nil` `:print` coerces to the default EDN canonicaliser; `:validate` / `:explain` `nil` disable that fn.
+  - Last-write-wins per key; returns the installed bundle map `{:validate … :explain … :print …}` reflecting the live state of all three fns after the call.
+  - The one-call substitute-Malli boot pattern, so the three fns never drift mid-boot.
 - **Example**:
   ```clojure
   ;; install validator + explainer together (e.g. a clojure.spec or Zod port)
@@ -252,7 +300,10 @@ The default validator ships Malli's `validate` / `explain` pair (plus an EDN can
   ```clojure
   (set-schema-explainer! explain-fn)
   ```
-- **Description**: "Install the explainer the framework uses to enrich `:rf.error/schema-validation-failure` traces' `:explain` key." `explain-fn` is `(fn [schema value] explanation)` — the `malli.core/explain` shape; `nil` disables explanations (the failure trace omits `:explain`). Last-write-wins; returns the installed explainer (may be `nil`). Companion to `set-schema-validator!`.
+- **Description**: Install the explainer the framework uses to enrich `:rf.error/schema-validation-failure` traces' `:explain` key.
+  - `explain-fn` is `(fn [schema value] explanation)` — the `malli.core/explain` shape.
+  - `nil` disables explanations (the failure trace omits `:explain`).
+  - Last-write-wins; returns the installed explainer (may be `nil`). Companion to `set-schema-validator!`.
 - **Example**:
   ```clojure
   ;; enrich :rf.error/schema-validation-failure traces with a custom explanation
@@ -266,7 +317,10 @@ The default validator ships Malli's `validate` / `explain` pair (plus an EDN can
   ```clojure
   (set-schema-printer! print-fn)
   ```
-- **Description**: "Install the schema-print companion the digest pipeline hashes." `(fn [schema-value] canonical-string)`. Must be pure and deterministic across runtimes. `nil` falls back to the default EDN canonicaliser, so the digest is never undefined. Last-write-wins; returns the installed printer (the default when `nil` was passed). Parallel to the validator / explainer setters: non-Malli ports register their own serialiser so cross-runtime digest comparison reflects their port's contract.
+- **Description**: Install the schema-print companion the digest pipeline hashes.
+  - `(fn [schema-value] canonical-string)`. Must be pure and deterministic across runtimes.
+  - `nil` falls back to the default EDN canonicaliser, so the digest is never undefined.
+  - Last-write-wins; returns the installed printer (the default when `nil` was passed). Parallel to the validator / explainer setters.
 - **Example**:
   ```clojure
   ;; a non-Malli port registers its own canonical schema serialiser
@@ -289,7 +343,10 @@ The default validator ships Malli's `validate` / `explain` pair (plus an EDN can
   ```clojure
   (snapshot-schema-fns) → {:validate fn|nil :explain fn|nil :print fn}
   ```
-- **Description**: Capture the currently-installed validator / explainer / printer bundle as one value, in the same shape `set-schema-fns!` accepts and returns. The bundle-level companion to `snapshot-schemas-by-frame`; the captured value round-trips losslessly through `restore-schema-fns!`. Unlike `reset-schema-validator!` (which restores the framework default), this captures whatever custom bundle is currently installed so a test can restore the *prior* custom bundle. `:validate` / `:explain` may be `nil`; `:print` is never `nil`.
+- **Description**: Capture the currently-installed validator / explainer / printer bundle as one value, in the same shape `set-schema-fns!` accepts and returns.
+  - The bundle-level companion to `snapshot-schemas-by-frame`; the captured value round-trips losslessly through `restore-schema-fns!`.
+  - Unlike `reset-schema-validator!` (which restores the framework default), this captures whatever custom bundle is currently installed, so a test can restore the *prior* custom bundle.
+  - `:validate` / `:explain` may be `nil`; `:print` is never `nil`.
 
 ### `restore-schema-fns!`
 
@@ -302,7 +359,7 @@ The default validator ships Malli's `validate` / `explain` pair (plus an EDN can
 
 ## Schema classification walkers
 
-The pure-data per-slot flag extractors and predicates. They walk a Malli **vector-form** EDN schema and report which slots carry `:sensitive? true` or `:large? true` per-slot props. They are consumed by the schema-validation-failure-trace redactor and by the owner-local schema-prop consumers (a machine's `:data-schema`, a resource's data/params schema, the HTTP body-privacy projector, story-mcp's tool-egress projector). They describe **shape**, not durable `app-db` egress policy — durable `app-db` classification is event-owned (a `reg-event` returns `:sensitive` / `:large` alongside `:db`). A compiled / opaque `m/schema` value is treated as an opaque leaf; register the vector form when per-slot flags need to be visible.
+The pure-data per-slot flag extractors and predicates. They walk a Malli **vector-form** EDN schema and report which slots carry `:sensitive? true` or `:large? true` per-slot props. Consumed by the schema-validation-failure-trace redactor and by the owner-local schema-prop consumers (a machine's `:data-schema`, a resource's data/params schema, the HTTP body-privacy projector, story-mcp's tool-egress projector). They describe **shape**, not durable `app-db` egress policy — durable `app-db` classification is event-owned (a `reg-event` returns `:sensitive` / `:large` alongside `:db`). A compiled / opaque `m/schema` value is treated as an opaque leaf; register the vector form when per-slot flags need to be visible.
 
 ### `extract-large-paths-from-schema`
 
@@ -311,7 +368,9 @@ The pure-data per-slot flag extractors and predicates. They walk a Malli **vecto
   ```clojure
   (extract-large-paths-from-schema schema base-path) → {path declaration}
   ```
-- **Description**: Walk a Malli schema EDN form at `base-path` and return a `{path declaration}` map for every `:large? true` slot found; each declaration carries `:source :schema`, plus `:hint` propagated verbatim when the slot props carry one. The pure-data `:large?` extractor the owner-local size-elision consumers read directly (it does NOT feed the `app-db` egress registry — that is frame-owned).
+- **Description**: Walk a Malli schema EDN form at `base-path` and return a `{path declaration}` map for every `:large? true` slot found.
+  - Each declaration carries `:source :schema`, plus `:hint` propagated verbatim when the slot props carry one.
+  - The pure-data `:large?` extractor the owner-local size-elision consumers read directly; it does NOT feed the `app-db` egress registry (that is frame-owned).
 - **Example**:
   ```clojure
   (schemas/extract-large-paths-from-schema
@@ -358,7 +417,9 @@ The pure-data per-slot flag extractors and predicates. They walk a Malli **vecto
   ```clojure
   (schema-sensitive-at? schema in-path) → boolean
   ```
-- **Description**: Path-targeted sensitivity check. `true` when the slot at `in-path` is sensitive — either an **ancestor** along the path is `:sensitive?` (the failing slot sits under a sensitive container) or a **descendant** of the slot is `:sensitive?` (the slot's value carries a sensitive child). `in-path` is the value-relative path Malli reports as `:in`; a `nil` or empty `in-path` is equivalent to `schema-has-sensitive?`. The leaf-precise check the `app-db` hot path uses for its narrowed `:value` slot, so a non-sensitive failing leaf whose *sibling* is sensitive is not over-redacted.
+- **Description**: Path-targeted sensitivity check. `true` when the slot at `in-path` is sensitive — either an **ancestor** along the path is `:sensitive?` (the failing slot sits under a sensitive container) or a **descendant** of the slot is `:sensitive?` (the slot's value carries a sensitive child).
+  - `in-path` is the value-relative path Malli reports as `:in`; a `nil` or empty `in-path` is equivalent to `schema-has-sensitive?`.
+  - The leaf-precise check the `app-db` hot path uses for its narrowed `:value` slot, so a non-sensitive failing leaf whose *sibling* is sensitive is not over-redacted.
 
 ### `schema-opaque?`
 
@@ -434,7 +495,9 @@ The per-frame registry and diagnostic-latch maintenance hooks. `re-frame.test-su
   ```clojure
   (clear-edn-print-cache!)
   ```
-- **Description**: Reset the `app-schemas-digest` printer memo. Test-support: the memo is process-lifetime and bounded by the registered-schema cardinality (schemas register once at boot), so production never needs this — but a test that registers many distinct fresh schemas clears it in fixture teardown so the cache doesn't grow unbounded across the suite. Returns `nil`.
+- **Description**: Reset the `app-schemas-digest` printer memo. Returns `nil`.
+  - Test-support only: the memo is process-lifetime and bounded by the registered-schema cardinality (schemas register once at boot), so production never needs this.
+  - A test that registers many distinct fresh schemas clears it in fixture teardown so the cache doesn't grow unbounded across the suite.
 
 ### `clear-sensitive-paths-cache!`
 

--- a/docs/api/re-frame.ssr.md
+++ b/docs/api/re-frame.ssr.md
@@ -1,12 +1,14 @@
 # re-frame.ssr
 
-Server-side rendering and hydration. `re-frame.ssr` is the same framework as the client side — same registrations, same cascade, same `app-db`, same subs — with four differences: the request creates a per-request frame, the cascade runs to completion before the response is built, the resulting hiccup is emitted as an HTML string, and a hydration payload ships with it so the client can pick up where the server left off without re-rendering. The surface ships in a separate artefact (`day8/re-frame2-ssr`); add it to your deps and require the namespace to get the rendering primitives, the streaming triple, the head model, the per-request response accumulator and its server-only `:rf.server/*` fx, the error-projection seam, and the `:platforms` fx-gating metadata. The Ring host-adapter lives alongside in [`re-frame.ssr.ring`](re-frame.ssr.ring.md).
+Server-side rendering and hydration. `re-frame.ssr` runs the same framework as the client — same registrations, cascade, `app-db`, and subs — with four differences: the request creates a per-request frame, the cascade runs to completion before the response is built, the resulting hiccup is emitted as an HTML string, and a hydration payload ships alongside so the client resumes without re-rendering.
+
+Ships in a separate artefact (`day8/re-frame2-ssr`); add it to your deps and require the namespace. The Ring host-adapter lives in [`re-frame.ssr.ring`](re-frame.ssr.ring.md).
 
 ```clojure
 (:require [re-frame.ssr :as ssr])
 ```
 
-For convenience, a curated set of render and head primitives is re-exported on the `re-frame.core` facade as late-bound wrappers — `rf/render-to-string`, `rf/render-tree-hash`, `rf/project-error`, the registration macros `rf/reg-head` / `rf/reg-error-projector`, and the head accessors `rf/render-head` / `rf/active-head` / `rf/head-model->html` / `rf/head-snapshot` (the accessor functions are documented in [`re-frame.core`](re-frame.core.md)). They resolve to this namespace's implementation at call time when the artefact is on the classpath, and throw a clear "SSR not loaded" error otherwise. The examples below use the `rf/` form where that is the idiomatic call site and the `ssr/` form for the host-adapter surface.
+A curated set of render and head primitives is re-exported on the `re-frame.core` facade as late-bound wrappers: `rf/render-to-string`, `rf/render-tree-hash`, `rf/project-error`, the registration macros `rf/reg-head` / `rf/reg-error-projector`, and the head accessors `rf/render-head` / `rf/active-head` / `rf/head-model->html` / `rf/head-snapshot` (accessors documented in [`re-frame.core`](re-frame.core.md)). They resolve to this namespace at call time when the artefact is on the classpath, and throw a clear "SSR not loaded" error otherwise. Examples below use `rf/` at idiomatic call sites and `ssr/` for the host-adapter surface.
 
 ## Rendering primitives
 
@@ -17,7 +19,10 @@ For convenience, a curated set of render and head primitives is re-exported on t
   ```clojure
   (render-to-string view-or-hiccup opts) → HTML string
   ```
-- **Description**: The canonical server-side render. Walks the hiccup tree once — resolving registered views, `:tag#id.cls` shorthand, and HTML5 void elements, escaping text and attribute values — and emits a string. JVM-runnable. Test-friendly because it's pure. `opts` keys (all optional): `:doctype?` prefixes `<!DOCTYPE html>`; `:emit-hash?` injects `data-rf-render-hash` on the tree's first DOM-tag element for client-side mismatch detection; `:render-hash` supplies a precomputed hash to stamp instead (avoiding a second canonical-EDN walk). Throws `:rf.error/invalid-tag-name` on a malformed tag name, `:rf.error/ssr-invalid-attribute-name` on a malformed attribute key, `:rf.error/ssr-raw-text-in-body` on a raw string child of a body-position `<script>` / `<style>`, `:rf.error/ssr-reagent-native-head` on a `:>` interop head, and `:rf.error/ssr-suspense-boundary-outside-stream` when a `:rf/suspense-boundary` marker reaches this non-streaming emitter.
+- **Description**: The canonical server-side render. Walks the hiccup tree once and emits a string. Pure and JVM-runnable.
+  - Resolves registered views, `:tag#id.cls` shorthand, and HTML5 void elements; escapes text and attribute values.
+  - `opts` keys (all optional): `:doctype?` prefixes `<!DOCTYPE html>`; `:emit-hash?` injects `data-rf-render-hash` on the tree's first DOM-tag element (for client-side mismatch detection); `:render-hash` supplies a precomputed hash to stamp instead, avoiding a second canonical-EDN walk.
+  - Raises: `:rf.error/invalid-tag-name` (malformed tag name), `:rf.error/ssr-invalid-attribute-name` (malformed attribute key), `:rf.error/ssr-raw-text-in-body` (raw string child of a body-position `<script>` / `<style>`), `:rf.error/ssr-reagent-native-head` (a `:>` interop head), `:rf.error/ssr-suspense-boundary-outside-stream` (a `:rf/suspense-boundary` marker reaching this non-streaming emitter).
 - **Example**:
   ```clojure
   (rf/with-new-frame [f (rf/make-frame {:images [app-image]})]
@@ -32,7 +37,7 @@ For convenience, a curated set of render and head primitives is re-exported on t
   ```clojure
   (render-tree-hash render-tree) → 32-bit FNV-1a structural hash (lowercase hex)
   ```
-- **Description**: A deterministic structural fingerprint of a render tree. Same canonical-EDN representation produces the same hash on JVM and CLJS. Used by the hydration compatibility check — if the server's hash doesn't match the client's hash, hydration is unsafe.
+- **Description**: A deterministic structural fingerprint of a render tree. The same canonical-EDN representation produces the same hash on JVM and CLJS. Drives the hydration compatibility check — a server/client hash mismatch means hydration is unsafe.
 - **Example**:
   ```clojure
   ;; Capture the hash at render time; it rides the hydration payload as
@@ -49,7 +54,7 @@ For convenience, a curated set of render and head primitives is re-exported on t
   ```clojure
   (install-render-to-string! set-hiccup-emitter!-fn)
   ```
-- **Description**: Install this namespace's `render-to-string` into a substrate adapter's `:render-to-string` slot. For hosts that wire a custom (non-bundled) adapter directly — the bundled Reagent adapter wires itself via the `:reagent/set-hiccup-emitter!` late-bind hook, so app code rarely calls this.
+- **Description**: Install this namespace's `render-to-string` into a substrate adapter's `:render-to-string` slot. For hosts wiring a custom (non-bundled) adapter directly. The bundled Reagent adapter wires itself via the `:reagent/set-hiccup-emitter!` late-bind hook, so app code rarely calls this.
 
 ### `adapter`
 
@@ -58,7 +63,9 @@ For convenience, a curated set of render and head primitives is re-exported on t
   ```clojure
   ssr/adapter   ;; the SSR substrate adapter map
   ```
-- **Description**: The SSR substrate adapter map. Pass to `rf/init!` to install the server-side / headless substrate — it carries this namespace's `render-to-string` directly in its `:render-to-string` slot, so no late-bind wiring is required at the call site. Server-side and headless (JVM) processes init with this adapter. Its `:render` slot throws `:rf.error/render-on-headless-adapter` — SSR renders via `render-to-string` exclusively.
+- **Description**: The SSR substrate adapter map — the server-side / headless (JVM) substrate. Pass to `rf/init!` to install it.
+  - Carries this namespace's `render-to-string` directly in its `:render-to-string` slot, so no late-bind wiring is needed at the call site.
+  - Its `:render` slot throws `:rf.error/render-on-headless-adapter` — SSR renders via `render-to-string` exclusively.
 - **Example**:
   ```clojure
   (rf/init! ssr/adapter)
@@ -66,7 +73,7 @@ For convenience, a curated set of render and head primitives is re-exported on t
 
 ## Streaming render
 
-Larger pages benefit from streaming — emit the shell-html and continue rendering boundary subtrees as their data becomes available. re-frame2's streaming model uses `:rf/suspense-boundary` markers in the render tree; each boundary becomes a continuation.
+Streaming emits the shell HTML first, then continues rendering boundary subtrees as their data settles. The render tree marks boundaries with `:rf/suspense-boundary`; each becomes a continuation.
 
 ### `streaming-render-shell`
 
@@ -76,7 +83,7 @@ Larger pages benefit from streaming — emit the shell-html and continue renderi
   (streaming-render-shell root-hiccup)
     → {:shell-html "..." :continuations [{:id :subtree} ...]}
   ```
-- **Description**: Walk the tree once; at each `:rf/suspense-boundary` emit a `<template …suspense-fallback>` placeholder and record a continuation. Returns the shell-html (ready to flush) and the continuations to drain.
+- **Description**: Walk the tree once. At each `:rf/suspense-boundary`, emit a `<template …suspense-fallback>` placeholder and record a continuation. Returns the shell HTML (ready to flush) and the continuations to drain.
 - **Example**:
   ```clojure
   ;; Host adapter: render the shell to flush immediately, keep the continuations.
@@ -94,7 +101,10 @@ Larger pages benefit from streaming — emit the shell-html and continue renderi
   (streaming-render-continuation frame-id entry)
     → {:id :html :delta :failed? :continuations}
   ```
-- **Description**: Drain one continuation against `frame-id`'s app-db. Snapshots before-db / after-db and computes the per-subtree delta. A nested `:rf/suspense-boundary` inside the subtree registers a new continuation, returned under `:continuations` — the host appends these at the tail of its FIFO drain queue (`[]` when the subtree carries none). Catches throws: emits `:rf.ssr/suspense-boundary-failed`, surfaces the original fallback HTML inline with `:failed? true`, omits `:delta`, and returns no nested continuations.
+- **Description**: Drain one continuation against `frame-id`'s app-db.
+  - Snapshots before-db / after-db and computes the per-subtree delta.
+  - A nested `:rf/suspense-boundary` inside the subtree registers a new continuation, returned under `:continuations` for the host to append at the tail of its FIFO drain queue (`[]` when the subtree carries none).
+  - On a throw: emits `:rf.ssr/suspense-boundary-failed`, surfaces the original fallback HTML inline with `:failed? true`, omits `:delta`, and returns no nested continuations.
 - **Example**:
   ```clojure
   ;; Drain the FIFO queue against fid's app-db, emitting each chunk;
@@ -115,7 +125,9 @@ Larger pages benefit from streaming — emit the shell-html and continue renderi
   (streaming-build-final-payload frame-id render-hash opts)
     → canonical :rf/hydration-payload
   ```
-- **Description**: Called after all continuations drain to populate the `__rf_payload` final chunk. `opts` MUST carry the fail-closed `:payload` policy — a vector allowlist of top-level app-db keys, or `:rf.ssr.payload/whole-app-db` to opt into shipping the whole app-db; absence throws `:rf.error/ssr-missing-payload-policy`. An optional `:version` overrides the `:rf2/runtime-version` late-bind hook as the payload's `:rf/version` source.
+- **Description**: Populate the `__rf_payload` final chunk after all continuations drain.
+  - `opts` **MUST** carry the fail-closed `:payload` policy: a vector allowlist of top-level app-db keys, or `:rf.ssr.payload/whole-app-db` to ship the whole app-db. Absence throws `:rf.error/ssr-missing-payload-policy`.
+  - Optional `:version` overrides the `:rf2/runtime-version` late-bind hook as the payload's `:rf/version` source.
 - **Example**:
   ```clojure
   ;; After every continuation drains, build the canonical __rf_payload chunk.
@@ -133,7 +145,7 @@ The following are the lower-level chunk-template builders the streaming host emi
   ```clojure
   (streaming-fallback-template id fallback-html) → HTML string
   ```
-- **Description**: The fallback chunk shape — the boundary's fallback markup wrapped in an inline `<template data-rf2-suspense-fallback>` placeholder in the shell HTML. A `<template>`'s content is inert (never painted), so this is the wire-carrier for the fallback markup; the client-side streaming runtime materialises each inert fallback into a live, visible mount.
+- **Description**: The fallback chunk shape — the boundary's fallback markup wrapped in an inline `<template data-rf2-suspense-fallback>` placeholder in the shell HTML. A `<template>`'s content is inert (never painted), so it is the wire-carrier for the fallback markup; the client-side streaming runtime materialises each inert fallback into a live, visible mount.
 
 ### `streaming-resolved-template`
 
@@ -151,7 +163,7 @@ The following are the lower-level chunk-template builders the streaming host emi
   ```clojure
   (streaming-failed-template id fallback-html) → HTML string
   ```
-- **Description**: The failed-continuation chunk shape — the same wire shape as `streaming-resolved-template` plus a `data-rf2-suspense-failed` marker, so the client-side runtime can surface the failure observably without surfacing a 500. Inline-fallback failure semantics.
+- **Description**: The failed-continuation chunk shape — the same wire shape as `streaming-resolved-template` plus a `data-rf2-suspense-failed` marker. Inline-fallback failure semantics: the client-side runtime surfaces the failure observably without surfacing a 500.
 
 ### `streaming-hydrate-delta-script`
 
@@ -160,7 +172,7 @@ The following are the lower-level chunk-template builders the streaming host emi
   ```clojure
   (streaming-hydrate-delta-script id delta-edn) → HTML string
   ```
-- **Description**: The per-subtree hydration delta chunk (`application/edn`). The client reads the EDN, then merges the delta into `app-db` as the subtree streams in.
+- **Description**: The per-subtree hydration delta chunk (`application/edn`). The client reads the EDN and merges the delta into `app-db` as the subtree streams in.
 
 The streaming surface is host-adapter territory — the SSR-aware host ([`re-frame.ssr.ring`](re-frame.ssr.ring.md) or equivalent) wires it. Most app code interacts via the host adapter and never touches `streaming-render-*` directly. The one app-facing piece is the client-side runtime, below.
 
@@ -171,7 +183,10 @@ The streaming surface is host-adapter territory — the SSR-aware host ([`re-fra
   ```clojure
   (streaming-install! opts) → stop! (0-arity fn)
   ```
-- **Description**: Install the client-side streaming runtime. Observes the document for arriving chunks: materialises each inert fallback `<template>` into a visible mount, swaps in resolved subtrees, merges each per-subtree hydration delta into the `:frame`'s app-db, and disconnects itself once the final `__rf_payload` node lands (the bootstrap's `:rf/hydrate` is the canonical reconciliation). Opts: `:frame` (REQUIRED — an absent frame emits + throws `:rf.error/no-frame-context`), `:root` (the DOM root to observe; default `js/document`), `:payload-id` (the final-payload `<script>` id; default `"__rf_payload"`). Returns a 0-arity `stop!` fn that disconnects the observer early. Idempotent per chunk.
+- **Description**: Install the client-side streaming runtime. Returns a 0-arity `stop!` fn that disconnects the observer early. Idempotent per chunk.
+  - Observes the document for arriving chunks: materialises each inert fallback `<template>` into a visible mount, swaps in resolved subtrees, and merges each per-subtree hydration delta into the `:frame`'s app-db.
+  - Disconnects itself once the final `__rf_payload` node lands (the bootstrap's `:rf/hydrate` is the canonical reconciliation).
+  - `opts`: `:frame` (**REQUIRED** — an absent frame emits + throws `:rf.error/no-frame-context`); `:root` (the DOM root to observe, default `js/document`); `:payload-id` (the final-payload `<script>` id, default `"__rf_payload"`).
 - **Example**:
   ```clojure
   ;; Streaming-aware bootstrap: install BEFORE the first chunks can land
@@ -181,7 +196,7 @@ The streaming surface is host-adapter territory — the SSR-aware host ([`re-fra
 
 ## The head model
 
-The `<head>` of an SSR document is structurally separate from the body. re-frame2 models it as a head-model — a data structure carrying `:title`, `:meta`, `:link`, `:json-ld`, `:html-attrs`, `:body-attrs` — registered per-route with `reg-head` and rendered separately from the body. A registered head-fn is evaluated and rendered through the `re-frame.core` facade accessors — `render-head`, `active-head`, `head-model->html`, and `head-snapshot` (documented in [`re-frame.core`](re-frame.core.md)). The [`:rf/head`](#subscriptions) subscription returns the active route's head-model.
+The `<head>` is modelled separately from the body as a head-model — a data structure carrying `:title`, `:meta`, `:link`, `:json-ld`, `:html-attrs`, `:body-attrs`, registered per-route with `reg-head`. A registered head-fn is evaluated and rendered through the `re-frame.core` facade accessors `render-head` / `active-head` / `head-model->html` / `head-snapshot` (documented in [`re-frame.core`](re-frame.core.md)). The [`:rf/head`](#subscriptions) subscription returns the active route's head-model.
 
 ### `reg-head`
 
@@ -190,7 +205,7 @@ The `<head>` of an SSR document is structurally separate from the body. re-frame
   ```clojure
   (reg-head id ?metadata head-fn)
   ```
-- **Description**: Register a head-fn keyed by id. Signature: `(fn [db route] head-model)`. Routes opt-in via `:head` route metadata.
+- **Description**: Register a head-fn keyed by id. The head-fn signature is `(fn [db route] head-model)`. Routes opt in via `:head` route metadata.
 - **Example**:
   ```clojure
   (rf/reg-head :app/head
@@ -203,9 +218,15 @@ The `<head>` of an SSR document is structurally separate from the body. re-frame
 
 ## Hydration
 
-The server-rendered HTML carries a `__rf_payload` chunk that the client deserialises into `app-db` on bootstrap. The structural-hash from `render-tree-hash` is captured at render time and checked at hydration; a mismatch between the server-render hash and the client-render hash surfaces **`:rf.ssr/hydration-mismatch`** (in `:hard-error` mode it also throws; otherwise it warns and re-renders client-side) rather than silently mounting a broken DOM. This is distinct from the two payload-provenance checks the reference `:rf/hydrate` handler runs — `:rf.ssr/version-mismatch` (the payload was produced by a different framework version) and `:rf.ssr/schema-digest-mismatch` (the app's schema set drifted since the payload was built); those guard payload compatibility, while `:rf.ssr/hydration-mismatch` guards the render-tree structural hash.
+The server-rendered HTML carries a `__rf_payload` chunk that the client deserialises into `app-db` on bootstrap. The `render-tree-hash` structural hash is captured at render time and re-checked at hydration.
 
-The hydration payload is the `__rf_payload` chunk seeded into `app-db` on bootstrap — see [the SSR tutorial §The client side](../ssr/concepts.md#the-client-side-hydrate-then-verify).
+Three checks guard hydration, each with its own trace:
+
+- **`:rf.ssr/hydration-mismatch`** — the server-render hash disagrees with the client-render hash. In `:hard-error` mode it also throws; otherwise it warns and re-renders client-side, rather than mounting a broken DOM.
+- `:rf.ssr/version-mismatch` — the payload was produced by a different framework version.
+- `:rf.ssr/schema-digest-mismatch` — the app's schema set drifted since the payload was built.
+
+The latter two are payload-provenance checks the reference `:rf/hydrate` handler runs; `hydration-mismatch` guards the render-tree structural hash. See [the SSR tutorial §The client side](../ssr/concepts.md#the-client-side-hydrate-then-verify).
 
 ### `hydrate!`
 
@@ -214,7 +235,13 @@ The hydration payload is the `__rf_payload` chunk seeded into `app-db` on bootst
   ```clojure
   (hydrate! opts) → applied-payload | nil
   ```
-- **Description**: Client-side boot helper — the symmetric counterpart of the server's `re-frame.ssr.ring/ssr-handler`. Fuses the three steps the client flow mandates: **read** the payload (supplied via `:payload`, or on CLJS read from the DOM's `__rf_payload` `<script>` via [`read-server-payload`](#read-server-payload)), **hydrate** via `dispatch-sync [:rf/hydrate payload]` against the target `:frame` before the first render (locked `:replace-frame-state` semantics), then **verify** by calling the supplied `:render-tree-fn` and comparing its hash against the server hash (omit `:render-tree-fn` to skip). `:frame` is REQUIRED (an absent frame emits + throws `:rf.error/no-frame-context`); a payload whose `:rf/frame-id` names a different frame than `:frame` emits + throws `:rf.error/hydration-frame-id-mismatch`; `:payload` is required on the JVM and optional on CLJS (read from the DOM when omitted); `:element-id` overrides the payload `<script>` id. Returns the payload that was applied, or `nil` on a client-only first load.
+- **Description**: Client-side boot helper — the symmetric counterpart of the server's `re-frame.ssr.ring/ssr-handler`. Returns the payload that was applied, or `nil` on a client-only first load. Fuses the three mandated client-flow steps:
+  1. **read** the payload — supplied via `:payload`, or on CLJS read from the DOM's `__rf_payload` `<script>` via [`read-server-payload`](#read-server-payload).
+  2. **hydrate** via `dispatch-sync [:rf/hydrate payload]` against the target `:frame` before the first render (locked `:replace-frame-state` semantics).
+  3. **verify** by calling the supplied `:render-tree-fn` and comparing its hash against the server hash (omit `:render-tree-fn` to skip).
+  - `:frame` is **REQUIRED** — an absent frame emits + throws `:rf.error/no-frame-context`.
+  - A payload whose `:rf/frame-id` names a different frame than `:frame` emits + throws `:rf.error/hydration-frame-id-mismatch`.
+  - `:payload` is required on the JVM and optional on CLJS (read from the DOM when omitted). `:element-id` overrides the payload `<script>` id.
 - **Example**:
   ```clojure
   ;; Client boot: read payload, dispatch :rf/hydrate, then verify —
@@ -232,7 +259,9 @@ The hydration payload is the `__rf_payload` chunk seeded into `app-db` on bootst
   (read-server-payload)            → payload-map | nil
   (read-server-payload element-id) → payload-map | nil
   ```
-- **Description**: Read the EDN hydration payload from the DOM's `__rf_payload` `<script>` (the pinned default id; pass `element-id` to read a host-overridden slot). Returns the parsed payload map, or `nil` when the page was not server-rendered (no payload script present). A malformed payload script fails closed: the parse failure surfaces as `:rf.error/malformed-hydration-payload` and `nil` is returned, so the host falls back to a client-only first render. `hydrate!` calls this when `:payload` is omitted.
+- **Description**: Read the EDN hydration payload from the DOM's `__rf_payload` `<script>` (the pinned default id; pass `element-id` to read a host-overridden slot). `hydrate!` calls this when `:payload` is omitted.
+  - Returns the parsed payload map, or `nil` when the page was not server-rendered (no payload script present).
+  - Fails closed: a malformed payload script surfaces `:rf.error/malformed-hydration-payload` and returns `nil`, so the host falls back to a client-only first render.
 - **Example**:
   ```clojure
   ;; Branch on "was this page server-rendered?" without booting.
@@ -248,7 +277,10 @@ The hydration payload is the `__rf_payload` chunk seeded into `app-db` on bootst
   (verify-hydration! frame-id render-tree)
   (verify-hydration! frame-id render-tree opts)
   ```
-- **Description**: Called by client code after the first render. Compares the post-render hash to the server hash stashed during `:rf/hydrate`; on disagreement emits `:rf.ssr/hydration-mismatch`. The second argument may be either a render tree (it is hashed) or a pre-computed hash string. `opts` may carry `:first-diff-path`, `:failing-id`, and `:server-hash` (the last overrides the stashed slot). Two per-frame `:ssr` knobs govern behaviour: `{:detect-mismatch? false}` skips the comparison, and `{:on-mismatch :hard-error}` escalates a detected mismatch to a thrown structured exception (default `:warn` → `:warned-and-replaced`). `hydrate!` calls this for you when given a `:render-tree-fn`; call it directly when the host must verify the actually-mounted tree.
+- **Description**: Called by client code after the first render. Compares the post-render hash to the server hash stashed during `:rf/hydrate`; on disagreement emits `:rf.ssr/hydration-mismatch`. `hydrate!` calls this for you when given a `:render-tree-fn`; call it directly when the host must verify the actually-mounted tree.
+  - The second argument may be a render tree (it is hashed) or a pre-computed hash string.
+  - `opts` may carry `:first-diff-path`, `:failing-id`, and `:server-hash` (the last overrides the stashed slot).
+  - Two per-frame `:ssr` knobs govern behaviour: `{:detect-mismatch? false}` skips the comparison; `{:on-mismatch :hard-error}` escalates a detected mismatch to a thrown structured exception (default `:warn` → `:warned-and-replaced`).
 - **Example**:
   ```clojure
   ;; Host that mounts first, then verifies the mounted tree explicitly.
@@ -257,7 +289,7 @@ The hydration payload is the `__rf_payload` chunk seeded into `app-db` on bootst
 
 ## Error projection
 
-A frame opts into SSR error projection via the `:ssr {:public-error-id ... :dev-error-detail? ...}` map on its `reg-frame` / `make-frame` metadata. This is **per-frame metadata**, not a `configure` key — different frames in the same process can carry different projector / dev-detail settings, so the natural lifetime is per-frame.
+A frame opts into SSR error projection via the `:ssr {:public-error-id ... :dev-error-detail? ...}` map on its `reg-frame` / `make-frame` metadata. This is **per-frame metadata**, not a `configure` key — different frames in the same process can carry different projector / dev-detail settings.
 
 ### `reg-error-projector`
 
@@ -266,7 +298,7 @@ A frame opts into SSR error projection via the `:ssr {:public-error-id ... :dev-
   ```clojure
   (reg-error-projector id ?metadata projector-fn) → id
   ```
-- **Description**: Register a projector keyed by id. Signature: `(fn [trace-event] :rf/public-error)`. Named per-frame via the frame's `:ssr {:public-error-id ...}` metadata. Returns `id`.
+- **Description**: Register a projector keyed by id. The projector signature is `(fn [trace-event] :rf/public-error)`. Named per-frame via the frame's `:ssr {:public-error-id ...}` metadata. Returns `id`.
 - **Example**:
   ```clojure
   (rf/reg-error-projector :app/public-error
@@ -284,7 +316,10 @@ A frame opts into SSR error projection via the `:ssr {:public-error-id ... :dev-
   ```clojure
   (project-error frame-id trace-event) → :rf/public-error
   ```
-- **Description**: Apply the active error-projector (selected by the frame's `:ssr {:public-error-id ...}` metadata) for the named frame. This is the seam between "internal error trace event with full diagnostic detail" and "client-safe public-error projection." When the frame's `:ssr {:dev-error-detail? true}` metadata is set, the projection carries an extra `:details` key with the raw trace event (absent by default).
+- **Description**: Apply the named frame's active error-projector (selected by its `:ssr {:public-error-id ...}` metadata) to a trace event. The seam between an internal error trace event (full diagnostic detail) and a client-safe public-error projection.
+  - When the frame's `:ssr {:dev-error-detail? true}` metadata is set, the projection carries an extra `:details` key with the raw trace event (absent by default).
+  - If the projector throws or returns a non-conforming shape, emits `:rf.error/sanitised-on-projection` and returns the locked generic-500 [`fallback-public-error`](#fallback-public-error) — the boundary cannot be bypassed by a bug in the projector.
+  - `reg-error-projector` (above) registers the projector this applies.
 - **Example**:
   ```clojure
   ;; Turn an internal error-trace event into the frame's client-safe
@@ -293,8 +328,6 @@ A frame opts into SSR error projection via the `:ssr {:public-error-id ... :dev-
   ;; => {:status 404 :code :not-found :message "Page not found"}
   ```
 
-The companion `reg-error-projector` (above) registers the projector that `project-error` applies — same `:rf/public-error` contract; if the projector throws or returns a non-conforming shape, `project-error` emits `:rf.error/sanitised-on-projection` and returns the locked generic-500 [`fallback-public-error`](#fallback-public-error) so the boundary cannot be bypassed by a bug in the projector.
-
 ### `default-error-projector-fn`
 
 - **Kind**: function
@@ -302,7 +335,11 @@ The companion `reg-error-projector` (above) registers the projector that `projec
   ```clojure
   (default-error-projector-fn trace-event) → :rf/public-error
   ```
-- **Description**: The runtime's built-in default projector, registered under `:rf.ssr/default-error-projector`. Maps `:rf.error/no-such-handler` and `:rf.error/no-such-route` to `404 :not-found`; `:rf.error/cofx-value-invalid` (a client-supplied coeffect rejected at the dispatch boundary) to `400 :bad-request`; `:rf.error/schema-validation-failure` to `400 :bad-request` only when the failure's `:where` tag is `:event` (a client-supplied event payload — server-side surfaces such as `:where :fx-args` fall through); and everything else to the locked generic `500 :internal-error` ([`fallback-public-error`](#fallback-public-error)).
+- **Description**: The runtime's built-in default projector, registered under `:rf.ssr/default-error-projector`. Maps trace events to public errors:
+  - `:rf.error/no-such-handler`, `:rf.error/no-such-route` → `404 :not-found`.
+  - `:rf.error/cofx-value-invalid` (a client-supplied coeffect rejected at the dispatch boundary) → `400 :bad-request`.
+  - `:rf.error/schema-validation-failure` → `400 :bad-request` only when the failure's `:where` tag is `:event` (a client-supplied event payload); server-side surfaces such as `:where :fx-args` fall through.
+  - Everything else → the locked generic `500 :internal-error` ([`fallback-public-error`](#fallback-public-error)).
 
 ### `apply-error-projection!`
 
@@ -312,7 +349,10 @@ The companion `reg-error-projector` (above) registers the projector that `projec
   (apply-error-projection! frame-id)
   (apply-error-projection! frame-id trace-event)
   ```
-- **Description**: Project an error trace event via the active projector for `frame-id` and stamp the resulting public-error's `:status` onto the response accumulator. Returns the public-error map, or `nil` on a no-op (frame missing / not a server frame / no pending trace). The 1-arity drains the frame's error-trace buffer and projects the LAST trace (last-write-wins); the 2-arity projects the supplied trace directly (for hosts that catch errors outside the trace stream). When the response already carries a `:redirect`, its status is locked through — the projection still returns the public-error map but does not overwrite `:status`.
+- **Description**: Project an error trace event via `frame-id`'s active projector and stamp the resulting public-error's `:status` onto the response accumulator. Returns the public-error map, or `nil` on a no-op (frame missing / not a server frame / no pending trace).
+  - 1-arity: drains the frame's error-trace buffer and projects the LAST trace (last-write-wins).
+  - 2-arity: projects the supplied trace directly (for hosts that catch errors outside the trace stream).
+  - When the response already carries a `:redirect`, its status is locked through — the projection returns the public-error map but does not overwrite `:status`.
 
 ### `project-render-exception!`
 
@@ -321,7 +361,10 @@ The companion `reg-error-projector` (above) registers the projector that `projec
   ```clojure
   (project-render-exception! frame-id throwable) → :rf/public-error | nil
   ```
-- **Description**: Route a render-time `Throwable` through the SSR error projector for `frame-id`. Synthesises a `:rf.error/ssr-render-failed` trace carrying the exception and drives the projector (via `apply-error-projection!`) so the response accumulator's `:status` is stamped with the projector's output; also emits the trace so monitoring listeners see the rich internal detail. Returns the public-error map (the host's contract for rendering the wire error body), or `nil` when projection is not applicable. Host adapters wrap their `render-to-string` call and route render-time throws through this. A per-frame dev escape-hatch — `:ssr {:on-view-exception :throw}` — re-throws unchanged instead of projecting.
+- **Description**: Route a render-time `Throwable` through `frame-id`'s SSR error projector. Host adapters wrap their `render-to-string` call and route render-time throws through this. Returns the public-error map (the host's contract for rendering the wire error body), or `nil` when projection is not applicable.
+  - Synthesises a `:rf.error/ssr-render-failed` trace carrying the exception and drives the projector (via `apply-error-projection!`), stamping the response accumulator's `:status` with the projector's output.
+  - Also emits the trace so monitoring listeners see the rich internal detail.
+  - Per-frame dev escape-hatch `:ssr {:on-view-exception :throw}` re-throws unchanged instead of projecting.
 
 ### `public-error-keys`
 
@@ -330,7 +373,7 @@ The companion `reg-error-projector` (above) registers the projector that `projec
   ```clojure
   public-error-keys   ;; => #{:status :code :message :retryable?}
   ```
-- **Description**: The four locked keys on the `:rf/public-error` shape. Conformant projector output carries exactly these (plus an optional `:details` in dev mode).
+- **Description**: The four locked keys on the `:rf/public-error` shape. Conformant projector output carries exactly these, plus an optional `:details` in dev mode.
 
 ### `fallback-public-error`
 
@@ -387,7 +430,7 @@ Each per-request frame accumulates its HTTP response — status, headers, cookie
   ```clojure
   (peek-response frame-id) → response-map
   ```
-- **Description**: A PURE read of the resolved response accumulator — does NOT drain pending error projections. Use from debug paths or midpoint inspections where draining the projector buffer (the side-effect baked into `get-response`) would consume a trace the host had not yet observed.
+- **Description**: A **pure** read of the resolved response accumulator — does NOT drain pending error projections. Use from debug paths or midpoint inspections where draining the projector buffer (the side-effect baked into `get-response`) would consume a trace the host had not yet observed.
 
 ### `flush-response!`
 
@@ -441,7 +484,7 @@ An SSR host adapter populates a per-frame request slot once per request (before 
   ```clojure
   (on-frame-destroyed! frame-id)
   ```
-- **Description**: Per-request frame teardown hook. Drops the per-frame entries in the pending-error-trace buffer, the request slot, and the response slot for `frame-id`, and invokes the head-snapshot cleanup. Called during per-request frame teardown via the `:ssr/on-frame-destroyed` late-bind hook. Idempotent — a second call against the same frame-id is a no-op.
+- **Description**: Per-request frame teardown hook. Drops the frame's entries in the pending-error-trace buffer, the request slot, and the response slot, and invokes the head-snapshot cleanup. Called during per-request frame teardown via the `:ssr/on-frame-destroyed` late-bind hook. Idempotent — a second call against the same frame-id is a no-op.
 
 ## Blocking-resource drain
 
@@ -453,7 +496,9 @@ An SSR host adapter populates a per-frame request slot once per request (before 
   (drain-blocking-resources! frame-id)
   (drain-blocking-resources! frame-id opts)
   ```
-- **Description**: Drain the current nav-token's BLOCKING resources for SSR `frame-id` until they settle or the render deadline fires, so the render walk sees a settled resource state (never a hung `:loading`). A no-op returning `{:settled? true}` when the resources artefact is absent — an SSR app without resources never blocks on them. The host render path calls this after frame setup + route resolution and before the render walk. `opts` keys (all optional): `:ssr-blocking-timeout-ms` (the wall-clock budget, default `5000`), `:pump!` (a 1-arity `(fn [tick-ms] …)` event-pump thunk; defaults to a host-platform yield so an in-flight async reply lands between re-checks), and `:tick-ms` (poll-granularity hint, default `5`). Returns the drain result map `{:settled? :timed-out :route-blocking-failure}`.
+- **Description**: Drain the current nav-token's BLOCKING resources for SSR `frame-id` until they settle or the render deadline fires, so the render walk sees a settled resource state (never a hung `:loading`). The host render path calls this after frame setup + route resolution and before the render walk. Returns the drain result map `{:settled? :timed-out :route-blocking-failure}`.
+  - A no-op returning `{:settled? true}` when the resources artefact is absent — an SSR app without resources never blocks on them.
+  - `opts` keys (all optional): `:ssr-blocking-timeout-ms` (wall-clock budget, default `5000`); `:pump!` (a 1-arity `(fn [tick-ms] …)` event-pump thunk; defaults to a host-platform yield so an in-flight async reply lands between re-checks); `:tick-ms` (poll-granularity hint, default `5`).
 - **Example**:
   ```clojure
   ;; Host render path: settle blocking resources before walking the tree.
@@ -501,9 +546,14 @@ All server-only — `:platforms #{:server}`. These build the response accumulato
 | `[:rf.server/set-cookie :rf.server/cookie]` | structured cookie map |
 | `[:rf.server/delete-cookie {:name ?:path ?:domain}]` | — |
 | `[:rf.server/redirect {:location ?:status}]` | default `:status 302`; truncates HTML. **Caller-trusted** `:location`. |
-| `[:rf.server/safe-redirect {:location ?:relative-only? ?:allow ?:status}]` | The caller-untrusted variant — parses `:location` (`:rf.error/safe-redirect-invalid-url`), rejects `javascript:` / `data:` / `vbscript:` schemes (`:rf.error/safe-redirect-scheme-rejected`), and enforces `:relative-only?` / `:allow` allowlist (`:rf.error/safe-redirect-host-disallowed`) before setting `:redirect`. Open-redirect mitigation for attacker-controlled `?next=` strings. |
+| `[:rf.server/safe-redirect {:location ?:relative-only? ?:allow ?:status}]` | The caller-untrusted variant — open-redirect mitigation for attacker-controlled `?next=` strings. Before setting `:redirect`, it parses `:location` (`:rf.error/safe-redirect-invalid-url`), rejects `javascript:` / `data:` / `vbscript:` schemes (`:rf.error/safe-redirect-scheme-rejected`), and enforces `:relative-only?` / `:allow` allowlist (`:rf.error/safe-redirect-host-disallowed`). |
 
-All seven validate at the fx boundary: a header name violating the RFC 7230 token grammar throws `:rf.error/header-invalid-name`; a header value carrying CR/LF/NUL throws `:rf.error/header-invalid-value`; cookie fields throw `:rf.error/cookie-invalid-name` / `:rf.error/cookie-invalid-<attr>`; a redirect `:location` carrying CR/LF/NUL throws `:rf.error/redirect-invalid-location`, and the retired `:url` / `:to` target keys throw `:rf.error/redirect-retired-target-key`. `:status` and `:redirect` are last-write-wins — a second write in the same drain emits `:rf.warning/multiple-status-set` / `:rf.warning/multiple-redirects`.
+Boundary validation (all seven):
+
+- A header name violating the RFC 7230 token grammar throws `:rf.error/header-invalid-name`; a header value carrying CR/LF/NUL throws `:rf.error/header-invalid-value`.
+- Cookie fields throw `:rf.error/cookie-invalid-name` / `:rf.error/cookie-invalid-<attr>`.
+- A redirect `:location` carrying CR/LF/NUL throws `:rf.error/redirect-invalid-location`; the retired `:url` / `:to` target keys throw `:rf.error/redirect-retired-target-key`.
+- `:status` and `:redirect` are last-write-wins — a second write in the same drain emits `:rf.warning/multiple-status-set` / `:rf.warning/multiple-redirects`.
 
 - **Example**:
   ```clojure

--- a/docs/api/re-frame.ssr.ring.md
+++ b/docs/api/re-frame.ssr.ring.md
@@ -1,6 +1,8 @@
 # re-frame.ssr.ring
 
-The Ring/Pedestal host adapter for re-frame2 server-side rendering. The SSR runtime in [`re-frame.ssr`](re-frame.ssr.md) owns the per-request lifecycle (create a per-request frame, drain its `:initial-events`, render, build the hydration payload, read the structured response accumulator, destroy the frame) but never writes to a network socket directly; this namespace materialises that structured response into the wire format a Ring-compatible server expects. Ring is the canonical Clojure HTTP-server abstraction — Jetty, http-kit, Pedestal, Reitit-ring, and Aleph all accept Ring-shaped handlers — so this single adapter covers the bulk of the Clojure HTTP ecosystem. Add the `day8/re-frame2-ssr-ring` artefact to your deps and require this namespace to get the host-adapter surface; the rendering / head primitives, the SSR events / subs / cofx, and the per-request `:rf.server/*` fx live in [`re-frame.ssr`](re-frame.ssr.md) (artefact `day8/re-frame2-ssr`), not here.
+The Ring/Pedestal host adapter for re-frame2 server-side rendering. It materialises the structured response produced by the SSR runtime in [`re-frame.ssr`](re-frame.ssr.md) into the wire format a Ring-compatible server expects; it never writes to a socket directly. The per-request lifecycle, rendering / head primitives, SSR events / subs / cofx, and the `:rf.server/*` fx all live in [`re-frame.ssr`](re-frame.ssr.md) (artefact `day8/re-frame2-ssr`), not here.
+
+Ships in the `day8/re-frame2-ssr-ring` artefact. See [Server-side rendering — the tutorial](../ssr/concepts.md) for the conceptual walkthrough.
 
 ```clojure
 (:require [re-frame.ssr.ring :as ssr.ring])
@@ -15,28 +17,48 @@ The Ring/Pedestal host adapter for re-frame2 server-side rendering. The SSR runt
   ```clojure
   (ssr-handler opts) → (fn [ring-request] ring-response)
   ```
-- **Description**: Return a Ring-shaped (synchronous) handler that renders one re-frame2 SSR request per call. The returned handler owns the whole per-request lifecycle: populate the per-frame request slot, register the per-request frame (which drains `:initial-events` synchronously so the `:rf.server/request` cofx can resolve), read the resolved response accumulator, branch on `:redirect`, otherwise render the `:root-view` + build the hydration payload + wrap it in the HTML shell + materialise structured cookies to `Set-Cookie` headers, and destroy the frame in a `finally`.
+- **Description**: Returns a synchronous Ring handler that renders one re-frame2 SSR request per call.
+
+  The returned handler owns the whole per-request lifecycle: populate the per-frame request slot; register the per-request frame (draining `:initial-events` synchronously so the `:rf.server/request` cofx can resolve); read the resolved response accumulator; branch on `:redirect`; otherwise render `:root-view`, build the hydration payload, wrap it in the HTML shell, materialise structured cookies to `Set-Cookie` headers; and destroy the frame in a `finally`.
 
   Required opts:
 
-  - `:initial-events` — an ordered **vector** of events dispatched synchronously, in order, into the per-request frame at creation; **or** a `(fn [request] → initial-events-vector)` that derives the setup vector from the Ring request. The fn form is the replay-safe seam for folding a request-derived fact into a boot event's **payload** (e.g. `(fn [req] [[:auth/server-init {:user (extract-user req)}]])`). For non-durable request reads *inside* a handler, declare `:rf.cofx/requires [:rf.server/request]` on the registration instead. Omission throws `:rf.error/ssr-ring-missing-initial-events` at construction; a value that is neither a vector nor a fn — or a fn returning a non-vector — throws `:rf.error/invalid-initial-events` per request.
-  - `:root-view` — a hiccup vector (e.g. `[:app/root]`) **or** a 0-arity fn returning hiccup, rendered against the per-request frame after the drain settles. Omission throws `:rf.error/ssr-ring-missing-root-view` at construction; any other shape throws `:rf.error/invalid-root-view` at render time.
-  - `:payload` — **REQUIRED, fail-closed.** The hydration-payload policy: one opt, two shapes. A non-empty **vector** of top-level app-db keys (keywords) is an allowlist (recommended — only the listed keys ship in `:rf/app-db`, every other key is dropped, including keys added later as the app evolves); the **keyword** `:rf.ssr.payload/whole-app-db` opts into shipping the whole `app-db` (use only when the app-db is structurally safe to expose end-to-end). All three defects throw at handler-construction time: absence (or an empty allowlist) throws `:rf.error/ssr-missing-payload-policy`; an unrecognised keyword throws `:rf.error/ssr-unknown-payload-policy`; an allowlist containing non-keyword entries throws `:rf.error/ssr-malformed-payload-allowlist`.
+  - `:initial-events` — an ordered vector of events dispatched synchronously, in order, into the per-request frame at creation; or a `(fn [request] → initial-events-vector)` that derives the vector from the Ring request. The fn form is the replay-safe seam for folding a request-derived fact into a boot event's payload, e.g. `(fn [req] [[:auth/server-init {:user (extract-user req)}]])`. For non-durable request reads inside a handler, declare `:rf.cofx/requires [:rf.server/request]` on the registration instead.
+    - Omission throws `:rf.error/ssr-ring-missing-initial-events` at construction.
+    - A value that is neither a vector nor a fn, or a fn returning a non-vector, throws `:rf.error/invalid-initial-events` per request.
+  - `:root-view` — a hiccup vector (e.g. `[:app/root]`) or a 0-arity fn returning hiccup, rendered against the per-request frame after the drain settles.
+    - Omission throws `:rf.error/ssr-ring-missing-root-view` at construction.
+    - Any other shape throws `:rf.error/invalid-root-view` at render time.
+  - `:payload` — **REQUIRED, fail-closed.** The hydration-payload policy, one opt with two shapes:
+    - A non-empty vector of top-level app-db keys (keywords) is an allowlist (recommended): only the listed keys ship in `:rf/app-db`; every other key is dropped, including keys added later.
+    - The keyword `:rf.ssr.payload/whole-app-db` ships the whole `app-db` (use only when the app-db is structurally safe to expose).
+    - Absence or an empty allowlist throws `:rf.error/ssr-missing-payload-policy`; an unrecognised keyword throws `:rf.error/ssr-unknown-payload-policy`; an allowlist with non-keyword entries throws `:rf.error/ssr-malformed-payload-allowlist`. All three throw at construction.
 
-  Optional opts: `:fx-overrides` (per-frame `:fx-overrides` map, passed through verbatim — useful for stubbing `:rf.http/managed` in tests), `:ssr` (per-frame `:ssr` config map, e.g. `{:dev-error-detail? true :public-error-id :myapp/projector}`), `:emit-hash?` (embed `data-rf-render-hash` on the root element; default `true`), `:version` (hydration payload's `:rf/version`; default `1`), `:schema-digest` (hydration payload's `:rf/schema-digest`), `:html-shell` (`(body-html payload-edn opts) → string`; defaults to [`default-html-shell`](#default-html-shell)), and `:content-type` (default `"text/html; charset=utf-8"`).
+  Optional opts:
 
-  **Error handling — `:on-error` vs `:error-view`.** Two opts handle two different failures; a robust deployment usually wires **both**:
+  - `:fx-overrides` — per-frame `:fx-overrides` map, passed through verbatim (e.g. to stub `:rf.http/managed` in tests).
+  - `:ssr` — per-frame `:ssr` config map, e.g. `{:dev-error-detail? true :public-error-id :myapp/projector}`.
+  - `:emit-hash?` — embed `data-rf-render-hash` on the root element; default `true`.
+  - `:version` — hydration payload's `:rf/version`; default `1`.
+  - `:schema-digest` — hydration payload's `:rf/schema-digest`.
+  - `:html-shell` — `(body-html payload-edn opts) → string`; defaults to [`default-html-shell`](#default-html-shell).
+  - `:content-type` — default `"text/html; charset=utf-8"`.
+
+  Error handling — `:error-view` vs `:on-error`. Two opts handle two different failures; a robust deployment wires both. A buggy `:error-view` falls back to the default template and a buggy `:on-error` falls back to `default-on-error` — neither bug bypasses the error boundary.
 
   | Aspect | `:error-view` | `:on-error` |
   |---|---|---|
   | Which failure? | An exception inside the re-frame drain or the render walk — something the error projector catches. | A transport / Ring-layer failure the projector cannot see — per-request frame setup throw, render-time CLJ exception, header/cookie materialise throw, a thrown initial-event. |
-  | What does it produce? | The projected error-page **body** (hiccup) — a registered-view keyword (resolved as `[error-view public-error]`) or a `(public-error) → hiccup` fn, rendered through the standard SSR emitter. | A raw Ring response map `{:status … :headers … :body …}` returned verbatim to the server. |
-  | What is its input? | The **public-error map** (sanitised by the projector — safe to render). | The raw `(request throwable)` — the unsanitised throwable. The locked default never reads it. |
+  | What does it produce? | The projected error-page body (hiccup) — a registered-view keyword (resolved as `[error-view public-error]`) or a `(public-error) → hiccup` fn, rendered through the standard SSR emitter. | A raw Ring response map `{:status … :headers … :body …}` returned verbatim to the server. |
+  | What is its input? | The public-error map (sanitised by the projector — safe to render). | The raw `(request throwable)` — the unsanitised throwable. The locked default never reads it. |
   | Default when omitted? | Minimal default error template. | Minimal locked 500 ([`default-on-error`](#default-on-error), topology-leak-safe). |
 
-  A buggy `:error-view` falls back to the default template and a buggy `:on-error` falls back to `default-on-error` — neither bug bypasses the error boundary.
+  Trusted shell-hook string opts. Four optional strings cross the trust boundary into the rendered HTML envelope, split by injection position:
 
-  **Trusted shell-hook string opts.** Four optional strings cross the trust boundary into the rendered HTML envelope, split by injection position. `:head` and `:body-end` are **raw content hooks** (injected verbatim, no escaping); `:script-src` (default `"/main.js"`) and `:app-element-id` (default `"app"`) are **escaped attribute hooks** (escape-attr'd into a quoted attribute value). The framework names these as trusted-string surfaces; the trust call itself is the caller's. Non-string non-nil values throw `:rf.error/ssr-trusted-shell-opt-invalid` at construction. Wiring the raw content hooks from untrusted input (CMS field, tenant-admin form, query-string parameter) is an arbitrary-script-injection XSS vector — use the structured alternatives ([`reg-head`](re-frame.ssr.md) for head fragments, registered views + the [`:rf.server/*` fx](re-frame.ssr.md) for body content) when content originates upstream of the trust boundary.
+  - `:head` and `:body-end` — raw content hooks, injected verbatim with no escaping.
+  - `:script-src` (default `"/main.js"`) and `:app-element-id` (default `"app"`) — escaped attribute hooks, escape-attr'd into a quoted attribute value.
+
+  Non-string non-nil values throw `:rf.error/ssr-trusted-shell-opt-invalid` at construction. Wiring the raw content hooks from untrusted input (CMS field, tenant-admin form, query-string parameter) is an arbitrary-script-injection XSS vector — use the structured alternatives ([`reg-head`](re-frame.ssr.md) for head fragments, registered views + the [`:rf.server/*` fx](re-frame.ssr.md) for body content) when content originates upstream of the trust boundary.
 - **Example**:
   ```clojure
   (require '[ring.adapter.jetty :as jetty]
@@ -66,11 +88,24 @@ The Ring/Pedestal host adapter for re-frame2 server-side rendering. The SSR runt
   ```clojure
   (stream-handler opts) → (fn [ring-request] ring-response)
   ```
-- **Description**: The streaming counterpart of `ssr-handler` — returns a synchronous Ring handler that streams SSR responses via `Transfer-Encoding: chunked`. It flushes a shell on the first byte and streams `:rf/suspense-boundary` subtrees as their data resolves; a boundary whose drain changed app-db also carries a speculative per-subtree hydration delta (projected through the same `:payload` policy as the final payload — an off-allowlist or empty delta emits no delta script), and the final chunk carries the canonical full hydration payload (if a speculative delta and the canonical payload ever disagree, the payload wins). Failure isolation is per-boundary: a boundary whose render throws keeps its fallback (with a `:rf.ssr/suspense-boundary-failed` trace) while the rest of the page streams on. Non-streaming responses (no `:rf/suspense-boundary` in the tree) still ride the chunked path with zero continuations, collapsing the wire shape to shell-prefix + shell-html + final-payload + shell-suffix. A `:redirect` set during the drain short-circuits to a bodiless Location response before any chunk is written. The shell renders on the request thread **before** the chunked head commits: a root-view / shell-walk throw fails closed to a non-200 projected error page (`:rf.error/ssr-render-failed` via the projector) with no writer thread spawned. Any `Content-Length` header accumulated during the drain is stripped (case-insensitively) so the host server owns chunked transfer framing.
+- **Description**: The streaming counterpart of `ssr-handler` — returns a synchronous Ring handler that streams SSR responses via `Transfer-Encoding: chunked`.
 
-  Opts mirror `ssr-handler` — same `:initial-events` (both the vector and the `(fn [request] → …)` forms), `:root-view`, `:payload`, `:fx-overrides`, `:ssr`, `:on-error`, `:error-view`, `:emit-hash?`, `:version`, `:schema-digest`, `:content-type`, plus the four trusted shell-hook opts (`:head` / `:body-end` / `:script-src` / `:app-element-id`, honoured by [`default-streaming-prefix`](#default-streaming-prefix) / [`default-streaming-suffix`](#default-streaming-suffix)). One exception: `:html-shell` is **not** supported and is rejected at handler-construction time (`:rf.error/ssr-streaming-unsupported-opt`) — the streaming path flushes a split prefix/suffix straddling the continuation chunks, so a one-piece shell callback can never run; customise the streaming envelope through the trusted shell-hook opts, or use `ssr-handler` when a bespoke one-piece shell is required.
+  Streaming behaviour:
 
-  Concurrency model: one raw daemon `java.lang.Thread` per in-flight streamed request — no framework pool and no framework in-flight cap by design. The model is no-leak (every writer's `catch`/`finally` closes the pipe and tears the frame down on every exit path); the in-flight ceiling is the **host** server's accept-queue / worker-thread limit (Jetty / http-kit / Aleph), which operators size as the one authoritative knob for high streaming concurrency or slow-client hardening.
+  - Flushes a shell on the first byte, then streams `:rf/suspense-boundary` subtrees as their data resolves.
+  - A boundary whose drain changed app-db also carries a speculative per-subtree hydration delta, projected through the same `:payload` policy as the final payload; an off-allowlist or empty delta emits no delta script.
+  - The final chunk carries the canonical full hydration payload. If a speculative delta and the canonical payload ever disagree, the payload wins.
+  - Failure isolation is per-boundary: a boundary whose render throws keeps its fallback (with a `:rf.ssr/suspense-boundary-failed` trace) while the rest of the page streams on.
+  - Non-streaming responses (no `:rf/suspense-boundary` in the tree) still ride the chunked path with zero continuations, collapsing the wire shape to shell-prefix + shell-html + final-payload + shell-suffix.
+  - A `:redirect` set during the drain short-circuits to a bodiless Location response before any chunk is written.
+  - The shell renders on the request thread before the chunked head commits: a root-view / shell-walk throw fails closed to a non-200 projected error page (`:rf.error/ssr-render-failed` via the projector) with no writer thread spawned.
+  - Any `Content-Length` header accumulated during the drain is stripped (case-insensitively) so the host server owns chunked transfer framing.
+
+  Opts mirror `ssr-handler`: `:initial-events` (both vector and `(fn [request] → …)` forms), `:root-view`, `:payload`, `:fx-overrides`, `:ssr`, `:on-error`, `:error-view`, `:emit-hash?`, `:version`, `:schema-digest`, `:content-type`, plus the four trusted shell-hook opts (`:head` / `:body-end` / `:script-src` / `:app-element-id`, honoured by [`default-streaming-prefix`](#default-streaming-prefix) / [`default-streaming-suffix`](#default-streaming-suffix)).
+
+  One exception: `:html-shell` is not supported and is rejected at construction (`:rf.error/ssr-streaming-unsupported-opt`). The streaming path flushes a split prefix/suffix straddling the continuation chunks, so a one-piece shell callback can never run — customise the streaming envelope through the trusted shell-hook opts, or use `ssr-handler` when a bespoke one-piece shell is required.
+
+  Concurrency model: one raw daemon `java.lang.Thread` per in-flight streamed request — no framework pool and no framework in-flight cap. Every writer's `catch`/`finally` closes the pipe and tears the frame down on every exit path (no-leak). The in-flight ceiling is the host server's accept-queue / worker-thread limit (Jetty / http-kit / Aleph), which operators size as the one knob for high streaming concurrency or slow-client hardening.
 - **Example**:
   ```clojure
   (require '[ring.adapter.jetty :as jetty]
@@ -95,7 +130,9 @@ The Ring/Pedestal host adapter for re-frame2 server-side rendering. The SSR runt
   ```clojure
   (ssr-middleware opts) → (fn [handler] wrapped-handler)
   ```
-- **Description**: Return Ring middleware that delegates to `ssr-handler` for the requests its `:match?` predicate accepts, and to the wrapped handler otherwise. Useful when SSR is one of several handlers in a Ring stack — e.g. static-asset middleware in front, JSON-API routes alongside. Opts are `ssr-handler`'s opts (including the required, fail-closed `:payload`) plus `:match?` — a `(request) → boolean` predicate; when truthy, SSR renders, when falsy the call falls through to the wrapped handler. `:match?` defaults to matching every GET request.
+- **Description**: Returns Ring middleware that delegates to `ssr-handler` for requests its `:match?` predicate accepts, and to the wrapped handler otherwise. Curried: `(ssr-middleware opts)` returns a `(handler) → wrapped-handler` middleware.
+
+  Opts are `ssr-handler`'s opts (including the required, fail-closed `:payload`) plus `:match?` — a `(request) → boolean` predicate. When truthy, SSR renders; when falsy, the call falls through to the wrapped handler. `:match?` defaults to matching every GET request.
 - **Example**:
   ```clojure
   ;; ssr-middleware is CURRIED: (ssr-middleware opts) returns a Ring
@@ -123,7 +160,7 @@ The Ring/Pedestal host adapter for re-frame2 server-side rendering. The SSR runt
   ;;     :html-shell   default-html-shell
   ;;     :content-type "text/html; charset=utf-8"}
   ```
-- **Description**: The default `ssr-handler` opts merged *under* caller-supplied opts at construction time (caller values win). A **data** var, not a fn — exposed so callers can read or extend the baseline. `:on-error` is deliberately not here: it is resolved separately so the defaults stay orthogonal to the on-error precedence.
+- **Description**: The default `ssr-handler` opts merged under caller-supplied opts at construction (caller values win). A data var, not a fn — exposed so callers can read or extend the baseline. `:on-error` is deliberately absent: it is resolved separately so the defaults stay orthogonal to the on-error precedence.
 - **Example**:
   ```clojure
   ;; Read the baseline the handler constructor merges under your opts.
@@ -138,7 +175,19 @@ The Ring/Pedestal host adapter for re-frame2 server-side rendering. The SSR runt
   ```clojure
   (default-html-shell body-html payload-edn opts) → HTML string
   ```
-- **Description**: The default HTML envelope: wraps the rendered body in a minimal-but-runnable document so a first-time user gets a working SSR endpoint without writing string-concatenation glue. Override via the `:html-shell` opt in `ssr-handler` when you need a custom `<head>` / scripts / styles. Arguments: `body-html` is the string returned by `re-frame.ssr/render-to-string`; `payload-edn` is the hydration payload pre-serialised with `pr-str`; `opts` are the adapter opts (the keys `:head` / `:html-attrs` / `:body-attrs` / `:body-end` / `:script-src` / `:app-element-id` / `:lang` influence the envelope). The hydration-payload `<script>` is stamped with the framework-pinned id `__rf_payload` (the client bootstrap reads it via `document.getElementById("__rf_payload")`) and its EDN body is escaped EDN-aware so a payload containing `</script>` cannot close the envelope — a custom shell must emit the payload `<script>` under this id (and apply equivalent escaping), or substitute its own bootstrap that reads a custom id. `<title>` is **not** emitted by the shell; the head fragment threaded in as `:head` is the canonical source. The two attribute-value hooks (`:script-src`, `:app-element-id`) are escape-attr'd; the two content hooks (`:head`, `:body-end`) are injected raw.
+- **Description**: The default HTML envelope: wraps the rendered body in a minimal, runnable document. Override via the `:html-shell` opt on `ssr-handler` for a custom `<head>` / scripts / styles.
+
+  Arguments:
+
+  - `body-html` — the string returned by `re-frame.ssr/render-to-string`.
+  - `payload-edn` — the hydration payload pre-serialised with `pr-str`.
+  - `opts` — the adapter opts; the keys `:head` / `:html-attrs` / `:body-attrs` / `:body-end` / `:script-src` / `:app-element-id` / `:lang` influence the envelope.
+
+  Behaviour:
+
+  - The hydration-payload `<script>` is stamped with the framework-pinned id `__rf_payload` (the client bootstrap reads it via `document.getElementById("__rf_payload")`), and its EDN body is escaped EDN-aware so a payload containing `</script>` cannot close the envelope. A custom shell must emit the payload `<script>` under this id (with equivalent escaping), or substitute its own bootstrap that reads a custom id.
+  - `<title>` is not emitted by the shell; the head fragment threaded in as `:head` is the canonical source.
+  - The two attribute-value hooks (`:script-src`, `:app-element-id`) are escape-attr'd; the two content hooks (`:head`, `:body-end`) are injected raw.
 - **Example**:
   ```clojure
   ;; The default envelope, invoked directly (the handler does this for you).
@@ -157,7 +206,9 @@ The Ring/Pedestal host adapter for re-frame2 server-side rendering. The SSR runt
   ```clojure
   (default-on-error request throwable) → ring-response
   ```
-- **Description**: The minimal 500 response used when a handler caller doesn't supply `:on-error`. Shared by `ssr-handler` **and** `stream-handler` so the topology-leak contract lives in exactly one place. The SSR runtime's error projector handles trace-emitted errors during drain; this hook covers exceptions the projector can't see (Ring-layer throws, render-time CLJ exceptions, writer-thread-pre-spawn throws). The body must not leak the throwable's message (`.getMessage` carries internal topology — JDBC URLs, deploy-root file paths, partial SQL, server-internal class names), so the fn **ignores** the throwable and emits a fixed generic plaintext body. Apps that want a branded transport-failure body supply an explicit leak-safe `:on-error` fn that returns a fixed response and ignores the throwable. (Exposed as a value — a 2-arity fn — not a `defn`, so it carries no `:arglists`.)
+- **Description**: The minimal 500 response used when a handler caller omits `:on-error`. Shared by `ssr-handler` and `stream-handler` so the topology-leak contract lives in one place. Covers exceptions the SSR error projector can't see (Ring-layer throws, render-time CLJ exceptions, writer-thread-pre-spawn throws); trace-emitted drain errors are handled by the projector instead.
+
+  The body must not leak the throwable's message (`.getMessage` carries internal topology — JDBC URLs, deploy-root file paths, partial SQL, server-internal class names), so the fn ignores the throwable and emits a fixed generic plaintext body. Apps wanting a branded transport-failure body supply an explicit leak-safe `:on-error` fn that returns a fixed response and ignores the throwable. Exposed as a value — a 2-arity fn, not a `defn`, so it carries no `:arglists`.
 - **Example**:
   ```clojure
   ;; The host-locked transport-failure net (used when :on-error is omitted).
@@ -176,7 +227,12 @@ The Ring/Pedestal host adapter for re-frame2 server-side rendering. The SSR runt
   ```clojure
   (default-streaming-prefix head-html opts) → HTML string
   ```
-- **Description**: The shell prefix flushed as the first streamed chunk — it mirrors `default-html-shell`'s open + `<head>` + body-open + app-div-open, and shares the `:html-attrs` / `:lang` fallback with the non-streaming shell so the two envelopes can't diverge. `head-html` is the resolved head fragment; `opts` honours `:html-attrs` / `:body-attrs` / `:lang` (default `"en"`) / `:app-element-id` (default `"app"`) / `:render-hash`. When `:render-hash` is supplied (the handler passes it iff `:emit-hash?` is true), `data-rf-render-hash` is stamped on the `#app` div — the first DOM root of the streamed document — mirroring the non-streaming handler's root-element marker.
+- **Description**: The shell prefix flushed as the first streamed chunk — it mirrors `default-html-shell`'s open + `<head>` + body-open + app-div-open, and shares the `:html-attrs` / `:lang` fallback with the non-streaming shell so the two envelopes can't diverge.
+
+  - `head-html` — the resolved head fragment.
+  - `opts` — honours `:html-attrs` / `:body-attrs` / `:lang` (default `"en"`) / `:app-element-id` (default `"app"`) / `:render-hash`.
+
+  When `:render-hash` is supplied (the handler passes it iff `:emit-hash?` is true), `data-rf-render-hash` is stamped on the `#app` div — the first DOM root of the streamed document — mirroring the non-streaming handler's root-element marker.
 - **Example**:
   ```clojure
   ;; The first streamed chunk — open + <head> + <body> + app-div-open.
@@ -193,7 +249,9 @@ The Ring/Pedestal host adapter for re-frame2 server-side rendering. The SSR runt
   ```clojure
   (default-streaming-suffix opts) → HTML string
   ```
-- **Description**: The shell suffix flushed after the final-payload chunk — it emits the bootstrap `<script>` (if `:script-src` is set; default `"/main.js"`, escape-attr'd), the raw `:body-end` HTML, and the document close (`</body></html>`). The app root (`</div>`) is **not** closed here: it is closed at the end of the shell chunk, so the resolved templates, hydration-delta scripts, and the final `__rf_payload` script all stream outside `#app`. The suffix is therefore purely the bootstrap script + raw `:body-end` + the document close — all of which already belong outside `#app`, mirroring the non-streaming `default-html-shell`.
+- **Description**: The shell suffix flushed after the final-payload chunk. It emits the bootstrap `<script>` (if `:script-src` is set; default `"/main.js"`, escape-attr'd), the raw `:body-end` HTML, and the document close (`</body></html>`).
+
+  The app root (`</div>`) is not closed here: it is closed at the end of the shell chunk, so the resolved templates, hydration-delta scripts, and the final `__rf_payload` script all stream outside `#app`. The suffix is therefore purely bootstrap script + raw `:body-end` + document close — all already outside `#app`, mirroring the non-streaming `default-html-shell`.
 - **Example**:
   ```clojure
   ;; The trailing chunk — bootstrap <script>, raw :body-end, document close.
@@ -210,7 +268,20 @@ The Ring/Pedestal host adapter for re-frame2 server-side rendering. The SSR runt
   ```clojure
   (cookie->set-cookie-header cookie-map) → Set-Cookie header string
   ```
-- **Description**: Serialise one structured `re-frame.ssr` cookie map to a `Set-Cookie` header value per RFC 6265 §4.1. The cookie's `:name` is required; `:value` is URL-encoded and serialises as the empty string when absent; everything else (`:max-age`, `:domain`, `:path`, `:expires` (epoch-millis long), `:secure`, `:http-only`, `:same-site`) is an attribute appended after semicolons. Re-exposed from the façade so tests, alternate host adapters (Pedestal, http-kit), and user code that needs a one-off serialisation can reach it without depending on an internal namespace. Validation is fail-loud: `:name` must be a string or keyword/symbol and is checked against the RFC 6265 §4.1.1 token grammar (either violation throws `:rf.error/cookie-invalid-name`); `:domain` / `:path` / `:max-age` / `:same-site` are checked for CR / LF / NUL before concatenation (throws `:rf.error/cookie-invalid-attribute`) to close header-splitting injection; a missing `:name` throws `:rf.error/cookie-missing-name`; a non-integer `:expires` throws `:rf.error/cookie-invalid-expires`.
+- **Description**: Serialises one structured `re-frame.ssr` cookie map to a `Set-Cookie` header value per RFC 6265 §4.1. Re-exposed from the façade so tests, alternate host adapters (Pedestal, http-kit), and user code needing a one-off serialisation can reach it without an internal namespace.
+
+  Fields:
+
+  - `:name` — required.
+  - `:value` — URL-encoded; serialises as the empty string when absent.
+  - Everything else (`:max-age`, `:domain`, `:path`, `:expires` (epoch-millis long), `:secure`, `:http-only`, `:same-site`) is an attribute appended after semicolons.
+
+  Validation is fail-loud:
+
+  - `:name` must be a string or keyword/symbol and match the RFC 6265 §4.1.1 token grammar; either violation throws `:rf.error/cookie-invalid-name`.
+  - A missing `:name` throws `:rf.error/cookie-missing-name`.
+  - `:domain` / `:path` / `:max-age` / `:same-site` are checked for CR / LF / NUL before concatenation (throws `:rf.error/cookie-invalid-attribute`) to close header-splitting injection.
+  - A non-integer `:expires` throws `:rf.error/cookie-invalid-expires`.
 - **Example**:
   ```clojure
   (ssr.ring/cookie->set-cookie-header

--- a/docs/api/re-frame.test-helpers.md
+++ b/docs/api/re-frame.test-helpers.md
@@ -1,6 +1,8 @@
 # re-frame.test-helpers
 
-`re-frame.test-helpers` is the **view-tree assertion axis** of re-frame2's testing surface. It treats a view as what it is — a function that returns [hiccup](../core/glossary.md#hiccup) — and walks the returned data structure: locate nodes by `:data-testid` (or any attribute), read out their text, and pluck or invoke an attached event handler. The walk helpers are pure functions over hiccup data, and the whole surface — single-frame fixture trio included — is **JVM-runnable with no JSDOM, no React, and no `act()`**. It pairs with `render-to-string` (the HTML-string view-test path, in [re-frame.ssr.md](re-frame.ssr.md)): reach for hiccup-walk when the assertion is about *structure* or *handlers*, and for `render-to-string` when it is about rendered *markup*. The sibling [re-frame.test-support.md](re-frame.test-support.md) covers the complementary runtime-state axis (registrar fixtures, `dispatch-sequence`, the `assert-*-equals` family); a test that needs both `:require`s both.
+`re-frame.test-helpers` is the view-tree assertion axis of the testing surface. A view is a function that returns [hiccup](../core/glossary.md#hiccup); these helpers walk that returned data structure — locate nodes by `:data-testid` (or any attribute), read their text, and pluck or invoke an attached event handler. The walk helpers are pure functions over hiccup data. The whole surface — single-frame fixture trio included — is JVM-runnable with no JSDOM, no React, and no `act()`.
+
+Pairs with `render-to-string` in [re-frame.ssr.md](re-frame.ssr.md) (the HTML-string view-test path): use hiccup-walk when asserting on *structure* or *handlers*, `render-to-string` when asserting on rendered *markup*. The runtime-state axis (registrar fixtures, `dispatch-sequence`, the `assert-*-equals` family) lives in [re-frame.test-support.md](re-frame.test-support.md); a test needing both `:require`s both.
 
 ```clojure
 (:require [re-frame.test-helpers :as th])
@@ -15,7 +17,10 @@
   ```clojure
   (expand-tree tree) → tree
   ```
-- **Description**: Recursively expand function components (including Form-2 fn-returning-fn components) and Form-3 class components inside a hiccup tree, invoking each with its args as Reagent's renderer would. After expansion every vector's first element is a keyword tag or a non-component value. Form-3 classes are expanded by calling the stashed `:reagent-render` fn directly — no React instantiation, no lifecycle methods (on the JVM, class detection is a no-op). The `find-*` / `text-content` walkers expand internally; call this directly to re-expand a sub-tree mid-walk.
+- **Description**: Recursively expand function components (including Form-2 fn-returning-fn components) and Form-3 class components inside a hiccup tree, invoking each with its args as Reagent's renderer would. After expansion every vector's first element is a keyword tag or a non-component value.
+
+  - Form-3 classes expand by calling the stashed `:reagent-render` fn directly — no React instantiation, no lifecycle methods (on the JVM, class detection is a no-op).
+  - The `find-*` / `text-content` walkers expand internally; call this directly only to re-expand a sub-tree mid-walk.
 - **Example**:
   ```clojure
   (th/expand-tree [parent-view {:n 5}])  ; => hiccup whose vectors all start
@@ -45,7 +50,7 @@
   ```clojure
   (children node) → vector
   ```
-- **Description**: Return everything after the tag (and optional attrs map). Always a vector (empty when the node has no children); `nil` for non-vector input.
+- **Description**: Return everything after the tag (and optional attrs map). Always a vector — empty when the node has no children; `nil` for non-vector input.
 - **Example**:
   ```clojure
   (th/children [:div {:k 1} "a" "b"])  ; => ["a" "b"]
@@ -59,7 +64,7 @@
   ```clojure
   (text-content node) → string
   ```
-- **Description**: Recursively collect string leaves under `node` (expanding nested components) and join. Numbers coerce to strings; nils are skipped; empty result is `""`. "What's the visible text?"
+- **Description**: Recursively collect string leaves under `node` (expanding nested components) and join. Numbers coerce to strings; nils are skipped; empty result is `""`.
 - **Example**:
   ```clojure
   (th/text-content [:div "Count: " [:b 5]])  ; => "Count: 5"
@@ -72,7 +77,7 @@
   ```clojure
   (extract-handler node event-key) → fn
   ```
-- **Description**: "Get the handler attached at this attribute on this node." Returns the value or `nil`. Equivalent to `(get (attrs node) event-key)`.
+- **Description**: Return the value under `event-key` in `node`'s attrs map, or `nil`. Equivalent to `(get (attrs node) event-key)`.
 - **Example**:
   ```clojure
   (let [btn (th/find-by-testid tree "counter-inc")]
@@ -88,7 +93,7 @@
   ```clojure
   (find-by-attr tree attr val) → node
   ```
-- **Description**: First hiccup node whose attrs map carries `attr == val`, or `nil`. Generic over the attribute keyword — `:data-testid`, `:id`, `:data-test`, custom.
+- **Description**: First hiccup node whose attrs map carries `attr == val`, or `nil`. Generic over the attribute keyword (`:data-testid`, `:id`, `:data-test`, custom).
 - **Example**:
   ```clojure
   ;; Generic over the attribute keyword.
@@ -116,7 +121,7 @@
   ```clojure
   (find-by-attr-prefix tree attr prefix) → vector
   ```
-- **Description**: Every node whose `attr` value (a string) STARTS with `prefix`. Non-string attr values do not match.
+- **Description**: Every node whose `attr` value (a string) starts with `prefix`. Non-string attr values do not match.
 - **Example**:
   ```clojure
   ;; Matches "row-1", "row-2", … — non-string attr values never match.
@@ -132,7 +137,7 @@
   ```clojure
   (find-by-testid tree test-id) → node
   ```
-- **Description**: Convenience over `find-by-attr` keyed on `:data-testid`. The common case.
+- **Description**: `find-by-attr` keyed on `:data-testid`.
 - **Example**:
   ```clojure
   (let [tree  (counter-view {:n 5})
@@ -147,7 +152,7 @@
   ```clojure
   (find-all-by-testid tree test-id) → vector
   ```
-- **Description**: Convenience over `find-all-by-attr` keyed on `:data-testid`.
+- **Description**: `find-all-by-attr` keyed on `:data-testid`.
 - **Example**:
   ```clojure
   (th/find-all-by-testid tree "cart-row")  ; => vector of every match
@@ -160,7 +165,7 @@
   ```clojure
   (find-by-testid-prefix tree prefix) → vector
   ```
-- **Description**: Convenience over `find-by-attr-prefix` keyed on `:data-testid`.
+- **Description**: `find-by-attr-prefix` keyed on `:data-testid`.
 - **Example**:
   ```clojure
   ;; Matches "item-1", "item-2", …
@@ -176,7 +181,10 @@
   ```clojure
   (invoke-handler node event-key & args) → any
   ```
-- **Description**: Find the handler under `event-key` on `node` and call it with `args`. Returns the handler's return value. **Throws** — `:rf.error/invoke-handler-bad-node` when `node` is not a hiccup vector, `:rf.error/invoke-handler-missing` when no handler fn sits under `event-key` (including the no-attrs-map case). The throwing failure mode is deliberate (a missing handler is almost always a test bug).
+- **Description**: Find the handler under `event-key` on `node`, call it with `args`, and return its value. Throws (a missing handler is treated as a test bug):
+
+  - `:rf.error/invoke-handler-bad-node` — `node` is not a hiccup vector.
+  - `:rf.error/invoke-handler-missing` — no handler fn under `event-key` (including the no-attrs-map case).
 - **Example**:
   ```clojure
   (let [btn (th/find-by-testid tree "counter-inc")]
@@ -193,7 +201,7 @@
   (testid id) → map
   (testid id extra) → map
   ```
-- **Description**: Build an attrs map carrying `:data-testid id`. The 2-arity merges `extra` into the map; `:data-testid` always wins on collision. Authoring helper at the view call site — pair it with `find-by-testid` at the assertion site.
+- **Description**: Build an attrs map carrying `:data-testid id`. The 2-arity merges `extra` into the map; `:data-testid` always wins on collision. Use at the view call site; pair with `find-by-testid` at the assertion site.
 - **Example**:
   ```clojure
   [:button (th/testid "counter-inc" {:on-click #(rf/dispatch [:counter/inc])})
@@ -203,7 +211,7 @@
 
 ## Single-frame e2e fixture
 
-The trio below — `with-app-fixture`, `expect-text`, `wait-until` — compresses the dominant single-frame e2e test pattern (create a frame, install handlers, dispatch, assert on the rendered view, destroy the frame) from five lines of boilerplate to two. Multi-frame setups keep using `re-frame.core`'s frame primitives directly; this fixture targets the common app-developer case. The two dynamic vars carry the fixture-stashed root view that the 2-arity forms of `expect-text` / `wait-until` render against.
+The trio below — `with-app-fixture`, `expect-text`, `wait-until` — covers the single-frame e2e pattern: create a frame, install handlers, dispatch, assert on the rendered view, destroy the frame. Multi-frame setups use `re-frame.core`'s frame primitives directly. The two dynamic vars carry the fixture-stashed root view that the 2-arity forms of `expect-text` / `wait-until` render against.
 
 ### `with-app-fixture`
 
@@ -213,7 +221,16 @@ The trio below — `with-app-fixture`, `expect-text`, `wait-until` — compresse
   (with-app-fixture opts-map frame-id body+)
   (with-app-fixture opts-map          body+)   ; anonymous gensym'd id
   ```
-- **Description**: Bracket `body` with a fresh single-frame fixture. Creates the frame (anonymous, or the supplied `frame-id` — a literal keyword, the discriminator between the two shapes), binds it as the current frame and stashes `:root-view` / `:root-view-args` for the body's dynamic extent, calls the opts' `:install` hook inside that scope, runs `body`, then destroys the frame on exit — success or exception. `opts-map` keys (all optional): `:install` (zero-arg fn run with the frame already bound — typically `reg-event` / `reg-sub` / `reg-view` calls the test relies on), `:root-view` (a hiccup-returning view fn, stashed for the 2-arity assertion forms), `:root-view-args` (args vector passed to `:root-view`, default `[]`), `:frame-config` (extra map merged into the frame config). Registrations land in the global registrar, so pair this with `re-frame.test-support`'s `make-reset-runtime-fixture` (or `with-fresh-registrar`) to roll them back between tests.
+- **Description**: Bracket `body` with a fresh single-frame fixture. Creates the frame (anonymous, or the supplied `frame-id` — a literal keyword, the discriminator between the two shapes), binds it as the current frame, stashes `:root-view` / `:root-view-args` for the body's dynamic extent, calls the opts' `:install` hook inside that scope, runs `body`, then destroys the frame on exit — success or exception.
+
+  `opts-map` keys (all optional):
+
+  - `:install` — zero-arg fn run with the frame already bound; typically the `reg-event` / `reg-sub` / `reg-view` calls the test relies on.
+  - `:root-view` — a hiccup-returning view fn, stashed for the 2-arity assertion forms.
+  - `:root-view-args` — args vector passed to `:root-view` (default `[]`).
+  - `:frame-config` — extra map merged into the frame config.
+
+  Registrations land in the global registrar, so pair this with `re-frame.test-support`'s `make-reset-runtime-fixture` (or `with-fresh-registrar`) to roll them back between tests.
 - **Example**:
   ```clojure
   (deftest counter-increments
@@ -233,7 +250,11 @@ The trio below — `with-app-fixture`, `expect-text`, `wait-until` — compresse
   (expect-text testid expected)
   (expect-text tree testid expected)
   ```
-- **Description**: Assert that the hiccup node carrying `:data-testid testid` has `text-content` equal to `expected`, reporting via `clojure.test/is`. The 2-arity renders the fixture-stashed root view (`*current-root-view*`, set by `with-app-fixture`) with `*current-root-view-args*`; the 3-arity walks an explicit `tree` and needs no fixture. `testid` may be a string (`"counter-display"`) or a keyword (`:counter-display`) — keywords are coerced via `name`; anything else raises `:rf.error/testid-bad-arg`. The 2-arity raises `:rf.error/no-root-view` outside a fixture body (or when the fixture supplied no `:root-view`). Returns `true` on pass, `false` on fail (the `clojure.test` failure is already reported either way, so callers rarely read the boolean).
+- **Description**: Assert that the hiccup node carrying `:data-testid testid` has `text-content` equal to `expected`, reporting via `clojure.test/is`. Returns `true` on pass, `false` on fail (the `clojure.test` failure is reported either way).
+
+  - 2-arity — renders the fixture-stashed root view (`*current-root-view*`, set by `with-app-fixture`) with `*current-root-view-args*`. Raises `:rf.error/no-root-view` outside a fixture body, or when the fixture supplied no `:root-view`.
+  - 3-arity — walks an explicit `tree`; needs no fixture.
+  - `testid` may be a string (`"counter-display"`) or keyword (`:counter-display`, coerced via `name`); anything else raises `:rf.error/testid-bad-arg`.
 - **Example**:
   ```clojure
   ;; 2-arity — against the fixture's :root-view:
@@ -253,7 +274,17 @@ The trio below — `with-app-fixture`, `expect-text`, `wait-until` — compresse
   (wait-until testid expected)
   (wait-until testid expected opts)
   ```
-- **Description**: Bounded-deadline poll until a condition is truthy — the view-test counterpart to `re-frame.test-support/poll-until`. The predicate form polls `(pred)` until truthy or the deadline elapses; the testid form polls the fixture-stashed root view until `(text-content (find-by-testid tree testid))` equals `expected` — `testid` may be a string or keyword (coerced via `name`; anything else raises `:rf.error/testid-bad-arg`). An exception thrown by the predicate/probe counts as a falsey poll, not a propagated error — a missing fixture root view therefore surfaces as the timeout, not as `:rf.error/no-root-view`. `opts` (all optional): `:timeout-ms` (default 2000), `:interval-ms` (default 5), `:label`. Per-platform shape matches `poll-until` — JVM: synchronous, returns the truthy value, throws `ex-info` carrying `:rf.error/id` `:rf.error/wait-until-timeout` (the canonical discriminator) on timeout; CLJS: returns a `js/Promise` resolving with the truthy value or rejecting on timeout (compose with `cljs.test/async`). Use for async runs (HTTP, scheduled events, machine `:after` transitions) whose post-condition is observable in the rendered view; for sync runs, `expect-text` after `dispatch-sync` is enough.
+- **Description**: Bounded-deadline poll until a condition is truthy — the view-test counterpart to `re-frame.test-support/poll-until`. Use for async runs (HTTP, scheduled events, machine `:after` transitions) whose post-condition is observable in the rendered view; for sync runs, `expect-text` after `dispatch-sync` suffices.
+
+  - Predicate form — polls `(pred)` until truthy or the deadline elapses.
+  - Testid form — polls the fixture-stashed root view until `(text-content (find-by-testid tree testid))` equals `expected`. `testid` may be a string or keyword (coerced via `name`; anything else raises `:rf.error/testid-bad-arg`).
+  - An exception thrown by the predicate/probe counts as a falsey poll, not a propagated error — so a missing fixture root view surfaces as the timeout, not as `:rf.error/no-root-view`.
+  - `opts` (all optional): `:timeout-ms` (default 2000), `:interval-ms` (default 5), `:label`.
+
+  Per-platform shape matches `poll-until`:
+
+  - JVM — synchronous; returns the truthy value; on timeout throws `ex-info` carrying `:rf.error/id` `:rf.error/wait-until-timeout` (the canonical discriminator).
+  - CLJS — returns a `js/Promise` resolving with the truthy value or rejecting on timeout (compose with `cljs.test/async`).
 - **Example**:
   ```clojure
   ;; JVM — testid form; blocks until the display text settles.
@@ -272,7 +303,7 @@ The trio below — `with-app-fixture`, `expect-text`, `wait-until` — compresse
 ### `*current-root-view-args*`
 
 - **Kind**: dynamic var
-- **Description**: Args vector passed to `*current-root-view*` when rendering the tree. Defaults to `[]` (the common zero-arg view). `with-app-fixture` sets it from the fixture opts' `:root-view-args` key, so a root view that takes arguments (e.g. a props map) is supplied once at the fixture site rather than at every `expect-text` call.
+- **Description**: Args vector passed to `*current-root-view*` when rendering the tree. Defaults to `[]` (the common zero-arg view). `with-app-fixture` sets it from the fixture opts' `:root-view-args` key, so a root view taking arguments (e.g. a props map) is supplied once at the fixture site rather than at every `expect-text` call.
 
 ## See also
 

--- a/docs/api/re-frame.test-support.md
+++ b/docs/api/re-frame.test-support.md
@@ -1,16 +1,18 @@
 # re-frame.test-support
 
-`re-frame.test-support` is re-frame2's **runtime-state** testing surface — the test-only fixture machinery and test-flavoured helpers that drive and assert against a frame's `app-db`, the registrar, the dispatch drain, and the trace stream. It is the runtime-state axis (registrar, frames, `app-db`, drain) of the testing API; its sibling `re-frame.test-helpers` owns the view-tree axis (hiccup walkers plus the `testid` authoring helper). This namespace deliberately does **not** re-export from `re-frame.core`, so a production build never picks up test-flavoured machinery by accident — a test file requires this namespace alongside `[re-frame.core :as rf]` (and `[re-frame.test-helpers :as th]` for view assertions).
+`re-frame.test-support` is the **runtime-state** testing surface: test-only fixture machinery and test-flavoured helpers that drive and assert against a frame's `app-db`, the registrar, the dispatch drain, and the trace stream. Its sibling `re-frame.test-helpers` owns the view-tree axis (hiccup walkers plus the `testid` authoring helper).
+
+This namespace does not re-export from `re-frame.core`, so a production build never picks up test-flavoured machinery by accident. A test file requires it alongside `[re-frame.core :as rf]` (and `[re-frame.test-helpers :as th]` for view assertions).
 
 ```clojure
 (:require [re-frame.test-support :as ts])
 ```
 
-Examples below also use `[re-frame.core :as rf]` for the production primitives that double as testing entry points (`dispatch-sync`, `app-db-value`, …).
+Examples below also use `[re-frame.core :as rf]` for the production primitives that double as testing entry points (`dispatch-sync`, `app-db-value`, …). For the practical how-to, see [Test an event handler](../core/testing/event-handlers.md) and [Test a pipeline run](../core/testing/pipeline-runs.md).
 
 ## Fixture machinery
 
-The fixture primitives follow one pattern: "snapshot the registrar before the test mutates registrations; restore after, regardless of pass / fail." Framework-shipped registrations (captured in the snapshot) survive; per-test registrations are rolled back.
+The fixture primitives follow one pattern: snapshot the registrar before the test mutates registrations; restore after, pass or fail. Framework-shipped registrations (captured in the snapshot) survive; per-test registrations are rolled back.
 
 ### `snapshot-registrar`
 
@@ -19,7 +21,7 @@ The fixture primitives follow one pattern: "snapshot the registrar before the te
   ```clojure
   (snapshot-registrar) → snapshot
   ```
-- **Description**: Capture the current registrar state.
+- **Description**: Capture the current registrar state. Returns a snapshot value for later restore.
 - **Example**:
   ```clojure
   ;; Capture before a test mutates registrations; roll back on the way out.
@@ -35,7 +37,7 @@ The fixture primitives follow one pattern: "snapshot the registrar before the te
   ```clojure
   (restore-registrar! snapshot) → nil
   ```
-- **Description**: Restore a previously captured registrar state.
+- **Description**: Restore a previously captured registrar `snapshot`. Returns `nil`.
 - **Example**:
   ```clojure
   ;; `snap` was captured earlier via `snapshot-registrar`.
@@ -49,7 +51,13 @@ The fixture primitives follow one pattern: "snapshot the registrar before the te
   ```clojure
   (merge-registrar-snapshots base overlay) → snapshot
   ```
-- **Description**: Two-level merge of two registrar snapshots (`kind → id → metadata`). Entries from `overlay` win on a per-`[kind id]` collision; ids present only in `base` survive; ids present only in `overlay` are added. Used by `make-reset-runtime-fixture` to fold a stable ns-load baseline back over whatever the registrar currently holds, so a test namespace's own ns-load registrations are present regardless of run order.
+- **Description**: Two-level merge of two registrar snapshots (`kind → id → metadata`), returning a new snapshot.
+
+  - `overlay` wins on a per-`[kind id]` collision.
+  - ids present only in `base` survive.
+  - ids present only in `overlay` are added.
+
+  `make-reset-runtime-fixture` uses this to fold a stable ns-load baseline back over whatever the registrar currently holds, so a test namespace's own ns-load registrations are present regardless of run order.
 - **Example**:
   ```clojure
   ;; `base` and `overlay` are each a value from `snapshot-registrar`.
@@ -64,7 +72,7 @@ The fixture primitives follow one pattern: "snapshot the registrar before the te
   ```clojure
   (with-fresh-registrar body-fn) → any
   ```
-- **Description**: The composed helper — snapshot + body + restore. Captures the registrar before `body-fn`, runs it, restores the captured state in a `finally` — even if `body-fn` throws. Returns `body-fn`'s return value. Most tests reach for this rather than the lower-level primitives.
+- **Description**: Snapshot + body + restore, composed. Captures the registrar, runs `body-fn`, then restores the captured state in a `finally` — even if `body-fn` throws. Returns `body-fn`'s return value.
 - **Example**:
   ```clojure
   ;; As a clojure.test / cljs.test :each fixture:
@@ -82,7 +90,26 @@ The fixture primitives follow one pattern: "snapshot the registrar before the te
   (make-reset-runtime-fixture)
   (make-reset-runtime-fixture opts) → fixture-fn | {:before … :after …}
   ```
-- **Description**: Build a `clojure.test` / `cljs.test` `:each` fixture that resets the per-process runtime around each test: reinstates the stable ns-load registrar and source-store baseline captured at fixture-build time (run-order independence inside a shared test bundle), snapshots the registrar, resets the frames registry, trace listeners, and per-artefact state (flows, schemas, machines, routing, resources, http, epoch — via late-bind hooks that no-op when an artefact is absent from the classpath), disposes then reinstalls the adapter, and restores everything in a `finally`. `opts` (all optional): `:adapter` — substrate adapter to install; also ensures the `:rf/default` frame (omitted: the fixture installs no adapter); `:init-fn` — zero-arg fn run after adapter install, before the test body, under the same ambient frame scope as the body; `:clear-kinds` — collection of registrar kinds cleared after the snapshot capture and before the body (the snapshot restores them on the way out); `:clear-app-schemas?` — boolean; clear the schemas artefact's per-frame side-table for the test's duration; `:ambient-frame` — frame id bound as the body's ambient scope when an adapter is installed, default `:rf/default`; pass `nil` to opt out (for tests that create their own top-level frames); `:async?` — boolean, default `false`; selects the return shape — `false` returns the synchronous fn-form fixture, `true` returns a `cljs.test` map-form fixture `{:before … :after …}`, required for suites with `(async done …)` tests. Pair with `use-fixtures :each`.
+- **Description**: Build a `clojure.test` / `cljs.test` `:each` fixture that resets the per-process runtime around each test. Pair with `use-fixtures :each`.
+
+  Around each test the fixture:
+
+  - reinstates the stable ns-load registrar and source-store baseline captured at fixture-build time (run-order independence inside a shared test bundle);
+  - snapshots the registrar;
+  - resets the frames registry, trace listeners, and per-artefact state (flows, schemas, machines, routing, resources, http, epoch — via late-bind hooks that no-op when an artefact is absent from the classpath);
+  - disposes then reinstalls the adapter;
+  - restores everything in a `finally`.
+
+  `opts` (all optional):
+
+  | Key | Meaning |
+  |-----|---------|
+  | `:adapter` | Substrate adapter to install; also ensures the `:rf/default` frame. Omitted: no adapter is installed. |
+  | `:init-fn` | Zero-arg fn run after adapter install, before the test body, under the same ambient frame scope as the body. |
+  | `:clear-kinds` | Collection of registrar kinds cleared after the snapshot capture and before the body (the snapshot restores them on the way out). |
+  | `:clear-app-schemas?` | Boolean; clear the schemas artefact's per-frame side-table for the test's duration. |
+  | `:ambient-frame` | Frame id bound as the body's ambient scope when an adapter is installed. Default `:rf/default`; pass `nil` to opt out (for tests that create their own top-level frames). |
+  | `:async?` | Boolean, default `false`. Selects the return shape: `false` returns the synchronous fn-form fixture; `true` returns a `cljs.test` map-form fixture `{:before … :after …}`, **required** for suites with `(async done …)` tests. |
 - **Example**:
   ```clojure
   (use-fixtures :each
@@ -103,7 +130,14 @@ The fixture primitives follow one pattern: "snapshot the registrar before the te
   (dispatch-sequence events)
   (dispatch-sequence events opts)
   ```
-- **Description**: "Run this list of events end-to-end against the current frame." Each event is delivered synchronously and the queue drains to fixed point before the next, so observable state between events reflects committed effects. `opts`: `:after-each (fn [db ev] ...)` for between-event assertions (invoked after each event's drain settles), `:frame` for non-default targets. Frame resolution: `:frame` opt → `(current-frame)` → `:rf/default`. Returns the final `app-db`.
+- **Description**: Run a list of `events` end-to-end against the resolved frame. Each event is delivered synchronously and the queue drains to fixed point before the next, so observable state between events reflects committed effects. Returns the final `app-db`.
+
+  `opts`:
+
+  - `:after-each (fn [db ev] ...)` — between-event assertion, invoked after each event's drain settles.
+  - `:frame` — target a non-default frame.
+
+  Frame resolution: `:frame` opt → `(current-frame)` → `:rf/default`.
 - **Example**:
   ```clojure
   ;; Run a list of events end-to-end; returns the final app-db.
@@ -123,7 +157,11 @@ The fixture primitives follow one pattern: "snapshot the registrar before the te
   (assert-path-equals path expected-val)
   (assert-path-equals path expected-val opts)
   ```
-- **Description**: "Assert `(get-in db path) == expected-val`" against the resolved frame's `app-db`. Mismatch fires a `clojure.test/is`-style failure via `do-report`. `opts`: `:frame` for non-default targets; frame resolution matches `dispatch-sequence` (`:frame` opt → `(current-frame)` → `:rf/default`). Returns `true` when the assertion passes, `false` otherwise — the failure has already been reported either way. The fn-side counterpart to the `:rf.assert/path-equals` story event-family — same name root, different runner channel.
+- **Description**: Assert `(get-in db path) == expected-val` against the resolved frame's `app-db`. Mismatch fires a `clojure.test/is`-style failure via `do-report`. Returns `true` on pass, `false` otherwise — the failure has already been reported either way.
+
+  `opts`: `:frame` targets a non-default frame; frame resolution matches `dispatch-sequence` (`:frame` opt → `(current-frame)` → `:rf/default`).
+
+  The fn-side counterpart to the `:rf.assert/path-equals` story event-family — same name root, different runner channel.
 - **Example**:
   ```clojure
   (rf/dispatch-sync [:counter/inc])
@@ -140,7 +178,11 @@ The fixture primitives follow one pattern: "snapshot the registrar before the te
   (assert-db-equals expected-db)
   (assert-db-equals expected-db opts)
   ```
-- **Description**: Full-db sync assertion — `(= expected-db app-db)` against the resolved frame. Mismatch fires a `clojure.test/is`-style failure via `do-report`. `opts`: `:frame` for non-default targets; frame resolution matches `dispatch-sequence`. Returns `true` when the assertion passes, `false` otherwise. No `:rf.assert/*` event analog exists for the full-db form (the event family is path-keyed). Companion to `assert-path-equals`; reach for it when the whole-db identity matters.
+- **Description**: Full-db sync assertion — `(= expected-db app-db)` against the resolved frame. Mismatch fires a `clojure.test/is`-style failure via `do-report`. Returns `true` on pass, `false` otherwise.
+
+  `opts`: `:frame` targets a non-default frame; frame resolution matches `dispatch-sequence`.
+
+  No `:rf.assert/*` event analog exists for the full-db form (the event family is path-keyed).
 - **Example**:
   ```clojure
   (rf/dispatch-sync [:counter/init])
@@ -159,7 +201,14 @@ The fixture primitives follow one pattern: "snapshot the registrar before the te
   (poll-until pred)
   (poll-until pred opts)
   ```
-- **Description**: Bounded-deadline poll. JVM: synchronous — returns the truthy value, throws `ex-info` carrying `:rf.error/id` `:rf.error/poll-until-timeout` (the canonical discriminator) on timeout. CLJS: returns a `js/Promise` resolving with the truthy value or rejecting on timeout with the same error shape; a `pred` that itself returns a `js/Promise` is awaited and its resolved value drives the truthy check. The timeout error's data also carries `:elapsed-ms` and `:label`. Opts: `:timeout-ms` (default 2000), `:interval-ms` (default 5), `:label`.
+- **Description**: Bounded-deadline poll of `pred`.
+
+  - **JVM**: synchronous — returns the truthy value; throws `ex-info` on timeout.
+  - **CLJS**: returns a `js/Promise` resolving with the truthy value, or rejecting on timeout. A `pred` that returns a `js/Promise` is awaited and its resolved value drives the truthy check.
+
+  The timeout error carries `:rf.error/id` `:rf.error/poll-until-timeout` (the canonical discriminator), plus `:elapsed-ms` and `:label` in its data.
+
+  `opts`: `:timeout-ms` (default 2000), `:interval-ms` (default 5), `:label`.
 - **Example**:
   ```clojure
   ;; JVM — synchronous; returns the truthy value (throws on timeout).
@@ -181,7 +230,18 @@ The fixture primitives follow one pattern: "snapshot the registrar before the te
   (with-trace-recorder! [recs-sym] body+)
   (with-trace-recorder! [recs-sym opts] body+)
   ```
-- **Description**: Bracket `body` with a fresh trace-tooling listener that accumulates matching trace events into an atom bound to `recs-sym`. The listener is registered before `body` runs and unregistered in a `finally` on the way out — even if `body` throws. `opts` (optional map literal; keys evaluated at macroexpansion): `:pred` — a 1-arg `(fn [ev] truthy?)` filter, default accept every event; `:shape` — `:flat` (default — the atom holds a vector of events) or `:by-op` (the atom holds a map keyed by `(:operation ev)`); `:key` — listener key, default a freshly-gensym'd keyword unique to the expansion site so two brackets in one test do not collide. Returns the value of `body`'s final form. JVM: resolves alias-qualified through the normal `(:require [re-frame.test-support :as ts])`. CLJS: the namespace carries no self-`:require-macros` (unlike `re-frame.core`), so CLJS test files must require the macro explicitly — `(:require-macros [re-frame.test-support :refer [with-trace-recorder!]])`, or `:as ts` in `:require-macros` for alias-qualified use.
+- **Description**: Bracket `body` with a fresh trace-tooling listener that accumulates matching trace events into an atom bound to `recs-sym`. The listener is registered before `body` runs and unregistered in a `finally` on the way out — even if `body` throws. Returns the value of `body`'s final form.
+
+  `opts` (optional map literal; keys evaluated at macroexpansion):
+
+  - `:pred` — a 1-arg `(fn [ev] truthy?)` filter. Default: accept every event.
+  - `:shape` — `:flat` (default; the atom holds a vector of events) or `:by-op` (the atom holds a map keyed by `(:operation ev)`).
+  - `:key` — listener key. Default: a freshly-gensym'd keyword unique to the expansion site, so two brackets in one test do not collide.
+
+  Macro requires:
+
+  - **JVM**: resolves alias-qualified through the normal `(:require [re-frame.test-support :as ts])`.
+  - **CLJS**: the namespace carries no self-`:require-macros` (unlike `re-frame.core`), so CLJS test files must require the macro explicitly — `(:require-macros [re-frame.test-support :refer [with-trace-recorder!]])`, or `:as ts` in `:require-macros` for alias-qualified use.
 - **Example**:
   ```clojure
   ;; Flat shape (default), default filter, simple read.


### PR DESCRIPTION
## What this is

A readability rewrite of the 16 namespace pages under `docs/api/`. They were **too dense** — run-on `Description` paragraphs that fused the contract with motivation, migration asides, and pointers in a single breath, plus bold-inflation and marketing/roadmap prose woven into what is supposed to be a terse reference.

`docs/core/AUTHORING.md` already sets the bar these pages are held to: the **terse-reference register** — exact and exhaustive, but scannable enough that *"a reader who arrives mid-task from a link or search lands, reads one entry, and leaves unblocked in under a minute."* The old pages didn't clear that bar; these do.

## The core move: contract, not motivation

The dominant defect was the `Description` field doing three jobs at once. The house rule is that a reference description states the **contract** — arguments, return shape, the `:rf.error/*` ids it can raise — and nothing else; motivation lives in the linked guide, once per page. So, uniformly across all 16 files:

- **Descriptions lead with a one-line "what it does"**, then state the contract as short sentences or a tight bullet list. No more wall-of-text paragraphs a reader has to parse to extract one fact.
- **Motivation is out of the reference.** Marketing framing (TanStack / RTK Query / SWR analogies), roadmap/changelog prose (*"landed and complete"*, *"first public-beta surface"*), and audience-sizing asides (*"the 80% of handlers that just update state"*) are cut. The teaching link is given **once per page** in the intro, not repeated on every entry.
- **Bold is tamed** to genuinely load-bearing words (`REQUIRED`, `fail-closed`) instead of half the sentence.
- **Page intros** are compressed to: what the namespace is, what you `(:require …)`, the artefact it ships in, and one guide link.

Before / after, `reg-sub`'s Description:

> **Before** — one paragraph fusing eight facts: *"'Computed view over `app-db` and other subs.' `reg-sub` supports three input-production modes — every subscription has an input query-vector producer: a layer-1 app-db reader has no producer, `:<-` is the literal producer… The optional first fn is a v2 `input-fn` — a pure function… it is not a v1 reaction-returning signal fn (it must not call `subscribe`, deref `app-db`, dispatch, or perform IO…). The runtime resolves each returned query vector… This is the only sub-registration form in v2 — `reg-sub-raw` is gone… The full input grammar… live in the Subscriptions concept guide."*
>
> **After** — a one-line lead, the input-fn contract as its own short paragraph, and the "only form / `reg-sub-raw` gone / pointer" as a third — then the modes table. Same facts, extractable at a glance.

## Fidelity

These pages were correctness-audited in #5214, so this is a **readability edit only** — no contract was changed. Guaranteed by objective before/after parity in every file:

| Invariant | Result |
|---|---|
| Headings (`#`…`####`, the anchor targets) | **identical count** in all 16 files |
| Code fences (signatures + examples) | **identical count** in all 16 files |
| `:rf.error/*` / `:rf.warning/*` ids | **identical unique set** in all 16 files |
| Entries / option keys / cross-link targets | none dropped |

Line counts **rise** (e.g. `re-frame.core` 1687 → 1778) — not because content was added, but because dense paragraphs became scannable bullet lists. Fewer facts crammed per line; faster extraction. That is the intended trade for reference docs, and the parity table above shows no new content slipped in.

## How it was produced

A workflow of **16 rewriters + 16 adversarial verifiers** (pipelined, one per namespace file). Each rewriter worked to the terse-reference rubric; each verifier then diffed its file against the correctness-audited `HEAD` baseline and had to confirm **zero** dropped/altered contract facts, **zero** renamed/removed headings (the `check_doc_slugs` anchor gate), and **zero** drift into teaching voice — approving only if the result was also genuinely more readable. All 16 approved; I then re-verified independently with the objective parity counts above and a read-through of the flagship pages.

## Gates

- `scripts/check_doc_slugs.py` (every internal link + heading anchor) — **no broken links**.
- Residue gates — `inject-cofx`, retired composition vocab, retired image keys, retired spellings — all **pass** (the rewrite only restructures existing correct prose).
- Nav integrity — only modifications, no files added/removed, `mkdocs.yml` untouched.

`README.md` (the API index) was left as-is — it is an index page under a different authoring bar and already clears it.
