### PR TITLE
fix(machines): non-parallel root timeout/:after + root :on target validation + fail-fast on-spawn refs (rf2-b6znpi/nvgolg/b4qbx0)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
@@ -467,6 +467,50 @@
                     (walk (conj path k) (:states n)))))]
         (walk [] (:states region-body))))))
 
+;; ---- non-parallel root `:after` / `:timeout` — reject loud (rf2-b6znpi) ---
+;;
+;; Per Spec 005 §Root-level `:after` — the timer-driven ancestor fallback:
+;; the feature is scoped to a `:type :parallel` machine root. Its runtime
+;; support is likewise parallel-only — `transition/schedule-root-after-fx`
+;; (the birth-time scheduler) is called ONLY from
+;; `parallel/run-initial-cascade`'s parallel branch; a flat/compound
+;; machine's birth (`parallel/bootstrap-step`) never calls it, and there is
+;; no root resolver that would fire a flat root `:after` at the decl-path
+;; `[]` empty-path node (`grammar/node-at` resolves an empty path to nil).
+;; `timeout/validate-timeouts!` + `validate-after-delays!` both happily
+;; accept a WELL-FORMED root `:timeout` / `:after` on a flat/compound
+;; machine (they validate the pairing / duration / delay-key SHAPE, not
+;; whether the runtime can ever schedule or resolve it), so — absent this
+;; check — such a machine registers cleanly and its "whole-machine
+;; deadline" silently never fires. Reject it loudly here instead, on the
+;; DESUGARED machine (`validate-machine!` calls this after
+;; `timeout/desugar-timeouts`), so a root `:timeout` — which lowers onto
+;; `:after` — is caught via its lowered form in the SAME check as a
+;; directly-authored root `:after`.
+
+(defn- validate-non-parallel-root-after!
+  "Reject a non-parallel (flat / compound) machine root's `:after` map —
+  whether hand-authored or lowered from a root `:timeout` / `:on-timeout`
+  — with `:rf.error/machine-non-parallel-root-after-not-supported`. A
+  `:type :parallel` root's `:after` is unaffected (that IS the supported,
+  scheduled, resolved feature per Spec 005). Absent / empty root `:after`
+  is fine on either machine shape."
+  [machine]
+  (when (and (not (parallel/parallel? machine))
+             (seq (:after machine)))
+    (throw (validation-error
+             :rf.error/machine-non-parallel-root-after-not-supported
+             (str "a non-parallel (flat/compound) machine root declares "
+                  ":after " (pr-str (:after machine)) " — either "
+                  "hand-authored or lowered from a root :timeout / "
+                  ":on-timeout. Root-level :after scheduling + resolution "
+                  "is supported ONLY for a :type :parallel machine root "
+                  "(Per Spec 005 §Root-level :after). On a flat/compound "
+                  "root the timer would register but NEVER schedule or "
+                  "fire. Move the deadline onto the machine's :initial "
+                  "state's own :after / :timeout instead.")
+             {:after (:after machine)}))))
+
 (defn- walk-state-nodes
   "Yield `[state-key state-node]` pairs for every node under `:states`,
   recursing through `:states` maps. Used by the registration-time
@@ -803,6 +847,65 @@
                    {:state    state-key
                     :on-error oe})))))))
 
