### PR TITLE
fix(ssr): cross-runtime-stable render-tree-hash for fn-heads + numerics; exactly-once boundary-failed (rf2-jsa2ml +2)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/emit.cljc
+++ b/implementation/ssr/src/re_frame/ssr/emit.cljc
@@ -348,7 +348,13 @@
    (cond
      (nil? el)         ""
      (string? el)      (html/escape-html el)
-     (number? el)      (str el)
+     ;; Canonicalise the numeric print form so the emitted HTML matches the
+     ;; render-tree hash byte-for-byte across runtimes (rf2-0ypnnk): a
+     ;; whole-valued double renders `9` (not the JVM `9.0`), agreeing with
+     ;; CLJS. `canonical-number` uses `pr-str`, which coincides with `str`
+     ;; for numbers (no quoting), so ordinary integers/decimals are
+     ;; unchanged.
+     (number? el)      (hash/canonical-number el)
      (boolean? el)     ""
      (vector? el)
      (let [head (first el)]

--- a/implementation/ssr/src/re_frame/ssr/hash.cljc
+++ b/implementation/ssr/src/re_frame/ssr/hash.cljc
@@ -34,6 +34,52 @@
 
 (declare canonical-edn-into)
 
+(defn canonical-number
+  "Cross-runtime-stable print form of a number — shared by the render-tree
+  hash (`canonical-edn-into`'s numeric leaf) and the HTML emitter
+  (`re-frame.ssr.emit`'s number branch) so the hash and the emitted markup
+  stay byte-consistent (rf2-0ypnnk).
+
+  ClojureScript has only IEEE doubles: it unifies a whole-valued double to
+  an integer (`1.0` IS the JS number 1, printing `\"1\"`) and has no ratio
+  type. The JVM prints `\"1.0\"` for that same `Double` and `\"1/2\"` for a
+  `Ratio`, so a render tree carrying either hashed AND rendered divergently
+  across runtimes — a spurious hydration mismatch that CRASHES under
+  `:ssr {:on-mismatch :hard-error}`. Canonicalise to the CLJS form:
+
+    - a whole-valued double/float within IEEE exact-integer range prints as
+      its integer form (no trailing `.0`), matching CLJS;
+    - a `Ratio` prints as its IEEE-double form (mirroring the head emitter's
+      rf2-8jl26 ratio coercion, and a CLJS view that computed the same value
+      by division);
+    - every other number keeps its default `pr-str` form — integers and
+      common decimals already agree across runtimes, and `pr-str`/`str`
+      coincide for numbers (no quoting), so the emitter reuses this for HTML.
+
+  Residual: a whole-valued double of magnitude ≥ 2^53 (the IEEE exact-
+  integer limit) or one that prints in scientific notation keeps the JVM
+  default — the JVM/JS shortest-round-trip float algorithms diverge there
+  and no cheap normalisation closes it. Such values are vanishingly rare in
+  SSR view output; the common price/progress `9.0`/`0.0` case is fully
+  canonical."
+  [x]
+  #?(:clj
+     (cond
+       (ratio? x)
+       (canonical-number (double x))
+
+       (and (or (instance? Double x) (instance? Float x))
+            (let [d (double x)]
+              (and (not (Double/isNaN d))
+                   (not (Double/isInfinite d))
+                   (== d (Math/rint d))                       ;; whole-valued
+                   (<= -9.007199254740992E15 d 9.007199254740992E15))))
+       (str (long x))
+
+       :else (pr-str x))
+     :cljs
+     (pr-str x)))
+
 (defn- append-children!
   "Append canonical-EDN of each non-nil child of `xs` into `sb`,
   separated by `sep`. Maps with nil values and sequential children
@@ -172,12 +218,32 @@
     (do (append-sorted-set! sb x) sb)
 
     (fn? x)
-    (do #?(:clj  (.append ^StringBuilder sb "#fn[")
-           :cljs (.push sb "#fn["))
-        #?(:clj  (.append ^StringBuilder sb ^String (.toString ^Object x))
-           :cljs (.push sb (.toString x)))
-        #?(:clj  (.append ^StringBuilder sb \])
-           :cljs (.push sb "]"))
+    ;; A raw fn head — `[my-component props]`, the idiomatic Reagent/UIx/
+    ;; Helix SSR shape where `my-component` is the deref'd defn VALUE (a raw
+    ;; fn, not a Var). `(.toString fn)` is NOT cross-runtime stable: JVM =
+    ;; class-name + identity-hashcode, CLJS = the JS source — never equal.
+    ;; The server hashes the raw render tree and the client re-hashes the
+    ;; SAME raw tree, so a fn `.toString` in the canonical EDN made byte-
+    ;; identical HTML hash differently → a spurious
+    ;; `:rf.ssr/hydration-mismatch` that CRASHES under
+    ;; `:ssr {:on-mismatch :hard-error}` (rf2-jsa2ml). No cross-runtime-
+    ;; stable fn identity exists, so drop it: every raw fn head serialises
+    ;; to one fixed token. The fn's props (the rest of the child vector)
+    ;; still hash, and a Var head stays identity-stable — a Var is NOT `fn?`
+    ;; on the JVM, so `[#'ns/view …]` falls to `:else` → `(pr-str …)` →
+    ;; `#'ns/view`, identical on both runtimes.
+    (do #?(:clj  (.append ^StringBuilder sb "#fn[]")
+           :cljs (.push sb "#fn[]"))
+        sb)
+
+    (number? x)
+    ;; Canonicalise the numeric print form so the JVM `1.0`/`1/2` and the
+    ;; CLJS `1`/`0.5` agree (rf2-0ypnnk) — see `canonical-number`. The
+    ;; emitter (`re-frame.ssr.emit`) applies the SAME normalisation to the
+    ;; HTML so the structural hash and the rendered markup stay byte-
+    ;; consistent for the same logical tree.
+    (do #?(:clj  (.append ^StringBuilder sb ^String (canonical-number x))
+           :cljs (.push sb (canonical-number x)))
         sb)
 
     :else
