### PR TITLE
fix(websocket-example): fire reply-event on request-timeout (rf2-vqg8l6)

### DIFF
--- a/examples/patterns/websocket/README.md
+++ b/examples/patterns/websocket/README.md
@@ -70,7 +70,12 @@ Everything below builds on those three. The rest is ordinary machine grammar —
   request-id; `:register-request` stamps the id onto the outgoing body, schedules
   a `:dispatch-later` timeout, and routes the body to the actor. The matching
   inbound `:ws/received` clears the slot and dispatches the registered reply
-  [event](../../../docs/core/glossary.md#event). The correlation id is a folded
+  [event](../../../docs/core/glossary.md#event). If the deadline fires first —
+  a `:ws/request-timeout` on a still-live socket — the request is *failed*, not
+  silently forgotten: the slot clears and the waiting reply fires with an
+  explicit `{:ok false :error :ws/timeout}` body, the per-request twin of the
+  socket-drop path below, so a timed-out caller learns the outcome instead of
+  hanging forever. The correlation id is a folded
   fact from a *recordable* [coeffect](../../../docs/core/glossary.md#coeffect)
   (`:ws.app/request-id`), not an ambient `(random-uuid)` — so a replay re-presents
   the same id and the reply still matches the recorded request. (This is

--- a/examples/patterns/websocket/connection.cljs
+++ b/examples/patterns/websocket/connection.cljs
@@ -290,8 +290,25 @@
                             :source-socket-id (socket-id data)}]]}]]})
 
       :clear-request
+      ;; A request's deadline fired — a `:ws/request-timeout` that passed
+      ;; `:current-socket?`, so the socket is still live but the reply never
+      ;; came. FAIL the request, don't just forget it: clear the in-flight
+      ;; slot AND fire the waiting `:reply-event` with an explicit timeout
+      ;; body, so a request that times out on a live socket learns its
+      ;; outcome instead of hanging forever. This is `:on-socket-lost`'s
+      ;; per-request twin — same `{:ok false :error …}` failure shape, but
+      ;; scoped to the single request whose timer elapsed rather than the
+      ;; whole in-flight set. (A request registered without a `:reply` has a
+      ;; nil `:reply-event`, so the dispatch is guarded — same as
+      ;; `:receive-message`.)
       (fn action-clear-request [{data :data [_ {:keys [request-id]}] :event}]
-        {:data (update data :in-flight dissoc request-id)})
+        (let [{:keys [reply-event]} (get-in data [:in-flight request-id])]
+          {:data (update data :in-flight dissoc request-id)
+           :fx   (cond-> []
+                   reply-event (conj [:dispatch (conj reply-event
+                                                      {:request-id request-id
+                                                       :ok         false
+                                                       :error      :ws/timeout})]))}))
 
       :receive-message
       ;; A message arrived and the `:current-socket?` guard has already

--- a/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
@@ -640,6 +640,60 @@
               (is (= rid (:request-id reply))
                   "the failure names the dropped request"))))))))
 
