### PR TITLE
test(examples): substrates login password-clear/validation + generation-guard tick + comment fix (rf2-t83ail +2)

### DIFF
--- a/examples/substrates/helix/login/core.cljs
+++ b/examples/substrates/helix/login/core.cljs
@@ -43,10 +43,12 @@
 ;; ============================================================================
 ;;
 ;; Everything from here down to the SUBSTRATE BOUNDARY divider — the schemas,
-;; the HTTP stub, the `:auth.login/flow` machine, the named subs — is identical
-;; across the Reagent, UIx, and Helix login examples. Same ids, same machine,
-;; same schemas, same stub, character for character. That's the point: the
-;; logic of a login flow doesn't care which view library draws it.
+;; the HTTP stub, the `:auth.login/flow` machine, the named subs — is the same
+;; across the Reagent, UIx, and Helix login examples: same ids, same machine,
+;; same schemas, same stub — identical registrations. (Not literally character
+;; for character: the surrounding comments and the machine map's key order
+;; differ file to file.) That's the point: the logic of a login flow doesn't
+;; care which view library draws it.
 ;;
 ;; You might expect this shared half to live in one file the three examples
 ;; require. It deliberately doesn't. Each example is its own self-contained

--- a/examples/substrates/uix/login/core.cljs
+++ b/examples/substrates/uix/login/core.cljs
@@ -4,8 +4,11 @@
    to change to move between them.
 
    Everything below the views — the state machine, the schemas, the
