### PR TITLE
fix(websocket): socket-id guard, in-flight/queued lifecycle (rf2-3cgvt7 +2)

### DIFF
--- a/examples/patterns/websocket/README.md
+++ b/examples/patterns/websocket/README.md
@@ -93,9 +93,12 @@ Everything below builds on those three. The rest is ordinary machine grammar —
   re-reads the URL and token from `:data` — so a `:ws/refresh-token` arriving
   *between* reconnects flows into the next socket with no extra wiring.
 
-- **An offline queue and a surviving subscription set.** A `:ws/send` while
-  disconnected enqueues into `:data :queue`; the `:connected` entry's `:always`
-  cascade flushes it. A `:ws/subscribe` records its topic in `:data :subscriptions`
+- **An offline queue and a surviving subscription set.** A `:ws/send` *or*
+  `:ws/request` issued while off-connection buffers its whole event into
+  `:data :queue`; the `:connected` entry's `:always` cascade re-dispatches each
+  one, so a queued send reaches the wire and a queued request rejoins the
+  register-and-correlate path — it is answered after connect, not silently
+  dropped. A `:ws/subscribe` records its topic in `:data :subscriptions`
   (a set), and every `:connected` entry re-issues the subscribe messages — so
   subscriptions ride straight through a reconnect.
 

