### PR TITLE
fix(examples-scripts): close asset-gate parser false-green/positive holes (rf2-cnu7qy +3)

### DIFF
--- a/examples/scripts/check-examples-assets.cjs
+++ b/examples/scripts/check-examples-assets.cjs
@@ -394,6 +394,14 @@ function attr(tag, name) {
   return m[2] != null ? m[2] : m[3] != null ? m[3] : m[4] != null ? m[4] : null;
 }
 
+// Strip CSS block comments `/* … */` from a source before scanning it for live
+// declarations. Commented-out CSS is inert, so an `@import`/`url()` inside a
+// comment must not be read as a live network fetch or an on-disk ref
+// (rf2-lvw3z9). Mirrors the og.svg comment strip used for the source-art check.
+function stripCssComments(css) {
+  return css.replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
 // Extract every ASSET-BEARING reference from an index.html's source, TAGGED
 // with the element/attribute it came from, so the direct-HTML network policy
 // (rf2-bf4vdy) can distinguish a remote asset fetch (rejected) from harmless
@@ -557,7 +565,9 @@ function extractCssImports(css) {
     const clean = raw.split(/[?#]/)[0].trim();
     if (clean && !out.includes(clean)) out.push(clean);
   };
-  for (const m of css.matchAll(
+  // Strip block comments first: a commented-out `@import` is inert and must
+  // not be read as a live network dep / on-disk ref (rf2-lvw3z9).
+  for (const m of stripCssComments(css).matchAll(
     /@import\s+(?:url\(\s*("([^"]*)"|'([^']*)'|([^)'"]*))\s*\)|("([^"]*)"|'([^']*)'))/gi,
   )) {
     push(m[2] || m[3] || m[4] || m[6] || m[7]);
@@ -579,9 +589,11 @@ function extractCssImports(css) {
 function extractCssUrls(css) {
   const out = [];
   const seen = new Set();
-  // Blank out `@import url(...)` occurrences first so they are not re-collected
-  // here (extractCssImports already owns the @import contract).
-  const body = css.replace(
+  // Strip block comments first (rf2-lvw3z9) — a commented-out `url(...)` is
+  // inert and must not be read as a live fetch — then blank out `@import
+  // url(...)` occurrences so they are not re-collected here (extractCssImports
+  // already owns the @import contract).
+  const body = stripCssComments(css).replace(
     /@import\s+url\(\s*(?:"[^"]*"|'[^']*'|[^)'"]*)\s*\)/gi,
     '',
   );

--- a/examples/scripts/check-examples-assets.cjs
+++ b/examples/scripts/check-examples-assets.cjs
@@ -380,15 +380,18 @@ function parseSrcset(value) {
   return urls;
 }
 
-// Read a single attribute's value off a tag string, ORDER-INDEPENDENTLY. HTML
-// attribute order is insignificant, so a value must be read positionally by
-// name rather than assuming a fixed attribute order (rf2-cnu7qy). Returns null
-// when the attribute is absent.
+// Read a single attribute's value off a tag string, ORDER-INDEPENDENTLY and
+// regardless of the value's quoting. HTML attribute order is insignificant
+// (rf2-cnu7qy) and HTML5 permits unquoted values (`<script src=main.js>`), so
+// the value form is one of: "double" | 'single' | bare-unquoted. The unquoted
+// form ends at the first whitespace / `>` / quote / `=` (rf2-3dzb6h). Returns
+// null when the attribute is absent.
 function attr(tag, name) {
   const m = tag.match(
-    new RegExp(`\\b${name}\\s*=\\s*("([^"]*)"|'([^']*)')`, 'i'),
+    new RegExp(`\\b${name}\\s*=\\s*("([^"]*)"|'([^']*)'|([^\\s>"'=]+))`, 'i'),
   );
-  return m ? (m[2] != null ? m[2] : m[3]) : null;
+  if (!m) return null;
+  return m[2] != null ? m[2] : m[3] != null ? m[3] : m[4] != null ? m[4] : null;
 }
 
 // Extract every ASSET-BEARING reference from an index.html's source, TAGGED
@@ -484,10 +487,14 @@ function extractHtmlRefs(html) {
     const clean = raw.split(/[?#]/)[0].trim();
     if (clean && !refs.includes(clean)) refs.push(clean);
   };
-  // href="..." / href='...' on <link> (and any element — anchors are
-  // in-page or external and get filtered by isExternalRef downstream).
-  for (const m of html.matchAll(/\b(?:href|src)\s*=\s*("([^"]*)"|'([^']*)')/gi)) {
-    push(m[2] != null ? m[2] : m[3]);
+  // href=... / src=... on <link> (and any element — anchors are in-page or
+  // external and get filtered by isExternalRef downstream). Double-quoted,
+  // single-quoted, AND bare unquoted values (`<script src=main.js>`), since
+  // HTML5 permits the unquoted form (rf2-3dzb6h).
+  for (const m of html.matchAll(
+    /\b(?:href|src)\s*=\s*("([^"]*)"|'([^']*)'|([^\s>"'=]+))/gi,
+  )) {
+    push(m[2] != null ? m[2] : m[3] != null ? m[3] : m[4]);
   }
   // srcset / imagesrcset candidate lists (<img>/<source> + preload <link>) —
   // each candidate URL must resolve on disk like a plain src (rf2-arkvq8). The
@@ -498,11 +505,12 @@ function extractHtmlRefs(html) {
     for (const u of parseSrcset(m[2] != null ? m[2] : m[3])) push(u);
   }
   // <video poster="..."> — the poster still resolves on disk like a src
-  // (rf2-arkvq8). The lookbehind excludes a `data-poster` attribute.
+  // (rf2-arkvq8). The lookbehind excludes a `data-poster` attribute; the
+  // unquoted alternative mirrors href/src (rf2-3dzb6h).
   for (const m of html.matchAll(
-    /(?<![-\w])poster\s*=\s*("([^"]*)"|'([^']*)')/gi,
+    /(?<![-\w])poster\s*=\s*("([^"]*)"|'([^']*)'|([^\s>"'=]+))/gi,
   )) {
-    push(m[2] != null ? m[2] : m[3]);
+    push(m[2] != null ? m[2] : m[3] != null ? m[3] : m[4]);
   }
   // <meta property="og:image" content="..."> — ORDER-INDEPENDENT. HTML
   // attribute order is insignificant, so a `content`-before-`property` meta is

--- a/examples/scripts/check-examples-assets.cjs
+++ b/examples/scripts/check-examples-assets.cjs
@@ -729,13 +729,100 @@ function contrastRatio(fgHex, bgHex) {
   return (hi + 0.05) / (lo + 0.05);
 }
 
-// Parse the `--ex-*: #hex;` custom-property declarations out of a style.css
-// source into a { tokenName: '#hex' } map. Only solid hex values are read
-// (the contrast checks operate on opaque token pairs).
+// Convert an opaque HSL colour to #rrggbb (WCAG contrast operates on opaque
+// pairs, so alpha is intentionally dropped upstream).
+function hslToHex(h, s, l) {
+  h = ((h % 360) + 360) % 360;
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const mm = l - c / 2;
+  let r = 0;
+  let g = 0;
+  let b = 0;
+  if (h < 60) [r, g, b] = [c, x, 0];
+  else if (h < 120) [r, g, b] = [x, c, 0];
+  else if (h < 180) [r, g, b] = [0, c, x];
+  else if (h < 240) [r, g, b] = [0, x, c];
+  else if (h < 300) [r, g, b] = [x, 0, c];
+  else [r, g, b] = [c, 0, x];
+  const to = (v) =>
+    Math.round((v + mm) * 255)
+      .toString(16)
+      .padStart(2, '0');
+  return `#${to(r)}${to(g)}${to(b)}`;
+}
+
+// Normalise a CSS colour literal to opaque #rrggbb, or null when the form is
+// not a computable opaque colour (var(), color-mix(), a named colour, …). Used
+// so the WCAG contrast gate can verify a palette expressed in ANY of the common
+// notations — not just #hex — and can tell a genuinely-opaque token from one it
+// cannot evaluate (rf2-nrieg0). Handles #rgb/#rgba/#rrggbb/#rrggbbaa (alpha
+// dropped), rgb()/rgba() (0-255 or %), and hsl()/hsla().
+function colorToHex(value) {
+  const v = String(value).trim();
+  let m = v.match(/^#([0-9a-fA-F]{3,8})$/);
+  if (m) {
+    let h = m[1];
+    if (h.length === 3 || h.length === 4) {
+      h = h
+        .split('')
+        .map((ch) => ch + ch)
+        .join('');
+    }
+    if (h.length < 6) return null; // e.g. a stray 5-digit form
+    return `#${h.slice(0, 6)}`; // drop any alpha pair
+  }
+  m = v.match(/^rgba?\(\s*([^)]*)\)$/i);
+  if (m) {
+    const parts = m[1].split(/[,/\s]+/).filter(Boolean).slice(0, 3);
+    if (parts.length < 3) return null;
+    const ch = parts.map((p) =>
+      p.endsWith('%')
+        ? Math.round((parseFloat(p) / 100) * 255)
+        : Math.round(parseFloat(p)),
+    );
+    if (ch.some((n) => Number.isNaN(n) || n < 0 || n > 255)) return null;
+    return `#${ch.map((n) => n.toString(16).padStart(2, '0')).join('')}`;
+  }
+  m = v.match(/^hsla?\(\s*([^)]*)\)$/i);
+  if (m) {
+    const parts = m[1].split(/[,/\s]+/).filter(Boolean);
+    if (parts.length < 3) return null;
+    const hh = parseFloat(parts[0]);
+    const ss = parseFloat(parts[1]) / 100;
+    const ll = parseFloat(parts[2]) / 100;
+    if ([hh, ss, ll].some((n) => Number.isNaN(n))) return null;
+    return hslToHex(hh, ss, ll);
+  }
+  return null;
+}
+
+// Every `--ex-*: value;` custom-property declaration as a { tokenName: rawValue }
+// map (value un-normalised, comments stripped). parseExTokens normalises each
+// value to hex; the contrast gate consults the raw map to distinguish a token
+// that is ABSENT/renamed (skip) from one that is DECLARED but not a computable
+// opaque colour (fail-loud) — rf2-nrieg0.
+function extractExTokenDecls(css) {
+  const decls = {};
+  for (const m of stripCssComments(css).matchAll(
+    /(--ex-[a-z0-9-]+)\s*:\s*([^;{}]+?)\s*(?=[;}])/gi,
+  )) {
+    decls[m[1]] = m[2].trim();
+  }
+  return decls;
+}
+
+// Parse the `--ex-*` custom-property declarations out of a style.css source
+// into a { tokenName: '#rrggbb' } map. Values in #hex / rgb() / hsl() notation
+// are all normalised to opaque hex (rf2-nrieg0); a token whose value is not a
+// computable opaque colour is omitted (and surfaced fail-loud by the contrast
+// gate when a contract row references it) — the contrast checks operate on
+// opaque token pairs.
 function parseExTokens(css) {
   const tokens = {};
-  for (const m of css.matchAll(/(--ex-[a-z0-9-]+)\s*:\s*(#[0-9a-fA-F]{3,8})\b/g)) {
-    tokens[m[1]] = m[2];
+  for (const [name, raw] of Object.entries(extractExTokenDecls(css))) {
+    const hex = colorToHex(raw);
+    if (hex) tokens[name] = hex;
   }
   return tokens;
 }
@@ -1211,14 +1298,46 @@ function checkSharedTree(io, opts = {}) {
     //     parsed --ex-* tokens so a palette edit that drops a pair below the
     //     floor turns the gate RED.
     const tokens = parseExTokens(style);
+    const decls = extractExTokenDecls(style);
     const resolve = (name) =>
       name.startsWith('--ex-') ? tokens[name] : name; // literal hex passthrough
+    // A contract token can be missing from `tokens` for two reasons: it was
+    // renamed/removed (skip — not this check's job) OR it is declared in the CSS
+    // but as a value the contrast gate cannot evaluate to an opaque colour
+    // (var()/color-mix()/named). The latter must FAIL LOUD, otherwise a palette
+    // refactor to an unparseable form silently disables the contrast gate
+    // (rf2-nrieg0). rgb()/hsl() are parsed, so they never reach this path.
+    const unverifiable = (name) =>
+      name.startsWith('--ex-') &&
+      Object.prototype.hasOwnProperty.call(decls, name) &&
+      !tokens[name];
     for (const row of sharedContrastContract(tokens)) {
       const fgHex = resolve(row.fg);
-      if (!fgHex) continue; // token not declared (renamed) — not this check's job
+      if (!fgHex) {
+        if (unverifiable(row.fg)) {
+          errors.push(
+            `examples/_shared/css/style.css: the ${row.role} contrast token ` +
+              `${row.fg} is declared as '${decls[row.fg]}', which the WCAG ` +
+              `contrast gate cannot evaluate as an opaque colour. Express it as ` +
+              `#hex / rgb() / hsl() so its contrast can be verified — a token ` +
+              `the gate cannot read silently disables the check (rf2-nrieg0).`,
+          );
+        }
+        continue; // token not declared (renamed) — not this check's job
+      }
       for (const bg of row.bgs) {
         const bgHex = resolve(bg);
-        if (!bgHex) continue;
+        if (!bgHex) {
+          if (unverifiable(bg)) {
+            errors.push(
+              `examples/_shared/css/style.css: the ${row.role} background token ` +
+                `${bg} is declared as '${decls[bg]}', which the WCAG contrast ` +
+                `gate cannot evaluate as an opaque colour. Express it as #hex / ` +
+                `rgb() / hsl() so its contrast can be verified (rf2-nrieg0).`,
+            );
+          }
+          continue;
+        }
         const ratio = contrastRatio(fgHex, bgHex);
         if (ratio < row.min) {
           const pair = row.invert
@@ -1314,6 +1433,8 @@ module.exports = {
   WCAG_NON_TEXT,
   contrastRatio,
   relativeLuminance,
+  colorToHex,
+  extractExTokenDecls,
   parseExTokens,
   sharedContrastContract,
   // OG source-art palette + responsive Xray-host shell contracts (rf2-y82dk9)

--- a/examples/scripts/check-examples-assets.cjs
+++ b/examples/scripts/check-examples-assets.cjs
@@ -380,6 +380,17 @@ function parseSrcset(value) {
   return urls;
 }
 
+// Read a single attribute's value off a tag string, ORDER-INDEPENDENTLY. HTML
+// attribute order is insignificant, so a value must be read positionally by
+// name rather than assuming a fixed attribute order (rf2-cnu7qy). Returns null
+// when the attribute is absent.
+function attr(tag, name) {
+  const m = tag.match(
+    new RegExp(`\\b${name}\\s*=\\s*("([^"]*)"|'([^']*)')`, 'i'),
+  );
+  return m ? (m[2] != null ? m[2] : m[3]) : null;
+}
+
 // Extract every ASSET-BEARING reference from an index.html's source, TAGGED
 // with the element/attribute it came from, so the direct-HTML network policy
 // (rf2-bf4vdy) can distinguish a remote asset fetch (rejected) from harmless
@@ -410,12 +421,6 @@ function extractAssetRefs(html) {
     if (seen.has(key)) return;
     seen.add(key);
     out.push({ ref: clean, source });
-  };
-  const attr = (tag, name) => {
-    const m = tag.match(
-      new RegExp(`\\b${name}\\s*=\\s*("([^"]*)"|'([^']*)')`, 'i'),
-    );
-    return m ? (m[2] != null ? m[2] : m[3]) : null;
   };
 
   // <script src=...> — always an asset fetch.
@@ -499,11 +504,15 @@ function extractHtmlRefs(html) {
   )) {
     push(m[2] != null ? m[2] : m[3]);
   }
-  // <meta property="og:image" content="...">
-  for (const m of html.matchAll(
-    /<meta\b[^>]*\bproperty\s*=\s*["']og:image["'][^>]*\bcontent\s*=\s*("([^"]*)"|'([^']*)')[^>]*>/gi,
-  )) {
-    push(m[2] != null ? m[2] : m[3]);
+  // <meta property="og:image" content="..."> — ORDER-INDEPENDENT. HTML
+  // attribute order is insignificant, so a `content`-before-`property` meta is
+  // equally valid and must be seen (rf2-cnu7qy). Scan each <meta> tag and read
+  // its attributes positionally via the shared order-independent attr helper,
+  // rather than a single regex that hard-codes property-before-content.
+  for (const m of html.matchAll(/<meta\b[^>]*>/gi)) {
+    const tag = m[0];
+    if ((attr(tag, 'property') || '').toLowerCase() !== 'og:image') continue;
+    push(attr(tag, 'content'));
   }
   return refs;
 }
@@ -513,10 +522,15 @@ function extractHtmlRefs(html) {
 // contract (an SVG og:image renders no preview card). Query/hash stripped.
 function extractOgImageRefs(html) {
   const out = [];
-  for (const m of html.matchAll(
-    /<meta\b[^>]*\bproperty\s*=\s*["']og:image["'][^>]*\bcontent\s*=\s*("([^"]*)"|'([^']*)')[^>]*>/gi,
-  )) {
-    const raw = m[2] != null ? m[2] : m[3];
+  // ORDER-INDEPENDENT: HTML attribute order is insignificant, so a
+  // `content`-before-`property` og:image meta is valid and MUST be visible to
+  // the raster contract + the network policy (rf2-cnu7qy). Scan each <meta> tag
+  // and read `property`/`content` positionally via the shared attr helper
+  // instead of a single regex that requires property-before-content.
+  for (const m of html.matchAll(/<meta\b[^>]*>/gi)) {
+    const tag = m[0];
+    if ((attr(tag, 'property') || '').toLowerCase() !== 'og:image') continue;
+    const raw = attr(tag, 'content');
     if (!raw) continue;
     const clean = raw.split(/[?#]/)[0].trim();
     if (clean && !out.includes(clean)) out.push(clean);

--- a/implementation/scripts/check-examples-assets.test.cjs
+++ b/implementation/scripts/check-examples-assets.test.cjs
@@ -1710,6 +1710,58 @@ it('the build-output main.js is never resolved on disk', () => {
   );
 });
 
+// ---- rf2-cnu7qy: og:image content-BEFORE-property order -------------------
+//
+// HTML attribute order is insignificant, so a `content`-first og:image meta is
+// valid. The old ordered regex only saw property-first metas, so a content-first
+// SVG/remote card was INVISIBLE to the raster contract, disk resolution, and the
+// network policy.
+
+it('rf2-cnu7qy: extractOgImageRefs sees a content-BEFORE-property og:image', () => {
+  assert.deepStrictEqual(
+    extractOgImageRefs('<meta content="_shared/img/og.png" property="og:image">'),
+    ['_shared/img/og.png'],
+  );
+});
+
+it('rf2-cnu7qy: extractHtmlRefs + extractAssetRefs see a content-first og:image', () => {
+  const html = '<meta content="https://og.example.com/card.png" property="og:image">';
+  assert.ok(extractHtmlRefs(html).includes('https://og.example.com/card.png'));
+  const tagged = extractAssetRefs(html);
+  assert.strictEqual(
+    Object.fromEntries(tagged.map((t) => [t.ref, t.source]))[
+      'https://og.example.com/card.png'
+    ],
+    'og:image',
+  );
+});
+
+it('TEETH rf2-cnu7qy: a content-first REMOTE og:image is REJECTED (was invisible)', () => {
+  const html = goodHtml().replace(
+    '<meta property="og:image" content="_shared/img/og.png">',
+    '<meta property="og:image" content="_shared/img/og.png">\n' +
+      '<meta content="https://og.example.com/card.png" property="og:image">',
+  );
+  const { errors } = scanPage(fullIo({ [PAGE]: html }), PAGE);
+  assert.ok(
+    errors.some((e) => e.includes('og:image') && e.includes('og.example.com')),
+    `expected the content-first remote og:image to be rejected, got: ${errors.join(' | ')}`,
+  );
+});
+
+it('TEETH rf2-cnu7qy: a content-first SVG og:image trips the raster contract', () => {
+  const html = goodHtml().replace(
+    '<meta property="og:image" content="_shared/img/og.png">',
+    '<meta content="_shared/img/og.svg" property="og:image">',
+  );
+  const io = fullIo({ [PAGE]: html, [OG_SVG]: '<svg/>' });
+  const { errors } = scanPage(io, PAGE);
+  assert.ok(
+    errors.some((e) => e.includes('og:image') && e.includes('not a raster')),
+    `expected a non-raster og:image error, got: ${errors.join(' | ')}`,
+  );
+});
+
 // ---- contract constant sanity -------------------------------------------
 
 it('REQUIRED_SHARED_ASSETS names favicon, the og.png raster, and style.css', () => {

--- a/implementation/scripts/check-examples-assets.test.cjs
+++ b/implementation/scripts/check-examples-assets.test.cjs
@@ -55,6 +55,7 @@ const {
   OG_PNG_WIDTH,
   OG_PNG_HEIGHT,
   contrastRatio,
+  colorToHex,
   parseExTokens,
   sharedContrastContract,
   WCAG_AA_NORMAL_TEXT,
@@ -1838,6 +1839,72 @@ it('TEETH rf2-lvw3z9: a commented-out remote @import does NOT false-fail the gat
     errors,
     [],
     `an inert commented-out remote @import must not fail the gate, got: ${errors.join(' | ')}`,
+  );
+});
+
+// ---- rf2-nrieg0: WCAG contrast on non-hex --ex-* tokens -------------------
+//
+// parseExTokens only read #hex, and the contrast loop silently `continue`d on a
+// non-hex token, disabling the WCAG gate under an rgb()/hsl() palette refactor.
+// Now rgb()/hsl() are parsed (and checked); a genuinely-opaque form (var()) is
+// fail-loud rather than silently skipped.
+
+it('rf2-nrieg0: colorToHex normalises #hex / rgb() / hsl(), null for var()', () => {
+  assert.strictEqual(colorToHex('#C8741A'), '#C8741A');
+  assert.strictEqual(colorToHex('#abc'), '#aabbcc');
+  assert.strictEqual(colorToHex('rgb(200,116,26)'), '#c8741a');
+  assert.strictEqual(colorToHex('rgba(200, 116, 26, 0.5)'), '#c8741a'); // alpha dropped
+  assert.strictEqual(colorToHex('hsl(120,100%,50%)'), '#00ff00');
+  assert.strictEqual(colorToHex('var(--ex-accent)'), null);
+  assert.strictEqual(colorToHex('rebeccapurple'), null);
+});
+
+it('rf2-nrieg0: parseExTokens now captures rgb()/hsl() tokens (was hex-only)', () => {
+  const tokens = parseExTokens(
+    ':root{--ex-bg:#F7F3EC; --ex-accent-deep: rgb(156,79,14); --ex-warn: hsl(43,79%,43%);}',
+  );
+  assert.strictEqual(tokens['--ex-bg'], '#F7F3EC');
+  assert.strictEqual(tokens['--ex-accent-deep'], '#9c4f0e'); // was DROPPED before
+  assert.ok(tokens['--ex-warn'], 'an hsl() token must be captured, not dropped');
+});
+
+it('TEETH rf2-nrieg0: a sub-AA rgb() accent foreground now FAILS (was skipped)', () => {
+  // The sub-AA amber #C8741A expressed as rgb() — previously invisible to the
+  // gate (silent `continue`), now parsed and caught.
+  const badStyle = GOOD_SHARED_STYLE.replace(
+    '--ex-accent-deep: #9C4F0E;',
+    '--ex-accent-deep: rgb(200,116,26);',
+  );
+  const errors = checkSharedTree(paletteIo(badStyle), { sharedRoot: SHARED_ROOT });
+  assert.ok(
+    errors.some((e) => e.includes('WCAG AA') && e.includes('rf2-febmqu')),
+    `expected the rgb() sub-AA foreground to fail, got: ${errors.join(' | ')}`,
+  );
+});
+
+it('TEETH rf2-nrieg0: a declared-but-unparseable var() contrast token FAILS LOUD', () => {
+  const badStyle = GOOD_SHARED_STYLE.replace(
+    '--ex-accent-deep: #9C4F0E;',
+    '--ex-accent-deep: var(--ex-accent);',
+  );
+  const errors = checkSharedTree(paletteIo(badStyle), { sharedRoot: SHARED_ROOT });
+  assert.ok(
+    errors.some((e) => e.includes('rf2-nrieg0') && e.includes('cannot evaluate')),
+    `expected a fail-loud unverifiable-token error, got: ${errors.join(' | ')}`,
+  );
+});
+
+it('rf2-nrieg0: an AA-safe rgb() palette scans CLEAN (no false-fail)', () => {
+  // #9C4F0E expressed as rgb() — parsed identically, must NOT false-fail.
+  const rgbStyle = GOOD_SHARED_STYLE.replace(
+    '--ex-accent-deep: #9C4F0E;',
+    '--ex-accent-deep: rgb(156,79,14);',
+  );
+  const errors = checkSharedTree(paletteIo(rgbStyle), { sharedRoot: SHARED_ROOT });
+  assert.deepStrictEqual(
+    errors,
+    [],
+    `an AA-safe rgb() palette must scan clean, got: ${errors.join(' | ')}`,
   );
 });
 

--- a/implementation/scripts/check-examples-assets.test.cjs
+++ b/implementation/scripts/check-examples-assets.test.cjs
@@ -1762,6 +1762,42 @@ it('TEETH rf2-cnu7qy: a content-first SVG og:image trips the raster contract', (
   );
 });
 
+// ---- rf2-3dzb6h: unquoted HTML attribute values ---------------------------
+//
+// HTML5 permits unquoted attribute values. The old quoted-only regexes missed
+// `<script src=main.js>` / `<link href=//cdn…>`, so an unquoted forbidden remote
+// dep shipped green and an unquoted broken local ref was never resolved on disk.
+
+it('rf2-3dzb6h: extractHtmlRefs reads an unquoted src/href', () => {
+  const refs = extractHtmlRefs('<script src=main.js></script><link href=base.css>');
+  assert.ok(refs.includes('main.js'));
+  assert.ok(refs.includes('base.css'));
+});
+
+it('rf2-3dzb6h: extractAssetRefs tags an unquoted remote script src + link href', () => {
+  const tagged = extractAssetRefs(
+    '<script src=https://cdn.evil/x.js></script>\n' +
+      '<link rel=stylesheet href=//cdn.evil/x.css>',
+  );
+  const byRef = Object.fromEntries(tagged.map((t) => [t.ref, t.source]));
+  assert.ok(byRef['https://cdn.evil/x.js'] && byRef['https://cdn.evil/x.js'].includes('script'));
+  assert.ok(byRef['//cdn.evil/x.css'] && byRef['//cdn.evil/x.css'].includes('link'));
+});
+
+it('TEETH rf2-3dzb6h: an unquoted remote <script src> is REJECTED (was invisible)', () => {
+  const html = goodHtml().replace(
+    '<script src="main.js"></script>',
+    '<script src=https://cdn.example.com/sdk.js></script>\n<script src="main.js"></script>',
+  );
+  const { errors } = scanPage(fullIo({ [PAGE]: html }), PAGE);
+  assert.ok(
+    errors.some(
+      (e) => e.includes('<script src>') && e.includes('cdn.example.com') && e.includes('rf2-bf4vdy'),
+    ),
+    `expected the unquoted external script to be rejected, got: ${errors.join(' | ')}`,
+  );
+});
+
 // ---- contract constant sanity -------------------------------------------
 
 it('REQUIRED_SHARED_ASSETS names favicon, the og.png raster, and style.css', () => {

--- a/implementation/scripts/check-examples-assets.test.cjs
+++ b/implementation/scripts/check-examples-assets.test.cjs
@@ -1798,6 +1798,49 @@ it('TEETH rf2-3dzb6h: an unquoted remote <script src> is REJECTED (was invisible
   );
 });
 
+// ---- rf2-lvw3z9: CSS block comments stripped before extraction ------------
+//
+// Commented-out CSS is inert. The extractors used to read a commented @import /
+// url() as live, turning the gate RED on a maintainer's debug comment — and
+// inconsistently with the og.svg check in the same file, which strips comments.
+
+// A checkSharedTree fixture whose style.css is under test; the rest of the tree
+// is valid so the ONLY thing that can turn it RED is the style.css itself.
+// Shared by the CSS-comment (rf2-lvw3z9) and contrast-token (rf2-nrieg0) teeth.
+const paletteIo = (styleCss) =>
+  makeIo({
+    [path.join(SHARED_ROOT, 'css', 'style.css')]: styleCss,
+    [path.join(SHARED_ROOT, 'css', 'structure.css')]: CASCADE_BASELINE + '\n' + RESPONSIVE_SHELL,
+    [path.join(SHARED_ROOT, 'img', 'favicon.svg')]: '<svg/>',
+    [path.join(SHARED_ROOT, 'img', 'og.png')]: VALID_OG_PNG,
+    [path.join(SHARED_ROOT, 'img', 'og.svg')]: '<svg/>',
+  });
+
+it('rf2-lvw3z9: extractCssImports ignores a commented-out @import', () => {
+  const imports = extractCssImports(
+    '/* @import url(https://fonts.googleapis.com/css2); */\n@import url("structure.css");',
+  );
+  assert.deepStrictEqual(imports, ['structure.css']);
+});
+
+it('rf2-lvw3z9: extractCssUrls ignores a commented-out url()', () => {
+  const urls = extractCssUrls(
+    '/* background: url(https://cdn.evil/x.png); */\n.a { background: url("real.png"); }',
+  );
+  assert.ok(urls.includes('real.png'));
+  assert.ok(!urls.includes('https://cdn.evil/x.png'), 'a commented url() must not be read as live');
+});
+
+it('TEETH rf2-lvw3z9: a commented-out remote @import does NOT false-fail the gate', () => {
+  const styleCss = '/* @import url(https://fonts.googleapis.com/css2?family=Inter); */\n' + GOOD_SHARED_STYLE;
+  const errors = checkSharedTree(paletteIo(styleCss), { sharedRoot: SHARED_ROOT });
+  assert.deepStrictEqual(
+    errors,
+    [],
+    `an inert commented-out remote @import must not fail the gate, got: ${errors.join(' | ')}`,
+  );
+});
+
 // ---- contract constant sanity -------------------------------------------
 
 it('REQUIRED_SHARED_ASSETS names favicon, the og.png raster, and style.css', () => {


### PR DESCRIPTION
Closes rf2-cnu7qy, rf2-3dzb6h, rf2-nrieg0, rf2-lvw3z9.

Four parser holes in `examples/scripts/check-examples-assets.cjs` that let a broken asset ship green (three false-green) or false-failed the gate on inert code (one false-positive). Each is a real defect: a checker's whole value is catching regressions, and a parser hole that lets a broken asset ship green defeats the gate.

Each fix is its own commit, with regression tests in the gate's own suite (`implementation/scripts/check-examples-assets.test.cjs`, wired into CI via `test:script-policy`). Every test PROVES the hole is closed: the checker now catches the regression it was blind to.

## Fixes

- **rf2-cnu7qy (P3, false-green)** — og:image checks hard-coded `property`-before-`content` attribute order, so a valid `content`-first `<meta>` was invisible to the raster contract, disk resolution, and the network policy. Now the `<meta>` attributes are read positionally via a shared order-independent `attr()` helper.
- **rf2-3dzb6h (P3, false-green)** — every attribute regex matched only quoted values, so a valid HTML5 unquoted `<script src=main.js>` / `<link href=//cdn…>` was missed, bypassing the remote-dependency policy and the missing-file check. Added a bare-unquoted alternative to `attr()` and the `href`/`src`/`poster` matches.
- **rf2-nrieg0 (P3, false-green)** — `parseExTokens` read only `#hex`, and the contrast loop silently `continue`d on any `rgb()/hsl()/var()` token, disabling the WCAG contrast gate AND its own live test (they share the parser). Now `rgb()/rgba()/hsl()/hsla()` are normalised to hex (so those palettes are still checked), and a contract-referenced token that is declared but not a computable opaque colour (`var()`/`color-mix()`/named) FAILS LOUD instead of being silently skipped.
- **rf2-lvw3z9 (P4, false-positive)** — CSS `@import`/`url()` extraction didn't strip `/* */` comments, so a commented-out `@import`/`url()` was read as live and turned the gate RED on inert code — inconsistent with the og.svg check in the same file, which already strips comments. Now block comments are stripped once before extraction.

## Quality gates

Focused checks run in the foreground (full spine deferred to CI):

- `node implementation/scripts/check-examples-assets.test.cjs` — **all passed** (108 tests, incl. 15 new). The LIVE tests scan the real examples tree, confirming no new false-positive.
- `node examples/scripts/check-examples-assets.cjs` — **exit 0**; all 35 example host pages resolve their assets and carry the `_shared` contract.
- Teeth-proof (old vs new on the beads' empirical probes):
  - cnu7qy content-first og:image: OLD `[]` → NEW `["_shared/img/og.png"]`
  - 3dzb6h unquoted remote src: OLD `[]` → NEW `["https://cdn.evil/x.js"]`
  - nrieg0 `rgb()` token: OLD dropped → NEW `--ex-accent-deep: #c8741a` captured
  - lvw3z9 commented `@import`: OLD read as live → NEW ignored

## Stance

Pre-alpha, no back-compat shims; ELEGANCE + CLARITY + CORRECTNESS + GOOD PRACTICE, avoiding over-engineering. Order-independent/quote-agnostic attribute reads and multi-notation colour parsing close the holes at the root rather than patching symptoms; the fail-loud path refuses to pass green on a token the gate cannot verify.