### PR TITLE
fix(story): composed-fragment :script + double-play + epoch-tap bleed + :loaders/:decorators composition (rf2-k23efg/chi9j3/xj0bj0/2g7ebs)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -1286,12 +1286,14 @@ list of fragments `F1 … Fn`:
 | Slot | Rule |
 |---|---|
 | `:setup` | APPEND: inherited (root→parent) ++ composed fragments (declared order) ++ child's own — variant-owned setup lands last. |
-| `:script` | APPEND through `:compose` only: composed fragments (declared order) ++ child's own. Parent scripts never append (a child does not silently run a parent's behaviour). |
+| `:script` | APPEND through `:compose` only: composed fragments (declared order) ++ child's own. Parent scripts never append (a child does not silently run a parent's behaviour). Applies BOTH to the reported top-level `:script` AND the EXECUTED `[:world :scripts]` primary (auto-run) play — the two must never diverge (rf2-k23efg). |
 | `:args` / `:argtypes` | DEEP-MERGE root → fragments → child (last wins). |
 | `:checks` | inherited+own (root→child) ++ composed check-ids. |
 | `:assertions` | child-only (own terminal judgement). |
 | `:network` | per-route merge: composed fragments under the variant chain. |
 | `:fx-overrides` / `:interceptor-overrides` | strict-conflict, per-key (below). |
+| `:loaders` / `:loaders-teardown` | APPEND: composed fragments (declared order) ++ the variant chain's own (`:extends`-merged, child-wins). |
+| `:decorators` | APPEND: globals → story → composed fragments (declared order) → the variant chain's own. |
 
 ### Variant-owned-wins for strict-conflict fields
 

--- a/tools/story/src/re_frame/story/plan.cljc
+++ b/tools/story/src/re_frame/story/plan.cljc
@@ -1236,6 +1236,21 @@
                                     frag-layers))
         {child-script :script scripts :scripts} (normalize-scripts id child)
         script       (vec (concat compose-script child-script))
