### PR TITLE
fix(frame): hot-reload reprojection generation-provenance + deferred-flush no mid-sweep abort (rf2-rf3zgt)

### DIFF
--- a/implementation/core/src/re_frame/live_frame.cljc
+++ b/implementation/core/src/re_frame/live_frame.cljc
@@ -63,7 +63,15 @@
       hot-reload `reg-*` burst onto a single `interop/next-tick` flush — see the
       §Auto-reprojection section below. So an ordinary `reg-*` re-eval swaps the
       affected live frame's generation WITHOUT a manual `make-frame` /
-      `reproject-live-frames!` call.
+      `reproject-live-frames!` call. Each frame reprojects against the pool it
+      was ORIGINALLY resolved against — the live store, or the SAME explicit
+      descriptor pool for a `make-frame` 2-arity frame (`frame-generation-pool`
+      §Generation PROVENANCE, rf2-rf3zgt) — never against a store its
+      composition was never selected from. The deferred (`next-tick`) flush
+      runs a RESILIENT variant of the sweep: a per-frame assembly failure is
+      diagnosed (trace DIAGNOSTIC channel) and does NOT abort the rest of the
+      sweep, so one bad hot-reload edit cannot silently stale every sibling
+      frame too (see `deferred-flush!`).
 
   Reload is frame-targeted: reloading `:counter/left` swaps the generation THAT
   frame runs; it does not move `:counter/right` merely because the two frames
@@ -138,7 +146,8 @@
             [re-frame.registrar      :as registrar]
             [re-frame.frame          :as frame]
             [re-frame.interop        :as interop]
-            [re-frame.error          :as error]))
+            [re-frame.error          :as error]
+            [re-frame.trace          :as trace]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -504,6 +513,65 @@
       (asm/assemble images descriptors))))
 
 ;; ===========================================================================
