### PR TITLE
fix(xray): cross-frame spine epoch-history reseed + select-dispatch-id mode parity + ensure-xray-frame! run-once guard (rf2-j5xjvt/pqt7cb/n4p5it)

### DIFF
--- a/tools/xray/spec/011-Launch-Modes.md
+++ b/tools/xray/spec/011-Launch-Modes.md
@@ -338,6 +338,25 @@ via `window.opener`. The pop-out renders into the new window but
 — no `BroadcastChannel`, no `postMessage`, no structured-clone
 serialisation. Same JS realm, no protocol cost.
 
+**Pop-out REFLECTS the opener's already-running instance; it must not
+RESET it (rf2-n4p5it).** `popout!` calls `mount/ensure-xray-frame!`
+with no arg — the SAME default `frame-id` the inline shell already
+seeded. `ensure-xray-frame!` gates its first-mount hook fan-out (trace-
+buffer seed, `:target-frame` + `:epoch-history` seed, transient-filter
+reset, column-width hydrate, mode hydrate, auto-open-watcher install)
+behind a `seeded-frame-ids` run-once guard keyed on `frame-id`: the
+FIRST call for a frame-id runs every hook; every subsequent call for
+that SAME frame-id is a no-op on the hook side (the frame
+(re-)registration itself stays idempotent via `reg-frame`'s surgical-
+update-on-re-register semantics regardless). Without the guard, a
+pop-out re-ran `::seed-trace-and-target-frame`, which re-derives the
+seed frame from the CURRENT head focusable event-bundle and
+re-dispatches `:rf.xray/set-target-frame` — reverting `:target-frame`
+(and the `:epoch-history` ring keyed on it) back to the head frame even
+when the user had already picked a different frame via the L1
+switcher, jumping the inline shell's App-DB / Epoch panels off the
+user's choice the instant the shell was popped out.
+
 **Styling (the second-window stylesheet hand-off).** The pop-out window
 is a distinct `document` whose `<head>` does NOT inherit the opener's
 injected Xray stylesheet. The shell's inline styles and class rules all

