### PR TITLE
fix(machines-viz): post-elk region-touch transitive ancestor walk + same-parent back-edge filter (rf2-olie1s)

### DIFF
--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/post_elk.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/post_elk.cljc
@@ -278,6 +278,42 @@
 ;; the (now-transposed) handles — the renderer's documented no-route
 ;; fallback.
 
+(defn- node-parent-map
+  "rf2-olie1s — `{child-id parent-id}` for every parsed node that carries a
+  `:parent-id` (i.e. every node that is NOT root-level). Pure: parsed
+  `:nodes` → map.
+
+  Shared by every consumer that needs 'what container does this node sit
+  DIRECTLY inside': `region-descendant-ids` (direct region membership),
+  `region-touch?`'s ancestor walk (`ancestor-chain`, transitive region
+  membership at any nesting depth), and the back-edge same-parent filter
+  (`same-parent?`, the coordinate-frame guard)."
+  [nodes]
+  (into {}
+        (keep (fn [n]
+                (when-let [p (:parent-id n)]
+                  [(:id n) p])))
+        nodes))
+
+(defn- ancestor-chain
+  "rf2-olie1s — a node's full ancestor chain: `id` itself plus every
+  ancestor reached by walking `:parent-id` transitively out to the root.
+  Pure: a `node-parent` map (from `node-parent-map`) + a node id → set of
+  ids.
+
+  A one-hop `:parent-id` lookup only sees a node's DIRECT container. Spec
+  005 allows a compound state to nest inside a parallel region, so a leaf
+  two (or more) levels deep sits behind an intermediate compound id, not the
+  region id, on a one-hop test — `region-touch?`'s bug. The full transitive
+  closure is the only correct answer to 'is this node contained, at any
+  depth, inside X'."
+  [node-parent id]
+  (loop [acc #{id} cur id]
+    (let [p (get node-parent cur)]
+      (if (and p (not (acc p)))
+        (recur (conj acc p) p)
+        acc))))
+
 (defn region-descendant-ids
   "rf2-lamdfl — for each region CONTAINER id, the set of its DIRECT child
   node-ids (region states + their synthetic event-nodes). Pure: parsed graph
@@ -290,9 +326,7 @@
   interior transpose moves the whole region body, not just the state boxes."
   [{:keys [nodes edges]}]
   (let [region-ids   (into #{} (comp (filter :region?) (map :id)) nodes)
-        node-parent  (into {} (keep (fn [n]
-                                      (when-let [p (:parent-id n)] [(:id n) p]))
-                                    nodes))
+        node-parent  (node-parent-map nodes)
         ;; state-id → its region container parent (only states whose parent
         ;; is a region container)
         state->region (into {} (filter (fn [[_ p]] (contains? region-ids p)))
@@ -529,18 +563,25 @@
           ;; cross-region): the transpose invalidates ELK's absolute bend-
           ;; points; the renderer falls back to the clean bezier through the
           ;; transposed handles.
-          node-parent   (into {} (keep (fn [n]
-                                         (when-let [p (:parent-id n)]
-                                           [(:id n) p]))
-                                       nodes))
+          ;;
+          ;; rf2-olie1s — a one-hop `:parent-id` test misses an edge whose
+          ;; endpoint is a leaf inside a compound state NESTED inside a
+          ;; region (Spec 005 allows arbitrary nesting depth): the leaf's
+          ;; DIRECT parent is the nested compound's own id, not the region
+          ;; id, so a one-hop test never sees it — its absolute ELK edge-
+          ;; points then survive the transpose untouched even though the
+          ;; compound container was just repositioned. Walk the FULL
+          ;; ancestor chain (`ancestor-chain`, transitive closure over
+          ;; `:parent-id`) so any depth of nesting inside a region is caught
+          ;; (this also subsumes the old direct-region-id checks — `id` is
+          ;; always its own first link in the chain).
+          node-parent   (node-parent-map nodes)
           region-touch?
           (fn [e]
-            (let [sp (get node-parent (:source e))
-                  tp (get node-parent (:target e))]
-              (or (contains? region-ids sp)
-                  (contains? region-ids tp)
-                  (contains? region-ids (:source e))
-                  (contains? region-ids (:target e)))))
+            (let [s-chain (ancestor-chain node-parent (:source e))
+                  t-chain (ancestor-chain node-parent (:target e))]
+              (boolean (or (some region-ids s-chain)
+                           (some region-ids t-chain)))))
           stale-edge-ids
           (into #{}
                 (comp (filter region-touch?)
@@ -583,12 +624,18 @@
   64)
 
 (defn- node-center
-  "Absolute centre `{:x :y}` of a positioned node. `positions` holds parent-
-  relative coords for nested nodes; the back-edge geometry compares nodes on
-  the SAME spine (siblings under one container), so a consistent frame
-  cancels — we use the recorded position directly (callers pass the absolute
-  map for top-level spines, the common back-edge case: door/gate/brew back-
-  edges are all top-level)."
+  "Centre `{:x :y}` of a positioned node, in WHATEVER frame `positions`
+  records it — root-relative for a top-level node, parent-relative for a
+  nested one (`elk-result->positions`). Valid ONLY when the caller compares
+  two nodes sharing that same frame, i.e. the SAME immediate container (both
+  root-level, or both children of the same parent) — never compare across
+  containers.
+
+  rf2-olie1s — `reroute-back-edges` enforces that constraint by restricting
+  back-edge CANDIDATES to same-parent edges (`same-parent?`) before either
+  `back-edge?` or `back-edge-detour` ever calls this; a nested-vs-root or
+  cross-container pair would otherwise mix frames and produce a nonsensical
+  geometric comparison (mis-detected sunk status, a garbage detour)."
   [positions id]
   (when-let [{:keys [x y width height]} (get positions id)]
     {:x (+ x (/ (or width projection/state-node-min-width) 2))
@@ -681,18 +728,47 @@
                         {:x (:x tc) :y detour-y})
                       tc]}))))
 
+(defn- same-parent?
+  "rf2-olie1s — do this edge's source and target sit DIRECTLY inside the
+  same container — the same `:parent-id`, or both root-level (no
+  `:parent-id` at all)? Pure: a `node-parent` map (from `node-parent-map`) +
+  a parsed edge → bool.
+
+  `node-center` reads a node's position as a single consistent frame — true
+  only for same-container siblings. `elk-result->positions` records PARENT-
+  RELATIVE coords for a nested node, so a nested-vs-root or cross-container
+  pair would compare positions recorded in DIFFERENT frames (mis-detected
+  sunk status, a garbage detour written into `:edge-points`). Restricting
+  back-edge candidates to same-parent pairs before `back-edge?` ever runs
+  keeps every comparison inside the single frame `node-center` is valid
+  for."
+  [node-parent edge]
+  (= (get node-parent (:source edge)) (get node-parent (:target edge))))
+
 (defn reroute-back-edges
   "rf2-gnrkke — the back-edge return-route detour pass (§4.3.1 close). Pure:
   `{:positions :edge-points :edge-labels}` + parsed graph + resolved
   direction → the same shape with every sunk back-edge's event-node lifted to
   mid-height and its `__in`/`__out` segments rerouted as a side-detour.
 
+  rf2-olie1s — candidates are restricted to SAME-PARENT edges (`same-
+  parent?`: source + target share one `:parent-id`, or both are root-level)
+  before `back-edge?` ever runs. A nested-vs-root or cross-hierarchy edge
+  would otherwise have its endpoints compared in DIFFERENT coordinate
+  frames (`elk-result->positions` records parent-relative coords for nested
+  nodes) — mis-detecting sunk status and writing a nonsensical detour.
+  Excluding those candidates up front means a nested/cross-hierarchy
+  back-edge is simply left untouched (its ELK route stands) rather than
+  corrupted.
+
   No back-edge ⇒ the layout is returned unchanged (a non-cyclic / already-
   compact machine is untouched). Only back-edges whose event-node SANK
   (`back-edge?`) are rerouted, so a back-edge ELK already placed compactly
   keeps its route."
   [{:keys [positions edge-points] :as layout} parsed direction]
-  (let [back-edges (filter #(back-edge? % positions direction) (:edges parsed))]
+  (let [node-parent (node-parent-map (:nodes parsed))
+        candidates  (filter #(same-parent? node-parent %) (:edges parsed))
+        back-edges  (filter #(back-edge? % positions direction) candidates)]
     (if (empty? back-edges)
       layout
       (reduce

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/post_elk_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/post_elk_cljs_test.cljc
@@ -22,7 +22,12 @@
   Positions are built PROGRAMMATICALLY from the parsed graph (via the public
   `layout/node-id` + `projection/event-node-id`) so the tests pin BEHAVIOUR,
   not a particular id-string scheme — a stub layout result keyed off the
-  real ids the live ELK pass would produce."
+  real ids the live ELK pass would produce.
+
+  Also covers rf2-olie1s: `region-touch?`'s transitive-ancestor-walk (a
+  nested-compound-in-region edge is region-touched, not just a one-hop
+  region child) and `reroute-back-edges`' same-parent candidate filter (a
+  cross-hierarchy/nested-vs-root back-edge is excluded, never mis-detected)."
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test    :refer-macros [deftest is testing]])
             [clojure.string :as str]
@@ -92,6 +97,49 @@
              :video {:initial :hidden
                      :states  {:hidden {:on {:show :shown}}
                                :shown  {:on {:hide :hidden}}}}}})
+
+(def nested-compound-in-region-machine
+  "rf2-olie1s — a parallel machine whose `:audio` region nests a COMPOUND
+  state (`:playing`, with its own `:low`/`:high` substates) so `:low`/`:high`
+  sit TWO hops from the region container: their DIRECT `:parent-id` is
+  `:playing`'s own (region-scoped) id, NOT the region container id. Exercises
+  `region-touch?`'s transitive-ancestor-walk fix — an edge between the two
+  nested leaves must still have its stale ELK route cleared when the region
+  transposes/re-stacks, even though neither leaf's direct parent is the
+  region."
+  {:type    :parallel
+   :regions {:audio {:initial :muted
+                     :states  {:muted   {:on {:unmute :playing}}
+                               :playing {:initial :low
+                                         :states  {:low  {:on {:raise :high}}
+                                                   :high {:on {:lower :low}}}
+                                         :on {:mute :muted}}}}
+             :video {:initial :hidden
+                     :states  {:hidden {:on {:show :shown}}
+                               :shown  {:on {:hide :hidden}}}}}})
+
+(def nested-back-edge-machine
+  "rf2-olie1s — a compound (non-parallel) machine whose nested leaf `:step2`
+  (inside the `:working` compound) transitions back to `:idle`, a TOP-LEVEL
+  sibling of `:working` — a genuine back-edge shape, but one whose source
+  (`:working__step2`, parented to `:working`) and target (`:idle`, parented
+  to the machine's synthetic root-container) carry DIFFERENT `:parent-id`.
+  The target is an explicit vector-path (`[:idle]`) because a bare keyword
+  target from inside a nested compound resolves SIBLING-relative (Spec 005 /
+  `resolve-target-path`) — `:reset :idle` would land on `:working/:idle`,
+  not the top-level state.
+
+  Exercises `reroute-back-edges`' same-parent filter: this cross-hierarchy
+  candidate must be EXCLUDED from back-edge detection/reroute, because its
+  endpoints' positions are recorded in different coordinate frames
+  (`:working`-relative for `:step2`, root-container-relative for `:idle`) —
+  comparing them geometrically is meaningless even when it happens to look
+  'sunk'."
+  {:initial :idle
+   :states  {:idle    {:on {:start :working}}
+             :working {:initial :step1
+                       :states  {:step1 {:on {:next :step2}}
+                                 :step2 {:on {:reset [:idle]}}}}}})
 
 ;; ---- helpers -----------------------------------------------------------
 
@@ -472,6 +520,34 @@
       (is (not (contains? (:edge-points out) (str (:id an-edge) "__in"))))
       (is (not (contains? (:edge-points out) (str (:id an-edge) "__out")))))))
 
+(deftest transpose-clears-nested-compound-region-edge-routes
+  ;; rf2-olie1s — region-touch? must walk the FULL ancestor chain, not just
+  ;; one :parent-id hop. :low/:high sit inside :playing, a compound state
+  ;; nested INSIDE the :audio region — their DIRECT :parent-id is
+  ;; :playing's own id, not the region id, so a one-hop region-touch? test
+  ;; misses this edge entirely and its stale absolute ELK route would
+  ;; survive the transpose untouched even though :playing (and the region)
+  ;; were just repositioned.
+  (let [parsed (layout/project-definition nested-compound-in-region-machine)
+        low->high (first (filter
+                            (fn [e]
+                              (and (= (:source e)
+                                      (layout/region-scoped-id :audio [:playing :low]))
+                                   (= (:target e)
+                                      (layout/region-scoped-id :audio [:playing :high]))))
+                            (:edges parsed)))
+        seeded {:positions (:positions (col-positions parsed))
+                :edge-points {(str (:id low->high) "__in")  [{:x 1 :y 1} {:x 2 :y 2}]
+                              (str (:id low->high) "__out") [{:x 3 :y 3} {:x 4 :y 4}]}
+                :edge-labels {}}
+        out (post-elk/transpose-parallel-regions seeded parsed)]
+    (testing "sanity: the fixture parses the nested-compound low->high edge"
+      (is (some? low->high)))
+
+    (testing "the low->high edge (two hops from the region) IS region-touched"
+      (is (not (contains? (:edge-points out) (str (:id low->high) "__in"))))
+      (is (not (contains? (:edge-points out) (str (:id low->high) "__out")))))))
+
 ;; ====================================================================
 ;; Step 3 — back-edge return-route detour (rf2-gnrkke)
 ;; ====================================================================
@@ -636,6 +712,44 @@
         stub   (col-positions parsed)]
     (testing "a machine with no sunk back-edge is returned unchanged"
       (is (= stub (post-elk/reroute-back-edges stub parsed :tb))))))
