### PR TITLE
fix(test-quiet): bound warn buffer, banner filters (rf2-6emzlh +2)

### DIFF
--- a/implementation/test-quiet/src/re_frame/test_quiet.cljc
+++ b/implementation/test-quiet/src/re_frame/test_quiet.cljc
@@ -90,7 +90,16 @@
   is mislabelled (prints the inner ns banner) or — once the inner run
   flushed its banner — orphaned (no banner at all).  Reading the ns off
   the var that actually failed makes the banner always match the
-  failure, regardless of nesting."
+  failure, regardless of nesting.
+
+  test-ns-hook fallback (rf2-g92dsm): a namespace's `test-ns-hook` runs
+  OUTSIDE `test-var`, so a bare failing assertion inside it reports with
+  an empty `*testing-vars*` — the var-derived ns is nil and the failure
+  would print with NO banner.  For that (and only that) no-var case,
+  `banner-ns` falls back to the innermost open namespace, tracked on a
+  begin/end-balanced `ns-stack` (a proper stack, NOT the clobberable
+  single cell above).  The failing var still wins whenever one exists, so
+  nested-run correctness is unchanged."
   (:require
     #?(:clj  [clojure.test]
        :cljs [cljs.test])))
@@ -106,40 +115,58 @@
 ;; thread, and under CLJS the single-threaded runtime makes it trivially
 ;; safe.
 ;;
-;; We DON'T track a single mutable "current ns" cell — that is the source
-;; of the nested-run mislabel / orphan bugs (rf2-8n97n.1 / .2), because a
-;; nested run's `:begin-test-ns` clobbers it.  Instead we record the SET
-;; of namespaces whose banner has already been flushed, and derive the
-;; namespace to flush from the failing var itself (see `failing-ns`).
+;; We DON'T derive the failure banner from a single mutable "current ns"
+;; cell — that is the source of the nested-run mislabel / orphan bugs
+;; (rf2-8n97n.1 / .2), because a nested run's `:begin-test-ns` clobbers it.
+;; The PRIMARY banner ns is derived from the failing VAR itself (see
+;; `failing-ns`), which is always correct regardless of nesting.
 ;;
-;; The set is cleared when an OUTERMOST namespace is entered (ns-depth 0
-;; at `:begin-test-ns`) so a fresh `run-tests` — or the next sibling ns
-;; within one run — re-flushes banners.  A NESTED run's `:begin-test-ns`
-;; fires while the outer ns is still open (ns-depth >= 1), so it does NOT
-;; clear: the outer run's already-printed banners stay suppressed while
-;; the inner ns can still print its own.  `:begin-test-ns`/`:end-test-ns`
-;; are balanced per ns and never nested for sibling nses, so the depth
-;; counter rises above 0 only across a nested run-tests boundary.
+;; We DO keep a STACK of the namespaces currently open — `:begin-test-ns`
+;; pushes, `:end-test-ns` pops — for two things:
+;;   - nesting depth: an EMPTY stack at `:begin-test-ns` means we are
+;;     entering an OUTERMOST namespace, which clears the printed-banner set
+;;     so a fresh `run-tests` (or the next sibling ns within one run)
+;;     re-flushes banners.  A NESTED run's `:begin-test-ns` fires while the
+;;     outer ns is still open (non-empty stack), so it does NOT clear: the
+;;     outer run's already-printed banners stay suppressed while the inner
+;;     ns can still print its own.  `:begin-test-ns`/`:end-test-ns` are
+;;     balanced per ns and never nested for sibling nses, so the stack is
+;;     non-empty only across a nested run-tests boundary.
+;;   - a FALLBACK banner ns: a `test-ns-hook` runs OUTSIDE `test-var`, so a
+;;     bare failing assertion inside it reports with an EMPTY
+;;     `*testing-vars*` — the var-derived `failing-ns` is then nil and the
+;;     failure would print with NO banner, violating the failure-banner
+;;     contract.  `banner-ns` falls back to the innermost open ns (the top
+;;     of this stack) when there is no failing var (rf2-g92dsm).  The stack
+;;     is only a FALLBACK; whenever a failing var exists it wins, so
+;;     nested-run correctness is unchanged.
 
 (def ^:private printed-banners
   (atom #{}))
 
-(def ^:private ns-depth
-  (atom 0))
+(def ^:private ns-stack
+  (atom []))
 
 (defn- on-begin-test-ns!
-  "Track nesting depth and clear the printed-banner set on entry to an
-  outermost namespace so each top-level run (and each sibling ns within
-  it) re-flushes its banner.  Nested-run entries (depth >= 1) preserve
-  the outer run's printed set."
-  []
-  (when (zero? @ns-depth)
+  "Push `ns-sym` onto the open-namespace stack and clear the printed-banner
+  set on entry to an OUTERMOST namespace (empty stack) so each top-level
+  run — and each sibling ns within it — re-flushes its banner.  Nested-run
+  entries (non-empty stack) preserve the outer run's printed set."
+  [ns-sym]
+  (when (empty? @ns-stack)
     (reset! printed-banners #{}))
-  (swap! ns-depth inc))
+  (swap! ns-stack conj ns-sym))
 
 (defn- on-end-test-ns!
   []
-  (swap! ns-depth (fn [d] (max 0 (dec d)))))
+  (swap! ns-stack (fn [s] (if (seq s) (pop s) s))))
+
+(defn- current-test-ns
+  "The namespace of the innermost currently-open `test-ns` (top of the
+  begin/end stack), or nil if none is open.  The FALLBACK banner ns for a
+  failure with no failing var in scope (see `banner-ns`)."
+  []
+  (peek @ns-stack))
 
 (defn- ns-banner-printed?
   [ns-sym]
@@ -175,6 +202,25 @@
        (when-let [ns (:ns (meta v))]
          (ns-name ns)))))
 
