### PR TITLE
fix(schemas): redact sensitive :map-of keys; add security-tier map-of-key guard (rf2-6ijdgh +1)

### DIFF
--- a/implementation/schemas/src/re_frame/schemas/walker.cljc
+++ b/implementation/schemas/src/re_frame/schemas/walker.cljc
@@ -766,14 +766,47 @@
                   [:fallback schema aligned]))
               [:fallback schema aligned])
 
-            ;; Homogeneous index-bearing container — drop the index/key
-            ;; segment and descend into the element (or `:map-of` value)
-            ;; schema. `:vector`/`:sequential`/`:set` have one shared
-            ;; element schema; `:map-of`'s value schema is child 1. The
-            ;; index/key is not a declarable slot for these, so it is
-            ;; dropped to align with the walker's index-free decl-paths.
+            ;; `:map-of` — the `:in` KEY segment is normally dropped (like
+            ;; the homogeneous index-bearing ops below) and the walk descends
+            ;; into the VALUE schema (child 1), because a `:map-of` key is a
+            ;; navigable locator, not a declarable app-db slot. BUT when the
+            ;; KEY SCHEMA (child 0) is itself sensitive-or-opaque
+            ;; (rf2-6ijdgh) the key IS the secret, and that sensitivity is
+            ;; INVISIBLE once we descend into the value: an opaque / nested-
+            ;; opaque key contributes NO walker declaration (the pure-data
+            ;; walker's `:else` bailout silently skips a compiled `m/schema`
+            ;; key), so the `:ok` outcome below yields `leaf-sensitive? =
+            ;; false` and `sanitize-sensitive-path` never runs — the secret
+            ;; key ships VERBATIM in `:path` / `:reason` while `:value` /
+            ;; `:explain` are (correctly, via `schema-has-opaque-child?`)
+            ;; redacted: a fail-OPEN leak. Fail-SAFE instead: hand the whole
+            ;; `:map-of` node (carrying the consumed prefix) to the fallback
+            ;; so `schema-sensitive-at?` detects the sensitive/opaque key
+            ;; (`schema-has-sensitive?` / `opaque-nested-tail?` on the
+            ;; leftover) → `leaf-sensitive? = true` → the sanitiser runs and
+            ;; scrubs the secret key. Mirrors the fail-closed
+            ;; sensitive-or-opaque posture used everywhere else in this file.
+            ;; (For a VECTOR-form sensitive key the fallback is a no-op
+            ;; equivalence — the key already claims the base-path decl so the
+            ;; leaf resolves sensitive; forcing fallback keeps the two key
+            ;; shapes on one uniform path.)
+            (= op :map-of)
+            (let [key-schema (nth children 0 nil)]
+              (if (or (schema-has-sensitive? key-schema)
+                      (schema-has-opaque-child? key-schema))
+                [:fallback schema aligned]
+                (let [child (nth children 1 nil)]
+                  (if (some? child)
+                    (recur child (subvec in 1) aligned)
+                    [:fallback schema aligned]))))
+
+            ;; Homogeneous index-bearing container — drop the index
+            ;; segment and descend into the element schema.
+            ;; `:vector`/`:sequential`/`:set` have one shared element
+            ;; schema. The index is not a declarable slot for these, so it
+            ;; is dropped to align with the walker's index-free decl-paths.
             (contains? index-bearing-ops op)
-            (let [child (nth children (if (= op :map-of) 1 0) nil)]
+            (let [child (nth children 0 nil)]
               (if (some? child)
                 (recur child (subvec in 1) aligned)
                 [:fallback schema aligned]))
@@ -914,15 +947,26 @@
               ;; reports the key VALUE verbatim, e.g. `["secret-token-123"
               ;; :age]`). A `:map-of` key is normally a navigable locator and
               ;; is KEPT so `:path` stays a `get-in` locator — BUT when the