+;; Generation PROVENANCE — which pool a frame's generation was resolved
+;; against (rf2-rf3zgt)
+;; ===========================================================================
+;;
+;; `make-frame`'s 2-arity `(opts descriptors)` resolves against an EXPLICIT
+;; descriptor pool (tests / harnesses / a pre-snapshotted store) instead of
+;; the live source store (EP-0023 §Image — mirrors `image-assembly/assemble`'s
+;; two arities). Reprojection (below) re-resolves a frame's CURRENT
+;; `:rf.gen/images` composition — but against WHICH pool? Before this fix
+;; `reproject-live-frame!` always passed `nil` (⇒ the LIVE store), so an
+;; explicit-pool frame swept up by ANY reprojection (the auto hook fires for
+;; EVERY `reg-*`, live-store-scoped or not — `mark-dirty-and-schedule!`
+;; below — and a manual `reproject-live-frames!` sweeps every image-loaded
+;; frame regardless of its pool) got re-resolved against a store its
+;; composition was never selected from: a `:select-ns` pattern that matches
+;; only the explicit pool typically ZERO-MATCHES the live store
+;; (`:rf.error/image-zero-match`, fail-loud) — or, worse, silently resolves
+;; against unrelated live registrations that merely happen to share the
+;; selected namespace.
+;;
+;; The fix: remember, per frame id, WHICH pool its generation was last
+;; resolved against (nil = the live store; a real descriptors value = that
+;; explicit pool), and thread the SAME pool through reprojection.
+;; `make-frame` is the ONE place a frame's pool arity is chosen — both first
+;; construction and every hot-reload re-construction — so it is the ONE place
+;; that records it; a re-`make-frame` that changes arity (explicit pool ↔
+;; live store) simply overwrites the record, keeping it always current.
+;;
+;; This is process-local dev bookkeeping (a `defonce` atom, the same shape as
+;; `pending-reprojection?` further below) rather than a new key on the sealed
+;; generation itself — `image-assembly` (the generation-schema owner) stays
+;; untouched; the provenance lives beside the OTHER reload/reprojection
+;; bookkeeping in this ns. Trade-off accepted: a frame id that is destroyed
+;; and never reused leaves a residual entry for the remainder of the process
+;; (no destroy-time cleanup hook here) — harmless, since `reproject-live-frame!`
+;; is already a no-op for an unregistered id and a REUSED id's entry is always
+;; freshly overwritten by the next `make-frame` call, so the residue is never
+;; read incorrectly; only dev-process memory, bounded by the number of
+;; distinct frame ids ever created in a session.
+
+(defonce ^{:private true
+           :doc "frame id -> the descriptor pool its CURRENT generation was
+  resolved against: nil for the live source store, a real descriptors value
+  for an explicit pool (`make-frame`'s 2-arity). Recorded by `make-frame` on
+  EVERY call (creation + hot-reload re-construction) so reprojection re-
+  resolves against the SAME provenance (rf2-rf3zgt) instead of silently
+  defaulting to the live store for a frame that was never resolved against
+  it. See the §Generation PROVENANCE section above for the full rationale."}
+  frame-generation-pool
+  (atom {}))
+
+(defn- record-frame-generation-pool!
+  "Record that `runnable-id`'s generation was just resolved against `descriptors`
+  (nil for the live store) — see `frame-generation-pool`. Returns nil."
+  [runnable-id descriptors]
+  (swap! frame-generation-pool assoc runnable-id descriptors)
+  nil)
+
+;; ===========================================================================
 ;; make-frame — the ONE public constructor (EP-0024 §One constructor)
 ;; ===========================================================================
 
@@ -660,6 +728,13 @@
          record-config (cond-> (apply dissoc opts image-selection-opt-keys)
                          true            (assoc :rf.frame/generation generation)
                          (some? adapter) (assoc :rf.frame/adapter adapter))]
+     ;; Record which pool this generation was resolved against BEFORE
+     ;; registering — see §Generation PROVENANCE above (rf2-rf3zgt): a later
+     ;; reprojection reads this back so it re-resolves against the SAME pool
+     ;; (explicit or live) rather than always falling through to the live
+     ;; store. Recorded on EVERY call (creation + hot-reload re-construction),
+     ;; so a re-`make-frame` that changes arity keeps the record current.
+     (record-frame-generation-pool! runnable-id descriptors)
      ;; Create (or idempotently update) the ONE `frames`-registry record under
      ;; the id. `reg-frame` is idempotent on an existing id (surgical update
      ;; preserving runtime state — EP-0024 §Duplicate id policy), installs the
@@ -814,17 +889,23 @@
 
 (defn reproject-live-frame!
   "Re-resolve ONE registered live `frame-id` from its current generation's OWN
-  image composition (`:rf.gen/images`) against the CURRENT live source store,
-  and swap the freshly-assembled generation onto the frame when it CHANGED
-  (EP-0023 §Default Image Semantics — a source-store change reprojects affected
-  EXPLICIT-image frames, not only default-image frames). Returns the reload diff
-  `{:added … :changed … :removed … :retained …}` when the frame moved, or nil
-  when its composition re-resolved byte-for-byte (no swap). A no-op for a
-  frame-id whose record carries no generation (not image-loaded)."
+  image composition (`:rf.gen/images`) against the pool that generation was
+  ORIGINALLY resolved against — the CURRENT live source store for an ordinary
+  frame, or the SAME explicit descriptor pool for a frame `make-frame`'s
+  2-arity created (`frame-generation-pool`, rf2-rf3zgt §Generation PROVENANCE
+  above) — and swap the freshly-assembled generation onto the frame when it
+  CHANGED (EP-0023 §Default Image Semantics — a source-store change
+  reprojects affected EXPLICIT-image frames, not only default-image frames).
+  Returns the reload diff `{:added … :changed … :removed … :retained …}` when
+  the frame moved, or nil when its composition re-resolved byte-for-byte (no
+  swap — this is also the outcome for every explicit-pool frame, since a
+  frozen pool value always re-resolves identically). A no-op for a frame-id
+  whose record carries no generation (not image-loaded)."
   [frame-id]
   (when-let [old-generation (frame/frame-generation frame-id)]
     (let [images         (vec (:rf.gen/images old-generation))
-          new-generation (resolve-generation! images nil)]
+          pool           (get @frame-generation-pool frame-id)
+          new-generation (resolve-generation! images pool)]
       (when-not (= old-generation new-generation)
         (swap-frame-generation! frame-id new-generation)
         (generation-diff old-generation new-generation)))))
