### PR TITLE
test(pair-mcp): freshness-form parse + real cursor-failure paths + corpus completeness (rf2-nwgaxu +2)

### DIFF
--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
@@ -60,9 +60,10 @@
   without compiling a runtime or opening a socket. The TEST corpus
   pins SHAPE, not runtime semantics — the framework's own fixtures
   pin the runtime semantics."
-  (:require [cljs.test :refer-macros [deftest is async]]
+  (:require [cljs.test :refer-macros [deftest is testing async]]
             [cljs.reader :as edn]
             [clojure.string :as str]
+            [clojure.set :as set]
             [applied-science.js-interop :as j]
             [re-frame2-pair-mcp.cache :as cache]
             [re-frame2-pair-mcp.nrepl :as nrepl]
@@ -70,6 +71,7 @@
             [re-frame2-pair-mcp.tools :as tools]
             [re-frame2-pair-mcp.tools.eval-cljs :as eval-cljs]
             [re-frame2-pair-mcp.tools.raw-state :as raw-state]
+            [re-frame2-pair-mcp.tools.registry :as registry]
             [re-frame2-pair-mcp.tools.writes :as writes]))
 
 ;; ---------------------------------------------------------------------------
@@ -1644,6 +1646,217 @@
                          :abuse-window {:count 0 :threshold 50 :tripped? false}}
      :edn-contains-keys #{:config :rate-limit :cross-check}}}
 
