### PR TITLE
fix(pair-mcp): re-validate positive runtime-preload probe + route read-ui :frame through shared coercion (rf2-dk6bv5/pvh95w)

### DIFF
--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/probe.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/probe.cljs
@@ -16,23 +16,55 @@
 
   Once `runtime-preloaded?` resolves to true for a `(conn, build-id)`
   pair, the result is cached on the conn-atom (`:probed-builds`)
-  for the lifetime of the socket. Subsequent `ensure-runtime!`
+  for the lifetime of the socket. Subsequent `runtime-preloaded?`
   calls for the same build short-circuit without an nREPL round-trip.
   The cache is cleared by `nrepl/close!` (operator-initiated teardown)
   and is reborn empty whenever `server.cljs/ensure-connection!` builds a
   fresh conn for a new shadow port. It is deliberately PRESERVED across a
   transient same-port socket reopen — the `__re_frame2_pair_runtime`
   marker lives in the browser CLJS heap, which a JVM-side socket hiccup
-  doesn't destroy, so re-probing would be wasteful. (A full page reload
-  DOES destroy the marker, but it leaves the JVM nREPL socket UP, so it
-  doesn't trigger a reconnect-reset. Negative probes aren't cached, and
-  the diagnostic ladder surfaces a genuinely-dead marker on the next
-  eval against the build.)
+  doesn't destroy, so re-probing would be wasteful.
 
   Negative results are NOT cached: a missing preload usually surfaces
   on the very first call, and re-probing on each subsequent call
   lets a freshly-added preload land without a server restart (e.g.
   the user edits `shadow-cljs.edn` and shadow-cljs hot-reloads).
+
+  ## Re-validating a cached positive (rf2-dk6bv5)
+
+  A cached positive marker is scoped to the nREPL SOCKET, which stays
+  open independently of the browser tab's own WebSocket. If the tab
+  later closes / crashes / navigates away, `:probed-builds` stays stuck
+  at true for the rest of the socket's life — the marker cache alone
+  cannot see that the browser side is gone. Left unchecked, every later
+  `ensure-runtime!` call would trust the stale cache, skip straight to
+  evaluating the real form, get a blank result back, and the caller would
+  read that blank as a legitimate `nil` — `{:ok? true :value nil}`,
+  indistinguishable from a form that genuinely returns nil, with the
+  `diagnose-preload-failure!` ladder unreachable (it only runs when the
+  marker probe itself returns false).
+
+  `ensure-runtime!` and `resolve-and-preflight!` therefore route through
+  `confirmed-live?`, not the raw marker cache: a cache hit (or a fresh
+  positive probe) is followed by ONE cheap JVM-side liveness read —
+  `freshness/jvm-build-freshness`'s `:runtime-count` (shadow's build-worker
+  `:runtimes` map — a DIFFERENT round-trip from the browser marker
+  eval, so the marker-cache's own round-trip savings are untouched). Every
+  `ensure-runtime!` call re-validates this way; only a DEFINITIVE
+  `:runtime-count 0` (not `nil` — an unreadable JVM half must never
+  false-positive a live runtime as gone) invalidates the stale cache entry
+  and falls through to the full diagnostic ladder, which then reports the
+  precise reason (almost always `:no-runtime-connected`) instead of a
+  misleading `:ok? true`.
+
+  This was picked over the two alternatives noted in the bead: a TTL
+  reopens the same footgun for the length of the window (and adds a
+  clock dependency to a synchronous cache check); a browser-side teardown
+  signal needs a live WebSocket at the exact moment of teardown, which is
+  precisely the mechanism that's failing. A cheap, JVM-side, every-call
+  re-check trades a small constant cost (already paid by `discover-app`'s
+  freshness token, reusing the same primitive) for closing the hole
+  outright.
 
   ## Build resolution + fail-loud preflight
 
@@ -56,6 +88,7 @@
   (:require [cljs.reader]
             [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.tools.eval-form :as ef]
+            [re-frame2-pair-mcp.tools.freshness :as freshness]
             [re-frame2-pair-mcp.tools.raw-state :as raw-state]
             [re-frame2-pair-mcp.tools.wire :as wire]))
 
