### PR TITLE
fix(mcp-base): re-sort coalesced sections by :section-path to honor the Ordering contract (rf2-8y5pen)

### DIFF
--- a/tools/mcp-base/src/re_frame/mcp_base/section_grouping.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/section_grouping.cljc
@@ -369,14 +369,27 @@
 
        :else
        (let [sorted   (vec (sort-by #(pr-str (patch-path %)) patches))
-             clusters (group-by-ancestor sorted max-coalesce-depth)]
-         (mapv (fn [cluster]
-                 (let [{:keys [prefix patches]} (promote-singleton cluster)]
-                   {:section-path prefix
-                    :section-kind (section-kind prefix patches
-                                                (container-existed? prefix))
-                    :patches      patches}))
-               clusters))))))
+             clusters (group-by-ancestor sorted max-coalesce-depth)
+             sections (mapv (fn [cluster]
+                               (let [{:keys [prefix patches]} (promote-singleton cluster)]
+                                 {:section-path prefix
+                                  :section-kind (section-kind prefix patches
+                                                              (container-existed? prefix))
+                                  :patches      patches}))
+                             clusters)]
+         ;; Coalescing (`group-by-ancestor`) and singleton-promotion both
+         ;; NARROW a cluster's prefix to a shorter ancestor path — which
+         ;; changes its sort key. `pr-str` of a vector closes with `]`
+         ;; (char 93) but separates elements with a space (char 32), so
+         ;; an ancestor's `pr-str` always sorts AFTER its own descendants
+         ;; — e.g. `(compare (pr-str [:cart]) (pr-str [:cart-items]))` is
+         ;; positive. The walk-order sort above is only a determinism aid
+         ;; for the coalescence pass; it does NOT double as the final
+         ;; section order once prefixes have moved. Re-sort by the
+         ;; resulting `:section-path` so the contract in §Ordering
+         ;; (`spec/section-grouping.md`) — sections sort by `:section-path`,
+         ;; lexicographic `pr-str`-keyed — holds post-coalescing too.
+         (vec (sort-by #(pr-str (:section-path %)) sections)))))))
 
 ;; ---- decoder helper ----------------------------------------------------
 

--- a/tools/mcp-base/test/re_frame/mcp_base/section_grouping_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/section_grouping_test.clj
@@ -264,3 +264,52 @@
     (is (= (mapv :section-path sections-a)
            (mapv :section-path sections-b))
         "input order doesn't alter section order — the sort makes it stable")))
