### PR TITLE
fix(instrumentation): 3-way frame resolution in trace-disable gate + first-id :dispatched destructure (rf2-yl4c0s)

### DIFF
--- a/implementation/core/src/re_frame/trace.cljc
+++ b/implementation/core/src/re_frame/trace.cljc
@@ -240,14 +240,40 @@
   nil)
 
 (defn- tagged-frame-trace-disabled?
-  "True when `tags` carries a `:frame` that is registered trace-disabled.
-  The empty-set common case (no tool frame mounted) short-circuits
-  before the membership test so the hot emit path is unaffected when no
-  inspector is running."
+  "True when the frame this (not-yet-built) trace envelope targets is
+  registered trace-disabled. Mirrors
+  `re-frame.trace.tooling/push-to-ring!`'s frame-resolution chain so the
+  suppression gate agrees with the ring on which frame an event belongs
+  to — `tags` here is exactly what becomes the envelope's `:tags`, so
+  `push-to-ring!`'s first two steps (`[:tags :frame]` and a top-level
+  `:frame` on the built envelope) collapse into the single `(:frame
+  tags)` read; its third step, the late-bound `:frame/current-frame-id`
+  hook, is mirrored as-is:
+
+    1. `:frame` under `tags` (the router / call sites stamp it on most
+       in-run emits).
+    2. The late-bound `:frame/current-frame-id` hook (published by
+       `re-frame.frame` at ns-load) — covers emits inside an in-flight
+       cascade whose call site doesn't stamp a `:frame` tag but whose
+       dynamic `*current-frame*` is bound (e.g. a sub recompute / view
+       render reached through the ambient scope rather than an explicit
+       `:frame` opt).
+
+  Without step 2 an un-tagged emit under a disabled tool frame ESCAPED
+  suppression (rf2-yl4c0s) — the inspector's own reactivity could leak
+  into the ring it inspects via any resolution path push-to-ring! honours
+  but this gate didn't. The empty-set common case (no tool frame
+  mounted) short-circuits before ANY frame resolution — including the
+  late-bind hook lookup — so the hot emit path pays a single nil-check
+  when no inspector is running."
   [tags]
   (let [disabled @trace-disabled-frames]
     (and (seq disabled)
-         (contains? disabled (:frame tags)))))
+         (let [frame-id (or (:frame tags)
+                             (when-let [current-frame
+                                        (late-bind/get-fn-cached :frame/current-frame-id)]
+                               (current-frame)))]
+           (contains? disabled frame-id)))))
 
 ;; ---- canonical frame reader (rf2-7737vq Stage A) --------------------------
 ;;