@@ -846,6 +927,62 @@
   []
   (reduce (fn [moved id]
             (if-let [diff (reproject-live-frame! id)]
+              (assoc moved id diff)
+              moved))
+          {}
+          (frame/image-loaded-frame-ids)))
+
+;; ---- the RESILIENT sweep — used ONLY by the deferred flush (rf2-rf3zgt) ---
+;;
+;; `reproject-live-frames!` above is all-or-nothing: a single frame's assembly
+;; failure propagates straight out of the `reduce`, discarding whatever the
+;; sweep had accomplished so far and leaving every frame AFTER the failing one
+;; (in enumeration order) un-reprojected. That is exactly right for a
+;; SYNCHRONOUS caller (a REPL session or a test forcing a flush) — an
+;; immediate, loud failure is the useful signal there, and `flush-pending-
+;; reprojection!` / `reproject-live-frames!` keep that contract unchanged.
+;;
+;; It is exactly WRONG for the deferred (`next-tick`) background flush
+;; (`deferred-flush!` below): that tick has no caller to report a throw to, so
+;; before this fix it caught the propagated exception and swallowed it with
+;; ZERO emission — and because the underlying sweep had already aborted
+;; mid-reduce, every sibling frame queued after the failing one silently
+;; stayed on its STALE generation too, with no diagnostic anywhere naming what
+;; happened or which frames were affected. One bad hot-reload edit in ONE
+;; frame's namespace silently broke hot-reload for every OTHER live frame in
+;; the same coalesced burst.
+;;
+;; The resilient sweep isolates each frame's reprojection in its OWN
+;; try/catch: a failure is DIAGNOSED (rf2-rf3zgt's judgment call — see
+;; `deferred-flush!`'s docstring for the emit-vs-swallow rationale) and the
+;; failed frame is left on its prior generation (indistinguishable from an
+;; unchanged frame to `reproject-live-frames!`'s callers), but the sweep
+;; CONTINUES to every other frame regardless of where in the enumeration
+;; order the failure fell.
+
+(defn- reproject-live-frames-resiliently!
+  "Like `reproject-live-frames!`, but a PER-FRAME assembly failure does NOT
+  abort the sweep: the failure is diagnosed on the trace DIAGNOSTIC channel
+  (`:rf.warning/reprojection-failed`, carrying `:frame` + `:exception` — dev
+  visibility, zero production cost, gated on `interop/debug-enabled?` inside
+  `trace/emit-error!`) and the sweep CONTINUES to every remaining frame — the
+  failed frame is simply left on its prior generation, same as a frame whose
+  composition re-resolved unchanged. Used ONLY by the deferred (`next-tick`)
+  flush; see its docstring for why the synchronous entry points keep the
+  all-or-nothing throw-through contract instead. Returns `{frame-id
+  reload-diff}` for every frame that MOVED (a failed frame is simply absent,
+  same as an unchanged one)."
+  []
+  (reduce (fn [moved id]
+            (if-let [diff (try
+                            (reproject-live-frame! id)
+                            (catch #?(:clj Throwable :cljs :default) ex
+                              (trace/emit-error! :rf.warning/reprojection-failed
+                                                 {:category  :rf.warning/reprojection-failed
+                                                  :frame     id
+                                                  :exception ex
+                                                  :where     :reproject-live-frame!})
+                              nil))]
               (assoc moved id diff)
               moved))
           {}
@@ -905,11 +1042,15 @@
 ;; wiring is therefore gated on `interop/debug-enabled?` — under `:advanced` +
 ;; `goog.DEBUG=false` the gate constant-folds to `false`, the `defonce` install
 ;; body DCEs, and the registration path carries ZERO reprojection cost. The
-;; hook adds NO new always-on error id: assembly errors flow through the
-;; existing `resolve-generation!` diagnostics, and the registrar fires
-;; registration hooks ISOLATED (a hook throw is swallowed, never blocking the
-;; `reg-*`), so a reprojection-assembly failure during a dev hot reload cannot
-;; break the underlying registration.
+;; hook adds NO new ALWAYS-ON error id: assembly errors never reach the
+;; always-on axis (Spec 009 §Observability channels) here — they are diagnosed
+;; on the trace DIAGNOSTIC channel only (`:rf.warning/reprojection-failed`,
+;; `reproject-live-frames-resiliently!` below), which is itself gated on
+;; `interop/debug-enabled?` inside `trace/emit-error!` and so carries the same
+;; ZERO production cost. And the registrar fires registration hooks ISOLATED
+;; (a hook throw is swallowed, never blocking the `reg-*`), so a reprojection-
+;; assembly failure during a dev hot reload cannot break the underlying
+;; registration EITHER WAY.
 
 (defonce ^{:private true
            :doc "Process-local DIRTY flag: true when a `reg-*` source-store change
@@ -955,18 +1096,47 @@
 
 (defn- deferred-flush!
   "The fire-and-forget tick body the coalescing scheduler arms on
-  `interop/next-tick`. Runs `flush-pending-reprojection!` but SWALLOWS any throw:
-  a deferred background dev-hot-reload reprojection has no caller to surface an
-  exception to (it runs on a microtask / the JVM executor thread, OUTSIDE any
-  `reg-*` call frame), so a throw there would become an unhandled rejection that
-  pollutes unrelated work. Crucially the flush has ALREADY cleared the dirty flag
-  before reprojecting, so a swallowed failure does not wedge the flag set (a
-  subsequent `reg-*` re-arms a fresh tick). The SYNCHRONOUS
+  `interop/next-tick`. A deferred background dev-hot-reload reprojection has
+  no caller to surface an exception to (it runs on a microtask / the JVM
+  executor thread, OUTSIDE any `reg-*` call frame), so this never lets a
+  reprojection failure escape as an unhandled rejection that pollutes
+  unrelated work.
+
+  rf2-rf3zgt (the judgment call — this ns was previously found to SWALLOW a
+  per-frame assembly failure with ZERO emission AND abort the sweep
+  mid-way, silently leaving every OTHER live frame queued after the failing
+  one on its stale generation): this now runs the RESILIENT sweep
+  (`reproject-live-frames-resiliently!`), which isolates each frame's
+  reprojection so one failure does NOT stop the others from reprojecting, and
+  DIAGNOSES the failure (`:rf.warning/reprojection-failed`, the trace
+  DIAGNOSTIC channel — dev visibility, zero production cost) instead of
+  swallowing it silently. The choice is DIAGNOSE, not RE-THROW: this is still
+  a background tick with no caller to report a hard failure to, and
+  ALWAYS-ON-axis promotion is deliberately NOT added here (Spec 009
+  §Observability channels — an always-on id is for failures an app must be
+  able to react to at runtime; a dev-hot-reload assembly typo is not that).
+
+  The dirty flag is cleared BEFORE reprojecting (read-then-reset), so a
+  re-entrant `reg-*` during the flush re-arms a fresh tick rather than being
+  lost — unchanged from before. The outer `try/catch` is now a defensive LAST
+  RESORT for something outside the per-frame boundary itself throwing (e.g.
+  enumerating `image-loaded-frame-ids`, the flag `reset!`) — vanishingly
+  unlikely, but diagnosed via `:rf.warning/reprojection-flush-failed` rather
+  than silently discarded, belt-and-suspenders. The SYNCHRONOUS
   `flush-pending-reprojection!` and the direct `reproject-live-frames!` keep
-  surfacing throws — only this deferred path is defensive. Returns nil."
+  their all-or-nothing throw-through contract UNCHANGED — a REPL/test caller
+  wants immediate fail-loud feedback, not a partially-applied sweep; only
+  THIS deferred path is resilient + defensive. Returns nil."
   []
-  (try (flush-pending-reprojection!)
-       (catch #?(:clj Throwable :cljs :default) _ nil))
+  (try
+    (when @pending-reprojection?
+      (reset! pending-reprojection? false)
+      (reproject-live-frames-resiliently!))
+    (catch #?(:clj Throwable :cljs :default) ex
+      (trace/emit-error! :rf.warning/reprojection-flush-failed
+                         {:category  :rf.warning/reprojection-flush-failed
+                          :exception ex
+                          :where     :deferred-flush!})))
   nil)
 
 (defn- mark-dirty-and-schedule!
@@ -977,8 +1147,9 @@
   re-evaluating all its registrations) sets the flag many times but schedules at
   most ONE deferred flush — reprojecting ONCE at the batch boundary, not per
   `reg-*`. `compare-and-set!` makes the schedule-decision atomic against the
-  burst. The scheduled body is the error-swallowing `deferred-flush!` (a
-  background tick has no caller to surface a throw to).
+  burst. The scheduled body is the RESILIENT, diagnosing `deferred-flush!` (a
+  background tick has no caller to surface a throw to, so a per-frame failure
+  is diagnosed rather than thrown — see its docstring).
 
   The NO-IMAGE-LOADED-FRAME skip keeps this off the hot path so an ordinary
   registration burst with no image-loaded frames costs essentially nothing

--- a/implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj
+++ b/implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj
@@ -472,10 +472,30 @@
       They are therefore DROPPED from this allow-list, as
       `allow-list-stays-honest` requires the moment the rows land.
 
+  rf2-rf3zgt DEV-HOT-RELOAD DIAGNOSTIC PAIR (held transitionally):
+    - `:rf.warning/reprojection-failed` — `re-frame.live-frame`'s deferred
+      (`next-tick`) reprojection sweep now DIAGNOSES a per-frame assembly
+      failure on the trace channel instead of silently aborting the whole
+      sweep (the mid-sweep-abort defect the bead fixed); carries `:frame` +
+      `:exception`.
+    - `:rf.warning/reprojection-flush-failed` — the same ns's belt-and-
+      suspenders outer catch around the deferred flush, for a failure outside
+      the per-frame boundary (vanishingly unlikely — enumerating live frame
+      ids, the dirty-flag swap itself).
+      Both are DIAGNOSTIC-channel-only (dev hot-reload, gated on
+      `interop/debug-enabled?` inside `trace/emit-error!` — zero production
+      cost) and were added by a worker scoped to `live_frame.cljc` alone (not
+      the hot-zone Spec 009 file); held here transitionally per this list's
+      own convention (see the `:rf.error/cofx-registration-invalid` precedent
+      above) until a follow-up authors the two catalogue rows in Spec 009
+      §Error event catalogue and drops them from here.
+
   `allow-list-stays-honest` fails if any entry becomes catalogued or stops being
   emitted, forcing the co-edit so the list cannot rot into a silent blanket
   suppression."
-  #{:rf.error/flow-cycle-extract-invariant})
+  #{:rf.error/flow-cycle-extract-invariant
+    :rf.warning/reprojection-failed
+    :rf.warning/reprojection-flush-failed})
 
 ;; ---------------------------------------------------------------------------
 ;; Tests

--- a/implementation/core/test/re_frame/live_frame_reload_cljs_test.cljc
+++ b/implementation/core/test/re_frame/live_frame_reload_cljs_test.cljc
@@ -787,3 +787,176 @@
           (lf/flush-pending-reprojection!)
           (registrar/unregister! :event :reentry/inc)
           (reset! source-store/kind->id->ns->descriptor snapshot))))))
+
+;; ===========================================================================
+;; 10. Generation PROVENANCE — reprojection resolves an EXPLICIT-POOL frame
+;;     against its OWN pool, never the live store (rf2-rf3zgt)
+;; ===========================================================================
+;;
+;; Bug: `reproject-live-frame!` always re-resolved a frame's `:rf.gen/images`
+;; against `nil` (⇒ the LIVE source store), even for a frame `make-frame`'s
+;; 2-arity created against an EXPLICIT descriptor pool. Any reprojection sweep
+;; — a manual `reproject-live-frames!` call, or the auto-hook firing on ANY
+;; `reg-*` anywhere — would then re-resolve that frame against a store its
+;; composition was never selected from. The fix (`frame-generation-pool`,
+;; §Generation PROVENANCE in live_frame.cljc) records which pool a frame's
+;; generation came from and threads the SAME pool through reprojection.
+
+(deftest reproject-resolves-explicit-pool-frame-against-its-own-pool
+  (testing "a frame created via make-frame's 2-arity (an EXPLICIT descriptor
+            pool) reprojects against that SAME pool, not the live source
+            store. The pool's namespace exists ONLY in the pool, never in the
+            live store, so a reprojection that (bug) fell through to the live
+            store would :rf.error/image-zero-match fail-loud here — proving
+            the fix threads the ORIGINAL pool through, not nil/live."
+    (let [pool  [(reg-desc "rpf-pool.provenance.ns" :event :rpf-pool/inc ::pool-v1)]
+          img   (image/image {:id :rpf-pool/img :select-ns {:include ["rpf-pool.provenance.ns"]}})
+          frame (lf/make-frame {:id :rpf-pool/main :images [img]} pool)
+          gen-before (lf/frame-generation frame)]
+      (testing "control: resolves against the explicit pool at creation"
+        (is (= ::pool-v1 (:handler-fn (asm/resolve-descriptor gen-before :event :rpf-pool/inc)))))
+      (testing "reprojecting does NOT throw and reports the frame UNCHANGED —
+                the live store has NOTHING under \"rpf-pool.provenance.ns\", so
+                a fall-through-to-live bug would zero-match fail-loud here"
+        (is (nil? (lf/reproject-live-frame! :rpf-pool/main))))
+      (testing "the frame's generation is untouched and still resolves through
+                the explicit pool"
+        (is (identical? gen-before (lf/frame-generation (lf/live-frame :rpf-pool/main))))
+        (is (= ::pool-v1 (:handler-fn (asm/resolve-descriptor
+                                         (lf/frame-generation (lf/live-frame :rpf-pool/main))
+                                         :event :rpf-pool/inc))))))))
+
+(deftest reproject-live-frames-mixes-explicit-pool-and-live-store-frames-safely
+  (testing "reproject-live-frames! sweeps an explicit-pool frame ALONGSIDE a
+            live-store frame in the SAME pass: each reprojects against its OWN
+            recorded provenance — the live frame picks up its reg-* re-eval,
+            the explicit-pool frame is left untouched (no cross-contamination,
+            no throw, no stray move either way).
+
+            DETERMINISM (rf2-roou7s idiom): creating the SECOND live frame
+            below (once the first is already live) fires the process-defonce
+            auto-reprojection hook for real — `interop/next-tick` is redef'd
+            to a no-op for the whole case so no background tick can race this
+            case's own manual `reproject-live-frames!` call and drain the
+            dirty flag out from under it."
+    (let [snapshot @source-store/kind->id->ns->descriptor]
+      (try
+        (with-redefs [interop/next-tick (fn [_f] nil)]
+          (lf/flush-pending-reprojection!))
+        (source-store/record-descriptor!
+          :event :rpf-live/inc
+          {:rf.provenance/ns "rpf-live.provenance.ns" :kind :event :id :rpf-live/inc
+           :handler-fn ::live-v1})
+        (with-redefs [interop/next-tick (fn [_f] nil)]
+          (let [pool       [(reg-desc "rpf-mix-pool.provenance.ns" :event :rpf-mix-pool/inc ::pool-v1)]
+                live-img   (image/image {:id :rpf-live/img :select-ns {:include ["rpf-live.provenance.ns"]}})
+                pool-img   (image/image {:id :rpf-mix-pool/img :select-ns {:include ["rpf-mix-pool.provenance.ns"]}})
+                live-frame (lf/make-frame {:id :rpf-live/main :images [live-img]})
+                pool-frame (lf/make-frame {:id :rpf-mix-pool/main :images [pool-img]} pool)
+                pool-gen-before (lf/frame-generation pool-frame)]
+            (source-store/record-descriptor!
+              :event :rpf-live/inc
+              {:rf.provenance/ns "rpf-live.provenance.ns" :kind :event :id :rpf-live/inc
+               :handler-fn ::live-v2})
+            (let [moved (lf/reproject-live-frames!)]
+              (testing "the live-store frame moved (picked up the reg-* re-eval)"
+                (is (contains? moved :rpf-live/main)))
+              (testing "the explicit-pool frame did NOT move and was not corrupted"
+                (is (not (contains? moved :rpf-mix-pool/main)))
+                (is (identical? pool-gen-before (lf/frame-generation (lf/live-frame :rpf-mix-pool/main))))
+                (is (= ::pool-v1
+                       (:handler-fn
+                         (asm/resolve-descriptor
+                           (lf/frame-generation (lf/live-frame :rpf-mix-pool/main))
+                           :event :rpf-mix-pool/inc))))))))
+        (finally
+          (reset! frame/frames {})
+          (reset! source-store/kind->id->ns->descriptor snapshot))))))
+
+;; ===========================================================================
+;; 11. Deferred-flush resilience — no mid-sweep abort, failure DIAGNOSED, not
+;;     silently swallowed (rf2-rf3zgt)
+;; ===========================================================================
+;;
+;; Bug: `deferred-flush!` (the `next-tick`-scheduled background tick) caught
+;; whatever `reproject-live-frames!`'s all-or-nothing `reduce` threw and
+;; swallowed it with ZERO emission — but that `reduce` had ALREADY aborted
+;; mid-sweep on the first failing frame, so every OTHER live frame queued
+;; AFTER it (in enumeration order) silently stayed on its stale generation
+;; too, with no diagnostic anywhere naming what broke. The fix
+;; (`reproject-live-frames-resiliently!`) isolates each frame's reprojection
+;; so ONE failure does not stop the sweep from reaching the rest, and
+;; diagnoses the failure on the trace channel (`:rf.warning/reprojection-failed`)
+;; instead of a silent black hole. `frame/image-loaded-frame-ids` is redef'd
+;; to a FIXED order so the regression is pinned deterministically — the real
+;; registry enumerates a hash-set whose natural iteration order this test must
+;; not depend on (an ordering where the good frame happened to process BEFORE
+;; the bad one would make the OLD buggy code look fine too).
+
+(deftest deferred-flush-does-not-abort-mid-sweep-on-one-frame-failure
+  (testing "the deferred (next-tick) reprojection flush isolates a PER-FRAME
+            assembly failure: a frame whose reprojection throws must NOT stop
+            the sweep from reaching + reprojecting the REMAINING frames (the
+            mid-sweep-abort defect), and the failure is DIAGNOSED rather than
+            silently swallowed."
+    (let [snapshot  @source-store/kind->id->ns->descriptor
+          diagnosed (atom [])]
+      (try
+        ;; Start from a clean slate: drain any reprojection a prior case left
+        ;; pending on the shared process-defonce flag (under a next-tick
+        ;; no-op so draining cannot itself arm a stray real tick).
+        (with-redefs [interop/next-tick (fn [_f] nil)]
+          (lf/flush-pending-reprojection!))
+        (registrar/register! :event :rpf-good/inc
+          {:rf.provenance/ns "rpf-good.provenance.ns" :handler-fn ::good-v1})
+        (registrar/register! :event :rpf-bad/inc
+          {:rf.provenance/ns "rpf-bad.provenance.ns" :handler-fn ::bad-v1})
+        (let [good-img (image/image {:id :rpf-good/img :select-ns {:include ["rpf-good.provenance.ns"]}})
+              bad-img  (image/image {:id :rpf-bad/img  :select-ns {:include ["rpf-bad.provenance.ns"]}})
+              tick     (atom nil)]
+          ;; Capture (never run) every scheduled tick for the rest of the case
+          ;; — including the ones make-frame's own reg-frame calls arm — so no
+          ;; real async tick can race this case's manual drive (the same
+          ;; rf2-roou7s determinism idiom the auto-reprojection tests above
+          ;; use). `frame/image-loaded-frame-ids` is ALSO fixed for the whole
+          ;; case: `mark-dirty-and-schedule!`'s guard only checks non-empty,
+          ;; so the fixed answer is harmless during setup and DETERMINISTIC at
+          ;; the sweep itself (bad frame first).
+          (with-redefs [interop/next-tick (fn [f] (reset! tick f) nil)
+                        frame/image-loaded-frame-ids
+                        (fn [] [:rpf-bad/main :rpf-good/main])]
+            (lf/make-frame {:id :rpf-good/main :images [good-img]})
+            (lf/make-frame {:id :rpf-bad/main  :images [bad-img]})
+            ;; A legitimate re-eval for the good frame — this is the change
+            ;; the sweep must still pick up despite the bad frame's failure.
+            (registrar/register! :event :rpf-good/inc
+              {:rf.provenance/ns "rpf-good.provenance.ns" :handler-fn ::good-v2})
+            ;; Forget the bad frame's ENTIRE selected namespace so its
+            ;; reprojection zero-match fails loud.
+            (registrar/unregister! :event :rpf-bad/inc)
+            (rf/register-listener! :trace ::rpf-rec
+              (fn [ev] (when (= :rf.warning/reprojection-failed (:operation ev))
+                         (swap! diagnosed conj ev))))
+            (try
+              (testing "running the captured deferred tick does not throw even
+                        though the bad frame's reprojection fails"
+                (is (nil? (@tick))))
+              (finally
+                (rf/unregister-listener! :trace ::rpf-rec))))
+          (testing "the GOOD frame still reprojected — the sweep reached it
+                    despite the bad frame's failure earlier in the fixed order"
+            (is (= ::good-v2
+                   (:handler-fn (asm/resolve-descriptor
+                                  (lf/frame-generation (lf/live-frame :rpf-good/main))
+                                  :event :rpf-good/inc)))))
+          (testing "the bad frame's failure was DIAGNOSED (not a silent black
+                    hole) via a :rf.warning/reprojection-failed trace event
+                    naming the frame"
+            (is (= 1 (count @diagnosed)))
+            (is (= :rpf-bad/main (get-in (first @diagnosed) [:tags :frame])))))
+        (finally
+          (with-redefs [interop/next-tick (fn [_f] nil)]
+            (reset! frame/frames {})
+            (lf/flush-pending-reprojection!))
+          (registrar/unregister! :event :rpf-good/inc)
+          (reset! source-store/kind->id->ns->descriptor snapshot))))))


