### PR TITLE
fix(pair-mcp): wholesale-guard slice-mode arg + route :ok? false through isError:true per spec/003 (rf2-brpc6v/acckgr)

### DIFF
--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/discover_app.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/discover_app.cljs
@@ -168,15 +168,24 @@
         (.then
           (fn [health]
             (cond
+              ;; rf2-acckgr: an unhealthy runtime (`:ok? false`) is a
+              ;; known-tool failure per spec/003's universal isError
+              ;; rule, not a success carrying bad news — err-text (not
+              ;; ok-text) so the host surfaces it as a failure and the
+              ;; response cache never masks it.
               (not (:ok? health))
-              (js/Promise.resolve (wire/ok-text health))
+              (js/Promise.resolve (wire/err-text health))
 
+              ;; rf2-acckgr: same universal isError rule — a
+              ;; precondition failure (`:ok? false`) built by the tool
+              ;; itself is still a known-tool failure, not a success
+              ;; carrying bad news.
               (not (:debug-enabled? health))
               (js/Promise.resolve
-                (wire/ok-text {:ok? false :reason :debug-disabled
-                               :hint (str "re-frame.interop/debug-enabled? is false. "
-                                          "This is a production build (or goog.DEBUG was "
-                                          "forced off). Trace and epoch surfaces are elided.")}))
+                (wire/err-text {:ok? false :reason :debug-disabled
+                                :hint (str "re-frame.interop/debug-enabled? is false. "
+                                           "This is a production build (or goog.DEBUG was "
+                                           "forced off). Trace and epoch surfaces are elided.")}))
 
               (empty? (:frames health))
               (js/Promise.resolve
@@ -187,11 +196,11 @@
                 ;; own frame explicitly (`reg-frame` / a root provider), so
                 ;; the hint points at app boot / explicit registration
                 ;; rather than teaching `init!` as a way to create a default.
-                (wire/ok-text {:ok? false :reason :no-frames-registered
-                               :hint (str "No frames registered yet. Wait for the app to boot, "
-                                          "or register a frame explicitly "
-                                          "(`re-frame.core/reg-frame` / a root frame-provider). "
-                                          "`rf/init!` installs adapters but does NOT create a frame.")}))
+                (wire/err-text {:ok? false :reason :no-frames-registered
+                                :hint (str "No frames registered yet. Wait for the app to boot, "
+                                           "or register a frame explicitly "
+                                           "(`re-frame.core/reg-frame` / a root frame-provider). "
+                                           "`rf/init!` installs adapters but does NOT create a frame.")}))
 
               (:ambiguous-frame? health)
               (do

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/eval_cljs.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/eval_cljs.cljs
@@ -170,34 +170,41 @@
                     :value value
                     :build resolved-build}))
 
