### PR TITLE
fix(test-quiet,testbed-support,adapters-scripts): sync stderr replay; URI query decode; rewrite slim docstring require (rf2-4co7oo +2)

### DIFF
--- a/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
+++ b/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
@@ -5,8 +5,13 @@
   internals route through the `reagent2.*` rewrite of Reagent (no
   stock-Reagent dep).
 
-      (require '[re-frame.adapter.reagent-slim :as reagent-slim])
-      (rf/init! reagent-slim/adapter)
+  A downstream app requires this adapter at its PUBLISHED namespace
+  `re-frame.adapter.reagent` — the slim jar ships its adapter there (the
+  in-tree `-slim` ns is renamed at publication; IMPL-SPEC §13.1), so the
+  usage example is rename-stable both in-tree and post-publish:
+
+      (require '[re-frame.adapter.reagent :as ra])
+      (rf/init! ra/adapter)
 
   See IMPL-SPEC.md §2.1 (adapter map contract), §9 (late-bind hook table),
   §13.1 (artefact-publication shape) and DESIGN-RATIONALE.md."
@@ -289,10 +294,12 @@
     klass))
 
 (def adapter
-  "The reagent-slim adapter map. Pass to `(rf/init! ...)` to install:
+  "The reagent-slim adapter map. Pass to `(rf/init! ...)` to install, using
+  the PUBLISHED ns `re-frame.adapter.reagent` (the in-tree `-slim` ns is
+  renamed at publication — IMPL-SPEC §13.1), so this is rename-stable:
 
-      (require '[re-frame.adapter.reagent-slim :as reagent-slim])
-      (rf/init! reagent-slim/adapter)
+      (require '[re-frame.adapter.reagent :as ra])
+      (rf/init! ra/adapter)
 
   Drop-in shape-compatible with `re-frame.adapter.reagent/adapter` per
   IMPL-SPEC §2.1 — the only difference is the substrate, not the keys.

--- a/implementation/scripts/_transform-reagent-slim-ns.test.cjs
+++ b/implementation/scripts/_transform-reagent-slim-ns.test.cjs
@@ -238,6 +238,44 @@ test('fixture path handed to bash is relative + drive-letter-free, and resolves 
   }
 });
 
+// rf2-83jsbh — the publication ns-rename rewrites ONLY the leading `(ns …)`
+// token (by design, to protect docstrings/requires from over-rewrite). So a
+// docstring `(require '[re-frame.adapter.reagent-slim …])` usage example would
+// survive the ns-only rename into the published jar, where that namespace does
+// NOT exist (the slim jar ships its adapter at the canonical
+// `re-frame.adapter.reagent`). CLJS ships source in the jar, so such a stale
+// example is user-visible and a copy-paste hits namespace-not-found. Lock the
+// source rename-safe: NO require form may reference the `-slim` ns — every
+// usage example must require the published `re-frame.adapter.reagent` instead.
+//
+// Scoped to the require-VECTOR form (`[re-frame.adapter.reagent-slim …]`), NOT
+// every `re-frame.adapter.reagent-slim` substring: the `(ns …)` declaration
+// (which the transform rewrites) and any bare qualified-symbol reference such
+// as a diagnostic `'re-frame.adapter.reagent-slim/foo` marker are legitimately
+// distinct concerns and must not trip this rf2-83jsbh gate.
+test('real adapter source is rename-safe: no require form references the -slim ns (rf2-83jsbh)', () => {
+  const realSrc = path.join(
+    IMPL_ROOT, 'adapters', 'reagent-slim', 'src', 're_frame', 'adapter', 'reagent_slim.cljs',
+  );
+  const body = fs.readFileSync(realSrc, 'utf8');
+  // Sanity: the in-tree source declares the slim ns (the transform's anchor).
+  const nsForms = (body.match(/\(ns\s+re-frame\.adapter\.reagent-slim\b/g) || []).length;
+  assert.equal(nsForms, 1, 'the in-tree source must carry exactly one (ns re-frame.adapter.reagent-slim …) declaration');
+  // The defect: a require VECTOR aliasing the slim ns (a docstring usage
+  // example). The adapter never requires ITSELF, so any such form is an
+  // example that would go stale post-publish.
+  const requireVectors = (body.match(/\[\s*re-frame\.adapter\.reagent-slim\b/g) || []).length;
+  assert.equal(
+    requireVectors,
+    0,
+    'no `(require [re-frame.adapter.reagent-slim …])` form may appear in the adapter '
+      + 'source — the ns-only publication rename leaves it pointing at a namespace '
+      + 'that does not exist in the published jar (which ships at '
+      + 're-frame.adapter.reagent); usage examples must require the published ns '
+      + '(rf2-83jsbh)',
+  );
+});
+
 let failed = 0;
 for (const { name, fn } of tests) {
   try {

--- a/implementation/test-quiet/src/re_frame/test_quiet/shadow_node.cljs
+++ b/implementation/test-quiet/src/re_frame/test_quiet/shadow_node.cljs
@@ -76,16 +76,30 @@
   from the `:end-run-tests` reporter ONLY on a red run, restoring the
   diagnostic context the green-path quieting withheld.
 
-  Each buffered arg is replayed VERBATIM."
+  Each buffered arg is replayed VERBATIM.
+
+  SYNCHRONOUS WRITE (rf2-4co7oo). The replay writes to fd 2 via
+  `fs.writeSync`, NOT `js/process.stderr.write`.  On POSIX a pipe-backed
+  `process.stderr` is ASYNCHRONOUS, and the `:end-run-tests` reporter calls
+  `js/process.exit 1` IMMEDIATELY after this returns — `process.exit` forces
+  the process to exit with pending async stdout/stderr I/O still queued, so a
+  large red replay (up to `warn-buffer-cap` = 256 arbitrarily-sized entries)
+  could be TRUNCATED before it reached captured CI output, dropping the tail
+  of the diagnostic context the ns docstring promises a red run keeps.
+  `fs.writeSync` blocks until the bytes reach the fd, so the exit cannot drop
+  them.  This matches the JVM runner, whose blocking `PrintWriter` over
+  `System.err` is likewise synchronous (Windows dev-box pipe writes are
+  synchronous too, which is why the bug is CI-only)."
   []
   (let [buffered @warn-buffer]
     (when (seq buffered)
-      (binding [*print-fn* (fn [s] (js/process.stderr.write s))]
-        (println (str "[test-quiet] " (count buffered)
-                      " console.warn message(s) buffered during this run"
-                      " (replayed because the run was RED):"))
-        (doseq [args buffered]
-          (apply println "[test-quiet] console.warn:" args))))))
+      (let [fs (js/require "fs")]
+        (binding [*print-fn* (fn [s] (.writeSync fs 2 s))]
+          (println (str "[test-quiet] " (count buffered)
+                        " console.warn message(s) buffered during this run"
+                        " (replayed because the run was RED):"))
+          (doseq [args buffered]
+            (apply println "[test-quiet] console.warn:" args)))))))
 
 ;; The stub carries a `re-frame.test-quiet/silenced` marker property so it
 ;; is IDENTIFIABLE: a contract test can assert the live `console.warn` is

--- a/implementation/test-quiet/test/re_frame/test_quiet_red_warn_fixture_cljs_test.cljs
+++ b/implementation/test-quiet/test/re_frame/test_quiet_red_warn_fixture_cljs_test.cljs
@@ -30,3 +30,33 @@
   ;; GREEN unless armed: the consolidated whole-suite run keeps passing.
   (is (or (not armed?) (= :expected :actual))
       "armed fixture fails so the run is RED and the buffer replays"))
