### PR TITLE
docs(examples): asset-gate header + slim-boundary path + dead doc-path fixups (rf2-4cf3c1 +2)

### DIFF
--- a/examples/core/counter/core.cljs
+++ b/examples/core/counter/core.cljs
@@ -7,7 +7,7 @@
    returns a new app-db, the subscription re-derives, and the view
    re-renders — round and round. That loop is the entire idea of re-frame2;
    every bigger app is this same shape with more parts bolted on. The guide
-   walks it slowly in `docs/core/concepts/events-and-the-pipeline.md`.
+   walks it slowly in `docs/core/run-to-completion.md`.
 
    The frame is stood up in exactly one place: the `frame-provider` at the
    render root in `run` below. It names the frame and seeds it once.

--- a/examples/core/notebook/core.cljs
+++ b/examples/core/notebook/core.cljs
@@ -84,7 +84,7 @@
 ;; quietly poison that — every replay would mint a different id. The
 ;; seeded docs (`:welcome`, `:six-dominoes`, …) have no `doc-` prefix, so
 ;; they're invisible to the scan and the first new id is `:doc-1`. See
-;; docs/core/concepts/events-and-the-pipeline.md on replayable events.
+;; docs/core/coeffects.md on replayable events.
 (defn- allocate-next-doc-id
   "Next `:doc-N` id: highest existing N plus one (or 1 when there are
    none). A pure function of the current documents, so it replays

--- a/examples/scripts/check-examples-assets.cjs
+++ b/examples/scripts/check-examples-assets.cjs
@@ -73,6 +73,14 @@
  *      in scanned CSS, reusing EXTERNAL_IMPORT_ALLOWLIST. `data:` URIs (inlined,
  *      no request) and same-document `url(#fragment)` paint refs stay exempt.
  *
+ *      LOCAL url() TARGETS are resolved to disk too (rf2-35lfqo). A
+ *      `background-image: url('missing.png')`, a `@font-face { src: url(x.woff2) }`,
+ *      or a `cursor: url(img/cursor.png)` pointing at a missing LOCAL file fires
+ *      no network request (so the remote-url policy above skips it) yet still
+ *      ships a broken asset, so each local `url(...)` target inside scanned CSS
+ *      must resolve to a real file in the source tree — the local counterpart
+ *      of the @import resolution above.
+ *
  *      Staging-aware resolution: a page references _shared assets at the
  *      relative path `_shared/...`, but in the SOURCE tree _shared lives
  *      ONCE at examples/_shared/ (not next to each page) — the orchestrator
@@ -96,10 +104,44 @@
  *      preview while a pure "the file exists" check stays green. The .svg is
  *      kept only as editable source art. (rf2-lr4am3)
  *
- *   4. Asserts the _shared source tree itself is intact: the required
- *      _shared files exist on disk (incl. the og.png raster + its og.svg
- *      source art) and structure.css remains reachable from style.css's
- *      @import.
+ * Steps 4-6 run ONCE over the examples/_shared source tree itself, independent
+ * of any page's reference graph, so each contract holds even if no scanned page
+ * links the file. Together they make this an accessibility / cascade / responsive
+ * gate over the shared design system, not merely a "the files exist" check:
+ *
+ *   4. Asserts the _shared source tree is intact + the shipped card is valid:
+ *      (a) EXISTENCE: the required _shared files are present on disk (incl. the
+ *          og.png raster + its og.svg source art) and structure.css remains
+ *          reachable from style.css's @import.
+ *      (b) OG RASTER BYTES: og.png actually decodes as a PNG (signature + IHDR)
+ *          at the documented 1200x630 dimensions — a renamed SVG/text file or a
+ *          wrong-size export fails, not just a missing file (rf2-mon7tz).
+ *      (c) OG SOURCE-ART PALETTE: og.svg carries no retired / sub-AA colour
+ *          literal as a live paint value, so the re-exported card cannot drift
+ *          back below the shared palette's accessibility decisions (rf2-y82dk9).
+ *      (d) NO REMOTE STYLING: style.css / structure.css carry no external
+ *          @import (rf2-vou5mm) and no remote url() fetch (rf2-o18ava), checked
+ *          here so the contract holds even for an unlinked shared stylesheet.
+ *
+ *   5. Asserts the shared ACCESSIBILITY contracts on style.css:
+ *      (a) WCAG CONTRAST: every shipped foreground/background --ex-* token pair
+ *          clears its floor (AA 4.5:1 normal text, 3:1 focus ring), computed
+ *          from the parsed tokens; a palette edit that drops a pair below the
+ *          floor turns the gate RED (rf2-febmqu).
+ *      (b) FOCUS INDICATOR: form controls keep a visible ':focus-visible' ring
+ *          on the AA-safe --ex-accent-deep token, and the pre-fix low-alpha
+ *          amber ring (≈1.5:1) is banned from returning (rf2-mon7tz).
+ *
+ *   6. Asserts the shared CSS-CASCADE + RESPONSIVE contracts on structure.css
+ *      (static, since the gate cannot observe layout):
+ *      (a) CASCADE SCOPING: the WebSocket send-form text-input baseline stays
+ *          scoped to '.send-form' (no global 'input[type="text"]' rule) and the
+ *          7GUIs Cells grid keeps its compact '.cells-grid input { width:56px }',
+ *          so the send-form sizing cannot blow out the spreadsheet grid
+ *          (rf2-gv5xd).
+ *      (b) RESPONSIVE SHELL: the inline-Xray '.rf2-testbed-shell' carries a
+ *          max-width media query that stacks it to a column instead of
+ *          overflowing horizontally on narrow viewports (rf2-y82dk9).
  *
  * This is NOT a per-example *.spec.cjs — examples/ stays test-free
  * (rf2-8cevm). It is a pure static scanner, wired into the always-run