--- a/examples/patterns/websocket/README.md
+++ b/examples/patterns/websocket/README.md
@@ -41,8 +41,11 @@ Everything below builds on those three. The rest is ordinary machine grammar —
 - **Stale-message rejection via the connection epoch.** The live socket-actor id
   — read from the runtime-maintained `:rf/spawned` slot in `:data` — is the
   epoch; the `:current-socket?` [guard](../../../docs/machines/glossary.md#guard)
-  rejects a `:ws/received` (or a `:ws/request-timeout`) from a socket that has
-  since been replaced. [Pattern-StaleDetection](../../../spec/Pattern-StaleDetection.md),
+  rejects any socket-sourced event from a connection that has since been
+  replaced — the lifecycle transitions (`:ws/opened`, `:ws/auth-ok`,
+  `:ws/auth-failed`, `:ws/closed`) as much as `:ws/received` and the
+  request-timeout — so a straggler can neither advance nor tear down the new
+  connection. [Pattern-StaleDetection](../../../spec/Pattern-StaleDetection.md),
   composed against a value already in `:data`.
 
 - **`:after` exponential backoff** on `:reconnecting` — a delay computed at state

--- a/examples/patterns/websocket/README.md
+++ b/examples/patterns/websocket/README.md
@@ -79,6 +79,12 @@ Everything below builds on those three. The rest is ordinary machine grammar —
   re-frame2 ships no managed WebSocket, so per-message correlation over the open
   socket is the app's to own.)
 
+- **In-flight requests fail on a socket drop.** A request already on the wire
+  when the socket dies can't be answered on this connection, so `:on-socket-lost`
+  clears the `:in-flight` map and fires each waiting `:reply` event with an
+  explicit `{:ok false :error :ws/connection-lost}` body — at-most-once
+  semantics, no silent leak, and no double-execution from a blind replay.
+
 - **Reconnect cascade with token refresh threaded through.** Leaving `:active`
   destroys the actor (the declarative `:spawn` desugars to a
   `:rf.machine/destroy` on exit), and the runtime clears its id from the

--- a/examples/patterns/websocket/connection.cljs
+++ b/examples/patterns/websocket/connection.cljs
@@ -39,6 +39,11 @@
         clock: every inbound event names the socket it came from, and the
         `:current-socket?` guard drops anything from a socket we've since
         replaced — the slow message that lands just after a reconnect.
+        This covers the whole socket-sourced surface — the lifecycle
+        transitions (`:ws/opened`, `:ws/auth-ok`, `:ws/auth-failed`,
+        `:ws/closed`) as much as `:ws/received` and the request timeout — so
+        a straggler from a dead socket can neither advance nor tear down the
+        new connection.
 
    The thing that actually owns the JS WebSocket is the `:websocket/socket`
    actor, over in `websocket.messages`. We spawn it on the `:active`
@@ -294,7 +299,8 @@
        ;; Transitions every leaf inherits. A leaf can override any of these
        ;; (deepest state wins); anything it doesn't handle falls through to
        ;; here. See docs/machines/glossary.md#transition.
-       :on    {:ws/closed   {:target :reconnecting
+       :on    {:ws/closed   {:guard  :current-socket?
+                             :target :reconnecting
                              :action :bump-retry}
                :ws/fatal    {:target :failed
                              :action :record-error}
@@ -313,18 +319,28 @@
        :states
        {:connecting
         {:tags #{:websocket/active :websocket/connecting}
-         :on   {:ws/opened {:target :authenticating}}}
+         ;; Guarded like every socket-sourced lifecycle event: an `:ws/opened`
+         ;; from a socket we've already replaced (a slow open landing after a
+         ;; disconnect+reconnect) must not advance THIS connection.
+         :on   {:ws/opened {:guard  :current-socket?
+                            :target :authenticating}}}
 
         :authenticating
         {:tags  #{:websocket/active :websocket/authenticating}
          :entry :send-auth
-         :on    {:ws/auth-ok     {:target :connected}
+         ;; Both auth outcomes are epoch-guarded: a straggler `:ws/auth-ok`
+         ;; from a replaced socket must not prematurely mark us `:connected`,
+         ;; and a straggler `:ws/auth-failed` must not tear a fresh
+         ;; authentication attempt down to `:failed`.
+         :on    {:ws/auth-ok     {:guard  :current-socket?
+                                  :target :connected}
                  ;; Note the vector: `[:failed]`, not bare `:failed`.
                  ;; `:failed` lives at the top level, not under `:active`,
                  ;; and a bare keyword would be read as the sibling
                  ;; `[:active :failed]` — which doesn't exist. The absolute
                  ;; vector says "from the root, please".
-                 :ws/auth-failed {:target [:failed]
+                 :ws/auth-failed {:guard  :current-socket?
+                                  :target [:failed]
                                   :action :record-error}}}
 
         :connected

--- a/examples/patterns/websocket/connection.cljs
+++ b/examples/patterns/websocket/connection.cljs
@@ -229,19 +229,28 @@
                      (:subscriptions data))})
 
       :flush-queue
-      ;; The `:always` step on `:connected`: if anything piled up in the
-      ;; queue while we were offline, drain it onto the wire now and clear
-      ;; it. Everything the user typed during the outage finally goes out.
+      ;; The `:always` step on `:connected`: replay everything buffered while
+      ;; we were off-connection. Each queued item is the ORIGINAL inbound
+      ;; event, so re-dispatch it INTO the connection machine — which is now
+      ;; `:connected`, so a `:ws/send` takes `:send-now` and a `:ws/request`
+      ;; takes `:register-request` (in-flight slot + correlation + timeout),
+      ;; exactly as if it had been issued while connected. Clearing `:queue`
+      ;; first stops the replay from re-enqueuing.
       (fn action-flush-queue [{data :data}]
         (let [q (:queue data)]
           {:data (assoc data :queue [])
-           :fx   (mapv (fn [msg]
-                         [:dispatch [(socket-id data) [:send msg]]])
-                       q)}))
+           :fx   (mapv (fn [event] [:dispatch [:ws/connection event]]) q)}))
 
       :enqueue-message
-      (fn action-enqueue-message [{data :data [_ msg] :event}]
-        {:data (update data :queue conj msg)})
+      ;; Off-connection there's no socket to send on, so buffer the WHOLE
+      ;; inbound event (`[:ws/send …]` or `[:ws/request …]`), not just its
+      ;; body. `:flush-queue` (above) re-dispatches each verbatim on the next
+      ;; `:connected` entry, so a queued request rejoins `:register-request`
+      ;; and gets correlated. (Buffering a bare body instead put a request's
+      ;; whole envelope onto the wire as if it were the payload —
+      ;; uncorrelated, never answered.)
+      (fn action-enqueue-message [{data :data event :event}]
+        {:data (update data :queue conj event)})
 
       :send-now
       ;; While `:connected`, sending is easy: straight to the wire, no

--- a/examples/patterns/websocket/connection.cljs
+++ b/examples/patterns/websocket/connection.cljs
@@ -168,9 +168,34 @@
       (fn action-refresh-token [{data :data [_ token] :event}]
         {:data (assoc data :auth-token token)})
 
