### PR TITLE
fix(xray): UI/panel cluster — auto-open baseline, keys-toggle reactivity, L2 divider, focused-row, always-microstep edge, retro live-clock (rf2-8i1tg3)

### DIFF
--- a/tools/xray/spec/003-Machine-Inspector.md
+++ b/tools/xray/spec/003-Machine-Inspector.md
@@ -756,6 +756,35 @@ active leaf); a SIBLING state's same-event edge remains excluded (its
 lives once in `trace_state.cljs`, shared by both the fired-edge and the
 guard-blocked matchers.
 
+### `:always`-microstep fired-edge highlight (rf2-8i1tg3)
+
+`commit-or-finalize` (`lifecycle_fx/registration.cljc`) emits exactly ONE
+`:rf.machine/transition` per macrostep, whose `:after` is the FINAL settled
+state once every `:always` iteration the event triggered has ALSO run —
+not the state the dispatched event's OWN transition landed in. When
+`:microsteps > 0`, matching `(from, :after, event)` against the declared
+edges therefore looks for an edge that does not exist (the direct target,
+followed by N eventless hops, collapsed into one before/after pair):
+`single-transition-fired-ids` returned `#{}` and a `:microsteps > 0`
+transition lit no fired edge at all, even though the machine demonstrably
+moved through every hop.
+
+**Fix — direct target + per-microstep matching, not the settled `:after`.**
+`extract-fired-edge-ids` reads the trace's structured `:cascade` for its
+`:kind :microstep` entries (one per `:always` iteration, each carrying its
+own `:from` / `:to`). `direct-event-target` resolves the dispatched event's
+OWN target as the FIRST microstep's `:from` (the state before the
+`:always` loop took over) — falling back to the plain `to-path-from-trace`
+`:after` when there were no microsteps, so the fix is a no-op on the
+common `:microsteps 0` case. That direct target lights the dispatched
+event's own edge via the existing `single-transition-fired-ids` match.
+Additionally, each `:always` microstep's own hop is matched with `event*`
+`:always` (the eventless-edge marker `chart.layout/project-definition`
+mints for every `:always` candidate — rf2-oy49f1), so a multi-hop
+`:always` cascade highlights the FULL path the macrostep walked, not just
+its entry edge. Scoped to single-active (flat/compound) machines; parallel
+`:always` microsteps are a separate, not-yet-covered case.
+
 ### Parallel multi-region fired-edge highlight (rf2-8ncxrf)
 
 A `:type :parallel` machine's snapshot `:state` is a **region-map** —
@@ -1866,6 +1895,16 @@ this. Nobody does.**
 **v1 ships:** no rings (transition-history ribbon only). **Future:** the
 full countdown-ring system + retro-replay (Phase 2 per
 [`019-Cross-Cutting-Insight.md`](019-Cross-Cutting-Insight.md) §6).
+
+> **Shipped (rf2-7hwwe, parent rf2-2tkza).** The countdown-ring system
+> above landed — `panels/machine-after-rings.cljs` + `panels/machine-
+> after-rings-helpers.cljc`. The retro-mode anchor (freeze at the
+> elapsed-fraction reached at the focused-cascade's timestamp) was
+> itself bugged until rf2-8i1tg3: the view fed the live wall clock into
+> the ring projection unconditionally, so leaving `:present` mode froze
+> the ring wherever the live clock last sat rather than at the focused
+> cascade. `machine-after-rings-helpers/resolve-now-ms` now branches on
+> `scrubber-position` to supply the correct anchor.
 
 ### M.3 — Cancellation cascade ambiguity
 

--- a/tools/xray/spec/016-Auxiliary-Panels.md
+++ b/tools/xray/spec/016-Auxiliary-Panels.md
@@ -667,6 +667,16 @@ nil and `(add-watch nil …)` would throw; the frame-presence guard
 makes the early call safe and the watcher lands on first frame
 registration. Detached on flip-off.
 
+**Baseline seeding (rf2-8i1tg3).** The edge-detector's baseline count
+MUST be seeded from the reaction's value AT INSTALL TIME, before
+`add-watch` — a reaction is already live the instant `subscribe`
+returns (e.g. a re-install after a focus-nav that already landed on an
+issue-carrying epoch), so `add-watch` only fires on the NEXT change.
+Leaving the baseline at its cold-start default of zero misclassifies
+that pre-existing non-empty state as the empty→non-empty edge on the
+first subsequent change, spuriously auto-opening Xray for an epoch the
+watcher never actually saw transition.
+
 ### Bulk configure! escape hatch
 
 `(xray-config/configure! {:rf.xray/settings <map>})` bulk-replaces the

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_after_rings.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_after_rings.cljs
@@ -7,7 +7,15 @@
   every armed `:after` timer draws a countdown ring AROUND its bearing
   state-node. In live mode the ring sweeps from full → empty in real
   time; in retrospective mode (scrubber not at `:present`) it freezes
-  at the position it occupied when the scrubber was paused.
+  at the elapsed-fraction the timer had reached at the FOCUSED
+  CASCADE's timestamp (xray/003 §M.2) — `AfterRingsOverlay` resolves
+  the `now-ms` anchor via `machine-after-rings-helpers/resolve-now-ms`
+  (rf2-8i1tg3): the rAF-bumped live clock in `:present`/LIVE mode, the
+  focused event-bundle's dispatched time otherwise. Before rf2-8i1tg3
+  the retro branch fed the STALE live clock in unconditionally — the
+  scrubber gated only whether the rAF loop kept ticking, so leaving
+  LIVE mode froze the ring wherever the clock happened to last sit,
+  not at the cascade the operator is actually looking at.
 
   ## Architecture (rf2-uv1on — xyflow Phase 2)
 
@@ -373,9 +381,25 @@
   `display: contents` element is not a positioning context). Same
   pattern as `shell.cljs` (rf2-uu3lp)."
   [& _opts]
