### PR TITLE
fix(examples): wire ^:dev/after-load hot-reload mount for core examples; correct docstrings (rf2-7eh81v)

### DIFF
--- a/examples/core/flows/core.cljs
+++ b/examples/core/flows/core.cljs
@@ -300,6 +300,21 @@
 ;; seed here. The id is `:rf/default`, the very same one `run` uses below.
 (def app-frame :rf/default)
 
+;; `mount!` is browser setup: create the root lazily, then render the view tree
+;; inside the frame-provider. `^:dev/after-load` is shadow's cue to re-run it on
+;; each reload so your edited views re-render into the same root and — since the
+;; ENSURE-shape provider reuses the frame `run` already created — the same frame.
+;; This is the canonical mount/boot shape, spelled the same in the counter and
+;; todomvc examples. See `docs/core/how-to/boot-and-mount-an-app.md`.
+(defn ^:dev/after-load mount! []
+  (when-let [el (and (exists? js/document)
+                     (js/document.getElementById "app"))]
+    (when-not @react-root
+      (reset! react-root (rdc/create-root el)))
+    (rdc/render @react-root
+                [rf/frame-provider {:id app-frame}
+                 [cart-app]])))
+
 (defn run []
   ;; `init!` tells re-frame2 which reactive substrate to render through —
   ;; here, Reagent. It has to come before any frame is constructed: a
@@ -307,16 +322,11 @@
   ;; would raise :rf.error/no-adapter-installed without this first.
   (rf/init! reagent-adapter/adapter)
   ;; Create the frame explicitly, here, rather than leaving it to
-  ;; `frame-provider` below. `reg-flow` (inside `install-flows!`) needs a
+  ;; `frame-provider` in `mount!`. `reg-flow` (inside `install-flows!`) needs a
   ;; LIVE frame to register against, and the render tree — where
   ;; `frame-provider` would otherwise create one — doesn't exist yet at this
   ;; point in `run`.
   (rf/reg-frame app-frame {:doc "Cart-with-flows demo frame."})
   (install-flows!)
   (rf/with-frame app-frame (rf/dispatch-sync [:cart/initialise]))
-  (when (exists? js/document)
-    (when-not @react-root
-      (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    (rdc/render @react-root
-                [rf/frame-provider {:id app-frame}
-                 [cart-app]])))
+  (mount!))

--- a/examples/core/login/core.cljs
+++ b/examples/core/login/core.cljs
@@ -651,13 +651,16 @@
 ;; the kind of bug that only shows up on Tuesdays.
 (defonce react-root (atom nil))
 
-(defn run []
-  ;; Tell re-frame2 to render through Reagent. The adapter is just a spec
-  ;; map; hand it straight to `init!`.
-  (rf/init! reagent-adapter/adapter)
-  (when (exists? js/document)
+;; `mount!` is browser setup: create the root lazily, then render the view tree
+;; inside the frame-provider. `^:dev/after-load` is shadow's cue to re-run it on
+;; each reload so your edited views re-render into the same root and same frame.
+;; This is the canonical mount/boot shape, spelled the same in the counter and
+;; todomvc examples. See `docs/core/how-to/boot-and-mount-an-app.md`.
+(defn ^:dev/after-load mount! []
+  (when-let [el (and (exists? js/document)
+                     (js/document.getElementById "app"))]
     (when-not @react-root
-      (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+      (reset! react-root (rdc/create-root el)))
     ;; Frame setup, all in one breath. Handing `frame-provider` an `{:id …}`
     ;; map is the "make sure this frame exists" shape: on first mount it
     ;; creates `:rf/default`, applies the config below, runs
@@ -684,3 +687,9 @@
                                     :fx-overrides   {:rf.http/managed :auth.login.demo/managed-stub}
                                     :initial-events [[:auth.login/initialise-form]]}
                  [root-view]])))
+
+(defn run []
+  ;; Tell re-frame2 to render through Reagent. The adapter is just a spec
+  ;; map; hand it straight to `init!`.
+  (rf/init! reagent-adapter/adapter)
+  (mount!))

--- a/examples/core/managed_http_counter/core.cljs
+++ b/examples/core/managed_http_counter/core.cljs
@@ -354,15 +354,24 @@
 ;; you. Same mount you'll find in examples/core/counter/core.cljs.
 (def app-frame :rf/default)
 
-(defn run []
-  ;; `init!` installs the Reagent adapter — and only the adapter. You hand it
-  ;; the adapter spec map (every adapter ns exports one as `adapter`). It does
-  ;; not create a frame; that's the frame-provider's job, just below.
-  (rf/init! reagent-adapter/adapter)
-  (when (exists? js/document)
+;; `mount!` is browser setup: create the root lazily, then render the view tree
+;; inside the frame-provider. `^:dev/after-load` is shadow's cue to re-run it on
+;; each reload so your edited views re-render into the same root and same frame.
+;; This is the canonical mount/boot shape, spelled the same in the counter and
+;; todomvc examples. See `docs/core/how-to/boot-and-mount-an-app.md`.
+(defn ^:dev/after-load mount! []
+  (when-let [el (and (exists? js/document)
+                     (js/document.getElementById "app"))]
     (when-not @react-root
-      (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+      (reset! react-root (rdc/create-root el)))
     (rdc/render @react-root
                 [rf/frame-provider {:id app-frame
                                     :initial-events [[:counter/initialise]]}
                  [counter-app]])))
+
+(defn run []
+  ;; `init!` installs the Reagent adapter — and only the adapter. You hand it
+  ;; the adapter spec map (every adapter ns exports one as `adapter`). It does
+  ;; not create a frame; that's the frame-provider's job, in `mount!`.
+  (rf/init! reagent-adapter/adapter)
+  (mount!))

--- a/examples/core/notebook/core.cljs
+++ b/examples/core/notebook/core.cljs
@@ -363,8 +363,8 @@
 (defonce react-root (atom nil))
 
 ;; re-frame2 won't conjure a frame for you — an app stands up its own. We
-;; do it in exactly one place: the `frame-provider {:id app-frame}` in the
-;; render call below. First mount creates the frame and fires
+;; do it in exactly one place: the `frame-provider {:id app-frame}` in
+;; `mount!` below. First mount creates the frame and fires
 ;; `:initial-events` once to seed app-db before anything paints; a hot
 ;; reload finds the frame already there and skips the seed. From then on
 ;; every `dispatch` and `subscribe` in the tree resolves to it. The name
@@ -373,14 +373,23 @@
 ;; docs/core/frames.md.
 (def app-frame :rf/default)
 
-(defn run []
-  ;; One job each: `init!` tells the runtime to render through Reagent. It
-  ;; does not make a frame — the `frame-provider` below does that.
-  (rf/init! reagent-adapter/adapter)
-  (when (exists? js/document)
+;; `mount!` is browser setup: create the root lazily, then render the view tree
+;; inside the frame-provider. `^:dev/after-load` is shadow's cue to re-run it on
+;; each reload so your edited views re-render into the same root and same frame.
+;; This is the canonical mount/boot shape, spelled the same in the counter and
+;; todomvc examples. See `docs/core/how-to/boot-and-mount-an-app.md`.
+(defn ^:dev/after-load mount! []
+  (when-let [el (and (exists? js/document)
+                     (js/document.getElementById "app"))]
     (when-not @react-root
-      (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+      (reset! react-root (rdc/create-root el)))
     (rdc/render @react-root
                 [rf/frame-provider {:id app-frame
                                     :initial-events [[:notebook/initialise]]}
                  [notebook]])))
+
+(defn run []
+  ;; One job each: `init!` tells the runtime to render through Reagent. It
+  ;; does not make a frame — the `frame-provider` in `mount!` does that.
+  (rf/init! reagent-adapter/adapter)
+  (mount!))

--- a/examples/core/seven_guis/cells/core.cljs
+++ b/examples/core/seven_guis/cells/core.cljs
@@ -468,7 +468,7 @@
 (defonce react-root (atom nil))
 
 ;; The frame's whole life happens in one place: the `frame-provider` down in
-;; `run`. First mount creates the frame, applies its config, and fires
+;; `mount!`. First mount creates the frame, applies its config, and fires
 ;; `:initial-events` once to seed app-db. After that every `dispatch` and
 ;; `subscribe` in the tree finds *this* frame. On hot reload the provider reuses
 ;; the frame it already made and skips the seeding, so your grid keeps the
@@ -480,15 +480,24 @@
 ;; no special powers, despite the official-looking name.
 (def app-frame :rf/default)
 
+;; `mount!` is browser setup: create the root lazily, then render the view tree
+;; inside the frame-provider. `^:dev/after-load` is shadow's cue to re-run it on
+;; each reload so your edited views re-render into the same root and same frame.
+;; This is the canonical mount/boot shape, spelled the same in the counter and
+;; todomvc examples. See `docs/core/how-to/boot-and-mount-an-app.md`.
+(defn ^:dev/after-load mount! []
+  (when-let [el (and (exists? js/document)
+                     (js/document.getElementById "app"))]
+    (when-not @react-root
+      (reset! react-root (rdc/create-root el)))
+    (rdc/render @react-root
+                [rf/frame-provider {:id app-frame
+                                    :initial-events [[:cells/initialise]]}
+                 [cells-grid]])))
+
 (defn run []
   ;; `init!` tells re-frame2 which reactive substrate to render through — here,
   ;; Reagent. Every adapter namespace exports an `adapter` var; you require the
   ;; namespace and hand that var straight in.
   (rf/init! reagent-adapter/adapter)
-  (when (exists? js/document)
-    (when-not @react-root
-      (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    (rdc/render @react-root
-                [rf/frame-provider {:id app-frame
-                                    :initial-events [[:cells/initialise]]}
-                 [cells-grid]])))
+  (mount!))

--- a/examples/core/seven_guis/circle_drawer/core.cljs
+++ b/examples/core/seven_guis/circle_drawer/core.cljs
@@ -281,7 +281,7 @@
 (defonce react-root (atom nil))
 
 ;; The frame's whole life story happens in one place: the
-;; `frame-provider {:id app-frame …}` down in `run`. On the first mount it
+;; `frame-provider {:id app-frame …}` down in `mount!`. On the first mount it
 ;; creates the frame, applies its config, and fires `:initial-events` once to
 ;; seed app-db. From then on, every `dispatch` and `subscribe` in the tree below
 ;; finds its way to that frame. Hot-reload is the nice part — the provider spots
@@ -293,13 +293,22 @@
 ;; other. See docs/core/frames.md.
 (def app-frame :rf/default)
 
-(defn run []
-  ;; `init!` tells re-frame2 to render through Reagent. One adapter, one process.
-  (rf/init! reagent-adapter/adapter)
-  (when (exists? js/document)
+;; `mount!` is browser setup: create the root lazily, then render the view tree
+;; inside the frame-provider. `^:dev/after-load` is shadow's cue to re-run it on
+;; each reload so your edited views re-render into the same root and same frame.
+;; This is the canonical mount/boot shape, spelled the same in the counter and
+;; todomvc examples. See `docs/core/how-to/boot-and-mount-an-app.md`.
+(defn ^:dev/after-load mount! []
+  (when-let [el (and (exists? js/document)
+                     (js/document.getElementById "app"))]
     (when-not @react-root
-      (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+      (reset! react-root (rdc/create-root el)))
     (rdc/render @react-root
                 [rf/frame-provider {:id app-frame
                                     :initial-events [[:drawer/initialise]]}
                  [drawer-view]])))
+
+(defn run []
+  ;; `init!` tells re-frame2 to render through Reagent. One adapter, one process.
+  (rf/init! reagent-adapter/adapter)
+  (mount!))

--- a/examples/core/seven_guis/crud/core.cljs
+++ b/examples/core/seven_guis/crud/core.cljs
@@ -234,7 +234,7 @@
 (defonce react-root (atom nil))
 
 ;; The frame's whole life happens in one place: the `frame-provider {:id app-frame …}`
-;; down in `run`. On the first mount it creates the frame, applies its config,
+;; down in `mount!`. On the first mount it creates the frame, applies its config,
 ;; and fires `:initial-events` once to seed app-db (that's `:crud/initialise`).
 ;; From then on, every `dispatch` and `subscribe` in the tree below it lands in
 ;; that frame. Hot-reload is the nice part: the provider finds the frame already
@@ -246,14 +246,23 @@
 ;; frame for you, so we name one here and hand it to the provider like any other.
 (def app-frame :rf/default)
 
-(defn run []
-  ;; `init!` tells the runtime to render through Reagent — once, for the whole
-  ;; process. It picks the substrate; it does not create a frame.
-  (rf/init! reagent-adapter/adapter)
-  (when (exists? js/document)
+;; `mount!` is browser setup: create the root lazily, then render the view tree
+;; inside the frame-provider. `^:dev/after-load` is shadow's cue to re-run it on
+;; each reload so your edited views re-render into the same root and same frame.
+;; This is the canonical mount/boot shape, spelled the same in the counter and
+;; todomvc examples. See `docs/core/how-to/boot-and-mount-an-app.md`.
+(defn ^:dev/after-load mount! []
+  (when-let [el (and (exists? js/document)
+                     (js/document.getElementById "app"))]
     (when-not @react-root
-      (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+      (reset! react-root (rdc/create-root el)))
     (rdc/render @react-root
                 [rf/frame-provider {:id             app-frame
                                     :initial-events [[:crud/initialise]]}
                  [crud-view]])))
+
+(defn run []
+  ;; `init!` tells the runtime to render through Reagent — once, for the whole
+  ;; process. It picks the substrate; it does not create a frame.
+  (rf/init! reagent-adapter/adapter)
+  (mount!))

--- a/examples/core/seven_guis/flight_booker/core.cljs
+++ b/examples/core/seven_guis/flight_booker/core.cljs
@@ -248,14 +248,23 @@
 ;; counter: examples/core/counter/core.cljs.
 (def app-frame :rf/default)
 
-(defn run []
-  ;; `init!` installs the reactive adapter for the process. The adapter ns
-  ;; exports an `adapter` var; pass it straight in.
-  (rf/init! reagent-adapter/adapter)
-  (when (exists? js/document)
+;; `mount!` is browser setup: create the root lazily, then render the view tree
+;; inside the frame-provider. `^:dev/after-load` is shadow's cue to re-run it on
+;; each reload so your edited views re-render into the same root and same frame.
+;; This is the canonical mount/boot shape, spelled the same in the counter and
+;; todomvc examples. See `docs/core/how-to/boot-and-mount-an-app.md`.
+(defn ^:dev/after-load mount! []
+  (when-let [el (and (exists? js/document)
+                     (js/document.getElementById "app"))]
     (when-not @react-root
-      (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+      (reset! react-root (rdc/create-root el)))
     (rdc/render @react-root
                 [rf/frame-provider {:id app-frame
                                     :initial-events [[:flight/initialise]]}
                  [flight-booker]])))
+
+(defn run []
+  ;; `init!` installs the reactive adapter for the process. The adapter ns
+  ;; exports an `adapter` var; pass it straight in.
+  (rf/init! reagent-adapter/adapter)
+  (mount!))

--- a/examples/core/seven_guis/temperature/core.cljs
+++ b/examples/core/seven_guis/temperature/core.cljs
@@ -193,7 +193,7 @@
 (defonce react-root (atom nil))
 
 ;; The frame's whole life story fits in one place: the `frame-provider {:id
-;; app-frame …}` in `run` below. First mount creates the frame and runs its
+;; app-frame …}` in `mount!` below. First mount creates the frame and runs its
 ;; `:initial-events` once to seed app-db. After that, every `dispatch` and
 ;; `subscribe` in the tree finds its way home to that frame. Mount again under
 ;; the same `:id` — a hot reload, say — and the provider hands back the frame
@@ -207,17 +207,26 @@
 ;; `docs/core/glossary.md#frame-identity-is-carried-not-found`.
 (def app-frame :rf/default)
 
-(defn run []
-  ;; `init!` tells re-frame2 which reactive substrate to render through — here,
-  ;; Reagent. Each adapter ns exports an `adapter` var; you require the ns and
-  ;; pass that var. One call, at startup. Note it installs the adapter, not a
-  ;; frame — the frame comes later, via the provider below.
-  ;; See `docs/core/glossary.md#init`.
-  (rf/init! reagent-adapter/adapter)
-  (when (exists? js/document)
+;; `mount!` is browser setup: create the root lazily, then render the view tree
+;; inside the frame-provider. `^:dev/after-load` is shadow's cue to re-run it on
+;; each reload so your edited views re-render into the same root and same frame.
+;; This is the canonical mount/boot shape, spelled the same in the counter and
+;; todomvc examples. See `docs/core/how-to/boot-and-mount-an-app.md`.
+(defn ^:dev/after-load mount! []
+  (when-let [el (and (exists? js/document)
+                     (js/document.getElementById "app"))]
     (when-not @react-root
-      (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+      (reset! react-root (rdc/create-root el)))
     (rdc/render @react-root
                 [rf/frame-provider {:id app-frame
                                     :initial-events [[:temp/initialise]]}
                  [temperature-converter]])))
+
+(defn run []
+  ;; `init!` tells re-frame2 which reactive substrate to render through — here,
+  ;; Reagent. Each adapter ns exports an `adapter` var; you require the ns and
+  ;; pass that var. One call, at startup. Note it installs the adapter, not a
+  ;; frame — the frame comes later, via the provider in `mount!`.
+  ;; See `docs/core/glossary.md#init`.
+  (rf/init! reagent-adapter/adapter)
+  (mount!))

--- a/examples/core/seven_guis/timer/core.cljs
+++ b/examples/core/seven_guis/timer/core.cljs
@@ -203,8 +203,8 @@
 ;; element, and exactly one of them would win. Lazy keeps that drama away.
 (defonce react-root (atom nil))
 
-;; All the frame's lifecycle happens in one spot — the `frame-provider` below.
-;; On first mount it creates the frame, applies its config, and fires
+;; All the frame's lifecycle happens in one spot — the `frame-provider` in
+;; `mount!` below. On first mount it creates the frame, applies its config, and fires
 ;; `:initial-events` once to seed app-db. After that, every `dispatch` and
 ;; `subscribe` in the tree resolves to this frame. On hot reload it reuses the
 ;; frame it already has and skips re-seeding, so the timer keeps right on ticking
@@ -214,14 +214,23 @@
 ;; block up top binds to.
 (def app-frame :rf/default)
 
-(defn run []
-  ;; `init!` tells the runtime to render through the Reagent adapter. That's all
-  ;; it does — it does *not* create a frame. The `frame-provider` below does that.
-  (rf/init! reagent-adapter/adapter)
-  (when (exists? js/document)
+;; `mount!` is browser setup: create the root lazily, then render the view tree
+;; inside the frame-provider. `^:dev/after-load` is shadow's cue to re-run it on
+;; each reload so your edited views re-render into the same root and same frame.
+;; This is the canonical mount/boot shape, spelled the same in the counter and
+;; todomvc examples. See `docs/core/how-to/boot-and-mount-an-app.md`.
+(defn ^:dev/after-load mount! []
+  (when-let [el (and (exists? js/document)
+                     (js/document.getElementById "app"))]
     (when-not @react-root
-      (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+      (reset! react-root (rdc/create-root el)))
     (rdc/render @react-root
                 [rf/frame-provider {:id app-frame
                                     :initial-events [[:timer/initialise]]}
                  [timer-view]])))
+
+(defn run []
+  ;; `init!` tells the runtime to render through the Reagent adapter. That's all
+  ;; it does — it does *not* create a frame. The `frame-provider` in `mount!` does that.
+  (rf/init! reagent-adapter/adapter)
+  (mount!))


### PR DESCRIPTION
Fixes rf2-7eh81v.

## Problem
Ten of twelve `examples/core` apps mounted via a bare `:init-fn <ns>/run` with **no** `^:dev/after-load` hook. shadow runs `:init-fn` once and re-runs only `^:dev/after-load` fns on reload, so the `rdc/render` call inside the plain `run` never re-fired on a code save — edited views did not hot-reload and the reuse-live-frame-on-remount path was never exercised. Meanwhile the mount-block comments (temperature, cells, circle_drawer, flows, managed_http_counter, timer, crud, flight_booker, …) described exactly that reuse-frame / skip-seed-on-hot-reload behaviour, so the docs over-claimed relative to the code. `counter` and `todomvc` already used the `^:dev/after-load mount!` shape and `counter` calls it "the canonical mount/boot shape".

## Fix (recommended option (a))
Split a canonical `^:dev/after-load mount!` out of `run` in each of the ten apps, matching counter/todomvc:
- `mount!` (tagged `^:dev/after-load`) creates the React root lazily and renders the frame-provider.
- `run` does the one-time `init!` — plus, for `flows`, the explicit `reg-frame` / `install-flows!` / `dispatch-sync` seed that must precede the render — then calls `(mount!)`.

On save shadow now re-runs `mount!`; the ENSURE-shape `frame-provider {:id …}` reuses the live frame and skips re-seeding, so the existing hot-reload prose is now accurate rather than aspirational. Mount-block comments updated to reference `mount!` / `^:dev/after-load` (previously "in `run`" / "below").

Apps changed: `flows`, `login`, `managed_http_counter`, `notebook`, `seven_guis/{cells, circle_drawer, crud, flight_booker, temperature, timer}`.

## Quality gates
- `npx shadow-cljs compile` on all 10 affected builds — **0 warnings each**: `:examples/temperature`, `:examples/flight-booker`, `:examples/timer`, `:examples/flows`, `:examples/managed-http-counter`, `:examples/crud`, `:examples/circle-drawer`, `:examples/cells`, `:examples/login`, `:examples/notebook`.
- Examples are test-free (rf2-8cevm); verification is compile + reasoning that `mount!` now re-runs on save via `^:dev/after-load`, exercising the frame-reuse path.
- Diff confined to `examples/core` (10 files).
