### PR TITLE
fix(xray): preserve explicit-nil resource params + machines-viz parallel-region cofx (rf2-7iw0bw +1)

### DIFF
--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout.cljc
@@ -150,21 +150,33 @@
       :else      (recur (get-in node [:states (first p)]) (next p)))))
 
 (defn raw-node-at
-  "Return the RAW (pre-projection) state-node map for `path` within machine
-  `definition`, or nil. For a flat / compound machine the path resolves
-  within `(:states definition)`. For a parallel machine a node `:path` is
-  IN-REGION (region-relative — the region-id is NOT part of the path, per
-  `project-parallel`'s in-region `:path` preservation), so we try every
-  region's `:states` body and return the first hit. A synthetic node (the
-  machine-root / region-container — empty or single-id path with no raw
-  match) resolves to nil. Used to recover a node's ORIGINAL `:entry` /
+  "Return the RAW (pre-projection) state-node map for the projected `node`
+  within machine `definition`, or nil. Resolution is REGION-AWARE
+  (rf2-6l01c8): a projected node carrying an explicit `:region` resolves
+  STRICTLY within that region's `[:regions <region> :states]` body using its
+  IN-REGION `:path` (region-relative — the region-id is NOT part of the path,
+  per `project-parallel`'s in-region `:path` preservation). Two parallel
+  regions can share the SAME in-region state path, so a cross-region scan
+  would return the WRONG region's raw node and mis-attribute its `:entry` /
+  `:exit` refs — and thus the surfaced `:rf.cofx/requires` — onto another
+  region's node. A NON-region node (flat / compound machine, or a parallel
+  root) resolves within `(:states definition)`, with the legacy region-scan
+  fallback preserved ONLY for the no-`:region` shape. A synthetic node (the
+  machine-root / region-container — empty path, or an in-region path with no
+  raw match) resolves to nil. Used to recover a node's ORIGINAL `:entry` /
   `:exit` keyword refs (the projection rewrote them to `name-of` strings)."
-  [definition path]
+  [definition {:keys [path region]}]
   (when (seq path)
-    (or (node-at-in-states (:states definition) path)
-        (some (fn [[_region region-def]]
-                (node-at-in-states (:states region-def) path))
-              (:regions definition)))))
+    (if region
+      ;; region-aware: pin the node to its OWN region's states — never a
+      ;; sibling region that happens to share the in-region path.
+      (node-at-in-states (:states (get-in definition [:regions region])) path)
+      ;; non-region node: top-level states, with the legacy region-scan
+      ;; fallback kept for the no-`:region` shape.
+      (or (node-at-in-states (:states definition) path)
+          (some (fn [[_region region-def]]
+                  (node-at-in-states (:states region-def) path))
+                (:regions definition))))))
 
 (defn requirement-label
   "Render one `:rf.cofx/requires` entry (Spec 002 §`parse-requires` grammar:
@@ -245,7 +257,8 @@
 
   Nodes need the ORIGINAL `:entry` / `:exit` keyword ref, which `collect-
   nodes` already rewrote to a `name-of` STRING; we re-resolve it against
-  the raw definition by node `:path` via `raw-node-at`."
+  the raw definition via `raw-node-at`, passing the whole node so the lookup
+  is region-aware (its `:region` + in-region `:path`, rf2-6l01c8)."
   [definition graph]
   (let [guards  (:guards definition)
         actions (:actions definition)]
@@ -259,7 +272,7 @@
                   (fn [nodes]
                     (mapv (fn [n]
                             (attach-node-requires
-                              actions (raw-node-at definition (:path n)) n))
+                              actions (raw-node-at definition n) n))
                           nodes)))))))
 
 (defn- resolve-target-path

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
@@ -3719,3 +3719,50 @@
       (is (some? ev))
       (is (nil? (:guardRequires (:data ev))))
       (is (nil? (:actionRequires (:data ev)))))))
