### PR TITLE
docs: fix stale comments (adapters/scripts manifest, test-react docs, patterns, capabilities) (rf2-yowytn +3)

### DIFF
--- a/examples/capabilities/machines/state_machine_walkthrough/core.cljc
+++ b/examples/capabilities/machines/state_machine_walkthrough/core.cljc
@@ -87,7 +87,7 @@
               :on-failure [:auth.login/flow [:auth.login/failure]]}]]})
 
     :record-error
-    ;; rf2-ibksxg — the classified failure map rides under :error.
+    ;; The classified failure map rides under :error.
     (fn [{data :data [_ {:keys [error]}] :event}]
       {:data (-> data
                  (update :attempts inc)

--- a/examples/capabilities/resources/linearlite/core.cljs
+++ b/examples/capabilities/resources/linearlite/core.cljs
@@ -358,9 +358,8 @@
           ;; The fx context carries the envelope frame as `:frame`. The
           ;; `:fail-next-write?` toggle is an ordinary app-db slice (written by
           ;; `:linearlite/set-fail-next-write`), so read it off the frame's
-          ;; APP-db partition (`:rf.db/app`). Reading
-          ;; `:rf.db/runtime` here — where the flag never lives — is why the
-          ;; simulated rollback never fired.
+          ;; APP-db partition (`:rf.db/app`) — app state lives there, not in
+          ;; the `:rf.db/runtime` partition (framework runtime only).
           db        (:rf.db/app (rf/frame-state-value (:frame frame-ctx)))
           fail?     (and write? (boolean (:fail-next-write? db)))]
       (if fail?

--- a/examples/capabilities/ssr/resources_ssr/core.cljc
+++ b/examples/capabilities/ssr/resources_ssr/core.cljc
@@ -186,8 +186,8 @@
 ;; table at all — see the ns docstring — so the `[:ssr request-id nav-token]`
 ;; owner `:rf/server-init` ensures under never registers there, and
 ;; `drain-blocking-resources!` would return `{:settled? true}` immediately,
-;; whether or not `:articles/list` had actually resolved (this is the bug
-;; this example previously shipped — rf2-u64kc8).
+;; whether or not `:articles/list` had actually resolved — a route-free page
+;; leaning on it reports itself settled even when the resource has not.
 ;;
 ;; For a route-free SSR page there is no non-route blocking-drain surface to
 ;; reach for instead (Spec 016 §SSR and hydration ties blocking to the route

--- a/examples/patterns/long_running_work/README.md
+++ b/examples/patterns/long_running_work/README.md
@@ -163,7 +163,7 @@ examples/patterns/long_running_work/
 
 ```bash
 # From implementation/:
-npm run dev:example -- examples/long-running-work
+shadow-cljs watch examples/long-running-work
 ```
 
 Edits recompile live; the command prints a local URL to open.

--- a/examples/patterns/long_running_work/core.cljs
+++ b/examples/patterns/long_running_work/core.cljs
@@ -44,9 +44,10 @@
 
      shadow-cljs watch examples/long-running-work
 
-   Run it headless:
-
-     npm run test:browser        (covers every example's cljs-test)"
+   The example tree is test-free; the coverage lives in the framework test
+   tree at ns `re-frame.long-running-work-cljs-test`
+   (implementation/adapters/reagent/test/re_frame/long_running_work_cljs_test.cljs),
+   which rides `npm run test:cljs`."
   ;; Plain Reagent here (`reagent.dom.client` + `re-frame.adapter.reagent`).
   ;; The trick worth watching is in views.cljs: a `r/with-let`
   ;; finally-clause that fires the `:cancel` cascade when the view

--- a/implementation/adapters/scripts/adapter-smoke-filter.cjs
+++ b/implementation/adapters/scripts/adapter-smoke-filter.cjs
@@ -68,9 +68,12 @@ const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
 // perf-bundle gate, and mcp-conformance — not by per-example Playwright
 // specs.
 //
-// Adding a new adapter smoke: append an entry with all four fields
-// (build, htmlSrc, outDir, specPath). `specPath` is the absolute path to
-// the spec.cjs the runner will execute; it MUST exist on disk.
+// Adding a new adapter smoke: add the adapter name to the ADAPTERS list
+// below (standard layout assumed). The .map derives all four fields
+// (build, htmlSrc, outDir, specPath) from the standard
+// implementation/adapters/<name>/testbed/ layout, and `specPath` MUST
+// resolve to a spec.cjs that exists on disk. Add a bespoke literal entry
+// only for a non-standard layout.
 const ADAPTERS = ['reagent', 'uix', 'helix'];
 const OUT_ROOT = path.join(REPO_ROOT, 'implementation', 'out', 'examples');
 

--- a/implementation/adapters/scripts/serve-and-run-adapter-smokes.cjs
+++ b/implementation/adapters/scripts/serve-and-run-adapter-smokes.cjs
@@ -24,10 +24,10 @@
  *    (run-adapter-smokes.cjs).
  * 5. Always tears the server down.
  *
- * Build list, mount paths, and HTML sources are declared in
- * ADAPTER_SMOKES below. Adding a new smoke: append an entry here ONLY
- * when a matching spec.cjs exists under ADAPTER_SMOKE_SPEC_ROOTS; never
- * stage a surface that nothing tests.
+ * Build list, mount paths, and HTML sources come from the ADAPTER_SMOKES
+ * set declared in adapter-smoke-filter.cjs (imported above). Adding a new
+ * smoke: add the adapter name there ONLY when a matching spec.cjs exists
+ * under ADAPTER_SMOKE_SPEC_ROOTS; never stage a surface that nothing tests.
  *
  * Cross-platform: compile shadow-cljs shell-free by resolving its JS
  * entry-point and spawning it under THIS node binary (process.execPath),

--- a/implementation/adapters/test-react/README.md
+++ b/implementation/adapters/test-react/README.md
@@ -18,7 +18,7 @@ Purpose: catch React-lifecycle-driven bugs at unit-test speed without spinning u
 | Real React reconciler quirks | no | no | yes |
 
 The three **bold** rows carry living regressions in
-`test/re_frame/adapter/test_react_test.cljc` (ported under rf2-n2cuo) — each
+`test/re_frame/adapter/test_react_cljs_test.cljc` (ported under rf2-n2cuo) — each
 asserts the bug's *symptom* (the error raised / the imbalance / the extra
 render), so a future regression in that class fails the unit test. If your bug
 class lives in the leftmost four rows and the seminal symptom is "React threw /
@@ -64,7 +64,7 @@ timing, stay on Playwright.
          (mapv :phase (test-react/lifecycle-log mount)))))
 ```
 
-The `mount!` / `trigger-update!` / `unmount!` trio drive the simulator. The test owns the clock — there is no auto-re-render on app-db change (tests call `trigger-update!` explicitly after a dispatch settles). The adapter's own tests (`test/re_frame/adapter/test_react_test.cljc`) install/dispose the adapter directly via `re-frame.substrate.adapter` in a per-test `:each` fixture; nothing forces you to use `re-frame.test-support/make-reset-runtime-fixture`, though that helper works here just as it does for the production adapters.
+The `mount!` / `trigger-update!` / `unmount!` trio drive the simulator. The test owns the clock — there is no auto-re-render on app-db change (tests call `trigger-update!` explicitly after a dispatch settles). The adapter's own tests (`test/re_frame/adapter/test_react_cljs_test.cljc`) install/dispose the adapter directly via `re-frame.substrate.adapter` in a per-test `:each` fixture; nothing forces you to use `re-frame.test-support/make-reset-runtime-fixture`, though that helper works here just as it does for the production adapters.
 
 ### Render bodies and recursive children
 

--- a/implementation/adapters/test-react/test/re_frame/adapter/test_react_dispose_sub_cache_cljs_test.cljc
+++ b/implementation/adapters/test-react/test/re_frame/adapter/test_react_dispose_sub_cache_cljs_test.cljc
@@ -1,6 +1,6 @@
 (ns re-frame.adapter.test-react-dispose-sub-cache-cljs-test
-  "CLJS-gate companion to the rf2-ghfkkk High finding's coverage in
-  `re-frame.adapter.test-react-test`.
+  "Companion to the rf2-ghfkkk High finding's coverage in
+  `re-frame.adapter.test-react-cljs-test`.
 
   The substantive assertion lives in both: test-react's `dispose-adapter!`
   MUST clear every live frame's per-frame sub-cache (entries + ref-counts),
@@ -13,15 +13,13 @@
   the FRAME, not the reaction) survived a dispose/reinstall cycle, allowing a
   later subscribe to read a stale value and breaking process isolation.
 
-  Why a SEPARATE ns from `test_react_test.cljc`: the sibling's ns
-  (`re-frame.adapter.test-react-test`) ends in `-test` but NOT `-cljs-test`,
-  so it runs only under the JVM cognitect runner (`clojure -M:test`) — the
-  shadow-cljs `:node-test` build's `cljs-test$` ns-regexp does not match it.
-  This ns ends in `-cljs-test`, so it ALSO rides `npm run test:cljs`, giving
-  the contract CLJS coverage. It uses the standard
-  `make-reset-runtime-fixture` (mirroring `plain_atom_dispose_cljs_test`) for
-  airtight per-test isolation rather than hand-managing frame/registrar
-  state."
+  Why a SEPARATE ns from `test_react_cljs_test.cljc`: the unique coverage
+  here is `dispose-adapter-clears-sub-caches-across-multiple-frames` — the
+  walk must cover EVERY live frame, not just `:rf/default`. Both files end in
+  `-cljs-test`, so both ride `npm run test:cljs` (and the JVM cognitect
+  runner). This ns uses the standard `make-reset-runtime-fixture` (mirroring
+  `plain_atom_dispose_cljs_test`) for airtight per-test isolation rather than
+  hand-managing frame/registrar state."
   (:require [re-frame.adapter.test-react :as test-react]
             [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.core :as rf]


### PR DESCRIPTION
Comment/doc-only fixes across four disjoint surfaces. Zero logic change; each bead one commit.

## rf2-yowytn — adapters/scripts stale manifest instructions
`ADAPTER_SMOKES` is now GENERATED from `const ADAPTERS = ['reagent','uix','helix']` via `.map`. The pre-extraction "append an entry" / "declared in ADAPTER_SMOKES below" comments described a hand-authored literal array that no longer exists.
- `adapter-smoke-filter.cjs`: add-a-smoke instruction reworded to "add the adapter name to the ADAPTERS list (standard layout assumed; bespoke literal only for a non-standard layout)".
- `serve-and-run-adapter-smokes.cjs`: header repointed at `adapter-smoke-filter.cjs`, aligning with its accurate body comment (L145-151).

## rf2-0vsal6 — test-react docs stale refs + false JVM-only claim
rf2-ezbzvm renamed the main self-test to `test_react_cljs_test.cljc` (ns `re-frame.adapter.test-react-cljs-test`); `test_react_test.cljc` no longer exists.
- README.md x2: repointed to `test_react_cljs_test.cljc`.
- Companion docstring: repointed the ns ref; rewrote the "Why a SEPARATE ns" rationale — the old claim that the sibling runs JVM-only (ends in `-test` not `-cljs-test`) is now false; both files end in `-cljs-test` and ride `npm run test:cljs`. Honest rationale: the unique multi-frame dispose case + `make-reset-runtime-fixture` variant.
- Out of scope (logic decision, left for a follow-up): the bead's T1 consolidation option (move the multi-frame test into the main file and retire the companion) — that's a test-logic change, not comment/doc.

## rf2-fottdw — long_running_work headless-test docstring
`core.cljs` "npm run test:browser (covers every example's cljs-test)" was stale three ways (misrepresented the test-free model, wrong runner, below siblings' bar). Rewritten to mirror nine_states/websocket: test-free tree; coverage at ns `re-frame.long-running-work-cljs-test` (`implementation/adapters/reagent/test/re_frame/long_running_work_cljs_test.cljs`) via `npm run test:cljs`. Secondary: README run command switched `npm run dev:example` → `shadow-cljs watch examples/long-running-work` to match core.cljs + the 3 sibling READMEs.

## rf2-9ce6gc — strip commit-scars from capabilities teaching comments
Three teaching-example comments carried commit-scars (unresolvable Beads ids / narration of since-fixed defects). Concept kept, scar dropped:
1. `state_machine_walkthrough/core.cljc`: dropped `rf2-ibksxg` id, kept the `:error` clause.
2. `ssr/resources_ssr/core.cljc`: dropped `rf2-u64kc8` id + "this example previously shipped"; reframed present-tense.
3. `resources/linearlite/core.cljs`: reframed to explain WHY the toggle lives in `:rf.db/app` rather than narrating the historic rollback failure.

## Quality gates
- `npm ci` (deps were absent on fresh worktree), then `npm run test:cljs` (foreground): **Ran 8386 tests / 38694 assertions — 0 failures, 0 errors.** .cljc/.cljs touched are comment/docstring-only; the gate confirms nothing broke.

## Stance
Pre-alpha, no shims; CLARITY + CORRECTNESS. Pure comment/doc polish, no logic change.