### PR TITLE
fix(resources): use first-load cleanup on infinite-feed page-0 abort/failure (rf2-s54uzc)

### DIFF
--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -2583,29 +2583,45 @@
   Verifies frame + work-id + generation; on match SPLITS the settlement by
   page identity (rf2-byl7bk.3.1, Spec 016 §Status semantics / §Infinite):
 
+    - a FIRST-LOAD (page 0) ABORT with NO accumulated pages (rf2-s54uzc) is
+      checked BEFORE the generic abort branch below: there is no usable data,
+      so it settles like the scalar first-load abort (`entry-abort-settled`'s
+      `:idle` branch) — `:status :idle`, no error, `:current-work nil` — NEVER
+      `:loaded`. Settling `:loaded` on an empty feed (the pre-fix behaviour)
+      lied about freshness and let a later `:rf.resource/ensure` fresh-skip a
+      feed that never actually loaded page 0. Drains blocking as `:success`
+      and marks the work row terminal `:cancelled` (an abort is not an
+      error), and ARMS the stale/GC timers — mirroring rf2-kz5op1's
+      `entry-abort-settled` fix in `failed-handler` — so an owner-free `:idle`
+      entry from a cancelled first load is reaped;
+
     - a FIRST-LOAD (page 0) failure with NO accumulated pages is NOT a
       load-more failure — it is a first load with no usable data. It settles
       the FIRST-load `:error` channel (`entry-failed` → `:status :error`,
       `:error` envelope, `:data nil`) and drains a blocking route as
       `:failure`, so a blocking infinite route flips to route `:error` exactly
       like a blocking SCALAR resource (`drain-blocking`'s `:status :error`
-      branch fires automatically — no route.cljc change). Spec 016 reserves
-      `:error` / `:status :error` for first-load (page 0) failure;
+      branch fires automatically — no route.cljc change), and ARMS the
+      stale/GC timers (rf2-s54uzc, mirroring rf2-ar9pcx's scalar `:error`
+      arming) so an owner-free errored empty feed is reaped. Spec 016
+      reserves `:error` / `:status :error` for first-load (page 0) failure;
 
-    - a LOAD-MORE (page N>0) failure — OR a page-0 failure when the feed
-      ALREADY has accumulated pages (an R6 window-preserving refetch that
-      fails its replacement page 0 is NOT a first load — there is a feed to
-      keep) — is the THIRD error channel: the feed returns to `:loaded`, KEEPS
-      ALL accumulated pages, and records `:page-error` (`entry-page-failed`),
-      so a view shows \"couldn't load more — retry\" without losing the feed.
-      The blocking slot drains as `:success` (the route blocks on page 0 only,
-      which already landed). Spec 016 reserves `:page-error` for load-more
-      (page N>0) failure only.
+    - a LOAD-MORE (page N>0) abort/failure — OR a page-0 abort/failure when
+      the feed ALREADY has accumulated pages (an R6 window-preserving refetch
+      that fails/aborts its replacement page 0 is NOT a first load — there is
+      a feed to keep) — settles to `:loaded` (data kept, no timer re-arming:
+      the timers were already armed on the feed's prior success). A FAILURE
+      here is the THIRD error channel: KEEPS ALL accumulated pages and records
+      `:page-error` (`entry-page-failed`), so a view shows \"couldn't load
+      more — retry\" without losing the feed. The blocking slot drains as
+      `:success` (the route blocks on page 0 only, which already landed).
+      Spec 016 reserves `:page-error` for load-more (page N>0) failure only.
 
   A stale / superseded / cross-frame reply is SUPPRESSED. An ABORT
   (`:rf.http/aborted`) is a cancellation, not a page error: the feed settles
   to `:loaded` (data kept) with NO `:page-error` written, and the work row
-  settles `:cancelled`.
+  settles `:cancelled` — UNLESS it is a first-load abort (see above), which
+  settles `:idle` (no data to keep).
 
   Event shape: `[_ <verification-payload> <http-result>]` — the transport
   appends the canonical `{:status :error :error <:rf.http/* envelope> …}` as the last arg."
@@ -2643,9 +2659,59 @@
                                        :outcome (if aborted? :aborted :page-failure)
                                        :completed-at completed-at})})
 
