### PR TITLE
fix(xray): migrate machine-epochs testbed off deleted runtime-db-value + complete redact-graph-for-egress identity projection (rf2-upze89/qo1l8w)

### DIFF
--- a/tools/xray/spec/025-Derivation-Graph-Panel.md
+++ b/tools/xray/spec/025-Derivation-Graph-Panel.md
@@ -211,7 +211,7 @@ classifications, `:source-form`, and `:refinement` are **structure, not
 values**, and are never walked. The value-bearing leaf fields inside node
 bodies are redacted by the policy walk above.
 
-#### Live resource IDENTITY redaction (rf2-k0meap.1)
+#### Live resource IDENTITY redaction (rf2-k0meap.1, extended rf2-qo1l8w)
 
 The value-path walk above matches a frame's declared `:sensitive` `:app-db`
 **paths** — but a live **resource** node carries its sensitive scope/params
@@ -219,20 +219,33 @@ in its **identity**, a place that walk can never reach: the concrete scoped
 key `[cache-scope resource-id canonical-params]` is the node **key**
 (`[:resource <scoped-key>]`), the node `:id`, and is embedded in the
 `:output` runtime path, the realized `:inputs` `[:scope …]` / `[:param …]`,
-and the in-flight `:work-ledger :record :resource/key`; a route-owned
-activation names it on a `:param` edge endpoint. So `redact-graph-for-egress`
-**also** projects each scoped key's secret-bearing **scope** and **params**
-into **stable opaque handles** — minted from the core CEDN-1 identity
-primitive (`identity/canonical-bytes`) then **hashed one-way** so the same
-key maps to the same handle (connectivity survives) but the raw scope/params
-can never be read back off the wire (fail-closed to `:rf/redacted` for any
-value outside the CEDN-1 domain). The non-sensitive registration
-`resource-id` is **preserved** so a tool still sees *which* resource the node
-is. The **same** projection is applied consistently to the `:nodes` keys, the
-identity positions inside node bodies (`:id` / `:output` / `:inputs` /
-`:work-ledger`), **and** every `:edges` endpoint that names a resource node —
-a redacted resource node is still a node, and the edges naming it still
-connect. Structure survives; the identity-embedded secret does not egress.
+the in-flight `:work-ledger :record :resource/key`, the resource work-id
+embedded in **both** `:work-ledger :work/id` and `:work-ledger :record
+:work/id` (a **third** identity position, independent of `:resource/key`),
+and the `:host-transient` in-flight handle address (which names that SAME
+work-id); a route-owned activation names it on a `:param` edge endpoint. So
+`redact-graph-for-egress` **also** projects each scoped key's secret-bearing
+**scope** and **params** into **stable opaque handles** — minted from the
+core CEDN-1 identity primitive (`identity/canonical-bytes`) then
+**hashed one-way** so the same key maps to the same handle (connectivity
+survives) but the raw scope/params can never be read back off the wire
+(fail-closed to `:rf/redacted` for any value outside the CEDN-1 domain). The
+non-sensitive registration `resource-id` is **preserved** so a tool still
+sees *which* resource the node is. The **same** projection is applied
+consistently to the `:nodes` keys, the identity positions inside node bodies
+(`:id` / `:output` / `:inputs` / `:work-ledger` / `:host-transient`), **and**
+every `:edges` endpoint that names a resource node — a redacted resource
+node is still a node, and the edges naming it still connect. Structure
+survives; the identity-embedded secret does not egress.
+
+This work-id / host-transient position is currently masked in production —
+`re-frame.resources.tooling/live-node-for` already projects the work-id
+(`project-work-id`, rf2-0t0l3w) before the composer or this redaction call
+site ever sees the node — but `redact-graph-for-egress` is the documented
+wire-boundary defense-in-depth layer, so it projects these positions
+independently rather than relying on that upstream pre-projection holding
+(rf2-qo1l8w; mirrors the fix the derivation-conformance egress mirror
+carried, rf2-tmyfkn/rf2-uh2clr).
 
 The projection is **idempotent** (rf2-g197ep): a value may egress more than
 once (re-egress on re-render / re-subscribe / a forwarder cascade that ships
@@ -302,7 +315,18 @@ the enclosing `[rf/frame-provider {:frame :rf/xray}]` in `shell.cljs`.
   equality across two (and three) passes plus per-position witnesses (node
   keys, `:id`, `:inputs`, `:output`, work-ledger `:resource/key`, edges), so a
   forwarder pipeline that re-egresses an already-projected graph cannot drift
-  the realized `:inputs` handles (rf2-g197ep).
+  the realized `:inputs` handles (rf2-g197ep). Plus the **work-id /
+  host-transient identity** arm (rf2-qo1l8w): a resource-shaped work-id
+  (`[:rf.work/resource <scoped-key> <generation>]`) embedding the same
+  session-token secret, planted directly into `:work-ledger :work/id`,
+  `:work-ledger :record :work/id`, and `:host-transient` (bypassing the
+  upstream `resources.tooling/project-work-id` pre-projection that masks this
+  gap in production) — asserting no raw secret survives in any of those three
+  positions, the resource work-id shape (`:rf.work/resource` head +
+  generation) survives projection, and the same opaque scoped-key handle is
+  consistent across all three positions (mirrors the derivation-conformance
+  egress mirror's `project-work-id` / `project-host-transient` fix,
+  rf2-tmyfkn/rf2-uh2clr, closing the same latent gap in the real call site).
 - **`derivation_graph_consumer_cljs_test.cljs`** (node) — the **behavioral
   consumer** test (rf2-4wtllq): registers the panel handlers via
   `registry/register-xray-handlers!` + `test-support/install-test-overrides!`

--- a/tools/xray/src/day8/re_frame2_xray/panels/derivation_graph_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/derivation_graph_helpers.cljc
@@ -372,6 +372,35 @@
           inputs)
     inputs))
 
