### PR TITLE
test(resources,http,ssr): owner-bump gate + synthetic-4xx + drain-façade coverage (rf2-k49jec +2)

### DIFF
--- a/implementation/http/test/re_frame/http_synthetic_4xx_test.clj
+++ b/implementation/http/test/re_frame/http_synthetic_4xx_test.clj
@@ -1,0 +1,195 @@
+(ns re-frame.http-synthetic-4xx-test
+  "Per rf2-wi8g9r — the `:else` synthetic-4xx arm of `handle-response!`
+  (transport.cljc §handle-response!) end-to-end.
+
+  THE ARM: a non-2xx status that is NOT 4xx/5xx — a 1xx, or a 3xx the
+  runtime did not follow — falls through the 4xx / 5xx / 2xx cascade to the
+  `:else` branch, which classifies it as `:rf.http/http-4xx` carrying the raw
+  body-text and (per rf2-ee38b.7) routes through `maybe-retry!` (NOT
+  `finalise-failure!`) so a caller with `:retry {:on #{:rf.http/http-4xx}}`
+  retries it consistently with a real 4xx.
+
+  REACHABILITY: `:redirect :error` (or `:manual`) selects the JDK
+  `HttpClient$Redirect/NEVER` client (rf2-ee38b.7 — `transport-jvm/redirect->
+  policy`), so a 302 response surfaces UNFOLLOWED at status 302 through the
+  classification cascade rather than being auto-followed. The redirect-policy
+  MAPPING is unit-tested in `http_transport_security_test`, but no test drove a
+  real 3xx response through the cascade — so a refactor reverting the `:else`
+  arm to `finalise-failure!`, or changing the synthesised kind, would pass every
+  existing test. These end-to-end tests pin it: a real 302-returning server, a
+  `:redirect :error` request, and assertions on (a) the synthesised
+  `:rf.http/http-4xx` kind, (b) the raw 302 body at `:body`, and (c) the
+  `maybe-retry!` routing (hit count > 1 under a `:rf.http/http-4xx` retry).
+
+  Strategy mirrors `http_backoff_cancellation_test`: a tiny in-process
+  `com.sun.net.httpserver.HttpServer` that always returns 302 and COUNTS its
+  hits.
+
+  Spec references:
+   - Spec 014 §Classification order (status classification before decode)
+   - Spec 014 §Failure categories (`:rf.http/http-4xx`)
+   - Spec 014 §Retry and backoff / §Request envelope (`:redirect`)"
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.flows :as flows]
+            [re-frame.frame :as frame]
+            [re-frame.http.managed :as http-managed]
+            [re-frame.http.registry :as registry]
+            [re-frame.machines :as machines]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support])
+  (:import [com.sun.net.httpserver HttpExchange HttpHandler HttpServer]
+           [java.net InetSocketAddress]
+           [java.util.concurrent.atomic AtomicInteger]))
+
+;; ---- per-test reset (mirrors http_backoff_cancellation_test) ---------------
+
+(defn- reset-runtime [t]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (flows/reset-flows!)
+  (schemas/clear-schemas-by-frame!)
+  (rf/init! plain-atom/adapter)
+  (frame/ensure-default-frame!)
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr     :reload)
+  (require 're-frame.machines :reload)
+  (require 're-frame.http.managed :reload)
+  (machines/reset-timers!)
+  (http-managed/clear-all-in-flight!)
+  (rf/with-frame :rf/default
+    (t)))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- hit-counting always-302 server ----------------------------------------
+
+(def ^:private redirect-body
+  "moved permanently-ish — body the JDK NEVER-policy client surfaces raw")
+
+(defn- start-counting-302-server!
+  "Start an HttpServer that always returns a 302 (with a Location header the
+  NEVER-policy client will NOT follow) carrying `redirect-body`, incrementing
+  `hits` on every request. Returns `{:server :port :hits}`."
+  []
+  (let [hits   (AtomicInteger. 0)
+        server (HttpServer/create (InetSocketAddress. "127.0.0.1" 0) 0)]
+    (.createContext server "/"
+                    (reify HttpHandler
+                      (handle [_ ex]
+                        (.incrementAndGet hits)
+                        (let [^HttpExchange ex ex
+                              bs (.getBytes redirect-body "UTF-8")]
+                          (try
+                            ;; A Location header a following client WOULD chase;
+                            ;; the :redirect :error client (NEVER) does not, so
+                            ;; the 302 surfaces unfollowed through the cascade.
+                            (.add (.getResponseHeaders ex) "Location" "/elsewhere")
+                            (.sendResponseHeaders ex 302 (long (count bs)))
+                            (with-open [os (.getResponseBody ex)]
+                              (.write os bs))
+                            (catch Throwable _ nil))))))
+    (.setExecutor server nil)
+    (.start server)
+    {:server server
+     :port   (.getPort (.getAddress server))
+     :hits   hits}))
+
+(defn- stop-server! [{:keys [^HttpServer server]}]
+  (.stop server 0))
+
+(defn- await-condition!
+  ([pred] (await-condition! pred 5000))
+  ([pred timeout-ms]
+   (test-support/poll-until pred {:timeout-ms timeout-ms :interval-ms 10
+                                  :label "http-synthetic-4xx condition"})
+   true))
+
+;; ---- (1) synthetic-4xx classification + raw body + maybe-retry! routing -----
+
+(deftest unfollowed-3xx-classifies-synthetic-4xx-and-retries
+  (testing "rf2-wi8g9r — an UNFOLLOWED 302 (:redirect :error → JDK NEVER) hits
+  the `:else` arm: it classifies as :rf.http/http-4xx carrying the raw 302
+  body, and — being a :rf.http/http-4xx — is RETRIED under a
+  `:retry {:on #{:rf.http/http-4xx}}` config (routed through maybe-retry!,
+  NOT finalise-failure!). The server is hit TWICE (attempt + one retry)."
+    (let [{:keys [^AtomicInteger hits] :as srv} (start-counting-302-server!)
+          replies (atom [])]
+      (try
+        (rf/reg-event :reply/recorder
+          (fn [_ [_ payload]] (swap! replies conj payload) {}))
+        (rf/reg-event :issue
+          (fn [_ _]
+            {:fx [[:rf.http/managed
+                   {:request    {:url      (str "http://127.0.0.1:" (:port srv) "/")
+                                 ;; NEVER-policy client — the 302 is NOT followed.
+                                 :redirect :error}
+                    :decode     :json
+                    ;; max-attempts 2 → exactly one retry, then exhaust.
+                    :retry      {:on           #{:rf.http/http-4xx}
+                                 :max-attempts 2
+                                 :backoff      {:base-ms 100 :factor 1 :max-ms 100}}
+                    :request-id :synth
+                    :on-failure [:reply/recorder]
+                    :on-success [:reply/recorder]}]]}))
+        (rf/dispatch-sync [:issue])
+        ;; The synthetic-4xx retried once → server hit exactly twice.
+        (await-condition! #(= 2 (.get hits)))
+        (is (= 2 (.get hits))
+            "the synthetic http-4xx routed through maybe-retry! and retried once (the :else arm is NOT a direct finalise-failure!)")
+        (await-condition! #(seq @replies))
+        (is (= 1 (count @replies))
+            "exactly one final reply after the retry exhausts")
+        (let [reply (first @replies)]
+          (is (= :error (:status reply))
+              "the exhausted synthetic-4xx lowers to a :status :error reply")
+          (is (= :rf.http/http-4xx (get-in reply [:error :kind]))
+              "the unfollowed 3xx classifies as the synthetic :rf.http/http-4xx kind")
+          (is (= 302 (get-in reply [:error :status]))
+              "the RAW 3xx status rides on the failure map")
+          (is (= redirect-body (get-in reply [:error :body]))
+              "the RAW 302 body-text rides at :body (decode never runs on a non-2xx)"))
+        (is (empty? (registry/in-flight-snapshot))
+            "the registry is clean after the synthetic-4xx exhausts its retries")
+        (finally
+          (stop-server! srv))))))
+
+;; ---- (2) GUARD: a 5xx-only retry does NOT catch the synthetic-4xx ----------
+
+(deftest synthetic-4xx-not-retried-under-5xx-only-retry
+  (testing "rf2-wi8g9r guard — the synthesised kind is genuinely
+  :rf.http/http-4xx (NOT :rf.http/http-5xx): a `:retry {:on #{:rf.http/http-5xx}}`
+  config does NOT match it, so the unfollowed 302 fails on the FIRST attempt
+  (hit count exactly 1) and finalises with the synthetic-4xx failure. This pins
+  the kind from the opposite direction — a mislabel as 5xx would spuriously
+  retry here."
+    (let [{:keys [^AtomicInteger hits] :as srv} (start-counting-302-server!)
+          replies (atom [])]
+      (try
+        (rf/reg-event :reply/recorder
+          (fn [_ [_ payload]] (swap! replies conj payload) {}))
+        (rf/reg-event :issue
+          (fn [_ _]
+            {:fx [[:rf.http/managed
+                   {:request    {:url      (str "http://127.0.0.1:" (:port srv) "/")
+                                 :redirect :error}
+                    :decode     :json
+                    :retry      {:on           #{:rf.http/http-5xx}
+                                 :max-attempts 3
+                                 :backoff      {:base-ms 100 :factor 1 :max-ms 100}}
+                    :request-id :synth-guard
+                    :on-failure [:reply/recorder]}]]}))
+        (rf/dispatch-sync [:issue])
+        (await-condition! #(seq @replies))
+        (let [reply (first @replies)]
+          (is (= :rf.http/http-4xx (get-in reply [:error :kind]))
+              "classified :rf.http/http-4xx — a 5xx-only retry does not match it")
+          (is (= 302 (get-in reply [:error :status]))))
+        (is (= 1 (.get hits))
+            "the synthetic-4xx is NOT in the 5xx retry set → exactly one attempt, no retry")
+        (is (= 1 (count @replies)))
+        (is (empty? (registry/in-flight-snapshot)))
+        (finally
+          (stop-server! srv))))))

--- a/implementation/resources/test/re_frame/resources_revision_substrate_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_revision_substrate_cljs_test.cljc
@@ -300,3 +300,112 @@
         "recorded nil ~ 0 vs current 0 — no conflict")
     (is (true? (state/revision-conflict? {:revision 1} nil))
         "recorded nil ~ 0 vs current 1 — conflict")))
