### PR TITLE
docs: fix stale comments (reagent React-19, security enums, skills setup/implementor) (rf2-2v0y90 +3)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/frame_provider_context_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/frame_provider_context_dom_cljs_test.cljs
@@ -509,10 +509,11 @@
 ;; Provider also gets double-rendered; the resolution chain MUST land
 ;; on the same frame keyword across both invocations.
 ;;
-;; The bead lists this as "React-19 strict-mode composition"; under
-;; React 18 (the test infra's installed version, package.json
-;; pinning) StrictMode produces the same double-invoke contract and
-;; is sufficient to validate the property.
+;; This IS the "React-19 strict-mode composition" validation: the
+;; test infra pins react/react-dom to 19.2.0 (implementation/
+;; package.json; Reagent 2.0.1's React-19.2.0 Floor), so StrictMode
+;; here double-invokes under React 19 — the scenario exercises the
+;; property on the version the framework actually ships against.
 
 (deftest scenario-6-strict-mode-composition
   "Scenario 6 — React StrictMode composition.

--- a/implementation/security/test/re_frame/security/fail_closed_invariant_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/fail_closed_invariant_security_cljs_test.cljc
@@ -298,8 +298,8 @@
 ;; BOUNDARY 3 — SSR hydration payload (ssr.hydrate/hydrate-event-handler).
 ;;   A deserialised, untrusted payload that is not a map — or whose app-db
 ;;   slice is present-but-not-a-map — MUST be REJECTED (existing app-db
-;;   unchanged + diagnostic), NEVER installed as the whole app-db under the
-;;   locked `:replace-app-db` policy. (rf2-gro94.)
+;;   unchanged + diagnostic), NEVER installed as the whole partition under the
+;;   locked `:replace-frame-state` policy. (rf2-gro94.)
 ;; ===========================================================================
 
 (def ^:private existing-db {:client/seeded true :count 0})

--- a/implementation/security/test/re_frame/security/gen.cljc
+++ b/implementation/security/test/re_frame/security/gen.cljc
@@ -190,9 +190,11 @@
   "Deep-walk `x`; true when `needle` appears anywhere - as a value, inside a
   collection, or inside a stringified form. When `exact?` is truthy, a walked
   STRING leaf matches only on exact `=` equality with `needle`; otherwise a
-  leaf matches when `needle` is a SUBSTRING of it (`re-find`). The `pr-str`
-  fallback always uses a substring scan, so `needle` surviving inside a
-  non-string leaf (e.g. a keyword/symbol form built from it) is also caught."
+  leaf matches when `needle` REGEX-matches it (`re-find` over `(re-pattern
+  needle)`). The `pr-str` fallback always uses the same regex search, so
+  `needle` surviving inside a non-string leaf (e.g. a keyword/symbol form
+  built from it) is also caught. `needle` MUST therefore be a regex-safe
+  literal (no unescaped regex metacharacters); the current sentinels are."
   [x needle exact?]
   (let [hit (volatile! false)]
     (walk/postwalk

--- a/implementation/security/test/re_frame/security/validation_redaction_invariant_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/validation_redaction_invariant_security_cljs_test.cljc
@@ -754,7 +754,7 @@
 
 (deftest every-kind-redacts-at-arbitrary-nesting
   (testing "rf2-o69h5 — across arbitrary collection/map nestings of a
-            :sensitive? slot, EVERY callable validation kind (event / cofx /
+            :sensitive? slot, EVERY callable validation kind (event /
             fx / sub-return / machine-data) redacts the sentinel and stamps
             :sensitive?. One escaped kind/shape = one leak."
     (let [result (gen/for-all

--- a/skills/re-frame2-implementor/references/phase-2-impl-order.md
+++ b/skills/re-frame2-implementor/references/phase-2-impl-order.md
@@ -288,7 +288,7 @@ For each capability the port declared `yes` for in D3, walk the matching EP. Sug
 
 **Read.** [`spec/008-Testing.md`](https://day8.github.io/re-frame2/spec/008-Testing/).
 
-**Contract.** `with-frame`, `dispatch-sync`, `compute-sub`, epoch surface (`epoch/restore-epoch!` + `epoch/replace-frame-state!`) for snapshot/restore, `:fx-overrides`, `:interceptor-overrides`, framework adapter (cljs.test → vitest/pytest/etc.). JVM-runnable for the pure-function surface.
+**Contract.** `with-frame`, `dispatch-sync`, `compute-sub`, epoch surface (`epoch/restore-epoch!` + `epoch/replace-frame-state!`) for snapshot/restore, `:fx-overrides`, `:interceptor-overrides`, framework adapter (cljs.test → vitest/jest/etc.). JVM-runnable for the pure-function surface.
 
 ### EP 005 — State machines (if D3 Q1 = yes)
 

--- a/skills/re-frame2-setup/references/deps-versions.md
+++ b/skills/re-frame2-setup/references/deps-versions.md
@@ -44,6 +44,8 @@ grep -oE 'day8/re-frame2[a-z-]* *\{:git/url[^}]*:git/sha "[^"]+"' deps.edn
 
 These eleven are the **publishable** lockstep set. (Two niche local roots — `reagent-slim`, `re-frame2-ssr-ring` — ride the same version but aren't greenfield.) `day8/re-frame2-xray` is tooling, not one of the eleven, but is a **day-one** dep (below).
 
+**One more per-feature artefact, tagged (post-v1).** `day8/re-frame2-resources` (Spec [016](../../../spec/016-Resources.md) / EP-0003 — the richest per-feature artefact) is a **settled contract at a fixed coordinate** that ships *after* v1, so it sits outside the eleven; [`spec/Conventions.md` §Packaging conventions](../../../spec/Conventions.md) enumerates it inline as **(post-v1)**. Its runtime has landed and it is already wired into `implementation/deps.edn` as `day8/re-frame2-resources {:local/root "resources"}`, so on the pre-publish `:local/root` dev route you can add it today — add it when you call `reg-resource`. The count stays **eleven** for the v1 publishable set.
+
 **Greenfield day-one shape.** Matching the [generator template](../README.md#relationship-to-the-generator-template), the day-one set is **four** re-frame2 coords — `day8/re-frame2` (core) + `day8/re-frame2-reagent` (adapter) + `day8/re-frame2-schemas` (the starter app attaches a whole-app-db schema — see the table row for the `:rf.error/schemas-artefact-missing` contract) + `day8/re-frame2-xray` (in-app devtools via `:devtools/preloads`) — plus an explicit `reagent/reagent` pin.
 
 The remaining per-feature artefacts (`-machines`, `-routing`, `-flows`, `-http`, `-ssr`, `-epoch`) stay pay-as-you-go — add them only when the author writes code that uses them (§When to add, below), so apps that don't use them don't pay the classpath cost.


### PR DESCRIPTION
Four comment/doc-only fixes across disjoint surfaces (no logic change). Each bead is a separate commit.

## Fixes

- **rf2-2v0y90** (`implementation/adapters/reagent`) — Scenario-6 StrictMode comment claimed React 18 was the installed version and hedged it was "sufficient" for the React-19 property. `implementation/package.json` pins react/react-dom to **19.2.0** (Reagent 2.0.1's React-19.2.0 Floor), so the scenario genuinely runs under React 19. Reworded to state React 19 is pinned and dropped the under-18 hedge — this *is* the React-19 validation. (Other, accurate historical "React 18+" mentions left untouched.)
- **rf2-315nsd** (`implementation/security`) — three stale/inaccurate comments in the security property-test tier:
  - `validation_redaction_invariant`: dropped `cofx` from the callable-validation-kind enumeration (`validate-cofx!` retired, EP-0017; the checks vector runs event/fx/sub-return/machine-data only).
  - `fail_closed_invariant`: BOUNDARY-3 header aligned to `:replace-frame-state` / "whole partition" (EP-0001), matching the file's own docstring and prod `ssr/hydrate.cljc`.
  - `gen.cljc`: `contains-string?` docstring corrected — the match is a **regex** search (`re-find` over `(re-pattern needle)`), not a substring scan; added a regex-safe-needle caveat. Doc-only (logic unchanged per worker brief).
- **rf2-8wvrij** (`skills/re-frame2-setup`) — `deps-versions.md` never mentioned `day8/re-frame2-resources`, which `spec/Conventions.md` enumerates **(post-v1)** in the per-feature tier and is already wired into `implementation/deps.edn` as a `:local/root` (usable today on the pre-publish dev route). Added a one-line (post-v1) note mirroring Conventions' tag; the guarded "eleven" v1 count is preserved.
- **rf2-v40iyn** (`skills/re-frame2-implementor`) — `phase-2-impl-order.md` EP-008 used `pytest` as an inline example test-runner, contradicting the skill's host-scope discipline (all eight in-scope hosts cross-compile to React+VDOM). Swapped `pytest` → `jest`, an in-scope JS runner.

## Quality gates

- `implementation` `npm run test:cljs` (after `npm ci`): **8360 tests, 38439 assertions, 0 failures, 0 errors** — green.
- `python scripts/check_doc_slugs.py`: exit 0 — green.

## Stance

Pre-alpha, no shims. Comment/doc text only — CLARITY + CORRECTNESS; no over-engineering. F3 (gen.cljc) took the doc-only correction per the worker brief rather than the logic-change option the bead offered as an alternative.

Do not merge — leaving for the merge loop.