@@ -188,9 +254,11 @@
 (defn canonical-edn
   "Print a render-tree node in a stable order. Maps are sorted by the
   canonical-EDN form of their keys (a total order — rf2-mff1ht);
-  sequences keep order. Functions and var-references appear
-  as their toString — stable enough for trees that re-render the same
-  view-fn from the same registry.
+  sequences keep order. A raw fn head serialises to one fixed identity-
+  free token (`#fn[]`) — its `.toString` is not cross-runtime stable
+  (rf2-jsa2ml); a Var reference keeps its `#'ns/name` print form (stable
+  both runtimes). Numeric leaves are canonicalised via `canonical-number`
+  so whole-valued doubles / ratios agree cross-runtime (rf2-0ypnnk).
 
   Per Spec 011 §Hydration-mismatch detection: **nil pruned**. Two render
   trees that differ only by absent-key vs nil-value are structurally

--- a/implementation/ssr/src/re_frame/ssr/html_helpers.cljc
+++ b/implementation/ssr/src/re_frame/ssr/html_helpers.cljc
@@ -28,7 +28,8 @@
                                     → bare attribute name (`disabled`);
                                     `false` / `nil` → omitted entirely."
   (:require [clojure.string :as str]
-            [re-frame.error :as error]))
+            [re-frame.error :as error]
+            [re-frame.ssr.hash :as hash]))
 
 (defn escape-html
   "Full text-node HTML escape: `& < > \" '`. Stringifies non-strings."
@@ -431,7 +432,22 @@
                            (nil? v)   nil
                            :else      (str (validate-attr-name! k)
                                            "=\""
-                                           (escape-attr v)
+                                           ;; A numeric attribute VALUE is
+                                           ;; canonicalised the same way the
+                                           ;; render-tree hash serialises it
+                                           ;; (rf2-0ypnnk) so a whole-valued
+                                           ;; double renders `value="0"` (not
+                                           ;; the JVM `value="0.0"`) and the
+                                           ;; emitted HTML matches the hash
+                                           ;; byte-for-byte cross-runtime.
+                                           ;; Without this the hash would
+                                           ;; AGREE while the server/client
+                                           ;; attribute strings diverged — a
+                                           ;; silent hydration inconsistency.
+                                           (escape-attr
+                                             (if (number? v)
+                                               (hash/canonical-number v)
+                                               v))
                                            "\"")))
                        attrs)]
     (if (seq rendered)

--- a/implementation/ssr/src/re_frame/ssr/streaming/client.cljs
+++ b/implementation/ssr/src/re_frame/ssr/streaming/client.cljs
@@ -420,7 +420,17 @@
           ;; later in this same sweep has a mount to swap into (finding 4).
           (materialise-fallbacks! root))
         (cond
-          failed?
+          ;; rf2-8ymnem — the failed-boundary trace is gated on swap SUCCESS.
+          ;; The failed content (the author's fallback HTML) only lands when
+          ;; `replace-mount-content!` finds a live mount, so emitting exactly
+          ;; when the swap happens is both correct and exactly-once: `seen` is
+          ;; conj'd only on a successful swap and the swapped-in <template> is
+          ;; removed, so a re-fire cannot re-process it. Previously the failed
+          ;; arm fired regardless of `swapped?`, so a resolved-failed
+          ;; <template> swept before its mount existed (a nested-boundary race
+          ;; / out-of-order stream) stayed un-`seen` and RE-EMITTED the trace
+          ;; on every MutationObserver re-sweep — multi-emit.
+          (and failed? swapped?)
           (trace/emit-error! :rf.ssr/suspense-boundary-failed
                              {:id        (read-boundary-id id-str)
                               :frame     frame-id

--- a/implementation/ssr/test/re_frame/ssr/hash_parity_fixtures.cljc
+++ b/implementation/ssr/test/re_frame/ssr/hash_parity_fixtures.cljc
@@ -30,6 +30,21 @@
   shared `.cljc` namespace) and pin the SAME canonical literal. The
   literal IS the cross-host byte-comparison point.")
 
+(defn fn-head-component
+  "A raw-fn hiccup head — the deref'd `defn` VALUE idiomatic to Reagent /
+  UIx / Helix SSR (`[fn-head-component props]`). Referenced by the
+  `fn-head-child` parity fixture (rf2-jsa2ml): `(.toString ...)` on a raw
+  fn is class-name + identity-hashcode on the JVM but the JS source on
+  CLJS — never equal. Before the fix the canonical EDN carried divergent
+  `#fn[…]` bytes, so byte-identical HTML hashed differently — a spurious
+  `:rf.ssr/hydration-mismatch` that crashed under
+  `:ssr {:on-mismatch :hard-error}`. The fix collapses every raw fn head
+  to the fixed identity-free token `#fn[]`, so both runtimes agree. The
+  body is irrelevant to the hash (only the head's serialisation is walked)
+  but is realistic hiccup so the fixture reads as a real component."
+  [props]
+  [:span (:label props)])
+
 ;; ---- the canonical corpus -------------------------------------------------
 ;;
 ;; Each fixture is `{:label, :input, :expected, :rationale}`. The
@@ -185,13 +200,48 @@
               Conventions' reserved-namespace scheme). Pins the
               canonical form of the framework's `:rf/*` shapes."})
 
+(def fn-head-child
+  {:label    "fn-head-child"
+   :input    [:div [fn-head-component {:label "hi"}]]
+   :expected "c105e684"
+   :rationale "rf2-jsa2ml — a raw-fn hiccup head (`[fn-head-component
+              props]`, the idiomatic Reagent/UIx/Helix SSR shape where the
+              head is the deref'd defn value). `(.toString fn)` is class +
+              identity-hashcode on the JVM but the JS source on CLJS —
+              never equal — so the pre-fix `#fn[<toString>]` serialisation
+              hashed byte-identical HTML differently, a spurious mismatch
+              that CRASHED under :on-mismatch :hard-error. The fix collapses
+              every raw fn head to the fixed token `#fn[]`; the canonical
+              form is `[:div [#fn[] {:label \"hi\"}]]` on BOTH runtimes and
+              the fn's props still hash. A Var head (`[#'ns/view …]`) is NOT
+              exercised here — it is not `fn?` on the JVM and stays
+              identity-stable via `:else` `pr-str`."})
+
+(def whole-double
+  {:label    "whole-double"
+   :input    [:progress {:value 0.0 :max 1.0}]
+   :expected "5ef66c2e"
+   :rationale "rf2-0ypnnk — whole-valued doubles (`0.0`/`1.0`, e.g. a
+              `[:progress {:value 0.0 :max 1.0}]` or a `9.0` price). The JVM
+              `pr-str`s `\"0.0\"`/`\"1.0\"`; CLJS unifies them to the JS
+              numbers 0/1 printing `\"0\"`/`\"1\"`, so the tree hashed AND
+              rendered divergently — a REAL cross-runtime split that crashed
+              under :on-mismatch :hard-error. `canonical-number` strips the
+              trailing `.0` so both runtimes canonicalise to
+              `[:progress {:max 1,:value 0}]`; the emitter applies the SAME
+              normalisation so the hash and the HTML stay consistent. On
+              CLJS `0.0`/`1.0` ARE the integer-valued numbers 0/1, so the
+              shared `.cljc` input exercises the JVM normalisation and the
+              CLJS native form converging on one literal."})
+
 (def all-fixtures
   "All canonical fixtures in declaration order. Test files iterate this
   list so adding a fixture requires no edits to per-runtime test code."
   [empty-map empty-vector empty-list empty-set scalar-string scalar-keyword
    scalar-int scalar-true scalar-false minimal-hiccup div-class
    namespaced-kw-attr nested-deep unicode-cafe unicode-emoji unicode-mixed
-   set-with-strings list-children large-flat namespaced-kw-key])
+   set-with-strings list-children large-flat namespaced-kw-key
+   fn-head-child whole-double])
 
 ;; ---- nil-pruning equivalence pairs ---------------------------------------
 ;;

--- a/implementation/ssr/test/re_frame/ssr/streaming_client_dom_cljs_test.cljs
+++ b/implementation/ssr/test/re_frame/ssr/streaming_client_dom_cljs_test.cljs
@@ -636,17 +636,18 @@
               [["card-revenue" string? "string id"]
                [:card/revenue  keyword? "keyword id"]]]
         (let [fid      (make-client-frame!)
-              host     (.createElement js/document "div")
+              host     (make-root! [id])
               captured (atom [])
               k        (str (gensym "stream-idtype-cb"))]
-          (set! (.-innerHTML host) "<div id=\"app\"><main></main></div>")
-          (.appendChild (.-body js/document) host)
           (trace-tooling/register-listener! k (fn [ev] (swap! captured conj ev)))
           (try
             ;; A failed-boundary chunk → process-resolved-template! emits
             ;; :rf.ssr/suspense-boundary-failed with :id (read-boundary-id …).
-            ;; No prior fallback mount is needed: the failed branch still
-            ;; emits the trace even when the swap finds no mount.
+            ;; `make-root!` seeds a fallback <template> for `id`, so the
+            ;; initial sweep materialises its live mount BEFORE the failed
+            ;; chunk is processed and the fallback swap SUCCEEDS — the failed
+            ;; trace is gated on swap success (rf2-8ymnem; the shipped FIFO
+            ;; shape always materialises a mount first).
             (append-chunk!
               host
               (failed-chunk-html id "<div class=\"card card-failed\">unavailable</div>"))
@@ -702,3 +703,68 @@
               (remove-root! host)
               (done))
             0))))))
