### PR TITLE
test(examples): flight-booker dates + todomvc + crud contract coverage (rf2-6t486x +2)

### DIFF
--- a/implementation/core/test/re_frame/crud_cljs_test.cljs
+++ b/implementation/core/test/re_frame/crud_cljs_test.cljs
@@ -1,0 +1,193 @@
+(ns re-frame.crud-cljs-test
+  "Behavioural regression coverage for the 7GUIs CRUD example (rf2-e4nwdr).
+
+  CRUD is the master/detail screen: a filtered name list, a draft slice behind
+  the two inputs, and Create/Update/Delete. Its demonstrated logic had no
+  event/sub coverage — only `re-frame.example-frame-scoping-cljs-test` touched
+  it, and only to assert its ns-load `[:crud]` app-schema landed on
+  `:rf/default`. The uncovered, silently-breakable behaviour:
+
+    - `:crud/can-update?` — Update/Delete are disabled when the selected row is
+      HIDDEN by the current prefix filter, and re-enabled when the filter is
+      cleared. The selection is NOT dropped; can-update? just asks whether the
+      selection is still in `:crud/filtered-people` (the example calls this out
+      as its point). A regression that lights Update/Delete on a filtered-out
+      selection is invisible.
+    - `:crud/create` — a monotonic `:next-id` allocator (replay-stable ids that
+      are never reissued) + select-the-new-row.
+    - `:crud/update` — merge the draft into the SELECTED row only.
+    - `:crud/delete` — remove + clear selection/draft.
+    - `:crud/select` — copy the person's name/surname into the draft.
+    - `:crud/filtered-people` — case-insensitive SURNAME prefix.
+
+  These belong in the framework test tree, NOT under `examples/` (examples stay
+  test-free per rf2-8cevm). They `:require` `seven-guis.crud.core` (a
+  Reagent-coupled `.cljs`-only ns) so they run under the consolidated
+  `:node-test` CLJS build, which has `../examples/core` on its source paths.
+  Handlers are driven via `dispatch-sync` on an anon frame; subs are read via
+  `rf/compute-sub` (every CRUD sub is an app-db sub, so a bare app-db suffices)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
+            [seven-guis.crud.core]))
+
+;; `:ambient-frame nil` — these tests create + drive their own anon frames with
+;; an explicit `{:frame f}`. The `[:crud]` app-schema is bound to `:rf/default`,
+;; not to these anon frames, so commits here run unvalidated; behavioural logic
+;; is what's under test, and the schema binding is pinned by example-frame-scoping.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       reagent-adapter/adapter
+     :ambient-frame nil}))
+
+;; ---------------------------------------------------------------------------
+;; helpers
+;; ---------------------------------------------------------------------------
+
+(defn- crud-frame!
+  "Boot a fresh anon frame seeded via `:crud/initialise` — the three 7GUIs
+  reference people (ids 1-3), next-id 4, empty filter, no selection, blank
+  draft. Returns the frame id."
+  []
+  (let [f (frame/make-anon-frame-record! {:doc "crud test frame"})]
+    (rf/dispatch-sync [:crud/initialise] {:frame f})
+    f))
+
+(defn- crud [f] (:crud (rf/app-db-value f)))
+(defn- people [f] (:people (crud f)))
+(defn- person [f id] (first (filter #(= id (:id %)) (people f))))
+(defn- sub [f query-v] (rf/compute-sub query-v (rf/app-db-value f)))
+(defn- surnames [ppl] (set (map :surname ppl)))
+
+;; ---------------------------------------------------------------------------
+;; seed + select
+;; ---------------------------------------------------------------------------
+
+(deftest initialise-seeds-the-reference-list
+  (testing "the seed is the three 7GUIs people with counted ids, next-id 4, no
+            filter, no selection, blank draft"
+    (let [f (crud-frame!)]
+      (is (= [1 2 3] (mapv :id (people f))))
+      (is (= #{"Emil" "Mustermann" "Tisch"} (surnames (people f))))
+      (is (= 4 (:next-id (crud f))))
+      (is (= "" (:filter-text (crud f))))
+      (is (nil? (:selected-id (crud f))))
+      (is (= {:name "" :surname ""} (:draft (crud f)))))))
+
+(deftest select-copies-name-and-surname-into-draft
+  (testing "selecting a row remembers the selection and copies that person's
+            name/surname into the draft (so the inputs show them)"
+    (let [f (crud-frame!)]
+      (rf/dispatch-sync [:crud/select 2] {:frame f})
+      (is (= 2 (:selected-id (crud f))))
+      (is (= {:name "Max" :surname "Mustermann"} (:draft (crud f)))))))
+
+;; ---------------------------------------------------------------------------
+;; create — monotonic, replay-stable ids that are never reissued
+;; ---------------------------------------------------------------------------
+
+(deftest create-appends-with-next-id-and-selects-it
+  (testing "create adds the draft as a new person with the next-id, bumps the
+            allocator, and selects the new row"
+    (let [f (crud-frame!)]
+      (rf/dispatch-sync [:crud/edit-name "Ada"] {:frame f})
+      (rf/dispatch-sync [:crud/edit-surname "Lovelace"] {:frame f})
+      (rf/dispatch-sync [:crud/create] {:frame f})
+      (is (= [1 2 3 4] (mapv :id (people f))) "appended with id 4")
+      (is (= {:id 4 :name "Ada" :surname "Lovelace"} (person f 4)))
+      (is (= 5 (:next-id (crud f))) "allocator bumped")
+      (is (= 4 (:selected-id (crud f))) "the new row is selected"))))
+
+(deftest create-ids-are-monotonic-and-never-reissued
+  (testing "rf2-e4nwdr — the id allocator is monotonic: a subsequent create
+            never reuses an id, even one freed by an intervening delete. An
+            allocator that reissues is a silent, replay-corrupting bug"
+    (let [f (crud-frame!)]
+      (rf/dispatch-sync [:crud/create] {:frame f})            ;; id 4, selected 4
+      (rf/dispatch-sync [:crud/create] {:frame f})            ;; id 5, selected 5
+      (is (= [1 2 3 4 5] (mapv :id (people f))))
+      (is (= 6 (:next-id (crud f))))
+      (rf/dispatch-sync [:crud/delete] {:frame f})            ;; delete selected 5
+      (is (= [1 2 3 4] (mapv :id (people f))))
+      (rf/dispatch-sync [:crud/create] {:frame f})            ;; next id must be 6, NOT 5
+      (is (= [1 2 3 4 6] (mapv :id (people f)))
+          "the freed id 5 is NOT reissued — allocation stays monotonic")
+      (is (= 7 (:next-id (crud f)))))))
+
+;; ---------------------------------------------------------------------------
+;; update — merge draft into the selected row only
+;; ---------------------------------------------------------------------------
+
+(deftest update-merges-draft-into-selected-row-only
+  (testing "update writes the draft onto the selected person and leaves every
+            other row untouched"
+    (let [f (crud-frame!)]
+      (rf/dispatch-sync [:crud/select 1] {:frame f})          ;; draft <- Hans Emil
+      (rf/dispatch-sync [:crud/edit-name "Johann"] {:frame f})
+      (rf/dispatch-sync [:crud/update] {:frame f})
+      (is (= {:id 1 :name "Johann" :surname "Emil"} (person f 1)) "selected row updated")
+      (is (= {:id 2 :name "Max" :surname "Mustermann"} (person f 2)) "other rows untouched")
+      (is (= {:id 3 :name "Roman" :surname "Tisch"} (person f 3))))))
+
+(deftest update-with-no-selection-is-a-noop
+  (testing "with nothing selected, update leaves the list unchanged"
+    (let [f (crud-frame!)]
+      (rf/dispatch-sync [:crud/edit-name "Ghost"] {:frame f})
+      (rf/dispatch-sync [:crud/update] {:frame f})
+      (is (= [{:id 1 :name "Hans" :surname "Emil"}
+              {:id 2 :name "Max" :surname "Mustermann"}
+              {:id 3 :name "Roman" :surname "Tisch"}]
+             (people f))))))
+
+;; ---------------------------------------------------------------------------
+;; delete — remove + clear selection/draft
+;; ---------------------------------------------------------------------------
+
+(deftest delete-removes-selected-and-clears-selection
+  (testing "delete removes the selected person and clears both selection and draft"
+    (let [f (crud-frame!)]
+      (rf/dispatch-sync [:crud/select 2] {:frame f})
+      (rf/dispatch-sync [:crud/delete] {:frame f})
+      (is (= [1 3] (mapv :id (people f))) "row 2 removed")
+      (is (nil? (:selected-id (crud f))) "selection cleared")
+      (is (= {:name "" :surname ""} (:draft (crud f))) "draft cleared"))))
+
+;; ---------------------------------------------------------------------------
+;; filtered-people — case-insensitive surname prefix
+;; ---------------------------------------------------------------------------
+
+(deftest filtered-people-matches-surname-prefix-case-insensitively
+  (testing ":crud/filtered-people keeps rows whose SURNAME starts with the
+            prefix, case-insensitively; a blank filter shows everyone"
+    (let [f (crud-frame!)]
+      (is (= #{"Emil" "Mustermann" "Tisch"} (surnames (sub f [:crud/filtered-people])))
+          "empty filter -> all")
+      (rf/dispatch-sync [:crud/set-filter "mus"] {:frame f})
+      (is (= #{"Mustermann"} (surnames (sub f [:crud/filtered-people]))))
+      (rf/dispatch-sync [:crud/set-filter "EMIL"] {:frame f})
+      (is (= #{"Emil"} (surnames (sub f [:crud/filtered-people])))
+          "prefix match is on the SURNAME and case-insensitive")
+      (rf/dispatch-sync [:crud/set-filter "z"] {:frame f})
+      (is (= #{} (surnames (sub f [:crud/filtered-people]))) "no match -> empty"))))
+
+;; ---------------------------------------------------------------------------
+;; can-update? — filter-visibility of the selection (the example's point)
+;; ---------------------------------------------------------------------------
+
+(deftest can-update?-tracks-selection-visibility-under-filter
+  (testing "rf2-e4nwdr — can-update? is true only when the selected row is
+            visible under the current filter. Hiding the selection with a
+            filter disables Update/Delete WITHOUT dropping the selection;
+            clearing the filter re-enables them. Lighting them on a
+            filtered-out selection would be a silent bug"
+    (let [f (crud-frame!)]
+      (is (false? (sub f [:crud/can-update?])) "no selection -> disabled")
+      (rf/dispatch-sync [:crud/select 1] {:frame f})          ;; Hans, surname Emil
+      (is (true? (sub f [:crud/can-update?])) "selected + visible -> enabled")
+      (rf/dispatch-sync [:crud/set-filter "Mus"] {:frame f})  ;; hides Emil
+      (is (false? (sub f [:crud/can-update?])) "selection hidden by filter -> disabled")
+      (is (= 1 (:selected-id (crud f))) "the selection is NOT dropped, only hidden")
+      (rf/dispatch-sync [:crud/set-filter ""] {:frame f})     ;; row reappears
+      (is (true? (sub f [:crud/can-update?])) "filter cleared -> re-enabled"))))

--- a/implementation/core/test/re_frame/flight_booker_cljs_test.cljs
+++ b/implementation/core/test/re_frame/flight_booker_cljs_test.cljs
@@ -1,0 +1,181 @@
+(ns re-frame.flight-booker-cljs-test
+  "Behavioural regression coverage for the 7GUIs Flight Booker example
+  (rf2-6t486x). The example demonstrates *derived UI state as a subscription*
+  — the Book button's enabled-ness is `:flight/book-enabled?`, a keystone sub
+  ANDing three smaller answers — yet had ZERO behavioural coverage: only
+  `re-frame.example-frame-scoping-cljs-test` touched it, and only to assert its
+  ns-load `[:flight]` app-schema landed on `:rf/default`. Nothing exercised the
+  actual date logic or the sub graph, so a regression that ACCEPTS an
+  impossible date, drops the deliberate `setUTCFullYear` low-year guard, or
+  lights Book when `return < start` would ship silently green.
+
+  These belong in the framework test tree, NOT under `examples/` (examples stay
+  test-free per rf2-8cevm). They exercise the example by `:require`ing
+  `seven-guis.flight-booker.core` — a Reagent-coupled `.cljs`-only namespace —
+  so they run under the consolidated `:node-test` CLJS build, which has
+  `../examples/core` on its source paths (mirrors the classpath reach of
+  `re-frame.seven-guis-cells-parser-cljs-test`).
+
+  Two axes:
+    1. `valid-date?` — the PURE calendar-validity fn. Leap-year correctness via
+       the UTC round-trip, the deliberate `setUTCFullYear` (NOT `js/Date.UTC`,
+       which would corrupt low four-digit years like `0026` to `1926`), and
+       rejection of shape-valid-but-impossible dates.
+    2. The sub graph (`:flight/return-enabled?` / `:flight/start-valid?` /
+       `:flight/return-valid?` / `:flight/dates-coherent?` /
+       `:flight/book-enabled?`) — driven by the real event handlers via
+       `dispatch-sync` on an anon frame, read back via `rf/compute-sub`."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
+            [seven-guis.flight-booker.core :as flight]))
+
+;; `:ambient-frame nil` — these tests create their own top-level anon frames via
+;; `make-anon-frame-record!` and drive them with an explicit `{:frame f}`, so
+;; there must be no ambient `:rf/default` scope masking frame resolution (the
+;; `[:flight]` app-schema is bound to `:rf/default`, not to these anon frames,
+;; so commits here run unvalidated — behavioural logic is what's under test,
+;; and the schema binding is already pinned by example-frame-scoping).
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       reagent-adapter/adapter
+     :ambient-frame nil}))
+
+;; ===========================================================================
+;; valid-date? — pure calendar validity (leap-year UTC round-trip)
+;; ===========================================================================
+
+(deftest valid-date?-accepts-real-calendar-dates
+  (testing "well-formed real dates round-trip cleanly and pass"
+    (doseq [s ["2026-05-06"   ;; the seed date
+               "2024-02-29"   ;; leap day of a divisible-by-4 year
+               "2000-02-29"   ;; divisible-by-400 century — a real leap day
+               "2026-12-31"   ;; year-end edge
+               "2026-01-01"]] ;; year-start edge
+      (is (true? (flight/valid-date? s)) (str s " is a real date")))))
+
+(deftest valid-date?-rejects-impossible-but-shape-valid-dates
+  (testing "the regex only checks SHAPE; these pass it but are not real dates,
+            and the UTC round-trip must reject each (a silent-accept regression
+            here is exactly what this example's derived-state design guards)"
+    (doseq [s ["2026-02-31"   ;; February never has 31 days
+               "2025-02-29"   ;; 2025 is NOT a leap year — overflows to March
+               "1900-02-29"   ;; divisible-by-100-not-400 — NOT a leap year
+               "2026-99-99"   ;; nonsense month and day
+               "2026-13-01"   ;; month 13
+               "2026-00-10"   ;; month 0
+               "2026-05-00"   ;; day 0
+               "2026-04-31"]] ;; April has 30 days
+      (is (false? (flight/valid-date? s))
+          (str s " is shape-valid but not a real calendar date")))))
+
+(deftest valid-date?-rejects-malformed-shapes
+  (testing "anything the ISO yyyy-mm-dd regex rejects is invalid, including nil"
+    (doseq [s ["2026-5-6"          ;; single-digit month/day
+               "20260506"          ;; no separators
+               "2026/05/06"        ;; wrong separator
+               "2026-05-06T00:00"  ;; trailing time
+               "not-a-date"
+               ""
+               nil]]
+      (is (false? (flight/valid-date? s))
+          (str (pr-str s) " is not ISO yyyy-mm-dd")))))
+
+(deftest valid-date?-low-year-uses-setUTCFullYear-not-date-utc
+  (testing "rf2-6t486x — the DELIBERATE `setUTCFullYear` (not `js/Date.UTC`):
+            a low four-digit year like 0026 must round-trip to 26, NOT be
+            corrupted to 1926 (the 0-99 -> 1900-1999 mapping `js/Date.UTC`
+            would apply). A revert to `js/Date.UTC` makes the round-trip fail
+            its own year check and this date would be wrongly rejected"
+    (is (true? (flight/valid-date? "0026-05-06"))
+        "year 0026 is a real date under setUTCFullYear's faithful low-year handling")
+    (is (true? (flight/valid-date? "0099-12-31"))
+        "year 0099 too — still below the js/Date.UTC 1900-window boundary")
+    (is (true? (flight/valid-date? "0001-01-01"))
+        "year 0001 — the extreme low edge")))
+
+;; ===========================================================================
+;; sub graph — driven through the real handlers on an anon frame
+;; ===========================================================================
+
+(defn- flight-frame!
+  "Boot a fresh anon frame seeded via `:flight/initialise` (one-way,
+  start = return = 2026-05-06). Returns the frame id."
+  []
+  (let [f (frame/make-anon-frame-record! {:doc "flight-booker test frame"})]
+    (rf/dispatch-sync [:flight/initialise] {:frame f})
+    f))
+
+(defn- sub
+  "Compute a flight sub against the frame's current app-db snapshot. Every
+  flight sub is an app-db (layer-1/`:<-`) sub, so a bare app-db value suffices."
+  [f query-v]
+  (rf/compute-sub query-v (rf/app-db-value f)))
+
+(deftest seed-state-lights-book
+  (testing "the seeded one-way form (both dates the same valid ISO date) is a
+            fully bookable state — every leg of the AND holds"
+    (let [f (flight-frame!)]
+      (is (false? (sub f [:flight/return-enabled?])) "one-way disables the return input")
+      (is (true?  (sub f [:flight/start-valid?])))
+      (is (true?  (sub f [:flight/return-valid?])) "one-way: return validity is not required")
+      (is (true?  (sub f [:flight/dates-coherent?])))
+      (is (true?  (sub f [:flight/book-enabled?])) "Book is clickable"))))
+
+(deftest invalid-start-date-blocks-book
+  (testing "an impossible start date fails start-valid? and drops book-enabled?"
+    (let [f (flight-frame!)]
+      (rf/dispatch-sync [:flight/set-start "2026-02-31"] {:frame f})
+      (is (false? (sub f [:flight/start-valid?])))
+      (is (false? (sub f [:flight/book-enabled?]))))))
+
+(deftest one-way-skips-return-validation
+  (testing "on a one-way trip the return field can hold total garbage and Book
+            stays enabled — return-valid? short-circuits to true when the
+            return input is disabled"
+    (let [f (flight-frame!)]
+      (rf/dispatch-sync [:flight/set-return "not-a-date-at-all"] {:frame f})
+      (is (false? (sub f [:flight/return-enabled?])))
+      (is (true?  (sub f [:flight/return-valid?])) "return validity waived while one-way")
+      (is (true?  (sub f [:flight/dates-coherent?])) "coherence is trivially true one-way")
+      (is (true?  (sub f [:flight/book-enabled?]))))))
+
+(deftest return-trip-requires-a-valid-return-date
+  (testing "switching to a return trip enables the return input, and an invalid
+            return date now blocks Book"
+    (let [f (flight-frame!)]
+      (rf/dispatch-sync [:flight/set-trip-type :return] {:frame f})
+      (is (true? (sub f [:flight/return-enabled?])))
+      (rf/dispatch-sync [:flight/set-return "2026-02-31"] {:frame f})
+      (is (false? (sub f [:flight/return-valid?])))
+      (is (false? (sub f [:flight/book-enabled?]))))))
+
+(deftest return-before-start-is-incoherent
+  (testing "rf2-6t486x — the silent bug this example prevents: Book must NOT
+            light when a return trip's return date precedes its start date.
+            Coherence is a lexicographic ISO compare (return >= start)"
+    (let [f (flight-frame!)]
+      (rf/dispatch-sync [:flight/set-trip-type :return] {:frame f})
+      (rf/dispatch-sync [:flight/set-start "2026-05-10"] {:frame f})
+      (rf/dispatch-sync [:flight/set-return "2026-05-06"] {:frame f})
+      (is (true?  (sub f [:flight/start-valid?])) "both dates parse")
+      (is (true?  (sub f [:flight/return-valid?])))
+      (is (false? (sub f [:flight/dates-coherent?])) "return < start")
+      (is (false? (sub f [:flight/book-enabled?])) "Book stays disabled"))))
+
+(deftest return-on-or-after-start-is-coherent
+  (testing "a return trip with return >= start is coherent and bookable, and the
+            boundary case return = start (>=, not >) also lights Book"
+    (let [f (flight-frame!)]
+      (rf/dispatch-sync [:flight/set-trip-type :return] {:frame f})
+      (rf/dispatch-sync [:flight/set-start "2026-05-06"] {:frame f})
+      ;; return strictly after start
+      (rf/dispatch-sync [:flight/set-return "2026-05-10"] {:frame f})
+      (is (true? (sub f [:flight/dates-coherent?])))
+      (is (true? (sub f [:flight/book-enabled?])))
+      ;; return exactly equal to start — the >= boundary
+      (rf/dispatch-sync [:flight/set-return "2026-05-06"] {:frame f})
+      (is (true? (sub f [:flight/dates-coherent?])) "return = start is coherent")
+      (is (true? (sub f [:flight/book-enabled?]))))))

--- a/implementation/core/test/re_frame/todomvc_cljs_test.cljs
+++ b/implementation/core/test/re_frame/todomvc_cljs_test.cljs
@@ -1,0 +1,206 @@
+(ns re-frame.todomvc-cljs-test
+  "Behavioural regression coverage for the TodoMVC example (rf2-km3ssc).
+
+  TodoMVC's dataflow — one event per intent, a layered sub graph, and a filter
+  the app DELIBERATELY never stores (it derives `:todo/showing` from the route
+  id: `one fact, one home`) — had almost no behavioural coverage. The only
+  prior test pinned the cold-boot id-allocation / sorted-map invariant on the
+  ADD path (rf2-mzqd4.1). Everything else was untested: `:todo/toggle-completed`,
+  `:todo/save` (blank title -> delete), `:todo/delete`, `:todo/clear-completed`,
+  `:todo/toggle-all` (mark-all-complete UNLESS all already complete), and the
+  sub graph — `:todo/showing` (route -> filter), `:todo/visible-todos` (filter
+  predicate), `:todo/all-complete?`, `:todo/footer-counts`. A regression in
+  toggle-all's all-complete? inversion, the visible-todos predicate, or the
+  route->filter mapping would produce a visibly broken TodoMVC with a green
+  suite.
+
+  These belong in the framework test tree, NOT under `examples/` (examples stay
+  test-free per rf2-8cevm). They `:require` `todomvc.core` (a Reagent-coupled
+  `.cljs`-only entry ns, transitively pulling its events / subs / db) so they
+  run under the consolidated `:node-test` CLJS build, which has
+  `../examples/core` on its source paths.
+
+  Two axes:
+    1. The event handlers — driven via `dispatch-sync` on an anon frame,
+       asserting the resulting `:todos` app-db slice.
+    2. The sub graph — read via `rf/compute-sub`. `:todo/showing` is a
+       runtime-db sub chain (`:<- [:rf.route/id]`, which reads the route slice
+       at `[:rf.runtime/routing :current :route-id]`), so those reads use a
+       FULL frame-state value with the route-id injected — exercising the exact
+       route->filter mapping across all three routes plus the fallback."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
+            ;; Requiring the entry ns fires todomvc's ns-load reg-event /
+            ;; reg-sub / reg-route / reg-fx / reg-cofx forms against the live
+            ;; registrar (captured into this ns's fixture baseline).
+            [todomvc.core]))
+
+;; `:ambient-frame nil` — these tests create + drive their own anon frames with
+;; an explicit `{:frame f}`; no ambient `:rf/default` scope is wanted.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       reagent-adapter/adapter
+     :ambient-frame nil}))
+
+;; ---------------------------------------------------------------------------
+;; helpers
+;; ---------------------------------------------------------------------------
+
+(defn- todo-frame!
+  "Boot a fresh anon frame seeded via `:todo/initialise`. The initialise cofx
+  reads localStorage; under Node there is none, so it seeds an empty
+  sorted-map — deterministic. Returns the frame id."
+  []
+  (let [f (frame/make-anon-frame-record! {:doc "todomvc test frame"})]
+    (rf/dispatch-sync [:todo/initialise] {:frame f})
+    f))
+
+(defn- todos [f]
+  (:todos (rf/app-db-value f)))
+
+(defn- with-route
+  "The frame's full state with the route-id injected into the runtime-db route
+  slice, so the `:rf.route/id`-derived `:todo/showing` chain computes as it
+  would under a real navigation. Pass to `compute-sub` for the showing /
+  visible-todos reads."
+  [f route-id]
+  (assoc-in (rf/frame-state-value f)
+            [:rf.db/runtime :rf.runtime/routing :current :route-id]
+            route-id))
+
+(defn- titles [todo-seq] (set (map :title todo-seq)))
+
+;; ---------------------------------------------------------------------------
+;; events
+;; ---------------------------------------------------------------------------
+
+(deftest add-allocates-ids-and-skips-blank
+  (testing "add appends with a monotonic id off the sorted-map's high key, trims
+            the title, and a blank/whitespace title is a no-op that allocates
+            no id"
+    (let [f (todo-frame!)]
+      (is (= [] (vec (keys (todos f)))) "initialise seeds an empty list")
+      (rf/dispatch-sync [:todo/add "Buy milk"] {:frame f})
+      (rf/dispatch-sync [:todo/add "   "] {:frame f})        ;; blank -> skipped
+      (rf/dispatch-sync [:todo/add "  Walk dog  "] {:frame f})
+      (is (= [1 2] (vec (keys (todos f))))
+          "blank allocated no id — the second real add is 2, not 3")
+      (is (= "Buy milk" (get-in (todos f) [1 :title])))
+      (is (= "Walk dog" (get-in (todos f) [2 :title])) "title is trimmed")
+      (is (false? (get-in (todos f) [1 :completed])) "new todos start active"))))
+
+(deftest toggle-completed-flips-one-row
+  (testing "toggle-completed flips exactly the addressed row's :completed flag"
+    (let [f (todo-frame!)]
+      (rf/dispatch-sync [:todo/add "a"] {:frame f})
+      (rf/dispatch-sync [:todo/add "b"] {:frame f})
+      (rf/dispatch-sync [:todo/toggle-completed 1] {:frame f})
+      (is (true?  (get-in (todos f) [1 :completed])))
+      (is (false? (get-in (todos f) [2 :completed])) "the other row is untouched")
+      (rf/dispatch-sync [:todo/toggle-completed 1] {:frame f})
+      (is (false? (get-in (todos f) [1 :completed])) "toggling again flips back"))))
+
+(deftest toggle-all-inverts-only-when-not-already-all-complete
+  (testing "rf2-km3ssc — toggle-all marks every row complete UNLESS they are
+            already all complete, in which case it marks them all active. A
+            regression in that all-complete? inversion is a silent bug"
+    (let [f (todo-frame!)]
+      (rf/dispatch-sync [:todo/add "a"] {:frame f})
+      (rf/dispatch-sync [:todo/add "b"] {:frame f})
+      (rf/dispatch-sync [:todo/add "c"] {:frame f})
+      ;; one already complete, two active -> NOT all complete -> mark all complete
+      (rf/dispatch-sync [:todo/toggle-completed 2] {:frame f})
+      (rf/dispatch-sync [:todo/toggle-all] {:frame f})
+      (is (every? :completed (vals (todos f))) "mixed -> all complete")
+      ;; now all complete -> toggle-all marks them all active
+      (rf/dispatch-sync [:todo/toggle-all] {:frame f})
+      (is (not-any? :completed (vals (todos f))) "all-complete -> all active"))))
+
+(deftest save-trims-non-blank-and-deletes-on-blank
+  (testing "save with a non-blank title updates + trims that row; save with a
+            blank title deletes the row entirely"
+    (let [f (todo-frame!)]
+      (rf/dispatch-sync [:todo/add "a"] {:frame f})
+      (rf/dispatch-sync [:todo/add "b"] {:frame f})
+      (rf/dispatch-sync [:todo/save 1 "  renamed  "] {:frame f})
+      (is (= "renamed" (get-in (todos f) [1 :title])) "non-blank save trims + updates")
+      (rf/dispatch-sync [:todo/save 2 "   "] {:frame f})
+      (is (nil? (get-in (todos f) [2])) "blank save deletes the row")
+      (is (= [1] (vec (keys (todos f))))))))
+
+(deftest delete-removes-the-row
+  (testing "delete removes exactly the addressed row"
+    (let [f (todo-frame!)]
+      (rf/dispatch-sync [:todo/add "a"] {:frame f})
+      (rf/dispatch-sync [:todo/add "b"] {:frame f})
+      (rf/dispatch-sync [:todo/delete 1] {:frame f})
+      (is (= [2] (vec (keys (todos f)))))
+      (is (= "b" (get-in (todos f) [2 :title]))))))
+
+(deftest clear-completed-removes-completed-and-keeps-sorted-map
+  (testing "clear-completed drops every completed row, keeps the active ones,
+            and the result stays a sorted-map (allocate-next-id depends on it)"
+    (let [f (todo-frame!)]
+      (rf/dispatch-sync [:todo/add "a"] {:frame f})
+      (rf/dispatch-sync [:todo/add "b"] {:frame f})
+      (rf/dispatch-sync [:todo/add "c"] {:frame f})
+      (rf/dispatch-sync [:todo/toggle-completed 1] {:frame f})
+      (rf/dispatch-sync [:todo/toggle-completed 3] {:frame f})
+      (rf/dispatch-sync [:todo/clear-completed] {:frame f})
+      (is (= [2] (vec (keys (todos f)))) "only the active row survives")
+      (is (sorted? (todos f)) "clear-completed re-folds into a sorted-map"))))
+
+;; ---------------------------------------------------------------------------
+;; sub graph — showing / visible-todos / all-complete? / footer-counts
+;; ---------------------------------------------------------------------------
+
+(deftest showing-derives-filter-from-route-id
+  (testing "rf2-km3ssc — :todo/showing maps the route id to the active filter;
+            the not-found route AND an unset route both fall through to :all
+            (the filter the app never stores). A regression in this mapping is
+            a silent bug"
+    (let [f (todo-frame!)]
+      (is (= :all       (rf/compute-sub [:todo/showing] (with-route f :todo/all))))
+      (is (= :active    (rf/compute-sub [:todo/showing] (with-route f :todo/active))))
+      (is (= :completed (rf/compute-sub [:todo/showing] (with-route f :todo/completed))))
+      (is (= :all       (rf/compute-sub [:todo/showing] (with-route f :rf.route/not-found)))
+          "not-found falls through to :all")
+      (is (= :all       (rf/compute-sub [:todo/showing] (rf/frame-state-value f)))
+          "an unset route (no slice) also falls through to :all"))))
+
+(deftest visible-todos-filters-per-showing
+  (testing "rf2-km3ssc — :todo/visible-todos applies the per-showing predicate:
+            :all -> everything, :active -> incomplete only, :completed ->
+            complete only. A wrong predicate is a silent bug"
+    (let [f (todo-frame!)]
+      (rf/dispatch-sync [:todo/add "active-one"] {:frame f})
+      (rf/dispatch-sync [:todo/add "done-one"] {:frame f})
+      (rf/dispatch-sync [:todo/toggle-completed 2] {:frame f})  ;; done-one complete
+      (is (= #{"active-one" "done-one"}
+             (titles (rf/compute-sub [:todo/visible-todos] (with-route f :todo/all)))))
+      (is (= #{"active-one"}
+             (titles (rf/compute-sub [:todo/visible-todos] (with-route f :todo/active)))))
+      (is (= #{"done-one"}
+             (titles (rf/compute-sub [:todo/visible-todos] (with-route f :todo/completed))))))))
+
+(deftest all-complete?-and-footer-counts
+  (testing ":todo/all-complete? is false while any row is active and true only
+            when there are rows and all are complete; :todo/footer-counts is
+            [active-count completed-count]"
+    (let [f (todo-frame!)]
+      (is (false? (boolean (rf/compute-sub [:todo/all-complete?] (rf/frame-state-value f))))
+          "empty list is not all-complete")
+      (rf/dispatch-sync [:todo/add "a"] {:frame f})
+      (rf/dispatch-sync [:todo/add "b"] {:frame f})
+      (rf/dispatch-sync [:todo/toggle-completed 1] {:frame f})
+      (is (false? (rf/compute-sub [:todo/all-complete?] (rf/frame-state-value f)))
+          "one active row -> not all complete")
+      (is (= [1 1] (rf/compute-sub [:todo/footer-counts] (rf/frame-state-value f)))
+          "one active, one completed")
+      (rf/dispatch-sync [:todo/toggle-completed 2] {:frame f})
+      (is (true? (rf/compute-sub [:todo/all-complete?] (rf/frame-state-value f)))
+          "every row complete -> all complete")
+      (is (= [0 2] (rf/compute-sub [:todo/footer-counts] (rf/frame-state-value f)))))))


### PR DESCRIPTION
## What

Behavioural contract coverage for three `examples/core` apps that were
demonstrated-but-untested. Three new framework-tree CLJS test files (examples
stay test-free per rf2-8cevm; tests live in `implementation/core/test/re_frame/`
and `:require` the example entry nses, same posture as
`seven-guis-cells-parser` / `example-frame-scoping`). Handlers are driven via
`dispatch-sync` on an anon frame; subs are read via `rf/compute-sub`.

- **rf2-6t486x — flight_booker** (`flight_booker_cljs_test.cljs`): pure
  `valid-date?` (leap-year UTC round-trip incl. 2024/2000/1900-02-29,
  impossible-date rejection `2026-02-31`/`2025-02-29`/`2026-99-99`/month-day
  0/13, malformed shapes incl. `nil`, and the deliberate `setUTCFullYear`
  low-year guard — `0026` round-trips to 26, not `1926`); the sub graph
  (`return-enabled?`/`start-valid?`/`return-valid?`/`dates-coherent?`/
  `book-enabled?`) incl. one-way skipping return validation and Book staying
  disabled when `return < start`.
- **rf2-km3ssc — todomvc** (`todomvc_cljs_test.cljs`): events beyond cold-boot
  add — toggle-completed, toggle-all (all-complete? inversion), save
  (blank→delete / trim), delete, clear-completed (sorted-map preserved); subs —
  `:todo/showing` route→filter across all three routes + not-found + unset→`:all`
  (route-id injected into the runtime-db route slice), `:todo/visible-todos`
  predicate, `:todo/all-complete?`, `:todo/footer-counts`.
- **rf2-e4nwdr — crud** (`crud_cljs_test.cljs`): select-copies-draft; create
  (monotonic, never-reissued ids incl. after a delete); update (merge draft into
  selected row only; no-op with no selection); delete (clears selection/draft);
  `filtered-people` case-insensitive surname prefix; `can-update?` filter
  visibility — hiding the selection disables Update/Delete without dropping the
  selection, clearing the filter re-enables them.

## Quality gates

- `npm run test:cljs` (full node-test suite, foreground): **Ran 8387 tests,
  38511 assertions, 0 failures, 0 errors** (includes the new tests).
- Negative control: temporarily breaking one new assertion produced exactly
  `1 failures` under `Testing re-frame.crud-cljs-test` (proves the harness
  discovers and runs the new namespaces — not a silent false-green), then
  reverted and re-confirmed clean green.

## Stance

Pre-alpha, no shims. Test-only change — no production edits; no real bug
surfaced in the exercised handlers/subs. CORRECTNESS + GOOD-PRACTICE via
adversarial assertions on the demonstrated-but-untested logic.

Do not merge (worker PR).
