### PR TITLE
test(examples): real-apps pagination + editor-lease-teardown + session-restore coverage (rf2-yt7ay6 +2)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
@@ -37,6 +37,11 @@
             ;; sub, and the `:rf.route/entry-blocked` redirect handler the
             ;; auth-gate tests exercise (rf2-p69yaz).
             [realworld-http.routing]
+            ;; Pagination pure helpers (page->offset / page-count / query-string /
+            ;; paginate-path) exercised directly by the pagination-helpers test
+            ;; (rf2-yt7ay6). The example source stays test-free; the assertions
+            ;; live here.
+            [realworld-http.http :as rh]
             [realworld-http.ssr :as ssr])
   (:require-macros [re-frame.core :refer [with-new-frame]]))
 
@@ -899,6 +904,101 @@
         "the JWT must be redacted from the SSR hydration payload")))
 
 ;; ============================================================================
+;; pagination — pure limit/offset helpers + the page-nav semantics (rf2-yt7ay6)
+;; ============================================================================
+;;
+;; Pagination is flagship Conduit behaviour and was entirely untested. Two
+;; halves: (1) the pure request-building maths (`page->offset` / `page-count` /
+;; `query-string` / `paginate-path` in http.cljs) — clamps and URL-encoding
+;; edges that a hand-typed `?page=0` or a tag with a reserved query character
+;; would otherwise get wrong; and (2) the page-nav events (`:home/show-page` /
+;; `:profile/show-page`) which reset-to-page-1 on a fresh filter but carry the
+;; active feed / tag / route forward when only the page changes.
+
+(defn- pagination-helpers-test []
+  ;; page->offset: 1-indexed UI page → 0-based wire offset, sub-1 clamped to 1.
+  (is (= 0  (rh/page->offset nil)) "nil page clamps to page 1 → offset 0")
+  (is (= 0  (rh/page->offset 0))   "page 0 is not a thing → clamps to offset 0")
+  (is (= 0  (rh/page->offset -5))  "a negative page clamps up to page 1")
+  (is (= 0  (rh/page->offset 1))   "page 1 → offset 0")
+  (is (= 10 (rh/page->offset 2))   "page 2 → offset one page-size in")
+  (is (= 20 (rh/page->offset 3))   "page 3 → offset two page-sizes in")
+
+  ;; page-count: ceil(count / page-size), floored at 1 (an empty list is 1 page).
+  (is (= 1 (rh/page-count nil)) "nil count → 1 page")
+  (is (= 1 (rh/page-count 0))   "empty list is still one (empty) page")
+  (is (= 1 (rh/page-count 10))  "exactly one full page → 1")
+  (is (= 2 (rh/page-count 11))  "one over a full page → 2 pages")
+  (is (= 3 (rh/page-count 25))  "25 items at page-size 10 → 3 pages")
+
+  ;; query-string: nils dropped, empty → "" (never a bare "?"), values encoded.
+  (is (= "" (rh/query-string {})) "empty map yields \"\", not \"?\"")
+  (is (= "" (rh/query-string {:tag nil})) "an all-nil map still yields \"\"")
+  (is (= "?author=jake" (rh/query-string {:tag nil :author "jake"}))
+      "nil-valued params are dropped; the surviving one is emitted")
+  (is (= "?tag=a%20b" (rh/query-string {:tag "a b"}))
+      "a space is URL-encoded (not left raw)")
+  (is (= "?tag=a%26b%3Dc%23d" (rh/query-string {:tag "a&b=c#d"}))
+      "reserved query characters (& = #) are percent-encoded so they can't corrupt the query")
+
+  ;; paginate-path: path + optional filters + the limit/offset window for a page.
+  ;; Multi-key order isn't guaranteed, so assert on the (order-independent) parts.
+  (let [p (rh/paginate-path "/articles" nil 1)]
+    (is (str/starts-with? p "/articles?"))
+    (is (str/includes? p "limit=10"))
+    (is (str/includes? p "offset=0")))
+  (let [p (rh/paginate-path "/articles" {:tag "clojure"} 3)]
+    (is (str/includes? p "tag=clojure") "the filter rides the query")
+    (is (str/includes? p "limit=10"))
+    (is (str/includes? p "offset=20") "page 3 → offset 20")))
+
+(defn- pagination-nav-events-test []
+  (with-new-frame [f (frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
+                                 :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
+    ;; --- :home/show-page carries the active feed forward ---
+    ;; Global feed, then page 3: the home route, no ?feed=, ?page=3.
+    (rf/dispatch-sync [:home/show-global-feed] {:frame f})
+    (rf/dispatch-sync [:home/show-page 3] {:frame f})
+    (is (= :realworld/home (rf/compute-sub [:rf.route/id] (rf/frame-state-value f))))
+    (is (= 3 (:page (rf/compute-sub [:rf.route/query] (rf/frame-state-value f))))
+        "global feed page-nav sets ?page= on the home route")
+    (is (nil? (:feed (rf/compute-sub [:rf.route/query] (rf/frame-state-value f))))
+        "no feed was active, so ?feed= stays absent")
+
+    ;; Following feed, then page 2: the following token is carried forward.
+    (rf/dispatch-sync [:home/show-your-feed] {:frame f})
+    (rf/dispatch-sync [:home/show-page 2] {:frame f})
+    (is (= :realworld/home (rf/compute-sub [:rf.route/id] (rf/frame-state-value f))))
+    (is (= 2 (:page (rf/compute-sub [:rf.route/query] (rf/frame-state-value f)))))
+    (is (= "following" (:feed (rf/compute-sub [:rf.route/query] (rf/frame-state-value f))))
+        "paging the following feed carries ?feed=following forward (you keep paging the same list)")
+
+    ;; --- :home/show-page carries the active tag forward (re-aims at /tag/:tag) ---
+    (rf/dispatch-sync [:tags/apply-filter "clojure"] {:frame f})
+    (rf/dispatch-sync [:home/show-page 2] {:frame f})
+    (is (= :realworld/home-tag (rf/compute-sub [:rf.route/id] (rf/frame-state-value f)))
+        "paging a tag-filtered list re-aims at the /tag/:tag PATH route")
+    (is (= "clojure" (:tag (rf/compute-sub [:rf.route/params] (rf/frame-state-value f))))
+        "the tag param is preserved so paging stays inside the tag")
+    (is (= 2 (:page (rf/compute-sub [:rf.route/query] (rf/frame-state-value f)))))
+
+    ;; --- :profile/show-page stays on the same tab + username, swaps only ?page= ---
+    (rf/dispatch-sync [:rf.route/navigate :realworld.profile/show {:username "eve"}] {:frame f})
+    (rf/dispatch-sync [:profile/show-page 2] {:frame f})
+    (is (= :realworld.profile/show (rf/compute-sub [:rf.route/id] (rf/frame-state-value f)))
+        "profile page-nav stays on the same (authored) tab")
+    (is (= "eve" (:username (rf/compute-sub [:rf.route/params] (rf/frame-state-value f))))
+        "the profile username is unchanged")
+    (is (= 2 (:page (rf/compute-sub [:rf.route/query] (rf/frame-state-value f)))))
+
+    ;; The favorites tab pages independently, still on its own route.
+    (rf/dispatch-sync [:rf.route/navigate :realworld.profile/favorites {:username "eve"}] {:frame f})
+    (rf/dispatch-sync [:profile/show-page 3] {:frame f})
+    (is (= :realworld.profile/favorites (rf/compute-sub [:rf.route/id] (rf/frame-state-value f)))
+        "the favorites tab stays on the favorites route when paging")
+    (is (= 3 (:page (rf/compute-sub [:rf.route/query] (rf/frame-state-value f)))))))
+
+;; ============================================================================
 ;; core — top-level smoke: boots the app, checks per-feature initialisers
 ;; populate the expected slices.
 ;; ============================================================================
@@ -992,6 +1092,12 @@
 (deftest realworld-ssr
   (testing "hydration-payload selects the SSR-safe slice keys"
     (hydration-payload-test)))
+
+(deftest realworld-pagination
+  (testing "pure helpers: page->offset / page-count / query-string / paginate-path edges (rf2-yt7ay6)"
+    (pagination-helpers-test))
+  (testing "page-nav events carry the active feed / tag / route forward (rf2-yt7ay6)"
+    (pagination-nav-events-test)))
 
 (deftest realworld-core-smoke
   (testing "app boot populates :auth, :articles, and :tags slices"

--- a/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
@@ -999,6 +999,65 @@
     (is (= 3 (:page (rf/compute-sub [:rf.route/query] (rf/frame-state-value f)))))))
 
 ;; ============================================================================
+;; auth — session-restore-with-token (the documented "restore stays put"
+;; invariant, previously untested — token-nil tests only hit the :idle no-op)
+;; (rf2-svj926)
+;; ============================================================================
+
+(defn- session-restore-with-token-test []
+  ;; A URL-routed stub: GET /user (and the login POST) return a User envelope;
+  ;; everything else (the deep-link article's on-match reads) returns empty.
+  ;; "/users/login" and "/users" both contain the substring "/user", so this
+  ;; one predicate covers the restore GET and the login POST.
+  (reg-canned-success-by-url! :realworld.test/restore-user
+                              (fn [url]
+                                (if (str/includes? url "/user")
+                                  {:user {:username "alice"
+                                          :email    "alice@example.com"
+                                          :token    "jwt-restore"}}
+                                  {})))
+
+  ;; --- RESTORE STAYS PUT: a cold boot with a saved token restores the session
+  ;;     without navigating (a deep link must survive a refresh) ---
+  (with-new-frame [f (frame/make-anon-frame-record! {:fx-overrides {:rf.http/managed       :realworld.test/restore-user
+                                                    :auth.session/persist :rf/no-op}})]
+    ;; Land on a deep link (a public article), as a refresh would.
+    (rf/dispatch-sync [:rf.route/handle-url-change "/article/some-slug"] {:frame f})
+    (is (= :realworld.article/show (rf/compute-sub [:rf.route/id] (rf/frame-state-value f)))
+        "cold boot lands on the deep-linked article")
+
+    ;; Boot with a saved JWT: the :has-token? guard routes to :begin-restore
+    ;; (NOT the token-nil :idle no-op the pre-existing tests exercised). The
+    ;; canned stub resolves the GET /user synchronously, so the machine settles.
+    (rf/dispatch-sync [:auth/initialise]
+                      {:frame f :rf.cofx {:auth.session/token "jwt-restore"}})
+    (is (= :authed (rf/compute-sub [:auth/state] (rf/frame-state-value f)))
+        "guard true → :begin-restore → :restoring → (GET /user success) → :restore-session → :authed")
+    (is (= "alice" (:username (rf/compute-sub [:auth/user] (rf/frame-state-value f))))
+        "the restored session is stored")
+    (is (= "jwt-restore" (get-in (rf/app-db-value f) [:auth :token]))
+        "the token rode :auth/initialise into durable app-db")
+    ;; THE INVARIANT: restore must NOT navigate — the deep link survives.
+    (is (= :realworld.article/show (rf/compute-sub [:rf.route/id] (rf/frame-state-value f)))
+        "restore stays put — :restore-session does NOT fire :auth/post-login-redirect"))
+
+  ;; --- CONTRAST: an INTERACTIVE login DOES bounce (proves navigation is
+  ;;     observable here, so the restore's non-navigation above is a real
+  ;;     signal, not a harness that simply never navigates) ---
+  (with-new-frame [f (frame/make-anon-frame-record! {:fx-overrides {:rf.http/managed       :realworld.test/restore-user
+                                                    :auth.session/persist :rf/no-op}})]
+    (rf/dispatch-sync [:rf.route/handle-url-change "/article/some-slug"] {:frame f})
+    (rf/dispatch-sync [:auth/initialise]
+                      {:frame f :rf.cofx {:auth.session/token nil}})
+    (is (= :idle (rf/compute-sub [:auth/state] (rf/frame-state-value f)))
+        "no token → the :idle no-op branch (the only path the old tests hit)")
+    (rf/dispatch-sync [:auth/flow [:auth/login {:email "alice@example.com" :password "x"}]]
+                      {:frame f})
+    (is (= :authed (rf/compute-sub [:auth/state] (rf/frame-state-value f))))
+    (is (= :realworld/home (rf/compute-sub [:rf.route/id] (rf/frame-state-value f)))
+        "interactive login bounces home via :store-session → :auth/post-login-redirect")))
+
+;; ============================================================================
 ;; core — top-level smoke: boots the app, checks per-feature initialisers
 ;; populate the expected slices.
 ;; ============================================================================
@@ -1098,6 +1157,10 @@
     (pagination-helpers-test))
   (testing "page-nav events carry the active feed / tag / route forward (rf2-yt7ay6)"
     (pagination-nav-events-test)))
+
+(deftest realworld-session-restore
+  (testing "restore-with-token reaches :authed, stores the session, and does NOT navigate (rf2-svj926)"
+    (session-restore-with-token-test)))
 
 (deftest realworld-core-smoke
   (testing "app boot populates :auth, :articles, and :tags slices"

--- a/implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs
@@ -626,3 +626,64 @@
             "the editor slice is cleared to a blank create draft on delete")
         (is (= :realworld/home (route-id f))
             "a successful delete navigates home")))))
