### PR TITLE
fix(schemas): redact sensitive keys under ambiguous validation wrappers (rf2-jqx2at)

### DIFF
--- a/implementation/schemas/src/re_frame/schemas/walker.cljc
+++ b/implementation/schemas/src/re_frame/schemas/walker.cljc
@@ -831,12 +831,20 @@
       integer indices — navigable scalar locators; KEEP them so `:path`
       stays a useful `get-in` locator for those shapes (the bead's regression
       requirement).
-    - Transparent wrappers (`:maybe` / `:and` / `:or` / `:multi` / `:orn`)
-      contribute NO `:in` segment — descend without consuming. For the
-      single-child wrappers (`:maybe` / `:and` / `:or`) the inner schema is
-      unambiguous so the lockstep walk continues precisely. For the
-      multi-branch wrappers (`:multi` / `:orn`) and any other / opaque op
-      the branch is ambiguous, so the walk drops to a FAIL-CLOSED tail.
+    - Transparent wrappers contribute NO `:in` segment — descend without
+      consuming. `:maybe` is genuinely single-child (`[:maybe inner]`) so
+      the lockstep walk continues precisely. `:and` / `:or` are MULTI-child
+      (rf2-jqx2at): with more than one child the branch that produced the
+      failing `:in` cannot be identified from the path alone (an `:or` value
+      matched some ONE branch; an `:and` value is constrained by ALL), so
+      following only the first child can mis-classify a LATER branch's
+      value-bearing segment — e.g. a `:sensitive?` `:map-of` key, or a `:set`
+      element — as a navigable locator and ship it VERBATIM in `:path` /
+      `:reason` (the earlier draft treated `:and` / `:or` as single-child
+      transparent — the leak this closes). They descend ONLY in the
+      degenerate single-child case (unambiguous); otherwise, like the
+      multi-branch wrappers (`:multi` / `:orn`) and any other / opaque op,
+      the branch is ambiguous and the walk drops to the FAIL-CLOSED tail.
 
   FAIL-CLOSED tail (rf2-ss06u.1 / rf2-ss06u.2 / rf2-612mri): once the
   lockstep walk cannot confidently continue (a multi-branch / opaque op,
@@ -945,11 +953,28 @@
                             (nth children 0 nil))]
                 (recur child (subvec in 1) (conj out seg)))
 
-              ;; Single-child transparent wrappers — no `:in` segment
-              ;; consumed; descend into the (unambiguous) inner schema.
-              (#{:maybe :and :or} op)
+              ;; `:maybe` — genuinely single-child transparent
+              ;; (`[:maybe inner]`); descend into the unambiguous inner
+              ;; schema without consuming a segment.
+              (= op :maybe)
               (if-let [child (first children)]
                 (recur child in out)
+                (fail-closed-tail out in))
+
+              ;; `:and` / `:or` — MULTI-child wrappers (rf2-jqx2at). With
+              ;; more than one child the branch that produced the failing
+              ;; `:in` cannot be identified from the path alone (an `:or`
+              ;; value matched some ONE branch; an `:and` value is
+              ;; constrained by ALL), so following only the first child can
+              ;; mis-classify a LATER branch's value-bearing segment — a
+              ;; `:sensitive?` `:map-of` key, a `:set` element — as a
+              ;; navigable locator and ship it verbatim in `:path` /
+              ;; `:reason`. Descend ONLY the degenerate single-child case
+              ;; (unambiguous); otherwise fail CLOSED on the remaining tail,
+              ;; exactly like `:multi` / `:orn` below.
+              (#{:and :or} op)
+              (if (= (count children) 1)
+                (recur (first children) in out)
                 (fail-closed-tail out in))
 
               ;; Multi-branch / opaque op — the branch is ambiguous, so the

--- a/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
@@ -57,6 +57,11 @@
             ;; opaque-schema fail-closed redaction arm. Malli is on the
             ;; schemas test classpath (the artefact deps on metosin/malli).
             [malli.core :as m]
+            ;; rf2-jqx2at — direct unit tests on the internal `:path`-tag
+            ;; sanitiser (`sanitize-sensitive-path`) which is NOT re-exported
+            ;; through the `re-frame.schemas` facade (validate-app-schema!'s
+            ;; private redaction helper).
+            [re-frame.schemas.walker :as walker]
             [re-frame.schemas.test-fixture :as tf]))
 
 (use-fixtures :each tf/reset-runtime)
