### PR TITLE
fix(story): snapshot identity captures variant :component + render inputs; watch-mode seeds hashes (rf2-bah5o2 +3)

### DIFF
--- a/tools/story/spec/002-Runtime.md
+++ b/tools/story/spec/002-Runtime.md
@@ -686,7 +686,16 @@ the hash includes:
   classification every other tag consumer reads: an `:extends`-parent tag
   edit perturbs the hash, a `:!x` marker that cancels an inherited tag
   does not, and raw `:!x` authoring syntax never reaches the hash.
-- Parent story `:component` id
+- The variant's `:component` view-id **override** — the renderer resolves
+  variant-first (`(or (:component variant) (:component story))`), so a
+  variant's own `:component` decides which view renders; two variants
+  differing only in it must get distinct hashes (rf2-bah5o2)
+- The variant's `:sub-overrides` / `:db-seed` / `:network` render inputs
+  — pinned subscription outputs the renderer surfaces, the pre-script
+  app-db seed, and the stubbed HTTP replies a fetch-on-mount view settles
+  to (rf2-9zj0nc)
+- Parent story `:component` id (the story-level default, via
+  `re-frame.story.identity/story-body-slice`)
 - Parent story decorators
 - Registered schema digest of `:component` (per
   [spec/011 §`:rf/schema-digest`](../../../spec/011-SSR.md))

--- a/tools/story/src/re_frame/story/identity.cljc
+++ b/tools/story/src/re_frame/story/identity.cljc
@@ -67,6 +67,11 @@
     NOT, and raw `:!x` authoring syntax never reaches the hash.
   - Variant `:viewport` / `:background` visual chrome
   - Variant `:args->events`, `:platforms`, `:substrates` targeting
+  - The variant's `:component` view-id override (rf2-bah5o2) — variant-
+    first resolution decides WHICH view renders
+  - The variant's `:sub-overrides` / `:db-seed` / `:network` render
+    inputs (rf2-9zj0nc) — pinned sub outputs, pre-script app-db seed,
+    stubbed HTTP replies
   - Parent story `:component` id
   - Parent story `:decorators`
   - The *registered* schema digest of the view (per spec/011
@@ -132,6 +137,20 @@
     screenshot, so a baseline must invalidate when they change.
   - `:args->events` / `:platforms` / `:substrates` — derivation +
     targeting that change what is rendered.
+  - `:component` — the per-variant view-id OVERRIDE (rf2-bah5o2). The
+    renderer resolves variant-first `(or (:component variant) (:component
+    story))`, so the variant's `:component` decides WHICH view renders;
+    two variants differing only in it — or a watch-session edit swapping
+    it — MUST get distinct hashes. (The parent story's `:component`
+    reaches the hash via `story-body-slice`; THIS is the variant-level
+    override slot, which the story slice cannot see.)
+  - `:sub-overrides` / `:db-seed` / `:network` — render inputs that change
+    the settled rendered state (rf2-9zj0nc): pinned subscription outputs
+    the renderer surfaces, the pre-script app-db seed, and stubbed HTTP
+    replies a fetch-on-mount view settles to. Plain authored data — the
+    canonicaliser handles them (hashing the raw authored map incl. any
+    `[:arg]` placeholders is sufficient for identity). All three already
+    land in the plan-hash; the snapshot path was the straggler.
 
   Excluded (documented, not an oversight):
   - `:args` — captured via `:effective-args` in `snapshot-tuple` (post-
@@ -162,7 +181,23 @@
                    [:events :play-script :plays
                     :loaders :loaders-complete-when :loaders-teardown
                     :decorators :args->events :platforms :substrates
-                    :viewport :background]))))
+                    :viewport :background
+                    ;; rf2-bah5o2 — the per-variant `:component` view-id
+                    ;; OVERRIDE (schemas §`:component`). The renderer resolves
+                    ;; variant-first `(or (:component variant) (:component
+                    ;; story))`, so a variant's own `:component` decides WHICH
+                    ;; view renders; without it two variants differing only in
+                    ;; `:component` collide and a watch-session `:component` swap
+                    ;; produces no drift. (Story-level `:component` rides
+                    ;; `story-body-slice`.)
+                    :component
+                    ;; rf2-9zj0nc — render inputs that change the settled
+                    ;; rendered state: `:sub-overrides` pins subscription outputs
+                    ;; the renderer surfaces, `:db-seed` seeds app-db before the
+                    ;; script, `:network` stubs the HTTP replies a fetch-on-mount
+                    ;; view settles to. All three already land in the plan-hash;
+                    ;; the snapshot-identity path was the straggler.
+                    :sub-overrides :db-seed :network]))))
 
 (defn- story-body-slice
   "Story-level slice that the variant inherits for identity purposes.

--- a/tools/story/src/re_frame/story/identity.cljc
+++ b/tools/story/src/re_frame/story/identity.cljc
@@ -217,9 +217,17 @@
     (when body
       (select-keys body [:component :decorators]))))
 
