### PR TITLE
fix(mcp-base): dedup/diff/cursor correctness (rf2-fwaolt +2)

### DIFF
--- a/tools/mcp-base/spec/cursor.md
+++ b/tools/mcp-base/spec/cursor.md
@@ -90,9 +90,23 @@ A hostile / corrupt cursor therefore cannot smuggle any tagged literal — or th
 
 ## One-form requirement (rf2-ykv9a0)
 
-A cursor is **one** opaque EDN payload map. The reader requires the decoded text to be **exactly one form** and rejects any trailing form as `::malformed`. A plain `read-string` reads only the FIRST form and never checks exhaustion, so before this a token whose decoded text was a valid map followed by a second form — e.g. `{:v 1 :offset 0 :sig "s"} #inst "2024-01-01"` or `{…} {:junk 1}` — decoded as the valid map, silently ignoring the trailing object and weakening the opacity / corruption guard.
+A cursor is **one** opaque EDN payload map. The reader (`read-edn-no-tags`) requires the decoded text to be **exactly one form** and rejects any trailing form as `::malformed`. A plain `read-string` reads only the FIRST form and never checks exhaustion, so before this a token whose decoded text was a valid map followed by a second form — e.g. `{:v 1 :offset 0 :sig "s"} #inst "2024-01-01"` or `{…} {:junk 1}` — decoded as the valid map, silently ignoring the trailing object and weakening the opacity / corruption guard.
 
-The reader closes that by wrapping the decoded text in `[ … ]` and reading the WHOLE thing as one vector: a single clean form yields a one-element vector (trailing whitespace / comments absorbed), while ANY trailing form yields a 2+-element vector → rejected. This is a pure-`read-string` technique that behaves identically on the JVM (`clojure.edn`) and CLJS (`cljs.reader`) without reaching into either host's pushback-reader internals; tagged literals anywhere inside still throw via the readers above.
+### Why not the naive one-element-vector wrap — the injected-`]` bypass
+
+The obvious closure — wrap the decoded text in `[ … ]` and accept a ONE-element vector — is **bypassable by `]`-injection** and is NOT what the implementation does. Attacker text `{…valid map…}] <junk>` wraps to `[{…}] <junk>]`: the *injected* `]` closes the wrapper early, so `read-string` reads the clean one-element vector `[{…}]`, returns the inner map, and SILENTLY DISCARDS everything after the injected `]`. A one-element-vector check would accept that corrupted cursor.
+
+### The EOF-sentinel exhaustion check (what the implementation does)
+
+`read-edn-no-tags` instead asserts reader **exhaustion** via an appended sentinel — the string-host analog of an `:eof` read sentinel. It wraps as `[ <decoded-text> <eof-sentinel> ]` and requires the read to yield **exactly** `[<one-form> <eof-sentinel>]` — a **two**-element vector whose SECOND element is the sentinel. The sentinel can only land as the trailing element if the reader consumed the WHOLE wrapped string:
+
+- a single clean form (trailing whitespace / comments absorbed) yields `[<map> <sentinel>]` → accepted, returning the sole payload form so the caller's `map?` / `valid?` checks are unchanged;
+- an **injected `]`** truncates the read before the sentinel, so the vector does NOT end with it → `::malformed`;
+- any **genuine trailing form** pushes the element count past 2 → `::malformed`.
+
+The sentinel is a qualified, unguessable keyword (`:re-frame.mcp-base.cursor/cursor-eof-sentinel`); even attacker text that reproduces the literal cannot pass — the cursor must still be a single payload map FOLLOWED by the sentinel (two forms, no more), so a trailing sentinel keyword pushes the count to 3 and rejects.
+
+This is a pure-`read-string` technique that behaves identically on the JVM (`clojure.edn`) and CLJS (`cljs.reader`) without reaching into either host's pushback-reader internals; tagged literals anywhere inside the wrapped text still throw via the `:readers` / `:default` overrides above. The injected-`]` bypass and the reproduced-sentinel case are both pinned in `cursor_test`'s `decode-cursor-rejects-trailing-forms`.
 
 ## Why this ns
 