+
+;; ============================================================================
+;; 10. SESSION-RESTORE-WITH-TOKEN — the documented "restore stays put" invariant,
+;;     plus the passive-re-key feed re-ensure (rf2-svj926)
+;; ============================================================================
+
+(deftest session-restore-with-token-stays-put-and-re-ensures-the-feed
+  (testing "examples/real-apps/realworld_resources — a cold boot with a saved token
+            drives :idle → :restoring → :authed via :restore-session, stores the
+            session, re-ensures the session feed under the restored principal (the
+            passive-re-key footgun fix), and does NOT navigate (a deep link must
+            survive a refresh)"
+    (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
+                                       :fx-overrides {:rf.nav/push-url :rf/no-op
+                                                      :realworld-resources.session/persist :rf/no-op}})]
+      ;; Land on a resource-free public route (a deep link stand-in), as a refresh
+      ;; would; assert restore leaves us right here.
+      (rf/dispatch-sync [:rf.route/navigate :realworld.auth/register] {:frame f})
+      (is (= :realworld.auth/register (route-id f)) "cold boot lands on the deep link")
+      ;; Boot WITH a saved token → the :has-token? guard routes to :begin-restore
+      ;; (the actual restore path; the pre-existing tests only pass token nil, which
+      ;; takes the :idle no-op branch).
+      (rf/dispatch-sync [:auth/initialise]
+                        {:frame f :rf.cofx {:realworld-resources.session/token "jwt-restore"}})
+      (is (= :restoring (rf/compute-sub [:auth/state] (state-value f)))
+          "a non-blank token → :begin-restore (GET /user in flight)")
+      ;; the GET /user reply settles the machine
+      (reply-success! @last-managed-args
+                      {:user {:username "alice" :email "alice@example.com" :token "jwt-restore"}}
+                      f)
+      (is (= :authed (rf/compute-sub [:auth/state] (state-value f)))
+          ":auth/success in :restoring → :restore-session → :authed")
+      (is (= "alice" (:username (rf/compute-sub [:auth/user] (state-value f))))
+          "the restored session is stored")
+      (is (= "jwt-restore" (get-in (rf/app-db-value f) [:auth :token]))
+          "the token rode :auth/initialise into durable app-db")
+      ;; THE PASSIVE-RE-KEY FIX: restore re-ensures the feed under the new principal
+      ;; (a `{:from-db :realworld/session}` re-key alone is passive — it won't fetch).
+      (is (some? (entry f (feed-key "alice" 1)))
+          ":restore-session re-ensures the session feed under the restored scope")
+      ;; THE INVARIANT: restore stays put — it does NOT fire :auth/post-login-redirect.
+      (is (= :realworld.auth/register (route-id f))
+          "restore stays put — it does NOT navigate (unlike interactive login)"))
+
+    ;; CONTRAST — an interactive login DOES bounce home, proving navigation is
+    ;; observable in this harness (so the non-navigation above is a real signal).
+    (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
+                                       :fx-overrides {:rf.nav/push-url :rf/no-op
+                                                      :realworld-resources.session/persist :rf/no-op}})]
+      (rf/dispatch-sync [:rf.route/navigate :realworld.auth/login] {:frame f})
+      (rf/dispatch-sync [:auth/initialise]
+                        {:frame f :rf.cofx {:realworld-resources.session/token nil}})
+      (is (= :idle (rf/compute-sub [:auth/state] (state-value f)))
+          "no token → the :idle no-op branch")
+      (rf/dispatch-sync [:auth/flow [:auth/login {:email "alice@example.com" :password "x"}]] {:frame f})
+      (reply-success! @last-managed-args
+                      {:user {:username "alice" :email "alice@example.com" :token "jwt"}}
+                      f)
+      (is (= :authed (rf/compute-sub [:auth/state] (state-value f))))
+      (is (= :realworld/home (route-id f))
+          "interactive login bounces home via :store-session → :auth/post-login-redirect"))))

