### PR TITLE
test(test-react,adapters-scripts): finally-restore + de-vacuous asserts + real listSpecFiles + loopback guard (rf2-dtmnl8 +3)

### DIFF
--- a/implementation/adapters/scripts/adapter-smoke-filter.cjs
+++ b/implementation/adapters/scripts/adapter-smoke-filter.cjs
@@ -51,6 +51,7 @@
 'use strict';
 
 const path = require('path');
+const fs = require('fs');
 
 // __dirname is <repo>/implementation/adapters/scripts. REPO_ROOT is <repo>.
 const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
@@ -138,6 +139,64 @@ function selectEntries(patterns, smokes = ADAPTER_SMOKES) {
   return smokes.filter((e) => entryMatches(e, patterns));
 }
 
+// ---- spec-file discovery + manifest reconciliation ----------------------
+// The Playwright runner (run-adapter-smokes.cjs) reconciles this manifest
+// against the spec.cjs files actually on disk before running, failing loud
+// on drift in either direction. The walker + the missing/undeclared
+// partition used to live ONLY in the runner, so the fast JS tier could only
+// exercise a RE-IMPLEMENTED copy of them (rf2-qf45gu): the copies could
+// drift, and a bug in the runner's OWN walk/partition (node_modules skip,
+// sort, the set-difference) surfaced only at Playwright-run time, never at
+// the JS gate. Own them here — next to the manifest they reconcile against —
+// so the runner AND its fast-tier test import the SAME real code.
+
+// A spec file is the unprefixed `spec.cjs` (the adapter-testbed convention)
+// or any `*.spec.cjs`. `examples/` is test-free, but the walker accepts the
+// suffixed form defensively.
+function isSpecFile(name) {
+  return name === 'spec.cjs' || name.endsWith('.spec.cjs');
+}
+
+// Recursively walk `roots`, returning the resolved absolute paths of every
+// spec file found, sorted. Skips `node_modules` dirs (defensive — none live
+// under a spec root today). A missing root is skipped, not an error, so a
+// not-yet-created root doesn't crash discovery.
+function listSpecFiles(roots) {
+  const out = [];
+  for (const root of roots) {
+    if (!fs.existsSync(root)) continue;
+    const stack = [root];
+    while (stack.length > 0) {
+      const dir = stack.pop();
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          if (entry.name === 'node_modules') continue;
+          stack.push(full);
+        } else if (entry.isFile() && isSpecFile(entry.name)) {
+          out.push(path.resolve(full));
+        }
+      }
+    }
+  }
+  return out.sort();
+}
+
+// Pure set-difference of declared (manifest) vs discovered (on-disk) spec
+// paths. Both sides are resolved to absolute before diffing, so callers may
+// pass either form. `missing` = declared-but-absent-on-disk (a renamed or
+// removed smoke still listed in the manifest); `undeclared` =
+// present-on-disk-but-not-declared (a new spec added under a spec root with
+// no manifest entry). Either list non-empty is a fail-loud drift.
+function reconcile(declared, discovered) {
+  const dcl = declared.map((p) => path.resolve(p));
+  const dsc = discovered.map((p) => path.resolve(p));
+  return {
+    missing: dcl.filter((p) => !dsc.includes(p)),
+    undeclared: dsc.filter((p) => !dcl.includes(p)),
+  };
+}
+
 module.exports = {
   ADAPTER_SMOKES,
   ADAPTER_SMOKE_SPEC_ROOTS,
@@ -147,4 +206,7 @@ module.exports = {
   entryIdentities,
   entryMatches,
   selectEntries,
+  isSpecFile,
+  listSpecFiles,
+  reconcile,
 };

--- a/implementation/adapters/scripts/run-adapter-smokes.cjs
+++ b/implementation/adapters/scripts/run-adapter-smokes.cjs
@@ -51,12 +51,13 @@
  */
 
 const path = require('path');
-const fs = require('fs');
 const {
   ADAPTER_SMOKES,
   ADAPTER_SMOKE_SPEC_ROOTS,
   parseFilterPatterns,
   selectEntries,
+  listSpecFiles,
+  reconcile,
 } = require('./adapter-smoke-filter.cjs');
 
 // playwright is a devDependency of implementation/package.json — there
@@ -111,36 +112,13 @@ const { isVerboseTests } = require(path.join(
 ));
 const VERBOSE_TESTS = isVerboseTests();
 
-// Specs live alongside the adapter testbed they exercise: each adapter
-// (Reagent / UIx / Helix) ships `implementation/adapters/<name>/testbed/
-// spec.cjs` (the unprefixed-`spec.cjs` convention).
-// The walker also accepts `*.spec.cjs`, though `examples/` is test-free.
-function isSpecFile(name) {
-  return name === 'spec.cjs' || name.endsWith('.spec.cjs');
-}
-
-function listSpecFiles(roots) {
-  const out = [];
-  for (const root of roots) {
-    if (!fs.existsSync(root)) continue;
-    const stack = [root];
-    while (stack.length > 0) {
-      const dir = stack.pop();
-      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-        const full = path.join(dir, entry.name);
-        if (entry.isDirectory()) {
-          // Skip node_modules dirs that may sit under tools/ in the
-          // future (none today, but the walker should be defensive).
-          if (entry.name === 'node_modules') continue;
-          stack.push(full);
-        } else if (entry.isFile() && isSpecFile(entry.name)) {
-          out.push(full);
-        }
-      }
-    }
-  }
-  return out.sort();
-}
+// Spec discovery (isSpecFile/listSpecFiles) and the manifest-vs-disk
+// reconciliation (reconcile) live in the shared adapter-smoke-filter.cjs
+// module — the one that already owns the ADAPTER_SMOKES manifest — so this
+// runner and the fast-tier _adapter-smoke-filter.test.cjs exercise the SAME
+// real code instead of two copies that could drift (rf2-qf45gu). Specs live
+// alongside the adapter testbed they exercise: each adapter (Reagent / UIx /
+// Helix) ships `implementation/adapters/<name>/testbed/spec.cjs`.
 
 function withTimeout(promise, ms, label) {
   let timer;
@@ -160,10 +138,9 @@ function withTimeout(promise, ms, label) {
   // manifest, or a new spec.cjs added under implementation/adapters/
   // without a matching manifest entry — instead of silently exercising the
   // wrong set.
-  const discovered = listSpecFiles(ADAPTER_SMOKE_SPEC_ROOTS).map((p) => path.resolve(p));
-  const declared = ADAPTER_SMOKES.map((e) => path.resolve(e.specPath));
-  const missing = declared.filter((p) => !discovered.includes(p));
-  const undeclared = discovered.filter((p) => !declared.includes(p));
+  const discovered = listSpecFiles(ADAPTER_SMOKE_SPEC_ROOTS);
+  const declared = ADAPTER_SMOKES.map((e) => e.specPath);
+  const { missing, undeclared } = reconcile(declared, discovered);
   if (missing.length > 0) {
     console.error(
       `ADAPTER_SMOKES manifest references spec(s) not on disk:\n  ${missing.join('\n  ')}\n` +

--- a/implementation/adapters/test-react/test/re_frame/adapter/test_react_cljs_test.cljc
+++ b/implementation/adapters/test-react/test/re_frame/adapter/test_react_cljs_test.cljc
@@ -370,6 +370,22 @@
                  (test-react/unmount! panel-a))}))
           "the guard fires organically: the unmount happens while the host's
            render is in flight, which is React's actual guard condition")