--- a/tools/mcp-base/spec/dedup.md
+++ b/tools/mcp-base/spec/dedup.md
@@ -20,7 +20,8 @@ The encode step (`empty-payload?` + `dedup-value`) was byte-identical across bot
 
 `dedup` owns:
 
-- `empty-payload?` — the no-win short-circuit predicate.
+- `empty-payload?` — the no-win short-circuit predicate (nil / empty / scalar, checked BEFORE `de-dupe-eq`).
+- `no-substitutions?` — the post-`de-dupe-eq` one-entry-root-only-cache detector (a non-empty collection with no repeated subtrees).
 - `dedup-value` — the equality-based encode + cross-MCP wrap.
 
 `dedup` does NOT own:
@@ -41,7 +42,18 @@ The encode step (`empty-payload?` + `dedup-value`) was byte-identical across bot
       (not (coll? v))))
 ```
 
-True for values where dedup yields no win — `nil`, empty collections, scalars. A payload with no repeated subtrees deduplicates to a one-entry cache whose wire shape is *very slightly larger* than the input; the predicate lets `dedup-value` skip the wrap for those degenerate cases so empty / single-record responses don't grow.
+True for values where dedup yields no win *without even running `de-dupe-eq`* — `nil`, empty collections, scalars. These short-circuit up front. (The related but distinct one-entry-root-only-cache case — a NON-empty collection that runs `de-dupe-eq` and turns out to have no repeated subtrees — is caught AFTER the walk by `no-substitutions?`, below.)
+
+### `no-substitutions? cache` → boolean
+
+```clojure
+(defn no-substitutions? [cache]
+  (and (map? cache)
+       (= 1 (count cache))
+       (contains? cache (de-dupe.core/make-cache-element 0))))
+```
+
+True when a `de-dupe-eq` cache made **no** substitutions — it carries exactly the one root entry (`de-dupe.cache/cache-0`) and nothing else, because the payload had no repeated subtrees. `de-dupe-eq` always emits `cache-0` for the whole structure and adds a further `cache-N` entry per substituted subtree, so a **one-entry** cache is unambiguously root-only. Such a cache, once wrapped, is strictly LARGER than the raw input (the `{:rf.mcp/dedup-table {cache-0 …}}` envelope adds two map layers for zero sharing win), so `dedup-value` returns the original value instead — the documented no-repeat-payloads-stay-raw contract must hold for ordinary collections, not just the empty / scalar degenerate cases. The check is on cache SHAPE, not a re-walk of the value; the explicit `cache-0` key guard hedges a future `de-dupe` change that keyed the root differently.
 
 ### `dedup-value v enabled?` → value
 
@@ -49,10 +61,13 @@ True for values where dedup yields no win — `nil`, empty collections, scalars.
 (defn dedup-value [v enabled?]
   (if (or (not enabled?) (empty-payload? v))
     v
-    {vocab/dedup-table-key (de-dupe.core/de-dupe-eq v)}))
+    (let [cache (de-dupe.core/de-dupe-eq v)]
+      (if (no-substitutions? cache)
+        v
+        {vocab/dedup-table-key cache}))))
 ```
 
-Applies structural dedup to `v` and wraps the result in the cross-MCP marker `{:rf.mcp/dedup-table <cache-map>}`. Returns `v` unchanged when `enabled?` is false or when `empty-payload?` short-circuits.
+Applies structural dedup to `v` and wraps the result in the cross-MCP marker `{:rf.mcp/dedup-table <cache-map>}`. Returns `v` unchanged when `enabled?` is false, when `empty-payload?` short-circuits, or when `de-dupe-eq` yielded a one-entry root-only cache (`no-substitutions?` — a non-empty collection with no repeated subtrees). Only a cache with an actual `cache-N` substitution is wrapped.
 
 #### Why `de-dupe-eq` (equality), not `de-dupe` (identity)
 

--- a/tools/mcp-base/spec/diff-encode.md
+++ b/tools/mcp-base/spec/diff-encode.md
@@ -69,6 +69,8 @@ A vector **length change** (an insert / delete) is emitted as a single whole-vec
 
 `clojure.data/diff`'s parallel-vector sparse form (with `nil` placeholders meaning "common at this position") loses information once you only carry one half plus the original — you can't tell `nil` (the leaf value `nil`) apart from `nil` (the no-change sentinel). Path-keyed patches are unambiguous for any value the runtime can produce: a changed vector element rides under a numeric **index** path (`[[:items 0 :qty] :assoc 2]`), which carries the position explicitly and never relies on a positional `nil` sentinel.
 
