### PR TITLE
fix(testbed-support): open-in-editor missing-file + column-only handling (rf2-i877cj +1)

### DIFF
--- a/tools/testbed-support/src/re_frame/testbed/open_in_editor_server.clj
+++ b/tools/testbed-support/src/re_frame/testbed/open_in_editor_server.clj
@@ -172,8 +172,24 @@
             (.exists cwd-f) (.getAbsolutePath cwd-f)
             :else           nil))
         (catch Throwable _ nil))
-      ;; 3. Unresolvable — hand the raw path back; launch-editor will try it.
+      ;; 3. Unresolvable — hand the raw path back; the existence gate in
+      ;;    `launch!` then rejects it rather than launching blind.
       path)))
+
+(defn ^:private file-exists?
+  "True when `path` names an existing filesystem entry. Mirrors
+  `launch-editor`'s OWN `fs.existsSync(fileName)` gate: `launch-editor`
+  silently no-ops on a missing file — it returns WITHOUT invoking its
+  error callback, so the `node` process exits 0 and `launch!` would report
+  a false `{:ok true}`. Checking the resolved path here (before the spawn)
+  turns that silent no-op into an explicit failure the endpoint answers as
+  a 422, so the client falls back to the `editor://` URI instead of
+  believing the file opened. Never throws — a nil/blank path or any IO /
+  security-manager error is treated as 'does not exist'."
+  [path]
+  (boolean
+    (when-not (str/blank? path)
+      (try (.exists (File. ^String path)) (catch Throwable _ false)))))
 
 ;; ---- the launch shim -----------------------------------------------------
 ;;
@@ -221,35 +237,47 @@
   "Shell out to node + launch-editor for `abs-path` at `line`/`column`,
   with an optional launch-editor `command` hint. Returns a map
   `{:ok bool :message string?}`. Runs from the dev JVM cwd so node resolves
-  the launch-editor package in the consumer's node_modules. Never throws —
-  any failure (node missing, package absent, launch error) degrades to
-  `{:ok false :message …}` so the endpoint can answer cleanly and the
-  client falls back to the editor:// URI."
+  the launch-editor package in the consumer's node_modules.
+
+  Rejects a missing file BEFORE spawning node. `launch-editor` silently
+  no-ops on a nonexistent file (`if (!fs.existsSync(fileName)) return` —
+  it never calls its error callback, so the node process exits 0), which
+  would report a false `{:ok true}` and make the endpoint answer 200 for an
+  unresolved / nonexistent `:file`, suppressing the client's `editor://`
+  fallback. A file that does not exist short-circuits to
+  `{:ok false :message \"file-not-found\"}` (no node spawn) so the endpoint
+  answers 422 and the client falls back.
+
+  Never throws — any other failure (node missing, package absent, launch
+  error) likewise degrades to `{:ok false :message …}` so the endpoint can
+  answer cleanly and the client falls back to the editor:// URI."
   [abs-path line column command]