+;; ---- `:on-spawn` keyword-ref resolution (rf2-b4qbx0) -----------------------
+;;
+;; Per Spec 005 §Declarative `:spawn` §`:on-spawn`: a KEYWORD `:on-spawn`
+;; resolves through the machine's `:on-spawn-actions` map, falling back to
+;; `:actions` — mirroring the runtime `transition/apply-on-spawn`'s
+;; `(or (chase-ref (:on-spawn-actions machine) aref)
+;;      (chase-ref (:actions machine) aref))`. Registration never validated
+;; this: `apply-on-spawn` silently treats a nil resolution as "no callback"
+;; (the same branch a genuinely-absent `:on-spawn` takes), so a dangling ref
+;; — a typo, a retired action name, a broken multi-hop indirection, a cycle
+;; — registers cleanly and the intended side effect just never runs, with
+;; no signal anywhere. `validate-on-spawn-ref!` closes the gap, following the
+;; FULL `ref-resolves?` chase (through EITHER registry, in order) so a
+;; multi-hop or cyclic indirection is caught here too, exactly as the
+;; `:guard` / `:action` ref checks already are.
+
+(defn- validate-on-spawn-ref!
+  "Validate one spawn-spec's `:on-spawn` keyword ref (if present) against
+  `machine`'s `:on-spawn-actions` map, falling back to `:actions` — the
+  SAME two-registry fallback `transition/apply-on-spawn` resolves through
+  at runtime. `where` (`:spawn` / `:spawn-all-child`) names the declaring
+  site for diagnostics. An inline fn `:on-spawn` needs no resolution;
+  absent `:on-spawn` is fine (the spawn simply has no callback). Emits
+  `:rf.error/machine-unresolved-on-spawn`."
+  [machine state-key spawn-spec where]
+  (when (map? spawn-spec)
+    (let [aref (:on-spawn spawn-spec)]
+      (when (and (keyword? aref)
+                 (not (ref-resolves? (:on-spawn-actions machine) aref))
+                 (not (ref-resolves? (:actions machine) aref)))
+        (throw (validation-error
+                 :rf.error/machine-unresolved-on-spawn
+                 (str where " on state " state-key " references :on-spawn "
+                      aref " which does not resolve — chased against the "
+                      "machine's :on-spawn-actions map, then its :actions "
+                      "map as a fallback (mirroring the runtime resolution "
+                      "order), and neither terminates at a fn. Register the "
+                      "callback under one of those maps, or fix the "
+                      ":on-spawn ref. Known :on-spawn-actions: "
+                      (pr-str (vec (keys (:on-spawn-actions machine))))
+                      "; known :actions: "
+                      (pr-str (vec (keys (:actions machine)))) ".")
+                 {:state                  state-key
+                  :where                  where
+                  :on-spawn               aref
+                  :known-on-spawn-actions (vec (keys (:on-spawn-actions machine)))
+                  :known-actions          (vec (keys (:actions machine)))}))))))
+
+(defn- validate-on-spawn-refs!
+  "Validate EVERY `:on-spawn` keyword ref on `state-node` — the single
+  `:spawn`'s `:on-spawn`, plus every `:spawn-all` child's `:on-spawn` — per
+  `validate-on-spawn-ref!`. `:spawn` / `:spawn-all` are mutually exclusive
+  (enforced by `validate-spawn-all!`), so at most one of the two doseqs
+  below does real work per node."
+  [machine state-key state-node]
+  (validate-on-spawn-ref! machine state-key (:spawn state-node) :spawn)
+  (doseq [child (get-in state-node [:spawn-all :children])]
+    (validate-on-spawn-ref! machine state-key child :spawn-all-child)))
+
 (defn- compound?
   "A state node is compound iff it declares a non-empty `:states` map."
   [state-node]
@@ -1138,7 +1241,21 @@
   `{:target [:missing]}` (unresolved → `:rf.error/machine-unresolved-target`)
   at registration rather than at the triggering dispatch (where a malformed
   target would otherwise throw `:rf.error/machine-bad-state-form` and an
-  unresolved one would commit an invalid snapshot)."
+  unresolved one would commit an invalid snapshot).
+
+  Per Spec 005 §Transition resolution steps 6-7 (rf2-nvgolg): a NON-PARALLEL
+  (flat / compound) machine root's OWN `:on` is the ancestor-fallback
+  transition slot `pick-transition` consults, at runtime, when no state-path
+  node handles the event — stamped with decl-path `[]`, so a keyword
+  `:target` resolves as a TOP-LEVEL sibling (`target-path`'s
+  `(drop-last [])` → `[]`) exactly like `resolves-to-state?` with an empty
+  `owning-path`. `walk-state-nodes-with-scope` only yields nodes INSIDE
+  `:states` (region or flat), so the root's own `:on` was UNCHECKED — an
+  invalid root `:on` target registered cleanly and committed an unresolved
+  `:state` at the first dispatch that fell through to it instead of failing
+  fast here. (A non-parallel root's `:after` cannot reach this point — it is
+  rejected outright by `validate-non-parallel-root-after!`, called earlier —
+  so only `:on` needs checking here.)"
   [machine]
   (doseq [[scope path node] (walk-state-nodes-with-scope machine)]
     (let [state-key (peek path)
@@ -1155,7 +1272,15 @@
       (when (contains? node :on-done)
         (check! :on-done (:on-done node)))
       (when-let [oe (get-in node [:spawn :on-error])]
-        (check! :spawn/on-error oe)))))
+        (check! :spawn/on-error oe))))
+  (when-not (parallel/parallel? machine)
+    (let [scope  (:states machine)
+          check! (fn [v]
+                   (doseq [{:keys [present? target]} (candidate-targets v)]
+                     (when present?
+                       (validate-target! scope [] :on :rf/root target))))]
+      (doseq [[_event v] (:on machine)]
+        (check! v)))))
 
 ;; ---- machine-level :schemas map (EP-0029 A3) -------------------------------
 ;;
@@ -1427,6 +1552,19 @@
   shape — `:regions` non-empty, mutually exclusive with `:initial` /
   `:states`, no nested parallel.
 
+  Per Spec 005 §Root-level `:after` (scoped to a `:type :parallel` root):
+  a NON-parallel (flat / compound) machine root's `:after` — hand-authored
+  or lowered from a root `:timeout` / `:on-timeout` — has no runtime
+  scheduling / resolution path and is rejected with
+  `:rf.error/machine-non-parallel-root-after-not-supported`.
+
+  Per Spec 005 §Transition resolution steps 6-7: a non-parallel machine
+  root's own `:on` (the ancestor fallback, decl-path `[]`) is validated
+  for target shape + resolution exactly like a state's `:on`, throwing
+  `:rf.error/machine-bad-target` / `:rf.error/machine-unresolved-target`
+  on a malformed or dangling target (a parallel root's region-qualified
+  `:on` is validated separately by `validate-parallel!`).
+
   Per Spec 005 §Schema validation / EP-0029 A3: the machine-level `:schemas`
   map (when present) must be a map whose sub-keys are within the closed set
   `#{:data :events :output :tags :meta}`. An unknown sub-key — including
@@ -1451,6 +1589,15 @@
   and action keyword refs must resolve against the machine's `:guards` /
   `:actions` maps. Throws `:rf.error/machine-unresolved-guard` /
   `:rf.error/machine-unresolved-action` on dangling refs.