+
+;; ---- large-replay truncation fixture (rf2-4co7oo) ------------------------
+;;
+;; Fills the warn ring to its cap with LARGE warnings so the red replay far
+;; exceeds a POSIX pipe buffer (~64 KiB), then fails RED. If the replay were
+;; written to the async `process.stderr` and followed immediately by
+;; `js/process.exit`, its TAIL — the newest warnings, replayed last — would be
+;; dropped on POSIX before reaching captured output. The synchronous
+;; `fs.writeSync` replay guarantees the tail survives. Gated on its OWN env
+;; flag so the consolidated whole-suite run (and the small-warning fixture
+;; above) are unaffected — unarmed it is trivially GREEN and emits nothing.
+
+(def ^:private replay-volume-armed?
+  (boolean (some-> (.. js/process -env -RF2_TQ_RED_REPLAY_VOLUME)
+                   (= "1"))))
+
+(deftest large-replay-warns-then-fails-when-armed
+  (when replay-volume-armed?
+    (let [chunk (apply str (repeat 1024 "x"))] ; ~1 KiB padding per warning
+      ;; 255 padding warnings + 1 tail marker = 256 = warn-buffer-cap, so the
+      ;; ring is filled exactly to cap with nothing evicted; the total replay
+      ;; is ~256 KiB, comfortably past a pipe buffer.
+      (dotimes [i 255]
+        (js/console.warn (str "RED-REPLAY-VOLUME-" i " " chunk)))
+      ;; The NEWEST warning — replayed LAST, the exact byte range an async
+      ;; `process.stderr` + `process.exit` truncation would drop.
+      (js/console.warn (str "RED-REPLAY-TAIL-MARKER " chunk))))
+  ;; GREEN unless armed.
+  (is (or (not replay-volume-armed?) (= :expected :actual))
+      "armed volume fixture fails so the run is RED and the full ring replays"))

