### PR TITLE
fix(story): run/verdict correctness — queue-drain, step-boundary keying, cannot-run floor, required-runner union, check-grouping redaction (rf2-m0cge5)

### DIFF
--- a/tools/story/src/re_frame/story/plan.cljc
+++ b/tools/story/src/re_frame/story/plan.cljc
@@ -1472,7 +1472,25 @@
                                         :db-seed       db-seed
                                         :sub-overrides sub-overrides})
         ;; ---- runner requirement ----
-        required     (compute-required-runner setup script* assertions)
+        ;; rf2-m0cge5 finding 10: unioned across EVERY auto-run play's
+        ;; script, not just `script*` (the primary/first play alone).
+        ;; `[:world :scripts]` retains every play, and the runtime
+        ;; auto-runs each `:auto-run? true` one in order
+        ;; (`runner/auto-runnable-plays` — the single definition both
+        ;; `runtime/run-phase-4!` and `runner-events/auto-run!` delegate
+        ;; to). Runner-selection trusts `:required-runner` VERBATIM, so an
+        ;; auto-run play OTHER than the first whose step lifts capability
+        ;; (e.g. an `:assert-dom` checkpoint → `:dom`) that this slot never
+        ;; reflected let `:auto` selection pick a runner that cannot
+        ;; execute it — a spurious mid-run failure instead of an honest
+        ;; `:cannot-run` refusal at selection time. `scripts*` is the
+        ;; fully arg-substituted + folded plays vector (mirrors `script*`
+        ;; for the first play by construction), so this SUBSUMES the old
+        ;; single-play computation whenever the first play auto-runs (the
+        ;; common case) and correctly extends it to every other auto-run
+        ;; play.
+        auto-run-scripts (vec (mapcat :script (runner/auto-runnable-plays scripts*)))
+        required     (compute-required-runner setup auto-run-scripts assertions)
         ;; ---- source coords ----
         source       (:source child)
         platforms    (or (:platforms ctx) #{:client})

--- a/tools/story/src/re_frame/story/play/runner_events.cljc
+++ b/tools/story/src/re_frame/story/play/runner_events.cljc
@@ -38,6 +38,7 @@
   cascade."
   (:refer-clojure :exclude [run!])
   (:require [re-frame.core              :as rf]
+            [re-frame.frame             :as frame]
             #?(:cljs [reagent.core      :as r])
             [re-frame.story.assertions  :as assertions]
             [re-frame.story.config      :as config]
@@ -88,8 +89,8 @@
      :clj  (atom  {})))
 
 (defonce
-  ^{:doc "frame-id → vector of per-dispatch-step settle boundaries
-         (rf2-rkd14). Each element is the `:epoch-id` of the
+  ^{:doc "[frame-id play-key] → vector of per-dispatch-step settle
+         boundaries (rf2-rkd14). Each element is the `:epoch-id` of the
          most-recently-committed epoch at the moment a dispatch-opening
          step's settle BEGAN (0 when none has committed yet), recorded in
          dispatch-step execution order. The evidence projection
@@ -111,6 +112,21 @@
          ring survives eviction — `stamp-tape` compares it directly
          against each SURVIVING record's own `:epoch-id`, so eviction can
          only ever drop beats, never misattribute them.
+
+         rf2-m0cge5 finding 2: keyed by the `[frame-id play-key]` PAIR, not
+         `frame-id` alone. A multi-play sequencer (`run-plays-sequentially!`
+         / `runtime/run-phase-4!`) accumulates boundaries across several
+         play-keys on ONE frame (`:clear-boundaries? false`); the per-`[frame
+         play-key]` run-token guard (`current-state-for-play`) does NOT block
+         a CONCURRENT `run!` / `re-run!` / `run-play!` for a DIFFERENT
+         play-key on the SAME frame — that concurrent call's default
+         `:clear-boundaries? true` used to wipe this ONE shared frame-id
+         bucket out from under the in-flight sequence. Keying by the pair
+         confines each play's boundaries to its own slot so a same-frame,
+         different-play-key run can never collide with it; a multi-play
+         reader concatenates the per-play-key slots in the same order it
+         drove the plays (mirrors `:executed-script`'s
+         `(mapcat :script auto-plays)`).
 
          Plain atom on both runtimes — it is read once at result-build
          time, not a reactive UI input."}
@@ -134,11 +150,16 @@
   (get @run-state frame-id))
 
 (defn settle-boundaries
-  "Read the recorded per-dispatch-step settle boundaries for `frame-id`,
-  or nil. The runner-recorded narrative attribution the evidence
-  projection consumes to stamp `:rf.story/script-idx`."
-  [frame-id]
-  (get @step-boundaries frame-id))
+  "Read the recorded per-dispatch-step settle boundaries for
+  `[frame-id play-key]`, or nil. The runner-recorded narrative attribution
+  the evidence projection consumes to stamp `:rf.story/script-idx`.
+
+  rf2-m0cge5 finding 2: keyed by the pair, not `frame-id` alone — see
+  `step-boundaries`'s docstring. A caller reading a MULTI-play sequence's
+  accumulated boundaries calls this once per play-key it drove (in the
+  same order) and concatenates the results."
+  [frame-id play-key]
+  (get @step-boundaries [frame-id play-key]))
 
 (defn last-epoch-id
   "The `:epoch-id` of the most-recently-committed epoch for `frame-id`, or
@@ -178,10 +199,15 @@
   play K's, so the full vector zips against the concatenated script in
   dispatch order — an ordering fact, independent of ring occupancy. A
   per-play clear would drop every earlier play's boundaries, leaving only
-  the last play's to be mis-zipped."
-  [frame-id step]
+  the last play's to be mis-zipped.
+
+  rf2-m0cge5 finding 2: writes to the `[frame-id play-key]` composite key
+  (see `step-boundaries`'s docstring), so a same-frame run of a DIFFERENT
+  play-key accumulates into its OWN slot and can never collide with — or
+  be wiped alongside — this one."
+  [frame-id play-key step]
   (when (evidence/dispatch-step? step)
-    (swap! step-boundaries update frame-id (fnil conj []) (last-epoch-id frame-id)))
+    (swap! step-boundaries update [frame-id play-key] (fnil conj []) (last-epoch-id frame-id)))
   nil)
 
 (defn current-state-for-play
@@ -205,19 +231,30 @@
   nil)
 
 (defn clear-step-boundaries!
-  "Reset the per-dispatch-step settle boundaries for `frame-id`.
-  Called at the START of a fresh script run so the narrative attribution
-  windows onto THIS run's epoch tape, not a previous run's boundaries.
+  "Reset the per-dispatch-step settle boundaries for `[frame-id play-key]`
+  (the 1-arity defaults `play-key` to nil — the default/single play, the
+  stepper's convention). Called at the START of a fresh script run so the
+  narrative attribution windows onto THIS run's epoch tape, not a previous
+  run's boundaries.
 
   Owned by every entry that WRITES boundaries: the public driver
-  `run!`, the orchestrator `runtime/run-phase-4!` (which also covers its
-  no-auto-plays branch), and the stepper start `play/begin-stepper!` (via the
-  `:clear-step-boundaries` late-bind seam). So a non-orchestrator re-run /
+  `run!` (clears its OWN resolved play-key), the multi-play sequencers
+  (`run-plays-sequentially!`, the orchestrator `runtime/run-phase-4!` —
+  which also covers its no-auto-plays branch) clear each play-key they are
+  ABOUT to drive, and the stepper start `play/begin-stepper!` (via the
+  `:clear-step-boundaries` late-bind seam, always play-key nil — the
+  stepper only ever walks the default play). So a non-orchestrator re-run /
   replay-in-place / stepping session never inherits stale accumulated
-  offsets that would mis-attribute the exact narrative."
-  [frame-id]
-  (swap! step-boundaries dissoc frame-id)
-  nil)
+  offsets that would mis-attribute the exact narrative.
+
+  rf2-m0cge5 finding 2: scoped to ONE `[frame-id play-key]` slot (see
+  `step-boundaries`'s docstring) — clearing play-key K's boundaries never
+  touches a DIFFERENT play-key's slot on the same frame, closing the
+  concurrent-run wipe hazard."
+  ([frame-id] (clear-step-boundaries! frame-id nil))
+  ([frame-id play-key]
+   (swap! step-boundaries dissoc [frame-id play-key])
+   nil))
 
 (defn clear-state!
   "Wipe the run-state for `frame-id` across all four process-global atoms
@@ -231,7 +268,12 @@
                         (into {} (remove (fn [[[fid _]]]
                                            (= fid frame-id)) m))))
   (swap! active-play dissoc frame-id)
-  (swap! step-boundaries dissoc frame-id)
+  ;; `step-boundaries` is keyed by [frame-id play-key] (rf2-m0cge5 finding
+  ;; 2) — evict every play-key's slot for this frame, mirroring the
+  ;; `runs-by-play` cleanup just above.
+  (swap! step-boundaries (fn [m]
+                           (into {} (remove (fn [[[fid _]]]
+                                              (= fid frame-id)) m))))
   nil)
 
 (defn clear-all-runs!
@@ -928,20 +970,50 @@
                                                       (pr-str (:payload rec)) " failed"))})
                 :else                 (runner/step-pass idx step))))))))
 