+
+  Per Spec 005 §Declarative `:spawn` §`:on-spawn`: every `:on-spawn`
+  keyword ref (a single `:spawn`, or a `:spawn-all` child) must resolve
+  against the machine's `:on-spawn-actions` map, falling back to
+  `:actions` — the SAME two-registry order the runtime resolves through.
+  Throws `:rf.error/machine-unresolved-on-spawn` on a dangling ref
+  (mirroring `:rf.error/machine-unresolved-action`'s fail-fast contract;
+  previously a dangling `:on-spawn` ref silently resolved to \"no
+  callback\" at runtime).
 
   Per Spec 005 §Initial-state cascading: every compound state-node
   (declares `:states`) MUST declare `:initial`. Throws
@@ -1553,6 +1700,12 @@
   (let [machine (choice/desugar-choices (timeout/desugar-timeouts machine))]
   (validate-history! machine)
   (validate-parallel! machine)
+  ;; rf2-b6znpi — a non-parallel root's `:after` (hand-authored or lowered
+  ;; from a root `:timeout` / `:on-timeout`) has no runtime scheduling /
+  ;; resolution path; reject it loudly rather than silently registering a
+  ;; whole-machine deadline that never fires. Runs on the DESUGARED machine
+  ;; so a root `:timeout` is caught via its lowered `:after` form too.
+  (validate-non-parallel-root-after! machine)
   ;; The machine-level `:schemas` map (EP-0029 A3) — closed sub-key set; an
   ;; unknown sub-key (incl. `:input`) or a non-map `:schemas` fails loud.
   (validate-schemas! machine)
@@ -1562,7 +1715,11 @@
     (validate-no-spawn-timeout-ms! s n)
     (validate-final-state! s n)
     (validate-spawn-on-error! s n)
-    (validate-compound-initial! s n))
+    (validate-compound-initial! s n)
+    ;; rf2-b4qbx0 — every `:on-spawn` keyword ref (single `:spawn` or a
+    ;; `:spawn-all` child) must resolve against `:on-spawn-actions`,
+    ;; falling back to `:actions`, at registration.
+    (validate-on-spawn-refs! machine s n))
   ;; The self-loop check needs each declaring node's absolute path to
   ;; resolve vector `:target`s, so it drives off the path-aware walker.
   (doseq [[path n] (walk-state-nodes-with-path machine)]

--- a/implementation/machines/test/re_frame/after_delay_validation_test.clj
+++ b/implementation/machines/test/re_frame/after_delay_validation_test.clj
@@ -107,12 +107,36 @@
       (is (some? thrown) "nested invalid :after delay SHOULD throw")
       (is (= :rf.error/machine-bad-after-delay (:rf.error/id (ex-data thrown)))))))
 
-(deftest invalid-delay-key-on-root-after-rejected
-  (testing "an invalid :after key on the machine-root :after fallback fails registration"
+(deftest invalid-delay-key-on-non-parallel-root-after-rejected-categorically
+  (testing "a non-parallel root :after fails registration regardless of delay-key validity (rf2-b6znpi)"
+    ;; Per rf2-b6znpi, a non-parallel (flat/compound) machine root's :after
+    ;; has no runtime scheduling / resolution path at ALL, so it is now
+    ;; rejected CATEGORICALLY by `validate-non-parallel-root-after!` — which
+    ;; runs BEFORE `validate-after-delays!` — regardless of whether its
+    ;; delay key would otherwise be well-formed. This supersedes the old
+    ;; assertion that an invalid root :after key surfaced
+    ;; :rf.error/machine-bad-after-delay: the machine shape itself is now
+    ;; rejected first, with the more specific / more correct diagnostic.
     (let [m {:initial :idle
              :data    {}
              :after   {0 :idle}
              :states  {:idle {}}}
           thrown (registration-throws? :adv/root m)]
-      (is (some? thrown) "root-level invalid :after delay SHOULD throw")
-      (is (= :rf.error/machine-bad-after-delay (:rf.error/id (ex-data thrown)))))))
+      (is (some? thrown) "root-level :after (invalid delay key or not) SHOULD throw")
+      (is (= :rf.error/machine-non-parallel-root-after-not-supported
+             (:rf.error/id (ex-data thrown)))
+          "the categorical non-parallel-root-:after rejection wins over the delay-key shape check"))))
+
+(deftest invalid-delay-key-on-parallel-root-after-still-rejected
+  (testing "the :after delay-key shape check STILL applies to a :type :parallel root's :after"
+    ;; A :type :parallel root's :after IS the supported, scheduled,
+    ;; resolved feature (Spec 005 §Root-level :after) — it is UNAFFECTED by
+    ;; the rf2-b6znpi non-parallel-root rejection, so its delay-key shape is
+    ;; still gated by validate-after-delays! exactly as before.
+    (let [m {:type    :parallel
+             :after   {0 {:target [:a :two]}}
+             :regions {:a {:initial :one :states {:one {} :two {}}}}}
+          thrown (registration-throws? :adv/parallel-root m)]
+      (is (some? thrown) "an invalid delay key on a parallel root's :after SHOULD throw")
+      (is (= :rf.error/machine-bad-after-delay (:rf.error/id (ex-data thrown)))
+          "the delay-key shape check still fires for the supported parallel-root :after"))))