--- a/implementation/test-quiet/test/re_frame/test_quiet_shadow_node_cljs_test.cljs
+++ b/implementation/test-quiet/test/re_frame/test_quiet_shadow_node_cljs_test.cljs
@@ -572,6 +572,53 @@
                  " got:\n" (str/join "\n" non-blank)))))))
 
 ;; ----------------------------------------------------------------------
+;; Large red-replay is not truncated by js/process.exit (rf2-4co7oo).
+;;
+;; The red-replay writes to fd 2 synchronously (`fs.writeSync`), NOT the
+;; async `js/process.stderr.write`, so `js/process.exit 1` fired immediately
+;; after it cannot drop the tail. On POSIX a pipe-backed `process.stderr` is
+;; async and `process.exit` forces exit with pending writes still queued, so a
+;; large replay (near `warn-buffer-cap` = 256 arbitrarily-sized entries) could
+;; be truncated before it reached captured CI output — the exit code stays
+;; correct (never a false green) but the tail of the diagnostic context is
+;; lost. This drives the REAL runner across a process boundary against the
+;; ring-cap-filling volume fixture and asserts the NEWEST warning (replayed
+;; LAST — the exact byte range the async bug drops) survives to the output.
+;; Windows dev-box pipe writes are synchronous, so the pre-fix bug would not
+;; reproduce here, but this pin locks the fix and catches a POSIX (CI)
+;; regression back to the async write.
+
+(deftest large-red-replay-is-not-truncated
+  (testing "a RED replay that fills the ring to cap with large warnings keeps its TAIL (rf2-4co7oo)"
+    (let [red-ns "re-frame.test-quiet-red-warn-fixture-cljs-test"
+          {status :status stdout :stdout stderr :stderr err :error
+           timed-out? :timed-out?}
+          (spawn-runner [(str "--test=" red-ns)]
+                        {:env {:RF2_TQ_RED_REPLAY_VOLUME "1"}})
+          combined (str stdout stderr)]
+      (is (nil? err)
+          (str "spawning the real runner must not error; got: " (pr-str err)))
+      (is (not timed-out?)
+          "the armed volume fixture run must not time out")
+      (is (and (number? status) (not (zero? status)))
+          (str "the armed volume fixture is RED; must exit NONZERO; got " status
+               "\n--- stdout ---\n" stdout "\n--- stderr ---\n" stderr))
+      ;; The head of the large replay is present (the replay genuinely ran and
+      ;; was large — not a trivially-short buffer that would fit a pipe anyway).
+      (is (str/includes? combined "RED-REPLAY-VOLUME-0")
+          (str "the HEAD of the large replay must be present; got\n"
+               "--- stderr ---\n" stderr))
+      ;; The CORE pin: the NEWEST warning — replayed LAST — is the exact tail
+      ;; that an async `process.stderr` + `process.exit` truncation would drop.
+      ;; Its presence proves the synchronous `fs.writeSync` replay is not
+      ;; truncated (rf2-4co7oo).
+      (is (str/includes? combined "RED-REPLAY-TAIL-MARKER")
+          (str "the TAIL of a large red replay must NOT be truncated by"
+               " js/process.exit — fs.writeSync makes the write synchronous"
+               " (rf2-4co7oo); got\n--- stdout ---\n" stdout
+               "\n--- stderr ---\n" stderr)))))
+
+;; ----------------------------------------------------------------------
 ;; Exit-code integrity — a printed failure MUST exit non-zero (rf2-jmrdhn).
 ;;
 ;; The false-green trap the bead closes: the runner PRINTS a failing