-  (let [file-spec (build-file-spec abs-path line column)
-        args (cond-> ["node" "-e" launch-shim file-spec]
-               command (conj command))]
-    (try
-      (let [pb (doto (ProcessBuilder. ^java.util.List args)
-                 (.redirectErrorStream false))
-            _  (.directory pb (File. (System/getProperty "user.dir")))
-            proc (.start pb)
-            ;; launch-editor returns ~immediately (it spawns the editor
-            ;; detached); bound the wait so a hung node never wedges the
-            ;; dev server's request thread.
-            done? (.waitFor proc 10 java.util.concurrent.TimeUnit/SECONDS)
-            exit  (when done? (.exitValue proc))
-            err   (when done?
-                    (slurp (.getErrorStream proc)))]
-        (cond
-          (not done?)  (do (.destroy proc)
-                           {:ok false :message "launch-editor timed out"})
-          (zero? exit) {:ok true}
-          :else        {:ok false
-                        :message (or (when (seq err) (str/trim err))
-                                     (str "launch-editor exited " exit))}))
-      (catch Throwable t
-        {:ok false :message (.getMessage t)}))))
+  (if-not (file-exists? abs-path)
+    {:ok false :message "file-not-found"}
+    (let [file-spec (build-file-spec abs-path line column)
+          args (cond-> ["node" "-e" launch-shim file-spec]
+                 command (conj command))]
+      (try
+        (let [pb (doto (ProcessBuilder. ^java.util.List args)
+                   (.redirectErrorStream false))
+              _  (.directory pb (File. (System/getProperty "user.dir")))
+              proc (.start pb)
+              ;; launch-editor returns ~immediately (it spawns the editor
+              ;; detached); bound the wait so a hung node never wedges the
+              ;; dev server's request thread.
+              done? (.waitFor proc 10 java.util.concurrent.TimeUnit/SECONDS)
+              exit  (when done? (.exitValue proc))
+              err   (when done?
+                      (slurp (.getErrorStream proc)))]
+          (cond
+            (not done?)  (do (.destroy proc)
+                             {:ok false :message "launch-editor timed out"})
+            (zero? exit) {:ok true}
+            :else        {:ok false
+                          :message (or (when (seq err) (str/trim err))
+                                       (str "launch-editor exited " exit))}))
+        (catch Throwable t
+          {:ok false :message (.getMessage t)})))))
 
 ;; ---- query parsing -------------------------------------------------------
 
@@ -463,6 +491,10 @@
         throwing into the shadow-cljs `:dev-http` Ring plumbing).
     403 `{\"ok\":false,\"error\":\"forbidden\"}`    — non-loopback / cross-origin.
     405 `{\"ok\":false,\"error\":\"method-not-allowed\"}` — not POST.
