### PR TITLE
fix(subs): dissoc cache slot before dispose! to stop double :rf.sub/dispose (rf2-awhtpc)

### DIFF
--- a/implementation/core/src/re_frame/subs/cache.cljc
+++ b/implementation/core/src/re_frame/subs/cache.cljc
@@ -270,23 +270,39 @@
   scope it raises `:rf.error/no-frame-context` rather than clearing an
   invented default. One-arity targets the named frame (the right shape
   for fixtures / tools outside any scope). Returns nil. See also:
-  `re-frame.subs/clear-sub` (registrar-side counterpart)."
+  `re-frame.subs/clear-sub` (registrar-side counterpart).
+
+  Per rf2-awhtpc: the cache atom is reset to `{}` BEFORE any
+  `interop/dispose!` call, not after. A layer-2+ slot's on-dispose
+  callback releases its `:<-` input refs via `unsubscribe!`, which — if
+  the input's slot were still present in the cache atom mid-walk — could
+  drive its ref-count to 0 and fire `dispose-entry-now!`, re-emitting a
+  SECOND `:rf.sub/dispose` (reason `:no-more-derefers`) for a slot this
+  same walk is about to visit with reason `:cache-clear`; the resulting
+  double-emit's ORDER (and thus which reason lands first) depended on
+  hash-map iteration order over the cache. Clearing the atom first means
+  every cascade-driven `unsubscribe!` finds nothing to evict, so it can
+  never re-fire — every slot in the pre-clear snapshot gets exactly one
+  emit, deterministically reasoned `:cache-clear`."
   ([] (clear-sub-cache! (frame/require-current-frame!
                           :clear-sub-cache!
                           {:where 're-frame.subs.cache/clear-sub-cache!})))
   ([frame-id]
    (when-let [cache (:sub-cache (frame/frame frame-id))]
-     (doseq [[k entry] @cache]
-       ;; Emit dispose per evicted key BEFORE the per-
-       ;; reaction `interop/dispose!`. Reason `:cache-clear`
-       ;; discriminates the explicit-teardown path from sync 1 → 0
-       ;; fires (`:no-more-derefers`) and hot-reload re-registration
-       ;; (`:hot-reload`).
-       (emit-dispose! frame-id k :cache-clear)
-       (when-let [r (:reaction entry)]
-         (try (interop/dispose! r)
-              (catch #?(:clj Throwable :cljs :default) _ nil))))
-     (reset! cache {}))))
+     (let [snapshot @cache]
+       ;; Evict the whole cache BEFORE any dispose! call — see the
+       ;; rf2-awhtpc note above.
+       (reset! cache {})
+       (doseq [[k entry] snapshot]
+         ;; Emit dispose per evicted key BEFORE the per-
+         ;; reaction `interop/dispose!`. Reason `:cache-clear`
+         ;; discriminates the explicit-teardown path from sync 1 → 0
+         ;; fires (`:no-more-derefers`) and hot-reload re-registration
+         ;; (`:hot-reload`).
+         (emit-dispose! frame-id k :cache-clear)
+         (when-let [r (:reaction entry)]
+           (try (interop/dispose! r)
+                (catch #?(:clj Throwable :cljs :default) _ nil))))))))
 
 (defn clear-all-frame-sub-caches!
   "CLJC-safe adapter-disposal sub-cache walk: dispose every cached entry
@@ -336,15 +352,28 @@
   atom), emitting one `:rf.sub/dispose` per slot with `:rf.sub/reason
   :frame-destroy` and `:frame frame-id`, then empty the cache. Per Spec
   009 §`:rf.sub/dispose` reason enum + Spec 006 §Disposal on frame
-  destroy. Returns nil."
+  destroy.
+
+  Per rf2-awhtpc: the cache atom is reset to `{}` BEFORE any
+  `interop/dispose!` call — same rationale as `clear-sub-cache!` above.
+  Without pre-clearing, disposing a layer-2+ slot cascades (via its
+  on-dispose callback) into `unsubscribe!` on its `:<-` inputs; if an
+  input's slot were still live in the cache mid-walk, that could drive
+  its ref-count to 0 and fire a SECOND `:rf.sub/dispose` (reason
+  `:no-more-derefers`) for a slot this walk is about to visit with
+  reason `:frame-destroy` — nondeterministic by hash-map iteration
+  order. Pre-clearing means the cascade always finds nothing to evict,
+  so every slot in the pre-clear snapshot gets exactly one emit,
+  deterministically reasoned `:frame-destroy`. Returns nil."
   [cache frame-id]
   (when cache
-    (doseq [[k entry] @cache]
-      (emit-dispose! frame-id k :frame-destroy)
-      (when-let [r (:reaction entry)]
-        (try (interop/dispose! r)
-             (catch #?(:clj Throwable :cljs :default) _ nil))))
-    (reset! cache {}))
+    (let [snapshot @cache]
+      (reset! cache {})
+      (doseq [[k entry] snapshot]
+        (emit-dispose! frame-id k :frame-destroy)
+        (when-let [r (:reaction entry)]
+          (try (interop/dispose! r)
+               (catch #?(:clj Throwable :cljs :default) _ nil))))))
   nil)
 
 (late-bind/set-fn! :subs.cache/dispose-all-for-frame-destroy!

--- a/implementation/core/test/re_frame/frame_destroy_composed_test.clj
+++ b/implementation/core/test/re_frame/frame_destroy_composed_test.clj
@@ -309,6 +309,72 @@
           (rf/unregister-listener! :trace ::dispose-emit))))))
 
 ;; ---------------------------------------------------------------------------
+;; 3b-2. Frame-destroy on a layered (:<- ) sub emits exactly one
+;; :rf.sub/dispose PER cached slot — no cascade re-emit (rf2-awhtpc)
+;;
+;; dispose-all-for-frame-destroy! used to walk the cache and call
+;; interop/dispose! per slot WITHOUT first evicting the whole cache atom.
+;; A layer-2+ sub's on-dispose callback releases its `:<-` input refs via
+;; unsubscribe! — if an input's slot was still present in the
+;; not-yet-cleared cache, dropping its ref-count to 0 fired a SECOND
+;; :rf.sub/dispose (reason :no-more-derefers) for that input, racing the
+;; walk's own :frame-destroy emit for the same slot; which one landed
+;; first (and thus which reason "won") depended on hash-map iteration
+;; order over the cache. The fix pre-clears the whole cache atom before
+;; any dispose! call, so the cascade always finds nothing left to evict.
+;; ---------------------------------------------------------------------------
+
+(deftest destroy-emits-exactly-one-dispose-per-slot-for-layered-sub
+  (testing "a layer-2 sub (:<- two inputs) held live at frame-destroy: every
+            cached slot (the sum + its two inputs) gets EXACTLY ONE
+            :rf.sub/dispose, reasoned :frame-destroy — no double-emit from
+            the on-dispose ref-count cascade racing the frame-destroy walk
+            (rf2-awhtpc)"
+    (rf/reg-frame :composed/layered-destroy {:doc "layered destroy"})
+    (rf/reg-event :composed/seed-layered (fn [{:keys [db]} _] {:db {:a 2 :b 3}}))
+    (rf/reg-sub :composed/layered-a (fn [db _] (:a db)))
+    (rf/reg-sub :composed/layered-b (fn [db _] (:b db)))
+    (rf/reg-sub :composed/layered-sum
+      :<- [:composed/layered-a]
+      :<- [:composed/layered-b]
+      (fn [[a b] _] (+ a b)))
+    (rf/dispatch-sync [:composed/seed-layered] {:frame :composed/layered-destroy})
+
+    (let [disposes (atom [])]
+      (rf/register-listener! :trace ::layered-destroy
+                             (fn [ev]
+                               (when (= :rf.sub/dispose (:operation ev))
+                                 (swap! disposes conj ev))))
+      (try
+        (let [r     (rf/subscribe :composed/layered-destroy [:composed/layered-sum])
+              cache (:sub-cache (frame/frame :composed/layered-destroy))]
+          (is (= 5 @r))
+          (is (= 3 (count @cache))
+              "precondition: sum + both inputs are cached before destroy"))
+
+        (is (nil? (frame/destroy-frame! :composed/layered-destroy)))
+
+        (let [evs      @disposes
+              by-query (group-by #(-> % :tags :rf.sub/query-v) evs)]
+          (is (= 3 (count evs))
+              "exactly THREE :rf.sub/dispose emits — one per cached slot, no
+               double-emit from the input-release cascade")
+          (is (= #{[:composed/layered-sum] [:composed/layered-a] [:composed/layered-b]}
+                 (set (keys by-query)))
+              "every cached query-vector (sum + both inputs) surfaced exactly
+               once")
+          (doseq [[q q-evs] by-query]
+            (is (= 1 (count q-evs))
+                (str q " must fire exactly one :rf.sub/dispose, not a "
+                     "duplicate from the ref-count cascade")))
+          (is (every? #(= :frame-destroy (-> % :tags :rf.sub/reason)) evs)
+              "every emit is reasoned :frame-destroy — the cascade found the
+               already-cleared cache and never re-emitted :no-more-derefers
+               for an input"))
+        (finally
+          (rf/unregister-listener! :trace ::layered-destroy))))))
+
+;; ---------------------------------------------------------------------------
 ;; 3c. Throwing cleanup hook emits a diagnostic, not silence (rf2-x3m8c f3)
 ;;
 ;; safe-call-hook! keeps best-effort teardown (the throw is swallowed and

--- a/implementation/core/test/re_frame/sub_dispose_trace_test.clj
+++ b/implementation/core/test/re_frame/sub_dispose_trace_test.clj
@@ -278,6 +278,46 @@
         (finally
           (rf/unregister-listener! :trace ::cache-clear))))))
 
+(deftest clear-sub-cache-emits-exactly-one-dispose-per-slot-for-layered-sub
+  (testing "clear-sub-cache! on a layered (:<- two inputs) sub: every cached
+            slot (the sum + both inputs) gets EXACTLY ONE :rf.sub/dispose,
+            reasoned :cache-clear — no double-emit from the on-dispose
+            ref-count cascade racing the cache-clear walk (rf2-awhtpc)"
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:a 2 :b 3}}))
+    (rf/reg-sub :sub/ca (fn [db _] (:a db)))
+    (rf/reg-sub :sub/cb (fn [db _] (:b db)))
+    (rf/reg-sub :sub/csum
+      :<- [:sub/ca]
+      :<- [:sub/cb]
+      (fn [[a b] _] (+ a b)))
+    (rf/dispatch-sync [:init])
+    (let [acc (collect-traces! ::cache-clear-layered)]
+      (try
+        (let [r     (rf/subscribe [:sub/csum])
+              cache (:sub-cache (frame/frame :rf/default))]
+          (is (= 5 @r))
+          (is (= 3 (count @cache))
+              "precondition: sum + both inputs are cached before clear"))
+        (subs-cache/clear-sub-cache!)
+        (let [disposes (dispose-events @acc)
+              by-query (group-by #(-> % :tags :rf.sub/query-v) disposes)]
+          (is (= 3 (count disposes))
+              "exactly THREE :rf.sub/dispose emits — sum + both inputs, no
+               cascade double-emit")
+          (is (= #{[:sub/csum] [:sub/ca] [:sub/cb]} (set (keys by-query)))
+              "every cached query-vector (sum + both inputs) surfaced exactly
+               once")
+          (doseq [[q q-evs] by-query]
+            (is (= 1 (count q-evs))
+                (str q " must fire exactly one :rf.sub/dispose, not a "
+                     "duplicate from the ref-count cascade")))
+          (is (every? #(= :cache-clear (-> % :tags :rf.sub/reason)) disposes)
+              "every emit is reasoned :cache-clear — the cascade found the
+               already-cleared cache and never re-emitted :no-more-derefers
+               for an input"))
+        (finally
+          (rf/unregister-listener! :trace ::cache-clear-layered))))))
+
 ;; ---- emit-shape pin ------------------------------------------------------
 ;;
 ;; The exact tag-map shape downstream consumers (Xray Epoch panel


### PR DESCRIPTION
## Summary

Fixes rf2-awhtpc (verified correctness bug from #5229 impl-review): on
`clear-sub-cache!` and `dispose-all-for-frame-destroy!`, disposing a
layer-2+ sub (one with `:<-` inputs) whose slot was still live in the
cache mid-walk could cascade — via the on-dispose callback's
`unsubscribe!` on each input — into a **second** `:rf.sub/dispose` for
an input slot the same walk was about to visit itself. Which reason
"won" (`:no-more-derefers` from the cascade vs. `:cache-clear` /
`:frame-destroy` from the walk) depended on hash-map iteration order
over the cache — nondeterministic.

## Fix

Both functions now snapshot the cache and reset the atom to `{}`
**before** any `interop/dispose!` call, then walk the snapshot to emit
+ dispose. Any cascade-driven `unsubscribe!` call now finds the cache
already empty, so `dispose-entry-now!` never re-fires — every slot in
the snapshot gets exactly one, deterministic emit (`:cache-clear` /
`:frame-destroy` respectively, never `:no-more-derefers`).

`implementation/core/src/re_frame/subs/cache.cljc` only — no spec
change, no facade change.

## Regression tests

- `frame_destroy_composed_test.clj` — new test
  `destroy-emits-exactly-one-dispose-per-slot-for-layered-sub`:
  subscribes a layer-2 sum (`:<-` two inputs), destroys the frame,
  asserts exactly 3 `:rf.sub/dispose` emits (sum + both inputs), each
  exactly once, all reasoned `:frame-destroy`.
- `sub_dispose_trace_test.clj` — twin test
  `clear-sub-cache-emits-exactly-one-dispose-per-slot-for-layered-sub`
  for the `clear-sub-cache!` path, same shape, reasoned `:cache-clear`.

Both tests fail against the pre-fix code (confirmed the double-emit
locally before applying the fix) and pass after.

## Quality gates

- `clojure -M:test` (from `implementation/core`): **1731 tests, 7615
  assertions, 0 failures, 0 errors** (run again after rebasing onto
  latest `origin/main`).
- `npm run test:cljs` (from `implementation/`): **8056 tests, 37026
  assertions, 0 failures, 0 errors**.

## Risks

Low. Change is scoped to two functions in one file
(`re_frame/subs/cache.cljc`); behavior for the non-cascading case
(independent subs, no `:<-`) is unchanged — only the ORDER of
cache-empty vs. dispose! calls moved, and existing coverage
(`dispose-emits-on-clear-sub-cache`,
`destroy-emits-sub-dispose-per-cached-slot`, throwing-dispose
composed tests) still passes untouched.