### PR DESCRIPTION
## Summary

Two dev-hot-reload-only bugs in `implementation/core/src/re_frame/live_frame.cljc`, both verified reproducing before the fix (rf2-rf3zgt):

1. **Reprojection re-resolved explicit-pool frames against the LIVE store, not their own generation's provenance.** `reproject-live-frame!` always called `resolve-generation! images nil`, unconditionally resolving against the live source store. A frame `make-frame`'s 2-arity created against an explicit descriptor pool (the test/harness/pre-snapshotted-store idiom) got swept up by ANY reprojection — a manual `reproject-live-frames!` call, or the auto-hook firing on any `reg-*` anywhere in the process — and re-resolved against a store its composition was never selected from: a `:select-ns` pattern matching only the explicit pool typically zero-matches the live store (`:rf.error/image-zero-match`, fail-loud), or worse, silently resolves against unrelated live registrations sharing the same namespace string.

   **Fix — generation provenance.** Added `frame-generation-pool`, a process-local `defonce` atom (frame id → the descriptor pool its generation was resolved against; `nil` = live store). `make-frame` records this on every call (creation + hot-reload re-construction); `reproject-live-frame!` reads it back and threads the SAME pool through `resolve-generation!` instead of hardcoding `nil`. This is deliberately NOT a new key on the sealed generation itself — `image-assembly` (the generation-schema owner) is untouched; the provenance lives beside the other reload/reprojection bookkeeping already in this ns. Accepted trade-off: a destroyed-and-never-reused frame id leaves a residual atom entry for the rest of the process (harmless — `reproject-live-frame!` is already a no-op for an unregistered id, and a reused id's entry is always freshly overwritten).

2. **The deferred (`next-tick`) flush swallowed assembly failures with ZERO emission AND aborted the sweep mid-way.** `reproject-live-frames!`'s `reduce` is all-or-nothing: one frame's assembly failure propagated straight out, discarding whatever the sweep had already accomplished and leaving every frame queued AFTER the failing one (in enumeration order) silently un-reprojected. `deferred-flush!` then caught that propagated exception and swallowed it with no diagnostic anywhere. Net effect: one bad hot-reload edit in ONE frame's namespace could silently break hot-reload for every OTHER live frame in the same coalesced burst, with zero visibility.

   **Judgment call (worker latitude, per the bead — dev-hot-reload, low production impact):** DIAGNOSE, don't re-throw, and don't abort. Added `reproject-live-frames-resiliently!`, a private sweep variant used ONLY by the deferred flush: each frame's reprojection runs in its OWN try/catch, so one failure does not stop the sweep from reaching the rest, and the failure is diagnosed via `trace/emit-error!` (`:rf.warning/reprojection-failed`, carrying `:frame` + `:exception`) — the same "swallow but don't be silent" pattern `re-frame.frame/safe-call-hook!` already establishes for teardown-hook failures. Rationale for NOT promoting to the always-on axis: this is a dev-hot-reload assembly typo, not a failure an app must react to at runtime (Spec 009 §Observability channels) — matches this ns's existing "no new always-on error id" stance. The SYNCHRONOUS entry points (`flush-pending-reprojection!`, `reproject-live-frames!`) keep their all-or-nothing throw-through contract UNCHANGED — a REPL/test caller wants immediate fail-loud feedback, not a partially-applied sweep; only the deferred/background path (which has no caller to report a hard failure to) is resilient. `deferred-flush!`'s outer try/catch is now a defensive last resort (diagnosed via `:rf.warning/reprojection-flush-failed` rather than silently discarded) for something outside the per-frame boundary itself throwing.

### Known drift accepted (flagged, not fixed here)

Introducing the two new `:rf.warning/*` diagnostic ids trips the `error-catalogue-channel-conformance-test` co-edit ratchet (every emitted category needs a Spec 009 §Error event catalogue row or an explicit allow-list entry). Since this worker is scoped to `live_frame.cljc` alone (not the hot-zone `spec/009-Instrumentation.md`), both ids were added to `out-of-catalogue-allow-list` in `error_catalogue_channel_conformance_test.clj` transitionally, mirroring the list's own established precedent (e.g. `:rf.error/cofx-registration-invalid`). A follow-up bead is filed to author the two catalogue rows and drop the allow-list entries.

## Quality gates

- `clojure -M:test` (from `implementation/core`): **1739 tests, 7635 assertions, 0 failures, 0 errors** (full suite, including the catalogue conformance test and the 3 new regression tests).
- `npm run test:cljs` (from `implementation/`): **8105 tests, 37178 assertions, 0 failures, 0 errors**.
- New regression tests (in `implementation/core/test/re_frame/live_frame_reload_cljs_test.cljc`):
  - `reproject-resolves-explicit-pool-frame-against-its-own-pool` — an explicit-pool frame's `:select-ns` selects a namespace that exists ONLY in the pool, never the live store; pre-fix, reprojecting it would `:rf.error/image-zero-match` fail-loud (fell through to the live store); post-fix it reprojects cleanly to an UNCHANGED generation.
  - `reproject-live-frames-mixes-explicit-pool-and-live-store-frames-safely` — a manual `reproject-live-frames!` sweep over BOTH an explicit-pool frame and a live-store frame in the same pass: the live frame picks up its `reg-*` re-eval, the explicit-pool frame is untouched (no cross-contamination either way).
  - `deferred-flush-does-not-abort-mid-sweep-on-one-frame-failure` — two live frames, one deliberately made to zero-match-fail at reprojection time; `frame/image-loaded-frame-ids` is redef'd to a FIXED enumeration order (bad frame first) so the mid-sweep-abort regression is pinned deterministically rather than depending on the registry's natural hash-set order. Asserts the captured deferred tick does not throw, the GOOD frame still reprojects despite the bad frame's earlier failure, and exactly one `:rf.warning/reprojection-failed` diagnostic fires naming the bad frame.

## Risk

Dev-hot-reload-only surface (production-elided — the whole reprojection wiring is gated on `interop/debug-enabled?`, and the new diagnostic channel calls are gated a second time inside `trace/emit-error!`). No production-path behavior change. The synchronous entry points' contract is explicitly unchanged. Touches only `implementation/core/src/re_frame/live_frame.cljc`, its own test file, and the conformance-test allow-list (mechanical, test-only).
