### PR TITLE
fix(test-react): monotonic-sequence teardown-order assertion; drop dead render cell (rf2-mxu3e4 +1)

### DIFF
--- a/implementation/adapters/test-react/README.md
+++ b/implementation/adapters/test-react/README.md
@@ -36,7 +36,7 @@ timing, stay on Playwright.
 > body*, synchronously unmounts the previous panel's separately-tracked root.
 > The guard fires because React (the global render depth) is rendering
 > somewhere — the same condition React 18+ keys off, and the cross-root case
-> the old per-mount `:currently-rendering?` flag could not see. The companion
+> a per-mount render flag could not see. The companion
 > `deferred-unmount-after-render-is-safe-rf2-4l7t2-fix` proves the guard
 > discriminates in-render from after-render (the microtask-defer fix), so it is
 > not a blunt always-throw. The "**yes**" above now means "the bug condition is

--- a/implementation/adapters/test-react/src/re_frame/adapter/test_react.cljc
+++ b/implementation/adapters/test-react/src/re_frame/adapter/test_react.cljc
@@ -99,8 +99,9 @@
 ;;
 ;;   :id              — gensym tag (for log readability)
 ;;   :render-tree     — atom holding the currently-rendered tree
-;;   :lifecycle-log   — atom holding a vector of {:phase ... :at ms} entries;
-;;                      the test driver inspects this to assert ordering.
+;;   :lifecycle-log   — atom holding a vector of {:phase ... :seq n} entries;
+;;                      the test driver inspects this to assert ordering (`:seq`
+;;                      is the monotonic order-key — see `phase-seq`).
 ;;   :currently-rendering? — atom<boolean>; true while THIS mount's render is
 ;;                      in flight. Distinct from the global render-depth (see
 ;;                      below): this cell marks the self-render case, the
@@ -145,13 +146,21 @@
   []
   (pos? @render-depth))
 
-(defn- now-ms []
-  #?(:clj (System/currentTimeMillis)
-     :cljs (.now js/Date)))
+;; A process-global monotonic order-key stamped on every logged phase. A
+;; wall-clock timestamp is the wrong tool for teardown-ORDER assertions here:
+;; a whole cascade completes sub-millisecond, so `now-ms`-style timestamps
+;; collapse to the SAME integer and a `<=`-on-ms ORDER check is vacuous — it
+;; stays green even on a reversed (root-downward) teardown, the exact bug the
+;; check exists to catch. This counter increments once per logged phase, so a
+;; strict `<` over two phases' `:seq` values discriminates their REAL firing
+;; order and fails deterministically on a reversal. `dispose-adapter!` resets
+;; it per test (only relative order within a cascade matters, so the reset is
+;; hygiene — keeping the numbers small + deterministic across the suite).
+(defonce ^:private phase-seq (atom 0))
 
 (defn- log-phase! [mount phase & {:as extras}]
   (swap! (:lifecycle-log mount)
-         conj (merge {:phase phase :at (now-ms)} extras)))
+         conj (merge {:phase phase :seq (swap! phase-seq inc)} extras)))
 
 ;; Declared so `run-render!` (which invokes a render body that may mount
 ;; children) can call the mount seam defined below it.
@@ -386,6 +395,11 @@
   ;; that bypassed run-render! by hand cannot leak a stuck "rendering" state
   ;; into the next case.
   (reset! render-depth 0)
+  ;; Reset the monotonic phase order-key so each test's lifecycle log starts
+  ;; from a small, deterministic sequence. Only relative order within a single
+  ;; cascade is load-bearing, so this is hygiene, not correctness — it mirrors
+  ;; the render-depth reset above.
+  (reset! phase-seq 0)
   nil)
 
 (def adapter
@@ -483,9 +497,12 @@
   nil)
 
 (defn lifecycle-log
-  "Return the lifecycle log for `mount` — a vector of `{:phase ... :at ms}`
-  entries, in the order they fired. Test assertions typically map over
-  `:phase` and compare to a canonical sequence."
+  "Return the lifecycle log for `mount` — a vector of `{:phase ... :seq n}`
+  entries, in the order they fired. `:seq` is a process-global monotonic
+  order-key (see `phase-seq`), the discriminating key for teardown-ORDER
+  assertions — a strict `<` over two phases' seqs reflects their real firing
+  order. Test assertions typically map over `:phase` and compare to a canonical
+  sequence, and read `:seq` to assert cross-mount teardown order."
   [mount]
   @(:lifecycle-log mount))
 

