### PR TITLE
docs(tools): fix stale docstrings in story-mcp/pair-mcp/mcp-conformance/template (rf2-jy8cgd +3)

### DIFF
--- a/tools/mcp-conformance/test/end-to-end-re-frame2-pair.cjs
+++ b/tools/mcp-conformance/test/end-to-end-re-frame2-pair.cjs
@@ -89,7 +89,9 @@ delete env.SHADOW_CLJS_NREPL_PORT;
 // redaction, the eval/write gates' SUCCESS/refusal under a real runtime)
 // are pinned by the gated live harnesses. This table is EMPTY: the
 // degraded walk below drives a cheap probe for every advertised tool, so
-// all 28 are SDK-called here. The table is wired through
+// every one of them is SDK-called here (the live count is printed at
+// runtime and pinned by the classification ratchet — no hardcoded total
+// to restale). The table is wired through
 // `assertCallCoverageRatchet` so a FUTURE tool that is genuinely
 // unreachable degraded has a reviewed home (e.g. `{ 'some-live-only-tool':
 // 'live-only; covered by live-re-frame2-pair-<x>.cjs under a real nREPL'

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
@@ -287,13 +287,17 @@
 (def corpus
   "Inline conformance corpus for re-frame2-pair-mcp's tool catalogue.
 
-  Coverage matrix:
+  Coverage matrix. Every advertised tool (see
+  `test/fixtures/tool-names.json` — 30 today) appears below: either with a
+  fixture in THIS inline corpus, or in the `Not exercised here` note that
+  follows — so a tool cannot silently drop out of the map by omission:
 
     | Tool                   | Happy | Missing-arg | Degraded-runtime |
     |------------------------|-------|-------------|-------------------|
     | discover-app           | yes   | n/a         | yes (+port-unresolved) |
     | eval-cljs              | yes   | yes         | (covered by ↑ )   |
     | dispatch               | yes   | yes         | yes               |
+    | dispatch-dry-run       | yes   | yes         | n/a (+gate/elision variants) |
     | restore-epoch          | yes   | yes         | gated-default     |
     | replace-app-db         | yes   | yes         | gated-default     |
     | trace-window           | yes   | n/a         | n/a               |
@@ -306,6 +310,7 @@
     | unsubscribe            | n/a   | yes         | n/a               |
     | list-subscriptions     | yes   | n/a         | n/a               |
     | list-streams           | yes   | n/a         | n/a               |
+    | get-stream-controls    | yes   | n/a         | n/a (no nREPL round-trip) |
     | handler-meta           | yes   | yes         | (short-circuit)   |
     | list-handlers          | yes   | yes         | (short-circuit)   |
     | set-operating-frame    | yes   | yes         | no-such-frame     |
@@ -313,6 +318,12 @@
     | get-operating-frame    | yes   | n/a         | ambiguous (nil)   |
     | get-re-frame2-pair-instructions | yes   | n/a         | n/a               |
     | (pipeline)             | cache-hit (precheck) ; unknown-tool error  |
+
+  Not exercised here (the 7 advertised tools with NO fixture in this
+  corpus; coverage lives in the named dedicated per-tool test namespaces):
+  `describe-image` (describe_image_test), `orient` (orient_test),
+  `read-sub` (read_sub_test), `read-ui` (read_ui_test), `record` +
+  `read-recording` (record_test), `watch-until` (watch_until_test).
 
   Streaming `subscribe` happy paths are covered exhaustively in
   `subscribe_test`; here we pin only the missing-arg shape because the

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/registry.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/registry.cljc
@@ -78,7 +78,7 @@
 (def gated-input-keys
   "The input-property keys the DEFAULT `tools/list` profile gates off
   behind an operator-only gate. Today: `:include-sensitive`
-  — baked into six value-surfacing tools' descriptors at load time and
+  — baked into five value-surfacing tools' descriptors at load time and
   stripped from the default wire surface by `strip-include-sensitive`
   when `--allow-sensitive-reads` is closed. As STRINGS (the
   descriptor-manifest row shape stringifies input keys), so the
@@ -131,12 +131,14 @@
   The `:include-sensitive` slot is stripped from every tool's input
   schema when the operator-only gate (`config/sensitive-reads-allowed?`)
   is closed — agents shouldn't see an opt-in they can't exercise. The
-  affected tools — the six that surface live or plan-resolved frame
-  VALUES (`preview-variant`, `run-variant`, `read-failures`, `read-a11y-violations`,
-  `explain-variant`, `record-as-variant`) — silently ignore
+  affected tools — the five that surface live or plan-resolved frame
+  VALUES (`preview-variant`, `run-variant`, `read-failures`,
+  `read-a11y-violations`, `record-as-variant`) — silently ignore
   caller-supplied `:include-sensitive true` at the helper layer
-  regardless, so the descriptor strip is purely a UX improvement and a
-  defence-in-depth signal."
+  regardless (`explain-variant` is NOT in this set (rf2-7k5mce): it is
+  a no-run projection over the registry, so it ships author data raw
+  like `get-variant` and carries no gate knob), so the descriptor
+  strip is purely a UX improvement and a defence-in-depth signal."
   []
   (let [strip? (not (config/sensitive-reads-allowed?))]
     (mapv (fn [{:keys [name description inputSchema outputSchema annotations typicalTokens]}]

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/schemas.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/schemas.cljc
@@ -202,10 +202,11 @@
 
 (defn with-include-sensitive
   "Inject the `:include-sensitive` slot into a tool's `:properties`
-  map. Used by the six tools that surface a live or plan-resolved frame
-  VALUE — `preview-variant`, `run-variant`, `read-failures`, `read-a11y-violations`,
-  `explain-variant`, `record-as-variant` (the affected set is the single
-  source of truth at `registry/tool-descriptors` §Sensitive-read gate).
+  map. Used by the five tools that surface a live or plan-resolved frame
+  VALUE — `preview-variant`, `run-variant`, `read-failures`,
+  `read-a11y-violations`, `record-as-variant` (the affected set is the single
+  source of truth at `registry/tool-descriptors` §Sensitive-read gate;
+  `explain-variant` is excluded — it ships author data raw, rf2-7k5mce).
 
   The slot is baked into the static descriptor at load time and
   stripped at `tools/list` time by `registry/tool-descriptors` when the

--- a/tools/template/src/day8/re_frame2_template/hooks.clj
+++ b/tools/template/src/day8/re_frame2_template/hooks.clj
@@ -140,8 +140,11 @@
 ;; deterministic — we allowlist it and reject anything outside it. If the
 ;; pinned deps-new version is bumped and adds a harness key, this list must
 ;; grow in lockstep (the gate would otherwise false-reject the new key);
-;; `arg-key-gate-rejects-unknown-test` exercises a representative harness
-;; key to keep that coupling honest.
+;; `harness-keys-not-rejected-test` exercises a representative harness key
+;; (`:overwrite`) to confirm the allowlist doesn't false-reject it, and
+;; `misspelled-story-flag-rejected-test` / `pluralised-story-flag-rejected-test`
+;; pin the negative direction (unknown keys ARE rejected) — together they
+;; keep that coupling honest.
 
 (def ^:private deps-new-harness-keys
   "The keys deps-new injects into the `data` map before `data-fn` runs


### PR DESCRIPTION
@
Comment/docstring-only drift fixes across four tool dirs (no logic change). From the 2026-07-09 review campaign.

## What changed (one commit per bead)

- **rf2-jy8cgd** (story-mcp) — three source docstrings said the sensitive-read gate covers SIX tools and listed `explain-variant`. Post #5373/rf2-7k5mce `explain-variant` ships author data raw and no longer carries `:include-sensitive`; the set is FIVE (`preview-variant`, `run-variant`, `read-failures`, `read-a11y-violations`, `record-as-variant`). Fixed `registry.cljc` (`gated-input-keys` + `tool-descriptors`) and `schemas.cljc` (`with-include-sensitive`). Now matches the test corpus (pins count=5, asserts `explain-variant` absent) and spec/002 + API.md.
- **rf2-mpp58c** (pair-mcp) — `conformance_test.cljs` "Coverage matrix" docstring under-reported (omitted covered `dispatch-dry-run` + `get-stream-controls`) and hid the gap (7 advertised tools with no fixture, invisible by omission). Added the two covered rows and an explicit "Not exercised here" note naming the 7 (`describe-image`/`orient`/`read-sub`/`read-ui`/`record`/`read-recording`/`watch-until`) and their dedicated per-tool test namespaces. Every advertised tool (30, per `tool-names.json`) now appears.
- **rf2-k4thya** (mcp-conformance) — `end-to-end-re-frame2-pair.cjs:92` said "all 28 are SDK-called". Live set is 30. Dropped the hardcoded number ("every one of them"), noting the real count prints at runtime and is pinned by the classification ratchet, so it cannot restale.
- **rf2-5v28xb** (template) — `hooks.clj` cited non-existent `arg-key-gate-rejects-unknown-test`. Replaced with the real guards: `harness-keys-not-rejected-test` (positive) + `misspelled-`/`pluralised-story-flag-rejected-test` (negative).

## Quality gates

- `npm run test:cljs` (foreground): **8333 tests, 38351 assertions, 0 failures, 0 errors** — proves nothing broke.
- story-mcp descriptor drift-check `clojure -M:gen --check` (foreground): **OK, tool-descriptors.edn in sync (20 tools)** — confirms the docstring edits do not touch the wire descriptor manifest.

## Stance

Pre-alpha, no shims. CLARITY + CORRECTNESS: lying comments about a privacy-gate surface, a coverage map that hides gaps, and a dangling test reference are all fixed; where a hardcoded number could restale it was dropped rather than merely bumped. No logic changed.
@