+
+;; ---- owner-liveness writes: the NO-OP GATE (rf2-k49jec / rf2-cxwuhl) --------
+;;
+;; THE GATE (state.cljc §attach-owner/detach-owner): an owner attach/release is
+;; an authoritative durable entry write a later optimistic rollback could
+;; clobber (`restore-before` overwrites `:active-owners` wholesale), so it bumps
+;; `:revision` — BUT ONLY when the `:active-owners` set ACTUALLY changes. A
+;; re-attach of an already-present owner, or a release of an absent owner, is a
+;; no-op: no write, nothing a rollback could clobber, so NO bump. The other
+;; bump sites (entry-succeeded / patch / populate / failure settles) are all
+;; unit-tested above; attach-owner/detach-owner had ZERO direct coverage and
+;; optimistic_settle §6 exercises only the POSITIVE path (a real mid-flight
+;; owner change → conflict caught). These tests pin the NEGATIVE gate directly.
+;;
+;; WHY THE GATE MATTERS: without it, every re-ensure that re-attaches a still-
+;; present owner would spuriously bump `:revision`, so any in-flight optimistic
+;; mutation would see a PHANTOM conflict at settle → an unnecessary
+;; `:invalidate`/refetch on every unrelated re-ensure. A regression removing the
+;; gate (an unconditional bump) is SILENT — every other test still passes. These
+;; assertions are the tripwire.
+
+(deftest attach-owner-bumps-revision-only-when-a-new-owner-lands
+  (testing "attaching a NEW owner adds it to :active-owners AND bumps :revision
+            (an authoritative durable write a rollback could clobber)"
+    (let [e0 (state/empty-entry :conduit/article)]
+      (is (= 0 (:revision e0)))
+      (let [e1 (state/attach-owner e0 :owner/a)]
+        (is (contains? (:active-owners e1) :owner/a) "the new owner is in the set")
+        (is (= 1 (:revision e1)) "a new owner bumps :revision 0 -> 1")
+        (testing "attaching a SECOND distinct owner also lands + bumps"
+          (let [e2 (state/attach-owner e1 :owner/b)]
+            (is (= #{:owner/a :owner/b} (:active-owners e2)) "set gains the 2nd owner")
+            (is (= 2 (:revision e2)) "the 2nd distinct owner bumps 1 -> 2"))))))
+  (testing "RE-ATTACHING an already-present owner is a NO-OP — the set is
+            unchanged and :revision is UNMOVED (the load-bearing gate: no
+            phantom conflict on every unrelated re-ensure)"
+    (let [e1 (state/attach-owner (state/empty-entry :conduit/article) :owner/a)
+          e2 (state/attach-owner e1 :owner/a)]
+      (is (= (:active-owners e1) (:active-owners e2)) ":active-owners unchanged")
+      (is (= 1 (:revision e2))
+          ":revision is NOT bumped by a re-attach of a present owner")
+      (is (identical? (:active-owners e1) (:active-owners e2))
+          "the re-attach returns the SAME set identity — genuinely no write")))
+  (testing "a nil owner is a no-op — no write, no bump (the (some? owner) gate)"
+    (let [e1 (state/attach-owner (state/empty-entry :conduit/article) :owner/a)
+          e2 (state/attach-owner e1 nil)]
+      (is (= e1 e2) "nil owner returns the entry unchanged")
+      (is (= 1 (:revision e2)) ":revision is UNMOVED by a nil-owner attach"))))
+
+(deftest detach-owner-bumps-revision-only-when-the-owner-was-present
+  (testing "detaching a PRESENT owner drops it from :active-owners AND bumps
+            :revision (release is an authoritative durable write)"
+    (let [e1 (state/attach-owner (state/empty-entry :conduit/article) :owner/a)
+          e2 (state/detach-owner e1 :owner/a)]
+      (is (not (contains? (:active-owners e2) :owner/a)) "the owner is gone")
+      (is (= 2 (:revision e2)) "the release bumps :revision 1 -> 2")))
+  (testing "detaching an ABSENT owner is a NO-OP — the set is unchanged and
+            :revision is UNMOVED (the release-side gate)"
+    (let [e1 (state/attach-owner (state/empty-entry :conduit/article) :owner/a)
+          e2 (state/detach-owner e1 :owner/absent)]
+      (is (= (:active-owners e1) (:active-owners e2)) ":active-owners unchanged")
+      (is (= 1 (:revision e2))
+          ":revision is NOT bumped by a release of an owner that was never present")))
+  (testing "detaching from an entry with NO :active-owners key is a no-op"
+    (let [e0 (state/empty-entry :conduit/article)]
+      (is (not (contains? (:active-owners e0) :owner/a)) "no owner set yet")
+      (let [e1 (state/detach-owner e0 :owner/a)]
+        (is (= 0 (:revision e1)) "the release of an absent owner makes no write, no bump"))))
+  (testing "a nil entry is returned unchanged (the (and entry …) gate)"
+    (is (nil? (state/detach-owner nil :owner/a))
+        "detach-owner of nil returns nil")))
+
+(deftest owner-gate-drives-the-optimistic-conflict-check-correctly
+  (testing "THE WHY (rf2-k49jec): a re-attach of a present owner leaves
+            :revision UNMOVED, so a snapshot recorded before it sees NO conflict
+            at settle — no PHANTOM optimistic-rollback conflict / spurious
+            invalidate on an unrelated re-ensure"
+    (let [attached (state/attach-owner (state/empty-entry :conduit/article) :owner/a)
+          recorded (state/entry-revision attached)      ;; snapshot the apply revision
+          re-ens   (state/attach-owner attached :owner/a)]   ;; a re-ensure re-attaches
+      (is (= recorded (state/entry-revision re-ens))
+          "the no-op re-attach did not move the write identity")
+      (is (false? (state/revision-conflict? re-ens recorded))
+          "so the settle conflict check sees NO conflict — the gate prevents the
+           phantom conflict that an unconditional bump would manufacture")))
+  (testing "conversely a GENUINE mid-flight owner change DOES bump, so it is
+            visible to the conflict check (the gate does not suppress real
+            writes — the departed/arrived lease is protected)"
+    (let [attached (state/attach-owner (state/empty-entry :conduit/article) :owner/a)
+          recorded (state/entry-revision attached)
+          ;; a real mid-flight change: a NEW owner arrives while the mutation
+          ;; is in flight — an authoritative write a rollback would clobber.
+          changed  (state/attach-owner attached :owner/b)]
+      (is (= (inc recorded) (state/entry-revision changed))
+          "the genuine new-owner attach bumped past the snapshot")
+      (is (true? (state/revision-conflict? changed recorded))
+          "so the settle detects the conflict and :invalidates rather than
+           blindly restoring the stale :before (which would DROP the new lease)"))
+    (testing "and the RELEASE side is symmetric — a present-owner release bumps
+              and is detected"
+      (let [with-two (-> (state/empty-entry :conduit/article)
+                         (state/attach-owner :owner/a)
+                         (state/attach-owner :owner/b))
+            recorded (state/entry-revision with-two)
+            released (state/detach-owner with-two :owner/a)]
+        (is (= (inc recorded) (state/entry-revision released))
+            "the present-owner release bumped past the snapshot")
+        (is (true? (state/revision-conflict? released recorded))
+            "so a rollback will NOT resurrect the departed owner")))))

--- a/implementation/ssr/test/re_frame/ssr_drain_facade_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_drain_facade_test.clj
@@ -1,0 +1,140 @@
+(ns re-frame.ssr-drain-facade-test
+  "Per rf2-zplpsp — the `re-frame.ssr/drain-blocking-resources!` FAÇADE
+  WRAPPER (ssr.cljc §196-264), tested IN THE SSR SLICE (where the resources
+  artefact is absent).
+
+  The drain LOOP + timeout POLICY live in the resources artefact
+  (`re-frame.resources.ssr/drain-blocking-resources!`, published as the
+  `:resources/drain-blocking-ssr!` late-bind hook and exercised by the
+  resources slice's `resources_ssr_cljs_test`). This façade is the thin ssr-
+  slice wrapper the Ring / streaming host render path actually calls: it
+  resolves the late-bound hook and, when present, forwards a normalised opts
+  map (`:deadline-ms` / `:pump!` / `:tick-ms`); when ABSENT it returns a
+  fixed settled-shape no-op.
+
+  The ssr slice never loads resources, so the hook is ALWAYS absent here — yet
+  nothing pinned the ssr-slice-specific branches:
+
+    1. HOOK-ABSENT no-op fast path — the DEFAULT path for every SSR app that
+       does not load the optional resources artefact. It MUST return
+       `{:settled? true :timed-out #{} :route-blocking-failure nil}` — the
+       shape the Ring host consults for its pre-render `:settled?` /
+       `:route-blocking-failure` decision. A regression returning nil / a
+       wrong shape would break that consult with no ssr-slice test to catch it.
+    2. `:pump!` RESOLUTION — `(if (contains? opts :pump!) (:pump! opts)
+       default-blocking-pump!)`: an EXPLICIT nil `:pump!` must WIN (pass nil
+       through), while an ABSENT `:pump!` defaults to the host-yield pump. The
+       `contains?` gate (not an `or`) is what makes explicit-nil distinguishable
+       from absent.
+    3. DEFAULT timeout — `default-ssr-blocking-timeout-ms` (5000) applied as
+       `:deadline-ms` when `:ssr-blocking-timeout-ms` is absent.
+
+  These are pinned by (a) calling the façade with the hook removed and asserting
+  the settled-shape, and (b) installing a RECORDING stub hook and asserting the
+  exact opts map the façade forwards."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.ssr :as ssr]))
+
+(def ^:private drain-key :resources/drain-blocking-ssr!)
+
+;; Private façade defaults, reached via the var AT CALL TIME (not captured at
+;; ns-load): sibling ssr suites reload `re-frame.ssr` in their fixtures, minting
+;; a fresh `default-blocking-pump!` fn object, so an `identical?` compare must
+;; read the CURRENT var root the façade also resolves — a load-time snapshot
+;; would go stale after any such reload.
+(defn- default-pump [] @#'ssr/default-blocking-pump!)
+(defn- default-timeout [] @#'ssr/default-ssr-blocking-timeout-ms)
+
+(defn- restore-hook!
+  "Restore the drain hook to its pre-test registration (or remove it when it
+  was absent), keeping the late-bind resolution cache consistent."
+  [prev]
+  (if prev
+    (late-bind/set-fn! drain-key prev)
+    (do (swap! late-bind/hooks dissoc drain-key)
+        (late-bind/invalidate-cache! drain-key)))
+  nil)
+
+;; ---- (1) hook-absent no-op fast path ---------------------------------------
+
+(def ^:private settled-shape
+  {:settled? true :timed-out #{} :route-blocking-failure nil})
+
+(deftest hook-absent-returns-the-settled-fast-path-shape
+  (testing "rf2-zplpsp — with NO resources artefact (the `:resources/drain-
+  blocking-ssr!` hook unregistered — the default for every no-resources SSR
+  app) the façade is a no-op returning the exact settled-shape the Ring host
+  consults: {:settled? true :timed-out #{} :route-blocking-failure nil}"
+    (let [prev (late-bind/get-fn drain-key)]
+      (try
+        (swap! late-bind/hooks dissoc drain-key)
+        (late-bind/invalidate-cache! drain-key)
+        (is (nil? (late-bind/get-fn drain-key))
+            "precondition: the drain hook is absent in the ssr slice")
+        (testing "1-arity (the host's default call — no opts)"
+          (is (= settled-shape (ssr/drain-blocking-resources! :ssr/some-frame))
+              "hook-absent 1-arity returns the settled-shape"))
+        (testing "2-arity opts are IGNORED on the absent path — still settled-shape"
+          (is (= settled-shape
+                 (ssr/drain-blocking-resources!
+                   :ssr/some-frame {:ssr-blocking-timeout-ms 123 :pump! nil :tick-ms 9}))
+              "even with opts, the hook-absent path short-circuits to settled-shape"))
+        (finally
+          (restore-hook! prev))))))
+
+;; ---- (2) hook-present opts resolution --------------------------------------
+
+(deftest hook-present-forwards-resolved-opts-and-return
+  (testing "rf2-zplpsp — with the drain hook PRESENT the façade forwards the
+  frame-id and a normalised opts map, and returns the hook's result verbatim"
+    (let [prev     (late-bind/get-fn drain-key)
+          captured (atom nil)
+          sentinel {:settled? false :timed-out #{[:x]} :route-blocking-failure {:route :r}}]
+      (try
+        (late-bind/set-fn! drain-key
+          (fn [frame-id opts]
+            (reset! captured {:frame-id frame-id :opts opts})
+            sentinel))
+
+        (testing "the hook's return rides back verbatim"
+          (is (= sentinel (ssr/drain-blocking-resources! :ssr/f))
+              "the façade does not reshape the resources drain result"))
+
+        (testing "DEFAULTS (1-arity / no opts): :deadline-ms = default 5000,
+                  :pump! = default host-yield pump, :tick-ms = 5"
+          (reset! captured nil)
+          (ssr/drain-blocking-resources! :ssr/f)
+          (let [{:keys [frame-id opts]} @captured]
+            (is (= :ssr/f frame-id) "frame-id is forwarded")
+            (is (= (default-timeout) (:deadline-ms opts))
+                "absent :ssr-blocking-timeout-ms → default-ssr-blocking-timeout-ms (5000) as :deadline-ms")
+            (is (= 5000 (:deadline-ms opts)) "…which is 5000ms")
+            (is (identical? (default-pump) (:pump! opts))
+                "absent :pump! defaults to the host-yield default-blocking-pump!")
+            (is (= 5 (:tick-ms opts)) "absent :tick-ms → 5")))
+
+        (testing "EXPLICIT :pump! nil WINS over the default (the `contains?` gate,
+                  not an `or`) — a sync test stub drives a never-settling resource
+                  straight to the deadline"
+          (reset! captured nil)
+          (ssr/drain-blocking-resources! :ssr/f {:pump! nil})
+          (let [opts (:opts @captured)]
+            (is (contains? opts :pump!) ":pump! key is present in the forwarded opts")
+            (is (nil? (:pump! opts))
+                "an EXPLICIT nil :pump! is passed through, NOT replaced by the default")
+            (is (not (identical? (default-pump) (:pump! opts)))
+                "…confirming the default did not win")))
+
+        (testing "EXPLICIT values thread through: :ssr-blocking-timeout-ms →
+                  :deadline-ms, a custom :pump!, and :tick-ms"
+          (reset! captured nil)
+          (let [my-pump (fn [_tick] :pumped)]
+            (ssr/drain-blocking-resources! :ssr/f
+              {:ssr-blocking-timeout-ms 250 :pump! my-pump :tick-ms 7})
+            (let [opts (:opts @captured)]
+              (is (= 250 (:deadline-ms opts)) "explicit :ssr-blocking-timeout-ms → :deadline-ms")
+              (is (identical? my-pump (:pump! opts)) "an explicit custom :pump! is threaded")
+              (is (= 7 (:tick-ms opts)) "explicit :tick-ms is threaded"))))
+        (finally
+          (restore-hook! prev))))))


### PR DESCRIPTION
Adds adversarial test coverage for three implementation test gaps identified in the 2026-07-09 review campaign. Test-only; no production edits (no bug surfaced).

## What / why

- **rf2-k49jec (resources)** — `attach-owner`/`detach-owner` (`state.cljc`) carry a load-bearing no-op gate: `:revision` bumps only when the `:active-owners` set actually changes. Every other bump site is unit-tested; these two had zero direct coverage. A regression to an unconditional bump would be silent and manufacture phantom optimistic-rollback conflicts on every unrelated re-ensure. Added pure unit tests to `resources_revision_substrate_cljs_test` covering both gates (new/re-attach/nil, present/absent/nil-entry) and their effect on the settle-time conflict check.

- **rf2-wi8g9r (http)** — the `:else` synthetic-4xx arm of `handle-response!` (`transport.cljc`): a non-2xx that is not 4xx/5xx (an unfollowed 3xx / 1xx) classifies as `:rf.http/http-4xx` with the raw body and routes through `maybe-retry!` (per rf2-ee38b.7). No test drove a real 3xx through the cascade. Added a JVM end-to-end test (302-returning hit-counting `HttpServer` + `:redirect :error` → JDK NEVER) asserting the synthetic kind, raw 302 status + body, and retry firing; plus a 5xx-only-retry guard pinning the kind is genuinely 4xx.

- **rf2-zplpsp (ssr)** — the `re-frame.ssr/drain-blocking-resources!` façade wrapper had no ssr-slice test. Added a JVM test pinning the hook-absent settled-shape fast path (the default for every no-resources SSR app) and, via a recording stub hook, the forwarded-opts resolution: defaults (deadline 5000, host-yield pump, tick 5), explicit `:pump! nil` pass-through, and explicit value threading.

## Quality gates (foreground, worktree off origin/main)

- `implementation/resources` → `clojure -M:test`: 622 tests, 6217 assertions, **0 failures, 0 errors**
- `implementation/http` → `clojure -M:test`: 467 tests, 3660 assertions, **0 failures, 0 errors**
- `implementation/ssr` → `clojure -M:test`: 372 tests, 1523 assertions, **0 failures, 0 errors**
- `implementation` → `npm run test:cljs`: 8336 tests, 38374 assertions, **0 failures, 0 errors**

## Stance

Pre-alpha, no shims. Primary lenses CORRECTNESS + GOOD-PRACTICE: adversarial tests that hit the real path (the exact no-op gate branches, a real 3xx through the classification cascade, the façade's hook-resolution + opts-building) rather than restating implementation. No over-engineering; no production changes.
