### PR TITLE
fix(reagent-slim): static-markup lowercase-event stripping + isolate after-render callback failures (rf2-ut3mod/p27yih)

### DIFF
--- a/implementation/adapters/reagent-slim/src/reagent2/dom/server.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/dom/server.cljs
@@ -540,10 +540,64 @@
 ;; (`:key`, `:ref`, `:dangerouslySetInnerHTML` — handled by caller).
 ;; ---------------------------------------------------------------------------
 
+;; WHATWG event-handler content attributes (HTML Living Standard
+;; §"Event handlers on elements, Document objects, and Window objects",
+;; plus the IDL `on*` attributes on Window/Document/Element), and the
+;; W3C Touch Events Level 2 §8 `GlobalEventHandlers` touch attributes
+;; (`ontouchstart` / `ontouchmove` / `ontouchend` / `ontouchcancel`).
+;; All lower-case; the lookup lower-cases the candidate name first so
+;; every casing (`onclick`, `ONCLICK`, `OnClick`) is covered.
+;;
+;; rf2-ut3mod: `event-handler-prop?`'s structural check (`on-` kebab /
+;; `on[A-Z]` camel) misses lowercase inline HTML event attributes —
+;; `:onclick`, `:onchange`, `"onclick"` — because there's no `-` and no
+;; upper-case letter after `on`. Those are exactly the canonical names
+;; a browser fires on, so a string-valued `:onclick "alert(1)"` rode
+;; through to the wire as `onclick="alert(1)"`, an XSS vector of the
+;; same class rf2-dwds9 closed for the structural forms. An allowlist
+;; (not a bare `on` + lowercase wildcard) is required so legitimate
+;; non-handler keys (`:once`, `:onyx`, `:only`, `:online`) survive.
+;;
+;; Curated to match `re-frame.ssr.html-helpers/event-handler-allowlist`
+;; (lifted by intent, not require — bundle isolation forbids `:require`
+;; between artefacts; see ns docstring). If HTML5 extends the
+;; event-handler list, both copies update.
+(def ^:private event-handler-allowlist
+  #{"onabort" "onafterprint" "onanimationcancel" "onanimationend"
+    "onanimationiteration" "onanimationstart" "onauxclick"
+    "onbeforeinput" "onbeforematch" "onbeforeprint" "onbeforetoggle"
+    "onbeforeunload" "onblur" "oncancel" "oncanplay" "oncanplaythrough"
+    "onchange" "onclick" "onclose" "oncontextlost" "oncontextmenu"
+    "oncontextrestored" "oncopy" "oncuechange" "oncut" "ondblclick"
+    "ondrag" "ondragend" "ondragenter" "ondragleave" "ondragover"
+    "ondragstart" "ondrop" "ondurationchange" "onemptied" "onended"
+    "onerror" "onfocus" "onformdata" "onfullscreenchange"
+    "onfullscreenerror" "ongotpointercapture" "onhashchange" "oninput"
+    "oninvalid" "onkeydown" "onkeypress" "onkeyup" "onlanguagechange"
+    "onload" "onloadeddata" "onloadedmetadata" "onloadstart"
+    "onlostpointercapture" "onmessage" "onmessageerror" "onmousedown"
+    "onmouseenter" "onmouseleave" "onmousemove" "onmouseout"
+    "onmouseover" "onmouseup" "onoffline" "ononline" "onpagehide"
+    "onpagereveal" "onpageshow" "onpageswap" "onpaste" "onpause"
+    "onplay" "onplaying" "onpointercancel" "onpointerdown"
+    "onpointerenter" "onpointerleave" "onpointermove" "onpointerout"
+    "onpointerover" "onpointerrawupdate" "onpointerup" "onpopstate"
+    "onprogress" "onratechange" "onrejectionhandled" "onreset"
+    "onresize" "onscroll" "onscrollend" "onsecuritypolicyviolation"
+    "onseeked" "onseeking" "onselect" "onselectionchange"
+    "onselectstart" "onslotchange" "onstalled" "onstorage" "onsubmit"
+    "onsuspend" "ontimeupdate" "ontoggle" "ontouchcancel" "ontouchend"
+    "ontouchmove" "ontouchstart" "ontransitioncancel"
+    "ontransitionend" "ontransitionrun" "ontransitionstart"
+    "onunhandledrejection" "onunload" "onvolumechange" "onwaiting"
+    "onwheel"})
+
 (defn- ^boolean event-handler-prop?
   "True when `k`'s name looks like a React event-handler prop
-  (`onClick`, `onChange`, `on-click`, …). Matches both kebab- and
-  camelCase forms before `attr-name` lowercasing."
+  (`onClick`, `onChange`, `on-click`, …) OR is a canonical lowercase
+  HTML event-handler attribute (`onclick`, `onchange`, …). Matches
+  kebab-, camel-, and lowercase forms before `attr-name` lowercasing
+  (rf2-ut3mod)."
   [k]
   (let [n (cond
             (keyword? k) (name k)
@@ -552,12 +606,14 @@
             :else        nil)]
     (and (some? n)
          (>= (count n) 3)
-         ;; Match `on-` (kebab) and `on[A-Z]` (camel).
+         ;; Match `on-` (kebab), `on[A-Z]` (camel), or a canonical
+         ;; lowercase HTML event-handler name.
          (or (and (str/starts-with? n "on-") (> (count n) 3))
              (and (str/starts-with? n "on")
                   (let [ch (.charAt n 2)]
                     (and (>= (.charCodeAt ch 0) 65)   ; 'A'
-                         (<= (.charCodeAt ch 0) 90)))))))) ; 'Z'
+                         (<= (.charCodeAt ch 0) 90)))) ; 'Z'
+             (contains? event-handler-allowlist (str/lower-case n))))))
 
 (defn- emit-attr
   "Emit one [k v] attribute pair to the StringBuilder. Skips nil and

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/batching.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/batching.cljs
@@ -128,7 +128,14 @@
     (when-some [fs after-render-queue]
       (set! after-render-queue nil)
       (dotimes [i (alength fs)]
-        ((aget fs i)))))
+        ;; Per-callback throw isolation (rf2-p27yih): swallow so one
+        ;; misbehaving :after-render callback cannot strand the rest of
+        ;; the queue or abort the flush. Mirrors
+        ;; `re-frame.substrate.spine/drain-after-render-queue!`, the
+        ;; shared React-adapter-spine flush path's identical guard.
+        (try
+          ((aget fs i))
+          (catch :default _ nil)))))
 
   (flush-queues [this]
     ;; Drain the reactive queue first — Reaction recomputes may enqueue

--- a/implementation/adapters/reagent-slim/test/reagent2/dom/server_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/dom/server_cljs_test.cljs
@@ -508,6 +508,48 @@
            (server/render-to-static-markup [:div {:onyx "x"}]))
         "`:onyx` (lowercase letter after `on`) is preserved")))
 
