### PR TITLE
fix(machines-viz): reserved-scheme synthetic node ids to preserve injectivity (rf2-4gtvln)

### DIFF
--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -453,9 +453,17 @@ guard-blocked transition is a no-op that never reached the target, so the
 highlight STOPS at the guard event-node and the onward arrow stays resting),
 `:crossHierarchy`, and elk-routed `:points`. Edge
 ids: `<spec-edge-id>__in` / `<spec-edge-id>__out`. Event-node ids:
-`event__<spec-edge-id>` via `chart.projection/event-node-id`. The
-`:eventLabel` slot on these edges is empty (the event-node holds the
-visible text).
+`__rf2_event_<spec-edge-id>__` via `chart.projection/event-node-id`
+(rf2-4gtvln — a RESERVED leading + trailing `__` scheme, mirroring
+`chart.layout/machine-root-id` / `root-container-id`; a real `node-id`
+hex-escapes every non-alphanumeric segment char and joins segments with
+`__`, so it can never START with `__`, keeping the synthetic id INJECTIVE
+against every real node-id — the earlier `event__<spec-edge-id>` prefix
+collided byte-for-byte with a real `[:event <src> <tgt> <evt>]` state path).
+Initial-marker ids follow the same scheme via
+`chart.projection/initial-marker-id` (`__rf2_initial_<state-node-id>__`),
+with the entry edge sourced from that id. The `:eventLabel` slot on these
+edges is empty (the event-node holds the visible text).
 
 > **Edge-half `:guardBlocked` is projection/rendering data, NOT a DOM pin
 > (rf2-bdwolc).** The per-half `:guardBlocked` flag drives the half's

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
@@ -228,14 +228,47 @@
     :else            :on))
 
 (defn event-node-id
-  "Stable string id for an event-node. The xyflow node inserted between
+  "Stable string id for an event-node — the xyflow node inserted between
   the source state and the (optional) target state in the events-as-nodes
   paradigm. Derived from the canonical edge-id (`chart.layout/edge-id`) so
   two transitions sharing source/target/event/guard/action keep distinct
   event-node ids — the same collision-tiebreak `chart.layout/project-flat`
-  applies."
+  applies.
+
+  rf2-4gtvln — minted through a RESERVED leading + trailing `__` scheme
+  (mirroring `chart.layout/machine-root-id` / `root-container-id`), NOT the
+  naive `event__<edge-id>` prefix. A real `node-id` hex-escapes every
+  non-alphanumeric segment char (`grammar/escape-id-segment`; a literal `_`
+  → `_5f`) and joins path segments with `__`, so it can never START with
+  `__` — the boundary here is unreachable from escaped segment content. The
+  old prefix collided byte-for-byte with a real state path
+  `[:event <src> <tgt> <evt>]` (whose `node-id` is
+  `event__<src>__<tgt>__<evt>`), so xyflow — which keys nodes by `:id` and
+  silently drops a duplicate — could lose the real state box or the
+  event-node."
   [edge]
-  (str "event__" (:id edge)))
+  (str "__rf2_event_" (:id edge) "__"))
+
+(defn initial-marker-id
+  "Stable string id for an initial-state marker node — the small filled dot
+  wired into each `:initial?` state via an unlabelled entry edge.
+  `state-id` is the target state's `node-id`.
+
+  rf2-4gtvln — minted through the SAME reserved leading + trailing `__`
+  scheme as `event-node-id` / `chart.layout/machine-root-id`, NOT the naive
+  `initial__<state-id>` prefix. A real `node-id` hex-escapes every
+  non-alphanumeric segment char and joins segments with `__`, so it can
+  never START with `__` — the boundary here is unreachable from escaped
+  segment content. The old prefix collided byte-for-byte with a real
+  two-segment state path `[:initial <X>]` (whose `node-id` is
+  `initial__<X>`) whenever a machine has a top-level compound state
+  literally named `:initial`, so xyflow (keys nodes by `:id`, drops a
+  duplicate) silently lost either the real `[:initial <X>]` state box or the
+  marker for `<X>`, and the entry edge mis-wired its glyph onto the
+  survivor. The single source of truth for BOTH the marker node's `:id` and
+  the entry edge's `:source`, so they can never drift."
+  [state-id]
+  (str "__rf2_initial_" state-id "__"))
 
 ;; ---- guarded-fork branch-order -----------------------------------------
 ;;
