### PR TITLE
fix(schemas): redact nested opaque schema validation data (P1 privacy leak, rf2-hi0tf8)

### DIFF
--- a/implementation/schemas/src/re_frame/schemas.cljc
+++ b/implementation/schemas/src/re_frame/schemas.cljc
@@ -181,6 +181,14 @@
 ;; walker cannot introspect (its failure redacts as sensitive).
 (def schema-has-large?                walker/schema-has-large?)
 (def schema-opaque?                   walker/schema-opaque?)
+;; rf2-hi0tf8 — the RECURSIVE sibling of `schema-opaque?`: true when the
+;; schema itself is opaque OR embeds a nested opaque child at any depth
+;; (a compiled `m/schema` value used as, say, a `:map` slot's tail inside
+;; an otherwise-walkable vector-form schema). `schema-opaque?` alone only
+;; classifies the root, which under-redacts a nested opaque child; every
+;; fail-closed redaction / registration-warning gate consults this one
+;; instead.
+(def schema-has-opaque-child?         walker/schema-has-opaque-child?)
 ;; rf2-ss06u.1 — `walker/sanitize-sensitive-path` (the `:path`-tag sanitiser
 ;; that scrubs value-bearing `:set`-element segments so a sensitive `:set`
 ;; element never ships verbatim in the structural `:path` tag) is an INTERNAL

--- a/implementation/schemas/src/re_frame/schemas/storage.cljc
+++ b/implementation/schemas/src/re_frame/schemas/storage.cljc
@@ -551,22 +551,30 @@
   (reset! walker-opaque-warned false))
 
 (defn- walker-introspectable?
-  "True when the schema value is a form the pure-data walker can
-  introspect for per-slot `:sensitive?` / `:large?` flags. Vector-form
-  Malli EDN is introspectable; so is a bare keyword (primitive type or
-  registry ref) — a keyword cannot carry per-slot props, so the walker
-  provably skips nothing and there is nothing to warn about (rf2-ee38b.6).
-  Compiled `m/schema` objects, maps, and other opaque values are NOT
-  introspectable — their internal per-slot flags are silently skipped."
+  "True when the schema value is a form the pure-data walker can fully
+  introspect for per-slot `:sensitive?` / `:large?` flags — the root is
+  vector-form Malli EDN or a bare keyword (primitive type or registry
+  ref — a keyword cannot carry per-slot props, so the walker provably
+  skips nothing and there is nothing to warn about, rf2-ee38b.6) AND no
+  NESTED child anywhere beneath it is itself opaque.
+
+  Per rf2-hi0tf8: a schema whose ROOT is walkable vector-form EDN can
+  still embed an opaque child at a deeper slot (e.g. `[:map [:token
+  (m/schema [:string {:sensitive? true}])]]`) — a root-only check would
+  call that schema introspectable even though the nested compiled
+  value's per-slot flags are exactly as invisible to the walk as a
+  top-level opaque schema's. `schema-has-opaque-child?` recurses the
+  whole tree so this predicate is accurate at any depth."
   [schema]
-  (or (vector? schema) (keyword? schema)))
+  (not (walker/schema-has-opaque-child? schema)))
 
 (defn- maybe-warn-walker-opaque!
   "Emit `:rf.warning/schema-walker-opaque` once per process when
-  `reg-app-schema` / `reg-app-schemas` is invoked with a genuinely
-  opaque schema value the walker cannot introspect (a compiled
-  `m/schema` object / other non-vector, non-keyword value). Vector
-  forms and bare keywords do not warn — see `walker-introspectable?`.
+  `reg-app-schema` / `reg-app-schemas` is invoked with a schema that is
+  opaque — at its ROOT or at any NESTED child — to the pure-data walker
+  (a compiled `m/schema` object / other non-vector, non-keyword value,
+  anywhere in the tree). Vector forms with no opaque descendant and bare
+  keywords do not warn — see `walker-introspectable?`.
 
   Callers MUST wrap invocations in `(when interop/debug-enabled? ...)`
   so the production bundle DCEs the consult+emit branch (Spec 009
@@ -582,20 +590,24 @@
                                :compiled-schema-object
                                :unknown)
                 :reason
-                (str "reg-app-schema was called with a compiled / opaque"
-                     " schema value (a non-vector, non-keyword form such"
-                     " as a compiled m/schema object). The schema-walker"
-                     " (used for per-slot `:sensitive?` / `:large?`"
-                     " extraction) can only introspect vector-form Malli"
-                     " EDN — per-slot flags inside an opaque value are"
-                     " silently skipped. The workable shape: register the"
-                     " vector form directly so the walker can introspect"
-                     " the per-slot flags. (The handler/cofx/sub"
-                     " registration-meta `:sensitive?` fallback has been"
-                     " removed — sensitivity is path-targeted and the"
-                     " redactor consults only per-slot schema"
-                     " declarations.) Per Spec 010 §The `:schema` value"
-                     " is opaque to re-frame.")})))))
+                (str "reg-app-schema was called with a schema that is"
+                     " opaque — either the registered value ITSELF is a"
+                     " compiled / opaque form (a non-vector, non-keyword"
+                     " value such as a compiled m/schema object), or a"
+                     " vector-form schema embeds one as a NESTED child."
+                     " The schema-walker (used for per-slot"
+                     " `:sensitive?` / `:large?` extraction) can only"
+                     " introspect vector-form Malli EDN — per-slot flags"
+                     " inside an opaque value, at any depth, are"
+                     " silently skipped. The workable shape: register"
+                     " the vector form directly, all the way down, so"
+                     " the walker can introspect every per-slot flag."
+                     " (The handler/cofx/sub registration-meta"
+                     " `:sensitive?` fallback has been removed —"
+                     " sensitivity is path-targeted and the redactor"
+                     " consults only per-slot schema declarations.) Per"
+                     " Spec 010 §The `:schema` value is opaque to"
+                     " re-frame.")})))))
 
 (defn- maybe-warn-validator-unavailable!
   "Emit `:rf.warning/schema-validator-unavailable` once per process when
@@ -692,10 +704,14 @@
             ;; return false and `:mismatching-value` would egress the live value
             ;; verbatim — the asymmetry the validate-*! redactor already closes
             ;; (`re-frame.schemas.validate` uses the same
-            ;; `(or schema-has-sensitive? schema-opaque?)` posture). A bare
-            ;; keyword is provably flag-free and is NOT opaque (`schema-opaque?`).
+            ;; `(or schema-has-sensitive? schema-has-opaque-child?)` posture). A
+            ;; bare keyword is provably flag-free and is NOT opaque
+            ;; (`schema-opaque?`). Per rf2-hi0tf8 the opaque check is the
+            ;; RECURSIVE `schema-has-opaque-child?`, not the root-only
+            ;; `schema-opaque?` — a vector-form `new-schema` can embed a nested
+            ;; opaque child the root-only check would miss.
             (let [sensitive? (or (walker/schema-has-sensitive? new-schema)
-                                 (walker/schema-opaque? new-schema))]
+                                 (walker/schema-has-opaque-child? new-schema))]
               (emit! :warning :rf.schema/violation
                      {:path               path
                       :pre-reload-schema  prior-schema

--- a/implementation/schemas/src/re_frame/schemas/validate.cljc
+++ b/implementation/schemas/src/re_frame/schemas/validate.cljc
@@ -682,10 +682,15 @@
                 ;; `{:sensitive? true}` slot leaks the failing value verbatim
                 ;; while the equivalent vector form redacts (the bead's
                 ;; asymmetry). A bare keyword is provably flag-free, so it is
-                ;; NOT opaque here (`walker/schema-opaque?`).
+                ;; NOT opaque here (`walker/schema-opaque?`). Per rf2-hi0tf8
+                ;; — `schema-opaque?` only classifies the ROOT form; a
+                ;; vector-form schema with a NESTED opaque child (e.g. a
+                ;; `:cat`/`:map` element that is itself a compiled `m/schema`
+                ;; value) is just as unintrospectable, so the whole-payload
+                ;; check uses the recursive `schema-has-opaque-child?`.
                 sensitive?  (and walk-schema?
                                  (or (walker/schema-has-sensitive? schema)
-                                     (walker/schema-opaque? schema)))
+                                     (walker/schema-has-opaque-child? schema)))
                 ;; Per rf2-vmhu4i — when the schema declares any `:large?`
                 ;; slot AND the failure is not sensitive (sensitive wins),
                 ;; elide the value-bearing slots to the `:rf.size/large-elided`