+        ;; rf2-k23efg: `compose-script` above only ever fed the REPORTED
+        ;; top-level `:script` — the runtime executes `[:world :scripts]`
+        ;; (below), never the top-level `:script` slot, so a composed
+        ;; fragment's `:script` was silently dropped from every actual run
+        ;; (plan/explain looked right; nothing happened). Fold it into the
+        ;; PRIMARY (first/auto-run) play too, exactly where it lands in the
+        ;; top-level `:script`: prepended onto that play's own script when
+        ;; the child declares one, or synthesized as a fresh auto-run play
+        ;; when the child composes a fragment's script but authors none of
+        ;; its own.
+        scripts      (cond
+                       (empty? compose-script) scripts
+                       (seq scripts) (update-in scripts [0 :script]
+                                                 #(vec (concat compose-script %)))
+                       :else [{:script compose-script :auto-run? true :name nil}])
         ;; terminal assertions are CHILD-ONLY (verdict is local)
         assertions   (vec (:assertions child))
         ;; ---- args: inherited deep-merge, THEN composed fragments, THEN
@@ -1384,6 +1399,23 @@
         fx-overrides (merge (when network-low (:fx-overrides network-low))
                             ctx-fx)
         interceptor-overrides ctx-ic
+        ;; ---- composed-fragment loaders / decorators (rf2-2g7ebs) ----
+        ;; `ctx` (above) is reduced over the `:extends` chain bodies ONLY —
+        ;; a composed fragment's `:loaders` / `:loaders-teardown` /
+        ;; `:decorators` never reached it, so they were silently dropped
+        ;; from every composed variant (the Fragment schema permits them;
+        ;; the compiler just never read them). Fold frag-layers in here,
+        ;; same declared-order-append discipline as `:setup` / `:script`:
+        ;; composed fragments contribute FIRST, the variant-chain's own
+        ;; value (`ctx`) lands after/outermost.
+        frag-loaders (vec (mapcat #(:loaders %) frag-layers))
+        loaders      (vec (concat frag-loaders (:loaders ctx)))
+        frag-loaders-teardown (vec (mapcat #(:loaders-teardown %) frag-layers))
+        loaders-teardown (vec (concat frag-loaders-teardown (:loaders-teardown ctx)))
+        ;; Decorators fold in `globals -> story -> fragment -> variant`
+        ;; order — composed fragments sit BETWEEN the ambient story
+        ;; decorators and the variant-chain's own decorators (below).
+        frag-decorators (vec (mapcat #(:decorators %) frag-layers))
         ;; ---- view arg schema + effective-args validation ----
         ;; `:effective-args` at plan time IS the resolved arg-map; the
         ;; render path layers control-panel overrides on top later. We
@@ -1445,19 +1477,22 @@
         source       (:source child)
         platforms    (or (:platforms ctx) #{:client})
         ;; ---- full decorator stack ----
-        ;; `(concat globals story variant-chain)` — globals outermost, then
-        ;; the parent story's `:decorators`, then the variant-chain slot
-        ;; (`(:decorators ctx)` — the `:extends`-merged, child-wins refs).
-        ;; The SAME ordered set `decorators/collect-decorator-refs`
-        ;; assembles at resolve time; folding it onto `[:world :decorators]`
-        ;; here makes the compiled plan the single source of truth, so the
-        ;; canvas + render-variant resolve the identical stack.
-        ;; Each layer falls through to `[]` when absent — the empty-collection
-        ;; concat is render-transparent.
+        ;; `(concat globals story fragments variant-chain)` — globals
+        ;; outermost, then the parent story's `:decorators`, then composed
+        ;; fragments' `:decorators` in declared order (rf2-2g7ebs —
+        ;; `frag-decorators` above; previously dropped entirely), then the
+        ;; variant-chain slot (`(:decorators ctx)` — the `:extends`-merged,
+        ;; child-wins refs). The SAME ordered set
+        ;; `decorators/collect-decorator-refs` assembles at resolve time;
+        ;; folding it onto `[:world :decorators]` here makes the compiled
+        ;; plan the single source of truth, so the canvas + render-variant
+        ;; resolve the identical stack. Each layer falls through to `[]`
+        ;; when absent — the empty-collection concat is render-transparent.
         story-decos  (vec (when-let [sid (args/parent-story-id id)]
                             (story-deco-lk sid)))
         full-decos   (vec (concat global-decos
                                   story-decos
+                                  frag-decorators
                                   (or (:decorators ctx) [])))
         world        (cond-> {:setup          setup
                               :args           arg-map
@@ -1493,14 +1528,19 @@
                        (seq network)          (assoc :network network)
                        (seq fx-overrides)     (assoc-in [:frame :fx-overrides] fx-overrides)
                        (seq interceptor-overrides) (assoc-in [:frame :interceptor-overrides] interceptor-overrides)
-                       (contains? ctx :loaders)     (assoc :loaders (:loaders ctx))
+                       ;; `loaders` / `loaders-teardown` already fold in
+                       ;; composed-fragment contributions (rf2-2g7ebs,
+                       ;; above) — `(seq …)`, not `(contains? ctx …)`, since
+                       ;; the slot may now be non-empty from fragments alone
+                       ;; even when the variant chain itself carries none.
+                       (seq loaders)                (assoc :loaders loaders)
                        ;; Carry `:loaders-complete-when` onto
                        ;; the plan's `:world` (it inherits through `:extends`
                        ;; into `ctx`) so the inline-plan run path (which has
                        ;; no registered body) drives phase-1 loaders + the
                        ;; completion predicate from the plan alone.
                        (contains? ctx :loaders-complete-when) (assoc :loaders-complete-when (:loaders-complete-when ctx))
-                       (contains? ctx :loaders-teardown) (assoc :loaders-teardown (:loaders-teardown ctx))
+                       (seq loaders-teardown)       (assoc :loaders-teardown loaders-teardown)
                        ;; The FULL stack (globals + story + variant chain),
                        ;; not just `(:decorators ctx)`. Folded when non-empty
                        ;; so a bare variant carries no slot

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -592,7 +592,7 @@
   so a registered variant and an INLINE plan assemble the
   same result through one path."
   [{:keys [variant-id decorator-stack effective-args snapshot executed-script
-           plan runner-selection]} start-ms]
+           plan runner-selection epoch-baseline]} start-ms]
   (let [app-db   (rf/app-db-value variant-id)
         ;; Read the epoch tape through the
         ;; late-bound `re-frame.core/epoch-history` facade (mirroring
@@ -602,13 +602,36 @@
         ;; the production classpath; the facade degrades to `[]` there
         ;; (per `re-frame.core/epoch-history`'s contract) while the
         ;; `:test`-alias epoch dep makes it the live tape under the gate.
-        tape     (vec (rf/epoch-history variant-id))
+        ;;
+        ;; rf2-xj0bj0: a same-id re-run resets the frame's app-db /
+        ;; runtime-db IN PLACE (`ensure-fresh-frame!` / `frames/reset-
+        ;; state!`) but never touches the epoch ring (dropping it is
+        ;; `destroy-frame!`'s job, and a destroy here would orphan the
+        ;; canvas's live mounted-view reactions) — so `epoch-history`
+        ;; still carries every PRIOR run's records too. `epoch-baseline`
+        ;; is the ring length `run-phase-0!` stamped at THIS run's start;
+        ;; dropping that many entries scopes the projected tape to just
+        ;; this run, so a second identical run projects IDENTICAL
+        ;; evidence rather than inheriting the first run's stale
+        ;; violations / warnings / narrative. Absent on the inline-plan
+        ;; path (a fresh anonymous frame every time) — `(or … 0)` is then
+        ;; a no-op, matching the pre-fix whole-tape read.
+        tape     (vec (drop (or epoch-baseline 0) (rf/epoch-history variant-id)))
         ;; The runner-recorded per-dispatch-step settle boundaries light
         ;; up the EXACT narrative attribution
         ;; (`evidence/spans-from-stamps`). The
         ;; stamp is a `:rf.story/*` key the determinism projection strips, so
         ;; the run-hash is unaffected (the `:epoch-tape` slot stays raw).
-        attribution (runner-events/settle-boundaries variant-id)
+        ;;
+        ;; rf2-xj0bj0: the runner stamps each boundary as an ABSOLUTE
+        ;; `rf/epoch-history` length (position in the WHOLE, unsliced
+        ;; ring) — `evidence/project-evidence` zips these positionally
+        ;; against `tape`. Since `tape` above is now `epoch-baseline`-
+        ;; relative (sliced), the boundaries must be shifted onto the SAME
+        ;; zero-point or every span attribution after the first run would
+        ;; be off by `epoch-baseline` positions.
+        attribution (some->> (runner-events/settle-boundaries variant-id)
+                              (mapv #(- % (or epoch-baseline 0))))
         ;; Project the tape ONCE here so the post-run evidence
         ;; validation (`requirements-unmet` → `validate-run-evidence`) reads
         ;; the SAME projected slots `result/run-result` derives the result
@@ -816,13 +839,24 @@
 
   The `:loaders-complete-when` vector form reads the epoch
   tape (`assertions/dispatched-events`, the SSOT) rather than a side-table
-  accumulator, so there is no accumulator to seed here."
+  accumulator, so there is no accumulator to seed here.
+
+  rf2-xj0bj0: `ensure-fresh-frame!` resets an EXISTING frame's app-db /
+  runtime-db IN PLACE (`frames/reset-state!`) rather than destroy!+
+  allocate! (to preserve the canvas's live mounted-view reactions) — so a
+  same-id re-run's epoch ring is NEVER cleared (only `destroy-frame!`
+  drops it). Stamp the CURRENT epoch-history length as `:epoch-baseline`
+  so `record-result-map` can slice the projected tape to just THIS run's
+  records, not the whole frame's accumulated history — otherwise a second
+  `run-variant` on the same id would project evidence
+  (`:schema-violations` / `:warnings` / `:effects` / `:narrative`)
+  polluted with the FIRST run's stale records."
   [{:keys [variant-id decorator-stack] :as ctx}]
   (ensure-fresh-frame! variant-id)
   (frames/allocate! variant-id decorator-stack)
   (swap! play/pending-exceptions assoc variant-id [])
   (play/install-trace-listener! variant-id)
-  ctx)
+  (assoc ctx :epoch-baseline (count (rf/epoch-history variant-id))))
 
 (defn- db-seed-violations
   "Validate the seeded `db` against the frame's REGISTERED app-db schemas
@@ -1319,7 +1353,16 @@
   (registry-free), then clear the per-frame `pending-exceptions` slot +
   install the play-runner privacy egress listener — the same ordering
   `run-phase-0!` uses so loader-phase events are captured (no
-  side-table to seed)."
+  side-table to seed).
+
+  Also stamps `:epoch-baseline` (rf2-xj0bj0), mirroring `run-phase-0!`, so
+  `record-result-map` slices the SAME way on both paths. An inline plan
+  mints a brand-new anonymous frame id every run (never reused), so this
+  is always 0 in practice — but computing it here (rather than leaving it
+  absent) keeps the inline path symmetric with the registered path for
+  whatever the frame's own allocation records before the loaders/setup/
+  script phases run, so an inline plan and an equivalent registered
+  variant project the same-shaped tape (and therefore the same run-hash)."
   [{:keys [variant-id plan decorator-stack] :as ctx}]
   (frames/allocate-inline! variant-id
                            decorator-stack
@@ -1327,7 +1370,7 @@
                            (inline-events-only? plan decorator-stack))
   (swap! play/pending-exceptions assoc variant-id [])
   (play/install-trace-listener! variant-id)
-  ctx)
+  (assoc ctx :epoch-baseline (count (rf/epoch-history variant-id))))
 
 (defn run-inline-plan
   "Execute an inline plan MAP (spec/017 §Inline plan) and

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -490,6 +490,37 @@
   ;; value held over from the previous mount.
   (reset! selection-prev nil))
 
+;; rf2-chi9j3: `component-did-mount` schedules a mount-time auto-run for an
+;; already-selected variant (deep-link / persisted selection) AFTER
+;; `hydrate-url-state!` runs. But `hydrate-url-state!` may ITSELF change
+;; `:selected-variant` (a `?variant=…` deep link) — and that selection
+;; change fires the already-installed `selection-watcher`, which schedules
+;; its OWN auto-run for the same variant. Without a guard, both paths
+;; schedule a `js/setTimeout` calling `play-runner-events/auto-run!` for
+;; the same variant, so its `:play-script` runs (and every event in it
+;; dispatches) TWICE.
+;;
+;; `mount-time-autorun-vid` is the pure decision this guard reduces to: it
+;; takes the selection observed BEFORE `hydrate-url-state!` ran and the
+;; CURRENT (post-hydration) selection, and returns the variant-id the
+;; mount-time block should schedule an auto-run for, or nil to skip.
+;;
+;;   - `pre-hydrate-vid` = `post-hydrate-vid` (unchanged across hydration,
+;;     including both nil) — the selection was ALREADY current before this
+;;     mount (a persisted / re-mount selection the watcher never saw as a
+;;     change, so it never scheduled anything) → the mount-time block is
+;;     the ONLY scheduler; return `post-hydrate-vid`.
+;;   - `pre-hydrate-vid` ≠ `post-hydrate-vid` — `hydrate-url-state!` JUST
+;;     changed the selection during THIS mount (a deep link), which means
+;;     `selection-watcher`'s change-handler already fired and scheduled its
+;;     own auto-run → return nil (skip; scheduling here would double-run).
+;;
+;; Pure data → data, so it is unit-testable without mounting the shell.
+(defn- mount-time-autorun-vid
+  [pre-hydrate-vid post-hydrate-vid]
+  (when (and post-hydrate-vid (= pre-hydrate-vid post-hydrate-vid))
+    post-hydrate-vid))
+
 ;; ---- url-state apply-fn ---------------------------------------------------
 ;;
 ;; rf2-o4u18: bridge between the pure `url-state` engine and the live
@@ -875,95 +906,113 @@
          (backgrounds-switcher/hydrate!)
          (start-hot-reload-poll!)
          (selection-watcher)
-         ;; rf2-o4u18 / rf2-ovb1en: hydrate the URL-state slots (workspace +
-         ;; mode-tab + viewport + background + tag-filter + variant / modes /
-         ;; substrate) — `url-state/hydrate-from-url!` is the authoritative,
-         ;; VALIDATING owner of all of them and sets the focused selection.
-         ;; `share/hydrate-from-url!` then owns ONLY the focused-variant
-         ;; cell-overrides slice (declared-key drift filter + share-import
-         ;; hint, rf2-9jthx); it reads — never rewrites — the validated
-         ;; selection / substrate, so the second pass can't undo the first
-         ;; pass's validation. Selection runs through the same shell-state-atom
-         ;; swap path the user's click would take, so the selection-watcher's
-         ;; preallocate-frame branch fires for deep-linked variants.
-         (hydrate-url-state!)
-         ;; rf2-o4u18: subscribe to popstate so the back-button restores
-         ;; prior URL state, and watch shell-state-atom so user-driven
-         ;; selection / viewport / background / tag-filter changes
-         ;; pushState the canonical URL. The focused variant's
-         ;; cell-override edits ARE pushed (rf2-5fyo3 — the share popover
-         ;; that once owned override serialisation was retired by
-         ;; rf2-ymnfx, so the live address bar is the only sharing
-         ;; surface) and restored on popstate via apply-parsed-to-state
-         ;; (rf2-j0hwf — closes the override round-trip on back/forward).
-         (url-state/install-popstate-listener!
-           state/shell-state-atom
-           (url-state-apply-fn))
-         (url-state/install-state-watcher! state/shell-state-atom)
-         ;; rf2-5fc15: install the Test Codegen recorder's trace-bus
-         ;; listener once at shell mount. The listener short-circuits
-         ;; on every emit when no recording is in flight, so leaving
-         ;; it installed is free; we only need to make sure it
-         ;; exists before the user clicks REC.
-         (recorder-ui/install-trace-listener!)
-         ;; rf2-d5u89: install the recorder's DOM-capture listeners
-         ;; on the canvas root so :click / :input / :change / :submit
-         ;; events translate into [:dom/click ...] / [:dom/type ...]
-         ;; / [:dom/submit ...] entries on the recorder's :entries
-         ;; stream. Delegate to a one-tick `setTimeout` so the React
-         ;; tree has committed the `[data-test=\"story-canvas-frame\"]`
-         ;; root before the install tries to find it. The listener
-         ;; short-circuits when no recording is in flight, so the
-         ;; install is free even when REC is idle.
-         (js/setTimeout
-           (fn []
-             (recorder-dom/install!)
-             ;; rf2-h0jc0: element-level click-to-code inspector. Hooks
-             ;; mousemove / click / keydown on the same canvas root the
-             ;; recorder uses. Listener gates on `(inspector/active?)`
-             ;; so the install is free when the chip is off — install
-             ;; once at shell-mount, gate per-event at the listener
-             ;; head. Same one-tick `setTimeout` discipline as the
-             ;; recorder so the React tree has committed the canvas-
-             ;; frame DOM node before the install tries to find it.
-             (element-inspector/install!))
-           0)
-         ;; rf2-one3t: install the save-as-variant dialog-open callback
-         ;; against the pure ns so `save-variant/save-current-as-variant!`
-         ;; can drive the modal without coupling the .cljc helper to
-         ;; Reagent / DOM. Idempotent.
-         (save-variant-ui/install!)
-         (rails/hydrate!)
-         ;; rf2-g8l8x — hydrate per-panel chrome-visibility map from
-         ;; localStorage BEFORE the embed-flag pass (embed is URL-
-         ;; driven, must not be clobbered by stale persisted slot).
-         (keybindings/hydrate!)
-         ;; rf2-pucku — hydrate the `:embed?` slot from the
-         ;; `?embed=1` URL flag. One-shot at mount.
-         (url-state/hydrate-embed-flag! state/shell-state-atom)
-         ;; rf2-g8l8x / rf2-p3i0t — install the chrome-level hotkey
-         ;; listener. Cmd-K palette ships its own listener.
-         (keybindings/install!)
-         (when-let [vid (:selected-variant @state/shell-state-atom)]
-           (ensure-listeners-for-variant! vid)
-           ;; rf2-v1ach: per-panel embed manages its own mount on
-           ;; commit. The cross-host bridges (project-root +
-           ;; keybinding detach) still need to fire so the popout
-           ;; escape hatch + Xray's source-coord chips resolve
-           ;; against Story's `:rf.story/project-root`.
-           (xray-preset/wire-cross-host!)
-           ;; rf2-q9kv5: apply per-story preset on the mount-time
-           ;; selection too (the selection-watcher only fires on
-           ;; change, so a pre-selected variant would otherwise miss
-           ;; the preset).
-           (xray-preset/on-variant-selected! vid)
-           ;; rf2-8i2a9: mount-time auto-run for an already-selected
-           ;; variant (deep-link / persisted selection). Yields a tick
-           ;; so the canvas has committed before the script's first
-           ;; DOM-sensitive step runs.
+         ;; rf2-chi9j3: capture the selection BEFORE `hydrate-url-state!`
+         ;; runs — the same value `selection-watcher` just seeded
+         ;; `selection-prev` from. When the URL carries a deep-linked
+         ;; `?variant=…`, `hydrate-url-state!` swaps `:selected-variant`
+         ;; synchronously, which fires the already-installed watcher and
+         ;; schedules ITS OWN mount-time auto-run (below, `selection-
+         ;; watcher`'s `js/setTimeout`). `mount-time-autorun-vid` uses this
+         ;; pre-hydration value to tell the two cases apart so the mount-
+         ;; time block never double-schedules a deep-linked variant's
+         ;; `:play-script`.
+         (let [pre-hydrate-vid (:selected-variant @state/shell-state-atom)]
+           ;; rf2-o4u18 / rf2-ovb1en: hydrate the URL-state slots (workspace +
+           ;; mode-tab + viewport + background + tag-filter + variant / modes /
+           ;; substrate) — `url-state/hydrate-from-url!` is the authoritative,
+           ;; VALIDATING owner of all of them and sets the focused selection.
+           ;; `share/hydrate-from-url!` then owns ONLY the focused-variant
+           ;; cell-overrides slice (declared-key drift filter + share-import
+           ;; hint, rf2-9jthx); it reads — never rewrites — the validated
+           ;; selection / substrate, so the second pass can't undo the first
+           ;; pass's validation. Selection runs through the same shell-state-atom
+           ;; swap path the user's click would take, so the selection-watcher's
+           ;; preallocate-frame branch fires for deep-linked variants.
+           (hydrate-url-state!)
+           ;; rf2-o4u18: subscribe to popstate so the back-button restores
+           ;; prior URL state, and watch shell-state-atom so user-driven
+           ;; selection / viewport / background / tag-filter changes
+           ;; pushState the canonical URL. The focused variant's
+           ;; cell-override edits ARE pushed (rf2-5fyo3 — the share popover
+           ;; that once owned override serialisation was retired by
+           ;; rf2-ymnfx, so the live address bar is the only sharing
+           ;; surface) and restored on popstate via apply-parsed-to-state
+           ;; (rf2-j0hwf — closes the override round-trip on back/forward).
+           (url-state/install-popstate-listener!
+             state/shell-state-atom
+             (url-state-apply-fn))
+           (url-state/install-state-watcher! state/shell-state-atom)
+           ;; rf2-5fc15: install the Test Codegen recorder's trace-bus
+           ;; listener once at shell mount. The listener short-circuits
+           ;; on every emit when no recording is in flight, so leaving
+           ;; it installed is free; we only need to make sure it
+           ;; exists before the user clicks REC.
+           (recorder-ui/install-trace-listener!)
+           ;; rf2-d5u89: install the recorder's DOM-capture listeners
+           ;; on the canvas root so :click / :input / :change / :submit
+           ;; events translate into [:dom/click ...] / [:dom/type ...]
+           ;; / [:dom/submit ...] entries on the recorder's :entries
+           ;; stream. Delegate to a one-tick `setTimeout` so the React
+           ;; tree has committed the `[data-test=\"story-canvas-frame\"]`
+           ;; root before the install tries to find it. The listener
+           ;; short-circuits when no recording is in flight, so the
+           ;; install is free even when REC is idle.
            (js/setTimeout
-             (fn [] (play-runner-events/auto-run! vid))
-             0))))
+             (fn []
+               (recorder-dom/install!)
+               ;; rf2-h0jc0: element-level click-to-code inspector. Hooks
+               ;; mousemove / click / keydown on the same canvas root the
+               ;; recorder uses. Listener gates on `(inspector/active?)`
+               ;; so the install is free when the chip is off — install
+               ;; once at shell-mount, gate per-event at the listener
+               ;; head. Same one-tick `setTimeout` discipline as the
+               ;; recorder so the React tree has committed the canvas-
+               ;; frame DOM node before the install tries to find it.
+               (element-inspector/install!))
+             0)
+           ;; rf2-one3t: install the save-as-variant dialog-open callback
+           ;; against the pure ns so `save-variant/save-current-as-variant!`
+           ;; can drive the modal without coupling the .cljc helper to
+           ;; Reagent / DOM. Idempotent.
+           (save-variant-ui/install!)
+           (rails/hydrate!)
+           ;; rf2-g8l8x — hydrate per-panel chrome-visibility map from
+           ;; localStorage BEFORE the embed-flag pass (embed is URL-
+           ;; driven, must not be clobbered by stale persisted slot).
+           (keybindings/hydrate!)
+           ;; rf2-pucku — hydrate the `:embed?` slot from the
+           ;; `?embed=1` URL flag. One-shot at mount.
+           (url-state/hydrate-embed-flag! state/shell-state-atom)
+           ;; rf2-g8l8x / rf2-p3i0t — install the chrome-level hotkey
+           ;; listener. Cmd-K palette ships its own listener.
+           (keybindings/install!)
+           (when-let [vid (:selected-variant @state/shell-state-atom)]
+             (ensure-listeners-for-variant! vid)
+             ;; rf2-v1ach: per-panel embed manages its own mount on
+             ;; commit. The cross-host bridges (project-root +
+             ;; keybinding detach) still need to fire so the popout
+             ;; escape hatch + Xray's source-coord chips resolve
+             ;; against Story's `:rf.story/project-root`.
+             (xray-preset/wire-cross-host!)
+             ;; rf2-q9kv5: apply per-story preset on the mount-time
+             ;; selection too (the selection-watcher only fires on
+             ;; change, so a pre-selected variant would otherwise miss
+             ;; the preset).
+             (xray-preset/on-variant-selected! vid)
+             ;; rf2-8i2a9 / rf2-chi9j3: mount-time auto-run for an
+             ;; already-selected variant (deep-link / persisted
+             ;; selection) — but ONLY when `hydrate-url-state!` did NOT
+             ;; just change the selection during THIS mount. When it did,
+             ;; `selection-watcher`'s change-handler already scheduled its
+             ;; own auto-run for `vid` (above); scheduling a second one
+             ;; here would run the deep-linked variant's `:play-script`
+             ;; TWICE (every dispatch doubled). Yields a tick so the
+             ;; canvas has committed before the script's first
+             ;; DOM-sensitive step runs.
+             (when-let [run-vid (mount-time-autorun-vid pre-hydrate-vid vid)]
+               (js/setTimeout
+                 (fn [] (play-runner-events/auto-run! run-vid))
+                 0))))))
      :component-will-unmount
      (fn [_]
        (stop-hot-reload-poll!)

--- a/tools/story/test/re_frame/story/compose_test.cljc
+++ b/tools/story/test/re_frame/story/compose_test.cljc
@@ -80,6 +80,104 @@
              (:script p))))))
 
 ;; ===========================================================================
