### PR TITLE
fix(test-discovery): include intended CLJC tests in Shadow CLJS coverage (rf2-ezbzvm)

### DIFF
--- a/implementation/adapters/test-react/test/re_frame/adapter/test_react_cljs_test.cljc
+++ b/implementation/adapters/test-react/test/re_frame/adapter/test_react_cljs_test.cljc
@@ -1,4 +1,4 @@
-(ns re-frame.adapter.test-react-test
+(ns re-frame.adapter.test-react-cljs-test
   "Tests for the Test-React adapter.
 
   Two layers:
@@ -213,10 +213,10 @@
 ;; sub-cache entry (with a ref-count), disposes the adapter, asserts the
 ;; sub-cache is empty + the ref-count is gone, and verifies a re-subscribe
 ;; after reinstall recomputes from the CURRENT app-db rather than serving a
-;; stale slot. Runs on both the JVM (`clojure -M:test`) and — by virtue of
-;; this ns also ending in `-test` — has a `-cljs-test` companion at
-;; `test_react_dispose_sub_cache_cljs_test.cljc` that exercises the same
-;; contract under `npm run test:cljs`.
+;; stale slot. Runs on both the JVM (`clojure -M:test`) and — now that this
+;; ns ends in `-cljs-test` — under CLJS via `npm run test:cljs` (rf2-ezbzvm).
+;; The standalone `test_react_dispose_sub_cache_cljs_test.cljc` companion
+;; pins the same contract independently.
 
 (defn- default-sub-cache-keys
   "The set of cache-keys currently materialised in the :rf/default frame's

--- a/implementation/core/test/re_frame/event_emit_cljs_test.cljc
+++ b/implementation/core/test/re_frame/event_emit_cljs_test.cljc
@@ -1,4 +1,4 @@
-(ns re-frame.event-emit-test
+(ns re-frame.event-emit-cljs-test
   "Per rf2-rirbq — the always-on event-emit substrate. Substrate-level
   contract: one record per processed event, fan-out to every
   registered listener, listener exceptions are swallowed, registry is
@@ -18,6 +18,7 @@
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
             [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
             [re-frame.trace :as trace]))
 
 ;; The schema-validation and flow-run hooks are published by the optional
@@ -29,7 +30,14 @@
 ;; (`schemas-by-frame`, `flows`) so a schema / flow registered by an
 ;; earlier namespace cannot roll back this namespace's clean dispatches —
 ;; the same isolation `smoke_test`'s fixture performs.
+;;
+;; `clear-all!` wipes the WHOLE registrar; in the shared `:node-test`
+;; bundle (rf2-ezbzvm) that also drops sibling namespaces' ns-load view /
+;; sub registrations. Snapshot the registrar first and restore it in the
+;; `finally` so the clean-slate is scoped to this test and cross-namespace
+;; registrations survive (test-support/{snapshot,restore}-registrar!).
 (defn- reset-runtime [test-fn]
+  (let [registrar-before (test-support/snapshot-registrar)]
   (registrar/clear-all!)
   (reset! frame/frames {})
   (schemas/clear-schemas-by-frame!)
@@ -50,7 +58,8 @@
       (finally
         (reset! late-bind/hooks hooks-before)
         (late-bind/invalidate-cache! :schemas/validate-app-schema!)
-        (late-bind/invalidate-cache! :flows/run-flows-on-db)))))
+        (late-bind/invalidate-cache! :flows/run-flows-on-db)
+        (test-support/restore-registrar! registrar-before))))))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/core/test/re_frame/event_emit_elision_prod_test.cljs
+++ b/implementation/core/test/re_frame/event_emit_elision_prod_test.cljs
@@ -4,7 +4,7 @@
   is compile-time elided in production builds (`:advanced` +
   `goog.DEBUG=false`).
 
-  This file is the prod-mode companion to `re-frame.event-emit-test`
+  This file is the prod-mode companion to `re-frame.event-emit-cljs-test`
   (default JVM / Node runners). It mirrors the rf2-hqbeh shape used by
   `re-frame.on-error-elision-prod-test`: the shared runner is
   `re-frame.prod-elision-runner`; the shadow-cljs build is
