### PR TITLE
test+cleanup(conformance): named-resolver static input coverage + drop dead sub-desc helper (rf2-kg9dtc, rf2-rkt69g)

### DIFF
--- a/implementation/derivation-conformance/test/re_frame/derivation_algebra_conformance_cljs_test.cljc
+++ b/implementation/derivation-conformance/test/re_frame/derivation_algebra_conformance_cljs_test.cljc
@@ -544,6 +544,57 @@
     (is (not-any? #(= [:sub :article/page] (:to %)) (:edges g))
         "no static :input edge points at the parametric sub (don't-execute rule)")))
 
+(deftest c-named-resolver-scope-input-appears-statically-through-the-composer
+  ;; Derivations §Conformance / §Static graph (spec/Derivations.md:840):
+  ;; "static inspection reports only registration-known edges, marks parametric
+  ;; edge sets :parametric, and NEVER executes param/scope functions (the
+  ;; don't-execute rule); named-resolver inputs appear statically." The single
+  ;; resource `register-one-of-each!` registers (:article/by-slug) carries a
+  ;; LITERAL :rf.scope/global scope, so the named-resolver subclause of this
+  ;; bullet — a resource whose scope is a {:from-db <id>} REFERENCE reporting
+  ;; the reference shape [:scope {:from-db <id>}] PLUS the resolver's declared
+  ;; [:db <rf-path>] inputs via the :scope-resolver enrichment — is never
+  ;; composed THROUGH graph/derivation-graph alongside the other four families
+  ;; (rf2-kg9dtc). The per-family resource-algebra-view suite pins the
+  ;; enrichment in ISOLATION (resources/…/resource_algebra_view_cljs_test:
+  ;; from-db-scope-carries-named-resolver-enrichment); this arm proves the
+  ;; CROSS-FAMILY composer preserves the named-resolver static input verbatim
+  ;; when the {:from-db} resource is stitched in beside subs / flows / routes /
+  ;; machines — the umbrella-tier property (a composer regression that dropped
+  ;; :scope-resolver or rewrote the [:scope …] input would slip past the
+  ;; per-family suite that only ever reads resource-algebra-view directly).
+  ;;
+  ;; ADVERSARIAL on the don't-execute rule: the resolver body THROWS. Reaching
+  ;; it during static composition would blow up the graph assembly — so its
+  ;; absence of a throw proves the composer reads the resolver's DECLARED
+  ;; metadata (a static fact) and never RUNS the resolver fn.
+  (register-one-of-each!)
+  (rf/reg-resource-scope :conf/tenant
+                         {:inputs {:tenant-id [:db [:session :tenant-id]]}}
+                         (fn [_inputs _ctx]
+                           (throw (ex-info "a named-resolver fn must NOT run during static graph inspection" {}))))
+  (rf/reg-resource :tenant/feed
+                   {:scope         {:from-db :conf/tenant}
+                    :params-schema [:map [:page :int]]}
+                   (fn [{:keys [page]} _ctx]
+                     {:request {:method :get :url "/api/feed" :params {:page page}}}))
+  (let [nodes (:nodes (graph/derivation-graph all-contributors))
+        res   (node-by-family nodes :resources :tenant/feed)]
+    (is (some? res) "the {:from-db} resource composed into the umbrella cross-family graph")
+    (testing "the named-resolver REFERENCE surfaces as a STATIC scope input,
+              reported verbatim beside the generic params input — the composer
+              preserves the [:scope {:from-db <id>}] shape"
+      (is (= [[:param :rf.params] [:scope {:from-db :conf/tenant}]]
+             (:inputs res))
+          "the {:from-db <id>} reference rides the composed node's :inputs verbatim — a static fact"))
+    (testing "the :scope-resolver enrichment (the resolver id + its declared
+              [:db <rf-path>] inputs) rides through the composer verbatim — the
+              resolver's inputs are DECLARED static facts, not executed"
+      (is (= :conf/tenant (get-in res [:scope-resolver :id]))
+          "the composed node names the referenced resolver id")
+      (is (= [[:db [:session :tenant-id]]] (get-in res [:scope-resolver :inputs]))
+          "the resolver's declared [:db <rf-path>] inputs surface statically through the composer"))))
+
 (deftest c-live-graph-has-the-mode-frame-shape-and-realizes-the-route-slice
   ;; The static / live split (Derivations §Static and live graphs): the live
   ;; graph carries `:mode :live` + `:frame`, and reports REALIZED nodes (the

--- a/implementation/event-conformance/test/re_frame/event_frame_isolation_conformance_cljs_test.cljc
+++ b/implementation/event-conformance/test/re_frame/event_frame_isolation_conformance_cljs_test.cljc
@@ -92,14 +92,19 @@
                                             :ambient-frame nil}))
 
 ;; ---------------------------------------------------------------------------
