### PR TITLE
test(story,mcp-conformance,reagent): story-slice identity + hermetic-list drift guard + lease no-frame raise (rf2-8fz0n8 +2)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/adapter/with_resource_lease_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/adapter/with_resource_lease_dom_cljs_test.cljs
@@ -277,3 +277,73 @@
               (is (not= provider-frame (ev-frame (nth @dispatches 0)))
                   "the surrounding provider's frame did NOT win")
               (act-fn (fn [] (rdc/unmount root))))))))))
+
+;; ---- adversarial: no frame resolvable → :rf.error/no-frame-context ---------
+;;
+;; rf2-za008k. with-resource-lease resolves its lease frame at RENDER time via
+;; `resolve-lease-frame`, whose `(or explicit-frame (frame/require-current-frame!
+;; …))` fallback RAISES `:rf.error/no-frame-context` when NOTHING resolves a
+;; frame — no `:frame` opt, no `*current-frame*` binding, and no enclosing
+;; `frame-provider` (the class `:context-type` reads the createContext
+;; no-provider sentinel). The raise is pinned at the reg-view level
+;; (frame_provider_context_dom_cljs_test Scenario 2) because it is a delegated
+;; one-liner, but there was NO with-resource-lease-SPECIFIC pin — so a future
+;; refactor swallowing the fallback (defaulting to `:rf/default`, or moving
+;; resolution to a commit-phase method where `*current-frame*` is already
+;; unwound) would ship green through this component. This mounts
+;; with-resource-lease with the fallback firing against a nil frame and asserts
+;; the loud error.
+
+(defn- capturing-error-boundary
+  "A Reagent error-boundary class that captures a render-time throw from its
+  single child into `captured` (an atom) instead of letting it propagate. A
+  class defining `componentDidCatch` IS an error boundary (React docs), and
+  React passes the ORIGINAL thrown value — here the cljs ExceptionInfo, its
+  ex-data intact — as the first arg, so `(ex-data @captured)` yields the
+  raised `:rf.error/*` data. Flips a ratom on catch so it renders a fallback
+  (not the throwing child) rather than retry."
+  [captured]
+  (let [errored? (r/atom false)]
+    (r/create-class
+      {:display-name "rf2-za008k/lease-error-boundary"
+       :component-did-catch (fn [_this err _info]
+                              (reset! captured err)
+                              (reset! errored? true))
+       :reagent-render (fn [child]
+                         (if @errored? [:div "boundary-fallback"] child))})))
+
+(deftest with-resource-lease-raises-when-no-frame-resolvable
+  (testing "Reagent — with NO :frame opt, NO *current-frame* binding, and NO
+            frame-provider, `resolve-lease-frame`'s fallback to
+            `frame/require-current-frame!` RAISES :rf.error/no-frame-context at
+            render time (rf2-za008k). Pins the with-resource-lease-specific
+            loud path its docstring promises — the reg-view-level raise
+            (frame_provider Scenario 2) does not cover THIS delegated call
+            site against a future refactor swallowing the fallback."
+    (if-not (browser?)
+      (is true ":node-test: no DOM — :browser-test runner exercises the assertion")
+      (let [act-fn (get-act)]
+        (if (nil? act-fn)
+          (is true "act() not reachable from this runner; skipping")
+          (let [render-error (atom nil)
+                boundary     (capturing-error-boundary render-error)
+                mount-node   (.createElement js/document "div")
+                root         (rdc/create-root mount-node)]
+            (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+            ;; *current-frame* nil + no provider + no :frame opt ⇒ nothing
+            ;; resolves the lease frame. The error boundary captures the raise
+            ;; with-resource-lease's render surfaces.
+            (binding [frame/*current-frame* nil]
+              (act-fn
+                (fn []
+                  (rdc/render root
+                    [boundary
+                     [reagent-adapter/with-resource-lease
+                      descriptor
+                      (fn [] [:div "should-not-render"])]]))))
+            (is (some? @render-error)
+                "no frame resolvable → with-resource-lease's render raised")
+            (is (= :rf.error/no-frame-context
+                   (:rf.error/id (ex-data @render-error)))
+                "the raised error is :rf.error/no-frame-context")
+            (try (act-fn (fn [] (rdc/unmount root))) (catch :default _ nil))))))))

--- a/tools/mcp-conformance/scripts/run-re-frame2-pair-live-hermetic-suite.cjs
+++ b/tools/mcp-conformance/scripts/run-re-frame2-pair-live-hermetic-suite.cjs
@@ -1437,4 +1437,12 @@ module.exports = {
   waitForChildExit,
   spawnAndGradeInnerTest,
   wipeStalePortFileCandidate,
+  // The authoritative live-inner-test inventory the hermetic suite boots
+  // shadow-cljs for. Exported (require.main-guarded above, so importing this
+  // module does NOT boot shadow-cljs / Chromium) so the completeness guard
+  // `test/live-list-completeness.test.cjs` (rf2-79qmsw) can cross-check it
+  // against the `test/live-re-frame2-pair-*.cjs` files on disk — a live gate
+  // added to disk but forgotten here would SKIP under `npm test` and never
+  // launch on CI, riding perpetually green.
+  INNER_TESTS,
 };

--- a/tools/mcp-conformance/scripts/test-all.cjs
+++ b/tools/mcp-conformance/scripts/test-all.cjs
@@ -62,6 +62,10 @@ const TESTS = [
     argv: ['--test', 'test/inner-test-close-grading.test.cjs'],
   },
   {
+    name: 'live-gate list completeness — disk ⇄ INNER_TESTS ⇄ test-all rows (rf2-79qmsw)',
+    argv: ['--test', 'test/live-list-completeness.test.cjs'],
+  },
+  {
     name: 'hermetic port-file escape refusal (rf2-khav7l)',
     argv: ['--test', 'test/port-file-escape.test.cjs'],
   },

--- a/tools/mcp-conformance/test/live-list-completeness.test.cjs
+++ b/tools/mcp-conformance/test/live-list-completeness.test.cjs
@@ -1,0 +1,143 @@
+// Completeness / anti-drift guard for the hermetic live-suite's
+// INNER_TESTS inventory and test-all.cjs's live rows (rf2-79qmsw).
+//
+// Uses Node's built-in `node:test` (same posture as
+// `inner-test-close-grading.test.cjs` — no extra dev-dependency). Runs in
+// the pure-Node unit cluster: `scripts/test-unit.cjs` DERIVES its set from
+// every `--test` row in `test-all.cjs`, so registering this file there (as a
+// `--test` row) makes PR CI pick it up automatically.
+//
+// ## The drift this pins
+//
+// The live gates live in `test/live-re-frame2-pair-*.cjs`. They are named in
+// TWO separate, hand-maintained lists:
+//
+//   1. `scripts/run-re-frame2-pair-live-hermetic-suite.cjs` `INNER_TESTS` —
+//      the ONLY place the live path actually FIRES (the hermetic suite boots
+//      shadow-cljs, sets `$SHADOW_CLJS_NREPL_PORT`, and spawns each entry).
+//   2. `scripts/test-all.cjs` `TESTS` live rows — spawned by `npm test`,
+//      where they SKIP-by-default (no `$SHADOW_CLJS_NREPL_PORT`) and ride
+//      green.
+//
+// Nothing derives either list from the files on disk, and nothing
+// cross-checks the two against each other. So a future
+// `live-re-frame2-pair-<new>.cjs` added to ONE list but forgotten in the
+// other:
+//   - forgotten in `test-all.cjs` → never spawned by `npm test` at all;
+//   - forgotten in `INNER_TESTS`  → never LAUNCHED on CI (the hermetic job is
+//     the only place the live path runs) — it rides perpetually green as an
+//     un-exercised gate.
+//
+// The `inner-test-close-grading` sentinel guard (rf2-6girz0) cannot catch
+// this: it only inspects tests already IN `INNER_TESTS`. This is the
+// silent-SKIP false-green class one meta-level up. The `test-unit.cjs`
+// derive-don't-re-list discipline is the fix, applied here as an assertion:
+// the DISK glob is the source of truth; both lists must cover it exactly.
+//
+// It requires both scripts AS MODULES (the orchestrator's auto-run is guarded
+// behind `require.main === module`, and `test-all.cjs` only runs `main()`
+// under the same guard, so requiring them boots nothing).
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const TEST_DIR = __dirname;
+const SCRIPTS_DIR = path.join(TEST_DIR, '..', 'scripts');
+
+const { INNER_TESTS } = require(
+  path.join(SCRIPTS_DIR, 'run-re-frame2-pair-live-hermetic-suite.cjs'),
+);
+const { TESTS } = require(path.join(SCRIPTS_DIR, 'test-all.cjs'));
+
+// The on-disk source of truth: every live gate file.
+const LIVE_FILE_RE = /^live-re-frame2-pair-.*\.cjs$/;
+
+function liveFilesOnDisk() {
+  return fs
+    .readdirSync(TEST_DIR)
+    .filter((name) => LIVE_FILE_RE.test(name))
+    .sort();
+}
+
+// The live basenames each list references. `INNER_TESTS` entries carry an
+// absolute `.path`; `test-all.cjs` live rows are `{ argv: ['test/<file>'] }`
+// (no `--test`) — take the last argv element and keep only the live gates.
+function innerTestBasenames() {
+  return INNER_TESTS.map((t) => path.basename(t.path))
+    .filter((name) => LIVE_FILE_RE.test(name))
+    .sort();
+}
+
+function testAllLiveBasenames() {
+  return TESTS.map((t) => path.basename(t.argv[t.argv.length - 1]))
+    .filter((name) => LIVE_FILE_RE.test(name))
+    .sort();
+}
+
+test('there is at least one live gate on disk (refuse to report green on an empty glob)', () => {
+  const disk = liveFilesOnDisk();
+  assert.ok(
+    disk.length > 0,
+    'no test/live-re-frame2-pair-*.cjs files found — either the glob broke or ' +
+      'the live gates were removed; refusing to certify the lists as complete ' +
+      'against an empty disk set',
+  );
+});
+
+test('every live gate on disk appears in the hermetic INNER_TESTS inventory (rf2-79qmsw)', () => {
+  const disk = new Set(liveFilesOnDisk());
+  const inner = new Set(innerTestBasenames());
+  const missing = [...disk].filter((f) => !inner.has(f));
+  assert.deepEqual(
+    missing,
+    [],
+    'live gate file(s) present on disk but MISSING from `INNER_TESTS` in ' +
+      'run-re-frame2-pair-live-hermetic-suite.cjs — the hermetic CI job is the ' +
+      'only place the live path fires, so a forgotten entry never launches and ' +
+      'rides perpetually green:\n  ' +
+      missing.join('\n  '),
+  );
+});
+
+test('every live gate on disk appears in the test-all.cjs live rows (rf2-79qmsw)', () => {
+  const disk = new Set(liveFilesOnDisk());
+  const testAll = new Set(testAllLiveBasenames());
+  const missing = [...disk].filter((f) => !testAll.has(f));
+  assert.deepEqual(
+    missing,
+    [],
+    'live gate file(s) present on disk but MISSING from the `TESTS` live rows ' +
+      'in test-all.cjs — a forgotten entry is never spawned by `npm test` at ' +
+      'all:\n  ' +
+      missing.join('\n  '),
+  );
+});
+
+test('INNER_TESTS references no live gate that is absent from disk (dangling entry after a rename/delete)', () => {
+  const disk = new Set(liveFilesOnDisk());
+  const dangling = innerTestBasenames().filter((f) => !disk.has(f));
+  assert.deepEqual(
+    dangling,
+    [],
+    '`INNER_TESTS` names live gate file(s) that no longer exist on disk — a ' +
+      'rename/delete left a dangling entry the hermetic suite would fail to ' +
+      'spawn:\n  ' +
+      dangling.join('\n  '),
+  );
+});
+
+test('test-all.cjs live rows reference no live gate that is absent from disk (dangling row after a rename/delete)', () => {
+  const disk = new Set(liveFilesOnDisk());
+  const dangling = testAllLiveBasenames().filter((f) => !disk.has(f));
+  assert.deepEqual(
+    dangling,
+    [],
+    'test-all.cjs names live gate file(s) that no longer exist on disk — a ' +
+      'rename/delete left a dangling row:\n  ' +
+      dangling.join('\n  '),
+  );
+});

--- a/tools/story/test/re_frame/story_runtime_test.clj
+++ b/tools/story/test/re_frame/story_runtime_test.clj
@@ -627,6 +627,74 @@
         (is (not= h1 (-> (story/snapshot-identity :story.id-render/v) :content-hash))
             "editing a :network reply must produce a fresh hash")))))
 
+;; ---- rf2-8fz0n8: the STORY-side identity inputs (story-body-slice) --------
+;;
+;; `story-body-slice` selects the parent story's `[:component :decorators]`
+;; into the tuple's `:story` slot. Every existing snapshot-identity guard
+;; drives the VARIANT-level slots (rf2-bah5o2 `:component`, rf2-9g48l
+;; `:decorators`); the sibling STORY-level slots that a component-less /
+;; decorator-inheriting variant renders through were untested. That is the
+;; same silent-drop-from-select-keys failure class: a refactor dropping
+;; `:component` or `:decorators` from `story-body-slice`'s select-keys ships
+;; green. These pin both.
+
+(deftest snapshot-identity-changes-with-story-component
+  (testing "rf2-8fz0n8 — the PARENT STORY's `:component` participates in the
+            hash via `story-body-slice`'s `(select-keys body [:component
+            :decorators])`. The renderer resolves variant-first `(or
+            (:component variant) (:component story))`, so for a variant that
+            declares NO own `:component` the STORY's `:component` decides
+            WHICH view renders — a watch-session edit of the story-level
+            `:component` MUST perturb the child variant's snapshot identity.
+            RED against a refactor dropping `:component` from
+            `story-body-slice`'s select-keys — the STORY-side sibling of the
+            variant-override guard rf2-bah5o2."
+    (story/reg-story :story.story-comp {:component :view-a})
+    ;; Component-less variant — the rendered view is the STORY's `:component`.
+    (story/reg-variant :story.story-comp/v {:events []})
+    (let [h1 (-> (story/snapshot-identity :story.story-comp/v) :content-hash)]
+      (story/reg-story :story.story-comp {:component :view-b})
+      (let [h2 (-> (story/snapshot-identity :story.story-comp/v) :content-hash)]
+        (is (not= h1 h2)
+            "editing the parent story's :component must produce a fresh hash"))
+      (testing "the :story tuple slice carries the parent story's :component"
+        (is (= :view-b (get-in (ident/snapshot-tuple :story.story-comp/v)
+                               [:story :component]))
+            "story-body-slice must select :component")))))
+
+(deftest snapshot-identity-changes-with-story-decorators
+  (testing "rf2-8fz0n8 — the PARENT STORY's `:decorators` participate in the
+            hash via `story-body-slice`'s `(select-keys body [:component
+            :decorators])`. Story decorators wrap EVERY variant of the story
+            (composed before the variant's own), so a story-level decorator
+            edit changes the child variant's settled rendered state and MUST
+            perturb its snapshot identity. RED against a refactor dropping
+            `:decorators` from `story-body-slice`'s select-keys — the
+            STORY-side sibling of the variant-decorators guard rf2-9g48l."
+    (story/reg-decorator :centered
+      {:kind :hiccup :wrap (fn [body _args] [:div.centered body])})
+    (story/reg-decorator :boxed
+      {:kind :hiccup :wrap (fn [body _args] [:div.boxed body])})
+    (story/reg-story :story.story-dec {:component :app/v :decorators [[:centered]]})
+    (story/reg-variant :story.story-dec/v {:events []})
+    (let [h1 (-> (story/snapshot-identity :story.story-dec/v) :content-hash)]
+      (story/reg-story :story.story-dec {:component :app/v :decorators [[:boxed]]})
+      (let [h2 (-> (story/snapshot-identity :story.story-dec/v) :content-hash)]
+        (is (not= h1 h2)
+            "swapping the parent story's decorator must produce a fresh hash"))
+      (testing "adding a decorator to a previously-decoratorless story perturbs the child hash"
+        (story/reg-story :story.story-dec {:component :app/v :decorators []})
+        (let [h-empty (-> (story/snapshot-identity :story.story-dec/v) :content-hash)]
+          (story/reg-story :story.story-dec {:component :app/v :decorators [[:centered]]})
+          (let [h-with (-> (story/snapshot-identity :story.story-dec/v) :content-hash)]
+            (is (not= h-empty h-with)
+                "appending a story decorator must produce a fresh child hash"))))
+      ;; The previous block left the story registered with [[:centered]].
+      (testing "the :story tuple slice carries the parent story's :decorators"
+        (is (= [[:centered]] (get-in (ident/snapshot-tuple :story.story-dec/v)
+                                     [:story :decorators]))
+            "story-body-slice must select :decorators")))))
+
 ;; ---- rf2-chzryf: identity keys off EFFECTIVE tags, not raw child :tags ----
 ;;
 ;; Follow-on from rf2-n0vmq2/#5308. The shared `re-frame.story.tags`
@@ -692,6 +760,31 @@
       (let [h2 (-> (story/snapshot-identity :story.eff-tag-ext/child) :content-hash)]
         (is (not= h1 h2)
             "an :extends-parent tag edit perturbs the child's hash")))))
+
+(deftest snapshot-identity-changes-with-story-fallback-tag
+  (testing "rf2-8fz0n8 — for a TAGLESS variant (no own `:tags`, no `:extends`
+            chain that declares tags) the effective tag set FALLS BACK to the
+            parent story's `:tags` (`re-frame.story.tags/raw-inherited-tags`
+            story-fallback branch, reached through `effective-tags-slice`).
+            So editing the parent STORY's `:tags` changes the child's
+            effective classification and MUST perturb the child's snapshot
+            identity — even though the child's own `:tags` are empty and
+            `story-body-slice` never selects `:tags`. RED against a break in
+            `effective-tags-slice`'s story-fallback path; the story-fallback
+            sibling of the `:extends`-parent guard rf2-chzryf."
+    (story/reg-story :story.story-tag {:component :app/v :tags #{:docs}})
+    ;; Tagless variant — inherits the story's tags as the fallback default.
+    (story/reg-variant :story.story-tag/v {:events []})
+    (is (= #{:docs} (:effective-tags (ident/snapshot-tuple :story.story-tag/v)))
+        "the tagless variant inherits the parent story's tags (fallback)")
+    (let [h1 (-> (story/snapshot-identity :story.story-tag/v) :content-hash)]
+      ;; Edit ONLY the parent story's tags — the child's raw body is untouched.
+      (story/reg-story :story.story-tag {:component :app/v :tags #{:docs :test}})
+      (is (= #{:docs :test} (:effective-tags (ident/snapshot-tuple :story.story-tag/v)))
+          "the child's effective set now reflects the parent story's tag edit")
+      (let [h2 (-> (story/snapshot-identity :story.story-tag/v) :content-hash)]
+        (is (not= h1 h2)
+            "a parent-story tag edit perturbs the tagless child's hash")))))
 
 (deftest snapshot-identity-canonical-key-stable
   (testing "the canonical-version tag canonicalises and map key order is


### PR DESCRIPTION
Test-only PR closing three review-campaign test-gap beads across three disjoint surfaces. No production behaviour changes (one export-only edit to the mcp-conformance hermetic suite to enable the cross-check).

## rf2-8fz0n8 — story (tools/story)
`snapshot-identity` had variant-level guards (rf2-bah5o2/9g48l/chzryf) but no coverage of the STORY-side inputs. Adds three adversarial JVM tests in `story_runtime_test.clj`:
- `snapshot-identity-changes-with-story-component` — parent-story `:component` edit perturbs a component-less child's hash + witnesses the `[:story :component]` tuple slice.
- `snapshot-identity-changes-with-story-decorators` — parent-story `:decorators` swap/append perturbs the child hash + witnesses `[:story :decorators]`.
- `snapshot-identity-changes-with-story-fallback-tag` — parent-story `:tags` edit perturbs a TAGLESS variant via the `effective-tags-slice` story-fallback path + witnesses `:effective-tags`.

## rf2-79qmsw — mcp-conformance (tools/mcp-conformance)
The live gates are named in two hand-maintained lists (`INNER_TESTS`, test-all live rows) with no derivation from disk and no cross-check — a live gate added to one but forgotten in the other rides perpetually green. Adds `test/live-list-completeness.test.cjs` (node --test, rides `test-unit.cjs`'s derived cluster): readdirSyncs `test/live-re-frame2-pair-*.cjs` and asserts each appears in BOTH lists, plus the reverse (no dangling entry after rename/delete). Exports `INNER_TESTS` (require.main-guarded, boots nothing) and registers the guard as a `--test` row.

## rf2-za008k — reagent (implementation/adapters/reagent)
No `with-resource-lease`-specific test for the no-frame-resolvable raise. Adds a browser-gated deftest mounting `with-resource-lease` (no `:frame`, `*current-frame*` nil, no provider) under a minimal error boundary, asserting `(:rf.error/id (ex-data e))` = `:rf.error/no-frame-context`.

## Quality gates (foreground)
- `cd implementation && npm run test:cljs` → **8369 tests, 38468 assertions, 0 failures, 0 errors**
- `cd implementation && npm run test:browser` → **255 tests, 853 assertions, 0 failures, 0 errors** (exercises the rf2-za008k browser assertion)
- `cd tools/story && clojure -M:test` → **1770 tests, 6504 assertions, 0 failures, 0 errors**
- `cd tools/mcp-conformance && npm run test:unit` → **81 pass, 0 fail** (9 platform-skips); the new guard verified RED by adding an unlisted live file (both coverage assertions fail), then cleaned up. Lists currently 6/6/6 in sync.

## Stance
Pre-alpha, no shims; CORRECTNESS + GOOD-PRACTICE. Test-only; the one production edit is an export to make the drift guard possible. Not merging.
