### PR TITLE
fix(routing): segment-boundary base-path strip + cross-host :uuid coercion (rf2-vuv84a +1)

### DIFF
--- a/implementation/routing/src/re_frame/routing/registry.cljc
+++ b/implementation/routing/src/re_frame/routing/registry.cljc
@@ -717,10 +717,17 @@
     ;; the `:else` string passthrough rather than fabricate float route data.
 
     (= :uuid type-form)
-    ;; rf2-cylse.5: host-symmetric + total. `parse-uuid` returns nil on a
-    ;; non-UUID string (both hosts) → leave the raw string for the
-    ;; validator. Makes the canonical Spec 012 :uuid path route match.
-    (if (string? v) (or (parse-uuid v) v) v)
+    ;; rf2-cylse.5 + rf2-rv7so9: host-symmetric + total. Lower-case BEFORE
+    ;; `parse-uuid` so a non-lowercase UUID coerces to the SAME lowercase-
+    ;; canonical UUID on both hosts. JVM `parse-uuid` already canonicalizes to
+    ;; lowercase (`UUID/fromString` → `(str)`), but CLJS `(uuid s)` stores the
+    ;; string VERBATIM, so a mixed-/upper-case capture would otherwise leave a
+    ;; host-divergent stored+re-emitted value — a Spec 011 SSR/hydrate mismatch
+    ;; and divergent canonical href. Lowercasing first matches the form
+    ;; `re-frame.identity/canonical-bytes` already blesses. A non-UUID string →
+    ;; `parse-uuid` nil (both hosts) → leave the RAW (original-case) string for
+    ;; the validator to reject.
+    (if (string? v) (or (parse-uuid (str/lower-case v)) v) v)
 
     (= :boolean type-form)
     (case v "true" true "false" false v)

--- a/implementation/routing/src/re_frame/routing/strategy.cljc
+++ b/implementation/routing/src/re_frame/routing/strategy.cljc
@@ -242,12 +242,17 @@
 
 (defn strip-base-path
   "Strip `base` off the front of path-form `url`, returning the app-relative
-  `/`-rooted remainder. `url` that does not start with `base` is returned
-  UNCHANGED (defensive — should not happen for a correctly-mounted app; fails
-  safe rather than mis-slicing an unrelated URL). A blank `base` is a no-op.
-  Pure."
+  `/`-rooted remainder. `url` is under the base only when it EQUALS `base` (the
+  mount root) or starts with `(str base \"/\")` (a path-SEGMENT boundary) — a
+  bare string-prefix test would mis-slice a prefix-sharing SIBLING (base `/app`
+  must NOT strip `/application`, `/apple`, `/app-admin`). A `url` that is not
+  under the base — including such a sibling, or a fully unrelated URL — is
+  returned UNCHANGED (defensive: fails safe rather than mis-slicing the path).
+  A blank `base` is a no-op. Pure. (rf2-vuv84a)"
   [base url]
-  (if (and (seq base) (clojure.string/starts-with? url base))
+  (if (and (seq base)
+           (or (= url base)
+               (clojure.string/starts-with? url (str base "/"))))
     (let [remainder (subs url (count base))]
       (if (clojure.string/starts-with? remainder "/")
         remainder

--- a/implementation/routing/test/re_frame/routing_registry_test.clj
+++ b/implementation/routing/test/re_frame/routing_registry_test.clj
@@ -1784,6 +1784,36 @@
             "URL → coerced params → URL is byte-identical")))))
 
 ;; ============================================================================
+;; rf2-rv7so9 — :uuid coercion is HOST-SYMMETRIC for a non-lowercase capture.
+;; The JVM half of the cross-host parity pin; the CLJS half lives in
+;; routing_url_non_edn_cljs_test.cljc (which runs on the node-test build).
+;; Both hosts must coerce a mixed-/upper-case UUID to the SAME lowercase-
+;; canonical value and re-emit the SAME lowercase URL — pre-fix, JVM
+;; `parse-uuid` lowercased but CLJS `(uuid s)` stored the string verbatim, so
+;; the SAME uppercase-UUID deep link produced host-divergent :params and href
+;; (a Spec 011 SSR/hydrate mismatch).
+;; ============================================================================
+
+(deftest uuid-path-non-lowercase-coerces-to-lowercase-canonical
+  (testing "ADVERSARIAL (rf2-rv7so9): a mixed-/upper-case :uuid path capture
+            coerces to the lowercase-canonical UUID, passes validation, and
+            re-emits the lowercase canonical URL — the JVM half of the parity
+            pin (CLJS half in routing_url_non_edn_cljs_test.cljc)"
+    (rf/reg-route :route/article {:params [:map [:id :uuid]]} "/articles/:id")
+    (let [canonical #uuid "550e8400-e29b-41d4-a716-446655440000"
+          upper     "550E8400-E29B-41D4-A716-446655440000"
+          m         (routing/match-url (str "/articles/" upper))]
+      (is (= :route/article (:route-id m)) "the canonical :uuid route matches")
+      (is (= canonical (get-in m [:params :id]))
+          "mixed-case capture coerces to the lowercase-canonical UUID (matches CLJS)")
+      (is (uuid? (get-in m [:params :id])) "the slice carries a UUID object")
+      (is (false? (:validation-failed? m))
+          "the coerced UUID conforms to [:id :uuid] — validation passes")
+      (is (= "/articles/550e8400-e29b-41d4-a716-446655440000"
+             (routing/route-url :route/article {:id (get-in m [:params :id])}))
+          "route-url re-emits the lowercase canonical URL (matches CLJS)"))))
+
+;; ============================================================================
 ;; rf2-cylse.1 — :int coercion is HOST-SYMMETRIC and TOTAL on oversized
 ;; integers. The JVM half of the cross-host parity pin; the CLJS half lives
 ;; in routing_history_cljs_test.cljs. Both hosts must agree EXACTLY.

