### PR TITLE
fix(examples): seed helix/login form + defer core/flows reg-flow + correct patterns/boot hydration shape (rf2-6g82yw/twhjxp/jffs5k)

### DIFF
--- a/examples/core/flows/core.cljs
+++ b/examples/core/flows/core.cljs
@@ -54,42 +54,51 @@
 (defn- line-total [{:keys [price qty]}]
   (* price qty))
 
-;; Every flow belongs to a frame, so `reg-flow` needs a frame in scope; call
-;; it bare and you'll get :rf.error/no-frame-context for your trouble. This
-;; example lives in the :rf/default frame, so we name it once here. (The
-;; toggleable `:cart/discount-rate` flow comes later, registered via
-;; :rf.fx/reg-flow from inside a handler — that route carries the dispatching
-;; frame along for you, no naming required.)
+;; `reg-flow` needs a LIVE frame to register against (docs/core/flows.md,
+;; Spec 013 §Frame-scoping), and `:rf/default` doesn't exist at ns-load —
+;; constructing a frame itself needs the substrate adapter installed first
+;; (`rf/init!`), and that only happens once `run` (MOUNT, further down)
+;; fires. So the two flows below don't register here directly; `install-
+;; flows!` wraps the registration and is called from `run`, right after
+;; `rf/init!` and `rf/reg-frame` have made `:rf/default` a real, live frame —
+;; the same point every other example that constructs a frame outside a
+;; `frame-provider` uses (see e.g.
+;; examples/patterns/nine_states/stories_host.cljs's `install-live-frame!`).
+;; Every flow belongs to a frame, so `reg-flow` needs a frame in scope; the
+;; toggleable `:cart/discount-rate` flow (further down) doesn't need this
+;; treatment — it registers later, via `:rf.fx/reg-flow` from inside a
+;; handler, and that route carries the dispatching frame along for you.
 ;; See docs/core/glossary.md#frame-identity-is-carried-not-found.
-(rf/with-frame :rf/default
+(defn- install-flows! []
+  (rf/with-frame :rf/default
 
-(rf/reg-flow :cart/subtotal
-  {:doc    "Every line item's price × qty, summed. Materialised into app-db
-            so the checkout handler can read it as ordinary data."
-   :inputs [[:cart :items]]
-   :output-path [:cart :subtotal]}
-  (fn [items] (reduce + 0 (map line-total items))))
+    (rf/reg-flow :cart/subtotal
+      {:doc    "Every line item's price × qty, summed. Materialised into app-db
+                so the checkout handler can read it as ordinary data."
+       :inputs [[:cart :items]]
+       :output-path [:cart :subtotal]}
+      (fn [items] (reduce + 0 (map line-total items))))
 
-;; Here's the cascade. `:cart/total` reads another flow's output
-;; (`[:cart :subtotal]`) alongside the discount rate. The runtime spots that
-;; shared path, works out that `:cart/subtotal` feeds `:cart/total`, and runs
-;; them in that order — both settle in a single walk. You never wire the
-;; ordering by hand; the dependency graph falls out of the paths.
-;;
-;; The discount starts switched off. `:cart/discount-rate` has no flow yet,
-;; so its path reads nil and this `:derive` treats that as 0% off. "Apply 10%
-;; discount" registers the flow; "Remove discount" clears it. While it's
-;; live, it derives a flat 10% off the current subtotal. And because it reads
-;; `[:cart :subtotal]`, the rate stays fresh as the cart changes — a tiered
-;; "5% over $50" rule would drop straight in.
-(rf/reg-flow :cart/total
-  {:doc    "Subtotal less the active discount. Reads :cart/subtotal's output
-            and the discount rate you can toggle at runtime."
-   :inputs [[:cart :subtotal] [:cart :discount-rate]]
-   :output-path [:cart :total]}
-  (fn [subtotal discount-rate]
-    (let [rate (or discount-rate 0)]
-      (Math/round (* subtotal (- 1 rate)))))))
+    ;; Here's the cascade. `:cart/total` reads another flow's output
+    ;; (`[:cart :subtotal]`) alongside the discount rate. The runtime spots that
+    ;; shared path, works out that `:cart/subtotal` feeds `:cart/total`, and runs
+    ;; them in that order — both settle in a single walk. You never wire the
+    ;; ordering by hand; the dependency graph falls out of the paths.
+    ;;
+    ;; The discount starts switched off. `:cart/discount-rate` has no flow yet,
+    ;; so its path reads nil and this `:derive` treats that as 0% off. "Apply 10%
+    ;; discount" registers the flow; "Remove discount" clears it. While it's
+    ;; live, it derives a flat 10% off the current subtotal. And because it reads
+    ;; `[:cart :subtotal]`, the rate stays fresh as the cart changes — a tiered
+    ;; "5% over $50" rule would drop straight in.
+    (rf/reg-flow :cart/total
+      {:doc    "Subtotal less the active discount. Reads :cart/subtotal's output
+                and the discount rate you can toggle at runtime."
+       :inputs [[:cart :subtotal] [:cart :discount-rate]]
+       :output-path [:cart :total]}
+      (fn [subtotal discount-rate]
+        (let [rate (or discount-rate 0)]
+          (Math/round (* subtotal (- 1 rate))))))))
 
 ;; ============================================================================
 ;; EVENTS
@@ -101,9 +110,11 @@
    {:sku "RF2-STKR"  :name "Sticker pack"       :price 500  :qty 3}])
 
 (rf/reg-event :cart/initialise
-  {:doc "Seed the cart. The :cart/subtotal and :cart/total flows fire on the
-         heels of this handler and materialise their outputs in the same
-         write — so the totals exist before the first render."}
+  {:doc "Seed the cart. `run` (MOUNT, below) dispatches this only after
+         `install-flows!` has registered :cart/subtotal and :cart/total, so
+         those flows fire on the heels of this handler and materialise their
+         outputs in the same write — the totals exist before the first
+         render."}
   (fn handler-cart-initialise [{:keys [db]} _]
     {:db (assoc db :cart {:items seed-items})}))
 
@@ -279,24 +290,33 @@
 ;; the shared `#app`.
 (defonce react-root (atom nil))
 