+      ;; The host's render body THREW, yet run-render!'s `finally` decremented
+      ;; the global render-depth back to zero on unwind. Assert that invariant
+      ;; DIRECTLY: without the finally-restore a leaked non-zero depth would
+      ;; poison every LATER test — the next unmount! anywhere would spuriously
+      ;; trip :rf.error/sync-unmount-during-render. Previously this was only
+      ;; covered indirectly (the trailing unmount! below would throw a
+      ;; confusing uncaught ExceptionInfo if depth leaked, and that coverage
+      ;; vanished if the trailing unmount was ever refactored away).
+      (is (false? (test-react/rendering?))
+          "run-render!'s finally restored render-depth to zero even though the
+           render body threw — no leaked in-flight state poisons later tests")
+      ;; mount-tree! registers into active-mounts only AFTER run-render!
+      ;; returns, so a throw mid-render never registers the host — the
+      ;; partially-constructed root cannot leak into the live forest.
+      (is (= 1 (count (test-react/mounted-roots)))
+          "only panel A is live — the throwing host never registered, no leak")
       ;; Panel A is still mounted — the guard short-circuited the unmount
       ;; before it could tear the root down (matching React: it refuses the
       ;; synchronous unmount rather than racing).
@@ -681,6 +697,18 @@
                                  (fn [_child]
                                    (reset! grandchild-ref
                                            (test-react/mount-child! [:span "leaf"])))})))})]
