### PR TITLE
fix(story): viewport-toggle app-db preservation + evidence-tape robustness + nested-control edit + url-apply mode clear (rf2-j8hklm/96qsjr/mzfh9c/gchydo)

### DIFF
--- a/tools/story/spec/022-Story-UI-Docs-And-Share.md
+++ b/tools/story/spec/022-Story-UI-Docs-And-Share.md
@@ -252,10 +252,17 @@ Share semantics:
   the one slot whose default is itself the omission token — `build-params`
   emits `substrate=` only for a non-default substrate — so an omitted param
   carries the SAME default-restore meaning as the other URL-owned slots and is
-  validated against the live substrate registry. A no-query popstate
+  validated against the live substrate registry. Mode-tab gets the SAME
+  treatment but is per-variant rather than global (rf2-gchydo): when the URL
+  keeps the focused variant but omits `mode-tab=`, the stale
+  `[:active-mode-tab <focused-variant>]` entry is cleared (dissoc'd, not
+  merely left unset) so the reader's `:dev` default applies — the same fix
+  the encode side already assumed (mode-tab changes are pushState'd, per
+  `url-relevant-slots-changed?`), so Back/Back past a tab switch reverts the
+  rendered tab, not just the address bar. A no-query popstate
   (back/forward to a bare URL) likewise clears the URL-owned selection / modes
-  / framing / filter / substrate rather than no-op'ing. So a share link like
-  `?variant=story.counter/loaded` restores
+  / framing / filter / substrate / mode-tab rather than no-op'ing. So a share
+  link like `?variant=story.counter/loaded` restores
   the DEFAULT view for the recipient instead of keeping their prior
   localStorage-seeded chrome — the address bar is the source of truth for the
   full share surface. The intentional localStorage fallback survives ONLY for

--- a/tools/story/src/re_frame/story/artifact.cljc
+++ b/tools/story/src/re_frame/story/artifact.cljc
@@ -81,6 +81,7 @@
   (:require [re-frame.core                        :as rf]
             [re-frame.story.play.evidence         :as evidence]
             [re-frame.story.play.runner           :as runner]
+            [re-frame.story.play.runner-events    :as runner-events]
             [re-frame.story.play.settled-boundary :as boundary]
             ;; The raw HTTP stub pair lives in `re-frame.http.test-support`
             ;; (reached through its home namespace, not the `re-frame.core`
@@ -273,14 +274,6 @@
             (uninstall))))
       (thunk))))
 