--- a/implementation/core/src/re_frame/trace/projection.cljc
+++ b/implementation/core/src/re_frame/trace/projection.cljc
@@ -238,9 +238,18 @@
 
 (defn- first-id
   "Lowest `:id` among the event bundle's events, or `##Inf` when no event
-  carries an id. Used for sorting event bundles into emission order."
-  [{:keys [event handler fx effects subs renders other]}]
-  (let [all (concat (when handler [handler])
+  carries an id. Used for sorting event bundles into emission order.
+
+  Reads `:dispatched` (the full `:rf.event/dispatched` trace EVENT), not
+  `:event` (the bare event VECTOR `absorb` also lands, which carries no
+  `:id`) — rf2-yl4c0s: destructuring `:event` here silently contributed
+  nothing to `all`, so a bundle containing ONLY the dispatched root (no
+  handler/fx/effects/subs/renders/other trace within its run) fell
+  through to the `##Inf` sentinel below and sorted LAST regardless of
+  its actual emission order."
+  [{:keys [dispatched handler fx effects subs renders other]}]
+  (let [all (concat (when dispatched [dispatched])
+                    (when handler [handler])
                     (when fx [fx])
                     effects subs renders other)
         ids (keep :id all)]

--- a/implementation/core/test/re_frame/trace/projection_test.cljc
+++ b/implementation/core/test/re_frame/trace/projection_test.cljc
@@ -259,6 +259,28 @@
       (is (= 10 (:dispatch-id c)))
       (is (nil? (:parent-dispatch-id c))))))
 
+(deftest group-by-event-orders-dispatched-root-only-bundle-by-its-own-id
+  (testing "a bundle carrying ONLY the dispatched root (no handler/fx/
+            effects/subs/renders/other trace within its run) sorts by
+            its own :dispatched event's :id, not by the ##Inf sentinel
+            (rf2-yl4c0s — first-id previously destructured :event, the
+            bare event VECTOR which carries no :id, instead of
+            :dispatched, so a root-only bundle silently fell through to
+            the sentinel and sorted LAST regardless of emission order)"
+    (let [root-only {:id 1 :op-type :rf.event :operation :rf.event/dispatched
+                      :tags {:rf.trace/dispatch-id :root-only :rf.event/v [:root-only]}}
+          ;; A full six-domino cascade whose own ids (100-107) are all
+          ;; HIGHER than the root-only bundle's id (1) — with the fix,
+          ;; the root-only bundle's first-id (1) beats the full
+          ;; cascade's first-id (100) and sorts first. Pre-fix, the
+          ;; root-only bundle's first-id fell to the ##Inf sentinel and
+          ;; sorted AFTER the full cascade instead.
+          full      (mapv #(update % :id + 99) (cascade-evs :full-cascade [:full]))
+          cs        (p/group-by-event (concat full [root-only]))]
+      (is (= 2 (count cs)))
+      (is (= [:root-only :full-cascade] (map :dispatch-id cs))
+          "the root-only bundle (id 1) sorts before the full cascade (ids 100-107)"))))
+
 (deftest group-by-event-dispatched-slot-carries-full-trace-event
   (testing "the :dispatched slot preserves the full :rf.event/dispatched
             trace so consumers (Xray Event lens) can read top-level

--- a/implementation/core/test/re_frame/trace_buffer_test.clj
+++ b/implementation/core/test/re_frame/trace_buffer_test.clj
@@ -640,6 +640,43 @@
     (is (trace/frame-trace-disabled? :tool/b)
         "the surviving tool frame's flag is untouched")))
 
+;; rf2-yl4c0s: `tagged-frame-trace-disabled?` read ONLY `[:tags :frame]` —
+;; but `push-to-ring!` resolves the destination frame THREE ways (`:frame`
+;; under `tags`, a top-level `:frame` on the built envelope, and the
+;; late-bound `:frame/current-frame-id` hook reading the ambient
+;; `*current-frame*`). An emit whose caller doesn't stamp a `:frame` tag —
+;; relying instead on the ambient `with-frame` / `*current-frame*` scope
+;; (the sub-recompute / view-render shape `push-to-ring!`'s docstring
+;; names) — ESCAPED suppression under a disabled tool frame. These two
+;; tests call `trace/emit!` directly with tags that carry NO `:frame` key,
+;; so only the current-frame-hook resolution path is exercised.
+
+(deftest untagged-emit-suppressed-when-current-frame-is-tool-disabled
+  (testing "an un-tagged emit (no :frame key in tags), resolved via the
+            ambient *current-frame* scope, is suppressed when that frame
+            is trace-disabled — not just a tagged emit"
+    (rf/reg-frame :tool/inspector {:rf.trace/frame-no-emit? true})
+    (let [seen (atom [])]
+      (rf/register-listener! :trace ::untagged (fn [ev] (swap! seen conj ev)))
+      (rf/with-frame :tool/inspector
+        (trace/emit! :rf.view :rf.view/render {:rf.view/render-key [:some/view nil]}))
+      (is (= [] @seen)
+          "the un-tagged emit never reached the listener — suppressed via the current-frame-hook path")
+      (rf/unregister-listener! :trace ::untagged))))
+
+(deftest untagged-emit-not-suppressed-under-a-plain-app-frame
+  (testing "control: the SAME un-tagged emit under a non-disabled app
+            frame's ambient scope IS delivered — proves the suppression
+            above is frame-specific, not some other global gate"
+    (rf/reg-frame :app/plain {:doc "ordinary application frame"})
+    (let [seen (atom [])]
+      (rf/register-listener! :trace ::untagged-control (fn [ev] (swap! seen conj ev)))
+      (rf/with-frame :app/plain
+        (trace/emit! :rf.view :rf.view/render {:rf.view/render-key [:some/view nil]}))
+      (is (seq @seen)
+          "an app frame's ambient scope does not suppress the emit")
+      (rf/unregister-listener! :trace ::untagged-control))))
+
 ;; ---- 6. B4 hot-reload dedup-by-shape ------------------------------------
 
 (deftest hot-reload-unchanged-handler-emits-zero-traces


### PR DESCRIPTION
## Summary

Two verified instrumentation bugs from #5229 impl-review (rf2-yl4c0s). Impl-only — spec/009-Instrumentation.md is NOT touched (that's the separate hot-zone bead rf2-ho20xj).

**1. Trace-disable gate escape (`implementation/core/src/re_frame/trace.cljc`)**

`tagged-frame-trace-disabled?` read only `[:tags :frame]`, but `re-frame.trace.tooling/push-to-ring!` resolves the destination frame **three ways**: `:frame` under `tags`, a top-level `:frame` on the built envelope, and the late-bound `:frame/current-frame-id` hook (reading the ambient `*current-frame*`). An un-tagged emit resolved only via the current-frame hook — e.g. a sub-recompute / view-render reached through ambient `with-frame` scope rather than an explicit `:frame` opt — escaped suppression under a disabled tool frame (the Xray/Story/re-frame2-pair self-instrumentation-flooding-the-ring bug the gate exists to prevent, rf2-2qaqh).

Fix: mirror `push-to-ring!`'s resolution chain (tags's first two steps collapse into one `(:frame tags)` read here since the envelope isn't built yet at gate-check time; the late-bind hook fallback is added as-is), still guarded by the existing empty-set short-circuit so the hot path pays a single nil-check when no tool frame is mounted.

**2. `first-id` mis-orders dispatched-root-only bundles (`implementation/core/src/re_frame/trace/projection.cljc`)**

`first-id` destructured `:event` (the bare event **vector**, which carries no `:id`) instead of `:dispatched` (the full `:rf.event/dispatched` trace **event**, which does). `:event` wasn't even referenced in the id-scan — a bundle containing ONLY the dispatched root (no handler/fx/effects/subs/renders/other trace within its run) silently fell through to the `##Inf` sentinel and sorted LAST regardless of its actual emission order.

Fix: destructure `:dispatched` and fold it into the id-scan.

## Tests added

- `implementation/core/test/re_frame/trace_buffer_test.clj`: `untagged-emit-suppressed-when-current-frame-is-tool-disabled` (an emit with no `:frame` tag, resolved via ambient `with-frame` scope, is suppressed under a trace-disabled frame) + `untagged-emit-not-suppressed-under-a-plain-app-frame` (control — same shape under a non-disabled frame IS delivered).
- `implementation/core/test/re_frame/trace/projection_test.cljc`: `group-by-event-orders-dispatched-root-only-bundle-by-its-own-id` (a dispatched-root-only bundle with a low id sorts before a full six-domino cascade with higher ids).

Verified both new tests fail against the pre-fix source (stashed the two src fixes, reran — 2 failures; restored — 0 failures) before finalizing.

## Quality gates

- `clojure -M:test` from `implementation/core/`: 1732 tests, 7602 assertions, 0 failures, 0 errors (run before and after rebase onto latest origin/main).
- `npm run test:cljs` from `implementation/`: 8056 tests, 37026 assertions, 0 failures, 0 errors.

## Risks / notes

- Low risk: both fixes are narrow, isolated to `trace.cljc` + `trace/projection.cljc` (+ their tests). No touches to `tooling.cljc`, `registrar.cljc`, `core.cljc`, or spec/009.
- No spec/009 clause change needed — both are implementation bugs against already-documented behavior (the gate's intent and `push-to-ring!`'s documented 3-way resolution were already normative; the gate just didn't mirror it).