### PR TITLE
docs(core,epoch,machines): fix comments/docstrings naming non-existent error/trace ids (rf2-ysu34k)

### DIFF
--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -1205,10 +1205,10 @@
   Per Spec 013 §Drain integration: `(:db effects)` here is the
   FLOW-AUGMENTED app-db value — the OUTERMOST flows-after-interceptor has
   already rewritten the pending `:db` effect by the time the chain returns.
-  So `:event/db-changed` reflects the flow-derived db and fires AFTER
+  So `:rf.event/db-changed` reflects the flow-derived db and fires AFTER
   `:rf.flow/computed` (per Spec 009 §Canonical per-event trace sequence).
 
-  On rollback, a second `:event/db-changed` (+ `frame-state-changed`) trace
+  On rollback, a second `:rf.event/db-changed` (+ `frame-state-changed`) trace
   is emitted for the restored state with `:phase :rollback` so listeners
   (subs, 10x, pair-tools) observe the post-rollback frame-state without
   ambiguity — the trace stream's load-bearing ordering is `:db-changed
@@ -1821,7 +1821,7 @@
   child dispatches. User fxs see it at `(:envelope m)`.
 
   Per rf2-twt7m Change 2: the full effects map is also threaded to
-  `do-fx` (the `:effects` opt) so the terminating `:event/do-fx` trace
+  `do-fx` (the `:effects` opt) so the terminating `:rf.fx/do-fx` trace
   marker can stamp `:fx` (the returned vector) and `:db-present?`
   (whether the handler returned a `:db` slot). The value of `:db`
   is NOT stamped — App-db diff traces already carry slice changes.
@@ -2376,8 +2376,8 @@
   handler opts out. `:call-site` and `:dispatch-id` are inherited from
   the parent scope (bound by `process-event!` outer wrapper) per
   `inherit-scope`. Scope covers the interceptor chain, db commit, flows,
