### PR TITLE
fix(ssr-ring): honor :content-type opt; strip stale Content-Length on non-streaming path (rf2-nncni3 +1)

### DIFF
--- a/implementation/ssr-ring/src/re_frame/ssr/ring.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring.clj
@@ -187,14 +187,22 @@
 
 (def handler-defaults
   "Default `ssr-handler` opts merged under caller-supplied opts at
-  construction time (`:emit-hash?`, `:html-shell`, `:content-type`).
-  A DATA var, not a fn — exposed so callers can read or extend the
-  baseline. `:on-error` is deliberately NOT here (it is resolved
-  separately via `lifecycle/resolve-on-error` so the defaults stay
-  orthogonal to on-error precedence)."
-  {:emit-hash?   true
-   :html-shell   shell/default-html-shell
-   :content-type "text/html; charset=utf-8"})
+  construction time (`:emit-hash?`, `:html-shell`). A DATA var, not a
+  fn — exposed so callers can read or extend the baseline. `:on-error`
+  is deliberately NOT here (it is resolved separately via
+  `lifecycle/resolve-on-error` so the defaults stay orthogonal to
+  on-error precedence).
+
+  `:content-type` carries NO default (rf2-nncni3): the opt is a genuine
+  override that force-replaces the response Content-Type when supplied.
+  A default of `text/html; charset=utf-8` here would force-replace an
+  app's own `:rf.server/set-header \"content-type\"` on every request; an
+  absent (nil) opt instead leaves the runtime's default-seeded
+  `text/html; charset=utf-8` (Spec 011 §Status defaults) — or the app's
+  explicit Content-Type — in control. So the on-the-wire default is
+  unchanged; only its source moves from this map to the runtime seed."
+  {:emit-hash? true
+   :html-shell shell/default-html-shell})
 
 ;; ---- ssr-handler ----------------------------------------------------------
 
@@ -265,9 +273,16 @@
     :html-shell     — (body-html payload-edn opts) → string. Defaults
                       to `default-html-shell`. Replace to inject custom
                       <head>, scripts, JSON-LD, etc.
-    :content-type   — Content-Type header for HTML responses. Default
-                      \"text/html; charset=utf-8\" (matches the SSR
-                      runtime's default in the response accumulator).
+    :content-type   — Content-Type OVERRIDE for the successfully-rendered
+                      response body (rf2-nncni3). When supplied, it
+                      force-replaces the response Content-Type (any casing)
+                      — the surface for serving a non-HTML SSR body (XML
+                      feed / sitemap, `application/xhtml+xml`, …). OMIT it
+                      (the default) to leave the runtime's default-seeded
+                      \"text/html; charset=utf-8\" — or an app's own
+                      `:rf.server/set-header \"content-type\"` — in control.
+                      The override applies to the rendered body only; a
+                      projected error page keeps the HTML default.
 
   ---- :on-error vs :error-view — the error-handling division (rf2-s2ndr) ----
 

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/headers.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/headers.clj
@@ -94,31 +94,50 @@
     headers-map
     cookies))
 
-(defn headers->ring-map+default-content-type
+(defn strip-header
+  "Remove every entry whose name equals `header-name` (case-insensitively)
+  from a Ring header map. RFC 7230 §3.2 makes header names case-insensitive
+  tokens, and `merge-pair-into-header-map` preserves whatever casing the fx
+  supplied, so a header can land under any casing (`Content-Type`,
+  `content-type`, `CONTENT-TYPE`, …); we drop EVERY key whose lower-case
+  matches. Shared by the `:content-type` override
+  (`headers->ring-map+content-type-override`) and the Content-Length strip
+  (`strip-content-length`) so both single-source the case-insensitive
+  header-removal rule."
+  [headers-map header-name]
+  (let [target (str/lower-case (str header-name))]
+    (into {}
+          (remove (fn [[k _v]] (= target (str/lower-case (str k)))))
+          headers-map)))
+
+(defn headers->ring-map+content-type-override
   "Collapse an ordered vec-of-[name value] pairs into Ring's
-  `{name string-or-vec}` shape, defaulting `Content-Type` to
-  `content-type` (case-insensitive) in the SAME single pass when the
-  pairs don't already declare one (rf2-uj9z8). Folds each pair into the
-  accumulator AND lower-cases each name once to flag whether
-  `Content-Type` was seen, appending the default at the end iff not and
-  iff `content-type` is non-nil.
+  `{name string-or-vec}` shape, then apply the handler's `:content-type`
+  OVERRIDE (rf2-nncni3): when `content-type` is non-nil, EVERY existing
+  Content-Type entry (any casing — RFC 7230 §3.2) is stripped from the
+  folded map and a single canonical `Content-Type` header carrying
+  `content-type` is assoc'd. A nil `content-type` leaves the folded map
+  untouched — the runtime's default-seeded (Spec 011 §Status defaults) or
+  app-`:rf.server/set-header`-set Content-Type flows to the wire verbatim.
 
-  Case-insensitive Content-Type detection (rf2-depii) covers every
-  casing variant (`CONTENT-TYPE`, `CoNtEnT-TyPe`, …) per RFC 7230 §3.2
-  (header names are tokens; tokens are case-insensitive) — a mixed-case
-  caller header must NOT get a duplicate default appended.
+  Why an OVERRIDE, not the earlier default-when-absent (rf2-uj9z8): the SSR
+  runtime's `default-response` ALWAYS seeds
+  `[\"content-type\" \"text/html; charset=utf-8\"]` on the accumulator, so a
+  default-when-absent pass could NEVER fire for the ssr-ring runtime — the
+  Content-Type was unconditionally already present, so the handler's
+  documented `:content-type` opt was silently suppressed (rf2-nncni3). The
+  opt is now a genuine override; it defaults to nil (removed from
+  `handler-defaults` and `stream-handler`'s defaults merge), so an app's
+  explicit `:rf.server/set-header \"content-type\"` stays in control when
+  the caller does not pass the opt.
 
-  Ordering: the PER-NAME ordering of multi-valued headers (multiple
-  `Set-Cookie` entries) is preserved by `merge-pair-into-header-map`'s
-  `conj`. The ACROSS-NAME ordering is the JDK's HAMT iteration order —
-  stable but not first-seen order; Ring servers don't promise cross-name
-  header order on the wire either."
+  Ordering / multi-value semantics of the fold are unchanged
+  (`merge-pair-into-header-map`): per-name multi-value order preserved via
+  `conj`, across-name order is the JDK HAMT iteration order — stable but
+  not first-seen; Ring servers don't promise cross-name header order on the
+  wire either."
   [pairs content-type]
-  (let [step (fn [[m saw-ct?] [k v :as pair]]
-               [(merge-pair-into-header-map m pair)
-                (or saw-ct?
-                    (= "content-type" (str/lower-case (str k))))])
-        [m saw-ct?] (reduce step [{} false] pairs)]
-    (if (or saw-ct? (nil? content-type))
+  (let [m (reduce merge-pair-into-header-map {} pairs)]
+    (if (nil? content-type)
       m
-      (assoc m "Content-Type" content-type))))
+      (assoc (strip-header m "content-type") "Content-Type" content-type))))

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/headers.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/headers.clj
@@ -110,6 +110,29 @@
           (remove (fn [[k _v]] (= target (str/lower-case (str k)))))
           headers-map)))
 
