### PR TITLE
fix(examples): websocket actor closes socket on :exit; long-running start; nine-states data schema (rf2-6gw1rh +2)

### DIFF
--- a/examples/patterns/long_running_work/worker.cljs
+++ b/examples/patterns/long_running_work/worker.cljs
@@ -408,6 +408,13 @@
 ;; ============================================================================
 
 (rf/reg-event :work/initialise
-  {:doc "Park the parent machine in :idle, ready to go."}
+  {:doc "Bring the :work/flow machine to life in its :idle start state, via
+         the `:rf.machine/start` creation marker — the same eager kick the
+         boot and websocket examples use. :idle is the initial state and has
+         no entry work, so start materialises it cleanly, with an :explicit
+         start-cause. Booting via an ordinary event (e.g. [:reset]) instead
+         lazily first-touches the machine, which flags the :lazy start-cause
+         the Xray [START] badge surfaces — an ordering smell, and out of step
+         with the sibling machine examples."}
   (fn handler-work-initialise [_ _]
-    {:fx [[:dispatch [:work/flow [:reset]]]]}))
+    {:fx [[:dispatch [:work/flow [:rf.machine/start]]]]}))

--- a/examples/patterns/nine_states/core.cljs
+++ b/examples/patterns/nine_states/core.cljs
@@ -114,10 +114,13 @@
 ;; SCHEMAS
 ;; ============================================================================
 ;;
-;; The machine carries its own `:data` shape (see the declaration below), so
-;; the only thing left to describe here is the form slice: what the form
-;; collects plus its per-field validation state. Note there's no `:status`
-;; field — the form region's state-keyword already IS the status.
+;; The machine schema-checks its own `:data` shape via `NineStatesData`
+;; below, attached on its `[:schemas :data]` slot — a machine's snapshot
+;; lives in runtime-db, so that (not a `reg-app-schema`, which guards
+;; app-db) is its validation surface. What's left to describe HERE is the
+;; form slice: what the form collects plus its per-field validation state.
+;; Note there's no `:status` field — the form region's state-keyword already
+;; IS the status.
 
 ;; A subtle but important call: `:draft` is a bare `:map`, not the stricter
 ;; "this is a valid submission" shape. A draft is meant to hold
@@ -140,6 +143,29 @@
 ;; ../../../docs/core/glossary.md#frame-identity-is-carried-not-found
 (rf/with-frame :rf/default
   (rf/reg-app-schema [:new-todo] NewTodoSlice))
+
+;; ---- The machine's own :data shape ----
+;; A todo, as it rides in the machine's `:items` list. Both producers build
+;; exactly this: the demo server's `gen-todos` and `:new-todo/submit`.
+(def Todo
+  [:map
+   [:id    :any]        ;; a random-uuid; it doubles as the row's React :key
+   [:title :string]
+   [:done? :boolean]])
+
+;; The parallel machine's shared `:data`. It hangs off the machine's
+;; `[:schemas :data]` slot (see `nine-states-machine`), so the runtime
+;; checks it after every transition and at each snapshot write — the machine
+;; equivalent of an app-schema, but for runtime-db-resident snapshot data.
+;; Three fields, one per axis's needs: `:items` (the list the `:data`
+;; region's cardinality guards count), `:error` (the failure the `:error`
+;; branch records), and `:archived-at` (the stamp the `:mode` region writes
+;; on `:archive`).
+(def NineStatesData
+  [:map
+   [:items       [:vector Todo]]
+   [:error       [:maybe :any]]
+   [:archived-at [:maybe :int]]])
 
 ;; ============================================================================
 ;; RECORDABLE COEFFECTS