-(defn- view-schema-digest
+(defn view-schema-digest
   "Return the *registered* schema digest of the view per /spec/007-Stories.md §Variant
   snapshot identity and spec/011 §`:rf/schema-digest`.
+
+  Public so the watch-mode detector's testable-hash cache can fold this
+  SAME per-frame digest into its cache key (rf2-3y7l7u). A view-schema
+  hot-reload perturbs the snapshot-tuple through this slot but does NOT
+  bump the Story registrar mutation-tick (the schema registry is the
+  FRAMEWORK side-table), so the cache — keyed on the Story tick — would
+  otherwise short-circuit a real drift. Reusing this one definition keeps
+  the cache-key signal exactly the snapshot-identity input.
 
   Sourced via the `:schemas/app-schemas-digest` late-bind hook so this
   ns does not statically `:require` the schemas artefact — in builds

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -56,7 +56,6 @@
             [re-frame.story.config :as config]
             [re-frame.story.decorators :as decorators]
             [re-frame.story.frames :as frames]
-            [re-frame.story.identity :as identity]
             [re-frame.story.play.runner-events :as play-runner-events]
             [re-frame.story.predicates :as pred]
             [re-frame.story.registrar :as registrar]
@@ -86,6 +85,7 @@
             [re-frame.story.ui.share :as share]
             [re-frame.story.ui.shell.rails :as rails]
             [re-frame.story.ui.url-state :as url-state]
+            [re-frame.story.ui.watch :as watch]
             [re-frame.story.ui.shell-styles :refer [styles]]
             [re-frame.story.ui.sidebar :as sidebar]
             [re-frame.story.theme.typography :as theme-typography]
@@ -165,76 +165,19 @@
 
 ;; ---- watch-mode detector (rf2-z1h0f) -------------------------------------
 ;;
-;; The chrome-level test widget's eye-icon toggles `[:tests :watch-
-;; mode?]` in the shell state. When on, this poll computes a snapshot-
-;; identity content-hash per testable variant, compares it against the
+;; The chrome-level test widget's eye-icon toggles `[:tests :watch-mode?]`
+;; in the shell state. When on, `detect-watch-drift!` polls a snapshot-
+;; identity content-hash per testable variant (via
+;; `watch/compute-testable-content-hashes`), compares it against the
 ;; recorded `[:tests :content-hashes]` slot, and dispatches
-;; `sidebar/watch-rerun!` for the variants whose hash drifted.
+;; `sidebar/watch-rerun!` for the variants whose hash drifted. Detection
+;; runs on the same 500ms cadence as the hot-reload poll.
 ;;
-;; Detection runs on the same 500ms cadence as the existing hot-reload
-;; poll — both polls share `setInterval` for v1.
-;;
-;; HOT PATH (rf2-zrswb): `compute-testable-content-hashes` runs every
-;; 500ms while watch mode is on. The naïve walk hashed every testable
-;; variant on every tick — pr-str of the canonical tuple per variant,
-;; cost O(V × variant-body-size). For a corpus of N testable variants
-;; the steady-state cost is dominated by serialisation that produces
-;; the same hash 99.9% of the time.
-;;
-;; The cache below keys on `[registrar-mutation-tick, active-modes,
-;; substrate, cell-overrides]` — the four inputs that can perturb a
-;; snapshot-identity hash across two polls. Registrar writes invalidate
-;; every variant entry; shell-state mode/substrate changes do too; and
-;; per-cell control edits land in `:cell-overrides` and ARE threaded
-;; through `args/resolve-args` into `snapshot-tuple`'s `:effective-args`
-;; slot (identity.cljc:213 + args.cljc:125-134) — they DO perturb the
-;; hash. When the key matches the previous tick's key, we return the
-;; cached map — zero hashing work. When it drifts, we recompute the lot
-;; once and re-seed the cache.
-;;
-;; Pre-rf2-mclvi the cache key dropped `:cell-overrides` citing
-;; `snapshot-identity` as the source of truth, but `snapshot-tuple`
-;; DOES read them via `resolve-args` — the cache was stale after every
-;; control edit, watch-mode missed re-runs.
-
-(defonce ^:private testable-hash-cache
-  (atom {:key nil :hashes nil}))
-
-(defn- compute-testable-content-hashes
-  "Walk the registered testable variants and return a `{variant-id →
-  hex-hash}` map of snapshot-identity content hashes. The hash captures
-  the variant's `:play-script` / `:events` / `:loaders` / `:decorators` /
-  `:tags` slots plus the parent story's slice, the view's registered
-  schema-digest, AND the variant's resolved effective args (which fold
-  in the user's live `:cell-overrides`). See `re-frame.story.identity`
-  §What's in the hash + /spec/007-Stories.md §Variant snapshot identity.
-
-  HOT PATH (rf2-zrswb): registrar-driven cache short-circuits when
-  neither the side-table nor the relevant shell-state slots
-  (`:active-modes` / `:substrate` / `:cell-overrides`) have drifted
-  since the last tick."
-  []
-  (let [shell      (state/get-state)
-        modes      (:active-modes shell)
-        subs       (:substrate shell)
-        overrides  (:cell-overrides shell)
-        tick       (registrar/current-mutation-tick)
-        key        [tick modes subs overrides]
-        cached     @testable-hash-cache]
-    (if (= key (:key cached))
-      (:hashes cached)
-      (let [testable (state/testable-variant-ids
-                       (:variants (state/registry-snapshot)))
-            hashes   (into {}
-                           (map (fn [vid]
-                                  (let [opts {:active-modes   modes
-                                              :substrate      subs
-                                              :cell-overrides (get overrides vid)}]
-                                    [vid (:content-hash
-                                           (identity/snapshot-identity vid opts))])))
-                           testable)]
-        (reset! testable-hash-cache {:key key :hashes hashes})
-        hashes))))
+;; The compute + its hot-path cache live in `re-frame.story.ui.watch` — a
+;; leaf that requires neither `shell` nor `sidebar`, so the toggle seed
+;; (`sidebar/set-watch-mode!`, rf2-asp2op) can share the SAME compute
+;; without a `sidebar → shell` load cycle. See that ns for the cache-key
+;; rationale (incl. the rf2-3y7l7u view-schema-digest signal).
 
 (defn detect-watch-drift!
   "When watch mode is on, compute the current testable-variant content
@@ -246,7 +189,7 @@
   interval."
   []
   (when (and config/enabled? (state/test-watch-mode? (state/get-state)))
-    (let [current (compute-testable-content-hashes)
+    (let [current (watch/compute-testable-content-hashes)
           shell   (state/get-state)
           prev    (get-in shell [:tests :content-hashes])
           drifted (state/watch-mode-drift prev current)]

--- a/tools/story/src/re_frame/story/ui/sidebar.cljs
+++ b/tools/story/src/re_frame/story/ui/sidebar.cljs
@@ -66,7 +66,8 @@
             [re-frame.story.ui.sidebar-search :as search]
             [re-frame.story.ui.sidebar-signals :as signals]
             [re-frame.story.ui.sidebar-styles :refer [styles]]
-            [re-frame.story.ui.state          :as state]))
+            [re-frame.story.ui.state          :as state]
+            [re-frame.story.ui.watch          :as watch]))
 
 ;; Styles live in `re-frame.story.ui.sidebar-styles` (pure-data leaf,
 ;; no Reagent dep). Required as `styles` above so the in-file call
@@ -727,6 +728,29 @@
   (doseq [vid variant-ids]
     (run-one-test! vid)))
 
+(defn set-watch-mode!
+  "Set the chrome-level watch-mode flag, seeding the drift baseline when
+  turning ON (rf2-asp2op). On toggle-ON we compute the CURRENT testable
+  snapshot hashes (`watch/compute-testable-content-hashes`) and record
+  them into `[:tests :content-hashes]` BEFORE flipping `[:tests
+  :watch-mode?]` — so the first `detect-watch-drift!` tick diffs a real
+  baseline. Without the seed the slot is `{}` on enable (its default, or
+  cleared by a prior toggle-OFF), so the first tick reads EVERY testable
+  variant as absent-from-prev → drifted, and the whole `:test` suite
+  spuriously re-runs the instant watch is switched on.
+
+  The compute lives in `re-frame.story.ui.watch` (registrar + identity
+  access) — it cannot fold into the pure `state/set-test-watch-mode` state
+  fn. Turning OFF just flips the flag; that same state fn clears the
+  recorded hashes so the next toggle-ON re-seeds fresh."
+  [on?]
+  (when on?
+    ;; Seed BEFORE the flag flips so no detector tick can observe
+    ;; watch-on against an empty baseline.
+    (state/swap-state! state/record-test-content-hashes
+                       (watch/compute-testable-content-hashes)))
+  (state/swap-state! state/set-test-watch-mode on?))
+
 (defn test-widget
   "Chrome-level test widget. Aggregates `run-variant` outcomes across
   every testable variant. `:test`-tagged + `:play-script`-bearing variants
@@ -792,9 +816,10 @@
                            (run-all-tests! variant-ids)))}
          (if any-run? "Running…" "Run all")]
         ;; rf2-z1h0f — watch-mode toggle. Eye glyph reads on/off; the
-        ;; chip's aria-pressed reflects the boolean. Toggle-on seeds
-        ;; `[:tests :content-hashes]` so the first detector tick after
-        ;; toggle-on doesn't fire a spurious re-run for every variant.
+        ;; chip's aria-pressed reflects the boolean. `set-watch-mode!`
+        ;; seeds `[:tests :content-hashes]` on toggle-ON (rf2-asp2op) so
+        ;; the first detector tick doesn't fire a spurious re-run for
+        ;; every variant.
         [:div {:style (:watch-row styles)}
          [:button
           {:style         (merge (:watch-btn styles)
@@ -809,8 +834,7 @@
                             "Watching — variants re-run on content change"
                             "Watch mode off — re-run is explicit")
            :on-click      (fn [_]
-                            (state/swap-state! state/set-test-watch-mode
-                                               (not watch-on?)))}
+                            (set-watch-mode! (not watch-on?)))}
           (if watch-on? "● watching" "○ watch")]]])])))
 
 (defn- search-input

--- a/tools/story/src/re_frame/story/ui/watch.cljc
+++ b/tools/story/src/re_frame/story/ui/watch.cljc
@@ -1,0 +1,80 @@
+(ns re-frame.story.ui.watch
+  "Watch-mode detector compute + hot-path cache (rf2-z1h0f / rf2-zrswb).
+
+  The chrome-level test widget's eye toggle enables watch mode; while on,
+  the shell polls `compute-testable-content-hashes` every 500ms, diffs it
+  against the recorded `[:tests :content-hashes]` slot, and re-runs the
+  variants whose snapshot-identity drifted.
+
+  This leaf hosts ONLY the pure-ish compute + its cache — it requires
+  neither `shell` nor `sidebar`, so BOTH can consume it without a load
+  cycle. The detector orchestration (`detect-watch-drift!`, which calls
+  `sidebar/watch-rerun!`) stays in `re-frame.story.ui.shell`; the toggle
+  seed (`sidebar/set-watch-mode!`, which must compute the baseline BEFORE
+  flipping the flag — rf2-asp2op) lives in `re-frame.story.ui.sidebar`.
+  Both call `compute-testable-content-hashes` here.
+
+  ## Hot path (rf2-zrswb)
+
+  `compute-testable-content-hashes` runs every 500ms while watch mode is
+  on. The naïve walk hashed every testable variant on every tick — the
+  canonical tuple serialised per variant, O(V × variant-body-size), to
+  produce the same hash 99.9% of the time.
+
+  The cache below keys on the inputs that can perturb a snapshot-identity
+  hash across two polls:
+
+  1. `registrar-mutation-tick` — a Story registrar write invalidates
+     every variant entry.
+  2. `active-modes` / `substrate` — shell-state render context.
+  3. `cell-overrides` — per-cell control edits land here and ARE threaded
+     through `args/resolve-args` into `snapshot-tuple`'s `:effective-args`
+     slot (identity.cljc + args.cljc), so they DO perturb the hash
+     (rf2-mclvi — a dropped `:cell-overrides` key served stale answers
+     after every control edit and the detector missed the re-run).
+
+  When the key matches the previous tick's key we return the cached map —
+  zero hashing work. When it drifts we recompute the lot once and re-seed."
+  (:require [re-frame.story.identity  :as identity]
+            [re-frame.story.registrar :as registrar]
+            [re-frame.story.ui.state  :as state]))
+
+(defonce ^:private testable-hash-cache
+  (atom {:key nil :hashes nil}))
+
+(defn compute-testable-content-hashes
+  "Walk the registered testable variants and return a `{variant-id →
+  hex-hash}` map of snapshot-identity content hashes. The hash captures
+  the variant's `:play-script` / `:events` / `:loaders` / `:decorators` /
+  `:component` / `:sub-overrides` / `:db-seed` / `:network` / `:tags`
+  slots plus the parent story's slice, the view's registered schema-
+  digest, AND the variant's resolved effective args (which fold in the
+  user's live `:cell-overrides`). See `re-frame.story.identity` §What's in
+  the hash + /spec/007-Stories.md §Variant snapshot identity.
+
+  HOT PATH (rf2-zrswb): the registrar-driven cache short-circuits when
+  none of the perturbing inputs (registrar tick, `:active-modes`,
+  `:substrate`, `:cell-overrides`) have drifted since the last tick — see
+  the ns docstring."
+  []
+  (let [shell      (state/get-state)
+        modes      (:active-modes shell)
+        subs       (:substrate shell)
+        overrides  (:cell-overrides shell)
+        tick       (registrar/current-mutation-tick)
+        key        [tick modes subs overrides]
+        cached     @testable-hash-cache]
+    (if (= key (:key cached))
+      (:hashes cached)
+      (let [testable (state/testable-variant-ids
+                       (:variants (state/registry-snapshot)))
+            hashes   (into {}
+                           (map (fn [vid]
+                                  (let [opts {:active-modes   modes
+                                              :substrate      subs
+                                              :cell-overrides (get overrides vid)}]
+                                    [vid (:content-hash
+                                           (identity/snapshot-identity vid opts))])))
+                           testable)]
+        (reset! testable-hash-cache {:key key :hashes hashes})
+        hashes))))

--- a/tools/story/src/re_frame/story/ui/watch.cljc
+++ b/tools/story/src/re_frame/story/ui/watch.cljc
@@ -32,6 +32,18 @@
      slot (identity.cljc + args.cljc), so they DO perturb the hash
      (rf2-mclvi — a dropped `:cell-overrides` key served stale answers
      after every control edit and the detector missed the re-run).
+  4. `view-schema-digest` per testable frame — rf2-3y7l7u. `snapshot-tuple`
+     ALSO hashes each variant frame's registered app-db schema digest
+     (identity/view-schema-digest, off the `:schemas/app-schemas-digest`
+     late-bind hook). A view-schema hot-reload perturbs THAT digest but
+     does NOT write the Story side-table, so it does NOT bump the
+     registrar mutation-tick — the four Story-side inputs above are all
+     static across the reload. Without this fifth signal the cache
+     short-circuits a real drift and the schema-affected variant never
+     re-runs. The digest is cheap (empty-set → the stable empty-string
+     digest for the common no-schema variant frame), and reusing
+     `identity/view-schema-digest` keeps the signal byte-identical to the
+     snapshot-tuple input it guards.
 
   When the key matches the previous tick's key we return the cached map —
   zero hashing work. When it drifts we recompute the lot once and re-seed."
@@ -41,6 +53,18 @@
 
 (defonce ^:private testable-hash-cache
   (atom {:key nil :hashes nil}))
+
+(defn- testable-schema-signal
+  "Fifth cache-key input (rf2-3y7l7u): the per-testable-frame view-schema
+  digests, in `testable` order. A view-schema hot-reload changes a
+  variant frame's registered app-db schema digest — which `snapshot-tuple`
+  hashes via `identity/view-schema-digest` — WITHOUT bumping the Story
+  registrar mutation-tick, so this is the only cache-key signal that moves
+  when a schema (and nothing else) changes. Cheap: each digest is a walk
+  of the frame's registered schema set (the stable empty-string digest for
+  a variant frame with no registered schemas / not yet allocated)."
+  [testable]
+  (mapv identity/view-schema-digest testable))
 
 (defn compute-testable-content-hashes
   "Walk the registered testable variants and return a `{variant-id →
@@ -53,28 +77,33 @@
   the hash + /spec/007-Stories.md §Variant snapshot identity.
 
   HOT PATH (rf2-zrswb): the registrar-driven cache short-circuits when
-  none of the perturbing inputs (registrar tick, `:active-modes`,
-  `:substrate`, `:cell-overrides`) have drifted since the last tick — see
-  the ns docstring."
+  none of the five perturbing inputs (registrar tick, `:active-modes`,
+  `:substrate`, `:cell-overrides`, per-frame view-schema digest) have
+  drifted since the last tick — see the ns docstring."
   []
   (let [shell      (state/get-state)
         modes      (:active-modes shell)
         subs       (:substrate shell)
         overrides  (:cell-overrides shell)
         tick       (registrar/current-mutation-tick)
-        key        [tick modes subs overrides]
+        ;; `testable` is needed BEFORE the cache check to form the
+        ;; view-schema signal, so it is computed every tick (a registrar
+        ;; walk + `:test`-tag filter — far cheaper than the per-variant
+        ;; snapshot hashing the cache guards).
+        testable   (state/testable-variant-ids
+                     (:variants (state/registry-snapshot)))
+        schema-sig (testable-schema-signal testable)
+        key        [tick modes subs overrides schema-sig]
         cached     @testable-hash-cache]
     (if (= key (:key cached))
       (:hashes cached)
-      (let [testable (state/testable-variant-ids
-                       (:variants (state/registry-snapshot)))
-            hashes   (into {}
-                           (map (fn [vid]
-                                  (let [opts {:active-modes   modes
-                                              :substrate      subs
-                                              :cell-overrides (get overrides vid)}]
-                                    [vid (:content-hash
-                                           (identity/snapshot-identity vid opts))])))
-                           testable)]
+      (let [hashes (into {}
+                         (map (fn [vid]
+                                (let [opts {:active-modes   modes
+                                            :substrate      subs
+                                            :cell-overrides (get overrides vid)}]
+                                  [vid (:content-hash
+                                         (identity/snapshot-identity vid opts))])))
+                         testable)]
         (reset! testable-hash-cache {:key key :hashes hashes})
         hashes))))

--- a/tools/story/test/re_frame/story/ui/test_watch_mode_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/test_watch_mode_cljs_test.cljc
@@ -19,7 +19,8 @@
             [re-frame.story :as story]
             [re-frame.story.ui.state :as state]
             #?@(:cljs [[re-frame.story.ui.shell   :as shell]
-                       [re-frame.story.ui.sidebar :as sidebar]])))
+                       [re-frame.story.ui.sidebar :as sidebar]
+                       [re-frame.story.ui.watch   :as watch]])))
 
 ;; ---- fixtures ------------------------------------------------------------
 
