### PR TITLE
fix(machines): correct resources-reader machine owner shape (rf2-lbtqw4)

### DIFF
--- a/examples/capabilities/resources/resources/README.md
+++ b/examples/capabilities/resources/resources/README.md
@@ -62,11 +62,16 @@ live. They go from "the framework decides" to "a workflow decides":
   per-row **Open in reader** button starts the `:resources.app/reader` machine,
   then dispatches `[:reader/load …]` into it (the birth cascade carries no
   event, so the slug rides in on that dispatch). The `:reading` state handles it
-  with the `:ensure-article` action, which ensures the article under a
-  `[:machine machine-id instance-id]` owner. **Stop reader** runs the
-  `[:rf.machine/destroy …]` effect; destroying the actor releases the owner. The
-  machine stays the workflow; the resource runtime just handles the cached-read
-  mechanics underneath it.
+  with the `:ensure-article` action, which ensures the article under the actor's
+  `[:machine actor-id]` owner (`[:machine :resources.app/reader]`) — the one
+  machine-owner key the framework auto-releases on actor destroy. **Stop reader**
+  runs the `[:rf.machine/destroy …]` effect; destroying the actor releases that
+  owner, so the read is not left pinned. (A three-part `[:machine machine-id
+  instance-id]` owner would be an *app-authoritative* lease the framework does
+  NOT auto-release — see [Spec 016 §Release authority is per owner
+  kind](../../../../spec/016-Resources.md#release-authority-is-per-owner-kind).)
+  The machine stays the workflow; the resource runtime just handles the
+  cached-read mechanics underneath it.
 
 ### No backend, real lifecycle
 

--- a/examples/capabilities/resources/resources/core.cljs
+++ b/examples/capabilities/resources/resources/core.cljs
@@ -263,11 +263,20 @@
 ;; instance-id this workflow owns get to ride in on `:reader/load`.
 ;;
 ;; The `:reading` state handles that `:reader/load` with the `:ensure-article`
-;; action. The action pulls slug + instance-id out of the event, tucks them into
-;; the snapshot `:data` (so the owner is self-describing — handy for tools and
-;; SSR), and ensures the article under the owner `[:machine machine-id
-;; instance-id]`. When the actor is later destroyed, the runtime releases that
-;; owner for us.
+;; action. The action pulls slug + instance-id out of the event, records them in
+;; the snapshot `:data` as the reader's domain state, and ensures the article
+;; under the owner `[:machine :resources.app/reader]` — the runtime ACTOR-ID
+;; owner (a singleton actor's id IS its machine-id). That two-part key is the ONE
+;; machine owner the framework auto-releases on actor destroy (Spec 016 §Release
+;; authority is per owner kind): destroying the actor releases exactly this owner
+;; for us, so the read is not left pinned.
+;;
+;; The owner is the actor-id, deliberately NOT `[:machine machine-id
+;; instance-id]`. A three-part owner that folds a DOMAIN instance-id into the key
+;; is an *app-authoritative* lease (like any `[:lease …]`) — the framework does
+;; NOT auto-release it, so leaning on actor-destroy to free it would leak the
+;; entry (it would pin the read alive, refetching forever). The reader keeps its
+;; instance-id in `:data`, never in the owner. See Spec 016 §Release authority.
 (rf/reg-machine :resources.app/reader
   {:doc     "A reader workflow that owns the article it is reading."
    :initial :reading
@@ -280,7 +289,7 @@
          :fx   [[:dispatch [:rf.resource/ensure
                             {:resource :article/by-slug
                              :params   {:slug slug}
-                             :owner    [:machine :resources.app/reader instance-id]
+                             :owner    [:machine :resources.app/reader]
                              :cause    [:machine-action :resources.app/reader.reading]}]]]}))}
    :states
    ;; `:reader/load` is a targetless transition — it runs `:ensure-article` and

--- a/implementation/adapters/reagent/test/re_frame/resources_example_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/resources_example_cljs_test.cljs
@@ -311,24 +311,54 @@
       (is (nil? (rf/compute-sub [:resources.app/reader] (rf/frame-state-value :rf/default)))
           "stop-reader clears the reader slice"))))
 