+    422 `{\"ok\":false,\"error\":\"file-not-found\"}` — the resolved `:file`
+        does not exist on disk (`launch-editor` would silently no-op and the
+        endpoint would otherwise answer a false 200; see `launch!`). Non-2xx
+        so the client falls back to the `editor://` URI.
     422 `{\"ok\":false,\"error\":\"<msg>\"}`       — launch failed."
   [{:keys [uri request-method query-string] :as req}]
   (when (= uri endpoint-path)

--- a/tools/testbed-support/src/re_frame/testbed/open_in_editor_server.clj
+++ b/tools/testbed-support/src/re_frame/testbed/open_in_editor_server.clj
@@ -196,18 +196,26 @@
 
 (defn ^:private build-file-spec
   "Build the `<abs-path>[:<line>][:<column>]` argv token `launch-editor`
-  parses itself. `line` and `column` are appended INDEPENDENTLY of one
-  another — a request carrying `column` with no `line` still appends the
-  column, consistent with the client (`open-endpoint/build-url` sends
-  `&line=`/`&column=` via independent `cond->` clauses) and the
-  `editor://` URI composer (`editor-uri.cljc` defaults each of
-  `coord-line`/`coord-column` independently). Nesting `column` inside
-  `(when line ...)` (the prior shape here) silently dropped a
-  column-without-line request."
+  parses itself.
+
+  A request carrying `column` with NO `line` is normalized to line 1
+  first. `launch-editor`'s `file:line:column` grammar takes the FIRST
+  number as the line, so a bare `path:<column>` would be misread as a line
+  jump and the column intent lost. Emitting `path:1:<column>` preserves
+  the column and aligns with the `editor://` URI fallback, which likewise
+  defaults a missing line to 1 whenever a column is present
+  (`editor-uri/coord-line` — `(or (:line coord) 1)`).
+
+  With a `line` present the column is appended after it (`path:line:col`),
+  and with neither the token stays a bare path. This keeps the client
+  contract (`open-endpoint/build-url` sends `&line=`/`&column=` via
+  independent `cond->` clauses) while never handing `launch-editor` a
+  column masquerading as a line."
   [abs-path line column]
-  (cond-> abs-path
-    line   (str ":" line)
-    column (str ":" column)))
+  (let [line (if (and column (nil? line)) 1 line)]
+    (cond-> abs-path
+      line   (str ":" line)
+      column (str ":" column))))
 
 (defn launch!
   "Shell out to node + launch-editor for `abs-path` at `line`/`column`,

--- a/tools/testbed-support/test/re_frame/testbed/open_in_editor_server_test.clj
+++ b/tools/testbed-support/test/re_frame/testbed/open_in_editor_server_test.clj
@@ -398,25 +398,30 @@
     (is (= "\"plain/path.cljs\""
            (str "\"" (#'oies/escape-json-string "plain/path.cljs") "\"")))))
 
-;; ---- launch!: column-without-line (rf2-2loouf finding 6) -----------------
+;; ---- build-file-spec: column-only normalization (rf2-bj02en) --------------
 ;;
-;; `column` used to be nested inside `(when line ...)`, so a request
-;; carrying `column` with no `line` silently dropped the column instead of
-;; appending it — inconsistent with the client (`open-endpoint/build-url`
-;; appends `line`/`column` via independent `cond->` clauses) and the
-;; `editor://` URI composer (`editor-uri.cljc` defaults each independently).
-;; `build-file-spec` is the extracted unit under test — the pure argv-token
-;; builder `launch!` delegates to before shelling out to `node`.
+;; `build-file-spec` is the pure argv-token builder `launch!` delegates to
+;; before shelling out to `node`. History: `column` was once nested inside
+;; `(when line ...)`, which silently dropped a column-without-line request
+;; (rf2-2loouf finding 6). The independent `cond->` fix stopped the drop but
+;; encoded a column-only request as `path:<column>` — and `launch-editor`'s
+;; `file:line:column` grammar reads that lone number as the LINE, so the
+;; column was misread as a line jump (rf2-bj02en). `build-file-spec` now
+;; NORMALIZES a column-only request to line 1, emitting `path:1:<column>` —
+;; matching the `editor://` URI fallback (`editor-uri/coord-line` defaults a
+;; missing line to 1) so both open paths land on the same file:line:column.
 
-(deftest build-file-spec-appends-column-without-line
-  (testing "column with no line is still appended (not silently dropped)"
-    (is (= "/abs/core.cljs:7" (#'oies/build-file-spec "/abs/core.cljs" nil 7))
-        "the prior `(when line ...)` nesting dropped column here"))
-  (testing "line with no column is unaffected (baseline)"
+(deftest build-file-spec-normalizes-column-only-to-line-1
+  (testing "column with no line is normalized to line 1, NOT encoded as a
+            bare `path:<column>` that launch-editor would misread as a line
+            (the rf2-bj02en regression)"
+    (is (= "/abs/core.cljs:1:7" (#'oies/build-file-spec "/abs/core.cljs" nil 7))
+        "column-only → line 1 + column, matching the editor:// URI fallback"))
+  (testing "line with no column is unaffected (baseline — no phantom column)"
     (is (= "/abs/core.cljs:3" (#'oies/build-file-spec "/abs/core.cljs" 3 nil))))
   (testing "both line and column present"
     (is (= "/abs/core.cljs:3:7" (#'oies/build-file-spec "/abs/core.cljs" 3 7))))
-  (testing "neither present: bare path"
+  (testing "neither present: bare path (no spurious `:1`)"
     (is (= "/abs/core.cljs" (#'oies/build-file-spec "/abs/core.cljs" nil nil)))))
 
 (deftest launch-passes-column-without-line-through-to-file-spec
@@ -424,7 +429,8 @@
             `line` reaches `launch!` with `line` nil / `column` 7 — parsing
             never drops it — and folding those exact values through
             `build-file-spec` (the function `launch!` delegates to) yields
-            the column-bearing spec, not a bare path"
+            the NORMALIZED `path:1:<column>` spec, not a bare `path:<column>`
+            launch-editor would misread as a line jump"
     (let [calls (atom [])]
       (with-redefs [oies/launch! (fn [& args] (swap! calls conj (vec args))
                                    {:ok true})]
@@ -438,6 +444,6 @@
           (let [[abs-path line column _cmd] (first @calls)]
             (is (nil? line) "no line param was sent")
             (is (= 7 column) "column parsed through, not dropped upstream")
-            (is (= (str abs-path ":7") (#'oies/build-file-spec abs-path line column))
-                "build-file-spec appends the column even with line nil —
-                 the finding-6 regression, now fixed")))))))
+            (is (= (str abs-path ":1:7") (#'oies/build-file-spec abs-path line column))
+                "build-file-spec normalizes column-only to line 1 —
+                 the rf2-bj02en regression, now fixed")))))))

--- a/tools/testbed-support/test/re_frame/testbed/open_in_editor_server_test.clj
+++ b/tools/testbed-support/test/re_frame/testbed/open_in_editor_server_test.clj
@@ -447,3 +447,59 @@
             (is (= (str abs-path ":1:7") (#'oies/build-file-spec abs-path line column))
                 "build-file-spec normalizes column-only to line 1 —
                  the rf2-bj02en regression, now fixed")))))))
+
+;; ---- missing-file guard: no false 200 (rf2-i877cj) -----------------------
+;;
+;; `launch-editor` SILENTLY no-ops on a nonexistent file — its internal
+;; `if (!fs.existsSync(fileName)) return` returns WITHOUT calling the error
+;; callback, so the node process exits 0 and `launch!` would report a false
+;; `{:ok true}`, making the endpoint answer HTTP 200 for an unresolved /
+;; nonexistent `:file`. That suppresses the client's `editor://` fallback
+;; (the client only falls back on a non-2xx). `launch!` now checks the
+;; resolved path's existence BEFORE spawning node and short-circuits to
+;; `{:ok false :message "file-not-found"}`, which the endpoint answers 422.
+
+(deftest file-exists?-detects-real-and-missing-paths
+  (testing "an existing file is detected"
+    (let [tmp (File/createTempFile "oies-exists" ".cljs")]
+      (try
+        (is (true? (#'oies/file-exists? (.getAbsolutePath tmp)))
+            "a real on-disk file exists")
+        (finally (.delete tmp)))))
+  (testing "a nonexistent path, nil, and blank are all 'does not exist'"
+    (is (false? (#'oies/file-exists?
+                  (str (System/getProperty "java.io.tmpdir")
+                       "/oies-absent-" (System/nanoTime) ".cljs"))))
+    (is (false? (#'oies/file-exists? nil)))
+    (is (false? (#'oies/file-exists? "   ")))))
+
+(deftest launch-rejects-missing-file-before-spawning-node
+  (testing "launch! on a path that does not exist short-circuits to a
+            file-not-found failure WITHOUT shelling out to node — mirroring
+            launch-editor's own existence gate so the endpoint never reports
+            a false success (this test does not require node to be present)"
+    (let [missing (str (System/getProperty "java.io.tmpdir")
+                       "/oies-launch-absent-" (System/nanoTime) ".cljs")]
+      (is (= {:ok false :message "file-not-found"}
+             (oies/launch! missing 10 5 nil))
+          "missing file rejected before the node spawn")))
+  (testing "a nil / blank abs-path is likewise file-not-found (never node)"
+    (is (= {:ok false :message "file-not-found"} (oies/launch! nil 1 1 nil)))
+    (is (= {:ok false :message "file-not-found"} (oies/launch! "   " 1 1 nil)))))
+
+(deftest endpoint-rejects-missing-file-with-422
+  (testing "request-level regression: a valid local POST whose `:file`
+            resolves to a nonexistent path answers 422 file-not-found (NOT a
+            false 200) — `launch!` runs FOR REAL (not stubbed) and
+            short-circuits before node, so the client gets a non-2xx and
+            falls back to the editor:// URI"
+    (let [missing (str "oies_missing_" (System/nanoTime) "/nope.cljs")
+          resp    (oies/handle
+                    {:uri            oies/endpoint-path
+                     :request-method :post
+                     :query-string   (str "file=" missing "&line=10&column=3")
+                     :headers        {"host" "localhost:8031"}})]
+      (is (= 422 (:status resp)) "missing file is a non-2xx, not a false 200")
+      (is (re-find #"\"ok\":false" (:body resp)))
+      (is (re-find #"\"error\":\"file-not-found\"" (:body resp))
+          "the client-visible error names the missing file, not launch-failed"))))


### PR DESCRIPTION
Cluster of two bug fixes on the JVM open-in-editor endpoint
(`re-frame.testbed.open-in-editor-server`, a shadow-cljs `:dev-http`
handler). Commits ordered smallest-cleanup → biggest-correctness-fix.

## rf2-bj02en (P4) — column-only normalized to line 1

A request carrying `column` with no `line` was encoded as `path:<column>`.
`launch-editor`'s `file:line:column` grammar reads the first number as the
**line**, so a column-only request was misread as a line jump and the
column intent lost. `build-file-spec` now normalizes a column-only request
to line 1, emitting `path:1:<column>` — matching the `editor://` URI
fallback, whose `editor-uri/coord-line` defaults a missing line to 1 when a
column is present. Both open paths now land on the same file:line:column.

Adversarial/negative coverage: `build-file-spec-normalizes-column-only-to-line-1`
asserts `(nil, 7)` → `/abs/core.cljs:1:7` (not the bare `:7` a prior fix
left), plus the end-to-end endpoint assertion.

## rf2-i877cj (P3) — no false 200 for a missing file

The endpoint could answer HTTP 200 when `launch-editor` silently no-ops for
an unresolved/nonexistent file. `launch-editor`'s internal
`if (!fs.existsSync(fileName)) return` returns **without** invoking its
error callback, so the node process exits 0 and `launch!` reported a false
`{:ok true}` — suppressing the client's `editor://` fallback (which only
triggers on a non-2xx). `launch!` now checks the resolved path's existence
**before** spawning node and short-circuits to
`{:ok false :message "file-not-found"}`, which the endpoint answers **422**.

Design note: the gate lives in `launch!` (not `handle`). This mirrors
`launch-editor`'s own `existsSync` gate at the launch layer, keeps the
security-guard tests (which stub `launch!`) pristine, and lets the
request-level regression test exercise the **real** `launch!` path rather
than a stub.

Adversarial/negative coverage: `launch-rejects-missing-file-before-spawning-node`
(missing/nil/blank → `file-not-found`, no node spawn — runs without node),
`endpoint-rejects-missing-file-with-422` (request-level: real `launch!`,
missing file → 422 `file-not-found`), and `file-exists?-detects-real-and-missing-paths`.

## Quality gates

- `cd tools/testbed-support && clojure -M:test` → **20 tests, 85 assertions,
  0 failures, 0 errors** (was 17/75). Authoritative gate for this JVM-only
  surface; transitively loads `editor-uri` (the only `implementation/` dep)
  via `deps.edn` `:local/root`.
- `python scripts/check_retired_spellings.py --verbose` → **PASS** (263 files, clean).
- `python scripts/check_thrown_error_messages.py --verbose` → **PASS** (263 files, clean).
- `scripts/test-fast-pr.sh` npm/CLJS gates (`test:cljs`, `test:script-*`,
  per-ns isolation) **not run**: fresh worktree has no `node_modules`, and
  the change is a JVM-only `.clj` that is never in any CLJS build and has no
  `implementation/` consumer — those gates add no coverage for it. The
  changed surface is fully gated by `clojure -M:test` above.

## Stance

Pre-alpha, no back-compat shims; optimized for ELEGANCE + CLARITY +
CORRECTNESS + GOOD PRACTICE; avoided over-engineering. Both fixes are
minimal, co-located with the mechanism they correct, and align the endpoint
with the existing `editor://` URI fallback semantics.

Closes rf2-bj02en. Closes rf2-i877cj.