+   ;; ---------- orient ----------------------------------------------------
+   ;; The first-contact app-shape summary. One nREPL round-trip
+   ;; (`re-frame2-pair.runtime/orient`); the tool echoes the resolved
+   ;; `:build` and degrades a blank/non-map eval to `:unexpected-shape`
+   ;; (isError) rather than a null.
+   {:fixture/id    :orient/happy
+    :fixture/doc   "orient forwards the runtime's app-shape summary map with the resolved :build echoed."
+    :fixture/tool  "orient"
+    :fixture/args  {}
+    :fixture/eval-script
+    [["__re_frame2_pair_runtime"  true]
+     [:default                    {:ok?    true
+                                   :frames {:all [:rf/default] :app [:rf/default] :operating :rf/default}
+                                   :registry {:counts {:event 3 :sub 2 :fx 1}
+                                              :events [:counter/inc] :subs [:counter/value] :fx [:http]}}]]
+    :fixture/expect
+    {:isError? false
+     :edn-submap {:ok? true :build :app}
+     :edn-contains-keys #{:frames :registry}}}
+
+   {:fixture/id    :orient/blank-eval-unexpected-shape
+    :fixture/doc   "orient on a blank/non-map eval (dropped WebSocket / navigated tab) rides :unexpected-shape (isError:true), never a null structuredContent."
+    :fixture/tool  "orient"
+    :fixture/args  {}
+    :fixture/eval-script
+    [["__re_frame2_pair_runtime"  true]
+     [:default                    nil]]
+    :fixture/expect
+    {:isError? true
+     :edn-submap {:ok? false :reason :unexpected-shape}}}
+
+   ;; ---------- read-sub --------------------------------------------------
+   ;; Validated one-shot subscription read (signalled prelude — the
+   ;; configure-raw-state! tap posture rides first, then read-sub!).
+   {:fixture/id    :read-sub/happy
+    :fixture/doc   "read-sub forwards the runtime read-sub! hit — :ok? true :value <elided> with :elision echoed."
+    :fixture/tool  "read-sub"
+    :fixture/allow-raw-state? false
+    :fixture/args  {:sub "[:counter/value]"}
+    :fixture/eval-script
+    [["__re_frame2_pair_runtime"  true]
+     ["configure-raw-state!"      nil]
+     ["read-sub!"                 {:ok? true :query-v [:counter/value] :frame :rf/default :value 42}]
+     [:default                    nil]]
+    :fixture/eval-form-must-contain
+    ["read-sub!"]
+    :fixture/expect
+    {:isError? false
+     :edn-submap {:ok? true :value 42}}}
+
+   {:fixture/id    :read-sub/missing-sub
+    :fixture/doc   "read-sub without :sub short-circuits on :missing-sub before any nREPL round-trip."
+    :fixture/tool  "read-sub"
+    :fixture/args  {}
+    :fixture/eval-script
+    [[:default nil]]
+    :fixture/expect
+    {:isError? true
+     :reason :missing-sub}}
+
+   ;; ---------- read-ui ---------------------------------------------------
+   ;; Typed ui/read — view-plane content + producing entity. The runtime
+   ;; fn always returns a map, projected via map-result-or-blank.
+   {:fixture/id    :read-ui/happy
+    :fixture/doc   "read-ui forwards the runtime ui-read envelope (content + entity) with the resolved :build echoed."
+    :fixture/tool  "read-ui"
+    :fixture/args  {:selector "#app .counter"}
+    :fixture/eval-script
+    [["__re_frame2_pair_runtime"  true]
+     ["ui-read"                   {:ok? true :via :selector
+                                   :entity {:view-id :my.app/counter :render-key 3 :subs-read [[:counter/value]]}
+                                   :content {:tag "div" :text "Count: 3" :attrs {"class" "counter"}}}]
+     [:default                    nil]]
+    :fixture/eval-form-must-contain
+    ["re-frame2-pair.runtime/ui-read"]
+    :fixture/expect
+    {:isError? false
+     :edn-submap {:ok? true :via :selector}
+     :edn-contains-keys #{:entity :content}}}
+
+   {:fixture/id    :read-ui/no-target-arg
+    :fixture/doc   "read-ui with no entry point (view-id/point/selector) short-circuits on :no-target-arg before any nREPL round-trip."
+    :fixture/tool  "read-ui"
+    :fixture/args  {}
+    :fixture/eval-script
+    [[:default nil]]
+    :fixture/expect
+    {:isError? true
+     :reason :no-target-arg}}
+
+   ;; ---------- describe-image --------------------------------------------
+   ;; EP-0023 forward read of a frame's resolved image generation. Routes
+   ;; through map-envelope-result — the isError-contract ratchet (rf2-01jwrq).
+   {:fixture/id    :describe-image/happy
+    :fixture/doc   "describe-image forwards the runtime's frame-generation summary (:images/:kinds/:counts)."
+    :fixture/tool  "describe-image"
+    :fixture/args  {:frame ":rf/default"}
+    :fixture/eval-script
+    [["__re_frame2_pair_runtime"  true]
+     ["describe-image"            {:ok? true :frame :rf/default
+                                   :images [:app] :kinds [:event :sub]
+                                   :counts {:event 3 :sub 2}}]
+     [:default                    nil]]
+    :fixture/expect
+    {:isError? false
+     :edn-submap {:ok? true :frame :rf/default}
+     :edn-contains-keys #{:images :kinds :counts}}}
+
+   {:fixture/id    :describe-image/ambiguous-frame-iserror
+    :fixture/doc   "describe-image surfaces the runtime's {:ok? false :reason :ambiguous-frame} as an isError envelope (map-envelope-result — every :ok? false is isError; rf2-01jwrq)."
+    :fixture/tool  "describe-image"
+    :fixture/args  {}
+    :fixture/eval-script
+    [["__re_frame2_pair_runtime"  true]
+     ["describe-image"            {:ok? false :reason :ambiguous-frame
+                                   :frames [:rf/default :stories]}]
+     [:default                    nil]]
+    :fixture/expect
+    {:isError? true
+     :edn-submap {:ok? false :reason :ambiguous-frame}}}
+
+   ;; ---------- record ----------------------------------------------------
+   ;; Installs a background signal recorder (signalled prelude). Returns a
+   ;; :recording-id immediately; routes through map-envelope-result.
+   {:fixture/id    :record/happy
+    :fixture/doc   "record installs the recorder and forwards the runtime's {:ok? true :recording-id …}."
+    :fixture/tool  "record"
+    :fixture/allow-raw-state? false
+    :fixture/args  {:signals "[{:focus true}]"}
+    :fixture/eval-script
+    [["__re_frame2_pair_runtime"  true]
+     ["configure-raw-state!"      nil]
+     ["start-recording!"          {:ok? true :recording-id "rec-abc" :status :recording}]
+     [:default                    nil]]
+    :fixture/eval-form-must-contain
+    ["re-frame2-pair.runtime/start-recording!"]
+    :fixture/expect
+    {:isError? false
+     :edn-submap {:ok? true}
+     :edn-contains-keys #{:recording-id}}}
+
+   {:fixture/id    :record/no-signals
+    :fixture/doc   "record without :signals short-circuits on :no-signals before any nREPL round-trip."
+    :fixture/tool  "record"
+    :fixture/args  {}
+    :fixture/eval-script
+    [[:default nil]]
+    :fixture/expect
+    {:isError? true
+     :reason :no-signals}}
+
+   ;; ---------- read-recording --------------------------------------------
+   ;; Reads back a recording's change-log; map-envelope-result routes the
+   ;; :no-such-recording refusal as isError (rf2-5m2oi1).
+   {:fixture/id    :read-recording/happy
+    :fixture/doc   "read-recording forwards the runtime change-log envelope (:ok? true :count :entries)."
+    :fixture/tool  "read-recording"
+    :fixture/args  {:recording-id "rec-abc"}
+    :fixture/eval-script
+    [["__re_frame2_pair_runtime"  true]
+     ["re-frame2-pair.runtime/read-recording"
+      {:ok? true :recording-id "rec-abc" :status :stopped :count 2 :entries []}]
+     [:default                    nil]]
+    :fixture/expect
+    {:isError? false
+     :edn-submap {:ok? true :recording-id "rec-abc" :count 2}}}
+
+   {:fixture/id    :read-recording/no-such-recording-iserror
+    :fixture/doc   "read-recording of an unknown/expired id surfaces {:ok? false :reason :no-such-recording} as isError (rf2-5m2oi1 — never a green result hiding a buried :ok? false)."
+    :fixture/tool  "read-recording"
+    :fixture/args  {:recording-id "rec-gone"}
+    :fixture/eval-script
+    [["__re_frame2_pair_runtime"  true]
+     ["re-frame2-pair.runtime/read-recording"
+      {:ok? false :reason :no-such-recording :recording-id "rec-gone"}]
+     [:default                    nil]]
+    :fixture/expect
+    {:isError? true
+     :edn-submap {:ok? false :reason :no-such-recording :recording-id "rec-gone"}}}
+
+   ;; ---------- watch-until -----------------------------------------------
+   ;; Server-polls a compiled predicate until it holds or times out. The
+   ;; happy fixture makes the FIRST poll hold so it resolves immediately
+   ;; (no setTimeout, no real wait).
+   {:fixture/id    :watch-until/held-on-first-poll
+    :fixture/doc   "watch-until resolves {:ok? true :held? true …} on the first poll where the predicate holds."
+    :fixture/tool  "watch-until"
+    :fixture/allow-raw-state? false
+    :fixture/args  {:signals "[{:app-db [:upload :status]}]"
+                    :pred "{:signal 0 :equals :done}"}
+    :fixture/eval-script
+    [["__re_frame2_pair_runtime"  true]
+     ["configure-raw-state!"      nil]
+     ["sample-signals"            {:held? true :sample {0 :done} :t 5}]
+     [:default                    nil]]
+    :fixture/eval-form-must-contain
+    ["re-frame2-pair.runtime/sample-signals"]
+    :fixture/expect
+    {:isError? false
+     :edn-submap {:ok? true :held? true}}}
+
+   {:fixture/id    :watch-until/no-signals
+    :fixture/doc   "watch-until without :signals short-circuits on :no-signals before any nREPL round-trip."
+    :fixture/tool  "watch-until"
+    :fixture/args  {}
+    :fixture/eval-script
+    [[:default nil]]
+    :fixture/expect
+    {:isError? true
+     :reason :no-signals}}
+
    ;; ---------- pipeline: unknown tool ------------------------------------
    {:fixture/id    :pipeline/unknown-tool
     :fixture/doc   "invoke against a name not in the registry returns :unknown-tool error carrying a recovery :hint + the :available-tools catalogue (rf2-tkmik)."
@@ -1791,3 +2004,41 @@
                          (count failed) " failed."))
                 (cache/clear!)
                 (done))))))))