-  and fx walk — covering :event/db-changed, :event/do-fx, :rf.fx/handled
-  (the inner fx scope re-binds), :sub/run (sub recompute re-binds),
+  and fx walk — covering :rf.event/db-changed, :rf.fx/do-fx, :rf.fx/handled
+  (the inner fx scope re-binds), :rf.sub/run (sub recompute re-binds),
   :rf.error/* (every error emit inside the chain).
 
   Per rf2-rirbq: `start-ms` is captured at the very start of cascade
@@ -2807,7 +2807,7 @@
   `:always` microsteps do not allocate a new epoch.
 
   `settle!` itself skips an empty buffer (a rejected/aborted dispatch that
-  never fired `:event/run-start`), so a no-handler / frame-destroyed early
+  never fired `:rf.event/run-start`), so a no-handler / frame-destroyed early
   exit commits no misleading record. rf2-erczwd: a rejected dispatch still
   buffers a frame-stamped, dispatch-id-bearing ERROR trace (`:no-such-handler`
   / `:frame-destroyed`), so the buffer is NOT empty at this seam. Threading the
@@ -3180,7 +3180,7 @@
       (interop/next-tick (fn [] (drain-try! frame-id))))))
 
 (defn- emit-dispatched-trace!
-  "Emit the :event :event/dispatched trace event for this envelope. Per
+  "Emit the :rf.event :rf.event/dispatched trace event for this envelope. Per
   Spec 009 §Dispatch correlation, :dispatch-id and :parent-dispatch-id
   ride on :tags. Per Spec 002 §Dispatch origin tagging, :origin rides
   on :tags too. Per rf2-1ve9h (Mike-approved Option A, 2026-05-28), the
@@ -3195,7 +3195,7 @@
   Per rf2-qsjda: queue-time `:rf.trace/no-emit?` consideration. The
   `*handler-scope*` binding's `:no-emit?` slot doesn't exist yet at
   enqueue time, so we read the flag directly off the target handler's
-  registration meta and short-circuit the `:event/dispatched` emit
+  registration meta and short-circuit the `:rf.event/dispatched` emit
   when set. Without this, a Xray-style bookkeeping handler would
   have its enqueue trace delivered to listeners (re-entering the
   consumer's trace-cb) before the handler-scope binding ever took

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -253,7 +253,7 @@
                      :input-kind    input-kind
                      :input-signals (or input-signals []))
         input-fn (assoc :input-fn input-fn)))
-    ;; Per Spec 009 §:op-type vocabulary: :sub/create marks subscription
+    ;; Per Spec 009 §:op-type vocabulary: :rf.sub/create marks subscription
     ;; materialisation — emitted at registration time so tools see when
     ;; the sub becomes available in the registry.
     (trace/emit! :rf.sub :rf.sub/create
@@ -776,7 +776,7 @@
       Layer-2 with a single `:<-` input gets the same fixed-arity-1
       treatment (the dominant layer-2 shape). Layer-2+ with ≥2 inputs
       uses the vec-of-inputs varargs shape.
-    - `validate-and-trace`  — Spec 009 :sub/run trace emit, perf bracket,
+    - `validate-and-trace`  — Spec 009 :rf.sub/run trace emit, perf bracket,
       Spec 010 step 6 validation, error contract
       (`:replaced-with-default` on throw).
 
@@ -1439,12 +1439,12 @@
         ;; reference within the same call is also a single resolution.
         (do (swap! memo assoc query-v nil) nil)
         (do
-          ;; Per Spec 009 §:op-type vocabulary: :sub/run marks a sub recompute.
+          ;; Per Spec 009 §:op-type vocabulary: :rf.sub/run marks a sub recompute.
           ;; The pure compute-sub form fires the same op-type as the reactive
           ;; recompute path so tools can observe both call sites uniformly.
           ;;
           ;; Per rf2-l1jz8 — the reactive recompute path (subs.memo/validate-
-          ;; and-trace) enriches its `:sub/run` tag with value-change +
+          ;; and-trace) enriches its `:rf.sub/run` tag with value-change +
           ;; cascade attribution (`:value-changed?` / `:prev-value` /
           ;; `:value` / `:cascade?` / `:cause-sub`). `compute-sub` deliberately
           ;; bypasses the per-frame reactive cache (it's the pure-snapshot
@@ -1452,7 +1452,7 @@
           ;; diff for `:value-changed?` and NO reactive context to attribute a
           ;; cascade against — each DISTINCT `:<-` input is re-resolved fresh
           ;; against the supplied `db`, not observed as a changed upstream
-          ;; signal. It therefore emits the BASE `:sub/run` shape only;
+          ;; signal. It therefore emits the BASE `:rf.sub/run` shape only;
           ;; attribution is a reactive-path concern. Consumers (Xray) read
           ;; attribution off the reactive epoch records, never off
           ;; compute-sub emissions.

--- a/implementation/core/src/re_frame/subs/memo.cljc
+++ b/implementation/core/src/re_frame/subs/memo.cljc
@@ -44,7 +44,7 @@
 
 ;; ---- recompute attribution sentinel + cause-sub resolution ---------------
 ;;
-;; The `:sub/run` trace carries value-change + cascade
+;; The `:rf.sub/run` trace carries value-change + cascade
 ;; attribution so Xray's Reactive panel can populate its "SUBS WHOSE
 ;; VALUE CHANGED" and "SUBS THAT CASCADED" sections. The memo wrapper
 ;; already holds the prior computed value and prior input value(s) in its
@@ -132,7 +132,7 @@
      return value against the sub's `:schema` meta. Failures emit
      :rf.error/schema-validation-failure and yield nil (recovery
      :replaced-with-default).
-  3. Spec 009 §:op-type vocabulary — emit :sub/run for the recompute.
+  3. Spec 009 §:op-type vocabulary — emit :rf.sub/run for the recompute.
      The memo-hit path does NOT emit (per Spec 006 §No-op via value
      equality). The emit fires AFTER (1)+(2) so the trace can carry the
      COMPUTED value and value-change / cascade attribution (see
@@ -144,7 +144,7 @@
 
   ## Recompute attribution (dev-only)
 
-  When `interop/debug-enabled?` the `:sub/run` tag carries:
+  When `interop/debug-enabled?` the `:rf.sub/run` tag carries:
 
     :value-changed?  — `(not= prev-value computed)`. The `::unset`
                        sentinel on the first recompute reports `true`.
@@ -193,7 +193,7 @@
   `:prev-value` and `:value` are wire-value-sensitive app data, but they
   are emitted RAW here and redacted DOWNSTREAM by the existing
   `re-frame.classification/project-sub-tags` chokepoint that `re-frame.trace/
-  build-event` already runs for every `:sub/run` event. That chokepoint
+  build-event` already runs for every `:rf.sub/run` event. That chokepoint
   resolves the sub's sensitive/large state from process-scoped marks +
   the sub-output propagation table — NEVER by reading the frame's app-db
   container.
@@ -224,9 +224,9 @@
   [body-fn in-vals query-id query-v frame-id input-signals sub-meta
    prev-value prev-in-vals vector-inputs?]
   ;; Publish the sub's HandlerScope for the duration of body-fn
-  ;; invocation + validation + the `:sub/run` emit. Per Spec 009
+  ;; invocation + validation + the `:rf.sub/run` emit. Per Spec 009
   ;; §:rf.trace/trigger-handler the sub's source-coord rides every emit
-  ;; (`:sub/run` success, `:rf.error/sub-exception` / schema-validation /
+  ;; (`:rf.sub/run` success, `:rf.error/sub-exception` / schema-validation /
   ;; transitive sub-miss errors). The emit MUST sit inside the scope.
   ;;
   ;; `vector-inputs?`: when true, the body ALWAYS receives the
@@ -486,7 +486,7 @@
             (emit-sub-skip! query-id query-v frame-id sub-meta [])
             @last-result)
           ;; Capture the prior cells BEFORE the recompute so the
-          ;; `:sub/run` attribution can report value-change
+          ;; `:rf.sub/run` attribution can report value-change
           ;; against the last computed value. Layer-1 has no upstream
           ;; sub inputs, so `input-signals` is `[]` and `prev-in-vals`
           ;; is irrelevant to cause-sub resolution (a layer-1 recompute
@@ -542,7 +542,7 @@
           (do
             (emit-sub-skip! query-id query-v frame-id sub-meta (vec input-signals))
             @last-result)
-          ;; Capture prior cells BEFORE the recompute for the `:sub/run`
+          ;; Capture prior cells BEFORE the recompute for the `:rf.sub/run`
           ;; attribution. `prev-in-vals` is the last-seen
           ;; single input value in singleton-list shape (matching the
           ;; `(list v0)` `in-vals` form) so `changed-cause-sub` can diff
@@ -604,7 +604,7 @@
           (do
             (emit-sub-skip! query-id query-v frame-id sub-meta (vec input-signals))
             @last-result)
-          ;; Capture prior cells BEFORE the recompute for the `:sub/run`
+          ;; Capture prior cells BEFORE the recompute for the `:rf.sub/run`
           ;; attribution. `prev-in-vals` is the last-seen
           ;; input-value seq (parallel to `input-signals`), which
           ;; `changed-cause-sub` diffs positionally to name the upstream

--- a/implementation/core/src/re_frame/trace/tooling.cljc
+++ b/implementation/core/src/re_frame/trace/tooling.cljc
@@ -304,7 +304,7 @@
 ;;   - For `:rf.registry/handler-replaced`: same shape composed from the
 ;;     new metadata. Re-emit suppressed iff matches the prior entry.
 ;;   - For `:rf.registry/handler-cleared`: the shape is the sentinel
-;;     `:rf.trace.tooling/cleared`. A second clear-of-a-cleared id
+;;     `::cleared` (= `:re-frame.trace.tooling/cleared`). A second clear-of-a-cleared id
 ;;     (e.g. a double-clear) is suppressed.
 ;;
 ;; The same dedup keys both `:rf.registry/handler-registered` and

--- a/implementation/core/test/re_frame/on_error_cljs_test.cljc
+++ b/implementation/core/test/re_frame/on_error_cljs_test.cljc
@@ -328,7 +328,7 @@
 ;;   - :rf.error/fx-handler-exception — recovers (the fx is skipped,
 ;;       siblings still fire, app-db is NOT rolled back).
 ;;   - :rf.error/no-such-fx / :rf.error/override-fallthrough /
-;;     :rf.error/no-such-cofx — invalid operations; the listener fires and
+;;     :rf.error/unregistered-cofx — invalid operations; the listener fires and
 ;;       the framework applies its built-in recovery.
 ;; ============================================================================
 

--- a/implementation/core/test/re_frame/on_error_elision_prod_test.cljs
+++ b/implementation/core/test/re_frame/on_error_elision_prod_test.cljs
@@ -294,7 +294,7 @@
 ;; (`:rf.error/fx-handler-exception`), an unknown fx-id
 ;; (`:rf.error/no-such-fx`), an override misconfiguration
 ;; (`:rf.error/override-fallthrough`), and an unknown cofx-id
-;; (`:rf.error/no-such-cofx`) were previously dev-trace-ONLY, so they lost
+;; (`:rf.error/unregistered-cofx`) were previously dev-trace-ONLY, so they lost
 ;; their diagnostic entirely under `:advanced` + `goog.DEBUG=false` — even
 ;; though Spec 009 catalogues them as production-reachable and Spec 011 maps
 ;; fx-handler-exception to a 500 off the always-on substrate. Now they fan

--- a/implementation/core/test/re_frame/success_path_trigger_handler_test.clj
+++ b/implementation/core/test/re_frame/success_path_trigger_handler_test.clj
@@ -320,7 +320,7 @@
 ;; handler's.
 ;;
 ;; The framework's stock cofx surface emits no success-path trace of its
-;; own (`cofx.cljc` only emits `:rf.error/no-such-cofx` on the miss
+;; own (`cofx.cljc` only emits `:rf.error/unregistered-cofx` on the miss
 ;; path). To exercise the success-path binding contract, the test
 ;; registers a cofx whose body itself calls `trace/emit!` — exactly the
 ;; pattern an instrumented cofx (http, persistence, websocket) would

--- a/implementation/epoch/src/re_frame/epoch/capture.cljc
+++ b/implementation/epoch/src/re_frame/epoch/capture.cljc
@@ -9,7 +9,7 @@
                           `:sub-runs`, `:renders`, `:effects` slots.
     find-trigger-event -- one walk extracting `:event-id` + `:event`
                           + `:dispatch-id` + `:rf.cofx` from the cascade's
-                          first `:event/run-start`, with a `:event-id`-only
+                          first `:rf.event/run-start`, with a `:event-id`-only
                           fallback.
 
   Per rf2-0wi86 Phase-2 seam B: this namespace owns the cascade-buffer
@@ -104,8 +104,8 @@
 
 ;; ---- sub-run ops (rf2-wi900) ----------------------------------------------
 ;;
-;; The subs sibling of render-ops. A `:sub/run` (reactive recompute) or
-;; `:sub/skip` (memo hit) fires when a reaction is derefed — and reactions
+;; The subs sibling of render-ops. A `:rf.sub/run` (reactive recompute) or
+;; `:rf.sub/skip` (memo hit) fires when a reaction is derefed — and reactions
 ;; deref LAZILY at React render time, which Reagent batches onto a later
 ;; tick AFTER the causing cascade settled. So like a render, a sub-run
 ;; arriving with no in-flight cascade for its frame is a post-settle async
@@ -147,7 +147,7 @@
 
 (defn in-flight-cascade?
   "True when the frame's in-flight capture buffer already holds an
-  `:event/run-start` emit — the canonical signal that a cascade has
+  `:rf.event/run-start` emit — the canonical signal that a cascade has
   begun draining into this buffer. The single home for the
   'is a cascade in flight for this frame?' question; both the
   post-settle back-fill routing below and
@@ -185,7 +185,7 @@
   also skipped, so a snapshotted/restored/db-replaced emit cannot leak
   into the next cascade's harvested record.
 
-  Per rf2-qs6dl: a view-render op (`:view/render` / `:rf.view/rendered`
+  Per rf2-qs6dl: a view-render op (`:rf.view/render` / `:rf.view/rendered`
   / `:rf.view/rendered-cap-reached`) that arrives with no in-flight
   cascade for its frame is a post-settle async re-render — it fired at
   React commit time, AFTER the causing cascade settled. Routing it into
@@ -196,7 +196,7 @@
   that cascade and is buffered as before.
 
   Per rf2-wi900: the identical post-settle timing applies to reactive
-  sub-runs (`:sub/run` / `:rf.sub/skip`) — reactions recompute lazily at
+  sub-runs (`:rf.sub/run` / `:rf.sub/skip`) — reactions recompute lazily at
   React deref time, AFTER the causing cascade settled, so a sub-run with
   no in-flight cascade is back-filled into the causing epoch via the
   `:epoch/record-sub-run!` hook (sibling of `:epoch/record-render!`). An
@@ -220,7 +220,7 @@
           frame-id (or (:frame tags)
                        (:frame event))]
       ;; rf2-vh1k3 — learn which subs each view reads from the
-      ;; `:reader-render-key` stamp the runtime sets on a `:sub/run`
+      ;; `:reader-render-key` stamp the runtime sets on a `:rf.sub/run`
       ;; that recomputes SYNCHRONOUSLY inside a view's render (the mount /
       ;; first-paint deref). A post-settle reactive recompute fires
       ;; outside any render binding and carries no stamp, so this learns
@@ -279,7 +279,7 @@
           ;; Out-of-cascade orphan — drop from the capture buffer (rf2-avvwm).
           ;; An emit with NO cascade context (no in-flight cascade for the
           ;; frame AND no `:dispatch-id` on its tags) belongs to no cascade:
-          ;; a frame-lifecycle emit (`:frame/created` / `:frame/re-registered`)
+          ;; a frame-lifecycle emit (`:rf.frame/created` / `:rf.frame/re-registered`)
           ;; fired between the last settled event and the next dequeue, or a
           ;; registry-time emit. Per Spec 009 §Dispatch correlation it stays
           ;; UNCORRELATED — neither a new epoch nor folded into another
@@ -294,7 +294,7 @@
           ;;
           ;; A `:dispatch-id`-bearing emit is ALWAYS buffered even when no
           ;; cascade is in flight for THIS frame at the instant of the emit:
-          ;; a child's `:event/dispatched` marker fires during the PARENT's
+          ;; a child's `:rf.event/dispatched` marker fires during the PARENT's
           ;; do-fx carrying the child's id, and rides the child's later
           ;; `harvest-buffer-for-event!` settle.
           (and (not (in-flight-cascade? frame-id))
@@ -320,8 +320,8 @@
 ;;
 ;; The walk visits the in-flight buffer for the frame at the moment the
 ;; substrate fires its render. Returns `{:cause-event-id <eid>
-;; :cause-subs <sub-ids vector>}`. The first `:event/run-start` we see
-;; supplies `:cause-event-id`; every `:sub/run` contributes to
+;; :cause-subs <sub-ids vector>}`. The first `:rf.event/run-start` we see
+;; supplies `:cause-event-id`; every `:rf.sub/run` contributes to
 ;; `:cause-subs` (deduped, preserving first-seen order). Empty buffer
 ;; (render outside any run — e.g. fixture-driven direct invocations,
 ;; or React's post-settle async batch) yields `{}` so consumers see the
@@ -337,12 +337,12 @@
 
   Return-map slots:
 
-    :cause-event-id — the event-id of the first :event/run-start seen
+    :cause-event-id — the event-id of the first :rf.event/run-start seen
                       in the run (i.e. the dispatching run's
                       trigger event).
     :cause-subs     — distinct sub-ids that ran in the run so far,
                       in first-seen order, capped at sub-cap.
-    :value-changed-subs — the SUBSET of subs whose :sub/run reported
+    :value-changed-subs — the SUBSET of subs whose :rf.sub/run reported
                       :rf.sub/value-changed? true (rf2-8wrzz.1). A `set`
                       of sub-ids, independently bounded by sub-cap: the
                       walk gates value-changed accumulation on its own
@@ -366,7 +366,7 @@
   ([frame-id sub-cap]
    (when interop/debug-enabled?
      (let [events  (state/buffer-for frame-id)
-           ;; Single reduce: capture first :event/run-start, accumulate
+           ;; Single reduce: capture first :rf.event/run-start, accumulate
            ;; distinct sub-ids in first-seen order up to `sub-cap`, and
            ;; count the existing :rf.view/rendered emits so the views.cljs
            ;; emit site can enforce the per-run view-render cap.
@@ -433,16 +433,16 @@
 ;; `project-all`'s fused reducer (the settle-time projection) and the
 ;; post-settle back-fill in `re-frame.epoch.listeners` (which projects a
 ;; single late-arriving event into the same row shape). Keeping the row
-;; literal in ONE place means a future field added to the `:sub/run` /
-;; `:view/render` projection lands on both surfaces automatically, avoiding
+;; literal in ONE place means a future field added to the `:rf.sub/run` /
+;; `:rf.view/render` projection lands on both surfaces automatically, avoiding
 ;; a lockstep maintenance hazard across two duplicate row literals.
 
 (defn sub-run-row
   "Project a `:rf.sub/run` trace event into its structured `:sub-runs`
-  row, or nil for any non-`:sub/run` op (a `:rf.sub/skip` memo hit
+  row, or nil for any non-`:rf.sub/run` op (a `:rf.sub/skip` memo hit
   projects no `:sub-runs` row — it rides only `:trace-events`).
 
-  Per rf2-l1jz8 the reactive recompute path enriches the `:sub/run` tag
+  Per rf2-l1jz8 the reactive recompute path enriches the `:rf.sub/run` tag
   with value-change + cascade attribution (`:value-changed?` /
   `:prev-value` / `:value` / `:cascade?` / `:cause-sub`); they are
   threaded onto the structured projection so Xray's Reactive panel reads
@@ -569,8 +569,8 @@
   Per-projection contracts preserved verbatim (no schema change):
 
     :sub-runs — Spec-Schemas §`:rf/epoch-record`. One entry per
-      `:sub/run` trace event. Cache-hit subs (rf2-719e fast-path) do
-      NOT emit `:sub/run` and are correctly absent.
+      `:rf.sub/run` trace event. Cache-hit subs (rf2-719e fast-path) do
+      NOT emit `:rf.sub/run` and are correctly absent.
 
     :renders — Spec-Schemas §`:rf/epoch-record` and Spec 004 §Render-tree
       primitives (rf2-t5tx Option C / rf2-piag). One entry per
@@ -607,7 +607,7 @@
                       tags (:tags ev)]
                   (cond
                     ;; Per rf2-l1jz8 — the reactive recompute path enriches
-                    ;; the `:sub/run` tag with value-change + cascade
+                    ;; the `:rf.sub/run` tag with value-change + cascade
                     ;; attribution; `sub-run-row` threads them onto the
                     ;; structured projection (shared with the post-settle
                     ;; back-fill in `listeners`).
@@ -662,7 +662,7 @@
 ;; ---- trigger-event resolution --------------------------------------------
 
 (defn find-trigger-event
-  "Walk the buffered events to find the first :event/run-start trace.
+  "Walk the buffered events to find the first :rf.event/run-start trace.
   That carries the `:event`, `:event-id`, `:dispatch-id`, the
   post-generation `:rf.cofx` replay token, AND (rf2-yigokd) the envelope's
   serializable `:fx-overrides` / `:interceptor-overrides` for the cascade.
@@ -707,7 +707,7 @@
   elided — that would starve the epoch-scoped Views + Trace panels.
 
   Per rf2-txrq9: single-walk reduction over `events`. We accumulate the
-  first `:event/run-start`, the first fallback `:event-id`, AND
+  first `:rf.event/run-start`, the first fallback `:event-id`, AND
   (rf2-cheez6.1, below) the cascade's mid-drain machine-minted generator
   facts in one traversal and prefer the run-start.
 
@@ -812,7 +812,7 @@
                 ;; Per rf2-ee38b (§correctness): the fallback arm does NOT
                 ;; pin `:dispatch-id`. Spec-Schemas §`:rf/epoch-record`
                 ;; documents `:dispatch-id` as "pinned from the
-                ;; `:event/run-start` tag … absent when the cascade carried
+                ;; `:rf.event/run-start` tag … absent when the cascade carried
                 ;; no dispatch-id (rejected dispatch / pre-run-start halt)"
                 ;; — the strictly-spec shape for a no-run-start cascade is
                 ;; ABSENT. Pinning `:dispatch-id` here would surface the id

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
@@ -484,7 +484,7 @@
      :inner-event      (route-inner-event event)}))
 
 (defn- start-cause
-  "Compute the `:rf.machine.start/cause` enum for a `maybe-boot` that ran
+  "Compute the `:cause` enum (on the `:rf.machine/started` trace) for a `maybe-boot` that ran
   the initial-entry cascade. Three-way:
 
     - `:spawned`  — the handler found a snapshot ALREADY in runtime-db (the


### PR DESCRIPTION
## Summary

Comment/docstring hygiene sweep (keyword audit F7, rf2-ysu34k). **Comments and docstrings only — zero behaviour change.** Fixes prose that named framework ids that do not exist, sending grep-driven readers (and AI agents) into dead ends.

### (1) `:rf.error/no-such-cofx` → `:rf.error/unregistered-cofx`
The real emitted id is `:rf.error/unregistered-cofx` (`core/src/re_frame/cofx.cljc:508`); `:rf.error/no-such-cofx` exists in **no** src or spec file. Fixed the three **current-tense** comments that name the live id:
- `core/test/re_frame/on_error_cljs_test.cljc` (also corrected the claim listing it as a production-reachable error)
- `core/test/re_frame/on_error_elision_prod_test.cljs`
- `core/test/re_frame/success_path_trigger_handler_test.clj` (the one wrongly asserting `cofx.cljc` only emits `:rf.error/no-such-cofx`)

**Kept the three deliberate tombstones** — `source_coord_cljs_test.cljs:79`, `source_coord_test.cljc:142`, `trigger_handler_coord_test.clj:146` — which correctly describe the *removed* `inject-cofx` (EP-0017 A.3) that historically emitted `:rf.error/no-such-cofx` (the `trigger_handler_coord` comment names `:rf.error/unregistered-cofx` as its "successor"). These are historical/negative references, not stale claims.

### (2) `trace/tooling.cljc:307`
`:rf.trace.tooling/cleared` (a non-existent namespace) → `::cleared` (= `:re-frame.trace.tooling/cleared`), the sentinel the code actually uses (lines 349-377).

### (3) `machines/.../lifecycle_fx/registration.cljc:487`
Docstring `:rf.machine.start/cause` → `:cause` — the real bare key stamped on the `:rf.machine/started` trace (`{... :cause (start-cause ctx)}`, line 565-570).

### (4) Trace-operation-id shorthands → canonical `:rf.*`
Normalised bare shorthands in `subs.cljc`, `subs/memo.cljc`, `epoch/capture.cljc`, `router.cljc` against the Spec 009 §op-type vocabulary: `:sub/run`→`:rf.sub/run`, `:sub/create`→`:rf.sub/create`, `:sub/skip`→`:rf.sub/skip`, `:event/run-start`→`:rf.event/run-start`, `:event/dispatched`→`:rf.event/dispatched`, `:event/db-changed`→`:rf.event/db-changed`, `:view/render`→`:rf.view/render`, `:frame/created`→`:rf.frame/created`, `:frame/re-registered`→`:rf.frame/re-registered`, and **`:event/do-fx`→`:rf.fx/do-fx`** (a namespace correction — the real op is `:rf.fx/do-fx`, op-type `:rf.fx`, per Spec 009:154/469/535/969, not `:rf.event/*`).

Left untouched: `router.cljc:956-957` (`:error`/`:event`/`:event-id`/… are the flat always-on error record's **map keys**, not a trace-op id).

## Quality gates
- `npm run test:cljs` — **8460 tests, 39074 assertions, 0 failures, 0 errors** (proves comment-only edits broke nothing).
- Diff is a clean 51/51 line-for-line swap; verified every changed line is a `;;` comment or docstring prose — no code, no data-string (`:description`) edits.
- `rg` confirms zero remaining non-deliberate hits for each stale spelling in the cited files.

## Stance
Pre-alpha, no shims. CLARITY + CORRECTNESS. Comment/docstring-only, no behaviour change, suites untouched and green.

## Note for reviewers (residual, out of scope)
Bare `:sub/run` / `:view/render` shorthands also appear in **non-cited** files — `classification.cljc`, `views.cljs`, `substrate/spine.cljs`, `trace.cljc`, `trace/cascade.cljc` (comments), and `late_bind/directory.cljc` (inside `:description` **code data-strings**, so out of scope for a comment-only bead). These were left per this bead's "cited files only" boundary and can be finished in a trivial follow-up.