### PR TITLE
test(testbed-support): open-in-editor security-guard negatives + handler branches + comment fixups (rf2-jwdi4r +2)

### DIFF
--- a/tools/testbed-support/test/re_frame/testbed/config_cljs_test.cljs
+++ b/tools/testbed-support/test/re_frame/testbed/config_cljs_test.cljs
@@ -18,7 +18,7 @@
        subdir with or without a leading slash).
     4. Blank / nil subdir → the root verbatim.
     5. Blank `checkout-root` → `nil` (the graceful-no-op contract that
-       `set-checkout-root!` already encodes for blank input).
+       `set-project-root!` already encodes for blank input).
 
   The consuming testbeds compile through `config.cljs` under `npm run
   test:xray-feature-gate`, but each calls `resolve-source-root` with
@@ -51,8 +51,12 @@
   reading `location.search` off the live document — behind the thin
   `query-param` adapter, and delegates the actual parse/decode/trim/
   non-blank contract to the PURE `query-param-from-search`, which takes a
-  query string verbatim. `js/URLSearchParams` is a host global present in
-  Node too, so that pure parser runs identically off-browser. That lets us
+  query string verbatim. That pure parser deliberately splits the query
+  string manually and decodes each component with `js/decodeURIComponent`
+  (NOT `js/URLSearchParams`, whose form-urlencoded semantics would corrupt a
+  literal `+` → space — see `config.cljs` and the preserves-literal-plus
+  test below); both `str/split` and `js/decodeURIComponent` are present in
+  Node too, so that parser runs identically off-browser. That lets us
   pin, with no `js/window` faking:
 
     a. the override-parsing contract — param selection, URL-decoding

--- a/tools/testbed-support/test/re_frame/testbed/open_in_editor_server_test.clj
+++ b/tools/testbed-support/test/re_frame/testbed/open_in_editor_server_test.clj
@@ -233,6 +233,75 @@
               "GET is no longer an allowed method")
           (is (zero? (count @calls))))))))
 