+The encoder honours the same **no in-band sentinel** principle for the KEY side: added-key detection keys off key **presence** (`find`), never a marker value (rf2-znjqja). An earlier `(get a k ::absent)` conflated "key missing" with "key present holding a value equal to the marker", so an unchanged key whose app-db leaf happened to equal `:re-frame.mcp-base.diff-encode/absent` was mis-reported as `:added` — a spurious `[path :assoc value]` false patch (replay still reconstructs the value, but the wire diff lies to the agent). `find` returns the `[k v]` entry for any present key (including a present `nil`) and `nil` only for a genuinely absent key, so no runtime value can collide.
+
 ## Self-contained records
 
 The diff is **intra-record** — each epoch's `:db-after` is encoded against the SAME record's `:db-before`. Records remain self-contained and decodable without reference to siblings. The slice can be reordered, paginated, or filtered without breaking decode.

--- a/tools/mcp-base/src/re_frame/mcp_base/dedup.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/dedup.cljc
@@ -39,8 +39,16 @@
 
   A payload with no repeated subtrees deduplicates to a one-entry cache
   (the wire shape is very slightly larger than the input). The encoder
-  skips wrapping in that case via the `empty-payload?` short-circuit, so
-  empty / single-record responses don't grow.
+  skips wrapping in two cases so no-repeat payloads stay raw:
+
+  - Empty / scalar values short-circuit BEFORE `de-dupe-eq` via
+    `empty-payload?`.
+  - A NON-EMPTY collection with no repeated subtrees runs `de-dupe-eq`
+    but produces a one-entry root-only cache
+    (`{de-dupe.cache/cache-0 <original>}`, no `cache-N` substitutions);
+    `no-substitutions?` detects that and returns the original value
+    unchanged. Without this, ordinary no-repeat payloads would grow by
+    the wrapper + `cache-0` slot on every response.
 
   ## What does NOT live here — the inverse (`dedup-expand`)
 
@@ -73,14 +81,45 @@
       (and (coll? v) (empty? v))
       (not (coll? v))))
 
+(def ^:private root-cache-key
+  "The slot `de-dupe-eq` always emits for the whole structure
+  (`de-dupe.cache/cache-0`). Every substituted subtree adds a further
+  `cache-N` entry, so a cache carrying ONLY this key made no
+  substitutions."
+  (dd/make-cache-element 0))
+
+(defn no-substitutions?
+  "True when a `de-dupe-eq` cache made NO substitutions — it holds
+  exactly the one root entry (`cache-0`) and nothing else, because the
+  payload had no repeated subtrees. A non-empty collection with no
+  repeats deduplicates to exactly this one-entry root-only cache, whose
+  wrapped wire shape is strictly LARGER than the raw input; `dedup-value`
+  detects it and returns the original value so the documented
+  no-repeat-payloads-stay-raw contract holds for ordinary (not just
+  empty / scalar) payloads too.
+
+  Checked on the cache SHAPE (single entry keyed by `cache-0`), not by
+  re-walking the value: any repeated subtree would have added a second
+  `cache-N` entry, so `(= 1 (count cache))` already implies root-only —
+  the explicit key check guards against a future `de-dupe` change that
+  keyed the root differently."
+  [cache]
+  (and (map? cache)
+       (= 1 (count cache))
+       (contains? cache root-cache-key)))
+
 (defn dedup-value
   "Apply structural dedup to `v` and wrap the result in the cross-MCP
   marker (`vocab/dedup-table-key`). Returns `v` unchanged when
-  `enabled?` is false or when `v` is empty / scalar (no dedup
-  opportunity). Uses `de-dupe.core/de-dupe-eq` (equality-based) — see
-  the namespace docstring for the identity-vs-equality rationale."
+  `enabled?` is false, when `v` is empty / scalar (no dedup opportunity),
+  or when the `de-dupe-eq` cache made no substitutions (a non-empty
+  collection with no repeated subtrees — `no-substitutions?`). Uses
+  `de-dupe.core/de-dupe-eq` (equality-based) — see the namespace
+  docstring for the identity-vs-equality rationale."
   [v enabled?]
   (if (or (not enabled?) (empty-payload? v))
     v
     (let [cache (dd/de-dupe-eq v)]
-      {vocab/dedup-table-key cache})))
+      (if (no-substitutions? cache)
+        v
+        {vocab/dedup-table-key cache}))))

