### PR TITLE
fix(story): snapshot-identity hash keys off effective tags (rf2-chzryf)

### DIFF
--- a/tools/story/spec/002-Runtime.md
+++ b/tools/story/spec/002-Runtime.md
@@ -677,7 +677,15 @@ the hash includes:
   canonicalised — per `re-frame.story.identity/variant-body-slice`)
 - Effective `:args` (post-merge with story + mode)
 - Decorator id sequence and their args
-- Tag set
+- The variant's **effective tag set** — resolved through the shared
+  `re-frame.story.tags` resolver (`:extends`-chain / parent-story
+  inheritance + `:!x` removal-marker resolution — see
+  [001 §Effective tags](001-Authoring.md)), NOT the raw child `:tags`.
+  This single slot subsumes both the variant's own tags and the parent
+  story's tags (as fallback), so identity keys off the same effective
+  classification every other tag consumer reads: an `:extends`-parent tag
+  edit perturbs the hash, a `:!x` marker that cancels an inherited tag
+  does not, and raw `:!x` authoring syntax never reaches the hash.
 - Parent story `:component` id
 - Parent story decorators
 - Registered schema digest of `:component` (per

--- a/tools/story/src/re_frame/story/identity.cljc
+++ b/tools/story/src/re_frame/story/identity.cljc
@@ -57,12 +57,18 @@
     (in declared order; canonicalised)
   - Effective `:args` (post-`:extends`-merge with story + active modes)
   - Variant `:decorators` id sequence + their ref-args
-  - Variant `:tags` set
+  - The variant's EFFECTIVE tag set — inheritance (`:extends`-chain union
+    / parent-story fallback) then `:!x` removal-marker resolution, via the
+    shared `re-frame.story.tags` resolver. This single slot subsumes BOTH
+    the variant's own tags AND the parent story's tags (as fallback), so
+    the identity keys off the variant's resolved classification exactly as
+    every other tag consumer reads it — an `:extends`-parent tag edit
+    perturbs the hash, a `:!x` marker that cancels an inherited tag does
+    NOT, and raw `:!x` authoring syntax never reaches the hash.
   - Variant `:viewport` / `:background` visual chrome
   - Variant `:args->events`, `:platforms`, `:substrates` targeting
   - Parent story `:component` id
   - Parent story `:decorators`
-  - Parent story `:tags`
   - The *registered* schema digest of the view (per spec/011
     §`:rf/schema-digest`) — sourced via the `:schemas/app-schemas-digest`
     late-bind hook so a schema change invalidates the snapshot identity.
@@ -94,7 +100,8 @@
   (:require [re-frame.late-bind         :as late-bind]
             [re-frame.story.args        :as args]
             [re-frame.story.fingerprint :as fingerprint]
-            [re-frame.story.registrar   :as registrar]))
+            [re-frame.story.registrar   :as registrar]
+            [re-frame.story.tags        :as tags]))
 
 ;; ---- snapshot tuple -------------------------------------------------------
 
@@ -120,7 +127,7 @@
   - `:events` — pre-render setup dispatches.
   - `:loaders` / `:loaders-complete-when` / `:loaders-teardown` — async
     setup + the symmetric teardown; both shape the frame's settled state.
-  - `:decorators` / `:tags` — composition + classification.
+  - `:decorators` — composition.
   - `:viewport` / `:background` — visual chrome that lands IN the
     screenshot, so a baseline must invalidate when they change.
   - `:args->events` / `:platforms` / `:substrates` — derivation +
@@ -130,6 +137,13 @@
   - `:args` — captured via `:effective-args` in `snapshot-tuple` (post-
     `:extends`-merge + active-mode merge), so reproducing it here would
     double-count.
+  - `:tags` — captured via `:effective-tags` in `snapshot-tuple`, the
+    variant's RESOLVED tag set (`:extends`/story inheritance + `:!x`
+    marker resolution, through the shared `re-frame.story.tags` resolver).
+    Selecting the RAW child `:tags` here would (a) leak `:!x` authoring
+    syntax into the hash, (b) miss `:extends`-chain tag inheritance, and
+    (c) diverge from every other tag consumer. The effective slot is the
+    single tag input; the raw child + story tag slots are NOT hashed.
   - `:argtypes` — controls-panel metadata only; it shapes the controls
     UI, not the rendered snapshot. The args it constrains are already
     captured via `:effective-args`.
