### PR TITLE
fix(test-quiet): runner exits non-zero on test failure (rf2-jmrdhn)

### DIFF
--- a/implementation/test-quiet/src/re_frame/test_quiet/shadow_node.cljs
+++ b/implementation/test-quiet/src/re_frame/test_quiet/shadow_node.cljs
@@ -106,12 +106,45 @@
 ;; break CI's pass/fail signal.  On a RED run we first replay any
 ;; buffered `console.warn` diagnostics (the green-path stub withheld
 ;; them) so a failing run keeps the context that may explain it.
+;;
+;; EXIT-CODE INTEGRITY (rf2-jmrdhn). This defmethod is the ONLY thing that
+;; turns a RED cljs.test summary into a non-zero node exit, so two hazards
+;; must never let a failing run go out the door GREEN:
+;;   1. The red replay is DIAGNOSTIC-ONLY. If `replay-buffered-warnings!`
+;;      threw, the old `(do (replay…) (js/process.exit 1))` never reached
+;;      the `exit 1` — the throw propagated out of the reporter and node
+;;      could unwind to a 0 exit. The replay is wrapped so a throw in it can
+;;      never SWALLOW the red exit.
+;;   2. Reaching a GREEN exit is the ONLY way `main` clears the seeded
+;;      failure exit code (`execute-cli` sets `process.exitCode = 1` before
+;;      running). So a run that executes tests but never dispatches THIS
+;;      defmethod — a torn-down async run, or a reporter whose env does not
+;;      match the `[:cljs.test/default …]` dispatch key — leaves the process
+;;      to drain its event loop and exit with the seeded 1, failing loudly
+;;      instead of a silent false-green.
 
 (defmethod ct/report [:cljs.test/default :end-run-tests] [m]
   (if (ct/successful? m)
     (js/process.exit 0)
-    (do (replay-buffered-warnings!)
+    (do (try
+          (replay-buffered-warnings!)
+          (catch :default _
+            ;; Diagnostic-only: a throw here must never mask the red exit.
+            nil))
         (js/process.exit 1))))
+
+(defn- seed-failure-exit!
+  "Seed the node process's exit code to FAILURE just before a test run
+  begins.  The ONLY path that clears it back to 0 is a confirmed GREEN
+  `:end-run-tests` (which `js/process.exit 0`s — see that defmethod's
+  EXIT-CODE INTEGRITY note).  So a run that starts tests but never reaches a
+  green summary — a torn-down async run, or a reporter env that never
+  dispatches our exit defmethod — drains the event loop and exits with this
+  seeded 1 rather than a silent false-green (rf2-jmrdhn).  It is a no-op on
+  the normal green/red paths, where the `:end-run-tests` defmethod calls
+  `js/process.exit` and overrides it."
+  []
+  (set! (.-exitCode js/process) 1))
 
 ;; ----------------------------------------------------------------------
 ;; Test-data reset (mirrors shadow.test.node/reset-test-data!).
@@ -186,10 +219,12 @@
                      (str/join ", " (map str unmatched)))
             (println "Use --list to see known test names.")
             (js/process.exit 1))
-          (st/run-test-vars test-env test-vars)))
+          (do (seed-failure-exit!)
+              (st/run-test-vars test-env test-vars))))
 
       :else
-      (st/run-all-tests test-env nil))))
+      (do (seed-failure-exit!)
+          (st/run-all-tests test-env nil)))))
 
 (defn main [& args]
   (reset-test-data!)

--- a/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
+++ b/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
@@ -280,6 +280,77 @@
                    " captured stdout:\n" out)))))))
 
 ;; ----------------------------------------------------------------------