-              ;; KEY SCHEMA (child 0) itself declares `:sensitive?`
-              ;; (rf2-612mri), the key IS the secret and must be scrubbed,
-              ;; else it ships verbatim in `:path` / `:reason` despite
-              ;; `:value` / `:explain` being redacted. Descend into the
-              ;; VALUE schema (child 1) either way.
+              ;; KEY SCHEMA (child 0) is sensitive-or-opaque the key IS the
+              ;; secret and must be scrubbed, else it ships verbatim in
+              ;; `:path` / `:reason` despite `:value` / `:explain` being
+              ;; redacted. Two shapes:
+              ;;   - a VECTOR-form `:sensitive?` key (rf2-612mri) —
+              ;;     `schema-has-sensitive?` sees it directly; and
+              ;;   - a COMPILED / nested-opaque key (rf2-6ijdgh),
+              ;;     `(m/schema [:string {:sensitive? true}])` or
+              ;;     `[:and (m/schema …)]` — invisible to
+              ;;     `schema-has-sensitive?` (the pure-data walker cannot
+              ;;     introspect the compiled value), so we ALSO OR in
+              ;;     `schema-has-opaque-child?`, the recursive opaque-aware
+              ;;     predicate, matching the fail-closed posture the value /
+              ;;     explain redaction already takes on an opaque key. Descend
+              ;;     into the VALUE schema (child 1) either way.
               (= op :map-of)
               (let [key-schema (nth children 0 nil)
                     val-schema (nth children 1 nil)
-                    seg-out    (if (schema-has-sensitive? key-schema)
+                    seg-out    (if (or (schema-has-sensitive? key-schema)
+                                       (schema-has-opaque-child? key-schema))
                                  path-redacted-sentinel
                                  seg)]
                 (recur val-schema (subvec in 1) (conj out seg-out)))

--- a/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
@@ -552,6 +552,75 @@
           ":path keeps the navigable plain map-of key (\"a\") — no over-redaction")
       (is (= :rf/redacted (-> v :tags :value))))))
 