--- a/implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs
@@ -62,7 +62,11 @@
             [re-frame.trace.tooling :as trace-tooling]
             ;; the example's production source — chains in every feature ns.
             [realworld-resources.core :as core]
-            [realworld-resources.scope :as scope])
+            [realworld-resources.scope :as scope]
+            ;; Pagination pure helpers (page->limit-offset / query-string),
+            ;; exercised directly by the pagination-helpers test (rf2-yt7ay6).
+            [realworld-resources.http :as rrh]
+            [realworld-resources.resources :as rres])
   (:require-macros [re-frame.core :refer [with-new-frame]]))
 
 ;; ============================================================================
@@ -196,6 +200,10 @@
                      {:frame frame})))
 
 (defn- state-value [frame] (rf/frame-state-value frame))
+
+(defn- route-id [frame] (rf/compute-sub [:rf.route/id] (state-value frame)))
+(defn- route-params [frame] (rf/compute-sub [:rf.route/params] (state-value frame)))
+(defn- route-query [frame] (rf/compute-sub [:rf.route/query] (state-value frame)))
 
 ;; ============================================================================
 ;; 1. SESSION-SCOPE RESOLVER — :realworld/session (EP-0016 D3)
@@ -433,3 +441,69 @@
           "the cofx is NOT provided — it is generator-backed (the app supplies it)")
       (is (fn? (:handler-fn cofx-meta))
           "a recordable generator carries a value-returning supplier fn"))))
