### PR TITLE
fix(schemas): correct malformed-JSON decode fallback (rf2-5a5qwp)

### DIFF
--- a/implementation/http/src/re_frame/http/decode.cljc
+++ b/implementation/http/src/re_frame/http/decode.cljc
@@ -319,11 +319,26 @@
       (if (some? body-binary) body-binary body-text)
 
       ;; Malli schema (or anything keyword-like that isn't recognised above).
-      ;; rf2-wu1n5 — re-raise a `:rf.error/malformed-json` ex-info
-      ;; (truncated escape, too-many-keys) rather than treating the
-      ;; body as plain text. Only NON-tagged throws fall through to the
-      ;; text path, which preserves the existing tolerant-of-non-JSON
-      ;; semantics for legacy callers.
+      ;; rf2-wu1n5 / rf2-5a5qwp — re-raise EVERY `json-parse` throw, tagged
+      ;; or not. Per Spec 014 §Decoding the schema branch must JSON-parse
+      ;; first and classify a malformed 2xx payload as a decode failure;
+      ;; there is no "tolerant of non-JSON" text fallback here (that
+      ;; concern is already handled up-front by the `json-content-type?`
+      ;; guard below, which rejects a DECLARED non-JSON Content-Type before
+      ;; parsing is ever attempted). A prior revision caught the parse
+      ;; exception and fell back to the raw `body-text` for any throw NOT
+      ;; tagged `:rf.error/malformed-json` — but only the keyword-cap
+      ;; overflow (rf2-wu1n5) is tagged; an ordinary JSON syntax error is
+      ;; an untagged host exception (Cheshire `JsonParseException` / CLJS
+      ;; `SyntaxError`), so THAT was the common case hitting the fallback.
+      ;; The raw text then rode into `malli-decode`, so malformed JSON
+      ;; could spuriously VALIDATE under a string-like schema, or surface
+      ;; as a misleading `:schema-validation-failure?` under a map schema
+      ;; instead of a plain decode failure. Removing the catch restores
+      ;; symmetry with the plain `:json` branch above (which never caught
+      ;; parse exceptions either) — any throw here propagates untouched to
+      ;; the transport's decode try/catch, which classifies it as
+      ;; `:rf.http/decode-failure`.
       (some? resolved)
       ;; rf2-upexd.2 — the schema decode path is JSON-ONLY: the only
       ;; Malli transformer the decoder wires is the `json-transformer`,
@@ -359,12 +374,7 @@
         ;; host-symmetric outcome, not a per-host parse divergence.
         (let [parsed (if (empty-2xx-json-body? body-text)
                        nil
-                       (try (util-json/json-parse body-text parse-opts)
-                            (catch #?(:clj Throwable :cljs :default) e
-                              (let [d (ex-data e)]
-                                (if (= :rf.error/malformed-json (:rf.error/id d))
-                                  (throw e)
-                                  body-text)))))]
+                       (util-json/json-parse body-text parse-opts))]
           (malli-decode resolved parsed)))
 
       :else

--- a/implementation/http/test/re_frame/http_decode_test.clj
+++ b/implementation/http/test/re_frame/http_decode_test.clj
@@ -169,6 +169,65 @@
       (is (= 2 (:limit d))
           "the per-call cap is threaded through to the reader"))))
 
