### PR TITLE
fix(check-examples-assets): validate srcset + video poster refs (rf2-arkvq8)

### DIFF
--- a/examples/scripts/check-examples-assets.cjs
+++ b/examples/scripts/check-examples-assets.cjs
@@ -27,8 +27,10 @@
  * It walks every tracked example index.html and, for each:
  *
  *   1. RESOLVES every local asset reference (link href, script src,
- *      og:image meta, and transitively the @import targets inside any
- *      referenced local CSS) to a real file in the repo source tree. A
+ *      img/source/video src, each `srcset`/`imagesrcset` candidate, a
+ *      `<video poster>` still (rf2-arkvq8), og:image meta, and transitively the
+ *      @import targets inside any referenced local CSS) to a real file in the
+ *      repo source tree. A
  *      reference to a missing/renamed/typo'd local asset fails the gate.
  *      The build output main.js (produced by shadow-cljs, not source) is
  *      skipped.
@@ -36,8 +38,10 @@
  *      DIRECT-HTML NETWORK REFS are NOT skipped (rf2-bf4vdy). An
  *      asset-bearing external reference in the page — a `<script src>`, an
  *      asset `<link href>` (stylesheet / preload / modulepreload / icon /
- *      manifest / prefetch), an `<img>/<source>/<video>/<audio> src`, or a
- *      LOCAL-staged-but-external og:image — pulls a third-party CDN
+ *      manifest / prefetch), an `<img>/<source>/<video>/<audio> src`, an
+ *      `<img>/<source> srcset` or `<link imagesrcset>` candidate, a
+ *      `<video poster>` still (rf2-arkvq8), or a LOCAL-staged-but-external
+ *      og:image — pulls a third-party CDN
  *      script / hosted stylesheet / hosted font / external media into every
  *      staged example at load time. That is the same reproducibility /
  *      offline-dev / hidden-dependency regression the external-CSS-@import
@@ -333,6 +337,49 @@ const ASSET_LINK_RELS = new Set([
   'manifest',
 ]);
 
+// Parse an HTML `srcset` / `imagesrcset` attribute value into its candidate
+// URLs, discarding the width/density descriptors (rf2-arkvq8). srcset is a
+// comma-separated list of `<url> [descriptor]` candidates — e.g.
+// `hero-320.png 320w, hero-640.png 640w` (width descriptors) or
+// `logo.png 1x, logo@2x.png 2x` (density descriptors). Every candidate URL is a
+// load-time image fetch, so a remote candidate is a third-party network
+// dependency and a local candidate must resolve on disk — exactly like a plain
+// `src`. Follows the WHATWG "parse a srcset attribute" shape: a candidate URL is
+// the run of non-whitespace characters, trailing commas terminate a
+// descriptor-less candidate (and are separators, not part of the URL), and the
+// descriptor (if any) runs to the next comma. Reading the URL as a
+// non-whitespace run keeps a comma-bearing `data:` URI (which has no internal
+// whitespace) intact rather than splitting it mid-URI. Returns the candidate
+// URLs in source order; the caller strips ?query/#hash as it does for src/href.
+function parseSrcset(value) {
+  const urls = [];
+  const isWs = (c) =>
+    c === ' ' || c === '\t' || c === '\n' || c === '\r' || c === '\f';
+  let i = 0;
+  const n = value.length;
+  while (i < n) {
+    // Skip whitespace and stray commas between candidates.
+    while (i < n && (isWs(value[i]) || value[i] === ',')) i++;
+    if (i >= n) break;
+    // The URL is the run of non-whitespace characters.
+    const start = i;
+    while (i < n && !isWs(value[i])) i++;
+    let url = value.slice(start, i);
+    // Trailing commas terminate a descriptor-less candidate (per the spec); they
+    // are separators between candidates, not part of the URL.
+    let hadTrailingComma = false;
+    while (url.endsWith(',')) {
+      url = url.slice(0, -1);
+      hadTrailingComma = true;
+    }
+    if (url) urls.push(url);
+    if (hadTrailingComma) continue; // next candidate begins immediately
+    // Skip this candidate's descriptor (e.g. `320w` / `2x`) up to the next comma.
+    while (i < n && value[i] !== ',') i++;
+  }
+  return urls;
+}
+
 // Extract every ASSET-BEARING reference from an index.html's source, TAGGED
 // with the element/attribute it came from, so the direct-HTML network policy
 // (rf2-bf4vdy) can distinguish a remote asset fetch (rejected) from harmless
