### PR TITLE
fix(xray): prefix-match rf.route/rf.machine op families in trace classifier + L2 badge (rf2-409jka +1)

### DIFF
--- a/tools/xray/spec/023-Trace-Panel.md
+++ b/tools/xray/spec/023-Trace-Panel.md
@@ -269,6 +269,7 @@ Every Spec-009 trace operation → its row. The **Stage** column is the Epoch pi
 | `:rf.flow/cleared` · `failed` · `skip` | FLOW | FLOW | cleared / failed / skipped | flow-id | — |
 | `:rf.route/activated` · `deactivated` · `cleared` · `fragment-changed` | EFFECT HANDLERS | ROUTING | activated / deactivated / cleared / fragment-changed | route-id / fragment | — |
 | `:rf.route/navigation-blocked` | EFFECT HANDLERS | ROUTING | navigation-blocked | route-id (guard) | — (→ outcome :blocked) |
+| `:rf.route.nav-token/allocated` (emitted every navigation; op-type `:rf.event`, SUB-namespaced `rf.route.nav-token` — matched by the `rf.route*` family prefix, not an exact `rf.route` namespace) | EFFECT HANDLERS | ROUTING | allocated | route-id | — |
 | `:rf.warning/no-not-found-route` | inline (its stage) | WARNING | no-not-found-route | url (unmatched, no `:rf.route/not-found` route registered) | — |
 | `:rf.event/dispatched [:rf.route/handle-url-change …]` | DISPATCH | EVENT | dispatched | url (the URL-change EVENT — **not** a standalone trace op; it rides the `:rf.event/dispatched` row above) | — (↗ child) |
 | `:rf.machine.timer/scheduled` | EFFECT HANDLERS | MACHINE | timer-scheduled | delay · state | — (↗ future epoch) |

