### PR TITLE
test(machines-viz): cover EP-0029 desugar/ISO-8601 + context-band redaction wiring (rf2-7j6gtc +1)

### DIFF
--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/context_redaction_wiring_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/context_redaction_wiring_cljs_test.cljc
@@ -1,0 +1,167 @@
+(ns day8.re-frame2-machines-viz.chart.context-redaction-wiring-cljs-test
+  "EP-0015 export-safety: the Context-band redaction WIRING through
+  `chart.projection/xyflow-graph` (rf2-vbo66r).
+
+  `context-redaction-cljs-test` pins the redact/display/classification
+  helpers in isolation, and `chart-dom-cljs-test` renders the value-FREE
+  static context shape (so redaction is a no-op there). But nothing
+  verified that `xyflow-graph` actually WIRES the redaction: that it
+
+    (a) applies redaction BY DEFAULT to a live `:context-band` (a
+        `:context-band-sensitive` slot → `:rf/redacted`);
+    (b) THREADS the `:context-band-sensitive` / `:context-band-large`
+        sets into the projection (not a hardcoded / empty classification);
+    (c) honours the `:context-band-raw?` trusted-local opt-in that skips
+        redaction;
+    (d) emits the resulting content into the root-container's
+        `:data {:context}` display rows.
+
+  This is the EP-0015 export-safety property (EP-0015 §96-110, §985-989):
+  a host feeding a live machine `:data` map into the band must not leak a
+  schema-marked secret / large slot into the SVG / PNG / clipboard export
+  (`export/chart-as-svg` clones the live viewport DOM, so whatever lands in
+  `:data {:context}` is serialised). A wiring regression — raw-by-default,
+  a dropped classification, a bypassed `redact-context` — leaks silently
+  and passes every value-free DOM test. These pins make it LOUD at the
+  cheap JVM projection layer (the browser `export-dom-cljs-test` covers the
+  end-to-end SVG counterpart).
+
+  Pure `.cljc` → the JVM corpus + the `cljs-test$` node-test build pin it."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [clojure.string :as str]
+            [day8.re-frame2-machines-viz.chart.layout :as layout]
+            [day8.re-frame2-machines-viz.chart.projection :as projection]))
+
+;; ---------------------------------------------------------------------------
+;; fixtures / helpers
+
+(def ^:private flat-machine
+  "A minimal flat machine so `project-definition` mints the synthetic
+  root-container frame whose header paints the Context band."
+  {:initial :a :states {:a {:on {:go :b}} :b {}}})
+
+(defn- context-rows
+  "The root-container's projected `:data {:context}` — the vector of
+  `[key-string value-display-string]` rows the band header paints (and the
+  SVG/PNG exporter serialises). nil when no band was fed."
+  [graph]
+  (let [root (first (filter #(= layout/root-container-id (:id %)) (:nodes graph)))]
+    (:context (:data root))))
+
+(defn- all-row-strings
+  "Every string across every `:data {:context}` row — the full surface a
+  secret could leak into."
+  [graph]
+  (mapcat identity (context-rows graph)))
+
+(defn- value-for
+  "The display string the band paints for context key `k` (a keyword) —
+  matched against its fully-qualified string form, the shape the projector
+  emits."
+  [graph k]
+  (let [target (str (symbol k))]
+    (some (fn [[ks v]] (when (= ks target) v)) (context-rows graph))))
+
+;; ---------------------------------------------------------------------------
+;; (a) redaction is applied BY DEFAULT to a live context-band
+
+(deftest xyflow-graph-redacts-sensitive-context-by-default
+  (testing "rf2-vbo66r — a live :context-band with a :context-band-sensitive
+            slot is redacted BY DEFAULT (no :context-band-raw?): the sensitive
+            row projects to the :rf/redacted sentinel and the secret VALUE
+            appears in NO display row, while a non-sensitive slot renders"
+    (let [secret "card-4111-1111-1111-1111"
+          parsed (layout/project-definition flat-machine)
+          graph  (projection/xyflow-graph
+                   parsed {}
+                   {:context-band            (array-map :card secret :count 7)
+                    :context-band-inferred?  false
+                    :context-band-sensitive  #{:card}})]
+      (is (some? (context-rows graph)) "the band produced context rows")
+      (is (not (some #(str/includes? % secret) (all-row-strings graph)))
+          "the secret VALUE must not appear in ANY display row (export-safety)")
+      (is (str/includes? (value-for graph :card) ":rf/redacted")
+          "the sensitive :card slot shows the content-free redacted sentinel")
+      (is (= "7" (value-for graph :count))
+          "the non-sensitive :count slot still renders its value"))))
+
+;; ---------------------------------------------------------------------------
+;; (b) the sensitive / large sets are actually THREADED into the projection
+
+(deftest xyflow-graph-threads-sensitive-set-not-hardcoded
+  (testing "rf2-vbo66r — the SAME secret value is redacted ONLY when its key
+            is in :context-band-sensitive; with an empty set the projector
+            passes it through. Proves the set is genuinely threaded into
+            redact-context (not a hardcoded classification)"
+    (let [secret "sk-live-abc123"
+          band   (array-map :key secret)
+          parsed (layout/project-definition flat-machine)
+          in-set (projection/xyflow-graph
+                   parsed {} {:context-band band :context-band-sensitive #{:key}})
+          no-set (projection/xyflow-graph
+                   parsed {} {:context-band band :context-band-sensitive #{}})]
+      (is (str/includes? (value-for in-set :key) ":rf/redacted")
+          "key ∈ sensitive set → redacted")
+      (is (not (some #(str/includes? % secret) (all-row-strings in-set)))
+          "…and the secret is absent")
+      (is (str/includes? (value-for no-set :key) secret)
+          "key ∉ sensitive set → passes through (so the set was truly threaded)"))))
+
+(deftest xyflow-graph-threads-large-set-into-redaction
+  (testing "rf2-vbo66r — a :context-band-large slot elides to the canonical
+            content-FREE :rf.size/large-elided marker; the value's content
+            never reaches a display row"
+    (let [payload "SENSITIVE-BLOB-CONTENT-xyzzy"
+          parsed  (layout/project-definition flat-machine)
+          graph   (projection/xyflow-graph
+                    parsed {}
+                    {:context-band       (array-map :blob payload)
+                     :context-band-large #{:blob}})]
+      (is (str/includes? (value-for graph :blob) ":rf.size/large-elided")
+          "the large slot shows the size-only elision marker")
+      (is (not (some #(str/includes? % payload) (all-row-strings graph)))
+          "the large value's content never reaches a display row"))))
+
+;; ---------------------------------------------------------------------------
+;; (c) :context-band-raw? true is the explicit trusted-local opt-out
+
+(deftest xyflow-graph-context-band-raw-opts-out-of-redaction
+  (testing "rf2-vbo66r — :context-band-raw? true is the explicit
+            trusted-local opt-in that SKIPS redaction: the SAME sensitive
+            slot that redacts by default now passes its raw value through"
+    (let [secret "card-4111-1111-1111-1111"
+          band   (array-map :card secret)
+          parsed (layout/project-definition flat-machine)
+          ;; identical band + sensitive classification; only :context-band-raw? differs
+          redacted (projection/xyflow-graph
+                     parsed {} {:context-band band :context-band-sensitive #{:card}})
+          raw      (projection/xyflow-graph
+                     parsed {} {:context-band band :context-band-sensitive #{:card}
+                                :context-band-raw? true})]
+      (is (not (some #(str/includes? % secret) (all-row-strings redacted)))
+          "default (raw? absent) → secret redacted away")
+      (is (str/includes? (value-for raw :card) secret)
+          "raw? true → the raw value passes through UNREDACTED (opt-out honoured)"))))
+
+;; ---------------------------------------------------------------------------
+;; (d) an unclassified band passes through unchanged; no band → no :context
+
+(deftest xyflow-graph-unclassified-context-passes-through
+  (testing "rf2-vbo66r — the default-on redaction never clobbers an
+            UNclassified live value (the production value-free shape is a
+            no-op under redaction)"
+    (let [parsed (layout/project-definition flat-machine)
+          graph  (projection/xyflow-graph
+                   parsed {}
+                   {:context-band (array-map :name "Alice" :count 3)})]
+      (is (= "\"Alice\"" (value-for graph :name)) "ordinary string renders via pr-str")
+      (is (= "3" (value-for graph :count))        "ordinary number renders"))))
+
+(deftest xyflow-graph-no-context-band-emits-no-context
+  (testing "rf2-vbo66r — with no :context-band fed, the root-container
+            carries no :context rows (the band gates on presence)"
+    (let [parsed (layout/project-definition flat-machine)
+          graph  (projection/xyflow-graph parsed {} {})]
+      (is (nil? (context-rows graph))
+          "no band → no :data {:context} (nothing to serialise into an export)"))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/engine_grammar_parity_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/engine_grammar_parity_test.cljc
@@ -40,7 +40,9 @@
                :cljs [cljs.test    :refer-macros [deftest is testing]])
             [day8.re-frame2-machines-viz.chart.layout :as layout]
             [day8.re-frame2-machines-viz.grammar :as g]
+            [re-frame.machines.choice :as choice]
             [re-frame.machines.parallel :as parallel]
+            [re-frame.machines.timeout :as timeout]
             [re-frame.machines.transition :as transition]))
 
 ;; ---------------------------------------------------------------------------
@@ -256,3 +258,142 @@
              (viz-resolve-target-path decl-path target))
           (str "target-path resolution drifted for decl-path "
                (pr-str decl-path) " target " (pr-str target))))))
+
+;; ---------------------------------------------------------------------------
+;; PARITY 5 — resolve-timeout-ms vs resolve-duration-ms (EP-0029 A4)
+;;
+;; PARITY: mirror of re-frame.machines.timeout/resolve-duration-ms — if this
+;; fails, the viz duration resolver drifted from the engine; re-sync, do not
+;; delete.
+;;
+;; grammar/resolve-timeout-ms (grammar.cljc) re-states, bundle-isolated from
+;; the runtime `machines` artefact, the engine's `:timeout` duration
+;; grammar: a POSITIVE INTEGER literal ms, OR an ISO-8601 duration STRING
+;; (fixed 365-day / 30-day year/month convention, fractional seconds rounded
+;; to the nearest ms), with EVERYTHING else — the XState "5s"/"10ms"
+;; shorthand, a non-positive/non-integer number, a bare "P", a fn/vector/nil
+;; — resolving to nil. The chart / mermaid / SCXML emitters render the ms
+;; the resolver produces (`after / <ms>` label, clock glyph, SCXML delay),
+;; so a drift in the arithmetic re-times every rendered timeout relative to
+;; what the engine actually fires.
+
+(def ^:private duration-fixtures
+  "Representative :timeout durations spanning every arm: positive-integer
+  literal, each ISO-8601 component, combined components, fractional
+  seconds, case-insensitivity, and every reject-to-nil shape (XState
+  shorthand, non-positive/non-integer, degenerate ISO, wrong type)."
+  [;; positive-integer literal ms
+   5000 1 999999
+   ;; ISO-8601 single components
+   "PT5S" "PT2M" "PT1H" "P1D" "P1W" "P1M" "P1Y"
+   ;; combined
+   "PT1H30M" "P1DT1H1M1S"
+   ;; fractional seconds (round to nearest ms)
+   "PT0.5S" "PT1.5S" "PT0.25S" "PT0.001S"
+   ;; case-insensitive
+   "pt5s" "p1d"
+   ;; non-positive / non-integer numbers → nil
+   0 -5 1.5
+   ;; XState shorthand → nil (operator-ruled divergence)
+   "5s" "10ms" "2m"
+   ;; degenerate / malformed ISO → nil
+   "P" "PT" "PT0S" "P0D" "soon" ""
+   ;; wrong types → nil
+   nil [1000] :pt5s])
+
+(deftest resolve-timeout-ms-parity
+  (testing "viz grammar/resolve-timeout-ms agrees with the engine
+            timeout/resolve-duration-ms on every duration shape"
+    (doseq [d duration-fixtures]
+      (is (= (timeout/resolve-duration-ms d)
+             (g/resolve-timeout-ms d))
+          (str "timeout duration resolution drifted for " (pr-str d))))))
+
+;; ---------------------------------------------------------------------------
+;; PARITY 6 — desugar-timeouts (EP-0029 A4)
+;;
+;; PARITY: mirror of re-frame.machines.timeout/desugar-timeouts — if this
+;; fails, the viz `:timeout` → `:after` lowering drifted from the engine;
+;; re-sync, do not delete.
+;;
+;; project-definition (layout.cljc) calls g/desugar-grammar — which applies
+;; g/desugar-timeouts — as the shared ingestion boundary for all three
+;; emitters, so the emitters render the SAME lowered `:after` table the
+;; engine drives. Both lower state-level, spawn-level, root-level, nested-
+;; compound, and parallel-region `:timeout` / `:on-timeout` into the
+;; equivalent `:after` entry; the two must produce EQUAL machine-defs so a
+;; rendered timer lands on the delay the engine actually fires. (The engine
+;; short-circuits a timeout-free machine to the identical object; the viz
+;; rebuilds it value-equal — the `=` assertion covers both.)
+
+(def ^:private timeout-machine-fixtures
+  "Representative machine-defs spanning every desugar arm."
+  [;; state-level timeout coexisting with :on
+   {:initial :a
+    :states  {:a {:timeout 1000 :on-timeout :b :on {:x :c}} :b {} :c {}}}
+   ;; ISO-8601 state timeout
+   {:initial :a :states {:a {:timeout "PT2S" :on-timeout :done} :done {}}}
+   ;; synthetic entry merges into an existing :after (collision → explicit wins)
+   {:initial :a
+    :states  {:a {:after {2000 :explicit} :timeout "PT2S" :on-timeout :from-timeout}}}
+   ;; spawn-level timeout anchored on the state :after
+   {:initial :a
+    :states  {:a {:spawn {:machine :child :timeout 500 :on-timeout :fallback}
+                  :on    {:x :b}}
+              :b {}}}
+   ;; root-level (whole-machine) timeout
+   {:initial :a :timeout 3000 :on-timeout :expired :states {:a {}}}
+   ;; nested compound
+   {:initial :outer
+    :states  {:outer {:initial :inner
+                      :states  {:inner {:timeout 1000 :on-timeout :done} :done {}}}}}
+   ;; parallel regions
+   {:type    :parallel
+    :regions {:r1 {:initial :x :states {:x {:timeout 1000 :on-timeout :y} :y {}}}
+              :r2 {:initial :p :states {:p {} :q {}}}}}
+   ;; timeout-free control (engine returns unchanged; viz rebuilds value-equal)
+   {:initial :a :states {:a {:on {:x :b}} :b {:after {500 :a}}}}])
+
+(deftest desugar-timeouts-parity
+  (testing "viz grammar/desugar-timeouts agrees with the engine
+            timeout/desugar-timeouts across every machine shape"
+    (doseq [m timeout-machine-fixtures]
+      (is (= (timeout/desugar-timeouts m)
+             (g/desugar-timeouts m))
+          (str ":timeout desugar drifted for " (pr-str m))))))
+
+;; ---------------------------------------------------------------------------
+;; PARITY 7 — desugar-choices (EP-0029 A5)
+;;
+;; PARITY: mirror of re-frame.machines.choice/desugar-choices — if this
+;; fails, the viz `:type :choice` → `:always` lowering drifted from the
+;; engine; re-sync, do not delete.
+;;
+;; g/desugar-grammar also applies g/desugar-choices at the shared ingestion
+;; boundary, so the emitters render the same lowered `:always` candidate
+;; vector the engine drives. Both lower a flat, nested-compound, and
+;; region-nested `:type :choice` state into an ordinary state carrying its
+;; `:choice` candidate vector under `:always`; the two must agree.
+
+(def ^:private choice-machine-fixtures
+  "Representative machine-defs spanning every choice-desugar arm."
+  [;; flat choice state with guarded candidates
+   {:initial :gate
+    :states  {:gate {:type :choice :choice [{:guard :g1 :target :a} {:target :b}]}
+              :a {} :b {}}}
+   ;; nested-compound + region-nested choice states together
+   {:initial :outer
+    :states  {:outer {:initial :gate
+                      :states  {:gate {:type :choice :choice [{:target :a}]} :a {}}}}
+    :regions {:r1 {:initial :rgate
+                   :states  {:rgate {:type :choice :choice [{:target :a}]} :a {}}}}}
+   ;; choice-free control (engine returns unchanged; viz rebuilds value-equal)
+   {:initial :a :states {:a {:always [{:target :b}]} :b {}}}])
+
+(deftest desugar-choices-parity
+  (testing "viz grammar/desugar-choices agrees with the engine
+            choice/desugar-choices across every machine shape"
+    (doseq [m choice-machine-fixtures]
+      (is (= (choice/desugar-choices m)
+             (g/desugar-choices m))
+          (str ":choice desugar drifted for " (pr-str m))))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/grammar_desugar_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/grammar_desugar_cljs_test.cljc
@@ -1,0 +1,258 @@
+(ns day8.re-frame2-machines-viz.grammar-desugar-cljs-test
+  "EP-0029 grammar-desugar + ISO-8601 duration coverage for the shared
+  emitter ingestion boundary (rf2-7j6gtc).
+
+  `grammar.cljc` re-states, bundle-isolated from the runtime `machines`
+  artefact, the EP-0029 named-intent desugars every emitter (chart /
+  mermaid / SCXML) MUST lower before walking a machine-def:
+
+    - `:timeout` / `:on-timeout` → `:after` (A4), via `desugar-timeouts`,
+      whose duration resolver `resolve-timeout-ms` mirrors
+      `re-frame.machines.timeout/resolve-duration-ms` (positive-integer ms
+      OR ISO-8601 STRING only — the XState `\"5s\"` shorthand is REJECTED);
+    - `:type :choice` / `:choice` → `:always` (A5), via `desugar-choices`;
+    - `desugar-grammar` = the single seam applying both, in the order the
+      engine applies them (timeouts then choices).
+
+  `chart.layout/project-definition` calls `g/desugar-grammar` as the
+  shared ingestion boundary for ALL THREE emitters, so a regression here
+  silently omits / mis-renders every `:timeout` and `:choice` form across
+  every surface. These are the EXACT-SHAPE unit assertions that pin the
+  desugar output; the drift-vs-engine parity pair lives in
+  `engine-grammar-parity-test`.
+
+  Pure `.cljc` → the JVM corpus + the `cljs-test$` node-test build both
+  pin it (no engine dep — these are isolation unit tests)."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [day8.re-frame2-machines-viz.grammar :as g]))
+
+;; ===========================================================================
+;; resolve-timeout-ms — the ISO-8601 / integer-ms duration resolver (A4)
+;; ===========================================================================
+;;
+;; Hand-copied non-trivial regex + Y/M/W/D/H/Min/Sec arithmetic + a
+;; Math/round on fractional seconds. These pin the EXACT ms each shape
+;; resolves to (so a drift in the arithmetic — a dropped component, a wrong
+;; ms-per constant, a rounding bug — is caught here regardless of the
+;; engine), plus the reject-to-nil contract on every non-duration.
+
+(deftest resolve-timeout-ms-positive-integer-is-literal-ms
+  (testing "a positive integer literal resolves to itself (ms)"
+    (is (= 5000 (g/resolve-timeout-ms 5000)))
+    (is (= 1    (g/resolve-timeout-ms 1)))))
+
+(deftest resolve-timeout-ms-iso-8601-components
+  (testing "each ISO-8601 component resolves to the right ms with the
+            fixed 365-day / 30-day year/month convention"
+    (is (= 5000     (g/resolve-timeout-ms "PT5S"))    "seconds")
+    (is (= 120000   (g/resolve-timeout-ms "PT2M"))    "minutes")
+    (is (= 3600000  (g/resolve-timeout-ms "PT1H"))    "hours")
+    (is (= 5400000  (g/resolve-timeout-ms "PT1H30M")) "hours + minutes")
+    (is (= 86400000 (g/resolve-timeout-ms "P1D"))     "days")
+    (is (= 604800000     (g/resolve-timeout-ms "P1W")) "weeks = 7 days")
+    (is (= (* 30 86400000) (g/resolve-timeout-ms "P1M")) "month = 30 days")
+    (is (= (* 365 86400000) (g/resolve-timeout-ms "P1Y")) "year = 365 days")
+    (is (= 90061000  (g/resolve-timeout-ms "P1DT1H1M1S"))
+        "combined date+time components sum")))
+
+(deftest resolve-timeout-ms-fractional-seconds-round-to-nearest-ms
+  (testing "fractional seconds are rounded to the nearest integer ms"
+    (is (= 500  (g/resolve-timeout-ms "PT0.5S")))
+    (is (= 1500 (g/resolve-timeout-ms "PT1.5S")))
+    (is (= 250  (g/resolve-timeout-ms "PT0.25S")))
+    (is (= 1    (g/resolve-timeout-ms "PT0.001S")) "1ms floor via round")))
+
+(deftest resolve-timeout-ms-is-case-insensitive
+  (testing "the ISO grammar is case-insensitive (the (?i) flag)"
+    (is (= 5000 (g/resolve-timeout-ms "pt5s")))
+    (is (= 86400000 (g/resolve-timeout-ms "p1d")))))
+
+(deftest resolve-timeout-ms-invalid-durations-are-nil
+  (testing "every non-duration resolves to nil (the caller fails loud)"
+    ;; non-positive / non-integer numbers
+    (is (nil? (g/resolve-timeout-ms 0))    "zero is meaningless")
+    (is (nil? (g/resolve-timeout-ms -5))   "negative is invalid")
+    (is (nil? (g/resolve-timeout-ms 1.5))  "a non-integer number is not a literal ms")
+    ;; XState shorthand — explicitly rejected (EP-0029 A4 divergence)
+    (is (nil? (g/resolve-timeout-ms "5s"))  "XState \"5s\" shorthand rejected")
+    (is (nil? (g/resolve-timeout-ms "10ms")) "XState \"10ms\" shorthand rejected")
+    (is (nil? (g/resolve-timeout-ms "2m")))
+    ;; degenerate / malformed ISO
+    (is (nil? (g/resolve-timeout-ms "P"))   "bare P has no component")
+    (is (nil? (g/resolve-timeout-ms "PT"))  "bare PT has no component")
+    (is (nil? (g/resolve-timeout-ms "PT0S")) "a zero-total duration is non-positive")
+    (is (nil? (g/resolve-timeout-ms "P0D"))  "P0D resolves to 0ms → nil")
+    (is (nil? (g/resolve-timeout-ms "soon")))
+    (is (nil? (g/resolve-timeout-ms ""))    "empty string")
+    ;; wrong TYPES entirely
+    (is (nil? (g/resolve-timeout-ms nil)))
+    (is (nil? (g/resolve-timeout-ms [1000])) "a vector is not a duration")
+    (is (nil? (g/resolve-timeout-ms :pt5s))  "a keyword is not a duration")))
+
+;; ===========================================================================
+;; desugar-timeouts — :timeout / :on-timeout → :after (A4)
+;; ===========================================================================
+
+(deftest desugar-timeouts-state-level-lowers-to-after
+  (testing "a state-level :timeout / :on-timeout becomes an :after entry
+            keyed by the resolved ms, dropping both timeout keys, and
+            coexisting with the state's other slots"
+    (let [in  {:initial :a
+               :states  {:a {:timeout 1000 :on-timeout :b :on {:x :c}}
+                         :b {} :c {}}}
+          out (g/desugar-timeouts in)
+          a   (get-in out [:states :a])]
+      (is (= {:on {:x :c} :after {1000 :b}} a)
+          "the state's :after carries {resolved-ms on-timeout}")
+      (is (not (contains? a :timeout))    "no :timeout key survives")
+      (is (not (contains? a :on-timeout)) "no :on-timeout key survives"))))
+
+(deftest desugar-timeouts-resolves-iso-duration-key
+  (testing "an ISO-8601 :timeout resolves its ms as the :after delay-key"
+    (let [out (g/desugar-timeouts
+                {:initial :a :states {:a {:timeout "PT2S" :on-timeout :done} :done {}}})]
+      (is (= {:after {2000 :done}} (get-in out [:states :a]))))))
+
+(deftest desugar-timeouts-merges-into-existing-after-existing-wins
+  (testing "the synthetic entry MERGES into an existing :after; on a
+            delay-key collision the EXPLICIT :after entry wins (it was
+            authored at that delay)"
+    (let [out (g/desugar-timeouts
+                {:initial :a
+                 :states  {:a {:after {2000 :explicit}
+                               :timeout "PT2S" :on-timeout :from-timeout}}})]
+      ;; 2000ms collides: the explicit :after target survives.
+      (is (= {:after {2000 :explicit}} (get-in out [:states :a]))
+          "explicit :after entry wins the merge on a colliding key"))))
+
+(deftest desugar-timeouts-spawn-level-anchors-on-state-after
+  (testing "a :spawn-level :timeout / :on-timeout desugars onto the STATE's
+            :after (anchored to the state's entry) and strips the spawn's
+            timeout keys, leaving the rest of the spawn spec intact"
+    (let [out (g/desugar-timeouts
+                {:initial :a
+                 :states  {:a {:spawn {:machine :child :timeout 500 :on-timeout :fallback}
+                               :on    {:x :b}}
+                           :b {}}})
+          a   (get-in out [:states :a])]
+      (is (= {:machine :child} (:spawn a)) "spawn spec keeps :machine, loses timeout keys")
+      (is (= {500 :fallback} (:after a))   "spawn timeout anchors on the state :after")
+      (is (= {:x :b} (:on a))              "the state's own :on is untouched"))))
+
+(deftest desugar-timeouts-root-level-anchors-on-root-after
+  (testing "a root-level (whole-machine) :timeout desugars onto the root
+            :after, dropping the root timeout keys, leaving :states intact"
+    (let [out (g/desugar-timeouts
+                {:initial :a :timeout 3000 :on-timeout :expired
+                 :states  {:a {}}})]
+      (is (= {3000 :expired} (:after out)) "root :after carries the whole-machine deadline")
+      (is (not (contains? out :timeout)))
+      (is (not (contains? out :on-timeout)))
+      (is (= {:a {}} (:states out)) ":states unchanged"))))
+
+(deftest desugar-timeouts-walks-nested-compound-states
+  (testing "the walk descends nested :states so a deep state's :timeout
+            still lowers"
+    (let [out (g/desugar-timeouts
+                {:initial :outer
+                 :states  {:outer {:initial :inner
+                                   :states  {:inner {:timeout 1000 :on-timeout :done}
+                                             :done  {}}}}})]
+      (is (= {:after {1000 :done}}
+             (get-in out [:states :outer :states :inner]))
+          "the deep :inner state's timeout lowered onto its :after"))))
+
+(deftest desugar-timeouts-walks-parallel-regions
+  (testing "the walk descends :regions so a region-substate's :timeout lowers"
+    (let [out (g/desugar-timeouts
+                {:type    :parallel
+                 :regions {:r1 {:initial :x
+                                :states  {:x {:timeout 1000 :on-timeout :y}
+                                          :y {}}}}})]
+      (is (= {:after {1000 :y}}
+             (get-in out [:regions :r1 :states :x]))
+          "the region substate's timeout lowered onto its :after"))))
+
+(deftest desugar-timeouts-timeout-free-machine-unchanged
+  (testing "a machine with no :timeout anywhere is returned value-equal
+            (no spurious keys introduced)"
+    (let [m {:initial :a :states {:a {:on {:x :b}} :b {:after {500 :a}}}}]
+      (is (= m (g/desugar-timeouts m))))))
+
+;; ===========================================================================
+;; desugar-choices — :type :choice / :choice → :always (A5)
+;; ===========================================================================
+
+(deftest desugar-choices-lowers-choice-to-always
+  (testing "a :type :choice transient state becomes an ordinary state
+            carrying its :choice candidate vector under :always, dropping
+            the :type / :choice keys"
+    (let [cands [{:guard :g1 :target :a} {:target :b}]
+          out   (g/desugar-choices
+                  {:initial :gate
+                   :states  {:gate {:type :choice :choice cands}
+                             :a {} :b {}}})
+          gate  (get-in out [:states :gate])]
+      (is (= {:always cands} gate) "candidate vector moves under :always")
+      (is (not (contains? gate :type))   "no :type key survives")
+      (is (not (contains? gate :choice)) "no :choice key survives"))))
+
+(deftest desugar-choices-walks-nested-and-regions
+  (testing "the walk lowers a choice state nested in a compound AND one
+            inside a parallel region"
+    (let [cands [{:target :a}]
+          out   (g/desugar-choices
+                  {:initial :outer
+                   :states  {:outer {:initial :gate
+                                     :states  {:gate {:type :choice :choice cands}
+                                               :a    {}}}}
+                   :regions {:r1 {:initial :rgate
+                                  :states  {:rgate {:type :choice :choice cands}
+                                            :a     {}}}}})]
+      (is (= {:always cands} (get-in out [:states :outer :states :gate]))
+          "nested compound choice lowered")
+      (is (= {:always cands} (get-in out [:regions :r1 :states :rgate]))
+          "region-nested choice lowered"))))
+
+(deftest desugar-choices-choice-free-machine-unchanged
+  (testing "a machine with no :type :choice anywhere is returned value-equal"
+    (let [m {:initial :a :states {:a {:always [{:target :b}]} :b {}}}]
+      (is (= m (g/desugar-choices m))))))
+
+;; ===========================================================================
+;; desugar-grammar — the combined ingestion seam (A4 then A5)
+;; ===========================================================================
+
+(deftest desugar-grammar-applies-both-desugars
+  (testing "the shared seam lowers BOTH a :timeout state AND a :choice
+            state in one pass (the exact ingestion boundary all three
+            emitters share)"
+    (let [out (g/desugar-grammar
+                {:initial :a
+                 :states  {:a    {:timeout 1000 :on-timeout :b}
+                           :gate {:type :choice :choice [{:target :a}]}
+                           :b    {}}})]
+      (is (= {:after {1000 :b}} (get-in out [:states :a]))
+          ":timeout lowered to :after")
+      (is (= {:always [{:target :a}]} (get-in out [:states :gate]))
+          ":choice lowered to :always")
+      (is (= {} (get-in out [:states :b]))))))
+
+(deftest desugar-grammar-is-idempotent
+  (testing "re-running the desugar on already-lowered output is a no-op"
+    (let [m   {:initial :a
+               :states  {:a    {:timeout "PT1S" :on-timeout :b}
+                         :gate {:type :choice :choice [{:target :a}]}
+                         :b    {}}}
+          one (g/desugar-grammar m)]
+      (is (= one (g/desugar-grammar one)) "second pass changes nothing"))))
+
+(deftest desugar-grammar-nil-safe
+  (testing "every desugar is nil-safe / non-map-safe (a non-map is returned
+            unchanged — an emitter can call the seam unconditionally)"
+    (is (nil? (g/desugar-grammar nil)))
+    (is (nil? (g/desugar-timeouts nil)))
+    (is (nil? (g/desugar-choices nil)))
+    (is (= :not-a-machine (g/desugar-grammar :not-a-machine)))
+    (is (= 42 (g/desugar-timeouts 42)))))


### PR DESCRIPTION
Adds test-only coverage for two machines-viz surfaces flagged in the 2026-07-09 review campaign as having zero verification. **No production changes.**

## rf2-7j6gtc — EP-0029 grammar desugar + ISO-8601 duration

`grammar.cljc`'s `desugar-timeouts` / `desugar-choices` / `desugar-grammar` and the hand-copied ISO-8601 `resolve-timeout-ms` had **zero coverage**, despite `project-definition` calling `desugar-grammar` as the shared ingestion boundary for all three emitters (chart / mermaid / SCXML) — a regression there silently omits or mis-renders every `:timeout`/`:on-timeout` (A4) and `:type :choice` (A5) form.

- **`grammar_desugar_cljs_test.cljc`** (new) — exact-shape unit assertions: `resolve-timeout-ms` (positive-int → ms, every ISO-8601 component with the fixed 365/30-day convention, fractional-second rounding, case-insensitivity, and the full reject-to-nil set incl. the rejected XState `"5s"`/`"10ms"` shorthand); `desugar-timeouts` (state / spawn / root / nested-compound / parallel-region + the existing-`:after` merge-collision + a timeout-free control); `desugar-choices` (flat / nested / region); `desugar-grammar` (combined A4+A5, idempotent, nil-safe).
- **`engine_grammar_parity_test.cljc`** — PARITY 5-7 pin the viz copies against the engine they mirror (`re-frame.machines.timeout/resolve-duration-ms` + `/desugar-timeouts`, `re-frame.machines.choice/desugar-choices`) so a silent drift goes RED.

## rf2-vbo66r — context-band redaction wiring (EP-0015 export-safety)

Helper tests pinned `redact-context` in isolation and the DOM tests use value-free static shapes (so redaction is a no-op there) — nothing verified that `chart.projection/xyflow-graph` actually **wires** the redaction, so a wiring regression (raw-by-default, dropped classification, bypassed `redact-context`) would leak a secret into the SVG/PNG/clipboard export silently and pass every existing test.

- **`context_redaction_wiring_cljs_test.cljc`** (new) — JVM projection pins: a live `:context-band` with a `:context-band-sensitive` slot redacts **by default** (secret value absent from every `:data {:context}` row); the sensitive/large sets are genuinely **threaded** (same value redacts only when its key is in the set); `:context-band-raw? true` honours the trusted-local opt-out; an unclassified band passes through; no band → no `:context`.

## Quality gates

- `npm run test:cljs` (node-test) — **8358 tests / 38427 assertions, 0 failures, 0 errors** (foreground).
- machines-viz `clojure -M:test` (JVM; runs the parity file, which the `cljs-test$` node build skips) — **599 tests / 2159 assertions, 0 failures, 0 errors** (foreground).
- New/extended namespaces in isolation — 33 tests / 156 assertions, 0 failures.

## Stance

Pre-alpha, no shims. Adversarial exact assertions over the untested boundaries; the desugar/duration parity leans on the existing `engine-grammar-parity-test` seam (engine dep is `:test`-only, bundle-isolation preserved). No production edits — no real bug surfaced (both surfaces behave correctly; they were merely unverified).
