### PR TITLE
test(ssr): wire generated SSR scaffold tests into npm/CI (rf2-97eebb)

### DIFF
--- a/tools/template/resources/day8/re_frame2_template/_reagent/deps_with_ssr.edn
+++ b/tools/template/resources/day8/re_frame2_template/_reagent/deps_with_ssr.edn
@@ -67,6 +67,19 @@
   {:exec-fn   {{namespace}}.server/-main
    :exec-args {:port 8030 :static-root "resources/public/js"}}
 
+  ;; `clojure -M:test` runs the headless JVM SSR gate
+  ;; (test/{{nested-dirs}}/ssr_test.clj) via the cognitect test-runner.
+  ;; The SSR scaffold's ONLY automated test is this JVM gate — the client
+  ;; `:app` bundle ships no cljs.test suite — so this alias is what
+  ;; `npm test` invokes (see package.json) and what the generated CI
+  ;; (.github/workflows/ci.yml) runs. The runner discovers `*-test`
+  ;; namespaces on the `test` path.
+  :test
+  {:extra-paths ["test"]
+   :extra-deps  {io.github.cognitect-labs/test-runner
+                 {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+   :main-opts   ["-m" "cognitect.test-runner"]}
+
   ;; `clojure -M:shadow` runs shadow-cljs in JVM mode via the alias.
   ;; You can also use `npx shadow-cljs ...` (shadow's own node-side CLI).
   ;; Both work; the npm-side route is the canonical workflow.

--- a/tools/template/resources/day8/re_frame2_template/_shared/package.json
+++ b/tools/template/resources/day8/re_frame2_template/_shared/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "watch":   "shadow-cljs watch app",
     "release": "shadow-cljs release app",
-    "test":    "shadow-cljs compile test && node out/node-test.js"
+    "test":    "{{test-script}}"
   },
   "devDependencies": {
     "shadow-cljs": "{{shadow-version}}"

--- a/tools/template/resources/day8/re_frame2_template/root/.github/workflows/ci.yml
+++ b/tools/template/resources/day8/re_frame2_template/root/.github/workflows/ci.yml
@@ -4,8 +4,11 @@
 #   - JDK 21 + Clojure CLI (matches re-frame2's reference build)
 #   - Node 22 LTS + npm
 #   - Maven / gitlibs + npm caches keyed by deps files
-#   - `npm install` then `npm test` — runs the :node-test build per
-#     shadow-cljs.edn (no browser; pure cljs.test under Node).
+#   - `npm install` then `npm test` — runs the scaffold's test suite.
+#     For an SPA scaffold that is the shadow-cljs :node-test build
+#     (pure cljs.test under Node, no browser); for an SSR scaffold
+#     `npm test` runs the headless JVM `clojure -M:test` gate instead
+#     (see package.json — the SSR client bundle ships no cljs.test suite).
 #
 # Add steps as your project grows:
 #   - `clojure -M:cljfmt check src test` (the scaffold ships .cljfmt.edn)
@@ -73,5 +76,5 @@ jobs:
         # for fully reproducible builds.
         run: npm install
 
-      - name: Run tests (shadow-cljs :node-test)
+      - name: Run tests (npm test)
         run: npm test

--- a/tools/template/src/day8/re_frame2_template/hooks.clj
+++ b/tools/template/src/day8/re_frame2_template/hooks.clj
@@ -43,11 +43,14 @@
    right source per the flag; the output filename is the same
    (`deps.edn`) regardless of which source ran.
 
-   `package.json` is the exception. Its sole per-flag delta — the
-   `description` parenthetical naming the Story playground — is small
-   enough to carry as the `{{story-tag}}` subst var, so a single
-   `_shared/package.json` source serves both paths. No
-   second `package_with_story.json` source exists.
+   `package.json` is the exception. Its per-flag deltas — the
+   `description` parenthetical naming the Story playground
+   (`{{story-tag}}`) and the `test` npm script (`{{test-script}}`: the
+   CLJS node-test bundle on the default / Story paths vs `clojure -M:test`
+   for the SSR scaffold's JVM `ssr_test.clj` gate) — are each small enough
+   to carry as a subst var, so a single `_shared/package.json` source
+   serves every path. No `package_with_story.json` / `package_with_ssr.json`
+   source exists.
 
    The steady-state shape (see tools/template/spec/003-DepsNew-Rebuild-Plan.md
    §1) is the same matrix; the v1 flag set (`:include-story?`,
@@ -336,6 +339,15 @@
                         `:include-story? true`. Lets the single
                         `_shared/package.json` source carry both variants
                         (the only per-flag delta was this one parenthetical).
+     {{test-script}}  — the package.json `test` npm script, which varies
+                        by `:include-ssr?`: the CLJS node-test bundle
+                        (`shadow-cljs compile test && node out/node-test.js`)
+                        on the default / Story paths, or `clojure -M:test`
+                        (the headless JVM `ssr_test.clj` gate) on the SSR
+                        path. A second `_shared/package.json` subst delta
+                        alongside `{{story-tag}}` — the SSR scaffold ships
+                        no cljs.test suite, so its `npm test` must run the
+                        JVM gate, not an empty node-test bundle.
      {{substrate-badge-url}} — shields.io badge URL keyed by substrate.
      {{rf2-version}}  — runtime coord version (kept in lockstep with
                         the repo-root VERSION file via the §3 release
@@ -430,6 +442,18 @@
        ;; a subst var lets one `_shared/package.json` source serve both
        ;; paths from a single file.
        :story-tag           (if include-story? ", with Story playground" "")
+       ;; package.json `test` script — the second per-flag delta the single
+       ;; `_shared/package.json` source carries via a subst var (alongside
+       ;; `{{story-tag}}`). The default + Story scaffolds ship a CLJS
+       ;; `events_test.cljs` run by the `:test` shadow node-test build; the
+       ;; SSR scaffold ships NO cljs.test suite — its only test is the
+       ;; headless JVM `ssr_test.clj`, run by the emitted deps.edn `:test`
+       ;; alias — so `npm test` (and the generated CI's `npm test` step)
+       ;; must invoke `clojure -M:test` there instead of the empty
+       ;; node-test bundle (which would false-green on zero tests).
+       :test-script         (if include-ssr?
+                              "clojure -M:test"
+                              "shadow-cljs compile test && node out/node-test.js")
        :namespace           (str top-ns "." main-ns)
        :nested-dirs         (str top-file "/" main-file)
        :substrate-badge-url badge-url

--- a/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
+++ b/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
@@ -82,7 +82,8 @@
             [clojure.pprint :as pprint]
             [clojure.string :as string]
             [day8.re-frame2-template.test-support
-             :refer [tmp-dir delete-recursively run-template! repo-root]])
+             :refer [tmp-dir delete-recursively run-template!
+                     run-template-opts! repo-root]])
   ;; java.nio types used directly by `link-node-modules!` below. The
   ;; tmp-dir / delete-recursively helpers that need Path / LinkOption /
   ;; FileVisitOption live in the shared test-support ns.
@@ -134,7 +135,20 @@
           ;; resolves + compiles against the in-repo Story source.
           (contains? (:deps deps) 'day8/re-frame2-story)
           (assoc-in [:deps 'day8/re-frame2-story]
-                    {:local/root (rel-of "tools/story")}))]
+                    {:local/root (rel-of "tools/story")})
+
+          ;; The SSR scaffold adds day8/re-frame2-ssr + day8/re-frame2-ssr-ring
+          ;; (re-frame.ssr + re-frame.ssr.ring live under implementation/ssr +
+          ;; implementation/ssr-ring). Rewrite them the same way so the
+          ;; emitted headless JVM ssr_test.clj resolves + runs against the
+          ;; in-repo SSR source.
+          (contains? (:deps deps) 'day8/re-frame2-ssr)
+          (assoc-in [:deps 'day8/re-frame2-ssr]
+                    {:local/root (rel-of "implementation/ssr")})
+
+          (contains? (:deps deps) 'day8/re-frame2-ssr-ring)
+          (assoc-in [:deps 'day8/re-frame2-ssr-ring]
+                    {:local/root (rel-of "implementation/ssr-ring")}))]
     (spit deps-file (with-out-str (pprint/pprint rewritten)))))
 
 ;; --- node_modules symlink --------------------------------------------------
@@ -442,6 +456,54 @@
        (finally
          (delete-recursively tmp))))))
 