@@ -326,3 +327,40 @@
            (is (nil? (get runs :story.x/b))
                (str "expected B to have no fresh run stamp — only the drifted "
                     "variant re-runs; runs was " (pr-str runs))))))))
+
+;; ---- rf2-asp2op: toggle-ON seeds the baseline → no spurious full re-run ---
+;;
+;; The watch toggle's contract (sidebar.cljs) promises: "Toggle-on seeds
+;; [:tests :content-hashes] so the first detector tick doesn't fire a
+;; spurious re-run for every variant." Before the fix the on-click only
+;; flipped the flag; the slot stayed {} on enable, so the first
+;; detect-watch-drift! tick read every testable variant as absent-from-prev
+;; → drifted, re-running the WHOLE :test suite the instant watch turned on.
+;; `sidebar/set-watch-mode!` now seeds the real baseline BEFORE the flag
+;; flips, so the first tick diffs against truth and re-runs nothing.
+
+#?(:cljs
+   (deftest toggle-on-seeds-baseline-no-spurious-full-rerun
+     (testing "rf2-asp2op — enabling watch via `sidebar/set-watch-mode!`
+               seeds [:tests :content-hashes] from the CURRENT registry
+               BEFORE the flag flips, so the first detector tick re-runs
+               NOTHING (the registry is unchanged since the seed)"
+       (story/reg-variant :story.x/a {:tags #{:test} :events []
+                                      :play-script [[:dispatch-sync [:rf.assert/path-equals [:c] 0]]]})
+       (story/reg-variant :story.x/b {:tags #{:test} :events []
+                                      :play-script [[:dispatch-sync [:rf.assert/path-equals [:c] 0]]]})
+       ;; Enable via the REAL toggle entry point (what the on-click calls).
+       (sidebar/set-watch-mode! true)
+       (testing "the baseline slot is seeded with BOTH testable variants"
+         (let [seeded (get-in (state/get-state) [:tests :content-hashes])]
+           (is (contains? seeded :story.x/a)
+               "toggle-on must seed the baseline, not leave it {}")
+           (is (contains? seeded :story.x/b))))
+       ;; First detector tick — registry UNCHANGED since the seed.
+       (shell/detect-watch-drift!)
+       (testing "no variant re-runs — the seeded baseline matches, so drift
+                 is empty (the pre-fix bug re-ran the whole suite here)"
+         (let [runs (get-in (state/get-state) [:tests :runs])]
+           (is (nil? (get runs :story.x/a))
+               (str "expected NO re-run on enable; runs was " (pr-str runs)))
+           (is (nil? (get runs :story.x/b))))))))