+
+;; ---------------------------------------------------------------------------
+;; Completeness guard (rf2-e5x5gd).
+;;
+;; The corpus ns docstring calls THIS namespace the cross-tool wire-shape
+;; RATCHET that pins, "for EACH MCP tool", the envelope tools/invoke
+;; produces — its whole point is catching cross-tool vocabulary renames
+;; that slip past the per-tool unit suites. But there was NO structural
+;; guard that every registered tool actually HAS a fixture, so 7 tools
+;; (orient / read-sub / read-ui / record / read-recording / watch-until /
+;; describe-image) drifted out of the corpus silently — three of them
+;; (describe-image / record / read-recording) carry recent isError-contract
+;; fixes the corpus is supposed to ratchet.
+;;
+;; This mirrors onboarding_catalogue_test's registered-tools coverage
+;; assertion: every `registry/tool-names` entry MUST own >=1 corpus
+;; fixture. A newly-registered tool with no fixture now fails HERE at
+;; compile-authoring time instead of escaping the ratchet.
+;;
+;; NB: unlike onboarding_catalogue_test we do NOT assert the reverse
+;; (no phantom fixture tools) — the corpus deliberately carries a
+;; `no-such-tool` fixture for the :unknown-tool pipeline path, which is
+;; not (and must not be) a registered tool.
+;; ---------------------------------------------------------------------------
+
+(deftest conformance-corpus-covers-every-registered-tool
+  (testing "every registered tool has at least one conformance corpus fixture"
+    (let [covered    (set (map :fixture/tool corpus))
+          registered (set registry/tool-names)
+          missing    (set/difference registered covered)]
+      (is (empty? missing)
+          (str "registered tools with NO conformance corpus fixture: "
+               (sort missing)
+               " — add at least a happy + one-error fixture for each. The "
+               "corpus is the cross-tool isError/vocabulary ratchet 'for "
+               "EACH MCP tool'; an uncovered tool escapes it silently. "
+               "Mirror an existing same-shape fixture (see the per-tool "
+               "sections above).")))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/freshness_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/freshness_test.cljs
@@ -10,6 +10,9 @@
   The load-bearing case is `:stale-build`: a build whose last flush is
   newer than the moment the browser code loaded."
   (:require [cljs.test :refer-macros [deftest is async]]
+            [cljs.reader]
+            [re-frame2-pair-mcp.nrepl :as nrepl]
+            [re-frame2-pair-mcp.test-utils :as tu]
             [re-frame2-pair-mcp.tools.freshness :as fresh]))
 
 ;; ---------------------------------------------------------------------------
@@ -357,3 +360,174 @@
           (.then (fn [half]
                    (is (nil? half) "no socket ⇒ nil, never a TCP connect")
                    (done)))))))