+(defn- run-ssr-emitted-test!
+  "The SSR variant of the emitted-test-run tier. The SSR scaffold's only
+  automated test is a headless JVM gate (`ssr_test.clj`) — no cljs.test
+  suite, no `:node-test` bundle — so it runs via the emitted deps.edn
+  `:test` alias (`clojure -M:test`), NOT `shadow compile test` + node.
+  That is the exact path `npm test` and the generated CI now invoke
+  (package.json `test` = `clojure -M:test` on the SSR path, per hooks.clj's
+  `{{test-script}}`); before this wiring nothing ran the emitted
+  ssr_test.clj, so an SSR-scaffold regression shipped uncaught (rf2-97eebb).
+
+  Generate the SSR scaffold (`:include-ssr? true`), rewrite the framework
+  coords — including day8/re-frame2-ssr + day8/re-frame2-ssr-ring — to
+  :local/root, then run `clojure -M:test` and assert exit 0 plus the
+  cljs.test summary lines, so a silent zero-test run can't false-green.
+
+  Needs only `clojure` on PATH — no node, no node_modules: the JVM SSR
+  render is a pure hiccup -> HTML emitter (no React / JSDOM), so unlike
+  the CLJS variants this tier never shells out to `node`."
+  []
+  (let [root (repo-root)
+        tmp  (tmp-dir "rf2-template-run-reagent-ssr-")]
+    (try
+      (let [proj (run-template-opts! tmp "acme/my-app"
+                                     {:substrate :reagent :include-ssr? true})]
+        (rewrite-deps-for-local-run! root proj :reagent)
+        (testing "reagent-ssr — clojure -M:test (headless JVM ssr_test.clj)"
+          (let [{:keys [exit out]} (run-process! ["clojure" "-M:test"] proj)]
+            (is (zero? exit)
+                (str "`clojure -M:test` exited " exit
+                     " for the emitted SSR scaffold. The headless JVM "
+                     "ssr_test.clj gate did not pass against the in-repo SSR "
+                     "source (implementation/ssr + ssr-ring rewritten to "
+                     ":local/root). Output:\n" out))
+            ;; cljs.test's default reporter prints
+            ;;   "Ran N tests containing M assertions."
+            ;;   "0 failures, 0 errors."
+            ;; Pin both lines so a silent zero-exit (no tests discovered by
+            ;; the cognitect runner) doesn't false-green.
+            (is (re-find #"Ran \d+ tests? containing \d+ assertions" out)
+                (str "expected 'Ran N tests' summary line — a silent "
+                     "zero-test run (the very false-green rf2-97eebb "
+                     "guards) would otherwise pass. Got:\n" out))
+            (is (re-find #"0 failures, 0 errors" out)
+                (str "expected '0 failures, 0 errors' line in output. "
+                     "Got:\n" out)))))
+      (finally
+        (delete-recursively tmp)))))
+
 (defn- skip-if-disabled!
   "When the gate is off, record a passing assertion that documents the
   skip — so the green-run line count is stable across enabled/disabled
@@ -528,6 +590,25 @@
               "`node` must be on PATH when RF2_TEMPLATE_RUN_EMITTED_TESTS=1")
           (when (and @clojure-cli-available? @node-available?)
             (compile-and-run-emitted-test! :reagent true {:release? true}))))))