--- a/tools/story/test/re_frame/story/ui/test_watch_mode_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/test_watch_mode_cljs_test.cljc
@@ -18,7 +18,8 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.story :as story]
             [re-frame.story.ui.state :as state]
-            #?@(:cljs [[re-frame.story.ui.shell   :as shell]
+            #?@(:cljs [[re-frame.late-bind        :as late-bind]
+                       [re-frame.story.ui.shell   :as shell]
                        [re-frame.story.ui.sidebar :as sidebar]
                        [re-frame.story.ui.watch   :as watch]])))
 
@@ -364,3 +365,38 @@
            (is (nil? (get runs :story.x/a))
                (str "expected NO re-run on enable; runs was " (pr-str runs)))
            (is (nil? (get runs :story.x/b))))))))
+
+;; ---- rf2-3y7l7u: a view-schema hot-reload busts the testable-hash cache --
+;;
+;; `compute-testable-content-hashes` caches on
+;; [registrar-tick modes substrate cell-overrides <per-frame view-schema
+;; digests>]. snapshot-tuple hashes each variant frame's app-db schema
+;; digest (identity/view-schema-digest, off :schemas/app-schemas-digest) —
+;; but a schema hot-reload does NOT write the Story side-table, so it does
+;; NOT bump the registrar mutation-tick. Before the fifth key input was
+;; added the cache served the stale hash across a schema change and the
+;; schema-affected variant never re-ran.
+
+#?(:cljs
+   (deftest schema-hot-reload-busts-testable-hash-cache
+     (testing "rf2-3y7l7u — mutating the view-schema digest (registrar tick,
+               modes, substrate, overrides all unchanged) must change the
+               cached testable hash; before the fix the cache short-circuited
+               the real drift"
+       (story/reg-variant :story.x/a {:tags #{:test} :events []
+                                      :play-script [[:dispatch-sync [:rf.assert/path-equals [:c] 0]]]})
+       (let [prior (late-bind/get-fn :schemas/app-schemas-digest)]
+         (try
+           ;; Schema generation 1.
+           (late-bind/set-fn! :schemas/app-schemas-digest
+                              (fn [_frame-id] "sha256:0000000000000001"))
+           (let [h1 (get (watch/compute-testable-content-hashes) :story.x/a)]
+             ;; Schema hot-reload — digest moves, Story side-table untouched.
+             (late-bind/set-fn! :schemas/app-schemas-digest
+                                (fn [_frame-id] "sha256:0000000000000002"))
+             (let [h2 (get (watch/compute-testable-content-hashes) :story.x/a)]
+               (is (some? h1) "the first compute must hash the variant")
+               (is (not= h1 h2)
+                   "the cache must bust on a view-schema hot-reload")))
+           (finally
+             (late-bind/set-fn! :schemas/app-schemas-digest prior)))))))

