### PR TITLE
test(skills-re-frame2): eval fixtures for Resources/mutations recipes (rf2-wwqg1c)

### DIFF
--- a/skills/re-frame2/evals/README.md
+++ b/skills/re-frame2/evals/README.md
@@ -53,7 +53,7 @@ Two harness extensions on top of the base schema:
 
 ## Coverage
 
-Eight evals, covering the three dimensions:
+Eleven evals, covering the three dimensions:
 
 | ID | Name | Dimension | What it probes |
 |---:|---|---|---|
@@ -65,14 +65,20 @@ Eight evals, covering the three dimensions:
 | 6 | `routing-correctness-greenfield-scaffold` | routing-correctness | Prompt is "start a new re-frame2 project from scratch". Does the agent defer to the sibling `re-frame2-setup` skill rather than improvising `deps.edn` / `shadow-cljs.edn` from the authoring skill? |
 | 7 | `recipe-correctness-story-recorder-sensitive-login` | recipe-correctness | Story-recorder privacy prompt (login + 2FA into a `:script`). Does the agent teach the CURRENT (path-based, fail-open) owner-classification contract — recorder filters off the emitted trace event's `:sensitive?`, stamped by the runtime from OWNER-declared path classification (a durable app-db secret via the writing event's `:sensitive` classification effect; the transient 2FA payload key in the submit handler's REGISTRATION `:sensitive` metadata), NOT handler metadata — and EXPLICITLY REJECT handler-meta `{:sensitive? true}` (a no-op) and the retired `redact-interceptor` / `add-marks` / frame `:sensitive {:app-db …}` annotation / schema-attached app-db marks as the mechanism? |
 | 8 | `recipe-correctness-story-variant-authoring-handoff` | recipe-correctness | Story variant authoring through the hybrid split. The prompt asks to author a variant AND "run it and keep iterating against the running library". Does the agent author with only the tools `re-frame2` is allow-listed for (`register-variant` / `preview-variant` / `get-variant` / `explain-variant`), and **hand off** the run/self-heal loop (`run-variant` / `read-failures`) to `re-frame2-pair` rather than claiming to call tools it cannot reach? Fails if the documented loop requires run-side tools unavailable to this skill. |
+| 9 | `recipe-correctness-resource-scoped-read-lifecycle` | recipe-correctness | Tenant-scoped billing-summary read shared across three screens (`patterns/resources.md`). Does the output register it with `reg-resource` under a REQUIRED fail-closed `:scope` (a `reg-resource-scope` named resolver referenced `{:from-db …}`, NOT `:rf.scope/global`, never omitted), read it PASSIVELY via a `[:rf/resource …]` sub, and CAUSE the fetch from a route `:resources` entry / `[:rf.resource/ensure …]` (owner + cause) — never from a view — while clearing the old scope causally on tenant switch (`resolve-resource-scope` + `:rf.resource/clear-scope`, no `:snapshot-db`) and never hand-rolling the cache key (CEDN-1)? |
+| 10 | `recipe-correctness-mutation-reply-to-workflow` | recipe-correctness | Article-save flow with post-success navigate + toast + field-error folding, concurrent saves (`patterns/resources-mutations.md`). Does the output use `reg-mutation` via `[:rf.mutation/execute …]` keyed by `:instance`, and keep the two axes apart — cache consequences (`:invalidates` list / `:populates` detail) DECLARATIVE on `reg-mutation`, app workflow in a call-site `:reply-to` handler (a causal event target reading the appended `{:status :value :error}` reply map, NOT a callback, NOT registration-level) — rejecting workflow-on-`reg-mutation` and the component-watcher idiom? |
+| 11 | `recipe-correctness-mutation-optimistic-mixed-scope` | recipe-correctness | Optimistic favorite (instant heart/count, clean rollback) invalidating a global article fact AND the session-scoped feed (`patterns/resources-mutations.md`). Does the output declare an `:optimistic` / `:optimistic-tags` plan (params / old-data, NO `result` arg) relying on the runtime-recorded inverse (no hand-written rollback), express the mixed-scope invalidation as per-target DESCRIPTORS (`{:scope :rf.scope/global …}` + `{:scope {:from-db …} :tags #{[:feed]}}`) rather than `:cross-scope? true`, and never `assoc` into `:rf.runtime/resources`? |
 