+#?(:clj
+   (defn- event-ns
+     "The namespace symbol carried by a `:begin-test-ns` report `m`.
+     clojure.test passes the `clojure.lang.Namespace`; normalise to its
+     `ns-name` symbol so it matches `failing-ns` and prints cleanly."
+     [m]
+     (when-let [ns (:ns m)]
+       (if (instance? clojure.lang.Namespace ns)
+         (ns-name ns)
+         (symbol (name ns))))))
+
+#?(:clj
+   (defn- banner-ns
+     "The namespace to head the failure banner: the FAILING var's ns when a
+     var is in scope (nesting-correct, rf2-8n97n), else the innermost open
+     `test-ns` (the `test-ns-hook` no-var fallback, rf2-g92dsm)."
+     []
+     (or (failing-ns) (current-test-ns))))
+
 ;; `defonce` (not `def`) so a namespace RELOAD does not re-capture: on a
 ;; first load `get-method` returns clojure.test's default (our override is
 ;; not installed yet); on a reload our override is already installed, so a
@@ -190,14 +236,15 @@
 
 #?(:clj
    (do
-     (defmethod clojure.test/report :begin-test-ns [_m]
-       ;; Default behaviour prints "\nTesting <ns>"; we suppress and
-       ;; defer to print-banner! on first failure/error.  The banner ns
-       ;; is derived from the failing var (failing-ns), not from this
-       ;; event, so a nested run-tests can't clobber it — here we only
-       ;; track nesting depth + clear the printed-banner set on an
-       ;; outermost entry.
-       (on-begin-test-ns!))
+     (defmethod clojure.test/report :begin-test-ns [m]
+       ;; Default behaviour prints "\nTesting <ns>"; we suppress and defer
+       ;; to print-banner! on first failure/error.  The banner ns is
+       ;; normally derived from the failing var (failing-ns), not this
+       ;; event, so a nested run-tests can't clobber it; we push this ns
+       ;; onto the open-ns stack (for nesting-depth tracking + the
+       ;; test-ns-hook no-var banner fallback) and clear the printed-banner
+       ;; set on an outermost entry.
+       (on-begin-test-ns! (event-ns m)))
 
      (defmethod clojure.test/report :end-test-ns [_m]
        (on-end-test-ns!))
@@ -218,12 +265,12 @@
        ;; under the SAME `with-test-out` the default uses, so both land
        ;; on `*test-out*` in order.
        (clojure.test/with-test-out
-         (print-banner! (failing-ns)))
+         (print-banner! (banner-ns)))
        (jvm-default-fail m))
 
      (defmethod clojure.test/report :error [m]
        (clojure.test/with-test-out
-         (print-banner! (failing-ns)))
+         (print-banner! (banner-ns)))
        (jvm-default-error m))))
 
 ;; ----------------------------------------------------------------------
@@ -242,6 +289,23 @@
        (let [ns (:ns (meta v))]
          (when ns (symbol (name ns)))))))
 
