### PR TITLE
docs(guide): fix retired 2-slot reg-resource-scope examples to 3-slot form (rf2-bno7td)

### DIFF
--- a/docs/core/how-to/add-auth.md
+++ b/docs/core/how-to/add-auth.md
@@ -348,11 +348,10 @@ To clear *a user's* cached reads you need a way to name "this user's scope." Tha
 ;; Register once at boot. The resolver is PURE — it derives a scope from db,
 ;; it does not fetch, dispatch, or read ambient state.
 (rf/reg-resource-scope :my-app/session
-  {:inputs {:username [:db [:auth :user :username]]}
-   :resolve
-   (fn [{:keys [username]} _ctx]
-     (when username
-       [:rf.scope/session {:username username}]))})   ;; nil when logged out — fail-closed
+  {:inputs {:username [:db [:auth :user :username]]}}
+  (fn [{:keys [username]} _ctx]
+    (when username
+      [:rf.scope/session {:username username}])))   ;; nil when logged out — fail-closed
 ```
 
 Now logout itself. There's one subtlety, and the ordering is the whole game: resolve the *old* scope from the coeffect `db` **before** you clear the auth slice. After the clear, the identity the scope derives from is gone.

--- a/docs/resources/coming-from-tanstack-query.md
+++ b/docs/resources/coming-from-tanstack-query.md
@@ -65,9 +65,9 @@ re-frame2 makes that leak *unrepresentable*. A cache entry's identity is a tripl
 
 ```clojure
 (rf/reg-resource-scope :realworld/session
-  {:inputs  {:username [:db [:auth :user :username]]}
-   :resolve (fn [{:keys [username]} _ctx]
-              (when username [:rf.scope/session {:username username}]))})
+  {:inputs {:username [:db [:auth :user :username]]}}
+  (fn [{:keys [username]} _ctx]
+    (when username [:rf.scope/session {:username username}])))
 ```
 
 Three properties fall out that a hand-assembled key can't give you:

--- a/docs/resources/concepts.md
+++ b/docs/resources/concepts.md
@@ -54,7 +54,7 @@ Two keys carry the minimum model. `:params-schema` defines the read's *identity*
 
 !!! warning "Gotcha — the `_ctx` second argument is reserved, currently `nil`"
 
-    Every author-supplied function this artefact calls (`:request`, a scope resolver's `:resolve`) receives a trailing `ctx` that is **literal nil** in this slice — declared for forward-compatibility, not to be relied on. Derive your request from `params` and your scope from declared `:inputs`, never from `ctx`. (The one exception is a route-resource `:params` / `:scope` / `:when` function, which carries a populated route context, because route-entry planning has a real match to thread.)
+    Every author-supplied function this artefact calls (`:request`, a scope resolver's resolver fn) receives a trailing `ctx` that is **literal nil** in this slice — declared for forward-compatibility, not to be relied on. Derive your request from `params` and your scope from declared `:inputs`, never from `ctx`. (The one exception is a route-resource `:params` / `:scope` / `:when` function, which carries a populated route context, because route-entry planning has a real match to thread.)
 
 ## Cause it to fetch from a route
 
@@ -237,10 +237,10 @@ Params say *which* article. Scope says *whose* cache. A genuinely public read de
 ```clojure
 ;; Adapted from examples/real-apps/realworld_resources/scope.cljs
 (rf/reg-resource-scope :realworld/session
-  {:inputs  {:username [:db [:auth :user :username]]}
-   :resolve (fn [{:keys [username]} _ctx]
-              (when username
-                [:rf.scope/session {:username username}]))})
+  {:inputs {:username [:db [:auth :user :username]]}}
+  (fn [{:keys [username]} _ctx]
+    (when username
+      [:rf.scope/session {:username username}])))
 
 ;; Adapted from examples/real-apps/realworld_resources/resources.cljs
 (rf/reg-resource :realworld/feed

--- a/docs/resources/tutorial/04-mutations-and-invalidation.md
+++ b/docs/resources/tutorial/04-mutations-and-invalidation.md
@@ -32,10 +32,10 @@ To key the cache per user, register a **named scope resolver** — a pure functi
 ;; src/conduit/scope.cljs
 ;; cf. examples/real-apps/realworld_resources/scope.cljs
 (rf/reg-resource-scope :conduit/session
-  {:doc     "The session's cache scope — nil when logged out (fail-closed)."
-   :inputs  {:username [:db [:auth :user :username]]}
-   :resolve (fn [{:keys [username]} _ctx]
-              (when username [:rf.scope/session {:username username}]))})
+  {:doc    "The session's cache scope — nil when logged out (fail-closed)."
+   :inputs {:username [:db [:auth :user :username]]}}
+  (fn [{:keys [username]} _ctx]
+    (when username [:rf.scope/session {:username username}])))
 ```
 
 Now register `:conduit/feed` exactly like Part 2's resources — tagged `#{[:feed]}` — but with `:scope {:from-db :conduit/session}` (meaning "resolve my scope through the `:conduit/session` resolver") instead of the default `:rf.scope/global`. Its cache entries are keyed by the signed-in username, so each user gets their own.

