### PR TITLE
test+docs(pair-mcp,template,reply-conformance): transport-edge seam + SSR-client compile + functor-law comment (rf2-lz9n16 +2)

### DIFF
--- a/implementation/reply-conformance/test/re_frame/reply_functor_law_cljs_test.cljc
+++ b/implementation/reply-conformance/test/re_frame/reply_functor_law_cljs_test.cljc
@@ -12,9 +12,10 @@
   CANNOT exercise a real family relocation seam; instead it pins the
   functor laws over SYNTHETIC event-transforms (`route-relay`,
   `spawn-on-done`, `grandparent-relay` below) that MODEL THE SHAPE such a
-  relocation would take, applied to REAL family reply maps (`route-reply`,
-  `spawn-reply` are genuine route-loader / machine-spawn replies). It is a
-  substrate-shape proof, not an integration proof: it proves
+  relocation would take, applied to canonical family reply values
+  (`route-reply` is a canonical-SHAPE route-loader :ok fixture carrying a real
+  route work-id; `spawn-reply` is a genuine machine-spawn builder output). It
+  is a substrate-shape proof, not an integration proof: it proves
   `re-frame.reply/map-completed-event` + `complete` obey the laws for the relay
   SHAPES a relocating family would build — it does NOT prove that any
   family actually wires those shapes through `map-completed-event` end to end.
@@ -92,11 +93,15 @@
             [re-frame.machines.reply :as m-reply]))
 
 ;; ---------------------------------------------------------------------------
-;; Canonical replies for the two relocating families. Both are REAL family
-;; reply maps (a genuine route-loader :ok reply / a genuine machine-spawn
-;; success reply) — so the law is exercised over a real family reply, not a
-;; synthetic stub. NOTE the asymmetry the docstring calls out: the replies
-;; are real, but the TRANSFORMS below are synthetic stand-ins — no family
+;; Canonical replies for the two relocating families. Their PROVENANCE
+;; differs after the rf2-b2a3a2 fixtures extraction: the ROUTE reply is a
+;; canonical-SHAPE fixture — built via `fixtures/canonical-ok-reply`, it
+;; carries a REAL `route-reply/work-id` but is NOT the output of a route
+;; loader's `live-reply`. The SPAWN reply IS a genuine family-builder output
+;; (`m-reply/success-reply`). Either way the law runs over a real, well-formed
+;; reply value (the route work-id is real; the canonical shape is pinned by the
+;; vocab suite), not an opaque stub. NOTE the further asymmetry the docstring
+;; calls out: the TRANSFORMS below are synthetic stand-ins too — no family
 ;; exposes a map-completed-event relocation seam to point at.
 ;; ---------------------------------------------------------------------------
 

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/shadow_discovery.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/shadow_discovery.cljs
@@ -93,6 +93,14 @@
             :else (recur (+ i 2))))))
     (catch :default _ nil)))
 
+(defn default-request
+  "Production HTTP-request seam: Node's `http.request`. Wrapped in a plain
+  fn (rather than passing `http/request` bare) so the injected fake in
+  `fetch-project-info`'s 3-arity is a drop-in — same `(opts callback) ->
+  ClientRequest` contract, no `this`-binding surprises."
+  [opts callback]
+  (http/request opts callback))
+
 (defn fetch-project-info
   "Issue `GET http://<host>:<http-port>/api/project-info` against shadow's
   web server. Returns a Promise resolving to the response body (string)
@@ -101,8 +109,16 @@
   `.catch` and translate failures to nil — see `discover-project-home`.
 
   Kept separate from the parsing step so tests can stub one or the
-  other in isolation."
-  [host http-port]
+  other in isolation.
+
+  The 3-arity injects the HTTP-request seam (`request-fn`, a
+  `(opts callback) -> ClientRequest`) so the below-the-socket branches —
+  non-200 reject, multi-chunk body assembly, the bounded-timeout
+  destroy+reject, and the settle-once double-settle guard — are unit-
+  testable with a fake ClientRequest, no live socket. The 2-arity threads
+  the production `default-request`."
+  ([host http-port] (fetch-project-info host http-port default-request))
+  ([host http-port request-fn]
   (js/Promise.
     (fn [resolve reject]
       (let [opts        #js {:host host
@@ -113,7 +129,7 @@
             settle-once (fn [f v]
                           (when (compare-and-set! settled? false true)
                             (f v)))
-            ^js req     (http/request
+            ^js req     (request-fn
                           opts
                           (fn [^js res]
                             (let [status (.-statusCode res)]
@@ -137,7 +153,7 @@
                   (try (.destroy req (js/Error. "shadow HTTP probe timed out"))
                        (catch :default _ nil))
                   (settle-once reject (js/Error. "shadow HTTP probe timed out"))))
-        (.end req)))))
+        (.end req))))))
 
 (defn discover-project-home*
   "Like [[discover-project-home]] but takes the HTTP-fetch fn as an

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/nrepl_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/nrepl_test.cljs
@@ -471,6 +471,70 @@
             (done)))))))
 
 ;; ===========================================================================
