### PR TITLE
fix(examples): seed login-with-stories form slice; drop cells dead registrations (rf2-itw3d3 +1)

### DIFF
--- a/examples/core/login/stories_host.cljs
+++ b/examples/core/login/stories_host.cljs
@@ -55,17 +55,30 @@
 
 ;; -- The live-app frame ----------------------------------------------------
 ;;
-;; The live `#/` surface needs the same demo-HTTP override the standalone
-;; example uses, so `:rf.http/managed` lands on the in-process
-;; `:auth.login.demo/managed-stub` and not on a backend that isn't there.
+;; The live `#/` surface needs the same two pieces of frame config the
+;; standalone example's `login.core/run` sets up, so this hand-rolled frame
+;; behaves identically:
+;;
+;; - `:fx-overrides` swaps in the in-process demo backend, so
+;;   `:rf.http/managed` lands on `:auth.login.demo/managed-stub` and not on
+;;   a backend that isn't there.
+;; - `:initial-events` seeds the login-form slice at [:auth :login-form]
+;;   *before* the first render. Drop it and the inputs read `nil` for their
+;;   `:value` on that first paint — and React quietly demotes a `nil`-valued
+;;   input to an uncontrolled one, then logs the "changing an uncontrolled
+;;   input to be controlled" warning on the first keystroke. The machine
+;;   seeds itself; the slice is app-db, so it has to be seeded here — exactly
+;;   as `login.core/run`'s frame-provider does.
+;;
 ;; Since the host is running its own boot from top to bottom, it sets the
-;; override up itself here rather than calling `login.core/run` (which would
+;; frame up itself here rather than calling `login.core/run` (which would
 ;; insist on running its own mount lifecycle).
 
 (defn- install-live-frame! []
   (rf/reg-frame :rf/default
-    {:doc          "Login showcase live-app frame."
-     :fx-overrides {:rf.http/managed :auth.login.demo/managed-stub}}))
+    {:doc            "Login showcase live-app frame."
+     :fx-overrides   {:rf.http/managed :auth.login.demo/managed-stub}
+     :initial-events [[:auth.login/initialise-form]]}))
 
 (rf/reg-view login-app []
   [:div {:style {:padding "1.5em" :font-family "system-ui, sans-serif"}}

--- a/examples/core/seven_guis/cells/core.cljs
+++ b/examples/core/seven_guis/cells/core.cljs
@@ -112,9 +112,8 @@
 
 (def CellsState
   [:map
-   [:cells       [:map-of :string CellEntry]]      ;; sparse: only edited cells exist
-   [:selected-id [:maybe :string]]
-   [:editing-id  [:maybe :string]]])
+   [:cells      [:map-of :string CellEntry]]       ;; sparse: only edited cells exist
+   [:editing-id [:maybe :string]]])
 
 ;; Hand the schema to the frame so every commit under `[:cells]` gets validated.
 ;; `reg-app-schema` needs a frame in scope, and `with-frame` supplies one by id
@@ -333,19 +332,12 @@
 (rf/reg-event :cells/initialise
   {:doc "Seed an empty spreadsheet."}
   (fn handler-cells-initialise [{:keys [db]} _]
-    {:db (assoc db :cells {:cells {} :selected-id "A1" :editing-id nil})}))
-
-(rf/reg-event :cells/select
-  {:doc "User clicked a cell. Marks it selected (without opening the editor)."}
-  (fn handler-cells-select [{:keys [db]} [_ id]]
-    {:db (assoc-in db [:cells :selected-id] id)}))
+    {:db (assoc db :cells {:cells {} :editing-id nil})}))
 
 (rf/reg-event :cells/start-editing
-  {:doc "Open the inline editor for cell `id` (also selects it)."}
+  {:doc "Open the inline editor for cell `id`."}
   (fn handler-cells-start-editing [{:keys [db]} [_ id]]
-    {:db (-> db
-        (assoc-in [:cells :selected-id] id)
-        (assoc-in [:cells :editing-id]  id))}))
+    {:db (assoc-in db [:cells :editing-id] id)}))
 
 (rf/reg-event :cells/commit
   {:doc "Save the user's edit. Parses any formula up front and stashes the AST
@@ -400,10 +392,6 @@
     (try
       (evaluate-cell id cells #{})
       (catch :default _ :error/eval))))
-
-(rf/reg-sub :cells/selected-id
-  {:doc "Id of the currently selected cell, or nil."}
-  (fn sub-cells-selected-id [db _] (get-in db [:cells :selected-id])))
 
 (rf/reg-sub :cells/editing-id
   {:doc "Id of the cell whose inline editor is open, or nil."}


### PR DESCRIPTION
Two correctness fixes on `examples/core`, from the 2026-07-09 correctness-review.

## rf2-itw3d3 (P2) — login-with-stories live `#/` never seeded the form slice

`login/stories_host.cljs`'s `install-live-frame!` re-implements the live-app frame by hand and copied only `:fx-overrides` from `login.core/run`'s frame-provider, **dropping** `:initial-events [[:auth.login/initialise-form]]`. On the `:examples/login-with-stories` build's `#/` page the form slice at `[:auth :login-form]` therefore stayed `nil`, the email/password inputs bound `:value nil` and rendered **uncontrolled**, and the first keystroke flipped them to controlled — firing React's "changing an uncontrolled input to be controlled" warning. That is the exact anti-pattern `login/core.cljs`'s own docstring teaches to avoid, live on a served page. Standalone `:examples/login` was unaffected.

**Fix:** add `:initial-events [[:auth.login/initialise-form]]` to the `reg-frame` config. `reg-frame`/`make-frame` runs `:initial-events` at construction (dispatch-sync to fixed point), so the slice is seeded before first render — mirroring `login.core/run`.

## rf2-y7ahud (P4) — cells: unused selection state

`seven_guis/cells/core.cljs` registered a `:cells/select` event, a `:cells/selected-id` sub, and a `:selected-id` slot in `CellsState`, but no view ever dispatched select or subscribed selected-id (7GUIs Cells mandates no selection highlight). The slot was seeded to `"A1"` and only ever written, never read.

**Fix (cleanest for a demo):** removed the dead registrations — schema slot, `:cells/initialise` seed, `:cells/select` event, `:cells/selected-id` sub — plus the redundant `selected-id` write in `:cells/start-editing`.

## Quality gates

Examples are test-free. Verified by compiling the affected builds (foreground):

- `npx shadow-cljs compile :examples/cells` → Build completed, 0 warnings
- `npx shadow-cljs compile :examples/login` → Build completed, 0 warnings
- `npx shadow-cljs compile :examples/login-with-stories` → Build completed, 0 warnings

Behaviour reasoned through: login-with-stories `#/` now seeds the form slice at frame construction → inputs are controlled from first render, no React warning; cells has no dead registrations and its behaviour (edit/commit/evaluate) is unchanged.

Full spine deferred to CI.

## Stance

Pre-alpha, no back-compat shims. ELEGANCE + CLARITY + CORRECTNESS + GOOD PRACTICE; no over-engineering. Touches only `examples/core`.