+
+;; ============================================================================
+;; 8. PAGINATION — pure limit/offset helpers + the page-nav semantics (rf2-yt7ay6)
+;; ============================================================================
+
+(deftest pagination-helpers-are-pure-limit-offset-and-encoded-query
+  (testing "examples/real-apps/realworld_resources — page->limit-offset clamps a
+            nil/sub-1 page to page 1 (the one place page arithmetic lives), and
+            query-string drops nil params, URL-encodes reserved characters, and
+            never emits a bare \"?\""
+    ;; page->limit-offset: 1-indexed page → {:limit :offset}, clamped at page 1.
+    (is (= {:limit 10 :offset 0}  (rres/page->limit-offset nil)) "nil → page 1")
+    (is (= {:limit 10 :offset 0}  (rres/page->limit-offset 0))   "page 0 clamps to page 1")
+    (is (= {:limit 10 :offset 0}  (rres/page->limit-offset -3))  "a negative page clamps to page 1")
+    (is (= {:limit 10 :offset 0}  (rres/page->limit-offset 1))   "page 1 → offset 0")
+    (is (= {:limit 10 :offset 10} (rres/page->limit-offset 2))   "page 2 → offset one page in")
+    (is (= {:limit 10 :offset 20} (rres/page->limit-offset 3))   "page 3 → offset two pages in")
+    ;; query-string: parity with the http sibling — drop nils, encode reserved,
+    ;; empty (or all-nil) → "".
+    (is (= "" (rrh/query-string {})) "empty map yields \"\", not \"?\"")
+    (is (= "" (rrh/query-string {:page nil})) "an all-nil map still yields \"\"")
+    (is (= "?author=jake" (rrh/query-string {:author "jake" :tag nil}))
+        "nil-valued params are dropped")
+    (is (= "?tag=a%20b" (rrh/query-string {:tag "a b"}))
+        "a space is URL-encoded")
+    (is (= "?tag=a%26b%3Dc%23d" (rrh/query-string {:tag "a&b=c#d"}))
+        "reserved query characters (& = #) are percent-encoded")))
+
+(deftest pagination-nav-events-carry-feed-tag-and-drop-page-1
+  (testing "examples/real-apps/realworld_resources — :home/go-to-page and
+            :profile/go-to-page keep the active feed / tag / route + username and
+            swap only ?page=, and page 1 drops the ?page= param (the canonical
+            first-page URL) so page N and N+1 share a filter under distinct keys"
+    (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
+                                       :fx-overrides {:rf.nav/push-url :rf/no-op}})]
+      ;; global feed, page 2 → ?page=2 on the home route
+      (rf/dispatch-sync [:home/show-global-feed] {:frame f})
+      (rf/dispatch-sync [:home/go-to-page 2] {:frame f})
+      (is (= :realworld/home (route-id f)))
+      (is (= 2 (:page (route-query f))) "global feed page 2 sets ?page=2")
+      ;; page 1 drops the param entirely
+      (rf/dispatch-sync [:home/go-to-page 1] {:frame f})
+      (is (nil? (:page (route-query f))) "page 1 drops ?page= (canonical first-page URL)")
+      ;; the following feed is carried forward across a page change
+      (rf/dispatch-sync [:home/show-your-feed] {:frame f})
+      (rf/dispatch-sync [:home/go-to-page 2] {:frame f})
+      (is (= 2 (:page (route-query f))))
+      (is (= "following" (:feed (route-query f)))
+          "paging the following feed carries ?feed=following forward")
+      ;; the tag is carried forward (re-aims at the /tag/:tag PATH route)
+      (rf/dispatch-sync [:home/apply-tag "clojure"] {:frame f})
+      (rf/dispatch-sync [:home/go-to-page 2] {:frame f})
+      (is (= :realworld/home-tag (route-id f)) "paging a tag list re-aims at /tag/:tag")
+      (is (= "clojure" (:tag (route-params f))) "the tag param is preserved")
+      (is (= 2 (:page (route-query f))))
+      (rf/dispatch-sync [:home/go-to-page 1] {:frame f})
+      (is (= :realworld/home-tag (route-id f)) "still on the tag route")
+      (is (nil? (:page (route-query f))) "tag page 1 drops ?page= too")
+      ;; the profile tab pages independently, on its own route + username
+      (rf/dispatch-sync [:rf.route/navigate :realworld.profile/show {:username "eve"}] {:frame f})
+      (rf/dispatch-sync [:profile/go-to-page 3] {:frame f})
+      (is (= :realworld.profile/show (route-id f)) "profile page-nav stays on the same tab")
+      (is (= "eve" (:username (route-params f))) "the username is unchanged")
+      (is (= 3 (:page (route-query f))))
+      (rf/dispatch-sync [:profile/go-to-page 1] {:frame f})
+      (is (nil? (:page (route-query f))) "profile page 1 drops ?page="))))

