### PR TITLE
fix(story): test-pane variant-switch autorun + scrubber mixed-step epoch slice + stepper step-back off-by-one (rf2-4e545l)

### DIFF
--- a/tools/story/src/re_frame/story/ui/test_mode/pure.cljc
+++ b/tools/story/src/re_frame/story/ui/test_mode/pure.cljc
@@ -225,10 +225,11 @@
 ;;   - per-step `:label` — `(pr-str (first event))` for a compact tick
 ;;     title; tooltip text the CLJS renderer wires onto each tick.
 ;;
-;;   - the trailing epoch-id slice — the last `count(play-events)` epoch-ids
-;;     pulled from the variant frame's history. The CLJS side captures
-;;     this on `run-variant` resolve so a later epoch (e.g. a Re-run on
-;;     a different tab) can't drift the scrubber's mapping.
+;;   - the epoch-id alignment (`epoch-id-slice`, below) — one epoch-id per
+;;     dispatch-only play event, matched against the run's OWN `:epoch-tape`
+;;     by `:trigger-event` identity rather than a positional trailing-N
+;;     slice (rf2-4e545l finding 4 — see that fn's docstring for why
+;;     position alone misaligns on a mixed `:click`+`:dispatch` script).
 ;;
 ;; All four helpers are pure data → data and JVM-testable.
 
@@ -300,20 +301,53 @@
                  (inc step-idx)))))))
 
 (defn epoch-id-slice
-  "Pure: given the variant frame's full `history` vector (oldest-first)
-  + the count `n` of play events, return the trailing `n` `:epoch-id`s
-  (in play-step order, oldest-first). Returns `[]` when the history
-  has fewer than `n` records (production / ring-buffer-trimmed contexts
-  — the scrubber gracefully degrades to no ticks rather than mis-mapping
-  steps to wrong epochs).
+  "Pure: given `epoch-tape` (the run's OWN ordered `:rf/epoch-record`
+  vector — `result :epoch-tape`, each record carrying the literal
+  dispatched `:trigger-event` vector) and `play-events` (the DISPATCH-ONLY
+  event-vecs `play/variant-play-events` extracts from the `:script` —
+  `:dispatch` / `:dispatch-sync` steps only), return the epoch-id the
+  scrubber should restore to for EACH play event, in play-event order.
+
+  rf2-4e545l finding 4: a `:click` / `:type` / `:focus` step has no
+  event-vector representation in `play-events` (`variant-play-events`
+  skips every non-dispatch step type) — but running it may STILL commit
+  an epoch, e.g. a `:click` whose DOM handler dispatches. The prior
+  implementation took a positional trailing-N slice of the FRAME's whole
+  epoch-history (`n` = `(count play-events)`); a non-dispatch step that
+  ALSO committed an epoch then interleaves an epoch the position-only
+  slice never accounted for, so ticks/labels attribute to the WRONG
+  epoch and clicking one restores the WRONG app-db.
+
+  This walks `epoch-tape` in order instead, matching each record's
+  `:trigger-event` against the next UNCONSUMED play-event: a match
+  consumes both and contributes that record's `:epoch-id`; a non-match
+  (a non-dispatch-step epoch, or any other epoch not among the
+  dispatch-only steps) is skipped rather than consumed. The result stays
+  aligned to the dispatch-only steps regardless of what interleaves
+  between them. (A `:click`/`:type` step whose OWN side-effecting
+  dispatch happens to carry the identical event vector as an upcoming
+  `:dispatch` step is the one residual ambiguity this can't disambiguate
+  — ordinary event-vector identity carries no per-invocation identity.)
+
+  Returns `[]` (never a partial or misaligned vector) when the tape runs
+  out before every play-event is matched — production / ring-buffer-
+  trimmed contexts, or a run whose tape doesn't carry the expected
+  events. The scrubber gracefully degrades to 'no epoch buffer' rather
+  than guessing.
 
   Pure data → data; JVM-testable."
-  [history n]
-  (let [hv (vec (or history []))]
-    (cond
-      (not (pos-int? n))    []
-      (< (count hv) n)      []
-      :else                 (mapv :epoch-id (subvec hv (- (count hv) n))))))
+  [epoch-tape play-events]
+  (let [tape (vec (or epoch-tape []))
+        evs  (vec (or play-events []))]
+    (if (empty? evs)
+      []
+      (loop [ti 0 ei 0 acc []]
+        (cond
+          (= ei (count evs))  acc
+          (= ti (count tape)) []
+          (= (:trigger-event (nth tape ti)) (nth evs ei))
+          (recur (inc ti) (inc ei) (conj acc (:epoch-id (nth tape ti))))
+          :else (recur (inc ti) ei acc))))))
 
 ;; ===========================================================================
 ;; UNIFIED RUN-RESULT PROJECTION  (tools/story/spec/021 §1)

