### PR TITLE
fix(xray): after-ring animation + per-delay ring keys + inherited-transition edge + app-db diff :r resolution (rf2-nms77h/2es2x8/6e8rh8/96csq4)

### DIFF
--- a/tools/xray/spec/003-Machine-Inspector.md
+++ b/tools/xray/spec/003-Machine-Inspector.md
@@ -723,6 +723,39 @@ muted `[NO OP] staying in {state}` cascade-row (rf2-iu3no) — that surface is
 the per-run narration; this section is the Machines TAB's topology
 read. Both key off the one `:rf.machine.event/unhandled-no-op` trace.
 
+### Inherited-transition fired-edge highlight (rf2-6e8rh8)
+
+Per Spec 005 deepest-wins, a transition declared on a **compound ANCESTOR**
+state applies to every descendant that doesn't override it — a `:door/close`
+handler declared at `:open` fires while the active leaf is `[:open :wide]`.
+The single-active `extract-fired-edge-ids` match (`single-transition-fired-
+ids`) originally required EXACT equality between the trace's
+`(from-path, to-path)` and the projected edge's `(:from-path, :to-path)`.
+That works for a STATE-LOCAL edge (the runtime's `:before :state` IS the
+declaring path) but fails for an INHERITED one: the runtime's `:before
+:state` is the active LEAF (`[:open :wide]`) while `chart.layout/project-
+definition` projects the inherited edge's `:from-path` at the DECLARING
+ancestor (`[:open]`) — the two paths are never `=`. The edge is not
+`:machine-level?` either (it's a real declared transition, not the
+top-level `:on` fallback), so that fallback doesn't catch it — the fired
+set came back empty and the chart lit no edge for a dispatch that
+demonstrably transitioned the machine. A compound TARGET's initial-descent
+breaks the `to*` match the same way: the edge's declared `:to-path` (the
+compound target, e.g. `:open`) is shallower than the runtime's landed leaf
+(`[:open :wide]`).
+
+**Fix — prefix match, not exact equality.** `single-transition-fired-ids`
+matches `from*` / `to*` against each candidate edge's `:from-path` /
+`:to-path` via `on-active-path?` (a possibly-equal PREFIX test), the same
+predicate `extract-guard-blocked-edge-ids` already used for the analogous
+rf2-tjm3u2 guard-blocked case. A STATE-LOCAL edge still matches (its
+`:from-path` / `:to-path` equal the leaf, a count-equal prefix); an
+INHERITED edge now matches too (its `:from-path` is a strict prefix of the
+active leaf); a SIBLING state's same-event edge remains excluded (its
+`:from-path` is not a prefix of the active path at all). `on-active-path?`
+lives once in `trace_state.cljs`, shared by both the fired-edge and the
+guard-blocked matchers.
+
 ### Parallel multi-region fired-edge highlight (rf2-8ncxrf)
 
 A `:type :parallel` machine's snapshot `:state` is a **region-map** —
@@ -760,8 +793,10 @@ regions sharing a state NAME never cross-light. A region that did NOT
 move this event contributes no edge. The returned ids are the EXACT
 canonical machines-viz edge-ids the live chart mints (agreement by
 construction). Single-active (flat / compound) transitions are
-unaffected — they take the existing `(from, to, event)` match + the
-machine-level fallback.
+unaffected — they take the existing `(from, to, event)` match (prefix-
+matched on `from`/`to` per [§Inherited-transition fired-edge highlight
+(rf2-6e8rh8)](#inherited-transition-fired-edge-highlight-rf2-6e8rh8)) +
+the machine-level fallback.
 
 **Per-region CHANGED fallback ordering (rf2-85a9do).** A changed region's
 edge is resolved through an ordered, mutually-exclusive fallback:

--- a/tools/xray/spec/004-App-DB-Diff.md
+++ b/tools/xray/spec/004-App-DB-Diff.md
@@ -283,6 +283,27 @@ a replace is length- and order-preserving, so it never shifts a
 subsequent index or adds/removes a slot — and their after-indices are
 skipped from the shift output (they classify as `:modified`).
 
+**A vector `:r`'s `:before`-value is resolved through the SAME replay
+slots (rf2-96csq4), not a raw `value-at`.** Although `:r` itself never
+runs through the replay, its edit-index still addresses a position in
+the FINAL after-vector — a position a prior `:+`/`:-` at the same
+parent may already have shifted. Resolving `:before` as a naive
+`(value-at before [parent-path after-idx])` reads the WRONG slot (or an
+out-of-range one) whenever the vector saw a mixed insert/delete-then-
+replace script. The correct before-value is `slots[after-idx]` — the
+survivor index the unified `:+`/`:-` replay already computed for that
+exact after-position (the replay's `:slots` output is 1:1 with the
+after-vector regardless of whether the caller asks about a survivor, an
+insert, *or* a replace target). REPRO: `[:x :y] → [:new :x :z]` ⇒
+`[[0] :+ :new] [[2] :r :z]`. The naive read, `(value-at before [2])`,
+is out-of-range on the 2-element before-vector — the missing-sentinel
+misclassifies the slot as `:added` and `:y`'s removal never surfaces
+anywhere (not `:modified`, not `:removed` — silently lost). The replay-
+resolved read, `slots[2]`, is `1` (`:y`'s original index), correctly
+classifying `[2]` as `:modified :y → :z`. Non-vector `:r` (map key,
+scalar, root replace) is unaffected — those addressing modes are never
+index-shifted, so the raw `value-at` lookup stays correct for them.
+
 > **Why the unified `:+`/`:-` replay (rf2-3eplfk).** An earlier
 > implementation replayed **only** the `:-` edits against pristine
 > `(range before-len)`, ignoring interleaved `:+` inserts. That is

--- a/tools/xray/src/day8/re_frame2_xray/diff/engine.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/diff/engine.cljc
@@ -974,6 +974,40 @@
                 acc))
             {}
             vec-replays)
+          ;; rf2-96csq4 — resolve a vector `:r`'s BEFORE-value through the
+          ;; unified replay, NOT a raw post-shift `value-at`. Editscript
+          ;; applies vector edits SEQUENTIALLY against an evolving
+          ;; sequence, so an `:r`'s edit-index addresses a position in the
+          ;; FINAL after-vector, not a pristine before-index, whenever a
+          ;; prior `:+`/`:-` at the SAME vector parent shifted positions
+          ;; (`:r` deliberately stays OUT of the replay itself — see
+          ;; `replay-vector-edits` — but the FINAL `:slots` it produces
+          ;; still aligns 1:1 with the after-vector, rf2-3eplfk). REPRO:
+          ;; before `[:x :y]`, after `[:new :x :z]` ⇒ editscript
+          ;; `[[0] :+ :new] [[2] :r :z]`; raw `(value-at before [2])` is
+          ;; out-of-range on a 2-element before-vector (missing-sentinel,
+          ;; misclassifying the slot as `:added` and losing `:y`'s
+          ;; removal), while `slots[2]` (from the SAME replay that already
+          ;; feeds the removals + shift channels) correctly resolves to
+          ;; before-index 1 (`:y`). Non-vector `:r` (map / scalar / root
+          ;; replace) is untouched — those keys are never index-shifted,
+          ;; so the raw `value-at` lookup stays correct for them.
+          r-before-value
+          (fn [path]
+            (let [parent-path (vec (butlast path))
+                  after-idx   (peek path)
+                  slot        (when (and (integer? after-idx)
+                                         (vector-parent? path))
+                                (get-in vec-replays [parent-path :slots after-idx]))]
+              (if (integer? slot)
+                (nth (vec (value-at before parent-path)) slot)
+                ;; Non-vector `:r`, or (defensively) a replay that
+                ;; produced no slot / an `::insert` marker at this
+                ;; after-index — shouldn't happen for a real Editscript
+                ;; `:r` (a fresh insert and an in-place replace never
+                ;; target the identical index), but fall back to the raw
+                ;; lookup rather than crash.
+                (value-at before path))))
           ;; Step 1 — expand each non-vector-deletion raw edit into
           ;; per-leaf ops at every path the operator can navigate to in
           ;; the AFTER tree.
@@ -987,7 +1021,7 @@
                        (expand-leaf-paths path :removed removed-val)
                        [{:path path :op :removed :value removed-val}]))
                 :r [{:path path :op :modified
-                     :before (value-at before path)
+                     :before (r-before-value path)
                      :after  value}]
                 :s [{:path path :op :modified
                      :before (value-at before path)
@@ -996,9 +1030,15 @@
             other-edits)
           ;; Step 2 — re-classify modifieds via the leaf-op rules so R7
           ;; type-change + R8 redaction branches surface in the op map.
+          ;; Consumes the entry's OWN `:before`/`:after` (already resolved
+          ;; correctly in Step 1, including the rf2-96csq4 replay-aware
+          ;; `:r` resolution) rather than re-deriving via a fresh
+          ;; `value-at before/after path` — re-deriving here was the
+          ;; SECOND site of the same post-shift bug (it silently discarded
+          ;; Step 1's correct `:before` and re-computed the wrong one).
           path-ops
           (reduce
-            (fn [acc {:keys [path op value before-val after-val]
+            (fn [acc {:keys [path op value]
                       :as entry}]
               (cond
                 (= op :added)
@@ -1008,9 +1048,7 @@
                 (assoc acc path {:op :removed :before (or value (value-at before path))})
 
                 (= op :modified)
-                (let [b (value-at before path)
-                      a (value-at after path)
-                      classified (leaf-op b a)]
+                (let [classified (leaf-op (:before entry) (:after entry))]
                   (assoc acc path classified))
 
                 :else

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_after_rings.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_after_rings.cljs
@@ -239,17 +239,24 @@
   scrubber sub; bumps `now-ms` when ticking is warranted; re-schedules
   itself iff still needed.
 
-  The two app-db reads inside the body are deliberately NOT
-  `rf/subscribe`-mediated — the loop is a side-effect driver, not a
-  view; using `subscribe` here would create a reactive dependency on
-  Xray's own frame from outside the view's reactive context, which is
-  the same self-noise hazard the trace collector avoids. We reach through
-  `rf/frame-app-db-value` (the JVM-runnable read; CLJS impl reads off
-  the frame's app-db atom) directly."
+  rf2-nms77h — the loop runs as a rAF/next-tick callback, OFF-render:
+  there is no established frame scope (no `with-frame`, no enclosing
+  Provider, no carried `*current-frame*` stamp), so the ambient
+  1-arity `rf/subscribe` has NO `:rf/default` floor and raises
+  `:rf.error/no-frame-context` (subs.cljc, frame.cljc) — the `catch`
+  below swallowed that error every tick, silently killing the loop
+  after its first iteration. The two reads below use the PUBLIC
+  explicit-frame opts form `(rf/subscribe query-v {:frame frame})`
+  (subs.cljc §Lookup algorithm), targeting the frame captured in
+  `tick-state` at `kick-tick!` time (rf2-nesy9) — the same frame the
+  dispatch below already correctly targets."
   []
   (try
-    (let [timers   @(rf/subscribe [:rf.xray/active-timers-for-focused-machine])
-          scrub    @(rf/subscribe [:rf.xray/machine-scrubber-position])
+    (let [frame    (:frame @tick-state)
+          timers   @(rf/subscribe [:rf.xray/active-timers-for-focused-machine]
+                                  {:frame frame})
+          scrub    @(rf/subscribe [:rf.xray/machine-scrubber-position]
+                                  {:frame frame})
           now      (now-ms)
           last-now (:last-now-ms @tick-state)
           due?     (or (zero? *tick-min-delta-ms*)
@@ -260,7 +267,7 @@
         ;; surrounding instance frame at the time the overlay armed the
         ;; clock), not a `{:frame :rf/xray}` literal.
         (rf/dispatch [:rf.xray/timer-tick now]
-                     {:frame (:frame @tick-state)})
+                     {:frame frame})
         (swap! tick-state assoc :last-now-ms now))
       (if (rings-h/needs-ticking? timers scrub)
         (raf! tick-loop!)

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_after_rings_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_after_rings_helpers.cljc
@@ -40,11 +40,15 @@
   ## Folding algorithm
 
   Walk the trace buffer oldest-first. Each `scheduled` event opens a
-  timer keyed by `(machine-id, state, epoch)`; a later `fired` /
-  `stale-after` / `cancelled` event for the same key closes it. The
-  latest event wins so re-schedules at the same key replace the prior
-  record (matches the runtime's idempotent `cancel-after-timer-entry!`
-  shape).
+  timer keyed by `(machine-id, state, epoch, delay)`; a later `fired`
+  / `stale-after` / `cancelled` event for the same key closes it. The
+  `delay` discriminator (rf2-2es2x8) matters because a single state's
+  `:after` map can schedule several timers CONCURRENTLY at the same
+  `(machine-id, state, epoch)` — one entry per delay — so `delay` is
+  required to keep them as independent records / independent rings.
+  The latest event wins so re-schedules at the same key replace the
+  prior record (matches the runtime's idempotent
+  `cancel-after-timer-entry!` shape).
 
   ## Ring geometry
 
@@ -110,43 +114,61 @@
 ;; ---- timer key resolution -----------------------------------------------
 
 (defn- timer-key
-  "Composite key for the timer-table fold. `(machine-id, state, epoch)`
-  is the runtime's identity tuple — re-scheduling at the same state
+  "Composite key for the timer-table fold. `(machine-id, state, epoch,
+  delay)` is the runtime's identity tuple.
+
+  rf2-2es2x8 — `epoch` alone does NOT disambiguate: `build-after-fx`
+  computes ONE epoch per scheduling node and reuses it across EVERY
+  entry in that node's `:after` map (Spec 005 §Multiple :after per
+  state — `{:after {5000 :warn 30000 :timeout}}` schedules both timers
+  concurrently at the same `(machine-id, state, epoch)`). Every
+  `:rf.machine.timer/*` trace (scheduled / fired / stale-after /
+  cancelled / skipped-on-server) carries `:delay` as the resolved ms
+  value, stable across a timer's whole scheduled→fired/cancelled
+  lifecycle, so it is included here as the discriminator — each
+  concurrent `:after` timer on a state gets its own key, its own fold
+  record, and its own ring. Re-scheduling at the same state still
   bumps the epoch (per `re-frame.machines.transition/pick-after-
-  transition`), so a fresh epoch ALWAYS starts a new record. Within an
-  epoch the latest event wins (the runtime's invariant: at most one
-  in-flight timer per (state, epoch)).
+  transition`), so a fresh epoch ALWAYS starts a new record regardless
+  of delay.
 
   Per rf2-82a0u the unified `:rf.machine.timer/cancelled` event
   carries `:epoch` (mirroring the `:scheduled` shape), so the closing
   match is exact for cancel rows — the `:*` fallback is retained for
   pre-rf2-82a0u trace replays + edge cases where the closing event's
   tags are projected through a lossy intermediary."
-  [machine-id state epoch]
+  [machine-id state epoch delay]
   {:machine-id machine-id
    :state      state
-   :epoch      (or epoch :*)})
+   :epoch      (or epoch :*)
+   :delay      (or delay :*)})
 
 ;; ---- public: project active timers --------------------------------------
 
 (defn- update-or-cancel
-  "Match a closing event against the open timer-table. When `epoch` is
-  provided, exact match; when nil, match the most recent open record
-  for `(machine-id, state)`. Returns `[k record-or-nil]` — `nil`
+  "Match a closing event against the open timer-table. When `epoch`
+  AND `delay` are both known, exact match on the full
+  `(machine-id, state, epoch, delay)` key; otherwise fall back to the
+  most recent open record for `(machine-id, state)` — narrowed to
+  `delay` when the closing event carries one, so two concurrent
+  `:after` timers on the same state/epoch (rf2-2es2x8) don't collide
+  in the fallback path either. Returns `[k record-or-nil]` — `nil`
   record means no open entry to update.
 
   Pure fn — JVM-runnable."
-  [open machine-id state epoch]
-  (let [exact-k (timer-key machine-id state epoch)
+  [open machine-id state epoch delay]
+  (let [exact-k (timer-key machine-id state epoch delay)
         exact   (get open exact-k)]
     (if exact
       [exact-k exact]
       ;; Fall back to the latest open record for the (machine-id, state)
-      ;; pair — the closing event didn't stamp epoch so we trust the
-      ;; ordering of the buffer.
+      ;; pair — the closing event didn't stamp epoch (and/or delay) so
+      ;; we trust the ordering of the buffer, narrowed by `:delay` when
+      ;; available so concurrent timers at the same state don't collide.
       (let [matches (filter (fn [[k _v]]
                               (and (= machine-id (:machine-id k))
-                                   (= state      (:state k))))
+                                   (= state      (:state k))
+                                   (or (nil? delay) (= delay (:delay k)))))
                             open)]
         (if (seq matches)
           ;; Pick the most-recently-armed one. The open record's
@@ -202,7 +224,7 @@
           (nil? state)      open
 
           (= :rf.machine.timer/scheduled op)
-          (assoc open (timer-key machine-id state epoch)
+          (assoc open (timer-key machine-id state epoch delay)
                  {:machine-id  machine-id
                   :state       state
                   :armed-at    t
@@ -215,7 +237,7 @@
                   :sub-id      sub-id})
 
           (= :rf.machine.timer/fired op)
-          (let [[k v] (update-or-cancel open machine-id state epoch)]
+          (let [[k v] (update-or-cancel open machine-id state epoch delay)]
             (if v
               (assoc open k
                      (assoc v
@@ -230,13 +252,13 @@
                 ;; + `:current-epoch` (the machine's epoch when the timer
                 ;; fired) — we close the scheduled-epoch record.
                 stale-epoch (or (:scheduled-epoch tags) epoch)
-                [k v] (update-or-cancel open machine-id state stale-epoch)]
+                [k v] (update-or-cancel open machine-id state stale-epoch delay)]
             (if v
               (assoc open k (assoc v :status :stale :closed-at t))
               open))
 
           (= :rf.machine.timer/cancelled op)
-          (let [[k v] (update-or-cancel open machine-id state epoch)]
+          (let [[k v] (update-or-cancel open machine-id state epoch delay)]
             (if v
               (assoc open k (assoc v
                                    :status :cancelled
@@ -251,7 +273,7 @@
               open))
 
           (= :rf.machine.timer/skipped-on-server op)
-          (assoc open (timer-key machine-id state epoch)
+          (assoc open (timer-key machine-id state epoch delay)
                  {:machine-id  machine-id
                   :state       state
                   :armed-at    t

--- a/tools/xray/src/day8/re_frame2_xray/panels/machines/trace_state.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machines/trace_state.cljs
@@ -256,20 +256,46 @@
 
 ;; ---- fired-edge ids (machines-viz canonical) ----------------------------
 
+(defn- on-active-path?
+  "True iff `path` (an edge's declaring `:from-path` / `:to-path`) is on
+  the active `state-path` — i.e. `path` is a (possibly equal) PREFIX of
+  `state-path`. A STATE-LOCAL edge declares on the active leaf (`path` ==
+  `state-path`); an INHERITED edge declares on an ANCESTOR still on the
+  active path (`path` is a strict prefix). A path declared on a DIFFERENT
+  branch (a sibling state reusing the same event, or the bug's sibling
+  guard case) is NOT a prefix of the active path, so it is excluded. nil
+  `state-path` (region-map / absent) disables the check upstream — never
+  reaches here."
+  [path state-path]
+  (and (<= (count path) (count state-path))
+       (= (vec path) (vec (take (count path) state-path)))))
+
 (defn- single-transition-fired-ids
   "Fired-edge ids for ONE single-active (flat / compound) transition: the
-  `(from*, to*, event*)` paths read off the trace (already path-coerced).
+  `(from*, to*, event*)` paths read off the trace (already path-coerced;
+  `from*` / `to*` are the runtime's actual LEAF before/after state).
   A STATE-LOCAL edge matches on all three; falls back to a MACHINE-LEVEL
   (top-level `:on`) edge matched on (to, event) alone — rf2-vcnvj projects
   the fallback ONCE from the synthetic MACHINE-ROOT node, so its
   `:from-path` is the root context `[]`, not the concrete leaf the runtime
   fired it from. Without that fallback the door `:door/audit` fallback
-  firing from `:alarming` would highlight no edge. Returns a seq of ids."
+  firing from `:alarming` would highlight no edge. Returns a seq of ids.
+
+  rf2-6e8rh8 — `:from-path` / `:to-path` match via `on-active-path?`
+  (prefix), NOT `=` (exact equality). Per Spec 005 deepest-wins, a
+  transition inherited from a compound ANCESTOR fires with the runtime's
+  `:before :state` at the active LEAF (e.g. `[:open :wide]`) while
+  `chart.layout/project-definition` projects the edge's `:from-path` at
+  the DECLARING ancestor (`[:open]`) — exact `=` never matches an
+  inherited edge. Symmetrically, a compound TARGET's initial-descent
+  lands the runtime's `:after :state` at a deeper leaf than the edge's
+  declared `:to-path`, so `to*` is matched the same way. `on-active-path?`
+  subsumes the STATE-LOCAL case (`path` == the leaf, count-equal prefix)."
   [edges from* to* event*]
   (let [local (keep (fn [e]
                       (when (and (not (:machine-level? e))
-                                 (= from*  (:from-path e))
-                                 (= to*    (:to-path e))
+                                 (on-active-path? (:from-path e) from*)
+                                 (on-active-path? (:to-path e) to*)
                                  (= event* (:event e)))
                         (:id e)))
                     edges)]
@@ -277,7 +303,7 @@
       local
       (keep (fn [e]
               (when (and (:machine-level? e)
-                         (= to*    (:to-path e))
+                         (on-active-path? (:to-path e) to*)
                          (= event* (:event e)))
                 (:id e)))
             edges))))
@@ -666,19 +692,6 @@
   preserving the pre-rf2-tjm3u2 behaviour for traces that carry no state)."
   [ev]
   (normalise-path (get-in ev [:tags :state])))
-
-(defn- on-active-path?
-  "True iff `from-path` (an edge's declaring source path) is on the active
-  `state-path` — i.e. `from-path` is a (possibly equal) PREFIX of
-  `state-path`. A STATE-LOCAL edge declares on the active leaf (`from-path`
-  == `state-path`); an INHERITED edge declares on an ANCESTOR still on the
-  active path (`from-path` is a strict prefix). An edge declared on a
-  DIFFERENT branch (the bug's sibling state reusing the same event + guard)
-  is NOT a prefix of the active path, so it is excluded. nil `state-path`
-  (region-map / absent) disables the check upstream — never reaches here."
-  [from-path state-path]
-  (and (<= (count from-path) (count state-path))
-       (= (vec from-path) (vec (take (count from-path) state-path)))))
 
 (defn extract-guard-blocked-edge-ids
   "Given a machine `definition`, a vector of trace events for the

--- a/tools/xray/test/day8/re_frame2_xray/diff/engine_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/diff/engine_cljs_test.cljc
@@ -1205,3 +1205,72 @@
       (is (= :same (engine/op-at p [:xs 2])))
       (is (nil? (engine/shifted-was-index p [:xs 2]))))))
 
+;; ---- rf2-96csq4 — vector :r before-value resolved through the replay ---
+;;
+;; A vector `:r` (in-place replace) edit's edit-index addresses a position
+;; in the FINAL after-vector — exactly like `:+`/`:-` — but `:r` itself
+;; stays OUT of the unified replay (`replay-vector-edits`; a replace never
+;; shifts anything). Resolving its `:before`-value via a raw
+;; `(value-at before [after-idx])` reads the WRONG (or out-of-range) slot
+;; whenever a prior `:+`/`:-` at the SAME parent shifted positions. The fix
+;; resolves through the SAME replay `:slots` that already feed the
+;; removals + shift channels: `slots[after-idx]` IS the true before-index.
+;; Each repro below was verified against Editscript 0.6.5's actual output.
+
+(deftest r-96csq4-insert-then-replace-resolves-true-before-index
+  (testing "rf2-96csq4 repro (the bead's exact example) — `[:x :y] →
+            [:new :x :z]` ⇒ `[[0] :+ :new] [[2] :r :z]`. Raw
+            `(value-at before [2])` is OUT OF RANGE on the 2-element
+            before-vector (missing-sentinel), misclassifying [2] as
+            `:added` and losing `:y`'s removal/change entirely — not
+            reported as `:modified`, not `:removed`, silently lost.
+            Correct: [2] is `:modified :y → :z` (via `slots[2] = 1`, the
+            true before-index the prior `:+` shifted it to)."
+    (let [p (engine/project [:x :y] [:new :x :z])]
+      (is (= :added (engine/op-at p [0])))
+      (is (= :new (:after (engine/entry-at p [0]))))
+      (is (= :same-shifted (engine/op-at p [1]))
+          ":x survives, shifted from before-idx 0")
+      (is (= 0 (engine/shifted-was-index p [1])))
+      (is (= :modified (engine/op-at p [2]))
+          "the replaced slot must classify as :modified — NOT :added
+           (pre-fix: :y was lost, an out-of-range value-at read produced
+           the missing-sentinel)")
+      (is (= {:op :modified :before :y :after :z}
+             (engine/entry-at p [2]))
+          ":y's true before-value must surface, not the missing-sentinel")
+      (is (empty? (get-in p [:vector-removals []]))
+          "a replace is not a removal — no vector-removals entry"))))
+
+(deftest r-96csq4-delete-then-replace-resolves-true-before-index
+  (testing "rf2-96csq4 — the delete-before-replace variant. `[:a :b :c] →
+            [:b :Z]` ⇒ `[[0] :-] [[1] :r :Z]`. Raw `(value-at before [1])`
+            reads `:b` — the WRONG, post-shift slot (the pre-fix bug's
+            'wrong-but-present before-value' symptom). The true
+            before-value at the replaced after-index 1 is `:c`
+            (`slots[1] = 2`, the survivor index the `:-` replay already
+            computed for it)."
+    (let [p (engine/project [:a :b :c] [:b :Z])]
+      (is (= [{:before-index 0 :before-value :a}]
+             (get-in p [:vector-removals []]))
+          "sanity — :a's removal is reported at the parent")
+      (is (= :same-shifted (engine/op-at p [0]))
+          ":b survives at after-idx 0, shifted from before-idx 1")
+      (is (= 1 (engine/shifted-was-index p [0])))
+      (is (= :modified (engine/op-at p [1])))
+      (is (= {:op :modified :before :c :after :Z}
+             (engine/entry-at p [1]))
+          "the replaced slot's true before-value is :c (before-idx 2) —
+           NOT :b, which is what the raw post-shift value-at read would
+           have wrongly produced"))))
+
+(deftest r-96csq4-map-key-replace-unaffected
+  (testing "rf2-96csq4 — a NON-vector :r (a map-key replace, `[[:status]
+            :r :done]`) is unaffected by the fix: map keys are never
+            index-shifted, so the raw value-at resolution was already
+            correct and stays correct"
+    (let [p (engine/project {:status :pending} {:status :done})]
+      (is (= :modified (engine/op-at p [:status])))
+      (is (= {:op :modified :before :pending :after :done}
+             (engine/entry-at p [:status]))))))
+

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_after_rings_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_after_rings_helpers_cljs_test.cljc
@@ -46,13 +46,20 @@
            :epoch        epoch}}))
 
 (defn- fired
-  [id machine-id state epoch & {:keys [fired?] :or {fired? true}}]
+  "`:delay` is optional — real `:rf.machine.timer/fired` traces always
+  carry it (the resolved ms value, stable across a timer's whole
+  lifecycle; `machines/transition.cljc emit-pick-traces!`), and rf2-2es2x8
+  needs it in fixtures exercising MULTIPLE concurrent `:after` timers on
+  one state (same `machine-id`/`state`/`epoch`, different `:delay`) so a
+  `:fired` for ONE delay closes only that timer's record."
+  [id machine-id state epoch & {:keys [fired? delay] :or {fired? true}}]
   {:id id :time id
    :operation :rf.machine.timer/fired
-   :tags {:machine-id machine-id
-          :state      state
-          :epoch      epoch
-          :fired?     fired?}})
+   :tags (cond-> {:machine-id machine-id
+                  :state      state
+                  :epoch      epoch
+                  :fired?     fired?}
+           (some? delay) (assoc :delay delay))})
 
 (defn- stale-after
   [id machine-id state scheduled-epoch current-epoch]
@@ -197,6 +204,41 @@
             fired (some #(when (= :fired (:status %)) %) (vals t))]
         (is (= 1 (:epoch armed)))
         (is (= 0 (:epoch fired)))))))
+
+(deftest fold-multiple-after-timers-same-state-same-epoch-stay-independent
+  (testing "rf2-2es2x8 — a state declaring MULTIPLE :after entries
+            ({:after {5000 :warn 30000 :timeout}}) schedules both timers
+            CONCURRENTLY at the SAME (machine-id, state, epoch) —
+            build-after-fx computes ONE epoch per scheduling node, reused
+            across every entry in that node's :after map (Spec 005
+            §Multiple :after per state). Before the fix `timer-key`
+            omitted the :delay discriminator, so the SECOND :scheduled
+            assoc-overwrote the first record at the identical key and
+            only one ring survived."
+    (let [t (h/fold-timer-events
+              [(scheduled 1000 :auth/login :idle 5000  0)
+               (scheduled 1000 :auth/login :idle 30000 0)])]
+      (is (= 2 (count t))
+          "both concurrent timers get their own independent fold record")
+      (is (= #{5000 30000} (set (map :duration-ms (vals t))))
+          "each record keeps its own delay/duration"))))
+
+(deftest fold-multiple-after-timers-fire-independently
+  (testing "rf2-2es2x8 — a :fired event for ONE delay closes only that
+            timer's record; the concurrent timer at the same
+            (machine-id, state, epoch) but a DIFFERENT delay stays
+            :armed, untouched"
+    (let [t (h/fold-timer-events
+              [(scheduled 1000 :auth/login :idle 5000  0)
+               (scheduled 1000 :auth/login :idle 30000 0)
+               (fired     6000 :auth/login :idle 0 :delay 5000)])
+          by-duration (into {} (map (fn [r] [(:duration-ms r) r]) (vals t)))]
+      (is (= 2 (count t)) "both records still present after the fire")
+      (is (= :fired (:status (get by-duration 5000)))
+          "the 5000ms timer's fired trace closed its own record")
+      (is (= :armed (:status (get by-duration 30000)))
+          "the concurrent 30000ms timer did NOT collapse into the fired
+           record — it keeps counting down independently"))))
 
 (deftest fold-ignores-events-without-machine-id-or-state
   (let [bad-machine {:id 1 :time 1

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_after_rings_tick_loop_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_after_rings_tick_loop_cljs_test.cljs
@@ -1,0 +1,142 @@
+(ns day8.re-frame2-xray.panels.machine-after-rings-tick-loop-cljs-test
+  "Off-render `tick-loop!` regression coverage (rf2-nms77h).
+
+  Sibling to `machine_after_rings_cljs_test.cljs`. Lives in a SEPARATE ns
+  so the `use-fixtures` map shape `cljs.test/async` requires does not
+  conflict with the fn-form `test-support/make-reset-runtime-fixture`
+  the existing after-rings tests use — mirrors the split
+  `settings/popup_dispatch_routing_cljs_test.cljs` uses for the same
+  reason.
+
+  ## The bug this test defends against
+
+  `tick-loop!` is the rAF/next-tick callback that drives the countdown
+  rings' sweep. It runs OFF-render — by the time it actually fires, any
+  `with-frame` / Provider scope active when `kick-tick!` armed it has
+  already unwound (a rAF/next-tick callback always resumes on a LATER
+  macro/microtask, after the synchronous call that scheduled it
+  returns). Before the fix its two internal reads (the active-timers sub
+  + the scrubber sub) used the ambient 1-arity `rf/subscribe`, which has
+  NO `:rf/default` floor and raises `:rf.error/no-frame-context` with no
+  scope established — the FIRST expression in the loop's body, so it
+  threw before `:rf.xray/timer-tick` was ever dispatched. The loop's
+  defensive `catch` swallowed that error every iteration and set
+  `:running? false`, so `:rings/now-ms` never advanced and the ring
+  painted once but never swept — silently, no console error. The fix
+  reads via the explicit-frame `(rf/subscribe query-v {:frame frame})`
+  opts form, targeting the frame captured in `tick-state` at
+  `kick-tick!` time.
+
+  ## Why this test invokes the private `tick-loop!` directly
+
+  Calling it outside `rf/with-frame` reproduces the EXACT off-render
+  condition deterministically (no waiting on the real rAF/next-tick
+  queue to invoke the callback itself). Its OWN `:rf.xray/timer-tick`
+  dispatch is still the real async `rf/dispatch` (not `dispatch-sync`),
+  so the test awaits the router drain via `test-support/poll-until`
+  under `cljs.test/async`, matching this codebase's standard pattern for
+  asserting on a queued (non-sync) dispatch."
+  (:require [cljs.test :refer-macros [deftest is use-fixtures async]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.adapter :as substrate-adapter]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-support :as xray-test-support]
+            [day8.re-frame2-xray.trace-collector :as trace-collector]
+            [day8.re-frame2-xray.panels.machine-after-rings :as after-rings]))
+
+;; ---- fixture (map shape per cljs.test/async requirement) ---------------
+
+(def ^:private fixture-snap (atom nil))
+
+(defn- setup-runtime! []
+  (xray-test-support/reset-all!)
+  (trace-collector/reset-for-test!)
+  (after-rings/stop-tick!)
+  ;; Snapshot the framework registrar so we can restore it post-test,
+  ;; matching the body of `test-support/make-reset-runtime-fixture`.
+  (reset! fixture-snap (test-support/snapshot-registrar))
+  (reset! frame/frames {})
+  (substrate-adapter/dispose-adapter!)
+  (substrate-adapter/install-adapter! plain-atom/adapter)
+  (frame/ensure-default-frame!)
+  (registry/register-xray-handlers!)
+  (xray-test-support/install-test-overrides!)
+  (frame/reg-frame :rf/xray {}))
+
+(defn- teardown-runtime! []
+  (after-rings/stop-tick!)
+  (when-let [snap @fixture-snap]
+    (test-support/restore-registrar! snap)
+    (reset! fixture-snap nil))
+  (reset! frame/frames {}))
+
+(use-fixtures :each
+  {:before setup-runtime!
+   :after  teardown-runtime!})
+
+;; ---- fixture data (mirrors machine_after_rings_cljs_test.cljs) --------
+
+(def ^:private fixture-definition
+  {:initial :idle
+   :states  {:idle    {:on    {:start :authing}
+                       :after {5000 :timeout}}
+             :authing {:on {:ok :done}}
+             :timeout {:on {:retry :idle}}
+             :done    {:final? true}}})
+
+(defn- override-machines! [machines]
+  (rf/dispatch-sync
+    [:rf.xray/set-registered-machines-override-for-test machines]))
+
+(defn- override-definitions! [definitions]
+  (rf/dispatch-sync
+    [:rf.xray/set-machine-definitions-override-for-test definitions]))
+
+(defn- push-scheduled!
+  [id machine-id state delay epoch]
+  (trace-collector/seed-trace-for-test!
+    {:id id :time id
+     :operation :rf.machine.timer/scheduled
+     :tags {:machine-id machine-id
+            :state state
+            :delay delay
+            :delay-source :literal
+            :epoch epoch}}))
+
+;; ---- rf2-nms77h — off-render tick-loop! dispatches with no ambient frame --
+
+(deftest tick-loop-runs-off-render-without-ambient-frame-context
+  (async done
+    (rf/with-frame :rf/xray
+      (override-machines!    [:auth/login])
+      (override-definitions! {:auth/login fixture-definition})
+      (push-scheduled! 1000 :auth/login :idle 5000 0)
+      ;; `kick-tick!` captures `:rf/xray` as the surrounding instance
+      ;; frame (mirrors the overlay reg-view's `rf/current-frame-id`
+      ;; capture at render time) into `tick-state`.
+      (after-rings/kick-tick! :rf/xray))
+    (is (nil? (:rings/now-ms (frame/frame-app-db-value :rf/xray)))
+        "sanity: nothing has bumped now-ms yet")
+    ;; Runs OUTSIDE `rf/with-frame` — the off-render condition the bug
+    ;; hits.
+    (#'day8.re-frame2-xray.panels.machine-after-rings/tick-loop!)
+    (-> (test-support/poll-until
+          #(pos? (or (:rings/now-ms (frame/frame-app-db-value :rf/xray)) 0))
+          {:label "tick-loop! dispatch drained onto :rf/xray"})
+        (.then (fn [_]
+                 (is (pos? (:rings/now-ms (frame/frame-app-db-value :rf/xray)))
+                     "the loop's :rf.xray/timer-tick dispatch landed on the
+                      captured :rf/xray frame — now-ms was bumped, proving
+                      the two internal reads did NOT hit
+                      :rf.error/no-frame-context (pre-fix this slot stayed
+                      nil forever: the throw happened before dispatch, and
+                      the catch swallowed it silently every iteration)")
+                 (done)))
+        (.catch (fn [e]
+                  (is false
+                      (str "tick-loop! never dispatched :rf.xray/timer-tick "
+                           "onto :rf/xray — " (.-message e)))
+                  (done))))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/machines/trace_state_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machines/trace_state_cljs_test.cljs
@@ -419,6 +419,94 @@
       (is (= #{(:id local-edge)} fired)
           "the state-local edge lights; the machine-level fallback is not pulled in"))))
 
+;; ---- inherited-transition fired-edge match (rf2-6e8rh8) -----------------
+;;
+;; Per Spec 005 deepest-wins, a transition declared on a compound ANCESTOR
+;; applies to a descendant leaf that doesn't override it. The runtime's
+;; `:before`/`:after` :state is the actual LEAF; `chart.layout/project-
+;; definition` projects the edge's `:from-path`/`:to-path` at the DECLARING
+;; path (the ancestor for an inherited source; the flat declared target —
+;; NOT initial-descended — for a compound target). Exact `=` never matches
+;; either; `single-transition-fired-ids` now matches via `on-active-path?`
+;; (a possibly-equal prefix test), mirroring the rf2-tjm3u2 guard-blocked
+;; fix's `on-active-path?` treatment.
+
+(deftest fired-ids-inherited-transition-on-active-path
+  (testing "rf2-6e8rh8 — an INHERITED transition (declared on an ANCESTOR
+            still on the active path) is matched: the ancestor's
+            :from-path is a strict PREFIX of the runtime's actual leaf
+            :before :state, not an exact match"
+    (let [;; `:open` is a COMPOUND with `:door/close` declared at the
+          ;; PARENT level; the active leaf is `[:open :wide]` (no override
+          ;; declared at the leaf, so the ancestor's transition applies).
+          def      {:initial :open
+                    :states  {:open {:initial :wide
+                                     :on      {:door/close :closed}
+                                     :states  {:wide {} :narrow {}}}
+                              :closed {}}}
+          close-id (canonical-edge-id def [:open] [:closed] :door/close)
+          events   [{:operation :rf.machine/transition
+                     :tags {:machine-id :door
+                            :before {:state [:open :wide]}
+                            :after  {:state :closed}
+                            :event  :door/close}}]
+          fired    (trace-state/extract-fired-edge-ids def events :door)]
+      (is (string? close-id))
+      (is (= #{close-id} fired)
+          "the inherited edge lights — its [:open] :from-path is a prefix
+           of the runtime's actual [:open :wide] leaf, matched via
+           on-active-path? rather than exact equality"))))
+
+(deftest fired-ids-compound-target-initial-descent
+  (testing "rf2-6e8rh8 — a transition TARGETING a compound state
+            initial-descends to a deeper leaf at runtime; the edge's
+            declared :to-path ([:open], the flat compound target — Not
+            initial-descended by chart.layout/resolve-target-path) is a
+            prefix of the runtime's landed leaf ([:open :wide]), not an
+            exact match"
+    (let [def      {:initial :closed
+                    :states  {:closed {:on {:door/open :open}}
+                              :open   {:initial :wide
+                                       :states  {:wide {} :narrow {}}}}}
+          open-id  (canonical-edge-id def [:closed] [:open] :door/open)
+          events   [{:operation :rf.machine/transition
+                     :tags {:machine-id :door
+                            :before {:state :closed}
+                            :after  {:state [:open :wide]}
+                            :event  :door/open}}]
+          fired    (trace-state/extract-fired-edge-ids def events :door)]
+      (is (string? open-id))
+      (is (= #{open-id} fired)
+          "the edge's declared :to-path [:open] is a prefix of the actual
+           landed leaf [:open :wide] — matched via on-active-path?"))))
+
+(deftest fired-ids-sibling-not-matched-by-inherited-prefix
+  (testing "rf2-6e8rh8 — the prefix match does NOT over-match a sibling
+            state's edge: only an ancestor ON the active path qualifies"
+    (let [;; `:open` and `:closed` are siblings; both declare `:door/audit`.
+          ;; The active leaf is under `:open`, so only :open's edge (an
+          ;; exact state-local match here) may light — :closed's identical-
+          ;; event edge must NOT.
+          def      {:initial :open
+                    :states  {:open   {:initial :wide
+                                       :on      {:door/audit :open}
+                                       :states  {:wide {} :narrow {}}}
+                              :closed {:on {:door/audit :closed}}}}
+          open-id  (canonical-edge-id def [:open] [:open] :door/audit)
+          closed-id (canonical-edge-id def [:closed] [:closed] :door/audit)
+          events   [{:operation :rf.machine/transition
+                     :tags {:machine-id :door
+                            :before {:state [:open :wide]}
+                            :after  {:state :open}
+                            :event  :door/audit}}]
+          fired    (trace-state/extract-fired-edge-ids def events :door)]
+      (is (string? open-id))
+      (is (string? closed-id))
+      (is (not= open-id closed-id))
+      (is (= #{open-id} fired)
+          "only :open's edge lights — :closed's identical-event edge is
+           NOT a prefix of the active [:open :wide] leaf"))))
+
 ;; ---- extract-guard-blocked-edge-ids (rf2-fzrzlw) ------------------------
 ;;
 ;; A guard-blocked transition is a NO-OP: the guard evaluated fail/threw, so


### PR DESCRIPTION
Four verified `/tools`-sweep bugs on the `tools/xray/` surface, each with a regression test and a spec-ratchet update in the same PR. All changes confined to `tools/xray/**` (src + spec + test).

## rf2-nms77h (P2) — `:after` countdown rings never animate
`tick-loop!` is a rAF/next-tick callback that runs OFF-render, so no frame scope is established by the time it fires. Its two internal reads used the ambient 1-arity `rf/subscribe`, which has NO `:rf/default` floor and raises `:rf.error/no-frame-context` — the first expression in the loop body, thrown before `:rf.xray/timer-tick` was ever dispatched. The defensive `catch` swallowed that error every iteration and set `:running? false`, silently self-terminating the sweep (ring painted once, never advanced).
- **Fix** (`machine_after_rings.cljs`): read via the explicit-frame `(rf/subscribe query-v {:frame frame})` opts form, targeting the frame captured in `tick-state` at `kick-tick!` time — the same frame the dispatch already correctly targeted.
- **Test**: new `machine_after_rings_tick_loop_cljs_test.cljs` (dedicated ns for the `cljs.test/async` fixture-map shape). Invokes the private `tick-loop!` OUTSIDE `with-frame` (the off-render condition) and awaits the async router drain via `test-support/poll-until`; asserts `:rings/now-ms` was bumped. Verified it fails when the fix is reverted (sanity-break check).
- **Spec**: unchanged because the docstring-level contract (reads target the captured frame) was already the documented intent — the bug was that the code contradicted it; no normative spec statement changed.

## rf2-2es2x8 (P2) — multiple `:after` timers on one state collapse into a single ring
`build-after-fx` computes ONE epoch per scheduling node and reuses it across every entry in that node's `:after` map, so two concurrent timers (`{:after {5000 :warn 30000 :timeout}}`) share `(machine-id, state, epoch)` and the fold's second `:scheduled` overwrote the first.
- **Fix** (`machine_after_rings_helpers.cljc`): `timer-key` now includes the `:delay` discriminator (carried on every `:rf.machine.timer/*` trace, stable across a timer's lifecycle); `update-or-cancel`'s fallback path is narrowed by `:delay` too so a `:fired` for one delay closes only that timer.
- **Test**: `machine_after_rings_helpers_cljs_test.cljc` — two new tests (concurrent same-state/same-epoch timers stay independent records; a `:fired` for one delay leaves the other `:armed`). Added an optional `:delay` to the `fired` fixture helper.
- **Spec**: `tools/xray/spec/003` — updated (Folding-algorithm section already exists in-code; the doc lives in the helper docstring + the Machine-Inspector spec's key description, both updated to `(machine-id, state, epoch, delay)`).

## rf2-6e8rh8 (P2) — no fired edge lit for an inherited (ancestor-declared) transition
`single-transition-fired-ids` required exact `(from-path, to-path)` equality vs the projected edge. Per Spec 005 deepest-wins, an inherited transition fires with the runtime's `:before :state` at the active LEAF (`[:open :wide]`) while `chart.layout/project-definition` projects the edge's `:from-path` at the DECLARING ancestor (`[:open]`) — never `=`. Compound-target initial-descent breaks the `to*` side symmetrically.
- **Fix** (`trace_state.cljs`): match `from*`/`to*` via `on-active-path?` (possibly-equal PREFIX test), reusing the predicate `extract-guard-blocked-edge-ids` already used for the analogous rf2-tjm3u2 case (moved it up so both share it). State-local edges still match (count-equal prefix); siblings on a different branch stay excluded.
- **Test**: `trace_state_cljs_test.cljs` — three new tests (inherited transition from a compound leaf lights the ancestor's edge; compound-target initial-descent; sibling not over-matched by the prefix). Ids projected through the live `chart.layout/project-definition` (agreement-by-construction).
- **Spec**: `tools/xray/spec/003` — new §"Inherited-transition fired-edge highlight (rf2-6e8rh8)" + cross-ref from the single-active paragraph.

## rf2-96csq4 (P2) — App-DB diff engine vector `:r` resolves `:before` incorrectly
`diff/engine.cljc` projected a vector `:r` edit's `:before` via a raw `(value-at before path)` using the post-shift editscript index. Editscript applies vector edits sequentially against an evolving sequence, so a `:r`'s edit-index addresses the FINAL after-vector; when a prior `:+`/`:-` at the same parent shifted positions, the raw read hit the wrong (or out-of-range) slot — losing the removal and misclassifying the slot as `:added`. Repro: `[:x :y] → [:new :x :z]` ⇒ `[[0] :+ :new] [[2] :r :z]`; `(value-at before [2])` is out-of-range, `:y` never surfaces.
- **Fix** (`engine.cljc`): resolve the `:r` before-value through the SAME unified replay `:slots` that already feed the removals + shift channels (`slots[after-idx]` IS the true before-index). Also removed a second re-derive site in Step 2 that discarded Step 1's correct `:before` and recomputed the wrong one. Non-vector `:r` (map key / scalar / root) is untouched (never index-shifted).
- **Test**: `engine_cljs_test.cljc` — three new tests (insert-then-replace resolves the true before-index; delete-then-replace; map-key `:r` unaffected). Editscript outputs verified against 0.6.5.
- **Spec**: `tools/xray/spec/004` — new paragraph under the rf2-3eplfk replay section documenting the `:r` before-value replay resolution.

## Quality gates
- `tools/xray/` `clojure -M:test` → **1225 tests, 5667 assertions, 0 failures, 0 errors**
- `implementation/` `npm run test:cljs` → **8073 tests, 37088 assertions, 0 failures, 0 errors** (exercises the new CLJS async tick-loop test + all `.cljc` tests on the node runtime)
- `implementation/` `npm run test:xray-feature-gate` → **16 scenarios, 0 failures, 13 matrix rows, exit 0** (nightly-full sweep)
- `mkdocs build --strict` → N/A: the changed spec files live under `tools/xray/spec/` which is not part of the mkdocs nav tree.

## Risks
- Low. Each fix is narrow and additive; the diff-engine `:r` change reuses an existing replay walk (no new algorithm), and all three other fixes reuse patterns already established elsewhere in the same files (explicit-frame subscribe; `:delay` discriminator; `on-active-path?` prefix match). Full JVM + CLJS + feature-gate suites green with the new regression tests.