-;; NOTE on the machine-owned resource pattern (the example's `:resources.app/
-;; reader` actor that ensures :article/by-slug under a `[:machine …]` owner,
-;; released on actor destroy): the example's start/stop EVENT glue is pinned by
-;; `reader-start-stop-events-record-and-clear-the-reader-slice` above. The
-;; machine-owned ENSURE itself runs on the reader's `:reading` :entry inside the
-;; spawn cascade, and a `[:machine …]` owner is fail-closed bound to a LIVE actor
-;; (a machine-owned ensure with no live actor is an orphan), so pinning the
-;; entry's first-load `:status` + owner deterministically in a headless node test
-;; would require driving the framework's machine spawn/destroy internals beyond
-;; the example surface. The generic ensure-under-owner + release-on-owner-drop
-;; mechanics this pattern composes are already pinned in the resources artefact
-;; runtime suites (`implementation/resources/test/`); this example is therefore
-;; semantic-pinned on the four causal patterns route / event-lease / manual-
-;; refresh / machine-start-stop, and the machine-owned resource ENSURE step is
-;; left to the artefact runtime + compile coverage (see examples/README.md's
-;; coverage table). Driving it via the live spawn here proved order-fragile in
-;; the shared cljs.test bundle; the start/stop glue is the stable example-
-;; specific assertion.
+;; The test above pins the example's start/stop EVENT glue (the app-db slice).
+;; The test below pins the MACHINE-OWNED RESOURCE contract the example teaches:
+;; the reader ensures its detail under the runtime ACTOR-ID owner
+;; `[:machine :resources.app/reader]`, and stop-reader (actor destroy) releases
+;; exactly that owner. This is the regression pin for rf2-lbtqw4 — the example
+;; previously ensured under a three-part `[:machine machine-id instance-id]`
+;; owner while relying on actor-destroy auto-release, which the framework fires
+;; ONLY for the two-part `[:machine actor-id]` key (Spec 016 §Release authority
+;; is per owner kind, 016:291), so the lease leaked. The generic
+;; ensure-under-owner + release-on-owner-drop mechanics are also pinned in the
+;; resources artefact suites (`implementation/resources/test/`); this pins the
+;; EXAMPLE's specific owner shape + stop-reader cleanup end-to-end against the
+;; example's own events.
+
+(deftest reader-owns-its-article-under-the-actor-id-owner-released-on-stop
+  (testing "examples/capabilities/resources/resources — start-reader births the
+            :resources.app/reader actor and drives :reader/load, whose
+            :ensure-article action ensures :article/by-slug under the TWO-PART
+            runtime actor-id owner [:machine :resources.app/reader] — the one
+            machine owner the framework auto-releases on destroy (Spec 016:291) —
+            and NOT a three-part [:machine machine-id instance-id] key (an
+            app-authoritative lease the framework would NOT auto-release: the
+            leak the old example shape caused). stop-reader destroys the actor,
+            releasing that owner so the read is not left pinned (rf2-lbtqw4)."
+    (let [slug        "resources-101"
+          instance-id (str "reader-" slug)
+          actor-owner [:machine :resources.app/reader]
+          three-part  [:machine :resources.app/reader instance-id]
+          dkey        (detail-key slug)]
+      ;; START — births the actor, then :reader/load runs :ensure-article, which
+      ;; ensures the detail under the actor-id owner. Managed-HTTP is the
+      ;; capturing stub, so the entry sits :loading; the owner attaches at ensure.
+      (rf/dispatch-sync [:resources.app/start-reader slug])
+      (let [e (entry dkey)]
+        (is (some? e)
+            "the reader's machine-owned detail entry exists after start-reader")
+        (is (contains? (:active-owners e) actor-owner)
+            "ensured under the two-part actor-id owner [:machine :resources.app/reader]")
+        ;; ADVERSARIAL/NEGATIVE — the three-part [:machine machine-id instance-id]
+        ;; key must NOT be an owner. The old (buggy) shape attached it here and
+        ;; then leaked, because actor-destroy auto-releases only the two-part key.
+        (is (not (contains? (:active-owners e) three-part))
+            "the domain instance-id is NOT folded into the owner (that would leak)"))
+      ;; STOP — destroy the actor; teardown releases [:machine :resources.app/reader].
+      (rf/dispatch-sync [:resources.app/stop-reader])
+      (let [e (entry dkey)]
+        (is (or (nil? e) (not (contains? (:active-owners e) actor-owner)))
+            "stop-reader released the machine owner — the read is not left pinned")))))
 
 ;; ============================================================================
 ;; 5. LAYERED PROJECTION SUB — a projection OVER the resource, not a hook

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/resource_release.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/resource_release.cljc
@@ -1,11 +1,16 @@
 (ns re-frame.machines.lifecycle-fx.resource-release
   "Machine→resource lease release on actor destroy.
 
-  Per Spec 016 §Release authority is per owner kind (016:290):
+  Per Spec 016 §Release authority is per owner kind (016:291):
 
-    | Machine | [:machine machine-id instance-id] | Actor destroy — when the
-    owning machine instance is stopped/destroyed (005-StateMachines), its
-    resource leases are released. |
+    | Machine | [:machine actor-id] | Actor destroy — when the owning machine
+    instance is stopped/destroyed (005-StateMachines), its resource leases are
+    released. |
+
+  (A three-part `[:machine machine-id instance-id]` owner that folds a domain
+  instance-id into the key is an APP-authoritative lease the framework does NOT
+  auto-release; the framework auto-releases the runtime-owned `[:machine
+  actor-id]` key only. Spec 016:291.)
 
   The owner key the machine runtime owns is `[:machine actor-id]` — the
   runtime-derivable machine-owner key the derivation algebra names (Spec


### PR DESCRIPTION
## What & why

The resources example's `:resources.app/reader` machine ensured its article under a **three-part** `[:machine machine-id instance-id]` owner (`core.cljs`) while `stop-reader` relied on **actor destroy** to release it. But the framework auto-releases only the **two-part runtime actor-id** key `[:machine actor-id]` (Spec 016:291). A three-part owner that folds a *domain* instance-id into the key is an **app-authoritative** lease the framework does **not** auto-release. So `stop-reader` destroyed the actor but the read stayed owner-pinned — a slow leak (the entry keeps refetching/polling forever).

Spec 016:291 is already correct and needs no change; the bug was the example teaching the wrong shape.

## Changes (all within the resources-reader surface)

- **`examples/capabilities/resources/resources/core.cljs`** — ensure under `[:machine :resources.app/reader]` (the actor-id owner the runtime releases on destroy). Rewrote the surrounding narrative to explain the actor-id owner vs. the app-authoritative three-part variant, and why folding a domain instance-id into the owner would leak. instance-id is kept as the reader's `:data`/app-db domain identity, never the owner.
- **`examples/capabilities/resources/resources/README.md`** — aligned the machine-owned-resource bullet with the two-part owner + Spec 016 link.
- **`implementation/machines/src/re_frame/machines/lifecycle_fx/resource_release.cljc`** — docstring-only: corrected the stale quoted Spec-016 table row (it quoted the three-part shape, contradicting the correct `[:machine actor-id]` code right below it) and cited 016:291.
- **`implementation/adapters/reagent/test/re_frame/resources_example_cljs_test.cljs`** — replaced the stale "left unpinned" NOTE with an **adversarial/negative regression test** driving the example's own `start-reader`/`stop-reader` events: asserts (1) the two-part `[:machine :resources.app/reader]` owner is attached, (2) the three-part key is **NOT** an owner (the old buggy shape would fail here), and (3) `stop-reader` releases the owner so the read is not left pinned.

## Quality gates

| Command | Result |
|---|---|
| `implementation/ $ npm ci` | ok (110 packages) |
| `implementation/ $ npm run test:cljs` | **PASS** — 8141 tests, 37326 assertions, 0 failures, 0 errors |
| `implementation/machines/ $ clojure -M:test` (machines JVM) | **PASS** — 886 tests, 2848 assertions, 0 failures, 0 errors |

Full `test-fast-pr.sh` spine deferred to CI. The 3 `:undeclared-var` compile warnings in the CLJS build are pre-existing in unrelated files (`resources_revalidation_cljs_test.cljc`, `story_open_in_editor_cljs_test.cljs`), not touched here.

## Stance

Pre-alpha; no back-compat shims. Primary lenses: ELEGANCE + CLARITY + CORRECTNESS + GOOD PRACTICE. Fix is scoped strictly to the resources-reader files; no core frame/dispatch/registrar edits. No collision with #5312 (which touches `linearlite` + `login` examples, not `resources/resources`).

Closes rf2-lbtqw4.