+;; ---------------------------------------------------------------------------
+;; rf2-ut3mod: lowercase inline HTML event attributes must strip too
+;;
+;; `event-handler-prop?`'s structural check (`on-` kebab / `on[A-Z]`
+;; camel) misses lowercase inline HTML event attributes — `:onclick`,
+;; string `"onclick"`, `:onchange` — because there is no `-` and no
+;; upper-case letter after `on`. Those are exactly the canonical names a
+;; browser fires on, so a string-valued `:onclick "alert(1)"` rode
+;; through to the wire as `onclick="alert(1)"`, an XSS vector of the
+;; same class rf2-dwds9 closed for the structural (kebab/camel) forms.
+;; ---------------------------------------------------------------------------
+
+(deftest lowercase-onclick-keyword-stripped-rf2-ut3mod
+  (testing "rf2-ut3mod: :onclick (all-lowercase keyword) with string
+            value does NOT emit an onclick attribute (XSS vector closed)"
+    (is (= "<div></div>"
+           (server/render-to-static-markup [:div {:onclick "alert(1)"}])))
+    (is (= "<button>x</button>"
+           (server/render-to-static-markup
+            [:button {:onclick "javascript:evil()"} "x"]))
+        "no leaked onclick attribute on the rendered button")))
+
+(deftest lowercase-onclick-string-key-stripped-rf2-ut3mod
+  (testing "rf2-ut3mod: string key \"onclick\" with string value does
+            NOT emit an onclick attribute"
+    (is (= "<div></div>"
+           (server/render-to-static-markup [:div {"onclick" "alert(1)"}])))))
+
+(deftest lowercase-onchange-stripped-rf2-ut3mod
+  (testing "rf2-ut3mod: :onchange (all-lowercase keyword) is stripped —
+            another canonical lowercase event name, not just :onclick"
+    (is (= "<input>"
+           (server/render-to-static-markup [:input {:onchange "evil()"}])))))
+
+(deftest lowercase-non-event-on-prefix-still-passes-through-rf2-ut3mod
+  (testing "rf2-ut3mod: the new lowercase-event allowlist must not
+            regress :once / :onyx — non-events keep passing through"
+    (is (= "<div once=\"true\"></div>"
+           (server/render-to-static-markup [:div {:once "true"}])))
+    (is (= "<div onyx=\"x\"></div>"
+           (server/render-to-static-markup [:div {:onyx "x"}])))))
+
 (deftest key-and-ref-still-stripped
   (testing "regression: :key and :ref drops still work after the new
             event-prop filter was added"

--- a/implementation/adapters/reagent-slim/test/reagent2/impl/batching_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/impl/batching_cljs_test.cljs
@@ -209,6 +209,45 @@
                      (done))))))))
 
 ;; ---------------------------------------------------------------------------