+(defn- redact-resource-work-id
+  "Project the scoped key embedded in a resource work-id
+  `[:rf.work/resource <scoped-key> <generation>]` — a work-id of another
+  shape (e.g. a non-resource family's work-id, or the historical bare
+  scalar) rides through unchanged. Mirrors the derivation-conformance
+  egress mirror's `project-work-id` (rf2-qo1l8w, closing the latent gap
+  rf2-tmyfkn/rf2-uh2clr fixed there but not here). Idempotent by
+  delegation: `project-scoped-key` already returns an already-projected
+  handle unchanged."
+  [work-id]
+  (if (and (vector? work-id) (= :rf.work/resource (first work-id)))
+    (update work-id 1 project-scoped-key)
+    work-id))
+
+(defn- redact-resource-host-transient
+  "Project the work-id embedded in a `:host-transient`
+  `[[:rf.http/in-flight <work-id>]]` in-flight handle address (rf2-qo1l8w)
+  — the abortable-handle address names the SAME work-id the work-ledger
+  link carries, so it must not leak the raw scoped key either. Other
+  shapes ride through untouched."
+  [host-transient]
+  (if (sequential? host-transient)
+    (mapv (fn [entry]
+            (if (and (vector? entry) (= 2 (count entry)) (= :rf.http/in-flight (first entry)))
+              (update entry 1 redact-resource-work-id)
+              entry))
+          host-transient)
+    host-transient))
+
 (def ^:private dead-frame-sentinel
   "A frame id that can NEVER resolve to a live frame, used to FAIL CLOSED a
   nil / unreachable egress frame WITHOUT borrowing the ambient scope.
@@ -391,9 +420,14 @@
 (defn- redact-resource-node-identity
   "Project ONE live resource node's secret-bearing identity fields:
   `:id` (the scoped key), `:output` (the scoped key embedded in the runtime
-  path), the realized `:inputs` `[:scope …]` / `[:param …]` payloads, and
+  path), the realized `:inputs` `[:scope …]` / `[:param …]` payloads,
   `:work-ledger :record :resource/key` (the scoped key on the work-ledger
-  summary). Structure / classification fields are untouched."
+  summary), the resource work-id embedded in BOTH `:work-ledger :work/id`
+  and `:work-ledger :record :work/id` (rf2-qo1l8w — a THIRD identity
+  position, independent of `:resource/key`; mirrors the derivation-
+  conformance egress mirror's rf2-tmyfkn fix), and the `:host-transient`
+  in-flight handle address (which names that SAME work-id). Structure /
+  classification fields are untouched."
   [node]
   (cond-> node
     (scoped-resource-key? (:id node))
@@ -406,7 +440,16 @@
     (update :inputs redact-resource-inputs)
 
     (scoped-resource-key? (get-in node [:work-ledger :record :resource/key]))
-    (update-in [:work-ledger :record :resource/key] project-scoped-key)))
+    (update-in [:work-ledger :record :resource/key] project-scoped-key)
+
+    (contains? (:work-ledger node) :work/id)
+    (update-in [:work-ledger :work/id] redact-resource-work-id)
+
+    (contains? (get-in node [:work-ledger :record]) :work/id)
+    (update-in [:work-ledger :record :work/id] redact-resource-work-id)
+
+    (contains? node :host-transient)
+    (update :host-transient redact-resource-host-transient)))
 
 (defn- resource-node-key?
   "True when `node-key` is a LIVE resource node id `[:resource <scoped-key>]`
@@ -466,13 +509,17 @@
   classifications, `:source-form`, and `:refinement` are structure, not
   values, and are never touched.
 
-  LIVE RESOURCE IDENTITY redaction (rf2-k0meap.1). A live resource node
-  carries its sensitive scope/params NOT in a value-bearing field but in its
-  IDENTITY — the concrete scoped key `[cache-scope resource-id
-  canonical-params]` that is the node KEY (`[:resource <scoped-key>]`), the
-  node's `:id`, and is embedded in the `:output` runtime path, the realized
-  `:inputs` `[:scope …]` / `[:param …]` edges, and the `:work-ledger :record
-  :resource/key`. The `rf/elide-wire-value` value-path walk is structurally
+  LIVE RESOURCE IDENTITY redaction (rf2-k0meap.1, extended rf2-qo1l8w). A
+  live resource node carries its sensitive scope/params NOT in a
+  value-bearing field but in its IDENTITY — the concrete scoped key
+  `[cache-scope resource-id canonical-params]` that is the node KEY
+  (`[:resource <scoped-key>]`), the node's `:id`, and is embedded in the
+  `:output` runtime path, the realized `:inputs` `[:scope …]` / `[:param …]`
+  edges, `:work-ledger :record :resource/key`, the resource work-id
+  embedded in BOTH `:work-ledger :work/id` and `:work-ledger :record
+  :work/id` (a THIRD identity position, independent of `:resource/key`),
+  and the `:host-transient` in-flight handle address (which names that
+  SAME work-id). The `rf/elide-wire-value` value-path walk is structurally
   BLIND to these identity-embedded secrets. So this projection ALSO replaces
   each scoped key's secret-bearing scope + params with STABLE OPAQUE HANDLES
   (`identity/canonical-bytes`-derived, fail-closed to `:rf/redacted` outside

--- a/tools/xray/test/day8/re_frame2_xray/panels/derivation_graph_redaction_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/derivation_graph_redaction_cljs_test.cljc
@@ -474,3 +474,112 @@
           "the projected work-ledger :resource/key is stable under re-projection")
       (is (= (:edges once) (:edges twice))
           "the projected edge endpoints are stable under re-projection"))))
