### PR TITLE
test(examples): contract coverage for notebook safe-href XSS, cells evaluator, circle-drawer undo (rf2-kpvpmj +2)

### DIFF
--- a/implementation/core/test/re_frame/circle_drawer_undo_cljs_test.cljs
+++ b/implementation/core/test/re_frame/circle_drawer_undo_cljs_test.cljs
@@ -1,0 +1,154 @@
+(ns re-frame.circle-drawer-undo-cljs-test
+  "Behavioural contract for the Circle Drawer example's undo/redo engine
+  (`seven-guis.circle-drawer.core` — rf2-r5rsgz). The 7GUIs undo/redo
+  challenge keeps history-as-data via a single `:drawer/undoable`
+  interceptor plus sibling `:drawer/undo` / `:drawer/redo` events; before
+  this test only its ns-load schema-scoping was covered
+  (`re-frame.example-frame-scoping-cljs-test`), never the actual behaviour.
+
+  Why HERE and not under examples/: the example tree is test-free
+  (rf2-8cevm), and the entry ns is a Reagent-coupled `.cljs`-only namespace.
+  Requiring it under the consolidated `:node-test` build fires its ns-load
+  `reg-interceptor` / `reg-event` forms; we then drive the real handlers with
+  `dispatch-sync` — the same posture as the sibling example tests.
+
+  We dispatch on an ANONYMOUS frame (not `:rf/default`) on purpose: the
+  example binds its `[:drawer]` app-schema to `:rf/default` at ns-load, but
+  the interceptor + events resolve from the (global) registrar / default
+  image regardless of frame. Driving an anon frame therefore exercises the
+  undo behaviour in isolation, without coupling to the coordinate schema
+  (validated separately in the frame-scoping test).
+
+  Contracts pinned:
+    - `:drawer/add-circle` records exactly ONE undo step and clears redo;
+    - a whole slider RESIZE (open + N draft drags + close) collapses to
+      exactly ONE undo step — the drag is draft-only and skips the
+      interceptor;
+    - undo restores the prior `:circles` and parks the current on `:redo`;
+      redo round-trips;
+    - a new action after undo clears `:redo`, and `:next-id` (outside the
+      snapshot) keeps climbing so ids never reissue;
+    - the interceptor's `not=` guard records NO undo step for an undoable
+      handler that leaves `:circles` unchanged."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
+            ;; Required for its ns-load side effects: the `:drawer/undoable`
+            ;; interceptor + the drawer events/handlers under test.
+            [seven-guis.circle-drawer.core]))
+
+;; `:ambient-frame nil` — this suite creates its own top-level (anon) frames,
+;; so it wants a clear ambient scope (the frame-scoping sibling uses the same
+;; opt-out for the same reason).
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       reagent-adapter/adapter
+     :ambient-frame nil}))
+
+(defn- drawer
+  "The `:drawer` slice of frame `f`'s app-db."
+  [f]
+  (:drawer (rf/app-db-value f)))
+
+(defn- boot!
+  "A fresh anon frame with the drawer initialised to a blank canvas."
+  []
+  (let [f (frame/make-anon-frame-record! {:doc "circle-drawer undo test"})]
+    (rf/dispatch-sync [:drawer/initialise] {:frame f})
+    f))
+
+(deftest initialise-seeds-empty-history
+  (let [d (drawer (boot!))]
+    (is (= [] (:circles d)))
+    (is (= [] (:undo d)))
+    (is (= [] (:redo d)))
+    (is (= 1 (:next-id d)) "id dispenser starts at 1")))
+
+(deftest add-circle-records-exactly-one-undo-step
+  (let [f (boot!)]
+    (rf/dispatch-sync [:drawer/add-circle 10 20] {:frame f})
+    (let [d (drawer f)]
+      (is (= 1 (count (:circles d))) "one circle added")
+      (is (= {:id 1 :x 10 :y 20 :radius 30} (first (:circles d)))
+          "circle takes the dispensed id + default radius")
+      (is (= 1 (count (:undo d))) "exactly ONE undo step recorded")
+      (is (= [] (peek (:undo d)))
+          "the recorded snapshot is the pre-add (empty) :circles")
+      (is (= [] (:redo d)) "redo is cleared by a new undoable action")
+      (is (= 2 (:next-id d)) "next-id advanced past the issued id"))))
+
+(deftest resize-via-dialog-collapses-to-one-undo-step
+  (testing "open-dialog + N draft drags + close-dialog adds exactly ONE undo
+            step; the drags themselves add none (draft-only, skip interceptor)"
+    (let [f (boot!)]
+      (rf/dispatch-sync [:drawer/add-circle 10 20] {:frame f})
+      (let [undo-before (count (:undo (drawer f)))
+            cid         (:id (first (:circles (drawer f))))]
+        (rf/dispatch-sync [:drawer/open-dialog cid] {:frame f})
+        (rf/dispatch-sync [:drawer/dialog-drag 50] {:frame f})
+        (rf/dispatch-sync [:drawer/dialog-drag 70] {:frame f})
+        (rf/dispatch-sync [:drawer/dialog-drag 90] {:frame f})
+        ;; Mid-drag: the on-screen circle keeps its committed radius and NO
+        ;; undo step has been recorded yet.
+        (is (= undo-before (count (:undo (drawer f))))
+            "dragging the slider records NO undo steps")
+        (is (= 30 (:radius (first (:circles (drawer f)))))
+            "the circle keeps its committed radius while dragging (draft-only)")
+        (is (= 90 (:draft-radius (:dialog (drawer f))))
+            "only the dialog draft moves during a drag")
+        (rf/dispatch-sync [:drawer/close-dialog] {:frame f})
+        (let [d (drawer f)]
+          (is (= (inc undo-before) (count (:undo d)))
+              "the entire resize collapses to exactly ONE undo step")
+          (is (= 90 (:radius (first (:circles d))))
+              "the drafted radius is committed on close")
+          (is (nil? (:dialog d)) "dialog closed"))))))
+
+(deftest undo-then-redo-round-trips-circles
+  (let [f (boot!)]
+    (rf/dispatch-sync [:drawer/add-circle 10 20] {:frame f})
+    (let [after-add (:circles (drawer f))]
+      (rf/dispatch-sync [:drawer/undo] {:frame f})
+      (let [d (drawer f)]
+        (is (= [] (:circles d)) "undo restored the pre-add (empty) :circles")
+        (is (= 1 (count (:redo d))) "the current :circles were parked on :redo")
+        (is (= after-add (peek (:redo d))) "…and it is exactly what was undone")
+        (is (= [] (:undo d)) "the consumed undo step was popped"))
+      (rf/dispatch-sync [:drawer/redo] {:frame f})
+      (let [d (drawer f)]
+        (is (= after-add (:circles d)) "redo restored the circle")
+        (is (= [] (:redo d)) "the redo step was consumed")
+        (is (= 1 (count (:undo d))) "current :circles parked back on :undo")))))
+
+(deftest new-action-after-undo-clears-redo-and-ids-never-reissue
+  (let [f (boot!)]
+    (rf/dispatch-sync [:drawer/add-circle 10 20] {:frame f})   ;; id 1, next-id -> 2
+    (rf/dispatch-sync [:drawer/undo] {:frame f})               ;; circles [], redo has 1
+    (is (= 1 (count (:redo (drawer f)))) "redo populated after undo")
+    (rf/dispatch-sync [:drawer/add-circle 30 40] {:frame f})   ;; a NEW undoable action
+    (let [d (drawer f)]
+      (is (= [] (:redo d))
+          "a new action after undo clears the redo stack (the undone future is gone)")
+      (is (= 1 (count (:circles d))) "one circle present")
+      (is (= 2 (:id (first (:circles d))))
+          "the new circle got id 2 — :next-id sits OUTSIDE the undo snapshot, so ids never reissue")
+      (is (= 3 (:next-id d)) "next-id keeps climbing"))))
+
+(deftest no-op-undoable-event-records-no-undo-step
+  (testing "close-dialog wears :drawer/undoable but, when the draft equals the
+            committed radius, it leaves :circles unchanged — the interceptor's
+            not= guard must then record NO undo step"
+    (let [f (boot!)]
+      (rf/dispatch-sync [:drawer/add-circle 10 20] {:frame f})
+      (let [cid         (:id (first (:circles (drawer f))))
+            undo-before (count (:undo (drawer f)))]
+        (rf/dispatch-sync [:drawer/open-dialog cid] {:frame f})
+        ;; close without dragging → draft == committed radius (30) → no change
+        (rf/dispatch-sync [:drawer/close-dialog] {:frame f})
+        (let [d (drawer f)]
+          (is (= undo-before (count (:undo d)))
+              "an undoable handler that changed nothing records NO undo step")
+          (is (= 30 (:radius (first (:circles d)))) "radius unchanged")
+          (is (nil? (:dialog d)) "dialog still closed"))))))