@@ -914,14 +919,25 @@
                        ;; sensitive. (`reg-app-schema` also warns once via
                        ;; `:rf.warning/schema-walker-opaque` at registration;
                        ;; this is the redaction half of the same fail-closed
-                       ;; posture.)
-                       opaque?          (walker/schema-opaque? schema)
-                       leaf-sensitive?  (or opaque?
-                                            (if in-path
-                                              (walker/schema-sensitive-at? schema in-path)
-                                              (walker/schema-has-sensitive? schema)))
-                       whole-sensitive? (or opaque?
-                                            (walker/schema-has-sensitive? schema))
+                       ;; posture.) Per rf2-hi0tf8 — a schema whose ROOT is
+                       ;; walkable vector-form EDN can still embed a NESTED
+                       ;; opaque child (e.g. `[:map [:token (m/schema
+                       ;; [:string {:sensitive? true}])]]`); `schema-opaque?`
+                       ;; alone only sees the root, so both decisions now
+                       ;; route through `schema-sensitive-at?`, which fails
+                       ;; closed on a nested opaque node exactly where it
+                       ;; sits — the failing LEAF's own opacity (or an
+                       ;; opaque ancestor/descendant along its path) for
+                       ;; `leaf-sensitive?`, and the WHOLE schema's opacity
+                       ;; anywhere for `whole-sensitive?` (`nil` path — the
+                       ;; same whole-schema scope `schema-has-sensitive?`
+                       ;; already used). Scoping `leaf-sensitive?` to the
+                       ;; failing path (rather than "opaque anywhere in the
+                       ;; schema") preserves the rf2-oh4se / rf2-3qam7b
+                       ;; leaf-precision contract — an opaque SIBLING must
+                       ;; not taint an unrelated non-opaque leaf's `:value`.
+                       leaf-sensitive?  (walker/schema-sensitive-at? schema in-path)
+                       whole-sensitive? (walker/schema-sensitive-at? schema nil)
                        ;; Per rf2-vmhu4i — a `:large?` (non-sensitive) schema
                        ;; elides the value-bearing slots to the size marker
                        ;; (sensitive wins; opaque is fail-closed sensitive,
@@ -1249,7 +1265,10 @@
   non-vector, non-keyword `m/schema` object the walker cannot introspect):
   it redacts as if sensitive, because Malli may have honoured a
   `{:sensitive? true}` slot the walker cannot see — without this an opaque
-  schema's failure leaks verbatim while the vector form redacts.
+  schema's failure leaks verbatim while the vector form redacts. Per
+  rf2-hi0tf8 the same fail-closed posture applies when the opaque value is
+  NESTED inside an otherwise-walkable vector-form schema (`schema-opaque?`
+  alone only sees the root) — `schema-has-opaque-child?` catches both.
 
   Per rf2-vmhu4i a `:large?`-flagged (and non-sensitive) schema elides the
   value-bearing slots to the `:rf.size/large-elided` marker (sensitive wins;
@@ -1261,7 +1280,7 @@
   tags map a path-based pre-scrub already touched) is safe."
   [schema tags]
   (let [sensitive? (or (walker/schema-has-sensitive? schema)
-                       (walker/schema-opaque? schema))
+                       (walker/schema-has-opaque-child? schema))
         large?     (and (not sensitive?)
                         (walker/schema-has-large? schema))]
     (cond-> tags

--- a/implementation/schemas/src/re_frame/schemas/walker.cljc
+++ b/implementation/schemas/src/re_frame/schemas/walker.cljc
@@ -524,6 +524,101 @@
   [schema]
   (not (or (vector? schema) (keyword? schema))))
 
+(defn- opaque-nested-tail?
+  "Private recursive helper for `schema-has-opaque-child?`. Identical to
+  `schema-opaque?`'s notion of opaque EXCEPT a bare fn or symbol reached
+  as a nested TAIL is NOT opaque here — see `schema-has-opaque-child?`'s
+  docstring for why a bare fn/symbol below the root is provably
+  flag-free. Only ever called on a value already reached by descending
+  through `children-of`, i.e. never on the caller's original root
+  argument — see `schema-has-opaque-child?` for the root/nested split."
+  [schema]
+  (cond
+    (keyword? schema) false
+    (fn? schema) false
+    (symbol? schema) false
+    (and (vector? schema) (pos? (count schema)))
+    (boolean (some opaque-nested-tail? (children-of schema)))
+    :else true))
+
+(defn schema-has-opaque-child?
+  "True when `schema` is itself opaque (`schema-opaque?`) OR contains, at
+  any depth BENEATH the root, a nested opaque child — a compiled
+  `m/schema` value, map, or other form the pure-data walker cannot
+  introspect for per-slot props — reachable by descending through
+  vector-form Malli EDN structure.
+
+  Per rf2-hi0tf8: `schema-opaque?` alone classifies only the ROOT form.
+  A schema whose root IS introspectable vector-form EDN can still embed
+  an opaque child at a deeper slot — e.g. `[:map [:token (m/schema
+  [:string {:sensitive? true}])]]` — and the per-slot `:sensitive?` /
+  `:large?` flags Malli honours inside that nested compiled value are
+  exactly as invisible to `walk-flagged-schema` as a top-level opaque
+  schema's flags are (the walk's terminal `:else acc` bailout silently
+  skips it, contributing NO declaration). Every fail-closed
+  redaction / warning gate that used to OR in `schema-opaque?` to catch a
+  top-level opaque schema must use this recursive predicate instead, or
+  the nested case leaks fail-OPEN while the equivalent top-level shape
+  redacts.
+
+  BARE FUNCTIONS (`pos-int?`, `string?`, a `(fn [v] …)` literal, …) AND
+  BARE SYMBOLS (a `'pos-int?` reader form — Malli resolves a symbol
+  schema to the named fn/var, e.g. an EDN-sourced fixture that cannot
+  embed a live fn literal) are opaque to `schema-opaque?` and stay
+  opaque HERE too when they are the schema being checked directly — a
+  bare fn/symbol used AS THE WHOLE registered `:schema` (no wrapper at
+  all, e.g. `re-frame.flows`' `{:schema (fn [v] …)}`) has no sibling
+  `{props}` position anywhere in its registration shape, so there is
+  genuinely no way it could carry a `:sensitive?`/`:large?` flag except
+  by wrapping (`[:fn {:sensitive? true} pred]`, itself vector-form and
+  walkable) — `schema-opaque?`'s fail-closed root treatment is correct
+  and stays UNCHANGED here
+  (`flows_schema_validation_test/non-conforming-output-emits-violation-
+  but-still-writes` pins exactly this).
+
+  A bare fn/symbol reached as a NESTED TAIL, however — `[:map [:n
+  pos-int?]]`, the idiomatic Malli shorthand exercised throughout this
+  codebase's own conformance corpus and machine/resource schemas — IS
+  the deliberate divergence: it cannot itself carry a `{props}` map, but
+  unlike the root case it DOES have a sibling props position one level
+  up — the entry `[:n {:sensitive? true} pos-int?]` — which
+  `walk-flagged-schema` ALREADY captures before ever looking at the
+  tail (same provably-flag-free reasoning as the walker's keyword
+  exception, rf2-ee38b.6). Without this root/nested split, every
+  ordinary `pos-int?`/`string?`-style leaf anywhere in a schema would
+  fail closed and over-redact (confirmed against the
+  `:machine/data-schema-rollback` conformance fixture, whose EDN-sourced
+  `[:map [:n pos-int?]]` data-schema — `pos-int?` reads as a bare SYMBOL
+  via `clojure.edn/read-string`, Malli resolves it at validate-time —
+  must NOT redact `{:n 0}`); collapsing the two positions the OTHER way
+  (treating a nested fn/symbol as opaque too) would have been the
+  simpler implementation but breaks that corpus fixture, and collapsing
+  them by making the ROOT case non-opaque instead would break the flows
+  fixture above — the split is load-bearing, not incidental.
+
+  Descends via `children-of` — the same child-extraction `walk-flagged-
+  schema` uses for every op category. This works uniformly without
+  per-op branching because both the outer `[op props? children...]` form
+  and every child ENTRY shape it produces (`:map`/`:multi`/`:orn`/`:altn`
+  `[k props? tail]` pairs, `:catn` `[name props? schema]` triples,
+  `:tuple`/`:cat`/`:vector`/`:set`/… bare positional children) share the
+  identical position-0-discriminator / optional-position-1-props-map /
+  trailing-payload convention — `children-of` always peels off exactly
+  the props-carrying wrapper and hands back the descendable tail(s),
+  regardless of which op produced the entry. A pure existence check
+  doesn't need per-op path bookkeeping the way the flag walk does.
+
+  Not memoised (unlike `extract-sensitive-paths-from-schema`): every call
+  site is a validation-FAILURE emit path, not the per-dispatch hot path,
+  so re-walking on each failure is the same cost profile as the sibling
+  `schema-has-sensitive?` / `schema-has-large?` checks already pay there.
+
+  Returns boolean. Pure; same input always produces the same output."
+  [schema]
+  (or (schema-opaque? schema)
+      (and (vector? schema) (pos? (count schema))
+           (boolean (some opaque-nested-tail? (children-of schema))))))
+
 (defn- prefix?
   "True when `prefix` is a prefix of `path` (or equal). Both are
   indexed vectors compared element-wise. Single-pass: counts each
@@ -577,12 +672,13 @@
   match because the walker never emits index segments. Dropping each
   index-bearing op's segment while descending re-aligns the two.
 
-  Returns `[:ok aligned-path]` when the whole path resolves against
-  recognised ops, or `[:fallback subschema aligned-prefix]` when an
-  unrecognised / opaque op is hit with path remaining — the caller then
-  redacts fail-SAFE iff the leftover `subschema` OR the **already-aligned
-  prefix** carries any sensitive declaration. `:map` segments are kept
-  (real app-db keys); index-bearing-op segments are dropped.
+  Returns `[:ok aligned-path leaf-schema]` when the whole path resolves
+  against recognised ops, or `[:fallback subschema aligned-prefix]` when
+  an unrecognised / opaque op is hit with path remaining — the caller
+  then redacts fail-SAFE iff the leftover `subschema` OR the
+  **already-aligned prefix** carries any sensitive declaration, OR
+  either subtree is opaque. `:map` segments are kept (real app-db
+  keys); index-bearing-op segments are dropped.
 
   Per rf2-ss06u.2 the fallback MUST carry `aligned-prefix` (the segments
   consumed so far) alongside the leftover subschema: a `:sensitive?`
@@ -595,13 +691,24 @@
   to protect. Returning the prefix lets `schema-sensitive-at?` test the
   consumed-ancestor sensitivity (`prefix? decl-path aligned-prefix`)
   too, so a descendant failure under a sensitive ancestor stays
-  redacted + stamped."
+  redacted + stamped.
+
+  Per rf2-hi0tf8 the `:ok` outcome ALSO carries the `leaf-schema` the
+  walk arrived at (the schema at `in-path`'s terminus), not just the
+  aligned path: a path can resolve cleanly through vector-form `:map` /
+  `:tuple` / … structure right up to a NESTED opaque child (a compiled
+  `m/schema` value used as a map slot's tail, e.g. `[:map [:token
+  (m/schema [:string {:sensitive? true}])]]`) — the walk successfully
+  \"arrives\" at that slot (the path is fully consumed), but the slot
+  itself is unintrospectable. Without `leaf-schema` the caller has no
+  way to notice the arrival point is opaque; `schema-sensitive-at?`
+  consults it via `schema-has-opaque-child?` to fail closed."
   [schema in-path]
   (loop [schema  schema
          in      (vec in-path)
          aligned []]
     (if (empty? in)
-      [:ok aligned]
+      [:ok aligned schema]
       (if-not (and (vector? schema) (pos? (count schema)))
         ;; Path remains but the schema is a bare keyword / opaque leaf —
         ;; cannot descend further; hand the leaf to the conservative
@@ -876,8 +983,9 @@
   extractable from the explainer output.
 
   When `in-path` is nil or empty the check is equivalent to
-  `schema-has-sensitive?` (the failing slot IS the whole registered
-  schema, so any sensitive declaration anywhere counts).
+  `(or (schema-has-sensitive? schema) (schema-has-opaque-child? schema))`
+  (the failing slot IS the whole registered schema, so any sensitive
+  declaration OR any unintrospectable nested child anywhere counts).
 
   Malli's `:in` carries collection indices / `:map-of` keys
   (`[1 :token]`, `[\"a\" :secret]`) whereas the walker's decl paths are
@@ -889,39 +997,74 @@
   redacted) just like a top-level one. When the path cannot be fully
   aligned (opaque / unrecognised op with path remaining) the check is
   fail-SAFE: it redacts iff the leftover subschema declares anything
-  sensitive (descendant under the unresolved op) OR a sensitive
-  declaration is an ANCESTOR of the already-consumed prefix (rf2-ss06u.2
-  — a `:sensitive?` container the alignment already descended through and
-  discarded, e.g. `[:s]` sensitive with the leaf `[:s :k]` under a
-  transparent `:and` / `:multi` / `:orn` wrapper).
+  sensitive OR is itself opaque / hides a nested opaque child (descendant
+  under the unresolved op) OR a sensitive declaration is an ANCESTOR of
+  the already-consumed prefix (rf2-ss06u.2 — a `:sensitive?` container
+  the alignment already descended through and discarded, e.g. `[:s]`
+  sensitive with the leaf `[:s :k]` under a transparent `:and` /
+  `:multi` / `:orn` wrapper).
+
+  Per rf2-hi0tf8: even when the path DOES fully align (every segment
+  resolves through recognised vector-form ops), the walk can arrive
+  exactly AT a nested opaque child — e.g. `[:map [:token (m/schema
+  [:string {:sensitive? true}])]]` resolving `[:token]` lands cleanly on
+  the compiled leaf. `align-in-path` returns that arrival schema so this
+  check can fail closed on it too (`schema-has-opaque-child?`), the same
+  way a top-level opaque schema already fails closed via `schema-opaque?`
+  — a nested opaque leaf's invisible `:sensitive?` flag is exactly as
+  dangerous as a root one's.
 
   Returns boolean. Pure; same `(schema, in-path)` always produces the
   same output."
   [schema in-path]
   (if (or (nil? in-path) (empty? in-path))
-    (schema-has-sensitive? schema)
-    (let [[outcome aligned-or-sub aligned-prefix] (align-in-path schema in-path)]
+    (or (schema-has-sensitive? schema) (schema-has-opaque-child? schema))
+    (let [[outcome aligned-or-sub aligned-third] (align-in-path schema in-path)]
       (if (= outcome :fallback)
         ;; Couldn't fully resolve the path. Redact fail-SAFE iff EITHER:
         ;;   - the leftover subschema carries any sensitive declaration
         ;;     (a descendant under the unresolved op), OR
+        ;;   - the leftover subschema is itself opaque or hides a nested
+        ;;     opaque child (rf2-hi0tf8 — the unresolved op MAY be an
+        ;;     opaque compiled value directly, or a resolvable wrapper
+        ;;     that embeds one further down), OR
         ;;   - a sensitive declaration is an ancestor of (or equal to) the
         ;;     prefix align-in-path already consumed (rf2-ss06u.2 — the
         ;;     consumed-ancestor `:sensitive?` is invisible in the leftover
         ;;     subtree; without this the failing value under a sensitive
         ;;     ancestor wrapped by :and/:multi/:orn LEAKS verbatim).
-        ;; The ancestor check is `prefix? decl-path aligned-prefix` only —
+        ;; The ancestor check is `prefix? decl-path aligned-third` only —
         ;; a sensitive SIBLING outside the consumed prefix must NOT taint
-        ;; the failing slot (preserves the precise-narrowing win).
+        ;; the failing slot (preserves the precise-narrowing win). Here
+        ;; `aligned-third` is the aligned PREFIX (the `:fallback` shape).
+        ;;
+        ;; `opaque-nested-tail?`, not `schema-has-opaque-child?`: `aligned-
+        ;; or-sub` was reached by DESCENDING from the root (exactly the
+        ;; nested position `schema-has-opaque-child?`'s docstring
+        ;; describes), so a bare fn/symbol found here is provably
+        ;; flag-free the same way a nested `pos-int?` tail is — it is
+        ;; NOT the whole-registration root case `schema-opaque?` fails
+        ;; closed on.
         (or (schema-has-sensitive? aligned-or-sub)
+            (opaque-nested-tail? aligned-or-sub)
             (let [decls (extract-sensitive-paths-from-schema schema [])]
               (boolean
-                (some (fn [decl-path] (prefix? decl-path aligned-prefix))
+                (some (fn [decl-path] (prefix? decl-path aligned-third))
                       (keys decls)))))
+        ;; Fully aligned (`:ok`). `aligned-or-sub` is the aligned decl-path;
+        ;; `aligned-third` is the LEAF SCHEMA the walk arrived at (the
+        ;; `:ok` shape). Per rf2-hi0tf8 that leaf may itself be a nested
+        ;; opaque child the path resolution walked straight into — check
+        ;; it alongside the existing ancestor/descendant sensitive-decl
+        ;; scan. `opaque-nested-tail?` (not `schema-has-opaque-child?`) for
+        ;; the same reason as the `:fallback` branch above — `leaf` was
+        ;; reached by descent, so a bare fn/symbol there is flag-free.
         (let [decls   (extract-sensitive-paths-from-schema schema [])
-              in-v    aligned-or-sub]
-          (boolean
-            (some (fn [decl-path]
-                    (or (prefix? decl-path in-v)   ;; ancestor sensitive
-                        (prefix? in-v decl-path))) ;; descendant sensitive
-                  (keys decls))))))))
+              in-v    aligned-or-sub
+              leaf    aligned-third]
+          (or (opaque-nested-tail? leaf)
+              (boolean
+                (some (fn [decl-path]
+                        (or (prefix? decl-path in-v)   ;; ancestor sensitive
+                            (prefix? in-v decl-path))) ;; descendant sensitive
+                      (keys decls)))))))))

