### PR TITLE
docs(examples): correct reply-envelope comment in helix/uix login (rf2-vhb1wa)

### DIFF
--- a/examples/substrates/helix/login/core.cljs
+++ b/examples/substrates/helix/login/core.cljs
@@ -88,7 +88,7 @@
 ;;
 ;; Second, that trailing `[:? :any]` is the slot for the HTTP reply. When the
 ;; managed-HTTP call comes back, the framework appends the payload —
-;; `{:kind ... :value ...}` on success, `{:kind ... :failure ...}` on failure —
+;; `{:status :ok :value …}` on success, `{:status :error :error …}` on failure —
 ;; as the last arg of the `:on-success` / `:on-failure` event vector, so a
 ;; delivered reply reads `[:auth.login/flow [:auth.login/success] <payload>]` —
 ;; three top-level elements, not two. Leave the optional slot out and the

--- a/examples/substrates/uix/login/core.cljs
+++ b/examples/substrates/uix/login/core.cljs
@@ -66,8 +66,8 @@
 ;; on the event too").
 ;;
 ;; The trailing `[:? :any]` is there to catch the managed-HTTP reply. The
-;; framework tacks the reply map (`{:kind ... :value ...}` or
-;; `{:kind ... :failure ...}`) onto the end of the `:on-success` / `:on-failure`
+;; framework tacks the reply map (`{:status :ok :value …}` or
+;; `{:status :error :error …}`) onto the end of the `:on-success` / `:on-failure`
 ;; vector, so what actually arrives is
 ;; `[:auth.login/flow [:auth.login/success] <payload>]` — three top-level
 ;; elements, not two. Leave off that optional slot and the `:cat` rejects every


### PR DESCRIPTION
## What

The `[:? :any]` schema-slot comment in both substrate login examples described the managed-HTTP reply envelope wrongly:

- `examples/substrates/helix/login/core.cljs` (was L91)
- `examples/substrates/uix/login/core.cljs` (was L69-70)

Both said `{:kind ... :value ...}` on success / `{:kind ... :failure ...}` on failure. The canonical envelope (per `implementation/http/src/re_frame/http/test_support.cljc`) is `{:status :ok :value …}` on success and `{:status :error :error …}` on failure — the top-level key is `:status`, not `:kind`, and the failure map rides under `:error`, not a non-existent `:failure` key.

## Why it mattered

The wrong wording contradicted each file's own `:record-error` action, which destructures `[_ {:keys [error]}]` and reads `(:message error)` — a reader trusting the comment would write `(:failure reply)` and get `nil`. It also broke each file's docstring claim that the substrate-agnostic half is "byte-for-byte the same as `examples/core/login`", whose reference comment already describes the envelope correctly. Corrected wording copied verbatim from `examples/core/login/core.cljs`.

Comment-only; no behaviour change.

## Quality gates
- `npx shadow-cljs compile :examples/login-helix :examples/login-uix` → both builds completed, **0 warnings**.
- Examples are test-free (locked 2026-05-19, rf2-8cevm); no test added.

## Stance
Pre-alpha, no back-compat shims; ELEGANCE + CLARITY + CORRECTNESS + GOOD PRACTICE. A CLARITY/CORRECTNESS fix to a teaching comment in a test-free example.
