### PR TITLE
fix(template): register SSR whole-app-db schema against the ssr-handler per-request frame so server validation is live (rf2-hbobni)

### DIFF
--- a/tools/template/resources/day8/re_frame2_template/_reagent/core_with_ssr.cljc
+++ b/tools/template/resources/day8/re_frame2_template/_reagent/core_with_ssr.cljc
@@ -21,8 +21,10 @@
    - `:counter/initialise` / `:counter/increment` — the shared events.
    - `:counter/value` — the shared subscription.
    - `counter-app` — the shared root view (`reg-view`).
-   - SERVER ENTRY: `server-init-events` / `root-view` — the vectors the
-     Ring host-adapter (see server.clj) hands to `ssr-handler`.
+   - SERVER ENTRY: `register-schema!` / `:ssr/register-schema` /
+     `server-init-events` / `root-view` — the per-request schema-attach
+     step and the vectors the Ring host-adapter (see server.clj) hands
+     to `ssr-handler`.
    - CLIENT ENTRY: `run`, which boots through `ssr/hydrate!` — READ the
      embedded payload, HYDRATE (dispatch the framework-owned `:rf/hydrate`
      event), VERIFY the render hash — then mounts on top of the seeded
@@ -118,31 +120,67 @@
 ;; SERVER ENTRY POINT
 ;; ============================================================================
 ;;