+#?(:cljs
+   (defn- event-ns
+     "The namespace symbol carried by a `:begin-test-ns` report `m`.
+     cljs.test passes the ns symbol; normalise via `name`/`symbol` so it
+     matches `failing-ns`."
+     [m]
+     (when-let [ns (:ns m)]
+       (symbol (name ns)))))
+
+#?(:cljs
+   (defn- banner-ns
+     "The namespace to head the failure banner: the FAILING var's ns when a
+     var is in scope (nesting-correct, rf2-8n97n), else the innermost open
+     `test-ns` (the no-current-var fallback, rf2-g92dsm)."
+     []
+     (or (failing-ns) (current-test-ns))))
+
 ;; `defonce` for the same reload-safety reason as the JVM capture above:
 ;; pin cljs.test's ORIGINAL default reporters so a reload (e.g. shadow
 ;; hot-reload) never re-captures our own installed override and recurses.
@@ -255,12 +319,13 @@
 
 #?(:cljs
    (do
-     (defmethod cljs.test/report [:cljs.test/default :begin-test-ns] [_m]
+     (defmethod cljs.test/report [:cljs.test/default :begin-test-ns] [m]
        ;; Suppress the default "Testing <ns>"; defer to print-banner! on
-       ;; first failure/error (banner ns derived from the failing var,
-       ;; not this event).  Here we only track nesting depth + clear the
-       ;; printed-banner set on an outermost entry.
-       (on-begin-test-ns!))
+       ;; first failure/error (banner ns normally derived from the failing
+       ;; var, not this event).  Push this ns onto the open-ns stack (for
+       ;; nesting-depth tracking + the no-current-var banner fallback) and
+       ;; clear the printed-banner set on an outermost entry.
+       (on-begin-test-ns! (event-ns m)))
 
      (defmethod cljs.test/report [:cljs.test/default :end-test-ns] [_m]
        (on-end-test-ns!))
@@ -279,9 +344,9 @@
        ;; the library's own output (formatter handling, counters, etc. are
        ;; not forked here).  Both write through `*out*`, so the banner and
        ;; the delegated block stay in order.
-       (print-banner! (failing-ns))
+       (print-banner! (banner-ns))
        (cljs-default-fail m))
 
      (defmethod cljs.test/report [:cljs.test/default :error] [m]
-       (print-banner! (failing-ns))
+       (print-banner! (banner-ns))
        (cljs-default-error m))))

--- a/implementation/test-quiet/src/re_frame/test_quiet/runner.clj
+++ b/implementation/test-quiet/src/re_frame/test_quiet/runner.clj
@@ -188,16 +188,22 @@
      literal's closing `}`.  We keep buffering the remainder and decide at
      the line's newline — drop the line only if the remainder is a
      balanced set literal followed by nothing but whitespace
-     (`banner-line-remainder?`) AND this line was preceded by the held
-     leading blank.  cognitect's banner is `(format \"\\nRunning tests in
-     %s\" dirs)`, so the genuine banner is ALWAYS opened by a blank line;
-     requiring that held blank means an exact-shape user/fixture line such
-     as a bare `(println \"Running tests in #{:fixture}\")` — same text,
-     but no leading blank — is forwarded rather than silently overdropped
-     (rf2-m8dbb9).  Otherwise the prefix was shared by a
-     user/fixture diagnostic such as `Running tests in #{:fixture} MARKER`
-     and the whole buffered line is forwarded (the rf2-14nojy.2 overdrop
-     guard).
+     (`banner-line-remainder?`), this line was preceded by the held
+     leading blank, AND cognitect's one discovery banner has NOT already
+     been dropped (`banner-dropped?`).  cognitect's banner is
+     `(format \"\\nRunning tests in %s\" dirs)`, so the genuine banner is
+     ALWAYS opened by a blank line; requiring that held blank means an
+     exact-shape user/fixture line such as a bare
+     `(println \"Running tests in #{:fixture}\")` — same text, but no
+     leading blank — is forwarded rather than silently overdropped
+     (rf2-m8dbb9).  cognitect emits the banner exactly ONCE, before any
+     test runs, so the `banner-dropped?` latch means a LATER blank-led
+     banner-shaped line — a test that prints `(println)` then
+     `(println \"Running tests in #{:fixture}\")` — is forwarded rather
+     than swallowed as a phantom second banner (rf2-6nrk8x).  Otherwise the
+     prefix was shared by a user/fixture diagnostic such as
+     `Running tests in #{:fixture} MARKER` and the whole buffered line is
+     forwarded (the rf2-14nojy.2 overdrop guard).
 
   cognitect's banner opens with a BLANK LINE — the format string is
   `\"\\nRunning tests in %s\"`, so the leading `\\n` renders an empty line
