### PR TITLE
docs(xray): correct get-issues op-type set in runtime-seam.md (drop dead :rf.schema/violation + :rf.hydration/mismatch) (rf2-hqo460)

### DIFF
--- a/docs/xray/api/runtime-seam.md
+++ b/docs/xray/api/runtime-seam.md
@@ -132,7 +132,7 @@ Nine read-only accessors. Every one returns a map; success is `:ok? true`; failu
   ```clojure
   (get-issues opts) → {:ok? true :issues <vec> :count <n>}
   ```
-- **Description**: Projection over the trace buffer filtered to issue-tier op-types — `:error` / `:warning` / `:rf.schema/violation` / `:rf.hydration/mismatch`. The Issues ribbon paints this; tools that want "what's broken right now?" reach for it.
+- **Description**: Projection over the trace buffer filtered to the severity `:op-type`s (`:error` / `:warning`) only (rf2-wd1pgb — `:rf.schema/violation` / `:rf.hydration/mismatch` are `:operation` values, never `:op-type` values; a real schema violation / hydration mismatch already rides `:op-type :warning`/`:error`). The Issues ribbon paints this; tools that want "what's broken right now?" reach for it.
 
 ### `get-handlers`
 


### PR DESCRIPTION
## Summary
- `docs/xray/api/runtime-seam.md`'s `get-issues` description still listed the dead `:rf.schema/violation` / `:rf.hydration/mismatch` members in the op-type set. rf2-wd1pgb (PR #5251) already removed those from the actual filter in `tools/xray/src/day8/re_frame2_xray/runtime.cljs` and corrected the equivalent row in `tools/xray/spec/API.md` — those two are `:operation` values, never `:op-type` values (a real schema violation / hydration mismatch already rides `:op-type :warning`/`:error`). `docs/xray/` sits outside `tools/xray/**`, so it was out of scope for that PR and lagged.
- Updated the sentence to match the corrected wording: the actual op-type set is `#{:error :warning}`.

Fixes rf2-hqo460.

## Quality gates
- `python -m mkdocs build --strict` — pass (exit 0), no broken-anchor/strict errors.
- `git grep -n "rf.schema/violation\|rf.hydration/mismatch" -- docs/xray` — only hit is the corrected sentence itself (explaining why those values are dead), matching the pattern already used in `tools/xray/spec/API.md`'s fixed row. No remaining stale listings.

## Risks
None — single-line doc-text fix, no code/spec changes.