### PR TITLE
fix(pair-mcp): suffix build-id match only for a bare (no-namespace) request so a namespaced id can't be redirected (rf2-uyfkcs)

### DIFF
--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/probe.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/probe.cljs
@@ -450,11 +450,17 @@
   "Resolve `requested` (a build-id keyword) against the `running` vector of
   build-id keywords by exact-or-unique-suffix match. Returns
   the canonical running keyword on a hit, else `requested` unchanged (so a
-  no/ambiguous match falls through to the diagnostic ladder). Pure."
+  no/ambiguous match falls through to the diagnostic ladder). Pure.
+
+  The suffix rule (step 2 above) applies ONLY when `requested` is itself
+  bare (no namespace) — a namespaced request that isn't an exact match
+  falls straight through to `requested` unchanged, never redirected to a
+  same-bare-named build in a different namespace."
   [requested running]
   (cond
     (nil? requested) requested
     (some #(= requested %) running) requested
+    (some? (namespace requested)) requested
     :else
     (let [tail     (name requested)
           suffixed (filterv #(= tail (name %)) running)]

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/build_id_resolver_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/build_id_resolver_test.cljs
@@ -77,6 +77,21 @@
          (probe/match-running-build :typo [:examples/machine-epochs]))
       "no match returns the requested id so the diagnostic ladder fires"))
 
+(deftest match-running-build-namespaced-request-never-redirected
+  ;; The suffix rule (rule 2) is documented as applying ONLY to a BARE
+  ;; (no-namespace) requested id. A fully-namespaced request that doesn't
+  ;; exactly match must fall through UNCHANGED — never redirected by
+  ;; bare-name suffix match to a same-named build in a different
+  ;; namespace, even when that other build is the sole suffix match.
+  (is (= :examples/step-deck
+         (probe/match-running-build :examples/step-deck [:other/step-deck]))
+      "a namespaced request with no exact match falls through unchanged, NOT redirected to :other/step-deck")
+  ;; The bare-name suffix-match behaviour keeps working for a genuinely
+  ;; bare request against the very same running set.
+  (is (= :other/step-deck
+         (probe/match-running-build :step-deck [:other/step-deck]))
+      "a genuinely bare request still suffix-matches the unique running build"))
+
 ;; ---------------------------------------------------------------------------
 ;; canonicalize-build! — the async resolver + alias caching.
 ;; ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`match-running-build` in `tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/probe.cljs` applied its unique-suffix match rule to *any* requested build id, including a fully-namespaced one. The design comment above the function already documented that the suffix rule is meant only for a bare (no-namespace) requested id, but the code never actually checked `(namespace requested)` — it just name-matched.

Repro (per rf2-uyfkcs): requesting `:examples/step-deck` (not running) while exactly one other running build shares the bare name `step-deck` in a different namespace (`:other/step-deck`) silently resolved to `:other/step-deck` instead of falling through to `:build-not-running` — pointing eval/dispatch/read at the wrong app. This contradicts the project's never-silently-pick-a-build posture.

## Fix

Added a `(some? (namespace requested)) requested` arm ahead of the suffix branch in `match-running-build`, so a namespaced request that isn't an exact match now falls straight through unchanged (→ `:build-not-running` via the existing diagnostic ladder), rather than being redirected via bare-name suffix match. Bare-name requests are unaffected and still suffix-match as before. Updated the function's docstring to state this explicitly.

## Test

Added `match-running-build-namespaced-request-never-redirected` to `build_id_resolver_test.cljs`:
- a namespaced request (`:examples/step-deck`) with a same-bare-name running build in a different namespace (`:other/step-deck`) resolves to the request unchanged (falls through to `:build-not-running`), NOT redirected to the other namespace's build.
- a genuinely bare request (`:step-deck`) against the same running set still suffix-matches to `:other/step-deck`, confirming the bare-name behaviour is preserved.

## Quality gates

- `npm test` (shadow-cljs compile server-test + node out/server-test.js): **1144 tests, 3834 assertions, 0 failures, 0 errors**
- `npm run check:descriptors`: **OK: tool-descriptors.edn in sync (30 tools)**

## Risk

Low. Change is a single added `cond` guard in a pure function (`match-running-build`), scoped entirely to `tools/re-frame2-pair-mcp/`. No other module touched. Behaviour change is strictly a removal of an incorrect silent-redirect path for namespaced ids — bare-id suffix matching, exact matching, and the ambiguous/no-match fallthrough are all unchanged.