--- a/tools/xray/src/day8/re_frame2_xray/panels/l2_timeline.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/l2_timeline.cljc
@@ -295,12 +295,19 @@
          events)))
 
 (defn- has-machine-op?
-  "True when any event in `events` is a `:rf.machine/*` trace —
-  state-machine transition / spawn / despawn."
+  "True when any event in `events` is a `:rf.machine*` trace —
+  state-machine transition / spawn / despawn. Match by NAMESPACE PREFIX:
+  most non-transition machine activity is emitted under sub-namespaces
+  (`:rf.machine.spawn/*`, `:rf.machine.lifecycle/destroyed`,
+  `:rf.machine.timer/*`, `:rf.machine.microstep/transition`), so an exact
+  `= \"rf.machine\"` match would under-report spawn/despawn/timer-only
+  epochs — contradicting the docstring. Mirrors the prefix-matchers in
+  `trace_helpers/area` and `managed_fx_helpers/classify-fx-id`."
   [events]
   (boolean
    (some (fn [ev]
-           (= "rf.machine" (op-namespace (:operation ev))))
+           (when-let [ns (op-namespace (:operation ev))]
+             (str/starts-with? ns "rf.machine")))
          events)))
 
 (defn- has-http-op?

--- a/tools/xray/src/day8/re_frame2_xray/panels/trace_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/trace_helpers.cljc
@@ -106,7 +106,13 @@
       (= op-ns "rf.epoch")               :epoch
       (= op-ns "rf.cofx")                :coeffect
       (= op-ns "rf.flow")                :flow
-      (= op-ns "rf.route")               :routing
+      ;; Routing rides op-type :rf.event; discriminate by NAMESPACE PREFIX
+      ;; before the generic :rf.event fallthrough. The nav-token substrate
+      ;; emits under sub-namespaces (`:rf.route.nav-token/allocated`, emitted
+      ;; every navigation), so an exact `= "rf.route"` match would badge the
+      ;; most common routing op as a bare EVENT. Prefix covers the whole
+      ;; `rf.route*` family; `rf.resource` does not start with `rf.route`.
+      (and op-ns (str/starts-with? op-ns "rf.route")) :routing
       (= op-ns "rf.resource")            :resource
       (= op-type :rf.event)              :event
       (= op-type :rf.fx)                 :fx

--- a/tools/xray/test/day8/re_frame2_xray/panels/l2_timeline_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/l2_timeline_cljs_test.cljc
@@ -276,7 +276,33 @@
     (let [flags (l2/event-bundle-activity-flags
                  {:other [(ev :rf.machine/spawn)
                           (ev :rf.machine/despawn)]})]
-      (is (true? (:machine? flags))))))
+      (is (true? (:machine? flags)))))
+  (testing "rf2-uxp0u5 — SUB-namespaced machine ops set the ◆ badge too.
+            Most non-transition machine activity is emitted under
+            sub-namespaces (`rf.machine.spawn`, `.lifecycle`, `.timer`,
+            `.microstep`, `.spawn-all`). An exact `= \"rf.machine\"` match
+            missed them all, so a spawn/despawn/timer/microstep-only epoch
+            under-reported its machine activity — contradicting the fn
+            docstring. Prefix-matching the `rf.machine*` family fixes it."
+    (doseq [op [:rf.machine.spawn/spawned
+                :rf.machine.lifecycle/destroyed
+                :rf.machine.timer/scheduled
+                :rf.machine.timer/fired
+                :rf.machine.timer/cancelled
+                :rf.machine.microstep/transition
+                :rf.machine.spawn-all/spawned]]
+      (is (true? (:machine? (l2/event-bundle-activity-flags {:other [(ev op)]})))
+          (str op " should set :machine?")))
+    ;; a spawn/timer-only bundle (NO accompanying bare :rf.machine/transition)
+    ;; still surfaces the ◆ badge — the false-negative the bug produced.
+    (let [flags (l2/event-bundle-activity-flags
+                 {:other [(ev :rf.machine.spawn/spawned)
+                          (ev :rf.machine.timer/fired)]})]
+      (is (true? (:machine? flags))))
+    ;; guard against over-broad matching: a non-machine op stays false.
+    (let [flags (l2/event-bundle-activity-flags
+                 {:other [(ev :rf.event/dispatched)]})]
+      (is (false? (:machine? flags))))))
 
 (deftest event-bundle-activity-flags-http-test
   (testing ":rf.http/* operation → http? true"

--- a/tools/xray/test/day8/re_frame2_xray/panels/trace_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/trace_helpers_cljs_test.cljc
@@ -157,9 +157,32 @@
   (testing "namespace fallback when :op-type isn't stamped"
     (is (= :epoch (h/area {:operation :rf.epoch/outcome})))
     (is (= :routing (h/area {:operation :rf.route/deactivated})))
+    (is (= :routing (h/area {:operation :rf.route.nav-token/allocated})))
     (is (= :machine (h/area {:operation :rf.machine.timer/scheduled}))))
   (testing "unknown ops fall back to :event-adjacent neutral"
     (is (= :event (h/area {:op-type :totally-made-up})))))
+
+(deftest nav-token-allocated-is-routing-not-a-bare-event
+  ;; rf2-409jka — every navigation emits `:rf.route.nav-token/allocated`
+  ;; at op-type :rf.event under the `rf.route.nav-token` SUB-namespace
+  ;; (implementation/routing/.../events.cljc). The prior exact
+  ;; `= "rf.route"` match let it fall through to the generic :rf.event
+  ;; branch: badged EVENT (not ROUTING), staged HANDLER (not
+  ;; SIDE-EFFECTS → wrong left-edge colour), and `target-detail` took the
+  ;; :event branch (rendering the absent `:rf.event/v` → em-dash instead
+  ;; of the route-id). Prefix-matching the `rf.route*` family fixes all
+  ;; three symptoms at once.
+  (let [row (ev {:id 1 :op-type :rf.event
+                 :operation :rf.route.nav-token/allocated
+                 :tags {:route-id :dashboard :nav-token 7}})]
+    (testing "classifies as ROUTING (not the bare EVENT it fell through to)"
+      (is (= :routing (h/area row)))
+      (is (= "ROUTING" (h/area-badge row))))
+    (testing "stages effect-side — SIDE-EFFECTS + :effects phase"
+      (is (= :SIDE-EFFECTS (h/stage row)))
+      (is (= :effects (h/phase row))))
+    (testing "target-detail renders the route-id (not an em-dash)"
+      (is (= ":dashboard" (h/target-detail row))))))
 
 (deftest area-badge-renders-uppercase-text
   (is (= "EVENT" (h/area-badge {:op-type :rf.event :operation :rf.event/dispatched})))


### PR DESCRIPTION
Two id-rename fallout fixes in `tools/xray`: both classifiers exact-matched an op-namespace and so missed the `:rf.route.*` / `:rf.machine.*` sub-namespaces the runtime actually emits. Both are now prefix-matchers, consistent with how the machine family is already handled in `trace_helpers/area` and `managed_fx_helpers/classify-fx-id`.

## rf2-409jka (P3) — Trace panel mis-badges routing nav-token ops

`panels/trace_helpers.cljc` `area` classified routing by an exact `(= op-ns "rf.route")`. `:rf.route.nav-token/allocated` (op-ns `rf.route.nav-token`) is emitted on **every navigation** yet fell through to the generic `:rf.event` branch → badged **EVENT** not ROUTING, staged **HANDLER** not SIDE-EFFECTS (wrong left-edge colour), and `target-detail` rendered an em-dash instead of the route-id. Now prefix-matches the whole `rf.route*` family.

Verified the only `rf.route*` trace **operations** are `rf.route` + `rf.route.nav-token` (`rf.route.internal/*` are event-ids dispatched as `:rf.event/dispatched`, never operations); no non-routing op namespace begins with `rf.route` (`rf.resource` does not).

## rf2-uxp0u5 (P4) — L2 ◆ activity badge under-reports machine ops

`panels/l2_timeline.cljc` `has-machine-op?` exact-matched `"rf.machine"`, missing `:rf.machine.spawn/*`, `:rf.machine.lifecycle/destroyed`, `:rf.machine.timer/*`, `:rf.machine.microstep/transition`, `:rf.machine.spawn-all/*`. A spawn/despawn/timer/microstep-only epoch (no bare `:rf.machine/transition`) showed no ◆ badge and was dropped from the activity tooltip — contradicting the fn's docstring. Now prefix-matches `rf.machine*`.

Verified every real machine trace operation uses a dot-separated `rf.machine*` namespace; the hyphenated `rf.machine-*` keywords are test machine-IDs (in `:tags`, never `:operation`), so the prefix cannot over-capture.

## Tests
Added ≥1 adversarial test per fix:
- `:rf.route.nav-token/allocated` → `:routing` + `"ROUTING"` + `:SIDE-EFFECTS`/`:effects` + route-id `target-detail`.
- each sub-namespaced machine op sets `:machine?`; a spawn/timer-only bundle still sets the badge; a non-machine op keeps `:machine?` false.

## Spec
`tools/xray/spec/023-Trace-Panel.md` — added the `:rf.route.nav-token/allocated` row to the op-classification matrix (the completeness contract). L2 spec unchanged: 018-Event-Spine.md already documents machine activity as covering "spawn/destroy"; this brings the code into conformance.

## Quality gates
- `clojure -M:test` (from `tools/xray`): **1233 tests, 5710 assertions, 0 failures, 0 errors** — the authoritative focused gate; directly exercises both changed classifiers incl. the new adversarial tests.
- Full spine + browser `test:xray-feature-gate` deferred to CI (heavy Playwright integration gate; the pure-data classifier changes are covered by the green JVM unit suite).

Stance: pre-alpha, no back-compat shims; ELEGANCE + CLARITY + CORRECTNESS + GOOD PRACTICE.