+;; rf2-k23efg — composed-fragment :script must be EXECUTED, not just
+;; reported. The runtime drives `[:world :scripts]` (the named-play set),
+;; NEVER the reported top-level `:script` slot — before the fix,
+;; `compose-script` folded only into the latter, so a composed fragment's
+;; script never actually ran (plan/explain looked right; nothing happened).
+;; ===========================================================================
+
+(deftest fragment-script-composes-into-executed-scripts
+  (testing "a composed fragment's :script appends into the EXECUTED
+            [:world :scripts] primary play, not just the reported
+            top-level :script"
+    (let [fragments {:fragment.checkout/ready-to-submit
+                     {:script [[:dispatch [:checkout/open]]]}}
+          variants  {:story.checkout/submits
+                     {:compose [:fragment.checkout/ready-to-submit]
+                      :script  [[:dispatch [:checkout/submit]]]}}
+          p (compose-plan :story.checkout/submits
+                          {:variants variants :fragments fragments})
+          scripts (get-in p [:world :scripts])]
+      (is (= 1 (count scripts)) "one primary auto-run play")
+      (is (true? (:auto-run? (first scripts))))
+      (is (= [[:dispatch [:checkout/open]] [:dispatch [:checkout/submit]]]
+             (:script (first scripts)))
+          "the executed play's script carries the composed fragment's
+           script FIRST, then the variant's own — matching the reported
+           top-level :script exactly")
+      (is (= (:script (first scripts)) (:script p))
+          "[:world :scripts]'s primary play and the reported top-level
+           :script never diverge"))))
+
+(deftest fragment-script-with-no-variant-script-still-executes
+  (testing "a variant that composes a fragment's :script but authors NO
+            script of its own still gets an executed primary play (not
+            an empty [:world :scripts])"
+    (let [fragments {:fragment/only-script
+                     {:script [[:dispatch [:seed-only]]]}}
+          variants  {:story.x/no-own-script
+                     {:compose [:fragment/only-script]}}
+          p (compose-plan :story.x/no-own-script
+                          {:variants variants :fragments fragments})
+          scripts (get-in p [:world :scripts])]
+      (is (= 1 (count scripts)))
+      (is (true? (:auto-run? (first scripts))))
+      (is (= [[:dispatch [:seed-only]]] (:script (first scripts)))))))
+
+;; ===========================================================================
+;; rf2-2g7ebs — composed-fragment :loaders / :loaders-teardown / :decorators
+;;
+;; `ctx` (the per-field `:extends`-chain merge) never read frag-layers for
+;; these three slots before the fix — silently dropped from every composed
+;; variant even though the Fragment schema permits them.
+;; ===========================================================================
+
+(deftest fragment-loaders-compose-and-append
+  (testing "a composed fragment's :loaders append BEFORE the variant's own"
+    (let [fragments {:fragment/socket {:loaders [[:socket/open]]}}
+          variants  {:story.x/v {:compose [:fragment/socket]
+                                 :loaders [[:socket/subscribe]]}}
+          p (compose-plan :story.x/v
+                          {:variants variants :fragments fragments})]
+      (is (= [[:socket/open] [:socket/subscribe]]
+             (get-in p [:world :loaders]))))))
+
+(deftest fragment-loaders-teardown-composes-and-appends
+  (testing "a composed fragment's :loaders-teardown appends BEFORE the
+            variant's own"
+    (let [fragments {:fragment/socket {:loaders-teardown [[:socket/close]]}}
+          variants  {:story.x/v {:compose          [:fragment/socket]
+                                 :loaders-teardown [[:socket/unsubscribe]]}}
+          p (compose-plan :story.x/v
+                          {:variants variants :fragments fragments})]
+      (is (= [[:socket/close] [:socket/unsubscribe]]
+             (get-in p [:world :loaders-teardown]))))))
+
+(deftest fragment-loaders-alone-still-fold-in
+  (testing "a fragment's :loaders fold in even when the variant declares
+            none of its own"
+    (let [fragments {:fragment/socket {:loaders [[:socket/open]]}}
+          variants  {:story.x/v {:compose [:fragment/socket]}}
+          p (compose-plan :story.x/v
+                          {:variants variants :fragments fragments})]
+      (is (= [[:socket/open]] (get-in p [:world :loaders]))))))
+
+(deftest fragment-decorators-compose-in-globals-story-fragment-variant-order
+  (testing "a composed fragment's :decorators fold into [:world :decorators]
+            BETWEEN the ambient (globals) layer and the variant chain's own
+            decorators (globals -> story -> fragment -> variant)"
+    (let [fragments {:fragment/themed {:decorators [:decorator/fragment-theme]}}
+          variants  {:story.x/v {:compose    [:fragment/themed]
+                                 :decorators [:decorator/variant-theme]}}
+          p (plan/variant-plan :story.x/v
+              {:lookup            variants
+               :fragment-lookup   fragments
+               :global-decorators [:decorator/global]})]
+      (is (= [:decorator/global :decorator/fragment-theme :decorator/variant-theme]
+             (get-in p [:world :decorators]))))))
+
+;; ===========================================================================
 ;; Check composition + identity preservation
 ;; ===========================================================================
 

--- a/tools/story/test/re_frame/story/ui/shell_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/shell_cljs_test.cljs
@@ -1,0 +1,47 @@
+(ns re-frame.story.ui.shell-cljs-test
+  "CLJS-side regression net for `re-frame.story.ui.shell`'s pure
+  mount-time decision logic.
+
+  rf2-chi9j3 — a deep-linked auto-run variant executed its
+  `:play-script` TWICE on shell mount: `component-did-mount` installs
+  `selection-watcher`, then `hydrate-url-state!` may itself change
+  `:selected-variant` (a `?variant=…` deep link), which fires the
+  already-installed watcher and schedules an auto-run — and THEN the
+  mount-time block unconditionally reads the (now-hydrated) selection
+  and schedules a SECOND auto-run for the same variant, without
+  distinguishing 'already selected before mount' from 'just selected by
+  this mount's URL hydration'.
+
+  `mount-time-autorun-vid` is the pure decision the fix reduces the
+  mount-time guard to (see the ns docstring above its definition in
+  `shell.cljs`); it needs no DOM / mount to exercise."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.story.ui.shell :as shell]))
+
+(def ^:private mount-time-autorun-vid @#'shell/mount-time-autorun-vid)
+
+(deftest mount-time-autorun-vid-schedules-when-unchanged
+  (testing "selection unchanged across hydration (persisted / re-mount
+            selection the watcher never saw as a change) — the mount-time
+            block is the ONLY scheduler, so it returns the vid"
+    (is (= :story.counter/default
+           (mount-time-autorun-vid :story.counter/default :story.counter/default)))))
+
+(deftest mount-time-autorun-vid-skips-when-hydration-just-selected
+  (testing "rf2-chi9j3 core case — a FRESH mount with no prior selection,
+            where `hydrate-url-state!` deep-links a `?variant=…` selection
+            during THIS mount, must SKIP the mount-time schedule: the
+            selection-watcher already fired (selection went nil -> vid)
+            and scheduled its own auto-run. Scheduling here too would run
+            the variant's :play-script twice."
+    (is (nil? (mount-time-autorun-vid nil :story.counter/deep-linked)))))
+
+(deftest mount-time-autorun-vid-skips-when-hydration-changed-selection
+  (testing "hydration changing an EXISTING selection to a different deep
+            link also skips — same reasoning, the watcher already
+            scheduled the new selection's auto-run"
+    (is (nil? (mount-time-autorun-vid :story.counter/a :story.counter/b)))))
+
+(deftest mount-time-autorun-vid-nil-when-nothing-selected
+  (testing "no selection before or after hydration — nothing to auto-run"
+    (is (nil? (mount-time-autorun-vid nil nil)))))

--- a/tools/story/test/re_frame/story_runtime_test.clj
+++ b/tools/story/test/re_frame/story_runtime_test.clj
@@ -1446,6 +1446,36 @@
            the first run's leftover state (which would give 2)"))
     (story/destroy-variant! :story.fresh/v)))
 
+(deftest run-variant-twice-epoch-tape-does-not-bleed
+  (testing "rf2-xj0bj0 — a second run-variant on the same id projects
+            evidence from ITS OWN epoch records only. The reset-in-place
+            path (frames/reset-state!, the fresh-run boundary) resets
+            app-db/runtime-db but never touches the epoch ring (only
+            destroy-frame! drops it) — so a naive whole-frame
+            epoch-history read would inherit the FIRST run's records too,
+            producing a tape roughly twice as long on the second run and
+            polluting the projected evidence."
+    (rf/reg-event :test/inc-counter3
+      (fn [{:keys [db]} _] {:db (update db :counter (fnil inc 0))}))
+    (story/reg-variant :story.fresh3/v
+      {:events [[:test/inc-counter3]]})
+    (let [r1 (async/deref-blocking (story/run-variant :story.fresh3/v) 5000)
+          r2 (async/deref-blocking (story/run-variant :story.fresh3/v) 5000)]
+      (is (= 1 (:counter (:app-db r1))))
+      (is (= 1 (:counter (:app-db r2))))
+      (is (pos? (count (:epoch-tape r1)))
+          "sanity: the epoch surface is live for this test (a non-empty
+           tape) — otherwise the assertion below would pass vacuously")
+      (is (= (count (:epoch-tape r1)) (count (:epoch-tape r2)))
+          "identical scripts against a fresh frame produce a SAME-SIZED
+           epoch tape on both runs — the second run's tape is scoped to
+           its OWN records, not the first run's tape plus its own (which
+           would be roughly double-length before the fix)")
+      (is (= (:schema-violations r1) (:schema-violations r2))
+          "identical re-runs project IDENTICAL evidence — no stale
+           violation/warning carries over from the first run"))
+    (story/destroy-variant! :story.fresh3/v)))
+
 (deftest run-variant-twice-reruns-loaders
   (testing "a LOADER variant reruns its loaders on the second run-variant —
             the prior :ready frame is destroyed, so run-loaders! does not


### PR DESCRIPTION
## Summary

Four verified story bug beads, all on the tools/story/ composed-fragment + play-execution surface:

- **rf2-k23efg** — composed-fragment `:script` steps were never executed. `plan.cljc`'s `compile-body` folded `compose-script` only into the REPORTED top-level `:script`; the runtime executes `[:world :scripts]` (the named-play set), never the top-level `:script` slot — so a composed fragment's script silently never ran even though `plan`/`explain` looked correct. Fixed by folding `compose-script` into the primary (auto-run) play too — prepended onto its own script when the child declares one, or synthesized as a fresh auto-run play when the child composes a fragment's script but authors none of its own.
- **rf2-2g7ebs** — composed-fragment `:loaders` / `:loaders-teardown` / `:decorators` were silently dropped. The per-field `ctx` merge in `plan.cljc` reduces over the `:extends` chain bodies only; a composed fragment's `:loaders`/`:loaders-teardown`/`:decorators` never reached it (the Fragment schema permits them; the compiler just never read them). Fixed by folding `frag-layers` in: loaders/teardown APPEND (fragments in declared order, then the variant-chain's own value); decorators fold in `globals -> story -> fragment -> variant` order.
- **rf2-chi9j3** — a deep-linked auto-run variant executed its `:play-script` TWICE on shell mount. `shell.cljs`'s `component-did-mount` installs `selection-watcher`, then `hydrate-url-state!` may itself change `:selected-variant` (a `?variant=…` deep link) — firing the already-installed watcher, which schedules its own auto-run — and the mount-time block then unconditionally scheduled a SECOND auto-run for the same now-selected variant. Fixed by capturing the pre-hydration selection and skipping the mount-time schedule when hydration itself just changed the selection (extracted as the pure, unit-testable `mount-time-autorun-vid` helper).
- **rf2-xj0bj0** — a same-id `run-variant` re-run bled the prior run's epoch tape into projected evidence. `ensure-fresh-frame!`'s reset-in-place path (`frames/reset-state!`) preserves the canvas's live mounted-view reactions by resetting app-db/runtime-db WITHOUT touching the epoch ring (only `destroy-frame!` drops it) — so a second run's evidence projection read the WHOLE accumulated tape, including the first run's stale records. Fixed by stamping the ring length at run start (`:epoch-baseline`, threaded through `run-phase-0!`/`run-inline-phase-0!`) and slicing the projected tape + shifting the narrative-attribution boundaries onto the same baseline, so a second identical run projects identical evidence.

**Shared root cause / convergence**: k23efg and 2g7ebs are the SAME root pattern (the composed-fragment expansion path in `plan.cljc` feeding the executed world slots) fixed together in one pass. chi9j3 and xj0bj0 are distinct runtime-timing bugs on the shell-mount and epoch-ring surfaces respectively, not sharing code with the plan.cljc fixes, but bundled per the dispatch brief (one coherent fragment-composition + play-execution area).

## Fix + test per bead

| Bead | File:line (fix) | Regression test |
|---|---|---|
| rf2-k23efg | `plan.cljc` `compile-body` — folds `compose-script` into the primary play in `scripts` before `scripts*` substitution | `compose_test.cljc`: `fragment-script-composes-into-executed-scripts`, `fragment-script-with-no-variant-script-still-executes` |
| rf2-2g7ebs | `plan.cljc` `compile-body` — `frag-loaders`/`frag-loaders-teardown`/`frag-decorators` folded into `loaders`/`loaders-teardown`/`full-decos` | `compose_test.cljc`: `fragment-loaders-compose-and-append`, `fragment-loaders-teardown-composes-and-appends`, `fragment-loaders-alone-still-fold-in`, `fragment-decorators-compose-in-globals-story-fragment-variant-order` |
| rf2-chi9j3 | `shell.cljs` — new `mount-time-autorun-vid` pure guard + `component-did-mount` captures `pre-hydrate-vid` | new `shell_cljs_test.cljs`: 4 tests on `mount-time-autorun-vid` |
| rf2-xj0bj0 | `runtime.cljc` — `:epoch-baseline` stamped in `run-phase-0!`/`run-inline-phase-0!`; `record-result-map` slices `tape` + shifts `attribution` | `story_runtime_test.clj`: `run-variant-twice-epoch-tape-does-not-bleed` (extends the existing `run-variant-twice-is-stateless` test-gap) |

## Spec reconciliation (tools/story/spec/017-Testing-Story.md)

- Added `:loaders`/`:loaders-teardown` and `:decorators` rows to the §Strict composition "Total merge order (as implemented)" table (rf2-2g7ebs — previously undocumented entirely).
- Strengthened the `:script` row to state the append rule covers BOTH the reported top-level `:script` and the EXECUTED `[:world :scripts]` primary play (rf2-k23efg).
- rf2-chi9j3 / rf2-xj0bj0: spec unchanged — no passage in spec/017 or spec/002-Runtime.md makes a normative claim about mount-time auto-run scheduling or the reset-in-place path's epoch-ring semantics; both are implementation-only bug fixes with no documented contract to correct.

## Quality gates

- `clojure -M:test` from `tools/story/` — **0 failures, 0 errors** (1716 tests, 6354 assertions), run twice for flake-check.
- `npm run test:cljs` from `implementation/` — **0 failures, 0 errors** (8064 tests, 37046 assertions) — validates `shell.cljs` compiles/loads correctly and the new CLJS test file passes.
- `npm run story:build` from `implementation/` — **build succeeded** (591 files compiled, 0 warnings attributable to this change) — confirms the story artefact still builds with all four fixes.

## Risks / notes

- The `:epoch-baseline` mechanism (xj0bj0) required also shifting the narrative-attribution boundaries (`runner-events/settle-boundaries`, recorded as ABSOLUTE epoch-history positions) onto the same baseline — without this, EXACT narrative attribution for any run past a frame's first epoch write would misalign by the baseline offset. This was caught by the existing `run-variant-narrative-exact-attribution-of-redispatch-fanout` / multi-play narrative tests during the fix (both now pass).
- The inline-plan path (`run-inline-phase-0!`) also now stamps `:epoch-baseline` for symmetry with the registered path — an inline plan mints a fresh anonymous frame every run so this is always 0 in practice, but keeping both paths consistent was needed to keep `inline-and-registered-equivalent-after-canonicalize`'s run-hash equivalence intact.
- Did not touch the 5 other open story beads (96qsjr, mzfh9c, gchydo, l3lyal, xk8oz4) or any xray/implementation/core surface.

## Test plan
- [x] `clojure -M:test` (tools/story) green
- [x] `npm run test:cljs` (implementation) green
- [x] `npm run story:build` (implementation) succeeds