### PR TITLE
fix(routing): fail-closed nav-guard match + spec-correct route-rank bit (rf2-dqlfty)

### DIFF
--- a/implementation/routing/src/re_frame/routing/can_leave.cljc
+++ b/implementation/routing/src/re_frame/routing/can_leave.cljc
@@ -180,10 +180,24 @@
   populated (the target is `:rf.route/not-found`-shaped but the gate
   still evaluates `:can-leave` on the CURRENT route — leaving a page for
   a dead link is still a leave). A `:can-enter` guard on a matched target
-  reads its own route from the registry via `route-id`."
+  reads its own route from the registry via `route-id`.
+
+  rf2-dqlfty: this runs on EVERY nav-guard evaluation — even when the
+  route declares no `:can-leave` / `:can-enter` at all, `maybe-block-
+  navigation` calls `pending-target` unconditionally before checking
+  whether a guard is declared. A raw `match-url` call here, left
+  unhandled, would let any unexpected throw escape the guard phase and
+  crash the event drain (rf2-6t1xb) for `:rf.route/navigate`,
+  `:rf/url-requested`, `:rf.route/transitioned`, and
+  `:rf.route/handle-url-change` alike. `match-url-fail-closed` catches
+  ANY throw and yields a nil match instead, so a hostile/throwing URL
+  degrades to the same `:rf.route/not-found`-shaped target as a bare
+  miss — exactly the fail-closed discipline `url-change-fx` and
+  `:rf.route/navigate`'s `{:url ...}` target-form already apply at the
+  commit phase."
   [requested-url]
-  (let [{:keys [route-id params query fragment]}
-        (registry/match-url requested-url)]
+  (let [{:keys [match]} (registry/match-url-fail-closed requested-url)
+        {:keys [route-id params query fragment]} match]
     {:route-id route-id
      :params   params
      :query    query

--- a/implementation/routing/src/re_frame/routing/match.cljc
+++ b/implementation/routing/src/re_frame/routing/match.cljc
@@ -334,11 +334,21 @@
            ;; patterns the catch-all bit ties (both 1), so the comparison
            ;; falls through to total-length exactly as before — only
            ;; rankings involving the bare `/*` change.
+           ;; rf2-dqlfty: rules 4 and 5 are BOOLEAN discriminators per
+           ;; Spec 012 §Route ranking algorithm — "named params beat rest
+           ;; params" / "exact routes beat optional-group routes" — not a
+           ;; magnitude comparison. The pre-fix `(- splat)` / `(- optional)`
+           ;; ranked by the raw segment COUNT, so two routes tied by the
+           ;; spec (e.g. differing only in HOW MANY optional groups they
+           ;; declare) ranked differently — a cross-host divergence, since
+           ;; a conforming implementation following the spec pseudocode
+           ;; ties them. `(if (pos? n) 0 1)` collapses "any" vs "none" to
+           ;; the same two-value cascade the spec pseudocode uses.
            :rank    [static
                      (if catch-all? 0 1)
                      total
-                     (- splat)
-                     (- optional)]})
+                     (if (pos? splat) 0 1)
+                     (if (pos? optional) 0 1)]})
         (let [ch (.charAt ^String pattern i)]
           (cond
             (= ch \/)

--- a/implementation/routing/test/re_frame/routing_can_leave_test.clj
+++ b/implementation/routing/test/re_frame/routing_can_leave_test.clj
@@ -7,6 +7,7 @@
             [re-frame.core :as rf]
             [re-frame.late-bind :as late-bind]
             [re-frame.routing :as routing]
+            [re-frame.routing.registry :as registry]
             [re-frame.routing.test-support]
             [re-frame.routing-test-support :as rts]))
 
@@ -551,3 +552,71 @@
                        (= :route/owner (-> ev :tags :frame))))
                 @traces)
           ":rf.route/external-url-requested carries :frame :route/owner (pre-fix: absent)"))))