+      ;; The parent's render nested two levels deep (parent → child →
+      ;; grandchild), so the global render-depth climbed to 3 then unwound.
+      ;; Because it is a COUNTER, not a boolean (src note ~lines 128-129), each
+      ;; nested render's run-render! `finally` decremented exactly its own
+      ;; level, leaving depth at zero once the outermost mount! returned. A
+      ;; boolean would have been clobbered to false by the innermost unwind
+      ;; while an outer render was still notionally in flight. This pins the
+      ;; counter-not-boolean nested-unwind restore, which no test checked
+      ;; directly before.
+      (is (false? (test-react/rendering?))
+          "render-depth restored to zero after a two-level nested render
+           unwound — the counter decrements each nested level independently")
       (is (= 3 (count (test-react/mounted-roots)))
           "parent + child + grandchild all live")
       (is (= [@child-ref] (test-react/children parent))

--- a/implementation/adapters/test-react/test/re_frame/adapter/test_react_cljs_test.cljc
+++ b/implementation/adapters/test-react/test/re_frame/adapter/test_react_cljs_test.cljc
@@ -450,31 +450,32 @@
           "the orphaned root leaks — subscribe/dispose imbalance detected")
       (is (true? @(:mounted? @orphan-ref))
           "the specific leaked root is the orphan the host forgot to track")
-      (is (not (zero? (count (test-react/mounted-roots))))
-          "a balanced teardown would zero the live-mount count; this buggy path leaks")
       ;; Clean up the orphan so the fixture's drain has nothing to forcibly tear.
       (test-react/unmount! @orphan-ref))))
 
 (deftest balanced-subscribe-dispose-returns-to-zero
   (testing "the CORRECT counterpart: a parent that lets the cascade tear all
-            children down returns the live-mount count and ref count to zero —
-            the green state a regression in B.2 would break"
-    (let [live   (atom 0)
-          parent (test-react/mount!
+            children down returns the live-mount count to zero and empties its
+            tracked-child set — the green state a regression in B.2 would break"
+    (let [parent (test-react/mount!
                    {:rf/component
                     (fn [_parent]
-                      (test-react/mount-child! [:li "a"]) (swap! live inc)
-                      (test-react/mount-child! [:li "b"]) (swap! live inc))})]
+                      (test-react/mount-child! [:li "a"])
+                      (test-react/mount-child! [:li "b"]))})]
       (is (= 3 (count (test-react/mounted-roots))))
-      ;; Correct teardown: just unmount the parent; the cascade handles
-      ;; children, and we mirror the ref release per child it tears down.
-      (let [n-children (count (test-react/children parent))]
-        (test-react/unmount! parent)
-        (dotimes [_ n-children] (swap! live dec)))
+      (is (= 2 (count (test-react/children parent)))
+          "both children are tracked under the parent before teardown")
+      ;; Correct teardown: just unmount the parent; the cascade tears every
+      ;; child down leaf-first — no per-resource bookkeeping needed.
+      (test-react/unmount! parent)
       (is (zero? (count (test-react/mounted-roots)))
           "cascade tore every child down — nothing leaks")
-      (is (zero? @live)
-          "ref count balanced back to zero"))))
+      ;; `children` returns only STILL-MOUNTED children, so an empty result
+      ;; after teardown is a REAL framework property: the cascade set every
+      ;; tracked child's mounted? false. A child the cascade failed to reach
+      ;; would still read as mounted and show up here.
+      (is (empty? (test-react/children parent))
+          "the parent's live-child set drained — the cascade reached every child"))))
 
 ;; ----------------------------------------------------------------------------
 ;; B.3 — Double-render

