### PR TITLE
fix(http): EDN-serializable cljs error :cause, abort-path stale-suppression, evict issuance-counters (rf2-6pcz0d +2)

### DIFF
--- a/implementation/http/src/re_frame/http/registry.cljc
+++ b/implementation/http/src/re_frame/http/registry.cljc
@@ -182,9 +182,17 @@
 
 (defonce ^:private issuance-counters
   ;; request-id → highest issuance number allocated so far. Monotonic per
-  ;; request-id; never decremented (a re-issuance after a completion still
-  ;; advances, so a late completion of the old attempt cannot collide with a
-  ;; fresh request reusing the same id).
+  ;; request-id WHILE THE ID IS LIVE: `next-issuance!` only ever advances it,
+  ;; so a superseded attempt (issuance N) and its superseder (N+1) carry
+  ;; distinct `:work/id`s, and a late completion of an old attempt cannot reuse
+  ;; a live issuance. rf2-k47b3d — the entry is EVICTED (not decremented) when
+  ;; the id's final attempt terminates with the counter still AT that attempt's
+  ;; issuance (`evict-issuance-on-completion!`), so an app minting an UNBOUNDED
+  ;; distinct-id space (e.g. `[:load-item item-id]` over an unbounded item
+  ;; space) no longer accumulates one permanent entry per id ever requested on
+  ;; a long-running JVM. A re-issuance after a full eviction restarts at 1 —
+  ;; safe because the prior attempt is already terminal (its trace/reply
+  ;; emitted), so there is no live work-id collision to discriminate.
   (atom {}))
 
 (defn next-issuance!
@@ -199,6 +207,36 @@
     1
     (get (swap! issuance-counters update request-id (fnil inc 0)) request-id)))
 
+(defn evict-issuance-on-completion!
+  "Evict `request-id`'s issuance counter when the attempt that carried
+  `issuance` reaches a TERMINAL completion (rf2-k47b3d), bounding the
+  `issuance-counters` map for apps minting UNBOUNDED distinct request-ids.
+
+  Eviction is CONDITIONAL and atomic: the counter is dropped ONLY when it
+  still equals `issuance` — no fresh request has re-issued under the same id
+  since this attempt was allocated. That single-`swap!` compare-and-drop is
+  what preserves the rf2-azcmd3 anti-collision invariant the monotonic counter
+  exists for: when a supersede is in flight, `next-issuance!` has ALREADY
+  bumped the counter PAST the superseded attempt's `issuance` (it bumps before
+  `supersede!`, handlers.cljc), so this evict sees `counter > issuance`, skips,
+  and the counter survives for the live successor. A single-issuance request
+  (the leak vector) satisfies `counter == issuance`, so it evicts cleanly on
+  completion. A `nil` `request-id` never had a counter (an anonymous request
+  stays at issuance 1 without touching the map) — no-op.
+
+  Called ONLY at the terminal-completion sites (`finalise-success!`,
+  `finalise-failure!`, `dispatch-aborted!`), NEVER on the retry-clear or
+  supersede-clear `clear-in-flight!` paths — those are not terminal (the
+  attempt continues under the same issuance, or a live successor owns the id)."
+  [request-id issuance]
+  (when (and (some? request-id) (some? issuance))
+    (swap! issuance-counters
+           (fn [m]
+             (if (= issuance (get m request-id))
+               (dissoc m request-id)
+               m))))
+  nil)
+
 (defn reset-issuance-counters-for-test!
   "Test-time helper (rf2-azcmd3): drop the per-request-id issuance counters so
   a fresh test run starts every request-id at issuance 1. Not part of the
@@ -206,6 +244,13 @@
   []
   (reset! issuance-counters {})
   nil)
+
+(defn issuance-counter-count
+  "Test/introspection helper (rf2-k47b3d): the number of resident per-request-id
+  issuance counters. Lets a leak test assert the map does not grow unbounded
+  across completed requests. Not part of the user-facing API."
+  []
+  (count @issuance-counters))
 
 (defn supersede!
   "If a request is already in flight under `request-id`, abort it with

--- a/implementation/http/src/re_frame/http/transport.cljc
+++ b/implementation/http/src/re_frame/http/transport.cljc
@@ -626,10 +626,36 @@
                            (contains? failure :body-text))
                        (assoc :rf.http/off-box-body :omit))]
       (trace/emit-error! (:kind failure) redacted)))
