### PR TITLE
fix(story-mcp): reject a scalar passed for a collection-typed argument (rf2-ldfrp0)

### DIFF
--- a/tools/story-mcp/src/re_frame/story_mcp/tools/args.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/args.cljc
@@ -20,6 +20,12 @@
     `:cell-overrides` reader for `run-variant` / `preview-variant` /
     `snapshot-identity`, with each kw-typed slot routed through
     `safe-keyword` against its live bounded set.
+  - `require-collection` / `require-map` / `run-opts-shape-error` —
+    reject a SCALAR sent for a collection-typed arg (`:tags`,
+    `:active-modes`) or a non-map sent for `:cell-overrides` with a
+    clean `isError` result, BEFORE any downstream reader gets a chance
+    to silently walk a scalar as a sequence (a string iterates
+    character-by-character) or drop it.
 
   ## Bounded-allowlist keyword resolution
 
@@ -137,12 +143,85 @@
       (transient {})
       overrides))))
 
+(defn require-collection
+  "Guard a collection-shaped MCP arg against a caller-supplied SCALAR.
+  MCP JSON arrays wire-decode to Clojure vectors; a malformed client
+  that sends a bare scalar (a JSON string / number / boolean) for an
+  array-typed slot would otherwise be silently walked as a sequence by
+  `into` / `keep` / `seq` downstream — a string in particular iterates
+  CHARACTER BY CHARACTER (`(seq \"abc\")` => `(\\a \\b \\c)`), producing
+  a wrong-but-successful result instead of a clean rejection.
+
+  Returns nil when `k` is absent from `arguments` or its value is
+  already a collection (`coll?` — vector, list, or set all pass);
+  otherwise an `isError` result naming the offending arg with a stable
+  `:rf.error/scalar-for-collection-arg` id.
+
+  Shared by every array-typed MCP arg (`list-stories`'s `:tags`,
+  `run-opts-shape-error`'s `:active-modes`) so a scalar is rejected
+  identically everywhere."
+  [arguments k]
+  (let [v (get arguments k)]
+    (when (and (some? v) (not (coll? v)))
+      (result/error-result
+        (str ":" (name k) " must be an array; got a scalar "
+             (some-> v class .getName) " (" (pr-str v) ").")
+        {:rf.error :rf.error/scalar-for-collection-arg
+         :arg      (keyword k)}))))
+
+(defn require-map
+  "Guard a map-shaped MCP arg (`:cell-overrides`) against a
+  caller-supplied non-map — a scalar OR a sequential/set collection.
+  Same rationale as `require-collection`: without this gate a non-map
+  `:cell-overrides` is silently DROPPED by `safe-cell-overrides`'s
+  `(when (map? overrides) ...)` guard (no overrides applied, no error
+  surfaced) rather than rejected.
+
+  Returns nil when `k` is absent from `arguments` or its value is
+  already a map; otherwise an `isError` result naming the offending
+  arg with a stable `:rf.error/non-map-arg` id."
+  [arguments k]
+  (let [v (get arguments k)]
+    (when (and (some? v) (not (map? v)))
+      (result/error-result
+        (str ":" (name k) " must be an object; got "
+             (some-> v class .getName) " (" (pr-str v) ").")
+        {:rf.error :rf.error/non-map-arg
+         :arg      (keyword k)}))))
+
+(defn run-opts-shape-error
+  "Validate the run-opts-bearing slots (`:active-modes` array-shaped,
+  `:cell-overrides` map-shaped) BEFORE `read-run-opts` reads them.
+  Shared by every `read-run-opts` call site (`preview-variant`,
+  `run-variant`, `snapshot-identity`) so a scalar sent for either slot
+  is rejected identically everywhere: without this gate, a scalar
+  `:active-modes` string is walked character-by-character by
+  `read-run-opts`'s `into`/`keep` (each character probed against the
+  mode allowlist and silently dropped, producing a confusing empty
+  `:active-modes []` instead of an error), and a scalar
+  `:cell-overrides` is silently dropped by `safe-cell-overrides`.
+
+  Returns nil when both slots are well-shaped (or absent); otherwise
+  the first offending arg's `isError` result. Callers short-circuit on
+  a non-nil return the same way they already short-circuit on
+  `with-variant` / `required-arg` errors."
+  [arguments]
+  (or (require-collection arguments :active-modes)
+      (require-map arguments :cell-overrides)))
+
 (defn read-run-opts
   "Build the `re-frame.story/run-variant` opts map from the standard MCP
   arg slots (`:substrate`, `:active-modes`, `:cell-overrides`) for the
   resolved variant `vk`. Each slot lands only when present, so the
   resulting map is the minimal shape `run-variant` / `snapshot-identity`
   / `variant-share-url` expect.
+
+  SHAPE VALIDATION is NOT this function's job — call
+  `run-opts-shape-error` first and short-circuit on a non-nil result.
+  This function assumes `:active-modes` (when present) is already a
+  collection and `:cell-overrides` (when present) is already a map;
+  fed a scalar, `:active-modes` silently degrades (a string iterates
+  character-by-character) rather than erroring.
 
   Shared by `tool-preview-variant`, `tool-run-variant`,
   `tool-snapshot-identity`, and `tool-variant-share-url` — all four

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/dev.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/dev.cljc
@@ -130,51 +130,52 @@
   [arguments]
   (targs/with-variant arguments
     (fn [vk _body]
-      (let [opts       (targs/read-run-opts vk arguments)
-            base-url   (or (:base-url arguments) "")
-            share-url  (story/variant-share-url vk base-url opts)
-            outcome    (try
-                         (async/deref-blocking (story/run-variant vk opts)
-                                               ;; Shared lifecycle ceiling:
-                                               ;; tunable `:timeout-ms`
-                                               ;; (default 10s, clamped to 30s),
-                                               ;; the SAME knob `run-variant` uses
-                                               ;; so the two cannot drift.
-                                               (targs/resolve-timeout-ms arguments))
-                         (catch Throwable e
-                           ;; A throw never produced a unified result; mint the
-                           ;; :error verdict directly so preview speaks the SAME
-                           ;; unified shape a settled run emits.
-                           {:status     :error
-                            :lifecycle  :error
-                            :assertions [(story/assertion-record
-                                           {:assertion :rf.error/run-failed
-                                            :passed?   false
-                                            :error     true
-                                            :reason    (ex-message e)})]
-                            :checks     []}))
-            incl?      (targs/include-sensitive? arguments)
-            raw-db     (:app-db outcome)
-            [assertions dropped] (egress/scrub-assertions+count (:assertions outcome) incl?)
-            payload    {:variant-id   vk
-                        :share-url    share-url
-                        :status       (:status outcome)
-                        :lifecycle    (:lifecycle outcome)
-                        :elapsed-ms   (:elapsed-ms outcome)
-                        :app-db       (egress/elide-app-db raw-db vk incl?)
-                        :assertions   assertions
-                        :checks       (vec (:checks outcome))
-                        ;; Derived trees are PATH-projected through scrub-rendered:
-                        ;; a value AT a classified path redacts, a re-keyed copy
-                        ;; ships raw (EP-0025 fail-open).
-                        :rendered-hiccup (egress/scrub-rendered (:rendered-hiccup outcome) raw-db vk incl?)
-                        :snapshot     (egress/scrub-rendered (:snapshot outcome) raw-db vk incl?)
-                        :effective-args (egress/scrub-rendered (:effective-args outcome) raw-db vk incl?)}]
-        ;; Surface the MUST-level egress indicator counts:
-        ;; how many sensitive assertion records were dropped + how many
-        ;; over-threshold leaves were elided across the payload. Omitted
-        ;; when zero (Conventions §Cross-MCP indicator-field vocabulary).
-        (egress/result-with-indicators payload dropped)))))
+      (or (targs/run-opts-shape-error arguments)
+          (let [opts       (targs/read-run-opts vk arguments)
+                base-url   (or (:base-url arguments) "")
+                share-url  (story/variant-share-url vk base-url opts)
+                outcome    (try
+                             (async/deref-blocking (story/run-variant vk opts)
+                                                   ;; Shared lifecycle ceiling:
+                                                   ;; tunable `:timeout-ms`
+                                                   ;; (default 10s, clamped to 30s),
+                                                   ;; the SAME knob `run-variant` uses
+                                                   ;; so the two cannot drift.
+                                                   (targs/resolve-timeout-ms arguments))
+                             (catch Throwable e
+                               ;; A throw never produced a unified result; mint the
+                               ;; :error verdict directly so preview speaks the SAME
+                               ;; unified shape a settled run emits.
+                               {:status     :error
+                                :lifecycle  :error
+                                :assertions [(story/assertion-record
+                                               {:assertion :rf.error/run-failed
+                                                :passed?   false
+                                                :error     true
+                                                :reason    (ex-message e)})]
+                                :checks     []}))
+                incl?      (targs/include-sensitive? arguments)
+                raw-db     (:app-db outcome)
+                [assertions dropped] (egress/scrub-assertions+count (:assertions outcome) incl?)
+                payload    {:variant-id   vk
+                            :share-url    share-url
+                            :status       (:status outcome)
+                            :lifecycle    (:lifecycle outcome)
+                            :elapsed-ms   (:elapsed-ms outcome)
+                            :app-db       (egress/elide-app-db raw-db vk incl?)
+                            :assertions   assertions
+                            :checks       (vec (:checks outcome))
+                            ;; Derived trees are PATH-projected through scrub-rendered:
+                            ;; a value AT a classified path redacts, a re-keyed copy
+                            ;; ships raw (EP-0025 fail-open).
+                            :rendered-hiccup (egress/scrub-rendered (:rendered-hiccup outcome) raw-db vk incl?)
+                            :snapshot     (egress/scrub-rendered (:snapshot outcome) raw-db vk incl?)
+                            :effective-args (egress/scrub-rendered (:effective-args outcome) raw-db vk incl?)}]
+            ;; Surface the MUST-level egress indicator counts:
+            ;; how many sensitive assertion records were dropped + how many
+            ;; over-threshold leaves were elided across the payload. Omitted
+            ;; when zero (Conventions §Cross-MCP indicator-field vocabulary).
+            (egress/result-with-indicators payload dropped))))))
 
 (defn tool-list-substrates
   "Dev: what substrates can be used. Reads the registered substrate set

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/docs.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/docs.cljc
@@ -56,45 +56,52 @@
   Pagination via `cursor/page`. The stable-sort key is the
   story id (string projection). Small registries return the bare
   `{:stories [...]}` payload; once entries exceed `:limit` the
-  response adds `:total :limit :has-more? :next-cursor`."
+  response adds `:total :limit :has-more? :next-cursor`.
+
+  A caller-supplied `:tags` that is a SCALAR (not an array) is
+  rejected up front via `targs/require-collection` — an `isError`
+  result, not a silent character-by-character walk of the string
+  (`(seq \"docs\")` => `(\\d \\o \\c \\s)`, each single-char probe
+  missing the tag-id allowlist and landing in `:ignored-tags`)."
   [args]
-  (let [stories      (story/registrations :story)
-        tag-set      (story/list-tags)
-        supplied     (:tags args)
-        supplied?    (some? supplied)
-        ;; Resolve each supplied entry against the registered-tag set
-        ;; WITHOUT interning unknowns. Partition by whether
-        ;; it resolved so the unknown names can ride the `:ignored-tags`
-        ;; diagnostic as their raw string forms.
-        tags         (into #{} (keep #(args/safe-keyword % tag-set)) (or supplied []))
-        ignored      (when supplied?
-                       (into [] (remove #(args/safe-keyword % tag-set)) supplied))
-        ;; A SUPPLIED filter always filters — even when nothing resolved
-        ;; (unknown-only ⇒ empty intersection ⇒ empty result), so a typo
-        ;; never widens to the whole catalogue. Only the
-        ;; no-`:tags` call returns the unfiltered registry.
-        filtered     (if supplied?
-                       (into {}
-                             (filter (fn [[_id body]]
-                                       (seq (set/intersection tags (set (:tags body))))))
-                             stories)
-                       stories)
-        index        (story/variants-by-story)
-        ;; Build the full sorted entry vec FIRST; pagination slices it.
-        ;; The sort is on string projection of the id for stable cross-
-        ;; page ordering — the fingerprint depends on it.
-        sorted       (sort-by (comp str key) filtered)
-        all-ids      (keys filtered)
-        entries      (mapv (fn [[sid body]]
-                             {:id   sid
-                              :doc  (:doc body)
-                              :tags (vec (:tags body))
-                              :variants (sort (get index sid #{}))})
-                           sorted)]
-    (cursor/paged-result entries all-ids args "list-stories"
-                         (fn [page]
-                           (cond-> {:stories page}
-                             (seq ignored) (assoc :ignored-tags ignored))))))
+  (or (targs/require-collection args :tags)
+      (let [stories      (story/registrations :story)
+            tag-set      (story/list-tags)
+            supplied     (:tags args)
+            supplied?    (some? supplied)
+            ;; Resolve each supplied entry against the registered-tag set
+            ;; WITHOUT interning unknowns. Partition by whether
+            ;; it resolved so the unknown names can ride the `:ignored-tags`
+            ;; diagnostic as their raw string forms.
+            tags         (into #{} (keep #(args/safe-keyword % tag-set)) (or supplied []))
+            ignored      (when supplied?
+                           (into [] (remove #(args/safe-keyword % tag-set)) supplied))
+            ;; A SUPPLIED filter always filters — even when nothing resolved
+            ;; (unknown-only ⇒ empty intersection ⇒ empty result), so a typo
+            ;; never widens to the whole catalogue. Only the
+            ;; no-`:tags` call returns the unfiltered registry.
+            filtered     (if supplied?
+                           (into {}
+                                 (filter (fn [[_id body]]
+                                           (seq (set/intersection tags (set (:tags body))))))
+                                 stories)
+                           stories)
+            index        (story/variants-by-story)
+            ;; Build the full sorted entry vec FIRST; pagination slices it.
+            ;; The sort is on string projection of the id for stable cross-
+            ;; page ordering — the fingerprint depends on it.
+            sorted       (sort-by (comp str key) filtered)
+            all-ids      (keys filtered)
+            entries      (mapv (fn [[sid body]]
+                                 {:id   sid
+                                  :doc  (:doc body)
+                                  :tags (vec (:tags body))
+                                  :variants (sort (get index sid #{}))})
+                               sorted)]
+        (cursor/paged-result entries all-ids args "list-stories"
+                             (fn [page]
+                               (cond-> {:stories page}
+                                 (seq ignored) (assoc :ignored-tags ignored)))))))
 
 (defn tool-get-story
   "Docs: one story's full body.

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/testing.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/testing.cljc
@@ -91,92 +91,93 @@
   [arguments]
   (targs/with-variant arguments
     (fn [vk _body]
-      (let [opts     (targs/read-run-opts vk arguments)
-            timeout  (targs/resolve-timeout-ms arguments)
-            outcome  (try
-                       (async/deref-blocking (story/run-variant vk opts) timeout)
-                       (catch Throwable e
-                         ;; A throw / timeout never produced a unified
-                         ;; result; assemble ONE through the SAME canonical
-                         ;; `story/run-result` boundary a settled run emits
-                         ;; (spec/017 §Run result) rather than hand-mint a
-                         ;; partial map — a hand-mint omitting the six `.4`
-                         ;; evidence slots (`:schema-violations` / `:warnings`
-                         ;; / `:effects` / `:sub-runs` / `:renders` /
-                         ;; `:narrative`) reads them back as an ABSENT key,
-                         ;; i.e. nil, which then projects RAW through
-                         ;; `egress/scrub-rendered` below and ships a bare
-                         ;; `nil` on the wire — failing the frozen
-                         ;; `[:sequential :any]` schema every OTHER run
-                         ;; outcome satisfies (rf2-5r6j96). `run-result`
-                         ;; against an empty tape fills every evidence slot
-                         ;; to `[]`, so the projection always has a
-                         ;; sequential to walk — one vocabulary, no
-                         ;; special-case error-branch shape for agents OR
-                         ;; the schema to carve out.
-                         (story/run-result
-                           {:variant/id vk
-                            :assertions [(story/assertion-record
-                                           {:assertion :rf.error/run-failed
-                                            :passed?   false
-                                            :error     true
-                                            :reason    (ex-message e)})]})))
-            incl?    (targs/include-sensitive? arguments)
-            raw-db   (:app-db outcome)
-            [assertions dropped] (egress/scrub-assertions+count (:assertions outcome) incl?)
-            payload  (cond-> {:status             (:status outcome)
-                              :frame              (:frame outcome vk)
-                              :app-db             (egress/elide-app-db raw-db vk incl?)
-                              :assertions         assertions
-                              :checks             (vec (:checks outcome))
-                              :consumed-selectors (:consumed-selectors outcome #{})
-                              ;; Evidence-slot projections (.4 — one tape, one
-                              ;; projection). Every value-bearing slot is
-                              ;; PATH-projected against the frame's
-                              ;; classification, same as :rendered-hiccup.
-                              ;; EP-0025 FAIL-OPEN: :narrative beats carry
-                              ;; :db-before/:db-after FULL app-db snapshots,
-                              ;; :warnings are trace-event records, :sub-runs
-                              ;; carry subscription :value — a secret re-keyed
-                              ;; into any of these non-app-db positions ships
-                              ;; RAW (value-match removed; classify the app-db
-                              ;; PATH to redact at the source). scrub-rendered
-                              ;; recurses the nested trees and the gate stays
-                              ;; symmetric (incl? true forwards raw).
-                              ;; Every slot is `(vec ...)`-wrapped BEFORE the
-                              ;; projection (not just the two that used to be)
-                              ;; — `scrub-rendered` has no nil short-circuit of
-                              ;; its own reaching `project-egress`, so a bare
-                              ;; absent-key nil would walk through as nil
-                              ;; (live frame) rather than the `[]` the frozen
-                              ;; `[:sequential :any]` schema requires
-                              ;; (rf2-5r6j96). `run-result` above already
-                              ;; fills every slot with `[]`; the `vec` here is
-                              ;; the belt-and-suspenders guard at the
-                              ;; projection call site itself, independent of
-                              ;; how `outcome` was assembled.
-                              :schema-violations  (egress/scrub-rendered (vec (:schema-violations outcome)) raw-db vk incl?)
-                              :warnings           (egress/scrub-rendered (vec (:warnings outcome)) raw-db vk incl?)
-                              :effects            (egress/scrub-rendered (vec (:effects outcome)) raw-db vk incl?)
-                              :sub-runs           (egress/scrub-rendered (vec (:sub-runs outcome)) raw-db vk incl?)
-                              :renders            (egress/scrub-rendered (vec (:renders outcome)) raw-db vk incl?)
-                              :narrative          (egress/scrub-rendered (vec (:narrative outcome)) raw-db vk incl?)
-                              ;; Derived trees: PATH-projected. A value AT a
-                              ;; classified path redacts; a re-keyed copy ships
-                              ;; raw (EP-0025 fail-open).
-                              :rendered-hiccup    (egress/scrub-rendered (:rendered-hiccup outcome) raw-db vk incl?)
-                              :elapsed-ms         (:elapsed-ms outcome)
-                              :snapshot           (egress/scrub-rendered (:snapshot outcome) raw-db vk incl?)}
-                       ;; Surface the :cannot-run refusals only when present —
-                       ;; the run-result carries them iff the runner could not
-                       ;; attempt some expectation.
-                       (contains? outcome :cannot-run)
-                       (assoc :cannot-run (:cannot-run outcome)))]
-        ;; Surface the MUST-level egress indicator counts:
-        ;; dropped sensitive assertion records + elided over-threshold
-        ;; leaves across every value-bearing slot. Omitted when zero
-        ;; (Conventions §Cross-MCP indicator-field vocabulary).
-        (egress/result-with-indicators payload dropped)))))
+      (or (targs/run-opts-shape-error arguments)
+          (let [opts     (targs/read-run-opts vk arguments)
+                timeout  (targs/resolve-timeout-ms arguments)
+                outcome  (try
+                           (async/deref-blocking (story/run-variant vk opts) timeout)
+                           (catch Throwable e
+                             ;; A throw / timeout never produced a unified
+                             ;; result; assemble ONE through the SAME canonical
+                             ;; `story/run-result` boundary a settled run emits
+                             ;; (spec/017 §Run result) rather than hand-mint a
+                             ;; partial map — a hand-mint omitting the six `.4`
+                             ;; evidence slots (`:schema-violations` / `:warnings`
+                             ;; / `:effects` / `:sub-runs` / `:renders` /
+                             ;; `:narrative`) reads them back as an ABSENT key,
+                             ;; i.e. nil, which then projects RAW through
+                             ;; `egress/scrub-rendered` below and ships a bare
+                             ;; `nil` on the wire — failing the frozen
+                             ;; `[:sequential :any]` schema every OTHER run
+                             ;; outcome satisfies (rf2-5r6j96). `run-result`
+                             ;; against an empty tape fills every evidence slot
+                             ;; to `[]`, so the projection always has a
+                             ;; sequential to walk — one vocabulary, no
+                             ;; special-case error-branch shape for agents OR
+                             ;; the schema to carve out.
+                             (story/run-result
+                               {:variant/id vk
+                                :assertions [(story/assertion-record
+                                               {:assertion :rf.error/run-failed
+                                                :passed?   false
+                                                :error     true
+                                                :reason    (ex-message e)})]})))
+                incl?    (targs/include-sensitive? arguments)
+                raw-db   (:app-db outcome)
+                [assertions dropped] (egress/scrub-assertions+count (:assertions outcome) incl?)
+                payload  (cond-> {:status             (:status outcome)
+                                  :frame              (:frame outcome vk)
+                                  :app-db             (egress/elide-app-db raw-db vk incl?)
+                                  :assertions         assertions
+                                  :checks             (vec (:checks outcome))
+                                  :consumed-selectors (:consumed-selectors outcome #{})
+                                  ;; Evidence-slot projections (.4 — one tape, one
+                                  ;; projection). Every value-bearing slot is
+                                  ;; PATH-projected against the frame's
+                                  ;; classification, same as :rendered-hiccup.
+                                  ;; EP-0025 FAIL-OPEN: :narrative beats carry
+                                  ;; :db-before/:db-after FULL app-db snapshots,
+                                  ;; :warnings are trace-event records, :sub-runs
+                                  ;; carry subscription :value — a secret re-keyed
+                                  ;; into any of these non-app-db positions ships
+                                  ;; RAW (value-match removed; classify the app-db
+                                  ;; PATH to redact at the source). scrub-rendered
+                                  ;; recurses the nested trees and the gate stays
+                                  ;; symmetric (incl? true forwards raw).
+                                  ;; Every slot is `(vec ...)`-wrapped BEFORE the
+                                  ;; projection (not just the two that used to be)
+                                  ;; — `scrub-rendered` has no nil short-circuit of
+                                  ;; its own reaching `project-egress`, so a bare
+                                  ;; absent-key nil would walk through as nil
+                                  ;; (live frame) rather than the `[]` the frozen
+                                  ;; `[:sequential :any]` schema requires
+                                  ;; (rf2-5r6j96). `run-result` above already
+                                  ;; fills every slot with `[]`; the `vec` here is
+                                  ;; the belt-and-suspenders guard at the
+                                  ;; projection call site itself, independent of
+                                  ;; how `outcome` was assembled.
+                                  :schema-violations  (egress/scrub-rendered (vec (:schema-violations outcome)) raw-db vk incl?)
+                                  :warnings           (egress/scrub-rendered (vec (:warnings outcome)) raw-db vk incl?)
+                                  :effects            (egress/scrub-rendered (vec (:effects outcome)) raw-db vk incl?)
+                                  :sub-runs           (egress/scrub-rendered (vec (:sub-runs outcome)) raw-db vk incl?)
+                                  :renders            (egress/scrub-rendered (vec (:renders outcome)) raw-db vk incl?)
+                                  :narrative          (egress/scrub-rendered (vec (:narrative outcome)) raw-db vk incl?)
+                                  ;; Derived trees: PATH-projected. A value AT a
+                                  ;; classified path redacts; a re-keyed copy ships
+                                  ;; raw (EP-0025 fail-open).
+                                  :rendered-hiccup    (egress/scrub-rendered (:rendered-hiccup outcome) raw-db vk incl?)
+                                  :elapsed-ms         (:elapsed-ms outcome)
+                                  :snapshot           (egress/scrub-rendered (:snapshot outcome) raw-db vk incl?)}
+                           ;; Surface the :cannot-run refusals only when present —
+                           ;; the run-result carries them iff the runner could not
+                           ;; attempt some expectation.
+                           (contains? outcome :cannot-run)
+                           (assoc :cannot-run (:cannot-run outcome)))]
+            ;; Surface the MUST-level egress indicator counts:
+            ;; dropped sensitive assertion records + elided over-threshold
+            ;; leaves across every value-bearing slot. Omitted when zero
+            ;; (Conventions §Cross-MCP indicator-field vocabulary).
+            (egress/result-with-indicators payload dropped))))))
 
 (defn tool-snapshot-identity
   "Testing: content-hash of the canonicalised variant (for external
@@ -185,7 +186,8 @@
   [arguments]
   (targs/with-variant arguments
     (fn [vk _body]
-      (result/edn-result (story/snapshot-identity vk (targs/read-run-opts vk arguments))))))
+      (or (targs/run-opts-shape-error arguments)
+          (result/edn-result (story/snapshot-identity vk (targs/read-run-opts vk arguments)))))))
 
 ;; `re-frame.story.ui.a11y/violations-by-frame` is the CLJS-side panel
 ;; atom — resolved once at ns-load via `cljs-resolve/resolve-cljs-var`. JVM-

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -677,6 +677,27 @@
       (is (= [:story.button] (mapv :id (:stories s))))
       (is (not (contains? s :ignored-tags))))))
 
+(deftest list-stories-scalar-tags-rejected
+  ;; rf2-ldfrp0: `:tags` advertises an array argument
+  ;; (`{:type "array" :items s/kw-or-string}`). A malformed client that
+  ;; sends a bare scalar string instead of `["docs"]` must NOT be silently
+  ;; walked character-by-character (`(seq "docs")` => `(\d \o \c \s)`,
+  ;; every single-char probe missing the registered-tag allowlist and
+  ;; landing in `:ignored-tags`) — that is a successful-looking WRONG
+  ;; result, not a protocol-level rejection. It must surface a clean
+  ;; `isError` result instead.
+  (doseq [[label bad-tags] [["a bare string" "docs"]
+                            ["a number" 42]
+                            ["a boolean" true]]]
+    (testing (str "a scalar :tags (" label ") is rejected, not iterated")
+      (let [r (invoke "list-stories" {:tags bad-tags})]
+        (is (error? r) (str bad-tags " must surface an isError result"))
+        (is (re-find #"(?i):tags must be an array" (-> r :content first :text))
+            "the error names the offending arg + expected shape")
+        (is (= :rf.error/scalar-for-collection-arg
+               (-> r :structuredContent :rf.error))
+            "a stable :rf.error id rides the structuredContent")))))
+
 (deftest get-story-happy
   (let [r (invoke "get-story" {:story-id "story.button"})]
     (is (success? r))
@@ -1076,6 +1097,45 @@
 (deftest snapshot-identity-unknown
   (let [r (invoke "snapshot-identity" {:variant-id "story.nope/missing"})]
     (is (error? r))))
+
+(deftest run-opts-scalar-active-modes-rejected
+  ;; rf2-ldfrp0: `:active-modes` advertises an array argument
+  ;; (`{:type "array" :items s/kw-or-string}`) on all three
+  ;; `read-run-opts` callers. A malformed client that sends a bare scalar
+  ;; string instead of `["mode-id"]` must NOT be silently walked
+  ;; character-by-character by `read-run-opts`'s `into`/`keep` (each
+  ;; character probed against the mode allowlist and dropped, producing a
+  ;; confusing empty `:active-modes []` instead of a rejection) — that is
+  ;; a successful-looking WRONG result, not a protocol-level error. It
+  ;; must surface a clean `isError` result instead.
+  (doseq [tool-name ["preview-variant" "run-variant" "snapshot-identity"]]
+    (testing (str tool-name " rejects a scalar :active-modes")
+      (let [r (invoke tool-name {:variant-id   "story.button/primary"
+                                  :active-modes "Mode.theme/dark"})]
+        (is (error? r) (str tool-name " must reject a scalar :active-modes, not coerce/crash"))
+        (is (re-find #"(?i):active-modes must be an array" (-> r :content first :text))
+            "the error names the offending arg + expected shape")
+        (is (= :rf.error/scalar-for-collection-arg
+               (-> r :structuredContent :rf.error))
+            "a stable :rf.error id rides the structuredContent")))))
+
+(deftest run-opts-non-map-cell-overrides-rejected
+  ;; rf2-ldfrp0: `:cell-overrides` advertises an object argument. A
+  ;; malformed client that sends a bare scalar instead of a map must NOT
+  ;; be silently DROPPED by `safe-cell-overrides`'s
+  ;; `(when (map? overrides) ...)` guard (no overrides applied, no error
+  ;; surfaced, the call silently succeeds as if the override was never
+  ;; sent) — it must surface a clean `isError` result instead.
+  (doseq [tool-name ["preview-variant" "run-variant" "snapshot-identity"]]
+    (testing (str tool-name " rejects a non-map :cell-overrides")
+      (let [r (invoke tool-name {:variant-id      "story.button/primary"
+                                  :cell-overrides  "not-a-map"})]
+        (is (error? r) (str tool-name " must reject a scalar :cell-overrides, not silently drop it"))
+        (is (re-find #"(?i):cell-overrides must be an object" (-> r :content first :text))
+            "the error names the offending arg + expected shape")
+        (is (= :rf.error/non-map-arg
+               (-> r :structuredContent :rf.error))
+            "a stable :rf.error id rides the structuredContent")))))
 
 ;; `snapshot-identity` forwards `:cell-overrides`
 ;; into `story/snapshot-identity`, where it perturbs the `:content-hash`


### PR DESCRIPTION
## Summary

- `:active-modes` and `:tags` advertise array-typed arguments (`{:type "array" :items s/kw-or-string}`) and `:cell-overrides` advertises an object-typed argument, but a malformed caller sending a **scalar** for any of them was not rejected:
  - A scalar string silently iterates character-by-character (`(seq "docs")` => `(\d \o \c \s)`), each character probed against the tag/mode allowlist and dropped — `list-stories` returns an empty `:stories` with garbage single-char entries in `:ignored-tags` instead of an error (a "successful wrong result").
  - A scalar number/boolean **crashes**: `(seq 42)` throws `Don't know how to create ISeq from: java.lang.Long`, caught generically upstream as a non-specific `isError` ("Tool handler threw: ...") rather than a clean, named rejection.
  - A scalar `:cell-overrides` was silently **dropped** by `safe-cell-overrides`'s `(when (map? overrides) ...)` guard — no override applied, no error surfaced.
- Fix: `re-frame.story-mcp.tools.args` gains `require-collection` / `require-map` (+ the shared `run-opts-shape-error` for the three `read-run-opts` callers — `preview-variant`, `run-variant`, `snapshot-identity`). Each validates the arg is actually a collection/map before any downstream reader touches it, returning a clean `isError` result with a stable `:rf.error` id (`:rf.error/scalar-for-collection-arg` / `:rf.error/non-map-arg`) — matching how sibling story-mcp tools (e.g. `register-variant`'s `:body` shape check) already reject malformed args.
- `list-stories`'s `:tags` gets the same `require-collection` guard.

## Quality gates

- `cd tools/story-mcp && clojure -M:test` — 301 tests, 1486 assertions, **0 failures, 0 errors**.
- Added regression tests: `list-stories-scalar-tags-rejected` (string/number/boolean scalar `:tags`), `run-opts-scalar-active-modes-rejected` (scalar `:active-modes` across all three `read-run-opts` callers), `run-opts-non-map-cell-overrides-rejected` (scalar `:cell-overrides` across all three callers).
- Verified the new tests actually catch the bug: temporarily reverted the `:tags` fix and reran — the scalar-string case degraded to the exact silent-wrong-result described in the bead (`:ignored-tags [\d \o \c \s]`), and the scalar-number/boolean cases crashed with a generic "Tool handler threw" message — confirming the tests exercise the real failure mode, not a tautology. Re-applied the fix; suite is green again.

## Risk

Low — additive validation on three narrow, already-documented-as-array/object arg slots (spec/API.md already documents `:active-modes [keyword]`, `:cell-overrides {keyword any}`, `:tags [keyword]`); no change to any well-shaped call path. All existing tests pass unmodified.