### PR TITLE
fix(test): scoped keyword-hygiene point fixes — taxonomy kind, retired ns, src-shipped stub, linter root (rf2-mk0idr)

### DIFF
--- a/docs/api/re-frame.http.md
+++ b/docs/api/re-frame.http.md
@@ -347,7 +347,7 @@ Test-support surface for driving the pipeline without the network: canned-reply 
   ```
 - **Description**: Lexical-scope stubbing.
   - `route-map` is `{[<method> <url>] {:reply {:ok <value>}}}` (success) or `{[<method> <url>] {:reply {:failure <failure-map>}}}` (failure).
-  - Inside the body, requests matching a stubbed route bypass the real client: the helper registers a per-scope stub fx (a process-unique `:rf.http/managed-test-stub-<n>` id, so nested scopes compose) and installs the matching `:rf.http/managed` override for the body's dynamic extent. Plain `dispatch-sync` calls auto-route by method + URL with no manual `:fx-overrides`; a per-call `:fx-overrides` still wins.
+  - Inside the body, requests matching a stubbed route bypass the real client: the helper registers a per-scope stub fx (a process-unique `:rf.test/managed-http-stub-<n>` id under the test-runner-internal `:rf.test/*` fx-stub family, so nested scopes compose) and installs the matching `:rf.http/managed` override for the body's dynamic extent. Plain `dispatch-sync` calls auto-route by method + URL with no manual `:fx-overrides`; a per-call `:fx-overrides` still wins.
   - Routes match against the post-`:before` request (the method + URL the pipeline would actually issue). A request with no matching route receives a synthesised `:rf.http/transport` failure reply.
   - The façade macro requires `re-frame.http.test-support` in the require closure — without it the call raises `:rf.error/http-artefact-missing`.
 

--- a/implementation/core/test/re_frame/cofx_cljs_test.cljc
+++ b/implementation/core/test/re_frame/cofx_cljs_test.cljc
@@ -583,12 +583,12 @@
            (rf/reg-cofx :rf.route/some-subsystem-fact
              {:recordable? true :provided? true}))
         "an `rf.X/*` (subsystem-shaped) id registers without throwing")
-    (is (= :rf.app/ambient-pref
-           (rf/reg-cofx :rf.app/ambient-pref
+    (is (= :rf.myapp/ambient-pref
+           (rf/reg-cofx :rf.myapp/ambient-pref
              {:doc "Lint would flag this app id; the registrar does not."}
              (fn [] "value")))
         "even an obviously app-shaped `rf.`-prefixed id is accepted at registration")
-    (is (some? (registrar/lookup :cofx :rf.app/ambient-pref))
+    (is (some? (registrar/lookup :cofx :rf.myapp/ambient-pref))
         "the `rf.`-prefixed registration is present in the registry")))
 
 ;; ===========================================================================

--- a/implementation/http/src/re_frame/http/test_support.cljc
+++ b/implementation/http/src/re_frame/http/test_support.cljc
@@ -573,10 +573,15 @@
 (defonce ^:private scope-stub-counter (atom 0))
 
 (defn- next-scope-stub-id
-  "Mint a process-unique `:rf.http/managed-test-stub-<n>` fx-id for one
-  `with-managed-request-stubs*` scope."
+  "Mint a process-unique `:rf.test/managed-http-stub-<n>` fx-id for one
+  `with-managed-request-stubs*` scope. The id lives under the reserved
+  test-runner-internal `:rf.test/*` fx-stub family (Conventions §Reserved
+  namespaces) — NOT the fixed-and-additive `:rf.http/*` reserved namespace,
+  whose member set is closed by Spec change and must never be minted into at
+  runtime. (The stable, documented `:fx-overrides` target keeps its own
+  `:rf.http/managed-test-stub` id; only this per-scope variant is minted.)"
   []
-  (keyword "rf.http" (str "managed-test-stub-" (swap! scope-stub-counter inc))))
+  (keyword "rf.test" (str "managed-http-stub-" (swap! scope-stub-counter inc))))
 
 (defn with-managed-request-stubs*
   "Function form: install stubs, route `:rf.http/managed` through them for

--- a/implementation/resources/test/re_frame/resources_revision_substrate_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_revision_substrate_cljs_test.cljc
@@ -190,7 +190,7 @@
                        (state/entry-start-load
                          {:generation 3 :work-id [:w 2] :request-id "r" :owner :o}))
           rec-rev  (state/entry-revision loading)
-          settled  (state/entry-failed loading {:error {:kind :rf.http/http-404}})]
+          settled  (state/entry-failed loading {:error {:kind :rf.http/http-4xx}})]
       (is (= :loading (:status loading)) "first load — no usable data yet")
       (is (= :error (:status settled)) "first-load failure → :error")
       (is (nil? (:data settled)))


### PR DESCRIPTION
Scoped keyword-hygiene point fixes from the 2026-07-09 keyword audit (finding F8, rf2-mk0idr). Per the bead's authoritative SCOPE TRIM (Mike): land the point fixes only — no mass migration of ad-hoc `:rf.<fixture>/*` test namespaces, and deliberate negative-test vocabulary (`:rf.egress/publik`, `:rf.scope/sesssion`, …) is CORRECT and stays.

## The four point fixes

1. **Taxonomy kind** — `implementation/resources/test/.../resources_revision_substrate_cljs_test.cljc`: the `entry-failed` first-load fixture modelled `{:kind :rf.http/http-404}`, which is not a member of the closed 8-kind managed-HTTP failure taxonomy. The machinery treats `:kind` opaquely, so the test passed while asserting an impossible runtime value. Changed to the taxonomy member `:rf.http/http-4xx`.

2. **Retired namespace** — `implementation/core/test/re_frame/cofx_cljs_test.cljc`: the `rf-prefixed-id-is-not-a-registration-time-collision` test used `:rf.app/ambient-pref` to show that an "obviously app-shaped `rf.`-prefixed id" registers cleanly. `:rf.app/*` is a RETIRED EP-0013 namespace (not reserved or emitted by the current model). Renamed to `:rf.myapp/ambient-pref`, which preserves the test's intent (a consumer app squatting under the reserved root — exactly what lint flags) without invoking a retired namespace.

4. **Src-shipped stub minting** — `implementation/http/src/re_frame/http/test_support.cljc`: `next-scope-stub-id` dynamically minted `:rf.http/managed-test-stub-<n>` ids with a runtime counter INTO the `:rf.http/*` reserved namespace, whose member set is fixed-and-additive by Spec change and must never be minted into at runtime. Relocated the per-scope id to the purpose-built test-runner-internal `:rf.test/*` fx-stub family (Conventions §Reserved namespaces → "Test-runner-internal events and fx-stub ids") as `:rf.test/managed-http-stub-<n>`. The scoped id is process-unique and referenced only internally by `with-managed-request-stubs*`; the stable, documented `:fx-overrides` target `:rf.http/managed-test-stub` is UNCHANGED (touching it would be a large cross-cutting change to the story tool + specs, out of scope). One docs prose line (`docs/api/re-frame.http.md`) updated to match the new scoped id — a direct consequence of the code change.

5. **Collision-linter root matching (verify only)** — swept `scripts/` + `tools/` + `implementation/` for reserved-root checks. Every reserved-root matcher uses the EXACT idiom `(= ns "rf")` OR `(str/starts-with? ns "rf.")` — `tools/xray/.../app_db_diff_helpers.cljc` `reserved-namespace-key?`, `tools/re-frame2-pair-mcp/.../reserved_frame_guard.cljs`, and `implementation/machines/.../{transition,internal_events}.cljc`. No loose bare-`"rf"` prefix-match exists anywhere, so confusable roots (`:rf-l5q3/*`, `:rf-tvu99/*`, `:rf2/*`) are correctly NOT flagged. **Verdict: already exact — no linter change needed.** (Item 3's mass migration skipped per scope trim.)

## Quality gates

All foreground, all green:

- `cd implementation/resources && clojure -M:test` → 622 tests, 6217 assertions, **0 failures, 0 errors**
- `cd implementation/http && clojure -M:test` → 467 tests, 3660 assertions, **0 failures, 0 errors**
- `cd implementation && npm run test:cljs` → 8460 tests, 39074 assertions, **0 failures, 0 errors**

## Stance

Pre-alpha, no back-compat shims. CORRECTNESS + GOOD-PRACTICE, no gold plating: only the four enumerated point fixes; the stable public stub id and all deliberate negative-test vocabulary are left intact.