-  (let [suppress? (and (= :rf.http/aborted (:kind failure))
-                       (reply-suppressing-abort-reason? (:reason failure)))]
-    (when-not suppress?
-      (dispatch-failure! ctx failure)))))
+  (cond
+    ;; rf2-lxd3 / rf2-u5kmf8 — supersede / epoch-restore reasons suppress the
+    ;; reply outright; the canonical stale trace for those is emitted at
+    ;; supersede / restore time, not here.
+    (and (= :rf.http/aborted (:kind failure))
+         (reply-suppressing-abort-reason? (:reason failure)))
+    nil
+
+    ;; rf2-4teurt — the rf2-yrrpe2 actor-destroy obsolete-target suppression
+    ;; must ALSO gate this abort-precedence reclassification path (the
+    ;; finalise-failure! + finalise-success! sample-2 routes into this shared
+    ;; tail), not only the direct `dispatch-aborted!` path. An `:actor-destroyed`
+    ;; reclassification whose reply target addresses the destroyed actor ITSELF
+    ;; must NOT deliver a live `:status :cancelled` reply to the dead actor — a
+    ;; JVM completion-wins-the-CAS race reaches here (the abort-fn flips
+    ;; `:aborted?` then loses the once-only CAS to the whenComplete thread, which
+    ;; reclassifies via `aborted-snapshot`). It lowers to the canonical
+    ;; `:status :stale` / `:work/status :suppressed` outcome, matching
+    ;; `dispatch-aborted!`. The `:rf.http/aborted` error trace already fired
+    ;; above; only the app delivery is replaced by the stale-suppressed trace.
+    ;; `(:actor-id failure)` is the destroyed actor's id carried from the abort
+    ;; snapshot (`aborted-failure`), falling back to the ctx's actor-id.
+    (and (= :rf.http/aborted (:kind failure))
+         (= :actor-destroyed (:reason failure))
+         (http-reply/actor-destroy-target-obsolete?
+           (reply-target-id ctx) (:actor-id failure)))
+    (emit-actor-destroy-stale-trace! (reply-ctx ctx))
+
+    :else
+    (dispatch-failure! ctx failure))))
 
 (defn- finalise-success! [ctx accepted]
   ;; rf2-wez75 — abort-precedence check. Two sampling points:

--- a/implementation/http/src/re_frame/http/transport.cljc
+++ b/implementation/http/src/re_frame/http/transport.cljc
@@ -480,6 +480,14 @@
                          sensitive?
                          {:frame (:frame ctx)})]
         (trace/emit-error! :rf.http/aborted redacted)))
