### PR TITLE
fix(ssr-ring): invoke streaming root-view fn exactly once to preserve hydration contract (rf2-t72b1c)

### DIFF
--- a/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
@@ -168,7 +168,17 @@
   gensym'd keys, time-of-day props can all vary between calls) and any
   variance between two invocations produces a hash mismatch on the wire
   vs the payload, firing a spurious `:rf.ssr/hydration-mismatch` on a
-  perfectly successful hydration. Resolve once, thread the result."
+  perfectly successful hydration. Resolve once, thread the result.
+
+  rf2-t72b1c — the streaming handler (`re-frame.ssr.ring.streaming`)
+  honours this exactly-once contract for the common case (a request with
+  zero continuations, i.e. no `:rf/suspense-boundary` in the tree). It
+  calls through to a SECOND invocation only when at least one continuation
+  drained — the one case app-db can legitimately have changed since the
+  shell render — trading a documented, narrow exactly-once exception
+  (rf2-1kqvbx) for a correct post-drain `:rf/render-hash`. See
+  `re-frame.ssr.ring.streaming/run-streaming-writer!`'s final-payload
+  comment for the full rationale."
   [root-view]
   (cond
     (vector? root-view) root-view

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
@@ -205,20 +205,30 @@
   daemon writer needs (`:head-model` was consumed here, for the hash,
   and does not itself ride the wire).
 
-  rf2-1kqvbx: `:doc-hash` no longer drives the FINAL-payload
-  `:rf/render-hash`. The final payload ships the live POST-drain `app-db`,
-  so its hash must describe the POST-drain render tree (the one a streaming
-  hydrate re-renders + verifies against). The writer re-resolves the root
-  view AFTER every continuation drains and recomputes that post-drain hash
-  via `lifecycle/render-document-hash` (body-only). When no continuation
-  mutates a root-read key the two hashes coincide; only a render-time
-  continuation mutation a root subtree reads makes the streamed-shell marker
-  (pre-drain) and the final-payload hash (post-drain) describe distinct
-  moments — which they genuinely are. `:head-hash` needs no post-drain
-  recompute: the head is request-thread-resolved and drain-invariant in v1
-  (it derives from the route / explicit `:head` opt, never from
-  continuation-mutated app-db), so the SAME pre-drain `:head-hash` is reused
-  for both the streamed shell marker and the final payload.
+  rf2-1kqvbx: when at least one continuation drains, `:doc-hash` no longer
+  drives the FINAL-payload `:rf/render-hash`. The final payload ships the
+  live POST-drain `app-db`, so its hash must describe the POST-drain render
+  tree (the one a streaming hydrate re-renders + verifies against). The
+  writer re-resolves the root view AFTER every continuation drains and
+  recomputes that post-drain hash via `lifecycle/render-document-hash`
+  (body-only). When no continuation mutates a root-read key the two hashes
+  coincide; only a render-time continuation mutation a root subtree reads
+  makes the streamed-shell marker (pre-drain) and the final-payload hash
+  (post-drain) describe distinct moments — which they genuinely are.
+
+  rf2-t72b1c: when there are ZERO continuations (no `:rf/suspense-boundary`
+  in the tree — the common case), nothing runs between the shell render and
+  the final-payload build that could mutate app-db, so the writer does NOT
+  re-resolve the root view a second time — it reuses `:doc-hash` verbatim.
+  This keeps a fn-form `:root-view` invoked EXACTLY ONCE per request
+  (`lifecycle/resolve-root-view`'s rf2-6t36h contract) for the overwhelming
+  majority of streaming requests; only a request with at least one
+  continuation pays the documented rf2-1kqvbx re-resolution cost.
+  `:head-hash` needs no post-drain recompute in either case: the head is
+  request-thread-resolved and drain-invariant in v1 (it derives from the
+  route / explicit `:head` opt, never from continuation-mutated app-db), so
+  the SAME pre-drain `:head-hash` is reused for both the streamed shell
+  marker and the final payload.
 
   Throws propagate to the caller (the handler's outer try/catch routes
   them through the projector → fail-closed non-200, rf2-r06pc). The
@@ -478,18 +488,33 @@
       ;; Chunk N+2 — final canonical __rf_payload.
       ;;
       ;; rf2-1kqvbx — the streaming final-payload `:rf/render-hash` must
-      ;; describe the POST-drain render state, NOT the pre-drain shell.
-      ;; `build-final-payload` reads the LIVE frame `app-db` AFTER every
-      ;; continuation has drained, so its `:rf/app-db` is the post-drain
-      ;; state; pairing it with the pre-drain `doc-hash` shipped a payload
-      ;; whose state and hash described different moments. When a continuation
-      ;; mutates app-db and the ROOT tree reads that key, a streaming hydrate
+      ;; describe the POST-drain render state, NOT the pre-drain shell, when
+      ;; a continuation could have mutated app-db in between. `build-final-
+      ;; payload` reads the LIVE frame `app-db` AFTER every continuation has
+      ;; drained, so its `:rf/app-db` is the post-drain state; pairing it
+      ;; with the pre-drain `doc-hash` would ship a payload whose state and
+      ;; hash described different moments. When a continuation mutates
+      ;; app-db and the ROOT tree reads that key, a streaming hydrate
       ;; re-renders the root tree against the payload's post-drain `:rf/app-db`,
       ;; hashes it, and fires a spurious `:rf.ssr/hydration-mismatch` against
-      ;; the stale pre-drain hash (Spec 011 §Hydration equivalence rule). So we
-      ;; RE-RESOLVE the root view here — on this daemon thread, inside the
-      ;; `rf/with-frame` binding, AFTER the drain loop — and recompute the
-      ;; BODY-ONLY hash over the post-drain tree via the SAME
+      ;; a stale pre-drain hash (Spec 011 §Hydration equivalence rule).
+      ;;
+      ;; rf2-t72b1c — but re-resolving `root-view` is only SAFE/NEEDED when a
+      ;; continuation actually ran. `resolve-root-view`'s contract (rf2-6t36h)
+      ;; promises a fn-form `:root-view` runs EXACTLY ONCE per request — a
+      ;; non-idempotent fn (unsorted-map iteration order / gensym'd keys /
+      ;; time-of-day props) hashes two DIFFERENT trees across two calls,
+      ;; producing a spurious mismatch that has NOTHING to do with app-db.
+      ;; `continuations` here is the shell's ORIGINAL (pre-loop) registration
+      ;; list — non-empty iff at least one continuation drained. With ZERO
+      ;; continuations nothing ran between the shell render and this block
+      ;; that could have mutated app-db, so re-resolving would be a needless
+      ;; SECOND invocation with no corresponding benefit: reuse the pre-drain
+      ;; `doc-hash` verbatim (TRUE exactly-once). Only when `continuations`
+      ;; is non-empty do we pay the documented, unavoidable cost of a second
+      ;; invocation — re-resolve the root view here, on this daemon thread,
+      ;; inside the `rf/with-frame` binding, AFTER the drain loop — and
+      ;; recompute the BODY-ONLY hash over the post-drain tree via the SAME
       ;; `lifecycle/render-document-hash` mechanism. The streamed-shell
       ;; `data-rf-render-hash` marker keeps the PRE-drain `doc-hash` (it marks
       ;; the tree actually streamed in chunk 1); the two coincide when no
@@ -547,15 +572,22 @@
       ;; reads operate on the request frame.
       (let [final-payload
             (rf/with-frame frame-id
-              ;; rf2-1kqvbx — re-resolve the root view against the POST-drain
-              ;; frame state and recompute the BODY-ONLY hash over it (rf2-1oxjxk),
-              ;; so the payload's `:rf/render-hash` describes the SAME moment as
-              ;; its post-drain `:rf/app-db`. Falls back to the pre-drain
+              ;; rf2-1kqvbx / rf2-t72b1c — re-resolve the root view against
+              ;; the POST-drain frame state and recompute the BODY-ONLY hash
+              ;; over it (rf2-1oxjxk) ONLY when a continuation drained
+              ;; (`(seq continuations)` — the pre-loop registration list, see
+              ;; the comment above): that's the one case app-db could have
+              ;; changed since the shell render, so the payload's
+              ;; `:rf/render-hash` needs to describe the SAME moment as its
+              ;; post-drain `:rf/app-db`. With zero continuations, reuse the
+              ;; pre-drain `doc-hash` verbatim — `root-view` is invoked
+              ;; EXACTLY ONCE per request (rf2-6t36h), the common case for a
+              ;; page with no `:rf/suspense-boundary`. Also falls back to
               ;; `doc-hash` when no `:root-view` could be re-resolved
               ;; (defensive — `validate-construction-opts!` requires
               ;; `:root-view`, so this is belt-and-braces).
               (let [post-drain-hash
-                    (if root-view
+                    (if (and root-view (seq continuations))
                       (lifecycle/render-document-hash
                         (lifecycle/resolve-root-view root-view))
                       doc-hash)]

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_streaming_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_streaming_test.clj
@@ -1357,3 +1357,80 @@
                    shipped :rf/app-db (no spurious :rf.ssr/hydration-mismatch)")))
           (finally
             (rf/destroy-frame! cfid)))))))
+
+;; ===========================================================================
+;; rf2-t72b1c — a fn-form :root-view with ZERO continuations (no
+;; `:rf/suspense-boundary` in the tree — the common case) is invoked
+;; EXACTLY ONCE per streaming request, per the shared `resolve-root-view`
+;; contract (rf2-6t36h).
+;;
+;; Defect: `stream-handler` unconditionally re-resolved `:root-view` a
+;; SECOND time when building the final payload's `:rf/render-hash` (the
+;; rf2-1kqvbx fix above), even for a request that streamed no continuations
+;; at all — a case where app-db had zero opportunity to change between the
+;; shell render and the final-payload build, so the second invocation was
+;; needless. A non-idempotent fn-form root view (unsorted-map iteration
+;; order / gensym'd keys / time-of-day props — the very hazards
+;; `resolve-root-view`'s docstring names) then hashes two DIFFERENT trees,
+;; producing a spurious `:rf.ssr/hydration-mismatch` on a perfectly
+;; successful hydration.
+;;
+;; The fix scopes the rf2-1kqvbx re-resolution to requests where at least
+;; one continuation actually drained; a zero-continuation request reuses
+;; the pre-drain hash verbatim, restoring TRUE exactly-once invocation for
+;; the overwhelming majority of streaming requests.
+;; ===========================================================================
+
+(deftest stream-handler-fn-root-view-invoked-exactly-once-when-no-continuations
+  (testing "rf2-t72b1c: a 0-arity fn :root-view with no suspense boundary
+            fires exactly once per streaming request — the writer must NOT
+            re-resolve it a second time for the final-payload hash when no
+            continuation drained to give app-db a chance to change"
+    (let [call-count (atom 0)]
+      (rf/reg-event :rf.test/init-once
+        {:platforms #{:server}}
+        (fn [_ _] {}))
+      (rf/reg-view* :pages/stream-once
+        (fn [] [:div.page "once"]))
+      (let [handler  (ssr-ring/stream-handler
+                       {:initial-events [[:rf.test/init-once]]
+                        :root-view (fn []
+                                     (swap! call-count inc)
+                                     [:pages/stream-once])
+                        :payload   :rf.ssr.payload/whole-app-db})
+            response (handler {:uri "/" :request-method :get})
+            body     (drain-stream (:body response))]
+        (is (= 200 (:status response)))
+        (is (str/includes? body "once") "shell streamed the resolved page")
+        (is (= 1 @call-count)
+            "rf2-t72b1c: fn-form :root-view must be invoked exactly once per
+             streaming request when no continuation drains — the shell
+             render is the ONE call; the final-payload hash reuses that
+             SAME pre-drain result rather than re-resolving root-view")))))
+
+(deftest stream-handler-fn-root-view-non-idempotent-hashes-consistently-when-no-continuations
+  (testing "rf2-t72b1c: a non-idempotent fn-form :root-view (a different
+            tree on every call) still produces a streamed marker hash that
+            matches the final payload's :rf/render-hash when the stream has
+            no continuations — the single invocation covers BOTH channels"
+    (rf/reg-event :rf.test/init-noni
+      {:platforms #{:server}}
+      (fn [_ _] {}))
+    (rf/reg-view* :pages/stream-noni
+      (fn [n] [:div {:data-call n} "noni"]))
+    (let [counter   (atom 0)
+          handler   (ssr-ring/stream-handler
+                      {:initial-events [[:rf.test/init-noni]]
+                       :root-view (fn [] [:pages/stream-noni (swap! counter inc)])
+                       :payload   :rf.ssr.payload/whole-app-db})
+          response  (handler {:uri "/" :request-method :get})
+          body      (drain-stream (:body response))
+          wire-hash (second (re-find #"data-rf-render-hash=\"([0-9a-f]{8})\"" body))
+          payload-hash (stream-payload-hash body)]
+      (is (= 200 (:status response)))
+      (is (some? wire-hash) "streamed shell carries the render-hash marker")
+      (is (some? payload-hash) "final payload carries :rf/render-hash")
+      (is (= wire-hash payload-hash)
+          "rf2-t72b1c: with no continuations the streamed marker and the
+           final payload hash describe the SAME single invocation — a
+           non-idempotent root-view fn does not desync them"))))

--- a/spec/011-SSR.md
+++ b/spec/011-SSR.md
@@ -1081,6 +1081,14 @@ The streaming surface composes from three late-bind hooks (per [Conventions §La
 
 Host adapters call these three hooks in order; the streaming runtime owns the walker, the registry, and the delta computation. The Ring adapter wires them via `re-frame.ssr.ring.streaming/stream-handler` (per [§Cross-references](#cross-references)).
 
+#### Fn-form `:root-view` invocation count under streaming (rf2-t72b1c)
+
+A fn-form `:root-view` is not guaranteed to be idempotent (unsorted-map iteration order, gensym'd keys, time-of-day props can all vary between calls); the non-streaming handler resolves it **exactly once** per request and reuses that single result for both the wire HTML and the payload's `:rf/render-hash` (rf2-6t36h). A second, silent invocation would hash two structurally-different trees and fire a spurious `:rf.ssr/hydration-mismatch` unrelated to any real state change.
+
+Streaming host adapters MUST honour the same exactly-once invocation for a request whose shell contains **zero** `:rf/suspense-boundary` continuations — the common case — since nothing runs between the shell render and the final-payload build that could change reactive state in between; the pre-drain render-tree hash is reused verbatim for the final payload.
+
+A request with **at least one** continuation is the sole exception: the final payload ships the live post-drain `app-db` (`:ssr.streaming/build-final-payload` reads it after every continuation has drained), so when a continuation mutates `app-db` and the root tree reads the mutated key, the pre-drain hash and the shipped post-drain state would describe different moments — itself a violation of the [hydration equivalence rule](#hydration-equivalence-rule-canonical). Host adapters therefore re-resolve `:root-view` a second time in that case, trading the narrower exactly-once guarantee for a correct post-drain `:rf/render-hash`. The two hashes coincide whenever no continuation mutates a root-read key.
+
 #### Writer concurrency model — one daemon thread per in-flight stream
 
 The chunked-response body is a `PipedInputStream`/`PipedOutputStream` pair: the Ring server reads from the input side while a **writer runs on its own thread** pumping shell → continuations → final-payload → close into the output side. The CLJS-JVM reference (`re-frame.ssr.ring.streaming/stream-handler`) spawns **one raw `java.lang.Thread` per in-flight streamed request** — there is intentionally **no framework-imposed thread pool, executor, or in-flight cap**. The concurrency posture is documented here as a deliberate v1 choice:


### PR DESCRIPTION
## Summary

`stream-handler`'s writer thread (`re-frame.ssr.ring.streaming/run-streaming-writer!`) unconditionally re-resolved a fn-form `:root-view` a **second** time when building the final payload's `:rf/render-hash` — even for the common case of a streaming request with **zero** `:rf/suspense-boundary` continuations. A non-idempotent 0-arity root-view fn (unsorted-map iteration order, gensym'd keys, time-of-day props — the exact hazards `resolve-root-view`'s docstring names) then hashes two structurally-different trees between the shell render and the final payload, firing a spurious `:rf.ssr/hydration-mismatch` on an otherwise-successful hydration — silently violating `resolve-root-view`'s documented exactly-once contract (rf2-6t36h).

**Fix:** scope the re-resolution to requests where at least one continuation actually drained (`(seq continuations)`, the shell's pre-loop registration list) — the *only* case app-db could have changed between the pre-drain shell render and the post-drain final-payload build (rf2-1kqvbx's existing post-drain-hash requirement). A zero-continuation request — the overwhelming majority of streaming SSR pages — now reuses the pre-drain `doc-hash` verbatim, invoking `:root-view` **exactly once**, matching the non-streaming handler's contract.

This is a one-line behavioural change (`(if root-view ...)` → `(if (and root-view (seq continuations)) ...)`) plus updated rationale comments/docstrings and a Spec 011 note. The narrower rf2-1kqvbx behaviour (re-resolve when a continuation drained, to keep the payload's hash describing the same post-drain moment as its shipped `app-db`) is preserved unchanged — its existing pinned regression test (`stream-handler-final-hash-reflects-post-drain-state`) still passes untouched.

## Changes

- `implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj` — gate the post-drain `root-view` re-resolution on `(seq continuations)`; update the `render-streaming-shell!` docstring and the final-payload rationale comments accordingly.
- `implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj` — cross-reference note on `resolve-root-view`'s docstring pointing at the streaming nuance.
- `implementation/ssr-ring/test/re_frame/ssr/ring_streaming_test.clj` — two new regression tests: exactly-once call-count for a zero-continuation streaming request, and wire/payload hash consistency for a non-idempotent root-view fn with no continuations.
- `spec/011-SSR.md` — new subsection documenting the fn-form `:root-view` invocation-count contract under streaming (exactly-once by default; re-resolved once more only when a continuation drained).

## Quality gates

- `clojure -M:test` in `implementation/ssr-ring` — 162 tests, 768 assertions, 0 failures, 0 errors (includes the 2 new regression tests).
- Confirmed RED pre-fix: temporarily reverted the source fix (keeping the new tests) and reran — both new tests failed as expected (`call-count` 2 instead of 1; wire hash `75efe07c` ≠ payload hash `75e924b7`). Restored the fix and reran to confirm GREEN.
- `clojure -M:test` in `implementation/ssr` (unmodified sibling artefact, sanity check) — 366 tests, 1472 assertions, 0 failures, 0 errors.
- `npm run test:cljs` from `implementation/` — 8122 tests, 37203 assertions, 0 failures, 0 errors.

## Test plan

- [x] New regression test pins exactly-once invocation for a streaming request with no suspense boundaries.
- [x] New regression test pins wire/payload hash consistency for a non-idempotent root-view fn with no suspense boundaries.
- [x] Existing rf2-1kqvbx post-drain-hash regression test (continuation mutates a root-read key) still passes unchanged.
- [x] Full ssr-ring + ssr JVM suites and the CLJS gate are green.