--- a/implementation/schemas/test/re_frame/schemas_reg_side_effects_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_reg_side_effects_test.clj
@@ -181,6 +181,36 @@
 ;; the `:rf/redacted` and `not str/includes? secret` assertions both fail, and
 ;; the violation egresses the credential — the leak this test pins closed.
 
+(deftest violation-redacts-mismatching-value-when-new-schema-nested-opaque-and-sensitive
+  (testing "rf2-hi0tf8 — when the NEW (re-registered) schema is a VECTOR-FORM
+            (root introspectable) schema that NESTS a compiled / opaque
+            m/schema value carrying a {:sensitive? true} slot, the hot-reload
+            violation still FAILS CLOSED. Pre-fix: the root-only
+            `schema-opaque?` disjunct saw a walkable :map form and returned
+            false, `schema-has-sensitive?`'s walk silently skipped the opaque
+            :secret child (no declaration recorded), so `sensitive?` computed
+            false and the live value egressed verbatim — the same leak
+            `violation-redacts-mismatching-value-when-new-schema-opaque-and-sensitive`
+            already pins for the FULLY opaque shape."
+    (let [secret "NESTED-OPAQUE-HOTRELOAD-SECRET-hi0tf8"]
+      (rf/reg-app-schema [:token] {:schema :int})
+      (set-app-db! {:token {:secret secret}})
+      (let [violations (capture :rf.schema/violation
+                         (fn []
+                           (rf/reg-app-schema
+                             [:token]
+                             {:schema [:map
+                                       [:secret
+                                        (m/schema [:string {:sensitive? true :min 999}])]]})))]
+        (is (= 1 (count violations)) "exactly one violation trace")
+        (let [{:keys [sensitive? tags] :as ev} (first violations)]
+          (is (= :rf/redacted (:mismatching-value tags))
+              "nested-opaque schema fails closed: live value scrubbed to :rf/redacted")
+          (is (true? sensitive?) ":sensitive? hoisted to top level (fail-closed stamp)")
+          (is (= [:token] (:path tags)) "structural :path is kept")
+          (is (not (str/includes? (pr-str ev) secret))
+              "the secret survives nowhere in the nested-opaque hot-reload violation trace"))))))
+
 (deftest violation-is-per-frame
   (testing "rf2-ee38b.6 — the violation check reads the live app-db of
             the registration's frame, not :rf/default"

--- a/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
@@ -1656,6 +1656,167 @@
       (is (not (str/includes? (pr-str out) secret))
           "the secret survives nowhere through the opaque seam"))))
 