@@ -248,6 +254,14 @@
         ;;   :passthrough      — this line diverged; forward chars verbatim.
         buf   (StringBuilder.)
         state (volatile! :watching)
+        ;; cognitect emits its discovery banner EXACTLY ONCE, via `println`
+        ;; before any test runs (`cognitect.test-runner/test`), so it is the
+        ;; first — and only — blank-led `Running tests in #{...}` line on the
+        ;; stream.  Once we have dropped it, every later banner-shaped line is
+        ;; genuine test/fixture stdout and must pass through: a test that
+        ;; prints a blank line then banner-shaped text was otherwise
+        ;; over-dropped, violating the pass-through contract (rf2-6nrk8x).
+        banner-dropped? (volatile! false)
         ;; `pending-blank?` holds back a single empty line that MIGHT be
         ;; the banner's leading newline (`\nRunning tests in #{...}`). It
         ;; is resolved at the next line's first character: dropped if that
@@ -322,11 +336,21 @@
                                 ;; was indistinguishable from the banner and
                                 ;; silently overdropped, contradicting the
                                 ;; pass-through stdout contract.
+                                ;; The leading-blank + balanced-set-literal
+                                ;; shape is NECESSARY but, on its own, not
+                                ;; SUFFICIENT: cognitect prints the banner only
+                                ;; once, so once we have dropped it, a later
+                                ;; blank-led banner-shaped line is genuine test
+                                ;; stdout and must be forwarded, not swallowed
+                                ;; as a second "banner" (rf2-6nrk8x). Gate the
+                                ;; drop on `banner-dropped?` and latch it here.
                                 :banner-candidate
                                 (let [remainder (subs (.toString buf) prefix-len)]
-                                  (if (and @pending-blank?
+                                  (if (and (not @banner-dropped?)
+                                           @pending-blank?
                                            (banner-line-remainder? remainder))
-                                    (drop-pending-blank!)
+                                    (do (vreset! banner-dropped? true)
+                                        (drop-pending-blank!))
                                     (do (flush-pending-blank!)
                                         (.write target (.toString buf))
                                         (.write target (int \newline)))))

--- a/implementation/test-quiet/src/re_frame/test_quiet/shadow_node.cljs
+++ b/implementation/test-quiet/src/re_frame/test_quiet/shadow_node.cljs
@@ -44,6 +44,7 @@
     [clojure.string :as str]
     [re-frame.test-quiet]
     [re-frame.test-quiet.shadow-node-cli :as cli]
+    [re-frame.test-quiet.warn-buffer :as wb]
     [shadow.test.env :as env]
     [shadow.test :as st]
     [cljs.test :as ct]))
@@ -54,12 +55,6 @@
 ;; Installed at ns-load time so it's in place before shadow's
 ;; `run-all-tests` walks the test ns set.
 
