### PR TITLE
fix(xray): resource payload egress paths + get-resource-state live-entry lookup (rf2-aw9cfs/497rv7)

### DIFF
--- a/tools/xray/spec/024-Resources-Panel.md
+++ b/tools/xray/spec/024-Resources-Panel.md
@@ -137,7 +137,23 @@ Two elision layers compose:
    cannot collapse into one. `get-resource-state` requires the **full**
    scoped key (`:resource-id` + `:scope` + `:params`); any missing part
    fails closed with `:reason :missing-key` (a partial key cannot address
-   an entry).
+   an entry). `get-resource-state` resolves that full key the SAME way
+   `list-resource-instances` selects its raw entries — by scanning
+   `:entries` and matching each candidate's `:resource/key` stamp (see the
+   byte-key-id paragraph below), never by a direct map-key lookup on the
+   scoped-key vector (rf2-497rv7).
+
+   The per-slot declaration match happens at the entry's ABSOLUTE
+   runtime-db coordinate, rooted at the entry's `key-id` (rf2-aw9cfs):
+   `[:rf.runtime/resources :entries <key-id> :data …]` for `:data` /
+   `:error` / `:refresh-error`, and `[… :resource/key 2 …]` / `[…
+   :resource/key 0 …]` for params / scope (the scoped key is `[scope
+   resource-id params]`) — mirroring exactly where the resources artefact's
+   own per-instance lowering (`re-frame.resources.classification/
+   reconcile-registry`) writes a resource's declared `:sensitive?` /
+   `:large?` slots. A slot-only path (omitting `<key-id>`) never matches a
+   real lowered declaration, so a declared-sensitive resource would
+   silently ride raw under `:include-runtime-db? true`.
 
 3. **Off-box egress for the TRACE-borne accessors** (`get-resource-history` /
    `list-resource-invalidations`, rf2-e0mq7a). These two project off the

--- a/tools/xray/src/day8/re_frame2_xray/panels/resources_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/resources_helpers.cljc
@@ -578,21 +578,27 @@
        :tags            [<tag> …]
        :gc-eligible?    false}
 