--- a/implementation/core/test/re_frame/seven_guis_cells_parser_cljs_test.cljs
+++ b/implementation/core/test/re_frame/seven_guis_cells_parser_cljs_test.cljs
@@ -125,3 +125,129 @@
       ;; pair, never the misleading 1.
       (is (cells/parse-error? v))
       (is (not= 1 v)))))
+
+;; ===========================================================================
+;; evaluate-cell — cycle guard (rf2-1r1dm7)
+;; ===========================================================================
+;;
+;; The example's docstring promises "Cycles (A1 -> B1 -> A1) caught by a
+;; visited-set walk, not a stack overflow." A regression here would blow the
+;; stack and take the whole grid render down — silently green — so pin it.
+
+(deftest evaluate-cell-cycle-guard-yields-error-not-stack-overflow
+  (testing "a two-cell cycle A1 -> B1 -> A1 is caught by the visited-set walk"
+    (let [cells {"A1" (cell-entry "=(+ B1 1)")
+                 "B1" (cell-entry "=(+ A1 1)")}]
+      (is (= :error/cycle (cells/evaluate-cell "A1" cells #{})))
+      (is (= :error/cycle (cells/evaluate-cell "B1" cells #{})))))
+  (testing "a self-cycle A1 -> A1 is also caught (never recurses forever)"
+    (is (= :error/cycle
+           (cells/evaluate-cell "A1" {"A1" (cell-entry "=(+ A1 1)")} #{})))))
+
+;; ===========================================================================
+;; evaluate-cell / evaluate-ast — the typed error taxonomy (rf2-1r1dm7)
+;; ===========================================================================
+;;
+;; "Bad arithmetic turned into typed error markers — the evaluator never
+;; throws." Each bad shape must surface as its own keyword marker, not an
+;; exception and not a misleading number.
+
+(deftest evaluate-cell-division-by-zero-marks-error
+  (testing "a literal /0 yields :error/div-by-zero (never throws)"
+    (is (= :error/div-by-zero
+           (cells/evaluate-cell "A1" {"A1" (cell-entry "=(/ 1 0)")} #{}))))
+  (testing "a divisor that COMPUTES to zero is caught too"
+    (is (= :error/div-by-zero
+           (cells/evaluate-cell "A1" {"A1" (cell-entry "=(/ 10 (- 3 3))")} #{}))))
+  (testing "a non-zero division still computes"
+    (is (= 3 (cells/evaluate-cell "A1" {"A1" (cell-entry "=(/ 6 2)")} #{})))))
+
+(deftest evaluate-cell-text-in-arithmetic-marks-type-error
+  (testing "feeding a text cell into arithmetic yields :error/type"
+    (let [cells {"A1" (cell-entry "hi")
+                 "B1" (cell-entry "=(+ A1 2)")}]
+      (is (= :error/type (cells/evaluate-cell "B1" cells #{})))))
+  (testing "a plain (non-formula) text cell evaluates to its own raw text"
+    (is (= "hi" (cells/evaluate-cell "A1" {"A1" (cell-entry "hi")} #{})))))
+
+(deftest evaluate-ast-marks-unknown-op-and-uncomputable
+  (testing "an operator outside + - * / is :error/unknown-op"
+    (is (= :error/unknown-op (cells/evaluate-ast [(symbol "%") 1 2] {} #{})))
+    (is (= :error/unknown-op (cells/evaluate-ast [(symbol "mod") 4 2] {} #{}))))
+  (testing "an AST node that is neither number, cell ref, nor list is
+            :error/eval (the belt-and-suspenders marker)"
+    (is (= :error/eval (cells/evaluate-ast "not-an-ast-node" {} #{})))
+    (is (= :error/eval (cells/evaluate-ast true {} #{})))))
+
+;; ===========================================================================
+;; evaluate-cell / evaluate-ast — arithmetic + empty-cell semantics
+;; ===========================================================================
+
+(deftest evaluate-cell-arithmetic-operators
+  (testing "variadic + - * / fold across all their arguments"
+    (is (= 6  (cells/evaluate-cell "A1" {"A1" (cell-entry "=(+ 1 2 3)")} #{})))
+    (is (= 5  (cells/evaluate-cell "A1" {"A1" (cell-entry "=(- 10 3 2)")} #{})))
+    (is (= 24 (cells/evaluate-cell "A1" {"A1" (cell-entry "=(* 2 3 4)")} #{})))
+    (is (= 10 (cells/evaluate-cell "A1" {"A1" (cell-entry "=(/ 100 5 2)")} #{}))))
+  (testing "nested formulas reduce inner expressions first"
+    (let [cells {"A1" (cell-entry "5")
+                 "B2" (cell-entry "4")
+                 "C1" (cell-entry "=(+ A1 (* B2 3))")}]
+      (is (= 17 (cells/evaluate-cell "C1" cells #{})))))
+  (testing "an untouched cell reads as 0 (empty-cell semantics)"
+    (is (= 0 (cells/evaluate-cell "Z9" {} #{})))
+    (is (= 1 (cells/evaluate-cell "B1" {"B1" (cell-entry "=(+ A1 1)")} #{}))
+        "a formula over an empty referent folds it in as 0")))
+
+;; ===========================================================================
+;; parse-num — the ^…$ anchored strict numeric gate
+;; ===========================================================================
+
+(deftest parse-num-strict-anchored
+  (testing "a wholly-numeric string parses (sign / decimal / exponent)"
+    (is (= 42    (cells/parse-num "42")))
+    (is (= 3.14  (cells/parse-num "3.14")))
+    (is (= -1500 (cells/parse-num "-1.5e3")))
+    (is (= 0.5   (cells/parse-num ".5")))
+    (is (= 7     (cells/parse-num "  7  "))))          ;; trims before parsing
+  (testing "partially-numeric junk is rejected by the ^…$ anchors — NOT read
+            as the leading numeric run js/parseFloat would greedily accept"
+    (doseq [s ["1abc" "1.2.3" "abc" "" "  " "1 2" "0x10"]]
+      (is (nil? (cells/parse-num s))
+          (str (pr-str s) " must not parse as a number")))))
+
+;; ===========================================================================
+;; tokenise / parse-tokens / parse-formula — the parse boundary (rf2-1r1dm7)
+;; ===========================================================================
+
+(deftest tokenise-splits-parens-and-atoms
+  (testing "parens fall out as their own tokens without needing spaces"
+    (is (= ["(" "+" "A1" "B2" ")"] (cells/tokenise "(+ A1 B2)")))
+    (is (= ["(" "+" "1" "(" "*" "2" "3" ")" ")"]
+           (cells/tokenise "(+ 1 (* 2 3))")))
+    (is (= ["42"] (cells/tokenise "42")))))
+
+(deftest parse-tokens-throws-on-unbalanced-parens
+  (testing "an unclosed '(' throws, tagging the offending token"
+    (let [e (try (cells/parse-tokens ["(" "+" "1"]) nil (catch :default e e))]
+      (is (some? e) "an unclosed '(' throws")
+      (is (= "(" (:token (ex-data e))) "the throw names the '(' token")))
+  (testing "an extra ')' throws, tagging it"
+    (let [e (try (cells/parse-tokens [")"]) nil (catch :default e e))]
+      (is (some? e) "an extra ')' throws")
+      (is (= ")" (:token (ex-data e))) "the throw names the ')' token"))))
+
+(deftest parse-formula-never-throws-returns-error-pair
+  (testing "parse-formula catches parse throws and returns an [:error/parse msg]
+            pair — the evaluator boundary never throws across it"
+    (doseq [raw ["=(+ 1 2"       ;; unclosed '('
+                 "=(+ 1 2))"      ;; extra ')'
+                 "=(% 1 2)"       ;; unknown token
+                 "=(+ 1 2) 3"]]   ;; trailing tokens after the expression
+      (let [ast (cells/parse-formula raw)]
+        (is (cells/parse-error? ast)
+            (str raw " must parse to an [:error/parse …] pair"))
+        (is (string? (cells/parse-error-text ast))
+            (str raw " carries an actionable message")))))
+  (testing "a well-formed formula does NOT parse to an error pair"
+    (is (not (cells/parse-error? (cells/parse-formula "=(+ 1 2)"))))))


### PR DESCRIPTION
Adds adversarial contract coverage for three examples/core behaviours that were demonstrated-but-untested (review-campaign 2026-07-09). Examples stay test-free (rf2-8cevm); these tests live in the framework test tree and require the example nses, running under the always-on `:node-test` gate — the same posture as `re-frame.seven-guis-cells-parser-cljs-test` / `re-frame.example-frame-scoping-cljs-test`. No production edits.

## What landed

- **rf2-kpvpmj — notebook `safe-href` XSS allowlist + `markdown->hiccup`** (new `notebook_markdown_cljs_test.cljs`). Pins the scheme allowlist in isolation (http/https/mailto + relative/#fragment pass; `javascript:`/`data:`/`vbscript:`/`file:` + casing + leading/trailing-whitespace variants rejected) and end-to-end via `markdown->hiccup` (unsafe link -> inert `:span.nb-unsafe-link`, no live `:a`/`:href`; safe link -> hardened `:a` with `rel`/`target`), plus heading/bold/italic/code/list structure. NB the RealWorld `safe-url?` is a separate CommonMark impl and already covered.
- **rf2-1r1dm7 — cells evaluator error taxonomy** (extends `seven_guis_cells_parser_cljs_test.cljs`). Cycle guard (`:error/cycle`, proving the visited-set walk, not a stack overflow), `:error/div-by-zero` (literal + computed divisor), `:error/type`, `:error/unknown-op` + `:error/eval` (via `evaluate-ast`), variadic/nested arithmetic + empty-cell-as-0, `parse-num` anchored strict gate, `tokenise`, and the parse boundary (`parse-tokens` throws on unbalanced parens; `parse-formula` never throws, returns `[:error/parse msg]`).
- **rf2-r5rsgz — circle-drawer undo/redo** (new `circle_drawer_undo_cljs_test.cljs`). Drives the real handlers via `dispatch-sync` on an anon frame. Add records exactly one undo step + clears redo; a whole resize (open + N draft drags + close) collapses to ONE undo step (drag is draft-only); undo/redo round-trip; new action after undo clears `:redo` and `:next-id` keeps climbing (ids never reissue); the interceptor's `not=` guard records no step for a no-change undoable handler.

## Finding — filed rf2-9tllom (P2, security)

While pinning `safe-href`, ground-truth testing surfaced a real allowlist BYPASS: a scheme whose token is broken by an embedded control char (TAB / LF / CR) or a leading non-whitespace control char (e.g. SOH) fails the scheme regex, is misclassified as scheme-less, and renders a LIVE `:a {:href ...}`. Browsers strip those control chars before scheme resolution, so it resolves to `javascript:` on click (classic filter-evasion class). `str/trim` only covers leading/trailing whitespace. Filed as **rf2-9tllom**; the `examples/core` edit is deferred (coordination-locked read-only in this worker; deserves its own dispatch + review). A labelled CHARACTERIZATION test pins the current behaviour and references rf2-9tllom so a fix flips it red.

## Quality gates

- `npm run test:cljs` (full `:node-test`, foreground): **Ran 8358 tests containing 38540 assertions. 0 failures, 0 errors.** (`npm ci` on the fresh worktree first.)
- All three test namespaces confirmed compiled into the bundle.

## Stance

Pre-alpha, no shims. CORRECTNESS + GOOD PRACTICE via adversarial assertions on the real behaviour; no production edits (the one real defect found is filed, not silently patched into a test-coverage PR). Do not merge — worker PR.