@@ -232,6 +258,12 @@
 
 (def nine-states-machine
   {:type :parallel
+
+   ;; The machine validates its own `:data` here, on every transition and at
+   ;; each snapshot write. A machine's `:data` lives in runtime-db, so it
+   ;; carries its own `[:schemas :data]` — not an app-schema, which guards
+   ;; the app-db partition. See docs/machines/concepts.md#validating-a-machines-data.
+   :schemas {:data NineStatesData}
 
    ;; The machine's shared :data — :items for the data region, plus the
    ;; mode region's :archived-at stamp. One shared bag rather than

--- a/examples/patterns/websocket/README.md
+++ b/examples/patterns/websocket/README.md
@@ -93,7 +93,10 @@ Everything below builds on those three. The rest is ordinary machine grammar —
 - **Reconnect cascade with token refresh threaded through.** Leaving `:active`
   destroys the actor (the declarative `:spawn` desugars to a
   `:rf.machine/destroy` on exit), and the runtime clears its id from the
-  `:rf/spawned` slot — there's no `:exit` action to write. After the `:after`
+  `:rf/spawned` slot — so the *connection* machine needs no `:exit` action to
+  forget the id. The actor itself does carry one: an `:exit :close-socket` on
+  its `:open` state closes the host `WebSocket` on the way down, because a live
+  socket is a handle the runtime can't drop for you. After the `:after`
   backoff, re-entering `:active` re-runs the `:spawn`'s `:data` function, which
   re-reads the URL and token from `:data` — so a `:ws/refresh-token` arriving
   *between* reconnects flows into the next socket with no extra wiring.

--- a/examples/patterns/websocket/connection.cljs
+++ b/examples/patterns/websocket/connection.cljs
@@ -63,8 +63,11 @@
    And because the runtime CLEARS that slot the instant the actor is torn
    down (leaving `:active` by any door), a stale read is impossible: the
    moment the socket dies, `(socket-id data)` goes `nil` on its own. That is
-   what makes it a safe connection clock — no `:exit` action nulling
-   anything, nothing to remember to clean up."
+   what makes it a safe connection clock — THIS machine needs no `:exit`
+   action to null the id out. (The host socket itself is another matter: a
+   live `WebSocket` is not a value the runtime can drop, so the SPAWNED actor
+   carries an `:exit :close-socket` to close it — see `websocket.messages`.
+   The id auto-clears; the socket the id points at does not.)"
   (:require [re-frame.core :as rf]
             ;; `re-frame.machines` ships in day8/re-frame2-machines.
             ;; Requiring it is what wires up the machine vocabulary: the

--- a/examples/patterns/websocket/messages.cljs
+++ b/examples/patterns/websocket/messages.cljs
@@ -176,11 +176,19 @@
                   ;; Anything else: shrug. The example doesn't bother with
                   ;; fire-and-forget sends beyond the cases above.
                   nil)))
+     ;; Close the host-side socket, the way a real `WebSocket`'s `.close()`
+     ;; would: mark it shut and drop its `mock-server-state` entry so nothing
+     ;; keeps trying to reach it. This is the seam the actor's `:exit`
+     ;; reaches for on teardown. It deliberately does NOT re-echo a `:closed`
+     ;; back to the actor — the actor is on its way out when this runs, so
+     ;; dispatching an event into a dying machine would fire mid-teardown
+     ;; (in sync mode, `later` runs it right now). The one place that WANTS a
+     ;; `:closed` delivered — an unexpected drop — is `simulate-disconnect!`,
+     ;; which dispatches it itself. Swap in a real socket and this line
+     ;; becomes `(.close socket)`.
      :close (fn mock-close []
               (reset! open? false)
-              (swap! mock-server-state update :sockets dissoc id)
-              (later
-                #(deliver-to-actor! dispatch actor-id :closed {:code 1000})))}))
+              (swap! mock-server-state update :sockets dissoc id))}))
 
 ;; The seams below let the views (and tests) poke the mock server from
 ;; outside, without pretending to be the actor.
@@ -230,8 +238,13 @@
 ;;
 ;; A small machine with a simple life. `:opening` opens the host-side
 ;; socket on entry, then immediately steps to `:open`, where it spends the