-;; Helpers — build a RUNNABLE image-resolver descriptor for an event / sub id.
+;; Helper — build a RUNNABLE image-resolver descriptor for an event id.
 ;;
 ;; The descriptor an image's `:rf.gen/resolver` carries is the SAME shape
 ;; `register!` stores: an event is `events/event-handler-meta` (handler-fn + the
 ;; framework wrapper chain), merged with the provenance / kind / id keys image
-;; assembly groups + dedupes by; a layer-1 sub carries `:input-kind :db` so the
-;; sub-cache feeds it the frame's app-db projection. A generation-routed
-;; `registrar/lookup` returns each verbatim, so the cascade runs it directly.
+;; assembly groups + dedupes by. A generation-routed `registrar/lookup` returns
+;; it verbatim, so the cascade runs it directly. (This suite is the LIVE EVENT
+;; DISPATCH isolation lock — "image -> frame -> event stream". The
+;; sub-through-image READ path is pinned elsewhere: the frame-targeted read
+;; contract in core's `re-frame.facade-frame-read-cljs-test`, and the
+;; sub-through-generation acceptance in
+;; `re-frame.live-run-frame-resolution-cljs-test` — so no sub descriptor helper
+;; lives here, rf2-rkt69g.)
 ;; ---------------------------------------------------------------------------
 
 (defn- event-desc
@@ -108,14 +113,6 @@
          {:rf.provenance/ns provenance-ns
           :kind             :event
           :id               id}))
-
-(defn- sub-desc
-  [provenance-ns id compute-fn]
-  {:rf.provenance/ns provenance-ns
-   :kind             :sub
-   :id               id
-   :input-kind       :db
-   :handler-fn       compute-fn})
 
 ;; ===========================================================================
 ;; (1) THE HEADLINE — two image-loaded frames, the SAME event id, DIFFERENT


### PR DESCRIPTION
Two disjoint conformance-surface fixes from the 2026-07-09 review campaign.

## rf2-kg9dtc — named-resolver static scope input uncovered in the umbrella (derivation-conformance)

`spec/Derivations.md:840` (§Conformance / Static graph) requires that **named-resolver inputs appear statically**: a resource whose `:scope` is a `{:from-db <id>}` reference reports the reference shape `[:scope {:from-db <id>}]` plus a `:scope-resolver` enrichment (the resolver id + its declared `[:db <rf-path>]` inputs). The umbrella cross-family suite registered only a literal `:rf.scope/global` resource (`:article/by-slug`), so this subclause was never composed **through** `graph/derivation-graph` alongside the other four families.

The per-family `resource-algebra-view` suite pins the enrichment in isolation (`from-db-scope-carries-named-resolver-enrichment`). The new arm `c-named-resolver-scope-input-appears-statically-through-the-composer` registers a `{:from-db}` resolver + resource on top of the "one of each" cross-family registration, composes through the composer, and asserts the composed resource node preserves the `[:scope {:from-db <id>}]` input and the `:scope-resolver` `{:id … :inputs …}` verbatim — the umbrella-tier property (a composer regression that dropped `:scope-resolver` or rewrote the `[:scope …]` input would slip past the per-family suite that only reads `resource-algebra-view` directly).

Adversarial on the don't-execute rule: the resolver body **throws**, so reaching it during static composition would blow up the graph assembly — its absence of a throw proves the composer reads the resolver's declared metadata, never runs the fn.

## rf2-rkt69g — dead `sub-desc` helper + misleading comment (event-conformance)

`event_frame_isolation_conformance_cljs_test` defined a `sub-desc` helper that was never called (grep-confirmed; the sibling `live-run-frame-resolution` suite has its **own** independent `sub-desc` that is used), and its helper-comment block described a sub-through-image path this suite never exercises. This tier is the LIVE EVENT DISPATCH isolation lock ("image -> frame -> event stream"); the sub-through-image READ path is pinned elsewhere — the frame-targeted read contract in core's `facade-frame-read-cljs-test`, and the sub-through-generation acceptance in `live-run-frame-resolution-cljs-test`. Removed the vestigial helper and trimmed the comment to describe only the event descriptor, pointing at where the sub path is actually pinned.

## Quality gates

All run in foreground:

- `implementation` `npm run test:cljs` — **8460 tests, 39074 assertions, 0 failures, 0 errors**
- `implementation/derivation-conformance` `clojure -M:test` — **20 tests, 446 assertions, 0 failures, 0 errors**
- `implementation/event-conformance` `clojure -M:test` — **58 tests, 204 assertions, 0 failures, 0 errors**

The new derivation-conformance test runs on both the CLJS node gate and the JVM gate (`*-cljs-test` ns); both were green.

## Stance

Pre-alpha, no shims. Test-only + comment-only changes; CORRECTNESS + CLARITY + GOOD-PRACTICE. Both changes are isolated conformance surfaces (`derivation-conformance` + `event-conformance`); no production source touched, no hot-zone files.