+;; ---- security negatives: the load-bearing rejection branches (rf2-jwdi4r) --
+;;
+;; The two adversarial paths the existing guard suite did NOT drive
+;; end-to-end. Both are safety branches — a false negative here re-opens the
+;; drive-by editor-launch vector — so each asserts the request is rejected
+;; AND `launch!` is never reached.
+
+(deftest guard-rejects-opaque-null-origin-post
+  (testing "rf2-jwdi4r: a POST carrying the opaque `Origin: null` (a
+            sandboxed iframe / `file:` page drive-by — the very context
+            `origin-host` documents as yielding nil) is rejected 403 and
+            NEVER reaches launch!. The Host is loopback, so this isolates the
+            ORIGIN gate: `origin-host` maps \"null\" → nil, which is not a
+            loopback origin, so `local-request?` fails and the launch path is
+            never touched. (origin-host-extracts-and-rejects-opaque only
+            proves the \"null\" → nil unit step; this proves the POST is
+            actually refused end-to-end.)"
+    (let [calls (atom [])]
+      (with-launch-spy calls
+        (let [resp (oies/handle
+                     (req {:method :post
+                           :host   "localhost:8031"
+                           :origin "null"
+                           :file   "/etc/passwd"}))]
+          (is (= 403 (:status resp)) "opaque-origin POST is forbidden")
+          (is (re-find #"\"error\":\"forbidden\"" (:body resp)))
+          (is (zero? (count @calls)) "launch! was NEVER called")
+          (is (= "null" (get-in resp [:headers "access-control-allow-origin"]))
+              "CORS denies via `null` — never reflects the opaque origin, never `*`")
+          (is (not= "*" (get-in resp [:headers "access-control-allow-origin"]))))))))
+
+(deftest guard-options-preflight-denies-remote-origin
+  (testing "rf2-jwdi4r: an OPTIONS preflight is answered BEFORE the
+            `local-request?` guard (it is the first `cond` branch in
+            `handle`), so `allow-origin` is the SOLE gate on preflight CORS.
+            A preflight from a REMOTE origin must therefore get
+            `access-control-allow-origin: null` (deny) — never `*` and never
+            the reflected remote origin — so the browser blocks the follow-up
+            cross-origin POST. launch! is never touched. (The existing
+            preflight test only covers the loopback-origin ALLOW case.)"
+    (let [calls (atom [])]
+      (with-launch-spy calls
+        (let [resp (oies/handle
+                     (req {:method :options
+                           :host   "localhost:8031"
+                           :origin "https://evil.example"}))]
+          (is (= 204 (:status resp)) "preflight still answers 204")
+          (is (= "null" (get-in resp [:headers "access-control-allow-origin"]))
+              "the remote origin is DENIED via `null`")
+          (is (not= "*" (get-in resp [:headers "access-control-allow-origin"]))
+              "never a wildcard")
+          (is (not= "https://evil.example"
+                    (get-in resp [:headers "access-control-allow-origin"]))
+              "the remote origin is never reflected back")
+          (is (zero? (count @calls)) "launch! was NEVER called")))))
+  (testing "rf2-jwdi4r: an OPTIONS preflight from a non-loopback Host with no
+            Origin likewise denies (ao=null) — the allow-origin gate never
+            emits a usable CORS header for anything but a validated loopback
+            origin"
+    (let [calls (atom [])]
+      (with-launch-spy calls
+        (let [resp (oies/handle
+                     (req {:method :options
+                           :host   "app.evil.example"
+                           :origin nil}))]
+          (is (= 204 (:status resp)))
+          (is (= "null" (get-in resp [:headers "access-control-allow-origin"])))
+          (is (zero? (count @calls))))))))
+
 (deftest guard-non-endpoint-path-falls-through
   (testing "a request for any other path still falls through (nil) untouched"
     (is (nil? (oies/handle {:uri "/something/else"

--- a/tools/testbed-support/test/re_frame/testbed/open_in_editor_server_test.clj
+++ b/tools/testbed-support/test/re_frame/testbed/open_in_editor_server_test.clj
@@ -311,8 +311,8 @@
 ;; ---- malformed query string: clean 400, never an uncaught throw ----------
 ;;
 ;; `parse-query` URL-decodes every key/value; a malformed percent-escape (a
-;; lone `%`, or `%` not followed by two hex digits) makes `URLDecoder/decode`
-;; throw `IllegalArgumentException`. Every other error path on this endpoint
+;; lone `%`, or `%` not followed by two hex digits) makes `decode-component`'s
+;; `URI/create` throw `IllegalArgumentException`. Every other error path on this endpoint
 ;; (missing file, forbidden, method-not-allowed, launch failure) answers a
 ;; clean JSON response — a malformed query must too, rather than propagating
 ;; uncaught into the shadow-cljs `:dev-http` Ring plumbing (rf2-bhejni).

--- a/tools/testbed-support/test/re_frame/testbed/open_in_editor_server_test.clj
+++ b/tools/testbed-support/test/re_frame/testbed/open_in_editor_server_test.clj
@@ -616,3 +616,205 @@
       (is (re-find #"\"ok\":false" (:body resp)))
       (is (re-find #"\"error\":\"file-not-found\"" (:body resp))
           "the client-visible error names the missing file, not launch-failed"))))
+
+;; ---- missing-file 400: the blank/absent `file` param branch (rf2-bnv3cu) --
+;;
+;; `handle` returns 400 `{:ok false :error "missing-file"}` when the `file`
+;; query param is blank or absent (before any resolution / launch). The
+;; suite covered malformed-query 400 and file-not-found 422 but never this
+;; distinct earlier branch.
+
+(deftest endpoint-missing-file-param-returns-400
+  (testing "rf2-bnv3cu: a valid local POST with a blank / absent `file`
+            param answers a clean 400 missing-file and never reaches launch!"
+    (let [calls (atom [])]
+      (with-launch-spy calls
+        (testing "no `file` param in the query string"
+          (let [resp (oies/handle
+                       {:uri            oies/endpoint-path
+                        :request-method :post
+                        :query-string   "line=10&column=3"
+                        :headers        {"host" "localhost:8031"}})]
+            (is (= 400 (:status resp)))
+            (is (re-find #"\"ok\":false" (:body resp)))
+            (is (re-find #"\"error\":\"missing-file\"" (:body resp)))))
+        (testing "an empty `file=` value"
+          (let [resp (oies/handle
+                       {:uri            oies/endpoint-path
+                        :request-method :post
+                        :query-string   "file=&line=10"
+                        :headers        {"host" "localhost:8031"}})]
+            (is (= 400 (:status resp)))
+            (is (re-find #"\"error\":\"missing-file\"" (:body resp)))))
+        (testing "no query string at all"
+          (let [resp (oies/handle
+                       {:uri            oies/endpoint-path
+                        :request-method :post
+                        :query-string   nil
+                        :headers        {"host" "localhost:8031"}})]
+            (is (= 400 (:status resp)))
+            (is (re-find #"\"error\":\"missing-file\"" (:body resp)))))
+        (is (zero? (count @calls))
+            "launch! was never called on any missing-file path")))))
+
+;; ---- editor hint: keyword -> launch-editor command (rf2-bnv3cu) -----------
+;;
+;; `editor-hint` + `editor-command-by-keyword` are PUBLIC and were 100%
+;; untested. The `editor` query param maps through `editor-hint` to
+;; `launch!`'s 4th-arg command hint; an untested map means a regression
+;; could silently drop a configured editor (`:rf.xray/editor :cursor`) back
+;; to launch-editor's auto-detect.
+
+(deftest editor-hint-maps-keyword-to-launch-command
+  (testing "rf2-bnv3cu: a known editor keyword (bare string) resolves to
+            launch-editor's launch command"
+    (is (= "code"          (oies/editor-hint "vscode")))
+    (is (= "code-insiders" (oies/editor-hint "vscode-insiders")))
+    (is (= "cursor"        (oies/editor-hint "cursor")))
+    (is (= "windsurf"      (oies/editor-hint "windsurf")))
+    (is (= "zed"           (oies/editor-hint "zed")))
+    (is (= "idea"          (oies/editor-hint "idea"))))
+  (testing "the value is lower-cased and trimmed before lookup"
+    (is (= "code"   (oies/editor-hint "VSCode")))
+    (is (= "cursor" (oies/editor-hint "  Cursor  ")))
+    (is (= "idea"   (oies/editor-hint "IDEA"))))
+  (testing "blank / unknown / non-string → nil (launch-editor auto-detects)"
+    (is (nil? (oies/editor-hint "")))
+    (is (nil? (oies/editor-hint "   ")))
+    (is (nil? (oies/editor-hint "custom")) "the {:custom …} shape is not in the map")
+    (is (nil? (oies/editor-hint "emacs")) "an editor with no mapping → auto-detect")
+    (is (nil? (oies/editor-hint nil)))
+    (is (nil? (oies/editor-hint 42)) "a non-string is rejected")))
+
+(deftest editor-command-by-keyword-is-the-launch-command-vocabulary
+  (testing "rf2-bnv3cu: the public keyword→command map maps the open-in-editor
+            keyword vocabulary to launch-editor bin names (a public-surface
+            sentinel — a new editor is a deliberate, reviewed addition)"
+    (is (= {"vscode"          "code"
+            "vscode-insiders" "code-insiders"
+            "cursor"          "cursor"
+            "windsurf"        "windsurf"
+            "zed"             "zed"
+            "idea"            "idea"}
+           oies/editor-command-by-keyword))))
+
+(deftest endpoint-passes-editor-hint-through-to-launch
+  (testing "rf2-bnv3cu: the `editor` query param maps through editor-hint to
+            launch!'s 4th-arg command hint — a request for a configured editor
+            reaches launch! with the resolved command, not auto-detect"
+    (let [calls (atom [])]
+      (with-launch-spy calls
+        (let [resp (oies/handle
+                     {:uri            oies/endpoint-path
+                      :request-method :post
+                      :query-string   "file=fake_ns/core.cljs&line=3&editor=vscode"
+                      :headers        {"host" "localhost:8031"}})]
+          (is (= 200 (:status resp)))
+          (is (= 1 (count @calls)))
+          (let [[_abs _line _col cmd] (first @calls)]
+            (is (= "code" cmd)
+                "editor=vscode resolved to launch-editor's `code` command
+                 (the mapping is applied, not the raw keyword)"))))))
+  (testing "an unknown editor keyword → nil command hint (auto-detect)"
+    (let [calls (atom [])]
+      (with-launch-spy calls
+        (oies/handle
+          {:uri            oies/endpoint-path
+           :request-method :post
+           :query-string   "file=fake_ns/core.cljs&editor=emacs"
+           :headers        {"host" "localhost:8031"}})
+        (is (nil? (nth (first @calls) 3))
+            "unknown editor → nil hint"))))
+  (testing "no `editor` param → nil command hint (baseline)"
+    (let [calls (atom [])]
+      (with-launch-spy calls
+        (oies/handle
+          {:uri            oies/endpoint-path
+           :request-method :post
+           :query-string   "file=fake_ns/core.cljs"
+           :headers        {"host" "localhost:8031"}})
+        (is (nil? (nth (first @calls) 3))
+            "no editor param → nil hint")))))
+
+;; ---- escape-json-string: backslash + doublequote (rf2-bnv3cu) -------------
+;;
+;; The control-char round-trip test covered \n/\t/\r + C0 + plain ASCII but
+;; never a value carrying a literal `\` or `"`. On Windows the resolved
+;; abs-path echoed in the 200 `:file` field is `C:\Users\...`, so the
+;; backslash rule is Windows-load-bearing: unescaped, the JSON body is
+;; invalid despite the `application/json` header.
+
+(deftest escape-json-string-escapes-backslash-and-doublequote
+  (testing "rf2-bnv3cu: a lone backslash and a double-quote are escaped
+            directly"
+    (is (= "a\\\\b" (#'oies/escape-json-string "a\\b"))
+        "one backslash → two")
+    (is (= "say \\\"hi\\\"" (#'oies/escape-json-string "say \"hi\""))
+        "double-quotes are escaped")
+    (is (= "C:\\\\Users\\\\me\\\\core.cljs"
+           (#'oies/escape-json-string "C:\\Users\\me\\core.cljs"))
+        "a Windows abs-path's backslashes are all doubled")))
+
+(deftest json-resp-escapes-windows-backslash-path
+  (testing "rf2-bnv3cu: a 200 response whose resolved `:file` is a Windows
+            abs-path (literal `\\` separators) plus a stray `\"` is escaped so
+            the `application/json` body is valid and round-trips to the exact
+            path through a real JSON-string decode — the Windows-relevant path
+            the prior backslash/quote-only encoder would still have handled,
+            but never had a regression test"
+    (let [calls (atom [])
+          file  "C:\\Users\\me\\code\\re-frame2\\src\\a\"b.cljs"]
+      (with-launch-spy calls
+        (with-redefs [oies/resolve-file (constantly file)]
+          (let [resp (oies/handle
+                       (req {:method :post
+                             :host   "localhost:8031"
+                             :origin nil
+                             :file   "resolve-file-is-redefed"}))]
+            (is (= 200 (:status resp)))
+            (is (str/includes? (:body resp) "\\\\")
+                "backslashes are doubled in the body")
+            (is (str/includes? (:body resp) "\\\"")
+                "the double-quote is escaped in the body")
+            (is (= file (json-body->file-value (:body resp) "\"file\":\""))
+                "the escaped Windows path round-trips to the exact original")))))))
+
+;; ---- resolve-file: the cwd-relative branch (rf2-bnv3cu) -------------------
+;;
+;; resolve-file's branch 2 (relative to the dev process cwd) is the
+;; JAR / off-classpath case Option B exists to close — a relative coord that
+;; getResource cannot reach on the classpath still resolves against the dev
+;; JVM's working directory. Branch 1 (classpath) is covered by
+;; resolve-file-resolves-classpath-path-with-plus; this pins branch 2's
+;; SUCCESS path directly.
+
+(deftest resolve-file-resolves-cwd-relative-off-classpath
+  (testing "rf2-bnv3cu: a relative `:file` that is NOT on the classpath
+            resolves against the working directory (`user.dir`) to its real
+            on-disk absolute path — the off-classpath branch"
+    (let [tmp      (File. (System/getProperty "java.io.tmpdir")
+                          (str "oies-cwd-" (System/nanoTime)))
+          sub      (str "off_classpath_" (System/nanoTime))
+          rel-path (str sub "/probe.cljs")
+          src-file (io/file tmp sub "probe.cljs")
+          prev-cwd (System/getProperty "user.dir")]
+      (try
+        (io/make-parents src-file)
+        (spit src-file ";; fixture\n")
+        ;; Point the JVM working dir at the throwaway tree; the explicit
+        ;; cwd branch reads `user.dir` live, so resolution finds the fixture.
+        (System/setProperty "user.dir" (.getAbsolutePath tmp))
+        (let [resolved (oies/resolve-file rel-path)]
+          (is (some? resolved)
+              "the off-classpath relative coord resolved via the cwd branch")
+          (is (.isAbsolute (File. ^String resolved))
+              "the cwd branch returns an ABSOLUTE path (branch 3 would return
+               the raw relative input unchanged)")
+          (is (= (.getCanonicalPath src-file)
+                 (.getCanonicalPath (File. ^String resolved)))
+              "resolved to the REAL on-disk fixture under the working dir"))
+        (finally
+          (System/setProperty "user.dir" prev-cwd)
+          (when (.exists src-file) (.delete src-file))
+          (.delete (io/file tmp sub))
+          (.delete tmp))))))


### PR DESCRIPTION
Adds the untested JVM open-in-editor branches flagged by the 2026-07-09 review campaign (surface `tools/testbed-support`) and fixes three stale test-file comments. Test-only + comment-only; no production code changed. One commit per bead.

## rf2-jwdi4r — security-guard negatives (the load-bearing rejection branches)
The endpoint launches the dev editor on a local file, so its loopback/origin/method guard is security-critical. Two adversarial paths were untested end-to-end:
- **Opaque `Origin: null` POST → 403, `launch!` never called.** A sandboxed-iframe / `file:`-page drive-by carries `Origin: null`. The Host is loopback, so the test isolates the *origin* gate: `origin-host` maps `"null"` → nil (not a loopback origin) → `local-request?` fails → forbidden before any launch. (The prior `origin-host-extracts-and-rejects-opaque` only proved the unit step, not that the POST is actually refused.)
- **Remote-origin OPTIONS preflight → `access-control-allow-origin: null`.** OPTIONS is answered *before* `local-request?`, so `allow-origin` is the sole preflight CORS gate. Asserts a remote-origin (and a non-loopback-host) preflight is denied via `null` — never `*`, never the reflected remote origin — and `launch!` is never touched.

No guard gap surfaced: the existing production guard already rejects both correctly. These tests lock that in.

## rf2-bnv3cu — handler/response branches
- **missing-file 400:** blank / absent / no-query-string `file` param → clean 400 `missing-file`, `launch!` never called.
- **editor hint (both PUBLIC, was 100% untested):** `editor-hint` keyword→command mapping (lower-case + trim; blank/unknown/non-string → nil auto-detect); a public-surface sentinel for `editor-command-by-keyword`; and end-to-end that the `editor=` query param reaches `launch!`'s 4th-arg command hint (so a configured editor is not silently dropped to auto-detect).
- **escape-json-string backslash + doublequote:** direct assertions plus a 200-response round-trip of a Windows abs-path (`C:\Users\...`) carrying a stray `"`, proving the `application/json` body stays valid (Windows-relevant — the resolved path echoed in `:file` is backslash-laden).
- **resolve-file cwd-relative branch:** the JAR / off-classpath case Option B exists to close resolves a non-classpath relative coord against `user.dir` to a real absolute path (branch 1 was already covered; this pins branch 2's success path).

## rf2-3kwvoh — stale test-file comments (comment-only)
Three "why" comments described a superseded impl (survived the 62hu6k/bhejni rewrites):
- `config_cljs_test.cljs` ns-docstring wrongly credited `js/URLSearchParams`; the pure parser deliberately uses `str/split` + `js/decodeURIComponent` to avoid the `+`→space corruption. Corrected.
- `config_cljs_test.cljs` referenced a nonexistent `set-checkout-root!`; real fn is `set-project-root!`.
- `open_in_editor_server_test.clj` named `URLDecoder/decode` as the throwing call; the current path throws in `decode-component`'s `URI/create`. Corrected.

## Quality gates
- `cd tools/testbed-support && clojure -M:test` — **31 tests, 145 assertions, 0 failures, 0 errors** (was 22/93 at baseline; +9 deftests, +52 assertions).
- `npm run test:cljs` — **not run.** The only CLJS-file change is a namespace-docstring (comment) edit with no logic and no string-literal-breaking characters; no `.cljc` touched; fresh worktree has no `node_modules` and the brief scopes this gate to `.cljc` changes / bars a full spine on a fresh worktree.

## Stance
Pre-alpha, no shims. Security-relevant correctness + good practice: the jwdi4r negatives drive the real guard with hostile inputs and assert rejection + zero `launch!` calls. No production edits — no guard gap or bug surfaced.
