### PR TITLE
fix(story): mixed-run false-green + plan :story/id stamp + events-only frame-provider mount ordering (rf2-l3lyal/xk8oz4/4iu7tu)

### DIFF
--- a/tools/story/src/re_frame/story/plan.cljc
+++ b/tools/story/src/re_frame/story/plan.cljc
@@ -1488,8 +1488,13 @@
         ;; plan the single source of truth, so the canvas + render-variant
         ;; resolve the identical stack. Each layer falls through to `[]`
         ;; when absent — the empty-collection concat is render-transparent.
-        story-decos  (vec (when-let [sid (args/parent-story-id id)]
-                            (story-deco-lk sid)))
+        ;; The parent story id (nil for an inline plan-map target with no
+        ;; `:variant/id`, or any id outside the variant-id grammar). Bound
+        ;; ONCE here — both the story-decorator lookup below AND the
+        ;; `:story/id` stamp on the returned plan (rf2-xk8oz4) read this
+        ;; SAME resolution, so they can never disagree about the parent.
+        sid          (args/parent-story-id id)
+        story-decos  (vec (when sid (story-deco-lk sid)))
         full-decos   (vec (concat global-decos
                                   story-decos
                                   frag-decorators
@@ -1637,6 +1642,16 @@
                                       #{} bodies)
              :explain         explain}
       source (assoc :source source)
+      ;; The parent story id (rf2-xk8oz4). `plan-hash-input-keys` includes
+      ;; `:story/id` SPECIFICALLY so two variants under different stories
+      ;; with otherwise-identical bodies do not collide — but this stamp
+      ;; is the only site that ever populates the slot the hash reads,
+      ;; and it was missing: `select-keys` silently dropped the absent
+      ;; key, so `plan-hash` was actually taken over `[:world :script
+      ;; :expect :required-runner :tags]` alone. Present only when a
+      ;; parent resolves (an inline plan-map target with no `:variant/id`
+      ;; carries no slot — render-transparent).
+      sid    (assoc :story/id sid)
       ;; The RAW (pre-`[:arg]`-substitution) sub-overrides.
       ;; A SIBLING of `:world` (NOT inside it) so it stays OUT of
       ;; `plan-hash-input-keys` — it is fully derivable from the resolved

--- a/tools/story/src/re_frame/story/result.cljc
+++ b/tools/story/src/re_frame/story/result.cljc
@@ -826,7 +826,19 @@
   positive signal (the vacuous-green duality). A run whose verdict is
   worse than any single assertion (the tape floor flipped a green
   assertion set to `:fail`) emits a run-level report carrying the floor
-  failure so the test surfaces it."
+  failure so the test surfaces it.
+
+  A `:cannot-run` verdict driven by a RUN-LEVEL refusal (`:cannot-run` on
+  the result — a `requirement-refusal` the runner could not even attempt,
+  e.g. `:rf.assert/visual-snapshot` under `:headless`) never lands in
+  `:assertions` — it is a run-level slot, not a per-assertion record — so
+  gating the run-level report on `(empty? assertions)` let a run with
+  >= 1 PASSING assertion alongside the refusal fall through every branch
+  and read false-GREEN (rf2-l3lyal: the refusal never reached
+  `clojure.test`). The gate is instead 'no per-assertion report already
+  conveys the refusal' — `(not-any? #(= :fail (:type %)) per-assertion)` —
+  so a mixed run (an unrelated passing assertion + a run-level refusal)
+  still gets the run-level `:cannot-run` report."
   [{:keys [status assertions schema-violations cannot-run] :as _result}]
   (let [per-assertion (mapv assertion->report assertions)
         worst         (requirements/aggregate-status assertions cannot-run)
@@ -843,7 +855,8 @@
             :expected :rf.story/clean-tape
             :actual   (or (seq schema-violations) :rf.story/tape-failure)}]
 
-          (and (= :cannot-run status) (empty? assertions))
+          (and (= :cannot-run status)
+               (not-any? #(= :fail (:type %)) per-assertion))
           [{:type :fail
             :message "run :cannot-run — the runner could not attempt this plan"
             :expected :rf.story/runnable

--- a/tools/story/src/re_frame/story/ui/canvas.cljs
+++ b/tools/story/src/re_frame/story/ui/canvas.cljs
@@ -474,14 +474,6 @@
         sub-ovr        (resolve-sub-overrides variant-id eff-args)
         substrates     (variant-substrate-set variant-id)
         multi?         (and variant-id (> (count substrates) 1))
-        ;; Skeleton gating. The lifecycle machine reports
-        ;; :pre-mount / :mounting / :loading while the four-phase
-        ;; loader cascade runs; once :ready / :error lands, the
-        ;; first-rendered sentinel flips (in component-did-mount /
-        ;; -did-update) and the skeleton hides.
-        lifecycle-phase (try (story-loaders/current-state variant-id)
-                             (catch :default _ nil))
-        first?         (variant-first-rendered? variant-id)
         ;; Events-only variants take the lifecycle fast-
         ;; path (`mount-ready!` jumps :pre-mount → :ready directly) so
         ;; the skeleton must not engage even on the brief render
@@ -490,6 +482,44 @@
         ;; `loaders/events-only-variant?`.
         events-only?   (story-loaders/events-only-variant?
                          variant-body decorator-pack)
+        ;; rf2-4iu7tu: events-only?'s skeleton suppression (below /
+        ;; `loading-phase?`'s events-only? arm) means THIS render — not
+        ;; `component-did-mount` — is the one that reaches `frame-provider`
+        ;; further down. `component-did-mount` / `run-if-needed!` normally
+        ;; allocates the frame, but that fires AFTER React commits this
+        ;; render, and `ensure-variant-frame!` (rf2-zme7)'s
+        ;; selection-watcher pre-allocation only fires on a `:selected-
+        ;; variant` CHANGE — a variant already selected before the canvas
+        ;; ever mounts (deep link / persisted selection read synchronously,
+        ;; or a bare test harness pre-seeding `:selected-variant`) sees
+        ;; neither. Without the frame, `[rf/frame-provider {:frame
+        ;; variant-id} …]` further down FAILS LOUD
+        ;; (`:rf.error/frame-provider-frame-absent`) — the exact race the
+        ;; rf2-j8hklm viewport-toggle DOM test (#5265) had to route around
+        ;; by omitting `:component` from its probe variant.
+        ;;
+        ;; `run-if-needed!` ENSURES the frame HERE, synchronously, during
+        ;; render — mirroring `re-frame.views.owned-frame/ensure-frame-fc`'s
+        ;; render-phase-ensure justification ("an effect would run after
+        ;; the first child render and race descendant subscribes/
+        ;; dispatches"). It is idempotent (keyed on `canvas-last-run-key`),
+        ;; so calling it here AND again from `component-did-mount` /
+        ;; `component-did-update` never double-runs the variant's `:events`
+        ;; — the second call is a no-op once the key matches. Scoped to
+        ;; `events-only?` only: non-events-only variants stay on the
+        ;; skeleton-gated path below, which already avoids this render ever
+        ;; reaching `frame-provider` before allocation. Runs BEFORE
+        ;; `lifecycle-phase` / `first?` below so those reads see the
+        ;; POST-allocation state (the fast-path `:ready`) on this same pass.
+        _              (when events-only? (run-if-needed!))
+        ;; Skeleton gating. The lifecycle machine reports
+        ;; :pre-mount / :mounting / :loading while the four-phase
+        ;; loader cascade runs; once :ready / :error lands, the
+        ;; first-rendered sentinel flips (in component-did-mount /
+        ;; -did-update) and the skeleton hides.
+        lifecycle-phase (try (story-loaders/current-state variant-id)
+                             (catch :default _ nil))
+        first?         (variant-first-rendered? variant-id)
         ;; A recorded assertion proves the loader cascade
         ;; resolved its outcome (success path → :ready; failure paths
         ;; like loader-never-completes / loader-rejects park at

--- a/tools/story/test/re_frame/story/plan_test.cljc
+++ b/tools/story/test/re_frame/story/plan_test.cljc
@@ -11,6 +11,7 @@
   (:require [clojure.test :refer [deftest is testing]]
             [malli.core :as m]
             [re-frame.story.assertions :as assertions]
+            [re-frame.story.fingerprint :as fingerprint]
             [re-frame.story.plan :as plan]
             [re-frame.story.sub-overrides :as sub-overrides]))
 
@@ -74,6 +75,54 @@
       (is (= [[:dispatch [:b]]] (:script p)))
       (is (= [nil] (:source-chain p))
           "the single anonymous body is the whole source chain"))))
+
+;; ---- :story/id stamp — plan-hash's cross-story collision guard (rf2-xk8oz4)
+
+(deftest compiled-plan-is-stamped-with-parent-story-id
+  (testing "a registered variant's compiled plan carries :story/id (the
+            variant's namespace) — fingerprint's plan-hash-input-keys
+            includes :story/id SPECIFICALLY so two variants under
+            different stories with identical bodies do not collide, but
+            compile-body never stamped it (rf2-xk8oz4): select-keys
+            silently dropped the absent key, so plan-hash was actually
+            taken over [:world :script :expect :required-runner :tags]
+            alone"
+    (let [m {:story.counter/at-five
+             {:setup  [[:dispatch [:counter/init 5]]]
+              :script [[:dispatch [:counter/inc]]]}}
+          p (plan-of :story.counter/at-five m)]
+      (is (= :story.counter (:story/id p))
+          "the parent story id is derived from the variant id's namespace")))
+  (testing "an inline map target with NO :variant/id stamps no :story/id
+            (nothing to derive it from — render-transparent)"
+    (let [p (plan/variant-plan {:setup [[:dispatch [:a]]]})]
+      (is (not (contains? p :story/id))))))
+
+(deftest identical-variant-bodies-under-different-stories-do-not-collide
+  (testing "rf2-xk8oz4 — two variants with STRUCTURALLY IDENTICAL bodies
+            (same :world / :script / :expect / :required-runner / :tags)
+            registered under DIFFERENT parent stories compile to DIFFERENT
+            plan-hashes, driving the REAL compiler (not a hand-stamped
+            plan — the test gap the bead called out). Pre-fix, compile-body
+            never populated :story/id, so plan-hash's :story/id input was
+            always absent and these collided."
+    (let [body {:setup      [[:dispatch [:counter/init 5]]]
+                :script     [[:dispatch [:counter/inc]]]
+                :assertions [[:rf.assert/path-equals [:count] 6]]}
+          m    {:story.a/same body :story.b/same body}
+          pa   (plan-of :story.a/same m)
+          pb   (plan-of :story.b/same m)]
+      (is (= :story.a (:story/id pa)))
+      (is (= :story.b (:story/id pb)))
+      ;; every plan-hash-input-keys slot but :story/id is identical
+      (is (= (:world pa) (:world pb)))
+      (is (= (:script pa) (:script pb)))
+      (is (= (:expect pa) (:expect pb)))
+      (is (= (:required-runner pa) (:required-runner pb)))
+      (is (= (:tags pa) (:tags pb)))
+      (is (not= (fingerprint/plan-hash pa) (fingerprint/plan-hash pb))
+          "the cross-story collision guard is now LIVE — identical bodies
+           under different stories hash DIFFERENTLY"))))
 
 ;; ---- args + [:arg key] substitution -------------------------------------
 

--- a/tools/story/test/re_frame/story/result_test.cljc
+++ b/tools/story/test/re_frame/story/result_test.cljc
@@ -652,6 +652,28 @@
       (is (= :fail (:type (first reports))))
       (is (re-find #":cannot-run" (:message (first reports)))))))
 
+(deftest result->reports-mixed-run-cannot-run-does-not-mask-refusal
+  (testing "rf2-l3lyal — a MIXED run (a passing assertion + a run-level
+            :cannot-run refusal) must NOT read false-GREEN: the refusal
+            lives in the run-level :cannot-run slot, never in
+            :assertions, so gating the run-level report on
+            (empty? assertions) let the passing assertion's report stand
+            alone and mask the refusal"
+    (let [refusal (requirements/requirement-refusal
+                    #{:pixels} #{:app-db} [:rf.assert/visual-snapshot]
+                    :runner-lacks-capability :headless)
+          r       (result/run-result
+                    {:assertions [{:assertion :rf.assert/path-equals :passed? true}]
+                     :unmet      [refusal]})
+          reports (result/result->reports r)]
+      (is (= :cannot-run (:status r)) "the run verdict is :cannot-run")
+      (is (= 2 (count reports))
+          "one per-assertion pass + one run-level :cannot-run — not just the pass")
+      (is (= :pass (:type (first reports))))
+      (is (= :fail (:type (last reports)))
+          "the run-level report surfaces the refusal as a failure, never masked")
+      (is (re-find #":cannot-run" (:message (last reports)))))))
+
 (deftest result->reports-zero-assertion-pass-emits-one-pass
   (testing "a vacuous-green run emits ONE run-level pass so the test sees a
             positive signal"

--- a/tools/story/test/re_frame/story/ui/events_only_first_render_frame_provider_dom_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/events_only_first_render_frame_provider_dom_cljs_test.cljs
@@ -1,0 +1,138 @@
+(ns re-frame.story.ui.events-only-first-render-frame-provider-dom-cljs-test
+  "DOM-mount regression for rf2-4iu7tu: an EVENTS-ONLY variant's first
+  render must not reach `frame-provider` before its frame is allocated.
+
+  ## The race
+
+  `loading-phase?` DELIBERATELY suppresses the loading skeleton for
+  events-only variants (`loaders/events-only-variant?` — no `:loaders`,
+  no `:loaders-complete-when`, no `:frame-setup` decorator), so
+  `canvas-inner`'s first render falls straight through to
+  `[rf/frame-provider {:frame variant-id} ...]`. That SCOPE-ONLY shape
+  FAILS LOUD (`:rf.error/frame-provider-frame-absent`) when the frame is
+  absent — and `component-did-mount` (which normally allocates it via
+  `run-if-needed!`) fires AFTER React commits this very render, so a
+  variant selected BEFORE the canvas ever mounts (a deep link, a
+  persisted selection, or — as here — a bare pre-seeded
+  `:selected-variant`) never got a pre-allocated frame: the
+  `selection-watcher` pre-allocation (rf2-zme7) only fires on a
+  `:selected-variant` CHANGE, and there is none to observe when the
+  selection predates the watcher's own installation.
+
+  This was surfaced by the rf2-j8hklm viewport-toggle DOM test (#5265),
+  which had to omit `:component` from its probe variant specifically to
+  dodge this crash (see `viewport_toggle_app_db_dom_cljs_test.cljs`'s
+  comment) — orthogonal to what THAT test verifies. This test drives the
+  race head-on: a `:component` IS registered, so the first commit must
+  reach (and survive) `frame-provider`.
+
+  ## Why this needs a REAL DOM mount
+
+  The bug is a React render-vs-commit-vs-componentDidMount ORDERING
+  defect — no pure-hiccup inspection can observe whether `frame-provider`
+  runs before or after `component-did-mount` allocates the frame; only a
+  real `react-dom` commit proves it. Ns ends in `-dom-cljs-test` so
+  shadow-cljs's `:browser-test` build discovers it and mounts real DOM via
+  `react-dom/client`; `:node-test` also loads it (its `cljs-test$` regex
+  matches the `-dom-cljs-test` suffix too) where the body self-gates on
+  `(browser?)` and no-ops."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            ["react-dom" :as react-dom]
+            [reagent.dom.client :as rdc]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.machines :as machines]
+            [re-frame.registrar :as registrar]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.story :as story]
+            [re-frame.story.loaders :as loaders]
+            [re-frame.story.ui.canvas :as canvas]
+            [re-frame.story.ui.state :as state]
+            [re-frame.subs :as subs]))
+
+;; ---- fixture --------------------------------------------------------------
+
+(defn- reset-all! []
+  (story/clear-all!)
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (try (rf/init! reagent-adapter/adapter)
+       (catch :default _ nil))
+  ;; Re-register the framework `:rf/machine` sub after the registrar
+  ;; clear (mirrors viewport_toggle_app_db_dom_cljs_test's reset-all!).
+  (subs/reg-runtime-sub :rf/machine
+    (fn [runtime-db [_ machine-id]]
+      (get-in runtime-db [:rf.runtime/machines :snapshots machine-id])))
+  (machines/reset-timers!)
+  (loaders/clear-watchers!)
+  (state/reset-shell-state!)
+  (story/install-canonical-vocabulary!)
+  (frame/ensure-default-frame!)
+  (canvas/reset-first-rendered!))
+
+(use-fixtures :each {:before reset-all!})
+
+;; ---- browser gate -----------------------------------------------------
+
+(defn- browser? []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+(defn- make-mount-node! []
+  (let [node (js/document.createElement "div")]
+    (js/document.body.appendChild node)
+    node))
+
+;; ---- the regression ---------------------------------------------------
+
+(deftest events-only-variant-first-render-does-not-fail-loud-on-absent-frame
+  (testing "rf2-4iu7tu: an events-only variant selected BEFORE the canvas
+            ever mounts reaches `canvas-inner`'s FIRST render with NO
+            frame allocated yet. Pre-fix that render fell through to
+            `frame-provider` on the absent frame and threw
+            `:rf.error/frame-provider-frame-absent`; post-fix
+            `canvas-inner` ensures the frame during THIS render (mirroring
+            `re-frame.views.owned-frame/ensure-frame-fc`'s render-phase
+            ensure), so the mount succeeds and the variant's view actually
+            paints with its seeded state."
+    (if-not (browser?)
+      (is true ":node-test — no DOM; :browser-test runs the real assertion")
+      (let [variant-id :story.eofr/probe]
+        (rf/reg-event :eofr/seed
+          (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)}))
+        (rf/reg-sub :eofr/n (fn [db _] (:n db)))
+        ;; Deliberately WITH a :component — the #5265 test omitted this to
+        ;; route AROUND the exact race this test drives straight at.
+        (rf/reg-view* :views/eofr-probe
+          (fn [_]
+            [:div {:data-test "eofr-probe"}
+             (str "n=" @(rf/subscribe [:eofr/n]))]))
+        (story/reg-variant variant-id
+          {:component :views/eofr-probe
+           :events    [[:eofr/seed 7]]})
+        ;; Pre-select BEFORE mount — no selection-watcher pre-allocation
+        ;; edge ever fires (the watcher doesn't exist yet; there's no
+        ;; :selected-variant CHANGE for it to observe even once installed).
+        ;; This is the exact condition #5265's comment names: "the SAME
+        ;; synchronous render pass that first builds the vdom" reaches
+        ;; frame-provider before component-did-mount ever runs.
+        (state/swap-state! state/select-variant variant-id)
+        (let [mount-node (make-mount-node!)
+              root       (rdc/create-root mount-node)]
+          (try
+            (is (nil?
+                  (try
+                    (react-dom/flushSync
+                      (fn [] (rdc/render root [canvas/canvas])))
+                    nil
+                    (catch :default e e)))
+                "the first commit must NOT throw
+                 :rf.error/frame-provider-frame-absent")
+            (is (= "n=7"
+                   (some-> (.querySelector mount-node "[data-test=\"eofr-probe\"]")
+                           .-textContent))
+                "the variant's view actually rendered — the frame existed
+                 by the time frame-provider scoped it, and the seed
+                 :events landed before the view's subscription read it")
+            (finally
+              (try (.unmount root) (catch :default _ nil)))))))))


### PR DESCRIPTION
## Summary

Three story bug fixes, all on `tools/story/`, per rf2-l3lyal / rf2-xk8oz4 / rf2-4iu7tu.

### rf2-l3lyal — `result->reports` false-GREEN on a mixed run (P2)

`result.cljc`'s `result->reports` gated its run-level `:cannot-run` report on `(empty? assertions)`. A run-level capability refusal (e.g. `:rf.assert/visual-snapshot` under `:headless`) lives in the result's top-level `:cannot-run` slot, never in `:assertions` — so a run with >= 1 PASSING assertion alongside the refusal hit every `cond` branch's `false` and fell to `:else []`, emitting only the passing per-assertion report. `story/is` (which fires these via `do-report`) then saw all-green clojure.test reports while `(:status result)` was `:cannot-run` — the exact false-GREEN class `result.cljc`'s own docstring forbids.

Fix: gate on "no per-assertion report already conveys the refusal" — `(not-any? #(= :fail (:type %)) per-assertion)` — instead of `(empty? assertions)`. A zero-assertion run still satisfies this (vacuously true), so the existing zero-assertion behaviour is unchanged; a mixed run now emits the run-level `:cannot-run` report alongside the per-assertion pass.

Test: `result->reports-mixed-run-cannot-run-does-not-mask-refusal` in `result_test.cljc` — a passing assertion + a `requirement-refusal` `:unmet`, asserts 2 reports (pass + run-level fail), not 1.

### rf2-xk8oz4 — plan compiler never stamps `:story/id` (P3)

`fingerprint.cljc`'s `plan-hash-input-keys` (`[:story/id :world :script :expect :required-runner :tags]`) has always included `:story/id` "so two variants under different stories with identical bodies do not collide" — but `plan.cljc`'s `compile-body` only ever resolved the parent story id to look up story-level decorators (`story-decos`); it never `assoc`'d `:story/id` onto the returned plan. `select-keys` silently drops an absent key, so `plan-hash` was actually computed over `[:world :script :expect :required-runner :tags]` alone — the cross-story collision guard was dead code.

Fix: hoist the `(args/parent-story-id id)` resolution into a shared `sid` binding (previously scoped inside a `when-let` used only for the decorator lookup) and `assoc :story/id sid` onto the compiled plan when a parent resolves. An inline plan-map target with no `:variant/id` carries no slot (render-transparent, matches existing behaviour for other identity slots).

Tests (`plan_test.cljc`): `compiled-plan-is-stamped-with-parent-story-id` (the stamp itself) + `identical-variant-bodies-under-different-stories-do-not-collide` — drives the REAL compiler (not a hand-stamped plan, closing the test gap the bead called out) on two variants under different stories with byte-identical bodies and proves `fingerprint/plan-hash` now differs.

### rf2-4iu7tu — events-only variant mount-ordering race (P3, reproduced)

**Reproduced.** An events-only variant selected BEFORE the canvas ever mounts (a deep link, a persisted selection, or a bare pre-seeded `:selected-variant` — exactly what the rf2-j8hklm viewport-toggle DOM test, #5265, had to dodge by omitting `:component`) reaches `canvas-inner`'s first render with no frame allocated. `loading-phase?` deliberately suppresses the loading skeleton for events-only variants, so that render falls straight through to `[rf/frame-provider {:frame variant-id} ...]`, which fails loud (`:rf.error/frame-provider-frame-absent`) on the absent frame. `component-did-mount`'s `run-if-needed!` normally allocates the frame, but fires AFTER React commits this render; the selection-watcher's pre-allocation (rf2-zme7) only fires on a `:selected-variant` CHANGE, which doesn't exist when the selection predates the watcher's own installation.

Fix: `canvas-inner` now calls `run-if-needed!` to ENSURE the frame during THIS render, for events-only variants only — miroring `re-frame.views.owned-frame/ensure-frame-fc`'s documented render-phase-ensure justification ("an effect would run after the first child render and race descendant subscribes/dispatches"). `run-if-needed!` is idempotent (keyed on `canvas-last-run-key`), so the later `component-did-mount` call is a no-op and `:events` never double-run. Non-events-only variants are untouched — they stay on the skeleton-gated path, which already avoids this race.

Test (new, DOM-mount): `events_only_first_render_frame_provider_dom_cljs_test.cljs` — registers an events-only variant WITH a `:component` (deliberately, unlike #5265's workaround), pre-selects it before mount, `flushSync`-mounts `canvas/canvas`, and asserts the commit does not throw and the view renders with its seeded state.

## Spec reconciliation

Spec unchanged for all three — in each case `tools/story/spec/017-Testing-Story.md` already documented the correct contract and the bug was implementation drift, not a spec gap:
- §Unified run result already says a run-level report fires "when the verdict is not covered by a single assertion" (not gated on empty assertions).
- §Variant plan's required normalized plan shape already lists `:story/id optional-keyword`, and `plan-hash-input-keys`'s docstring already stated `:story/id`'s collision-guard purpose.
- rf2-4iu7tu is an internal render/commit-ordering timing defect; the spec's §Shell lifecycle doesn't (and shouldn't) describe React lifecycle-hook timing at that granularity.

## Quality gates

- `tools/story/` `clojure -M:test` — 1733 tests, 6410 assertions, 0 failures, 0 errors.
- `implementation/` `npm run test:cljs` — 8084 tests, 37109 assertions, 0 failures, 0 errors.
- `implementation/` `npm run test:browser` — 236 tests, 775 assertions, 0 failures, 0 errors (real gate for rf2-4iu7tu's render/mount fix).
- `implementation/` `npm run story:build` — succeeds (pre-existing unrelated warnings only).
- `clj-kondo` on all changed files — 0 errors, 1 pre-existing unrelated warning (unused binding at `plan.cljc:944`, outside this diff).

## Test plan

- [x] `result_test.cljc` new mixed-run regression passes
- [x] `plan_test.cljc` new `:story/id` stamp + cross-story collision-guard regressions pass
- [x] new DOM-mount regression for rf2-4iu7tu passes under `:browser-test`
- [x] full JVM + CLJS + browser suites green