### PR TITLE
fix(examples): session-restore decode-failure + SSR blocking preload + realworld article-cache invalidation (rf2-rbl4kw/u64kc8/pug8zj)

### DIFF
--- a/examples/capabilities/ssr/resources_ssr/README.md
+++ b/examples/capabilities/ssr/resources_ssr/README.md
@@ -61,10 +61,15 @@ per-request, and the wire payload stays minimal.
   resource under an `[:ssr request-id nav-token]`
   [owner](../../../../docs/resources/glossary.md#owner--cause) with
   [cause](../../../../docs/resources/glossary.md#owner--cause)
-  `:ssr-preload`. Then `handle-request` calls
-  `ssr/drain-blocking-resources!` to **wait** for that ensure to settle —
-  reach `:loaded`, or time out into a structured first-load failure —
-  before the render runs. The
+  `:ssr-preload`. This page has no route table at all — the simplest
+  possible SSR shape — so `handle-request` can't reach for the framework's
+  `ssr/drain-blocking-resources!`: that drain is ROUTE-blocking-keyed, it
+  waits only on resources a `reg-route` on-route-entry plan enqueued for the
+  current nav-token, and a route-free `[:ssr …]`-owned ensure never
+  registers there. Instead `handle-request` calls `await-resource-loaded!`
+  (defined alongside it), which polls the resource's own runtime entry
+  directly via the public `rf/resource-state` introspection read until it
+  reaches `:loaded` / `:error`, or a render-deadline budget elapses. The
   [view](../../../../docs/core/glossary.md#view) reads through the passive
   `[:rf.resource/state …]`
   [subscription](../../../../docs/core/glossary.md#subscription), and by the
@@ -115,7 +120,7 @@ per-request, and the wire payload stays minimal.
   explicit, checkable statement that this handoff is safe.
 
 The SSR-resource runtime is **real**: `handle-request` drives the actual
-server path, not a skeleton stand-in. The blocking drain, the per-entry
+server path, not a skeleton stand-in. The blocking poll, the per-entry
 projection (redaction / omission / scoped-key privacy / index omission),
 and the client hydration reconcile + refetch plan all run end-to-end.
 

--- a/examples/capabilities/ssr/resources_ssr/core.cljc
+++ b/examples/capabilities/ssr/resources_ssr/core.cljc
@@ -29,13 +29,27 @@
      immediately and serves from cache. Stale, redacted, or omitted entries
      refetch — because for those the client has nothing usable in hand.
 
-   This drives the real server path, not a stand-in. It drains the blocking
-   page resource before rendering (`ssr/drain-blocking-resources!`) and ships
-   only the allowed runtime-db projection (`payload-policy/project-runtime-db`)
-   under `:rf/runtime-db` — never the full cache. The `:rf/app-db` slice goes
-   through the same fail-closed allowlist (`apply-policy`) the production Ring
-   host uses. The static `index.html` next to this file carries a pre-baked payload
-   so the browser side runs without a Clojure server in the box.
+   This drives the real server path, not a stand-in. It blocks on the
+   preloaded page resource before rendering (`await-resource-loaded!`,
+   server entry point below) and ships only the allowed runtime-db
+   projection (`payload-policy/project-runtime-db`) under `:rf/runtime-db` —
+   never the full cache. The `:rf/app-db` slice goes through the same
+   fail-closed allowlist (`apply-policy`) the production Ring host uses. The
+   static `index.html` next to this file carries a pre-baked payload so the
+   browser side runs without a Clojure server in the box.
+
+   One wrinkle worth calling out: this page has no route table (no
+   `reg-route`, no router install) — it renders unconditionally, the
+   simplest possible SSR shape. The framework's own SSR blocking-drain
+   (`re-frame.ssr/drain-blocking-resources!`) is ROUTE-blocking-keyed — it
+   waits only on resources a `reg-route` on-route-entry plan enqueued for
+   the current nav-token, so on a route-free page it has nothing to read and
+   returns settled immediately without ever looking at `:articles/list`.
+   There is no non-route blocking-drain surface to reach for instead (Spec
+   016 §SSR and hydration ties blocking to the route resource plan), so this
+   example polls the one resource it cares about directly via the public
+   `rf/resource-state` introspection read — see `await-resource-loaded!`
+   below.
 
    For the full picture see [Resources: SSR and hydration](../../../docs/resources/concepts.md#ssr-and-hydration)
    and [Server-side rendering](../../../docs/ssr/concepts.md).
@@ -162,22 +176,77 @@
   [(rf/view :pages/articles)])
 
 ;; ============================================================================
+;; DIRECT RESOURCE-PRELOAD POLL (route-free — no `reg-route` in this example)
+;; ============================================================================
+;;
+;; The framework's `ssr/drain-blocking-resources!` is ROUTE-blocking-keyed:
+;; it drains only the resources a `reg-route` on-route-entry plan enqueued
+;; for the CURRENT nav-token (`[:rf.runtime/routing :resource-blocking
+;; <nav-token>]`, written by the routing artefact). This page has no route
+;; table at all — see the ns docstring — so the `[:ssr request-id nav-token]`
+;; owner `:rf/server-init` ensures under never registers there, and
+;; `drain-blocking-resources!` would return `{:settled? true}` immediately,
+;; whether or not `:articles/list` had actually resolved (this is the bug
+;; this example previously shipped — rf2-u64kc8).
+;;
+;; For a route-free SSR page there is no non-route blocking-drain surface to
+;; reach for instead (Spec 016 §SSR and hydration ties blocking to the route
+;; resource plan). So `await-resource-loaded!` polls the ONE resource this
+;; page cares about directly, via the public `rf/resource-state`
+;; introspection read — the same bounded-yield-then-recheck shape the
+;; framework's own drain loop uses internally (`re-frame.ssr`'s
+;; `default-blocking-pump!`), just keyed on a single scoped resource instead
+;; of a route's blocking set. Unlike the framework's route-blocking-timeout
+;; policy, a deadline here does not settle the entry to a structured
+;; first-load failure — it simply stops waiting and lets the render proceed
+;; with whatever status the entry is already in.
+
+#?(:clj
+   (def ^:private preload-deadline-ms
+     "Wall-clock render-deadline budget for `await-resource-loaded!` —
+      mirrors the framework's own SSR blocking-drain default
+      (`re-frame.ssr`'s `default-ssr-blocking-timeout-ms`)."
+     5000))
+
+#?(:clj
+   (defn- await-resource-loaded!
+     "Poll a resource's runtime entry (`rf/resource-state`) until its
+      `:status` reaches a terminal `:loaded` / `:error`, or
+      `preload-deadline-ms` elapses. Yields the JVM thread between checks
+      (`Thread/sleep`) so the managed-HTTP transport's async reply lands and
+      its reply event dispatches — the JVM transport issues requests via
+      `HttpClient/sendAsync`, so nothing settles the entry synchronously
+      inside the `:rf.resource/ensure` dispatch itself."
+     [{:keys [resource scope params frame]}]
+     (let [deadline (+ (System/currentTimeMillis) preload-deadline-ms)]
+       (loop []
+         (let [entry (rf/resource-state {:resource resource :scope scope
+                                          :params params :frame frame})]
+           (if (or (contains? #{:loaded :error} (:status entry))
+                   (>= (System/currentTimeMillis) deadline))
+             entry
+             (do (Thread/sleep 5)
+                 (recur))))))))
+
+;; ============================================================================
 ;; SERVER ENTRY POINT
 ;; ============================================================================
 ;;
 ;; This is one request, start to finish: mint a per-request frame whose
-;; `:initial-events` fire `:rf/server-init`, drain the blocking page resource,
-;; render to a string, and build a hydration payload carrying the allowed
-;; resource projection under `:rf/runtime-db`. The frame is torn down in a
-;; `finally` on every exit path — success or throw — so a request can never
-;; leak a frame and slowly drown the JVM.
+;; `:initial-events` fire `:rf/server-init`, block on the preloaded page
+;; resource, render to a string, and build a hydration payload carrying the
+;; allowed resource projection under `:rf/runtime-db`. The frame is torn
+;; down in a `finally` on every exit path — success or throw — so a request
+;; can never leak a frame and slowly drown the JVM.
 ;;
 ;; Two steps are what make this the real server path rather than a toy:
 ;;
-;;   1. `ssr/drain-blocking-resources!` waits for the `[:ssr …]`-owned ensure to
-;;      settle — reach `:loaded`, or time out into a structured first-load
-;;      failure — before we walk the tree. So the render never catches the page
-;;      mid-fetch with a `:loading` skeleton frozen into the HTML.
+;;   1. `await-resource-loaded!` waits for the `[:ssr …]`-owned ensure to
+;;      settle — reach `:loaded` / `:error` — before we walk the tree. So
+;;      the render never catches the page mid-fetch with a `:loading`
+;;      skeleton frozen into the HTML. See the DIRECT RESOURCE-PRELOAD POLL
+;;      section above for why this page polls directly instead of calling
+;;      `ssr/drain-blocking-resources!`.
 ;;   2. `payload-policy/project-runtime-db` boils the runtime-db down to just
 ;;      what's safe to serialize: the durable `:rf.runtime/resources`
 ;;      `:entries`, with `:sensitive?` values redacted, `:large?` values
@@ -200,10 +269,12 @@
          (rf/with-frame f
            ;; (1) Settle the blocking page resource before we render a thing.
            ;; The `[:ssr …]`-owned ensure that `:rf/server-init` kicked off has
-           ;; to land on a terminal status (:loaded / :error), or time out into
-           ;; a settled first-load failure, so the render walk works with real
-           ;; data instead of an in-flight guess.
-           (ssr/drain-blocking-resources! f)
+           ;; to land on a terminal status (:loaded / :error) before the render
+           ;; walk works with real data instead of an in-flight guess.
+           (await-resource-loaded! {:resource :articles/list
+                                     :scope    :rf.scope/global
+                                     :params   {}
+                                     :frame    f})
            (let [final-db      (rf/app-db-value f)
                  final-runtime (rf/runtime-db-value f)   ;; this is where :rf.runtime/resources lives
                  hiccup        ((rf/view :app/root))

--- a/examples/real-apps/realworld_http/core.cljs
+++ b/examples/real-apps/realworld_http/core.cljs
@@ -389,13 +389,20 @@
       (and (= method :post) (str/ends-with? u "/users"))
       {:user demo-user}
 
-      ;; GET /user — session restore on boot. We return an empty payload on
-      ;; purpose: it fails the schema decode, drops into the failure branch,
-      ;; and the auth machine settles back to :idle. Net effect — the demo
-      ;; always opens logged-out, so you get to click "Sign in" and watch the
-      ;; flow rather than arriving mysteriously authenticated.
+      ;; GET /user — session restore on boot. We deliberately synthesise a
+      ;; DECODE FAILURE (not a success with an empty body): a real backend
+      ;; returning `{}` would fail `:decode schema/UserResponse`'s schema
+      ;; validation, and `:begin-restore`'s `:on-failure` would fire. The
+      ;; canned-success stub never runs `:decode`, though — an empty-map
+      ;; *success* reply would land in `:on-success` instead, taking the auth
+      ;; machine to `:authed` with a nil `:user` (a broken, half-authenticated
+      ;; state). Routing this through `:rf.http/managed-canned-failure` (see
+      ;; the `::decode-failure` sentinel below) reproduces the real failure
+      ;; path. Net effect — the demo always opens logged-out, so you get to
+      ;; click "Sign in" and watch the flow rather than arriving mysteriously
+      ;; (and brokenly) authenticated.
       (and (= method :get) (str/ends-with? u "/user"))
-      {}
+      ::decode-failure
 
       ;; POST /articles/:slug/comments — synthesise the saved Comment
       ;; the optimistic submit path expects.
@@ -439,12 +446,26 @@
                then defers the reply via `:dispatch-later`, so it shows up in
                the trace and survives time-travel instead of being a raw
                `js/setTimeout`. The little delay is what makes the `:loading`
-               state actually visible."
+               state actually visible.
+
+               `demo-payload-for-args` signals a genuine failure (rather than
+               a payload) with the `::decode-failure` sentinel — GET /user's
+               session-restore stub is the one route the demo wants to FAIL,
+               so it delegates to `:rf.http/managed-canned-failure` instead of
+               `-success`. `:rf.http/managed-canned-success` never runs
+               `:decode`, so handing it an empty body would incorrectly land
+               on the `:on-success` branch."
    :platforms #{:server :client}}
   (fn fx-managed-demo-stub [frame-ctx args-map]
-    (let [payload (demo-payload-for-args args-map)
-          stub    (registrar/handler :fx :rf.http/managed-canned-success)]
-      (stub frame-ctx (assoc args-map :after-ms demo-reply-delay-ms :value payload)))))
+    (let [payload (demo-payload-for-args args-map)]
+      (if (= ::decode-failure payload)
+        (let [stub (registrar/handler :fx :rf.http/managed-canned-failure)]
+          (stub frame-ctx (assoc args-map
+                                  :after-ms demo-reply-delay-ms
+                                  :kind     :rf.http/decode-failure
+                                  :tags     {:schema-validation-failure? true})))
+        (let [stub (registrar/handler :fx :rf.http/managed-canned-success)]
+          (stub frame-ctx (assoc args-map :after-ms demo-reply-delay-ms :value payload)))))))
 
 ;; The React root lives in an atom and gets created lazily inside `run`, so
 ;; that merely loading this namespace touches no DOM. That restraint earns

--- a/examples/real-apps/realworld_resources/README.md
+++ b/examples/real-apps/realworld_resources/README.md
@@ -55,7 +55,7 @@ Every write is a `reg-mutation` — most in `mutations.cljs`, with the editor's 
 | `:realworld/follow` / `:realworld/unfollow` | POST/DELETE `/profiles/:username/follow` | populates the profile banner from the reply; invalidates `[:profile username]` |
 | `:realworld/post-comment` | POST `/articles/:slug/comments` | invalidates `[:comments slug]`, so the mounted page's comments refetch |
 | `:realworld/delete-comment` | DELETE `/articles/:slug/comments/:id` | invalidates `[:comments slug]` |
-| `:realworld/save-article` | POST `/articles` (create) / PUT `/articles/:slug` (edit) | invalidates the global lists (and the article's own detail, on edit) **and** the session feed |
+| `:realworld/save-article` | POST `/articles` (create) / PUT `/articles/:slug` (edit) | invalidates the global lists (and the article's own detail, on edit), the session feed, **and** the author's own My Articles cache (`[:author-articles username]`, keyed off the reply, since a create has no prior slug to key against) |
 | `:realworld/delete-article` | DELETE `/articles/:slug` | invalidates the article, the lists, **and** the session feed |
 | `:realworld/update-settings` | PUT `/user` | invalidates `[:profile username]` so a later profile visit re-reads the new bio |
 
@@ -138,7 +138,7 @@ The Conduit list endpoints page with `limit`/`offset`. The UI is 1-indexed with 
 
 The create/edit page (`article_editor.cljs`) is the app's most form-heavy surface. It is a good tour because it composes three different contracts in one place:
 
-- **The write is the `:realworld/save-article` mutation.** One mutation handles both create (POST) and edit (PUT), branching on whether the draft carries a `:slug`. Its `:invalidates` makes the lists and the feed stale (and, on edit, the article's own detail), so navigating to the saved article reads fresh data with nothing more to arrange. Delete is the sibling `:realworld/delete-article`.
+- **The write is the `:realworld/save-article` mutation.** One mutation handles both create (POST) and edit (PUT), branching on whether the draft carries a `:slug`. Its `:invalidates` makes the lists and the feed stale (and, on edit, the article's own detail), so navigating to the saved article reads fresh data with nothing more to arrange. It also stales the author's own My Articles cache — keyed off `result`, the decoded reply, since a *create* has no prior `:slug` to key an invalidation descriptor against. Delete is the sibling `:realworld/delete-article`.
 - **The can-submit gate is a [Spec 013 flow](../../../spec/013-Flows.md).** `:editor/can-submit?` materialises "the draft is valid **and** dirty" into `app-db` at `[:editor :can-submit?]`. Why a flow and not a subscription? Because the *submit handler* needs to read it as plain app-db data to gate the submit, and a subscription's value is only available to views, not to event handlers. The submit button reads the same materialised value through an ordinary subscription over the flow's output path. (Materialising a derived value so a *handler* can read it is exactly what flows are for.)
 - **A `:can-leave` navigation guard.** The editor routes declare `:can-leave [:editor/can-leave?]`. So a dirty draft parks a navigate-away as *pending*, and the app shell renders a "discard changes?" dialog off the `:rf/pending-navigation` subscription. Saving re-seeds the baseline, so the just-saved navigate is not itself blocked.
 

--- a/examples/real-apps/realworld_resources/article_editor.cljs
+++ b/examples/real-apps/realworld_resources/article_editor.cljs
@@ -160,12 +160,22 @@
    ;; anyway. The session feed lives in the session scope, so it gets its own
    ;; per-target descriptor naming `{:from-db :realworld/session}`: one mutation,
    ;; reaching across both scopes.
-   :invalidates   (fn [{:keys [slug]} _result]
+   ;;
+   ;; A third descriptor stales the author's OWN `:realworld/author-articles`
+   ;; (My Articles) cache, keyed off the reply's `:article :author :username` —
+   ;; the fact the decoded result carries, not `params` (a create has no `:slug`
+   ;; to key against, and `[:article-list]` above only reaches the global feed's
+   ;; list-identity tag, which `:realworld/author-articles` never carries — see
+   ;; its `:tags` fn in resources.cljs). Without this, a freshly-created article
+   ;; is invisible on My Articles until its cached page naturally goes stale.
+   :invalidates   (fn [{:keys [slug]} result]
                     [{:scope :rf.scope/global
                       :tags  (cond-> #{[:article-list]}
                                slug (conj [:article slug]))}
                      {:scope {:from-db :realworld/session}
-                      :tags  #{[:feed]}}])}
+                      :tags  #{[:feed]}}
+                     {:scope :rf.scope/global
+                      :tags  #{[:author-articles (get-in result [:article :author :username])]}}])}
   (fn [{:keys [slug] :as draft} _ctx]
     {:request {:method (if slug :put :post)
                :url    (rh/full-url (if slug

--- a/examples/real-apps/realworld_resources/http.cljs
+++ b/examples/real-apps/realworld_resources/http.cljs
@@ -234,11 +234,20 @@
       (and (= method :post) (str/ends-with? u "/users/login")) {:user demo-user}
       (and (= method :post) (str/ends-with? u "/users"))       {:user demo-user}
 
-      ;; GET /user — session restore. We return an empty payload on purpose: the
-      ;; decode fails into the failure branch, so the demo always starts
-      ;; unauthenticated and never auto-restores a session. PUT /user is the
-      ;; settings update (a mutation).
-      (and (= method :get) (str/ends-with? u "/user"))  {}
+      ;; GET /user — session restore. We deliberately synthesise a DECODE
+      ;; FAILURE (not a success with an empty body): a real backend returning
+      ;; `{}` would fail `:decode schema/UserResponse`'s schema validation, and
+      ;; `:begin-restore`'s `:on-failure` would fire. The canned-success stub
+      ;; never runs `:decode`, though — an empty-map *success* reply would
+      ;; land in `:on-success` instead, taking the auth machine to `:authed`
+      ;; with a nil `:user` (a broken, half-authenticated state). The
+      ;; `::decode-failure` sentinel (handled by the `:realworld-resources.demo/
+      ;; http-stub` fx below) routes this through
+      ;; `:rf.http/managed-canned-failure` instead, reproducing the real
+      ;; failure path — the demo always starts unauthenticated and never
+      ;; auto-restores a session. PUT /user is the settings update (a
+      ;; mutation).
+      (and (= method :get) (str/ends-with? u "/user"))  ::decode-failure
       (and (= method :put) (str/ends-with? u "/user"))  {:user demo-user}
 
       ;; --- write mutations -------------------------------------------------
@@ -316,9 +325,23 @@
                It delegates to the framework-shipped
                `:rf.http/managed-canned-success` with the per-URL payload plus
                `:after-ms` — the deferred reply rides `:dispatch-later`, so it's
-               tape-visible and time-travel-safe, not a raw `js/setTimeout`."
+               tape-visible and time-travel-safe, not a raw `js/setTimeout`.
+
+               `demo-payload-for-args` signals a genuine failure (rather than
+               a payload) with the `::decode-failure` sentinel — GET /user's
+               session-restore stub is the one route the demo wants to FAIL,
+               so it delegates to `:rf.http/managed-canned-failure` instead of
+               `-success`. `:rf.http/managed-canned-success` never runs
+               `:decode`, so handing it an empty body would incorrectly land
+               on the `:on-success` branch."
    :platforms #{:server :client}}
   (fn fx-managed-demo-stub [frame-ctx args-map]
-    (let [payload (demo-payload-for-args args-map)
-          stub    (registrar/handler :fx :rf.http/managed-canned-success)]
-      (stub frame-ctx (assoc args-map :after-ms demo-reply-delay-ms :value payload)))))
+    (let [payload (demo-payload-for-args args-map)]
+      (if (= ::decode-failure payload)
+        (let [stub (registrar/handler :fx :rf.http/managed-canned-failure)]
+          (stub frame-ctx (assoc args-map
+                                  :after-ms demo-reply-delay-ms
+                                  :kind     :rf.http/decode-failure
+                                  :tags     {:schema-validation-failure? true})))
+        (let [stub (registrar/handler :fx :rf.http/managed-canned-success)]
+          (stub frame-ctx (assoc args-map :after-ms demo-reply-delay-ms :value payload)))))))


### PR DESCRIPTION
## Summary

Three unrelated example bug-fixes from the /tools examples sweep, bundled by one worker per dispatch (disjoint dirs, no shared files):

- **rf2-rbl4kw** — `examples/real-apps/realworld_http` + `examples/real-apps/realworld_resources`: the session-restore demo stub's `GET /user` route returned an empty `{}` body through the framework's `:rf.http/managed-canned-success` stub. That stub never runs `:decode` (only the real transport does), so the empty body was delivered as a *success* reply, not the decode failure the surrounding comment claimed. `:begin-restore`'s `:on-success` fired, taking the auth machine to `:authed` with `(:user value)` = nil — a broken authed-with-nil-user state, and `:store-session`/`:restore-session` wiped the just-restored token. Fixed by routing that one reply through `:rf.http/managed-canned-failure` (`:kind :rf.http/decode-failure`) instead, via a `::decode-failure` sentinel `demo-payload-for-args` returns and the `:realworld*.demo/http-stub` fx branches on.

- **rf2-u64kc8** — `examples/capabilities/ssr/resources_ssr`: the blocking SSR preload was a no-op. `ssr/drain-blocking-resources!` is ROUTE-blocking-keyed — it only drains resources a `reg-route` on-route-entry plan enqueued for the current nav-token (`[:rf.runtime/routing :resource-blocking <nav-token>]`). This example has no route table at all, so the `[:ssr req nav]`-owned ensure never registered there, and the drain returned `{:settled? true}` immediately regardless of whether `:articles/list` had resolved — the render could ship a stale `:loading` skeleton with any genuinely async fetch. Per the bead's option (b) (no non-route blocking-drain surface exists for a route-free page), added `await-resource-loaded!`, a direct poll on the resource's own entry via the public `rf/resource-state` introspection read (mirrors the framework's own bounded-yield-then-recheck shape, just keyed on one scoped resource instead of a route's blocking set). Docstrings + README updated to describe the real mechanism.

- **rf2-pug8zj** — `examples/real-apps/realworld_resources`: creating an article never invalidated the author's own `:realworld/author-articles` (My Articles) cache — its list-identity tag `[:author-articles username]` was omitted from `:realworld/save-article`'s `:invalidates` (only `[:article-list]`, the *global* feed's tag, fired on create). Added a third invalidation descriptor keyed off the mutation's own decoded reply (`(get-in result [:article :author :username])`), since a create has no prior `:slug` to key against. The companion MEDIUM finding (favoriting doesn't invalidate the Favorited-Articles tab) is already tracked separately in rf2-5pv3sh and is out of scope here.

Examples are test-free (rf2-8cevm) — no smoke tests added; each fix was reasoned through the corrected mechanism and verified by building.

## Quality gates

- `npx shadow-cljs compile examples/realworld examples/realworld-resources examples/resources-ssr` — all three builds compile, 0 warnings (run twice: once before rebase, once after, both green).
- `clojure` JVM require-check of `resources-ssr.core` (the `.cljc` server-side `:clj` branch, incl. the new `await-resource-loaded!`) — loads cleanly via the `:test` alias classpath.
- `npm run test:cljs` — 8064 tests / 37059 assertions, 0 failures, 0 errors (full node-runtime suite, unaffected by these example-only changes; run as a regression check).

## Test plan

- [x] `examples/realworld` compiles
- [x] `examples/realworld-resources` compiles
- [x] `examples/resources-ssr` compiles (both CLJS client branch and CLJ server branch)
- [x] `npm run test:cljs` green