### PR TITLE
ci: de-flake the jvm-test-quiet gate (rf2-16n94y)

### DIFF
--- a/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
+++ b/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
@@ -90,11 +90,21 @@
 
   The timeout/kill policy lives HERE (rf2-8dfq5j.3) so EVERY subprocess
   test inherits fail-fast behaviour: on expiry the child is force-killed
-  (`destroyForcibly`), the drain threads are interrupted, and the result
+  (`destroyForcibly`) AND then REAPED under a bounded `waitFor` before the
+  helper returns, the drain threads are interrupted, and the result
   carries `:timed-out? true` plus whatever stdout/stderr drained before
   the kill — so an assertion sees a structured failure with command
   context, not a hung suite.  `:exit` is -1 on a timeout (no real exit
-  code).  Pass `timeout-ms` to override the default ceiling."
+  code).  Pass `timeout-ms` to override the default ceiling.
+
+  Why block for the reap (rf2-16n94y): `destroyForcibly` only REQUESTS
+  termination (SIGKILL on *nix) and returns immediately — the OS reaper
+  records the child's exit asynchronously, so a caller that checks
+  `.isAlive` right after the kill can still observe a LIVE process.  That
+  race intermittently reddened the `jvm-test-quiet` CI gate on loaded
+  runners.  Waiting for the reap here makes `:timed-out? true` guarantee a
+  genuinely dead child for every subprocess path, not merely a kill
+  request in flight."
   ([^Process proc] (drain-process proc default-drain-timeout-ms))
   ([^Process proc timeout-ms]
    (let [out-f (future (slurp (.getInputStream proc)))
@@ -103,9 +113,19 @@
      (if done?
        {:exit (.exitValue proc) :out @out-f :err @err-f :timed-out? false}
        (do
-         ;; The child outlived the ceiling — force-kill it and interrupt
-         ;; the drain threads so neither this helper nor the futures hang.
+         ;; The child outlived the ceiling — force-kill it, then BLOCK on a
+         ;; bounded `waitFor` until it is actually reaped.  `destroyForcibly`
+         ;; is asynchronous: it returns before the OS reaper records the
+         ;; exit, so without this wait a caller checking `.isAlive` could
+         ;; still see a live process (the rf2-16n94y CI flake).  SIGKILL
+         ;; always terminates, so this returns promptly; the 10s bound is a
+         ;; belt so a pathologically un-reapable child cannot wedge the
+         ;; helper (the caller's own outer deadline is the final guard).
          (.destroyForcibly proc)
+         (.waitFor proc 10000 java.util.concurrent.TimeUnit/MILLISECONDS)
+         ;; The child is dead now, so its pipes are at EOF and the drain
+         ;; futures complete on their own; the cancels are a no-op belt for
+         ;; the rare case a future is still mid-read.
          (future-cancel out-f)
          (future-cancel err-f)
          {:exit       -1


### PR DESCRIPTION
## Root cause

The `jvm-test-quiet` gate (added by #5374 / rf2-jg1ag2) flaked red-on-first-run / green-on-re-run on unrelated PRs (#5375, #5380), taxing every implementation-touching PR. The failing job on #5380 ran only **1m6s** — nowhere near the 15-min budget — so this was never a timeout; it was a single non-deterministic test failure:

```
FAIL in (drain-process-kills-and-flags-a-hanging-child) (test_quiet_runner_contract_test.clj:1080)
a child that never exits is force-killed and flagged timed-out (rf2-8dfq5j.3)
expected: (not (.isAlive proc))
  actual: (not (not true))
```

The subprocess-harness helper `drain-process`, on its timeout branch, force-killed the child with `.destroyForcibly` and returned immediately. `destroyForcibly` only **requests** termination (SIGKILL on \*nix) — the OS reaper records the child's exit **asynchronously**. The test then checks `(.isAlive proc)` right after the drain returns: on a fast/idle machine the reap completes in that window, but on a loaded CI runner it doesn't, so `.isAlive` returns `true` and the assertion reds.

## Fix chosen — and why

Least-risky, coverage-preserving option (brief option (a): fix the specific flaky test's timing once pinned):

- On the timeout branch, block on a **bounded `waitFor`** after `destroyForcibly`, so the child is genuinely **reaped** before the helper returns. `:timed-out? true` now guarantees a dead child for every subprocess path — the helper's docstring already claimed the child "is force-killed", and this makes that observably true.
- 10s bound is a belt against a pathologically un-reapable child (SIGKILL always terminates promptly in practice); the caller's own outer deadline remains the final guard.

**Only the error/timeout branch changes.** The ~24 normal green subprocess spawns take the `done?` path and are completely untouched. So:
- **No coverage lost** — every jg1ag2 contract assertion still runs per-PR.
- **No job-level retry** (would mask future real regressions).
- **No per-PR/nightly split** (the suite already finishes in <1 min).

This is a root-cause fix, not a mitigation.

## Quality gates

Run from `implementation/test-quiet` (foreground):

- `clojure -M:test` — **green x3** after fix: `Ran 27 tests containing 98 assertions. 0 failures, 0 errors.` (~49-56s each; baseline pre-fix was also 27/98).
- Previously-flaky test in isolation (`-v …/drain-process-kills-and-flags-a-hanging-child`) — **green x5**, all 4 assertions pass.
- No YAML edited — this is a pure test-harness correctness fix.

## Stance

Pre-alpha, no shims. Correctness + good-practice: eliminates the async-kill race at its source in the shared drain primitive rather than papering over it with a retry.