### PR TITLE
test+docs(xray,test-quiet): outcome-tier branches + stderr ring-cap + comment fixups (rf2-1bk96k +3)

### DIFF
--- a/implementation/test-quiet/test/re_frame/test_quiet_pin_test.clj
+++ b/implementation/test-quiet/test/re_frame/test_quiet_pin_test.clj
@@ -18,10 +18,16 @@
   immediately fails this pin with the captured stdout in the
   assertion message so triage is one-glance.
 
-  Loaded by every artefact's `:test` alias via the
-  `day8/re-frame2-test-quiet` `:local/root` extra-dep, so the pin
-  runs once per artefact-test invocation and surfaces creep
-  artefact-by-artefact rather than at end-of-build."
+  Runs ONLY under test-quiet's OWN `:test` alias — NOT once per
+  dependent artefact.  A `:local/root` dep exposes only the
+  dependency's top-level `:paths` (here `[src]`); these pin namespaces
+  live under `test/` (the `:test` alias's `:extra-paths`), which a
+  `:local/root` never transitively exposes, so a dependent artefact's
+  `:test` classpath carries `.../test-quiet/src` but never
+  `.../test-quiet/test` — cognitect's test-runner cannot discover this
+  ns from another artefact's suite.  The alias is wired into the JVM
+  gate by `scripts/test-jvm-implementation.sh` and the `jvm-test-quiet`
+  CI job (`.github/workflows/test.yml`, added by rf2-jg1ag2)."
   (:require [clojure.test :refer [deftest is testing run-tests]]
             [clojure.string :as str]
             [re-frame.test-quiet]

--- a/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
+++ b/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
@@ -1081,3 +1081,124 @@
                   "the child must be force-killed on the timeout, not left alive"))
             ;; Cleanup belt: ensure the child is gone regardless.
             (.destroyForcibly proc)))))))
