### PR TITLE
fix(mcp-conformance): tighten 8 grading-precision assertions (isError dedup, cofx anchor, SKIP-banner, closed-world ratchet, …) (rf2-6i2yi4)

### DIFF
--- a/tools/mcp-conformance/lib/dedup-envelope.cjs
+++ b/tools/mcp-conformance/lib/dedup-envelope.cjs
@@ -86,7 +86,28 @@ function expandCache(cache) {
       // objects on the JSON wire.
       const out = {};
       for (const k of Object.keys(v)) {
-        out[k] = expandValue(v[k]);
+        // Route the KEY through expandValue too, not just the value. The
+        // real `de-dupe.core/expand` dispatches on `map-entry?` before
+        // `coll?` and expands BOTH halves of every map-entry — `cachable?`
+        // permits a de-duped map KEY, and this codebase has vector/
+        // path-keyed structures where that fires. Expanding only `v[k]`
+        // and using `k` verbatim leaves a de-duped key as the raw
+        // "de-dupe.cache/cache-N" placeholder string in the decoded
+        // object, so a downstream lookup against the real (expanded) key
+        // fails a conformant server. Plain (non-ref) keys pass through
+        // `expandValue` unchanged, so this is safe to apply uniformly.
+        const expandedKey = expandValue(k);
+        // JS object keys must be strings; a Clojure map key can expand to
+        // an arbitrary structure (e.g. a path vector). Use it directly
+        // when it already is a string/number, otherwise fall back to a
+        // deterministic canonical string so the entry is still reachable
+        // (rather than silently colliding/overwriting under implicit
+        // `String(...)` coercion).
+        const jsKey =
+          typeof expandedKey === 'string' || typeof expandedKey === 'number'
+            ? expandedKey
+            : JSON.stringify(expandedKey);
+        out[jsKey] = expandValue(v[k]);
       }
       return out;
     }
@@ -130,6 +151,18 @@ function expandCache(cache) {
     return expanded;
   }
 
+  // Eagerly expand EVERY cache entry, not just those reachable from
+  // cache-0. The real de-dupe.core/decompress-cache expands every key
+  // before picking cache-0 off the result, so a malformed ORPHAN entry
+  // (unreferenced from the root — e.g. a dangling ref to a nonexistent
+  // cache id, or itself cyclic) throws for a real client but, if only
+  // `expandEntry(ROOT_CACHE_ID)` below were called, would never be
+  // visited here and would decode cleanly (grading GREEN a wire payload
+  // a real client rejects outright). `expandEntry` memoises, so this
+  // costs nothing extra for the reachable subset.
+  for (const cacheId of Object.keys(cache)) {
+    expandEntry(cacheId);
+  }
   return expandEntry(ROOT_CACHE_ID);
 }
 