+
+(deftest failed-boundary-trace-emits-exactly-once-when-mount-arrives-late
+  (testing "rf2-8ymnem — the failed-boundary trace is gated on a SUCCESSFUL
+            fallback swap. A resolved-failed <template> whose live mount does
+            not exist yet (the nested-boundary race / out-of-order-stream
+            shape) emits NOTHING — it stays un-`seen` and retryable — and
+            emits EXACTLY ONCE when a later sweep materialises the mount and
+            the swap lands. Before the fix the failed arm fired on every sweep
+            regardless of swap success, so a no-mount failed chunk re-emitted
+            :rf.ssr/suspense-boundary-failed on each MutationObserver
+            re-sweep (multi-emit). The shipped FIFO emitter never hits this
+            (a fallback template always materialises a mount first), so the
+            bug is latent — this drives the non-FIFO shape directly."
+    (if-not (browser?)
+      (is true ":node-test: no DOM")
+      (async
+        done
+        (let [fid          (make-client-frame!)
+              id           :card.racey
+              host         (.createElement js/document "div")
+              captured     (atom [])
+              k            (str (gensym "stream-exactly-once-cb"))
+              failed-count #(count (filter (fn [ev]
+                                             (= :rf.ssr/suspense-boundary-failed
+                                                (:operation ev)))
+                                           @captured))]
+          ;; NO fallback <template> for `id` yet — the failed chunk arrives
+          ;; before any live mount exists.
+          (set! (.-innerHTML host) "<div id=\"app\"><main></main></div>")
+          (.appendChild (.-body js/document) host)
+          (trace-tooling/register-listener! k (fn [ev] (swap! captured conj ev)))
+          (append-chunk!
+            host
+            (failed-chunk-html id "<div class=\"card card-failed\">unavailable</div>"))
+          (let [stop! (streaming-client/install! {:frame fid :root host})]
+            ;; Sweep 1 (synchronous initial sweep): no mount → swapped? false
+            ;; → the failed arm is gated → NO trace, and the failed <template>
+            ;; stays retryable.
+            (is (zero? (failed-count))
+                "no failed trace while the failed chunk has no live mount to swap into")
+            ;; Force a SECOND sweep with the mount STILL absent (an unrelated
+            ;; DOM mutation drives the observer). The OLD code re-emitted here.
+            (append-chunk! host "<div class=\"noise\"></div>")
+            (js/setTimeout
+              (fn []
+                (is (zero? (failed-count))
+                    "a re-sweep with the mount still absent still emits nothing (no multi-emit)")
+                ;; Now the fallback <template> for `id` streams in. The next
+                ;; sweep materialises its mount, then re-processes the still-
+                ;; retryable failed chunk → swap succeeds → EXACTLY ONE trace.
+                (append-chunk!
+                  host
+                  (ssr/streaming-fallback-template
+                    id "<div class=\"card skeleton\">loading</div>"))
+                (js/setTimeout
+                  (fn []
+                    (is (= 1 (card-count host "card-failed"))
+                        "the failed fallback HTML swapped into the now-materialised mount")
+                    (is (= 1 (failed-count))
+                        "the failed-boundary trace fired EXACTLY once — on the successful swap")
+                    (stop!)
+                    (remove-root! host)
+                    (done))
+                  0))
+              0)))))))