+
+;; ---------------------------------------------------------------------------
+;; build-state-jvm-form + jvm-build-freshness-once — the JVM half END TO END
+;; on a SUCCESS response (rf2-nwgaxu).
+;;
+;; Every `assemble` test above stubs `fresh/jvm-build-freshness` WHOLESALE
+;; (`with-jvm-half!`), and the `retry-once-on-nil` tests drive a pure thunk
+;; — so the ACTUAL JVM-side form (`build-state-jvm-form`) and the round-trip
+;; that emits + parses it (`jvm-build-freshness-once`) are NEVER exercised
+;; on a success-shaped response. A malformed form — an unbalanced paren, a
+;; fat-fingered token from a bad string concat, a shape that no longer reads
+;; back the four documented keys — would stay GREEN because nothing proves
+;; the form PARSES or that a realistic JVM payload lands as the
+;; {:compile-cycle :build-flushed-at :runtime-count :heartbeat-age-ms} map.
+;;
+;; These drive the REAL public `fresh/jvm-build-freshness` (threading
+;; through the private `jvm-build-freshness-once` + `build-state-jvm-form`)
+;; against a socket-bearing conn and a stubbed `nrepl/jvm-eval`, so BOTH the
+;; form emission AND the value parse run for real. `jvm-eval` is stubbed to
+;; capture the emitted form AND to answer with a realistic success payload —
+;; mirroring `port_to_build_test`'s approach for its sibling JVM form
+;; (`port->build-jvm-form`), which build-state-jvm-form previously lacked.
+;; ---------------------------------------------------------------------------
+
+(defn- socket-conn
+  "A conn-atom that PASSES `conn-has-socket?` (a live, non-closed socket),
+  so `jvm-build-freshness` runs the real JVM round-trip instead of
+  short-circuiting to nil. The socket value is inert — the round-trip is
+  stubbed at `nrepl/jvm-eval`."
+  []
+  (atom {:socket :fake-live-socket :closed? false}))
+
+(deftest jvm-build-freshness-emits-a-parseable-well-formed-form
+  ;; The parse ratchet: the build-state form the REAL jvm-build-freshness
+  ;; emits MUST read back as a single well-formed `(try ...)` s-expression.
+  ;; A malformed form (unbalanced parens / a mangled token from a bad string
+  ;; concat) throws in `cljs.reader/read-string` here instead of silently
+  ;; staying green behind the wholesale stub.
+  (async done
+    (let [seen (atom nil)
+          orig nrepl/jvm-eval
+          payload {:compile-cycle 3 :build-flushed-at 100 :runtime-count 1 :heartbeat-age-ms 20}
+          stub (fn
+                 ([_c form] (reset! seen form)
+                            (js/Promise.resolve {:value (pr-str payload)}))
+                 ([_c form _o] (reset! seen form)
+                               (js/Promise.resolve {:value (pr-str payload)})))]
+      (set! nrepl/jvm-eval stub)
+      (-> (fresh/jvm-build-freshness (socket-conn) :app)
+          (.then
+            (fn [_]
+              (let [form @seen]
+                (is (string? form) "the real jvm-build-freshness emitted a JVM form")
+                ;; Substring-pin the shadow internals the form reaches into
+                ;; (mirrors port_to_build_test's substring pins on its form).
+                (is (re-find #"shadow\.cljs\.devtools\.server\.runtime/get-instance!" form))
+                (is (re-find #"shadow\.cljs\.devtools\.server\.supervisor/get-worker" form))
+                (is (re-find #":build-state" form))
+                (is (re-find #":shadow\.build/build-info" form))
+                (is (re-find #":compile-cycle" form))
+                (is (re-find #":flush-complete" form))
+                (is (re-find #":runtimes" form))
+                (is (re-find #":last-pong" form))
+                (is (re-find #"System/currentTimeMillis" form))
+                (is (re-find #"catch Throwable" form)
+                    "the form is defended so a missing worker collapses to nil, not a throw")
+                (is (re-find #"get-worker sup :app" form)
+                    "the build-id is rendered as its :app keyword literal")
+                ;; THE PARSE RATCHET: the emitted form reads back as ONE
+                ;; well-formed (try (let ...) (catch ...)) s-expression.
+                ;; read-string THROWS on an unbalanced / mangled form.
+                (let [parsed (cljs.reader/read-string form)]
+                  (is (seq? parsed) "the emitted form parses as a single s-expression")
+                  (is (= 'try (first parsed))
+                      "the form is the defended (try (let ...) (catch ...)) shape")))
+              nil))
+          (.finally (fn [] (tu/restore-jvm-eval! stub orig)))
+          (.then (fn [_] (done)))))))
+
+(deftest jvm-build-freshness-renders-a-namespaced-build-id-literal
+  ;; The bid rendering branch for a namespaced keyword build-id — the real
+  ;; caller (`assemble`) passes keyword build-ids like :examples/machine-epochs.
+  (async done
+    (let [seen (atom nil)
+          orig nrepl/jvm-eval
+          stub (fn
+                 ([_c form] (reset! seen form) (js/Promise.resolve {:value "nil"}))
+                 ([_c form _o] (reset! seen form) (js/Promise.resolve {:value "nil"})))]
+      (set! nrepl/jvm-eval stub)
+      (-> (fresh/jvm-build-freshness (socket-conn) :examples/machine-epochs)
+          (.then
+            (fn [_]
+              (is (re-find #"get-worker sup :examples/machine-epochs" @seen)
+                  "a namespaced build-id rides as its full keyword literal")
+              ;; Still a parseable (try ...) form for the namespaced id.
+              (is (= 'try (first (cljs.reader/read-string @seen))))
+              nil))
+          (.finally (fn [] (tu/restore-jvm-eval! stub orig)))
+          (.then (fn [_] (done)))))))
+
+(deftest jvm-build-freshness-parses-a-success-payload-into-the-documented-shape
+  ;; A realistic JVM success payload must parse back into the four
+  ;; documented keys — proving `jvm-build-freshness-once`'s
+  ;; `(some-> (:value resp) cljs.reader/read-string)` + `map?` guard read
+  ;; the emitted form's return shape, not a degraded nil.
+  (async done
+    (let [payload {:compile-cycle 12 :build-flushed-at 1699999999999
+                   :runtime-count 2 :heartbeat-age-ms 42}
+          orig nrepl/jvm-eval
+          stub (fn
+                 ([_c _form] (js/Promise.resolve {:value (pr-str payload)}))
+                 ([_c _form _o] (js/Promise.resolve {:value (pr-str payload)})))]
+      (set! nrepl/jvm-eval stub)
+      (-> (fresh/jvm-build-freshness (socket-conn) :app)
+          (.then
+            (fn [half]
+              (is (map? half) "a success payload parses back to a map (not nil-degraded)")
+              (is (= payload half) "the four documented keys round-trip verbatim")
+              (is (= 12 (:compile-cycle half)))
+              (is (= 1699999999999 (:build-flushed-at half)))
+              (is (= 2 (:runtime-count half)))
+              (is (= 42 (:heartbeat-age-ms half)))
+              nil))
+          (.finally (fn [] (tu/restore-jvm-eval! stub orig)))
+          (.then (fn [_] (done)))))))
+
+(deftest jvm-build-freshness-blank-value-degrades-to-nil
+  ;; A blank/non-map JVM value (a socket hiccup, an old shadow) must degrade
+  ;; to nil through the REAL once + retry so the caller sees :liveness
+  ;; :unknown — driven end-to-end, not via the pure-thunk retry tests.
+  (async done
+    (let [orig nrepl/jvm-eval
+          stub (fn
+                 ([_c _form] (js/Promise.resolve {:value ""}))
+                 ([_c _form _o] (js/Promise.resolve {:value ""})))]
+      (set! nrepl/jvm-eval stub)
+      (-> (fresh/jvm-build-freshness (socket-conn) :app)
+          (.then (fn [half]
+                   (is (nil? half) "a blank value ⇒ nil (a non-map read degrades, never throws)")
+                   nil))
+          (.finally (fn [] (tu/restore-jvm-eval! stub orig)))
+          (.then (fn [_] (done)))))))
+
+(deftest assemble-drives-the-real-jvm-half-end-to-end
+  ;; The fullest ratchet: `assemble` WITHOUT stubbing jvm-build-freshness —
+  ;; only `nrepl/jvm-eval` is stubbed — so the real `build-state-jvm-form`
+  ;; is emitted, the real round-trip parses a realistic success payload, and
+  ;; the parsed half drives the liveness verdict. A malformed form or a
+  ;; shape drift would surface as a WRONG verdict / a dropped field HERE,
+  ;; not as a green wholesale stub.
+  (async done
+    (let [;; flush (500) < load (1000) ⇒ :fresh; runtime connected, hb recent.
+          payload {:compile-cycle 9 :build-flushed-at 500
+                   :runtime-count 1 :heartbeat-age-ms 100}
+          orig nrepl/jvm-eval
+          stub (fn
+                 ([_c _form] (js/Promise.resolve {:value (pr-str payload)}))
+                 ([_c _form _o] (js/Promise.resolve {:value (pr-str payload)})))]
+      (set! nrepl/jvm-eval stub)
+      (-> (fresh/assemble (socket-conn) :app browser-half)
+          (.then
+            (fn [token]
+              (is (= 9 (:compile-cycle token)) "the REAL JVM half's compile-cycle merged in")
+              (is (= 500 (:build-flushed-at token)))
+              (is (= 1 (:runtime-count token)))
+              (is (= :fresh (:liveness token))
+                  "load (1000) > flush (500), runtime connected ⇒ :fresh via the REAL form")
+              (is (nil? (:hint token)) "a fresh verdict carries no hint")
+              nil))
+          (.finally (fn [] (tu/restore-jvm-eval! stub orig)))
+          (.then (fn [_] (done)))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/trace_window_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/trace_window_test.cljs
@@ -26,6 +26,7 @@
             [clojure.string :as str]
             [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.test-utils :as tu]
+            [re-frame2-pair-mcp.tools.cursor :as cursor]
             [re-frame2-pair-mcp.tools.trace-window :as tw]))
 
 ;; ---------------------------------------------------------------------------
@@ -223,3 +224,91 @@
                                (is (not (contains? edn :advisory))
                                    "advisory should NOT fire when count > 0")
                                (done))))))))))))
+
+;; ---------------------------------------------------------------------------
+;; Cursor paths driven through the REAL trace-window-tool (rf2-j9i3vh).
+;;
+;; Three gaps closed: the MALFORMED-:cursor short-circuit
+;; (trace_window.cljs L71-73), the AGED-OUT branch (L136-139), and — the
+;; asymmetry the bead flagged — trace-window-tool's OWN :next-cursor mint
+;; (L148-154). cursor_pagination_test only ever asserted the slice/mint
+;; logic against a HAND-REIMPLEMENTED copy (`runtime-form-output`); these
+;; drive the actual `trace-window-tool` so a divergence between the real
+;; emitted envelope and the reimplementation can no longer stay green.
+;; ---------------------------------------------------------------------------
+
+(deftest malformed-cursor-returns-cursor-stale
+  (testing "a garbage :cursor short-circuits to the :rf.mcp/cursor-stale envelope before any runtime eval"
+    (async done
+      ;; No eval stub: the malformed branch returns before the runtime
+      ;; round-trip, so an unstubbed socket call would fail the test if it
+      ;; regressed to fall through.
+      (-> (tw/trace-window-tool nil (tu/args->js {:cursor "AAAA"}))
+          (.then (fn [result]
+                   (is (true? (tu/error? result)) "a malformed cursor rides isError")
+                   (let [edn (tu/extract-edn result)]
+                     (is (false? (:ok? edn)))
+                     (is (= :rf.mcp/cursor-stale (:reason edn)))
+                     (is (= "trace-window" (:tool edn)))
+                     (is (string? (:hint edn))))
+                   (done)))))))
+
+(deftest aged-out-ring-returns-cursor-stale
+  (testing ":id-aged-out? true from the runtime trips the cursor-stale envelope through the real tool"
+    (async done
+      (let [script [["__re_frame2_pair_runtime" true]
+                    [:default                    {:epochs        []
+                                                  :id-aged-out?  true
+                                                  :requested-id  :epoch-7
+                                                  :head-id       :epoch-57
+                                                  :next-id       nil
+                                                  :history-count 50
+                                                  :remaining     0}]]]
+        (-> (with-substr-eval! script
+              (fn []
+                (-> (tw/trace-window-tool nil (tu/args->js {:ms 1000}))
+                    (.then (fn [result]
+                             (is (true? (tu/error? result)))
+                             (let [edn (tu/extract-edn result)]
+                               (is (false? (:ok? edn)))
+                               (is (= :rf.mcp/cursor-stale (:reason edn)))
+                               (is (= "trace-window" (:tool edn)))
+                               (is (= :epoch-7 (:requested-id edn)))
+                               (is (= :epoch-57 (:head-id edn))))
+                             (done)))))))))))
+
+(deftest next-cursor-mint-encodes-sticky-window-and-frame
+  (testing "the REAL trace-window-tool mints a :next-cursor that decodes to the sticky :after-id / :ms / :frame"
+    (async done
+      (let [ring   [{:epoch-id :e1 :committed-at 100}
+                    {:epoch-id :e2 :committed-at 200}]
+            script [["__re_frame2_pair_runtime" true]
+                    [:default {:epochs        ring
+                               :id-aged-out?  false
+                               :requested-id  nil
+                               :head-id       :e3
+                               ;; page short of the full slice ⇒ mint a cursor
+                               :next-id       :e2
+                               :history-count 3
+                               :remaining     1}]]]
+        (-> (with-substr-eval! script
+              (fn []
+                (-> (tw/trace-window-tool nil (tu/args->js {:ms 5000 :frame ":rf/default"}))
+                    (.then (fn [result]
+                             (let [edn         (tu/extract-edn result)
+                                   next-cursor (:next-cursor edn)
+                                   decoded     (cursor/decode-cursor next-cursor)]
+                               (is (true? (:ok? edn)))
+                               (is (true? (:has-more? edn)) "a next-id ⇒ has-more?")
+                               (is (some? next-cursor) "the real tool minted a continuation cursor")
+                               (is (not= :re-frame2-pair-mcp.tools.cursor/malformed decoded)
+                                   "the minted cursor round-trips (not malformed)")
+                               (is (= :e2 (:after-id decoded))
+                                   "the cursor resumes after the last emitted epoch id")
+                               (is (= 5000 (:ms decoded))
+                                   "the sticky :ms window rides the cursor for page 2")
+                               (is (= :rf/default (:frame decoded))
+                                   "the sticky frame rides the cursor")
+                               (is (number? (:until-ms decoded))
+                                   "the first-call clock is pinned so page 2 sees the same window"))
+                             (done)))))))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/watch_epochs_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/watch_epochs_test.cljs
@@ -152,3 +152,62 @@
                                (is (= 1 (:count edn)))
                                (is (not (contains? edn :advisory)))
                                (done))))))))))))
+
+;; ---------------------------------------------------------------------------
+;; Cursor-failure paths driven through the REAL watch-epochs-tool
+;; (rf2-j9i3vh).
+;;
+;; The cursor-stale branches — a MALFORMED :cursor (watch_epochs.cljs L73)
+;; and an AGED-OUT ring id (L136-141) — were previously exercised ONLY
+;; against a HAND-REIMPLEMENTED copy of the server-side slice logic in
+;; cursor_pagination_test (`runtime-form-output`). A divergence in the REAL
+;; tool's emitted envelope / branch condition would stay green. These feed
+;; a garbage :cursor and a canned {:id-aged-out? true} runtime response
+;; through the actual `watch-epochs-tool` and assert the
+;; :rf.mcp/cursor-stale envelope it returns.
+;; ---------------------------------------------------------------------------
+
+(deftest malformed-cursor-returns-cursor-stale
+  (testing "a garbage :cursor short-circuits to the :rf.mcp/cursor-stale envelope BEFORE any runtime eval"
+    (async done
+      ;; No eval stub installed on purpose: the malformed-cursor branch
+      ;; returns before probe/eval-after-runtime!, so it must NOT touch the
+      ;; socket. If the branch regressed and fell through to the eval, the
+      ;; unstubbed nrepl call would reject and the assertions would fail.
+      (-> (we/watch-epochs-tool nil (tu/args->js {:cursor "not-a-valid-cursor!!!"}))
+          (.then (fn [result]
+                   (is (true? (tu/error? result)) "a malformed cursor rides isError")
+                   (let [edn (tu/extract-edn result)]
+                     (is (false? (:ok? edn)))
+                     (is (= :rf.mcp/cursor-stale (:reason edn))
+                         "a malformed cursor maps to the same stale reason as an age-out")
+                     (is (= "watch-epochs" (:tool edn)))
+                     (is (string? (:hint edn))))
+                   (done)))))))
+
+(deftest aged-out-ring-returns-cursor-stale
+  (testing "an :id-aged-out? true runtime response with a live :since-id trips the cursor-stale envelope"
+    (async done
+      (let [script [["__re_frame2_pair_runtime" true]
+                    [:default                    {:matches       []
+                                                  :id-aged-out?  true
+                                                  :requested-id  :epoch-99
+                                                  :head-id       :epoch-149
+                                                  :next-id       nil
+                                                  :history-count 50
+                                                  :since-count   0
+                                                  :remaining     0}]]]
+        (-> (with-substr-eval! script
+              (fn []
+                (-> (we/watch-epochs-tool nil (tu/args->js {:since-id ":epoch-99"}))
+                    (.then (fn [result]
+                             (is (true? (tu/error? result)) "an aged-out ring id rides isError")
+                             (let [edn (tu/extract-edn result)]
+                               (is (false? (:ok? edn)))
+                               (is (= :rf.mcp/cursor-stale (:reason edn)))
+                               (is (= "watch-epochs" (:tool edn)))
+                               (is (= :epoch-99 (:requested-id edn))
+                                   "the requested id rides back so the agent sees what aged out")
+                               (is (= :epoch-149 (:head-id edn))
+                                   "the current head rides back for a rewind")
+                               (done))))))))))))


### PR DESCRIPTION
Closes three review-campaign test-gap beads in `tools/re-frame2-pair-mcp` (test-only; no production edits).

## rf2-nwgaxu — freshness JVM-form parse ratchet
`build-state-jvm-form` + `jvm-build-freshness-once` were never exercised end-to-end on a success response (`assemble` stubbed `jvm-build-freshness` wholesale; the retry tests drove a pure thunk), so a malformed form could stay green. New tests drive the REAL public `jvm-build-freshness` (through the private once + form) against a socket-bearing conn with a stubbed `nrepl/jvm-eval`: substring-pin the shadow internals + build-id literal, `read-string` the emitted form to assert a single well-formed `(try (let ...) (catch ...))` s-expression, parse a realistic success payload into the four documented keys, degrade a blank value to nil, and drive `assemble` end-to-end (only `jvm-eval` stubbed) so the real form's parsed output drives the verdict.

**Finding:** the parse ratchet PASSES — the emitted freshness form is well-formed; no malformed form surfaced.

## rf2-j9i3vh — cursor-failure paths through the real tool fns
The cursor-stale branches were exercised only against a hand-reimplemented copy of the slice logic. New tests drive the actual `watch-epochs-tool` / `trace-window-tool`: a malformed `:cursor` short-circuits to the `:rf.mcp/cursor-stale` envelope (no runtime eval), an `:id-aged-out? true` response trips cursor-stale (requested-id/head-id ride back), and — the asymmetry the bead flagged — the real `trace-window-tool` `:next-cursor` mint decodes to the sticky `:after-id` / `:ms` / `:frame`.

## rf2-e5x5gd — conformance-corpus completeness guard + 7 fixtures
The corpus omitted 7 of 30 registered tools with no completeness guard. Added a guard mirroring `onboarding_catalogue_test` (every `registry/tool-names` entry must own ≥1 fixture; the reverse phantom check is intentionally omitted for the deliberate `no-such-tool` pipeline fixture) plus minimal happy + one-error fixtures for orient, read-sub, read-ui, record, read-recording, watch-until, describe-image — exercising the isError contract (describe-image `:ambiguous-frame`, read-recording `:no-such-recording`, etc.). Corpus now covers all 30 tools.

## Quality gates (foreground, full)
- `cd tools/re-frame2-pair-mcp && npm test` (shadow compile server-test + node): **1193 tests, 4008 assertions, 0 failures, 0 errors**
- `cd implementation && npm run test:cljs`: **8333 tests, 38351 assertions, 0 failures, 0 errors**

## Stance
Pre-alpha, no shims; CORRECTNESS + GOOD-PRACTICE. Test-only — no production code changed. New tests are adversarial and hit the REAL fns, not reimplemented copies.