+
+(deftest reagent-ssr-emitted-tests-run-test
+  ;; The SSR scaffold's headless JVM gate (`ssr_test.clj`), run via the
+  ;; emitted deps.edn `:test` alias (`clojure -M:test`) — the exact path
+  ;; `npm test` and the generated CI now invoke on the SSR scaffold.
+  ;; Reagent-only because `:include-ssr?` is Reagent-only in v1. Unlike
+  ;; the CLJS variants above this needs ONLY `clojure` on PATH (no node:
+  ;; the JVM SSR render is a pure hiccup -> HTML emitter), yet rides the
+  ;; same RF2_TEMPLATE_RUN_EMITTED_TESTS gate. Before this tier nothing
+  ;; ran the emitted ssr_test.clj — the empty CLJS node-test bundle the
+  ;; SSR package.json used to run false-greened on zero tests (rf2-97eebb).
+  (testing "the emitted SSR Reagent app's ssr_test.clj runs green via
+            `clojure -M:test` (the JVM gate npm/CI now invoke)"
+    (if-not @enabled?
+      (skip-if-disabled! "reagent-ssr")
+      (do (is @clojure-cli-available?
+              "`clojure` CLI must be on PATH when RF2_TEMPLATE_RUN_EMITTED_TESTS=1")
+          (when @clojure-cli-available?
+            (run-ssr-emitted-test!))))))
 
 ;; ===========================================================================
 ;; MANUAL setup-skill scaffold fixture

--- a/tools/template/test/day8/re_frame2_template/template_test.clj
+++ b/tools/template/test/day8/re_frame2_template/template_test.clj
@@ -1158,6 +1158,33 @@
               (is (contains? (:exec-args server-alias) :static-root)
                   ":server :exec-args carries a :static-root the server serves main.js from")))
 
