### PR TITLE
docs(machines): update stale XState-v5 parity labels to v6 (rf2-kpusje)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
@@ -13,7 +13,7 @@
     - a keyword `actor-id` — the IMPERATIVE form: an action emits
       `[:rf.machine/destroy actor-id]` directly with the actor id it
       holds. This is first-class current API — re-frame2's spelling of
-      XState v5 `stopChild(actorId)` (the gold-standard imperative
+      XState v5 `stopChild(actorId)` (the imperative
       teardown that sits alongside automatic exit-cascade teardown), OR
     - a map `{:rf/parent-id ... :rf/invoke-id ...}` — the declarative-
       `:spawn` exit-cascade form, where the runtime resolves the actor

--- a/implementation/machines/src/re_frame/machines/parallel.cljc
+++ b/implementation/machines/src/re_frame/machines/parallel.cljc
@@ -26,8 +26,7 @@
   (single vs parallel) so the transition engine doesn't need to know
   the parallel layer exists.
 
-  `:raise` semantics (XState v5 / SCXML gold
-  standard). A flat / compound machine drains its own `:raise` queue FIFO
+  `:raise` semantics (XState v5 / SCXML). A flat / compound machine drains its own `:raise` queue FIFO
   inside `re-frame.machines.transition`. A PARALLEL machine owns the
   macrostep's single internal-event queue HERE: each region DEFERS its
   raises (its `machine-transition-single` settles `:always` locally but
@@ -645,7 +644,7 @@
 
 ;; ---- parallel macrostep internal-event queue ------------------------------
 ;;
-;; XState v5 / SCXML gold standard: `raise` enqueues on the machine's ONE
+;; XState v5 / SCXML: `raise` enqueues on the machine's ONE
 ;; internal event queue; the macrostep pops the front and broadcasts that
 ;; internal event to every active region, FIFO, until the queue drains —
 ;; then commits once. A parallel-region `:raise` is therefore NOT
@@ -695,7 +694,7 @@
 
 ;; ---- root parallel `:on` — the ancestor fallback --------------------------
 ;;
-;; XState v5 / SCXML gold standard: a transition declared on a `<parallel>`
+;; XState v5 / SCXML: a transition declared on a `<parallel>`
 ;; node is the ANCESTOR FALLBACK for its regions — deepest-wins with parent
 ;; fallthrough, the parallel analog of the machine-root `:on` fallback every
 ;; flat / compound machine already has (`transition/pick-transition` steps
@@ -1325,7 +1324,7 @@
 
 ;; ---- birth-time `:always` + raise settle ----------------------------------
 ;;
-;; XState v5 / SCXML gold standard: the INITIAL macrostep is initial-entry
+;; XState v5 / SCXML: the INITIAL macrostep is initial-entry
 ;; + the eventless (`always`) drain. `createActor(m).start()` evaluates
 ;; `always` on the entered initial state(s); if an `always` guard already
 ;; holds, the actor settles PAST the initial leaf with NO external event —

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -250,7 +250,7 @@
 ;;
 ;; ---- cross-region guard/action context ------------------------------------
 ;;
-;; XState v5 / SCXML gold standard: a parallel region's guard can predicate
+;; XState v5 / SCXML: a parallel region's guard can predicate
 ;; on a SIBLING region's active state via `stateIn(stateValue)` (XState v5
 ;; `xstate/guards`) / the `In(stateID)` predicate (W3C SCXML B.1). This is
 ;; the canonical orthogonal-region coordination primitive — region A's
@@ -350,7 +350,7 @@
 
 ;; ---- guard-throw signal (XState v5 alignment) -----------------------------
 ;;
-;; Per Spec 005 §`:rf.machine/guard-evaluated` (gold-standard alignment,
+;; Per Spec 005 §`:rf.machine/guard-evaluated` (XState v5 alignment,
 ;; rf2-18mox0): XState v5 does NOT swallow a guard exception. A throwing
 ;; guard SURFACES the error and ABORTS transition selection — it is never
 ;; silently demoted to a lower-priority candidate, a wildcard tier, or an
@@ -1674,7 +1674,7 @@
   (`(count src-path) > (count C-path)`) AND `C` itself is being exited
   (`lca-len < (count C-path)`, so `C`'s node — at index `(count C-path) - 1`
   along `src-path` — sits strictly below the surviving LCA boundary and is
-  torn down). This aligns with the XState v5 / W3C SCXML gold standard
+  torn down). This aligns with the XState v5 / W3C SCXML rule
   (Appendix D writes the history value while iterating `statesToExit`):
   history captures \"where this compound was when WE LEFT IT\", so the
   compound must actually be left. A transition that merely moves between
@@ -2127,7 +2127,7 @@
 
 ;; ---- root-level `:after` for parallel machines ----------------------------
 ;;
-;; XState v5 gold standard: `after` may be declared at ANY level, including a
+;; XState v5 / SCXML: `after` may be declared at ANY level, including a
 ;; `<parallel>` node. A parallel-ROOT `:after` is ROOT-OWNED — scheduled when
 ;; the parallel root is entered (machine birth), alive for the WHOLE machine,
 ;; and cancelled only when the machine itself is torn down. It is NOT bound to

--- a/implementation/machines/test/re_frame/cross_region_guard_ctx_test.clj
+++ b/implementation/machines/test/re_frame/cross_region_guard_ctx_test.clj
@@ -1,7 +1,7 @@
 (ns re-frame.cross-region-guard-ctx-test
   "Per Spec 005 §Cross-region coordination — tags as `stateIn`.
 
-  XState v5 / SCXML gold standard: a parallel region's guard can
+  XState v5 / SCXML: a parallel region's guard can
   predicate on a SIBLING region's active state via `stateIn(stateValue)`
   (XState v5 `xstate/guards`) / the `In(stateID)` predicate (W3C SCXML
   B.1) — the canonical orthogonal-region coordination primitive.

--- a/implementation/machines/test/re_frame/machine_property_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/machine_property_cljs_test.cljc
@@ -11,7 +11,7 @@
 
   Spec 005 itself flags a 'model-based testing harness' as planned, and
   XState v5 ships `@xstate/test` model-based testing — the analogous
-  gold-standard. This is the additive property tier, NOT a replacement for
+  reference. This is the additive property tier, NOT a replacement for
   the example + conformance suites.
 
   ## Properties asserted (over deterministic draws)

--- a/implementation/machines/test/re_frame/machine_raise_fifo_test.clj
+++ b/implementation/machines/test/re_frame/machine_raise_fifo_test.clj
@@ -2,7 +2,7 @@
   "`:raise` drains FIFO (XState v5 / SCXML internal-event queue), NOT
   depth-first.
 
-  XState v5 / SCXML gold standard: `raise` / `<raise>` enqueues on the
+  XState v5 / SCXML: `raise` / `<raise>` enqueues on the
   machine's ONE internal event queue, drained breadth-first within the
   macrostep. A transition that raises `[B]` then `[C]`, where B's handler
   itself raises `[D]`, processes them `B, C, D` — D goes to the BACK of the

--- a/implementation/machines/test/re_frame/parallel_raise_broadcast_test.clj
+++ b/implementation/machines/test/re_frame/parallel_raise_broadcast_test.clj
@@ -3,7 +3,7 @@
   macrostep and re-broadcasts to ALL regions against the full evolving
   snapshot. It is NOT region-local.
 
-  XState v5 / SCXML gold standard: `raise` enqueues on the machine's ONE
+  XState v5 / SCXML: `raise` enqueues on the machine's ONE
   internal event queue; the macrostep pops the front and broadcasts the
   internal event to every active region (every parallel state in SCXML),
   FIFO, until the queue drains, then commits once. So a region's raise

--- a/implementation/machines/test/re_frame/parallel_root_on_test.clj
+++ b/implementation/machines/test/re_frame/parallel_root_on_test.clj
@@ -1,6 +1,6 @@
 (ns re-frame.parallel-root-on-test
-  "Per Spec 005 §Transition broadcast §Root parallel `:on` (XState v5 / SCXML
-  gold standard). The parallel ROOT's own `:on` is the ANCESTOR FALLBACK for
+  "Per Spec 005 §Transition broadcast §Root parallel `:on` (XState v5 / SCXML).
+  The parallel ROOT's own `:on` is the ANCESTOR FALLBACK for
   its regions: deepest-wins with parent fallthrough, the parallel analog of
   the flat / compound machine-root `:on` fallback.
 
@@ -313,7 +313,7 @@
 
 ;; ---- 13. ROOT-LEVEL :after on a parallel root -----------------------------
 ;;
-;; XState v5 gold standard: `after` may be declared at any level, including a
+;; XState v5 / SCXML: `after` may be declared at any level, including a
 ;; <parallel> node. A parallel-ROOT `:after` is ROOT-OWNED — scheduled at
 ;; machine birth, alive for the whole machine, stale-gated by the root's OWN
 ;; per-path epoch (NOT bound to any region's lifecycle). It is the timer-driven

--- a/implementation/machines/test/re_frame/scxml_conformance_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/scxml_conformance_cljs_test.cljc
@@ -106,7 +106,8 @@
 
   ## Divergences from the SCXML core
 
-  re-frame2 follows XState v5 (the gold standard) for self-transition
+  re-frame2 follows the XState v6 direction (which retains v5's
+  internal-by-default self-transition rule) for self-transition
   defaults, which FLIPS SCXML's default: a targeted self/ancestor
   transition is INTERNAL by default; the external restart is the opt-in
   `:reenter? true`. SCXML's `type=\"external\"` default is therefore a
@@ -1019,7 +1020,8 @@
 ;; ===========================================================================
 ;; §10. Self-transitions (internal default vs external opt-in)
 ;;
-;; XState v5 is the gold standard. THREE cases the engine must distinguish:
+;; The XState v6 direction is the parity reference (this self-transition
+;; semantic is unchanged since v5). THREE cases the engine must distinguish:
 ;;
 ;;   (1) TARGETLESS — the action fires; NO onexit/onentry; the active
 ;;       configuration (including active descendants) is PRESERVED unchanged.
@@ -1301,7 +1303,7 @@
 ;; ===========================================================================
 ;; §10c. Explicit targets on the active path RE-RESOLVE DESCENDANTS
 ;;       (the middle case; and parent-declared reenter
-;;       to a specific descendant). XState v5 gold standard.
+;;       to a specific descendant). XState v5 rule.
 ;;
 ;; The defining XState v5 rule (stately.ai/docs/transitions):
 ;;   "A common mistake is using target: 'process' on a parent state

--- a/implementation/machines/test/re_frame/scxml_irp_semantic_core_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/scxml_irp_semantic_core_cljs_test.cljc
@@ -24,8 +24,9 @@
   `*_cljs_test.cljc` convention (discovered by both `npm run test:cljs` and
   `clojure -M:test`).
 
-  XState v5 (xstate@5.32.0, the recorded gold standard) is the reference for
-  every behaviour; the W3C SCXML IRP semantic-core is the canonical corpus.
+  The XState v6 direction is the parity reference for every behaviour
+  (the semantic core here is v5→v6 stable and was recorded against
+  xstate@5.32.0); the W3C SCXML IRP semantic-core is the canonical corpus.
   Where re-frame2 deliberately diverges from the raw SCXML shape
   (substrate-constrained, or behavioural parity via different expression),
   the case asserts the RE-FRAME2 behaviour and CITES the documented
@@ -484,7 +485,7 @@
             apart and proves the root-vs-embedded distinction: on the same
             embedded-final config `final-on-leaf?` is TRUE (the active leaf is
             final) while `top-level-final?` is FALSE (the path is length 2, not
-            a direct child of the root). xstate v5 / SCXML §3.7 gold standard
+            a direct child of the root). xstate v5 / SCXML §3.7
             (rf2-bnjb3 / rf2-zlmz7). Spec 005 §Final states §Top-level vs
             embedded."
     (let [m {:initial :work :data {}
@@ -519,7 +520,7 @@
             drain FIFO — an action raising [:b] then [:c], where :b's action
             raises [:d], processes :b, :c, :d (the nested :d goes to the BACK,
             behind the still-pending sibling :c), NOT depth-first. xstate v5
-            / SCXML gold standard (rf2-nr434). Spec 005 §`:raise` FIFO."
+            / SCXML (rf2-nr434). Spec 005 §`:raise` FIFO."
     (let [log (atom [])
           la  (fn [label & raises]
                 (fn [{:keys [data]}]


### PR DESCRIPTION
## Summary

Per Mike's 2026-06-22 ruling (EP-0029): **the XState v6 direction is the machine parity reference, superseding the v5 gold-standard framing.** This refreshes the stale parity-reference labels across the `implementation/machines` slice. Comment/docstring text only — **zero logic change**.

The precise target (per the ruling + `spec/005-StateMachines.md` §"Lessons from xstate", which states *"Parity reference: the XState v6 direction... v5 is not the live behavioural baseline"*) is **the v5 gold-standard framing** — not every `XState v5` string. The spec body itself deliberately *keeps* `XState v5 / SCXML` technical attribution and `Verified against xstate@5.32.0` citations, so those are preserved to stay consistent and truthful.

### What changed (21 sites, 10 files)
- **Dropped the superseded "gold standard" / "gold-standard" authority epithet**, keeping the accurate `XState v5 / SCXML` technical attribution (matches the spec body, e.g. §3.13 findLCCA, the exit-set rule). Files: `transition.cljc`, `parallel.cljc`, `destroy.cljc`, and the test docstrings in `cross_region_guard_ctx`, `machine_raise_fifo`, `parallel_raise_broadcast`, `parallel_root_on`, `machine_property`, `scxml_irp_semantic_core`.
- **Retargeted the explicit "v5 is re-frame2's reference / re-frame2 follows v5" authority statements to the XState v6 direction** (the semantics are v5→v6 stable), matching the spec's Lessons-from-xstate framing. Sites: `scxml_conformance` (self-transition defaults + §10 header) and `scxml_irp_semantic_core` (the "is the reference for every behaviour" note — reworded so the v6 parity reference is named while the historical `xstate@5.32.0` verification record is preserved).

### What was deliberately kept as history / technical attribution
- `XState v5 / SCXML §X` semantic-origin attributions and `XState v5 alignment` headers — the spec keeps identical forms; these cite where a stable semantic originated, not a stale parity target.
- **All `verified against xstate@5.32.0` verification citations** — factual records of what was actually run. Re-verifying those cases against v6 and updating the pin (as the bead's FIX also mentions) is a separate, non-comment task and cannot be done truthfully by a comment-only pass; changing the pin without a real v6 run would fabricate the verification.

## Quality gates
- `npm run test:cljs` (foreground, node runtime): **Ran 8459 tests / 39070 assertions — 0 failures, 0 errors.**
- Grep-confirmed: **0** `gold standard`/`gold-standard` epithets remain in `implementation/machines`; the **20** `xstate@5.32.0` verification citations are preserved.
- Diff is comment/docstring text only (`git diff` reviewed) — no code, no structural change.

## Stance
Pre-alpha, no shims; CLARITY + CORRECTNESS; avoided over-engineering (no blanket v5→v6 relabel — that would diverge from the spec's own convention and fabricate verification history).

Closes rf2-kpusje.