-;; rest of its days. Cleanup isn't its problem: leaving `:active` upstairs
-;; destroys this actor, and that's that.
+;; rest of its days. The one thing it MUST do on the way out is close that
+;; host socket — an `:exit :close-socket` on `:open` does exactly that. The
+;; runtime clears the `:rf/spawned` id the parent tracks all on its own, but
+;; the JS `WebSocket` (or our mock stand-in) is a live handle the runtime
+;; knows nothing about, so a clean Disconnect / `:ws/fatal` / `:ws/auth-failed`
+;; that destroys the actor would leak it. The actor's `:exit` is the one bit
+;; of teardown that IS its problem.
 ;;
 ;; Two ids do the talking. The runtime stamps `:rf/self-id` and
 ;; `:rf/parent-id` into a spawned actor's `:data`; the actor tags its own
@@ -261,6 +274,21 @@
           ;; frame at all and raise `:rf.error/no-frame-context`. Effects,
           ;; not side effects.
           {:fx [[:dispatch [parent-id [:ws/opened {:source-socket-id self-id}]]]]}))
+
+      :close-socket
+      ;; On exit from `:open`: close the host-side socket the actor opened.
+      ;; Letting go of the `:rf/spawned` id (which the runtime does for us on
+      ;; teardown) frees the ACTOR, not the socket — so without this the JS
+      ;; `WebSocket` leaks. `((:close socket))` marks the mock shut and prunes
+      ;; its `mock-server-state` entry (a real socket would take a `.close()`
+      ;; there); `clear-socket!` drops our host-store reference. No `:closed`
+      ;; is re-dispatched — the actor is already on its way out.
+      (fn action-close-socket [{data :data}]
+        (let [self-id (:rf/self-id data)]
+          (when-let [socket (get-socket self-id)]
+            ((:close socket)))
+          (clear-socket! self-id))
+        nil)
 
       :send-via-socket
       ;; The parent sends us `[<actor-id> [:send body]]` for each outbound
@@ -292,10 +320,15 @@
           {:fx [[:dispatch [parent-id ev]]]}))
 
       :forward-closed