--- a/implementation/scripts/_adapter-smoke-filter.test.cjs
+++ b/implementation/scripts/_adapter-smoke-filter.test.cjs
@@ -36,6 +36,9 @@ const {
   parseFilterPatterns,
   normalizeForFilter,
   entryIdentities,
+  isSpecFile,
+  listSpecFiles,
+  reconcile,
 } = require('../adapters/scripts/adapter-smoke-filter.cjs');
 
 let failed = 0;
@@ -267,41 +270,50 @@ it('normalizeForFilter collapses _, \\ and / to a single -', () => {
 });
 
 // ---- manifest vs on-disk reconciliation ---------------------------------
-// Mirror the runner's reconciliation guard so drift is caught at the fast
-// JS-harness tier too (not only at Playwright-run time).
+// Exercise the REAL discovery + reconciliation the runner uses. isSpecFile,
+// listSpecFiles, and reconcile are imported from adapter-smoke-filter.cjs
+// (the module that owns the manifest) — the SAME functions
+// run-adapter-smokes.cjs calls before a Playwright run. Previously this
+// suite re-implemented copies of the walker and asserted on THOSE, so a bug
+// in the runner's own walk/partition was caught only at Playwright-run time
+// and the two copies could silently drift (rf2-qf45gu).
 
-function isSpecFile(name) {
-  return name === 'spec.cjs' || name.endsWith('.spec.cjs');
-}
-function listSpecFiles(roots) {
-  const out = [];
-  for (const root of roots) {
-    if (!fs.existsSync(root)) continue;
-    const stack = [root];
-    while (stack.length > 0) {
-      const dir = stack.pop();
-      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-        const full = path.join(dir, entry.name);
-        if (entry.isDirectory()) {
-          if (entry.name === 'node_modules') continue;
-          stack.push(full);
-        } else if (entry.isFile() && isSpecFile(entry.name)) {
-          out.push(path.resolve(full));
-        }
-      }
-    }
-  }
-  return out.sort();
-}
+it('isSpecFile accepts spec.cjs and *.spec.cjs and rejects everything else (rf2-qf45gu)', () => {
+  assert.ok(isSpecFile('spec.cjs'), 'bare spec.cjs is a spec file');
+  assert.ok(isSpecFile('reagent.spec.cjs'), 'suffixed *.spec.cjs is a spec file');
+  assert.ok(!isSpecFile('spec.js'), 'wrong extension is not a spec file');
+  assert.ok(!isSpecFile('index.cjs'), 'a plain .cjs is not a spec file');
+  assert.ok(!isSpecFile('specXcjs'), 'no dot before cjs is not a spec file');
+});
 
