### PR TITLE
fix(pair-mcp): mark :ok? false tool paths as isError (rf2-01jwrq +3)

### DIFF
--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -3525,10 +3525,17 @@ see what each frame actually resolves. (EP-0026 retired image-declared host
 capabilities, so there is no longer a missing-**capability** discriminator on
 this read.)
 
-**Error envelopes**:
+**Error envelopes** (all `isError: true`, per the §"Every `:ok? false`
+response is `isError: true`" rule — rf2-01jwrq):
 
 - `{:ok? false :reason :ambiguous-frame …}` — multi-frame session, no `frame` and no session pin.
 - `{:ok? false :reason :describe-image-failed :message "..."}` — runtime threw (including `:rf.error/frame-no-generation` when an explicit `frame` names no live frame carrying a generation).
+- `{:ok? false :reason :unexpected-shape :value …}` — the runtime eval came back blank/non-map (a degraded read — dropped WebSocket / navigated tab).
+
+Because `describe-image` is `:cacheable?` and the response cache bypasses
+`isError` results, keeping the `:ambiguous-frame` refusal `isError: true`
+also keeps it OUT of the cache — a transient ambiguous-frame can never be
+cached and mask a later valid read.
 
 **Drill-down**: `describe-image` is the per-frame overview; drill a specific
 `(kind, id)` with `handler-meta {:frame … :kind … :id …}` for the full

--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -3108,8 +3108,16 @@ unmounted, no other subscribers) no longer shows up here.
 ```
 
 `:subs` is an empty vector when nothing is subscribed in the frame —
-never `:ok? false` for the empty case. The query-vectors are sorted
-(by `pr-str`) so the listing is stable across calls.
+never `:ok? false` for the empty case. Genuine emptiness is the runtime's
+OWN `{:ok? true … :subs []}` MAP (a real answer). The query-vectors are
+sorted (by `pr-str`) so the listing is stable across calls.
+
+A **blank / non-map** eval is NOT emptiness (rf2-21vvfs): it means the
+runtime did not answer (the browser tab closed / navigated in the narrow
+race between the liveness re-check and the sub-cache drain). That degraded
+read surfaces as `{:ok? false :reason :unexpected-shape :value …}` with
+`isError: true` — never a fabricated `{:ok? true :subs []}` masking a dead
+read as "no subscriptions".
 
 `list-subscriptions` opts INTO the per-session response cache (it reads
 the live reactive sub-cache, a pure function of frame state, just like
@@ -3122,8 +3130,10 @@ gate applies to verbatim values surfaced off-box).
 
 `:reason :runtime-not-preloaded` if the preload hasn't run;
 `:reason :ambiguous-frame` in a multi-frame session with no selected
-frame; `:reason :list-subscriptions-failed` (with `:message`) on any
-other failure.
+frame; `:reason :unexpected-shape` on a blank/non-map degraded eval (see
+above); `:reason :list-subscriptions-failed` (with `:message`) on any
+other failure. All ride `isError: true` per the universal `:ok? false`
+rule (rf2-21vvfs).
 
 [1]: #universal-size-elision-on-app-db-slots
 [2]: ../../../spec/Tool-Pair.md#how-ai-tools-attach
@@ -3187,7 +3197,13 @@ returns the sub only if it matches on both axes.
 ```
 
 `:subs` is an empty vector when no streams are open (or when the
-filters match nothing) — never `:ok? false` for the empty case. A
+filters match nothing) — never `:ok? false` for the empty case. Genuine
+emptiness is the runtime's OWN `{:ok? true :subs []}` MAP. A **blank /
+non-map** eval is NOT emptiness (rf2-21vvfs): on the very tool that
+diagnoses a dead / quiet stream, a degraded read (the browser tab closed
+mid-race) surfaces as `{:ok? false :reason :unexpected-shape :value …}`
+with `isError: true` — never a fabricated `{:ok? true :subs []}` reporting
+a false-clean "zero streams". A
 non-nil `:overflow-reason` is the load-bearing signal: the queue has
 been evicting older events under the byte or event budget configured
 on its `subscribe` call. Tune `max-buffered-events` /
@@ -3204,8 +3220,10 @@ that applies. `list-streams` does NOT carry sensitive event
 bodies; only registration metadata crosses the wire.
 
 `:reason :runtime-not-preloaded` if the preload hasn't run;
+`:reason :unexpected-shape` on a blank/non-map degraded eval (see above);
 `:reason :list-streams-failed` (with `:message`) on any other
-failure.
+failure. All ride `isError: true` per the universal `:ok? false` rule
+(rf2-21vvfs).
 
 ## get-stream-controls
 

--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -2578,7 +2578,9 @@ malformed `stop` is rejected up front rather than silently collapsing to
 the default wall-clock window — the same honest-error posture
 `subscribe`'s `:invalid-filter-edn` adopts. `:reason :ambiguous-frame`
 when an `:app-db` / `:sub` signal needs a frame but none resolves
-(multi-frame session, no selection).
+(multi-frame session, no selection) — this runtime refusal rides
+`isError: true` too (rf2-5m2oi1), per the universal `:ok? false` rule,
+not a success-shaped envelope.
 
 ## read-recording
 
@@ -2609,8 +2611,14 @@ read-and-close in one round-trip), `build` (string).
 
 Each entry is one **change** — the moment signal `:i` took a new value.
 Two signals that changed on the same paint share a `:frame`.
