### PR TITLE
test(examples): real-apps editor CRUD + optimistic/follow/feed + resources non-favorite mutations (rf2-54eebb +2)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
@@ -1537,3 +1537,42 @@
     (profile-follow-test))
   (testing "home-context flattens the two home routes into {:tag :feed :page} (rf2-rq65wv)"
     (home-context-test)))
+
+;; ============================================================================
+;; http — failure->message multi-branch projection (rf2-xm57ne)
+;; ============================================================================
+;;
+;; The failure projector was untested in BOTH realworld apps. This pins the
+;; realworld_http side (the realworld_resources sibling is pinned in
+;; realworld_resources_cljs_test.cljs): the {:errors {:body [...]}} extraction,
+;; the {:errors {field [...]}} projection, a raw string body, and every
+;; category fallback keyed off the closed :rf.http/* taxonomy.
+
+(defn- http-failure->message-test []
+  (is (= "email or password is invalid"
+         (rh/failure->message {:kind :rf.http/http-4xx :status 422
+                               :body {:errors {:body ["email or password is invalid"]}}}))
+      "{:errors {:body [...]}} surfaces the server's first body message")
+  (is (= "email: is taken"
+         (rh/failure->message {:kind :rf.http/http-4xx :status 422
+                               :body {:errors {:email ["is taken"]}}}))
+      "a keyed {:errors {field [...]}} projects as \"field: message\"")
+  (is (= "raw upstream text"
+         (rh/failure->message {:kind :rf.http/http-5xx :status 502 :body "raw upstream text"}))
+      "a string body is surfaced verbatim")
+  (is (= "Network error — please try again." (rh/failure->message {:kind :rf.http/transport})))
+  (is (= "Request timed out." (rh/failure->message {:kind :rf.http/timeout})))
+  (is (= "Request rejected (status 404)." (rh/failure->message {:kind :rf.http/http-4xx :status 404})))
+  (is (= "Server error (status 503)." (rh/failure->message {:kind :rf.http/http-5xx :status 503})))
+  (is (= "Couldn't parse server response." (rh/failure->message {:kind :rf.http/decode-failure})))
+  (is (= "custom detail" (rh/failure->message {:kind :rf.http/accept-failure :detail {:message "custom detail"}})))
+  (is (= "Unexpected response shape." (rh/failure->message {:kind :rf.http/accept-failure})))
+  (is (= "Request cancelled." (rh/failure->message {:kind :rf.http/aborted})))
+  (is (= "spelled-out message" (rh/failure->message {:kind :some/unknown :message "spelled-out message"}))
+      "an unknown kind falls back to the failure's own :message")
+  (is (= "Request failed." (rh/failure->message {}))
+      "a shapeless failure falls back to the final catch-all"))
+
+(deftest realworld-http-failure-projection
+  (testing "failure->message multi-branch projection (rf2-xm57ne)"
+    (http-failure->message-test)))

--- a/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
@@ -47,6 +47,9 @@
             ;; editor-pure-helpers-test (rf2-54eebb). Example source stays
             ;; test-free; assertions live here.
             [realworld-http.article-editor :as editor]
+            ;; The `home-context` pure flattener (tags.cljs) exercised directly by
+            ;; home-context-test (rf2-rq65wv).
+            [realworld-http.tags :as tags]
             [realworld-http.ssr :as ssr])
   (:require-macros [re-frame.core :refer [with-new-frame]]))
 
@@ -1328,3 +1331,209 @@
     (editor-delete-test))
   (testing "a client-invalid submit fills per-field errors and fires no request (rf2-54eebb)"
     (editor-invalid-submit-test)))
+
+;; ============================================================================
+;; favorites / comments / feed / profile — optimistic-success + follow-author +
+;; article-delete + blank-comment + feed-load + profile-follow (rf2-rq65wv)
+;; ============================================================================
+;;
+;; favorite-toggle-test above covers the FAILURE rollback only; several
+;; demonstrated handlers had no coverage. These pin the success-sync re-seed, the
+;; detail-page follow-author + article-delete flows, the comment-form client
+;; validation, the user-feed load lifecycle, the profile follow/unfollow/rollback,
+;; and the pure home-context flattener.
+
+(defn- favorite-synced-success-test []
+  ;; :article/favorite-synced re-seeds the article from the server's authoritative
+  ;; reply (via select-keys), overwriting the optimistic guess.
+  (reg-canned-success! :realworld.test/favorite-ok
+    {:article {:slug "hello" :title "Hello" :description "Short" :body "Body" :tagList []
+               :createdAt "x" :updatedAt "x"
+               :favorited true :favoritesCount 42
+               :author {:username "alice" :bio nil :image nil :following false}}})
+  (with-new-frame [f (frame/make-anon-frame-record!
+                       {:initial-events [[:app/initialise]]
+                        :fx-overrides {:rf.http/managed :realworld.test/favorite-ok}})]
+    (rf/dispatch-sync [:articles/initialise] {:frame f})
+    (rf/dispatch-sync [:auth/store-session {:username "alice" :email "a@b.c" :token "jwt" :bio nil :image nil}] {:frame f})
+    (rf/dispatch-sync [:articles/loaded
+                       {:kind :success
+                        :value {:articles [{:slug "hello" :title "Hello" :description "Short"
+                                            :body "Body" :tagList [] :createdAt "x" :updatedAt "x"
+                                            :favorited false :favoritesCount 0
+                                            :author {:username "alice" :bio nil :image nil :following false}}]}}]
+                      {:frame f})
+    (rf/dispatch-sync [:article/toggle-favorite "hello"] {:frame f})
+    (let [art (first (rf/compute-sub [:articles/data] (rf/frame-state-value f)))]
+      (is (true? (:favorited art)) "the article is favorited after the synced reply")
+      ;; The count is the SERVER's 42, not the optimistic guess of 1 — proving the
+      ;; success handler re-seeded from the reply rather than trusting the optimism.
+      (is (= 42 (:favoritesCount art))
+          ":article/favorite-synced re-seeds the count from the server reply (select-keys)"))))
+
+(defn- article-follow-author-test []
+  ;; :article/toggle-follow-author — optimistic flip, then :article/author-follow-synced
+  ;; re-seeds the author from the returned profile; the -rollback handler restores
+  ;; the prior flag (driven directly, as comment-delete-rollback-stale-index-test
+  ;; drives its rollback).
+  (reg-canned-success-by-url! :realworld.test/follow-author
+    (fn [url]
+      (cond
+        (str/includes? url "/follow")    {:profile {:username "eve" :bio "Writer" :image nil :following true}}
+        (str/ends-with? url "/comments") {:comments []}
+        :else {:article {:slug "hello" :title "Hello" :description "d" :body "b"
+                         :tagList [] :createdAt "x" :updatedAt "x"
+                         :favorited false :favoritesCount 0
+                         :author {:username "eve" :bio nil :image nil :following false}}})))
+  (with-new-frame [f (frame/make-anon-frame-record!
+                       {:initial-events [[:app/initialise]]
+                        :fx-overrides {:rf.http/managed :realworld.test/follow-author}})]
+    (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
+    (rf/dispatch-sync [:rf.route/handle-url-change "/article/hello"] {:frame f})
+    (is (false? (:following (rf/compute-sub [:article/author] (rf/frame-state-value f))))
+        "eve starts unfollowed")
+    (rf/dispatch-sync [:article/toggle-follow-author] {:frame f})
+    (let [author (rf/compute-sub [:article/author] (rf/frame-state-value f))]
+      (is (true? (:following author)) "the author is followed after the synced reply")
+      (is (= "Writer" (:bio author))
+          ":article/author-follow-synced re-seeds the author from the returned profile"))
+    ;; Rollback handler (driven directly): restores the captured prior flag.
+    (rf/dispatch-sync [:article/author-follow-rollback false {:kind :rf.http/http-4xx}] {:frame f})
+    (is (false? (:following (rf/compute-sub [:article/author] (rf/frame-state-value f))))
+        ":article/author-follow-rollback restores the captured prior following flag")))
+
+(defn- article-detail-delete-test []
+  ;; :article/delete (detail page) → :article/delete-success → navigate home; and
+  ;; :article/delete-failed surfaces a readable error.
+  (reg-canned-success-by-url! :realworld.test/detail-delete
+    (fn [url]
+      (if (str/ends-with? url "/comments")
+        {:comments []}
+        {:article {:slug "hello" :title "Hello" :description "d" :body "b" :tagList []
+                   :createdAt "x" :updatedAt "x" :favorited false :favoritesCount 0
+                   :author {:username "alice" :bio nil :image nil :following false}}})))
+  (with-new-frame [f (frame/make-anon-frame-record!
+                       {:initial-events [[:app/initialise]]
+                        :fx-overrides {:rf.http/managed :realworld.test/detail-delete}})]
+    (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
+    (rf/dispatch-sync [:rf.route/handle-url-change "/article/hello"] {:frame f})
+    (is (= "hello" (:slug (rf/compute-sub [:article/data] (rf/frame-state-value f)))))
+    (rf/dispatch-sync [:article/delete] {:frame f})
+    (is (= :realworld/home (rf/compute-sub [:rf.route/id] (rf/frame-state-value f)))
+        "a successful detail-page delete navigates home")
+    ;; The failure branch (driven directly): a readable error lands on the slice.
+    (rf/dispatch-sync [:article/delete-failed {:error {:kind :rf.http/http-5xx :status 500}}] {:frame f})
+    (is (some? (rf/compute-sub [:article/error] (rf/frame-state-value f)))
+        ":article/delete-failed surfaces a readable error message")))
+
+(defn- comment-blank-body-test []
+  ;; :comment-form/submit with a blank body → client-side validation, no round trip.
+  (with-new-frame [f (frame/make-anon-frame-record!
+                       {:initial-events [[:app/initialise]]
+                        :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
+    (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
+    ;; A whitespace-only body is still blank after trim.
+    (rf/dispatch-sync [:comment-form/edit-field :body "   "] {:frame f})
+    (rf/dispatch-sync [:comment-form/submit] {:frame f})
+    (is (= "Comment body is required."
+           (rf/compute-sub [:comment-form/field-error :body] (rf/frame-state-value f)))
+        "a blank comment body fails on the client with a per-field :body error")
+    (is (nil? (rf/compute-sub [:comment-form/submit-error] (rf/frame-state-value f)))
+        "the client-validation branch leaves :submit-error alone (that's the transport door)")))
+
+(defn- feed-load-test []
+  ;; :feed/load → :feed/loaded populates the user-feed slice + grand count.
+  (reg-canned-success! :realworld.test/feed-ok
+    {:articles [{:slug "f1" :title "Feed one" :description "d" :body "b" :tagList []
+                 :createdAt "x" :updatedAt "x" :favorited false :favoritesCount 0
+                 :author {:username "bob" :bio nil :image nil :following true}}]
+     :articlesCount 7})
+  (with-new-frame [f (frame/make-anon-frame-record!
+                       {:initial-events [[:app/initialise]]
+                        :fx-overrides {:rf.http/managed :realworld.test/feed-ok}})]
+    (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
+    (rf/dispatch-sync [:feed/load] {:frame f})
+    (is (= 1 (count (rf/compute-sub [:feed/data] (rf/frame-state-value f))))
+        ":feed/loaded populates the user-feed slice")
+    (is (= 7 (rf/compute-sub [:feed/count] (rf/frame-state-value f)))
+        "the grand articles-count is stored for pagination")
+    (is (not (rf/compute-sub [:feed/loading?] (rf/frame-state-value f)))
+        "a settled feed load is no longer loading")))
+
+(defn- feed-load-failure-test []
+  (reg-canned-failure! :realworld.test/feed-fail :rf.http/http-5xx {:status 500 :body "boom"})
+  (with-new-frame [f (frame/make-anon-frame-record!
+                       {:initial-events [[:app/initialise]]
+                        :fx-overrides {:rf.http/managed :realworld.test/feed-fail}})]
+    (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
+    (rf/dispatch-sync [:feed/load] {:frame f})
+    (is (some? (rf/compute-sub [:feed/error] (rf/frame-state-value f)))
+        ":feed/load-failed surfaces a readable error on the feed slice")))
+
+(defn- profile-follow-test []
+  ;; :profile/follow + :profile/followed (re-seed from reply) + :profile/unfollow +
+  ;; :profile/follow-rollback, plus the favorites-tab load path.
+  (reg-canned-success-by-url! :realworld.test/profile-follow
+    (fn [method url]
+      (cond
+        (str/includes? url "/follow")
+        {:profile {:username "eve" :bio "Bio" :image nil :following (= :post method)}}
+        (str/includes? url "/profiles/")
+        {:profile {:username "eve" :bio "Bio" :image nil :following false}}
+        ;; article list reads (favorited / authored tabs)
+        :else {:articles [{:slug "a1" :title "A1" :description "d" :body "b" :tagList []
+                           :createdAt "x" :updatedAt "x" :favorited true :favoritesCount 3
+                           :author {:username "eve" :bio nil :image nil :following false}}]
+               :articlesCount 3})))
+  (with-new-frame [f (frame/make-anon-frame-record!
+                       {:initial-events [[:app/initialise]]
+                        :fx-overrides {:rf.http/managed :realworld.test/profile-follow}})]
+    (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
+    ;; Land on the favorites tab so :profile.favorites/load runs too.
+    (rf/dispatch-sync [:rf.route/handle-url-change "/profile/eve/favorites"] {:frame f})
+    (is (= "eve" (:username (rf/compute-sub [:profile/data] (rf/frame-state-value f))))
+        "the profile banner loads")
+    (is (= 1 (count (rf/compute-sub [:profile.favorites/data] (rf/frame-state-value f))))
+        "the favorites tab list loads (:profile.favorites/load)")
+    (is (false? (:following (rf/compute-sub [:profile/data] (rf/frame-state-value f))))
+        "eve starts unfollowed")
+    ;; Follow → optimistic true → :profile/followed re-seeds from the reply.
+    (rf/dispatch-sync [:profile/follow] {:frame f})
+    (is (true? (:following (rf/compute-sub [:profile/data] (rf/frame-state-value f))))
+        ":profile/followed re-seeds :following true from the returned profile")
+    ;; Unfollow → :profile/unfollowed re-seeds false.
+    (rf/dispatch-sync [:profile/unfollow] {:frame f})
+    (is (false? (:following (rf/compute-sub [:profile/data] (rf/frame-state-value f))))
+        ":profile/unfollowed re-seeds :following false")
+    ;; Rollback handler (driven directly): restores the captured prior flag.
+    (rf/dispatch-sync [:profile/follow-rollback true {:kind :rf.http/http-4xx}] {:frame f})
+    (is (true? (:following (rf/compute-sub [:profile/data] (rf/frame-state-value f))))
+        ":profile/follow-rollback restores the captured prior following flag")))
+
+(defn- home-context-test []
+  ;; tags/home-context flattens the two home routes into one {:tag :feed :page}.
+  (let [rt {:rf.runtime/routing {:current {:params {:tag "clojure"}
+                                           :query  {:feed "following" :page 2}}}}]
+    (is (= {:tag "clojure" :feed "following" :page 2} (tags/home-context rt))
+        "the tag (path param) + feed/page (query) flatten into one context map"))
+  (let [rt {:rf.runtime/routing {:current {}}}]
+    (is (= {:tag nil :feed nil :page nil} (tags/home-context rt))
+        "an empty route yields an all-nil context (no NPE)")))
+
+(deftest realworld-favorites-follow-feed
+  (testing ":article/favorite-synced re-seeds the count from the server reply (rf2-rq65wv)"
+    (favorite-synced-success-test))
+  (testing ":article/toggle-follow-author optimistic + synced + rollback (rf2-rq65wv)"
+    (article-follow-author-test))
+  (testing ":article/delete navigates home; :article/delete-failed surfaces an error (rf2-rq65wv)"
+    (article-detail-delete-test))
+  (testing ":comment-form/submit blank body fails on the client, no round trip (rf2-rq65wv)"
+    (comment-blank-body-test))
+  (testing "user feed :feed/load / :feed/loaded populate the slice (rf2-rq65wv)"
+    (feed-load-test))
+  (testing "user feed :feed/load-failed surfaces an error (rf2-rq65wv)"
+    (feed-load-failure-test))
+  (testing "profile follow / unfollow / rollback + favorites-tab load (rf2-rq65wv)"
+    (profile-follow-test))
+  (testing "home-context flattens the two home routes into {:tag :feed :page} (rf2-rq65wv)"
+    (home-context-test)))

--- a/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
@@ -42,6 +42,11 @@
             ;; (rf2-yt7ay6). The example source stays test-free; the assertions
             ;; live here.
             [realworld-http.http :as rh]
+            ;; Article-editor pure helpers (validate-draft / parse-tag-list /
+            ;; draft-from-article / article-body) exercised directly by
+            ;; editor-pure-helpers-test (rf2-54eebb). Example source stays
+            ;; test-free; assertions live here.
+            [realworld-http.article-editor :as editor]
             [realworld-http.ssr :as ssr])
   (:require-macros [re-frame.core :refer [with-new-frame]]))
 
@@ -1165,3 +1170,161 @@
 (deftest realworld-core-smoke
   (testing "app boot populates :auth, :articles, and :tags slices"
     (app-smoke-test)))
+
+;; ============================================================================
+;; article-editor — edit-mode load (PUT) / load-failure / delete / invalid-submit
+;; + pure helpers (rf2-54eebb)
+;; ============================================================================
+;;
+;; editor-create-test above covers the CREATE path only. Untested until now: the
+;; edit-mode load (draft-from-article seed + :mode/edit + PUT-on-submit), the
+;; load-failure render gate, the delete flow, the client-side invalid-submit
+;; branch, and the four pure helpers the handlers lean on.
+
+(defn- ed-has-tag? [f tag]
+  (rf/compute-sub [:rf.machine/has-tag? :ui/article-editor tag]
+                  (rf/frame-state-value f)))
+
+(defn- editor-pure-helpers-test []
+  ;; validate-draft — one message per blank required field; empty map when valid.
+  (is (= {} (editor/validate-draft {:title "T" :description "D" :body "B"}))
+      "a fully-filled draft validates clean (no error map)")
+  (is (= #{:title :description :body}
+         (set (keys (editor/validate-draft {:title "" :description "" :body ""}))))
+      "every blank required field earns its own error")
+  (is (= #{:description}
+         (set (keys (editor/validate-draft {:title "T" :description "   " :body "B"}))))
+      "a whitespace-only field counts as blank (str/blank?)")
+  ;; parse-tag-list — split on comma, trim each, drop blanks, vector out.
+  (is (= ["a" "b" "c"] (editor/parse-tag-list "a, b ,c"))
+      "tags split on comma, each trimmed")
+  (is (= [] (editor/parse-tag-list "")) "empty string → no tags")
+  (is (= [] (editor/parse-tag-list nil)) "nil → no tags (no NPE on the split)")
+  (is (= ["x"] (editor/parse-tag-list " , x , ,")) "blank entries between commas are dropped")
+  ;; draft-from-article — joins the tagList vector back into the comma string the
+  ;; form edits.
+  (is (= {:title "T" :description "D" :body "B" :tagList "a, b"}
+         (editor/draft-from-article {:title "T" :description "D" :body "B" :tagList ["a" "b"]}))
+      "an article decodes into the editable draft shape (tagList joined)")
+  ;; article-body — wraps the draft into the {:article …} request body, parsing tags.
+  (is (= {:article {:title "T" :description "D" :body "B" :tagList ["a" "b"]}}
+         (editor/article-body {:title "T" :description "D" :body "B" :tagList "a, b"}))
+      "the request body parses the tag string back into a vector"))
+
+(defn- editor-edit-load-and-put-test []
+  (let [seen (atom [])]
+    (reg-canned-success-by-url! :realworld.test/editor-edit
+      (fn [method url]
+        (swap! seen conj [method url])
+        {:article {:slug "hello-world" :title "Hello, world" :description "Intro"
+                   :body "Body text" :tagList ["intro" "demo"]
+                   :createdAt "2026-05-01" :updatedAt "2026-05-01"
+                   :favorited false :favoritesCount 0
+                   :author {:username "alice" :bio nil :image nil :following false}}}))
+    (with-new-frame [f (frame/make-anon-frame-record!
+                         {:initial-events [[:app/initialise]]
+                          :fx-overrides {:rf.http/managed :realworld.test/editor-edit}})]
+      ;; /editor/:slug is :requires-auth — sign in so the :can-enter guard passes and
+      ;; the route's :on-match [:editor/load-article] fires (vs a login redirect).
+      (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
+      (rf/dispatch-sync [:rf.route/handle-url-change "/editor/hello-world"] {:frame f})
+      ;; :editor/load-article → :use-edit + :fetch-started + GET /articles/hello-world;
+      ;; the canned reply lands → :editor/loaded seeds the draft, :fetch-succeeded.
+      (is (true? (ed-has-tag? f :mode/edit)) "edit-mode entry flips the :mode region to :edit")
+      (is (true? (ed-has-tag? f :editor/can-delete)) ":mode/edit lights the :editor/can-delete tag")
+      (is (true? (ed-has-tag? f :lifecycle/idle)) "a settled load leaves the lifecycle region at :idle")
+      (let [slice (rf/compute-sub [:editor/slice] (rf/frame-state-value f))
+            draft (rf/compute-sub [:editor/draft] (rf/frame-state-value f))]
+        (is (= "hello-world" (:slug slice)) "the slug is captured for the PUT target")
+        (is (= "Hello, world" (:title draft)) "the draft is seeded from the loaded article")
+        (is (= "intro, demo" (:tagList draft)) "the tag list is joined into the comma-separated string"))
+      (is (false? (rf/compute-sub [:editor/dirty?] (rf/frame-state-value f)))
+          "a freshly-seeded edit draft equals its baseline → not dirty")
+      (is (true? (rf/compute-sub [:editor/can-leave?] (rf/frame-state-value f)))
+          "a clean edit draft may leave freely")
+      ;; Edit a field → dirty + valid → the flow enables submit → PUT (not POST).
+      (reset! seen [])
+      (rf/dispatch-sync [:editor/edit-field :title "Hello, edited"] {:frame f})
+      (is (true? (rf/compute-sub [:editor/can-submit?] (rf/frame-state-value f)))
+          "an edited, valid draft can submit")
+      (rf/dispatch-sync [:editor/submit] {:frame f})
+      (is (some (fn [[m u]] (and (= :put m) (str/ends-with? u "/articles/hello-world"))) @seen)
+          "edit-mode submit issues a PUT to /articles/:slug (not a POST to /articles)")
+      ;; :editor/submit-success → :submit-succeeded (:saved) + :use-edit + navigate.
+      (is (true? (ed-has-tag? f :lifecycle/saved)) "a successful save advances the lifecycle → :saved")
+      (is (true? (ed-has-tag? f :mode/edit)) "the editor stays in :edit mode after saving"))))
+
+(defn- editor-load-failure-test []
+  (reg-canned-failure! :realworld.test/editor-load-fail
+                       :rf.http/http-5xx {:status 500 :body "server error"})
+  (with-new-frame [f (frame/make-anon-frame-record!
+                       {:initial-events [[:app/initialise]]
+                        :fx-overrides {:rf.http/managed :realworld.test/editor-load-fail}})]
+    (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
+    (rf/dispatch-sync [:rf.route/handle-url-change "/editor/doomed"] {:frame f})
+    ;; :editor/load-article → GET fails → :editor/load-failed → :fetch-failed.
+    (is (true? (ed-has-tag? f :lifecycle/error))
+        "a load failure lands the lifecycle region in :error (the page-level error gate)")
+    (is (some? (rf/compute-sub [:editor/submit-error] (rf/frame-state-value f)))
+        "the load-failure message is surfaced via :submit-error")))
+
+(defn- editor-delete-test []
+  (let [seen (atom [])]
+    (reg-canned-success-by-url! :realworld.test/editor-delete
+      (fn [method url]
+        (swap! seen conj [method url])
+        {:article {:slug "doomed" :title "Doomed" :description "d" :body "b" :tagList []
+                   :createdAt "x" :updatedAt "x" :favorited false :favoritesCount 0
+                   :author {:username "alice" :bio nil :image nil :following false}}}))
+    (with-new-frame [f (frame/make-anon-frame-record!
+                         {:initial-events [[:app/initialise]]
+                          :fx-overrides {:rf.http/managed :realworld.test/editor-delete}})]
+      (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
+      (rf/dispatch-sync [:rf.route/handle-url-change "/editor/doomed"] {:frame f})
+      (is (= "doomed" (:slug (rf/compute-sub [:editor/slice] (rf/frame-state-value f))))
+          "the article is loaded into edit mode")
+      (reset! seen [])
+      (rf/dispatch-sync [:editor/delete] {:frame f})
+      ;; :editor/delete → DELETE /articles/doomed → :editor/delete-success → reset + home.
+      (is (some (fn [[m u]] (and (= :delete m) (str/ends-with? u "/articles/doomed"))) @seen)
+          ":editor/delete issues a DELETE to /articles/:slug")
+      (is (= :realworld/home (rf/compute-sub [:rf.route/id] (rf/frame-state-value f)))
+          "a successful delete navigates home")
+      (is (nil? (:slug (rf/compute-sub [:editor/slice] (rf/frame-state-value f))))
+          "the editor slice is reset to a blank create draft on delete")
+      (is (true? (ed-has-tag? f :mode/create))
+          "the :mode region resets to :create after a delete"))))
+
+(defn- editor-invalid-submit-test []
+  (with-new-frame [f (frame/make-anon-frame-record!
+                       {:initial-events [[:app/initialise]]
+                        :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
+    (rf/dispatch-sync [:editor/initialise] {:frame f})
+    ;; A create draft with only a title → description + body still blank → the
+    ;; client-invalid branch fires (per-field errors + :_form, no round trip).
+    (rf/dispatch-sync [:editor/edit-field :title "Only a title"] {:frame f})
+    (rf/dispatch-sync [:editor/submit] {:frame f})
+    (let [errors (rf/compute-sub [:editor/errors] (rf/frame-state-value f))]
+      (is (contains? errors :description) "the blank description earns a per-field error")
+      (is (contains? errors :body) "the blank body earns a per-field error")
+      (is (not (contains? errors :title)) "the filled title has no error")
+      (is (= "Please fix the highlighted fields." (:_form errors))
+          "the whole-form prompt is set under :_form"))
+    (is (some? (rf/compute-sub [:editor/field-error :description] (rf/frame-state-value f)))
+        "submit-attempted? makes a per-field error visible even on an untouched field")
+    (is (true? (ed-has-tag? f :lifecycle/idle))
+        "an invalid submit issues no request — lifecycle stays :idle (no :submit-started)")
+    (is (nil? (rf/compute-sub [:editor/submit-error] (rf/frame-state-value f)))
+        "the client-validation branch clears :submit-error (that door is for transport failures)")))
+
+(deftest realworld-article-editor-edit-delete
+  (testing "pure helpers: validate-draft / parse-tag-list / draft-from-article / article-body (rf2-54eebb)"
+    (editor-pure-helpers-test))
+  (testing "edit-mode load seeds the draft, flips :mode/edit, and submit issues a PUT (rf2-54eebb)"
+    (editor-edit-load-and-put-test))
+  (testing "a load failure lands the lifecycle in :error and surfaces the message (rf2-54eebb)"
+    (editor-load-failure-test))
+  (testing ":editor/delete issues a DELETE, resets the slice, and navigates home (rf2-54eebb)"
+    (editor-delete-test))
+  (testing "a client-invalid submit fills per-field errors and fires no request (rf2-54eebb)"
+    (editor-invalid-submit-test)))

--- a/implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs
@@ -188,6 +188,16 @@
   [username page]
   (state/scoped-resource-key [:rf.scope/session {:username username}] :realworld/feed {:page page}))
 
+(defn- profile-key
+  "The global-scope :realworld/profile banner key for a username."
+  [username]
+  (state/scoped-resource-key :rf.scope/global :realworld/profile {:username username}))
+
+(defn- comments-key
+  "The global-scope :realworld/comments key for a slug."
+  [slug]
+  (state/scoped-resource-key :rf.scope/global :realworld/comments {:slug slug}))
+
 (defn- reply-success!
   "Replay the captured `:on-success` with the transport's success result
    appended as the LAST arg — the exact shape the live managed-HTTP transport
@@ -687,3 +697,213 @@
       (is (= :authed (rf/compute-sub [:auth/state] (state-value f))))
       (is (= :realworld/home (route-id f))
           "interactive login bounces home via :store-session → :auth/post-login-redirect"))))
+
+;; ============================================================================
+;; 11. NON-FAVORITE MUTATIONS + failure->message (rf2-xm57ne)
+;; ============================================================================
+;;
+;; Section 3 above (favorite-populates-…) pins the FAVORITE mutation only. These
+;; pin the rest of the write surface: the unfavorite zero-clamp adversarial edge,
+;; the follow/unfollow :populates seed, the post/delete-comment :invalidates
+;; refetch, the update-settings mutation + its :settings/replied continuation, and
+;; the two detail-page mutation continuations (:ui/follow-author-replied re-stale,
+;; :ui/article-deleted navigate-home). Plus the shared failure->message projector.
+
+(deftest unfavorite-optimistic-patch-clamps-count-at-zero
+  (testing "examples/real-apps/realworld_resources — :realworld/unfavorite's optimistic
+            patch (toggle-article-fav) clamps :favoritesCount at zero, so an
+            over-eager unfavorite of an already-zero article can't go negative
+            (mutations.cljs zero-clamp adversarial edge)"
+    (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
+                                       :fx-overrides {:rf.nav/push-url :rf/no-op}})]
+      (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
+      ;; Seed the article detail with favorited=true, favoritesCount=0 (the edge:
+      ;; a zero count that an unfavorite would otherwise push to -1).
+      (rf/dispatch-sync [:rf.resource/ensure
+                         {:resource :realworld/article :scope :rf.scope/global
+                          :params {:slug "hello-conduit"} :owner [:lease :test/detail]}]
+                        {:frame f})
+      (reply-success! @last-managed-args
+                      {:article {:slug "hello-conduit" :title "Hello, Conduit"
+                                 :favorited true :favoritesCount 0}}
+                      f)
+      (is (= 0 (-> (entry f (article-key "hello-conduit")) :data :article :favoritesCount))
+          "seeded at a zero favorites count")
+      (reset! last-managed-args nil)
+      ;; Unfavorite → the :optimistic-tags apply runs immediately (before the
+      ;; request), patching every [:article slug] entry via toggle-article-fav.
+      (rf/dispatch-sync [:rf.mutation/execute
+                         {:mutation :realworld/unfavorite
+                          :params   {:slug "hello-conduit" :username "alice"}
+                          :instance [:favorite "hello-conduit"]
+                          :cause    [:test :unfav]}]
+                        {:frame f})
+      (let [art (-> (entry f (article-key "hello-conduit")) :data :article)]
+        (is (false? (:favorited art)) "the optimistic apply flips favorited off")
+        (is (= 0 (:favoritesCount art))
+            "the count clamps at zero — an over-eager unfavorite can't go negative")))))
+
+(deftest follow-and-unfollow-populate-the-profile-banner-from-the-reply
+  (testing "examples/real-apps/realworld_resources — :realworld/follow / :realworld/unfollow
+            seed the [:profile username] banner from their reply (:populates), so the
+            banner's :following flips immediately without waiting on the refetch"
+    (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
+                                       :fx-overrides {:rf.nav/push-url :rf/no-op}})]
+      (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
+      ;; own + load the profile banner (following=false) so :populates has an entry.
+      (rf/dispatch-sync [:rf.resource/ensure
+                         {:resource :realworld/profile :scope :rf.scope/global
+                          :params {:username "eve"} :owner [:lease :test/profile]}]
+                        {:frame f})
+      (reply-success! @last-managed-args {:profile {:username "eve" :bio "" :image "" :following false}} f)
+      (is (false? (-> (entry f (profile-key "eve")) :data :profile :following))
+          "the banner starts unfollowed")
+      (reset! last-managed-args nil)
+      ;; FOLLOW → reply following=true → :populates seeds the banner.
+      (rf/dispatch-sync [:rf.mutation/execute
+                         {:mutation :realworld/follow :params {:username "eve"}
+                          :instance [:follow "eve"] :cause [:test :follow]}]
+                        {:frame f})
+      (reply-success! @last-managed-args {:profile {:username "eve" :bio "" :image "" :following true}} f)
+      (is (true? (-> (entry f (profile-key "eve")) :data :profile :following))
+          ":realworld/follow :populates the banner to :following true from its reply")
+      (reset! last-managed-args nil)
+      ;; UNFOLLOW → reply following=false → :populates seeds it back.
+      (rf/dispatch-sync [:rf.mutation/execute
+                         {:mutation :realworld/unfollow :params {:username "eve"}
+                          :instance [:follow "eve"] :cause [:test :unfollow]}]
+                        {:frame f})
+      (reply-success! @last-managed-args {:profile {:username "eve" :bio "" :image "" :following false}} f)
+      (is (false? (-> (entry f (profile-key "eve")) :data :profile :following))
+          ":realworld/unfollow :populates the banner back to :following false"))))
+
+(deftest post-and-delete-comment-invalidate-the-comments-read
+  (testing "examples/real-apps/realworld_resources — :realworld/post-comment and
+            :realworld/delete-comment invalidate [:comments slug], so the mounted
+            article page's owned comments read refetches to truth"
+    (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
+                                       :fx-overrides {:rf.nav/push-url :rf/no-op}})]
+      (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
+      ;; own + load the comments read so the invalidation has a live owner to refetch.
+      (rf/dispatch-sync [:rf.resource/ensure
+                         {:resource :realworld/comments :scope :rf.scope/global
+                          :params {:slug "hello-conduit"} :owner [:lease :test/comments]}]
+                        {:frame f})
+      (reply-success! @last-managed-args {:comments [{:id 1 :body "hi" :author {:username "eve"}}]} f)
+      (is (= :loaded (:status (entry f (comments-key "hello-conduit")))))
+      (reset! last-managed-args nil)
+      ;; POST comment → invalidates [:comments slug] → the owned read refetches.
+      (rf/dispatch-sync [:rf.mutation/execute
+                         {:mutation :realworld/post-comment
+                          :params   {:slug "hello-conduit" :body "great read"}
+                          :instance [:post-comment "hello-conduit"] :cause [:test :post]}]
+                        {:frame f})
+      (reply-success! @last-managed-args {:comment {:id 2 :body "great read" :author {:username "alice"}}} f)
+      (let [ce (entry f (comments-key "hello-conduit"))]
+        (is (or (contains? #{:loading :fetching} (:status ce)) (some? (:invalidated-at ce)))
+            ":realworld/post-comment reached the comments read (invalidate → refetch)"))
+      (reset! last-managed-args nil)
+      ;; DELETE comment → invalidates [:comments slug] → refetch again.
+      (rf/dispatch-sync [:rf.mutation/execute
+                         {:mutation :realworld/delete-comment
+                          :params   {:slug "hello-conduit" :id 2}
+                          :instance [:delete-comment "hello-conduit" 2] :cause [:test :del]}]
+                        {:frame f})
+      (reply-success! @last-managed-args {} f)
+      (let [ce (entry f (comments-key "hello-conduit"))]
+        (is (or (contains? #{:loading :fetching} (:status ce)) (some? (:invalidated-at ce)))
+            ":realworld/delete-comment reached the comments read (invalidate → refetch)")))))
+
+(deftest update-settings-mutation-folds-user-into-auth-and-navigates
+  (testing "examples/real-apps/realworld_resources — :settings/submit fires the
+            :realworld/update-settings mutation; the :reply-to [:settings/replied]
+            continuation folds the saved User into the auth slice and navigates to
+            the profile on :ok"
+    (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
+                                       :fx-overrides {:rf.nav/push-url :rf/no-op
+                                                      :realworld-resources.session/persist :rf/no-op}})]
+      (rf/dispatch-sync [:auth/store-session {:username "alice" :email "a@b.c" :token "jwt"
+                                              :bio nil :image nil}] {:frame f})
+      ;; Seed the draft from the user, then edit the bio.
+      (rf/dispatch-sync [:settings/load] {:frame f})
+      (rf/dispatch-sync [:settings/edit-field :bio "A brand new bio"] {:frame f})
+      (rf/dispatch-sync [:settings/submit] {:frame f})
+      (is (some? @last-managed-args) "the settings PUT lowered a write")
+      ;; Reply with the saved User → :settings/replied folds it into auth + navigates.
+      (reply-success! @last-managed-args
+                      {:user {:username "alice" :email "a@b.c" :token "jwt2"
+                              :bio "A brand new bio" :image nil}}
+                      f)
+      (is (= "A brand new bio" (get-in (rf/app-db-value f) [:auth :user :bio]))
+          ":settings/replied folded the saved User into the auth slice")
+      (is (= :realworld.profile/show (route-id f))
+          ":settings/replied navigates to the user's profile on :ok")
+      (is (= "alice" (:username (route-params f)))
+          "the profile route carries the saved username"))))
+
+(deftest follow-author-continuation-restales-the-detail-article
+  (testing "examples/real-apps/realworld_resources — :ui/follow-author fires the follow
+            mutation with :reply-to [:ui/follow-author-replied slug]; on settle the
+            continuation re-stales [:article slug] so the detail page's embedded
+            author flag refetches (the follow mutation itself only invalidates
+            [:profile username])"
+    (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
+                                       :fx-overrides {:rf.nav/push-url :rf/no-op}})]
+      (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
+      ;; own + load the article detail so the re-stale has a live owner to refetch.
+      (rf/dispatch-sync [:rf.resource/ensure
+                         {:resource :realworld/article :scope :rf.scope/global
+                          :params {:slug "hello-conduit"} :owner [:lease :test/detail]}]
+                        {:frame f})
+      (reply-success! @last-managed-args
+                      {:article {:slug "hello-conduit" :title "Hello"
+                                 :author {:username "eve" :following false}}}
+                      f)
+      (is (= :loaded (:status (entry f (article-key "hello-conduit")))))
+      (reset! last-managed-args nil)
+      ;; Follow the author from the detail page.
+      (rf/dispatch-sync [:ui/follow-author "hello-conduit" "eve" false] {:frame f})
+      (reply-success! @last-managed-args {:profile {:username "eve" :following true}} f)
+      (let [ae (entry f (article-key "hello-conduit"))]
+        (is (or (contains? #{:loading :fetching} (:status ae)) (some? (:invalidated-at ae)))
+            ":ui/follow-author-replied re-staled [:article slug] → the detail refetches")))))
+
+(deftest delete-article-continuation-navigates-home
+  (testing "examples/real-apps/realworld_resources — :ui/delete-article fires the
+            :realworld/delete-article mutation with :reply-to [:ui/article-deleted];
+            the continuation clears the instance and navigates home on :ok"
+    (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
+                                       :fx-overrides {:rf.nav/push-url :rf/no-op}})]
+      (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
+      ;; Land somewhere other than home so the navigate-home is observable.
+      (rf/dispatch-sync [:rf.route/navigate :realworld.auth/register] {:frame f})
+      (is (= :realworld.auth/register (route-id f)))
+      (reset! last-managed-args nil)
+      (rf/dispatch-sync [:ui/delete-article "hello-conduit"] {:frame f})
+      (is (some? @last-managed-args) "the delete mutation lowered a write")
+      (reply-success! @last-managed-args {} f)
+      (is (= :realworld/home (route-id f))
+          ":ui/article-deleted navigates home on a successful delete"))))
+
+(deftest failure->message-projects-every-taxonomy-branch
+  (testing "examples/real-apps/realworld_resources — rh/failure->message prefers the
+            server's {:errors {:body [...]}} / {:errors {field [...]}} words, then a
+            raw string body, then a category message per the closed :rf.http/* taxonomy"
+    (is (= "email or password is invalid"
+           (rrh/failure->message {:kind :rf.http/http-4xx :status 422
+                                  :body {:errors {:body ["email or password is invalid"]}}})))
+    (is (= "username: has already been taken"
+           (rrh/failure->message {:kind :rf.http/http-4xx :status 422
+                                  :body {:errors {:username ["has already been taken"]}}})))
+    (is (= "upstream said no"
+           (rrh/failure->message {:kind :rf.http/http-5xx :status 502 :body "upstream said no"})))
+    (is (= "Network error — please try again." (rrh/failure->message {:kind :rf.http/transport})))
+    (is (= "Request timed out." (rrh/failure->message {:kind :rf.http/timeout})))
+    (is (= "Request rejected (status 404)." (rrh/failure->message {:kind :rf.http/http-4xx :status 404})))
+    (is (= "Server error (status 500)." (rrh/failure->message {:kind :rf.http/http-5xx :status 500})))
+    (is (= "Couldn't parse server response." (rrh/failure->message {:kind :rf.http/decode-failure})))
+    (is (= "shape detail" (rrh/failure->message {:kind :rf.http/accept-failure :detail {:message "shape detail"}})))
+    (is (= "Unexpected response shape." (rrh/failure->message {:kind :rf.http/accept-failure})))
+    (is (= "Request cancelled." (rrh/failure->message {:kind :rf.http/aborted})))
+    (is (= "own message" (rrh/failure->message {:kind :some/unknown :message "own message"})))
+    (is (= "Request failed." (rrh/failure->message {})))))


### PR DESCRIPTION
## What

Adversarial contract tests for the two `examples/real-apps/` RealWorld apps, extending the existing test-free-example contract-test files (`realworld_cljs_test.cljs`, `realworld_resources_cljs_test.cljs`). Three review-campaign coverage-gap beads, one commit each:

### rf2-54eebb — realworld_http article-editor (P3)
- pure helpers: `validate-draft` / `parse-tag-list` / `draft-from-article` / `article-body` (whitespace-blank + nil-safe edges);
- edit-mode load — `/editor/:slug` (auth-gated) → `:editor/load-article` seeds the draft, flips `:mode/edit` + `:editor/can-delete`, submit issues a **PUT** (not POST);
- load failure — `:editor/load-failed` → lifecycle `:error` + surfaced message;
- `:editor/delete` — DELETE, slice reset, navigate home;
- client-invalid submit — per-field errors + `:_form`, no request (lifecycle stays `:idle`).

### rf2-rq65wv — realworld_http optimistic / follow / feed / profile (P4)
- `:article/favorite-synced` re-seeds from the server reply (count is the server's, not the optimistic guess);
- `:article/toggle-follow-author` optimistic + `:article/author-follow-synced` + `-rollback`;
- `:article/delete` → home; `:article/delete-failed` message;
- `:comment-form/submit` blank-body client validation;
- user feed `:feed/load` / `:feed/loaded` / `:feed/load-failed`;
- profile `:profile/follow` / `-followed` / `-unfollow` / `-unfollowed` / `-follow-rollback` + favorites-tab load;
- pure `home-context` flattener.

### rf2-xm57ne — realworld_resources non-favorite mutations + failure->message (P4)
- `:realworld/unfavorite` optimistic patch clamps `:favoritesCount` at zero (over-eager unfavorite can't go negative);
- `:realworld/follow` / `:realworld/unfollow` `:populates` the banner from the reply;
- `:realworld/post-comment` / `:realworld/delete-comment` `:invalidates` `[:comments slug]` → owned read refetches;
- `:settings/submit` → `:realworld/update-settings` + `:settings/replied` continuation (fold user into auth, navigate to profile);
- `:ui/follow-author` → `:ui/follow-author-replied` re-stales `[:article slug]`; `:ui/delete-article` → `:ui/article-deleted` navigates home;
- `failure->message` multi-branch projection in **both** apps.

## Quality gates

- `cd implementation && npm run test:cljs` — **8396 tests, 38796 assertions, 0 failures, 0 errors** (full suite, foreground).

## Stance

Pre-alpha, no shims. CORRECTNESS + GOOD-PRACTICE. **No production changes** — all additions are tests driving real handlers via `dispatch-sync` with exact assertions; no bugs surfaced. Examples stay test-free (rf2-8cevm) — every assertion lives in the existing adapter-tree contract-test files (#5386 pattern). Commits are split one-per-bead.
