### PR TITLE
test(conformance,epoch): de-vacuous skip-ops catalogue + sub-cache disposal + events assertion (rf2-gba3ou +2)

### DIFF
--- a/implementation/derivation-conformance/deps.edn
+++ b/implementation/derivation-conformance/deps.edn
@@ -34,9 +34,11 @@
 ;;                         materialized derivation's output equals what its
 ;;                         derivation fn computes from the same inputs; the
 ;;                         optional delta law is deferred per item 10.
-;;   (e) LIFECYCLE       — the §Conformance 'Lifecycle' RELEASE axis: frame
-;;                         destroy / route exit-supersession / machine
-;;                         final-state destroy releases the owned graph node.
+;;   (e) LIFECYCLE       — the §Conformance 'Lifecycle' RELEASE axis, all four
+;;                         spec clauses: frame destroy / subscription disposal
+;;                         (ref-count → 0, CLJS-only) / route exit-supersession
+;;                         / machine final-state destroy releases the owned
+;;                         graph node.
 ;;   (f) EVALUATION      — the §Conformance 'Evaluation policy' on-demand
 ;;                         no-write law: reading an `:on-demand` node causes
 ;;                         NO durable write (no app-db / runtime-db mutation).

--- a/implementation/derivation-conformance/test/re_frame/derivation_algebra_conformance_cljs_test.cljc
+++ b/implementation/derivation-conformance/test/re_frame/derivation_algebra_conformance_cljs_test.cljc
@@ -67,15 +67,19 @@
                           slice-1); a conforming implementation with NO
                           delta support still conforms.
     (e) LIFECYCLE       — the §Conformance 'Lifecycle' bullet's RELEASE
-                          axis (rf2-pomhpf): destroying a frame releases
-                          frame-owned graph nodes; route exit / supersession
-                          releases the prior route owner; machine destroy
-                          (here, final-state auto-destroy) releases the
-                          machine-owned snapshot node. The per-family suites
-                          and the (c) live arm only ever read a PRESENT
-                          owner; this arm drives the teardown TRANSITION and
-                          asserts the node / owner has LEFT the live graph —
-                          the axis the lifecycle classification exists for.
+                          axis (rf2-pomhpf), all FOUR spec clauses
+                          (spec/Derivations.md §Conformance Lifecycle):
+                          (1) destroying a frame releases frame-owned graph
+                          nodes; (2) subscription disposal releases its
+                          cache-entry node (rf2-q72kuo); (3) route exit /
+                          supersession releases the prior route owner; and
+                          (4) machine destroy (here, final-state auto-destroy)
+                          releases the machine-owned snapshot node. The
+                          per-family suites and the (c) live arm only ever
+                          read a PRESENT owner; these arms drive the teardown
+                          TRANSITION and assert the node / owner has LEFT the
+                          live graph — the axis the lifecycle classification
+                          exists for.
     (f) EVALUATION      — the §Conformance 'Evaluation policy' bullet's
                           on-demand-no-write law (rf2-qdxvkb; §Evaluation
                           policy rule 1): reading an `:on-demand` node (a
@@ -132,6 +136,11 @@
             [re-frame.resources.work-ledger :as work-ledger]
             [re-frame.machines.tooling :as machines-tooling]
             [re-frame.machines.paths :as machine-paths]
+            ;; rf2-q72kuo — the (e) subscription-disposal arm drives the real
+            ;; subscribe / unsubscribe cache path (CLJS): `subs/subscribe`
+            ;; mints the live cache entry, `subs/unsubscribe` drops the sole
+            ;; ref → sync dispose → eviction (Spec 006 §Reference counting).
+            [re-frame.subs :as subs]
             [re-frame.subs.tooling :as subs-tooling]
             [re-frame.flows.tooling :as flows-tooling]
             [re-frame.substrate.plain-atom :as plain-atom]
@@ -839,12 +848,16 @@
 ;; (e) LIFECYCLE — the §Conformance 'Lifecycle' bullet's RELEASE axis
 ;;     (rf2-pomhpf). Every prior arm (the per-family suites + the (c) live
 ;;     arm) only ever reads a PRESENT owner — positive presence. The lifecycle
-;;     classification exists for the RELEASE boundary: "destroying a frame
-;;     releases frame-owned graph nodes …; route exit releases route owners;
-;;     machine destroy releases machine-owned leases and timers" (§Lifecycle
-;;     and owner). These tests drive the teardown TRANSITION and assert the
-;;     node / owner has LEFT the live graph — the strongest adversarial arm,
-;;     a frame/route/machine teardown vacating the graph.
+;;     classification exists for the RELEASE boundary. The spec enumerates
+;;     FOUR release clauses (§Conformance Lifecycle): "destroying a frame
+;;     releases frame-owned graph nodes and host-transient state; subscription
+;;     disposal releases cache-entry nodes; route exit releases route owners;
+;;     machine destroy releases machine-owned leases and timers". These arms
+;;     drive each teardown TRANSITION and assert the node / owner has LEFT the
+;;     live graph — the strongest adversarial arm, a frame / subscription /
+;;     route / machine teardown vacating the graph. (Clause 2, subscription
+;;     disposal, is CLJS-only — the cached reactions are not deref-able on the
+;;     JVM — so its arm rides a reader conditional; rf2-q72kuo.)
 ;; ===========================================================================
 
 (deftest e-destroying-a-frame-releases-its-frame-owned-graph-nodes
@@ -984,6 +997,61 @@
           "the :machine-instance-owned snapshot node is gone after final-state auto-destroy")
       (is (nil? (get-in rt (machine-paths/snapshot-path :job/runner)))
           "the machine-owned snapshot is released from runtime-db (machine destroy releases its leases)"))))
