### PR TITLE
ci(lint): harden clj-kondo install against transient 429 (rf2-cq0s2j)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -186,8 +186,15 @@ jobs:
       # upstream `install-clj-kondo` script is the documented path and
       # leaves the binary on $PATH.
       - name: Install clj-kondo
+        # `raw.githubusercontent.com` is CDN-fronted and HTTP-429s under
+        # rate limiting, which (with bare `curl -f`) dies in ~11s and reds
+        # unrelated PRs (rf2-cq0s2j; cost a fix-worker cycle on #5304).
+        # `--retry 5 --retry-all-errors --retry-delay 3` retries transient
+        # failures — including the 429 that `-f` alone treats as fatal —
+        # with a 3s base backoff. GNU curl on ubuntu-24.04 runners supports
+        # `--retry-all-errors` (since 7.71).
         run: |
-          curl -fsSL -o install-clj-kondo \
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o install-clj-kondo \
             https://raw.githubusercontent.com/clj-kondo/clj-kondo/master/script/install-clj-kondo
           chmod +x install-clj-kondo
           sudo ./install-clj-kondo --version 2026.04.15


### PR DESCRIPTION
## What

The `Install clj-kondo` step in `.github/workflows/lint.yml` fetched the upstream `install-clj-kondo` script from CDN-fronted `raw.githubusercontent.com` with a bare `curl -fsSL`. Under CDN rate limiting this HTTP-429s and dies in ~11s before clj-kondo runs, reddening unrelated PRs (this cost a fix-worker cycle on #5304 / surfaced by rf2-rt13fn).

Fix: add `--retry 5 --retry-all-errors --retry-delay 3` to the curl invocation so transient failures — including the 429 that `-f` alone treats as fatal — retry with a 3s base backoff instead of hard-failing.

## Scope

Single-file, hot-zone (`.github/workflows/lint.yml`). I swept every workflow for the same bare-curl / raw.githubusercontent / install-script fetch pattern (`test.yml`, `portability.yml`, `docs.yml`, `release*.yml`, `expensive-tests.yml`, `post-merge-*.yml`): **`lint.yml` is the only file that fetches an install script this way** — the other `bootstrap` hits are esbuild-bundle references, not network fetches. No other workflow needed the same hardening.

## Diff

```diff
       - name: Install clj-kondo
+        # (comment: rationale — 429 flake, retry with backoff)
         run: |
-          curl -fsSL -o install-clj-kondo \
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o install-clj-kondo \
             https://raw.githubusercontent.com/clj-kondo/clj-kondo/master/script/install-clj-kondo
```

## Quality gates

- CI itself is the validating gate — the lint workflow cannot be run locally. This PR's own `Lint required` run exercises the modified step end-to-end.
- `lint.yml` validated as well-formed YAML locally (PyYAML `safe_load` parses cleanly).
- Flag support confirmed: GNU curl on `ubuntu-24.04` runners supports `--retry-all-errors` (available since curl 7.71); `--retry` / `--retry-delay` are long-standing.

## Risks

- Low. Worst case on a genuine (non-transient) fetch failure is ~15s of added retry latency before the step fails as before — the retry only re-attempts, it never masks a real error (a persistent 404/network-down still exits non-zero after retries exhaust).

## Stance

Pre-alpha, no back-compat shims; ELEGANCE + CLARITY + CORRECTNESS. Minimal surgical CI-hardening — one step, three flags, a rationale comment.

Closes rf2-cq0s2j.