+(defn strip-content-length
+  "Remove any `Content-Length` header (case-insensitively) from a Ring
+  response header map. A re-frame2 SSR body is ALWAYS assembled by the
+  adapter AFTER the `:initial-events` drain — the non-streaming shell +
+  hydration payload, or the streaming chunk-producing `PipedInputStream` —
+  so app / server-init code CANNOT know the final byte count when it runs.
+  App / server init MAY nonetheless `:rf.server/set-header` (or
+  `append-header`) a `Content-Length` during the drain. Left in place, a
+  Ring server that honours that stale fixed length truncates the HTML (too
+  short) or blocks the client waiting for bytes (too long).
+
+  Stripping lets the Ring server own transfer framing — computing
+  `Content-Length` for the materialised String / empty body, or chunking the
+  streaming `InputStream` body (Spec 011 §Streaming SSR — chunked-transfer
+  framing).
+
+  rf2-d95m4i — single-sourced here and applied by BOTH materialiser paths:
+  the streaming head (rf2-h3dg0) AND the non-streaming
+  `pipeline/ssr-response->ring-response`, closing the asymmetry where only
+  the streaming path stripped a stale app-set length."
+  [headers-map]
+  (strip-header headers-map "content-length"))
+
 (defn headers->ring-map+content-type-override
   "Collapse an ordered vec-of-[name value] pairs into Ring's
   `{name string-or-vec}` shape, then apply the handler's `:content-type`

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
@@ -87,11 +87,15 @@
   responses). `:redirect` short-circuits per Spec 011 §Redirect
   precedence — status + Location header, no body.
 
-  The optional 3-arg form (rf2-uj9z8) accepts a `default-content-type`
-  that's stamped onto the Ring header map if (and only if) the response
-  pairs don't already carry a Content-Type (case-insensitive). The
-  defaulting happens INSIDE the single header-fold pass
-  (`headers->ring-map+default-content-type`).
+  The optional 3-arg form accepts a `content-type` OVERRIDE (rf2-nncni3):
+  when non-nil it force-replaces any Content-Type on the accumulator (any
+  casing) with a single canonical `Content-Type` header. A nil
+  `content-type` leaves the accumulator's Content-Type (the runtime seed or
+  an app `:rf.server/set-header`) untouched. The override happens inside the
+  header fold (`headers->ring-map+content-type-override`). The earlier
+  default-when-absent form (rf2-uj9z8) was a silent no-op for the ssr-ring
+  runtime — `default-response` always seeds a Content-Type, so the passed
+  opt could never be applied (rf2-nncni3).
 
   Host-serialisability fail-closed (rf2-v0qbng): this materialiser is the
   LAST line between the runtime accumulator and the wire, and the
@@ -128,7 +132,7 @@
                                       "redirect; the browser has no target)")
                        :recovery :warned-and-emitted-statusonly}))
        {:status  (fail-closed-status (or redirect-status status) 302)
-        :headers (-> (headers/headers->ring-map+default-content-type
+        :headers (-> (headers/headers->ring-map+content-type-override
                        headers default-content-type)
                      (headers/append-set-cookies cookies)
                      ;; The Location value must be a string — a non-string
@@ -139,7 +143,7 @@
                                                         (str target)))))
         :body    ""})
      {:status  (fail-closed-status status 200)
-      :headers (-> (headers/headers->ring-map+default-content-type
+      :headers (-> (headers/headers->ring-map+content-type-override
                      headers default-content-type)
                    (headers/append-set-cookies cookies))
       :body    (or body "")})))
@@ -470,12 +474,14 @@
         ;; merge :status) so any header / cookie the render walk
         ;; accumulated also rides the wire.
         post-render-resp (ssr/flush-response! frame-id)]