+;; Exit-code integrity for failures that ESCAPE clojure.test's counters —
+;; rf2-jmrdhn.
+;;
+;; `red-runner-contract` / `error-runner-contract` above pin the COUNTED
+;; paths (a failing `is`, a throwing `is`) — clojure.test tallies those and
+;; cognitect exits 1 from the tally.  But the false-green trap the bead
+;; closes is a failure that clojure.test NEVER counts, so a naive runner
+;; could print/emit the problem yet exit 0.  Two such cases exist on the JVM
+;; and MUST still exit non-zero:
+;;   - a namespace that THROWS at load time (cognitect `require`s it during
+;;     discovery, so the throw is outside any `is`/report);
+;;   - a `:once` fixture that throws (it runs OUTSIDE `test-var`, so its
+;;     exception is not tallied as an `:error`).
+;; Both propagate out of `-main`, so `clojure.main` exits non-zero — this
+;; pins that no counter-escaping failure can slip out GREEN.
+
+(deftest namespace-load-throw-exits-nonzero
+  (testing "a test ns that throws at LOAD time exits non-zero (uncounted failure; rf2-jmrdhn)"
+    (with-fixture-dir
+      (fn [dir]
+        (write-raw-fixture! dir "load_throw_test"
+          (str "(ns probe.load-throw-test\n"
+               "  (:require [clojure.test :refer [deftest is]]\n"
+               "            [re-frame.test-quiet]))\n"
+               ;; anchor so cognitect's contains-tests? selects the ns…
+               "(deftest anchor (is (= 1 1)))\n"
+               ;; …then a top-level throw at require time — outside any `is`,
+               ;; so clojure.test never tallies it.
+               "(throw (ex-info \"LOAD-THROW-MARKER\" {}))"))
+        (let [{:keys [exit out err timed-out?]}
+              (run-runner dir "-n" "probe.load-throw-test")]
+          (is (not timed-out?)
+              "the load-throw run must terminate, not hang")
+          ;; The CORE pin: a load-time exception is not a counted test
+          ;; failure, but it MUST still fail the process.
+          (is (not (zero? exit))
+              (str "a namespace that throws at load time must exit NON-ZERO"
+                   " even though clojure.test never counts it (rf2-jmrdhn);"
+                   " got exit " exit "\n--- stdout ---\n" out
+                   "\n--- stderr ---\n" err))
+          (is (str/includes? (str out err) "LOAD-THROW-MARKER")
+              (str "the load-time exception message must surface so the"
+                   " failure is diagnosable; got\n--- stdout ---\n" out
+                   "\n--- stderr ---\n" err)))))))
+
+(deftest once-fixture-throw-exits-nonzero
+  (testing "a :once fixture that throws exits non-zero (uncounted failure; rf2-jmrdhn)"
+    (with-fixture-dir
+      (fn [dir]
+        (write-raw-fixture! dir "fixture_throw_test"
+          (str "(ns probe.fixture-throw-test\n"
+               "  (:require [clojure.test :refer [deftest is use-fixtures]]\n"
+               "            [re-frame.test-quiet]))\n"
+               ;; A :once fixture runs OUTSIDE test-var; its throw is not
+               ;; tallied as an :error, so a naive runner could exit 0.
+               "(use-fixtures :once (fn [f] (throw (ex-info \"FIXTURE-THROW-MARKER\" {}))))\n"
+               "(deftest a-test (is (= 1 1)))"))
+        (let [{:keys [exit out err timed-out?]}
+              (run-runner dir "-n" "probe.fixture-throw-test")]
+          (is (not timed-out?)
+              "the fixture-throw run must terminate, not hang")
+          (is (not (zero? exit))
+              (str "a :once fixture that throws must exit NON-ZERO even though"
+                   " its exception is never tallied as a test error"
+                   " (rf2-jmrdhn); got exit " exit "\n--- stdout ---\n" out
+                   "\n--- stderr ---\n" err))
+          (is (str/includes? (str out err) "FIXTURE-THROW-MARKER")
+              (str "the fixture exception message must surface; got"
+                   "\n--- stdout ---\n" out "\n--- stderr ---\n" err)))))))
+
+;; ----------------------------------------------------------------------
 ;; Nested-run banner correctness — rf2-8n97n.1 (mislabel) + .2 (orphan).
 ;;
 ;; A `deftest` that nests a `run-tests` over a sibling namespace and then

