### PR TITLE
test(routing): with-base-path CLJS legs + validate-route-pattern! rejection coverage (rf2-33uv27 +1)

### DIFF
--- a/implementation/routing/test/re_frame/routing_registry_test.clj
+++ b/implementation/routing/test/re_frame/routing_registry_test.clj
@@ -5,6 +5,7 @@
   parsing, and metadata validation). Split from routing_test.clj per
   rf2-u8qe7y finding 3."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [clojure.string :as string]
             [re-frame.core :as rf]
             [re-frame.identity :as identity]
             [re-frame.routing :as routing]
@@ -885,22 +886,85 @@
 ;; Lens 5 T1-T8.
 
 (deftest invalid-route-patterns-fail-at-registration
-  (testing "non-canonical path patterns raise actionable errors at reg-route"
-    (doseq [[route-id pattern]
-            [[:route/no-leading-slash "cart"]
-             [:route/splat-not-final "/files/*rest/more"]
-             [:route/nested-optional "/a{/:b{/:c}?}?"]
-             [:route/optional-not-slash-prefixed "/articles{:id}?"]]]
+  ;; rf2-gsmxlj — one fixture per `match/validate-route-pattern!` rejection
+  ;; branch (match.cljc:151-253 + its helpers). The validator is the fail-loud
+  ;; reg-route authoring-boundary grammar gate; Spec 012 relies on it to stop a
+  ;; malformed `:path` producing surprising matcher / URL-emitter behaviour
+  ;; later. Each fixture drives the REAL boundary (`rf/reg-route`) with the
+  ;; malformed pattern class the branch is meant to reject and asserts the
+  ;; canonical thrown-error shape PLUS the specific `:reason` naming the
+  ;; offending construct — so a single-pass-loop refactor that drops a check or
+  ;; emits the wrong `:reason` fails here.
+  (testing "grammar-violating :path patterns raise :rf.error/invalid-route-pattern
+            at reg-route, each naming the offending construct via :reason"
+    (doseq [[route-id pattern reason-substr]
+            [;; ---- top-level shape (match.cljc:174-184) ----
+             [:route/empty-path               ""                  ":path must not be empty"]
+             [:route/no-leading-slash         "cart"              ":path must start with"]
+             ;; ---- empty path segments (match.cljc:201-203). A TRAILING `/` is
+             ;; canonicalised away before validation, so the empty-segment branch
+             ;; is reached via an INTERIOR double slash, not a trailing one.
+             [:route/interior-double-slash    "/x//y"             "empty path segments are not allowed"]
+             ;; ---- reserved `}` / `?` in the main loop (match.cljc:209-213) ----
+             [:route/bare-close-brace         "/a}b"              "`}` appears without a matching optional-group opener"]
+             [:route/bare-question            "/a?b"              "`?` is reserved for the optional-group suffix"]
+             ;; ---- params / splats not occupying a whole segment ----
+             [:route/param-mid-segment        "/a:id"             "named params must occupy a whole path segment"]
+             [:route/splat-mid-segment        "/a*rest"           "splats must occupy a whole path segment"]
+             ;; ---- bad param / splat identifier names (route-name-re) ----
+             [:route/bad-param-name           "/:1bad"            "param name must be a bare identifier"]
+             [:route/bad-splat-name           "/*1bad"            "splat name must be a bare identifier"]
+             ;; ---- splat not final (already covered pre-rf2-gsmxlj) ----
+             [:route/splat-not-final          "/files/*rest/more" "splats must be the final path segment"]
+             ;; ---- optional-group grammar (validate-optional-group!,
+             ;;      match.cljc:98-149) ----
+             [:route/group-unclosed           "/a{/:b"            "optional groups must close with `}?`"]
+             [:route/group-no-suffix          "/a{/:b}"           "optional groups must end with `}?`"]
+             [:route/group-empty              "/a{}?"             "optional groups must not be empty"]
+             [:route/group-empty-segment      "/a{//}?"           "optional groups may not contain empty segments"]
+             [:route/group-not-slash-prefixed "/articles{:id}?"   "optional groups must wrap a slash-prefixed sub-pattern"]
+             [:route/group-nested             "/a{/:b{/:c}?}?"    "nested optional groups are not part of the grammar"]
+             [:route/group-splat              "/a{/*rest}?"       "splats are not allowed inside optional groups"]
+             [:route/group-bad-param-name     "/a{/:1bad}?"       "param name must be a bare identifier"]
+             [:route/group-reserved-literal   "/shop{/a:b}?"      "literal path segments must percent-encode reserved characters"]]]
       (let [ex (try
                  (rf/reg-route route-id {} pattern)
                  nil
                  (catch clojure.lang.ExceptionInfo e e))]
-        (is (some? ex) (str pattern " should be rejected"))
-        (is (= :rf.error/invalid-route-pattern (:rf.error/id (ex-data ex))))
-        (is (= route-id (:route-id (ex-data ex))))
-        (is (= pattern (:pattern (ex-data ex))))
-        (is (some? (:reason (ex-data ex)))
-            "ex-data includes an actionable reason"))))
+        (is (some? ex) (str (pr-str pattern) " should be rejected at reg-route"))
+        (when ex
+          (let [data (ex-data ex)]
+            (is (= :rf.error/invalid-route-pattern (:rf.error/id data))
+                (str (pr-str pattern) " → :rf.error/invalid-route-pattern"))
+            (is (= route-id (:route-id data))
+                (str (pr-str pattern) " → :route-id slot names the route"))
+            (is (= pattern (:pattern data))
+                (str (pr-str pattern) " → :pattern slot echoes the offending pattern"))
+            (is (integer? (:index data))
+                (str (pr-str pattern) " → :index slot names the offending position"))
+            (is (and (string? (:reason data))
+                     (string/includes? (:reason data) reason-substr))
+                (str (pr-str pattern) " → :reason must name the offending construct "
+                     (pr-str reason-substr) " (was " (pr-str (:reason data)) ")")))))))
+
+  (testing "a non-string :path is the one rejection branch with NO positional
+            :index — a type error, not a position in the string
+            (match.cljc:171-172)"
+    (let [ex (try
+               (rf/reg-route :route/non-string-path {} 42)
+               nil
+               (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? ex) "a non-string :path is rejected at reg-route")
+      (when ex
+        (let [data (ex-data ex)]
+          (is (= :rf.error/invalid-route-pattern (:rf.error/id data)))
+          (is (= :route/non-string-path (:route-id data)))
+          (is (= 42 (:pattern data)) ":pattern echoes the non-string value")
+          (is (nil? (:index data))
+              "a type error carries no positional :index (the pattern is not a string)")
+          (is (and (string? (:reason data))
+                   (string/includes? (:reason data) ":path is required and must be a string"))
+              ":reason names the type violation")))))
 
   (testing "canonical optional groups and final splats still register"
     (is (= :route/articles

--- a/implementation/routing/test/re_frame/routing_url_strategy_cljs_test.cljs
+++ b/implementation/routing/test/re_frame/routing_url_strategy_cljs_test.cljs
@@ -17,6 +17,13 @@
   Plus an ADVERSARIAL negative: a malformed `#`-URL fails closed to a
   route-miss, exactly as a malformed path-URL does.
 
+  5. The `with-base-path` combinator's three CLJS-only side-effecting legs
+     (rf2-33uv27): `:push!` / `:replace!` re-add the deployment base before
+     driving `window.history`, and `:install-listener!` STRIPS the base off
+     each browser-driven change before `on-change` — a `/realworld`-deployed
+     app's address bar carries the mount-point URL while the router stays
+     app-relative.
+
   Node has no `window`, so a jsdom-style history/location stub is installed
   per-test (mirroring `routing_history_cljs_test.cljs`). Per Spec 012 §URL
   strategies."
@@ -256,3 +263,89 @@
   (testing "hash-encode does not double-hash an already-`#`-prefixed input"
     (is (= "#/active" (strategy/hash-encode "#/active")))
     (is (= "#/active" (strategy/hash-encode (strategy/hash-encode "/active"))))))
+
+;; ==========================================================================
+;; 5. with-base-path (rf2-g8pbwg / rf2-33uv27) — the three CLJS-only
+;;    side-effecting legs (:push! / :replace! / :install-listener!) driven
+;;    against the live stubbed window.
+;;
+;; The JVM suite (`routing_url_strategy_test.clj`) pins the host-agnostic
+;; :encode/:decode wrapping + the blank-base no-op; these three side-effecting
+;; legs are CLJS-only and had ZERO executed coverage (rf2-33uv27). They are the
+;; egress (`:push!`/`:replace!` re-add the base so the address bar carries the
+;; real mount-point URL) and ingress (`:install-listener!` STRIPS the base so
+;; the app-side handler stays app-relative) halves the base-path combinator
+;; exists for — a `/realworld`-deployed app. Driven here over the DEFAULT
+;; history strategy (the case the bead describes); the wrapper's `:decode`
+;; strip is already round-tripped by section 3's live-window test for the
+;; shipped strategies.
+;; ==========================================================================
+
+(deftest with-base-path-push!-re-adds-base-to-history-entry-cljs
+  (testing "rf2-33uv27: a with-base-path-wrapped history strategy's :push!
+            re-adds the base before driving window.history — every pushed
+            entry carries the real /realworld mount-point href, not the bare
+            app-relative path"
+    (let [wrapped (strategy/with-base-path strategy/history-url-strategy "/realworld")]
+      ((:push! wrapped) "/active")
+      ((:push! wrapped) "/completed")
+      (is (= ["/" "/realworld/active" "/realworld/completed"]
+             (:entries @*history-state*))
+          "each :push! entry is the base-prefixed href (a new entry per push)")
+      (is (= "/realworld/completed" (current-url *history-state*))
+          "the address bar sits on the base-prefixed completed href"))))
+
+(deftest with-base-path-replace!-re-adds-base-and-overwrites-cljs
+  (testing "rf2-33uv27: the wrapped :replace! re-adds the base AND overwrites
+            the current history entry (no new entry) — mirroring the shipped
+            strategy's replace semantics under the base prefix"
+    (let [wrapped (strategy/with-base-path strategy/history-url-strategy "/realworld")]
+      ((:push! wrapped) "/active")
+      (let [before (count (:entries @*history-state*))]
+        ((:replace! wrapped) "/completed")
+        (is (= before (count (:entries @*history-state*)))
+            ":replace! did not add a history entry")
+        (is (= "/realworld/completed" (current-url *history-state*))
+            "the current entry was overwritten with the base-prefixed href")
+        (is (= "/realworld/completed" (last (:entries @*history-state*)))
+            "no stray /active remains as the tail — it was replaced in place")))))
+
+(deftest with-base-path-install-listener!-strips-base-before-on-change-cljs
+  (testing "rf2-33uv27: the wrapped :install-listener! STRIPS the base off each
+            browser-driven change before calling on-change — a /realworld app's
+            Back/Forward navs reach the router app-relative (/active), never the
+            base-prefixed /realworld/active that would route-miss on every
+            back-button"
+    (let [wrapped  (strategy/with-base-path strategy/history-url-strategy "/realworld")
+          received (atom [])
+          teardown ((:install-listener! wrapped) (fn [p] (swap! received conj p)))]
+      ;; Drive the browser to base-prefixed URLs and fire popstate: the inner
+      ;; history-decode reads /realworld/active off the stubbed location; the
+      ;; wrapper strips /realworld so on-change sees the app-relative /active.
+      (.pushState js/globalThis.window.history nil "" "/realworld/active")
+      (.dispatchEvent js/globalThis.window #js {:type "popstate"})
+      (.pushState js/globalThis.window.history nil "" "/realworld/completed")
+      (.dispatchEvent js/globalThis.window #js {:type "popstate"})
+      (is (= ["/active" "/completed"] @received)
+          "on-change received the base-STRIPPED app-relative path on each change")
+      ;; the returned teardown thunk removes the browser listener.
+      (teardown)
+      (reset! received [])
+      (.pushState js/globalThis.window.history nil "" "/realworld/active")
+      (.dispatchEvent js/globalThis.window #js {:type "popstate"})
+      (is (= [] @received)
+          "the teardown thunk removed the popstate listener — no further deliveries"))))
+
+(deftest with-base-path-install-listener!-mount-root-delivers-app-root-cljs
+  (testing "rf2-33uv27: at the bare mount root (location == the base itself,
+            /realworld) the wrapped listener delivers `/` — the app root — not
+            an empty string, exactly as strip-base-path's mount-root case
+            specifies"
+    (let [wrapped  (strategy/with-base-path strategy/history-url-strategy "/realworld")
+          received (atom nil)
+          teardown ((:install-listener! wrapped) (fn [p] (reset! received p)))]
+      (.pushState js/globalThis.window.history nil "" "/realworld")
+      (.dispatchEvent js/globalThis.window #js {:type "popstate"})
+      (is (= "/" @received)
+          "the mount root decodes+strips to the app root `/`")
+      (teardown))))


### PR DESCRIPTION
## Summary

Adversarial test coverage for two routing test-gap beads. Test-only; no production change.

### rf2-33uv27 — `with-base-path` CLJS side-effecting legs executed
`strategy.cljc`'s three CLJS-only wrapped legs (`:push!` / `:replace!` base re-add, `:install-listener!` base-strip) had zero executed coverage; the JVM suite pins only the pure `:encode`/`:decode` + blank-base no-op. New CLJS deftests (in `routing_url_strategy_cljs_test.cljs`, reusing the existing stubbed-window fixture) drive them over the default history strategy — the `/realworld` sub-path case the bead describes:
- `:push!` re-adds the base to each `window.history` entry
- `:replace!` re-adds the base **and** overwrites in place (no new entry)
- `:install-listener!` strips the base off each browser-driven change before `on-change` (incl. the mount-root → `/` case); teardown thunk removes the listener

### rf2-gsmxlj — `validate-route-pattern!` rejection branches
Extended `invalid-route-patterns-fail-at-registration` from 4 fixtures to one per rejection branch, driving the real `rf/reg-route` boundary and asserting the canonical error shape (`:rf.error/invalid-route-pattern` + `:route-id`/`:pattern`/`:index`) **plus** the specific `:reason` naming the offending construct. Branches: empty path, no leading slash, interior `//`, bare `}` / `?`, param/splat mid-segment, bad param/splat identifier, splat-not-final, optional-group unclosed / no-`}?`-suffix / empty / empty-segment / not-slash-prefixed / nested / splat-in-group / bad-name-in-group / reserved-literal-in-group. A separate case pins the non-string `:path` branch (the one rejection with no positional `:index`).

## Finding (filed rf2-irygd6, P2, not fixed here)
Writing the first executed coverage of the `with-base-path` legs surfaced a real divergence: over the **hash** strategy, `:encode` yields `/demos#/active` (base outside the fragment — the correct sub-path shape) but `:push!`/`:replace!` drive `hash-encode("/demos/active")` = `#/demos/active` (base swallowed into the fragment). Root cause: for a non-identity `:encode` strategy, prepend-base-then-inner-encode ≠ inner-encode-then-prepend-base. History strategy + base is unaffected and correct. The correct hash+base semantics is a design/spec call, so it's filed for triage rather than fixed here (per the no-production-edits-unless-clear-fix stance). The new tests deliberately cover only the history legs, which are correct.

## Quality gates (foreground)
- `npm run test:cljs` — **8390 tests, 38702 assertions, 0 failures, 0 errors** (fresh `npm ci`)
- `cd implementation/routing && clojure -M:test` — **391 tests, 1748 assertions, 0 failures, 0 errors**
- No browser-gated tests added (new CLJS tests run under node via the existing window stub), so `test:browser` not required for these.

## Stance
Pre-alpha, no shims; CORRECTNESS + GOOD-PRACTICE; test-only, no over-engineering. Touched only `implementation/routing`.
