### PR TITLE
fix(images): retire stale rf/frame-shadows guidance in error strings (rf2-lvxry4)

### DIFF
--- a/implementation/core/src/re_frame/image.cljc
+++ b/implementation/core/src/re_frame/image.cljc
@@ -483,9 +483,9 @@
                           "selection).")
    :replace          (str ":replace is RETIRED — composition resolves by IMAGE "
                           "ORDER (the later image in :images wins). Define the "
-                          "override in a LATER image and read rf/frame-shadows to "
-                          "assert on what it shadowed; there is no acknowledgement "
-                          "key.")
+                          "override in a LATER image and read "
+                          "(:rf.gen/shadows (rf/frame-generation f)) to assert on "
+                          "what it shadowed; there is no acknowledgement key.")
    :replace-standard (str ":replace-standard is RETIRED — framework standards are "
                           "protected and not an ordinary app extension point. An "
                           "app image cannot shadow a standard.")
@@ -624,8 +624,8 @@
   and `:rf.image/requires` are RETIRED (EP-0026, rf2-dlvmpc): a spec carrying one
   fails loud (`check-retired-keys!`) with a migration diagnostic. Composition now
   resolves by IMAGE ORDER (the later image in `:images` wins) and reports
-  shadows via `rf/frame-shadows`; standards are protected; host-capability
-  declarations are removed end-to-end.
+  shadows via `(:rf.gen/shadows (rf/frame-generation f))`; standards are
+  protected; host-capability declarations are removed end-to-end.
 
   Returns a normalized image value:
 

--- a/implementation/core/src/re_frame/image_assembly.cljc
+++ b/implementation/core/src/re_frame/image_assembly.cljc
@@ -1275,7 +1275,7 @@
   <defined-in> :shadowed-by <winner>}]` list, one entry per cross-image shadow,
   naming the loser image + the FINAL winner. An empty vector when no later image
   shadowed an earlier one (the common deliberate-no-override case). The public
-  `rf/frame-shadows` accessor reads this directly (an ordinary read, not a
-  bespoke reload-report field). Pure."
+  `(:rf.gen/shadows (rf/frame-generation f))` read surfaces this directly (an
+  ordinary read, not a bespoke reload-report field). Pure."
   [generation]
   (:rf.gen/shadows generation))

--- a/scripts/check_retired_image_keys.py
+++ b/scripts/check_retired_image_keys.py
@@ -4,8 +4,9 @@
 EP-0026 (rf2-dlvmpc) RETIRES five EP-0023 image source keys and the three
 image-capability surfaces with FAIL-LOUD rejection. The public `rf/image` value
 now accepts exactly `:id`, `:select-ns`, and `:registrations`; composition
-resolves by IMAGE ORDER and reports shadows via `rf/frame-shadows`; framework
-standards are protected; image-declared host capabilities are removed end-to-end.
+resolves by IMAGE ORDER and reports shadows via
+`(:rf.gen/shadows (rf/frame-generation f))`; framework standards are protected;
+image-declared host capabilities are removed end-to-end.
 
 This gate keeps that retirement done. It fails if a RETIRED spelling reappears as
 LIVE, copy-pasteable API on the teaching/reference/source surface — outside the
@@ -463,7 +464,8 @@ _FIX_HINT = (
     "Migrate the example/code:\n"
     "  :include-ns / :exclude-ns -> :select-ns {:include [globs] :exclude [globs]}\n"
     "  :replace                  -> compose a LATER image (image order wins); "
-    "read rf/frame-shadows to assert on what it shadowed\n"
+    "read (:rf.gen/shadows (rf/frame-generation f)) to assert on what it "
+    "shadowed\n"
     "  :replace-standard         -> framework standards are protected; an app "
     "image cannot shadow one\n"
     "  :rf.image/requires / make-frame :capabilities / :rf.gen/requires -> "


### PR DESCRIPTION
## Summary

API-shrink prose residue **round 3** (rf2-lvxry4, follow-on from rf2-qmncuk). The public `rf/frame-shadows` facade projection was **removed** (rf2-i4hk4b); the shadow model now reads off `frame-generation` as `(:rf.gen/shadows (rf/frame-generation f))`. The internal `re-frame.live-frame/frame-shadows` accessor still exists and is untouched.

Three implementation-source sites still pointed users at the removed facade — including a **user-facing runtime error message** — so they are retired to the current read.

## Changes

- **`implementation/core/src/re_frame/image.cljc`**
  - the `:replace` retired-image-key **error message** (the runtime string that told users to "read rf/frame-shadows") → now `(:rf.gen/shadows (rf/frame-generation f))`
  - the `image` docstring shadow-report note
- **`implementation/core/src/re_frame/image_assembly.cljc`** — the `generation-shadows` docstring accessor note
- **`scripts/check_retired_image_keys.py` (the PAIRED gate)** — its module docstring + `_FIX_HINT` mirror the image.cljc `:replace` message verbatim (a deliberate prose lockstep noted in rf2-i4hk4b, ~line 466). Both moved in the same PR so the pairing stays in sync.

### Pairing note
Neither python gate **asserts** the `frame-shadows` string (`check_retired_image_keys.py` fires on retired *keys*; `check_retired_spellings.py` on `:frame` coeffects / `:url`/`:to` redirect keys). The `:replace` sync is a **prose lockstep**, updated here so the two stay identical — the pairing is **not** broken. The `:replace` retirement test asserts the error-id + retired-key (from the map data), not the message text, so the string change is safe.

### Out of scope (left as-is, correct)
- the internal `re-frame.live-frame/frame-shadows` def (still exists)
- test comments documenting the *removal* (`facade_frame_read_cljs_test.cljc`, removed-context)
- the `lf/frame-shadows` internal-accessor test usages

## Quality gates
- `python scripts/check_retired_image_keys.py` — **PASS** (exit 0); `--self-test` **PASS**
- `python scripts/check_retired_spellings.py` — **PASS** (exit 0); `--self-test` **PASS**
- `clojure -M:test` focused (image + ep0026 namespaces) — **119 tests, 484 assertions, 0 failures, 0 errors**
- `npm run test:cljs` — **8304 tests, 38178 assertions, 0 failures, 0 errors**
- Full `test-fast-pr` spine deferred to CI.

Stance: pre-alpha, no back-compat shims; elegance + clarity + correctness.