@@ -147,18 +161,26 @@
       (select-keys body
                    [:events :play-script :plays
                     :loaders :loaders-complete-when :loaders-teardown
-                    :tags :decorators :args->events :platforms :substrates
+                    :decorators :args->events :platforms :substrates
                     :viewport :background]))))
 
 (defn- story-body-slice
   "Story-level slice that the variant inherits for identity purposes.
-  Per `002-Runtime.md` §Snapshot-identity computation the parent story's `:component` id and
-  `:decorators` are part of the variant's identity."
+  Per `002-Runtime.md` §Snapshot-identity computation the parent story's
+  `:component` id and `:decorators` are part of the variant's identity.
+
+  The parent story's `:tags` are NOT selected here — they reach the hash
+  (as a fallback default) through the variant's `:effective-tags` slot in
+  `snapshot-tuple`. Hashing the story's RAW `:tags` here as well would
+  double-count and re-introduce spurious invalidation: a story-tag edit
+  that does NOT change a given variant's effective set (because the variant
+  declares its own tags, so story tags are not inherited) would still
+  perturb that variant's hash."
   [variant-id]
   (let [story-id (args/parent-story-id variant-id)
         body     (when story-id (registrar/handler-meta :story story-id))]
     (when body
-      (select-keys body [:component :decorators :tags]))))
+      (select-keys body [:component :decorators]))))
 
 (defn- view-schema-digest
   "Return the *registered* schema digest of the view per /spec/007-Stories.md §Variant
@@ -185,6 +207,27 @@
   [target-frame-id]
   (when-let [f (late-bind/get-fn :schemas/app-schemas-digest)]
     (f target-frame-id)))
+
+(defn- effective-tags-slice
+  "Return `variant-id`'s EFFECTIVE tag set via the shared
+  `re-frame.story.tags` resolver — the SAME resolution every other tag
+  consumer (membership `variants-with-tags`, docs / sidebar chips, the tag
+  filter, plan compilation, snapshot UI state) reads through. Folds the
+  `:extends`-chain union (or parent-story fallback) then `:!x` removal-
+  marker resolution, so:
+
+  - an `:extends`-parent tag edit perturbs the identity (RAW child `:tags`
+    could not see it),
+  - a `:!x` marker that cancels an inherited tag does NOT perturb it, and
+  - raw `:!x` authoring syntax never reaches the hash.
+
+  Reads live side-tables via the registrar (`:variant` + `:story`
+  registrations). Returns a set; `fingerprint/content-hash` canonicalises
+  it with a stable order."
+  [variant-id]
+  (tags/effective-tags variant-id
+                       {:variant (registrar/registrations :variant)
+                        :story   (registrar/registrations :story)}))
 
 (defn snapshot-tuple
   "Build the canonical tuple that feeds `content-hash` for a variant.
@@ -219,6 +262,13 @@
       :variant               variant
       :story                 story
       :effective-args        effective
+      ;; The variant's RESOLVED tag set (shared `re-frame.story.tags`
+      ;; resolver — `:extends`/story inheritance + `:!x` marker removal),
+      ;; the single tag input to the hash. Raw child + story `:tags` slots
+      ;; are intentionally NOT selected in the body slices; this subsumes
+      ;; them. Keeps watch-mode drift + visual-regression identity keyed
+      ;; off the SAME effective classification every other consumer reads.
+      :effective-tags        (effective-tags-slice variant-id)
       :view-schema-digest    schema-digest
       ;; `:active-modes` already perturbs identity via
       ;; `:effective-args` (mode args are merged in by `resolve-args`),

--- a/tools/story/test/re_frame/story_runtime_test.clj
+++ b/tools/story/test/re_frame/story_runtime_test.clj
@@ -570,6 +570,72 @@
         (finally
           (late-bind/set-fn! :schemas/app-schemas-digest prior))))))
 
