### PR TITLE
fix(examples): repair realworld_resources editor flow — green main :node-test (regression from #5353)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs
@@ -318,7 +318,11 @@
             continuation re-seeds a clean draft and navigates to the saved article"
     (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
                                        :fx-overrides {:rf.nav/push-url :rf/no-op}})]
-      ;; create-mode entry registers the :editor/can-submit? flow against this frame
+      ;; Boot registers the :editor/can-submit? flow ONCE against the frame
+      ;; (`:app/initialise` -> `:editor/register-flow`, rf2-xugvye); the create-route
+      ;; `:on-match` (`:editor/initialise`) then only resets the slice. Mirror that
+      ;; boot ordering here so the flow materialises `[:editor :can-submit?]`.
+      (rf/dispatch-sync [:editor/register-flow] {:frame f})
       (rf/dispatch-sync [:editor/initialise] {:frame f})
       ;; blank draft → the flow output is false (invalid + clean)
       (is (false? (rf/compute-sub [:editor/can-submit?] (state-value f)))


### PR DESCRIPTION
## Green main — CLJS `:node-test` regression from #5353

`main` was RED on the CI `:node-test` gate (blocking all merges). This repairs it.

### Root cause
PR #5353's xugvye change (`a4b6d4eb9`, "register editor can-submit? flow once at boot, not per entry") moved the `:editor/can-submit?` flow registration out of the per-entry route handlers (`:editor/initialise` / `:editor/load-article`) into a boot one-shot `:editor/register-flow`, dispatched from `:app/initialise`. **That change is a legitimate improvement and the real app still works** — boot registers the flow.

But the pre-existing integration test `editor-flow-gates-submit-and-reply-to-navigates-to-the-saved-article` (`realworld_resources_cljs_test.cljs`) drives the editor via `[:editor/initialise]` against a fresh `with-new-frame` frame and **never dispatches the boot event**. Post-xugvye the flow is therefore never registered against that frame:

- `[:editor :can-submit?]` never materialises → `:editor/can-submit?` stays `false` (:330)
- `:editor/submit` takes its valid-but-clean no-op branch → no mutation lowered → `@last-managed-args` is `nil` (:337)
- the draft is never re-seeded → stays dirty → `:can-leave?` false / `:dirty?` true (:344, :346)

The #5353 worker verified by compile only and never ran this pre-existing test.

### Fix — forward-fix, preserves xugvye entirely
Make the test mirror the **real boot sequence**: dispatch the boot one-shot `[:editor/register-flow]` before entering the create route, exactly as `:app/initialise` does at boot. The now-stale comment ("create-mode entry registers the flow") is corrected. No source change — xugvye's "register once at boot, not per-entry" design is kept intact, and this is faithful to how the real app actually registers the flow.

kkqy6q (lease release) and 0rwkj1 (safe-url) are untouched; `:editor/dirty?` failing was collateral of the no-op submit, not a kkqy6q defect.

### Green gate (exact CI `:node-test`, `npm run test:cljs`)
```
Ran 8315 tests containing 38232 assertions.
0 failures, 0 errors.
```
(Confirmed the 4 failures reproduce on `origin/main` before the fix.)

rf2-kkqy6q rf2-0rwkj1 rf2-xugvye
