### PR TITLE
fix(examples): encode RealWorld article-list query parameters (rf2-rt13fn)

### DIFF
--- a/examples/real-apps/realworld_http/articles.cljs
+++ b/examples/real-apps/realworld_http/articles.cljs
@@ -238,18 +238,16 @@
          showing)."
    :rf.http/decode-schemas [schema/ArticlesResponse]}
   ;; The route lives in runtime-db. The 1-indexed `?page=` off the route query
-  ;; becomes the wire's limit/offset window via `rh/paginate-path`. The active
-  ;; tag is a path param; the page is a query param; and on the wire it all
-  ;; collapses to `/articles?tag=…&limit=…&offset=…`. Frontend route shape and
-  ;; API query string are deliberately independent.
+  ;; becomes the wire's limit/offset window via `rh/paginate-path`, which also
+  ;; URL-encodes the `:tag` filter. The active tag is a path param; the page is
+  ;; a query param; and on the wire it all collapses to
+  ;; `/articles?tag=…&limit=…&offset=…`. Frontend route shape and API query
+  ;; string are deliberately independent.
   (fn [{:keys [db] rt :rf.db/runtime} _]
     (let [current   (get-in rt [:rf.runtime/routing :current])
           tag       (get-in current [:params :tag])
           page      (or (get-in current [:query :page]) 1)
-          base      (if tag
-                      (str "/articles?tag=" tag)
-                      "/articles")
-          path      (rh/paginate-path base page)
+          path      (rh/paginate-path "/articles" (when tag {:tag tag}) page)
           has-data? (seq (get-in db [:articles :data]))]
       {:db (-> db
                (assoc-in [:articles :status] (if has-data? :fetching :loading))

--- a/examples/real-apps/realworld_http/favorites.cljs
+++ b/examples/real-apps/realworld_http/favorites.cljs
@@ -66,7 +66,7 @@
    :rf.http/decode-schemas [schema/ArticlesResponse]}
   (fn [{:keys [db] rt :rf.db/runtime} _]
     (let [page (or (get-in rt [:rf.runtime/routing :current :query :page]) 1)
-          path (rh/paginate-path "/articles/feed" page)]
+          path (rh/paginate-path "/articles/feed" nil page)]
       {:db (-> db
                (assoc-in [:feed :status]
                          (if (seq (get-in db [:feed :data])) :fetching :loading))

--- a/examples/real-apps/realworld_http/http.cljs
+++ b/examples/real-apps/realworld_http/http.cljs
@@ -99,14 +99,33 @@
   [articles-count]
   (max 1 (long (js/Math.ceil (/ (or articles-count 0) page-size)))))
 
+(defn query-string
+  "Assemble a `?k=v&k2=v2…` query string from a map of query params, with every
+   value URL-encoded via `js/encodeURIComponent` so a tag, username, or other
+   filter value carrying a reserved query character (`&`, `=`, `#`, a space,
+   …) reaches the API as that literal value instead of corrupting the query
+   string it's embedded in. Nil-valued params are dropped, and an empty (or
+   all-nil) map yields `\"\"`, not a bare `\"?\"`."
+  [params]
+  (let [pairs (for [[k v] params :when (some? v)]
+                (str (name k) "=" (js/encodeURIComponent (str v))))]
+    (if (seq pairs)
+      (str "?" (clojure.string/join "&" pairs))
+      "")))
+
 (defn paginate-path
-  "Tack the `limit` + `offset` query params for `page` (1-indexed) onto a list
-   `path`, keeping whatever params the path already has (so
-   `/articles?tag=foo` becomes `/articles?tag=foo&limit=10&offset=20`). The
-   API base gets prepended later, by the request builder via `full-url`."
-  [path page]
-  (let [sep (if (clojure.string/includes? path "?") "&" "?")]
-    (str path sep "limit=" page-size "&offset=" (page->offset page))))
+  "Assemble a Conduit list-endpoint `path` (e.g. `/articles` or
+   `/articles/feed`) plus optional `filters` — a map like `{:tag \"clojure\"}`,
+   `{:author \"jake\"}`, or `{:favorited \"jake\"}`; `nil`/`{}` for the
+   unfiltered list — plus the `limit`/`offset` pagination window for `page`
+   (1-indexed). Every value goes through `query-string`, so it's properly
+   URL-encoded rather than concatenated raw — a tag or username with a
+   reserved query character no longer corrupts the request. The API base gets
+   prepended later, by the request builder via `full-url`."
+  [path filters page]
+  (str path (query-string (assoc filters
+                                  :limit page-size
+                                  :offset (page->offset page)))))
 
 ;; ============================================================================
 ;; RETRY POLICIES

--- a/examples/real-apps/realworld_http/profile.cljs
+++ b/examples/real-apps/realworld_http/profile.cljs
@@ -201,12 +201,13 @@
   {:doc "Fetch the articles this user wrote. Public; house retry. Also
          broadcasts `:show-articles` so the `:ui/profile` :tab region knows
          which tab is live. `?page=` paginates via `rh/paginate-path` (the
-         official RealWorld limit/offset shape)."
+         official RealWorld limit/offset shape), which also URL-encodes the
+         `:author` filter."
    :rf.http/decode-schemas [schema/ArticlesResponse]}
   (fn [{:keys [db] rt :rf.db/runtime} _]
     (let [username (username-from-db rt)
           page     (or (get-in rt [:rf.runtime/routing :current :query :page]) 1)
-          path     (rh/paginate-path (str "/articles?author=" username) page)]
+          path     (rh/paginate-path "/articles" {:author username} page)]
       {:db (-> db
                (assoc-in [:profile.articles :status] :loading)
                (assoc-in [:profile.articles :error] nil)
@@ -241,12 +242,13 @@
   {:doc "Fetch the articles this user favorited. Public; house retry. Also
          broadcasts `:show-favorites` so the `:ui/profile` :tab region knows
          which tab is live. `?page=` paginates via `rh/paginate-path` (the
-         official RealWorld limit/offset shape)."
+         official RealWorld limit/offset shape), which also URL-encodes the
+         `:favorited` filter."
    :rf.http/decode-schemas [schema/ArticlesResponse]}
   (fn [{:keys [db] rt :rf.db/runtime} _]
     (let [username (username-from-db rt)
           page     (or (get-in rt [:rf.runtime/routing :current :query :page]) 1)
-          path     (rh/paginate-path (str "/articles?favorited=" username) page)]
+          path     (rh/paginate-path "/articles" {:favorited username} page)]
       {:db (-> db
                (assoc-in [:profile.favorites :status] :loading)
                (assoc-in [:profile.favorites :error] nil)

--- a/examples/real-apps/realworld_resources/http.cljs
+++ b/examples/real-apps/realworld_resources/http.cljs
@@ -52,6 +52,20 @@
 (defn full-url [path]
   (str api-base path))
 
+(defn query-string
+  "Assemble a `?k=v&k2=v2…` query string from a map of query params, with every
+   value URL-encoded via `js/encodeURIComponent` so a tag, username, or other
+   filter value carrying a reserved query character (`&`, `=`, `#`, a space,
+   …) reaches the API as that literal value instead of corrupting the query
+   string it's embedded in. Nil-valued params are dropped, and an empty (or
+   all-nil) map yields `\"\"`, not a bare `\"?\"`."
+  [params]
+  (let [pairs (for [[k v] params :when (some? v)]
+                (str (name k) "=" (js/encodeURIComponent (str v))))]
+    (if (seq pairs)
+      (str "?" (str/join "&" pairs))
+      "")))
+
 ;; ============================================================================
 ;; RETRY POLICY
 ;; ============================================================================

--- a/examples/real-apps/realworld_resources/resources.cljs
+++ b/examples/real-apps/realworld_resources/resources.cljs
@@ -23,8 +23,7 @@
    the old data on screen (that's stale-while-revalidate). An inactive entry —
    one nobody owns — becomes GC-eligible after its own window. And re-`ensure`-ing
    a still-fresh entry is just a cache-hit: no fetch, no dedupe, nothing to see."
-  (:require [clojure.string]
-            [re-frame.core :as rf]
+  (:require [re-frame.core :as rf]
             ;; Managed HTTP — the one built-in transport for resources and
             ;; mutations. Loading the ns registers the `:rf.http/managed` fx the
             ;; runtime lowers each ensure/refetch onto.
@@ -78,14 +77,18 @@
     {:limit  page-size
      :offset (* (dec p) page-size)}))
 
-(defn- with-pagination
-  "Tack the `limit` / `offset` pair (derived from `:page`) onto a list URL,
-   whether or not it already has a query string. Keeps the resource `:request`
-   fns short while every page stays its own distinct cache key."
-  [url page]
-  (let [{:keys [limit offset]} (page->limit-offset page)
-        sep (if (clojure.string/includes? url "?") "&" "?")]
-    (str url sep "limit=" limit "&offset=" offset)))
+(defn- list-path
+  "Assemble a Conduit list-endpoint `path` (e.g. `/articles` or
+   `/articles/feed`) plus optional `filters` — a map like `{:tag \"clojure\"}`,
+   `{:author \"jake\"}`, or `{:favorited \"jake\"}`; `nil`/`{}` for the
+   unfiltered list — plus the `limit`/`offset` pagination pair derived from
+   `:page`. Every value goes through `rh/query-string`, so it's properly
+   URL-encoded rather than concatenated raw — a tag or username with a
+   reserved query character no longer corrupts the request. Keeps the
+   resource `:request` fns short while every (filters, page) pair stays its
+   own distinct cache key."
+  [path filters page]
+  (str path (rh/query-string (merge filters (page->limit-offset page)))))
 
 ;; A simple rule runs through all of this: reads retry, writes don't. Each read's
 ;; `:request` returns the shared `rh/data-fetch-retry` policy in its managed-HTTP
@@ -127,11 +130,7 @@
                            (map (fn [a] [:article (:slug a)]) (:articles data))))}
   (fn [{:keys [tag page]} _ctx]
     {:request {:method :get
-               :url    (-> (if tag
-                             (str "/articles?tag=" tag)
-                             "/articles")
-                           rh/full-url
-                           (with-pagination page))}
+               :url    (rh/full-url (list-path "/articles" (when tag {:tag tag}) page))}
      :decode  schema/ArticlesResponse
      :retry   rh/data-fetch-retry}))
 
