### PR TITLE
fix(examples): rewrite linearlite app-db events to effectful reg-event shape (rf2-0ht87o)

### DIFF
--- a/examples/capabilities/resources/linearlite/core.cljs
+++ b/examples/capabilities/resources/linearlite/core.cljs
@@ -357,8 +357,8 @@
           write?    (not= method :get)
           ;; The fx context carries the envelope frame as `:frame`. The
           ;; `:fail-next-write?` toggle is an ordinary app-db slice (written by
-          ;; `:linearlite/set-fail-next-write`, a plain db-in/db-out handler), so
-          ;; read it off the frame's APP-db partition (`:rf.db/app`). Reading
+          ;; `:linearlite/set-fail-next-write`), so read it off the frame's
+          ;; APP-db partition (`:rf.db/app`). Reading
           ;; `:rf.db/runtime` here — where the flag never lives — is why the
           ;; simulated rollback never fired.
           db        (:rf.db/app (rf/frame-state-value (:frame frame-ctx)))
@@ -391,19 +391,19 @@
 ;; reads the sub.
 
 (rf/reg-event :linearlite/set-fail-next-write
-  (fn [db [_ on?]] (assoc db :fail-next-write? on?)))
+  (fn [{:keys [db]} [_ on?]] {:db (assoc db :fail-next-write? on?)}))
 
 (rf/reg-event :linearlite/set-new-issue-draft
-  (fn [db [_ text]] (assoc db :new-issue-draft text)))
+  (fn [{:keys [db]} [_ text]] {:db (assoc db :new-issue-draft text)}))
 
 (rf/reg-event :linearlite/begin-edit
-  (fn [db [_ id title]] (assoc db :editing {:id id :title title})))
+  (fn [{:keys [db]} [_ id title]] {:db (assoc db :editing {:id id :title title})}))
 
 (rf/reg-event :linearlite/set-edit-draft
-  (fn [db [_ text]] (assoc-in db [:editing :title] text)))
+  (fn [{:keys [db]} [_ text]] {:db (assoc-in db [:editing :title] text)}))
 
 (rf/reg-event :linearlite/cancel-edit
-  (fn [db _] (dissoc db :editing)))
+  (fn [{:keys [db]} _] {:db (dissoc db :editing)}))
 
 (rf/reg-sub :linearlite/fail-next-write? (fn [db _] (boolean (:fail-next-write? db))))
 (rf/reg-sub :linearlite/new-issue-draft  (fn [db _] (or (:new-issue-draft db) "")))


### PR DESCRIPTION
## What

`examples/capabilities/resources/linearlite/core.cljs` had five app-db events written in the **removed** re-frame v1 `reg-event-db` db-in/db-out shape `(fn [db [_ x]] (assoc db …))`:

- `:linearlite/set-fail-next-write`
- `:linearlite/set-new-issue-draft`
- `:linearlite/begin-edit`
- `:linearlite/set-edit-draft`
- `:linearlite/cancel-edit`

Under re-frame2's unified `reg-event` (EP-0018; `reg-event-db`/`-fx` removed), a handler is always invoked as `(handler-fn coeffects-map event)` and must return a closed effects map. So in these five: arg1 bound to the **whole coeffects map** (not app-db), the raw-db return had its non-`:db` keys dropped by `police-effect-map-shape!`, and the written-back `:db` was the app-db unchanged. All five were **silent no-ops**:

1. **New-issue form frozen** — the controlled `<input>` reads `:linearlite/new-issue-draft`; the write no-op'd so you could never type a title.
2. **Rollback demo unreachable (the headline)** — the demo http-stub arms on `(:fail-next-write? db)`; the toggle no-op'd, so the write always "succeeded" and the optimistic-apply→503→rollback arc the ns docstring sells could never fire.
3. **Inline title editing dead** — `begin-edit`/`set-edit-draft`/`cancel-edit` no-op'd, so `:editing` never set and the edit form never opened.

## Fix

Rewrite all five in the effectful shape `(fn [{:keys [db]} ev] {:db …})`, matching the three working effectful write handlers already in the same file (`create-issue`/`commit-edit`/`change-status`). Also dropped a now-stale comment that described `set-fail-next-write` as "a plain db-in/db-out handler". No other removed-API usage in the file (grep-verified: no `reg-event-db`/`reg-event-fx`).

## Verification (reasoned through, per the test-free examples policy)

Corrected behaviour, traced against the subs/views that read each slice:
- `set-fail-next-write` → `{:db (assoc db :fail-next-write? on?)}` — toggle now arms; the http-stub reads it off `:rf.db/app` and answers the next write with a 503 → rollback demo fires.
- `set-new-issue-draft` → writes `:new-issue-draft` — the controlled input now updates as you type.
- `begin-edit` → writes `:editing {:id :title}` — `editing-this?` becomes true → inline edit form opens.
- `set-edit-draft` → `assoc-in [:editing :title]` — edit input updates as you type.
- `cancel-edit` → `dissoc :editing` — edit form closes.

## Quality gates

- `npx shadow-cljs compile examples/linearlite` — **PASS** (208 files, 0 warnings).
- `npx shadow-cljs compile node-test` + `node out/node-test.js --test=re-frame.linearlite-example-cljs-test` — **PASS** (8 tests, 35 assertions, 0 failures, 0 errors). Confirms the three effectful handlers + resource/mutation/route/sub/view registrations still work after the change.
- Focused checks only; full spine deferred to CI.

## Follow-up (not in this PR)

The existing contract test (`implementation/adapters/reagent/test/re_frame/linearlite_example_cljs_test.cljs`) leaves this class **unguarded**: it overrides the demo stub with a capturing no-op, drives success/failure by replaying replies, and never dispatches these five events. A regression test that drives the fail-next-write seam through the **actual** demo stub belongs in substrate contract tests (`implementation/`), not `examples/` (test-free per rf2-8cevm). Noted rather than added here.

## Stance

pre-alpha, no back-compat shims; ELEGANCE + CLARITY + CORRECTNESS. Minimal, surgical fix that brings the five handlers into the current idiomatic effectful `reg-event` shape.

Closes rf2-0ht87o.