--- a/tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc
@@ -359,11 +359,25 @@
   (let [after-assocs
         (reduce-kv
           (fn [acc k bv]
-            (let [av (get a k ::absent)
-                  p  (conj path k)]
+            (let [p (conj path k)
+                  ;; Detect a NEW key by KEY PRESENCE, not by a sentinel
+                  ;; VALUE. `find` returns the `[k v]` entry when `k` is
+                  ;; present (even if its value is `nil`) and `nil` only
+                  ;; when `k` is genuinely absent from `a`. The former
+                  ;; `(get a k ::absent)` conflated "key missing" with "key
+                  ;; present and its value equals `::absent`": an app-db leaf
+                  ;; is any runtime value, so a legal key holding the literal
+                  ;; `:re-frame.mcp-base.diff-encode/absent` (or, before this,
+                  ;; any value chosen to equal the marker) was mis-read as
+                  ;; added — emitting a spurious `[p :assoc bv]` for an
+                  ;; UNCHANGED leaf. Replay still reconstructs the value, but
+                  ;; the wire diff falsely reports a change and misleads the
+                  ;; agent. `find` has no in-band sentinel, so no user value
+                  ;; can collide.
+                  e (find a k)]
               (cond
-                ;; Key added.
-                (= av ::absent)
+                ;; Key added — genuinely absent from `a`.
+                (nil? e)
                 (conj acc [p :assoc bv])
                 ;; A changed EXISTING key: delegate to `collect-patches-into`
                 ;; so the dispatch is decided in ONE place — two maps recurse
@@ -372,7 +386,7 @@
                 ;; which short-circuits to a no-op) is a single leaf
                 ;; `[p :assoc bv]` replacement.
                 :else
-                (collect-patches-into acc av bv p))))
+                (collect-patches-into acc (val e) bv p))))
           acc
           b)]
     (reduce-kv

--- a/tools/mcp-base/test/re_frame/mcp_base/dedup_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/dedup_test.clj
@@ -38,6 +38,54 @@
   (is (nil? (dedup/dedup-value nil true)))
   (is (= 42 (dedup/dedup-value 42 true))))
 
