### PR TITLE
fix(template): gate SSR client+host compile; drop retired malli soft-pass scaffolding (rf2-e0xspa +1)

### DIFF
--- a/tools/template/resources/day8/re_frame2_template/_reagent/core_with_ssr.cljc
+++ b/tools/template/resources/day8/re_frame2_template/_reagent/core_with_ssr.cljc
@@ -30,12 +30,15 @@
      event), VERIFY the render hash — then mounts on top of the seeded
      state. No flash, no re-fetch."
   (:require [re-frame.core :as rf]
-            ;; Schema hooks + the Malli adapter — required as side-effecting
-            ;; loads so the `reg-app-schema` call below has a real validator
-            ;; to resolve to (without the Malli adapter the default validator
-            ;; soft-passes per Spec 010).
+            ;; Schema hooks — required as a side-effecting load so the
+            ;; `reg-app-schema` calls below have a live validator to resolve
+            ;; to. Requiring `re-frame.schemas` makes the default Malli
+            ;; validator live: the artefact `:require`s its Malli adapter
+            ;; itself at ns-load (on both platforms), so a registered schema
+            ;; validates rather than soft-passing — "schema implies
+            ;; validation" (rf2-v96fh). Mirrors the canonical SSR example
+            ;; (examples/capabilities/ssr/ssr/core.cljc).
             [re-frame.schemas]
-            #?(:cljs [re-frame.schemas.malli])
             ;; The SSR machinery: the framework-owned `:rf/hydrate` event, the
             ;; render/hash hooks, and (JVM-side) the pure hiccup -> HTML
             ;; emitter. Required on both platforms so `:rf/hydrate` is

--- a/tools/template/resources/day8/re_frame2_template/_shared/events.cljs
+++ b/tools/template/resources/day8/re_frame2_template/_shared/events.cljs
@@ -29,12 +29,15 @@
             ;;      gate." That is why the `register-listener!` form
             ;;      below sits inside `(when ^boolean goog.DEBUG ...)`.
             [re-frame.trace.tooling :as trace-tooling]
-            ;; Schema artefact — required as a side-effecting load so
-            ;; the late-bind hooks publish before {{namespace}}.schema
-            ;; runs its `reg-app-schema` registrations. Pulls in Malli
-            ;; via the schemas artefact's deps.
+            ;; Schema artefact — required as a side-effecting load so the
+            ;; late-bind hooks publish before {{namespace}}.schema runs its
+            ;; `reg-app-schema` registrations. Requiring `re-frame.schemas`
+            ;; makes the default Malli validator LIVE: the artefact
+            ;; `:require`s `re-frame.schemas.malli` itself at ns-load, so a
+            ;; registered schema validates rather than soft-passing —
+            ;; "schema implies validation" (rf2-v96fh). No separate Malli
+            ;; require is needed.
             [re-frame.schemas]
-            [re-frame.schemas.malli]
             ;; Schema registrations — loaded for the
             ;; `(reg-app-schema [] CounterDb)` side-effect that
             ;; wires the root app-db validator before any handler commits.

--- a/tools/template/resources/day8/re_frame2_template/_shared/schema.cljs
+++ b/tools/template/resources/day8/re_frame2_template/_shared/schema.cljs
@@ -16,10 +16,14 @@
    and the [Feature-modularity prefix
    convention](https://github.com/day8/re-frame2/blob/main/spec/Conventions.md#feature-modularity-prefix-convention).
 
-   The schemas artefact (`day8/re-frame2-schemas`) and the Malli adapter
-   (`re-frame.schemas.malli`) are loaded as side-effects in events.cljs
-   — that publishes Malli's `validate` and `explain` into the framework's
-   late-bind hook table before any `reg-app-schema` call runs.
+   The schemas artefact (`day8/re-frame2-schemas`) is loaded as a
+   side-effect in events.cljs. Requiring `re-frame.schemas` makes the
+   default Malli validator live — the artefact `:require`s its Malli
+   adapter (`re-frame.schemas.malli`) itself at ns-load, publishing
+   Malli's `validate` and `explain` into the framework's late-bind hook
+   table before any `reg-app-schema` call runs. \"Schema implies
+   validation\" (rf2-v96fh): there is no registered-but-silently-inert
+   state.
 
    Schemas validate **in dev** (and on JVM unless production-hardened);
    the validation check elides automatically under `:advanced`

--- a/tools/template/resources/day8/re_frame2_template/_shared/ssr_test.clj
+++ b/tools/template/resources/day8/re_frame2_template/_shared/ssr_test.clj
@@ -20,11 +20,19 @@
    sees its own per-request frame id (`ssr-ring/ssr-handler` gensyms it
    internally), so a test that supplies the frame id itself cannot catch a
    regression in how the schema attaches to THAT path (rf2-hbobni). The
-   two tests below exercise the REAL `ssr-ring/ssr-handler` construction
-   server.clj uses — the happy path renders normally, and a deliberately
-   schema-violating commit is REJECTED, proving `:ssr/register-schema`
-   attaches the whole-app-db schema to the exact frame `ssr-handler`
-   constructs for the request, not a different/default one.
+   two tests below exercise the REAL server path — the happy path drives
+   `server.clj`'s own `make-handler` (not a hand-rolled copy) and renders
+   normally, and a deliberately schema-violating commit is REJECTED,
+   proving `:ssr/register-schema` attaches the whole-app-db schema to the
+   exact frame `ssr-handler` constructs for the request, not a
+   different/default one.
+
+   Requiring `{{namespace}}.server` here is load-bearing beyond the one
+   test that calls it: it is the ONLY thing that compiles the Ring host
+   under `clojure -M:test` (the SSR scaffold's sole automated gate). Before
+   this require nothing loaded `server.clj`, so a framework rename on the
+   host surface (`ssr-ring/ssr-handler`, `ssr/adapter`) shipped
+   broken-but-green and first broke on `clojure -X:server` (rf2-e0xspa).
 
    Run it with `clojure -M:test` (the `:test` alias picks it up alongside
    the CLJS node-test build)."
@@ -33,7 +41,13 @@
             [re-frame.core :as rf]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.ring :as ssr-ring]
-            [{{namespace}}.core :as app]))
+            [{{namespace}}.core :as app]
+            ;; The Ring host. Requiring it compiles server.clj under
+            ;; `clojure -M:test`, so a rename on its framework surface fails
+            ;; the build here instead of on first `clojure -X:server`
+            ;; (rf2-e0xspa). The happy-path test below drives its real
+            ;; `make-handler`.
+            [{{namespace}}.server :as server]))
 
 (deftest ssr-render-produces-hydration-ready-html
   (testing "the SSR server flow renders the counter to HTML with a render hash"
@@ -83,17 +97,19 @@
                client-side hydration-mismatch check"))))))
 
 (deftest ssr-handler-renders-through-the-real-production-path
-  (testing "the REAL ssr-ring/ssr-handler construction (mirroring server.clj's
-            make-handler) renders normally end-to-end — :ssr/register-schema
-            doesn't disturb the happy path"
+  (testing "server.clj's OWN make-handler (the composite Ring handler
+            `clojure -X:server` serves) renders normally end-to-end —
+            :ssr/register-schema doesn't disturb the happy path, and
+            requiring the host ns compiles server.clj (rf2-e0xspa)"
     (rf/init! ssr/adapter)
-    (let [handler (ssr-ring/ssr-handler
-                    {:initial-events app/server-init-events
-                     :root-view      app/root-view
-                     :payload        [:counter/value]})
+    ;; Build the actual production handler from server.clj — not a
+    ;; hand-rolled `ssr-ring/ssr-handler` copy. `static-root` only matters
+    ;; for the `/main.js` route; the SSR render path below (`:uri \"/\"`)
+    ;; never touches it, so any path serves.
+    (let [handler (server/make-handler "resources/public/js")
           resp    (handler {:uri "/" :request-method :get})]
       (is (= 200 (:status resp))
-          "the production ssr-handler path renders a normal 200 response")
+          "the production server/make-handler path renders a normal 200 response")
       (is (string/includes? (:body resp) "data-rf-render-hash")
           "the response body carries the render-hash tripwire"))))
 

--- a/tools/template/test/day8/re_frame2_template/template_emission_test.clj
+++ b/tools/template/test/day8/re_frame2_template/template_emission_test.clj
@@ -46,19 +46,22 @@
 
 ;; --- Static-parse machinery ----------------------------------------------
 
-(defn- read-cljs-forms
-  "Read every top-level form from a .cljs file. Each form is returned in
-  source order. Uses `clojure.tools.reader` (not `clojure.edn`) because
-  the emitted views.cljs contains `#(...)` function literals and the
-  framework cljc files use reader conditionals. We bind `*read-eval*`
-  off and treat unknown tags as identity so any future `#js` etc. in
-  the scaffold doesn't trip us."
-  [^java.io.File f]
+(defn- read-source-forms
+  "Read every top-level form from a Clojure/ClojureScript source file,
+  resolving reader conditionals under `features` (`#{:cljs}` for the
+  browser branch of a `.cljc`; `#{:clj}` for the JVM branch / a plain
+  `.clj` host like the SSR `server.clj`). Each form is returned in source
+  order. Uses `clojure.tools.reader` (not `clojure.edn`) because the
+  emitted views.cljs contains `#(...)` function literals and the framework
+  cljc files use reader conditionals. We bind `*read-eval*` off and treat
+  unknown tags as identity so any future `#js` etc. in the scaffold
+  doesn't trip us."
+  [^java.io.File f features]
   (let [eof    (Object.)
         reader (rt/source-logging-push-back-reader (slurp f))
         ;; tools.reader respects *data-readers*; supply a permissive
         ;; default-data-reader so unknown tags don't throw.
-        opts   {:eof eof :read-cond :allow :features #{:cljs}
+        opts   {:eof eof :read-cond :allow :features features
                 :default (fn [_tag value] value)}]
     (binding [tr/*read-eval* false
               tr/*default-data-reader-fn* (fn [_tag value] value)]
@@ -67,6 +70,13 @@
           (if (identical? form eof)
             acc
             (recur (conj acc form))))))))
+
+(defn- read-cljs-forms
+  "Read a source file under the `:cljs` reader-conditional view (the
+  browser branch of a `.cljc`). The common case — see `read-source-forms`
+  for the general form (the SSR audit reads `server.clj` under `:clj`)."
+  [^java.io.File f]
+  (read-source-forms f #{:cljs}))
 
 (defn- parse-ns-requires
   "Given a `(ns ns-sym ...)` form, return a map
@@ -166,7 +176,16 @@
        sub-namespaces) — Story ships as its own downstream tool coord
        (`day8/re-frame2-story`) under `tools/story/`. The template's
        with-stories core requires `re-frame.story`; the audit needs
-       to find it where it actually lives."
+       to find it where it actually lives.
+
+    4. `implementation/ssr/src/re_frame/ssr.cljc` (+ `re-frame.ssr.*`)
+       and `implementation/ssr-ring/src/re_frame/ssr/ring.clj` — the SSR
+       runtime (`day8/re-frame2-ssr`) and its Ring host adapter
+       (`day8/re-frame2-ssr-ring`) ship as their own downstream coords.
+       The `:include-ssr?` scaffold's `core.cljc` requires `re-frame.ssr`
+       and its `server.clj` requires `re-frame.ssr.ring`; the audit needs
+       to resolve both. `re-frame.ssr.ring` is JVM-only, so a `.clj`
+       candidate is included (rf2-e0xspa)."
   [root ns-sym]
   (let [name- (name ns-sym)]
     (cond
@@ -188,7 +207,13 @@
                                 (io/file root "implementation/core/src/re_frame" (str rel ".cljs"))
                                 ;; tools/story/ — re-frame.story + re-frame.story.* live here.
                                 (io/file root "tools/story/src/re_frame" (str rel ".cljc"))
-                                (io/file root "tools/story/src/re_frame" (str rel ".cljs"))]
+                                (io/file root "tools/story/src/re_frame" (str rel ".cljs"))
+                                ;; implementation/ssr/ — re-frame.ssr + re-frame.ssr.*.
+                                (io/file root "implementation/ssr/src/re_frame" (str rel ".cljc"))
+                                (io/file root "implementation/ssr/src/re_frame" (str rel ".cljs"))
+                                ;; implementation/ssr-ring/ — re-frame.ssr.ring (JVM-only .clj).
+                                (io/file root "implementation/ssr-ring/src/re_frame" (str rel ".clj"))
+                                (io/file root "implementation/ssr-ring/src/re_frame" (str rel ".cljc"))]
                          adapter-flavour
                          (conj (io/file root "implementation/adapters"
                                         adapter-flavour
@@ -413,50 +438,57 @@
        `reg-view` would ship the Reagent scaffold broken-but-green.
     2. Bare, `:refer`-ed framework symbols whose source ns
        is `re-frame.*` (none in the current scaffolds, but the audit
-       still covers the shape so a future `:refer` stays honest)."
-  [substrate ^java.io.File file root]
-  (when (.isFile file)
-    (let [forms      (read-cljs-forms file)
-          ns-form    (first forms)
-          requires   (parse-ns-requires ns-form)
-          body-forms (rest forms)
-          ;; (1) A vector of [referenced-symbol resolved-ns] pairs for
-          ;; every qualified symbol whose alias resolves to a re-frame.*
-          ;; ns.
-          qual-refs  (->> (collect-qualified-symbols body-forms)
-                          (keep (fn [qsym]
-                                  (let [alias-sym (symbol (namespace qsym))
-                                        target-ns (get requires alias-sym)]
-                                    (when (and target-ns
-                                               (string/starts-with?
-                                                 (name target-ns)
-                                                 "re-frame."))
-                                      [qsym target-ns]))))
-                          ;; Dedup by (target-ns + symbol-name) — the same
-                          ;; reference often appears many times in a file
-                          ;; (e.g. rf/dispatch in views).
-                          (group-by (fn [[qsym target-ns]]
-                                      [target-ns (symbol (name qsym))]))
-                          keys)
-          ;; (2) Bare, `:refer`-ed framework symbols that actually appear
-          ;; in the body. We intersect the ns form's `:refer` set with the
-          ;; bare symbols the body uses, so an unused `:refer` (dead, but
-          ;; harmless) isn't flagged — only symbols the scaffold relies on.
-          referred   (::referred requires)
-          bare-used  (collect-bare-symbols body-forms)
-          bare-refs  (->> referred
-                          (keep (fn [[sym target-ns]]
-                                  (when (and (contains? bare-used sym)
-                                             (string/starts-with?
-                                               (name target-ns)
-                                               "re-frame."))
-                                    [sym target-ns]))))]
-      (doseq [[target-ns sym] qual-refs]
-        (audit-framework-symbol! substrate file root target-ns sym
-                                 "references"))
-      (doseq [[sym target-ns] bare-refs]
-        (audit-framework-symbol! substrate file root target-ns sym
-                                 "refers (bare)")))))
+       still covers the shape so a future `:refer` stays honest).
+
+  `features` selects the reader-conditional view: the 3-arg arity reads
+  under `:cljs` (the browser branch of a `.cljc` / a `.cljs` file); the
+  SSR host audit passes `#{:clj}` to read `server.clj` under the JVM
+  branch (rf2-e0xspa)."
+  ([substrate ^java.io.File file root]
+   (audit-framework-surface! substrate file root #{:cljs}))
+  ([substrate ^java.io.File file root features]
+   (when (.isFile file)
+     (let [forms      (read-source-forms file features)
+           ns-form    (first forms)
+           requires   (parse-ns-requires ns-form)
+           body-forms (rest forms)
+           ;; (1) A vector of [referenced-symbol resolved-ns] pairs for
+           ;; every qualified symbol whose alias resolves to a re-frame.*
+           ;; ns.
+           qual-refs  (->> (collect-qualified-symbols body-forms)
+                           (keep (fn [qsym]
+                                   (let [alias-sym (symbol (namespace qsym))
+                                         target-ns (get requires alias-sym)]
+                                     (when (and target-ns
+                                                (string/starts-with?
+                                                  (name target-ns)
+                                                  "re-frame."))
+                                       [qsym target-ns]))))
+                           ;; Dedup by (target-ns + symbol-name) — the same
+                           ;; reference often appears many times in a file
+                           ;; (e.g. rf/dispatch in views).
+                           (group-by (fn [[qsym target-ns]]
+                                       [target-ns (symbol (name qsym))]))
+                           keys)
+           ;; (2) Bare, `:refer`-ed framework symbols that actually appear
+           ;; in the body. We intersect the ns form's `:refer` set with the
+           ;; bare symbols the body uses, so an unused `:refer` (dead, but
+           ;; harmless) isn't flagged — only symbols the scaffold relies on.
+           referred   (::referred requires)
+           bare-used  (collect-bare-symbols body-forms)
+           bare-refs  (->> referred
+                           (keep (fn [[sym target-ns]]
+                                   (when (and (contains? bare-used sym)
+                                              (string/starts-with?
+                                                (name target-ns)
+                                                "re-frame."))
+                                     [sym target-ns]))))]
+       (doseq [[target-ns sym] qual-refs]
+         (audit-framework-symbol! substrate file root target-ns sym
+                                  "references"))
+       (doseq [[sym target-ns] bare-refs]
+         (audit-framework-symbol! substrate file root target-ns sym
+                                  "refers (bare)"))))))
 
 ;; --- scratch.cljs with-frame shape audit -----------------------------------
 ;;
@@ -936,6 +968,58 @@
           (doseq [rel ["src/acme/my_app/core.cljs"
                        "src/acme/my_app/stories.cljs"]]
             (audit-framework-surface! :reagent (io/file proj rel) root)))
+        (finally
+          (delete-recursively tmp))))))
+
+;; --- :include-ssr? -------------------------------------------------------
+;;
+;; The SSR scaffold is the template's LEAST-covered variant (rf2-e0xspa):
+;; its emitted-run tier (`emitted_test_run_test.clj`) executes only
+;; `clojure -M:test`, which loads `core.cljc`'s `:clj` branch (via
+;; `ssr_test.clj`'s `[…core :as app]` require) and — since rf2-e0xspa —
+;; `server.clj` (via `ssr_test.clj`'s new `[…server :as server]` require).
+;; But NO gate compiles `core.cljc`'s `:cljs` CLIENT branch (the hydration
+;; path: `ssr/hydrate!`, `rf/view`, `rf/frame-provider`, the reagent
+;; adapter, `reagent.dom.client`), and that emitted-run tier is opt-in
+;; (`RF2_TEMPLATE_RUN_EMITTED_TESTS`). So a framework rename on the SSR
+;; client/host surface used to ship broken-but-green.
+;;
+;; This audit closes that gap CHEAPLY on every PR (no node, no shadow, no
+;; env gate): it reads the emitted `core.cljc` under the `:cljs`
+;; reader-conditional view — the exact CLIENT branch no compile touches —
+;; and `server.clj` under the `:clj` view, and asserts every referenced
+;; `re-frame.*` / `re-frame.ssr(.ring)` symbol is actually defined in the
+;; framework source. A rename (e.g. `ssr/hydrate!` → `ssr/hydrate`,
+;; `ssr-ring/ssr-handler` → `…/handler`, `rf/frame-provider` → `…/provider`)
+;; trips this JVM check. `framework-ns-file` above resolves the SSR coords
+;; (implementation/ssr/ + implementation/ssr-ring/).
+
+(deftest reagent-ssr-emission-static-parse-test
+  (testing ":include-ssr? true emits a core.cljc whose :cljs CLIENT branch
+            + a server.clj Ring host that reference only defined re-frame.*
+            + re-frame.ssr(.ring) symbols (rf2-e0xspa)"
+    (let [tmp  (tmp-dir "rf2-emission-ssr-")
+          root (repo-root)]
+      (try
+        (let [proj (run-template-opts! tmp "acme/my-app"
+                                       {:substrate :reagent :include-ssr? true})]
+          ;; The CLIENT (:cljs) branch of the shared core.cljc — compiled
+          ;; by no gate. Read under `:features #{:cljs}` so the audit sees
+          ;; exactly the browser-side requires (`reagent.dom.client`, the
+          ;; reagent adapter) + hydration calls (`ssr/hydrate!`, `rf/view`,
+          ;; `rf/frame-provider`).
+          (audit-framework-surface! :reagent
+                                    (io/file proj "src/acme/my_app/core.cljc")
+                                    root #{:cljs})
+          ;; The Ring host — a JVM-only `.clj`. Read under `:features
+          ;; #{:clj}`. Its framework surface (`ssr-ring/ssr-handler`,
+          ;; `ssr/adapter`, `rf/init!`) is now ALSO compiled for real by the
+          ;; emitted `ssr_test.clj`'s `[…server :as server]` require under
+          ;; `clojure -M:test`; this ungated static check is the fast-loop
+          ;; net that catches a rename without the opt-in emitted-run tier.
+          (audit-framework-surface! :reagent
+                                    (io/file proj "src/acme/my_app/server.clj")
+                                    root #{:clj}))
         (finally
           (delete-recursively tmp))))))
 


### PR DESCRIPTION
Two `tools/template`-only correctness fixes from the 2026-07-09 correctness review. Touches only `tools/template`.

## rf2-e0xspa (P2) — SSR scaffold client (:cljs) + server.clj compiled by no gate

The SSR scaffold was the template's least-covered variant. Its emitted-run tier runs only `clojure -M:test` (which loads `core.cljc`'s `:clj` branch via `ssr_test.clj`'s `[…core :as app]` require); **no** gate compiled `core.cljc`'s `:cljs` CLIENT hydration branch (`ssr/hydrate!`, `rf/view`, `rf/frame-provider`, the reagent adapter), **nothing** loaded `server.clj` (the Ring host — `ssr_test.clj` reconstructed `ssr-handler` inline), and the static-parse audit skipped both files. A framework rename on any SSR client/host surface shipped **broken-but-green** and first broke on a newcomer's `npx shadow-cljs watch app` / `clojure -X:server`.

Closed on two fronts:

- **Ungated static-parse audit** (`template_emission_test.clj`, runs on every PR — no node, no shadow): generalised the reader to a features set; extended `framework-ns-file` to resolve `re-frame.ssr` (`implementation/ssr/`) and `re-frame.ssr.ring` (`implementation/ssr-ring/`, JVM `.clj`); added `reagent-ssr-emission-static-parse-test` auditing `core.cljc` under `:cljs` and `server.clj` under `:clj`. A rename now trips a fast JVM check.
- **Real require coverage** (emitted `_shared/ssr_test.clj`): it now requires the app's `.server` ns and drives its own `make-handler` (not a hand-rolled `ssr-handler` copy), so `clojure -M:test` — the SSR scaffold's only automated gate, run by `npm test` + generated CI — compiles `server.clj` for real. The coverage also ships to consumers.

### Proof the gate now has teeth

Temporarily renamed `ssr/hydrate!` → `ssr/hydrate-BROKEN!` (client branch) and `ssr-ring/ssr-handler` → `ssr-ring/ssr-handler-BROKEN` (host) in the template sources; `reagent-ssr-emission-static-parse-test` failed with **2 failures** naming both undefined symbols against the correct framework files (`implementation/ssr/src/re_frame/ssr.cljc`, `implementation/ssr-ring/src/re_frame/ssr/ring.clj`). Reverted.

## rf2-v1i18z (P3) — redundant re-frame.schemas.malli require + retired soft-pass guidance

`re-frame.schemas` now `:require`s `re-frame.schemas.malli` itself at ns-load (rf2-v96fh — "schema implies validation"; verified at `implementation/schemas/src/re_frame/schemas.cljc:66`), so the separate `[re-frame.schemas.malli]` require in `events.cljs` + `core_with_ssr.cljc` is redundant and the "or the default validator soft-passes" comments teach a footgun the framework removed. Dropped the extra require and rewrote the guidance (`events.cljs`, `schema.cljs` docstring, `core_with_ssr.cljc`) to the current contract — matching the canonical SSR example (`examples/capabilities/ssr/ssr/core.cljc`), which already requires only `[re-frame.schemas]`. No runtime change (validation was live either way).

## Quality gates

- `clojure -M:test` (tools/template, ungated): **47 tests, 649 assertions, 0 failures, 0 errors** (green before and after the teeth experiment revert).
- `RF2_TEMPLATE_RUN_EMITTED_TESTS=1 clojure -M:test -v …/reagent-ssr-emitted-tests-run-test` (gated SSR emitted-run tier, clojure-only): **1 test, 4 assertions, 0 failures, 0 errors** — the inner `clojure -M:test` on the emitted SSR scaffold (now requiring `server.clj` + driving `make-handler`) exited 0. Real compile/require coverage of the Ring host proven end-to-end.
- Full spine deferred to CI.

## Stance

Pre-alpha, no back-compat shims. ELEGANCE + CLARITY + CORRECTNESS + GOOD PRACTICE. The static-parse audit reuses the existing surface-drift machinery (one consistent mechanism, ungated), and the `ssr_test.clj` change makes the emitted scaffold's own test exercise the emitted server it always claimed to mirror.