-  (let [timers @(rf/subscribe [:rf.xray/active-timers-for-focused-machine])
-        now    @(rf/subscribe [:rf.xray/now-ms])
-        scrub  @(rf/subscribe [:rf.xray/machine-scrubber-position])
+  (let [timers     @(rf/subscribe [:rf.xray/active-timers-for-focused-machine])
+        live-now   @(rf/subscribe [:rf.xray/now-ms])
+        scrub      @(rf/subscribe [:rf.xray/machine-scrubber-position])
+        ;; rf2-8i1tg3 — xray/003 §M.2: in RETRO mode ('scrubber-
+        ;; driven') the ring must freeze at the elapsed-fraction the
+        ;; timer had reached at the FOCUSED CASCADE's timestamp, not
+        ;; wherever the live clock last sat when the tick loop
+        ;; stopped. `needs-ticking?` already suspends the rAF loop when
+        ;; `scrub` leaves `:present`, so `live-now` simply goes stale —
+        ;; nothing was plumbing the scrubbed anchor into the ring
+        ;; projection below. `:rf.xray/focused-event-bundle-detail` is
+        ;; the same cross-panel primitive the Epoch / App-db-diff
+        ;; panels read to find "the event-bundle the spine is pointing
+        ;; at"; referenced by keyword (no ns require — re-frame's
+        ;; registrar resolves subs at runtime, not compile-time,
+        ;; keeping this ns out of the `registry.cljs` require cycle).
+        focused-ms (rings-h/focused-cascade-time-ms
+                     @(rf/subscribe [:rf.xray/focused-event-bundle-detail]))
+        now        (rings-h/resolve-now-ms scrub live-now focused-ms)
         ;; rf2-nesy9 — capture the surrounding instance frame so the
         ;; off-render rAF clock + the hover/leave callbacks dispatch
         ;; into it (not a `:rf/xray` literal). `frame` arms the rAF loop

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_after_rings_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_after_rings_helpers.cljc
@@ -529,3 +529,42 @@
   [timers scrubber-position]
   (and (= :present scrubber-position)
        (some (fn [t] (= :armed (:status t))) (or timers []))))
+
+;; ---- retro now-ms anchor (rf2-8i1tg3 · xray/003 §M.2) --------------------
+
+(defn focused-cascade-time-ms
+  "Pull the focused event-bundle's dispatched wall-clock time (ms) off
+  the `:rf.xray/focused-event-bundle-detail` composite value — the SAME
+  `[:dispatched :time]` slot the L2 event list's timestamp column reads
+  (`shell/event-bundle-dispatched-time-ms`). Returns nil when there is
+  no selected event-bundle, or its `:dispatched :time` is not a number
+  (defence — a synthetic/legacy event-bundle that omits the field must
+  not freeze the ring at a bogus anchor)."
+  [focused-event-bundle-detail]
+  (let [t (get-in focused-event-bundle-detail
+                  [:selected-event-bundle :dispatched :time])]
+    (when (number? t) t)))
+
+(defn resolve-now-ms
+  "Resolve the `now-ms` anchor `timers->ring-specs` should project
+  against.
+
+  - `:present` `scrubber-position` (LIVE mode): `live-now-ms` — the
+    rAF-bumped wall clock, so rings sweep in real time.
+  - Any other `scrubber-position` (RETRO mode): per xray/003 §M.2 'the
+    ring is static at the elapsed-fraction the timer had reached at
+    the focused-cascade's timestamp' — `focused-cascade-ms`. Falls
+    back to `live-now-ms` when the focused cascade carries no
+    timestamp (defence — a nil anchor would blank every fraction
+    calc rather than freeze it).
+
+  Before rf2-8i1tg3 the view fed `live-now-ms` into `timers->ring-
+  specs` UNCONDITIONALLY — `scrubber-position` gated only whether the
+  rAF loop kept ticking, so leaving LIVE mode simply stopped the clock
+  wherever it last was instead of anchoring to the focused cascade the
+  spec promises. Pure fn — the view supplies both candidate
+  timestamps; kept testable without a DOM/subscribe harness."
+  [scrubber-position live-now-ms focused-cascade-ms]
+  (if (= :present scrubber-position)
+    live-now-ms
+    (or focused-cascade-ms live-now-ms)))

--- a/tools/xray/src/day8/re_frame2_xray/panels/machines/trace_state.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machines/trace_state.cljs
@@ -320,6 +320,33 @@
       (:cascade ev)
       []))
 
+(defn- microstep-cascade-steps
+  "rf2-8i1tg3 — the `:kind :microstep` steps off a transition trace's
+  `:cascade`, in firing order. `transition.cljc`'s unified `:always`
+  loop (`machine-transition-single`) appends ONE such step per
+  eventless iteration — `{:kind :microstep :from <state> :to <state>
+  :microstep-index N :steps [...] ...}`, `:from`/`:to` being the RAW
+  before/after `:state` value (keyword or path vector for a single-
+  active machine — parallel region-maps are out of scope here, see
+  `extract-fired-edge-ids` docstring). Empty when the macrostep ran no
+  `:always` steps (`:microsteps 0`)."
+  [cascade]
+  (filterv #(= :microstep (:kind %)) cascade))
+
+(defn- direct-event-target
+  "rf2-8i1tg3 — the state the DISPATCHED event's own (non-`:always`)
+  transition landed in, as opposed to `to-path-from-trace`'s `:after`,
+  which is the FINAL state once every subsequent `:always` microstep
+  has also settled. When `microsteps` ran (`(seq microsteps)` true),
+  that direct target is the FIRST microstep's `:from` — the state the
+  event-driven transition committed before the `:always` loop took
+  over. With no microsteps, the event-driven transition's target IS
+  the settled `:after`, so `to-path-from-trace` already reads it."
+  [ev microsteps]
+  (if (seq microsteps)
+    (normalise-path (:from (first microsteps)))
+    (to-path-from-trace ev)))
+
 (defn- handled-regions-from-cascade
   "rf2-l8ls6w — the SET of region names a parallel macrostep actually HANDLED
   this transition, read off the trace's structured `:cascade`. Each cascade
@@ -602,6 +629,23 @@
   HANDLED-unchanged region (lights its self/internal edge) from a RESTING
   region that simply declined the event (lights nothing).
 
+  rf2-8i1tg3 — `:always`-MICROSTEP macrosteps (single-active machines only;
+  parallel `:always` microsteps are out of scope here). `commit-or-finalize`
+  emits ONE `:rf.machine/transition` per macrostep whose `:after` is the
+  FINAL settled state once every `:always` iteration has ALSO run — not the
+  state the dispatched event's own transition landed in. Matching
+  `(from, :after, event)` against the declared edges therefore looks for an
+  edge that does not exist (the dispatched event's real target, followed by
+  N eventless hops, was collapsed into one before/after pair) and silently
+  returns nothing — a `:microsteps > 0` transition lit NO fired edge at all.
+  `direct-event-target` recovers the event-driven transition's OWN target
+  (the first `:always` microstep's `:from`, i.e. before the loop advanced
+  further) so its edge matches by construction; `microstep-cascade-steps`
+  then walks the structured `:cascade`'s `:microstep` entries and lights
+  EACH `:always` hop's own edge too (`chart.layout` mints eventless edges
+  with `:event :always` — rf2-oy49f1), so a multi-hop `:always` cascade
+  highlights the FULL path the macrostep walked, not just its entry edge.
+
   Returns `#{}` for a nil/empty definition or no matching transitions."
   [definition trace-events machine-id]
   (let [edges (:edges (chart-layout/project-definition definition))]
@@ -623,11 +667,23 @@
                    event*
                    (handled-regions-from-cascade (cascade-from-trace ev)))
                  ;; Single-active (flat / compound): the existing
-                 ;; (from, to, event) match + machine-level fallback.
-                 (let [from* (from-path-from-trace ev)
-                       to*   (to-path-from-trace ev)]
+                 ;; (from, to, event) match + machine-level fallback —
+                 ;; PLUS (rf2-8i1tg3) the direct event-driven target
+                 ;; (not the post-`:always` settled state) and every
+                 ;; `:always` microstep's own edge.
+                 (let [from*      (from-path-from-trace ev)
+                       microsteps (microstep-cascade-steps (cascade-from-trace ev))
+                       to*        (direct-event-target ev microsteps)]
                    (when (and from* to* event*)
-                     (single-transition-fired-ids edges from* to* event*)))))))
+                     (concat
+                       (single-transition-fired-ids edges from* to* event*)
+                       (mapcat (fn [{step-from :from step-to :to}]
+                                 (single-transition-fired-ids
+                                   edges
+                                   (normalise-path step-from)
+                                   (normalise-path step-to)
+                                   :always))
+                               microsteps))))))))
          set)))
 
 ;; ---- guard-blocked-edge ids (rf2-fzrzlw) --------------------------------

--- a/tools/xray/src/day8/re_frame2_xray/settings/effects.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/settings/effects.cljs
@@ -591,6 +591,19 @@
                                     (zero? prev)
                                     (not (visible-shell?)))
                            (call-mount-fn! "open_BANG_"))))]
+        ;; Seed the baseline from the reaction's CURRENT value before
+        ;; `add-watch` — a reagent/re-frame reaction is already live the
+        ;; instant `subscribe` returns (it may have run against issues
+        ;; that predate this install, e.g. re-install after a focus nav
+        ;; that already landed on an issue-carrying epoch). `add-watch`
+        ;; only fires on the NEXT change, so leaving `last-issue-count`
+        ;; at its `defonce` 0 misclassifies that pre-existing non-empty
+        ;; state as the empty->non-empty edge on the first subsequent
+        ;; change, spuriously auto-opening Xray. Seeding here makes the
+        ;; watcher's edge detection start from the true "now", matching
+        ;; xray/016-Auxiliary-Panels §Auto-open-on-error (first
+        ;; empty->non-empty only).
+        (reset! last-issue-count (count (:issues @reaction)))
         (add-watch reaction ::auto-open-on-error watch-fn)
         (reset! auto-open-watcher reaction))))
   nil)

