### PR TITLE
fix+test(reagent-slim): strip :where publish-marker leak + value-summary parity + lease opts-map coverage (rf2-gjvu84 +2)

### DIFF
--- a/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
+++ b/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
@@ -169,7 +169,16 @@
   (or explicit-frame
       (frame/require-current-frame!
         :with-resource-lease
-        {:where 're-frame.adapter.reagent-slim/with-resource-lease})))
+        ;; Canonical (post-publish-stable) ns marker: the publication
+        ;; ns-transform (.github/scripts/transform-reagent-slim-ns.sh)
+        ;; rewrites ONLY the leading `(ns …)` token, so a `-slim` symbol
+        ;; here would survive verbatim into the shipped day8/reagent-slim
+        ;; jar — pointing a `:rf.error/no-frame-context` reader at
+        ;; `re-frame.adapter.reagent-slim`, a namespace the jar ships as
+        ;; the canonical `re-frame.adapter.reagent`. Use the canonical ns
+        ;; (rename-stable in-tree AND post-publish; matches `:display-name`
+        ;; below), rf2-gjvu84.
+        {:where 're-frame.adapter.reagent/with-resource-lease})))
 
 (defn- ensure-lease!
   "Dispatch `:rf.resource/ensure` for the render-time-resolved `desired`

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_with_resource_lease_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_with_resource_lease_dom_cljs_test.cljs
@@ -185,3 +185,49 @@
                 "the surrounding provider's frame did NOT win")
             (finally
               (try (.unmount root) (catch :default _ nil)))))))))
+
+;; ---- opts-map arm: explicit :frame pin + custom :cause (rf2-pdjy4g) --------
+;;
+;; The three tests above all call `[with-resource-lease descriptor (fn [] …)]`
+;; — a body thunk directly after the descriptor — which always takes
+;; `lease-args`' `(fn? (first args))` → `[nil body]` arm, so the opts-map arm
+;; `[(first args) (second args)]` and `resolve-lease-frame`'s
+;; `(or explicit-frame …)` truthy branch are NEVER exercised. This mounts with
+;; an opts MAP between the descriptor and the body thunk, pinning `:frame`
+;; explicitly and overriding `:cause`, then asserts both flow through.
+
+(deftest slim-with-resource-lease-explicit-frame-and-cause-opts
+  (testing "reagent-slim — an opts map {:frame :cause} between descriptor and
+            body pins the lease to the EXPLICIT :frame (bypassing the
+            surrounding provider / ambient resolution) and records the custom
+            :cause on the ensure"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — :browser-test runner exercises the assertion")
+      (let [provider-frame :rf.reagent-slim-lease-opts/provider
+            explicit-frame :rf.reagent-slim-lease-opts/explicit
+            custom-cause   :dashboard-widget
+            dispatches     (atom [])
+            mount-node     (.createElement js/document "div")
+            root           (rdc/create-root mount-node)]
+        (rf/reg-frame provider-frame {:doc "surrounding provider (should be bypassed)"})
+        (rf/reg-frame explicit-frame {:doc "explicitly pinned lease frame"})
+        (with-redefs [router/dispatch! (capturing-dispatch! dispatches)]
+          (try
+            (render-sync! root
+              [rf/frame-provider {:frame provider-frame}
+               [reagent-slim-adapter/with-resource-lease
+                descriptor-p0
+                {:frame explicit-frame :cause custom-cause}
+                (fn [] [:div "leased"])]])
+            (is (= 1 (count @dispatches)) "one ensure on mount")
+            (is (= :rf.resource/ensure (ev-id (nth @dispatches 0))))
+            (is (= explicit-frame (ev-frame (nth @dispatches 0)))
+                "ensure targeted the EXPLICIT :frame opt, not the surrounding provider")
+            (is (not= provider-frame (ev-frame (nth @dispatches 0)))
+                "the surrounding provider frame did NOT win over the explicit :frame")
+            (is (= custom-cause (:cause (ev-payload (nth @dispatches 0))))
+                "ensure carried the custom :cause opt (not the default [:lease :mount])")
+            (is (= (:resource descriptor-p0) (:resource (ev-payload (nth @dispatches 0))))
+                "the descriptor still flowed through alongside the opts map")
+            (finally
+              (try (.unmount root) (catch :default _ nil)))))))))