--- a/examples/scripts/check-reagent-slim-boundary.cjs
+++ b/examples/scripts/check-reagent-slim-boundary.cjs
@@ -106,8 +106,11 @@ const SOURCE_EXTS = new Set(['.clj', '.cljs', '.cljc']);
 
 // ---------------------------------------------------------------------------
 // Source enumeration. Walk the stock-Reagent tree for .clj/.cljs/.cljc files,
-// skipping node_modules / build-output dirs. The slim tree is a SIBLING
-// (examples/reagent-slim/) and is never reached by this prefix walk.
+// skipping node_modules / build-output dirs. The slim tree lives UNDER
+// examples/substrates/ (examples/substrates/reagent_slim/), NOT as a sibling of
+// the walked roots, and is never reached by this walk: substrates/ is not one
+// of STOCK_REAGENT_ROOTS (core / capabilities / patterns / real-apps), so the
+// walk never descends into it.
 // ---------------------------------------------------------------------------
 
 function listStockReagentSources(roots = STOCK_REAGENT_ROOTS) {


### PR DESCRIPTION
Comment/doc-only fixups across `examples/scripts` + `examples/core` (review-campaign 2026-07-09). No logic changes.

## Fixes

- **rf2-4cf3c1** — `examples/scripts/check-examples-assets.cjs`: the header map listed 4 steps and step 4 named only file-existence + structure.css `@import` reachability, but `checkSharedTree` also enforces og.png byte-validation (rf2-mon7tz), og.svg palette conformance (rf2-y82dk9), WCAG contrast over `--ex-*` tokens (rf2-febmqu), the `:focus-visible`/amber-ban focus contract (rf2-mon7tz), the Cells-grid/send-form cascade scoping (rf2-gv5xd), and the responsive Xray-host shell media query (rf2-y82dk9). Also `scanPage` resolves local CSS `url()` targets to disk (rf2-35lfqo). Expanded steps 1 + 4-6 so the map reflects that this is an a11y/cascade/responsive gate.
- **rf2-8li2mp** — `examples/scripts/check-reagent-slim-boundary.cjs:110`: the source-enumeration comment cited a non-existent `examples/reagent-slim/` and called it a SIBLING. Rewrote to name the actual `examples/substrates/reagent_slim/` (matches the file's own citations at lines 14, 66-68, 170-172, 247) and explain it is never in `STOCK_REAGENT_ROOTS` because it lives under `substrates/`. Corrected path verified on disk.
- **rf2-y0ja6h** — `examples/core/{counter,notebook}/core.cljs`: `docs/core/concepts/events-and-the-pipeline.md` is a 404 (no `docs/core/concepts/` dir). Repointed counter → `docs/core/run-to-completion.md` (the dataflow loop / drain / render boundary) and notebook → `docs/core/coeffects.md` (recorded inputs → replayable events, the fresh-id/no-`rand` concern). Both targets verified present.

## Quality gates (foreground)

- `node examples/scripts/check-examples-assets.cjs` → exit 0 (35 pages, _shared tree intact)
- `node examples/scripts/check-reagent-slim-boundary.cjs` → exit 0 (69 stock sources, boundary intact)
- `node --test implementation/scripts/check-examples-assets.test.cjs` → 1 pass, 0 fail
- `node --test implementation/scripts/check-reagent-slim-boundary.test.cjs` → 1 pass, 0 fail
- Repointed doc paths (`docs/core/run-to-completion.md`, `docs/core/coeffects.md`) confirmed to exist on disk

## Stance

Pre-alpha, no shims. Comment/doc text only, no logic changes; CLARITY + CORRECTNESS. Each bead a separate commit.