-      :bump-retry
-      (fn action-bump-retry [{data :data}]
-        {:data (update data :retries inc)})
+      :on-socket-lost
+      ;; The live socket just dropped (a `:ws/closed` that passed
+      ;; `:current-socket?`). Two things happen as we head to `:reconnecting`:
+      ;;   1. Bump the retry counter — it drives the `:after` backoff and the
+      ;;      `:max-retries-exceeded?` guard.
+      ;;   2. FAIL every in-flight request. Each was already put on the wire
+      ;;      that just died, so its reply can never arrive on this
+      ;;      connection; left in `:in-flight` it would leak forever — its
+      ;;      timeout is stamped with the now-dead socket id, so the
+      ;;      `:current-socket?` guard drops that timeout after we reconnect
+      ;;      and the slot never clears. Loss semantics are FAIL, not replay:
+      ;;      the server may already have processed the request before the
+      ;;      drop, so a blind re-send risks double execution — failing is the
+      ;;      safe, explicit default. Each waiting `:reply-event` is fired
+      ;;      with a `{:ok false :error :ws/connection-lost}` body so the
+      ;;      caller learns the outcome instead of hanging forever.
+      (fn action-on-socket-lost [{data :data}]
+        {:data (-> data
+                   (update :retries inc)
+                   (assoc :in-flight {}))
+         :fx   (into []
+                     (keep (fn [[rid {:keys [reply-event]}]]
+                             (when reply-event
+                               [:dispatch (conj reply-event
+                                                {:request-id rid
+                                                 :ok         false
+                                                 :error      :ws/connection-lost})])))
+                     (:in-flight data))})
 
       :reset-retries
       (fn action-reset-retries [{data :data}]
@@ -301,7 +326,7 @@
        ;; here. See docs/machines/glossary.md#transition.
        :on    {:ws/closed   {:guard  :current-socket?
                              :target :reconnecting
-                             :action :bump-retry}
+                             :action :on-socket-lost}
                :ws/fatal    {:target :failed
                              :action :record-error}
                :ws/send     {:action :enqueue-message}

--- a/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
@@ -322,8 +322,12 @@
         (let [s (snapshot (:rf.db/runtime (rf/frame-state-value f)))]
           (is (= :disconnected (:state s)))
           (is (= 2 (count (get-in s [:data :queue]))))
-          (is (= [{:type :note :body "A"}
-                  {:type :note :body "B"}]
+          ;; The queue now buffers the WHOLE inbound event (so a queued
+          ;; :ws/request can rejoin :register-request on flush — see
+          ;; websocket-queued-request-*), not the bare body — so each entry
+          ;; is a `[:ws/send …]` vector.
+          (is (= [[:ws/send {:type :note :body "A"}]
+                  [:ws/send {:type :note :body "B"}]]
                  (get-in s [:data :queue]))))
         ;; Connect — sync-mode mock means the cascade runs to
         ;; :connected inside this dispatch, and the :always
@@ -560,7 +564,7 @@
             (is (= :reconnecting (:state s))
                 "live :ws/closed passed the guard and dropped to :reconnecting")
             (is (= (inc retries0) (get-in s [:data :retries]))
-                "the retry counter bumped on the real drop")))))))
+                ":on-socket-lost bumped the retry counter on the real drop")))))))
 
 (defn- stale-auth-events-guarded-test []
   ;; rf2-3cgvt7 — sync-mode delivery races through :authenticating inside a
@@ -635,6 +639,56 @@
               (is (= :ws/connection-lost (:error reply)))
               (is (= rid (:request-id reply))
                   "the failure names the dropped request"))))))))