@@ -194,9 +193,7 @@
                            (map (fn [a] [:article (:slug a)]) (:articles data))))}
   (fn [{:keys [username page]} _ctx]
     {:request {:method :get
-               :url    (-> (str "/articles?author=" username)
-                           rh/full-url
-                           (with-pagination page))}
+               :url    (rh/full-url (list-path "/articles" {:author username} page))}
      :decode  schema/ArticlesResponse
      :retry   rh/data-fetch-retry}))
 
@@ -221,9 +218,7 @@
                            (map (fn [a] [:article (:slug a)]) (:articles data))))}
   (fn [{:keys [username page]} _ctx]
     {:request {:method :get
-               :url    (-> (str "/articles?favorited=" username)
-                           rh/full-url
-                           (with-pagination page))}
+               :url    (rh/full-url (list-path "/articles" {:favorited username} page))}
      :decode  schema/ArticlesResponse
      :retry   rh/data-fetch-retry}))
 
@@ -280,7 +275,6 @@
                            (map (fn [a] [:article (:slug a)]) (:articles data))))}
   (fn [{:keys [page]} _ctx]
     {:request {:method :get
-               :url    (-> (rh/full-url "/articles/feed")
-                           (with-pagination page))}
+               :url    (rh/full-url (list-path "/articles/feed" nil page))}
      :decode  schema/ArticlesResponse
      :retry   rh/data-fetch-retry}))