+          ;; -- :test alias wiring — the headless JVM ssr_test.clj gate --
+          ;; The SSR scaffold ships NO cljs.test suite, so `clojure -M:test`
+          ;; (this alias) is the ONLY automated test — what `npm test` and the
+          ;; generated CI run (rf2-97eebb). Without the alias the emitted
+          ;; ssr_test.clj is orphaned and never executes.
+          (let [test-alias (get-in (read-edn (io/file root "deps.edn"))
+                                   [:aliases :test])]
+            (is (some? test-alias)
+                "SSR deps.edn declares a :test alias (runs ssr_test.clj on the JVM)")
+            (is (= ["test"] (:extra-paths test-alias))
+                ":test alias puts the test/ dir on the classpath")
+            (is (contains? (:extra-deps test-alias)
+                           'io.github.cognitect-labs/test-runner)
+                ":test alias pulls in the cognitect test-runner")
+            (is (= ["-m" "cognitect.test-runner"] (:main-opts test-alias))
+                ":test alias runs `clojure -M:test` via the cognitect test-runner"))
+
+          ;; -- package.json `test` script runs the JVM gate, NOT an empty
+          ;;    CLJS node-test bundle (the SSR scaffold has no cljs.test suite,
+          ;;    so a node-test run would false-green on zero tests) --
+          (let [pkg-text (slurp (io/file root "package.json"))]
+            (is (.contains pkg-text "\"test\":    \"clojure -M:test\"")
+                "SSR package.json `test` npm script runs the JVM `clojure -M:test` gate")
+            (is (not (.contains pkg-text "node out/node-test.js"))
+                "SSR package.json `test` script does NOT run the CLJS node-test
+                 bundle — the SSR path ships no cljs.test suite (rf2-97eebb)"))
+
           ;; -- core.cljc carries the SSR wiring --
           (let [core-text (slurp (io/file root "src/acme/my_app/core.cljc"))]
             (is (.contains core-text "(ns acme.my-app.core")


### PR DESCRIPTION
## What

The template's SSR scaffold (`:include-ssr? true`) emits a headless JVM gate `test/<ns>/ssr_test.clj`, but **nothing ran it**:

- the emitted `deps_with_ssr.edn` had **no `:test` alias** (despite the README documenting `clojure -M:test`), and
- the shared `package.json` `test` script ran `shadow-cljs compile test && node out/node-test.js` — an **empty** CLJS node-test bundle on the SSR path (no `events_test.cljs` is emitted), which **false-greens on zero tests**.

So SSR-scaffold regressions shipped uncaught. This wires the emitted SSR gate into the generated project's npm/CI **and** into this repo's template test coverage.

## Precedent mirrored (no new pattern invented)

The NON-SSR emitted-scaffold-test precedent is the `emitted_test_run_test.clj` behavioural tier, run via the `jvm-tools-template` (test.yml) and `test-template` (template-release.yml) jobs' existing `clojure -M:test` + `RF2_TEMPLATE_RUN_EMITTED_TESTS=1` steps. The SSR variant is added **to that same tier**, so it rides the existing CI steps automatically — **no new npm script, no new CI job**.

## Changes

**Generated project (what a consumer scaffolds):**
- `_reagent/deps_with_ssr.edn` — add the `:test` alias (cognitect test-runner) the README already promises; `clojure -M:test` runs `ssr_test.clj`.
- `_shared/package.json` — `test` script becomes `{{test-script}}` (a second subst delta alongside `{{story-tag}}`): `clojure -M:test` on the SSR path, the node-test bundle otherwise. Non-SSR output is **byte-identical** (byte-exact contract test still green).
- `hooks.clj` — derive `:test-script` from `:include-ssr?`; documented in the ns + `data-fn` docstrings.
- `root/.github/workflows/ci.yml` — the `npm test` step now adapts per scaffold, so its name/comment are made variant-generic (SPA node-test vs SSR JVM gate). No structural change.

**Template coverage (this repo):**
- `emitted_test_run_test.clj` — new `reagent-ssr-emitted-tests-run-test`: generates the SSR scaffold, rewrites the framework coords (incl. `ssr` + `ssr-ring`) to `:local/root`, runs `clojure -M:test`, asserts exit 0 + the cljs.test summary lines. Needs only `clojure` (no node — JVM SSR render is a pure hiccup→HTML emitter).
- `template_test.clj` — `include-ssr-true-reagent-test` now asserts the emitted `:test` alias shape + that `package.json` runs the JVM gate, not the empty node-test bundle.

## Quality gates
- `clojure -M:test` (tools/template, fast/no-env-gate): **46 tests, 635 assertions, 0 failures, 0 errors** — incl. the byte-exact package.json contract and the new SSR shape assertions.
- `RF2_TEMPLATE_RUN_EMITTED_TESTS=1 clojure -M:test -v …reagent-ssr-emitted-tests-run-test`: the new SSR behavioural gate generates the SSR scaffold and **actually runs the emitted `ssr_test.clj` on the JVM** — **Ran 1 tests / 4 assertions, 0 failures, 0 errors** (the emitted gate's 3 deftests, incl. the schema-rejection path, pass end-to-end).
- Emitted `ci.yml` parses cleanly as YAML; emitted `package.json` validity covered by the passing byte-exact + SSR shape tests.

## Stance
Pre-alpha, no back-compat shims; surgical, additive wiring alongside the existing template test/CI shape.