### PR TITLE
fix(story-mcp): run-variant error-outcome fills all 6 evidence slots so structuredContent passes valid-run-result? (rf2-5r6j96)

### DIFF
--- a/tools/story-mcp/src/re_frame/story_mcp/tools/egress.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/egress.cljc
@@ -306,8 +306,19 @@
       consumer that needs the raw tree off a non-live frame opts in via
       `include?` (the `--allow-sensitive-reads` escape hatch)."
   [tree app-db variant-id include?]
-  (if include?
-    tree
+  (cond
+    ;; Nil-safe — mirrors `elide-app-db`'s pre-check (rf2-5r6j96: this
+    ;; short-circuit was DOCUMENTED above but never implemented, so a nil
+    ;; `tree` fell through to `project-egress` — walking to nil unchanged
+    ;; under a live frame, but UNCONDITIONALLY redacted to `:rf/redacted`
+    ;; under a non-live frame per the four-case rule below, either of
+    ;; which is a needless trip through the egress walker for a tree with
+    ;; nothing in it to protect).
+    (nil? tree) tree
+
+    include? tree
+
+    :else
     ;; Project through the SINGLE record-level boundary `re-frame.core/project-egress`
     ;; (EP-0025 B4, rf2-ojp8pi): a `:rf.observe/derived-tree` record naming the
     ;; off-box-tool egress PROFILE — `project-egress` resolves the profile to

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/testing.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/testing.cljc
@@ -97,18 +97,30 @@
                        (async/deref-blocking (story/run-variant vk opts) timeout)
                        (catch Throwable e
                          ;; A throw / timeout never produced a unified
-                         ;; result; mint the :error verdict directly so the
-                         ;; wire shape is the SAME unified shape a settled run
-                         ;; emits (one vocabulary, no special-case branch for
-                         ;; agents to learn).
-                         {:status     :error
-                          :frame      vk
-                          :assertions [(story/assertion-record
-                                         {:assertion :rf.error/run-failed
-                                          :passed?   false
-                                          :error     true
-                                          :reason    (ex-message e)})]
-                          :checks     []}))
+                         ;; result; assemble ONE through the SAME canonical
+                         ;; `story/run-result` boundary a settled run emits
+                         ;; (spec/017 §Run result) rather than hand-mint a
+                         ;; partial map — a hand-mint omitting the six `.4`
+                         ;; evidence slots (`:schema-violations` / `:warnings`
+                         ;; / `:effects` / `:sub-runs` / `:renders` /
+                         ;; `:narrative`) reads them back as an ABSENT key,
+                         ;; i.e. nil, which then projects RAW through
+                         ;; `egress/scrub-rendered` below and ships a bare
+                         ;; `nil` on the wire — failing the frozen
+                         ;; `[:sequential :any]` schema every OTHER run
+                         ;; outcome satisfies (rf2-5r6j96). `run-result`
+                         ;; against an empty tape fills every evidence slot
+                         ;; to `[]`, so the projection always has a
+                         ;; sequential to walk — one vocabulary, no
+                         ;; special-case error-branch shape for agents OR
+                         ;; the schema to carve out.
+                         (story/run-result
+                           {:variant/id vk
+                            :assertions [(story/assertion-record
+                                           {:assertion :rf.error/run-failed
+                                            :passed?   false
+                                            :error     true
+                                            :reason    (ex-message e)})]})))
             incl?    (targs/include-sensitive? arguments)
             raw-db   (:app-db outcome)
             [assertions dropped] (egress/scrub-assertions+count (:assertions outcome) incl?)
@@ -131,12 +143,24 @@
                               ;; PATH to redact at the source). scrub-rendered
                               ;; recurses the nested trees and the gate stays
                               ;; symmetric (incl? true forwards raw).
