### PR TITLE
ci: gate the JVM test-quiet contract suite (was dark-landing) (rf2-jg1ag2)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1250,6 +1250,73 @@ jobs:
       - name: Run JVM tests (event-conformance tier)
         run: clojure -M:test
 
+  jvm-test-quiet:
+    name: JVM test-quiet (clojure -M:test)
+    # rf2-jg1ag2 — closes a dark-landing hole. implementation/test-quiet
+    # is the test-runtime quiet-reporter artefact (day8/re-frame2-test-quiet,
+    # rf2-try1x): its JVM runner (re-frame.test-quiet.runner) is the
+    # `:main-opts` of EVERY per-artefact `:test` alias. Its OWN `:test`
+    # tree is the ADVERSARIAL CONTRACT suite for that runner —
+    # test_quiet_runner_contract_test.clj (~24 subprocess deftests that
+    # relaunch a fresh JVM against throwaway fixtures) plus the
+    # stdout-line-count pins (test_quiet_pin_test.clj /
+    # ..._pin_passing_test.clj). It pins the JVM RED/ERROR/exit-code paths,
+    # the discovery-banner overdrop guards (rf2-pjlx6.1/.2, rf2-14nojy.2,
+    # rf2-m8dbb9, rf2-6nrk8x, rf2-khecvs), nested-run banner+tally
+    # (rf2-8n97n.1/.2/.3), the test-ns-hook fallback (rf2-g92dsm), the
+    # central stderr buffer + red-replay (rf2-nrk066), exit-code integrity
+    # for counter-escaping failures (rf2-jmrdhn), and subprocess
+    # deadlock/timeout (rf2-spzkgo, rf2-8dfq5j.3).
+    #
+    # Before this job the suite ran in NO automated gate: no workflow job
+    # had `working-directory: implementation/test-quiet`;
+    # scripts/test-jvm-implementation.sh omitted it; and the classifier's
+    # implementation_jvm=true (already armed for test-quiet/** by
+    # report-changed-surfaces.sh, rf2-am7grp) only ran OTHER artefacts'
+    # suites THROUGH the quiet runner (green happy-path) — it never ran the
+    # contract-test namespace. So the ONLY pins for the JVM red/error/
+    # banner/stderr behaviour were dark and a regression shipped green.
+    # Gated on implementation_jvm, mirroring every sibling per-feature
+    # jvm-* job. The suite relaunches ~24 fresh JVMs, so a modest
+    # timeout guards against a wedged child (the harness has its own
+    # per-child drain timeouts, rf2-8dfq5j.3).
+    needs: detect_changed_surfaces
+    if: needs.detect_changed_surfaces.outputs.implementation_jvm == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: implementation/test-quiet
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Clojure CLI
+        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
+        with:
+          cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache Maven / gitlibs
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          key: ${{ runner.os }}-clj-test-quiet-${{ hashFiles('implementation/test-quiet/deps.edn') }}
+          restore-keys: |
+            ${{ runner.os }}-clj-test-quiet-
+            ${{ runner.os }}-clj-
+
+      - name: Run JVM tests (test-quiet contract suite)
+        run: clojure -M:test
+
   cljs:
     name: CLJS (shadow-cljs :node-test)
     # rf2-f79t8 — job-level gating (NOT a workflow-trigger path filter:
@@ -3227,6 +3294,7 @@ jobs:
       - jvm-reply-conformance
       - jvm-derivation-conformance
       - jvm-event-conformance
+      - jvm-test-quiet
       - cljs
       - js-harness-self-tests
       - cljs-browser

--- a/TESTING.md
+++ b/TESTING.md
@@ -88,7 +88,7 @@ The classifier is the **source of truth for "which jobs run when"** on a PR: the
 
 | Output | Fires when … | Gates |
 |---|---|---|
-| `implementation_jvm` | any JVM artefact under `implementation/` changes | the per-artefact JVM suites + src-less conformance tiers + `jvm-security` |
+| `implementation_jvm` | any JVM artefact under `implementation/` changes | the per-artefact JVM suites + src-less conformance tiers + `jvm-security` + `jvm-test-quiet` (the quiet-runner adversarial contract suite) |
 | `adapter_diagnostic` | an adapter artefact changes | the skip-ok classpath probes |
 | `cljs_node_test` | anything compiled into `:node-test` changes (core, adapters, feature artefacts, conformance fixtures, build config + scripts, story/xray src+test CLJS, machines-viz) | the consolidated `cljs` job |
 | `cljs_browser` | a `:browser-test`-covered surface changes (incl. machines-viz DOM suites) | the Playwright `cljs-browser` job |