+
+;; ---- lifecycle requires are region-aware (rf2-6l01c8) ------------------
+;;
+;; Two parallel regions can share the SAME in-region state path. The
+;; raw-node lookup that recovers a node's `:entry`/`:exit` refs (to surface
+;; the declared `:rf.cofx/requires`) must key off the node's OWN `:region`,
+;; not the first region whose in-region path matches. Pre-fix it scanned
+;; regions and returned the FIRST hit, so region B's node was decorated with
+;; region A's `:entryRequires`/`:exitRequires` — a lifecycle cofx displayed
+;; against the wrong parallel region.
+
+(def cofx-parallel-dup-machine
+  "A `:type :parallel` machine whose regions `:a` and `:b` each own a state
+  named `:active` (identical in-region path `[:active]`) with DISTINCT entry
+  / exit actions declaring DISTINCT `:rf.cofx/requires`. The fix must resolve
+  each `:active` node's lifecycle refs within its OWN region."
+  {:type    :parallel
+   :actions {:a-enter {:rf.cofx/requires [:region-a/enter-fact] :fn (fn [_] nil)}
+             :a-exit  {:rf.cofx/requires [:region-a/exit-fact]  :fn (fn [_] nil)}
+             :b-enter {:rf.cofx/requires [:region-b/enter-fact] :fn (fn [_] nil)}
+             :b-exit  {:rf.cofx/requires [:region-b/exit-fact]  :fn (fn [_] nil)}}
+   :regions {:a {:initial :active
+                 :states  {:active {:entry :a-enter :exit :a-exit}}}
+             :b {:initial :active
+                 :states  {:active {:entry :b-enter :exit :b-exit}}}}})
+
+(deftest lifecycle-requires-resolve-per-parallel-region
+  (testing "rf2-6l01c8 — duplicate-named parallel-region states carry their
+            OWN region's :entryRequires / :exitRequires on the xyflow node
+            :data, never a sibling region's"
+    (let [parsed  (layout/project-definition cofx-parallel-dup-machine)
+          graph   (projection/xyflow-graph parsed {} {})
+          a-active (node-by-id graph (layout/region-scoped-id :a [:active]))
+          b-active (node-by-id graph (layout/region-scoped-id :b [:active]))]
+      (is (some? a-active) "region :a's :active node projects")
+      (is (some? b-active) "region :b's :active node projects")
+      ;; region :a's node carries ONLY region :a's lifecycle requires
+      (is (= ["region-a/enter-fact"] (:entryRequires (:data a-active)))
+          "region :a entry requires resolve within region :a")
+      (is (= ["region-a/exit-fact"]  (:exitRequires (:data a-active)))
+          "region :a exit requires resolve within region :a")
+      ;; region :b's node carries ONLY region :b's lifecycle requires — the
+      ;; pre-fix cross-region scan would have shown region :a's here
+      (is (= ["region-b/enter-fact"] (:entryRequires (:data b-active)))
+          "region :b entry requires resolve within region :b, not region :a's")
+      (is (= ["region-b/exit-fact"]  (:exitRequires (:data b-active)))
+          "region :b exit requires resolve within region :b, not region :a's"))))

--- a/tools/xray/spec/024-Resources-Panel.md
+++ b/tools/xray/spec/024-Resources-Panel.md
@@ -135,9 +135,12 @@ Two elision layers compose:
    redacted. The **raw scoped key is the row identity** (never egressed in
    place) so two entries whose scope/params redact to the same sentinel
    cannot collapse into one. `get-resource-state` requires the **full**
-   scoped key (`:resource-id` + `:scope` + `:params`); any missing part
-   fails closed with `:reason :missing-key` (a partial key cannot address
-   an entry). `get-resource-state` resolves that full key the SAME way
+   scoped key (`:resource-id` + `:scope` + `:params`) **by key presence,
+   not value** (rf2-7iw0bw): an axis ABSENT from the call fails closed with
+   `:reason :missing-key` (a partial key cannot address an entry), but an
+   axis present with an explicit **nil** value (e.g. `:params nil`) is a
+   valid key part that addresses the nil-params entry — distinct from the
+   wildcard, never coerced to missing. `get-resource-state` resolves that full key the SAME way
    `list-resource-instances` selects its raw entries — by scanning
    `:entries` and matching each candidate's `:resource/key` stamp (see the
    byte-key-id paragraph below), never by a direct map-key lookup on the
@@ -551,7 +554,12 @@ matching the candidate set in Spec 016 §Xray and AI tooling. All are
 
 `:scope` / `:resource-id` / `:params` filter against the raw cache key
 **before** projection (so an accessor can scope its read by the cache
-key); the remaining axes filter the already-projected rows. Per EP-0002
+key); the remaining axes filter the already-projected rows. These three
+key axes match **by presence** (rf2-7iw0bw): an OMITTED axis is a wildcard,
+while an axis supplied with an explicit **nil** value is an EXACT match
+against a nil-valued key part (a nil-params resource stays addressable and
+distinct from "any params") — never widened to a match-everything wildcard.
+Per EP-0002
 the frame target is carried explicitly — a frameless call with no
 resolvable context fails closed (`{:ok? false :reason
 :no-frame-resolved}`).

