### PR TITLE
fix(build): wire Story test.check into the tools-root aggregate (rf2-ydu4od)

### DIFF
--- a/tools/deps.edn
+++ b/tools/deps.edn
@@ -136,7 +136,26 @@
                  ;; per-tool `tools/template :test` alias already pulls
                  ;; it in; the aggregate runner needs the same dep.
                  io.github.seancorfield/deps-new
-                 {:git/tag "v0.12.1" :git/sha "883e82c"}}
+                 {:git/tag "v0.12.1" :git/sha "883e82c"}
+                 ;; rf2-ydu4od — Story's own `:test` alias
+                 ;; (tools/story/deps.edn) pins `org.clojure/test.check` on
+                 ;; the :test alias ONLY, to exercise the OPTIONAL
+                 ;; `re-frame.story.generate.test-check` adapter (rf2-6nk6d).
+                 ;; `re-frame.story.generate-test` (tools/story/test/...)
+                 ;; hard-requires `clojure.test.check.generators` behind a
+                 ;; `:clj` reader conditional, so the aggregate needs the
+                 ;; SAME dep the per-tool alias carries or that namespace
+                 ;; fails to load under `cd tools && clojure -M:test`. Before
+                 ;; this entry the aggregate happened to resolve a
+                 ;; DIFFERENT test.check version (1.1.3) purely as an
+                 ;; incidental transitive dep of deps-new → sci →
+                 ;; borkdude/dynaload — undocumented and one dependency bump
+                 ;; away from silently disappearing. Pinning it explicitly
+                 ;; here, at the SAME version as Story's own alias, makes
+                 ;; the dependency intentional and reproducible rather than
+                 ;; accidental.
+                 org.clojure/test.check
+                 {:mvn/version "1.1.1"}}
    :extra-paths ["xray/test"
                  "mcp-base/test"
                  "story/test"


### PR DESCRIPTION
## Summary

- `tools/deps.edn`'s aggregate `:test` alias ran `re-frame.story.generate-test` (which hard-requires `clojure.test.check.generators` behind a `:clj` reader conditional) only by accident — `org.clojure/test.check` reached the aggregate classpath purely as an incidental transitive dependency of `io.github.seancorfield/deps-new` (via `sci` → `borkdude/dynaload`), resolving to version **1.1.3**, undocumented and unpinned.
- `tools/story/deps.edn`'s own `:test` alias explicitly pins `org.clojure/test.check {:mvn/version "1.1.1"}` (rf2-6nk6d) to exercise the OPTIONAL `re-frame.story.generate.test-check` adapter. The aggregate never mirrored that pin, unlike every other test-only dep it aggregates (`test-runner`, `deps-new`, `test-quiet`, `template`).
- Fix: add the same explicit `org.clojure/test.check {:mvn/version "1.1.1"}` pin to `tools/deps.edn`'s `:test` alias `:extra-deps`, mirroring how the other tool artefacts wire their test-only deps into the aggregate. `-Stree` confirms 1.1.1 now wins (`:use-top`) over the previously-incidental 1.1.3.

Additive change to the tools-root aggregate only (`tools/deps.edn`) — no change to `implementation/deps.edn` (hot-zone) or to `tools/story/deps.edn` itself.

## Quality gates

Before (baseline, `cd tools && clojure -M:test`):
- `clojure -A:test -Stree` showed `org.clojure/test.check 1.1.3` resolved only as a transitive dep (via `deps-new` → `sci` → `borkdude/dynaload`) — not declared anywhere in the aggregate.
- Full aggregate run: `Ran 3573 tests containing 15075 assertions. 0 failures, 0 errors.` (already accidentally green because of the incidental transitive resolution — the underlying gap was *undocumented/unpinned*, not a currently-red build.)

After:
- `clojure -A:test -Stree` now shows `org.clojure/test.check 1.1.1` winning (`:use-top`), matching `tools/story/deps.edn`'s own `:test` alias pin exactly.
- Scoped run — `clojure -M:test -n re-frame.story.generate-test`: `Ran 15 tests containing 64 assertions. 0 failures, 0 errors.` — includes the test.check-adapter suite (`test-check-adapter-is-available-on-the-test-classpath`, `test-check-gen-fn-is-deterministic-in-the-seed`, `test-check-driven-property-passes-and-emits-seed-bearing-artifacts`, `test-check-driven-property-falsifies-shrinks-and-promotes`, `test-check-adapter-degrades-clearly-without-the-library`), each exercising real `clojure.test.check.generators` draws (not a graceful no-op skip).
- Full aggregate run: `Ran 3573 tests containing 15075 assertions. 0 failures, 0 errors.` — identical counts to baseline, confirming no other artefact's coverage was dropped, and the aggregate gains a correctly-pinned, intentional dependency rather than relying on an accidental transitive one.
- Sanity check: `cd tools/story && clojure -M:test -n re-frame.story.generate-test` (per-tool alias, unaffected by this change) — `Ran 15 tests containing 64 assertions. 0 failures, 0 errors.`

No failing Story generative tests were uncovered — the gap was purely a missing/undocumented dependency declaration in the aggregate, not a functional bug in Story's test.check adapter.