-Three is Anthropic's minimum. Eight gives **four** recipe-correctness evals
+Three is Anthropic's minimum. Eleven gives **seven** recipe-correctness evals
 and **two** each for discovery and routing-correctness, so every dimension keeps
 multi-eval coverage and any single eval can flake without the dimension going
 dark. The skew toward recipe-correctness reflects that dimension's higher defect
-risk (idiom drift in produced code, including the
-Story-recorder privacy contract eval 7 guards and the Story authoring/run
-boundary eval 8 guards).
+risk (idiom drift in produced code) — including the Resources/mutations recipe
+surface (evals 9–11), the most idiom-dense recipe area the skill teaches: the
+fail-closed mandatory `:scope`, the passive-view / causal-fetch split, call-site
+`:reply-to` workflow vs declarative cache consequences, and optimistic plans with
+runtime-recorded inverses — plus the Story-recorder privacy contract eval 7
+guards and the Story authoring/run boundary eval 8 guards.
 
 > **Staying in sync.** The table above, the eval count in this paragraph, and
 > the per-dimension breakdown are checked against `evals.json` by

--- a/skills/re-frame2/evals/evals.json
+++ b/skills/re-frame2/evals/evals.json
@@ -138,6 +138,58 @@
         "The agent's explanation of the boundary matches the shipped hybrid split: authoring (register/preview/read-back) is static and owned here; running (run-variant / read-failures / record-as-variant) is runtime-bound and owned by re-frame2-pair — consistent with scripts/check_skill_mcp_drift.py's intentional_server_only partition.",
         "The agent does NOT propose adding run-variant / read-failures to the re-frame2 skill's allowed-tools as a workaround, nor does it hallucinate a successful run result it never executed."
       ]