--- a/implementation/adapters/test-react/src/re_frame/adapter/test_react.cljc
+++ b/implementation/adapters/test-react/src/re_frame/adapter/test_react.cljc
@@ -102,10 +102,6 @@
 ;;   :lifecycle-log   — atom holding a vector of {:phase ... :seq n} entries;
 ;;                      the test driver inspects this to assert ordering (`:seq`
 ;;                      is the monotonic order-key — see `phase-seq`).
-;;   :currently-rendering? — atom<boolean>; true while THIS mount's render is
-;;                      in flight. Distinct from the global render-depth (see
-;;                      below): this cell marks the self-render case, the
-;;                      global cell marks "React is rendering somewhere."
 ;;   :mounted?        — atom<boolean>; false after unmount. The simulator
 ;;                      THROWS on trigger-update! / unmount! after teardown.
 ;;   :children        — atom<vector<MountedComponent>>; child roots this mount
@@ -116,7 +112,7 @@
 ;;   :unmount-fn      — the unmount thunk for this mount; `unmount!` calls it.
 
 (defrecord ^:no-doc MountedComponent
-  [id render-tree lifecycle-log currently-rendering? mounted? children unmount-fn])
+  [id render-tree lifecycle-log mounted? children unmount-fn])
 
 ;; All live mounts; `dispose-adapter!` walks this to drain.
 (defonce ^:private active-mounts (atom #{}))
@@ -127,9 +123,9 @@
 ;; is exactly this cross-root case: a parent re-renders and, from inside that
 ;; render body, synchronously unmounts a SEPARATELY-tracked sibling/child root
 ;; (the senbl panel-host unmounting the previous panel's root on a chip-row
-;; switch). The per-mount :currently-rendering? cell cannot see that — it is
-;; false on the sibling being torn down — so the guard keys off this global
-;; counter. A counter (not a boolean) so nested child renders restore the flag
+;; switch). A per-mount "am I rendering?" boolean could not see that — it would
+;; be false on the sibling being torn down — so the guard keys off this global
+;; counter. A counter (not a boolean) so nested child renders restore it
 ;; correctly on unwind.
 (defonce ^:private render-depth (atom 0))
 
@@ -178,16 +174,14 @@
 
 (defn- run-render!
   "Run one render of `mount` with `tree` as its output. Increments the global
-  render depth and sets the per-mount :currently-rendering? flag for the
-  duration, records a :render phase entry, stores the tree, and — if the tree
-  declares an imperative render body (`:rf/component`) — invokes that body with
-  `mount` bound as `*rendering-mount*` so it can mount children or issue a
-  (guard-tripping) re-entrant unmount. Throws from the render body are NOT
-  caught — they propagate to the caller (React 18+ unmounts the root); the
-  flags/depth are restored on unwind via `finally`."
+  render depth for the duration, records a :render phase entry, stores the
+  tree, and — if the tree declares an imperative render body (`:rf/component`)
+  — invokes that body with `mount` bound as `*rendering-mount*` so it can mount
+  children or issue a (guard-tripping) re-entrant unmount. Throws from the
+  render body are NOT caught — they propagate to the caller (React 18+ unmounts
+  the root); the render depth is restored on unwind via `finally`."
   [mount tree]
   (swap! render-depth inc)
-  (reset! (:currently-rendering? mount) true)
   (try
     (reset! (:render-tree mount) tree)
     (log-phase! mount :render)
@@ -195,7 +189,6 @@
       (binding [*rendering-mount* mount]
         (body mount)))
     (finally
-      (reset! (:currently-rendering? mount) false)
       (swap! render-depth dec))))
 
 (defn- unmount-thunk
@@ -257,7 +250,6 @@
                    (gensym "test-react-mount-")
                    (atom nil)   ; render-tree
                    (atom [])    ; lifecycle-log
-                   (atom false) ; currently-rendering?
                    (atom true)  ; mounted?
                    (atom [])    ; children
                    nil)         ; unmount-fn — filled in below
@@ -342,9 +334,9 @@
 (defn- dispose-adapter! []
   ;; Drain any still-mounted components so a test fixture that forgets to
   ;; unmount doesn't leak across cases. Per the rf2-4l7t2 lesson the drain
-  ;; MUST tolerate the currently-rendering? guard — we set mounted? false
+  ;; MUST tolerate the sync-unmount-during-render guard — we set mounted? false
   ;; WITHOUT routing through the public `unmount!` (which would throw on a
-  ;; stuck currently-rendering? cell) and log a :forced-teardown phase so the
+  ;; non-zero render-depth) and log a :forced-teardown phase so the
   ;; test surface can spot drift.
   ;;
   ;; The hiccup-emitter is deliberately NOT cleared: it holds no host