+
+;; ----------------------------------------------------------------------
+;; Stderr ring is BOUNDED — front-trim keeps the newest cap — rf2-hd3t77.
+;;
+;; `stderr-buffer-cap` is 256 KB and `buffering-stderr-writer` front-trims
+;; (`(.delete sb 0 (- n cap))`) so the ring retains the NEWEST `cap`
+;; characters and drops older ones (runner.clj `stderr-buffer-cap` +
+;; `buffering-stderr-writer`).  The CLJS analogue is rigorously pinned
+;; (`warn-buffer-is-bounded-and-materialised` drives 4x cap); the JVM ring
+;; had NO equivalent — the green/red stderr pins write tiny payloads, so a
+;; broken trim (wrong end, off-by-one, dropped) was uncaught and could OOM
+;; a chatty red suite.  This drives a RED run that floods `*err*` with
+;; ~600 KB (well past the 256 KB cap), then asserts the newest tail marker
+;; is REPLAYED, the oldest head marker is DROPPED, and the replayed volume
+;; is bounded to ~cap — proving the ring capped rather than merely that a
+;; marker happened to be absent.
+
+(deftest stderr-ring-front-trims-to-newest-cap-on-red
+  (testing "an *err* flood past the 256 KB cap keeps the NEWEST cap chars, drops the oldest (rf2-hd3t77)"
+    (with-fixture-dir
+      (fn [dir]
+        ;; ~600 KB of filler (2000 lines x ~300 chars) brackets a HEAD
+        ;; marker (written FIRST → oldest → must be front-trimmed away) and
+        ;; a TAIL marker (written LAST → newest → must survive), all to
+        ;; *err* on a run that then FAILS so the ring is replayed.
+        (write-fixture! dir "ringcap_fixture_test" "ringcap-fixture-test"
+                        (str "(deftest a-huge-warning-and-failing-test"
+                             " (binding [*out* *err*]"
+                             "   (println \"HEAD-MARKER-OLDEST-MUST-BE-DROPPED\")"
+                             "   (dotimes [_ 2000] (println (apply str (repeat 300 \"F\"))))"
+                             "   (println \"TAIL-MARKER-NEWEST-MUST-SURVIVE\"))"
+                             " (is (= :exp :act)))"))
+        (let [{:keys [exit out err]} (run-runner dir)
+              cap (* 256 1024)]
+          (is (= 1 exit)
+              (str "the flooding-and-failing suite is red; must exit 1; got "
+                   exit "\n--- stdout ---\n" out
+                   "\n--- stderr head ---\n" (subs err 0 (min 300 (count err)))))
+          (is (str/includes? err "buffered stderr replayed because the run was RED")
+              (str "the red replay label must be present; got stderr head:\n"
+                   (subs err 0 (min 300 (count err)))))
+          ;; NEWEST retained: the tail marker written last survives the ring.
+          (is (str/includes? err "TAIL-MARKER-NEWEST-MUST-SURVIVE")
+              (str "the NEWEST bytes must be retained by the front-trim ring"
+                   " (rf2-hd3t77); tail marker missing. stderr length="
+                   (count err)))
+          ;; OLDEST dropped: the head marker written first is trimmed away.
+          (is (not (str/includes? err "HEAD-MARKER-OLDEST-MUST-BE-DROPPED"))
+              (str "the OLDEST bytes must be front-trimmed once past the "
+                   cap "-char cap (rf2-hd3t77); the head marker leaked, so"
+                   " the ring either did not trim or trimmed the WRONG end."
+                   " stderr length=" (count err)))
+          ;; BOUNDED: the replay is ~cap + the fixed label, NOT the full
+          ;; ~600 KB stream — proving the ring actually capped. Without the
+          ;; front-trim, (count err) would be ~600 KB.
+          (is (< (count err) (+ cap 4096))
+              (str "the replayed stderr must be bounded to ~" cap " chars +"
+                   " the replay label (rf2-hd3t77); an unbounded ring would"
+                   " replay the whole ~600 KB flood. got " (count err)
+                   " chars")))))))
+
+;; ----------------------------------------------------------------------
+;; Raw `System.err` bridge is buffered too — rf2-hd3t77.
+;;
+;; `-main` swaps `System/setErr` for a `PrintStream` over an
+;; `OutputStream` proxy that routes raw `System.err` bytes into the SAME
+;; ring as `*err*` (runner.clj sys-bridge), with a documented restore in
+;; the `finally`.  Both existing stderr pins write via
+;; `(binding [*out* *err*] (println ...))` — i.e. through the `*err*`
+;; `PrintWriter`, NEVER raw `System/err` — so the bridge OutputStream and
+;; its `write(byte[],off,len)` decoding arity were entirely unexercised
+;; and the docstring claim "a library that writes System.err directly is
+;; buffered too" was unbacked.  These two pins write via
+;; `(.println System/err ...)` (the bridge's multi-byte arity) and assert
+;; the raw-`System.err` payload is buffered+dropped on green / replayed on
+;; red — exactly the `*err*`-path contract, now proven for the raw path.
+
+(deftest raw-system-err-buffered-and-dropped-on-green
+  (testing "a GREEN run that writes RAW System.err stays quiet — the bridge buffers + drops it (rf2-hd3t77)"
+    (with-fixture-dir
+      (fn [dir]
+        (write-fixture! dir "raw_syserr_green_fixture_test" "raw-syserr-green-fixture-test"
+                        (str "(deftest a-raw-syserr-but-passing-test"
+                             " (.println System/err \"RAW-SYSERR-MARKER-GREEN\")"
+                             " (is (= 1 1)))"))
+        (let [{:keys [exit out err]} (run-runner dir)]
+          (is (zero? exit)
+              (str "the raw-System.err-but-passing suite is green; must exit 0; got "
+                   exit "\n--- stdout ---\n" out "\n--- stderr ---\n" err))
+          ;; The CORE green pin: a RAW System.err write is routed through the
+          ;; setErr bridge into the ring, so on green it is dropped — absent
+          ;; from BOTH streams (proving the bridge, not just the *err* path).
+          (is (not (str/includes? (str out err) "RAW-SYSERR-MARKER-GREEN"))
+              (str "a raw System.err write on a GREEN run must be buffered by"
+                   " the setErr bridge and dropped — not leaked (rf2-hd3t77);"
+                   " got\n--- stdout ---\n" out "\n--- stderr ---\n" err))
+          (is (str/includes? out "0 failures, 0 errors.")
+              (str "the green summary must still print; got:\n" out)))))))
+
+(deftest raw-system-err-replayed-on-red
+  (testing "a RED run replays RAW System.err context via the setErr bridge (rf2-hd3t77)"
+    (with-fixture-dir
+      (fn [dir]
+        (write-fixture! dir "raw_syserr_red_fixture_test" "raw-syserr-red-fixture-test"
+                        (str "(deftest a-raw-syserr-and-failing-test"
+                             " (.println System/err \"RAW-SYSERR-MARKER-RED diagnostic context\")"
+                             " (is (= :exp :act)))"))
+        (let [{:keys [exit out err]} (run-runner dir)]
+          (is (= 1 exit)
+              (str "the raw-System.err-and-failing suite is red; must exit 1; got "
+                   exit "\n--- stdout ---\n" out "\n--- stderr ---\n" err))
+          (is (str/includes? out "FAIL in (a-raw-syserr-and-failing-test)")
+              (str "the FAIL block must still reach stdout; got:\n" out))
+          ;; The CORE red pin: the RAW System.err payload, routed through the
+          ;; bridge into the ring, is REPLAYED to real stderr on red.
+          (is (str/includes? err "RAW-SYSERR-MARKER-RED")
+              (str "a raw System.err write must be buffered by the setErr"
+                   " bridge and REPLAYED on a RED run (rf2-hd3t77); got"
+                   "\n--- stdout ---\n" out "\n--- stderr ---\n" err))
+          (is (str/includes? err "buffered stderr replayed because the run was RED")
+              (str "the replay must be labelled; got stderr:\n" err)))))))

--- a/tools/xray/src/day8/re_frame2_xray/epoch.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/epoch.cljs
@@ -189,8 +189,11 @@
   ;; epoch-id. The view supplies both from `:rf.xray/observed-frame` +
   ;; `:rf.xray/focus-epoch-id` so this event stays a thin trampoline into
   ;; the `:rf.xray.fx/restore-epoch` effect (which calls the framework's
-  ;; `rf/restore-epoch!`, targeting the epoch's `:db-after` — "if the
-  ;; event still exists, app state must be as if the event happened").
+  ;; `rf/restore-epoch!`, reinstalling the epoch's WHOLE `:frame-state-after`
+  ;; — app-db AND runtime-db in one atomic write, per epoch ·
+  ;; `restore-epoch!`; the retained `:db-after` is only an app-db projection
+  ;; for diffs, never the restore source — "if the event still exists, app
+  ;; state must be as if the event happened").
   ;; No dialog, no confirmation — the button just does it (programmers
   ;; are power users). A nil frame / epoch-id is a guarded no-op (the
   ;; button is disabled when no epoch is focused, but the event stays

--- a/tools/xray/test/day8/re_frame2_xray/panels/trace_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/trace_helpers_cljs_test.cljc
@@ -358,10 +358,27 @@
   (testing "inert — cache-hit / unchanged / skipped"
     (is (= :inert (h/outcome-tier {:operation :rf.sub/skip})))
     (is (= :inert (h/outcome-tier {:operation :rf.view/skip}))))
-  (testing "gone — disposed / unmounted / cleared / cancelled"
+  (testing "gone — disposed / unmounted / cleared"
     (is (= :gone (h/outcome-tier {:operation :rf.sub/dispose})))
     (is (= :gone (h/outcome-tier {:operation :rf.view/unmounted})))
     (is (= :gone (h/outcome-tier {:operation :rf.flow/cleared}))))
+  (testing "gone — the remaining synonyms (cancelled / stale / released / destroyed)"
+    ;; rf2-1bk96k: these four terminals sit in the same :gone regex branch
+    ;; (trace_helpers.cljc §outcome-tier) but were never pinned; a regex
+    ;; edit that dropped one would tint :active instead.
+    (is (= :gone (h/outcome-tier {:operation :rf.machine.timer/cancelled})))
+    (is (= :gone (h/outcome-tier {:operation :rf.sub/stale})))
+    (is (= :gone (h/outcome-tier {:operation :rf.resource/released})))
+    (is (= :gone (h/outcome-tier {:operation :rf.machine/destroyed}))))
+  (testing "pending — queued / scheduled / pending / later"
+    ;; rf2-1bk96k: the entire :pending tier was unasserted. A real
+    ;; :rf.machine.timer/scheduled op (whose verb IS tested elsewhere)
+    ;; must tint :pending, NOT :active — a silent regex regression here
+    ;; would collapse pending into the active tier.
+    (is (= :pending (h/outcome-tier {:operation :rf.machine.timer/scheduled})))
+    (is (= :pending (h/outcome-tier {:operation :rf.event/queued})))
+    (is (= :pending (h/outcome-tier {:operation :rf.fx/later})))
+    (is (= :pending (h/outcome-tier {:operation :rf.resource/pending}))))
   (testing "error / warning keep their semantic tier"
     (is (= :error (h/outcome-tier {:op-type :error :operation :rf.error/x})))
     (is (= :warning (h/outcome-tier {:op-type :warning :operation :rf.warning/x})))))
@@ -419,6 +436,13 @@
          (h/outcome-colour {:operation :rf.sub/skip})))
   (is (= (:dim tokens/tokens)
          (h/outcome-colour {:operation :rf.sub/dispose})))
+  ;; rf2-1bk96k: pending rides the cool info blue; warning keeps its
+  ;; semantic yellow. Both `outcome-tier->token` rows were unpinned, so a
+  ;; token-map edit could silently retint them.
+  (is (= (:info tokens/tokens)
+         (h/outcome-colour {:operation :rf.machine.timer/scheduled})))
+  (is (= (:yellow tokens/tokens)
+         (h/outcome-colour {:op-type :warning :operation :rf.warning/x})))
   (is (= (:red tokens/tokens)
          (h/outcome-colour {:op-type :error :operation :rf.error/x}))))
 