### PR DESCRIPTION
## Summary
- Both RealWorld examples (`realworld_http` and `realworld_resources`) built article-list request URLs by concatenating the `tag`/`author`/`favorited` filter value directly into the query string (e.g. `(str "/articles?tag=" tag)`). A value containing a reserved query character (`&`, `#`, `=`, a space, …) would corrupt the query string instead of reaching the API as that literal value.
- `realworld_http/http.cljs`: added `query-string`, a `map -> "?k=v&k2=v2"` builder that URL-encodes every value via `js/encodeURIComponent` and drops nil params. `paginate-path` now takes a `filters` map (e.g. `{:tag "clojure"}`) instead of a pre-concatenated path, and assembles the whole query string (filters + `limit`/`offset`) through `query-string`. Updated the four call sites: `articles.cljs` (`:tag`), `profile.cljs` (`:author`, `:favorited`), `favorites.cljs` (unfiltered feed, `nil` filters).
- `realworld_resources/http.cljs`: same `query-string` helper. `resources.cljs`'s private `with-pagination` becomes `list-path`, taking the same `filters` map shape and building the URL through `rh/query-string`. Updated the four resource `:request` fns that build list URLs (`:realworld/articles`, `:realworld/author-articles`, `:realworld/favorited-articles`, `:realworld/feed`). Dropped the now-unused `clojure.string` require.

## Quality gates
- `npx shadow-cljs compile examples/realworld examples/realworld-resources` (from `implementation/`) — both builds green, 0 warnings.
- Examples are test-free (rf2-8cevm) — no smoke tests added. Verified by reasoning + a standalone Node check of the exact encoding logic:
  - `{tag: "c++ & friends", limit: 10, offset: 20}` → `?tag=c%2B%2B%20%26%20friends&limit=10&offset=20` (previously the literal `&` would have split the query into bogus extra params)
  - `{author: "jane#doe", ...}` → `?author=jane%23doe&...`
  - `{favorited: "a=b&c", ...}` → `?favorited=a%3Db%26c&...`
  - unfiltered lists (`nil`/`{}` filters) still yield the same `?limit=…&offset=…` shape as before.
- **CI green-up (transient flake, no code change):** the `clj-kondo (fail on errors, warnings informational)` + `Lint required` checks had failed with `curl: (22) The requested URL returned error: 429` — a rate-limit from `raw.githubusercontent.com` during the workflow's "Install clj-kondo" step. clj-kondo never ran (no lint error; no "linting took" line in the job log). Verified the six changed files lint clean locally with the **exact** CI toolchain: `clj-kondo 2026.04.15`, the full `--parallel --fail-level error --lint implementation --lint examples --lint testbeds --lint tools/*` command → `errors: 0`. Cleared by re-running the failed jobs (`gh run rerun --failed`); both checks now pass green.

## Risks
- Low. Purely an encoding/assembly change to example (not framework) code; behaviour for filter values without reserved characters is byte-identical to before.
