### PR TITLE
fix(testbed-support): open-in-editor returns clean 400 on malformed query escape instead of uncaught throw (rf2-bhejni)

### DIFF
--- a/tools/testbed-support/src/re_frame/testbed/open_in_editor_server.clj
+++ b/tools/testbed-support/src/re_frame/testbed/open_in_editor_server.clj
@@ -409,6 +409,11 @@
   Responses:
     200 `{\"ok\":true,\"file\":\"<abs>\"}`        — editor launched.
     400 `{\"ok\":false,\"error\":\"missing-file\"}` — no `file` param.
+    400 `{\"ok\":false,\"error\":\"malformed-query\"}` — undecodable percent-escape
+        in the query string (e.g. a lone `%` or `%` not followed by two hex
+        digits — `URLDecoder/decode` throws `IllegalArgumentException` on
+        these; caught here so a malformed query answers cleanly instead of
+        throwing into the shadow-cljs `:dev-http` Ring plumbing).
     403 `{\"ok\":false,\"error\":\"forbidden\"}`    — non-loopback / cross-origin.
     405 `{\"ok\":false,\"error\":\"method-not-allowed\"}` — not POST.
     422 `{\"ok\":false,\"error\":\"<msg>\"}`       — launch failed."
@@ -436,18 +441,27 @@
         (json-resp 405 ao {:ok false :error "method-not-allowed"})
 
         :else
-        (let [q      (parse-query query-string)
-              file   (get q "file")
-              line   (->int (get q "line"))
-              column (->int (get q "column"))
-              cmd    (editor-hint (get q "editor"))]
-          (if (str/blank? file)
-            (json-resp 400 ao {:ok false :error "missing-file"})
-            (let [abs-path (resolve-file file)
-                  {:keys [ok message]} (launch! abs-path line column cmd)]
-              (if ok
-                (json-resp 200 ao {:ok true :file abs-path})
-                (json-resp 422 ao {:ok false :error (or message "launch-failed")})))))))))
+        ;; `parse-query` URL-decodes every key/value; a malformed percent-escape
+        ;; (a lone `%`, or `%` not followed by two hex digits) makes
+        ;; `URLDecoder/decode` throw `IllegalArgumentException`. Every other
+        ;; error path on this endpoint answers a clean JSON response — this
+        ;; one must too, so the decode is caught here rather than left to
+        ;; propagate uncaught into the Ring boundary.
+        (try
+          (let [q      (parse-query query-string)
+                file   (get q "file")
+                line   (->int (get q "line"))
+                column (->int (get q "column"))
+                cmd    (editor-hint (get q "editor"))]
+            (if (str/blank? file)
+              (json-resp 400 ao {:ok false :error "missing-file"})
+              (let [abs-path (resolve-file file)
+                    {:keys [ok message]} (launch! abs-path line column cmd)]
+                (if ok
+                  (json-resp 200 ao {:ok true :file abs-path})
+                  (json-resp 422 ao {:ok false :error (or message "launch-failed")})))))
+          (catch IllegalArgumentException _
+            (json-resp 400 ao {:ok false :error "malformed-query"})))))))
 
 (defn handler
   "The shadow-cljs `:dev-http` `:handler` entry-point. A not-found

--- a/tools/testbed-support/test/re_frame/testbed/open_in_editor_server_test.clj
+++ b/tools/testbed-support/test/re_frame/testbed/open_in_editor_server_test.clj
@@ -238,6 +238,42 @@
                             :request-method :post
                             :headers {"host" "localhost:8031"}})))))
 
+;; ---- malformed query string: clean 400, never an uncaught throw ----------
+;;
+;; `parse-query` URL-decodes every key/value; a malformed percent-escape (a
+;; lone `%`, or `%` not followed by two hex digits) makes `URLDecoder/decode`
+;; throw `IllegalArgumentException`. Every other error path on this endpoint
+;; (missing file, forbidden, method-not-allowed, launch failure) answers a
+;; clean JSON response — a malformed query must too, rather than propagating
+;; uncaught into the shadow-cljs `:dev-http` Ring plumbing (rf2-bhejni).
+
+(deftest malformed-query-returns-clean-400
+  (testing "a lone `%` in the query string (an incomplete percent-escape)
+            answers a clean 400, not an uncaught IllegalArgumentException"
+    (let [calls (atom [])]
+      (with-launch-spy calls
+        (let [resp (oies/handle
+                     {:uri            oies/endpoint-path
+                      :request-method :post
+                      :query-string   "file=%"
+                      :headers        {"host" "localhost:8031"}})]
+          (is (= 400 (:status resp)) "malformed query is a clean 400, not a throw")
+          (is (re-find #"\"ok\":false" (:body resp)))
+          (is (re-find #"\"error\":\"malformed-query\"" (:body resp)))
+          (is (zero? (count @calls)) "launch! was never called")))))
+  (testing "a `%` not followed by two hex digits (e.g. `%zz`) also answers
+            a clean 400"
+    (let [calls (atom [])]
+      (with-launch-spy calls
+        (let [resp (oies/handle
+                     {:uri            oies/endpoint-path
+                      :request-method :post
+                      :query-string   "file=abc%zz"
+                      :headers        {"host" "localhost:8031"}})]
+          (is (= 400 (:status resp)))
+          (is (re-find #"\"error\":\"malformed-query\"" (:body resp)))
+          (is (zero? (count @calls))))))))
+
 ;; ---- header / origin parsing helpers -------------------------------------
 
 (deftest loopback-host?-classifies-correctly


### PR DESCRIPTION
## Summary

- `parse-query` in `tools/testbed-support/src/re_frame/testbed/open_in_editor_server.clj` URL-decodes every query key/value with `URLDecoder/decode`, which throws `IllegalArgumentException` on a malformed percent-escape (a lone `%`, or `%` not followed by two hex digits).
- Nothing between `parse-query` and the Ring boundary (`handle` → `handler`) caught this, so a POST that passed the loopback/origin guard but carried a malformed query string (e.g. `POST /__rf-open-in-editor?file=%` or `?file=abc%zz`) threw **uncaught** into the shadow-cljs `:dev-http` Ring plumbing — instead of the documented 400/403/405/422 contract. Every other error path on this endpoint (missing file, forbidden, method-not-allowed, launch failure) already returns a clean JSON response; this one now does too.
- Fix: wrap the query-parse + dispatch branch in `handle` in a `try/catch IllegalArgumentException`, answering `(json-resp 400 ao {:ok false :error "malformed-query"})`, mirroring the existing `missing-file` shape. Docstring's `Responses` section updated to document the new 400 case.

## Test plan

- [x] Added `malformed-query-returns-clean-400` to `open_in_editor_server_test.clj`, asserting both a lone `%` and a `%zz` (bad hex digits) query answer a clean 400 with `{"ok":false,"error":"malformed-query"}` and never reach `launch!` (was previously an uncaught throw).
- [x] Full suite green (see Quality gates below).

## Quality gates

From `tools/testbed-support/`:
```
clojure -M:test
Ran 14 tests containing 58 assertions.
0 failures, 0 errors.
```

Isolation: `tools/testbed-support/**` only — no other surfaces touched.

Closes rf2-bhejni.