--- a/implementation/adapters/reagent-slim/test/reagent2/impl/diag_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/impl/diag_cljs_test.cljs
@@ -1,0 +1,157 @@
+(ns reagent2.impl.diag-cljs-test
+  "rf2-grd5hd — coverage + mirror-parity pin for `reagent2.impl.diag/value-summary`,
+  the day8/reagent-slim EP-0015 diagnostic REDACTION primitive (Spec 015
+  §Data-Classification, rf2-uwqale).
+
+  `value-summary` exists so a hiccup head / child vector / Form-3 spec baked
+  into a framework error message or ex-data slot carries only a SHAPE summary
+  (type / count / sorted keys / bounded head) — never the app-owned value —
+  before off-box capture (console, error boundary, host log, SSR error
+  handler) can grab the raw value the record projector never got to classify.
+
+  Two properties are pinned here:
+
+    1. BRANCH + REDACTION coverage — every `cond` arm of `value-summary`
+       (nil / map / vector / set / string / keyword / symbol / boolean /
+       number / seq / fn / seqable / scalar), the 24-char head truncation,
+       and the `sort-by str` catch fallback are exercised, each asserting the
+       offending VALUE never rides into the summary.
+
+    2. MIRROR PARITY — `value-summary` is a hand-copied 'content-byte-for-byte
+       mirror' of `re-frame.error/diag-value-summary` (replicated INLINE
+       because the slim bundle-isolation gate forbids the production build
+       `:require`-ing re-frame.*). A hand-replicated mirror with no parity
+       test silently drifts, so this asserts the two agree over a value
+       corpus. Bundle-isolation binds only PRODUCTION builds; this test-only
+       ns may require both — the slim bundle-isolation gate
+       (check-reagent-slim-bundle-isolation.cjs) inspects shipped bundles,
+       not the test classpath.
+
+  Pure data — no runtime state; rides `npm run test:cljs` via the `cljs-test$`
+  ns-regexp."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [reagent2.impl.diag :as diag]
+            [re-frame.error :as error]))
+
+;; ---- per-branch shape coverage --------------------------------------------
+
+(deftest value-summary-degenerate-shapes
+  (testing "nil / fn / boolean / seq summarise to their bare shape tag"
+    (is (= {:type :nil} (diag/value-summary nil)))
+    (is (= :fn (:type (diag/value-summary (fn [] nil)))))
+    (is (= {:type :boolean :head "true"}  (diag/value-summary true)))
+    (is (= {:type :boolean :head "false"} (diag/value-summary false)))
+    ;; A lazy-seq (and a plain list) is caught by the `seq?` arm BEFORE the
+    ;; catch-all `seqable?` arm — count is intentionally NOT carried (an
+    ;; unbounded/lazy seq must not be realised on the failure path).
+    (is (= {:type :seq} (diag/value-summary (map inc [1 2 3]))))
+    (is (= {:type :seq} (diag/value-summary '(1 2 3))))))
+
+(deftest value-summary-collections-are-shape-only
+  (testing "vector / set carry :count but never their elements"
+    (is (= {:type :vector :count 3}
+           (diag/value-summary [:div {:on-click (fn [] nil)} "child xyzzy"])))
+    (is (= :set (:type (diag/value-summary #{1 2 3}))))
+    (is (= 3   (:count (diag/value-summary #{1 2 3}))))
+    ;; no child content in the printed vector summary
+    (is (not (re-find #"xyzzy"
+                      (pr-str (diag/value-summary [:div "child xyzzy"])))))))
+
+(deftest value-summary-scalar-heads
+  (testing "keyword / symbol / number keep a recognition head"
+    (is (= {:type :keyword :head ":ws.app/request"}
+           (diag/value-summary :ws.app/request)))
+    (is (= {:type :symbol :head "reagent2.template/as-element"}
+           (diag/value-summary 'reagent2.template/as-element)))
+    (is (= {:type :number :head "42"} (diag/value-summary 42)))))
+
+;; ---- REDACTION: string head is bounded at the 24-char head-limit ----------
+
+(deftest value-summary-string-head-truncates-at-head-limit
+  (testing "a long/secret string carries :count + a bounded, ellipsised head —
+            the tail of the secret never rides into the summary"
+    (let [secret  "super-secret-bearer-token-value-1234567890"
+          s       (diag/value-summary secret)]
+      (is (= :string (:type s)))
+      (is (= (count secret) (:count s)) "the full length is structural, not the value")
+      (is (not= secret (:head s)) "the whole secret is NOT the head")
+      ;; head-limit is 24; head is 24 chars + a single ellipsis char.
+      (is (<= (count (:head s)) 25) "head bounded at head-limit (+ ellipsis)")
+      (is (re-find #"…$" (:head s)) "an over-limit head is ellipsis-marked")
+      (is (not (re-find #"1234567890" (:head s)))
+          "the bounded head truncated before the tail of the secret")))
+  (testing "a string AT/under the limit is carried whole with no ellipsis"
+    (let [short "short-string"                        ;; 12 chars
+          s     (diag/value-summary short)]
+      (is (= {:type :string :count 12 :head "short-string"} s))
+      (is (not (re-find #"…" (:head s)))))))
+
+;; ---- REDACTION: a map keeps structural keys, drops values -----------------
+
+(deftest value-summary-map-keeps-keys-drops-values
+  (testing "a map summary carries sorted structural keys + count, never values"
+    (let [m {:token "secret" :pdf "%PDF-1.4 huge blob" :n 7}
+          s (diag/value-summary m)]
+      (is (= :map (:type s)))
+      (is (= 3 (:count s)))
+      (is (= [:n :pdf :token] (:keys s)) "keys are sorted-by-str + structural")
+      (let [printed (pr-str s)]
+        (is (not (re-find #"secret" printed)))
+        (is (not (re-find #"%PDF" printed))
+            "no map VALUE leaked into the summary's printed form")))))
+
+;; ---- the sort-by str CATCH fallback ---------------------------------------
+
+(deftest value-summary-map-key-sort-throw-falls-back-to-unsorted-keys
+  (testing "when `(sort-by str (keys v))` throws, the summary falls back to
+            `(vec (keys v))` WITHOUT throwing — the shape still summarises"
+    ;; A JS object whose toString throws makes `(str k)` — and therefore the
+    ;; `sort-by str` keyfn — throw, exercising the `(catch :default …)` arm.
+    (let [boom-key (js-obj)]
+      (set! (.-toString boom-key) (fn [] (throw (js/Error. "boom"))))
+      (let [m {boom-key :v :ok 1}
+            s (diag/value-summary m)]
+        (is (= :map (:type s)) "still summarised as a map")
+        (is (= 2 (:count s)) "count survives the sort failure")
+        (is (vector? (:keys s)) "keys fell back to (vec (keys v))")
+        (is (= 2 (count (:keys s))) "both keys retained in the fallback")))))
+
+;; ---- MIRROR PARITY vs re-frame.error/diag-value-summary -------------------
+
+(def ^:private parity-corpus
+  "A value corpus spanning every `value-summary` branch, including the head
+  boundary (over/under 24 chars) and a hiccup-shaped vector. Each value is
+  fed to BOTH summariser twins; the summaries must be `=`."
+  [nil
+   {}
+   {:a 1 :b {:nested "v"} :c/d 2}
+   [:div {:class "x"} "leaf text over twenty-four characters long here"]
+   #{:x :y :z}
+   ""
+   "short"
+   "boundary-exactly-24-chrs"                              ;; 24 chars, no ellipsis
+   "a string that is definitely longer than twenty-four characters"
+   :ws.app/request
+   'reagent2.template/as-element
+   true
+   false
+   0
+   -12345678901234567890                                   ;; long numeric head
+   3.14159
+   '(1 2 3)
+   (map inc [1 2 3])
+   #js [1 2 3]                                             ;; seqable? arm (not seq?)
+   (js/Date. 0)])                                          ;; final :scalar arm
+
+(deftest value-summary-mirrors-re-frame-error-diag-value-summary
+  (testing "the slim mirror agrees with re-frame.error/diag-value-summary
+            byte-for-byte over the corpus (drift guard for the hand-copy)"
+    (doseq [v parity-corpus]
+      (is (= (error/diag-value-summary v) (diag/value-summary v))
+          (str "mirror drift for value: " (pr-str v))))))
+
+(deftest value-summary-mirrors-on-fn-and-lambda
+  (testing "a fn value summarises to the SAME bare {:type :fn} on both twins"
+    (let [f (fn [] :x)]
+      (is (= (error/diag-value-summary f) (diag/value-summary f)))
+      (is (= {:type :fn} (diag/value-summary f))))))


### PR DESCRIPTION
Three reagent-slim adapter fixes/tests from the 2026-07-09 review campaign
(`ai/findings/2026-07-09.review-adapters-reagent-slim.md`). One commit per bead.
Surface is isolated to `implementation/adapters/reagent-slim` (+ a throwaway
transform-fixture verification, no script change needed).

## rf2-gjvu84 [bug] — stale `:where` slim-ns marker survived the publish transform
`resolve-lease-frame` passed `{:where 're-frame.adapter.reagent-slim/with-resource-lease}`
to `require-current-frame!`. The publication ns-transform
(`.github/scripts/transform-reagent-slim-ns.sh`) rewrites ONLY the leading `(ns …)`
token by design, so this quoted qualified-symbol survived verbatim into the shipped
`day8/reagent-slim` jar — where `re-frame.adapter.reagent-slim` does NOT exist (the jar
ships its adapter at the canonical `re-frame.adapter.reagent`). A consumer reading
`:where` after a `:rf.error/no-frame-context` chased a namespace not in the artefact.

**Fix:** set the marker to the canonical `'re-frame.adapter.reagent/with-resource-lease`
— rename-stable both in-tree and post-publish, matching the component's `:display-name`.
No transform-script change (the transform is correct; the marker just had to be
rename-stable). **Proven** against the transform on a throwaway fixture copy:
post-transform the marker reads `re-frame.adapter.reagent/with-resource-lease` with no
`-slim` residue in the `:where` symbol.

## rf2-grd5hd [test] — `reagent2.impl.diag/value-summary` untested + no mirror-parity pin
`value-summary` is the EP-0015 / Spec 015 §Data-Classification REDACTION primitive
(rf2-uwqale) and had ZERO coverage; it is a hand-copied content-byte-for-byte mirror
of `re-frame.error/diag-value-summary` (replicated inline because the slim
bundle-isolation gate forbids a production `:require` of `re-frame.*`), so it could
silently drift. New `test/reagent2/impl/diag_cljs_test.cljs`:
- exercises every `cond` arm + the 24-char head truncation + the `(sort-by str)` catch
  fallback (via a key whose `toString` throws);
- asserts the offending VALUE never rides into the summary;
- pins MIRROR PARITY vs `re-frame.error/diag-value-summary` over a value corpus
  (tests may require both — bundle-isolation binds only production builds).

## rf2-pdjy4g [test] — `with-resource-lease` opts-map arm + explicit-frame pin untested
All three existing lease DOM tests use `[with-resource-lease descriptor (fn [] …)]`
(body thunk directly after descriptor), always taking `lease-args`' `[nil body]` arm —
so the opts-map arm and `resolve-lease-frame`'s `(or explicit-frame …)` truthy branch
were dead in tests. Adds a DOM deftest mounting
`[with-resource-lease descriptor {:frame … :cause …} (fn [] …)]` under a conflicting
surrounding provider, asserting the ensure targets the EXPLICIT `:frame` (not the
provider / ambient resolution) and carries the custom `:cause`.

## Quality gates (all foreground, all green)
- `npm run test:cljs` — **8377 tests, 38520 assertions, 0 failures, 0 errors** (includes the new diag node tests + mirror-parity pin)
- `npm run test:reagent-slim:bundle-isolation` — **PASS: 6 contracts, 25 sentinel checks** (the slim boundary still holds post-gjvu84)
- `npm run test:browser` — **255 tests, 857 assertions, 0 failures, 0 errors** (validates the new opts-map DOM deftest under a real DOM)
- `node scripts/_transform-reagent-slim-ns.test.cjs` — **6 passed**; plus manual transform verification confirming the `:where` marker is canonical + `-slim`-free post-publish

## Stance
Pre-alpha, no shims. Minimal, correct edits scoped to `implementation/adapters/reagent-slim`; ELEGANCE + CORRECTNESS + GOOD-PRACTICE. The bug fix touches one symbol; the tests add coverage/pins for pre-existing untested surfaces. No unrelated edits.