+
+#?(:cljs
+   (deftest e-subscription-disposal-releases-its-cache-entry-node
+     ;; §Conformance Lifecycle, clause 2 ("subscription disposal releases
+     ;; cache-entry nodes") + §Lifecycle and owner (`:subscription-cache-entry`
+     ;; — the entry lives while a reader refs it; disposal on ref-count → 0
+     ;; releases it). The ONE family whose lifecycle RELEASE the (e) section
+     ;; did not drive: `b-storage-…` reads :subscription-cache-entry only as a
+     ;; PRESENT classification (the present-owner-only shape this section
+     ;; exists to go beyond). This is also the FIRST arm to drive the REAL
+     ;; live sub-cache → composer path end-to-end (`cplus-…` uses synthetic
+     ;; constantly-fn sub contributors; the only other real-path live arm,
+     ;; `gplus-…`, covers RESOURCES not subs). CLJS-only: `sub-cache-algebra-view`
+     ;; returns nil on the JVM (the cached reactions are not deref-able there),
+     ;; so the JVM gate elides this whole arm via the reader conditional.
+     (register-one-of-each!)
+     ;; A PARAMETRIC sub whose one realized input edge is a plain layer-1
+     ;; reader, so a concrete subscribe materializes exactly one clean cache
+     ;; entry (+ its :cart/items input) carrying a realized `[:sub q]` edge —
+     ;; no resource / unregistered-input fan-out.
+     (rf/reg-sub :cart/item-qty
+                 (fn [[_ _sku]] [[:cart/items]])
+                 (fn [[items] [_ sku]] (some #(when (= sku (:sku %)) (:qty %)) items)))
+     (rf/dispatch-sync [::seed-cart cart-items])
+     (let [q [:cart/item-qty "b"]
+           r (subs/subscribe q {:frame :rf/default})]
+       (is (= 3 @r)
+           "sanity: the parametric sub computes its whole value from the realized input")
+       ;; PRESENT in the composed LIVE graph — through the REAL
+       ;; `subs-tooling/sub-cache-algebra-view` the :subs contributor's
+       ;; :live-fn wires (`all-contributors`), reading live :sub-cache with
+       ;; :ref-count. A live cache-entry node is keyed `[:sub query-v]` by the
+       ;; composer (`graph/sub-node-id`), NOT the bare static sub-id. Presence
+       ;; is a FAILING PRECONDITION (rf2-djofbh): absence is a failure, not a
+       ;; skip — so the release assertion below cannot vacuously pass.
+       (let [g-before (graph/live-derivation-graph :rf/default all-contributors)
+             node     (get (:nodes g-before) [:sub q])]
+         (testing "the live subscribe materialized the cache-entry node (failing precondition)"
+           (is (some? node)
+               "subscribing MUST surface the [:sub [:cart/item-qty \"b\"]] cache-entry node in the composed live graph")
+           (is (= :derivation (:kind node)))
+           (is (= :subscription-cache-entry (:lifecycle node))
+               "the live node carries the :subscription-cache-entry lifecycle it is released under")
+           (is (= 1 (:ref-count node))
+               "one live reader keeps the cache entry alive — the :ref-count lifecycle evidence")))
+       ;; Dispose: the sole reader drops → synchronous ref-count → 0 → the
+       ;; reaction disposes and its on-dispose callback evicts the entry
+       ;; (Spec 006 §Reference counting and disposal; rf2-cmfln sync dispose).
+       (subs/unsubscribe :rf/default q)
+       (let [g-after (graph/live-derivation-graph :rf/default all-contributors)]
+         (testing "subscription disposal releases the cache-entry node from the live graph"
+           (is (nil? (get (:nodes g-after) [:sub q]))
+               "the :subscription-cache-entry node LEFT the composed live graph on disposal (ref-count → 0)")
+           (is (not (contains? (set (keys @(:sub-cache (frame/frame :rf/default)))) q))
+               "and the underlying :sub-cache entry is evicted — the release the node absence reflects"))))))
 
 ;; ===========================================================================
 ;; (f) EVALUATION POLICY — the §Conformance 'Evaluation policy' bullet's

--- a/implementation/epoch/src/re_frame/epoch/capture.cljc
+++ b/implementation/epoch/src/re_frame/epoch/capture.cljc
@@ -60,15 +60,26 @@
     :rf.epoch/restore-version-mismatch
     :rf.epoch/restore-during-drain
     :rf.epoch/restore-non-ok-record
-    ;; replace-frame-state! success (`:rf.epoch/db-replaced`) + two of its
-    ;; three failure modes (Tool-Pair §Pair-tool writes). All three ops
-    ;; listed here fire after the synthetic record has been built and the
-    ;; cascade-buffer (if any) has been harvested. The surface's third
-    ;; failure op, `:rf.epoch/replace-history-disabled`, is not yet skipped
-    ;; here (tracked by rf2-gba3ou).
+    ;; replace-frame-state! success (`:rf.epoch/db-replaced`) + all three of
+    ;; its precondition failure modes (Tool-Pair §Pair-tool writes). All fire
+    ;; after the synthetic record has been built and the cascade-buffer (if
+    ;; any) has been harvested — outside any cascade, each with a :frame tag.
+    ;; (The third failure op, `:rf.epoch/replace-history-disabled`, was added
+    ;; to skip-ops by rf2-gba3ou — see its dedicated note below; it was
+    ;; previously tracked-but-unskipped per rf2-f38xvb.)
     :rf.epoch/db-replaced
     :rf.epoch/replace-during-drain
     :rf.epoch/replace-schema-mismatch
+    ;; rf2-gba3ou / rf2-unpldn — depth-0 (history disabled) reject. The
+    ;; synthetic undo-anchor cannot land in the disabled ring, so
+    ;; replace-frame-state! rejects loudly with this op + a false return
+    ;; (`tool_pair/check-replace-frame-state-preconditions!`). It fires
+    ;; out-of-cascade with a :frame tag exactly like its two siblings
+    ;; above, so it must be skipped for the same reason. (Benign today —
+    ;; the orphan-drop branch backstops it — but skip-ops is the
+    ;; deliberate defense and the catalogue test now derives from the
+    ;; emit sites, so a forgotten op fails loudly.)
+    :rf.epoch/replace-history-disabled
     ;; Redact-fn exception warning (EP-0015 §15 + open-issue 6, RULED /
     ;; Tool-Pair §Time-travel §Redaction hook). Emitted by
     ;; `assembly/apply-redact-fn` at PROJECTION time (`projected-record`),

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -26,7 +26,9 @@
   React-commit / React-deref timing the synchronous JVM cascade can't
   reproduce. Consolidated there from this file (rf2-yp81r) so the whole
   attribution surface is one cohesive, invariant-keyed grep target."
-  (:require [clojure.string :as str]
+  (:require [clojure.java.io :as io]
+            [clojure.set :as set]
+            [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
@@ -133,6 +135,21 @@
   (some (fn [ev] (and (= :error (:op-type ev))
                       (= op     (:operation ev))))
         events))
+
+(defn- epoch-source-files
+  "Every epoch-artefact `.cljc` source file, discovered off the classpath
+  (the :local/root `src` dir) so a NEW file with a fresh emit site is
+  scanned automatically by `skip-ops-catalogue-pins-every-rf-epoch-op`.
+  The epoch package directory is located via a known file resource's
+  parent; the `re-frame.epoch` facade lives one level up."
+  []
+  (let [pkg-dir (-> (io/resource "re_frame/epoch/capture.cljc")
+                    io/file
+                    (.getParentFile))
+        facade  (io/file (io/resource "re_frame/epoch.cljc"))]
+    (cons facade
+          (filter #(str/ends-with? (.getName ^java.io.File %) ".cljc")
+                  (.listFiles pkg-dir)))))
 
 ;; ---- recording -------------------------------------------------------------
 
@@ -3411,35 +3428,132 @@
 
 (deftest skip-ops-catalogue-pins-every-rf-epoch-op
   (testing "skip-ops covers every :rf.epoch/* + :rf.warning/* op this
-            namespace emits with a :frame tag (catalogue test — adds
-            a fail-loudly signal if a new in-namespace op is
-            introduced and forgotten in `skip-ops`)"
-    ;; The exhaustive set as of rf2-wp70d. Update both this catalogue
-    ;; AND `skip-ops` when adding/removing an op the namespace emits.
-    ;; (`:rf.epoch.cb/silenced-on-frame-destroy` is op-type :rf.epoch.cb,
-    ;; not :rf.epoch — and it emits AFTER the frame's ring buffer has
-    ;; been dropped so it can't race a future cascade. Not in skip-ops.)
-    (let [expected #{:rf.epoch/snapshotted
-                     :rf.epoch/outcome                  ;; rf2-18g1w
-                     :rf.epoch/restored
-                     :rf.epoch/restore-unknown-epoch
-                     :rf.epoch/restore-schema-mismatch
-                     :rf.epoch/restore-missing-handler
-                     :rf.epoch/restore-version-mismatch
-                     :rf.epoch/restore-during-drain
-                     :rf.epoch/restore-non-ok-record    ;; rf2-v0jwt
-                     :rf.epoch/db-replaced
-                     :rf.epoch/replace-during-drain
-                     :rf.epoch/replace-schema-mismatch
-                     ;; rf2-wp70d: redact-fn exception warning emits
-                     ;; AFTER `harvest-buffer!` has emptied this
-                     ;; frame's cascade buffer, so it must be skipped
-                     ;; lest it accrete into the next cascade's record.
-                     :rf.warning/epoch-redact-fn-exception}
-          actual   @#'capture/skip-ops]
-      (is (= expected actual)
-          "skip-ops catalogue matches the documented set of
-           out-of-cascade :rf.epoch/* + :rf.warning/* emits"))))
+            namespace emits with a :frame tag OUTSIDE a cascade — the
+            out-of-cascade op set is DERIVED from the emit sites (source
+            reality), NOT a hand-literal compared against another
+            hand-literal, so a new op added to an emit site but forgotten
+            in `skip-ops` fails loudly (rf2-gba3ou — the prior
+            literal==literal shape was false-green: it missed
+            :rf.epoch/replace-history-disabled from BOTH literals)"
+    ;; --- (a) derive the emitted out-of-cascade op set from reality ------
+    ;; The epoch artefact emits an :rf.epoch/* | :rf.warning/* OPERATION
+    ;; through exactly two syntactic seams, both scanned here:
+    ;;   (trace/emit! <op-type> :rf.epoch/OP ...)   — the success emits
+    ;;                                                 (snapshotted / outcome
+    ;;                                                 / restored / db-replaced
+    ;;                                                 / the redact-fn warning)
+    ;;   {:outcome :fail :op :rf.epoch/OP ...}       — the precondition-failure
+    ;;                                                 results, emitted by
+    ;;                                                 `emit-precondition-failure!`
+    ;;                                                 via `trace/emit-error!`.
+    ;; Tag KEYS that share the :rf.epoch/ prefix (:rf.epoch/id,
+    ;; :rf.epoch/sensitive?, :rf.epoch/redacted-modified-paths-count) sit
+    ;; in map-KEY position, never after `emit!`/`:op`, so they are not
+    ;; operations and are not matched.
+    (let [src            (apply str (map slurp (epoch-source-files)))
+          hits->kws      (fn [hits] (into #{} (map #(keyword (subs % 1))) hits))
+          emit-ops       (hits->kws (map second
+                                         (re-seq #"emit!\s+:[A-Za-z.]+\s+(:rf\.(?:epoch|warning)/[a-z][a-z0-9-]*)"
+                                                 src)))
+          fail-ops       (hits->kws (map second
+                                         (re-seq #":op\s+(:rf\.(?:epoch|warning)/[a-z][a-z0-9-]*)"
+                                                 src)))
+          derived        (into emit-ops fail-ops)
+          ;; Every :rf.epoch/* op the artefact emits today fires OUTSIDE a
+          ;; cascade — the deliberate-enumeration design (capture.cljc
+          ;; §skip-ops catalogue). If a FUTURE in-cascade :rf.epoch/* op is
+          ;; introduced (e.g. an in-drain :rf.epoch/cascade-rollback trace)
+          ;; it MUST surface in the epoch record — NOT be skipped — so list
+          ;; it here to exempt it from the skip-ops obligation below. Empty
+          ;; today (no in-cascade :rf.epoch/* op exists yet).
+          in-cascade     #{}
+          out-of-cascade (set/difference derived in-cascade)
+          ;; --- (b) the human-readable pin, kept honest against reality ----
+          ;; This catalogue is ASSERTED equal to the scanned set below, so
+          ;; it can no longer silently drift (the rf2-gba3ou defect). Update
+          ;; it AND `skip-ops` when adding/removing an emitted op.
+          ;; (`:rf.epoch.cb/silenced-on-frame-destroy` is op-type :rf.epoch.cb,
+          ;; not :rf.epoch — and it emits AFTER the frame's ring buffer has
+          ;; been dropped so it can't race a future cascade. Not in skip-ops.)
+          expected       #{:rf.epoch/snapshotted
+                           :rf.epoch/outcome                  ;; rf2-18g1w
+                           :rf.epoch/restored
+                           :rf.epoch/restore-unknown-epoch
+                           :rf.epoch/restore-schema-mismatch
+                           :rf.epoch/restore-missing-handler
+                           :rf.epoch/restore-version-mismatch
+                           :rf.epoch/restore-during-drain
+                           :rf.epoch/restore-non-ok-record    ;; rf2-v0jwt
+                           :rf.epoch/db-replaced
+                           :rf.epoch/replace-during-drain
+                           :rf.epoch/replace-history-disabled ;; rf2-gba3ou / rf2-unpldn
+                           :rf.epoch/replace-schema-mismatch
+                           ;; rf2-wp70d: redact-fn exception warning emits
+                           ;; AFTER `harvest-buffer!` has emptied this
+                           ;; frame's cascade buffer, so it must be skipped
+                           ;; lest it accrete into the next cascade's record.
+                           :rf.warning/epoch-redact-fn-exception}
+          skip-ops       @#'capture/skip-ops]
+      ;; Anti-vacuity guard: an empty scanned set would make the SUPERSET
+      ;; assertion trivially true (the exact trap the old test fell into).
+      ;; A zero-match regex or a broken source path fails HERE.
+      (is (seq out-of-cascade)
+          "emit-site scan resolved the epoch source (non-vacuous)")
+      ;; The readable catalogue tracks the scanned reality — no silent drift.
+      (is (= expected out-of-cascade)
+          "documented catalogue == the ops actually emitted out-of-cascade")
+      ;; (a) TEETH: skip-ops is a SUPERSET of every out-of-cascade emitted
+      ;; op. An op added to an emit site but forgotten in skip-ops fails
+      ;; HERE (this is what missed :rf.epoch/replace-history-disabled).
+      (is (set/subset? out-of-cascade skip-ops)
+          "skip-ops covers every out-of-cascade :rf.epoch/* + :rf.warning/* op the namespace emits")
+      ;; No stale entry: every skipped op is one the namespace actually
+      ;; emits out-of-cascade (a removed emit left in skip-ops fails here).
+      (is (set/subset? skip-ops out-of-cascade)
+          "skip-ops has no stale entry the namespace no longer emits out-of-cascade"))))
+
+;; ---- rf2-gba3ou: depth-0 reject emit does not leak into next cascade ------
+;;
+;; Companion behavioural pin to the derived-catalogue test above. The
+;; depth-0 `replace-frame-state!` reject emits :rf.epoch/replace-history-disabled
+;; OUTSIDE a cascade with a :frame tag (Tool-Pair §Pair-tool writes / rf2-unpldn).
+;; The existing depth-0 tests (`replace-frame-state-app-only-depth-0-rejects-...`,
+;; `four-mutators-all-reject-under-depth-0`) assert reject / false / no-phantom-
+;; anchor but NOT that the emit stays out of the NEXT cascade's record. Depth 0
+;; disables the ring, so the next cascade's assembled record is observed via the
+;; epoch listener fan-out (rf2-douii — depth 0 still fires listeners). Skip-ops
+;; is the deliberate defense; the orphan-drop branch backstops the in-namespace
+;; leak so it is benign today (rf2-gba3ou) — this pins the end-to-end no-leak
+;; contract regardless of which layer enforces it.
+(deftest depth-0-replace-reject-emit-does-not-leak-into-next-cascade
+  (testing "rf2-gba3ou — the out-of-cascade :rf.epoch/replace-history-disabled
+            emit from a depth-0 replace-frame-state! reject does NOT surface in
+            the NEXT cascade's assembled record for that frame"
+    (rf/configure! {:epoch-history {:depth 0 :trace-events-keep 50}})
+    (rf/reg-frame :test/main {})
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :bump (fn [{:keys [db]} _] {:db (update db :n inc)}))
+
+    (let [seen (atom [])]
+      (rf/register-listener! :epoch ::watcher (fn [r] (swap! seen conj r)))
+      ;; Cascade 1 — a real event.
+      (rf/dispatch-sync [:seed] {:frame :test/main})
+      ;; Out-of-cascade reject: depth 0 → history disabled → rejected,
+      ;; emitting :rf.epoch/replace-history-disabled with a :frame tag.
+      (is (false? (rf/replace-frame-state! :test/main {:rf.db/app {:n 999}}))
+          "depth-0 replace-frame-state! is rejected (not a false success)")
+      ;; Cascade 2 — its record must reflect ONLY the :bump cascade.
+      (rf/dispatch-sync [:bump] {:frame :test/main})
+
+      (let [bump-rec (last @seen)]
+        (is (= :bump (:event-id bump-rec))
+            "next cascade's record is the real :bump event")
+        (is (= [:bump] (:trigger-event bump-rec))
+            ":trigger-event is the real event, not the leaked reject sentinel")
+        (is (not-any? (fn [ev] (= :rf.epoch/replace-history-disabled (:operation ev)))
+                      (:trace-events bump-rec))
+            "the out-of-drain reject emit does NOT leak into the next cascade's :trace-events"))
+      (rf/unregister-listener! :epoch ::watcher))))
 
 ;; ---- restore trace-tag :rf.epoch/id golden guard (rf2-5wzfez) ---------------
 ;;

--- a/implementation/event-conformance/test/re_frame/event_model_conformance_cljs_test.cljc
+++ b/implementation/event-conformance/test/re_frame/event_model_conformance_cljs_test.cljc
@@ -1302,6 +1302,42 @@
       (is (some #{:rf.error/reg-event-ctx-removed} @seen)
           "reg-event-ctx removal also fans out on the always-on channel"))))
 
+(deftest handled-event-fans-out-on-the-always-on-events-channel
+  ;; rf2-f5b8pd — the `:events` sibling of the error-channel fan-out above.
+  ;; The ns docstring (§`registries this tier asserts against`) AND the §8
+  ;; preamble both claim this tier asserts the always-on `register-event-
+  ;; listener!` fan-out, but only the error half (`retired-name-error-fans-
+  ;; out-…`) was ever driven — the `:events` half was a claim with no
+  ;; assertion behind it. This closes that gap so the claim is TRUE.
+  (testing "Spec 009 §Event-emit listener / EP-0018: a real one-form `reg-event`
+            dispatch fans out EXACTLY ONE tight record on the always-on
+            `:events` channel — `register-listener! :events` IS the low-level
+            `register-event-listener!` registry (core.cljc §stream verb), the
+            ADVANCED corpus-wide production-survivable hook fanned across EVERY
+            frame (survives `goog.DEBUG=false`), DISTINCT from the frame-owned
+            `:observability` sink locked in §8. A regression that stopped firing
+            the always-on per-event channel turns this RED"
+    (let [seen (atom [])]
+      (rf/register-listener! :events :evt-conf/handled-recorder
+        (fn [r] (swap! seen conj r)))
+      (rf/reg-frame :evt-conf/events-main {})
+      (rf/reg-event :evt-conf/events-probe
+        {:frame :evt-conf/events-main}
+        (fn [{:keys [db]} _] {:db (assoc db :touched true)}))
+      (rf/dispatch-sync [:evt-conf/events-probe] {:frame :evt-conf/events-main})
+      (is (= 1 (count @seen))
+          "exactly one always-on event-emit record per processed event")
+      (let [r (first @seen)]
+        (is (= :evt-conf/events-probe (:event-id r))
+            "the record names the processed event")
+        (is (= :evt-conf/events-main (:frame r))
+            "the record carries the resolved frame-id (fanned across EVERY frame)")
+        (is (= :ok (:outcome r))
+            "a clean settle reports :ok on the always-on channel")
+        (is (contains? r :elapsed-ms)
+            "the tight record carries the wall-clock :elapsed-ms slot (Spec 009 §Record shape)"))
+      (rf/unregister-listener! :events :evt-conf/handled-recorder))))
+
 ;; ===========================================================================
 ;; (5) PUBLIC FACADE classification — reg-event-ctx is NOT a public (doc'd)
 ;;     facade var, while reg-event IS. JVM-only meta probe (CLJS has no


### PR DESCRIPTION
Three test-hardening / false-green fixes across disjoint conformance artefacts. Each replaces a vacuous or absent assertion with one derived from reality, and each has a proven-teeth injection.

## rf2-gba3ou — skip-ops catalogue was false-green (epoch)
`skip-ops-catalogue-pins-every-rf-epoch-op` compared two hand-literals (`expected == @#'capture/skip-ops`), never deriving the emitted op set — so it missed `:rf.epoch/replace-history-disabled` absent from BOTH literals.
- **src touch:** add `:rf.epoch/replace-history-disabled` to `capture/skip-ops` (the depth-0 `replace-frame-state!` reject emits it out-of-cascade with a `:frame` tag, like its two siblings).
- catalogue test now **derives** the out-of-cascade op set by scanning the epoch emit sites (`trace/emit! <type> :rf.epoch/OP` and `:op :rf.epoch/OP`), asserts `skip-ops` is a **superset**, plus an anti-vacuity guard and a stale-entry check; the human pin is asserted equal to the scanned reality.
- new `depth-0-replace-reject-emit-does-not-leak-into-next-cascade` behavioural pin (observed via the epoch listener since depth 0 disables the ring).
- **Teeth:** removing the op from `skip-ops` turns the catalogue test RED on the superset assertion (the old literal==literal shape stayed green).

## rf2-q72kuo — subscription-disposal release never driven (derivation-conformance)
The (e) LIFECYCLE section drove 3 of 4 spec release clauses; clause 2 (subscription disposal releases cache-entry nodes) was only ever read as a PRESENT classification.
- new CLJS-only `e-subscription-disposal-releases-its-cache-entry-node`: subscribe to a parametric sub, confirm the entry present in the composed LIVE graph via the REAL `sub-cache-algebra-view` (`[:sub q]` keyed, `:ref-count`), then `unsubscribe` (ref-count → 0, sync dispose) and assert the node LEFT the live graph + the `:sub-cache` entry is evicted. First arm to exercise the real live sub-cache → composer path.
- coupled comment fix: (e) section header, ns-docstring (e) bullet, and `deps.edn` (e) bullet now enumerate all four clauses.
- **Teeth:** skipping the `unsubscribe` leaves the node + entry present → both release assertions RED.

## rf2-f5b8pd — register-event-listener! fan-out overclaimed (event-conformance)
The ns docstring + §8 preamble claimed the tier asserts the always-on `register-event-listener!` (`:events`) fan-out; nothing did (every assertion used `:trace` / `:errors`).
- new `handled-event-fans-out-on-the-always-on-events-channel`: a real one-form `reg-event` dispatch fans out exactly one tight record on the always-on `:events` channel (`register-listener! :events` == the low-level `register-event-listener!` registry, distinct from the frame-owned `:observability` sink locked in §8), asserting the Spec 009 record shape. Makes the comment true.
- **Teeth:** registering on the wrong stream (`:errors`) → no record → count + shape assertions RED.

## Quality gates (foreground)
- `implementation/epoch` `clojure -M:test` — **382 tests, 1522 assertions, 0 failures** (re-confirmed post teeth-revert).
- `implementation/derivation-conformance` `clojure -M:test` — **19 tests, 442 assertions, 0 failures** (JVM elides the CLJS-only arm).
- `implementation/event-conformance` `clojure -M:test` — **58 tests, 204 assertions, 0 failures**.
- `implementation` `npm run test:cljs` — **8362 tests, 38451 assertions, 0 failures** (covers the CLJS-only derivation arm + the dual-runtime event assertion); focused derivation-conformance arm re-confirmed 20/2822 green post-revert.

## Stance
Pre-alpha, no shims. CORRECTNESS + GOOD-PRACTICE: each change makes a vacuous/absent assertion real (derive-from-reality over literal==literal), scoped to test surfaces + one tiny `skip-ops` src addition; no unrelated production edits. Not over-engineered — the epoch scan carries an explicit (empty today) in-cascade allow-set so a future in-drain `:rf.epoch/*` op is not wrongly forced into `skip-ops`.