--- a/tools/story/test/re_frame/story_runtime_test.clj
+++ b/tools/story/test/re_frame/story_runtime_test.clj
@@ -570,6 +570,63 @@
         (finally
           (late-bind/set-fn! :schemas/app-schemas-digest prior))))))
 
+(deftest snapshot-identity-changes-with-variant-component
+  (testing "rf2-bah5o2 — the per-variant `:component` view-id OVERRIDE
+            participates in the hash. The renderer resolves variant-first
+            `(or (:component variant) (:component story))`, so a variant's
+            OWN `:component` decides WHICH view renders. Before the fix
+            `variant-body-slice` omitted `:component`, so a watch-session
+            edit swapping the view produced NO drift (the re-registration
+            bumped the mutation-tick but the recomputed hash was unchanged)
+            and two variants differing only in `:component` shared a
+            content-hash. plan.cljc DID fold `:component` into the plan-
+            hash; only the snapshot path was incomplete."
+    (story/reg-story :story.id-comp {:component :app/parent})
+    (story/reg-variant :story.id-comp/v {:events [] :component :view-a})
+    (let [h1 (-> (story/snapshot-identity :story.id-comp/v) :content-hash)]
+      (story/reg-variant :story.id-comp/v {:events [] :component :view-b})
+      (let [h2 (-> (story/snapshot-identity :story.id-comp/v) :content-hash)]
+        (is (not= h1 h2)
+            "swapping the variant's :component override must produce a fresh hash"))
+      (testing "the :variant tuple slice now carries the variant's own
+                :component — the slot that resolves the two-variant collision"
+        (is (= :view-b (get-in (ident/snapshot-tuple :story.id-comp/v)
+                               [:variant :component]))
+            "variant-body-slice must select :component")))))
+
+(deftest snapshot-identity-changes-with-render-inputs
+  (testing "rf2-9zj0nc — the variant's `:sub-overrides` / `:db-seed` /
+            `:network` render inputs participate in the hash. Each changes
+            the settled rendered state (pinned sub outputs / pre-script
+            app-db seed / stubbed HTTP replies). Before the fix
+            `variant-body-slice` omitted all three, so an edit produced no
+            drift and the visual-regression baseline stayed stale — even
+            though the plan-hash DID capture them, confirming the snapshot
+            path was the incomplete one."
+    (story/reg-story :story.id-render {:component :app/v})
+    (testing ":sub-overrides edit perturbs the hash"
+      (story/reg-variant :story.id-render/v
+        {:events [] :sub-overrides {[:cart/total] 0}})
+      (let [h1 (-> (story/snapshot-identity :story.id-render/v) :content-hash)]
+        (story/reg-variant :story.id-render/v
+          {:events [] :sub-overrides {[:cart/total] 999}})
+        (is (not= h1 (-> (story/snapshot-identity :story.id-render/v) :content-hash))
+            "editing a :sub-overrides value must produce a fresh hash")))
+    (testing ":db-seed edit perturbs the hash"
+      (story/reg-variant :story.id-render/v {:events [] :db-seed {[:count] 1}})
+      (let [h1 (-> (story/snapshot-identity :story.id-render/v) :content-hash)]
+        (story/reg-variant :story.id-render/v {:events [] :db-seed {[:count] 2}})
+        (is (not= h1 (-> (story/snapshot-identity :story.id-render/v) :content-hash))
+            "editing a :db-seed value must produce a fresh hash")))
+    (testing ":network edit perturbs the hash"
+      (story/reg-variant :story.id-render/v
+        {:events [] :network {[:get "/api/x"] {:reply {:ok {:status 200}}}}})
+      (let [h1 (-> (story/snapshot-identity :story.id-render/v) :content-hash)]
+        (story/reg-variant :story.id-render/v
+          {:events [] :network {[:get "/api/x"] {:reply {:ok {:status 500}}}}})
+        (is (not= h1 (-> (story/snapshot-identity :story.id-render/v) :content-hash))
+            "editing a :network reply must produce a fresh hash")))))
+
 ;; ---- rf2-chzryf: identity keys off EFFECTIVE tags, not raw child :tags ----
 ;;
 ;; Follow-on from rf2-n0vmq2/#5308. The shared `re-frame.story.tags`