+;; rf2-p27yih: per-callback throw isolation
+;;
+;; flush-after-render previously invoked each callback with no
+;; per-callback exception isolation: an earlier callback that threw
+;; propagated straight out of the drain, permanently dropping every
+;; callback still queued behind it (the vector had already been
+;; atomically swapped to nil, so those callbacks were gone for good —
+;; not merely deferred). Wrap each invocation in try/catch, matching
+;; `re-frame.substrate.spine/drain-after-render-queue!`'s identical
+;; per-callback guard on the shared React-adapter-spine flush path.
+;; ---------------------------------------------------------------------------
+
+(deftest after-render-throw-does-not-strand-later-callbacks
+  (testing "an after-render callback that throws does not prevent
+            later-registered callbacks from running (rf2-p27yih)"
+    (async done
+      (let [order (atom [])]
+        (batching/do-after-render (fn [] (swap! order conj :a)))
+        (batching/do-after-render (fn [] (throw (js/Error. "boom"))))
+        (batching/do-after-render (fn [] (swap! order conj :c)))
+        (-> (next-microtask)
+            (.then (fn [_]
+                     (is (= [:a :c] @order)
+                         "callback :c still ran after the middle callback threw")
+                     (done))))))))
+
+(deftest after-render-throw-isolated-under-synchronous-flush
+  (testing "flush! isolates an after-render throw too (rf2-p27yih) —
+            the synchronous test-flush primitive shares flush-after-render
+            with the microtask path"
+    (let [order (atom [])]
+      (batching/do-after-render (fn [] (swap! order conj :a)))
+      (batching/do-after-render (fn [] (throw (js/Error. "boom"))))
+      (batching/do-after-render (fn [] (swap! order conj :c)))
+      (batching/flush!)
+      (is (= [:a :c] @order)
+          "synchronous flush! isolated the throw; :c still ran"))))
+
+;; ---------------------------------------------------------------------------
 ;; rea-schedule wiring (Stage 4-A hook → Stage 4-B implementation)
 ;;
 ;; Per the rea-schedule contract: when ratom's rea-queue gets its


### PR DESCRIPTION
## Summary

- rf2-ut3mod (P1): the reagent-slim static-markup serializer's `event-handler-prop?` only matched kebab (`:on-click`) and camelCase (`:onClick`) event-handler shapes. Lowercase inline HTML event attributes — `:onclick`, string `"onclick"`, `:onchange`, etc. — fell through the filter and were emitted verbatim as `onclick="..."`, an XSS surface of the same class rf2-dwds9 already closed for the structural forms. Fixed by adding a WHATWG event-handler-name allowlist (mirroring `re-frame.ssr.html-helpers/event-handler-allowlist`, duplicated by intent per this artefact's existing bundle-isolation convention) and consulting it in `event-handler-prop?`. Non-event `on`-prefixed keys (`:once`, `:onyx`) still pass through.
- rf2-p27yih (P3): `reagent2.impl.batching/flush-after-render` invoked queued `:after-render` callbacks with no per-callback exception isolation. An earlier callback that threw propagated out of the drain and permanently stranded every callback queued behind it (the backing array had already been atomically swapped to `nil`), diverging from the shared React adapter spine's `drain-after-render-queue!`, which already isolates per-callback throws. Fixed by wrapping each callback invocation in `try/catch`, matching the spine's guard.

## Test plan

- [x] Added `implementation/adapters/reagent-slim/test/reagent2/dom/server_cljs_test.cljs` regression tests: `:onclick` keyword, string-key `"onclick"`, `:onchange`, plus a non-regression check that `:once` / `:onyx` still pass through.
- [x] Added `implementation/adapters/reagent-slim/test/reagent2/impl/batching_cljs_test.cljs` regression tests: an after-render callback that throws does not strand later callbacks, under both the microtask drain and the synchronous `flush!` path.
- [x] `npm run test:cljs` — 8122 tests, 0 failures.
- [x] `npm run test:adapter-smokes` — 3 adapter-smoke specs, 0 failures.
- [x] `npm run test:reagent-slim:bundle-isolation` — PASS (6 contracts, 25 sentinel checks).

## Quality gates

| Gate | Result |
|---|---|
| `npm run test:cljs` | PASS — 8122 tests, 37203 assertions, 0 failures, 0 errors |
| `npm run test:adapter-smokes` | PASS — 3 adapter-smoke specs, 0 failures |
| `npm run test:reagent-slim:bundle-isolation` | PASS — 6 contracts, 25 sentinel checks |
| JVM tests | N/A — both fixes are CLJS-only in the reagent-slim adapter; no `.clj`/`.cljc` shared surface touched |
| `mkdocs build --strict` | N/A/skipped — no doc files touched by this PR |