@@ -175,6 +208,18 @@
   (when (and (some? conn) (satisfies? IDeref conn))
     (swap! conn update :probed-builds (fnil conj #{}) build-id)))
 
+(defn- unmark-conn-probed!
+  "Drop a previously-recorded positive probe for `build-id` from the
+  conn-atom's cache (rf2-dk6bv5). Called when `confirmed-live?`'s
+  liveness re-check proves a cached positive is now stale — the browser
+  tab closed/crashed/navigated away sometime after the marker was
+  cached. The next `runtime-preloaded?` call for this build must re-probe
+  from scratch rather than keep trusting the stale entry. Defensive
+  against a non-atom `conn` (test stubs)."
+  [conn build-id]
+  (when (and (some? conn) (satisfies? IDeref conn))
+    (swap! conn update :probed-builds disj build-id)))
+
 (defn runtime-preloaded?
   "Probe `js/globalThis.__re_frame2_pair_runtime` — the load-time
   marker set by the preloaded `re-frame2-pair.runtime` namespace.
@@ -195,6 +240,52 @@
                    (when ok? (mark-conn-probed! conn build-id))
                    ok?)))
         (.catch (fn [_] false)))))
+
+;; ---------------------------------------------------------------------------
+;; Liveness re-validation (rf2-dk6bv5) — see the ns docstring's
+;; "Re-validating a cached positive" section for the full rationale.
+;; ---------------------------------------------------------------------------
+
+(defn- browser-disconnected?
+  "True iff the JVM-side freshness half reports a DEFINITIVE zero
+  connected REPL runtimes for the build. `nil` (the JVM half is
+  unreadable — old shadow, a socket hiccup, or, in a unit test, a conn
+  with no live `:socket` at all) is INCONCLUSIVE and must never be
+  treated as disconnected — only a confirmed `0` is proof the browser
+  tab is gone."
+  [jvm-half]
+  (= 0 (:runtime-count jvm-half)))
+
+(defn confirmed-live?
+  "The re-validated liveness check every eval-path guard uses in place
+  of a bare `runtime-preloaded?` call (rf2-dk6bv5). Resolves to true only
+  when BOTH hold:
+
+    1. the marker probe (`runtime-preloaded?`, itself cache-accelerated)
+       says the preload landed;
+    2. a cheap JVM-side liveness read — `freshness/jvm-build-freshness`'s
+       `:runtime-count` (shadow's build-worker `:runtimes` map) — does
+       NOT show a definitive zero connected runtimes.
+
+  This is a DIFFERENT round-trip from the browser marker eval (JVM-side,
+  no browser eval at all), so it re-validates on EVERY call — including
+  a cache hit — without disturbing the marker cache's own round-trip
+  savings. When the JVM half proves the browser has disconnected since
+  the marker was cached, the stale cache entry is dropped
+  (`unmark-conn-probed!`) so the next call re-probes from scratch, and
+  this call resolves false — routing the caller to the full diagnostic
+  ladder instead of a misleading `{:ok? true}`."
+  [conn build-id]
+  (-> (runtime-preloaded? conn build-id)
+      (.then (fn [ok?]
+               (if-not ok?
+                 false
+                 (-> (freshness/jvm-build-freshness conn build-id)
+                     (.then (fn [jvm-half]
+                              (if (browser-disconnected? jvm-half)
+                                (do (unmark-conn-probed! conn build-id)
+                                    false)
+                                true)))))))))
 
 ;; Forward declare for diagnose-preload-failure! — running-builds is
 ;; defined below alongside resolve-build! and friends; the ladder uses
@@ -306,14 +397,19 @@
   (nrepl/cljs-eval-value conn build-id (ef/emit (ef/rt-call 'health))))
 
 (defn ensure-runtime!
-  "Confirm the re-frame2-pair runtime is preloaded. Resolves to nil on success,
-  rejects with a structured error otherwise. Tools that need the
-  runtime call this first.
+  "Confirm the re-frame2-pair runtime is preloaded AND still actually
+  connected. Resolves to nil on success, rejects with a structured error
+  otherwise. Tools that need the runtime call this first.
 
-  After the first positive probe per `(conn, build-id)`, this resolves
-  synchronously from cache — no nREPL round-trip per tool call.
+  Routes through `confirmed-live?`, not the bare marker probe (rf2-dk6bv5):
+  a cached-positive marker still pays one cheap JVM-side liveness
+  re-check on every call (a different round-trip from the browser marker
+  eval — the marker cache's own round-trip savings are untouched), so a
+  browser tab that closed/crashed/navigated away AFTER the marker was
+  cached is caught here instead of silently trusted forever.
 
-  On a failed probe the diagnostic ladder
+  On a failed probe (bare marker absent, or the liveness re-check proved
+  the browser has since disconnected) the diagnostic ladder
   (`diagnose-preload-failure!`) inspects the failure mode and rejects
   with one of four specific reasons — `:nrepl-unreachable`,
   `:build-not-running`, `:no-runtime-connected`, or
@@ -321,9 +417,9 @@
   The blanket `:runtime-not-preloaded` reason is reserved as the
   degradation fallback if the ladder itself errors."
   [conn build-id]
-  (-> (runtime-preloaded? conn build-id)
-      (.then (fn [ok?]
-               (if ok?
+  (-> (confirmed-live? conn build-id)
+      (.then (fn [live?]
+               (if live?
                  nil
                  (-> (diagnose-preload-failure! conn build-id)
                      (.then (fn [diag]
@@ -599,15 +695,19 @@
       error lacked.)
 
   NEVER resolves for a runtime-absent build, so the caller can never
-  emit `:ok? true :value nil` for an eval that didn't actually run."
+  emit `:ok? true :value nil` for an eval that didn't actually run —
+  including the rf2-dk6bv5 case where the marker cache is stale (the
+  browser tab closed/crashed/navigated away since it was cached):
+  `confirmed-live?` re-validates via a cheap JVM-side liveness read on
+  EVERY call, not just the raw marker probe."
   [conn build explicit?]
   (-> (resolve-build! conn build explicit?)
       (.then
         (fn [build-id]
-          (-> (runtime-preloaded? conn build-id)
+          (-> (confirmed-live? conn build-id)
               (.then
-                (fn [ok?]
-                  (if ok?
+                (fn [live?]
+                  (if live?
                     build-id
                     ;; Resolved a concrete build but its runtime sentinel
                     ;; is absent — enrich with the running-build list so

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/read_ui.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/read_ui.cljs
@@ -122,9 +122,9 @@
     :no-target-arg           — none of :view-id / :point / :selector given.
     :no-element              — the entry point matched nothing.
     :rf.error/ui-read-bad-selector — a malformed CSS selector."
-  (:require [clojure.string :as str]
-            [re-frame2-pair-mcp.tools.wire :as wire]
+  (:require [re-frame2-pair-mcp.tools.wire :as wire]
             [re-frame2-pair-mcp.tools.eval-form :as ef]
+            [re-frame2-pair-mcp.tools.args :as args]
             [re-frame2-pair-mcp.tools.probe :as probe]))
 
 (def default-max-text
@@ -134,26 +134,24 @@
   slots, so the agent recognises an elision uniformly."
   2000)
 
-(defn- frame-edn
-  "Render the `:frame` opt for the runtime call. A supplied frame string
-  (`\":stories\"` / `\"stories\"`) coerces to a keyword; nil drops the key
-  so the runtime resolves the operating frame itself."
-  [frame]
-  (some-> frame (str/replace #"^:" "") keyword))
-
 (defn- read-ui-form
   "Compose the single `(re-frame2-pair.runtime/ui-read {...})` form via the
   shared `eval-form` DSL — the SAME plumbing read-dom uses.
   Only present entry points / knobs ride (the runtime enforces the
   precedence view-id > point > selector). Pure form-builder, no
   connection: callable directly by the form-composition regression guard
-  so the alias-trap check covers BOTH ops, not just read-dom."
+  so the alias-trap check covers BOTH ops, not just read-dom.
+
+  `frame`, when supplied, is expected ALREADY coerced to a keyword (or
+  nil) by the caller — see `read-ui-tool`'s `args/->frame-keyword` call.
+  This form-builder does no coercion of its own, matching `read-dom-form`'s
+  contract."
   [vid pt selector max-text frame]
   (let [opts (cond-> {:max-text max-text}
                (some? vid)      (assoc :view-id vid)
                (some? pt)       (assoc :point pt)
                (some? selector) (assoc :selector selector)
-               (some? frame)    (assoc :frame (frame-edn frame)))]
+               (some? frame)    (assoc :frame frame))]
     (ef/emit (ef/rt-call 'ui-read opts))))
 
 (defn read-ui-tool
@@ -171,7 +169,15 @@
         selector (wire/arg raw-args :selector)
         max-text (let [m (wire/arg raw-args :max-text)]
                    (if (and (number? m) (pos? m)) (long m) default-max-text))
-        frame    (wire/arg raw-args :frame)
+        ;; :frame arrives untyped off the JSON/MCP wire — route it through
+        ;; the shared coercer every sibling read tool uses
+        ;; (get-path/read-sub/read-dom/handler-meta), NOT a locally
+        ;; reimplemented `str/replace`. `args/->frame-keyword` (->
+        ;; `base-args/fresh-keyword`) accepts a string or keyword and
+        ;; falls back to nil for anything else (number/boolean/array/
+        ;; object) instead of throwing a raw TypeError on a malformed
+        ;; client's non-string :frame (rf2-pvh95w).
+        frame    (some-> (wire/arg raw-args :frame) args/->frame-keyword)
         build-id (wire/arg-build conn raw-args)]
     (if-not (or (some? view-id) (some? point) (some? selector))
       (js/Promise.resolve

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/probe_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/probe_test.cljs
@@ -27,6 +27,7 @@
             [applied-science.js-interop :as j]
             [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.test-utils :as tu]
+            [re-frame2-pair-mcp.tools.freshness :as freshness]
             [re-frame2-pair-mcp.tools.probe :as probe]))
 
 ;; ---------------------------------------------------------------------------
@@ -337,6 +338,130 @@
         (fn []
           (assert-ladder-rejects-with-reason
             (fresh-conn) :runtime-loaded-but-preload-missing #"preload" done nil))))))
+
+;; ---------------------------------------------------------------------------
+;; Liveness re-validation (rf2-dk6bv5).
+;;
+;; A positively-cached marker probe (`:probed-builds`) is scoped to the
+;; nREPL socket, which stays open independently of the browser tab's own
+;; WebSocket. If the tab closes/crashes/navigates away AFTER the marker
+;; was cached, `runtime-preloaded?` alone would keep resolving true
+;; forever — `ensure-runtime!` would wave every later call straight
+;; through to a real eval that comes back blank, and the caller would
+;; read that blank as a legitimate nil (`{:ok? true :value nil}`),
+;; indistinguishable from a genuine nil, with the diagnostic ladder
+;; unreachable (it only runs when the marker probe itself is false).
+;;
+;; `ensure-runtime!` closes this by routing through `confirmed-live?`,
+;; which pairs the (still-cached) marker probe with a cheap JVM-side
+;; liveness read — `freshness/jvm-build-freshness`'s `:runtime-count` —
+;; on EVERY call. `freshness/jvm-build-freshness` uses `nrepl/jvm-eval`
+;; (a DIFFERENT round-trip from the browser marker eval `cljs-eval-value`
+;; probes), so stubbing it independently lets these tests simulate the
+;; runtime going blank WITHOUT touching the marker cache itself.
+;; ---------------------------------------------------------------------------
+
+(defn- with-stubbed-freshness-sequence!
+  "Stub `freshness/jvm-build-freshness` to resolve to each of `values` in
+  turn (one per call; the last value repeats once `values` is
+  exhausted), counting invocations into `calls*`. Restored in `.finally`
+  via the identity-guarded `tu/restore-freshness!`."
+  [values calls* body-fn]
+  (let [orig freshness/jvm-build-freshness
+        n    (count values)
+        stub (fn [_conn _build-id]
+               (let [i (swap! calls* inc)]
+                 (js/Promise.resolve (nth values (min (dec i) (dec n))))))]
+    (set! freshness/jvm-build-freshness stub)
+    (-> (js/Promise.resolve nil)
+        (.then (fn [_] (body-fn)))
+        (.finally (fn [] (tu/restore-freshness! stub orig))))))
+
+(deftest ensure-runtime-revalidates-a-previously-cached-positive-probe
+  ;; THE acceptance test: a runtime confirmed live once must NOT be
+  ;; trusted forever from the marker cache. The first `ensure-runtime!`
+  ;; call succeeds and caches the marker; between it and the second call
+  ;; the browser tab goes away (`:runtime-count` drops to a DEFINITIVE
+  ;; 0). The second call must reject via the diagnostic ladder — NOT
+  ;; resolve as if the runtime were still live.
+  (async done
+    (let [conn            (fresh-conn)
+          eval-calls      (atom 0)
+          freshness-calls (atom 0)
+          ;; The marker-eval stub: true on the very first call (caches
+          ;; the positive marker); nil (blank) thereafter — faithful to
+          ;; a genuinely-disconnected browser, which is what the ladder's
+          ;; own re-check would also see in production once the tab is
+          ;; actually gone.
+          cljs-fn         (fn [_form]
+                            (let [n (swap! eval-calls inc)]
+                              (if (= 1 n) true nil)))
+          jvm-fn          (fn [form-str]
+                            (if (re-find #"active-builds" form-str)
+                              {:value "[:app]"}
+                              {:value "1"}))
+          drive!          (fn []
+                            (-> (probe/ensure-runtime! conn :app)
+                                (.then (fn [_]
+                                         ;; First call: still connected — resolves.
+                                         (probe/ensure-runtime! conn :app)))
+                                (.then (fn [_]
+                                         (is false "second ensure-runtime! must reject once the tab disconnects")))
+                                (.catch (fn [err]
+                                          (let [data (ex-data err)]
+                                            (is (= :no-runtime-connected (:reason data))
+                                                "the liveness re-check's :runtime-count 0 routes to the precise reason")
+                                            (is (= :app (:build data))))))))]
+      (-> (with-stubbed-freshness-sequence!
+            [{:runtime-count 1} {:runtime-count 0}] freshness-calls
+            (fn [] (with-tri-stub! cljs-fn jvm-fn drive!)))
+          (.then (fn [_]
+                   (is (= 2 @freshness-calls)
+                       "the liveness read re-runs on EVERY ensure-runtime! call, cache hit or not")
+                   (done)))))))
+
+(deftest ensure-runtime-cache-hit-stays-live-when-jvm-confirms-runtime
+  ;; Control: a cache hit whose liveness re-check confirms the runtime is
+  ;; STILL connected (:runtime-count > 0) must keep resolving — the fix
+  ;; must not turn every cache hit into a spurious rejection.
+  (async done
+    (let [conn  (fresh-conn)
+          calls (atom 0)]
+      (-> (with-stubbed-freshness-sequence! [{:runtime-count 1}] (atom 0)
+            (fn []
+              (with-stubbed-eval! true calls
+                (fn []
+                  (-> (probe/ensure-runtime! conn :app)
+                      (.then (fn [_] (probe/ensure-runtime! conn :app)))
+                      (.then (fn [_] (probe/ensure-runtime! conn :app)))
+                      (.catch (fn [err]
+                                (is false (str "must not reject: " (.-message err))))))))))
+          (.then (fn [_]
+                   (is (= 1 @calls)
+                       "the marker probe is still cache-hit — only the JVM liveness read re-runs")
+                   (done)))))))
+
+(deftest ensure-runtime-cache-hit-tolerant-of-unreadable-jvm-half
+  ;; An unreadable JVM half (nil — old shadow, a socket hiccup, or, as in
+  ;; every OTHER test in this suite, a conn with no live :socket at all)
+  ;; is INCONCLUSIVE, not proof of disconnection. It must never
+  ;; false-positive a live runtime as gone — this is the default
+  ;; behaviour every other test in this file already relies on (their
+  ;; `fresh-conn` carries no socket, so `jvm-build-freshness` short-
+  ;; circuits to nil without a round-trip); this test pins it explicitly.
+  (async done
+    (let [conn  (fresh-conn)
+          calls (atom 0)]
+      (-> (with-stubbed-eval! true calls
+            (fn []
+              (-> (probe/ensure-runtime! conn :app)
+                  (.then (fn [v]
+                           (is (nil? v)
+                               "resolves nil (success) when the JVM half is unreadable")))
+                  (.catch (fn [err]
+                            (is false (str "must not reject on an unreadable JVM half: "
+                                           (.-message err))))))))
+          (.then (fn [_] (done)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; `err->result`. A runtime/preflight/transport REJECTION is a known-tool

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/read_dom_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/read_dom_test.cljs
@@ -200,7 +200,11 @@
            ;; read-ui variants (re-frame2 view plane) — the SAME guard now
            ;; covers them, since read-ui rides the same eval-form plumbing.
            ["read-ui view-id"         (#'read-ui/read-ui-form :my.app/counter nil nil 2000 nil)]
-           ["read-ui point+frame"     (#'read-ui/read-ui-form nil {:x 12 :y 34} nil 100 ":stories")]
+           ;; `frame` rides pre-coerced (a keyword or nil) — read-ui-form
+           ;; does no coercion of its own, matching read-dom-form's
+           ;; contract; the caller (read-ui-tool) coerces via
+           ;; `args/->frame-keyword` before calling in (rf2-pvh95w).
+           ["read-ui point+frame"     (#'read-ui/read-ui-form nil {:x 12 :y 34} nil 100 :stories)]
            ["read-ui selector"        (#'read-ui/read-ui-form nil nil "#save" 2000 nil)]]]
     (let [suspects (unresolved-alias-suspects form)]
       (is (empty? suspects)

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/read_ui_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/read_ui_test.cljs
@@ -93,6 +93,52 @@
                      (is (str/includes? form ":frame :stories") "frame coerced to keyword"))
                    (done)))))))
 
+(deftest non-string-frame-does-not-throw-and-drops-cleanly
+  ;; rf2-pvh95w: read-ui used to reimplement :frame coercion locally
+  ;; (a private `frame-edn` doing a bare `(str/replace frame #"^:" "")`
+  ;; with no type guard). `str/replace` requires a STRING first arg, so a
+  ;; JSON :frame of any non-string type (number/boolean/array/object —
+  ;; e.g. a malformed client) reached it and threw a raw synchronous
+  ;; TypeError BEFORE any Promise/.catch boundary — an uncaught crash,
+  ;; not a clean `:ok? false`.
+  ;;
+  ;; :frame now routes through the shared `args/->frame-keyword` (->
+  ;; `base-args/fresh-keyword`), the same coercer every sibling read tool
+  ;; (get-path/read-sub/read-dom/handler-meta) already uses — its
+  ;; `:else nil` fallback resolves a non-string/non-keyword :frame to
+  ;; nil (dropped from the emitted form; the runtime resolves the
+  ;; operating frame itself) instead of throwing.
+  ;;
+  ;; The call to `read-ui-tool` below IS the regression guard: a
+  ;; resurfaced `frame-edn`-style bug would throw synchronously right
+  ;; here, failing the test with an uncaught exception rather than a
+  ;; normal assertion failure.
+  (async done
+    (let [seen (atom nil)]
+      (-> (with-captured-form! seen {:ok? true}
+            (fn []
+              (read-ui/read-ui-tool (fresh-conn)
+                                    #js {:selector "#save" :frame 42})))
+          (.then (fn [_]
+                   (is (not (str/includes? @seen ":frame"))
+                       "a non-string (number) :frame is dropped, not embedded raw")
+                   (done)))))))
+
+(deftest array-frame-does-not-throw-and-drops-cleanly
+  ;; The array/object shape the bead calls out explicitly — a JSON array
+  ;; :frame arriving off a malformed client must degrade the same way a
+  ;; number does, not throw.
+  (async done
+    (let [seen (atom nil)]
+      (-> (with-captured-form! seen {:ok? true}
+            (fn []
+              (read-ui/read-ui-tool (fresh-conn)
+                                    #js {:selector "#save" :frame #js ["not" "a" "string"]})))
+          (.then (fn [_]
+                   (is (not (str/includes? @seen ":frame"))
+                       "a non-string (array) :frame is dropped, not embedded raw")
+                   (done)))))))
+
 ;; ---------------------------------------------------------------------------
 ;; Tool wiring — preflight + envelope passthrough.
 ;; ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two verified re-frame2-pair-mcp bugs on the `tools/re-frame2-pair-mcp/` surface, each with a regression test.

### rf2-dk6bv5 — stale positive runtime-preload probe cache

`probe.cljs`'s `runtime-preloaded?` caches a positive marker probe on the conn-atom (`:probed-builds`) for the life of the nREPL socket. That cache is scoped to the socket, which stays open independently of the browser tab's own WebSocket — so if the tab later closes/crashes/navigates away, every later tool call kept trusting the stale cache, skipped straight to evaluating the real form, got a blank result back, and the caller read that blank as a legitimate `nil` (`{:ok? true :value nil}`), indistinguishable from a genuine nil — with the `diagnose-preload-failure!` ladder unreachable (it only fires when the marker probe itself returns false).

**Design choice (of the bead's 3 options): (b), a cheap liveness re-check in `ensure-runtime!`** — specifically, a new `confirmed-live?` combinator that pairs the (still-cached) marker probe with `freshness/jvm-build-freshness`'s `:runtime-count` (shadow's build-worker `:runtimes` map, read via `nrepl/jvm-eval` — a JVM-side call, **not** a browser round-trip, so it's a *different* round-trip from the browser marker eval and doesn't disturb the marker cache's own savings). This runs on **every** `ensure-runtime!` / `resolve-and-preflight!` call, cache hit or not. Only a **definitive** `:runtime-count 0` invalidates the stale cache entry (`unmark-conn-probed!`) and falls through to the full diagnostic ladder (reporting the precise reason, almost always `:no-runtime-connected`); an unreadable JVM half (`nil` — old shadow, socket hiccup, or a conn with no live socket in tests) stays inconclusive and never false-positives a live runtime as gone.

Rejected: (a) a TTL reopens the same footgun for the length of the window and adds a clock dependency; (c) a browser-side teardown signal needs a live WebSocket at the exact moment of teardown — precisely the mechanism that's failing.

Reused `freshness/jvm-build-freshness` rather than duplicating a JVM form — it's the same primitive `discover-app`'s freshness token already calls, and the test suite already has a stub seam for it (`test-utils/with-stubbed-freshness!`).

### rf2-pvh95w — read-ui's local `:frame` coercion has no type guard

`read_ui.cljs`'s private `frame-edn` did `(some-> frame (str/replace #"^:" "") keyword)`; `str/replace` requires a string first arg, so a JSON `:frame` of any non-string type (number/boolean/array/object from a malformed client) reached it and threw a raw synchronous TypeError before any Promise/`.catch` boundary. Every sibling read tool (get-path/read-sub/read-dom/handler-meta) already coerces `:frame` through the shared `args/->frame-keyword` (-> `base-args/fresh-keyword`), whose `:else nil` fallback degrades cleanly.

Fix: route read-ui's `:frame` through `args/->frame-keyword` in `read-ui-tool`; drop the local `frame-edn`. `read-ui-form` now expects an already-coerced `frame` (keyword or nil), matching `read-dom-form`'s contract — updated the one test call-site in `read_dom_test.cljs` that exercised the old self-coercing contract to pass a pre-coerced keyword.

## Tests

- `probe_test.cljs`: `ensure-runtime-revalidates-a-previously-cached-positive-probe` (the acceptance test — a positively-probed runtime that then goes blank/dead is caught by the liveness re-check, not reported as `{:ok? true}`), plus two controls (`ensure-runtime-cache-hit-stays-live-when-jvm-confirms-runtime`, `ensure-runtime-cache-hit-tolerant-of-unreadable-jvm-half`) pinning the fix doesn't regress the happy path or false-positive on an unreadable JVM half.
- `read_ui_test.cljs`: `non-string-frame-does-not-throw-and-drops-cleanly` (number) and `array-frame-does-not-throw-and-drops-cleanly` (array) — both call `read-ui-tool` directly (no `.catch` wrapper) so a resurfaced TypeError would fail the test with an uncaught exception, not a normal assertion failure.

## Quality gates

- `npm test` (from `tools/re-frame2-pair-mcp/`): **1149 tests, 3841 assertions, 0 failures, 0 errors.**
- `npm run check:descriptors`: **OK, tool-descriptors.edn in sync (30 tools).**