### PR TITLE
fix(core,flows): keep falsy keys in segment-delta; re-entrant dispose; reject reserved flow output-path (rf2-tq8l9m +2)

### DIFF
--- a/implementation/core/src/re_frame/interceptor.cljc
+++ b/implementation/core/src/re_frame/interceptor.cljc
@@ -197,7 +197,11 @@
                           (if (contains? ks-a k) acc (assoc acc k (get b k))))
                         {} ks-b)
         ;; Keys present in BOTH maps — values are compared via `=`.
-        common  (filter ks-b ks-a)
+        ;; Membership via `contains?`, NOT the set as a predicate: a set
+        ;; returns the element, so a key literally `false`/`nil` would test
+        ;; falsy and be dropped from `common`, silently omitting a changed
+        ;; value under a falsy key from the `:changed` diff.
+        common  (filter #(contains? ks-b %) ks-a)
         changed (reduce (fn [acc k]
                           (let [vb (get b k) va (get a k)]
                             (if (= vb va)

--- a/implementation/core/src/re_frame/substrate/plain_atom.cljc
+++ b/implementation/core/src/re_frame/substrate/plain_atom.cljc
@@ -75,7 +75,8 @@
      (interop/make-reaction
        (fn [] (apply compute-fn (map deref source-containers))))
      :cljs
-     (let [on-dispose-fns (atom [])]
+     (let [on-dispose-fns (atom [])
+           disposed?      (volatile! false)]
        (reify
          IDeref
          (-deref [_] (apply compute-fn (map deref source-containers)))
@@ -83,8 +84,16 @@
          (-add-on-dispose [_ f]
            (swap! on-dispose-fns conj f))
          (-dispose [_]
-           (doseq [f @on-dispose-fns] (f))
-           (reset! on-dispose-fns []))))))
+           ;; Idempotent + re-entrant safe (rf2-1bzlai), mirroring the spine
+           ;; (spine.cljs). Flip the guard FIRST so a re-entrant `-dispose`
+           ;; from inside an on-dispose callback (or a plain second call)
+           ;; short-circuits before any teardown re-runs; snapshot-and-clear
+           ;; the callbacks before firing so each runs exactly once.
+           (when-not @disposed?
+             (vreset! disposed? true)
+             (let [fns @on-dispose-fns]
+               (reset! on-dispose-fns [])
+               (doseq [f fns] (f)))))))))
 
 (defn- render [_ _ _]
   ;; SSR uses render-to-string exclusively. Calling render on the JVM is

--- a/implementation/core/test/re_frame/interceptor_test.clj
+++ b/implementation/core/test/re_frame/interceptor_test.clj
@@ -918,3 +918,28 @@
       (is (= 1 (count ix)) "exactly one interceptor-exception")
       (is (nil? (get-in (first ix) [:tags :source-coord]))
           "no :source-coord tag — the fn path captured none"))))
+
+;; ---- ctx-delta falsy-key correctness (rf2-tq8l9m) -------------------------
+
+(deftest compute-ctx-delta-keeps-changed-values-under-falsy-keys
+  ;; rf2-tq8l9m — `segment-delta` computed the both-maps `common` key set via
+  ;; `(filter ks-b ks-a)`, using the key SET as the filter predicate. A set
+  ;; returns the ELEMENT (not a boolean), so a key literally `false` / `nil`
+  ;; tested falsy and was DROPPED from `common` — silently omitting a
+  ;; changed-in-place value under that key from the `:changed` diff. Fixed by
+  ;; an explicit `(contains? ks-b %)` membership test that keeps falsy keys.
+  ;; `compute-ctx-delta` is private (a dev-only trace projection); reach it via
+  ;; its var. Pure fn — no runtime needed.
+  (let [compute (deref #'interceptor/compute-ctx-delta)]
+    (testing "a changed value under a false / nil coeffect key lands in :changed"
+      (let [delta (compute {:coeffects {false :old, nil :n-old, :ok 1}}
+                           {:coeffects {false :new, nil :n-new, :ok 1}})]
+        (is (= {false {:before :old :after :new}
+                nil   {:before :n-old :after :n-new}}
+               (get-in delta [:coeffects :changed]))
+            "both the false-keyed and nil-keyed changes are entered into :changed")
+        (is (nil? (:added (:coeffects delta))) "no spurious :added")
+        (is (nil? (:removed (:coeffects delta))) "no spurious :removed")))
+    (testing "an unchanged value under a falsy key is NOT reported as changed"
+      (is (nil? (compute {:effects {false :same}} {:effects {false :same}}))
+          "identical falsy-keyed segments produce no delta"))))

--- a/implementation/core/test/re_frame/plain_atom_dispose_cljs_test.cljs
+++ b/implementation/core/test/re_frame/plain_atom_dispose_cljs_test.cljs
@@ -18,6 +18,7 @@
   :node-test build picks it up."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.disposable :as rf-disposable]
             [re-frame.frame :as frame]
             [re-frame.subs :as subs]
             [re-frame.substrate.plain-atom :as plain-atom]
@@ -121,3 +122,33 @@
     (is (not (contains? (cache-keys) [:a*4])))
     (is (not (contains? (cache-keys) [:a*2])))
     (is (not (contains? (cache-keys) [:a])))))
