### PR TITLE
fix(flows): guard in-drain clear-flow against deferred-commit resurrection (rf2-2qd9wp)

### DIFF
--- a/implementation/flows/src/re_frame/flows.cljc
+++ b/implementation/flows/src/re_frame/flows.cljc
@@ -543,7 +543,30 @@
   per-frame-independence invariant (Spec 002 rule 1 / Spec 013
   §Frame-scoping) holds by construction, not by careful keying."
   [frame-id db runtime-db]
-  (let [flow-map (get (registry/flows-snapshot) frame-id)]
+  (let [flow-map (get (registry/flows-snapshot) frame-id)
+        ;; DRAIN (read-and-clear) this frame's pending abandoned output
+        ;; paths — recorded by an IN-DRAIN same-frame `reg-flow`
+        ;; `:output-path` move OR an IN-DRAIN `clear-flow` (either would have
+        ;; a direct app-db write clobbered by the deferred commit).
+        ;; `abandoned-before` is the snapshot the catch / post-commit
+        ;; rollback re-records (the move re-attempts next drain if the event
+        ;; aborts); `abandoned-paths` is the SAME set, consumed here exactly
+        ;; once.
+        ;;
+        ;; Computed and vacated from the pending `:db` UNCONDITIONALLY —
+        ;; BEFORE the empty-`flow-map` early return below. An in-drain
+        ;; `clear-flow` that removed the frame's LAST flow leaves `flow-map`
+        ;; empty here, but the abandoned path it recorded still must be
+        ;; dissoc'd from the pending `:db`: the early return has no flow
+        ;; walk to carry that dissoc, so skipping it would let the deferred
+        ;; commit publish the handler's returned `:db` — which still carries
+        ;; the cleared flow's stale value at the abandoned path —
+        ;; resurrecting it. Frame-scoped.
+        abandoned-before (registry/abandoned-output-paths-snapshot frame-id)
+        abandoned-paths  (registry/drain-abandoned-output-paths! frame-id)
+        ;; Each `vacate-path-in-db` is a pure `db → db` LEAF dissoc
+        ;; (no-op-safe). No-op set ⇒ `db` unchanged.
+        db (reduce registry/vacate-path-in-db db abandoned-paths)]
     (if-not (seq flow-map)
       db
       (let [ordered (topo/topo-sort flow-map)
@@ -553,20 +576,7 @@
             ;; survive (their outputs were never installed). Scoped to
             ;; `frame-id` so a concurrently-draining sibling frame is
             ;; structurally untouched. Restored in the catch below.
-            last-inputs-before (registry/frame-last-inputs-snapshot frame-id)
-            ;; DRAIN (read-and-clear) this frame's pending abandoned output
-            ;; paths — recorded by an IN-DRAIN same-frame `reg-flow`
-            ;; `:output-path` move (a direct app-db write would be clobbered by
-            ;; the deferred commit). `abandoned-before` is the snapshot the
-            ;; catch / post-commit rollback re-records (the move re-attempts
-            ;; next drain if the event aborts); `abandoned-paths` is the SAME
-            ;; set, consumed here exactly once. They are dissoc'd from the
-            ;; pending `:db` below, BEFORE the flow walk, so the vacate rides
-            ;; the value the deferred commit publishes (the handler's returned
-            ;; `:db` cannot resurrect the old path) and the new flow's
-            ;; recompute lands on a clean slot. Frame-scoped.
-            abandoned-before   (registry/abandoned-output-paths-snapshot frame-id)
-            abandoned-paths    (registry/drain-abandoned-output-paths! frame-id)]
+            last-inputs-before (registry/frame-last-inputs-snapshot frame-id)]
         ;; EP-0025: a flow's EXPLICIT output data-classification declarations are
         ;; installed at `reg-flow` time (not drain time) and there is NO
         ;; input->output propagation, so there is no drain-time mark-mutation
@@ -585,16 +595,10 @@
           ;; (the per-flow `:rf.flow/skip` / `:rf.flow/computed` traces carry
           ;; the dirty/clean signal tools actually read).
           (loop [remaining ordered
-                 ;; Vacate the IN-DRAIN abandoned output paths from the pending
-                 ;; `:db` FIRST — before any flow computes — so the
-                 ;; old path is gone from the value the deferred commit
-                 ;; publishes (the handler's returned `:db` carried it, but this
-                 ;; transform is applied to that SAME value, so it cannot
-                 ;; resurrect it) and a flow newly owning the slot recomputes
-                 ;; onto a clean base. Each `vacate-path-in-db` is a pure
-                 ;; `db → db` LEAF dissoc (no-op-safe). No-op set ⇒ `db`
-                 ;; unchanged. (`abandoned-paths` was read-and-cleared above.)
-                 db        (reduce registry/vacate-path-in-db db abandoned-paths)]
+                 ;; `db` already carries the abandoned-paths vacate applied
+                 ;; above (before any flow computes), so a flow newly owning
+                 ;; a moved-to slot recomputes onto a clean base.
+                 db        db]
             (if (empty? remaining)
               db
               (let [flow         (flow-map (first remaining))

--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -1364,7 +1364,23 @@
            (fn []
              (when-let [flow (get-in @flows [frame-id id])]
                (let [path (:output-path flow)]
-                 (vacate-output-path! frame-id path)
+                 ;; Same in-drain hazard `reg-flow`'s `:output-path`-move
+                 ;; branch guards against (see the comment above its
+                 ;; `record-abandoned-output-path!` call): a `clear-flow`
+                 ;; issued OUT of a drain can vacate `path` directly — there
+                 ;; is no pending commit to clobber it. But a `clear-flow`
+                 ;; issued IN a drain (reentrant from an event handler body /
+                 ;; `:rf.fx/clear-flow`) races the SAME deferred `:db`
+                 ;; commit: a direct write here would be overwritten by the
+                 ;; handler's returned `:db` (which still carries the
+                 ;; cleared flow's last value at `path`), resurrecting it.
+                 ;; So RECORD the abandoned path instead; the current
+                 ;; drain's `run-flows-on-db` dissocs it from the PENDING
+                 ;; `:db` before the flow walk, riding the same value the
+                 ;; deferred commit publishes.
+                 (if (frame/in-drain? frame-id)
+                   (record-abandoned-output-path! frame-id path)
+                   (vacate-output-path! frame-id path))
                  ;; Spec 015 §7: drop this flow's output data-classification
                  ;; declarations from the frame's app-db elision registry so a
                  ;; deregistered flow leaves no orphaned redaction behind.

--- a/implementation/flows/test/re_frame/flows_lifecycle_drain_race_test.clj
+++ b/implementation/flows/test/re_frame/flows_lifecycle_drain_race_test.clj
@@ -439,3 +439,94 @@
     (rf/dispatch-sync [:touch] {:frame :rf/default})
     (is (= 500 (:out-b (rf/app-db-value :rf/default)))
         ":out-b materialised on the next drain after the move")))
+
+;; ---------------------------------------------------------------------------
+;; An IN-DRAIN `clear-flow` must NOT resurrect the cleared output through the
+;; deferred `:db` commit (rf2-2qd9wp) — the exact same-shaped hazard as
+;; `reg-flow`'s in-drain `:output-path` move above, but on the deregistration
+;; path. Two companion bugs, two tests:
+;;
+;;   1. `clear-flow-in-drain-does-not-resurrect-cleared-output` — clears ONE
+;;      of TWO flows registered on the frame, so `flow-map` is still
+;;      NON-EMPTY afterwards. Isolates the `clear-flow` fix: it must record
+;;      the abandoned path (`record-abandoned-output-path!`) instead of
+;;      vacating app-db directly when `frame/in-drain?` is true, mirroring
+;;      `reg-flow`'s in-drain branch.
+;;
+;;   2. `clear-flow-in-drain-last-flow-on-frame-does-not-resurrect-cleared-
+;;      output` — clears the frame's ONLY flow, so `flow-map` is EMPTY
+;;      afterwards. Exercises the companion bug: `run-flows-on-db` must drain
+;;      the pending abandoned path and vacate it from the pending `:db`
+;;      BEFORE its empty-`flow-map` early return, or the recorded path from
+;;      fix #1 is never applied and the deferred commit resurrects it anyway.
+;; ---------------------------------------------------------------------------
+
+(deftest clear-flow-in-drain-does-not-resurrect-cleared-output
+  ;; An in-drain `clear-flow` (reentrant, from an event handler body) clears
+  ;; :scaled while a SIBLING flow (:kept) remains registered on the frame —
+  ;; `flow-map` is non-empty after the clear. The handler returns its db
+  ;; UNCHANGED (no manual `(dissoc db :out-a)`), so the framework's
+  ;; abandoned-path bookkeeping is the only thing keeping :out-a gone once
+  ;; the deferred commit publishes the handler's pending `:db`.
+  (testing "in-drain clear-flow vacates the cleared output through the deferred commit (sibling flow keeps flow-map non-empty)"
+    (rf/reg-event :seed (fn [_ _] {:db {:n 5}}))
+    (rf/reg-flow :scaled {:inputs [[:n]] :output-path [:out-a]} (fn [n] (* 2 (or n 0))))
+    (rf/reg-flow :kept   {:inputs [[:n]] :output-path [:out-kept]} (fn [n] (* 7 (or n 0))))
+    (rf/dispatch-sync [:seed])
+    (is (= 10 (:out-a (rf/app-db-value :rf/default)))
+        "precondition: :scaled materialised :out-a = 2 × :n = 10")
+    (is (= 35 (:out-kept (rf/app-db-value :rf/default)))
+        "precondition: :kept materialised :out-kept = 7 × :n = 35")
+
+    ;; A handler that, mid-drain, clears :scaled and returns its db UNCHANGED.
+    (rf/reg-event :clear-scaled
+                  (fn [{:keys [db]} _]
+                    (flows/clear-flow :scaled {:frame :rf/default})
+                    {:db db}))
+    (rf/dispatch-sync [:clear-scaled] {:frame :rf/default})
+
+    (let [db (rf/app-db-value :rf/default)]
+      (is (not (contains? db :out-a))
+          (str ":out-a ABSENT — the in-drain clear-flow vacated the cleared "
+               "output through the deferred commit. Pre-fix the direct "
+               "vacate write was clobbered by the handler's returned :db "
+               "and :out-a resurrected as " (:out-a db) "."))
+      (is (= 35 (:out-kept db))
+          ":out-kept (the sibling flow, never cleared) is untouched")
+      (is (not (contains? (get (flows/flows-snapshot) :rf/default) :scaled))
+          "registry row gone: clear-flow removed :scaled")
+      (is (contains? (get (flows/flows-snapshot) :rf/default) :kept)
+          "the sibling flow's registry row survives"))))
+
+(deftest clear-flow-in-drain-last-flow-on-frame-does-not-resurrect-cleared-output
+  ;; An in-drain `clear-flow` clears the frame's ONLY flow — `flow-map` is
+  ;; EMPTY on the SAME drain's `run-flows-on-db` call. Pre-fix, the
+  ;; empty-`flow-map` early return skipped draining the abandoned path
+  ;; `clear-flow` had just recorded, so it was never vacated from the pending
+  ;; `:db` and the deferred commit resurrected it — even with fix #1 (above)
+  ;; alone applied.
+  (testing "in-drain clear-flow of the frame's LAST flow still vacates through the deferred commit"
+    (rf/reg-event :seed (fn [_ _] {:db {:n 5}}))
+    (rf/reg-flow :solo {:inputs [[:n]] :output-path [:out-solo]} (fn [n] (* 2 (or n 0))))
+    (rf/dispatch-sync [:seed])
+    (is (= 10 (:out-solo (rf/app-db-value :rf/default)))
+        "precondition: :solo materialised :out-solo = 2 × :n = 10")
+
+    ;; A handler that, mid-drain, clears the ONLY flow on the frame and
+    ;; returns its db UNCHANGED.
+    (rf/reg-event :clear-solo
+                  (fn [{:keys [db]} _]
+                    (flows/clear-flow :solo {:frame :rf/default})
+                    {:db db}))
+    (rf/dispatch-sync [:clear-solo] {:frame :rf/default})
+
+    (let [db (rf/app-db-value :rf/default)]
+      (is (not (contains? db :out-solo))
+          (str ":out-solo ABSENT — the in-drain clear-flow of the frame's "
+               "LAST flow still vacated through the deferred commit (the "
+               "empty-flow-map drain BEFORE the early return). Pre-fix it "
+               "resurrected as " (:out-solo db) "."))
+      (is (not (contains? (flows/flows-snapshot) :rf/default))
+          "the per-frame flows entry is pruned entirely — clearing the last flow drops the frame key")
+      (is (empty? (registry/abandoned-output-paths-snapshot :rf/default))
+          "the abandoned-path bookkeeping was drained, not left pending forever"))))

--- a/implementation/flows/test/re_frame/flows_test.clj
+++ b/implementation/flows/test/re_frame/flows_test.clj
@@ -967,6 +967,7 @@
     (rf/reg-event :foo!  (fn [{:keys [db]} [_ v]] {:db (assoc-in db [:wizard :foo] v)}))
     (rf/reg-event :leave (fn [_ _]
                               {:fx [[:rf.fx/clear-flow :step-2/computed]]}))
+    (rf/reg-event :touch (fn [{:keys [db]} _] {:db db}))   ;; no-op; exists only to drain
     (rf/dispatch-sync [:init])
     (is (nil? (get-in (rf/app-db-value :rf/default) [:wizard :result]))
         "no flow yet — :result is unset")
@@ -979,12 +980,22 @@
     (rf/dispatch-sync [:foo! 5])
     (is (= 9 (get-in (rf/app-db-value :rf/default) [:wizard :result]))
         "flow ran on this drain with 5 + 4 = 9")
-    ;; Now clear via fx.
+    ;; Now clear via fx. The registry removal is immediate (never deferred),
+    ;; but `:fx` walks AFTER :leave's own flow transform / `:db` install
+    ;; (rf2-2qd9wp / Spec 013 §Sequencing — the same one-event lag
+    ;; `:rf.fx/reg-flow` already documents in
+    ;; `fx-reg-flow-mid-event-lag-and-followup-dispatch-workaround`): the
+    ;; app-db vacate is recorded as an abandoned path and dissoc'd from the
+    ;; pending `:db` on the NEXT drain, not this one.
     (rf/dispatch-sync [:leave])
     (is (not (contains? (get (flows/flows-snapshot) :rf/default) :step-2/computed))
-        "registry slot removed")
+        "registry slot removed immediately")
+    (is (= 9 (get-in (rf/app-db-value :rf/default) [:wizard :result]))
+        ":result is UNCHANGED on :leave's own drain — the vacate lags one event, mirroring :rf.fx/reg-flow's lag")
+    ;; Drive one more drain to apply the deferred vacate.
+    (rf/dispatch-sync [:touch])
     (is (not (contains? (get (rf/app-db-value :rf/default) :wizard) :result))
-        ":rf.fx/clear-flow dissoc-in'd the output path")))
+        ":rf.fx/clear-flow's dissoc-in lands on the NEXT drain")))
 
 (deftest fx-reg-flow-mid-event-lag-and-followup-dispatch-workaround
   ;; Pin the LEAST-OBVIOUS flow behaviour as an explicit contract: a flow


### PR DESCRIPTION
## Summary

Two companion bugs verified in the #5229 impl-review, both in `implementation/flows/`:

1. **`clear-flow`'s app-db vacate always wrote directly** (`registry.cljc`, inside `clear-flow`'s serialized thunk). A `clear-flow` issued from *inside* an event handler body (reentrant, mid-drain) had that direct write clobbered by the same event's deferred `:db` commit — the handler's returned `:db` still carries the cleared flow's last value at the output path, and installing it resurrects the "cleared" output. `reg-flow`'s same-frame `:output-path`-move branch already guards this exact hazard via `record-abandoned-output-path!`; `clear-flow` now mirrors it — branching on `frame/in-drain?` exactly like `reg-flow` does.

2. **`run-flows-on-db`'s empty-`flow-map` early return skipped the abandoned-path drain entirely** (`flows.cljc`). Clearing a frame's *last* flow leaves `flow-map` empty on that same drain; pre-fix, the abandoned path recorded by (1) was never drained/vacated from the pending `:db`, so the resurrection reproduced even with (1) alone fixed. The abandoned-path drain + pending-`:db` vacate now run unconditionally before the empty-map check.

Both fixes mirror the existing `reg-flow` in-drain machinery exactly (`record-abandoned-output-path!` / `drain-abandoned-output-paths!` / `restore-abandoned-output-paths!`) — no new mechanism, no spec change. Spec 013's `clear-flow` observable contract ("the slot is vacated when the flow goes away") was already correct; the implementation was violating it in the in-drain case.

**Side effect (intentional, not a regression):** `:rf.fx/clear-flow`'s app-db vacate now lags one event, matching the lag `:rf.fx/reg-flow` already documents (`fx-reg-flow-mid-event-lag-and-followup-dispatch-workaround`) — the `:fx` walk runs *after* its own event's flow transform, so the abandoned path can only be applied on the *next* drain. Updated `fx-reg-flow-and-clear-flow-round-trip` to assert the vacate on a follow-up drain instead of immediately (it was inadvertently pinning the old buggy immediate-vacate behaviour).

## Regression tests added

`implementation/flows/test/re_frame/flows_lifecycle_drain_race_test.clj` (single-threaded, deterministic — mirrors the existing `reg-flow-path-move-in-drain-does-not-resurrect-old-output` test):

- `clear-flow-in-drain-does-not-resurrect-cleared-output` — clears one of two flows on a frame (flow-map stays non-empty), isolating fix (1).
- `clear-flow-in-drain-last-flow-on-frame-does-not-resurrect-cleared-output` — clears a frame's only flow (flow-map goes empty), exercising the companion fix (2).

## Quality gates

- `implementation/flows`: `clojure -M:test` — 189 tests, 4757 assertions, **0 failures, 0 errors**.
- `implementation/` (repo root `implementation/`): `npm run test:cljs` — 8056 tests, 37026 assertions, **0 failures, 0 errors**.

## Risks

- Isolated to `implementation/flows/**` (not a hot-zone surface); no spec change made or needed.
- The `:rf.fx/clear-flow` one-event-lag behaviour change is a visible semantic shift for anyone relying on immediate post-fx vacate, but it aligns clear-flow with reg-flow's already-documented contract rather than introducing a new inconsistency.