--- a/docs/routing/concepts.md
+++ b/docs/routing/concepts.md
@@ -370,10 +370,10 @@ When a resource is per-user, scope it with a **named scope resolver**. Register 
 ```clojure
 ;; Adapted from examples/real-apps/realworld_resources/scope.cljs + routing.cljs
 (rf/reg-resource-scope :realworld/session
-  {:inputs  {:username [:db [:auth :user :username]]}
-   :resolve (fn [{:keys [username]} _ctx]
-              (when username
-                [:rf.scope/session {:username username}]))})
+  {:inputs {:username [:db [:auth :user :username]]}}
+  (fn [{:keys [username]} _ctx]
+    (when username
+      [:rf.scope/session {:username username}])))
 
 ;; The personalised feed, as a route resource:
 {:resource :realworld/feed


### PR DESCRIPTION
## Summary

Docs-only fix. The retired 2-slot `:resolve`-in-map `reg-resource-scope` form (a `:resolve` key inside the metadata map) still appeared as copy-pasteable example code in five guide docs — code that would now throw `:rf.error/invalid-resource-scope-spec` if run as-is, since the validator only accepts the current 3-slot `(scope-id metadata resolve-fn)` grammar.

Rewrites each illustration to the 3-slot form (drop `:resolve` key, move the resolver fn to the third positional slot), matching `examples/real-apps/realworld_resources/scope.cljs:70` and the already-fixed `scope_registry.cljc` docstring (rf2-s8t1qi):

- `docs/resources/coming-from-tanstack-query.md`
- `docs/resources/concepts.md` — second `reg-resource-scope` example (the first, prose-only, was already fine); also updates a nearby prose reference from "a scope resolver's `:resolve`" to "a scope resolver's resolver fn"
- `docs/resources/tutorial/04-mutations-and-invalidation.md`
- `docs/routing/concepts.md`
- `docs/core/how-to/add-auth.md`

Verified via `git grep -n "reg-resource-scope"` / `git grep -n ":resolve"` across `docs/` that no other guide-doc call sites or `:resolve`-key prose remain in scope (docs/api/*.md and the historical EP-0016 proposal doc are out of scope per the bead; `docs/cljs/playground-rf2.js` is a generated build artefact embedding the already-fixed cljc docstrings verbatim).

## Quality gates

- `python -m mkdocs build --strict` — exit 0. Output contains only pre-existing INFO-level notices (nav-config omissions, a couple of unrecognized relative links) unrelated to this change; no strict-mode errors.
- No code changed → no test churn.

## Risks

Low. Docs-only; no code, spec, or API surface touched. Disjoint from the concurrent `lxwpob` merge-worker (docs/api/*.md + facade).