+
+(deftest dispose-is-re-entrant-safe-on-cljs-plain-atom
+  (testing "rf2-kmuc46 — the plain-atom CLJS derived value's -dispose is
+            re-entrant safe + idempotent (rf2-1bzlai): a -dispose re-entered
+            from inside an on-dispose callback (and a plain second call) fires
+            every registered callback EXACTLY once"
+    ;; Reach the derived-value constructor via the public adapter map (the
+    ;; ctor is artefact-private). Pre-fix -dispose had no `disposed?` guard: a
+    ;; callback that re-entered -dispose re-deref'd the still-full callback
+    ;; vector (the `reset!` ran only AFTER the doseq), firing every callback a
+    ;; SECOND time. On a real host that double-fires an input-release callback,
+    ;; decrementing a still-referenced input's ref-count one extra time →
+    ;; premature eviction. The fix flips the guard FIRST and snapshots-and-
+    ;; clears the callbacks before firing (mirroring the spine).
+    (let [make-dv (:make-derived-value plain-atom/adapter)
+          dv      (make-dv [(atom 0)] identity)
+          fires   (atom 0)]
+      (is (= 0 @dv) "sanity: derived value recomputes from its source")
+      ;; First callback RE-ENTERS -dispose on the same object; second counts.
+      ;; Callbacks fire in registration order, so the re-entrant call happens
+      ;; while the counter callback is still pending — the exact double-fire
+      ;; window the guard must close.
+      (rf-disposable/-add-on-dispose dv (fn [] (rf-disposable/-dispose dv)))
+      (rf-disposable/-add-on-dispose dv (fn [] (swap! fires inc)))
+      (rf-disposable/-dispose dv)
+      (is (= 1 @fires)
+          "counting callback fired exactly once despite the re-entrant dispose")
+      ;; A plain sequential second call stays a no-op too (idempotency).
+      (rf-disposable/-dispose dv)
+      (is (= 1 @fires) "a subsequent plain -dispose does not re-fire callbacks"))))

--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -475,6 +475,14 @@
      {:recovery :fix-registration
       :extra    (merge {:flow flow} extras)})))
 
+;; Forward reference: `runtime-partition-key` (the reserved `:rf.db/runtime`
+;; partition const) is defined below with the input-side partition primitives
+;; it co-documents. `validation-rules` only READS it at call time (when
+;; `validate-flow` runs a pred), by which point the ns is fully loaded; the
+;; `declare` also suppresses the CLJS undeclared-var warning. Same forward-ref
+;; idiom this ns already uses for `vacate-output-path!`.
+(declare runtime-partition-key)
+
 ;; The validation rules, in evaluation order. Each rule has a predicate
 ;; over the flow map (returns truthy to accept), a stable `:error-kw`
 ;; discriminator, a `:reason` diagnostic, and optional `:extras` that
