### PR TITLE
fix(resources): normalize lone vector tags in invalidation descriptors (rf2-ypgayg)

### DIFF
--- a/implementation/resources/src/re_frame/resources/mutation_runtime.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_runtime.cljc
@@ -1030,12 +1030,18 @@
   `{:scope <scope-or-same-marker> :tags #{…} :cross-scope? bool
   :refetch-populated? bool}`, validating fail-closed. `:scope` defaults to
   `:rf.scope/same` (Spec 016 §Scoped invalidation descriptors). `:tags` must
-  be a non-nil collection of tags; the boolean flags default false. The
-  `:scope` VALUE is NOT canonicalized here (a `:rf.scope/same` marker and a
-  `{:from-db …}` reference are not concrete scopes yet) — the events layer
-  resolves + canonicalizes the concrete scope at settle time. Returns the
-  canonical descriptor map; throws `:rf.error/mutation-invalid-invalidation`
-  on a non-map descriptor or a non-collection `:tags`."
+  be a non-nil collection of tags; the boolean flags default false. `:tags`
+  is lowered through the shared `state/normalize-tag-set` (the SAME
+  normalizer the bare tag-set shorthand and the direct
+  `:rf.resource/invalidate-tags` `:tags` use), so a LONE vector tag written
+  directly (`{:tags [:article slug]}`) is the ONE tag `#{[:article slug]}`,
+  NOT a scalar set of its elements `#{:article slug}` (a naive `(set tags)`
+  silently matches nothing — rf2-ypgayg). The `:scope` VALUE is NOT
+  canonicalized here (a `:rf.scope/same` marker and a `{:from-db …}`
+  reference are not concrete scopes yet) — the events layer resolves +
+  canonicalizes the concrete scope at settle time. Returns the canonical
+  descriptor map; throws `:rf.error/mutation-invalid-invalidation` on a
+  non-map descriptor or a non-collection `:tags`."
   [descriptor raw where]
   (when-not (map? descriptor)
     (throw (invalidation-descriptor-error
@@ -1054,7 +1060,7 @@
                     "descriptors.")
                raw {:descriptor (pr-str descriptor) :tags (pr-str tags)})))
     {:scope              (if (contains? descriptor :scope) scope same-scope-marker)
-     :tags               (set tags)
+     :tags               (state/normalize-tag-set tags)
      :cross-scope?       (boolean cross-scope?)
      :refetch-populated? (boolean refetch-populated?)}))
 

--- a/implementation/resources/test/re_frame/resources_invalidation_descriptors_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_invalidation_descriptors_cljs_test.cljc
@@ -664,6 +664,56 @@
         "the article was marked stale by the lone-vector :tags")))
 
 ;; ===========================================================================
