### PR TITLE
fix(mcp-conformance): grade hermetic live-suite on child close not exit so a late-flushed conformant gate passes (rf2-6girz0)

### DIFF
--- a/tools/mcp-conformance/package.json
+++ b/tools/mcp-conformance/package.json
@@ -22,6 +22,7 @@
     "test:call-coverage-ratchet": "node --test test/call-coverage-ratchet.test.cjs",
     "test:classification-ratchet": "node --test test/classification-ratchet.test.cjs",
     "test:hermetic-setup-timeout": "node --test test/hermetic-setup-timeout.test.cjs",
+    "test:inner-test-close-grading": "node --test test/inner-test-close-grading.test.cjs",
     "test:port-file-escape": "node --test test/port-file-escape.test.cjs",
     "test:unit": "node scripts/test-unit.cjs",
     "test": "node scripts/test-all.cjs"

--- a/tools/mcp-conformance/scripts/run-re-frame2-pair-live-hermetic-suite.cjs
+++ b/tools/mcp-conformance/scripts/run-re-frame2-pair-live-hermetic-suite.cjs
@@ -352,6 +352,67 @@ function waitForChildExit(child, hasExited) {
   });
 }
 
+// Spawn one INNER_TESTS child and resolve once its stdio is fully drained
+// AND it has terminated. Lives at module scope, taking `spawnFn` as a
+// dependency, so the regression harness (`inner-test-close-grading.test.cjs`)
+// can drive the REAL grading logic against a fake child that reproduces the
+// write-then-exit race without spawning a real process.
+//
+// Grades on 'close', NOT 'exit' (rf2-6girz0). Node fires 'exit' as soon as
+// the child process itself terminates, which can race the stdio pipes
+// still draining into the `stdout`/`stderr` 'data' handlers below —
+// 'close' is the event Node guarantees fires only once stdout/stderr are
+// fully read. Every INNER_TESTS entry hits the worst case: its success
+// path is `console.log(sentinel)` immediately followed by
+// `process.exit(exitCode)` (write-then-exit, see `_runner.cjs`'s
+// `runWithWatchdog`), so a conformant, fully-passing child can have its
+// final sentinel-bearing stdout chunk arrive AFTER 'exit' fires — grading
+// on 'exit' would resolve with a truncated `stdoutText` and the caller's
+// sentinel check would then fail a gate that actually passed. 'close'
+// carries the same `(code, signal)` payload as 'exit', so this is a
+// like-for-like swap with no loss of signal-death detection.
+//
+// Resolves `{ code, stdoutText }` on a code-terminated exit (code
+// non-null); rejects on spawn error or signal-termination (code === null),
+// matching the pre-fix contract — only the event grading changed.
+function spawnAndGradeInnerTest({
+  spawnFn,
+  execPath,
+  testPath,
+  cwd,
+  env,
+  testFile,
+  onChunk,
+  log: logFn,
+}) {
+  return new Promise((resolve, reject) => {
+    let stdoutText = '';
+    const child = spawnFn(execPath, [testPath], {
+      cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env,
+    });
+    child.stdout.on('data', (d) => {
+      stdoutText += String(d);
+      onChunk(`[${testFile}:stdout] `, d);
+    });
+    child.stderr.on('data', (d) => onChunk(`[${testFile}:stderr] `, d, 'stderr'));
+    child.on('error', reject);
+    child.on('close', (code, signal) => {
+      // signal-terminated children report null exit codes; treat the
+      // signal as a non-zero status so the conformance gate fails loud
+      // rather than silently passing.
+      if (code === null) {
+        logFn(`${testFile} killed by ${signal}`);
+        reject(new Error(`${testFile} killed by ${signal}`));
+        return;
+      }
+      logFn(`${testFile} exited ${code}`);
+      resolve({ code, stdoutText });
+    });
+  });
+}
+
 // Build the idempotent async teardown. Lives at
 // module scope so the teardown regression harness
 // (`runner-cleanup.test.cjs`) can drive the REAL teardown logic against a