+
+(defn- queued-request-registers-and-replies-on-connect-test []
+  ;; rf2-ryt25d — a :ws/request issued OFF-connection must be buffered as its
+  ;; event and, on connect, rejoin :register-request so it registers, sends
+  ;; the body (not the envelope) and correlates its reply. Covers the offline
+  ;; (disconnected) window end-to-end, then the reconnect window's enqueue.
+  (with-sync-mock!
+    (fn []
+      (with-new-frame [f (new-frame)]
+        ;; --- offline window: request while :disconnected --------------------
+        (let [rid (random-uuid)]
+          (rf/dispatch-sync [:ws.app/request "queued-hello"]
+                            {:frame f :rf.cofx {:ws.app/request-id rid}})
+          (let [s (snapshot (:rf.db/runtime (rf/frame-state-value f)))]
+            (is (= :disconnected (:state s)))
+            (is (= 1 (count (get-in s [:data :queue]))))
+            (is (= :ws/request (ffirst (get-in s [:data :queue])))
+                "buffered as the WHOLE :ws/request event, not a bare body"))
+          ;; Connect — the :connected entry flushes the queued request through
+          ;; :register-request; the mock echoes and the reply correlates, all
+          ;; inside this sync dispatch.
+          (rf/dispatch-sync [:ws/connection
+                             [:ws/connect {:url "ws://mock" :auth-token "demo"}]]
+                            {:frame f})
+          (let [s  (snapshot (:rf.db/runtime (rf/frame-state-value f)))
+                db (rf/app-db-value f)]
+            (is (true? (machine-has-tag? f :websocket/connected)))
+            (is (= [] (get-in s [:data :queue])) "queue drained on connect")
+            (is (= {} (get-in s [:data :in-flight]))
+                "queued request registered AND its reply cleared the slot")
+            (let [reply (get-in db [:messages :last-reply])]
+              (is (some? reply) "the queued request got a correlated reply")
+              (is (= rid (:request-id reply))
+                  "correlation id round-tripped from the queued envelope")
+              (is (true? (:ok reply)))
+              (is (= {:type :request :body "queued-hello"} (:echo reply))
+                  "the request BODY (not the queue envelope) went on the wire"))))
+        ;; --- reconnect window: request while :reconnecting -----------------
+        ;; Drop to :reconnecting, then a request there is buffered the same way
+        ;; (the reconnect window uses the identical :enqueue-message path).
+        (messages/simulate-disconnect! (rf/capture-frame f))
+        (is (true? (machine-has-tag? f :websocket/reconnecting)))
+        (let [rid2 (random-uuid)]
+          (rf/dispatch-sync [:ws.app/request "reconnect-hello"]
+                            {:frame f :rf.cofx {:ws.app/request-id rid2}})
+          (let [s (snapshot (:rf.db/runtime (rf/frame-state-value f)))]
+            (is (= 1 (count (get-in s [:data :queue])))
+                "a request issued while :reconnecting is buffered")
+            (is (= :ws/request (ffirst (get-in s [:data :queue])))
+                "buffered as the whole :ws/request event for a later flush")))))))
 
 ;; ============================================================================
 ;; REQUEST/REPLY + SERVER PUSH + SUBSCRIPTIONS
@@ -854,6 +908,11 @@
   (testing "rf2-r1rkvb — a socket drop fails + clears every in-flight request
             (no leak); the waiting reply-event gets a connection-lost body"
     (drop-fails-in-flight-request-test)))
+
+(deftest websocket-queued-request-registers-and-replies-on-connect
+  (testing "rf2-ryt25d — a :ws/request buffered off-connection registers and
+            correlates its reply on connect; the reconnect window buffers alike"
+    (queued-request-registers-and-replies-on-connect-test)))
 
 (deftest websocket-request-reply-correlation
   (testing "request-reply correlation — :in-flight slot fills then clears on reply"

--- a/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
@@ -516,6 +516,86 @@
           (is (false? (machine-has-tag? f :websocket/failed)))
           (is (nil? (socket-id-of s))))))))
 
