### PR TITLE
fix(pair-mcp): exclude snapshot from precheck (elision staleness) + terminate drain-poll on dead conn (rf2-ajhwbm)

### DIFF
--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -2874,17 +2874,20 @@ On termination, the `tools/call` result is
  :rate-dropped   <integer>   ; poll cycles DEFERRED by the per-session rate cap — events stayed queued for a later cycle, not lost (omitted when zero)
  :ticks     <integer>
  :reason    :aborted | :sub-gone | :max-ms-reached | :max-events-reached |
-            :rf.error/stream-abuse-detected}
+            :rf.error/stream-abuse-detected | :rf.error/drain-failed}
 ```
 
 `:reason` is `:aborted` when the client cancelled the call,
 `:sub-gone` when the runtime's subscription disappeared (typically a
 full page reload, or an `unsubscribe` op fired separately),
 `:max-ms-reached` / `:max-events-reached` when the caller's
-upper-bounds fire, or `:rf.error/stream-abuse-detected` when the
+upper-bounds fire, `:rf.error/stream-abuse-detected` when the
 session's rolling-window overflow count exceeded
 `abuse-overflow-threshold` (rf2-3ijbl — see [§Universal: server
-resource controls](#universal-server-resource-controls-streaming-surfaces)).
+resource controls](#universal-server-resource-controls-streaming-surfaces)),
+or `:rf.error/drain-failed` when consecutive nREPL drain rejections
+exceeded the internal retry cap (rf2-ajhwbm — a permanently-dead
+connection, e.g. shadow-cljs restarted onto a new port mid-session).
 
 ### Termination paths
 
@@ -2903,6 +2906,18 @@ resource controls](#universal-server-resource-controls-streaming-surfaces)).
    stderr log line; the operator can raise the threshold via
    `--abuse-overflow-threshold=N` if the workload legitimately
    produces high overflow rates.
+5. **Dead connection (rf2-ajhwbm)** — the drain eval rejects (nREPL
+   round-trip failure) on `max-consecutive-drain-errors` (5)
+   consecutive poll cycles in a row. A single rejection is treated as
+   a transient hiccup and the loop backs off and retries; only a
+   SUSTAINED run of rejections — the signature of a connection that
+   is never coming back, e.g. shadow-cljs restarted onto a new port —
+   terminates the stream with `:reason :rf.error/drain-failed`. Any
+   successful drain in between resets the counter, so isolated blips
+   never accumulate toward the cap. Without this cap, `max-ms`
+   defaults to 0 (unbounded), so a dead connection would otherwise
+   poll (and reject) forever, leaking the concurrent-stream slot for
+   the rest of the session.
 
 ### Failure modes
 

--- a/tools/re-frame2-pair-mcp/spec/Principles.md
+++ b/tools/re-frame2-pair-mcp/spec/Principles.md
@@ -872,17 +872,18 @@ Saving the round-trip too needs a server-side hash precheck
 first, only ship the body on miss) — out of scope for
 rf2-3rt1f, filed as a follow-on bead.
 
-**Precheck eligibility (rf2-36xod follow-on; rf2-3ljsa; rf2-ww877w)**.
-The precheck landed: `(re-frame2-pair.runtime/app-db-hash frame)` is
-shipped first, and a match short-circuits the tool eval. Because that
-hash is `(hash app-db@frame)` ONLY, a tool is precheck-eligible solely
-when its result is a pure function of `app-db@frame`. For `snapshot`
-this constrains the resolved `:include` to the single app-db-derived
-slice `{:app-db}`. The other four slices change WITHOUT an app-db
-write, so a snapshot retaining any of them (including the default
-all-five `:include`) is NOT precheck-eligible and falls back to the
-post-eval result-hash cache above, which hashes the full text and so
-never serves a stale slice:
+**Precheck eligibility (rf2-36xod follow-on; rf2-3ljsa; rf2-ww877w;
+rf2-ajhwbm)**. The precheck landed:
+`(re-frame2-pair.runtime/app-db-hash frame)` is shipped first, and a
+match short-circuits the tool eval. Because that hash is
+`(hash app-db@frame)` ONLY, a tool is precheck-eligible solely when its
+result is a pure function of `app-db@frame` — but as of rf2-ajhwbm, NO
+tool currently qualifies. For `snapshot` the candidate was the single
+app-db-derived slice `{:app-db}`; the other four slices change WITHOUT
+an app-db write, so a snapshot retaining any of them (including the
+default all-five `:include`) is NOT precheck-eligible and falls back to
+the post-eval result-hash cache above, which hashes the full text and
+so never serves a stale slice:
 
 - `:machines` is RUNTIME-DB state (rf2-ww877w) — EP-0001 (rf2-vzld77)
   moved machine snapshots out of app-db into the durable runtime-db
@@ -891,6 +892,16 @@ never serves a stale slice:
 - `:sub-cache` is a reactive cache over external inputs.
 - `:epochs`/`:traces` accrue a record on every pipeline run, even a
   no-`:db` handler.
+- `:app-db` (rf2-ajhwbm) LOOKED sound — it IS the frame db — but the
+  resolved `:app-db` slice is walked through
+  `re-frame.core/elide-wire-value` before it crosses the wire, exactly
+  like `get-path` below. A later elision declaration (or a
+  sensitive/large classification flip) can re-shape the egress of an
+  UNCHANGED app-db subtree while `(hash app-db)` stays constant — a
+  precheck hit under the old rule would re-serve the PRIOR,
+  differently-redacted payload: a staleness / privacy regression, not
+  merely a missed optimisation. So even the narrowest `{:include
+  [:app-db]}` snapshot is now precheck-ineligible.
 
 `get-path` is also NOT precheck-eligible (rf2-ww877w): although it
 reads an app-db subtree, its wire result is post-processed by
@@ -900,6 +911,10 @@ declaration (or a sensitive/large classification flip) can re-shape
 the egress of an UNCHANGED subtree, which the `(hash app-db)` precheck
 hash cannot observe — so `get-path` falls back to the post-eval
 result-hash cache, which hashes the actual post-elision text.
+
+Both tools' precheck-target dispatch stays in place as infrastructure
+for a future tool whose result is genuinely pure over `app-db@frame`
+alone (see `precheck.cljs`'s ns docstring).
 
 **Why opt-in by default**. Agent hosts that haven't been
 taught the `:rf.mcp/cache-hit` marker shape would receive a

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/precheck.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/precheck.cljs
@@ -10,21 +10,25 @@
   WITHOUT running the tool — saving both the wire bytes AND the full
   tool eval.
 
-  Eligibility (today): single-frame `snapshot` whose resolved
-  `:include` is app-db-derived only. Its result is a function of
-  `(frame, args, app-db@frame)`; same frame + same args + same db-hash
-  ⇒ same result. Multi-frame `snapshot` (`:frames :all` or a vector) is
-  NOT eligible because we'd need to hash every frame's db separately and
-  combine — out of scope; the post-eval `apply-cache` path catches
-  those.
+  Eligibility (today): NONE. `snapshot` and `get-path` were the two
+  candidate tools — both are precheck-INELIGIBLE, for the identical
+  reason (rf2-ajhwbm, rf2-ww877w): see below. Every call therefore
+  falls through to the post-eval `apply-cache`, which hashes the full
+  serialized (post-elision) result text and so can never serve a stale
+  payload. This namespace's tagged-tuple dispatch (`precheck-target` /
+  `precheck-form`) stays in place as forward-looking infrastructure for
+  a FUTURE tool whose result is a genuinely pure function of
+  `app-db@frame` alone — see the `:explicit` tag note below.
 
-  Snapshot's `:include` slices split by what the precheck hash sees. The
-  precheck hash is `(re-frame2-pair.runtime/app-db-hash
+  `snapshot`'s `:include` slices split by what the precheck hash sees.
+  The precheck hash is `(re-frame2-pair.runtime/app-db-hash
   frame)` = `(hash app-db@frame)` only — it tracks `:db-after` at every
   settled mutation. So a slice is precheck-sound IFF it is a pure
   function of `app-db@frame`:
 
-    - `:app-db`   — IS the frame db. Sound.
+    - `:app-db`   — reads the frame db, but its WIRE result is
+                    post-processed by `re-frame.core/elide-wire-value`
+                    (rf2-ajhwbm — see below). NOT sound.
     - `:machines` — runtime-db state. Machine snapshots live in the
                     durable runtime-db partition (EP-0001), read via
                     `rf/runtime-db-value` at `[:rf.runtime/machines
@@ -41,16 +45,28 @@
     - `:traces`   — the per-frame trace ring; same accrue-without-db-
                     change behaviour as `:epochs`. NOT sound.
 
-  Only `:app-db` is precheck-sound. A default snapshot (no `:include`)
-  resolves to ALL FIVE slices, which contains the four unsound ones — so
-  the default is NOT precheck-eligible and falls through to the post-eval
-  `apply-cache`, which hashes the full result text and so cannot serve a
-  stale `:machines`/`:epochs`/`:traces`/`:sub-cache` payload. Precheck is
-  taken only when the caller narrows `:include` to the app-db-derived
-  subset.
+  None of the five slices are precheck-sound (rf2-ajhwbm dropped
+  `:app-db`, the last holdout — see below). So no resolved `:include`
+  — not even the narrowest single-slice `{:app-db}` — is
+  precheck-eligible; every `snapshot` call falls through to the
+  post-eval `apply-cache`, which hashes the full result text and so
+  cannot serve a stale `:app-db`/`:machines`/`:epochs`/`:traces`/
+  `:sub-cache` payload.
 
-  `get-path` is NOT precheck-eligible. Although it reads an
-  app-db subtree, its wire result is post-processed by
+  `:app-db` was believed sound (it IS the frame db) until rf2-ajhwbm:
+  the snapshot tool wraps its resolved `:app-db` slice through
+  `re-frame.core/elide-wire-value` before it crosses the wire (see
+  `snapshot.cljs` `slice-walk-src`) — EXACTLY the same egress path
+  `get-path` takes. The elision registry lives in the runtime-db
+  partition (`[:rf.runtime/elision]`), not app-db, so a later elision
+  declaration (or a sensitive/large classification flip) can re-shape
+  the egress of an UNCHANGED app-db subtree while `(hash app-db)` stays
+  constant. A precheck hit under the old `{:app-db}`-is-sound rule
+  would re-serve the PRIOR, differently-redacted payload — a staleness
+  / privacy regression, not just a correctness nit.
+
+  `get-path` is NOT precheck-eligible (rf2-ww877w), for the identical
+  elide-wire-value reason: its app-db subtree read is post-processed by
   `re-frame.core/elide-wire-value`, whose elision registry lives in the
   runtime-db partition (`[:rf.runtime/elision]` — see
   `implementation/core/src/re_frame/elision.cljc`). A later elision
@@ -65,26 +81,9 @@
   eligible — their result depends on the epoch ring / health surface,
   not just `(hash app-db)`. Plumbing a per-surface hash is the
   follow-on work (see `cache.cljs` docstring)."
-  (:require [applied-science.js-interop :as j]
-            [re-frame2-pair-mcp.nrepl :as nrepl]
+  (:require [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.tools.eval-form :as ef]
-            [re-frame2-pair-mcp.tools.wire :as wire]
-            [re-frame2-pair-mcp.tools.args :as args]))
-
-(def app-db-derived-snapshot-slices
-  "Snapshot slices whose value is a pure function of `app-db@frame`.
-  Only these are precheck-sound under the `(hash app-db@frame)` precheck
-  hash; `:machines`/`:sub-cache`/`:epochs`/`:traces` can change while
-  that hash stays constant, so a snapshot whose resolved `:include` is
-  NOT a subset of this set is precheck-ineligible and falls back to the
-  post-eval result-hash cache. See the ns docstring for the per-slice
-  rationale.
-
-  `:machines` is excluded: machine snapshots live in the runtime-db
-  partition (EP-0001), so a machine transition rewrites the slice
-  without an app-db write — the `(hash app-db)` precheck hash can't see
-  it move."
-  #{:app-db})
+            [re-frame2-pair-mcp.tools.wire :as wire]))
 
 (defn precheck-target
   "Resolve the precheck target for a single-frame precheck. Returns a
@@ -97,54 +96,41 @@
   against a magic keyword, so the eligibility distinction is type-level,
   not value-level. Future targets (e.g. multi-frame combined-hash, or an
   operating-frame-resolved hash) add a new tag without colliding with a
-  reserved keyword. The only live tag is `:explicit`.
+  reserved keyword.
 
-  `snapshot` is eligible only when BOTH (a) `:frames` resolves to a
-  single frame (an explicit one-element vector or a single scalar) AND
-  (b) the resolved `:include` is a subset of
-  `app-db-derived-snapshot-slices` — i.e. `#{:app-db}`.
-  `:all` or a multi-element vector — or an `:include` that retains
-  `:machines`/`:sub-cache`/`:epochs`/`:traces` (including the default
-  all-five include) — returns nil so the caller falls back to the
-  post-eval cache, which hashes the full result text and so cannot serve
-  stale non-app-db slices.
+  No tool registers today (rf2-ajhwbm): both candidates fall through to
+  `nil` below, for the SAME reason — their wire result is post-processed
+  by `re-frame.core/elide-wire-value`, whose elision registry lives in
+  the runtime-db partition (`[:rf.runtime/elision]`), not app-db. A
+  later elision declaration (or sensitive/large classification flip)
+  can re-shape the egress of an unchanged app-db subtree, which the
+  `(hash app-db)` precheck hash cannot observe:
 
-  `get-path` is NOT precheck-eligible. Its app-db subtree
-  read is post-processed by `re-frame.core/elide-wire-value`, whose
-  elision registry lives in the runtime-db partition; a later elision
-  declaration (or sensitive/large classification flip) can change the
-  egress shape of an unchanged subtree, which the `(hash app-db)`
-  precheck hash cannot observe. It falls through to the post-eval
-  `apply-cache`, which hashes the actual serialized (post-elision)
-  result text."
-  [tool raw-args]
+  - `snapshot` (rf2-ajhwbm) — even the narrowest single-slice
+    `{:include [:app-db]}` walks its `:app-db` slice through
+    `elide-wire-value` (see `snapshot.cljs` `slice-walk-src`) before it
+    crosses the wire, so no resolved `:include` is precheck-sound. A
+    stale-hash hit would re-serve a payload redacted under a PRIOR
+    elision declaration — a staleness / privacy regression, not merely
+    a missed optimisation.
+  - `get-path` (rf2-ww877w) — its app-db subtree read takes the
+    identical `elide-wire-value` egress path.
+
+  Both fall through to the post-eval `apply-cache`, which hashes the
+  actual serialized (post-elision) result text and therefore recomputes
+  whenever the egress shape changes. The `:explicit` tag and
+  `precheck-form`/`fetch-precheck-hash` plumbing below stay in place as
+  the mechanism a FUTURE genuinely-app-db-pure tool would register
+  against — not dead code, just currently unreached."
+  [tool _raw-args]
   (case tool
-    "snapshot"
-    (let [raw-frames (when raw-args (j/get raw-args "frames"))
-          frames     (args/parse-frames-arg raw-frames)
-          include    (args/parse-include-arg (wire/arg raw-args :include))
-          app-db-derived? (every? app-db-derived-snapshot-slices include)]
-      (cond
-        ;; an :include retaining a non-app-db-derived slice
-        ;; (:machines/:sub-cache/:epochs/:traces) — the precheck hash
-        ;; can't see those move, so NOT eligible.
-        (not app-db-derived?)
-        nil
-        ;; explicit single-frame vector
-        (and (vector? frames) (= 1 (count frames)))
-        [:explicit (first frames)]
-        ;; vector with multiple frames — not eligible
-        (vector? frames)
-        nil
-        ;; :all — not eligible
-        (= :all frames)
-        nil
-        :else nil))
-
-    ;; get-path — NOT precheck-eligible. The elision registry
-    ;; (runtime-db) can re-shape the egress of an unchanged app-db
-    ;; subtree, which the app-db precheck hash can't observe; the
-    ;; post-eval result-hash cache is the sound backstop.
+    ;; `snapshot` — NOT precheck-eligible (rf2-ajhwbm). Every resolved
+    ;; `:include`, even the narrowest `{:app-db}`, egresses through
+    ;; `elide-wire-value`; the elision registry it reads lives in
+    ;; runtime-db, invisible to the `(hash app-db)` precheck hash.
+    ;;
+    ;; `get-path` — NOT precheck-eligible (rf2-ww877w). Same
+    ;; elide-wire-value egress hazard.
     ;;
     ;; Other tools — not precheck-eligible yet.
     nil))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/subscribe.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/subscribe.cljs