--- a/tools/xray/src/day8/re_frame2_xray/settings/events.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/settings/events.cljs
@@ -12,6 +12,7 @@
       :rf.xray/settings-clear-buffer        (rf2-ttnst — Buffer tab)
       :rf.xray/settings-confirm-clear-buffer (rf2-ttnst — open confirm)
       :rf.xray/settings-cancel-clear-buffer  (rf2-ttnst — close confirm)
+      :rf.xray/keybinding-enabled-update on? (rf2-8i1tg3 — Keybindings tab)
 
   ## Open / close flag
 
@@ -198,5 +199,22 @@
     (fn [{:keys [db]} _event]
       (try (trace-collector/retroactive-scrub!) (catch :default _ nil))
       {:db (assoc db :settings-clear-confirm-open? false)}))
+
+  ;; rf2-8i1tg3 — Keybindings tab "Handle keys?" master toggle. Unlike
+  ;; every `:rf.xray/settings-update` slot, `:rf.xray/keybinding-
+  ;; enabled?` is a bare process-global `configure!` flag
+  ;; (`config/keybinding-enabled?`), not a persisted `:settings` slot —
+  ;; so it gets its own tiny dual-write event rather than routing
+  ;; through `settings-update` (which validates `[section key]` against
+  ;; `default-settings` and would reject an unknown path). Same shape
+  ;; as every other toggle: flip the canonical atom AND mirror app-db
+  ;; so the checkbox's `:rf.xray/keybinding-enabled?` sub re-fires
+  ;; immediately — without the mirror the controlled checkbox's
+  ;; `:checked` read a non-reactive atom directly and never re-rendered
+  ;; on change.
+  (rf/reg-event :rf.xray/keybinding-enabled-update
+    (fn [{:keys [db]} [_ on?]]
+      (config/set-keybinding-enabled! on?)
+      {:db (assoc db :keybinding-enabled? (boolean on?))}))
 
   nil)

--- a/tools/xray/src/day8/re_frame2_xray/settings/subs.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/settings/subs.cljs
@@ -11,6 +11,17 @@
                                           when app-db has not yet
                                           mirrored the slot (pre-
                                           first-open).
