### PR TITLE
docs(impl): fix stale docstrings/comments in core/epoch/ssr-ring (rf2-406gir +3)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -965,7 +965,9 @@
 (defn replace-runtime-db!
   "Replace ONLY the runtime-db partition of `id`'s frame-state, leaving
   app-db untouched (Spec 002 §Frame-state value accessors and mutators).
-  The privileged runtime / full-frame write surface. Atomic install through
+  Internal single-partition helper retained for symmetry with
+  `replace-app-db!`; the public/epoch-backed write surface is
+  `replace-frame-state!` (API-shrink #3, rf2-t3lftq). Atomic install through
   the one physical container. Returns the set of changed partition keys, or
   `nil` for an unknown / destroyed frame."
   [id runtime-db]

--- a/implementation/epoch/src/re_frame/epoch/capture.cljc
+++ b/implementation/epoch/src/re_frame/epoch/capture.cljc
@@ -52,7 +52,7 @@
     ;; skipped for the same reason: re-buffering it would leak it into
     ;; the next cascade's record.
     :rf.epoch/outcome
-    ;; restore-epoch! success + the five documented failure modes.
+    ;; restore-epoch! success + the six documented failure modes.
     :rf.epoch/restored
     :rf.epoch/restore-unknown-epoch
     :rf.epoch/restore-schema-mismatch
@@ -60,9 +60,12 @@
     :rf.epoch/restore-version-mismatch
     :rf.epoch/restore-during-drain
     :rf.epoch/restore-non-ok-record
-    ;; replace-app-db! success + its two failure modes (Tool-Pair §Pair-
-    ;; tool writes). All three fire after the synthetic record
-    ;; has been built and the cascade-buffer (if any) has been harvested.
+    ;; replace-frame-state! success (`:rf.epoch/db-replaced`) + two of its
+    ;; three failure modes (Tool-Pair §Pair-tool writes). All three ops
+    ;; listed here fire after the synthetic record has been built and the
+    ;; cascade-buffer (if any) has been harvested. The surface's third
+    ;; failure op, `:rf.epoch/replace-history-disabled`, is not yet skipped
+    ;; here (tracked by rf2-gba3ou).
     :rf.epoch/db-replaced
     :rf.epoch/replace-during-drain
     :rf.epoch/replace-schema-mismatch

--- a/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
+++ b/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
@@ -1,6 +1,6 @@
 (ns re-frame.epoch.tool-pair
   "Tool-Pair boundary surfaces — the preconditions, restore-perform, and
-  off-box projection helpers behind `restore-epoch!`, `replace-app-db!`,
+  off-box projection helpers behind `restore-epoch!`, `replace-frame-state!`,
   `projected-record`, and `projected-history`.
 
   The name (rf2-dga99) covers BOTH halves of the seam: the WRITE-in
@@ -14,7 +14,7 @@
   Responsibilities:
 
     * **Precondition validators** — `check-restore-preconditions!` and
-      `check-replace-app-db-preconditions!` are pure data transforms
+      `check-replace-frame-state-preconditions!` are pure data transforms
       (no trace emission, no app-db writes); they return
       `{:outcome :ok ...}` or `{:outcome :fail :op <kw> :tags <map>}`
       so the orchestrating facade fn can emit the trace and decide
@@ -46,7 +46,7 @@
       own docstring is the authoritative per-slot contract.
 
   Per rf2-0wi86 Phase-2 seam E. The orchestrators `restore-epoch!` and
-  `replace-app-db!` live in the `re-frame.epoch` facade — they wire
+  `replace-frame-state!` live in the `re-frame.epoch` facade — they wire
   the precondition check + the trace emission + the perform / listener
   fan-out steps together. Pure-data shape of the preconditions makes
   the orchestrators a four-line case-match."
@@ -498,7 +498,7 @@
 ;; ---- write-boundary liveness guard (rf2-7i872) ----------------------------
 ;;
 ;; Precondition validation (`check-restore-preconditions!` /
-;; `check-replace-app-db-preconditions!`) resolves the frame, but a frame
+;; `check-replace-frame-state-preconditions!`) resolves the frame, but a frame
 ;; can be destroyed in the window BETWEEN the precondition pass and the
 ;; actual container write (the validate-then-destroy race — most often a
 ;; tool gesture interleaving with the owning component's teardown). Once
@@ -511,7 +511,7 @@
 ;; returns `false`) — NOT a synthetic success. This helper resolves the
 ;; container at the write boundary and yields the canonical no-such-handler
 ;; failure when it has disappeared, so `perform-restore!` /
-;; `perform-replace-app-db!` can bail BEFORE emitting success, recording a
+;; `perform-replace!` can bail BEFORE emitting success, recording a
 ;; synthetic epoch, or fanning out to listeners.
 
 (defn live-container-or-fail
@@ -783,7 +783,7 @@
               ;; `:trace-events` AFTER the frame has been rewound. The replace-*
               ;; injection siblings already re-anchor to their synthetic epoch
               ;; (`set-last-settled-epoch!` in `record-synthetic-replace-epoch!` /
-              ;; `perform-replace-app-db!`); restore was the one mutating write
+              ;; `perform-replace!`); restore was the one mutating write
               ;; that did not. The restored target IS the epoch whose state is now
               ;; installed, so restore-induced repaint belongs to it — restored-
               ;; target attribution. Set ONLY on the success branch: a failed /

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
@@ -465,7 +465,7 @@
                            :head-hash   (when emit-hash? head-hash))
         html        (html-shell body-html payload-edn shell-opts)
         ;; rf2-c0bq1 — RE-FLUSH after the render walk. The `resp` arg was
-        ;; read at `ring.clj:343` (the single `get-response`) BEFORE the
+        ;; read by the single `get-response` in `ssr-handler` BEFORE the
         ;; render ran, so it carries the pre-render status. A reactive
         ;; sub that THROWS during `render-to-string` under production
         ;; hardening (`interop/debug-enabled? = false`) recovers to nil —

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_draintime_error_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_draintime_error_test.clj
@@ -48,7 +48,7 @@
        unmatched URL emits a drain-time `:rf.error/no-such-handler`
        (`:kind :route`), buffered by the always-on
        `error-emit-projection-listener`, projected to 404 by
-       `ssr/get-response` (the read at `ring.clj:343`). Asserted on the
+       `ssr/get-response` (the single `get-response` read in `ssr-handler`). Asserted on the
        wire (Jetty + `java.net.http`) AND via a direct in-process
        handler call — the 404 is the DISCRIMINATING status that proves
        the routing projector arm rode the wire, not the generic 500
@@ -155,7 +155,7 @@
 ;; `:rf.error/no-such-handler` (`:kind :route`) tagged with that frame —
 ;; one of the exact emit sites rf2-7d30s audited. The always-on
 ;; `error-emit-projection-listener` buffers it; `ssr/get-response` (the
-;; read at ring.clj:343, BEFORE render) flushes the buffer through the
+;; read in `ssr-handler`, BEFORE render) flushes the buffer through the
 ;; default projector, which maps `:no-such-handler` → 404, and stamps it
 ;; onto the response accumulator. `build-full-response` then materialises
 ;; that 404 onto the Ring response status. 404 (not the generic 500) is

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_rendertime_sub_failclosed_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_rendertime_sub_failclosed_test.clj
@@ -12,8 +12,8 @@
   core/accumulator layer — but it did NOT reach the wire through the
   reference Ring adapter:
 