+(defn- frame-router-state
+  "Read the raw `{:queue :scheduled? ...}` router state for `frame-id`, or
+  nil for an unknown / destroyed frame. There is no dedicated public
+  accessor for router/queue state on the framework facade (`re-frame.core`)
+  yet; Story already depends on `re-frame.frame` directly elsewhere
+  (`re-frame.story.frames`), so this reaches one level further into the
+  SAME already-depended-on ns rather than adding a new cross-boundary
+  dependency. Tolerant — a throwing host (or an absent/destroyed frame)
+  reads as nil."
+  [frame-id]
+  (try
+    (some-> (frame/frame frame-id) :router deref)
+    (catch #?(:clj Throwable :cljs :default) _ nil)))
+
 (defn- queue-empty?
-  "True iff `frame-id`'s event queue has drained. Under a
-  settled-boundary runner the preceding `[:dispatch …]` step ran the
-  router to a FIXED POINT (`settled-boundary` — the `dispatch-sync*`
-  run-to-completion drain in headless), so by the time a following
-  `[:wait-until [:queue-empty]]` is evaluated the queue is, by contract,
-  drained. The predicate is the explicit, readable settle-on-drain form;
-  it is satisfied whenever the runner has reached the settled boundary,
-  which the step driver guarantees before this step runs. Returns true."
-  [_frame-id]
-  ;; The settled-boundary contract (re-frame.story.play.settled-boundary)
-  ;; guarantees the queue has drained to a fixed point before the next
-  ;; step executes; there is no partial-drain state to observe here.
-  true)
+  "True iff `frame-id`'s event queue has GENUINELY drained — no envelope
+  left in the router's `:queue` AND no pending async drain tick
+  (`:scheduled?`). A real read of the frame's router state (rf2-m0cge5
+  finding 1) — the previous implementation was a hard-coded `true` stub.
+
+  That stub's own comment justified it ONLY from the `[:dispatch …]` case:
+  under `settled-boundary` a preceding dispatch step already ran the
+  router to a fixed point, so the queue IS drained by the time a
+  following `[:wait-until [:queue-empty]]` runs. But this step can ALSO
+  follow a `:click` / `:type` / `:focus` step — `exec-click!` / `exec-type!`
+  / `exec-focus!` (above) fire a synthetic DOM event directly and never
+  call `boundary/dispatch-and-settle!`. A handler the synthetic event
+  triggers may issue an ASYNC `[:dispatch …]` that has not yet drained —
+  the router schedules an async drain via `interop/next-tick`, genuinely
+  deferred, never inline (`re-frame.router/ensure-drain-scheduled!`). A
+  hard-coded `true` silently reported that pending dispatch as settled, so
+  a following `:assert-*` step could read app-db BEFORE it landed — the
+  exact dispatch-vs-settle race `[:wait-until [:queue-empty]]` exists to
+  catch. Per `exec-wait-until!`'s one-shot (non-polling) headless contract,
+  an unmet predicate now correctly FAILS readably instead of passing
+  vacuously.
+
+  Tolerant — an unregistered / destroyed frame reads as drained (nothing
+  left to wait for)."
+  [frame-id]
+  (let [state (frame-router-state frame-id)]
+    (or (nil? state)
+        (and (empty? (:queue state))
+             (not (:scheduled? state))))))
 
 (defn- wait-until-satisfied?
   "Evaluate a decomposed `:wait-until` predicate against `frame-id`'s
@@ -1093,9 +1165,13 @@
   Public so the step-debugger substrate (`play/step-once!`) can drive a
   full rich-DSL step without re-implementing the executor. Reached from
   `play.cljc` via the `:run-play-step` late-bind hook to avoid the
-  play ↔ runner-events require cycle."
+  play ↔ runner-events require cycle.
+
+  Always records its settle boundary under play-key nil — the stepper
+  (`play/variant-play-steps`) only ever walks the DEFAULT play, never a
+  named `:plays` entry."
   [frame-id idx step]
-  (record-settle-boundary! frame-id step)
+  (record-settle-boundary! frame-id nil step)
   (let [result (try
                  (exec-step! frame-id idx step)
                  (catch #?(:clj Throwable :cljs :default) e
@@ -1238,7 +1314,7 @@
             (schedule! (or ms 0) #(run-loop! frame-id play-key token done-cb)))
 
           :else
-          (let [_      (record-settle-boundary! frame-id step)
+          (let [_      (record-settle-boundary! frame-id play-key step)
                 result (try
                          (exec-step! frame-id idx step)
                          (catch #?(:clj Throwable :cljs :default) e
@@ -1342,8 +1418,14 @@
      ;; drop every earlier play's boundaries, leaving only the LAST play's
      ;; to be mis-zipped against the concatenated script's leading dispatch
      ;; steps — a false-green evidence-provenance failure.
+     ;;
+     ;; rf2-m0cge5 finding 2: clears ONLY this run's OWN `[variant-id pk]`
+     ;; slot, never the whole frame — a concurrent run! for a DIFFERENT
+     ;; play-key on this SAME frame (not blocked by the per-`[frame
+     ;; play-key]` run-token guard above) writes to its OWN slot and can
+     ;; no longer wipe an in-flight multi-play sequence's accumulator.
      (when clear-boundaries?
-       (clear-step-boundaries! variant-id))
+       (clear-step-boundaries! variant-id pk))
      (set-state! variant-id pk started)
      (set-active-play! variant-id pk)
      (run-loop! variant-id pk token done-cb)
@@ -1419,10 +1501,14 @@
   Resolves `done-cb` with a vector of terminal states once every play
   has finished (or the loop is interrupted by a missing frame).
 
-  Clears the per-dispatch-step settle boundaries ONCE up front, then
-  drives each play with `:clear-boundaries? false` so the boundaries
-  ACCUMULATE across the sequence. The evidence narrative spans the
-  CONCATENATED play scripts, and `:epoch-id` only ever increases across
+  Clears the per-dispatch-step settle boundaries for EVERY play-key this
+  sequence is about to drive, ONCE up front, then drives each play with
+  `:clear-boundaries? false` so each play's OWN `[variant-id play-key]`
+  slot ACCUMULATES across the sequence (rf2-m0cge5 finding 2: boundaries
+  are keyed by the pair, not by `variant-id` alone, so this clear can never
+  wipe a DIFFERENT, concurrently-running play-key's slot on this same
+  frame — see `step-boundaries`'s docstring). The evidence narrative spans
+  the CONCATENATED play scripts, and `:epoch-id` only ever increases across
   the run (rf2-96qsjr — independent of ring eviction), so each play's
   boundaries tail the previous play's for `stamp-tape`'s dispatch-order
   zip to stay aligned. Letting each `run!` clear would leave only the
@@ -1430,7 +1516,8 @@
   earlier-play steps."
   [variant-id plays done-cb]
   (let [acc (atom [])]
-    (clear-step-boundaries! variant-id)
+    (doseq [pk (map :name plays)]
+      (clear-step-boundaries! variant-id pk))
     (letfn [(step! [remaining]
               (if (empty? remaining)
                 (when done-cb

--- a/tools/story/src/re_frame/story/result.cljc
+++ b/tools/story/src/re_frame/story/result.cljc
@@ -278,14 +278,45 @@
   [a]
   (when (vector? a) (vec (rest a))))
 
+(def ^:private redaction-prone-assertion-ids
+  "Assertion ids whose evaluator may rebuild the run RECORD's `:payload`
+  from a REDACTED expected value for a sensitive path/sub
+  (`assertions/evaluate-path-equals` / `evaluate-sub-equals` rebuild
+  `:payload` as `[path-or-sub-vec exp-redacted]`). The compiled check
+  plan's atom, by contrast, always carries the RAW author-declared
+  expected value — plan atoms are never redacted (redaction only happens
+  at run time, against a live frame). rf2-m0cge5 finding 11: an
+  exact-payload match between the two therefore never agrees for a
+  sensitive assertion."
+  #{assertions/id-path-equals assertions/id-sub-equals})
+
 (defn- record-matches-atom?
   "True iff assertion `record` was produced by assertion `atom-v` — same
   `:rf.assert/*` id AND same payload. Pure data → data. The payload match
-  disambiguates two `:rf.assert/path-equals` against different paths within
-  one check."
+  disambiguates two atoms of the same id against different paths within
+  one check.
+
+  For the two REDACTION-PRONE ids (`redaction-prone-assertion-ids`), the
+  comparison instead uses a redaction-invariant key: only the payload's
+  FIRST element (the path / sub-vec — a structural coordinate, never
+  itself redacted by either evaluator) is compared, never the second
+  (the possibly-redacted expected value). Without this, a sensitive
+  `:rf.assert/path-equals` — whose run RECORD carries `[path
+  :rf/redacted]` while the check plan's atom still carries the raw
+  `[path <secret>]` — never matches: the record is never grouped under
+  its check, so the check's `:assertions` reads empty and aggregates
+  vacuously to `:pass` even when the sensitive assertion FAILED (the
+  run-level verdict stays correct — `records` still folds it directly —
+  but the check-level grouping lies). The path/sub-vec position stays an
+  exact, disambiguating key for every other case (two atoms of this id
+  against DIFFERENT paths in one check remain distinct)."
   [record atom-v]
-  (and (= (:assertion record) (atom-id atom-v))
-       (= (vec (:payload record)) (atom-payload atom-v))))
+  (let [id (atom-id atom-v)]
+    (boolean
+      (and (= (:assertion record) id)
+           (if (contains? redaction-prone-assertion-ids id)
+             (= (first (:payload record)) (first (atom-payload atom-v)))
+             (= (vec (:payload record)) (atom-payload atom-v)))))))
 
 (defn check-record
   "Build ONE check record (spec/017 §Run result — Check record) for
@@ -753,10 +784,21 @@
                          (remove #(contains? consumed-selectors (:selector %))))
         tape-red?      (evidence/evidence-shows-failure?
                          tape unconsumed (:effects evidence-slots) nil :unconsumed)
-        ;; The agreement floor escalates ONLY a would-be pass — a real
-        ;; :fail / :error / :cannot-run already outranks it (the floor never
-        ;; downgrades a higher verdict).
-        status         (if (and (= :pass base-status) tape-red?)
+        ;; The agreement floor escalates a would-be `:pass` OR a
+        ;; `:cannot-run` to `:fail` — a real `:error` already outranks it
+        ;; (the floor never downgrades a higher verdict), per the ONE
+        ;; precedence rule `:error` > `:fail` > `:cannot-run` > `:pass`
+        ;; (rf2-m0cge5 finding 9). Before this fix the floor lifted only
+        ;; `:pass` → `:fail`: a run that was ALSO `:cannot-run` (some
+        ;; expectation the runner could not even attempt) left `status`
+        ;; at `:cannot-run` even when the tape independently carried an
+        ;; unconsumed schema-validation failure (`tape-red?` true) — a
+        ;; MUST-fail masked by a lower-ranked refusal, the opposite of
+        ;; "never mask a real failure". `:cannot-run` and `tape-red?` are
+        ;; orthogonal signals (an unmet-requirement refusal and an
+        ;; unconsumed schema violation can both be true of the same run),
+        ;; so both floor-eligible base statuses escalate.
+        status         (if (and tape-red? (#{:pass :cannot-run} base-status))
                          :fail
                          base-status)
         identity-slots (select-keys parts [:variant/id :plan-hash :run-hash

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -592,7 +592,7 @@
   so a registered variant and an INLINE plan assemble the
   same result through one path."
   [{:keys [variant-id decorator-stack effective-args snapshot executed-script
-           plan runner-selection epoch-baseline]} start-ms]
+           executed-play-keys plan runner-selection epoch-baseline]} start-ms]
   (let [app-db   (rf/app-db-value variant-id)
         ;; Read the epoch tape through the
         ;; late-bound `re-frame.core/epoch-history` facade (mirroring
@@ -641,7 +641,21 @@
         ;; zero-point shift needed, unlike the old count-based scheme,
         ;; because identity comparison is unaffected by how `tape` was
         ;; sliced or how much of the ring survived eviction.
-        attribution (runner-events/settle-boundaries variant-id)
+        ;;
+        ;; rf2-m0cge5 finding 2: `step-boundaries` is keyed by `[frame-id
+        ;; play-key]`, not `frame-id` alone (a concurrent run for a
+        ;; DIFFERENT play-key on this frame must never collide with —  or
+        ;; wipe — this run's boundaries). Read each auto-play's OWN slot,
+        ;; in the SAME order `run-phase-4!` drove them (`executed-script`
+        ;; concatenates their scripts in this order too), and concatenate —
+        ;; reconstructing the one attribution vector `stamp-tape` zips
+        ;; against the concatenated dispatch steps. Absent
+        ;; `executed-play-keys` (a pre-phase-4 error result, no script
+        ;; ever ran) degrades to `[]`, identical to the old `nil` — both
+        ;; read as "absent" by `stamp-tape`'s `(empty? bounds)` check.
+        attribution (into []
+                          (mapcat #(runner-events/settle-boundaries variant-id %))
+                          (or executed-play-keys []))
         ;; Project the tape ONCE here so the post-run evidence
         ;; validation (`requirements-unmet` → `validate-run-evidence`) reads
         ;; the SAME projected slots `result/run-result` derives the result
@@ -1004,9 +1018,10 @@
 (defn- run-phase-4!
   "Phase 4: run the play-script. Returns `[ctx' play-promise]` — `ctx'`
   carries `:executed-script` (the folded steps the auto-plays ran, for the
-  unified result's two-level narrative), and the
-  orchestrator chains `then` on the promise to know when to build the
-  result.
+  unified result's two-level narrative) and `:executed-play-keys` (the
+  auto-plays' `:name`s, in the SAME order — rf2-m0cge5 finding 2, see
+  below), and the orchestrator chains `then` on the promise to know when
+  to build the result.
 
   Drives the rich-DSL `:play-script` runner via
   `runner-events/run!`. Variants without `:play-script` / `:plays`
@@ -1037,15 +1052,28 @@
           ;; The folded steps the auto-plays ran, concatenated in order —
           ;; the script the unified result's two-level narrative spans.
           executed   (vec (mapcat :script auto-plays))
-          ctx'       (assoc ctx :executed-script executed)
-          ;; Reset the per-dispatch-step settle boundaries before
-          ;; the auto-plays drive, so the narrative attribution windows onto
-          ;; THIS run's epoch tape. The boundaries snapshot the last-
-          ;; committed `:epoch-id` at each dispatch step (setup-phase
-          ;; epochs carry an id at or before the first boundary → leading
-          ;; nil span), the SAME identity `record-result-map` compares
-          ;; against when it filters the tape (rf2-96qsjr).
-          _          (runner-events/clear-step-boundaries! variant-id)]
+          ;; The auto-plays' own play-keys, in the SAME order as `executed`
+          ;; concatenates their scripts. `record-result-map` reads each
+          ;; play-key's OWN settle-boundaries slot and concatenates them in
+          ;; this order to reconstruct the full per-dispatch-step attribution
+          ;; vector (rf2-m0cge5 finding 2 — `step-boundaries` is keyed by
+          ;; `[frame-id play-key]`, not `frame-id` alone).
+          play-keys  (mapv :name auto-plays)
+          ctx'       (assoc ctx
+                            :executed-script executed
+                            :executed-play-keys play-keys)
+          ;; Reset the per-dispatch-step settle boundaries for EVERY
+          ;; play-key this run is about to drive, before the auto-plays run,
+          ;; so the narrative attribution windows onto THIS run's epoch
+          ;; tape. The boundaries snapshot the last-committed `:epoch-id` at
+          ;; each dispatch step (setup-phase epochs carry an id at or before
+          ;; the first boundary → leading nil span), the SAME identity
+          ;; `record-result-map` compares against when it filters the tape
+          ;; (rf2-96qsjr). Clearing per-play-key (rather than the whole
+          ;; frame) means a concurrent run for a DIFFERENT play-key on this
+          ;; frame can never be wiped by — or wipe — this reset.
+          _          (doseq [pk play-keys]
+                       (runner-events/clear-step-boundaries! variant-id pk))]
       (if (empty? auto-plays)
         ;; No script ran, but the world settled (phase-2 setup committed).
         ;; The terminal `:assertions` check the FINAL settled state, so they

--- a/tools/story/test/re_frame/story/plan_test.cljc
+++ b/tools/story/test/re_frame/story/plan_test.cljc
@@ -336,6 +336,42 @@
       (is (contains? (:required-runner p) :app-db)
           "the DOM-free :dispatch script still contributes :app-db"))))
 
+(deftest required-runner-unions-across-every-auto-run-play
+  (testing "a NON-first :auto-run? true play whose step lifts capability
+            (a :click DOM step) is unioned into :required-runner — not
+            just the primary (first) play's tokens (rf2-m0cge5 finding 10).
+            Before the fix, `:required-runner` was computed over the
+            primary `:script` (the first play) alone even though
+            `[:world :scripts]` retains every play and the runtime
+            auto-runs each `:auto-run? true` one; `:auto` runner-selection
+            trusts `:required-runner` verbatim, so it could pick a
+            headless runner unable to execute the second play's DOM step
+            — a spurious mid-run failure instead of an honest
+            `:cannot-run` refusal at selection time."
+    (let [m {:story.r/multi-autorun
+             {:plays [{:name "first"  :auto-run? true
+                       :script [[:dispatch [:a]]]}
+                      {:name "second" :auto-run? true
+                       :script [[:click "[data-test=go]"]]}]}}
+          p (plan-of :story.r/multi-autorun m)]
+      (is (contains? (:required-runner p) :dom)
+          "the SECOND auto-run play's :click step lifts :required-runner
+           to :dom, even though the first play never touches the DOM")
+      (is (contains? (:required-runner p) :app-db)
+          "the first play's :dispatch still contributes :app-db")))
+  (testing "a play with :auto-run? false is NOT unioned — it never
+            executes automatically, so its capability tokens correctly
+            stay out of :required-runner"
+    (let [m {:story.r/manual-dom
+             {:plays [{:name "auto"   :auto-run? true
+                       :script [[:dispatch [:a]]]}
+                      {:name "manual" :auto-run? false
+                       :script [[:click "[data-test=go]"]]}]}}
+          p (plan-of :story.r/manual-dom m)]
+      (is (not (contains? (:required-runner p) :dom))
+          "the manually-triggered play's DOM step never auto-runs, so it
+           does not lift :required-runner"))))
+
 ;; ---- explain -------------------------------------------------------------
 
 (deftest explain-includes-source-chain-and-substitutions

--- a/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
@@ -843,8 +843,9 @@
 ;; ---- rf2-vkdam: the public driver OWNS the boundary reset ----------------
 ;;
 ;; `record-settle-boundary!` APPENDS a per-dispatch-step settle boundary onto
-;; the process-global `step-boundaries` atom (keyed by frame-id). Previously
-;; only the orchestrator (`runtime/run-phase-4!`) cleared, so a non-orchestrator
+;; the process-global `step-boundaries` atom (keyed by `[frame-id play-key]`
+;; — rf2-m0cge5 finding 2). Previously only the orchestrator
+;; (`runtime/run-phase-4!`) cleared, so a non-orchestrator
 ;; re-run via the public `run!` (interactive Re-run / replay-in-place) kept
 ;; accumulating boundaries until teardown — a latent hazard for any future
 ;; consumer reading `settle-boundaries` after such a run (stale offsets →
@@ -869,15 +870,69 @@
        (async/deref-blocking (story/run-variant :story.vkdam/rerun) 5000)
        ;; First public run via `run!` (NOT the orchestrator).
        (run-blocking :story.vkdam/rerun)
-       (let [after-first (count (re/settle-boundaries :story.vkdam/rerun))]
+       ;; `run-blocking` drives `run!`'s 2-arity form, which resolves to
+       ;; play-key nil (the `:play-script` variant's single default play) —
+       ;; `settle-boundaries` is keyed by `[frame-id play-key]` (rf2-m0cge5
+       ;; finding 2), so reads pass that same nil.
+       (let [after-first (count (re/settle-boundaries :story.vkdam/rerun nil))]
          (is (= 3 after-first)
              "three dispatch steps record three boundaries")
          ;; Second public run — an interactive Re-run. WITHOUT the reset this
          ;; would accumulate to six; WITH it, `run!` clears at start so the
          ;; frame again holds exactly THIS run's three boundaries.
          (run-blocking :story.vkdam/rerun)
-         (is (= 3 (count (re/settle-boundaries :story.vkdam/rerun)))
+         (is (= 3 (count (re/settle-boundaries :story.vkdam/rerun nil)))
              "the public driver reset its boundaries — no stale accumulation")))))
+
+;; ---- rf2-m0cge5 finding 2: step-boundaries keyed by [frame-id play-key] --
+;;
+;; `step-boundaries` was previously keyed by `frame-id` ALONE. A multi-play
+;; sequencer (`run-plays-sequentially!` / `runtime/run-phase-4!`) accumulates
+;; boundaries across several plays on ONE frame via `:clear-boundaries?
+;; false`; the per-`[frame play-key]` run-token guard does NOT block a
+;; CONCURRENT `run!` for a DIFFERENT play-key on that SAME frame — that
+;; concurrent call's default `:clear-boundaries? true` used to wipe the ONE
+;; shared frame-id bucket out from under the in-flight sequence. Keying by
+;; the `[frame-id play-key]` pair confines each play's boundaries to its own
+;; slot, closing the hazard.
+
+#?(:clj
+   (deftest concurrent-run-for-different-play-key-does-not-wipe-boundaries
+     (testing "a concurrent run! for a DIFFERENT play-key on the SAME frame
+              (default :clear-boundaries? true) does not wipe an in-flight
+              sequence's accumulated boundaries for ANOTHER play-key
+              (rf2-m0cge5 finding 2)"
+       (rf/reg-event :m0cge5/touch
+         (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
+       (story/reg-variant :story.m0cge5/two-key
+         {:events []
+          :play-script {:auto-run? false :script []}})
+       ;; Allocate the frame so `run!` has a live frame to dispatch into.
+       (async/deref-blocking (story/run-variant :story.m0cge5/two-key) 5000)
+       (let [spec-a {:name "A" :auto-run? false
+                     :script [[:dispatch-sync [:m0cge5/touch]]]}
+             spec-b {:name "B" :auto-run? false
+                     :script [[:dispatch-sync [:m0cge5/touch]]]}
+             done-a (promise)
+             done-b (promise)]
+         ;; Simulate the sequencer driving play "A" WITHOUT clearing (as
+         ;; `run-plays-sequentially!` drives every play it owns).
+         (re/run! :story.m0cge5/two-key "A" spec-a (fn [_] (deliver done-a :ok))
+                  {:clear-boundaries? false})
+         (deref done-a 5000 :timeout)
+         (is (= 1 (count (re/settle-boundaries :story.m0cge5/two-key "A")))
+             "play A recorded its own boundary")
+         ;; A concurrent ad-hoc run for a DIFFERENT play-key "B" — e.g. an
+         ;; interactive Re-run of a different play via the toolbar dropdown —
+         ;; using the DEFAULT :clear-boundaries? true.
+         (re/run! :story.m0cge5/two-key "B" spec-b (fn [_] (deliver done-b :ok)))
+         (deref done-b 5000 :timeout)
+         (is (= 1 (count (re/settle-boundaries :story.m0cge5/two-key "A")))
+             "play A's boundaries are UNTOUCHED by the concurrent play B run
+              — before the fix both shared the frame-id-only key, so B's
+              default clear wiped A's entry mid-sequence")
+         (is (= 1 (count (re/settle-boundaries :story.m0cge5/two-key "B")))
+             "play B recorded its own boundary under its own key")))))
 
 ;; ---- rf2-96qsjr: narrative attribution survives epoch-ring eviction ------
 ;;

--- a/tools/story/test/re_frame/story/play/step_runner_test.cljc
+++ b/tools/story/test/re_frame/story/play/step_runner_test.cljc
@@ -195,6 +195,7 @@
 ;; ===========================================================================
 
 (def ^:private exec-step! @#'re/exec-step!)
+(def ^:private queue-empty? @#'re/queue-empty?)
 
 (def ^:private step-frame :story.step-runner/frame)
 
@@ -239,6 +240,40 @@
             settled boundary"
     (let [res (exec-step! step-frame 0 [:wait-until [:queue-empty]])]
       (is (nil? (:passed? res))))))
+
+(deftest queue-empty-reads-the-real-router-queue
+  (testing "queue-empty? reads the frame's ACTUAL router queue rather than
+            a hard-coded `true` stub (rf2-m0cge5 finding 1). `[:click]` /
+            `[:type]` / `[:focus]` fire a synthetic DOM event directly and
+            never call `boundary/dispatch-and-settle!`, so a handler the
+            event triggers may enqueue an ASYNC `[:dispatch …]` that has not
+            yet drained (the router schedules async drains via
+            `interop/next-tick` — genuinely deferred, never inline). A
+            following `[:wait-until [:queue-empty]]` must see that as NOT
+            drained rather than silently reporting `true` — the exact
+            dispatch-vs-settle race the step exists to catch."
+    (is (true? (queue-empty? step-frame))
+        "a frame with an empty router queue and no pending drain reads as
+         drained")
+    ;; Directly manipulate the frame's router state (rather than racing a
+    ;; REAL async `rf/dispatch` against `interop/next-tick`'s host scheduler
+    ;; — on the JVM `next-tick` runs on a SEPARATE executor thread, so timing
+    ;; the check against a live dispatch would be inherently flaky). This
+    ;; exercises the read mechanism deterministically: a non-empty `:queue`
+    ;; is exactly the state an async-dispatched, not-yet-drained envelope
+    ;; leaves behind.
+    (let [router (:router (frame/frame step-frame))]
+      (swap! router update :queue conj {:event [:step/inc]})
+      (is (false? (queue-empty? step-frame))
+          "a non-empty router queue reads as NOT drained — the old
+           hard-coded stub silently reported `true` here, hiding a pending
+           dispatch from a following :assert-* read")
+      ;; Draining the queue (what the router's own drain loop does once the
+      ;; scheduled tick runs) flips the read back to true.
+      (swap! router assoc :queue (empty (:queue @router)))
+      (is (true? (queue-empty? step-frame))
+          "once the queue is actually empty again, the real check reports
+           true"))))
 
 (deftest wait-until-times-out-readably-when-predicate-never-true
   (testing "an unmet [:wait-until pred] records a step-fail with a readable

--- a/tools/story/test/re_frame/story/result_test.cljc
+++ b/tools/story/test/re_frame/story/result_test.cljc
@@ -100,6 +100,47 @@
       (is (= :pass (:status (first recs))) "an empty group is vacuously :pass")
       (is (empty? (:assertions (first recs)))))))
 
+(deftest check-groups-sensitive-path-equals-record-by-redaction-invariant-key
+  (testing "a sensitive :rf.assert/path-equals record — whose :payload was
+            rebuilt from the REDACTED expected value at run time
+            ([path :rf/redacted], per assertions.cljc `evaluate-path-equals`)
+            — still groups under its check even though the check plan's atom
+            carries the RAW author-declared expected value ([path <secret>]).
+            Before rf2-m0cge5 finding 11's fix, the exact-payload match never
+            agreed for a sensitive assertion (`:rf/redacted` != the raw
+            secret), so the check's :assertions read empty and the check
+            vacuously aggregated to :pass even though the assertion FAILED
+            (the run-level verdict stayed correct via the ungrouped
+            `records` fold — only the check-level grouping lied)."
+    (let [records [{:assertion :rf.assert/path-equals
+                    :payload   [[:user :ssn] :rf/redacted]
+                    :status    :fail
+                    :expected  :rf/redacted
+                    :actual    :rf/redacted}]
+          check->atoms {:check/no-leak [[:rf.assert/path-equals [:user :ssn] "123-45-6789"]]}
+          recs (result/check-records check->atoms records)
+          c    (first recs)]
+      (is (= :check/no-leak (:check c)))
+      (is (= 1 (count (:assertions c)))
+          "the redacted record IS grouped under its check — matched by the
+           redaction-invariant path key, not the (unequal) raw payload")
+      (is (= :fail (:status c))
+          "the check's own status reflects the sensitive assertion's real
+           FAILURE, not a vacuous :pass from an empty group")))
+  (testing "a NON-sensitive :rf.assert/sub-equals record still matches by
+            full payload when unaffected by redaction — the fix only
+            changes the comparison KEY for the two redaction-prone ids, it
+            does not weaken disambiguation for the ordinary case"
+    (let [records [{:assertion :rf.assert/sub-equals :payload [[:sub/a] 1] :status :pass}
+                   {:assertion :rf.assert/sub-equals :payload [[:sub/b] 2] :status :fail}]
+          check->atoms {:check/a [[:rf.assert/sub-equals [:sub/a] 1]]}
+          recs (result/check-records check->atoms records)
+          c    (first recs)]
+      (is (= 1 (count (:assertions c)))
+          "only the matching sub-vec's record groups under the check —
+           different sub-vecs remain disambiguated")
+      (is (= :pass (:status c))))))
+
 ;; ===========================================================================
 ;; RUN RESULT — the unified shape + the agreement floor
 ;; ===========================================================================
@@ -186,6 +227,35 @@
                   :consumed-selectors #{sel}})]
       (is (= :pass (:status r))
           "the consumed violation is excused — the floor does not trip"))))
+
+(deftest tape-floor-escalates-cannot-run-to-fail
+  (testing "a run whose base status is :cannot-run (an unmet-requirement
+            refusal) that ALSO carries an unconsumed schema-validation
+            failure on the tape (tape-red? true) escalates to :fail — the
+            agreement floor previously lifted ONLY a :pass, so this case
+            silently stayed :cannot-run and masked a genuine MUST-fail
+            (rf2-m0cge5 finding 9). Precedence: :error > :fail > :cannot-run
+            > :pass — :cannot-run and tape-red? are ORTHOGONAL signals (an
+            unmet capability refusal says nothing about whether the tape
+            independently carries an unconsumed failure), so both
+            floor-eligible base statuses must escalate."
+    (let [refusal (requirements/requirement-refusal
+                    #{:pixels} #{:app-db} [:rf.assert/visual-snapshot]
+                    :runner-lacks-capability :headless)
+          tape    [(epoch {:trace-events
+                           [{:operation :rf.error/schema-validation-failure
+                             :tags {:where :event :failing-id :checkout/submit}}]})]
+          r       (result/run-result
+                    {:epoch-tape  tape
+                     :assertions  [{:assertion :rf.assert/path-equals :passed? true}]
+                     :unmet       [refusal]})]
+      (is (= :fail (:status r))
+          "tape-red? escalates the :cannot-run base-status to :fail")
+      (is (= [refusal] (:cannot-run r))
+          "the unmet refusal still surfaces on :cannot-run even though the
+           top-level :status escalated past it — the two are separate
+           result slots")
+      (is (= 1 (count (:schema-violations r))) "the violation is still projected"))))
 
 ;; ===========================================================================
 ;; SCHEMA-ERROR EXACT CONSUMPTION  (spec/017 §Schema rule, rf2-5x1wt.21)

--- a/tools/story/test/re_frame/story_teardown_test.clj
+++ b/tools/story/test/re_frame/story_teardown_test.clj
@@ -355,7 +355,7 @@
           "runs-by-play evicted on destroy — no leak")
       (is (not (contains? @runner-events/active-play :story.runstate/v))
           "active-play evicted on destroy — no leak")
-      (is (nil? (runner-events/settle-boundaries :story.runstate/v))
+      (is (nil? (runner-events/settle-boundaries :story.runstate/v nil))
           "step-boundaries evicted on destroy — no leak"))))
 
 ;; ===========================================================================


### PR DESCRIPTION
## Summary

Five MEDIUM-confidence story run/verdict-correctness findings from rf2-k7crbc chunk A (bead rf2-m0cge5), all on the `tools/story/` surface. Each finding was independently verified against the actual code before fixing; all five reproduced.

### Finding 1 — `queue-empty?` hard-coded stub (runner_events.cljc)
`(defn- queue-empty? [_frame-id] true)` always reported the queue drained. Its own comment justified this only from the `:dispatch` case (already settled via `settled-boundary`), but `[:wait-until [:queue-empty]]` can also follow a `:click`/`:type`/`:focus` step — `exec-click!`/`exec-type!`/`exec-focus!` fire a synthetic DOM event directly and never call `boundary/dispatch-and-settle!`. A handler the event triggers may issue an async `[:dispatch …]` that has not yet drained (the router schedules async drains via `interop/next-tick`, genuinely deferred). The stub silently hid this dispatch-vs-settle race.

**Fix:** `queue-empty?` now reads the frame's real router state (`:queue` empty + not `:scheduled?`) via `re-frame.frame` (already a Story dependency elsewhere, e.g. `frames.cljc`) — no touch to `implementation/core`.

### Finding 2 — `step-boundaries` keyed by frame-id only (runner_events.cljc + runtime.cljc)
A multi-play sequencer accumulates settle boundaries across plays on one frame (`:clear-boundaries? false`). The per-`[frame play-key]` run-token guard does not block a *concurrent* `run!`/`re-run!`/`run-play!` for a *different* play-key on the same frame — that call's default `:clear-boundaries? true` wiped the one shared frame-id bucket mid-sequence, silently misaligning `record-result-map`'s narrative attribution.

**Fix:** `step-boundaries` is now keyed by `[frame-id play-key]`. `run-phase-4!` threads the driven play-keys through `ctx` as `:executed-play-keys`; `record-result-map` reads each play-key's own slot and concatenates them in the same order the plays ran, reconstructing the exact attribution vector. The end-to-end multi-play attribution test (`run-variant-multi-play-narrative-attributes-every-play-step`) stays green, confirming the read-side reconstruction is correct.

### Finding 9 — cannot-run floor doesn't escalate tape-red (result.cljc)
The agreement floor only lifted `:pass` → `:fail`. A run whose base status was `:cannot-run` (an unmet-requirement refusal) that *also* carried an unconsumed schema-validation failure on the tape stayed `:cannot-run`, masking a genuine MUST-fail — the opposite of the stated precedence `:error` > `:fail` > `:cannot-run` > `:pass`.

**Fix:** escalates to `:fail` whenever `tape-red?` and `base-status ∈ {:pass :cannot-run}`. The `:cannot-run` refusal vector still surfaces on the `:cannot-run` slot even when `:status` escalates past it (they're separate result slots).

### Finding 10 — `:required-runner` computed over first play only (plan.cljc)
`compute-required-runner` was called with `script*` (the primary/first play's script alone), but `[:world :scripts]` retains every play and the runtime auto-runs every `:auto-run? true` one. A later auto-run play whose step lifts capability (e.g. a DOM step) was omitted from `:required-runner`; runner-selection trusts the slot verbatim, so `:auto` selection could pick a runner unable to execute it — a spurious failure instead of an honest `:cannot-run` refusal at selection time.

**Fix:** unions capability tokens across every `runner/auto-runnable-plays` entry (the same predicate the runtime itself uses to decide what auto-runs), not just the first play. A play with `:auto-run? false` correctly stays excluded (it never executes automatically).

### Finding 11 — sensitive assertion never groups under its check (result.cljc)
`record-matches-atom?` paired run records to check-plan atoms by exact `(id, payload)` equality. For a sensitive `:rf.assert/path-equals`, the run record's `:payload` is rebuilt from the *redacted* expected value (`[path :rf/redacted]`) while the compiled check plan's atom carries the *raw* author value (`[path <secret>]`) — the plan is never redacted (redaction only happens at run time against a live frame). Equality was always false, so the record was never grouped under its check: the check's `:assertions` read empty and aggregated vacuously to `:pass` even when the sensitive assertion FAILED (the run-level verdict stayed correct via the ungrouped fold — only the check-level grouping lied).

**Fix:** the two redaction-prone ids (`:rf.assert/path-equals`, `:rf.assert/sub-equals`) now match by a redaction-invariant key — the payload's first element (the path/sub-vec, a structural coordinate never itself redacted) — instead of the full payload. Every other assertion id keeps the original exact-payload match; disambiguation between two same-id atoms against different paths is unaffected either way.

## Quality gates

- `clojure -M:test` from `tools/story/`: **1738 tests, 6427 assertions, 0 failures, 0 errors**
- `npm run story:build` from `implementation/`: build completed, 0 warnings in touched files
- `npm run test:cljs` from `implementation/`: **8091 tests, 37134 assertions, 0 failures, 0 errors**

A regression test was added per confirmed fix:
- `queue-empty-reads-the-real-router-queue` (step_runner_test.cljc)
- `concurrent-run-for-different-play-key-does-not-wipe-boundaries` (runner_events_cljs_test.cljc)
- `tape-floor-escalates-cannot-run-to-fail` (result_test.cljc)
- `required-runner-unions-across-every-auto-run-play` (plan_test.cljc)
- `check-groups-sensitive-path-equals-record-by-redaction-invariant-key` (result_test.cljc)

Two existing tests were updated for the new `[frame-id play-key]` arity on `settle-boundaries` (`runner_events_cljs_test.cljc`, `story_teardown_test.clj`) — both pass play-key `nil`, matching the affected variants' single-script/default-play shape.

## Scope note

Touches only `tools/story/**` per dispatch. Story chunk-B (rf2-4e545l) and chunk-C (rf2-cmjly3) are separate beads on the same surface and dispatch serially after this merges.