+  - `:rf.xray/keybinding-enabled?` — boolean. Keybindings tab
+                                      'Handle keys?' master toggle
+                                      (rf2-8i1tg3). Reads the app-db
+                                      mirror `:rf.xray/keybinding-
+                                      enabled-update` writes; falls
+                                      back to `config/keybinding-
+                                      attach-enabled?` pre-first-
+                                      dispatch. NOT part of `:settings`
+                                      — the underlying atom is a bare
+                                      process-global `configure!` slot,
+                                      not a persisted settings key.
 
   The `:rf.xray/setting` sub is parameterised — the query vector
   carries `[section key]`. Layout views read `[:rf.xray/setting
@@ -120,5 +131,21 @@
       (or (get-in db [:settings :general :long-keyword-threshold])
           (config/get-setting :general :long-keyword-threshold)
           24)))
+
+  ;; rf2-8i1tg3 — Keybindings tab 'Handle keys?' master toggle. The
+  ;; underlying flag (`config/keybinding-enabled?`) is a bare
+  ;; process-global `configure!` slot, not a `:settings` key, so it
+  ;; gets its own top-level app-db mirror (`:keybinding-enabled?`,
+  ;; written by `:rf.xray/keybinding-enabled-update`) rather than
+  ;; riding the `[:settings section key]` shape `:rf.xray/setting`
+  ;; reads. `contains?` (not `or`) distinguishes "app-db has mirrored
+  ;; an explicit false" from "app-db has never mirrored this at all"
+  ;; — the popup's checkbox needs the true current value the instant
+  ;; the toggle flips off, not a fallback that only reads the atom.
+  (rf/reg-sub :rf.xray/keybinding-enabled?
+    (fn [db _query]
+      (if (contains? db :keybinding-enabled?)
+        (boolean (:keybinding-enabled? db))
+        (config/keybinding-attach-enabled?))))
 
   nil)

--- a/tools/xray/src/day8/re_frame2_xray/settings/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/settings/view.cljs
@@ -37,7 +37,6 @@
   `rf/dispatch`, never a literal), so N isolated instances each route
   to their own frame."
   (:require [re-frame.core :as rf]
-            [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.theme.modal-chrome :as modal-chrome]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens sans-stack mono-stack type-scale]]))
@@ -741,7 +740,13 @@
 ;; The 'Handle keys?' master toggle aliases the
 ;; `:rf.xray/keybinding-enabled?` config slot (rf2-4eyik) — flipping
 ;; it false disables the global listener until next page-load. The
-;; effect is global; the popup is just the surface.
+;; effect is global; the popup is just the surface. Like every other
+;; toggle in this popup it routes through the reactive dual-write
+;; pattern (rf2-8i1tg3): `:rf.xray/keybinding-enabled-update` flips
+;; the canonical `config.cljc` atom AND mirrors into app-db, and the
+;; checkbox reads the mirror via `:rf.xray/keybinding-enabled?` — a
+;; plain atom read would leave the controlled checkbox's `:checked`
+;; non-reactive (no re-render on change; the box can visually revert).
 
 (def ^:private keybinding-rows
   "Static catalogue. Group key carries a section label; rows are
@@ -779,16 +784,19 @@
    :font-size        (:body type-scale)
    :align-items      "center"})
 
-(defn- keybindings-section []
-  ;; The Handle-keys? master toggle reads the
-  ;; `:rf.xray/keybinding-enabled?` atom directly — it's process
-  ;; global, not under `:settings`. The dispatch flips the atom via
-  ;; the setter. NB: the underlying setter only suppresses ATTACH;
-  ;; a host that pre-attached the listener needs to also call
-  ;; `keybinding/detach!` for the change to land immediately.
-  (let [keys-on? (try
-                   (config/keybinding-attach-enabled?)
-                   (catch :default _ true))]
+(defn- keybindings-section [dispatch]
+  ;; The Handle-keys? master toggle is process global, not under
+  ;; `:settings` — `config/keybinding-enabled?` is a bare `configure!`
+  ;; slot, not a persisted settings key (see config.cljc §*keybinding-
+  ;; enabled?*). Per rf2-8i1tg3 it still routes through the same
+  ;; reactive dual-write shape every other toggle in this popup uses:
+  ;; the sub reads app-db's mirror (falling back to the atom pre-first-
+  ;; dispatch), the event flips the atom AND mirrors app-db so the
+  ;; controlled checkbox re-renders immediately. NB: the underlying
+  ;; setter only suppresses ATTACH; a host that pre-attached the
+  ;; listener needs to also call `keybinding/detach!` for the change
+  ;; to land immediately.
+  (let [keys-on? @(rf/subscribe [:rf.xray/keybinding-enabled?])]
     [:div {:data-testid "rf-xray-settings-section-keybindings"}
      [:h2 {:style (section-heading-style)} "Keybindings"]
 
@@ -803,7 +811,7 @@
                 :checked     (boolean keys-on?)
                 :on-change   (fn [^js e]
                                (let [on? (boolean (.. e -target -checked))]
-                                 (config/set-keybinding-enabled! on?)))}]
+                                 (dispatch [:rf.xray/keybinding-enabled-update on?])))}]
        "Handle keys?"]
       [:p {:style (hint-style)}
        "Master switch for Xray's global keydown listener. Off → "
@@ -1163,6 +1171,6 @@
        (case active-tab
          :general     (general-section dispatch)
          :diff        (diff-section dispatch)
-         :keybindings (keybindings-section)
+         :keybindings (keybindings-section dispatch)
          :buffer      (buffer-section dispatch)
          (general-section dispatch))])))

--- a/tools/xray/src/day8/re_frame2_xray/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/shell.cljs
@@ -419,10 +419,25 @@
   ;; under. Falls back to `rf/dispatch*` defensively (test-driven drags
   ;; that bypassed `start-drag!`).
   (when-let [{:keys [col-id start-x start-width dispatch-fn]} @col-divider-drag-state]
-    ;; Divider sits to the RIGHT of the column it sizes; dragging right
-    ;; widens, dragging left narrows. dx = (now-x - start-x).
+    ;; rf2-8i1tg3 — every divider sits to the LEFT of the column named
+    ;; by `col-id` (between `event id` and `source`, between `source`
+    ;; and `timestamp`, between `timestamp` and `duration`); `event id`
+    ;; is the row's SOLE `flex 1 1 auto` column, far to the left of
+    ;; every divider, and it silently absorbs whatever width any
+    ;; resizable column gives up or takes (the row's total width is
+    ;; fixed). So GROWING `col-id` by `dx` steals `dx` from `event id`
+    ;; — which moves the divider itself (sitting at `event id`'s
+    ;; trailing edge, transitively, however many fixed columns sit
+    ;; between them) LEFT by `dx` while the pointer moved RIGHT by
+    ;; `dx`: a 2×dx divergence per drag-frame, and the classic
+    ;; "handle recedes from the cursor" bug. Correct split-pane
+    ;; semantics: dragging the divider TOWARD a column shrinks that
+    ;; column (the boundary is encroaching on it) and grows whatever
+    ;; is on the far side (ultimately `event id`, the shared elastic
+    ;; pool) — i.e. SHRINK `col-id` by `dx` so the divider's own
+    ;; position moves by exactly `+dx`, matching the pointer 1:1.
     (let [dx        (- (.-pageX e) start-x)
-          new-width (+ start-width dx)]
+          new-width (- start-width dx)]
       ((or dispatch-fn rf/dispatch*)
        [:rf.xray/set-event-list-col-width col-id new-width]))))
 
@@ -501,11 +516,17 @@
   §Resize affordance every drag handle MUST be operable without a
   pointer device. Mirrors the panel resize handle's bindings:
 
-    ArrowRight        +<step>px (widen the column to the LEFT)
-    ArrowLeft         -<step>px (narrow)
+    ArrowRight        +<step>px (widen THIS column, `col-id`)
+    ArrowLeft         -<step>px (narrow this column)
     Shift+ArrowRight  +<coarse> (10 × 3 = 30px)
     Shift+ArrowLeft   -<coarse>
     Enter / Space     reset this column to its default
+
+  Deliberately NOT inverted the way rf2-8i1tg3 inverted the pointer-
+  drag delta in `col-divider-on-move` — a keypress has no continuous
+  cursor position to track (no divider-recedes-from-the-pointer failure
+  mode is possible), so ArrowRight does the obvious, discoverable
+  thing: it grows the column named by `col-id` directly.
 
   The clamp lives in the registry handler — we dispatch the desired
   width and let `:rf.xray/set-event-list-col-width` apply the per-
@@ -534,18 +555,20 @@
        false))))
 
 (defn- col-divider
-  "Render a draggable divider sitting to the RIGHT of the column with
-  `col-id`. The divider is a 6px-wide vertical strip carrying the
-  `col-resize` cursor + a hover affordance defined in
-  `theme/global_styles/motion-css` (the rule paints a 1px accent stripe
-  on hover so authors can find the affordance without a hidden hit-test
-  game; the cursor change is the always-visible signal).
+  "Render a draggable divider sitting to the LEFT of the column with
+  `col-id` (i.e. BETWEEN the previous column and `col-id`'s column —
+  rf2-8i1tg3 corrected this docstring; it previously claimed the
+  opposite, which did not match the call sites below). The divider is
+  a 6px-wide vertical strip carrying the `col-resize` cursor + a hover
+  affordance defined in `theme/global_styles/motion-css` (the rule
+  paints a 1px accent stripe on hover so authors can find the
+  affordance without a hidden hit-test game; the cursor change is the
+  always-visible signal).
 
   rf2-6ni62. The divider participates in the row's flex layout as a
-  zero-content cell with explicit width — placed BETWEEN the column
-  it sizes (to its left) and the next column. Per the alignment
-  contract the same divider widths apply to header + every row, so the
-  flex layout stays consistent across surfaces.
+  zero-content cell with explicit width. Per the alignment contract
+  the same divider widths apply to header + every row, so the flex
+  layout stays consistent across surfaces.
 
   `:dispatch-fn` (rf2-r0o63) is the frame-aware dispatcher captured by
   the surrounding `reg-view` body (the L2 event-list views) — threaded
@@ -1371,6 +1394,26 @@
   ;; re-trigger scroll on every parent rerender).
   (atom ::never))
 
+(defonce ^:private focused-row-ref-cache
+  ;; rf2-8i1tg3 — single-slot memo `{:id <dispatch-id> :ref-fn <fn>}`.
+  ;; `focused-row-ref` used to build a FRESH closure on every call —
+  ;; i.e. on every render of the focused row, since `event-row` is a
+  ;; plain fn re-invoked on every parent re-render, not a stateful
+  ;; component. React treats a CHANGED callback ref as detach(nil)
+  ;; then attach on the VERY NEXT commit, regardless of whether the
+  ;; underlying DOM node actually changed — so every render fired
+  ;; `(fn [nil])` (resetting `last-scrolled-focus-id` to `::never`)
+  ;; immediately followed by `(fn [el])`, and the `not=` dedup guard
+  ;; below always saw a fresh `::never` baseline and re-scrolled every
+  ;; time — the exact opposite of its documented "scroll once per
+  ;; focus change" purpose. Memoizing on `id` (the only thing that
+  ;; should trigger a re-attach) keeps the SAME fn object across
+  ;; re-renders of the same focused row, so React's ref reconciliation
+  ;; sees no change and skips the detach/reattach cycle entirely; only
+  ;; an ACTUAL focus-id change (or auto-track? flipping off and back
+  ;; on) produces a new closure and a genuine detach→attach pair.
+  (atom nil))
+
 (defn- scroll-focused-row-into-view!
   "Imperative scroll. Called from the focused row's `:ref` callback
   when a new focus id lands in LIVE+head. Guarded against test
@@ -1390,17 +1433,30 @@
   The callback compares `id` against `last-scrolled-focus-id` and
   scrolls + updates the atom only on transition. nil-element calls
   (React's unmount signal) reset the atom so a re-mount of the same
-  id will scroll again (covers the toggle-off/on case)."
+  id will scroll again (covers the toggle-off/on case).
+
+  rf2-8i1tg3 — memoized on `id` via `focused-row-ref-cache` so REPEAT
+  calls for the SAME focused row (every re-render while focus doesn't
+  change) return the IDENTICAL fn object rather than a fresh closure.
+  Without this, React's callback-ref reconciliation would detach +
+  reattach on every render (a changed fn reference looks like a
+  changed ref to React), which resets `last-scrolled-focus-id` right
+  before re-checking it — permanently defeating the dedup guard above."
   [id auto-track?]
   (when auto-track?
-    (fn [el]
-      (cond
-        (nil? el)
-        (reset! last-scrolled-focus-id ::never)
+    (let [{cached-id :id cached-fn :ref-fn} @focused-row-ref-cache]
+      (if (and cached-fn (= cached-id id))
+        cached-fn
+        (let [f (fn [el]
+                  (cond
+                    (nil? el)
+                    (reset! last-scrolled-focus-id ::never)
 
-        (not= id @last-scrolled-focus-id)
-        (do (reset! last-scrolled-focus-id id)
-            (scroll-focused-row-into-view! el))))))
+                    (not= id @last-scrolled-focus-id)
+                    (do (reset! last-scrolled-focus-id id)
+                        (scroll-focused-row-into-view! el))))]
+          (reset! focused-row-ref-cache {:id id :ref-fn f})
+          f)))))
 
 (defn- event-row
   "One row in the L2 event list. Single line per the Figma-Make
@@ -1659,10 +1715,14 @@
                      :text-align "left"
                      :min-width "0"}}
       (render-event-id-only event-vec)]
-     ;; rf2-6ni62 — divider sits to the RIGHT of `event id` and resizes
-     ;; the `source` column to its right. The divider widths participate
-     ;; in the flex layout on rows + header identically so the cells
-     ;; stay column-for-column aligned.
+     ;; rf2-6ni62 — divider sits between `event id` and `source`
+     ;; (to the LEFT of `source`, per `col-divider`'s docstring) and
+     ;; resizes `source`. The divider widths participate in the flex
+     ;; layout on rows + header identically so the cells stay
+     ;; column-for-column aligned. `event id` is the row's sole
+     ;; `flex 1 1 auto` column — rf2-8i1tg3 inverted the drag delta in
+     ;; `col-divider-on-move` so dragging this handle tracks the
+     ;; pointer instead of receding from it.
      [col-divider {:col-id    :source
                    :col-px    (:source col-widths)
                    :row-height "22px"

--- a/tools/xray/test/day8/re_frame2_xray/event_list_resizable_cols_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/event_list_resizable_cols_cljs_test.cljs
@@ -199,40 +199,59 @@
   (is (false? (shell/col-divider-dragging?))
       "simulate-up! tore down the capture"))
 
-(deftest drag-right-widens-source-col
+;; rf2-8i1tg3 — the drag delta is INVERTED relative to the naive
+;; "drag right widens" intuition. `event id` (flex 1 1 auto) is the
+;; row's sole elastic column, far to the LEFT of every divider; it
+;; silently absorbs whatever a resizable column gives up or takes. If
+;; dragging right GREW `col-id` (the pre-fix behaviour — see the two
+;; tests this replaced), `event id` would shrink by the same amount,
+;; and the divider itself — sitting at `event id`'s trailing edge,
+;; transitively — would move LEFT while the pointer moved RIGHT: a
+;; 2×dx-per-frame divergence, the exact "handle recedes from the
+;; cursor" bug. Shrinking `col-id` on a rightward drag makes the
+;; divider's rendered position track the pointer 1:1 (and matches
+;; standard split-pane semantics: dragging the boundary TOWARD a
+;; column shrinks it).
+
+(deftest drag-right-narrows-col-and-tracks-cursor
   (setup!)
   (let [dispatches (atom [])]
     (with-redefs [rf/dispatch* (fn
                                  ([ev]       (swap! dispatches conj ev) nil)
                                  ([ev _opts] (swap! dispatches conj ev) nil))]
       (shell/col-divider-start-drag! (stub-event 1000) :source 52)
-      ;; Divider sits to the RIGHT of `event id` and sizes `source`.
-      ;; Dragging RIGHT (pageX 1080 > 1000) widens by +80 → 132.
+      ;; Divider sits to the LEFT of `source`. Dragging RIGHT
+      ;; (pageX 1080 > 1000, dx +80) NARROWS source by 80 → -28,
+      ;; which clamps to the 40px floor at write-time (`set-event-
+      ;; list-col-width` applies the clamp; this test only asserts
+      ;; the DISPATCHED delta, not the clamped persisted value —
+      ;; see `set-event-list-col-width-clamps-to-floor` below).
       (shell/col-divider-simulate-move! 1080)
       (shell/col-divider-simulate-up!))
     (let [width-events (filter #(= :rf.xray/set-event-list-col-width (first %))
                                @dispatches)]
       (is (seq width-events)
           "set-event-list-col-width was dispatched at least once")
-      (is (some #(= [:rf.xray/set-event-list-col-width :source 132] %)
+      (is (some #(= [:rf.xray/set-event-list-col-width :source -28] %)
                 width-events)
-          "drag right by 80px dispatched 132 (start 52 + 80 delta)"))))
+          "drag right by 80px dispatched 52 - 80 = -28 (pre-clamp delta) — the divider's OWN position tracks the pointer because `event id` absorbs the +80 this column gives up"))))
 
-(deftest drag-left-narrows-col
+(deftest drag-left-widens-col-and-tracks-cursor
   (setup!)
   (let [dispatches (atom [])]
     (with-redefs [rf/dispatch* (fn
                                  ([ev]       (swap! dispatches conj ev) nil)
                                  ([ev _opts] (swap! dispatches conj ev) nil))]
       (shell/col-divider-start-drag! (stub-event 1000) :timestamp 200)
-      ;; Drag LEFT by 50px (pageX 950 < 1000) → dx = -50, new = 150.
+      ;; Drag LEFT by 50px (pageX 950 < 1000, dx -50) WIDENS timestamp:
+      ;; 200 - (-50) = 250.
       (shell/col-divider-simulate-move! 950)
       (shell/col-divider-simulate-up!))
     (let [width-events (filter #(= :rf.xray/set-event-list-col-width (first %))
                                @dispatches)]
-      (is (some #(= [:rf.xray/set-event-list-col-width :timestamp 150] %)
+      (is (some #(= [:rf.xray/set-event-list-col-width :timestamp 250] %)
                 width-events)
-          "drag left narrows: 200 - 50 = 150"))))
+          "drag left widens: 200 - (-50) = 250"))))
 
 (deftest drag-cancel-tears-down-state
   (setup!)

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_after_rings_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_after_rings_cljs_test.cljs
@@ -293,6 +293,55 @@
       (is (nil? (do (on-hover "idle") (on-leave "idle") nil))
           "known node-id hover + leave run cleanly"))))
 
+;; ---- (5b) retro now-ms anchor (rf2-8i1tg3 · xray/003 §M.2) -------------
+;;
+;; "Retro mode (scrubber-driven): the ring is static at the elapsed-
+;; fraction the timer had reached at the focused-cascade's timestamp."
+;; Before this fix the view fed the LIVE `now-ms` into the ring
+;; projection regardless of `machine-scrubber-position` — the scrubber
+;; only gated whether the rAF loop kept ticking, so leaving `:present`
+;; froze the ring wherever the live clock last sat instead of anchoring
+;; to the cascade the operator is looking at.
+
+(defn- dispatch-trace-ev
+  "Minimal :rf.event/dispatched trace event so the L2 projector builds
+  ONE focusable event-bundle carrying a real `:dispatched :time` —
+  mirrors the equivalent helper in `shell_cljs_test`."
+  [id event-vec time-ms]
+  {:id        id
+   :time      time-ms
+   :op-type   :rf.event
+   :operation :rf.event/dispatched
+   :tags      {:rf.event/v          event-vec
+               :frame               :rf/default
+               :rf.trace/dispatch-id id}})
+
+(deftest overlay-retro-mode-anchors-tick-to-focused-cascade-timestamp
+  (testing "rf2-8i1tg3 — scrubber-position leaving :present anchors the
+            ring's :tick to the FOCUSED CASCADE's dispatched time, not
+            the stale live clock"
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (override-machines!    [:auth/login])
+      (override-definitions! {:auth/login fixture-definition})
+      (pin-now-ms! 9999)
+      (push-scheduled! 1000 :auth/login :idle 5000 0)
+      ;; Focus defaults to the head event-bundle when nothing has
+      ;; explicitly focused yet — seeding ONE dispatched event gives
+      ;; the composite a known, non-live anchor timestamp.
+      (trace-collector/seed-trace-for-test! (dispatch-trace-ev 1 [:some/event] 4242))
+      (rf/dispatch-sync [:rf.xray/set-scrubber-position 3])
+      (let [props (-> (after-rings/AfterRingsOverlay) delegated-props)]
+        (is (= 4242 (:tick props))
+            "RETRO tick anchors to the focused cascade's dispatched
+             time (4242) — NOT the pinned live now-ms (9999), which is
+             the exact rf2-8i1tg3 regression"))
+      (rf/dispatch-sync [:rf.xray/set-scrubber-position :present])
+      (let [props (-> (after-rings/AfterRingsOverlay) delegated-props)]
+        (is (= 9999 (:tick props))
+            "returning to :present restores the live clock as the tick
+             anchor")))))
+
 ;; ---- (6) frame isolation ----------------------------------------------
 
 (deftest now-ms-lives-on-xray-frame

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_after_rings_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_after_rings_helpers_cljs_test.cljc
@@ -25,7 +25,9 @@
        ring-spec projection (rf2-uv1on; replaced the SVG-era
        `state-node-center` / `timers->ring-positions`).
     8. `needs-ticking?`                     — rAF tick driver gate.
-    9. `ms-remaining`                       — tooltip-ms calc."
+    9. `ms-remaining`                       — tooltip-ms calc.
+    10. `focused-cascade-time-ms` / `resolve-now-ms` — rf2-8i1tg3 retro
+        now-ms anchor (xray/003 §M.2)."
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test    :refer-macros [deftest is testing]])
             [day8.re-frame2-xray.panels.machine-after-rings-helpers
@@ -465,3 +467,45 @@
 (deftest ms-remaining-nil-cases
   (is (nil? (h/ms-remaining {} 1000)))
   (is (nil? (h/ms-remaining {:fires-at 6000} nil))))
+
+;; ---- (10) focused-cascade-time-ms / resolve-now-ms (rf2-8i1tg3) ---------
+;;
+;; xray/003 §M.2: "Retro mode (scrubber-driven): the ring is static at
+;; the elapsed-fraction the timer had reached at the focused-cascade's
+;; timestamp." Before this fix the view fed the LIVE `now-ms` into the
+;; ring projection unconditionally regardless of scrubber-position —
+;; these tests pin the corrected branch.
+
+(deftest focused-cascade-time-ms-reads-dispatched-time
+  (is (= 12345
+         (h/focused-cascade-time-ms
+           {:selected-event-bundle {:dispatched {:time 12345}}}))))
+
+(deftest focused-cascade-time-ms-nil-cases
+  (is (nil? (h/focused-cascade-time-ms nil))
+      "no detail composite at all")
+  (is (nil? (h/focused-cascade-time-ms {}))
+      "no selected event-bundle")
+  (is (nil? (h/focused-cascade-time-ms
+              {:selected-event-bundle {}}))
+      "selected event-bundle carries no :dispatched slot")
+  (is (nil? (h/focused-cascade-time-ms
+              {:selected-event-bundle {:dispatched {:time "not-a-number"}}}))
+      "non-numeric :time defends against a malformed/synthetic event-bundle"))
+
+(deftest resolve-now-ms-present-uses-live-clock
+  (is (= 9999 (h/resolve-now-ms :present 9999 1111))
+      "LIVE mode (:present) always uses the rAF-bumped live clock, even
+       when a focused-cascade timestamp is also available"))
+
+(deftest resolve-now-ms-retro-uses-focused-cascade-timestamp
+  (is (= 1111 (h/resolve-now-ms 3 9999 1111))
+      "RETRO mode (scrubber-position anything but :present) anchors to
+       the focused cascade's timestamp, NOT the live clock — the exact
+       rf2-8i1tg3 regression: pre-fix this returned 9999 (the stale
+       live clock)"))
+
+(deftest resolve-now-ms-retro-falls-back-to-live-clock-when-no-focused-ms
+  (is (= 9999 (h/resolve-now-ms 3 9999 nil))
+      "defensive fallback — a nil focused-cascade timestamp must not
+       freeze the ring at nil (every fraction calc would blank)"))

--- a/tools/xray/test/day8/re_frame2_xray/panels/machines/trace_state_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machines/trace_state_cljs_test.cljs
@@ -269,6 +269,72 @@
           fired       (trace-state/extract-fired-edge-ids def events :cart)]
       (is (= #{populate-id submit-id} fired)))))
 
+;; ---- :always-microstep fired-edge (rf2-8i1tg3) ---------------------------
+;;
+;; `commit-or-finalize` emits ONE `:rf.machine/transition` per macrostep
+;; whose `:after` is the FINAL settled state once every `:always`
+;; iteration has ALSO run — not the state the dispatched event's OWN
+;; transition landed in. Matching `(from, :after, event)` looked for an
+;; edge that does not exist, so a `:microsteps > 0` transition lit NO
+;; fired edge at all (`#{}`). The fix derives the direct event-driven
+;; target from the FIRST `:kind :microstep` cascade step and additionally
+;; lights each `:always` hop's own edge (matched on `event* :always`).
+
+(defn- always-microstep-definition
+  "`:populate` is event-driven (:empty -> :populated); `:populated`
+  declares an eventless `:always` straight through to
+  `:auto-processing` — the runtime settles `:always` to a fixed point
+  BEFORE the outer `:rf.machine/transition` trace commits, so the
+  trace's `:after` is `:auto-processing`, never the event-driven
+  `:populated` target."
+  []
+  {:initial :empty
+   :states  {:empty           {:on {:populate :populated}}
+             :populated       {:always :auto-processing}
+             :auto-processing {:final? true}}})
+
+(deftest extract-fired-edge-ids-always-microstep-lights-direct-and-chain-edges
+  (testing "rf2-8i1tg3 — a :microsteps > 0 macrostep lights BOTH the
+            dispatched event's own edge (:empty -> :populated) AND
+            the :always microstep's own edge (:populated ->
+            :auto-processing) — NOT the (from, FINAL-settled, event)
+            triple that matches no declared edge"
+    (let [def         (always-microstep-definition)
+          populate-id (canonical-edge-id def [:empty] [:populated] :populate)
+          always-id   (canonical-edge-id def [:populated] [:auto-processing] :always)
+          events      [{:operation  :rf.machine/transition
+                        :tags       {:machine-id :cart}
+                        :from       [:empty]
+                        :to         [:auto-processing]
+                        :event      :populate
+                        :microsteps 1
+                        :cascade    [{:kind             :microstep
+                                      :from             [:populated]
+                                      :to               [:auto-processing]
+                                      :microstep-index  0}]}]
+          fired       (trace-state/extract-fired-edge-ids def events :cart)]
+      (is (string? populate-id))
+      (is (string? always-id))
+      (is (not= populate-id always-id))
+      (is (= #{populate-id always-id} fired)
+          "both the event-driven edge AND the always-microstep edge light"))))
+
+(deftest extract-fired-edge-ids-no-microsteps-unaffected
+  (testing "rf2-8i1tg3 regression guard — a plain (:microsteps 0)
+            transition is unaffected by the microstep-target derivation
+            (falls through to the pre-existing to-path-from-trace read)"
+    (let [def         (toy-definition)
+          populate-id (canonical-edge-id def [:empty] [:populated] :populate)
+          events      [{:operation  :rf.machine/transition
+                        :tags       {:machine-id :cart}
+                        :from       [:empty]
+                        :to         [:populated]
+                        :event      :populate
+                        :microsteps 0
+                        :cascade    []}]
+          fired       (trace-state/extract-fired-edge-ids def events :cart)]
+      (is (= #{populate-id} fired)))))
+
 (deftest extract-fired-edge-ids-reads-modern-before-after-shape
   (testing "modern :tags {:before/:after {:state ...}} drives the match"
     (let [def         (toy-definition)

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -412,6 +412,11 @@
    :rf.xray/settings-active-tab
    :rf.xray/settings-clear-confirm-open?
    :rf.xray/settings-open?
+   ;; rf2-8i1tg3 — Keybindings tab "Handle keys?" master toggle sub.
+   ;; NOT part of `:rf.xray/setting` — the underlying atom
+   ;; (`config/keybinding-enabled?`) is a bare process-global
+   ;; `configure!` slot, not a persisted `:settings` key.
+   :rf.xray/keybinding-enabled?
    :rf.xray/show-me-when-this-changed-result
    :rf.xray/show-tool-frames?
    ;; rf2-r9lyy — opt-in surface for the :ungrouped pseudo-event-bundle bucket.
@@ -737,6 +742,11 @@
    :rf.xray/settings-select-tab
    :rf.xray/settings-toggle
    :rf.xray/settings-update
+   ;; rf2-8i1tg3 — Keybindings tab "Handle keys?" master toggle's
+   ;; reactive dual-write event (flips the `config/keybinding-enabled?`
+   ;; atom AND mirrors app-db so the checkbox's `:rf.xray/keybinding-
+   ;; enabled?` sub re-fires immediately, matching every other toggle).
+   :rf.xray/keybinding-enabled-update
    ;; rf2-nugvv (2026-06-04) — the Share affordance (rf2-nqw0v) + its
    ;; per-cascade structured export (rf2-0us27) events are removed with
    ;; the Machine panel's Share button (the modal's sole UI entry point).

--- a/tools/xray/test/day8/re_frame2_xray/settings/effects_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/settings/effects_cljs_test.cljs
@@ -503,3 +503,44 @@
     (when-let [html (html-root)]
       (is (= "12px" (.getPropertyValue (.-style html) "--rf-xray-font-size"))
           "<html> --rf-xray-font-size carries the persisted compact value"))))
+
+;; ---- Keybindings tab "Handle keys?" reactive dual-write (rf2-8i1tg3) ----
+;;
+;; Was: the Keybindings tab's master toggle read `config/keybinding-
+;; attach-enabled?` directly (a bare atom) and wrote via `config/set-
+;; keybinding-enabled!` — no dispatch, no app-db mirror, unlike every
+;; other toggle in this popup. The controlled checkbox's `:checked`
+;; never re-fired reactively off a change. The fix routes the toggle
+;; through `:rf.xray/keybinding-enabled-update` (flips the atom AND
+;; mirrors app-db) + a new `:rf.xray/keybinding-enabled?` sub the
+;; checkbox reads.
+
+(deftest keybinding-enabled-update-flips-atom-and-mirrors-app-db
+  (testing "rf2-8i1tg3 — dispatching :rf.xray/keybinding-enabled-update
+            flips the canonical config atom AND the app-db mirror the
+            new sub reads, in one atomic step"
+    (setup!)
+    (rf/with-frame :rf/xray
+      (is (true? @(rf/subscribe [:rf.xray/keybinding-enabled?]))
+          "default (never configured) reads true")
+      (rf/dispatch-sync [:rf.xray/keybinding-enabled-update false])
+      (is (false? (config/keybinding-attach-enabled?))
+          "the canonical atom flipped")
+      (is (false? @(rf/subscribe [:rf.xray/keybinding-enabled?]))
+          "the reactive sub mirror flipped in the SAME dispatch — no
+           stale controlled-checkbox read")
+      (rf/dispatch-sync [:rf.xray/keybinding-enabled-update true])
+      (is (true? (config/keybinding-attach-enabled?)))
+      (is (true? @(rf/subscribe [:rf.xray/keybinding-enabled?]))))))
+
+(deftest keybinding-enabled-sub-falls-back-to-atom-pre-first-dispatch
+  (testing "rf2-8i1tg3 — before any :rf.xray/keybinding-enabled-update
+            dispatch, the sub falls back to the live config atom
+            (mirrors every other `:rf.xray/setting`-style sub's pre-
+            first-open fallback) rather than a hardcoded default"
+    (setup!)
+    (config/set-keybinding-enabled! false)
+    (rf/with-frame :rf/xray
+      (is (false? @(rf/subscribe [:rf.xray/keybinding-enabled?]))
+          "sub reads the atom directly when app-db has never mirrored it"))
+    (config/set-keybinding-enabled! true)))

--- a/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
@@ -1474,8 +1474,9 @@
     (let [scroll-calls (atom 0)
           stub-el      #js {:scrollIntoView (fn [_opts]
                                               (swap! scroll-calls inc))}
-          ;; Reset the module-level atom so this test is hermetic.
+          ;; Reset the module-level atoms so this test is hermetic.
           _            (reset! @#'shell/last-scrolled-focus-id ::reset-marker)
+          _            (reset! @#'shell/focused-row-ref-cache nil)
           ref-fn       (#'shell/focused-row-ref 42 true)]
       (is (fn? ref-fn) "ref-fn is a function when auto-track? is true")
       ;; First call → scroll.
@@ -1498,6 +1499,31 @@
             callback."
     (is (nil? (#'shell/focused-row-ref 42 false))
         "auto-track? false → nil ref")))
+
+(deftest focused-row-ref-is-referentially-stable-across-rerenders
+  (testing "rf2-8i1tg3 — `event-row` is a plain fn re-invoked on every
+            parent re-render (not a stateful component), so calling
+            `focused-row-ref` repeatedly for the SAME still-focused row
+            simulates every re-render while focus doesn't change. React
+            treats a CHANGED callback-ref as detach-then-reattach on the
+            very next commit — a fresh closure per call would fire the
+            ref with `nil` (resetting the dedup atom) immediately before
+            re-attaching, permanently defeating the not= guard in
+            `focused-row-ref-scrolls-on-focus-change-only` above. The
+            fix memoizes on `id`: the SAME `[id auto-track?]` must
+            return the IDENTICAL fn object so React sees no ref change
+            and never detaches/reattaches for a row that stays focused."
+    (reset! @#'shell/focused-row-ref-cache nil)
+    (let [ref-fn-1 (#'shell/focused-row-ref 7 true)
+          ref-fn-2 (#'shell/focused-row-ref 7 true)]
+      (is (identical? ref-fn-1 ref-fn-2)
+          "repeat calls for the same still-focused id return the SAME fn object"))
+    ;; A genuine focus change (new id) MUST still produce a new closure
+    ;; — otherwise the cache would never invalidate.
+    (let [ref-fn-a (#'shell/focused-row-ref 1 true)
+          ref-fn-b (#'shell/focused-row-ref 2 true)]
+      (is (not (identical? ref-fn-a ref-fn-b))
+          "a different focus id produces a fresh fn object"))))
 
 ;; -------------------------------------------------------------------------
 ;; (4a) Ribbon nav button enable/disable state — rf2-htik0 Bug 1


### PR DESCRIPTION
## Summary

Fixes all 6 MEDIUM-confidence UI/panel findings enumerated in rf2-8i1tg3 (from the `/tools` xray sweep). All findings, fixes, and tests confirmed below — none deferred.

| # | Finding | File | Fix |
|---|---|---|---|
| 1 | Auto-open baseline never seeded | `settings/effects.cljs` | Seed `last-issue-count` from the reaction's current value before `add-watch` |
| 2 | Non-reactive keys toggle | `settings/{view,events,subs}.cljs` | New `:rf.xray/keybinding-enabled-update` event (dual-write) + `:rf.xray/keybinding-enabled?` sub |
| 3 | L2 divider drag recedes from pointer | `shell.cljs` | Invert the drag delta so the divider tracks the cursor 1:1 |
| 4 | Focused-row ref churn | `shell.cljs` | Memoize the ref callback on dispatch-id (single-slot cache) |
| 5 | `:always`-microstep fired-edge empty | `panels/machines/trace_state.cljs` | Derive the direct event-driven target + light every microstep's own edge |
| 6 | Retro-ring uses live clock | `panels/machine_after_rings.cljs` + helpers | Anchor to the focused cascade's dispatched timestamp when scrubber != `:present` |

### Per-finding detail

**1. Auto-open baseline (`settings/effects.cljs`)** — `install-auto-open-watcher!` now does `(reset! last-issue-count (count (:issues @reaction)))` before `add-watch`, so a reaction that's already non-empty at install time (e.g. re-install after a focus-nav that already landed on an issue-carrying epoch) doesn't get misclassified as the empty->non-empty edge on the next change. Test: existing `settings/effects_cljs_test.cljs` auto-open-watcher tests continue to pass; the seeding is exercised implicitly by every existing watcher test (all now start from a correctly-seeded baseline).

**2. Keys-toggle reactivity (`settings/view.cljs` + `events.cljs` + `subs.cljs`)** — The "Handle keys?" master toggle was reading `config/keybinding-attach-enabled?` directly (non-reactive) and writing via `config/set-keybinding-enabled!` with no dispatch/mirror, unlike every other toggle in the popup. New `:rf.xray/keybinding-enabled-update` event flips the atom AND mirrors app-db in one step; new `:rf.xray/keybinding-enabled?` sub reads the mirror (falling back to the atom pre-first-dispatch). `keybindings-section` now takes `dispatch` and subscribes reactively. Tests: `settings/effects_cljs_test.cljs` — 2 new tests (dual-write + pre-first-dispatch fallback).

**3. L2 divider drag (`shell.cljs`)** — `event id` is the row's sole `flex 1 1 auto` column, far to the left of every divider; it silently absorbs whatever a resizable column gives up or takes. Growing the dragged column by `d` therefore shrank `event id` by `d`, moving the divider itself LEFT by `d` while the pointer moved RIGHT by `d` (2xd divergence per frame — the classic "handle recedes from the cursor" bug), and also inverted from standard split-pane semantics (drag toward a column should shrink it). `col-divider-on-move` now computes `new-width = start-width - dx`, which both fixes the pointer-tracking AND restores the intuitive direction. Keyboard resize (no continuous pointer to track) is deliberately left unchanged. Docstrings (`col-divider`, `col-divider-on-move`, call-site comments) corrected — they'd claimed the divider sits to the divider-labeled column's RIGHT when the call sites actually place it to the LEFT. Tests: `event_list_resizable_cols_cljs_test.cljs` — the two pre-existing drag tests (`drag-right-widens-source-col` / `drag-left-narrows-col`, which encoded the buggy behavior) are replaced with `drag-right-narrows-col-and-tracks-cursor` / `drag-left-widens-col-and-tracks-cursor`.

**4. Focused-row ref churn (`shell.cljs`)** — `focused-row-ref` built a fresh closure on every call (i.e. every render of the focused row, since `event-row` is a plain fn, not a stateful component). React treats a changed callback-ref as detach(nil)->reattach on the very next commit, which reset `last-scrolled-focus-id` to `::never` immediately before re-checking it — permanently defeating the `not=` dedup guard. Now memoized on `id` via a single-slot `focused-row-ref-cache`, so the SAME still-focused row gets the identical fn object across re-renders. Benign today per the bead (only exercised in snap-to-head LIVE mode where `scrollIntoView block:nearest` is a no-op when already visible) but a latent scroll-stealing bug. Tests: `shell_cljs_test.cljs` — new `focused-row-ref-is-referentially-stable-across-rerenders` (asserts `identical?` across repeat calls for the same id, and a fresh object for a different id).

**5. `:always`-microstep fired-edge (`panels/machines/trace_state.cljs`)** — `commit-or-finalize` emits ONE `:rf.machine/transition` per macrostep whose `:after` is the FINAL settled state once every `:always` iteration has ALSO run, not the state the dispatched event's own transition landed in. `single-transition-fired-ids` matched `(from, :after, event)` against declared edges — a triple that doesn't correspond to any edge when microsteps ran — returning `#{}`. New `direct-event-target` reads the first `:kind :microstep` cascade step's `:from` as the true event-driven target (falls through to the plain `:after` when there are no microsteps — a no-op on the common case); `extract-fired-edge-ids` additionally lights each `:always` hop's own edge (matched on `event* :always`, the eventless-edge marker `chart.layout` mints). Scoped to single-active machines; parallel `:always` microsteps are a separate, not-yet-covered case (noted in the spec addition). Tests: `trace_state_cljs_test.cljs` — 2 new tests (direct+chain lighting; `:microsteps 0` regression guard).

**6. Retro-ring live-clock (`panels/machine_after_rings.cljs` + `_helpers.cljc`)** — The view subscribed to the scrubber-position but used it ONLY to gate `needs-ticking?`; it always fed the live `:rf.xray/now-ms` into `timers->ring-specs`, so leaving `:present` mode simply stopped the clock wherever it last sat instead of anchoring to the focused cascade, per xray/003 §M.2 ("Retro mode: the ring is static at the elapsed-fraction the timer had reached at the focused-cascade's timestamp"). New `machine-after-rings-helpers/resolve-now-ms` + `focused-cascade-time-ms` branch on scrubber-position: `:present` uses the live clock, anything else uses the focused event-bundle's dispatched time (via `:rf.xray/focused-event-bundle-detail`, referenced by keyword — no ns require, avoiding the `registry.cljs` cycle). Tests: `machine_after_rings_helpers_cljs_test.cljc` — 4 new pure-fn tests; `machine_after_rings_cljs_test.cljs` — 1 new view-level test asserting the `:tick` prop anchors to the focused cascade's timestamp in retro mode and the live clock in `:present`.

### Xray spec ratchet

- **`spec/003-Machine-Inspector.md`** — new "`:always`-microstep fired-edge highlight (rf2-8i1tg3)" subsection (finding 5); a "Shipped" note under M.2 correcting the stale "v1 ships: no rings" status and cross-referencing the retro-anchor fix (finding 6).
- **`spec/016-Auxiliary-Panels.md`** — new baseline-seeding paragraph under "Auto-open-on-error semantics" (finding 1).
- Findings 2, 3, 4 — **spec unchanged**: none of them have a documented behavioral contract that changed. #2's Keybindings-tab description ("master Handle keys? toggle") is unaffected — only the internal reactive-wiring was broken. #3 — no spec section documents the L2 divider's drag-direction mechanics (only "user-resizable"). #4 — the documented auto-scroll contract (LIVE mode scrolls, RETRO suspends) is unaffected; this was a latent, currently-inert implementation bug.

## Quality gates

- `cd tools/xray && clojure -M:test` — **1230 tests, 5675 assertions, 0 failures, 0 errors.**
- `cd implementation && npm run test:cljs` — **8099 tests, 37157 assertions, 0 failures, 0 errors.**
- `cd implementation && npm run test:xray-feature-gate` — **16 scenarios, 0 failures** (13 matrix rows covered).
- `cd implementation && npm run test:browser` — **235 tests, 773 assertions, 0 failures, 0 errors.**

## Risks

- Finding 3's fix changes the L2 divider's drag DIRECTION (previously backwards + non-tracking; now correct + tracking) — a visible behavior change for anyone who'd adapted to the old (buggy) direction. Pre-alpha posture — no compat shim, this is the correct fix.
- Finding 5 is scoped to single-active (flat/compound) machines; parallel-machine `:always` microsteps are a separate case, explicitly noted as out of scope in both the code comments and the spec addition — a natural follow-up bead if needed.
