### PR TITLE
fix(core): no-handler epoch, registrar rollback, flow-target normalization (rf2-erczwd +2)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -1784,7 +1784,22 @@
         ;; `:sensitive` and `:large` frame keys now fail loud.)
         _              (when-let [validate (late-bind/get-fn
                                             :frame-classification/validate!)]
-                         (validate id config))]
+                         (validate id config))
+        existing       (get @frames id)
+        ;; rf2-hhlzky: construct the frame record BEFORE any process-global
+        ;; write (the registrar row + the trace-suppression flags below).
+        ;; `new-frame-record` calls `adapter/make-state-container`, which THROWS
+        ;; (`:rf.error/no-adapter-installed` / `:rf.error/adapter-disposed`) when
+        ;; no adapter is installed — a `reg-frame` issued before `rf/init!` or
+        ;; after `destroy-adapter!`. Building the record here means such a
+        ;; construction failure escapes this `let` BEFORE `registrar/register!`
+        ;; and `trace/set-frame-no-emit!` run, so a frame that never came into
+        ;; existence leaves NO registrar row and NO trace-disabled residue (which
+        ;; would otherwise persist with no destroy path to clear it). This is the
+        ;; DEFER form of the rollback the bead calls for — there is nothing to
+        ;; unwind because nothing was written. Re-registration is a surgical
+        ;; update (no container is built), so `new-record` is nil there.
+        new-record     (when (nil? existing) (new-frame-record id config))]
     (registrar/register! :frame id config)
     ;; Frame-level trace-emission gate: a frame registered
     ;; with `:rf.trace/frame-no-emit? true` is a tool / inspector frame
@@ -1807,11 +1822,11 @@
       (when-let [set-retained! (late-bind/get-fn-cached
                                 :trace.tooling/set-frame-events-retained!)]
         (set-retained! id (:rf.trace/events-retained config))))
-    (let [existing (get @frames id)]
-      (cond
-        ;; First registration: create everything.
+    (cond
+        ;; First registration: install the record built above (rf2-hhlzky —
+        ;; construction already succeeded, so the writes above are safe).
         (nil? existing)
-        (let [f (new-frame-record id config)]
+        (let [f new-record]
           (swap! frames assoc id f)
           ;; EP-0025: there is no durable app-db classification install here
           ;; anymore — the frame `:sensitive` / `:large {:app-db …}` annotation
@@ -1923,7 +1938,7 @@
           (trace/emit! :rf.frame :rf.frame/re-registered
                        {:frame id :config stored-config})
           (fire-frame-registered-hook! id)
-          id)))))
+          id))))
 
 (defn make-anon-frame-record!
   "INTERNAL anonymous-instance creation (EP-0024): generate a

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -2808,7 +2808,12 @@
 
   `settle!` itself skips an empty buffer (a rejected/aborted dispatch that
   never fired `:event/run-start`), so a no-handler / frame-destroyed early
-  exit commits no misleading record.
+  exit commits no misleading record. rf2-erczwd: a rejected dispatch still
+  buffers a frame-stamped, dispatch-id-bearing ERROR trace (`:no-such-handler`
+  / `:frame-destroyed`), so the buffer is NOT empty at this seam. Threading the
+  settling envelope's `:dispatch-id` lets the scoped no-run-start harvest drop
+  THAT dispatch's own traces — so the skip fires and no fake `:ok` epoch lands
+  — while any unrelated buffered child marker survives for its own settle.
 
   EP-0001 (rf2-3aizt1, decision #2): `frame-state-before` / `frame-state-after`
   are whole frame-state values (both partitions); `build-record` derives the
@@ -2819,9 +2824,9 @@
   Threaded into the epoch record's `:committed-at` so the durable
   causal-time fact is replayable per EP-0010 §Time / Spec 002 §Recordable
   coeffects, not an ambient assembly-time host-clock read."
-  [frame-id frame-state-before frame-state-after committed-at]
+  [frame-id frame-state-before frame-state-after committed-at settling-dispatch-id]
   (when-let [settle! (late-bind/get-fn-cached :epoch/settle!)]
-    (settle! frame-id frame-state-before frame-state-after committed-at)))
+    (settle! frame-id frame-state-before frame-state-after committed-at settling-dispatch-id)))
 
 ;; ---- drain-loop! phases ---------------------------------------------------
 ;;