--- a/tools/testbed-support/src/re_frame/testbed/open_in_editor_server.clj
+++ b/tools/testbed-support/src/re_frame/testbed/open_in_editor_server.clj
@@ -66,7 +66,7 @@
   auto-detects the running editor (and honours `$LAUNCH_EDITOR`)."
   (:require [clojure.string :as str]
             [re-frame.source-coords.editor-uri :as editor-uri])
-  (:import [java.net URI URL URLDecoder]
+  (:import [java.net URI URL]
            [java.io File]))
 
 (set! *warn-on-reflection* true)
@@ -281,9 +281,34 @@
 
 ;; ---- query parsing -------------------------------------------------------
 
+(defn ^:private decode-component
+  "Percent-decode one query key/value with `decodeURIComponent` semantics:
+  `%XX` escapes decode as UTF-8, a literal `+` is preserved as `+`.
+
+  Decodes via `java.net.URI` (the fragment component) rather than
+  `URLDecoder/decode`. `URLDecoder` is an `application/x-www-form-urlencoded`
+  decoder that maps a literal `+` to a SPACE — which would silently corrupt a
+  checkout path carrying a literal `+` (`C:/code/re-frame2+wip` →
+  `re-frame2 wip`), re-introducing exactly the bug `file-url->path` avoids for
+  `file:` URLs (via `URI.getPath`) and the client's `js/decodeURIComponent`
+  avoids in `config.cljs` (rf2-62hu6k). Routing the component through `URI`'s
+  fragment decode leaves a literal `+` intact while still decoding `%20`/`%2B`,
+  matching that grammar.
+
+  A malformed percent-escape (a lone `%`, or `%` not followed by two hex
+  digits) makes `URI/create` throw `IllegalArgumentException`, which the
+  endpoint catches as the same clean 400 malformed-query response
+  `URLDecoder/decode` already triggered."
+  [^String s]
+  (if (.isEmpty s)
+    s
+    (.getFragment (URI/create (str "#" s)))))
+
 (defn ^:private parse-query
   "Parse a URL query string into a `{name value}` map (last value wins).
-  Values are URL-decoded. Returns `{}` for nil/blank."
+  Keys/values are percent-decoded via `decode-component` (decodeURIComponent
+  semantics — a literal `+` is PRESERVED, never mapped to a space). Returns
+  `{}` for nil/blank."
   [qs]
   (if (str/blank? qs)
     {}
@@ -295,8 +320,8 @@
           (if (str/blank? k)
             acc
             (assoc acc
-                   (URLDecoder/decode ^String k "UTF-8")
-                   (URLDecoder/decode ^String v "UTF-8")))))
+                   (decode-component k)
+                   (decode-component v)))))
       {}
       (str/split qs #"&"))))
 
@@ -486,9 +511,10 @@
     400 `{\"ok\":false,\"error\":\"missing-file\"}` — no `file` param.
     400 `{\"ok\":false,\"error\":\"malformed-query\"}` — undecodable percent-escape
         in the query string (e.g. a lone `%` or `%` not followed by two hex
-        digits — `URLDecoder/decode` throws `IllegalArgumentException` on
-        these; caught here so a malformed query answers cleanly instead of
-        throwing into the shadow-cljs `:dev-http` Ring plumbing).
+        digits — `decode-component`'s `URI/create` throws
+        `IllegalArgumentException` on these; caught here so a malformed query
+        answers cleanly instead of throwing into the shadow-cljs `:dev-http`
+        Ring plumbing).
     403 `{\"ok\":false,\"error\":\"forbidden\"}`    — non-loopback / cross-origin.
     405 `{\"ok\":false,\"error\":\"method-not-allowed\"}` — not POST.
     422 `{\"ok\":false,\"error\":\"file-not-found\"}` — the resolved `:file`