+;; ----------------------------------------------------------------------------
+;; ADVERSARIAL / NEGATIVE — WebSocket lifecycle guards + in-flight/queued
+;; correlation (rf2-3cgvt7 / rf2-r1rkvb / rf2-ryt25d)
+;; ----------------------------------------------------------------------------
+
+(defn- stale-lifecycle-events-dropped-test []
+  ;; rf2-3cgvt7 — the `:current-socket?` epoch guard now covers the LIFECYCLE
+  ;; transitions too (:ws/opened / :ws/auth-ok / :ws/auth-failed / :ws/closed),
+  ;; not just :ws/received. The most dangerous straggler is a stale :ws/closed:
+  ;; unguarded, a late close from a socket we've already replaced would tear
+  ;; the LIVE connection down. Prove it's dropped, and that a genuine close
+  ;; still passes.
+  (with-sync-mock!
+    (fn []
+      (with-new-frame [f (new-frame)]
+        (rf/dispatch-sync [:ws/connection
+                           [:ws/connect {:url "ws://mock" :auth-token "demo"}]]
+                          {:frame f})
+        (is (true? (machine-has-tag? f :websocket/connected)))
+        (let [s0       (snapshot (:rf.db/runtime (rf/frame-state-value f)))
+              live-id  (socket-id-of s0)
+              stale-id (str "stale-" (random-uuid))
+              retries0 (get-in s0 [:data :retries])]
+          (is (not= stale-id live-id))
+          ;; A stale :ws/closed must NOT drop us to :reconnecting.
+          (rf/dispatch-sync [:ws/connection
+                             [:ws/closed {:source-socket-id stale-id :code 1006}]]
+                            {:frame f})
+          (let [s (snapshot (:rf.db/runtime (rf/frame-state-value f)))]
+            (is (true? (machine-has-tag? f :websocket/connected))
+                "stale :ws/closed dropped by :current-socket? — still connected")
+            (is (= live-id (socket-id-of s))
+                "the live socket survived the stale close")
+            (is (= retries0 (get-in s [:data :retries]))
+                "no retry bump from a stale close"))
+          ;; The LIVE :ws/closed (correct source) still passes the guard.
+          (rf/dispatch-sync [:ws/connection
+                             [:ws/closed {:source-socket-id live-id :code 1006}]]
+                            {:frame f})
+          (let [s (snapshot (:rf.db/runtime (rf/frame-state-value f)))]
+            (is (= :reconnecting (:state s))
+                "live :ws/closed passed the guard and dropped to :reconnecting")
+            (is (= (inc retries0) (get-in s [:data :retries]))
+                "the retry counter bumped on the real drop")))))))
+
+(defn- stale-auth-events-guarded-test []
+  ;; rf2-3cgvt7 — sync-mode delivery races through :authenticating inside a
+  ;; single dispatch, so the auth-outcome guards can't be pinned by parking
+  ;; the machine there (and an async park would strand a real `setTimeout` —
+  ;; the documented flake this file avoids). Verify them deterministically:
+  ;;   (1) the guard fn — the SAME `:current-socket?` the close test exercises
+  ;;       end-to-end — rejects a stale-sourced auth event and admits a live
+  ;;       one, and
+  ;;   (2) the auth (and opened/closed) transitions actually CARRY that guard.
+  (let [guard (get-in ws.connection/connection-machine [:guards :current-socket?])
+        live  "socket-live"
+        data  {:rf/spawned {[:active] live}}]
+    (is (true?  (boolean (guard {:data  data
+                                 :event [:ws/auth-ok {:source-socket-id live}]})))
+        "live-sourced :ws/auth-ok is admitted")
+    (is (false? (boolean (guard {:data  data
+                                 :event [:ws/auth-failed {:source-socket-id "socket-old"}]})))
+        "stale-sourced :ws/auth-failed is rejected")
+    (is (false? (boolean (guard {:data  {}    ;; socket torn down: no :rf/spawned
+                                 :event [:ws/auth-ok {:source-socket-id live}]})))
+        "with no live socket, even a matching id is rejected (nil epoch)"))
+  (let [m ws.connection/connection-machine]
+    (is (= :current-socket?
+           (get-in m [:states :active :states :connecting :on :ws/opened :guard]))
+        ":ws/opened is epoch-guarded")
+    (is (= :current-socket?
+           (get-in m [:states :active :states :authenticating :on :ws/auth-ok :guard]))
+        ":ws/auth-ok is epoch-guarded")
+    (is (= :current-socket?
+           (get-in m [:states :active :states :authenticating :on :ws/auth-failed :guard]))
+        ":ws/auth-failed is epoch-guarded")
+    (is (= :current-socket?
+           (get-in m [:states :active :on :ws/closed :guard]))
+        ":ws/closed is epoch-guarded")))
+
 ;; ============================================================================
 ;; REQUEST/REPLY + SERVER PUSH + SUBSCRIPTIONS
 ;; ============================================================================
@@ -718,6 +798,17 @@
 (deftest websocket-disconnect-cleanly
   (testing "clean :ws/disconnect — :connected → :disconnected, socket-id cleared"
     (disconnect-cleanly-test)))