### PR DESCRIPTION
Review-campaign (2026-07-09) follow-ups on `tools/xray` + `implementation/test-quiet` — two test-coverage gaps and two stale-comment fixes. One commit per bead.

## rf2-1bk96k — [test] xray outcome-tier untested branches (P4)
`trace_helpers.cljc` `outcome-tier` had untested public-fn branches: the whole `:pending` tier (`queued|scheduled|pending|later`) and the `:gone` synonyms `cancelled|stale|released|destroyed`; `outcome-colour` never pinned the `:pending`(`:info`) / `:warning`(`:yellow`) tints. Added a `:pending` case + the four `:gone` synonyms to `outcome-tier-distinguishes-states`, and the missing tints to `outcome-colour-tints-the-verb-column`. Purely cosmetic surface — test-only.

## rf2-5q631c — [comments] xray epoch.cljs stale restore target (P4)
`epoch.cljs` reset-to-epoch comment said `rf/restore-epoch!` reinstalls from `:db-after`. Authoritative source (`epoch.cljc` `restore-epoch!` + xray `runtime.cljs`) reinstalls the WHOLE `:frame-state-after` (app-db AND runtime-db) atomically; `:db-after` is only an optional diff projection. Comment-only.

## rf2-hd3t77 — [test] test-quiet JVM stderr ring-cap + System/err bridge (P3)
Two `runner.clj` behaviours with strong docstring promises had no assertion:
- **256 KB front-trim ring** — `stderr-ring-front-trims-to-newest-cap-on-red` floods `*err*` with ~600 KB on a red run; asserts the newest tail marker is replayed, the oldest head marker is dropped, and the replay is bounded to ~cap (proving the ring capped, not just that a marker was absent).
- **System/setErr bridge** — existing pins only ever wrote via the `*err*` PrintWriter, never raw `System.err`. `raw-system-err-{buffered-and-dropped-on-green,replayed-on-red}` write via `(.println System/err ...)` (the bridge's multi-byte arity) and assert buffered+dropped on green / replayed on red.

Now runnable: rf2-jg1ag2 (dependency) has landed, wiring test-quiet's `:test` alias into `scripts/test-jvm-implementation.sh` + the `jvm-test-quiet` CI job.

## rf2-uggnel — [comments] test-quiet pin per-artefact docstring (P3)
`test_quiet_pin_test.clj` claimed the pin "runs once per artefact-test invocation ... artefact-by-artefact". FALSE — a `:local/root` dep exposes only the dependency's top-level `:paths` (`[src]`); the pin namespaces live under `test/`. Verified empirically: `clojure -Spath -M:test` in `implementation/core` lists `.../test-quiet/src` but never `.../test-quiet/test`. Corrected to state the pin runs only under test-quiet's own `:test` alias. The sibling `test_quiet_pin_passing_test.clj` docstring (bead-referenced) carries no such claim and was left unchanged.

## Quality gates
All foreground, all green:
- `implementation` → `npm run test:cljs`: 8415 tests, 38788 assertions, 0 failures, 0 errors
- `tools/xray` → `clojure -M:test`: 1234 tests, 5755 assertions, 0 failures, 0 errors
- `implementation/test-quiet` → `clojure -M:test`: 30 tests, 110 assertions, 0 failures, 0 errors (3 new deftests included)

## Stance
Pre-alpha, no shims. CORRECTNESS + CLARITY + GOOD-PRACTICE. Adversarial exact assertions hitting the real subprocess `-main` path. No production edits — all four beads were test/comment surfaces and no real bug surfaced.