-                              :schema-violations  (egress/scrub-rendered (:schema-violations outcome) raw-db vk incl?)
+                              ;; Every slot is `(vec ...)`-wrapped BEFORE the
+                              ;; projection (not just the two that used to be)
+                              ;; — `scrub-rendered` has no nil short-circuit of
+                              ;; its own reaching `project-egress`, so a bare
+                              ;; absent-key nil would walk through as nil
+                              ;; (live frame) rather than the `[]` the frozen
+                              ;; `[:sequential :any]` schema requires
+                              ;; (rf2-5r6j96). `run-result` above already
+                              ;; fills every slot with `[]`; the `vec` here is
+                              ;; the belt-and-suspenders guard at the
+                              ;; projection call site itself, independent of
+                              ;; how `outcome` was assembled.
+                              :schema-violations  (egress/scrub-rendered (vec (:schema-violations outcome)) raw-db vk incl?)
                               :warnings           (egress/scrub-rendered (vec (:warnings outcome)) raw-db vk incl?)
-                              :effects            (egress/scrub-rendered (:effects outcome) raw-db vk incl?)
+                              :effects            (egress/scrub-rendered (vec (:effects outcome)) raw-db vk incl?)
                               :sub-runs           (egress/scrub-rendered (vec (:sub-runs outcome)) raw-db vk incl?)
-                              :renders            (egress/scrub-rendered (:renders outcome) raw-db vk incl?)
-                              :narrative          (egress/scrub-rendered (:narrative outcome) raw-db vk incl?)
+                              :renders            (egress/scrub-rendered (vec (:renders outcome)) raw-db vk incl?)
+                              :narrative          (egress/scrub-rendered (vec (:narrative outcome)) raw-db vk incl?)
                               ;; Derived trees: PATH-projected. A value AT a
                               ;; classified path redacts; a re-keyed copy ships
                               ;; raw (EP-0025 fail-open).

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -3416,6 +3416,65 @@
           (is (tree-contains? (:sub-runs s) "TOPSECRET")
               "opt-in surfaces the raw value in :sub-runs"))))))
 