-(def ^:private warn-buffer-cap
-  "Bounded warning ring size.  Caps memory + replay volume on a red run
-  while keeping enough recent context to explain a failure (the newest
-  `warn-buffer-cap` warnings are retained; older ones are dropped)."
-  256)
-
 (defonce ^:private warn-buffer
   ;; A bounded ring of buffered warning arg-vectors. `defonce` so a
   ;; hot-reload of this `:dev/always` ns does not clobber warnings
@@ -68,15 +63,12 @@
 
 (defn- buffer-warning!
   "Append `args` (one `console.warn` call's arguments) to the bounded
-  ring, dropping the oldest entries past `warn-buffer-cap`."
+  ring via `warn-buffer/bound-conj`, which caps the ring to the newest
+  `warn-buffer/warn-buffer-cap` entries and MATERIALISES the trimmed
+  window into a fresh vector — so discarded warnings are not retained via
+  a shared `subvec` backing (rf2-6emzlh)."
   [args]
-  (swap! warn-buffer
-         (fn [buf]
-           (let [buf' (conj buf args)
-                 n    (count buf')]
-             (if (> n warn-buffer-cap)
-               (subvec buf' (- n warn-buffer-cap))
-               buf')))))
+  (swap! warn-buffer wb/bound-conj args))
 
 (defn- replay-buffered-warnings!
   "Replay the buffered warnings to stderr, prefixed so they are

--- a/implementation/test-quiet/src/re_frame/test_quiet/warn_buffer.cljs
+++ b/implementation/test-quiet/src/re_frame/test_quiet/warn_buffer.cljs
@@ -1,0 +1,38 @@
+(ns re-frame.test-quiet.warn-buffer
+  "Pure bounded-ring helper for the CLJS `:node-test` runner's buffered
+  `console.warn` diagnostic (see `re-frame.test-quiet.shadow-node`).
+
+  Lives apart from the runner so it can be unit-pinned: the runner ns
+  carries `{:dev/always true}` and expands `shadow.test.env/get-test-data`
+  (a macro that enumerates the build's test namespaces at compile time),
+  so a test ns requiring the runner directly forms a compile cycle — the
+  same reason `re-frame.test-quiet.shadow-node-cli` is factored out.  This
+  helper has no such dependency, so `re-frame.test-quiet-shadow-node-cljs-test`
+  can pin the memory bound directly.")
+
+(def warn-buffer-cap
+  "Bounded warning ring size.  Caps memory + replay volume on a red run
+  while keeping enough recent context to explain a failure (the newest
+  `warn-buffer-cap` warnings are retained; older ones are dropped)."
+  256)
+
+(defn bound-conj
+  "Append `x` to ring vector `buf`, retaining at most `cap` (default
+  `warn-buffer-cap`) NEWEST entries.
+
+  The trimmed window is MATERIALISED into a fresh vector rather than
+  returned as a `subvec`.  This is the whole point of the helper: a
+  ClojureScript `Subvec` shares — and thereby RETAINS — its entire
+  underlying vector via `.-v`, and `conj`-ing onto a `Subvec` grows that
+  underlying vector rather than the window.  So trimming with `subvec`
+  alone would keep every discarded warning (and its arg vectors) alive
+  until process exit, silently defeating the bound (rf2-6emzlh).  `into
+  []` copies only the window into a new `PersistentVector`, dropping the
+  discarded head so memory stays bounded to `cap` entries."
+  ([buf x] (bound-conj buf x warn-buffer-cap))
+  ([buf x cap]
+   (let [buf' (conj buf x)
+         n    (count buf')]
+     (if (> n cap)
+       (into [] (subvec buf' (- n cap)))
+       buf'))))

--- a/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
+++ b/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
@@ -456,6 +456,58 @@
                    " failure must not leak into it; got:\n" out)))))))
 
 ;; ----------------------------------------------------------------------
+;; test-ns-hook failure banner — rf2-g92dsm.
+;;
+;; The quiet reporter suppresses `:begin-test-ns` and derives the failure
+;; banner ns from `*testing-vars*` (the failing var).  But a namespace's
+;; `test-ns-hook` — a supported clojure.test path (`test-ns` calls it in
+;; place of `test-all-vars`) — runs OUTSIDE `test-var`, so a bare failing
+;; assertion inside it reports with an EMPTY `*testing-vars*`: the
+;; var-derived ns is nil and the failure printed with NO banner, violating
+;; the failure-banner contract.  The fix maintains a begin/end ns stack and
+;; falls back to the innermost open ns when no failing var is in scope.
+;; This pin drives the REAL `-main` against a fixture whose `test-ns-hook`
+;; fails, and asserts the ns banner is present above the FAIL block.
+
+(deftest test-ns-hook-failure-gets-ns-banner
+  (testing "a failing test-ns-hook (no test-var in scope) still prints its ns banner (rf2-g92dsm)"
+    (with-fixture-dir
+      (fn [dir]
+        ;; `test-ns-hook` TAKES PRECEDENCE over test-all-vars, so the bare
+        ;; `(is ...)` inside it is what runs — with an empty *testing-vars*.
+        ;; The `deftest` is present only so cognitect's `contains-tests?`
+        ;; discovery filter includes this ns (it requires >=1 :test var); it
+        ;; does NOT run, because the hook replaces test-all-vars.  The ns
+        ;; name ends in `-test` so cognitect's default ns-filter selects it.
+        (write-raw-fixture! dir "ns_hook_fail_test"
+          (str "(ns probe.ns-hook-fail-test\n"
+               "  (:require [clojure.test :refer [deftest is]]\n"
+               "            [re-frame.test-quiet]))\n"
+               ;; satisfies cognitect's contains-tests? (>=1 :test var);
+               ;; never runs — test-ns-hook replaces test-all-vars.
+               "(deftest a-discovery-anchor (is (= 1 1)))\n"
+               "(defn test-ns-hook []\n"
+               "  (is (= :hook-expected :hook-actual)))"))
+        (let [{:keys [exit out err]} (run-runner dir)]
+          (is (= 1 exit)
+              (str "the failing test-ns-hook must exit 1; got " exit
+                   "\n--- stdout ---\n" out "\n--- stderr ---\n" err))
+          ;; The CORE of rf2-g92dsm: pre-fix `failing-ns` was nil (no var in
+          ;; scope) so print-banner! no-op'd and the FAIL had no heading. The
+          ;; ns-stack fallback must now supply the banner.
+          (is (str/includes? out "Testing probe.ns-hook-fail-test")
+              (str "a failing test-ns-hook must still carry its ns banner —"
+                   " the var-derived ns is nil, so the ns-stack fallback must"
+                   " supply it (rf2-g92dsm); got:\n" out))
+          (is (str/includes? out "FAIL in")
+              (str "the FAIL block must reach stdout; got:\n" out))
+          (is (and (str/includes? out "expected:")
+                   (str/includes? out "actual:"))
+              (str "expected:/actual: lines must reach stdout; got:\n" out))
+          (is (str/includes? out "1 failures, 0 errors.")
+              (str "the failing summary must reach stdout; got:\n" out)))))))
+
+;; ----------------------------------------------------------------------
 ;; Diagnostics-survive contract — rf2-lbo79.2.
 ;;
 ;; The wrapper used to bind `*out*` to a blanket SINK for the whole

--- a/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
+++ b/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
@@ -680,6 +680,59 @@
                    " dropped; got " hits " occurrences:\n" out)))))))
 
 ;; ----------------------------------------------------------------------
+;; Blank-led banner-shape OVER-DROP after the real banner — rf2-6nrk8x.
+;;
+;; The rf2-m8dbb9 fix drops a banner-shaped line only when it is preceded
+;; by a held leading blank — but it applied that rule to EVERY blank-led
+;; `Running tests in #{...}` line, not just cognitect's one discovery
+;; banner.  cognitect prints its banner exactly ONCE (via `println`, before
+;; any test runs), so a test that ITSELF prints a blank line then
+;; banner-shaped text — `(println)` then `(println "Running tests in
+;; #{:fixture}")` — matched the same shape and was silently swallowed as a
+;; phantom SECOND banner, losing valid diagnostic stdout and violating the
+;; pass-through contract.  The fix latches `banner-dropped?` when the real
+;; banner is dropped and forwards every later blank-led banner-shaped line.
+;; This pin drives the REAL `-main`: the fixture's blank-led banner-shape
+;; line must survive while cognitect's genuine banner is still dropped.
+
+(deftest blank-led-banner-shape-user-line-survives
+  (testing "a test's own blank-line-then-banner-shape stdout survives after the real banner is dropped (rf2-6nrk8x)"
+    (with-fixture-dir
+      (fn [dir]
+        ;; The fixture prints a blank line IMMEDIATELY followed by an
+        ;; exact-shape banner line carrying a keyword-set body (distinct from
+        ;; cognitect's own `#{"<dir>"}` string-set banner). Pre-fix, the held
+        ;; leading blank + balanced-set shape made the filter overdrop it as a
+        ;; second banner; post-fix the `banner-dropped?` latch forwards it.
+        (write-fixture! dir "blank_led_banner_fixture_test" "blank-led-banner-fixture-test"
+                        (str "(deftest a-blank-then-banner-test"
+                             " (println)"
+                             " (println \"Running tests in #{:user-diagnostic}\")"
+                             " (is (= 1 1)))"))
+        (let [{:keys [exit out err]} (run-runner dir)]
+          (is (zero? exit)
+              (str "the fixture is green; must exit 0; got " exit
+                   "\n--- stdout ---\n" out "\n--- stderr ---\n" err))
+          ;; The CORE of rf2-6nrk8x: the test's OWN blank-led banner-shape
+          ;; line is genuine stdout and must reach the real stdout.
+          (is (str/includes? out "Running tests in #{:user-diagnostic}")
+              (str "a test's blank-line-then-banner-shape stdout must survive"
+                   " once cognitect's one banner has already been dropped"
+                   " (rf2-6nrk8x over-drop); got:\n" out))
+          ;; cognitect's genuine banner renders the DIR set as a string set —
+          ;; `#{\"<dir>\"}` — so `Running tests in #{\"` uniquely identifies
+          ;; it. Its absence proves the real banner was STILL dropped (the
+          ;; latch narrowed the drop to exactly one banner, it did not stop
+          ;; dropping the real one).
+          (is (not (str/includes? out "Running tests in #{\""))
+              (str "cognitect's genuine discovery banner (`Running tests in"
+                   " #{\"<dir>\"}`) must STILL be dropped — the latch narrows"
+                   " the drop to the one real banner, it must not forward it;"
+                   " got:\n" out))
+          (is (str/includes? out "0 failures, 0 errors.")
+              (str "the green summary must still print; got:\n" out)))))))
+
+;; ----------------------------------------------------------------------
 ;; Unterminated-partial survival across System/exit — rf2-pjlx6.2.
 ;;
 ;; cognitect exits straight from the computed fail/error counts, so the

--- a/implementation/test-quiet/test/re_frame/test_quiet_shadow_node_cljs_test.cljs
+++ b/implementation/test-quiet/test/re_frame/test_quiet_shadow_node_cljs_test.cljs
@@ -44,7 +44,8 @@
   ;; anyway because shadow-node is the :node-test build's :main.
   (:require [cljs.test :refer-macros [deftest is testing] :refer [successful?]]
             [clojure.string :as str]
-            [re-frame.test-quiet.shadow-node-cli :as cli]))
+            [re-frame.test-quiet.shadow-node-cli :as cli]
+            [re-frame.test-quiet.warn-buffer :as wb]))
 
 ;; ----------------------------------------------------------------------
 ;; --test= selection / flag parsing.
@@ -89,6 +90,55 @@
         "multiple unknown flags accumulate in input order")
     (is (not (contains? (cli/parse-args ["--test=ok.ns"]) :unknown-args))
         "a clean arg set carries no :unknown-args key at all")))