+;; ---- rf2-chzryf: identity keys off EFFECTIVE tags, not raw child :tags ----
+;;
+;; Follow-on from rf2-n0vmq2/#5308. The shared `re-frame.story.tags`
+;; resolver feeds every OTHER tag consumer (membership, docs chips, the
+;; tag filter, plan compilation, snapshot UI state). Snapshot identity was
+;; the straggler still reading the RAW child `:tags`. These tests pin the
+;; decision: the content-hash keys off the variant's EFFECTIVE tag set.
+
+(deftest snapshot-identity-hashes-effective-not-raw-tags
+  (testing "rf2-chzryf — two authorings that resolve to the SAME effective
+            tag set produce the SAME hash. `#{:docs}` and
+            `#{:dev :!dev :docs}` both resolve to `#{:docs}` (the `:!dev`
+            marker drops itself AND cancels the unioned `:dev`), so the
+            snapshot identity of the SAME variant is stable across the edit.
+            RED against the raw-tags reader: `#{:docs}` ≠
+            `#{:dev :!dev :docs}` as raw sets, so it would perturb the hash."
+    (story/reg-story :story.eff-tag {:component :app/v})
+    (story/reg-variant :story.eff-tag/v {:events [] :tags #{:docs}})
+    (let [h-plain (-> (story/snapshot-identity :story.eff-tag/v) :content-hash)]
+      ;; Re-register the SAME variant with a marker authoring that RESOLVES
+      ;; to the identical effective set `#{:docs}`.
+      (story/reg-variant :story.eff-tag/v {:events [] :tags #{:dev :!dev :docs}})
+      (let [h-marker (-> (story/snapshot-identity :story.eff-tag/v) :content-hash)]
+        (is (= h-plain h-marker)
+            "identical effective tag set → identical hash (raw authoring differs)")
+        ;; Witness the tuple slot directly: it carries the RESOLVED set,
+        ;; and the raw `:!x` marker never appears in it.
+        (let [eff (:effective-tags (ident/snapshot-tuple :story.eff-tag/v))]
+          (is (= #{:docs} eff) "the tuple carries the effective set")
+          (is (not (contains? eff :!dev)) "raw `:!x` marker never reaches the hash"))))))
+
+(deftest snapshot-identity-changes-with-effective-tag-set
+  (testing "rf2-chzryf — a genuine change to the effective tag set DOES
+            perturb the hash (tags remain identity-bearing, they are not
+            simply dropped from the identity)."
+    (story/reg-story :story.eff-tag-chg {:component :app/v})
+    (story/reg-variant :story.eff-tag-chg/v {:events [] :tags #{:docs}})
+    (let [h1 (-> (story/snapshot-identity :story.eff-tag-chg/v) :content-hash)]
+      (story/reg-variant :story.eff-tag-chg/v {:events [] :tags #{:docs :test}})
+      (let [h2 (-> (story/snapshot-identity :story.eff-tag-chg/v) :content-hash)]
+        (is (not= h1 h2)
+            "adding an effective tag must produce a fresh hash")))))
+
+(deftest snapshot-identity-changes-with-extends-parent-tag
+  (testing "rf2-chzryf — the correctness win: editing an `:extends`-PARENT's
+            tags changes the CHILD's effective classification and MUST
+            perturb the child's snapshot identity. RED against the raw-tags
+            reader — the child's raw `:tags` are empty and its story's tags
+            are unchanged, so the pre-fix identity slice (child raw + story
+            raw, never the extends-parent) would NOT see the change."
+    (story/reg-story :story.eff-tag-ext {:component :app/v})
+    ;; Child ONLY :extends the parent — declares no tags of its own, so its
+    ;; effective set is entirely inherited from the parent.
+    (story/reg-variant :story.eff-tag-ext/parent {:events [] :tags #{:dev}})
+    (story/reg-variant :story.eff-tag-ext/child  {:extends :story.eff-tag-ext/parent})
+    (is (= #{:dev} (:effective-tags (ident/snapshot-tuple :story.eff-tag-ext/child)))
+        "the child inherits the parent's tags through the :extends chain")
+    (let [h1 (-> (story/snapshot-identity :story.eff-tag-ext/child) :content-hash)]
+      ;; Edit ONLY the parent's tags. The child's raw body is untouched.
+      (story/reg-variant :story.eff-tag-ext/parent {:events [] :tags #{:docs}})
+      (is (= #{:docs} (:effective-tags (ident/snapshot-tuple :story.eff-tag-ext/child)))
+          "the child's effective set now reflects the parent's edit")
+      (let [h2 (-> (story/snapshot-identity :story.eff-tag-ext/child) :content-hash)]
+        (is (not= h1 h2)
+            "an :extends-parent tag edit perturbs the child's hash")))))
+
 (deftest snapshot-identity-canonical-key-stable
   (testing "the canonical-version tag canonicalises and map key order is
             hash-stable"


### PR DESCRIPTION
## What

Follow-on from rf2-n0vmq2/#5308. The shared `re-frame.story.tags` resolver became the single authority every tag consumer reads (membership `variants-with-tags`, docs/sidebar chips, tag filter, plan compilation, snapshot UI state). `identity.cljc`'s snapshot-identity content-hash — the watch-mode drift input + visual-regression key — was the last consumer still reading the **raw** child `:tags` (and, via `story-body-slice`, the parent story's raw `:tags`).

## Decision: key the content-hash off the variant's EFFECTIVE tag set

Not merely a consistency clean-up — raw hashing had a real correctness hole:

1. **Correctness hole (raw missed real changes).** An `:extends`-**parent** tag edit changes the child's effective classification, but the child's raw `:tags` (and its story's) are unchanged — the pre-fix identity slice never hashed the extends-parent, so watch-mode drift silently **missed** it.
2. **Spurious invalidations (raw over-fired).** Because `story-body-slice` also hashed the parent story's raw `:tags`, a story-tag edit that does *not* change a given variant's effective set (the variant declares its own tags, so story tags aren't inherited) still perturbed that variant's hash.
3. **`:!x` markers are authoring syntax.** The resolver docstring: a `:!x` marker "is authoring syntax, never a visible / queryable tag." Folding raw `:!x` markers into a content identity is incoherent when every other surface strips them (e.g. cleaning up `#{:dev :!dev :docs}` → `#{:docs}`, same classification, would spuriously change the hash).

The RAW-is-correct steelman ("drift should key only off the variant's own source") fails: the pre-fix design already hashed the *story's* raw tags into the child, so it already treated inherited tags as identity-bearing — and if tags matter to identity at all (they do, documented as "classification"), the **effective** set is what the variant actually is.

## Change

- Drop `:tags` from `variant-body-slice` **and** `story-body-slice` (the story slice keeps only `:component` + `:decorators`).
- Add a single `:effective-tags` slot to `snapshot-tuple`, computed through `tags/effective-tags` over the live registrar `:variant` + `:story` side-tables. The effective set subsumes both the variant's own tags and the parent story's (as fallback), so there is exactly **one** tag input — no double-counting, no spurious story-refactor invalidation, and identity matches the classification every other consumer reads.

## Files changed

- `tools/story/src/re_frame/story/identity.cljc` — resolver wiring + docstrings.
- `tools/story/test/re_frame/story_runtime_test.clj` — 3 regressions.
- `tools/story/spec/002-Runtime.md` — §Snapshot-identity computation (effective tag set; parent-story tags subsumed).

Top-level `spec/007-Stories.md` is out of this worker's surface (tools/story only) — unchanged; its "Parent story `:tags`" statement stays true (they still participate, now via the effective resolution).

## Regressions (JVM, `story_runtime_test.clj`)

- `snapshot-identity-hashes-effective-not-raw-tags` — `#{:docs}` and `#{:dev :!dev :docs}` hash **identically** (both resolve to `#{:docs}`); tuple slot carries the resolved set and never the `:!dev` marker.
- `snapshot-identity-changes-with-effective-tag-set` — a genuine effective-set change still perturbs the hash (tags remain identity-bearing).
- `snapshot-identity-changes-with-extends-parent-tag` — the correctness win: an `:extends`-parent tag edit perturbs the child hash.

## Quality gates

- `cd tools/story && clojure -M:test` — **1765 tests, 6491 assertions, 0 failures, 0 errors** (includes the 3 new regressions). Full spine deferred to CI.

## Stance

Pre-alpha, no back-compat shims; ELEGANCE + CLARITY + CORRECTNESS. One tag input to the hash, matching the single-authority resolver; no over-engineering.