### PR TITLE
fix(story): apply inherited classification to registered extended variants (rf2-lsr95i)

### DIFF
--- a/tools/story/src/re_frame/story/frames.cljc
+++ b/tools/story/src/re_frame/story/frames.cljc
@@ -638,11 +638,16 @@
   the frame exists (`make-frame` for `allocate!`, `rf/reg-frame` for
   `allocate-inline!`) and BEFORE the lifecycle / init events, so a
   classified path is already redacted in any trace the run's setup emits.
-  No-op when `v-body` declares no app-db classification. Shared by both
-  `allocate!` (a registered variant's own body) and `allocate-inline!`
-  (rf2-cmjly3 finding 12 — an inline plan's `[:world :sensitive]` /
-  `[:world :large]`, threaded through by the caller since an inline run
-  has no registered variant body for this fn to read).
+  No-op when `classification` declares no app-db classification. Shared by
+  both `allocate!` (the caller threads the ALREADY-COMPILED plan's
+  `[:world :sensitive]` / `[:world :large]` — rf2-lsr95i, see `allocate!`)
+  and `allocate-inline!` (rf2-cmjly3 finding 12 — an inline plan's
+  `[:world :sensitive]` / `[:world :large]`, threaded through the same
+  way since an inline run has no registered variant body). Both callers
+  hand this fn the plan's EFFECTIVE (`:extends`-merged) classification,
+  never the raw un-merged variant body — a registered variant that only
+  `:extends`es a classified parent, declaring none of its own, still
+  inherits + redacts the parent's paths.
 
   EP-0025 fail-loud: the lowered effects are validated through the SAME
   pure validator the router's FINAL-effects commit-plane boundary uses
@@ -667,8 +672,8 @@
   class: every other throw site between `rf/reg-frame` and the
   `allocated?` flip (`loaders/mount!` / `apply-frame-setup!`'s `:init`
   events) already shares it."
-  [subject-id v-body]
-  (let [effects (->classification-effects v-body)]
+  [subject-id classification]
+  (let [effects (->classification-effects classification)]
     (when (seq effects)
       (when-let [defect (elision/classification-effect-defect effects)]
         (rf-error/throw-error!
@@ -711,91 +716,114 @@
   `reg-frame`'s surgical-update path — config is replaced but the
   app-db / sub-cache are preserved. That's the wrong shape for a
   story-runtime which expects a fresh app-db; the caller (`runtime/
-  reset-variant`) destroys first."
-  [variant-id decorator-stack]
-  (when config/enabled?
-    (install-canonical-frame-events!)
-    (let [fx-stack       (decorators/fx-overrides-map (:fx-override decorator-stack))
-          fx-overrides   (register-fx-overrides! fx-stack)
-          ;; Inline the variant-body lookup (`variant-body` is defined
-          ;; lower in this ns) — go through the registrar directly so
-          ;; the events-only classification doesn't depend
-          ;; on the file's declaration order.
-          v-body         (registrar/handler-meta :variant variant-id)
-          ;; EP-0026 §Default Image / §Layered Resolution — the FULL `:images`
-          ;; vector this variant frame is created with:
-          ;;
-          ;;   [<story-images…> <variant-images…> runtime-image]   (later wins)
-          ;;
-          ;; A Story declares its APP image ONCE on the parent story body's
-          ;; `:images`; every variant inherits it and MAY layer its own
-          ;; `:images` (a BEHAVIOUR variant overriding specific `[kind id]`s).
-          ;; The canonical Story RUNTIME IMAGE is composed LAST so the Story
-          ;; machinery (lifecycle machine, `:rf.assert/*` handlers, fx-stub
-          ;; redirects, runtime helpers, toolbar cofx) is always live in the
-          ;; frame and never shadowed out by an app image. See
-          ;; `compose-variant-images`.
-          ;;
-          ;; `nil` when NO app image resolves anywhere (none on the variant,
-          ;; none on its story): the absence-is-DEFAULT signal — the frame is
-          ;; created with NO `:images`, so `rf/make-frame` resolves the EP-0026
-          ;; DEFAULT image (the whole-store projection) for the convenient
-          ;; single-app / standalone-testbed case.
-          composed-imgs  (compose-variant-images variant-id (:images v-body))
-          ;; The variant's own behaviour-variant image ids (for frame-meta
-          ;; tooling read-back) — the AUTHORED app images, NOT the
-          ;; library-composed runtime image (a library contract, not an
-          ;; author-declared behaviour set).
-          author-images  (into (vec (story-images variant-id))
-                                (:images v-body))
-          ;; Thread the variant's EP-0015 frame-owned
-          ;; `:sensitive` / `:large` classification onto the reg-frame config,
-          ;; plus the image ids (for frame-meta tooling read-back).
-          config-map     (variant-frame-config
-                           variant-id fx-overrides
-                           (assoc (select-keys v-body [:sensitive :large])
-                                  :image-ids (keep image-id author-images)))
-          events-only?   (loaders/events-only-variant? v-body decorator-stack)]
-      ;; EP-0023 §Stories / §Frame-derived live registration resolution
-      ;; — the frame carries the resolved, sealed image GENERATION so
-      ;; `process-event!`'s `call-with-frame-resolution` routes the whole cascade
-      ;; (event-handler lookup, cofx, fx) for any `{:frame variant-id}` dispatch
-      ;; through THIS frame's image generation. The runtime image keeps the Story
-      ;; machinery live in that generation; an app image scopes the frame to its
-      ;; own registrations so two variants reuse the SAME global id with
-      ;; DIFFERENT meanings ("behavior variant -> image", EP-0023 §Stories). When
-      ;; NO app image resolves, the frame resolves the EP-0026 DEFAULT image (the
-      ;; whole-store projection) — absence-is-default. The framework's `rf/image`
-      ;; / assembly own all validation — a malformed image or a zero-match
-      ;; `:select-ns :include` glob FAILS LOUDLY here at frame creation.
-      ;;
-      ;; EP-0024 — ONE `make-frame` call. The unified constructor accepts
-      ;; BOTH the image-selection opts AND the full record-config in one
-      ;; call over the one registry. `:images` is supplied only when an app
-      ;; image resolves (absent ⇒ the default image generation).
-      (rf/make-frame (cond-> {:id variant-id}
-                       (seq composed-imgs) (assoc :images composed-imgs)
-                       :always             (merge config-map)))
-      ;; EP-0025: apply the variant's durable app-db `:sensitive` / `:large`
-      ;; classification as commit-plane classification effects into the frame's
-      ;; elision registry NOW — after the container exists, BEFORE the
-      ;; lifecycle / init / frame-setup events run, so a classified path is
-      ;; already redacted in any trace the variant's setup emits. (The frame
-      ;; annotation that previously rode `reg-frame` is removed.)
-      (apply-variant-classification! variant-id v-body)
-      ;; Drive the lifecycle by variant shape. Events-only
-      ;; variants jump straight to :ready (no skeleton ever shows);
-      ;; everything else takes the classical four-phase route through
-      ;; :mounting → :loading → :ready.
-      (if events-only?
-        (loaders/mount-ready! variant-id)
-        (loaders/mount!       variant-id))
-      ;; Apply :frame-setup decorators (their :init events + :app-db-patch).
-      ;; By construction the events-only path has no :frame-setup
-      ;; decorators (that's part of the events-only? predicate), so this
-      ;; is a no-op on the fast-path branch.
-      (apply-frame-setup! variant-id (:frame-setup decorator-stack))
-      variant-id)))
+  reset-variant`) destroys first.
+
+  `classification` (optional, 3-arity; rf2-lsr95i) is the variant's
+  EFFECTIVE `:sensitive`/`:large` app-db classification — a map with
+  `:sensitive`/`:large` keys, already `:extends`-merged root→child. The
+  runtime (`run-phase-0!`) threads its ALREADY-COMPILED plan's `[:world
+  :sensitive]` / `[:world :large]` here (`plan/variant-plan` folds
+  `:sensitive`/`:large` through the `:extends` chain via `context-keys`
+  — the SAME merge `allocate-inline!` already receives for an inline
+  plan run, rf2-cmjly3 finding 12). Omitted (2-arity — direct/test
+  callers with no compiled plan on hand) falls back to the raw variant
+  body's OWN `:sensitive`/`:large`, i.e. no `:extends` inheritance; that
+  is only correct for a variant with no `:extends` parent, which is what
+  every such caller in this codebase exercises. Before this fn threaded
+  a classification arg, `allocate!` ALWAYS read the raw un-merged body —
+  so a variant that only `:extends`ed a classified parent, declaring no
+  classification itself, silently dropped the parent's redaction."
+  ([variant-id decorator-stack] (allocate! variant-id decorator-stack nil))
+  ([variant-id decorator-stack classification]
+   (when config/enabled?
+     (install-canonical-frame-events!)
+     (let [fx-stack       (decorators/fx-overrides-map (:fx-override decorator-stack))
+           fx-overrides   (register-fx-overrides! fx-stack)
+           ;; Inline the variant-body lookup (`variant-body` is defined
+           ;; lower in this ns) — go through the registrar directly so
+           ;; the events-only classification doesn't depend
+           ;; on the file's declaration order.
+           v-body         (registrar/handler-meta :variant variant-id)
+           ;; EP-0026 §Default Image / §Layered Resolution — the FULL `:images`
+           ;; vector this variant frame is created with:
+           ;;
+           ;;   [<story-images…> <variant-images…> runtime-image]   (later wins)
+           ;;
+           ;; A Story declares its APP image ONCE on the parent story body's
+           ;; `:images`; every variant inherits it and MAY layer its own
+           ;; `:images` (a BEHAVIOUR variant overriding specific `[kind id]`s).
+           ;; The canonical Story RUNTIME IMAGE is composed LAST so the Story
+           ;; machinery (lifecycle machine, `:rf.assert/*` handlers, fx-stub
+           ;; redirects, runtime helpers, toolbar cofx) is always live in the
+           ;; frame and never shadowed out by an app image. See
+           ;; `compose-variant-images`.
+           ;;
+           ;; `nil` when NO app image resolves anywhere (none on the variant,
+           ;; none on its story): the absence-is-DEFAULT signal — the frame is
+           ;; created with NO `:images`, so `rf/make-frame` resolves the EP-0026
+           ;; DEFAULT image (the whole-store projection) for the convenient
+           ;; single-app / standalone-testbed case.
+           composed-imgs  (compose-variant-images variant-id (:images v-body))
+           ;; The variant's own behaviour-variant image ids (for frame-meta
+           ;; tooling read-back) — the AUTHORED app images, NOT the
+           ;; library-composed runtime image (a library contract, not an
+           ;; author-declared behaviour set).
+           author-images  (into (vec (story-images variant-id))
+                                 (:images v-body))
+           ;; Thread the variant's EP-0015 frame-owned
+           ;; `:sensitive` / `:large` classification onto the reg-frame config,
+           ;; plus the image ids (for frame-meta tooling read-back).
+           config-map     (variant-frame-config
+                            variant-id fx-overrides
+                            (assoc (select-keys v-body [:sensitive :large])
+                                   :image-ids (keep image-id author-images)))
+           events-only?   (loaders/events-only-variant? v-body decorator-stack)]
+       ;; EP-0023 §Stories / §Frame-derived live registration resolution
+       ;; — the frame carries the resolved, sealed image GENERATION so
+       ;; `process-event!`'s `call-with-frame-resolution` routes the whole cascade
+       ;; (event-handler lookup, cofx, fx) for any `{:frame variant-id}` dispatch
+       ;; through THIS frame's image generation. The runtime image keeps the Story
+       ;; machinery live in that generation; an app image scopes the frame to its
+       ;; own registrations so two variants reuse the SAME global id with
+       ;; DIFFERENT meanings ("behavior variant -> image", EP-0023 §Stories). When
+       ;; NO app image resolves, the frame resolves the EP-0026 DEFAULT image (the
+       ;; whole-store projection) — absence-is-default. The framework's `rf/image`
+       ;; / assembly own all validation — a malformed image or a zero-match
+       ;; `:select-ns :include` glob FAILS LOUDLY here at frame creation.
+       ;;
+       ;; EP-0024 — ONE `make-frame` call. The unified constructor accepts
+       ;; BOTH the image-selection opts AND the full record-config in one
+       ;; call over the one registry. `:images` is supplied only when an app
+       ;; image resolves (absent ⇒ the default image generation).
+       (rf/make-frame (cond-> {:id variant-id}
+                        (seq composed-imgs) (assoc :images composed-imgs)
+                        :always             (merge config-map)))
+       ;; EP-0025: apply the variant's durable app-db `:sensitive` / `:large`
+       ;; classification as commit-plane classification effects into the frame's
+       ;; elision registry NOW — after the container exists, BEFORE the
+       ;; lifecycle / init / frame-setup events run, so a classified path is
+       ;; already redacted in any trace the variant's setup emits. (The frame
+       ;; annotation that previously rode `reg-frame` is removed.)
+       ;;
+       ;; rf2-lsr95i: prefer the caller-supplied EFFECTIVE (`:extends`-merged)
+       ;; classification; fall back to the raw body's own `:sensitive`/`:large`
+       ;; only when no `classification` was threaded (the 2-arity direct/test
+       ;; callers below `run-phase-0!`, none of which exercise `:extends`).
+       (apply-variant-classification!
+         variant-id (or classification (select-keys v-body [:sensitive :large])))
+       ;; Drive the lifecycle by variant shape. Events-only
+       ;; variants jump straight to :ready (no skeleton ever shows);
+       ;; everything else takes the classical four-phase route through
+       ;; :mounting → :loading → :ready.
+       (if events-only?
+         (loaders/mount-ready! variant-id)
+         (loaders/mount!       variant-id))
+       ;; Apply :frame-setup decorators (their :init events + :app-db-patch).
+       ;; By construction the events-only path has no :frame-setup
+       ;; decorators (that's part of the events-only? predicate), so this
+       ;; is a no-op on the fast-path branch.
+       (apply-frame-setup! variant-id (:frame-setup decorator-stack))
+       variant-id))))
 
 ;; ---- inline-plan allocation ----------------------------------------------
 ;;

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -875,10 +875,20 @@
   projected tape to just THIS run's records, not the whole frame's
   accumulated history — otherwise a second `run-variant` on the same id
   would project evidence (`:schema-violations` / `:warnings` / `:effects`
-  / `:narrative`) polluted with the FIRST run's stale records."
-  [{:keys [variant-id decorator-stack] :as ctx}]
+  / `:narrative`) polluted with the FIRST run's stale records.
+
+  rf2-lsr95i: thread the ALREADY-COMPILED plan's `[:world :sensitive]` /
+  `[:world :large]` — root→child `:extends`-merged by `plan/variant-plan`
+  (`context-keys`) — into `frames/allocate!`'s `classification` arg,
+  mirroring `run-inline-phase-0!`'s `allocate-inline!` call below. Before
+  this, `allocate!` read a variant's OWN raw (un-merged) body for its
+  classification, so a variant that only `:extends`ed a `:sensitive`/
+  `:large` parent — declaring none itself — silently dropped the
+  parent's redaction at wire egress."
+  [{:keys [variant-id decorator-stack plan] :as ctx}]
   (ensure-fresh-frame! variant-id)
-  (frames/allocate! variant-id decorator-stack)
+  (frames/allocate! variant-id decorator-stack
+                     (select-keys (:world plan) [:sensitive :large]))
   (swap! play/pending-exceptions assoc variant-id [])
   (play/install-trace-listener! variant-id)
   (assoc ctx :epoch-baseline (runner-events/last-epoch-id variant-id)))

--- a/tools/story/test/re_frame/story_runtime_test.clj
+++ b/tools/story/test/re_frame/story_runtime_test.clj
@@ -1795,6 +1795,78 @@
             "the malformed path did not land in the elision registry (no partial commit)")))
     (story/destroy-variant! :story.classif/bad)))
 
+;; ---- rf2-lsr95i: registered `:extends` inherits `:sensitive`/`:large` -----
+;;
+;; The plan compiler (`plan.cljc` `context-keys`) already folds a variant's
+;; `:sensitive` / `:large` root→child through its `:extends` chain into the
+;; compiled plan's `[:world :sensitive]` / `[:world :large]` — the SAME merge
+;; `[:world :decorators]` / `[:world :setup]` get (`extends-inherits-
+;; decorators-when-child-declares-none` above documents the sibling case for
+;; decorators). But `frames/allocate!` ignored that compiled plan for
+;; classification and re-read a variant's RAW (un-merged) body instead — so a
+;; child that only `:extends`ed a `:sensitive`/`:large` parent, declaring no
+;; classification of its own, silently dropped the parent's redaction: the
+;; inherited secret rode into the child frame's wire trace unredacted (a
+;; privacy gap). The fix threads the compiled plan's `[:world :sensitive]` /
+;; `[:world :large]` into `allocate!`, mirroring how `allocate-inline!`
+;; already receives it for an inline plan (rf2-cmjly3 finding 12, below).
+
+(deftest extends-inherits-sensitive-classification-when-child-declares-none
+  (testing "rf2-lsr95i — a registered variant that only `:extends`es a
+            `:sensitive`-classified parent, declaring no classification of
+            its own, still redacts the inherited path at wire egress"
+    (rf/reg-event :auth/login-lsr95i
+      (fn [{:keys [db]} _] {:db (assoc-in db [:auth :token] "BEARER-secret-lsr95i")}))
+    (story/reg-variant :story.classif-ext.lsr95i/parent
+      {:events    [[:auth/login-lsr95i]]
+       :sensitive {:app-db [[:auth :token]]}})
+    ;; The child ONLY `:extends`es the parent — no `:events`, no
+    ;; `:sensitive` of its own. Setup APPENDS root→child (§Merge rules), so
+    ;; the bare child inherits the parent's `:events` and runs the SAME
+    ;; login step under its own frame; the classification must inherit
+    ;; identically (both are `context-keys` in the plan compiler).
+    (story/reg-variant :story.classif-ext.lsr95i/child
+      {:extends :story.classif-ext.lsr95i/parent})
+    (let [r (async/deref-blocking (story/run-variant :story.classif-ext.lsr95i/child) 5000)]
+      (is (= :ready (:lifecycle r))
+          "the extended child runs to :ready")
+      (is (= "BEARER-secret-lsr95i"
+             (get-in (rf/app-db-value :story.classif-ext.lsr95i/child) [:auth :token]))
+          "the inherited :events wrote the raw secret into the child's app-db")
+      (let [walked (rf/elide-wire-value
+                     (rf/app-db-value :story.classif-ext.lsr95i/child)
+                     {:frame :story.classif-ext.lsr95i/child})]
+        (is (= :rf/redacted (get-in walked [:auth :token]))
+            "the PARENT's :sensitive declaration, inherited through a bare
+             :extends, redacts the child frame's path at egress — RED
+             against the pre-fix `allocate!`, which read the child's raw
+             (un-merged) body and saw no :sensitive declaration at all")))
+    (story/destroy-variant! :story.classif-ext.lsr95i/child)
+    (story/destroy-variant! :story.classif-ext.lsr95i/parent)))
+
+(deftest extends-child-own-classification-still-applies
+  (testing "rf2-lsr95i companion — a child that DECLARES its own
+            `:sensitive` axis on an `:extends`ed variant still redacts (the
+            plan-threaded fix must not regress the non-inherited case)"
+    (rf/reg-event :docs/upload-lsr95i
+      (fn [{:keys [db]} _] {:db (assoc-in db [:docs :blob] "large-blob-lsr95i")}))
+    (story/reg-variant :story.classif-ext.lsr95i/base
+      {:events [[:docs/upload-lsr95i]]})
+    (story/reg-variant :story.classif-ext.lsr95i/override
+      {:extends :story.classif-ext.lsr95i/base
+       :large   {:app-db [[:docs :blob]]}})
+    (let [r (async/deref-blocking (story/run-variant :story.classif-ext.lsr95i/override) 5000)]
+      (is (= :ready (:lifecycle r)))
+      (let [walked (rf/elide-wire-value
+                     (rf/app-db-value :story.classif-ext.lsr95i/override)
+                     {:frame :story.classif-ext.lsr95i/override})
+            elided (get-in walked [:docs :blob])]
+        (is (and (map? elided) (contains? elided :rf.size/large-elided))
+            "the child's OWN :large declaration on an :extends'd variant
+             still elides at egress")))
+    (story/destroy-variant! :story.classif-ext.lsr95i/override)
+    (story/destroy-variant! :story.classif-ext.lsr95i/base)))
+
 ;; ---- rf2-cmjly3 finding 12: inline-plan :sensitive/:large classification --
 ;;
 ;; Prior to the fix, `allocate-inline!` never called


### PR DESCRIPTION
## Summary

- `frames/allocate!` read a registered variant's raw (un-merged) body for its `:sensitive`/`:large` classification — so a variant that only `:extends`ed a classified parent, declaring no classification of its own, silently dropped the parent's redaction at wire egress (a privacy gap).
- The plan compiler (`plan.cljc` `context-keys`) already folds `:sensitive`/`:large` root→child through the `:extends` chain into the compiled plan's `[:world :sensitive]` / `[:world :large]` — the same merge `[:world :decorators]` / `[:world :setup]` already get. `allocate!` just wasn't consuming it.
- Fix: `run-phase-0!` (`runtime.cljc`) now threads the already-compiled plan's `(select-keys (:world plan) [:sensitive :large])` into `frames/allocate!`'s new optional `classification` arg, mirroring how `allocate-inline!` already receives it for an inline plan run (rf2-cmjly3 finding 12). `allocate!`'s 2-arity (direct/test callers with no compiled plan, none of which exercise `:extends`) falls back to the raw body's own classification, preserving prior behaviour for the no-`:extends` case.

## Fix

- `tools/story/src/re_frame/story/frames.cljc`: `allocate!` gains an optional 3rd `classification` arg (defaults to the raw body's own `:sensitive`/`:large` when omitted); `apply-variant-classification!` now takes an already-resolved classification map from both callers instead of a raw variant body.
- `tools/story/src/re_frame/story/runtime.cljc`: `run-phase-0!` threads `(select-keys (:world plan) [:sensitive :large])` into `frames/allocate!`.

## Regression test

Added to `tools/story/test/re_frame/story_runtime_test.clj`:
- `extends-inherits-sensitive-classification-when-child-declares-none` — a parent declares `:sensitive {:app-db [[:auth :token]]}`; a child only `:extends`es it (no `:events`, no `:sensitive` of its own — inherits the parent's login step via setup-append). Asserts the child's frame redacts `[:auth :token]` to `:rf/redacted` at wire egress. Verified RED against pre-fix `allocate!` (raw value leaked instead of `:rf/redacted`).
- `extends-child-own-classification-still-applies` — companion case: a child that `:extends`es a plain parent but declares its own `:large` axis still elides at egress (guards against regressing the non-inherited case).

## Quality gates

- `tools/story` `clojure -M:test` — 1746 tests, 6444 assertions, 0 failures, 0 errors (post-fix, post-rebase onto latest `origin/main`).
- New regression test confirmed RED against pre-fix source (temporarily stashed the fix): failed with the raw secret instead of `:rf/redacted`; companion test passed pre-fix as expected (isolates the bug to the inheritance path only).
- `implementation/` `npm run story:build` — green (652 files, 591 compiled, 0 warnings; one pre-existing unrelated xray JSDoc parse warning).
- `npm run test:cljs` not run — this change is scoped to `tools/story/**` only, no shared `implementation/` code touched.

## Risk

Low. Change is additive (new optional arg, existing 2-arity callers unaffected) and scoped entirely to `tools/story/**`.