--- a/tools/story/src/re_frame/story/ui/test_mode/state.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/state.cljs
@@ -84,8 +84,15 @@
         ;; (one per `:dispatch`/`:dispatch-sync` step), the shape the
         ;; scrubber's slot expects.
         play-events  (play/variant-play-events variant-id)
-        history      (rf/epoch-history variant-id)
-        epoch-ids    (pure/epoch-id-slice history (count play-events))]
+        ;; rf2-4e545l finding 4: match against THIS run's own scoped
+        ;; `:epoch-tape` (the result's raw `:rf/epoch-record` vector,
+        ;; each carrying its `:trigger-event`) by trigger-event identity
+        ;; rather than a positional trailing-N slice of the frame's WHOLE
+        ;; epoch-history — a mixed :click+:dispatch script where the
+        ;; :click ALSO commits an epoch (its DOM handler dispatches)
+        ;; would otherwise misalign a positional slice. See
+        ;; `pure/epoch-id-slice`'s docstring.
+        epoch-ids    (pure/epoch-id-slice (:epoch-tape result) play-events)]
     (swap! results-atom assoc variant-id
            {:result        result
             :ran-at-ms     now

--- a/tools/story/src/re_frame/story/ui/test_mode/stepper_state.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/stepper_state.cljs
@@ -169,15 +169,29 @@
 
   Step-back never re-dispatches the popped event — that would create a
   fresh epoch and lose the deterministic mapping between cursor and
-  history. The popped event simply becomes pending again."
+  history. The popped event simply becomes pending again.
+
+  rf2-4e545l finding 7: `begin!` seeds `:epoch-stack` with the pre-play
+  epoch AND `step!` (for the FIRST forward step) pushes that SAME
+  pre-play epoch again (there is no domino between `begin!`'s seed and
+  step 0's push) — so the stack carries a duplicate bottom entry. The
+  top of the stack (`peek`) is always the pre-image of the MOST RECENT
+  step, i.e. exactly the state to restore to on a step-back. Popping
+  BEFORE peeking (the prior code) read the entry one further down the
+  stack instead, under-shooting by one epoch for every cursor >= 2 (the
+  cursor == 1 case only looked correct because the duplicate bottom
+  entry happened to mask the shift). Peek THEN pop is the correct
+  order — it restores the top image and leaves the new top as the
+  pre-image for the NEXT step-back, matching the stack cursor==(c-1)
+  would have built by forward-stepping alone."
   [variant-id]
   (let [slot (get @results-atom variant-id)]
     (when (stepper-pure/can-step-back? slot)
-      (let [stack    (or (:epoch-stack slot) [])
-            ;; Pop the head; the NEW head is the pre-image of the
-            ;; previous step (the cursor we're stepping back to).
-            new-stack (vec (butlast stack))
-            target-id (peek new-stack)]
+      (let [stack     (or (:epoch-stack slot) [])
+            ;; Peek the CURRENT top — the pre-image of the step we're
+            ;; undoing — before popping it off.
+            target-id (peek stack)
+            new-stack (vec (butlast stack))]
         (when target-id
           (rf/restore-epoch! variant-id target-id))
         ;; Pop the substrate's last-run step + result so the row outcomes

--- a/tools/story/src/re_frame/story/ui/test_mode/view.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/view.cljs
@@ -630,9 +630,9 @@
 (defn test-view
   "Top-level `:test` mode pane for `variant-id`.
 
-  On first mount for a variant the pane auto-runs the variant once
-  so the user lands on the result; subsequent visits to the tab
-  show the most recent result until the Re-run button is clicked.
+  On first encounter of a variant the pane auto-runs it once so the
+  user lands on the result; subsequent visits to the tab show the most
+  recent result until the Re-run button is clicked.
 
   Returns nil when given no variant id (the shell already gates
   this, but the helper guards itself too).
@@ -640,56 +640,70 @@
   Per spec/009 the pane is read-only — no inputs mutate args /
   overrides / modes. The Re-run button mutates **runtime state**
   (re-allocates the variant frame via `reset-variant`) but not
-  the variant's authoring shape."
+  the variant's authoring shape.
+
+  rf2-4e545l finding 3: shell.cljs mounts this component with NO React
+  key (`[test-mode-view/test-view variant-id]`), and `:active-mode-tab`
+  is per-variant persisted, so switching `:selected-variant` between two
+  variants BOTH already on the `:test` tab reconciles as a PROP UPDATE
+  at this component's tree position — React reuses the same instance
+  rather than unmounting/remounting it. A `:component-did-mount`-only
+  auto-run (the prior implementation) never re-fires on a prop update,
+  so the newly-focused variant's pane rendered blank until a manual
+  Re-run. `r/with-let`'s body runs on EVERY render (mount AND
+  reconciled update alike), so tracking the last-seen `variant-id` here
+  and re-checking the auto-run condition on a change catches a
+  reconciled swap the same way a fresh mount would — the same pattern
+  `variant-cell` (workspace.cljc, rf2-zme7/kgn0c/c56hr) uses to
+  pre-allocate a variant's frame from inside a render body rather than a
+  lifecycle hook."
   [variant-id]
   (when variant-id
-    (r/create-class
-      {:display-name "rf-story-test-view"
-       :component-did-mount
-       (fn [_this]
-         ;; Auto-run on first mount per variant. If a slot already
-         ;; exists (returning to the tab without re-mount) we don't
-         ;; re-fire — the user clicks Re-run to refresh.
-         (when (pure/variant-has-tests? variant-id)
-           (when-not (get @state/results-atom variant-id)
-             (state/run-variant-pane! variant-id))))
-       :reagent-render
-       (fn [variant-id]
-         (cond
-           (not (pure/variant-has-tests? variant-id))
-           [:section {:style     (:wrap styles)
-                      :data-test "story-test-view"
-                      :aria-label "Variant tests"}
-            [empty-state variant-id]]
+    (r/with-let [last-variant (atom nil)]
+      (when (not= variant-id @last-variant)
+        (reset! last-variant variant-id)
+        ;; Auto-run on first encounter of this variant (a fresh mount OR
+        ;; a reconciled prop swap). If a slot already exists (returning
+        ;; to the tab without a variant change) we don't re-fire — the
+        ;; user clicks Re-run to refresh.
+        (when (and (pure/variant-has-tests? variant-id)
+                   (not (get @state/results-atom variant-id)))
+          (state/run-variant-pane! variant-id)))
+      (cond
+        (not (pure/variant-has-tests? variant-id))
+        [:section {:style     (:wrap styles)
+                   :data-test "story-test-view"
+                   :aria-label "Variant tests"}
+         [empty-state variant-id]]
 
-           :else
-           [:section {:style     (:wrap styles)
-                      :data-test "story-test-view"
-                      :aria-label "Variant tests"}
-            [header variant-id]
-            [summary-section variant-id]
-            ;; the unified run-result surfaces (spec/021 §1):
-            ;; checks grouped by id, the per-test assertions (terminal +
-            ;; script-checkpoint, with the failed-only filter), schema
-            ;; violations (consumed + unconsumed), and cannot-run refusals.
-            [checks-section variant-id]
-            [stepper-view/stepper-section variant-id]
-            [scrubber-section variant-id]
-            [rows-section variant-id]
-            [schema-section variant-id]
-            [cannot-run-section variant-id]
-            ;; visual + a11y check RESULTS (spec/021 §4).
-            ;; Reads the browser-tier oracle records (structural-a11y /
-            ;; axe-a11y / visual-snapshot) off the SAME unified `:assertions`
-            ;; slot and presents them readably (violations as a
-            ;; finding+locus list; screenshot identity; honest cannot-run),
-            ;; rather than as the raw `:actual` EDN blob the generic
-            ;; assertions table would show.
-            [visual-a11y-view/visual-a11y-section variant-id]
-            ;; result → evidence-spine link (spec/021 §2),
-            ;; a graceful "evidence pending" until the spine display lands.
-            [evidence-section variant-id]
-            ;; generated-failure promotion entry point
-            ;; (spec/021 §3). Captures THIS run as an artifact and opens the
-            ;; promotion dialog. Distinct from save-current-state.
-            [promotion-section variant-id]]))})))
+        :else
+        [:section {:style     (:wrap styles)
+                   :data-test "story-test-view"
+                   :aria-label "Variant tests"}
+         [header variant-id]
+         [summary-section variant-id]
+         ;; the unified run-result surfaces (spec/021 §1):
+         ;; checks grouped by id, the per-test assertions (terminal +
+         ;; script-checkpoint, with the failed-only filter), schema
+         ;; violations (consumed + unconsumed), and cannot-run refusals.
+         [checks-section variant-id]
+         [stepper-view/stepper-section variant-id]
+         [scrubber-section variant-id]
+         [rows-section variant-id]
+         [schema-section variant-id]
+         [cannot-run-section variant-id]
+         ;; visual + a11y check RESULTS (spec/021 §4).
+         ;; Reads the browser-tier oracle records (structural-a11y /
+         ;; axe-a11y / visual-snapshot) off the SAME unified `:assertions`
+         ;; slot and presents them readably (violations as a
+         ;; finding+locus list; screenshot identity; honest cannot-run),
+         ;; rather than as the raw `:actual` EDN blob the generic
+         ;; assertions table would show.
+         [visual-a11y-view/visual-a11y-section variant-id]
+         ;; result → evidence-spine link (spec/021 §2),
+         ;; a graceful "evidence pending" until the spine display lands.
+         [evidence-section variant-id]
+         ;; generated-failure promotion entry point
+         ;; (spec/021 §3). Captures THIS run as an artifact and opens the
+         ;; promotion dialog. Distinct from save-current-state.
+         [promotion-section variant-id]]))))

--- a/tools/story/test/re_frame/story/ui/test_mode/stepper_state_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/test_mode/stepper_state_cljs_test.cljs
@@ -92,8 +92,11 @@
 ;; ---- step-back! ----------------------------------------------------------
 
 (deftest step-back-pops-and-restores
-  (testing "step-back! pops the epoch stack, calls restore-epoch against
-            the new head, and decrements cursor"
+  (testing "step-back! restores against the CURRENT top of the epoch
+            stack (the pre-image of the step being undone), then pops
+            it — rf2-4e545l finding 7. The prior implementation popped
+            BEFORE peeking, which restored one epoch too far (the entry
+            one further down the stack) for cursor >= 2."
     (let [vid      :story.unit/back
           restored (atom [])]
       (seed-slot! vid [[:e/a] [:e/b]])
@@ -111,11 +114,54 @@
                     assertions/read-assertions (fn [_] [])]
         (st/step-back! vid)
         (let [s (get @st/results-atom vid)]
-          (is (= [[vid :epoch/before-a]] @restored)
-              "restored against the NEW head of the popped stack")
+          (is (= [[vid :epoch/before-b]] @restored)
+              "restored against the TOP of the stack (before-b) — the
+               pre-image of the step cursor=2 just ran, NOT the entry
+               one further down (before-a, the pre-fix bug)")
           (is (= 1 (:cursor s)) "cursor decrements to 1")
           (is (= [:epoch/seed :epoch/before-a] (:epoch-stack s))
-              "stack popped"))))))
+              "stack popped (the top is removed regardless of the
+               peek/pop ordering fix — only the RESTORE target
+               changed)"))))))
+
+(deftest step-back-cursor-2-plus-does-not-undershoot
+  (testing "rf2-4e545l finding 7 — reproduces the reported scenario
+            directly: `begin!` seeds :epoch-stack with the pre-play
+            epoch, and step 0 (no domino between begin! and the first
+            step!) pushes that SAME epoch again, so the stack carries a
+            duplicate bottom entry [S0 S0 S1 S2 …]. Stepping back from
+            cursor=3 must restore S2 (the state right before the THIRD
+            step ran) — not S1, which the pre-fix `(peek (butlast
+            stack))` under-shoot returned."
+    (let [vid      :story.unit/back-cursor3
+          restored (atom [])]
+      (seed-slot! vid [[:e/a] [:e/b] [:e/c]])
+      (swap! st/results-atom update vid
+             (fn [s] (-> s
+                         (assoc :cursor 3)
+                         ;; The real duplicate-seed shape begin!/step!
+                         ;; build: seed pushed twice (S0 S0), then one
+                         ;; genuine pre-image per subsequent step (S1, S2).
+                         (assoc :epoch-stack [:epoch/s0 :epoch/s0
+                                              :epoch/s1 :epoch/s2]))))
+      (with-redefs [rf/restore-epoch! (fn [v eid]
+                                       (swap! restored conj [v eid]))
+                    rf/epoch-history (fn [_] [{:epoch-id :x}])
+                    assertions/read-assertions (fn [_] [])]
+        (st/step-back! vid)
+        (is (= [[vid :epoch/s2]] @restored)
+            "restores S2 — the pre-image of the step just taken —
+             rather than S1 (the pre-fix off-by-one under-shoot)")
+        (is (= 2 (:cursor (get @st/results-atom vid))))
+        ;; Stepping back again from cursor=2 must land on S1, exercising
+        ;; the SAME correct behaviour continues past the duplicate-seed
+        ;; entry at the bottom.
+        (st/step-back! vid)
+        (is (= [[vid :epoch/s2] [vid :epoch/s1]] @restored)
+            "a second step-back restores S1 — the duplicate seed at the
+             bottom of the stack is consumed correctly, never restoring
+             one epoch too far")
+        (is (= 1 (:cursor (get @st/results-atom vid))))))))
 
 (deftest step-back-noops-at-start
   (testing "step-back! does nothing when cursor is 0"

--- a/tools/story/test/re_frame/story/ui/test_mode/view_variant_switch_dom_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/test_mode/view_variant_switch_dom_cljs_test.cljs
@@ -1,0 +1,144 @@
+(ns re-frame.story.ui.test-mode.view-variant-switch-dom-cljs-test
+  "DOM-mount regression for rf2-4e545l finding 3: the `:test` mode
+  pane's `test-view` must auto-run a NEWLY-focused variant even when
+  React reconciles the switch as a prop update rather than a fresh
+  mount.
+
+  ## Why this needs a REAL DOM mount
+
+  shell.cljs mounts the pane with NO React key
+  (`[test-mode-view/test-view variant-id]`), and `:active-mode-tab` is
+  per-variant persisted, so switching `:selected-variant` between two
+  variants BOTH already on the `:test` mode-tab keeps the SAME
+  component TYPE at the SAME tree position — React reconciles this as a
+  PROP update on the existing instance rather than unmounting and
+  remounting it. Whether that reconciliation actually happens (as
+  opposed to a fresh mount) is a React-commit fact; no amount of pure
+  hiccup-tree inspection proves it — only a real render + a SECOND real
+  render after the prop swap can. `test-view`'s prior implementation
+  drove the auto-run from `:component-did-mount` alone, which never
+  re-fires on a reconciled prop update, so the newly-focused variant's
+  pane rendered blank until the user clicked Re-run.
+
+  ## Pipeline under test
+
+      mount [test-mode.view/test-view variant-a] (no React key)
+            |
+      test-view's r/with-let body -> variant-has-tests? + no stored
+      result -> state/run-variant-pane! variant-a
+            |
+      re-render the SAME root with [test-mode.view/test-view variant-b]
+      -- same component type, no key, so React reconciles as a PROP
+      UPDATE (no unmount/remount)
+            |
+      ASSERT: variant-b's slot in test-mode.state/results-atom shows
+      the run fired (:running? true, stamped synchronously by
+      run-variant-pane!'s begin-run! prelude before the async
+      reset-variant promise even settles) -- proving auto-run re-fired
+      for the reconciled variant, not just the fresh mount.
+
+  ns ends in `-dom-cljs-test` so shadow-cljs's `:browser-test` build
+  discovers it and mounts real DOM via `react-dom/client`; `:node-test`
+  also loads it (its `cljs-test$` regex matches the `-dom-cljs-test`
+  suffix too) where the body self-gates on `(browser?)` and no-ops."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            ["react-dom" :as react-dom]
+            [reagent.dom.client :as rdc]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.machines :as machines]
+            [re-frame.registrar :as registrar]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.story :as story]
+            [re-frame.story.loaders :as loaders]
+            [re-frame.story.ui.state :as state]
+            [re-frame.story.ui.test-mode.state :as tm-state]
+            [re-frame.story.ui.test-mode.view :as view]
+            [re-frame.subs :as subs]))
+
+;; ---- fixture --------------------------------------------------------------
+
+(defn- reset-all! []
+  (story/clear-all!)
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (try (rf/init! reagent-adapter/adapter)
+       (catch :default _ nil))
+  ;; Re-register the framework `:rf/machine` sub after the registrar
+  ;; clear (mirrors the sibling viewport-toggle-app-db-dom-cljs-test's
+  ;; reset-all!).
+  (subs/reg-runtime-sub :rf/machine
+    (fn [runtime-db [_ machine-id]]
+      (get-in runtime-db [:rf.runtime/machines :snapshots machine-id])))
+  (machines/reset-timers!)
+  (loaders/clear-watchers!)
+  (reset! tm-state/results-atom {})
+  (state/reset-shell-state!)
+  (story/install-canonical-vocabulary!)
+  (frame/ensure-default-frame!))
+
+(use-fixtures :each {:before reset-all!})
+
+;; ---- browser gate -----------------------------------------------------
+
+(defn- browser? []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+(defn- make-mount-node! []
+  (let [node (js/document.createElement "div")]
+    (js/document.body.appendChild node)
+    node))
+
+;; ---- the regression ---------------------------------------------------
+
+(deftest switching-variant-prop-without-remount-autoruns-new-variant
+  (testing "rf2-4e545l finding 3 — mounting test-view with NO React key
+            (mirroring shell.cljs's `[test-mode-view/test-view
+            variant-id]` call site) and then re-rendering the SAME root
+            with a DIFFERENT variant-id (simulating :selected-variant
+            changing while :active-mode-tab stays :test for both)
+            reconciles as a prop update, not a remount. The
+            newly-focused variant must still auto-run."
+    (if-not (browser?)
+      (is true ":node-test — no DOM; :browser-test runs the real assertion")
+      (let [va :story.testview-switch/a
+            vb :story.testview-switch/b]
+        (rf/reg-event :testview-switch/set-a
+          (fn [{:keys [db]} _] {:db (assoc db :v "a")}))
+        (rf/reg-event :testview-switch/set-b
+          (fn [{:keys [db]} _] {:db (assoc db :v "b")}))
+        (story/reg-variant va
+          {:events      [[:testview-switch/set-a]]
+           :play-script [[:dispatch-sync [:rf.assert/path-equals [:v] "a"]]]})
+        (story/reg-variant vb
+          {:events      [[:testview-switch/set-b]]
+           :play-script [[:dispatch-sync [:rf.assert/path-equals [:v] "b"]]]})
+        (let [mount-node (make-mount-node!)
+              root       (rdc/create-root mount-node)]
+          (try
+            ;; Initial mount on variant A — no React key, mirroring
+            ;; shell.cljs's call site.
+            (react-dom/flushSync
+              (fn [] (rdc/render root [view/test-view va])))
+            (is (true? (get-in @tm-state/results-atom [va :running?]))
+                "variant A auto-ran on first mount (run-variant-pane!'s
+                 begin-run! prelude stamps :running? synchronously)")
+            (is (some? (.querySelector mount-node "[data-test=\"story-test-view\"]"))
+                "precondition: the pane actually rendered")
+
+            ;; Re-render the SAME root with a DIFFERENT variant-id —
+            ;; same component type, no key, so React reconciles this as
+            ;; a PROP UPDATE (no unmount/remount) at the same tree
+            ;; position.
+            (react-dom/flushSync
+              (fn [] (rdc/render root [view/test-view vb])))
+            (is (true? (get-in @tm-state/results-atom [vb :running?]))
+                "rf2-4e545l: variant B auto-ran too, even though React
+                 reconciled the swap as a prop update rather than a
+                 fresh mount — the pre-fix :component-did-mount-only
+                 auto-run never re-fired here, leaving the pane blank
+                 until a manual Re-run")
+
+            (finally
+              (try (.unmount root) (catch :default _ nil)))))))))

--- a/tools/story/test/re_frame/story_ui_test.clj
+++ b/tools/story/test/re_frame/story_ui_test.clj
@@ -1188,18 +1188,39 @@
     (is (= [] (test-mode/play-step-statuses [] [])))
     (is (= [] (test-mode/play-step-statuses nil nil)))))
 
-(deftest test-mode-epoch-id-slice-trailing-window
-  (testing "epoch-id-slice returns the trailing n epoch-ids"
-    (let [history [{:epoch-id 10} {:epoch-id 11} {:epoch-id 12}
-                   {:epoch-id 13} {:epoch-id 14}]]
-      (is (= [12 13 14] (test-mode/epoch-id-slice history 3)))
-      (is (= [10 11 12 13 14] (test-mode/epoch-id-slice history 5)))
-      (is (= [14] (test-mode/epoch-id-slice history 1)))))
-  (testing "epoch-id-slice short-circuits to [] when history is too small"
-    ;; production / ring-buffer-trimmed contexts: degrade gracefully
-    ;; rather than mis-mapping play-steps onto wrong epochs.
-    (is (= [] (test-mode/epoch-id-slice [{:epoch-id 1}] 3))))
-  (testing "epoch-id-slice tolerates nil history and non-positive n"
-    (is (= [] (test-mode/epoch-id-slice nil 3)))
-    (is (= [] (test-mode/epoch-id-slice [{:epoch-id 1}] 0)))
-    (is (= [] (test-mode/epoch-id-slice [{:epoch-id 1}] -2)))))
+(deftest test-mode-epoch-id-slice-trigger-event-alignment
+  (testing "epoch-id-slice matches each play-event against the tape by
+            :trigger-event, in order, when every tape record corresponds
+            1-to-1 to a play event (the simple no-interleaving case)"
+    (let [play-events [[:a] [:b] [:c]]
+          tape        [{:epoch-id 10 :trigger-event [:a]}
+                       {:epoch-id 11 :trigger-event [:b]}
+                       {:epoch-id 12 :trigger-event [:c]}]]
+      (is (= [10 11 12] (test-mode/epoch-id-slice tape play-events)))))
+  (testing "rf2-4e545l finding 4 — a non-dispatch step (:click/:type) that
+            ALSO commits an epoch interleaves a tape record whose
+            :trigger-event is not among play-events; epoch-id-slice
+            skips it rather than misattributing it to the next
+            dispatch-only play-event"
+    (let [play-events [[:a] [:b] [:c]]
+          ;; a :click between the [:a] and [:b] dispatch steps fires its
+          ;; own on-click handler dispatch — an epoch NOT represented in
+          ;; play-events (variant-play-events skips :click entirely).
+          tape        [{:epoch-id 100 :trigger-event [:a]}
+                       {:epoch-id 101 :trigger-event [:click/side-effect]}
+                       {:epoch-id 102 :trigger-event [:b]}
+                       {:epoch-id 103 :trigger-event [:c]}]]
+      (is (= [100 102 103] (test-mode/epoch-id-slice tape play-events))
+          "epoch 101 (the interleaved click-triggered epoch) is skipped —
+           NOT attributed to play-event [:b], which a positional
+           trailing-N slice would have done")))
+  (testing "epoch-id-slice returns [] when the tape runs out before every
+            play-event is matched — production / ring-buffer-trimmed
+            contexts degrade gracefully rather than mis-mapping steps"
+    (let [play-events [[:a] [:b] [:c]]
+          tape        [{:epoch-id 10 :trigger-event [:a]}]]
+      (is (= [] (test-mode/epoch-id-slice tape play-events)))))
+  (testing "epoch-id-slice tolerates nil/empty tape and play-events"
+    (is (= [] (test-mode/epoch-id-slice nil [[:a]])))
+    (is (= [] (test-mode/epoch-id-slice [{:epoch-id 1 :trigger-event [:a]}] nil)))
+    (is (= [] (test-mode/epoch-id-slice [] [])))))


### PR DESCRIPTION
## Summary

Chunk B of the rf2-k7crbc story bundle — 3 MEDIUM test-mode UI/stepper findings, all reproduced before fixing, one regression test per confirmed fix. Branches off main including chunk A (#5277).

### Finding 3 — test-view no-autorun on variant switch — REPRODUCED, FIXED

`tools/story/src/re_frame/story/ui/test_mode/view.cljs`: `test-view` drove its auto-run only from `:component-did-mount`, and `shell.cljs:842` mounts it with **no React key** (`[test-mode-view/test-view variant-id]`). `:active-mode-tab` is per-variant persisted, so switching `:selected-variant` between two variants **both already on `:test`** reconciles as a prop update at the same tree position — React reuses the instance rather than remounting it. `:component-did-mount` never re-fires, so the newly-focused variant's pane stayed blank until a manual Re-run.

**Fix:** converted `test-view` from `r/create-class` + `:component-did-mount` to `r/with-let` with a `last-variant` atom (the rf2-zme7/kgn0c/c56hr pattern `variant-cell` in workspace.cljc already uses) — the body runs on every render (mount AND reconciled update), so the auto-run check catches a prop-only swap the same way a fresh mount would.

**Test:** new DOM-mount browser test `view_variant_switch_dom_cljs_test.cljs` — mounts `test-view` with no key, re-renders the same root with a different variant-id (forcing React's reconciliation path, not a remount), asserts the second variant's slot shows the run fired. This is the real gate for a mount/reconcile bug (per project convention, CLJS DOM-mount test over Playwright).

### Finding 4 — scrubber epoch-slice misaligns on mixed :click+:dispatch scripts — REPRODUCED, FIXED

`tools/story/src/re_frame/story/ui/test_mode/pure.cljc`'s `epoch-id-slice` matched the scrubber's dispatch-only `play-events` against a **positional trailing-N slice** of the frame's whole `epoch-history`. A `:click`/`:type` step has no event-vector representation in `play-events` (`variant-play-events` skips every non-dispatch step type) but running it may still commit an epoch (its DOM handler dispatches) — that interleaved epoch pushes the position-only slice out of alignment, so ticks/labels attribute to the wrong epoch and clicking one restores the wrong app-db.

**Fix:** rewrote `epoch-id-slice` to walk the run's own `:epoch-tape` (already threaded onto the unified result — `re-frame.story.result`'s `run-result` → `project-evidence`, each record carrying its literal `:trigger-event`) and match each tape record's `:trigger-event` against the **next unconsumed play-event**, skipping non-matching (interleaved, non-dispatch-step) records rather than consuming them. Falls back to `[]` (never a partial/misaligned vector) if the tape runs out before every play-event is matched. `state.cljs`'s `store-result!` now sources `(:epoch-tape result)` instead of a live `rf/epoch-history` call.

**Test:** JVM pure-data tests in `story_ui_test.clj` pin the trigger-event alignment, including the exact interleaving scenario from the finding (a `:click`-triggered epoch between two dispatch-only play events).

### Finding 7 — stepper step-back! off-by-one — REPRODUCED, FIXED

`tools/story/src/re_frame/story/ui/test_mode/stepper_state.cljs`: `begin!` seeds `:epoch-stack [(current-epoch-id variant-id)]` and step 0's `step!` call pushes that **same** epoch again (no domino between `begin!` and the first `step!`) — the stack carries a duplicate bottom entry `[S0 S0 S1 S2 …]`. `step-back!` used `(peek (butlast stack))`, which under-shoots by one epoch for cursor ≥ 2 (cursor == 1 was accidentally correct, since the duplicate masked the shift for exactly that case).

**Fix:** peek the current top of the stack *before* popping it (`target-id (peek stack)`, then `new-stack (vec (butlast stack))`) — restores the correct pre-image of the step just taken, matching what the stack would look like at `cursor - 1` if built purely by forward-stepping.

**Test:** updated the existing `step-back-pops-and-restores` test (which had encoded the pre-fix, buggy expectation) and added `step-back-cursor-2-plus-does-not-undershoot`, which reproduces the exact duplicate-seed stack shape and asserts two successive step-backs land on the correct epochs.

## Quality gates

| Gate | Result |
|---|---|
| `tools/story` `clojure -M:test` | 1738 tests, 6426 assertions, 0 failures |
| `implementation` `npm run test:cljs` | 8104 tests, 37171 assertions, 0 failures |
| `implementation` `npm run test:browser` | 237 tests, 778 assertions, 0 failures (includes the new finding-3 DOM-mount regression) |
| `implementation` `npm run story:build` | succeeded (pre-existing unrelated warnings only) |

## Per-finding reproduced?

- Finding 3 (test-pane no-autorun): reproduced by code inspection (no React key at the shell.cljs mount site + `:component-did-mount`-only trigger) — fixed, regressed via real DOM mount/reconcile test.
- Finding 4 (scrubber epoch-slice): reproduced by tracing `variant-play-events` (dispatch-only) against `epoch-history` (every committed epoch, including non-dispatch-step-triggered ones) — fixed, regressed via JVM pure-data tests pinning the interleaving scenario.
- Finding 7 (stepper off-by-one): reproduced by symbolic trace of `begin!`/`step!`'s stack construction vs. the old `step-back!`'s peek/pop order — fixed, regressed via CLJS unit tests including the exact duplicate-seed shape.

## Risks

- The `:trigger-event` identity match in finding 4's fix has one residual ambiguity, documented in the docstring: a `:click`/`:type` step whose own side-effecting dispatch happens to carry the identical event vector as an upcoming `:dispatch` step can't be disambiguated by event-vector identity alone. This is a narrow edge case; the common case (click firing an unrelated event) is fixed correctly.
- Finding 3's `r/with-let`-based fix calls a mutating fn (`state/run-variant-pane!`) from within the render body, mirroring the already-established `variant-cell` pattern (workspace.cljc) — same risk profile as existing code, not a new pattern.