+(defn- timeout-fails-in-flight-request-test []
+  ;; rf2-vqg8l6 — a request that TIMES OUT while the socket is still ALIVE must
+  ;; not leave its caller hanging. The `:ws/request-timeout` handler (guarded by
+  ;; `:current-socket?`, so the socket is live) FAILS the request the same way a
+  ;; socket drop does: it clears the in-flight slot AND fires the waiting
+  ;; `:reply-event` with an explicit `{:ok false :error :ws/timeout}` body —
+  ;; `:on-socket-lost`'s per-request twin, scoped to the one request whose timer
+  ;; elapsed. Unlike a drop, the connection stays up.
+  (with-sync-mock!
+    (fn []
+      (with-new-frame [f (new-frame)]
+        (rf/dispatch-sync [:ws/connection
+                           [:ws/connect {:url "ws://mock" :auth-token "demo"}]]
+                          {:frame f})
+        (is (true? (machine-has-tag? f :websocket/connected)))
+        (let [live-id (socket-id-of (snapshot (:rf.db/runtime (rf/frame-state-value f))))
+              rid     (random-uuid)]
+          ;; A request whose wire :type the mock does NOT echo, so it sits
+          ;; in-flight with no reply to clear it — a genuine no-answer.
+          (rf/dispatch-sync [:ws/connection
+                             [:ws/request {:request-id rid
+                                           :body       {:type :silent-no-echo}
+                                           :reply      [:ws.app/request-reply]
+                                           :timeout-ms 5000}]]
+                            {:frame f})
+          (is (contains? (get-in (snapshot (:rf.db/runtime (rf/frame-state-value f)))
+                                 [:data :in-flight])
+                         rid)
+              "a request with no immediate reply sits in :in-flight")
+          ;; Fire its timeout carrying the LIVE socket-id, so it passes
+          ;; :current-socket? — the socket-still-alive timeout case. (new-frame
+          ;; suppresses the real :dispatch-later, so we synthesise the timeout
+          ;; event exactly as :register-request would have scheduled it.)
+          (rf/dispatch-sync [:ws/connection
+                             [:ws/request-timeout {:request-id       rid
+                                                   :source-socket-id live-id}]]
+                            {:frame f})
+          (let [s  (snapshot (:rf.db/runtime (rf/frame-state-value f)))
+                db (rf/app-db-value f)]
+            ;; A timeout does NOT tear the connection down (that's the drop
+            ;; path) — the socket is still the same live actor.
+            (is (true? (machine-has-tag? f :websocket/connected))
+                "a request timeout leaves the live connection connected")
+            (is (= live-id (socket-id-of s))
+                "the socket survived the request timeout")
+            (is (not (contains? (get-in s [:data :in-flight]) rid))
+                ":in-flight slot cleared on timeout — no indefinite leak")
+            (let [reply (get-in db [:messages :last-reply])]
+              (is (some? reply) "the waiting reply-event fired on the timeout")
+              (is (false? (:ok reply)) "reply is an explicit failure")
+              (is (= :ws/timeout (:error reply)))
+              (is (= rid (:request-id reply))
+                  "the failure names the timed-out request"))))))))
+
 (defn- queued-request-registers-and-replies-on-connect-test []
   ;; rf2-ryt25d — a :ws/request issued OFF-connection must be buffered as its
   ;; event and, on connect, rejoin :register-request so it registers, sends
@@ -908,6 +962,12 @@
   (testing "rf2-r1rkvb — a socket drop fails + clears every in-flight request
             (no leak); the waiting reply-event gets a connection-lost body"
     (drop-fails-in-flight-request-test)))
+
+(deftest websocket-timeout-fails-in-flight-request
+  (testing "rf2-vqg8l6 — a request that times out on a still-live socket fails +
+            clears its in-flight slot; the waiting reply-event gets a :ws/timeout
+            body, and the connection stays up"
+    (timeout-fails-in-flight-request-test)))
 
 (deftest websocket-queued-request-registers-and-replies-on-connect
   (testing "rf2-ryt25d — a :ws/request buffered off-connection registers and


### PR DESCRIPTION
## What

The websocket example's `:ws/request-timeout` → `:clear-request` transition only `(update data :in-flight dissoc request-id)` — it never fired the stashed `:reply-event`. A request that **times out while the socket is still alive** therefore left its caller hanging forever.

This is the exact asymmetry rf2-r1rkvb's `:on-socket-lost` (#5310) just fixed for the socket-**drop** case ("so the caller learns the outcome instead of hanging forever") — left unaddressed for the **timeout** case.

## Fix

`:clear-request` is now `:on-socket-lost`'s **per-request twin**: it looks up the in-flight slot, clears it, **and** fires the waiting `:reply-event` with an explicit failure body:

```clojure
{:request-id request-id :ok false :error :ws/timeout}
```

- Same `{:ok false :error …}` failure shape as the socket-drop path, but scoped to the single request whose timer elapsed rather than the whole in-flight set.
- `:ws/timeout` is the reason-descriptor twin of `:ws/connection-lost` — matching the file's convention where the error label is a *reason* (`:ws/connection-lost`), not the triggering event id (`:ws/closed`).
- The dispatch is guarded for a request registered without a `:reply` (nil reply-event), same as `:receive-message`.
- Unlike a drop, the connection **stays up** — a timeout fails one request, it doesn't tear the socket down.

README request/reply bullet extended to tell the timeout-fires-a-failure half of the story (it was silent on what a fired deadline does).

## Tests

Adds `websocket-timeout-fails-in-flight-request` (adversarial, in the reagent websocket test tree — examples stay test-free): a timed-out in-flight request on a **still-live** socket clears its slot, fires its `:reply-event` with the `:ws/timeout` failure (`:ok false`, correct `:request-id`), and the connection stays `:connected`. The timeout event carries the live socket-id so it passes `:current-socket?` — the socket-still-alive case.

## Quality gates

- `npm run test:cljs` (from `implementation/`): **8305 tests / 38187 assertions, 0 failures, 0 errors** — new timeout-reply test passes, no regression in the existing websocket lifecycle tests. `npm ci` run once (node_modules absent in the fresh worktree).
- Full `test-fast-pr` spine deferred to CI.

## Stance

Pre-alpha, no back-compat shims; ELEGANCE + CLARITY + CORRECTNESS — a symmetric per-request failure path reusing the existing failure-reply shape, no new vocabulary. Example-only surface (+ its reagent test).

Closes rf2-vqg8l6.