+;; `send-op!` response assembly + resolution + timeout.
+;;
+;; Once the op is written, `attach-handlers!` routes each decoded nREPL frame
+;; to the `on-frame` accumulator registered under `[:pending id]`. We reach
+;; that accumulator through `(:pending @conn)` and feed frames directly — no
+;; socket, no bencode round-trip — to cover the response-assembly + resolution
+;; branch, then a short-deadline op with NO `:done` frame to cover the timeout
+;; branch. Both branches were previously below the seam: the existing
+;; `send-op!-live-socket-writes-normally` deliberately feeds no `:done` frame
+;; and asserts only the write + pending registration.
+;; ===========================================================================
+
+(deftest send-op!-assembles-frames-and-resolves-on-done
+  (testing "value/out/err/ex frames merge; status accretes; :done resolves + clears pending"
+    (async done
+      (let [sock (j/lit {:write (fn [_] nil)})
+            conn (nrepl/make-conn 0 "127.0.0.1")]
+        (swap! conn assoc :socket sock :closed? false)
+        (let [p (nrepl/send-op! conn {"op" "eval" "code" "(+ 1 1)"})]
+          (-> p
+              (.then (fn [res]
+                       (is (= "42" (:value res)) "last :value wins")
+                       (is (= "hello" (:out res)) ":out accretes across frames")
+                       (is (= "oops" (:err res)) ":err captured")
+                       (is (= "boom" (:ex res)) ":ex captured")
+                       (is (contains? (:status res) "done")
+                           ":status is the union of every frame's status")
+                       (is (= {} (:pending @conn))
+                           "the id is dissoc'd from :pending once :done resolves")
+                       (done))))
+          ;; After connect!'s fast-path microtask the op is registered pending;
+          ;; feed a realistic multi-frame nREPL response into its accumulator.
+          (js/queueMicrotask
+            (fn []
+              (let [on-frame (-> @conn :pending vals first)]
+                (on-frame #js {"out" "hel"})
+                (on-frame #js {"out" "lo"})
+                (on-frame #js {"err" "oops"})
+                (on-frame #js {"value" "42"})
+                (on-frame #js {"ex" "boom"})
+                (on-frame #js {"status" #js ["done"]})))))))))
+
+(deftest send-op!-timeout-rejects-and-cleans-pending
+  (testing "no :done frame before the deadline → reject + pending dissoc'd"
+    (async done
+      (let [sock (j/lit {:write (fn [_] nil)})
+            conn (nrepl/make-conn 0 "127.0.0.1")]
+        (swap! conn assoc :socket sock :closed? false)
+        ;; A 1ms deadline with no :done frame ever fed drives the setTimeout
+        ;; reject path.
+        (let [p (nrepl/send-op! conn {"op" "eval" "code" "(loop [])"}
+                                {:timeout-ms 1})]
+          (-> p
+              (.then (fn [_]
+                       (is false "an op with no :done frame must time out, not resolve")
+                       (done))
+                     (fn [err]
+                       (is (re-find #"timed out after 1ms" (.-message err))
+                           "reject message names the op-specific deadline")
+                       (is (= {} (:pending @conn))
+                           "the timed-out id is dissoc'd — no pending leak")
+                       (done)))))))))
+
+;; ===========================================================================
 ;; `discover-port*` async cascade.
 ;;
 ;; The five-step cascade — explicit > env > MCP roots/list > shadow HTTP probe

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/shadow_discovery_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/shadow_discovery_test.cljs
@@ -1,15 +1,24 @@
 (ns re-frame2-pair-mcp.shadow-discovery-test
   "Unit tests for the shadow-cljs HTTP probe.
 
-  Two surfaces under test:
+  Three surfaces under test, none of which opens a real socket:
 
     - `extract-project-home` — pure transit-json string → string|nil.
       Driven directly from synthetic JSON bodies; no HTTP.
-    - `discover-project-home` — wraps `fetch-project-info`. We swap the
-      module-level `fetch-project-info` for a stub via the
-      `with-redefs` macro so the cascade observes the three outcomes
-      (success / non-200 / connection refused / parse failure) without
-      a real socket.
+    - `fetch-project-info` — the HTTP-edge fn. Its 3-arity takes an
+      injected request-fn (a `(opts callback) -> ClientRequest`, mirroring
+      Node's `http.request`), so a FAKE ClientRequest drives the
+      below-the-socket branches directly: 200 single- and multi-chunk body
+      assembly, a non-200 reject, a request `error`, the bounded-timeout
+      `destroy` + reject, the response `error`, and the settle-once
+      double-settle guard.
+    - `discover-project-home*` — the fetch+parse composition. Here the
+      whole `fetch-project-info` step is stubbed AWAY via the injected
+      fetch-fn seam (it just returns a resolved/rejected Promise), so
+      these tests pin the compose-and-nil-on-error contract only — NOT
+      fetch-project-info's own edge handling (non-200 / connection
+      refused / timeout are simulated by the stub, not exercised). That
+      handling is covered by the `fetch-project-info` tests above.
 
   No test in this file talks to a live shadow server — the live probe
   is exercised by hand against `http://localhost:9630/api/project-info`
@@ -76,6 +85,189 @@
     (is (nil? (sd/extract-project-home "")))
     (is (nil? (sd/extract-project-home "[\"^ \", \"~:project-home\""))
         "truncated array")))
+
+;; ===========================================================================
+;; fetch-project-info — the HTTP edge, driven through an injected request-fn.
+;;
+;; `fetch-project-info`'s 3-arity takes a request-fn matching Node's
+;; `http.request` shape — `(opts callback) -> ClientRequest`, where `callback`
+;; receives the IncomingMessage. `make-fake-transport` returns such a fn plus a
+;; `state` atom the test drives: it records the response callback and the
+;; ClientRequest's `on` / `setTimeout` / `destroy` / `end` calls, so the test
+;; can fire a fake response (and its data/end/error events), a request error,
+;; or the timeout, and assert how `fetch-project-info` settles. No socket.
+;; ===========================================================================
+
+(defn- fake-res
+  "Minimal stand-in for Node's http IncomingMessage. `.statusCode` is fixed;
+  `.on` records event handlers into `handlers`; `.setEncoding` / `.resume` are
+  inert. The test fires the recorded data/end/error handlers to drive the body
+  assembly."
+  [status handlers]
+  #js {:statusCode  status
+       :setEncoding (fn [_enc] nil)
+       :resume      (fn [] nil)
+       :on          (fn [event cb] (swap! handlers assoc event cb) nil)})
+
+(defn- make-fake-transport
+  "Returns `[request-fn state]`. `request-fn` matches the seam
+  `fetch-project-info` expects — `(opts callback) -> ClientRequest` — recording
+  the response `callback` under `:res-cb` and returning a fake ClientRequest
+  whose `on` / `setTimeout` / `destroy` / `end` calls land in `state`. Drive
+  settlement by invoking `(:res-cb @state)` with a `fake-res`, then that res's
+  recorded data/end/error handlers; or the recorded req `error` handler; or
+  `(:timeout-cb @state)`."
+  []
+  (let [state (atom {:req-handlers {} :res-cb nil :timeout-cb nil
+                     :destroyed nil :ended false :opts nil})
+        req   #js {:on         (fn [event cb]
+                                 (swap! state assoc-in [:req-handlers event] cb) nil)
+                   :setTimeout (fn [_ms cb] (swap! state assoc :timeout-cb cb) nil)
+                   :destroy    (fn [err] (swap! state assoc :destroyed err) nil)
+                   :end        (fn [] (swap! state assoc :ended true) nil)}
+        request-fn (fn [opts cb]
+                     (swap! state assoc :opts opts :res-cb cb)
+                     req)]
+    [request-fn state]))
+
+;; The `done`-calling `.then` chain is the LAST form of every `async` body
+;; below (matching the convention the discover-project-home* tests use):
+;; drive the fake req/res settlement FIRST, then attach `.then`. Attaching
+;; `.then` and only THEN settling synchronously in the same body trips
+;; cljs.test's run-block into a spurious "done called more than one time".
+
+(deftest fetch-project-info-threads-opts-and-ends-the-request
+  (testing "host + port reach the request opts and the request is .end()ed"
+    (async done
+      (let [[request-fn state] (make-fake-transport)
+            res-handlers (atom {})
+            p (sd/fetch-project-info "10.0.0.5" 9700 request-fn)]
+        ((:res-cb @state) (fake-res 200 res-handlers))
+        ((get @res-handlers "data") "{ok}")
+        ((get @res-handlers "end"))
+        (-> p
+            (.then (fn [_]
+                     (let [opts (:opts @state)]
+                       (is (= "10.0.0.5" (.-host opts)))
+                       (is (= 9700 (.-port opts)))
+                       (is (= "/api/project-info" (.-path opts)))
+                       (is (true? (:ended @state))
+                           "req.end() fires the request"))
+                     (done))))))))
+
+(deftest fetch-project-info-200-single-chunk-resolves-body
+  (testing "a 200 with one chunk resolves the body verbatim"
+    (async done
+      (let [[request-fn state] (make-fake-transport)
+            res-handlers (atom {})
+            p (sd/fetch-project-info "127.0.0.1" 9630 request-fn)]
+        ((:res-cb @state) (fake-res 200 res-handlers))
+        ((get @res-handlers "data") "{body}")
+        ((get @res-handlers "end"))
+        (-> p
+            (.then (fn [body]
+                     (is (= "{body}" body))
+                     (done))))))))
+
+(deftest fetch-project-info-200-multi-chunk-assembles-body
+  (testing "a chunked 200 body is concatenated in arrival order"
+    (async done
+      (let [[request-fn state] (make-fake-transport)
+            res-handlers (atom {})
+            p (sd/fetch-project-info "127.0.0.1" 9630 request-fn)]
+        ((:res-cb @state) (fake-res 200 res-handlers))
+        ((get @res-handlers "data") "ab")
+        ((get @res-handlers "data") "cd")
+        ((get @res-handlers "data") "ef")
+        ((get @res-handlers "end"))
+        (-> p
+            (.then (fn [body]
+                     (is (= "abcdef" body)
+                         "the data-event accumulator joins all chunks")
+                     (done))))))))
+
+(deftest fetch-project-info-non-200-rejects-with-status
+  (testing "a non-200 response rejects, carrying the status code"
+    (async done
+      (let [[request-fn state] (make-fake-transport)
+            res-handlers (atom {})
+            p (sd/fetch-project-info "127.0.0.1" 9630 request-fn)]
+        ((:res-cb @state) (fake-res 404 res-handlers))
+        (-> p
+            (.then (fn [_]
+                     (is false "a non-200 must reject, not resolve")
+                     (done))
+                   (fn [err]
+                     (is (re-find #"HTTP 404" (.-message err))
+                         "reject message names the status code")
+                     (done))))))))
+
+(deftest fetch-project-info-request-error-rejects
+  (testing "a ClientRequest 'error' (e.g. connection refused) rejects"
+    (async done
+      (let [[request-fn state] (make-fake-transport)
+            p (sd/fetch-project-info "127.0.0.1" 9630 request-fn)]
+        ((get-in @state [:req-handlers "error"]) (js/Error. "ECONNREFUSED"))
+        (-> p
+            (.then (fn [_]
+                     (is false "a request error must reject")
+                     (done))
+                   (fn [err]
+                     (is (= "ECONNREFUSED" (.-message err)))
+                     (done))))))))
+
+(deftest fetch-project-info-timeout-destroys-and-rejects
+  (testing "the bounded-probe timeout destroys the request and rejects"
+    (async done
+      (let [[request-fn state] (make-fake-transport)
+            p (sd/fetch-project-info "127.0.0.1" 9630 request-fn)]
+        ((:timeout-cb @state))
+        (-> p
+            (.then (fn [_]
+                     (is false "a timed-out probe must reject")
+                     (done))
+                   (fn [err]
+                     (is (re-find #"timed out" (.-message err)))
+                     (is (some? (:destroyed @state))
+                         "req.destroy tears the socket down before rejecting")
+                     (done))))))))
+
+(deftest fetch-project-info-response-error-rejects
+  (testing "a mid-body response 'error' event rejects the probe"
+    (async done
+      (let [[request-fn state] (make-fake-transport)
+            res-handlers (atom {})
+            p (sd/fetch-project-info "127.0.0.1" 9630 request-fn)]
+        ((:res-cb @state) (fake-res 200 res-handlers))
+        ((get @res-handlers "data") "partial")
+        ((get @res-handlers "error") (js/Error. "socket hang up"))
+        (-> p
+            (.then (fn [_]
+                     (is false "a response error must reject")
+                     (done))
+                   (fn [err]
+                     (is (= "socket hang up" (.-message err)))
+                     (done))))))))
+
+(deftest fetch-project-info-double-settle-guard-holds
+  (testing "once end has resolved, a late timeout is swallowed (settle-once)"
+    (async done
+      (let [[request-fn state] (make-fake-transport)
+            res-handlers (atom {})
+            p (sd/fetch-project-info "127.0.0.1" 9630 request-fn)]
+        ((:res-cb @state) (fake-res 200 res-handlers))
+        ((get @res-handlers "data") "done-body")
+        ((get @res-handlers "end"))
+        ;; A late timeout fires AFTER the resolve — compare-and-set! swallows it.
+        ((:timeout-cb @state))
+        (-> p
+            (.then (fn [body]
+                     (is (= "done-body" body)
+                         "the FIRST settlement (resolve on end) wins")
+                     (done))
+                   (fn [_]
+                     (is false "a resolved probe must not later reject")
+                     (done))))))))
 
 ;; ===========================================================================
 ;; discover-project-home* — fetch + parse composition.

--- a/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
+++ b/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
@@ -457,23 +457,42 @@
          (delete-recursively tmp))))))
 
 (defn- run-ssr-emitted-test!
-  "The SSR variant of the emitted-test-run tier. The SSR scaffold's only
-  automated test is a headless JVM gate (`ssr_test.clj`) — no cljs.test
-  suite, no `:node-test` bundle — so it runs via the emitted deps.edn
-  `:test` alias (`clojure -M:test`), NOT `shadow compile test` + node.
-  That is the exact path `npm test` and the generated CI now invoke
-  (package.json `test` = `clojure -M:test` on the SSR path, per hooks.clj's
-  `{{test-script}}`); before this wiring nothing ran the emitted
-  ssr_test.clj, so an SSR-scaffold regression shipped uncaught (rf2-97eebb).
+  "The SSR variant of the emitted-test-run tier. The SSR scaffold has TWO
+  runtime halves, and this tier now covers both:
+
+    1. SERVER — the headless JVM gate (`ssr_test.clj`). No cljs.test suite,
+       no `:node-test` bundle, so it runs via the emitted deps.edn `:test`
+       alias (`clojure -M:test`), NOT `shadow compile test` + node. That is
+       the exact path `npm test` and the generated CI invoke (package.json
+       `test` = `clojure -M:test` on the SSR path, per hooks.clj's
+       `{{test-script}}`); before this wiring nothing ran the emitted
+       ssr_test.clj, so an SSR-scaffold regression shipped uncaught
+       (rf2-97eebb).
+
+    2. CLIENT — `clojure -M:shadow compile app`. `ssr_test.clj` loads only
+       the `#?(:clj)` render half of `core.cljc`, so the `#?(:cljs)`
+       HYDRATION branch (`reagent.dom.client/create-root` + `.render`
+       interop, `ssr/hydrate!`, `rf/frame-provider`, `rf/view`, the
+       `^:export init` entry point) was compile-UNTESTED — the sibling
+       static-parse (template_emission_test.clj) only checks re-frame.*
+       symbol EXISTENCE, missing reagent.dom.client interop / arity /
+       macro-expansion breaks. The other four CLJS-emitting variants all
+       get a real `shadow compile app`; the SSR client branch now does too
+       (rf2-ue5ev3). Compile-only — no `node` run — because the SSR
+       scaffold ships no client cljs.test bundle.
 
   Generate the SSR scaffold (`:include-ssr? true`), rewrite the framework
   coords — including day8/re-frame2-ssr + day8/re-frame2-ssr-ring — to
-  :local/root, then run `clojure -M:test` and assert exit 0 plus the
-  cljs.test summary lines, so a silent zero-test run can't false-green.
+  :local/root, link node_modules, `shadow compile app` (the client branch),
+  then `clojure -M:test` (the server gate) asserting exit 0 plus the
+  cljs.test summary lines so a silent zero-test run can't false-green.
 
-  Needs only `clojure` on PATH — no node, no node_modules: the JVM SSR
-  render is a pure hiccup -> HTML emitter (no React / JSDOM), so unlike
-  the CLJS variants this tier never shells out to `node`."
+  Needs `clojure` on PATH plus a project-local `node_modules`: the added
+  `:app` (`:browser`) compile resolves React (via reagent) at compile time
+  and — like the CLJS variants — searches ONLY the project-local
+  node_modules (it ignores NODE_PATH). No `node` RUNTIME is needed, though:
+  the browser compile is JVM/Closure-driven, and the JVM SSR render is a
+  pure hiccup -> HTML emitter (no React / JSDOM)."
   []
   (let [root (repo-root)
         tmp  (tmp-dir "rf2-template-run-reagent-ssr-")]
@@ -481,26 +500,56 @@
       (let [proj (run-template-opts! tmp "acme/my-app"
                                      {:substrate :reagent :include-ssr? true})]
         (rewrite-deps-for-local-run! root proj :reagent)
-        (testing "reagent-ssr — clojure -M:test (headless JVM ssr_test.clj)"
-          (let [{:keys [exit out]} (run-process! ["clojure" "-M:test"] proj)]
-            (is (zero? exit)
-                (str "`clojure -M:test` exited " exit
-                     " for the emitted SSR scaffold. The headless JVM "
-                     "ssr_test.clj gate did not pass against the in-repo SSR "
-                     "source (implementation/ssr + ssr-ring rewritten to "
-                     ":local/root). Output:\n" out))
-            ;; cljs.test's default reporter prints
-            ;;   "Ran N tests containing M assertions."
-            ;;   "0 failures, 0 errors."
-            ;; Pin both lines so a silent zero-exit (no tests discovered by
-            ;; the cognitect runner) doesn't false-green.
-            (is (re-find #"Ran \d+ tests? containing \d+ assertions" out)
-                (str "expected 'Ran N tests' summary line — a silent "
-                     "zero-test run (the very false-green rf2-97eebb "
-                     "guards) would otherwise pass. Got:\n" out))
-            (is (re-find #"0 failures, 0 errors" out)
-                (str "expected '0 failures, 0 errors' line in output. "
-                     "Got:\n" out)))))
+        (let [linked?   (link-node-modules! root proj)
+              node-path (.getCanonicalPath (io/file root "implementation/node_modules"))
+              env-overrides {"NODE_PATH" node-path}]
+          (is linked?
+              (str "project-local node_modules must resolve for the SSR "
+                   "`:app` (:browser) compile — it ignores NODE_PATH. "
+                   "Symlink/junction into " (.getPath proj)
+                   " failed; ensure implementation/node_modules exists "
+                   "(`npm install` in implementation/) and the OS allows "
+                   "a symlink or `mklink /J` junction."))
+
+          ;; --- client compile ----------------------------------------------
+          ;; `shadow compile app` pulls core.cljc's #?(:cljs) hydration branch
+          ;; (reagent.dom.client interop, ssr/hydrate!, ^:export init) onto the
+          ;; compile classpath — the client half ssr_test.clj (JVM :clj) never
+          ;; touches. A broken react-dom.client interop / adapter API rename /
+          ;; macro-expansion error fails here rather than on a newcomer's first
+          ;; `npx shadow-cljs watch app`.
+          (testing "reagent-ssr — clojure -M:shadow compile app (client :cljs hydration branch)"
+            (let [{:keys [exit out]}
+                  (run-process! ["clojure" "-M:shadow" "compile" "app"]
+                                proj env-overrides)]
+              (is (zero? exit)
+                  (str "`clojure -M:shadow compile app` exited " exit
+                       " for the emitted SSR scaffold. The client #?(:cljs) "
+                       "hydration branch of core.cljc did not compile against "
+                       "the in-repo source (reagent/re-frame2-* rewritten to "
+                       ":local/root). Output:\n" out))))
+
+          ;; --- server gate -------------------------------------------------
+          (testing "reagent-ssr — clojure -M:test (headless JVM ssr_test.clj)"
+            (let [{:keys [exit out]} (run-process! ["clojure" "-M:test"] proj)]
+              (is (zero? exit)
+                  (str "`clojure -M:test` exited " exit
+                       " for the emitted SSR scaffold. The headless JVM "
+                       "ssr_test.clj gate did not pass against the in-repo SSR "
+                       "source (implementation/ssr + ssr-ring rewritten to "
+                       ":local/root). Output:\n" out))
+              ;; cljs.test's default reporter prints
+              ;;   "Ran N tests containing M assertions."
+              ;;   "0 failures, 0 errors."
+              ;; Pin both lines so a silent zero-exit (no tests discovered by
+              ;; the cognitect runner) doesn't false-green.
+              (is (re-find #"Ran \d+ tests? containing \d+ assertions" out)
+                  (str "expected 'Ran N tests' summary line — a silent "
+                       "zero-test run (the very false-green rf2-97eebb "
+                       "guards) would otherwise pass. Got:\n" out))
+              (is (re-find #"0 failures, 0 errors" out)
+                  (str "expected '0 failures, 0 errors' line in output. "
+                       "Got:\n" out))))))
       (finally
         (delete-recursively tmp)))))
 
@@ -592,16 +641,23 @@
             (compile-and-run-emitted-test! :reagent true {:release? true}))))))
 
 (deftest reagent-ssr-emitted-tests-run-test
-  ;; The SSR scaffold's headless JVM gate (`ssr_test.clj`), run via the
+  ;; The SSR scaffold's TWO halves: the client `:cljs` hydration branch via
+  ;; `clojure -M:shadow compile app` (rf2-ue5ev3 — core.cljc's #?(:cljs)
+  ;; reagent.dom.client interop + ssr/hydrate! + ^:export init, which the
+  ;; JVM `ssr_test.clj` :clj-only load never compiles), and the server
+  ;; render via the headless JVM gate (`ssr_test.clj`) run through the
   ;; emitted deps.edn `:test` alias (`clojure -M:test`) — the exact path
-  ;; `npm test` and the generated CI now invoke on the SSR scaffold.
-  ;; Reagent-only because `:include-ssr?` is Reagent-only in v1. Unlike
-  ;; the CLJS variants above this needs ONLY `clojure` on PATH (no node:
-  ;; the JVM SSR render is a pure hiccup -> HTML emitter), yet rides the
-  ;; same RF2_TEMPLATE_RUN_EMITTED_TESTS gate. Before this tier nothing
-  ;; ran the emitted ssr_test.clj — the empty CLJS node-test bundle the
-  ;; SSR package.json used to run false-greened on zero tests (rf2-97eebb).
-  (testing "the emitted SSR Reagent app's ssr_test.clj runs green via
+  ;; `npm test` and the generated CI invoke on the SSR scaffold.
+  ;; Reagent-only because `:include-ssr?` is Reagent-only in v1. Needs
+  ;; `clojure` on PATH plus a project-local node_modules for the `:app`
+  ;; compile (React via reagent; no `node` RUNTIME — the browser compile is
+  ;; JVM/Closure-driven and the JVM SSR render is a pure hiccup -> HTML
+  ;; emitter), and rides the same RF2_TEMPLATE_RUN_EMITTED_TESTS gate.
+  ;; Before this tier nothing ran the emitted ssr_test.clj — the empty CLJS
+  ;; node-test bundle the SSR package.json used to run false-greened on zero
+  ;; tests (rf2-97eebb); and the client branch shipped compile-untested.
+  (testing "the emitted SSR Reagent app's client :cljs branch compiles
+            (`shadow compile app`) + its ssr_test.clj runs green via
             `clojure -M:test` (the JVM gate npm/CI now invoke)"
     (if-not @enabled?
       (skip-if-disabled! "reagent-ssr")


### PR DESCRIPTION
Three disjoint P4 review-campaign beads on isolated surfaces.

## rf2-lz9n16 — pair-mcp transport-edge seam + unit cover (`tools/re-frame2-pair-mcp`)
Two transport I/O fns had below-the-seam branches with zero unit coverage (deferred to the manual live-nrepl path).

- **`fetch-project-info`** (`shadow_discovery.cljs`) — add a 3-arity injecting the HTTP-request seam: a `(opts callback) -> ClientRequest` matching Node's `http.request` (the 2-arity threads the new `default-request` wrapper; production callers unchanged). New tests drive a fake ClientRequest to cover the branches the design left below the earlier `discover-project-home*` seam: 200 single- + multi-chunk body assembly, non-200 reject, request `error`, response `error`, bounded-timeout destroy+reject, and the settle-once double-settle guard.
- Reworded the `shadow_discovery_test` docstring nit that overclaimed the `discover-project-home*` tests exercise non-200 / connection-refused (they stub `fetch-project-info` away — that handling is now covered by the new fetch tests).
- **`send-op!`** (`nrepl.cljs`) — drive the pending `on-frame` accumulator directly (value/out/err/ex merge + status union + resolve-on-`:done` + pending cleanup) and a short-deadline op with no `:done` frame (setTimeout reject + pending dissoc). No production change to `nrepl.cljs`.

## rf2-ue5ev3 — SSR client `:cljs` branch compile-tested (`tools/template`)
`run-ssr-emitted-test!` ran only the headless JVM gate (`clojure -M:test`), which loads core.cljc's `#?(:clj)` render half — so the `#?(:cljs)` hydration branch (`reagent.dom.client` create-root/render interop, `ssr/hydrate!`, `rf/frame-provider`, `^:export init`) shipped compile-untested. Added a `clojure -M:shadow compile app` step (link node_modules + NODE_PATH, assert exit 0) so the SSR client branch gets a real compile like the other four CLJS-emitting variants. Compile-only (no `node` run — the SSR scaffold ships no client cljs.test bundle).

## rf2-7h6jew — functor-law NS comment corrected (`implementation/reply-conformance`)
After the rf2-b2a3a2 fixtures extraction, the route reply is a canonical-SHAPE fixture (real route work-id, not a route loader's `live-reply` output); only the spawn reply is a genuine family-builder output. Reworded the NS-level comment (and the identical overstatement in the ns docstring) to say so. Comment-only; no rigour change.

## Quality gates (all foreground, green)
- `tools/re-frame2-pair-mcp` `npm test` — 1203 tests, 4028 assertions, 0 failures, 0 errors, no warnings
- `tools/template` `clojure -M:test` (gate off) — 47 tests, 649 assertions, 0 failures
- `tools/template` SSR tier gate-ON (`RF2_TEMPLATE_RUN_EMITTED_TESTS=1`, single var) — 1 test, 6 assertions, 0 failures (new `shadow compile app` step exercised end-to-end)
- `implementation/reply-conformance` `clojure -M:test` — 30 tests, 446 assertions, 0 failures
- `implementation` `npm run test:cljs` — 8419 tests, 38786 assertions, 0 failures, 0 errors

## Stance
Pre-alpha, no shims; primary lenses CORRECTNESS + GOOD-PRACTICE. The only production change is the minimal injectable seam in `fetch-project-info` (2-arity wrapper preserves the existing contract); everything else is test/comment work on isolated surfaces.