-  Optional `egress-fn` (rf2-tgm1xu): `(fn [value slot-key] -> egressed)`
-  applied to the PAYLOAD-bearing values (the key's scope/params + the
-  entry's `:data`/`:error`/`:refresh-error`) BEFORE `summarize`, so a
-  `:sensitive?` slot summarizes as `[redacted]` and a `:large?` slot as
-  `[large — elided]` on the off-box path. The METADATA (status, owners,
-  tags, request-id, generation, timestamps) is projected from the raw entry
-  and NEVER routed through egress — a redacted summary STILL exposes the
-  metadata. The RAW `scoped-key` is kept verbatim as `:scoped-key` (the
-  identity / react key), so per-row egress can never collapse two entries
-  whose scope/params redact to the same sentinel. A `nil` slot is left as
-  nil (nothing to redact) so the derived `:has-data?` fact survives."
+  Optional `egress-fn` (rf2-tgm1xu, rf2-aw9cfs): `(fn [value slot-key key-id]
+  -> egressed)` applied to the PAYLOAD-bearing values (the key's
+  scope/params + the entry's `:data`/`:error`/`:refresh-error`) BEFORE
+  `summarize`, so a `:sensitive?` slot summarizes as `[redacted]` and a
+  `:large?` slot as `[large — elided]` on the off-box path. `key-id` is the
+  entry's own `map-key` (the CEDN-1 byte key-id the live `:entries` map uses,
+  rf2-9e0tyq) — threaded so the off-box `resource-egress-fn` can re-root its
+  declaration-matching `:path` at the SAME absolute coordinate the resources
+  artefact lowers its per-instance `:sensitive?` / `:large?` declarations to
+  (a slot-only path, missing the key-id, never matches — rf2-aw9cfs). The
+  METADATA (status, owners, tags, request-id, generation, timestamps) is
+  projected from the raw entry and NEVER routed through egress — a redacted
+  summary STILL exposes the metadata. The RAW `scoped-key` is kept verbatim
+  as `:scoped-key` (the identity / react key), so per-row egress can never
+  collapse two entries whose scope/params redact to the same sentinel. A
+  `nil` slot is left as nil (nothing to redact) so the derived `:has-data?`
+  fact survives."
   ([entry+key now-ms] (instance-row entry+key now-ms nil))
   ([[map-key entry] now-ms egress-fn]
-   (let [egress       (or egress-fn (fn [v _slot] v))
-         eg           (fn [v slot] (when (some? v) (egress v slot)))
+   (let [egress       (or egress-fn (fn [v _slot _key-id] v))
+         eg           (fn [v slot] (when (some? v) (egress v slot map-key)))
          ;; rf2-9e0tyq — the `:entries` map key is now the opaque CEDN-1 byte
          ;; `key-id` STRING; the kind-preserving scoped-key VECTOR lives on the
          ;; entry as `:resource/key`. Read the scope/rid/params from there (fall
@@ -1783,8 +1789,8 @@
 ;;     facts the operator needs to answer "is it stale, who owns it, what's
 ;;     the request id". They ALWAYS project, never routed through egress.
 ;;
-;; `instance-row` takes an optional `egress-fn` `(fn [value slot-key])` and
-;; applies it to ONLY the value-bearing slots before `summarize`, keeping
+;; `instance-row` takes an optional `egress-fn` `(fn [value slot-key key-id])`
+;; and applies it to ONLY the value-bearing slots before `summarize`, keeping
 ;; the RAW scoped-key as the row identity. The PRIOR design routed the WHOLE
 ;; entry through `egress-runtime-db-value` BEFORE projection: with the
 ;; off-box runtime-db default the entry collapsed to the bare `:rf/redacted`

--- a/tools/xray/src/day8/re_frame2_xray/runtime.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/runtime.cljs
@@ -471,7 +471,7 @@
 ;; (`:data` / `:error` / `:refresh-error`) and the key's scope/params carry
 ;; PII or a large blob, so ONLY they follow the off-box egress posture.
 ;;
-;; `resource-egress-fn` builds the `(fn [value slot-key])` closure
+;; `resource-egress-fn` builds the `(fn [value slot-key key-id])` closure
 ;; `resources-helpers/project-instances` / `instance-row` call on each
 ;; payload value (scope / params / data / error / refresh-error) BEFORE
 ;; summarizing. It routes the value through `egress-runtime-db-value` so the
@@ -481,24 +481,56 @@
 ;; per-slot `:sensitive?` / `:large?` posture (a value already redacted/
 ;; elided upstream keeps its sentinel). The in-panel
 ;; `resources-helpers/summarize` always wraps the result, so even an
-;; opted-in raw payload renders as a bounded summary, never a flood. The
-;; helper threads the slot's relative runtime-db path so a per-slot
-;; declaration (e.g. all `:data` payloads) can match under the opt-in.
+;; opted-in raw payload renders as a bounded summary, never a flood.
+;;
+;; rf2-aw9cfs: the resources artefact LOWERS a resource's `:sensitive?` /
+;; `:large?` declarations PER INSTANCE onto the entry's ABSOLUTE runtime-db
+;; path, rooted at the entry's byte `key-id`
+;; (`re-frame.resources.classification/reconcile-registry`:
+;; `[:rf.runtime/resources :entries <key-id> :data …]` for data,
+;; `[… :resource/key 2 …]` for params, `[… :resource/key 0 …]` for scope —
+;; the scoped key is `[scope resource-id params]`). A SLOT-ONLY path (missing
+;; the `<key-id>` segment — the pre-fix shape) never matches those lowered
+;; declarations, so a real `:sensitive?`/`:large?` resource silently rode
+;; raw under `:include-runtime-db? true`. The helper therefore threads the
+;; entry's `key-id` (its literal `:entries` map key, per rf2-9e0tyq) into the
+;; path, re-rooting each slot exactly where the lowering wrote it.
+
+(defn- resource-payload-path-suffix
+  "The lowered-declaration path SUFFIX, relative to an entry's `key-id`, a
+  payload `slot-key` re-roots under (rf2-aw9cfs) — mirrors
+  `re-frame.resources.classification/instance-declaration-paths`'s re-rooting:
+  a `:data`-rooted declaration lands directly under the entry (`[key-id
+  :data]`); a `:scope`- / `:params`-rooted one lands under the scoped-key
+  `:resource/key` carrier at index 0 / 2 (the scoped key is `[scope
+  resource-id params]`). `:error` / `:refresh-error` are not currently
+  lowered by the resources registry but live at the entry's own key, so they
+  re-root there too — a harmless no-match today that is correct the day the
+  registry starts classifying them."
+  [slot-key]
+  (case slot-key
+    :scope  [:resource/key 0]
+    :params [:resource/key 2]
+    [slot-key]))
 
 (defn- resource-egress-fn
-  "Return the `(fn [value slot-key] -> egressed)` payload-egress closure for
-  the resource accessors (rf2-tgm1xu). Each value routes through
-  `egress-runtime-db-value` with `egress-opts` — the runtime-db partition
-  default (redact unless `:include-runtime-db? true`) composed with the
-  per-slot value posture under the opt-in. The slot's relative runtime-db
-  path (`[:rf.runtime/resources :entries <slot>]`) is threaded so a
-  declaration keyed by that path still matches under the opt-in."
+  "Return the `(fn [value slot-key key-id] -> egressed)` payload-egress
+  closure for the resource accessors (rf2-tgm1xu, rf2-aw9cfs). Each value
+  routes through `egress-runtime-db-value` with `egress-opts` — the
+  runtime-db partition default (redact unless `:include-runtime-db? true`)
+  composed with the per-slot value posture under the opt-in. `key-id` is the
+  entry's CEDN-1 byte key-id (its literal `:entries` map key); the
+  `:path` threaded is the ABSOLUTE `[:rf.runtime/resources :entries <key-id>
+  …]` coordinate the resources artefact lowers its per-instance declarations
+  to, so a real `:sensitive?` / `:large?` resource matches under the opt-in
+  instead of silently riding raw."
   [egress-opts]
-  (fn [value slot-key]
+  (fn [value slot-key key-id]
     (egress-runtime-db-value
       value
       (assoc egress-opts
-             :path (conj (vec resources-helpers/entries-rel-path) slot-key)))))
+             :path (into (conj (vec resources-helpers/entries-rel-path) key-id)
+                         (resource-payload-path-suffix slot-key))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Event-level default-suppress gate (rf2-to36uj)
@@ -1067,8 +1099,17 @@
 (defn get-resource-state
   "Tool: `get-resource-state`. The LIVE durable state of ONE resource
   instance addressed by its scoped key (Spec 016 §Introspection /
-  §Status semantics). Resolves the entry at `[:rf.runtime/resources
-  :entries [scope resource-id params]]` in the frame's runtime-db.
+  §Status semantics).
+
+  rf2-497rv7: the frame's `:rf.runtime/resources :entries` map is keyed on
+  the opaque CEDN-1 **byte `key-id` string** (rf2-9e0tyq), NOT the
+  `[scope resource-id params]` scoped-key vector — a direct `get-in … [scope
+  resource-id params]` lookup therefore never hits a live entry. This
+  resolves the entry the SAME way `list-resource-instances` selects its raw
+  entries (`resources-helpers/select-raw-entries`): scanning `:entries` and
+  matching each candidate's kind-preserving `:resource/key` stamp (falling
+  back to the map key for a legacy entry that lacks the stamp) against the
+  full `[scope resource-id params]` triple.
 
   Required: `:resource-id` + `:scope` + `:params` (the scoped key). Per
   EP-0002 the frame target is carried explicitly (`:frame`); a frameless
@@ -1107,10 +1148,16 @@
        :hint "Pass :resource-id + :scope + :params (the full scoped key)."}
 
       :else
-      (let [scoped-key  [scope resource-id params]
-            runtime-db  (:rf.db/runtime (rf/frame-state-value fid))
-            entry-path  (conj (vec resources-helpers/entries-rel-path) scoped-key)
-            entry       (get-in runtime-db entry-path)]
+      (let [runtime-db      (:rf.db/runtime (rf/frame-state-value fid))
+            all-entries     (get-in runtime-db resources-helpers/entries-rel-path)
+            ;; rf2-497rv7 — scan by the SAME key axes list-resource-instances
+            ;; uses upstream, rather than a direct map-key lookup on the
+            ;; scoped-key vector (which never matches the byte-key-id `:entries`
+            ;; map). All three axes are bound, so at most one entry matches.
+            matches         (resources-helpers/select-raw-entries
+                              all-entries
+                              {:scope scope :resource-id resource-id :params params})
+            [map-key entry] (first matches)]
         (if (nil? entry)
           {:ok? false :reason :no-such-instance
            :frame fid :resource-id resource-id}
@@ -1123,12 +1170,13 @@
                              :frame               fid}]
             ;; PER-SLOT egress (rf2-tgm1xu): the projection redacts only the
             ;; payload values (scope/params/data/error) before summarizing;
-            ;; the metadata projects from the raw entry. The RAW scoped-key
+            ;; the metadata projects from the raw entry. The RAW map-key
+            ;; (the entry's `:resource/key` scoped-key, per `instance-row`)
             ;; is the row identity.
             {:ok?   true
              :frame fid
              :state (resources-helpers/instance-row
-                      [scoped-key entry] (.now js/Date)
+                      [map-key entry] (.now js/Date)
                       (resource-egress-fn egress-opts))}))))))
 
 ;; rf2-e0mq7a — the trace-value egress closure for the resource

--- a/tools/xray/test/day8/re_frame2_xray/panels/resources_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/resources_helpers_cljs_test.cljc
@@ -484,7 +484,7 @@
   (let [;; an egress-fn that redacts the :params slot (mirrors the off-box
         ;; `resource-egress-fn` for a `:sensitive?` owner) and passes other
         ;; slots through — page-params + the cursor project through `:params`.
-        egress-fn     (fn [v slot] (if (= :params slot) h/redacted-sentinel v))
+        egress-fn     (fn [v slot _key-id] (if (= :params slot) h/redacted-sentinel v))
         rows          (h/project-instances infinite-entries now egress-fn)
         live          (first (filter #(= {:tag "clj"} (get-in % [:scoped-key 2])) rows))]
     (testing "each VALUE-bearing page-param in the chain is redacted off-box"

--- a/tools/xray/test/day8/re_frame2_xray/panels/resources_local_render_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/resources_local_render_cljs_test.cljc
@@ -142,10 +142,10 @@
 ;; A frame-keyed egress fn matching how the Resources panel SHOULD route a
 ;; frame-sourced value through the EP-0015 on-box default before summarizing —
 ;; the `instance-row` egress-fn seam (rf2-tgm1xu) wired to the local-render
-;; profile. `slot` is ignored: the observed frame's path policy governs which
-;; nested slots redact, exactly as the App-DB local render does.
+;; profile. `slot` / `key-id` are ignored: the observed frame's path policy
+;; governs which nested slots redact, exactly as the App-DB local render does.
 (defn- local-egress-fn [observed-frame]
-  (fn [v _slot] (local-render/local-render-value v observed-frame)))
+  (fn [v _slot _key-id] (local-render/local-render-value v observed-frame)))
 
 (defn- no-raw-secret?
   "The render-safe summary must NEVER carry the raw secret in ANY of its

--- a/tools/xray/test/day8/re_frame2_xray/runtime_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/runtime_cljs_test.cljs
@@ -54,6 +54,14 @@
             ;; are JVM-only aliases (core.cljc `#?(:clj ...)`). The runtime
             ;; itself requires this same ns (rf2-qwm0a).
             [re-frame.trace.tooling :as trace-tooling]
+            ;; rf2-497rv7 / rf2-aw9cfs — the live `:rf.runtime/resources
+            ;; :entries` map is keyed on the CEDN-1 byte `key-id` STRING
+            ;; (rf2-9e0tyq), not the `[scope resource-id params]` scoped-key
+            ;; vector. `state/key-id` builds faithful byte-keyed fixtures —
+            ;; the same precedent `panels/resources-helpers-cljs-test` sets.
+            ;; Xray's `src/` never requires the resources artefact (bundle
+            ;; isolation); this is a TEST-only fixture-building require.
+            [re-frame.resources.state :as state]
             [day8.re-frame2-xray.runtime :as runtime]))
 
 ;; ---------------------------------------------------------------------------
@@ -1265,11 +1273,22 @@
    :active-owners #{}
    :tags          #{[:article "old"]}})
 
+(defn- byte-keyed-entries
+  "Re-key a `{scoped-key-vector entry}` fixture map into the LIVE runtime
+  shape (rf2-9e0tyq / rf2-497rv7): `{<key-id-string> (assoc entry
+  :resource/key scoped-key)}`. Callers write fixtures in the natural
+  scoped-key-vector form; this is the SAME re-keying `runtime-db-with` /
+  `entries*` apply in the resources artefact's own SSR tests."
+  [entries]
+  (into {}
+        (map (fn [[sk e]] [(state/key-id sk) (assoc e :resource/key sk)]))
+        entries))
+
 (defn- seed-resource-entries! [entries]
   (rf/reg-event :test/seed-resources
     {:rf/machine? true}
     (fn [_ _]
-      {:rf.db/runtime {:rf.runtime/resources {:entries entries}}}))
+      {:rf.db/runtime {:rf.runtime/resources {:entries (byte-keyed-entries entries)}}}))
   (rf/dispatch-sync [:test/seed-resources]))
 
 (deftest list-resource-instances-exposes-metadata-on-default-path
@@ -1394,6 +1413,126 @@
                :params      {:slug "does-not-exist"}})]
       (is (false? (:ok? r)))
       (is (= :no-such-instance (:reason r))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-497rv7 — `get-resource-state` resolves the LIVE byte-key-id entry.
+;; ---------------------------------------------------------------------------
+;;
+;; BEFORE the fix, `get-resource-state` looked the entry up via a direct
+;; `get-in` on the `[scope resource-id params]` scoped-key VECTOR — but the
+;; live `:entries` map is keyed on the opaque CEDN-1 byte `key-id` STRING
+;; (rf2-9e0tyq), so a valid, present resource instance ALWAYS surfaced
+;; `:no-such-instance`. Every `get-resource-state-*` test above already seeds
+;; through `seed-resource-entries!` (now byte-keyed) and would have failed
+;; pre-fix; this test additionally pins the byte-keyed contract explicitly
+;; and adversarially — a SECOND distractor entry is seeded so the fix must
+;; be resolving by the FULL key match, not by "the only entry present"."
+
+(deftest get-resource-state-resolves-the-live-byte-keyed-entry
+  (testing "rf2-497rv7 — the entries map is byte-key-id keyed, not scoped-key
+            keyed; get-resource-state must scan/match by :resource/key (the
+            same mechanism list-resource-instances' select-raw-entries uses),
+            not by a direct map-key lookup on the scoped-key vector"
+    (seed-resource-entries! {tgm1xu-key   tgm1xu-entry
+                             tgm1xu-key-2 tgm1xu-entry-2})
+    (let [r (runtime/get-resource-state
+              {:resource-id :article/by-slug
+               :scope       tgm1xu-scope
+               :params      {:slug "welcome"}})]
+      (is (true? (:ok? r)) "a present, correctly-keyed instance resolves")
+      (is (= :loaded (:status (:state r)))
+          "resolves THE RIGHT entry (not the distractor :error one)")
+      (is (= [:w 4] (:request-id (:state r)))))
+    (let [r2 (runtime/get-resource-state
+               {:resource-id :article/by-slug
+                :scope       tgm1xu-scope
+                :params      {:slug "old"}})]
+      (is (true? (:ok? r2)) "the distractor entry ALSO resolves by its own key")
+      (is (= :error (:status (:state r2)))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-aw9cfs — resource payload egress paths thread the entry's key-id, so a
+;; REAL lowered `:sensitive?` / `:large?` declaration (the resources
+;; artefact's per-instance registry lowering,
+;; `re-frame.resources.classification/reconcile-registry`) actually redacts /
+;; elides the payload under `:include-runtime-db? true`.
+;; ---------------------------------------------------------------------------
+;;
+;; BEFORE the fix, `resource-egress-fn` threaded a SLOT-ONLY path
+;; (`[:rf.runtime/resources :entries :data]`, missing the entry's key-id), so
+;; it could never match a real declaration lowered at
+;; `[:rf.runtime/resources :entries <key-id> :data]` — a `:sensitive?` /
+;; `:large?` resource's payload rode RAW under the trusted-local opt-in
+;; instead of redacting/eliding per its own declared classification. We seed
+;; a declaration directly at the CORRECT absolute (key-id-rooted) coordinate
+;; via `elision/apply-classification-effects` — the same commit-plane
+;; primitive `reconcile-registry` itself writes through — so the test proves
+;; the accessor honours a REAL lowered declaration without depending on the
+;; optional resources artefact's runtime event handlers.
+
+(defn- declare-resource-classification!
+  "Seed a `:source :effect` `:sensitive` / `:large` declaration directly onto
+  `:rf/default`'s runtime-db (the fixture's sole registered frame, same as
+  `seed-sensitive-schema!` above) at absolute `paths` — the SAME primitive
+  (`elision/apply-classification-effects`) the resources artefact's
+  `reconcile-registry` per-instance lowering writes through, so the fixture
+  models a REAL lowered declaration without requiring that optional
+  artefact."
+  [axis paths]
+  (frame/swap-runtime-db! :rf/default
+    (fn [rt] (elision/apply-classification-effects rt {axis paths}))))
+
+(deftest resource-egress-fn-threads-key-id-for-sensitive-data
+  (testing "rf2-aw9cfs — a :sensitive? declaration lowered at the entry's
+            key-id-rooted :data path redacts the payload under
+            :include-runtime-db? true; the pre-fix slot-only path never
+            matched this declaration"
+    (seed-resource-entries! {tgm1xu-key tgm1xu-entry})
+    (let [key-id (state/key-id tgm1xu-key)]
+      (declare-resource-classification!
+        :sensitive [[:rf.runtime/resources :entries key-id :data]])
+      (let [row (:state (runtime/get-resource-state
+                          {:resource-id         :article/by-slug
+                           :scope               tgm1xu-scope
+                           :params              {:slug "welcome"}
+                           :include-runtime-db? true}))]
+        (is (:redacted? (:data row))
+            "the key-id-rooted :sensitive? declaration redacts :data even
+             under the trusted-local runtime-db opt-in")
+        (is (= "[redacted]" (:preview (:data row)))))
+      ;; list-resource-instances threads the SAME resource-egress-fn — pin it
+      ;; there too so both live-cache accessors share the fix.
+      (let [row (first (:instances (runtime/list-resource-instances
+                                     {:include-runtime-db? true})))]
+        (is (:redacted? (:data row))
+            "list-resource-instances honours the SAME key-id-rooted declaration")))))
+
+(deftest resource-egress-fn-threads-key-id-for-sensitive-params
+  (testing "rf2-aw9cfs — a :sensitive? declaration lowered at the entry's
+            key-id-rooted PARAMS offset (`:resource/key 2` — the scoped key
+            is [scope resource-id params], so a :params-rooted declaration
+            re-roots at index 2, distinct from the :data re-rooting the
+            sibling test pins) redacts the params under
+            :include-runtime-db? true — proving `resource-payload-path-
+            suffix`'s :params branch, not just its :data default"
+    (seed-resource-entries! {tgm1xu-key tgm1xu-entry})
+    (let [key-id (state/key-id tgm1xu-key)]
+      (declare-resource-classification!
+        :sensitive [[:rf.runtime/resources :entries key-id :resource/key 2]])
+      (let [row (:state (runtime/get-resource-state
+                          {:resource-id         :article/by-slug
+                           :scope               tgm1xu-scope
+                           :params              {:slug "welcome"}
+                           :include-runtime-db? true}))]
+        (is (:redacted? (:params row))
+            "the key-id-rooted :sensitive? declaration on the params offset
+             redacts :params even under the trusted-local runtime-db opt-in")
+        (is (= "[redacted]" (:preview (:params row))))
+        ;; The :data sibling slot is UNDECLARED at this offset — it must NOT
+        ;; be swept up by the params-only declaration (precision, not a
+        ;; blanket entry-wide redaction).
+        (is (not (:redacted? (:data row)))
+            "an undeclared sibling slot is untouched by the params decl")))))
 
 ;; ---------------------------------------------------------------------------
 ;; rf2-e0mq7a — get-resource-history / list-resource-invalidations egress the


### PR DESCRIPTION
Fixes two Xray resource-inspection bugs in `tools/xray` (both P2). Isolated surface — only `tools/xray/**` touched.

## rf2-497rv7 — get-resource-state live-entry lookup

`get-resource-state` resolved the entry via a direct `get-in` on the `[scope resource-id params]` scoped-key VECTOR, but the live `:rf.runtime/resources :entries` map is keyed on the opaque CEDN-1 byte `key-id` STRING (rf2-9e0tyq), with the kind-preserving scoped-key carried on each entry as `:resource/key`. A valid, present resource instance therefore **always** returned `:no-such-instance`.

**Fix**: resolve via the same `resources-helpers/select-raw-entries` scan `list-resource-instances` already uses — matching each candidate's `:resource/key` stamp (falling back to the map key for a legacy entry) against the full `[scope resource-id params]` triple. All three axes are bound, so at most one entry matches. The matched map-key is kept as the row identity.

## rf2-aw9cfs — resource payload egress paths

`resource-egress-fn` threaded a **slot-only** path (`[:rf.runtime/resources :entries <slot>]`, missing the entry's key-id). The resources artefact lowers a resource's per-instance `:sensitive?` / `:large?` declarations onto the entry's **absolute key-id-rooted** path (`reconcile-registry`: `[:rf.runtime/resources :entries <key-id> :data …]` for data, `[… :resource/key 2 …]` / `[… :resource/key 0 …]` for params / scope). The slot-only path never matched those declarations, so a `:sensitive?` / `:large?` resource's payload rode **raw** under `:include-runtime-db? true`.

**Fix**: the egress closure now takes the entry's `key-id` and re-roots each slot at the same absolute coordinate the lowering wrote it (new `resource-payload-path-suffix` helper mirrors `instance-declaration-paths`' re-rooting). `instance-row` threads the entry's `map-key` as the egress-fn's new third arg. The 2-arg `(fn [value slot-key])` egress-fn contract becomes 3-arg `(fn [value slot-key key-id])`; the two in-repo test egress-fns updated to match.

## Spec reconciliation

`tools/xray/spec/024-Resources-Panel.md` updated (XRAY SPEC RATCHET): documents that `get-resource-state` resolves by the `:resource/key` scan (not a direct scoped-key map-key lookup), and that the per-slot declaration match happens at the entry's absolute key-id-rooted coordinate (`[… <key-id> :data]` / `[… :resource/key 2|0]`), with a slot-only path matching nothing.

## Regression tests

`tools/xray/test/day8/re_frame2_xray/runtime_cljs_test.cljs`:
- Fixed the `seed-resource-entries!` fixture to seed the **live byte-keyed** shape (`{key-id (assoc entry :resource/key sk)}`) — it previously seeded the dead vector-keyed shape, which is exactly why the byte-key bug was uncaught. Every existing `get-resource-state-*` test now exercises the real live shape.
- `get-resource-state-resolves-the-live-byte-keyed-entry` — adversarial: two byte-keyed entries seeded, each resolves by its own full key (proves match, not "only entry present").
- `resource-egress-fn-threads-key-id-for-sensitive-data` — a `:sensitive?` declaration lowered at `[… <key-id> :data]` redacts `:data` under `:include-runtime-db? true` (pre-fix slot-only path never matched); pinned for both `get-resource-state` and `list-resource-instances`.
- `resource-egress-fn-threads-key-id-for-sensitive-params` — a `:sensitive?` declaration at the params offset (`:resource/key 2`) redacts `:params`, and an undeclared sibling slot is untouched (precision).

## Quality gates

- `tools/xray/` `clojure -M:test` (foreground): **1230 tests, 5675 assertions, 0 failures, 0 errors**.
- `implementation/` `npm run test:cljs` (foreground, exercises the new/modified CLJS regression tests): **8119 tests, 37206 assertions, 0 failures, 0 errors**.
- `implementation/` `npm run test:xray-feature-gate` (foreground): **15/16 PASS**. The one FAIL is `machine-epochs multi-machine frame-isolated stepper` — mount probe `reason: "cljs.core / re_frame.core.runtime_db_value unavailable"`, a **pre-existing / unrelated** machine-inspector testbed issue (the mis-diagnosed rf2-upze89 `runtime-db-value` reference). It is disjoint from this diff — none of the 6 changed files touch machines, the machine-epochs testbed, or `runtime-db-value`; re-ran after `npx shadow-cljs stop` (no zombie server) and it persisted identically. All resource-related scenarios pass.
- No mkdocs doc touched (spec change is under `tools/xray/spec/`, not the mkdocs tree) — docs build not required.