+      ;; A `:closed` event reached us — an unexpected drop that
+      ;; `simulate-disconnect!` delivered, or (with a real socket) its
+      ;; `onclose`. Forward it up to the parent, stamped with our socket id so
+      ;; `:current-socket?` can vet it. Host-socket cleanup is NOT done here:
+      ;; walking to `:closed` exits `:open`, and `:open`'s `:exit :close-socket`
+      ;; has already shut the host socket down. This action is pure messaging.
       (fn action-forward-closed [{data :data [_ {:keys [code reason]}] :event}]
         (let [self-id   (:rf/self-id data)
               parent-id (:rf/parent-id data)]
-          (clear-socket! self-id)
           {:fx [[:dispatch [parent-id
                             [:ws/closed {:source-socket-id self-id
                                          :code             code
@@ -320,15 +353,24 @@
                             :action :forward-closed}}}
 
       :open
-      {:on {:send     {:action :send-via-socket}
-            :received {:action :forward-received}
-            :closed   {:target :closed
-                       :action :forward-closed}}}
+      ;; Where the actor spends its life — and where `:exit :close-socket`
+      ;; lives, NOT on `:opening`: `:opening` `:always`-steps straight to
+      ;; `:open`, so an exit there would slam shut the socket we just opened.
+      ;; `:open` is the only state the actor rests in, so its exit is the
+      ;; reliable teardown seam. It fires on BOTH doors out: destroy (the
+      ;; parent leaving `:active` tears the actor down) and the `:open` ->
+      ;; `:closed` walk a `:closed` event triggers.
+      {:exit :close-socket
+       :on   {:send     {:action :send-via-socket}
+              :received {:action :forward-received}
+              :closed   {:target :closed
+                         :action :forward-closed}}}
 
       :closed
-      ;; The end of the line. The parent's exit-from-:active is about to
-      ;; destroy this actor anyway; until it does, this state just quietly
-      ;; soaks up any stragglers.
+      ;; The end of the line. Reaching here means we exited `:open`, so
+      ;; `:close-socket` has already shut the host socket down; the parent's
+      ;; exit-from-`:active` will destroy this actor shortly. Until it does,
+      ;; this state just quietly soaks up any stragglers.
       {}}})
 
 ;; ============================================================================


### PR DESCRIPTION
Fixes three correctness/consistency defects in `examples/patterns`, one bead per commit.

## rf2-6gw1rh (P2) — websocket socket actor leaks its host socket on teardown
The `:websocket/socket` actor owned a host-side handle but declared no `:exit` to close it: `clear-socket!` only dropped the `sockets-by-actor` map ref, and `mock-close` (the only thing that flips `open?=false`, prunes `mock-server-state`, and would call a real `.close()`) was **dead code**. Every teardown not preceded by an inbound `:closed` — a clean Disconnect, `:ws/fatal`, `:ws/auth-failed` — destroyed the actor while leaking the host handle (stale `open?=true` accumulation; a real socket never `.close()`d).

Fix:
- Add `:exit :close-socket` on the `:open` state (`:rf.machine/destroy` runs the active configuration's `:exit` cascade before teardown, so `:exit` is the correct seam). It calls `((:close socket))` + `clear-socket!`.
- Placed on `:open`, **not** `:opening`: `:opening` `:always`-steps straight to `:open`, so an exit there would slam shut the just-opened socket during that step. `:open` is the only state the actor rests in / is torn down from, and it is also exited on the `:open -> :closed` walk a `:closed` event triggers — so one seam covers destroy AND the `simulate-disconnect!` drop.
- Wire the formerly-dead `mock-close` and drop its `:closed` echo (re-dispatching `:closed` into a dying actor fires mid-teardown in sync mode). The one path that wants `:closed` delivered — an unexpected drop — is `simulate-disconnect!`, which dispatches it itself. `:forward-closed` is now pure messaging.
- Correct the three docstrings that taught the opposite (connection.cljs clock note, messages.cljs actor header, README reconnect bullet): the `:rf/spawned` id auto-clears, but the host socket it points at does not.

A dedicated websocket-teardown regression test would belong in the machines contract tests under `implementation/`, not `examples/` (examples are test-free) — noted, not added here; the existing `websocket_cljs_test` disconnect/reconnect/drop paths already cover the corrected behaviour.

## rf2-fe4vw2 (P3) — long_running_work boots via lazy `[:reset]`
`:work/initialise` woke `:work/flow` with an ordinary `[:reset]` event, yielding the `:lazy` start-cause (the `[START]` badge smell) and diverging from the boot + websocket siblings. Changed to the `[:rf.machine/start]` creation marker — `:idle` has no entry work, so start materialises it identically with a clean `:explicit` cause.

## rf2-ai1abk (P4) — nine_states omitted `[:schemas :data]`
The parallel machine set a `:data` default but no schema, leaving `:data` (incl. `:items`) unvalidated — the only pattern example to omit machine-`:data` validation, and its comment falsely claimed it carried a shape. Added a `NineStatesData` schema (with a `Todo` item schema matching both producers) on the machine's `[:schemas :data]` slot, and corrected the comment.

## Quality gates
- `npx shadow-cljs compile :examples/websocket :examples/nine-states :examples/long-running-work` → all three **Build completed, 0 warnings**.
- Full CLJS `node-test` suite: **8308 tests, 38206 assertions, 0 failures, 0 errors** (covers `websocket_cljs_test`, `nine_states_cljs_test`, `long_running_work_cljs_test`).
- Full spine deferred to CI.

## Stance
Pre-alpha, no back-compat shims. ELEGANCE + CLARITY + CORRECTNESS + GOOD PRACTICE; the `:exit`-on-`:open` placement is the minimal correct seam (not the bead's literal "on :opening + :open", which would break the `:always` open step). Touches only `examples/patterns`.
