### PR TITLE
fix(resources): arm GC timer on aborted first-load settle (rf2-kz5op1)

### DIFF
--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -2251,7 +2251,13 @@
       ;; route rather than surfacing a spurious error). NO :error /
       ;; :refresh-error write. The host handle is cleared.
       aborted?
-      (let [entry' (entry-abort-settled entry)
+      (let [entry'    (entry-abort-settled entry)
+            ;; rf2-kz5op1 — mirrors `first-load-error?` in the sibling :else
+            ;; (failure) branch below: a FIRST-load abort has no usable data,
+            ;; so `entry-abort-settled` settles it to a non-error stable
+            ;; `:idle` (never `:loaded`, which only a REFRESH abort reaches).
+            first-load-abort? (= :idle (:status entry'))
+            spec      (registry/resource-meta (:resource/id entry'))
             rdb'   (-> runtime-db
                        (assoc-in (state/entry-path resource-key) entry')
                        (work-ledger/update-record
@@ -2260,13 +2266,43 @@
                          ;; terminal outcome carries the reply token's causal
                          ;; `:completed-at`.
                          :cancelled {:reason :aborted :completed-at completed-at})
-                       (route/drain-blocking resource-key entry' :success))]
+                       (route/drain-blocking resource-key entry' :success))
+            ;; rf2-kz5op1 — a FIRST-LOAD abort settle MUST arm the GC timer
+            ;; (and the stale timer, if declared), mirroring rf2-ar9pcx's
+            ;; :error-settle fix. GC timers are otherwise armed only on a
+            ;; SUCCESSFUL settle (`succeeded-handler`) or a first-load
+            ;; `:error` settle; before this fix a first-load ABORT went to
+            ;; `:idle` with `:current-work nil` and emitted NO
+            ;; `:rf.resource/schedule-timers` — so an owner-free `:idle` entry
+            ;; from a cancelled first load was never reaped (the same
+            ;; unbounded per-frame cache leak, via the non-error settle
+            ;; sibling). A REFRESH abort (entry returns to `:loaded`, prior
+            ;; data kept) is NOT re-armed here — its stale/GC timers were
+            ;; armed on the prior success and this settle makes no freshness
+            ;; change; re-arming would double-arm (symmetric with the
+            ;; background-refresh-failure guard). No poll timer: an aborted
+            ;; entry is GC fodder, never a poll target (symmetric with the
+            ;; owner-free / no-owner gate the success + release-owner paths
+            ;; already enforce). Per Spec 016 §Stale and GC scheduling /
+            ;; §Cancellation is opportunistic.
+            stale-delay-ms (when first-load-abort?
+                             (state/positive-or-nil (:stale-after-ms spec)))
+            gc-delay-ms    (when first-load-abort?
+                             (state/positive-or-nil (:gc-after-ms spec)))]
         (work-ledger/clear-handle! frame-id work-id)
         (trace/emit! :rf.event :rf.resource/work-abort-requested
                      {:rf.frame/id frame-id :resource/key resource-key
                       :work/id work-id :generation generation
                       :status-before (:status entry) :status-after (:status entry')})
-        {:rf.db/runtime rdb'})
+        (cond-> {:rf.db/runtime rdb'}
+          (or stale-delay-ms gc-delay-ms)
+          (assoc :fx [[:rf.resource/schedule-timers
+                       {:frame-id       frame-id
+                        :resource/key   resource-key
+                        :stale-delay-ms stale-delay-ms
+                        :gc-delay-ms    gc-delay-ms
+                        :poll-delay-ms  nil
+                        :server?        (state/server-frame? frame-id)}]])))
 
       :else
       (let [entry' (state/entry-failed entry {:error error})

--- a/implementation/resources/test/re_frame/resources_invalidation_gc_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_invalidation_gc_cljs_test.cljc
@@ -135,6 +135,18 @@
                         :generation (:generation e)
                         :error {:kind :rf.http/server-error :reason reason}}])))
 
+(defn- abort!
+  "Feed an internal FAILED reply carrying an `:rf.http/aborted` envelope (an
+  intentional cancellation, not a failure — rf2-z70ujl) for a scoped key,
+  reading the LIVE entry's current work-id + generation. `failed-handler`
+  branches this into the ABORT / cancellation settle, never `:error`."
+  [scoped-key]
+  (let [e (entry scoped-key)]
+    (rf/dispatch-sync [:rf.resource.internal/failed
+                       {:resource/key scoped-key :work/id (:current-work e)
+                        :generation (:generation e)
+                        :error {:kind :rf.http/aborted :reason :user}}])))
+
 (defn- last-schedule-for [scoped-key]
   (last (filter #(= scoped-key (:resource/key %)) @scheduled-timers)))
 
@@ -655,6 +667,67 @@
       (is (= :error (:status (entry k))) "still :error, idle (no current-work)")
       (rf/dispatch-sync [:rf.resource.internal/gc-fired {:resource/key k}])
       (is (nil? (entry k)) "GC reaped the owner-free errored entry"))))
+
+(deftest first-load-abort-arms-gc-and-is-collected-after-release
+  ;; rf2-kz5op1 — a FIRST load that is ABORTED (an intentional cancellation,
+  ;; NOT a failure — rf2-z70ujl) settles a non-error stable `:idle` with
+  ;; `:current-work nil` (no usable data). The `:error` settle twin
+  ;; (rf2-ar9pcx) already arms a GC timer for this shape; BEFORE this fix the
+  ;; abort sibling did not, so an owner-free `:idle` entry from a cancelled
+  ;; first load was NEVER reaped — the same unbounded per-frame cache leak,
+  ;; via the different non-error settle path. The abort settle MUST now ALSO
+  ;; arm a GC timer (mirroring the :error twin), and once owner-free the fired
+  ;; GC re-check collects it.
+  (rf/reg-resource :gca/article (article-spec {:gc-after-ms 5000}) article-spec-request)
+  (let [scope {:user "u"}
+        k     (state/scoped-resource-key scope :gca/article {:slug "w"})]
+    (reset! scheduled-timers [])
+    (ensure! :gca/article scope "w" [:lease :gca 1])
+    (abort! k)   ;; first-load aborted → :idle (no usable data)
+    (testing "rf2-kz5op1 / Spec 016 §Cancellation is opportunistic / §Stale and
+              GC scheduling — a first-load ABORT settle arms the GC timer (so
+              the owner-free idle entry can be reaped) — it was never armed
+              before this fix"
+      (let [e (entry k)]
+        (is (= :idle (:status e)) "first-load abort settled :idle (no usable data)")
+        (is (nil? (:current-work e)) "no in-flight work after the abort settle"))
+      (let [args (last-schedule-for k)]
+        (is (some? args) "schedule-timers emitted on the abort settle")
+        (is (= 5000 (:gc-delay-ms args)) "GC timer armed at :gc-after-ms")
+        (is (nil? (:poll-delay-ms args)) "no poll timer for an aborted entry")))
+    (testing "the owner releases → owner-free + idle; the fired GC re-check
+              collects the aborted entry (no longer leaked)"
+      (rf/dispatch-sync [:rf.resource/release-owner {:owner [:lease :gca 1]}])
+      (is (empty? (:active-owners (entry k))) "entry now owner-free")
+      (is (= :idle (:status (entry k))) "still :idle, no current-work")
+      (rf/dispatch-sync [:rf.resource.internal/gc-fired {:resource/key k}])
+      (is (nil? (entry k)) "GC reaped the owner-free aborted entry"))))
+
+(deftest background-refresh-abort-does-not-rearm-gc
+  ;; rf2-kz5op1 guard — a BACKGROUND-refresh abort (the entry keeps prior data
+  ;; and returns to `:loaded`, not `:idle`) is NOT a first-load abort: its
+  ;; stale/GC timers were armed on the prior success, and `entry-abort-settled`
+  ;; makes no freshness change, so the refresh-abort settle re-arms NOTHING (no
+  ;; double-arm) — mirrors `background-refresh-failure-does-not-rearm-gc`.
+  (rf/reg-resource :gcra/article (article-spec {:gc-after-ms 5000}) article-spec-request)
+  (let [scope {:user "u"}
+        k     (state/scoped-resource-key scope :gcra/article {:slug "w"})]
+    (ensure! :gcra/article scope "w" [:route :r 1])
+    (succeed! k {:title "W"})        ;; first load succeeds → :loaded, GC armed
+    ;; a background refetch that is then aborted (entry keeps data, returns to
+    ;; :loaded)
+    (rf/dispatch-sync [:rf.resource/refetch {:resource :gcra/article :scope scope
+                                             :params {:slug "w"}}])
+    (reset! scheduled-timers [])
+    (abort! k)                       ;; background refresh abort
+    (testing "rf2-kz5op1 — a background-refresh abort (status :loaded, data
+              kept) re-arms NO timer (the GC was already armed on the prior
+              success — no double-arm from the abort path)"
+      (let [e (entry k)]
+        (is (= :loaded (:status e)) "background refresh abort kept :loaded")
+        (is (= {:title "W"} (:data e)) "prior data kept"))
+      (is (empty? (filter #(= k (:resource/key %)) @scheduled-timers))
+          "no schedule-timers re-armed on the background-refresh abort"))))
 
 (deftest background-refresh-failure-does-not-rearm-gc
   ;; rf2-ar9pcx guard — a BACKGROUND-refresh failure (the entry keeps prior data


### PR DESCRIPTION
## Summary

- An ABORTED first-load left an owner-free `:idle` resource entry with NO GC timer armed -- a per-frame cache leak. The `:error` settle path (rf2-ar9pcx) already arms GC; the abort sibling in `failed-handler`'s `aborted?` branch (`implementation/resources/src/re_frame/resources/events.cljc`) was left unpatched.
- Fix mirrors the `:error` twin exactly: after `entry-abort-settled`, arm the GC (+ stale, if declared) timer via `:rf.resource/schedule-timers` when the settle is a FIRST-load abort (`entry'` status `:idle`, no usable data). A REFRESH abort (returns to `:loaded`, prior data kept) is NOT re-armed -- its timers were already armed on the prior success, so re-arming would double-arm. No poll timer, symmetric with the `:error` twin (an aborted entry is GC fodder, never a poll target).
- Confirmed `gc-fired-handler`'s eligibility re-check is purely structural (`owner-free + no current-work`, regardless of `:status`), so the owner-free `:idle` entry produced by this settle is correctly reaped once the fired GC timer re-checks it.

## Test added

`implementation/resources/test/re_frame/resources_invalidation_gc_cljs_test.cljc`:
- `first-load-abort-arms-gc-and-is-collected-after-release` -- aborts a first-load, asserts `:rf.resource/schedule-timers` is emitted with the resource's `:gc-after-ms` (no poll delay), then releases the owner and dispatches `:rf.resource.internal/gc-fired`, asserting the owner-free `:idle` entry is reaped.
- `background-refresh-abort-does-not-rearm-gc` -- guard mirroring the existing `background-refresh-failure-does-not-rearm-gc`: a background-refresh abort (entry stays `:loaded`, prior data kept) re-arms no timer (no double-arm).

Also added an `abort!` test helper (dispatches `:rf.resource.internal/failed` with an `:rf.http/aborted` envelope) alongside the existing `fail!` helper.

## Quality gates

- `clojure -M:test` from `implementation/resources` -- 602 tests, 6086 assertions, 0 failures, 0 errors.
- `npm run test:cljs` from `implementation` -- 8058 tests, 37037 assertions, 0 failures, 0 errors (includes the new regression tests).

## Risks

- Impl-only, isolated to `implementation/resources/src/re_frame/resources/events.cljc` (the `aborted?` branch of `failed-handler`) + one test file. No public API / schema change. Mirrors an already-shipped pattern (rf2-ar9pcx) so risk is low.