+    ;; rf2-k47b3d — an abort is TERMINAL for this request-id (this is the
+    ;; direct abort-fn choke: user / actor-destroy / supersede / epoch-restore
+    ;; all land here). Evict the issuance counter so an unbounded distinct-id
+    ;; space does not accumulate a permanent entry. Conditional-atomic: a
+    ;; supersede has ALREADY bumped the counter past this (superseded) attempt's
+    ;; issuance, so the evict skips and the live successor keeps the id; only a
+    ;; genuinely-quiescent id is dropped.
+    (registry/evict-issuance-on-completion! (:request-id ctx) (:issuance ctx))
     (cond
       ;; Per rf2-lxd3 (supersede) / rf2-u5kmf8 (epoch-restore) — these reasons
       ;; suppress the reply (the cancellation replaces the original outcome; the
@@ -641,6 +649,9 @@
     (finalise-failure! ctx (aborted-failure ctx abort-state))
     (when-not (already-replied? ctx)
       (registry/clear-in-flight! (:request-id ctx) (:handle ctx))
+      ;; rf2-k47b3d — terminal completion: evict this id's issuance counter
+      ;; (conditional-atomic; skips when a live re-issue has bumped past it).
+      (registry/evict-issuance-on-completion! (:request-id ctx) (:issuance ctx))
       (if-let [post-cas-abort (aborted-snapshot ctx)]
         ;; Sample (2): abort flipped between our pre-CAS sample and
         ;; our CAS-win. We hold the once-only token AND have cleared the
@@ -726,6 +737,11 @@
                         (aborted-failure ctx abort-state)
                         failure)]
       (registry/clear-in-flight! (:request-id ctx) (:handle ctx))
+      ;; rf2-k47b3d — terminal completion: evict this id's issuance counter
+      ;; (conditional-atomic; skips when a live re-issue has bumped past it, so
+      ;; a superseded-then-reclassified attempt does not drop the successor's
+      ;; live counter).
+      (registry/evict-issuance-on-completion! (:request-id ctx) (:issuance ctx))
       ;; rf2-sixs3 — the redact + emit-error! + supersede-suppressed
       ;; dispatch tail is shared with finalise-success!'s sample-(2) abort
       ;; path via `emit-and-dispatch-failure!`. We have already won the

--- a/implementation/http/src/re_frame/http/transport_cljs.cljc
+++ b/implementation/http/src/re_frame/http/transport_cljs.cljc
@@ -421,6 +421,15 @@
           :url     url}
 
          :else
+         ;; rf2-6pcz0d — `:cause` is the rejection CLASS NAME string, not the
+         ;; raw js/Error. A raw Error is not EDN-serializable, so it broke
+         ;; off-box capture / Tool-Pair / Xray serialization of both the reply
+         ;; (reply.cljc's EDN-serializable contract) and the `:rf.http/transport`
+         ;; trace, AND slipped past the privacy `:cause` redactor's `(string?
+         ;; …)` guard (privacy.cljc:364). `(.-name err)` matches BOTH sibling
+         ;; paths: the JVM `classify-jvm-error` (`:cause cls`, transport_jvm.cljc)
+         ;; and the CLJS `prepare-body!` (`:cause (some-> (.-name err))`,
+         ;; transport.cljc). `:message` still carries the human message.
          {:kind    :rf.http/transport
           :message (or (.-message err) (str err))
-          :cause   err}))))
+          :cause   (some-> err .-name)}))))

--- a/implementation/http/test/re_frame/http_actor_destroy_stale_test.clj
+++ b/implementation/http/test/re_frame/http_actor_destroy_stale_test.clj
@@ -219,3 +219,79 @@
         (finally
           (trace/unregister-listener! ::yrrpe2-2)
           (stop-server! srv))))))
+
+;; ---- (3) rf2-4teurt — the abort-precedence RECLASSIFICATION path -----------
+;; ----     (JVM completion-wins-the-CAS race) must apply the SAME obsolete- --
+;; ----     target stale suppression as the direct dispatch-aborted! path -----
+
+(deftest completion-wins-cas-obsolete-target-suppresses-stale-on-destroy
+  (testing "rf2-4teurt — the rf2-yrrpe2 obsolete-target suppression was enforced ONLY in dispatch-aborted! (the direct abort-fn path). The rf2-wez75 abort-precedence RECLASSIFICATION is a SECOND path to an :rf.http/aborted reply: when abort-on-actor-destroy flips :aborted? but LOSES the once-only :finalised? CAS to the completion (whenComplete) thread, finalise-success!/finalise-failure! sees the flipped cell, reclassifies to :actor-destroyed, and routes through emit-and-dispatch-failure!. Before the fix that tail's ONLY suppression gate was #{:request-id-superseded :epoch-restored}, so an :actor-destroyed reclassification with an obsolete (self-addressing) target delivered a LIVE :cancelled reply to the destroyed actor. The fix applies actor-destroy-target-obsolete? + emit-actor-destroy-stale-trace! inside emit-and-dispatch-failure! too."
+    (let [latch  (CountDownLatch. 1)
+          {:keys [port] :as srv} (start-blocking-server! latch 200 "application/json" "{\"too\":\"late\"}")
+          dispatched (atom [])
+          traces  (atom [])]
+      (try
+        (trace/register-listener! ::teurt-3
+          (fn [ev]
+            (swap! traces conj ev)
+            (when (= :rf.event/dispatched (:operation ev))
+              (swap! dispatched conj (first (:rf.event/v (:tags ev)))))))
+        (rf/reg-machine :worker/proc
+          {:initial :idle
+           :data    {:port port}
+           :actions {:fire-request
+                     (fn [{data :data}]
+                       {:fx [[:rf.http/managed
+                              {:request    {:url    (str "http://127.0.0.1:" (:port data) "/slow")
+                                            :method :get}
+                               :decode     :json
+                               :request-id [:worker/proc :slow]
+                               ;; reply addressed to the actor itself → obsolete
+                               ;; once the actor is under teardown
+                               :on-failure [:worker/proc#1 [:self/failed]]}]]})}
+           :states  {:idle    {:on {:start :running}}
+                     :running {:entry :fire-request}}})
+        (rf/reg-machine :sup/flow
+          {:initial :idle
+           :states
+           {:idle    {:on {:start :working}}
+            :working {:spawn {:machine-id :worker/proc
+                               :start      [:start]}
+                      :on    {:cancel :idle}}}})
+        (rf/dispatch-sync [:sup/flow [:start]])
+        (await-condition! #(seq (http-managed/actor-in-flight-snapshot)))
+        (is (contains? (http-managed/actor-in-flight-snapshot) :worker/proc#1))
+        (let [self-dispatches-before (count (filter #{:worker/proc#1} @dispatched))
+              ;; Reach the LIVE in-flight handle and reproduce Path B
+              ;; DETERMINISTICALLY: flip its abort-precedence cell EXACTLY as
+              ;; abort-on-actor-destroy does (:reason :actor-destroyed + the
+              ;; actor's own id) but WITHOUT firing the abort-fn — so the
+              ;; once-only :finalised? CAS stays open and the completion thread
+              ;; (released next) WINS it, driving the reclassification through
+              ;; finalise-* → emit-and-dispatch-failure! rather than through
+              ;; dispatch-aborted!. This isolates the exact reclassification
+              ;; path from the inherently-flaky real thread race.
+              handle (first (get (http-managed/actor-in-flight-snapshot) :worker/proc#1))]
+          (is (some? handle) "the actor-bound in-flight handle is reachable")
+          (is (some? (:aborted? handle)) "the handle carries the abort-precedence cell")
+          (reset! (:aborted? handle) {:reason :actor-destroyed :actor-id :worker/proc#1})
+          ;; Release the server: the completion thread runs finalise-* with the
+          ;; flipped cell and the CAS still open → the reclassification path.
+          (.countDown latch)
+          ;; The canonical stale-suppression trace must land — proof the
+          ;; obsolete suppression fired on THIS path (not a live delivery).
+          (await-condition! #(seq (stale-traces @traces)))
+          (let [tags (:tags (first (stale-traces @traces)))]
+            (is (= :stale (:rf.reply/status tags))
+                "the reclassified obsolete completion lowers to :status :stale")
+            (is (= :suppressed (:rf.reply/work-status tags)))
+            (is (= :rf.http/actor-destroyed-target-obsolete (:rf.reply/stale-reason tags))))
+          ;; Quiescence: the obsolete self-addressed reply MUST NOT be
+          ;; dispatched. Before the fix, emit-and-dispatch-failure! delivered a
+          ;; live :cancelled reply to :worker/proc#1 here.
+          (Thread/sleep 150)
+          (is (= self-dispatches-before (count (filter #{:worker/proc#1} @dispatched)))
+              "the abort-precedence reclassification MUST NOT deliver a live :cancelled reply to the destroyed actor's self-addressed target"))
+        (finally
+          (trace/unregister-listener! ::teurt-3)
+          (stop-server! srv))))))

--- a/implementation/http/test/re_frame/http_cljs_test.cljs
+++ b/implementation/http/test/re_frame/http_cljs_test.cljs
@@ -9,7 +9,8 @@
 
   Also covers rf2-r40km — the CLJS-only `:rf.http/cors` classification
   branch of `re-frame.http.transport-cljs/classify-cljs-error`."
-  (:require [cljs.test :refer-macros [deftest is testing async]]
+  (:require [cljs.reader :as edn]
+            [cljs.test :refer-macros [deftest is testing async]]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
@@ -179,6 +180,32 @@
           out (classify-cljs-error err "https://other.invalid/x")]
       (is (= :rf.http/transport (:kind out))
           "non-TypeError stays at :rf.http/transport regardless of URL"))))
+
+(deftest classify-transport-cause-is-edn-serializable-string
+  (testing "rf2-6pcz0d — the generic-rejection `:rf.http/transport` branch
+  stores `:cause` as the rejection CLASS-NAME STRING (`(.-name err)`), NOT the
+  raw js/Error object. The failure map rides `:error` on the canonical reply
+  (reply.cljc's EDN-serializable contract) and the `:rf.http/transport` trace;
+  a raw js/Error is NOT EDN-serializable (off-box capture / Tool-Pair / Xray
+  would throw on serialize) and would ALSO slip past the privacy `:cause`
+  redactor's `(string? …)` guard. This matches BOTH sibling paths — the JVM
+  `classify-jvm-error` (`:cause` = class name) and the CLJS `prepare-body!`
+  (`:cause` = `(.-name err)`)."
+    (let [err (js/Error. "connection-reset")
+          out (classify-cljs-error err "/api/items")]
+      (is (= :rf.http/transport (:kind out)))
+      (is (string? (:cause out))
+          ":cause is a STRING (the error class name), not the raw js/Error")
+      (is (= "Error" (:cause out))
+          ":cause is `(.-name err)` — \"Error\" for a plain js/Error")
+      (is (= "connection-reset" (:message out))
+          ":message still carries the human message")
+      ;; Adversarial EDN round-trip: a raw js/Error `:cause` prints as an
+      ;; unreadable `#object[…]` tag, so `read-string` would THROW (or not
+      ;; round-trip) before the fix. A string `:cause` round-trips cleanly,
+      ;; proving the whole failure map is EDN-serializable end to end.
+      (is (= out (edn/read-string (pr-str out)))
+          "the transport failure map round-trips through EDN (pr-str → read-string)"))))
 
 ;; ---- rf2-u5xwa — `cross-origin?` heuristic under a deterministic origin --
 