--- a/tools/xray/spec/018-Event-Spine.md
+++ b/tools/xray/spec/018-Event-Spine.md
@@ -1147,6 +1147,20 @@ The scoping + filtering happens at the data layer (`:rf.xray/filtered-event-bund
 
 The spine carries `:mode`; the L2 event list reads it for LIVE-tracking + sticky-on-older + the head-row pulse cue. (The dedicated Mode pill widget that earlier drafts placed in the ribbon was dropped — the spine cue in L2 is the only mode surface.)
 
+**Every head-aware mode selector must agree on what "head" means
+(rf2-pqt7cb).** `focus-event-bundle-reducer`'s LIVE/RETRO pivot is `(=
+dispatch-id head-id)` — so every event handler that resolves `head-id`
+before calling it must use the SAME head definition the user actually
+sees in L2. With the `show-ungrouped?` opt-in (§6 above) ON, the
+user-visible head can be the `:ungrouped` bucket itself; `head-id` MUST
+be computed via `spine/focusable-head-id`'s 2-arity (threading
+`show-ungrouped?`), never the 1-arity (which hard-codes `false`).
+`:rf.xray/focus-event` and `:rf.xray/select-dispatch-id` both resolve a
+head-id this way — a caller that dropped the flag would silently pick
+a DIFFERENT head-id than its sibling for the identical buffer, mis-
+selecting LIVE vs RETRO and (in LIVE's case) letting the spine
+auto-advance away from a selection the caller meant to pin.
+
 ---
 
 ## §7 Filter system
@@ -1450,27 +1464,47 @@ reducer so the App-db diff renders the diff body for the picked frame
 on the next render-frame, and the Views panel's `:has-event-bundle?`
 guard does not flip to `false` between picks.
 
-**Cross-frame L2-row click re-seed (rf2-q8hvw).** With the picker
-**untouched** the view scope is nil, so the L2 list spans EVERY frame's
-cascades (`matcher/filter-event-bundles-by-view-scope` is a no-op on a nil
-scope). Clicking a row for a cascade that settled in a NON-head frame
-must therefore resolve its settling epoch against THAT frame's ring —
-but `:rf.xray/epoch-history` is keyed on `:rf.xray/target-frame`, which
-is re-seeded only by the PICKER (`set-frame`) and the
-`:rf.xray/epoch-recorded` listener (which appends only when the
-recording frame IS the current target). So the two COMMITTED focus
-handlers that resolve an epoch-id from the slot —
-`:rf.xray/focus-event`, `:rf.xray/focus-epoch` — first call
-`spine/reseed-epoch-history-for-frame`, which re-keys
-`:rf.xray/target-frame` + `:rf.xray/epoch-history` onto the clicked
-cascade's frame (resolved via `rf/epoch-history`) BEFORE the epoch-id
-lookup runs. The re-seed is a no-op when the clicked frame already
-equals `:target-frame` (a same-frame click), and a no-op when the
-frame is unknown (nil). This makes the line above — "click-on-row
-picker-less navigation also rebinds" — true for a cross-frame click,
-not just a same-frame one: pre-fix the clicked cascade's epoch
-resolved to nil and the epoch-keyed panels (App-DB diff, Views'
-focused-cascade-pair, Machine Inspector) rendered empty/stale.
+**Cross-frame L2-row click re-seed (rf2-q8hvw, rf2-o1c3r).** With the
+picker **untouched** the view scope is nil, so the L2 list spans EVERY
+frame's cascades (`matcher/filter-event-bundles-by-view-scope` is a
+no-op on a nil scope). Clicking a row for a cascade that settled in a
+NON-head frame must therefore resolve its settling epoch against THAT
+frame's ring — but `:rf.xray/epoch-history` is keyed on
+`:rf.xray/target-frame`, which is re-seeded only by the PICKER
+(`set-frame`) and the `:rf.xray/epoch-recorded` listener (which
+appends only when the recording frame IS the current target). So the
+COMMITTED focus handlers that resolve an epoch-id from the slot —
+`:rf.xray/focus-event`, `:rf.xray/focus-epoch`, `:rf.xray/select-
+dispatch-id` — first call `spine/reseed-epoch-history-for-frame`,
+which re-keys `:rf.xray/target-frame` + `:rf.xray/epoch-history` onto
+the clicked cascade's frame (resolved via `rf/epoch-history`) BEFORE
+the epoch-id lookup runs. The re-seed is a no-op when the clicked
+frame already equals `:target-frame` (a same-frame click), and a
+no-op when the frame is unknown (nil). This makes the line above —
+"click-on-row picker-less navigation also rebinds" — true for a
+cross-frame click, not just a same-frame one: pre-fix the clicked
+cascade's epoch resolved to nil and the epoch-keyed panels (App-DB
+diff, Views' focused-cascade-pair, Machine Inspector) rendered
+empty/stale.
+
+**Cross-frame STEP re-seed (rf2-j5xjvt).** The `j`/`k` step handlers
+(`:rf.xray/focus-event-prev`/`-next`) walk the SAME whole-buffer,
+picker-agnostic cascade list, so a single step can land on a row that
+settled in a different frame than the current `:target-frame` — the
+step is a "picker-less navigation" exactly like a click. But the step
+handlers don't know which frame they're landing on until AFTER the
+walk resolves, whereas the click handlers already have the clicked
+row's frame from the dispatch args. `spine/step-target-frame` closes
+that gap: a pure, side-effect-free helper that runs the same
+current-position + step-target resolution `focus-step-reducer`
+performs internally, returning just the landing row's `:frame`. The
+event handler calls it FIRST, reseeds `:epoch-history` onto that frame
+via `reseed-epoch-history-for-frame` (mirroring the click handlers'
+order), THEN calls `focus-step-reducer` with the now-correct ring.
+Pre-fix, a cross-frame step resolved `:epoch-id` against whatever ring
+happened to be current — nil whenever the stepped row's frame
+disagreed with `:target-frame`, even though that frame's ring
+genuinely held the settling epoch.
 
 **`:rf.xray/preview-event` resolves WITHOUT committing the re-key
 (rf2-uo0rc.5).** A preview is a transient hover, not a commit, so it
@@ -1493,13 +1527,16 @@ Test gates: `spine_cljs_test.cljs` pins the `:target-frame` +
 `:epoch-history` writes on both arities of `set-frame-reducer`, the
 `reseed-epoch-history-for-frame` no-op / re-key cases, and the
 end-to-end cross-frame `:rf.xray/focus-event` / `:rf.xray/focus-epoch`
-resolution (multi-frame, picker untouched); the
-`app_db_diff_cljs_test.cljs` + `views_subs_cljs_test.cljs` regression
-suites pin the panel render bodies post-reseed. For the preview path
-(rf2-uo0rc.5) `spine_cljs_test.cljs` additionally pins that
-preview-clear RESTORES the committed `:dispatch-id` / `:epoch-id` (RETRO
-hover-then-leave) and that the `:rf.xray/preview-event` handler does
-NOT persist a cross-frame `:target-frame` / `:epoch-history` re-key.
+/ `:rf.xray/select-dispatch-id` resolution (multi-frame, picker
+untouched), plus the rf2-j5xjvt cross-frame STEP case (`focus-event-
+prev` landing on a different-frame row re-seeds before resolving) and
+its same-frame no-op sibling; the `app_db_diff_cljs_test.cljs` +
+`views_subs_cljs_test.cljs` regression suites pin the panel render
+bodies post-reseed. For the preview path (rf2-uo0rc.5)
+`spine_cljs_test.cljs` additionally pins that preview-clear RESTORES
+the committed `:dispatch-id` / `:epoch-id` (RETRO hover-then-leave) and
+that the `:rf.xray/preview-event` handler does NOT persist a
+cross-frame `:target-frame` / `:epoch-history` re-key.
 
 **Frame-strict cascade lookup (rf2-bz7flo).** Dispatch ids are unique
 only WITHIN a frame (Spec 002 §Frame isolation + rf2-g6ih4); the

--- a/tools/xray/src/day8/re_frame2_xray/mount.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/mount.cljs
@@ -341,6 +341,35 @@
   ;; registrations).
   (atom []))
 
+(defonce ^:private seeded-frame-ids
+  ;; rf2-n4p5it — the set of frame-ids whose first-mount hooks have
+  ;; already fired at least once. `ensure-xray-frame!` fans the hook
+  ;; table out UNGUARDED prior to this fix: `popout!` calls
+  ;; `(ensure-xray-frame!)` with no arg, defaulting to the SAME
+  ;; `shell/default-frame-id` the inline shell already seeded, so a
+  ;; pop-out remount re-ran EVERY first-mount hook — including
+  ;; `::seed-trace-and-target-frame`, which re-derives the seed frame
+  ;; from the CURRENT head focusable event-bundle and re-dispatches
+  ;; `:rf.xray/set-target-frame`. That reverted `:target-frame` (and
+  ;; the `:epoch-history` ring keyed on it) back to the head frame
+  ;; even when the user had already picked a different frame via the
+  ;; L1 switcher — the inline shell's App-DB / Epoch panels jumped off
+  ;; the user's choice the instant they popped the shell out. Spec
+  ;; 011 §Pop-out: the pop-out shares the opener's runtime and frame —
+  ;; reflecting it, not resetting it.
+  ;;
+  ;; This is bookkeeping for the HOOK FAN-OUT ONLY — `image-reads/seat-
+  ;; xray-frame!` keeps its own independent idempotency check
+  ;; (`xray-frame-seated?`, queried against the live frame registry)
+  ;; and always runs; a re-seat is a cheap no-op when already seated.
+  ;;
+  ;; `defonce` so the guard survives shadow-cljs `:after-load` (a hot-
+  ;; reload of an already-open shell must not re-seed it either).
+  ;; Test-only escape hatch: `reset-for-test!` below clears this so
+  ;; fixtures that wipe the frame registry between tests also get a
+  ;; fresh first-mount pass.
+  (atom #{}))
+
 (defn- register-first-mount-hook!
   "Register a 1-ary fn `(fn [frame-id] …)` to run on first
   `ensure-xray-frame!` after the shell's frame is registered. Hooks
@@ -363,11 +392,29 @@
 
 (defn ensure-xray-frame!
   "Register the shell frame if not already registered, then run each
-  registered first-mount hook in insertion order. Idempotent via
-  `reg-frame`'s surgical-update-on-re-register semantics (per Spec
-  002 §reg-frame) — first call creates the frame and seeds, subsequent
-  calls are surgical no-ops on the frame side and (per each hook's own
-  idempotency contract) no-ops on the hook side.
+  registered first-mount hook — but ONLY on the first call for a given
+  `frame-id`. Idempotent via `reg-frame`'s surgical-update-on-re-
+  register semantics (per Spec 002 §reg-frame) on the frame side, AND
+  via the `seeded-frame-ids` run-once guard on the hook side (rf2-
+  n4p5it) — first call creates the frame and seeds; every subsequent
+  call for the SAME `frame-id` is a surgical no-op on the frame side
+  and skips the hook fan-out entirely.
+
+  ## rf2-n4p5it — run-once guard
+
+  Pre-fix the hook fan-out ran UNGUARDED on every call — harmless for
+  the inline shell (`open!` only calls this once, before the frame
+  exists), but `popout!` also calls `(ensure-xray-frame!)` with the
+  SAME default `frame-id` the inline shell already seeded. Without a
+  guard, popping out re-ran `::seed-trace-and-target-frame`, which
+  re-derives the seed frame from the CURRENT head focusable event-
+  bundle and re-dispatches `:rf.xray/set-target-frame` — reverting
+  `:target-frame` (and the `:epoch-history` ring keyed on it) back to
+  the head frame even when the user had already picked a different
+  frame via the L1 switcher. The pop-out is supposed to REFLECT the
+  opener's already-running instance, not reset it (Spec 011 §Pop-out).
+  See `seeded-frame-ids` above for the guard's contract, including the
+  test-only `reset-for-test!` escape hatch.
 
   EP-0023 §Xray Beside The Target (rf2-32siq3.36): the production singleton is
   SEATED in its OWN image-loaded frame via `image_view_reads/seat-xray-frame!`
@@ -483,8 +530,25 @@
    ;; through `host-registry` (generation-bypassing) so the inspector still sees
    ;; the inspected app's registrar, not its own image's — see that ns.
    (image-reads/seat-xray-frame! frame-id)
-   (doseq [{:keys [handler]} @first-mount-hooks]
-     (handler frame-id))))
+   ;; rf2-n4p5it — run the hook fan-out only on the FIRST call for this
+   ;; `frame-id`. `seat-xray-frame!` above stays unconditional (its own
+   ;; `xray-frame-seated?` check makes a re-seat a cheap no-op); it's
+   ;; the SEED/HYDRATE hook table that must not re-fire on a same-
+   ;; frame-id remount (popout! after inline open!, or a repeat
+   ;; ensure-xray-frame! call generally).
+   (when-not (contains? @seeded-frame-ids frame-id)
+     (swap! seeded-frame-ids conj frame-id)
+     (doseq [{:keys [handler]} @first-mount-hooks]
+       (handler frame-id)))))
+
+(defn reset-for-test!
+  "Reset the `ensure-xray-frame!` run-once guard (rf2-n4p5it) so test
+  fixtures that wipe the frame registry between tests also get a
+  fresh first-mount hook pass on the next `ensure-xray-frame!` call.
+  Test-only — never call from production code."
+  []
+  (reset! seeded-frame-ids #{})
+  nil)
 
 ;; ---- first-mount hook registrations -------------------------------------
 ;;

--- a/tools/xray/src/day8/re_frame2_xray/panels.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels.cljs
@@ -183,10 +183,11 @@
   populated, and the user sees blank inputs even though the host has
   been dispatching events.
 
-  `ensure-xray-frame!` is idempotent (sentinel-guarded hooks +
-  reg-frame's surgical-update-on-re-register semantics per Spec 002
-  §reg-frame) so multiple panel mounts collapse to one seed pass +
-  zero re-registrations across shadow-cljs reloads."
+  `ensure-xray-frame!` is idempotent (a `seeded-frame-ids` run-once
+  guard on the hook fan-out per rf2-n4p5it + reg-frame's surgical-
+  update-on-re-register semantics per Spec 002 §reg-frame) so multiple
+  panel mounts collapse to one seed pass + zero re-registrations
+  across shadow-cljs reloads."
   []
   (registry/register-xray-handlers!)
   (mount/ensure-xray-frame!))

--- a/tools/xray/src/day8/re_frame2_xray/registry.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/registry.cljs
@@ -477,13 +477,24 @@
     ;; epoch-id nil → the epoch-keyed panels strand on an empty/stale
     ;; state. The cross-frame ring is resolved via `rf/epoch-history` at
     ;; dispatch time; the re-seed is a no-op when the frame is unchanged.
+    ;;
+    ;; rf2-pqt7cb — the head-id computation threads `show-ungrouped?`
+    ;; (the same live setting `:rf.xray/focus-event` reads via
+    ;; `db->show-ungrouped?`). Without it, `focusable-head-id`'s 1-arg
+    ;; form hard-codes `show-ungrouped? false`, so with the opt-in ON
+    ;; this handler can pick a DIFFERENT head-id than `:rf.xray/focus-
+    ;; event` does for the identical buffer — `focus-event-bundle-
+    ;; reducer`'s LIVE/RETRO mode selection (`(= dispatch-id head-id)`)
+    ;; then diverges between the two handlers for the same selected row.
     (rf/reg-event :rf.xray/select-dispatch-id
       (fn [{:keys [db]} [_ dispatch-id frame-id]]
-        {:db (let [db       (spine/reseed-epoch-history-for-frame
-                         db frame-id (rf/epoch-history frame-id))
-              history  (get db :epoch-history [])
-              epoch-id (spine/epoch-id-for-event-bundle history dispatch-id)
-              head-id  (spine/focusable-head-id (spine/db->event-bundles db))]
+        {:db (let [db              (spine/reseed-epoch-history-for-frame
+                                 db frame-id (rf/epoch-history frame-id))
+              history         (get db :epoch-history [])
+              epoch-id        (spine/epoch-id-for-event-bundle history dispatch-id)
+              show-ungrouped? (spine/db->show-ungrouped? db)
+              head-id         (spine/focusable-head-id (spine/db->event-bundles db)
+                                                        show-ungrouped?)]
           (spine/focus-event-bundle-reducer db dispatch-id frame-id epoch-id head-id))}))
 
     ;; Programmatic clear of the focused event-bundle. Resets the spine

--- a/tools/xray/src/day8/re_frame2_xray/spine.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/spine.cljs
@@ -584,6 +584,52 @@
                           :previewing? false)
        frame-id   (assoc-in [:focus :frame] frame-id)))))
 
+(defn step-target-frame
+  "Pure helper: resolve the `:frame` a spine step (`:rf.xray/focus-
+  event-prev` / `-next`, `delta` -1/+1) would land on, WITHOUT
+  resolving `:epoch-id` or writing to db. Mirrors the current-position
+  + step-target resolution `focus-step-reducer` performs internally
+  (`compose-focus` for the current row, `step-event-bundle` for the
+  stepped row) so the two stay in lockstep.
+
+  ## rf2-j5xjvt — reseed-before-resolve for the step path
+
+  The click handlers (`:rf.xray/focus-event`, `:rf.xray/select-
+  dispatch-id`, `:rf.xray/focus-epoch`) all call `reseed-epoch-
+  history-for-frame` for the clicked row's frame BEFORE resolving its
+  settling `:epoch-id`, because `:epoch-history` is a SINGLE per-frame
+  ring keyed on `:target-frame` (rf2-q8hvw). The step handlers
+  (`focus-event-prev` / `-next`) didn't have an equivalent — they
+  don't know which frame the step lands on until AFTER `focus-step-
+  reducer`'s internal walk runs, by which point the reducer has
+  already tried to resolve `:epoch-id` against whatever ring the
+  caller happened to pass in. A stepped row landing in a frame other
+  than the current `:target-frame` therefore resolved `:epoch-id` to
+  nil even though that frame's ring genuinely holds a settling epoch
+  for it.
+
+  This helper lets the event handler learn the target frame FIRST (a
+  pure, side-effect-free query) so it can reseed `:epoch-history` for
+  that frame — exactly as the click handlers do — before calling
+  `focus-step-reducer`, which then resolves `:epoch-id` against the
+  now-correct ring. Returns nil when there is no row to step to
+  (empty `event-bundles`); the caller's reseed is then a no-op via
+  `reseed-epoch-history-for-frame`'s own nil-frame branch, and
+  `focus-step-reducer` itself performs the real boundary no-op check.
+
+  Pure data; JVM-runnable."
+  [db event-bundles delta show-ungrouped?]
+  (let [slot-frame    (get-in db [:focus :frame])
+        focusable*    (focusable-event-bundles event-bundles show-ungrouped?)
+        focusable     (if slot-frame
+                        (filterv #(= slot-frame (:frame %)) focusable*)
+                        focusable*)
+        current       (compose-focus (get db :focus) event-bundles show-ungrouped?)
+        current-id    (:dispatch-id current)
+        current-frame (:frame current)
+        stepped       (step-event-bundle focusable current-frame current-id delta)]
+    (:frame stepped)))
+
 (defn focus-step-reducer
   "Pure reducer for `:rf.xray/focus-event-prev` / `-next`. Steps
   the `:dispatch-id` through the event-bundle vector by `delta` (-1 or
@@ -613,7 +659,21 @@
   resolves to nil. Production callers in `install!` go through the
   4-arg arity. rf2-r9lyy — the 5-arg arity threads
   `show-ungrouped?` so the step walk includes the `:ungrouped`
-  bucket when the user has opted in."
+  bucket when the user has opted in.
+
+  ## rf2-j5xjvt — caller reseeds `:epoch-history` before calling this
+
+  This reducer resolves `:epoch-id` against WHATEVER `epoch-history`
+  the caller passes in — it does not itself know or re-key the ring.
+  Production callers (`:rf.xray/focus-event-prev` / `-next` in
+  `install!`) call `step-target-frame` first to learn which frame the
+  step lands on, reseed `:epoch-history` onto that frame via
+  `reseed-epoch-history-for-frame`, THEN call this reducer with the
+  reseeded ring — mirroring the reseed-before-resolve order the click
+  handlers (`:rf.xray/focus-event`, `:rf.xray/select-dispatch-id`)
+  already follow. Without that reseed, a step landing in a frame other
+  than the current `:target-frame` resolves `:epoch-id` to nil even
+  when the target frame's ring holds a genuine settling epoch."
   ([db event-bundles delta]
    (focus-step-reducer db event-bundles [] delta false))
   ([db event-bundles epoch-history delta]
@@ -1025,15 +1085,31 @@
             epoch-id       (epoch-id-for-event-bundle (db->epoch-history db) dispatch-id)]
         (focus-event-bundle-reducer db dispatch-id frame-id epoch-id head-id))}))
 
+  ;; rf2-j5xjvt — a step landing in a frame other than the current
+  ;; `:target-frame` must reseed `:epoch-history` onto THAT frame
+  ;; before `focus-step-reducer` resolves `:epoch-id`, exactly as the
+  ;; click handlers reseed before resolving (rf2-q8hvw). `step-target-
+  ;; frame` learns the landing frame first (a pure query); the reseed
+  ;; is then a no-op when the step stays within the current frame.
   (rf/reg-event :rf.xray/focus-event-prev
     (fn [{:keys [db]} _event]
-      {:db (focus-step-reducer db (db->event-bundles db) (db->epoch-history db) -1
-                          (db->show-ungrouped? db))}))
+      (let [event-bundles   (db->event-bundles db)
+            show-ungrouped? (db->show-ungrouped? db)
+            target-frame    (step-target-frame db event-bundles -1 show-ungrouped?)
+            db              (reseed-epoch-history-for-frame
+                              db target-frame (rf/epoch-history target-frame))]
+        {:db (focus-step-reducer db event-bundles (db->epoch-history db) -1
+                            show-ungrouped?)})))
 
   (rf/reg-event :rf.xray/focus-event-next
     (fn [{:keys [db]} _event]
-      {:db (focus-step-reducer db (db->event-bundles db) (db->epoch-history db) +1
-                          (db->show-ungrouped? db))}))
+      (let [event-bundles   (db->event-bundles db)
+            show-ungrouped? (db->show-ungrouped? db)
+            target-frame    (step-target-frame db event-bundles +1 show-ungrouped?)
+            db              (reseed-epoch-history-for-frame
+                              db target-frame (rf/epoch-history target-frame))]
+        {:db (focus-step-reducer db event-bundles (db->epoch-history db) +1
+                            show-ungrouped?)})))
 
   (rf/reg-event :rf.xray/focus-epoch
     ;; Per rf2-5qp4g — focus the spine by epoch-id (the primary key

--- a/tools/xray/src/day8/re_frame2_xray/test_support.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/test_support.cljs
@@ -36,6 +36,7 @@
   cluster item 3e (audit rf2-i0veg §3e)."
   (:require [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.install :as install]
+            [day8.re-frame2-xray.mount :as mount]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.trace-collector :as trace-collector]
             ;; rf2-e8330v (xxo3zz F3) — per-panel test-override seams.
@@ -52,11 +53,12 @@
             [day8.re-frame2-xray.static.schemas.panel :as static-schemas-panel]))
 
 (defn reset-sentinels!
-  "Reset ONLY the install + registry idempotency sentinels, in
+  "Reset ONLY the install + registry + mount idempotency sentinels, in
   dependency order:
 
       install/reset-for-test!  ; trace-cb + epoch-cb reg flags
       registry/reset-for-test! ; per-panel reg-event/reg-sub flags
+      mount/reset-for-test!    ; ensure-xray-frame! run-once guard (rf2-n4p5it)
 
   Does NOT touch the trace-collector rings or the settings atom — safe
   to call MID-setup (after frames are registered) because it only flips
@@ -64,6 +66,7 @@
   []
   (install/reset-for-test!)
   (registry/reset-for-test!)
+  (mount/reset-for-test!)
   nil)
 
 (defn reset-all!

--- a/tools/xray/test/day8/re_frame2_xray/mount_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/mount_cljs_test.cljs
@@ -1077,6 +1077,90 @@
                     "app-db container preserved across re-register")))))))))
 
 ;; -------------------------------------------------------------------------
+;; (8c) rf2-n4p5it — ensure-xray-frame! run-once guard
+;; -------------------------------------------------------------------------
+;;
+;; `popout!` calls `(ensure-xray-frame!)` with no arg — the SAME default
+;; `frame-id` the inline shell already seeded via `open!`. Pre-fix the
+;; hook fan-out was unguarded, so this second call re-ran
+;; `::seed-trace-and-target-frame`, which re-derives the seed frame from
+;; the CURRENT head focusable event-bundle and re-dispatches
+;; `:rf.xray/set-target-frame` — reverting `:target-frame` back to the
+;; head frame even after the user had already picked a different frame
+;; via the L1 switcher. This test drives `ensure-xray-frame!` directly a
+;; second time (exactly what `popout!` does under the hood) rather than
+;; standing up a real second `window.open` — mirrors the direct-call
+;; pattern `init_filter_reset_cljs_test.cljs` uses for the same fn.
+
+(deftest ensure-xray-frame-does-not-reseed-target-frame-on-second-call-rf2-n4p5it
+  (testing "rf2-n4p5it — a second `ensure-xray-frame!` call for the SAME
+            frame-id must NOT re-run the first-mount hook fan-out, so a
+            user-picked `:target-frame` survives a pop-out remount"
+    (with-stub-document
+      (fn [_doc]
+        (let [{:keys [render-fn]} (mk-render-stub)]
+          (with-redefs [substrate-adapter/render render-fn
+                        rf/epoch-history (fn [frame-id]
+                                           (case frame-id
+                                             :cart-frame [{:epoch-id :e-cart :frame :cart-frame
+                                                           :db-before {} :db-after {:k 1}
+                                                           :trigger-event [:cart/add]
+                                                           :event-id :cart/add
+                                                           :trace-events []}]
+                                             []))]
+            ;; Pre-mount traffic on :cart-frame — the head focusable
+            ;; event-bundle's frame, so the FIRST ensure-xray-frame!
+            ;; (inside open!) seeds :target-frame to :cart-frame.
+            (trace-collector/seed-trace-for-test!
+              (pre-mount-dispatch-event 1 100 :cart-frame :cart/add-item))
+            (mount/open!)
+            (rf/with-frame :rf/xray
+              (is (= :cart-frame @(rf/subscribe [:rf.xray/target-frame]))
+                  "precondition: first mount seeded :target-frame from the
+                   head focusable event-bundle's frame"))
+            ;; The user picks a DIFFERENT frame — e.g. via the L1 frame
+            ;; switcher, which drives :target-frame in lockstep with
+            ;; :epoch-history exactly like the seed hook does.
+            (rf/with-frame :rf/xray
+              (rf/dispatch-sync [:rf.xray/set-target-frame :other-frame]))
+            (rf/with-frame :rf/xray
+              (is (= :other-frame @(rf/subscribe [:rf.xray/target-frame]))
+                  "precondition: user's picker choice is now :other-frame"))
+            ;; popout! calls (ensure-xray-frame!) again with the same
+            ;; default frame-id — simulate that second call directly.
+            (mount/ensure-xray-frame!)
+            (rf/with-frame :rf/xray
+              (is (= :other-frame @(rf/subscribe [:rf.xray/target-frame]))
+                  "rf2-n4p5it — the second ensure-xray-frame! call must NOT
+                   revert :target-frame back to the head frame; the
+                   user's picker choice survives the remount"))))))))
+
+(deftest ensure-xray-frame-reset-for-test-restores-fresh-first-mount-pass
+  (testing "rf2-n4p5it — `mount/reset-for-test!` clears the run-once
+            guard so a subsequent `ensure-xray-frame!` call performs a
+            fresh first-mount seed again (the fixture-reset contract
+            every Xray test fixture relies on via
+            `test-support/reset-sentinels!`)"
+    (with-stub-document
+      (fn [_doc]
+        (let [{:keys [render-fn]} (mk-render-stub)]
+          (with-redefs [substrate-adapter/render render-fn
+                        rf/epoch-history (fn [_] [])]
+            (mount/open!)
+            (rf/with-frame :rf/xray
+              (rf/dispatch-sync [:rf.xray/set-target-frame :other-frame]))
+            ;; Without a reset, a second call is a guarded no-op (proven
+            ;; by the sibling test above).
+            (mount/reset-for-test!)
+            (mount/ensure-xray-frame!)
+            (rf/with-frame :rf/xray
+              (is (nil? @(rf/subscribe [:rf.xray/target-frame]))
+                  "post-reset, ensure-xray-frame! re-ran the seed hook —
+                   cold start (no pre-mount cascades) seeds :target-frame
+                   back to UNSELECTED (nil), proving the hook actually
+                   re-fired rather than staying guarded"))))))))
+
+;; -------------------------------------------------------------------------
 ;; (9) Teardown covers both mount singletons (rf2-yudol, rf2-sbfb7)
 ;; -------------------------------------------------------------------------
 ;;

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -1441,6 +1441,71 @@
       (rf/dispatch-sync [:rf.xray/clear-selected-dispatch-id])
       (is (nil? (:dispatch-id @(rf/subscribe [:rf.xray/focus])))))))
 
+;; ---- rf2-pqt7cb — select-dispatch-id head-id must thread show-ungrouped? --
+;;
+;; `:rf.xray/select-dispatch-id`'s head-id computation must match the
+;; sibling `:rf.xray/focus-event` handler's — both feed the same
+;; `focus-event-bundle-reducer`, whose LIVE/RETRO mode selection is
+;; `(= dispatch-id head-id)`. Pre-fix `select-dispatch-id` called
+;; `focusable-head-id` with the 1-arg form (hard-codes `show-ungrouped?
+;; false`), so with the opt-in ON it could compute a DIFFERENT head-id
+;; than `focus-event` for the identical buffer — diverging LIVE/RETRO.
+;;
+;; Repro: show-ungrouped? on, buffer [routed-a routed-b ungrouped]. The
+;; :ungrouped bucket sorts last (highest raw :id) so it's the user-
+;; visible head under the opt-in. Selecting routed-b (a non-head row)
+;; must pin RETRO on BOTH handlers.
+
+(defn- seed-buffer-with-ungrouped-head!
+  "Seed Xray's trace buffer with two routed dispatches plus one event
+  carrying NO `:rf.trace/dispatch-id` tag — `group-by-event` buckets it
+  under the synthetic `:ungrouped` id (registry-time emits / REPL evals
+  / frame lifecycle outside a drain). The ungrouped event's `:id` is
+  the highest, so it sorts last — the user-visible head once
+  `show-ungrouped?` reveals the bucket."
+  []
+  (trace-collector/seed-trace-for-test!
+    {:id 1 :op-type :rf.event :operation :rf.event/dispatched
+     :tags {:rf.trace/dispatch-id :routed-a
+            :frame :rf/default
+            :rf.event/v [:cart/routed-a]}})
+  (trace-collector/seed-trace-for-test!
+    {:id 2 :op-type :rf.event :operation :rf.event/dispatched
+     :tags {:rf.trace/dispatch-id :routed-b
+            :frame :rf/default
+            :rf.event/v [:cart/routed-b]}})
+  (trace-collector/seed-trace-for-test!
+    ;; No :rf.trace/dispatch-id tag → :ungrouped bucket.
+    {:id 3 :op-type :rf.event :operation :registry-time/emit
+     :tags {:frame :rf/default}}))
+
+(deftest select-dispatch-id-mode-matches-focus-event-with-show-ungrouped-rf2-pqt7cb
+  (testing "rf2-pqt7cb — with show-ungrouped? on, selecting a non-head
+            (per the full, :ungrouped-inclusive contract) row via
+            :rf.xray/select-dispatch-id must pin RETRO, matching what
+            :rf.xray/focus-event computes for the identical buffer +
+            dispatch-id. Pre-fix select-dispatch-id excluded :ungrouped
+            from its own head-id computation, so it picked :routed-b
+            itself as head and wrongly stayed LIVE — the spine would
+            then auto-advance away from the pinned selection on the
+            next trace, breaking the programmatic pin."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/settings-update :general :show-ungrouped? true])
+      (seed-buffer-with-ungrouped-head!)
+      (rf/dispatch-sync [:rf.xray/select-dispatch-id :routed-b :rf/default])
+      (let [select-mode (:mode @(rf/subscribe [:rf.xray/focus]))]
+        (is (= :retro select-mode)
+            "select-dispatch-id must pin RETRO — :ungrouped (not
+             :routed-b) is the show-ungrouped? head")
+        ;; Parity check: focus-event on the identical dispatch-id/buffer
+        ;; must compute the SAME mode (the divergence rf2-pqt7cb named).
+        (rf/dispatch-sync [:rf.xray/clear-selected-dispatch-id])
+        (rf/dispatch-sync [:rf.xray/focus-event :routed-b :rf/default])
+        (is (= select-mode (:mode @(rf/subscribe [:rf.xray/focus])))
+            "select-dispatch-id and focus-event must agree on LIVE/
+             RETRO mode for the identical buffer + dispatch-id")))))
+
 (deftest event-select-epoch-passive-scrub
   (testing ":rf.xray/select-epoch pins the spine focus epoch (passive
             scrub) — rf2-uy7nz: the single source of truth is

--- a/tools/xray/test/day8/re_frame2_xray/spine_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/spine_cljs_test.cljs
@@ -1798,3 +1798,98 @@
           ":target-frame stays on the head frame — no spurious re-key")
       (is (= [:e1 :e2 :e3] (mapv :epoch-id history))
           ":epoch-history is still the head frame's full ring"))))
+
+;; -------------------------------------------------------------------------
+;; (13) rf2-j5xjvt — spine STEP cross-frame reseeds :epoch-history
+;;
+;; Section (12) covers the CLICK handlers (focus-event, focus-epoch,
+;; select-dispatch-id) re-seeding `:epoch-history` onto a non-target
+;; frame's row before resolving its settling epoch (rf2-q8hvw /
+;; rf2-o1c3r). The STEP handlers (`:rf.xray/focus-event-prev` / `-next`,
+;; the `j` / `k` keys) had no equivalent: they resolved epoch-id against
+;; whatever `:epoch-history` ring happened to be current, so a step that
+;; lands in a frame other than the current `:target-frame` resolved
+;; `:epoch-id` to nil even though that frame's ring genuinely holds a
+;; settling epoch for the stepped row. Unlike section (12)'s fixture,
+;; `:target-frame` / `[:focus :frame]` are deliberately left UNSET here
+;; — a set `[:focus :frame]` scopes the step walk to one frame
+;; (rf2-oziyr picker-scoping), which would prevent the walk from ever
+;; crossing frames in the first place. A genuinely untouched picker
+;; (never seeded, or seeded then explicitly cleared) is what lets a
+;; single step land in a different frame — the repro this section
+;; drives.
+;; -------------------------------------------------------------------------
+
+(defn- mount-multi-frame-picker-never-touched! []
+  ;; Fresh framework rings — the runtime-reset fixture does NOT clear
+  ;; the epoch histories, so wipe them so this test owns the slot state.
+  (epoch-api/clear-history!)
+  (setup-xray-frame!)
+  (seed-framework-epoch-ring! :rf/default  [{:epoch-id :e1 :dispatch-id :c1}
+                                            {:epoch-id :e2 :dispatch-id :c2}
+                                            {:epoch-id :e3 :dispatch-id :c3}])
+  (seed-framework-epoch-ring! :cart-frame  [{:epoch-id :cart-e9 :dispatch-id :cart-c9}])
+  (seed-cascades! multi-frame-cascades)
+  ;; Deliberately no `:rf.xray/set-target-frame` dispatch — `:target-
+  ;; frame` and `[:focus :frame]` stay absent, so the step walk spans
+  ;; every frame (the true "picker never touched" state).
+  )
+
+(deftest focus-step-prev-cross-frame-reseeds-epoch-history-rf2-j5xjvt
+  (testing "rf2-j5xjvt — stepping PREV from the head lands on a
+            :cart-frame row (the whole-buffer walk, picker never
+            touched); the step must re-seed :epoch-history onto
+            :cart-frame BEFORE resolving the stepped row's settling
+            epoch, exactly as the click handlers do."
+    (mount-multi-frame-picker-never-touched!)
+    ;; RED baseline: with the slot never seeded, the cart cascade's
+    ;; epoch is absent from whatever (empty) ring the pre-fix reducer
+    ;; would have resolved against.
+    (let [boot-history (rf/with-frame :rf/xray
+                         @(rf/subscribe [:rf.xray/epoch-history]))]
+      (is (empty? boot-history)
+          "precondition: :epoch-history was never seeded")
+      (is (nil? (spine/epoch-id-for-event-bundle boot-history :cart-c9))
+          "RED baseline: resolving against the un-reseeded (empty) slot
+           yields nil (the bug)"))
+    ;; The actual failing path: dispatch the real step event.
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/focus-event-prev]))
+    ;; GREEN: the spine focus now carries the stepped row's epoch.
+    (let [r (focus-sub)]
+      (is (= :cart-c9 (:dispatch-id r))
+          "stepping prev from the head :c3 lands on :cart-c9 — the
+           previous row in the whole-buffer walk, settled in :cart-frame")
+      (is (= :cart-frame (:frame r)))
+      (is (= :cart-e9 (:epoch-id r))
+          "the stepped row's settling epoch resolves — was nil pre-fix"))
+    ;; The slot itself is now re-keyed onto the stepped row's frame.
+    (let [target  (rf/with-frame :rf/xray @(rf/subscribe [:rf.xray/target-frame]))
+          history (rf/with-frame :rf/xray @(rf/subscribe [:rf.xray/epoch-history]))]
+      (is (= :cart-frame target)
+          ":target-frame re-keyed onto the stepped row's frame")
+      (is (= [:cart-e9] (mapv :epoch-id history))
+          ":epoch-history is the stepped frame's ring contents"))))
+
+(deftest focus-step-same-frame-leaves-slot-untouched-rf2-j5xjvt
+  (testing "rf2-j5xjvt — stepping WITHIN the current target frame (the
+            picker/focus already scoped to :rf/default) is a no-op for
+            the :epoch-history slot — the re-seed only fires on an
+            actual frame change, mirroring the click handlers' same-
+            frame no-op (rf2-q8hvw)."
+    (mount-multi-frame-picker-untouched!)
+    ;; [:focus :frame] is pinned to :rf/default by the boot seed, so the
+    ;; step walk is scoped to :rf/default cascades only (rf2-oziyr) —
+    ;; stepping prev from head :c3 lands on :c2, same frame.
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/focus-event-prev]))
+    (let [r       (focus-sub)
+          target  (rf/with-frame :rf/xray @(rf/subscribe [:rf.xray/target-frame]))
+          history (rf/with-frame :rf/xray @(rf/subscribe [:rf.xray/epoch-history]))]
+      (is (= :c2 (:dispatch-id r)))
+      (is (= :e2 (:epoch-id r))
+          "same-frame step resolves the head frame's epoch unchanged")
+      (is (= :rf/default target)
+          ":target-frame stays on the head frame — no spurious re-key")
+      (is (= [:e1 :e2 :e3] (mapv :epoch-id history))
+          ":epoch-history is still the head frame's full ring"))))


### PR DESCRIPTION
## Summary

Three verified xray bug beads, all on `tools/xray/`:

- **rf2-j5xjvt** — the spine STEP handlers (`:rf.xray/focus-event-prev`/`-next`, `j`/`k`) never re-seeded `:epoch-history` for the stepped row's frame before resolving `:epoch-id`. A single step landing in a frame other than `:target-frame` resolved the stepped row's settling epoch to `nil` even though that frame's ring genuinely held it. Fix: new pure `spine/step-target-frame` helper lets the event handler learn the landing frame *before* calling `focus-step-reducer`, so it can `reseed-epoch-history-for-frame` first — mirroring the reseed-before-resolve order the click handlers (`:rf.xray/focus-event`, `:rf.xray/select-dispatch-id`) already follow (rf2-q8hvw/rf2-o1c3r).
- **rf2-pqt7cb** — `:rf.xray/select-dispatch-id` computed its head-id via `focusable-head-id`'s 1-arg form (hard-codes `show-ungrouped? false`), diverging from the sibling `:rf.xray/focus-event` handler's head detection. With the `show-ungrouped?` opt-in ON, the two handlers could pick a *different* head-id for the identical buffer, mis-selecting LIVE vs RETRO mode and letting the spine auto-advance away from a pinned selection. Fix: thread `spine/db->show-ungrouped?` into the head-id computation.
- **rf2-n4p5it** — `ensure-xray-frame!` had no run-once guard on its first-mount hook fan-out. `popout!` calls `(ensure-xray-frame!)` with the *same* default `frame-id` the inline shell already seeded, so popping out re-ran `::seed-trace-and-target-frame`, reverting `:target-frame` (and `:epoch-history`) back to the head frame even after the user had picked a different frame via the L1 switcher. Fix: a `seeded-frame-ids` run-once guard (per `frame-id`), with a `reset-for-test!` escape hatch wired into `test-support/reset-sentinels!` so every existing test fixture keeps getting a fresh first-mount pass.

Each fix ships a regression test and a spec reconciliation (per bead):

- rf2-j5xjvt — `spine_cljs_test.cljs` (2 new tests: cross-frame step reseed RED→GREEN, same-frame no-op); `tools/xray/spec/018-Event-Spine.md` §6 updated (new "Cross-frame STEP re-seed" paragraph + test-gates line).
- rf2-pqt7cb — `registry_cljs_test.cljs` (1 new test: mode parity between `select-dispatch-id` and `focus-event` with `show-ungrouped?` on); `tools/xray/spec/018-Event-Spine.md` §6 updated (new "head-aware mode selector" paragraph + `select-dispatch-id` added to the enumerated reseed handlers, which was already stale pre-existing this PR).
- rf2-n4p5it — `mount_cljs_test.cljs` (2 new tests: direct `ensure-xray-frame!` re-call preserves `:target-frame`, `reset-for-test!` restores a fresh pass); `tools/xray/spec/011-Launch-Modes.md` §Pop-out updated (new "reflect, not reset" paragraph).

## Quality gates

- `tools/xray/` → `clojure -M:test`: **1225 tests, 5667 assertions, 0 failures, 0 errors**
- `implementation/` → `npm run test:cljs` (full node-test suite, includes all new/changed xray tests): **8074 tests, 37080 assertions, 0 failures, 0 errors**
- `implementation/` → `npm run test:xray-feature-gate`: **16 scenarios, 0 failures, 13 matrix rows covered**
- `implementation/` → `npm run test:browser`: **233 tests, 763 assertions, 0 failures, 0 errors**

## Risks

- `mount/ensure-xray-frame!`'s new run-once guard is a `defonce` atom — any test fixture that calls `ensure-xray-frame!` (directly, via `open!`, or via `panels/mount-*!`) across multiple tests relies on `test-support/reset-sentinels!` (called from `reset-all!`/`reset-runtime!`) to reset it between tests. I audited every xray test file that touches this path (`mount_cljs_test.cljs`, `panels_mount_cljs_test.cljs`, `two_instance_isolation_cljs_test.cljs`, `static/shell_cljs_test.cljs`, `shell_cljs_test.cljs`, `settings/effects_cljs_test.cljs`, `init_filter_reset_cljs_test.cljs`, `core_cljs_test.cljs`) and confirmed each uses one of those helpers in its `:each` fixture — full node-test suite is green, confirming no cross-test leakage.
- `spine.cljs`'s registry.cljs paragraph enumerating the reseed-before-resolve handlers was already missing `:rf.xray/select-dispatch-id` (a pre-existing spec drift from the earlier rf2-o1c3r fix, unrelated to this bead cluster) — folded that correction in alongside the rf2-j5xjvt addition since I was already editing the same paragraph.