### PR TITLE
test(mcp-base,ssr-ring,schemas): CLJS redaction arms + fail-closed branches + :maybe wrapper (rf2-k76ohl +2)

### DIFF
--- a/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
@@ -721,6 +721,73 @@
                   ["a" :plain]))
         "plain :map-of key with a fully non-sensitive value → NOT leaf-sensitive")))
 
+;; -- direct unit tests: the `:maybe` transparent-wrapper arm (rf2-f2qcgl) --
+;;
+;; `:maybe` is a genuinely single-child transparent wrapper (`[:maybe inner]`)
+;; that contributes NO `:in` segment — both redaction-path walkers descend into
+;; the inner schema WITHOUT consuming a path segment (align-in-path
+;; walker.cljc:816-819; sanitize-sensitive-path walker.cljc:1003-1006). `:maybe`
+;; is exercised in `walk-flagged-schema` (the DECL extractor) via its `:else`
+;; descend-into-each-child arm, but the two REDACTION-path `:maybe` arms above
+;; had no direct test — `:maybe` is absent from the security artefact's
+;; generative redaction wrap-set (`:map`/`:vector`/`:sequential`/`:map-of`/
+;; `:tuple`), whose only `:maybe` occurrence is a childless malformed-schema
+;; case. These pin the child-present transparent descent on both walkers.
+
+(deftest schema-sensitive-at?-descends-maybe-transparent-wrapper
+  (testing "rf2-f2qcgl — schema-sensitive-at? aligns a path THROUGH a `:maybe`
+            wrapper without consuming a segment: a `:sensitive?` leaf nested
+            inside `[:maybe [:map …]]` resolves sensitive at the value path that
+            skips the wrapper (align-in-path :maybe arm, walker.cljc:816-819)"
+    ;; The exact bead shape: the sensitive slot sits under `:s` -> `:maybe` ->
+    ;; `:k`. Malli's `:in` for the failing `:k` value skips the transparent
+    ;; `:maybe`, so the aligned path is [:s :k] and the extracted decl-path is
+    ;; likewise [:s :k] (walk-flagged-schema descends `:maybe` at the same
+    ;; base-path) — they prefix-match, so the leaf resolves sensitive.
+    (is (true? (walker/schema-sensitive-at?
+                 [:map [:s [:maybe [:map [:k {:sensitive? true} :string]]]]]
+                 [:s :k]))
+        "sensitive leaf under a `:maybe` wrapper → leaf sensitive at [:s :k]")
+    ;; Companion: the same wrapper shape with a NON-sensitive leaf must NOT
+    ;; over-redact — the `:maybe` descent is transparent, not a fail-open bail.
+    (is (false? (walker/schema-sensitive-at?
+                  [:map [:s [:maybe [:map [:k :string]]]]]
+                  [:s :k]))
+        "non-sensitive leaf under a `:maybe` wrapper → NOT leaf sensitive")
+    ;; A sensitive leaf directly under a top-level `:maybe` (no outer :map):
+    ;; `[:maybe [:map …]]` with :in [:k]. Align descends the `:maybe` with the
+    ;; segment intact, keeps [:k], and resolves sensitive.
+    (is (true? (walker/schema-sensitive-at?
+                 [:maybe [:map [:k {:sensitive? true} :string]]]
+                 [:k]))
+        "top-level `:maybe` wrapper is transparent for the leaf decision too")))
+
+(deftest sanitize-sensitive-path-transparent-through-maybe
+  (testing "rf2-f2qcgl — sanitize-sensitive-path descends a `:maybe` wrapper
+            without consuming a segment (walker.cljc:1003-1006), so navigable
+            segments on either side keep their locator identity"
+    ;; Map key kept: `:s` (map key, before the wrapper) and `:k` (map key,
+    ;; inside the wrapper) are both navigable `get-in` locators — the `:maybe`
+    ;; between them is transparent, so neither is scrubbed.
+    (is (= [:s :k]
+           (walker/sanitize-sensitive-path
+             [:map [:s [:maybe [:map [:k {:sensitive? true} :string]]]]]
+             [:s :k]))
+        "navigable map keys survive verbatim across a `:maybe` wrapper"))
+  (testing "rf2-f2qcgl — a value-bearing `:set` element nested under a `:maybe`
+            is still scrubbed: the walk descends the transparent `:maybe`, then
+            the `:set` arm ALWAYS scrubs the failing element value"
+    ;; Malli reports a `:set` failure's `:in` segment as the failing ELEMENT
+    ;; VALUE itself (not an index); the secret element must NOT ride verbatim in
+    ;; `:path`. The outer map key `:s` is kept; the set element is redacted.
+    (let [out (walker/sanitize-sensitive-path
+                [:map [:s [:maybe [:set [:string {:sensitive? true}]]]]]
+                [:s "SECRET-SET-ELEMENT"])]
+      (is (= [:s :rf/redacted] out)
+          "map key kept; set element scrubbed to the sentinel across `:maybe`")
+      (is (not (some #{"SECRET-SET-ELEMENT"} out))
+          "the sensitive set element does NOT survive in the sanitized path"))))
+
 ;; -- end-to-end via validate-app-schema! (:path / :reason / whole-tags egress) --
 
 (deftest app-db-validation-or-wrapped-map-of-sensitive-key-scrubbed

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/pipeline_materialiser_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/pipeline_materialiser_test.clj
@@ -199,6 +199,74 @@
                           {:redirect {:location "/x"}} nil)))
         "absent redirect status still defaults to 302")))
 