--- a/tools/xray/src/day8/re_frame2_xray/panels/resources_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/resources_helpers.cljc
@@ -1719,7 +1719,14 @@
 (defn- scoped-key-matches?
   "Does the scoped key `[scope rid params]` match the supplied filter
   axes? `scope` / `resource-id` / `params` are compared against the RAW
-  key parts; a nil filter axis is a wildcard.
+  key parts by KEY PRESENCE (rf2-7iw0bw): an axis ABSENT from the filter
+  map is a wildcard; an axis PRESENT — even bound to nil — is an EXACT
+  match. An explicit `:params nil` therefore matches ONLY entries whose
+  scoped key carries nil params, keeping a nil-params resource addressable
+  and DISTINCT from the wildcard. The prior `nil?` test conflated an absent
+  axis with a present-nil one, so an explicit nil scope/params silently
+  widened to a match-everything wildcard (and, for the exact-read accessor,
+  a nil-params entry could never be pinned).
 
   rf2-9e0tyq / rf2-hgy5kf: the `:entries` map is keyed on the opaque CEDN-1
   byte `key-id` STRING, so the kind-preserving `[scope rid params]` scoped-key
@@ -1727,13 +1734,13 @@
   the map key for a legacy entry that lacks the stamp) — exactly as
   `instance-row` projects. Matching the map key directly would silently match
   NOTHING for live byte-keyed runtime data."