+;; ---- rf2-hi0tf8 — NESTED opaque schema fail-closed redaction --------------
+;;
+;; rf2-u9bjgr closed the TOP-LEVEL opaque case (a compiled `m/schema` value
+;; registered directly). It left one gap: a VECTOR-FORM schema — introspectable
+;; at its root — that embeds a compiled `m/schema` value as a CHILD somewhere
+;; inside it. `walk-flagged-schema` recurses into vector-form structure but its
+;; terminal `:else acc` bailout SILENTLY SKIPS a nested opaque child (no
+;; declaration, no warning) exactly like it would the root, but the
+;; `(or schema-has-sensitive? schema-opaque?)` fail-closed composition at every
+;; call site only consulted `schema-opaque?` on the ROOT, which is false for a
+;; vector-form schema regardless of what opaque values it nests. A nested
+;; `{:sensitive? true}` slot Malli honours therefore rode every value-bearing
+;; trace tag VERBATIM. The fix: `schema-has-opaque-child?` recurses the whole
+;; tree (and `align-in-path` / `schema-sensitive-at?` also check the schema a
+;; fully-resolved path ARRIVES at, since a leaf-precise app-db path can resolve
+;; cleanly right onto a nested opaque slot).
+
+(deftest schema-has-opaque-child-predicate
+  (testing "rf2-hi0tf8 — schema-has-opaque-child? is true for a schema that IS
+            opaque (mirrors schema-opaque?) AND for a vector-form schema that
+            NESTS an opaque child at any depth; false when no opaque value is
+            reachable anywhere in the tree"
+    (is (true? (schemas/schema-has-opaque-child?
+                 (m/schema [:map [:password {:sensitive? true} :string]])))
+        "a root-opaque compiled schema is caught (subsumes schema-opaque?)")
+    (is (true? (schemas/schema-has-opaque-child?
+                 [:map [:token (m/schema [:string {:sensitive? true}])]]))
+        "a :map slot whose tail is a compiled m/schema value is caught")
+    (is (true? (schemas/schema-has-opaque-child?
+                 [:cat [:= :auth/login]
+                  (m/schema [:map [:password {:sensitive? true} :string]])]))
+        "a :cat element that is a compiled m/schema value is caught")
+    (is (true? (schemas/schema-has-opaque-child?
+                 [:vector (m/schema [:string {:sensitive? true}])]))
+        "a homogeneous :vector element schema that is opaque is caught")
+    (is (true? (schemas/schema-has-opaque-child?
+                 [:multi {:dispatch :kind}
+                  [:a (m/schema [:map [:secret {:sensitive? true} :string]])]]))
+        "an :multi dispatch branch that is a compiled m/schema value is caught")
+    (is (false? (schemas/schema-has-opaque-child?
+                  [:map [:id :int] [:name :string]
+                   [:auth [:map [:token {:sensitive? true} :string]]]]))
+        "an all-vector-form schema (however deep, however sensitive) has no
+         opaque descendant")
+    (is (false? (schemas/schema-has-opaque-child? :int))
+        "a bare keyword has no opaque descendant")
+    ;; rf2-hi0tf8 confirm-by-corpus: [:map [:n pos-int?]] is the EXACT shape
+    ;; of the machine/data-schema-rollback conformance fixture's [:schemas
+    ;; :data] schema. A bare predicate fn NESTED as a :map slot's tail cannot
+    ;; carry a {props} map (there is no syntax for props on an unwrapped fn
+    ;; — that requires [:fn {...} pred], itself vector-form); any
+    ;; :sensitive?/:large? on the :n slot would live on the SLOT's entry
+    ;; ([:n {:sensitive? true} pos-int?]), which walk-flagged-schema already
+    ;; sees before touching the tail. A NESTED bare fn is therefore provably
+    ;; flag-free — the SAME reasoning the walker's keyword exception
+    ;; (rf2-ee38b.6) already applies — and must NOT be treated as opaque, or
+    ;; every ordinary pos-int?/string?-style leaf in the codebase's own
+    ;; conformance corpus would over-redact.
+    (is (false? (schemas/schema-has-opaque-child? [:map [:n pos-int?]]))
+        "a nested bare predicate fn (pos-int? / string? / …) is provably
+         flag-free, same as a bare keyword — not opaque")
+    ;; rf2-hi0tf8 — the ACTUAL runtime shape the conformance fixture hits:
+    ;; the EDN loader (`clojure.edn/read-string`, no reader-resolver) reads
+    ;; `pos-int?` as a bare SYMBOL, not a live fn value; Malli resolves the
+    ;; symbol to the named fn/var at validate-time (confirmed: `(m/validate
+    ;; [:map [:n 'pos-int?]] {:n 0})` => false, `{:n 5}` => true). A NESTED
+    ;; bare symbol is exactly as provably flag-free as a nested bare fn.
+    (is (false? (schemas/schema-has-opaque-child? [:map [:n 'pos-int?]]))
+        "a nested bare SYMBOL (the EDN-sourced shape Malli resolves) is
+         provably flag-free — not opaque")
+    ;; rf2-hi0tf8 — the ROOT case does NOT get the nested exclusion: a bare
+    ;; fn/symbol used AS THE WHOLE registered :schema (no wrapper at all,
+    ;; e.g. re-frame.flows' {:schema (fn [v] ...)}) has no sibling {props}
+    ;; position anywhere in ITS registration shape — unlike the nested-tail
+    ;; case there is no entry one level up that could carry the flag — so
+    ;; schema-opaque?'s existing fail-closed root treatment is preserved
+    ;; here (flows_schema_validation_test/non-conforming-output-emits-
+    ;; violation-but-still-writes pins exactly this via redact-validation-
+    ;; tags, the seam this predicate feeds)."
+    (is (true? (schemas/schema-has-opaque-child? pos-int?))
+        "a bare fn used AS the whole schema still fails closed, matching
+         schema-opaque? — the root/nested split is deliberate, not an
+         oversight")
+    (is (true? (schemas/schema-has-opaque-child? 'pos-int?))
+        "a bare symbol used AS the whole schema likewise fails closed")))
+
+(deftest event-validation-nested-opaque-schema-fails-closed
+  (testing "rf2-hi0tf8 — a VECTOR-FORM event schema (root introspectable) whose
+            :cat element is a NESTED compiled m/schema value with a
+            :sensitive? slot inside still redacts the failing payload
+            fail-closed. Pre-fix: schema-has-sensitive? silently skipped the
+            opaque :cat element (no declaration recorded) and schema-opaque?
+            on the ROOT [:cat ...] form was false, so sensitive? computed
+            false and the secret rode verbatim — the equivalent fully-opaque
+            schema (event-validation-opaque-schema-fails-closed above) already
+            redacted."
+    (let [secret        "NESTED-OPAQUE-EVENT-SECRET-hi0tf8"
+          nested-opaque (m/schema [:map [:password {:sensitive? true} :string]])
+          schema        [:cat [:= :auth/login] nested-opaque]
+          traces        (atom [])]
+      (rf/register-listener! :trace ::nested-opq-evt (fn [ev] (swap! traces conj ev)))
+      ;; :password is a VECTOR where a :string is required -> fails the schema.
+      (schemas/validate-event! :auth/login [:auth/login {:password [secret]}]
+                               {:schema schema})
+      (rf/unregister-listener! :trace ::nested-opq-evt)
+      (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
+                             @traces))]
+        (is (some? v) "a validation-failure trace fired")
+        (is (true? (:sensitive? v)) "fail-closed: top-level :sensitive? stamp")
+        (is (= :rf/redacted (-> v :tags :value)) ":value redacted")
+        (is (= :rf/redacted (-> v :tags :received)) ":received redacted")
+        (is (= :rf/redacted (-> v :tags :explain)) ":explain redacted")
+        (is (not (str/includes? (pr-str v) secret))
+            "the secret survives nowhere in the nested-opaque event failure trace")))))
+
+(deftest app-db-validation-nested-opaque-schema-fails-closed
+  (testing "rf2-hi0tf8 — a VECTOR-FORM app-db schema (root introspectable)
+            whose failing slot's OWN tail is a nested compiled m/schema value
+            declaring :sensitive? redacts fail-closed, even though the
+            failing :in path resolves CLEANLY (align-in-path's :ok outcome)
+            straight onto that opaque leaf. Pre-fix: schema-sensitive-at?'s
+            :ok branch only consulted extract-sensitive-paths-from-schema
+            (which cannot see into the opaque leaf, so it found no
+            declaration) and never checked whether the arrival schema itself
+            was opaque — the narrowed :value leaked the secret verbatim."
+    (let [secret "NESTED-OPAQUE-APPDB-SECRET-hi0tf8"]
+      (rf/reg-app-schema [:token]
+                         {:schema [:map [:token (m/schema [:string {:sensitive? true}])]]})
+      (let [traces (atom [])]
+        (rf/register-listener! :trace ::nested-opq-db (fn [ev] (swap! traces conj ev)))
+        ;; :token's value is a VECTOR where the nested compiled schema
+        ;; requires a :string -> fails exactly at the opaque leaf ([:token]).
+        (schemas/validate-app-schema! {:token {:token [secret]}} :token/bad)
+        (rf/unregister-listener! :trace ::nested-opq-db)
+        (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
+                               @traces))]
+          (is (some? v) "a validation-failure trace fired")
+          (is (true? (:sensitive? v)) "fail-closed: top-level :sensitive? stamp")
+          (is (= :rf/redacted (-> v :tags :value)) ":value redacted at the leaf")
+          (is (not (str/includes? (pr-str v) secret))
+              "the secret survives nowhere in the nested-opaque app-db failure trace"))))))
+
+(deftest redact-validation-tags-nested-opaque-schema-fails-closed
+  (testing "rf2-hi0tf8 — the off-namespace redact-validation-tags seam
+            (machine-data / sub-override / flow-output / boundary) fails
+            closed for a VECTOR-FORM schema that nests a compiled / opaque
+            m/schema child"
+    (let [secret   "NESTED-OPAQUE-SEAM-SECRET-hi0tf8"
+          schema   [:map [:secret (m/schema [:string {:sensitive? true}])]]
+          tags     {:where    :machine-data
+                    :value    {:secret secret}
+                    :received {:secret secret}
+                    :explain  {:value {:secret secret}}}
+          out      (schemas/redact-validation-tags schema tags)]
+      (is (true? (:sensitive? out)) "fail-closed: :sensitive? stamped")
+      (is (= :rf/redacted (:value out)) ":value redacted")
+      (is (= :rf/redacted (:received out)) ":received redacted")
+      (is (= :rf/redacted (:explain out)) ":explain redacted")
+      (is (not (str/includes? (pr-str out) secret))
+          "the secret survives nowhere through the nested-opaque seam"))))
+
 ;; ---- rf2-vmhu4i — :large? value-bearing slot elision ----------------------
 ;;
 ;; The validation-failure redaction path consulted only schema-has-sensitive?;

--- a/implementation/schemas/test/re_frame/schemas_walker_opaque_warning_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_walker_opaque_warning_test.clj
@@ -109,6 +109,19 @@
                           reason))
             "no positive recommendation to USE the registration-meta fallback")))))
 
