### PR TITLE
fix(machines): ensure cofx for :choice + per-state :after; close timer-cancel reason vocab (rf2-4y4bzq +2)

### DIFF
--- a/implementation/machines/src/re_frame/machines/cofx_attach.cljc
+++ b/implementation/machines/src/re_frame/machines/cofx_attach.cljc
@@ -69,10 +69,21 @@
   with their own require on `re-frame.cofx` (the core delivery surface).
   Keeping them out of `lifecycle-fx.validation` / `lifecycle-fx.registration`
   keeps those files focused and lets the engine require this leaf without a
-  cycle (it requires `grammar`, `cofx`, `trace`, `interop`, `registrar`,
-  `error`, plus — for the sub-valued source evaluator hook — `subs` /
-  `frame` / `late-bind`; none of subs / frame require the machines engine, so
-  no cycle).
+  cycle (it requires `grammar` / `choice`, `cofx`, `trace`, `interop`,
+  `registrar`, `error`, plus — for the sub-valued source evaluator hook —
+  `subs` / `frame` / `late-bind`; `choice` is a leaf requiring only `error`,
+  and none of subs / frame require the machines engine, so no cycle).
+
+  ## Pre-desugar surfaces (`:choice` / state-level `:after`)
+
+  The index + ensure-set computation run on the RAW machine (before
+  `choice/desugar-choices` / `timeout/desugar-timeouts` lower the authoring
+  sugar at transition / birth time). So this ns settles the sugar the way the
+  runtime does: a `:type :choice` transient node's `:choice` candidate vector
+  is its `:always` candidate set (`always-entries`), and a state-level `:after`
+  table transition contributes to the ensure-set for its synthetic timer event
+  (`after-diet-for-event`) — mirroring how the parallel ROOT `:after` is
+  handled by `parallel-root-diet`.
 
   XState offers NO parity guidance here — it has no replay contract; this
   surface is re-frame2's own (EP-0017 §Rationale — Why consumer attachment
@@ -82,6 +93,7 @@
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
+            [re-frame.machines.choice :as choice]
             [re-frame.machines.grammar :as grammar]
             [re-frame.registrar :as registrar]
             [re-frame.subs :as subs]