-`:reason :missing-recording-id` if omitted/blank; `:reason
-:no-such-recording` for an unknown id.
+
+**Error envelopes** (all `isError: true`, per the §"Every `:ok? false`
+response is `isError: true`" rule — rf2-5m2oi1): `:reason
+:missing-recording-id` if omitted/blank (client-side short-circuit,
+before the socket); `:reason :no-such-recording` for an unknown/expired
+recording-id (the runtime refusal — so the host can route recovery
+through the error channel). A legitimate empty read is `{:ok? true …}`
+(a real map), so a normal empty drain is never mislabelled an error.
 
 ## watch-until
 

--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -3010,6 +3010,11 @@ connection, e.g. shadow-cljs restarted onto a new port mid-session).
   nonsense filter that would silently match nothing.
 - `:reason :runtime-not-preloaded` if the preload hasn't run.
 - `:reason :subscribe-failed` on any other failure during subscribe.
+- A runtime `subscribe!` that returns `{:ok? false …}` AFTER the stream
+  slot is reserved (e.g. `:unknown-topic`, or a future resource-cap /
+  frame-resolution refusal) releases the reserved slot and rides back with
+  `isError: true` — the failure is never shipped as a success-shaped
+  envelope (rf2-yeuqhr), per the universal `:ok? false` rule.
 - `:reason :rf.error/concurrent-stream-limit` if the session already
   has `max-concurrent-streams` open subscriptions. Surfaced as
   `isError: true` WITHOUT touching the nREPL socket. The error

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/describe_image.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/describe_image.cljs
@@ -57,7 +57,13 @@
         form        (ef/emit (ef/rt-call 'describe-image opts))]
     (probe/eval-after-runtime!
       conn build-id form :describe-image-failed
-      (fn [v]
-        (if (map? v)
-          (wire/ok-text v)
-          (wire/err-text {:ok? false :reason :unexpected-shape :value v}))))))
+      ;; The runtime `describe-image` returns a self-describing `{:ok? …}`
+      ;; envelope: `{:ok? true …}` on a read, `{:ok? false :reason
+      ;; :ambiguous-frame}` when a multi-frame session resolves no frame.
+      ;; `map-envelope-result` routes the `:ok? false` refusal — and a
+      ;; blank/non-map degraded eval — through `wire/err-text` (isError:true)
+      ;; per the universal `:ok? false` contract, rather than shipping the
+      ;; refusal as a success. describe-image is `:cacheable?` (registry),
+      ;; and the cache bypasses isError results, so this also keeps an
+      ;; ambiguous-frame error out of the response cache.
+      probe/map-envelope-result)))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/list_streams.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/list_streams.cljs
@@ -66,4 +66,13 @@
                                 (str "(assoc r :subs " (filter-form topic sub-id) ")"))))]
     (probe/eval-after-runtime!
       conn build-id form :list-streams-failed
-      (fn [v] (wire/ok-text (if (map? v) v {:ok? true :subs []}))))))
+      ;; A non-map/blank eval means the runtime did NOT answer (the browser
+      ;; tab closed/navigated in the race between the liveness re-check and
+      ;; this drain eval). Surface that as `:unexpected-shape` err-text
+      ;; (isError:true) rather than FABRICATING `{:ok? true :subs []}` — a
+      ;; fake "no streams" answer is the worst possible lie on the very tool
+      ;; that diagnoses a dead stream. A genuinely-empty list is the
+      ;; runtime's own `{:ok? true :subs []}` MAP, so real emptiness is
+      ;; unaffected. `map-envelope-result` also routes any `:ok? false`
+      ;; runtime refusal through err-text.
+      probe/map-envelope-result)))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/list_subscriptions.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/list_subscriptions.cljs
@@ -141,4 +141,13 @@
                    base-call)]
     (probe/eval-after-runtime!
       conn build-id form :list-subscriptions-failed
-      (fn [v] (wire/ok-text (if (map? v) v {:ok? true :subs []}))))))
+      ;; A non-map/blank eval means the runtime did NOT answer (the browser
+      ;; tab closed/navigated in the race between the liveness re-check and
+      ;; this drain eval). Surface that as `:unexpected-shape` err-text
+      ;; (isError:true) rather than FABRICATING `{:ok? true :subs []}` — a
+      ;; fake "no subscriptions" answer masks a degraded read. A genuinely-
+      ;; empty cache is the runtime's own `{:ok? true :subs []}` MAP, so
+      ;; real emptiness is unaffected. `map-envelope-result` also routes the
+      ;; runtime's `{:ok? false :reason :ambiguous-frame}` refusal through
+      ;; err-text.
+      probe/map-envelope-result)))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/probe.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/probe.cljs
@@ -907,3 +907,42 @@
                  :build  build-id
                  :hint   blank-hint}
                 error-extras))))))
+
+(defn map-envelope-result
+  "The universal `on-value` projection for a tool whose runtime fn returns
+  a SELF-DESCRIBING `{:ok? bool …}` envelope with NO per-tool `:build`
+  stamp / blank-hint decoration — the lighter sibling of
+  `map-result-or-blank`.
+
+  A ready 1-arity callback (pass it DIRECTLY as `eval-after-runtime!`'s
+  `on-value`, unlike `map-result-or-blank`, which is a BUILDER closing
+  over the per-tool `:build` / blank reason+hint). Routes the universal
+  `:ok? false` ↔ `isError:true` contract three ways:
+
+    - a `:ok? false` MAP ⇒ `(wire/err-text envelope)` — the runtime's own
+      structured refusal (e.g. `:ambiguous-frame`, `:no-such-recording`)
+      forwarded verbatim with `isError:true`, per spec/003-Tool-Catalogue
+      §\"Every `:ok? false` response is `isError: true`\".
+    - a NON-MAP / blank ⇒ `(wire/err-text {:ok? false :reason
+      :unexpected-shape :value v})` — a blank `cljs-eval` result (dropped
+      WebSocket / navigated tab between the liveness re-check and the
+      drain eval) is an honest degraded read, NOT a fabricated
+      empty-success. This is the sibling convention read-dom / read-ui
+      already surface via `map-result-or-blank`.
+    - any other MAP ⇒ `(wire/ok-text v)` — the legitimate answer
+      (including a genuinely-empty `{:ok? true :subs []}`, which is a
+      real MAP so real emptiness is never mislabelled).
+
+  Keeping every failure `isError` is also what keeps it out of the
+  response cache (cache eligibility bypasses `isError` results), so a
+  transient failure on a `:cacheable?` tool (describe-image) can never be
+  cached and mask a later successful read.
+
+  Used by describe-image / record / read-recording / list-streams /
+  list-subscriptions — tools whose runtime fn already speaks the
+  `{:ok? …}` envelope and needs no per-call decoration."
+  [v]
+  (cond
+    (not (map? v))    (wire/err-text {:ok? false :reason :unexpected-shape :value v})
+    (false? (:ok? v)) (wire/err-text v)
+    :else             (wire/ok-text v)))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/record.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/record.cljs
@@ -322,7 +322,13 @@
         ;; so this uses the `-signalled!` sibling.
         (probe/eval-after-runtime-signalled!
           conn build-id form :record-failed
-          (fn [envelope] (wire/ok-text envelope)))))))
+          ;; `start-recording!` returns `{:ok? false :reason
+          ;; :ambiguous-frame}` when an `:app-db`/`:sub` signal needs a
+          ;; frame and none resolves in a multi-frame session. Route the
+          ;; refusal (and a blank/non-map degraded eval) through
+          ;; `wire/err-text` (isError:true) per the universal `:ok? false`
+          ;; contract rather than shipping it as a success envelope.
+          probe/map-envelope-result)))))
 
 ;; ---------------------------------------------------------------------------
 ;; read-recording — read back the change-log.
@@ -351,4 +357,10 @@
                                {:drain drain? :stop stop?}))]
         (probe/eval-after-runtime!
           conn build-id form :read-recording-failed
-          (fn [envelope] (wire/ok-text envelope)))))))
+          ;; `read-recording` returns `{:ok? false :reason
+          ;; :no-such-recording …}` for an unknown/expired recording-id.
+          ;; Route that refusal (and a blank/non-map degraded eval) through
+          ;; `wire/err-text` (isError:true) per the universal `:ok? false`
+          ;; contract. A legitimate empty drain is `{:ok? true …}` (a real
+          ;; map), so a normal empty read is never mislabelled an error.
+          probe/map-envelope-result)))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/subscribe.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/subscribe.cljs
@@ -689,13 +689,22 @@
                       (js/setTimeout poll (* 2 poll-ms))))))))]
     {:state state :terminate terminate :poll poll}))
 
-(defn- run-acquired
+(defn run-acquired
   "Drive the subscription lifecycle once the resource-controls
   stream slot is reserved. Returns a Promise resolving to
   the MCP tool result; on any pre-controller exit path the slot is
   released here — the stream-controller's `terminate` only fires
   AFTER `make-stream-controller` wires up, so failures before that
-  point need explicit release."
+  point need explicit release.
+
+  Public (not `defn-`) so `subscribe_resource_controls_test` can drive
+  the `:ok? false` failure branch directly — that branch is defensive /
+  client-side-unreachable through `subscribe-tool` (the topic is guarded
+  before the slot is acquired), so a direct call is the only way to
+  exercise it. A `#'` var-quote on this async, Promise-returning fn does
+  NOT invoke identically to a direct call under shadow-cljs `:node-test`
+  (it desynchronises the test's nREPL `set!` seam and strands a real
+  socket op), so the fn is public rather than reached via `#'`."
   [{:keys [conn raw-args topic build-id filter-map max-buf-events
            max-buf-bytes poll-ms max-ms max-events
            incl? elision? dedup? cap signal send-note progress-tk]}]

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/subscribe.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/subscribe.cljs
@@ -715,8 +715,16 @@
         (.then
           (fn [subscribe-resp]
             (if-not (:ok? subscribe-resp)
+              ;; The runtime `subscribe!` refused (`:ok? false`, e.g.
+              ;; `:unknown-topic`, or a future resource-cap / frame-
+              ;; resolution reason). This IS a failure — we release the
+              ;; reserved stream slot — so it MUST ride `wire/err-text`
+              ;; (isError:true) per the universal `:ok? false` contract,
+              ;; not `ok-text`. Shipping it as a success would decouple the
+              ;; isError flag from the `:ok? false` payload the code just
+              ;; branched on as a fault.
               (do (resource/release-stream!)
-                  (wire/ok-text subscribe-resp))
+                  (wire/err-text subscribe-resp))
               (let [sub-id (:sub-id subscribe-resp)]
                 (js/Promise.
                   (fn [resolve _reject]

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
@@ -1236,25 +1236,49 @@
 
    ;; ---------- list-subscriptions (reactive sub-cache) -------------------
    {:fixture/id    :list-subscriptions/empty
-    :fixture/doc   "list-subscriptions on a frame with no live reactive subs returns an empty list envelope. The runtime sentinel is present (only the sub-cache query is empty) — a missing sentinel would be a preflight failure (isError), not an empty success."
+    :fixture/doc   "list-subscriptions on a frame with no live reactive subs returns an empty list envelope. GENUINE emptiness is the runtime's OWN `{:ok? true :subs []}` MAP (a real answer), not a blank eval — so it rides isError:false. (rf2-21vvfs: a blank/non-map eval is a DEGRADED read, not emptiness — see the /degraded-blank sibling.)"
+    :fixture/tool  "list-subscriptions"
+    :fixture/args  {}
+    :fixture/eval-script
+    [["__re_frame2_pair_runtime"  true]
+     [:default                    {:ok? true :frame :rf/default :count 0 :subs []}]]
+    :fixture/expect
+    {:isError? false
+     :edn-submap {:ok? true :subs []}}}
+
+   {:fixture/id    :list-subscriptions/degraded-blank
+    :fixture/doc   "rf2-21vvfs: a BLANK/non-map eval (the runtime sentinel is present, but the browser tab closed/navigated in the race between the liveness re-check and the sub-cache drain) is a DEGRADED read — NOT an empty listing. It surfaces as :unexpected-shape (isError:true), never a fabricated `{:ok? true :subs []}` masking a dead read."
     :fixture/tool  "list-subscriptions"
     :fixture/args  {}
     :fixture/eval-script
     [["__re_frame2_pair_runtime"  true]
      [:default                    nil]]
     :fixture/expect
-    {:isError? false}}
+    {:isError? true
+     :reason  :unexpected-shape}}
 
    ;; ---------- list-streams (streaming-tap diagnostic) -------------------
    {:fixture/id    :list-streams/empty
-    :fixture/doc   "list-streams with no active streaming-tap subscriptions returns an empty list envelope. The runtime sentinel is present (only the subscription-info query is empty) — a missing sentinel would be a preflight failure (isError), not an empty success."
+    :fixture/doc   "list-streams with no active streaming-tap subscriptions returns an empty list envelope. GENUINE emptiness is the runtime's OWN `{:ok? true :subs []}` MAP, not a blank eval — so it rides isError:false. (rf2-21vvfs: a blank/non-map eval is a DEGRADED read — see the /degraded-blank sibling.)"
+    :fixture/tool  "list-streams"
+    :fixture/args  {}
+    :fixture/eval-script
+    [["__re_frame2_pair_runtime"  true]
+     [:default                    {:ok? true :subs []}]]
+    :fixture/expect
+    {:isError? false
+     :edn-submap {:ok? true :subs []}}}
+
+   {:fixture/id    :list-streams/degraded-blank
+    :fixture/doc   "rf2-21vvfs: a BLANK/non-map eval on the very tool that diagnoses a dead/quiet stream is a DEGRADED read, not 'zero streams'. It surfaces as :unexpected-shape (isError:true), never a fabricated `{:ok? true :subs []}` reporting a false-clean state."
     :fixture/tool  "list-streams"
     :fixture/args  {}
     :fixture/eval-script
     [["__re_frame2_pair_runtime"  true]
      [:default                    nil]]
     :fixture/expect
-    {:isError? false}}
+    {:isError? true
+     :reason  :unexpected-shape}}
 
    ;; ---------- operating-frame trio --------------------------------------
    ;; The three Tool-Pair §Tool-surface-obligations ops. The runtime

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/describe_image_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/describe_image_test.cljs
@@ -27,6 +27,7 @@
             [applied-science.js-interop :as j]
             [re-frame2-pair-mcp.test-utils :as tu]
             [re-frame2-pair-mcp.nrepl :as nrepl]
+            [re-frame2-pair-mcp.cache :as cache]
             [re-frame2-pair-mcp.tools :as tools]
             [re-frame2-pair-mcp.tools.describe-image :as di]))
 
@@ -187,14 +188,66 @@
 (deftest ambiguous-frame-rides-through-as-error
   (async done
     ;; The runtime returns the :ambiguous-frame refusal (a map with :ok?
-    ;; false); the tool surfaces it. wire/ok-text wraps maps; an :ok? false
-    ;; map still rides as the structured envelope.
+    ;; false); the tool MUST surface it as an :isError result (rf2-01jwrq).
+    ;; Before the fix the `:ok? false` map took the (map? v) → ok-text
+    ;; branch and shipped WITHOUT isError — a SUCCESS-shaped tools/call
+    ;; carrying a `:ok? false` payload. Now `map-envelope-result` routes it
+    ;; through wire/err-text per the universal `:ok? false` contract.
     (stub-eval! nil {:ok? false :reason :ambiguous-frame :operation :describe-image})
     (-> (di/describe-image-tool (fresh-conn) (args-js {}))
         (.then (fn [r]
+                 (is (err? r)
+                     "an :ok? false ambiguous-frame refusal rides isError:true")
                  (let [edn (read-result-text r)]
                    (is (false? (:ok? edn)))
                    (is (= :ambiguous-frame (:reason edn))))
+                 (done))))))
+
+(deftest ambiguous-frame-iserror-matches-ok?
+  ;; Adversarial cross-check (rf2-01jwrq, mirrors the port_to_build_test
+  ;; rf2-bcayt7 pattern): the isError:true flag (text slot) and the
+  ;; payload's :ok? false (structured slot) MUST agree. A regression back
+  ;; to ok-text would ship :ok? false WITHOUT isError, decoupling the two
+  ;; slots. A DISTINCT :ok? false reason (not the :ambiguous-frame the
+  ;; primary test uses) proves the behaviour is the universal rule, not
+  ;; one-reason-specific.
+  (async done
+    (stub-eval! nil {:ok? false :reason :some-other-runtime-refusal
+                     :operation :describe-image})
+    (-> (di/describe-image-tool (fresh-conn) (args-js {:frame ":main"}))
+        (.then (fn [r]
+                 (let [edn (read-result-text r)]
+                   ;; isError:true ⟺ :ok? false
+                   (is (true? (err? r)))
+                   (is (false? (:ok? edn)))
+                   (is (= :some-other-runtime-refusal (:reason edn))))
+                 (done))))))
+
+(deftest ambiguous-frame-error-is-not-cache-eligible
+  ;; SECONDARY concern (rf2-01jwrq): describe-image is `:cacheable? true`
+  ;; (registry), and apply-cache bypasses ONLY isError results. Now that a
+  ;; `:ok? false` ambiguous-frame refusal rides as err-text (isError:true),
+  ;; apply-cache passes it through untouched and NEVER stores it — so a
+  ;; transient ambiguous-frame can't be cached and mask a later valid read.
+  ;; A regression to ok-text (isError:false) would make the error
+  ;; cache-eligible, defeating "errors are never cached".
+  (async done
+    (cache/clear!)
+    (stub-eval! nil {:ok? false :reason :ambiguous-frame :operation :describe-image})
+    (-> (di/describe-image-tool (fresh-conn) (args-js {}))
+        (.then (fn [r]
+                 (is (err? r) "precondition: the refusal is isError")
+                 (let [opts {:tool "describe-image" :args (args-js {})
+                             :enabled? true :build :app}
+                       out1 (cache/apply-cache r opts)
+                       out2 (cache/apply-cache r opts)]
+                   (is (identical? r out1)
+                       "isError describe-image result passes through apply-cache untouched")
+                   (is (zero? (cache/size))
+                       "the error left no cache entry")
+                   (is (not (contains? (read-result-text out2) :rf.mcp/cache-hit))
+                       "a repeated identical error never manufactures a :rf.mcp/cache-hit"))
+                 (cache/clear!)
                  (done))))))
 
 (deftest non-map-return-degrades-to-error

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/list_subscriptions_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/list_subscriptions_test.cljs
@@ -27,15 +27,24 @@
 
   The live end-to-end coverage runs against a real shadow-cljs runtime
   (`test/stdio-roundtrip.js`, the cross-server conformance harness)."
-  (:require [cljs.test :refer-macros [deftest is testing]]
+  (:require [cljs.test :refer-macros [deftest is testing async]]
             [cljs.reader]
             [applied-science.js-interop :as j]
+            [re-frame2-pair-mcp.test-utils :as tu]
+            [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.tools :as tools]
             [re-frame2-pair-mcp.tools.eval-form :as ef]
-            [re-frame2-pair-mcp.tools.args :as args]))
+            [re-frame2-pair-mcp.tools.args :as args]
+            [re-frame2-pair-mcp.tools.list-streams :as ls]
+            [re-frame2-pair-mcp.tools.list-subscriptions :as lsub]))
 
 (defn- descriptor-named [nm]
   (some #(when (= nm (:name %)) %) tools/tool-descriptors))
+
+(defn- fresh-conn []
+  (let [conn (nrepl/make-conn 0 "127.0.0.1")]
+    (swap! conn assoc :probed-builds #{:app})
+    conn))
 
 ;; ---------------------------------------------------------------------------
 ;; list-subscriptions — reactive sub-cache descriptor
@@ -183,3 +192,72 @@
   (testing "list-subscriptions reuses ->frame-keyword, so both arg shapes resolve"
     (is (= :rf/default (args/->frame-keyword "rf/default")))
     (is (= :rf/default (args/->frame-keyword ":rf/default")))))
+
+;; ---------------------------------------------------------------------------
+;; Degraded-eval contract (rf2-21vvfs) — a blank/non-map eval must NOT be
+;; fabricated into a fake `{:ok? true :subs []}` "everything fine, zero
+;; streams" answer on the very tools that diagnose a dead/quiet stream. A
+;; non-map surfaces as `:unexpected-shape` err-text (isError:true); a
+;; genuinely-empty read (the runtime's own `{:ok? true :subs []}` map) is
+;; unaffected.
+;; ---------------------------------------------------------------------------
+
+(deftest list-streams-blank-eval-is-iserror-not-fabricated-empty
+  ;; The narrow race: the browser tab closes/navigates between the
+  ;; liveness re-check and the drain eval, so `cljs-eval-value` reads a
+  ;; blank shadow result as nil. The tool MUST surface that degraded read
+  ;; as an error, not manufacture "zero streams".
+  (async done
+    (-> (tu/with-stubbed-eval! nil
+          (fn [] (ls/list-streams-tool (fresh-conn) #js {})))
+        (.then (fn [r]
+                 (is (true? (tu/error? r))
+                     "a blank/non-map eval rides isError:true, not a fabricated empty success")
+                 (let [edn (tu/extract-edn r)]
+                   (is (false? (:ok? edn)))
+                   (is (= :unexpected-shape (:reason edn))
+                       "the degraded read is :unexpected-shape, not a fake :subs []"))
+                 (done))))))
+
+(deftest list-subscriptions-blank-eval-is-iserror-not-fabricated-empty
+  (async done
+    (-> (tu/with-stubbed-eval! nil
+          (fn [] (lsub/list-subscriptions-tool (fresh-conn) #js {})))
+        (.then (fn [r]
+                 (is (true? (tu/error? r))
+                     "a blank/non-map eval rides isError:true, not a fabricated empty success")
+                 (let [edn (tu/extract-edn r)]
+                   (is (false? (:ok? edn)))
+                   (is (= :unexpected-shape (:reason edn))))
+                 (done))))))
+
+(deftest list-streams-genuine-empty-stays-ok
+  ;; Non-regression: a genuinely-empty listing is the runtime's own
+  ;; `{:ok? true :subs []}` MAP — a real success. `map-envelope-result`
+  ;; only diverts a non-map or an explicit `:ok? false`, so real emptiness
+  ;; must still ride as a non-error success.
+  (async done
+    (-> (tu/with-stubbed-eval! {:ok? true :subs []}
+          (fn [] (ls/list-streams-tool (fresh-conn) #js {})))
+        (.then (fn [r]
+                 (is (not (tu/error? r))
+                     "an empty-but-ok listing is a success, not an error")
+                 (let [edn (tu/extract-edn r)]
+                   (is (true? (:ok? edn)))
+                   (is (= [] (:subs edn))))
+                 (done))))))
+
+(deftest list-subscriptions-runtime-ok-false-is-iserror
+  ;; A runtime `{:ok? false :reason :ambiguous-frame}` refusal (multi-frame
+  ;; session, no selection) must ride isError too — not the old
+  ;; ok-text-wraps-any-map behaviour.
+  (async done
+    (-> (tu/with-stubbed-eval! {:ok? false :reason :ambiguous-frame}
+          (fn [] (lsub/list-subscriptions-tool (fresh-conn) #js {})))
+        (.then (fn [r]
+                 (is (true? (tu/error? r))
+                     "an :ambiguous-frame refusal rides isError:true")
+                 (let [edn (tu/extract-edn r)]
+                   (is (false? (:ok? edn)))
+                   (is (= :ambiguous-frame (:reason edn))))
+                 (done))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/record_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/record_test.cljs
@@ -192,6 +192,26 @@
                  (is (= :no-signals (:reason (tu/extract-edn r))))
                  (done))))))
 
+(deftest record-runtime-ok-false-is-iserror
+  ;; Adversarial (rf2-5m2oi1): a REACHABLE runtime `:ok? false` — the
+  ;; `start-recording!` `:ambiguous-frame` refusal when an `:app-db`/`:sub`
+  ;; signal needs a frame and none resolves in a multi-frame session — MUST
+  ;; ride back as :isError, not a green tools/call carrying a buried
+  ;; `:ok? false`. Before the fix the handler wrapped every envelope in
+  ;; wire/ok-text with no `:ok?` guard. isError:true ⟺ :ok? false.
+  (async done
+    (let [canned {:ok? false :reason :ambiguous-frame :operation :start-recording}]
+      (-> (tu/with-stubbed-eval! canned
+            (fn []
+              (record/record-tool (fresh-conn) #js {:signals "[{:app-db [:cart]}]"})))
+          (.then (fn [r]
+                   (is (true? (tu/error? r))
+                       "an :ambiguous-frame refusal from the runtime rides isError:true")
+                   (let [edn (tu/extract-edn r)]
+                     (is (false? (:ok? edn)))
+                     (is (= :ambiguous-frame (:reason edn))))
+                   (done)))))))
+
 (deftest record-tool-malformed-stop-errors-honestly
   ;; Regression: a malformed `stop` EDN makes `record-tool`
   ;; short-circuit to an honest `:ok? false` envelope
@@ -243,6 +263,48 @@
                  (is (tu/error? r))
                  (is (= :missing-recording-id (:reason (tu/extract-edn r))))
                  (done))))))
+
+(deftest read-recording-no-such-recording-is-iserror
+  ;; Adversarial (rf2-5m2oi1): reading a recording-id that aged out / was
+  ;; stopped returns the runtime `{:ok? false :reason :no-such-recording
+  ;; …}`. That MUST ride as :isError so the host can route recovery
+  ;; through the error channel — not a green result hiding a buried
+  ;; `:ok? false`. isError:true ⟺ :ok? false; a DISTINCT reason from the
+  ;; client-side :missing-recording-id short-circuit above.
+  (async done
+    (let [canned {:ok? false :reason :no-such-recording :recording-id "rec-gone"}]
+      (-> (tu/with-stubbed-eval! canned
+            (fn []
+              (record/read-recording-tool (fresh-conn) #js {:recording-id "rec-gone"})))
+          (.then (fn [r]
+                   (is (true? (tu/error? r))
+                       "an unknown/expired recording-id rides isError:true")
+                   (let [edn (tu/extract-edn r)]
+                     (is (false? (:ok? edn)))
+                     (is (= :no-such-recording (:reason edn)))
+                     (is (= "rec-gone" (:recording-id edn))))
+                   (done)))))))
+
+(deftest read-recording-legitimate-empty-drain-stays-ok
+  ;; Guard the non-regression: a legitimate empty drain is the runtime's
+  ;; `{:ok? true :count 0 :entries []}` MAP — a real success, NOT a fault.
+  ;; `map-envelope-result` only diverts an explicit `:ok? false`, so an
+  ;; empty-but-ok read must still ride as a non-error success.
+  (async done
+    (let [canned {:ok? true :recording-id "rec-x" :status :recording
+                  :count 0 :entries []}]
+      (-> (tu/with-stubbed-eval! canned
+            (fn []
+              (record/read-recording-tool (fresh-conn)
+                                          #js {:recording-id "rec-x" :drain true})))
+          (.then (fn [r]
+                   (is (not (tu/error? r))
+                       "an empty-but-ok drain is a success, not an error")
+                   (let [edn (tu/extract-edn r)]
+                     (is (true? (:ok? edn)))
+                     (is (= 0 (:count edn)))
+                     (is (= [] (:entries edn))))
+                   (done)))))))
 
 (deftest read-recording-drain-and-stop-ride-the-form
   ;; The :drain / :stop bool args must reach the runtime read-recording

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/subscribe_resource_controls_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/subscribe_resource_controls_test.cljs
@@ -90,6 +90,58 @@
     (is (re-find #"unsubscribe" (:hint reject)))))
 
 ;; ---------------------------------------------------------------------------
+;; `run-acquired` failure branch (rf2-yeuqhr). When the runtime
+;; `subscribe!` returns `{:ok? false …}` AFTER the stream slot is reserved,
+;; `run-acquired` releases the slot and MUST wrap the failure in
+;; `wire/err-text` (isError:true) — not `ok-text`. The handler already
+;; knows it failed (it releases the reserved resource); reporting success
+;; would decouple the isError flag from the `:ok? false` payload. The
+;; branch is currently defensive (subscribe-tool guards `:topic`
+;; client-side before acquiring), so we drive `run-acquired` directly with
+;; a stubbed `:ok? false` subscribe! response to exercise it.
+;; ---------------------------------------------------------------------------
+
+(defn- primed-conn []
+  (let [conn (nrepl/make-conn 0 "127.0.0.1")]
+    (swap! conn assoc :probed-builds #{:app})
+    conn))
+
+(deftest run-acquired-subscribe-ok-false-is-iserror-and-releases-slot
+  (async done
+    (let [orig  nrepl/cljs-eval-value
+          ;; Every eval (the signal-runtime! reconfigure AND the subscribe!
+          ;; call) resolves the runtime refusal; only the subscribe! result
+          ;; is inspected by the failure branch.
+          canned {:ok? false :reason :unknown-topic :topic :bogus}
+          stub  (fn ([_c _b _f]    (js/Promise.resolve canned))
+                  ([_c _b _f _o] (js/Promise.resolve canned)))]
+      (set! nrepl/cljs-eval-value stub)
+      ;; Reserve a slot the way subscribe-tool would before calling
+      ;; run-acquired, so we can prove the failure branch releases it.
+      (resource/reset-for-tests!)
+      (resource/acquire-stream!)
+      (is (= 1 (resource/active-stream-count)) "slot reserved before run-acquired")
+      (-> (sub/run-acquired
+            {:conn (primed-conn) :raw-args #js {} :topic :bogus :build-id :app
+             :filter-map nil :max-buf-events nil :max-buf-bytes nil
+             :poll-ms 100 :max-ms 0 :max-events 0
+             :incl? false :elision? true :dedup? false :cap nil
+             :signal nil :send-note nil :progress-tk nil})
+          (.then (fn [r]
+                   (is (true? (tu/error? r))
+                       "a runtime :ok? false subscribe! rides isError:true, not ok-text")
+                   (let [edn (tu/extract-edn r)]
+                     (is (false? (:ok? edn)))
+                     (is (= :unknown-topic (:reason edn))
+                         "the runtime's own refusal rides back verbatim"))
+                   (is (zero? (resource/active-stream-count))
+                       "the failure branch released the reserved stream slot — no leak")))
+          (.finally (fn []
+                      (tu/restore-eval! stub orig)
+                      (resource/reset-for-tests!)
+                      (done)))))))
+
+;; ---------------------------------------------------------------------------
 ;; Final-summary envelope — `:rate-dropped` surfaces only when non-zero.
 ;; ---------------------------------------------------------------------------
 ;;

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/subscribe_resource_controls_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/subscribe_resource_controls_test.cljs
@@ -121,7 +121,10 @@
       (resource/reset-for-tests!)
       (resource/acquire-stream!)
       (is (= 1 (resource/active-stream-count)) "slot reserved before run-acquired")
-      (-> (sub/run-acquired
+      ;; `run-acquired` is private (defn-); var-quote to reach it from the
+      ;; test, the codebase convention for exercising a private fn directly
+      ;; (mirrors #'record/start-recording-form in record_test).
+      (-> (#'sub/run-acquired
             {:conn (primed-conn) :raw-args #js {} :topic :bogus :build-id :app
              :filter-map nil :max-buf-events nil :max-buf-bytes nil
              :poll-ms 100 :max-ms 0 :max-events 0

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/subscribe_resource_controls_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/subscribe_resource_controls_test.cljs
@@ -121,10 +121,11 @@
       (resource/reset-for-tests!)
       (resource/acquire-stream!)
       (is (= 1 (resource/active-stream-count)) "slot reserved before run-acquired")
-      ;; `run-acquired` is private (defn-); var-quote to reach it from the
-      ;; test, the codebase convention for exercising a private fn directly
-      ;; (mirrors #'record/start-recording-form in record_test).
-      (-> (#'sub/run-acquired
+      ;; `run-acquired` is public specifically so this test can drive its
+      ;; `:ok? false` failure branch directly (see its docstring): a `#'`
+      ;; var-quote on this async fn desynchronises the nREPL `set!` seam
+      ;; under :node-test and strands a real socket op, so we call it bare.
+      (-> (sub/run-acquired
             {:conn (primed-conn) :raw-args #js {} :topic :bogus :build-id :app
              :filter-map nil :max-buf-events nil :max-buf-bytes nil
              :poll-ms 100 :max-ms 0 :max-events 0


### PR DESCRIPTION
Routes every `:ok? false` / degraded-eval path on five pair-mcp tools through `wire/err-text` (`isError: true`) instead of `wire/ok-text`, matching the rf2-bcayt7 / discover-app precedent and the universal spec/003 rule "**Every `:ok? false` response is `isError: true`**". Four beads, same isError-contract class.

## Per-bead fix

- **rf2-01jwrq (P2 · describe-image)** — the runtime `{:ok? false :reason :ambiguous-frame}` refusal took the `(map? v)` → ok-text branch, shipping a SUCCESS-shaped `tools/call` carrying a `:ok? false` payload. Since describe-image is `:cacheable?` and the cache bypasses only isError results, the mislabelled error was also cache-eligible. Fixed via the new `probe/map-envelope-result` helper; the isError flag now keeps the refusal out of the response cache too.
- **rf2-5m2oi1 (P2 · record + read-recording)** — both handlers wrapped every envelope in ok-text with no `:ok?` guard; `start-recording!`'s `:ambiguous-frame` and `read-recording`'s `:no-such-recording` rode back as green results. Both routed through `map-envelope-result`; a legitimate empty drain stays `:ok? true`.
- **rf2-yeuqhr (P3 · subscribe)** — `run-acquired`'s failure branch released the reserved stream slot (it *knows* it failed) yet wrapped the failure in ok-text. Switched to `err-text` (keeps the `release-stream!`).
- **rf2-21vvfs (P3 · list-streams / list-subscriptions)** — a non-map/blank eval FABRICATED `{:ok? true :subs []}` — a fake "zero streams" on the very tools that diagnose a dead stream. Now surfaces `:unexpected-shape` isError; genuine emptiness is the runtime's own `{:ok? true :subs []}` map, unaffected.

New shared helper `probe/map-envelope-result` — the lighter sibling of `map-result-or-blank` for tools whose runtime fn returns a self-describing `{:ok? …}` envelope needing no per-call `:build`/hint decoration.

## Tests

- Adversarial isError↔`:ok? false` cross-check per fix (mirrors the `port_to_build_test` rf2-bcayt7 pattern), each using a distinct reason to prove the universal rule.
- describe-image: asserts the `:ok? false` result passes through `apply-cache` untouched and is never cached.
- subscribe: drives `run-acquired` directly with a stubbed `:ok? false` subscribe! response; asserts isError AND that the reserved stream slot is released (no leak).
- record/read-recording + list-*: non-regression guards that genuine emptiness (`:ok? true` map) still rides as a success.
- Conformance corpus: the `:list-streams/empty` + `:list-subscriptions/empty` fixtures modelled emptiness as a *blank* eval — which was the fabrication bug itself; re-pointed at the runtime's real `{:ok? true :subs []}` map, and added `/degraded-blank` fixtures asserting a blank eval now rides `:unexpected-shape` isError.
- spec/003-Tool-Catalogue failure contracts for all five tools documented as isError.

## Quality gates

- `cd tools/re-frame2-pair-mcp && npm test` (`shadow-cljs compile server-test && node out/server-test.js`) — **PASS**: 1182 tests / 3949 assertions, 0 failures, 0 errors, 0 warnings. Includes the in-package conformance corpus (80 fixtures, covers all five tools).
- The cross-server `tools/mcp-conformance` protocol sweep and the full PR spine are deferred to CI.

## Stance

Pre-alpha, no back-compat shims; ELEGANCE + CLARITY + CORRECTNESS. The fix collapses four near-identical `:ok? false` handlers onto one well-precedented helper rather than four inline conds.

Closes rf2-01jwrq, rf2-5m2oi1, rf2-yeuqhr, rf2-21vvfs.