+;; ---------------------------------------------------------------------------
+;; rf2-5r6j96 — a run-variant timeout / exception ships a structuredContent
+;; that PASSES `valid-run-result?`. The catch branch used to hand-mint a
+;; partial map (`:status` / `:frame` / `:assertions` / `:checks` only),
+;; omitting the six `.4` evidence slots (`:schema-violations` / `:warnings`
+;; / `:effects` / `:sub-runs` / `:renders` / `:narrative`). An ABSENT key
+;; reads back as nil; `egress/scrub-rendered` had no nil short-circuit of
+;; its own, so a live-frame walk of nil returns nil unchanged — and the
+;; frozen `RunResult` schema declares each of those six slots
+;; `[:optional true] [:sequential :any]`: a PRESENT nil violates it (nil
+;; is not sequential). These pin the FIX end-to-end via the real
+;; `tool-run-variant` handler (the wire pipeline, not a hand-rolled
+;; simulation of its internals) for both ways the catch branch is
+;; genuinely reachable: `story/run-variant` throwing synchronously, and
+;; `async/deref-blocking`'s `.get(timeout, unit)` timing out on a promise
+;; that never settles.
+;; ---------------------------------------------------------------------------
+
+(deftest run-variant-exception-outcome-passes-valid-run-result?
+  (testing "story/run-variant throwing synchronously still ships a schema-valid structuredContent"
+    (with-clean-frame [vid :story.button/primary]
+      ;; Run the variant once for real first so the frame is LIVE — the
+      ;; production-reachable shape (any path that could genuinely throw /
+      ;; time out is necessarily reached AFTER `story/run-variant`'s own
+      ;; phase-0 frame allocation, which runs synchronously and unconditionally
+      ;; resolves rather than rejects on every OTHER internal error).
+      (invoke "run-variant" {:variant-id "story.button/primary"})
+      (with-redefs [story/run-variant
+                    (fn [& _] (throw (ex-info "simulated run-variant boom" {})))]
+        (let [r (invoke "run-variant" {:variant-id "story.button/primary"})
+              s (:structuredContent r)]
+          (is (success? r))
+          (is (= :error (:status s)))
+          (is (story/valid-run-result? s)
+              (str "structuredContent must conform to the frozen RunResult schema; "
+                   (story/explain-run-result s)))
+          (doseq [k [:schema-violations :warnings :effects :sub-runs :renders :narrative]]
+            (is (= [] (get s k)) (str k " defaults to [] rather than nil"))))))))
+
+(deftest run-variant-timeout-outcome-passes-valid-run-result?
+  (testing "a genuine async/deref-blocking timeout still ships a schema-valid structuredContent"
+    (with-clean-frame [vid :story.button/primary]
+      (invoke "run-variant" {:variant-id "story.button/primary"})
+      (with-redefs [story/run-variant
+                    ;; A future that never completes — `deref-blocking`'s
+                    ;; `.get(timeout-ms, …)` genuinely times out (a real
+                    ;; TimeoutException, not a rejected/completed future).
+                    (fn [& _] (java.util.concurrent.CompletableFuture.))]
+        (let [r (invoke "run-variant" {:variant-id "story.button/primary"
+                                       :timeout-ms 50})
+              s (:structuredContent r)]
+          (is (success? r))
+          (is (= :error (:status s)))
+          (is (story/valid-run-result? s)
+              (str "structuredContent must conform to the frozen RunResult schema; "
+                   (story/explain-run-result s)))
+          (doseq [k [:schema-violations :warnings :effects :sub-runs :renders :narrative]]
+            (is (= [] (get s k)) (str k " defaults to [] rather than nil"))))))))
+
 (deftest read-failures-strips-sensitive-assertion-records-by-default
   (testing "an assertion record stamped :sensitive? true is dropped at egress"
     (with-clean-frame [vid :story.button/primary]


### PR DESCRIPTION
## Summary

- `tool-run-variant`'s outer catch branch (a genuine `deref-blocking` timeout, or a synchronous throw out of `story/run-variant`) hand-minted a partial `{:status :error :frame vk :assertions [...] :checks []}` map, omitting the six `.4` evidence slots (`:schema-violations` / `:warnings` / `:effects` / `:sub-runs` / `:renders` / `:narrative`). An absent key reads back as `nil`; `egress/scrub-rendered` had no `nil` short-circuit of its own (its docstring claimed one that was never implemented in the code), so a live-frame walk of `nil` returned `nil` unchanged — and the frozen `RunResult` schema declares each of those six slots `[:optional true][:sequential :any]`, so a *present* `nil` fails validation. A documented run timeout/exception shipped a `structuredContent` that failed `valid-run-result?`.
- **Verified the premise before fixing** (this was a contested finding — one reviewer flagged it, one found zero): reproduced empirically via a direct payload-assembly probe AND end-to-end through the real `tool-run-variant` handler (forcing both a synchronous throw and a genuine `async/deref-blocking` timeout). Confirmed the frame is always LIVE when this catch branch is reachable in practice (any path that can genuinely reject/time out runs after `story/run-variant`'s own phase-0 frame allocation; every other internal error is caught and resolved internally by `story/run-variant` itself, never reaching this outer catch). Under that live-frame case, 4 of the 6 slots resolved to bare `nil`, confirmed via `story/explain-run-result`.
- **Fix**: build the error outcome through the canonical `story/run-result` assembly (fills every evidence slot with `[]` against an empty tape — the same assembly every other run-result producer uses) instead of hand-minting a parallel partial shape; additionally `(vec ...)`-wrap all six evidence slots uniformly at the `scrub-rendered` call site (belt-and-suspenders, independent of how `outcome` was built); and added the `(nil? tree)` short-circuit to `scrub-rendered` itself, matching its own docstring and mirroring `elide-app-db`'s existing nil pre-check.
- Added two regression tests exercising the real `tool-run-variant` handler end-to-end (a synchronous throw and a genuine timeout) — both fail against the pre-fix code with the exact predicted nil-slot schema violations, confirmed by temporarily reverting and re-running.

## Quality gates

- `cd tools/story-mcp && clojure -M:test` — 298 tests, 1459 assertions, **0 failures, 0 errors** (up from 296/1441 pre-change; the 2 new regression tests + their assertions).
- Confirmed the 2 new regression tests fail against the pre-fix source with the exact predicted schema-violation errors (temporarily reverted `testing.cljc`/`egress.cljc` to `HEAD`, re-ran, saw 10 failures matching the bug description; restored the fix, re-ran, 0 failures).