-   managed-HTTP effect — is substrate-agnostic and byte-for-byte the same as
-   examples/core/login. Only the views differ. Here a view is a UIx `defui`
+   managed-HTTP effect — is substrate-agnostic: the same ids, machine, schemas,
+   and stub as examples/core/login (identical registrations, deliberately
+   duplicated rather than shared — not a byte-for-byte copy: the surrounding
+   comments and the machine's key order differ file to file). Only the views
+   differ. Here a view is a UIx `defui`
    that reads subscriptions through the `use-subscribe` hook; the Reagent twin
    reaches for `reg-view`. Same data, different doorway.
 

--- a/implementation/core/test/re_frame/example_generation_guard_cljs_test.cljs
+++ b/implementation/core/test/re_frame/example_generation_guard_cljs_test.cljs
@@ -1,0 +1,130 @@
+(ns re-frame.example-generation-guard-cljs-test
+  "Framework-tree regression for the `:dispatch-later` GENERATION-GUARD idiom —
+   a self-rescheduling tick chain with NO cancel API, retired via a generation
+   token. rf2-jo4oqv.
+
+   The idiom: `:dispatch-later` is fire-and-forget (no handle to cancel a tick
+   in flight). To retire a chain you BUMP a `:tick-gen` counter; every scheduled
+   tick carries the generation it was armed under, and a tick whose generation
+   no longer matches app-db just declines to act — no state change, no
+   reschedule. So the old chain quietly dies on its next fire and a fresh arming
+   leaves exactly ONE live chain.
+
+   This test pins the idiom against `seven-guis.timer.core` — the canonical
+   Reagent precedent the substrate `helix.process-monitor.core` example's
+   README cites for its own tick loop (examples/substrates/helix/process_monitor
+   uses the identical guard). timer.core is requireable + node-drivable and its
+   `:tick-gen` guard is the pure form of the pattern (a tick either advances +
+   reschedules or no-ops), so pinning it protects the shared idiom. It belongs
+   in the framework test tree (examples stay test-free, rf2-8cevm) and runs
+   under `:node-test` (`../examples/core` is on its source-paths).
+
+   Neither this idiom was tested behaviourally before
+   (`git grep 'tick-gen' -- implementation/` found no test): the frame-scoping
+   test only asserts timer.core's ns-load app-schema, and the resources/machine
+   timer tests cover a DIFFERENT mechanism (cancel-then-arm via a real timer
+   registry). A regression — stale ticks that stop no-op'ing, or a bump that
+   fails to retire — would spawn overlapping chains with no guard.
+
+   The scheduled follow-ups are observed by capturing the `:dispatch-later` fx
+   via a function-value `:fx-overrides` entry on the frame (spec/002
+   §`:fx-overrides`, rf2-nrpj1): the override runs in place of the reserved
+   `:dispatch-later` body, so NO real host timer is ever armed (deterministic,
+   no wall-clock flakiness) and we read back exactly what each handler tried to
+   schedule."
+  (:require [cljs.test :refer-macros [deftest testing use-fixtures is]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
+            ;; timer.core registers an app-schema on :rf/default at ns-load via
+            ;; `with-frame`; it pulls re-frame.schemas transitively. Require here
+            ;; so the ns is self-sufficient.
+            [re-frame.schemas]
+            [seven-guis.timer.core :as timer])
+  (:require-macros [re-frame.core :refer [with-new-frame]]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-adapter/adapter}))
+
+;; ---------------------------------------------------------------------------
+;; Helpers
+;; ---------------------------------------------------------------------------
+
+(defn- tick-gen [f]
+  (get-in (rf/app-db-value f) [:timer :tick-gen]))
+
+(defn- elapsed-ms [f]
+  (get-in (rf/app-db-value f) [:timer :elapsed-ms]))
+
+(defn- scheduled-events
+  "The `:event`s of every captured `:dispatch-later` in `captured` (an atom of
+   the `:dispatch-later` arg maps)."
+  [captured]
+  (mapv :event @captured))
+
+;; ---------------------------------------------------------------------------
+;; Generation guard: stale ticks die, a bump leaves exactly one live chain
+;; ---------------------------------------------------------------------------
+
+(deftest generation-guard-retires-stale-chains-keeps-one-live
+  (testing "rf2-jo4oqv — the :dispatch-later generation guard: a stale-gen tick
+            no-ops (no state change, no reschedule) while a live-gen tick
+            advances + reschedules under the SAME gen; a bump (reset) retires
+            the old chain and arms exactly ONE fresh chain"
+    (let [captured      (atom [])
+          capture-later (fn [_ctx args] (swap! captured conj args))]
+      (with-new-frame [f (frame/make-anon-frame-record!
+                           {:fx-overrides {:dispatch-later capture-later}})]
+
+        ;; ---- boot: :initialise arms exactly one chain under gen 0 ----
+        (rf/dispatch-sync [:timer/initialise] {:frame f})
+        (is (= 0 (tick-gen f)) ":initialise seeded generation 0")
+        (is (= [[:timer/tick 0]] (scheduled-events captured))
+            ":initialise armed exactly one tick chain, carrying gen 0")
+
+        ;; ---- (a) a STALE-gen tick no-ops ----
+        (reset! captured [])
+        (let [db-before (rf/app-db-value f)]
+          (rf/dispatch-sync [:timer/tick 999] {:frame f})
+          (is (= db-before (rf/app-db-value f))
+              "a tick carrying a retired generation leaves app-db UNCHANGED
+               (no elapsed bump)")
+          (is (empty? @captured)
+              "a stale-gen tick schedules NO follow-up — declining to act is
+               how the old chain dies"))
+
+        ;; ---- a LIVE-gen tick advances and reschedules under the same gen ----
+        (reset! captured [])
+        (let [before (elapsed-ms f)]
+          (rf/dispatch-sync [:timer/tick 0] {:frame f})
+          (is (= (+ before timer/tick-ms) (elapsed-ms f))
+              "a live-gen tick advanced elapsed by exactly one tick")
+          (is (= [[:timer/tick 0]] (scheduled-events captured))
+              "a live-gen tick rescheduled exactly one follow-up, under the
+               SAME live generation"))
+
+        ;; ---- (b) reset BUMPS the generation → exactly one live chain ----
+        (reset! captured [])
+        (rf/dispatch-sync [:timer/reset] {:frame f})
+        (is (= 1 (tick-gen f)) "reset bumped the generation to 1")
+        (is (zero? (elapsed-ms f)) "reset zeroed elapsed")
+        (is (= [[:timer/tick 1]] (scheduled-events captured))
+            "reset armed exactly ONE fresh chain, under the new generation 1")
+
+        ;; the OLD chain (gen 0) is now stale — its next fire no-ops
+        (reset! captured [])
+        (let [db-before (rf/app-db-value f)]
+          (rf/dispatch-sync [:timer/tick 0] {:frame f})
+          (is (= db-before (rf/app-db-value f))
+              "the pre-reset gen-0 tick is now stale — no state change")
+          (is (empty? @captured)
+              "the stale gen-0 chain schedules nothing — retired by the bump"))
+
+        ;; ...while the NEW chain (gen 1) proceeds — proving EXACTLY ONE live
+        ;; chain survives the bump
+        (reset! captured [])
+        (rf/dispatch-sync [:timer/tick 1] {:frame f})
+        (is (= [[:timer/tick 1]] (scheduled-events captured))
+            "the gen-1 chain is the single live chain and keeps ticking")))))

--- a/implementation/core/test/re_frame/example_login_form_slice_cljs_test.cljs
+++ b/implementation/core/test/re_frame/example_login_form_slice_cljs_test.cljs
@@ -1,0 +1,175 @@
+(ns re-frame.example-login-form-slice-cljs-test
+  "Framework-tree regression for the login example's FORM SLICE — the
+   `:auth.login/submit-form` event at examples/core/login/core.cljs (mirrored
+   byte-for-similar into examples/substrates/{uix,helix}/login). rf2-t83ail.
+
+   These belong in the framework test tree, NOT under examples/ (examples stay
+   test-free per rf2-8cevm). The ns requires the example's production source
+   (`login.core`) so its events / subs / machine / schemas register at ns-load,
+   then drives `:auth.login/submit-form` directly. It runs under the
+   consolidated `:node-test` CLJS build (`../examples/core` is on its
+   source-paths) — the only runtime where `login.core`'s ns-load + durable
+   handlers actually execute. Sibling of `re-frame.login-cljs-test` (which pins
+   the MACHINE's `[:schemas :data]` boundary); this ns pins the SLICE half.
+
+   Two security-relevant behaviours were previously UNCOVERED
+   (`git grep ':auth.login/submit-form' -- implementation/` = zero):
+
+     1. PASSWORD-CLEARING HYGIENE. A clean submit blanks
+        `[:auth :login-form :draft :password]` in the SAME commit that hands
+        the draft to the machine — the app-db half of keep-secrets-out-of-
+        traces. A silent regression that stopped clearing `:password` would
+        leave the secret sitting in app-db snapshots / recordings with no
+        failing test.
+
+     2. PRE-SUBMIT MALLI VALIDATION against `login.core/Credentials`. A clean
+        draft dispatches into the machine + clears field errors; an invalid
+        draft populates `:errors`, latches `:submit-attempted?`, and dispatches
+        NOTHING (so a bad draft never bounces silently off the machine's
+        `:submit` schema boundary).
+
+   The clean-branch machine dispatch is asserted by capturing the `:dispatch`
+   fx via a function-value `:fx-overrides` entry (spec/002 §`:fx-overrides`,
+   rf2-nrpj1) — the override runs in place of the reserved `:dispatch` body, so
+   we observe the exact event `submit-form` emits WITHOUT the machine + managed-
+   HTTP running. That makes the assertion a direct, deterministic pin on
+   `submit-form`'s output contract rather than an integration walk."
+  (:require [cljs.test :refer-macros [deftest testing use-fixtures is]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
+            ;; login.core pulls these transitively; require here so the ns is
+            ;; self-sufficient (mirrors re-frame.login-cljs-test).
+            [re-frame.schemas]
+            [re-frame.machines]
+            [login.core])
+  (:require-macros [re-frame.core :refer [with-new-frame]]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-adapter/adapter}))
+
+;; ---------------------------------------------------------------------------
+;; Helpers
+;; ---------------------------------------------------------------------------
+
+(defn- slice
+  "The whole login-form slice at app-db [:auth :login-form] for frame `f`."
+  [f]
+  (get-in (rf/app-db-value f) [:auth :login-form]))
+
+(defn- seed-draft!
+  "Boot the slice then type `email` / `password` into the draft via the real
+   `:auth.login/edit-field` handler (controlled-input round trip)."
+  [f email password]
+  (rf/dispatch-sync [:auth.login/initialise-form] {:frame f})
+  (rf/dispatch-sync [:auth.login/edit-field :email email] {:frame f})
+  (rf/dispatch-sync [:auth.login/edit-field :password password] {:frame f}))
+
+(defn- submit-capturing-dispatch!
+  "Dispatch `:auth.login/submit-form` on frame `f` while capturing every
+   `:dispatch` fx it emits (the machine hand-off) into `captured`, WITHOUT
+   running the reserved `:dispatch` body — so the machine + managed-HTTP never
+   fire. `captured` is an atom of the dispatched event vectors."
+  [f captured]
+  (rf/dispatch-sync [:auth.login/submit-form]
+                    {:frame        f
+                     :fx-overrides {:dispatch (fn [_ctx ev] (swap! captured conj ev))}}))
+
+;; ---------------------------------------------------------------------------
+;; (1) clean submit — password-clearing hygiene + machine hand-off
+;; ---------------------------------------------------------------------------
+
+(deftest clean-submit-clears-password-and-hands-draft-to-machine
+  (testing "rf2-t83ail — a clean submit blanks [:draft :password] in the same
+            commit it hands the draft to the machine (secret-field hygiene),
+            flips :status to :submitting, clears :errors, latches
+            :submit-attempted?, and dispatches exactly one machine submit
+            carrying the REAL password (its one sanctioned trip off the box)"
+    (with-new-frame [f (frame/make-anon-frame-record! {})]
+      (seed-draft! f "alice@example.com" "hunter2pw")
+      (let [captured (atom [])]
+        (submit-capturing-dispatch! f captured)
+        (let [s (slice f)]
+          ;; --- secret-field hygiene: the password is gone from app-db ---
+          (is (= "" (get-in s [:draft :password]))
+              "the password is blanked in the app-db slice draft after submit")
+          (is (= "alice@example.com" (get-in s [:draft :email]))
+              "only the SECRET is cleared — the email draft is left intact")
+          ;; --- the slice mirrors the hand-off ---
+          (is (= :submitting (:status s))
+              "the slice :status advanced to :submitting on the clean branch")
+          (is (= {} (:errors s))
+              "stale field errors were cleared on the clean branch")
+          (is (true? (:submit-attempted? s))
+              ":submit-attempted? latched on submit")
+          ;; --- the machine hand-off carries the real password ---
+          (is (= 1 (count @captured))
+              "exactly one :dispatch fx (the machine hand-off) was emitted")
+          (is (= [:auth.login/flow
+                  [:auth.login/submit {:email "alice@example.com"
+                                       :password "hunter2pw"}]]
+                 (first @captured))
+              "the draft handed to the machine still carries the REAL password
+               — proving the blank happens AFTER the draft is captured for
+               dispatch (blank it first and the login would submit an empty
+               password)"))))))
+
+;; ---------------------------------------------------------------------------
+;; (2) invalid submit — errors surface, nothing dispatched, password retained
+;; ---------------------------------------------------------------------------
+
+(deftest invalid-submit-populates-errors-and-dispatches-nothing
+  (testing "rf2-t83ail — an invalid draft (bad email + short password) fails the
+            pre-submit Credentials validation: :errors is populated per field,
+            :submit-attempted? latches, :status stays :idle, and NOTHING is
+            dispatched (the draft never reaches — and never silently bounces
+            off — the machine's :submit schema boundary)"
+    (with-new-frame [f (frame/make-anon-frame-record! {})]
+      (seed-draft! f "not-an-email" "short")
+      (let [captured (atom [])]
+        (submit-capturing-dispatch! f captured)
+        (let [s (slice f)]
+          (is (true? (:submit-attempted? s))
+              ":submit-attempted? latched even on the invalid branch (the
+               visibility rule — every invalid field may now speak)")
+          (is (contains? (:errors s) :email)
+              "the bad email produced a field error")
+          (is (contains? (:errors s) :password)
+              "the short password produced a field error")
+          (is (= :idle (:status s))
+              ":status did NOT advance to :submitting on an invalid submit")
+          (is (zero? (count @captured))
+              "no :dispatch fx — the invalid draft was NOT handed to the
+               machine")
+          ;; The password is RETAINED here — nothing left the box (no dispatch,
+          ;; no HTTP), so this is not the leak the hygiene rule guards against;
+          ;; the user needs the password kept for the fix-up. This pins that
+          ;; clearing is coupled to the successful hand-off, not to submit alone.
+          (is (= "short" (get-in s [:draft :password]))
+              "the password is RETAINED on the invalid branch (kept for the
+               fix-up; the clear is coupled to a clean hand-off, not to the
+               submit click)"))))))
+
+;; ---------------------------------------------------------------------------
+;; (3) a partially-valid draft (good email, short password) still blocks
+;; ---------------------------------------------------------------------------
+
+(deftest partially-valid-submit-still-blocks-and-keeps-secret
+  (testing "rf2-t83ail — a valid email but a too-short password still fails
+            validation: only the :password error surfaces, nothing is
+            dispatched, and the (short) password is retained"
+    (with-new-frame [f (frame/make-anon-frame-record! {})]
+      (seed-draft! f "alice@example.com" "tiny")
+      (let [captured (atom [])]
+        (submit-capturing-dispatch! f captured)
+        (let [s (slice f)]
+          (is (not (contains? (:errors s) :email))
+              "the valid email produced no error")
+          (is (contains? (:errors s) :password)
+              "the short password produced a field error")
+          (is (zero? (count @captured))
+              "a single invalid field is enough to block the machine hand-off")
+          (is (= "tiny" (get-in s [:draft :password]))
+              "the password is retained (never handed off, so never cleared)"))))))


### PR DESCRIPTION
Closes rf2-t83ail, rf2-jo4oqv, rf2-eghvnw (review-campaign 2026-07-09; surface examples/substrates).

## What

Three commits, one per bead:

1. **rf2-t83ail [bug][test]** — pin the login example's form-slice `:auth.login/submit-form` (security-adjacent). Two previously-uncovered behaviours (`git grep ':auth.login/submit-form' -- implementation/` = zero):
   - **Password-clearing hygiene** — a clean submit blanks `[:auth :login-form :draft :password]` in the same commit it hands the draft to the machine (the app-db half of keep-secrets-out-of-traces). A silent regression that stopped clearing `:password` would leave the secret in app-db snapshots/recordings with no failing test. The test also pins that the machine hand-off still carries the *real* password (blank happens after capture-for-dispatch).
   - **Pre-submit Malli validation** against `Credentials` — clean draft dispatches + clears errors; invalid draft populates `:errors`, latches `:submit-attempted?`, keeps the password for fix-up, dispatches nothing. Plus a partially-valid (short-password) case.
2. **rf2-jo4oqv [test]** — pin the `:dispatch-later` generation-guard tick loop against `seven-guis.timer.core` (the canonical Reagent precedent the substrate `helix.process-monitor` example cites). Asserts: a stale-gen tick no-ops (no state change, no reschedule); a bump retires the old chain and arms exactly one fresh chain.
3. **rf2-eghvnw [comments]** — soften the uix/helix login docstrings' false "byte-for-byte / character-for-character identical" claim to the accurate "same ids, machine, schemas, stub — identical registrations" (the machine map key order and comments genuinely differ file to file).

## Where

Tests live in the framework test tree (`implementation/core/test/re_frame/`), requiring the example nses — examples stay test-free (rf2-8cevm). Both target the requireable+drivable Reagent core examples the beads prescribe; the tested logic is the shared artefact copied byte-similar into the uix/helix substrate login examples. Only the eghvnw comment edit touches `examples/`.

Both tests observe the emitted `:dispatch` / `:dispatch-later` fx via function-value `:fx-overrides` entries (spec/002 §`:fx-overrides`, rf2-nrpj1), so assertions are deterministic — no machine, managed-HTTP, or real host timer runs.

## No bug found

t83ail: the current password-clear + validation behaviour is correct; this PR pins it. No password-retention regression surfaced.

## Quality gates

- `npm run test:cljs` (full node-test suite, foreground): **8390 tests, 38723 assertions, 0 failures, 0 errors**. New test modules confirmed compiled + discovered (`cljs-test$`).

## Stance

Pre-alpha, no shims. CORRECTNESS + GOOD-PRACTICE (security-relevant hygiene). Behavioural pins on shared example logic; no over-engineering.