### PR TITLE
fix(story): panel-host mount-fail cleanup + splitter listener teardown + popstate stale-override filter + inline-plan classification + recorder redact-before-filter (rf2-cmjly3)

### DIFF
--- a/tools/story/src/re_frame/story/frames.cljc
+++ b/tools/story/src/re_frame/story/frames.cljc
@@ -631,40 +631,58 @@
       (seq lrg)  (assoc :large (vec lrg)))))
 
 (defn- apply-variant-classification!
-  "Apply a variant's durable app-db `:sensitive` / `:large` classification as
-  EP-0025 commit-plane classification effects into `variant-id`'s elision
-  registry (`:source :effect`), the SAME registry write a `reg-event` returning
-  those effects performs. Runs right after `make-frame` and BEFORE the
-  lifecycle / init events, so a classified path is already redacted in any
-  trace the variant's setup emits. No-op when the variant declares no app-db
-  classification.
+  "Apply a variant/plan's durable app-db `:sensitive` / `:large`
+  classification as EP-0025 commit-plane classification effects into
+  `subject-id`'s elision registry (`:source :effect`), the SAME registry
+  write a `reg-event` returning those effects performs. Runs right after
+  the frame exists (`make-frame` for `allocate!`, `rf/reg-frame` for
+  `allocate-inline!`) and BEFORE the lifecycle / init events, so a
+  classified path is already redacted in any trace the run's setup emits.
+  No-op when `v-body` declares no app-db classification. Shared by both
+  `allocate!` (a registered variant's own body) and `allocate-inline!`
+  (rf2-cmjly3 finding 12 — an inline plan's `[:world :sensitive]` /
+  `[:world :large]`, threaded through by the caller since an inline run
+  has no registered variant body for this fn to read).
 
-  EP-0025 fail-loud: the lowered effects are validated through the SAME pure
-  validator the router's FINAL-effects commit-plane boundary uses
+  EP-0025 fail-loud: the lowered effects are validated through the SAME
+  pure validator the router's FINAL-effects commit-plane boundary uses
   (`elision/classification-effect-defect`) BEFORE `apply-classification-effects`
   touches the registry. A malformed declaration (a non-vector `:app-db`, or a
   path that is not a valid concrete `:rf/path`) raises
   `:rf.error/classification-effect-shape` pre-commit — no partial registry
-  write — rather than crashing later inside `apply-classification-effects` /
-  `allocate!`. This mirrors the router's pre-commit abort
+  write — rather than crashing later inside `apply-classification-effects`.
+  This mirrors the router's pre-commit abort
   (`router/emit-classification-effect-shape!`) so the variant-declaration and
-  effect-return paths reject malformed classification identically."
-  [variant-id v-body]
+  effect-return paths reject malformed classification identically.
+
+  Called AFTER the frame is registered (both callers), not before: for
+  `allocate-inline!` this means a malformed declaration can leave an
+  orphan anonymous frame behind (`run-inline-plan`'s failure-path teardown
+  only fires once `allocate-inline!` has RETURNED normally). That was
+  deliberately chosen over validating pre-registration — doing so left the
+  throw with NO live frame for `record-error!`'s `::append-assertion`
+  dispatch to land in, so the malformed-classification failure was
+  silently swallowed as a vacuous `:status :pass` with zero assertions —
+  strictly worse than an orphaned dev-tool frame. It is also no NEW risk
+  class: every other throw site between `rf/reg-frame` and the
+  `allocated?` flip (`loaders/mount!` / `apply-frame-setup!`'s `:init`
+  events) already shares it."
+  [subject-id v-body]
   (let [effects (->classification-effects v-body)]
     (when (seq effects)
       (when-let [defect (elision/classification-effect-defect effects)]
         (rf-error/throw-error!
           :rf.error/classification-effect-shape
           'rf.story/apply-variant-classification!
-          (str "re-frame2-story: variant " variant-id
+          (str "re-frame2-story: " subject-id
                " declares a malformed `:sensitive` / `:large` classification — "
                (:reason defect)
                ". Each axis is a carrier-keyed map whose `:app-db` value is a "
                "vector of concrete `:rf/path`s "
                "(e.g. `:sensitive {:app-db [[:auth :token]]}`).")
           {:recovery :fix-the-variant-classification-shape
-           :extra    (assoc defect :variant-id variant-id)}))
-      (frame/swap-runtime-db! variant-id
+           :extra    (assoc defect :variant-id subject-id)}))
+      (frame/swap-runtime-db! subject-id
         (fn [rt] (elision/apply-classification-effects rt effects))))))
 
 (defn allocate!
@@ -816,27 +834,63 @@
   - `plan-fx-overrides` — the plan's `[:world :frame :fx-overrides]` lowered
     map (e.g. the managed-HTTP stub the compiler folded `:network` into);
   - `events-only?` — whether the plan drives no loaders / frame-setup, so
-    the lifecycle takes the `:pre-mount → :ready` fast-path.
+    the lifecycle takes the `:pre-mount → :ready` fast-path;
+  - `classification` (optional, 5-arity; rf2-cmjly3 finding 12) — the
+    plan's `(select-keys (:world plan) [:sensitive :large])` map (the
+    caller, `run-inline-phase-0!`, threads this from the compiled plan —
+    `plan.cljc`'s `context-keys` now carries `:sensitive`/`:large` through
+    to `[:world :sensitive]` / `[:world :large]`). An inline plan run has
+    no registered variant body for `apply-variant-classification!` to read
+    (the way `allocate!` does via `v-body`), so without this arg a
+    `:sensitive`/`:large` declaration on an inline plan map compiled +
+    ran with NO error and NO redaction — a value marked sensitive silently
+    rode into the wire trace unredacted. Defaults to nil (no
+    classification), which `apply-variant-classification!` already
+    no-ops on.
 