@@ -3016,7 +3021,13 @@
                     frame/*run-time-ms*            time-ms]
             (process-event! envelope))
           (let [fs-after (frame/frame-state-value frame-id)]
-            (settle-event-epoch! frame-id fs-before fs-after time-ms))
+            ;; rf2-erczwd: thread the settling envelope's :dispatch-id so a
+            ;; rejected/aborted dispatch (no-handler / frame-destroyed) whose
+            ;; only buffered emit is its own dispatch-id-bearing error trace
+            ;; commits no fake :ok epoch — the scoped no-run-start harvest drops
+            ;; that trace, and settle!'s empty-buffer skip fires.
+            (settle-event-epoch! frame-id fs-before fs-after time-ms
+                                  (:dispatch-id envelope)))
           (let [event    (:event envelope)
                 ;; rf2-fcbrjo: append this settled event's id to the bounded
                 ;; cycle-evidence ring (ids only; drop the head past K).

--- a/implementation/core/test/re_frame/frame_lifecycle_test.clj
+++ b/implementation/core/test/re_frame/frame_lifecycle_test.clj
@@ -594,6 +594,36 @@
       (is (nil? (frame/frame :child))
           "the just-created child container was torn back down — no half-registered frame"))))
 
+(deftest reg-frame-construction-failure-leaves-no-registrar-or-trace-residue
+  (testing "rf2-hhlzky — a reg-frame whose frame CONSTRUCTION fails (no adapter
+            installed: reg-frame before rf/init!) leaves NO registrar row and NO
+            trace-disabled residue. `new-frame-record` (which calls
+            make-state-container) is built BEFORE the registrar / trace-
+            suppression writes, so a construction throw escapes before any
+            process-global metadata is written — nothing to roll back."
+    (let [fid :test/no-adapter-frame]
+      ;; Cold-start the adapter lifecycle to the never-installed state so
+      ;; make-state-container raises :rf.error/no-adapter-installed — the exact
+      ;; "reg-frame before rf/init!" scenario the bead names. The test frame
+      ;; carries :rf.trace/frame-no-emit? true, whose set-frame-no-emit! write
+      ;; is the trace residue we assert never lands.
+      (adapter/reset-lifecycle-state-for-tests!)
+      (let [thrown-id (try (rf/reg-frame fid {:rf.trace/frame-no-emit? true})
+                           nil
+                           (catch clojure.lang.ExceptionInfo e
+                             (:rf.error/id (ex-data e))))]
+        (is (= :rf.error/no-adapter-installed thrown-id)
+            "construction fails loud with the no-adapter throw (frame never built)"))
+      ;; No half-registered process-global state survives the failed build:
+      (is (nil? (registrar/lookup :frame fid))
+          "no :frame registrar row was written for the frame that failed to build")
+      (is (nil? (frame/frame fid))
+          "no frame record landed in the frames atom")
+      (is (false? (trace/frame-trace-disabled? fid))
+          "no trace-disabled residue — set-frame-no-emit! never ran for the failed frame")
+      ;; Restore a working adapter so the fixture teardown / next test are clean.
+      (rf/init! plain-atom/adapter))))
+
 (deftest top-level-reg-frame-initial-events-runs-synchronously
   (testing "Top-level reg-frame (NOT inside a handler) runs :initial-events
             synchronously — the fast path is preserved (EP-0027 §Construction)"

--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -352,6 +352,16 @@
       `:ok` as `outcome` explicitly. Skips recording when the captured
       buffer is empty (a truly empty cascade — likely a rejected
       dispatch — is degenerate and would emit a misleading record).
+    (settle! frame-id frame-state-before frame-state-after committed-at settling-dispatch-id)
+      Clean per-event settle threading the settling ENVELOPE's dispatch-id —
+      the arity the ROUTER's per-event seam (`settle-event-epoch!`) calls.
+      `settling-dispatch-id` scopes the NO-RUN-START harvest (rf2-erczwd): a
+      rejected / aborted dispatch (no-handler / frame-destroyed) emits a
+      frame-stamped, dispatch-id-bearing error trace that buffers but fired no
+      `:event/run-start`; the harvest drops THAT dispatch's own traces so the
+      empty-buffer skip suppresses the misleading `:ok` epoch, while an
+      unrelated buffered child marker survives for its own settle. `:outcome`
+      is `:ok`.
     (settle! frame-id frame-state-before frame-state-after committed-at outcome halt-reason)
       Drain-boundary commit with explicit outcome. The runtime commits
       one of three outcomes: `:ok` / `:halted-depth` / `:halted-destroy`
@@ -389,8 +399,12 @@
   synthesises the halting event's trigger explicitly while `settle!` lets
   `build-record` derive it from the harvested buffer."
   ([frame-id frame-state-before frame-state-after committed-at]
-   (settle! frame-id frame-state-before frame-state-after committed-at :ok nil))
+   (settle! frame-id frame-state-before frame-state-after committed-at :ok nil nil))
+  ([frame-id frame-state-before frame-state-after committed-at settling-dispatch-id]
+   (settle! frame-id frame-state-before frame-state-after committed-at :ok nil settling-dispatch-id))
   ([frame-id frame-state-before frame-state-after committed-at outcome halt-reason]
+   (settle! frame-id frame-state-before frame-state-after committed-at outcome halt-reason nil))
+  ([frame-id frame-state-before frame-state-after committed-at outcome halt-reason settling-dispatch-id]
    (when interop/debug-enabled?
      ;; Per rf2-nj6p7: scoped harvest — take only the settling event's
      ;; traces (its `:dispatch-id` + pre-cascade tagalongs), LEAVING any
@@ -398,13 +412,18 @@
      ;; do-fx, carrying the child's id) in the buffer for the child's own
      ;; settle. Keeps each epoch's `:trace-events` to one `:dispatch-id`
      ;; (Spec 009 §Dispatch correlation: one dispatch-id = one epoch).
-     (let [events (state/harvest-buffer-for-event! frame-id)]
+     ;; rf2-erczwd: `settling-dispatch-id` (the router-threaded envelope id)
+     ;; scopes the NO-RUN-START branch so a rejected/aborted dispatch's own
+     ;; error trace is dropped (not returned) rather than committed as a fake
+     ;; `:ok` epoch.
+     (let [events (state/harvest-buffer-for-event! frame-id settling-dispatch-id)]
        ;; Empty-buffer policy (consistent across outcomes): an empty
        ;; capture buffer means no cascade context was recorded for
        ;; this event — skip emission rather than commit a record with
        ;; no :event-id / :trigger-event. A rejected/aborted dispatch
        ;; (no `:event/run-start` ever fired) reaches this seam with an
-       ;; empty buffer and is correctly suppressed. Halt paths whose
+       ;; empty harvest (its own traces dropped by the scoped no-run-start
+       ;; branch, rf2-erczwd) and is correctly suppressed. Halt paths whose
        ;; halting event never ran (the per-event depth-exceed boundary,
        ;; per rf2-nj6p7) use `commit-halt-record!` instead, which
        ;; synthesises the halting event's trigger explicitly.

--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -843,10 +843,12 @@
     (swap! capture-buffers dissoc frame-id)
     buffer))
 
-(defn- settling-dispatch-id
+(defn- run-start-dispatch-id
   "The `:dispatch-id` of the event being settled, read off the FIRST
   `:rf.event/run-start` emit in the buffer. nil when no run-start fired (a
-  rejected / aborted dispatch, or a halt path whose event never ran)."
+  rejected / aborted dispatch, or a halt path whose event never ran) — the
+  no-run-start branch of `harvest-buffer-for-event!` then falls back to the
+  settling ENVELOPE's dispatch-id (rf2-erczwd) to scope its drop."
   [events]
   (some (fn [ev]
           (when (= :rf.event/run-start (:operation ev))
@@ -883,8 +885,12 @@
 ;; the whole frame buffer (frame destroyed / drain-interrupted), the per-event
 ;; depth-halt `commit-halt-record!` reads-and-CLEARS the whole buffer
 ;; (`harvest-buffer!`), and a rejected/aborted child dispatch reaches the
-;; no-run-start branch below which clears-and-returns the whole buffer. Each of
-;; those wholesale-clears the stranded marker; none leaves it to accrete. The
+;; no-run-start branch below which — given the settling ENVELOPE's dispatch-id
+;; (rf2-erczwd) — drops THAT dispatch's OWN traces (the child's marker is "mine"
+;; when the child itself is the rejected settling event) plus orphans, while
+;; retaining any UNRELATED sibling's marker for its own settle. Each terminal
+;; path drops the stranded marker at the point its own dispatch is rejected /
+;; the frame torn down; none leaves it to accrete. The
 ;; nil-id orphan self-cleaning rf2-ee38b established at this same seam (an
 ;; orphan has no settle to ever claim it AND rides no terminal clear of its own)
 ;; is unchanged — orphans are still dropped here on every harvest.
@@ -916,13 +922,29 @@
   clear the whole buffer (frame destroy / drain-interrupt / depth-halt /
   rejected dispatch); see the design note above this defn.
 
-  Falls back to a full read-and-clear when the buffer carries no
-  `:event/run-start` (a rejected / aborted dispatch) — there is no
-  settling id to scope by, and `settle!`'s empty-buffer / no-trigger
-  policy handles the degenerate record."
-  [frame-id]
+  NO-RUN-START (rejected / aborted dispatch — rf2-erczwd). When the buffer
+  carries no `:event/run-start`, no cascade ran to completion, so there is
+  NOTHING legitimate to commit — a no-handler / frame-destroyed dispatch still
+  emits a frame-stamped, dispatch-id-bearing ERROR trace that lands in this
+  buffer, and returning it made `settle!` commit a misleading `:ok` epoch
+  (the no-run-start / no-epoch invariant was violated). So:
+
+    * 2-arity — given the settling ENVELOPE's `settling-dispatch-id` (threaded
+      from the router's per-event settle seam), DROP this dispatch's OWN traces
+      (`:dispatch-id` = `settling-dispatch-id`, e.g. its `:no-such-handler`
+      error trace) AND orphans (nil id), RETAIN any UNRELATED child marker
+      (`:dispatch-id` ≠ settling, non-nil) for its own settle, and RETURN [].
+      `settle!`'s empty-buffer skip then commits no epoch — the rejection's
+      own trace is dropped while a legitimately-buffered sibling marker
+      survives. Symmetric with the run-start branch's claim-based retention.
+    * 1-arity — no envelope id to scope by (a direct low-level test call);
+      falls back to a full read-and-clear returning the whole buffer, and
+      `settle!`'s empty-buffer / no-trigger policy handles the degenerate
+      record."
+  ([frame-id] (harvest-buffer-for-event! frame-id nil))
+  ([frame-id settling-dispatch-id]
   (let [buffer (get @capture-buffers frame-id [])]
-    (if-let [settling-id (settling-dispatch-id buffer)]
+    (if-let [settling-id (run-start-dispatch-id buffer)]
       ;; Three-way partition by the event's :rf.trace/dispatch-id:
       ;;   * MINE   (= event-dispatch-id settling-id)
       ;;       — the settling event's own traces; returned to ride this epoch.
@@ -973,9 +995,26 @@
           (swap! capture-buffers assoc frame-id theirs)
           (swap! capture-buffers dissoc frame-id))
         mine)
-      ;; No run-start — rejected/aborted dispatch. Clear and return all.
-      (do (swap! capture-buffers dissoc frame-id)
-          buffer))))
+      ;; No run-start — rejected/aborted dispatch (no-handler / frame-destroyed).
+      ;; No cascade ran, so nothing legitimate to commit (rf2-erczwd).
+      (if settling-dispatch-id
+        ;; Scope the drop to THIS dispatch: drop its own traces (the rejection's
+        ;; frame-stamped error trace, `:dispatch-id` = settling) + orphans, RETAIN
+        ;; any unrelated sibling marker for its own settle, RETURN [] so `settle!`
+        ;; commits no misleading `:ok` epoch. Symmetric with the run-start branch.
+        (let [theirs (filterv (fn [ev]
+                                (let [event-dispatch-id (-> ev :tags :rf.trace/dispatch-id)]
+                                  (and (some? event-dispatch-id)
+                                       (not= event-dispatch-id settling-dispatch-id))))
+                              buffer)]
+          (if (seq theirs)
+            (swap! capture-buffers assoc frame-id theirs)
+            (swap! capture-buffers dissoc frame-id))
+          [])
+        ;; 1-arity fallback (no envelope id — a direct low-level test call):
+        ;; full read-and-clear, returning the whole buffer.
+        (do (swap! capture-buffers dissoc frame-id)
+            buffer))))))
 
 (defn drop-frame-buffer!
   "Drop the frame's in-flight capture buffer."

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -2188,6 +2188,87 @@
           "the committed record is the real cascade, not the suppressed
            empty-buffer boundary"))))
 
+;; ---- no-handler dispatch commits no fake ok epoch (rf2-erczwd) -------------
+;;
+;; A dispatch to an UNREGISTERED event on a LIVE frame early-exits via
+;; `diag/handle-no-handler!` — it never fires `:event/run-start`, but it DOES
+;; emit a `:rf.error/no-such-handler` trace that is frame-stamped AND carries
+;; the cascade scope's `:dispatch-id` (bound by `process-event!`). That trace
+;; buffers into epoch capture, so the buffer is NON-EMPTY at the settle seam.
+;; The prior no-run-start harvest returned the whole buffer, and `settle!`
+;; committed any non-empty harvest — synthesising a misleading `:ok` epoch
+;; (with a fallback `:event-id` derived from the error trace) for a dispatch
+;; that never ran, contradicting the no-run-start / no-epoch invariant. The fix
+;; threads the settling envelope's `:dispatch-id` into the scoped harvest so
+;; the rejection's own trace is DROPPED (not returned), the empty-buffer skip
+;; fires, and no epoch / listener advances.
+
+(deftest no-handler-dispatch-commits-no-epoch
+  (testing "rf2-erczwd — dispatching an UNREGISTERED event on an existing frame
+            records NO epoch and fires NO epoch listener, even though the
+            no-such-handler error trace buffers into epoch capture. The
+            no-run-start / no-epoch invariant holds through the real router."
+    (rf/reg-frame :test/main {})
+    (rf/reg-event :real (fn [{:keys [db]} _] {:db {:n 1}}))
+    ;; A real cascade first, so history is non-empty — we then prove the
+    ;; no-handler dispatch does NOT advance it (and does not overwrite it).
+    (rf/dispatch-sync [:real] {:frame :test/main})
+    (let [fired          (atom [])
+          history-before (rf/epoch-history :test/main)]
+      (is (= 1 (count history-before))
+          "the real cascade committed exactly one record")
+      (rf/register-epoch-listener! ::probe (fn [r] (swap! fired conj r)))
+      ;; Dispatch an event with NO registered handler on the LIVE frame.
+      ;; Recovers (`:replaced-with-default`) — no throw — but emits the
+      ;; frame-stamped, dispatch-id-bearing no-such-handler error trace.
+      (rf/dispatch-sync [:no/such-handler 42] {:frame :test/main})
+      (let [history-after (rf/epoch-history :test/main)]
+        (is (= history-before history-after)
+            "epoch history did NOT advance for the no-handler dispatch —
+             no fake :ok epoch committed")
+        (is (= 1 (count history-after))
+            "still exactly one record (the real cascade)")
+        (is (= :real (:event-id (last history-after)))
+            "the last record is still the real cascade, not a synthesised
+             no-such-handler record with a fallback :event-id")
+        (is (empty? @fired)
+            "no epoch listener fired for the rejected dispatch"))
+      (rf/unregister-epoch-listener! ::probe))
+    ;; A subsequent real dispatch STILL commits — proving the suppression is
+    ;; scoped to the rejected dispatch, not a frame-wide disable.
+    (rf/dispatch-sync [:real] {:frame :test/main})
+    (is (= 2 (count (rf/epoch-history :test/main)))
+        "a real cascade after the rejected dispatch commits normally")))
+
+(deftest no-run-start-harvest-scopes-drop-to-settling-dispatch
+  (testing "rf2-erczwd (unit) — harvest-buffer-for-event! given a settling
+            dispatch-id, on a NO-RUN-START buffer, DROPS the settling
+            dispatch's own traces (its error trace) + orphans and RETAINS an
+            unrelated child marker, returning [] so settle! commits nothing."
+    (let [frame   :test/scoped-harvest
+          ;; The rejected dispatch's OWN error trace — carries the settling id,
+          ;; no run-start.
+          own-err {:op-type :error :operation :rf.error/no-such-handler
+                   :tags {:rf.trace/dispatch-id :S :rf.trace/event-id :no/such}}
+          ;; An unrelated child's queue-time marker buffered during an earlier
+          ;; parent's do-fx — carries a DIFFERENT id; must survive for its
+          ;; own settle.
+          child   {:op-type :rf.event :operation :rf.event/dispatched
+                   :tags {:rf.trace/dispatch-id :C :rf.trace/event-id :child}}
+          ;; An orphan (nil dispatch-id) — must be dropped (self-cleaning).
+          orphan  {:op-type :rf.frame :operation :rf.frame/created
+                   :tags {:frame frame}}]
+      (state/buffer-event! frame own-err)
+      (state/buffer-event! frame child)
+      (state/buffer-event! frame orphan)
+      (let [returned (state/harvest-buffer-for-event! frame :S)]
+        (is (= [] returned)
+            "no cascade ran — nothing returned, so settle! commits no fake epoch")
+        (is (= [child] (state/buffer-for frame))
+            "the unrelated child marker is RETAINED; the settling dispatch's own
+             error trace + the orphan are dropped"))
+      (state/drop-frame-buffer! frame))))
+
 ;; ---- recording is gated on debug-enabled? ---------------------------------
 
 (deftest configure-roundtrip

--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -160,11 +160,10 @@
   `frame/require-current-frame!`. Called under no scope and no explicit
   `:frame`, it raises `:rf.error/no-frame-context` rather than defaulting to
   `:rf/default`. The override is a frame TARGET (keyword id or frame value),
-  normalized to its frame-id via `frame/frame-target->id`. NOTE: the READ
-  path (this fn, `flow-meta-at`) normalizes and so accepts a frame VALUE;
-  the `reg-flow` / `clear-flow` `:frame` opt is used RAW (no
-  `frame-target->id`), so those writes expect a frame-id keyword — a frame
-  value would not resolve there."
+  normalized to its frame-id via `frame/frame-target->id`. Per rf2-8mxnnk the
+  `reg-flow` / `clear-flow` WRITE paths normalize their explicit `:frame`
+  override the same way, so a frame VALUE keys / reads the same flow uniformly
+  across register, clear, and `flow-meta-at`."
   [opts]
   (let [override (:frame opts)]
     (if (some? override)
@@ -933,7 +932,16 @@
   ([flow-id metadata derive-fn]
    (let [[flow frame] (reconstruct-flow flow-id metadata derive-fn)]
    (validate-flow flow)
-   (let [frame-id (or frame
+   (let [;; rf2-8mxnnk: normalize an EXPLICIT `:frame` target — a frame VALUE
+         ;; (make-frame's return token) or a frame-id keyword — to its frame-id
+         ;; BEFORE the liveness check / registry keying, mirroring the READ path
+         ;; (`resolve-read-frame` / `flow-meta-at`). Without this a frame VALUE
+         ;; keys `@flows` (and the `frame/frame` liveness probe) by the raw map,
+         ;; so a LIVE frame reads as not-live (`:rf.error/flow-frame-not-live`)
+         ;; and a later `flow-meta-at` — which normalizes — misses the flow. The
+         ;; scope-derived id is already a keyword, so only the explicit override
+         ;; is normalized (idempotent on a keyword).
+         frame-id (or (some-> frame frame/frame-target->id)
                       (frame/require-current-frame!
                         :reg-flow
                         {:where    'rf/reg-flow
@@ -1334,7 +1342,14 @@
   (cross-ref `dissoc-in-safe`)."
   ([id] (clear-flow id {}))
   ([id {:keys [frame] :as _opts}]
-   (let [frame-id (or frame
+   (let [;; rf2-8mxnnk: normalize an EXPLICIT `:frame` target (frame VALUE or
+         ;; frame-id keyword) to its frame-id BEFORE the registry lookup /
+         ;; vacate — mirroring the READ path. Without this a frame VALUE keys
+         ;; the `@flows` lookup by the raw map, so the clear silently MISSES the
+         ;; flow (registered / read under the frame-id) and leaves it live. The
+         ;; scope-derived id is already a keyword; only the explicit override is
+         ;; normalized.
+         frame-id (or (some-> frame frame/frame-target->id)
                       (frame/require-current-frame!
                         :clear-flow
                         {:where    'rf/clear-flow

--- a/implementation/flows/test/re_frame/flows_test.clj
+++ b/implementation/flows/test/re_frame/flows_test.clj
@@ -1198,6 +1198,62 @@
         "the :flow registrar slot stays empty — single-store, nothing to unregister (rf2-en00bk)")))
 
 ;; ---------------------------------------------------------------------------
+;; 7b. rf2-8mxnnk — reg-flow / clear-flow normalize a FRAME-VALUE `:frame`
+;;
+;; The public frame-target contract (EP-0024) admits a frame VALUE
+;; (make-frame's return token) EVERYWHERE a frame-id keyword is accepted; the
+;; internal normalization seam (`frame/frame-target->id`) funnels a value to
+;; its id. The flows READ path (`flow-meta-at`) already normalized; the WRITE
+;; paths (`reg-flow` / `clear-flow`) did NOT, so an explicit `{:frame <value>}`
+;; keyed the per-frame store by the raw map — a live frame read as not-live at
+;; registration, and a clear silently missed the flow. This pins that both
+;; write paths normalize, so register-by-value + read-by-id + read-by-value +
+;; clear-by-value all observe the SAME flow.
+;; ---------------------------------------------------------------------------
+
+(deftest reg-and-clear-flow-normalize-frame-value-target
+  (testing "reg-flow with an explicit FRAME-VALUE `:frame` registers the flow
+            (does NOT report the live frame as not-live), and flow-meta-at
+            observes the SAME flow whether keyed by id or by value"
+    (let [frame-val (rf/make-frame {:id :fv/host})]
+      (is (frame/frame-value? frame-val)
+          "make-frame returns a frame VALUE, not a bare keyword")
+      ;; Pre-fix this THREW :rf.error/flow-frame-not-live because the raw
+      ;; value keyed the `frame/frame` liveness probe (which keys `@frames`
+      ;; by the bare id) and missed the live frame.
+      (is (= :area
+             (rf/reg-flow :area
+                          {:frame       frame-val
+                           :inputs      [[:w] [:h]]
+                           :output-path [:rect :area]}
+                          (fn [w h] (* (or w 0) (or h 0)))))
+          "reg-flow against a frame VALUE succeeds (frame normalized to its id)")
+      ;; Read by id AND by value resolve the same registered flow.
+      (is (some? (flows/flow-meta-at :area {:frame :fv/host}))
+          "flow-meta-at by frame-id finds the flow registered via the value")
+      (is (some? (flows/flow-meta-at :area {:frame frame-val}))
+          "flow-meta-at by frame VALUE finds the same flow")
+      (is (= (flows/flow-meta-at :area {:frame :fv/host})
+             (flows/flow-meta-at :area {:frame frame-val}))
+          "by-id and by-value observe the IDENTICAL flow meta")
+      ;; The store is keyed by the normalized id, not the raw value map.
+      (is (contains? (get (flows/flows-snapshot) :fv/host) :area)
+          "the per-frame store is keyed by the normalized frame-id")
+      (is (not (contains? (flows/flows-snapshot) frame-val))
+          "the store is NOT keyed by the raw frame-value map"))
+
+    (testing "clear-flow with an explicit FRAME-VALUE `:frame` clears the flow
+              registered under the frame-id (does not silently miss it)"
+      (let [frame-val (rf/make-frame {:id :fv/host})]  ; idempotent re-make; same id
+        (flows/clear-flow :area {:frame frame-val})
+        (is (nil? (flows/flow-meta-at :area {:frame :fv/host}))
+            "clear-by-value removed the flow observed by id")
+        (is (nil? (flows/flow-meta-at :area {:frame frame-val}))
+            "clear-by-value removed the flow observed by value")
+        (is (not (contains? (get (flows/flows-snapshot) :fv/host) :area))
+            "the per-frame store slot is gone after the value-keyed clear")))))
+
+;; ---------------------------------------------------------------------------
 ;; 8. `_hot-reload-hook` defonce-idempotency on namespace reload
 ;;
 ;; The flows registry installs a registrar replacement-hook


### PR DESCRIPTION
Three P3 correctness fixes on the core frame / registration lifecycle surface,
one commit per bead (smallest cleanup → biggest correctness fix). All touch the
coupled core dispatch/epoch, frame registrar, and flow-registration paths; each
carries an adversarial/negative regression.

## rf2-8mxnnk — normalize frame-value targets in flow registration and clear
`reg-flow` / `clear-flow` used the explicit `:frame` override RAW, while the READ
path (`flow-meta-at` / `resolve-read-frame`) already normalized it via
`frame/frame-target->id`. So a frame VALUE (`make-frame`'s return token) keyed the
per-frame `@flows` store — and the `frame/frame` liveness probe — by the raw map:
a live frame read as not-live at registration (`:rf.error/flow-frame-not-live`)
and a value-keyed clear silently missed the flow. Both write paths now normalize
the explicit override (idempotent on a keyword; scope-derived id already a
keyword). Regression registers + clears by frame VALUE and asserts `flow-meta-at`
observes the SAME flow by id and by value.

## rf2-hhlzky — roll back reg-frame registrar/trace writes when construction fails
`reg-frame` wrote the `:frame` registrar row + trace-suppression flags
(`set-frame-no-emit!` / events-retained) BEFORE constructing the record. If
`new-frame-record` threw (e.g. `make-state-container` reporting no adapter —
`reg-frame` before `rf/init!`), the frame never existed yet the process-global
metadata + trace suppression persisted with no destroy path to clear them. Fix
defers the writes: the record is built in the `let`-binding, BEFORE any
process-global write, so a construction throw escapes before anything is written
— nothing to unwind. Re-registration (surgical, no container) is unaffected.
Regression: `reg-frame` before init with `:rf.trace/frame-no-emit? true` throws
`:rf.error/no-adapter-installed` and leaves no registrar row / no trace residue.

## rf2-erczwd — no-handler dispatch commits no fake ok epoch
A dispatch to an unregistered event on a live frame early-exits via
`handle-no-handler!` — no `:event/run-start` fires, but it emits a frame-stamped,
dispatch-id-bearing `:rf.error/no-such-handler` trace (the cascade scope's
dispatch-id is bound by `process-event!`). That trace buffered into epoch capture,
so the buffer was NON-EMPTY at settle; the no-run-start harvest returned the whole
buffer and `settle!` committed it — synthesising a misleading `:ok` epoch (with a
fallback `:event-id` off the error trace) for a dispatch that never ran. Fix
threads the settling envelope's `:dispatch-id`
(`settle-event-epoch!` → `settle!` → `harvest-buffer-for-event!`); the scoped
no-run-start branch drops THIS dispatch's own traces + orphans, RETAINS any
unrelated buffered child marker for its own settle, and returns `[]` so the
empty-buffer skip fires and no epoch/listener advances. Symmetric with the
run-start branch's claim-based retention; the 1-arity harvest (test seam) keeps
the whole-buffer-clear fallback. Regressions: an integration test (dispatch
unregistered event → no epoch, no listener fire) and a focused unit test of the
scoped no-run-start harvest.

## Quality gates
Run from the worktree root / `implementation/`:

- `sh scripts/test-fast-pr.sh` — **PASS** (Python drift gates incl. retired-spelling / thrown-error / ambient-durable-read, core JVM `0 failures, 0 errors`, CLJS node integration, JS harness helpers, per-ns isolation 15/15, markdown link/anchor gates)
- `npm run test:cljs` (full CLJS node integration) — **PASS** — Ran 8135 tests, 37279 assertions, 0 failures, 0 errors
- `sh scripts/test-jvm-implementation.sh` (full transitive JVM sweep) — **PASS** — all 19 artefacts (core, reagent/reagent-slim/uix/helix/test-react adapters, schemas, machines, routing, flows, http, ssr, ssr-ring, epoch, resources, security, reply/derivation/event-conformance) `0 failures, 0 errors`
- Targeted namespaces (subset, run standalone first): `re-frame.flows-test` 61/258, `re-frame.frame-lifecycle-test` 34/162, `re-frame.epoch-test` 156/659, `re-frame.epoch-attribution-test` 43/206 — all `0 failures, 0 errors`

No gate skipped.

## Stance
Pre-alpha, no back-compat shims; optimized for ELEGANCE + CLARITY + CORRECTNESS +
GOOD PRACTICE; avoided over-engineering. Changes are strictly scoped to the core
frame / dispatch / registrar / flow files; no other in-flight worker surface
touched.
