### PR TITLE
fix(pair-mcp): discover-app port-unresolved isError + conformance no-nREPL assert (rf2-bcayt7 +1)

### DIFF
--- a/tools/mcp-conformance/test/end-to-end-re-frame2-pair.cjs
+++ b/tools/mcp-conformance/test/end-to-end-re-frame2-pair.cjs
@@ -227,10 +227,12 @@ runWithWatchdog(
       // (restore-epoch / replace-app-db) are NOT here — they are refused
       // PRE-connection with `:writes-disabled`, not `:nrepl-port-not-found`
       // (writes/refuse-pre-connection fires before ensure-connection!), so
-      // they get their own assertion block below. The closed-world inline
-      // tools (get-re-frame2-pair-instructions / get-stream-controls) DO
-      // appear here: dispatch still routes them through ensure-connection!,
-      // which rejects degraded before the inline body runs.
+      // they get their own assertion block below. The two CLOSED-WORLD
+      // tools (get-re-frame2-pair-instructions / get-stream-controls) are
+      // ALSO not here (rf2-6amhbt): they read only server-local state (no
+      // nREPL), so the server dispatches them at the pre-connection
+      // boundary — they SUCCEED degraded and are covered by the
+      // closed-world success block below, not this degraded walk.
       { name: 'discover-app', arguments: {} },
       // eval-cljs is default-ON (no pre-connection gate unless --no-eval),
       // so degraded it routes through ensure-connection! and returns the
@@ -242,8 +244,6 @@ runWithWatchdog(
       { name: 'dispatch-dry-run', arguments: { event: '[:rf-conformance/probe]' } },
       { name: 'get-operating-frame', arguments: {} },
       { name: 'get-path', arguments: { path: '[:does :not :matter]' } },
-      { name: 'get-re-frame2-pair-instructions', arguments: {} },
-      { name: 'get-stream-controls', arguments: {} },
       { name: 'handler-meta', arguments: { kind: 'event', id: ':rf-conformance/probe' } },
       { name: 'list-handlers', arguments: { kind: 'event' } },
       // EP-0017 cofx introspection over the SDK wire. The `cofx` kind is
@@ -312,6 +312,56 @@ runWithWatchdog(
     for (const tool of DEGRADED_TOOLS) {
       degradedResp[tool.name] = await assertDegraded(tool);
     }
+
+    // 3b-closed-world. Closed-world success path (rf2-6amhbt). Unlike
+    // every tool in the degraded walk above, `get-re-frame2-pair-instructions`
+    // and `get-stream-controls` read ONLY server-local state — inline
+    // onboarding text / the in-process resource-control atoms — with NO
+    // nREPL round-trip. The server dispatches them at the pre-connection
+    // boundary (bypassing `ensure-connection!`), so even in THIS degraded
+    // harness (no nREPL) they MUST SUCCEED (isError:false) rather than
+    // return the shared `:nrepl-port-not-found` envelope. This pins the
+    // spec/003 "answers even when the runtime is down" contract at the real
+    // MCP boundary — the exact behaviour the earlier harness mis-encoded as
+    // a degraded failure. Each still routes through the SDK's
+    // CallToolResultSchema + the declared outputSchema parse, so a
+    // structuredContent regression turns RED. Mirrors the analogous Story
+    // closed-world block in end-to-end-story.cjs. These two calls also keep
+    // both tools SDK-covered for the callTool coverage ratchet below.
+    for (const readTool of [
+      'get-re-frame2-pair-instructions',
+      'get-stream-controls',
+    ]) {
+      const r = await client.callTool({ name: readTool, arguments: {} });
+      if (r.isError) {
+        throw new Error(
+          'closed-world tool ' + readTool + ' MUST succeed (isError=false) ' +
+            'with no nREPL — it reads server-local state and is dispatched ' +
+            'pre-connection (rf2-6amhbt); got: ' + JSON.stringify(r),
+        );
+      }
+      const text = r.content?.[0]?.text || '';
+      if (text.includes('nrepl-port-not-found')) {
+        throw new Error(
+          readTool + ' MUST NOT return the degraded :nrepl-port-not-found ' +
+            'envelope — it answers without a runtime; got: ' + text.slice(0, 200),
+        );
+      }
+      if (r.structuredContent === undefined || r.structuredContent === null ||
+          typeof r.structuredContent !== 'object' ||
+          Array.isArray(r.structuredContent)) {
+        throw new Error(
+          readTool + ' success envelope MUST carry a JSON-object ' +
+            ':structuredContent slot; got: ' + JSON.stringify(r),
+        );
+      }
+      // isError:false MUST agree with :ok? true (universal cross-check).
+      assertIsErrorMatchesOk('tools/call ' + readTool + ' (closed-world)', r);
+    }
+    console.log(
+      'OK   closed-world tools (get-re-frame2-pair-instructions/' +
+        'get-stream-controls) -> success envelopes with no nREPL (rf2-6amhbt)',
+    );
 
     // 3c. Gated WRITE tools — pre-connection refusal. The two
     // state-mutating tools `restore-epoch` and `replace-app-db` are gated

--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -3212,6 +3212,16 @@ an operator is most likely diagnosing a denied or stalled stream). It is
 the only read tool whose `:openWorldHint` is `false`: the state is
 server-local, the read never leaves the process.
 
+Because it needs no connection, the server dispatches it at the
+**pre-connection** boundary (rf2-6amhbt) — BEFORE `ensure-connection!`,
+symmetric with the unknown-tool (rf2-4mc6q1) and gated-write
+(rf2-wz66k7) pre-connection guards. So on a stock / degraded install with
+no nREPL port it returns its `:ok? true` payload rather than the shared
+`:nrepl-port-not-found` discovery error — the "answers even when the
+runtime is down" claim holds at the real MCP boundary, not merely at the
+tool-body layer. `get-re-frame2-pair-instructions` shares this
+closed-world pre-connection dispatch.
+
 **Privacy**: the payload is control state only — caps, counts, bucket
 pressure. No event payloads, no app-db data, so it is unconditionally
 safe (no `--allow-sensitive-reads` gate).
@@ -3697,6 +3707,12 @@ round-trip; the text is a `def` in the compiled `.js` bundle so
 the call is one MCP frame and zero socket bytes. The cache layer
 (`cache.cljs`) marks this tool `cacheable? true` since the text is
 a pure-data function of the bundle.
+
+Like `get-stream-controls`, it is a **closed-world** tool: the server
+dispatches it at the **pre-connection** boundary (rf2-6amhbt), BEFORE
+`ensure-connection!`, so an agent orienting on a fresh / degraded session
+with no shadow build running gets the onboarding text rather than a
+`:nrepl-port-not-found` discovery error.
 
 **Args**: none recognised. `:additionalProperties false`.
 

--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -484,7 +484,12 @@ the one whose `:output-dir` is among those roots (`8031` →
 `:examples/step-deck` in this repo). No manual grep of `shadow-cljs.edn`.
 A `port` that maps to no build returns `:ok? false :reason
 :port-unresolved` (loud, not a silent fall-through to `:app` — the
-operator asked for that port). An explicit `build` arg wins over `port`.
+operator asked for that port), and — per the §"Every `:ok? false`
+response is `isError: true`" rule above — it rides as an **`isError`
+result** (rf2-bcayt7), the same envelope its sibling discover-app
+precondition failures use. Keeping it `isError` also keeps an unresolved
+port out of the response cache, so it can never mask a later valid
+port→build mapping. An explicit `build` arg wins over `port`.
 
 **Single-build auto-selection (rf2-v70kv).** When you omit `build` and
 **exactly one** shadow-cljs build is running, discover-app auto-selects

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/server.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/server.cljs
@@ -410,7 +410,7 @@
 (defn- handle-list [_req]
   (js/Promise.resolve #js {:tools (tools/tool-descriptors-js)}))
 
-(declare handle-call*)
+(declare handle-call* handle-call-local)
 
 (defn- handle-call [launch-flags req extra]
   (let [params (j/get req :params)
@@ -437,7 +437,18 @@
         ;; default-safe write posture would be observably false at the real
         ;; MCP boundary. The tool body's own gate stays as defence in depth.
         (js/Promise.resolve refusal)
-        (handle-call* launch-flags name args extra)))))
+        (if (tools/closed-world-tool? name)
+          ;; A closed-world tool (get-stream-controls /
+          ;; get-re-frame2-pair-instructions) reads only server-local state —
+          ;; no nREPL round-trip — so it is DISPATCHED HERE, before
+          ;; `ensure-connection!` (rf2-6amhbt). Otherwise a stock / degraded
+          ;; install with no nREPL port would run discovery, REJECT with
+          ;; `:nrepl-port-not-found`, and the tool body — which needs no
+          ;; connection — would never run, contradicting the spec/003
+          ;; "answers even when the runtime is down" contract. Symmetric with
+          ;; the unknown-tool + gated-write pre-connection guards above.
+          (handle-call-local name args extra)
+          (handle-call* launch-flags name args extra))))))
 
 (defn handle-call-for-tests
   "Test seam onto the private `handle-call`. Lets the
@@ -451,25 +462,43 @@
                #js {:params #js {:name tool-name :arguments args}}
                extra))
 
