### PR TITLE
fix(story): shared effective-tag resolver strips :!tag + subtracts base (rf2-n0vmq2)

### DIFF
--- a/tools/story/spec/001-Authoring.md
+++ b/tools/story/spec/001-Authoring.md
@@ -1004,6 +1004,30 @@ Query the default-excluded set via:
 tag set when included in a child variant's `:tags`. Per Phase 1 §2.1
 Storybook-borrowed ergonomic.
 
+#### Effective tags — the shared resolver
+
+Every tag consumer (plan compilation, `variants-with-tags`, the docs /
+sidebar tag chips, the sidebar tag filter, and testable-variant selection)
+reads a variant's **effective** tag set, computed by the single resolver in
+`re-frame.story.tags`. It applies three steps, in order:
+
+1. **Inheritance.** A variant's tags are the UNION of `:tags` across its
+   `:extends` chain (root→child, additive). When neither the variant nor any
+   `:extends` ancestor declares `:tags`, they FALL BACK to the parent story's
+   `:tags` (story tags are a default, not an addition — a variant that
+   declares its own tags does not union with the story).
+2. **Marker removal.** A `:!x` removal marker is dropped from the output — it
+   is authoring syntax, never a visible or queryable tag.
+3. **Base subtraction.** Each `:!x` marker subtracts its base `:x`, so an
+   inherited or unioned `:dev` is cancelled by `:!dev`.
+
+So a child that `:extends` a parent tagged `#{:dev}` and declares `#{:!dev}`
+has an effective set of `#{}`: it does not surface a `:dev` chip, is excluded
+from `(variants-with-tags #{:dev})`, and never shows `:!dev` as a chip or a
+filter facet. The resolver is the single authority — the raw authored `:tags`
+(with markers and unresolved inheritance) live only in the registration
+side-table; every downstream surface reads the effective set.
+
 ### `(reg-mode id metadata)`
 
 ```clojure

--- a/tools/story/spec/002-Runtime.md
+++ b/tools/story/spec/002-Runtime.md
@@ -741,6 +741,8 @@ tests / REPL via `deref-blocking`, CLJS callers chain with `then` / await.
                                                  ;   returns a 0-arity unsubscribe fn
                                                  ;   (call it to stop watching)
 (variants-with-tags tags)                        ; query — returns coll of variant ids
+                                                 ;   (matches EFFECTIVE tags: `:extends`/story
+                                                 ;   inheritance + `:!x` removal — see 001 §Effective tags)
 (variant->edn variant-id)                        ; canonical-form serialised body
 (workspace->edn workspace-id)                    ; same, for workspace layouts
 (snapshot-identity variant-id)

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -546,8 +546,11 @@
   (query/variants-by-story))
 
 (defn variants-with-tags
-  "Per `002-Runtime.md` §Programmatic API — return the set of variant ids whose `:tags`
-  intersects `query-tags`. The assertions/play surface leans on this;
+  "Per `002-Runtime.md` §Programmatic API — return the set of variant ids
+  whose EFFECTIVE `:tags` intersect `query-tags`. Effective tags apply
+  `:extends`/parent-story inheritance and `:!x` removal-marker resolution
+  (the shared `re-frame.story.tags` resolver), so an inherited tag matches
+  and a removed one does not. The assertions/play surface leans on this;
   the render shell leans on this to compose the sidebar tree."
   [query-tags]
   (query/variants-with-tags query-tags))

--- a/tools/story/src/re_frame/story/plan.cljc
+++ b/tools/story/src/re_frame/story/plan.cljc
@@ -121,6 +121,7 @@
             [re-frame.story.registrar    :as registrar]
             [re-frame.story.requirements :as requirements]
             [re-frame.story.malli-schema :as msu]
+            [re-frame.story.tags         :as tags]
             [re-frame.story.play.runner  :as runner]
             [re-frame.registrar          :as framework-registrar]))
 
@@ -259,10 +260,13 @@
     (args/deep-merge parent child)
     (if (some? child) child parent)))
 
-(defn- merge-tags
-  "Tags are additive through `:extends` (§Merge rules — append/union)."
-  [parent child]
-  (into (set parent) (set child)))
+;; Tags are additive through `:extends` (§Merge rules — append/union), then
+;; resolved through the SHARED `re-frame.story.tags` resolver (`:!x` removal
+;; markers stripped + their base subtracted, story fallback when the chain
+;; declares none). `compile-body` unions `:tags` across the resolved `bodies`
+;; and hands the union to `tags/resolve-markers` so the plan's `:tags` is the
+;; EFFECTIVE set — identical to what `variants-with-tags`, docs chips, and the
+;; sidebar filter compute through the same resolver.
 
 ;; ============================================================================
 ;; Script normalization
@@ -1098,6 +1102,15 @@
   [story-id]
   (:decorators (registrar/handler-meta :story story-id)))
 
+(defn- default-story-lookup
+  "Default parent-story-body lookup — reads the Story side-table `:story`
+  kind. Feeds the shared tag resolver's story-fallback layer (a variant that
+  declares no tags on its `:extends` chain inherits the parent story's
+  `:tags`). Production bundles elide the side-table (nil → no story tags);
+  pure tests thread an explicit `:story-lookup`."
+  [story-id]
+  (registrar/handler-meta :story story-id))
+
 (defn expand-checks
   "Expand a plan's `:expect :checks` ids into the
   `{check-id [assertion-atom …]}` map the unified run-result groups its
@@ -1151,11 +1164,16 @@
   - `:story-decorators` — a 1-arg fn `(story-id) → decorators-vec` OR a
     `{story-id → decorators-vec}` map resolving the parent story's
     `:decorators` slot (folded between globals and the variant chain).
-    Defaults to the Story side-table `:story` kind."
+    Defaults to the Story side-table `:story` kind.
+  - `:story-lookup` — a 1-arg fn `(story-id) → story-body` OR a
+    `{story-id → story-body}` map resolving the parent story body, whose
+    `:tags` feed the shared tag resolver's story-fallback layer (used only
+    when the `:extends` chain declares no tags). Defaults to the Story
+    side-table `:story` kind."
   ([id body lookup] (compile-body id body lookup nil))
   ([id body lookup {:keys [view-lookup validator-fns sub-lookup
                            fragment-lookup check-lookup
-                           global-decorators story-decorators
+                           global-decorators story-decorators story-lookup
                            run-args] :as _opts}]
   (let [view-lookup  (coerce-kind-lookup :view-lookup view-lookup default-view-lookup)
         sub-lookup   (coerce-kind-lookup :sub-lookup sub-lookup default-sub-lookup)
@@ -1163,6 +1181,8 @@
                                          default-fragment-lookup)
         chk-lookup   (coerce-kind-lookup :check-lookup check-lookup
                                          default-check-lookup)
+        story-lookup (coerce-kind-lookup :story-lookup story-lookup
+                                         default-story-lookup)
         ;; ---- ambient decorator layers ----
         ;; The full decorator stack folded into `[:world :decorators]` is
         ;; `(concat globals story variant-chain)` — the SAME set
@@ -1530,6 +1550,19 @@
                                   story-decos
                                   frag-decorators
                                   (or (:decorators ctx) [])))
+        ;; ---- effective tags (shared resolver) ----
+        ;; Union `:tags` across the resolved `:extends` chain (`bodies` is
+        ;; root→child and includes an inline body correctly, unlike a re-walk
+        ;; via `lookup`), fall back to the parent story's `:tags` when the
+        ;; chain declares none, then resolve `:!x` removal markers through the
+        ;; shared `re-frame.story.tags` resolver. So the plan's `:tags` is the
+        ;; EFFECTIVE set — a `:!dev` cancels an inherited `:dev` and never
+        ;; leaks itself, matching what every other tag consumer computes.
+        chain-tags   (reduce (fn [acc b] (into acc (:tags b))) #{} bodies)
+        eff-tags     (tags/resolve-markers
+                       (if (seq chain-tags)
+                         chain-tags
+                         (set (:tags (when sid (story-lookup sid))))))
         world        (cond-> {:setup          setup
                               :args           arg-map
                               :argtypes       argtypes
@@ -1670,8 +1703,7 @@
                       :assertions   assertions
                       :required-runner required
                       :platforms    platforms
-                      :tags         (reduce (fn [acc layer] (merge-tags acc (:tags layer)))
-                                            #{} bodies)
+                      :tags         eff-tags
                       :source       source}]
     (cond-> {:variant/id      id
              :source-chain    (mapv :variant/id chain)
@@ -1679,8 +1711,7 @@
              :script          script*
              :expect          (normalize-expect checks assertions)
              :required-runner required
-             :tags            (reduce (fn [acc layer] (merge-tags acc (:tags layer)))
-                                      #{} bodies)
+             :tags            eff-tags
              :explain         explain}
       source (assoc :source source)
       ;; The parent story id (rf2-xk8oz4). `plan-hash-input-keys` includes
@@ -1769,7 +1800,7 @@
          compile-opts (select-keys opts [:view-lookup :validator-fns :sub-lookup
                                          :fragment-lookup :check-lookup
                                          :global-decorators :story-decorators
-                                         :run-args])]
+                                         :story-lookup :run-args])]
      (cond
        (keyword? target)
        (if-let [body (lookup-fn target)]

--- a/tools/story/src/re_frame/story/query.cljc
+++ b/tools/story/src/re_frame/story/query.cljc
@@ -67,9 +67,11 @@
   (registrar/variants-by-story))
 
 (defn variants-with-tags
-  "Per `002-Runtime.md` §Programmatic API — return the set of variant ids whose `:tags`
-  intersects `query-tags`. The assertions/play surface leans on this;
-  the render shell leans on this to compose the sidebar tree."
+  "Per `002-Runtime.md` §Programmatic API — return the set of variant ids
+  whose EFFECTIVE `:tags` intersect `query-tags` (`:extends`/parent-story
+  inheritance + `:!x` removal markers, via the shared `re-frame.story.tags`
+  resolver). The assertions/play surface leans on this; the render shell
+  leans on this to compose the sidebar tree."
   [query-tags]
   (registrar/variants-with-tags query-tags))
 

--- a/tools/story/src/re_frame/story/registrar.cljc
+++ b/tools/story/src/re_frame/story/registrar.cljc
@@ -70,7 +70,8 @@
   (:require [clojure.string           :as str]
             [malli.core               :as m]
             [re-frame.story.late-bind :as late-bind]
-            [re-frame.story.schemas   :as schemas]))
+            [re-frame.story.schemas   :as schemas]
+            [re-frame.story.tags      :as tags]))
 
 ;; ---- source-coord plumbing ------------------------------------------------
 ;;
@@ -626,16 +627,27 @@
   (atom {:tick -1 :by-query {}}))
 
 (defn- compute-variants-with-tags [qs]
-  (->> (registrations :variant)
-       (filter (fn [[_ body]]
-                 (let [tset (:tags body #{})]
-                   (some #(contains? tset %) qs))))
-       (map first)
-       set))
+  ;; Match against each variant's EFFECTIVE tag set (the shared
+  ;; `re-frame.story.tags` resolver — story/extends inheritance + `:!x`
+  ;; marker resolution), NOT the raw child `:tags`. So a variant matches a
+  ;; tag it inherits, and a `:!x` marker that cancels an inherited tag
+  ;; excludes it (a child that removed `:dev` with `:!dev` is NOT returned
+  ;; for the `#{:dev}` query, and `:!dev` is never itself a queryable tag).
+  (let [variants (registrations :variant)
+        lookups  {:variant variants :story (registrations :story)}]
+    (->> variants
+         (filter (fn [[vid _body]]
+                   (let [tset (tags/effective-tags vid lookups)]
+                     (some #(contains? tset %) qs))))
+         (map first)
+         set)))
 
 (defn variants-with-tags
-  "Return the variant ids whose `:tags` set intersects `query-tags`. Per
-  `002-Runtime.md` §Programmatic API — the public `variants-with-tags` wraps this.
+  "Return the variant ids whose EFFECTIVE tag set intersects `query-tags`.
+  Per `002-Runtime.md` §Programmatic API — the public `variants-with-tags`
+  wraps this. The effective set is resolved through the shared
+  `re-frame.story.tags` resolver (story/extends inheritance + `:!x` removal
+  markers), so an inherited tag matches and a removed one does not.
 
   Memoised on the registrar mutation-tick: repeated calls
   with the same query between two registrar writes return the same

--- a/tools/story/src/re_frame/story/tags.cljc
+++ b/tools/story/src/re_frame/story/tags.cljc
@@ -1,0 +1,150 @@
+(ns re-frame.story.tags
+  "Effective-tag resolution — the SINGLE authority that turns a variant's
+  AUTHORED `:tags` into the EFFECTIVE tag set every consumer reads.
+
+  Three responsibilities, applied in order (spec/001 §`!`-prefix removal
+  syntax + §Authoring inheritance):
+
+  1. **Inheritance.** A variant's tags come from its `:extends` chain
+     (UNION, additive — root→child) whenever it or any ancestor declares
+     `:tags`; otherwise they FALL BACK to the parent story's `:tags`. Story
+     tags are a DEFAULT, not an addition — a variant that declares its own
+     tags does not union with its story (`002-Runtime.md` §Authoring
+     inheritance / the `own-tags` cascade rule).
+  2. **Marker removal.** A `:!x` removal-marker keyword is dropped from the
+     output — it is authoring syntax, never a visible / queryable tag.
+  3. **Base subtraction.** Each `:!x` marker subtracts its base `:x` from the
+     set, so `:!dev` cancels an inherited / unioned `:dev`.
+
+  So `#{:dev :!dev :docs}` resolves to `#{:docs}`, and `#{:!dev}` to `#{}`.
+
+  This is the ONE resolver plan compilation, tag queries
+  (`variants-with-tags`), docs / sidebar chips, the tag filter, and
+  testable-variant selection funnel through — so a `:!x` marker can never
+  leak as a chip, a query hit, or a filter facet, and inherited tags read
+  identically across every surface. Before this ns, plan compilation unioned
+  the RAW tags (leaking `:!x` and matching an inherited `:x` the author had
+  removed), while the UI surfaces read the raw child `:tags` with no
+  inheritance at all (three divergent behaviours).
+
+  Pure data → data. Lookups are INJECTED (a fn `id → body` OR a `{id → body}`
+  map), so this ns stays a require-leaf — it never `:require`s the registrar,
+  and any Story ns can consume it without a cycle. Live callers pass the
+  registrar side-table; pure tests pass an explicit map."
+  (:require [re-frame.story.predicates :as pred]))
+
+;; ---- `:!x` removal markers -----------------------------------------------
+
+(defn removal-marker?
+  "True iff `tag` is a `:!x` removal-marker keyword — a keyword whose NAME
+  begins with `!` (namespace ignored, so `:a/!b` is a marker too). Mirrors
+  the membership-strip check in `re-frame.story.registrar`."
+  [tag]
+  (and (keyword? tag)
+       (let [n (name tag)]
+         (and (pos? (count n)) (= \! (first n))))))
+
+(defn marker-base
+  "The base tag a `:!x` removal marker cancels — `:!dev` → `:dev`, `:a/!b`
+  → `:a/b` (namespace preserved). Returns a non-marker unchanged."
+  [tag]
+  (if (removal-marker? tag)
+    (keyword (namespace tag) (subs (name tag) 1))
+    tag))
+
+(defn resolve-markers
+  "Given a RAW tag set already unioned across inheritance layers, return the
+  EFFECTIVE set: drop every `:!x` marker (responsibility 2) AND subtract each
+  marker's base `:x` (responsibility 3). The shared marker-resolution core.
+  A set with no markers is returned unchanged. Pure data → data."
+  [raw-tags]
+  (let [raw     (set raw-tags)
+        markers (into #{} (filter removal-marker?) raw)]
+    (if (empty? markers)
+      raw
+      (let [bases (into #{} (map marker-base) markers)]
+        (into #{}
+              (remove (fn [t] (or (removal-marker? t) (contains? bases t))))
+              raw)))))
+
+;; ---- inheritance ---------------------------------------------------------
+
+(def ^:dynamic *max-extends-depth*
+  "Bound on the `:extends` chain walk for tag resolution, mirroring
+  `re-frame.story.plan/*max-extends-depth*`. The resolver is best-effort —
+  the plan compiler is the authority that RAISES on a broken chain — so
+  hitting the bound (or a missing parent / a cycle) simply stops the walk."
+  32)
+
+(defn- as-fn
+  "Coerce a `id → body` lookup into a 1-arg fn: a fn is used as-is; a map is
+  read via `get`; nil yields a constant-nil lookup (the layer contributes
+  nothing)."
+  [lookup]
+  (cond
+    (nil? lookup) (constantly nil)
+    (map? lookup) #(get lookup %)
+    :else         lookup))
+
+(defn extends-chain-tags
+  "Union the AUTHORED `:tags` across `variant-id`'s `:extends` chain
+  (child→root), via `variant-lookup` (a fn or a `{id → raw-body}` map).
+  Defensive: stops on a missing parent, a re-visited id (cycle), or the
+  depth bound — it NEVER raises. Pure over the lookup."
+  [variant-id variant-lookup]
+  (let [vl (as-fn variant-lookup)]
+    (loop [tags #{} id variant-id visited #{} depth 0]
+      (let [body (vl id)]
+        (if (or (nil? body) (contains? visited id) (>= depth *max-extends-depth*))
+          tags
+          (let [tags'  (into tags (:tags body))
+                parent (:extends body)]
+            (if (nil? parent)
+              tags'
+              (recur tags' parent (conj visited id) (inc depth)))))))))
+
+(defn raw-inherited-tags
+  "The RAW (pre-marker-resolution) inherited tag set for `variant-id`: the
+  `:extends`-chain union when it (or any ancestor) declares tags, else the
+  parent story's `:tags` (fallback, NOT a union — responsibility 1). Pure
+  over the injected `lookups` (`{:variant <id→body> :story <id→body>}`)."
+  [variant-id {:keys [variant story]}]
+  (let [chain (extends-chain-tags variant-id variant)]
+    (if (seq chain)
+      chain
+      (set (:tags ((as-fn story) (pred/parent-story-id variant-id)))))))
+
+(defn effective-tags
+  "The EFFECTIVE tag set for `variant-id` — inheritance (extends union /
+  story fallback) then `:!x` marker resolution. The single authority every
+  tag consumer reads.
+
+  `lookups` is `{:variant <id→body> :story <id→body>}`, each a fn OR a
+  `{id → body}` map. Both are OPTIONAL — an absent lookup contributes no
+  layer, so a caller with only the variant side-table still resolves the
+  extends chain + markers. Pure data → data."
+  ([variant-id] (effective-tags variant-id nil))
+  ([variant-id lookups]
+   (resolve-markers (raw-inherited-tags variant-id lookups))))
+
+(defn resolve-body-tags
+  "Return `id->body` with each variant body's `:tags` replaced by its
+  EFFECTIVE set (`effective-tags`). The single projection every UI consumer
+  of a variant registry reads through — the sidebar tree, tag chips, the tag
+  filter, testable selection, and search all see the SAME resolved tags, so a
+  `:!x` marker never reaches a chip or a facet and inherited tags surface
+  everywhere.
+
+  `lookups` (optional) is `{:variant <id→body> :story <id→body>}`; the
+  `:variant` layer defaults to `id->body` itself (the `:extends` chain
+  resolves within the passed map). Pure data → data."
+  ([id->body] (resolve-body-tags id->body nil))
+  ([id->body {:keys [variant story]}]
+   (let [vl (or variant id->body)]
+     (persistent!
+       (reduce-kv (fn [acc id body]
+                    (assoc! acc id
+                            (assoc body :tags
+                                   (effective-tags id {:variant vl :story story}))))
+                  (transient {})
+                  id->body)))))

--- a/tools/story/src/re_frame/story/ui/docs.cljc
+++ b/tools/story/src/re_frame/story/ui/docs.cljc
@@ -50,6 +50,7 @@
             [re-frame.story.predicates :as pred]
             [re-frame.story.plan       :as plan]
             [re-frame.story.registrar  :as registrar]
+            [re-frame.story.tags       :as tags]
             [re-frame.story.ui.evidence-spine :as spine]
             [re-frame.story.ui.markdown :as md]
             [re-frame.story.ui.test-mode.pure :as test-pure]
@@ -163,15 +164,18 @@
         [:modes :substrates :platforms]))))
 
 (defn variant-tags
-  "Return the sorted vector of tags on `variant-id`. Falls back to the
-  parent story's `:tags` set if the variant body declares none. Used
-  by both the docs header chips and the bottom-of-page tag picker."
+  "Return the sorted vector of EFFECTIVE tags on `variant-id`, through the
+  shared `re-frame.story.tags` resolver: `:extends`-chain inheritance (union)
+  with a parent-story `:tags` fallback when the chain declares none, then
+  `:!x` removal-marker resolution (a `:!dev` cancels an inherited `:dev` and
+  never shows itself as a chip). Used by both the docs header chips and the
+  bottom-of-page tag picker — the SAME set the sidebar filter and
+  `variants-with-tags` compute."
   [variant-id]
-  (let [vb       (registrar/handler-meta :variant variant-id)
-        story-id (pred/parent-story-id variant-id)
-        sb       (when story-id (registrar/handler-meta :story story-id))
-        ts       (or (:tags vb) (:tags sb) #{})]
-    (vec (sort ts))))
+  (vec (sort (tags/effective-tags
+               variant-id
+               {:variant #(registrar/handler-meta :variant %)
+                :story   #(registrar/handler-meta :story %)}))))
 
 ;; The header chips call `pred/parent-story-id` directly.
 

--- a/tools/story/src/re_frame/story/ui/state/filters.cljc
+++ b/tools/story/src/re_frame/story/ui/state/filters.cljc
@@ -100,8 +100,12 @@
   callers that don't have an axis-index handy (tests, downstream tools)
   work; the 3-arity is the facet-aware form the sidebar uses.
 
-  The `:!`-prefix removal syntax is resolved at registration time in
-  `re-frame.story.registrar` via `validate-tag-membership!`, not here."
+  This predicate matches on the variant body's `:tags` VERBATIM — the
+  `:extends`/story inheritance + `:!`-prefix removal-marker resolution is
+  applied UPSTREAM by the shared `re-frame.story.tags` resolver (the sidebar
+  reads `registry-snapshot`, which projects effective tags onto every
+  variant body), so the filter never sees a `:!x` marker and inherited tags
+  match here as expected."
   ([variant-body tag-filter]
    (or (empty? tag-filter)
        (let [tset (or (:tags variant-body) #{})]

--- a/tools/story/src/re_frame/story/ui/state/snapshot.cljc
+++ b/tools/story/src/re_frame/story/ui/state/snapshot.cljc
@@ -9,17 +9,28 @@
   control panel / workspace panes consume the snapshot. Lives in its
   own leaf so future memoisation (e.g. cache keyed on the registrar
   mutation-tick) is local."
-  (:require [re-frame.story.registrar :as registrar]))
+  (:require [re-frame.story.registrar :as registrar]
+            [re-frame.story.tags      :as tags]))
 
 (defn registry-snapshot
   "Return a single map containing every Story-side artefact kind. Used
   by the shell's render fns to walk the registry without N atom-deref
-  calls (and to support future memoisation if perf becomes an issue)."
+  calls (and to support future memoisation if perf becomes an issue).
+
+  The `:variants` slot carries EFFECTIVE tags: each variant body's `:tags`
+  is resolved through the shared `re-frame.story.tags` resolver
+  (`:extends`/story inheritance + `:!x` removal markers) before it reaches
+  the sidebar tree, tag chips, tag filter, testable selection, and search —
+  so a `:!x` marker never leaks as a chip or facet and inherited tags surface
+  uniformly. This is the SINGLE UI-side resolution point; every downstream
+  consumer reads the projected `:tags` verbatim."
   []
-  {:stories      (registrar/registrations :story)
-   :variants     (registrar/registrations :variant)
-   :workspaces   (registrar/registrations :workspace)
-   :modes        (registrar/registrations :mode)
-   :decorators   (registrar/registrations :decorator)
-   :story-panels (registrar/registrations :story-panel)
-   :tags         (registrar/registrations :tag)})
+  (let [variants (registrar/registrations :variant)
+        stories  (registrar/registrations :story)]
+    {:stories      stories
+     :variants     (tags/resolve-body-tags variants {:story stories})
+     :workspaces   (registrar/registrations :workspace)
+     :modes        (registrar/registrations :mode)
+     :decorators   (registrar/registrations :decorator)
+     :story-panels (registrar/registrations :story-panel)
+     :tags         (registrar/registrations :tag)}))

--- a/tools/story/test/re_frame/story/tags_test.cljc
+++ b/tools/story/test/re_frame/story/tags_test.cljc
@@ -1,0 +1,137 @@
+(ns re-frame.story.tags-test
+  "Tests for the shared effective-tag resolver (rf2-n0vmq2).
+
+  `re-frame.story.tags` is pure data → data, so every test runs on both the
+  JVM and CLJS without a host: inheritance layers are supplied through
+  explicit `{id → body}` lookup maps. The plan regressions drive the real
+  compiler (`re-frame.story.plan`) with an explicit `:lookup`; the filter
+  regression proves the snapshot projection feeds the sidebar filter."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.story.tags :as tags]
+            [re-frame.story.plan :as plan]
+            [re-frame.story.ui.state.filters :as filters]))
+
+;; ---- pure marker helpers -------------------------------------------------
+
+(deftest removal-marker?-recognises-bang-prefix
+  (is (true?  (tags/removal-marker? :!dev)))
+  (is (true?  (tags/removal-marker? :a/!b)))
+  (is (false? (tags/removal-marker? :dev)))
+  (is (false? (tags/removal-marker? :a/b)))
+  (is (false? (tags/removal-marker? "not-a-keyword")))
+  (is (false? (tags/removal-marker? nil))))
+
+(deftest marker-base-strips-bang-preserving-namespace
+  (is (= :dev (tags/marker-base :!dev)))
+  (is (= :a/b (tags/marker-base :a/!b)))
+  (testing "a non-marker is returned unchanged"
+    (is (= :dev (tags/marker-base :dev)))))
+
+(deftest resolve-markers-strips-and-subtracts
+  (testing "a marker drops itself AND subtracts its base"
+    (is (= #{:docs} (tags/resolve-markers #{:dev :!dev :docs}))))
+  (testing "a marker with no matching base still never surfaces"
+    (is (= #{} (tags/resolve-markers #{:!dev}))))
+  (testing "a set with no markers is returned unchanged"
+    (is (= #{:dev :docs} (tags/resolve-markers #{:dev :docs}))))
+  (testing "namespaced marker cancels its namespaced base"
+    (is (= #{:team/qa} (tags/resolve-markers #{:team/qa :role/dev :role/!dev})))))
+
+;; ---- extends-chain union -------------------------------------------------
+
+(deftest extends-chain-tags-unions-root-to-child
+  (let [m {:story.a/parent {:tags #{:dev :test}}
+           :story.a/child  {:extends :story.a/parent :tags #{:docs}}}]
+    (is (= #{:dev :test :docs} (tags/extends-chain-tags :story.a/child m)))))
+
+(deftest extends-chain-tags-is-defensive
+  (testing "a missing parent stops the walk without raising"
+    (let [m {:story.a/child {:extends :story.a/ghost :tags #{:docs}}}]
+      (is (= #{:docs} (tags/extends-chain-tags :story.a/child m)))))
+  (testing "a cycle stops the walk without raising"
+    (let [m {:story.a/x {:extends :story.a/y :tags #{:dev}}
+             :story.a/y {:extends :story.a/x :tags #{:docs}}}]
+      (is (= #{:dev :docs} (tags/extends-chain-tags :story.a/x m))))))
+
+;; ---- effective-tags: inheritance + markers -------------------------------
+
+(deftest effective-tags-inherited-tag-removed-by-marker
+  (testing "rf2-n0vmq2 — a child :extends a parent tagged :dev and declares
+            :!dev; the inherited :dev is removed and :!dev never surfaces"
+    (let [m {:story.login/base  {:tags #{:dev :test}}
+             :story.login/child {:extends :story.login/base :tags #{:!dev}}}
+          eff (tags/effective-tags :story.login/child {:variant m})]
+      (is (= #{:test} eff))
+      (is (not (contains? eff :dev)))
+      (is (not (contains? eff :!dev))))))
+
+(deftest effective-tags-story-fallback-only-when-chain-empty
+  (let [variants {:story.t/no-tags  {}
+                  :story.t/own-tags {:tags #{:test}}}
+        stories  {:story.t {:tags #{:dev :docs}}}
+        lookups  {:variant variants :story stories}]
+    (testing "a variant that declares none inherits the parent story's tags"
+      (is (= #{:dev :docs} (tags/effective-tags :story.t/no-tags lookups))))
+    (testing "a variant that declares its own tags does NOT union with the story"
+      (is (= #{:test} (tags/effective-tags :story.t/own-tags lookups))))))
+
+(deftest effective-tags-empty-when-nothing-declared
+  (is (= #{} (tags/effective-tags :story.none/v {:variant {:story.none/v {}}}))))
+
+;; ---- resolve-body-tags projection ----------------------------------------
+
+(deftest resolve-body-tags-projects-effective-onto-each-body
+  (let [variants {:story.p/base  {:tags #{:dev}}
+                  :story.p/child {:extends :story.p/base :tags #{:!dev :docs}}}
+        projected (tags/resolve-body-tags variants)]
+    (is (= #{:dev}  (:tags (:story.p/base projected))))
+    (is (= #{:docs} (:tags (:story.p/child projected)))
+        "the child's inherited :dev is cancelled by :!dev; :!dev is stripped")
+    (testing "non-tag slots are preserved"
+      (is (= :story.p/base (:extends (:story.p/child projected)))))))
+
+;; ---- sidebar filter regression (snapshot projection → filter) ------------
+
+(deftest filter-excludes-variant-that-removed-the-tag
+  (testing "no visible :!dev chip / no :dev filter hit after resolution"
+    (let [variants  {:story.f/base  {:tags #{:dev}}
+                     :story.f/child {:extends :story.f/base :tags #{:!dev}}
+                     :story.f/keeps {:tags #{:dev}}}
+          projected (tags/resolve-body-tags variants)
+          dev-hits  (set (keys (filters/filter-variants projected #{:dev})))]
+      (testing "the child that removed :dev is filtered out"
+        (is (not (contains? dev-hits :story.f/child))))
+      (testing "variants that keep :dev (own + inherited-untouched) still match"
+        (is (= #{:story.f/base :story.f/keeps} dev-hits)))
+      (testing ":!dev is never a visible tag on any projected body"
+        (is (not-any? (fn [[_ b]] (contains? (:tags b) :!dev)) projected))))))
+
+;; ---- plan compilation regression -----------------------------------------
+
+(deftest plan-tags-resolve-markers-through-extends
+  (testing "rf2-n0vmq2 — plan :tags is the EFFECTIVE set (inherited :dev
+            removed by :!dev), not the raw union"
+    (let [m {:story.login/filled {:tags #{:dev :test} :events []}
+             :story.login/error  {:extends    :story.login/filled
+                                   :tags       #{:!dev}
+                                   :events     []}}
+          p (plan/variant-plan :story.login/error {:lookup m})]
+      (is (= #{:test} (:tags p)))
+      (is (= #{:test} (get-in p [:explain :tags])))
+      (is (not (contains? (:tags p) :dev)))
+      (is (not (contains? (:tags p) :!dev))))))
+
+(deftest plan-tags-additive-through-extends-without-markers
+  (testing "the additive :extends union is preserved when no marker is present"
+    (let [m {:story.s/parent {:tags #{:test} :events []}
+             :story.s/child  {:extends :story.s/parent :tags #{:docs} :events []}}
+          p (plan/variant-plan :story.s/child {:lookup m})]
+      (is (= #{:test :docs} (:tags p))))))
+
+(deftest plan-tags-story-fallback-via-story-lookup
+  (testing "a variant that declares no tags inherits the parent story's via
+            the :story-lookup opt"
+    (let [m {:story.fb/v {:events []}}
+          stories {:story.fb {:tags #{:dev :docs}}}
+          p (plan/variant-plan :story.fb/v {:lookup m :story-lookup stories})]
+      (is (= #{:dev :docs} (:tags p))))))

--- a/tools/story/test/re_frame/story_test.clj
+++ b/tools/story/test/re_frame/story_test.clj
@@ -668,6 +668,26 @@
     (is (= #{:story.tag/a :story.tag/c} (story/variants-with-tags #{:test})))
     (is (= #{:story.tag/a :story.tag/b} (story/variants-with-tags #{:docs :dev})))))
 
+(deftest variants-with-tags-excludes-marker-removed-inherited-tag
+  (testing "rf2-n0vmq2 — a child that :extends a :dev-tagged parent and
+            declares :!dev is EXCLUDED from the #{:dev} query (the inherited
+            :dev was cancelled), while a sibling that keeps :dev is returned"
+    (story/reg-variant :story.rm/base  {:events [] :tags #{:dev}})
+    (story/reg-variant :story.rm/child {:events [] :extends :story.rm/base :tags #{:!dev}})
+    (story/reg-variant :story.rm/keeps {:events [] :tags #{:dev}})
+    (let [hits (story/variants-with-tags #{:dev})]
+      (is (contains? hits :story.rm/base))
+      (is (contains? hits :story.rm/keeps))
+      (is (not (contains? hits :story.rm/child))
+          ":!dev removed the inherited :dev, so the child is not a #{:dev} hit"))))
+
+(deftest variants-with-tags-matches-inherited-story-tag
+  (testing "rf2-n0vmq2 — a variant that declares no tags inherits its parent
+            story's :tags and is returned for a query on the inherited tag"
+    (story/reg-story   :story.inh {:tags #{:dev}})
+    (story/reg-variant :story.inh/v {:events []})
+    (is (contains? (story/variants-with-tags #{:dev}) :story.inh/v))))
+
 (deftest all-kinds-with-counts-reflects-state
   (testing "all-kinds-with-counts mirrors the side-table"
     (story/reg-story   :story.x   {:doc "x"})

--- a/tools/story/test/re_frame/story_ui_test.clj
+++ b/tools/story/test/re_frame/story_ui_test.clj
@@ -699,6 +699,14 @@
     (story/reg-variant :story.t2/a {:events []})
     (is (= [:dev :docs] (docs/variant-tags :story.t2/a)))))
 
+(deftest docs-variant-tags-resolves-removal-marker
+  (testing "rf2-n0vmq2 — a child that :extends a :dev-tagged parent and
+            declares :!dev shows NO :dev and NO :!dev chip (effective set)"
+    (story/reg-variant :story.tm/base  {:tags #{:dev :test} :events []})
+    (story/reg-variant :story.tm/child {:extends :story.tm/base :tags #{:!dev} :events []})
+    (is (= [:test] (docs/variant-tags :story.tm/child)))
+    (is (not (some #{:dev :!dev} (docs/variant-tags :story.tm/child))))))
+
 (deftest docs-args-rows-pulls-doc-from-argtypes
   (testing "args-rows surfaces :doc from the variant's :argtypes entry"
     (story/reg-variant :story.a/x


### PR DESCRIPTION
## What

Story documented `:!tag` removal markers and accepted them for membership by stripping `!`, but the consumers were inconsistent:

- **plan compilation** unioned the RAW tags (`merge-tags`) — so a child `:extends`-ing a `:dev`-tagged parent and declaring `#{:!dev}` produced `#{:dev :!dev}`: it still matched `:dev` and leaked `:!dev`;
- **UI surfaces** (sidebar chips, tag filter, testable selection, search) read the raw child `:tags` with **no inheritance at all**;
- **docs chips** did a partial variant-or-story fallback.

Three divergent behaviours; markers never actually resolved anywhere.

## Fix — one shared resolver

New pure leaf `re-frame.story.tags` (requires only `predicates`, so no require cycle) is the single authority:

1. **Inheritance** — `:extends`-chain union (root→child), with a parent-story `:tags` fallback when the chain declares none (preserves the existing "own-tags don't merge with the story" cascade rule).
2. **Marker removal** — a `:!x` marker is dropped from the output.
3. **Base subtraction** — each `:!x` subtracts its base `:x`.

So `#{:dev :!dev :docs}` → `#{:docs}` and `#{:!dev}` → `#{}`.

Every consumer now funnels through it:

| Surface | Wiring |
|---|---|
| plan compilation | `plan/compile-body` unions `:tags` across the resolved chain + story fallback, then `tags/resolve-markers` (adds a `:story-lookup` opt; `merge-tags` removed) |
| tag queries | `registrar/variants-with-tags` → `tags/effective-tags` |
| docs / picker chips | `docs/variant-tags` → `tags/effective-tags` |
| sidebar chips / tag filter / testable selection / search | `registry-snapshot` projects effective tags onto every variant body via `tags/resolve-body-tags` — the single UI-side resolution point, so all downstream pure consumers read the resolved `:tags` verbatim |

Specs updated: `001-Authoring.md` §Effective tags (new), `002-Runtime.md` `variants-with-tags` note.

## Regressions added

- `tags_test.cljc` (portable): marker helpers, `resolve-markers`, defensive extends-chain walk, `effective-tags` inheritance + fallback + markers, snapshot projection, sidebar-filter end-to-end, plan-compile.
- `story_test.clj`: `variants-with-tags` **excludes** a child that removed an inherited `:dev` with `:!dev`; **matches** a variant inheriting a story tag.
- `story_ui_test.clj`: `docs/variant-tags` shows no `:dev`/`:!dev` chip after removal.

Covers the bead's three asks: inherited `:dev` removed by `:!dev`; no visible `:!dev` chip; exclusion from `variants-with-tags #{:dev}`.

## Quality gates

| Gate | Command | Result |
|---|---|---|
| Story JVM | `cd tools/story && clojure -M:test` | **PASS** — 1762 tests, 6484 assertions, 0 failures, 0 errors |
| CLJS node integration | `cd implementation && npm run test:cljs` | **PASS** — 8135 tests, 37279 assertions, 0 failures, 0 errors |
| Story build | `cd implementation && npm run story:build` | **PASS** — 653 files, 592 compiled, 0 warnings |
| Fast PR spine | `sh scripts/test-fast-pr.sh` | **PASS** — core JVM 1761/0, CLJS 8135/0, markdown link/anchor + EP-status + runtime-grading gates green; `mkdocs --strict` soft-skipped locally (not on PATH; CI runs it) |

## Stance

Pre-alpha, no back-compat shims; optimized for ELEGANCE + CLARITY + CORRECTNESS + GOOD PRACTICE; avoided over-engineering (one resolver leaf, injected lookups, no new registry).