+(deftest no-substitutions?-detects-one-entry-root-only-cache
+  ;; `de-dupe-eq` always emits `cache-0` for the root; every substituted
+  ;; subtree adds a further `cache-N`. A one-entry cache therefore made
+  ;; NO substitutions.
+  (testing "a no-repeat non-empty collection ⇒ one-entry root-only cache"
+    (is (true? (boolean (dedup/no-substitutions? (dd/de-dupe-eq {:a 1 :b 2})))))
+    (is (true? (boolean (dedup/no-substitutions? (dd/de-dupe-eq [1 2 3])))))
+    (is (true? (boolean (dedup/no-substitutions? (dd/de-dupe-eq {:a {:x 1} :b {:y 2}}))))))
+  (testing "a repeated-subtree cache has >1 entry ⇒ substitutions happened"
+    (is (false? (boolean (dedup/no-substitutions? (dd/de-dupe-eq [{:x 1} {:x 1}]))))))
+  (testing "non-map / empty inputs are not a root-only cache"
+    (is (false? (boolean (dedup/no-substitutions? nil))))
+    (is (false? (boolean (dedup/no-substitutions? {}))))))
+
+(deftest dedup-value-no-repeats-non-empty-returns-input-verbatim
+  ;; The headline fix (rf2-fwaolt): a NON-EMPTY collection with no
+  ;; repeated subtrees must stay RAW on the wire — `de-dupe-eq` yields a
+  ;; one-entry root-only cache whose wrapped shape is strictly larger than
+  ;; the input, violating the documented no-repeat-payloads-stay-raw
+  ;; contract. `empty-payload?` does NOT catch these (they're non-empty),
+  ;; so before the fix they wrapped and grew.
+  (testing "a flat no-repeat map is returned identical, NOT wrapped"
+    (let [v {:a 1 :b 2 :c 3}
+          out (dedup/dedup-value v true)]
+      (is (identical? v out)
+          "no dedup opportunity ⇒ verbatim passthrough, not a dedup-table wrap")
+      (is (not (contains? out vocab/dedup-table-key)))))
+  (testing "a nested no-repeat structure is returned identical"
+    (let [v {:user {:name "ada"} :session {:state :idle} :items [1 2 3]}]
+      (is (identical? v (dedup/dedup-value v true)))))
+  (testing "a no-repeat vector is returned identical"
+    (let [v [{:id 1} {:id 2} {:id 3}]]      ; all distinct ⇒ no substitution
+      (is (identical? v (dedup/dedup-value v true))))))
+
+(deftest dedup-value-repeated-subtree-still-wraps
+  ;; The adversarial complement to the no-op skip: a payload that DOES
+  ;; carry a repeated subtree must STILL wrap (the skip must not swallow a
+  ;; genuine dedup win). Its cache has >1 entry, so `no-substitutions?` is
+  ;; false and the wrap fires.
+  (let [shared {:big [:repeated :subtree]}
+        v      [shared shared shared]
+        out    (dedup/dedup-value v true)]
+    (is (map? out))
+    (is (contains? out vocab/dedup-table-key)
+        "a repeated subtree is a real dedup win — the wrap must fire")
+    (is (= v (dd/expand (get out vocab/dedup-table-key)))
+        "and the wrap still round-trips")))
+
 (deftest dedup-value-wraps-in-cross-mcp-marker
   (let [shared {:repeated [:big :subtree :here]}
         v      {:a shared :b shared :c shared}

--- a/tools/mcp-base/test/re_frame/mcp_base/diff_encode_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/diff_encode_test.clj
@@ -38,6 +38,71 @@
          (de/collect-patches {:a {:b 1}} {:a [1 2 3]} []))))
 
 ;; ---------------------------------------------------------------------------
+;; collect-patches — added-key detection is by KEY PRESENCE, not a
+;; sentinel VALUE (rf2-znjqja).
+;;
+;; The added-key arm keys off `find` (presence), never a marker value. An
+;; app-db leaf can be ANY runtime value — including the private
+;; :re-frame.mcp-base.diff-encode/absent keyword the old
+;; `(get a k ::absent)` used as its missing-marker. A value-comparison
+;; test mis-read an UNCHANGED key holding that value as `:added`, emitting
+;; a spurious `[path :assoc value]` false patch that misleads the agent
+;; even though replay still reconstructs the value.
+;; ---------------------------------------------------------------------------
+
+;; The exact keyword the old code used as `::absent` in the diff-encode ns.
+(def ^:private old-sentinel :re-frame.mcp-base.diff-encode/absent)
+
+(deftest collect-patches-sentinel-valued-unchanged-key-emits-no-patch
+  ;; db-before and db-after both hold the former sentinel value at :k,
+  ;; UNCHANGED, alongside a real sibling change. Only the sibling must
+  ;; produce a patch. Old `(get a k ::absent)` mis-flagged :k as added and
+  ;; emitted a spurious `[[:k] :assoc <sentinel>]` on top of the real one.
+  (let [a {:k old-sentinel :sibling 1}
+        b {:k old-sentinel :sibling 2}]
+    (is (= [[[:sibling] :assoc 2]]
+           (de/collect-patches a b []))
+        "an unchanged key whose value equals the former sentinel must NOT report as changed")))
+
+(deftest collect-patches-nil-valued-unchanged-key-emits-no-patch
+  ;; `find` must also distinguish a present nil value from an absent key
+  ;; (it returns the entry for a present nil). A present-nil unchanged key
+  ;; emits no patch.
+  (let [a {:k nil :sibling 1}
+        b {:k nil :sibling 2}]
+    (is (= [[[:sibling] :assoc 2]]
+           (de/collect-patches a b []))
+        "a present nil value is not an added key")))
+
+(deftest collect-patches-sentinel-valued-key-genuine-transitions
+  (testing "genuinely ADDED key holding the sentinel value ⇒ one :assoc"
+    (is (= [[[:k] :assoc old-sentinel]]
+           (de/collect-patches {} {:k old-sentinel} []))))
+  (testing "genuinely REMOVED key holding the sentinel value ⇒ one :dissoc"
+    (is (= [[[:k] :dissoc]]
+           (de/collect-patches {:k old-sentinel} {} []))))
+  (testing "key CHANGED from the sentinel value to another value ⇒ one :assoc"
+    (is (= [[[:k] :assoc 99]]
+           (de/collect-patches {:k old-sentinel} {:k 99} []))))
+  (testing "key CHANGED to the sentinel value ⇒ one :assoc"
+    (is (= [[[:k] :assoc old-sentinel]]
+           (de/collect-patches {:k 1} {:k old-sentinel} [])))))
+
+(deftest diff-encode-sentinel-valued-key-round-trips-without-false-patch
+  ;; End-to-end through encoder/decoder. The round-trip alone does NOT
+  ;; catch the bug (replay reconstructs the sentinel value either way);
+  ;; the load-bearing assertion is that ONLY the genuine change reaches
+  ;; the wire — no spurious :k patch.
+  (let [epoch   {:db-before {:k old-sentinel :count 1}
+                 :db-after  {:k old-sentinel :count 2}}
+        encoded (de/diff-encode-db-after epoch)
+        patches (vec (mapcat :patches (get-in encoded [:db-after :sections])))]
+    (is (= [[[:count] :assoc 2]] patches)
+        "only the genuine :count change is on the wire — no false :k patch")
+    (is (= epoch (de/decode-db-after encoded))
+        "and the sentinel-valued stable key round-trips")))
+
+;; ---------------------------------------------------------------------------
 ;; collect-patches — same-length vectors diff structurally.
 ;; ---------------------------------------------------------------------------
 

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dedup_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dedup_test.cljs
@@ -71,13 +71,27 @@
   (is (= {} (dedup/dedup-value {} true)))
   (is (= 42 (dedup/dedup-value 42 true))))
 