@@ -1917,7 +1950,7 @@
         (mapv (fn [n]
                 (let [sid (:id n)
                       pos (get positions sid {:x 0 :y 0})]
-                  (cond-> {:id        (str "initial__" sid)
+                  (cond-> {:id        (initial-marker-id sid)
                            :type      "initial-marker"
                            :position  {:x (- (:x pos) initial-marker-x-offset)
                                        :y (+ (:y pos) initial-marker-y-offset)}
@@ -1949,8 +1982,8 @@
               initial-nodes)
         entry-edges
         (mapv (fn [n]
-                {:id          (str "initial__" (:id n) "__entry")
-                 :source      (str "initial__" (:id n))
+                {:id          (str (initial-marker-id (:id n)) "entry")
+                 :source      (initial-marker-id (:id n))
                  :target      (:id n)
                  :targetHandle "left"
                  :type        "transition"

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/chart_dom_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/chart_dom_cljs_test.cljs
@@ -1054,7 +1054,7 @@
     (if-not (browser?)
       (is true ":node-test: no DOM — browser-test runner exercises this")
       (let [start-id (canonical-edge-id idle-loading-done [:idle] [:loading] :start)
-            fired-ev-id (str "event__" start-id)]
+            fired-ev-id (projection/event-node-id {:id start-id})]
         (with-mounted-chart
           {:machine-id     :test/flow
            :definition     idle-loading-done
@@ -1124,7 +1124,7 @@
     (if-not (browser?)
       (is true ":node-test: no DOM — browser-test runner exercises this")
       (let [close-id (canonical-edge-id guarded-door-machine [:open] [:closed] :door/close)
-            blocked-ev-id (str "event__" close-id)]
+            blocked-ev-id (projection/event-node-id {:id close-id})]
         (with-mounted-chart
           {:machine-id     :test/door
            :definition     guarded-door-machine

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/post_elk_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/post_elk_cljs_test.cljc
@@ -341,7 +341,7 @@
     (testing "a region's event-nodes are folded in under that region"
       ;; audio has muted--unmute-->playing + playing--mute-->muted = 2 events
       (let [audio-rid (layout/region-node-id :audio)
-            ev-ids (filter #(str/starts-with? % "event__")
+            ev-ids (filter #(str/starts-with? % "__rf2_event_")
                            (get desc audio-rid))]
         (is (= 2 (count ev-ids)))))))
 
@@ -382,7 +382,7 @@
     (testing "intra-region children TRANSPOSE (a vertical stack becomes a row)"
       ;; original audio children: same x (20), increasing y → a column.
       ;; after transpose: same y, increasing x → a row.
-      (let [audio-child-ids (filter #(not (str/starts-with? % "event__"))
+      (let [audio-child-ids (filter #(not (str/starts-with? % "__rf2_event_"))
                                     (get desc audio-rid))
             child-positions (map #(get np %) audio-child-ids)
             xs (map :x child-positions)
@@ -456,10 +456,10 @@
         ;; consecutive states (the +0.5 inter-rank events-as-nodes shape). The
         ;; vertical pitch (108px) is sized for the heights the bug inherits.
         state-ids  (fn [rid] (->> (get desc rid)
-                                  (remove #(str/starts-with? % "event__"))
+                                  (remove #(str/starts-with? % "__rf2_event_"))
                                   sort))
         event-ids  (fn [rid] (->> (get desc rid)
-                                  (filter #(str/starts-with? % "event__"))
+                                  (filter #(str/starts-with? % "__rf2_event_"))
                                   sort))
         region-cols
         (fn [rid x0]

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
@@ -156,7 +156,7 @@
   label) is gone."
   [graph parsed-edge-id]
   (first (filter #(and (= "rf2-event" (:type %))
-                       (= (str "event__" parsed-edge-id) (:id %)))
+                       (= (projection/event-node-id {:id parsed-edge-id}) (:id %)))
                  (:nodes graph))))
 
 (defn- inbound-edge-for
@@ -1052,8 +1052,8 @@
     (let [parsed   (layout/project-definition idle-loading)
           graph    (projection/xyflow-graph parsed {} {})
           idle-id  (layout/node-id [:idle])
-          marker-id (str "initial__" idle-id)
-          entry    (edge-by-id graph (str marker-id "__entry"))]
+          marker-id (projection/initial-marker-id idle-id)
+          entry    (edge-by-id graph (str marker-id "entry"))]
       (is (some? entry))
       (is (= "" (:eventLineLabel (:data entry))))
       (is (= "" (:eventLabel (:data entry)))))))
@@ -1680,7 +1680,7 @@
              (projection/->elk-children parsed nil))
           "the 1-arity and nil-2-arity are identical")
       (let [children (root-children (projection/->elk-children parsed nil))
-            leaves   (remove #(re-find #"^event__" (:id %)) children)]
+            leaves   (remove #(re-find #"^__rf2_event_" (:id %)) children)]
         (is (every? #(= projection/state-node-min-width (:width %)) leaves)
             "every leaf at the width floor when unmeasured")))))
 
@@ -1747,7 +1747,7 @@
             the initial state. End-to-end through the production path."
     (let [parsed   (layout/project-definition door-cyclic-machine)
           children (root-children (projection/->elk-children parsed))
-          state-children (remove #(re-find #"^event__" (:id %)) children)
+          state-children (remove #(re-find #"^__rf2_event_" (:id %)) children)
           ids      (mapv :id state-children)]
       (is (= (layout/node-id [:locked]) (first ids))
           "the initial state leads the elk state children")
@@ -1765,7 +1765,7 @@
           compound (get by-id (layout/node-id [:authenticated]))
           ;; the compound's STATE children (skip its nested event-nodes).
           sub-states (->> (:children compound)
-                          (remove #(re-find #"^event__" (:id %)))
+                          (remove #(re-find #"^__rf2_event_" (:id %)))
                           (mapv :id))]
       (is (= (layout/node-id [:authenticated :browsing]) (first sub-states))
           "the compound's initial substate leads its local model order"))))
@@ -1998,9 +1998,9 @@
     (let [parsed   (layout/project-definition idle-loading)
           graph    (projection/xyflow-graph parsed {} {})
           idle-id   (layout/node-id [:idle])
-          marker-id (str "initial__" idle-id)
+          marker-id (projection/initial-marker-id idle-id)
           marker   (node-by-id graph marker-id)
-          entry    (edge-by-id graph (str marker-id "__entry"))]
+          entry    (edge-by-id graph (str marker-id "entry"))]
       (is (some? marker) "initial-marker node emitted")
       (is (= "initial-marker" (:type marker)))
       (is (some? entry) "entry edge emitted")
@@ -2022,7 +2022,7 @@
           ;; observable on the marker.
           positions {idle-id {:x 300 :y 120}}
           graph     (projection/xyflow-graph parsed positions {})
-          marker    (node-by-id graph (str "initial__" idle-id))]
+          marker    (node-by-id graph (projection/initial-marker-id idle-id))]
       (is (pos? projection/initial-marker-x-offset))
       (is (= (- 300 projection/initial-marker-x-offset)
              (get-in marker [:position :x]))
@@ -2086,7 +2086,7 @@
     (let [parsed      (layout/project-definition compound-machine)
           graph       (projection/xyflow-graph parsed {} {})
           browsing-id (layout/node-id [:authenticated :browsing])
-          marker      (node-by-id graph (str "initial__" browsing-id))]
+          marker      (node-by-id graph (projection/initial-marker-id browsing-id))]
       (is (some? marker) "the compound's initial substate gets a marker")
       (is (= (layout/node-id [:authenticated]) (:parentId marker))
           "marker keeps the container coordinate frame via :parentId")
@@ -2110,11 +2110,96 @@
     (let [parsed      (layout/project-definition compound-machine)
           graph       (projection/xyflow-graph parsed {} {})
           browsing-id (layout/node-id [:authenticated :browsing])
-          marker      (node-by-id graph (str "initial__" browsing-id))]
+          marker      (node-by-id graph (projection/initial-marker-id browsing-id))]
       (is (some? marker) "the compound's initial substate gets a marker")
       (is (= (layout/node-id [:authenticated]) (:parentId marker)))
       (is (not (contains? marker :parentNode))
           "rf2-xh1lm — the pre-v12 :parentNode key MUST NOT appear"))))
+
+;; ---- rf2-4gtvln — reserved-scheme synthetic ids are INJECTIVE against
+;;      real node-ids -------------------------------------------------------
+;;
+;; The initial-marker and event-node ids used to be minted by prepending a
+;; bare word + "__" onto an already-escaped node-id ("initial__" / "event__").
+;; Because `grammar/escape-id-segment` leaves the plain words "initial" /
+;; "event" untouched and `node-id` joins path segments with "__", a REAL
+;; multi-segment state path whose FIRST segment is literally :initial / :event
+;; minted the SAME id as the synthetic marker / event-node — and xyflow (keys
+;; nodes by :id, silently DROPS a duplicate) then lost a node. The fix routes
+;; both synthetic ids through a reserved leading + trailing "__" scheme
+;; (`initial-marker-id` / `event-node-id`) a real node-id can never produce.
+
+(defn- node-ids-distinct?
+  "Every projected node :id is pairwise distinct — the xyflow injectivity
+  contract (a duplicate id silently drops a node)."
+  [graph]
+  (let [ids (mapv :id (:nodes graph))]
+    (= (count ids) (count (distinct ids)))))
+
+(deftest xyflow-graph-initial-named-state-does-not-collide-with-marker
+  (testing "rf2-4gtvln — a machine with a top-level compound state literally
+            named :initial makes the real [:initial :a] path mint node-id
+            \"initial__a\", byte-identical to the OLD initial-marker id for
+            the machine's initial state :a. The projection must keep BOTH the
+            real state box AND the marker, with DISTINCT ids (pre-fix xyflow
+            dropped one)."
+    (let [machine {:initial :a
+                   :states  {:a       {}
+                             :initial {:states {:a {}}}}}
+          parsed  (layout/project-definition machine)
+          graph   (projection/xyflow-graph parsed {} {})
+          real-initial-a (layout/node-id [:initial :a])              ;; "initial__a"
+          marker-id      (projection/initial-marker-id
+                           (layout/node-id [:a]))]                   ;; reserved scheme
+      ;; the fixture genuinely reproduces the pre-fix collision: the OLD
+      ;; marker id for :a is byte-identical to the real [:initial :a] node id.
+      (is (= real-initial-a (str "initial__" (layout/node-id [:a])))
+          "sanity: the OLD \"initial__\"-prefixed marker id WOULD have collided")
+      (is (node-ids-distinct? graph)
+          "every projected node id is distinct — no node silently dropped")
+      (is (some? (node-by-id graph real-initial-a))
+          "the REAL [:initial :a] compound-substate box survives projection")
+      (is (some? (node-by-id graph marker-id))
+          "the initial-marker for :a survives projection")
+      (is (not= real-initial-a marker-id)
+          "the marker id and the real [:initial :a] node id are DISTINCT")
+      (is (= "state" (:type (node-by-id graph real-initial-a)))
+          "the \"initial__a\" id now belongs SOLELY to the real state — the
+           marker no longer squats it")
+      (is (= "initial-marker" (:type (node-by-id graph marker-id)))
+          "the marker keeps its reserved-scheme id"))))
+
+(deftest xyflow-graph-event-named-state-does-not-collide-with-event-node
+  (testing "rf2-4gtvln (secondary) — a machine with a top-level compound
+            state literally named :event whose nested path [:event :a :b :go]
+            mints node-id \"event__a__b__go\", byte-identical to the OLD
+            event-node id for the a --go--> b transition. The projection must
+            keep BOTH, with DISTINCT ids."
+    (let [machine {:initial :a
+                   :states  {:a     {:on {:go :b}}
+                             :b     {}
+                             :event {:states {:a {:states {:b {:states {:go {}}}}}}}}}
+          parsed  (layout/project-definition machine)
+          graph   (projection/xyflow-graph parsed {} {})
+          real-event-path (layout/node-id [:event :a :b :go])        ;; "event__a__b__go"
+          go-edge (first (filter #(= :go (:event %)) (:edges parsed)))
+          ev-id   (projection/event-node-id go-edge)]
+      (is (some? go-edge) "fixture parses the a --go--> b transition")
+      ;; the fixture genuinely reproduces the pre-fix collision.
+      (is (= real-event-path (str "event__" (:id go-edge)))
+          "sanity: the OLD \"event__\"-prefixed event-node id WOULD have collided")
+      (is (node-ids-distinct? graph)
+          "every projected node id is distinct — no node silently dropped")
+      (is (some? (node-by-id graph real-event-path))
+          "the REAL [:event :a :b :go] state box survives projection")
+      (is (some? (node-by-id graph ev-id))
+          "the a --go--> b event-node survives projection")
+      (is (not= real-event-path ev-id)
+          "the event-node id and the real [:event ...] node id are DISTINCT")
+      (is (= "state" (:type (node-by-id graph real-event-path)))
+          "the \"event__a__b__go\" id now belongs SOLELY to the real state")
+      (is (= "rf2-event" (:type (node-by-id graph ev-id)))
+          "the event-node keeps its reserved-scheme id"))))
 
 (deftest xyflow-graph-self-transition-routes-through-event-node
   (testing "rf2-qo5xy — a self-transition (source == target in the
@@ -2165,7 +2250,7 @@
           by-id    (into {} (map (juxt :id identity) children))
           authed   (get by-id (layout/node-id [:authenticated]))]
       (is (some? authed) "compound parent nests inside the root frame")
-      (let [kid-types (group-by #(if (re-find #"^event__" (:id %))
+      (let [kid-types (group-by #(if (re-find #"^__rf2_event_" (:id %))
                                    :event :state)
                                 (:children authed))]
         (is (= 2 (count (:state kid-types)))
@@ -2585,7 +2670,7 @@
           fired-ev-nodes (set (map :id (filter #(and (= "rf2-event" (:type %))
                                                      (:fired (:data %)))
                                                (:nodes graph))))]
-      (is (= #{(str "event__" (:id start)) (str "event__" (:id always))}
+      (is (= #{(projection/event-node-id start) (projection/event-node-id always)}
              fired-ev-nodes)
           "exactly the two event-nodes for the fired ids light up"))))
 
@@ -2900,7 +2985,7 @@
           parsed-ids (set (map :id (:edges parsed)))
           ev-node-ids (set (map :id (filter #(= "rf2-event" (:type %))
                                             (:nodes graph))))
-          expected (set (map #(str "event__" %) parsed-ids))]
+          expected (set (map #(projection/event-node-id {:id %}) parsed-ids))]
       (is (= expected ev-node-ids)
           "every parsed edge id has a matching event-node"))))
 
@@ -2932,10 +3017,14 @@
     (let [parsed (layout/project-definition multi-self-loop-machine)
           graph  (projection/xyflow-graph parsed {} {})
           ev-nodes (filter #(= "rf2-event" (:type %)) (:nodes graph))
-          on-idle  (filter (fn [e] (let [in (inbound-edge-for graph
-                                                              (subs (:id e)
-                                                                    (count "event__")))]
-                                     (= (:source in) (layout/node-id [:idle]))))
+          ;; rf2-4gtvln — match each event-node back to its parsed edge via
+          ;; the public `event-node-id` (a parsed edge carries its source
+          ;; state directly), rather than reverse-parsing the reserved-scheme
+          ;; id string.
+          on-idle  (filter (fn [e]
+                             (some #(and (= (projection/event-node-id %) (:id e))
+                                         (= (:source %) (layout/node-id [:idle])))
+                                   (:edges parsed)))
                            ev-nodes)]
       (is (= 3 (count on-idle))
           "fixture has 3 events on :idle → 3 event-nodes")
@@ -3388,7 +3477,7 @@
           c1 (:id (get by-guard :gate-high?))   ;; priority 1
           c2 (:id (get by-guard :gate-low?))    ;; priority 2
           c3 (:id (get by-guard nil))           ;; priority 3
-          ev #(str "event__" %)]
+          ev #(projection/event-node-id {:id %})]
       (is (= 2 (count conns)) "3-branch fork → 2 connector edges (1→2, 2→3)")
       (let [pairs (set (map (juxt :source :target) conns))]
         (is (contains? pairs [(ev c1) (ev c2)])
@@ -3454,7 +3543,7 @@
           c1 (:id (get by-guard :gate-high?))   ;; priority 1
           c2 (:id (get by-guard :gate-low?))    ;; priority 2
           c3 (:id (get by-guard nil))           ;; priority 3
-          ev #(str "event__" %)
+          ev #(projection/event-node-id {:id %})
           ;; index every connector by its [source target] event-node pair.
           by-pair (into {} (map (juxt (juxt :source :target) identity)) conns)]
       (is (= 2 (count conns)) "3-branch fork → 2 connector edges (1→2, 2→3)")


### PR DESCRIPTION
## What

The initial-marker and event-node ids were minted by prepending a bare word + `__` onto an already-escaped node-id (`(str "initial__" sid)` at `chart/projection.cljc:1920,1952-1953`; `(str "event__" (:id edge))` at `:238`). Because `grammar/escape-id-segment` leaves the plain words `initial` / `event` untouched and `node-id` joins path segments with `__`, a **real** multi-segment state path whose first segment is literally `:initial` / `:event` minted the **same** id as the synthetic marker / event-node. xyflow keys nodes by `:id` and silently drops a duplicate, so a valid machine with a top-level compound state named `:initial` (or `:event`) lost a node and mis-wired the entry glyph — defeating the INJECTIVE id guarantee (rf2-ee38b.21) the layout relies on.

**Repro (valid machine):** `{:initial :a :states {:a {} :initial {:states {:a {}}}}}` — the real `[:initial :a]` node (`node-id` `"initial__a"`) collided byte-for-byte with the initial-marker for `:a` (old id `"initial__a"`).

## Fix

Mint both synthetic ids through a **reserved leading + trailing `__` scheme**, mirroring `chart.layout/machine-root-id` / `root-container-id`:

- `event-node-id` → `__rf2_event_<edge-id>__`
- new `initial-marker-id` → `__rf2_initial_<state-id>__` (single source of truth for both the marker node `:id` and the entry edge `:source`, so they can never drift)

A real `node-id` hex-escapes every non-alphanumeric segment char (a literal `_` → `_5f`) and never starts with `__`, so the reserved boundary is **unreachable** from escaped segment content — the synthetic ids can never collide with a real node-id.

## Adversarial tests

Two new regression tests in `projection_cljs_test.cljc`:
- **`xyflow-graph-initial-named-state-does-not-collide-with-marker`** — top-level compound `:initial`; asserts node-id injectivity (all chart node ids distinct), the real `[:initial :a]` box present, and the marker distinct from it. A `sanity` assertion proves the OLD prefix would have collided byte-for-byte.
- **`xyflow-graph-event-named-state-does-not-collide-with-event-node`** — nested `[:event :a :b :go]` path reproducing the secondary `event__` collision; same injectivity assertions.

Both fail under the old scheme (duplicate ids → `node-ids-distinct?` false). Tests that hard-coded the old prefixes now route through the public minting fns / new scheme.

## Spec

`tools/machines-viz/spec/API.md` updated to document the reserved id scheme (Xray/machines-viz keep-current rule).

## Quality gates

- **`clojure -M:test` (tools/machines-viz, JVM)** — ✅ green. `Ran 571 tests containing 2039 assertions. 0 failures, 0 errors.`
- **`npm run test:cljs` (implementation/, :node-test — cross-artefact, includes machines-viz `*-cljs-test` suites)** — ✅ **no failures in any touched file.** `Ran 8317 tests` with 4 **pre-existing** baseline failures, all in unrelated namespaces I did not touch (`examples/real-apps/realworld_resources` `:editor/dirty?`, reagent-slim SSR). Main's HEAD commit notes "2 CI-fixes resumed", corroborating the RED baseline. My machines-viz cljc suites compiled and passed under the CLJS node target.
- Full spine deferred to CI.

## Stance

Pre-alpha, no back-compat shims. ELEGANCE + CLARITY + CORRECTNESS + GOOD PRACTICE: routes an ad-hoc prefix through the same reserved-scheme minting the codebase already uses for its other synthetic ids, with a single source of truth for the marker id and its entry edge; no over-engineering.