+
+(deftest websocket-stale-lifecycle-events-dropped
+  (testing "rf2-3cgvt7 — a stale :ws/closed from a replaced socket is dropped
+            by :current-socket? (live connection survives); the real close passes"
+    (stale-lifecycle-events-dropped-test)))
+
+(deftest websocket-stale-auth-events-guarded
+  (testing "rf2-3cgvt7 — the :current-socket? guard rejects stale-sourced auth
+            events, and :ws/opened / :ws/auth-ok / :ws/auth-failed / :ws/closed
+            all carry it"
+    (stale-auth-events-guarded-test)))
 
 (deftest websocket-request-reply-correlation
   (testing "request-reply correlation — :in-flight slot fills then clears on reply"

--- a/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
@@ -364,7 +364,8 @@
             ;; cleared its id from the :rf/spawned slot for us — no :exit
             ;; null-out needed. So the connection clock reads nil.
             (is (nil?   (socket-id-of s)))
-            ;; :bump-retry ran.
+            ;; :on-socket-lost bumped the retry counter (and cleared the
+            ;; then-empty in-flight map).
             (is (= 1 (get-in s [:data :retries]))))
           ;; Fire the :after timer to re-enter :active. The :after key
           ;; is the fn-form delay; the runtime stamps the matching key
@@ -596,6 +597,45 @@
            (get-in m [:states :active :on :ws/closed :guard]))
         ":ws/closed is epoch-guarded")))
 
+(defn- drop-fails-in-flight-request-test []
+  ;; rf2-r1rkvb — a request already put on the wire, then orphaned by a socket
+  ;; drop, must not leak in :in-flight forever. On the drop it is FAILED: the
+  ;; slot clears and the waiting :reply-event fires with an explicit
+  ;; connection-lost body (loss semantics = fail, not replay).
+  (with-sync-mock!
+    (fn []
+      (with-new-frame [f (new-frame)]
+        (rf/dispatch-sync [:ws/connection
+                           [:ws/connect {:url "ws://mock" :auth-token "demo"}]]
+                          {:frame f})
+        (is (true? (machine-has-tag? f :websocket/connected)))
+        ;; A request whose wire :type the mock does NOT echo, so it sits
+        ;; in-flight with no reply to clear it.
+        (let [rid (random-uuid)]
+          (rf/dispatch-sync [:ws/connection
+                             [:ws/request {:request-id rid
+                                           :body       {:type :silent-no-echo}
+                                           :reply      [:ws.app/request-reply]
+                                           :timeout-ms 5000}]]
+                            {:frame f})
+          (is (contains? (get-in (snapshot (:rf.db/runtime (rf/frame-state-value f)))
+                                 [:data :in-flight])
+                         rid)
+              "a request with no immediate reply sits in :in-flight")
+          ;; Drop the socket.
+          (messages/simulate-disconnect! (rf/capture-frame f))
+          (let [s  (snapshot (:rf.db/runtime (rf/frame-state-value f)))
+                db (rf/app-db-value f)]
+            (is (= :reconnecting (:state s)))
+            (is (= {} (get-in s [:data :in-flight]))
+                ":in-flight cleared on socket drop — no indefinite leak")
+            (let [reply (get-in db [:messages :last-reply])]
+              (is (some? reply) "the waiting reply-event fired on the drop")
+              (is (false? (:ok reply)) "reply is an explicit failure")
+              (is (= :ws/connection-lost (:error reply)))
+              (is (= rid (:request-id reply))
+                  "the failure names the dropped request"))))))))
+
 ;; ============================================================================
 ;; REQUEST/REPLY + SERVER PUSH + SUBSCRIPTIONS
 ;; ============================================================================
@@ -809,6 +849,11 @@
             events, and :ws/opened / :ws/auth-ok / :ws/auth-failed / :ws/closed
             all carry it"
     (stale-auth-events-guarded-test)))