-    ;; Content-Type defaulting (rf2-uj9z8): the 3-arg form folds the
-    ;; header pairs into the Ring map AND defaults Content-Type in one
-    ;; walk. The SSR runtime defaults [:rf/response :headers] to include
-    ;; content-type so the default is usually a no-op, but we still pass
-    ;; `content-type` through so an opts override and absence-of-default
-    ;; both work.
+    ;; Content-Type override (rf2-nncni3): the 3-arg form force-replaces
+    ;; the accumulator's Content-Type with the handler's `:content-type`
+    ;; opt when it is non-nil. The SSR runtime always seeds a Content-Type
+    ;; on [:rf/response :headers], so the earlier default-when-absent form
+    ;; could NEVER apply the opt — a caller `:content-type` was silently
+    ;; dropped. With the opt now defaulting to nil (removed from
+    ;; `handler-defaults`), a nil `content-type` leaves the runtime seed /
+    ;; app-`set-header` value in control; a non-nil opt overrides it.
     (ssr-response->ring-response post-render-resp html content-type)))
 
 (defn project-render-throw->ring-response
@@ -520,9 +526,17 @@
                             {:status 500 :code :internal-error
                              :message "Something went wrong"
                              :retryable? false})
-          body-html     (resolve-error-body frame-id (:error-view opts) public-error*)
-          content-type  (:content-type opts)]
-      (ssr-response->ring-response resp* body-html content-type))))
+          body-html     (resolve-error-body frame-id (:error-view opts) public-error*)]
+      ;; rf2-nncni3 — do NOT apply the handler's `:content-type` override on
+      ;; the error path. That opt labels the SUCCESSFUL rendered body (an XML
+      ;; feed / bespoke type); the projected error body is always an HTML
+      ;; fallback, so it keeps the runtime's `text/html; charset=utf-8` seed
+      ;; (Spec 011 §Status defaults) — labelling an HTML error page as, say,
+      ;; `application/xml` would be a wire-content mismatch. An app that set a
+      ;; custom Content-Type via `:rf.server/set-header` before the throw
+      ;; still has it on `resp*` (unchanged behaviour); we only decline to
+      ;; force the construction-time opt here.
+      (ssr-response->ring-response resp* body-html))))
 
 (defn build-full-response
   "Render the caller's `:root-view` against `frame-id`, build the

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
@@ -104,7 +104,15 @@
   valid Ring response regardless of what slipped past that gate: `:status`
   is coerced to an int (`fail-closed-status` — non-int fails closed to
   500), the Location target is coerced to a string, and header values are
-  coerced to strings in the fold (`headers/merge-pair-into-header-map`)."
+  coerced to strings in the fold (`headers/merge-pair-into-header-map`).
+
+  Content-Length is stripped from EVERY response (rf2-d95m4i): the body is
+  always adapter-assembled AFTER the drain (a String/empty body here, or the
+  streaming InputStream that swaps in downstream), so an app-set
+  `Content-Length` can never match it. The streaming path hardened against
+  this (rf2-h3dg0); doing it in the shared materialiser closes the same
+  hazard on the non-streaming (and redirect) paths and lets the Ring server
+  own transfer framing (`headers/strip-content-length`)."
   ([resp body] (ssr-response->ring-response resp body nil))
   ([{:keys [status headers cookies redirect]} body default-content-type]
    (if redirect
@@ -140,12 +148,20 @@
                      ;; boundary) is coerced so the Ring header map is valid.
                      (cond-> target (assoc "Location" (if (string? target)
                                                         target
-                                                        (str target)))))
+                                                        (str target))))
+                     ;; rf2-d95m4i — a bodiless redirect never matches a
+                     ;; stale app-set Content-Length either; strip it.
+                     (headers/strip-content-length))
         :body    ""})
      {:status  (fail-closed-status status 200)
       :headers (-> (headers/headers->ring-map+content-type-override
                      headers default-content-type)
-                   (headers/append-set-cookies cookies))
+                   (headers/append-set-cookies cookies)
+                   ;; rf2-d95m4i — strip any app-set Content-Length: the body
+                   ;; is the adapter-assembled shell + hydration payload built
+                   ;; AFTER the drain, so a drain-time fixed length will not
+                   ;; match it; let the Ring server frame the String body.
+                   (headers/strip-content-length))
       :body    (or body "")})))
 
 (defn setup-request-frame!

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
@@ -898,9 +898,14 @@
   ;; way via the shared `lifecycle/resolve-on-error`: caller's
   ;; `:on-error` wins, else the locked `default-on-error` (rf2-kzvwq
   ;; topology-leak contract).
-  (let [opts        (-> (merge {:emit-hash?   true
-                                :content-type "text/html; charset=utf-8"}
-                               raw-opts)
+  ;; rf2-nncni3 — `:content-type` carries NO default here (mirrors
+  ;; `ssr-ring/handler-defaults`): the opt is a genuine override that
+  ;; force-replaces the streamed head's Content-Type when supplied. A
+  ;; non-nil default would clobber an app's own `:rf.server/set-header
+  ;; "content-type"`; an absent (nil) opt leaves the runtime's
+  ;; default-seeded `text/html; charset=utf-8` — or the app's Content-Type
+  ;; — in control (the on-the-wire default is unchanged).
+  (let [opts        (-> (merge {:emit-hash? true} raw-opts)
                         (assoc :on-error (lifecycle/resolve-on-error raw-opts)))
         {:keys [on-error content-type]} opts]
     (fn ring-handler [request]

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
@@ -45,8 +45,7 @@
   in-place and merges the per-subtree `data-rf2-suspense-hydrate` delta as
   chunks arrive, reconciling against the final `__rf_payload`
   (`:replace-frame-state`) when it lands."
-  (:require [clojure.string :as str]
-            [re-frame.core :as rf]
+  (:require [re-frame.core :as rf]
             [re-frame.interop :as interop]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.html-helpers :as html]
@@ -642,32 +641,6 @@
 
 ;; ---- public surface ------------------------------------------------------
 
-(defn strip-content-length
-  "Remove any `Content-Length` header (case-insensitively) from a Ring
-  response header map. The streaming body is a chunk-producing
-  `PipedInputStream` whose final byte count is unknown when the head
-  commits, so the response MUST use `Transfer-Encoding: chunked`
-  framing (Spec 011 §Streaming SSR — the wire shape pins chunked
-  transfer). A stale fixed `Content-Length` — set/appended by app or
-  server init code (`:rf.server/set-header` / `:rf.server/append-header`
-  during the `:initial-events` drain) before streaming was chosen — would
-  otherwise survive onto the streamed response, and a Ring server may
-  honour that length instead of chunking: truncated HTML, clients
-  waiting on the wrong byte count, or lost progressive chunks.
-
-  Ring header NAMES are caller-cased verbatim by the materialiser
-  (`headers/merge-pair-into-header-map` preserves whatever casing the
-  fx supplied), so a `Content-Length` can land under any casing
-  (`Content-Length`, `content-length`, `CONTENT-LENGTH`, …). RFC 7230
-  §3.2 makes header names case-insensitive tokens, so we drop EVERY
-  key whose lower-case is `content-length` — letting the Ring server
-  own transfer framing for the InputStream body."
-  [headers-map]
-  (into {}
-        (remove (fn [[k _v]]
-                  (= "content-length" (str/lower-case (str k)))))
-        headers-map))
-
 (defn- redirect-response!
   "Short-circuit a streaming request to a bodiless Location response and
   destroy the per-request frame inline. Shared (rf2-tqjc7h) by BOTH redirect
@@ -739,14 +712,18 @@
   handler's outer catch BEFORE any thread or pipe exists → on-error, no detached
   writer, no orphaned pipe.
 
-  rf2-h3dg0 — STRIP any `Content-Length` header (case-insensitively) from the
-  materialised head before wiring the chunk-writer body. App / server init can
-  `:rf.server/set-header` (or `append-header`) a `Content-Length` during the
-  `:initial-events` drain — a fixed length that is meaningless (and actively harmful)
-  once the body becomes a chunk-producing PipedInputStream of unknown final
-  size. Left in place, a Ring server may honour that length instead of chunked
-  transfer framing → truncated HTML / clients blocked on the wrong byte count /
-  lost chunks, violating Spec 011's chunked-transfer streaming contract.
+  rf2-h3dg0 / rf2-d95m4i — any `Content-Length` header (case-insensitively) is
+  stripped from the materialised head before wiring the chunk-writer body. App
+  / server init can `:rf.server/set-header` (or `append-header`) a
+  `Content-Length` during the `:initial-events` drain — a fixed length that is
+  meaningless (and actively harmful) once the body becomes a chunk-producing
+  PipedInputStream of unknown final size. Left in place, a Ring server may
+  honour that length instead of chunked transfer framing → truncated HTML /
+  clients blocked on the wrong byte count / lost chunks, violating Spec 011's
+  chunked-transfer streaming contract. The strip now lives in the shared
+  `pipeline/ssr-response->ring-response` materialiser (rf2-d95m4i single-source
+  — the non-streaming path had the same exposure), so the head is already
+  Content-Length-free when it returns here.
 
   rf2-ekwda — the writer runs on a DAEMON thread: one blocked on `.write` to the
   bounded 16 KiB pipe of a slow-loris client must NOT keep the JVM alive at
@@ -754,9 +731,9 @@
   via the slower destroy)."
   [frame-id rendered resp2 content-type opts]
   (let [;; No body default-stamp here (we pass our own InputStream); `:body` is
-        ;; assoc'd after the writer is wired below.
-        resp-map (-> (pipeline/ssr-response->ring-response resp2 "" content-type)
-                     (update :headers strip-content-length))
+        ;; assoc'd after the writer is wired below. Content-Length is already
+        ;; stripped by the shared materialiser (rf2-d95m4i / rf2-h3dg0).
+        resp-map (pipeline/ssr-response->ring-response resp2 "" content-type)
         ;; 16 KiB pipe buffer — large enough to absorb the shell chunk in one
         ;; write so the writer rarely blocks on a slow consumer, small enough
         ;; that one stuck client doesn't pin a non-trivial chunk of heap.

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/pipeline_materialiser_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/pipeline_materialiser_test.clj
@@ -20,13 +20,13 @@
        alt-host response, so it must NOT silently honour the retired keys.
        Pinned here directly.
 
-    2. `headers->ring-map+default-content-type` POSITIVE paths — the
-       suppression path (a caller Content-Type in any casing suppresses
-       the default) is covered by `ring_test/content-type-default-no-
-       duplicate-on-mixed-case`. The complementary contracts were not:
-         (a) the default IS appended when the pairs declare no
-             Content-Type,
-         (b) a `nil` `content-type` arg means NO default is appended,
+    2. `headers->ring-map+content-type-override` paths (rf2-nncni3) — the
+       override-strips-existing path (a non-nil override replaces any-casing
+       Content-Type) is covered by `ring_test/content-type-override-
+       replaces-any-casing`. The complementary contracts here:
+         (a) the override IS set when the pairs declare no Content-Type,
+         (b) a `nil` `content-type` arg is NO override — the folded map
+             (runtime seed / app-set Content-Type) flows verbatim,
          (c) repeated header names collapse into a vector
              (`merge-pair-into-header-map`'s string→vector→conj arms),
        the last being the load-bearing multi-valued-header round-trip
@@ -231,36 +231,43 @@
       (is (= "5" loc) "the non-string target is coerced via str"))))
 
 ;; ===========================================================================
-;; headers->ring-map+default-content-type — POSITIVE default-append +
-;; nil-content-type paths (the suppression path is covered by
-;; ring_test/content-type-default-no-duplicate-on-mixed-case)
+;; headers->ring-map+content-type-override — override-when-present +
+;; nil-content-type passthrough (rf2-nncni3). The override-strips-existing
+;; path across every casing is covered by
+;; ring_test/content-type-override-replaces-any-casing.
 ;; ===========================================================================
 
-(deftest content-type-default-appended-when-absent
-  (testing "rf2-ynjts.14: pairs that declare no Content-Type get the default
-            appended (the positive complement of the suppression test)"
-    (let [result (headers/headers->ring-map+default-content-type
+(deftest content-type-override-sets-when-pairs-carry-none
+  (testing "rf2-nncni3: pairs that declare no Content-Type get the override
+            value set (with no existing Content-Type, override = assoc)"
+    (let [result (headers/headers->ring-map+content-type-override
                    [["X-Custom" "v"]]
                    "text/html; charset=utf-8")]
       (is (= "text/html; charset=utf-8" (get result "Content-Type"))
-          "default Content-Type appended when the pairs carry none")
+          "the override Content-Type is set when the pairs carry none")
       (is (= "v" (get result "X-Custom")) "other pairs survive the fold"))))
 
-(deftest content-type-no-default-when-content-type-arg-nil
-  (testing "rf2-ynjts.14: a nil `content-type` arg means NO default is
-            appended even when the pairs declare none — the caller opted
-            out of defaulting (the redirect path passes nil)"
-    (let [result (headers/headers->ring-map+default-content-type
+(deftest content-type-nil-override-leaves-pairs-untouched
+  (testing "rf2-nncni3: a nil `content-type` arg is NO override — the folded
+            map flows verbatim, so the runtime seed / app-set Content-Type
+            stays in control (the redirect path passes nil)"
+    (let [result (headers/headers->ring-map+content-type-override
                    [["X-Custom" "v"]]
                    nil)]
       (is (not (contains? result "Content-Type"))
-          "no Content-Type key when the default arg is nil and pairs carry none")
-      (is (= "v" (get result "X-Custom"))))))
+          "no Content-Type key when the override is nil and pairs carry none")
+      (is (= "v" (get result "X-Custom"))))
+    (testing "a nil override preserves a caller-supplied Content-Type verbatim"
+      (let [result (headers/headers->ring-map+content-type-override
+                     [["content-type" "application/json"]]
+                     nil)]
+        (is (= "application/json" (get result "content-type"))
+            "the accumulator's own Content-Type survives an absent override")))))
 
-(deftest empty-pairs-with-nil-default-yields-empty-map
-  (testing "rf2-ynjts.14: empty pairs + nil default → empty header map (no
+(deftest empty-pairs-with-nil-override-yields-empty-map
+  (testing "rf2-nncni3: empty pairs + nil override → empty header map (no
             spurious keys)"
-    (is (= {} (headers/headers->ring-map+default-content-type [] nil)))))
+    (is (= {} (headers/headers->ring-map+content-type-override [] nil)))))
 
 ;; ===========================================================================
 ;; merge-pair-into-header-map — repeated names collapse into a vector
@@ -309,7 +316,7 @@
                (headers/merge-pair-into-header-map ["X-Count" 5])
                (headers/merge-pair-into-header-map ["X-Count" 6])))
         "two non-string values under one name collapse to a vector of strings")
-    (let [result (headers/headers->ring-map+default-content-type
+    (let [result (headers/headers->ring-map+content-type-override
                    [["X-Count" 5]
                     ["X-Count" 6]
                     ["X-Other" "keep"]]
@@ -321,7 +328,7 @@
       (is (= "keep" (get result "X-Other"))
           "headers folded AFTER the repeat are NOT wiped (no nil-map)")
       (is (= "text/html" (get result "Content-Type"))
-          "the defaulted Content-Type survives — the map was never nulled"))))
+          "the override Content-Type is set — the map was never nulled"))))
 
 ;; ===========================================================================
 ;; merge-pair-into-header-map — dev-gated warning on a non-string value
@@ -383,7 +390,7 @@
   (testing "rf2-ynjts.14: the full fold collapses repeated names into a
             vector AND keeps singletons scalar in one pass — the contract
             the materialiser relies on for multi-valued headers"
-    (let [result (headers/headers->ring-map+default-content-type
+    (let [result (headers/headers->ring-map+content-type-override
                    [["Set-Cookie" "a=1"]
                     ["Set-Cookie" "b=2"]
                     ["X-One" "only"]]

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_streaming_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_streaming_test.clj
@@ -983,6 +983,43 @@
           "Content-Type default survives the strip — only Content-Length
            is removed"))))
 
+;; ===========================================================================
+;; rf2-nncni3 — the stream-handler :content-type opt is honored on the wire
+;;
+;; The streaming path threads `:content-type` into the same materialiser as
+;; the non-streaming handler. A custom opt must force-replace the runtime's
+;; default-seeded text/html on the streamed head; omitting it leaves the
+;; default in control. (Parity with the non-streaming coverage in ring_test.)
+;; ===========================================================================
+
+(deftest stream-handler-honors-custom-content-type-opt
+  (testing "rf2-nncni3: a custom :content-type opt force-replaces the
+            default-seeded text/html on the STREAMED response head — no
+            duplicate content-type key, and the body still streams in full"
+    (let [handler  (ssr-ring/stream-handler
+                     {:initial-events [[:rf.test.server/init]]
+                      :root-view      [:test/root]
+                      :content-type   "application/xhtml+xml; charset=utf-8"
+                      :payload        :rf.ssr.payload/whole-app-db})
+          response (handler {:uri "/" :request-method :get})
+          headers  (:headers response)
+          ct       (some (fn [[k v]]
+                           (when (= "content-type" (clojure.string/lower-case (str k))) v))
+                         headers)
+          ct-keys  (filter (fn [k] (= "content-type" (clojure.string/lower-case (str k))))
+                           (keys headers))
+          body     (drain-stream (:body response))]
+      (is (= 200 (:status response)))
+      (is (= 1 (count ct-keys))
+          (str "exactly one content-type key on the streamed head, no "
+               "duplicate — keys: " (pr-str (keys headers))))
+      (is (= "application/xhtml+xml; charset=utf-8" ct)
+          "the custom :content-type opt is on the streamed head, not text/html")
+      (is (str/includes? body "<!DOCTYPE html>")
+          "the streamed body is still emitted in full (override did not break it)")
+      (is (str/includes? body "Article A")
+          "the resolved body content streamed"))))
+
 ;; ---- :html-shell is rejected at construction (rf2-oq4m5) -----------------
 ;;
 ;; The non-streaming `ssr-handler` honours a one-piece `:html-shell` fn;

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
@@ -2138,6 +2138,61 @@
           "the app-set content-type flows to the wire when the opt is absent"))))
 
 ;; ===========================================================================
+;; rf2-d95m4i — non-streaming materialiser strips a stale app-set
+;; Content-Length
+;;
+;; The non-streaming body is the adapter-assembled shell + hydration payload,
+;; built AFTER the :initial-events drain, so an app-set fixed Content-Length
+;; can never match it. Left in place a Ring server that honours the length
+;; truncates the HTML (too short) or blocks the client (too long). The
+;; streaming path was hardened (rf2-h3dg0); this pins the same guarantee on
+;; the non-streaming sibling path.
+;; ===========================================================================
+
+(deftest ssr-handler-strips-stale-app-set-content-length
+  (testing "rf2-d95m4i: an :initial-events-set Content-Length is stripped
+            (case-insensitively) from the non-streaming Ring response so the
+            server owns byte framing for the String body; the full HTML rides
+            the wire, not truncated to the stale length"
+    (rf/reg-event :init/cl-stale
+      {:platforms #{:server}}
+      (fn [_ _]
+        {:db {:articles [{:id "a" :title "Article A"}]}
+         ;; A deliberately WRONG fixed length — canonical- AND lower-cased,
+         ;; proving the strip is case-insensitive across the materialiser's
+         ;; verbatim header casing.
+         :fx [[:rf.server/set-header    {:name "Content-Length" :value "7"}]
+              [:rf.server/append-header {:name "content-length" :value "13"}]]}))
+    (rf/reg-sub :articles (fn [db _] (:articles db)))
+    (rf/reg-view* :pages/cl-body
+      (fn []
+        (into [:ul]
+              (for [{:keys [title]} (rf/subscribe-once [:articles])]
+                [:li title]))))
+    (let [handler  (ssr-ring/ssr-handler
+                     {:initial-events [[:init/cl-stale]]
+                      :root-view      [:pages/cl-body]
+                      :payload        :rf.ssr.payload/whole-app-db})
+          response (handler {:uri "/" :request-method :get})
+          headers  (:headers response)
+          keys-lc  (into #{} (map (fn [k] (str/lower-case (str k)))) (keys headers))
+          body     (:body response)]
+      (is (= 200 (:status response)))
+      (is (string? body) "the non-streaming body is a materialised String")
+      (is (not (contains? keys-lc "content-length"))
+          (str "NO Content-Length header survives on the non-streaming "
+               "response (any casing) — the server frames the String body. "
+               "Header keys (lower-cased): " (pr-str keys-lc)))
+      ;; The stale values (7 / 13) are nowhere near the real body length;
+      ;; assert the full HTML rode the wire (not capped to a fake length).
+      (is (str/includes? body "<!DOCTYPE html>") "shell present")
+      (is (str/includes? body "Article A") "resolved view content present")
+      (is (str/includes? body "__rf_payload") "hydration payload present")
+      (is (> (count body) 13)
+          "the real body is far longer than the stale Content-Length — proof
+           the response was not capped to the fake length"))))
+
+;; ===========================================================================
 ;; rf2-7ksyr — hydration payload </script> injection (security audit §P1)
 ;;
 ;; A user-controlled string round-tripping through app-db that contains

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
@@ -2022,41 +2022,120 @@
             "X-Audit append-header reached the wire (multi-valued)")))))
 
 ;; ===========================================================================
-;; rf2-depii — Content-Type default is case-insensitive (no duplicate)
+;; rf2-nncni3 / rf2-depii — Content-Type override strips any casing (no dup)
 ;;
-;; `headers->ring-map+default-content-type` defaults Content-Type only
-;; when the pairs don't already declare one — and the detection is
-;; case-insensitive, so any casing (CONTENT-TYPE, CoNtEnT-TyPe) of a
-;; caller-supplied header suppresses the default. RFC 7230 §3.2 —
-;; header names are tokens; tokens are case-insensitive.
+;; `headers->ring-map+content-type-override` force-replaces the accumulator's
+;; Content-Type with a non-nil override, stripping EVERY existing
+;; Content-Type entry regardless of casing (CONTENT-TYPE, CoNtEnT-TyPe, …)
+;; before assoc'ing the single canonical `Content-Type`. RFC 7230 §3.2 —
+;; header names are case-insensitive tokens, so the strip must catch every
+;; casing or a stale duplicate would ride the wire.
 ;;
-;; rf2-ee38b.11 — re-pointed at the live single-pass fn (the prior
-;; `ensure-content-type` / `headers->ring-map` helpers were orphaned by
-;; the rf2-uj9z8 single-pass refactor and have been deleted). The live
-;; fn is the production path, so the test now gives real confidence.
+;; (rf2-nncni3 replaces the prior rf2-depii default-when-absent premise: the
+;; opt is now a genuine OVERRIDE, so the override value wins — not the
+;; caller's accumulator pair.)
 ;; ===========================================================================
 
-(deftest content-type-default-no-duplicate-on-mixed-case
-  (testing "rf2-depii: a preexisting Content-Type pair in ANY casing
-            suppresses the default — exactly one content-type key in the
-            folded Ring header map, carrying the CALLER's value"
+(deftest content-type-override-replaces-any-casing
+  (testing "rf2-nncni3: a non-nil override strips a preexisting Content-Type
+            in ANY casing and leaves exactly one canonical key carrying the
+            OVERRIDE value — no duplicate, no casing survivor"
     (let [fold (requiring-resolve
-                 're-frame.ssr.ring.headers/headers->ring-map+default-content-type)]
+                 're-frame.ssr.ring.headers/headers->ring-map+content-type-override)]
       (doseq [casing ["content-type"
                       "Content-Type"
                       "CONTENT-TYPE"
                       "CoNtEnT-TyPe"
                       "content-Type"]]
-        (let [pairs  [[casing "application/json"]]
-              result (fold pairs "text/html; charset=utf-8")
+        (let [pairs   [[casing "application/json"]]
+              result  (fold pairs "text/html; charset=utf-8")
               ct-keys (filter (fn [k] (= "content-type" (str/lower-case (str k))))
                               (keys result))]
           (is (= 1 (count ct-keys))
               (str "casing " (pr-str casing)
-                   " — exactly one content-type key after the fold, no duplicate"))
-          (is (= "application/json" (get result (first ct-keys)))
+                   " — exactly one content-type key after the override, no duplicate"))
+          (is (= "text/html; charset=utf-8" (get result (first ct-keys)))
               (str "casing " (pr-str casing)
-                   " — the caller's Content-Type value wins, not the default")))))))
+                   " — the override value wins over the accumulator's pair")))))))
+
+;; ===========================================================================
+;; rf2-nncni3 — the handler :content-type opt is honored on the wire
+;;
+;; The documented `:content-type` opt was a silent no-op: the runtime always
+;; seeds a Content-Type on the accumulator, so the earlier default-when-absent
+;; fold could never apply the opt. It is now a genuine OVERRIDE. These tests
+;; pin the wire contract end-to-end through the full non-streaming handler:
+;;   (a) a custom opt force-replaces the default seed on the wire,
+;;   (b) omitting the opt leaves the runtime's text/html seed unchanged,
+;;   (c) omitting the opt leaves an app-set `:rf.server/set-header`
+;;       Content-Type in control (the opt no longer clobbers it).
+;; ===========================================================================
+
+(defn- response-content-type
+  "The single content-type header value on a Ring response (any casing),
+  or nil. Also asserts (via the returned key count) there is no duplicate."
+  [response]
+  (some (fn [[k v]] (when (= "content-type" (str/lower-case (str k))) v))
+        (:headers response)))
+
+(defn- response-content-type-key-count
+  [response]
+  (count (filter (fn [k] (= "content-type" (str/lower-case (str k))))
+                 (keys (:headers response)))))
+
+(deftest ssr-handler-honors-custom-content-type-opt
+  (testing "rf2-nncni3: a custom :content-type opt force-replaces the
+            runtime's default-seeded text/html on the wire — the documented
+            opt is no longer a silent no-op, and no duplicate key survives"
+    (rf/reg-event :init/ct-ok {:platforms #{:server}} (fn [_ _] {}))
+    (rf/reg-view* :pages/ct-body (fn [] [:div "body"]))
+    (let [handler  (ssr-ring/ssr-handler
+                     {:initial-events [[:init/ct-ok]]
+                      :root-view      [:pages/ct-body]
+                      :content-type   "application/xhtml+xml; charset=utf-8"
+                      :payload        :rf.ssr.payload/whole-app-db})
+          response (handler {:uri "/" :request-method :get})]
+      (is (= 200 (:status response)))
+      (is (= 1 (response-content-type-key-count response))
+          "exactly one content-type key — the override left no duplicate")
+      (is (= "application/xhtml+xml; charset=utf-8"
+             (response-content-type response))
+          "the custom :content-type opt is on the wire, not text/html"))))
+
+(deftest ssr-handler-default-content-type-is-html-when-opt-absent
+  (testing "rf2-nncni3: with NO :content-type opt the runtime's default seed
+            (text/html; charset=utf-8) rides the wire unchanged"
+    (rf/reg-event :init/ct-def {:platforms #{:server}} (fn [_ _] {}))
+    (rf/reg-view* :pages/ct-def-body (fn [] [:div "body"]))
+    (let [handler  (ssr-ring/ssr-handler
+                     {:initial-events [[:init/ct-def]]
+                      :root-view      [:pages/ct-def-body]
+                      :payload        :rf.ssr.payload/whole-app-db})
+          response (handler {:uri "/" :request-method :get})
+          ct       (response-content-type response)]
+      (is (= 1 (response-content-type-key-count response)))
+      (is (str/includes? ct "text/html") "default seed content-type on the wire")
+      (is (str/includes? ct "utf-8")))))
+
+(deftest ssr-handler-app-set-content-type-flows-when-opt-absent
+  (testing "rf2-nncni3: an app `:rf.server/set-header \"content-type\"` stays
+            in control when the handler passes NO :content-type opt — the opt
+            default is nil, so it does not clobber the app's explicit value"
+    (rf/reg-event :init/ct-appset
+      {:platforms #{:server}}
+      (fn [_ _]
+        {:fx [[:rf.server/set-header {:name  "Content-Type"
+                                      :value "application/json"}]]}))
+    (rf/reg-view* :pages/ct-appset-body (fn [] [:div "body"]))
+    (let [handler  (ssr-ring/ssr-handler
+                     {:initial-events [[:init/ct-appset]]
+                      :root-view      [:pages/ct-appset-body]
+                      :payload        :rf.ssr.payload/whole-app-db})
+          response (handler {:uri "/" :request-method :get})]
+      (is (= 1 (response-content-type-key-count response))
+          "exactly one content-type key")
+      (is (= "application/json" (response-content-type response))
+          "the app-set content-type flows to the wire when the opt is absent"))))
 
 ;; ===========================================================================
 ;; rf2-7ksyr — hydration payload </script> injection (security audit §P1)


### PR DESCRIPTION
Two correctness fixes on `implementation/ssr-ring`, committed separately.

## rf2-nncni3 (P2) — `:content-type` handler opt silently ignored

The documented `:content-type` opt on `ssr-handler` / `stream-handler` was a
silent no-op. It was threaded as a *default-when-absent* value into the
header fold, but `re-frame.ssr.response/default-response` ALWAYS seeds a
`content-type` on the accumulator, so the "no content-type present" branch
could never fire — a caller passing e.g. `application/xhtml+xml` silently got
`text/html; charset=utf-8` on the wire (both handlers).

**Fix:** make the opt a genuine OVERRIDE that force-replaces the accumulator's
Content-Type (any casing) at materialise time, and default it to **nil**
(removed from `handler-defaults` and `stream-handler`'s merge) so an app's own
`:rf.server/set-header "content-type"` stays in control when the caller omits
the opt. On-the-wire default is unchanged (`text/html` now sourced from the
runtime seed). The projected error page keeps the HTML default — the opt
labels the successful body only.

- `headers`: rename `headers->ring-map+default-content-type` →
  `headers->ring-map+content-type-override`; add case-insensitive `strip-header`.
- `pipeline`: materialiser + `build-full-response*` wire the override; the
  misleading "so an opts override work" comment is corrected; error path no
  longer force-labels the HTML fallback.
- `ring`/`streaming`: drop the `:content-type` default; opt docstring updated.

## rf2-d95m4i (P3) — non-streaming path never stripped app-set Content-Length

The streaming path strips a stale app-set `Content-Length` (rf2-h3dg0); the
non-streaming materialiser did not. An `:initial-events`-drain-set
`Content-Length` survived verbatim into the Ring response, but the body is the
shell + hydration payload assembled AFTER the drain, so the fixed length can
never match it → host-dependent truncation/hang.

**Fix:** single-source the strip in the shared `ssr-response->ring-response`
materialiser (body + redirect branches) so BOTH paths are covered;
`strip-content-length` now lives in `headers` (built on `strip-header`); the
streaming path's now-redundant local strip + unused `clojure.string` require
are removed.

## Tests (≥1 adversarial per fix)

- custom `:content-type` honored on `ssr-handler` AND `stream-handler`; omitted
  opt leaves the runtime seed / app-set header in control; override strips
  every casing with no duplicate.
- an app-set `Content-Length` during the drain does NOT survive into the
  non-streaming Ring response (any casing); the full HTML rides the wire.

## Quality gates

- `implementation/ssr-ring` `clojure -M:test` — **167 tests, 789 assertions, 0 failures, 0 errors** ✅
- `implementation/ssr` `clojure -M:test` (the contract wired) — **370 tests, 1508 assertions, 0 failures, 0 errors** ✅
- `implementation` `npm run test:cljs` — 8315 tests, 38232 assertions, **4 failures, 0 errors**. All 4 are pre-existing and out-of-surface: `adapters/reagent/.../realworld_resources_cljs_test.cljs`. ssr-ring is JVM-only (zero `.cljc`/`.cljs`), so this `.clj`-only diff produces a byte-identical CLJS `node-test.js` — the failures are independent of this PR.
- Full spine deferred to CI.

No `spec/011-SSR.md` change: both fixes are adapter-level (the `:content-type` opt and Content-Length transport framing are not part of the spec's documented runtime header contract, which stays accurate).

## Stance

Pre-alpha, no back-compat shims — ELEGANCE + CLARITY + CORRECTNESS + GOOD PRACTICE, avoiding over-engineering.