--- a/implementation/routing/test/re_frame/routing_url_non_edn_cljs_test.cljc
+++ b/implementation/routing/test/re_frame/routing_url_non_edn_cljs_test.cljc
@@ -254,3 +254,53 @@
     (let [url (routing/route-url :route/fr {} {} "50% done")]
       (is (= "50% done" (:fragment (routing/match-url url)))
           "a %-significant string fragment round-trips through encode/decode"))))
+
+;; ===========================================================================
+;; rf2-rv7so9 — :uuid coercion is host-symmetric for a non-lowercase capture
+;; ===========================================================================
+;;
+;; Spec 011 cross-host parity + EP-0012 prism laws: a mixed-/upper-case UUID in
+;; a path segment must coerce to the SAME lowercase-canonical UUID and re-emit
+;; the SAME canonical URL on JVM and CLJS. Pre-fix, JVM `parse-uuid` lowercased
+;; (UUID/fromString → canonical), but CLJS `(uuid s)` stores the string
+;; VERBATIM — so `match-url` yielded a host-DIVERGENT :params value (and
+;; `route-url` a host-divergent href) for a non-lowercase input: an
+;; SSR(JVM)+hydrate(CLJS) deep-link mismatch. Because this `.cljc` runs on BOTH
+;; the JVM (`clojure -M:test`) and the CLJS node runner, a fixed lowercase
+;; expectation here pins the two hosts to the SAME value.
+
+(deftest uuid-path-mixed-case-coerces-host-symmetric
+  (testing "ADVERSARIAL (rf2-rv7so9): a mixed-/upper-case :uuid path capture
+            coerces to the lowercase-canonical UUID and re-emits the lowercase
+            canonical URL — IDENTICALLY on JVM and CLJS (this test runs on both)"
+    (rf/reg-route :route/art {:params [:map [:id :uuid]]} "/articles/:id")
+    (let [canonical #uuid "550e8400-e29b-41d4-a716-446655440000"
+          upper     "550E8400-E29B-41D4-A716-446655440000"
+          m         (routing/match-url (str "/articles/" upper))]
+      ;; SAME parsed value on both hosts — the lowercase-canonical UUID object.
+      (is (= canonical (get-in m [:params :id]))
+          "mixed-case capture coerces to the lowercase-canonical UUID (same JVM+CLJS)")
+      (is (uuid? (get-in m [:params :id])) "the slice carries a UUID object, not a string")
+      ;; the coerced value conforms to :uuid, so the canonical route matches.
+      (is (= :route/art (:route-id m)) "the canonical :uuid route matches, not not-found")
+      (is (not (:validation-failed? m)) "the coerced UUID passes :uuid validation")
+      ;; SAME re-emitted canonical URL on both hosts — lowercase, not input case.
+      (is (= "/articles/550e8400-e29b-41d4-a716-446655440000"
+             (routing/route-url :route/art {:id (get-in m [:params :id])}))
+          "route-url re-emits the lowercase canonical URL on both hosts"))))
+
+(deftest uuid-path-non-uuid-capture-preserves-original-case-both-hosts
+  (testing "a non-UUID :uuid capture is left as the RAW ORIGINAL-case string on
+            both hosts (parse-uuid → nil → passthrough of `v`, NOT the
+            lower-cased form) — the lower-casing lives strictly INSIDE the
+            parse attempt, so it never mutates a value the validator rejects.
+            (The JVM validation-reject itself is pinned in
+            routing_registry_test.clj.)"
+    (rf/reg-route :route/art2 {:params [:map [:id :uuid]]} "/a/:id")
+    (let [m (routing/match-url "/a/NOT-A-UUID")]
+      ;; if the fix had lower-cased `v` unconditionally this would read
+      ;; "not-a-uuid"; the fallback must preserve the caller's original case.
+      (is (= "NOT-A-UUID" (get-in m [:params :id]))
+          "a non-UUID capture stays the raw original-case string (same JVM+CLJS)")
+      (is (string? (get-in m [:params :id]))
+          "no coercion occurred — it is a string, not a UUID object"))))