+
+;; ----------------------------------------------------------------------
+;; Warning-ring memory bound — rf2-6emzlh.
+;;
+;; The buffered-`console.warn` ring claims to cap memory to the newest
+;; `warn-buffer-cap` warnings.  The pre-fix trim used `subvec`, which in
+;; ClojureScript shares — and thereby RETAINS — its entire underlying
+;; vector via `.-v` (and `conj`-ing onto a `Subvec` grows that underlying
+;; vector), so every discarded warning stayed alive until process exit and
+;; the "bound" leaked without limit.  `warn-buffer/bound-conj` now
+;; materialises the trimmed window into a fresh `PersistentVector`.  This
+;; is an in-memory STRUCTURAL property (the backing must not be a growing
+;; `Subvec`), so it can only be pinned as a pure unit test — not across the
+;; process boundary the other shadow-node pins use.
+
+(deftest warn-buffer-is-bounded-and-materialised
+  (testing "bound-conj retains only the newest cap entries as a fresh vector (rf2-6emzlh)"
+    ;; Fill FAR past a tiny cap: the ring must report exactly `cap` entries,
+    ;; hold the NEWEST ones, and — the core pin — its backing must NOT be a
+    ;; Subvec (which would retain the full discarded history via its shared
+    ;; underlying vector).
+    (let [cap 4
+          buf (reduce (fn [b i] (wb/bound-conj b [i] cap)) [] (range 1000))]
+      (is (= cap (count buf))
+          "the ring is bounded to cap entries no matter how many are appended")
+      (is (= [[996] [997] [998] [999]] buf)
+          "the ring retains the NEWEST cap entries, dropping the oldest")
+      (is (not (instance? cljs.core/Subvec buf))
+          (str "the trimmed ring must NOT be a Subvec — a Subvec shares and"
+               " retains its full underlying vector, so the bound would leak"
+               " every discarded warning until process exit (rf2-6emzlh)"))
+      (is (instance? cljs.core/PersistentVector buf)
+          "the trimmed ring is a materialised PersistentVector, not a view")))
+  (testing "below the cap the ring is a plain growing vector (no trim, no Subvec)"
+    (let [buf (reduce (fn [b i] (wb/bound-conj b [i] 10)) [] (range 3))]
+      (is (= [[0] [1] [2]] buf))
+      (is (not (instance? cljs.core/Subvec buf))
+          "an untrimmed ring is never a Subvec")))
+  (testing "under the REAL default cap the ring never exceeds warn-buffer-cap"
+    ;; Drive several multiples of the real cap through the real default arity
+    ;; so a regression that dropped the materialisation (or the cap) is caught
+    ;; against the production constant, not just a synthetic tiny cap.
+    (let [buf (reduce (fn [b i] (wb/bound-conj b [i]))
+                      []
+                      (range (* 4 wb/warn-buffer-cap)))]
+      (is (= wb/warn-buffer-cap (count buf))
+          "the ring stays capped at the production warn-buffer-cap")
+      (is (not (instance? cljs.core/Subvec buf))
+          "the production-cap ring must not degrade into a retaining Subvec"))))
 
 ;; ----------------------------------------------------------------------
 ;; Var filtering — simple symbols match by ns, qualified by fully-qualified


