### PR TITLE
docs(impl): fix stale comments in flows/http/uix/helix (rf2-dx9nwu +3)

### DIFF
--- a/implementation/adapters/helix/src/re_frame/adapter/helix.cljs
+++ b/implementation/adapters/helix/src/re_frame/adapter/helix.cljs
@@ -5,9 +5,12 @@
   → core.
 
   Shares the React-shaped substrate machinery (container quartet,
-  derived value, render-root, render-to-string, frame-provider, use-
-  subscribe, flush-views!, source-coord wrapper, warn-once-cache) with
-  the UIx adapter via `re-frame.substrate.spine`. Helix-specific
+  derived value, render-root, render-to-string, use-subscribe, flush-
+  views!, source-coord wrapper, warn-once-cache) with the UIx adapter
+  via `re-frame.substrate.spine`. The frame-provider CORE
+  (`build-frame-provider-element`) is likewise shared, but the user-
+  facing `frame-provider` is a NATIVE Helix `defnc` in this ns
+  (rf2-z7hfp moved the seam up), NOT a spine re-export. Helix-specific
   configuration: gensym prefixes, substrate name (used in warn-once
   text), and helix.hooks `use-memo*` / `use-callback*` (the spine
   passes JS-array deps unconditionally). The React frame-context

--- a/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
+++ b/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
@@ -5,9 +5,12 @@
   → core.
 
   Shares the React-shaped substrate machinery (container quartet,
-  derived value, render-root, render-to-string, frame-provider, use-
-  subscribe, flush-views!, source-coord wrapper, warn-once-cache) with
-  the Helix adapter via `re-frame.substrate.spine`. UIx-specific
+  derived value, render-root, render-to-string, use-subscribe, flush-
+  views!, source-coord wrapper, warn-once-cache) with the Helix adapter
+  via `re-frame.substrate.spine`. The frame-provider CORE
+  (`build-frame-provider-element`) is likewise shared, but the user-
+  facing `frame-provider` is a NATIVE UIx `defui` in this ns (rf2-z7hfp
+  moved the seam up), NOT a spine re-export. UIx-specific
   configuration: gensym prefixes, substrate name (used in warn-once
   text), and the runtime hook fns from `uix.hooks.alpha` (the
   `uix.core` macros expand to these)."

--- a/implementation/flows/test/re_frame/flows_test.clj
+++ b/implementation/flows/test/re_frame/flows_test.clj
@@ -850,9 +850,13 @@
           "the cyclic replacement of :b throws :rf.error/flow-cycle")
 
       ;; 4. THE KEY ASSERTION: the prior :b is STILL in the registry —
-      ;;    not silently deleted. The bug today (flows.cljc:149) dissocs
-      ;;    by id on rollback, vacating the prior registration along
-      ;;    with the just-written one.
+      ;;    not silently deleted. A naive rollback that wrote the new
+      ;;    registration first and then dissoc'd it by id on rejection
+      ;;    WOULD have vacated the prior registration along with the
+      ;;    just-written one. The atomic prospective-map swap prevents
+      ;;    this: cycle/overlap detection runs on the prospective map
+      ;;    inside the swap! update fn and never commits on rejection,
+      ;;    so the prior registration is left untouched.
       (is (contains? (get (flows/flows-snapshot) :rf/default) :b)
           "after a failed cyclic replacement, the prior :b registration is preserved")
       (let [b-after (get-in (flows/flows-snapshot) [:rf/default :b])]

--- a/implementation/http/src/re_frame/http/reply.cljc
+++ b/implementation/http/src/re_frame/http/reply.cljc
@@ -29,9 +29,11 @@
       sanctioned second identity for process-global transport
       correlation; `transport-request-id` builds it.
 
-   2. **Canonical reply map** (`success-reply` / `failure-reply` /
-      `aborted-reply`). The transport's success / failure / abort facts
-      become a single `re-frame.reply`-conformant reply map with one
+   2. **Canonical reply map** (`success-reply` / `failure-reply`; the
+      standalone `aborted-reply` mirrors the abort case for conformance
+      tests only and has no production caller — production lowers aborts
+      through `failure-reply`). The transport's success / failure / abort
+      facts become a single `re-frame.reply`-conformant reply map with one
       closed `:status` (`:ok` / `:error` / `:cancelled`), `:value` on
       `:ok`, the classified `:rf.http/*` failure map riding verbatim
       under `:error`, plus `:work/id`, `:work/kind :http`,
@@ -200,8 +202,10 @@
   the closed-set `:rf.http/*` failure map the transport classified.
 
   Status mapping (Managed-Effects §Status taxonomy):
-   - `:rf.http/aborted`  → `:status :cancelled` (see `aborted-reply` for the
-     dedicated builder; this fn handles it too for completeness);
+   - `:rf.http/aborted`  → `:status :cancelled` (this is the PRODUCTION abort
+     path — `dispatch-failure!` always lowers aborts through `failure-reply`;
+     the standalone `aborted-reply` builder produces the identical map but has
+     no production caller, existing only for conformance/lowering tests);
    - `:rf.http/timeout`  → `:status :error` + `:work/status :timed-out`
      (timeout is NOT a top-level status);
    - everything else     → `:status :error` + `:work/status :failed`.


### PR DESCRIPTION
Comment/docstring-only corrections across four disjoint surfaces. Zero logic change.

## Fixes (one commit per bead)

- **rf2-dx9nwu** (`implementation/flows`) — `flows_test.clj:853`: the cycle-rollback test carried a comment describing a live footgun (`bug today (flows.cljc:149)` dissocs by id on rollback, vacating the prior registration). That path was refactored to an atomic prospective-map swap (detection runs on the prospective map inside `swap!`, never commits on rejection), so the failure is structurally impossible and the passing test asserts the correct post-fix behaviour. Reworded to past tense; dropped the stale `flows.cljc:149` pin.
- **rf2-g4p2u0** (`implementation/http`) — `reply.cljc`: the `failure-reply` docstring cross-ref and the ns-level builder list named `aborted-reply` as the dedicated abort builder with `failure-reply` handling it "too for completeness". Production is the reverse — `dispatch-failure!` always lowers aborts through `failure-reply`, and `aborted-reply` has no production caller (conformance/lowering tests only). Reworded so `failure-reply` is the production abort path and `aborted-reply` is flagged standalone/test-only.
- **rf2-6ete2m** (`implementation/adapters/uix`) — `uix.cljs`: ns docstring listed bare `frame-provider` among spine re-exports; it is a NATIVE UIx `defui` here (post-rf2-z7hfp seam move). Dropped it from the shared list; noted only the CORE `build-frame-provider-element` is spine-shared.
- **rf2-7zavwq** (`implementation/adapters/helix`) — `helix.cljs`: twin of the UIx fix; `frame-provider` is a NATIVE Helix `defnc`. Same correction.

## Quality gates

- `npm run test:cljs` (foreground, full run): **8375 tests, 38563 assertions, 0 failures, 0 errors.** Comment-only change proves nothing broke.

## Stance

Pre-alpha, no shims. Primary lenses CLARITY + CORRECTNESS — these fixes remove misleading maintainer signals (a phantom live bug + a wrong line ref; an inverted production/test primacy; a docstring contradicting its own file's most distinctive construct). No logic touched; four disjoint surfaces, one commit each.