### PR TITLE
fix(mcp-conformance): make snippet-gate + redaction nets actually detect their regressions (rf2-j5ixcg/9mj9i5)

### DIFF
--- a/tools/mcp-conformance/test/end-to-end-flag-gates.cjs
+++ b/tools/mcp-conformance/test/end-to-end-flag-gates.cjs
@@ -33,11 +33,16 @@
 //      is the security-critical claim: a fresh / CI boot cannot mutate the
 //      registry by ANY gated path. Probing all three default-off means a
 //      dropped gate-check on any of them turns RED.
-//   1b. Boot WITHOUT the flag (well, WITH it to seed a fixture, then) ⇒
-//      `record-as-variant` WITHOUT `:write-back` SUCCEEDS — the
-//      intentionally UNGATED snippet-only recording path. Together with
-//      probe 1's write-back:true refusal this pins the gating boundary
-//      exactly on `:write-back`.
+//   1b. Boot WITHOUT the flag, with the target variant pre-registered via
+//      a boot-time `-e` seed (in-process `story/reg-variant*`, NOT the
+//      gated MCP `register-variant` surface) ⇒ `record-as-variant`
+//      WITHOUT `:write-back` SUCCEEDS — the intentionally UNGATED
+//      snippet-only recording path, genuinely exercised under a
+//      gate-CLOSED boot. A regression that added an unconditional gate
+//      check to `record-as-variant` (dropping the `(when write-back? …)`
+//      guard) turns RED here (rf2-j5ixcg). Together with probe 1's
+//      write-back:true refusal this pins the gating boundary exactly on
+//      `:write-back`.
 //   2. Boot WITH `--allow-writes` ⇒ `register-variant` succeeds
 //      (`isError: false`, registered) — the positive control proving the
 //      flag spelling NAMING.md pins is the one the parser actually wires.
@@ -152,12 +157,17 @@ const WATCHDOG_MS = Number(process.env.FLAG_GATE_WATCHDOG_MS) || 300000;
 // `runWithWatchdog`, which these callers bypass.)
 let activeFlagGateClient = null;
 