--- a/implementation/test-quiet/test/re_frame/test_quiet_shadow_node_cljs_test.cljs
+++ b/implementation/test-quiet/test/re_frame/test_quiet_shadow_node_cljs_test.cljs
@@ -572,6 +572,67 @@
                  " got:\n" (str/join "\n" non-blank)))))))
 
 ;; ----------------------------------------------------------------------
+;; Exit-code integrity — a printed failure MUST exit non-zero (rf2-jmrdhn).
+;;
+;; The false-green trap the bead closes: the runner PRINTS a failing
+;; assertion but exits 0, so a local gate reads green while CI goes red.
+;; This drives the REAL runner across a process boundary (the only place the
+;; exit code is observable) against a deliberately-failing suite and asserts
+;; BOTH halves at once — the FAIL block reaches stdout AND the process exits
+;; non-zero — so a regression that decouples the two (a swallowed red exit, a
+;; run torn down before the `:end-run-tests` exit fires) is caught. The
+;; negative control proves the exit is tied to the ACTUAL failure, not always
+;; non-zero.
+
+(deftest deliberately-failing-test-exits-nonzero
+  (testing "a real failing test PRINTS its FAIL block AND exits non-zero (rf2-jmrdhn)"
+    ;; The armed red fixture runs a genuine `(is (= :expected :actual))` that
+    ;; fails — the ordinary counted-failure path, not an edge case. The whole
+    ;; point of rf2-jmrdhn is that this must NOT be able to print a failure
+    ;; while exiting 0.
+    (let [red-ns "re-frame.test-quiet-red-warn-fixture-cljs-test"
+          {status :status stdout :stdout stderr :stderr err :error
+           timed-out? :timed-out?}
+          (spawn-runner [(str "--test=" red-ns)]
+                        {:env {:RF2_TQ_RED_WARN_FIXTURE "1"}})]
+      (is (nil? err)
+          (str "spawning the real runner must not error; got: " (pr-str err)))
+      (is (not timed-out?)
+          "the armed fixture run must not time out")
+      ;; The CORE pin: a printed failure MUST drive a non-zero exit.
+      (is (and (number? status) (not (zero? status)))
+          (str "a deliberately-failing test must exit NON-ZERO — a printed"
+               " failure with a 0 exit is the local-green≠CI-red trap"
+               " (rf2-jmrdhn); got status " status
+               "\n--- stdout ---\n" stdout "\n--- stderr ---\n" stderr))
+      ;; It genuinely RAN (not a false green from running nothing)…
+      (is (str/includes? stdout "Ran ")
+          (str "the suite must have actually run (a `Ran ...` summary) — a"
+               " non-zero exit with no run would be a different failure;"
+               " got:\n" stdout))
+      ;; …and the failure was PRINTED — the exact symptom the exit code must
+      ;; now agree with.
+      (is (str/includes? stdout "FAIL in")
+          (str "the FAIL block must reach stdout AND the exit must be"
+               " non-zero — the two must never disagree (rf2-jmrdhn); got:\n"
+               stdout))))
+  (testing "the SAME fixture is GREEN + exits 0 when unarmed (negative control)"
+    ;; Proving the non-zero exit is tied to the ACTUAL failure, not a runner
+    ;; that always exits non-zero.
+    (let [red-ns "re-frame.test-quiet-red-warn-fixture-cljs-test"
+          {status :status stdout :stdout stderr :stderr err :error}
+          (spawn-runner [(str "--test=" red-ns)])]
+      (is (nil? err)
+          (str "spawning the real runner must not error; got: " (pr-str err)))
+      (is (zero? status)
+          (str "the unarmed fixture is GREEN; a correct run must still exit 0"
+               " — the exit code tracks the real result, it is not always"
+               " non-zero; got status " status
+               "\n--- stdout ---\n" stdout "\n--- stderr ---\n" stderr))
+      (is (not (str/includes? stdout "FAIL in"))
+          (str "the unarmed fixture prints no failure; got:\n" stdout)))))
+
+;; ----------------------------------------------------------------------
 ;; Shared spawn timeout/output policy (rf2-8dfq5j.3).
 ;;
 ;; The process-level pins above all route through `spawn-runner`, which


