### PR TITLE
fix(examples): release editor lease on edit-new/delete; harden markdown safe-url; register flow once (rf2-kkqy6q +2)

### DIFF
--- a/examples/real-apps/realworld_resources/article_editor.cljs
+++ b/examples/real-apps/realworld_resources/article_editor.cljs
@@ -212,12 +212,25 @@
 
 (rf/reg-event :editor/initialise
   {:doc "Create-mode entry (`:realworld.editor/new` `:on-match`). Resets the editor
-         slice to a blank draft, clears any leftover save instance, and registers
-         the `:editor/can-submit?` flow against the dispatching frame."}
+         slice to a blank draft, clears any leftover save instance, registers the
+         `:editor/can-submit?` flow against the dispatching frame, and — because
+         edit and create share the one `editor-page` component (core.cljs), so an
+         edit -> new navigation never unmounts it — releases the outgoing edit
+         lease (mirroring the slug-change branch of `:editor/load-article`) so its
+         `:realworld/article` cache entry can go inactive and GC."}
   (fn [{:keys [db]} _]
-    {:db (assoc db :editor (editor-slice))
-     :fx [[:dispatch [:rf.mutation/clear {:instance save-instance}]]
-          [:rf.fx/reg-flow can-submit-flow]]}))
+    (let [prev-slug (get-in db [:editor :slug])]
+      {:db (assoc db :editor (editor-slice))
+       :fx (cond-> [[:dispatch [:rf.mutation/clear {:instance save-instance}]]
+                    [:rf.fx/reg-flow can-submit-flow]]
+             ;; edit -> new re-uses the same `editor-page` component, so no
+             ;; unmount fires to release the edit lease — and blanking the slice
+             ;; to a nil slug here would strand it. Release the outgoing slug's
+             ;; lease before the slice is cleared, or its `:realworld/article`
+             ;; cache entry stays pinned active for the rest of the session
+             ;; (N edits -> N leaked entries).
+             prev-slug
+             (conj [:dispatch [:editor/release-article prev-slug]]))})))
 
 (rf/reg-event :editor/load-article
   {:doc "Edit-mode entry (`:realworld.editor/edit` `:on-match`). Seeds the draft
@@ -355,9 +368,19 @@
               [:dispatch [:rf.route/navigate :realworld.article/show {:slug (:slug article)}]]]})
 
       :else