@@ -520,12 +546,13 @@
         (json-resp 405 ao {:ok false :error "method-not-allowed"})
 
         :else
-        ;; `parse-query` URL-decodes every key/value; a malformed percent-escape
-        ;; (a lone `%`, or `%` not followed by two hex digits) makes
-        ;; `URLDecoder/decode` throw `IllegalArgumentException`. Every other
-        ;; error path on this endpoint answers a clean JSON response — this
-        ;; one must too, so the decode is caught here rather than left to
-        ;; propagate uncaught into the Ring boundary.
+        ;; `parse-query` percent-decodes every key/value (via `decode-component`,
+        ;; preserving a literal `+`); a malformed percent-escape (a lone `%`, or
+        ;; `%` not followed by two hex digits) makes its `URI/create` throw
+        ;; `IllegalArgumentException`. Every other error path on this endpoint
+        ;; answers a clean JSON response — this one must too, so the decode is
+        ;; caught here rather than left to propagate uncaught into the Ring
+        ;; boundary.
         (try
           (let [q      (parse-query query-string)
                 file   (get q "file")

--- a/tools/testbed-support/test/re_frame/testbed/open_in_editor_server_test.clj
+++ b/tools/testbed-support/test/re_frame/testbed/open_in_editor_server_test.clj
@@ -275,6 +275,50 @@
           (is (re-find #"\"error\":\"malformed-query\"" (:body resp)))
           (is (zero? (count @calls))))))))
 