@@ -58,6 +58,27 @@
 ;; mirroring would force a two-file sync on every runtime budget tweak.
 ;; Pass nil → runtime defaults.
 
+(def ^:private max-consecutive-drain-errors
+  "Consecutive rejected drain evals tolerated before the poll loop gives
+  up and terminates the stream (rf2-ajhwbm).
+
+  A single rejection is usually a transient nREPL hiccup — the `.catch`
+  below backs off and retries rather than collapsing the stream. But a
+  PERMANENTLY dead connection (e.g. shadow-cljs restarted onto a new
+  port mid-session) rejects every future drain the SAME way, and
+  `max-ms` defaults to 0 (unbounded) — retrying forever would leak the
+  resource-controls concurrent-stream slot and the poll loop's
+  `setTimeout` chain for the rest of the MCP session, silently
+  exhausting `--max-concurrent-streams`.
+
+  Capping consecutive failures bounds the leak: on the Nth rejection in
+  a row the loop calls `terminate` instead of rescheduling, which
+  releases the stream slot and resolves the outer `tools/call` with an
+  honest `:rf.error/drain-failed` summary. The counter resets to zero
+  on any successful drain, so isolated blips never accumulate toward
+  the cap."
+  5)
+
 (def ^:private initial-state
   "The rolling per-stream accounting map. Held inside one
   atom for the lifetime of a `subscribe-tool` call; merged once per
@@ -154,8 +175,10 @@
 
 (defn final-summary
   "The terminal `ok-text` result emitted when the subscription ends —
-  client cancel, unsubscribe, max-events / max-ms hit, sub-gone, or
-  abuse-detected.
+  client cancel, unsubscribe, max-events / max-ms hit, sub-gone,
+  abuse-detected, or a permanently-dead nREPL connection
+  (`max-consecutive-drain-errors` consecutive drain rejections —
+  rf2-ajhwbm).
 
   `state` is the deref'd rolling accumulators map (see
   `initial-state`); `wire/with-indicators` splices the
@@ -509,7 +532,8 @@
   `tools/call` Promise with the final-summary envelope. `poll` runs
   the rate-gate → drain → state-merge → progress-emit → reschedule
   cycle until termination triggers (client abort, max-events reached,
-  sub-gone, or abuse-detected).
+  sub-gone, abuse-detected, or `max-consecutive-drain-errors`
+  consecutive drain rejections — rf2-ajhwbm).
 
   Public (not `defn-`) so `subscribe_resource_controls_test.cljs` can
   drive a single `poll` invocation with a stubbed
