### PR TITLE
test(conformance): strict machine :evaluation + selector-refinement + owner guard; actor-id timer fixtures (rf2-b366vj +3)

### DIFF
--- a/implementation/derivation-conformance/test/re_frame/derivation_algebra_conformance_cljs_test.cljc
+++ b/implementation/derivation-conformance/test/re_frame/derivation_algebra_conformance_cljs_test.cljc
@@ -427,9 +427,19 @@
     (testing "machine — runtime-db / on-transition (+scheduled for :after) / machine-instance"
       (is (= :runtime-db        (:storage mach)))
       (is (= :machine-instance  (:lifecycle mach)))
-      (is (contains? (:evaluation mach) :on-transition) "always evaluates :on-transition")
-      (is (contains? (:evaluation mach) :scheduled)
-          "an :after timer adds :scheduled to the policy set")
+      ;; EXACT set-equality (rf2-b366vj), matching the resource sibling at
+      ;; line 417. :upload/main has an :after timer and NO spawn, so it
+      ;; classifies to EXACTLY #{:on-transition :scheduled}
+      ;; (machines/tooling.cljc:198-200: cond-> #{:on-transition},
+      ;; declares-after?->conj :scheduled, declares-spawn?->conj :on-reply).
+      ;; The prior loose `contains?` pair asserted only presence, so a
+      ;; declares-spawn? false-positive (or any bug adding a spurious
+      ;; :on-reply / :manual to a non-spawning machine) stayed GREEN — the
+      ;; closed-vocabulary arm (b-every-classification-…) also passes because
+      ;; :on-reply is a member of the policy set. Exact-set-equality catches
+      ;; the over-classification.
+      (is (= #{:on-transition :scheduled} (:evaluation mach))
+          "a non-spawning machine with an :after timer classifies to EXACTLY on-transition + scheduled — no spurious member")
       (is (true? (:materialized? mach))))))
 
 (deftest b-every-classification-is-in-its-closed-vocabulary

--- a/implementation/derivation-conformance/test/re_frame/derivation_algebra_conformance_cljs_test.cljc
+++ b/implementation/derivation-conformance/test/re_frame/derivation_algebra_conformance_cljs_test.cljc
@@ -571,11 +571,20 @@
       (is (= :runtime-db (:storage slice)))
       (is (= :on-route   (:evaluation slice)))
       (is (= :frame      (:lifecycle slice)))
-      ;; the live OWNER is [:route route-id nav-token] when a nav-token has
-      ;; been allocated (Derivations §Lifecycle and owner).
-      (when-let [owner (:owner slice)]
-        (is (= [:route :route/article (:nav-token slice)] owner)
-            "the live route OWNER is [:route route-id nav-token]")))))
+      ;; the live OWNER is [:route route-id nav-token] (Derivations §Lifecycle
+      ;; and owner). Under the plain-atom dispatch-sync navigation this suite
+      ;; drives, routing/tooling.cljc:340-341 deterministically assoc's :owner
+      ;; (present whenever route-id AND nav-token are non-nil), so this is a
+      ;; FAILING PRECONDITION (rf2-djofbh/rf2-onazhx), not a vacuity-risk skip:
+      ;; a regression dropping :owner (broken nav-token allocation) MUST fail
+      ;; here, not silently skip. The earlier `(when-let [owner (:owner slice)]
+      ;; …)` masked exactly that — the same when-guard anti-pattern the
+      ;; rf2-djofbh hardening pass converted to failing preconditions elsewhere
+      ;; in this file (lines 530-537, 836-843, 880-882).
+      (is (some? (:owner slice))
+          "the navigation MUST allocate a route owner — its absence is a failure, not a skip")
+      (is (= [:route :route/article (:nav-token slice)] (:owner slice))
+          "the live route OWNER is [:route route-id nav-token]"))))
 
 ;; ---------------------------------------------------------------------------
 ;; (c+) The live graph's NON-route realized composition (rf2-k0meap.3 point-1).

--- a/implementation/derivation-conformance/test/re_frame/derivation_algebra_conformance_cljs_test.cljc
+++ b/implementation/derivation-conformance/test/re_frame/derivation_algebra_conformance_cljs_test.cljc
@@ -374,6 +374,24 @@
         (is (= :resource-process (:refinement res)))
         (is (= :route-fact       (:refinement route)))
         (is (= :machine-process  (:refinement mach)))))