### PR DESCRIPTION
Fixes four correctness beads on the Story snapshot-identity / watch-mode surface (from the 2026-07-09 correctness review). Pre-alpha stance: no back-compat shims; primary lenses CORRECTNESS + CLARITY + ELEGANCE, avoiding over-engineering.

## Per-bead fix

- **rf2-bah5o2 (P2)** — `identity.cljc variant-body-slice` omitted the per-variant `:component` view-id OVERRIDE (the renderer resolves variant-first `(or (:component variant) (:component story))`). A watch-session `:component` swap produced no drift and two variants differing only in `:component` collided. Added `:component` to the slice.
- **rf2-9zj0nc (P2)** — same slice omitted the `:sub-overrides` / `:db-seed` / `:network` render inputs (all change the settled render). Added all three. One shared fix site with bah5o2; the plan-hash already captured all four, confirming the snapshot path was the straggler. Also updated the identity ns "What's in the hash" list and the stale enumerated list in `tools/story/spec/002-Runtime.md §Snapshot-identity computation`.
- **rf2-asp2op (P3)** — enabling watch mode only flipped `[:tests :watch-mode?]`; `[:tests :content-hashes]` stayed `{}`, so the first `detect-watch-drift!` tick read every testable variant as drifted and spuriously re-ran the whole `:test` suite. Extracted the detector compute + hot-path cache into a new leaf `re-frame.story.ui.watch` (requires neither `shell` nor `sidebar`, breaking the `sidebar → shell` cycle); the new `sidebar/set-watch-mode!` seeds the real baseline BEFORE flipping the flag.
- **rf2-3y7l7u (P4)** — the testable-hash cache keyed on `[tick modes substrate cell-overrides]`, but `snapshot-tuple` also hashes each variant frame's view-schema digest — sourced from the FRAMEWORK schema registry, which does not bump the Story registrar tick. A schema hot-reload moved the hash while the key stayed static. Folded a fifth signal (per-frame `view-schema-digest`, now public) into the cache key.