+    },
+    {
+      "id": 9,
+      "name": "recipe-correctness-resource-scoped-read-lifecycle",
+      "dimension": "recipe-correctness",
+      "prompt": "In our re-frame2 admin console the current tenant's billing summary is shown on three different screens. Fetch it once and cache it, keep it fresh (re-fetch if it's older than a minute or when the window regains focus), and make sure it never leaks between tenants when an admin switches the impersonated tenant. Wire up the read side — how each screen reads it and what actually causes it to load.",
+      "expected_output": "The agent loads patterns/resources.md and models a shared, cached, revalidated server-state read with reg-resource. The tenant boundary forces a fail-closed :scope — a reg-resource-scope named resolver referenced as {:from-db ...}, NOT :rf.scope/global, and never omitted. Views read passively through a [:rf/resource ...] subscription; the fetch is CAUSED from a route :resources entry or an event-dispatched [:rf.resource/ensure ...] (owner + cause), never from a view. The tenant switch clears the old scope causally (:rf.resource/clear-scope with the old scope resolved via resolve-resource-scope from the cofx db). It does not hand-roll the cache key or a parallel loading/error slice.",
+      "files": [],
+      "expectations": [
+        "Skill skills/re-frame2/ is invoked and patterns/resources.md is read.",
+        "The output registers the read with (rf/reg-resource ...) carrying a REQUIRED :scope — it does NOT omit :scope (omission is the fail-closed :rf.error/resource-missing-scope-policy) and does NOT declare it :rf.scope/global (the tenant / impersonation boundary is viewer-relative, not a global claim).",
+        "The tenant identity is derived once as a named scope resolver via (rf/reg-resource-scope ...) and referenced as {:from-db <resolver-id>}, rather than hand-assembling the tenant id into params / the cache key at each call site (the TanStack query-key divergence).",
+        "Views read the cached state PASSIVELY through a [:rf/resource {:resource ... :scope ... :params ...}] subscription (or a sibling :rf.resource/* projection sub) — a view / subscription never triggers the fetch.",
+        "The fetch is CAUSED from a route :resources entry (owner [:route route-id nav-token]) OR an event that dispatches [:rf.resource/ensure {... :owner ... :cause ...}] — with an :owner (liveness lease) distinct from the :cause — not from render.",
+        "The resource request fn returns a managed-HTTP args map ({:request ... :decode ...}) and does NOT supply :request-id / :on-success / :on-failure (the runtime owns reply addressing and stale suppression).",
+        "On tenant switch / impersonation change the output clears the affected scope causally with [:rf.resource/clear-scope ...], resolving the old concrete scope from the handler's coeffect db via (rf/resolve-resource-scope db ...) — NOT via a :snapshot-db payload key.",
+        "The output does NOT hand-roll a resource cache keyed by raw params / host = / a hash and does NOT assoc-in to the framework-owned :rf.runtime/resources — it lets the framework compute the [scope resource-id params] identity (CEDN-1)."
+      ]
+    },
+    {
+      "id": 10,
+      "name": "recipe-correctness-mutation-reply-to-workflow",
+      "dimension": "recipe-correctness",
+      "prompt": "Write the re-frame2 save flow for editing an article. On submit, PUT it to the server. When the save succeeds the article list and the article detail both need to reflect the change; then navigate to the saved article's page and pop a 'Saved' toast. If the server rejects with field-level errors, surface those back on the form. Two editors might hit Save on different articles at the same time.",
+      "expected_output": "The agent loads patterns/resources-mutations.md and models the write with reg-mutation dispatched via [:rf.mutation/execute ...] keyed by a per-submission :instance (so concurrent saves never clobber). It keeps the two axes apart: cache consequences (refresh the list via :invalidates, seed the detail via :populates) are DECLARATIVE on reg-mutation; app workflow (navigate, toast, fold field errors) lives in a call-site :reply-to handler — a causal event target, not a callback, and NOT a registration-level :reply-to (there is none). The :reply-to handler reads the appended reply map ({:status :value :error ...}) and cases on :ok / :error. It rejects putting navigation/toast on reg-mutation and rejects the component-watcher idiom.",
+      "files": [],
+      "expectations": [
+        "Skill skills/re-frame2/ is invoked and patterns/resources-mutations.md is read.",
+        "The write is registered with (rf/reg-mutation ...) whose request fn returns a managed-HTTP args map and does NOT set :request-id / :on-success / :on-failure.",
+        "The submit dispatches [:rf.mutation/execute {:mutation ... :params ... :instance ... :cause ...}] with a per-submission :instance id, and the output notes this instance keying is what stops two concurrent saves from clobbering each other.",
+        "Navigation, the toast, and folding server field-errors onto the form are done in a call-site :reply-to handler passed on [:rf.mutation/execute {... :reply-to [...]}] — described as a causal event target that lands on the event tape, NOT a callback, and NOT a registration-level :reply-to on reg-mutation.",
+        "The :reply-to handler reads the reply map appended as the final event arg — it destructures :status (:ok / :error) plus :value / :error and cases on status rather than assuming success.",
+        "Cache consequences are DECLARATIVE on reg-mutation: refreshing the article list is an :invalidates entry (tags) and seeding the detail entry is :populates (authoritative load) — NOT dispatched by hand from the :reply-to handler.",
+        "The output EXPLICITLY keeps the two axes apart — it does NOT put navigation / toast / auth-slice writes on reg-mutation's :populates / :invalidates (cache axis), and does NOT drive the post-save workflow by watching [:rf/mutation ...] from a component lifecycle hook (the watcher-reaction anti-pattern)."
+      ]
+    },
+    {
+      "id": 11,
+      "name": "recipe-correctness-mutation-optimistic-mixed-scope",
+      "dimension": "recipe-correctness",
+      "prompt": "In our re-frame2 feed, tapping the heart on an article should flip it to 'favorited' and bump the favorites count instantly — before the server replies — and roll back cleanly if the request fails. Favoriting also has to invalidate two separate things: the global article record and the current signed-in user's session-scoped feed list. Set this up.",
+      "expected_output": "The agent loads patterns/resources-mutations.md and declares an OPTIMISTIC reg-mutation plan (:optimistic and/or :optimistic-tags) that applies the flip/increment before the request is sent; it relies on the runtime to record the inverse and commit / roll back / reconcile on settle, and does NOT hand-write a rollback. The mixed-scope invalidation uses per-target DESCRIPTORS — one {:scope :rf.scope/global ...} target and one {:scope {:from-db ...} :tags #{[:feed]}} session-scoped target — NOT :cross-scope? true. It does not assoc into the framework-owned resource cache.",
+      "files": [],
+      "expectations": [
+        "Skill skills/re-frame2/ is invoked and patterns/resources-mutations.md is read.",
+        "The instant flip / count-bump is declared as an OPTIMISTIC plan on (rf/reg-mutation ...) — :optimistic (the exact-target twin of :patches) and/or :optimistic-tags — applied before the reply; the optimistic callback takes params only (its patch-fn takes old-data) with NO result arg, since the apply runs before any reply exists.",
+        "The output relies on the runtime to record the inverse and commit / roll back on settle (an accepted :ok commits, an :error / :cancelled rolls back) and does NOT hand-write the rollback / inverse.",
+        "The two-scope invalidation is expressed as per-target DESCRIPTORS on :invalidates — a vector of {:scope ... :tags ...} maps, one :rf.scope/global target and one session-scoped {:from-db <resolver-id>} target for #{[:feed]}.",
+        "The output does NOT reach for :cross-scope? true as the mixed-scope path (that is the audited scope-agnostic escape — it MUST carry :cause — not the ergonomic path when the scopes can be named).",
+        "The output does NOT hand-edit the framework-owned resource cache (:rf.runtime/resources) or hand-roll optimistic writes against reserved mutation keys — the optimistic plan plus the runtime-recorded inverse is the mechanism.",
+        "The optimistic mutation's request fn does NOT set :request-id / :on-success / :on-failure, and the output either names :on-conflict (default :invalidate) or notes optimistic plans are incompatible with :invalidate-timing :before-request."
+      ]
     }
   ]
 }