@@ -77,7 +77,7 @@
   (testing "A buggy listener cannot break the cascade under prod. The
             substrate catches listener throws silently — the dispatch
             settles and sibling listeners still run. Mirrors the dev-
-            mode contract from `re-frame.event-emit-test`; pinned here
+            mode contract from `re-frame.event-emit-cljs-test`; pinned here
             so the prod-build behaviour is locked too."
     (let [seen (atom [])]
       (rf/register-listener! :events

--- a/implementation/core/test/re_frame/on_error_cljs_test.cljc
+++ b/implementation/core/test/re_frame/on_error_cljs_test.cljc
@@ -1,4 +1,4 @@
-(ns re-frame.on-error-test
+(ns re-frame.on-error-cljs-test
   "Per rf2-bacs4 — exercise the corpus-wide `register-error-listener!`
   registry (the single always-on error observability surface; the
   per-frame `:on-error` recovery policy was REMOVED per rf2-hiqtk8 —

--- a/implementation/core/test/re_frame/on_error_elision_prod_test.cljs
+++ b/implementation/core/test/re_frame/on_error_elision_prod_test.cljs
@@ -80,7 +80,7 @@
   (testing "A buggy listener cannot break the cascade under prod. The
             substrate catches listener throws silently — the dispatch
             settles and sibling listeners still run. Mirrors the dev-
-            mode contract from `re-frame.on-error-test`; pinned here
+            mode contract from `re-frame.on-error-cljs-test`; pinned here
             so the prod-build behaviour is locked too."
     (let [seen (atom [])]
       (rf/register-listener! :errors
@@ -177,7 +177,7 @@
 ;; throw lost its diagnostic entirely in production. Now they ALSO fan out
 ;; through the always-on error-emit listener (surface #4), which survives
 ;; `goog.DEBUG=false`. Each test here is the production-mode counterpart
-;; of the dev-mode test in `re-frame.on-error-test`. Recovery is
+;; of the dev-mode test in `re-frame.on-error-cljs-test`. Recovery is
 ;; framework-owned (the per-category typed defaults); there is no
 ;; app-steering policy (rf2-hiqtk8).
 ;; ==========================================================================

--- a/implementation/core/test/re_frame/reg_meta_noswallow_cljs_test.cljc
+++ b/implementation/core/test/re_frame/reg_meta_noswallow_cljs_test.cljc
@@ -1,4 +1,4 @@
-(ns re-frame.reg-meta-noswallow-test
+(ns re-frame.reg-meta-noswallow-cljs-test
   "No-silent-swallow on `reg-*` registration METADATA KEYS (rf2-x68lzo).
 
   Per Conventions §No silent swallow: a BARE (unqualified) registration-metadata
@@ -21,12 +21,21 @@
             [re-frame.cofx :as cofx]
             [re-frame.interceptor-registry :as icpt-reg]
             [re-frame.registrar :as registrar]
+            [re-frame.test-support :as test-support]
             [re-frame.trace :as trace]))
 
+;; `clear-all!` gives each test a clean registrar, but in the shared
+;; `:node-test` bundle (rf2-ezbzvm) it also drops sibling namespaces'
+;; ns-load registrations (e.g. reg-view'd components other suites render).
+;; Snapshot first and restore in `finally` so the clean-slate is scoped to
+;; this test and cross-namespace registrations survive.
 (defn- reset-registry [test-fn]
-  (registrar/clear-all!)
-  (test-fn)
-  (registrar/clear-all!))
+  (let [snapshot (test-support/snapshot-registrar)]
+    (registrar/clear-all!)
+    (try
+      (test-fn)
+      (finally
+        (test-support/restore-registrar! snapshot)))))
 
 (use-fixtures :each reset-registry)
 

--- a/implementation/core/test/re_frame/reply_cljs_test.cljc
+++ b/implementation/core/test/re_frame/reply_cljs_test.cljc
@@ -1,4 +1,4 @@
-(ns re-frame.reply-test
+(ns re-frame.reply-cljs-test
   "Conformance for the EP-0011 uniform-reply-envelope substrate
   (`re-frame.reply`). Pins the three conformance groups EP-0011
   §Validation requires of the shared substrate slice:

--- a/implementation/core/test/re_frame/trace/projection_cljs_test.cljc
+++ b/implementation/core/test/re_frame/trace/projection_cljs_test.cljc
@@ -1,4 +1,4 @@
-(ns re-frame.trace.projection-test
+(ns re-frame.trace.projection-cljs-test
   "Tests for `re-frame.trace.projection/group-by-event` +
   `domino-bucket`. Pure-data — no fixture, no frame, no router; JVM and
   CLJS run the same suite.

--- a/implementation/machines/test/re_frame/actor_liveness_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/actor_liveness_cljs_test.cljc
@@ -1,4 +1,4 @@
-(ns re-frame.actor-liveness-test
+(ns re-frame.actor-liveness-cljs-test
   "A dynamically-spawned machine actor's LIVENESS is derived from its
   (revertible) runtime-db snapshot, NOT from a per-instance registrar entry.
 

--- a/implementation/machines/test/re_frame/actor_resource_lease_release_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/actor_resource_lease_release_cljs_test.cljc
@@ -1,4 +1,4 @@
-(ns re-frame.actor-resource-lease-release-test
+(ns re-frame.actor-resource-lease-release-cljs-test
   "Machine-SIDE contract for releasing an actor's resource leases on destroy
   (Spec 016 §Release authority is per owner kind, 016:290).
 
@@ -30,8 +30,9 @@
        release is silently skipped (`resource-release/release-owner-registered?`
        gates it).
 
-  Named `*-test.cljc` so both cognitect.test-runner (JVM, plain-atom) and
-  shadow-cljs (CLJS, reagent) discover + run it."
+  Named `*-cljs-test.cljc` so both cognitect.test-runner (JVM, plain-atom) and
+  shadow-cljs (CLJS, reagent) discover + run it — the `cljs-test$`
+  ns-regexp on the `:node-test` build only matches the `-cljs-test` suffix."
   (:require
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])

--- a/implementation/machines/test/re_frame/after_fire_reap_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/after_fire_reap_cljs_test.cljc
@@ -1,4 +1,4 @@
-(ns re-frame.after-fire-reap-test
+(ns re-frame.after-fire-reap-cljs-test
   "rf2-8cndln — a guard-suppressed `:after` timer fire must REAP its own
   registry entry at fire time, not leak it.
 

--- a/implementation/machines/test/re_frame/destroy_silent_idempotent_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/destroy_silent_idempotent_cljs_test.cljc
@@ -1,4 +1,4 @@
-(ns re-frame.destroy-silent-idempotent-test
+(ns re-frame.destroy-silent-idempotent-cljs-test
   "Destroy idempotence is a deliberate contract, aligned with the XState
   convention.
 
@@ -24,9 +24,11 @@
   The spec contract lives at Spec 005 §Destroy is silent-idempotent,
   with a cross-link from §Final states D6.
 
-  The file is named `*-test.cljc` so it's discovered by both
+  The file is named `*-cljs-test.cljc` so it's discovered by both
   cognitect.test-runner (JVM) and shadow-cljs (CLJS); both paths
-  exercise the same destroy fx handler."
+  exercise the same destroy fx handler. (The `:node-test` build's
+  `cljs-test$` ns-regexp matches only the `-cljs-test` suffix, so a
+  plain `-test.cljc` would silently ride the JVM path alone.)"
   (:require
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])

--- a/implementation/machines/test/re_frame/handler_source_egress_strip_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/handler_source_egress_strip_cljs_test.cljc
@@ -1,4 +1,4 @@
-(ns re-frame.handler-source-egress-strip-test
+(ns re-frame.handler-source-egress-strip-cljs-test
   "rf2-tlf4if — handler source-as-data does NOT leak across the frame-state
   egress boundary.
 

--- a/implementation/machines/test/re_frame/machines_reply_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/machines_reply_cljs_test.cljc
@@ -1,4 +1,4 @@
-(ns re-frame.machines-reply-test
+(ns re-frame.machines-reply-cljs-test
   "Pure unit tests for `re-frame.machines.reply` — the machine family's
   slice of the uniform reply envelope (EP-0011 §Machine Completion /
   §Timer Reply; Managed-Effects §The uniform reply envelope).
@@ -12,6 +12,7 @@
   `re-frame.reply/validate-reply` contract so the closed-status taxonomy +
   value/error conventions + data-only invariant hold uniformly."
   (:require [clojure.test :refer [deftest is testing]]
+            [clojure.edn :as edn]
             [re-frame.machines.reply :as m-reply]
             [re-frame.reply :as reply]))
 
@@ -35,7 +36,7 @@
   (testing "work-id is =-comparable and EDN-serializable"
     (let [wid (m-reply/spawn-work-id :a/b#3 [:x])]
       (is (= wid (m-reply/spawn-work-id :a/b#3 [:x])))
-      (is (= wid (read-string (pr-str wid)))))))
+      (is (= wid (edn/read-string (pr-str wid)))))))
 
 ;; ---- cross-platform actor-generation determinism --------------------------
 ;; A `:fixed-actor-id` carrying a `#` followed by a non-fully-numeric suffix

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -88,8 +88,10 @@
                 "adapters/helix/testbed"
                 ;; rf2-ee38b.16 — test-react adapter (headless CLJC class-3
                 ;; lifecycle simulator). src+test paths added so the
-                ;; :node-test build discovers re-frame.adapter.test-react-test
-                ;; (ns ends in `-test`, matching the `cljs-test$` regexp). The
+                ;; :node-test build discovers re-frame.adapter.test-react-cljs-test
+                ;; (ns ends in `-cljs-test`, matching the `cljs-test$` regexp;
+                ;; renamed from `-test` per rf2-ezbzvm — a plain `-test` suffix
+                ;; does NOT match, so the CLJS half was silently excluded). The
                 ;; JVM half runs via scripts/test-jvm-implementation.sh.
                 ;; NOT for production: bundle-isolation holds structurally —
                 ;; nothing under examples/ or production builds :requires


### PR DESCRIPTION
## What

Twelve `.cljc` implementation tests carried CLJS reader-conditional branches and/or docstrings claiming they run under Shadow CLJS (`:node-test` / `npm run test:cljs`), but their namespaces ended in `-test` rather than `-cljs-test`. The `:node-test` build's ns-regexp is `cljs-test$`, which matches **only** the `-cljs-test` suffix — so the CLJS half of these tests was **silently excluded** and never ran (a coverage gap invisible on green runs).

Empirically confirmed before the fix: `/cljs-test$/` returns `false` for `re-frame.on-error-test` and `re-frame.adapter.test-react-test`, and none of the affected namespaces appeared in the compiled `out/node-test.js`.

## Fix

Follows the established repo convention — 130+ dual-runtime `*-cljs-test.cljc` files already run on **both** the JVM (cognitect `-test$` discovery) and CLJS (the `cljs-test$` regex). So the fix **renames the intended namespaces** to the `-cljs-test` suffix rather than special-casing the hot-zone `shadow-cljs.edn` regex. No build restructure.

Renamed (file + ns) to `-cljs-test`, now discovered by `:node-test`:

| Artefact | Namespaces |
|---|---|
| core | `on-error`, `event-emit`, `reg-meta-noswallow`, `reply`, `trace.projection` |
| machines | `actor-liveness`, `actor-resource-lease-release`, `destroy-silent-idempotent`, `handler-source-egress-strip`, `after-fire-reap`, `machines-reply` |
| adapter | `adapter.test-react` |

The only `shadow-cljs.edn` edit is a **comment correction** (lines 89–96): it wrongly claimed `re-frame.adapter.test-react-test` (ns ending `-test`) matched `cljs-test$`. Docstrings that carried the same wrong rationale (`actor-resource-lease-release`, `destroy-silent-idempotent`) were corrected too.

## Cross-namespace contamination surfaced + fixed

Enabling these in the shared node-test bundle exposed two fixtures (`event-emit`, `reg-meta-noswallow`) that called `registrar/clear-all!` **without restoring** — harmless in per-artefact JVM isolation, but in the shared bundle they wiped sibling namespaces' ns-load registrations, breaking `reg-view-react-key-cljs-test` (which renders a reg-view'd component and hit `TypeError: Cannot read properties of null (reading 'reagent_component')`). Both fixtures now snapshot + restore the registrar via the purpose-built `test-support/{snapshot,restore}-registrar!`. `machines-reply` used a bare `read-string` (not CLJS-resolvable) → `clojure.edn/read-string`.

## Quality gates

- **`npm run test:cljs`**: `8156 → 8301` tests, `37414 → 38143` assertions (**+145 tests, +729 assertions**), **0 failures, 0 errors**. The +145 tests are the newly-discovered CLJS suites; all 12 renamed namespaces verified present in `out/node-test.js`.
- **JVM** (targeted `clojure -M:test -n …`): core renamed nses **93 tests / 467 assertions** green; machines renamed nses **30 / 189** green; test-react **22 / 73** green — confirming the `-cljs-test` files still run on the JVM.
- **shadow-cljs.edn** re-parses cleanly (comment-only edit; `shadow-cljs compile node-test` succeeds; brackets balanced).
- Full spine deferred to CI.

Stance: pre-alpha, no back-compat shims; ELEGANCE + CLARITY + CORRECTNESS. Surgical — only test-namespace discovery + the exposed fixture-isolation bugs; no build restructure.

Closes rf2-ezbzvm.