--- a/implementation/routing/test/re_frame/routing_url_strategy_test.clj
+++ b/implementation/routing/test/re_frame/routing_url_strategy_test.clj
@@ -187,6 +187,25 @@
             with the base is returned unchanged rather than mis-sliced"
     (is (= "/other/path" (strategy/strip-base-path "/realworld" "/other/path")))))
 
+(deftest with-base-path-strips-only-on-segment-boundary
+  (testing "ADVERSARIAL (rf2-vuv84a): strip-base-path treats a URL as under the
+            base ONLY at a path-SEGMENT boundary — the mount root (url = base)
+            or `base/…`. A prefix-SHARING sibling that merely string-prefixes
+            the base is returned UNCHANGED, not mis-sliced."
+    ;; siblings that share the base as a bare STRING prefix must NOT be stripped
+    ;; (the pre-fix defect: `/app` string-prefixed `/application` -> `/lication`).
+    (is (= "/application/x" (strategy/strip-base-path "/app" "/application/x"))
+        "/app must NOT strip /application (segment boundary, not string prefix)")
+    (is (= "/apple" (strategy/strip-base-path "/app" "/apple")))
+    (is (= "/app-admin" (strategy/strip-base-path "/app" "/app-admin")))
+    (is (= "/realworld-demo" (strategy/strip-base-path "/realworld" "/realworld-demo"))
+        "the motivating case: /realworld must not mangle /realworld-demo")
+    ;; genuine under-base URLs still strip correctly.
+    (is (= "/x" (strategy/strip-base-path "/app" "/app/x")))
+    (is (= "/x/y" (strategy/strip-base-path "/app" "/app/x/y")))
+    (is (= "/" (strategy/strip-base-path "/app" "/app"))
+        "the bare mount root (url = base) strips to the app root `/`")))
+
 (deftest with-base-path-blank-base-is-a-no-op
   (testing "a blank/nil base returns the wrapped strategy UNCHANGED — no
             wrapping cost for the common no-sub-path app"


### PR DESCRIPTION
Two correctness fixes on the `implementation/routing` surface, from the 2026-07-09 correctness review. Each bead is a separate commit.

## rf2-vuv84a — `strip-base-path` mis-slices a prefix-sharing sibling
`strategy.cljc` used a bare `starts-with? url base`, so base `/app`
string-prefixed `/application`, `/apple`, `/app-admin` (NOT under the mount)
and mis-sliced them (`/application/x` → `/lication/x`). A deployed-under-`/app`
app receiving a deep-link / popstate / hand-typed sibling URL had its `:decode`
mangle the path and dispatch `:rf.route/handle-url-change` with a corrupted URL —
defeating the combinator's own "pass unrelated URLs through UNCHANGED" intent.

**Fix:** treat a URL as under the base only at a path-SEGMENT boundary — it
EQUALS `base` (mount root → `/`) or starts with `(str base "/")`. Everything
else, including a prefix-sharing sibling, is returned unchanged.

## rf2-rv7so9 — `:uuid` coercion diverges across JVM/CLJS for non-lowercase UUIDs
`registry.cljc` `coerce-by-type-form` ran `parse-uuid` on the raw capture. JVM
`parse-uuid` canonicalizes to lowercase; CLJS `(uuid s)` stores the string
VERBATIM — so a mixed-/upper-case UUID path segment produced a host-divergent
`:params` value and re-emitted href (SSR(JVM)+hydrate(CLJS) mismatch — the
Spec 011 cross-host-parity class the other scalar coercions all guard).

**Fix:** lower-case before parse — `(or (parse-uuid (str/lower-case v)) v)` —
yielding the lowercase-canonical UUID on both hosts (the form
`re-frame.identity/canonical-bytes` already blesses). A non-UUID capture keeps
its raw original case so the validator still rejects it. Existing tests use
lowercase → non-breaking.

## Adversarial tests
- **strip (JVM `.clj`):** base `/app` does NOT strip `/application` / `/apple` /
  `/app-admin`; `/realworld` does not mangle `/realworld-demo`; `/app/x`,
  `/app/x/y`, and the bare mount `/app` still strip correctly.
- **:uuid parity — JVM half (`routing_registry_test.clj`) + CLJS half
  (`routing_url_non_edn_cljs_test.cljc`, node-test build):** both assert a
  mixed-case UUID coerces to the SAME lowercase-canonical `#uuid`, validation
  passes, and `route-url` re-emits the SAME lowercase URL; the CLJS half also
  pins that a non-UUID capture preserves original case.

## Quality gates
- `cd implementation/routing && clojure -M:test` → **391 tests, 1648 assertions, 0 failures, 0 errors**
- `cd implementation && npm run test:cljs` → **8307 tests, 38194 assertions, 0 failures, 0 errors**
- Full spine deferred to CI.

## Stance
Pre-alpha, no back-compat shims; ELEGANCE + CLARITY + CORRECTNESS. Both fixes are
minimal (one predicate; one `str/lower-case` before parse) and align each host to
the canonical form the identity layer already blesses.
