### PR TITLE
docs(resources): fix scope_registry docstring to 3-slot reg-resource-scope form (rf2-s8t1qi)

### DIFF
--- a/implementation/resources/src/re_frame/resources/scope_registry.cljc
+++ b/implementation/resources/src/re_frame/resources/scope_registry.cljc
@@ -12,41 +12,45 @@
   registration, route resources, event-side ensure, subscriptions,
   invalidation descriptors, populate/patch/remove targets, and `clear-scope`.
 
-  ## The `{:inputs … :resolve …}` grammar (the ONE canonical form)
+  ## The `{:inputs …}` metadata + resolver-fn grammar (the ONE canonical form)
 
       (rf/reg-resource-scope :realworld/session
-        {:inputs  {:username [:db [:auth :user :username]]}
-         :resolve (fn [{:keys [username]} _ctx]
-                    (when username [:rf.scope/session {:username username}]))})
+        {:inputs {:username [:db [:auth :user :username]]}}
+        (fn [{:keys [username]} _ctx]
+          (when username [:rf.scope/session {:username username}])))
 
-  - `:inputs` — a map `{name source-descriptor}`. The ONLY shipped source
-    descriptor is `[:db <rf-path>]`, where `<rf-path>` is an EP-0012
+  The 3-slot shape is `(scope-id metadata resolve-fn)`: the resolver is the
+  THIRD (value) slot, not a `:resolve` key inside the metadata map.
+
+  - `:inputs` (metadata) — a map `{name source-descriptor}`. The ONLY shipped
+    source descriptor is `[:db <rf-path>]`, where `<rf-path>` is an EP-0012
     concrete `:rf/path` (the path algebra in `re-frame.path`). `[:runtime
     <path>]` is RESERVED, not shipped — declaring one is a loud
     registration error (route-derived scope un-defers only when an in-repo
     consumer carries a principal in a path segment and needs named-resolver
     scope at a non-route site, per Spec 016 §Route-derived scope is
     reserved).
-  - `:resolve` — `(fn [inputs ctx] -> scope | nil)`. PURE. **The first arg is
-    ALWAYS the resolved input map** — this is the one stable, Name-over-place
-    meaning across every registration (rf2-wvh95f F3). It derives a scope from
-    that map; it MUST NOT fetch, dispatch, mutate state, read ambient host
-    state, or perform transport work. The `ctx` arg is RESERVED and is invoked
-    as literal `nil` in this slice — a resolver MUST derive scope from its
-    declared `:inputs`, not from `ctx`. A `nil` result is FAIL-CLOSED at every
-    scope-requiring site (never an implicit global read).
+  - The resolver (the third, value slot) — `(fn [inputs ctx] -> scope | nil)`.
+    PURE. **The first arg is ALWAYS the resolved input map** — this is the one
+    stable, Name-over-place meaning across every registration (rf2-wvh95f F3).
+    It derives a scope from that map; it MUST NOT fetch, dispatch, mutate
+    state, read ambient host state, or perform transport work. The `ctx` arg
+    is RESERVED and is invoked as literal `nil` in this slice — a resolver
+    MUST derive scope from its declared `:inputs`, not from `ctx`. A `nil`
+    result is FAIL-CLOSED at every scope-requiring site (never an implicit
+    global read).
 
   ### Reading the whole db — name it as an input (no first-arg meaning-shift)
 
   When a resolver genuinely needs the whole db, declare it as an explicit
-  named input and read it off the inputs map — the `:resolve` first arg STAYS
+  named input and read it off the inputs map — the resolver's first arg STAYS
   the inputs map:
 
       (rf/reg-resource-scope :realworld/session
-        {:inputs  {:db [:db []]}
-         :resolve (fn [{:keys [db]} _ctx]
-                    (when-let [u (get-in db [:auth :user :username])]
-                      [:rf.scope/session {:username u}]))})
+        {:inputs {:db [:db []]}}
+        (fn [{:keys [db]} _ctx]
+          (when-let [u (get-in db [:auth :user :username])]
+            [:rf.scope/session {:username u}])))
 
   ## Whole-db function sugar — the ONE documented explicit alternative
 
@@ -57,7 +61,7 @@
   This bare-fn form is the SINGLE explicit alternative to the canonical
   inputs-map grammar (rf2-wvh95f F3). It is NOT a peer and it carries a
   DELIBERATE, documented first-arg meaning-shift: in this form ALONE the