+
+(deftest reroute-back-edges-excludes-cross-hierarchy-candidates
+  ;; rf2-olie1s — node-center's centre read is only valid within one
+  ;; coordinate frame (same :parent-id). :step2 (parented to :working) and
+  ;; :idle (parented to the synthetic root-container, a DIFFERENT parent)
+  ;; sit in DIFFERENT frames; a bare geometric comparison of their positions
+  ;; can look "sunk" even though the comparison is meaningless.
+  ;; reroute-back-edges must exclude this candidate rather than mis-detect +
+  ;; reroute it.
+  (let [parsed (layout/project-definition nested-back-edge-machine)
+        back-e (first (filter (fn [e]
+                                (and (= (:source e) (layout/node-id [:working :step2]))
+                                     (= (:target e) (layout/node-id [:idle]))))
+                              (:edges parsed)))
+        ev-id  (projection/event-node-id back-e)
+        ;; hand-built positions: :idle at the top (y 0), :step2 lower
+        ;; (y 200), and the reset event-node sunk BELOW both (y 300) — the
+        ;; naive geometric signature back-edge? flags as sunk, even though
+        ;; :idle and :step2/the event are recorded relative to DIFFERENT
+        ;; parents (different frames; the raw comparison is bogus).
+        positions {(layout/node-id [:idle])          {:x 200 :y 0   :width 120 :height 50}
+                   (layout/node-id [:working :step1]) {:x 200 :y 100 :width 120 :height 50}
+                   (layout/node-id [:working :step2]) {:x 200 :y 200 :width 120 :height 50}
+                   ev-id                              {:x 200 :y 300 :width 96  :height 34}}
+        stub {:positions positions :edge-points {} :edge-labels {}}
+        out  (post-elk/reroute-back-edges stub parsed :tb)]
+    (testing "sanity: the fixture parses the cross-hierarchy back-edge"
+      (is (some? back-e)))
+
+    (testing "sanity: the naive geometric check WOULD flag this cross-hierarchy edge as sunk"
+      (is (true? (post-elk/back-edge? back-e positions :tb))))
+
+    (testing "reroute-back-edges excludes it — the event-node position is UNTOUCHED"
+      (is (= (get positions ev-id) (get-in out [:positions ev-id]))))
+
+    (testing "reroute-back-edges excludes it — no detour routes are written"
+      (is (not (contains? (:edge-points out) (str (:id back-e) "__in"))))
+      (is (not (contains? (:edge-points out) (str (:id back-e) "__out")))))))
 
 ;; ====================================================================
 ;; Composing pass