@@ -546,6 +551,128 @@
       (is (= [:by-id "a" :secret] (-> v :tags :path))
           ":path keeps the navigable plain map-of key (\"a\") — no over-redaction")
       (is (= :rf/redacted (-> v :tags :value))))))
+
+;; ---- sensitive :map-of KEY nested under an ambiguous :or / :and wrapper -----
+;; (rf2-jqx2at). `sanitize-sensitive-path` treated `:and` / `:or` as SINGLE-child
+;; transparent wrappers and followed ONLY the first child. When a sensitive
+;; `:map-of` KEY schema lives in a LATER branch — an `:or` whose non-sensitive
+;; branch is first, or an `:and` whose sensitive conjunct is not first — the walk
+;; descended the WRONG branch, classified the failing `:in` key segment as a
+;; navigable `:map-of` locator (its key schema was the WRONG branch's
+;; non-sensitive one), and KEPT it. So the raw sensitive key shipped VERBATIM in
+;; `:path` and `:reason` (and thus every serialized trace tag) even though
+;; `:value` / `:explain` were correctly redacted — the same scalar-key leak class
+;; as rf2-612mri, but hidden behind a multi-branch wrapper. `:and` / `:or` are
+;; MULTI-child ambiguous wrappers: with more than one child the branch that
+;; produced the failing `:in` cannot be identified from the path alone (an `:or`
+;; value matched some ONE branch; an `:and` value is constrained by ALL), so the
+;; walk now fails CLOSED on the whole remaining tail (like `:multi` / `:orn`),
+;; scrubbing the secret key. The degenerate single-child case stays an
+;; unambiguous, precise descent (navigable locators preserved). These fail before
+;; the fix (the secret key rides in `:path` / `:reason`) and pass after.
+
+;; -- direct `sanitize-sensitive-path` unit tests (deterministic; independent of
+;;    Malli's `:in` shape) --
+
+(deftest sanitize-fails-closed-on-multi-child-or
+  (testing "rf2-jqx2at — a sensitive :map-of key reached under a MULTI-child :or
+            is scrubbed via the fail-closed tail (the ambiguous :or cannot pick
+            a branch, so every remaining segment is scrubbed)"
+    (let [schema [:or
+                  [:map-of :int :int]                                     ;; branch 0 — non-sensitive key
+                  [:map-of [:string {:sensitive? true}] [:map [:age :int]]]] ;; branch 1 — sensitive key
+          in     ["secret-token-123" :age]
+          out    (walker/sanitize-sensitive-path schema in)]
+      (is (= [:rf/redacted :rf/redacted] out)
+          "every tail segment past the ambiguous :or is scrubbed to the sentinel")
+      (is (not (some #{"secret-token-123"} out))
+          "the sensitive :map-of key does NOT survive in the sanitized path"))))
+
+(deftest sanitize-fails-closed-on-multi-child-and
+  (testing "rf2-jqx2at — a sensitive :map-of key reached under a MULTI-child :and
+            (sensitive conjunct not first) is scrubbed via the fail-closed tail"
+    (let [schema [:and
+                  [:map-of :string [:map [:age :int]]]                    ;; conjunct 0 — non-sensitive key
+                  [:map-of [:string {:sensitive? true}] [:map [:age :int]]]] ;; conjunct 1 — sensitive key
+          in     ["secret-token-xyz" :age]
+          out    (walker/sanitize-sensitive-path schema in)]
+      (is (= [:rf/redacted :rf/redacted] out))
+      (is (not (some #{"secret-token-xyz"} out))
+          "the sensitive :map-of key does NOT survive in the sanitized path"))))
+
+(deftest sanitize-single-child-and-or-descend-precisely
+  (testing "rf2-jqx2at regression — a DEGENERATE single-child :and / :or is
+            unambiguous, so the walk still descends precisely and KEEPS the
+            navigable :map key (the fail-closed rule must not over-redact the
+            unambiguous case)"
+    (is (= [:k] (walker/sanitize-sensitive-path [:or  [:map [:k :int]]] [:k]))
+        "single-child :or descends into its one branch and keeps the map key")
+    (is (= [:k] (walker/sanitize-sensitive-path [:and [:map [:k :int]]] [:k]))
+        "single-child :and descends into its one branch and keeps the map key")))
+
+;; -- end-to-end via validate-app-schema! (:path / :reason / whole-tags egress) --
+
+(deftest app-db-validation-or-wrapped-map-of-sensitive-key-scrubbed
+  (testing "rf2-jqx2at — a :map-of with a :sensitive? KEY schema nested under a
+            MULTI-child :or (non-sensitive branch FIRST) scrubs the secret key
+            from :path AND :reason; the secret never appears anywhere in tags"
+    (let [v (app-db-failure-trace
+              [:secrets]
+              [:or
+               [:map-of :int :int]
+               [:map-of [:string {:sensitive? true}] [:map [:age :int]]]]
+              {:secrets {"secret-token-abc" {:age "not-an-int"}}}
+              :secrets/bad)]
+      (is (some? v) "a trace fired")
+      (is (true? (:sensitive? v))
+          "top-level :sensitive? stamp present — a sensitive key schema is in the :or")
+      (is (= :rf/redacted (-> v :tags :value)) ":value redacted")
+      (is (= :rf/redacted (-> v :tags :explain)) ":explain redacted")
+      (is (not (str/includes? (pr-str (-> v :tags :path)) "secret-token-abc"))
+          "the secret key does NOT appear in :path")
+      (is (not (str/includes? (pr-str (-> v :tags :reason)) "secret-token-abc"))
+          "the secret key does NOT appear in the generated :reason text")
+      (is (not (str/includes? (pr-str (:tags v)) "secret-token-abc"))
+          "the secret key does NOT appear anywhere in the emitted tags"))))
+
+(deftest app-db-validation-and-wrapped-map-of-sensitive-key-scrubbed
+  (testing "rf2-jqx2at — a :map-of with a :sensitive? KEY schema nested under a
+            MULTI-child :and (sensitive conjunct NOT first) scrubs the secret key
+            from :path AND :reason; the secret never appears anywhere in tags"
+    (let [v (app-db-failure-trace
+              [:secrets]
+              [:and
+               [:map-of :string [:map [:age :int]]]
+               [:map-of [:string {:sensitive? true}] [:map [:age :int]]]]
+              {:secrets {"secret-token-xyz" {:age "not-an-int"}}}
+              :secrets/bad)]
+      (is (some? v) "a trace fired")
+      (is (true? (:sensitive? v))
+          "top-level :sensitive? stamp present — a sensitive key schema is in the :and")
+      (is (= :rf/redacted (-> v :tags :value)) ":value redacted")
+      (is (= :rf/redacted (-> v :tags :explain)) ":explain redacted")
+      (is (not (str/includes? (pr-str (-> v :tags :path)) "secret-token-xyz"))
+          "the secret key does NOT appear in :path")
+      (is (not (str/includes? (pr-str (-> v :tags :reason)) "secret-token-xyz"))
+          "the secret key does NOT appear in :reason")
+      (is (not (str/includes? (pr-str (:tags v)) "secret-token-xyz"))
+          "the secret key does NOT appear anywhere in the emitted tags"))))
+
+(deftest app-db-validation-non-sensitive-or-key-stays-navigable
+  (testing "rf2-jqx2at regression — a fully NON-sensitive multi-child :or failure
+            is not stamped :sensitive? and its value rides verbatim
+            (sanitize-sensitive-path is not invoked on a non-sensitive failure,
+            so a plain :map-of key is untouched — no over-redaction)"
+    (let [v (app-db-failure-trace
+              [:data]
+              [:or [:map-of :int :int] [:map-of :string :int]]
+              {:data {"plain-key" "not-an-int"}}
+              :data/bad)]
+      (is (some? v) "a trace fired")
+      (is (not (contains? v :sensitive?))
+          "no :sensitive? stamp — nothing in the :or is sensitive")
+      (is (not= :rf/redacted (-> v :tags :value))
+          ":value rides verbatim — a non-sensitive failure is not scrubbed"))))
 
 ;; ---- ancestor-sensitive container wrapped by :and/:multi/:orn (rf2-ss06u.2)
 ;; When a slot is declared {:sensitive? true} as a CONTAINER and the failing


### PR DESCRIPTION
## Summary

P2 privacy/correctness fix. `walker/sanitize-sensitive-path` (the `:path`-tag sanitiser consumed by `validate-app-schema!`) treated `:and` / `:or` as **single-child transparent** wrappers and followed only the **first** child. When a sensitive `:map-of` key schema lived in a **later** branch — an `:or` whose non-sensitive branch is first, or an `:and` whose sensitive conjunct is not first — the lockstep walk descended the wrong branch, classified the failing `:in` key segment as a navigable `:map-of` locator (against the *wrong* branch's non-sensitive key schema), and **kept it**. The raw sensitive key then shipped **verbatim** in the `:path` and `:reason` trace tags (and thus every serialized trace tag) even though `:value` / `:explain` were correctly redacted.

## Fix

`:and` / `:or` are MULTI-child ambiguous wrappers: with more than one child the branch that produced the failing `:in` cannot be identified from the path alone (an `:or` value matched some ONE branch; an `:and` value is constrained by ALL). The walk now **fails closed** on the whole remaining tail for multi-child `:and` / `:or` — scrubbing every remaining segment — exactly like `:multi` / `:orn` already do. The degenerate **single-child** case stays an unambiguous, precise descent so navigable locators are preserved. `:maybe` remains genuinely single-child transparent.

This is the residual class of the rf2-612mri scalar-key leak, hidden behind a multi-branch wrapper. `align-in-path` (the redaction *decision* path) already fails safe on `:and` / `:or` via its `:else` fallback, so `:value` / `:explain` / the `:sensitive?` stamp were already correct — only the `:path` / `:reason` sanitiser leaked.

Files changed:
- `implementation/schemas/src/re_frame/schemas/walker.cljc` — split the `#{:maybe :and :or}` single-child branch: `:maybe` descends unconditionally; multi-child `:and` / `:or` fail closed, single-child `:and` / `:or` descend. Docstring corrected (it previously mis-described `:and` / `:or` as single-child).
- `implementation/schemas/test/re_frame/schemas_sensitive_test.clj` — adversarial + regression tests (see below).

## Tests

Per wrapper shape (`:or`, `:and`): the sensitive key is redacted, a non-sensitive/degenerate case is untouched.
- Deterministic `sanitize-sensitive-path` unit tests (no reliance on Malli's `:in` shape): multi-child `:or` and `:and` scrub the secret key to `:rf/redacted`; single-child `:or` / `:and` descend precisely and keep the navigable `:k`.
- End-to-end `validate-app-schema!` tests: the secret `:map-of` key is absent from `:path`, `:reason`, and the whole tag map; `:value` / `:explain` redacted and `:sensitive?` stamped; a fully non-sensitive multi-child `:or` failure is not over-redacted (value rides verbatim, no stamp).

## Quality gates

- `implementation/schemas` JVM (`clojure -M:test`): **334 tests, 18922 assertions, 0 failures, 0 errors** (includes the new tests).
- CLJS node-runtime (`npm run test:cljs`): **8145 tests, 37346 assertions, 0 failures, 0 errors**.
- Full pre-checkin spine deferred to CI.

## Stance

Pre-alpha, no back-compat shims. Change is scoped strictly to the validation/redaction path (`walker.cljc` sanitiser + its tests); no core frame/dispatch/registrar/epoch/flow or image-boundary files touched. Direction: elegance + clarity + correctness — the fix reuses the existing fail-closed tail and mirrors the `:multi` / `:orn` handling rather than adding new machinery. Over-redaction on ambiguous wrapper shapes is the accepted tradeoff (value-protection never under-redacts); navigability is preserved on the resolvable shapes and the degenerate single-child case.