+
+(deftest sections-are-sorted-ascending-by-final-section-path
+  ;; rf2-8y5pen: the initial sort keys patches by their FULL path, but
+  ;; coalescing (`group-by-ancestor`) and singleton-promotion both
+  ;; NARROW a cluster's prefix to a shorter common-ancestor path —
+  ;; changing its sort key. `pr-str` of a vector closes with `]` (char
+  ;; 93) but separates elements with a space (char 32), so an
+  ;; ancestor's `pr-str` is ALWAYS greater than its own descendants':
+  ;; `(pr-str [:cart])` > `(pr-str [:cart-items])` even though
+  ;; `:cart` < `:cart-items` as keywords. A walk-order-only sort (never
+  ;; re-deriving order post-coalescing) can therefore emit sections
+  ;; out of the documented ascending order. This test asserts the
+  ;; FINAL output is always ascending by `(pr-str :section-path)` —
+  ;; the §Ordering contract in `spec/section-grouping.md` — not merely
+  ;; stable across input-order permutations (the older test above).
+  (testing "bead repro: [:cart] (narrowed ancestor) vs [:cart-summary] (untouched sibling)"
+    ;; {:cart {:qty 1} :cart-summary old} -> {:cart {:qty 5} :cart-summary new}.
+    ;; [:cart :qty] promotes (singleton, depth > 1) to the [:cart]
+    ;; ancestor; [:cart-summary] is an untouched top-level singleton.
+    ;; Sorted by full path pre-coalescing, [:cart ...] < [:cart-summary]
+    ;; (matching keyword order) — the walk-order-only bug preserved
+    ;; that ordering into the output. But post-promotion the KEYS
+    ;; being compared are [:cart] vs [:cart-summary], and
+    ;; `(pr-str [:cart])` = "[:cart]" > `(pr-str [:cart-summary])` =
+    ;; "[:cart-summary]" because `]` (93) > `-` (45) at the
+    ;; first point of difference right after the shared "[:cart"
+    ;; prefix. The contract requires [:cart-summary] first.
+    (let [patches  [[[:cart :qty] :assoc 5]
+                    [[:cart-summary] :assoc :new]]
+          sections (sg/group-patches-into-sections patches)
+          paths    (mapv :section-path sections)]
+      (is (= [:cart] (:section-path (first (filter #(= [:cart] (:section-path %)) sections))))
+          "sanity: [:cart :qty] promotes to the [:cart] ancestor")
+      (is (= [[:cart-summary] [:cart]] paths)
+          "ancestor [:cart] sorts AFTER [:cart-summary] by pr-str, even though it was
+           walked first — the contract order, not the walk order")))
+  (testing "general property: output section-paths are ascending by pr-str, regardless of input order"
+    (let [patches [[[:cart :qty] :assoc 5]
+                   [[:cart-summary] :assoc :new]
+                   [[:a :b :c] :assoc 1]
+                   [[:ab] :assoc 2]
+                   [[:flash] :assoc "Saved"]]]
+      (doseq [ordering (list patches
+                             (vec (reverse patches))
+                             (shuffle patches))]
+        (let [sections (sg/group-patches-into-sections ordering)
+              paths    (mapv (comp pr-str :section-path) sections)]
+          (is (= (sort paths) paths)
+              (str "sections must be ascending by (pr-str :section-path); got " paths)))))))


### PR DESCRIPTION
## Summary

`group-patches-into-sections` (`tools/mcp-base/src/re_frame/mcp_base/section_grouping.cljc`) sorted patches by their **full** path (`(pr-str (patch-path %))`) before coalescing, then `group-by-ancestor` narrows a cluster's prefix to a shorter common-ancestor path (and singleton-promotion narrows singleton clusters to their parent). The final `mapv` emitted sections in that original walk order and never re-sorted by the *resulting* `:section-path`.

Because `pr-str` of a vector closes with `]` (char 93) but separates elements with a space (char 32), an ancestor path's `pr-str` is **always** greater than its own descendants' — e.g. `(compare (pr-str [:cart]) (pr-str [:cart-items]))` is positive. So a coalesced-to-ancestor section's sort key silently changes after coalescing, but the output order was never re-derived — violating `spec/section-grouping.md` §Ordering ("Sections sort by `:section-path` (lexicographic, `pr-str`-keyed)").

**Repro (from the bead):** diffing `{:cart {:qty 1} :cart-summary :old}` → `{:cart {:qty 5} :cart-summary :new}` produced `:sections` paths `[[:cart] [:cart-summary]]`; the contract requires `[[:cart-summary] [:cart]]`.

## Fix

Re-sort the final `sections` vector by `(pr-str (:section-path %))` **after** coalescing/promotion, so the emitted order always reflects the narrowed paths rather than the pre-coalescing walk order.

## Spec check

`tools/mcp-base/spec/section-grouping.md` §Ordering already documents the correct contract ("Sections sort by `:section-path` ... stable across re-renders"). The bug was code not matching the doc — the fix makes the code conform. **No doc changes needed/made.**

## Test

Added `sections-are-sorted-ascending-by-final-section-path` to `tools/mcp-base/test/re_frame/mcp_base/section_grouping_test.clj`:
- Reproduces the bead's exact `[:cart]` (narrowed ancestor via singleton-promotion) vs `[:cart-summary]` (untouched sibling) case and asserts the contract order `[[:cart-summary] [:cart]]`.
- A general property check over multiple input orderings (original / reversed / shuffled) asserting the output is always ascending by `(pr-str :section-path)`.

This closes the test gap the bead flagged: the pre-existing `section-order-is-deterministic-across-input-orders` test only asserted the SAME relative order across input permutations, never that the order was actually ascending by the final path.

## Quality gates

- `clojure -M:test` from `tools/mcp-base/`: **249 tests, 840 assertions, 0 failures, 0 errors** (includes the new regression test).
- Manually re-ran the bead's exact repro against the fixed code — confirmed output is now `[[:cart-summary] [:cart]]`.
- Scope: touched only `tools/mcp-base/src/re_frame/mcp_base/section_grouping.cljc` and its test file. No hot-zone files touched. `tools/mcp-conformance` (a separate concurrent worker's surface) was not touched or run — flagging as a downstream consumer of mcp-base that may want to re-verify, but out of scope for this fix.

## Risk

Low. Fix only affects the final output *order* of sections; `:section-path`, `:section-kind`, and `:patches` per section are unchanged, and `sections->patches` (the round-trip inverse) is order-insensitive at the section level already (it just concats `:patches`). No behavioural change other than correcting order to match the documented contract.