--- a/implementation/http/test/re_frame/http_managed_test.clj
+++ b/implementation/http/test/re_frame/http_managed_test.clj
@@ -19,6 +19,7 @@
             [re-frame.http.decode :as http-decode]
             [re-frame.http.encoding :as http-encoding]
             [re-frame.http.managed :as http-managed]
+            [re-frame.http.registry :as registry]
             [re-frame.late-bind :as late-bind]
             ;; rf2-cdmle — the canned-stub fxs no longer register at
             ;; `re-frame.http.managed` load time. This test file uses
@@ -2265,3 +2266,58 @@
           (re-frame.http.test-support/uninstall-managed-request-stubs!)
           (trace/unregister-listener! listener-id)
           (late-bind/set-fn! :router/dispatch! original))))))
+
+;; ---- rf2-k47b3d — issuance-counter eviction bounds the map -----------------
+
+(deftest issuance-counter-evicts-on-completion
+  (testing "rf2-k47b3d — a request-id's issuance counter is EVICTED when its
+  final attempt reaches a terminal completion, so an app minting an UNBOUNDED
+  distinct-id space (e.g. `[:fetch-doc uuid]` over an unbounded id space) does
+  NOT accumulate one permanent `issuance-counters` entry per id ever requested
+  on a long-running JVM (the leak the monotonic-forever design carried)."
+    (registry/reset-issuance-counters-for-test!)
+    (is (zero? (registry/issuance-counter-count)))
+    ;; Adversarial: 500 DISTINCT single-issuance request-ids, each issued once
+    ;; then completed. Pre-fix the map would end holding 500 entries; the
+    ;; conditional-atomic evict on completion keeps it at zero.
+    (doseq [i (range 500)]
+      (let [rid      [:fetch-doc i]
+            issuance (registry/next-issuance! rid)]
+        (is (= 1 issuance) "a fresh distinct id starts at issuance 1")
+        (is (= 1 (registry/issuance-counter-count))
+            "exactly one live counter while the request is in flight")
+        (registry/evict-issuance-on-completion! rid issuance)
+        (is (zero? (registry/issuance-counter-count))
+            "the counter is evicted the moment the request completes")))
+    (is (zero? (registry/issuance-counter-count))
+        "the map stays bounded across 500 distinct single-issuance request-ids")))
+
+(deftest issuance-counter-eviction-preserves-live-successor
+  (testing "rf2-k47b3d — the eviction is CONDITIONAL-ATOMIC (evict only when
+  the counter still equals the completing attempt's issuance), preserving the
+  rf2-azcmd3 anti-collision invariant: a SUPERSEDED attempt's terminal eviction
+  MUST NOT drop the live successor's counter, because `next-issuance!` already
+  bumped it past the superseded attempt's issuance BEFORE the supersede."
+    (registry/reset-issuance-counters-for-test!)
+    (let [rid [:search-box :q]
+          n1  (registry/next-issuance! rid)   ; attempt A: issuance 1
+          n2  (registry/next-issuance! rid)]  ; supersede → attempt B: issuance 2
+      (is (= 1 n1))
+      (is (= 2 n2) "the superseding attempt gets a distinct, higher issuance")
+      ;; Attempt A (the SUPERSEDED one) terminates. Its evict keys on issuance 1,
+      ;; but the counter is already at 2 → the atomic compare-and-drop SKIPS.
+      (registry/evict-issuance-on-completion! rid n1)
+      (is (= 1 (registry/issuance-counter-count))
+          "the superseded attempt's eviction does NOT drop the live counter")
+      (is (= 3 (registry/next-issuance! rid))
+          "the counter survived at 2, so the next issuance is 3 — no work-id collision")
+      ;; The final live attempt terminates with the counter at its own issuance.
+      (registry/evict-issuance-on-completion! rid 3)
+      (is (zero? (registry/issuance-counter-count))
+          "the id's final attempt evicts cleanly, bounding the map")))
+  ;; A nil request-id never had a counter (anonymous requests stay at issuance 1
+  ;; without touching the map) — eviction is a no-op.
+  (registry/reset-issuance-counters-for-test!)
+  (registry/evict-issuance-on-completion! nil 1)
+  (is (zero? (registry/issuance-counter-count))
+      "evicting a nil request-id is a no-op"))