-      ;; ABORT — an intentional cancellation of the page fetch. The feed keeps
-      ;; its pages and returns to :loaded WITHOUT a :page-error (a cancellation
-      ;; is not a load-more failure). The work row settles terminal :cancelled.
+      ;; FIRST-LOAD ABORT (rf2-s54uzc) — a page-0 fetch with NO accumulated
+      ;; pages was aborted: there is no usable data, so this is a first load
+      ;; with no data, NOT the generic infinite-abort settle below. BEFORE
+      ;; this fix the generic abort branch unconditionally settled `:loaded`
+      ;; — including an EMPTY feed, which lied about freshness and let a
+      ;; later `:rf.resource/ensure` fresh-skip a feed that never actually
+      ;; loaded page 0. Settle instead like the scalar first-load abort
+      ;; (`entry-abort-settled`'s `:idle` branch): `:status :idle`, no error,
+      ;; `:current-work nil`. Drain blocking as `:success` (an aborted first
+      ;; load un-blocks the route rather than surfacing a spurious error,
+      ;; symmetric with the scalar path) and mark the work row terminal
+      ;; `:cancelled`. Arms the stale/GC timers — mirroring rf2-kz5op1's
+      ;; `entry-abort-settled` fix in `failed-handler` — so an owner-free
+      ;; `:idle` entry from a cancelled first load is reaped (GC timers are
+      ;; otherwise armed only on a successful settle or a first-load `:error`
+      ;; settle).
+      (and aborted? first-load?)
+      (let [entry' (-> (assoc entry :status :idle :current-work nil)
+                       state/clear-refetch-sweep
+                       state/bump-revision)
+            spec   (registry/resource-meta (:resource/id entry'))
+            rdb'   (-> runtime-db
+                       (assoc-in (state/entry-path resource-key) entry')
+                       (work-ledger/update-record
+                         work-id work-ledger/mark-terminal
+                         :cancelled {:reason :aborted :completed-at completed-at})
+                       (route/drain-blocking resource-key entry' :success))
+            stale-delay-ms (state/positive-or-nil (:stale-after-ms spec))
+            gc-delay-ms    (state/positive-or-nil (:gc-after-ms spec))]
+        (work-ledger/clear-handle! frame-id work-id)
+        (trace/emit! :rf.event :rf.resource/work-abort-requested
+                     {:rf.frame/id frame-id :resource/key resource-key
+                      :work/id work-id :generation generation
+                      :status-before (:status entry) :status-after (:status entry')})
+        (cond-> {:rf.db/runtime rdb'}
+          (or stale-delay-ms gc-delay-ms)
+          (assoc :fx [[:rf.resource/schedule-timers
+                       {:frame-id       frame-id
+                        :resource/key   resource-key
+                        :stale-delay-ms stale-delay-ms
+                        :gc-delay-ms    gc-delay-ms
+                        :poll-delay-ms  nil
+                        :server?        (state/server-frame? frame-id)}]])))
+
+      ;; ABORT (non-first-load) — an intentional cancellation of a load-more,
+      ;; or a page-0 REFETCH abort over a feed that already has accumulated
+      ;; pages (R6 window-preserving — there is a feed to keep, so it is not a
+      ;; first load; the `first-load?` branch above handles the empty-feed
+      ;; case). The feed keeps its pages and returns to :loaded WITHOUT a
+      ;; :page-error (a cancellation is not a load-more failure). The work row
+      ;; settles terminal :cancelled. No timer re-arming here — the stale/GC
+      ;; timers were already armed on the feed's prior success (symmetric with
+      ;; the background-refresh-abort guard).
       aborted?
       ;; an abort during a multi-page refetch sweep STOPS the sweep (clear the
       ;; cursor — a cancelled leg does not chain the next; rf2-byl7bk.3.3). The
@@ -2680,12 +2746,22 @@
       ;; `:rf.resource/page-failed`) so the channel and the trace agree.
       first-load?
       (let [entry' (state/entry-failed entry {:error error})
+            spec   (registry/resource-meta (:resource/id entry'))
             rdb'   (-> runtime-db
                        (assoc-in (state/entry-path resource-key) entry')
                        (work-ledger/update-record
                          work-id work-ledger/mark-terminal
                          :failed {:error error :completed-at completed-at})
-                       (route/drain-blocking resource-key entry' :failure))]
+                       (route/drain-blocking resource-key entry' :failure))
+            ;; rf2-s54uzc — mirrors rf2-ar9pcx's scalar first-load `:error`
+            ;; arming (`failed-handler`'s `:else` branch): a first-load
+            ;; infinite-feed failure settles `:error` with `:current-work nil`
+            ;; the same as the scalar path, so it must arm the GC (+ stale)
+            ;; timer the same way — otherwise an owner-free errored empty feed
+            ;; is never reaped (the same unbounded per-frame cache leak this
+            ;; handler's abort twin, above, is also fixed against).
+            stale-delay-ms (state/positive-or-nil (:stale-after-ms spec))
+            gc-delay-ms    (state/positive-or-nil (:gc-after-ms spec))]
         (work-ledger/clear-handle! frame-id work-id)
         (trace/emit! :rf.event :rf.resource/work-completed
                      {:rf.frame/id frame-id :resource/key resource-key
@@ -2695,7 +2771,15 @@
                       :work/id work-id :generation generation
                       :status-before (:status entry) :status-after (:status entry')
                       :error error})
-        {:rf.db/runtime rdb'})
+        (cond-> {:rf.db/runtime rdb'}
+          (or stale-delay-ms gc-delay-ms)
+          (assoc :fx [[:rf.resource/schedule-timers
+                       {:frame-id       frame-id
+                        :resource/key   resource-key
+                        :stale-delay-ms stale-delay-ms
+                        :gc-delay-ms    gc-delay-ms
+                        :poll-delay-ms  nil
+                        :server?        (state/server-frame? frame-id)}]])))
 
       ;; LOAD-MORE PAGE FAILURE — the third error channel: keep the feed,
       ;; record :page-error, return to :loaded. This is a page N>0 failure, OR

--- a/implementation/resources/test/re_frame/resources_infinite_load_more_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_infinite_load_more_cljs_test.cljc
@@ -50,10 +50,18 @@
 
 (def ^:private last-managed-args (atom nil))
 
+;; rf2-s54uzc — captures the `:rf.resource/schedule-timers` fx (real host
+;; timer scheduling is tested elsewhere) so the page-0 abort/failure timer-
+;; arming fix can be asserted deterministically, without a wall clock —
+;; mirrors `resources-invalidation-gc-cljs-test`'s capturing pattern.
+(def ^:private scheduled-timers (atom []))
+
 (defn- capturing-transport-fixture
   [f]
   (reset! last-managed-args nil)
+  (reset! scheduled-timers [])
   (rf/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
+  (rf/reg-fx :rf.resource/schedule-timers (fn [_ctx args] (swap! scheduled-timers conj args) nil))
   (f))
 
 (use-fixtures :each
@@ -84,6 +92,16 @@
   ([failure] (reply-failure! @last-managed-args failure))
   ([args failure]
    (rf/dispatch-sync (conj (:on-failure args) {:status :error :error failure}))))
+
+(defn- reply-aborted!
+  "Feed the captured `:on-failure` reply an `:rf.http/aborted` envelope (an
+  intentional cancellation, not a failure — rf2-z70ujl) — `page-failed-
+  handler` branches this into the ABORT / cancellation settle."
+  ([] (reply-aborted! @last-managed-args))
+  ([args] (reply-failure! args {:kind :rf.http/aborted :reason :user})))
+
+(defn- last-schedule-for [scoped-key]
+  (last (filter #(= scoped-key (:resource/key %)) @scheduled-timers)))
 
 (def ^:private next-cursor
   "Read the next cursor off a page's `:page-info` envelope; nil ⇒ terminal."
@@ -471,6 +489,120 @@
       (is (nil? @last-managed-args) "fresh loaded feed served from cache, no refetch")
       (is (= gen0 (:generation (entry k))) "no new generation")
       (is (= 1 (state/page-count (entry k))) "feed untouched"))))
+
+;; ===========================================================================
+;; 8b. rf2-s54uzc — page-0 abort/failure uses FIRST-LOAD cleanup, not the
+;;     load-more / kept-feed cleanup — an infinite feed's first page never
+;;     landed, so there is no feed to keep.
+;; ===========================================================================
+;;
+;; BEFORE this fix, an ABORTED page-0 fetch (no accumulated pages) settled
+;; through the SAME branch as a load-more abort — unconditionally `:status
+;; :loaded` — even though the feed had ZERO pages. A `:loaded` empty feed is
+;; indistinguishable from a genuinely loaded feed to the fresh-skip check
+;; (`ensure-infinite-fresh-skip-serves-cache`, above), so a later
+;; `:rf.resource/ensure` served the (permanently empty) "cache" forever — the
+;; reported infinite-feed hang. The fix settles a first-load (page-0, no
+;; accumulated pages) abort to `:idle` (mirrors the scalar `entry-abort-
+;; settled` first-load branch), so a later ensure re-fetches. The non-abort
+;; first-load `:error` settle ALSO gained GC/stale timer arming (it silently
+;; omitted this, unlike the scalar first-load failure path).
+
+(deftest page-0-abort-settles-idle-not-loaded
+  (testing "rf2-s54uzc — an ABORTED page-0 fetch with NO accumulated pages
+            settles :idle (first-load cleanup), NEVER :loaded (the load-more
+            cleanup) — the pre-fix bug settled :loaded on an empty feed"
+    (rf/reg-resource :ab0/feed (feed-spec) feed-spec-request)
+    (ensure! :ab0/feed)
+    (let [k   (feed-key :ab0/feed)
+          wid (:current-work (entry k))]
+      (reply-aborted!)
+      (let [e (entry k)]
+        (is (= :idle (:status e)) "first-load abort settles :idle, not :loaded")
+        (is (= [] (:data e)) "no pages accumulated")
+        (is (nil? (:current-work e)) "no in-flight work after the abort settle")
+        (is (nil? (:error e)) "an abort is not an :error settle"))
+      (is (= :cancelled (:status (work-ledger/get-record (runtime-db) wid)))
+          "the work row settles terminal :cancelled"))))
+
+(deftest page-0-abort-does-not-fresh-skip-future-ensure
+  (testing "rf2-s54uzc — RED against the pre-fix behaviour: because the abort
+            settles :idle (not :loaded), a later ensure of the SAME feed
+            re-fetches page 0 rather than fresh-skipping a permanently-empty
+            'cache' (the reported infinite-feed hang)"
+    (rf/reg-resource :ab1/feed (feed-spec) feed-spec-request)
+    (ensure! :ab1/feed)
+    (reply-aborted!)
+    (reset! last-managed-args nil)
+    (ensure! :ab1/feed)
+    (is (some? @last-managed-args)
+        "a second ensure after a page-0 abort issues a NEW page-0 fetch — it
+         must NOT fresh-skip the empty, never-loaded feed")
+    (is (= 0 (get-in @last-managed-args [:request :params :page-index]))
+        "the re-issued fetch is page-0")
+    (is (= :loading (:status (entry (feed-key :ab1/feed))))
+        "the re-issued first load is :loading")))
+
+(deftest page-0-abort-arms-gc-and-stale-timers
+  (testing "rf2-s54uzc — a page-0 ABORT (first-load cleanup) arms the GC (+
+            stale) timer exactly like the scalar first-load abort (rf2-
+            kz5op1) — before this fix the infinite page-0 abort branch never
+            emitted :rf.resource/schedule-timers, leaking an owner-free empty
+            feed"
+    (rf/reg-resource :ab2/feed (feed-spec {:gc-after-ms 5000 :stale-after-ms 1000})
+                     feed-spec-request)
+    (ensure! :ab2/feed)
+    (let [k (feed-key :ab2/feed)]
+      (reset! scheduled-timers [])
+      (reply-aborted!)
+      (let [args (last-schedule-for k)]
+        (is (some? args) "schedule-timers emitted on the page-0 abort settle")
+        (is (= 5000 (:gc-delay-ms args)) "GC timer armed at :gc-after-ms")
+        (is (= 1000 (:stale-delay-ms args)) "stale timer armed at :stale-after-ms")
+        (is (nil? (:poll-delay-ms args)) "no poll timer for an aborted entry")))))
+
+(deftest page-0-failure-arms-gc-and-stale-timers
+  (testing "rf2-s54uzc — a page-0 FAILURE (non-abort) with no accumulated
+            pages also arms the GC (+ stale) timer, mirroring the scalar
+            first-load :error arming (rf2-ar9pcx) — before this fix the
+            infinite first-load failure branch omitted timer scheduling
+            entirely"
+    (rf/reg-resource :fl0/feed (feed-spec {:gc-after-ms 5000 :stale-after-ms 1000})
+                     feed-spec-request)
+    (ensure! :fl0/feed)
+    (let [k (feed-key :fl0/feed)]
+      (reset! scheduled-timers [])
+      (reply-failure! {:kind :rf.http/server :status 503})
+      (let [e (entry k)]
+        (is (= :error (:status e)) "first-load failure settles :error")
+        (is (nil? (:current-work e)) "no in-flight work after the error settle"))
+      (let [args (last-schedule-for k)]
+        (is (some? args) "schedule-timers emitted on the page-0 :error settle")
+        (is (= 5000 (:gc-delay-ms args)) "GC timer armed at :gc-after-ms")
+        (is (= 1000 (:stale-delay-ms args)) "stale timer armed at :stale-after-ms")
+        (is (nil? (:poll-delay-ms args)) "no poll timer for an errored entry")))))
+
+(deftest load-more-abort-keeps-loaded-no-rearm
+  (testing "rf2-s54uzc guard — an ABORTED load-more (page N>0, feed already
+            has pages) is NOT a first load: it keeps its pages, stays
+            :loaded, and re-arms NO timer (already armed on the prior page-0
+            success) — confirms the first-load split didn't change this
+            sibling path"
+    (rf/reg-resource :lma/feed (feed-spec {:gc-after-ms 5000}) feed-spec-request)
+    (ensure! :lma/feed)
+    (reply-success! (page [:a] "c1"))
+    (let [k (feed-key :lma/feed)]
+      (is (some? (last-schedule-for k)) "the page-0 success armed the GC timer")
+      (reset! scheduled-timers [])
+      (load-more! :lma/feed)
+      (reply-aborted!)
+      (let [e (entry k)]
+        (is (= :loaded (:status e)) "load-more abort keeps :loaded")
+        (is (= 1 (state/page-count e)) "page-0 kept")
+        (is (nil? (:page-error e)) "an abort is not a page-error"))
+      (is (empty? (filter #(= k (:resource/key %)) @scheduled-timers))
+          "no timer re-armed by the load-more abort (already armed on the
+           prior page-0 success)"))))
 
 ;; ===========================================================================
 ;; 9. rf2-bi8vg1 — a load-more given a MISTAKEN (non-route) owner is


### PR DESCRIPTION
## Summary

`page-failed-handler` (infinite-feed page reply handler) settled an ABORTED page-0 fetch — a first load with NO accumulated pages — through the same branch as a load-more abort: unconditionally `:status :loaded`. A `:loaded` empty feed is indistinguishable from a genuinely loaded one to the fresh-skip check, so a later `:rf.resource/ensure` served the permanently-empty "cache" forever instead of retrying page 0 (the reported infinite-feed hang).

Fix (`implementation/resources/src/re_frame/resources/events.cljc`, `page-failed-handler`):

- Split `(and aborted? first-load?)` into its own `cond` clause BEFORE the generic abort branch. It now settles like the scalar first-load abort (`entry-abort-settled`'s `:idle` branch): `:status :idle`, no error, `:current-work nil`; drains blocking as `:success`; marks the work row terminal `:cancelled`; and ARMS the stale/GC timers (mirroring rf2-kz5op1's `entry-abort-settled` fix in `failed-handler`) so an owner-free `:idle` entry from a cancelled first load is reaped.
- The generic (non-first-load) abort branch is unchanged — a load-more abort, or a page-0 REFETCH abort over a feed that already has pages (R6 window-preserving), still settles `:loaded` with pages kept, no timer re-arm.
- The non-abort first-load `:error` failure branch now ALSO arms the stale/GC timers, mirroring rf2-ar9pcx's scalar first-load `:error` arming — it previously omitted this entirely, leaking an owner-free errored empty feed.

## Quality gates

- `clojure -M:test` from `implementation/resources/` — 609 tests, 6115 assertions, **0 failures, 0 errors**.
- `npm run test:cljs` from `implementation/` — 8133 tests, 37263 assertions, **0 failures, 0 errors**.
- New regression tests (`implementation/resources/test/re_frame/resources_infinite_load_more_cljs_test.cljc`, section "8b"):
  - `page-0-abort-settles-idle-not-loaded`
  - `page-0-abort-does-not-fresh-skip-future-ensure`
  - `page-0-abort-arms-gc-and-stale-timers`
  - `page-0-failure-arms-gc-and-stale-timers`
  - `load-more-abort-keeps-loaded-no-rearm` (guard: confirms the sibling load-more path is unchanged)
  - Verified RED against the pre-fix source: temporarily restored the pre-fix `events.cljc` and reran — all 4 new bug-covering tests failed exactly as expected (10 failures total incl. cascading assertions), confirming they exercise the actual bug before the fix.

## Risk

Low — isolated to `page-failed-handler`'s abort/failure branching for infinite feeds; scalar resources and the load-more/kept-feed path are untouched (guarded by a new regression test). No spec change; behaviour now matches the documented Spec 016 first-load semantics that scalar resources already had.