+;; ===========================================================================
+;; fail-closed-status — the :warning trace on a non-integer status (rf2-njkw94)
+;;
+;; `non-integer-status-fails-closed-to-500` above pins the 500 OUTCOME, but the
+;; `:rf.ssr/ssr-non-integer-status` :warning trace the fail-closed arm emits
+;; (pipeline.clj:70) was never asserted — an inconsistency in an otherwise
+;; trace-pinned slice (the sibling `ssr-non-string-header-value` warning HAS a
+;; trace test above; `redirect-no-target` is pinned end-to-end). Mirror the
+;; `collect-non-string-header-warnings` listener pattern so the operator-facing
+;; diagnostic is contract-pinned, not merely emitted.
+;; ===========================================================================
+
+(defn- collect-non-integer-status-warnings
+  "Run `thunk` while listening for `:rf.ssr/ssr-non-integer-status` warning
+  traces; return the collected events."
+  [thunk]
+  (let [traces (atom [])]
+    (rf/register-listener! :trace ::non-integer-status-watch
+      (fn [ev] (when (= :rf.ssr/ssr-non-integer-status (:operation ev))
+                 (swap! traces conj ev))))
+    (try
+      (thunk)
+      (finally
+        (rf/unregister-listener! :trace ::non-integer-status-watch)))
+    @traces))
+
+(deftest non-integer-status-emits-exactly-one-fail-closed-warning
+  (testing "rf2-njkw94: a non-integer :status reaching the materialiser emits
+            exactly one :warning trace naming the offending value-type + the
+            fail-closed-to-500 recovery; the response still fails closed to 500"
+    (let [warnings (collect-non-integer-status-warnings
+                     (fn []
+                       (let [ring (pipeline/ssr-response->ring-response
+                                    {:status "404"
+                                     :headers [["Content-Type" "text/html"]]}
+                                    "<p>x</p>")]
+                         (is (= 500 (:status ring))
+                             "the non-int status still fails closed to 500"))))]
+      (is (= 1 (count warnings))
+          "exactly one non-integer-status warning for one non-int status")
+      (let [ev   (first warnings)
+            tags (:tags ev)]
+        (is (= :rf.ssr/ssr-non-integer-status (:operation ev)))
+        (is (= :warning (:op-type ev)) "emitted at :warning severity")
+        (is (= :ssr-ring/ssr-response->ring-response (:where tags))
+            "the warning names the materialiser call site")
+        (is (= "404" (:status tags))
+            "the warning carries the offending status value")
+        (is (= "java.lang.String" (:status-type tags))
+            "the warning names the value's concrete type")
+        ;; `:recovery` is hoisted from :tags to a top-level event slot per
+        ;; Spec 009 §Core-field hoist (trace.cljc dissocs it from :tags).
+        (is (= :failed-closed-to-500 (:recovery ev))
+            "the warning carries the fail-closed recovery disposition")))))
+
+(deftest integer-status-emits-no-fail-closed-warning
+  (testing "rf2-njkw94: a genuine integer status (the contract-compliant path)
+            emits NO ssr-non-integer-status warning — the trace is a
+            defect-only diagnostic, not a per-request emission"
+    (let [warnings (collect-non-integer-status-warnings
+                     (fn []
+                       (pipeline/ssr-response->ring-response
+                         {:status 200 :headers []} "x")
+                       (pipeline/ssr-response->ring-response
+                         {:headers []} "x")))]  ;; absent status → 200 default
+      (is (= [] warnings)
+          "no warning for a valid integer status or an absent (defaulted) one"))))
+
 (deftest non-string-header-value-coerced-in-materialiser
   (testing "rf2-v0qbng: a non-string header value on the accumulator (what a
             soft-passed `:rf.server/set-header {:name \"X-Count\" :value 5}`

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
@@ -1145,6 +1145,41 @@
                             #"initial-events must be a vector OR a"
                             (lifecycle/resolve-initial-events! '(:list-not-vector) req))))))
 
+(deftest resolve-root-view-invalid-shape-unit-contract
+  (testing "lifecycle/resolve-root-view — hiccup passthrough, 0-arity fn
+            resolution, and the :else invalid-shape throw (unit).
+            Sibling to initial-events-resolve-fn-unit-contract:
+            resolve-initial-events! has a dedicated invalid-shape unit but the
+            resolve-root-view :else arm (lifecycle.clj:186-193) — which throws
+            :rf.error/invalid-root-view for a value that is neither a hiccup
+            vector nor a 0-arity fn — was untested (rf2-njkw94)."
+    ;; A hiccup vector passes through verbatim.
+    (is (= [:div "x"] (lifecycle/resolve-root-view [:div "x"])))
+    ;; A 0-arity fn is invoked exactly once; its hiccup result is returned.
+    (let [calls (atom 0)]
+      (is (= [:section] (lifecycle/resolve-root-view
+                          (fn [] (swap! calls inc) [:section]))))
+      (is (= 1 @calls) "the fn-form is resolved exactly once (rf2-6t36h)"))
+    ;; Every non-vector, non-fn shape hits the :else arm and throws the
+    ;; canonical :rf.error/invalid-root-view — pinned across scalar shapes so
+    ;; the fail-closed branch (not accidental happy-path fallthrough) fires.
+    (doseq [bad ["a-string" :a-keyword {:a :map} 42 nil]]
+      (let [ex (try (lifecycle/resolve-root-view bad)
+                    (catch clojure.lang.ExceptionInfo e e))]
+        (is (instance? clojure.lang.ExceptionInfo ex)
+            (str "resolve-root-view must throw for " (pr-str bad)))
+        (is (= :rf.error/invalid-root-view (:rf.error/id (ex-data ex)))
+            (str "canonical :rf.error/id for " (pr-str bad)))
+        (is (= 'rf.ssr/ssr-handler (:where (ex-data ex)))
+            "the where-symbol names the public ssr-handler entry point")
+        (is (= :supply-a-hiccup-vector-or-0-arity-fn (:recovery (ex-data ex)))
+            "the recovery disposition is carried through")
+        (is (= bad (:received (ex-data ex)))
+            "ex-data carries the offending :received value")
+        (is (re-find #"root-view must be a hiccup vector or a 0-arity fn"
+                     (ex-message ex))
+            "the human message names the public concept + expected fix")))))
+
 ;; ===========================================================================
 ;; ssr-handler — :ssr opt reaches the per-request frame's :ssr metadata
 ;;

--- a/tools/mcp-base/test/re_frame/mcp_base/cljs_branches_cljs_test.cljs
+++ b/tools/mcp-base/test/re_frame/mcp_base/cljs_branches_cljs_test.cljs
@@ -24,7 +24,8 @@
   'no throw on malformed input when Malli is absent', so we don't reach
   into the private helpers — we pin the behaviour the consumers depend
   on."
-  (:require [cljs.test :refer-macros [deftest is testing]]
+  (:require [clojure.string :as str]
+            [cljs.test :refer-macros [deftest is testing]]
             [re-frame.mcp-base.args :as args]
             [re-frame.mcp-base.cap :as cap]
             [re-frame.mcp-base.cursor :as cursor]
@@ -32,6 +33,7 @@
             [re-frame.mcp-base.envelope :as envelope]
             [re-frame.mcp-base.overflow :as overflow]
             [re-frame.mcp-base.section-grouping :as sg]
+            [re-frame.mcp-base.sensitive :as sensitive]
             [re-frame.mcp-base.vocab :as vocab]))
 
 ;; ---------------------------------------------------------------------------
@@ -441,3 +443,137 @@
          (envelope/with-indicators {:trace [1]} {:dropped 0 :elided 2})))
   (is (= {:trace [1] :dropped-sensitive 3 :elided-large 2}
          (envelope/with-indicators {:trace [1]} {:dropped 3 :elided 2}))))
+
+;; ---------------------------------------------------------------------------
+;; 8. `sensitive.cljc` CLJS reader-conditional arms (rf2-k76ohl — SECURITY).
+;;
+;;    `re-frame.mcp-base.sensitive` is the spec/009 §Privacy default-suppress
+;;    filter every MCP forwarder routes trace-like data through. Its `:cljs`
+;;    arms — the `(atom 0)` malformed-counter, the 11-branch `stamp-type-tag`
+;;    cond, and the `js/console.warn` egress in `log-malformed!` — run in
+;;    PRODUCTION inside re-frame2-pair-mcp (a CLJS Node bundle). Yet no CLJS
+;;    test pinned them: the JVM suite (sensitive_test.clj) proves the log-egress
+;;    redaction (`malformed-warning-redacts-raw-stamp-value`, using `*err*`) but
+;;    the CLJS runtime path — the one the MCP servers actually run — had no
+;;    counterpart. pair-mcp's own CLJS suite wraps every call in
+;;    `(with-redefs [js/console (clj->js {:warn (fn [& _])})] …)`, ABSORBING the
+;;    warning and asserting nothing about its content; the security-tier CLJS
+;;    property test asserts the counter + that a VALUE-slot secret never
+;;    survives egress, but never captures the `console.warn` bytes to prove the
+;;    STAMP value (the log-boundary leak surface) is redacted.
+;;
+;;    This block closes that gap on CLJS: (a) the malformed warning is
+;;    value-free (raw stamp absent, `:rf/redacted` + reason present); (b) the
+;;    malformed counter is exactly-once-per-event through `strip-sensitive` and
+;;    resets to zero; (c) representative `stamp-type-tag` branches.
+;; ---------------------------------------------------------------------------
+
+(defn- capture-console-warn
+  "Run `thunk`, returning a vector of every `js/console.warn` call joined to a
+  string. Directly saves + swaps + restores the REAL `js/console.warn` property
+  that `sensitive/log-malformed!` calls — so the assertion exercises the ACTUAL
+  CLJS log-egress path, not a stand-in. (The test-quiet node runner also
+  replaces `console.warn` to buffer expected warnings; we save + restore
+  whatever is installed, so this composes with the runner.)"
+  [thunk]
+  (let [captured (atom [])
+        orig     (.-warn js/console)]
+    (set! (.-warn js/console) (fn [& args] (swap! captured conj (apply str args))))
+    (try
+      (thunk)
+      (finally
+        (set! (.-warn js/console) orig)))
+    @captured))
+
+(deftest sensitive-malformed-warning-redacts-raw-stamp-value-cljs
+  ;; CLJS counterpart to JVM `malformed-warning-redacts-raw-stamp-value`. The
+  ;; contract-drift warning must carry a value-free type tag + the fixed
+  ;; `:rf/redacted` sentinel — NEVER the raw stamp, which on a serialisation bug
+  ;; could be a secret-bearing string / keyword / map / vector / number. This
+  ;; is the log-boundary egress guarantee on the CLJS runtime pair-mcp runs.
+  (sensitive/reset-malformed-count!)
+  (doseq [[stamp leak-needle]
+          [["sk_live_SECRET_TOKEN_abc123" "sk_live_SECRET_TOKEN_abc123"]
+           [:secret/api-key-VALUE          "api-key-VALUE"]
+           [{:api_key "AKIA_LEAK"
+             :token   "bearer_LEAK"}       "AKIA_LEAK"]
+           [["leaky-vector-ELEMENT"]       "leaky-vector-ELEMENT"]
+           [42424242                        "42424242"]]]
+    (let [warns (capture-console-warn
+                  #(sensitive/sensitive-event? {:operation :rf.event/dispatched
+                                                :sensitive? stamp}))
+          text  (str/join "\n" warns)]
+      (is (= 1 (count warns))
+          (str "exactly one console.warn fired for " (pr-str stamp)
+               " (proves the capture is non-vacuous)"))
+      (is (not (str/includes? text leak-needle))
+          (str "malformed warning leaked the raw stamp payload for " (pr-str stamp)))
+      (is (str/includes? text ":rf/redacted")
+          (str "malformed warning must emit the :rf/redacted sentinel for " (pr-str stamp)))
+      (is (str/includes? text "non-boolean truthy")
+          "warning must still surface the fail-closed contract-drift reason")))
+  (sensitive/reset-malformed-count!))
+
+(deftest sensitive-malformed-count-exactly-once-per-event-cljs
+  ;; CLJS counterpart to JVM `strip-sensitive-malformed-count-is-exactly-one-
+  ;; per-event`. `sensitive-event?` is side-effecting on the malformed path
+  ;; (bump + log); the single-pass classifier in `strip-sensitive` runs it
+  ;; exactly once per event, so the `(atom 0)` malformed-counter is a faithful
+  ;; per-event metric on the CLJS atom path too. A two-pass shape would bump ~2×.
+  (sensitive/reset-malformed-count!)
+  (is (zero? (sensitive/malformed-count))
+      "precondition: counter starts at zero after reset")
+  (capture-console-warn ; absorb the expected contract-drift warnings
+    (fn []
+      (let [evts           [{:id 1 :sensitive? false}
+                            {:id 2 :sensitive? "true"} ; malformed → drop, bump 1
+                            {:id 3}
+                            {:id 4 :sensitive? :yes}    ; malformed → drop, bump 1
+                            {:id 5 :sensitive? true}]   ; well-formed → drop, NO bump
+            [kept dropped] (sensitive/strip-sensitive evts false)]
+        (is (= [{:id 1 :sensitive? false} {:id 3}] kept))
+        (is (= 3 dropped) "all three sensitive events drop")
+        (is (= 2 (sensitive/malformed-count))
+            "exactly one bump per MALFORMED event — single-pass, not ~2× per scan"))))
+  ;; Well-formed stamps do NOT bump the counter.
+  (capture-console-warn
+    (fn []
+      (sensitive/sensitive-event? {:sensitive? true})
+      (sensitive/sensitive-event? {:sensitive? false})
+      (sensitive/sensitive-event? {:sensitive? nil})
+      (sensitive/sensitive-event? {})))
+  (is (= 2 (sensitive/malformed-count))
+      "true / false / nil / absent stamps do NOT bump the counter")
+  (is (zero? (sensitive/reset-malformed-count!))
+      "reset returns the new value (zero)")
+  (is (zero? (sensitive/malformed-count))
+      "reset zeroes the counter for the next test"))
+
+(deftest sensitive-stamp-type-tag-branches-cljs
+  ;; The `:cljs` arm of `stamp-type-tag` is an 11-branch cond (the JVM arm is a
+  ;; one-liner `.getSimpleName`), reachable only through the fail-closed log
+  ;; path. `stamp-type-tag` / `log-malformed!` are private, so we observe each
+  ;; branch via the value-free `type=<tag>` token in the captured warning —
+  ;; pinning that each truthy non-boolean shape maps to the right tag AND that
+  ;; the value is redacted regardless of the branch taken.
+  (sensitive/reset-malformed-count!)
+  (doseq [[stamp expected-tag] [["a-string"          "string"]
+                                [:a-keyword          "keyword"]
+                                ['a-symbol           "symbol"]
+                                [42                   "number"]
+                                [{:a 1}              "map"]
+                                [[1 2]               "vector"]
+                                [#{1 2}              "set"]
+                                [(map identity [1])  "seq"]]]
+    (let [warns (capture-console-warn
+                  #(sensitive/sensitive-event? {:sensitive? stamp}))
+          text  (str/join "\n" warns)]
+      (is (= 1 (count warns))
+          (str "one warning fired for stamp " (pr-str stamp)))
+      (is (str/includes? text (str "type=" expected-tag))
+          (str "stamp " (pr-str stamp) " must log the value-free type tag "
+               expected-tag))
+      (is (str/includes? text "value=:rf/redacted")
+          (str "the value stays redacted regardless of the type tag ("
+               expected-tag ")"))))
+  (sensitive/reset-malformed-count!))


### PR DESCRIPTION
Adds test-only coverage for three untested defensive branches across disjoint artefacts, from the 2026-07-09 review campaign. No production source changes (the CLJS log-egress redaction was already correct — this closes an assertion gap, not a bug).

## rf2-k76ohl (SECURITY) — mcp-base CLJS log-egress redaction
`re-frame.mcp-base.sensitive` (spec/009 §Privacy default-suppress filter) runs its `:cljs` arms in production inside re-frame2-pair-mcp (a CLJS Node bundle), but no CLJS test pinned the log-boundary egress guarantee. The JVM suite proves malformed-stamp redaction via `*err*`; pair-mcp's CLJS suite absorbs `console.warn` and asserts nothing about its content; the security-tier CLJS property test checks the counter + that a value-slot secret never survives egress, but never captures the `console.warn` bytes to prove the STAMP value (the log-boundary leak surface) is redacted. A CLJS-only regression in `stamp-type-tag` / `log-malformed!` leaking a raw secret to `js/console.warn` would have passed every gate.

Adds three deftests to `cljs_branches_cljs_test.cljs`, capturing the real `js/console.warn` property `log-malformed!` calls:
- malformed warning value-free — raw stamp absent, `:rf/redacted` + contract-drift reason present, across 5 secret-shaped stamps;
- `malformed-count` exactly-once-per-event through `strip-sensitive` + reset-to-zero (the CLJS `(atom 0)` path);
- representative `stamp-type-tag` branches (string/keyword/symbol/number/map/vector/set/seq).

A `count==1` non-vacuity guard proves the capture actually intercepts.

## rf2-njkw94 — ssr-ring fail-closed branches
- `resolve-root-view` `:else` arm throws `:rf.error/invalid-root-view` for a non-hiccup/non-fn root-view — new `resolve-root-view-invalid-shape-unit-contract` (analogous to the sibling `initial-events-resolve-fn-unit-contract`): hiccup passthrough, exactly-once fn resolution, and the throw pinned across scalar shapes (id/where/recovery/received/message).
- `fail-closed-status` emits a `:rf.ssr/ssr-non-integer-status` `:warning` trace on a non-int status (500 outcome was tested, trace was not) — new listener-based assertion mirroring `non-string-header-value-emits-exactly-one-dev-warning` (asserts the hoisted top-level `:recovery`), plus a no-warning-for-valid-status pin.

## rf2-f2qcgl — schemas `:maybe` transparent-wrapper arms
`walker.cljc`'s `align-in-path` and `sanitize-sensitive-path` each carry a dedicated `:maybe` transparent-wrapper branch (descend the single child without consuming an `:in` segment) with no direct test. Adds two deterministic units to `schemas_sensitive_test.clj`: `schema-sensitive-at?` resolves a `:sensitive?` leaf under `[:maybe [:map …]]` at the segment-skipping path (`[:s :k]` => true, plus non-sensitive companion + top-level shape); `sanitize-sensitive-path` keeps navigable map keys through `:maybe` and still scrubs a nested `:set` element. Fail-safe branch (path-precision, never a leak).

## Quality gates (all foreground, all green)
- `implementation/schemas` `clojure -M:test` — 341 tests, 18950 assertions, 0 failures, 0 errors
- `implementation/ssr-ring` `clojure -M:test` — 170 tests, 831 assertions, 0 failures, 0 errors
- `tools/mcp-base` `clojure -M:test` — 257 tests, 865 assertions, 0 failures, 0 errors
- `tools/mcp-base` `npm run test:cljs` — 18 tests, 146 assertions, 0 failures, 0 errors
- `implementation` `npm run test:cljs` (full node-runtime suite) — 8386 tests, 38694 assertions, 0 failures, 0 errors

## Stance
Pre-alpha, no shims. Test-only; no production edits (no bug surfaced — the CLJS redaction path was already correct, this pins it). CORRECTNESS + GOOD-PRACTICE, security-relevant (k76ohl is a privacy egress surface). Deliberately skipped the OPTIONAL third njkw94 branch (`resolve-error-body :else`) — caught+recovered, already covered behaviourally, low value.