-(defn- epoch-count
-  "The current epoch-history length for `frame-id` — the append-only tape
-  cursor a replay settle boundary snapshots. Tolerant: 0 when
-  the frame has no history / the epoch dep is absent (facade → `[]`)."
-  [frame-id]
-  (try (count (rf/epoch-history frame-id))
-       (catch #?(:clj Throwable :cljs :default) _ 0)))
-
 (defn- step-dispatch-opts
   "Build the per-call dispatch opts a replayed `[:dispatch …]` step carries
   (EP-0017 §6 / Tool-Pair §Replay). Replay is UNCONDITIONALLY
@@ -307,16 +300,19 @@
   per dispatch step), in program order — `{:status :settled :boundary …}`
   on success, a `cannot-run-refusal` / `{:status :error …}` otherwise.
 
-  The returned vector carries an `:attribution` metadata slot:
-  the epoch-history LENGTH snapshotted at the start of each dispatch step's
-  settle, in dispatch-step order. `replay-result` reads it (via
-  `(:attribution (meta outcomes))`) and hands it to `project-evidence` so
-  the replay narrative is attributed EXACTLY (`evidence/spans-from-stamps`)
-  rather than via the EVEN heuristic. The metadata leaves the documented
-  return VALUE (the outcomes vector) unchanged. The boundaries are
-  positional — the Nth element is the Nth dispatch step's settle boundary —
-  so they zip directly onto the dispatch steps of the `:event-program` the
-  narrative spans.
+  The returned vector carries an `:attribution` metadata slot: the
+  last-committed `:epoch-id` (`runner-events/last-epoch-id` — a genuine
+  monotonic identity, NOT a ring-length snapshot; rf2-96qsjr) at the start
+  of each dispatch step's settle, in dispatch-step order. `replay-result`
+  reads it (via `(:attribution (meta outcomes))`) and hands it to
+  `project-evidence` so the replay narrative is attributed EXACTLY
+  (`evidence/spans-from-stamps`) rather than via the EVEN heuristic. The
+  metadata leaves the documented return VALUE (the outcomes vector)
+  unchanged. The boundaries are positional with respect to DISPATCH-STEP
+  ORDER — the Nth element is the Nth dispatch step's settle boundary — so
+  they zip directly onto the dispatch steps of the `:event-program` the
+  narrative spans, regardless of how much of the `epoch-history` ring
+  (default depth 50) survives eviction by the time the tape is read.
 
   This is the IMPURE seam — it dispatches into a live frame. The caller
   owns frame allocation + teardown + the epoch-tape read; `replay-run-
@@ -336,10 +332,14 @@
                                     (when-let [evec (runner/step-event step)]
                                       (let [required (boundary/step-required-boundary step)
                                             dispatch-opts (step-dispatch-opts step)]
-                                        ;; Snapshot the tape cursor BEFORE the
-                                        ;; settle — this dispatch step owns the
-                                        ;; records committed from here forward.
-                                        (vswap! boundaries conj (epoch-count frame-id))
+                                        ;; Snapshot the last-committed
+                                        ;; `:epoch-id` BEFORE the settle — this
+                                        ;; dispatch step owns every record
+                                        ;; whose OWN id is greater (rf2-96qsjr:
+                                        ;; an identity, not a ring-length
+                                        ;; snapshot, so it stays correct
+                                        ;; whatever the ring evicts).
+                                        (vswap! boundaries conj (runner-events/last-epoch-id frame-id))
                                         (boundary/dispatch-and-settle!
                                           frame-id evec replay-hooks required step
                                           dispatch-opts)))))

--- a/tools/story/src/re_frame/story/play/evidence.cljc
+++ b/tools/story/src/re_frame/story/play/evidence.cljc
@@ -529,32 +529,54 @@
 ;;
 ;; This is the PRODUCER-side bridge that lights up `explicit-beats?` /
 ;; `spans-from-stamps`. The runner / replay path records, per
-;; dispatch-opening step (in executed-script order), the epoch-history
-;; LENGTH at the moment that step's settle began (`settle-boundaries`). The
-;; epoch tape is append-only during a run, so dispatch step K owns the
-;; contiguous run of records `[boundary_K, boundary_{K+1})` — and the LAST
-;; dispatch step owns through the tape end. This naturally rolls any epochs
-;; committed by intervening non-dispatch steps (an `[:assert …]` checkpoint
-;; that dispatches its `:rf.assert/*` verdict, a `:wait-until`) into the
-;; PRECEDING dispatch span, exactly the forward-attribution model the
-;; narrative documents (spec/017 §Epoch tape and narrative). Records before
-;; the first boundary (setup-phase cascades, framework bootstrap) are
-;; stamped nil → the leading span.
+;; dispatch-opening step (in executed-script order), the last-committed
+;; `:epoch-id` at the moment that step's settle began (`settle-boundaries`).
+;; `:epoch-id` is the framework's genuine, globally-monotonic per-record
+;; identity (`re-frame.epoch.state/next-epoch-id`) — NOT a position in
+;; `tape`. Dispatch step K owns every record whose OWN `:epoch-id` is
+;; greater than boundary K but not greater than boundary K+1 (the LAST
+;; dispatch step owns through the tape end). This naturally rolls any
+;; epochs committed by intervening non-dispatch steps (an `[:assert …]`
+;; checkpoint that dispatches its `:rf.assert/*` verdict, a `:wait-until`)
+;; into the PRECEDING dispatch span, exactly the forward-attribution model
+;; the narrative documents (spec/017 §Epoch tape and narrative). Records
+;; whose `:epoch-id` is at or before the first boundary (setup-phase
+;; cascades, framework bootstrap) are stamped nil → the leading span.
 ;;
-;; `boundaries` is positional, NOT keyed by step index: its Nth element is
-;; the settle boundary of the Nth DISPATCH step in `script` (in order). This
-;; is what makes the mechanism runtime-agnostic — the live multi-play runner
-;; and the replay path both execute the concatenated dispatch steps in the
-;; same order the boundaries are recorded, so the zip is exact without any
-;; cross-play index arithmetic.
+;; rf2-96qsjr: comparing by `:epoch-id` rather than `tape` POSITION is what
+;; makes this robust to `epoch-history`'s bounded ring (default depth 50)
+;; evicting older records mid-run. A position-based zip requires the tape
+;; to be exactly as long, from the same zero-point, as it was when the
+;; boundaries were recorded — an assumption a long run (a big `:script`, a
+;; heavy cascade, or multi-play accumulation across ALL auto-plays) breaks
+;; the moment total epochs exceed the ring depth. `:epoch-id` never
+;; depends on tape length or ring occupancy: a record still IN the tape
+;; always carries the same id it was assigned at commit time, so eviction
+;; can only ever drop beats (the evicted records are simply gone), never
+;; misattribute a surviving one to the wrong step.
+;;
+;; `boundaries` is positional only with respect to DISPATCH-STEP ORDER, not
+;; epoch-tape order: its Nth element is the settle boundary of the Nth
+;; DISPATCH step in `script` (in order). This is what makes the mechanism
+;; runtime-agnostic — the live multi-play runner and the replay path both
+;; execute the concatenated dispatch steps in the same order the boundaries
+;; are recorded, so the zip is exact without any cross-play index
+;; arithmetic.
 
 (defn stamp-tape
   "Stamp each `:rf/epoch-record` in `tape` with the 0-based
   `:rf.story/script-idx` of the authored `script` step whose settle
-  produced it, using the runner-recorded `boundaries` (the epoch-history
-  length at the start of each dispatch step's settle, in dispatch-step
+  produced it, using the runner-recorded `boundaries` (the last-committed
+  `:epoch-id` at the start of each dispatch step's settle, in dispatch-step
   order). Pure data → data; the stamped tape is what the EXACT narrative
   attribution (`explicit-beats?` / `spans-from-stamps`) consumes.
+
+  Ownership is decided by comparing each record's OWN `:epoch-id` against
+  the boundaries (rf2-96qsjr) — NOT the record's position in `tape` — so a
+  tape that has had earlier records evicted from the `epoch-history` ring
+  (default depth 50) still attributes every SURVIVING record correctly;
+  only the evicted records' beats are lost, never misattributed to the
+  wrong step.
 
   The stamp is a `:rf.story/*` accumulator key, so the deterministic
   projection (`re-frame.story.fingerprint/project`) strips it before the
@@ -564,9 +586,10 @@
   Degrades gracefully: with no `boundaries` (a bare tape — replay/live
   paths that did not record settle boundaries) the tape is returned
   verbatim (unstamped), so `narrative` falls back to the EVEN partition
-  exactly as before. A record at or past the last boundary belongs to the
-  last dispatch step; records before the first boundary are stamped nil
-  (the leading setup span)."
+  exactly as before. A record whose `:epoch-id` is at or past the last
+  boundary belongs to the last dispatch step; records at or before the
+  first boundary (or carrying no `:epoch-id` at all — a defensive
+  fallback) are stamped nil (the leading setup span)."
   [script tape boundaries]
   (let [records       (vec (or tape []))
         bounds        (vec (or boundaries []))
@@ -578,19 +601,21 @@
     (if (empty? bounds)
       records
       (mapv
-        (fn [pos record]
-          (let [;; The index into `bounds` of the LAST dispatch step whose
-                ;; settle had already begun at this record's tape position —
-                ;; i.e. the dispatch step that owns this record. A record
-                ;; before the first boundary owns to no step (leading nil).
-                owner (loop [k (dec (count bounds))]
-                        (cond
-                          (neg? k)                  nil
-                          (<= (nth bounds k) pos)    k
-                          :else                     (recur (dec k))))]
+        (fn [record]
+          (let [eid   (:epoch-id record)
+                ;; The index into `bounds` of the LAST dispatch step whose
+                ;; settle had already begun before this record's OWN
+                ;; `:epoch-id` was assigned — i.e. the dispatch step that
+                ;; owns this record. A record at or before the first
+                ;; boundary owns to no step (leading nil).
+                owner (when (some? eid)
+                        (loop [k (dec (count bounds))]
+                          (cond
+                            (neg? k)                nil
+                            (< (nth bounds k) eid)  k
+                            :else                   (recur (dec k)))))]
             (assoc record :rf.story/script-idx
                    (when (some? owner) (nth dispatch-idxs owner nil)))))
-        (range)
         records))))
 
 (defn narrative
@@ -610,10 +635,12 @@
     beat lands in the span of the step that produced it; unstamped / setup
     beats lead under a `nil` span. This is the precise model the
     PRODUCER feeds: the runner / replay path records each dispatch step's
-    settle boundary (the epoch-history length at the start of its settle),
-    and `project-evidence` stamps the tape via `stamp-tape` before handing
-    it here. A re-dispatch step that settles to N committed
-    epochs has all N attributed to the one authored step — exactly.
+    settle boundary (the last-committed `:epoch-id` at the start of its
+    settle — a genuine monotonic identity, robust to `epoch-history` ring
+    eviction, rf2-96qsjr), and `project-evidence` stamps the tape via
+    `stamp-tape` before handing it here. A re-dispatch step that settles to
+    N committed epochs has all N attributed to the one authored step —
+    exactly.
   - EVEN — absent stamps (a bare `epoch-history` tape with no recorded
     attribution — e.g. a hand-built tape or a host that did not record
     settle boundaries), records are partitioned across the dispatch steps
@@ -849,9 +876,10 @@
     two-level `:narrative` spans. Absent, the narrative is a single
     `nil`-step span over the whole tape.
   - `:attribution` — the runner-recorded per-dispatch-step settle
-    boundaries (the epoch-history length at the start of each dispatch
-    step's settle, in dispatch-step order). When present, the
-    `:narrative` is attributed EXACTLY via these boundaries
+    boundaries (the last-committed `:epoch-id` at the start of each
+    dispatch step's settle, in dispatch-step order — a genuine monotonic
+    identity, robust to `epoch-history` ring eviction, rf2-96qsjr). When
+    present, the `:narrative` is attributed EXACTLY via these boundaries
     (`stamp-tape` → `spans-from-stamps`); absent, the narrative falls
     back to the EVEN forward partition. The stamp lands ONLY
     on the records the narrative projection consumes — the verbatim

--- a/tools/story/src/re_frame/story/play/runner_events.cljc
+++ b/tools/story/src/re_frame/story/play/runner_events.cljc
@@ -89,15 +89,31 @@
 
 (defonce
   ^{:doc "frame-id → vector of per-dispatch-step settle boundaries
-         (rf2-rkd14). Each element is the epoch-history LENGTH at the
-         moment a dispatch-opening step's settle began, recorded in
+         (rf2-rkd14). Each element is the `:epoch-id` of the
+         most-recently-committed epoch at the moment a dispatch-opening
+         step's settle BEGAN (0 when none has committed yet), recorded in
          dispatch-step execution order. The evidence projection
          (`runtime/record-result-map`) reads this through
          `settle-boundaries` and hands it to
          `evidence/project-evidence` as `:attribution`, lighting up the
          EXACT narrative attribution (`spans-from-stamps`) instead of the
-         EVEN heuristic. Plain atom on both runtimes — it is read once at
-         result-build time, not a reactive UI input."}
+         EVEN heuristic.
+
+         rf2-96qsjr: boundaries are the framework's genuine, globally-
+         monotonic `:epoch-id` — NOT an `epoch-history` ring-LENGTH
+         snapshot. A length snapshot plateaus at the configured ring
+         depth (default 50) once the ring fills, so two boundaries
+         recorded after that point are numerically IDENTICAL — a long
+         run (a big `:script`, a heavy cascade, or multi-play accumulation
+         across ALL auto-plays) silently collapses distinct dispatch
+         steps onto the same cursor and misattributes their epochs. An
+         `:epoch-id` never plateaus and never depends on how much of the
+         ring survives eviction — `stamp-tape` compares it directly
+         against each SURVIVING record's own `:epoch-id`, so eviction can
+         only ever drop beats, never misattribute them.
+
+         Plain atom on both runtimes — it is read once at result-build
+         time, not a reactive UI input."}
   step-boundaries
   (atom {}))
 
@@ -124,31 +140,48 @@
   [frame-id]
   (get @step-boundaries frame-id))
 
-(defn- epoch-count
-  "The current epoch-history length for `frame-id` (the append-only tape
-  cursor the settle boundary snapshots). Tolerant — 0 when the frame has
-  no history / the epoch dep is absent (the facade degrades to `[]`)."
+(defn last-epoch-id
+  "The `:epoch-id` of the most-recently-committed epoch for `frame-id`, or
+  `0` if none has committed yet. `0` is never a real epoch-id — the
+  framework counter is 1-based (`re-frame.epoch.state/next-epoch-id`) — so
+  it composes as a safe exclusive lower bound with plain `<` comparisons.
+
+  rf2-96qsjr: this is a genuine, globally-monotonic IDENTITY, not a
+  ring-length/count snapshot. `rf/epoch-history` is a bounded per-frame
+  ring (default depth 50); a count of its current length PLATEAUS once
+  the ring is full (`(count (rf/epoch-history frame-id))` stops growing
+  even though epochs keep committing), so a boundary bookkeeper built on
+  it silently loses the ability to tell dispatch steps apart on a long
+  run. `:epoch-id` keeps incrementing regardless of ring occupancy and
+  survives eviction unchanged — a record that is still IN the ring always
+  carries the same `:epoch-id` it was assigned at commit time, so
+  comparing against it stays correct however much of the ring has been
+  evicted since. Public — `runtime.cljc` reads this too (`:epoch-baseline`
+  uses the same identity so the tape-scoping and the boundary bookkeeping
+  agree on what a run's epochs look like). Tolerant — 0 when the frame
+  has no history / the epoch dep is absent (the facade degrades to `[]`)."
   [frame-id]
-  (try (count (rf/epoch-history frame-id))
+  (try (or (:epoch-id (last (rf/epoch-history frame-id))) 0)
        (catch #?(:clj Throwable :cljs :default) _ 0)))
 
 (defn- record-settle-boundary!
-  "Snapshot the epoch-history length at the START of a dispatch-opening
-  `step`'s settle. No-op for non-dispatch steps (assert / wait / unknown)
-  — those commit no span of their own; their epochs roll into
+  "Snapshot the last-committed `:epoch-id` at the START of a dispatch-
+  opening `step`'s settle. No-op for non-dispatch steps (assert / wait /
+  unknown) — those commit no span of their own; their epochs roll into
   the preceding dispatch span (the narrative's forward-attribution model).
   The boundaries accumulate in dispatch-step execution order, which — for
   both the single-play and multi-play (sequential) runner — is exactly the
   order the dispatch steps appear in the concatenated executed-script the
   narrative spans. For multi-play this holds ONLY because the sequencer
   clears once up front and drives each play with `:clear-boundaries? false`:
-  the boundaries from play K+1 (absolute epoch-history
-  lengths) tail play K's, so the full vector zips positionally against the
-  concatenated script. A per-play clear would drop every earlier play's
-  boundaries, leaving only the last play's to be mis-zipped."
+  the boundaries from play K+1 (epoch-ids, which only ever increase) tail
+  play K's, so the full vector zips against the concatenated script in
+  dispatch order — an ordering fact, independent of ring occupancy. A
+  per-play clear would drop every earlier play's boundaries, leaving only
+  the last play's to be mis-zipped."
   [frame-id step]
   (when (evidence/dispatch-step? step)
-    (swap! step-boundaries update frame-id (fnil conj []) (epoch-count frame-id)))
+    (swap! step-boundaries update frame-id (fnil conj []) (last-epoch-id frame-id)))
   nil)
 
 (defn current-state-for-play
@@ -1293,22 +1326,22 @@
      ;; public entry that resets run-state and then writes boundaries via
      ;; `run-loop!`/`record-settle-boundary!`. Owning the reset alongside the
      ;; write keeps the attribution windowed onto THIS run's epoch tape. The
-     ;; leading-nil-span semantics hold: the boundaries snapshot the ABSOLUTE
-     ;; epoch-history length, so any setup epochs already on the tape precede
-     ;; the first boundary (in the orchestrator path setup runs in phase-2,
-     ;; before phase-4 drives `run!`).
+     ;; leading-nil-span semantics hold: the boundaries snapshot the last-
+     ;; committed `:epoch-id`, so any setup epochs already on the tape carry
+     ;; an id at or before the first boundary (in the orchestrator path
+     ;; setup runs in phase-2, before phase-4 drives `run!`).
      ;;
      ;; A MULTI-PLAY sequencer (`run-plays-sequentially!`, the orchestrator
      ;; `runtime/run-phase-4!`) passes `:clear-boundaries? false` for the
      ;; 2nd…Nth play so the boundaries ACCUMULATE across the whole auto-run
      ;; sequence. The narrative spans the CONCATENATED script
-     ;; (`(mapcat :script auto-plays)`), and the epoch tape is append-only
-     ;; across the run (no per-play reset), so each play's absolute boundaries
-     ;; tail the previous play's — keeping the positional zip in `stamp-tape`
-     ;; aligned. Clearing per-play would drop every earlier play's boundaries,
-     ;; leaving only the LAST play's absolute boundaries to be mis-zipped
-     ;; against the concatenated script's leading dispatch steps — a
-     ;; false-green evidence-provenance failure.
+     ;; (`(mapcat :script auto-plays)`), and `:epoch-id` only ever increases
+     ;; across the run (rf2-96qsjr — true regardless of ring eviction), so
+     ;; each play's boundaries tail the previous play's — keeping the
+     ;; dispatch-order zip in `stamp-tape` aligned. Clearing per-play would
+     ;; drop every earlier play's boundaries, leaving only the LAST play's
+     ;; to be mis-zipped against the concatenated script's leading dispatch
+     ;; steps — a false-green evidence-provenance failure.
      (when clear-boundaries?
        (clear-step-boundaries! variant-id))
      (set-state! variant-id pk started)
@@ -1389,11 +1422,12 @@
   Clears the per-dispatch-step settle boundaries ONCE up front, then
   drives each play with `:clear-boundaries? false` so the boundaries
   ACCUMULATE across the sequence. The evidence narrative spans the
-  CONCATENATED play scripts, and the epoch tape is append-only across
-  the run, so each play's absolute boundaries must tail the previous
-  play's for the positional `stamp-tape` zip to stay aligned. Letting each
-  `run!` clear would leave only the last play's boundaries, mis-attributing
-  later-play effects to earlier-play steps."
+  CONCATENATED play scripts, and `:epoch-id` only ever increases across
+  the run (rf2-96qsjr — independent of ring eviction), so each play's
+  boundaries tail the previous play's for `stamp-tape`'s dispatch-order
+  zip to stay aligned. Letting each `run!` clear would leave only the
+  last play's boundaries, mis-attributing later-play effects to
+  earlier-play steps."
   [variant-id plays done-cb]
   (let [acc (atom [])]
     (clear-step-boundaries! variant-id)

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -609,29 +609,39 @@
         ;; `destroy-frame!`'s job, and a destroy here would orphan the
         ;; canvas's live mounted-view reactions) — so `epoch-history`
         ;; still carries every PRIOR run's records too. `epoch-baseline`
-        ;; is the ring length `run-phase-0!` stamped at THIS run's start;
-        ;; dropping that many entries scopes the projected tape to just
-        ;; this run, so a second identical run projects IDENTICAL
-        ;; evidence rather than inheriting the first run's stale
-        ;; violations / warnings / narrative. Absent on the inline-plan
-        ;; path (a fresh anonymous frame every time) — `(or … 0)` is then
-        ;; a no-op, matching the pre-fix whole-tape read.
-        tape     (vec (drop (or epoch-baseline 0) (rf/epoch-history variant-id)))
+        ;; is the last-committed `:epoch-id` `run-phase-0!` stamped at
+        ;; THIS run's start; keeping only records whose OWN `:epoch-id` is
+        ;; greater scopes the projected tape to just this run, so a second
+        ;; identical run projects IDENTICAL evidence rather than
+        ;; inheriting the first run's stale violations / warnings /
+        ;; narrative. Absent on the inline-plan path (a fresh anonymous
+        ;; frame every time) — `(or … 0)` is then a no-op (every real
+        ;; `:epoch-id` is > 0), matching the pre-fix whole-tape read.
+        ;;
+        ;; rf2-96qsjr: filtering by `:epoch-id` identity — rather than
+        ;; `drop`-ping a COUNT of entries off the front — stays correct
+        ;; even when the `epoch-history` ring (default depth 50) has
+        ;; evicted records from the front since `epoch-baseline` was
+        ;; captured: a count-based drop assumes the ring is append-only
+        ;; (never true once total epochs exceed the ring depth), while an
+        ;; identity filter only ever asks "is this record's own id newer
+        ;; than the baseline?" — a question the ring's occupancy can't
+        ;; perturb.
+        tape     (vec (filter #(> (or (:epoch-id %) 0) (or epoch-baseline 0))
+                              (rf/epoch-history variant-id)))
         ;; The runner-recorded per-dispatch-step settle boundaries light
         ;; up the EXACT narrative attribution
         ;; (`evidence/spans-from-stamps`). The
         ;; stamp is a `:rf.story/*` key the determinism projection strips, so
         ;; the run-hash is unaffected (the `:epoch-tape` slot stays raw).
         ;;
-        ;; rf2-xj0bj0: the runner stamps each boundary as an ABSOLUTE
-        ;; `rf/epoch-history` length (position in the WHOLE, unsliced
-        ;; ring) — `evidence/project-evidence` zips these positionally
-        ;; against `tape`. Since `tape` above is now `epoch-baseline`-
-        ;; relative (sliced), the boundaries must be shifted onto the SAME
-        ;; zero-point or every span attribution after the first run would
-        ;; be off by `epoch-baseline` positions.
-        attribution (some->> (runner-events/settle-boundaries variant-id)
-                              (mapv #(- % (or epoch-baseline 0))))
+        ;; rf2-96qsjr: the runner stamps each boundary as a genuine
+        ;; `:epoch-id` (NOT a ring-position), and `stamp-tape` compares it
+        ;; directly against each `tape` record's OWN `:epoch-id` — no
+        ;; zero-point shift needed, unlike the old count-based scheme,
+        ;; because identity comparison is unaffected by how `tape` was
+        ;; sliced or how much of the ring survived eviction.
+        attribution (runner-events/settle-boundaries variant-id)
         ;; Project the tape ONCE here so the post-run evidence
         ;; validation (`requirements-unmet` → `validate-run-evidence`) reads
         ;; the SAME projected slots `result/run-result` derives the result
@@ -845,18 +855,19 @@
   runtime-db IN PLACE (`frames/reset-state!`) rather than destroy!+
   allocate! (to preserve the canvas's live mounted-view reactions) — so a
   same-id re-run's epoch ring is NEVER cleared (only `destroy-frame!`
-  drops it). Stamp the CURRENT epoch-history length as `:epoch-baseline`
-  so `record-result-map` can slice the projected tape to just THIS run's
-  records, not the whole frame's accumulated history — otherwise a second
-  `run-variant` on the same id would project evidence
-  (`:schema-violations` / `:warnings` / `:effects` / `:narrative`)
-  polluted with the FIRST run's stale records."
+  drops it). Stamp the CURRENT last-committed `:epoch-id` as
+  `:epoch-baseline` (rf2-96qsjr — an identity, not a ring-length count; see
+  `runner-events/last-epoch-id`) so `record-result-map` can filter the
+  projected tape to just THIS run's records, not the whole frame's
+  accumulated history — otherwise a second `run-variant` on the same id
+  would project evidence (`:schema-violations` / `:warnings` / `:effects`
+  / `:narrative`) polluted with the FIRST run's stale records."
   [{:keys [variant-id decorator-stack] :as ctx}]
   (ensure-fresh-frame! variant-id)
   (frames/allocate! variant-id decorator-stack)
   (swap! play/pending-exceptions assoc variant-id [])
   (play/install-trace-listener! variant-id)
-  (assoc ctx :epoch-baseline (count (rf/epoch-history variant-id))))
+  (assoc ctx :epoch-baseline (runner-events/last-epoch-id variant-id)))
 
 (defn- db-seed-violations
   "Validate the seeded `db` against the frame's REGISTERED app-db schemas
@@ -1029,10 +1040,11 @@
           ctx'       (assoc ctx :executed-script executed)
           ;; Reset the per-dispatch-step settle boundaries before
           ;; the auto-plays drive, so the narrative attribution windows onto
-          ;; THIS run's epoch tape. The boundaries snapshot the ABSOLUTE
-          ;; epoch-history length at each dispatch step (setup-phase epochs
-          ;; precede the first boundary → leading nil span), matching the
-          ;; absolute tape `record-result-map` reads.
+          ;; THIS run's epoch tape. The boundaries snapshot the last-
+          ;; committed `:epoch-id` at each dispatch step (setup-phase
+          ;; epochs carry an id at or before the first boundary → leading
+          ;; nil span), the SAME identity `record-result-map` compares
+          ;; against when it filters the tape (rf2-96qsjr).
           _          (runner-events/clear-step-boundaries! variant-id)]
       (if (empty? auto-plays)
         ;; No script ran, but the world settled (phase-2 setup committed).
@@ -1355,14 +1367,15 @@
   `run-phase-0!` uses so loader-phase events are captured (no
   side-table to seed).
 
-  Also stamps `:epoch-baseline` (rf2-xj0bj0), mirroring `run-phase-0!`, so
-  `record-result-map` slices the SAME way on both paths. An inline plan
-  mints a brand-new anonymous frame id every run (never reused), so this
-  is always 0 in practice — but computing it here (rather than leaving it
-  absent) keeps the inline path symmetric with the registered path for
-  whatever the frame's own allocation records before the loaders/setup/
-  script phases run, so an inline plan and an equivalent registered
-  variant project the same-shaped tape (and therefore the same run-hash)."
+  Also stamps `:epoch-baseline` (rf2-xj0bj0; identity-based per rf2-96qsjr),
+  mirroring `run-phase-0!`, so `record-result-map` filters the SAME way on
+  both paths. An inline plan mints a brand-new anonymous frame id every
+  run (never reused), so this is always 0 in practice — but computing it
+  here (rather than leaving it absent) keeps the inline path symmetric
+  with the registered path for whatever the frame's own allocation
+  records before the loaders/setup/script phases run, so an inline plan
+  and an equivalent registered variant project the same-shaped tape (and
+  therefore the same run-hash)."
   [{:keys [variant-id plan decorator-stack] :as ctx}]
   (frames/allocate-inline! variant-id
                            decorator-stack
@@ -1370,7 +1383,7 @@
                            (inline-events-only? plan decorator-stack))
   (swap! play/pending-exceptions assoc variant-id [])
   (play/install-trace-listener! variant-id)
-  (assoc ctx :epoch-baseline (count (rf/epoch-history variant-id))))
+  (assoc ctx :epoch-baseline (runner-events/last-epoch-id variant-id)))
 
 (defn run-inline-plan
   "Execute an inline plan MAP (spec/017 §Inline plan) and

--- a/tools/story/src/re_frame/story/ui/canvas.cljs
+++ b/tools/story/src/re_frame/story/ui/canvas.cljs
@@ -638,10 +638,24 @@
         (mark-rendered-if-ready!))
       :component-will-unmount
       (fn [_this]
-        (reset! canvas-last-run-key nil)
-        ;; Clear the first-rendered sentinel on unmount so a
-        ;; re-mount sees the skeleton for the appropriate loader window.
-        (reset-first-rendered!))
+        ;; rf2-j8hklm: scope the first-rendered reset to THIS instance's
+        ;; own variant — `canvas-last-run-key` (a `run-key` map, or nil)
+        ;; still names the variant this mounted instance was running.
+        ;; Reading it BEFORE resetting, then clearing only that variant's
+        ;; sentinel, stops an unmount from re-arming the loading skeleton
+        ;; for every OTHER already-rendered variant. The prior 0-arg
+        ;; `reset-first-rendered!` wiped the GLOBAL sentinel set on every
+        ;; unmount — harmless while canvas only ever unmounted on a
+        ;; genuine variant switch, but a real defect once a stable-tree-
+        ;; position remount (fixed alongside this) is no longer the only
+        ;; path here; a legitimate unmount (e.g. leaving Story for a
+        ;; workspace pane) must not blank the skeleton state for variants
+        ;; it never touched.
+        (let [unmounting-variant (:variant-id @canvas-last-run-key)]
+          (reset! canvas-last-run-key nil)
+          (if unmounting-variant
+            (reset-first-rendered! unmounting-variant)
+            (reset-first-rendered!))))
      :reagent-render
      (fn []
        (let [shell      @state/shell-state-atom

--- a/tools/story/src/re_frame/story/ui/controls.cljs
+++ b/tools/story/src/re_frame/story/ui/controls.cljs
@@ -365,9 +365,23 @@
 (defn- on-change-at-path
   "Write `value` through to `[:cell-overrides variant-id & path]` via
   the shell-state atom. `path` is `[arg-key & sub-path]` where the
-  sub-path may be empty for top-level scalars."
+  sub-path may be empty for top-level scalars.
+
+  Threads the arg-key's current 'saved' value (active-modes applied,
+  cell-overrides excluded — the SAME baseline `args-editor` resolves for
+  its diff-from-saved affordance) as `set-cell-override`'s vivification
+  seed (rf2-mzfh9c). Without it, editing ONE entry of a not-yet-
+  overridden `:vector`/`:set` arg would have no way to know its sibling
+  entries and would silently drop them; the seed is read fresh on every
+  write (cheap — a registry-backed deep-merge, no validation) rather than
+  threaded through the render tree, so this stays a one-line change at
+  the single choke point every widget's on-change already funnels
+  through."
   [variant-id path value]
-  (state/swap-state! state/set-cell-override variant-id (vec path) value))
+  (let [shell (state/get-state)
+        base  (get (args/resolve-args variant-id {:active-modes (:active-modes shell)})
+                   (first path))]
+    (state/swap-state! state/set-cell-override variant-id (vec path) value base)))
 
 (declare arg-widget*)
 

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -747,7 +747,26 @@
 
   Per rf2-zgu68 also surfaces a viewport-px chip at the bottom-right
   when a non-`:full` viewport mode is active. The chip self-elides
-  for `:full`."
+  for `:full`.
+
+  rf2-j8hklm: `[canvas/canvas]` sits behind a STABLE always-present
+  `:div` wrapper regardless of `sized?` — only the wrapper's OWN style
+  varies (the real `vp-style` sizing box when sized, `display: contents`
+  otherwise so the wrapper drops out of layout and `canvas/canvas`'s own
+  `:flex \"1\"` sizes it against the outer flex container exactly as
+  when it rendered unwrapped). Previously `sized?` picked between TWO
+  DIFFERENT hiccup shapes at this tree position — `[:div ... [canvas/
+  canvas]]` vs bare `[canvas/canvas]` — so toggling the viewport across
+  the `:full`-vs-sized boundary changed the React element TYPE at this
+  slot (`:div` vs the canvas class) and forced React to unmount + remount
+  the canvas subtree. `canvas/canvas`'s `component-will-unmount` cleared
+  the run-key sentinel, so the fresh mount's `component-did-mount` always
+  re-ran `run-variant` — wiping the live variant's interactive app-db even
+  though the viewport is deliberately excluded from `run-key` precisely
+  so a viewport toggle should NOT re-run it. Keying `[canvas/canvas]` at
+  an identical tree position across both branches keeps React's
+  reconciler on the SAME component instance, so the toggle only ever
+  updates the wrapper's style — never a remount."
   []
   (let [vp        (viewport-switcher/effective-viewport)
         bg        (backgrounds-switcher/effective-background)
@@ -771,11 +790,9 @@
            :data-test   "story-canvas-frame"
            :data-viewport (name (viewport-switcher/effective-id))
            :data-background (name (backgrounds-switcher/effective-id))}
-     (if sized?
-       [:div {:style     vp-style
-              :data-test "story-canvas-frame-sized"}
-        [canvas/canvas]]
-       [canvas/canvas])
+     [:div (cond-> {:style (or vp-style {:display "contents"})}
+             sized? (assoc :data-test "story-canvas-frame-sized"))
+      [canvas/canvas]]
      ;; rf2-zgu68 — viewport-px indicator chip. Self-elides for `:full`.
      [canvas/viewport-indicator vp]]))
 

--- a/tools/story/src/re_frame/story/ui/state/transitions.cljc
+++ b/tools/story/src/re_frame/story/ui/state/transitions.cljc
@@ -129,19 +129,78 @@
 
 ;; ---- cell overrides ------------------------------------------------------
 
+(defn- vivify-for-key
+  "Coerce `v` into a collection `next-key` can address into (rf2-mzfh9c).
+  An integer `next-key` means the nested Malli walker is addressing a
+  `:vector`/`:set`/`:tuple` repeater ENTRY, so `v` needs to be indexable:
+  `nil` (no override established yet) becomes `[]`; a `set` becomes a
+  STABLE vector via the same `(sort-by str …)` projection
+  `ui/controls.cljs`'s `vector-coerce` uses for rendering, so index `i`
+  addresses the exact entry the panel is currently showing at row `i`.
+  A non-integer `next-key` means a `:map` group, so `nil` becomes `{}`.
+  Anything already the right shape (a vector already, a map already)
+  passes through unchanged — this is a VIVIFY step, not a re-normalise."
+  [v next-key]
+  (if (int? next-key)
+    (cond
+      (nil? v) []
+      (set? v) (vec (sort-by str v))
+      :else    v)
+    (if (nil? v) {} v)))
+
+(defn- assoc-in-kind-aware
+  "Like `assoc-in`, but vivifies a MISSING or wrong-shaped intermediate
+  value into the collection kind the NEXT path segment actually needs
+  (`vivify-for-key`) instead of letting plain `assoc-in` mint an
+  int-keyed MAP for a missing vector/set, or throwing when it tries to
+  `assoc` a set by index (rf2-mzfh9c). When `coll` (or any intermediate
+  value walked along `path`) was a `set`, the walked result at that
+  level is coerced BACK into a set before returning — the vector
+  projection `vivify-for-key` uses is an addressing convenience, not a
+  change of the arg's declared collection kind."
+  [coll path value]
+  (if (empty? path)
+    value
+    (let [[k & more] path
+          was-set?   (set? coll)
+          coll'      (vivify-for-key coll k)
+          updated    (assoc coll' k (assoc-in-kind-aware (get coll' k) more value))]
+      (if was-set? (set updated) updated))))
+
 (defn set-cell-override
   "Set a single arg override for `variant-id`. `path` is a vector
   `[arg-key & sub-path]` — the first element is the top-level arg-key,
-  the remaining elements address into the nested value via `assoc-in`
-  semantics. Used by the nested Malli walker.
+  the remaining elements address into the nested value. Used by the
+  nested Malli walker.
+
+  A non-empty `sub-path` walks `assoc-in-kind-aware` against the
+  ARG-KEY's current override (or `base` when no override exists yet)
+  rather than raw `assoc-in` against `state` — the collection at
+  `[:cell-overrides variant-id arg-key]` may be absent (no override
+  established yet) or, for a `:set`-kind repeater, a real `set`; plain
+  `assoc-in` would either mint an int-keyed MAP for the absent case or
+  throw trying to `assoc` a set by index (rf2-mzfh9c). `base` — typically
+  the arg's current resolved value (the SAME 'saved' value the controls
+  panel already computes for its diff-from-saved affordance,
+  active-modes applied, cell-overrides excluded) — seeds the walk so an
+  edit to ONE entry of a not-yet-overridden `:vector`/`:set` preserves
+  every sibling entry instead of silently truncating to a singleton.
 
   An empty path is a no-op (caller error; the state is returned
   unchanged). For top-level scalar overrides use `set-cell-override-
   scalar`, a thin wrapper that wraps the arg-key in a singleton vector."
-  [state variant-id path value]
-  (if (seq path)
-    (assoc-in state (into [:cell-overrides variant-id] path) value)
-    state))
+  ([state variant-id path value] (set-cell-override state variant-id path value nil))
+  ([state variant-id path value base]
+   (if (seq path)
+     (let [top-key  (first path)
+           sub-path (vec (rest path))]
+       (if (empty? sub-path)
+         (assoc-in state [:cell-overrides variant-id top-key] value)
+         (assoc-in state [:cell-overrides variant-id top-key]
+                   (assoc-in-kind-aware
+                     (get-in state [:cell-overrides variant-id top-key] base)
+                     sub-path value))))
+     state)))
 
 (defn set-cell-override-scalar
   "Set a top-level arg override for `variant-id`. Thin wrapper around

--- a/tools/story/src/re_frame/story/ui/url_state.cljc
+++ b/tools/story/src/re_frame/story/ui/url_state.cljc
@@ -211,6 +211,12 @@
       `:uix`/`:helix`. A present-but-unregistered substrate (rejected by the
       `:substrate?` validator) likewise degrades to `:reagent` so a stale URL
       can't pin a substrate the host app never registered.
+    - omitted `mode-tab=` (alongside a KEPT variant) clears that variant's
+      `[:active-mode-tab variant-id]` entry (rf2-gchydo) so the reader's
+      `:dev` default applies — mode-tab is per-variant (unlike the slots
+      above), so the clear is `dissoc`, scoped to the focused variant only,
+      not an unconditional `:always` write (mirrors the `:cell-overrides`
+      per-variant clear immediately below it).
   This means a share URL like `?variant=story.counter/loaded` restores the
   DEFAULT framing / filter / modes for the recipient rather than keeping
   their prior localStorage-seeded chrome, and back/forward from a populated
@@ -259,6 +265,25 @@
 
       (and keep-variant? mode-tab)
       (assoc-in [:active-mode-tab variant-id] mode-tab)
+
+      ;; rf2-gchydo: the URL is authoritative for the focused variant's
+      ;; mode-tab too — mirrors the cell-overrides clear immediately
+      ;; below. Mode-tab changes ARE pushState'd
+      ;; (`install-state-watcher!` treats `:active-mode-tab` as URL-
+      ;; relevant, per `url-relevant-slots-changed?` above), so a URL
+      ;; that keeps this variant but carries NO `mode-tab=` param must
+      ;; clear any stale `[:active-mode-tab variant-id]` entry — dissoc
+      ;; rather than an explicit `:dev` assoc, so the reader's
+      ;; `default-mode-tab` fallback (`re-frame.story.ui.state/active-
+      ;; mode-tab`) is the single source of truth for the default,
+      ;; not a value duplicated here. Without this, select a variant
+      ;; (push, no mode-tab=) → Test tab (push mode-tab=test) → Docs
+      ;; (push mode-tab=docs) → Back twice to the first entry (no
+      ;; mode-tab=) left `[:active-mode-tab variant-id]` at `:docs`
+      ;; instead of reverting to `:dev` — the canvas rendered the wrong
+      ;; tab while the address bar had already reverted.
+      (and keep-variant? (not mode-tab))
+      (update :active-mode-tab dissoc variant-id)
 
       ;; rf2-j0hwf: install the focused variant's parsed cell-overrides
       ;; under [:cell-overrides variant-id] so a popstate / shared-URL

--- a/tools/story/test/re_frame/story/play/evidence_test.cljc
+++ b/tools/story/test/re_frame/story/play/evidence_test.cljc
@@ -316,6 +316,92 @@
                           :rf.story/script-idx))
           "no stamp key is added on the fallback path"))))
 
+;; ---- rf2-96qsjr: stamp-tape survives epoch-history ring eviction ---------
+;;
+;; `epoch-history` is a bounded per-frame ring (default depth 50); once
+;; total epochs exceed the depth, the ring evicts the OLDEST records.
+;; `boundaries` are the runner-recorded `:epoch-id` at the start of each
+;; dispatch step's settle (a genuine monotonic identity — see
+;; `runner-events/last-epoch-id`), NOT a ring-length COUNT: a count
+;; PLATEAUS at the ring depth once full, so two boundaries recorded after
+;; that point are numerically identical and a position-based zip against
+;; the (now-truncated) tape silently attributes surviving epochs to the
+;; WRONG step. Fixture below simulates a 5-dispatch-step run against a
+;; ring depth of 3 — epochs 1 and 2 are evicted; epochs 3/4/5 survive
+;; with THEIR OWN real `:epoch-id`s (48/49/50 — arbitrary large numbers,
+;; standing in for "whatever the process-global epoch counter had
+;; reached", proving the mechanism does not depend on ids starting at 1
+;; or being contiguous from 0). Fixed boundaries are RECORDED as each
+;; step's own settle began — i.e. the id of the LAST epoch committed
+;; before that step's dispatch, exactly what `last-epoch-id` snapshots.
+
+(deftest stamp-tape-survives-ring-eviction-no-plateau
+  (testing "rf2-96qsjr: five dispatch steps' worth of boundaries, recorded
+            as genuine (non-plateauing) epoch-ids, correctly attribute
+            each SURVIVING record to the step that actually produced it
+            — even though the two earliest records were evicted from the
+            tape entirely"
+    (let [script  [[:dispatch [:set 1]]
+                   [:dispatch [:set 2]]
+                   [:dispatch [:set 3]]
+                   [:dispatch [:set 4]]
+                   [:dispatch [:set 5]]]
+          ;; Only the LAST 3 of 5 committed epochs survive the depth-3
+          ;; ring (their own ids are 48/49/50 — the first two, 46/47,
+          ;; were evicted and are simply gone from `tape`).
+          tape    [(epoch 48 {:trigger-event [:set 3]})
+                   (epoch 49 {:trigger-event [:set 4]})
+                   (epoch 50 {:trigger-event [:set 5]})]
+          ;; Recorded BEFORE each step's own dispatch — genuinely
+          ;; monotonic, no plateau, regardless of the ring depth.
+          boundaries [45 46 47 48 49]
+          stamped (evidence/stamp-tape script tape boundaries)]
+      (is (= [2 3 4] (mapv :rf.story/script-idx stamped))
+          "epoch 48 -> step 2 (dispatched [:set 3]); 49 -> step 3
+           ([:set 4]); 50 -> step 4 ([:set 5]) — each surviving record's
+           OWN epoch-id decides ownership, not its position in the
+           (evicted) tape")
+      (let [n (evidence/narrative script stamped)]
+        (is (= [] (:epochs (nth n 0))) "step 0's own epoch (id 46) was evicted — no beats")
+        (is (= [] (:epochs (nth n 1))) "step 1's own epoch (id 47) was evicted — no beats")
+        (is (= [[:set 3]] (mapv :trigger-event (:epochs (nth n 2))))
+            "step 2 correctly owns its surviving epoch")
+        (is (= [[:set 4]] (mapv :trigger-event (:epochs (nth n 3))))
+            "step 3 correctly owns its surviving epoch")
+        (is (= [[:set 5]] (mapv :trigger-event (:epochs (nth n 4))))
+            "step 4 correctly owns its surviving epoch")))))
+
+(deftest stamp-tape-plateaued-count-boundaries-would-misattribute
+  (testing "rf2-96qsjr: documents the OLD count-based boundary bug as a
+            CONTRAST, not a desired behaviour. Once a depth-3 ring is
+            full, `(count (epoch-history ...))` plateaus at 3 for every
+            subsequent boundary snapshot, so feeding `stamp-tape` boundary
+            values shaped like that (rather than genuine epoch-ids)
+            collapses every surviving record onto the LAST step —
+            demonstrating why the producer had to stop recording
+            ring-length counts. `runner-events/last-epoch-id` never
+            emits boundaries shaped like this in production; this input
+            is deliberately pathological."
+    (let [script  [[:dispatch [:set 1]]
+                   [:dispatch [:set 2]]
+                   [:dispatch [:set 3]]
+                   [:dispatch [:set 4]]
+                   [:dispatch [:set 5]]]
+          tape    [(epoch 48 {:trigger-event [:set 3]})
+                   (epoch 49 {:trigger-event [:set 4]})
+                   (epoch 50 {:trigger-event [:set 5]})]
+          ;; What a COUNT-based recorder would have produced: 0, 1, 2,
+          ;; then PLATEAUED at 3 (the ring depth) for every subsequent
+          ;; boundary once it filled — steps 3 and 4 are indistinguishable.
+          plateaued-count-boundaries [0 1 2 3 3]
+          stamped (evidence/stamp-tape script tape plateaued-count-boundaries)]
+      (is (= [4 4 4] (mapv :rf.story/script-idx stamped))
+          "these tiny plateaued counts are all `<` every real epoch-id in
+           `tape` (48-50), so every record's owner-search bottoms out at
+           the LAST boundary (index 4) — collapsing steps 2/3/4's
+           distinct epochs onto step 4 alone. This is the 'confident but
+           wrong' misattribution the bug reported."))))
+
 (deftest narrative-no-dispatch-steps-leads-whole-tape
   (testing "a script with no dispatch steps puts the whole tape in a leading span"
     (let [script [[:assert-db [:k] 1] [:wait 10]]

--- a/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
@@ -879,6 +879,63 @@
          (is (= 3 (count (re/settle-boundaries :story.vkdam/rerun)))
              "the public driver reset its boundaries — no stale accumulation")))))
 
+;; ---- rf2-96qsjr: narrative attribution survives epoch-ring eviction ------
+;;
+;; End-to-end sibling of the pure `evidence-test` stamp-tape gates: a REAL
+;; run, through the orchestrator (`story/run-variant`), whose dispatch-step
+;; count exceeds a small configured epoch-history ring depth. Proves the
+;; producer (`runner-events/last-epoch-id`) and the consumer
+;; (`runtime/record-result-map` + `evidence/stamp-tape`) agree end-to-end —
+;; not just that the pure fns compose correctly in isolation.
+
+#?(:clj
+   (deftest narrative-attribution-survives-epoch-ring-eviction
+     (testing "rf2-96qsjr: five dispatch steps against a depth-3 epoch-
+              history ring still attribute each SURVIVING epoch to its
+              correct originating script step — the boundary bookkeeping
+              records the framework's genuine monotonic :epoch-id (never
+              plateaus), so ring eviction can only ever drop beats, never
+              misattribute a surviving one"
+       (try
+         (epoch/configure! {:depth 3})
+         (rf/reg-event :re-eviction/set
+           (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)}))
+         (story/reg-variant :story.runner/eviction
+           {:events []
+            :play-script {:script [[:dispatch-sync [:re-eviction/set 1]]
+                                   [:dispatch-sync [:re-eviction/set 2]]
+                                   [:dispatch-sync [:re-eviction/set 3]]
+                                   [:dispatch-sync [:re-eviction/set 4]]
+                                   [:dispatch-sync [:re-eviction/set 5]]]}})
+         (let [result    (async/deref-blocking (story/run-variant :story.runner/eviction) 5000)
+               narrative (:narrative result)
+               span-for  (fn [want]
+                           (some #(when (= [:dispatch-sync [:re-eviction/set want]] (:step %)) %)
+                                 narrative))]
+           (is (= 5 (:n (:app-db result)))
+               "sanity: the run itself executed every step (the LAST
+                :set wins on app-db) — attribution below is what's under
+                test, not whether the run happened")
+           (is (= [] (mapv :trigger-event (:epochs (span-for 1))))
+               "step 0's own epoch (n=1) was evicted by the depth-3 ring
+                — no beats, but critically NOT a later step's epoch
+                misattributed here")
+           (is (= [] (mapv :trigger-event (:epochs (span-for 2))))
+               "step 1's own epoch (n=2) was likewise evicted")
+           (is (= [[:re-eviction/set 3]] (mapv :trigger-event (:epochs (span-for 3))))
+               "step 2's surviving epoch is attributed to step 2 — NOT
+                step 0, which is where the old ring-length-snapshot
+                boundary scheme (plateaued at the ring depth) would have
+                shifted it")
+           (is (= [[:re-eviction/set 4]] (mapv :trigger-event (:epochs (span-for 4))))
+               "step 3's surviving epoch is attributed to step 3")
+           (is (= [[:re-eviction/set 5]] (mapv :trigger-event (:epochs (span-for 5))))
+               "step 4's surviving epoch is attributed to step 4"))
+         (finally
+           ;; `:depth` is a process-global epoch-history knob — restore
+           ;; the framework default so it doesn't leak into sibling tests.
+           (epoch/configure! {:depth 50}))))))
+
 #?(:clj
    (deftest bare-vector-with-unknown-event-still-dispatches
      (testing "a bare event vector with no registered handler still dispatches; the play status does not fail because dispatch is a no-assertion step"

--- a/tools/story/test/re_frame/story/ui/controls_nested_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/controls_nested_cljs_test.cljc
@@ -6,11 +6,16 @@
   default-element-value seeding for collection adds, and the path-
   aware cell-override writes against shell-state.
 
-  Splits into two tiers:
+  Splits into three tiers:
 
-  - **JVM + CLJS** (`state.cljc` is `.cljc`) — the path-aware
-    `set-cell-override` fn (plus its `-scalar` wrapper). Pure data →
-    data.
+  - **JVM + CLJS** (`state.cljc` / `args.cljc` are `.cljc`) — the
+    path-aware `set-cell-override` fn (plus its `-scalar` wrapper) in
+    isolation, AND the rf2-mzfh9c edit -> `resolve-args` round-trip: a
+    nested-control edit against a REGISTERED variant's real args,
+    resolved back through `args/resolve-args` the way the canvas
+    actually reads them. `story/reg-variant` + `args/resolve-args` are
+    plain registrar reads — no Reagent / DOM needed — so this tier runs
+    on both runtimes.
   - **CLJS-only** (`controls.cljs` is CLJS-only — it depends on
     Reagent / DOM) — `infer-widget` widget-spec emission on every
     collection operator, plus `resolve-argtypes` integration with the
@@ -21,22 +26,24 @@
   picked up by both `cljs-test$` and `-cljs-test$` regexes)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             #?(:cljs [re-frame.core :as rf])
-            #?(:cljs [re-frame.story :as story])
+            [re-frame.story :as story]
+            [re-frame.story.args :as args]
             #?(:cljs [re-frame.story.ui.controls :as controls])
             [re-frame.story.ui.state :as state]))
 
 ;; ---- fixtures ------------------------------------------------------------
 
-#?(:cljs
-   (defn reset-fixture [test-fn]
-     (story/clear-all!)
-     (state/reset-shell-state!)
-     (story/install-canonical-vocabulary!)
-     (test-fn))
-   :clj
-   (defn reset-fixture [test-fn]
-     (state/reset-shell-state!)
-     (test-fn)))
+(defn reset-fixture [test-fn]
+  (story/clear-all!)
+  (state/reset-shell-state!)
+  ;; `install-canonical-vocabulary!` seeds the lifecycle-machine
+  ;; event/registrar entries a LIVE variant run needs; nothing in this
+  ;; file dispatches a run — the JVM+CLJS round-trip tests below only
+  ;; read `story/reg-variant` bodies back through `args/resolve-args`
+  ;; (plain registrar data, no frame involved) — so it stays CLJS-only,
+  ;; matching what this file has always needed.
+  #?(:cljs (story/install-canonical-vocabulary!))
+  (test-fn))
 
 (use-fixtures :each reset-fixture)
 
@@ -253,10 +260,139 @@
                             :outer :inner :leaf]))))))
 
 (deftest set-cell-override-tolerates-integer-indices
-  (testing "vector indices are valid path elements (per assoc-in)"
+  (testing "vector indices are valid path elements — WITHOUT a base seed
+            (the caller supplied none) the missing collection vivifies
+            as a real VECTOR (rf2-mzfh9c), NOT the int-keyed map plain
+            `assoc-in` would have minted for a missing intermediate value"
     (let [s  state/default-shell-state
           s1 (state/set-cell-override s :story.a/x [:items 0] "x")]
-      (is (= "x" (get-in s1 [:cell-overrides :story.a/x :items 0]))))))
+      (is (= "x" (get-in s1 [:cell-overrides :story.a/x :items 0])))
+      (is (vector? (get-in s1 [:cell-overrides :story.a/x :items]))
+          "rf2-mzfh9c: a real vector — not {0 \"x\"}, the collection-kind
+           corruption the bug reported")
+      (is (= ["x"] (get-in s1 [:cell-overrides :story.a/x :items]))))))
+
+;; ---- rf2-mzfh9c: kind-aware vivification (nested :vector/:set edit) -----
+;;
+;; Editing an EXISTING entry of a not-yet-overridden `:vector`/`:set` arg
+;; is the most common controls-panel interaction (open panel, edit an
+;; array entry directly, never touch [+]/[-]). Plain `assoc-in` against
+;; `state` cannot know the collection's sibling entries, so
+;; `set-cell-override`'s 5-arity accepts a `base` seed — the arg's
+;; current resolved value (`args/resolve-args`, cell-overrides excluded)
+;; — and walks it via `assoc-in-kind-aware` instead of raw `assoc-in`.
+
+(deftest set-cell-override-with-base-seeds-missing-vector-preserving-siblings
+  (testing "rf2-mzfh9c: a `base` seed lets a first-ever edit of an
+            unoverridden vector preserve sibling entries instead of
+            truncating to a singleton or corrupting into a map"
+    (let [s  state/default-shell-state
+          s1 (state/set-cell-override s :story.a/x [:items 0] "x" ["a" "b"])]
+      (is (vector? (get-in s1 [:cell-overrides :story.a/x :items])))
+      (is (= ["x" "b"] (get-in s1 [:cell-overrides :story.a/x :items]))
+          "index 0 replaced; sibling \"b\" at index 1 survives"))))
+
+(deftest set-cell-override-with-set-base-seeds-preserving-siblings-as-a-set
+  (testing "a :set base seed round-trips as a SET (matching the arg's
+            declared collection kind), sorted the same way the controls
+            panel's own vector-coerce renders it for editing"
+    (let [s  state/default-shell-state
+          s1 (state/set-cell-override s :story.a/x [:items 0] "x" #{"a" "b"})]
+      (is (set? (get-in s1 [:cell-overrides :story.a/x :items])))
+      (is (= #{"x" "b"} (get-in s1 [:cell-overrides :story.a/x :items]))))))
+
+(deftest set-cell-override-set-override-already-established-does-not-throw
+  (testing "rf2-mzfh9c: editing an entry when the OVERRIDE (not just the
+            base) is already a real set does not throw — the reported
+            'assoc undefined on PersistentHashSet' failure mode"
+    (let [s0 state/default-shell-state
+          s1 (state/set-cell-override-scalar s0 :story.a/x :items #{"a" "b"})
+          s2 (state/set-cell-override s1 :story.a/x [:items 0] "x")]
+      (is (set? (get-in s2 [:cell-overrides :story.a/x :items])))
+      (is (contains? (get-in s2 [:cell-overrides :story.a/x :items]) "x")))))
+
+(deftest set-cell-override-deeply-nested-vivifies-map-levels-with-set-base
+  (testing "a deep path mixes map-vivification (keyword segments) and
+            set-vivification (the integer segment) correctly at each
+            level, preserving sibling keys at every level"
+    (let [s  state/default-shell-state
+          ;; :group has an unrelated sibling key + a nested :tags SET,
+          ;; none of it overridden yet.
+          s1 (state/set-cell-override s :story.a/x [:group :tags 0] "x"
+                                      {:tags #{"a" "b"} :other 1})]
+      (is (= {:tags #{"x" "b"} :other 1}
+             (get-in s1 [:cell-overrides :story.a/x :group]))
+          "the nested set becomes {x b}; the group's :other sibling
+           survives untouched"))))
+
+;; ---- rf2-mzfh9c: the edit -> resolve-args ROUND TRIP ---------------------
+;;
+;; The isolated set-cell-override tests above pin the shell-state write
+;; shape; they never prove the write actually SURVIVES a real
+;; `args/resolve-args` deep-merge read against a REGISTERED variant's
+;; base args — the exact seam `args.cljc`'s documented 'vectors/sets
+;; replace, not merge element-wise' semantics corrupted before this fix.
+;; `story/reg-variant` + `args/resolve-args` are plain registrar reads
+;; (no frame / dispatch), so this tier runs on JVM + CLJS.
+
+(deftest set-cell-override-edit-vector-entry-then-resolve-args-round-trip
+  (testing "rf2-mzfh9c: editing ONE entry of a registered variant's
+            un-overridden :vector arg, seeded the SAME way the controls
+            panel seeds it (`args/resolve-args` minus cell-overrides),
+            round-trips through `resolve-args` as the sibling-preserving
+            vector — not an int-keyed map, not a truncated singleton"
+    (story/reg-variant :story.nest.roundtrip/vector-arg
+      {:args   {:items ["a" "b" "c"]}
+       :events []})
+    (let [base       (get (args/resolve-args :story.nest.roundtrip/vector-arg) :items)
+          shell      (state/set-cell-override state/default-shell-state
+                                              :story.nest.roundtrip/vector-arg
+                                              [:items 1] "X" base)
+          overrides  (get-in shell [:cell-overrides :story.nest.roundtrip/vector-arg])
+          eff        (args/resolve-args :story.nest.roundtrip/vector-arg
+                                        {:cell-overrides overrides})]
+      (is (= ["a" "b" "c"] base) "precondition: the registered base vector")
+      (is (vector? (:items overrides))
+          "the override itself stays a real vector, not an int-keyed map")
+      (is (= ["a" "X" "c"] (:items overrides))
+          "only the edited index changed; siblings a/c survive")
+      (is (= ["a" "X" "c"] (:items eff))
+          "resolve-args' deep-merge (vectors replace whole) reflects the
+           SAME sibling-preserving vector — the edit->resolve-args round
+           trip the isolated set-cell-override tests never proved"))))
+
+(deftest set-cell-override-edit-set-entry-then-resolve-args-round-trip
+  (testing "rf2-mzfh9c: the same round-trip for a :set-kind arg — the
+            override stays a real set (matching the schema's declared
+            kind), and a SECOND edit against the now-established set
+            override does not throw"
+    (story/reg-variant :story.nest.roundtrip/set-arg
+      {:args   {:tags #{"a" "b"}}
+       :events []})
+    (let [base       (get (args/resolve-args :story.nest.roundtrip/set-arg) :tags)
+          ;; The panel's repeater renders a SET via a stable sorted
+          ;; vector projection — index 0 is "a" (sort-by str).
+          shell      (state/set-cell-override state/default-shell-state
+                                              :story.nest.roundtrip/set-arg
+                                              [:tags 0] "x" base)
+          overrides  (get-in shell [:cell-overrides :story.nest.roundtrip/set-arg])
+          eff        (args/resolve-args :story.nest.roundtrip/set-arg
+                                        {:cell-overrides overrides})]
+      (is (set? base))
+      (is (set? (:tags overrides))
+          "the override is a real set, not a vector or an int-keyed map")
+      (is (= #{"x" "b"} (:tags overrides)))
+      (is (= #{"x" "b"} (:tags eff)))
+      ;; A SECOND edit against the now-established set override (no base
+      ;; passed — none needed, an override already exists) must not throw.
+      (let [shell2     (state/set-cell-override shell
+                                                :story.nest.roundtrip/set-arg
+                                                [:tags 0] "y")
+            overrides2 (get-in shell2 [:cell-overrides :story.nest.roundtrip/set-arg])]
+        (is (set? (:tags overrides2)))
+        (is (= #{"y" "x"} (:tags overrides2))
+            "sort-by str on #{x b} is [b x] — index 0 is \"b\"; replacing
+             it with \"y\" leaves {y x}")))))
 
 (deftest set-cell-override-singleton-path-equivalent-to-scalar-wrapper
   (testing "a 1-element path produces the same result as the scalar wrapper"

--- a/tools/story/test/re_frame/story/ui/url_state_test.cljc
+++ b/tools/story/test/re_frame/story/ui/url_state_test.cljc
@@ -418,6 +418,85 @@
           "navigating to the override-free shared URL clears the stale edit —
            the address bar is authoritative"))))
 
+;; ---- rf2-gchydo: mode-tab is URL-authoritative too (per-variant) -------
+;;
+;; `:active-mode-tab` gets the SAME authoritative-clear treatment as
+;; `:cell-overrides` (rf2-2cpoo) above — it is per-variant, so the clear
+;; is scoped to the focused variant via `dissoc`, NOT an unconditional
+;; `:always` write like the global rf2-fkmnh slots below.
+
+(deftest apply-parsed-clears-stale-mode-tab-when-url-omits-it
+  (testing "rf2-gchydo — hydrating a URL that KEEPS the focused variant but
+            carries NO mode-tab= clears the stale [:active-mode-tab
+            variant-id] entry so the reader's :dev default applies.
+            Reproduces the bead's repro: select variant A (no mode-tab=),
+            Test tab (mode-tab=test), Docs (mode-tab=docs), Back twice to
+            the first entry (no mode-tab=) — the stale :docs must not
+            survive."
+    (let [stale {:selected-variant :story.foo/bar
+                 :active-mode-tab  {:story.foo/bar :docs}}
+          out   (us/apply-parsed-to-state stale {:variant-id :story.foo/bar} {})]
+      (is (= :story.foo/bar (:selected-variant out)))
+      (is (nil? (get-in out [:active-mode-tab :story.foo/bar]))
+          "the stale entry is dissoc'd, not left at :docs — the reader's
+           default-mode-tab (:dev) fallback now applies"))))
+
+(deftest apply-parsed-sets-mode-tab-when-url-carries-it
+  (testing "rf2-gchydo — a URL that DOES carry mode-tab= overwrites a stale
+            entry (authoritative, not a merge) — the sibling of the clear
+            test above"
+    (let [stale {:selected-variant :story.foo/bar
+                 :active-mode-tab  {:story.foo/bar :test}}
+          out   (us/apply-parsed-to-state
+                  stale {:variant-id :story.foo/bar :mode-tab :docs} {})]
+      (is (= :docs (get-in out [:active-mode-tab :story.foo/bar]))))))
+
+(deftest apply-parsed-clears-mode-tab-leaves-other-variants-intact
+  (testing "rf2-gchydo — clearing the focused variant's mode-tab touches
+            ONLY its entry; another variant's mode-tab survives (mode-tab
+            is per-variant, the URL speaks for the focused variant alone)"
+    (let [stale {:selected-variant :story.foo/bar
+                 :active-mode-tab  {:story.foo/bar   :docs
+                                    :story.other/baz :test}}
+          out   (us/apply-parsed-to-state stale {:variant-id :story.foo/bar} {})]
+      (is (nil? (get-in out [:active-mode-tab :story.foo/bar]))
+          "the focused variant's stale mode-tab is cleared")
+      (is (= :test (get-in out [:active-mode-tab :story.other/baz]))
+          "an unfocused variant's mode-tab is left intact"))))
+
+(deftest apply-parsed-mode-tab-untouched-when-variant-not-kept
+  (testing "rf2-gchydo — mode-tab is per-variant: when NO variant is kept
+            (e.g. an invalid/rejected variant id, or none at all) there is
+            no focused variant's entry to clear, so OTHER variants'
+            mode-tab entries are left alone entirely (unlike the global
+            rf2-fkmnh slots below, this is not an unconditional :always
+            write)"
+    (let [stale {:active-mode-tab {:story.other/baz :test}}
+          out   (us/apply-parsed-to-state stale {} {})]
+      (is (nil? (:selected-variant out)))
+      (is (= :test (get-in out [:active-mode-tab :story.other/baz]))
+          "no variant kept -> the mode-tab map is untouched"))))
+
+(deftest apply-parsed-mode-tab-back-forward-scenario
+  (testing "rf2-gchydo — the bead's concrete Back/Back scenario end-to-end:
+            select variant (no mode-tab), Test tab (mode-tab=test), Docs
+            tab (mode-tab=docs), Back twice to the first (variant-only)
+            history entry — the address bar has reverted to no mode-tab=,
+            so hydrating it must revert the canvas's active tab too"
+    (let [;; History entry 1: variant selected, default (:dev) tab — no
+          ;; mode-tab= param, matching share/parse-params' shape for it.
+          entry-1 {:variant-id :story.foo/bar}
+          ;; The Test/Docs clicks pushed mode-tab=test then mode-tab=docs;
+          ;; simulate the resulting stale in-memory state just before
+          ;; Back/Back lands on entry-1 again.
+          stale   {:selected-variant :story.foo/bar
+                   :active-mode-tab  {:story.foo/bar :docs}}
+          out     (us/apply-parsed-to-state stale entry-1 {})]
+      (is (= :story.foo/bar (:selected-variant out)))
+      (is (nil? (get-in out [:active-mode-tab :story.foo/bar]))
+          "Back/Back to the mode-tab-less entry reverts the stale :docs —
+           address bar and rendered UI agree again"))))
+
 ;; ---- rf2-fkmnh: URL authoritative for ALL URL-owned chrome slots --------
 
 (deftest apply-parsed-clears-active-modes-when-url-omits-modes

--- a/tools/story/test/re_frame/story/ui/viewport_toggle_app_db_dom_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/viewport_toggle_app_db_dom_cljs_test.cljs
@@ -1,0 +1,211 @@
+(ns re-frame.story.ui.viewport-toggle-app-db-dom-cljs-test
+  "DOM-mount regression for rf2-j8hklm: toggling the toolbar viewport
+  across the `:full`-vs-sized boundary must NOT force-remount the
+  canvas / re-run the variant, wiping the live variant's interactive
+  app-db.
+
+  ## Why this needs a REAL DOM mount
+
+  The bug is a React RECONCILIATION-identity defect: `shell.cljs`'s
+  `framed-canvas` used to pick between TWO DIFFERENT hiccup shapes —
+  `[:div {...} [canvas/canvas]]` when a sized viewport was active, or
+  bare `[canvas/canvas]` otherwise — at the SAME tree position. Toggling
+  `sized?` therefore changed the React element TYPE at that slot, which
+  forces React to unmount the old subtree and mount a fresh one — no
+  amount of pure hiccup-tree inspection proves whether that actually
+  happens; only a real React commit + a SECOND real React commit after
+  the toggle can. This is also the acceptance criterion the bead itself
+  names as the test gap: 'no test mounts the real shell and toggles
+  viewport to check state survival.'
+
+  ## Pipeline under test
+
+      mount [shell/framed-canvas] (viewport :full)
+            |
+      canvas/canvas's component-did-mount -> run-if-needed! -> run-variant
+            |  (variant's :events seed app-db)
+            v
+      simulate user interaction: dispatch a NON-setup event into the
+      variant's frame directly (mirrors 'user increments a counter')
+            |
+      vs/select! :tablet  (crosses the :full -> sized boundary)
+            |
+      flushSync a second commit
+            v
+      ASSERT: the variant frame's app-db still carries the interactive
+      mutation -- canvas was NOT remounted / re-run.
+
+  ns ends in `-dom-cljs-test` so shadow-cljs's `:browser-test` build
+  discovers it and mounts real DOM via `react-dom/client`; `:node-test`
+  also loads it (its `cljs-test$` regex matches the `-dom-cljs-test`
+  suffix too) where the body self-gates on `(browser?)` and no-ops."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            ["react-dom" :as react-dom]
+            [reagent.core :as r]
+            [reagent.dom.client :as rdc]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.machines :as machines]
+            [re-frame.registrar :as registrar]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.story :as story]
+            [re-frame.story.loaders :as loaders]
+            [re-frame.story.ui.canvas :as canvas]
+            [re-frame.story.ui.shell :as shell]
+            [re-frame.story.ui.state :as state]
+            [re-frame.story.ui.viewport-switcher :as vs]
+            [re-frame.subs :as subs]))
+
+;; `framed-canvas` is `defn-` in shell.cljs; the established Story-test
+;; seam for reaching a private fn is the var-quote (e.g.
+;; `re-frame.story.ui.shell-cljs-test`'s `mount-time-autorun-vid`).
+(def ^:private framed-canvas @#'shell/framed-canvas)
+
+;; ---- fixture --------------------------------------------------------------
+
+(defn- reset-all! []
+  (story/clear-all!)
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (try (rf/init! reagent-adapter/adapter)
+       (catch :default _ nil))
+  ;; Re-register the framework `:rf/machine` sub after the registrar
+  ;; clear (mirrors render-shell-cljs-test's reset-all!).
+  (subs/reg-runtime-sub :rf/machine
+    (fn [runtime-db [_ machine-id]]
+      (get-in runtime-db [:rf.runtime/machines :snapshots machine-id])))
+  (machines/reset-timers!)
+  (loaders/clear-watchers!)
+  (state/reset-shell-state!)
+  (story/install-canonical-vocabulary!)
+  (frame/ensure-default-frame!)
+  (canvas/reset-first-rendered!))
+
+(use-fixtures :each {:before reset-all!})
+
+;; ---- browser gate -----------------------------------------------------
+
+(defn- browser? []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+(defn- make-mount-node! []
+  (let [node (js/document.createElement "div")]
+    (js/document.body.appendChild node)
+    node))
+
+;; ---- the regression ---------------------------------------------------
+
+(deftest viewport-toggle-across-full-vs-sized-boundary-preserves-app-db
+  (testing "rf2-j8hklm: selecting a sized viewport preset after the
+            canvas has already mounted + run its variant does NOT wipe
+            interactive app-db state accumulated since that run"
+    (if-not (browser?)
+      (is true ":node-test — no DOM; :browser-test runs the real assertion")
+      (let [variant-id :story.viewport-toggle/probe]
+        (rf/reg-event :vp-toggle/set
+          (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)}))
+        (rf/reg-event :vp-toggle/inc
+          (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
+        ;; Deliberately NO `:component` — this test only needs the
+        ;; variant's FRAME (allocated by `run-variant`'s `component-did-
+        ;; mount`) and its app-db, not a rendered view. Registering one
+        ;; would route `canvas-inner` through `rf/frame-provider {:frame
+        ;; variant-id}` on the SAME synchronous render pass that first
+        ;; builds the vdom — BEFORE `component-did-mount` has had a
+        ;; chance to allocate that frame — which fails loud
+        ;; (`:rf.error/frame-provider-frame-absent`) for this variant's
+        ;; events-only fast path (no loaders means no skeleton gates that
+        ;; first pass). That race is orthogonal to rf2-j8hklm and not
+        ;; this test's concern; omitting `:component` keeps `canvas-inner`
+        ;; on its `nil? view-id` branch (a harmless placeholder message)
+        ;; so only the mechanism under test — `framed-canvas` /
+        ;; `canvas/canvas`'s mount lifecycle — is exercised.
+        (story/reg-variant variant-id
+          {:events [[:vp-toggle/set 1]]})
+        (state/swap-state! state/select-variant variant-id)
+        (let [mount-node (make-mount-node!)
+              root       (rdc/create-root mount-node)]
+          (try
+            ;; Initial mount: viewport defaults to :full (unsized).
+            ;; `component-did-mount` -> `run-if-needed!` -> `run-variant`
+            ;; runs synchronously for this loader-less, events-only
+            ;; variant (phases 0-2 execute inside the `js/Promise`
+            ;; executor, which JS runs synchronously before `run-variant`
+            ;; returns), so the seed event has already landed by the time
+            ;; `flushSync` returns.
+            (react-dom/flushSync
+              (fn [] (rdc/render root [framed-canvas])))
+            (is (= 1 (:n (rf/app-db-value variant-id)))
+                "the variant's setup :events seeded app-db on first mount")
+            (is (nil? (.querySelector mount-node "[data-test=\"story-canvas-frame-sized\"]"))
+                "precondition: the default :full viewport is UNSIZED —
+                 the sized wrapper marker is absent")
+
+            ;; Simulate a user interaction: a dispatch the variant's
+            ;; OWN :events never fire (not a setup re-run artifact).
+            (rf/dispatch-sync [:vp-toggle/inc] {:frame variant-id})
+            (is (= 2 (:n (rf/app-db-value variant-id)))
+                "the simulated interaction landed")
+
+            ;; Cross the :full -> sized boundary. If the canvas remounts
+            ;; here, `component-will-unmount` clears the run-key sentinel
+            ;; and the fresh `component-did-mount` unconditionally re-runs
+            ;; `run-variant`, resetting the frame to the bare :n 1 seed —
+            ;; wiping the :n 2 interactive state asserted above.
+            (react-dom/flushSync
+              (fn []
+                (vs/select! :tablet)
+                (r/flush)))
+
+            (is (some? (.querySelector mount-node "[data-test=\"story-canvas-frame-sized\"]"))
+                "the toggle actually took effect — :tablet is a sized preset")
+            (is (= 2 (:n (rf/app-db-value variant-id)))
+                "rf2-j8hklm: the interactive app-db mutation SURVIVES the
+                 viewport toggle — the canvas was not force-remounted /
+                 re-run across the :full-vs-sized boundary")
+
+            (finally
+              (try (.unmount root) (catch :default _ nil)))))))))
+
+(deftest viewport-toggle-back-to-full-also-preserves-app-db
+  (testing "rf2-j8hklm: the inverse direction — sized back to :full —
+            is the SAME reconciliation boundary and must be equally
+            stable"
+    (if-not (browser?)
+      (is true ":node-test — no DOM; :browser-test runs the real assertion")
+      (let [variant-id :story.viewport-toggle/probe-reverse]
+        (rf/reg-event :vp-toggle-rev/set
+          (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)}))
+        (rf/reg-event :vp-toggle-rev/inc
+          (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
+        ;; No `:component` — see the sibling test above for why.
+        (story/reg-variant variant-id
+          {:events [[:vp-toggle-rev/set 1]]})
+        ;; Start already on a sized preset.
+        (vs/select! :tablet)
+        (state/swap-state! state/select-variant variant-id)
+        (let [mount-node (make-mount-node!)
+              root       (rdc/create-root mount-node)]
+          (try
+            (react-dom/flushSync
+              (fn [] (rdc/render root [framed-canvas])))
+            (is (= 1 (:n (rf/app-db-value variant-id))))
+            (is (some? (.querySelector mount-node "[data-test=\"story-canvas-frame-sized\"]"))
+                "precondition: mounted already sized")
+
+            (rf/dispatch-sync [:vp-toggle-rev/inc] {:frame variant-id})
+            (is (= 2 (:n (rf/app-db-value variant-id))))
+
+            (react-dom/flushSync
+              (fn []
+                (vs/select! :full)
+                (r/flush)))
+
+            (is (nil? (.querySelector mount-node "[data-test=\"story-canvas-frame-sized\"]"))
+                "the toggle actually took effect — back to :full")
+            (is (= 2 (:n (rf/app-db-value variant-id)))
+                "the interactive mutation survives the reverse toggle too")
+
+            (finally
+              (try (.unmount root) (catch :default _ nil)))))))))


### PR DESCRIPTION
## Summary

Four independent story bug fixes from the /tools sweep, all scoped to `tools/story/**`:

### rf2-j8hklm — viewport-toggle canvas remount wipes interactive app-db
`shell.cljs`'s `framed-canvas` picked between two different hiccup shapes at the same tree position — `[:div {...} [canvas/canvas]]` when the toolbar viewport was "sized" (`:tablet`, etc.), bare `[canvas/canvas]` when `:full`. Toggling across that boundary changed the React element TYPE at that slot, forcing an unmount/remount of the canvas subtree; `canvas/canvas`'s `component-did-mount` then unconditionally re-ran `run-variant`, resetting the frame's app-db even though the viewport is deliberately excluded from `run-key`.

**Fix:** `[canvas/canvas]` now sits behind a stable always-present `:div` wrapper; only the wrapper's own `:style` varies (the real sizing box when sized, `{:display "contents"}` otherwise, so the unsized case's layout is unchanged). Also scoped `canvas.cljs`'s `component-will-unmount` first-rendered-sentinel reset to the unmounting variant (it previously wiped every variant's sentinel globally on any unmount).

### rf2-96qsjr — play-evidence tape assumes epoch-history is append-only
`play/runner_events.cljc` recorded each dispatch step's settle boundary as `(count (rf/epoch-history frame-id))` — a ring-length snapshot. `rf/epoch-history` is a bounded per-frame ring (default depth 50); once total epochs exceed the depth this count plateaus, so two boundaries recorded after that point are numerically identical, and `evidence/stamp-tape`'s positional zip against the (now-truncated) tape misattributes surviving epochs to the wrong script step — "confident but wrong" narrative.

**Fix:** boundaries now record the framework's genuine, globally-monotonic `:epoch-id` (`runner-events/last-epoch-id`) instead of a ring-length count. `stamp-tape` compares each surviving record's own `:epoch-id` against the boundaries rather than its position in the tape, so eviction can only ever drop beats, never misattribute a surviving one. `runtime.cljc`'s `record-result-map` (tape-scoping via `:epoch-baseline`) and `artifact.cljc`'s replay path (`replay-into-frame!`) got the same treatment — both had the identical count-based bug.

### rf2-mzfh9c — nested :vector/:set/:tuple control edit corrupts the arg
`ui/controls.cljs`'s `on-change-at-path` -> `state/set-cell-override` used plain `assoc-in` against shell-state. Before any `[+]`/`[-]` click established a real override, editing an existing array entry directly made `assoc-in` mint an int-keyed map (`{:items {0 "x"}}` instead of `["x" "b"]`), which `args.cljc`'s deep-merge then replaced the base vector with wholesale — corrupting the type and dropping siblings. Editing an entry when the override was already a real `:set` threw (`assoc` on `PersistentHashSet`).

**Fix:** `set-cell-override` gained a 5th `base` argument and a kind-aware `assoc-in-kind-aware` / `vivify-for-key` walk: a missing/wrong-shaped intermediate value is vivified into the collection kind the next path segment needs (vector for an integer index, set-projected-to-vector-then-back for a `:set`, map otherwise) instead of the generic map `assoc-in` mints. `on-change-at-path` seeds `base` from the arg's current resolved ("saved") value — the same baseline the panel already computes for its diff-from-saved affordance — so an edit preserves every sibling entry.

### rf2-gchydo — url_state never clears stale `:active-mode-tab`
`ui/url_state.cljc`'s `apply-parsed-to-state` only ever set `[:active-mode-tab variant-id]` when the URL carried `mode-tab=`; it never cleared it when the URL kept the variant but omitted the param. Since mode-tab changes are pushState'd, Back/Back past a tab switch left the canvas rendering a stale tab while the address bar had already reverted.

**Fix:** added a `(and keep-variant? (not mode-tab))` clause that dissocs the stale `[:active-mode-tab variant-id]` entry, mirroring the existing per-variant `:cell-overrides` clear immediately below it (scoped to the focused variant, not an unconditional `:always` write like the global chrome slots, since mode-tab is per-variant).

## Shared-root-cause finding

Beads 1 and 2 are structurally similar but independent: both are "a stale/incorrectly-scoped identity mechanism breaks under a condition the original author didn't consider" (React element identity across a conditional branch; a ring-length count treated as if it were monotonic). Beads 3 and 4 are also independent of each other and of 1/2. No shared code path — fixed each on its own merits.

## Spec reconciliation

- **rf2-j8hklm**: spec unchanged because no passage in `002-Runtime.md` / `003-Render-Shell.md` / `014-Chrome-Features.md` describes canvas mount/remount behavior on viewport toggle — the old bug and the fix are both implementation-only (`shell.cljs` / `canvas.cljs`).
- **rf2-96qsjr**: spec unchanged because `017-Testing-Story.md`'s narrative-attribution passage only documents the external two-tier contract (exact-when-stamped vs. even-fallback), never the internal comparison basis (position/count vs. identity) — that stays true after the fix.
- **rf2-mzfh9c**: spec unchanged because `001-Authoring.md` Collection-forms section and `019-Story-UI-Controls-And-View-States.md` only describe the resulting write target (`[:cell-overrides variant-id arg-key idx]`) and that cell-overrides fold into `:args` via `resolve-args` — never the `assoc-in` mechanics that corrupted it. The documented contract is unchanged by the fix.
- **rf2-gchydo**: spec updated — `022-Story-UI-Docs-And-Share.md`'s Share-semantics authoritative-clear enumeration (rf2-fkmnh) named `:active-modes`/`:tag-filter`/`:viewport`/`:background`/`:substrate` but silently omitted mode-tab, even though the file's own "EVERY URL-owned chrome slot" claim and its encode-side enumeration already included mode-tab. Added mode-tab to the enumerated clear list, noting its per-variant (dissoc) scope vs. the other slots' global (`:always`) treatment.

## Quality gates

- `clojure -M:test` (from `tools/story/`): Ran 1730 tests containing 6395 assertions. 0 failures, 0 errors.
- `npm run test:cljs` (from `implementation/`, node runtime): Ran 8061 tests containing 37042 assertions. 0 failures, 0 errors. (3 pre-existing unrelated `:undeclared-var` warnings in files this PR does not touch.)
- `npm run test:browser` (from `implementation/`, Playwright/Chromium — the only gate that actually mounts real React DOM for the rf2-j8hklm regression test): Ran 232 tests containing 767 assertions. 0 failures, 0 errors.
- `npm run story:build` (from `implementation/`): succeeded — Build completed (652 files, 591 compiled, 0 warnings, 64.01s).
- `npm run test:bundle-isolation` (from `implementation/`, extra sanity check since Story sits behind the tools/production boundary): PASS — bundle-isolation + uix/helix-reagent-free both green.

## Test plan
- [x] New DOM-mount regression (`viewport_toggle_app_db_dom_cljs_test.cljs`) proves the canvas is NOT remounted across a real `:full`->sized->`:full` viewport toggle, in both directions, via `react-dom/client` + `flushSync` (browser-test only; self-skips under node-test)
- [x] New pure `stamp-tape` eviction tests (`evidence_test.cljc`) + a JVM integration test (`runner_events_cljs_test.cljc`) driving a real 5-dispatch-step run against a depth-3 epoch-history ring
- [x] New `set-cell-override` kind-aware-vivification unit tests + a JVM+CLJS edit->`resolve-args` round-trip test (`controls_nested_cljs_test.cljc`) against a REGISTERED variant's real args — closing the exact test gap the bead named ("pins the raw shape in isolation but never the edit->resolve-args round-trip")
- [x] New `apply-parsed-to-state` mode-tab clearing tests (`url_state_test.cljc`), including the bead's own Back/Back scenario

## Notes
- No overlap with `l3lyal` (result.cljc) or `xk8oz4` (plan.cljc/fingerprint.cljc) — different files entirely, left untouched, and none of my changes force a touch on their target surfaces either.