--- a/implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs
@@ -205,6 +205,26 @@
 (defn- route-params [frame] (rf/compute-sub [:rf.route/params] (state-value frame)))
 (defn- route-query [frame] (rf/compute-sub [:rf.route/query] (state-value frame)))
 
+(defn- owner-index-for
+  "Map the entry-liveness owner-index (keyed on opaque byte key-ids) back to
+   scoped-key vectors, so lease-teardown assertions can read owners in the same
+   `[:lease …]` shape the app mints them. Mirrors the resources-machine-owner-
+   release suite's owner-index helper."
+  [frame]
+  (let [rdb    (runtime-db frame)
+        es     (get-in rdb (state/entries-path))
+        id->sk (into {} (map (fn [[k-id e]] [k-id (:resource/key e)])) es)]
+    (into {} (map (fn [[owner members]]
+                    [owner (into #{} (map #(get id->sk % %)) members)]))
+          (get-in rdb (state/owner-index-path)))))
+
+(defn- gc-recheck!
+  "Fire the GC re-check for a scoped key on `frame` (the timer-fired event).
+   An owner-free, work-free entry is collected; a still-pinned one survives."
+  [frame scoped-key]
+  (rf/dispatch-sync [:rf.resource.internal/gc-fired {:resource/key scoped-key}]
+                    {:frame frame}))
+
 ;; ============================================================================
 ;; 1. SESSION-SCOPE RESOLVER — :realworld/session (EP-0016 D3)
 ;; ============================================================================
@@ -507,3 +527,102 @@
       (is (= 3 (:page (route-query f))))
       (rf/dispatch-sync [:profile/go-to-page 1] {:frame f})
       (is (nil? (:page (route-query f))) "profile page 1 drops ?page="))))
+
+;; ============================================================================
+;; 9. THE EDITOR EDIT-MODE LOAD + LEASE TEARDOWN + DELETE (rf2-hv7eid)
+;; ============================================================================
+;;
+;; The editor's CREATE path is covered above (editor-flow-gates-…). This pins the
+;; recently-changed EDIT path: the read-side `:reply-to` seed-on-load, and the
+;; lease-teardown NO-LEAK property (rf2-kkqy6q). The footgun: `:editor/load-article`
+;; mints an app-owned `[:lease :editor/article slug]` on the article read; every
+;; exit path MUST have a matching release or `N edits → N leaked entries`. edit→save
+;; and edit→leave release via the component unmount (slug still set); the two
+;; slice-blanking paths — edit→NEW (`:editor/initialise`) and edit→DELETE
+;; (`:editor/replied` delete branch) — must release the OUTGOING slug BEFORE they
+;; blank the slice to a nil slug, else the lease orphans and the entry stays pinned
+;; active forever. Asserted in the shape of the machine-owner-release suite
+;; (active-owners empty + owner-index cleared + GC reclaims).
+
+(deftest editor-edit-load-seeds-baseline-then-edit-to-new-releases-lease-and-reclaims
+  (testing "examples/real-apps/realworld_resources — edit-mode entry seeds the draft
+            + baseline from the article read via the ensure's :reply-to
+            [:editor/article-loaded] continuation (rf2-p1yri7), pinning the
+            [:lease :editor/article slug] owner; edit→New Article
+            (:editor/initialise, same re-used component, no unmount) releases that
+            outgoing lease so the article entry is reclaimed (edit→new leaks
+            nothing — rf2-kkqy6q FAIL 1)"
+    (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
+                                       :fx-overrides {:rf.nav/push-url :rf/no-op}})]
+      (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
+      ;; EDIT-MODE ENTRY: navigating to /editor/:slug fires the route's :on-match
+      ;; [[:editor/load-article]], which ensures :realworld/article under the
+      ;; releaseable lease with :reply-to [:editor/article-loaded].
+      (rf/dispatch-sync [:rf.route/navigate :realworld.editor/edit {:slug "hello-conduit"}] {:frame f})
+      (is (some? @last-managed-args) "edit entry lowered the article read")
+      (let [lease [:lease :editor/article "hello-conduit"]]
+        (is (contains? (:active-owners (entry f (article-key "hello-conduit"))) lease)
+            "the article read is pinned by the editor's releaseable lease")
+        ;; the read settles → the :reply-to continuation seeds the baseline
+        (reply-success! @last-managed-args
+                        {:article {:slug "hello-conduit" :title "Hello, Conduit"
+                                   :description "A desc" :body "Some body" :tagList ["clojure"]}}
+                        f)
+        (testing "the :reply-to [:editor/article-loaded] continuation seeded draft + baseline"
+          (is (= "Hello, Conduit" (:title (rf/compute-sub [:editor/draft] (state-value f))))
+              "the draft is seeded from the loaded article")
+          (is (= "clojure" (:tagList (rf/compute-sub [:editor/draft] (state-value f))))
+              "the tag list is joined into the draft's comma-separated string")
+          (is (= "hello-conduit" (rf/compute-sub [:editor/slug] (state-value f))))
+          (is (false? (rf/compute-sub [:editor/dirty?] (state-value f)))
+              "a freshly-seeded edit draft equals its baseline → not dirty")
+          (is (true? (rf/compute-sub [:editor/can-leave?] (state-value f)))
+              "a clean edit draft may leave freely (the :can-leave guard passes)"))
+
+        ;; EDIT → NEW ARTICLE: the same editor-page component is re-used, so no
+        ;; unmount fires; :editor/initialise (the /editor on-match) must release
+        ;; the OUTGOING slug's lease before it blanks the slice.
+        (rf/dispatch-sync [:editor/initialise] {:frame f})
+        (testing "edit→new released the outgoing lease (no orphaned owner)"
+          (is (not (contains? (:active-owners (entry f (article-key "hello-conduit"))) lease))
+              "the outgoing edit lease is released on edit→new")
+          (is (nil? (get (owner-index-for f) lease))
+              "the lease is gone from the owner-index (no dangling pin)")
+          (is (nil? (rf/compute-sub [:editor/slug] (state-value f)))
+              "the slice is blanked to a fresh create draft (nil slug)"))
+        (testing "the released, settled article entry is GC-reclaimed (leak closed)"
+          (is (nil? (:current-work (entry f (article-key "hello-conduit"))))
+              "the settled read pins no in-flight work")
+          (gc-recheck! f (article-key "hello-conduit"))
+          (is (nil? (entry f (article-key "hello-conduit")))
+              "an owner-free, work-free entry is reclaimed — edit→new leaks nothing"))))))
+
+(deftest editor-delete-clears-slice-releases-lease-and-navigates-home
+  (testing "examples/real-apps/realworld_resources — :editor/delete fires the delete
+            mutation under the shared save instance with :reply-to [:editor/replied];
+            the delete branch clears the slice, releases the OUTGOING slug's lease
+            BEFORE the navigate-home unmount would read a now-nil slug, and heads
+            home (rf2-kkqy6q FAIL 2 — the matching-release invariant)"
+    (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
+                                       :fx-overrides {:rf.nav/push-url :rf/no-op}})]
+      (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
+      (rf/dispatch-sync [:rf.route/navigate :realworld.editor/edit {:slug "doomed"}] {:frame f})
+      (reply-success! @last-managed-args
+                      {:article {:slug "doomed" :title "Doomed" :description "d"
+                                 :body "b" :tagList []}}
+                      f)
+      (let [lease [:lease :editor/article "doomed"]]
+        (is (contains? (:active-owners (entry f (article-key "doomed"))) lease)
+            "the edit lease is held before delete")
+        ;; DELETE → the delete mutation lowers; reply with no :article (the delete
+        ;; endpoint returns no body) → the :editor/replied DELETE branch runs.
+        (rf/dispatch-sync [:editor/delete] {:frame f})
+        (reply-success! @last-managed-args {} f)
+        (is (not (contains? (:active-owners (entry f (article-key "doomed"))) lease))
+            "the delete flow releases the edit lease before clearing the slice (rf2-kkqy6q)")
+        (is (nil? (get (owner-index-for f) lease))
+            "the lease is gone from the owner-index after delete (no dangling owner)")
+        (is (nil? (rf/compute-sub [:editor/slug] (state-value f)))
+            "the editor slice is cleared to a blank create draft on delete")
+        (is (= :realworld/home (route-id f))
+            "a successful delete navigates home")))))