+;; ---- sensitive :map-of KEY that is OPAQUE / nested-opaque (rf2-6ijdgh) -------
+;; The rf2-612mri fix covered a VECTOR-form `:sensitive?` key
+;; (`[:string {:sensitive? true}]`), whose sensitivity the pure-data walker sees
+;; directly. The OPAQUE-key intersection was missed: a COMPILED `m/schema` value
+;; (or a vector wrapper hiding one, e.g. `[:and (m/schema …)]`) used as the
+;; `:map-of` KEY carries a `:sensitive?` flag Malli honours but the walker cannot
+;; introspect — so `schema-has-sensitive?` on the key returns false. Before the
+;; fix, `align-in-path`'s `:map-of` branch dropped the key and descended only the
+;; VALUE schema, leaving `leaf-sensitive? = false`, so `:path`/`:reason` were
+;; NEVER sanitised even though `:value`/`:explain` WERE redacted fail-closed (via
+;; `schema-has-opaque-child?`): the secret KEY shipped VERBATIM in `:path` /
+;; `:reason` — a fail-OPEN privacy leak. Verified on Malli 0.20.1 (JVM). The fix
+;; ORs `schema-has-opaque-child?` into BOTH the align-in-path key-position
+;; fallback (so the leaf resolves sensitive) AND the sanitize-sensitive-path
+;; key-scrub gate (so the key is scrubbed) — deep whole-structure scan, not just
+;; the value slot. These fail before the fix and pass after.
+
+(deftest app-db-validation-opaque-map-of-sensitive-key-scrubbed-from-path
+  (testing "rf2-6ijdgh — a :map-of with a COMPILED (m/schema) :sensitive? KEY and
+            a failing value child scrubs the secret key from :path AND :reason;
+            the secret never appears ANYWHERE in the whole emitted tag map
+            (deep whole-structure scan, not just the redacted :value slot)"
+    (let [v (app-db-failure-trace
+              [:by-token]
+              [:map-of (m/schema [:string {:sensitive? true}]) [:map [:age :int]]]
+              {:by-token {"SECRET-KEY-XYZ" {:age "not-an-int"}}}
+              :by-token/bad)]
+      (is (some? v) "a trace fired")
+      (is (true? (:sensitive? v))
+          "top-level :sensitive? stamp present — the opaque key fails closed")
+      (is (= :rf/redacted (-> v :tags :value)) ":value redacted")
+      (is (= :rf/redacted (-> v :tags :explain)) ":explain redacted")
+      ;; The sensitive opaque KEY is scrubbed to the sentinel; the navigable
+      ;; inner :age segment (a real :map key, not the secret) survives.
+      (is (= [:by-token :rf/redacted :age] (-> v :tags :path))
+          ":path's opaque sensitive :map-of key segment is the :rf/redacted sentinel")
+      (is (not (str/includes? (pr-str (-> v :tags :path)) "SECRET-KEY-XYZ"))
+          "the secret key does NOT appear in :path")
+      (is (not (str/includes? (pr-str (-> v :tags :reason)) "SECRET-KEY-XYZ"))
+          "the secret key does NOT appear in the generated :reason text")
+      ;; Belt-and-braces: a DEEP whole-structure scan of the entire tag map —
+      ;; the leak lived in :path/:reason while :value/:explain looked redacted.
+      (is (not (str/includes? (pr-str (:tags v)) "SECRET-KEY-XYZ"))
+          "the secret key does NOT appear ANYWHERE in the emitted tags"))))
+
+(deftest app-db-validation-nested-opaque-map-of-sensitive-key-scrubbed-from-path
+  (testing "rf2-6ijdgh — a :map-of whose KEY is a VECTOR WRAPPER hiding a compiled
+            m/schema (`[:and (m/schema [:string {:sensitive? true}])]`) — the
+            root is walkable EDN but the nested opaque child's :sensitive? is
+            invisible to the walker — still scrubs the secret key everywhere"
+    (let [v (app-db-failure-trace
+              [:by-token]
+              [:map-of [:and (m/schema [:string {:sensitive? true}])] [:map [:age :int]]]
+              {:by-token {"NESTED-SECRET-ABC" {:age "not-an-int"}}}
+              :by-token/bad)]
+      (is (some? v) "a trace fired")
+      (is (true? (:sensitive? v))
+          "top-level :sensitive? stamp present — the nested-opaque key fails closed")
+      (is (= :rf/redacted (-> v :tags :value)) ":value redacted")
+      (is (= :rf/redacted (-> v :tags :explain)) ":explain redacted")
+      (is (= [:by-token :rf/redacted :age] (-> v :tags :path))
+          ":path's nested-opaque sensitive :map-of key segment is the :rf/redacted sentinel")
+      (is (not (str/includes? (pr-str (-> v :tags :path)) "NESTED-SECRET-ABC"))
+          "the secret key does NOT appear in :path")
+      (is (not (str/includes? (pr-str (-> v :tags :reason)) "NESTED-SECRET-ABC"))
+          "the secret key does NOT appear in the generated :reason text")
+      (is (not (str/includes? (pr-str (:tags v)) "NESTED-SECRET-ABC"))
+          "the secret key does NOT appear ANYWHERE in the emitted tags"))))
+
 ;; ---- sensitive :map-of KEY nested under an ambiguous :or / :and wrapper -----
 ;; (rf2-jqx2at). `sanitize-sensitive-path` treated `:and` / `:or` as SINGLE-child
 ;; transparent wrappers and followed ONLY the first child. When a sensitive
@@ -609,6 +678,48 @@
         "single-child :or descends into its one branch and keeps the map key")
     (is (= [:k] (walker/sanitize-sensitive-path [:and [:map [:k :int]]] [:k]))
         "single-child :and descends into its one branch and keeps the map key")))