-;; `frame-provider` stands the frame up at the render root. On first mount it
-;; creates the frame and runs its `:initial-events` once to seed it (here
-;; `[:cart/initialise]`); on hot reload it reuses the frame as-is and skips
-;; the seed, so your live state survives a save. Wrapping the render is also
-;; what lets the `reg-view`-injected `dispatch`/`subscribe` find this frame —
-;; render without a provider and they raise :rf.error/no-frame-context. The
-;; id is `:rf/default`, an ordinary frame id, the very same one the
-;; `with-frame` flow registrations use up top.
+;; `frame-provider`'s ENSURE shape (`{:id …}`) would normally be where
+;; `:rf/default` gets created — but by the time it mounts below, `run` has
+;; already created the frame itself (`rf/reg-frame`), registered the two
+;; named flows against it (`install-flows!`), and dispatched the cart's seed
+;; — in that order, so the seeding dispatch's own `:db` write is the one the
+;; flow walk sees, and `:cart/subtotal` / `:cart/total` materialise in that
+;; SAME write. So this mount just REUSES the frame; there's nothing left to
+;; seed here. The id is `:rf/default`, the very same one `run` uses below.
 (def app-frame :rf/default)
 
 (defn run []
-  ;; Tell the runtime to render through Reagent. This picks the substrate; it
-  ;; doesn't create a frame — that's frame-provider's job below.
+  ;; `init!` tells re-frame2 which reactive substrate to render through —
+  ;; here, Reagent. It has to come before any frame is constructed: a
+  ;; frame's state container is substrate-specific, so `rf/reg-frame` (next)
+  ;; would raise :rf.error/no-adapter-installed without this first.
   (rf/init! reagent-adapter/adapter)
+  ;; Create the frame explicitly, here, rather than leaving it to
+  ;; `frame-provider` below. `reg-flow` (inside `install-flows!`) needs a
+  ;; LIVE frame to register against, and the render tree — where
+  ;; `frame-provider` would otherwise create one — doesn't exist yet at this
+  ;; point in `run`.
+  (rf/reg-frame app-frame {:doc "Cart-with-flows demo frame."})
+  (install-flows!)
+  (rf/with-frame app-frame (rf/dispatch-sync [:cart/initialise]))
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
     (rdc/render @react-root
-                [rf/frame-provider {:id app-frame
-                                    :initial-events [[:cart/initialise]]}
+                [rf/frame-provider {:id app-frame}
                  [cart-app]])))