@@ -344,10 +391,14 @@ const ASSET_LINK_RELS = new Set([
 // What counts as asset-bearing:
 //   - <script src=...>                          (always a fetch)
 //   - <link rel="<asset rel>" href=...>         (stylesheet/preload/icon/…)
+//   - <link ... imagesrcset=...>                (responsive preload candidates)
 //   - <img|source|video|audio|track src=...>    (media fetch)
+//   - <img|source srcset=...>                   (responsive image candidates)
+//   - <video poster=...>                        (poster-still image fetch)
 //   - <meta property="og:image" content=...>    (social-preview fetch)
 // An <a href> / a <link rel="canonical"> / any non-asset element href is pure
-// navigation and is intentionally NOT returned.
+// navigation and is intentionally NOT returned. srcset/imagesrcset each expand
+// to their candidate URLs; the poster is a single image fetch (rf2-arkvq8).
 function extractAssetRefs(html) {
   const out = [];
   const seen = new Set();
@@ -373,21 +424,41 @@ function extractAssetRefs(html) {
     if (src) push(src, '<script src>');
   }
 
-  // <link rel="..." href=...> — asset-bearing only for the rels above.
+  // <link rel="..." href=...> — asset-bearing only for the rels above. A
+  // `<link rel="preload" as="image" imagesrcset=...>` also carries a responsive
+  // candidate list (like <img srcset>) and often has NO href, so imagesrcset is
+  // handled independently of the href/rel gate (rf2-arkvq8).
   for (const m of html.matchAll(/<link\b[^>]*>/gi)) {
     const tag = m[0];
-    const href = attr(tag, 'href');
-    if (!href) continue;
     const rel = (attr(tag, 'rel') || '').toLowerCase().trim();
     const tokens = rel.split(/\s+/).filter(Boolean);
     const isAsset = tokens.some((t) => ASSET_LINK_RELS.has(t));
-    if (isAsset) push(href, `<link rel="${rel || '(none)'}" href>`);
+    const href = attr(tag, 'href');
+    if (href && isAsset) push(href, `<link rel="${rel || '(none)'}" href>`);
+    const imagesrcset = attr(tag, 'imagesrcset');
+    if (imagesrcset) {
+      for (const u of parseSrcset(imagesrcset)) {
+        push(u, `<link rel="${rel || '(none)'}" imagesrcset>`);
+      }
+    }
   }
 
-  // <img|source|video|audio|track src=...> — media fetch.
+  // <img|source|video|audio|track src=...> — media fetch. <img>/<source> also
+  // carry a `srcset` candidate list and <video> a `poster` still, each a
+  // load-time image fetch (rf2-arkvq8).
   for (const m of html.matchAll(/<(img|source|video|audio|track)\b[^>]*>/gi)) {
-    const src = attr(m[0], 'src');
-    if (src) push(src, `<${m[1].toLowerCase()} src>`);
+    const tag = m[0];
+    const el = m[1].toLowerCase();
+    const src = attr(tag, 'src');
+    if (src) push(src, `<${el} src>`);
+    if (el === 'img' || el === 'source') {
+      const srcset = attr(tag, 'srcset');
+      if (srcset) for (const u of parseSrcset(srcset)) push(u, `<${el} srcset>`);
+    }
+    if (el === 'video') {
+      const poster = attr(tag, 'poster');
+      if (poster) push(poster, '<video poster>');
+    }
   }
 
   // <meta property="og:image" content=...> — social-preview fetch.
@@ -411,6 +482,21 @@ function extractHtmlRefs(html) {
   // href="..." / href='...' on <link> (and any element — anchors are
   // in-page or external and get filtered by isExternalRef downstream).
   for (const m of html.matchAll(/\b(?:href|src)\s*=\s*("([^"]*)"|'([^']*)')/gi)) {
+    push(m[2] != null ? m[2] : m[3]);
+  }
+  // srcset / imagesrcset candidate lists (<img>/<source> + preload <link>) —
+  // each candidate URL must resolve on disk like a plain src (rf2-arkvq8). The
+  // negative lookbehind keeps a `data-srcset` (lazy-load) attribute out.
+  for (const m of html.matchAll(
+    /(?<![-\w])(?:imagesrcset|srcset)\s*=\s*("([^"]*)"|'([^']*)')/gi,
+  )) {
+    for (const u of parseSrcset(m[2] != null ? m[2] : m[3])) push(u);
+  }
+  // <video poster="..."> — the poster still resolves on disk like a src
+  // (rf2-arkvq8). The lookbehind excludes a `data-poster` attribute.
+  for (const m of html.matchAll(
+    /(?<![-\w])poster\s*=\s*("([^"]*)"|'([^']*)')/gi,
+  )) {
     push(m[2] != null ? m[2] : m[3]);
   }
   // <meta property="og:image" content="...">
@@ -1175,6 +1261,7 @@ module.exports = {
   extractHtmlRefs,
   extractAssetRefs,
   extractOgImageRefs,
+  parseSrcset,
   extractCssImports,
   extractCssUrls,
   resolveRef,

--- a/implementation/scripts/check-examples-assets.test.cjs
+++ b/implementation/scripts/check-examples-assets.test.cjs
@@ -42,6 +42,7 @@ const {
   extractHtmlRefs,
   extractAssetRefs,
   extractOgImageRefs,
+  parseSrcset,
   extractCssImports,
   extractCssUrls,
   resolveRef,
@@ -342,6 +343,188 @@ it('extractAssetRefs does NOT treat an <a href> or rel=canonical as an asset', (
   assert.ok(!refs.includes('https://example.com/docs'), 'anchors are navigation, not assets');
   assert.ok(!refs.includes('https://example.com/page'), 'rel=canonical is metadata, not an asset');
   assert.ok(!refs.includes('https://example.com/rss'), 'rel=alternate is metadata, not an asset');
+});
+
+// ---- srcset + video poster refs (rf2-arkvq8) ----------------------------
+//
+// Before rf2-arkvq8 the scanner only read href/src-style refs, so a `srcset`
+// candidate (`<img srcset="a-320.png 320w, a-640.png 640w">`) and a
+// `<video poster="still.png">` were invisible to BOTH the network policy (a
+// remote candidate/poster slipped through) and the missing-file check (a
+// broken local candidate/poster stayed green). srcset/imagesrcset candidates
+// and the poster still are now extracted for both gates.
+
+it('parseSrcset returns candidate URLs, dropping width/density descriptors', () => {
+  assert.deepStrictEqual(
+    parseSrcset('hero-320.png 320w, hero-640.png 640w, hero-960.png 960w'),
+    ['hero-320.png', 'hero-640.png', 'hero-960.png'],
+  );
+  assert.deepStrictEqual(
+    parseSrcset('logo.png 1x, logo@2x.png 2x'),
+    ['logo.png', 'logo@2x.png'],
+  );
+});
+
+it('parseSrcset handles a single descriptor-less candidate', () => {
+  assert.deepStrictEqual(parseSrcset('only.png'), ['only.png']);
+  // A trailing comma on a descriptor-less candidate is a separator, not URL.
+  assert.deepStrictEqual(parseSrcset('a.png, b.png 2x'), ['a.png', 'b.png']);
+});
+
+it('parseSrcset keeps a comma-bearing data: URI candidate intact', () => {
+  // A data: URI has no internal whitespace, so it is read as ONE candidate URL
+  // even though it contains commas — a naive comma-split would shred it.
+  assert.deepStrictEqual(
+    parseSrcset('data:image/svg+xml,%3Csvg%3E%3C/svg%3E 1x, next.png 2x'),
+    ['data:image/svg+xml,%3Csvg%3E%3C/svg%3E', 'next.png'],
+  );
+});
+
+it('parseSrcset tolerates extra whitespace and stray commas', () => {
+  assert.deepStrictEqual(
+    parseSrcset('  a.png   320w ,  b.png  2x  '),
+    ['a.png', 'b.png'],
+  );
+});
+
+it('extractHtmlRefs picks up srcset / imagesrcset candidates + video poster', () => {
+  const refs = extractHtmlRefs(
+    [
+      '<img srcset="_shared/img/hero-320.png 320w, _shared/img/hero-640.png 640w">',
+      '<source srcset="_shared/img/pic@2x.png 2x">',
+      '<link rel="preload" as="image" imagesrcset="_shared/img/pre-1.png 1x">',
+      '<video poster="_shared/img/poster.png"><source src="clip.mp4"></video>',
+    ].join('\n'),
+  );
+  for (const ref of [
+    '_shared/img/hero-320.png',
+    '_shared/img/hero-640.png',
+    '_shared/img/pic@2x.png',
+    '_shared/img/pre-1.png',
+    '_shared/img/poster.png',
+  ]) {
+    assert.ok(refs.includes(ref), `expected ${ref} in refs, got: ${refs.join(', ')}`);
+  }
+});
+
+it('extractHtmlRefs does NOT treat data-srcset / data-poster (lazy-load) as refs', () => {
+  const refs = extractHtmlRefs(
+    '<img data-srcset="lazy.png 2x" data-poster="lazy-poster.png">',
+  );
+  assert.ok(!refs.includes('lazy.png'), 'data-srcset must not be read as a srcset');
+  assert.ok(!refs.includes('lazy-poster.png'), 'data-poster must not be read as a poster');
+});
+
+it('extractAssetRefs tags srcset candidates, imagesrcset, and the video poster', () => {
+  const tagged = extractAssetRefs(
+    [
+      '<img srcset="https://img.example.com/a-320.png 320w, https://img.example.com/a-640.png 640w">',
+      '<link rel="preload" as="image" imagesrcset="https://img.example.com/pre.png 1x">',
+      '<video poster="https://img.example.com/still.png"></video>',
+    ].join('\n'),
+  );
+  const byRef = Object.fromEntries(tagged.map((t) => [t.ref, t.source]));
+  assert.ok(byRef['https://img.example.com/a-320.png'].includes('srcset'));
+  assert.ok(byRef['https://img.example.com/a-640.png'].includes('srcset'));
+  assert.ok(byRef['https://img.example.com/pre.png'].includes('imagesrcset'));
+  assert.strictEqual(byRef['https://img.example.com/still.png'], '<video poster>');
+});
+
+it('TEETH: a missing LOCAL srcset candidate is reported (rf2-arkvq8)', () => {
+  // The page references two responsive candidates; the 640w one is absent on
+  // disk — the missing-file check must fire on the srcset candidate.
+  const html = goodHtml().replace(
+    '</head>',
+    '<img srcset="_shared/img/hero-320.png 320w, _shared/img/hero-640.png 640w">\n</head>',
+  );
+  const HERO320 = path.join(EXAMPLES_ROOT, '_shared', 'img', 'hero-320.png');
+  const io = fullIo({ [PAGE]: html, [HERO320]: 'PNGDATA' });
+  const { errors } = scanPage(io, PAGE);
+  assert.ok(
+    errors.some(
+      (e) => e.includes('_shared/img/hero-640.png') && e.includes('does not resolve'),
+    ),
+    `expected the missing srcset candidate to be reported, got: ${errors.join(' | ')}`,
+  );
+  // The present candidate must NOT be flagged.
+  assert.ok(
+    !errors.some((e) => e.includes('hero-320.png')),
+    `the present srcset candidate must not be flagged, got: ${errors.join(' | ')}`,
+  );
+});
+
+it('TEETH: a missing LOCAL <video poster> is reported (rf2-arkvq8)', () => {
+  const html = goodHtml().replace(
+    '</head>',
+    '<video poster="_shared/img/poster.png"></video>\n</head>',
+  );
+  const { errors } = scanPage(fullIo({ [PAGE]: html }), PAGE);
+  assert.ok(
+    errors.some(
+      (e) => e.includes('_shared/img/poster.png') && e.includes('does not resolve'),
+    ),
+    `expected the missing poster to be reported, got: ${errors.join(' | ')}`,
+  );
+});
+
+it('TEETH: a remote srcset candidate is REJECTED by the network policy (rf2-arkvq8)', () => {
+  const html = goodHtml().replace(
+    '</head>',
+    '<img srcset="_shared/img/hero-320.png 320w, https://cdn.example.com/hero-2x.png 2x">\n</head>',
+  );
+  const HERO320 = path.join(EXAMPLES_ROOT, '_shared', 'img', 'hero-320.png');
+  const { errors } = scanPage(fullIo({ [PAGE]: html, [HERO320]: 'PNGDATA' }), PAGE);
+  assert.ok(
+    errors.some(
+      (e) => e.includes('srcset') && e.includes('cdn.example.com') && e.includes('rf2-bf4vdy'),
+    ),
+    `expected the remote srcset candidate to be rejected, got: ${errors.join(' | ')}`,
+  );
+  // A network candidate is a policy rejection, never checked on disk.
+  assert.ok(
+    !errors.some((e) => e.includes('cdn.example.com') && e.includes('does not resolve')),
+    `a remote srcset candidate must never be resolved on disk, got: ${errors.join(' | ')}`,
+  );
+});
+
+it('TEETH: a remote <video poster> is REJECTED by the network policy (rf2-arkvq8)', () => {
+  const html = goodHtml().replace(
+    '</head>',
+    '<video poster="//cdn.example.com/still.png"></video>\n</head>',
+  );
+  const { errors } = scanPage(fullIo({ [PAGE]: html }), PAGE);
+  assert.ok(
+    errors.some(
+      (e) => e.includes('<video poster>') && e.includes('//cdn.example.com/still.png'),
+    ),
+    `expected the remote poster to be rejected, got: ${errors.join(' | ')}`,
+  );
+});
+
+it('a page with all-local srcset candidates + poster present scans clean (rf2-arkvq8)', () => {
+  const html = goodHtml().replace(
+    '</head>',
+    [
+      '<img srcset="_shared/img/hero-320.png 320w, _shared/img/hero-640.png 640w">',
+      '<video poster="_shared/img/poster.png"></video>',
+      '</head>',
+    ].join('\n'),
+  );
+  const HERO320 = path.join(EXAMPLES_ROOT, '_shared', 'img', 'hero-320.png');
+  const HERO640 = path.join(EXAMPLES_ROOT, '_shared', 'img', 'hero-640.png');
+  const POSTER = path.join(EXAMPLES_ROOT, '_shared', 'img', 'poster.png');
+  const io = fullIo({
+    [PAGE]: html,
+    [HERO320]: 'PNGDATA',
+    [HERO640]: 'PNGDATA',
+    [POSTER]: 'PNGDATA',
+  });
+  const { errors } = scanPage(io, PAGE);
+  assert.deepStrictEqual(
+    errors,
+    [],
+    `all-local srcset + poster should scan clean, got: ${errors.join(' | ')}`,
+  );
 });
 
 // ---- staging-aware resolution -------------------------------------------


### PR DESCRIPTION
## What

`check-examples-assets` only extracted `href`/`src`-style refs, so responsive-image `srcset` candidates and `<video poster>` stills were invisible to **both** gates the scanner enforces:

- the **direct-HTML network policy** (rf2-bf4vdy) — a remote `srcset` candidate or a remote `poster` slipped through as a hidden third-party dependency; and
- the **missing-file check** — a broken local `srcset`/`poster` target stayed green.

This extends both extraction paths to cover them.

## Changes (touch only the validator + its tests)

- **`examples/scripts/check-examples-assets.cjs`**
  - New `parseSrcset()` — a WHATWG-shaped `srcset`/`imagesrcset` parser: splits the comma-separated candidate list, drops the `320w` / `2x` descriptors, and (by reading each URL as a non-whitespace run) keeps a comma-bearing `data:` URI candidate intact instead of shredding it on commas.
  - `extractHtmlRefs` (on-disk resolution) now emits every `srcset`/`imagesrcset` candidate URL and the `<video poster>` still. A negative lookbehind keeps `data-srcset` / `data-poster` (lazy-load) attributes out.
  - `extractAssetRefs` (network policy, tagged) now emits `<img>/<source> srcset` candidates, `<link imagesrcset>` candidates, and `<video poster>` — so a remote one is rejected exactly like a remote `<img src>`.
  - Header/function doc-comments updated to list the new asset-bearing shapes.
- **`implementation/scripts/check-examples-assets.test.cjs`**
  - `parseSrcset` unit tests (width + density descriptors, single descriptor-less candidate, comma-bearing `data:` URI, whitespace tolerance).
  - Extraction tests for `srcset`/`imagesrcset`/`poster`, plus the `data-*` negative control.
  - Adversarial teeth: a missing local `srcset` candidate **and** a missing `<video poster>` are reported; a remote `srcset` candidate **and** a remote `poster` are rejected by the network policy; an all-local page scans clean.

No behaviour change for existing shapes; the live examples tree ships no `srcset`/`poster` today, so the gate stays green. Workflows untouched (the gate runs via the existing `test:script-policy` wiring).

## Quality gates

Run foreground from the worktree:

- `node examples/scripts/check-examples-assets.cjs` → **PASS** (35 host pages + `_shared` tree, exit 0).
- `node implementation/scripts/check-examples-assets.test.cjs` → **all 91 tests PASS** (6 new srcset/poster teeth + the existing suite).
- **Teeth-proof on the real tree:** injected a missing `srcset` candidate + `<video poster>` into `examples/core/counter/index.html` → scanner went **RED** (3 violations, exit 1) → `git checkout` restored → **GREEN** (exit 0).

CI-only gates (full `test:script-policy` / other npm gates) deferred to the PR pipeline; no `.github/workflows/*` touched.

## Stance

pre-alpha, no back-compat shims; ELEGANCE + CLARITY + CORRECTNESS. The parser is the minimal spec-shaped extraction the two existing policies need — no new gate, no new config surface.