@@ -535,6 +543,28 @@
     :error-kw :rf.error/flow-bad-path
     :reason   ":output-path elements must each be a path segment (the shared EP-0012 segment domain: keyword / string / symbol / boolean / integer / UUID / instant / nil)"
     :extras   (fn [flow] {:bad-elements (vec (remove valid-path-element? (:output-path flow)))})}
+
+   ;; A well-formed `:output-path` may NOT be rooted at the reserved runtime-db
+   ;; partition key (`:rf.db/runtime`). That leading key is reserved for the
+   ;; INPUT side — `runtime-input?` opts a flow input into the runtime-db
+   ;; partition — whereas a flow OUTPUT is always an app-db write:
+   ;; `evaluate-flow!` (flows.cljc) `assoc-in`s the derived value into the
+   ;; app-db partition, so a `[:rf.db/runtime …]` output would write the
+   ;; reserved partition key INSIDE app-db. This enforces at the registration
+   ;; boundary the invariant asserted in prose at flows.cljc §output-path (an
+   ;; app-db output can never prefix-collide with a runtime-db input), closing
+   ;; the namespace-squat / spurious-topo-edge / false-cycle footguns. Distinct
+   ;; from the `:rf.error/flow-bad-path` shape family — the path is well-formed,
+   ;; it just names a reserved partition — so it carries its own discriminator.
+   ;; Fires AFTER the shape rules above confirm a non-empty vector of valid
+   ;; segments, so `(first (:output-path flow))` is a real leading segment.
+   {:pred     (fn [flow] (not= runtime-partition-key (first (:output-path flow))))
+    :error-kw :rf.error/flow-reserved-output-path
+    :reason   (str ":output-path may not be rooted at the reserved runtime-db partition key "
+                   ":rf.db/runtime — a leading :rf.db/runtime is reserved for a runtime-db INPUT; "
+                   "a flow output is always an app-db write, so a :rf.db/runtime-rooted output "
+                   "would write the reserved partition key inside app-db")
+    :extras   (fn [flow] {:bad-elements [(first (:output-path flow))]})}
 
    ;; The OPTIONAL output data-classification keys (`:sensitive` / `:large`
    ;; per-path vectors; `:large?` whole-output boolean) are validated FAIL-FAST.

--- a/implementation/flows/test/re_frame/flows_test.clj
+++ b/implementation/flows/test/re_frame/flows_test.clj
@@ -25,6 +25,7 @@
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
+            [re-frame.flows.registry :as registry]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.trace]))
 
@@ -485,6 +486,46 @@
           "error id is :rf.error/flow-bad-path")
       (is (= [[:nested]] (:bad-elements (ex-data ex)))
           "ex-data names the offending element(s)"))))