-  `:resolve` first arg is the **whole db**, not the inputs map. Prefer the
+  resolver's first arg is the **whole db**, not the inputs map. Prefer the
   canonical inputs-map grammar (above) — including for the whole-db case via
   the explicit `{:inputs {:db [:db []]} …}` declaration — so a resolver author
   reads ONE stable first-arg meaning everywhere; reach for the bare-fn sugar
@@ -125,7 +129,8 @@
   rejected fail-closed at registration until an in-repo consumer carrying a
   principal in a path segment needs named-resolver scope at a non-route site
   (sub / event ensure / invalidation / `clear-scope`). Per Spec 016 §The
-  `{:inputs … :resolve …}` grammar / §Route-derived scope is reserved."
+  `{:inputs …}` metadata + resolver-fn grammar / §Route-derived scope is
+  reserved."
   #{:db})
 
 (def reserved-input-sources
@@ -243,8 +248,9 @@
 (defn- canonical-spec
   "Normalize the 3-slot `(reg-resource-scope scope-id metadata resolve-fn)`
   registration into the canonical STORED spec map. Per Spec 016 §The
-  `{:inputs … :resolve …}` grammar + §Whole-db function sugar (rf2-wvh95f F3,
-  brought into the canonical 3-slot registration grammar by rf2-bqstzr).
+  `{:inputs …}` metadata + resolver-fn grammar + §Whole-db function sugar
+  (rf2-wvh95f F3, brought into the canonical 3-slot registration grammar by
+  rf2-bqstzr).
 
   The `:resolve` fn is the THIRD slot (the resolver HANDLER); the middle
   `metadata` slot carries the reflection-config keys (`:inputs`, `:doc`). This


### PR DESCRIPTION
## Summary

`implementation/resources/src/re_frame/resources/scope_registry.cljc`'s ns-level docstring illustrated `reg-resource-scope` with the **retired 2-slot `:resolve`-in-map shape** (a `:resolve` key nested inside the metadata map) and labelled it "the ONE canonical form" — but the validator in this same file (`canonical-spec`) throws `:rf.error/invalid-resource-scope-spec` on that exact shape: the resolver must be the **third positional slot**, not a metadata key. Copying the docstring's own example produces code that throws at registration. This is what caused rf2-3bizcf (tenant-switcher testbed drift, silently-red browser smoke).

Fixed both 2-slot illustrations in the ns docstring (the primary `## The {:inputs ... :resolve ...} grammar` example, and the "Reading the whole db" example) to the current 3-slot `(scope-id metadata resolve-fn)` form, matching `examples/real-apps/realworld_resources/scope.cljs:70` and the file's own error-message text. Also renamed the misleading `{:inputs … :resolve …}` heading (and its two prose cross-references elsewhere in the file) to match Spec 016's actual section heading, `The {:inputs …} metadata + resolver-fn grammar`.

The "Whole-db function sugar" example (the 2-arg bare-fn form) was already correct — no `:resolve` key involved — so it is unchanged.

Docstring/comment-only change. No code, validator, or behaviour change.

## Quality gates

- `npm run test:cljs` (from `implementation/`): **8063 tests, 37052 assertions, 0 failures, 0 errors** — resources artefact compiles and all CLJS tests pass.
- `git grep -n ":resolve" implementation/resources/src/re_frame/resources/scope_registry.cljc` — confirmed no remaining 2-slot `:resolve`-in-map illustration; every remaining `:resolve` hit is either prose describing "the resolver is the third slot" or the internal stored-spec map key (unrelated to the retired registration shape).
- `mkdocs build --strict` — not runnable in this sandbox (mkdocs not installed); source-inspected instead: `docs/api/re-frame.resources.md`'s `reg-resource-scope` entry carries its own distinct docstring text sourced from the facade (`core.cljc`/`core-resources.cljc`), which this PR does not touch, and the `implementation/scripts/api-manifest/` doc generator has no reference to `scope_registry.cljc` — so this ns docstring does not feed any generated doc.

## Risks

- Docstring-only; behaviourally inert. Low risk.
- **Flagged, not fixed (out of scope for this single-file bead):** the same retired 2-slot `:resolve`-in-map illustration still appears in the hand-authored doc tree — `docs/resources/coming-from-tanstack-query.md`, `docs/resources/concepts.md`, `docs/resources/tutorial/04-mutations-and-invalidation.md`, `docs/routing/concepts.md`, `docs/core/how-to/add-auth.md`. Filed as follow-up bead **rf2-bno7td**.

rf2-s8t1qi