### PR TITLE
fix(test-quiet): bounded waitFor after destroyForcibly in drain-process (port rf2-16n94y) (rf2-5m8ocd)

### DIFF
--- a/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
+++ b/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
@@ -80,6 +80,24 @@
   hanging the whole JVM suite (rf2-8dfq5j.3)."
   60000)
 
+(def ^:private force-kill-reap-timeout-ms
+  "Bounded ceiling to wait for a force-killed child to actually be REAPED
+  after `destroyForcibly` (rf2-5m8ocd, porting rf2-16n94y).  `Process.
+  destroyForcibly` only *requests* forced termination — the JDK docs
+  explicitly allow the child to remain alive briefly after the call and
+  direct callers that need termination to have COMPLETED to `waitFor`.
+  Without this wait the timeout branch could return `:timed-out? true`
+  while the OS had not yet reaped the child, so a caller checking
+  `.isAlive` immediately (the `drain-process-kills-and-flags-a-hanging-child`
+  contract below) lost the reap race on a loaded CI runner — a residual
+  intermittent test-quiet flake.  A SIGKILLed child is normally reaped in
+  milliseconds; this generous bound only bites a pathologically
+  unkillable child, and even then keeps the helper bounded (well under
+  the outer 30s contract-test guard and the CI job timeout).  Reached
+  ONLY on the exceptional timeout branch — the fast `done?` path that the
+  ~24 real subprocesses take is untouched."
+  10000)
+
 (defn- drain-process
   "Drain `proc`'s stdout AND stderr concurrently, then `waitFor` UNDER A
   TIMEOUT.  Returns {:exit :out :err :timed-out?}.  The concurrent drain
@@ -106,6 +124,13 @@
          ;; The child outlived the ceiling — force-kill it and interrupt
          ;; the drain threads so neither this helper nor the futures hang.
          (.destroyForcibly proc)
+         ;; `destroyForcibly` only REQUESTS termination; block (bounded)
+         ;; until the OS has actually reaped the child before returning, so
+         ;; `:timed-out? true` never races ahead of the real kill and a
+         ;; caller's immediate `.isAlive` check is reliable (rf2-5m8ocd,
+         ;; porting rf2-16n94y).
+         (.waitFor proc force-kill-reap-timeout-ms
+                   java.util.concurrent.TimeUnit/MILLISECONDS)
          (future-cancel out-f)
          (future-cancel err-f)
          {:exit       -1


### PR DESCRIPTION
## What & why

The `jvm-test-quiet` gate flaked intermittently on unrelated PRs (rf2-5m8ocd; e.g. #5411 branched after the earlier #5384 attempt yet still flaked and needed `--admin`). Root cause is a single unfixed asynchronous-kill race in the shared `drain-process` helper.

`drain-process`'s timeout branch called `(.destroyForcibly proc)` and immediately returned `{:timed-out? true …}` **without waiting for the OS to reap the child**. `Process.destroyForcibly` only *requests* forced termination — the JDK docs allow the child to remain alive briefly after the call and direct callers that need termination to have *completed* to `waitFor`. So on a loaded CI runner the child was not yet reaped when the caller checked liveness, and the `drain-process-kills-and-flags-a-hanging-child` contract's immediate `(is (not (.isAlive proc)) …)` assertion lost the reap race → intermittent red.

This is the same race-class PR #5384 (rf2-16n94y) targeted, but **#5384 was closed unmerged**, so `origin/main` never had the fix. This PR ports that fix shape onto current main.

## The fix

Add a **bounded** `(.waitFor proc force-kill-reap-timeout-ms MILLISECONDS)` immediately after `(.destroyForcibly proc)` in the timeout branch, so `drain-process` returns `:timed-out? true` only once the child is actually gone.

- A SIGKILLed child is normally reaped in milliseconds, so `waitFor` returns near-instantly; the 10s ceiling only bounds a pathologically unkillable child and stays well under the outer 30s contract-test guard and the CI job timeout.
- Reached **only** on the exceptional timeout branch — the fast `done?` path that the ~24 real subprocesses take is untouched, so normal suite time is unchanged.
- The line ~1080 `(is (not (.isAlive proc)) …)` assertion is **kept exactly as-is**: it is the contract the helper must satisfy. This fix makes it reliably true rather than weakening it.
- Source-level hardening only — no workflow retry, no `--admin`, no watered-down assertion. Confined to a single JVM-only test-helper (`java.lang.Process`); no `src/` or CLJS change.
- Grepped the whole `test-quiet` suite for siblings of the race-class (any `.isAlive`/`.exitValue`/read/exit-code assertion made immediately after an async `destroyForcibly`/spawn without a bounded settle): the only such assertion is the line ~1080 contract, which this single helper fix now satisfies. The other `ProcessBuilder`/`.start` sites all delegate to `drain-process` and read its returned map; the line ~1083 `.destroyForcibly` is a fire-and-forget cleanup with no following assertion.

## Quality gates

- `cd implementation/test-quiet && clojure -M:test` → **30 tests / 110 assertions, 0 failures / 0 errors** (matches expected).
- **Stability loop: 18/18 consecutive green** runs of `clojure -M:test`, each executed **under 6 concurrent CPU burners** to stress the load-sensitive reap race (plus 2 earlier standalone green passes = 20 total). All 30/110, 0/0.
- Full shared-harness suite `cd implementation && npm run test:cljs` → **8460 tests / 39074 assertions, 0 failures / 0 errors** (170s).
- Note: local green is necessary but not sufficient for a load-sensitive flake — PR CI on Linux/under-load is the real confirmation.

## Stance

Pre-alpha, no shims. Correctness + good-practice: fix the race at its single ownership point (the helper), not by teaching callers to poll after the fact or by masking with retries.