--- a/examples/patterns/boot/boot.cljs
+++ b/examples/patterns/boot/boot.cljs
@@ -232,7 +232,21 @@
     ;; self-transition to `:ready` once the write lands.
     (fn [{data :data}]
       {:data (assoc data :phase :hydrating)
-       :fx   [[:dispatch [:boot/apply-hydration]]]})}
+       :fx   [[:dispatch [:boot/apply-hydration]]]})
+
+    :promote-hydrated
+    ;; Runs on the :hydrating → :ready transition, triggered by the very
+    ;; `:boot/hydrated` event `:boot/apply-hydration` (below) dispatches once
+    ;; it has promoted the staged payloads into app-db. That handler carries
+    ;; the SAME payload as this event's arg, and this action is the only
+    ;; place it's allowed to reach the machine's own snapshot: mirroring it
+    ;; into `:data` here — from inside the machine's own action — is what
+    ;; Spec 005 §Where snapshots live means by "the machine sets its own
+    ;; :data." An ordinary handler writing straight into
+    ;; `[:rf.runtime/machines ...]` (which `:boot/apply-hydration` used to
+    ;; do) is the thing this action replaces.
+    (fn [{data :data [_ staged] :event}]
+      {:data (merge data staged)})}
 
    :states
    {;; ---- :configuring — the :initial state; a single :spawn fetches /config
@@ -304,7 +318,7 @@
     ;; ---- :hydrating — promotes the loaded payloads into app-db ---------
     :hydrating
     {:entry :enter-hydrating
-     :on    {:boot/hydrated {:target :ready}}}
+     :on    {:boot/hydrated {:target :ready :action :promote-hydrated}}}
 
     ;; ---- :ready / :failed — terminal -------------------------------------
     :ready  {:meta {:terminal? true}}
@@ -334,35 +348,26 @@
 (rf/reg-event :boot/apply-hydration
   {:doc "Promote every staged payload at [:boot/staging ...] into the
          top-level app-db slices the running app reads, then fire
-         :boot/hydrated back at :app/boot so it can finish the trip from
-         :hydrating to :ready."}
-  ;; The app slices go to app-db (`:db`). The snapshot mirror below is a
-  ;; separate `:rf.db/runtime` effect, because a machine snapshot lives in
-  ;; runtime-db, not app-db (docs/core/glossary.md#runtime-db).
-  ;;
-  ;; ADVANCED — and genuinely rare. This is the *only* handler in the whole
-  ;; examples tree that writes a `:rf.db/runtime` effect, and it's here to
-  ;; teach one specific shape: mirroring loaded values into a machine snapshot
-  ;; so the snapshot is self-describing for SSR and tools. Everyday handlers
-  ;; write app-db through `:db` and leave the machine runtime to mind its own
-  ;; snapshot. Reach for `:rf.db/runtime` only when you're deliberately writing
-  ;; boot/hydration glue like this.
-  (fn handler-boot-apply-hydration [{:keys [db] rt :rf.db/runtime} _]
+         :boot/hydrated — carrying that same payload — back at :app/boot so
+         it can finish the trip from :hydrating to :ready."}
+  ;; An ordinary app handler like this one writes app-db and ONLY app-db
+  ;; (`:db`, below) — never a machine's snapshot. A machine's snapshot lives
+  ;; in runtime-db, and Spec 005 §Where snapshots live is unambiguous: user
+  ;; code MUST NOT write under [:rf.runtime/machines ...] — only the owning
+  ;; machine's own actions may. So the payload this handler promotes into
+  ;; app-db rides along on the `:boot/hydrated` event instead, and it's
+  ;; :app/boot's own `:promote-hydrated` action (see the machine's `:actions`
+  ;; above) that mirrors it into the machine's `:data` — from inside the
+  ;; machine, with framework authority, the only place that's allowed to
+  ;; happen.
+  (fn handler-boot-apply-hydration [{:keys [db]} _]
     (let [staging (:boot/staging db)]
       {:db (-> db
                (assoc :config (:config staging))
                (assoc :flags  (:flags staging))
                (assoc :user   (:user staging))
                (assoc :routes (:routes staging)))
-       ;; Mirror the same values into the boot machine's :data so the snapshot
-       ;; stands on its own for SSR and tools.
-       :rf.db/runtime (update-in (or rt {})
-                                 [:rf.runtime/machines :snapshots :app/boot :data] assoc
-                                 :config (:config staging)
-                                 :flags  (:flags staging)
-                                 :user   (:user staging)
-                                 :routes (:routes staging))
-       :fx [[:dispatch [:app/boot [:boot/hydrated]]]]})))
+       :fx [[:dispatch [:app/boot [:boot/hydrated staging]]]]})))
 
 ;; ============================================================================
 ;; PUBLIC ENTRY EVENT

--- a/examples/substrates/helix/login/core.cljs
+++ b/examples/substrates/helix/login/core.cljs
@@ -525,9 +525,17 @@
     ;; `use-subscribe` hook and the `(rf/capture-frame)` capture in `login-form`
     ;; resolve to it. The provider is required — without it those reads raise
     ;; `:rf.error/no-frame-context`.
