### PR TITLE
chore(core): remove 2 unreachable-code branches in frame_classification.cljc (rf2-c5517z)

### DIFF
--- a/implementation/core/src/re_frame/frame_classification.cljc
+++ b/implementation/core/src/re_frame/frame_classification.cljc
@@ -186,10 +186,16 @@
   (`retired-frame-keys` — `:sensitive` / `:large`):
   `:rf.error/bad-frame-classification`, thrown before frame registration
   mutates state, naming the offending key. No-op when `config` carries no
-  retired key (the common case)."
+  retired key (the common case).
+
+  Finds the offending key via `some` (rather than `doseq` over an
+  unconditional-`throw` body) so the throw sits outside any loop — a
+  `doseq`/`for` body that unconditionally throws expands with a `recur`
+  following the `throw` in its chunked- and unchunked-seq branches, which
+  the CLJS analyzer correctly flags as unreachable code (the `recur` can
+  never run once the `throw` fires)."
   [frame-id config]
-  (doseq [k retired-frame-keys
-          :when (contains? config k)]
+  (when-let [k (some #(when (contains? config %) %) retired-frame-keys)]
     (throw (classification-error
              frame-id
              (retired-frame-key-reason k)


### PR DESCRIPTION
## Summary

Fixes rf2-c5517z: two pre-existing 'unreachable code' warnings in `implementation/core/src/re_frame/frame_classification.cljc`, surfaced by `npm run test:bundle-isolation` during rf2-m90brg (not introduced by it).

Both warnings pinned to the same location — `reject-retired-frame-keys!`'s `doseq` call (line 191, col 2):

```clojure
(doseq [k retired-frame-keys
        :when (contains? config k)]
  (throw (classification-error ...)))
```

Root cause: `doseq`'s macroexpansion produces separate chunked-seq and unchunked-seq loop branches, each of which wraps the body as `(do (throw ...) (recur ...))`. Since the body unconditionally throws, the trailing `recur` in each branch is genuinely unreachable — the CLJS analyzer correctly flags it twice (once per branch), both attributed to the `doseq` form's source location. Confirmed via `clojure.core/macroexpand-1` on the exact form.

Fix: replace the `doseq`+unconditional-throw pattern with `some` to find the first offending key, then throw once outside any loop — no macro-generated recur-after-throw to flag. Same first-match-in-iteration-order semantics; same no-op case when `config` carries no retired key.

## Quality gates

- `npm run test:bundle-isolation` — PASS, 0 warnings (both unreachable-code warnings gone; bundle-isolation + uix/helix-reagent-free checks pass)
- `npm run test:cljs` — PASS, 8116 tests / 37195 assertions, 0 failures, 0 errors
- `clojure -M:test` (implementation/core) — PASS, 1747 tests / 7649 assertions, 0 failures, 0 errors

## Risk

Low. Single private function, behaviour-preserving rewrite (same throw semantics, same no-op case), full test suites green, no test relied on doseq's chunked-seq internals or on `:sensitive`+`:large` co-occurrence ordering.