-it('declared manifest spec set == spec.cjs files on disk under ADAPTER_SMOKE_SPEC_ROOTS', () => {
-  const declared = ADAPTER_SMOKES.map((e) => path.resolve(e.specPath)).sort();
+it('reconcile partitions declared-vs-discovered into missing + undeclared (rf2-qf45gu)', () => {
+  const a = path.resolve(REPO_ROOT, 'x', 'a.spec.cjs');
+  const b = path.resolve(REPO_ROOT, 'x', 'b.spec.cjs');
+  const c = path.resolve(REPO_ROOT, 'x', 'c.spec.cjs');
+  // declared has {a,b}; on disk has {b,c} → a is missing, c is undeclared.
+  const { missing, undeclared } = reconcile([a, b], [b, c]);
+  assert.deepStrictEqual(missing, [a], 'declared-but-absent lands in missing');
+  assert.deepStrictEqual(undeclared, [c], 'on-disk-but-undeclared lands in undeclared');
+  // Set-equal inputs (any order, mixed abs/rel) reconcile clean — reconcile
+  // resolves both sides before diffing.
+  const rel = path.relative(process.cwd(), a);
+  const clean = reconcile([a, b], [b, rel]);
+  assert.deepStrictEqual(clean.missing, [], 'no drift → empty missing');
+  assert.deepStrictEqual(clean.undeclared, [], 'no drift → empty undeclared');
+});
+
+it('the real listSpecFiles + reconcile agree with the manifest on the live repo (rf2-qf45gu)', () => {
+  const declared = ADAPTER_SMOKES.map((e) => e.specPath);
   const discovered = listSpecFiles(ADAPTER_SMOKE_SPEC_ROOTS);
+  // listSpecFiles returns resolved, sorted absolute paths.
   assert.deepStrictEqual(
     discovered,
-    declared,
-    `manifest/disk drift.\n  on disk:  ${discovered.join('\n            ')}\n  declared: ${declared.join('\n            ')}`,
+    ADAPTER_SMOKES.map((e) => path.resolve(e.specPath)).sort(),
+    `manifest/disk drift.\n  on disk:  ${discovered.join('\n            ')}`,
   );
+  const { missing, undeclared } = reconcile(declared, discovered);
+  assert.deepStrictEqual(missing, [], `manifest references spec(s) not on disk: ${missing.join(', ')}`);
+  assert.deepStrictEqual(undeclared, [], `spec(s) on disk not in the manifest: ${undeclared.join(', ')}`);
 });
 
 it('ADAPTER_SMOKE_SPEC_ROOTS resolve under the repo root', () => {

--- a/implementation/scripts/_script-spawn-policy.test.cjs
+++ b/implementation/scripts/_script-spawn-policy.test.cjs
@@ -247,14 +247,24 @@ for (const [base, dir] of GATE_LAUNCHERS) {
 // window) by the `'-a', '127.0.0.1'` pair. NB `[\s\S]{0,80}?` not `[^]`
 // (the JS-regex `[^]`-any-char gotcha).
 const LOOPBACK_BIND_RE = loopbackBindRe('HTTP_SERVER_BIN');
+// [base, dir] pairs — most launchers live under implementation/scripts/, but
+// the adapter-smoke orchestrator moved to implementation/adapters/scripts/.
+// It is the very exemplar every failure message here points authors to
+// ("Match serve-and-run-adapter-smokes.cjs") yet it was itself UNGUARDED
+// (rf2-vwydab): it serves the compiled adapter bundle on loopback only
+// (readiness probe + headless browser both hit 127.0.0.1), so a future edit
+// dropping its explicit `-a 127.0.0.1` would silently re-expose the bundle
+// on 0.0.0.0 and trip no test. Guard it alongside the others, reading from
+// ADAPTERS_SCRIPTS_DIR.
 const IMPL_LOOPBACK_LAUNCHERS = [
-  'serve-and-run-browser-tests.cjs',
-  'check-story-static.cjs',
-  'serve-and-run-xray-feature-gate.cjs',
+  ['serve-and-run-browser-tests.cjs', SCRIPTS_DIR],
+  ['check-story-static.cjs', SCRIPTS_DIR],
+  ['serve-and-run-xray-feature-gate.cjs', SCRIPTS_DIR],
+  ['serve-and-run-adapter-smokes.cjs', ADAPTERS_SCRIPTS_DIR],
 ];
-for (const base of IMPL_LOOPBACK_LAUNCHERS) {
+for (const [base, dir] of IMPL_LOOPBACK_LAUNCHERS) {
   test(`${base}: http-server is bound to 127.0.0.1 explicitly (rf2-utvst)`, () => {
-    const src = fs.readFileSync(path.join(SCRIPTS_DIR, base), 'utf8');
+    const src = fs.readFileSync(path.join(dir, base), 'utf8');
     assert.match(
       src,
       LOOPBACK_BIND_RE,


### PR DESCRIPTION
Review-campaign (2026-07-09) test-infra coverage/quality gaps across `implementation/adapters/test-react` and `implementation/adapters/scripts`. Four beads, one commit each.

## rf2-dtmnl8 — render-depth finally-restore-on-throw, directly
`run-render!` promises render-depth is restored via `finally` even when a render body throws; a leaked non-zero depth would poison every later test (the next `unmount!` anywhere spuriously trips `:rf.error/sync-unmount-during-render`). Previously covered only indirectly (a trailing `unmount!` would throw a confusing uncaught `ExceptionInfo`), and the counter-not-boolean nested-unwind claim was unchecked.
- organic test: after the thrown block, assert `(false? (rendering?))` (finally-restore) + `(= 1 (count (mounted-roots)))` (the throwing host never registers — `mount-tree!` `conj`s into `active-mounts` only after `run-render!` returns — so no partial-mount leak).
- deep-cascade test: after the two-level nested mount, assert `(false? (rendering?))` — the counter decremented each nested level independently on unwind.

## rf2-axc9bc — de-vacuous the B.2 subscribe/dispose assertions
- balanced test: dropped the `live` atom theatre (test-local `swap inc/dec` bookkeeping that oversold arithmetic as an adapter "ref count" — there is none). Now asserts real properties: both children tracked before teardown, and `(empty? (children parent))` after (`children` returns only still-mounted children, so empty proves the cascade tore each down).
- unbalanced test: dropped `(is (not (zero? (count (mounted-roots)))))` — subsumed by the adjacent `(is (= 1 (count (mounted-roots))))`.

## rf2-vwydab — guard the adapter orchestrator's loopback bind
The loopback-bind policy's failure message tells authors to "Match serve-and-run-adapter-smokes.cjs", yet that orchestrator was NOT in the guarded set. It binds `-a 127.0.0.1` today, but a future edit dropping it (re-exposing the served bundle on 0.0.0.0) tripped no test. Added it to `IMPL_LOOPBACK_LAUNCHERS` (now `[base, dir]` pairs, reading from `ADAPTERS_SCRIPTS_DIR`).

## rf2-qf45gu — exercise the REAL listSpecFiles/reconcile
`run-adapter-smokes.cjs` owned `isSpecFile`/`listSpecFiles`/reconciliation; the fast-tier test RE-IMPLEMENTED the walker and asserted on the copy, so a bug in the runner's own walk/partition was caught only by a full Playwright run. Moved `isSpecFile` + `listSpecFiles` + a pure `reconcile(declared,discovered)->{missing,undeclared}` into `adapter-smoke-filter.cjs` (owns the manifest). The runner imports them (dropped local copies + the now-unused `fs` require); the test imports the same functions and adds direct coverage of `isSpecFile`, the reconcile partition (synthetic missing+undeclared), and a live-repo no-drift check.

## Quality gates (foreground, all green)
- `npm run test:cljs` — 8360 tests / 38442 assertions, 0 failures, 0 errors
- test-react artefact `clojure -M:test` — 24 tests / 87 assertions, 0 failures, 0 errors
- `node scripts/_script-spawn-policy.test.cjs` — 120 passed (loopback guard now covers the orchestrator)
- `node scripts/_adapter-smoke-filter.test.cjs` — all passed, incl. the 3 new rf2-qf45gu tests

## Stance
Pre-alpha, no shims. Test-only edits plus one minimal production export (`isSpecFile`/`listSpecFiles`/`reconcile` from `adapter-smoke-filter.cjs`, scoped to adapters/scripts) so the fast tier runs the real code path. CORRECTNESS + GOOD-PRACTICE; no over-engineering.