### PR DESCRIPTION
Adds adversarial contract tests for three flagship coverage gaps in the two RealWorld real-apps (`examples/real-apps/realworld_http` + `realworld_resources`), surfaced by the 2026-07-09 review campaign. Examples stay test-free (rf2-8cevm): all assertions land in the `implementation/` RealWorld test home that already exercises the example code (`realworld_cljs_test.cljs` + `realworld_resources_cljs_test.cljs`). No production edits — no bug surfaced.

One commit per bead:

- **rf2-yt7ay6 — pagination (both apps).** Pure request-building maths: `page->offset` / `page-count` / `query-string` / `paginate-path` (http) and `page->limit-offset` / `query-string` (resources) — nil / sub-1 page clamps, `empty -> ""` not `"?"`, nil-param drop, reserved-char (`& = #`, space) percent-encoding. Plus the page-nav events (`:home/show-page` / `:profile/show-page`; `:home/go-to-page` / `:profile/go-to-page`): they carry the active feed / tag / route + username forward and swap only `?page=` (resources drops `?page=` on page 1 for the canonical first-page URL).

- **rf2-hv7eid — realworld_resources editor edit-load + lease teardown + delete.** The editor test previously covered only CREATE. Adds: edit-mode entry seeding draft + baseline from the article read via the ensure's `:reply-to [:editor/article-loaded]` continuation (rf2-p1yri7); and the "N edits -> N leaked entries" lease-teardown **no-leak** property (rf2-kkqy6q fix) — edit->new (`:editor/initialise`) releases the outgoing `[:lease :editor/article slug]` and the settled entry GC-reclaims; edit->delete (`:editor/replied` delete branch) releases the lease before blanking the slice, clears the slice, and navigates home. Asserted in the shape of the machine-owner-release suite (active-owners empty + owner-index cleared + GC reclaims).

- **rf2-svj926 — session-restore-with-token (both apps).** The pre-existing auth tests only pass token nil (the `:idle` no-op branch), so the real restore path was untested. Adds a cold-boot-with-token test: `:idle -> :restoring -> :authed` via `:restore-session`, session stored, and the documented invariant that **restore does NOT navigate** (a deep link survives a refresh) — with an interactive-login contrast that DOES bounce home, proving navigation is observable so the non-navigation is a real signal. Resources additionally asserts `:restore-session` re-ensures the session feed under the restored principal (the passive-re-key footgun fix).

## Quality gates

- `cd implementation && npm run test:cljs` (foreground, full suite): **8340 tests, 38447 assertions, 0 failures, 0 errors**. New tests included and passing.

## Stance

Pre-alpha, no shims; CORRECTNESS + GOOD-PRACTICE. Test-only change: adds coverage in the existing `implementation/` test home; no `*.spec.cjs` under `examples/`; `examples/real-apps` treated as read-only reference. Do NOT merge (worker PR).