@@ -220,9 +232,18 @@
   unrecognised shape degrades to `[]` (the runtime normaliser is the
   throw's designated surface — `:rf.error/machine-bad-always`). Absent
   `:always` (missing key, or present with nil) → `[]`. Mirrors
-  `validation/always-entries`."
+  `validation/always-entries`.
+
+  A `:type :choice` transient node carries its candidate vector under
+  `:choice`, NOT `:always` — the choice lowers to `:always` only at
+  `choice/desugar-node-choice`, and the index + ensure-set run on the RAW
+  pre-desugar machine (rf2-4y4bzq). Since a choice state routes through the
+  IDENTICAL `:always` cascade the runtime settles it into, treat a choice
+  node's `:choice` vector as its `:always` candidates here; validation
+  guarantees a choice node never ALSO declares `:always` (a reserved key), so
+  there is no ambiguity."
   [node]
-  (let [a (:always node)]
+  (let [a (if (choice/choice-node? node) (:choice node) (:always node))]
     (if (nil? a)
       []
       (case (grammar/transition-value-form a)
@@ -251,17 +272,24 @@
   "Sweep every transition slot + callback slot of every state node (and the
   machine / region roots) for an inline `:rf.cofx/requires` declaration, and
   reject it. The legal home — a named `:guards` / `:actions` entry map — is
-  parsed by `index-ensure-sets`; this pass catches the ILLEGAL homes."
+  parsed by `index-ensure-sets`; this pass catches the ILLEGAL homes. A
+  `:type :choice` node's candidates are swept via `always-entries` (which
+  reads its `:choice` vector — the choice lowers to `:always`); the diagnostic
+  labels them `:choice` so the author sees the slot they actually wrote
+  (rf2-4y4bzq)."
   [machine]
   (let [roots (if (and (map? (:regions machine)) (seq (:regions machine)))
                 (cons machine (vals (:regions machine)))
                 [machine])
         check-node!
         (fn [path node]
-          (let [where (str "state " (if (seq path) (peek path) :rf/root))]
+          (let [where       (str "state " (if (seq path) (peek path) :rf/root))
+                ;; a choice node's candidates ride `:choice`; `always-entries`
+                ;; surfaces them, but label the site `:choice` not `:always`.
+                always-label (if (choice/choice-node? node) " :choice" " :always")]
             (doseq [[_ev v] (:on node)]    (check-no-inline-requires! (str where " :on") v))
             (doseq [[_d v]  (:after node)] (check-no-inline-requires! (str where " :after") v))
-            (doseq [e (always-entries node)] (check-no-inline-requires! (str where " :always") e))
+            (doseq [e (always-entries node)] (check-no-inline-requires! (str where always-label) e))
             (when (contains? node :on-done)
               (check-no-inline-requires! (str where " :on-done") (:on-done node)))
             (check-no-inline-requires! (str where " :entry") (:entry node))
@@ -471,6 +499,15 @@
 ;; since the event-id matches an `:on` key, but the `:on-done` slot is not).
 (def ^:private done-event-id :rf.machine/done)
 
+;; The synthetic timer event id (`transition/after-elapsed-event-id`). Inlined
+;; as a literal so this leaf does not require `transition` — the docstring's
+;; require contract (`grammar` / `choice` / `cofx` / `trace` / `interop`) stays
+;; cycle-free. `pick-after-transition` / `root-after-match` in `transition` are
+;; the runtime peers. Defined here (ahead of `ensure-set-in-scope`) because both
+;; the per-state `after-diet-for-event` and the parallel-root `parallel-root-
+;; diet` route on it.
+(def ^:private after-elapsed-event-id :rf.machine.timer/after-elapsed)
+
 (defn- on-done-diet-for-event
   "Add (into `add!`) the `:on-done` guard/action diets of the completed node a
   raised done event targets. `event` is `[:rf.machine/done
@@ -495,6 +532,49 @@
               (when-let [tgt (resolve-target-path states done-path (:target cand))]
                 (add-always! tgt)))))))))
 
+(defn- after-diet-for-event
+  "Add (into `add!`) the guard/action diet of a per-state (or per-region)
+  `:after`-TABLE transition the synthetic timer event fires, plus the `:always`
+  closure reachable from each candidate's target. `event` is
+  `[:rf.machine.timer/after-elapsed delay-key epoch decl-path]`; the runtime
+  routes it to the SCHEDULING node at `decl-path` and selects the `:after`
+  entry at `delay-key` (`transition/pick-after-transition`) — a slot separate
+  from `:on`, so an `:after` guard/action declaring `:rf.cofx/requires` is
+  invisible to the `:on` walk. This adds it, mirroring how `parallel-root-diet`
+  handles the parallel-ROOT `:after` (rf2-iyrc9t: the per-state / per-region
+  `:after` had no such clause).
+
+  `region` is the region name when `states` is a parallel region's `:states`
+  body, else nil. Within a region the carried decl-path is region-qualified
+  (`[region & in-region-path]`), so strip the region head to resolve within
+  the region scope; a decl-path naming a DIFFERENT region is not this region's
+  timer (declines). A root-owned timer (`decl-path` `[]`, resolved by
+  `parallel-root-diet`) does not resolve to a `:states` node here, so it is a
+  no-op on this path — no double-count. The resolution is a sound
+  over-approximation (no active-path liveness check — an un-fired / stale
+  timer's ensured facts are a harmless idempotent no-op), exactly as the
+  parallel-root clause is. No-op when the event is not an after-elapsed timer,
+  the decl-path does not resolve, or the node declares no `:after` at
+  `delay-key`."
+  [by-entry states event region add! add-always!]
+  (when (and (vector? event) (= after-elapsed-event-id (first event)))
+    (let [[_ delay-key _epoch raw-decl-path] event
+          decl-path (cond
+                      (nil? raw-decl-path) nil
+                      ;; region-qualified: strip the head iff it names THIS
+                      ;; region (else the timer belongs to a sibling region).
+                      region (when (= region (first raw-decl-path))
+                               (vec (rest raw-decl-path)))
+                      :else  (vec raw-decl-path))]
+      (when (seq decl-path)
+        (let [node (node-at states decl-path)]
+          (when (and (map? node) (contains? (:after node) delay-key))
+            (doseq [cand (candidate-maps (get-in node [:after delay-key]))]
+              (add! (entry-diet by-entry :guards  (:guard cand)))
+              (add! (entry-diet by-entry :actions (:action cand)))
+              (when-let [tgt (resolve-target-path states decl-path (:target cand))]
+                (add-always! tgt)))))))))
+
 (defn- ensure-set-in-scope
   "Compute the ensure-set (a set of `parse-requires` entries, deduped by
   `:id`) for a single `states` scope, active `path`, and inner event type
@@ -512,10 +592,18 @@
   `:on {:rf.machine/done …}` escape hatch, but the `:on-done` slot is a
   separate candidate the runtime selects.
 
+  When `event` is the synthetic `:after` timer signal
+  (`[:rf.machine.timer/after-elapsed delay-key epoch decl-path]`), the
+  scheduling node's `:after`-table transition at `decl-path` / `delay-key`
+  joins the set (guard/action diet + the `:always` closure from its target) —
+  a slot separate from `:on`, so the `:on` walk misses it (rf2-iyrc9t).
+  `region` is the region name when `states` is a parallel region's body (so the
+  region-qualified decl-path can be stripped / declined), else nil.
+
   `by-entry` is the registration index's `:by-entry` map. Returns a vector of
   parsed-requires entries (deduped by id, declaration-order-insensitive — the
   ensure step is order-independent)."
-  [by-entry states path event]
+  [by-entry states path event region]
   (let [event-id (when (vector? event) (first event))
         acc      (volatile! [])
         seen-ids (volatile! #{})
@@ -578,13 +666,14 @@
     ;; `:always` closure reachable from its target so an `:on-done` callback's
     ;; `:rf.cofx/requires` is ensured before the done transition is selected.
     (on-done-diet-for-event by-entry states event add! add-always!)
+    ;; (e) the synthetic `:after` timer signal
+    ;; (`[:rf.machine.timer/after-elapsed delay-key epoch decl-path]`) fires the
+    ;; scheduling node's `:after`-table transition at decl-path/delay-key — a
+    ;; slot separate from `:on`. Add its candidates' guard/action diet + the
+    ;; `:always` closure from each target, mirroring `parallel-root-diet`'s
+    ;; root-`:after` clause (rf2-iyrc9t).
+    (after-diet-for-event by-entry states event region add! add-always!)
     @acc))
-
-;; The synthetic timer event id (`transition/after-elapsed-event-id`). Inlined
-;; as a literal so this leaf does not require `transition` — the docstring's
-;; require contract (`grammar` / `path-walk` / `cofx` / `trace` / `interop`)
-;; stays cycle-free. `root-after-match` in `transition` is the runtime peer.
-(def ^:private after-elapsed-event-id :rf.machine.timer/after-elapsed)
 
 (defn- root-target-always-diet
   "The `:always`-closure diet reachable from a PARALLEL-ROOT transition's
@@ -708,7 +797,7 @@
                                       (keyword? region-state) [region-state]
                                       :else nil)]
                     :when (and scope rpath)]
-              (add! (ensure-set-in-scope by-entry scope rpath event)))
+              (add! (ensure-set-in-scope by-entry scope rpath event region)))
             ;; the parallel root's own live transition surfaces.
             (parallel-root-diet by-entry machine event event-id add!)
             @acc)
@@ -717,7 +806,7 @@
                            (keyword? state) [state]
                            :else nil)]
             (if path
-              (ensure-set-in-scope by-entry (scope-for machine) path event)
+              (ensure-set-in-scope by-entry (scope-for machine) path event nil)
               [])))))))
 
 (defn- initial-path-for-scope

--- a/implementation/machines/src/re_frame/machines/reply.cljc
+++ b/implementation/machines/src/re_frame/machines/reply.cljc
@@ -532,8 +532,14 @@
   the cancel-reason taxonomy a cancelled-timer reply's `:cancel/reason`
   carries: `:on-exit` (state exit), `:on-destroy` (actor destroy),
   `:on-resolution` (subscription-delay re-resolution), `:on-supersede`
-  (in-place reschedule), `:on-frame-destroy` (frame teardown)."
-  #{:on-exit :on-destroy :on-resolution :on-supersede :on-frame-destroy})
+  (in-place reschedule), `:on-frame-destroy` (frame teardown), and
+  `:on-restore` (epoch-restore host-timer cleanup — `timer/cancel-frame-
+  timers-on-restore!` releases the orphaned host handles the unwound epochs
+  left attached; Spec 005 §Root parallel `:after` trace catalogue). Matches
+  the closed `:reason` vocabulary spec/005's `:rf.machine.timer/cancelled`
+  catalogue enumerates (rf2-e3ryis)."
+  #{:on-exit :on-destroy :on-resolution :on-supersede :on-frame-destroy
+    :on-restore})
 
 (defn cancelled-timer-reply
   "Build the `:status :cancelled` reply for a cancelled machine `:after`

--- a/implementation/machines/src/re_frame/machines/timer.cljc
+++ b/implementation/machines/src/re_frame/machines/timer.cljc
@@ -181,7 +181,8 @@
   destroy — flows through this single emit so consumers can pair
   scheduled→fired→cancelled by `(actor-id, state, epoch)` and branch on
   `:reason` from the closed set `:on-exit / :on-destroy / :on-resolution
-  / :on-supersede / :on-frame-destroy`.
+  / :on-supersede / :on-frame-destroy / :on-restore` (the epoch-restore
+  host-timer cleanup, `cancel-frame-timers-on-restore!`).
 
   Payload shape mirrors `:rf.machine.timer/scheduled` for arm-fire-
   cancel pairing — same `:actor-id` / `:state` / `:delay` / `:epoch`
@@ -240,7 +241,7 @@
   "Cancel and clear a single :after timer-table entry under `frame-id`,
   emitting one `:rf.machine.timer/cancelled` trace stamped with
   `reason` (closed set: `:on-exit / :on-destroy / :on-resolution /
-  :on-supersede / :on-frame-destroy`). Idempotent —
+  :on-supersede / :on-frame-destroy / :on-restore`). Idempotent —
   a second call against the same `[frame-id k]` is a no-op (the entry
   is gone so no trace fires)."
   [frame-id k reason]

--- a/implementation/machines/test/re_frame/machine_cofx_attach_test.clj
+++ b/implementation/machines/test/re_frame/machine_cofx_attach_test.clj
@@ -508,3 +508,149 @@
                                      [:go-all])))
                      :rf/time-ms)
           "the parallel root :on guard's provided requires is in the ensure-set"))))
+
+;; ===========================================================================
+;; :type :choice candidates in the ensure-set (rf2-4y4bzq)
+;; ===========================================================================
+;;
+;; A `:type :choice` transient node carries its candidate vector under
+;; `:choice`, which LOWERS to `:always` only at `choice/desugar-choices` (run
+;; at transition / birth time). The index + ensure-set run on the RAW
+;; pre-desugar machine, so the ensure-set must treat a choice node's `:choice`
+;; vector as its `:always` candidates — otherwise a choice candidate guard's
+;; :rf.cofx/requires is never ensured, the guard reads nil, and strict replay
+;; diverges (it selects a DIFFERENT candidate). The inline-fn restriction must
+;; likewise sweep :choice.
+
+(deftest inline-requires-on-choice-candidate-rejected
+  (testing "an :rf.cofx/requires placed directly on a :type :choice candidate
+            (an inline declaration with no :fn to deliver to) fails
+            registration with :rf.error/machine-cofx-requires-inline — the
+            :choice slot is swept like :always (the choice lowers to :always)"
+    (let [m {:initial :idle
+             :data    {}
+             :states  {:idle     {:on {:go :checking}}
+                       :checking {:type   :choice
+                                  :choice [{:rf.cofx/requires [:rf/time-ms]
+                                            :target :a}
+                                           {:target :b}]}
+                       :a {} :b {}}}
+          e (is (thrown? ExceptionInfo
+                         (machines/make-machine-handler m)))]
+      (is (= :rf.error/machine-cofx-requires-inline
+             (:rf.error/id (ex-data e)))
+          "the inline-on-choice-candidate declaration is rejected"))))
+
+(deftest ensure-set-for-includes-choice-candidate-requires
+  (testing "white-box: ensure-set-for treats a :type :choice node's :choice
+            vector as its :always candidates, so a choice candidate GUARD's
+            :rf.cofx/requires is in the ensure-set (reachable through the
+            choice target) — before rf2-4y4bzq always-entries read (:always
+            choice-node)=nil and the fact was dropped"
+    (rf/reg-cofx :test/choice-roll {:recordable? true} (fn [] 6))
+    (let [m (cofx-attach/index-ensure-sets
+              {:initial :idle
+               :guards  {:needs-roll {:rf.cofx/requires [:test/choice-roll]
+                                      :fn (fn [_] true)}}
+               :states  {:idle     {:on {:go :checking}}
+                         :checking {:type   :choice
+                                    :choice [{:guard :needs-roll :target :a}
+                                             {:target :b}]}
+                         :a {} :b {}}})
+          es (cofx-attach/ensure-set-for m {:state :idle :data {}} [:go])]
+      (is (contains? (set (map :id es)) :test/choice-roll)
+          "the ensure-set for [:go] at :idle includes the choice candidate
+           guard's requires — reachable through the :checking choice target"))))
+
+(deftest choice-candidate-guard-reads-ensured-generated-fact
+  (testing "end-to-end: a :type :choice candidate GUARD requiring a
+            generator-backed fact reads the GENERATED value (never nil) — the
+            ensure-set closure treats the choice node's :choice vector as its
+            :always candidates, so the fact is ensured BEFORE the choice settles
+            (it lowers to :always in the same macrostep) and routes correctly"
+    (rf/reg-cofx :test/roll {:recordable? true} (fn [] 6))
+    (let [seen (atom ::unset)
+          m {:initial :idle
+             :data    {}
+             :guards  {:rolled-six?
+                       {:rf.cofx/requires [:test/roll]
+                        :fn (fn [{cofx :rf.cofx}]
+                              (reset! seen (:test/roll cofx))
+                              (= 6 (:test/roll cofx)))}}
+             :states  {:idle     {:on {:go :checking}}
+                       :checking {:type   :choice
+                                  :choice [{:guard :rolled-six? :target :hit}
+                                           {:target :miss}]}
+                       :hit  {}
+                       :miss {}}}]
+      (rf/reg-machine :attach/choice-guard m)
+      ;; No :test/roll on the token — the ensure step must generate it BEFORE
+      ;; the choice node settles (it lowers to :always in the [:go] macrostep).
+      (rf/dispatch-sync [:attach/choice-guard [:go]]
+                        {:rf.cofx {:rf/time-ms SCRIPTED-TIME-MS}})
+      (is (= 6 @seen)
+          "the choice candidate guard read the GENERATED :test/roll (not nil) —
+           ensured before the choice settled")
+      (is (= :hit (mtest/machine-state :attach/choice-guard))
+          "the choice routed to :hit on the ensured value"))))
+
+;; ===========================================================================
+;; state-level / per-region :after candidates in the ensure-set (rf2-iyrc9t)
+;; ===========================================================================
+;;
+;; The synthetic timer event [:rf.machine.timer/after-elapsed delay epoch
+;; decl-path] routes to the scheduling node's :after-TABLE transition at
+;; decl-path/delay — a slot SEPARATE from :on, so the :on walk misses it. The
+;; parallel ROOT :after was already handled (parallel-root-diet); the
+;; per-state / per-region :after was the asymmetric gap. A state-level :after
+;; guard/action declaring :rf.cofx/requires must have its facts ensured when
+;; the timer fires, else the guard reads nil / replay diverges.
+
+(deftest ensure-set-for-includes-state-after
+  (testing "white-box: ensure-set-for for a state-level :after timer event
+            ([:rf.machine.timer/after-elapsed delay epoch [state]]) includes the
+            :after candidate's requires — the :after slot the :on walk missed
+            (rf2-iyrc9t)"
+    (rf/reg-cofx :test/token {:recordable? true} (fn [] :T))
+    (let [m (cofx-attach/index-ensure-sets
+              {:initial :waiting
+               :data    {}
+               :guards  {:needs-token
+                         {:rf.cofx/requires [:test/token]
+                          :fn (fn [{cofx :rf.cofx}] (some? (:test/token cofx)))}}
+               :states  {:waiting {:after {5000 {:guard  :needs-token
+                                                 :target :done}}}
+                         :done    {}}})
+          ;; the state timer carries the scheduling node's decl-path [:waiting].
+          es (cofx-attach/ensure-set-for
+               m {:state :waiting :data {}}
+               [:rf.machine.timer/after-elapsed 5000 1 [:waiting]])]
+      (is (contains? (set (map :id es)) :test/token)
+          "the ensure-set for the state :after timer includes the :after guard's
+           requires — before rf2-iyrc9t only the parallel ROOT :after was
+           handled, so a per-state :after read nil"))))
+
+(deftest ensure-set-for-includes-per-region-after
+  (testing "white-box: for a parallel machine, the synthetic region-qualified
+            :after timer ([... [<region> <state>]]) resolves within the region
+            scope (region head stripped) and adds the region-state :after
+            candidate's requires (rf2-iyrc9t — the region path)"
+    (rf/reg-cofx :test/region-token {:recordable? true} (fn [] :RT))
+    (let [m (cofx-attach/index-ensure-sets
+              {:type    :parallel
+               :data    {}
+               :guards  {:needs-region-token
+                         {:rf.cofx/requires [:test/region-token]
+                          :fn (fn [{cofx :rf.cofx}] (some? (:test/region-token cofx)))}}
+               :regions {:a {:initial :waiting
+                             :states  {:waiting {:after {3000 {:guard  :needs-region-token
+                                                               :target :done}}}
+                                       :done    {}}}
+                         :b {:initial :one :states {:one {} :two {}}}}})
+          ;; region-a timer: decl-path is region-qualified [:a :waiting].
+          es (cofx-attach/ensure-set-for
+               m {:state {:a :waiting :b :one} :data {}}
+               [:rf.machine.timer/after-elapsed 3000 1 [:a :waiting]])]
+      (is (contains? (set (map :id es)) :test/region-token)
+          "the region-qualified :after timer's guard requires is ensured — the
+           decl-path region head was stripped to resolve within region-a"))))

--- a/implementation/machines/test/re_frame/machines_reply_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/machines_reply_cljs_test.cljc
@@ -251,6 +251,23 @@
         (is (= reason (:cancel/reason r)))
         (is (reply/valid-reply? r) (str reason " ⇒ " (reply/validate-reply r)))))))
 
+(deftest on-restore-cancel-reason-in-closed-vocab
+  (testing "rf2-e3ryis — :on-restore (epoch-restore host-timer cleanup) is a
+            member of the closed timer-cancel-reasons vocab and produces a valid
+            cancelled-timer reply. `timer/cancel-frame-timers-on-restore!` emits
+            :reason :on-restore, so the closed set MUST sanction it — otherwise a
+            downstream reply/trace-schema validator or a consumer branching on
+            the vocab (exhaustive case / filter-pill enum) rejects or
+            misclassifies the epoch-restore cancellation."
+    (is (contains? m-reply/timer-cancel-reasons :on-restore)
+        ":on-restore is a member of the closed cancel-reason vocabulary")
+    (let [r (m-reply/cancelled-timer-reply
+              {:actor-id :a/m :state :waiting :delay 5000
+               :decl-path [:waiting] :epoch 2 :frame :rf/default
+               :reason :on-restore})]
+      (is (= :on-restore (:cancel/reason r)))
+      (is (reply/valid-reply? r) (str "on-restore ⇒ " (reply/validate-reply r))))))
+
 (deftest cancelled-actor-reply-is-canonical
   (testing "rf2-sfunt8 — a cancelled (destroyed) spawned actor is :status :cancelled"
     (let [r (m-reply/cancelled-actor-reply


### PR DESCRIPTION
Three correctness fixes on the machines cofx / timer-reply surface (from the 2026-07-09 correctness-review). Pre-alpha stance: no back-compat shims; ELEGANCE + CLARITY + CORRECTNESS — the fixes mirror mechanisms the codebase already has (the `:always` closure, `parallel-root-diet`'s root-`:after` clause, the closed reply vocab) rather than inventing new machinery.

## Fixes

**rf2-4y4bzq (P2) — cofx ensure-set misses `:choice` states.** A `:type :choice` transient node carries its candidate vector under `:choice`, which lowers to `:always` only at `choice/desugar-choices` (transition/birth time). The index + ensure-set run on the RAW pre-desugar machine, so `always-entries` read `(:always <choice-node>)` = nil and a choice candidate guard/action's `:rf.cofx/requires` never joined the ensure-set → the guard read the recordable cofx as nil and strict replay diverged (selecting a different candidate). `check-inline-restriction!` also never swept `:choice`. Fix: `always-entries` treats a choice node's `:choice` vector as its `:always` candidates (mirroring the desugar; validation guarantees a choice node never also declares `:always`); the inline-fn sweep now covers `:choice` with an accurate label.

**rf2-iyrc9t (P2) — cofx ensure-set misses state-level / per-region `:after`.** The synthetic timer event `[:rf.machine.timer/after-elapsed delay epoch decl-path]` routes to the scheduling node's `:after`-TABLE transition — a slot separate from `:on` that `ensure-set-in-scope`'s `:on` walk missed. The parallel ROOT `:after` was already handled (`parallel-root-diet` clause b); the per-state/region `:after` was the asymmetric gap. Fix: new `after-diet-for-event` resolves the scheduling node at the carried decl-path (region-stripped for a parallel region, declines a sibling region's timer), and adds the `:after` candidate's guard/action diet + the `:always` closure from its target. `ensure-set-in-scope` gains a `region` param so it can strip/decline the region-qualified decl-path.

**rf2-e3ryis (P3) — `:on-restore` outside the closed timer-cancel-reasons vocab.** `timer/cancel-frame-timers-on-restore!` emits `:reason :on-restore`, which becomes `:cancel/reason :on-restore` on the reply/trace — but `reply/timer-cancel-reasons` and the `emit-cancelled!` / `cancel-after-timer-entry!` docstrings enumerated the closed set WITHOUT it. Fix: add `:on-restore` to the set + the two docstrings. spec/005's `:rf.machine.timer/cancelled` trace catalogue already lists `:on-restore`, so this aligns the implementation to the spec — no contract change.

## Adversarial tests (≥1 per fix)

- `choice-candidate-guard-reads-ensured-generated-fact` (end-to-end: choice guard reads the ensured GENERATED fact, routes correctly), `ensure-set-for-includes-choice-candidate-requires` (white-box), `inline-requires-on-choice-candidate-rejected` (registration error).
- `ensure-set-for-includes-state-after` + `ensure-set-for-includes-per-region-after` (white-box: the `:after` guard's requires is in the ensure-set; region-stripping works).
- `on-restore-cancel-reason-in-closed-vocab` (the `:on-restore` reason is a member of the closed vocab and produces a valid reply).

## Quality gates

- `cd implementation/machines && clojure -M:test` — **901 tests / 2876 assertions, 0 failures, 0 errors**.
- `cd implementation && npm run test:cljs` — **8306 tests / 38192 assertions, 0 failures, 0 errors**.
- spec/005 untouched → doc-slug validator not required. Full spine deferred to CI.

## Notes / follow-up

- Commits: the two cofx-ensure-set beads (rf2-4y4bzq, rf2-iyrc9t) share `cofx_attach.cljc` + its test with interleaved edits, so they are one commit (both bead IDs referenced); rf2-e3ryis is a separate commit.
- Cross-check: **spec/009**'s `:rf.machine.timer/cancelled` trace-catalogue reason enumeration is missing `:on-restore` (spec/005 has it). Out of this PR's surface (spec/009 is hot-zone); worth a follow-up bead to align spec/009. The xray tooling (`machine_after_rings_helpers.cljc`) passes `:reason` through unmapped, so it does not reject `:on-restore` today (its prose docstring listing the closed set is stale but harmless).
