### PR TITLE
ci: run :node-test on examples changes (coupled reagent-adapter test) — prevents #5353-class main-red (rf2-8ckcf2)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -542,7 +542,34 @@ else
         # paths; only the orchestrator scripts under examples/scripts/
         # (matched above) fire it. The cljs_browser gate covers
         # CLJS-source regressions touched by examples/.
+        #
+        # rf2-8ckcf2 — false-green fix (ROOT CAUSE of the #5353 main-red).
+        # examples/ carries no tests of its own, BUT example PRODUCTION
+        # source sits on the consolidated :node-test classpath
+        # (implementation/shadow-cljs.edn lists ../examples/core,
+        # ../examples/real-apps, ../examples/capabilities/*, … as
+        # :source-paths), and framework/adapter test namespaces may
+        # `:require` it. The reagent-adapter test
+        # re-frame.realworld-resources-cljs-test
+        # (implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs
+        # — its ns matches the :node-test build's `cljs-test$` ns-regexp)
+        # `:require`s realworld-resources.core + realworld-resources.scope
+        # from examples/real-apps/realworld_resources/. So an examples-only
+        # change can break a :node-test test, yet firing only cljs_browser
+        # left the `cljs` job (gated on cljs_node_test) SKIPPED: PR #5353
+        # (an examples/real-apps editor fix) merged green and turned main
+        # red undetected. Fire cljs_node_test on ANY examples change so the
+        # consolidated node-test suite re-runs the coupled tests. Broad
+        # (whole examples/ tree) rather than examples/real-apps-only — the
+        # classifier is deliberately conservative, other example-coupled
+        # tests may exist or be added, node-test is the fast default gate,
+        # and an examples change that no test `:require`s simply recompiles
+        # nothing new (harmless). (examples/scripts/*.cjs orchestration
+        # helpers are matched by their own earlier cases and stay scoped to
+        # the browser gates — they are not CLJS source any node-test
+        # `:require`s.)
         cljs_browser=true
+        cljs_node_test=true
         ;;
       testbeds/tenant_switcher/*)
         # rf2-h5e3v7 — the tenant-switcher testbed is the ONE top-level


### PR DESCRIPTION
## What / why

Root cause of the #5353 main-red incident (rf2-8ckcf2). The CI changed-surface classifier (`.github/scripts/report-changed-surfaces.sh`, invoked by the `detect_changed_surfaces` job in `.github/workflows/test.yml`) did **not** fire the CLJS `:node-test` job (`cljs_node_test`) for `examples/`-only changes — the generic `examples/*)` case set only `cljs_browser=true`, on the assumption that `examples/**` is test-free.

But example **production source** is on the consolidated `:node-test` classpath (`implementation/shadow-cljs.edn` lists `../examples/real-apps`, `../examples/core`, `../examples/capabilities/*`, … as `:source-paths`), and framework/adapter tests may `:require` it. The reagent-adapter test `re-frame.realworld-resources-cljs-test` (`implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs` — ns matches the `:node-test` build's `cljs-test$` ns-regexp) `:require`s `realworld-resources.core` + `realworld-resources.scope` from `examples/real-apps/realworld_resources/`.

So PR #5353 (an `examples/real-apps` editor fix) skipped `:node-test`, merged green, and broke that coupled test — main went red undetected until a later worker ran the full `test:cljs`.

## Fix

Add `cljs_node_test=true` to the generic `examples/*)` case in the classifier, so **any** examples change re-runs the consolidated node-test suite (which carries the coupled reagent-adapter test). Broad (whole `examples/` tree) rather than `examples/real-apps`-only, per the conservative-classifier philosophy: other example-coupled tests may exist/be added, node-test is the fast default gate, and an examples change that no test `:require`s simply recompiles nothing new (harmless).

Note: the bead referenced the path-map as living in `.github/workflows/test.yml`, but the classifier logic is implemented in `.github/scripts/report-changed-surfaces.sh` (test.yml only invokes it via `run:`). The one-line correct fix is in the script; test.yml needs no change. Editing the script also triggers `mark_all` in the classifier's own self-case, so this PR runs the full matrix as its own proof.

## Quality gates

- `python -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"` — valid YAML.
- `bash -n .github/scripts/report-changed-surfaces.sh` — syntax OK.
- Classifier simulation (`report-changed-surfaces.sh <path>`):
  - `examples/real-apps/realworld_resources/src/realworld_resources/core.cljs` → `cljs_node_test=true` (was `false` — the #5353 path, now covered).
  - `examples/core/src/foo.cljs` → `cljs_node_test=true` (broad coverage).
  - `examples/scripts/spec-helpers.cjs` → stays browser-scoped (`adapter_testbed_smokes=true`), does NOT over-fire node-test (earlier specific case still wins).
  - `spec/README.md` → `cljs_node_test=false` (no regression to the spec-only path).
- Confirmed the coupling: test ns `re-frame.realworld-resources-cljs-test` matches the `:node-test` `cljs-test$` ns-regexp; both `adapters/reagent/test` and `../examples/real-apps` are on the shared `:source-paths` in `implementation/shadow-cljs.edn`.
- CI cannot be run locally; the above parse + simulation review is the gate.