+;; rf2-ypgayg — the DESCRIPTOR-MAP arm missed the shared lone-vector-tag fix
+;; ===========================================================================
+
+(deftest lone-vector-tag-descriptor-map-normalizes-to-one-tag
+  ;; rf2-ru73k6 F1 fixed the bare tag-set shorthand and the direct
+  ;; `:rf.resource/invalidate-tags` `:tags`, but `normalize-one-descriptor`
+  ;; (the per-target DESCRIPTOR MAP arm) still lowered `:tags` through a naive
+  ;; `(set tags)` — a lone vector tag `{:tags [:article "w"]}` split into the
+  ;; scalar set `#{:article "w"}`, silently matching nothing. It must route
+  ;; through the SAME `state/normalize-tag-set` normalizer.
+  (testing "a single descriptor map with a lone vector :tags normalizes to one tag"
+    (let [[d & more] (mstate/normalize-invalidation-descriptors
+                       {:tags [:article "w"]} 'test)]
+      (is (nil? more))
+      (is (= :rf.scope/same (:scope d)))
+      (is (= #{[:article "w"]} (:tags d))
+          "the lone tag is the single tag, NOT #{:article \"w\"}")))
+  (testing "a vector of descriptor maps also normalizes each lone vector :tags"
+    (let [[d1 d2] (mstate/normalize-invalidation-descriptors
+                    [{:scope :rf.scope/global :tags [:article "w"]}
+                     {:tags [:article-list]}] 'test)]
+      (is (= #{[:article "w"]} (:tags d1)))
+      (is (= #{[:article-list]} (:tags d2))))))
+
+(deftest lone-vector-tag-descriptor-map-matches-end-to-end
+  ;; The adversarial end-to-end for the descriptor-map arm: a mutation whose
+  ;; :invalidates returns a DESCRIPTOR MAP `{:tags [:article slug]}` — the
+  ;; per-target form, not the bare shorthand — must still invalidate the
+  ;; entry carrying that lone vector tag.
+  (reg-article-resource!)
+  (rf/reg-mutation :m/save-descriptor
+    {:scope :rf.scope/global
+     :params-schema [:map [:slug :string]]
+     ;; a descriptor MAP whose :tags is a LONE vector tag written directly
+     ;; (not wrapped in a set) — the bug this bead fixes.
+     :invalidates (fn [{:keys [slug]} _result] {:tags [:article slug]})}
+    (fn [{:keys [slug]} _] {:request {:method :put :url (str "/a/" slug)}}))
+  (rf/dispatch-sync [:rf.resource/ensure {:resource :r/article :scope :rf.scope/global
+                                          :params {:slug "w"} :owner [:v :a]}])
+  (reply-success! @last-managed-args {:title "old"})
+  (rf/dispatch-sync [:rf.resource/release-owner {:resource :r/article :scope :rf.scope/global
+                                                 :params {:slug "w"} :owner [:v :a]}])
+  (reset! last-managed-args nil)
+  (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/save-descriptor :params {:slug "w"} :instance :lv2}])
+  (reply-success! @last-managed-args {:title "new"})
+  (testing "the descriptor-map lone vector tag matched + invalidated the [:article \"w\"] entry"
+    (is (some? (:invalidated-at (entry global-key)))
+        "the article carrying tag [:article \"w\"] was marked stale")))
+
+;; ===========================================================================
 ;; rf2-fi6tda.4 finding 3 — pin the per-pass :rf.resource/invalidated EP fields
 ;; ===========================================================================
 


### PR DESCRIPTION
## Summary

`normalize-one-descriptor` (the per-target DESCRIPTOR MAP arm of `:invalidates` normalization) lowered a descriptor's `:tags` through a naive `(set tags)`. A lone vector tag written directly — `{:tags [:article slug]}` — split into the scalar set `#{:article slug}` instead of the intended `#{[:article slug]}`, so the invalidation silently matched nothing.

rf2-ru73k6 F1 already fixed this for the bare tag-set shorthand and the direct `:rf.resource/invalidate-tags` event `:tags`, both routed through the shared `state/normalize-tag-set`. This bead closes the remaining gap: the descriptor-map arm now routes through the same normalizer, so a lone vector tag has one meaning across every `:invalidates` input form.

- `implementation/resources/src/re_frame/resources/mutation_runtime.cljc`: `normalize-one-descriptor`'s `:tags (set tags)` → `:tags (state/normalize-tag-set tags)`; docstring updated to document the normalization + cross-reference rf2-ypgayg.
- `implementation/resources/test/re_frame/resources_invalidation_descriptors_cljs_test.cljc`: new regression coverage — a pure test pinning descriptor-map (and vector-of-descriptor-maps) lone-vector-tag normalization, plus an end-to-end mutation test confirming a lone-vector-tag descriptor invalidates the matching cache entry.

## Quality gates

- New regression tests confirmed RED against the pre-fix `(set tags)` (4 failing assertions: scalar-split `#{"w" :article}` instead of `#{[:article "w"]}`, and the end-to-end entry never marked stale), then GREEN after the fix.
- `clojure -M:test` from `implementation/resources` — 604 tests, 6092 assertions, 0 failures, 0 errors.
- `npm run test:cljs` from `implementation` — 8125 tests, 37229 assertions, 0 failures, 0 errors.

## Risk

Low — single-line normalization fix on an already-shared, already-tested normalizer; scoped to the descriptor-map `:invalidates` arm only. No spec change (Spec 016 semantics for a tag/tag-set were already normative; this is a code-conformance fix).