+
+(defn- flow-reserved-output-path? [^Throwable t]
+  (= :rf.error/flow-reserved-output-path (:rf.error/id (ex-data t))))
+
+(deftest reg-flow-rejects-runtime-partition-rooted-output-path
+  ;; rf2-923gl4 — a flow `:output-path` may NOT be rooted at the reserved
+  ;; runtime-db partition key (`:rf.db/runtime`). The leading key is reserved
+  ;; for the INPUT side (`runtime-input?`); a flow output is always an app-db
+  ;; write, and `evaluate-flow!` `assoc-in`s the derived value into the app-db
+  ;; partition — so a `[:rf.db/runtime …]` output would write the reserved key
+  ;; INSIDE app-db, enabling namespace-squat / spurious-topo-edge / false-cycle
+  ;; footguns and leaving the flows.cljc prose invariant unenforced. Pre-fix
+  ;; the registration was accepted; the rule rejects it at the API boundary.
+  (testing "a multi-segment :rf.db/runtime-rooted :output-path is rejected"
+    (let [ex (try
+               (rf/reg-flow :bad {:inputs [[:n]] :output-path [registry/runtime-partition-key :cur]} identity)
+               (catch Throwable t t))]
+      (is (some? ex) "registration threw")
+      (is (flow-reserved-output-path? ex)
+          "error id is :rf.error/flow-reserved-output-path (distinct from the flow-bad-path shape family)")
+      (is (= 'rf/reg-flow (:where (ex-data ex))) ":where names the user-facing surface")
+      (is (= :fix-registration (:recovery (ex-data ex))) ":recovery names the disposition")
+      (is (= [registry/runtime-partition-key] (:bad-elements (ex-data ex)))
+          "ex-data names the offending leading segment")
+      (is (re-find #":rf\.db/runtime" (:reason (ex-data ex)))
+          ":reason names the reserved partition key")))
+  (testing "a single-segment [:rf.db/runtime] :output-path is likewise rejected"
+    (let [ex (try
+               (rf/reg-flow :bad2 {:inputs [[:n]] :output-path [registry/runtime-partition-key]} identity)
+               (catch Throwable t t))]
+      (is (flow-reserved-output-path? ex)
+          "a bare [:rf.db/runtime] output-path is rejected too")))
+  (testing ":rf.db/runtime is legal DEEPER in an output-path (only the leading
+            position is reserved — it names an ordinary app-db key there)"
+    ;; The reservation is positional: only a LEADING :rf.db/runtime confuses
+    ;; the topo/dirty-check partition logic. A :rf.db/runtime key nested under
+    ;; a real app-db root is just an ordinary keyword key and must still pass.
+    (is (some? (rf/reg-flow :deep {:inputs [[:n]] :output-path [:app registry/runtime-partition-key]} identity))
+        "a non-leading :rf.db/runtime segment registers cleanly")
+    (flows/clear-flow :deep)))
 
 (deftest reg-flow-accepts-shared-domain-path-elements
   (testing "path elements across the SHARED EP-0012 segment domain all pass


### PR DESCRIPTION
Three P4 correctness fixes from the 2026-07-09 correctness-review, confined to `implementation/core` + `implementation/flows`. Each bead is a separate commit; each adds ≥1 adversarial test.

## Fixes

- **rf2-tq8l9m — `segment-delta` drops falsy keys (core).** `interceptor.cljc` computed the both-maps `common` key set via `(filter ks-b ks-a)`, using the key SET as a filter predicate. A set returns the element, so a key literally `false`/`nil` tested falsy and was dropped from `common`, silently omitting a changed-in-place value under that key from the `:changed` diff (dev-only `:rf/icpt-after-deltas` projection). Fix: explicit `(contains? ks-b %)` membership test.
- **rf2-kmuc46 — plain-atom CLJS `-dispose` not re-entrant safe (core).** The CLJS `make-derived-value` `-dispose` had no `disposed?` guard, so a dispose re-entered from an on-dispose callback re-deref'd the still-full callback vector and fired every callback twice — violating the `IDisposable` contract (rf2-1bzlai). Fix: mirror the spine — flip the guard first, snapshot-and-clear callbacks before firing.
- **rf2-923gl4 — `reg-flow` accepts `:rf.db/runtime`-rooted `:output-path` (flows).** A flow could register `:output-path [:rf.db/runtime …]`, writing the reserved partition key inside app-db (the leading key is reserved for the runtime-db INPUT side). Fix: a `validate-flow` rule with a new `:rf.error/flow-reserved-output-path` discriminator rejecting a leading `runtime-partition-key` output-path. Positional — a non-leading `:rf.db/runtime` segment still passes.

## Quality gates (foreground)

- `implementation/flows` — `clojure -M:test`: 191 tests, 4775 assertions, **0 failures, 0 errors**.
- `implementation/core` — `clojure -M:test`: 1761 tests, 7667 assertions, **0 failures, 0 errors** (includes the new segment-delta JVM test).
- `implementation` — `npm run test:cljs`: 8316 tests, 38235 assertions, **4 failures, 0 errors** — all 4 are the known pre-existing `realworld_resources_cljs_test` failures tracked by rf2-5qi5mp; no other failures. Includes the new CLJS re-entrant-dispose test.
- Full spine deferred to CI.

## Stance

Pre-alpha, no back-compat shims; ELEGANCE + CLARITY + CORRECTNESS + GOOD PRACTICE. Minimal in-family changes; no over-engineering.

## Follow-up note

The Spec 009 error catalog (`spec/009-Instrumentation.md`, hot-zone) does not yet list `:rf.error/flow-reserved-output-path`; that doc row is out of this worker's assigned surface and should be added separately.