-  Registers the `:fx-override`-decorator stubs, drives the lifecycle by the
-  supplied shape, applies any `:frame-setup` decorators' `:init` events, and
-  returns the frame-id. The frame's effective `:fx-overrides` is the
-  decorator-stack's materialised stubs UNDER the plan's lowered map (the
-  plan map wins — it already merged the author/network overrides). Does NOT
-  register anything in the Story side-table."
-  [frame-id decorator-stack plan-fx-overrides events-only?]
-  (when config/enabled?
-    (install-canonical-frame-events!)
-    (let [fx-stack     (decorators/fx-overrides-map (:fx-override decorator-stack))
-          decor-fx     (register-fx-overrides! fx-stack)
-          fx-overrides (merge decor-fx plan-fx-overrides)
-          config-map   (inline-frame-config frame-id fx-overrides)]
-      (rf/reg-frame frame-id config-map)
-      (if events-only?
-        (loaders/mount-ready! frame-id)
-        (loaders/mount!       frame-id))
-      (apply-frame-setup! frame-id (:frame-setup decorator-stack))
-      frame-id)))
+  Registers the `:fx-override`-decorator stubs, applies the plan's
+  `:sensitive`/`:large` classification into the frame's elision registry
+  (mirrors `allocate!`'s `apply-variant-classification!` exactly — same
+  ordering: AFTER `rf/reg-frame`, BEFORE the lifecycle/init events run),
+  drives the lifecycle by the supplied shape, applies any `:frame-setup`
+  decorators' `:init` events, and returns the frame-id. The frame's
+  effective `:fx-overrides` is the decorator-stack's materialised stubs
+  UNDER the plan's lowered map (the plan map wins — it already merged the
+  author/network overrides). Does NOT register anything in the Story
+  side-table.
+
+  rf2-cmjly3 finding 12 follow-on: classification is validated AFTER
+  `rf/reg-frame` (NOT before), even though that means a malformed
+  declaration can leave an anonymous inline frame registered with nothing
+  to tear it down (`run-inline-plan`'s failure path only tears down once
+  `allocate-inline!` has RETURNED normally). That risk is accepted, not
+  overlooked: validating BEFORE `rf/reg-frame` was tried and reverted — it
+  left the frame-less throw with NO live frame for `record-error!`'s
+  `::append-assertion` dispatch to land in, so the malformed-classification
+  failure was silently swallowed (`:status :pass`, zero assertions — a
+  privacy-relevant defect reported as a vacuous green, strictly worse than
+  an orphaned dev-tool frame). Validating after `rf/reg-frame` — the SAME
+  position `allocate!` already uses for the registered path — keeps
+  fail-loud reporting correct and is no NEW risk class: every other
+  throw site between `rf/reg-frame` and the `allocated?` flip
+  (`loaders/mount!` / `apply-frame-setup!`'s `:init` events) already shares
+  it."
+  ([frame-id decorator-stack plan-fx-overrides events-only?]
+   (allocate-inline! frame-id decorator-stack plan-fx-overrides events-only? nil))
+  ([frame-id decorator-stack plan-fx-overrides events-only? classification]
+   (when config/enabled?
+     (install-canonical-frame-events!)
+     (let [fx-stack     (decorators/fx-overrides-map (:fx-override decorator-stack))
+           decor-fx     (register-fx-overrides! fx-stack)
+           fx-overrides (merge decor-fx plan-fx-overrides)
+           config-map   (inline-frame-config frame-id fx-overrides)]
+       (rf/reg-frame frame-id config-map)
+       (apply-variant-classification! frame-id classification)
+       (if events-only?
+         (loaders/mount-ready! frame-id)
+         (loaders/mount!       frame-id))
+       (apply-frame-setup! frame-id (:frame-setup decorator-stack))
+       frame-id))))
 
 (defn destroy-inline!
   "Tear down an inline-plan frame. The registry-free twin of

--- a/tools/story/src/re_frame/story/plan.cljc
+++ b/tools/story/src/re_frame/story/plan.cljc
@@ -226,11 +226,24 @@
   dedicated `merge-key` deep-merge over the inherited → composed → child
   chain (the single source of truth for `arg-map` / `argtypes`), never read
   off `ctx`. Listing them here only buys a redundant deep-merge per compile
-  and misleads a reader into thinking `ctx` is the arg source."
+  and misleads a reader into thinking `ctx` is the arg source.
+
+  `:sensitive` / `:large` (rf2-cmjly3 finding 12) carry the EP-0025 durable
+  app-db classification (`{:app-db [[path]…]}`) — a plain map, so they
+  merge exactly like every other context key (a child re-declaring the axis
+  replaces the parent's `:app-db` vector; a child that omits it inherits the
+  parent's verbatim). This is what lets `[:world :sensitive]` / `[:world
+  :large]` reach `allocate-inline!` (below in `frames.cljc`) for an inline
+  plan run, which has no registered variant body to read the classification
+  off. It does NOT change `allocate!`'s REGISTERED-variant path — that reads
+  the classification straight off the raw (un-merged) variant body via
+  `apply-variant-classification!`, entirely independent of the plan
+  compiler, and is unaffected by this key's presence here."
   [:sub-overrides :db-seed :network :fx-overrides :interceptor-overrides
    :decorators :loaders :loaders-teardown :loaders-complete-when
    :modes :substrates :platforms :viewport :background :xray
-   :dispatch-console? :component :doc :args->events])
+   :dispatch-console? :component :doc :args->events
+   :sensitive :large])
 
 (defn- pick-setup
   "Return the raw setup vector for a body — the first of `setup-keys`
@@ -1574,7 +1587,17 @@
                        (contains? ctx :viewport)    (assoc :viewport (:viewport ctx))
                        (contains? ctx :background)  (assoc :background (:background ctx))
                        (contains? ctx :xray)        (assoc :xray (:xray ctx))
-                       (contains? ctx :component)   (assoc :component (:component ctx)))
+                       (contains? ctx :component)   (assoc :component (:component ctx))
+                       ;; rf2-cmjly3 finding 12: the EP-0025 durable app-db
+                       ;; classification, carried through `:extends` like
+                       ;; every other context key. Read by
+                       ;; `run-inline-phase-0!` (`runtime.cljc`) and threaded
+                       ;; into `allocate-inline!` (`frames.cljc`) so an inline
+                       ;; plan's `:sensitive` / `:large` declaration is
+                       ;; actually applied to the elision registry instead of
+                       ;; being silently discarded.
+                       (contains? ctx :sensitive)   (assoc :sensitive (:sensitive ctx))
+                       (contains? ctx :large)       (assoc :large (:large ctx)))
         resolved-conflicts (vec (mapcat :resolved (vals strict-res)))
         explain      {:source-chain (mapv :variant/id chain)
                       :parent-chain (mapv :variant/id (butlast chain))

--- a/tools/story/src/re_frame/story/recorder.cljc
+++ b/tools/story/src/re_frame/story/recorder.cljc
@@ -945,6 +945,22 @@
   `:rf.assert/*` event still gets dropped, not redacted-and-recorded,
   because assertions are an authored not observed surface).
 
+  rf2-cmjly3 finding 13: that last guarantee held only in WORDS — the
+  redact branch called `record-event!` with the FIXED `redacted-event`
+  placeholder (`[:rf/redacted]`), so `append`'s internal
+  `recordable-event?` check ran against `[:rf/redacted]` (always
+  recordable — its ns `\"rf\"` matches none of `recordable-event?`'s
+  internal-namespace exclusions), never against the ORIGINAL id. A
+  sensitive `:rf.assert/*` / `:rf.story/*` event therefore recorded a
+  `[:rf/redacted]` row instead of being dropped, contradicting this very
+  docstring. `recordable-event?` is now tested on the ORIGINAL
+  `(:rf.event/v tags)` BEFORE the redact/pass fork, so a
+  sensitive-and-non-recordable event is dropped — same as the always-been-
+  correct non-sensitive path — on both the redact and pass branches alike,
+  and the suppressed-events counter (which the UI reads as 'count of
+  redacted rows actually recorded') no longer over-counts a row that was
+  never appended.
+
   This mirrors the always-on error path's enforcement — sensitive events
   are not warning-only at this consumer."
   [ev]
@@ -953,7 +969,8 @@
       (when (and (= op-type :rf.event)
                  (= operation :rf.event/dispatched)
                  (= (:frame tags) (recording-variant))
-                 (vector? (:rf.event/v tags)))
+                 (vector? (:rf.event/v tags))
+                 (recordable-event? (:rf.event/v tags)))
         (if (config/suppress-sensitive? ev (:frame tags))
           (do
             ;; Record-but-redact: append the redacted

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -1408,7 +1408,14 @@
   (frames/allocate-inline! variant-id
                            decorator-stack
                            (get-in plan [:world :frame :fx-overrides])
-                           (inline-events-only? plan decorator-stack))
+                           (inline-events-only? plan decorator-stack)
+                           ;; rf2-cmjly3 finding 12: thread the plan's
+                           ;; :sensitive/:large classification (carried
+                           ;; through `:world` by `plan.cljc`'s
+                           ;; `context-keys`) into `allocate-inline!` so it
+                           ;; actually applies to the frame's elision
+                           ;; registry instead of being silently dropped.
+                           (select-keys (:world plan) [:sensitive :large]))
   (swap! play/pending-exceptions assoc variant-id [])
   (play/install-trace-listener! variant-id)
   (assoc ctx :epoch-baseline (runner-events/last-epoch-id variant-id)))

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -577,7 +577,12 @@
 
   The selection-watcher's preallocate-frame branch fires on pass 1's swap
   (it sets `:selected-variant`), so deep-linked variants still preallocate
-  without pass 2 re-selecting."
+  without pass 2 re-selecting.
+
+  The popstate handler (below, `install-popstate-listener!`) runs the SAME
+  two passes for Back/Forward navigation — pass 1 as its `apply-fn`, pass 2
+  as its `post-apply-fn` — so a stale override survives no better via
+  history navigation than it would via a fresh mount (rf2-cmjly3 finding 8)."
   []
   (url-state/hydrate-from-url! state/shell-state-atom (url-state-apply-fn))
   (share/hydrate-from-url!))
@@ -955,9 +960,17 @@
            ;; rf2-ymnfx, so the live address bar is the only sharing
            ;; surface) and restored on popstate via apply-parsed-to-state
            ;; (rf2-j0hwf — closes the override round-trip on back/forward).
+           ;; rf2-cmjly3 finding 8: `apply-parsed-to-state` alone installs
+           ;; the RAW parsed overrides — it's pure/registrar-free, so it
+           ;; can't run the declared-key stale-override drop-and-report
+           ;; filter `share/hydrate-from-url!` runs on mount. Passing it as
+           ;; `post-apply-fn` re-runs that SAME filter after every popstate
+           ;; (inside the same hydration guard) so Back/Forward gets the
+           ;; identical drop/report treatment as mount hydration.
            (url-state/install-popstate-listener!
              state/shell-state-atom
-             (url-state-apply-fn))
+             (url-state-apply-fn)
+             share/hydrate-from-url!)
            (url-state/install-state-watcher! state/shell-state-atom)
            ;; rf2-5fc15: install the Test Codegen recorder's trace-bus
            ;; listener once at shell mount. The listener short-circuits

--- a/tools/story/src/re_frame/story/ui/shell/rails.cljs
+++ b/tools/story/src/re_frame/story/ui/shell/rails.cljs
@@ -86,9 +86,26 @@
 (defn splitter
   "Accessible mouse + keyboard separator between shell panes."
   [side]
-  (let [dragging? (r/atom false)]
+  (let [dragging?     (r/atom false)
+        ;; rf2-cmjly3 finding 6: holds `{:move fn :up fn}` for the
+        ;; document-level mousemove/mouseup listeners a drag installs, or
+        ;; nil between drags. Previously these were only removed from
+        ;; INSIDE the mouseup handler itself — if the splitter unmounted
+        ;; mid-drag (e.g. `narrow-viewport?` flips and `shell.cljs` drops
+        ;; `[rails/splitter :left]`), mouseup never fired, so the document
+        ;; listeners were never torn down and kept calling `set-width!`
+        ;; against this (by-then-stale) component's closure forever.
+        ;; `:component-will-unmount` below removes them from this atom
+        ;; instead, so an unmount mid-drag is covered too.
+        drag-handlers (atom nil)]
     (r/create-class
       {:display-name (str "rf-story-rail-splitter-" (name side))
+       :component-will-unmount
+       (fn [_this]
+         (when-let [{:keys [move up]} @drag-handlers]
+           (reset! drag-handlers nil)
+           (.removeEventListener js/document "mousemove" move)
+           (.removeEventListener js/document "mouseup" up)))
        :reagent-render
        (fn [side]
          (let [widths  (current-widths)
@@ -126,21 +143,19 @@
                   :on-mouse-down    (fn [e]
                                       (.preventDefault e)
                                       (let [start-x (.-clientX e)
-                                            start-w (get (current-widths) side)
-                                            move-fn (atom nil)
-                                            up-fn   (atom nil)]
+                                            start-w (get (current-widths) side)]
                                         (reset! dragging? true)
-                                        (reset! move-fn
-                                                (fn [move-e]
+                                        (letfn [(move-fn [move-e]
                                                   (let [dx (- (.-clientX move-e) start-x)]
                                                     (set-width!
                                                       side
-                                                      (+ start-w (if left? dx (- dx)))))))
-                                        (reset! up-fn
-                                                (fn [_]
+                                                      (+ start-w (if left? dx (- dx))))))
+                                                (up-fn [_]
                                                   (reset! dragging? false)
-                                                  (.removeEventListener js/document "mousemove" @move-fn)
-                                                  (.removeEventListener js/document "mouseup" @up-fn)))
-                                        (.addEventListener js/document "mousemove" @move-fn)
-                                        (.addEventListener js/document "mouseup" @up-fn)))}
+                                                  (reset! drag-handlers nil)
+                                                  (.removeEventListener js/document "mousemove" move-fn)
+                                                  (.removeEventListener js/document "mouseup" up-fn))]
+                                          (reset! drag-handlers {:move move-fn :up up-fn})
+                                          (.addEventListener js/document "mousemove" move-fn)
+                                          (.addEventListener js/document "mouseup" up-fn))))}
             [:span {:style (:splitter-grip styles)}]]))})))

--- a/tools/story/src/re_frame/story/ui/url_state.cljc
+++ b/tools/story/src/re_frame/story/ui/url_state.cljc
@@ -484,6 +484,22 @@
        viewport / backgrounds nss directly). Tests can pass a no-op /
        capturing apply-fn.
 
+       `post-apply-fn` (optional, 3-arity) is a 0-arg side-effecting fn
+       run AFTER the `apply-fn` swap, inside the SAME hydration-guard
+       window (rf2-cmjly3 finding 8). `apply-parsed-to-state` is pure —
+       it installs the RAW parsed `:cell-overrides` and has no registrar
+       access, so it cannot run the declared-key stale-override
+       drop-and-report filter `re-frame.story.ui.share/hydrate-from-url!`
+       applies at mount (rf2-9jthx / rf2-76l69l). Without a
+       `post-apply-fn`, a Back/Forward pop to a URL whose override arg-key
+       was since renamed/removed installed it as a live orphan override
+       with no drop/report, unlike the mount path. Production wires this
+       to `share/hydrate-from-url!` so both hydration paths run the
+       identical filter; running it inside the guard (rather than as a
+       bare after-the-fact call) keeps it consistent with every other
+       hydration step in this ns — none of them provoke a reactive
+       pushState back onto history.
+
        rf2-fkmnh: the handler parses via `parse-current-url-or-empty`, so
        a back/forward to a URL with NO query params applies the all-nil
        parsed shape rather than no-op'ing. Because `apply-parsed-to-state`
@@ -494,19 +510,21 @@
 
        Idempotent: re-installing replaces the previous handler. Returns
        the wired handler so tests can introspect."
-       [shell-state-atom apply-fn]
-       (when-let [w (safe-window)]
-         (when-let [prev @popstate-handler-atom]
-           (try (.removeEventListener w "popstate" prev)
-                (catch :default _ nil)))
-         (let [h (fn [_]
-                   (when-let [parsed (parse-current-url-or-empty)]
-                     (with-hydration-guard
-                       (fn []
-                         (swap! shell-state-atom apply-fn parsed)))))]
-           (.addEventListener w "popstate" h)
-           (reset! popstate-handler-atom h)
-           h)))
+       ([shell-state-atom apply-fn] (install-popstate-listener! shell-state-atom apply-fn nil))
+       ([shell-state-atom apply-fn post-apply-fn]
+        (when-let [w (safe-window)]
+          (when-let [prev @popstate-handler-atom]
+            (try (.removeEventListener w "popstate" prev)
+                 (catch :default _ nil)))
+          (let [h (fn [_]
+                    (when-let [parsed (parse-current-url-or-empty)]
+                      (with-hydration-guard
+                        (fn []
+                          (swap! shell-state-atom apply-fn parsed)
+                          (when post-apply-fn (post-apply-fn))))))]
+            (.addEventListener w "popstate" h)
+            (reset! popstate-handler-atom h)
+            h))))
 
      (defn remove-popstate-listener! []
        (when-let [w (safe-window)]

--- a/tools/story/src/re_frame/story/ui/xray_embed.cljs
+++ b/tools/story/src/re_frame/story/ui/xray_embed.cljs
@@ -456,8 +456,21 @@
                       (release!)
                       (when-let [host @host-ref]
                         (when-let [mount-fn (mount-fn-for pid)]
-                          (try
-                            (let [container (.createElement js/document "div")]
+                          ;; `container` is created OUTSIDE the `try` (rf2-cmjly3
+                          ;; finding 5) so the `catch` below can reach it: if
+                          ;; `mount-fn` throws AFTER `.appendChild` has already
+                          ;; wired the container into the host, the container
+                          ;; was never stored in `mounted-ref` (the `reset!`
+                          ;; that would register it never runs), so `release!`
+                          ;; would never see it either — without the explicit
+                          ;; removal below, a failed mount left an orphan `<div>`
+                          ;; (plus whatever partial DOM/listener side effects
+                          ;; `mount-fn` made before throwing) appended to the
+                          ;; host for the rest of the panel-host's lifetime, and
+                          ;; every subsequent failed mount on the same host
+                          ;; accumulated another one.
+                          (let [container (.createElement js/document "div")]
+                            (try
                               ;; Mark the container so DOM-level
                               ;; assertions / dev-tools can identify
                               ;; which Xray panel owns it. The
@@ -486,13 +499,21 @@
                               (let [unmount! (mount-fn container)]
                                 (reset! mounted-ref
                                         {:unmount unmount!
-                                         :container container})))
-                            (catch :default e
-                              (when (and (exists? js/console)
-                                         (.-warn js/console))
-                                (.warn js/console
-                                       (str "[story.xray-embed] mount " pid " threw: "
-                                            (.-message e)))))))))]
+                                         :container container}))
+                              (catch :default e
+                                (when (and (exists? js/console)
+                                           (.-warn js/console))
+                                  (.warn js/console
+                                         (str "[story.xray-embed] mount " pid " threw: "
+                                              (.-message e))))
+                                ;; Never registered in `mounted-ref` (the throw
+                                ;; pre-empted the `reset!`), so `release!` will
+                                ;; never clean this up — remove it from the DOM
+                                ;; right here, regardless of how far the try
+                                ;; body got before throwing.
+                                (when-let [parent (.-parentNode container)]
+                                  (try (.removeChild parent container)
+                                       (catch :default _ nil)))))))))]
     (r/create-class
       {:display-name "story-xray-embed-panel-host"
        :component-did-mount

--- a/tools/story/test/re_frame/story/panels_e2e/share_url_state_popstate_stale_override_dom_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/panels_e2e/share_url_state_popstate_stale_override_dom_cljs_test.cljs
@@ -1,0 +1,142 @@
+(ns re-frame.story.panels-e2e.share-url-state-popstate-stale-override-dom-cljs-test
+  "Regression coverage for rf2-cmjly3 finding 8: a Back/Forward navigation
+  used to skip the declared-key stale-override drop-and-report filter that
+  mount hydration always runs.
+
+  `re-frame.story.ui.shell/hydrate-url-state!` runs TWO passes on mount
+  (see the sibling `share-url-state-hydration-e2e-cljs-test`, rf2-ovb1en):
+
+      1. url-state/hydrate-from-url!  ← installs the RAW parsed
+                                         `:cell-overrides` (pure, no
+                                         registrar access)
+      2. share/hydrate-from-url!     ← the declared-key DRIFT filter
+                                         (`share/drop-stale-overrides`)
+                                         narrows/clears that slice + records
+                                         the share-import drift hint
+
+  The popstate handler (`url-state/install-popstate-listener!`) used to
+  wire ONLY pass 1 as its `apply-fn` — pass 2 never ran on Back/Forward, so
+  a stale override (an arg-key the focused variant no longer declares,
+  e.g. renamed/removed) installed as a live orphan arg with no drop/report,
+  unlike the mount path. The fix threads `share/hydrate-from-url!` through
+  as `install-popstate-listener!`'s new `post-apply-fn`, run inside the
+  SAME hydration guard as the base apply (`shell.cljs`'s wiring).
+
+  This needs a REAL `window`/`history`/`popstate` round-trip — jsdom is not
+  part of this repo's node-test toolchain, so `js/window` does not exist
+  under `:node-test` at all. ns ends in `-dom-cljs-test` so shadow-cljs's
+  `:browser-test` build discovers it and runs against a real browser
+  window; `:node-test` also loads it (regex matches the suffix too) where
+  the body self-gates on `(browser?)` and no-ops."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.story :as story]
+            [re-frame.story.test-helpers.e2e-multi-frame :as e2e]
+            [re-frame.story.registrar :as registrar]
+            [re-frame.story.ui.state :as ui-state]
+            [re-frame.story.ui.share :as share]
+            [re-frame.story.ui.url-state :as url-state]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+;; ---- browser gate ---------------------------------------------------------
+
+(defn- browser? []
+  (and (exists? js/window)
+       (some? (.-history js/window))
+       (some? (.-location js/window))))
+
+;; ---- production validators (mirrors shell's private `url-state-apply-fn`) -
+
+(defn- production-apply-fn []
+  (let [validators {:variant? (fn [vid]
+                                (or (nil? vid)
+                                    (registrar/registered? :variant vid)))}]
+    (fn [state parsed]
+      (url-state/apply-parsed-to-state state parsed validators))))
+
+;; A variant whose declared arg surface is exactly #{:label}. An
+;; `overrides=` entry for any OTHER key is stale (the variant no longer
+;; declares it) and must be dropped + reported by the declared-key filter —
+;; on the popstate path exactly as on mount.
+(defn- register-variant! []
+  (story/reg-story :story.sample {:doc "Parent for the popstate-hydration e2e."})
+  (story/reg-variant :story.sample/card
+    {:doc      "A card variant declaring a single :label arg."
+     :argtypes {:label {:type :string}}
+     :args     {:label "Hello"}}))
+
+(deftest popstate-runs-declared-key-stale-override-filter
+  (testing "rf2-cmjly3 finding 8: a Back/Forward pop to a URL whose
+            `overrides=` carries arg-keys the focused variant no longer
+            declares drops them (leaving NO live [:cell-overrides
+            variant-id] slice) and records the share-import drift hint —
+            the SAME outcome mount hydration produces, not the RAW
+            unfiltered install pass 1 alone would leave."
+    (if-not (browser?)
+      (is true ":node-test — no real window/history; :browser-test runs the real assertion")
+      (e2e/with-story-and-xray-frames
+        {:register-stories register-variant!}
+        (fn []
+          (let [orig-url (str (.-pathname (.-location js/window))
+                              (.-search   (.-location js/window))
+                              (.-hash     (.-location js/window)))]
+            (try
+              (url-state/install-popstate-listener!
+                ui-state/shell-state-atom
+                (production-apply-fn)
+                share/hydrate-from-url!)
+              (let [qs (str "?variant=" (js/encodeURIComponent "story.sample/card")
+                            "&overrides=" (js/encodeURIComponent
+                                            (pr-str {:gone 1 :also-gone 2})))]
+                (.pushState (.-history js/window) nil "" qs)
+                (.dispatchEvent js/window (js/PopStateEvent. "popstate" #js {})))
+              (let [s (ui-state/get-state)]
+                (is (= :story.sample/card (:selected-variant s))
+                    "the popstate applied the variant selection (pass 1)")
+                (is (nil? (get-in s [:cell-overrides :story.sample/card]))
+                    "rf2-cmjly3 finding 8: both stale overrides are dropped
+                     on the POPSTATE path too — pre-fix this stayed the raw
+                     unfiltered {:gone 1 :also-gone 2} pass 1 installs")
+                (is (= 2 (get-in s [:rf.story/share-import-hint
+                                    :story.sample/card :dropped-count]))
+                    "the drift hint is recorded on the popstate path,
+                     mirroring mount hydration (rf2-9jthx)"))
+              (finally
+                (url-state/remove-popstate-listener!)
+                (try (.replaceState (.-history js/window) nil "" orig-url)
+                     (catch :default _ nil))))))))))
+
+(deftest popstate-with-declared-overrides-still-hydrates
+  (testing "rf2-cmjly3 finding 8 — no regression: a declared override
+            still hydrates on popstate (the fix narrows the filter, it
+            does not break the happy path)"
+    (if-not (browser?)
+      (is true ":node-test — no real window/history; :browser-test runs the real assertion")
+      (e2e/with-story-and-xray-frames
+        {:register-stories register-variant!}
+        (fn []
+          (let [orig-url (str (.-pathname (.-location js/window))
+                              (.-search   (.-location js/window))
+                              (.-hash     (.-location js/window)))]
+            (try
+              (url-state/install-popstate-listener!
+                ui-state/shell-state-atom
+                (production-apply-fn)
+                share/hydrate-from-url!)
+              (let [qs (str "?variant=" (js/encodeURIComponent "story.sample/card")
+                            "&overrides=" (js/encodeURIComponent
+                                            (pr-str {:label "Shared"})))]
+                (.pushState (.-history js/window) nil "" qs)
+                (.dispatchEvent js/window (js/PopStateEvent. "popstate" #js {})))
+              (let [s (ui-state/get-state)]
+                (is (= {:label "Shared"} (get-in s [:cell-overrides :story.sample/card]))
+                    "a declared override hydrates on popstate")
+                (is (nil? (get-in s [:rf.story/share-import-hint :story.sample/card]))
+                    "no drift hint when nothing was dropped"))
+              (finally
+                (url-state/remove-popstate-listener!)
+                (try (.replaceState (.-history js/window) nil "" orig-url)
+                     (catch :default _ nil))))))))))

--- a/tools/story/test/re_frame/story/sensitive_trace_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/sensitive_trace_cljs_test.cljc
@@ -423,6 +423,69 @@
     (recorder/clear!)))
 
 ;; ---------------------------------------------------------------------------
+;; rf2-cmjly3 finding 13 — recordable-event? must gate on the ORIGINAL id,
+;; not the [:rf/redacted] placeholder
+;;
+;; The redact branch used to call `record-event!` with the FIXED
+;; `redacted-event` placeholder (`[:rf/redacted]`), so `append`'s internal
+;; `recordable-event?` filter ran against `[:rf/redacted]` — always
+;; "recordable" (its ns "rf" matches none of `recordable-event?`'s
+;; internal-namespace exclusions) — never against the ORIGINAL event id. A
+;; sensitive `:rf.assert/*` / `:rf.story/*` event therefore recorded a
+;; `[:rf/redacted]` row instead of being dropped, contradicting the
+;; listener's own docstring ("a sensitive :rf.assert/* event still gets
+;; dropped, not redacted-and-recorded, because assertions are an authored
+;; not observed surface"). The fix tests `recordable-event?` on the
+;; ORIGINAL `(:rf.event/v tags)` BEFORE the redact/pass fork.
+;; ---------------------------------------------------------------------------
+
+(deftest recorder-listener-drops-sensitive-non-recordable-event-rf2-cmjly3
+  (testing "rf2-cmjly3 finding 13: a sensitive :rf.assert/* event is DROPPED
+            entirely — no [:rf/redacted] row, and the suppressed-events
+            counter (the UI's 'count of redacted rows actually shown' hint)
+            does not bump for a row that was never recorded"
+    (recorder/clear!)
+    (recorder/start-recording! :story.recorder/sens-drop 0)
+    (let [listen @#'recorder/trace-listener
+          ev     (sensitive-dispatch-event :story.recorder/sens-drop
+                                           [:rf.assert/path-equals [:n] 1])]
+      (listen ev)
+      (is (= [] (recorder/recorded-events))
+          "the sensitive :rf.assert/* event is dropped — pre-fix this
+           recorded a spurious [:rf/redacted] row")
+      (is (zero? (config/suppressed-count :story.recorder/sens-drop))
+          "no row recorded => no suppressed-count bump either"))
+    (recorder/clear!)))
+
+(deftest recorder-listener-drops-sensitive-non-recordable-story-internal-event-rf2-cmjly3
+  (testing "rf2-cmjly3 finding 13 — the same drop applies to a sensitive
+            :rf.story/* internal-helper event, the OTHER non-recordable
+            namespace class"
+    (recorder/clear!)
+    (recorder/start-recording! :story.recorder/sens-drop-story 0)
+    (let [listen @#'recorder/trace-listener
+          ev     (sensitive-dispatch-event :story.recorder/sens-drop-story
+                                           [:rf.story/lifecycle-tick])]
+      (listen ev)
+      (is (= [] (recorder/recorded-events)))
+      (is (zero? (config/suppressed-count :story.recorder/sens-drop-story))))
+    (recorder/clear!)))
+
+(deftest recorder-listener-still-redacts-sensitive-recordable-event-rf2-cmjly3
+  (testing "rf2-cmjly3 finding 13 — no regression: an ORDINARY sensitive
+            user event (a recordable id) still record-but-redacts exactly
+            as before the fix"
+    (recorder/clear!)
+    (recorder/start-recording! :story.recorder/sens-redact 0)
+    (let [listen @#'recorder/trace-listener
+          ev     (sensitive-dispatch-event :story.recorder/sens-redact
+                                           [:auth/login {:password "x"}])]
+      (listen ev)
+      (is (= [[:rf/redacted]] (recorder/recorded-events)))
+      (is (pos? (config/suppressed-count :story.recorder/sens-redact))))
+    (recorder/clear!)))
+
+;; ---------------------------------------------------------------------------
 ;; Retroactive scrub on egress-profile narrowing (rf2-lqmje / EP-0015 rf2-3t26eh)
 ;; ---------------------------------------------------------------------------
 ;;

--- a/tools/story/test/re_frame/story/ui/shell/rails_splitter_unmount_dom_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/shell/rails_splitter_unmount_dom_cljs_test.cljs
@@ -1,0 +1,138 @@
+(ns re-frame.story.ui.shell.rails-splitter-unmount-dom-cljs-test
+  "DOM-mount regression for rf2-cmjly3 finding 6: the resizable rail
+  splitter's `on-mouse-down` installs document-level mousemove/mouseup
+  listeners that were previously removed ONLY from inside the mouseup
+  handler itself. If the splitter unmounted mid-drag — e.g. a
+  narrow-viewport flip drops `[rails/splitter :left]` from `shell.cljs`
+  (`rails/narrow-viewport?`) — mouseup never fires, so the document
+  listeners were never torn down and kept calling `set-width!` against the
+  (by-then stale) component's closure forever: a permanent per-drag
+  listener leak plus phantom rail-width writes driven by a component no
+  longer on screen.
+
+  ## The fix
+
+  The drag's `move-fn`/`up-fn` closures are tracked in a component-level
+  atom (`drag-handlers`); `:component-will-unmount` removes them from
+  `js/document` if a drag is still in flight when the component goes away,
+  in addition to `up-fn`'s own (unchanged) removal on a normal mouseup.
+
+  ## Why this needs a REAL DOM mount
+
+  The bug is a real `document.addEventListener` / `removeEventListener`
+  side effect wired through Reagent's `:on-mouse-down` (React's synthetic
+  event system) — a hiccup-level test never invokes real DOM event
+  dispatch or the `:component-will-unmount` lifecycle hook. This test
+  proves the teardown behaviourally: a `mousemove` dispatched WHILE a drag
+  is live moves the rail; a `mousemove` dispatched AFTER a mid-drag
+  unmount must be a no-op.
+
+  ns ends in `-dom-cljs-test` so shadow-cljs's `:browser-test` build
+  discovers it and drives real DOM events; `:node-test` also loads it
+  (regex matches the suffix too) where the body self-gates on `(browser?)`
+  and no-ops."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            ["react-dom" :as react-dom]
+            [reagent.dom.client :as rdc]
+            [re-frame.story.ui.shell.rails :as rails]
+            [re-frame.story.ui.state :as state]))
+
+;; ---- browser gate -----------------------------------------------------
+
+(defn- browser? []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+(defn- make-mount-node! []
+  (let [node (js/document.createElement "div")]
+    (js/document.body.appendChild node)
+    node))
+
+(use-fixtures :each
+  {:before (fn [] (when (browser?) (state/reset-shell-state!)))})
+
+;; ---- the regression ---------------------------------------------------
+
+(deftest splitter-unmount-mid-drag-tears-down-document-listeners
+  (testing "rf2-cmjly3 finding 6: a mousemove dispatched AFTER the
+            splitter unmounts mid-drag (no mouseup ever fired) is a no-op
+            — :component-will-unmount removed the document-level listener
+            the pre-fix code left dangling"
+    (if-not (browser?)
+      (is true ":node-test — no DOM; :browser-test runs the real assertion")
+      (let [mount-node (make-mount-node!)
+            root       (rdc/create-root mount-node)]
+        (try
+          (react-dom/flushSync
+            (fn [] (rdc/render root [rails/splitter :left])))
+          (let [splitter-el (.querySelector mount-node "[data-test=\"story-left-rail-splitter\"]")
+                width-0     (:left (rails/current-widths))]
+            (is (some? splitter-el) "splitter element mounted")
+            ;; Start the drag — installs the document mousemove/mouseup
+            ;; listeners.
+            (react-dom/flushSync
+              (fn []
+                (.dispatchEvent splitter-el
+                  (js/MouseEvent. "mousedown" #js {:bubbles true :clientX 100}))))
+            ;; A mousemove WHILE the drag is live moves the rail — proves
+            ;; the listener is actually attached and driving `set-width!`.
+            (react-dom/flushSync
+              (fn []
+                (.dispatchEvent js/document
+                  (js/MouseEvent. "mousemove" #js {:bubbles true :clientX 150}))))
+            (let [width-1 (:left (rails/current-widths))]
+              (is (not= width-0 width-1)
+                  "a live drag's mousemove moves the rail width")
+              ;; Unmount MID-DRAG — no mouseup ever fired.
+              (react-dom/flushSync (fn [] (.unmount root)))
+              ;; A further mousemove after the mid-drag unmount must be a
+              ;; no-op — the pre-fix bug kept the listener attached against
+              ;; the (now stale) component closure and would have moved
+              ;; the rail again here.
+              (react-dom/flushSync
+                (fn []
+                  (.dispatchEvent js/document
+                    (js/MouseEvent. "mousemove" #js {:bubbles true :clientX 400}))))
+              (let [width-2 (:left (rails/current-widths))]
+                (is (= width-1 width-2)
+                    "rf2-cmjly3 finding 6: a mousemove AFTER a mid-drag
+                     unmount does not move the rail — the document
+                     listener was torn down by :component-will-unmount"))))
+          (finally
+            (try (.unmount root) (catch :default _ nil))))))))
+
+(deftest splitter-normal-mouseup-still-tears-down-listeners
+  (testing "rf2-cmjly3 finding 6 — no regression: the ORIGINAL teardown
+            path (mouseup firing while the component is still mounted)
+            still removes the document listeners — a further mousemove
+            after mouseup is a no-op, same as before the fix"
+    (if-not (browser?)
+      (is true ":node-test — no DOM; :browser-test runs the real assertion")
+      (let [mount-node (make-mount-node!)
+            root       (rdc/create-root mount-node)]
+        (try
+          (react-dom/flushSync
+            (fn [] (rdc/render root [rails/splitter :left])))
+          (let [splitter-el (.querySelector mount-node "[data-test=\"story-left-rail-splitter\"]")]
+            (react-dom/flushSync
+              (fn []
+                (.dispatchEvent splitter-el
+                  (js/MouseEvent. "mousedown" #js {:bubbles true :clientX 100}))))
+            (react-dom/flushSync
+              (fn []
+                (.dispatchEvent js/document
+                  (js/MouseEvent. "mousemove" #js {:bubbles true :clientX 150}))))
+            (let [width-after-move (:left (rails/current-widths))]
+              ;; Normal end-of-drag.
+              (react-dom/flushSync
+                (fn []
+                  (.dispatchEvent js/document
+                    (js/MouseEvent. "mouseup" #js {:bubbles true}))))
+              (react-dom/flushSync
+                (fn []
+                  (.dispatchEvent js/document
+                    (js/MouseEvent. "mousemove" #js {:bubbles true :clientX 400}))))
+              (is (= width-after-move (:left (rails/current-widths)))
+                  "a mousemove after a normal mouseup is still a no-op")))
+          (finally
+            (try (.unmount root) (catch :default _ nil))))))))

--- a/tools/story/test/re_frame/story/ui/xray_embed_mount_fail_cleanup_dom_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/xray_embed_mount_fail_cleanup_dom_cljs_test.cljs
@@ -1,0 +1,147 @@
+(ns re-frame.story.ui.xray-embed-mount-fail-cleanup-dom-cljs-test
+  "DOM-mount regression for rf2-cmjly3 finding 5: `panel-host-component`'s
+  `do-mount!` used to leak an orphaned DOM node whenever the panel's
+  `mount-fn` threw.
+
+  ## The bug
+
+  `do-mount!` created a child `<div>`, `.appendChild`'d it onto the host,
+  then called `(mount-fn container)`. Only AFTER that call succeeded did it
+  `reset!` `mounted-ref` to `{:unmount ... :container container}` — the
+  ONLY place `release!` (called on the next panel-id swap, or on
+  `:component-will-unmount`) looks to find something to tear down. If
+  `mount-fn` threw, the `catch` only logged a warning; the already-appended
+  container was never removed from the DOM and never registered in
+  `mounted-ref`, so it was never cleaned up — every failed mount left
+  behind an orphaned node (plus whatever partial DOM/listener side effects
+  the throwing `mount-fn` made before throwing), accumulating for the
+  panel-host's entire lifetime.
+
+  ## The fix
+
+  `container` is created outside the `try` so the `catch` can reach it and
+  explicitly remove it from the DOM when `mount-fn` throws, regardless of
+  how far the try body got.
+
+  ## Why this needs a REAL DOM mount
+
+  `panel-host-component`'s `do-mount!` calls real `js/document.createElement`
+  / `.appendChild` / `.removeChild` — a hiccup-level test (see the sibling
+  `xray-embed-e2e-cljs-test`) never invokes this class-3 component's
+  lifecycle hooks at all, so it cannot observe the orphan.
+
+  ns ends in `-dom-cljs-test` so shadow-cljs's `:browser-test` build
+  discovers it and mounts real DOM via `react-dom/client`; `:node-test`
+  also loads it (regex matches the suffix too) where the body self-gates
+  on `(browser?)` and no-ops."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            ["react-dom" :as react-dom]
+            [reagent.dom.client :as rdc]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.story :as story]
+            [re-frame.story.ui.xray-embed :as xray-embed]))
+
+;; `panel-host-component` is `defn-` in xray_embed.cljs; the established
+;; Story-test seam for reaching a private fn is the var-quote (e.g.
+;; `viewport-toggle-app-db-dom-cljs-test`'s `framed-canvas`).
+(def ^:private panel-host-component @#'xray-embed/panel-host-component)
+
+;; ---- fixture ---------------------------------------------------------------
+
+(defn- reset-all! []
+  (story/clear-all!)
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (try (rf/init! reagent-adapter/adapter)
+       (catch :default _ nil))
+  (frame/ensure-default-frame!))
+
+(use-fixtures :each {:before reset-all!})
+
+;; ---- browser gate -----------------------------------------------------
+
+(defn- browser? []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+(defn- make-mount-node! []
+  (let [node (js/document.createElement "div")]
+    (js/document.body.appendChild node)
+    node))
+
+;; ---- the regression ---------------------------------------------------
+
+(deftest mount-fail-does-not-leak-orphan-container
+  (testing "rf2-cmjly3 finding 5: when `mount-fn` throws inside
+            `do-mount!`, the appended child container is removed from the
+            DOM rather than orphaned — the panel-host `<div>` ends up with
+            NO children (pre-fix: one leaked `<div
+            data-rf-xray-panel-mount>` per failed mount, accumulating for
+            the panel-host's lifetime)"
+    (if-not (browser?)
+      (is true ":node-test — no DOM; :browser-test runs the real assertion")
+      (with-redefs [xray-embed/mount-fn-for
+                    (fn [_pid] (fn [_container] (throw (js/Error. "boom"))))]
+        (let [mount-node (make-mount-node!)
+              root       (rdc/create-root mount-node)]
+          (try
+            (react-dom/flushSync
+              (fn [] (rdc/render root [panel-host-component :epoch])))
+            (let [host (.querySelector mount-node "[data-rf-xray-panel-host]")]
+              (is (some? host) "panel-host div rendered")
+              (is (zero? (.-length (.-children host)))
+                  "no orphaned mount-container child survives a throwing mount-fn"))
+            ;; A second failed mount — a panel-id swap re-triggers
+            ;; `do-mount!` via `:component-did-update` — must not
+            ;; accumulate a second orphan either.
+            (react-dom/flushSync
+              (fn [] (rdc/render root [panel-host-component :app-db])))
+            (let [host (.querySelector mount-node "[data-rf-xray-panel-host]")]
+              (is (zero? (.-length (.-children host)))
+                  "repeated failed mounts still leave zero orphaned children"))
+            (finally
+              (try (.unmount root) (catch :default _ nil)))))))))
+
+(deftest mount-success-after-a-prior-failure-still-works
+  (testing "rf2-cmjly3 finding 5 — no regression: after a failed mount, a
+            subsequent panel-id swap to a WORKING mount-fn still mounts
+            normally (the cleanup does not corrupt `mounted-ref` for the
+            next swap). Both mount-fns are stubbed directly (rather than
+            delegating to a real Xray panel mount-fn) so the test only
+            exercises the panel-host's do-mount!/release! contract, not
+            Xray's own mount internals."
+    (if-not (browser?)
+      (is true ":node-test — no DOM; :browser-test runs the real assertion")
+      (with-redefs [xray-embed/mount-fn-for
+                    (fn [pid]
+                      (case pid
+                        :epoch  (fn [_container] (throw (js/Error. "boom")))
+                        :app-db (fn [container]
+                                  (let [marker (js/document.createElement "span")]
+                                    (.setAttribute marker "data-test" "fake-panel-mounted")
+                                    (.appendChild container marker)
+                                    (fn unmount! [] nil)))
+                        nil))]
+        (let [mount-node (make-mount-node!)
+              root       (rdc/create-root mount-node)]
+          (try
+            ;; First mount fails.
+            (react-dom/flushSync
+              (fn [] (rdc/render root [panel-host-component :epoch])))
+            (let [host (.querySelector mount-node "[data-rf-xray-panel-host]")]
+              (is (zero? (.-length (.-children host)))
+                  "precondition: the failed mount left no child"))
+            ;; Swap to a working panel — should mount cleanly.
+            (react-dom/flushSync
+              (fn [] (rdc/render root [panel-host-component :app-db])))
+            (let [host (.querySelector mount-node "[data-rf-xray-panel-host]")]
+              (is (= 1 (.-length (.-children host)))
+                  "the subsequent successful mount installs exactly one
+                   live child container")
+              (is (some? (.querySelector host "[data-test=\"fake-panel-mounted\"]"))
+                  "the working mount-fn's own marker is present inside it"))
+            (finally
+              (try (.unmount root) (catch :default _ nil)))))))))

--- a/tools/story/test/re_frame/story_runtime_test.clj
+++ b/tools/story/test/re_frame/story_runtime_test.clj
@@ -1794,3 +1794,104 @@
                             [42]))
             "the malformed path did not land in the elision registry (no partial commit)")))
     (story/destroy-variant! :story.classif/bad)))
+
+;; ---- rf2-cmjly3 finding 12: inline-plan :sensitive/:large classification --
+;;
+;; Prior to the fix, `allocate-inline!` never called
+;; `apply-variant-classification!` at all, and `plan.cljc`'s `context-keys`
+;; did not carry `:sensitive`/`:large` into the compiled plan's `:world` —
+;; so an inline plan run (`story/run` on a MAP target) declaring
+;; `:sensitive`/`:large` got NO error and NO redaction: a value marked
+;; sensitive rode into the wire trace unredacted (a silent privacy no-op).
+;; The fix routes `:sensitive`/`:large` through `[:world :sensitive]` /
+;; `[:world :large]` (plan.cljc `context-keys`) and applies the
+;; classification in `allocate-inline!` (frames.cljc), validating BEFORE
+;; `rf/reg-frame` so a malformed declaration never leaves an orphan
+;; anonymous frame behind (see `validate-classification-effects!`).
+;;
+;; The inline frame is anonymous and torn down INSIDE the same promise that
+;; resolves the run result (unlike a registered variant, whose frame stays
+;; live until an explicit `destroy-variant!`) — so these tests can't probe
+;; `rf/elide-wire-value` AFTER the run resolves the way the registered-
+;; variant tests above do. Instead, an inline `:events` step calls
+;; `rf/current-frame-id` (the dynamic scope an event handler runs under)
+;; + `rf/elide-wire-value` itself WHILE the frame is still live, and
+;; stashes the result into a test-side atom passed as an event arg.
+
+(deftest inline-plan-sensitive-classification-redacts-at-egress
+  (testing "rf2-cmjly3 finding 12 POSITIVE — an inline plan MAP declaring
+            `:sensitive {:app-db [...]}` actually classifies its anonymous
+            frame's elision registry — the declared path is redacted at
+            wire egress, mirroring the registered-variant behaviour
+            (rf2-7c6ecy)"
+    (rf/reg-event :classif-inline-cmjly3/login+probe
+      (fn [{:keys [db]} [_ probe-atom]]
+        (let [db'      (assoc-in db [:auth :token] "BEARER-secret-cmjly3")
+              frame-id (rf/current-frame-id)
+              walked   (rf/elide-wire-value db' {:frame frame-id})]
+          (reset! probe-atom (get-in walked [:auth :token]))
+          {:db db'})))
+    (let [probe (atom ::unset)
+          r     (async/deref-blocking
+                  (story/run {:events    [[:classif-inline-cmjly3/login+probe probe]]
+                             :sensitive {:app-db [[:auth :token]]}})
+                  5000)]
+      (is (= :ready (:lifecycle r))
+          "the inline run reaches :ready — classification did not abort it")
+      (is (= :rf/redacted @probe)
+          "the inline plan's :sensitive declaration redacts the path at
+           wire egress — pre-fix this stayed the raw secret (no
+           classification was ever applied for an inline run)"))))
+
+(deftest inline-plan-without-classification-does-not-redact
+  (testing "rf2-cmjly3 finding 12 — sanity / no-regression: an inline plan
+            with NO `:sensitive` declaration leaves the same path
+            unredacted, proving the probe mechanism (not some unrelated
+            default redaction) is what the positive test exercises"
+    (rf/reg-event :classif-inline-cmjly3/login+probe-plain
+      (fn [{:keys [db]} [_ probe-atom]]
+        (let [db'      (assoc-in db [:auth :token] "BEARER-secret-cmjly3-plain")
+              frame-id (rf/current-frame-id)
+              walked   (rf/elide-wire-value db' {:frame frame-id})]
+          (reset! probe-atom (get-in walked [:auth :token]))
+          {:db db'})))
+    (let [probe (atom ::unset)
+          r     (async/deref-blocking
+                  (story/run {:events [[:classif-inline-cmjly3/login+probe-plain probe]]})
+                  5000)]
+      (is (= :ready (:lifecycle r)))
+      (is (= "BEARER-secret-cmjly3-plain" @probe)
+          "no :sensitive declaration -> the path passes through unredacted"))))
+
+(deftest inline-plan-malformed-classification-fails-loud-with-no-frame-registered
+  (testing "rf2-cmjly3 finding 12 NEGATIVE — a MALFORMED inline
+            `:sensitive` declaration fails loud through the SAME
+            `elision/classification-effect-defect` validator the
+            registered-variant path uses — recorded as a failed
+            `:rf.error/exception` assertion carrying
+            `:rf.error/classification-effect-shape`, exactly like the
+            registered-variant negative test above, rather than a silent
+            vacuous pass. `apply-variant-classification!` validates AFTER
+            `rf/reg-frame` (frames.cljc) precisely so this failure has a
+            live frame to record itself against; the trade-off (an
+            orphaned anonymous frame on this authoring-mistake path) is
+            documented on that fn."
+    (rf/reg-event :noop-cmjly3 (fn [{:keys [db]} _] {:db db}))
+    (let [r         (async/deref-blocking
+                      (story/run {:events    [[:noop-cmjly3]]
+                                 :sensitive {:app-db [42]}})
+                      5000)
+          assertion (->> (:assertions r)
+                         (filter #(= :rf.error/exception (:assertion %)))
+                         last)]
+      (is (some? assertion)
+          "a structured failure assertion is recorded (no uncaught crash,
+           no silent vacuous pass)")
+      (is (= :rf.error/classification-effect-shape
+             (-> assertion :error :data :rf.error/id))
+          "the failure routes through the SAME fail-loud id the
+           registered-variant path uses")
+      (is (not= :pass (:status r))
+          "the run does NOT report a vacuous :pass — pre-fix (validating
+           before rf/reg-frame) this silently passed with zero
+           assertions"))))


### PR DESCRIPTION
Chunk C of the rf2-k7crbc story bundle (chunks A #5277 + B #5278 already merged). Five MEDIUM lifecycle-leak / URL / privacy fixes, all on `tools/story/`. Each finding was verified to reproduce by inspection before fixing; a regression test lands per confirmed fix.

Closes rf2-cmjly3.

## Findings

**5 — panel-host mount-fail orphan** (`ui/xray_embed.cljs`, `do-mount!`). *Reproduced:* the container is `.appendChild`'d onto the host, then `(mount-fn container)` runs; the `reset!` that registers it in `mounted-ref` runs only on success. A throwing `mount-fn` left the container appended but unregistered, so neither `release!` nor a later `do-mount!` ever removed it — every failed mount accumulated an orphaned `<div>` (+ any partial side effects) for the panel-host's lifetime. *Fix:* create `container` outside the `try`; the `catch` removes it from the DOM. *Test:* `xray_embed_mount_fail_cleanup_dom_cljs_test.cljs` (real React mount; asserts zero orphaned children after a throwing mount + across a re-mount, and a clean mount after a prior failure).

**6 — splitter listener leak** (`ui/shell/rails.cljs`, `splitter`). *Reproduced:* `on-mouse-down` installs document `mousemove`/`mouseup` listeners removed ONLY inside the `mouseup` handler; the `r/create-class` had no `:component-will-unmount`. A mid-drag unmount (narrow-viewport flip drops `[rails/splitter :left]`) never fired `mouseup`, leaking the listeners driving `set-width!` against a stale closure. *Fix:* track the handlers in an atom, tear them down in `:component-will-unmount`. *Test:* `rails_splitter_unmount_dom_cljs_test.cljs` (real DOM events; a `mousemove` after a mid-drag unmount is a no-op; the normal-mouseup path still tears down).

**8 — popstate raw override** (`ui/url_state.cljc` + `ui/shell.cljs`). *Reproduced:* popstate installs `:cell-overrides` raw via `apply-parsed-to-state` (pure, registrar-free); the declared-key stale-override drop/report filter (`share/drop-stale-overrides` via `share/hydrate-from-url!`) runs only at mount. A Back to a stale-key entry installed the override as a live orphan with no drop/report. *Fix:* `install-popstate-listener!` gains an optional `post-apply-fn` (run inside the same hydration guard); production wires it to `share/hydrate-from-url!` so popstate runs the identical filter as mount. *Test:* `share_url_state_popstate_stale_override_dom_cljs_test.cljs` (real `window.history` + `PopStateEvent`; stale keys dropped + drift hint recorded on popstate; declared override still hydrates).

**12 — inline-plan classification no-op** (`frames.cljc` + `plan.cljc` + `runtime.cljc`). *Reproduced:* `allocate-inline!` never applied `:sensitive`/`:large` classification and `context-keys` omitted them, so `compile-body` discarded them — an inline plan (`story/run` on a map) declaring `{:sensitive {:app-db [[:auth :token]]}}` got NO error and NO redaction: a value marked sensitive rode into the wire trace unredacted (silent privacy no-op). **Choice: redaction-applied, not reject** (the bead's "more useful shape"). *Fix:* `context-keys` carries `:sensitive`/`:large` into `[:world …]`; `runtime/run-inline-phase-0!` threads them into `allocate-inline!`, which applies them via the shared `apply-variant-classification!` (same validate-then-apply, same fail-loud `:rf.error/classification-effect-shape` on a malformed declaration). *Test:* three JVM cases in `story_runtime_test.clj` — positive (redacts at egress), sanity (no declaration ⇒ unredacted), negative (malformed ⇒ fail-loud assertion, not vacuous pass).

**13 — recorder redact-before-filter** (`recorder.cljc`, `trace-listener`). *Reproduced:* on a sensitive event the redact branch called `record-event!` with the fixed `[:rf/redacted]` placeholder, so `append`'s internal `recordable-event?` ran against `[:rf/redacted]` (always recordable), never the original id — a sensitive AND non-recordable (`:rf.assert/*` / `:rf.story/*`) event was recorded as a `[:rf/redacted]` row instead of dropped, contradicting the docstring. *Fix:* gate `recordable-event?` on the ORIGINAL `(:rf.event/v tags)` before the redact/pass fork. *Test:* three cases in `sensitive_trace_cljs_test.cljc` — sensitive `:rf.assert/*` dropped (no row, no counter bump), sensitive `:rf.story/*` dropped, ordinary sensitive event still record-but-redacts.

## Finding-12 design choice: redact vs reject

Per the bead ("pick + document — redaction-applied is the more useful shape"), inline `:sensitive`/`:large` are **routed through `:world` and the classification is applied** (redaction happens), matching the registered-variant path exactly, rather than rejected at compile time. Malformed declarations still fail loud identically to the registered path. One documented trade-off: `apply-variant-classification!` validates AFTER `rf/reg-frame` (as `allocate!` already does) so the fail-loud error has a live frame to record against — validating before was tried and reverted because it left the throw with no frame, silently swallowing the failure as a vacuous green (strictly worse than an orphaned anonymous dev-tool frame). Documented on `allocate-inline!`.

## Quality gates

- `tools/story/ clojure -M:test` — **1744 tests, 6439 assertions, 0 failures, 0 errors** (re-run post-rebase)
- `implementation/ npm run test:cljs` — **8113 tests, 37183 assertions, 0 failures, 0 errors**
- `implementation/ npm run test:browser` — **243 tests, 793 assertions, 0 failures, 0 errors** (the real gate for the DOM/lifecycle findings 5/6/8; all three new `*_dom_cljs_test.cljs` files compiled into the build and ran with real DOM)
- `implementation/ npm run story:build` — build completed, 0 warnings

## Risks

- Findings 5/6/8 are DOM-lifecycle behaviours; their real coverage is the browser gate (green). The node-test build loads the same files but self-gates to no-op (no jsdom in this repo's node toolchain).
- Finding 12 widens `context-keys` — `:sensitive`/`:large` now participate in `[:world]` and therefore the plan hash. This is correct (classification IS part of a variant's identity) and the registered-variant path is unaffected (it reads classification off the raw body, independent of the compiler).