-    1. `ssr-handler` reads `(ssr/get-response frame-id)` ONCE at
-       `ring.clj:343` — BEFORE the render walk. The render has not run,
+    1. `ssr-handler` reads `(ssr/get-response frame-id)` ONCE,
+       BEFORE the render walk. The render has not run,
        so the buffer is empty and `:status` is the default 200.
     2. `build-full-response*` (`pipeline.clj`) runs the render walk inside
        `with-frame`. The reactive sub throws HERE. Under

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
@@ -2502,9 +2502,9 @@
 ;; because only the `<head>` metadata is missing — the body still renders.
 ;;
 ;; Pre-rf2-lia3i the degraded-200 outcome was SAFE BY TIMING ONLY:
-;; `ssr-handler` reads `get-response` (ring.clj:343 — drains + reads the
+;; `ssr-handler` reads `get-response` (the single post-shell read — drains + reads the
 ;; status) BEFORE `build-full-response` → `resolve-head` fires the head
-;; trace (pipeline.clj:286), so the buffered head trace was never
+;; trace (the `resolve-head` call in `build-full-response*`), so the buffered head trace was never
 ;; projected onto the already-captured status. A reorder (head resolution
 ;; before `get-response`, a second flush after the render, or a re-read of
 ;; `get-response`) would have let the default projector map the head trace


### PR DESCRIPTION
Comment/docstring-only fixes flagged by the 2026-07-09 review campaign. Four beads, one per commit; zero logic/behaviour change.

## What changed

- **rf2-406gir** (`core/frame.cljc`) — `replace-runtime-db!` docstring called itself "the privileged runtime / full-frame write surface". Stale post API-shrink #3 (rf2-t3lftq): the one public/epoch-backed write surface is `replace-frame-state!`, and `replace-runtime-db!` has zero non-comment src callers. Reworded to match its sibling `replace-app-db!` (internal single-partition helper).
- **rf2-f38xvb** (`epoch/capture.cljc`) — skip-ops catalogue: "five documented failure modes" → "six" (restore-non-ok-record was the sixth, rf2-v0jwt); dead name `replace-app-db!` → `replace-frame-state!`; reconciled the replace count — the surface has three rf.epoch failure ops but only two are skipped here (the third, `:rf.epoch/replace-history-disabled`, is a separate logic gap tracked by rf2-gba3ou, so the comment now notes it rather than mis-counting).
- **rf2-et1gq7** (`epoch/tool_pair.cljc`) — six references to fns/surfaces by dead names post the rf2-t3lftq rename: `replace-app-db!` → `replace-frame-state!` (x2), `check-replace-app-db-preconditions!` → `check-replace-frame-state-preconditions!` (x2), `perform-replace-app-db!` → `perform-replace!` (x2). The "former four-mutator family" historical provenance lists (`:814`/`:868`) left untouched.
- **rf2-7ypoko** (`ssr-ring/pipeline.clj` + 3 test files) — stale numeric line refs (`ring.clj:343` → actual :444; `pipeline.clj:286` → actual :396) replaced with drift-proof call-site names ("the single `get-response` read in `ssr-handler`", "the `resolve-head` call in `build-full-response*`").

## Quality gates

- `npm run test:cljs`: **8333 tests, 38351 assertions, 0 failures, 0 errors.** (Comment-only change, so green is expected; this proves nothing broke.)

## Stance

Pre-alpha, no shims. Primary lenses CLARITY + CORRECTNESS: comments/docstrings now name live surfaces and use drift-proof references instead of brittle line numbers. No logic touched; every changed line is a `;;` comment or docstring string.