### PR DESCRIPTION
Three correctness fixes on the `implementation/http` transport surface, from the 2026-07-09 correctness-review. One commit per bead.

## rf2-6pcz0d — CLJS transport error `:cause` was a raw js/Error (P2)
`classify-cljs-error`'s generic-rejection branch stored the RAW `js/Error` under `:cause`. That failure map rides `:error` on the canonical reply (reply.cljc's EDN-serializable contract) and the `:rf.http/transport` trace; a raw Error is not EDN-serializable, so off-box capture / Tool-Pair / Xray serialization threw, and it slipped past the privacy `:cause` redactor's `(string? …)` guard. Fixed to `(some-> err .-name)` — the class-name string — matching BOTH sibling paths (JVM `classify-jvm-error`, CLJS `prepare-body!`).

## rf2-4teurt — obsolete-target suppression bypassed on the abort-precedence path (P2)
The rf2-yrrpe2 actor-destroy obsolete-target suppression was enforced ONLY in `dispatch-aborted!`. The rf2-wez75 abort-precedence reclassification (`finalise-failure!` + `finalise-success!` sample-2 → `emit-and-dispatch-failure!`) had only the `#{:request-id-superseded :epoch-restored}` gate, so a JVM completion-wins-the-CAS race delivered a LIVE `:cancelled` reply to a destroyed actor. Fixed by applying `actor-destroy-target-obsolete?` + `emit-actor-destroy-stale-trace!` inside `emit-and-dispatch-failure!`, matching `dispatch-aborted!`. Ordinary targets / `:user` aborts keep live delivery (unchanged).