+    ;;
+    ;; `:initial-events` seeds the form slice ([:auth.login/initialise-form]) to
+    ;; its empty shape, so the controlled inputs read an empty draft — not nil —
+    ;; on that first render. Skip it and each input's `:value` reads `(:email
+    ;; nil)` = nil on first paint, which React treats as an UNCONTROLLED input,
+    ;; then flips to controlled the moment the slice is seeded — the exact
+    ;; warning this seeding avoids.
     (.render @react-root
              ($ helix-adapter/frame-provider
-                {:id           :rf/default
-                 :doc          "Login (Helix) demo frame."
-                 :fx-overrides {:rf.http/managed :auth.login.demo/managed-stub}}
+                {:id             :rf/default
+                 :doc            "Login (Helix) demo frame."
+                 :fx-overrides   {:rf.http/managed :auth.login.demo/managed-stub}
+                 :initial-events [[:auth.login/initialise-form]]}
                 ($ root-view)))))


### PR DESCRIPTION
## Summary

Three verified DOA / wrong-shape example bugs from the /tools sweep, fixed by one worker across three disjoint example dirs:

- **`examples/substrates/helix/login`** (rf2-6g82yw): the Helix `frame-provider` omitted `:initial-events [[:auth.login/initialise-form]]`, so the form slice was unseeded and controlled inputs read `(:email nil)` on first render — an uncontrolled→controlled React warning. Added the seed, matching the Reagent (`examples/core/login`) and UIx (`examples/substrates/uix/login`) mirrors exactly.

- **`examples/core/flows`** (rf2-twhjxp): `reg-flow` calls ran at namespace-load against a not-yet-live `:rf/default` frame, throwing `:rf.error/flow-frame-not-live` before `run` ever fired — the example was dead on arrival (blank page). Investigation surfaced a second layer: frame *construction* itself needs the substrate adapter installed first (`rf/init!`), which also only happens inside `run`. Fix: defer frame creation (`rf/reg-frame`), flow registration (`install-flows!`), and the cart's seed dispatch (`:cart/initialise`) into `run`, right after `rf/init!` — in that order, so the seeding dispatch's own `:db` write is what the flow walk sees and `:cart/subtotal` / `:cart/total` still materialise in the same write the original design intended (no regression to the "totals exist before first render" guarantee).

- **`examples/patterns/boot`** (rf2-jffs5k): `:boot/apply-hydration` (a plain app handler, no `:rf/machine?`/`:rf/framework-authority?` stamp) wrote a `:rf.db/runtime` effect straight into the `:app/boot` machine's own snapshot under `[:rf.runtime/machines :snapshots :app/boot :data]` — spec-forbidden (Spec 005 §Where snapshots live: user code MUST NOT write under `[:rf.runtime/machines ...]`) and taught the wrong shape (the only handler in the examples tree doing this). Fix: the handler now writes only app-db and carries the promoted payload as an arg on the `:boot/hydrated` event; a new `:promote-hydrated` action on the `:app/boot` machine (invoked via the `:hydrating` → `:ready` transition) mirrors that payload into the machine's own `:data` from inside the machine — the only place framework authority allows a snapshot write.

All three are isolated, single-file changes (`examples/core/flows/core.cljs`, `examples/patterns/boot/boot.cljs`, `examples/substrates/helix/login/core.cljs`) — no shared surface, no hot-zone files touched.

## Quality gates

- `npx shadow-cljs compile examples/flows examples/login-helix examples/boot` — 0 warnings, all three builds compile clean.
- `node scripts/check-examples-compile.cjs` (full examples-compile gate) — **all 44 example builds compiled with zero warnings**.
- `npm run test:cljs` — **8060 tests, 37042 assertions, 0 failures, 0 errors**.
- Runtime verification (not a committed test — examples stay test-free per rf2-8cevm): served each fixed example standalone via `examples/scripts/serve-example.cjs --no-watch` and loaded it headlessly with Playwright (already a repo devDependency), inspecting console output + rendered DOM:
  - **flows**: no console errors; first render shows `Subtotal $97.00` / `Total $97.00` immediately (matches the 3 seeded line items) — confirms flows fire in the same commit as the cart seed.
  - **login-helix**: no console warnings; both inputs render `value=""` (empty string, not missing/`nil`) on first paint — confirms the uncontrolled→controlled warning is gone.
  - **boot**: no `:rf.warning/app-handler-runtime-effect` or schema-validation errors; the app reaches `:ready` and renders the fully-hydrated `main-app` view (config/flags/routes/user all present) — confirms the machine completes `:hydrating` → `:ready` via the new `:promote-hydrated` action without incident.

## Risks

- The `examples/core/flows` fix is the most structurally invasive of the three (frame creation + flow registration moved from ns-load into `run`) — worth a second read of the new `install-flows!` / `run` ordering, though it's runtime-verified and mirrors the proven pattern already used in `examples/patterns/nine_states/stories_host.cljs`'s `install-live-frame!`.
- None of the three touch shared/hot-zone surfaces; no merge-conflict risk expected with concurrent clusters (xray/story/mcp-conformance/template) or PR #5250.