### PR DESCRIPTION
## What & why

The test-quiet runners must **fail loudly**: any test failure/error has to drive a **non-zero process exit** so a local `clojure -M:test` / gate run can never read GREEN while CI goes RED — the local-green≠CI-red trap that cost a fix-worker cycle on #5307 (rf2-jmrdhn).

### CLJS (`shadow_node.cljs`) — the real gap, now closed
The runner's non-zero exit hinged entirely on the `[:cljs.test/default :end-run-tests]` defmethod firing and calling `js/process.exit`. Two false-green hazards are closed:

1. **The RED replay is diagnostic-only.** The old `(do (replay-buffered-warnings!) (js/process.exit 1))` would never reach `exit 1` if the replay threw — the throw propagated out of the reporter and node could unwind to a 0 exit. The replay is now wrapped so a throw in it can never swallow the red exit.
2. **Default-to-fail.** `execute-cli` now seeds `process.exitCode = 1` immediately before running tests. A confirmed GREEN `:end-run-tests` (which `js/process.exit 0`s) is the *only* thing that clears it. So a run that starts tests but never reaches a green summary — a torn-down async run, or a reporter env that never dispatches our `[:cljs.test/default …]` exit defmethod — drains the event loop and exits non-zero instead of a silent false-green. No-op on the normal green/red paths.

### JVM (`runner.clj`) — verified already robust, pinned
No code change. cognitect exits 1 from the fail/error tally, and failures that **escape clojure.test's counters** (a namespace that throws at load time; a `:once` fixture that throws) propagate out of `-main` so `clojure.main` exits non-zero. Confirmed empirically (proof below) and locked with regression tests.

## Files changed
- `implementation/test-quiet/src/re_frame/test_quiet/shadow_node.cljs` — red replay guarded + `seed-failure-exit!` before both run branches.
- `implementation/test-quiet/test/re_frame/test_quiet_shadow_node_cljs_test.cljs` — adversarial CLJS exit-code pin (real spawned runner: a failing suite prints its FAIL block **and** exits non-zero; green negative control).
- `implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj` — JVM pins: namespace-load-throw and `:once`-fixture-throw (both uncounted) still exit non-zero.

## Quality gates

**JVM contract suite** — `cd implementation/test-quiet && clojure -M:test`
```
Ran 27 tests containing 98 assertions.
0 failures, 0 errors.
```
PASS (was 25/92; +2 adversarial exit-code tests).

**Exit-code proof — real JVM `-main`** (fresh JVM per case, asserting `$?`):
```
GREEN passing suite                           exit=0
RED normal deftest failure                    exit=1
RED namespace load-throw (uncounted)          exit=1
RED :once fixture throw (uncounted)           exit=1
```
A passing suite exits 0; every failure mode — including the two that clojure.test never tallies — exits non-zero.

**CLJS node-test** (`npm run test:cljs`): the CLJS exit-code pin drives the real spawned `out/node-test.js` and can only run after the full node-test build. **Full `test-fast-pr.sh` spine deferred to CI.** Both edited CLJS files reader-parse clean (`:features #{:cljs}`).

## Stance
Pre-alpha, no back-compat shims; elegance + clarity + correctness + good practice. Surgical: the default-to-fail seed is inert on the normal green/red paths and only bites when a run would otherwise exit 0 without a confirmed green completion.