-  [scoped-key {:keys [scope resource-id params]}]
+  [scoped-key {:keys [scope resource-id params] :as key-filter}]
   (let [[ks krid kparams] (if (and (vector? scoped-key) (= 3 (count scoped-key)))
                             scoped-key
                             [nil nil nil])]
-    (and (or (nil? scope)       (= scope ks))
-         (or (nil? resource-id) (= resource-id krid))
-         (or (nil? params)      (= params kparams)))))
+    (and (or (not (contains? key-filter :scope))       (= scope ks))
+         (or (not (contains? key-filter :resource-id)) (= resource-id krid))
+         (or (not (contains? key-filter :params))      (= params kparams)))))
 
 (defn filter-instance-rows
   "Filter projected instance rows by the tool-accessor axes (Spec 016):

--- a/tools/xray/src/day8/re_frame2_xray/runtime.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/runtime.cljs
@@ -1057,18 +1057,22 @@
   Returns `{:ok? true :frame <id> :instances [<row> …] :count N}` or
   `{:ok? false :reason :no-frame-resolved}`."
   ([] (list-resource-instances nil))
-  ([{:keys [frame scope resource-id params status stale? tag owner request-id
-            include-sensitive? include-large? include-runtime-db?] :as _opts}]
+  ([{:keys [frame resource-id status stale? tag owner request-id
+            include-sensitive? include-large? include-runtime-db?] :as opts}]
    (let [fid (resolve-frame frame)]
      (if-let [fail (frame-failure frame fid)]
        fail
        (let [runtime-db  (:rf.db/runtime (rf/frame-state-value fid))
              all-entries (get-in runtime-db resources-helpers/entries-rel-path)
              ;; upstream key-filter BEFORE projection (scope/resource-id/params
-             ;; against the raw cache key)
+             ;; against the raw cache key). By KEY PRESENCE (rf2-7iw0bw): an
+             ;; OMITTED axis is a wildcard, while an explicit `:params nil` is
+             ;; an EXACT match on nil-params entries — NOT a match-everything
+             ;; wildcard. `select-keys` keeps only the axes the caller actually
+             ;; supplied, so absent stays wildcard and present-nil stays exact.
              entries     (resources-helpers/select-raw-entries
                            all-entries
-                           {:scope scope :resource-id resource-id :params params})
+                           (select-keys opts [:scope :resource-id :params]))
              egress-opts {:include-sensitive?  include-sensitive?
                           :include-large?      include-large?
                           :include-runtime-db? include-runtime-db?
@@ -1116,9 +1120,12 @@
   call with no resolvable context fails closed.
 
   Required scoped-key parts: `:resource-id` AND `:scope` AND `:params`.
-  Any missing part fails closed with `:reason :missing-key` (a partial key
-  cannot address an entry — Spec 016 §Introspection: the scoped key is the
-  full `[scope resource-id params]` triple).
+  Requiredness is by KEY PRESENCE, not value (rf2-7iw0bw): an ABSENT axis
+  fails closed with `:reason :missing-key` (a partial key cannot address an
+  entry — Spec 016 §Introspection: the scoped key is the full `[scope
+  resource-id params]` triple), but an axis PRESENT with an explicit nil
+  value (e.g. `:params nil`) is a VALID key part that addresses the
+  nil-params entry — distinct from the wildcard, never coerced to missing.
 
   Returns `{:ok? true :frame <id> :state <instance-row>}` (the row
   carries the PRIVACY-summarized status/data/error projection — Spec 016
@@ -1134,7 +1141,8 @@
   generation / timestamps) is NEVER redacted — a redacted summary STILL
   exposes the metadata (the EP-0003 contract)."
   [{:keys [frame resource-id scope params
-           include-sensitive? include-large? include-runtime-db?]}]
+           include-sensitive? include-large? include-runtime-db?]
+    :as opts}]
   (let [fid  (resolve-frame frame)
         fail (frame-failure frame fid)]
     (cond
@@ -1142,8 +1150,14 @@
 
       ;; A scoped key is the full [scope resource-id params] triple — any
       ;; missing part cannot address an entry (rf2-tgm1xu: missing scope or
-      ;; params reports :missing-key, not a silent nil-key probe).
-      (or (nil? resource-id) (nil? scope) (nil? params))
+      ;; params reports :missing-key, not a silent nil-key probe). Presence,
+      ;; NOT nil?, is the test (rf2-7iw0bw): an explicit `:params nil` is a
+      ;; VALID key part addressing a nil-params entry, so only an ABSENT
+      ;; axis fails closed — an explicit nil is preserved through to the
+      ;; exact select-raw-entries match below.
+      (not (and (contains? opts :resource-id)
+                (contains? opts :scope)
+                (contains? opts :params)))
       {:ok? false :reason :missing-key
        :hint "Pass :resource-id + :scope + :params (the full scoped key)."}
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/resources_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/resources_helpers_cljs_test.cljc
@@ -1260,3 +1260,54 @@
       (is (= 2 (count (h/filter-history-rows timeline-rows {:limit 2}))))
       (is (= 1 (count (h/filter-history-rows timeline-rows
                         {:resource-id :article/by-slug :limit 1})))))))
+
+;; ---- (9b) explicit-nil params preserved (rf2-7iw0bw) --------------------
+;;
+;; A resource registered with NO params has the kind-preserving scoped key
+;; `[scope resource-id nil]`. The key-axis filter must treat an explicit
+;; `:params nil` as an EXACT match on that nil-params entry — distinct from
+;; an OMITTED `:params` axis (a wildcard). The prior `nil?` test conflated
+;; the two, so an explicit nil silently widened to match every entry and a
+;; nil-params entry could never be pinned exactly.
+
+(def ^:private nilparams-entries
+  (byte-keyed
+    {;; the nil-params entry — a resource read with no params
+     [session-scope :article/current nil]
+     {:resource/id :article/current :status :loaded
+      :data {:title "Current"} :generation 1
+      :active-owners #{} :tags #{}}
+     ;; a DISTRACTOR under the SAME resource-id but with real params
+     [session-scope :article/current {:slug "welcome"}]
+     {:resource/id :article/current :status :loaded
+      :data {:title "Welcome"} :generation 2
+      :active-owners #{} :tags #{}}}))
+
+(deftest select-raw-entries-preserves-explicit-nil-params-test
+  (testing "explicit `:params nil` is an EXACT match on the nil-params entry,
+            NOT a wildcard (rf2-7iw0bw)"
+    ;; the fixture holds exactly one nil-params entry + one real-params entry
+    ;; under the same resource-id
+    (is (= 2 (count nilparams-entries)))
+    (let [sel (h/select-raw-entries nilparams-entries {:params nil})]
+      (is (= 1 (count sel))
+          "explicit nil params selects ONLY the nil-params entry, not both")
+      (is (= [session-scope :article/current nil]
+             (:resource/key (first (vals sel))))
+          "the selected entry is the nil-params one"))
+    ;; the real-params filter still selects only the real-params entry
+    (let [sel (h/select-raw-entries nilparams-entries {:params {:slug "welcome"}})]
+      (is (= 1 (count sel)))
+      (is (= [session-scope :article/current {:slug "welcome"}]
+             (:resource/key (first (vals sel)))))))
+  (testing "an OMITTED :params axis stays a wildcard — presence, not value,
+            decides (rf2-7iw0bw)"
+    ;; resource-id present, params ABSENT → both entries match (wildcard)
+    (is (= 2 (count (h/select-raw-entries nilparams-entries
+                      {:resource-id :article/current}))))
+    ;; the empty filter matches everything
+    (is (= 2 (count (h/select-raw-entries nilparams-entries {})))))
+  (testing "explicit nil params + a NON-matching scope still filters exactly"
+    ;; nil params AND a scope that no entry carries → no match
+    (is (empty? (h/select-raw-entries nilparams-entries
+                  {:scope :rf.scope/global :params nil})))))

--- a/tools/xray/test/day8/re_frame2_xray/runtime_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/runtime_cljs_test.cljs
@@ -1451,6 +1451,83 @@
       (is (= :error (:status (:state r2)))))))
 
 ;; ---------------------------------------------------------------------------
+;; rf2-7iw0bw — an EXPLICIT nil params is a VALID scoped-key part, preserved
+;; (not coerced to :missing-key, not widened to a wildcard).
+;; ---------------------------------------------------------------------------
+;;
+;; A resource read with no params has scoped key `[scope resource-id nil]`.
+;; The accessors key off KEY PRESENCE, not `nil?`: an explicit `:params nil`
+;; addresses the nil-params entry exactly, while OMITTING `:params` still
+;; fails closed (get-resource-state) / stays a wildcard (list-resource-
+;; instances). The pre-fix `nil?` test conflated the two — an explicit nil
+;; either reported :missing-key or matched every entry.
+
+(def ^:private nilparams-key [tgm1xu-scope :article/current nil])
+
+(def ^:private nilparams-entry
+  {:resource/id   :article/current
+   :status        :loaded
+   :data          {:title "Current"}
+   :error         nil
+   :generation    1
+   :request-id    [:w 7]
+   :active-owners #{}
+   :tags          #{}
+   :loaded-at     900000
+   :stale-at      9999999999999})
+
+;; a DISTRACTOR under the SAME scope + resource-id but with REAL params, so
+;; the fix must resolve by the FULL key (incl. the nil params), not by
+;; resource-id alone.
+(def ^:private nilparams-distractor-key [tgm1xu-scope :article/current {:slug "welcome"}])
+(def ^:private nilparams-distractor-entry
+  (assoc nilparams-entry :generation 2 :request-id [:w 8]
+         :data {:title "Welcome"}))
+
+(deftest get-resource-state-preserves-explicit-nil-params
+  (testing "rf2-7iw0bw — an explicit `:params nil` resolves the nil-params
+            entry (NOT :missing-key), even alongside a real-params distractor"
+    (seed-resource-entries! {nilparams-key            nilparams-entry
+                             nilparams-distractor-key nilparams-distractor-entry})
+    (let [r (runtime/get-resource-state
+              {:resource-id :article/current
+               :scope       tgm1xu-scope
+               :params      nil})]
+      (is (true? (:ok? r)) "explicit nil params is a valid key, not :missing-key")
+      (is (= [:w 7] (:request-id (:state r)))
+          "resolves THE nil-params entry, not the real-params distractor")))
+  (testing "rf2-7iw0bw — OMITTING :params still fails closed with :missing-key
+            (presence, not value, is the test)"
+    (seed-resource-entries! {nilparams-key nilparams-entry})
+    (let [r (runtime/get-resource-state
+              {:resource-id :article/current
+               :scope       tgm1xu-scope})]
+      (is (false? (:ok? r)))
+      (is (= :missing-key (:reason r))
+          "an ABSENT :params axis is still a partial key"))))
+
+(deftest list-resource-instances-preserves-explicit-nil-params
+  (testing "rf2-7iw0bw — an explicit `:params nil` filter lists ONLY the
+            nil-params entry, not the real-params distractor (not a wildcard)"
+    (seed-resource-entries! {nilparams-key            nilparams-entry
+                             nilparams-distractor-key nilparams-distractor-entry})
+    (let [r (runtime/list-resource-instances
+              {:resource-id :article/current
+               :scope       tgm1xu-scope
+               :params      nil})]
+      (is (true? (:ok? r)))
+      (is (= 1 (:count r)) "explicit nil params is exact, matching one entry")
+      (is (= [:w 7] (:request-id (first (:instances r))))
+          "the listed row is the nil-params entry")))
+  (testing "rf2-7iw0bw — OMITTING :params stays a wildcard (both entries)"
+    (seed-resource-entries! {nilparams-key            nilparams-entry
+                             nilparams-distractor-key nilparams-distractor-entry})
+    (let [r (runtime/list-resource-instances
+              {:resource-id :article/current
+               :scope       tgm1xu-scope})]
+      (is (= 2 (:count r)) "absent params axis matches every entry (wildcard)"))))
+
+;; ---------------------------------------------------------------------------
 ;; rf2-aw9cfs — resource payload egress paths thread the entry's key-id, so a
 ;; REAL lowered `:sensitive?` / `:large?` declaration (the resources
 ;; artefact's per-instance registry lowering,


### PR DESCRIPTION
Two correctness fixes on the xray-family tools surface.

## rf2-7iw0bw — preserve explicit-nil resource params (tools/xray)

The resource key-axis matcher (`scoped-key-matches?`) and the exact-read
accessor (`get-resource-state`) tested each key axis with `nil?`, conflating
an **absent** axis with one **present but bound to nil**. A resource read
with no params has scoped key `[scope resource-id nil]`; an explicit
`:params nil` therefore either widened to a match-everything wildcard
(`list-resource-instances` / the shared filter) or reported `:missing-key`
(`get-resource-state`) — a nil-params entry could never be pinned exactly,
nor kept distinct from "any params".

Fix: all three key axes (`:scope`/`:resource-id`/`:params`) now match by
**key presence** — absent = wildcard, present (even nil) = exact.
`get-resource-state` fails closed only on an absent axis; `list-resource-
instances` builds its key-filter via `select-keys` so an omitted axis stays
wildcard while `:params nil` stays exact. Spec 024-Resources-Panel updated.

## rf2-6l01c8 — parallel-region-aware lifecycle cofx (tools/machines-viz)

`raw-node-at` recovered a node's `:entry`/`:exit` refs (to surface their
`:rf.cofx/requires`) by scanning every region's `:states` for the node's
in-region `:path` and returning the FIRST hit. Two parallel regions can
share the same in-region state path, so a region's node was decorated with
the FIRST matching region's `:entryRequires`/`:exitRequires` — a lifecycle
cofx shown against the wrong region.

Fix: a projected node carrying an explicit `:region` resolves STRICTLY
within `[:regions <region> :states]` via its in-region `:path`; the legacy
top-level + region-scan fallback is kept only for the no-`:region` shape.

## Tests (adversarial, verified they fail pre-fix)

- xray: `select-raw-entries` distinguishes explicit `:params nil` (matches
  only the nil-params entry) from an omitted axis (wildcard); runtime
  `get-resource-state`/`list-resource-instances` resolve/list a nil-params
  entry under `:params nil` alongside a real-params distractor, while an
  omitted `:params` still fails closed / stays wildcard. Verified the `.cljc`
  helper test fails under the old `nil?` matcher (matched 2, not 1).
- machines-viz: `:type :parallel` machine with duplicate-named `:active`
  states across regions `:a`/`:b`, distinct entry/exit `:rf.cofx/requires`;
  asserts each region's xyflow node `:data` carries its OWN requirements.
  Verified it fails under the region-blind lookup (region :b showed region
  :a's facts).

## Quality gates

| Command | Result |
|---|---|
| `cd tools/xray && clojure -M:test` | PASS — 1232 tests, 5695 assertions, 0 failures/errors |
| `cd tools/machines-viz && clojure -M:test` | PASS — 569 tests, 2024 assertions, 0 failures/errors |

The xray `runtime.cljs` accessor edits are `.cljs`, exercised only by the
consolidated `:node-test` build (`npm run test:cljs`); the full
`test-fast-pr.sh` spine (incl. the node-test build) is **deferred to CI** per
worker gate discipline (fresh-worktree npm install is very slow). The heart
of the xray fix — the `scoped-key-matches?` matcher — is `.cljc` and green on
the JVM gate above.

## Stance

Pre-alpha, no back-compat shims; ELEGANCE + CLARITY + CORRECTNESS + GOOD
PRACTICE; no over-engineering. Both changes are minimal, presence/identity-
correct, and add one solid adversarial regression each.

Spec: tools/xray/spec/024-Resources-Panel.md updated for rf2-7iw0bw. For
rf2-6l01c8 the machines-viz spec is unchanged — the fix restores the
already-specified per-region lifecycle-requirement contract (Spec 005
orthogonal-region identity; tools/xray Spec 009 unaffected), not a new
surface.
