### PR TITLE
fix(ssr): cookie-name guard, surfaced error projector, SSR readme (rf2-9t17id +2)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/error_projector.cljc
+++ b/implementation/ssr/src/re_frame/ssr/error_projector.cljc
@@ -220,11 +220,21 @@
                                :handler-fn projector-fn))
    id))
 
+(defn- frame-configured-projector-id
+  "The `:public-error-id` the frame's `:ssr` config EXPLICITLY names, or nil
+  when the frame declares no `:ssr` config / no id. Distinct from
+  `frame-projector-id`, which resolves the raw config to the built-in
+  default — `project-error` needs the RAW configured id to tell a missing
+  EXPLICITLY-configured projector (a recognised-but-unhonourable config,
+  worth a diagnostic) apart from the plain default-fallback path (rf2-mlodrn)."
+  [frame-id]
+  (get-in (frame/frame-meta frame-id) [:ssr :public-error-id]))
+
 (defn- frame-projector-id
   "Read the :ssr config's :public-error-id for a frame, falling back
   to :rf.ssr/default-error-projector when no config / no id."
   [frame-id]
-  (or (get-in (frame/frame-meta frame-id) [:ssr :public-error-id])
+  (or (frame-configured-projector-id frame-id)
       :rf.ssr/default-error-projector))
 
 (defn- frame-dev-error-detail?
@@ -241,9 +251,19 @@
   or returns a non-conforming shape, emits :rf.error/sanitised-on-projection
   and returns the locked generic-500 fallback. Per Spec 011
   §Server error projection — \"the fallback ensures the boundary
-  cannot be bypassed by a bug in the projector.\""
+  cannot be bypassed by a bug in the projector.\"
+
+  rf2-mlodrn: when a frame EXPLICITLY configures `:ssr {:public-error-id …}`
+  but that id is NOT registered, the recognised config cannot be honoured —
+  it would silently downgrade the projector's intended 404 / 400 / custom
+  mappings into the generic 500. That case is surfaced as a sanitised
+  projection failure (dev trace + always-on axis) with
+  `:projection-failure-reason :missing-projector`, rather than swallowed. The
+  plain default-fallback path (no `:public-error-id` configured) stays silent
+  — the built-in default projector is always registered by the SSR façade."
   [frame-id trace-event]
-  (let [projector-id  (frame-projector-id frame-id)
+  (let [configured-id (frame-configured-projector-id frame-id)
+        projector-id  (frame-projector-id frame-id)
         projector-fn  (registrar/handler :error-projector projector-id)
         dev-detail?   (frame-dev-error-detail? frame-id)
         ;; Two failure modes for the projector:
@@ -285,11 +305,47 @@
           (public-error-shape? result)
           result
 
-          ;; Already-warned cases (the catch handled the trace) and the
-          ;; no-projector-registered case (silent — the user named an id
-          ;; that doesn't exist; the fallback is the safe behaviour).
-          (or (= ::threw result) (= ::no-projector result))
+          ;; The projector threw — the catch arm above already fired the
+          ;; sanitisation trace + always-on record; just fall back here.
+          (= ::threw result)
           fallback-public-error
+
+          ;; No projector registered under the resolved id.
+          (= ::no-projector result)
+          (do
+            ;; rf2-mlodrn: a frame that EXPLICITLY configured
+            ;; `:ssr {:public-error-id …}` naming an UNREGISTERED projector
+            ;; has a recognised config the runtime cannot honour — it would
+            ;; silently turn the intended public mappings (404 / 400 / custom
+            ;; auth codes) into the generic 500. Surface it as a sanitised
+            ;; projection failure (dev trace + always-on axis, the SAME
+            ;; category the throw / non-conforming arms use — NON-PROJECTING,
+            ;; the projection listener skips it, so no re-entry) with a
+            ;; `:projection-failure-reason :missing-projector` discriminator.
+            ;; The DEFAULT-fallback path (`configured-id` nil — no config)
+            ;; stays silent: the built-in default projector is always
+            ;; registered by the SSR façade, so a nil `configured-id` reaching
+            ;; here is only a bare test registrar, not a misconfiguration.
+            (when (some? configured-id)
+              (let [tags {:projector-id              configured-id
+                          :frame                     frame-id
+                          :original-operation        (:operation trace-event)
+                          :projection-failure-reason :missing-projector
+                          :reason                    (str "Configured :public-error-id "
+                                                          (pr-str configured-id)
+                                                          " names an unregistered error"
+                                                          " projector — using the locked"
+                                                          " generic-500 fallback.")
+                          :recovery                  :register-the-configured-projector-or-fix-the-id}]
+                (trace/emit-error! :rf.error/sanitised-on-projection tags)
+                ;; EP-0008 (rf2-hhutya): ALSO ride the always-on axis so an
+                ;; off-box shipper on a `-Dre-frame.debug=false` JVM SSR host
+                ;; sees the misconfiguration. One-shot + NON-PROJECTING.
+                (emit-always-on-error!
+                  (merge {:error :rf.error/sanitised-on-projection
+                          :time  (interop/now-ms)}
+                         tags))))
+            fallback-public-error)
 
           :else
           (do

--- a/implementation/ssr/src/re_frame/ssr/response.cljc
+++ b/implementation/ssr/src/re_frame/ssr/response.cljc
@@ -185,10 +185,11 @@
     s))
 
 (defn- validate-cookie-name!
-  "Throw `:rf.error/cookie-invalid-name` if the cookie name violates the
-  RFC 6265 §4.1.1 token grammar. Same shape as the rf2-rpedl validator
-  in `ssr-ring/cookie.clj` — applied here at the fx boundary so non-ring
-  host adapters get the same gate. Per rf2-z7gor."
+  "Throw `:rf.error/cookie-invalid-name` if the cookie name is nil, is not a
+  string / keyword / symbol, or violates the RFC 6265 §4.1.1 token grammar.
+  Same shape as the rf2-rpedl validator in `ssr-ring/cookie.clj` — applied
+  here at the fx boundary so non-ring host adapters get the same gate. Per
+  rf2-z7gor + rf2-9t17id (the TYPE guard)."
   [n]
   (when (nil? n)
     (error/throw-error!
@@ -196,6 +197,31 @@
       'rf.ssr/response
       "cookie :name is required; supply a non-nil :name on the cookie map."
       {:recovery :supply-a-cookie-name
+       :extra    {:name n}}))
+  ;; rf2-9t17id — type-guard BEFORE `(name n)`. A cookie `:name` is only a
+  ;; string or a Named (keyword / symbol); anything else (a Long `42`, a
+  ;; vector `[]`, a map `{}`, a boolean `true`, …) makes `name` throw a raw
+  ;; host exception (`ClassCastException` on the JVM) with nil ex-data,
+  ;; bypassing the documented `:rf.error/cookie-invalid-name` contract and
+  ;; reaching adapter / `:on-error` code as a generic host exception. The
+  ;; args-schema boundary catches this only when a validator is live and the
+  ;; schema pins the type — when schemas are absent or soft-pass (Spec 010),
+  ;; the fx boundary is the last line of defence, so reject the unsupported
+  ;; TYPE loudly through the same structured error id. Mirrors the Ring
+  ;; materialiser's guard (rf2-d95o1y in `re-frame.ssr.ring.cookie`); the JVM
+  ;; branch matches Ring's `clojure.lang.Named` check exactly (the fx runs
+  ;; server-only, `:platforms #{:server}`).
+  (when-not (or (string? n)
+                #?(:clj  (instance? clojure.lang.Named n)
+                   :cljs (or (keyword? n) (symbol? n))))
+    (error/throw-error!
+      :rf.error/cookie-invalid-name
+      'rf.ssr/response
+      (str "cookie :name must be a string or a keyword/symbol; got "
+           (pr-str n)
+           #?(:clj (str " (a " (.getName (class n)) ")") :cljs "")
+           ". Use a string or keyword token-grammar cookie name.")
+      {:recovery :use-a-token-grammar-cookie-name
        :extra    {:name n}}))
   (let [s (#?(:clj clojure.core/name :cljs cljs.core/name) n)]
     (when-not (http-validation/valid-token-name? s)

--- a/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
@@ -872,6 +872,60 @@
       (is (= :internal-error (:code public)))
       (is (some #(= :rf.error/sanitised-on-projection (:operation %)) @traces)))))
 
+(deftest ssr-error-projector-configured-but-unregistered-surfaces-diagnostic
+  (testing "rf2-mlodrn — a frame that configures :ssr {:public-error-id …}
+            naming an UNREGISTERED projector is a recognised-but-unhonourable
+            config: project-error SURFACES a :rf.error/sanitised-on-projection
+            diagnostic (:projection-failure-reason :missing-projector) instead
+            of silently downgrading the projector's intended mapping to the
+            generic 500. Pre-rf2-mlodrn this fell back with NO dev trace and
+            NO always-on record."
+    (let [project-error ssr/project-error
+          ;; A :public-error-id that was NEVER reg-error-projector'd.
+          f             (frame/make-anon-frame-record!
+                          {:platform :server
+                           :ssr {:public-error-id   :myapp/never-registered
+                                 :dev-error-detail? false}})
+          traces        (atom [])
+          _             (rf/register-listener! :trace ::mp (fn [ev] (swap! traces conj ev)))
+          ;; :no-such-handler would have projected to a 404 under a real
+          ;; projector — the misconfiguration silently made it a 500.
+          public        (project-error f {:operation :rf.error/no-such-handler :tags {}})]
+      (rf/unregister-listener! :trace ::mp)
+      ;; The boundary still holds — the fallback is the safe wire shape.
+      (is (= 500 (:status public))
+          "the locked generic-500 fallback still applies (boundary can't be bypassed)")
+      (is (= :internal-error (:code public)))
+      ;; …but the misconfiguration is now OBSERVABLE.
+      (let [diag (some #(when (= :rf.error/sanitised-on-projection (:operation %)) %)
+                       @traces)]
+        (is (some? diag)
+            ":rf.error/sanitised-on-projection fired — the missing configured
+             projector is surfaced, not swallowed")
+        (is (= :missing-projector (get-in diag [:tags :projection-failure-reason]))
+            "the diagnostic carries :projection-failure-reason :missing-projector")
+        (is (= :myapp/never-registered (get-in diag [:tags :projector-id]))
+            "the diagnostic names the unregistered configured id"))))
+
+  (testing "rf2-mlodrn — the plain default-fallback path (NO :public-error-id
+            configured) stays SILENT: with no :ssr config the frame resolves
+            to the built-in default projector, which honours the mapping — so
+            there is no missing-projector diagnostic (the change is surgical
+            to the CONFIGURED-but-unregistered case, not noisy on the default
+            path)."
+    (let [project-error ssr/project-error
+          f             (frame/make-anon-frame-record! {:platform :server})
+          traces        (atom [])
+          _             (rf/register-listener! :trace ::mp2 (fn [ev] (swap! traces conj ev)))
+          public        (project-error f {:operation :rf.error/no-such-handler :tags {}})]
+      (rf/unregister-listener! :trace ::mp2)
+      (is (= 404 (:status public))
+          "the built-in default projector maps :no-such-handler → 404
+           (honoured, not fallen-back)")
+      (is (not-any? #(= :rf.error/sanitised-on-projection (:operation %)) @traces)
+          "no sanitised-on-projection diagnostic on the default path — the
+           default projector is registered, so it is not a missing-projector"))))
+
 ;; ===========================================================================
 ;; rf2-ynjts.13 — default-error-projector-fn pure-unit case-arm coverage.
 ;; The end-to-end tests above drive :no-such-handler → 404 and

--- a/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
@@ -35,6 +35,7 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.ssr :as ssr]
+            [re-frame.ssr.response :as response]
             [re-frame.ssr.test-fixture :as tf]
             [re-frame.trace :as trace]))
 
@@ -2117,6 +2118,46 @@
           (expect-fx-error-keyword!
             traces :rf.error/cookie-invalid-max-age
             (str "hostile :max-age " (pr-str hostile))))))))
+
+(deftest ssr-set-cookie-rejects-non-string-name-type
+  (testing "rf2-9t17id — a cookie :name that is neither a string nor a Named
+            (keyword / symbol) is rejected at the fx boundary with the
+            documented :rf.error/cookie-invalid-name, NOT a raw host
+            ClassCastException. Exercised on the DIRECT fx-handler path — the
+            schema-soft-pass path the fx boundary must self-defend: with the
+            :rf.server/cookie args schema absent or soft-passing (Spec 010),
+            `(name n)` on a non-Named value would otherwise throw a bare host
+            exception with nil ex-data, bypassing the structured-error
+            contract and reaching adapter / :on-error code."
+    (let [f (frame/make-anon-frame-record! {:platform :server})]
+      (doseq [bad-name [42 3.14 [:not :a :name] {:cookie :map} true]]
+        (is (thrown-with-msg?
+              clojure.lang.ExceptionInfo
+              #":rf\.error/cookie-invalid-name"
+              (response/set-cookie-fx {:frame f} {:name bad-name :value "x"}))
+            (str "set-cookie-fx with a non-string/non-Named :name "
+                 (pr-str bad-name)
+                 " must throw :rf.error/cookie-invalid-name, not a raw host"
+                 " exception"))
+        (is (empty? (:cookies (response/response-of f)))
+            (str "the rejected cookie (" (pr-str bad-name)
+                 ") never lands on the accumulator")))
+      ;; delete-cookie is sugar over the same validator — same TYPE guard.
+      (is (thrown-with-msg?
+            clojure.lang.ExceptionInfo
+            #":rf\.error/cookie-invalid-name"
+            (response/delete-cookie-fx {:frame f} {:name 99 :path "/"}))
+          "delete-cookie-fx runs the same cookie-name type guard")))
+
+  (testing "rf2-9t17id regression guard — string / keyword / symbol :name
+            still pass the type guard and reach the token-grammar check
+            (a keyword :name coerces via `name`)."
+    (let [f (frame/make-anon-frame-record! {:platform :server})]
+      (response/set-cookie-fx {:frame f} {:name "session" :value "a"})
+      (response/set-cookie-fx {:frame f} {:name :csrf     :value "b"})
+      (response/set-cookie-fx {:frame f} {:name 'tracker  :value "c"})
+      (is (= 3 (count (:cookies (response/response-of f))))
+          "string, keyword, and symbol cookie names all pass the type guard"))))
 
 (deftest ssr-set-cookie-clean-attributes-still-accepted
   (testing "rf2-kjf3m.1 regression guard: legitimate cookie attributes still

--- a/tools/template/resources/day8/re_frame2_template/_shared/README_with_ssr.md
+++ b/tools/template/resources/day8/re_frame2_template/_shared/README_with_ssr.md
@@ -1,0 +1,289 @@
+# {{name}}
+
+[![Built with re-frame2](https://img.shields.io/badge/built%20with-re--frame2-blue.svg)](https://github.com/day8/re-frame2)
+[![Substrate]({{substrate-badge-url}})](https://github.com/day8/re-frame2/tree/main/implementation/adapters/{{substrate}})
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+A new **server-side-rendered** [re-frame2](https://github.com/day8/re-frame2)
+application, scaffolded from `day8/re-frame2-template` (deps-new) with
+`:include-ssr? true`.
+
+Substrate: **{{substrate}}**.
+
+The app is written **once** and runs **twice**: the JVM renders the page to
+HTML so the first paint arrives ready-made, and the browser then *hydrates*
+that same HTML and takes over, fully interactive. Because both runs share the
+same events / subscription / schema / view, the registration root is a single
+`.cljc` file (`src/{{nested-dirs}}/core.cljc`) — the `#?(:clj …)` / `#?(:cljs …)`
+reader conditionals carve out only the few spots that genuinely differ (the JVM
+render path vs the browser mount). See Spec 011 — SSR & Hydration.
+
+## Run the development build
+
+SSR runs two processes side by side: the **shadow-cljs watcher** compiles the
+client bundle (`main.js`), and the **JVM render server** (Ring/Jetty) renders
+each request to HTML and serves that bundle so the page can hydrate.
+
+```sh
+npm install
+npx shadow-cljs watch app        # terminal 1 — builds + watches the client bundle
+```
+
+```sh
+clojure -X:server                # terminal 2 — the SSR / Jetty host
+```
+
+Then open <http://127.0.0.1:8030> in your browser.
+
+The `:server` alias (`deps.edn`) runs `{{namespace}}.server/-main`, which
+installs the JVM-side SSR render adapter and boots Jetty on `127.0.0.1:8030`.
+The first request renders the counter on the server; view source and you will
+see the fully-formed markup plus an embedded hydration payload — no blank shell,
+no client round-trip before first paint.
+
+Rebuild the client on save with the watcher above; to pick up a change to the
+**server** side (`server.clj`), restart `clojure -X:server` (or
+`(require '{{namespace}}.server :reload)` from a connected REPL).
+
+## Server render + client hydration — how the two halves meet
+
+`src/{{nested-dirs}}/core.cljc` holds the whole app, shared by both runtimes:
+
+- **`CounterDb`** — the whole-app-db Malli schema, kept as a plain value so it
+  can be registered against whichever frame the entry point stands up (the
+  throwaway per-request server frame, or the fixed client frame). `reg-app-schema`
+  is frame-local (EP-0002), so it is attached under a live frame scope, never at
+  namespace load.
+- **`:counter/initialise` / `:counter/increment`** — the shared events.
+- **`:counter/value`** — the shared subscription.
+- **`counter-app`** (`^{:rf/id :app/root}`) — the shared root view. `reg-view`
+  injects a frame-bound `subscribe` / `dispatch` resolved at render time, which
+  is exactly what lets one view run twice: on the JVM a deref reads the current
+  value; on the client the same deref registers a reaction.
+
+The **server entry** (`server-init-events` + `root-view`) is what
+`src/{{nested-dirs}}/server.clj` hands to `re-frame.ssr.ring/ssr-handler`. The
+handler owns the per-request lifecycle — frame create → drain → response read →
+render → frame destroy — and gensyms the per-request frame id internally, so the
+schema is attached via the `:ssr/register-schema` step that rides *first* in
+`:initial-events` (it runs under the ambient per-request frame the handler is
+constructing, so the whole-app-db schema is live before `:rf/server-init` seeds
+the counter).
+
+The **client entry** (`init`, `:cljs` branch) boots through `ssr/hydrate!`,
+which rolls three ordered steps into one:
+
+1. **READ** the embedded `__rf_payload` `<script>`. A malformed payload fails
+   closed (nothing replaces app-db); a missing one just means "nobody
+   server-rendered this" — a plain first load.
+2. **HYDRATE** — `dispatch-sync [:rf/hydrate payload]` *before* the first render,
+   swapping in the server's app-db slice and stashing the server's render hash.
+3. **VERIFY** — hash the first render tree and compare it to the server's. On
+   disagreement the runtime raises `:rf.ssr/hydration-mismatch`, carrying the
+   `data-rf-render-hash` tripwire the server stamped on the root element.
+
+## HTTP responses and error projection
+
+Server-side effects live under the reserved `:rf.server/*` fx namespace — an
+event handler can `:rf.server/set-status`, `:rf.server/set-header` /
+`:rf.server/append-header`, `:rf.server/set-cookie` / `:rf.server/delete-cookie`,
+and `:rf.server/redirect` / `:rf.server/safe-redirect`. The runtime accumulates
+these in a framework-private per-request side-channel (never in app-db, so they
+never ride the hydration payload to the client) and the Ring host materialises
+them into the wire response.
+
+When a view or subscription **throws** during the server render, the internal
+trace event (rich, monitor-bound) is projected to a **sanitised public-error**
+shape written to the HTTP response — the two surfaces have different audiences.
+The default projector maps `:rf.error/no-such-handler` → 404, client-input schema
+failures → 400, and everything else → a locked generic 500. Override it per app
+with `reg-error-projector` and name it on the frame:
+
+```clojure
+(rf/reg-error-projector :myapp/public-error
+  (fn [trace-event]
+    (case (:operation trace-event)
+      :auth/unauthorised {:status 401 :code :unauthorised
+                          :message "Sign in to continue" :retryable? false}
+      {:status 500 :code :internal-error
+       :message "Something went wrong" :retryable? false})))
+
+;; on the per-request frame's :ssr config (server.clj's ssr-handler opts)
+:ssr {:public-error-id   :myapp/public-error
+      :dev-error-detail? false}
+```
+
+Naming a `:public-error-id` that is **not registered** is surfaced as a
+`:rf.error/sanitised-on-projection` diagnostic (reason `:missing-projector`) — a
+recognised-but-unhonourable config never silently degrades your intended 404/400
+mappings into a 500. See [Spec 011 §Server error projection](https://github.com/day8/re-frame2/blob/main/spec/011-SSR.md).
+
+## Build for release
+
+```sh
+npx shadow-cljs release app      # minified client bundle → resources/public/js/
+clojure -X:server                # the same JVM host serves the release bundle
+```
+
+`shadow-cljs release` sets `:closure-defines {goog.DEBUG false}` (asserts and
+dev-only branches compile away). For production, put a real static-asset server
+/ CDN in front of `/main.js` and reverse-proxy the SSR route; the Jetty host
+here is the zero-ceremony dev/test default. Any Ring-shaped host (HttpKit,
+Pedestal, Reitit-ring) consumes the same `ssr-handler` without change.
+
+## Run tests
+
+```sh
+clojure -M:test
+```
+
+The `:test` alias runs the headless JVM gate `test/{{nested-dirs}}/ssr_test.clj`.
+It boots the SSR adapter, drives the **real** `ssr-ring/ssr-handler` construction
+(the exact path `server.clj` serves), renders the `:app/root` view to a string
+with `render-to-string`, and asserts the HTML content plus the structural
+`data-rf-render-hash` marker the client compares against — no React / JSDOM, it
+runs end-to-end on the JVM. It also proves the per-request schema attach is live
+by rejecting a deliberately schema-violating commit on that same production path.
+
+## Project layout
+
+```
+.
+├── deps.edn                 ; Clojure deps — re-frame2 + ssr + ssr-ring + jetty; :server + :test aliases
+├── shadow-cljs.edn          ; CLJS build config — the :app client bundle
+├── package.json             ; npm deps (react, react-dom, shadow-cljs runtime)
+├── README.md                ; this file
+├── .gitignore .editorconfig .cljfmt.edn .clj-kondo/config.edn
+├── lefthook.yml             ; pre-commit format + lint hook
+├── .github/workflows/
+│   └── ci.yml               ; baseline GitHub Actions CI
+├── resources/public/
+│   ├── index.html           ; static host page (the SSR server renders its own shell per request)
+│   ├── css/app.css          ; minimal plain CSS
+│   └── js/                  ; shadow-cljs writes main.js here; server.clj's :static-root serves it
+├── src/{{nested-dirs}}/
+│   ├── core.cljc            ; THE app — events / sub / schema / view, shared JVM render + CLJS hydration
+│   └── server.clj           ; the Ring / Jetty SSR host (:server alias entry point)
+├── test/{{nested-dirs}}/
+│   └── ssr_test.clj         ; headless JVM SSR gate (render-to-string + render-hash + schema enforcement)
+└── dev/
+    ├── user.clj             ; JVM-side (user/refresh) entry
+    └── scratch.cljs         ; REPL scratch namespace
+```
+
+The per-slice sources a non-SSR scaffold emits are **folded into `core.cljc`** on
+this branch — the events, subscription, schema, and view are written once so the
+server and client share exactly the same registrations.
+
+Xray devtools ship in the client `:app` build's dev preloads (`shadow-cljs.edn`)
+and attach when the hydrated client runs; release builds drop the preload
+automatically.
+
+## What's in the scaffold
+
+A minimal **counter app** demonstrates the SSR dataflow end-to-end:
+
+- The server seeds `:counter/value` (default `0`) via `:rf/server-init`, renders
+  the counter to HTML, and embeds the hydration payload.
+- The client reads that payload, hydrates into it (no flash, no re-fetch), and
+  takes over — the `+1` button then dispatches `:counter/increment` live.
+- `:counter/value` is the subscription that derives the displayed number on both
+  sides.
+
+The state key is intentionally feature-scoped (`:counter/value`, not a bare
+`:count`) so generated applications start with AI-readable, non-colliding app-db
+slices. This is the same counter walked through in
+[the re-frame2 guide](https://github.com/day8/re-frame2/tree/main/docs/core).
+
+## Best practices baked into the scaffold
+
+re-frame2 ships distinctive postures on **error visibility**, **typed
+boundaries**, **privacy / egress**, and **HTTP failure handling**. They apply to
+any re-frame2 app — SSR or SPA.
+
+### Errors are events too
+
+Every error inside the dispatch pipeline — schema violation, handler exception,
+sub exception, fx exception, drain-depth overflow — emits a structured trace
+event with `:op-type :error` (per
+[Spec 009 §Error contract](https://github.com/day8/re-frame2/blob/main/spec/009-Instrumentation.md)).
+On the **server** the SSR error projector (above) maps those trace events onto
+sanitised HTTP-response shapes; on the **client**, an app-level listener
+(`re-frame.trace.tooling/register-listener!`) projects them onto the UI. The two
+are separate surfaces — the projector owns the wire response, the client listener
+owns what the interactive UI shows — but both start from the same structured
+error event.
+
+### Typed app-db boundaries
+
+`core.cljc` registers a **whole-app-db schema** (`CounterDb`) at the empty path
+`[]`. The runtime validates every write against the registered schemas; a
+non-conforming write rolls back the `:db` effect and emits
+`:rf.error/schema-validation-failure`. App-db schemas are **frame-local**
+(EP-0002): the scaffold attaches the schema under a live frame scope
+(`register-schema!` — the server via the `:ssr/register-schema` initial-event, the
+client via the explicit-frame arity), never at namespace load. Closed maps
+(`{:closed true}`) catch typos; schema validation elides automatically under
+`:advanced` `goog.DEBUG=false` release builds.
+
+For multi-feature apps, register **per-feature schemas at their prefix path**
+rather than one giant root schema. Full detail:
+[Spec 010 §`app-db` schemas — path-based](https://github.com/day8/re-frame2/blob/main/spec/010-Schemas.md#app-db-schemas--path-based).
+
+### Privacy / egress classification — declare it on the frame
+
+re-frame2 makes runtime state highly observable (Xray, the trace stream, off-box
+monitors) — a productivity feature **and** a privacy surface. **App-db schemas
+validate shape; they do NOT classify egress.** Egress classification for durable
+app-db paths is owned by the **frame** (declared on `reg-frame`), never
+re-attached to a schema. As soon as you add auth/API data to app-db, classify it
+from the event that writes it — return the `:sensitive` / `:large` commit-plane
+effects alongside `:db` (EP-0025). On SSR the `:payload` allowlist on
+`ssr-handler` is a second privacy gate: ship only the slices the client needs in
+the hydration payload (this scaffold ships `[:counter/value]`), so server-only
+secrets never cross to the wire. Full model:
+[Spec 015 §The three-layer model](https://github.com/day8/re-frame2/blob/main/spec/015-Data-Classification.md).
+
+### HTTP — closed failure-category set and a single `:on-failure` branch
+
+When your app talks to a backend, add `day8/re-frame2-http` and use
+`:rf.http/managed` (per
+[Spec 014](https://github.com/day8/re-frame2/blob/main/spec/014-HTTPRequests.md)).
+Every managed-async completion delivers the framework's
+[uniform reply envelope](https://github.com/day8/re-frame2/blob/main/spec/Managed-Effects.md#the-uniform-reply-envelope)
+— one canonical reply map with a single **closed** `:status` (`:ok` / `:error` /
+`:cancelled` / `:stale`), `:value` / `:error`, `:work/id`, and `:completed-at`.
+`:on-success` / `:on-failure` are pure ROUTING sugar over the one direct reply
+target; both receive the identical canonical map. Only the *retryable* subset of
+the `:rf.http/*` failure categories is admissible under `:retry :on`; branch on
+`(:kind (:error reply))` to project each category onto a UI-facing message.
+
+### Naming conventions
+
+The scaffold follows the **`:domain/action` keyword shape** throughout — the id
+prefix identifies the feature. Reserved namespaces (`:rf/*`, `:rf.<area>/*`,
+`:rf.error/*`) are framework-owned; app ids live under your own domain prefix. A
+feature reads another feature's state through its subs and writes it through its
+events — never by reaching into another slice directly. Full normative
+catalogue: [spec/Conventions.md](https://github.com/day8/re-frame2/blob/main/spec/Conventions.md).
+
+## Next steps
+
+- Read [the re-frame2 guide](https://github.com/day8/re-frame2/tree/main/docs/core).
+- Study the canonical SSR worked example this scaffold mirrors,
+  [`examples/capabilities/ssr`](https://github.com/day8/re-frame2/tree/main/examples/capabilities/ssr).
+- Browse the [Pattern Specification](https://github.com/day8/re-frame2/tree/main/spec)
+  — in particular [Spec 011 — SSR & Hydration](https://github.com/day8/re-frame2/blob/main/spec/011-SSR.md).
+
+## Migrating from re-frame v1?
+
+If you are porting an existing re-frame app, see
+[`migration/from-re-frame-v1/README.md`](https://github.com/day8/re-frame2/blob/main/migration/from-re-frame-v1/README.md)
+and the [`re-frame-migration`](https://github.com/day8/re-frame2/tree/main/skills/re-frame-migration)
+skill — a Claude Code workflow that walks the port mechanically and flags the
+cases that need a human decision.
+
+## License
+
+Generated by `day8/re-frame2-template` — see the template repo for licensing of
+the scaffold. Your project's code is yours; pick whatever license you like.

--- a/tools/template/src/day8/re_frame2_template/hooks.clj
+++ b/tools/template/src/day8/re_frame2_template/hooks.clj
@@ -523,7 +523,11 @@
        schema / view, the shared per-slice CLJS sources
        (`events.cljs` / `subs.cljs` / `schema.cljs` / `events_test.cljs` /
        `views.cljs`) are NOT emitted; the shared file-map instead emits a
-       headless JVM `ssr_test.clj`. See 004-SSR-Validation-Report §3.
+       headless JVM `ssr_test.clj` AND overlays an SSR-flavoured
+       `README_with_ssr.md` → `README.md` (rf2-6ikgyr) over the default SPA
+       README the `root/` bulk-copy laid down — the default one describes the
+       static dev-server workflow + per-slice file names the SSR branch does
+       not emit. See 004-SSR-Validation-Report §3 / §188.
      - CSS overlay (substrate-invariant, under `:css :tailwind`; Q6 lock /
        rf2-gthro, wiring rf2-nxqcov): overwrites the plain-CSS `app.css` +
        `index.html` (emitted by the `root/` bulk-copy) with the Tailwind v4
@@ -590,10 +594,23 @@
                          ;; SSR shape: the events / subs / schema / view all
                          ;; live in `core.cljc` (see the per-substrate
                          ;; branch), so the only shared source is the
-                         ;; headless JVM SSR gate.
+                         ;; headless JVM SSR gate. The SSR path also swaps in
+                         ;; an SSR-flavoured README (rf2-6ikgyr): the default
+                         ;; `root/README.md` (bulk-copied first) describes the
+                         ;; static-SPA dev-server workflow + the per-slice
+                         ;; file names this branch does NOT emit, so
+                         ;; `README_with_ssr.md` overwrites it with the SSR
+                         ;; quick-start (JVM render server + client watcher),
+                         ;; the core.cljc / server.clj / ssr_test.clj shape,
+                         ;; and the error-projector surface. Since all
+                         ;; transforms run AFTER the `root/` bulk-copy (and
+                         ;; tools.build's copy-dir overwrites), the SSR README
+                         ;; wins — the same overlay mechanism the Tailwind CSS
+                         ;; variant uses (004-SSR-Validation-Report §188).
                          include-ssr?
                          (assoc "ssr_test.clj"
-                                (str "test/" nested "/ssr_test.clj")))
+                                (str "test/" nested "/ssr_test.clj")
+                                "README_with_ssr.md" "README.md"))
         shared         [["_shared" "." shared-files :only]]
 
         ;; Per-substrate transforms. `:only` keeps each substrate

--- a/tools/template/test/day8/re_frame2_template/template_test.clj
+++ b/tools/template/test/day8/re_frame2_template/template_test.clj
@@ -1206,7 +1206,45 @@
             (is (.contains ssr-test-text "data-rf-render-hash")
                 "ssr_test.clj asserts the render-hash marker on the emitted HTML")
             (is (.contains ssr-test-text "[acme.my-app.core :as app]")
-                "ssr_test.clj requires the app core ns by derived namespace")))
+                "ssr_test.clj requires the app core ns by derived namespace"))
+
+          ;; -- the emitted README is the SSR variant, NOT the SPA shape
+          ;;    (rf2-6ikgyr) — README_with_ssr.md overwrote the default
+          ;;    root/README.md the bulk-copy laid down --
+          (let [readme-text (slurp (io/file root "README.md"))]
+            ;; SSR-specific dev workflow: the JVM render server + its port +
+            ;; the second-terminal boot step the SPA README never mentions.
+            (is (.contains readme-text "clojure -X:server")
+                "SSR README documents the `clojure -X:server` JVM host boot step")
+            (is (.contains readme-text "127.0.0.1:8030")
+                "SSR README points at the SSR host (127.0.0.1:8030)")
+            ;; SSR-specific emitted files (the SPA README lists the per-slice
+            ;; sources instead).
+            (is (.contains readme-text "core.cljc")
+                "SSR README describes core.cljc (shared server render + client hydration)")
+            (is (.contains readme-text "server.clj")
+                "SSR README describes the Ring host server.clj")
+            (is (.contains readme-text "ssr_test.clj")
+                "SSR README describes the headless JVM ssr_test.clj gate")
+            ;; SSR concepts.
+            (is (re-find #"(?i)hydrat" readme-text)
+                "SSR README explains server render + client hydration")
+            (is (.contains readme-text "reg-error-projector")
+                "SSR README documents the SSR error-projector surface")
+            ;; The gate is JVM ssr_test.clj (`clojure -M:test`), NOT the
+            ;; CLJS-only node runner the SPA README ships.
+            (is (.contains readme-text "clojure -M:test")
+                "SSR README runs the JVM ssr_test.clj with `clojure -M:test`")
+            ;; -- and NOT the SPA-shape content that mis-describes this branch --
+            (is (not (.contains readme-text "8280"))
+                "SSR README does NOT tell the user to open the SPA dev port 8280")
+            (is (not (.contains readme-text "out/node-test.js"))
+                "SSR README does NOT ship the CLJS-only `node out/node-test.js`
+                 command — the SSR gate is JVM ssr_test.clj")
+            (doseq [spa-file ["events.cljs" "subs.cljs" "views.cljs" "schema.cljs"]]
+              (is (not (.contains readme-text spa-file))
+                  (str "SSR README does NOT reference the SPA-shape source "
+                       spa-file " — those slices are folded into core.cljc")))))
         (finally
           (delete-recursively tmp))))))
 


### PR DESCRIPTION
Three-bead cluster on the **SSR** subsystem. Commits ordered smallest-cleanup → biggest-correctness-fix; each bead is its own commit.

## rf2-6ikgyr — emit an SSR-specific generated README (P3)

The `:include-ssr? true` scaffold received the default **SPA** README from the `root/` bulk-copy: it described the static dev-server workflow (`shadow-cljs watch app`; open `localhost:8280`) and per-slice source file names (`events.cljs` / `subs.cljs` / `views.cljs` / `events_test.cljs`) that the SSR branch does **not** emit — the SSR path folds those into `core.cljc` and ships `server.clj` + a headless JVM `ssr_test.clj`.

- New `_shared/README_with_ssr.md`, overlaid onto `README.md` under the SSR branch (the same overwrite-after-root-copy mechanism the Tailwind CSS variant uses). `004-SSR-Validation-Report` anticipated this separate `_with_ssr` README at §188 because deps-new has no conditional (Mustache) syntax.
- The SSR README documents the two-process dev flow (`npx shadow-cljs watch app` + `clojure -X:server`, open `127.0.0.1:8030`), the `core.cljc` / `server.clj` / `ssr_test.clj` shape, server render + client hydration + the `data-rf-render-hash` tripwire, the `:rf.server/*` response fx, and the `reg-error-projector` surface. The universally-relevant best-practices sections are adapted to the SSR file shape.
- **Test** (`include-ssr-true-reagent-test`, extended): asserts the emitted README carries the SSR workflow and does **not** carry the SPA shape (no `8280`, no `out/node-test.js`, no `events.cljs`/`subs.cljs`/`views.cljs`/`schema.cljs`).

## rf2-9t17id — type-guard cookie names at the core response fx boundary (P3)

`validate-cookie-name!` (`re-frame.ssr.response`) nil-checked `:name` then called `clojure.core/name`. A non-string / non-Named `:name` (a `Long`, a vector, a map, a boolean) makes `name` throw a raw host `ClassCastException` with nil ex-data — bypassing the documented `:rf.error/cookie-invalid-name` contract and reaching adapter / `:on-error` code as a generic host exception. The args-schema boundary catches this only when a validator is live and the schema pins the type; when schemas are absent or soft-pass (Spec 010), the fx boundary is the last line of defence.

- Added a type guard **before** `(name n)`: accept strings and Named values (keyword / symbol) only, else throw the structured `:rf.error/cookie-invalid-name`. Mirrors the Ring materialiser's guard (rf2-d95o1y); the JVM branch matches Ring's `clojure.lang.Named` check exactly (the fx runs server-only).
- **Adversarial test** (`ssr-set-cookie-rejects-non-string-name-type`): the **direct fx-handler path** — `set-cookie-fx` / `delete-cookie-fx` with a non-string/non-Named `:name` (`42` / `3.14` / vector / map / `true` / `99`) throws `:rf.error/cookie-invalid-name` (an `ExceptionInfo` carrying the keyword), not a raw host exception, and nothing lands on the accumulator; a regression guard confirms string / keyword / symbol names still pass.

## rf2-mlodrn — surface a missing configured error projector, not a silent 500 (P3)

When a frame configured `:ssr {:public-error-id …}` but named a projector that was never registered, `project-error` resolved `projector-fn` to nil, hit the `::no-projector` arm, and returned the locked generic-500 with **no** dev trace and **no** always-on diagnostic — silently turning intended 404/400/custom mappings into 500s.

- Split the `::no-projector` handling: when the frame **explicitly** configured a `:public-error-id` that is unregistered, emit `:rf.error/sanitised-on-projection` (same category as the throw / non-conforming arms — NON-PROJECTING, so no re-entry) on both the dev trace and the always-on error-emit axis, tagged `:projection-failure-reason :missing-projector`. The plain default-fallback path (no `:public-error-id` configured) stays **silent** — the built-in default projector is always registered by the SSR façade. Added `frame-configured-projector-id` (the raw configured id) to tell the two apart. The boundary still falls back to the locked generic-500 — it cannot be bypassed.
- **Adversarial test** (`ssr-error-projector-configured-but-unregistered-surfaces-diagnostic`): a frame naming `:myapp/never-registered` surfaces the diagnostic (`:projection-failure-reason :missing-projector`, `:projector-id` names the id) and still returns 500; a negative control proves the no-config default path stays silent and honours `:no-such-handler` → 404.

## Quality gates

All run from the worker worktree.

| Gate | Command | Result |
|---|---|---|
| SSR JVM artefact | `cd implementation/ssr && clojure -M:test` | **PASS** — 368 tests, 1491 assertions, 0 failures, 0 errors |
| SSR-Ring JVM (transitive consumer) | `cd implementation/ssr-ring && clojure -M:test` | **PASS** — 162 tests, 768 assertions, 0 failures, 0 errors |
| tools/template JVM | `cd tools/template && clojure -M:test` | **PASS** — 45 tests, 628 assertions, 0 failures, 0 errors |
| CLJS node integration | `cd implementation && npm run test:cljs` | **PASS** — 8135 tests, 37279 assertions, 0 failures, 0 errors |
| Fast PR spine | `sh scripts/test-fast-pr.sh` | **PASS** — all python guards + core JVM + per-ns isolation + markdown link/anchor gates green |

Notes:
- The `.md` addition triggered the markdown link/anchor gates in the fast-PR spine; they passed. `mkdocs --strict` soft-skips on Windows (CI runs it).
- JVM scope: the affected surface is `implementation/ssr` (edited) and `implementation/ssr-ring` (its consumer) plus `tools/template`; those three JVM artefacts + core (via the fast-PR spine) were run directly. The remaining `implementation/*` artefacts don't consume `re-frame.ssr`, so the full `test-jvm-implementation.sh` sweep was scoped to the transitive surface rather than re-run wholesale.

## Stance

Pre-alpha, no back-compat shims; optimized for **ELEGANCE + CLARITY + CORRECTNESS + GOOD PRACTICE**; avoided over-engineering.