-(deftest dedup-non-empty-collection-emits-marker
-  (let [payload [{:a 1} {:b 2}]
+(deftest dedup-repeated-subtree-collection-emits-marker
+  ;; A non-empty collection WITH a repeated subtree is a genuine dedup
+  ;; opportunity, so the wrap fires. (A non-empty collection with NO
+  ;; repeats stays raw — see `dedup-no-repeat-collection-stays-raw`;
+  ;; mcp-base's `no-substitutions?` skips the wrapper there.)
+  (let [shared  {:big :subtree}
+        payload [shared shared]
         wrapped (dedup/dedup-value payload true)]
     (is (map? wrapped))
     (is (contains? wrapped :rf.mcp/dedup-table))
     (is (map? (:rf.mcp/dedup-table wrapped))
         "the table itself is a hash-map keyed by namespaced symbols")))
+
+(deftest dedup-no-repeat-collection-stays-raw
+  ;; The corrected wire contract (rf2-fwaolt): a non-empty collection
+  ;; with no repeated subtrees deduplicates to a one-entry root-only
+  ;; cache whose wrapped shape is strictly larger than the input, so
+  ;; `dedup-value` returns it RAW rather than growing the wire.
+  (let [payload [{:a 1} {:b 2}]]
+    (is (= payload (dedup/dedup-value payload true))
+        "no dedup opportunity ⇒ verbatim passthrough, not a dedup-table wrap")))
 
 (deftest dedup-marker-key-is-the-cross-mcp-vocabulary
   ;; The marker key matches the cross-MCP §5 (Structural dedup):

--- a/tools/story-mcp/test/re_frame/story_mcp/tools/dedup_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools/dedup_test.clj
@@ -69,13 +69,27 @@
   (is (= {} (dedup/dedup-value {} true)))
   (is (= 42 (dedup/dedup-value 42 true))))
 
-(deftest dedup-non-empty-collection-emits-marker
-  (let [payload [{:a 1} {:b 2}]
+(deftest dedup-repeated-subtree-collection-emits-marker
+  ;; A non-empty collection WITH a repeated subtree is a genuine dedup
+  ;; opportunity, so the wrap fires. (A non-empty collection with NO
+  ;; repeats stays raw — see `dedup-no-repeat-collection-stays-raw`;
+  ;; mcp-base's `no-substitutions?` skips the wrapper there.)
+  (let [shared  {:big :subtree}
+        payload [shared shared]
         wrapped (dedup/dedup-value payload true)]
     (is (map? wrapped))
     (is (contains? wrapped :rf.mcp/dedup-table))
     (is (map? (:rf.mcp/dedup-table wrapped))
         "the table itself is a hash-map keyed by namespaced symbols")))
+
+(deftest dedup-no-repeat-collection-stays-raw
+  ;; The corrected wire contract (rf2-fwaolt): a non-empty collection
+  ;; with no repeated subtrees deduplicates to a one-entry root-only
+  ;; cache whose wrapped shape is strictly larger than the input, so
+  ;; `dedup-value` returns it RAW rather than growing the wire.
+  (let [payload [{:a 1} {:b 2}]]
+    (is (= payload (dedup/dedup-value payload true))
+        "no dedup opportunity ⇒ verbatim passthrough, not a dedup-table wrap")))
 
 (deftest dedup-marker-key-is-the-cross-mcp-vocabulary
   ;; The marker key matches the cross-MCP §5 (Structural dedup):


### PR DESCRIPTION
Three small correctness/clarity fixes on the **tools/mcp-base** surface, one commit per bead (ordered smallest cleanup → biggest correctness fix). Each fix carries ≥1 adversarial/negative test and updates the owning `tools/mcp-base/spec/` contract in the same commit.

## Beads

### rf2-ejg4sw (P4) — cursor spec documents EOF-sentinel parsing
`spec/cursor.md` §One-form requirement still described the **naive one-element-vector wrap** that the implementation explicitly rejects as `]`-injection-bypassable. Rewrote the section to match `cursor.cljc`'s `read-edn-no-tags`: the appended EOF-sentinel exhaustion check (`[ <text> <eof-sentinel> ]` → require `[<one-form> <eof-sentinel>]`), the injected-bracket bypass it closes, and the reproduced-sentinel case. Doc-only; keeps the spec aligned with `cursor.cljc` and `cursor_test`'s `decode-cursor-rejects-trailing-forms`.

### rf2-fwaolt (P3) — dedup skips no-op one-entry caches
`dedup-value` wrapped **every** non-empty collection in the `:rf.mcp/dedup-table` marker, including payloads where `de-dupe-eq` produced only the `cache-0` root entry (no repeated subtrees → no substitutions). That **grew** ordinary no-repeat payloads on the wire and violated the documented no-repeat-payloads-stay-raw contract — `empty-payload?` only caught the empty/scalar degenerate cases, never a non-empty collection with no repeats.

Fix: added `no-substitutions?` to detect the one-entry root-only cache after `de-dupe-eq` (`cache-0` present, count 1, no `cache-N`) and return the original value unchanged. A genuine repeated subtree still adds a `cache-N` entry, so the wrap still fires for real dedup wins. `spec/dedup.md` documents the new detector.

Empirically confirmed cache shapes via the pinned `day8/de-dupe v0.3.0`: `{:a 1 :b 2}` → `{cache-0 {:a 1 :b 2}}` (count 1, skip); `[{:x 1} {:x 1}]` → count 2 (wrap).

### rf2-znjqja (P3) — diff encode detects added keys by presence, not a sentinel
`collect-map-patches-into` used `::absent` as **both** a missing marker and a possible legal user value: `(get a k ::absent)` cannot distinguish "key missing" from "key present holding a value equal to `::absent`". An app-db leaf is any runtime value, so an **unchanged** key whose value equalled `:re-frame.mcp-base.diff-encode/absent` was mis-read as `:added` and emitted a spurious `[path :assoc value]` false patch — replay still reconstructs the value, but the wire diff falsely reports a change and misleads the agent.

Fix: detect added keys by **key presence** via `find` — it returns the `[k v]` entry for any present key (including a present `nil`) and `nil` only for a genuinely absent key, so no runtime value can collide. Single map lookup, no in-band sentinel. `spec/diff-encode.md` now documents the key-side no-in-band-sentinel principle alongside the existing value-side one.

## Downstream consumer CI fix (r2 — commit f3c99ddbb)

The rf2-fwaolt dedup fix is an **intentional wire-shape change**: a non-empty collection with no repeated subtrees now ships RAW instead of wrapped in a one-entry `:rf.mcp/dedup-table`. mcp-base's own suite + mcp-conformance stayed green, but **two downstream consumers went red in CI** — both carried a mirror `dedup-non-empty-collection-emits-marker` test whose fixture `[{:a 1} {:b 2}]` has no repeated subtrees and so asserted the OLD "any non-empty collection wraps" contract:

- **JVM `tools/story-mcp` (`clojure -M:test`)** — 3 failed assertions in `dedup-non-empty-collection-emits-marker` (`(map? wrapped)` / `(contains? wrapped :rf.mcp/dedup-table)` / `(map? (:rf.mcp/dedup-table wrapped))`).
- **Node `tools/re-frame2-pair-mcp` (shadow-cljs `:server-test`)** — the identical 3 assertions in the mirror `dedup_test.cljs`.

**Root cause: case (a)** — the consumers pinned the pre-fix wire shape; no genuine contract regression. The mcp-base change is correct and stays as-is (verified: mcp-base's diff-encode `find`-based change is a **no-op for every consumer fixture** — it only differs on a leaf value equal to the private `::absent` sentinel, which no fixture uses; the failures are purely the dedup wrap-skip).

**Fix (test-only, both consumers):**
- rename `dedup-non-empty-collection-emits-marker` → `dedup-repeated-subtree-collection-emits-marker` and give it a repeated-subtree fixture (`[shared shared]`) so the marker genuinely fires (this is the honest assertion under the corrected contract);
- add `dedup-no-repeat-collection-stays-raw` pinning the corrected behaviour (no-repeat non-empty collection ⇒ verbatim passthrough, not a wrap).

No production code touched in r2; the change is confined to the two consumer test files.

## Quality gates

| Gate | Command | Result |
|---|---|---|
| mcp-base artefact (JVM) | `cd tools/mcp-base && clojure -M:test` | **PASS** — 257 tests, 865 assertions, 0 failures, 0 errors |
| story-mcp artefact (JVM) — was RED | `cd tools/story-mcp && clojure -M:test` | **PASS** — 302 tests, 1487 assertions, 0 failures, 0 errors (+1 new test) |
| story-mcp descriptor drift-check | `cd tools/story-mcp && clojure -M:gen --check` | **PASS** — in sync (20 tools) |
| pair-mcp server-test (Node) — was RED | `cd tools/re-frame2-pair-mcp && npm test` | **PASS** — 1168 tests, 3883 assertions, 0 failures, 0 errors (+1 new test) |
| pair-mcp descriptor drift-check | `cd tools/re-frame2-pair-mcp && npm run check:descriptors` | **PASS** — in sync (30 tools) |
| mcp-conformance | — | **UNAFFECTED** — r2 touches only two consumer test files; zero production/conformance-fixture change, so the already-green conformance run cannot regress. |

New adversarial/negative tests added per behavioural fix:
- **dedup (mcp-base)**: non-empty no-repeat map/vector/nested return the input `identical?` (would fail against the pre-fix wrap); repeated-subtree case still wraps + round-trips; direct `no-substitutions?` unit coverage.
- **diff-encode (mcp-base)**: sentinel-valued unchanged key emits no patch (with a real sibling change; fails against the old `get`-with-default); present-`nil` unchanged key emits no patch; genuine add/remove/change transitions of a sentinel-valued key; end-to-end encode/decode carries **only** the genuine change on the wire.
- **consumers (r2)**: story-mcp + pair-mcp each pin the corrected no-repeat-stays-raw contract and keep a repeated-subtree wrap assertion.

## Stance

Pre-alpha, no back-compat shims; optimized for ELEGANCE + CLARITY + CORRECTNESS + GOOD PRACTICE; avoided over-engineering. Isolated to `tools/mcp-base` (+ its `spec/`) plus the two downstream consumer test files greened in r2; no other in-flight worker surface touched.