@@ -520,6 +544,14 @@
            incl? elision? dedup? cap]}]
   (let [drain-src    (drain-form sub-id topic elision? incl?)
         terminated?  (atom false)
+        ;; Consecutive rejected-drain counter (rf2-ajhwbm). Local to
+        ;; this stream — NOT part of the shared `state` accumulator
+        ;; map (that atom is session-visible bookkeeping surfaced on
+        ;; the final summary; this is internal poll-loop plumbing).
+        ;; Reset to zero on any successful drain; incremented on
+        ;; rejection; the loop gives up once it reaches
+        ;; `max-consecutive-drain-errors`.
+        drain-errors (atom 0)
         terminate
         (fn terminate [reason]
           ;; Idempotent: a double-fire (e.g. abuse-detected fires the
@@ -574,6 +606,11 @@
             (-> (nrepl/cljs-eval-value conn build-id drain-src)
                 (.then
                   (fn [drain-resp]
+                    ;; A successful drain (whatever its content) proves
+                    ;; the connection is alive — clear the consecutive-
+                    ;; failure counter so an isolated earlier blip never
+                    ;; accumulates toward the terminate cap (rf2-ajhwbm).
+                    (reset! drain-errors 0)
                     (if (:gone? drain-resp)
                       (terminate :sub-gone)
                       (let [;; The drain envelope carries the
@@ -637,8 +674,19 @@
                 (.catch
                   (fn [_err]
                     ;; nREPL hiccup — back off and try again rather
-                    ;; than collapsing the stream.
-                    (js/setTimeout poll (* 2 poll-ms)))))))]
+                    ;; than collapsing the stream, UNLESS this is the
+                    ;; Nth consecutive rejection in a row. A permanently
+                    ;; dead connection (e.g. shadow-cljs restarted onto
+                    ;; a new port) rejects every future drain the same
+                    ;; way, and `max-ms` defaults to 0 (unbounded) — so
+                    ;; retrying forever would leak the concurrent-stream
+                    ;; slot + this poll loop for the rest of the session
+                    ;; (rf2-ajhwbm). Give up and terminate instead, which
+                    ;; releases the slot and resolves the outer call
+                    ;; with an honest `:rf.error/drain-failed` summary.
+                    (if (>= (swap! drain-errors inc) max-consecutive-drain-errors)
+                      (terminate :rf.error/drain-failed)
+                      (js/setTimeout poll (* 2 poll-ms))))))))]
     {:state state :terminate terminate :poll poll}))
 
 (defn- run-acquired

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/invoke_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/invoke_test.cljs
@@ -71,6 +71,7 @@
 ;; ---------------------------------------------------------------------------
 
 (def ^:private orig-fetch-precheck-hash precheck/fetch-precheck-hash)
+(def ^:private orig-precheck-target     precheck/precheck-target)
 (def ^:private orig-get-path-tool       get-path/get-path-tool)
 (def ^:private orig-snapshot-tool       snapshot/snapshot-tool)
 (def ^:private orig-reset-operating-frame-tool operating-frame/reset-operating-frame-tool)
@@ -78,6 +79,7 @@
 
 (defn- restore-stubs! []
   (set! precheck/fetch-precheck-hash orig-fetch-precheck-hash)
+  (set! precheck/precheck-target     orig-precheck-target)
   (set! get-path/get-path-tool       orig-get-path-tool)
   (set! snapshot/snapshot-tool       orig-snapshot-tool)
   (set! operating-frame/reset-operating-frame-tool orig-reset-operating-frame-tool)
@@ -131,20 +133,30 @@
 ;; this Promise-chain-independent.
 ;;
 ;; `kind` is the keyword the caller picked to identify which slot
-;; to stub — `:fetch-precheck-hash`, `:get-path-tool`,
-;; `:snapshot-tool`. Anything else is a programmer error and we
-;; throw immediately rather than silently no-op.
+;; to stub — `:fetch-precheck-hash`, `:precheck-target`,
+;; `:get-path-tool`, `:snapshot-tool`. Anything else is a programmer
+;; error and we throw immediately rather than silently no-op.
+;;
+;; `:precheck-target` exists because, post rf2-ajhwbm, NO real tool
+;; registers a non-nil precheck target (both `snapshot` and `get-path`
+;; are precheck-ineligible — see `precheck.cljs`). The phase-1
+;; pipeline-mechanics tests below (precheck hit ⇒ dispatch skipped)
+;; are deliberately tool-agnostic; stubbing `precheck-target` directly
+;; is how they manufacture an eligible target without depending on a
+;; real (and, pre-fix, buggy) eligibility path.
 ;; ---------------------------------------------------------------------------
 
 (defn- set-stubs! [stubs]
   (doseq [[kind stub] stubs]
     (case kind
       :fetch-precheck-hash (set! precheck/fetch-precheck-hash stub)
+      :precheck-target     (set! precheck/precheck-target     stub)
       :get-path-tool       (set! get-path/get-path-tool       stub)
       :snapshot-tool       (set! snapshot/snapshot-tool       stub)
       :reset-operating-frame-tool (set! operating-frame/reset-operating-frame-tool stub)
       (throw (ex-info (str "Unknown stub kind: " kind)
                       {:kind kind :known #{:fetch-precheck-hash
+                                           :precheck-target
                                            :get-path-tool
                                            :snapshot-tool
                                            :reset-operating-frame-tool}})))))
@@ -160,14 +172,15 @@
 
 (deftest precheck-hit-short-circuits-dispatch
   (async done
-    ;; The precheck-eligible vehicle is a single-frame APP-DB-ONLY
-    ;; snapshot. The pipeline mechanics under test (precheck hit ⇒
-    ;; dispatch skipped) are tool-agnostic; we just need a tool whose
-    ;; `precheck-target` is non-nil so `precheck-step` issues the
-    ;; stubbed fetch.
-    (let [args        (args-js {:cache "true"
-                                :frames #js ["rf/default"]
-                                :include #js ["app-db"]})
+    ;; No real tool registers a precheck target post-rf2-ajhwbm
+    ;; (`snapshot` and `get-path` are BOTH precheck-ineligible — see
+    ;; `precheck.cljs`). The pipeline mechanics under test (precheck
+    ;; hit ⇒ dispatch skipped) are tool-agnostic, so we stub
+    ;; `precheck-target` directly to manufacture an eligible target for
+    ;; whichever tool name `invoke` dispatches — `precheck-step` then
+    ;; issues the stubbed fetch exactly as it would for a genuinely
+    ;; eligible tool.
+    (let [args        (args-js {:cache "true" :frames #js ["rf/default"]})
           dispatched? (atom false)
           ;; The cache key includes the resolved build, so the priming
           ;; MUST use the same build the `invoke` pipeline derives
@@ -180,7 +193,8 @@
                                 :build (wire/arg-build nil args)
                                 :precheck-hash 42})]
       (set-stubs!
-        {:fetch-precheck-hash (fn [_conn _args _frame] (js/Promise.resolve 42))
+        {:precheck-target     (fn [_tool _args] [:explicit :rf/default])
+         :fetch-precheck-hash (fn [_conn _args _frame] (js/Promise.resolve 42))
          :snapshot-tool       (fn [_conn _args]
                                 (reset! dispatched? true)
                                 (js/Promise.resolve (mcp-result "{:should-not-ship :true}")))})
@@ -207,15 +221,16 @@
 
 (deftest precheck-miss-stores-hash-for-next-call
   (async done
-    ;; Vehicle is the single-frame app-db-only snapshot (the sole
-    ;; precheck-eligible surface). The mechanics: cold miss stores the
-    ;; precheck-hash; the next call short-circuits.
-    (let [args       (args-js {:cache "true"
-                               :frames #js ["rf/default"]
-                               :include #js ["app-db"]})
+    ;; No real tool is precheck-eligible post-rf2-ajhwbm — stub
+    ;; `precheck-target` directly (see `precheck-hit-short-circuits-
+    ;; dispatch` above) so the mechanics (cold miss stores the
+    ;; precheck-hash; the next call short-circuits) stay covered
+    ;; tool-agnostically.
+    (let [args       (args-js {:cache "true" :frames #js ["rf/default"]})
           call-count (atom 0)]
       (set-stubs!
-        {:fetch-precheck-hash (fn [_conn _args _frame] (js/Promise.resolve 999))
+        {:precheck-target     (fn [_tool _args] [:explicit :rf/default])
+         :fetch-precheck-hash (fn [_conn _args _frame] (js/Promise.resolve 999))
          :snapshot-tool       (fn [_conn _args]
                                 (swap! call-count inc)
                                 (js/Promise.resolve (mcp-result "{:app-db {:k :v}}")))})
@@ -471,26 +486,34 @@
                  (done))))))
 
 ;; ---------------------------------------------------------------------------
-;; Snapshot precheck eligibility is gated on `:include`.
+;; Snapshot precheck eligibility — NONE, for every `:include` shape
+;; (rf2-ajhwbm).
 ;;
-;; The precheck hash is `(hash app-db@frame)` only. `:epochs`/`:traces`
-;; accrue a record on EVERY pipeline run (incl. no-`:db` handlers) and
-;; `:sub-cache` can move over external inputs — all WITHOUT an app-db
-;; write, so the precheck hash stays constant while those slices change.
-;; A snapshot whose resolved `:include` keeps any of those three is
-;; therefore NOT precheck-eligible; it must fall back to the post-eval
-;; result-hash cache, which hashes the full text and so recomputes.
+;; The precheck hash is `(hash app-db@frame)` only. `:machines`/
+;; `:sub-cache`/`:epochs`/`:traces` can all move WITHOUT an app-db
+;; write, so an `:include` retaining any of them is unsound (unchanged).
+;; `:app-db` LOOKED sound (it IS the frame db) but is not: the resolved
+;; `:app-db` slice is walked through `re-frame.core/elide-wire-value`
+;; before it crosses the wire (`snapshot.cljs` `slice-walk-src`), and the
+;; elision registry that walk consults lives in the runtime-db partition,
+;; not app-db — a later elision-declaration change re-shapes the egress
+;; of an unchanged app-db subtree, invisible to the app-db precheck hash.
+;; So EVERY snapshot `:include`, including the narrowest `{:app-db}`,
+;; falls back to the post-eval result-hash cache, which hashes the full
+;; text and so recomputes whenever the egress shape changes.
 ;; ---------------------------------------------------------------------------
 
 ;; The MCP wire passes `:frames` / `:include` as JS arrays of strings,
 ;; not EDN strings — `parse-frames-arg` / `parse-include-arg` coerce
 ;; arrays/sequentials. Build args with JS arrays to match the live shape.
 (deftest precheck-target-snapshot-eligibility-by-include
-  (testing "single-frame snapshot, app-db-only include → eligible"
-    (is (= [:explicit :rf/default]
-           (precheck/precheck-target
-             "snapshot" (args-js {:frames #js ["rf/default"] :include #js ["app-db"]})))
-        ":include [:app-db] is app-db-derived — precheck-eligible")
+  (testing "single-frame snapshot, app-db-only include → ineligible (rf2-ajhwbm)"
+    (is (nil? (precheck/precheck-target
+                "snapshot" (args-js {:frames #js ["rf/default"] :include #js ["app-db"]})))
+        ;; :app-db egresses through elide-wire-value, whose elision
+        ;; registry lives in runtime-db — the SAME hazard get-path was
+        ;; excluded for (rf2-ww877w). No longer treated as sound.
+        ":include [:app-db] still egresses through elide-wire-value ⇒ ineligible")
     (is (nil? (precheck/precheck-target
                 "snapshot" (args-js {:frames #js ["rf/default"]
                                      :include #js ["app-db" "machines"]})))
@@ -502,8 +525,8 @@
   (testing "single-frame snapshot, default (all-five) include → ineligible"
     (is (nil? (precheck/precheck-target
                 "snapshot" (args-js {:frames #js ["rf/default"]})))
-        "default include carries :epochs/:traces/:sub-cache — ineligible"))
-  (testing "single-frame snapshot retaining a non-app-db slice → ineligible"
+        "default include carries :epochs/:traces/:sub-cache → ineligible"))
+  (testing "single-frame snapshot retaining any slice → ineligible"
     (doseq [slice [#js ["app-db" "epochs"]
                    #js ["app-db" "traces"]
                    #js ["app-db" "sub-cache"]
@@ -513,7 +536,7 @@
                    #js ["machines"]]]
       (is (nil? (precheck/precheck-target
                   "snapshot" (args-js {:frames #js ["rf/default"] :include slice})))
-          (str "include " (vec slice) " retains an unsound slice — ineligible"))))
+          (str "include " (vec slice) " — ineligible"))))
   (testing "multi-frame snapshot stays ineligible regardless of include"
     (is (nil? (precheck/precheck-target
                 "snapshot" (args-js {:frames #js ["a" "b"] :include #js ["app-db"]}))))))
@@ -578,27 +601,51 @@
                    (done)))))))
 
 ;; ---------------------------------------------------------------------------
-;; NO over-invalidation. A single-frame APP-DB-ONLY snapshot is
-;; precheck-eligible: an unchanged app-db hash serves the precheck hit
-;; (the optimisation holds for the sound case).
+;; END-TO-END staleness guard (rf2-ajhwbm). A single-frame APP-DB-ONLY
+;; snapshot used to be treated as precheck-sound — `(hash app-db)`
+;; unchanged ⇒ serve the prior payload without re-dispatching. But the
+;; `:app-db` slice egresses through `elide-wire-value`, whose elision
+;; registry lives in runtime-db, NOT app-db. An elision declaration can
+;; change mid-session while app-db itself never moves — under the old
+;; rule the precheck hash would still match and a STALE, differently-
+;; redacted payload would be re-served as a "cache-hit". This test
+;; models exactly that: app-db is genuinely unchanged across both
+;; calls (the precheck hash, if consulted, would match), but the
+;; tool's egressed text differs (standing in for the elision flip).
+;; The regression guard: precheck must never be consulted for
+;; snapshot, so the differing text is served FRESH via the post-eval
+;; result-hash cache, never as a bogus precheck hit.
 ;; ---------------------------------------------------------------------------
 
-(deftest single-frame-appdb-only-snapshot-still-precheck-hits
+(deftest single-frame-appdb-only-snapshot-no-longer-precheck-hits
   (async done
-    (let [args (args-js {:cache "true" :frames #js ["rf/default"] :include #js ["app-db"]})]
+    (let [args        (args-js {:cache "true" :frames #js ["rf/default"] :include #js ["app-db"]})
+          fetch-count (atom 0)
+          call-count  (atom 0)]
       (set-stubs!
-        {:fetch-precheck-hash (fn [_conn _args _target] (js/Promise.resolve 1234))
+        {;; If precheck WERE consulted it would match (app-db is
+         ;; unchanged across the two calls) and serve a stale hit — so
+         ;; this stub must never fire.
+         :fetch-precheck-hash (fn [_conn _args _target]
+                                (swap! fetch-count inc)
+                                (js/Promise.resolve 1234))
          :snapshot-tool       (fn [_conn _args]
-                                (js/Promise.resolve (mcp-result "{:app-db {:k :v}}")))})
+                                (swap! call-count inc)
+                                ;; Egressed text differs between calls —
+                                ;; standing in for an elision-declaration
+                                ;; flip re-shaping the SAME app-db
+                                ;; subtree's post-elision wire form.
+                                (js/Promise.resolve
+                                  (mcp-result (str "{:app-db {:k :v} :call " @call-count "}"))))})
       (-> (tools/invoke nil "snapshot" args nil)
           (.then (fn [_first] (tools/invoke nil "snapshot" args nil)))
           (.then (fn [second-result]
-                   (is (cache-hit? second-result)
-                       "unchanged app-db hash ⇒ precheck hit served")
-                   (is (= :precheck
-                          (get-in (extract-edn second-result)
-                                  [:rf.mcp/cache-hit :via]))
-                       "via :precheck — the sound short-circuit is preserved")
+                   (is (zero? @fetch-count)
+                       "precheck NEVER consulted — no snapshot :include is precheck-eligible (rf2-ajhwbm)")
+                   (is (= 2 @call-count)
+                       "second call re-dispatches — no stale precheck hit")
+                   (is (not (cache-hit? second-result))
+                       "differing post-elision text ⇒ fresh result, never served as a stale hit")
                    (done)))))))
 
 ;; ---------------------------------------------------------------------------

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/subscribe_resource_controls_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/subscribe_resource_controls_test.cljs
@@ -62,6 +62,14 @@
     (is (= "rf.error" (namespace kw)))
     (is (= "stream-abuse-detected" (name kw)))))
 
+(deftest drain-failed-keyword-is-namespaced
+  ;; The dead-connection termination reason (rf2-ajhwbm), same
+  ;; rf.error/* convention as the abuse-detected sentinel above.
+  (let [kw :rf.error/drain-failed]
+    (is (qualified-keyword? kw))
+    (is (= "rf.error" (namespace kw)))
+    (is (= "drain-failed" (name kw)))))
+
 ;; ---------------------------------------------------------------------------
 ;; Resource-controls config surfaces through to subscribe behaviour.
 ;; ---------------------------------------------------------------------------
@@ -216,3 +224,109 @@
                      (is (zero? (:rate-dropped @state))
                          "no rate-drop when a token was available")))
             (.finally (fn [] (restore!) (done))))))))
+
+;; ---------------------------------------------------------------------------
+;; Dead-connection cap (rf2-ajhwbm). A permanently-dead nREPL connection
+;; (e.g. shadow-cljs restarted onto a new port mid-session) rejects
+;; every drain eval the SAME way. `max-ms` defaults to 0 (unbounded), so
+;; without a cap on consecutive failures the poll loop — and the
+;; resource-controls concurrent-stream slot it holds — would leak for
+;; the rest of the MCP session. `poll` is driven BY HAND here (the
+;; stubbed `js/setTimeout` is an inert no-op, same pattern as the
+;; rate-gate tests above) so the test doesn't depend on real timer
+;; delays; each `(poll)` call's returned Promise settles once that
+;; cycle's `.then`/`.catch` handler has run, which is enough to
+;; sequence the next manual `(poll)` call deterministically.
+;; ---------------------------------------------------------------------------
+
+(deftest dead-connection-terminates-and-releases-stream-slot
+  (async done
+    (let [state       (fresh-state)
+          resolved    (atom nil)
+          orig-eval   nrepl/cljs-eval-value
+          orig-set-to js/setTimeout
+          eval-stub   (fn ([_c _b _form] (js/Promise.reject (js/Error. "dead conn")))
+                        ([_c _b _form _o] (js/Promise.reject (js/Error. "dead conn"))))
+          restore!    (fn []
+                        (tu/restore-eval! eval-stub orig-eval)
+                        (set! js/setTimeout orig-set-to))]
+      (set! nrepl/cljs-eval-value eval-stub)
+      (set! js/setTimeout (fn [& _] 0))
+      (resource/reset-for-tests!)
+      ;; Reserve a slot the way `subscribe-tool` would, so we can prove
+      ;; `terminate` releases it rather than leaking it.
+      (resource/acquire-stream!)
+      (let [{:keys [poll]}
+            (sub/make-stream-controller
+              {:conn :stub :build-id "b" :sub-id "sub-dead" :topic :trace
+               :resolve (fn [v] (reset! resolved v))
+               :state state
+               :signal nil :send-note nil :progress-tk nil
+               :poll-ms 1 :max-events 0
+               :incl? false :elision? true :dedup? false})]
+        (letfn [(drive [n]
+                  (if (or (some? @resolved) (<= n 0))
+                    (do
+                      (is (some? @resolved)
+                          "a permanently-dead nREPL connection MUST terminate the stream rather than poll forever")
+                      ;; `resolve` receives the `wire/ok-text`-wrapped MCP
+                      ;; JS envelope `final-summary` builds, not a plain
+                      ;; map — unwrap via the shared EDN extractor.
+                      (is (= :rf.error/drain-failed (:reason (tu/extract-edn @resolved)))
+                          "the honest dead-connection reason, not a silent hang")
+                      (is (zero? (resource/active-stream-count))
+                          "terminate releases the concurrent-stream slot — no leak on a dead conn")
+                      (restore!)
+                      (done))
+                    (-> (poll)
+                        (.then (fn [_] (drive (dec n)))))))]
+          ;; 20 is a generous ceiling above any sane consecutive-failure
+          ;; cap — the assertion inside `drive` fails loudly if
+          ;; termination never happens within it.
+          (drive 20))))))
+
+(deftest isolated-drain-error-does-not-terminate
+  ;; A single rejected drain is a transient nREPL hiccup, not a dead
+  ;; connection — the consecutive-failure counter resets on the NEXT
+  ;; successful drain (rf2-ajhwbm), so an alternating fail/succeed
+  ;; pattern must never accumulate toward the terminate cap. This pins
+  ;; the resilience the fix must NOT regress: back off and retry stays
+  ;; the behaviour for isolated blips.
+  (async done
+    (let [state       (fresh-state)
+          resolved    (atom nil)
+          orig-eval   nrepl/cljs-eval-value
+          orig-set-to js/setTimeout
+          call-n      (atom 0)
+          respond     (fn []
+                        (if (odd? (swap! call-n inc))
+                          (js/Promise.reject (js/Error. "transient"))
+                          (js/Promise.resolve {:ok? true :sub-id "sub-flaky"
+                                               :events [] :gone? false})))
+          eval-stub   (fn ([_c _b _form] (respond))
+                        ([_c _b _form _o] (respond)))
+          restore!    (fn []
+                        (tu/restore-eval! eval-stub orig-eval)
+                        (set! js/setTimeout orig-set-to))]
+      (set! nrepl/cljs-eval-value eval-stub)
+      (set! js/setTimeout (fn [& _] 0))
+      (resource/reset-for-tests!)
+      (let [{:keys [poll]}
+            (sub/make-stream-controller
+              {:conn :stub :build-id "b" :sub-id "sub-flaky" :topic :trace
+               :resolve (fn [v] (reset! resolved v))
+               :state state
+               :signal nil :send-note nil :progress-tk nil
+               :poll-ms 1 :max-events 0
+               :incl? false :elision? true :dedup? false})]
+        (letfn [(drive [n]
+                  (if (<= n 0)
+                    (do
+                      (is (nil? @resolved)
+                          "alternating fail/succeed never runs two consecutive failures — must NOT terminate")
+                      (is (= 12 @call-n) "every cycle drove a real eval call — the loop kept going")
+                      (restore!)
+                      (done))
+                    (-> (poll)
+                        (.then (fn [_] (drive (dec n)))))))]
+          (drive 12))))))


### PR DESCRIPTION
## Summary

Two correctness/resource-safety fixes on `tools/re-frame2-pair-mcp/`, split from rf2-5pv3sh (per-surface child rf2-ajhwbm).

**Finding 1 — precheck.cljs elision-blind staleness.** `app-db-derived-snapshot-slices` treated `:app-db` as precheck-sound, so a single-frame `snapshot {:include [:app-db]}` short-circuited on a `(hash app-db)` precheck hit. But the `:app-db` slice egresses through `re-frame.core/elide-wire-value`, whose sensitive/large classification lives in the runtime-db `[:rf.runtime/elision]` partition, not app-db — the exact reason `get-path` was already excluded (rf2-ww877w). If an elision declaration changed mid-session while app-db stayed unchanged, the precheck hash still matched, serving a stale, differently-redacted payload as a false cache-hit (a staleness/privacy regression). Fix: drop `snapshot` from precheck eligibility entirely, mirroring `get-path`. No tool is currently precheck-eligible; the `precheck-target`/`precheck-form`/`fetch-precheck-hash` plumbing stays as infrastructure for a future genuinely app-db-pure tool.

**Finding 2 — subscribe.cljs drain-poll leak on dead conn.** The drain `.catch` rescheduled `(js/setTimeout poll (* 2 poll-ms))` unconditionally on every nREPL rejection; `max-ms` defaults to 0 (unbounded); abuse-detection only counts queue overflow, never eval errors. A permanently-dead connection (e.g. shadow-cljs restarted onto a new port) rejected every future drain forever, so `resource/release-stream!` (which only runs inside `terminate`) never fired — leaking the concurrent-stream slot + poll loop for the rest of the session, silently exhausting `--max-concurrent-streams`. Fix: cap consecutive drain rejections (`max-consecutive-drain-errors`, 5); on the Nth in a row, `terminate` with `:reason :rf.error/drain-failed` instead of rescheduling. Any successful drain resets the counter so isolated hiccups keep the existing backoff-and-retry resilience.

Spec docs (`Principles.md`, `003-Tool-Catalogue.md` in this tool's local `spec/`) updated to match both behaviour changes.

## Test plan
- [x] `precheck.cljs` — `app-db-derived-snapshot-slices` var + the `"snapshot"` eligibility branch removed; every `precheck-target` call now falls through to `nil`.
- [x] `invoke_test.cljs` — rewrote the snapshot-eligibility assertions (all `:include` shapes, including the narrowest `{:app-db}`, now assert `nil`); added a `:precheck-target` stub seam so the two tool-agnostic pipeline-mechanics tests (`precheck-hit-short-circuits-dispatch`, `precheck-miss-stores-hash-for-next-call`) no longer depend on a real (now-removed) eligible tool; replaced the "still-precheck-hits" test with `single-frame-appdb-only-snapshot-no-longer-precheck-hits`, an end-to-end regression proving a snapshot with unchanged app-db but differing egressed text (standing in for an elision-declaration flip) is served fresh, never as a stale precheck hit.
- [x] `subscribe.cljs` — added `max-consecutive-drain-errors` (5), a per-stream `drain-errors` counter (reset on success, incremented on rejection), and the terminate-on-cap branch in the drain `.catch`.
- [x] `subscribe_resource_controls_test.cljs` — added `dead-connection-terminates-and-releases-stream-slot` (sustained rejections terminate with `:rf.error/drain-failed` and release the concurrent-stream slot) and `isolated-drain-error-does-not-terminate` (alternating fail/succeed never accumulates toward the cap — pins the pre-existing backoff-and-retry resilience is preserved), plus a keyword-shape pin (`drain-failed-keyword-is-namespaced`).

## Quality gates
- `npm test` (from `tools/re-frame2-pair-mcp/`): 1143 tests, 3832 assertions, 0 failures, 0 errors.
- `npm run check:descriptors`: OK, `tool-descriptors.edn` in sync (30 tools).