+
+;; ===========================================================================
+;; 6. THE WORK-ID / HOST-TRANSIENT IDENTITY ARM (rf2-qo1l8w).
+;;
+;; §5's `live-resource-node` fixture uses a BARE INT (99) as its work-id,
+;; which never exercises the actual secret-bearing SHAPE a resource work-id
+;; takes: `[:rf.work/resource <scoped-key> <generation>]` (per
+;; `re-frame.resources.tooling/project-work-id`, rf2-0t0l3w). This gap is
+;; currently NOT exploitable in production because
+;; `re-frame.resources.tooling/live-node-for` already projects the work-id
+;; BEFORE the composer or Xray's redaction ever sees the node — but
+;; `redact-graph-for-egress` is documented as the wire-boundary
+;; defense-in-depth layer, and would silently leak the raw scope/params
+;; embedded in a canonical work-id if that upstream projection ever
+;; regressed. This fixture plants the REAL resource-shaped work-id directly
+;; (bypassing the upstream pre-projection) to prove the redaction layer
+;; closes the gap on its own — mirroring the derivation-conformance egress
+;; mirror's adversarial fixture (rf2-tmyfkn/rf2-uh2clr, PR #5291) that found
+;; this same gap already fixed there but latent in the real call site here.
+;; ===========================================================================
+
+(def ^:private work-id-scoped-key
+  ;; a DIFFERENT resource-id than §5's `live-scoped-key` — this fixture
+  ;; targets the work-id / host-transient identity positions specifically,
+  ;; reusing the §5 `secret-token`/`secret-scope`/`secret-params` fixture so
+  ;; the shared `contains-secret?` helper applies unchanged.
+  [secret-scope :article/checkout secret-params])
+
+(def ^:private resource-work-id
+  ;; the REAL resource-family work-id shape — embeds the scoped key
+  ;; directly, NOT pre-projected (rf2-0t0l3w's `project-work-id` runs
+  ;; upstream in production; this fixture bypasses it to test the
+  ;; defense-in-depth layer in isolation).
+  [:rf.work/resource work-id-scoped-key 3])
+
+(def ^:private work-id-resource-node
+  {:id             :article/checkout
+   :kind           :process
+   :refinement     :resource-process
+   :rf/family      :resources
+   :storage        :runtime-db
+   :authority      {:kind :remote :system :server}
+   :evaluation     #{:on-route}
+   :lifecycle      {:kind :static}
+   :status         :loading
+   :work-ledger    {:work/id resource-work-id
+                     :record {:work/id   resource-work-id
+                              :work/kind :rf.http/managed
+                              :status    :pending}}
+   :host-transient [[:rf.http/in-flight resource-work-id]]})
+
+(def ^:private work-id-resource-graph
+  {:mode  :live
+   :frame secure-frame
+   :nodes {[:resource :article/checkout] work-id-resource-node}
+   :edges []})
+
+(deftest live-resource-work-id-identity-is-redacted-at-egress
+  ;; rf2-qo1l8w: the SAME identity-projection gap the derivation-conformance
+  ;; mirror closed (rf2-tmyfkn/rf2-uh2clr, PR #5291) for `:work-ledger
+  ;; :work/id` / `:work-ledger :record :work/id` / `:host-transient` must
+  ;; ALSO close in the REAL `redact-graph-for-egress` — not just its test
+  ;; mirror. RED against the pre-fix `redact-resource-node-identity` (which
+  ;; only projected `:id` / `:output` / `:inputs` / `:work-ledger :record
+  ;; :resource/key`).
+  (let [redacted (h/redact-graph-for-egress work-id-resource-graph secure-frame)
+        node     (-> redacted :nodes vals first)]
+
+    (testing "(a) NO raw secret survives ANYWHERE in the egressed graph — not
+              in :work-ledger :work/id, :work-ledger :record :work/id, or
+              :host-transient"
+      (is (contains-secret? work-id-resource-graph)
+          "sanity: the raw graph DOES carry the secret inside the work-id")
+      (is (not (contains-secret? redacted))
+          "the secret must not survive in the work-id / host-transient
+           identity positions"))
+
+    (testing "(b) :work-ledger :work/id keeps the resource work-id SHAPE —
+              `[:rf.work/resource <projected-scoped-key> <generation>]`"
+      (let [wid (get-in node [:work-ledger :work/id])]
+        (is (= :rf.work/resource (first wid)) "the work-id family head survives")
+        (is (= 3 (nth wid 2)) "the generation (non-secret) rides through")
+        (is (projected-scoped-key? (nth wid 1))
+            "the embedded scoped key is projected to opaque-handle shape")
+        (is (= :article/checkout (nth (nth wid 1) 1))
+            "the registration resource-id inside the work-id is preserved")))
+
+    (testing "(c) :work-ledger :record :work/id is projected the SAME way"
+      (let [wid (get-in node [:work-ledger :record :work/id])]
+        (is (= :rf.work/resource (first wid)))
+        (is (projected-scoped-key? (nth wid 1)))))
+
+    (testing "(d) :host-transient's in-flight handle embeds the SAME work-id
+              — its scoped key is projected too"
+      (let [[tag wid] (first (:host-transient node))]
+        (is (= :rf.http/in-flight tag))
+        (is (= :rf.work/resource (first wid)))
+        (is (projected-scoped-key? (nth wid 1))
+            "the host-transient handle's embedded work-id scoped key is opaqued")))
+
+    (testing "(e) the SAME projected scoped key appears in :work-ledger
+              :work/id, :work-ledger :record :work/id, AND :host-transient —
+              consistent identity across all three positions"
+      (let [ledger-key    (nth (get-in node [:work-ledger :work/id]) 1)
+            record-key    (nth (get-in node [:work-ledger :record :work/id]) 1)
+            transient-key (nth (second (first (:host-transient node))) 1)]
+        (is (= ledger-key record-key transient-key)
+            "the same work-id scoped key projects to the identical opaque
+             handle everywhere it appears")))))

--- a/tools/xray/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/xray/testbeds/feature_matrix/scenarios.cjs
@@ -2661,8 +2661,10 @@ async function runRoutesEpochs(page, state) {
   // until the slot fills. The probe reads the canonical location: per
   // EP-0001 the pending-nav slot is durable routing RUNTIME-DB state at
   // `[:rf.runtime/routing :pending-navigation]` — read via the public
-  // `re-frame.core/runtime-db-value` seam, NOT app-db. The deck strip
-  // (`:rf/pending-navigation` runtime-sub) is the secondary cross-check.
+  // `re-frame.core/frame-state-value` seam's `:rf.db/runtime` partition
+  // (rf2-t3lftq, API-shrink #3, retired the dedicated `runtime-db-value`
+  // reader), NOT app-db. The deck strip (`:rf/pending-navigation`
+  // runtime-sub) is the secondary cross-check.
   const pendingProbe = await waitForValue(
     () => page.evaluate(() => {
       const el = document.querySelector('[data-testid="routes-epochs-current-strip"]');
@@ -2671,7 +2673,7 @@ async function runRoutesEpochs(page, state) {
       try {
         const cljs = window.cljs && window.cljs.core;
         const rf = window.re_frame && window.re_frame.core;
-        if (cljs && rf && typeof rf.runtime_db_value === 'function') {
+        if (cljs && rf && typeof rf.frame_state_value === 'function') {
           const kw = (s) => {
             const t = String(s).replace(/^:/, '');
             const p = t.split('/');
@@ -2679,7 +2681,8 @@ async function runRoutesEpochs(page, state) {
               ? (cljs.keyword.call ? cljs.keyword.call(null, p[0], p[1]) : cljs.keyword(p[0], p[1]))
               : (cljs.keyword.call ? cljs.keyword.call(null, t) : cljs.keyword(t));
           };
-          const rdb = rf.runtime_db_value(kw('rf/default'));
+          const frameState = rf.frame_state_value(kw('rf/default'));
+          const rdb = frameState ? cljs.get(frameState, kw('rf.db/runtime')) : null;
           const path = cljs.PersistentVector.fromArray(
             [kw('rf.runtime/routing'), kw('pending-navigation')], true);
           const pn = rdb ? cljs.get_in(rdb, path) : null;
@@ -2734,8 +2737,10 @@ async function runRoutesEpochs(page, state) {
 // parallel-region broadcast · ignored event · microstep · timer · spawn ·
 // deep-compound LCA · history) is genuinely exercised and is observable in
 // THAT track's frame machine snapshot, read directly via the public
-// `re-frame.core/runtime-db-value` accessor (`readTrackSnapshots`, scoped to
-// `:machine/<track>`). We assert those per-frame snapshot facts — they are
+// `re-frame.core/frame-state-value` accessor's `:rf.db/runtime` partition
+// (`readTrackSnapshots`, scoped to `:machine/<track>`; rf2-t3lftq,
+// API-shrink #3, retired the dedicated `runtime-db-value` reader). We
+// assert those per-frame snapshot facts — they are
 // the robust, non-flaky proof each machine feature fired in its own frame.
 //
 // We additionally open the Machines tab and confirm `rf-xray-machine-
@@ -2790,8 +2795,9 @@ async function restartMachineTrack(page) {
 // Machine snapshots are durable framework RUNTIME-DB state per EP-0001
 // (re-frame.machines.paths/snapshot-path): they live at
 // `[:rf.runtime/machines :snapshots <machine-id>]` in the runtime-db
-// PARTITION, read via the public `re-frame.core/runtime-db-value` seam — NOT
-// in app-db.
+// PARTITION, read via the public `re-frame.core/frame-state-value` seam's
+// `:rf.db/runtime` key (rf2-t3lftq, API-shrink #3, retired the dedicated
+// `runtime-db-value` reader) — NOT in app-db.
 //
 // `trackId` is the track name (e.g. 'door', 'media'); the frame id is
 // `:machine/<trackId>`. `machineIds` is the set of machine-ids the track
@@ -2800,8 +2806,8 @@ async function readTrackSnapshots(page, trackId, machineIds) {
   return page.evaluate(({ trackId, machineIds }) => {
     const cljs = window.cljs && window.cljs.core;
     const rf = window.re_frame && window.re_frame.core;
-    if (!cljs || !rf || typeof rf.runtime_db_value !== 'function') {
-      return { mounted: false, reason: 'cljs.core / re_frame.core.runtime_db_value unavailable' };
+    if (!cljs || !rf || typeof rf.frame_state_value !== 'function') {
+      return { mounted: false, reason: 'cljs.core / re_frame.core.frame_state_value unavailable' };
     }
     function keyword(s) {
       const trimmed = String(s).replace(/^:/, '');
@@ -2815,7 +2821,8 @@ async function readTrackSnapshots(page, trackId, machineIds) {
         ? cljs.keyword.call(null, trimmed)
         : cljs.keyword(trimmed);
     }
-    const db = rf.runtime_db_value(keyword(`:machine/${trackId}`));
+    const frameState = rf.frame_state_value(keyword(`:machine/${trackId}`));
+    const db = frameState ? cljs.get(frameState, keyword('rf.db/runtime')) : null;
     if (db == null) return { mounted: false, reason: `no :machine/${trackId} runtime-db` };
     function snapshot(machineId) {
       const path = cljs.PersistentVector.fromArray([


### PR DESCRIPTION
## Summary

- **rf2-upze89** (P2, real gate failure): `tools/xray/testbeds/feature_matrix/scenarios.cjs`'s machine-epochs scenario (`readTrackSnapshots`) and the routes-epochs pending-navigation probe both called `re-frame.core/runtime_db_value`, which was deleted from the facade by rf2-t3lftq (API-shrink #3, commit `02ec7dbc4`, consolidating frame-state I/O to `replace-frame-state!`). Migrated both call sites to `frame_state_value(frame-id)` + extracting `:rf.db/runtime`, matching the exact migration pattern t3lftq applied elsewhere (e.g. `implementation/machines/test/re_frame/machines/test_support.cljc`: `(:rf.db/runtime (rf/frame-state-value frame-id))`).
- **rf2-qo1l8w** (P3, defense-in-depth): `tools/xray`'s real `redact-graph-for-egress` (`derivation_graph_helpers.cljc`) had the same latent identity-projection gap the derivation-conformance test mirror (`derivation_algebra_conformance_cljs_test.cljc`, rf2-tmyfkn/rf2-uh2clr, PR #5291) already closed in its own copy: the resource work-id embedded in `:work-ledger :work/id`, `:work-ledger :record :work/id`, and the `:host-transient` in-flight handle address were not projected through the opaque scoped-key handle. Currently masked in production because `re-frame.resources.tooling/live-node-for` pre-projects the work-id before Xray's redaction ever sees the node — but `redact-graph-for-egress` is the documented wire-boundary defense-in-depth layer, so it should not rely on that upstream projection holding. Added `redact-resource-work-id` / `redact-resource-host-transient`, mirroring the conformance suite's `project-work-id` / `project-host-transient`, and wired them into `redact-resource-node-identity`.

Updated `tools/xray/spec/025-Derivation-Graph-Panel.md` (the identity-redaction section + test-coverage list) to document the extended surface — spec ratchet per CLAUDE.md.

## Quality gates

- `clojure -M:test` from `tools/xray/`: **1231 tests, 5687 assertions, 0 failures, 0 errors** (includes the new `live-resource-work-id-identity-is-redacted-at-egress` regression test for qo1l8w, RED against pre-fix `redact-resource-node-identity`).
- `npm run test:xray-feature-gate` from `implementation/`: **16/16 scenarios pass, 0 failures** (was 15/16 before this fix — the machine-epochs scenario's mount probe no longer hits `runtime_db_value unavailable`).
- `npm run test:cljs` from `implementation/`: **8127 tests, 37246 assertions, 0 failures, 0 errors**.

## Risks

- Low. Both fixes are surgical: upze89 is a pure call-site migration to the already-established replacement read path (no new semantics); qo1l8w only adds redaction coverage for identity positions that are currently unreachable in production (no observed behavior change for any existing caller), verified idempotent via the existing test suite's re-projection assertions.
- Disjoint from concurrent worker territory (`implementation/resources`, `implementation/schemas`, `tools/story`, `core.cljc`/routing/spec) — touched only `tools/xray/**`.