### PR DESCRIPTION
## Summary

Two silent geometry bugs on `tools/machines-viz/src/day8/re_frame2_machines_viz/chart/post_elk.cljc`, both scoped to the opt-in `:direction :auto` post-ELK pass (rf2-olie1s, split from rf2-5pv3sh finding 3-4).

**Finding 3 — `region-touch?` one-hop parent test.** The stale-route-clearing predicate only checked an edge's DIRECT `:parent-id` against the region-id set. Spec 005 allows a compound state nested inside a parallel region; a leaf inside such a nested compound sits TWO (or more) hops from the region container, so a one-hop test never flagged an edge touching that leaf — its absolute ELK edge-points survived the region transpose/re-stack untouched even though the compound container was just repositioned.

Fix: walk the full `:parent-id` ancestor chain (`ancestor-chain`, transitive closure) instead of a single lookup. Extracted a shared `node-parent-map` helper (previously duplicated inline in both `region-descendant-ids` and the `region-touch?` closure).

**Finding 4 — `reroute-back-edges` no same-parent filter.** `node-center`'s absolute-centre read is only valid within one consistent coordinate frame (`elk-result->positions` records parent-relative coords for nested nodes). `reroute-back-edges` ran `back-edge?`/`back-edge-detour` over EVERY edge with no same-parent guard, so a nested-vs-root or cross-hierarchy edge could have its endpoints compared in DIFFERENT frames — mis-detecting sunk status and writing a nonsensical detour into `:edge-points`.