--- a/implementation/machines/test/re_frame/on_spawn_ref_validation_test.clj
+++ b/implementation/machines/test/re_frame/on_spawn_ref_validation_test.clj
@@ -1,0 +1,164 @@
+(ns re-frame.on-spawn-ref-validation-test
+  "rf2-b4qbx0 — an `:on-spawn` KEYWORD ref resolves through the machine's
+  `:on-spawn-actions` map, falling back to `:actions`
+  (`transition/apply-on-spawn`'s `(or (chase-ref (:on-spawn-actions
+  machine) aref) (chase-ref (:actions machine) aref))`). BEFORE this fix,
+  registration validated the `:spawn` / `:spawn-all` SHAPE (machine-id xor
+  definition, unknown keys, …) but never chased the `:on-spawn` ref itself
+  — a dangling ref (a typo, a retired action name, a broken multi-hop
+  indirection, a cycle) registered cleanly, and at runtime `apply-on-spawn`
+  treats the nil resolution EXACTLY like a genuinely-absent `:on-spawn`:
+  the spawn completes silently, and the intended callback just never runs.
+
+  `validate-on-spawn-ref!` closes the gap: it follows the FULL `chase-ref`
+  indirection chain (through EITHER registry, in that order), exactly as
+  the sibling `:guard` / `:action` registration-time checks already do.
+
+  This suite pins:
+   1. a dangling keyword :on-spawn ref (neither registry has it) fails at
+      REGISTRATION with :rf.error/machine-unresolved-on-spawn;
+   2. a ref that resolves via :on-spawn-actions registers fine;
+   3. a ref that resolves via the :actions FALLBACK (absent from
+      :on-spawn-actions) registers fine;
+   4. an inline fn :on-spawn needs no resolution and registers fine;
+   5. a :spawn-all CHILD's dangling :on-spawn ref is caught too, tagged
+      :spawn-all-child;
+   6. a single-hop keyword INDIRECTION within :on-spawn-actions resolves;
+   7. a CYCLIC indirection (`:a` -> `:a`) is treated as unresolved, exactly
+      like the runtime `chase-ref`'s cycle guard."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+(use-fixtures :each
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(defn- registration-throws?
+  "Try registering `machine` under `machine-id`. Returns the ExceptionInfo
+  if registration threw, else nil."
+  [machine-id machine]
+  (try (rf/reg-machine machine-id machine) nil
+       (catch clojure.lang.ExceptionInfo e e)))
+
+(def ^:private child-def
+  "A trivial spawn target — shape is irrelevant to these tests."
+  {:initial :running :data {} :states {:running {}}})
+
+;; ---- (1) dangling keyword :on-spawn ref -------------------------------------
+
+(deftest dangling-on-spawn-ref-rejected-at-registration
+  (testing "a :spawn's :on-spawn keyword that resolves against NEITHER registry fails registration"
+    (let [parent {:initial :idle
+                  :states  {:idle    {:on {:start :working}}
+                            :working {:spawn {:machine-id :rf.on-spawn-tv/child
+                                               :on-spawn   :no-such-callback}}}}]
+      (rf/reg-machine :rf.on-spawn-tv/child child-def)
+      (let [thrown (registration-throws? :rf.on-spawn-tv/dangling parent)]
+        (is (some? thrown)
+            "a dangling :on-spawn ref SHOULD fail registration, not silently no-op at runtime")
+        (is (= :rf.error/machine-unresolved-on-spawn (:rf.error/id (ex-data thrown)))
+            "error category names the unresolved-on-spawn contract")
+        (is (= :no-such-callback (:on-spawn (ex-data thrown))))
+        (is (= :spawn (:where (ex-data thrown))))))))
+
+;; ---- (2) resolves via :on-spawn-actions ------------------------------------
+
+(deftest on-spawn-ref-resolving-via-on-spawn-actions-registers
+  (testing "an :on-spawn ref found in :on-spawn-actions registers fine"
+    (let [parent {:initial          :idle
+                  :on-spawn-actions {:record (fn [_ctx] nil)}
+                  :states           {:idle    {:on {:start :working}}
+                                     :working {:spawn {:machine-id :rf.on-spawn-tv/child2
+                                                        :on-spawn   :record}}}}]
+      (rf/reg-machine :rf.on-spawn-tv/child2 child-def)
+      (rf/reg-machine :rf.on-spawn-tv/via-on-spawn-actions parent)
+      (rf/dispatch-sync [:rf.on-spawn-tv/via-on-spawn-actions [:start]])
+      (is (= :working (:state (mtest/snapshot :rf.on-spawn-tv/via-on-spawn-actions)))
+          "registration + dispatch both succeed — the spawn-bearing state was entered"))))
+
+;; ---- (3) resolves via the :actions FALLBACK --------------------------------
+
+(deftest on-spawn-ref-resolving-via-actions-fallback-registers
+  (testing "an :on-spawn ref ABSENT from :on-spawn-actions but present in :actions resolves via the fallback"
+    (let [observed (atom nil)
+          parent {:initial :idle
+                  ;; NO :on-spawn-actions at all — the ref must fall back
+                  ;; to :actions, mirroring apply-on-spawn's `(or (chase-ref
+                  ;; on-spawn-actions …) (chase-ref actions …))`.
+                  :actions {:record (fn [{:keys [id]}] (reset! observed id) nil)}
+                  :states  {:idle    {:on {:start :working}}
+                            :working {:spawn {:machine-id :rf.on-spawn-tv/child3
+                                               :on-spawn   :record}}}}]
+      (rf/reg-machine :rf.on-spawn-tv/child3 child-def)
+      (rf/reg-machine :rf.on-spawn-tv/via-actions-fallback parent)
+      (rf/dispatch-sync [:rf.on-spawn-tv/via-actions-fallback [:start]])
+      (is (= :rf.on-spawn-tv/child3#1 @observed)
+          "the :actions-fallback-resolved callback actually ran at spawn time"))))
+
+;; ---- (4) inline fn :on-spawn needs no resolution ---------------------------
+
+(deftest inline-fn-on-spawn-needs-no-resolution
+  (testing "an inline fn :on-spawn registers fine — no keyword ref to chase"
+    (let [observed (atom nil)
+          parent {:initial :idle
+                  :states  {:idle    {:on {:start :working}}
+                            :working {:spawn {:machine-id :rf.on-spawn-tv/child4
+                                               :on-spawn   (fn [{:keys [id]}] (reset! observed id) nil)}}}}]
+      (rf/reg-machine :rf.on-spawn-tv/child4 child-def)
+      (rf/reg-machine :rf.on-spawn-tv/inline-fn parent)
+      (rf/dispatch-sync [:rf.on-spawn-tv/inline-fn [:start]])
+      (is (= :rf.on-spawn-tv/child4#1 @observed)
+          "the inline fn ran"))))
+
+;; ---- (5) :spawn-all child's dangling :on-spawn -----------------------------
+
+(deftest spawn-all-child-dangling-on-spawn-rejected
+  (testing "a :spawn-all child's dangling :on-spawn ref fails registration, tagged :spawn-all-child"
+    (let [gc-x   {:initial :running :data {} :states {:running {}}}
+          gc-y   {:initial :running :data {} :states {:running {}}}
+          parent {:initial :idle
+                  :states  {:idle    {:on {:fork :forking}}
+                            :forking {:spawn-all
+                                      {:children        [{:id :x :machine-id :rf.on-spawn-tv/gc-x
+                                                          :on-spawn :missing-cb}
+                                                         {:id :y :machine-id :rf.on-spawn-tv/gc-y}]
+                                       :join            :all
+                                       :on-child-done   :gc/done
+                                       :on-child-error  :gc/failed
+                                       :on-all-complete [:all/done]}}}}]
+      (rf/reg-machine :rf.on-spawn-tv/gc-x gc-x)
+      (rf/reg-machine :rf.on-spawn-tv/gc-y gc-y)
+      (let [thrown (registration-throws? :rf.on-spawn-tv/spawn-all-dangling parent)]
+        (is (some? thrown) "a dangling :spawn-all child :on-spawn ref SHOULD fail registration")
+        (is (= :rf.error/machine-unresolved-on-spawn (:rf.error/id (ex-data thrown))))
+        (is (= :spawn-all-child (:where (ex-data thrown))))
+        (is (= :missing-cb (:on-spawn (ex-data thrown))))))))
+
+;; ---- (6) single-hop indirection within :on-spawn-actions resolves ---------
+
+(deftest on-spawn-ref-single-hop-indirection-resolves
+  (testing "an :on-spawn ref that indirects ONE hop within :on-spawn-actions before hitting a fn resolves"
+    (let [parent {:initial          :idle
+                  :on-spawn-actions {:short :long
+                                     :long  (fn [_ctx] nil)}
+                  :states           {:idle    {:on {:start :working}}
+                                     :working {:spawn {:machine-id :rf.on-spawn-tv/child6
+                                                        :on-spawn   :short}}}}]
+      (rf/reg-machine :rf.on-spawn-tv/child6 child-def)
+      (is (nil? (registration-throws? :rf.on-spawn-tv/indirection parent))
+          "a resolvable single-hop indirection registers cleanly"))))
+
+;; ---- (7) cyclic indirection is treated as unresolved -----------------------
+
+(deftest on-spawn-ref-cycle-rejected
+  (testing "a CYCLIC :on-spawn-actions indirection (:a -> :a) is unresolved, like the runtime chase-ref"
+    (let [parent {:initial          :idle
+                  :on-spawn-actions {:a :a}
+                  :states           {:idle    {:on {:start :working}}
+                                     :working {:spawn {:machine-id :rf.on-spawn-tv/child7
+                                                        :on-spawn   :a}}}}]
+      (rf/reg-machine :rf.on-spawn-tv/child7 child-def)
+      (let [thrown (registration-throws? :rf.on-spawn-tv/cycle parent)]
+        (is (some? thrown) "a cyclic :on-spawn-actions indirection fails registration")
+        (is (= :rf.error/machine-unresolved-on-spawn (:rf.error/id (ex-data thrown))))))))

--- a/implementation/machines/test/re_frame/root_after_non_parallel_test.clj
+++ b/implementation/machines/test/re_frame/root_after_non_parallel_test.clj
@@ -1,0 +1,110 @@
+(ns re-frame.root-after-non-parallel-test
+  "rf2-b6znpi — a non-parallel (flat / compound) machine root's `:after` has
+  NO runtime scheduling / resolution path: `transition/schedule-root-after-
+  fx` (the birth-time scheduler) is called ONLY from `parallel/run-initial-
+  cascade`'s parallel branch, and there is no root resolver that would fire
+  a flat root `:after` at the empty decl-path (`grammar/node-at` resolves
+  an empty path to nil). BEFORE this fix, `timeout/validate-timeouts!` +
+  `validate-after-delays!` happily accepted a well-formed root `:timeout` /
+  `:after` on a flat/compound machine — it registered cleanly and its
+  \"whole-machine deadline\" simply never fired, silently.
+
+  Per the bead's two offered remedies (schedule it for real, OR reject it
+  loud at registration), the operator-ruled fix is REJECT: Spec 005
+  §Root-level `:after` scopes the feature to a `:type :parallel` root only,
+  so accepting it on a flat/compound root was never a documented capability
+  — only a validation gap. `validate-non-parallel-root-after!` closes it.
+
+  This suite pins:
+   1. a hand-authored root `:after` on a flat machine is rejected;
+   2. a hand-authored root `:after` on a COMPOUND machine (nested `:states`)
+      is rejected too;
+   3. a root `:timeout` / `:on-timeout` on a flat machine — which LOWERS
+      onto `:after` — is rejected via the SAME error category;
+   4. a flat machine with NO root `:after` / `:timeout` is unaffected;
+   5. a `:type :parallel` root's `:after` is UNAFFECTED (still the
+      supported, scheduled, resolved feature)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.machines :as machines]
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+(use-fixtures :each
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(defn- registration-throws?
+  "Try registering `machine` under `machine-id`. Returns the ExceptionInfo
+  if registration threw, else nil."
+  [machine-id machine]
+  (try (rf/reg-machine machine-id machine) nil
+       (catch clojure.lang.ExceptionInfo e e)))
+
+;; ---- (1) flat machine, hand-authored root :after ---------------------------
+
+(deftest flat-root-after-rejected
+  (testing "a flat machine's hand-authored root :after fails registration"
+    (let [m {:initial :a
+             :after   {5000 {:target :b}}
+             :states  {:a {}
+                       :b {}}}
+          thrown (registration-throws? :rf.root-after-np/flat m)]
+      (is (some? thrown) "a non-parallel root :after SHOULD fail registration")
+      (is (= :rf.error/machine-non-parallel-root-after-not-supported
+             (:rf.error/id (ex-data thrown)))
+          "error category names the non-parallel-root-after-not-supported contract")
+      (is (= {5000 {:target :b}} (:after (ex-data thrown)))
+          "ex-data carries the offending root :after map"))))
+
+;; ---- (2) compound machine (nested :states), hand-authored root :after -----
+
+(deftest compound-root-after-rejected
+  (testing "a compound machine's hand-authored root :after fails registration too"
+    (let [m {:initial :outer
+             :after   {5000 {:target :outer}}
+             :states  {:outer {:initial :inner
+                               :states  {:inner {}}}}}
+          thrown (registration-throws? :rf.root-after-np/compound m)]
+      (is (some? thrown) "a compound machine is STILL non-parallel — root :after rejected")
+      (is (= :rf.error/machine-non-parallel-root-after-not-supported
+             (:rf.error/id (ex-data thrown)))))))
+
+;; ---- (3) flat machine, root :timeout / :on-timeout (lowers onto :after) ---
+
+(deftest flat-root-timeout-rejected-via-lowered-after
+  (testing "a flat machine's root :timeout / :on-timeout is rejected via its lowered :after form"
+    (let [m {:initial    :a
+             :timeout    "PT5S"
+             :on-timeout {:target :timed-out}
+             :states     {:a          {}
+                          :timed-out {}}}
+          thrown (registration-throws? :rf.root-after-np/timeout m)]
+      (is (some? thrown) "a well-formed root :timeout on a flat machine SHOULD still fail registration")
+      (is (= :rf.error/machine-non-parallel-root-after-not-supported
+             (:rf.error/id (ex-data thrown)))
+          "the SAME error category catches both hand-authored :after and lowered :timeout")
+      (is (= {5000 {:target :timed-out}} (:after (ex-data thrown)))
+          "ex-data carries the LOWERED :after map (the desugared form)"))))
+
+;; ---- (4) sanity: no root :after / :timeout — unaffected --------------------
+
+(deftest flat-machine-without-root-after-registers-fine
+  (testing "a flat machine with no root :after / :timeout registers and runs normally"
+    (let [m {:initial :a
+             :states  {:a {:on {:go :b}}
+                       :b {}}}]
+      (rf/reg-machine :rf.root-after-np/plain m)
+      (rf/dispatch-sync [:rf.root-after-np/plain [:go]])
+      (is (= :b (:state (mtest/snapshot :rf.root-after-np/plain)))
+          "unaffected machine transitions normally"))))
+
+;; ---- (5) sanity: a :type :parallel root's :after is UNAFFECTED ------------
+
+(deftest parallel-root-after-still-registers
+  (testing "a :type :parallel root's :after is NOT rejected — it is the supported feature"
+    (is (nil? (machines/validate-machine!
+                {:type    :parallel
+                 :after   {1000 {:target [:a :two]}}
+                 :regions {:a {:initial :one :states {:one {} :two {}}}
+                           :b {:initial :one :states {:one {} :two {}}}}}))
+        "a parallel root's :after validates cleanly — unaffected by the non-parallel rejection")))

--- a/implementation/machines/test/re_frame/root_on_target_validation_test.clj
+++ b/implementation/machines/test/re_frame/root_on_target_validation_test.clj
@@ -1,0 +1,114 @@
+(ns re-frame.root-on-target-validation-test
+  "rf2-nvgolg — a NON-parallel (flat / compound) machine root's own `:on` is
+  the ANCESTOR-FALLBACK transition slot: per Spec 005 §Transition resolution
+  steps 6-7, `pick-transition` consults it, stamped with decl-path `[]`,
+  when no state-path node handles the event. Target resolution at that
+  decl-path is exactly like a state's `:on` — a keyword resolves as a
+  TOP-LEVEL sibling (`target-path`'s `(drop-last [])` → `[]`).
+
+  BEFORE this fix, `validate-transition-targets!` walked ONLY nodes INSIDE
+  `:states` (`walk-state-nodes-with-scope`) — the root's OWN `:on` was never
+  checked. A machine like `{:initial :a :on {:go :missing} :states {:a
+  {}}}` registered cleanly and would only surface `:rf.error/machine-
+  unresolved-target` LATE, at the first dispatch that fell through to the
+  root fallback and tried to commit the unresolved `:missing` state —
+  rather than failing fast at registration like every other transition
+  slot's target.
+
+  This suite pins:
+   1. an unresolved keyword root :on target fails at REGISTRATION with
+      :rf.error/machine-unresolved-target (not later, at dispatch);
+   2. an unresolved VECTOR root :on target fails the same way;
+   3. a malformed-shape root :on target (neither keyword nor vector) fails
+      with :rf.error/machine-bad-target;
+   4. a VALID root :on target registers cleanly AND fires correctly at
+      runtime (the ancestor-fallback semantics are unaffected);
+   5. a :type :parallel root's :on is NOT double-validated here — its
+      region-qualified shape is `validate-parallel!`'s job, unaffected by
+      this addition."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.machines :as machines]
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+(use-fixtures :each
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(defn- registration-throws?
+  "Try registering `machine` under `machine-id`. Returns the ExceptionInfo
+  if registration threw, else nil."
+  [machine-id machine]
+  (try (rf/reg-machine machine-id machine) nil
+       (catch clojure.lang.ExceptionInfo e e)))
+
+;; ---- (1) unresolved KEYWORD root :on target --------------------------------
+
+(deftest root-on-unresolved-keyword-target-rejected-at-registration
+  (testing "a root :on keyword target naming no declared state fails registration"
+    (let [m {:initial :a
+             :on      {:go :missing}
+             :states  {:a {}}}
+          thrown (registration-throws? :rf.root-on-tv/unresolved-kw m)]
+      (is (some? thrown) "an unresolved root :on target SHOULD fail registration, not just at dispatch")
+      (is (= :rf.error/machine-unresolved-target (:rf.error/id (ex-data thrown)))
+          "error category names the unresolved-target contract")
+      (is (= :missing (:target (ex-data thrown)))
+          "ex-data carries the offending target")
+      (is (= :rf/root (:state (ex-data thrown)))
+          "ex-data attributes the failure to the machine root"))))
+
+;; ---- (2) unresolved VECTOR root :on target ---------------------------------
+
+(deftest root-on-unresolved-vector-target-rejected-at-registration
+  (testing "a root :on absolute-vector target naming no declared state fails registration"
+    (let [m {:initial :a
+             :on      {:go [:a :nowhere]}
+             :states  {:a {}}}
+          thrown (registration-throws? :rf.root-on-tv/unresolved-vec m)]
+      (is (some? thrown))
+      (is (= :rf.error/machine-unresolved-target (:rf.error/id (ex-data thrown)))))))
+
+;; ---- (3) malformed-shape root :on target -----------------------------------
+
+(deftest root-on-malformed-target-rejected-at-registration
+  (testing "a root :on target that is neither keyword nor vector is malformed shape"
+    (let [m {:initial :a
+             :on      {:go {:target 42}}
+             :states  {:a {}}}
+          thrown (registration-throws? :rf.root-on-tv/malformed m)]
+      (is (some? thrown))
+      (is (= :rf.error/machine-bad-target (:rf.error/id (ex-data thrown)))
+          "a non-keyword/non-vector target is malformed shape, not unresolved"))))
+
+;; ---- (4) a VALID root :on target registers AND fires -----------------------
+
+(deftest root-on-valid-target-registers-and-fires
+  (testing "a root :on target naming a real top-level state registers cleanly and fires as the ancestor fallback"
+    (let [m {:initial :a
+             ;; :logout is declared on NEITHER :a nor :b — only the root
+             ;; :on fallback handles it, the documented "common transition
+             ;; every state inherits" use case (Spec 005 §Transition
+             ;; resolution).
+             :on      {:logout :signed-out}
+             :states  {:a         {:on {:next :b}}
+                       :b         {}
+                       :signed-out {}}}]
+      (rf/reg-machine :rf.root-on-tv/valid m)
+      (rf/dispatch-sync [:rf.root-on-tv/valid [:next]])
+      (is (= :b (:state (mtest/snapshot :rf.root-on-tv/valid)))
+          "(precondition) local :on transition still works")
+      (rf/dispatch-sync [:rf.root-on-tv/valid [:logout]])
+      (is (= :signed-out (:state (mtest/snapshot :rf.root-on-tv/valid)))
+          "the root :on ancestor fallback fired from ANY state, landing on the top-level target"))))
+
+;; ---- (5) a parallel root's :on is unaffected (validate-parallel!'s job) ---
+
+(deftest parallel-root-on-unaffected-by-this-check
+  (testing "a :type :parallel root's region-qualified :on still validates via validate-parallel!, not this new check"
+    (is (nil? (machines/validate-machine!
+                {:type    :parallel
+                 :on      {:go-all {:target [[:a :two] [:b :two]]}}
+                 :regions {:a {:initial :one :states {:one {} :two {}}}
+                           :b {:initial :one :states {:one {} :two {}}}}}))
+        "a valid region-qualified root :on validates cleanly (unaffected by the non-parallel-only addition)")))


### PR DESCRIPTION
## Summary

Three related root-machine-validation bug fixes on `implementation/machines/**` (isolated artefact). All three share a common theme: a non-parallel machine root's declaration-level surfaces (`:after`/`:timeout`, `:on`) and `:on-spawn` refs were validated for *shape* at registration but not for whether the runtime can actually honour them — so a bad config registered cleanly and broke silently, late, at runtime.

### rf2-b6znpi — non-parallel root `:after`/`:timeout` now fails loud at registration

A flat/compound machine root's `:timeout` lowers onto root `:after` (per `timeout.cljc`), and `validate-after-delays!` happily accepts a well-formed non-parallel root `:after`. But `transition/schedule-root-after-fx` (the birth-time scheduler) is called ONLY from `parallel/run-initial-cascade`'s **parallel** branch — a flat/compound birth (`bootstrap-step`) never schedules it, and there's no root resolver that could fire it (an empty decl-path `[]` resolves to `nil` via `grammar/node-at`). So a non-parallel root `:after`/`:timeout` registered cleanly and its "whole-machine deadline" **silently never fired**.

Per Spec 005 §Root-level `:after`, the feature is explicitly scoped to a `:type :parallel` root — this was a validation gap, not a documented capability. Fix: `validate-non-parallel-root-after!` rejects a non-parallel root's `:after` (hand-authored or lowered from `:timeout`) at registration with `:rf.error/machine-non-parallel-root-after-not-supported`. A `:type :parallel` root's `:after` is unaffected.

**Test:** `implementation/machines/test/re_frame/root_after_non_parallel_test.clj` — flat root `:after` rejected, compound root `:after` rejected, root `:timeout` rejected via its lowered `:after` form, unaffected machine registers+runs fine, parallel root `:after` still validates cleanly. Also updated a pre-existing test (`after_delay_validation_test.clj`) whose scenario (an invalid delay-KEY on a non-parallel root `:after`) is now superseded by the categorical rejection — split into an updated assertion + a new test pinning the delay-key check still applies to a *parallel* root's `:after`.

### rf2-nvgolg — non-parallel root `:on` targets now validated at registration

A non-parallel machine root's own `:on` is the ancestor-fallback transition slot (`pick-transition` steps 6-7, decl-path `[]`) — but `validate-transition-targets!` only walked nodes *inside* `:states`, never the root's own `:on`. `{:initial :a :on {:go :missing} :states {:a {}}}` registered cleanly and would only surface `:rf.error/machine-unresolved-target` **at the first dispatch** that fell through to the root fallback.

Fix: extended `validate-transition-targets!` to also validate the non-parallel root's `:on` targets, with `scope (:states machine)` and `path []` — exactly mirroring `target-path`'s runtime resolution semantics for a root-level `:on` hit. A parallel root's region-qualified `:on` is unaffected (still `validate-parallel!`'s job).

**Test:** `implementation/machines/test/re_frame/root_on_target_validation_test.clj` — unresolved keyword/vector targets rejected, malformed target shape rejected, a valid root `:on` target registers AND fires correctly as the ancestor fallback, parallel root `:on` unaffected.

### rf2-b4qbx0 — fail fast on unresolved `:on-spawn` refs

A KEYWORD `:on-spawn` ref resolves through `:on-spawn-actions`, falling back to `:actions` (`transition/apply-on-spawn`). Registration validated `:spawn`/`:spawn-all` shape but never chased the `:on-spawn` ref itself — `apply-on-spawn`'s runtime lookup returns `nil` for a dangling ref and treats that identically to "no callback declared", so a typo / retired action name / broken indirection / cycle registered cleanly and the intended side effect just never ran.

Fix: `validate-on-spawn-refs!` chases the full `:on-spawn-actions` → `:actions` fallback (mirroring the runtime order exactly, via the existing `ref-resolves?` cycle-safe chaser) for every `:spawn` and `:spawn-all` child, throwing `:rf.error/machine-unresolved-on-spawn` on a dangling ref.

**Test:** `implementation/machines/test/re_frame/on_spawn_ref_validation_test.clj` — dangling ref rejected, resolves via `:on-spawn-actions`, resolves via `:actions` fallback, inline fn needs no resolution, `:spawn-all` child dangling ref rejected, single-hop indirection resolves, cyclic indirection rejected.

## Notes

- The two new error categories (`:rf.error/machine-non-parallel-root-after-not-supported`, `:rf.error/machine-unresolved-on-spawn`) are thrown through `validation.cljc`'s existing `validation-error` wrapper (category passed as a variable, not a literal, to `thrown-ex-info`) — like every other `machine-*` category in this namespace, they're invisible to `error_catalogue_channel_conformance_test`'s literal-keyword source scan, so no allow-list entry was needed (verified: the conformance test passes unchanged). Filed rf2-uymoom to add their Spec 009 catalogue rows (spec/009 is hot-zone, owned by another in-flight pair right now).
- spec/005-StateMachines.md was left unchanged — it already scopes root-level `:after` to a `:type :parallel` root, so the implementation now *conforms* to the existing spec text rather than needing a spec change.
- Discovered and filed (not fixed — out of this PR's `implementation/machines/**` scope) a pre-existing, unrelated `npm run test:xray-feature-gate` failure: rf2-upze89 (`tools/xray/testbeds/feature_matrix/scenarios.cjs` still calls the retired `re-frame.core/runtime-db-value`, deleted by an earlier API-shrink #3 commit already on `origin/main`). Reproduced identically on a clean worktree with only this PR's diff, confirming it predates and is independent of this work.

## Quality gates

- `clojure -M:test` in `implementation/machines` — **886 tests, 2848 assertions, 0 failures** (full suite, including the 4 new/updated test namespaces).
- `npm run test:cljs` (from `implementation/`) — **8116 tests, 37195 assertions, 0 failures**.
- `clojure -M:test -n re-frame.error-catalogue-channel-conformance-test` (from `implementation/core`) — **9 tests, 21 assertions, 0 failures** (confirms no allow-list entry needed for the two new error ids).
- `npm run test:xray-feature-gate` (from `implementation/`) — 15/16 scenarios pass; the 1 failure (`machine-epochs multi-machine frame-isolated stepper`) is the pre-existing, unrelated rf2-upze89 issue above (reproduced identically 3x, confirmed present without this PR's diff).

## Test plan

- [x] All three beads have a dedicated regression test file
- [x] Full machines JVM suite green
- [x] Full CLJS suite green
- [x] Error-catalogue conformance gate green (no allow-list drift)
- [x] xray-feature-gate run + pre-existing unrelated failure triaged + filed separately