### PR DESCRIPTION
## What

Adds three adversarial `recipe-correctness` eval fixtures for the **Resources/mutations** recipe surface (`skills/re-frame2/patterns/resources.md` + `resources-mutations.md`, Spec 016) — the most idiom-dense recipe area the skill teaches, which had **zero** eval coverage. The existing 8 evals skewed to RemoteData / websocket-machine / forms / machine-HTTP / Story, leaving the fail-closed-semantics surface most likely to drift in a fresh session untested (rf2-wwqg1c).

New fixtures (ids 9–11), self-contained + idiomatic re-frame2, each objectively checkable over the real recipe discriminators:

| ID | Name | Probes |
|---:|---|---|
| 9 | `recipe-correctness-resource-scoped-read-lifecycle` | Read side — mandatory fail-closed `:scope` (`reg-resource-scope` `{:from-db …}`, not `:rf.scope/global`, never omitted), passive `[:rf/resource …]` view read, fetch CAUSED from route `:resources` / `[:rf.resource/ensure …]` (owner + cause) never a view, causal `clear-scope` on tenant switch (`resolve-resource-scope`, no `:snapshot-db`), no hand-rolled key (CEDN-1), request fn without `:request-id`/`:on-success`/`:on-failure`. |
| 10 | `recipe-correctness-mutation-reply-to-workflow` | Write side — `reg-mutation` via `[:rf.mutation/execute …]` keyed by `:instance`; the two-axis split (declarative cache consequences vs call-site `:reply-to` workflow — a causal event target reading the appended `{:status :value :error}` reply map, not a callback, not registration-level); rejects workflow-on-`reg-mutation` + the component-watcher idiom. |
| 11 | `recipe-correctness-mutation-optimistic-mixed-scope` | Optimistic plan (`:optimistic`/`:optimistic-tags`, runtime-recorded inverse, no hand-rolled rollback); per-target scoped invalidation DESCRIPTORS vs `:cross-scope?`; `:on-conflict` / `:before-request` incompatibility. |

`evals/README.md` coverage table, total-count sentence, and per-dimension tally updated to match: **eleven** evals; recipe-correctness 4 → 7 (discovery / routing-correctness stay 2 each).

## Quality gates

Foreground:
- `python scripts/check_skill_eval_docs.py --verbose` → **exit 0**, no eval-docs drift across all targets (A1 count, A2 names/ids, A3 dimension tally, A4 identity uniqueness).
- `python scripts/check_skill_eval_docs.py --self-test` → all fixtures pass.
- JSON parse-check: ids `1..11` sequential + unique, names unique, schema key-parity with existing fixtures (`{dimension, expectations, expected_output, files, id, name, prompt}`), 3 new fixtures discovered.

Scope: touches only `skills/re-frame2/evals/` (fixtures + docs). No framework/tool/example code.

## Stance

Pre-alpha, no shims; CORRECTNESS + CLARITY. Fixtures mirror the existing harness shape exactly and are grounded in the canonical tokens the two recipe leaves teach; no over-engineering (three fixtures partition the read / write-workflow / optimistic-mixed-scope sub-surfaces the bead enumerates).