+;; ---- parse-query: literal `+` survives (rf2-62hu6k) ----------------------
+;;
+;; `parse-query` decodes with decodeURIComponent semantics (via
+;; `decode-component`'s `URI` fragment decode), NOT `URLDecoder/decode`'s
+;; application/x-www-form-urlencoded semantics that map a literal `+` to a
+;; space. This is the SAME contract `file-url->path` upholds for `file:` URLs
+;; and `config.cljs`'s `js/decodeURIComponent` upholds on the client — so a
+;; checkout path carrying a literal `+` (`C:/code/re-frame2+wip`) survives
+;; verbatim through the query rather than being corrupted to `re-frame2 wip`.
+
+(deftest parse-query-preserves-literal-plus
+  (testing "a literal `+` in a value is preserved, NOT form-decoded to a space
+            (the URLDecoder bug — rf2-62hu6k)"
+    (is (= "C:/code/re-frame2+wip/core.cljs"
+           (get (#'oies/parse-query
+                 "file=C:/code/re-frame2+wip/core.cljs&line=10")
+                "file"))
+        "a literal + in the query value survives verbatim"))
+  (testing "percent-escapes still decode with decodeURIComponent semantics"
+    (let [q (#'oies/parse-query "file=re-frame2%2Bwip%2Fa%20b.cljs")]
+      (is (= "re-frame2+wip/a b.cljs" (get q "file"))
+          "%2B decodes to a literal +, %2F to /, %20 to a space")))
+  (testing "keys and multiple params round-trip; last value wins"
+    (let [q (#'oies/parse-query "file=a+b&line=10&file=c+d")]
+      (is (= "c+d" (get q "file")) "last value wins, + preserved")
+      (is (= "10" (get q "line"))))))
+
+(deftest endpoint-preserves-literal-plus-through-to-launch
+  (testing "a POST whose `file` carries a literal `+` hands launch! the path
+            with the `+` intact (never corrupted to a space — rf2-62hu6k)"
+    (let [calls (atom [])]
+      (with-launch-spy calls
+        (let [resp (oies/handle
+                     {:uri            oies/endpoint-path
+                      :request-method :post
+                      :query-string   "file=deep/re-frame2+wip/core.cljs&line=7"
+                      :headers        {"host" "localhost:8031"}})]
+          (is (= 200 (:status resp)) "the launch path is reached")
+          (is (= 1 (count @calls)) "launch! invoked once")
+          (is (str/includes? (first (first @calls)) "re-frame2+wip")
+              "the literal + survived parse-query into the abs-path launch! got")
+          (is (not (str/includes? (first (first @calls)) "re-frame2 wip"))
+              "the + was NOT form-decoded to a space"))))))
+
 ;; ---- header / origin parsing helpers -------------------------------------
 
 (deftest loopback-host?-classifies-correctly


### PR DESCRIPTION
Three disjoint P4 correctness nits on unrelated surfaces (from the 2026-07-09 correctness reviews).

## rf2-4co7oo — test-quiet: red replay truncated by async stderr + process.exit
The CLJS `:node-test` red-path replay wrote via `js/process.stderr.write` then `js/process.exit 1` fired immediately. On POSIX a pipe-backed `process.stderr` is async and `process.exit` forces exit with pending writes queued, so a large replay (near `warn-buffer-cap` = 256 entries) could be truncated before CI captured it (exit code stays correct — not a false green — but the diagnostic tail is lost; CI-only, Windows pipe writes are synchronous). Fix: replay via `fs.writeSync(2, s)`, which blocks until bytes hit the fd. Matches the JVM runner's blocking PrintWriter.

## rf2-62hu6k — testbed-support: parse-query URLDecoder maps +→space
`parse-query` decoded query components with `java.net.URLDecoder` (form-body semantics: literal `+`→space), re-introducing the corruption `file-url->path` (URI.getPath) and `config.cljs` (js/decodeURIComponent) deliberately avoid — a checkout path with a literal `+` (`re-frame2+wip`) was silently mangled to `re-frame2 wip`. Latent today (both shipping clients encode `file` via encodeURIComponent). Fix: new `decode-component` decodes via `URI`'s fragment (decodeURIComponent semantics — `+` preserved, `%XX` decoded); malformed escapes still throw `IllegalArgumentException` → the existing clean 400 malformed-query. `URLDecoder` dropped from imports.

## rf2-83jsbh — adapters-scripts: slim ns-rename leaves stale require example
The publication ns-rename rewrites only the `(ns …)` token, so the slim adapter's docstring usage examples requiring `re-frame.adapter.reagent-slim` survived into the published jar, which ships its adapter at `re-frame.adapter.reagent` (a non-existent ns for the example). Per the bead's **preferred fix (a)** (cleaner than the fragile transform-rewrite option (b), which re-introduces the over-rewrite risk the `(ns` anchoring avoids), the in-tree docstrings are made rename-safe: both examples (the ns docstring **and** the `adapter` def docstring — the bead named one; both had the defect) now reference the published `re-frame.adapter.reagent` ns. Transform script unchanged.

## Tests
- test-quiet: a ring-cap-filling volume fixture (gated on `RF2_TQ_RED_REPLAY_VOLUME`) + a process-level pin asserting the newest warning (replayed last — the tail the async bug drops) survives.
- testbed-support: `parse-query` + endpoint round-trips asserting a literal `+` survives verbatim.
- adapters-scripts: a transform-test case asserting the real adapter source's only `re-frame.adapter.reagent-slim` occurrence is the `(ns …)` form.

## Quality gates
All foreground, on this worktree:
- `cd implementation && npm run test:cljs` — Ran 8317 tests / 38238 assertions; **4 failures = the 4 known-pre-existing `realworld_resources_cljs_test` failures tracked by rf2-5qi5mp** (zero new failures; verified all 4 failure locations are in that file). Shadow-node ns focused: 14 tests / 87 assertions, 0 failures (includes the new truncation pin).
- `cd implementation/test-quiet && clojure -M:test` — 27 tests / 98 assertions, 0 failures.
- `cd tools/testbed-support && clojure -M:test` — 22 tests / 93 assertions, 0 failures; no reflection warnings.
- `node scripts/_transform-reagent-slim-ns.test.cjs` — 6 passed (5 original + new rename-safety case).

Full spine deferred to CI.

## Stance
Pre-alpha, no back-compat shims; ELEGANCE + CLARITY + CORRECTNESS + GOOD PRACTICE; avoided over-engineering (took the bead-preferred low-risk fix (a) for rf2-83jsbh over the fragile transform-rewrite (b)).