+    (testing "the machine-selector SUB node carries the :machine-selector
+              refinement — the NODE-LABEL half of the 'Selector refinement'
+              conformance clause (spec/Derivations.md §Conformance line 842).
+              The :selector EDGE half is pinned by c-static-edges; this pins the
+              node-label half, stamped by mark-machine-selectors
+              (core .../derivation/graph.cljc:667-690) INDEPENDENTLY of the
+              :selector-edge emitter (machine-edges). A regression breaking
+              mark-machine-selectors while machine-edges still emits the edge
+              would drop the label and slip past BOTH the edge assertion and the
+              a- validate-if-present refinement loop — so this REQUIRES the
+              label. The refinement RIDES :derivation, never replaces it
+              (rf2-tp6wwb)."
+      (let [sel (node-by-family nodes :subs :upload/progress)]
+        (is (some? sel) "the machine-selector sub node is present")
+        (is (= :machine-selector (:refinement sel))
+            "the :upload/progress selector sub is enriched with :refinement :machine-selector")
+        (is (= :derivation (:kind sel))
+            "the machine-selector refinement rides the :derivation superkind, never replaces it")))
     (testing "the route fact's id is the ONE consumer-facing slice name :rf/route
               (one-name-per-fact), with the per-route id under :source-form"
       (let [route (node-by-family nodes :routes :route/article)]

--- a/implementation/reply-conformance/test/re_frame/reply_vocab_conformance_cljs_test.cljc
+++ b/implementation/reply-conformance/test/re_frame/reply_vocab_conformance_cljs_test.cljc
@@ -163,7 +163,7 @@
 
 (defn- after-stale-reply []
   (m-reply/after-stale-reply
-    {:machine-id      :a/multi
+    {:actor-id        :a/multi
      :state           :loading
      :delay           30000
      :decl-path       [:loading]
@@ -182,7 +182,7 @@
 ;; the one success-producing family the completion-time tier never exercised).
 (defn- after-fired-reply []
   (m-reply/after-fired-reply
-    {:machine-id :a/multi
+    {:actor-id   :a/multi
      :state      :loading
      :delay      30000
      :decl-path  [:loading]
@@ -191,7 +191,7 @@
 
 (defn- after-fired-reply-with-time []
   (m-reply/after-fired-reply
-    {:machine-id   :a/multi
+    {:actor-id     :a/multi
      :state        :loading
      :delay        30000
      :decl-path    [:loading]
@@ -384,6 +384,43 @@
                ", expected " work-head))
       (is (= wid (edn-roundtrip wid))
           (str family " " situation " :work/id is not EDN-round-trippable / =-comparable")))))
+
+(deftest timer-family-work-ids-share-the-actor-bearing-logical-id
+  ;; rf2-unucf7 — the machine `:after` timer's FIRED / STALE / CANCEL
+  ;; completions are ONE actor-owned timer instance, so their `:work/id`s MUST
+  ;; share the SAME actor-bearing logical-id `[:a/multi :loading]`
+  ;; (`re-frame.machines.reply/timer-work-id`, L386-392: `(and (some? actor-id)
+  ;; (some? decl-path)) -> (into [actor-id] (vec decl-path))`). The three
+  ;; fixtures feed `:actor-id :a/multi` + `:decl-path [:loading]` (matching the
+  ;; `:cancel` builder), so each work-id is `[:rf.work/timer [:a/multi :loading]
+  ;; epoch]`. `every-work-id-…-edn-tuple` above pins only the HEAD + EDN-round-
+  ;; trip; this pins the LOGICAL-ID actor-prepend the cross-family tier
+  ;; otherwise never cross-checks. So a regression that drops or mis-orders the
+  ;; actor in timer-work-id's logical-id — the actor-LESS `[:loading]` branch
+  ;; the old `:machine-id` dead-key fixtures silently took — goes RED here.
+  (let [fired  (:work/id (after-fired-reply))
+        stale  (:work/id (after-stale-reply))
+        cancel (:work/id (m-reply/cancelled-timer-reply
+                           {:actor-id  :a/multi
+                            :state     :loading
+                            :delay     30000
+                            :decl-path [:loading]
+                            :epoch     1
+                            :frame     :app/main
+                            :reason    :on-exit}))]
+    (testing "all three timer completions carry the :rf.work/timer head"
+      (doseq [[situation wid] [[:fired fired] [:stale stale] [:cancel cancel]]]
+        (is (= :rf.work/timer (first wid))
+            (str situation " timer :work/id head is not :rf.work/timer"))))
+    (testing "each timer :work/id logical-id is the ACTOR-bearing [:a/multi :loading]
+              — the actor-owned timer identity, NOT the actor-less [:loading]"
+      (doseq [[situation wid] [[:fired fired] [:stale stale] [:cancel cancel]]]
+        (is (= [:a/multi :loading] (second wid))
+            (str situation " timer logical-id must be actor-prefixed [:a/multi :loading], not "
+                 (pr-str (second wid))))))
+    (testing "so the whole timer family shares ONE logical-id across situations"
+      (is (= (second fired) (second stale) (second cancel))
+          "fired / stale / cancel timer work-ids share one actor-bearing logical-id"))))
 
 ;; ---------------------------------------------------------------------------
 ;; (a) SUCCESS — every family that produces a success reply produces the


### PR DESCRIPTION
Four conformance-suite hardening fixes from the 2026-07-09 correctness review. Each makes a vacuous / loose assertion strict so a real contract regression is caught; no production source changes, no existing coverage weakened.

## Fixes

- **rf2-b366vj** (P3, derivation-conformance) — machine `:evaluation` was asserted with two loose `(contains? (:evaluation mach) …)` presence checks, so a spurious `:on-reply` on the non-spawning `:upload/main` machine shipped undetected (the closed-vocabulary arm also passed, `:on-reply` being a valid policy). Replaced with exact set-equality `(= #{:on-transition :scheduled} (:evaluation mach))`, matching the resource sibling at line 417.
- **rf2-tp6wwb** (P3, derivation-conformance) — the "Selector refinement" conformance clause pinned only its `:selector`-edge half; the node-label half (`:refinement :machine-selector` on `:upload/progress`) was unexercised, so a `mark-machine-selectors` regression that still emitted the edge slipped past both the edge assertion and the a- validate-if-present loop. Added a required assertion for the node-label half (rides `:derivation`, never replaces it).
- **rf2-onazhx** (P4, derivation-conformance) — a residual `when-let` owner guard in the c-live-graph route arm could vacuously SKIP its assertion, inconsistent with the rf2-djofbh failing-precondition hardening applied elsewhere in the file. Dropped the `when-let`; assert `:owner` presence + shape unconditionally.
- **rf2-unucf7** (P3, reply-conformance) — the 3 `:after`-timer fixtures passed the actor key as `:machine-id`, but the machine-reply builders destructure `:actor-id`, so `actor-id` resolved to nil and `timer-work-id` took its actor-less branch — the actor-bearing work-id + correlation branches were never exercised. Renamed `:machine-id` → `:actor-id` at the 3 sites (matching the `:cancel` builder), and added the bead's optional cross-check pinning the timer family's fired/stale/cancel work-ids to the shared actor-bearing logical-id `[:a/multi :loading]`.

## Teeth proofs

Injected the guarded regression, confirmed the strengthened assertion goes RED, reverted — for three of the four:

- **rf2-b366vj** — spurious `:on-reply` at `machines/tooling.cljc:200` → this assertion RED (`#{:on-reply :on-transition :scheduled}` ≠ `#{:on-transition :scheduled}`); the old `contains?` pair would have stayed green.
- **rf2-tp6wwb** — neutered the stamp in `mark-machine-selectors` → ONLY the new node-label assertion RED (`:machine-selector` vs nil); the `:selector` edge assertion stayed green.
- **rf2-unucf7** — dropped the actor in `timer-work-id` → all three logical-id assertions RED (`[:loading]` vs `[:a/multi :loading]`); the head/EDN gate stayed green.
- **rf2-onazhx** — teeth by construction: converting the `when-let` to an unconditional `(is (some? (:owner slice)))` eliminates the vacuous-skip; verified green on both gates.

## Quality gates

- `cd implementation/derivation-conformance && clojure -M:test` → **19 tests, 442 assertions, 0 failures, 0 errors** (JVM).
- `cd implementation/reply-conformance && clojure -M:test` → **30 tests, 446 assertions, 0 failures, 0 errors** (JVM; +1 test / +7 assertions from the new cross-check).
- `cd implementation && npm run test:cljs` (full node bundle) → **8316 tests, 38242 assertions, 4 failures**. All 4 failures are pre-existing and unrelated — `realworld_resources_cljs_test.cljs`, tracked by **rf2-5qi5mp** (P1, "#5353 real-apps editor fix broke realworld_resources"). My conformance namespaces are green in the bundle.
- Full spine deferred to CI.

## Stance

Pre-alpha, no back-compat shims; ELEGANCE + CLARITY + CORRECTNESS + GOOD PRACTICE. These are conformance TEST suites — the fixes make vacuous/loose assertions strict so a real contract regression is caught. Touches only `implementation/derivation-conformance` + `implementation/reply-conformance`.