+;; ---- rf2-5a5qwp: malformed JSON under a schema :decode must NEVER fall
+;; back to raw body-text ------------------------------------------------
+;;
+;; Before this bead, the schema branch's `json-parse` catch fell back to
+;; the raw `body-text` for any throw NOT tagged `:rf.error/malformed-json`
+;; — but an ordinary JSON syntax error IS untagged (only the keyword-cap
+;; overflow is tagged), so malformed JSON was the common case hitting the
+;; fallback. That let malformed JSON spuriously VALIDATE under a
+;; string-like schema (the raw text just IS a string), and misclassify as
+;; a `:schema-validation-failure?` under a map schema instead of a plain
+;; decode failure. Per Spec 014 §Decoding, schema decode must JSON-parse
+;; first and classify a malformed 2xx payload as a decode failure — not a
+;; degenerate "successful" decode, and not a schema-validation failure.
+
+;; Genuinely-malformed JSON per Cheshire/Jackson (see
+;; `cheshire-rejects-malformed-input-cleanly` in util_json_test.clj):
+;; Jackson is tolerant of some shapes by design (trailing commas,
+;; missing close-braces fall through to its end-of-stream handler
+;; rather than throwing), so these pick inputs definitively rejected —
+;; an invalid token and a misspelt literal.
+
+(deftest decode-response-body-schema-branch-malformed-json-throws-not-string-schema
+  (testing "rf2-5a5qwp — a :string schema would happily validate the raw
+            malformed body-text (it IS a string) if the old fallback
+            fired; it must instead propagate the raw JSON-parse exception
+            (a Cheshire/Jackson `JsonParseException`, not an ex-info) so
+            the caller classifies the response as :rf.http/decode-failure,
+            NOT a successful string decode"
+    (let [thrown (try (decode/decode-response-body
+                         {:body-text "tru" ; truncated `true` — invalid token
+                          :headers   {"content-type" "application/json"}
+                          :decode    :string})
+                       ::no-throw
+                       (catch Exception e e))]
+      (is (not= ::no-throw thrown)
+          "malformed JSON under a :string schema must throw, not decode
+           to the raw text as if it were a valid string value")
+      (is (not= :rf.error/http-schema-validation-failed (:rf.error/id (ex-data thrown)))
+          "the throw must be the raw JSON-parse failure, not a (masking)
+           schema-validation-failed — there is no valid value to fail
+           validation against"))))
+
+(deftest decode-response-body-schema-branch-malformed-json-throws-not-schema-validation-failure
+  (testing "rf2-5a5qwp — a :map schema over malformed JSON must surface as
+            a plain decode failure (an unparseable body), NOT get
+            misclassified as :schema-validation-failure? true (which would
+            wrongly imply a well-formed-but-wrong-shaped payload)"
+    (let [thrown (try (decode/decode-response-body
+                         {:body-text "{\"id\":nul}" ; misspelt `null`
+                          :headers   {"content-type" "application/json"}
+                          :decode    [:map [:id :int]]})
+                       ::no-throw
+                       (catch Exception e e))]
+      (is (not= ::no-throw thrown)
+          "malformed JSON under a :map schema must throw")
+      (is (not= :rf.error/http-schema-validation-failed (:rf.error/id (ex-data thrown)))
+          "must not be misclassified as a schema-validation failure — the
+           body never parsed to a value in the first place"))))
+
 (deftest decode-response-body-json-branch-also-reraises-too-many-keys
   (testing "rf2-ohwgm — the plain :json branch likewise threads the cap
             (the cap-throw originates in the reader, so :json surfaces it


### PR DESCRIPTION
## What

The Malli-schema branch of `re-frame.http.decode/decode-response-body` caught the `json-parse` exception and, for any throw NOT tagged `:rf.error/malformed-json`, fell back to the raw `body-text`. Only the keyword-cap overflow (rf2-wu1n5) is tagged; an **ordinary JSON syntax error is an untagged host exception** (Cheshire `JsonParseException` on JVM / `SyntaxError` on CLJS), so malformed JSON was the common case hitting the fallback.

The raw body-text then flowed into `malli-decode`, so:
- under a string-like schema (`:string`, `:any`, …) malformed JSON **spuriously validated** (the raw text just *is* a string), and
- under a map schema it surfaced as a misleading `:schema-validation-failure?` instead of a plain decode failure.

Spec 014 §Decoding requires the schema path to JSON-parse first and classify a malformed 2xx payload as a **decode failure**.

## Fix

Remove the catch after the empty-body special case. Any `json-parse` throw now propagates untouched to the transport's decode try/catch, which classifies it as `:rf.http/decode-failure` (`:schema-validation-failure?` false for a bare syntax error). This restores symmetry with the plain `:json` branch, which never caught parse exceptions either. The declared-non-JSON-Content-Type concern is already handled up-front by the `json-content-type?` guard, so there is no tolerant-of-non-JSON text path to preserve in this branch.

Impl-only + own-artefact test; no shared-spec edits (Spec 014 already mandates this behaviour — the code was the drift, not the spec).

## Tests

Two regressions added to `http_decode_test.clj`:
- `decode-response-body-schema-branch-malformed-json-throws-not-string-schema` — malformed JSON under a `:string` schema must throw (not decode to raw text as a "valid" string).
- `decode-response-body-schema-branch-malformed-json-throws-not-schema-validation-failure` — malformed JSON under a `:map` schema must not be misclassified as `:schema-validation-failure?`.

## Quality gates

All run in the foreground, green:
- **http JVM** (`clojure -M:test` in `implementation/http`): `Ran 458 tests containing 2122 assertions. 0 failures, 0 errors.` (exit 0) — this is the load-bearing gate; the fix + new tests live here.
- **CLJS** (`npm run test:cljs`): `Ran 8116 tests containing 37195 assertions. 0 failures, 0 errors.` (exit 0)
- **schemas JVM** (`clojure -M:test` in `implementation/schemas`): `Ran 322 tests containing 18866 assertions. 0 failures, 0 errors.` (exit 0)

## Notes

Bead titled "schemas" but the evidence + fix live on `implementation/http` (`re_frame/http/decode.cljc`); no `implementation/schemas/**` change was needed. No shared-spec (Spec-Schemas / 009) edits — did not touch the epoch pair's surfaces.