+
+;; ============================================================================
+;; rf2-dqlfty — nav-guard phase fails CLOSED on a throwing/hostile URL
+;; ============================================================================
+;;
+;; The finding: `pending-target` (the target the leave/enter guards branch
+;; on) called raw `registry/match-url`, bypassing `match-url-fail-closed` —
+;; the SAME wrapper `url-change-fx` already routes through (rf2-6t1xb).
+;; `pending-target` runs UNCONDITIONALLY inside `maybe-block-navigation`,
+;; even when the route declares no `:can-leave` / `:can-enter` at all, so
+;; any unexpected throw out of `match-url` escaped the guard phase and
+;; crashed the event drain for EVERY nav entry point (`:rf/url-requested`,
+;; `:rf.route/navigate`, `:rf.route/transitioned`,
+;; `:rf.route/handle-url-change`) instead of failing closed to
+;; `:rf.route/not-found` like a bare miss.
+
+(deftest nav-guard-hostile-url-fails-closed-not-found-rf2-dqlfty
+  (testing "rf2-dqlfty: a URL that makes `match-url` THROW during the
+            nav-guard phase must not crash the event drain — the
+            guard-phase target now resolves through `match-url-fail-closed`
+            exactly like `url-change-fx`, so the throw is swallowed and the
+            navigation proceeds to :rf.route/not-found instead of an
+            uncaught exception escaping `dispatch-sync`"
+    (rf/reg-route :route/home {} "/")
+    (rf/reg-fx :rf.nav/push-url
+               {:platforms #{:server :client}}
+               (fn [_ _] nil))
+    (rf/dispatch-sync [:rf.route/transitioned "/"])
+    (with-redefs [registry/match-url
+                  (fn [_] (throw (ex-info "simulated hostile-URL parse failure" {})))]
+      ;; Pre-fix this call throws straight out of dispatch-sync (crashes
+      ;; the event drain); post-fix it completes cleanly.
+      (rf/dispatch-sync [:rf/url-requested {:url "/hostile"}])
+      (is (= :rf.route/not-found
+             (get-in (rf/runtime-db-value :rf/default)
+                     [:rf.runtime/routing :current :route-id]))
+          "the throwing URL fails closed to :rf.route/not-found rather than
+           crashing the event drain"))))
+
+(deftest nav-guard-hostile-url-does-not-bypass-declared-can-leave-guard-rf2-dqlfty
+  (testing "rf2-dqlfty: the fail-closed target still lets a DECLARED
+            :can-leave guard run against the CURRENT route (only the
+            TARGET half of `pending-target` — derived from the hostile
+            URL — is nil'd out); a dirty-form guard still blocks a hostile
+            navigation attempt rather than silently crashing past it"
+    (rf/reg-route :editor/article
+                  {:params    [:map [:id :string]]
+                   :can-leave :editor/can-leave?} "/editor/articles/:id")
+    (rf/reg-event :editor/dirty (fn [{:keys [db]} [_ v]] {:db (assoc-in db [:editor :dirty?] v)}))
+    (rf/reg-sub :editor/can-leave?
+                (fn [db _] (not (get-in db [:editor :dirty?]))))
+    (rf/reg-fx :rf.nav/push-url
+               {:platforms #{:server :client}}
+               (fn [_ _] nil))
+    (rf/dispatch-sync [:rf.route/transitioned "/editor/articles/A"])
+    (rf/dispatch-sync [:editor/dirty true])
+    (with-redefs [registry/match-url
+                  (fn [_] (throw (ex-info "simulated hostile-URL parse failure" {})))]
+      (rf/dispatch-sync [:rf/url-requested {:url "/hostile"}])
+      (is (some? (get-in (rf/runtime-db-value :rf/default)
+                         [:rf.runtime/routing :pending-navigation]))
+          "the dirty-form :can-leave guard still blocks the throwing URL —
+           no crash, no silent bypass")
+      (is (= :editor/article
+             (get-in (rf/runtime-db-value :rf/default)
+                     [:rf.runtime/routing :current :route-id]))
+          "the active route is unchanged (leave was blocked, not crashed
+           past)"))))

--- a/implementation/routing/test/re_frame/routing_registry_test.clj
+++ b/implementation/routing/test/re_frame/routing_registry_test.clj
@@ -1996,6 +1996,70 @@
     (is (= :route/catch-all (:route-id (routing/match-url "/anything/deep")))
         "catch-all still catches URLs no concrete route matches")))
 
+;; ---- rf2-dqlfty: rank rule 5 is a boolean bit, not the optional-group ----
+;; COUNT (and rule 4 the same shape for splats)
+;;
+;; Spec 012 §Route ranking algorithm rule 5: "Exact routes beat
+;; optional-group routes" — the pseudocode's discriminator is
+;; `(if has-optional? 0 1)`, a BOOLEAN bit. Pre-fix, `parse-pattern`
+;; ranked rule 5 (and rule 4, "named params beat rest params") by the raw
+;; segment COUNT (`(- optional)` / `(- splat)`), so two routes differing
+;; ONLY in HOW MANY optional groups (or splats) they declare ranked
+;; differently where the spec ties them — a cross-host divergence, since
+;; a conforming implementation following the spec pseudocode ties them.
+
+(deftest parse-pattern-optional-group-count-does-not-affect-rank-rf2-dqlfty
+  (testing "rf2-dqlfty — one optional group and two optional groups rank
+            IDENTICALLY at rule 5 (rank element 4): both simply `have` an
+            optional group, and the spec discriminator is has-optional?,
+            not a magnitude"
+    (let [one-group  (:rank (routing.match/parse-pattern "/docs{/a}?"))
+          two-groups (:rank (routing.match/parse-pattern "/docs{/a}?{/b}?"))]
+      (is (= one-group two-groups)
+          "one optional group and two optional groups rank IDENTICALLY —
+           the spec ties them (rule 5 is has-optional?, not a magnitude);
+           pre-fix these ranked [1 1 1 0 -1] vs [1 1 1 0 -2] — NOT tied")
+      (is (= 0 (nth one-group 4))
+          "rank element 4 (rule 5) is the boolean bit: 0 = has an optional group")))
+
+  (testing "rf2-dqlfty — an EXACT route (no optional group) still out-ranks
+            both optional-group routes (rule 5 keeps discriminating exact
+            vs optional — only the WITHIN-optional-group magnitude is
+            collapsed)"
+    (let [exact      (:rank (routing.match/parse-pattern "/docs"))
+          one-group  (:rank (routing.match/parse-pattern "/docs{/a}?"))]
+      (is (pos? (compare exact one-group))
+          "the exact route out-ranks the optional-group route (rule 5)"))))
+
+(deftest parse-pattern-splat-count-does-not-affect-rank-rf2-dqlfty
+  (testing "rf2-dqlfty — rule 4 (\"named params beat rest params\") is the
+            same boolean shape: a named param still beats a splat, but the
+            fix must not regress that cascade"
+    (let [named (:rank (routing.match/parse-pattern "/files/:name"))
+          splat (:rank (routing.match/parse-pattern "/files/*rest"))]
+      (is (pos? (compare named splat))
+          "named param out-ranks the splat at rule 4 (rank element 3)")
+      (is (= 1 (nth named 3)) "named: rule-4 bit is 1 (no splat)")
+      (is (= 0 (nth splat 3)) "splat: rule-4 bit is 0 (has a splat)"))))
+
+(deftest match-url-optional-group-count-tie-breaks-on-registration-order-rf2-dqlfty
+  (testing "rf2-dqlfty — two routes differing ONLY in optional-group COUNT
+            are a genuine structural TIE per Spec 012 rule 5; match-url
+            resolves the tie via rule 6 (registration order) exactly as it
+            would for any other structurally-identical pair. Register the
+            route with MORE optional groups FIRST: pre-fix, the route with
+            FEWER optional groups always won regardless of registration
+            order (rule 5's raw count shadowed rule 6) — this test would
+            have picked :route/one-group either way if it were registered
+            first, so the two-groups-first order is the one that actually
+            discriminates the bug from the fix"
+    (rf/reg-route :route/two-groups {} "/docs{/a}?{/b}?")
+    (rf/reg-route :route/one-group  {} "/docs{/a}?")
+    (is (= :route/two-groups (:route-id (routing/match-url "/docs")))
+        "the FIRST-registered route (:route/two-groups, despite having
+         MORE optional groups) wins the tie for a URL both match — rule 6
+         registration-order tiebreak, not rule 5's group count")))
+
 (deftest match-against-root-pattern-matches-root-path
   (testing "rf2-aleg9 — the special `/` pattern matches the root URL
             and returns an empty params map; a deeper URL returns nil"


### PR DESCRIPTION
## Summary

Two verified routing bugs from #5229 impl-review (rf2-dqlfty), both isolated to `implementation/routing/`.

**1. FAIL-CLOSED BYPASS** (`can_leave.cljc`, `pending-target`) — the nav-guard phase called raw `registry/match-url` instead of `match-url-fail-closed`. `pending-target` runs **unconditionally** inside `maybe-block-navigation` for every `:rf/url-requested` / `:rf.route/navigate` / `:rf.route/transitioned` / `:rf.route/handle-url-change`, regardless of whether the route declares `:can-leave` / `:can-enter`. Any unexpected throw out of `match-url` therefore escaped the guard phase and crashed the event drain, instead of failing closed to `:rf.route/not-found` the way a bare miss does. Fixed by routing the guard-phase match through `match-url-fail-closed`, exactly mirroring what `url-change-fx` already does (rf2-6t1xb).

**2. ROUTE-RANK** (`match.cljc`, `parse-pattern`) — the rank tuple's rule 4 ("named params beat rest params") and rule 5 ("exact routes beat optional-group routes") used the raw splat/optional-group **COUNT** (`(- splat)` / `(- optional)`) instead of Spec 012's boolean discriminator (`(if has-splat? 0 1)` / `(if has-optional? 0 1)`). Two routes differing only in *how many* optional groups (or splats) they declare ranked differently, where the spec's pseudocode ties them — a cross-host divergence. Fixed both to `(if (pos? n) 0 1)`.

Spec 012's rule 4/5 pseudocode already states the boolean form correctly (`spec/012-Routing.md` §Route ranking algorithm) — only the implementation had drifted from it. No spec changes were needed; flagging per the dispatch brief rather than editing the hot-zone file.

## Tests added

- `routing_can_leave_test.clj`:
  - `nav-guard-hostile-url-fails-closed-not-found-rf2-dqlfty` — a `match-url` throw during the guard phase no longer crashes `dispatch-sync`; the navigation resolves to `:rf.route/not-found`.
  - `nav-guard-hostile-url-does-not-bypass-declared-can-leave-guard-rf2-dqlfty` — a declared `:can-leave` guard still runs correctly against the *current* route when the *target* half of `pending-target` is nil'd out by the fail-closed wrapper.
- `routing_registry_test.clj`:
  - `parse-pattern-optional-group-count-does-not-affect-rank-rf2-dqlfty` — one vs. two optional groups now rank identically (rule 5), while an exact route still out-ranks both.
  - `parse-pattern-splat-count-does-not-affect-rank-rf2-dqlfty` — rule 4's boolean shape is unchanged (named param still beats a splat).
  - `match-url-optional-group-count-tie-breaks-on-registration-order-rf2-dqlfty` — two structurally-tied routes (differing only in optional-group count) resolve via rule-6 registration order, not group count.

Verified each new test fails on the pre-fix code (temporarily reverted both source fixes via `git stash`) and passes once the fixes are restored.

## Quality gates

- `clojure -M:test` in `implementation/routing/` — 375 tests, 1598 assertions, 0 failures, 0 errors.
- `npm run test:cljs` from `implementation/` — 8056 tests, 37026 assertions, 0 failures, 0 errors.

## Risks

- Low. Both fixes are narrowly scoped and isolated to `implementation/routing/` (`can_leave.cljc` + `match.cljc`); no other artefact touches these code paths directly. The rank fix changes the *tiebreak outcome* for the narrow case of routes differing only in optional-group/splat count — this is a correctness fix aligning with the already-published spec, not a new behavior. The `:rf.warning/route-shadowed-by-equal-score` warning may now fire for a few more route-shape pairs than before (routes that are now correctly recognized as structurally tied); this is the intended, spec-conforming outcome.