Fix: added `same-parent?` and restrict back-edge candidates (in `reroute-back-edges`) to edges whose source and target share one `:parent-id` before `back-edge?` ever runs. A nested/cross-hierarchy back-edge is now simply left untouched (its ELK route stands) rather than corrupted.

## Spec reconciliation

`tools/machines-viz/spec/001-Topology-Parity.md` §4.3.1/§4.3.2 document the CORRECT geometry contract (back-edge detected geometrically and rerouted; region containment via `:parent-id`) — spec unchanged because these are bug fixes bringing the implementation in line with the already-documented contract, not a change to any normative statement. No spec file needed updating.

## Quality gates

- `clojure -M:test` (from `tools/machines-viz/`): 568 tests, 2018 assertions, 0 failures, 0 errors.
- `npm run test:cljs` (from `implementation/`, exercises the shared machines-viz node-test build): 8085 tests, 37116 assertions, 0 failures, 0 errors.
- `npm run test:browser` (from `implementation/`): 235 tests, 773 assertions, 0 failures, 0 errors.
- Added one regression test per finding, both independently verified to FAIL against the pre-fix source (reverted `post_elk.cljc` to `HEAD`, reran with the new tests in place — 5 assertion failures across the two new tests) and PASS against the fix.

## Risks

- Both fixes only change behaviour on the opt-in `:direction :auto` path for machines that exhibit the specific pattern (nested compound inside a parallel region; a back-edge whose endpoints sit under different containers) — the default `:direction :tb`/`:lr` path and every existing corpus fixture (flat back-edges, flat parallel regions) is provably unaffected (full suite green, and the fix subsumes the old direct-region-id checks so no behaviour regresses for the one-hop case).
- `region-descendant-ids` (used for the region-interior TRANSPOSE, not the edge-route clearing) still only collects DIRECT region children — a nested-compound-in-region leaf's own position isn't re-transposed by that step. That's a distinct, pre-existing limitation from the one this bead's findings describe (which is specifically about `region-touch?`'s stale-route clearing and `reroute-back-edges`' frame mixing); flagging it here for visibility rather than expanding this PR's scope.

Branch off `origin/main` post-#5263/#5266/#5267 merges (rebased clean, no conflicts).