## rf2-k47b3d — issuance-counters grew unboundedly (P3, long-running-JVM leak)
`next-issuance!` recorded a permanent entry per distinct `:request-id` and never evicted on completion — a leak for apps minting unbounded distinct request-ids. Added `evict-issuance-on-completion!`: a single-`swap!` CONDITIONAL-ATOMIC drop that evicts only when the counter still equals the completing attempt's issuance. That guard preserves the rf2-azcmd3 anti-collision invariant (a supersede has already bumped the counter past the superseded attempt, so the evict skips and the live successor keeps the id). Wired in at the three TERMINAL sites only (`finalise-success!`, `finalise-failure!`, `dispatch-aborted!`) — never the retry-clear / supersede-clear paths.

## Adversarial tests (≥1 per fix)
- **rf2-6pcz0d** (`http_cljs_test.cljs`): a generic transport failure's `:cause` is a string and the whole failure map round-trips through EDN (`pr-str` → `read-string`).
- **rf2-4teurt** (`http_actor_destroy_stale_test.clj`): deterministic Path B — the in-flight handle's `:aborted?` cell is flipped to `:actor-destroyed` WITHOUT firing the abort-fn (so the released completion wins the once-only CAS), and the self-addressed reply is stale-suppressed, not delivered.
- **rf2-k47b3d** (`http_managed_test.clj`): 500 distinct single-issuance ids leave the map at zero; a superseded attempt's terminal eviction does NOT drop the live successor's counter (next issuance is still 3, no collision); nil id is a no-op.

## Quality gates
- `cd implementation && npm run test:cljs` → **PASS** (8306 tests, 38192 assertions, 0 failures, 0 errors)
- `cd implementation/http && clojure -M:test` → **PASS** (465 tests, 3648 assertions, 0 failures, 0 errors)
- Full spine deferred to CI.

## Stance
Pre-alpha, no back-compat shims; ELEGANCE + CLARITY + CORRECTNESS. Each fix aligns a divergent path with an existing sibling contract rather than adding new machinery; the eviction is a single conditional-atomic `swap!` with no timestamps or background sweep.