+(defn- invoke-and-guard
+  "Dispatch a resolved tool call through `tools/invoke` and convert a
+  thrown handler into the structured `:handler-threw` envelope. Routed
+  through `wire/result` so the structuredContent projection preserves
+  keyword namespaces (a raw `clj->js` would truncate `:rf.error/*` reason
+  values). Shared by the connected path (`handle-call*`) and the
+  closed-world pre-connection path (`handle-call-local`)."
+  [conn name args extra]
+  (-> (tools/invoke conn name args extra)
+      (.catch (fn [err]
+                (log! "handler threw for" name "—" (.-message err))
+                (wire/result {:ok?     false
+                              :reason  :handler-threw
+                              :message (.-message err)}
+                             true)))))
+
+(defn- handle-call-local
+  "Pre-connection dispatch for a closed-world tool (rf2-6amhbt). The
+  handler reads only server-local state (resource-control atoms /
+  inline text), so it is invoked WITHOUT `ensure-connection!` — no
+  discovery, no elicitation, no nREPL socket. Uses the cached conn from
+  `session-state` (may be `nil` in degraded mode); the closed-world
+  handlers ignore `conn`, so the nil-conn path is safe. This is what
+  makes the spec/003 'answers even when the runtime is down' contract
+  observably true at the real MCP boundary — not merely at the tool-body
+  layer (which the conformance corpus already pins via `tools/invoke`)."
+  [name args extra]
+  (invoke-and-guard (:conn @session-state) name args extra))
+
 (defn- handle-call*
   "Normal tool-dispatch path: ensure the nREPL connection, then route to
   the tool dispatcher. Reached for every tool EXCEPT a gated write
-  refused at the pre-connection boundary."
+  refused, or a closed-world tool dispatched, at the pre-connection
+  boundary."
   [launch-flags name args extra]
   (-> (ensure-connection! launch-flags)
-      (.then (fn [conn]
-               (-> (tools/invoke conn name args extra)
-                   (.catch (fn [err]
-                             (log! "handler threw for" name "—" (.-message err))
-                             ;; Route the server-level error envelope through
-                             ;; `wire/result` so the structuredContent
-                             ;; projection preserves keyword namespaces (a raw
-                             ;; `clj->js` here truncates `:rf.error/*` reason
-                             ;; values).
-                             (wire/result {:ok?     false
-                                           :reason  :handler-threw
-                                           :message (.-message err)}
-                                          true))))))
+      (.then (fn [conn] (invoke-and-guard conn name args extra)))
       (.catch
         (fn [err]
           ;; Discovery failed — surface a structured tool-call error.

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools.cljs
@@ -87,6 +87,12 @@
 (def tool-descriptors descriptors/tool-descriptors)
 (def tool-descriptors-js descriptors/tool-descriptors-js)
 
+;; Re-export the registry's closed-world predicate onto the façade so
+;; `server.cljs` (which already requires this ns) can route the
+;; server-local reads AROUND `ensure-connection!` at the pre-connection
+;; boundary — see `registry/closed-world-tool?` (rf2-6amhbt).
+(def closed-world-tool? registry/closed-world-tool?)
+
 (defn- edit-distance
   "Cheap Levenshtein distance between two strings — used only to surface a
   `did you mean` candidate in the `:unknown-tool` hint. Runs over the

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/discover_app.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/discover_app.cljs
@@ -17,9 +17,17 @@
 
 (defn- port-unresolved-result
   "Error envelope for a `:port` arg that didn't resolve to a build via
-  the `:dev-http` map."
+  the `:dev-http` map.
+
+  rf2-bcayt7: a `:port` that maps to no build is a known-tool failure
+  (`:ok? false`), so it rides `wire/err-text` (`isError: true`) — the
+  same universal rule the other discover-app precondition failures
+  already follow (unhealthy runtime / `:debug-disabled` /
+  `:no-frames-registered` all use `err-text`). Keeping it `isError` also
+  keeps the response cache from ever masking a later valid mapping (cache
+  eligibility bypasses `isError` results)."
   [port]
-  (wire/ok-text
+  (wire/err-text
     {:ok?    false
      :reason :port-unresolved
      :port   port

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/registry.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/registry.cljs
@@ -269,6 +269,12 @@
     ;; control readings. Same posture as `list-streams` (volatile
     ;; streaming-registry read).
     :cacheable? false
+    ;; CLOSED-WORLD (rf2-6amhbt): the handler reads server-local atoms
+    ;; with NO nREPL round-trip, so the server dispatches it at the
+    ;; pre-connection boundary (bypassing `ensure-connection!`) — it
+    ;; answers even when no shadow build is running, honouring the
+    ;; spec/003 "answers even when the runtime is down" contract.
+    :closed-world? true
     :descriptor data/get-stream-controls}
    {:name       "handler-meta"
     :handler    (ignoring-extra #(handler-meta/handler-meta-tool %1 %2))
@@ -326,6 +332,12 @@
    {:name       "get-re-frame2-pair-instructions"
     :handler    (ignoring-extra #(get-re-frame2-pair-instructions/get-re-frame2-pair-instructions-tool %1 %2))
     :cacheable? true
+    ;; CLOSED-WORLD (rf2-6amhbt): the onboarding text is an inline `def`
+    ;; in the bundle — zero socket bytes — so the server dispatches it at
+    ;; the pre-connection boundary (bypassing `ensure-connection!`). An
+    ;; agent orienting on a fresh/degraded session gets the catalogue
+    ;; instead of a misleading `:nrepl-port-not-found`.
+    :closed-world? true
     :descriptor data/get-re-frame2-pair-instructions}])
 
 ;; ---------------------------------------------------------------------------
@@ -358,6 +370,28 @@
   "Materialised set of tool names whose `:cacheable?` is truthy.
   Built once at load time so `cacheable?` is an O(1) membership test."
   (into #{} (comp (filter :cacheable?) (map :name)) tools))
+
+(def ^:private closed-world-set
+  "Materialised set of tool names flagged `:closed-world?` — the tools
+  whose handler answers WITHOUT an nREPL round-trip (server-local reads:
+  `get-stream-controls`, `get-re-frame2-pair-instructions`). Built once at
+  load time so `closed-world-tool?` is an O(1) membership test."
+  (into #{} (comp (filter :closed-world?) (map :name)) tools))
+
+(defn closed-world-tool?
+  "Predicate — does this tool answer WITHOUT a live nREPL connection?
+
+  True for the server-local reads (`get-stream-controls`,
+  `get-re-frame2-pair-instructions`) whose handlers touch only in-process
+  state (resource-control atoms / an inline text `def`). The server
+  dispatches these at the pre-connection boundary — BEFORE
+  `ensure-connection!` — so they answer even on a stock / degraded install
+  with no shadow build running, symmetric with the unknown-tool
+  (rf2-4mc6q1) and gated-write (rf2-wz66k7) pre-connection guards.
+
+  Unknown names return false (they route to the `:unknown-tool` guard)."
+  [tool]
+  (contains? closed-world-set tool))
 
 (defn cacheable?
   "Predicate — should this tool consult the per-session response cache?

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/closed_world_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/closed_world_test.cljs
@@ -1,0 +1,100 @@
+(ns re-frame2-pair-mcp.closed-world-test
+  "Server-boundary closed-world dispatch tests (rf2-6amhbt).
+
+  The server handler (`server.cljs/handle-call`) runs `ensure-connection!`
+  for the connected tools BEFORE the dispatcher. But two tools —
+  `get-stream-controls` and `get-re-frame2-pair-instructions` — read only
+  server-local state (resource-control atoms / an inline text `def`) with
+  NO nREPL round-trip. On a stock / degraded install with no nREPL port,
+  routing them through `ensure-connection!` would REJECT with
+  `:nrepl-port-not-found` and the closed-world body would never run,
+  contradicting the spec/003 'answers even when the runtime is down'
+  contract.
+
+  These tests pin the OUTER ring: the pre-connection closed-world dispatch
+  (`registry/closed-world-tool?` + the server `handle-call` branch) proves
+  the tool answers SUCCESSFULLY before `ensure-connection!` — discovery
+  never runs; the session-state stays pristine. Mirrors
+  `unknown_tool_test.cljs` and `writes_test.cljs`, the symmetric
+  pre-connection guards."
+  (:require [cljs.test :refer-macros [deftest is async use-fixtures]]
+            [re-frame2-pair-mcp.test-utils :as tu]
+            [re-frame2-pair-mcp.server :as server]
+            [re-frame2-pair-mcp.tools :as tools]
+            [re-frame2-pair-mcp.tools.registry :as registry]))
+
+(use-fixtures :each
+  {:before (fn [] (server/reset-session-state-for-tests!))
+   :after  (fn [] (server/reset-session-state-for-tests!))})
+
+(def ^:private read-edn tu/extract-edn)
+(def ^:private err? tu/error?)
+
+;; ---------------------------------------------------------------------------
+;; closed-world-tool? — the pure predicate.
+;; ---------------------------------------------------------------------------
+
+(deftest closed-world-tool?-flags-exactly-the-server-local-reads
+  (is (true? (registry/closed-world-tool? "get-stream-controls")))
+  (is (true? (registry/closed-world-tool? "get-re-frame2-pair-instructions")))
+  ;; The predicate is re-exported onto the façade the server consumes.
+  (is (identical? tools/closed-world-tool? registry/closed-world-tool?))
+  ;; Everything else needs a live runtime — NOT closed-world. A false
+  ;; positive here would route a nREPL-dependent tool around the
+  ;; connection and hand it a nil conn.
+  (doseq [tool ["discover-app" "eval-cljs" "dispatch" "snapshot" "get-path"
+                "subscribe" "list-streams" "restore-epoch" "replace-app-db"]]
+    (is (false? (registry/closed-world-tool? tool))
+        (str tool " needs a live runtime — must NOT be closed-world")))
+  (is (false? (registry/closed-world-tool? "no-such-tool"))
+      "an unknown name is never closed-world"))
+
+;; ---------------------------------------------------------------------------
+;; Server boundary — the closed-world dispatch precedes ensure-connection!
+;;
+;; The session-state is reset (pristine, :discovered? false) by the
+;; fixture, and no --port-file / env is configured, so the real discovery
+;; cascade would REJECT with :nrepl-port-not-found if `handle-call`
+;; reached `ensure-connection!`. Proving the result is a SUCCESS envelope
+;; (isError false, :ok? true) AND that the session stayed pristine shows
+;; the dispatch ran WITHOUT discovery.
+;; ---------------------------------------------------------------------------
+
+(deftest instructions-answered-before-connection
+  (async done
+    (-> (server/handle-call-for-tests {} "get-re-frame2-pair-instructions" #js {} nil)
+        (.then (fn [result]
+                 (is (not (err? result))
+                     "closed-world instructions succeed with NO nREPL — not a degraded error")
+                 (let [edn (read-edn result)]
+                   (is (true? (:ok? edn)))
+                   (is (not= :nrepl-port-not-found (:reason edn))
+                       "never the degraded discovery error")
+                   (is (string? (:text edn)) "the onboarding prose rides back"))
+                 (let [snap (server/session-state-snapshot)]
+                   (is (false? (:discovered? snap))
+                       "discovery was NOT run — dispatched before ensure-connection!")
+                   (is (nil? (:discovery-error snap))
+                       "no discovery attempt recorded — connection step never reached"))
+                 (done)))
+        (.catch (fn [e] (is false (str "handle-call rejected: " (.-message e))) (done))))))
+
+(deftest stream-controls-answered-before-connection
+  (async done
+    (-> (server/handle-call-for-tests {} "get-stream-controls" #js {} nil)
+        (.then (fn [result]
+                 (is (not (err? result))
+                     "closed-world stream-controls succeed with NO nREPL")
+                 (let [edn (read-edn result)]
+                   (is (true? (:ok? edn)))
+                   (is (not= :nrepl-port-not-found (:reason edn)))
+                   ;; The in-process resource-control payload rides back —
+                   ;; a wired-but-empty handler would fail this.
+                   (is (map? (:config edn)) "server-local :config payload present")
+                   (is (contains? edn :concurrent-streams)))
+                 (let [snap (server/session-state-snapshot)]
+                   (is (false? (:discovered? snap))
+                       "discovery was NOT run — dispatched before ensure-connection!")
+                   (is (nil? (:discovery-error snap))))
+                 (done)))
+        (.catch (fn [e] (is false (str "handle-call rejected: " (.-message e))) (done))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
@@ -291,7 +291,7 @@
 
     | Tool                   | Happy | Missing-arg | Degraded-runtime |
     |------------------------|-------|-------------|-------------------|
-    | discover-app           | yes   | n/a         | yes               |
+    | discover-app           | yes   | n/a         | yes (+port-unresolved) |
     | eval-cljs              | yes   | yes         | (covered by ↑ )   |
     | dispatch               | yes   | yes         | yes               |
     | restore-epoch          | yes   | yes         | gated-default     |
@@ -349,6 +349,25 @@
      [:default                    nil]]
     :fixture/expect
     {:edn-submap {:ok? false :reason :runtime-loaded-but-preload-missing}}}
+
+   ;; A `:port` that maps to no build short-circuits BEFORE any
+   ;; cljs-eval-value round-trip: `resolve-build-by-port` reads the
+   ;; `:dev-http` map via `jvm-eval`; the corpus's default JVM stub answers
+   ;; the non-`active-builds` lookup form with `{:value "1"}`, which
+   ;; `read-string`s to `1` — not a keyword build-id — so the resolver
+   ;; returns nil and discover-app emits `:port-unresolved`. rf2-bcayt7
+   ;; pins that this rides as an `isError` result (a known-tool `:ok? false`
+   ;; failure), NOT a success-shaped ok-text envelope that the response
+   ;; cache could retain and mask a later valid port→build mapping.
+   {:fixture/id    :discover-app/port-unresolved
+    :fixture/doc   "discover-app with a :port that maps to no build rides as isError carrying :port-unresolved (rf2-bcayt7 — every :ok? false is isError; never a cacheable ok-text)."
+    :fixture/tool  "discover-app"
+    :fixture/args  {:port 9999}
+    :fixture/eval-script
+    [[:default nil]]
+    :fixture/expect
+    {:isError? true
+     :edn-submap {:ok? false :reason :port-unresolved :port 9999}}}
 
    ;; ---------- eval-cljs --------------------------------------------------
    ;; The launch-flag gate ships DEFAULT-ON in published builds — the

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/port_to_build_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/port_to_build_test.cljs
@@ -146,10 +146,13 @@
             (fn [] (discover-app/discover-app conn (tu/args->js {:port 9999}))))
           (.then
             (fn [result]
-              ;; The payload carries :ok? false but rides the ok-text
-              ;; envelope (matching the other discover-app precondition
-              ;; failures), so :isError is not set.
-              (is (not (tu/error? result)))
+              ;; rf2-bcayt7: the payload carries :ok? false and now rides
+              ;; the err-text envelope (isError: true) — the universal
+              ;; "every :ok? false is isError" rule, matching the OTHER
+              ;; discover-app precondition failures (unhealthy runtime /
+              ;; :debug-disabled / :no-frames-registered all err-text).
+              (is (tu/error? result)
+                  "an unmapped port rides isError, not a success envelope")
               (let [edn (tu/extract-edn result)]
                 (is (false? (:ok? edn)))
                 (is (= :port-unresolved (:reason edn)))
@@ -157,6 +160,26 @@
                 (is (string? (:hint edn)))
                 (is (nil? (:resolved-build-id @conn))
                     "an unresolved port must not cache anything"))
+              (done)))))))
+
+(deftest discover-app-port-unresolved-iserror-matches-ok?
+  ;; Adversarial cross-check (rf2-bcayt7): the isError:true flag and the
+  ;; payload's :ok? false MUST agree — a regression back to ok-text would
+  ;; ship :ok? false WITHOUT isError, decoupling the two slots and letting
+  ;; the response cache retain an unresolved-port answer that masks a later
+  ;; valid mapping. A distinct port proves the behaviour isn't 9999-specific.
+  (async done
+    (let [conn (fresh-conn)]
+      (-> (with-port-resolution! nil healthy-health
+            (fn [] (discover-app/discover-app conn (tu/args->js {:port 65535}))))
+          (.then
+            (fn [result]
+              (let [edn (tu/extract-edn result)]
+                ;; isError:true (text slot) <-> :ok? false (structured slot)
+                (is (true? (tu/error? result)))
+                (is (false? (:ok? edn)))
+                (is (= :port-unresolved (:reason edn)))
+                (is (= 65535 (:port edn))))
               (done)))))))
 
 (deftest discover-app-explicit-build-wins-over-port


### PR DESCRIPTION
Two-bead cluster on the **pair-mcp / mcp-conformance** surface.

## rf2-bcayt7 — discover-app port-unresolved rides isError (P3, BUG)

`discover-app` returned `{:ok? false :reason :port-unresolved}` through
`wire/ok-text` when a `:port` mapped to no build — a known-tool failure
shipped as a success envelope, the odd one out among its sibling
precondition failures (unhealthy runtime / `:debug-disabled` /
`:no-frames-registered`, which already use `err-text`). Switched the
port-unresolved path to `wire/err-text` per spec/003's universal "every
`:ok? false` is `isError: true`" rule. Keeping it `isError` also keeps an
unresolved port out of the response cache, so it can never mask a later
valid port→build mapping.

- `discover_app.cljs`: `port-unresolved-result` `ok-text` → `err-text`
- `port_to_build_test.cljs`: flipped the fails-loud test to assert
  `isError`; **added an adversarial** `isError`↔`:ok?` cross-check on a
  distinct port (65535)
- `conformance_test.cljs`: **added** a `:discover-app/port-unresolved`
  corpus fixture pinning the `isError` envelope through the full
  `tools/invoke` wire pipeline
- `spec/003`: made the `isError` contract explicit for `:port-unresolved`

## rf2-6amhbt — closed-world tools answer without nREPL (P3, BUG)

`get-stream-controls` and `get-re-frame2-pair-instructions` read only
server-local state (resource-control atoms / an inline text `def`) — no
nREPL round-trip — yet the server ran them through `ensure-connection!`
first, so on a stock/degraded install they returned
`:nrepl-port-not-found`, contradicting the spec/003 "answers even when the
runtime is down" contract. The conformance end-to-end even encoded that
broken boundary as expected (both in `DEGRADED_TOOLS`).

Added a closed-world pre-connection dispatch, symmetric with the existing
unknown-tool and gated-write pre-connection guards:

- `registry.cljs`: flag both entries `:closed-world? true` + derive a
  single-source `closed-world-tool?` predicate
- `tools.cljs`: re-export `closed-world-tool?` onto the server-facing façade
- `server.cljs`: route closed-world tools to a new `handle-call-local`
  (invokes with the cached, maybe-nil conn) BEFORE `ensure-connection!`;
  extracted the shared `invoke-and-guard` from `handle-call*`
- `closed_world_test.cljs` (**new, adversarial**): both tools succeed
  pre-connection with the session-state pristine (no discovery ran)
- `end-to-end-re-frame2-pair.cjs`: dropped both from `DEGRADED_TOOLS`;
  **added** a closed-world success block asserting `isError:false` +
  object `structuredContent` + `isError`↔`:ok?` cross-check with no nREPL
- `spec/003`: documented the closed-world pre-connection dispatch on both
  tool sections

## Quality gates

Focused artefact tests only (full `test-fast-pr.sh` spine deferred to CI):

- `tools/re-frame2-pair-mcp` — `npm test` (`shadow-cljs compile
  server-test && node out/server-test.js`): **PASS** — 1172 tests, 3913
  assertions, 0 failures / 0 errors (includes the new `closed_world_test`,
  the updated `port_to_build_test`, and the new port-unresolved corpus
  fixture).
- `tools/re-frame2-pair-mcp` — `npm run build` (`shadow-cljs compile
  server`): **PASS** — 0 warnings.
- `tools/mcp-conformance` — `node test/end-to-end-re-frame2-pair.cjs`
  (degraded, no nREPL): **PASS** — `RE-FRAME2-PAIR-MCP MCP-CLIENT
  CONFORMANCE GREEN`; new line `closed-world tools
  (get-re-frame2-pair-instructions/get-stream-controls) -> success
  envelopes with no nREPL`; callTool coverage ratchet 31/30.

`node_modules` was absent in the fresh worktree; ran a focused per-artefact
`npm install` (pair-mcp + mcp-conformance) rather than the full spine.
The JVM wire-vocab conformance suite (`tools/mcp-conformance/wire-vocab`)
is untouched by this change (no `.clj` edits) and left to CI.

## Stance

Pre-alpha, no back-compat shims. ELEGANCE + CLARITY + CORRECTNESS + GOOD
PRACTICE, avoiding over-engineering: the closed-world flag rides the
existing single-source registry (no drift possible), the server reuses the
established pre-connection-guard pattern, and each fix adds a negative test.
