### PR TITLE
fix(examples): invalid-login guards, linearlite toggle, canonical login-story failures (rf2-9uxqha +2)

### DIFF
--- a/examples/capabilities/resources/linearlite/core.cljs
+++ b/examples/capabilities/resources/linearlite/core.cljs
@@ -355,9 +355,13 @@
           url       (str (:url req))
           body      (:body req)
           write?    (not= method :get)
-          ;; The fx context carries the envelope frame as `:frame`. Read the
-          ;; fail-next-write flag off that frame's runtime db.
-          db        (:rf.db/runtime (rf/frame-state-value (:frame frame-ctx)))
+          ;; The fx context carries the envelope frame as `:frame`. The
+          ;; `:fail-next-write?` toggle is an ordinary app-db slice (written by
+          ;; `:linearlite/set-fail-next-write`, a plain db-in/db-out handler), so
+          ;; read it off the frame's APP-db partition (`:rf.db/app`). Reading
+          ;; `:rf.db/runtime` here — where the flag never lives — is why the
+          ;; simulated rollback never fired.
+          db        (:rf.db/app (rf/frame-state-value (:frame frame-ctx)))
           fail?     (and write? (boolean (:fail-next-write? db)))]
       (if fail?
         ;; Armed: answer the WRITE with a 503 so the optimistic apply rolls back.

--- a/examples/core/login/core.cljs
+++ b/examples/core/login/core.cljs
@@ -53,6 +53,12 @@
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.registrar :as registrar]
+            ;; Malli directly — for the pre-submit form validator below
+            ;; (`m/explain` + `me/humanize`), the same pure validator the form
+            ;; recipe builds (docs/core/how-to/build-a-form.md, "Validation is a
+            ;; pure function").
+            [malli.core :as m]
+            [malli.error :as me]
             ;; Turns on Malli validation, so the machine's `[:schemas :data]`
             ;; checks have something to run. (No app-db schema in this
             ;; example — machine snapshots live in runtime-db, not app-db.)
@@ -399,6 +405,18 @@
 ;; later hold it to.
 (def login-form-defaults {:email "" :password ""})
 
+;; The pre-submit validator. It checks the draft against the very same
+;; `Credentials` schema the machine's `:submit` boundary enforces, so the form
+;; and the machine agree on "valid" down to the last character. `m/explain` +
+;; `me/humanize` turn a schema miss into the form pattern's
+;; `{<field> ["msg" ...]}` shape — exactly what `:auth.login/field-error`
+;; renders — and a clean draft yields `{}`. It's an ordinary pure function you
+;; can call from a REPL; the slice doesn't care that it wraps Malli. See
+;; docs/core/how-to/build-a-form.md, "Validation is a pure function".
+(defn- validate
+  [schema value]
+  (or (some-> (m/explain schema value) me/humanize) {}))
+
 ;; Lay down the slice in its standard form-recipe shape — empty draft,
 ;; `:idle` status, all the bookkeeping fields blank. Dispatched once at
 ;; boot (from `run`) so the very first render reads a real draft.
@@ -430,33 +448,50 @@
              (assoc-in  [:auth :login-form :draft field] value)
              (update-in [:auth :login-form :touched] (fnil conj #{}) field))}))
 
-;; Submit. This is the handoff point — the one and only place the draft
-;; crosses from the slice into the machine (and gets checked against
-;; `Credentials` on the way). It reads the draft, latches
-;; `:submit-attempted?`, nudges the slice `:status` to `:submitting`, and
-;; dispatches the draft at the machine. From here on the *machine* owns the
-;; in-flight / authed / error / locked story; the slice `:status` is just a
-;; mirror tagging along.
+;; Submit. First it *validates* the draft against `Credentials` — the same
+;; schema the machine's `:submit` boundary enforces — and latches
+;; `:submit-attempted?` either way, which is the whole trick behind the
+;; visibility rule: the moment the user first presses submit, every invalid
+;; field is allowed to speak (docs/core/how-to/build-a-form.md, step 3).
 ;;
-;; Now the careful bit — secret-field hygiene. In the same commit that hands
-;; the password to the machine, we blank `[:draft :password]`. The thinking:
-;; once the request is in flight the password has done its one job, and a
-;; secret that lingers in app-db is a secret waiting to be caught in the
-;; next snapshot or recording. So we don't let it linger. Its only sanctioned
-;; trip off the box is the HTTP request body (and `:sensitive? true` scrubs
-;; even that from the trace); it never touches `:submitted` or the machine
-;; `:data`. See docs/core/how-to/add-auth.md.
+;; If the draft is clean, this is the handoff point — the one and only place
+;; the draft crosses from the slice into the machine. It flips the slice
+;; `:status` to `:submitting`, clears any stale field errors, and dispatches
+;; the draft at the machine. From here on the *machine* owns the in-flight /
+;; authed / error / locked story; the slice `:status` is just a mirror.
+;;
+;; If the draft is *invalid*, we stop right here: the field errors land in
+;; `:errors` (rendered under each input) and nothing is dispatched. Handing a
+;; bad draft to the machine would only bounce off its `:submit` schema
+;; boundary — and since the view renders machine errors, that rejection would
+;; be *silent*, the password cleared and the form quietly doing nothing. So
+;; the form catches it first, keeps the password for the fixup, and shows the
+;; user exactly what's wrong.
+;;
+;; Now the careful bit — secret-field hygiene. On the clean branch, in the same
+;; commit that hands the password to the machine, we blank `[:draft :password]`.
+;; The thinking: once the request is in flight the password has done its one
+;; job, and a secret that lingers in app-db is a secret waiting to be caught in
+;; the next snapshot or recording. So we don't let it linger. Its only
+;; sanctioned trip off the box is the HTTP request body (and `:sensitive? true`
+;; scrubs even that from the trace); it never touches `:submitted` or the
+;; machine `:data`. See docs/core/how-to/add-auth.md.
 (rf/reg-event :auth.login/submit-form
-  {:doc "Submit the login form: read the draft from the slice, dispatch it
-         into the :auth.login/flow machine's :submit sub-event, and clear the
-         password out of the draft (secret-field hygiene)."}
+  {:doc "Submit the login form: validate the draft against Credentials. If
+         clean, hand it to the :auth.login/flow machine's :submit sub-event and
+         clear the password (secret-field hygiene); if not, surface the field
+         errors and don't submit. Latches :submit-attempted? either way."}
   (fn handler-login-form-submit [{:keys [db]} _]
-    (let [draft (get-in db [:auth :login-form :draft])]
-      {:db (-> db
-               (assoc-in [:auth :login-form :submit-attempted?] true)
-               (assoc-in [:auth :login-form :status] :submitting)
-               (assoc-in [:auth :login-form :draft :password] ""))
-       :fx [[:dispatch [:auth.login/flow [:auth.login/submit draft]]]]})))
+    (let [draft  (get-in db [:auth :login-form :draft])
+          errors (validate Credentials draft)
+          db'    (assoc-in db [:auth :login-form :submit-attempted?] true)]
+      (if (empty? errors)
+        {:db (-> db'
+                 (assoc-in [:auth :login-form :status] :submitting)
+                 (assoc-in [:auth :login-form :errors] {})
+                 (assoc-in [:auth :login-form :draft :password] ""))
+         :fx [[:dispatch [:auth.login/flow [:auth.login/submit draft]]]]}
+        {:db (assoc-in db' [:auth :login-form :errors] errors)}))))
 
 ;; Wipe the slate — slice back to empty, status back to `:idle`.
 (rf/reg-event :auth.login/reset-form
@@ -548,9 +583,11 @@
 ;; owns the draft; machine owns the status; the view just renders them.
 (rf/reg-view ^{:doc "The login form view: email + password + submit button + error display."}
           login-form []
-  (let [draft @(subscribe [:auth.login/draft])
-        busy? @(rf/subscribe [:rf/machine-has-tag? :auth.login/flow :auth/busy])
-        err   @(subscribe [:auth.login/error])]
+  (let [draft     @(subscribe [:auth.login/draft])
+        busy?     @(rf/subscribe [:rf/machine-has-tag? :auth.login/flow :auth/busy])
+        err       @(subscribe [:auth.login/error])
+        email-err @(subscribe [:auth.login/field-error :email])
+        pw-err    @(subscribe [:auth.login/field-error :password])]
     [:form.login-form
      {:data-testid "login-form"
       :on-submit (fn [e]
@@ -563,12 +600,14 @@
                :data-testid "login-email"
                :value       (:email draft)
                :on-change   #(dispatch [:auth.login/edit-field :email (.. % -target -value)])}]
+     (when email-err [:p.error {:data-testid "login-email-error"} email-err])
      [:input  {:type        "password"
                :placeholder "Password"
                :disabled    busy?
                :data-testid "login-password"
                :value       (:password draft)
                :on-change   #(dispatch [:auth.login/edit-field :password (.. % -target -value)])}]
+     (when pw-err [:p.error {:data-testid "login-password-error"} pw-err])
      [:button {:type "submit" :disabled busy?
                :data-testid "login-submit"}
       (if busy? "Signing in…" "Sign in")]

--- a/examples/core/login/stories.cljs
+++ b/examples/core/login/stories.cljs
@@ -121,6 +121,18 @@
    them."
   {:email "ada@example.com" :password "correct-horse"})
 
+(defn- failure-reply
+  "The canonical managed-HTTP failure envelope the machine's `:record-error`
+   action reads: `{:status :error :error <classified-failure-map>}`, the message
+   riding under `:error`. This is exactly what `:rf.http/managed-canned-failure`
+   delivers on a real 4xx, so driving `:auth.login/failure` with it is faithful
+   to the live cascade. A bare `{:failure …}` map — the retired shape — leaves
+   `:record-error` reading a nil `:error`, so the flow falls back to its generic
+   \"Login failed.\" message instead of the server's."
+  [status message]
+  {:status :error
+   :error  {:kind :rf.http/http-4xx :status status :message message}})
+
 (defn register-all!
   "Register all of the login example's Story artefacts. Safe to call twice —
    it's idempotent, and the canonical vocabulary installs itself on the first
@@ -231,8 +243,7 @@
                  the error."
      :setup      [[:auth.login/flow [:auth.login/submit good-creds]]
                   [:auth.login/flow [:auth.login/failure
-                                     {:failure {:status  401
-                                                :message "Invalid credentials."}}]]]
+                                     (failure-reply 401 "Invalid credentials.")]]]
      :decorators [[story/force-fx-stub-id :rf.http/managed {}]]
      :tags       #{:dev :docs}
      :substrates #{:reagent}})
@@ -251,16 +262,16 @@
                  retries."
      :setup      [[:auth.login/flow [:auth.login/submit good-creds]]
                   [:auth.login/flow [:auth.login/failure
-                                     {:failure {:status 401 :message "Invalid credentials."}}]]
+                                     (failure-reply 401 "Invalid credentials.")]]
                   [:auth.login/flow [:auth.login/submit good-creds]]
                   [:auth.login/flow [:auth.login/failure
-                                     {:failure {:status 401 :message "Invalid credentials."}}]]
+                                     (failure-reply 401 "Invalid credentials.")]]
                   [:auth.login/flow [:auth.login/submit good-creds]]
                   [:auth.login/flow [:auth.login/failure
-                                     {:failure {:status 401 :message "Invalid credentials."}}]]
+                                     (failure-reply 401 "Invalid credentials.")]]
                   [:auth.login/flow [:auth.login/submit good-creds]]
                   [:auth.login/flow [:auth.login/failure
-                                     {:failure {:status 423 :message "Account locked."}}]]]
+                                     (failure-reply 423 "Account locked.")]]]
      :decorators [[story/force-fx-stub-id :rf.http/managed {}]]
      :tags       #{:dev :docs}
      :substrates #{:reagent}})

--- a/examples/substrates/helix/login/core.cljs
+++ b/examples/substrates/helix/login/core.cljs
@@ -25,6 +25,11 @@
             [helix.dom          :as d]
             [re-frame.core :as rf]
             [re-frame.registrar :as registrar]
+            ;; Malli directly — for the pre-submit form validator below
+            ;; (`m/explain` + `me/humanize`), the same pure validator the form
+            ;; recipe builds (docs/core/how-to/build-a-form.md).
+            [malli.core :as m]
+            [malli.error :as me]
             [re-frame.schemas]
             [re-frame.machines]
             [re-frame.http.managed]
@@ -297,6 +302,17 @@
 ;; `:submit` boundary will hold it to later.
 (def login-form-defaults {:email "" :password ""})
 
+;; The pre-submit validator. It checks the draft against the very same
+;; `Credentials` schema the machine's `:submit` boundary enforces, so the form
+;; and the machine agree on "valid" down to the last character. `m/explain` +
+;; `me/humanize` turn a schema miss into the form pattern's
+;; `{<field> ["msg" ...]}` shape — exactly what `:auth.login/field-error`
+;; renders — and a clean draft yields `{}`. See docs/core/how-to/build-a-form.md,
+;; "Validation is a pure function".
+(defn- validate
+  [schema value]
+  (or (some-> (m/explain schema value) me/humanize) {}))
+
 ;; Lay down a fresh form slice: empty `:draft`, `:status :idle`, and the rest.
 (rf/reg-event :auth.login/initialise-form
   {:doc "Seed the login-form slice at [:auth :login-form] to its starting
@@ -324,31 +340,49 @@
              (assoc-in  [:auth :login-form :draft field] value)
              (update-in [:auth :login-form :touched] (fnil conj #{}) field))}))
 
-;; Submit. This reads the draft out of the slice, latches `:submit-attempted?`,
-;; flips the slice `:status` to `:submitting`, and dispatches the draft INTO the
-;; machine. That dispatch is the one and only place the draft crosses over —
-;; and crossing over means meeting `Credentials` at the machine's boundary. From
-;; here on the machine owns the real status (in-flight / authed / error /
-;; locked); the slice's `:status` just shadows it.
+;; Submit. First it VALIDATES the draft against `Credentials` — the same schema
+;; the machine's `:submit` boundary enforces — and latches `:submit-attempted?`
+;; either way, which is what lets every invalid field speak up the moment the
+;; user first presses submit (the form pattern's visibility rule,
+;; docs/core/how-to/build-a-form.md).
 ;;
-;; Watch how the password is handled. The handler lifts it off the draft, sends
-;; it to the machine, and CLEARS `[:draft :password]` in the very same commit.
-;; The moment the request is on its way the secret has done its one job, so we
-;; don't leave it lounging in app-db where the next snapshot or recording could
-;; scoop it up. Its only trip off the box is inside the HTTP body (scrubbed by
-;; `:sensitive? true`); it never touches `:submitted` or the machine's `:data`.
-;; See docs/core/how-to/keep-secrets-out-of-traces.md.
+;; On a clean draft this is the hand-off: it flips `:status` to `:submitting`,
+;; clears any stale field errors, and dispatches the draft INTO the machine.
+;; That dispatch is the one and only place the draft crosses over. From here on
+;; the machine owns the real status (in-flight / authed / error / locked); the
+;; slice's `:status` just shadows it.
+;;
+;; On an INVALID draft we stop here: the field errors land in `:errors`
+;; (rendered under each input) and nothing is dispatched. Handing a bad draft to
+;; the machine would only bounce off its `:submit` schema boundary — and because
+;; the view renders machine errors, that rejection would be SILENT, the password
+;; cleared and the form quietly inert. So the form catches it first, keeps the
+;; password for the fixup, and shows what's wrong.
+;;
+;; Watch how the password is handled. On the clean branch the handler lifts it
+;; off the draft, sends it to the machine, and CLEARS `[:draft :password]` in
+;; the very same commit. The moment the request is on its way the secret has
+;; done its one job, so we don't leave it lounging in app-db where the next
+;; snapshot or recording could scoop it up. Its only trip off the box is inside
+;; the HTTP body (scrubbed by `:sensitive? true`); it never touches `:submitted`
+;; or the machine's `:data`. See docs/core/how-to/keep-secrets-out-of-traces.md.
 (rf/reg-event :auth.login/submit-form
-  {:doc "Submit the login form: read the draft from the slice, dispatch it
-         into the :auth.login/flow machine's :submit sub-event, and clear the
-         password out of the draft (secret-field hygiene)."}
+  {:doc "Submit the login form: validate the draft against Credentials. If
+         clean, dispatch it into the :auth.login/flow machine's :submit
+         sub-event and clear the password (secret-field hygiene); if not,
+         surface the field errors and don't submit. Latches :submit-attempted?
+         either way."}
   (fn handler-login-form-submit [{:keys [db]} _]
-    (let [draft (get-in db [:auth :login-form :draft])]
-      {:db (-> db
-               (assoc-in [:auth :login-form :submit-attempted?] true)
-               (assoc-in [:auth :login-form :status] :submitting)
-               (assoc-in [:auth :login-form :draft :password] ""))
-       :fx [[:dispatch [:auth.login/flow [:auth.login/submit draft]]]]})))
+    (let [draft  (get-in db [:auth :login-form :draft])
+          errors (validate Credentials draft)
+          db'    (assoc-in db [:auth :login-form :submit-attempted?] true)]
+      (if (empty? errors)
+        {:db (-> db'
+                 (assoc-in [:auth :login-form :status] :submitting)
+                 (assoc-in [:auth :login-form :errors] {})
+                 (assoc-in [:auth :login-form :draft :password] ""))
+         :fx [[:dispatch [:auth.login/flow [:auth.login/submit draft]]]]}
+        {:db (assoc-in db' [:auth :login-form :errors] errors)}))))
 
 ;; Wipe the slice back to its empty, :idle starting shape.
 (rf/reg-event :auth.login/reset-form
@@ -432,14 +466,16 @@
 ;; identical — both are just subscriptions.
 
 (defnc login-form []
-  (let [draft    (helix-adapter/use-subscribe [:auth.login/draft])
-        busy?    (helix-adapter/use-subscribe [:rf/machine-has-tag?
-                                               :auth.login/flow :auth/busy])
-        err      (helix-adapter/use-subscribe [:auth.login/error])
+  (let [draft     (helix-adapter/use-subscribe [:auth.login/draft])
+        busy?     (helix-adapter/use-subscribe [:rf/machine-has-tag?
+                                                :auth.login/flow :auth/busy])
+        err       (helix-adapter/use-subscribe [:auth.login/error])
+        email-err (helix-adapter/use-subscribe [:auth.login/field-error :email])
+        pw-err    (helix-adapter/use-subscribe [:auth.login/field-error :password])
         ;; Take `dispatch` off the render-time capture-frame. It resolves to
         ;; this frame (`:rf/default`) through the provider in `run`. Every
         ;; dispatch goes to a frame; there is no global dispatch.
-        dispatch (:dispatch (rf/capture-frame))]
+        dispatch  (:dispatch (rf/capture-frame))]
     ;; Controlled inputs: each input's `:value` reads the draft from the
     ;; `:auth.login/draft` sub, and `:on-change` dispatches
     ;; `:auth.login/edit-field`. The draft lives in app-db, not in a `use-state`
@@ -458,12 +494,14 @@
                   :data-testid "login-email"
                   :value       (:email draft)
                   :on-change   #(dispatch [:auth.login/edit-field :email (.. % -target -value)])})
+       (when email-err (d/p {:class "error" :data-testid "login-email-error"} email-err))
        (d/input  {:type        "password"
                   :placeholder "Password"
                   :disabled    busy?
                   :data-testid "login-password"
                   :value       (:password draft)
                   :on-change   #(dispatch [:auth.login/edit-field :password (.. % -target -value)])})
+       (when pw-err (d/p {:class "error" :data-testid "login-password-error"} pw-err))
        (d/button {:type "submit" :disabled busy?
                   :data-testid "login-submit"}
           (if busy? "Signing in…" "Sign in"))

--- a/examples/substrates/uix/login/core.cljs
+++ b/examples/substrates/uix/login/core.cljs
@@ -21,6 +21,11 @@
             [uix.dom  :as uix-dom]
             [re-frame.core :as rf]
             [re-frame.registrar :as registrar]
+            ;; Malli directly — for the pre-submit form validator below
+            ;; (`m/explain` + `me/humanize`), the same pure validator the form
+            ;; recipe builds (docs/core/how-to/build-a-form.md).
+            [malli.core :as m]
+            [malli.error :as me]
             [re-frame.schemas]
             [re-frame.machines]
             [re-frame.http.managed]
@@ -285,6 +290,17 @@
 ;; enforces, so the form and the machine agree on what "valid" means.
 (def login-form-defaults {:email "" :password ""})
 
+;; The pre-submit validator. It checks the draft against the very same
+;; `Credentials` schema the machine's `:submit` boundary enforces, so the form
+;; and the machine agree on "valid" down to the last character. `m/explain` +
+;; `me/humanize` turn a schema miss into the form pattern's
+;; `{<field> ["msg" ...]}` shape — exactly what `:auth.login/field-error`
+;; renders — and a clean draft yields `{}`. See docs/core/how-to/build-a-form.md,
+;; "Validation is a pure function".
+(defn- validate
+  [schema value]
+  (or (some-> (m/explain schema value) me/humanize) {}))
+
 ;; Lay down the slice in its starting shape: empty `:draft`, `:status :idle`,
 ;; and the rest. Fires once, via the frame-provider's `:initial-events`.
 (rf/reg-event :auth.login/initialise-form
@@ -313,32 +329,49 @@
              (assoc-in  [:auth :login-form :draft field] value)
              (update-in [:auth :login-form :touched] (fnil conj #{}) field))}))
 
-;; Submit. Pull the draft out of the slice, latch `:submit-attempted?`, flip the
-;; slice `:status` to `:submitting`, and hand the draft to the machine. That
-;; hand-off is the single place the draft ever crosses into the machine, and the
-;; machine's `:where :event` boundary checks it against `Credentials` on the way
-;; in. From there the machine — not the slice — owns the real story: in flight,
-;; authed, errored, locked. The slice's `:status` is just a mirror, kept around
-;; so the slice stays a tidy form-pattern shape.
+;; Submit. First it *validates* the draft against `Credentials` — the same
+;; schema the machine's `:submit` boundary enforces — and latches
+;; `:submit-attempted?` either way, which is what lets every invalid field
+;; speak up the moment the user first presses submit (the form pattern's
+;; visibility rule, docs/core/how-to/build-a-form.md).
 ;;
-;; And a word on the password. We read it off the draft, give it to the machine,
-;; then clear `[:draft :password]` in the very same commit. Once the request is
-;; on its way the secret has done its job, and there's no reason to leave it
-;; sitting in app-db where the next snapshot or recording would scoop it up. Its
-;; only trip off the box is inside the HTTP request body (scrubbed by that
-;; `:sensitive? true` flag), and it's never written to `:submitted` or the
-;; machine's `:data`. See docs/core/how-to/keep-secrets-out-of-traces.md.
+;; On a clean draft this is the hand-off: flip `:status` to `:submitting`,
+;; clear any stale field errors, and dispatch the draft into the machine. That
+;; hand-off is the single place the draft ever crosses into the machine. From
+;; there the machine — not the slice — owns the real story: in flight, authed,
+;; errored, locked. The slice's `:status` is just a mirror.
+;;
+;; On an *invalid* draft we stop here: the field errors land in `:errors`
+;; (rendered under each input) and nothing is dispatched. Handing a bad draft
+;; to the machine would only bounce off its `:submit` schema boundary — and
+;; because the view renders machine errors, that rejection would be *silent*,
+;; the password cleared and the form quietly inert. So the form catches it
+;; first, keeps the password for the fixup, and shows what's wrong.
+;;
+;; And a word on the password. On the clean branch we read it off the draft,
+;; give it to the machine, then clear `[:draft :password]` in the very same
+;; commit. Once the request is on its way the secret has done its job, and
+;; there's no reason to leave it sitting in app-db where the next snapshot or
+;; recording would scoop it up. Its only trip off the box is inside the HTTP
+;; request body (scrubbed by that `:sensitive? true` flag), and it's never
+;; written to `:submitted` or the machine's `:data`. See
+;; docs/core/how-to/keep-secrets-out-of-traces.md.
 (rf/reg-event :auth.login/submit-form
-  {:doc "Submit the login form: read the draft from the slice, hand it to the
-         :auth.login/flow machine's :submit sub-event, and clear the password
-         out of the draft (secret-field hygiene)."}
+  {:doc "Submit the login form: validate the draft against Credentials. If
+         clean, hand it to the :auth.login/flow machine's :submit sub-event and
+         clear the password (secret-field hygiene); if not, surface the field
+         errors and don't submit. Latches :submit-attempted? either way."}
   (fn handler-login-form-submit [{:keys [db]} _]
-    (let [draft (get-in db [:auth :login-form :draft])]
-      {:db (-> db
-               (assoc-in [:auth :login-form :submit-attempted?] true)
-               (assoc-in [:auth :login-form :status] :submitting)
-               (assoc-in [:auth :login-form :draft :password] ""))
-       :fx [[:dispatch [:auth.login/flow [:auth.login/submit draft]]]]})))
+    (let [draft  (get-in db [:auth :login-form :draft])
+          errors (validate Credentials draft)
+          db'    (assoc-in db [:auth :login-form :submit-attempted?] true)]
+      (if (empty? errors)
+        {:db (-> db'
+                 (assoc-in [:auth :login-form :status] :submitting)
+                 (assoc-in [:auth :login-form :errors] {})
+                 (assoc-in [:auth :login-form :draft :password] ""))
+         :fx [[:dispatch [:auth.login/flow [:auth.login/submit draft]]]]}
+        {:db (assoc-in db' [:auth :login-form :errors] errors)}))))
 
 ;; Wipe the slate: put the slice back to its empty, :idle starting shape.
 (rf/reg-event :auth.login/reset-form
@@ -422,11 +455,13 @@
 ;; The draft lives in app-db, which is exactly why you won't find a
 ;; `uix/use-state` anywhere in here.
 (defui login-form []
-  (let [draft    (uix-adapter/use-subscribe [:auth.login/draft])
-        busy?    (uix-adapter/use-subscribe [:rf/machine-has-tag?
-                                             :auth.login/flow :auth/busy])
-        err      (uix-adapter/use-subscribe [:auth.login/error])
-        dispatch (:dispatch (rf/capture-frame))]
+  (let [draft     (uix-adapter/use-subscribe [:auth.login/draft])
+        busy?     (uix-adapter/use-subscribe [:rf/machine-has-tag?
+                                              :auth.login/flow :auth/busy])
+        err       (uix-adapter/use-subscribe [:auth.login/error])
+        email-err (uix-adapter/use-subscribe [:auth.login/field-error :email])
+        pw-err    (uix-adapter/use-subscribe [:auth.login/field-error :password])
+        dispatch  (:dispatch (rf/capture-frame))]
     ($ :form.login-form
        {:data-testid "login-form"
         :on-submit (fn [e]
@@ -439,12 +474,14 @@
                    :data-testid "login-email"
                    :value       (:email draft)
                    :on-change   #(dispatch [:auth.login/edit-field :email (.. % -target -value)])})
+       (when email-err ($ :p.error {:data-testid "login-email-error"} email-err))
        ($ :input  {:type        "password"
                    :placeholder "Password"
                    :disabled    busy?
                    :data-testid "login-password"
                    :value       (:password draft)
                    :on-change   #(dispatch [:auth.login/edit-field :password (.. % -target -value)])})
+       (when pw-err ($ :p.error {:data-testid "login-password-error"} pw-err))
        ($ :button {:type "submit" :disabled busy?
                    :data-testid "login-submit"}
           (if busy? "Signing in…" "Sign in"))


### PR DESCRIPTION
Three example-surface bug fixes, distinct apps → non-overlapping files.
Commits ordered smallest-cleanup → biggest-correctness.

## rf2-zpngom (P4) — login stories use canonical failure envelope
`examples/core/login/stories.cljs`

The `:auth.login/flow` machine's `:record-error` action reads managed-HTTP
failures from the canonical `:error` field (envelope `{:status :error :error {…}}`),
but the `auth-error` / `locked-out` Story variants manually dispatched a **retired**
`{:failure …}` map. With `:error` nil, `:record-error` fell back to its generic
`"Login failed."` message instead of the intended server message — so the auth-error
showcase displayed the wrong text. Added a `failure-reply` helper that builds the
canonical envelope (mirroring what `:rf.http/managed-canned-failure` actually
delivers on a 4xx) and drove both variants through it. Kept as plain data — the
helper is evaluated at registration time, so no function slot lands in a variant.

## rf2-mil5fy (P3) — Linearlite fail-next-write toggle
`examples/capabilities/resources/linearlite/core.cljs`

The "Fail the next write" toggle stores `:fail-next-write?` in **app-db** (via
`:linearlite/set-fail-next-write`, a plain db-in/db-out handler), but the demo HTTP
stub read the flag off the `:rf.db/runtime` partition — where it never lives — so
`fail?` was always false and the simulated 503 rollback never fired in the browser.
`frame-state-value` returns `{:rf.db/app … :rf.db/runtime …}`; the stub now reads
`:rf.db/app`, so arming the toggle drives the optimistic-apply → request → rollback
arc the example exists to demonstrate.

## rf2-9uxqha (P3) — silent invalid-login submissions
`examples/substrates/uix/login/core.cljs`, `examples/substrates/helix/login/core.cljs`,
`examples/core/login/core.cljs`

A short-password (or bad-email) draft was rejected by the machine's `:submit`
event-schema boundary **after** `:auth.login/submit-form` had already cleared the
password and flipped the slice to `:submitting`. Since the views render only machine
errors (never set — the machine never transitions), the submit was silently
swallowed: the password field blanked and nothing happened.

Fix: `:auth.login/submit-form` now validates the draft against the same `Credentials`
schema the boundary enforces (`m/explain` + `me/humanize`, exactly the pure validator
in `docs/core/how-to/build-a-form.md`). Clean draft submits as before; an invalid one
lands per-field errors in `:errors`, keeps the password for the fixup, and does not
dispatch. The views render `:auth.login/field-error` under each input. `:submit-attempted?`
latches either way, so the visibility rule lights every invalid field on the first
submit press. (malli 0.20.1 is already on the example classpath via `re-frame.schemas`.)

**Scope note (please review):** the bead named UIx/Helix. I applied the identical
change to the reagent reference (`examples/core/login/core.cljs`) as well, because the
three login examples share a **byte-for-byte-identical** substrate-agnostic layer
(the files document this prominently) that this fix modifies. Fixing only two would
have broken that invariant and left the same latent silent-rejection bug in the
reference example. No other in-flight worker touches `core/login/core.cljs` (zpngom
touches `stories.cljs` in the same dir). The reagent login contract test
(`implementation/adapters/reagent/test/re_frame/login_cljs_test.cljs`) dispatches
directly to the machine with valid creds and bypasses `submit-form`, so it is
unaffected. Split/revert the core change if you prefer strict bead scope.

## Quality gates

Focused checks only (fresh worktree has no `node_modules`; full `test-fast-pr.sh`
spine + `npm install` is very slow):

- `clj-kondo --lint` on all 5 changed files — **PASS** (errors: 0; one pre-existing
  `status-labels` unused-var warning in linearlite, outside this change).
- malli on classpath — **CONFIRMED** (`clojure -Spath` → `metosin/malli/0.20.1`),
  so the new `[malli.core]` / `[malli.error]` requires resolve at CLJS compile time.
- Behaviour reasoned through end-to-end for each fix.

**Deferred to CI** (fresh-worktree `npm install` too slow to run locally):
full `test-fast-pr.sh` spine, the shadow-cljs example builds (`:examples/login`,
`:examples/login-uix`, `:examples/login-helix`, `:examples/linearlite`,
`:examples/login-with-stories`), and `npm run test:adapter-smokes`.

Examples remain test-free (locked convention): no `*.spec.cjs` added under `examples/`.

## Stance
Pre-alpha, no back-compat shims; ELEGANCE + CLARITY + CORRECTNESS + GOOD PRACTICE;
avoid over-engineering.