--- a/tools/mcp-conformance/lib/exec-safety.cjs
+++ b/tools/mcp-conformance/lib/exec-safety.cjs
@@ -207,6 +207,7 @@ function resolveTrustedExe(name, opts) {
   const exts = pathExtensionsFor(platform, env);
   const tried = []; // for diagnostic error message
   const rejectedInsideWorkspace = [];
+  const rejectedUnverifiable = [];
 
   for (const dir of dirs) {
     for (const ext of exts) {
@@ -222,7 +223,21 @@ function resolveTrustedExe(name, opts) {
       // Realpath through any symlink — what we trust is the *target*,
       // not the link. A PATH entry pointing at a workspace-internal
       // tool via a symlink is the exact accident the audit flagged.
-      const real = realpathSyncOrNull(candidate) || candidate;
+      const real = realpathSyncOrNull(candidate);
+      if (real === null) {
+        // A realpath failure means the symlink TARGET could not be
+        // verified. The prior behaviour (`realpathSyncOrNull(candidate)
+        // || candidate`) silently fell back to the raw, UNRESOLVED
+        // candidate and returned it as trusted — defeating this
+        // module's whole purpose. Known real-world trigger: on
+        // Windows, `fs.realpathSync` is known to throw on certain
+        // reparse points (App-Execution-Alias stubs under
+        // `%LOCALAPPDATA%\Microsoft\WindowsApps`, a common default PATH
+        // entry) that `fs.statSync` above sees as an ordinary file.
+        // Treat the candidate as rejected and keep searching instead.
+        rejectedUnverifiable.push(candidate);
+        continue;
+      }
       if (isPathInside(real, workspaceRootReal)) {
         rejectedInsideWorkspace.push({ candidate, real });
         continue;
@@ -231,15 +246,24 @@ function resolveTrustedExe(name, opts) {
     }
   }
 
-  if (rejectedInsideWorkspace.length > 0) {
-    const list = rejectedInsideWorkspace
+  if (rejectedInsideWorkspace.length > 0 || rejectedUnverifiable.length > 0) {
+    const insideList = rejectedInsideWorkspace
       .map((r) => `  ${r.candidate} -> ${r.real}`)
       .join('\n');
+    const unverifiableList = rejectedUnverifiable
+      .map((c) => `  ${c} -> <realpath failed; target unverifiable>`)
+      .join('\n');
     throw new Error(
-      `resolveTrustedExe: every candidate for "${name}" resolved inside ` +
-        `the workspace (${workspaceRootReal}). Refusing to execute ` +
-        `workspace-relative binaries via PATH (rf2-33vvc accident-gating).\n` +
-        `Rejected candidates:\n${list}\n` +
+      `resolveTrustedExe: no candidate for "${name}" could be trusted. ` +
+        `Refusing to execute a workspace-relative or unverifiable binary ` +
+        `via PATH (rf2-33vvc accident-gating; rf2-6i2yi4 realpath-failure ` +
+        `hardening).\n` +
+        (rejectedInsideWorkspace.length > 0
+          ? `Rejected — resolved inside the workspace (${workspaceRootReal}):\n${insideList}\n`
+          : '') +
+        (rejectedUnverifiable.length > 0
+          ? `Rejected — realpath could not verify the symlink target:\n${unverifiableList}\n`
+          : '') +
         `Install ${name} system-wide or adjust PATH so a host binary ` +
         `appears first.`,
     );

--- a/tools/mcp-conformance/lib/token-match.cjs
+++ b/tools/mcp-conformance/lib/token-match.cjs
@@ -1,0 +1,32 @@
+// Exact-token text containment — a stricter alternative to
+// `String#includes` for checking a structured-error-reason keyword (or
+// any hyphenated token) appears in free-form response text.
+//
+// ## Why this exists
+//
+// `String#includes` treats a token as present whenever it is a literal
+// SUBSTRING — it can't distinguish `:invalid-cofx` from
+// `:invalid-cofx-time-ms` (the former IS a substring of the latter), so
+// a conformance assertion built on `.includes(reason)` collapses two
+// distinct structured-error reasons onto the shortest one: a server
+// returning the WRONG reason (`:invalid-cofx-time-ms` for a case that
+// should have produced `:invalid-cofx`, or vice versa) still satisfies
+// the shorter check and grades GREEN.
+//
+// `includesToken` anchors the match: it requires no keyword-continuation
+// character (a word character or hyphen — the characters EDN keywords
+// use internally) immediately before or after the match, so
+// `:invalid-cofx` only matches a text where it appears as a complete
+// keyword, not as a prefix of a longer one.
+
+'use strict';
+
+function escapeRegExp(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function includesToken(text, token) {
+  return new RegExp('(?<![\\w-])' + escapeRegExp(token) + '(?![\\w-])').test(text);
+}
+
+module.exports = { escapeRegExp, includesToken };

--- a/tools/mcp-conformance/package.json
+++ b/tools/mcp-conformance/package.json
@@ -24,6 +24,9 @@
     "test:hermetic-setup-timeout": "node --test test/hermetic-setup-timeout.test.cjs",
     "test:inner-test-close-grading": "node --test test/inner-test-close-grading.test.cjs",
     "test:port-file-escape": "node --test test/port-file-escape.test.cjs",
+    "test:stale-port-file-trust": "node --test test/stale-port-file-trust.test.cjs",
+    "test:token-match": "node --test test/token-match.test.cjs",
+    "test:is-error-matches-ok": "node --test test/is-error-matches-ok.test.cjs",
     "test:unit": "node scripts/test-unit.cjs",
     "test": "node scripts/test-all.cjs"
   },

--- a/tools/mcp-conformance/scripts/run-re-frame2-pair-live-hermetic-suite.cjs
+++ b/tools/mcp-conformance/scripts/run-re-frame2-pair-live-hermetic-suite.cjs
@@ -510,6 +510,54 @@ function isContainmentEscape(e) {
     e.message.includes('symlink-escape accident-gating'));
 }
 
+// Wipe one stale nREPL port-file candidate before boot. A symlink-ESCAPE
+// refusal is FATAL (rf2-khav7l — never continue and later trust a file
+// we refused to clean). A BENIGN unlink failure (EACCES / EBUSY — a
+// Windows file lock from a not-yet-reaped prior shadow-cljs process, a
+// permission quirk) is tolerated ONLY when the file is actually gone
+// afterward. `readPortFile()` (the `waitUntil('nREPL port file', ...)`
+// poll in `main`) has NO staleness/liveness gate: it trusts the first
+// candidate that parses to a finite integer, so a stale file surviving a
+// failed unlink would be trusted on the very first poll — before THIS
+// run's shadow-cljs has any chance to rebind and rewrite it. Best case
+// that wastes the whole boot timeout; worst case it connects to a
+// stale/zombie runtime from a prior run (state bleed between runs).
+// Re-stat after a benign failure: if the file is genuinely gone (the
+// unlink raced a concurrent removal), proceed as before; if it is still
+// there, fail LOUD now instead of silently deferring the risk to the
+// read side (rf2-6i2yi4). `unlink`/`statExists`/`logFn` are injectable
+// so the call-site regression test can drive this against a fake
+// benign-failing unlink without needing a real Windows file lock.
+function wipeStalePortFileCandidate(
+  p,
+  fixtureDir,
+  { unlink = safeUnlinkInside, statExists = exists, logFn = log } = {},
+) {
+  try {
+    const removed = unlink(p, fixtureDir);
+    if (removed) logFn(`removed stale port file ${p}`);
+  } catch (e) {
+    if (isContainmentEscape(e)) {
+      throw new Error(
+        `stale nREPL port candidate ${p} escapes FIXTURE_DIR ` +
+          `(${e.message}); aborting — the runner must not continue and ` +
+          'later trust a port file it refused to clean (rf2-khav7l).',
+      );
+    }
+    if (statExists(p)) {
+      throw new Error(
+        `could not remove stale nREPL port file ${p} (${e.message}), and ` +
+          're-stat confirms it is STILL on disk — refusing to continue: ' +
+          'the poll loop below has no staleness gate and would trust this ' +
+          'file on its very first check, before shadow-cljs rebinds ' +
+          '(rf2-6i2yi4 stale port-file trust). The file may be held by a ' +
+          'lingering prior process — remove it manually and re-run.',
+      );
+    }
+    logFn(`could not remove stale port file ${p} (${e.message}), but it is gone now; continuing`);
+  }
+}
+
 // `candidates` + `fixtureDir` are parameterised (defaulting to the
 // module constants) so the call-site regression test can drive
 // this exact function against a temp fixture with a symlinked
@@ -962,28 +1010,14 @@ async function main() {
   // FIXTURE_DIR can't be coerced into deleting a file outside the
   // fixture tree.
   //
-  // A symlink-ESCAPE refusal on a load-bearing stale
-  // port candidate is FATAL — we do NOT log-and-continue and then later
-  // read that same escaped file as the live nREPL source. A BENIGN unlink
-  // failure (EACCES / EBUSY — a Windows file lock, a permission quirk)
-  // is tolerated: it doesn't widen trust, and the read path
-  // re-checks containment regardless. `isContainmentEscape` discriminates
-  // the two so a transient lock doesn't abort the whole run while a real
-  // escape does.
+  // A symlink-ESCAPE refusal on a load-bearing stale port candidate is
+  // FATAL (rf2-khav7l). A BENIGN unlink failure (EACCES / EBUSY) is
+  // tolerated only when the file is confirmed gone afterward — see
+  // `wipeStalePortFileCandidate`'s docstring for why a surviving stale
+  // file must fail loud here rather than being silently trusted by the
+  // staleness-blind `readPortFile()` poll below (rf2-6i2yi4).
   for (const p of NREPL_PORT_FILE_CANDIDATES) {
-    try {
-      const removed = safeUnlinkInside(p, FIXTURE_DIR);
-      if (removed) log(`removed stale port file ${p}`);
-    } catch (e) {
-      if (isContainmentEscape(e)) {
-        throw new Error(
-          `stale nREPL port candidate ${p} escapes FIXTURE_DIR ` +
-            `(${e.message}); aborting — the runner must not continue and ` +
-            'later trust a port file it refused to clean (rf2-khav7l).',
-        );
-      }
-      log(`could not remove stale port file ${p} (${e.message}); continuing`);
-    }
+    wipeStalePortFileCandidate(p, FIXTURE_DIR);
   }
   try {
     const removed = safeUnlinkInside(FIXTURE_BUNDLE_PATH, FIXTURE_DIR);
@@ -1385,6 +1419,14 @@ if (require.main === module) {
 // its sentinel-bearing stdout `data` AFTER `exit` but BEFORE `close`,
 // proving the harness reads the fully-drained stdout (via `close`) rather
 // than scoring a conformant, late-flushing child as failed.
+//
+// `wipeStalePortFileCandidate` is exported for the stale-port-file-trust
+// regression harness (`stale-port-file-trust.test.cjs`, rf2-6i2yi4): it
+// drives the REAL wipe logic with an injected `unlink` that fails
+// benignly (mimicking a Windows EBUSY lock) while an injected `statExists`
+// still reports the file present, proving the runner now fails LOUD
+// instead of logging-and-continuing into a poll loop that would have
+// trusted the surviving stale file.
 module.exports = {
   runTrusted,
   SETUP_COMMAND_TIMEOUT_MS,
@@ -1394,4 +1436,5 @@ module.exports = {
   settledWithin,
   waitForChildExit,
   spawnAndGradeInnerTest,
+  wipeStalePortFileCandidate,
 };

--- a/tools/mcp-conformance/scripts/test-all.cjs
+++ b/tools/mcp-conformance/scripts/test-all.cjs
@@ -66,8 +66,20 @@ const TESTS = [
     argv: ['--test', 'test/port-file-escape.test.cjs'],
   },
   {
+    name: 'hermetic stale port-file wipe fails loud on a surviving stale file (rf2-6i2yi4)',
+    argv: ['--test', 'test/stale-port-file-trust.test.cjs'],
+  },
+  {
     name: 'dedup-envelope decoder — cyclic-cache throws + acyclic happy path (rf2-87h71e)',
     argv: ['--test', 'test/dedup-envelope.test.cjs'],
+  },
+  {
+    name: 'exact-token match — anchors :invalid-cofx vs :invalid-cofx-time-ms (rf2-6i2yi4)',
+    argv: ['--test', 'test/token-match.test.cjs'],
+  },
+  {
+    name: 'universal isError <-> :ok? cross-check reads through the dedup decoder (rf2-6i2yi4)',
+    argv: ['--test', 'test/is-error-matches-ok.test.cjs'],
   },
   {
     name: 'callTool coverage ratchet unit tests (rf2-ke5n56)',
@@ -120,23 +132,39 @@ function banner(line) {
   process.stdout.write('\n' + sep + '\n' + line + '\n' + sep + '\n');
 }
 
+// The shared pre-flight skip helper (`_runner.cjs` `runWithWatchdog.skip`)
+// prints a `SKIP <reason>` line and exits 0 BEFORE running any real
+// assertions. That exit-0 is indistinguishable from a real pass by
+// status code alone — the six live-re-frame2-pair-* rows all SKIP this
+// way when `$SHADOW_CLJS_NREPL_PORT` is unset, which is the normal state
+// of a local `npm test` run. Detect the banner in the child's captured
+// stdout so the summary can tell "skipped" apart from "actually ran and
+// passed" instead of collapsing both into a bare exit-0 OK.
+const SKIP_BANNER = /^SKIP /m;
+
 function main() {
   const results = [];
   let firstFailure = null;
 
   for (const test of TESTS) {
     banner('▶ ' + test.name + '\n  ' + test.argv.join(' '));
-    // `process.execPath` is always absolute; `spawnSync` inherits stdio
-    // so the child's stdout/stderr stream through verbatim. `shell: false`
-    // keeps the accident-gating from the lib/exec-safety.cjs preamble: no
-    // shell-interpolation of test names.
+    // `process.execPath` is always absolute. stdout is piped (not
+    // inherited) so we can inspect it for the SKIP banner; it is written
+    // to our own stdout immediately after the child exits, so nothing is
+    // lost — only the live-interleaving with stderr is (stderr stays
+    // `inherit`, unaffected). `shell: false` keeps the accident-gating
+    // from the lib/exec-safety.cjs preamble: no shell-interpolation of
+    // test names.
     const child = spawnSync(process.execPath, test.argv, {
       cwd: ROOT,
-      stdio: 'inherit',
+      stdio: ['inherit', 'pipe', 'inherit'],
       env: process.env,
     });
+    const stdoutText = child.stdout ? child.stdout.toString('utf8') : '';
+    process.stdout.write(stdoutText);
     const status = child.status === null ? 'signal:' + child.signal : child.status;
-    results.push({ name: test.name, status });
+    const skipped = child.status === 0 && SKIP_BANNER.test(stdoutText);
+    results.push({ name: test.name, status, skipped });
     if (child.status !== 0 && firstFailure === null) {
       firstFailure = { test: test.name, status: child.status, signal: child.signal };
       break;
@@ -144,8 +172,10 @@ function main() {
   }
 
   banner('mcp-conformance summary');
+  let skipCount = 0;
   for (const r of results) {
-    const tick = r.status === 0 ? 'OK  ' : 'FAIL';
+    const tick = r.status !== 0 ? 'FAIL' : r.skipped ? 'SKIP' : 'OK  ';
+    if (r.skipped) skipCount++;
     process.stdout.write(`  [${tick}] ${r.name} (exit=${r.status})\n`);
   }
 
@@ -160,7 +190,15 @@ function main() {
     process.exit(firstFailure.status === null ? 1 : firstFailure.status);
   }
 
-  process.stdout.write('\nALL CONFORMANCE TESTS GREEN\n');
+  if (skipCount > 0) {
+    process.stdout.write(
+      `\nALL CONFORMANCE TESTS GREEN (${skipCount} SKIPPED — see [SKIP] rows ` +
+        'above; the live-re-frame2-pair-* gates require a running server on ' +
+        '$SHADOW_CLJS_NREPL_PORT and are not exercised by this run)\n',
+    );
+  } else {
+    process.stdout.write('\nALL CONFORMANCE TESTS GREEN\n');
+  }
   process.exit(0);
 }
 

--- a/tools/mcp-conformance/test/_runner.cjs
+++ b/tools/mcp-conformance/test/_runner.cjs
@@ -567,6 +567,24 @@ function assertClassificationRatchet(tools, expected) {
     );
   }
 
+  // 0b. `closed-world` entries must be a subset of `classifications` (now
+  // known exact-equal to the live tool-set per check 0 above). Unlike a
+  // stale `classifications` row, a dangling `closed-world` entry naming a
+  // renamed/removed tool is NEVER visited by the per-tool loop below (it
+  // only iterates live `tools`), so without this check it survives a
+  // rename undetected — silently tolerated instead of tripping RED.
+  const staleClosedWorld = Array.from(closedWorld).filter(
+    (n) => !Object.prototype.hasOwnProperty.call(table, n),
+  );
+  if (staleClosedWorld.length > 0) {
+    throw new Error(
+      'classification ratchet (rf2-yi451): the fixture `closed-world` list ' +
+        'names a tool absent from `classifications` (dangling row — the ' +
+        'tool was renamed or removed; update or delete the row): ' +
+        JSON.stringify(staleClosedWorld),
+    );
+  }
+
   for (const t of tools) {
     const a = t.annotations || {};
     const posture = table[t.name];
@@ -838,6 +856,47 @@ function structured(resp) {
   return decodeDedupEnvelope((resp && resp.structuredContent) || {});
 }
 
+// Universal isError <-> :ok? cross-check. The spec contract
+// (spec/003-Tool-Catalogue.md §381) is universal: EVERY `:ok? false`
+// structuredContent MUST carry `isError === true`, and every `:ok? true`
+// MUST carry a falsy isError. This cross-check pins the contract for an
+// ARBITRARY structured envelope at the SDK boundary — a single gate
+// covering every tool, rather than tool-specific + outcome-specific
+// checks — catching any tool that decouples its isError flag from its
+// `:ok?` slot (the class the pair-mcp read-dom/read-ui envelope
+// belonged to, rf2-87h71e / rf2-q7cavs).
+//
+// Reads `:ok?` through `structured()` — the shared dedup-decoder —
+// rather than the raw wire `resp.structuredContent`. A dedup-eligible
+// tool ships its structured payload wrapped in
+// `{:rf.mcp/dedup-table {...}}`; reading the raw field finds no
+// top-level `:ok?` slot at all, so this cross-check would silently no-op
+// on exactly the envelopes a real MCP client (which always expands the
+// dedup table before reading semantic slots) would grade (rf2-6i2yi4
+// finding 1). Tolerates an envelope with no `:ok?` slot (a non-`:ok?`-
+// shaped result is out of scope — there is nothing to cross-check).
+function assertIsErrorMatchesOk(label, resp) {
+  const sc = structured(resp);
+  if (sc === undefined || sc === null || typeof sc !== 'object') return;
+  if (!Object.prototype.hasOwnProperty.call(sc, 'ok?')) return;
+  const ok = sc['ok?'];
+  if (ok === false && resp.isError !== true) {
+    throw new Error(
+      label + ' carries :ok? false but isError is not true (' +
+        JSON.stringify(resp.isError) + ') — violates the universal ' +
+        'spec/003 §381 contract (every :ok? false is isError:true). ' +
+        'A failure that is not flagged isError is cache-eligible and ' +
+        'can mask a later success (rf2-87h71e / rf2-q7cavs).',
+    );
+  }
+  if (ok === true && resp.isError === true) {
+    throw new Error(
+      label + ' carries :ok? true but isError is true — a success ' +
+        'envelope must not be flagged a fault (rf2-87h71e converse).',
+    );
+  }
+}
+
 module.exports = {
   runWithWatchdog,
   connectServer,
@@ -851,4 +910,5 @@ module.exports = {
   responseText,
   track,
   structured,
+  assertIsErrorMatchesOk,
 };

--- a/tools/mcp-conformance/test/classification-ratchet.test.cjs
+++ b/tools/mcp-conformance/test/classification-ratchet.test.cjs
@@ -148,3 +148,49 @@ test('RED: a destructive tool re-labelled read-only ⇒ throws', () => {
     /write-live classification regressed[\s\S]*pins `destructive`/,
   );
 });
+
+// --- rf2-6i2yi4 finding 4: a dangling `closed-world` entry is caught ---
+//
+// `closed-world` is consulted PER-TOOL inside the per-tool loop
+// (`closedWorld.has(t.name)`), which only ever iterates the LIVE
+// tool-set. Before the fix, a `closed-world` row naming a tool that no
+// longer exists at all (removed, with its `classifications` row removed
+// too — so check 0's exact-keyset guard is satisfied) was never visited
+// by that loop and therefore never validated: a real removal that
+// correctly updated `classifications` but forgot to also drop the
+// matching `closed-world` row shipped GREEN. This is the same class of
+// fixture-hygiene gap check 0 already closes for `classifications`
+// (a stale row there DOES trip), just on the `closed-world` side.
+
+test('RED: rf2-6i2yi4 finding 4 — a `closed-world` row naming a REMOVED tool is caught, not silently tolerated', () => {
+  // `read-inline` was removed from the server; `classifications` was
+  // correctly updated (its row dropped, so check 0's exact-keyset guard
+  // passes against the 3-tool live set below) but `closed-world` still
+  // names it — a dangling row nothing else would visit.
+  const staleFixture = {
+    classifications: {
+      'read-live': 'read-only',
+      'write-live': 'destructive',
+      'pin-live': 'neither',
+    },
+    'closed-world': ['read-inline'],
+  };
+  const tools = [
+    tool('read-live', { readOnlyHint: true, openWorldHint: true }),
+    tool('write-live', { destructiveHint: true, openWorldHint: true }),
+    tool('pin-live', { openWorldHint: true }),
+  ];
+  // Every LIVE tool here is correctly classified — under the pre-fix
+  // code this fixture would NOT throw at all (the per-tool loop never
+  // visits the absent 'read-inline', so the dangling row is invisible).
+  assert.throws(
+    () => assertClassificationRatchet(tools, staleFixture),
+    (err) => {
+      assert.match(err.message, /closed-world/);
+      assert.match(err.message, /read-inline/);
+      assert.match(err.message, /dangling/);
+      return true;
+    },
+    'a closed-world row naming a tool absent from classifications must throw',
+  );
+});

--- a/tools/mcp-conformance/test/dedup-envelope.test.cjs
+++ b/tools/mcp-conformance/test/dedup-envelope.test.cjs
@@ -114,3 +114,87 @@ test('non-dedup envelope passes through untouched', () => {
   const plain = { 'ok?': true, value: [1, 2, 3] };
   assert.equal(decodeDedupEnvelope(plain), plain);
 });
+
+// ---------------------------------------------------------------------
+// rf2-6i2yi4 finding 5: a de-duped map KEY (not just VALUE) is expanded.
+//
+// The real `de-dupe.core/expand` dispatches on `map-entry?` before
+// `coll?` and expands BOTH halves of every map-entry; `cachable?`
+// permits a de-duped map key. A decoder that only recurses into `v[k]`
+// while using `k` verbatim leaves a de-duped key as the raw
+// "de-dupe.cache/cache-N" placeholder string — before this fix, the
+// assertion below would have found `Object.keys(out)` still carrying
+// that raw placeholder instead of the expanded key.
+// ---------------------------------------------------------------------
+
+test('a de-duped map KEY is expanded, not left as the raw cache-ref placeholder (rf2-6i2yi4 finding 5)', () => {
+  // cache-0's single entry has a KEY that is itself a cache reference to
+  // a de-duped vector — the "path-keyed structure" shape the finding
+  // describes.
+  const cache = {
+    [cacheId(0)]: { [cacheId(1)]: 'value-for-vector-key' },
+    [cacheId(1)]: ['a', 'b'],
+  };
+  const out = decodeDedupEnvelope(envelope(cache));
+  // JS object keys must be strings; a non-string expanded key (here an
+  // array) is rendered via its canonical JSON form rather than left
+  // as the unexpanded ref.
+  const expectedKey = JSON.stringify(['a', 'b']);
+  assert.deepEqual(Object.keys(out), [expectedKey]);
+  assert.equal(out[expectedKey], 'value-for-vector-key');
+});
+
+test('a de-duped map key that expands to a plain string is used directly (no JSON-quoting)', () => {
+  const cache = {
+    [cacheId(0)]: { [cacheId(1)]: 'v' },
+    [cacheId(1)]: 'plain-string-key',
+  };
+  const out = decodeDedupEnvelope(envelope(cache));
+  assert.deepEqual(out, { 'plain-string-key': 'v' });
+});
+
+// ---------------------------------------------------------------------
+// rf2-6i2yi4 finding 7: eagerly validate EVERY cache entry, not just
+// those reachable from cache-0.
+//
+// The real `de-dupe.core/decompress-cache` expands every key before
+// picking cache-0 off the result. Before this fix, `expandCache` called
+// only `expandEntry(ROOT_CACHE_ID)`, so a malformed entry unreachable
+// from the root (an "orphan") was never visited and decoded cleanly —
+// grading GREEN a wire payload a real client rejects outright. These
+// tests would NOT have thrown before the fix (the malformed orphan was
+// simply never visited).
+// ---------------------------------------------------------------------
+
+test('a malformed ORPHAN cache entry (unreachable from cache-0, dangling ref) still throws (rf2-6i2yi4 finding 7)', () => {
+  const cache = {
+    [cacheId(0)]: { fine: 1 }, // well-formed, does not reference cache-1
+    [cacheId(1)]: { missing: cacheId(9) }, // orphan: dangling ref
+  };
+  assert.throws(
+    () => decodeDedupEnvelope(envelope(cache)),
+    /no matching entry/i,
+    'an orphaned entry with a dangling ref must still be rejected',
+  );
+});
+
+test('a malformed ORPHAN cache entry (unreachable from cache-0, self-cyclic) still throws', () => {
+  const cache = {
+    [cacheId(0)]: { fine: 1 },
+    [cacheId(1)]: { self: cacheId(1) }, // orphan: self-cyclic
+  };
+  assert.throws(
+    () => decodeDedupEnvelope(envelope(cache)),
+    /cyclic dedup cache/i,
+    'an orphaned self-cyclic entry must still be rejected',
+  );
+});
+
+test('a well-formed orphan entry is harmless — root value unaffected', () => {
+  const cache = {
+    [cacheId(0)]: { fine: 1 },
+    [cacheId(1)]: { unused: 'harmless' }, // orphan but well-formed
+  };
+  const out = decodeDedupEnvelope(envelope(cache));
+  assert.deepEqual(out, { fine: 1 });
+});

--- a/tools/mcp-conformance/test/end-to-end-re-frame2-pair.cjs
+++ b/tools/mcp-conformance/test/end-to-end-re-frame2-pair.cjs
@@ -36,6 +36,7 @@ const {
   assertClassificationRatchet,
   assertCallCoverageRatchet,
   track,
+  assertIsErrorMatchesOk,
 } = require('./_runner.cjs');
 
 const RE_FRAME2_PAIR_MCP_DIR = path.resolve(__dirname, '..', '..', 're-frame2-pair-mcp');
@@ -279,41 +280,13 @@ runWithWatchdog(
       },
     ];
 
-    // Universal isError <-> :ok? cross-check. The spec contract
-    // (spec/003-Tool-Catalogue.md §381) is universal: EVERY `:ok? false`
-    // structuredContent MUST carry `isError === true`, and every
-    // `:ok? true` MUST carry a falsy isError. This cross-check pins the
-    // contract for an ARBITRARY structured envelope at the SDK boundary —
-    // a single gate covering every tool, rather than tool-specific +
-    // outcome-specific checks — catching any tool that decouples its
-    // isError flag from its `:ok?` slot (the class the pair-mcp
-    // read-dom/read-ui envelope belongs to).
-    //
-    // Reads `:ok?` from the namespace-faithful structuredContent slot
-    // (`qualify-keywords` renders `:ok?` as the JS key "ok?"). Tolerates
-    // an envelope with no `:ok?` slot (a non-`:ok?`-shaped result is out
-    // of scope — there is nothing to cross-check).
-    function assertIsErrorMatchesOk(label, resp) {
-      const sc = resp.structuredContent;
-      if (sc === undefined || sc === null || typeof sc !== 'object') return;
-      if (!Object.prototype.hasOwnProperty.call(sc, 'ok?')) return;
-      const ok = sc['ok?'];
-      if (ok === false && resp.isError !== true) {
-        throw new Error(
-          label + ' carries :ok? false but isError is not true (' +
-            JSON.stringify(resp.isError) + ') — violates the universal ' +
-            'spec/003 §381 contract (every :ok? false is isError:true). ' +
-            'A failure that is not flagged isError is cache-eligible and ' +
-            'can mask a later success (rf2-87h71e / rf2-q7cavs).',
-        );
-      }
-      if (ok === true && resp.isError === true) {
-        throw new Error(
-          label + ' carries :ok? true but isError is true — a success ' +
-            'envelope must not be flagged a fault (rf2-87h71e converse).',
-        );
-      }
-    }
+    // Universal isError <-> :ok? cross-check (spec/003-Tool-Catalogue.md
+    // §381): EVERY `:ok? false` structuredContent MUST carry
+    // `isError === true`, and every `:ok? true` MUST carry a falsy
+    // isError. `assertIsErrorMatchesOk` lives in `_runner.cjs` (routed
+    // through the shared `structured()` dedup-decoder, not the raw wire
+    // `resp.structuredContent` — see its docstring there for the
+    // dedup-envelope rationale, rf2-6i2yi4 finding 1).
 
     // Call one tool and assert the shared degraded envelope. Returns the
     // SDK response so the structuredContent dual-slot check below can

--- a/tools/mcp-conformance/test/exec-safety.test.cjs
+++ b/tools/mcp-conformance/test/exec-safety.test.cjs
@@ -242,6 +242,102 @@ test('resolveTrustedExe: follows symlinks and rejects when target is inside work
   }
 });
 
+// A realpath FAILURE (as opposed to a clean resolution) used to fall
+// back to the raw, unresolved candidate path
+// (`realpathSyncOrNull(candidate) || candidate`) — trusting exactly the
+// path this module exists to verify. On Windows, `fs.realpathSync` is
+// known to throw on certain reparse points (App-Execution-Alias stubs
+// under `%LOCALAPPDATA%\Microsoft\WindowsApps`) that `fs.statSync` sees
+// as an ordinary file — so this isn't a hypothetical failure mode. These
+// two tests monkeypatch `fs.realpathSync` (restored in `finally`) to
+// simulate that failure on a specific candidate, independent of the
+// actual host OS/filesystem (rf2-6i2yi4 finding 6).
+
+test('resolveTrustedExe: a realpath failure on a candidate is rejected (not trusted unresolved) — falls through to the next candidate', () => {
+  const workspace = freshTmpDir('realpath-fail-workspace');
+  const unverifiableDir = freshTmpDir('realpath-fail-unverifiable');
+  const trustedDir = freshTmpDir('realpath-fail-trusted');
+  const realRealpathSync = fs.realpathSync;
+  try {
+    // First PATH dir: a candidate that EXISTS (passes statSync) but
+    // whose realpath will be made to throw.
+    const unverifiableExe = path.join(unverifiableDir, 'mytool');
+    fs.writeFileSync(unverifiableExe, '#!/bin/sh\necho unverifiable\n', { mode: 0o755 });
+    // Second PATH dir: a genuine, verifiable, outside-workspace binary.
+    const trustedExeFile = path.join(trustedDir, 'mytool');
+    fs.writeFileSync(trustedExeFile, '#!/bin/sh\necho trusted\n', { mode: 0o755 });
+    const trustedExeReal = realRealpathSync(trustedExeFile);
+
+    fs.realpathSync = function patchedRealpathSync(p, ...rest) {
+      if (path.resolve(p) === path.resolve(unverifiableExe)) {
+        const e = new Error('simulated realpath failure (e.g. reparse point)');
+        e.code = 'UNKNOWN';
+        throw e;
+      }
+      return realRealpathSync.call(fs, p, ...rest);
+    };
+
+    const env = { PATH: [unverifiableDir, trustedDir].join(path.delimiter) };
+    const resolved = resolveTrustedExe('mytool', {
+      workspaceRoot: workspace,
+      env,
+      platform: 'linux',
+    });
+    assert.equal(
+      resolved,
+      trustedExeReal,
+      'must skip the unverifiable candidate (NOT return its raw unresolved ' +
+        'path) and resolve the next, verifiable candidate',
+    );
+    assert.notEqual(
+      resolved,
+      unverifiableExe,
+      'must never return the raw, unresolved candidate path',
+    );
+  } finally {
+    fs.realpathSync = realRealpathSync;
+    rmrf(workspace);
+    rmrf(unverifiableDir);
+    rmrf(trustedDir);
+  }
+});
+
+test('resolveTrustedExe: throws (does not silently trust an unresolved candidate) when every candidate is realpath-unverifiable', () => {
+  const workspace = freshTmpDir('realpath-fail-only-workspace');
+  const outsideDir = freshTmpDir('realpath-fail-only-outside');
+  const realRealpathSync = fs.realpathSync;
+  try {
+    const exe = path.join(outsideDir, 'mytool');
+    fs.writeFileSync(exe, '#!/bin/sh\necho x\n', { mode: 0o755 });
+
+    fs.realpathSync = function patchedRealpathSync(p, ...rest) {
+      if (path.resolve(p) === path.resolve(exe)) {
+        throw new Error('simulated realpath failure');
+      }
+      return realRealpathSync.call(fs, p, ...rest);
+    };
+
+    assert.throws(
+      () =>
+        resolveTrustedExe('mytool', {
+          workspaceRoot: workspace,
+          env: { PATH: outsideDir },
+          platform: 'linux',
+        }),
+      (err) => {
+        assert.match(err.message, /unverifiable/i);
+        return true;
+      },
+      'must throw rather than falling back to the raw unresolved candidate ' +
+        '(the pre-fix behaviour)',
+    );
+  } finally {
+    fs.realpathSync = realRealpathSync;
+    rmrf(workspace);
+    rmrf(outsideDir);
+  }
+});
+
 // ---------------------------------------------------------------------
 // safeUnlinkInside
 // ---------------------------------------------------------------------

--- a/tools/mcp-conformance/test/is-error-matches-ok.test.cjs
+++ b/tools/mcp-conformance/test/is-error-matches-ok.test.cjs
@@ -1,0 +1,101 @@
+// Unit tests for `_runner.cjs`'s `assertIsErrorMatchesOk` (rf2-6i2yi4
+// finding 1).
+//
+// ## The bug this pins
+//
+// `assertIsErrorMatchesOk` is the universal isError <-> `:ok?`
+// cross-check (spec/003-Tool-Catalogue.md §381) run against every
+// `tools/call` response in `end-to-end-re-frame2-pair.cjs`. It used to
+// read `resp.structuredContent` directly. A dedup-eligible tool ships
+// its structured payload wrapped in `{:rf.mcp/dedup-table {...}}` — the
+// raw field then has NO top-level `:ok?` slot at all (it is one layer
+// down, inside the cache), so the pre-fix check's
+// `!Object.prototype.hasOwnProperty.call(sc, 'ok?')` guard treated the
+// envelope as "not `:ok?`-shaped" and silently no-op'd — exactly the
+// dedup-wrapped envelope the check exists to grade. A real MCP client
+// always expands the dedup table before reading semantic slots, so this
+// was a genuine blind spot: a dedup-eligible tool's `:ok? false` result
+// with `isError` decoupled would pass unobserved.
+//
+// FIX: route `resp` through the shared `structured()` dedup-decoder
+// before reading `:ok?`.
+//
+// ## What this proves
+//
+// Test 1 is the RED-then-GREEN proof: it first shows the RAW wire field
+// has no top-level `:ok?` (sanity — this is what the pre-fix code read),
+// then shows `assertIsErrorMatchesOk` still catches the violation because
+// it decodes first. Reverting to reading `resp.structuredContent`
+// directly would make this test's `assert.throws` fail (silently
+// pass/no-op instead).
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { assertIsErrorMatchesOk } = require('./_runner.cjs');
+const { DEDUP_TABLE_KEY, ROOT_CACHE_ID } = require('../lib/dedup-envelope.cjs');
+
+function dedupWrapped(payload) {
+  return { [DEDUP_TABLE_KEY]: { [ROOT_CACHE_ID]: payload } };
+}
+
+test('assertIsErrorMatchesOk: RED-then-GREEN — a dedup-wrapped :ok? false + isError:false is caught (rf2-6i2yi4 finding 1)', () => {
+  const resp = {
+    isError: false,
+    structuredContent: dedupWrapped({ 'ok?': false, reason: 'boom' }),
+  };
+  // Sanity: the RAW wire field (what the pre-fix code read directly)
+  // carries NO top-level `:ok?` slot at all — it's one layer down,
+  // inside the dedup cache.
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(resp.structuredContent, 'ok?'),
+    false,
+    'sanity: the raw wire structuredContent has no top-level :ok? slot',
+  );
+  assert.throws(
+    () => assertIsErrorMatchesOk('probe', resp),
+    /:ok\? false but isError is not true/,
+    'must decode the dedup envelope to find :ok? false and catch the violation',
+  );
+});
+
+test('assertIsErrorMatchesOk: converse — a dedup-wrapped :ok? true + isError:true is caught', () => {
+  const resp = { isError: true, structuredContent: dedupWrapped({ 'ok?': true }) };
+  assert.throws(() => assertIsErrorMatchesOk('probe', resp), /:ok\? true but isError is true/);
+});
+
+test('assertIsErrorMatchesOk: a legitimate dedup-wrapped :ok? false + isError:true does not throw', () => {
+  const resp = { isError: true, structuredContent: dedupWrapped({ 'ok?': false }) };
+  assert.doesNotThrow(() => assertIsErrorMatchesOk('probe', resp));
+});
+
+test('assertIsErrorMatchesOk: a legitimate dedup-wrapped :ok? true + isError:false does not throw', () => {
+  const resp = { isError: false, structuredContent: dedupWrapped({ 'ok?': true }) };
+  assert.doesNotThrow(() => assertIsErrorMatchesOk('probe', resp));
+});
+
+test('assertIsErrorMatchesOk: a non-dedup (plain) envelope still cross-checks as before', () => {
+  assert.throws(
+    () =>
+      assertIsErrorMatchesOk('probe', {
+        isError: false,
+        structuredContent: { 'ok?': false },
+      }),
+    /:ok\? false but isError is not true/,
+  );
+  assert.doesNotThrow(() =>
+    assertIsErrorMatchesOk('probe', {
+      isError: false,
+      structuredContent: { 'ok?': true },
+    }),
+  );
+});
+
+test('assertIsErrorMatchesOk: a non-:ok?-shaped result is out of scope (no throw)', () => {
+  assert.doesNotThrow(() =>
+    assertIsErrorMatchesOk('probe', { isError: false, structuredContent: { foo: 1 } }),
+  );
+  assert.doesNotThrow(() => assertIsErrorMatchesOk('probe', {}));
+});

--- a/tools/mcp-conformance/test/live-re-frame2-pair-cofx.cjs
+++ b/tools/mcp-conformance/test/live-re-frame2-pair-cofx.cjs
@@ -87,6 +87,7 @@
 const path = require('node:path');
 const os = require('node:os');
 const { runWithWatchdog, responseText } = require('./_runner.cjs');
+const { includesToken } = require('../lib/token-match.cjs');
 
 const SERVER = path.resolve(__dirname, '..', '..', 're-frame2-pair-mcp', 'out', 'server.js');
 
@@ -240,11 +241,13 @@ runWithWatchdog(
         );
       }
       const text = responseText(resp);
-      if (!text.includes(m.reason)) {
+      if (!includesToken(text, m.reason)) {
         throw new Error(
           'dispatch [:counter/stamp] with ' + m.why + ' MUST carry the ' +
-            'documented structured error ' + m.reason + ' (EP-0017 cofx ' +
-            'contract); got: ' + text.slice(0, 300),
+            'documented structured error ' + m.reason + ' as an exact token ' +
+            '(EP-0017 cofx contract), not merely as a substring of a longer ' +
+            'reason (e.g. :invalid-cofx-time-ms satisfying a :invalid-cofx ' +
+            'check); got: ' + text.slice(0, 300),
         );
       }
       // The malformed-cofx refusal is reachable here ONLY because we have a

--- a/tools/mcp-conformance/test/stale-port-file-trust.test.cjs
+++ b/tools/mcp-conformance/test/stale-port-file-trust.test.cjs
@@ -1,0 +1,157 @@
+// Regression test for the hermetic live-suite's stale nREPL port-file
+// cleanup (rf2-6i2yi4).
+//
+// Uses Node's built-in `node:test` (same posture as the sibling
+// `*.test.cjs` files in this directory — no extra dev-dependency). Runs
+// in-process: it requires the orchestrator AS A MODULE (the auto-run is
+// guarded behind `require.main === module`, so requiring it does NOT
+// boot shadow-cljs / Chromium) and drives the exported
+// `wipeStalePortFileCandidate` against FAKE `unlink`/`statExists`/`logFn`
+// — no real file, no real Windows file lock.
+//
+// ## The bug this pins
+//
+// Before this fix, `main()`'s stale-port-file wipe loop caught a BENIGN
+// unlink failure (EACCES / EBUSY — a Windows file lock from a
+// not-yet-reaped prior shadow-cljs process) and only logged it, then
+// continued. `readPortFile()` (driving the `waitUntil('nREPL port
+// file', ...)` poll right after) has NO staleness/liveness gate — it
+// trusts the first candidate that parses to a finite integer. A stale
+// port file surviving the failed unlink would therefore satisfy that
+// poll on its very FIRST check, before shadow-cljs has any chance to
+// rebind and rewrite it: best case that wastes the whole boot timeout
+// polling a dead port, worst case it connects to a stale/zombie runtime
+// from a prior run (state bleed between runs).
+//
+// FIX: after a benign unlink failure, re-stat the candidate. If it is
+// genuinely gone (the failure raced a concurrent removal), proceed as
+// before. If it is STILL on disk, fail loud immediately rather than
+// deferring the risk to the staleness-blind read side.
+//
+// ## What this test drives
+//
+// It requires the orchestrator as a module and exercises the exported
+// `wipeStalePortFileCandidate` against fakes:
+//
+//   1. RED-then-GREEN proof of the exact bug: a fake `unlink` that
+//      throws a benign EBUSY-shaped error while a fake `statExists`
+//      reports the file is STILL present. Asserts the call throws
+//      (fail-loud) and the thrown message names the candidate + the
+//      rf2-6i2yi4 marker. Reverting to the pre-fix behaviour (swallow +
+//      log) would make this assertion fail — the proof is red against
+//      the old code, green against the new.
+//   2. A benign failure where the file is confirmed GONE afterward
+//      (`statExists` returns false) does NOT throw — the transient-lock
+//      happy path is unbroken.
+//   3. A successful unlink (no throw) logs and does not throw,
+//      regardless of `statExists` — the common case is unaffected.
+//   4. A containment-escape error (message carries the
+//      `symlink-escape accident-gating` marker) is FATAL even when
+//      `statExists` would report the file gone — escape detection is
+//      not weakened by this fix.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const ORCH = path.join(
+  __dirname,
+  '..',
+  'scripts',
+  'run-re-frame2-pair-live-hermetic-suite.cjs',
+);
+
+// Requiring is side-effect-free: the orchestrator guards its auto-run
+// behind `require.main === module`, so no shadow-cljs / Chromium spawns.
+const { wipeStalePortFileCandidate } = require(ORCH);
+
+const FIXTURE_DIR = '/fake/fixture';
+const CANDIDATE = '/fake/fixture/.shadow-cljs/nrepl.port';
+
+function benignError() {
+  // Shaped like a real Node fs errno failure: has a `.code`, and its
+  // `.message` carries NEITHER of the containment-escape marker strings.
+  const e = new Error('EBUSY: resource busy or locked, unlink ' + CANDIDATE);
+  e.code = 'EBUSY';
+  return e;
+}
+
+function escapeError() {
+  return new Error(
+    `refusing to unlink ${CANDIDATE}: symlink-escape accident-gating — ` +
+      'realpath resolves outside the allowed root',
+  );
+}
+
+test('wipeStalePortFileCandidate: benign failure + file STILL present fails loud (rf2-6i2yi4 red-then-green)', () => {
+  const logs = [];
+  assert.throws(
+    () =>
+      wipeStalePortFileCandidate(CANDIDATE, FIXTURE_DIR, {
+        unlink: () => {
+          throw benignError();
+        },
+        statExists: () => true, // re-stat: still on disk
+        logFn: (m) => logs.push(m),
+      }),
+    (err) => {
+      assert.match(err.message, /STILL on disk/);
+      assert.match(err.message, /rf2-6i2yi4/);
+      assert.ok(err.message.includes(CANDIDATE), 'names the stale candidate');
+      return true;
+    },
+  );
+});
+
+test('wipeStalePortFileCandidate: benign failure + file confirmed GONE does not throw (transient-lock happy path)', () => {
+  const logs = [];
+  assert.doesNotThrow(() =>
+    wipeStalePortFileCandidate(CANDIDATE, FIXTURE_DIR, {
+      unlink: () => {
+        throw benignError();
+      },
+      statExists: () => false, // re-stat: gone now
+      logFn: (m) => logs.push(m),
+    }),
+  );
+  assert.ok(
+    logs.some((m) => m.includes('gone now')),
+    'logs the benign-but-resolved outcome',
+  );
+});
+
+test('wipeStalePortFileCandidate: successful unlink does not throw and logs removal', () => {
+  const logs = [];
+  let statExistsCalled = false;
+  assert.doesNotThrow(() =>
+    wipeStalePortFileCandidate(CANDIDATE, FIXTURE_DIR, {
+      unlink: () => true,
+      statExists: () => {
+        statExistsCalled = true;
+        return true;
+      },
+      logFn: (m) => logs.push(m),
+    }),
+  );
+  assert.equal(statExistsCalled, false, 're-stat is only consulted on a failed unlink');
+  assert.ok(logs.some((m) => m.includes('removed stale port file')));
+});
+
+test('wipeStalePortFileCandidate: containment-escape is fatal even if statExists would say gone', () => {
+  assert.throws(
+    () =>
+      wipeStalePortFileCandidate(CANDIDATE, FIXTURE_DIR, {
+        unlink: () => {
+          throw escapeError();
+        },
+        statExists: () => false,
+        logFn: () => {},
+      }),
+    (err) => {
+      assert.match(err.message, /khav7l/);
+      return true;
+    },
+  );
+});

--- a/tools/mcp-conformance/test/token-match.test.cjs
+++ b/tools/mcp-conformance/test/token-match.test.cjs
@@ -1,0 +1,68 @@
+// Unit tests for `lib/token-match.cjs` (rf2-6i2yi4).
+//
+// ## The bug this pins
+//
+// `test/live-re-frame2-pair-cofx.cjs`'s malformed-cofx assertion used to
+// be `if (!text.includes(m.reason)) throw`. `:invalid-cofx` is a strict
+// substring of `:invalid-cofx-time-ms`, so a server returning
+// `:invalid-cofx-time-ms` for what should have been a plain
+// `:invalid-cofx` case (a non-map cofx, or unreadable EDN) still
+// satisfies `text.includes(':invalid-cofx')` — 2 of the 3 malformed-cofx
+// refusal reasons were never actually distinguished.
+//
+// FIX: `includesToken` anchors the match so a token only counts as
+// present when it appears as a COMPLETE keyword (no word/hyphen
+// character immediately before or after), not merely as a prefix of a
+// longer one.
+//
+// ## What this proves
+//
+// Test 1 is the RED-then-GREEN proof: it first shows plain
+// `String#includes` is fooled by the exact wire text this bug allowed
+// through (the reason `:invalid-cofx` "matching" text that actually
+// carries `:invalid-cofx-time-ms`), then shows `includesToken` correctly
+// rejects that same input — i.e. reverting `live-re-frame2-pair-cofx.cjs`
+// to `.includes` would make the tightened check pass on a case it must
+// reject, and this test documents exactly why.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { includesToken } = require('../lib/token-match.cjs');
+
+test('includesToken: RED-then-GREEN — plain .includes is fooled by a longer sibling reason, includesToken is not', () => {
+  const text = 'dispatch refused: :invalid-cofx-time-ms (non-integer :rf/time-ms)';
+  // RED: this is the exact false-pass the pre-fix assertion allowed —
+  // `.includes(':invalid-cofx')` is true against text that actually
+  // carries the DIFFERENT reason `:invalid-cofx-time-ms`.
+  assert.equal(
+    text.includes(':invalid-cofx'),
+    true,
+    'sanity: plain .includes conflates the two reasons (the bug)',
+  );
+  // GREEN: the tightened check correctly rejects it — this token is
+  // absent as a COMPLETE keyword.
+  assert.equal(includesToken(text, ':invalid-cofx'), false);
+  // And the longer reason IS correctly found as a complete keyword.
+  assert.equal(includesToken(text, ':invalid-cofx-time-ms'), true);
+});
+
+test('includesToken: matches the short reason when it genuinely stands alone', () => {
+  const text = 'dispatch refused: :invalid-cofx (non-map cofx arg)';
+  assert.equal(includesToken(text, ':invalid-cofx'), true);
+  assert.equal(includesToken(text, ':invalid-cofx-time-ms'), false);
+});
+
+test('includesToken: token at the very start/end of text still matches', () => {
+  assert.equal(includesToken(':invalid-cofx', ':invalid-cofx'), true);
+  assert.equal(includesToken('prefix :invalid-cofx', ':invalid-cofx'), true);
+  assert.equal(includesToken(':invalid-cofx suffix', ':invalid-cofx'), true);
+});
+
+test('includesToken: does not match when the token is a prefix/suffix of a surrounding keyword', () => {
+  // Literal substring IS present in both, but each time as part of a
+  // longer keyword — the anchoring must reject both.
+  assert.equal(includesToken('reason: :invalid-cofxy', ':invalid-cofx'), false); // suffix-continued
+  assert.equal(includesToken('reason: x:invalid-cofx', ':invalid-cofx'), false); // prefix-continued
+});


### PR DESCRIPTION
## Summary

rf2-6i2yi4 bundles 8 MEDIUM/LOW grading-precision findings on the `tools/mcp-conformance/` harness itself -- assertions loose enough that they would stay green through the exact regression they exist to catch. All 8 are fixed, each with a red-then-green unit proof.

## Per-finding fix + discrimination note

**1. `assertIsErrorMatchesOk` was dedup-blind** (`test/end-to-end-re-frame2-pair.cjs`)
Read `resp.structuredContent` directly instead of through the `structured()` dedup-decoder. A dedup-eligible tool ships `{:rf.mcp/dedup-table {...}}` at the top level, so the raw field has no `:ok?` slot -- the check's own "not `:ok?`-shaped, skip" guard silently no-opped on exactly the envelopes it exists to grade.
Fix: extracted the assertion to `test/_runner.cjs` and routed it through `structured(resp)`.
Catches: `test/is-error-matches-ok.test.cjs` constructs a dedup-wrapped `{ 'ok?': false }` payload with `isError:false` -- asserts the raw field has no top-level `:ok?` (sanity, proving the pre-fix blind spot), then asserts the tightened check still throws.

**2. cofx refusal-reason substring collision** (`test/live-re-frame2-pair-cofx.cjs`)
`text.includes(m.reason)` -- `:invalid-cofx` is a literal substring of `:invalid-cofx-time-ms`, so a server returning the wrong reason for 2 of the 3 malformed-cofx cases still passed.
Fix: new `lib/token-match.cjs` `includesToken` -- anchors the match so no word/hyphen character may immediately precede/follow it.
Catches: `test/token-match.test.cjs` shows `text.includes(':invalid-cofx')` is `true` against text that actually carries `:invalid-cofx-time-ms` (the bug, reproduced), then shows `includesToken` correctly returns `false` for the same input.

**3. SKIP-as-GREEN in the npm-test summary** (`scripts/test-all.cjs`)
All six `live-re-frame2-pair-*` rows exit 0 with a `SKIP` banner when `$SHADOW_CLJS_NREPL_PORT` is unset; the summary treated `status===0` as OK with no distinction, printing "ALL CONFORMANCE TESTS GREEN" identically whether every live gate ran or all six silently skipped.
Fix: child stdout is now piped (not just inherited) and scanned for the `SKIP ` banner `_runner.cjs`'s skip helper prints; the summary renders `[SKIP]` rows and softens the final line to name the skip count when any occurred.
Catches: verified live -- a full local `npm test` run (no nREPL) now prints `[SKIP]` for all six live-* rows and `ALL CONFORMANCE TESTS GREEN (6 SKIPPED -- ...)` instead of an unqualified green banner.

**4. Classification ratchet closed-world gap** (`test/_runner.cjs`)
`closed-world` was consulted per-tool *inside* the loop over the live tool-set, so a `closed-world` row naming a renamed/removed tool was never visited -- silently tolerated, unlike a stale `classifications` row (which already tripped).
Fix: added an exact-subset check -- every `closed-world` entry must exist in `classifications` -- run once up front.
Catches: `test/classification-ratchet.test.cjs` constructs a fixture where a tool was cleanly removed from `classifications` (satisfying the existing exact-keyset guard) but left dangling in `closed-world`; asserts this now throws naming the stale entry (pre-fix: no throw at all, since none of the 3 live tools trip either open/closed-world branch).

**5. dedup-envelope map-KEY blind spot** (`lib/dedup-envelope.cjs`)
`expandValue` only recursed into map values, using keys verbatim. The real `de-dupe.core/expand` expands both halves of every map-entry, and `cachable?` permits a de-duped map key (this codebase has vector/path-keyed structures) -- a de-duped key stayed as the raw `de-dupe.cache/cache-N` placeholder string.
Fix: keys are now routed through `expandValue` too; a non-string expanded key (e.g. an array) is rendered via `JSON.stringify` since JS object keys must be strings.
Catches: `test/dedup-envelope.test.cjs` -- a cache entry keyed by a ref to `['a','b']` decodes to a key of `Object.keys(out)` equal to `JSON.stringify(['a','b'])` (was: the raw `de-dupe.cache/cache-N` string, unfindable by any real lookup).

**6. `resolveTrustedExe` realpath-failure fallback** (`lib/exec-safety.cjs`)
`realpathSyncOrNull(candidate) || candidate` silently fell back to the *unresolved* candidate on a realpath failure -- trusting exactly the unverified path the module exists to reject. Known real trigger: `fs.realpathSync` throwing on Windows App-Execution-Alias reparse points under `%LOCALAPPDATA%\Microsoft\WindowsApps` (default PATH entry) that `fs.statSync` sees as an ordinary file.
Fix: a realpath failure is now treated as a rejected candidate; the search continues to the next PATH entry, and throws (naming it "unverifiable") if every candidate fails this way.
Catches: `test/exec-safety.test.cjs` monkeypatches `fs.realpathSync` to throw on one specific candidate -- proves the function skips it and resolves the next trusted candidate (not the raw path), and throws (rather than silently returning the raw path) when every candidate is unverifiable.

**7. dedup-envelope orphan-cache validation gap** (`lib/dedup-envelope.cjs`)
`expandCache` only visited entries reachable from `cache-0`. The real `de-dupe.core/decompress-cache` eagerly expands every key before picking `cache-0`, so a malformed orphan entry (unreferenced, e.g. a dangling ref or self-cycle) decoded cleanly here instead of throwing like a real client.
Fix: `expandCache` now eagerly expands every cache key (memoised, so no extra cost for the reachable subset) before returning the root's expansion.
Catches: `test/dedup-envelope.test.cjs` -- an orphaned entry with a dangling ref, and a separate orphaned self-cyclic entry, both now throw (pre-fix: neither did, since only `cache-0` was ever visited).

**8. Hermetic suite stale port-file trust** (`scripts/run-re-frame2-pair-live-hermetic-suite.cjs`)
A benign unlink failure (EACCES/EBUSY -- a lingering Windows lock) on a stale nREPL port file was logged and the run continued; `readPortFile` has no staleness/liveness gate and trusts the first parseable candidate -- a surviving stale file would be trusted on the very first poll, before shadow-cljs rebinds (best case: wastes the whole boot timeout; worst case: connects to a stale/zombie runtime).
Fix: extracted `wipeStalePortFileCandidate` (dependency-injectable for testing); on a benign unlink failure it now re-stats the candidate and fails loud if the file is still present, instead of silently continuing.
Catches: `test/stale-port-file-trust.test.cjs` drives the extracted function with a fake unlink that fails benignly while a fake re-stat reports the file still present -- asserts it now throws (pre-fix: logged and continued).

## Quality gates

- `node scripts/test-unit.cjs` (the full pure-Node `--test` cluster, CI's `test:unit` step): 85 tests, 76 pass, 9 platform-skipped (Windows symlink arms), 0 fail.
- `node test/end-to-end-re-frame2-pair.cjs` (degraded-mode conformance against a freshly `shadow-cljs compile server`'d bundle): green, including the universal isError/`:ok?` cross-check now routed through `structured()`.
- `npm test` (`scripts/test-all.cjs`, full local inventory -- unit + degraded e2e + all 6 live-* SKIP + story-mcp + flag-gates): green, with the SKIP-summary fix visibly rendering `[SKIP]` rows + a softened "6 SKIPPED" summary line instead of an unqualified "ALL CONFORMANCE TESTS GREEN".
- Every tightened assertion ships its own red-then-green unit proof (see per-finding notes above); no live-nREPL/browser infrastructure was needed for any of the 8 proofs.

Scope: `tools/mcp-conformance/**` only, per the bead ownership. No other surface touched.