## Adversarial tests (≥1 per fix)

- `story_runtime_test.clj` (JVM): variant `:component` swap perturbs the hash (+ slice witness); `:sub-overrides` / `:db-seed` / `:network` edits each perturb.
- `test_watch_mode_cljs_test.cljc` (CLJS): toggle-ON seeds both testable variants and the first detector tick re-runs nothing; a view-schema hot-reload busts the cache.

## Quality gates

Focused gates (foreground, this worktree):

- `cd tools/story && clojure -M:test` — **PASS** (1767 tests, 6496 assertions, 0 failures/0 errors).
- `cd implementation && npm run story:build` — **PASS** (654 files, 593 compiled, 0 warnings; the lone JSDoc warning is pre-existing in `tools/xray`, unrelated). Confirms `watch.cljc` / `shell.cljs` / `sidebar.cljs` compile with no load cycle.
- `cd implementation && npm run test:cljs` (the fast default CLJS gate) — **PASS** (8307 tests, 38193 assertions, 0 failures/0 errors), covering both new CLJS tests and all existing watch-mode tests after the detector extraction.

Full spine deferred to CI.

## Notes / risk

- `tools/story/spec/002-Runtime.md` is the Story-local spec, NOT the top-level hot-zone `spec/002-Frames.md`, so the hot-zone doc-slug rule does not apply.
- Scope is confined to `tools/story` (+ its local spec). No touch to `implementation/resources`, machines, `examples/linearlite`, or `tools/re-frame2-pair-mcp`.
- The detector compute moved namespaces (`shell` → new `watch` leaf); `shell/detect-watch-drift!` and its public surface are unchanged.