-async function withStoryServer(extraArgs, body) {
+// Shared spawn+connect+teardown ceremony. `clojureArgs` is the FULL arg
+// vector after `clojure` (both `withStoryServer`'s `-M -m … extraArgs` form
+// and `withGateClosedSeededStoryServer`'s `-M -e seedForm -m …` form route
+// through here) so the watchdog-handle capture + teardown logic has one
+// home.
+async function bootStoryServer(clojureArgs, body) {
   const { client } = await connectServer({
     clientName: 'mcp-conformance-flag-gates',
     transportSpec: {
       command: CLOJURE,
-      args: ['-M', '-m', 're-frame.story-mcp.server', ...extraArgs],
+      args: clojureArgs,
       cwd: STORY_MCP_CWD,
       env: { ...process.env },
     },
@@ -174,6 +184,45 @@ async function withStoryServer(extraArgs, body) {
     await closeQuietly(client);
     activeFlagGateClient = null;
   }
+}
+
+async function withStoryServer(extraArgs, body) {
+  return bootStoryServer(['-M', '-m', 're-frame.story-mcp.server', ...extraArgs], body);
+}
+
+// rf2-j5ixcg: boot the server with the write gate CLOSED (no
+// `--allow-writes`, no sysprop, no env var) but with `FIXTURE_VARIANT`
+// ALREADY REGISTERED — seeded via a `clojure -e` form evaluated BEFORE
+// `-main` runs, calling `story/reg-variant*` directly. `reg-variant*` is
+// the registrar's in-process primitive; the write GATE
+// (`write/assert-writes-allowed`) lives only in the MCP tool layer
+// (`write.cljc` / `recorder.cljc`), never in the registrar itself — so
+// seeding this way is a legitimate boot-time fixture, genuinely
+// independent of `--allow-writes`, NOT a detour around the contract this
+// harness exists to pin.
+//
+// This is what makes `assertSnippetOnlyRecordIsUngated` discriminating: a
+// registered target under a CLOSED gate is unreachable through the MCP
+// surface alone (`register-variant` is itself gated), which is exactly
+// why an earlier version of that probe seeded the fixture by booting
+// gate-OPEN — indistinguishable from a regression that gated
+// `record-as-variant` unconditionally, since `assert-writes-allowed`
+// passes identically whether skipped or invoked-and-open. Seeding
+// out-of-band gives the probe a registered target UNDER A CLOSED GATE,
+// so the real guard (`(when write-back? …)`) is what determines the
+// outcome.
+function seedVariantEvalForm() {
+  return (
+    "(require '[re-frame.story :as story]) " +
+    '(story/reg-variant* :' + FIXTURE_VARIANT + ' ' + FIXTURE_BODY_EDN + ')'
+  );
+}
+
+async function withGateClosedSeededStoryServer(body) {
+  return bootStoryServer(
+    ['-M', '-e', seedVariantEvalForm(), '-m', 're-frame.story-mcp.server'],
+    body,
+  );
 }
 
 function callRegisterVariant(client) {
@@ -277,49 +326,60 @@ async function assertWriteGateClosedByDefault() {
 // This probe + `assertRecordAsVariantWriteBackGate` together pin the
 // gating boundary EXACTLY on `:write-back`:
 //
-//   - write-back:FALSE ⇒ ALWAYS succeeds, snippet only, NO mutation
-//     (this probe).
+//   - write-back:FALSE ⇒ ALWAYS succeeds, snippet only, NO mutation,
+//     REGARDLESS of the write gate's boot posture (this probe).
 //   - write-back:TRUE  ⇒ requires the gate open; gate-closed refuses
 //     once a target is registered (the other probe).
 //
-// We need a registered target to record against, which a gate-OFF boot
-// cannot create through the MCP surface, so this boots WITH --allow-writes
-// to seed the fixture; the load-bearing claim is that the write-back:FALSE
-// call succeeds and reports `:written-back? false` (no registry mutation)
-// — proving the snippet-only path is gated by NOTHING, exactly the spec
-// contract.
+// rf2-j5ixcg: an earlier version of this probe booted WITH
+// `--allow-writes` to seed the fixture (`register-variant` itself needs
+// the gate open to register through the MCP surface), then called
+// `record-as-variant` under that SAME gate-open boot. That made the probe
+// blind to its own regression: `write/assert-writes-allowed` returns nil
+// (pass) whenever the gate is open, identically whether
+// `tool-record-as-variant` correctly SKIPS the check for `write-back:
+// false` or a regression added an UNCONDITIONAL gate check — under a
+// gate-OPEN boot the two are indistinguishable, so a dropped
+// `(when write-back? …)` guard would have shipped green.
+//
+// Fix (bead option (b) — the gate-closed fixture path IS feasible): seed
+// the target variant via `withGateClosedSeededStoryServer`, which
+// registers it in-process via `story/reg-variant*` through a boot-time
+// `-e` form, BEFORE `-main` ever runs — bypassing the gated MCP
+// `register-variant` tool entirely. The server then boots with the write
+// gate CLOSED (no `--allow-writes`), and this probe calls
+// `record-as-variant` WITHOUT `:write-back` against the pre-seeded
+// target. Now a regression that added an unconditional gate check DOES
+// turn this probe RED (the closed gate refuses), while the correct
+// `(when write-back? …)` guard still lets it through — the probe is
+// finally discriminating on the exact regression it claims to net.
 async function assertSnippetOnlyRecordIsUngated() {
-  await withStoryServer(['--allow-writes'], async (client) => {
-    // Seed a fixture to record against (needs a registered variant).
-    const seed = await client.callTool({
-      name: 'register-variant',
-      arguments: { 'variant-id': FIXTURE_VARIANT, body: FIXTURE_BODY_EDN },
-    });
-    if (seed.isError) {
-      throw new Error(
-        'snippet-only-ungated setup: register-variant failed: ' +
-          JSON.stringify(seed),
-      );
-    }
-    // Snippet-only record: NO `:write-back` — the ungated path. MUST
-    // succeed and return a `:play-snippet`, and MUST NOT report a
-    // write-back (`:written-back? false`).
+  await withGateClosedSeededStoryServer(async (client) => {
+    // Snippet-only record: NO `:write-back` — the ungated path, probed
+    // against a GATE-CLOSED boot (the target was seeded in-process, not
+    // through the gated MCP surface). MUST succeed and return a
+    // `:play-snippet`, and MUST NOT report a write-back
+    // (`:written-back? false`).
     const rec = await client.callTool({
       name: 'record-as-variant',
       arguments: { 'variant-id': FIXTURE_VARIANT },
     });
     if (rec.isError) {
       throw new Error(
-        'record-as-variant snippet-only (no :write-back) MUST succeed — it ' +
-          'is the INTENTIONALLY UNGATED recording path (spec/003 §"What\'s ' +
-          'gated"); got isError: ' + JSON.stringify(rec),
+        'record-as-variant snippet-only (no :write-back) MUST succeed even ' +
+          'with the write gate CLOSED — it is the INTENTIONALLY UNGATED ' +
+          'recording path (spec/003 §"What\'s gated"); a regression that ' +
+          'added an unconditional gate check to record-as-variant ' +
+          '(dropping the `(when write-back? …)` guard — rf2-j5ixcg) would ' +
+          'surface here as isError; got: ' + JSON.stringify(rec),
       );
     }
     const struct = structured(rec);
     if (struct.gated === true) {
       throw new Error(
-        'record-as-variant snippet-only MUST NOT be gated (write-back absent); ' +
-          'got a gated envelope: ' + JSON.stringify(rec),
+        'record-as-variant snippet-only MUST NOT be gated (write-back ' +
+          'absent) even with the write gate CLOSED; got a gated envelope: ' +
+          JSON.stringify(rec),
       );
     }
     if (typeof struct['play-snippet'] !== 'string') {
@@ -336,17 +396,12 @@ async function assertSnippetOnlyRecordIsUngated() {
     }
     console.log(
       'OK   story-mcp record-as-variant snippet-only (no --write-back) -> ' +
-        'ungated success + :play-snippet, :written-back? false',
+        'ungated success + :play-snippet, :written-back? false (write gate ' +
+        'CLOSED — genuinely discriminating, rf2-j5ixcg)',
     );
-    // Symmetric teardown.
-    try {
-      await client.callTool({
-        name: 'unregister-variant',
-        arguments: { 'variant-id': FIXTURE_VARIANT },
-      });
-    } catch (_e) {
-      // best-effort; fresh-JVM-per-boot makes a stray registration harmless.
-    }
+    // No teardown: the gate is closed (unregister-variant is itself
+    // gated), and the fresh-JVM-per-boot shape means the seeded
+    // registration dies with this process.
   });
 }
 

--- a/tools/mcp-conformance/test/live-re-frame2-pair-redaction.cjs
+++ b/tools/mcp-conformance/test/live-re-frame2-pair-redaction.cjs
@@ -387,6 +387,64 @@ function assertOk(resp, name) {
   }
 }
 
+// Extract the `:declared` slot's rendered VALUE (the text of the map
+// literal / `nil` immediately following the key) from an eval-cljs
+// response's text — one level of brace-nesting, matching the shape
+// `re-frame.elision/sensitive-declarations` actually returns: a map from
+// classified PATH VECTOR to a decl map, e.g.
+// `{[:rf-conformance/secret] {:source :effect}}`, or `{}` when nothing is
+// classified. Returns `null` if `:declared` is absent entirely (a
+// malformed / unexpected eval return — the caller treats that as a
+// precondition failure too).
+function declaredValueText(text) {
+  // The closing `\}` alternative deliberately carries NO trailing `\b`:
+  // a map literal is almost always followed by another non-word char
+  // (`,` / `}` / end-of-string), and `\b` never matches between two
+  // non-word characters — a boundary assertion there would silently
+  // fail to match the common case. `nil(?!\w)` gets the equivalent
+  // "don't swallow a longer identifier" guard the word-boundary was
+  // after, scoped to the one alternative that actually needs it.
+  const m = /:declared\s+(\{(?:[^{}]|\{[^{}]*\})*\}|nil(?!\w))/.exec(text);
+  return m ? m[1] : null;
+}
+
+// The load-bearing seed/declare precondition: `:declared` must be a
+// NON-EMPTY map whose keys include the path THIS step just classified —
+// `pathLiteral` is the rendered path vector, e.g. `[:rf-conformance/secret]`.
+//
+// rf2-9mj9i5: `:declared` is a literal key written into every SEED_FORM /
+// INNER_DECLARE_FORM return map (`:declared (re-frame.elision/sensitive-
+// declarations fid)`), so the substring `:declared` (or
+// `sensitive-declarations`) appears in the pr-str on ANY successful eval —
+// classified or not. A bare key-PRESENCE check is a tautology that can
+// never fail: it only proves the eval didn't error, never that the
+// classification actually landed. If the EP-0025 commit-plane `:sensitive`
+// effect silently failed to register the declaration (the bypass class
+// rf2-2h7153 flags), `sensitive-declarations` would return `{}` / `nil`
+// and the old check would still pass.
+//
+// This asserts the VALUE instead: non-empty (rejects the `{}` / `nil`
+// shape `sensitive-declarations` returns when nothing is classified) AND
+// containing the exact classified-path literal — so a silently-failed
+// classification effect trips this precondition rather than passing it
+// unnoticed (today the downstream sentinel/redaction assertions still
+// catch the leak; this closes the defense-in-depth hole so the
+// precondition itself is real).
+function assertDeclared(text, pathLiteral, label) {
+  const value = declaredValueText(text);
+  if (value === null || value === 'nil' || value === '{}' || !value.includes(pathLiteral)) {
+    throw new Error(
+      label + ' did not confirm the sensitive declaration landed — ' +
+        '`:declared` MUST be a non-empty map containing the classified ' +
+        'path ' + pathLiteral + ' (a bare key-presence check is a ' +
+        'tautology — `:declared` is a literal key in the eval form\'s ' +
+        'return value and renders on ANY successful eval, rf2-9mj9i5); ' +
+        'got :declared value: ' + JSON.stringify(value) + '. Full: ' +
+        text.slice(0, 300),
+    );
+  }
+}
+
 // Read the `:dropped-sensitive` count off the envelope text. The pull-mode
 // epoch tools surface a `:dropped-sensitive N` indicator (the count of
 // whole epoch records `strip-sensitive` dropped on egress). Returns the
@@ -537,12 +595,7 @@ async function seedRuntime(client, label) {
         'would be vacuous. Got: ' + seedText.slice(0, 300),
     );
   }
-  if (!seedText.includes('sensitive-declarations') && !seedText.includes(':declared')) {
-    throw new Error(
-      label + ' eval-cljs seed did not confirm the sensitive declaration ' +
-        'landed; got: ' + seedText.slice(0, 300),
-    );
-  }
+  assertDeclared(seedText, '[' + SECRET_KEY + ']', label + ' eval-cljs seed');
   return seed;
 }
 
@@ -648,12 +701,7 @@ async function runInnerProjectionArm() {
     const declare = await client.callTool({ name: 'eval-cljs', arguments: { form: INNER_DECLARE_FORM } });
     assertOk(declare, 'inner eval-cljs declare-sensitive');
     const declareText = responseText(declare);
-    if (!declareText.includes('sensitive-declarations') && !declareText.includes(':declared')) {
-      throw new Error(
-        'inner eval-cljs declare did not confirm the sensitive declaration ' +
-          'landed; got: ' + declareText.slice(0, 300),
-      );
-    }
+    assertDeclared(declareText, '[' + INNER_SECRET_KEY + ']', 'inner eval-cljs declare');
     // The stamped rollup on the recorded epoch MUST STILL be false after
     // the declaration — `sensitive-rollup` runs once at assembly and is
     // not recomputed. This is the load-bearing precondition: the OUTER


### PR DESCRIPTION
## Summary

Both fixes are on `tools/mcp-conformance/**` only — two conformance-net META-TEST-QUALITY bugs where the assertion could never go RED on the regression it claims to guard.

### rf2-j5ixcg — `assertSnippetOnlyRecordIsUngated` (test/end-to-end-flag-gates.cjs)

**Bug:** the probe booted story-mcp gate-**OPEN** (`--allow-writes`) to seed a fixture (needs a registered variant, and `register-variant` is itself gated), then called `record-as-variant` with no `:write-back` under that **same** gate-open boot. `write/assert-writes-allowed` returns nil (pass) whenever the gate is open — identically whether `tool-record-as-variant` correctly *skips* the check for `write-back:false`, or a regression dropped the `(when write-back? …)` guard and gates unconditionally. Gate-open makes the two cases indistinguishable, so a regression that broke the "snippet-only is ungated" contract for every real (gate-OFF) deploy would ship green.

**Fix chosen: option (b) from the bead** — the gate-closed fixture path is feasible, so this makes the net real rather than just narrowing its claim. Added `withGateClosedSeededStoryServer`, which spawns story-mcp with a `clojure -M -e "<seed-form>" -m re-frame.story-mcp.server` invocation: the `-e` form calls `story/reg-variant*` **directly, in-process**, before `-main` ever runs — bypassing the gated MCP `register-variant` tool entirely (the write gate lives only in `write.cljc`/`recorder.cljc`, never in the registrar). The server then boots with the gate **CLOSED** (no `--allow-writes`), and the probe calls `record-as-variant` with no `:write-back` against the pre-seeded target. Verified empirically that `-e ... -m ...` works and the seeded registration survives `-main`'s `install-canonical-vocabulary!` (idempotent, doesn't touch the variant registry).

### rf2-9mj9i5 — redaction net precondition (test/live-re-frame2-pair-redaction.cjs)

**Bug:** `seedRuntime` and the inner-projection arm's declare step both checked `seedText.includes(':declared')` — but `:declared` is a **literal map key** written into the SEED_FORM/INNER_DECLARE_FORM return value (`:declared (re-frame.elision/sensitive-declarations fid)`), so the substring is present in the pr-str on **any** successful eval, whether or not the classification actually landed. A silently-failed EP-0025 commit-plane `:sensitive` effect (the rf2-2h7153 bypass class) would still pass this precondition.

**Fix:** added `assertDeclared(text, pathLiteral, label)`, which extracts the `:declared` slot's rendered **value** (one level of brace-nesting, matching `sensitive-declarations`' actual shape — a map from classified path-vector to a decl map, e.g. `{[:rf-conformance/secret] {:source :effect}}`, or `{}` when nothing is classified) and asserts it is non-empty AND contains the specific path literal this step just classified. Both call sites (`seedRuntime` for `SECRET_KEY`, the inner-declare arm for `INNER_SECRET_KEY`) now go through this.

## Quality gates

- `cd tools/mcp-conformance && npm test` (the canonical `scripts/test-all.cjs` orchestrator, which is what `implementation/scripts/test-mcp-conformance.cjs` gates [4]+[5]/6 chain through) — **ALL CONFORMANCE TESTS GREEN**, including a from-scratch `npx shadow-cljs compile server` build of `tools/re-frame2-pair-mcp` so the `re-frame2-pair-mcp end-to-end` step actually ran (not just skipped for a missing bundle). The two live-* redaction/subscribe/etc. gates SKIP as documented without `$SHADOW_CLJS_NREPL_PORT` — expected, unrelated to this change.
- **Red-then-green discrimination proof, rf2-j5ixcg:** temporarily changed `recorder.cljc`'s `(or (when write-back? (write/assert-writes-allowed "record-as-variant")) ...)` to `(or (write/assert-writes-allowed "record-as-variant") ...)` (the exact regression the bead describes — unconditional gate). Re-ran `npm run test:flag-gates`: `assertSnippetOnlyRecordIsUngated` threw `record-as-variant snippet-only (no :write-back) MUST succeed even with the write gate CLOSED ... got: {"structuredContent":{"gated":true,"tool":"record-as-variant"} ...}` — **RED**, as intended. Reverted the recorder.cljc change (confirmed `git diff` clean on that file) and re-ran: **GREEN** again.
- **Discrimination proof, rf2-9mj9i5:** the live redaction gate needs a real shadow-cljs nREPL + browser (heavy infra: `shadow-cljs watch` compile + Playwright chromium download), out of scope for this isolated fix and SKIPped in normal CI without `$SHADOW_CLJS_NREPL_PORT` anyway. Instead verified the precondition LOGIC directly: extracted `declaredValueText`/`assertDeclared` verbatim and fed them constructed response texts mirroring the exact `pr-str` shapes confirmed from `elision.cljc` (`sensitive-declarations` returns `{}` when unclassified, `{[path] {:source :effect}}` when classified) and `wire.cljs` (`(pr-str {:ok? true :value ... })`).
  - GREEN text (`:declared {[:rf-conformance/secret] {:source :effect}}`) → old check passes, new check passes.
  - RED text simulating the exact regression (`:ok? true` but `:declared {}` — eval succeeds, classification silently didn't register) → **old check still passes (the tautology)**, **new check correctly throws**.
  - Also verified `:declared nil` and "wrong path classified" (`{[:some/other-path] ...}`) both correctly throw under the new check.
- `node -c` on both edited files (syntax) + a plain `node test/live-re-frame2-pair-redaction.cjs` run with no `$SHADOW_CLJS_NREPL_PORT` confirms the SKIP path is unaffected (exit 0).

## Notes

- Both fixes stay entirely within `tools/mcp-conformance/**` (`test/end-to-end-flag-gates.cjs`, `test/live-re-frame2-pair-redaction.cjs`) — no hot-zone files touched, no other cluster's surface touched.
- `recorder.cljc` was touched only transiently for the red-then-green proof and is unmodified in this PR (confirmed via `git diff` before committing).