--- a/scripts/test-jvm-implementation.sh
+++ b/scripts/test-jvm-implementation.sh
@@ -72,6 +72,21 @@ artefacts=(
   # to the global registrar). The EP-0013 multi-realm substrate was retired
   # under EP-0023/EP-0024 (rf2-afdlyr / rf2-tu2vr7) — no realm-routing here.
   implementation/event-conformance
+  # rf2-jg1ag2 — the test-runtime quiet-reporter artefact
+  # (day8/re-frame2-test-quiet, rf2-try1x) ships its own JVM `:test`
+  # alias whose test tree is the ADVERSARIAL CONTRACT suite for the JVM
+  # runner itself (test_quiet_runner_contract_test.clj — ~24 subprocess
+  # deftests — plus test_quiet_pin_test.clj / ..._pin_passing_test.clj).
+  # It pins the JVM RED/ERROR/exit-code paths, the discovery-banner
+  # overdrop guards, nested-run banner+tally, the test-ns-hook fallback,
+  # and the central stderr buffer + red-replay. Every OTHER artefact's
+  # `:test` alias merely ROUTES THROUGH the quiet runner (green
+  # happy-path), so before this line the contract suite ran in NO
+  # automated gate — a regression in the JVM red/error/banner/stderr
+  # behaviour shipped green. Listed last because it relaunches a fresh
+  # JVM per deftest (slowest artefact), matching the dedicated
+  # `jvm-test-quiet` PR-CI job (test.yml).
+  implementation/test-quiet
 )
 
 for artefact in "${artefacts[@]}"; do


### PR DESCRIPTION
## What

The entire JVM test-quiet contract + pin suite (`implementation/test-quiet/test/**` — `test_quiet_runner_contract_test.clj` + `test_quiet_pin_test.clj` + `test_quiet_pin_passing_test.clj`, 27 tests / 98 assertions) ran in **no automated gate**:

- no `.github/workflows/*` job had `working-directory: implementation/test-quiet`;
- `scripts/test-jvm-implementation.sh`'s hardcoded artefact list omitted it;
- the classifier's `implementation_jvm=true` (already armed for `test-quiet/**` by `report-changed-surfaces.sh`, rf2-am7grp) only ran **other** artefacts' suites **through** the quiet runner — the green happy-path — never the contract-test namespace itself.

So the ONLY pins for the JVM RED/ERROR/exit-code paths, discovery-banner overdrop guards, nested-run banner+tally, test-ns-hook fallback, central stderr buffer + red-replay, and subprocess deadlock/timeout were **dark** — a regression in any JVM red/error/banner/stderr behaviour shipped green.

## The wiring change

- **New `jvm-test-quiet` PR-CI job** in `test.yml`, gated on `implementation_jvm` (mirrors every sibling per-feature `jvm-*` job), running `clojure -M:test` in `implementation/test-quiet`. `timeout-minutes: 15` guards the ~24 fresh-JVM subprocess spawns. Added to the `all-required-passed` aggregator's `needs:`.
- **`scripts/test-jvm-implementation.sh`** — added `implementation/test-quiet` to the artefact list (local rigorous sweep), placed last (slowest).
- **`TESTING.md`** — documented the gate in the changed-surface classifier table.

The classifier already fires `implementation_jvm=true` on a `test-quiet/**` change, and `mark_all` fires on this PR's own `test.yml`/`TESTING.md` edits — so `jvm-test-quiet` **runs on this very PR** (self-verifying).

## Quality gates

- `cd implementation/test-quiet && clojure -M:test` → **green**: `Ran 27 tests containing 98 assertions. 0 failures, 0 errors.` (confirms enabling the gate won't red main).
- `python -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"` → **YAML OK**.
- `bash -n scripts/test-jvm-implementation.sh` → **OK**.
- `report-changed-surfaces.sh` on a `test-quiet/**` path and on this PR's surfaces → both emit `implementation_jvm=true`.

## Stance

Pre-alpha, no shims. Minimal correct wiring — one dedicated job mirroring the established per-artefact pattern, no new classifier surface needed (the existing `implementation_jvm` output already covers it). ELEGANCE + CORRECTNESS + GOOD PRACTICE: closes a false-green safety-net hole using the repo's own conventions.
