### PR TITLE
fix(core,machines): named-cofx entry-map double-wrap silently breaks inline/defmachine guards + de-dead the consume-undeclared lint (rf2-ful212, rf2-wbh50l)

### DIFF
--- a/implementation/core/src/re_frame/source_coords.cljc
+++ b/implementation/core/src/re_frame/source_coords.cljc
@@ -252,16 +252,29 @@
 (defn wrap-element-fns
   "Production-branch co-location: rewrite the `slot-key` map's
   `{<id> <fn-or-ref>}` entries to `{<id> {:fn <fn-or-ref>}}`, dropping
-  every debug slot. A keyword-reference value (`{<id> :other-id}`) is
-  preserved verbatim — `:fn` would be a misnomer for an indirection, and
-  the transition engine's `chase-ref` follows the bare keyword. No-op
-  when the slot is absent or not a map. Returns the updated spec.
+  every debug slot. Three value shapes (per `re-frame.machines.cofx-attach`
+  §entry-map shape helpers — bare fn / named-entry map / keyword ref):
+
+    - a bare fn → wrapped as `{:fn <fn>}`;
+    - an already-shaped named-entry MAP (`{:rf.cofx/requires [...]
+      :fn (fn …)}` — the named-cofx form a user authors directly) →
+      preserved VERBATIM, NOT re-wrapped under a fresh `:fn`. Re-wrapping
+      would nest `:rf.cofx/requires` one level down, emptying the
+      cofx-ensure index and resolving the guard/action `:fn` to a map
+      rather than the fn (rf2-ful212). A user-authored entry-map carries
+      no debug slots in production (those are added only by the dev arm's
+      [[collocate-element-source]]), so there is nothing to drop;
+    - a keyword-reference value (`{<id> :other-id}`) → preserved verbatim
+      (`:fn` would be a misnomer for an indirection, and the transition
+      engine's `chase-ref` follows the bare keyword).
+
+  No-op when the slot is absent or not a map. Returns the updated spec.
 
   This is the `(else)` arm of the reg-machine macro's
   `(if interop/debug-enabled? <collocate> <wrap>)` gate — it references
   NO source literals, so under `:advanced` + `goog.DEBUG=false` the
   whole dev arm (with its coord maps + `pr-str` source strings) DCEs and
-  only `{:fn <fn>}` entries ship."
+  only `{:fn <fn>}` / verbatim entry-map entries ship."
   [spec slot-key]
   (let [m (get spec slot-key)]
     (if-not (map? m)
@@ -269,7 +282,10 @@
       (assoc spec slot-key
              (reduce-kv
                (fn [acc id v]
-                 (assoc acc id (if (keyword? v) v {:fn v})))
+                 (assoc acc id (cond
+                                 (keyword? v) v
+                                 (map? v)     v
+                                 :else        {:fn v})))
                {} m)))))
 
 (defn collocate-element-source
@@ -277,11 +293,26 @@
   entries to `{<id> {:fn <fn> :source-coords {...} :source-code \"...\"}}`,
   merging the per-id `source-data` (a `{<id> {:source-coords {...}
   :source-code \"...\"}}` map the reg-machine macro stamped at expansion
-  time). Entries with no matching `source-data` (e.g. a let-bound symbol
-  the walker couldn't `pr-str` meaningfully) still get a `{:fn <fn>}`
-  wrapper. Keyword-reference values are preserved verbatim (no `:fn`
-  wrapper — `chase-ref` follows the bare keyword). Returns the updated
-  spec.
+  time). Three value shapes (per `re-frame.machines.cofx-attach` §entry-map
+  shape helpers — bare fn / named-entry map / keyword ref):
+
+    - a bare fn → wrapped as `{:fn <fn>}` with the source-data merged on;
+    - an already-shaped named-entry MAP (`{:rf.cofx/requires [...]
+      :fn (fn …)}` — the named-cofx form authored inline in `reg-machine`
+      or via `defmachine`) → the source-data is merged ONTO the entry, so
+      `:fn` / `:rf.cofx/requires` stay at the top level. It is NOT
+      re-wrapped under a fresh `:fn`: doing so nested `:rf.cofx/requires`
+      one level down, which emptied the cofx-ensure index and resolved the
+      guard/action `:fn` to a map rather than the fn — so the guard/action
+      silently never ran (rf2-ful212). This matches the shape the
+      `def`/let-bound-symbol registration path yields (there the macro walker
+      sees only a symbol and leaves the user's entry-map verbatim);
+    - a keyword-reference value → preserved verbatim (no `:fn` wrapper —
+      `chase-ref` follows the bare keyword).
+
+  Entries with no matching `source-data` (e.g. a let-bound symbol the walker
+  couldn't `pr-str` meaningfully) still get their bare-fn `{:fn <fn>}`
+  wrapper / verbatim entry-map. Returns the updated spec.
 
   This is the dev arm of the reg-machine macro's `(if interop/debug-
   enabled? <collocate> <wrap>)` gate. The `source-data` literal is
@@ -295,9 +326,10 @@
              (reduce-kv
                (fn [acc id v]
                  (assoc acc id
-                        (if (keyword? v)
-                          v
-                          (merge {:fn v} (get source-data id)))))
+                        (cond
+                          (keyword? v) v
+                          (map? v)     (merge v (get source-data id))
+                          :else        (merge {:fn v} (get source-data id)))))
                {} m)))))
 
 (defn collocate-state-source

--- a/implementation/machines/src/re_frame/machines/cofx_attach.cljc
+++ b/implementation/machines/src/re_frame/machines/cofx_attach.cljc
@@ -88,7 +88,9 @@
   XState offers NO parity guidance here — it has no replay contract; this
   surface is re-frame2's own (EP-0017 §Rationale — Why consumer attachment
   for machines)."
-  (:require [re-frame.cofx :as cofx]
+  (:require #?(:clj  [clojure.edn :as edn]
+               :cljs [cljs.reader :as edn])
+            [re-frame.cofx :as cofx]
             [re-frame.error :as error]
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
@@ -960,6 +962,30 @@
 ;; simply un-ensured, never wrong). We only lint when the `:source-code` slot
 ;; is present (the macro path in dev); the plain-fn / production path skips.
 
+(defn- source-code->form
+  "Best-effort parse the macro-captured `:source-code` into a form for the
+  consume-undeclared token scan. The `reg-machine` / `defmachine` macro stamps
+  `:source-code` as a `pr-str` STRING (via
+  `re-frame.source-coords/walk-element-source` →
+  `collocate-element-source`), so the scan must read it BACK to a form before
+  `tree-seq` — a `tree-seq` over a raw string yields the string as a single
+  LEAF, finding zero keyword tokens, which left the diagnostic dead against
+  real macro output (rf2-wbh50l).
+
+  A non-string `:source-code` (a pre-stringified FORM — the shape the scan's
+  own contract documents and hand-built specs may carry directly) is returned
+  as-is. Returns nil on an unreadable string (an exotic reader macro the EDN
+  reader can't parse) — a tolerated false-NEGATIVE per the recommendation-grade
+  design: an unscanned entry simply leaves an undeclared read un-flagged, never
+  mis-flagged. Uses the SAFE EDN reader (`clojure.edn` / `cljs.reader` — no
+  `#=`/eval, mirroring `re-frame.ssr.boot`)."
+  [source-code]
+  (if (string? source-code)
+    (try
+      (edn/read-string source-code)
+      (catch #?(:clj Throwable :cljs :default) _ nil))
+    source-code))
+
 (defn- emit-consume-undeclared!
   "Emit `:rf.warning/machine-cofx-consume-undeclared` (dev-only diagnostic)."
   [machine-id slot entry-id leaf]
@@ -1004,13 +1030,16 @@
                   (when (and meta (not (:recordable? meta)))
                     (emit-ambient-durable! machine-id slot entry-id id)))))
             ;; (1) consume-without-declaring — heuristic source scan. The
-            ;; macro-captured `:source-code` is a quoted form; scan it for
+            ;; macro-captured `:source-code` is a `pr-str` STRING; parse it
+            ;; back to a form (rf2-wbh50l — a `tree-seq` over the raw string
+            ;; is a single LEAF, so the scan found nothing and the diagnostic
+            ;; never fired against real macro output) then scan it for
             ;; `:rf.cofx`-record leaf reads not covered by `declared`. We
             ;; look for symbol/keyword tokens of the shape `<ns>/<name>`
             ;; destructured beside a `:rf.cofx`/`cofx` binding. Shallow by
             ;; design (a recommendation, not a gate).
-            (when source-code
-              (let [tokens (->> (tree-seq coll? seq source-code)
+            (when-let [form (source-code->form source-code)]
+              (let [tokens (->> (tree-seq coll? seq form)
                                 (filter keyword?)
                                 set)]
                 ;; A declared id appearing as a destructure key is fine; an

--- a/implementation/machines/test/re_frame/machine_cofx_attach_test.clj
+++ b/implementation/machines/test/re_frame/machine_cofx_attach_test.clj
@@ -29,6 +29,7 @@
   routed-around green)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.interop :as interop]
             [re-frame.machines :as machines]
             [re-frame.machines.cofx-attach :as cofx-attach]
             [re-frame.machines.test-support :as mtest]
@@ -654,3 +655,98 @@
       (is (contains? (set (map :id es)) :test/region-token)
           "the region-qualified :after timer's guard requires is ensured — the
            decl-path region head was stripped to resolve within region-a"))))
+
+;; ===========================================================================
+;; rf2-ful212: INLINE-LITERAL / defmachine named-cofx entry-maps resolve
+;; ===========================================================================
+;;
+;; Every ensure-set test above registers via a `def`/let-bound SYMBOL (`m`),
+;; which the reg-machine macro's compile-time literal-walk cannot see into — so
+;; `source-coords/collocate-element-source` never runs and the user's entry-map
+;; reaches the engine verbatim. That path ESCAPES the bug, which is why the
+;; suite was silently green.
+;;
+;; When the SAME named-cofx `:guards`/`:actions` entry (`{:rf.cofx/requires
+;; [...] :fn (fn …)}`) is registered as an INLINE LITERAL in `reg-machine` (or
+;; via `defmachine`), the macro's dev arm walked the literal and — pre-fix —
+;; DOUBLE-WRAPPED the entry (the WHOLE entry-map landed under a fresh `:fn`),
+;; nesting `:rf.cofx/requires` one level down. That EMPTIED the cofx-ensure
+;; index (`entry-requires` read nil → no cofx ensured) AND resolved the
+;; guard/action `:fn` to a MAP (not a fn) → the guard silently never fired
+;; (state stayed :idle). The prod arm (`wrap-element-fns`) double-wrapped
+;; identically, and the ensure-index is NOT dev-gated, so the break shipped to
+;; production too. These pin the inline-literal + defmachine paths in BOTH arms.
+
+(rf/defmachine ful212-defmachine
+  {:initial :idle
+   :data    {}
+   :guards  {:rolled-six?
+             {:rf.cofx/requires [:test/roll]
+              :fn (fn [{cofx :rf.cofx}] (= 6 (:test/roll cofx)))}}
+   :states  {:idle {:on {:go {:target :done :guard :rolled-six?}}}
+             :done {}}})
+
+(deftest inline-literal-named-cofx-guard-fires-dev-arm
+  (testing "rf2-ful212 (dev arm): a named-cofx GUARD registered as an INLINE
+            LITERAL in reg-machine (macro dev arm → collocate-element-source)
+            resolves its generator-backed cofx and FIRES. Pre-fix the entry was
+            double-wrapped: the ensure-index was empty and the guard :fn was a
+            map, so the guard silently never fired (seen ::unset, state :idle)."
+    (rf/reg-cofx :test/roll {:recordable? true} (fn [] 6))
+    (let [seen (atom ::unset)]
+      ;; INLINE LITERAL — the reg-machine macro walks this map, so
+      ;; collocate-element-source runs on the named-cofx entry.
+      (rf/reg-machine :ful212/inline-dev
+        {:initial :idle
+         :data    {}
+         :guards  {:rolled-six?
+                   {:rf.cofx/requires [:test/roll]
+                    :fn (fn [{cofx :rf.cofx}]
+                          (reset! seen (:test/roll cofx))
+                          (= 6 (:test/roll cofx)))}}
+         :states  {:idle {:on {:go {:target :done :guard :rolled-six?}}}
+                   :done {}}})
+      (rf/dispatch-sync [:ful212/inline-dev [:go]]
+                        {:rf.cofx {:rf/time-ms SCRIPTED-TIME-MS}})
+      (is (= 6 @seen)
+          "the inline-literal guard read the ENSURED generated fact (not nil) —
+           the ensure-index saw :rf.cofx/requires at the entry top level")
+      (is (= :done (mtest/machine-state :ful212/inline-dev))
+          "the guard :fn resolved to the fn (not the double-wrapped map) and
+           fired the transition"))))
+
+(deftest inline-literal-named-cofx-guard-fires-prod-arm
+  (testing "rf2-ful212 (prod arm): the SAME inline-literal named-cofx guard,
+            registered under `interop/debug-enabled? false` (macro prod arm →
+            wrap-element-fns), also resolves + fires — wrap-element-fns
+            preserves the entry-map verbatim rather than double-wrapping it. The
+            ensure-index is NOT dev-gated, so the fix must hold in prod too."
+    (rf/reg-cofx :test/roll {:recordable? true} (fn [] 6))
+    (with-redefs [interop/debug-enabled? false]
+      (rf/reg-machine :ful212/inline-prod
+        {:initial :idle
+         :data    {}
+         :guards  {:rolled-six?
+                   {:rf.cofx/requires [:test/roll]
+                    :fn (fn [{cofx :rf.cofx}] (= 6 (:test/roll cofx)))}}
+         :states  {:idle {:on {:go {:target :done :guard :rolled-six?}}}
+                   :done {}}}))
+    (rf/dispatch-sync [:ful212/inline-prod [:go]]
+                      {:rf.cofx {:rf/time-ms SCRIPTED-TIME-MS}})
+    (is (= :done (mtest/machine-state :ful212/inline-prod))
+        "the prod-arm (wrap-element-fns) entry-map is preserved verbatim, so the
+         guard resolves + fires on the ensured generated value")))
+
+(deftest defmachine-named-cofx-guard-fires
+  (testing "rf2-ful212 (defmachine): a value-registered machine defined with
+            `defmachine` (which walks + stamps the literal at the def site)
+            whose :guards entry is a named-cofx form resolves its cofx and FIRES
+            when later passed to reg-machine — the stamped value carried the
+            (previously double-wrapped) entry through registration."
+    (rf/reg-cofx :test/roll {:recordable? true} (fn [] 6))
+    (rf/reg-machine :ful212/defmachine ful212-defmachine)
+    (rf/dispatch-sync [:ful212/defmachine [:go]]
+                      {:rf.cofx {:rf/time-ms SCRIPTED-TIME-MS}})
+    (is (= :done (mtest/machine-state :ful212/defmachine))
+        "the defmachine-stamped named-cofx guard resolved its cofx and fired —
+         the entry-map was collocated without double-wrapping")))

--- a/implementation/machines/test/re_frame/machine_cofx_lint_test.clj
+++ b/implementation/machines/test/re_frame/machine_cofx_lint_test.clj
@@ -19,36 +19,37 @@
   Pre-rf2-hh4069 both diagnostics shipped registration-wired with ZERO test
   coverage. This suite pins them.
 
-  ## Findings surfaced while writing these tests (rf2-hh4069)
+  ## rf2-ful212 + rf2-wbh50l (fixed): consume-undeclared alive end-to-end
 
-  Driving the REAL path revealed the consume-undeclared diagnostic is
-  currently UNREACHABLE end-to-end — two interacting bugs, both filed:
+  Driving the REAL path while writing rf2-hh4069's tests revealed the
+  consume-undeclared diagnostic was UNREACHABLE end-to-end — two interacting
+  bugs, both since fixed:
 
     - rf2-wbh50l — the `reg-machine` macro stamps each entry's `:source-code`
       as a `pr-str` STRING (`re-frame.source-coords/walk-element-source` →
-      `collocate-element-source`), but the scan treats `:source-code` as a
+      `collocate-element-source`), but the scan treated `:source-code` as a
       FORM (`(tree-seq coll? seq source-code)`). `tree-seq` over a STRING is a
-      leaf — no keyword tokens — so the scan finds nothing and the diagnostic
-      never fires against real macro output. (`consume-undeclared-*-string`
-      pins this; the `*-form` tests exercise the scan logic against the
-      form-shaped input the code's own contract documents.)
+      leaf — no keyword tokens — so the scan found nothing. FIXED:
+      `lint-machine!` now parses the string back to a form (safe EDN reader,
+      `source-code->form`) before the scan. The `*-form` tests still exercise
+      the scan against form-shaped input; `consume-undeclared-fires-against-
+      macro-string-source` now asserts the STRING path FIRES.
 
     - rf2-ful212 — a machine registered as an INLINE LITERAL (or via
       `defmachine`) whose `:guards` / `:actions` entry is the named cofx form
-      `{:rf.cofx/requires [...] :fn (fn ...)}` is DOUBLE-WRAPPED by
+      `{:rf.cofx/requires [...] :fn (fn ...)}` was DOUBLE-WRAPPED by
       `collocate-element-source` (`{:fn <the-whole-entry-map> :source-code
-      \"...\"}`), nesting `:rf.cofx/requires` under `:fn`. That empties the
-      cofx-ensure index (`by-entry`) AND breaks guard/action resolution
-      (the guard's `:fn` is a map, not a fn → the guard never fires). Only
-      the `def`/let-bound-symbol registration path (which the existing
-      `machine_cofx_attach_test` uses) escapes it.
+      \"...\"}`), nesting `:rf.cofx/requires` under `:fn`. That emptied the
+      cofx-ensure index (`by-entry`) AND broke guard/action resolution (the
+      guard's `:fn` was a map, not a fn → the guard never fired). FIXED:
+      `collocate-element-source` / `wrap-element-fns` now merge source onto an
+      already-shaped entry-map without re-wrapping. (The regression proofs live
+      in `machine_cofx_attach_test`; `consume-undeclared-fires-end-to-end-
+      through-reg-machine` below proves the lint through the real macro path.)
 
-  Because a full fix spans core (`re-frame.source-coords`, out of this
-  worker's machines-only boundary), these tests drive `lint-machine!` the way
-  registration does — `(lint-machine! id (index-ensure-sets machine))` — and
-  register the ambient cases via the `def`/symbol path (no macro stamping) so
-  the by-entry index is intact. The macro end-to-end path is tracked in
-  rf2-ful212 + rf2-wbh50l."
+  The ambient cases still register via the `def`/symbol path (no macro
+  stamping); the `-form` consume cases drive `(lint-machine! id (index-ensure-
+  sets machine))` directly with a hand-built `:source-code`."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.interop :as interop]
@@ -230,15 +231,13 @@
 
 ;; ---- the string-shaped :source-code the macro actually stamps -------------
 
-(deftest consume-undeclared-currently-dead-against-macro-string-source
-  (testing "PINS rf2-wbh50l: the reg-machine macro stamps `:source-code` as a
-            pr-str STRING, but the scan does `(tree-seq coll? seq
-            source-code)` — a STRING is a tree-seq LEAF, so no keyword tokens
-            are found and the diagnostic never fires against real macro
-            output. The identical read that fires as a FORM (see -form test
-            above) is silent as a STRING. When rf2-wbh50l lands (parse the
-            string before scanning), flip this to assert the warning DOES
-            fire."
+(deftest consume-undeclared-fires-against-macro-string-source
+  (testing "rf2-wbh50l FIXED: the reg-machine macro stamps `:source-code` as a
+            pr-str STRING; the scan now parses it back to a form (via the safe
+            EDN reader) before `tree-seq`, so the identical read that fires as
+            a FORM (see -form test above) NOW fires as the STRING the macro
+            actually stamps. Previously a STRING was a `tree-seq` LEAF → zero
+            keyword tokens → the diagnostic was dead against real macro output."
     (rf/reg-cofx :lint/declared4   {:recordable? true} (fn [] :D))
     (rf/reg-cofx :lint/undeclared3 {:recordable? true} (fn [] :U))
     (let [m {:initial :idle
@@ -251,10 +250,67 @@
              :states  {:idle {:on {:go {:target :done :guard :g}}}
                        :done {}}}]
       (lint! :lint/consume-string m)
+      (let [w (warns CONSUME)]
+        (is (= 1 (count w))
+            "the scan now reads the STRING source-code as a form (rf2-wbh50l)")
+        (is (= {:machine-id :lint/consume-string
+                :slot       :guards
+                :entry-id   :g
+                :rf.cofx/id :lint/undeclared3}
+               (:tags (first w)))
+            "flags the undeclared registered cofx the fn read")))))
+
+(deftest consume-undeclared-tolerates-unreadable-string-source
+  (testing "an unreadable `:source-code` STRING (an exotic reader macro the
+            safe EDN reader chokes on) is a tolerated false-NEGATIVE: the scan
+            parses nothing and emits no warning rather than throwing —
+            recommendation-grade, never a hard gate (rf2-wbh50l)"
+    (rf/reg-cofx :lint/declared5   {:recordable? true} (fn [] :D))
+    (rf/reg-cofx :lint/undeclared5 {:recordable? true} (fn [] :U))
+    (let [m {:initial :idle
+             :data    {}
+             :guards  {:g {:rf.cofx/requires [:lint/declared5]
+                           :fn (fn [_] true)
+                           ;; `#=` eval / unbalanced form the EDN reader rejects
+                           :source-code "(fn [] #=(str :lint/undeclared5"}}
+             :states  {:idle {:on {:go {:target :done :guard :g}}}
+                       :done {}}}]
+      (is (nil? (lint! :lint/consume-unreadable m))
+          "lint-machine! returns without throwing on an unreadable source")
       (is (empty? (warns CONSUME))
-          "KNOWN BUG (rf2-wbh50l): the scan cannot read a STRING source-code
-           as a form — the diagnostic is dead against real macro output. Flip
-           to `(is (seq (warns CONSUME)))` when fixed."))))
+          "an unreadable source is silently un-scanned, never mis-flagged"))))
+
+;; ---- end-to-end through the REAL reg-machine macro wiring -----------------
+
+(deftest consume-undeclared-fires-end-to-end-through-reg-machine
+  (testing "rf2-ful212 + rf2-wbh50l END-TO-END: a named guard registered as an
+            INLINE LITERAL via `reg-machine` (the macro stamps :source-code as a
+            pr-str STRING and collocates the named-cofx entry) that DECLARES one
+            cofx but READS a different undeclared registered cofx now trips
+            consume-undeclared through the real registration wiring
+            (reg-machine → lint-machine!). This exercises BOTH fixes at once:
+            the entry-shape fix (so the ensure-index sees the entry and
+            lint-machine! iterates it) AND the string-parse fix (so the scan
+            reads the macro-stamped STRING). Before, the diagnostic was
+            doubly-dead — empty index + unscannable string."
+    (rf/reg-cofx :lint/e2e-declared   {:recordable? true} (fn [] :D))
+    (rf/reg-cofx :lint/e2e-undeclared {:recordable? true} (fn [] :U))
+    (rf/reg-machine :lint/e2e-consume
+      {:initial :idle
+       :data    {}
+       :guards  {:g {:rf.cofx/requires [:lint/e2e-declared]
+                     ;; declares :lint/e2e-declared but READS :lint/e2e-undeclared
+                     :fn (fn [{cofx :rf.cofx}]
+                           (some? (:lint/e2e-undeclared cofx)))}}
+       :states  {:idle {:on {:go {:target :done :guard :g}}}
+                 :done {}}})
+    (let [ids (set (map #(:rf.cofx/id (:tags %)) (warns CONSUME)))]
+      (is (contains? ids :lint/e2e-undeclared)
+          "the undeclared registered cofx read is flagged through real macro
+           output — the diagnostic is alive end-to-end")
+      (is (not (contains? ids :lint/e2e-declared))
+          "the DECLARED cofx (present in the :rf.cofx/requires the whole entry
+           map pr-strs into) is NOT flagged — it is in the declared diet"))))
 
 ;; ===========================================================================
 ;; 3. production gate — both lints DCE / no-op under debug-enabled? false


### PR DESCRIPTION
## Summary

Two interacting CORRECTNESS bugs in the machine consumer-attachment (`:rf.cofx/requires`) path, both silently green until now.

### rf2-ful212 (P2, core) — named-cofx entry-map double-wrap
`re-frame.source-coords/collocate-element-source` (dev arm of the `reg-machine` / `defmachine` macro) rewrote every `:guards`/`:actions` entry value `v` to `(merge {:fn v} source-data)`, assuming `v` is a bare fn/keyword. For the NAMED-COFX form `{:rf.cofx/requires [...] :fn (fn ...)}` it double-wrapped — the whole entry-map landed under a fresh `:fn`, nesting `:rf.cofx/requires` one level down. For a machine registered as an INLINE LITERAL (or via `defmachine`) this:

1. read `(:rf.cofx/requires v)` = nil → the cofx-ensure index (`by-entry`) went EMPTY → no cofx ensured;
2. resolved the guard/action `:fn` to a MAP, not a fn → the guard/action silently never ran.

The prod arm `wrap-element-fns` double-wrapped identically, and the ensure-index is NOT dev-gated, so the break shipped to production too. Only the `def`/let-bound-symbol path escaped it (the walker leaves a non-literal spec untouched), which is why the all-symbol `machine_cofx_attach_test` was green.

**Fix:** both co-location helpers now detect an already-shaped entry-map and merge source ONTO it (dev) / preserve it verbatim (prod), keeping `:fn` / `:rf.cofx/requires` at the entry top level — matching the shape the `def`/symbol path yields.

### rf2-wbh50l (P3, machines) — consume-undeclared lint dead against real macro output
`cofx-attach/lint-machine!` scanned `:source-code` via `(tree-seq coll? seq source-code)`, but the macro stamps `:source-code` as a `pr-str` STRING. tree-seq over a STRING is a single LEAF → zero tokens → `:rf.warning/machine-cofx-consume-undeclared` NEVER fired against real macro output (further masked by rf2-ful212 emptying `by-entry`).

**Fix:** `source-code->form` best-effort parses the string back to a form (safe EDN reader — `clojure.edn` / `cljs.reader`, no `#=`/eval; precedent `re-frame.ssr.boot`) before the scan. A pre-stringified FORM is scanned directly; an unreadable string yields nil → a tolerated false-NEGATIVE (recommendation-grade, never mis-flagged, never throws). The require rides only the dev-gated lint path, so it DCEs under `:advanced` + `goog.DEBUG=false`.

## Proof (the regressions that were silently green)
- **ful212:** an inline-literal named-cofx guard now resolves its generator-backed cofx and fires (`state :idle` → `:done`, `seen` = generated value not nil) in BOTH the dev arm (`collocate-element-source`) and the prod arm (`wrap-element-fns`), and the same via `defmachine`.
- **wbh50l:** the `-string` pin flips to assert the lint FIRES; an unreadable-source tolerance case; and an end-to-end proof that consume-undeclared fires through the real `reg-machine` wiring (exercises both fixes at once).

## Quality gates (all foreground, 0 failures)
- `npm run test:cljs` — 8445 tests / 38929 assertions, 0 failures / 0 errors
- `implementation/core` `clojure -M:test` — 1761 tests / 7667 assertions, 0 failures / 0 errors
- `implementation/machines` `clojure -M:test` — 915 tests / 2900 assertions, 0 failures / 0 errors
- `npm run test:elision` — PASS (production 47/47 absent)
- `npm run test:perf-bundle` — PASS (off-count=0; no bundle bloat from the `cljs.reader` require)

## Stance
Pre-alpha, no shims. CORRECTNESS + ELEGANCE + GOOD-PRACTICE: the fix makes the macro path yield the SAME entry shape the symbol path already produces (single source of truth), minimal + no over-engineering.