-      {:db (assoc db :editor (editor-slice))
-       :fx [[:dispatch [:rf.mutation/clear {:instance save-instance}]]
-            [:dispatch [:rf.route/navigate :realworld/home]]]})))
+      (let [prev-slug (get-in db [:editor :slug])]
+        {:db (assoc db :editor (editor-slice))
+         :fx (cond-> [[:dispatch [:rf.mutation/clear {:instance save-instance}]]]
+               ;; Release the deleted article's lease BEFORE the slice is cleared
+               ;; out from under it. The navigate-home below unmounts the editor,
+               ;; whose `:editor/release-article` (no slug) reads the editor
+               ;; slice's slug — but that's now nil, so it would release nothing
+               ;; and leak the lease (and the delete's `[:article slug]`
+               ;; invalidation could even refetch the just-deleted slug while the
+               ;; orphaned lease keeps it active). Releasing the captured
+               ;; outgoing slug here closes that gap.
+               prev-slug (conj [:dispatch [:editor/release-article prev-slug]])
+               true      (conj [:dispatch [:rf.route/navigate :realworld/home]]))}))))
 
 (rf/reg-event :editor/delete
   {:doc "Delete the article (edit mode only). Fires the delete mutation under the

--- a/examples/real-apps/realworld_resources/article_editor.cljs
+++ b/examples/real-apps/realworld_resources/article_editor.cljs
@@ -20,8 +20,9 @@
       into app-db at `[:editor :can-submit?]`. The submit handler then reads it as
       plain data (no subscribing mid-handler), and the submit button reads the same
       value through a plain sub over the flow's `:output-path`. The flow is
-      registered per-frame from `:editor/initialise` via `:rf.fx/reg-flow`, so it
-      binds to whatever frame the app booted on. See the flow glossary:
+      registered ONCE at boot from `:editor/register-flow` (dispatched by
+      `:app/initialise`) via `:rf.fx/reg-flow`, so it binds to the boot frame and
+      isn't re-registered on every editor entry. See the flow glossary:
       ../../../docs/core/glossary.md#flow.
 
    3. A navigation `:can-leave` guard. The editor route declares
@@ -118,10 +119,12 @@
 ;; through a plain sub over the `:output-path`. One derived fact, two readers, no
 ;; duplication. See the flow glossary: ../../../docs/core/glossary.md#flow.
 ;;
-;; It's registered per-frame via `:rf.fx/reg-flow` from `:editor/initialise` (not
-;; at ns-load), so it binds to whatever frame the app booted on. The flow's first
-;; walk fires on the next drain; a fresh editor starts invalid and clean anyway,
-;; so that one-event lag never carries a stale value.
+;; It's registered ONCE at boot via `:rf.fx/reg-flow` from `:editor/register-flow`
+;; (dispatched by `:app/initialise`, not at ns-load and not per route entry), so it
+;; binds to the boot frame and lives as long as it — the same lifetime as the
+;; `[:editor …]` slice it derives over. The flow's first walk fires on the next
+;; drain; a fresh editor starts invalid and clean anyway, so that one-event lag
+;; never carries a stale value.
 
 ;; The 3-slot triple `[flow-id metadata derive-fn]` (rf2-bqstzr) — the exact
 ;; shape both `reg-flow` and `:rf.fx/reg-flow` take, so `[:rf.fx/reg-flow
@@ -210,19 +213,34 @@
 ;; EVENTS
 ;; ============================================================================
 
+(rf/reg-event :editor/register-flow
+  {:doc "Boot-time one-shot: register the `:editor/can-submit?` flow ONCE against
+         the boot frame. Dispatched from `:app/initialise` at boot — NOT per route
+         entry. `:rf.fx/reg-flow` replaces by id, so re-registering on every
+         `/editor` entry wouldn't stack copies — but it WOULD leave the flow
+         registered after you leave the editor, quietly recomputing over the
+         editor slice for the rest of the session. Registering once at boot (the
+         flow lives as long as the frame, like the `[:editor …]` slice it derives
+         over) is the honest singleton shape; each route entry then only resets
+         the slice. (The http sibling reuses its same-named `:editor/initialise`
+         as this boot one-shot; here `:editor/initialise` is the create-route
+         `:on-match`, so the boot registration gets its own event.)"}
+  (fn [_ _]
+    {:fx [[:rf.fx/reg-flow can-submit-flow]]}))
+
 (rf/reg-event :editor/initialise
   {:doc "Create-mode entry (`:realworld.editor/new` `:on-match`). Resets the editor
-         slice to a blank draft, clears any leftover save instance, registers the
-         `:editor/can-submit?` flow against the dispatching frame, and — because
-         edit and create share the one `editor-page` component (core.cljs), so an
-         edit -> new navigation never unmounts it — releases the outgoing edit
-         lease (mirroring the slug-change branch of `:editor/load-article`) so its
-         `:realworld/article` cache entry can go inactive and GC."}
+         slice to a blank draft and clears any leftover save instance. Because
+         edit and create share the one `editor-page` component (core.cljs), an
+         edit -> new navigation never unmounts it, so this also releases the
+         outgoing edit lease (mirroring the slug-change branch of
+         `:editor/load-article`) so its `:realworld/article` cache entry can go
+         inactive and GC. The `:editor/can-submit?` flow is registered ONCE at
+         boot by `:editor/register-flow`, not per entry."}
   (fn [{:keys [db]} _]
     (let [prev-slug (get-in db [:editor :slug])]
       {:db (assoc db :editor (editor-slice))
-       :fx (cond-> [[:dispatch [:rf.mutation/clear {:instance save-instance}]]
-                    [:rf.fx/reg-flow can-submit-flow]]
+       :fx (cond-> [[:dispatch [:rf.mutation/clear {:instance save-instance}]]]
              ;; edit -> new re-uses the same `editor-page` component, so no
              ;; unmount fires to release the edit lease — and blanking the slice
              ;; to a nil slug here would strand it. Release the outgoing slug's
@@ -237,16 +255,16 @@
          from the existing article via a one-shot resource ensure under a
          releaseable lease, and asks to be told when that read settles with the
          ensure's call-site `:reply-to [:editor/article-loaded]` — no off-render
-         reaction. Registers the flow, clears any leftover save instance, and (on
-         a same-component `/editor/A` -> `/editor/B` re-match) releases the
-         outgoing slug's lease before taking the new one. The seeded baseline is
-         what gives the dirty-check something to compare against."}
+         reaction. Clears any leftover save instance, and (on a same-component
+         `/editor/A` -> `/editor/B` re-match) releases the outgoing slug's lease
+         before taking the new one. The `:editor/can-submit?` flow is registered
+         ONCE at boot by `:editor/register-flow`, not per entry. The seeded
+         baseline is what gives the dirty-check something to compare against."}
   (fn [{:keys [db] rt :rf.db/runtime} _]
     (let [slug      (get-in rt [:rf.runtime/routing :current :params :slug])
           prev-slug (get-in db [:editor :slug])]
       {:db (assoc db :editor (editor-slice slug blank-draft))
        :fx (cond-> [[:dispatch [:rf.mutation/clear {:instance save-instance}]]
-                    [:rf.fx/reg-flow can-submit-flow]
                     ;; Ensure the article read so the editor can seed its
                     ;; baseline. A fresh entry is a cache-hit (the `:reply-to`
                     ;; continuation fires immediately); otherwise it fetches and

--- a/examples/real-apps/realworld_resources/core.cljs
+++ b/examples/real-apps/realworld_resources/core.cljs
@@ -60,16 +60,19 @@
 ;; ============================================================================
 
 (rf/reg-event :app/initialise
-  {:doc "App boot. Seeds the two form drafts and nothing else. Session restore
-         is deliberately not here — it's its own `:initial-events` step
-         (`:auth/initialise`) so its recordable token coeffect can ride its own
-         dispatch. And the page reads (articles, tags, feed, …) aren't here
-         either: the route's `:resources` metadata pulls those in on the first
-         URL→route sync. Booting an app is mostly about deciding what NOT to do
-         up front."}
+  {:doc "App boot. Seeds the two form drafts and registers the editor's
+         `:editor/can-submit?` flow once (the boot one-shot `:editor/register-flow`
+         — the editor route's `:on-match` handlers deliberately do NOT re-register
+         it per entry). Session restore is deliberately not here — it's its own
+         `:initial-events` step (`:auth/initialise`) so its recordable token
+         coeffect can ride its own dispatch. And the page reads (articles, tags,
+         feed, …) aren't here either: the route's `:resources` metadata pulls those
+         in on the first URL→route sync. Booting an app is mostly about deciding
+         what NOT to do up front."}
   (fn [_ _]
     {:fx [[:dispatch [:auth.login-form/initialise]]
-          [:dispatch [:auth.register-form/initialise]]]}))
+          [:dispatch [:auth.register-form/initialise]]
+          [:dispatch [:editor/register-flow]]]}))
 
 ;; The JWT at [:auth :token] is both durable and sensitive — exactly the kind of
 ;; thing you don't want leaking off the box. The `:sensitive` effect marks it as

--- a/examples/real-apps/realworld_shared/markdown.cljs
+++ b/examples/real-apps/realworld_shared/markdown.cljs
@@ -53,25 +53,48 @@
   "Schemes a markdown link/image is allowed to navigate to / load."
   #{"http" "https" "mailto"})
 
+(defn- url-scheme
+  "The lower-cased URL scheme of `u` if it has one, else nil for a relative
+   reference. A scheme is the run of characters before the first ':' WHEN that
+   colon precedes the first '/', '?', or '#' — i.e. it delimits a scheme rather
+   than sitting inside a path/query/fragment. This mirrors how browsers (RFC
+   3986) parse a scheme: a colon in the first path segment IS a scheme, even
+   without a well-formed scheme name — which is exactly what a de-obfuscated
+   `javascript:` collapses back to. `u` is expected to be control-char-stripped
+   already (see `safe-url?`)."
+  [u]
+  (when-let [colon (str/index-of u ":")]
+    (let [seps (keep #(str/index-of u %) ["/" "?" "#"])
+          sep  (if (seq seps) (apply min seps) (count u))]
+      (when (< colon sep)
+        (str/lower-case (subs u 0 colon))))))
+
 (defn safe-url?
   "True when `url` is safe to place in an :href / :src. Allows the
    allowlisted absolute schemes (http/https/mailto) and scheme-relative
-   navigation (a relative path, an in-page #fragment, or `./`/`../`).
-   Rejects everything else — notably `javascript:`, `data:`, and
-   `vbscript:` URLs, the classic anchor/img XSS vectors."
+   navigation (a relative path, an in-page #fragment, `./`/`../`, or a
+   protocol-relative `//host`). Rejects everything else — notably
+   `javascript:`, `data:`, and `vbscript:` URLs, the classic anchor/img XSS
+   vectors, INCLUDING control-char-obfuscated variants (e.g. an ASCII TAB
+   spliced into `javascript:`) that a browser would collapse back into a live
+   scheme before it resolves the link."
   [url]
-  (let [u (str/trim (or url ""))]
-    (cond
-      (str/blank? u) false
-      ;; A leading scheme `foo:` — allow only the allowlisted set. The regex
-      ;; anchors at the start and refuses leading control/whitespace tricks
-      ;; (e.g. "java\tscript:") because those are not a valid scheme char run.
-      (re-find #"^[a-zA-Z][a-zA-Z0-9+.-]*:" u)
-      (let [scheme (str/lower-case (re-find #"^[a-zA-Z][a-zA-Z0-9+.-]*" u))]
-        (contains? safe-url-schemes scheme))
-      ;; No scheme → relative path / #fragment / `./`/`../` / protocol-
-      ;; relative. None can smuggle a script scheme, so it is safe navigation.
-      :else true)))
+  ;; Browsers strip ASCII tab/newline/CR (and ignore the other C0 control
+  ;; chars) from a URL before resolving its scheme, so a payload like
+  ;; "java<TAB>script:alert(1)" fires as javascript: on click. Detect the
+  ;; scheme against a copy with every ASCII control + space char removed, then
+  ;; run it through the allowlist — an unknown or obfuscated scheme is
+  ;; default-DENIED, never waved through the `:else` branch as if it were a
+  ;; relative URL (the bug the old `:else true` had: a non-matching scheme run
+  ;; fell through and was KEPT, contradicting this fn's own contract).
+  (let [u (str/replace (or url "") #"[\x00-\x20\x7f]" "")]
+    (if (str/blank? u)
+      false
+      (if-let [scheme (url-scheme u)]
+        (contains? safe-url-schemes scheme)
+        ;; No scheme → relative path / #fragment / `./`/`../` / protocol-
+        ;; relative. None can smuggle a script scheme, so it is safe navigation.
+        true))))
 
 (defn- scrub-attrs
   "Given a hiccup attribute map, drop any :href / :src whose URL is not


### PR DESCRIPTION
Three correctness fixes on `examples/real-apps`, from the 2026-07-09 correctness review. Each bead is its own commit.

## rf2-kkqy6q (P2) — editor leaks `:realworld/article` lease on edit→new and edit→delete
The resources editor mints `[:lease :editor/article slug]` in `:editor/load-article`, but two paths blanked the editor slice's slug to `nil` **without first releasing the lease**:
- **edit→new**: `core.cljs` renders both `:realworld.editor/new` and `/edit` as the same `[editor/editor-page]`, so `/editor/:slug → /editor` never unmounts the component. `:editor/initialise` blanked the slice and never released the prev slug's lease → orphaned, its `:realworld/article` cache entry pinned active for the session (N edits = N leaks).
- **edit→delete**: `:editor/replied`'s delete branch blanked the slice then navigated home; the resulting unmount fired `:editor/release-article` (no slug), which read the now-`nil` slice slug and released nothing.

**Fix**: capture `prev-slug` before resetting the slice and release it — in `:editor/initialise` (mirroring the slug-change branch of `:editor/load-article`) and in the `:editor/replied` delete branch (before the navigate-home unmount). Restores the file's own invariant that an app-minted lease has a matching release. `edit→save` and `edit→non-editor-route` were already correct and are untouched.

## rf2-0rwkj1 (P3) — shared markdown `safe-url?` allowed control-char scheme obfuscation
`realworld_shared/markdown.cljs` `safe-url?`'s `cond` fell to `:else true` for any string that didn't match the scheme regex, so `"java<TAB>script:alert(1)"` (the char run stops at the tab) was treated as a safe relative URL and **kept** on `:href`/`:src` — contradicting the fn's own comment. Browsers strip ASCII tab/newline/CR before scheme resolution, collapsing it back to `javascript:`. Since nextjournal `md/->hiccup` bypasses markdown-it's `validateLink`, this fn is the only defense for hiccup `:href`/`:src`.

**Fix**: strip ASCII control + space chars before scheme detection, then run any resulting scheme through the allowlist (default-**deny** unknown/obfuscated schemes) via a new `url-scheme` helper that matches RFC 3986 / browser parsing (a colon before the first `/`,`?`,`#` = scheme). Comment now matches code.

## rf2-xugvye (P4) — editor re-registered `can-submit?` flow per route-entry
`:editor/initialise` and `:editor/load-article` each emitted `[:rf.fx/reg-flow can-submit-flow]` on every editor entry — the exact per-entry re-registration the http sibling deliberately documents against (replace-by-id, but leaves the flow registered recomputing over the editor slice for the rest of the session).

**Fix** (mirrors the http variant's split): add a boot one-shot `:editor/register-flow`, dispatched once from `:app/initialise`, and drop the per-entry `reg-flow` so the route `:on-match` handlers only reset the slice. Because the resources `:editor/initialise` is itself the create-route `:on-match` (per-entry), it can't double as the boot one-shot the way the http variant's same-named event does — hence a separate boot event. Docstrings/comments updated.

## Quality gates
- `npx shadow-cljs compile examples/realworld-resources` → **Build completed. (303 files, 302 compiled, 0 warnings)**. This build pulls in `realworld_shared.markdown` (via `realworld_resources.views`), so all three changed files compiled.
- Examples are **test-free** (rf2-8cevm), so verification is compile + reasoning through corrected behaviour: edit→new and edit→delete now release the lease so GC can reclaim; `java<TAB>script:` is rejected; the flow is registered exactly once.
- No `implementation/` regression test added: the lease-leak is example-specific event-flow logic, and `safe-url?` lives in `examples/realworld_shared` (not on `implementation/`'s test classpath) — an implementation/ test would require putting example code on the framework test classpath. There are no existing realworld/markdown tests to extend. Flagging for reviewer if a home is wanted.
- Full spine deferred to CI.

## Stance
Pre-alpha, no back-compat shims; ELEGANCE + CLARITY + CORRECTNESS + GOOD PRACTICE. Minimal, focused changes on `examples/real-apps` only.