@@ -377,7 +369,7 @@
   ;; active-mounts (mount-tree! adds every mount, parent or child), so a flat
   ;; walk drains the whole forest without recursing through :children. We do
   ;; NOT route through the public unmount thunk (it would throw on the
-  ;; currently-rendering? / render-depth guard) — forced teardown is the
+  ;; render-depth guard) — forced teardown is the
   ;; escape hatch the guard deliberately cannot block.
   ;;
   ;; rf2-ghfkkk — dispose every live frame's sub-cache (the reactive-
@@ -413,7 +405,7 @@
   2-of-3 optional (no `flush-render!`) + 1 lifecycle fn. The
   reactive-container half is shared with plain-atom; the
   render half is the novel surface (class-3 lifecycle simulation with the
-  `:currently-rendering?` invariant). See `mount!` / `trigger-update!` /
+  global-render-depth sync-unmount-during-render invariant). See `mount!` / `trigger-update!` /
   `unmount!` for the test driver helpers."
   {:kind                      :rf.adapter/test-react
    :make-state-container      atom-container/make-state-container

--- a/implementation/adapters/test-react/test/re_frame/adapter/test_react_cljs_test.cljc
+++ b/implementation/adapters/test-react/test/re_frame/adapter/test_react_cljs_test.cljc
@@ -16,7 +16,7 @@
           the current panel's child root; on a chip-row 'switch panel'
           re-render, the parent's render body synchronously unmounts the
           PREVIOUS panel's root. The guard fires ORGANICALLY — no
-          hand-fabricated :currently-rendering? — because the unmount happens
+          hand-fabricated in-flight render state — because the unmount happens
           while React (the global render depth) is rendering somewhere.
 
        2. Unbalanced subscribe/dispose (mount/unmount ref-count). A faulty
@@ -345,8 +345,8 @@
 ;; rendering." The original fix deferred the unmount to a microtask.
 ;;
 ;; Here the bug is reproduced ORGANICALLY: the host's render body issues the
-;; unmount while the global render depth is non-zero — no test sets
-;; :currently-rendering? by hand. That converts the headline capability from
+;; unmount while the global render depth is non-zero — no test fabricates
+;; in-flight render state by hand. That converts the headline capability from
 ;; "guard logic verified" to "bug condition reproduced."
 
 (deftest organic-sync-unmount-during-render-rf2-4l7t2

--- a/implementation/adapters/test-react/test/re_frame/adapter/test_react_cljs_test.cljc
+++ b/implementation/adapters/test-react/test/re_frame/adapter/test_react_cljs_test.cljc
@@ -61,7 +61,7 @@
 ;; ---- lifecycle-log query helpers -------------------------------------------
 ;; The assertions below repeatedly interrogate a mount's lifecycle log by
 ;; phase — counting how many times a phase fired (render-count contracts) and
-;; reading the first `:at` timestamp for a phase (teardown-ordering checks).
+;; reading the first `:seq` order-key for a phase (teardown-ordering checks).
 ;; These two helpers name those queries so each assertion reads as the
 ;; property under test rather than a `->>`/filter thread.
 
@@ -72,14 +72,18 @@
        (filter (comp #{phase} :phase))
        count))
 
-(defn- phase-first-at
-  "The `:at` timestamp of the first `phase` entry in the mount's lifecycle
-  log, or nil if the phase never fired."
+(defn- phase-first-seq
+  "The monotonic `:seq` order-key of the first `phase` entry in the mount's
+  lifecycle log, or nil if the phase never fired. `:seq` increments once per
+  logged phase across the whole adapter, so a strict `<` over two phases' seqs
+  reflects their REAL firing order — unlike the wall-clock `:at` this replaced,
+  which collapsed to equal integers for a sub-millisecond teardown cascade and
+  made the ORDER check vacuous (it could not fail on a reversed teardown)."
   [mount phase]
   (->> (test-react/lifecycle-log mount)
        (filter (comp #{phase} :phase))
        first
-       :at))
+       :seq))
 
 ;; ----------------------------------------------------------------------------
 ;; A. Demonstration scenarios
@@ -322,10 +326,12 @@
           "parent unmount cascaded to the child — nothing leaks")
       (is (some #{:will-unmount} (mapv :phase (test-react/lifecycle-log @child-ref)))
           "the child saw its own :will-unmount during the cascade")
-      (let [child-unmount-at  (phase-first-at @child-ref :will-unmount)
-            parent-unmount-at (phase-first-at parent :will-unmount)]
-        (is (<= child-unmount-at parent-unmount-at)
-            "children tear down before (or no later than) their parent")))))
+      (let [child-unmount-seq  (phase-first-seq @child-ref :will-unmount)
+            parent-unmount-seq (phase-first-seq parent :will-unmount)]
+        (is (< child-unmount-seq parent-unmount-seq)
+            "child tears down STRICTLY before its parent — monotonic order-key,
+             so a reversed (parent-first) teardown FAILS here (the old <=-on-ms
+             check passed vacuously because sub-ms timestamps collapsed to equal)")))))
 
 ;; ----------------------------------------------------------------------------
 ;; B.1 — Organic sync-unmount-during-render (the rf2-4l7t2 class)
@@ -684,10 +690,12 @@
       (test-react/unmount! parent)
       (is (zero? (count (test-react/mounted-roots)))
           "the whole forest drained — no orphaned descendant")
-      (let [gc-at     (phase-first-at @grandchild-ref :will-unmount)
-            child-at  (phase-first-at @child-ref :will-unmount)
-            parent-at (phase-first-at parent :will-unmount)]
-        (is (and gc-at child-at parent-at)
+      (let [gc-seq     (phase-first-seq @grandchild-ref :will-unmount)
+            child-seq  (phase-first-seq @child-ref :will-unmount)
+            parent-seq (phase-first-seq parent :will-unmount)]
+        (is (and gc-seq child-seq parent-seq)
             "every level recorded a :will-unmount during the cascade")
-        (is (<= gc-at child-at parent-at)
-            "teardown order is grandchild ≤ child ≤ parent — leaf-upward unwind")))))
+        (is (< gc-seq child-seq parent-seq)
+            "teardown order is grandchild < child < parent — leaf-upward unwind
+             (strict monotonic seq: a root-downward regression FAILS this, where
+             the old <=-on-ms check stayed green because the cascade ran sub-ms)")))))


### PR DESCRIPTION
Fixes two correctness findings on the Test-React adapter (`implementation/adapters/test-react`), one commit each. Behaviour-preserving except that a previously vacuous ORDER assertion now has teeth.

## rf2-mxu3e4 (P2) — leaf-upward teardown ORDER assertions were vacuous (false-green)

The two teardown-ORDER assertions compared millisecond `:at` timestamps with `<=`. The whole cascade completes sub-millisecond, so every timestamp collapsed to the SAME integer and `(<= equal equal)` was always true. A regression that REVERSED the cascade to root-downward teardown (parent `:will-unmount` before its children — the exact violation of React's children-first contract this adapter exists to verify) would still produce same-ms-equal timestamps and stay green. The probe could not fail on the bug it existed to catch.

**Fix:** stamp every logged phase with a process-global monotonic `:seq` order-key (increment per `log-phase!`), replacing the vacuous wall-clock `:at` (a simulator that owns its own clock has no meaningful wall-time). The two ordering tests now assert **strict `<`** over `:seq` (`child < parent`; `grandchild < child < parent`), which fails deterministically on a teardown-order reversal every run/platform. `now-ms` removed (dead); `phase-seq` reset in `dispose-adapter!` alongside `render-depth`.

**Proven to have teeth:** temporarily moving the parent's `:will-unmount` above the child cascade (root-downward) made both ordering tests FAIL — `(not (< 12 11 10))` and `(not (< 8 7))` — while the sibling "teardown happened" assertions stayed green, confirming only the ORDER claim was vacuous. Reverted before commit.

## rf2-a0w3ty (P3) — dead `:currently-rendering?` render cell (guard-regression trap)

The per-mount `:currently-rendering?` atom was set true/false on every render but NEVER read: the sync-unmount guard keys exclusively off the global `render-depth`/`rendering?`, and no test dereferences the cell. It was dead state documented as load-bearing — a trap inviting a future maintainer to swap the guard onto the dead cell, reintroducing the cross-root blindness (a parent unmounting a SEPARATE sibling root during render) the global counter exists to fix (the rf2-4l7t2 organic case).

**Fix (bead option a):** delete the field, its two `reset!`s, and its constructor slot; trim the docstrings/comments (src + test + README) to describe only the global render-depth guard. No behaviour change — the guard already covers the self-render case via the counter.

## Quality gates

Foreground, from `implementation/`:
- `npm run test:cljs` (full node-test CLJS suite, includes the test-react `-cljs-test` namespaces): **8310 tests, 38212 assertions, 0 failures, 0 errors**.
- Test-React adapter's own JVM suite (`clojure -M:test` in `adapters/test-react`): **24 tests, 84 assertions, 0 failures, 0 errors** — covers the `#?(:clj …)` reader branch.
- Teeth proof (reversed cascade): 2 ordering-test failures as expected, then reverted.

Full spine deferred to CI.

## Stance

Pre-alpha, no back-compat shims. ELEGANCE + CLARITY + CORRECTNESS + GOOD PRACTICE: the vacuous wall-clock `:at` is replaced outright (not left beside the real order-key as a fresh footgun), and the dead cell is removed rather than wired up. Touches only `implementation/adapters/test-react`.