--- a/implementation/ssr/test/re_frame/ssr_hash_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_hash_test.clj
@@ -191,3 +191,68 @@
       (is (str/starts-with? html "<!DOCTYPE html>"))
       (is (not (str/includes? html "data-rf-render-hash"))
           "no hash attribute when :emit-hash? false"))))
+
+;; ---- rf2-jsa2ml: raw-fn hiccup heads hash identity-free -------------------
+
+(deftest render-tree-hash-drops-raw-fn-identity
+  (testing "rf2-jsa2ml — a raw-fn hiccup head (`[my-component props]`, the
+            deref'd defn VALUE idiomatic to Reagent/UIx/Helix SSR) has NO
+            cross-runtime-stable identity: (.toString fn) is class +
+            identity-hashcode on the JVM but the JS source on CLJS. The server
+            hashes the raw render tree and the client re-hashes the SAME tree,
+            so a fn `.toString` in the canonical EDN made byte-identical HTML
+            hash differently — a spurious :rf.ssr/hydration-mismatch that
+            CRASHES under :on-mismatch :hard-error. The fix serialises every
+            raw fn head to the fixed identity-free token `#fn[]`."
+    (let [f1 (fn [_] [:span "a"])
+          f2 (fn [_] [:span "a"])]
+      (is (= "#fn[]" (hash/canonical-edn f1))
+          "a raw fn serialises to the identity-free token, not #fn[<toString>]")
+      ;; The decisive property: two DISTINCT fn objects standing for the same
+      ;; logical view (server's deref'd defn vs client's) hash identically.
+      ;; Before the fix f1/f2 had different identity-hashcodes in their
+      ;; toString → different canonical EDN → different hashes → false mismatch.
+      (is (not= (.toString f1) (.toString f2))
+          "sanity: the two fn objects DO have divergent toStrings (the trap)")
+      (is (= (hash/render-tree-hash [:div [f1 {:x 1}]])
+             (hash/render-tree-hash [:div [f2 {:x 1}]]))
+          "distinct fn objects for the same tree hash identically — no spurious mismatch")
+      ;; The fn's props still discriminate: a different prop → a different hash.
+      (is (not= (hash/render-tree-hash [:div [f1 {:x 1}]])
+                (hash/render-tree-hash [:div [f1 {:x 2}]]))
+          "the head is identity-free but the props are still hashed")))
+  (testing "a Var head stays identity-stable — a Var is NOT fn? on the JVM, so
+            `[#'ns/view …]` falls to :else → pr-str → #'ns/name (identical
+            both runtimes)"
+    (is (= "#'clojure.core/identity"
+           (hash/canonical-edn #'clojure.core/identity))
+        "a Var reference keeps its stable #'ns/name print form")))
+
+;; ---- rf2-0ypnnk: whole-valued doubles canonicalise cross-runtime ----------
+
+(deftest whole-valued-doubles-canonicalise-hash-and-html-consistently
+  (testing "rf2-0ypnnk — a whole-valued double is serialised WITHOUT the
+            trailing .0 in BOTH the render-tree hash AND the emitted HTML, so
+            the JVM `9.0`/`0.0` match the CLJS `9`/`0` (CLJS unifies 1.0→1).
+            The two surfaces MUST agree — child AND attribute position — or
+            the hash passes while the server/client DOM diverges (and, under
+            :on-mismatch :hard-error, hydration crashes)."
+    ;; hash side — canonical EDN drops the .0 for a child AND an attr value.
+    (is (= "[:span 9]" (hash/canonical-edn [:span 9.0]))
+        "whole-double child → `9` in the canonical EDN")
+    (is (= "[:progress {:max 1,:value 0}]"
+           (hash/canonical-edn [:progress {:value 0.0 :max 1.0}]))
+        "whole-double attr values → `0`/`1` in the canonical EDN")
+    ;; HTML side — the emitter applies the SAME normalisation, child + attr.
+    (is (= "<span>9</span>" (emit/render-to-string [:span 9.0] {}))
+        "whole-valued double CHILD renders `9`, not the JVM `9.0`")
+    (let [html (emit/render-to-string [:progress {:value 0.0 :max 1.0}] {})]
+      (is (str/includes? html "value=\"0\"") "whole-double attr renders value=\"0\"")
+      (is (str/includes? html "max=\"1\"")   "whole-double attr renders max=\"1\"")
+      (is (not (str/includes? html ".0"))    "no trailing .0 leaks into the HTML"))
+    ;; integers, non-whole doubles, and ratios behave as documented.
+    (is (= "42"   (hash/canonical-number 42))   "an integer is unchanged")
+    (is (= "3.14" (hash/canonical-number 3.14)) "a non-whole double is unchanged")
+    (is (= "0.5"  (hash/canonical-number 1/2))  "a ratio coerces to its IEEE-double form")
+    (is (= "<span>3.14</span>" (emit/render-to-string [:span 3.14] {}))
+        "a non-whole double child is unchanged")))


### PR DESCRIPTION
Fixes three SSR correctness bugs from the 2026-07-09 correctness-review, all under `implementation/ssr`. Unifying principle: `render-tree-hash` MUST produce byte-identical output on JVM and CLJS for the same logical tree — any cross-runtime print divergence is a spurious `:rf.ssr/hydration-mismatch` (and a crash under `:on-mismatch :hard-error`).

## rf2-jsa2ml (P2) — raw-fn-headed hiccup children
`[my-component props]` (the idiomatic Reagent/UIx/Helix SSR shape where the head is the deref'd defn value) was serialised as `#fn[<toString>]`. `(.toString fn)` is class + identity-hashcode on the JVM but the JS source on CLJS — never equal — so byte-identical HTML hashed differently. **Fix:** every raw fn head serialises to the fixed identity-free token `#fn[]` (no cross-runtime-stable fn identity exists). The fn's props still hash; a Var head stays identity-stable (a Var is not `fn?` on the JVM → `pr-str` → `#'ns/name`).

## rf2-0ypnnk (P3) — whole-valued doubles / ratios
A whole-valued double `pr-str`s `"1.0"` on the JVM but `"1"` on CLJS (CLJS unifies `1.0`→`1`); ratios likewise. Both the hash AND the HTML diverged. **Fix:** a shared `canonical-number` prints a whole-valued double (within IEEE exact-integer range) as its integer form and coerces a Ratio to its double form, applied in BOTH `canonical-edn-into` (hash) AND the HTML emitter — `emit-element`'s number-child branch and `attr-string`'s numeric attribute values — so the hash and the rendered markup stay byte-consistent (without the emitter half, the hash would agree while the DOM diverged).

## rf2-8ymnem (P4 latent) — streaming failed-boundary multi-emit
`process-resolved-template!` emitted `:rf.ssr/suspense-boundary-failed` regardless of swap success, while `seen` was conj'd only on success. A resolved-failed `<template>` swept before its live mount existed re-emitted the trace on every MutationObserver re-sweep. **Fix:** gate the emit on `(and failed? swapped?)` — the failed content only lands on a successful swap, which removes the template + marks it seen, so the trace fires exactly once. Latent on the shipped FIFO emitter (a fallback mount always materialises first).

## Tests
- JVM↔CLJS hash-parity corpus: added `fn-head-child` (`c105e684`) and `whole-double` (`5ef66c2e`) fixtures — pinned literals verified identical on both runtimes by the JVM + CLJS parity suites.
- Adversarial JVM tests: distinct fn objects for the same tree hash identically (no spurious mismatch); a whole double hashes + renders as its integer form in child and attr position.
- Adversarial CLJS-DOM test: a no-mount failed chunk emits nothing across re-sweeps and emits exactly once when its mount arrives late.

## Quality gates
Run foreground (full spine deferred to CI):
- `implementation/ssr` `clojure -M:test` — **370 tests, 1508 assertions, 0 failures**
- `implementation/ssr-ring` `clojure -M:test` — **162 tests, 768 assertions, 0 failures**
- `implementation` `npm run test:cljs` (node) — **8309 tests, 38209 assertions, 0 failures** (validates cross-runtime hash parity for the new fixtures)

Note: the streaming client fix is CLJS-DOM; the node gate compiles it and runs non-DOM assertions, but the exactly-once DOM assertions are browser-gated (`npm run test:browser`) — deferred to CI. No `spec/011` / conformance-fixture change was needed (the documented traversal contract is unchanged; the conformance corpus has no fn/double inputs).

## Stance
Pre-alpha, no back-compat shims; ELEGANCE + CLARITY + CORRECTNESS + GOOD PRACTICE.