@@ -1159,34 +1220,17 @@ async function main() {
       log(`running ${testFile} - ${test.name}`);
       // Capture the inner test's stdout so we can assert it actually RAN
       // (printed its GREEN sentinel) — not merely exited 0 (a SKIP also
-      // exits 0).
-      let stdoutText = '';
-      const testStatus = await new Promise((resolve, reject) => {
-        const child = crossSpawn(process.execPath, [test.path], {
-          cwd: MCP_CONFORMANCE_ROOT,
-          stdio: ['ignore', 'pipe', 'pipe'],
-          env: testEnv,
-        });
-        child.stdout.on('data', (d) => {
-          stdoutText += String(d);
-          recordChunk(`[${testFile}:stdout] `, d);
-        });
-        child.stderr.on('data', (d) => recordChunk(`[${testFile}:stderr] `, d, 'stderr'));
-        child.on('error', reject);
-        child.on('exit', (code, signal) => {
-          // signal-terminated children report null exit codes; treat
-          // the signal as a non-zero status so the conformance gate
-          // fails loud rather than silently passing.
-          if (code === null) {
-            log(`${testFile} killed by ${signal}`);
-            reject(new Error(
-              `${path.basename(test.path)} killed by ${signal}`,
-            ));
-            return;
-          }
-          log(`${testFile} exited ${code}`);
-          resolve(code);
-        });
+      // exits 0). Grading happens on 'close' — see
+      // `spawnAndGradeInnerTest` (rf2-6girz0).
+      const { code: testStatus, stdoutText } = await spawnAndGradeInnerTest({
+        spawnFn: crossSpawn,
+        execPath: process.execPath,
+        testPath: test.path,
+        cwd: MCP_CONFORMANCE_ROOT,
+        env: testEnv,
+        testFile,
+        onChunk: recordChunk,
+        log,
       });
       if (testStatus !== 0) {
         // Surface the inner test's exit code verbatim so CI sees a
@@ -1334,6 +1378,13 @@ if (require.main === module) {
 // slow-exiting fake child, proving the awaited browser-close + the
 // SIGTERM→exit→SIGKILL escalation are WAITED for (or hard-capped), never
 // fire-and-forgotten.
+//
+// `spawnAndGradeInnerTest` is exported for the close-vs-exit grading
+// regression harness (`inner-test-close-grading.test.cjs`, rf2-6girz0): it
+// drives the REAL grading logic against a fake `spawnFn` whose child emits
+// its sentinel-bearing stdout `data` AFTER `exit` but BEFORE `close`,
+// proving the harness reads the fully-drained stdout (via `close`) rather
+// than scoring a conformant, late-flushing child as failed.
 module.exports = {
   runTrusted,
   SETUP_COMMAND_TIMEOUT_MS,
@@ -1342,4 +1393,5 @@ module.exports = {
   makeCleanup,
   settledWithin,
   waitForChildExit,
+  spawnAndGradeInnerTest,
 };

--- a/tools/mcp-conformance/scripts/test-all.cjs
+++ b/tools/mcp-conformance/scripts/test-all.cjs
@@ -58,6 +58,10 @@ const TESTS = [
     argv: ['--test', 'test/hermetic-setup-timeout.test.cjs'],
   },
   {
+    name: 'hermetic INNER_TESTS grading on close, not exit (rf2-6girz0)',
+    argv: ['--test', 'test/inner-test-close-grading.test.cjs'],
+  },
+  {
     name: 'hermetic port-file escape refusal (rf2-khav7l)',
     argv: ['--test', 'test/port-file-escape.test.cjs'],
   },

--- a/tools/mcp-conformance/test/inner-test-close-grading.test.cjs
+++ b/tools/mcp-conformance/test/inner-test-close-grading.test.cjs
@@ -1,0 +1,225 @@
+// Regression test for the hermetic live-suite's INNER_TESTS grading event
+// (rf2-6girz0).
+//
+// Uses Node's built-in `node:test` (same posture as
+// `runner-cleanup.test.cjs` / `runner-watchdog.test.cjs` — no extra
+// dev-dependency). Runs in-process: it requires the orchestrator AS A
+// MODULE (the auto-run is guarded behind `require.main === module`, so
+// requiring it does NOT boot shadow-cljs / Chromium) and drives the
+// exported `spawnAndGradeInnerTest` factory against a FAKE `spawnFn` — no
+// real child process, no real stdio pipe.
+//
+// ## The bug this pins
+//
+// The hermetic orchestrator's INNER_TESTS loop used to grade each spawned
+// inner test on the child's 'exit' event, then read the stdout it had
+// captured so far to check for the test's GREEN sentinel. Node's own docs
+// note that 'exit' fires as soon as the child process itself terminates,
+// which can race the stdio pipes still draining into the parent's 'data'
+// handlers — 'close' is the event Node guarantees fires only once
+// stdout/stderr are fully read. Every INNER_TESTS entry hits the worst
+// case: `_runner.cjs`'s success path is `console.log(sentinel)`
+// immediately followed by `process.exit(exitCode)` — the sentinel is the
+// very last write before the process tears down, a write-then-exit shape
+// that is worse on Windows (where `process.exit()` can truncate
+// not-yet-flushed pipe writes). Grading on 'exit' meant a genuinely
+// conformant, fully-passing inner gate could have its final
+// sentinel-bearing stdout chunk arrive AFTER grading already ran against a
+// truncated `stdoutText` — scoring a PASSING gate as FAILED and blocking
+// merge for a server that actually passed.
+//
+// FIX: grade on 'close' instead of 'exit' (same `(code, signal)` payload,
+// fires only after stdio is fully drained).
+//
+// ## What this test drives
+//
+// It requires the orchestrator as a module and exercises the exported
+// `spawnAndGradeInnerTest` factory against fakes:
+//
+//   1. A fake child that emits its sentinel-bearing stdout chunk AFTER
+//      'exit' but BEFORE 'close' — the exact race rf2-6girz0 describes.
+//      Proves the graded `stdoutText` contains the late-arriving sentinel
+//      (would have been truncated under the old 'exit'-based grading).
+//   2. A fake child that emits 'exit' alone (no 'close' yet) — proves the
+//      grading promise does NOT resolve on 'exit' alone; it only resolves
+//      once 'close' fires.
+//   3. A fake child that exits non-zero — proves a genuinely failing
+//      child's exit code is still surfaced faithfully after the fix.
+//   4. A fake child that exits 0 but never prints the sentinel (a
+//      "silently non-conformant" child, as opposed to a merely
+//      late-flushing one) — proves the graded stdout still lacks the
+//      sentinel, so the caller's sentinel-check in `main()`'s INNER_TESTS
+//      loop still fails it. The close-grading fix reads MORE of a child's
+//      stdout, but does not turn the sentinel gate into a rubber stamp.
+//   5. A fake child killed by a signal (code === null) — proves the
+//      reject-on-signal contract is unchanged by the close/exit swap.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const path = require('node:path');
+
+const ORCH = path.join(
+  __dirname,
+  '..',
+  'scripts',
+  'run-re-frame2-pair-live-hermetic-suite.cjs',
+);
+
+const { spawnAndGradeInnerTest } = require(ORCH);
+
+const SENTINEL = 'GREEN example-inner-test-sentinel';
+
+// A fake child_process.ChildProcess: an EventEmitter standing in for the
+// process itself, with `.stdout` / `.stderr` EventEmitters standing in for
+// the piped streams `spawnAndGradeInnerTest` attaches 'data' handlers to.
+function makeFakeChild() {
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  return child;
+}
+
+function grade(spawnFn, onChunk) {
+  return spawnAndGradeInnerTest({
+    spawnFn,
+    execPath: 'node',
+    testPath: 'fake-inner-test.cjs',
+    cwd: '.',
+    env: {},
+    testFile: 'fake-inner-test.cjs',
+    onChunk: onChunk || (() => {}),
+    log: () => {},
+  });
+}
+
+test('spawnAndGradeInnerTest reads a late-arriving sentinel chunk that lands AFTER exit but BEFORE close (rf2-6girz0)', async () => {
+  const child = makeFakeChild();
+  let exitFiredAt = null;
+  let dataFiredAt = null;
+
+  const spawnFn = () => {
+    // Model `_runner.cjs`'s write-then-exit success path under the
+    // worst-case pipe-drain race: 'exit' fires, THEN the sentinel-bearing
+    // stdout chunk arrives, THEN 'close' fires once stdio is fully read.
+    setImmediate(() => {
+      exitFiredAt = Date.now();
+      child.emit('exit', 0, null);
+      setImmediate(() => {
+        dataFiredAt = Date.now();
+        child.stdout.emit('data', Buffer.from(`${SENTINEL}\n`));
+        setImmediate(() => child.emit('close', 0, null));
+      });
+    });
+    return child;
+  };
+
+  const result = await grade(spawnFn);
+
+  assert.ok(
+    dataFiredAt >= exitFiredAt,
+    'test fixture invariant broken: the sentinel chunk must arrive at/after ' +
+      "exit to model the race — otherwise this test doesn't exercise the bug",
+  );
+  assert.equal(result.code, 0);
+  assert.ok(
+    result.stdoutText.includes(SENTINEL),
+    'grading on close should have captured the late-arriving sentinel chunk; ' +
+      'stdoutText was: ' + JSON.stringify(result.stdoutText),
+  );
+});
+
+test('spawnAndGradeInnerTest does NOT resolve on exit alone — it waits for close', async () => {
+  const child = makeFakeChild();
+  let resolved = false;
+
+  const spawnFn = () => {
+    setImmediate(() => child.emit('exit', 0, null));
+    return child;
+  };
+
+  const p = grade(spawnFn).then((result) => {
+    resolved = true;
+    return result;
+  });
+
+  // Give 'exit' plenty of room to fire and (if grading were still keyed to
+  // 'exit') resolve the promise.
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  assert.equal(
+    resolved,
+    false,
+    "grading resolved on 'exit' alone, before 'close' fired — this is the " +
+      'exact pre-fix behaviour rf2-6girz0 reports',
+  );
+
+  child.emit('close', 0, null);
+  const result = await p;
+  assert.equal(resolved, true);
+  assert.equal(result.code, 0);
+});
+
+test('spawnAndGradeInnerTest still fails a genuinely non-conformant child that exits non-zero', async () => {
+  const child = makeFakeChild();
+
+  const spawnFn = () => {
+    setImmediate(() => {
+      child.stdout.emit('data', Buffer.from('ran, but the gate itself failed\n'));
+      child.emit('exit', 1, null);
+      setImmediate(() => child.emit('close', 1, null));
+    });
+    return child;
+  };
+
+  const result = await grade(spawnFn);
+
+  assert.equal(
+    result.code,
+    1,
+    'a genuinely failing inner test must still surface its non-zero exit ' +
+      'code after the close-grading fix',
+  );
+});
+
+test('spawnAndGradeInnerTest still surfaces a sentinel-less stdout for a silently non-conformant child (exit 0, sentinel never printed)', async () => {
+  const child = makeFakeChild();
+
+  const spawnFn = () => {
+    setImmediate(() => {
+      child.stdout.emit('data', Buffer.from('exited clean but forgot to print the sentinel\n'));
+      child.emit('exit', 0, null);
+      setImmediate(() => child.emit('close', 0, null));
+    });
+    return child;
+  };
+
+  const result = await grade(spawnFn);
+
+  assert.equal(result.code, 0);
+  // Reproduce the orchestrator's own sentinel gate (see `main()`'s
+  // INNER_TESTS loop in the orchestrator) against the graded stdout: the
+  // close-grading fix reads MORE of a child's stdout than the old
+  // exit-based grading, but it must not turn the sentinel check into a
+  // rubber stamp — a child that never actually prints its sentinel, even
+  // once its stdio is fully drained, is still distinguishable as failed.
+  assert.ok(
+    !result.stdoutText.includes(SENTINEL),
+    'fixture invariant broken: this child must not have printed the sentinel',
+  );
+});
+
+test('spawnAndGradeInnerTest still rejects a signal-killed child (code === null) after the close-grading fix', async () => {
+  const child = makeFakeChild();
+
+  const spawnFn = () => {
+    setImmediate(() => {
+      child.emit('exit', null, 'SIGKILL');
+      setImmediate(() => child.emit('close', null, 'SIGKILL'));
+    });
+    return child;
+  };
+
+  await assert.rejects(() => grade(spawnFn), /killed by SIGKILL/);
+});


### PR DESCRIPTION
## Problem

`run-re-frame2-pair-live-hermetic-suite.cjs`'s INNER_TESTS loop graded each spawned inner test on the child process's `'exit'` event, then read the stdout captured so far to check for the test's GREEN sentinel. Node's docs note `'exit'` fires as soon as the child process itself terminates, which can race the stdio pipes still draining into the parent's `'data'` handlers — `'close'` is the event Node guarantees fires only once stdout/stderr are fully read.

Every `INNER_TESTS` entry hits the worst-case shape: `_runner.cjs`'s success path is `console.log(sentinel-line)` immediately followed by `process.exit(exitCode)` — the sentinel is the very last write before the process tears down (worse on Windows, where `process.exit()` can truncate not-yet-flushed pipe writes). A genuinely conformant, fully-passing inner gate could have its final sentinel-bearing stdout chunk arrive *after* `'exit'` already resolved the grading promise, so the sentinel check ran against a truncated `stdoutText` — scoring a **passing** gate as **failed** and blocking merge for a server that actually passed.

## Fix

Extracted the spawn+grade logic into a standalone `spawnAndGradeInnerTest(...)` function and switched its terminal event from `'exit'` to `'close'` (same `(code, signal)` payload, fires only once stdio is drained — a like-for-like swap with no loss of signal-death detection). `main()`'s INNER_TESTS loop now calls this function instead of inlining the promise.

The extraction follows the same pattern already used for `makeCleanup` / `runTrusted` / `waitForChildExit` in this file: a `spawnFn`-injectable, module-scope function that a fake-child regression test can drive without booting a real process.

## Regression test

New `tools/mcp-conformance/test/inner-test-close-grading.test.cjs` drives `spawnAndGradeInnerTest` against a fake `spawnFn`/child (`node:events` `EventEmitter`, no real process) covering:

1. **The exact rf2-6girz0 race** — a child whose sentinel-bearing stdout chunk arrives *after* `'exit'` but *before* `'close'`: proves the graded `stdoutText` contains the late-arriving sentinel.
2. The grading promise does **not** resolve on `'exit'` alone — it waits for `'close'`.
3. A genuinely non-conformant child (non-zero exit) is still failed.
4. A "silently non-conformant" child (exit 0, sentinel never printed even after `'close'`) still surfaces sentinel-less stdout — the close-grading fix reads more stdout, it doesn't become a rubber stamp.
5. A signal-killed child (`code === null`) still rejects — contract unchanged.

Registered in `scripts/test-all.cjs`'s `TESTS` inventory (so `scripts/test-unit.cjs` / PR CI picks it up automatically) and given its own `npm run test:inner-test-close-grading` script for parity with the other `--test` unit gates.

### Proof: the harness now passes a conformant-but-late-flushing child, and still fails a non-conformant one

Verified by A/B: temporarily reverted `spawnAndGradeInnerTest`'s terminal event back to `'exit'` (a throwaway local copy, not committed) and re-ran the exact same regression file against it:

- **Pre-fix (`'exit'`-based grading):** 2 of 5 tests fail — the "late-arriving sentinel" test fails its own fixture invariant (the promise resolved and returned *before* the sentinel data even arrived), and the "does not resolve on exit alone" test fails because the promise **did** resolve on `'exit'` alone. This reproduces the exact false-negative the bead describes.
- **Post-fix (`'close'`-based grading):** all 5 tests pass — the late-flushing conformant child is read correctly, and the non-conformant / silently-non-conformant / signal-killed children are still correctly failed.

## Quality gates

- `node -c scripts/run-re-frame2-pair-live-hermetic-suite.cjs` — syntax OK.
- `node --test test/inner-test-close-grading.test.cjs` — 5/5 pass.
- `node scripts/test-unit.cjs` (the mcp-conformance Node unit-regression cluster, the same gate `mcp-conformance-re-frame2-pair` CI job runs via `npm run test:unit`) — **54 pass, 0 fail, 9 skip** (skips are pre-existing Windows symlink-privilege skips, unrelated to this change).
- `npm test` (`scripts/test-all.cjs`) locally: the unit cluster + the JS-only conformance suites all pass; the `re-frame2-pair-mcp end-to-end` row fails locally only because `tools/re-frame2-pair-mcp`'s shadow-cljs bundle isn't pre-built in this environment (CI builds it via `npx shadow-cljs compile server` before this step) — a pre-existing environmental gap unrelated to this fix, not a regression.
- The hermetic suite itself (`run-re-frame2-pair-live-hermetic-suite.cjs`) is not part of `test-all.cjs`'s inventory — it runs as its own CI job (`mcp-conformance-re-frame2-pair`, `npm run test:re-frame2-pair-live-hermetic-suite`) requiring a pre-built shadow-cljs bundle + Chromium, mirroring why `makeCleanup`/`runTrusted`/`waitForChildExit` are also validated via extracted-function + fake-child unit tests rather than full end-to-end runs.

## Risk

Isolated to `tools/mcp-conformance/`; pure refactor of the grading event plus a new test file. No change to any spec surface, hot-zone file, or other artefact.