+
+(deftest sanitize-scrubs-opaque-map-of-key
+  (testing "rf2-6ijdgh — a :map-of whose KEY is a COMPILED m/schema (opaque to the
+            pure-data walker, so schema-has-sensitive? on it is false) is scrubbed
+            via the opaque-aware gate; the navigable inner :age key is kept"
+    (let [schema [:map-of (m/schema [:string {:sensitive? true}]) [:map [:age :int]]]
+          out    (walker/sanitize-sensitive-path schema ["SECRET-KEY-XYZ" :age])]
+      (is (= [:rf/redacted :age] out)
+          "the opaque sensitive :map-of key is scrubbed; the :age locator survives")
+      (is (not (some #{"SECRET-KEY-XYZ"} out))
+          "the secret key does NOT survive in the sanitized path"))))
+
+(deftest sanitize-scrubs-nested-opaque-map-of-key
+  (testing "rf2-6ijdgh — a :map-of KEY that is a vector wrapper hiding a compiled
+            m/schema (`[:and (m/schema …)]`) is scrubbed via the recursive
+            opaque-aware (schema-has-opaque-child?) gate"
+    (let [schema [:map-of [:and (m/schema [:string {:sensitive? true}])] [:map [:age :int]]]
+          out    (walker/sanitize-sensitive-path schema ["NESTED-SECRET-ABC" :age])]
+      (is (= [:rf/redacted :age] out))
+      (is (not (some #{"NESTED-SECRET-ABC"} out))
+          "the nested-opaque secret key does NOT survive in the sanitized path"))))
+
+(deftest schema-sensitive-at?-true-for-opaque-map-of-key
+  (testing "rf2-6ijdgh — schema-sensitive-at? (the leaf decision that gates path
+            sanitisation) is TRUE at a failing value under an opaque sensitive
+            :map-of key; before the fix align-in-path descended only the VALUE
+            schema and returned false, so the sanitiser never ran"
+    (is (true? (walker/schema-sensitive-at?
+                 [:map-of (m/schema [:string {:sensitive? true}]) [:map [:age :int]]]
+                 ["SECRET-KEY-XYZ" :age]))
+        "compiled m/schema key → leaf sensitive (fails closed)")
+    (is (true? (walker/schema-sensitive-at?
+                 [:map-of [:and (m/schema [:string {:sensitive? true}])] [:map [:age :int]]]
+                 ["NESTED-SECRET-ABC" :age]))
+        "nested-opaque [:and (m/schema …)] key → leaf sensitive (fails closed)")
+    ;; Regression guard: a NON-sensitive, NON-opaque :map-of key must stay a
+    ;; navigable locator (only the nested value is sensitive here) — no
+    ;; over-redaction of the key.
+    (is (false? (walker/schema-sensitive-at?
+                  [:map-of :string [:map [:plain :int]]]
+                  ["a" :plain]))
+        "plain :map-of key with a fully non-sensitive value → NOT leaf-sensitive")))
 
 ;; -- end-to-end via validate-app-schema! (:path / :reason / whole-tags egress) --
 

--- a/implementation/security/test/re_frame/security/schema_redaction_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/schema_redaction_security_cljs_test.cljc
@@ -116,6 +116,17 @@
       [[[:string {:sensitive? true}] [sentinel]] rng])
     (fn [rng]
       (let [[wrap rng1] (gen/rand-nth rng [:map :vector :sequential :map-of :tuple
+                                           ;; rf2-gocef0 / rf2-6ijdgh — the
+                                           ;; sensitive :map-of KEY class. Every
+                                           ;; other :map-of shape here puts the
+                                           ;; sensitive slot in the VALUE; this
+                                           ;; arm plants the sentinel AS the key
+                                           ;; under a `:sensitive?` key schema, so
+                                           ;; Malli reports the secret verbatim as
+                                           ;; the :in KEY segment and the walker's
+                                           ;; :map-of key-scrub branch must scrub
+                                           ;; it from :path / :reason.
+                                           :map-of-key
                                            ;; rf2-ss06u.1 / rf2-ss06u.2 — the
                                            ;; set-element-value `:path` leak
                                            ;; and the consumed-ancestor
@@ -138,6 +149,18 @@
 
           :map-of
           [[[:map-of :string inner-schema] {"k" inner-val}] rng2]
+
+          ;; rf2-gocef0 / rf2-6ijdgh — the sensitive slot is the :map-of KEY
+          ;; (not the value): [:map-of [:string {:sensitive? true}] inner], the
+          ;; sentinel planted AS the key. Malli reports the failing key VALUE
+          ;; verbatim as the :in segment, so `sanitize-sensitive-path`'s
+          ;; :map-of key-scrub branch must scrub it from :path / :reason — the
+          ;; one collection-navigation-segment-carries-the-secret sibling this
+          ;; tier pinned for its neighbours (:set element, :tuple) but not
+          ;; itself. inner-val ALSO carries the sentinel at the leaf, so BOTH
+          ;; the key AND the value must redact.
+          :map-of-key
+          [[[:map-of [:string {:sensitive? true}] inner-schema] {sentinel inner-val}] rng2]
 
           :tuple
           ;; sensitive slot is element 1; element 0 is an int filler.
@@ -238,6 +261,12 @@
              ["map-of-value"
               [:map-of :string [:map [:secret {:sensitive? true} :string]]]
               {"a" {:secret [sentinel]}}]
+             ;; rf2-gocef0 / rf2-6ijdgh — the sensitive :map-of KEY sibling
+             ;; (the secret is the KEY, not the value). Both the key AND the
+             ;; nested value carry the sentinel; both must redact.
+             ["map-of-sensitive-key"
+              [:map-of [:string {:sensitive? true}] [:map [:age :int]]]
+              {sentinel {:age [sentinel]}}]
              ["sequential"
               [:sequential [:map [:pw {:sensitive? true} :string]]]
               [{:pw [sentinel]}]]
@@ -286,6 +315,31 @@
           (str "the sentinel leaked into the :path tag: " (pr-str (-> v :tags :path))))
       (is (not (contains-sentinel? v))
           (str "the sentinel leaked somewhere in the trace: " (pr-str (:tags v)))))))
+
+(deftest map-of-sensitive-key-path-tag-carries-no-secret
+  (testing "rf2-gocef0 / rf2-6ijdgh - a :map-of with a :sensitive? KEY must not
+            ship the failing key VALUE in ANY slot, including the structural
+            :path tag; :path carries :rf/redacted for the key, not the secret.
+            The one collection-navigation-segment sibling pinned for its
+            neighbours (:set ss06u.1, :tuple, :cat/:catn) but not itself."
+    (let [v (failure-trace
+              [:map-of [:string {:sensitive? true}] [:map [:age :int]]]
+              {sentinel {:age [sentinel]}})]
+      (is (some? v) "a trace fired")
+      (is (true? (:sensitive? v)) "top-level :sensitive? stamp")
+      (is (= :rf/redacted (-> v :tags :value)) ":value redacted")
+      (is (= :rf/redacted (-> v :tags :explain)) ":explain redacted")
+      ;; The crux: the sensitive KEY is :rf/redacted in :path, not the secret;
+      ;; the navigable inner :age key (a real :map key) survives.
+      (is (= [:root :rf/redacted :age] (-> v :tags :path))
+          (str "the sensitive :map-of key must be :rf/redacted in :path: "
+               (pr-str (-> v :tags :path))))
+      (is (not (contains-sentinel? (-> v :tags :path)))
+          (str "the secret key leaked into the :path tag: " (pr-str (-> v :tags :path))))
+      (is (not (contains-sentinel? (-> v :tags :reason)))
+          (str "the secret key leaked into the :reason tag: " (pr-str (-> v :tags :reason))))
+      (is (not (contains-sentinel? v))
+          (str "the secret leaked somewhere in the trace: " (pr-str (:tags v)))))))
 
 (deftest ss06u-ancestor-sensitive-wrapper-corpus-all-redacted
   (testing "rf2-ss06u.2 - a sensitive container whose failing leaf is under a

--- a/implementation/security/test/re_frame/security/validation_redaction_invariant_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/validation_redaction_invariant_security_cljs_test.cljc
@@ -690,7 +690,7 @@
     (fn [rng]
       [[[:string {:sensitive? true}] [sentinel]] rng])
     (fn [rng]
-      (let [[wrap rng1] (gen/rand-nth rng [:map :vector :sequential :map-of :tuple
+      (let [[wrap rng1] (gen/rand-nth rng [:map :vector :sequential :map-of :map-of-key :tuple
                                            :set :and :or :multi :orn])
             [[inner-schema inner-val] rng2] ((gen-shape (dec depth)) rng1)]
         (case wrap
@@ -699,6 +699,12 @@
           :vector     [[[:vector inner-schema] [inner-val]] rng2]
           :sequential [[[:sequential inner-schema] [inner-val]] rng2]
           :map-of     [[[:map-of :string inner-schema] {"k" inner-val}] rng2]
+          ;; rf2-gocef0 / rf2-6ijdgh — sensitive :map-of KEY: the sentinel is
+          ;; planted AS the key under a `:sensitive?` key schema; the walker's
+          ;; :map-of key-scrub branch must scrub it from :path / :reason across
+          ;; every callable validation kind. Both key and value carry the
+          ;; sentinel; both must redact.
+          :map-of-key [[[:map-of [:string {:sensitive? true}] inner-schema] {sentinel inner-val}] rng2]
           :tuple      [[[:tuple :int inner-schema] [0 inner-val]] rng2]
           :set        (let [[k rng3] (gen-key rng2)]
                         [[[:set [:map [k inner-schema]]] #{{k inner-val}}] rng3])


### PR DESCRIPTION
## Summary

Closes a privacy fail-OPEN leak (rf2-6ijdgh, P2) and adds its guarding fixture in the adversarial-property security tier (rf2-gocef0, P3).

A compiled `m/schema` value (or a vector wrapper hiding one, e.g. `[:and (m/schema …)]`) used as a `:sensitive?` `:map-of` **KEY** leaked the secret key VERBATIM into the schema-validation-failure trace's `:path` and `:reason` tags — and thus the whole serialized `:tags` egress to trace listeners / Xray / pair-MCP. Verified on Malli 0.20.1 (JVM). The `:value`/`:explain` slots redacted correctly (via `schema-has-opaque-child?`), so the trace **looked** redacted while the secret key rode out through `:path`/`:reason`.

### rf2-6ijdgh — the fix (`implementation/schemas/src/re_frame/schemas/walker.cljc`)

Two opaque-blind loci, both fixed to the fail-closed sensitive-or-opaque posture used everywhere else in the file:

1. **`align-in-path` `:map-of` branch** dropped the key segment and descended only the VALUE schema, never inspecting the KEY schema. An opaque/nested-opaque key contributes no walker declaration, so `leaf-sensitive?` stayed `false` and `sanitize-sensitive-path` never ran. Now: when the key schema is sensitive-or-opaque, the whole `:map-of` node is handed to the fail-SAFE fallback so the leaf resolves sensitive.
2. **`sanitize-sensitive-path` `:map-of` key-scrub** gated on `schema-has-sensitive?` (not opaque-aware). Now ORs in `schema-has-opaque-child?` (the recursive opaque-aware predicate).

The VECTOR-form sensitive key (rf2-612mri) already worked; this closes the opaque-KEY intersection missed by rf2-u9bjgr/rf2-hi0tf8 and rf2-612mri.

Adversarial tests in `schemas_sensitive_test.clj`: a compiled-`m/schema` key and a nested-opaque `[:and (m/schema …)]` key assert the secret appears **nowhere** in the whole tag map (deep whole-structure scan, not just the value slot: `:path` → `[:by-token :rf/redacted :age]`); plus direct `sanitize-sensitive-path` / `schema-sensitive-at?` unit tests and a non-sensitive-key no-over-redaction guard.

### rf2-gocef0 — the security-tier guard (`implementation/security/test/…`)

Every `:map-of` shape the tier generated/pinned put the sensitive slot in the VALUE position, so a regression to the key-scrub branch would slip past the whole-event deep scan. Adds a `:map-of-key` arm to both `gen-shape` generators (sentinel planted AS the key under a `:sensitive?` key schema; inner-val also carries the sentinel, so BOTH key and value must redact), a `map-of-sensitive-key` hostile-corpus entry, and a dedicated `map-of-sensitive-key-path-tag-carries-no-secret` test pinning the `:path` tag.

## Quality gates

Foreground, from the worktree (full spine deferred to CI):

| Gate | Result |
| --- | --- |
| `implementation/schemas` — `clojure -M:test` (JVM) | 339 tests / 18944 assertions, **0 failures, 0 errors** |
| `implementation/security` — `clojure -M:test` (JVM) | 92 tests / 666 assertions, **0 failures, 0 errors** |
| `implementation` — `npm run test:security` (CLJS/node) | 93 tests / 673 assertions, **0 failures, 0 errors** |
| `implementation` — `npm run test:cljs` (CLJS/node) | 8306 tests / 38198 assertions, **0 failures, 0 errors** |

## Stance

Pre-alpha, no back-compat shims. Privacy leaks are HIGH severity: this is a fail-OPEN egress leak of a secret used as a map key. The fix follows the file's existing fail-closed sensitive-or-opaque posture (no new mechanism), and the tests verify both KEY and VALUE redaction via deep whole-structure scans. Scope limited to `implementation/schemas` + `implementation/security`.