+(deftest warning-fires-when-vector-form-schema-nests-an-opaque-child
+  (testing "rf2-hi0tf8 — a VECTOR-FORM schema (introspectable at its root)
+            that embeds a compiled m/schema value as a NESTED child (a
+            :map slot's tail) also emits the warning; the root-only
+            `schema-opaque?` check used to miss this and stay silent"
+    (let [recorded (record-traces! ::nested-opaque-child)]
+      (rf/reg-app-schema [:token]
+                         {:schema [:map [:secret {} {:malli/schema :compiled}]]})
+      (let [warns (warnings-of recorded :rf.warning/schema-walker-opaque)]
+        (is (= 1 (count warns))
+            "a nested opaque child triggers the warning exactly once")
+        (is (= [:token] (-> warns first :tags :path)))))))
+
 ;; ---- negative paths (no warning) ------------------------------------------
 
 (deftest warning-suppressed-when-schema-is-vector-form

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -967,6 +967,7 @@
   ["re-frame.schemas" "schema-sensitive-at?"]               {:tier :implementation :owner "015" :status "v1"}
   ["re-frame.schemas" "schema-has-large?"]                  {:tier :implementation :owner "015" :status "v1"}
   ["re-frame.schemas" "schema-opaque?"]                     {:tier :implementation :owner "015" :status "v1"}
+  ["re-frame.schemas" "schema-has-opaque-child?"]           {:tier :implementation :owner "015" :status "v1"}
   ["re-frame.schemas" "extract-sensitive-paths-from-schema"] {:tier :implementation :owner "015" :status "v1"}
   ["re-frame.schemas" "extract-large-paths-from-schema"]     {:tier :implementation :owner "015" :status "v1"}
   ["re-frame.schemas" "clear-sensitive-paths-cache!"]    {:tier :implementation :owner "010" :status "v1"}

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -6,7 +6,7 @@
  {:doc
  "GENERATED public-API manifest — do NOT hand-edit the :vars list. Regenerate with: clojure -M -m re-frame.api-manifest.gen (run from implementation/scripts/api-manifest/). The tier/owner/status axes are curated in spec/api-manifest-metadata.edn; existence + kind + facade? are derived from live public vars. See that generator ns for the design.",
  :keystone "rf2-3nbl5.2",
- :var-count 471,
+ :var-count 472,
  :tier-vocab
  [:front-porch
   :advanced
@@ -291,6 +291,7 @@
   {:namespace "re-frame.schemas", :var "restore-schema-fns!", :tier :implementation, :kind :fn, :owner "010", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.schemas", :var "restore-schemas-by-frame!", :tier :implementation, :kind :fn, :owner "010", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.schemas", :var "schema-has-large?", :tier :implementation, :kind :fn, :owner "015", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.schemas", :var "schema-has-opaque-child?", :tier :implementation, :kind :fn, :owner "015", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.schemas", :var "schema-has-sensitive?", :tier :implementation, :kind :fn, :owner "015", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.schemas", :var "schema-opaque?", :tier :implementation, :kind :fn, :owner "015", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.schemas", :var "schema-sensitive-at?", :tier :implementation, :kind :fn, :owner "015", :status "v1", :facade? false, :runtime-verified? true}


### PR DESCRIPTION
## Summary

- P1 privacy leak: a nested opaque schema's validation data (a compiled `m/schema`, map, or other non-vector/non-keyword value embedded as a CHILD inside an otherwise-walkable vector-form schema) leaked sensitive values verbatim into `:rf.error/schema-validation-failure` traces — every fail-closed redaction/warning gate only checked `walker/schema-opaque?` on the ROOT form, missing nested opacity.
- Adds `walker/schema-has-opaque-child?` — a recursive sibling of `schema-opaque?` — and wires it into every fail-closed composition site: event/fx/sub validation, app-db validation (both the whole-schema and leaf-precise decisions, via `schema-sensitive-at?`), the off-namespace `redact-validation-tags` seam (machine-data / sub-override / flow-output / boundary), and the hot-reload `:rf.schema/violation` trace — plus the registration-time `:rf.warning/schema-walker-opaque` discoverability nudge.
- Closes a second, narrower gap in `schema-sensitive-at?`: an app-db `:in` path can resolve *cleanly* (via `align-in-path`'s `:ok` outcome) straight onto a nested opaque leaf without the check ever inspecting that leaf's own opacity. `align-in-path` now also returns the arrival schema so `schema-sensitive-at?` can fail closed on it.
- Deliberate precision carve-out: a bare predicate fn (`pos-int?`) or the bare *symbol* Malli resolves it to when a schema is EDN-sourced (`clojure.edn/read-string` has no reader-resolver) is excluded from the recursive opaque check **only when reached as a nested tail** — any hypothetical `:sensitive?` prop on that slot lives on the entry one level up (`[:n {:sensitive? true} pos-int?]`), which the walker already sees regardless of the tail's shape (same reasoning as the walker's existing bare-keyword exception, rf2-ee38b.6). A bare fn/symbol used **as the whole registered schema** still fails closed, matching `schema-opaque?`'s unchanged root contract.

## Quality gates

- **Public-API manifest drift-check + Lint required** (fixed post-rebase) — the fix re-exports `re-frame.schemas/schema-has-opaque-child?`, a new public var that needs a sidecar classification row. Added it to `spec/api-manifest-metadata.edn` (`:implementation` / owner 015 / v1, matching its sibling schema predicates) and regenerated the committed `spec/api-manifest.edn` (471 → 472 public vars). `clojure -M -m re-frame.api-manifest.gen --check` and the `api-md-check` projection now both pass locally. ("Lint required" is the aggregation gate over `[clj-kondo, splint, api-manifest]`; clj-kondo + splint were already green, so this manifest fix greens both.) No error-catalogue / allow-list change was needed: `:rf.warning/schema-walker-opaque` is a **pre-existing** id already catalogued in spec/009 (the fix only re-uses it, does not introduce it), and `error-catalogue-channel-conformance-test` passes locally (9 tests, 21 assertions, 0 failures).
- Rebased cleanly onto latest `origin/main` (no conflicts).
- `clojure -M:test` in `implementation/schemas` — 328 tests, 18899 assertions, 0 failures.
- `clojure -M:test` in `implementation/flows`, `implementation/machines`, `implementation/core`, `implementation/resources`, `implementation/routing`, `implementation/http`, `implementation/ssr` — all 0 failures (downstream consumers of the shared redaction seam).
- `npm run test:cljs` from `implementation/` — 8130 tests, 37256 assertions, 0 failures (includes the full conformance corpus; re-run post-rebase, count rose from 8116 as the rebase pulled in newly-merged tests).
- Regression tests added (RED confirmed against pre-fix code via patch-based reversal, then GREEN against the fix):
  - `schema-has-opaque-child-predicate` — direct unit coverage of the new recursive predicate, including the root-vs-nested fn/symbol precision split.
  - `event-validation-nested-opaque-schema-fails-closed` — event surface.
  - `app-db-validation-nested-opaque-schema-fails-closed` — app-db surface, specifically the `align-in-path` `:ok`-arrives-on-opaque-leaf gap.
  - `redact-validation-tags-nested-opaque-schema-fails-closed` — the off-namespace seam (machine-data / sub-override / flow-output / boundary).
  - `violation-redacts-mismatching-value-when-new-schema-nested-opaque-and-sensitive` — hot-reload `:rf.schema/violation` trace.
  - `warning-fires-when-vector-form-schema-nests-an-opaque-child` — registration-time discoverability warning.
- A real regression was caught and fixed during development: the initial (fn/symbol-blind) version of the recursive predicate broke the `:machine/data-schema-rollback` conformance fixture (its `[:schemas :data]` schema is `[:map [:n pos-int?]]`, and the EDN loader reads `pos-int?` as a bare symbol) by over-redacting an ordinary non-sensitive predicate-fn leaf. Caught via the full `npm run test:cljs` conformance-corpus run, fixed via the nested-tail carve-out, and pinned with dedicated regression tests plus a root/nested-divergence test cross-checked against `flows_schema_validation_test.clj`'s existing pinned root-opaque-fn contract.

## Risks

- None identified beyond the above — the fn/symbol precision split was specifically verified against both directions of the tension (the machine conformance fixture requiring nested fn/symbol leaves to NOT redact, and the flows test requiring a root-level bare-fn schema to STILL redact) before landing.