+   ;; rf2-acckgr: :on-rejected / :on-timeout / :on-missing all build
+   ;; `:ok? false` envelopes — per spec/003's universal isError rule
+   ;; every one of them MUST ride as `wire/err-text` (isError: true), not
+   ;; `wire/ok-text`. A rejected/timed-out/missing-mailbox await is a
+   ;; known-tool failure, not a success carrying bad news — leaving it
+   ;; ok-text lets it cache as a normal success and read as green by the
+   ;; MCP host.
    :on-rejected
    (fn [{:keys [rejection]}]
-     (wire/ok-text {:ok?       false
-                    :reason    :rf.error/eval-cljs-rejected
-                    :rejection rejection
-                    :build     resolved-build}))
+     (wire/err-text {:ok?       false
+                     :reason    :rf.error/eval-cljs-rejected
+                     :rejection rejection
+                     :build     resolved-build}))
 
    :on-timeout
    (fn [_]
-     (wire/ok-text {:ok?        false
-                    :reason     :rf.error/eval-cljs-timeout
-                    :timeout-ms timeout-ms
-                    :build      resolved-build}))
+     (wire/err-text {:ok?        false
+                     :reason     :rf.error/eval-cljs-timeout
+                     :timeout-ms timeout-ms
+                     :build      resolved-build}))
 
    :on-missing
    (fn [{:keys [reason sentinel]}]
      (if (= :bad-sentinel reason)
-       (wire/ok-text {:ok?      false
-                      :reason   :rf.error/eval-cljs-await-wrap-failed
-                      :hint     "the await wrapper returned an unrecognised sentinel"
-                      :sentinel sentinel
-                      :build    resolved-build})
-       (wire/ok-text {:ok?    false
-                      :reason :rf.error/eval-cljs-mailbox-missing
-                      :hint   (str "eval-cljs await mailbox vanished before the result was read. "
-                                   "This indicates a wire-shape regression or a page-reload "
-                                   "destroying the mailbox between the wrap and the poll.")
-                      :build  resolved-build})))})
+       (wire/err-text {:ok?      false
+                       :reason   :rf.error/eval-cljs-await-wrap-failed
+                       :hint     "the await wrapper returned an unrecognised sentinel"
+                       :sentinel sentinel
+                       :build    resolved-build})
+       (wire/err-text {:ok?    false
+                       :reason :rf.error/eval-cljs-mailbox-missing
+                       :hint   (str "eval-cljs await mailbox vanished before the result was read. "
+                                    "This indicates a wire-shape regression or a page-reload "
+                                    "destroying the mailbox between the wrap and the poll.")
+                       :build  resolved-build})))})
 
 ;; ---------------------------------------------------------------------------
 ;; Tool entry point.

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/get_path.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/get_path.cljs
@@ -183,31 +183,47 @@
           (probe/eval-after-runtime-signalled!
             conn build-id form :get-path-failed
             (fn [envelope]
-              (let [server-elided (when (:ok? envelope) (:elided-count envelope))
-                    {:keys [value indicators]}
-                    (wp/run-wire-pipeline
-                      (pluck envelope)
-                      {:kind :scalar-value
-                       :server-elided server-elided})
-                    {:keys [elided]} indicators
-                    rebuilt (wire/with-indicators
-                              (rebuild (dissoc envelope :elided-count) value)
-                              {:elided elided})]
-                ;; A known-tool runtime failure (`:ok? false`, e.g. a
-                ;; singular `:path-not-found` miss) MUST ride back as an
-                ;; `isError` envelope, per the published wire
-                ;; contract (spec/001-Wire-Protocol.md, API.md
-                ;; §isError) and the dispatch/read-sub
-                ;; no-silent-success parity model. An `ok-text`
-                ;; wrapper would let the failure cache as a normal
-                ;; success (cache eligibility keys off `isError`, not
-                ;; `:ok?`) and read as green by the MCP host. The
-                ;; `:wholesale-read-of-reserved-frame` refusal is
-                ;; built upstream as its own `err-text` and never
-                ;; reaches this tail.
-                (if (false? (:ok? rebuilt))
-                  (wire/err-text rebuilt)
-                  (wire/ok-text rebuilt))))))]
+              ;; rf2-acckgr: a nil / non-map `envelope` (a dead runtime
+              ;; after a page reload, answering blank) must NOT fall
+              ;; through to the `:ok? false` check below — `(:ok?
+              ;; nil)` is `nil`, not `false`, so `(false? (:ok?
+              ;; rebuilt))` would silently pass and ship an ok-text
+              ;; envelope built from a nil `rebuilt`. Guard it up front,
+              ;; mirroring `read-sub`'s `(and (map? envelope) (:ok?
+              ;; envelope))` non-map guard.
+              (if-not (map? envelope)
+                (wire/err-text {:ok?    false
+                                :reason :blank-eval-result
+                                :value  envelope
+                                :hint   (str "get-path got a blank/non-map result from the "
+                                             "runtime — likely a page reload dropped the "
+                                             "connection mid-read. Retry; if it persists, "
+                                             "call discover-app to confirm the runtime is live.")})
+                (let [server-elided (when (:ok? envelope) (:elided-count envelope))
+                      {:keys [value indicators]}
+                      (wp/run-wire-pipeline
+                        (pluck envelope)
+                        {:kind :scalar-value
+                         :server-elided server-elided})
+                      {:keys [elided]} indicators
+                      rebuilt (wire/with-indicators
+                                (rebuild (dissoc envelope :elided-count) value)
+                                {:elided elided})]
+                  ;; A known-tool runtime failure (`:ok? false`, e.g. a
+                  ;; singular `:path-not-found` miss) MUST ride back as an
+                  ;; `isError` envelope, per the published wire
+                  ;; contract (spec/001-Wire-Protocol.md, API.md
+                  ;; §isError) and the dispatch/read-sub
+                  ;; no-silent-success parity model. An `ok-text`
+                  ;; wrapper would let the failure cache as a normal
+                  ;; success (cache eligibility keys off `isError`, not
+                  ;; `:ok?`) and read as green by the MCP host. The
+                  ;; `:wholesale-read-of-reserved-frame` refusal is
+                  ;; built upstream as its own `err-text` and never
+                  ;; reaches this tail.
+                  (if (false? (:ok? rebuilt))
+                    (wire/err-text rebuilt)
+                    (wire/ok-text rebuilt)))))))]
     (cond
       ;; Server-side backstop: refuse a WHOLESALE root read
       ;; (`path: []`, or a `[]` element in a batch `paths`) of a reserved

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/handler_meta.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/handler_meta.cljs
@@ -316,9 +316,17 @@
                       ;;     healthy runtime): surface :unexpected-shape.
                       (stamp-frame
                         (cond
+                          ;; rf2-acckgr: a genuine shape defect (should
+                          ;; not happen against a healthy runtime) —
+                          ;; NOT a legitimate structured miss like
+                          ;; :not-registered below. Stamp it with the
+                          ;; codec's own error meta so `renv/error?`
+                          ;; routes it through `wire/err-text` instead
+                          ;; of silently riding back as ok-text.
                           (not (map? meta-map))
-                          {:ok? false :reason :unexpected-shape
-                           :kind kind :id id-val :value meta-map}
+                          (renv/mark-codec-error
+                            {:ok? false :reason :unexpected-shape
+                             :kind kind :id id-val :value meta-map})
 
                           (false? (:ok? meta-map))
                           (assoc meta-map :kind kind :id id-val)

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/operating_frame.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/operating_frame.cljs
@@ -231,10 +231,15 @@
     (probe/eval-after-runtime!
       conn build-id form :reset-operating-frame-failed
       (fn [v]
-        (wire/ok-text
-          (if (map? v)
-            v
-            {:ok? false :reason :unexpected-shape :value v}))))))
+        ;; rf2-acckgr: `frames-list` (via `select-frame!` here) always
+        ;; answers `:ok? true` against a live runtime, so a non-map `v`
+        ;; means the eval came back blank/degraded — a known-tool
+        ;; failure, not a success carrying bad news. err-text (not
+        ;; ok-text), mirroring the sibling guard in
+        ;; `set-operating-frame-tool`.
+        (if (map? v)
+          (wire/ok-text v)
+          (wire/err-text {:ok? false :reason :unexpected-shape :value v}))))))
 
 (def operating-frame-mutating-tools
   "Tool names whose successful invocation changes the session's operating
@@ -271,7 +276,10 @@
     (probe/eval-after-runtime!
       conn build-id form :get-operating-frame-failed
       (fn [v]
-        (wire/ok-text
-          (if (map? v)
-            v
-            {:ok? false :reason :unexpected-shape :value v}))))))
+        ;; rf2-acckgr: `frames-list` always answers `:ok? true` against
+        ;; a live runtime, so a non-map `v` means the eval came back
+        ;; blank/degraded — a known-tool failure, not a success carrying
+        ;; bad news. err-text (not ok-text).
+        (if (map? v)
+          (wire/ok-text v)
+          (wire/err-text {:ok? false :reason :unexpected-shape :value v}))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/result_envelope.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/result_envelope.cljs
@@ -317,6 +317,26 @@
   [result-map]
   (boolean (some-> result-map meta ::codec-error)))
 
+(defn mark-codec-error
+  "Stamp `result-map` with the same `::codec-error` metadata
+  `envelope->result` attaches to its own `:eval-error` /
+  `:unserializable` / unknown-tag projections, so `error?` treats it as
+  a genuine transport/codec-level fault (routes to `wire/err-text`)
+  rather than a legitimate `on-value` structured answer (`wire/
+  ok-text`).
+
+  For a tool's OWN `on-value` shaper to reach for when it detects a
+  shape the runtime should never produce against a healthy build — e.g.
+  `handler-meta`'s `:unexpected-shape` (a non-map meta-map back from an
+  otherwise-successful eval) — that isn't one of `envelope->result`'s
+  own tagged outcomes but IS a defect signal, not a miss like
+  `:not-registered`. rf2-acckgr: without this stamp such a map lacks
+  the `::codec-error` meta `error?` keys off, so it silently rode back
+  as `wire/ok-text` despite carrying `:ok? false` — masking the defect
+  as a success per spec/003's universal isError rule."
+  [result-map]
+  (with-meta result-map {::codec-error true}))
+
 ;; `truncate-preview` (the test-only preview-shape helper) lives in
 ;; `re-frame2-pair-mcp.test-utils/truncate-preview` — the
 ;; MCP server never calls it; only tests assert the preview contract.

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/snapshot.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/snapshot.cljs
@@ -233,7 +233,7 @@
     ;; away from this; the guard enforces it so a stray full
     ;; read can't blow the context window. Sliced reads + the default
     ;; `:app` scope (reserved frames already excluded) pass through.
-    (if-let [refused (guard/snapshot-refusal frames path mode)]
+    (if-let [refused (guard/snapshot-refusal frames path slice-mode)]
       (js/Promise.resolve refused)
       (probe/eval-after-runtime-signalled!
         conn build-id form :snapshot-failed

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/tail_build.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/tail_build.cljs
@@ -111,8 +111,14 @@
                                   (fn []
                                     (let [elapsed (- (js/Date.now) start)]
                                       (if (>= elapsed wait-ms)
+                                        ;; rf2-acckgr: a timed-out probe
+                                        ;; wait is `:ok? false` — a
+                                        ;; known-tool failure per
+                                        ;; spec/003's universal isError
+                                        ;; rule, not a success carrying
+                                        ;; bad news.
                                         (resolve
-                                          (wire/ok-text
+                                          (wire/err-text
                                             {:ok?           false
                                              :reason        :timed-out
                                              :timed-out?    true
@@ -141,7 +147,9 @@
                 ;; (distinct from :timed-out, which means "polled but
                 ;; never changed"). With probe-error included the
                 ;; operator gets the underlying exception verbatim.
-                (wire/ok-text {:ok?         false
-                               :reason      :probe-errored
-                               :probe-error (.-message err)
-                               :note        probe-errored-note}))))))))
+                ;; rf2-acckgr: `:ok? false` MUST ride as err-text per
+                ;; spec/003's universal isError rule.
+                (wire/err-text {:ok?         false
+                                :reason      :probe-errored
+                                :probe-error (.-message err)
+                                :note        probe-errored-note}))))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
@@ -512,9 +512,12 @@
      :edn-submap {:ok? true :value {:hello "world"} :build :app}}}
 
    ;; Await + rejected thenable: the mailbox-read returns :rejected;
-   ;; the server surfaces :rf.error/eval-cljs-rejected.
+   ;; the server surfaces :rf.error/eval-cljs-rejected. rf2-acckgr: this
+   ;; is a known-tool failure and MUST be isError: true per spec/003's
+   ;; universal isError rule — it used to ride back as ok-text
+   ;; (isError: false), masking the rejection as a success.
    {:fixture/id    :eval-cljs/await-rejected
-    :fixture/doc   "eval-cljs :await true on a thenable that rejects returns {:ok? false :reason :rf.error/eval-cljs-rejected :rejection <pr-str>} (rf2-xn4f9)."
+    :fixture/doc   "eval-cljs :await true on a thenable that rejects returns {:ok? false :reason :rf.error/eval-cljs-rejected :rejection <pr-str>} as an isError envelope (rf2-xn4f9 / rf2-acckgr)."
     :fixture/tool  "eval-cljs"
     :fixture/args  {:form "(js/Promise.reject (ex-info \"nope\" {}))"
                     :await true :build "app"}
@@ -524,7 +527,7 @@
      ["cljs.reader/read-string"    {:status :rejected :rejection "#error {:message \"nope\"}"}]
      [:default                     nil]]
     :fixture/expect
-    {:isError? false
+    {:isError? true
      :edn-submap {:ok? false
                   :reason :rf.error/eval-cljs-rejected
                   :rejection "#error {:message \"nope\"}"

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/discover_app_representation_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/discover_app_representation_test.cljs
@@ -93,3 +93,67 @@
                 (is (str/includes? (tu/extract-text result) ":build-id :examples/step-deck")
                     "rendered with its colon in the canonical text"))
               (done)))))))
+
+(deftest discover-app-unhealthy-runtime-is-isError
+  ;; rf2-acckgr regression: an unhealthy runtime (`:ok? false` from
+  ;; `runtime-health!`) is a known-tool failure per spec/003's universal
+  ;; isError rule, not a success carrying bad news. It used to ride back
+  ;; as ok-text (isError: false), masking the failure as a success.
+  (async done
+    (let [conn (fresh-conn)
+          _    (prime! conn :examples/step-deck)
+          args (tu/args->js {:build "examples/step-deck"})
+          unhealthy {:ok?    false
+                     :reason :rf.error/some-runtime-fault
+                     :hint   "the runtime reported a fault"}]
+      (-> (tu/with-stubbed-eval! unhealthy
+            (fn [] (discover-app/discover-app conn args)))
+          (.then
+            (fn [result]
+              (is (tu/error? result)
+                  "an unhealthy runtime MUST be isError: true")
+              (let [edn (tu/extract-edn result)]
+                (is (false? (:ok? edn)))
+                (is (= :rf.error/some-runtime-fault (:reason edn))))
+              (done)))))))
+
+(deftest discover-app-debug-disabled-is-isError
+  ;; rf2-acckgr regression: `:debug-disabled` is a tool-built `:ok?
+  ;; false` precondition failure — same universal isError rule as the
+  ;; unhealthy-runtime branch above. It used to ride back as ok-text.
+  (async done
+    (let [conn (fresh-conn)
+          _    (prime! conn :examples/step-deck)
+          args (tu/args->js {:build "examples/step-deck"})
+          debug-off {:ok? true :debug-enabled? false :frames [:rf/default]}]
+      (-> (tu/with-stubbed-eval! debug-off
+            (fn [] (discover-app/discover-app conn args)))
+          (.then
+            (fn [result]
+              (is (tu/error? result)
+                  "a debug-disabled build MUST be isError: true")
+              (let [edn (tu/extract-edn result)]
+                (is (false? (:ok? edn)))
+                (is (= :debug-disabled (:reason edn))))
+              (done)))))))
+
+(deftest discover-app-no-frames-registered-is-isError
+  ;; rf2-acckgr regression: `:no-frames-registered` is likewise a
+  ;; tool-built `:ok? false` precondition failure that used to ride
+  ;; back as ok-text.
+  (async done
+    (let [conn (fresh-conn)
+          _    (prime! conn :examples/step-deck)
+          args (tu/args->js {:build "examples/step-deck"})
+          no-frames {:ok? true :debug-enabled? true
+                     :coord-annotation-enabled? true :frames []}]
+      (-> (tu/with-stubbed-eval! no-frames
+            (fn [] (discover-app/discover-app conn args)))
+          (.then
+            (fn [result]
+              (is (tu/error? result)
+                  "no frames registered MUST be isError: true")
+              (let [edn (tu/extract-edn result)]
+                (is (false? (:ok? edn)))
+                (is (= :no-frames-registered (:reason edn))))
+              (done)))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dx_papercuts_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dx_papercuts_test.cljs
@@ -202,6 +202,28 @@
                      (is (false? (get-in edn [:results [:missing :k] :exists?]))))
                    (done)))))))
 
+(deftest get-path-blank-runtime-result-is-isError
+  ;; rf2-acckgr regression: a nil / non-map envelope back from the
+  ;; runtime (e.g. a dead runtime after a page reload answering blank)
+  ;; must NOT silently ship as ok-text. `(:ok? nil)` is `nil`, not
+  ;; `false`, so the old `(if (false? (:ok? rebuilt)) err-text ok-text)`
+  ;; check let a nil envelope fall through to ok-text — masking the
+  ;; failure as a success.
+  (async done
+    (let [conn (fresh-conn)
+          _    (swap! conn update :probed-builds (fnil conj #{}) :app)]
+      (-> (tu/with-stubbed-eval! nil
+            (fn []
+              (get-path/get-path-tool
+                conn (tu/args->js {:path "[:cart :total]" :frame ":rf/default"}))))
+          (.then (fn [r]
+                   (is (tu/error? r)
+                       "a blank/non-map eval result MUST be isError: true")
+                   (let [edn (tu/extract-edn r)]
+                     (is (false? (:ok? edn)))
+                     (is (= :blank-eval-result (:reason edn))))
+                   (done)))))))
+
 ;; ===========================================================================
 ;; Papercut 4 — snapshot full-mode epoch overflow.
 ;; ===========================================================================

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/eval_cljs_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/eval_cljs_test.cljs
@@ -567,8 +567,12 @@
                    :await true
                    :build "app"})))
         (.then (fn [r]
-                 (is (not (err? r))
-                     "rejection is :ok? false but not isError (not a transport-layer error)")
+                 ;; rf2-acckgr regression: a rejected await IS a known-tool
+                 ;; failure and MUST ride as isError: true per spec/003's
+                 ;; universal isError rule — it was previously masked as a
+                 ;; success (isError: false), which this test used to pin.
+                 (is (err? r)
+                     "rejection is a known-tool failure — MUST be isError: true")
                  (let [edn (read-edn r)]
                    (is (false? (:ok? edn)))
                    (is (= :rf.error/eval-cljs-rejected (:reason edn)))
@@ -596,11 +600,37 @@
                    :timeout-ms 75
                    :build      "app"})))
         (.then (fn [r]
-                 (is (not (err? r)) "timeout is :ok? false but not a transport error")
+                 ;; rf2-acckgr regression: a timed-out await IS a known-tool
+                 ;; failure and MUST ride as isError: true per spec/003's
+                 ;; universal isError rule.
+                 (is (err? r) "timeout is a known-tool failure — MUST be isError: true")
                  (let [edn (read-edn r)]
                    (is (false? (:ok? edn)))
                    (is (= :rf.error/eval-cljs-timeout (:reason edn)))
                    (is (= 75 (:timeout-ms edn)) "caller's timeout echoed back")
+                   (is (= :app (:build edn))))
+                 (done))))))
+
+(deftest await-bad-sentinel-surfaces-structured
+  ;; rf2-acckgr regression: the await wrapper returning an unrecognised
+  ;; sentinel (a `wrap-form` regression) hits `:on-missing`'s
+  ;; `:bad-sentinel` branch, which builds `:ok? false` — it MUST ride as
+  ;; isError: true, not a masked ok-text success.
+  (async done
+    (-> (with-stubbed-await!
+          {:wrap-result {:some/unexpected-key 42}
+           :poll-script []}
+          (fn []
+            (eval-cljs/eval-cljs-tool
+              (fresh-conn)
+              #js {:form  "(+ 1 2)"
+                   :await true
+                   :build "app"})))
+        (.then (fn [r]
+                 (is (err? r) "an unrecognised await sentinel MUST be isError: true")
+                 (let [edn (read-edn r)]
+                   (is (false? (:ok? edn)))
+                   (is (= :rf.error/eval-cljs-await-wrap-failed (:reason edn)))
                    (is (= :app (:build edn))))
                  (done))))))
 

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/handler_meta_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/handler_meta_test.cljs
@@ -340,6 +340,16 @@
             (fn []
               (-> (hm/handler-meta-tool nil (args-js {:kind "event" :id ":anything"}))
                   (.then (fn [result]
+                           ;; rf2-acckgr regression: this tool-built
+                           ;; :unexpected-shape map lacked the codec's
+                           ;; ::codec-error meta, so it silently rode
+                           ;; back as ok-text (isError: false) despite
+                           ;; carrying :ok? false — masking the defect
+                           ;; as a success. Sibling test
+                           ;; `handler-meta-unserializable-surfaces-structured`
+                           ;; already asserts this; it was missing here.
+                           (is (is-error? result)
+                               "an :unexpected-shape defect MUST be isError: true")
                            (let [edn (extract-edn result)]
                              (is (false? (:ok? edn)))
                              (is (= :unexpected-shape (:reason edn)))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/operating_frame_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/operating_frame_test.cljs
@@ -1,0 +1,86 @@
+(ns re-frame2-pair-mcp.operating-frame-test
+  "Unit tests for `get-operating-frame` / `reset-operating-frame`'s
+  blank-runtime-result handling.
+
+  `set-operating-frame-tool` already routes a non-map / `:ok? false`
+  runtime answer through `wire/err-text`; `get-operating-frame-tool` and
+  `reset-operating-frame-tool` did not — a nil / non-map answer from a
+  degraded runtime (the eval came back blank) silently rode back as
+  `wire/ok-text` despite carrying `:ok? false` (rf2-acckgr). These tests
+  pin the fix: BOTH siblings now match `set-operating-frame-tool`'s
+  guard."
+  (:require [cljs.test :refer-macros [deftest is async]]
+            [re-frame2-pair-mcp.nrepl :as nrepl]
+            [re-frame2-pair-mcp.test-utils :as tu]
+            [re-frame2-pair-mcp.tools.operating-frame :as op-frame]))
+
+(defn- fresh-conn []
+  (let [conn (nrepl/make-conn 0 "127.0.0.1")]
+    (swap! conn assoc :probed-builds #{:app})
+    conn))
+
+(defn- stub-eval!
+  "Install a `cljs-eval-value` stub. Answers the preload probe with
+  `true` (so `ensure-runtime!` short-circuits) and every other
+  (non-prelude) eval with `canned` — the shape `get-form` /
+  `reset-form` resolve to."
+  [canned]
+  (let [respond (fn [form]
+                  (if (and (string? form) (re-find #"__re_frame2_pair_runtime" form))
+                    (js/Promise.resolve true)
+                    (js/Promise.resolve canned)))]
+    (set! nrepl/cljs-eval-value
+          (fn
+            ([_c _b form] (respond form))
+            ([_c _b form _o] (respond form))))))
+
+(def ^:private pristine-eval nrepl/cljs-eval-value)
+
+(defn- restore-eval! [] (set! nrepl/cljs-eval-value pristine-eval))
+
+(deftest get-operating-frame-blank-runtime-result-is-isError
+  (async done
+    (stub-eval! nil)
+    (-> (op-frame/get-operating-frame-tool (fresh-conn) (tu/args->js {}))
+        (.then (fn [r]
+                 (is (tu/error? r)
+                     "a blank/non-map get-operating-frame result MUST be isError: true")
+                 (let [edn (tu/extract-edn r)]
+                   (is (false? (:ok? edn)))
+                   (is (= :unexpected-shape (:reason edn))))
+                 (restore-eval!)
+                 (done))))))
+
+(deftest get-operating-frame-healthy-map-still-succeeds
+  ;; Negative guard: a genuine `frames-list` map keeps riding as ok-text.
+  (async done
+    (stub-eval! {:ok? true :frames [:rf/default] :selected nil :operating :rf/default})
+    (-> (op-frame/get-operating-frame-tool (fresh-conn) (tu/args->js {}))
+        (.then (fn [r]
+                 (is (not (tu/error? r)) "a healthy frames-list map is not an error")
+                 (is (true? (:ok? (tu/extract-edn r))))
+                 (restore-eval!)
+                 (done))))))
+
+(deftest reset-operating-frame-blank-runtime-result-is-isError
+  (async done
+    (stub-eval! nil)
+    (-> (op-frame/reset-operating-frame-tool (fresh-conn) (tu/args->js {}))
+        (.then (fn [r]
+                 (is (tu/error? r)
+                     "a blank/non-map reset-operating-frame result MUST be isError: true")
+                 (let [edn (tu/extract-edn r)]
+                   (is (false? (:ok? edn)))
+                   (is (= :unexpected-shape (:reason edn))))
+                 (restore-eval!)
+                 (done))))))
+
+(deftest reset-operating-frame-healthy-map-still-succeeds
+  (async done
+    (stub-eval! {:ok? true :frames [:rf/default] :selected nil :operating :rf/default})
+    (-> (op-frame/reset-operating-frame-tool (fresh-conn) (tu/args->js {}))
+        (.then (fn [r]
+                 (is (not (tu/error? r)) "a healthy frames-list map is not an error")
+                 (is (true? (:ok? (tu/extract-edn r))))
+                 (restore-eval!)
+                 (done))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/reserved_frame_guard_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/reserved_frame_guard_test.cljs
@@ -193,6 +193,48 @@
                    (is (empty? @seen))
                    (done)))))))
 
+(deftest snapshot-wholesale-mode-full-no-path-is-refused
+  ;; rf2-brpc6v regression: `mode "full"` + no `path` is the OTHER
+  ;; wholesale shape the guard exists to catch (docs at
+  ;; `reserved-frame-guard.cljs` name it explicitly), independent of
+  ;; `path: []`. The bug routed the parsed `:epochs-mode` (default
+  ;; `:diff`) into the guard instead of the parsed slice `mode`
+  ;; (`:summary`/`:full`), so this exact shape sailed through to the
+  ;; eval round-trip and shipped the full unelided :rf/xray state. Assert
+  ;; the refusal fires BEFORE the eval — the huge canned payload never
+  ;; crosses.
+  (async done
+    (let [seen (atom [])]
+      (stub-eval! seen {:value huge-xray-snapshot :elided-count 0 :tool-frames-excluded []})
+      (-> (snapshot/snapshot-tool (fresh-conn) (tu/args->js {:frames #js [":rf/xray"] :mode "full"}))
+          (.then (fn [r]
+                   (is (tu/error? r) "mode full + no-path read of :rf/xray is refused")
+                   (let [edn (tu/extract-edn r)]
+                     (is (= :wholesale-read-of-reserved-frame (:reason edn)))
+                     (is (re-find #":rf/xray" (:frame edn)))
+                     (is (re-find #"orient" (:hint edn)) "redirects to orient"))
+                   (is (empty? @seen)
+                       "the snapshot read eval was NEVER reached — refused before the round-trip")
+                   (done)))))))
+
+(deftest snapshot-epochs-mode-full-alone-does-not-trip-the-guard
+  ;; Negative guard, other half of the rf2-brpc6v fix: the OBSCURE
+  ;; `:epochs-mode full` arg (unrelated to the wholesale slice mode) must
+  ;; NOT spuriously trip the guard when the documented `:mode` stays at
+  ;; its `:summary` default and no `path` narrows the read. Before the
+  ;; fix this shape was (wrongly) refused because the guard received
+  ;; epochs-mode instead of slice-mode.
+  (async done
+    (let [seen (atom [])]
+      (stub-eval! seen {:value {:rf/xray {:epochs [{:idx 0}]}}
+                        :elided-count 0 :tool-frames-excluded []})
+      (-> (snapshot/snapshot-tool (fresh-conn) (tu/args->js {:frames #js [":rf/xray"] :epochs-mode "full"}))
+          (.then (fn [r]
+                   (is (not (tu/error? r)) "epochs-mode full alone (summary slice mode, no path) is allowed")
+                   (is (true? (:ok? (tu/extract-edn r))))
+                   (is (seq @seen) "the read eval WAS reached")
+                   (done)))))))
+
 (deftest snapshot-sliced-rf-xray-succeeds
   ;; Negative guard: a SLICED read of :rf/xray reaches the eval and
   ;; returns ok — don't over-block.

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/result_envelope_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/result_envelope_test.cljs
@@ -191,6 +191,21 @@
     (is (renv/error? codec-err)
         "a codec error tag IS a codec error")))
 
+(deftest mark-codec-error-flags-a-tool-built-defect-map
+  ;; rf2-acckgr: a tool's OWN `on-value` shaper can detect a defect the
+  ;; runtime should never produce against a healthy build (handler-meta's
+  ;; `:unexpected-shape`) — that isn't one of `envelope->result`'s own
+  ;; tagged outcomes, but IS a genuine fault, not a legitimate structured
+  ;; miss like `:not-registered`. `mark-codec-error` lets the tool opt
+  ;; that map into the SAME `error?` routing the codec's own tags get.
+  (let [defect (renv/mark-codec-error {:ok? false :reason :unexpected-shape :value 42})]
+    (is (= {:ok? false :reason :unexpected-shape :value 42} defect)
+        "the map's data is unchanged — only metadata is added")
+    (is (renv/error? defect)
+        "a marked map routes through error? as a genuine codec error")
+    (is (renv/error? (assoc defect :kind :event))
+        "the mark survives assoc — metadata propagates through persistent map ops, matching how handler-meta's stamp-frame further shapes the map")))
+
 (deftest truncate-preview-caps-long-text
   (let [long-text (apply str (repeat 500 "x"))
         out       (tu/truncate-preview long-text)]

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/tail_build_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/tail_build_test.cljs
@@ -113,6 +113,12 @@
                 (-> (tail/tail-build-tool nil (tu/args->js {:probe "(some-stuck-form)"
                                                             :wait-ms 250}))
                     (.then (fn [result]
+                             ;; rf2-acckgr regression: a timed-out probe wait
+                             ;; is a known-tool failure (:ok? false) and MUST
+                             ;; ride as isError: true per spec/003's universal
+                             ;; isError rule — not a success carrying bad news.
+                             (is (tu/error? result)
+                                 "a timed-out tail-build MUST be isError: true")
                              (let [edn (tu/extract-edn result)]
                                (is (false? (:ok? edn)))
                                (is (= :timed-out (:reason edn)))
@@ -137,6 +143,11 @@
               (-> (tail/tail-build-tool nil (tu/args->js {:probe "(zorp)"
                                                           :wait-ms 250}))
                   (.then (fn [result]
+                           ;; rf2-acckgr regression: :probe-errored is a
+                           ;; known-tool failure and MUST ride as
+                           ;; isError: true, not a masked ok-text success.
+                           (is (tu/error? result)
+                               "a :probe-errored tail-build MUST be isError: true")
                            (let [edn (tu/extract-edn result)]
                              (is (false? (:ok? edn)))
                              (is (= :probe-errored (:reason edn))


### PR DESCRIPTION
## Summary

Two verified P2 bug beads on the `tools/re-frame2-pair-mcp/` surface.

**rf2-brpc6v** — `snapshot-tool` passed the parsed **epochs-mode** arg (`:diff`/`:full`, default `:diff`) to `reserved-frame-guard/snapshot-refusal`, whose `mode` parameter is documented and implemented as the **slice mode** (`:summary`/`:full`, default `:summary`). Result: the documented `mode:full` + no-`path` context-window backstop for reserved `:rf/*` tool frames (e.g. `:rf/xray`) never fired — a wholesale unelided read could sail through. One-line fix at `snapshot.cljs`: pass `slice-mode`, not `mode`.

**rf2-acckgr** — multiple read/eval tools shipped a `{:ok? false ...}` result via `wire/ok-text` (`isError: false`), violating spec/003-Tool-Catalogue.md's universal rule ("every `:ok? false` response is `isError: true`", sole exception `watch-until`'s `:watch-timeout`). This masks dead-runtime / rejection / timeout / precondition failures as **success** to the agent host, and makes them response-cache-eligible (cache eligibility bypasses `isError`), risking a stale failure masking a later real success. Fixed sites:

- `get-path.cljs` — a nil/non-map eval envelope (dead runtime after a page reload) fell through `(false? (:ok? rebuilt))` (which is `false` only for an explicit `false`, not `nil`) straight to `ok-text`. Now guarded up front, mirroring `read-sub`'s non-map guard.
- `discover-app.cljs` — the unhealthy-runtime (`(not (:ok? health))`), `:debug-disabled`, and `:no-frames-registered` precondition failures all rode as `ok-text`. All three now route through `err-text`.
- `handler-meta.cljs` — the tool-built `:unexpected-shape` defect map (a non-map meta-map from an otherwise-healthy eval) lacked the codec's `::codec-error` meta that `renv/error?` keys off, so it silently rode as `ok-text`. Added `renv/mark-codec-error` (a small public helper alongside the existing `error?`) and stamped the defect map with it. The sibling `:not-registered` miss is **unchanged** — `result-envelope.cljs`'s own docstring documents it as a legitimate structured answer, not a codec error, and an existing test (`handler-meta-not-registered-passes-through`) pins that.
- `operating-frame.cljs` — `get-operating-frame-tool` / `reset-operating-frame-tool` shipped a non-map blank result via `ok-text`; `set-operating-frame-tool` already guarded this correctly. Both siblings now match it.
- `eval-cljs.cljs` — the `:on-rejected` / `:on-timeout` / `:on-missing` (both `:bad-sentinel` and mailbox-missing branches) await-sentinel callbacks all built `:ok? false` maps wrapped in `ok-text`. All four now build `err-text`.
- `tail-build.cljs` — `:timed-out` and `:probe-errored` both rode as `ok-text`. Both now `err-text`.

Checked spec/003-Tool-Catalogue.md against every touched tool's documented section — the universal isError rule and each per-tool section already state the correct contract; the code was violating the spec, not the reverse. **No spec text changes required.**

## Quality gates

- `tools/re-frame2-pair-mcp` unit + conformance-corpus suite (`npm test`, shadow-cljs `server-test` build): **1140 tests, 3823 assertions, 0 failures** (was 1 failure — a conformance-corpus fixture pinning the old `:eval-cljs/await-rejected` `isError: false` behaviour — fixed in the same commit).
- `tools/mcp-conformance` degraded-mode end-to-end suite (`npm run test:re-frame2-pair`, real compiled `out/server.js`, real MCP SDK client): **green**, including the corpus-wide "every `:ok? false` envelope is `isError:true`" cross-check.
- Did **not** run `test:re-frame2-pair-live-hermetic-suite` (the live-nREPL + headless-Chromium hermetic suite) — it's the "expensive" tier (360s watchdog, real shadow-cljs + Playwright boot) and its one `isError`-focused inner test (`live-re-frame2-pair-iserror.cjs`) exercises `read-dom`/`read-ui` bad-selector, an unrelated already-correct code path (`probe/map-result-or-blank`) — no coverage overlap with the six sites fixed here to justify the setup cost.
- Regression test added per site: `reserved_frame_guard_test.cljs` (brpc6v: `mode:full` + no-path now refused; negative guard for bare `:epochs-mode full`), `dx_papercuts_test.cljs` (get-path blank envelope), `discover_app_representation_test.cljs` (unhealthy / debug-disabled / no-frames-registered), new `operating_frame_test.cljs` (get/reset blank-result), `eval_cljs_test.cljs` (rejected/timeout now assert `isError`; new bad-sentinel test), `tail_build_test.cljs` (timed-out/probe-errored now assert `isError`), `handler_meta_test.cljs` (added the missing `is-error?` assertion its sibling test already had), `result_envelope_test.cljs` (new `mark-codec-error` unit test).

## Risks

- The `handler-meta` `:not-registered` miss was left `ok-text` (not touched) — it's an existing, explicitly-documented, test-pinned carve-out distinct from the `:unexpected-shape` defect this PR fixes. Flagging in case a future audit wants to revisit that carve-out against the letter of the universal rule; out of scope here per the bead's own enumerated sites.
- `discover-app`'s `:debug-disabled` / `:no-frames-registered` branches weren't explicitly named in the bead's site list (only the unhealthy-runtime branch at the cited line was) but are the identical bug pattern in the same `cond`, three lines apart — fixed together for consistency; flagging in case that's considered out-of-scope creep.