### PR TITLE
fix(http): handle relative URLs on JVM transport (rf2-4y04lq)

### DIFF
--- a/implementation/http/src/re_frame/http/transport_jvm.cljc
+++ b/implementation/http/src/re_frame/http/transport_jvm.cljc
@@ -130,9 +130,35 @@
      header (surfaced as a `:rf.warning/http-header-invalid` trace rather
      than sinking the whole request — rf2-9lun0). `sensitive?` is carried
      only so that warning's `:url` can be routed through the privacy
-     composer (rf2-1jcpm)."
+     composer (rf2-1jcpm).
+
+     rf2-4y04lq — a RELATIVE `url` (e.g. `\"/api/items\"`) is rejected here
+     with a clear `ex-info` before the JDK ever sees it. The browser Fetch
+     transport resolves a relative url against the page's document base;
+     the JVM has no such base. Left unchecked, `HttpRequest/newBuilder`
+     throws its own `IllegalArgumentException: URI with undefined scheme`
+     — a correct but unhelpful message that names neither the offending
+     url nor the fix. This throw is uncaught HERE by design: the caller
+     (`jvm-fetch`, called from `run-attempt!`'s try/catch) classifies any
+     escaping `Throwable` via `classify-jvm-error`, which routes an
+     `ex-info` like this one to the existing `:rf.http/transport`
+     catch-all — no new failure category, no new `:rf.error/*` id. Per
+     Spec 014 §JVM transport — absolute URLs required."
      [{:keys [method url headers body timeout-ms sensitive? frame]}]
-     (let [b (HttpRequest/newBuilder (URI/create url))
+     (let [uri (URI/create url)
+           _   (when-not (.isAbsolute uri)
+                 (throw (ex-info
+                          (str "JVM HTTP transport requires an absolute URL "
+                               "(scheme + host); got relative URL " (pr-str url)
+                               ". The CLJS Fetch transport resolves a relative "
+                               "URL against the browser's document base — the "
+                               "JVM has no such base to resolve against. Supply "
+                               "an absolute URL, or add a `:before` HTTP "
+                               "interceptor (Spec 014 §Middleware) that "
+                               "rewrites `:request :url` to an absolute form "
+                               "before dispatch.")
+                          {:url url})))
+           b (HttpRequest/newBuilder uri)
            publisher (cond
                        (nil? body) (HttpRequest$BodyPublishers/noBody)
                        (string? body) (HttpRequest$BodyPublishers/ofString ^String body)

--- a/implementation/http/test/re_frame/http_jvm_relative_url_test.clj
+++ b/implementation/http/test/re_frame/http_jvm_relative_url_test.clj
@@ -1,0 +1,136 @@
+(ns re-frame.http-jvm-relative-url-test
+  "rf2-4y04lq — JVM HTTP transport: relative `:url` contract.
+
+  The browser Fetch transport resolves a relative `:url` (`\"/api/items\"`)
+  against the page's document base; the JVM `java.net.http.HttpClient`
+  transport has no equivalent base. Left unguarded, `jvm-build-request`
+  handed the relative url straight to `HttpRequest/newBuilder`, which threw
+  the JDK's own `IllegalArgumentException: URI with undefined scheme` — a
+  correct-but-unhelpful message that names neither the offending url nor
+  the fix, and (via `classify-jvm-error`'s catch-all) still surfaced as an
+  ordinary `:rf.http/transport` failure, just an opaque one.
+
+  Per Spec 014 §JVM transport — absolute URLs required, a relative `:url`
+  reaching the JVM transport is now rejected AT REQUEST-CONSTRUCTION TIME
+  with a clear message naming the offending url and the fix (supply an
+  absolute URL, or rewrite it via a `:before` HTTP interceptor). The
+  failure category is unchanged — still `:rf.http/transport`, the existing
+  catch-all — so no new `:rf.error/*` id or failure kind was needed.
+
+  Two layers of coverage:
+   - a unit test calling `jvm-build-request` directly (mirrors the
+     `http-transport-security-test` direct-call idiom) pins the throw
+     message contract precisely, plus the absolute-url non-regression
+     complement; and
+   - an end-to-end dispatch test (mirrors `http-managed-test`'s
+     `jvm-transport-failure`) proves a REAL (non-stub, non-canned)
+     `:rf.http/managed` request with a relative url resolves to a
+     `:status :error` / `:rf.http/transport` reply carrying the clear
+     message, rather than hanging, crashing, or silently mis-issuing the
+     request against the wrong host."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.flows :as flows]
+            [re-frame.frame :as frame]
+            [re-frame.http.managed :as http-managed]
+            [re-frame.http.transport-jvm :as transport-jvm]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+;; ---- per-test reset --------------------------------------------------------
+
+(defn- reset-runtime [t]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (flows/reset-flows!)
+  (schemas/clear-schemas-by-frame!)
+  (rf/init! plain-atom/adapter)
+  ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`,
+  ;; and the managed-HTTP fx now requires a carried frame stamp. Register
+  ;; `:rf/default` explicitly and pin it as the established scope.
+  (frame/ensure-default-frame!)
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr     :reload)
+  (require 're-frame.http.managed :reload)
+  (http-managed/clear-all-in-flight!)
+  (http-managed/clear-all-http-interceptors!)
+  (rf/with-frame :rf/default
+    (t)))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- helpers ---------------------------------------------------------------
+
+(defn- await-reply!
+  "Wait up to `timeout-ms` for `(pred db)` to be truthy against
+  `(rf/app-db-value :rf/default)`. Mirrors `http-managed-test`'s
+  `await-reply!` (rf2-fun38's `poll-until` idiom)."
+  ([pred] (await-reply! pred 5000))
+  ([pred timeout-ms]
+   (test-support/poll-until
+     #(let [db (rf/app-db-value :rf/default)] (when (pred db) db))
+     {:timeout-ms timeout-ms :label "jvm relative-url reply"})))
+
+;; ---- 1. unit — jvm-build-request rejects a relative url --------------------
+
+(deftest relative-url-throws-clear-ex-info
+  (testing "rf2-4y04lq — a relative :url throws an ex-info naming the url
+            and the absolute-url requirement, NOT the JDK's opaque
+            \"URI with undefined scheme\" message"
+    (let [ex (try (transport-jvm/jvm-build-request
+                    {:method :get :url "/api/items"})
+                  nil
+                  (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? ex) "a relative url must throw")
+      (is (str/includes? (.getMessage ^Throwable ex) "absolute")
+          "the message explains the absolute-url requirement")
+      (is (str/includes? (.getMessage ^Throwable ex) "/api/items")
+          "the message names the offending url")
+      (is (= "/api/items" (:url (ex-data ex)))
+          "the offending url rides ex-data for programmatic access"))))
+
+(deftest scheme-relative-url-also-rejected
+  (testing "rf2-4y04lq — a protocol-relative url (`//host/path`, no scheme)
+            is ALSO relative per `URI/isAbsolute` and is rejected the same
+            way as a path-only relative url"
+    (let [ex (try (transport-jvm/jvm-build-request
+                    {:method :get :url "//example.invalid/api/items"})
+                  nil
+                  (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? ex))
+      (is (str/includes? (.getMessage ^Throwable ex) "absolute")))))
+
+(deftest absolute-url-does-not-throw
+  (testing "rf2-4y04lq (complement) — an absolute :url builds normally,
+            unaffected by the new guard"
+    (let [req (transport-jvm/jvm-build-request
+                {:method :get :url "https://example.invalid/api/items"})]
+      (is (some? req)))))
+
+;; ---- 2. end-to-end — a real (non-stub) dispatch classifies cleanly --------
+
+(deftest real-dispatch-with-relative-url-fails-clearly
+  (testing "rf2-4y04lq — a real (non-stub, non-canned) :rf.http/managed
+            dispatch with a relative :url resolves to a :status :error /
+            :rf.http/transport reply carrying the clear message. The
+            request never reaches a live socket; the failure names the fix
+            rather than surfacing the JDK's opaque rejection."
+    (rf/reg-event :jvm-relative/load
+      (fn [{:keys [db]} [_ msg]]
+        (if-let [reply (:rf/reply msg)]
+          {:db (assoc db :reply reply)}
+          {:fx [[:rf.http/managed
+                 {:request {:method :get :url "/api/items"}
+                  :decode  :json}]]})))
+    (rf/dispatch-sync [:jvm-relative/load])
+    (let [db (await-reply! #(some? (:reply %)) 5000)]
+      (is (= :error (get-in db [:reply :status])))
+      (is (= :rf.http/transport (get-in db [:reply :error :kind])))
+      (is (str/includes? (get-in db [:reply :error :message]) "absolute")
+          "the delivered failure message explains the absolute-url requirement")
+      (is (not (str/includes? (get-in db [:reply :error :message]) "undefined scheme"))
+          "the delivered failure message is the clear guard message, not the
+           JDK's raw \"URI with undefined scheme\" text"))))

--- a/spec/014-HTTPRequests.md
+++ b/spec/014-HTTPRequests.md
@@ -191,6 +191,10 @@ A related but distinct JVM degradation is **shape**, not silent no-op: a binary 
 
 `:elapsed-ms` on the `:rf.http/timeout` failure category (see [§Failure categories](#failure-categories-closed-set)) is populated on BOTH hosts with the same semantics: a **measured wall-clock delta** captured across the attempt. The JVM uses a monotonic `System/nanoTime` start mark (`run-attempt!`); CLJS uses a `performance.now()` (or `Date.now()` fallback) delta stamped on the synthetic timeout rejection (`cljs-fetch`). On both hosts `:elapsed-ms` is therefore `>= :limit-ms` by the scheduling margin, so a consumer may compute overshoot (`(- :elapsed-ms :limit-ms)`) portably.
 
+#### JVM transport — absolute URLs required
+
+The browser Fetch transport resolves a relative `:url` (e.g. `"/api/items"`) against the page's document base; the JVM `java.net.http.HttpClient` transport has no equivalent base to resolve against. A relative `:url` reaching the JVM transport is therefore rejected at request-construction time (rf2-4y04lq) with a clear `:rf.http/transport` failure naming the offending url and the fix — supply an absolute URL, or add a `:before` HTTP interceptor ([§Middleware](#middleware)) that rewrites `:request :url` to an absolute form (e.g. prefixing a configured base) before the request reaches the transport, the same mechanism a base-URL-prefix use case already exercises. Without this guard the JDK's own rejection (`IllegalArgumentException: URI with undefined scheme`) surfaced with no actionable guidance. Every relative-URL example in this document (see [§Examples](#examples)) targets the CLJS host; a cross-host caller keeps the request absolute, or rewrites it via a `:before` interceptor, for JVM/SSR portability.
+
 ### Body encoding
 
 If `:body` is a thunk `(fn body)`, the fx invokes it just before sending (after `:retry :backoff` delays elapse). Each retry re-invokes the thunk to obtain a fresh handle — useful when `:body` is a single-shot stream that can't be replayed. Whatever the thunk returns is then encoded per the rules below.


### PR DESCRIPTION
## Summary

- rf2-4y04lq: the JVM `java.net.http.HttpClient` transport had no document base to resolve a relative `:url` against (unlike the browser Fetch transport). A relative url reached `HttpRequest/newBuilder` and threw the JDK's own `IllegalArgumentException: URI with undefined scheme` — correct but unhelpful, naming neither the offending url nor the fix.
- Direction chosen: **reject loud with a clear error**, not resolve-against-a-base. There is no existing "configured JVM base URL" concept in the framework, and the existing test corpus already treats absolute URLs as the JVM-real-transport convention (relative urls only ever appear in stub/canned-reply tests, which never reach the transport) — resolving against an app-level base is already the documented `:before` HTTP interceptor pattern (Spec 014 §Middleware), not a framework built-in.
- `jvm-build-request` (`implementation/http/src/re_frame/http/transport_jvm.cljc`) now checks `URI/isAbsolute` before building the request and throws a clear `ex-info` naming the offending url and the fix (supply an absolute URL, or add a `:before` interceptor). The throw is still caught by `run-attempt!`'s existing `try`/`catch` and classified via `classify-jvm-error` into the existing `:rf.http/transport` catch-all — no new failure category, no new `:rf.error/*` id, no spec/009 hot-zone edit needed.
- Documented the JVM contract in `spec/014-HTTPRequests.md` (new `#### JVM transport — absolute URLs required` subsection), the sole spec file this bead touches.

## Quality gates

- `clojure -M:test` from `implementation/http` — 460 tests, 2129 assertions, 0 failures/errors (includes the new `http_jvm_relative_url_test.clj`).
- `npm run test:cljs` from `implementation/` — 8116 tests, 37195 assertions, 0 failures/errors.
- `mkdocs build --strict` — SKIPPED: `mkdocs` is not installed in this environment (`command not found`). Doc change is a single new subsection under an existing heading, no links added beyond existing in-doc anchors (`#middleware`, `#examples`) already used elsewhere in the same file.

## Risk / notes

- Verified the existing test corpus's relative-URL usages (`http_managed_test.clj`, `http_helpers_integration_test.clj`, `http_test.clj`) all route through canned-stub / `with-managed-request-stubs` fx-overrides or are pure fx-vector construction tests — none reach `jvm-build-request`, so none are affected by the new guard. The only real-transport dispatch tests in the JVM suite (`jvm-transport-failure`, `valid-url-passes-validation`) already used absolute URLs.
- No new catalogued error id; the fix stays inside the existing `:rf.http/transport` failure category.