-;; server.clj wires these two into `re-frame.ssr.ring/ssr-handler`, which
-;; owns the per-request lifecycle (frame create -> drain -> response read
-;; -> render -> frame destroy). The handler dispatches `server-init-events`
-;; into a fresh per-request `:server` frame, drains to fixed point, then
-;; renders `root-view`. The schema is registered per-request by
-;; `register-schema!` (server.clj calls it from `:on-error`-free happy
-;; path via the handler's construction; here we expose the pieces).
+;; server.clj wires `server-init-events` + `root-view` into
+;; `re-frame.ssr.ring/ssr-handler`, which owns the per-request lifecycle
+;; (frame create -> drain -> response read -> render -> frame destroy) —
+;; and gensyms the per-request frame id INTERNALLY. server.clj (and this
+;; namespace) never see that id, so the schema can't be attached with an
+;; explicit `{:frame frame-id}` call the way the CLIENT does below (where
+;; `app-frame` is a known symbol).
+;;
+;; Instead `:ssr/register-schema` rides as the FIRST `:initial-events`
+;; step (see `server-init-events`): its handler body runs with
+;; `frame/*current-frame*` bound to the very frame `ssr-handler` is
+;; constructing for THIS request — the binding covers "the duration of
+;; the handler chain" per Spec 002 §Dispatch resolution chain — so a
+;; no-`:frame`-override `register-schema!` call resolves that ambient
+;; frame. This is the scope path `schemas.cljc`'s `resolve-frame` names
+;; as valid ("a frame `:initial-events` step"). It runs BEFORE
+;; `:rf/server-init` so the counter seed commit that follows has a
+;; schema to validate against.
+
+;; A JVM-side helper attaching the whole-app-db schema. Two forms:
+;;   (register-schema!)          — the AMBIENT frame (a carried-invariant
+;;                                 scope). `:ssr/register-schema` below
+;;                                 uses this form — the server never sees
+;;                                 its own per-request frame id.
+;;   (register-schema! frame-id) — an EXPLICIT frame. The CLIENT's `init`
+;;                                 (below) uses this form, since
+;;                                 `app-frame` IS a known symbol.
+;; reg-app-schema is frame-local, so either form must run under a live
+;; frame scope — never at ns-load.
+(defn register-schema!
+  ([] (rf/reg-app-schema [] {:schema CounterDb}))
+  ([frame-id] (rf/reg-app-schema [] {:schema CounterDb :frame frame-id})))
+
+;; The schema-attach step — dispatched FIRST by `server-init-events`
+;; (below), never by the client (`:platforms #{:server}`; the client
+;; calls `register-schema!` directly from `init` instead). Returns `{}`
+;; — no `:db` effect — so THIS step's own commit is never itself subject
+;; to app-db schema validation (app-db schemas validate only when a
+;; `:db` effect lands, Mike ruling #11); it exists purely to attach the
+;; schema before the step that actually seeds the counter.
+(rf/reg-event :ssr/register-schema
+  {:doc       "Per-request schema attach — registers the whole-app-db
+                schema against the frame ssr-handler is constructing for
+                this request (the ambient `:initial-events` scope)."
+   :platforms #{:server}}
+  (fn [_cofx _event]
+    (register-schema!)
+    {}))
 
 (def server-init-events
   "The `:initial-events` vector the Ring SSR handler dispatches into each
-   per-request server frame."
-  [[:rf/server-init]])
+   per-request server frame. `:ssr/register-schema` runs FIRST so the
+   whole-app-db schema is live before `:rf/server-init`'s seed commits —
+   see the comment above for why the schema can't be attached any other
+   way on this path."
+  [[:ssr/register-schema]
+   [:rf/server-init]])
 
 (def root-view
   "The root view id the SSR handler renders after the drain settles."
   [:app/root])
-
-;; A JVM-side helper the SSR test (and server.clj) call to attach the
-;; whole-app-db schema to a frame. reg-app-schema is frame-local, so this
-;; must run under a live frame scope — never at ns-load.
-(defn register-schema!
-  "Attach the whole-app-db schema to `frame-id`. Call once per frame,
-   under a live frame scope."
-  [frame-id]
-  (rf/reg-app-schema [] {:schema CounterDb :frame frame-id}))
 
 ;; ============================================================================
 ;; CLIENT ENTRY POINT
@@ -184,7 +222,9 @@
      (rf/reg-frame app-frame {:doc      "{{name}} SSR client app-frame"
                               :platform :client})
      ;; Register the schema against the client frame — the mirror of the
-     ;; per-request registration on the server.
+     ;; server's `:ssr/register-schema` step, using the explicit-frame
+     ;; arity since `app-frame` (unlike the server's per-request id) is a
+     ;; known symbol.
      (register-schema! app-frame)
      ;; One call, all three steps — READ, HYDRATE, VERIFY — against the
      ;; same `app-frame` the mount below uses. `:render-tree-fn` must hash

--- a/tools/template/resources/day8/re_frame2_template/_shared/ssr_test.clj
+++ b/tools/template/resources/day8/re_frame2_template/_shared/ssr_test.clj
@@ -14,12 +14,25 @@
    compiles and produces hydration-ready HTML with the
    `data-rf-render-hash` tripwire the client compares against.
 
+   `ssr-render-produces-hydration-ready-html` (above) hand-rolls
+   `reg-frame` + `register-schema!` directly, which is a DIFFERENT code
+   path from the one `server.clj` actually serves — `server.clj` never
+   sees its own per-request frame id (`ssr-ring/ssr-handler` gensyms it
+   internally), so a test that supplies the frame id itself cannot catch a
+   regression in how the schema attaches to THAT path (rf2-hbobni). The
+   two tests below exercise the REAL `ssr-ring/ssr-handler` construction
+   server.clj uses — the happy path renders normally, and a deliberately
+   schema-violating commit is REJECTED, proving `:ssr/register-schema`
+   attaches the whole-app-db schema to the exact frame `ssr-handler`
+   constructs for the request, not a different/default one.
+
    Run it with `clojure -M:test` (the `:test` alias picks it up alongside
    the CLJS node-test build)."
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.string :as string]
             [re-frame.core :as rf]
             [re-frame.ssr :as ssr]
+            [re-frame.ssr.ring :as ssr-ring]
             [{{namespace}}.core :as app]))
 
 (deftest ssr-render-produces-hydration-ready-html
@@ -68,3 +81,48 @@
           (is (string/includes? html "data-rf-render-hash")
               "the root element carries the render-hash tripwire for the
                client-side hydration-mismatch check"))))))
+
+(deftest ssr-handler-renders-through-the-real-production-path
+  (testing "the REAL ssr-ring/ssr-handler construction (mirroring server.clj's
+            make-handler) renders normally end-to-end — :ssr/register-schema
+            doesn't disturb the happy path"
+    (rf/init! ssr/adapter)
+    (let [handler (ssr-ring/ssr-handler
+                    {:initial-events app/server-init-events
+                     :root-view      app/root-view
+                     :payload        [:counter/value]})
+          resp    (handler {:uri "/" :request-method :get})]
+      (is (= 200 (:status resp))
+          "the production ssr-handler path renders a normal 200 response")
+      (is (string/includes? (:body resp) "data-rf-render-hash")
+          "the response body carries the render-hash tripwire"))))
+
+(deftest ssr-handler-rejects-a-schema-violating-commit-on-the-real-path
+  (testing "the REAL ssr-ring/ssr-handler path — the one server.clj actually
+            serves — enforces the whole-app-db schema (rf2-hbobni)"
+    (rf/init! ssr/adapter)
+    ;; A test-only step appended AFTER the app's own `server-init-events`,
+    ;; committing a key CounterDb's `{:closed true}` map forbids. If
+    ;; `:ssr/register-schema` failed to attach the schema to THIS
+    ;; per-request frame (the bug rf2-hbobni describes — the schema landing
+    ;; on a different/default frame the server never renders against), this
+    ;; commit would sail through uncaught and the assertion below would
+    ;; fail, catching the regression.
+    (rf/reg-event :ssr-test/corrupt-commit
+      {:doc "Test-only — forces a schema-violating app-db commit to prove
+             server-side validation is live on the production ssr-handler
+             path."}
+      (fn [{:keys [db]} _event]
+        {:db (assoc db :ssr-test/not-in-schema true)}))
+    (let [handler (ssr-ring/ssr-handler
+                    {:initial-events (conj app/server-init-events
+                                           [:ssr-test/corrupt-commit])
+                     :root-view      app/root-view
+                     :payload        [:counter/value]})
+          resp    (handler {:uri "/" :request-method :get})]
+      (is (= 500 (:status resp))
+          (str "expected the schema-violating commit to be REJECTED by the "
+               "production ssr-handler path (proving server-side app-db "
+               "validation is live), but got status " (:status resp)
+               " — this is exactly the silently-inert-validation bug "
+               "rf2-hbobni describes if it regresses")))))

--- a/tools/template/test/day8/re_frame2_template/template_test.clj
+++ b/tools/template/test/day8/re_frame2_template/template_test.clj
@@ -1173,7 +1173,12 @@
             (is (.contains core-text "server-init-events")
                 "core.cljc exposes server-init-events for the Ring host")
             (is (.contains core-text "register-schema!")
-                "core.cljc exposes register-schema! for per-frame schema attach"))
+                "core.cljc exposes register-schema! for per-frame schema attach")
+            (is (.contains core-text ":ssr/register-schema")
+                "core.cljc's server-init-events attaches the whole-app-db schema
+                 via an ambient :initial-events step, so it lands on the SAME
+                 per-request frame ssr-handler constructs, not a
+                 different/default one (rf2-hbobni)"))
 
           ;; -- server.clj carries the Ring host wiring --
           (let [server-text (slurp (io/file root "src/acme/my_app/server.clj"))]


### PR DESCRIPTION
## Summary

- The SSR scaffold's `server-init-events` dispatched only `:rf/server-init`; `register-schema!` (which required an explicit `frame-id`) was never called on the production `server.clj` path because `ssr-ring/ssr-handler` gensyms its per-request frame id internally — `server.clj` (and `core_with_ssr.cljc`) never see it. Server-side whole-app-db validation was therefore **silently inert on every real HTTP request**; client-side validation worked fine, making the gap asymmetric and easy to miss.
- Fix: fold a new `:ssr/register-schema` event into `server-init-events` as the **first** step. Its handler calls the new ambient-frame arity of `register-schema!` (no explicit `:frame` override). Because a frame's `:initial-events` step runs with `frame/*current-frame*` bound to the frame under construction (Spec 002 §Dispatch resolution chain), the schema attaches to the *exact* per-request frame `ssr-handler` is building for that request — not a different/default one. The step returns `{}` (no `:db` effect) so its own commit is never itself subject to app-db schema validation (validation only fires when a `:db` effect lands — Mike ruling #11).
- `register-schema!` keeps its explicit-frame arity for the client (`app-frame` is a known symbol there) and gains a 0-arity ambient form for the server event.

## Why this shape (Option (a) from the bead)

The bead names two options: (a) fold a schema-registering event into `ssr-handler`'s `:initial-events`, relying on the ambient frame during the drain, or (b) flag it as an `ssr-ring` API gap. Option (a) is viable — `schemas.cljc`'s `resolve-frame` explicitly names "a frame `:initial-events` step" as a valid carried-invariant scope — so no `ssr-ring` API change was needed.

## Quality gates

- `tools/template/` `clojure -M:test` — **45 tests / 614 assertions, 0 failures, 0 errors** (before and after rebase onto `origin/main`).
- `clj-kondo --lint` on the modified real `.clj` file (`template_test.clj`) — 0 errors, 0 warnings.
- **End-to-end manual verification** (since the template's own suite only static-asserts the emitted scaffold's shape): generated a fresh `:include-ssr? true` scaffold via `run-template-opts!`, rewrote all `day8/re-frame2*` coords to `:local/root` against this branch's in-repo sources (including `re-frame.ssr` / `re-frame.ssr.ring`, which the existing `emitted_test_run_test.clj` harness doesn't rewrite since it only drives the CLJS compile tier), and ran the emitted `ssr_test.clj` for real with `clojure.test`:
  - **3 tests / 9 assertions, 0 failures, 0 errors** against the fixed source.
  - **Control check**: reverted `server-init-events` in the generated scaffold back to the pre-fix shape (`[[:rf/server-init]]`, no schema step) and reran — the new negative test correctly failed (`expected: (= 500 (:status resp)) actual: (not (= 500 200))`), confirming the test catches the exact regression rf2-hbobni describes. Restored the fix and confirmed green again.

## New test coverage

`_shared/ssr_test.clj` gains two tests that exercise the **real** `ssr-ring/ssr-handler` construction (mirroring `server.clj`'s `make-handler`) rather than the pre-existing hand-rolled `reg-frame` + `register-schema!` test, which bypasses this exact bug (per the bead's TEST GAP note — the hand-rolled test supplies its own known frame-id, which can't catch a regression in how the schema attaches on the `ssr-handler` path):

1. `ssr-handler-renders-through-the-real-production-path` — happy-path 200, proving the fix doesn't disturb normal rendering.
2. `ssr-handler-rejects-a-schema-violating-commit-on-the-real-path` — appends a test-only event that commits a key `CounterDb`'s `{:closed true}` map forbids; asserts the production path rejects it with 500, proving server-side validation is live.

`template_test.clj`'s static shape-assertion gains one line locking in `:ssr/register-schema`'s presence in the emitted `core.cljc`.

## Risks

- Low. Change is isolated to the SSR scaffold template body + its test coverage; no `implementation/` or `ssr-ring` API surface touched. The new event name (`:ssr/register-schema`) follows the existing `:ssr/client-bootstrap` convention from the canonical worked example (`examples/capabilities/ssr/ssr/core.cljc`) for app-owned SSR-adjacent setup events (not the framework-reserved `:rf/*` root).