+
+(deftest websocket-drop-fails-in-flight-request
+  (testing "rf2-r1rkvb — a socket drop fails + clears every in-flight request
+            (no leak); the waiting reply-event gets a connection-lost body"
+    (drop-fails-in-flight-request-test)))
 
 (deftest websocket-request-reply-correlation
   (testing "request-reply correlation — :in-flight slot fills then clears on reply"


### PR DESCRIPTION
Fixes the WebSocket lifecycle cluster in `examples/patterns/websocket` — three
coupled bugs on socket identity, the in-flight queue, and reconnect. One worker
owns the surface; landed as three separate commits (guard → in-flight → queue).

## What changed

**rf2-3cgvt7 — Guard lifecycle events with the current socket id.**
The socket actor already stamps every dispatch with `:source-socket-id`, but only
`:ws/received` and `:ws/request-timeout` were epoch-guarded. Added `:current-socket?`
to the four socket-sourced lifecycle transitions — `:ws/opened`, `:ws/auth-ok`,
`:ws/auth-failed`, `:ws/closed`. A straggler from a replaced socket can now neither
advance nor tear down the new connection (highest-value case: an unguarded stale
`:ws/closed` would drop a live connection to `:reconnecting`). Matches the
top-of-file docstring's stale-detection promise, which previously over-claimed.

**rf2-r1rkvb — Fail in-flight requests when the socket drops.**
A request already on the wire when the socket dies could sit in `:data :in-flight`
forever — its timeout is stamped with the now-dead socket id, so `:current-socket?`
drops that timeout after reconnect and the slot never clears. New `:on-socket-lost`
action (on the now-guarded `:ws/closed`) bumps the retry counter *and* clears
`:in-flight`, firing each waiting `:reply` with `{:ok false :error :ws/connection-lost}`.
**Loss semantics: FAIL, not replay** — the server may already have processed a
request before the drop, so a blind re-send risks double execution; at-most-once
with an explicit failure is the safe default.

**rf2-ryt25d — Route queued requests through the register/correlate path.**
A `:ws/request` issued off-connection was enqueued as the request *envelope* but
flushed as a raw wire body, so it was sent malformed and never correlated. The queue
now buffers the **whole inbound event** (`:enqueue-message`), and `:flush-queue`
re-dispatches each event into the connection machine on `:connected` entry — so a
queued `:ws/send` rejoins `:send-now` and a queued `:ws/request` rejoins
`:register-request` (in-flight slot + correlation + timeout). Covers the offline
(`:disconnected`) and reconnect (`:reconnecting`) windows.

The three are coupled by design: the socket-id guard (3cgvt7) is what makes
fail-on-drop (r1rkvb) fire only for the *live* socket's close; the queue/flush
rework (ryt25d) and in-flight failure (r1rkvb) partition cleanly — queued requests
were never sent (send on connect), in-flight requests were already sent (fail on drop).

## Files changed

- `examples/patterns/websocket/connection.cljs` — the three machine-spec fixes + docstring accuracy.
- `examples/patterns/websocket/README.md` — three "what this demonstrates" bullets brought in line.
- `implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs` — offline-queue
  assertion updated for the new queue shape; +4 deftests (>=1 adversarial per behavioral fix):
  `websocket-stale-lifecycle-events-dropped`, `websocket-stale-auth-events-guarded`,
  `websocket-drop-fails-in-flight-request`, `websocket-queued-request-registers-and-replies-on-connect`.

## Quality gates

| Gate | Command | Result |
|---|---|---|
| CLJS node integration (full bundle) | `cd implementation && npm run test:cljs` | **PASS** — 8139 tests, 37314 assertions, 0 failures, 0 errors (includes the 4 new websocket deftests + updated offline-queue assertion) |
| Fast PR spine | `sh scripts/test-fast-pr.sh` | **PASS** — "PASS fast PR spine" (exit 0): core JVM, JS harness policy/helpers, per-ns isolation 15/15, retired-spelling / thrown-error / ambient-durable / README-inventory gates, and — README.md touched — README link/anchor + docs-slug + EP-status-sync + runtime-subsystem-grading markdown gates |
| Reader-parse sanity | Clojure reader over both edited CLJS files | PASS |
| `mkdocs --strict` | (part of fast spine) | SKIPPED — mkdocs not on PATH locally (Windows soft-skip; CI runs it) |

Transitive surface (core / machines / schemas / fx / reagent adapter, all reachable
from the websocket module) is exercised by the full node-test bundle above.

## Stance

Pre-alpha, no back-compat shims; optimized for ELEGANCE + CLARITY + CORRECTNESS +
GOOD PRACTICE, avoiding over-engineering. Scoped to the websocket surface only.

## Follow-on (out of scope — flagged, not actioned)

`spec/Pattern-WebSocket.md`'s worked-machine code sample predates the example's
`:rf/spawned` rewrite (the README already notes the divergence) and still shows the
pre-fix shapes for all three behaviors: unguarded lifecycle transitions (its
stale-detection prose already says "every event" is checked — the code sample never
implemented it), `:enqueue-message` buffering a bare body, and timeout-only in-flight
clearing. Reconciling that illustration is a spec-review decision for the mayor; left
untouched here to keep this bug-fix scoped to `examples/patterns`.