### PR DESCRIPTION
Three small correctness fixes on the **test-quiet** shared test-reporter surface (the quiet runner + reporter every artefact's `:test` alias / `:node-test` build routes through). Commits ordered smallest-cleanup → biggest-correctness-fix; each bead claimed immediately before its commit so history mirrors tracker state.

## Fixes

### rf2-6emzlh (P3) — CLJS warn ring leaked via `subvec`
The buffered-`console.warn` ring claimed to cap memory to the newest `warn-buffer-cap` (256) warnings but trimmed with `subvec`. In ClojureScript a `Subvec` shares — and thereby retains — its entire underlying vector via `.-v`, and `conj`-ing onto a `Subvec` grows that underlying vector rather than the window, so every discarded warning stayed alive until process exit: the "bound" leaked without limit. Extracted the pure ring logic into a new `re-frame.test-quiet.warn-buffer/bound-conj` (factored out for the same compile-cycle reason as `shadow-node-cli`), which materialises the trimmed window into a fresh `PersistentVector` via `into []`.
- **Adversarial pin:** `warn-buffer-is-bounded-and-materialised` asserts the trimmed ring is NOT a `Subvec` (the structural leak) and stays capped at the production `warn-buffer-cap` under 4×-cap load.

### rf2-6nrk8x (P3) — JVM banner filter over-dropped blank-led user stdout
The banner-filtering writer dropped EVERY blank-led `Running tests in #{...}` line, not just cognitect's single discovery banner. cognitect prints its banner exactly once (via `println`, before any test runs), so a test that itself prints a blank line then banner-shaped text — `(println)` then `(println "Running tests in #{:fixture}")` — matched the same shape and was swallowed as a phantom second banner, losing valid diagnostic stdout and violating the pass-through contract. Latched `banner-dropped?` when the real banner is dropped and forward every later blank-led banner-shaped line.
- **Adversarial pin:** `blank-led-banner-shape-user-line-survives` drives the real `-main` and asserts the fixture's blank-led banner-shape line survives while cognitect's genuine `#{"<dir>"}` banner is STILL dropped.

### rf2-g92dsm (P4) — reporter omitted ns banner for `test-ns-hook` failures
The reporter derived the failure banner ns from the failing var (`*testing-vars*`). But a namespace's `test-ns-hook` — a supported clojure.test path (`test-ns` calls it in place of `test-all-vars`) — runs OUTSIDE `test-var`, so a bare failing assertion inside it reports with an empty `*testing-vars*`: the var-derived ns was nil, `print-banner!` no-op'd, and the failure printed with NO namespace banner, violating the failure-banner contract. Maintained a begin/end-balanced `ns-stack` (replacing the depth counter) and fall back to the innermost open ns when no failing var is in scope. The failing var still wins whenever one exists, so nested-run banner correctness (rf2-8n97n) is unchanged. Shared `.cljc`, so both the JVM and CLJS reporters get the fix; the `test-ns-hook` path itself is JVM-scoped (cljs.test has no `test-ns-hook`), matching the existing nested-run test scope.
- **Adversarial pin:** `test-ns-hook-failure-gets-ns-banner` drives the real `-main` against a fixture whose `test-ns-hook` fails and asserts the `Testing probe.ns-hook-fail-test` banner heads the FAIL block.

## Quality gates
All run from the worktree; all PASS.
- `cd implementation/test-quiet && clojure -M:test` (JVM runner + reporter contract) — **25 tests, 92 assertions, 0 failures, 0 errors**
- `cd implementation && npm run test:cljs` (CLJS node-test via quiet shadow-node) — **8136 tests, 37287 assertions, 0 failures, 0 errors**
- `sh scripts/test-fast-pr.sh` (fast-PR spine: drift gates + core JVM + CLJS + per-ns isolation) — **PASS fast PR spine**
- `sh scripts/test-jvm-implementation.sh` (ALL JVM implementation artefacts through the modified quiet runner — the transitive surface, since runner.clj/reporter.cljc are the `:main-opts`/reporter of every `:test` alias) — **PASS implementation JVM artefacts**

## Stance
Pre-alpha, no back-compat shims; optimised for ELEGANCE + CLARITY + CORRECTNESS + GOOD PRACTICE, avoiding over-engineering. Each fix isolates the pure decision so it can be unit/contract-pinned, and adds a negative/adversarial test that fails on the pre-fix behaviour.