### PR TITLE
docs(api): editorial pass for clarity and readability across the API reference

### DIFF
--- a/docs/api/re-frame.adapter.helix.md
+++ b/docs/api/re-frame.adapter.helix.md
@@ -1,6 +1,13 @@
 # re-frame.adapter.helix
 
-`re-frame.adapter.helix` binds re-frame2 to the Helix React substrate. It ships as its own artefact (`day8/re-frame2-helix`) and depends on `re-frame.core`, never the reverse. A Helix app requires this namespace and passes its `adapter` Var into `(rf/init! ...)`. This namespace carries the Helix-shaped hooks, the merged `frame-provider`, the view-wrapping seam, and the adapter spec; the substrate-agnostic carry and scoping primitives (`capture-frame`, `with-frame`, `with-new-frame`) live on [`re-frame.core`](re-frame.core.md). The surface mirrors the [UIx adapter](re-frame.adapter.uix.md) one-for-one. For choosing between substrates, see [Use UIx, Helix, or reagent-slim](../core/how-to/use-uix-helix-or-slim.md).
+`re-frame.adapter.helix` binds re-frame2 to the Helix React substrate. It ships as its own artefact (`day8/re-frame2-helix`) and depends on `re-frame.core`, never the reverse. A Helix app requires this namespace and passes its `adapter` Var into `(rf/init! ...)`. It exposes:
+
+- the Helix-shaped hooks `use-subscribe`, `use-resource-lease`, and `use-current-frame`;
+- the merged `frame-provider` component;
+- the `wrap-view` view-wrapping seam;
+- the `adapter` spec.
+
+The substrate-agnostic carry and scoping primitives (`capture-frame`, `with-frame`, `with-new-frame`) live on [`re-frame.core`](re-frame.core.md). The surface mirrors the [UIx adapter](re-frame.adapter.uix.md) one-for-one. For choosing between substrates, see [Use UIx, Helix, or reagent-slim](../core/how-to/use-uix-helix-or-slim.md).
 
 ```clojure
 (:require [re-frame.adapter.helix :as helix-adapter])
@@ -37,9 +44,9 @@
   (use-subscribe query-v) → current sub value
   (use-subscribe frame-kw query-v) → current sub value
   ```
-- **Description**: Hook-shaped equivalent of `subscribe` for Helix components. Returns the current sub value and re-renders the calling component when it changes.
-  - 1-arg form resolves the frame through the surrounding scope (dynamic-var, then React context); raises `:rf.error/no-frame-context` when no frame is in scope.
-  - 2-arg form pins an explicit frame id.
+- **Description**: The hook-shaped equivalent of `subscribe` for Helix components. Returns the current sub value and re-renders the calling component when it changes.
+  - The 1-arg form resolves the frame through the surrounding scope: dynamic-var first, then React context. It raises `:rf.error/no-frame-context` when no frame is in scope.
+  - The 2-arg form pins an explicit frame id.
 
 ### `use-resource-lease`
 
@@ -49,7 +56,7 @@
   (use-resource-lease descriptor) → nil
   (use-resource-lease descriptor opts) → nil
   ```
-- **Description**: Holds a resource liveness lease for the calling component's mounted lifetime. On mount dispatches `:rf.resource/ensure` with an app-minted `[:lease …]` owner; on unmount dispatches `:rf.resource/release-owner` for that lease. Returns nil — manages liveness only; read the data with `use-subscribe` on a `[:rf.resource/*]` query.
+- **Description**: Holds a resource liveness lease for the calling component's mounted lifetime. On mount it dispatches `:rf.resource/ensure` with an app-minted `[:lease …]` owner; on unmount it dispatches `:rf.resource/release-owner` for that lease. Returns nil: it manages liveness only. Read the data with `use-subscribe` on a `[:rf.resource/*]` query.
   - `descriptor` — resource-instance identity `{:resource … :scope … :params …}`.
   - `opts` — `:cause` (recorded on the ensure; defaults to `[:lease :mount]`) and `:frame` (pin to an explicit frame id, bypassing ambient resolution).
   - Without `:frame`, the frame resolves through the same chain as `use-subscribe`, raising `:rf.error/no-frame-context` when no frame is in scope.
@@ -66,7 +73,7 @@
   ```clojure
   (use-current-frame) → frame-kw, or :rf.frame/no-provider when no provider is above
   ```
-- **Description**: Raw React-context read of the surrounding `frame-provider`'s frame keyword. Returns `:rf.frame/no-provider` when no frame-provider sits above (never a synthesised default). Consults the React-context tier only, not the dynamic-var tier; for the full resolution chain use `(rf/current-frame-id)`.
+- **Description**: A raw React-context read of the surrounding `frame-provider`'s frame keyword. When no frame-provider sits above, it returns `:rf.frame/no-provider` — never a synthesised default. It consults the React-context tier only, not the dynamic-var tier; for the full resolution chain, use `(rf/current-frame-id)`.
 
 > **NOT USED** — no call sites found in `implementation/`, `examples/`, or `tools/`.
 
@@ -80,9 +87,9 @@
   ($ helix-adapter/frame-provider {:frame :session} child…)                        ;; SCOPE an existing frame
   ($ helix-adapter/frame-provider {:id :session :images [session-image]} child…)   ;; ENSURE create-if-absent / reuse
   ```
-- **Description**: The Helix-shaped merged frame provider, dispatched on the prop map. Children ride the `$` trailing-args channel — pass them after the prop map, as for any Helix component (no `:children` prop-map key).
-  - `{:frame …}` scopes an already-created frame; fails loud if absent (`:rf.error/frame-provider-frame-absent`). A nil `:frame` raises `:rf.error/no-frame-context`; a non-keyword raises `:rf.error/bad-frame-provider-arg`.
-  - `{:id …}` ensures a named frame (create-if-absent / reuse-no-reseed, `make-frame` opts, no destroy-on-unmount). A missing / nil / non-keyword `:id` raises `:rf.error/ensure-frame-provider-missing-id`.
+- **Description**: The Helix-shaped merged frame provider, dispatched on the prop map. Children ride the `$` trailing-args channel. Pass them after the prop map, as for any Helix component (there is no `:children` prop-map key).
+  - `{:frame …}` scopes an already-created frame; it fails loud if the frame is absent (`:rf.error/frame-provider-frame-absent`). A nil `:frame` raises `:rf.error/no-frame-context`; a non-keyword raises `:rf.error/bad-frame-provider-arg`.
+  - `{:id …}` ensures a named frame: create it if absent, or reuse it without re-seeding. This shape accepts `make-frame` opts and never destroys the frame on unmount. A missing, nil, or non-keyword `:id` raises `:rf.error/ensure-frame-provider-missing-id`.
 - **Example**:
   ```clojure
   ;; ENSURE shape at the render root: create the frame on first mount, seed it
@@ -100,7 +107,7 @@
   ```clojure
   (wrap-view id metadata user-fn) → wrapped fn
   ```
-- **Description**: Adapter-side source-coord injection. Wraps `user-fn` in a function component that injects `data-rf2-source-coord` on the rendered root DOM element in debug builds; production builds elide and return `user-fn` unchanged. The returned fn has the same call signature as `user-fn` and is suitable as a Helix component head.
+- **Description**: Adapter-side source-coord injection. Wraps `user-fn` in a function component that injects `data-rf2-source-coord` on the rendered root DOM element in debug builds. Production builds elide the injection and return `user-fn` unchanged. The returned fn has the same call signature as `user-fn` and is suitable as a Helix component head.
 - **Example**:
   ```clojure
   ;; Code-gen / scaffolding seam: wrap a component head so its root DOM element
@@ -120,7 +127,7 @@
   (flush-views!)
   (flush-views! f)
   ```
-- **Description**: Wraps React's `act()` for tests. Calls `(act f)`; the 0-arity form flushes pending effects. Returns nil.
+- **Description**: Wraps React's `act()` for tests. The 1-arity form calls `(act f)`; the 0-arity form flushes pending effects. Returns nil.
 - **Example**:
   ```clojure
   ;; Test-only: flush pending renders synchronously, returns nil.
@@ -135,7 +142,7 @@
   ```clojure
   (set-hiccup-emitter! f)
   ```
-- **Description**: Installs a render-tree → HTML fn. Parity with the Reagent and UIx adapters' late-bind seam.
+- **Description**: Installs a render-tree → HTML fn. This is the Helix side of the SSR late-bind seam, at parity with the Reagent and UIx adapters. Normally you don't call this directly; requiring `re-frame.ssr` wires the emitter for you. Pass `nil` to reset.
 - **Example**:
   ```clojure
   ;; SSR: install a render-tree → HTML emitter (normally wired for you by

--- a/docs/api/re-frame.adapter.reagent.md
+++ b/docs/api/re-frame.adapter.reagent.md
@@ -1,10 +1,15 @@
 # re-frame.adapter.reagent
 
-`re-frame.adapter.reagent` binds re-frame2's substrate-agnostic core to Reagent, the browser-default reactive substrate. Requiring it gives you four things: the `adapter` spec you pass to `(rf/init! …)` at boot, the `with-resource-lease` mount-lifecycle component, and two operational helpers — `flush-views!` (tests) and `set-hiccup-emitter!` (the SSR render-to-string seam).
+`re-frame.adapter.reagent` binds re-frame2's substrate-agnostic core to Reagent, the browser-default reactive substrate. Requiring it gives you four things:
 
-There is no per-substrate hook surface here. The substrate-agnostic ergonomic surface (`capture-frame`, `with-frame`, `with-new-frame`, `frame-provider`) and the `reg-view` registry live in [`re-frame.core`](re-frame.core.md) and compose across every substrate. The dependency is one-way: this adapter depends on `re-frame.core`; core never depends on it.
+- the `adapter` spec you pass to `(rf/init! …)` at boot;
+- the `with-resource-lease` mount-lifecycle component;
+- `flush-views!`, the test helper;
+- `set-hiccup-emitter!`, the SSR render-to-string seam.
 
-It ships in the `day8/re-frame2-reagent` (full) and `day8/reagent-slim` (slim) artefacts — see the variant table under [`adapter`](#adapter). For substrate choice see [Use UIx, Helix, or reagent-slim](../core/how-to/use-uix-helix-or-slim.md).
+There is no per-substrate hook surface here. The substrate-agnostic ergonomic surface (`capture-frame`, `with-frame`, `with-new-frame`, `frame-provider`) and the `reg-view` registry live in [`re-frame.core`](re-frame.core.md). They compose across every substrate. The dependency is one-way: this adapter depends on `re-frame.core`; core never depends on it.
+
+The adapter ships in two artefacts: `day8/re-frame2-reagent` (full) and `day8/reagent-slim` (slim). See the variant table under [`adapter`](#adapter). For substrate choice, see [Use UIx, Helix, or reagent-slim](../core/how-to/use-uix-helix-or-slim.md).
 
 ```clojure
 (:require [re-frame.adapter.reagent :as reagent-adapter])
@@ -21,8 +26,8 @@ It ships in the `day8/re-frame2-reagent` (full) and `day8/reagent-slim` (slim) a
    :render …
    :dispose-adapter! …}
   ```
-- **Description**: The Reagent adapter map — the substrate spec passed to `(rf/init! ...)` to install the browser-default Reagent substrate (stock `reagent.core` / `reagent.dom.client`).
-  - No default-adapter registry and no keyword form: require the adapter ns and pass its `adapter` Var explicitly at the call site.
+- **Description**: The Reagent adapter map: the substrate spec you pass to `(rf/init! ...)` to install the browser-default Reagent substrate (stock `reagent.core` / `reagent.dom.client`).
+  - There is no default-adapter registry and no keyword form. Require the adapter ns and pass its `adapter` Var explicitly at the call site.
   - When this adapter is installed, `current-adapter` (in [`re-frame.core`](re-frame.core.md)) returns `:rf.adapter/reagent`.
   - The Reagent `frame-provider` is the substrate-agnostic provider from [`re-frame.core`](re-frame.core.md); children stay trailing-positional hiccup (`[rf/frame-provider {:frame …} & children]`).
 - **Example**:
@@ -33,14 +38,14 @@ It ships in the `day8/re-frame2-reagent` (full) and `day8/reagent-slim` (slim) a
   (rf/init! reagent-adapter/adapter)   ;; install the substrate once, at boot
   ```
 
-Reagent ships in two variants, full and slim. Both publish their adapter at the same canonical ns — `re-frame.adapter.reagent` — so the require and `init!` line are identical. The variant is selected by the Maven coordinate you depend on, not by the boot line:
+Reagent ships in two variants, full and slim. Both publish their adapter at the same canonical ns, `re-frame.adapter.reagent`, so the require and the `init!` line are identical. You select the variant by the Maven coordinate you depend on, not by the boot line:
 
 | Variant | Maven coordinate | Adapter ns (require) | Includes | Use when |
 |---|---|---|---|---|
 | Full | `day8/re-frame2-reagent` | `re-frame.adapter.reagent` | stock Reagent (`reagent.core`, `reagent.dom.client`, `reagent.dom.server`) | client apps that may also render to a string on the JVM |
 | Slim | `day8/reagent-slim` | `re-frame.adapter.reagent` (renamed from the in-tree `-slim` ns at publication) | the `reagent2` rewrite; static HTML export via a pure-CLJS `reagent2.dom.server`, no `react-dom/server` | browser-only bundles; ~7–10 KB gzipped smaller (up to ~22–27 KB where the HTML-export path was in play) |
 
-A build depends on exactly one variant, so the adapter ns is single-source per app; you select slim vs full through your `deps.edn` coordinate.
+A build depends on exactly one variant, so the adapter ns is single-source per app. You select slim vs full through your `deps.edn` coordinate.
 
 In-repo `:git/sha` consumers require `re-frame.adapter.reagent-slim` directly, because the monorepo carries both adapters on one classpath. The publication step renames it to `re-frame.adapter.reagent` before packaging the jar.
 
@@ -58,16 +63,16 @@ The migration (a four-line swap) is in [Use UIx, Helix, or reagent-slim](../core
   [with-resource-lease descriptor body-thunk]
   [with-resource-lease descriptor opts body-thunk]
   ```
-- **Description**: Reagent component that holds a resource liveness lease for its mounted lifetime — the Reagent counterpart of the UIx / Helix `use-resource-lease` hook.
+- **Description**: A Reagent component that holds a resource liveness lease for its mounted lifetime. It is the Reagent counterpart of the UIx / Helix `use-resource-lease` hook.
 
   Arguments:
   - `descriptor` — the resource-instance identity `{:resource … :scope … :params …}`.
-  - `opts` (optional map between the descriptor and the body thunk) — `:cause` recorded on the ensure for observability (defaults to `[:lease :mount]`); `:frame` pins the lease to an explicit frame id, bypassing ambient resolution.
+  - `opts` — an optional map between the descriptor and the body thunk. `:cause` is recorded on the ensure for observability (defaults to `[:lease :mount]`). `:frame` pins the lease to an explicit frame id, bypassing ambient resolution.
   - `body-thunk` — a 0-arg fn returning the hiccup rendered while the lease is held.
 
   Behaviour:
   - On mount, dispatches `:rf.resource/ensure` with a per-instance `[:lease token]` owner; on unmount, dispatches `:rf.resource/release-owner` for that owner into the same frame.
-  - Frame resolution: explicit `:frame` opt → surrounding `frame-provider` context → dynamic frame binding → raises `:rf.error/no-frame-context`.
+  - Frame resolution tries, in order: the explicit `:frame` opt, the surrounding `frame-provider` context, then the dynamic frame binding. If none is in scope, it raises `:rf.error/no-frame-context`.
   - The lease token is minted once per mounted instance, so a hot-reload re-mount settles to exactly one held lease.
   - Under `render-to-string` (SSR) lifecycle methods do not run, so the acquire/release is a no-op.
 - **Example**:
@@ -93,10 +98,10 @@ The migration (a four-line swap) is in [Use UIx, Helix, or reagent-slim](../core
   (flush-views!)
   (flush-views! f)
   ```
-- **Description**: Wraps React's `act()` for tests; flushes pending Reagent renders synchronously. Returns nil.
+- **Description**: Wraps React's `act()` for tests. Flushes pending Reagent renders synchronously and returns nil.
   - 0-arity: drains the queued renders and effects.
   - 1-arity: runs the thunk `f`, then the synchronous render drain, inside `act()`.
-  - When `act()` is unreachable in the current React build, degrades to the plain synchronous flush — `f` still runs and the render queue still drains, without the `act()` wrapper.
+  - When `act()` is unreachable in the current React build, this degrades to a plain synchronous flush. `f` still runs and the render queue still drains, just without the `act()` wrapper.
   - Surfaced identically across all substrates: same name, same adapter-ns location, same nil-return.
 - **Example**:
   ```clojure
@@ -114,9 +119,9 @@ The migration (a four-line swap) is in [Use UIx, Helix, or reagent-slim](../core
   ```clojure
   (set-hiccup-emitter! f)
   ```
-- **Description**: Install a render-tree → HTML fn — the hiccup → HTML emitter used by render-to-string.
+- **Description**: Install a render-tree → HTML fn: the hiccup → HTML emitter used by render-to-string.
   - Last call wins; pass `nil` to reset.
-  - Normally you don't call this directly: requiring [`re-frame.ssr`](re-frame.ssr.md) resolves the late-bind hook and wires the emitter for you.
+  - Normally you don't call this directly. Requiring [`re-frame.ssr`](re-frame.ssr.md) resolves the late-bind hook and wires the emitter for you.
   - It is the Reagent-side late-bind seam for SSR, matching the parallel seam on the UIx and Helix adapters.
 - **Example**:
   ```clojure

--- a/docs/api/re-frame.adapter.uix.md
+++ b/docs/api/re-frame.adapter.uix.md
@@ -1,8 +1,13 @@
 # re-frame.adapter.uix
 
-The UIx adapter connects re-frame2's substrate-agnostic core to UIx, a hooks-first React substrate. It exposes hooks (`use-subscribe`, `use-resource-lease`, `use-current-frame`), the `frame-provider` component, the `adapter` spec map you pass to `init!`, and adapter seams for tests, SSR, and code-gen.
+The UIx adapter connects re-frame2's substrate-agnostic core to UIx, a hooks-first React substrate. It exposes:
 
-Ships in the `day8/re-frame2-uix` artefact. The dependency direction is one-way: the adapter depends on `re-frame.core`, never the reverse. There is no auto-injection — UIx components call `use-subscribe` and `(rf/capture-frame)` directly.
+- the hooks `use-subscribe`, `use-resource-lease`, and `use-current-frame`;
+- the `frame-provider` component;
+- the `adapter` spec map you pass to `init!`;
+- adapter seams for tests, SSR, and code-gen.
+
+It ships in the `day8/re-frame2-uix` artefact. The dependency direction is one-way: the adapter depends on `re-frame.core`, never the reverse. There is no auto-injection; UIx components call `use-subscribe` and `(rf/capture-frame)` directly.
 
 ```clojure
 (:require [re-frame.adapter.uix :as uix-adapter])
@@ -61,12 +66,12 @@ For narrative coverage and the substrate decision set, see [Use UIx, Helix, or r
   (use-subscribe query-v) → current sub value
   (use-subscribe frame-kw query-v) → current sub value
   ```
-- **Description**: Subscribe inside a UIx component; the hook-shaped equivalent of `subscribe`.
+- **Description**: Subscribe inside a UIx component. This is the hook-shaped equivalent of `subscribe`.
 
   Returns the current sub value and re-renders the calling component when the value changes.
 
-  - 1-arg form resolves the frame through the standard chain — `with-frame` dynamic scope first, then the surrounding `frame-provider`. Raises `:rf.error/no-frame-context` when neither is in scope (there is no `:rf/default` floor).
-  - 2-arg form pins to an explicit frame-id, bypassing the chain.
+  - The 1-arg form resolves the frame through the standard chain: `with-frame` dynamic scope first, then the surrounding `frame-provider`. It raises `:rf.error/no-frame-context` when neither is in scope (there is no `:rf/default` floor).
+  - The 2-arg form pins to an explicit frame-id, bypassing the chain.
 - **Example**:
   ```clojure
   (defui cart-total []
@@ -84,7 +89,7 @@ For narrative coverage and the substrate decision set, see [Use UIx, Helix, or r
   ```
 - **Description**: Holds a resource liveness lease for the calling component's mounted lifetime. On mount, dispatches `:rf.resource/ensure` with an app-minted `[:lease …]` owner; on unmount, dispatches `:rf.resource/release-owner` for that same lease.
 
-  Returns nil — a lifecycle hook, not a read. Pair it with `use-subscribe` on a `[:rf.resource/*]` query to read the data.
+  Returns nil: this is a lifecycle hook, not a read. Pair it with `use-subscribe` on a `[:rf.resource/*]` query to read the data.
 
   - `descriptor` — the resource-instance identity `{:resource … :scope … :params …}`.
   - `opts` keys: `:cause` (recorded on the ensure; defaults to `[:lease :mount]`) and `:frame` (pin to an explicit frame-id).
@@ -106,9 +111,9 @@ For narrative coverage and the substrate decision set, see [Use UIx, Helix, or r
   ```clojure
   (use-current-frame) → frame-kw, or :rf.frame/no-provider
   ```
-- **Description**: Returns the frame keyword of the surrounding `frame-provider`, for components that thread the frame through hand-written child callbacks.
+- **Description**: Returns the frame keyword of the surrounding `frame-provider`. It exists for components that thread the frame through hand-written child callbacks.
 
-  React-context tier only. Returns the no-provider sentinel `:rf.frame/no-provider` when no provider sits above — never nil, never a synthesised default. Does not consult the `with-frame` dynamic var; for the full resolution chain use `rf/current-frame-id`.
+  This hook reads the React-context tier only. When no provider sits above, it returns the no-provider sentinel `:rf.frame/no-provider` — never nil, and never a synthesised default. It does not consult the `with-frame` dynamic var; for the full resolution chain, use `rf/current-frame-id`.
 
 > **NOT USED** — no call sites found in `implementation/`, `examples/`, or `tools/`.
 
@@ -129,9 +134,9 @@ For narrative coverage and the substrate decision set, see [Use UIx, Helix, or r
   - `:rf.error/no-frame-context` on a nil `:frame`
   - `:rf.error/bad-frame-provider-arg` on a non-keyword `:frame`
 
-  `{:id …}` — ENSURE a named frame (create-if-absent / reuse-no-reseed, `make-frame` opts incl. `:images` / `:initial-events`, no destroy-on-unmount). `:id` must be a keyword; a missing / nil / non-keyword `:id` raises `:rf.error/ensure-frame-provider-missing-id`. Re-mounting the ENSURE shape under the same `:id` neither destroys durable state nor re-runs `:initial-events`.
+  `{:id …}` — ENSURE a named frame: create it if absent, or reuse it without re-seeding. This shape accepts `make-frame` opts, including `:images` / `:initial-events`, and never destroys the frame on unmount. `:id` must be a keyword; a missing, nil, or non-keyword `:id` raises `:rf.error/ensure-frame-provider-missing-id`. Re-mounting the ENSURE shape under the same `:id` neither destroys durable state nor re-runs `:initial-events`.
 
-  Children ride the idiomatic `$` trailing-args channel — pass them after the prop map, as for any other UIx component (no `:children` prop-map key).
+  Children ride the idiomatic `$` trailing-args channel. Pass them after the prop map, as for any other UIx component (there is no `:children` prop-map key).
 - **Example**:
   ```clojure
   ;; ENSURE shape at the render root: create the frame on first mount, seed it
@@ -149,7 +154,7 @@ For narrative coverage and the substrate decision set, see [Use UIx, Helix, or r
   ```clojure
   (wrap-view id metadata user-fn) → wrapped fn
   ```
-- **Description**: Adapter-side source-coord injection. Most users register through `reg-view*`; `wrap-view` is for code-gen and library scaffolding.
+- **Description**: Adapter-side source-coord injection: wraps a component head so its rendered root DOM element carries `data-rf2-source-coord` in debug builds (see the Notes below). Most users register through `reg-view*`; `wrap-view` is for code-gen and library scaffolding.
 - **Example**:
   ```clojure
   ;; Code-gen / scaffolding seam: wrap a component head so its root DOM element
@@ -167,7 +172,7 @@ For narrative coverage and the substrate decision set, see [Use UIx, Helix, or r
   (flush-views!)
   (flush-views! f)
   ```
-- **Description**: Wraps React's `act()` for tests.
+- **Description**: Wraps React's `act()` for tests. Flushes pending renders synchronously and returns nil.
 - **Example**:
   ```clojure
   ;; Test-only: flush pending renders synchronously, returns nil.
@@ -182,7 +187,7 @@ For narrative coverage and the substrate decision set, see [Use UIx, Helix, or r
   ```clojure
   (set-hiccup-emitter! f)
   ```
-- **Description**: Install a render-tree → HTML fn. Parity with the Reagent adapter's late-bind seam for SSR.
+- **Description**: Install a render-tree → HTML fn. This is the UIx side of the SSR late-bind seam, at parity with the Reagent adapter. Normally you don't call this directly; requiring `re-frame.ssr` wires the emitter for you. Pass `nil` to reset.
 - **Example**:
   ```clojure
   ;; SSR: install a render-tree → HTML emitter (normally wired for you by
@@ -193,8 +198,8 @@ For narrative coverage and the substrate decision set, see [Use UIx, Helix, or r
 
 ## Notes
 
-- **Shared React Context.** The `frame-provider` in all three adapters (Reagent, UIx, Helix) consumes the same `createContext` object, factored into `re-frame.adapter.context` (a CLJS-only file in core). There is exactly one Context, not three, so a mixed-substrate app composes — a UIx `frame-provider` can wrap a Reagent or Helix subtree, and vice versa.
-- **DOM source-coord annotations.** Adapters inject `data-rf2-source-coord` on every registered view's root element; `wrap-view` is the explicit seam for that injection. The attribute is gated on debug builds and elided from production `:advanced` builds via dead-code elimination, so it costs no shipped bytes; it powers click-to-source in Xray and re-frame2-pair. Full contract in the [Observability concept guide](../core/observability.md).
+- **Shared React Context.** The `frame-provider` in all three adapters (Reagent, UIx, Helix) consumes the same `createContext` object, factored into `re-frame.adapter.context` (a CLJS-only file in core). There is exactly one Context, not three. A mixed-substrate app therefore composes: a UIx `frame-provider` can wrap a Reagent or Helix subtree, and vice versa.
+- **DOM source-coord annotations.** Adapters inject `data-rf2-source-coord` on every registered view's root element; `wrap-view` is the explicit seam for that injection. The attribute is gated on debug builds and elided from production `:advanced` builds via dead-code elimination, so it costs no shipped bytes. It powers click-to-source in Xray and re-frame2-pair. The full contract is in the [Observability concept guide](../core/observability.md).
 
 ## See also
 

--- a/docs/api/re-frame.core.md
+++ b/docs/api/re-frame.core.md
@@ -1,18 +1,27 @@
 # re-frame.core
 
-`re-frame.core` is the single namespace every re-frame2 app requires — the facade. It re-exports the registration verbs, the pipeline verbs, the view surface, the effect/interceptor surface, the frame primitive, the boot/configure lane, the instrumentation and registrar-query reads, and every optional feature's registration macro.
+`re-frame.core` is the facade: the single namespace every re-frame2 app requires. It re-exports:
+
+- the registration verbs
+- the pipeline verbs
+- the view surface
+- the effect/interceptor surface
+- the frame primitive
+- the boot/configure lane
+- the instrumentation and registrar-query reads
+- every optional feature's registration macro
 
 ```clojure
 (:require [re-frame.core :as rf])
 ```
 
-Core surfaces are documented in full below. Feature surfaces (machines, routing, flows, schemas, SSR, HTTP, resources) are re-exported here for single-import ergonomics; each has a brief entry with a pointer to its own namespace doc, which carries the deep contract. For the mental model, see the [Subscriptions](../core/subscriptions.md), [Frames](../core/frames.md), and [Effects](../core/effects.md) concept guides.
+Core surfaces are documented in full below. Feature surfaces (machines, routing, flows, schemas, SSR, HTTP, resources) are re-exported here so a single import covers everything. Each feature has a brief entry with a pointer to its own namespace doc, which carries the deep contract. For the mental model, see the [Subscriptions](../core/subscriptions.md), [Frames](../core/frames.md), and [Effects](../core/effects.md) concept guides.
 
 ## Registration
 
 Every entry here registers a named handler into the frame's registrar.
 
-**Return value.** Every `reg-*` returns its primary id — the keyword (or path, for `reg-app-schema`) you registered with.
+**Return value.** Every `reg-*` returns its primary id: the keyword you registered with (or the path, for `reg-app-schema`).
 
 ### `reg-event`
 
@@ -21,7 +30,7 @@ Every entry here registers a named handler into the frame's registrar.
   ```clojure
   (reg-event id ?metadata handler)
   ```
-- **Description**: The one public event-registration form. The handler is `(fn [coeffects event-vec] effect-map)` — a coeffects map in, a **closed** effects map `{:db ... :fx [...]}` out (or `nil` for a no-op). The db write is an explicit `:db` effect; there is no db-only return shape.
+- **Description**: The one public event-registration form. The handler is `(fn [coeffects event-vec] effect-map)`. It receives a coeffects map and returns a **closed** effects map `{:db ... :fx [...]}`, or `nil` for a no-op. The db write is an explicit `:db` effect; there is no db-only return shape.
 - **Metadata map (extended form)**: the optional middle slot carries reflection keys (`:doc`, `:schema`, `:tags`, …) and a reserved `:interceptors` vector:
   ```clojure
   (rf/reg-event :cart/add
@@ -52,9 +61,9 @@ Every entry here registers a named handler into the frame's registrar.
   ```clojure
   (reg-sub id ?metadata input-fn? computation-fn)
   ```
-- **Description**: A computed view over `app-db` and other subs. Three input-production modes (see table): a layer-1 `app-db` reader has no input producer, `:<-` is a literal producer, and a parametric `input-fn` computes inputs from the outer `query-v`.
+- **Description**: A computed view over `app-db` and other subs. There are three input-production modes (see the table below). A layer-1 `app-db` reader has no input producer. `:<-` is a literal producer. A parametric `input-fn` computes inputs from the outer `query-v`.
 
-  The optional first fn is the v2 **`input-fn`** — a *pure* function from the outer `query-v` to a **vector of query vectors**. It must not call `subscribe`, deref `app-db`, dispatch, or perform IO, and must not return live reactions (it is not a v1 reaction-returning signal fn). The runtime resolves each returned query vector in the *same frame* as the outer subscription.
+  The optional first fn is the v2 **`input-fn`**: a *pure* function from the outer `query-v` to a **vector of query vectors**. It must not call `subscribe`, deref `app-db`, dispatch, or perform IO. It must not return live reactions either — it is not a v1 reaction-returning signal fn. The runtime resolves each returned query vector in the *same frame* as the outer subscription.
 
   This is the only sub-registration form in v2; `reg-sub-raw` is gone (see the [migration reference](../../migration/from-re-frame-v1/README.md)). Full input grammar and error ids: [Subscriptions concept guide](../core/subscriptions.md).
 
@@ -95,10 +104,10 @@ Every entry here registers a named handler into the frame's registrar.
   ```clojure
   (reg-fx id ?metadata handler)
   ```
-- **Description**: Define a named side effect. The handler is **binary**, context-first: `(fn [ctx args] ...)` (changed from v1's unary shape).
+- **Description**: Define a named side effect. The handler is **binary** and context-first: `(fn [ctx args] ...)`. This is a change from v1's unary shape.
   - `ctx` is a small map carrying `:frame` (the active frame id), `:event` (the originating event vector), and `:envelope` (the parent dispatch envelope).
   - `args` is the value the event handler placed beside the fx-id in its `:fx` vector.
-  - Accepts a `:platforms` metadata key (a set of `:server` / `:client`) that gates fx execution by active platform — see [re-frame.ssr.md](re-frame.ssr.md).
+  - Accepts a `:platforms` metadata key (a set of `:server` / `:client`) that gates fx execution by the active platform. See [re-frame.ssr.md](re-frame.ssr.md).
 - **Example**:
   ```clojure
   (rf/reg-fx :app/scroll-to-top
@@ -112,10 +121,13 @@ Every entry here registers a named handler into the frame's registrar.
   ```clojure
   (reg-cofx id ?metadata supplier)
   ```
-- **Description**: Register a named supplier for a world fact a handler can ask for. The supplier is a plain **value-returning** function — `(fn [] value)`, or `(fn [arg] value)` for ids parameterised at the call site — not a context-mutating fn. The runtime calls it and puts the result into the coeffects map under the cofx's id.
+- **Description**: Register a named supplier for a world fact a handler can ask for. The supplier is a plain **value-returning** function, not a context-mutating fn: `(fn [] value)`, or `(fn [arg] value)` for ids parameterised at the call site. The runtime calls it and puts the result into the coeffects map under the cofx's id.
   - A handler opts in with `:rf.cofx/requires` registration metadata. v2 has no `inject-cofx` interceptor.
-  - The middle slot carries the fact's grade: `{:recordable? true}` for a replayable fact; `{:recordable? true :provided? true}` for a recordable fact stamped by an owner boundary (no generator); a bare registration for an ambient (unrecorded) read.
-  - Reading a sub from a handler is done the same way — wrap `subscribe-once` in a cofx and declare it.
+  - The middle slot carries the fact's grade:
+    - `{:recordable? true}` — a replayable fact.
+    - `{:recordable? true :provided? true}` — a recordable fact stamped by an owner boundary (no generator).
+    - A bare registration — an ambient (unrecorded) read.
+  - Reading a sub from a handler works the same way: wrap `subscribe-once` in a cofx and declare it.
   - Full model: [Effects](../core/effects.md), [Coeffects](../core/coeffects.md).
 - **Example**:
   ```clojure
@@ -139,9 +151,9 @@ Every entry here registers a named handler into the frame's registrar.
   ```clojure
   (reg-frame id metadata)
   ```
-- **Description**: Atomic create-and-register. A frame is the scoping unit — one `app-db`, one event queue, one pipeline — minted with metadata you later read via `frame-meta`. The frame owns the `:observability` sink policy.
+- **Description**: Atomic create-and-register. A frame is the scoping unit: one `app-db`, one event queue, one pipeline. It is minted with metadata you later read via `frame-meta`. The frame owns the `:observability` sink policy.
   - Durable `app-db` data classification is **not** a frame annotation: a `reg-frame` config carrying `:sensitive` / `:large` **fails loud** at registration.
-  - Classify durable `app-db` paths by returning the four commit-plane classification effects (`:sensitive` / `:large` / `:clear-sensitive` / `:clear-large`) from a `reg-event` alongside `:db`, wired to run at frame creation via `:initial-events`.
+  - To classify durable `app-db` paths, return the four commit-plane classification effects (`:sensitive` / `:large` / `:clear-sensitive` / `:clear-large`) from a `reg-event` alongside `:db`. Wire that event to run at frame creation via `:initial-events`.
   - See [re-frame.http.md](re-frame.http.md), [re-frame.schemas.md](re-frame.schemas.md), and [Keep secrets out of traces](../core/how-to/keep-secrets-out-of-traces.md).
 - **Example**:
   ```clojure
@@ -189,7 +201,7 @@ Each `clear-*` removes an entry from the registrar; the no-arg form clears the w
   (clear-sub)
   (clear-sub id)
   ```
-- **Description**: Forget one sub. This is the registrar-side clear (the inverse of `reg-sub`); the runtime cache decrement is `unsubscribe`.
+- **Description**: Forget one sub. This clears the registrar side — the inverse of `reg-sub`. To decrement the runtime cache instead, use `unsubscribe`.
 - **Example**:
   ```clojure
   (rf/clear-sub :counter/value)   ;; forget one sub registration
@@ -215,7 +227,7 @@ Each `clear-*` removes an entry from the registrar; the no-arg form clears the w
 
 These are the two verbs that drive the pipeline.
 
-`dispatch`, `dispatch-sync`, and `subscribe` are macro-in-call-position / fn-in-value-position on CLJS (Convention A — the same pattern `reg-event` / `reg-sub` / etc. use). In call position the **macro** form captures the call-site source coords so tools like Xray can navigate from a trace event back to the originating expression. In value position — an argument, a `let`-binding, `(or dispatch-fn rf/dispatch)` — the SAME name resolves to a plain-fn value instead, which composes through a higher-order function (`(map dispatch events)`) where a macro can't sit; that path skips the stamping. Both route through the same dispatcher; only the trace stamping differs. There is no `*`-suffixed twin.
+On CLJS, `dispatch`, `dispatch-sync`, and `subscribe` are macros in call position and plain fns in value position (Convention A — the same pattern `reg-event` / `reg-sub` / etc. use). In call position the **macro** form captures the call-site source coords, so tools like Xray can navigate from a trace event back to the originating expression. In value position (an argument, a `let`-binding, `(or dispatch-fn rf/dispatch)`) the SAME name resolves to a plain-fn value instead. The fn value composes through higher-order functions like `(map dispatch events)`, where a macro can't sit; that path skips the stamping. Both forms route through the same dispatcher; only the trace stamping differs. There is no `*`-suffixed twin.
 
 **The `opts` map.** `dispatch` and `subscribe` accept a uniform opts map: `:frame`, `:fx-overrides`, `:interceptor-overrides`, `:trace-id`, `:source`. Target a non-default frame via `(rf/dispatch [::save x] {:frame :todo})`; the frame **id** is the public routing address.
 
@@ -227,13 +239,13 @@ These are the two verbs that drive the pipeline.
   (dispatch event)
   (dispatch event opts)
   ```
-- **Description**: Async dispatch — drops the event onto the frame's queue and returns immediately. The default.
+- **Description**: Async dispatch: drops the event onto the frame's queue and returns immediately. This is the default.
 - **Example**:
   ```clojure
   [:button {:on-click #(rf/dispatch [:counter/inc])} "+"]
   ```
 
-- **Fn form**: in VALUE position (not called directly — e.g. `(run! rf/dispatch events)`), `dispatch` resolves to the plain-fn value instead of expanding as a macro; it skips call-site stamping, so it composes through `map` / `comp` / `partial`. `opts` may carry `:frame` (a frame-id keyword or a live frame value). Returns `nil`. (A JVM programmatic caller reaches `re-frame.router/dispatch!` directly.)
+- **Fn form**: In VALUE position — passed rather than called, e.g. `(run! rf/dispatch events)` — `dispatch` resolves to the plain-fn value instead of expanding as a macro. It skips call-site stamping, so it composes through `map` / `comp` / `partial`. `opts` may carry `:frame` (a frame-id keyword or a live frame value). Returns `nil`. (A JVM programmatic caller reaches `re-frame.router/dispatch!` directly.)
 
 ### `dispatch-sync`
 
@@ -243,13 +255,13 @@ These are the two verbs that drive the pipeline.
   (dispatch-sync event)
   (dispatch-sync event opts)
   ```
-- **Description**: Synchronous dispatch — drains to completion before returning. For tests, REPL workflows, and one-shot app-boot events. Never call from inside a running event handler — that raises `:rf.error/dispatch-sync-in-handler`.
+- **Description**: Synchronous dispatch: drains to completion before returning. Use it for tests, REPL workflows, and one-shot app-boot events. Never call it from inside a running event handler; that raises `:rf.error/dispatch-sync-in-handler`.
 - **Example**:
   ```clojure
   (rf/dispatch-sync [:counter/initialise])   ;; one-shot app-boot event
   ```
 
-- **Fn form**: in VALUE position, `dispatch-sync` resolves to the plain-fn value. Mirrors `dispatch`'s value-position forms — `opts` may carry `:frame` (a frame-id keyword or a live frame value).
+- **Fn form**: In VALUE position, `dispatch-sync` resolves to the plain-fn value. It mirrors `dispatch`'s value-position forms: `opts` may carry `:frame` (a frame-id keyword or a live frame value).
   ```clojure
   ;; Fn-form — drive a sequence of events synchronously from runner / test code.
   (doseq [evec events]
@@ -265,9 +277,9 @@ These are the two verbs that drive the pipeline.
   (subscribe query-v)
   (subscribe query-v opts)
   ```
-- **Description**: The reactive handle. Returns a reaction whose value is the registered sub's current output; recomputes when upstreams change. Valid inside views, inside other subs, and (via the cofx wrapper) inside event handlers.
+- **Description**: The reactive handle. It returns a reaction whose value is the registered sub's current output, recomputed when upstreams change. Valid inside views, inside other subs, and (via the cofx wrapper) inside event handlers.
   - Target a non-ambient frame via the `{:frame …}` opt — `(rf/subscribe [:counter/value] {:frame :other})`; `:other` may be a frame-id keyword or a live frame value.
-  - In VALUE position, `subscribe` resolves to the plain-fn value (Convention A) for HoF / programmatic reads — no call-site capture. A JVM programmatic caller reaches `re-frame.subs/subscribe` directly.
+  - In VALUE position, `subscribe` resolves to the plain-fn value (Convention A) for HoF / programmatic reads, with no call-site capture. A JVM programmatic caller reaches `re-frame.subs/subscribe` directly.
 - **Example**:
   ```clojure
   [:span @(rf/subscribe [:counter/value])]
@@ -281,7 +293,7 @@ These are the two verbs that drive the pipeline.
   (subscribe-once query-v) → value
   (subscribe-once query-v opts) → value
   ```
-- **Description**: One-shot read: subscribe, deref, immediately unsubscribe. Returns the *current* value with no reactive handle retained. For handler bodies and the REPL — not views, and **not** machine callbacks (a machine `:guard` / `:action` / `:entry` / `:exit` MUST NOT call `subscribe-once`; it takes host facts as recorded coeffects, incl. the machines-only `{:rf/sub …}` source — see [re-frame.machines](re-frame.machines.md)). Target a non-ambient frame via `(subscribe-once query-v {:frame f})`, mirroring `subscribe`.
+- **Description**: One-shot read: subscribe, deref, immediately unsubscribe. Returns the *current* value with no reactive handle retained. Use it in handler bodies and at the REPL — not in views, and **not** in machine callbacks. A machine `:guard` / `:action` / `:entry` / `:exit` MUST NOT call `subscribe-once`; it takes host facts as recorded coeffects, including the machines-only `{:rf/sub …}` source (see [re-frame.machines](re-frame.machines.md)). Target a non-ambient frame via `(subscribe-once query-v {:frame f})`, mirroring `subscribe`.
 - **Example**:
   ```clojure
   ;; One-shot read of the current value — no reactive handle retained.
@@ -297,7 +309,7 @@ These are the two verbs that drive the pipeline.
   (unsubscribe query-v) → nil
   (unsubscribe frame-id query-v) → nil
   ```
-- **Description**: Decrement the cache ref-count for a query. When the count hits zero, the entry is disposed **synchronously** — see [Subscriptions](../core/subscriptions.md). The Reagent / UIx / Helix adapters wire it on unmount; most callers never reach for it directly. Target a non-ambient frame with the frame-first `(unsubscribe frame-id query-v)` form — unlike `subscribe` / `subscribe-once`, `unsubscribe` has no `{:frame …}` opts form (it is pure teardown, never a hot in-view call).
+- **Description**: Decrement the cache ref-count for a query. When the count hits zero, the entry is disposed **synchronously** (see [Subscriptions](../core/subscriptions.md)). The Reagent / UIx / Helix adapters wire it on unmount; most callers never reach for it directly. Target a non-ambient frame with the frame-first `(unsubscribe frame-id query-v)` form. Unlike `subscribe` / `subscribe-once`, `unsubscribe` has no `{:frame …}` opts form — it is pure teardown, never a hot in-view call.
 - **Example**:
   ```clojure
   ;; Manual ref-count pairing (tests / REPL) — balances an explicit subscribe.
@@ -314,7 +326,7 @@ These are the two verbs that drive the pipeline.
   (clear-sub-cache!)
   (clear-sub-cache! frame-id)
   ```
-- **Description**: Dispose every cached entry in a frame's runtime sub-cache and clear the cache; disposal is synchronous and unconditional. The no-arg form targets the **ambient** frame (raising `:rf.error/no-frame-context` under no established scope); the one-arg form names the frame. Tests; rarely needed in app code.
+- **Description**: Dispose every cached entry in a frame's runtime sub-cache and clear the cache. Disposal is synchronous and unconditional. The no-arg form targets the **ambient** frame and raises `:rf.error/no-frame-context` when no scope is established; the one-arg form names the frame. Mostly for tests; rarely needed in app code.
 - **Example**:
   ```clojure
   (rf/clear-sub-cache! :app/main)   ;; evict one frame's cached subs
@@ -328,7 +340,7 @@ These are the two verbs that drive the pipeline.
   ```clojure
   (compute-sub query-v db) → value
   ```
-- **Description**: The test-friendly companion to `subscribe`. Runs the sub graph against a **value** of `app-db` — no cache, no reactivity, no frame — and returns the value. Query-vector first, db second.
+- **Description**: The test-friendly companion to `subscribe`. It runs the sub graph against a **value** of `app-db` and returns the result — no cache, no reactivity, no frame. Arguments are query-vector first, db second.
   - `db` may be a bare app-db map, or a full frame-state value (`{:rf.db/app … :rf.db/runtime …}`) when the graph mixes app-db and runtime-db subs.
   - JVM-runnable.
 - **Example**:
@@ -348,7 +360,7 @@ The framework ships a small, fixed set of standard `:rf/*` events you dispatch l
   ```clojure
   [:rf/set-db new-db-map]
   ```
-- **Description**: The framework-standard `app-db` seeding event. **Replaces** the whole `app-db` partition with the supplied map (a replace, not a merge). Rides the normal post-commit path — schema validation, rollback, trace emission, epoch recording — so seeding is an ordinary traceable event, not a privileged direct write. Returns `{:db new-db}` from a pure handler, so it touches only the `app-db` partition, never runtime-db.
+- **Description**: The framework-standard `app-db` seeding event. It **replaces** the whole `app-db` partition with the supplied map — a replace, not a merge. It rides the normal post-commit path (schema validation, rollback, trace emission, epoch recording), so seeding is an ordinary traceable event, not a privileged direct write. The handler is pure and returns `{:db new-db}`, so it touches only the `app-db` partition, never runtime-db.
 - **Validation**: takes **exactly one map argument**. A missing / `nil` / non-map argument, or any extra trailing arg (`[:rf/set-db {} :junk]`), throws `:rf.error/set-db-bad-value`. Empty `app-db` is `[:rf/set-db {}]`.
 - **Example**:
   ```clojure
@@ -363,7 +375,7 @@ The framework ships a small, fixed set of standard `:rf/*` events you dispatch l
 
 ## Views
 
-The view layer is **substrate-agnostic** — the shared dataflow (frames, subscriptions, dispatch, source metadata, registry ids) is uniform across Reagent, UIx, and Helix, and the same `capture-frame` carry primitive composes across all three. The substrate-specific hooks (`use-subscribe`, `wrap-view`, …) live in each adapter's namespace doc ([re-frame.adapter.reagent.md](re-frame.adapter.reagent.md) / [re-frame.adapter.uix.md](re-frame.adapter.uix.md) / [re-frame.adapter.helix.md](re-frame.adapter.helix.md)).
+The view layer is **substrate-agnostic**. The shared dataflow — frames, subscriptions, dispatch, source metadata, registry ids — is uniform across Reagent, UIx, and Helix, and the same `capture-frame` carry primitive composes across all three. The substrate-specific hooks (`use-subscribe`, `wrap-view`, …) live in each adapter's namespace doc ([re-frame.adapter.reagent.md](re-frame.adapter.reagent.md) / [re-frame.adapter.uix.md](re-frame.adapter.uix.md) / [re-frame.adapter.helix.md](re-frame.adapter.helix.md)).
 
 ### `reg-view`
 
@@ -374,7 +386,7 @@ The view layer is **substrate-agnostic** — the shared dataflow (frames, subscr
   (reg-view sym docstring [args] body+)
   (reg-view ^{:rf/id :explicit/id} sym [args] body+)
   ```
-- **Description**: The `defn`-shape view registration — the app-facing lane. It auto-defs the symbol, auto-derives the id from `(keyword *ns* sym)`, auto-injects `dispatch` / `subscribe` as lexical bindings, and rejects non-defn-shape bodies at macroexpand. In all shapes the symbol is `def`-ed, so sibling code can write `[my-view item]`. Render an app-facing view by **Var reference** or `(rf/view id)` — bare keyword-tagged hiccup `[:my-view "args"]` is rejected (see [Spec 004 §Resolved decisions](../../spec/004-Views.md#bare-my-view-args-in-raw-hiccup-is-rejected)).
+- **Description**: The `defn`-shape view registration — the app-facing lane. It auto-defs the symbol, auto-derives the id from `(keyword *ns* sym)`, and auto-injects `dispatch` / `subscribe` as lexical bindings. It rejects non-defn-shape bodies at macroexpand. In all shapes the symbol is `def`-ed, so sibling code can write `[my-view item]`. Render an app-facing view by **Var reference** or `(rf/view id)`. Bare keyword-tagged hiccup `[:my-view "args"]` is rejected (see [Spec 004 §Resolved decisions](../../spec/004-Views.md#bare-my-view-args-in-raw-hiccup-is-rejected)).
 - **Example**:
   ```clojure
   (rf/reg-view counter-buttons []
@@ -398,7 +410,7 @@ The view layer is **substrate-agnostic** — the shared dataflow (frames, subscr
   - you are writing a **Form-3 component** (`(rf/reg-view* :id (r/create-class {...}))` — the one app-facing reason to touch the starred form);
   - you are writing **consumer-side library code** that registers without imposing a `def`.
 
-  There is no auto-injected `dispatch` / `subscribe` in a `reg-view*` body; capture a `(rf/capture-frame)` at render and use its ops if the view needs frame-bound dispatch.
+  A `reg-view*` body has no auto-injected `dispatch` / `subscribe`. If the view needs frame-bound dispatch, capture a `(rf/capture-frame)` at render and use its ops.
 - **Example**:
   ```clojure
   ;; Computed id — the id isn't a literal symbol at the call site.
@@ -423,7 +435,7 @@ The view layer is **substrate-agnostic** — the shared dataflow (frames, subscr
   ```clojure
   (view view-id) → render-fn
   ```
-- **Description**: Runtime lookup handle. Returns the **registered render-fn** (or `nil` when the id is not registered), not hiccup. Use in hiccup as `[(rf/view :id) args...]` to late-bind a view by id — a host that resolves a stored view id, plugin-style dispatch, dynamic chrome. The Var form (`[my-view args]`) is the app-facing default; this lookup form is for the case where the caller holds the id, not the symbol.
+- **Description**: Runtime lookup handle. Returns the **registered render-fn**, not hiccup (`nil` when the id is not registered). Use it in hiccup as `[(rf/view :id) args...]` to late-bind a view by id — for a host that resolves a stored view id, plugin-style dispatch, or dynamic chrome. The Var form (`[my-view args]`) is the app-facing default; this lookup form is for callers who hold the id, not the symbol.
 - **Example**:
   ```clojure
   [(rf/view :app/header) {:title "Cart"}]   ;; resolves the registered render-fn at render time
@@ -439,7 +451,7 @@ The view layer is **substrate-agnostic** — the shared dataflow (frames, subscr
   ```
 - **Description**: One component, two config shapes chosen by the prop map. See the [frame-provider glossary entry](../core/glossary.md#frame-provider).
   - **`{:frame existing-id}` — SCOPE.** Scopes a React subtree to a frame that **already exists**; creates / refreshes / destroys nothing. **Fails loud** (`:rf.error/frame-provider-frame-absent`) when the named frame is absent. `:frame` must be a keyword. The scope-into-React counterpart to `with-frame`.
-  - **`{:id the-id …}` — ENSURE.** Creates the frame if absent (via `make-frame`, taking the same constructor opts: `:id` / `:images` / record-config incl. `:initial-events`), **reuses it without re-seeding** if present (an idempotent re-mount preserves durable state and does not replay `:initial-events`), and provides its id to descendants. There is **no destroy-on-unmount**. `:id` is required and must be a keyword. True ownership stays explicit: `make-frame` + `destroy-frame!` inside a `create-class`.
+  - **`{:id the-id …}` — ENSURE.** Creates the frame if absent, reuses it if present, and provides its id to descendants. Creation goes via `make-frame`, taking the same constructor opts: `:id` / `:images` / record-config incl. `:initial-events`. Reuse **does not re-seed**: an idempotent re-mount preserves durable state and does not replay `:initial-events`. There is **no destroy-on-unmount**. `:id` is required and must be a keyword. True ownership stays explicit: `make-frame` + `destroy-frame!` inside a `create-class`.
 - **Example**:
   ```clojure
   ;; SCOPE — :todo already exists; this subtree just renders against it.
@@ -462,7 +474,7 @@ The view layer is **substrate-agnostic** — the shared dataflow (frames, subscr
   (capture-frame)          → {:frame :dispatch :dispatch-sync :subscribe}
   (capture-frame frame-id) → {:frame :dispatch :dispatch-sync :subscribe}
   ```
-- **Description**: Captures the active frame at CREATION time and returns an **operation bundle** whose `:dispatch` / `:dispatch-sync` / `:subscribe` ops always target the captured frame — they survive async boundaries (`Promise.then`, `setTimeout`, WebSocket `onmessage`, observer callbacks) where the ambient frame lookup would have unwound.
+- **Description**: Captures the active frame at CREATION time and returns an **operation bundle**. The bundle's `:dispatch` / `:dispatch-sync` / `:subscribe` ops always target the captured frame. They survive async boundaries — `Promise.then`, `setTimeout`, WebSocket `onmessage`, observer callbacks — where the ambient frame lookup would have unwound.
   - The handle is *locked* to one frame: a per-call `:frame` opt MUST NOT override it.
   - It is an operation bundle, not a container — read the frame's app-db value via `(rf/app-db-value (:frame handle))`, not the handle itself.
   - Full async-boundary contract: [Frames — the async boundary](../core/frames.md).
@@ -494,7 +506,7 @@ The view layer is **substrate-agnostic** — the shared dataflow (frames, subscr
   ```
 - **Description**: The two **lexical** (non-React) frame-scoping macros — for regions that aren't a view tree (tests, the REPL, SSR). Each rejects the other's argument shape at compile time.
   - `with-frame` pins `*current-frame*` to an **existing** frame-id for the dynamic extent of `body`, creating and destroying nothing. The lexical counterpart to the `rf/frame-provider` `{:frame …}` SCOPE shape.
-  - `with-new-frame` evaluates `expr`, binds the resulting frame target to `sym` (a live frame value from `make-frame`, or a keyword id from `reg-frame` — either is accepted downstream), runs `body` in that frame's dynamic context, and **destroys the frame on exit**. The throwaway-frame form for one-off harnesses.
+  - `with-new-frame` evaluates `expr` and binds the resulting frame target to `sym` — a live frame value from `make-frame`, or a keyword id from `reg-frame`; either is accepted downstream. It runs `body` in that frame's dynamic context, then **destroys the frame on exit**. The throwaway-frame form for one-off harnesses.
 - **Example**:
   ```clojure
   ;; Pin form — bind *current-frame* to an existing id for the body (most common)
@@ -512,7 +524,7 @@ The view layer is **substrate-agnostic** — the shared dataflow (frames, subscr
 
 The effect map is what an event handler returns; the interceptor chain runs before and after the handler. Handlers stay pure (they return descriptions of effects, not the effects themselves), and the runtime actions those descriptions at exactly one point.
 
-The effect map is **closed**: app handlers return `:db` + `:fx` only (a third reserved top-level key, `:rf.db/runtime`, exists for framework / runtime-extension authority — never for app handlers). `:db` is the new `app-db` value (replaced in the commit phase); `:fx` is a vector of `[fx-id args]` pairs (`[fx-id]` is the no-args shorthand), each run by the runtime's fx walker against the registered `reg-fx` handler. Both reserved keys are covered by the [effect map](../core/glossary.md#effect-map) glossary entry.
+The effect map is **closed**: app handlers return `:db` + `:fx` only. (A third reserved top-level key, `:rf.db/runtime`, exists for framework / runtime-extension authority — never for app handlers.) `:db` is the new `app-db` value, replaced in the commit phase. `:fx` is a vector of `[fx-id args]` pairs (`[fx-id]` is the no-args shorthand); the runtime's fx walker runs each pair against the registered `reg-fx` handler. Both reserved keys are covered by the [effect map](../core/glossary.md#effect-map) glossary entry.
 
 ### `reg-interceptor`
 
@@ -547,7 +559,7 @@ The effect map is **closed**: app handlers return `:db` + `:fx` only (a third re
   ```clojure
   (->interceptor & {:keys [id before after]})
   ```
-- **Description**: **INTERNAL — not the public authoring form.** The framework-internal lowering constructor that turns a `{:before … :after …}` descriptor into an executable chain entry (capturing the definition-site `:source-coord` from `(meta &form)`). Application code registers interceptors with `reg-interceptor` and references them by id; `->interceptor` must not appear directly in a public `:interceptors` chain.
+- **Description**: **INTERNAL — not the public authoring form.** The framework-internal lowering constructor. It turns a `{:before … :after …}` descriptor into an executable chain entry, capturing the definition-site `:source-coord` from `(meta &form)`. Application code registers interceptors with `reg-interceptor` and references them by id; `->interceptor` must not appear directly in a public `:interceptors` chain.
 
 ### `->interceptor*`
 
@@ -567,7 +579,7 @@ The effect map is **closed**: app handlers return `:db` + `:fx` only (a third re
   ```
 - **Description**: For the duration of `body`, every `dispatch` / `dispatch-sync` merges this fx-overrides map into its envelope. Lexical scope; composes with `with-frame`.
   - The three override scopes compose with a clear precedence: **per-call** (`(rf/dispatch event {:fx-overrides {...}})`) wins, then **lexical** (`with-fx-overrides`), then **per-frame** (`(rf/reg-frame :todo {:fx-overrides {...}})`).
-  - At the pattern level the override value is an **id**; the CLJS reference implementation also accepts a **fn** value for test wiring (the asymmetry is deliberate — ports that don't ship fn-valued overrides remain pattern-conformant).
+  - At the pattern level the override value is an **id**. The CLJS reference implementation also accepts a **fn** value for test wiring. The asymmetry is deliberate: ports that don't ship fn-valued overrides remain pattern-conformant.
 - **Example**:
   ```clojure
   ;; Swap the real managed-HTTP fx for a canned-failure stub for the test body —
@@ -583,8 +595,8 @@ The effect map is **closed**: app handlers return `:db` + `:fx` only (a third re
   ```clojure
   validate-at-boundary-interceptor
   ```
-- **Description**: A **pre-built interceptor value**, not a fn, registered under the framework id `:rf.schema/at-boundary`. Reference it **by id** from a `reg-event` metadata map's `:interceptors` vector — `{:interceptors [:rf.schema/at-boundary]}`; chains are reference-only, so the Var itself never appears as an inline chain entry.
-  - It forces `:schema` validation of the dispatched event vector even in production builds where dev-time validation is elided — for handlers that ingest data from outside the app's trust boundary (HTTP replies, websocket frames, postMessage).
+- **Description**: A **pre-built interceptor value**, not a fn, registered under the framework id `:rf.schema/at-boundary`. Reference it **by id** from a `reg-event` metadata map's `:interceptors` vector: `{:interceptors [:rf.schema/at-boundary]}`. Chains are reference-only, so the Var itself never appears as an inline chain entry.
+  - It forces `:schema` validation of the dispatched event vector even in production builds, where dev-time validation is normally elided. Use it on handlers that ingest data from outside the app's trust boundary: HTTP replies, websocket frames, postMessage.
   - **Do not call it as a fn** — invoking it raises `ArityException`.
   - Full contract: [re-frame.schemas.md](re-frame.schemas.md).
 - **Example**:
@@ -617,7 +629,7 @@ The framework reserves a few `:fx` entries and one standard interceptor referenc
 
 ## Frames
 
-A frame is the scoping unit for `app-db`, the event queue, and the pipeline. Most apps have exactly one frame, established at the root with `rf/frame-provider`. `init!` does **not** create one for you — frame identity is carried, not synthesised from absence (see [Frame identity is carried, not found](../core/glossary.md#frame-identity-is-carried-not-found)). Apps that need isolation between subsystems register additional frames and dispatch / subscribe against them via `{:frame :other}`.
+A frame is the scoping unit for `app-db`, the event queue, and the pipeline. Most apps have exactly one frame, established at the root with `rf/frame-provider`. `init!` does **not** create one for you: frame identity is carried, not synthesised from absence (see [Frame identity is carried, not found](../core/glossary.md#frame-identity-is-carried-not-found)). Apps that need isolation between subsystems register additional frames and dispatch / subscribe against them via `{:frame :other}`.
 
 ### `make-frame`
 
@@ -627,11 +639,14 @@ A frame is the scoping unit for `app-db`, the event queue, and the pipeline. Mos
   (make-frame opts) ; → live frame value
   (make-frame opts descriptors) ; → live frame value (explicit descriptor pool — tests / harnesses)
   ```
-- **Description**: The single public constructor for a live frame. It accepts image-selection *and* frame-configuration options in one call and **returns the live frame value** — one frame value backed by one registry. For per-mount lifecycles: devcards, modal stacks, multiple live widget instances, dynamic tabs, tests, and the SSR per-request frame pattern.
+- **Description**: The single public constructor for a live frame. It accepts image-selection *and* frame-configuration options in one call and **returns the live frame value**: one frame value backed by one registry. Use it for per-mount lifecycles — devcards, modal stacks, multiple live widget instances, dynamic tabs, tests, and the SSR per-request frame pattern.
   - `opts` must be a map — a non-map (including `nil`) raises `:rf.error/make-frame-bad-opts`; a non-vector `:images` raises `:rf.error/make-frame-bad-images`.
-  - Image-selection opts: `:images` (always a vector); `:id` (optional — registers the frame in the one process-local live-frame registry; a duplicate live id is **idempotent replacement** that preserves durable state on re-mount); `:adapter`.
+  - Image-selection opts:
+    - `:images` — always a vector.
+    - `:id` — optional. Registers the frame in the one process-local live-frame registry. A duplicate live id is **idempotent replacement**, preserving durable state on re-mount.
+    - `:adapter`.
   - Frame-configuration opts (same call): `:initial-events` (a vector of event vectors dispatched into the new frame at creation), `:fx-overrides`, `:platform`, `:ssr`, `:doc`, `:preset`, `:tags`.
-  - **Pass the value directly — no accessor needed:** `dispatch` / `subscribe` / `destroy-frame!` / `app-db-value` / `frame-provider` all accept the frame value OR its id interchangeably (API-shrink #1, rf2-csbbwu — there is no separate value→id accessor to reach for).
+  - **Pass the value directly — no accessor needed.** `dispatch` / `subscribe` / `destroy-frame!` / `app-db-value` / `frame-provider` all accept the frame value OR its id interchangeably. There is no separate value→id accessor to reach for (API-shrink #1, rf2-csbbwu).
   - Lifecycle is the caller's responsibility — pair a direct `make-frame` with a `destroy-frame!`, or use the UI-owned `rf/frame-provider` boundary.
   - See the [Frames concept guide](../core/frames.md) and [EP-0024](../EP/EP-0024-unified-frame-identity-and-lifecycle.md).
 - **Example**:
@@ -646,7 +661,7 @@ A frame is the scoping unit for `app-db`, the event queue, and the pipeline. Mos
 
 ### Resetting a frame — destroy + reg-frame
 
-There is no dedicated "reset" function — `reset-frame!` was retired (rf2-lxwpob): a full replace is reproducible by composing the two lifecycle primitives, not a third verb. To fully replace a frame — tearing it down through the normative `destroy-frame!` boundary (running `:on-destroy`, releasing per-feature resources) and re-registering it fresh, so machine snapshots, the route slice, flows, and `app-db` are all rebuilt from the registered config — compose:
+There is no dedicated "reset" function; `reset-frame!` was retired (rf2-lxwpob). A full replace composes the two lifecycle primitives — no third verb needed. Tear the frame down through the normative `destroy-frame!` boundary (running `:on-destroy`, releasing per-feature resources), then re-register it fresh. Machine snapshots, the route slice, flows, and `app-db` are all rebuilt from the registered config:
 
 ```clojure
 ;; Full frame replace (destroy + re-reg with the SAME config).
@@ -658,7 +673,7 @@ There is no dedicated "reset" function — `reset-frame!` was retired (rf2-lxwpo
 - For an image-loaded frame, re-supply the SAME `:images` vector too (via `make-frame`, not bare `reg-frame`) — otherwise the recreated frame degrades to the default image generation.
 - To wipe just the `app-db` partition while keeping live runtime-db, reach for `(replace-frame-state! frame-id {:rf.db/app {}})` instead.
 - There is **no** `:initial-db` config key — seeding `app-db` is itself an ordinary, traceable event, `[:rf/set-db {…}]`.
-- **Not atomic** across a handler-cascade boundary (unlike the retired `reset-frame!`): `destroy-frame!` has no handler-scope guard, so calling it from inside a handler destroys the frame before the following `reg-frame` hits its own construction-in-handler guard and throws, leaving the frame destroyed-and-not-reconstructed. Frame construction/destruction are already top-level/view-only operations, so this only bites a call site that was already violating that rule.
+- **Not atomic** across a handler-cascade boundary (unlike the retired `reset-frame!`). `destroy-frame!` has no handler-scope guard. Called from inside a handler, it destroys the frame; the following `reg-frame` then hits its own construction-in-handler guard and throws, leaving the frame destroyed and not reconstructed. Frame construction/destruction are already top-level/view-only operations, so this only bites a call site that was already violating that rule.
 
 ### `destroy-frame!`
 
@@ -684,7 +699,7 @@ There is no dedicated "reset" function — `reset-frame!` was retired (rf2-lxwpo
   ```clojure
   (current-frame-id) → keyword
   ```
-- **Description**: Return the active frame id the in-effect scope carries — the dynamic `*current-frame*` stamp or a React-context `frame-provider` scope (CLJS only). The context **reader** form; frame-scoped, requires a scope. There is **no `:rf/default` floor** — called under no established scope it raises `:rf.error/no-frame-context` (EP-0002).
+- **Description**: Return the active frame id the in-effect scope carries: the dynamic `*current-frame*` stamp, or a React-context `frame-provider` scope (CLJS only). This is the context **reader** form; it requires an established scope. There is **no `:rf/default` floor**. Called under no established scope, it raises `:rf.error/no-frame-context` (EP-0002).
 
 ### `frame-generation`
 
@@ -693,9 +708,13 @@ There is no dedicated "reset" function — `reset-frame!` was retired (rf2-lxwpo
   ```clojure
   (frame-generation frame-target) → generation map
   ```
-- **Description**: Return the SEALED, resolved image **generation** a live frame is running — the inert image-assembly generation it resolves `(kind, id)` lookups through. The raw read over the EP-0023 frame→generation model, for tools (Pair MCP `describe-image`, Xray).
+- **Description**: Return the SEALED, resolved image **generation** a live frame is running: the inert image-assembly generation it resolves `(kind, id)` lookups through. This is the raw read over the EP-0023 frame→generation model, for tools (Pair MCP `describe-image`, Xray).
   - `frame-target` is a registered frame id **or** a direct live frame object.
-  - Returns the generation map with stable public keys: `:rf.gen/resolver` (the sealed `[kind id]` map), `:rf.gen/images`, `:rf.gen/kinds`, and `:rf.gen/shadows` (the cross-image **shadow report** — a flat vector `[{:registration [kind id] :image <defined-in> :shadowed-by <winner>} …]`, `[]` when no later image shadowed an earlier one; what a LATER image overrode in an EARLIER one, EP-0026). Read the shadow report with `(:rf.gen/shadows (rf/frame-generation f))` — there is no dedicated accessor (the `frame-shadows` var was removed, rf2-i4hk4b).
+  - Returns the generation map with stable public keys:
+    - `:rf.gen/resolver` — the sealed `[kind id]` map.
+    - `:rf.gen/images` and `:rf.gen/kinds`.
+    - `:rf.gen/shadows` — the cross-image **shadow report**: what a LATER image overrode in an EARLIER one (EP-0026). A flat vector `[{:registration [kind id] :image <defined-in> :shadowed-by <winner>} …]`; `[]` when no later image shadowed an earlier one.
+  - Read the shadow report with `(:rf.gen/shadows (rf/frame-generation f))`. There is no dedicated accessor — the `frame-shadows` var was removed (rf2-i4hk4b).
   - **Fails loud** (`:rf.error/frame-no-generation`) when `frame-target` does not resolve to a live frame carrying a generation.
 
 ### `image`
@@ -712,7 +731,7 @@ There is no dedicated "reset" function — `reset-frame!` was retired (rf2-lxwpo
 
 ### Image hot-reload — re-`make-frame`
 
-There is no dedicated "reload" function — `reload-images!` was folded into re-construction (rf2-lxwpob). Re-calling `make-frame` against the SAME `:id` with a NEW `:images` vector re-seals the frame's `(kind, id)` resolver after handler/sub/view source changes, preserving frame memory — `reg-frame`'s surgical-update path swaps only the generation; app-db, runtime-db, caches, and lifecycle continue unchanged:
+There is no dedicated "reload" function; `reload-images!` was folded into re-construction (rf2-lxwpob). To re-seal a frame's `(kind, id)` resolver after handler/sub/view source changes, re-call `make-frame` against the SAME `:id` with a NEW `:images` vector. Frame memory is preserved: `reg-frame`'s surgical-update path swaps only the generation, while app-db, runtime-db, caches, and lifecycle continue unchanged:
 
 ```clojure
 (rf/make-frame {:id :my/frame :images [new-image]})
@@ -737,7 +756,7 @@ There is no dedicated "reload" function — `reload-images!` was folded into re-
   ```clojure
   (generation-diff before after) → diff map
   ```
-- **Description**: A PURE diff between two sealed image generations. Replaces the report the retired `reload-images!` verb used to return — read `frame-generation` before/after a re-`make-frame` reload and diff the two.
+- **Description**: A PURE diff between two sealed image generations. It replaces the report the retired `reload-images!` verb used to return: read `frame-generation` before and after a re-`make-frame` reload, then diff the two.
   - Returns `{:added #{[kind id] …} :changed #{…} :removed #{…} :retained #{…}}`.
 
 ## Lifecycle and configure
@@ -784,7 +803,7 @@ The surfaces that bring a re-frame2 process up and take it down. The one-line bo
   ```clojure
   (install-adapter! adapter-map)
   ```
-- **Description**: Must be called before any frame is created. **Lower-level than `init!`**; ordinary apps call `init!` instead. Installs once — a second call without an intervening `destroy-adapter!` raises `:rf.error/adapter-already-installed`. Use it for a custom boot pipeline with steps between adapter-install and first-frame creation.
+- **Description**: Must be called before any frame is created. **Lower-level than `init!`**; ordinary apps call `init!` instead. It installs once: a second call without an intervening `destroy-adapter!` raises `:rf.error/adapter-already-installed`. Use it for a custom boot pipeline with steps between adapter-install and first-frame creation.
 - **Example**:
   ```clojure
   (rf/install-adapter! reagent-adapter/adapter)   ;; seat the substrate (lower-level than init!)
@@ -856,15 +875,20 @@ The surfaces that bring a re-frame2 process up and take it down. The one-line bo
   ```clojure
   (configure! config-map)
   ```
-- **Description**: Process-level data knobs, typically set once at boot. One of three orthogonal configuration surfaces — `configure!` for process-level data knobs; the `set-!` / `install-!` setters for adapter-pluggable hooks; per-frame metadata for frame-scoped overrides. The key vocabulary is closed-and-additive (existing keys cannot be renamed; new keys are added by extending the table). Three keys ship:
+- **Description**: Process-level data knobs, typically set once at boot. It is one of three orthogonal configuration surfaces:
+  - `configure!` — process-level data knobs;
+  - the `set-!` / `install-!` setters — adapter-pluggable hooks;
+  - per-frame metadata — frame-scoped overrides.
+
+  The key vocabulary is closed-and-additive: existing keys cannot be renamed, and new keys are added by extending the table. Three keys ship:
 
   | Key | Opts | Default | Status | What it tunes |
   |---|---|---|---|---|
   | `:epoch-history` | `{:depth N :trace-events-keep N :redact-fn fn}` | `{:depth 50, :trace-events-keep 50, :redact-fn nil}` | v1 (dev-only) | Per-frame epoch ring depth, trace-event retention cap per record, and an optional projection-side redactor applied only at off-box egress (inside `projected-record`). |
-  | `:trace-buffer` | `{:events-retained N}` | `{:events-retained 50}` | v1 (dev-only) | The dev-only per-frame trace ring's event-slot count — one slot per event, regardless of how many trace events its run emitted. 0 disables retention (the surface stays live). |
+  | `:trace-buffer` | `{:events-retained N}` | `{:events-retained 50}` | v1 (dev-only) | The dev-only per-frame trace ring's event-slot count: one slot per event, regardless of how many trace events its run emitted. 0 disables retention (the surface stays live). |
   | `:elision` | `{:rf.size/threshold-bytes N}` | `{:rf.size/threshold-bytes 16384}` | v1 | The size threshold above which `elide-wire-value` substitutes a `:rf.size/large-elided` marker. 0 disables runtime auto-detect. |
 
-  There is **no `:sub-cache` knob** — sub-cache disposal is synchronous on derefer-count → 0. SSR error-projection policy (`:public-error-id`, `:dev-error-detail?`) is **not** a `configure!` key — it is per-frame metadata on the frame's `:ssr` map. Framework-owned semantic sub-keys use a namespaced keyword (`:rf.size/threshold-bytes`); ergonomic per-knob sub-keys are unqualified (`:depth`, `:trace-events-keep`, `:redact-fn`).
+  There is **no `:sub-cache` knob**: sub-cache disposal happens synchronously when the derefer count hits 0. SSR error-projection policy (`:public-error-id`, `:dev-error-detail?`) is **not** a `configure!` key; it is per-frame metadata on the frame's `:ssr` map. Framework-owned semantic sub-keys use a namespaced keyword (`:rf.size/threshold-bytes`); ergonomic per-knob sub-keys are unqualified (`:depth`, `:trace-events-keep`, `:redact-fn`).
 - **Example**:
   ```clojure
   (rf/configure! {:epoch-history {:depth 100}
@@ -906,7 +930,7 @@ The surfaces that bring a re-frame2 process up and take it down. The one-line bo
   ```clojure
   (require-feature! feature) → true (or throws)
   ```
-- **Description**: Assert the optional feature is loaded. Returns `true` when its implementation artefact is on the classpath. Throws a structured `:rf.error/feature-not-loaded` ex-info carrying the exact copy-pasteable Maven coordinate + require form when it is not; an unknown feature keyword throws `:rf.error/unknown-feature`. Use as an early guard at the top of code that depends on an optional feature.
+- **Description**: Assert the optional feature is loaded. Returns `true` when its implementation artefact is on the classpath. When it is not, throws a structured `:rf.error/feature-not-loaded` ex-info carrying the exact copy-pasteable Maven coordinate + require form. An unknown feature keyword throws `:rf.error/unknown-feature`. Use as an early guard at the top of code that depends on an optional feature.
 - **Example**:
   ```clojure
   (rf/require-feature! :epoch)   ;; absent => :rf.error/feature-not-loaded with copy-paste deps + require
@@ -914,7 +938,7 @@ The surfaces that bring a re-frame2 process up and take it down. The one-line bo
 
 ## Instrumentation and listeners
 
-Two surfaces stacked. The first is **dev-only**: a trace bus that emits one richly-tagged record per noteworthy event, buffered into a ring, fanned out to registered listeners synchronously, and elided entirely under `:advanced` + `goog.DEBUG=false`. The second is **always-on**: tight, production-survivable substrates (event-emit, error-emit) that deliver one record per processed event and one per `:rf.error/*` event. The epoch (time-travel) surfaces are dev-only and also available natively as [re-frame.epoch.md](re-frame.epoch.md). The complete error catalogue is normative in Spec 009.
+Two surfaces stacked. The first is **dev-only**: a trace bus that emits one richly-tagged record per noteworthy event. Records are buffered into a ring and fanned out to registered listeners synchronously; the whole surface is elided under `:advanced` + `goog.DEBUG=false`. The second is **always-on**: tight, production-survivable substrates (event-emit, error-emit) that deliver one record per processed event and one per `:rf.error/*` event. The epoch (time-travel) surfaces are dev-only and also available natively as [re-frame.epoch.md](re-frame.epoch.md). The complete error catalogue is normative in Spec 009.
 
 ### `register-listener!`
 
@@ -923,9 +947,12 @@ Two surfaces stacked. The first is **dev-only**: a trace bus that emits one rich
   ```clojure
   (register-listener! stream id callback-fn)
   ```
-- **Description**: Register `callback-fn` under `id` to receive every record the runtime emits on `stream`. Synchronous delivery — the callback returns before the next record. Re-registering the same id on a stream replaces.
-  - Streams: `:trace` (dev-only, DCE'd in production); `:events` and `:errors` (**always-on** — survive CLJS `:advanced` + `goog.DEBUG=false`); `:epoch` (optional artefact).
-  - Returns `id` (`nil` on the `:epoch` stream when the `day8/re-frame2-epoch` artefact is absent); an unknown `stream` throws `:rf.error/unknown-listener-stream`.
+- **Description**: Register `callback-fn` under `id` to receive every record the runtime emits on `stream`. Delivery is synchronous: the callback returns before the next record. Re-registering the same id on a stream replaces.
+  - Streams:
+    - `:trace` — dev-only, DCE'd in production.
+    - `:events` and `:errors` — **always-on**; they survive CLJS `:advanced` + `goog.DEBUG=false`.
+    - `:epoch` — optional artefact.
+  - Returns `id` (`nil` on the `:epoch` stream when the `day8/re-frame2-epoch` artefact is absent). An unknown `stream` throws `:rf.error/unknown-listener-stream`.
 - **Example**:
   ```clojure
   ;; Dev-only: tap every trace event the runtime emits (DCE'd in production).
@@ -960,7 +987,7 @@ Two surfaces stacked. The first is **dev-only**: a trace bus that emits one rich
   (rf/unregister-listener! :trace :my-app/trace-tap)
   ```
 
-There is deliberately **no** facade `clear-listeners!` verb. Dropping every listener on a stream is a test-isolation concern owned by the fixture layer: `re-frame.test-support`'s reset clears the registries through the lower-level sinks directly (`re-frame.trace.tooling/clear-listeners!`, `re-frame.event-emit/clear-event-listeners!`, `re-frame.error-emit/clear-error-listeners!`, and the `:epoch/clear-epoch-listeners!` reset hook). The former per-stream `clear-listeners!` façade verb was retired in API-shrink #4.
+There is deliberately **no** facade `clear-listeners!` verb. Dropping every listener on a stream is a test-isolation concern owned by the fixture layer. `re-frame.test-support`'s reset clears the registries through the lower-level sinks directly: `re-frame.trace.tooling/clear-listeners!`, `re-frame.event-emit/clear-event-listeners!`, `re-frame.error-emit/clear-error-listeners!`, and the `:epoch/clear-epoch-listeners!` reset hook. The former per-stream `clear-listeners!` façade verb was retired in API-shrink #4.
 
 ### `emit-trace-event!`
 
@@ -983,7 +1010,7 @@ There is deliberately **no** facade `clear-listeners!` verb. Dropping every list
   (trace-buffer frame-id) → vector of event bundles, oldest-first
   (trace-buffer frame-id opts) → vector; {:flat true} yields raw trace events
   ```
-- **Description**: Read the named frame's dev-only, event-keyed ring non-destructively — one bundle per retained pipeline run by default; `{:flat true}` returns the raw trace events instead.
+- **Description**: Read the named frame's dev-only, event-keyed ring non-destructively. By default it returns one bundle per retained pipeline run; `{:flat true}` returns the raw trace events instead.
   - Returns `[]` for a destroyed / never-registered frame, and `[]` in production (the ring is never allocated).
   - On the `re-frame.core` facade this is a **JVM-only** alias — CLJS callers use `re-frame.trace.tooling/trace-buffer` directly.
   - The retained event-slot count is the `(rf/configure! {:trace-buffer {:events-retained N}})` knob.
@@ -1013,7 +1040,7 @@ There is deliberately **no** facade `clear-listeners!` verb. Dropping every list
   ```clojure
   (group-by-event events) → vector of event records
   ```
-- **Description**: Pure data projection of a list of trace events into per-event records `{:dispatch-id :parent-dispatch-id :frame :event :dispatched :handler :fx :effects :subs :renders :other}` (one record per `[frame dispatch-id]` pipeline run), sorted by emission order. JVM-runnable.
+- **Description**: A pure data projection. It turns a list of trace events into per-event records `{:dispatch-id :parent-dispatch-id :frame :event :dispatched :handler :fx :effects :subs :renders :other}` — one record per `[frame dispatch-id]` pipeline run, sorted by emission order. JVM-runnable.
 - **Example**:
   ```clojure
   (rf/group-by-event (rf/trace-buffer :app/main {:flat true}))
@@ -1049,9 +1076,9 @@ There is deliberately **no** facade `clear-listeners!` verb. Dropping every list
   (elide-wire-value v) → v or an elision-marker substitution
   (elide-wire-value v opts) → v or an elision-marker substitution
   ```
-- **Description**: The framework primitive that walks tree-shaped values at the wire boundary and substitutes elision markers for sensitive or large slots — the **single normative emission site** for the `:rf/redacted` sentinel and the `:rf.size/large-elided` marker. Walks `v` consulting the frame's runtime-db classification declarations; the frame resolves from the explicit `:frame` opt, else the carried scope.
-  - Redaction is strictly **path-based** — a secret re-keyed off its classified path ships raw (the **fail-open** default; to redact it, classify the destination path).
-  - A *live* frame carrying no declarations passes the value through unchanged; a frameless or unresolvable-frame call **fails closed** — the whole value is redacted to `:rf/redacted` (opt out with `:rf.size/include-sensitive? true`).
+- **Description**: The framework primitive that walks tree-shaped values at the wire boundary and substitutes elision markers for sensitive or large slots. It is the **single normative emission site** for the `:rf/redacted` sentinel and the `:rf.size/large-elided` marker. It walks `v` consulting the frame's runtime-db classification declarations; the frame resolves from the explicit `:frame` opt, else from the carried scope.
+  - Redaction is strictly **path-based**: a secret re-keyed off its classified path ships raw. That is the **fail-open** default; to redact it, classify the destination path.
+  - A *live* frame carrying no declarations passes the value through unchanged. A frameless or unresolvable-frame call **fails closed**: the whole value is redacted to `:rf/redacted`. Opt out with `:rf.size/include-sensitive? true`.
   - This is the low-level *value* walker; the record-level boundary primitive is `project-egress`.
 - **Example**:
   ```clojure
@@ -1067,7 +1094,7 @@ There is deliberately **no** facade `clear-listeners!` verb. Dropping every list
   ```clojure
   (project-egress record-or-value opts)
   ```
-- **Description**: The public, record-level boundary primitive — **the required step before any off-box sink**. Dispatches on a record's `:kind` (`:rf.observe/handled-event` / `:rf.observe/error`) to a per-kind projector, falling back to walking a kindless input as a tree-shaped value; each tree-shaped slot is delegated to `elide-wire-value` against the frame's classification.
+- **Description**: The public, record-level boundary primitive — **the required step before any off-box sink**. It dispatches on a record's `:kind` (`:rf.observe/handled-event` / `:rf.observe/error`) to a per-kind projector, and falls back to walking a kindless input as a tree-shaped value. Each tree-shaped slot is delegated to `elide-wire-value` against the frame's classification.
   - `opts` carries `:rf.egress/profile` (the closed six-member enum), `:frame`, `:path`, and advanced `:rf.size/*` overrides.
   - An unknown profile throws `:rf.error/unknown-egress-profile`.
   - **Fail-closed**: a tree slot projects only when the frame is known — no `:rf/default` synthesis.
@@ -1095,7 +1122,7 @@ There is deliberately **no** facade `clear-listeners!` verb. Dropping every list
   - `f` receives a single **already-projected** record (projected under the owning frame's classification and the entry's egress profile); it does **no** sink-local redaction.
   - Re-registering the same id replaces. Returns `sink-id`.
   - **Always-on** — survives CLJS `:advanced` + `goog.DEBUG=false`.
-  - The production-normal observability seam (frame-scoped + profile-projected), parallel to the corpus-wide `register-listener!` surface (cross-frame and raw).
+  - This is the production-normal observability seam: frame-scoped and profile-projected. It parallels the corpus-wide `register-listener!` surface, which is cross-frame and raw.
 - **Example**:
   ```clojure
   (rf/reg-frame :app/main
@@ -1157,7 +1184,7 @@ There is deliberately **no** facade `clear-listeners!` verb. Dropping every list
   ```clojure
   (restore-epoch! frame-id epoch-id) → boolean
   ```
-- **Description**: Restore the frame's whole **frame-state** — both the app-db and runtime-db partitions — to the named epoch's `:frame-state-after`, reinstalled in one atomic write (so machine snapshots, the route slice, and other runtime-db material rewind alongside app-db). Returns `true` on success; `false` for an unknown / destroyed frame (and emits `:rf.error/no-such-handler` of kind `:frame`).
+- **Description**: Restore the frame's whole **frame-state** — both the app-db and runtime-db partitions — to the named epoch's `:frame-state-after`. The state is reinstalled in one atomic write, so machine snapshots, the route slice, and other runtime-db material rewind alongside app-db. Returns `true` on success. Returns `false` for an unknown / destroyed frame, and emits `:rf.error/no-such-handler` of kind `:frame`.
 - **Example**:
   ```clojure
   ;; Time-travel: rewind a frame's whole frame-state to a recorded epoch.
@@ -1172,7 +1199,7 @@ There is deliberately **no** facade `clear-listeners!` verb. Dropping every list
   ```clojure
   (replace-frame-state! frame-id frame-state) → boolean
   ```
-- **Description**: The ONE frame-state write surface (rf2-t3lftq — API-shrink #3 consolidated the former `replace-app-db!` / `reset-app-db!` / `replace-runtime-db!` / `replace-frame-state!` four-mutator family into this). `frame-state` is a PARTIAL frame-state map — any subset of `{:rf.db/app … :rf.db/runtime …}`: a present key replaces that partition, an absent key is preserved unchanged. Bypasses the dispatch loop; records a synthetic epoch so `restore-epoch!` can rewind. A map carrying no recognized partition key, or an unrecognized key, is rejected as `:rf.error/replace-frame-state-bad-keys` (checked before frame resolution). Returns `true` on success, `false` on a documented failure.
+- **Description**: The ONE frame-state write surface. (API-shrink #3, rf2-t3lftq, consolidated the former `replace-app-db!` / `reset-app-db!` / `replace-runtime-db!` / `replace-frame-state!` four-mutator family into this.) `frame-state` is a PARTIAL frame-state map: any subset of `{:rf.db/app … :rf.db/runtime …}`. A present key replaces that partition; an absent key is preserved unchanged. It bypasses the dispatch loop and records a synthetic epoch so `restore-epoch!` can rewind. A map carrying no recognized partition key, or an unrecognized key, is rejected as `:rf.error/replace-frame-state-bad-keys` (checked before frame resolution). Returns `true` on success, `false` on a documented failure.
 - **Examples**:
   ```clojure
   ;; App-only state injection (the former replace-app-db!).
@@ -1190,7 +1217,7 @@ There is deliberately **no** facade `clear-listeners!` verb. Dropping every list
 
 ### Epoch-settled listeners
 
-Epoch drain-settle listeners are the `:epoch` stream of the stream-parameterized listener verb — there is no separate facade `register-epoch-listener!` fn (the per-channel pair was retired in API-shrink #4; the epoch stream registers through the one verb exactly like `:trace` / `:events` / `:errors`).
+Epoch drain-settle listeners are the `:epoch` stream of the stream-parameterized listener verb. There is no separate facade `register-epoch-listener!` fn — the per-channel pair was retired in API-shrink #4. The epoch stream registers through the one verb exactly like `:trace` / `:events` / `:errors`.
 
 - **Signature**: `(rf/register-listener! :epoch key callback-fn)` / `(rf/unregister-listener! :epoch key)`
 - **Description**: Process-global assembled-epoch listener, dev-only. The callback fires once per drain-settle with the assembled `:rf/epoch-record`; re-registering the same `key` replaces. A callback whose previously-observed frame is destroyed receives a one-shot `:rf.epoch.cb/silenced-on-frame-destroy` trace. Returns `key`, or `nil` when the `day8/re-frame2-epoch` artefact is absent.
@@ -1211,7 +1238,7 @@ Epoch drain-settle listeners are the `:epoch` stream of the stream-parameterized
   (projected-record record)
   (projected-record record opts)
   ```
-- **Description**: Project an `:rf/epoch-record` for off-box egress — routes the record through the egress projection (applying the optional `(rf/configure! {:epoch-history {:redact-fn …}})` redactor) so an epoch record can be shipped off-box safely. The ring and listeners always deliver the raw record, so projection never affects `restore-epoch!` fidelity. See [re-frame.epoch.md](re-frame.epoch.md).
+- **Description**: Project an `:rf/epoch-record` for off-box egress. It routes the record through the egress projection, applying the optional `(rf/configure! {:epoch-history {:redact-fn …}})` redactor, so an epoch record can be shipped off-box safely. The ring and listeners always deliver the raw record, so projection never affects `restore-epoch!` fidelity. See [re-frame.epoch.md](re-frame.epoch.md).
 
 ### `projected-history`
 
@@ -1235,8 +1262,8 @@ The registrar holds every registered handler — events, subs, fx, cofx, flows, 
   (registrations kind) → {id metadata-map}
   (registrations kind pred-fn) → {id metadata-map}
   ```
-- **Description**: Walk the registrar with the full metadata map per id — source-coords, `:rf/sensitive`, `:rf/machine?`, `:platforms`, the doc string. Use when you want metadata; optional `pred-fn` filters by the metadata map.
-  - Frame-targeted form `(registrations {:frame :tenants/acme :kind :sub})` (an optional `:pred` filters as above) returns only the ids that frame's image carries, resolved through the frame's sealed image generation (EP-0023).
+- **Description**: Walk the registrar, returning the full metadata map per id: source-coords, `:rf/sensitive`, `:rf/machine?`, `:platforms`, the doc string. Use it when you want metadata; the optional `pred-fn` filters by the metadata map.
+  - The frame-targeted form `(registrations {:frame :tenants/acme :kind :sub})` returns only the ids that frame's image carries, resolved through the frame's sealed image generation (EP-0023). An optional `:pred` filters as above.
   - A map argument is always a frame-targeted read: a map without `:frame` raises `:rf.error/registrar-query-needs-frame`; a `:frame` that does not resolve to a live frame carrying a generation raises `:rf.error/frame-no-generation`.
 - **Example**:
   ```clojure
@@ -1255,7 +1282,7 @@ The registrar holds every registered handler — events, subs, fx, cofx, flows, 
   ```
 - **Description**: What `reg-*` stamped at this id. View registrations include source-coord keys (`:ns` / `:line` / `:column` / `:file`); pair tools resolve `data-rf2-source-coord` DOM annotations to `:file` via this lookup.
   - Registrar kinds: `:event`, `:sub`, `:fx`, `:cofx`, `:interceptor`, `:view`, `:frame`, `:route`, `:head`, `:error-projector`, `:flow`, `:resource`.
-  - The two machine kinds `:machine-guard` / `:machine-action` are additionally accepted on the positional arity with a 2-vector id — `(handler-meta :machine-guard [machine-id guard-id])` — derived on demand from the machine's registration spec (dev-only source; not frame-targetable).
+  - The two machine kinds `:machine-guard` / `:machine-action` are additionally accepted on the positional arity with a 2-vector id: `(handler-meta :machine-guard [machine-id guard-id])`. They are derived on demand from the machine's registration spec (a dev-only source; not frame-targetable).
   - The map arity is the frame-targeted read; the same map-arity errors as `registrations` apply (`:rf.error/registrar-query-needs-frame`, `:rf.error/frame-no-generation`).
   - App-db schemas are **not** a registrar kind — look them up via `(app-schema-meta-at path)` in [re-frame.schemas.md](re-frame.schemas.md).
 - **Example**:
@@ -1301,7 +1328,7 @@ The registrar holds every registered handler — events, subs, fx, cofx, flows, 
   ```clojure
   (app-db-value frame-id) → app-db value (plain map)
   ```
-- **Description**: Return the current `app-db` value for this frame — the deref'd `app-db` map (a plain value, not the container), or `nil` for an unknown / destroyed frame. Accepts a frame-id keyword or a live frame object.
+- **Description**: Return the current `app-db` value for this frame: the deref'd `app-db` map — a plain value, not the container. Returns `nil` for an unknown / destroyed frame. Accepts a frame-id keyword or a live frame object.
 - **Example**:
   ```clojure
   (rf/app-db-value :rf/default)
@@ -1315,18 +1342,18 @@ The registrar holds every registered handler — events, subs, fx, cofx, flows, 
   ```clojure
   (frame-state-value frame-id) → {:rf.db/app … :rf.db/runtime …}
   ```
-- **Description**: Return the coherent frame-state projection for the named frame — `{:rf.db/app <app-db> :rf.db/runtime <runtime-db>}`, or `nil` for an unknown / destroyed frame. The full-frame read for SSR / epoch / time-travel / Xray. A fresh frame's state is `{:rf.db/app {} :rf.db/runtime {}}`. The runtime-db-only read (retired `runtime-db-value`, rf2-t3lftq — API-shrink #3) is `(:rf.db/runtime (frame-state-value frame-id))`.
+- **Description**: Return the coherent frame-state projection for the named frame: `{:rf.db/app <app-db> :rf.db/runtime <runtime-db>}`, or `nil` for an unknown / destroyed frame. This is the full-frame read for SSR / epoch / time-travel / Xray. A fresh frame's state is `{:rf.db/app {} :rf.db/runtime {}}`. For a runtime-db-only read, use `(:rf.db/runtime (frame-state-value frame-id))` — the dedicated `runtime-db-value` was retired (rf2-t3lftq, API-shrink #3).
 - **Example**:
   ```clojure
   (:rf.db/runtime (rf/frame-state-value :rf/default))
   ;; => {:rf.runtime/machines {...}}
   ```
 
-> `snapshot-of` was retired by rf2-t3lftq (API-shrink #3) — an empirically zero-caller convenience over `app-db-value` + `get-in`. Use `(get-in (rf/app-db-value frame-id) path)` directly.
+> `snapshot-of` was retired by rf2-t3lftq (API-shrink #3); it was an empirically zero-caller convenience over `app-db-value` + `get-in`. Use `(get-in (rf/app-db-value frame-id) path)` directly.
 
 ## Feature registration (re-exports)
 
-These surfaces are re-exported on the `re-frame.core` facade for single-import ergonomics, but each is **defined in full — signature, metadata grammar, examples — in its feature namespace doc**. Entries here are brief; author against the linked doc. (Each feature's keyword surfaces — its `:fx` ids, standard events, and standard subs — also live in the feature doc.)
+These surfaces are re-exported on the `re-frame.core` facade so a single import covers everything. Each is **defined in full — signature, metadata grammar, examples — in its feature namespace doc**. Entries here are brief; author against the linked doc. Each feature's keyword surfaces (its `:fx` ids, standard events, and standard subs) also live in the feature doc.
 
 ### Machines → [re-frame.machines.md](re-frame.machines.md)
 
@@ -1336,15 +1363,15 @@ A state machine is registered with one call and *is* an event handler; the trans
 
 - **Kind**: macro
 - **Signature**: `(reg-machine machine-id ?metadata machine-spec)`
-- The canonical machine-registration macro — compiles a transition-table spec into a `reg-event` handler, co-locating per-element source coords for Xray navigation. The optional middle slot is a registration-metadata map (its `:schema` validates the dispatched outer event vector). Full contract in [re-frame.machines.md](re-frame.machines.md).
+- The canonical machine-registration macro. It compiles a transition-table spec into a `reg-event` handler, co-locating per-element source coords for Xray navigation. The optional middle slot is a registration-metadata map; its `:schema` validates the dispatched outer event vector. Full contract in [re-frame.machines.md](re-frame.machines.md).
 
 #### `defmachine`
 
 - **Kind**: macro
 - **Signature**: `(defmachine name ?docstring machine-spec)`
-- The `def`-shape companion to `reg-machine` — defines the machine-spec value, binding `name`, with per-element source captured at the definition site so a later `(reg-machine :id name)` retains it. (The plain-fn `reg-machine*` is **not** on the facade — it lives in `re-frame.machines`.) Full contract in [re-frame.machines.md](re-frame.machines.md).
+- The `def`-shape companion to `reg-machine`. It defines the machine-spec value and binds `name`, capturing per-element source at the definition site so a later `(reg-machine :id name)` retains it. (The plain-fn `reg-machine*` is **not** on the facade — it lives in `re-frame.machines`.) Full contract in [re-frame.machines.md](re-frame.machines.md).
 
-A machine's snapshot is read with the ordinary `subscribe` naming its framework sub vector — `@(rf/subscribe [:rf/machine machine-id])` for the whole `{:state :data :tags}` snapshot, `@(rf/subscribe [:rf.machine/has-tag? machine-id tag])` for a reactive `:tags`-membership predicate. Full contract in [re-frame.machines.md](re-frame.machines.md).
+Read a machine's snapshot with the ordinary `subscribe`, naming its framework sub vector. `@(rf/subscribe [:rf/machine machine-id])` returns the whole `{:state :data :tags}` snapshot. `@(rf/subscribe [:rf.machine/has-tag? machine-id tag])` is a reactive `:tags`-membership predicate. Full contract in [re-frame.machines.md](re-frame.machines.md).
 
 ### Routing → [re-frame.routing.md](re-frame.routing.md)
 
@@ -1354,15 +1381,15 @@ Routes are data; the current route lives in runtime-db (read via the `:rf/route`
 
 - **Kind**: macro
 - **Signature**: `(reg-route id metadata path)`
-- Register a route as data — the id is the dispatch target, the path is the URL shape, the metadata carries match events and guards (`:on-match`, `:can-leave`, `:params`, `:query`, …). Full contract in [re-frame.routing.md](re-frame.routing.md).
+- Register a route as data. The id is the dispatch target; the path is the URL shape; the metadata carries match events and guards (`:on-match`, `:can-leave`, `:params`, `:query`, …). Full contract in [re-frame.routing.md](re-frame.routing.md).
 
 #### `route-link`
 
 - **Kind**: registered view (function)
 - **Signature**: `[rf/route-link {:to :route-id :params {...} :query {...} :fragment "..."} & children]`
-- A registered view at `:route/link` — renders an `<a href=...>` from a route id and intercepts plain primary-button clicks to dispatch `:rf.route/url-requested` (modifier-key / middle clicks and `:target`/`:download` anchors defer to the browser). Full contract in [re-frame.routing.md](re-frame.routing.md).
+- A registered view at `:route/link`. It renders an `<a href=...>` from a route id and intercepts plain primary-button clicks to dispatch `:rf.route/url-requested`. Modifier-key / middle clicks and `:target`/`:download` anchors defer to the browser. Full contract in [re-frame.routing.md](re-frame.routing.md).
 
-There is no `install-url-listener!` / `remove-url-listener!` (or `install-history-listener!` / `remove-history-listener!`) on this facade — the browser URL-change listener is wired automatically by the `:url-bound?` frame lifecycle (creation installs, destroy removes). See [re-frame.routing.md § Browser URL listener](re-frame.routing.md).
+There is no `install-url-listener!` / `remove-url-listener!` (or `install-history-listener!` / `remove-history-listener!`) on this facade. The browser URL-change listener is wired automatically by the `:url-bound?` frame lifecycle: creation installs it, destroy removes it. See [re-frame.routing.md § Browser URL listener](re-frame.routing.md).
 
 ### Flows → [re-frame.flows.md](re-frame.flows.md)
 
@@ -1399,11 +1426,11 @@ Malli schemas attached to `app-db` paths; validated on writes in dev, elided in 
   (reg-app-schemas {path-1 schema-1, path-2 schema-2, ...})
   (reg-app-schemas {path-1 schema-1, ...} opts)
   ```
-- The bulk plural form — registers many path→schema entries against the active frame (or the `:frame` opt) in one call, each stamped with this call's source coords. Returns the vector of paths registered. Full contract in [re-frame.schemas.md](re-frame.schemas.md).
+- The bulk plural form. It registers many path→schema entries against the active frame (or the `:frame` opt) in one call; each entry is stamped with this call's source coords. Returns the vector of paths registered. Full contract in [re-frame.schemas.md](re-frame.schemas.md).
 
 ### SSR → [re-frame.ssr.md](re-frame.ssr.md)
 
-Server-side rendering is the same framework server-side. A curated set of rendering and head primitives is re-exported here as **late-bound wrappers** that resolve to the `re-frame.ssr` implementation when the `day8/re-frame2-ssr` artefact is on the classpath and throw a clear "SSR not loaded" error otherwise. The host-adapter surface ([re-frame.ssr.ring.md](re-frame.ssr.ring.md)) and the per-request `:rf.server/*` fx are **not** re-exported. Standard SSR events (`:rf/server-init`, `:rf/hydrate`), subs (`:rf/head`, `:rf/public-error`), and the server-only fx live in the SSR doc.
+Server-side rendering is the same framework server-side. A curated set of rendering and head primitives is re-exported here as **late-bound wrappers**. Each wrapper resolves to the `re-frame.ssr` implementation when the `day8/re-frame2-ssr` artefact is on the classpath, and throws a clear "SSR not loaded" error otherwise. The host-adapter surface ([re-frame.ssr.ring.md](re-frame.ssr.ring.md)) and the per-request `:rf.server/*` fx are **not** re-exported. Standard SSR events (`:rf/server-init`, `:rf/hydrate`), subs (`:rf/head`, `:rf/public-error`), and the server-only fx live in the SSR doc.
 
 #### `reg-head`
 
@@ -1425,7 +1452,7 @@ Server-side rendering is the same framework server-side. A curated set of render
   (render-to-string view-or-hiccup) → HTML string
   (render-to-string view-or-hiccup opts) → HTML string
   ```
-- The canonical server-side render — walks the hiccup tree once, emits a string. `opts` may carry `:doctype?` and `:emit-hash?`. JVM-runnable; pure. Full contract in [re-frame.ssr.md](re-frame.ssr.md).
+- The canonical server-side render: it walks the hiccup tree once and emits a string. `opts` may carry `:doctype?` and `:emit-hash?`. JVM-runnable; pure. Full contract in [re-frame.ssr.md](re-frame.ssr.md).
 
 #### `render-tree-hash`
 
@@ -1449,7 +1476,7 @@ Server-side rendering is the same framework server-side. A curated set of render
 
 - **Kind**: function
 - **Signature**: `(active-head frame-id) → :rf/head-model`
-- Resolve the head-model for the currently active route in the named frame (a frame-scoped read — the frame is carried, not ambient; a `nil` frame-id raises `:rf.error/no-frame-context`). Full contract in [re-frame.ssr.md](re-frame.ssr.md).
+- Resolve the head-model for the currently active route in the named frame. This is a frame-scoped read: the frame is carried, not ambient, and a `nil` frame-id raises `:rf.error/no-frame-context`. Full contract in [re-frame.ssr.md](re-frame.ssr.md).
 
 #### `head-model->html`
 
@@ -1475,7 +1502,7 @@ Managed HTTP is an optional capability: one fx-id (`[:rf.http/managed …]`), on
 
 - **Kind**: macro
 - **Signature**: `(reg-http-interceptor id interceptor-map)`
-- Register an HTTP interceptor on a frame's `:rf.http/managed` middleware chain (`:before (fn [ctx] ctx')` request-side, `:after (fn [ctx response] response')` response-side; `:before` in registration order, `:after` in reverse). Full contract in [re-frame.http.md](re-frame.http.md).
+- Register an HTTP interceptor on a frame's `:rf.http/managed` middleware chain. `:before (fn [ctx] ctx')` runs request-side, in registration order. `:after (fn [ctx response] response')` runs response-side, in reverse order. Full contract in [re-frame.http.md](re-frame.http.md).
 
 #### `clear-http-interceptor`
 
@@ -1491,7 +1518,7 @@ Managed HTTP is an optional capability: one fx-id (`[:rf.http/managed …]`), on
 
 - **Kind**: macro
 - **Signature**: `(with-managed-request-stubs route-map body+)`
-- Lexical-scope HTTP stubbing — `route-map` is `{[<method> <url>] {:reply {:ok v}}}` (or `{:failure …}`); inside the body, matching requests bypass the real client and auto-route by method + URL with no manual `:fx-overrides`. Full contract in [re-frame.http.md](re-frame.http.md).
+- Lexical-scope HTTP stubbing. `route-map` is `{[<method> <url>] {:reply {:ok v}}}` (or `{:failure …}`). Inside the body, matching requests bypass the real client and auto-route by method + URL, with no manual `:fx-overrides`. Full contract in [re-frame.http.md](re-frame.http.md).
 
 #### `with-managed-request-stubs*`
 
@@ -1507,7 +1534,7 @@ Resources are an optional capability (cached server-state reads plus mutations) 
 
 - **Kind**: macro
 - **Signature**: `(reg-resource resource-id metadata request-fn)`
-- Register a resource as data — `metadata` carries the required fail-closed `:scope` policy + `:params-schema`; the `request-fn` returns a managed-HTTP args map. Full contract in [re-frame.resources.md](re-frame.resources.md).
+- Register a resource as data. `metadata` carries the required fail-closed `:scope` policy plus `:params-schema`; the `request-fn` returns a managed-HTTP args map. Full contract in [re-frame.resources.md](re-frame.resources.md).
 
 #### `reg-mutation`
 
@@ -1519,7 +1546,7 @@ Resources are an optional capability (cached server-state reads plus mutations) 
 
 - **Kind**: macro
 - **Signature**: `(reg-resource-scope scope-id metadata resolve-fn)`
-- Register a named resource-scope resolver under `scope-id` (referenced by a resource's `:scope` policy) in the canonical 3-slot grammar: the `:resolve` fn is the value slot, and `metadata` carries the declared `:inputs` (omit `:inputs` for the 2-arg whole-db sugar). Returns `scope-id`. Full contract in [re-frame.resources.md](re-frame.resources.md).
+- Register a named resource-scope resolver under `scope-id`; a resource's `:scope` policy references it. The canonical 3-slot grammar applies: the `:resolve` fn is the value slot, and `metadata` carries the declared `:inputs` (omit `:inputs` for the 2-arg whole-db sugar). Returns `scope-id`. Full contract in [re-frame.resources.md](re-frame.resources.md).
 
 #### `clear-resource`
 

--- a/docs/api/re-frame.epoch.md
+++ b/docs/api/re-frame.epoch.md
@@ -1,12 +1,12 @@
 # re-frame.epoch
 
-`re-frame.epoch` is the per-frame epoch-history surface: dev-only time-travel and post-mortem. On each dequeued event (at its run-to-completion boundary, not once per drain) the runtime records one `:rf/epoch-record` into a per-frame ring buffer, capturing before/after frame-state, the triggering event, and the harvested trace stream. Pair-shaped tools (Xray, re-frame2-pair, Story) read this history. Production builds (`:advanced` + `goog.DEBUG=false`) elide the whole surface — no allocation, storage, or overhead.
+`re-frame.epoch` is the per-frame epoch-history surface: dev-only time-travel and post-mortem. On each dequeued event, the runtime records one `:rf/epoch-record` into a per-frame ring buffer. Recording happens at the event's run-to-completion boundary, not once per drain. Each record captures before/after frame-state, the triggering event, and the harvested trace stream. Pair-shaped tools (Xray, re-frame2-pair, Story) read this history. Production builds (`:advanced` + `goog.DEBUG=false`) elide the whole surface: no allocation, no storage, no overhead.
 
 ```clojure
 (:require [re-frame.epoch :as epoch])
 ```
 
-Most of this surface is re-exported on the `re-frame.core` facade, so `rf/restore-epoch!` and `epoch/restore-epoch!` name the same function. Examples below use the `rf/` form for re-exported names and the `epoch/` form for the epoch-only helpers (`clear-history!`, `current-config`, `register-epoch-listener!`, `unregister-epoch-listener!`, `clear-epoch-listeners!`, `configure!`). The epoch drain-settle **listener** is NOT a per-channel facade re-export — its app-facing route is the `:epoch` stream of the one listener verb, `(rf/register-listener! :epoch id f)` / `(rf/unregister-listener! :epoch id)` (the `epoch/register-epoch-listener!` native form below is the same underlying registry). See [Observability](../core/observability.md) for how epochs fit the broader trace model.
+Most of this surface is re-exported on the `re-frame.core` facade, so `rf/restore-epoch!` and `epoch/restore-epoch!` name the same function. Examples below use the `rf/` form for re-exported names and the `epoch/` form for the epoch-only helpers (`clear-history!`, `current-config`, `register-epoch-listener!`, `unregister-epoch-listener!`, `clear-epoch-listeners!`, `configure!`). The epoch drain-settle **listener** is NOT a per-channel facade re-export. Its app-facing route is the `:epoch` stream of the one listener verb: `(rf/register-listener! :epoch id f)` / `(rf/unregister-listener! :epoch id)`. The `epoch/register-epoch-listener!` native form below is the same underlying registry. See [Observability](../core/observability.md) for how epochs fit the broader trace model.
 
 ## Epoch history
 
@@ -34,7 +34,7 @@ Per-frame epoch snapshots, recorded on each dequeued event's run-to-completion i
   ```clojure
   (clear-history!) → nil
   ```
-- **Description**: Drops every recorded epoch for every frame, plus any in-flight per-frame capture buffer. Used by test fixtures so each fixture's drain starts from a fresh capture state (a leftover mid-flight buffer would otherwise be picked up by the next fixture's first run).
+- **Description**: Drops every recorded epoch for every frame, plus any in-flight per-frame capture buffer. Test fixtures use it so each fixture's drain starts from a fresh capture state. Without it, a leftover mid-flight buffer would be picked up by the next fixture's first run.
 
 ```clojure
 ;; Reset epoch state between test fixtures.
@@ -50,9 +50,9 @@ Per-frame epoch snapshots, recorded on each dequeued event's run-to-completion i
   ```clojure
   (restore-epoch! frame-id epoch-id) → boolean
   ```
-- **Description**: Restores the frame's whole frame-state — both app-db and runtime-db partitions — to the named epoch's `:frame-state-after`, in one atomic write. Machine snapshots, the route slice, and other runtime-db material rewind alongside app-db, not just the application slice.
+- **Description**: Restores the frame's whole frame-state to the named epoch's `:frame-state-after` in one atomic write. Both partitions rewind, app-db and runtime-db alike. Machine snapshots, the route slice, and other runtime-db material travel back too, not just the application slice.
   - Returns `true` on success and emits `:rf.epoch/restored`.
-  - Returns `false` on any failure; each failure is a no-op on frame-state and emits a structured error trace:
+  - Returns `false` on any failure. Each failure is a no-op on frame-state and emits a structured error trace:
     - `:rf.error/no-such-handler` (kind `:frame`) — frame not registered / destroyed
     - `:rf.epoch/restore-during-drain` — called while a drain is in flight
     - `:rf.epoch/restore-unknown-epoch` — epoch-id not in the frame's current history
@@ -69,7 +69,7 @@ Per-frame epoch snapshots, recorded on each dequeued event's run-to-completion i
 
 ## Pair-tool writes
 
-`replace-frame-state!` is the ONE state-injection surface — it replaces a frame's partitions directly, bypassing the dispatch loop. It records a synthetic `:rf/epoch-record` (so `restore-epoch!` can rewind past the injection) and emits `:rf.epoch/db-replaced` on success. Dev-only; production builds elide it.
+`replace-frame-state!` is the ONE state-injection surface. It replaces a frame's partitions directly, bypassing the dispatch loop. It records a synthetic `:rf/epoch-record`, so `restore-epoch!` can rewind past the injection, and emits `:rf.epoch/db-replaced` on success. Dev-only; production builds elide it.
 
 ### `replace-frame-state!`
 
@@ -78,7 +78,7 @@ Per-frame epoch snapshots, recorded on each dequeued event's run-to-completion i
   ```clojure
   (replace-frame-state! frame-id new-frame-state) → boolean
   ```
-- **Description**: The ONE frame-state write surface (rf2-t3lftq — API-shrink #3 consolidated the former `replace-app-db!` / `reset-app-db!` / `replace-runtime-db!` / `replace-frame-state!` four-mutator family, which shared identical machinery differing only in which partition keys they touched, into this). `new-frame-state` is a PARTIAL frame-state map — any subset of `{:rf.db/app … :rf.db/runtime …}`: a present key replaces that partition, an ABSENT key is preserved unchanged. A db-shaped key never silently touches the other partition. Bypasses the dispatch loop. Returns `true` on success. No-ops returning `false` (each emitting a structured trace) on:
+- **Description**: The ONE frame-state write surface. API-shrink #3 (rf2-t3lftq) consolidated the former four-mutator family — `replace-app-db!` / `reset-app-db!` / `replace-runtime-db!` / `replace-frame-state!` — into this single fn. Those four shared identical machinery and differed only in which partition keys they touched. `new-frame-state` is a PARTIAL frame-state map: any subset of `{:rf.db/app … :rf.db/runtime …}`. A present key replaces that partition; an ABSENT key is preserved unchanged. A db-shaped key never silently touches the other partition. Bypasses the dispatch loop. Returns `true` on success. No-ops returning `false` (each emitting a structured trace) on:
   - `:rf.error/replace-frame-state-bad-keys` — the map carries no recognized partition key, or an unrecognized key (checked BEFORE frame resolution)
   - `:rf.error/no-such-handler` — frame not registered
   - `:rf.epoch/replace-during-drain`
@@ -110,11 +110,11 @@ Per-frame epoch snapshots, recorded on each dequeued event's run-to-completion i
   ```clojure
   (register-epoch-listener! id callback-fn) → id
   ```
-- **Description**: Registers a process-global assembled-epoch listener. Returns the `id`. The app-facing route is `(rf/register-listener! :epoch id callback-fn)` — the `:epoch` stream of the one stream-parameterized listener verb; `epoch/register-epoch-listener!` is the direct epoch-namespace form of the same registry (there is no `rf/register-epoch-listener!` facade re-export — retired in API-shrink #4).
+- **Description**: Registers a process-global assembled-epoch listener. Returns the `id`. The app-facing route is `(rf/register-listener! :epoch id callback-fn)`, the `:epoch` stream of the one stream-parameterized listener verb. `epoch/register-epoch-listener!` is the direct epoch-namespace form of the same registry. There is no `rf/register-epoch-listener!` facade re-export; it was retired in API-shrink #4.
   - `callback-fn` is invoked once per committed record with the fully-assembled raw `:rf/epoch-record`, after it lands in the frame's ring buffer. Listeners receive every record regardless of `:outcome`.
   - `id` may be any comparable value; registering the same `id` twice replaces.
-  - Listener exceptions are caught and isolated (emitting `:rf.epoch.cb/listener-exception`) — one broken listener cannot block others.
-  - When a frame a callback has observed is destroyed, a one-shot `:rf.epoch.cb/silenced-on-frame-destroy` trace is emitted for that callback.
+  - Listener exceptions are caught and isolated, emitting `:rf.epoch.cb/listener-exception`. One broken listener cannot block others.
+  - When a frame that a callback has observed is destroyed, the framework emits a one-shot `:rf.epoch.cb/silenced-on-frame-destroy` trace for that callback.
 
 ```clojure
 ;; Observe each assembled epoch as frames settle (app-facing route).
@@ -135,7 +135,7 @@ Per-frame epoch snapshots, recorded on each dequeued event's run-to-completion i
   ```clojure
   (unregister-epoch-listener! id) → nil
   ```
-- **Description**: The inverse. App-facing route: `(rf/unregister-listener! :epoch id)`.
+- **Description**: The inverse of `register-epoch-listener!`: removes the listener registered under `id`. App-facing route: `(rf/unregister-listener! :epoch id)`.
 - **Example**: `(epoch/unregister-epoch-listener! :my-app/epoch-watch)`
 
 ### `clear-epoch-listeners!`
@@ -154,7 +154,7 @@ Per-frame epoch snapshots, recorded on each dequeued event's run-to-completion i
 
 ## Off-box egress projection
 
-Tools that forward epoch records across a process boundary (Xray-MCP `watch-epochs`, story / pair recorders, hosted post-mortem forwarders) must route through these helpers at the wire boundary. The on-box ring buffer and `register-epoch-listener!` fan-out always deliver the raw record so on-box devtools (Xray diff, REPL, `restore-epoch!`) can reason about exact state. See [keep secrets out of traces](../core/how-to/keep-secrets-out-of-traces.md) for the projection model.
+Tools that forward epoch records across a process boundary must route through these helpers at the wire boundary. That covers Xray-MCP `watch-epochs`, story / pair recorders, and hosted post-mortem forwarders. The on-box ring buffer and the `register-epoch-listener!` fan-out always deliver the raw record, so on-box devtools (Xray diff, REPL, `restore-epoch!`) can reason about exact state. See [keep secrets out of traces](../core/how-to/keep-secrets-out-of-traces.md) for the projection model.
 
 ### `projected-record`
 
@@ -164,9 +164,9 @@ Tools that forward epoch records across a process boundary (Xray-MCP `watch-epoc
   (projected-record record)
   (projected-record record opts)
   ```
-- **Description**: Projects an `:rf/epoch-record` for off-box egress — the single normative projection emission site for forwarding records across a process boundary. Routes the full-value payload slots (`:frame-state-before`, `:frame-state-after`, `:db-before`, `:db-after`, `:trace-events`) through the record-level egress boundary under a `:rf.egress/profile`, redacting sensitive paths to `:rf/redacted` and eliding large paths to `:rf.size/large-elided` markers. The frame-state `:rf.db/runtime` partition, the structured `:effects` `:args`, and the `:trigger-event` / trace-event args all fail closed (redacted) by default. `record` may be `nil` (returns `nil`). The 2-arity threads trusted-local egress `opts`; the 1-arity is the safe, fully-redacted off-box path.
+- **Description**: Projects an `:rf/epoch-record` for off-box egress. This is the single normative projection emission site for forwarding records across a process boundary. It routes the full-value payload slots (`:frame-state-before`, `:frame-state-after`, `:db-before`, `:db-after`, `:trace-events`) through the record-level egress boundary under a `:rf.egress/profile`. Sensitive paths redact to `:rf/redacted`; large paths elide to `:rf.size/large-elided` markers. The frame-state `:rf.db/runtime` partition, the structured `:effects` `:args`, and the `:trigger-event` / trace-event args all fail closed (redacted) by default. `record` may be `nil` (returns `nil`). The 2-arity threads trusted-local egress `opts`; the 1-arity is the safe, fully-redacted off-box path.
   - **Profiles** (the primary `:rf.egress/profile` selector — *"which boundary is this?"*):
-    - `:rf.egress/off-box-observability` (DEFAULT) — hosted monitoring / log shippers / Story / pair recorders (redact sensitive, elide large, omit structural digests).
+    - `:rf.egress/off-box-observability` (DEFAULT) — for hosted monitoring, log shippers, Story, and pair recorders. Redacts sensitive paths, elides large ones, and omits structural digests.
     - `:rf.egress/off-box-tool` — the MCP / AI / tool wire. Same redact/elide defaults, but includes structural marker indicators (`:digest`) so a tool can reason about an elided large slot's shape. An unknown profile is rejected against the closed enum.
   - The advanced per-call `:include-*` overrides (`:include-sensitive?` / `:include-large?` / `:include-runtime-db?` / `:include-fx-args?` / `:include-event-args?`, all default `false`) compose over the selected profile.
 
@@ -205,8 +205,8 @@ Tools that forward epoch records across a process boundary (Xray-MCP `watch-epoc
   ```
 - **Description**: Buffer-depth and redactor knobs for the epoch ring.
   - `:depth` — non-negative integer; per-frame ring-buffer depth (default 50). `0` disables recording.
-  - `:trace-events-keep` — non-negative integer; caps how many of the most-recent records per frame retain their raw `:trace-events` vector (older records keep only the cheap structured `:sub-runs` / `:renders` / `:effects` projections). Defaults to 50 (matching the default `:depth`) so trace + epoch evict atomically; pass a smaller value to bound dev-session heap.
-  - `:redact-fn` — `fn?` or `nil`; the advanced projection-side override, invoked once per record at the off-box egress boundary inside `projected-record`, never at storage time (the ring buffer and every listener receive the raw record, since epoch records are causal replay material). A throwing fn emits `:rf.warning/epoch-redact-fn-exception` and falls back to the projected record. `nil` clears any previously-installed fn.
+  - `:trace-events-keep` — non-negative integer. Caps how many of the most-recent records per frame retain their raw `:trace-events` vector; older records keep only the cheap structured `:sub-runs` / `:renders` / `:effects` projections. Defaults to 50 (matching the default `:depth`) so trace and epoch evict atomically. Pass a smaller value to bound dev-session heap.
+  - `:redact-fn` — `fn?` or `nil`; the advanced projection-side override. It is invoked once per record at the off-box egress boundary inside `projected-record`, never at storage time. The ring buffer and every listener receive the raw record, since epoch records are causal replay material. A throwing fn emits `:rf.warning/epoch-redact-fn-exception` and falls back to the projected record. `nil` clears any previously-installed fn.
   - Invalid `:depth` / `:trace-events-keep` (not a non-negative integer) and a malformed `:redact-fn` (not `fn?` / `nil`) are silently dropped at the boundary.
 
   Apps usually set this through `rf/configure!` with the `:epoch-history` key; see [re-frame.core.md](re-frame.core.md).
@@ -240,14 +240,14 @@ Tools that forward epoch records across a process boundary (Xray-MCP `watch-epoc
   (settle! frame-id frame-state-before frame-state-after committed-at)
   (settle! frame-id frame-state-before frame-state-after committed-at outcome halt-reason)
   ```
-- **Description**: The hook the router calls once per dequeued event — at each event's run-to-completion boundary, not once per drain. Framework-internal: the router invokes it; application and tool code never call it directly. Per call it:
+- **Description**: The hook the router calls once per dequeued event, at each event's run-to-completion boundary — not once per drain. Framework-internal: the router invokes it; application and tool code never call it directly. Per call it:
   - harvests that event's trace buffer;
   - assembles the `:rf/epoch-record` (deriving the `:db-before` / `:db-after` app-db projections from the whole-frame-state snapshots);
   - appends it to the per-frame ring buffer;
   - emits `:rf.epoch/snapshotted` with an `:outcome` tag plus its consumer-facing companion `:rf.epoch/outcome` (`:ok` / `:blocked` / `:error`);
   - fans out to every registered listener.
 
-  A drain that processes a parent event and an `:fx [[:dispatch …]]` child it queued commits two records (one per event); a machine macrostep stays one epoch. `committed-at` is the committing causal token's `:rf.cofx` `:rf/time-ms`, threaded down by the router (not an ambient assembly-time clock read), which keeps the record replayable. The 4-arity is the clean `:ok` settle (skipped when the captured buffer is empty); the 6-arity is the drain-boundary commit with an explicit outcome (`:ok` / `:halted-depth` / `:halted-destroy`).
+  A drain that processes a parent event and an `:fx [[:dispatch …]]` child it queued commits two records, one per event. A machine macrostep stays one epoch. `committed-at` is the committing causal token's `:rf.cofx` `:rf/time-ms`, threaded down by the router rather than read from an ambient assembly-time clock; this keeps the record replayable. The 4-arity is the clean `:ok` settle, skipped when the captured buffer is empty. The 6-arity is the drain-boundary commit with an explicit outcome (`:ok` / `:halted-depth` / `:halted-destroy`).
 
 ```clojure
 ;; Framework-internal — the router invokes this through the :epoch/settle! late-bind hook.

--- a/docs/api/re-frame.flows.md
+++ b/docs/api/re-frame.flows.md
@@ -26,7 +26,7 @@ See [Flows: derived values your handlers can read](../core/flows.md) for the con
   ```clojure
   (reg-flow flow-id metadata derive-fn)
   ```
-- **Description**: Register a flow. Returns `flow-id` (per the `reg-*` return-value convention). A rejected registration mutates nothing — the prior definition, if any, survives.
+- **Description**: Register a flow. Returns `flow-id` (per the `reg-*` return-value convention). A rejected registration mutates nothing; the prior definition, if any, survives.
 
   The 3-slot grammar is `flow-id` first, the pure `derive-fn` last, and `metadata` (the reflection-config map) in the middle. `metadata` carries:
 
@@ -64,7 +64,7 @@ See [Flows: derived values your handlers can read](../core/flows.md) for the con
 
   - Leaf-only removal: an emptied parent map is left in place.
   - Sibling frames' state is preserved.
-  - The frame resolves from the `opts` `:frame` key (a frame-id keyword), else the surrounding scope. Under no scope and no `:frame` it raises `:rf.error/no-frame-context`.
+  - The frame resolves from the `opts` `:frame` key (a frame-id keyword), else the surrounding scope. With no scope and no `:frame`, it raises `:rf.error/no-frame-context`.
   - A no-op when `id` is not registered against the frame.
 - **Example**:
   ```clojure
@@ -100,7 +100,7 @@ read. Outputs stay `app-db`-only.
   (fn [route-id] (= route-id :checkout)))
 ```
 
-`:inputs` is a positional vector of frame-state paths; the values at those paths arrive as positional args to the `derive-fn` in the same order (a map-keyed `:inputs` form is a deferred design option, not v1). Each path reads against the pending frame-state's two partitions: a bare path reads `app-db`, a path led by `:rf.db/runtime` reads `runtime-db`. The metadata slot is pure data — no fn registration with a separate id, no interceptor wiring, no closure capture. The conformance harness validates flows by walking the registered data and applying it to a synthesised frame-state.
+`:inputs` is a positional vector of frame-state paths. The values at those paths arrive as positional args to the `derive-fn`, in the same order. (A map-keyed `:inputs` form is a deferred design option, not v1.) Each path reads against the pending frame-state's two partitions: a bare path reads `app-db`, and a path led by `:rf.db/runtime` reads `runtime-db`. The metadata slot is pure data — no fn registration with a separate id, no interceptor wiring, no closure capture. The conformance harness validates flows by walking the registered data and applying it to a synthesised frame-state.
 
 | Slot / key | Required | Notes |
 |---|---|---|
@@ -110,8 +110,8 @@ read. Outputs stay `app-db`-only.
 | `:output-path` (metadata) | yes | Where to write the output in `app-db`. |
 | `:doc` (metadata) | no | One-sentence what-and-why; surfaces in tooling. |
 | `:frame` (metadata) | no | The frame the flow registers against (the override; else the surrounding `with-frame` scope). |
-| `:schema` (metadata) | no | Malli schema for the output value. Validated on every recompute in dev; elided in production, like all schema validation. On failure the runtime emits `:rf.error/schema-validation-failure :where :flow-output` — **observational**: the output is still written and the trace surfaces the producer bug. Routes through the registered validator, so an app without the schemas artefact pays nothing. |
-| `:sensitive` (metadata) | no | Output data-classification: a vector of output subpaths (each a vector of scalar keys; `[]` marks the whole output) declared sensitive. Installed into the frame's elision registry rooted at `:output-path`, so trace and egress projections redact those slots. No input→output propagation — a flow classifies its own output only. Malformed values are rejected (`:rf.error/flow-bad-marks`); so are the retired `:sensitive?` boolean spelling and `:rf.egress/output-sensitivity`. |
+| `:schema` (metadata) | no | Malli schema for the output value. Validated on every recompute in dev; elided in production, like all schema validation. On failure the runtime emits `:rf.error/schema-validation-failure :where :flow-output`. The failure is **observational**: the output is still written, and the trace surfaces the producer bug. Validation routes through the registered validator, so an app without the schemas artefact pays nothing. |
+| `:sensitive` (metadata) | no | Output data-classification: a vector of output subpaths (each a vector of scalar keys; `[]` marks the whole output) declared sensitive. Installed into the frame's elision registry rooted at `:output-path`, so trace and egress projections redact those slots. There is no input→output propagation: a flow classifies its own output only. Malformed values are rejected (`:rf.error/flow-bad-marks`), as are the retired `:sensitive?` boolean spelling and `:rf.egress/output-sensitivity`. |
 | `:large` (metadata) | no | Output data-classification: a vector of output subpaths (same shape as `:sensitive`) declared large for wire-size elision. Malformed values are rejected (`:rf.error/flow-bad-marks`). |
 | `:large?` (metadata) | no | Boolean; `true` marks the whole output large. Non-boolean values are rejected (`:rf.error/flow-bad-marks`). |
 
@@ -119,7 +119,7 @@ read. Outputs stay `app-db`-only.
 
 Flows are single-store: the `:flow` registrar kind is reserved-but-empty (`reg-flow` does not write it). The same id can register against multiple frames with divergent definitions.
 
-For per-frame discovery, read the encapsulated runtime registry via the public snapshot accessor `re-frame.flows/flows-snapshot` (returns the `{frame-id {flow-id flow-map}}` shape) or the frame-scoped `re-frame.flows/flow-meta-at` — not the private registry atom (in `re-frame.flows.registry`), which is an implementation detail behind the snapshot contract. The per-frame runtime registry is the source of truth for evaluation.
+For per-frame discovery, read the encapsulated runtime registry through its public accessors: `re-frame.flows/flows-snapshot` (returns the `{frame-id {flow-id flow-map}}` shape) or the frame-scoped `re-frame.flows/flow-meta-at`. Do not reach for the private registry atom (in `re-frame.flows.registry`); it is an implementation detail behind the snapshot contract. The per-frame runtime registry is the source of truth for evaluation.
 
 #### Frame-destroy teardown
 
@@ -134,7 +134,7 @@ Two reserved fx-ids register or clear a flow at runtime from inside an event han
 | `[:rf.fx/reg-flow [flow-id metadata derive-fn]]` | the 3-slot triple (same shape as `reg-flow`) | v1 | Register a flow at runtime via `:fx`. The dispatching frame threads through as the `:frame` metadata key. |
 | `[:rf.fx/clear-flow id]` | flow id | v1 | Clear a registered flow at runtime via `:fx`. |
 
-The arguments mirror `reg-flow` / `clear-flow` exactly — the same 3-slot triple / flow id (an fx body's return value is not observable). When the flows artefact is not on the classpath both effects no-op.
+The arguments mirror `reg-flow` / `clear-flow` exactly: the same 3-slot triple, the same flow id. (An fx body's return value is not observable.) When the flows artefact is not on the classpath, both effects no-op.
 
 ```clojure
 ;; Clear a runtime-registered flow from inside a handler — e.g. disengaging a
@@ -150,7 +150,7 @@ The arguments mirror `reg-flow` / `clear-flow` exactly — the same 3-slot tripl
 
 The reason is structural: the `:fx` walk is the last drain stage, and it runs after the flow transform has already evaluated this event's flows. The newly-registered flow was not in the registry when the transform walked, so it has nothing to compute on this event. It computes on the next drain on that frame.
 
-In the common case the lag is invisible — you register a flow in an `:enter`-style handler and the user's next interaction materialises the output. When you need the initial value now, dispatch a follow-up no-op event from the same handler to re-trigger the drain (the flow is in the registry by the time that dispatched event drains):
+In the common case the lag is invisible: you register a flow in an `:enter`-style handler, and the user's next interaction materialises the output. When you need the initial value now, dispatch a follow-up no-op event from the same handler to re-trigger the drain. The flow is in the registry by the time that dispatched event drains:
 
 ```clojure
 (rf/reg-event :wizard/enter-step-2
@@ -170,7 +170,7 @@ The one-event lag before a newly registered flow first computes preserves the on
 
 ## Introspection and tooling
 
-Read-only views over the per-frame flow registry. They never touch the registration write-path; tools (Xray, re-frame2-pair) and conformance fixtures consume them. None of the three has a `re-frame.core` facade export.
+Read-only views over the per-frame flow registry. They never touch the registration write-path. Tools (Xray, re-frame2-pair) and conformance fixtures consume them. None of the three has a `re-frame.core` facade export.
 
 ### `flows-snapshot`
 
@@ -179,7 +179,7 @@ Read-only views over the per-frame flow registry. They never touch the registrat
   ```clojure
   (flows-snapshot)
   ```
-- **Description**: Return the per-frame flow registry value: `{frame-id {flow-id flow-map}}`. The public seam for observing the registry shape — read it rather than dereferencing the private `flows` atom. Snapshot; observers must not mutate it.
+- **Description**: Return the per-frame flow registry value: `{frame-id {flow-id flow-map}}`. This is the public seam for observing the registry shape. Read it rather than dereferencing the private `flows` atom. The return value is a snapshot; observers must not mutate it.
 - **Example**:
   ```clojure
   ;; Which flows are registered, and against which frames?
@@ -194,7 +194,7 @@ Read-only views over the per-frame flow registry. They never touch the registrat
   (flow-meta-at flow-id)
   (flow-meta-at flow-id opts)
   ```
-- **Description**: Return the registration metadata map for `flow-id` in a frame, or `nil` — the canonical per-frame flow introspection surface.
+- **Description**: Return the registration metadata map for `flow-id` in a frame, or `nil`. This is the canonical per-frame flow introspection surface.
 
   - Returns the full flow-map stamped at `reg-flow`: its source-coords `:ns` / `:line` / `:file`, `:inputs`, `:derive`, `:output-path`, and any output-classification keys.
   - Frame-divergent by construction: the same `flow-id` registered against two frames returns each frame's own definition.
@@ -214,11 +214,21 @@ Read-only views over the per-frame flow registry. They never touch the registrat
   (flow-algebra-view)
   (flow-algebra-view frame-id)
   ```
-- **Description**: Return the static derivation-algebra view of every registered flow — each flow lowered into the normalized derivation-node shape so a tool can show subscriptions, flows, resources, route facts, and machine selectors as one family.
+- **Description**: Return the static derivation-algebra view of every registered flow. Each flow is lowered into the normalized derivation-node shape, so a tool can show subscriptions, flows, resources, route facts, and machine selectors as one family.
 
-  Each node carries: the flow's `:id`; `:kind` `:derivation`; `:source-form` `{:kind :reg-flow :id flow-id}`; declared `:inputs` (each lowered to `[:db path]` or `[:runtime …rest]`); `:output` `[:db <output-path>]`; the fixed classifications `:storage` `:app-db` / `:evaluation` `:after-event` / `:lifecycle` `:frame` / `:materialized?` `true`; `:owner` `[:frame frame-id]`; the opaque `:derive` token; and `:source` / `:schema` / `:doc` when present.
+  Each node carries:
 
-  Zero-arity returns `{frame-id {flow-id node}}`; the one-arity form returns `{flow-id node}` for a single frame. This is a JVM convenience alias; CLJS consumers call `re-frame.flows.tooling/flow-algebra-view` directly.
+  - the flow's `:id`
+  - `:kind` `:derivation`
+  - `:source-form` `{:kind :reg-flow :id flow-id}`
+  - the declared `:inputs`, each lowered to `[:db path]` or `[:runtime …rest]`
+  - `:output` `[:db <output-path>]`
+  - the fixed classifications: `:storage` `:app-db`, `:evaluation` `:after-event`, `:lifecycle` `:frame`, `:materialized?` `true`
+  - `:owner` `[:frame frame-id]`
+  - the opaque `:derive` token
+  - `:source` / `:schema` / `:doc` when present
+
+  The zero-arity form returns `{frame-id {flow-id node}}`. The one-arity form returns `{flow-id node}` for a single frame. This is a JVM convenience alias; CLJS consumers call `re-frame.flows.tooling/flow-algebra-view` directly.
 
 ## Runtime and test-support internals
 
@@ -231,10 +241,10 @@ The flow-transform entry point the router installs, plus the test-fixture resets
   ```clojure
   (run-flows-on-db frame-id db runtime-db)
   ```
-- **Description**: The outermost-`:after` flow transform. Walks this frame's registered flows in topological order over the pending frame-state, dirty-checks each one, recomputes and `assoc-in`s the result into a transformed `app-db`, and returns the flow-augmented `app-db` value.
+- **Description**: The outermost-`:after` flow transform. It walks this frame's registered flows in topological order over the pending frame-state, dirty-checks each one, and `assoc-in`s each recomputed result into a transformed `app-db`. It returns the flow-augmented `app-db` value.
 
-  - `db` is the pending `app-db` partition; `runtime-db` the pending `runtime-db` partition (pass `nil` to resolve only bare `app-db` inputs).
-  - The router installs and calls this as the outermost `:after` interceptor — it fires last, against the chain's pending `:db` effect and before the `:db` install — so applications never call it.
+  - `db` is the pending `app-db` partition; `runtime-db` is the pending `runtime-db` partition (pass `nil` to resolve only bare `app-db` inputs).
+  - The router installs and calls this as the outermost `:after` interceptor. It fires last, against the chain's pending `:db` effect and before the `:db` install. Applications never call it.
   - Flow outputs write `app-db` only.
   - A flow `:derive` throw halts the walk (downstream flows do not run), rolls back the frame's dirty-check bookkeeping, and re-raises as `:rf.error/flow-eval-exception` (ex-data carries `:rf.flow/failed-id`). The router discards the pending `:db` effect, so the event aborts with no partial commit.
 
@@ -245,7 +255,7 @@ The flow-transform entry point the router installs, plus the test-fixture resets
   ```clojure
   (reset-flows!)
   ```
-- **Description**: Test-only. Clear the per-frame flow registry and the paired dirty-check `last-inputs` state (plus any pending abandoned-output-path moves), so a re-registration after a reset cannot silently no-op against a stale `=`-equal entry. Returns `nil`.
+- **Description**: Test-only. Clear the per-frame flow registry and the paired dirty-check `last-inputs` state, plus any pending abandoned-output-path moves. This ensures a re-registration after a reset cannot silently no-op against a stale `=`-equal entry. Returns `nil`.
 
 ### `reset-last-inputs!`
 
@@ -258,7 +268,7 @@ The flow-transform entry point the router installs, plus the test-fixture resets
 
 ## Failure semantics
 
-**Production-survivable.** A throw inside a flow's `:derive` fn surfaces as `:rf.error/flow-eval-exception` on the always-on error-emit substrate — registered `register-error-listener!` callbacks fire under CLJS `:advanced` + `goog.DEBUG=false`. The error is not trace-only; production deployments catch it.
+**Production-survivable.** A throw inside a flow's `:derive` fn surfaces as `:rf.error/flow-eval-exception` on the always-on error-emit substrate. Registered `register-error-listener!` callbacks fire even under CLJS `:advanced` + `goog.DEBUG=false`. The error is not trace-only; production deployments catch it.
 
 See [Report errors in production](../core/how-to/report-errors-in-production.md) for wiring the always-on error listeners that catch these in a deployed app.
 

--- a/docs/api/re-frame.http.md
+++ b/docs/api/re-frame.http.md
@@ -1,6 +1,6 @@
 # re-frame.http
 
-Managed HTTP is an optional capability. An event dispatches the `[:rf.http/managed args-map]` fx and the implementation owns retries, cancellation, timeouts, decode, and failure classification. The `re-frame.http` namespace holds the verb-helper synthesis fns (`get`, `post`, `put`, `delete`, `patch`, `head`, `options`) that build that fx. The fx itself, its abort/canned siblings, the request-interceptor middleware, and the test stubs are keyword-addressed or re-exported on the `re-frame.core` façade.
+Managed HTTP is an optional capability. An event dispatches the `[:rf.http/managed args-map]` fx. The implementation owns retries, cancellation, timeouts, decode, and failure classification. The `re-frame.http` namespace holds the verb-helper synthesis fns (`get`, `post`, `put`, `delete`, `patch`, `head`, `options`) that build that fx. The fx itself, its abort/canned siblings, the request-interceptor middleware, and the test stubs are keyword-addressed or re-exported on the `re-frame.core` façade.
 
 The CLJS reference ships managed HTTP (Fetch in the browser, `java.net.http.HttpClient` on the JVM). Ports that omit it must not reuse the `:rf.http/*` namespace for anything else.
 
@@ -10,7 +10,7 @@ See [Managed HTTP — The request is a map](../async/http.md) for the teaching g
 (:require [re-frame.http :as rf.http])
 ```
 
-The verb helpers live in `re-frame.http`. The `:rf.http/managed` fx is keyword-addressed (used in an event's `:fx`); the interceptor and test-stub fns (`reg-http-interceptor`, `clear-http-interceptor`, `with-managed-request-stubs`) are re-exported on the `re-frame.core` façade — so the examples below also `[re-frame.core :as rf]`. Everything ships in the `day8/re-frame2-http` artefact.
+The verb helpers live in `re-frame.http`. The `:rf.http/managed` fx is keyword-addressed — you use it in an event's `:fx`. The interceptor and test-stub fns (`reg-http-interceptor`, `clear-http-interceptor`, `with-managed-request-stubs`) are re-exported on the `re-frame.core` façade, so the examples below also require `[re-frame.core :as rf]`. Everything ships in the `day8/re-frame2-http` artefact.
 
 ## Keyword surfaces — the managed-HTTP fx
 
@@ -22,8 +22,8 @@ The verb helpers live in `re-frame.http`. The `:rf.http/managed` fx is keyword-a
   - `:request` — the request envelope; `:url` is **required**. A missing / nil / blank final URL raises `:rf.error/http-bad-request` at dispatch, after the `:before` chain runs.
   - `:decode` — decode policy.
   - `:accept` — accept fn.
-  - `:retry` — `{:on #{categories} :max-attempts N :backoff {:base-ms :factor :max-ms :jitter}}`. `:on` must be a set drawn from the retryable subset `#{:rf.http/transport :rf.http/cors :rf.http/timeout :rf.http/http-4xx :rf.http/http-5xx}`, else `:rf.error/http-bad-retry-on` at dispatch.
-  - `:timeout-ms` — per-attempt timeout, default 30000; explicit `nil` or `0` opts out.
+  - `:retry` — `{:on #{categories} :max-attempts N :backoff {:base-ms :factor :max-ms :jitter}}`. `:on` must be a set drawn from the retryable subset `#{:rf.http/transport :rf.http/cors :rf.http/timeout :rf.http/http-4xx :rf.http/http-5xx}`. Anything else raises `:rf.error/http-bad-retry-on` at dispatch.
+  - `:timeout-ms` — per-attempt timeout, default 30000. An explicit `nil` or `0` opts out.
   - `:on-success` / `:on-failure` — success / failure target events; event vector or nil. Any other value raises `:rf.error/http-bad-reply-target`.
   - `:request-id` — for abort / supersede.
   - `:abort-signal` — optional (CLJS).
@@ -33,7 +33,7 @@ The verb helpers live in `re-frame.http`. The `:rf.http/managed` fx is keyword-a
 
 - **Kind**: fx
 - **Args**: request-id
-- **Description**: Abort the in-flight request with the given `:request-id`. The aborted request's reply is the canonical `{:status :cancelled :cancel/reason :user :error {:kind :rf.http/aborted ...}}` envelope, delivered per [Reply addressing](#reply-addressing) — bare to an explicit `:on-failure`, under `:rf/reply` for co-located addressing.
+- **Description**: Abort the in-flight request with the given `:request-id`. The aborted request's reply is the canonical `{:status :cancelled :cancel/reason :user :error {:kind :rf.http/aborted ...}}` envelope. It is delivered per [Reply addressing](#reply-addressing): bare to an explicit `:on-failure`, or under `:rf/reply` for co-located addressing.
 - **Example**:
   ```clojure
   (rf/reg-event :request/abort
@@ -82,11 +82,11 @@ Every reply is the one canonical reply envelope — a plain map keyed on a close
 Where the payload lands depends on how the reply was addressed:
 
 - **Explicit `:on-success` / `:on-failure`** — pure routing sugar. Both receive the identical envelope appended as the last event-vector arg. A `:cart/loaded` handler sees `[:cart/loaded {:status :ok :value decoded-body …}]` and destructures it directly (`[_ {:keys [value]}]` for success, `[_ {:keys [error]}]` for failure).
-- **Default (co-located) addressing** — omit both targets. The same envelope is merged under `:rf/reply` into the originating message and re-dispatched as `[<originating-event-id> (assoc original-msg :rf/reply ...)]` back to the same handler, which reads it at `:rf/reply` and branches on `(:status reply)`. The `:rf/reply` wrapper is the co-located form only; explicit targets get the bare envelope.
+- **Default (co-located) addressing** — omit both targets. The same envelope is merged under `:rf/reply` into the originating message, and the result is re-dispatched as `[<originating-event-id> (assoc original-msg :rf/reply ...)]` back to the same handler. That handler reads the envelope at `:rf/reply` and branches on `(:status reply)`. The `:rf/reply` wrapper is the co-located form only; explicit targets get the bare envelope.
 - **`:on-success nil` / `:on-failure nil`** — silences that side; no reply dispatch.
 - Any other non-vector value for either key raises `:rf.error/http-bad-reply-target`.
 
-Both shapes detailed in [Managed HTTP — Handling the reply](../async/http.md#handling-the-reply).
+Both shapes are detailed in [Managed HTTP — Handling the reply](../async/http.md#handling-the-reply).
 
 ## Failure categories (closed set)
 
@@ -117,7 +117,7 @@ Call-site helpers that synthesise the canonical `[:rf.http/managed args-map]` fx
   (rf.http/get url)
   (rf.http/get url args)
   ```
-- **Description**: Synthesise a GET fx vector. `args` merges top-level into the canonical args map (caller wins) except `:request`, which merges with `{:method :get :url url}` — the helper's `:method` and `:url` overwrite caller-supplied ones. All seven helpers share this merge contract.
+- **Description**: Synthesise a GET fx vector. `args` merges top-level into the canonical args map, and the caller wins. The exception is `:request`: it merges with `{:method :get :url url}`, and the helper's `:method` and `:url` overwrite caller-supplied ones. All seven helpers share this merge contract.
 
 ### `post`
 
@@ -214,7 +214,7 @@ Call-site helpers that synthesise the canonical `[:rf.http/managed args-map]` fx
   {:fx [(rf.http/options "/api/items")]}
   ```
 
-The verb helpers require `[re-frame.http :as rf.http]` alongside `re-frame.core`; the namespace ships in the `day8/re-frame2-http` artefact, the same one as the fx.
+The verb helpers require `[re-frame.http :as rf.http]` alongside `re-frame.core`. The namespace ships in the `day8/re-frame2-http` artefact — the same artefact as the fx.
 
 ```clojure
 {:fx [(rf.http/get "/api/cart"
@@ -227,7 +227,7 @@ The verb helpers require `[re-frame.http :as rf.http]` alongside `re-frame.core`
 
 ## Request-interceptor middleware
 
-A middleware surface that mirrors the rest of the `reg-*` family, for injecting behaviour into every request (auth header, request-id stamp, logging). The fn forms (`reg-http-interceptor`, `clear-http-interceptor`) are re-exported on the `re-frame.core` façade — a façade call with `day8/re-frame2-http` absent raises `:rf.error/http-artefact-missing`. The data-shaped `:rf.fx/*` siblings below are keyword-addressed.
+A middleware surface that mirrors the rest of the `reg-*` family. Use it to inject behaviour into every request: an auth header, a request-id stamp, logging. The fn forms (`reg-http-interceptor`, `clear-http-interceptor`) are re-exported on the `re-frame.core` façade. A façade call with `day8/re-frame2-http` absent raises `:rf.error/http-artefact-missing`. The data-shaped `:rf.fx/*` siblings below are keyword-addressed.
 
 ### `reg-http-interceptor`
 
@@ -238,9 +238,9 @@ A middleware surface that mirrors the rest of the `reg-*` family, for injecting 
   ```
 - **Description**: Register an HTTP interceptor on a frame's `:rf.http/managed` middleware chain. Returns `id`.
   - `interceptor-map` carries at least one of `:before (fn [ctx] ctx')` (request-side) and `:after (fn [ctx response] response')` (response-side), plus optional `:frame` (explicit-frame override) and the standard `:rf/registration-metadata`.
-  - Target frame is the explicit `:frame`, else the carried scope it registers under (`with-frame` / an `:initial-events` step). Registering under **no** scope raises `:rf.error/no-frame-context` — there is no `:rf/default` default.
+  - The target frame is the explicit `:frame` when given, else the carried scope it registers under (`with-frame` / an `:initial-events` step). Registering under **no** scope raises `:rf.error/no-frame-context` — there is no `:rf/default` default.
   - An invalid shape (non-keyword id, neither `:before` nor `:after`, a non-fn slot, a non-keyword `:frame`) raises `:rf.error/http-bad-interceptor`.
-  - Re-registering an existing id replaces the slot in place (position preserved); after a `clear-http-interceptor`, re-registering the same id appends to the end of the chain.
+  - Re-registering an existing id replaces the slot in place, position preserved. After a `clear-http-interceptor`, re-registering the same id appends to the end of the chain.
   - The `:before` chain runs in registration order; the `:after` chain runs in reverse registration order. `:after` sees the same ctx the `:before` chain produced (request-correlated handling).
 
 ### `clear-http-interceptor`
@@ -254,8 +254,8 @@ A middleware surface that mirrors the rest of the `reg-*` family, for injecting 
 - **Description**: Unregister an interceptor by id.
   - `(clear-http-interceptor id)` resolves the frame from the carried scope it runs under.
   - `(clear-http-interceptor id {:frame target})` names the frame explicitly via the trailing opts map, mirroring `reg-http-interceptor`'s `:frame` and the family's public-frame-targeting law (never a positional frame arg on a public surface).
-  - Either form raises `:rf.error/no-frame-context` when the frame is absent (single-arity under no scope, or opts `{:frame nil}`); it never clears against a synthesised `:rf/default`.
-  - The 2-arity is shape-discriminated on the second arg: an opts map is the public form; a bare frame target first is the internal frame-first `(frame id)` plumbing.
+  - Either form raises `:rf.error/no-frame-context` when the frame is absent (single-arity under no scope, or opts `{:frame nil}`). It never clears against a synthesised `:rf/default`.
+  - The 2-arity is shape-discriminated: an opts map as the second arg is the public form, while a bare frame target in the first position is the internal frame-first `(frame id)` plumbing.
 - **Example**:
   ```clojure
   (rf/clear-http-interceptor :auth-header)
@@ -265,7 +265,7 @@ A middleware surface that mirrors the rest of the `reg-*` family, for injecting 
 
 - **Kind**: fx
 - **Args**: `{:id <kw> :before <fn>? :after <fn>? :frame <id>? ...}` — `:id` plus the same interceptor-map slots as the fn form, including `:rf/registration-metadata`
-- **Description**: Data-shaped sibling of `reg-http-interceptor` for callers driving registration through the dispatch surface (EDN conformance fixtures, boot event handlers). The fx body splits `:id` off and passes the remaining map to the fn form; when the args omit `:frame`, the fx-context frame (the cascade envelope stamp) is threaded in. Registered at load of `re-frame.http.managed`; dev+prod.
+- **Description**: Data-shaped sibling of `reg-http-interceptor`, for callers driving registration through the dispatch surface (EDN conformance fixtures, boot event handlers). The fx body splits `:id` off and passes the remaining map to the fn form. When the args omit `:frame`, the fx-context frame (the cascade envelope stamp) is threaded in. Registered at load of `re-frame.http.managed`; dev+prod.
 - **Example**:
   ```clojure
   {:fx [[:rf.fx/reg-http-interceptor
@@ -296,19 +296,19 @@ A middleware surface that mirrors the rest of the `reg-*` family, for injecting 
              (assoc resp :elapsed-ms (- (js/Date.now) (::started ctx))))})
 ```
 
-`:before` runs before the request is dispatched to the platform's HTTP client; `:after` runs after the response is built and before `:on-success` / `:on-failure` fire. If either throws, the corresponding side is not delivered (request: not dispatched; response: reply suppressed) and `:rf.error/http-interceptor-failed` fires with `:frame`, `:interceptor-id`, `:url`, and `:cause` (`:phase :after` is stamped on the response side; absent for `:before`). See [Managed HTTP — Interceptors](../async/http-going-further.md#interceptors-stamp-every-request-once).
+`:before` runs before the request is dispatched to the platform's HTTP client. `:after` runs after the response is built and before `:on-success` / `:on-failure` fire. If either throws, the corresponding side is not delivered: a throwing `:before` means the request is not dispatched; a throwing `:after` means the reply is suppressed. In both cases `:rf.error/http-interceptor-failed` fires with `:frame`, `:interceptor-id`, `:url`, and `:cause`. On the response side it also stamps `:phase :after`; that tag is absent for `:before`. See [Managed HTTP — Interceptors](../async/http-going-further.md#interceptors-stamp-every-request-once).
 
 ## Testing: stubbed responses
 
-Test-support surface for driving the pipeline without the network: canned-reply fx plus a stubbing macro that reroutes requests at named routes. The `with-managed-request-stubs` macro is re-exported on the `re-frame.core` façade; the raw `install` / `uninstall` pair is reached only through the home namespace `re-frame.http.test-support`.
+Test-support surface for driving the pipeline without the network: canned-reply fx, plus a stubbing macro that reroutes requests at named routes. The `with-managed-request-stubs` macro is re-exported on the `re-frame.core` façade. The raw `install` / `uninstall` pair is reached only through the home namespace `re-frame.http.test-support`.
 
 ### `[:rf.http/managed-canned-success {:value v}]`
 
 - **Kind**: fx
 - **Description**: Synthesise the canonical success reply (`{:status :ok :value v}`) directly into `:fx`, for inline "stub THIS request" patterns.
   - `:value` defaults to `{:stubbed true}` when absent.
-  - `:after-ms` (optional) — a positive value defers the reply via a `:dispatch-later` tick; absent / `0` / non-positive delivers immediately.
-  - Runs the frame's `:before` and `:after` interceptor chains around the synthesised reply, exactly like the real transport path; reply addressing (`:on-success` / default co-located) applies as for `:rf.http/managed`.
+  - `:after-ms` (optional) — a positive value defers the reply via a `:dispatch-later` tick. Absent, `0`, or non-positive delivers immediately.
+  - Runs the frame's `:before` and `:after` interceptor chains around the synthesised reply, exactly like the real transport path. Reply addressing (`:on-success` / default co-located) applies as for `:rf.http/managed`.
   - Registered at load of `re-frame.http.test-support`.
 - **Example**:
   ```clojure
@@ -324,8 +324,8 @@ Test-support surface for driving the pipeline without the network: canned-reply 
 
 - **Kind**: fx
 - **Description**: Synthesise the canonical failure reply directly into `:fx`.
-  - `:kind` defaults to `:rf.http/transport`; `:tags` merge into the `:error` map.
-  - An `:rf.http/aborted` kind yields `:status :cancelled`; every other kind `:status :error`.
+  - `:kind` defaults to `:rf.http/transport`. `:tags` merge into the `:error` map.
+  - An `:rf.http/aborted` kind yields `:status :cancelled`; every other kind yields `:status :error`.
   - Supports the same optional `:after-ms` deferral, interceptor-chain behaviour, and reply addressing (`:on-failure` / default co-located) as `:rf.http/managed-canned-success`.
   - Registered at load of `re-frame.http.test-support`.
 - **Example**:
@@ -347,9 +347,10 @@ Test-support surface for driving the pipeline without the network: canned-reply 
   ```
 - **Description**: Lexical-scope stubbing.
   - `route-map` is `{[<method> <url>] {:reply {:ok <value>}}}` (success) or `{[<method> <url>] {:reply {:failure <failure-map>}}}` (failure).
-  - Inside the body, requests matching a stubbed route bypass the real client: the helper registers a per-scope stub fx (a process-unique `:rf.test/managed-http-stub-<n>` id under the test-runner-internal `:rf.test/*` fx-stub family, so nested scopes compose) and installs the matching `:rf.http/managed` override for the body's dynamic extent. Plain `dispatch-sync` calls auto-route by method + URL with no manual `:fx-overrides`; a per-call `:fx-overrides` still wins.
+  - Inside the body, requests matching a stubbed route bypass the real client. The helper registers a per-scope stub fx with a process-unique `:rf.test/managed-http-stub-<n>` id, under the test-runner-internal `:rf.test/*` fx-stub family, so nested scopes compose. It then installs the matching `:rf.http/managed` override for the body's dynamic extent.
+  - Plain `dispatch-sync` calls auto-route by method + URL with no manual `:fx-overrides`. A per-call `:fx-overrides` still wins.
   - Routes match against the post-`:before` request (the method + URL the pipeline would actually issue). A request with no matching route receives a synthesised `:rf.http/transport` failure reply.
-  - The façade macro requires `re-frame.http.test-support` in the require closure — without it the call raises `:rf.error/http-artefact-missing`.
+  - The façade macro needs `re-frame.http.test-support` in the require closure. Without it, the call raises `:rf.error/http-artefact-missing`.
 
 ### `with-managed-request-stubs*`
 
@@ -376,8 +377,8 @@ Test-support surface for driving the pipeline without the network: canned-reply 
   ```clojure
   (install-managed-request-stubs! route-map)
   ```
-- **Description**: Lower-level than `with-managed-request-stubs`; use when stubs span multiple `deftest`s. Registers the `:rf.http/managed-test-stub` fx (the stable, documented `:fx-overrides` target) that persists until `uninstall-managed-request-stubs!`. Returns the stub fx-id.
-  - Unlike the wrapper, this does **not** install the `:rf.http/managed` override — dispatch with `{:fx-overrides {:rf.http/managed :rf.http/managed-test-stub}}` (or wrap dispatches in `with-fx-overrides`) to route through it.
+- **Description**: Lower-level than `with-managed-request-stubs`. Use it when stubs span multiple `deftest`s. It registers the `:rf.http/managed-test-stub` fx — the stable, documented `:fx-overrides` target — which persists until `uninstall-managed-request-stubs!`. Returns the stub fx-id.
+  - Unlike the wrapper, this does **not** install the `:rf.http/managed` override. Dispatch with `{:fx-overrides {:rf.http/managed :rf.http/managed-test-stub}}` (or wrap dispatches in `with-fx-overrides`) to route through it.
   - Nested installs snapshot the prior handler and restore it on uninstall (LIFO).
   - Not a `re-frame.core` façade export — call it through its home namespace `re-frame.http.test-support`.
 - **Example**:
@@ -397,7 +398,7 @@ Test-support surface for driving the pipeline without the network: canned-reply 
   ```clojure
   (uninstall-managed-request-stubs!)
   ```
-- **Description**: Tear down the most recent install: restores the previously installed stub handler when installs were nested (LIFO), else clears the stub fx and restores real-request routing. Idempotent — a teardown without a matching install is a safe no-op. Not a `re-frame.core` façade export — call it through its home namespace `re-frame.http.test-support`.
+- **Description**: Tear down the most recent install. When installs were nested, it restores the previously installed stub handler (LIFO); otherwise it clears the stub fx and restores real-request routing. Idempotent — a teardown without a matching install is a safe no-op. Not a `re-frame.core` façade export — call it through its home namespace `re-frame.http.test-support`.
 - **Example**:
   ```clojure
   (re-frame.http.test-support/uninstall-managed-request-stubs!)
@@ -423,9 +424,9 @@ HTTP carries secrets: passwords in request bodies, auth tokens in request header
 
 | Surface | What it covers | Where declared |
 |---|---|---|
-| Built-in header denylist | A closed, **immutable** set of always-sensitive header names (`Authorization`, `Cookie`, `Set-Cookie`, `X-API-Key`, `X-Auth-Token`, `X-CSRF-Token`, …). Redacted in every `:rf.http/*` trace's `:headers` slot regardless of any `:sensitive?` flag; case-insensitive. No frame can remove a name. | framework default |
-| Built-in query-param denylist | A closed, **immutable** set of always-sensitive query-param names (`api_key`, `access_token`, `token`, `secret`, `password`, `session`, `signature`, …). The value is redacted inline in `:url` slots (`?api_key=:rf/redacted&page=2`); name + position preserved. A hit also stamps `:sensitive? true` on the event — the name is the signal. | framework default |
-| Managed-HTTP carriers | App-specific sensitive header / query-param names, declared on the `:rf.http/managed` `reg-fx` registration (the transient-payload case). `:headers` is a vector of names (vector-only — header names always union onto the built-ins). `:query-params` is a vector of names (union) OR an `{:include […] :except […]}` policy map — effective policy `(defaults − except) ∪ include`; `:except` subtracts a built-in query-param default for this app's own dev trace. Names are case-insensitive; a malformed block fails loud. | `reg-fx :rf.http/managed` `:carriers {:headers […] :query-params […]}` |
+| Built-in header denylist | A closed, **immutable** set of always-sensitive header names (`Authorization`, `Cookie`, `Set-Cookie`, `X-API-Key`, `X-Auth-Token`, `X-CSRF-Token`, …). Redacted in every `:rf.http/*` trace's `:headers` slot, regardless of any `:sensitive?` flag. Matching is case-insensitive. No frame can remove a name. | framework default |
+| Built-in query-param denylist | A closed, **immutable** set of always-sensitive query-param names (`api_key`, `access_token`, `token`, `secret`, `password`, `session`, `signature`, …). The value is redacted inline in `:url` slots (`?api_key=:rf/redacted&page=2`), with name and position preserved. A hit also stamps `:sensitive? true` on the event; the name is the signal. | framework default |
+| Managed-HTTP carriers | App-specific sensitive header / query-param names, declared on the `:rf.http/managed` `reg-fx` registration (the transient-payload case). `:headers` is a vector of names — vector-only, because header names always union onto the built-ins. `:query-params` is a vector of names (union) OR an `{:include […] :except […]}` policy map with effective policy `(defaults − except) ∪ include`; `:except` subtracts a built-in query-param default for this app's own dev trace. Names are case-insensitive. A malformed block fails loud. | `reg-fx :rf.http/managed` `:carriers {:headers […] :query-params […]}` |
 | Per-request / per-call `:sensitive?` | The coarse opt-in that redacts a single request's body / params / all URL param values wholesale. | the `:rf.http/managed` args map (`:sensitive?` at top level, or under `:request`) |
 
 ```clojure
@@ -450,7 +451,7 @@ HTTP carries secrets: passwords in request bodies, auth tokens in request header
   ```clojure
   (managed-handler frame-ctx args-map)
   ```
-- **Description**: The `:rf.http/managed` fx handler body, re-exported so an app can re-register `:rf.http/managed` to declare its `:carriers` block (as in the example above) without knowing the internal handler fn. Not called directly from app code — pass it to `reg-fx`.
+- **Description**: The `:rf.http/managed` fx handler body. It is re-exported so an app can re-register `:rf.http/managed` to declare its `:carriers` block (as in the example above) without knowing the internal handler fn. Do not call it directly from app code — pass it to `reg-fx`.
 
 ### Response-body classification — on the `:decode` schema
 
@@ -468,13 +469,13 @@ The denylists and `:sensitive?` flag cover request carriers. The response body i
             :on-success [:auth/logged-in]}]]}))
 ```
 
-- **Per-slot.** A `:sensitive?` slot redacts to `:rf/redacted`; a `:large?` slot elides to the size marker; both → sensitive wins. A non-marked sibling rides verbatim. A root-level prop classifies the whole body (e.g. `[:string {:sensitive? true}]` for an opaque-token response).
-- **Off-box fail-closed.** Only an introspectable Malli schema (the raw EDN `[op props? …]` vector form) carries per-slot marks the walker can read. An unschematized body — the keyword decode modes (`:json` / `:text` / …), a custom decoder fn, a registry-keyword ref, or a compiled `m/schema` object — has an unknown shape, so it is omitted entirely off-box (**fail-closed**) rather than shipped raw.
-- **Raw error bodies are unconditionally omitted off-box.** A 4xx/5xx `:body` and a decode-failure `:body-text` are never decoded (status classification runs before decode), so they fail closed off-box irrespective of `:sensitive?` — error bodies frequently echo request context or tokens.
+- **Per-slot.** A `:sensitive?` slot redacts to `:rf/redacted`. A `:large?` slot elides to the size marker. When a slot carries both, sensitive wins. A non-marked sibling rides verbatim. A root-level prop classifies the whole body — e.g. `[:string {:sensitive? true}]` for an opaque-token response.
+- **Off-box fail-closed.** Only an introspectable Malli schema (the raw EDN `[op props? …]` vector form) carries per-slot marks the walker can read. An unschematized body has an unknown shape, so it is omitted entirely off-box (**fail-closed**) rather than shipped raw. Unschematized means any of: the keyword decode modes (`:json` / `:text` / …), a custom decoder fn, a registry-keyword ref, or a compiled `m/schema` object.
+- **Raw error bodies are unconditionally omitted off-box.** A 4xx/5xx `:body` and a decode-failure `:body-text` are never decoded, because status classification runs before decode. They therefore fail closed off-box irrespective of `:sensitive?`. Error bodies frequently echo request context or tokens.
 
 !!! warning "Classification does not propagate — declare each surface a secret crosses"
 
-    A token in the response body (classified by the `:decode` schema) and the same token stored durably in `app-db` are **two** declarations on two surfaces. There is no propagation that carries one to the other. When `:on-success` writes the token into `app-db`, classify that durable path too — a `reg-event` returning `:sensitive [[:auth :token]]` alongside `:db` ([re-frame.core.md §Standard events](re-frame.core.md) and [keep secrets out of traces](../core/how-to/keep-secrets-out-of-traces.md)). And never copy a secret into a sibling app-db path you have not classified (e.g. a JWT duplicated at `[:auth :user :token]`): the copy ships raw until *that* path is classified or the duplicate is dropped.
+    A token in the response body (classified by the `:decode` schema) and the same token stored durably in `app-db` are **two** declarations on two surfaces. There is no propagation that carries one to the other. When `:on-success` writes the token into `app-db`, classify that durable path too: a `reg-event` returning `:sensitive [[:auth :token]]` alongside `:db` ([re-frame.core.md §Standard events](re-frame.core.md) and [keep secrets out of traces](../core/how-to/keep-secrets-out-of-traces.md)). And never copy a secret into a sibling app-db path you have not classified — e.g. a JWT duplicated at `[:auth :user :token]`. The copy ships raw until *that* path is classified or the duplicate is dropped.
 
 ## Trace events emitted by `:rf.http/managed`
 

--- a/docs/api/re-frame.machines.md
+++ b/docs/api/re-frame.machines.md
@@ -1,13 +1,13 @@
 # re-frame.machines
 
-State machines, per Spec 005. A machine is registered with one macro (`reg-machine`) and *is* an event handler: the transition table — a map of `:states`, `:on`, `:entry`, `:exit`, `:after` — compiles into a `reg-event` handler at registration time. Dispatch an event at the machine's id and the table decides the transition; the resulting `:db` and `:fx` flow through the normal cascade. The same trace bus, time-travel, and override surfaces that work for plain handlers work for machines.
+State machines, per Spec 005. You register a machine with one macro (`reg-machine`), and the machine *is* an event handler. Its transition table — a map of `:states`, `:on`, `:entry`, `:exit`, `:after` — compiles into a `reg-event` handler at registration time. Dispatch an event at the machine's id, and the table decides the transition. The resulting `:db` and `:fx` flow through the normal cascade. The same trace bus, time-travel, and override surfaces that work for plain handlers also work for machines.
 
 ```clojure
 (:require [re-frame.core     :as rf]        ;; reg-machine / defmachine — the facade registration macros
           [re-frame.machines :as machines]) ;; engine, query, transition, tooling, runtime helpers
 ```
 
-A machine's snapshot is read with the ordinary `subscribe` naming its framework sub vector — `@(rf/subscribe [:rf/machine machine-id])` for the snapshot, `@(rf/subscribe [:rf.machine/has-tag? machine-id tag])` for a `:tags`-membership predicate. There is no named-read-sugar fn: a runtime-db framework read is a subscription vector, one grammar.
+Read a machine's snapshot with the ordinary `subscribe`, naming its framework sub vector. Use `@(rf/subscribe [:rf/machine machine-id])` for the snapshot, and `@(rf/subscribe [:rf.machine/has-tag? machine-id tag])` for a `:tags`-membership predicate. There is no named-read-sugar fn: every runtime-db framework read is a subscription vector, one grammar.
 
 Surfaces split two ways:
 
@@ -29,9 +29,9 @@ For the full treatment — the underlying model, the recognition kit, and the ra
   (reg-machine machine-id opts machine-spec)
   ```
 - **Description**: The canonical registration macro. Compiles the spec into a `reg-event` handler and captures per-element source for Xray.
-    - Walks the literal spec at expansion time; co-locates per-element source (`{:fn .. :source-coords .. :source-code ..}`) onto each `:guards` / `:actions` / `:on-spawn-actions` entry, plus a reference-site `:source-coords` onto each `:states`-tree map node (state-node / transition map). Xray uses these to navigate from a snapshot back to the guard/action definition or the state-node.
+    - Walks the literal spec at expansion time. It attaches per-element source (`{:fn .. :source-coords .. :source-code ..}`) to each `:guards` / `:actions` / `:on-spawn-actions` entry, and a reference-site `:source-coords` to each `:states`-tree map node (state-node or transition map). Xray uses these to navigate from a snapshot back to the guard or action definition, or to the state-node.
     - Top-level call-site coords land on `handler-meta`.
-    - The optional `opts` registration-metadata map sits in the middle slot. Its `:schema` key validates the dispatched outer event vector at the `:where :event` boundary; any other keys ride onto the registration metadata.
+    - The optional `opts` registration-metadata map sits in the middle slot. Its `:schema` key validates the dispatched outer event vector at the `:where :event` boundary. Any other keys ride onto the registration metadata.
     - The framework-owned `:rf/machine?` / `:rf/machine` keys are stamped by the registration home and must **not** appear in `opts`.
     - Reached on the `re-frame.core` facade as `rf/reg-machine`.
 
@@ -82,9 +82,9 @@ The snapshot lives at `[:rf.runtime/machines :snapshots :session]` in the frame'
   (defmachine name machine-spec)
   (defmachine name docstring machine-spec)
   ```
-- **Description**: Defines a machine-spec *value* with per-element source captured — a drop-in for `def` whose body is a literal machine-spec map.
-    - Walks the literal spec at expansion time; co-locates per-element source (`{:fn .. :source-coords .. :source-code ..}`) onto each `:guards` / `:actions` / `:on-spawn-actions` entry, plus a reference-site `:source-coords` onto each `:states`-tree map node.
-    - The source is stamped on the value, so when it is later passed to `reg-machine`, `(rf/handler-meta :machine-guard [machine-id guard-id])` and the Xray machine-cascade source rendering light up for value-registered machines exactly as for inline ones.
+- **Description**: Defines a machine-spec *value* with per-element source captured. It is a drop-in for `def` whose body is a literal machine-spec map.
+    - Walks the literal spec at expansion time. It attaches per-element source (`{:fn .. :source-coords .. :source-code ..}`) to each `:guards` / `:actions` / `:on-spawn-actions` entry, and a reference-site `:source-coords` to each `:states`-tree map node.
+    - The source is stamped on the value itself. When the value is later passed to `reg-machine`, `(rf/handler-meta :machine-guard [machine-id guard-id])` and the Xray machine-cascade source rendering light up for value-registered machines exactly as for inline ones.
     - Needed because a plain `(def m {…})` + `(reg-machine :id m)` hands `reg-machine` only the symbol, so its literal-walk captures nothing. `defmachine` captures at the definition site.
     - The dev-only `:source-*` slots DCE under `:advanced` + `goog.DEBUG=false`.
     - Reached on the `re-frame.core` facade as `rf/defmachine`.
@@ -112,7 +112,7 @@ The snapshot lives at `[:rf.runtime/machines :snapshots :session]` in the frame'
   ```
 - **Description**: Plain-fn surface beneath the macro. No source-coord walking.
     - For code-gen pipelines, REPL workflows, or conformance harnesses that synthesise specs from data.
-    - The 3-arity takes the same middle-slot `opts` registration-metadata map as the macro: `:schema` validates the dispatched outer event vector at the `:where :event` boundary; the framework-owned `:rf/machine?` / `:rf/machine` keys must not appear in `opts`.
+    - The 3-arity takes the same middle-slot `opts` registration-metadata map as the macro. `:schema` validates the dispatched outer event vector at the `:where :event` boundary. The framework-owned `:rf/machine?` / `:rf/machine` keys must not appear in `opts`.
 - **Example**:
   ```clojure
   ;; Same effect as the macro, minus the source-coord walking.
@@ -188,7 +188,7 @@ The snapshot lives at `[:rf.runtime/machines :snapshots :session]` in the frame'
   ```clojure
   (re-frame.machines/machine-meta machine-id) → registration-metadata map
   ```
-- **Description**: Returns the registered machine's spec map, or `nil` when `machine-id` does not name a registered machine. The spec map holds the transition table, doc, schemas, and per-element source-coords — read from the `:rf/machine` slot of the `:event` registration metadata.
+- **Description**: Returns the registered machine's spec map, or `nil` when `machine-id` does not name a registered machine. The spec map holds the transition table, doc, schemas, and per-element source-coords. It is read from the `:rf/machine` slot of the `:event` registration metadata.
 - **Example**:
   ```clojure
   ;; The registered spec back out — table, doc, schemas, source-coords.
@@ -206,9 +206,9 @@ The snapshot lives at `[:rf.runtime/machines :snapshots :session]` in the frame'
   (re-frame.machines/machine-by-system-id system-id {:frame target})
   ```
 - **Description**: Reverse-lookup: given a `system-id`, returns the spawned-machine id bound to it, or `nil`.
-    - The single-arity resolves the frame from the ambient scope, raising `:rf.error/no-frame-context` under no scope.
-    - The opts form `(machine-by-system-id system-id {:frame target})` names a frame explicitly — the trailing `{:frame …}` opts map, the same public-frame-targeting shape `subscribe` takes.
-    - The 2-arity is shape-discriminated on the second arg: an opts map is the public form; a bare frame target is the *internal* frame-last plumbing.
+    - The single-arity resolves the frame from the ambient scope. Under no scope it raises `:rf.error/no-frame-context`.
+    - The opts form `(machine-by-system-id system-id {:frame target})` names a frame explicitly. The trailing `{:frame …}` opts map is the same public frame-targeting shape `subscribe` takes.
+    - The 2-arity is shape-discriminated on the second arg. An opts map is the public form; a bare frame target is the *internal* frame-last plumbing.
 - **Example**:
   ```clojure
   ;; Resolve a :system-id-bound actor, then address it directly.
@@ -218,7 +218,7 @@ The snapshot lives at `[:rf.runtime/machines :snapshots :session]` in the frame'
 
 ## Keyword surfaces
 
-The framework-registered subscription vectors and reserved effect tuples that address machines by keyword. These are unioned into every resolved image generation (a `:select-ns` image cannot reach them by namespace), so an image-loaded frame resolves them the same way a default frame does.
+The framework-registered subscription vectors and reserved effect tuples that address machines by keyword. These are unioned into every resolved image generation, since a `:select-ns` image cannot reach them by namespace. An image-loaded frame therefore resolves them the same way a default frame does.
 
 ### `[:rf/machine machine-id]`
 
@@ -241,7 +241,7 @@ The framework-registered subscription vectors and reserved effect tuples that ad
   ```clojure
   [:rf.machine/has-tag? machine-id tag]
   ```
-- **Description**: Returns `true` iff the named machine's current snapshot's `:tags` set contains `tag`, `false` otherwise (including unknown / not-yet-initialised machines). A *derived* sub: it reads the snapshot's containment-bit directly rather than chaining off `:rf/machine`, so a view that only cares about one tag re-renders only when that bit flips.
+- **Description**: Returns `true` iff the `:tags` set in the named machine's current snapshot contains `tag`. Returns `false` otherwise, including for unknown or not-yet-initialised machines. This is a *derived* sub: it reads the snapshot's containment-bit directly rather than chaining off `:rf/machine`. A view that only cares about one tag therefore re-renders only when that bit flips.
 - **Example**:
   ```clojure
   @(rf/subscribe [:rf.machine/has-tag? :auth.login/flow :auth/busy])  ;; => true / false
@@ -256,12 +256,12 @@ The framework-registered subscription vectors and reserved effect tuples that ad
   ```
 - **Description**: Spawn a dynamic actor instance. Emitted from any event handler's `:fx` (including machine actions and the declarative `:spawn` desugar). `spawn-spec` carries exactly one of `:machine-id` (the registered machine type to instantiate) or `:definition` (an inline spec map), plus optional keys:
     - `:data` — overrides the type's initial `:data`.
-    - `:id-prefix` — actor ids are the deterministic `<prefix>#<n>` from a per-type counter; the prefix defaults to `:machine-id`; ids are never gensym'd.
+    - `:id-prefix` — actor ids are the deterministic `<prefix>#<n>` from a per-type counter. The prefix defaults to `:machine-id`. Ids are never gensym'd.
     - `:fixed-actor-id` — an explicit actor address; skips allocation.
-    - `:system-id` — binds the actor in the frame's `[:rf.runtime/machines :system-ids]` reverse index; a collision emits `:rf.error/system-id-collision` and rebinds last-write-wins.
-    - `:start` — a single event vector dispatched to the new actor as `[<spawned-id> <start>]`; when absent the runtime dispatches the synthetic `[<spawned-id> [:rf.machine.spawn/spawned]]`.
-    - `:on-spawn` — an *advisory* callback `(fn [{:keys [data id]}] …)`; the return value is dropped; a non-nil return emits the dev-only `:rf.warning/on-spawn-return-ignored`.
-    - Declarative `:spawn` state nodes accept the same keys plus `:on-done` / `:on-error` / `:timeout` / `:on-timeout`; on the declarative path the framework binds the child's allocated id into the parent's `:data` at `[:rf/spawned <invoke-id>]`.
+    - `:system-id` — binds the actor in the frame's `[:rf.runtime/machines :system-ids]` reverse index. A collision emits `:rf.error/system-id-collision` and rebinds last-write-wins.
+    - `:start` — a single event vector dispatched to the new actor as `[<spawned-id> <start>]`. When absent, the runtime dispatches the synthetic `[<spawned-id> [:rf.machine.spawn/spawned]]`.
+    - `:on-spawn` — an *advisory* callback `(fn [{:keys [data id]}] …)`. The return value is dropped. A non-nil return emits the dev-only `:rf.warning/on-spawn-return-ignored`.
+    - Declarative `:spawn` state nodes accept the same keys plus `:on-done` / `:on-error` / `:timeout` / `:on-timeout`. On the declarative path, the framework binds the child's allocated id into the parent's `:data` at `[:rf/spawned <invoke-id>]`.
     - Fails closed when `:machine-id` names an unregistered type and no `:definition` is supplied (`:rf.error/machine-spawn-unregistered-type`). Backed by [`spawn-fx`](#re-framemachinesspawn-fx).
 - **Example**:
   ```clojure
@@ -288,7 +288,7 @@ The framework-registered subscription vectors and reserved effect tuples that ad
   [:rf.machine/destroy actor-id]
   ```
 - **Description**: Tear down an actor. Symmetric counterpart to `:rf.machine/spawn`; backed by [`destroy-machine-fx`](#re-framemachinesdestroy-machine-fx).
-    - Runs the actor's `:exit` cascade, cancels its armed `:after` timers, dissociates `[:rf.runtime/machines :snapshots <actor-id>]` (in runtime-db), releases its `:system-id` binding, and unregisters its event handler when one is registered.
+    - Runs the actor's `:exit` cascade and cancels its armed `:after` timers. Dissociates `[:rf.runtime/machines :snapshots <actor-id>]` (in runtime-db) and releases its `:system-id` binding. Unregisters its event handler when one is registered.
     - A spawned actor has no per-instance registration — its liveness is its snapshot's presence.
     - Silent-idempotent: destroying an already-destroyed actor is a no-op.
 - **Example**:
@@ -298,7 +298,7 @@ The framework-registered subscription vectors and reserved effect tuples that ad
       {:fx [[:rf.machine/destroy (machines/machine-by-system-id :logger)]]}))
   ```
 
-**Final states and `:on-done`.** Leaf states marked `:final?` auto-destroy the machine on entry; the parent (if any) receives `:on-done` with the child's `:data` slot. A spawn-shaped sub-process completes, the parent receives the result through `:on-done`, and the framework destroys the child — no manual `:rf.machine/destroy` needed.
+**Final states and `:on-done`.** Leaf states marked `:final?` auto-destroy the machine on entry. The parent (if any) receives `:on-done` with the child's `:data` slot. So a spawn-shaped sub-process completes, the parent receives the result through `:on-done`, and the framework destroys the child. No manual `:rf.machine/destroy` is needed.
 
 | State-node key | What it does |
 |---|---|
@@ -316,8 +316,8 @@ See [Final states: when a machine is done](../machines/concepts.md#final-states-
   [:rf.machine/dispatch-to-system [system-id event]]
   ```
 - **Description**: The action-side way one machine addresses its spawned child actor by *role* (`:logger`, `:websocket`, `:retry-coordinator`) instead of by allocated id.
-    - Resolves `system-id` through the emitting frame's `[:rf.runtime/machines :system-ids]` reverse index (in runtime-db) and dispatches `event` to the bound actor; no-op when the `system-id` is unbound.
-    - Canonical action-side surface: a machine action can't read app-db and its `:on-spawn` return is dropped, so the fx form is how an action messages a named actor.
+    - Resolves `system-id` through the emitting frame's `[:rf.runtime/machines :system-ids]` reverse index (in runtime-db) and dispatches `event` to the bound actor. A no-op when the `system-id` is unbound.
+    - This is the canonical action-side surface. A machine action can't read app-db, and its `:on-spawn` return is dropped, so the fx form is how an action messages a named actor.
     - Args ride as a single 2-element pair (the fx contract is a `[fx-id args]` pair).
     - Backed by [`dispatch-to-system-fx`](#re-framemachinesdispatch-to-system-fx); the call-site twin is the [`dispatch-to-system`](#re-framemachinesdispatch-to-system) fn.
 - **Example**:
@@ -332,7 +332,7 @@ See [Final states: when a machine is done](../machines/concepts.md#final-states-
   ```clojure
   [:rf.machine/update-snapshot {:rf/machine-id <id> :rf/patch {:data {...}}}]
   ```
-- **Description**: Snapshot-level escape hatch. Emit from a callback's (or any event handler's) `:fx` vector to touch a machine's `:state` / `:meta` / `:data` atomically. The `:data` patch is gated by [`validate-update-snapshot-data!`](#re-framemachinesvalidate-update-snapshot-data) against the actor's `[:schemas :data]` schema *before* the fx writes it, so the escape hatch is not exempt from the `:where :machine-data` boundary. Per Spec 005 §Snapshot-level escape hatch.
+- **Description**: Snapshot-level escape hatch. Emit from a callback's (or any event handler's) `:fx` vector to touch a machine's `:state` / `:meta` / `:data` atomically. The `:data` patch is gated by [`validate-update-snapshot-data!`](#re-framemachinesvalidate-update-snapshot-data) against the actor's `[:schemas :data]` schema *before* the fx writes it. The escape hatch is therefore not exempt from the `:where :machine-data` boundary. Per Spec 005 §Snapshot-level escape hatch.
 - **Example**:
   ```clojure
   {:fx [[:rf.machine/update-snapshot {:rf/machine-id :session
@@ -354,7 +354,7 @@ See [Final states: when a machine is done](../machines/concepts.md#final-states-
 
 ## Cross-machine messaging
 
-When a child actor spawns declaratively under a parent, the framework binds the child's allocated id into the parent's `:data` at `[:rf/spawned <invoke-id>]` (an `:on-spawn` callback cannot capture it — its return is dropped); naming by `:system-id` lets the parent address the child by *role* without threading that id. The canonical action-side surface is the [`[:rf.machine/dispatch-to-system [system-id event]]`](#rfmachinedispatch-to-system-system-id-event) fx tuple (above); the helpers below are the direct-call twins.
+When a child actor spawns declaratively under a parent, the framework binds the child's allocated id into the parent's `:data` at `[:rf/spawned <invoke-id>]`. An `:on-spawn` callback cannot capture that id, because its return is dropped. Naming by `:system-id` lets the parent address the child by *role* without threading the id around. The canonical action-side surface is the [`[:rf.machine/dispatch-to-system [system-id event]]`](#rfmachinedispatch-to-system-system-id-event) fx tuple (above). The helpers below are the direct-call twins.
 
 ### `re-frame.machines/dispatch-to-system`
 
@@ -364,9 +364,9 @@ When a child actor spawns declaratively under a parent, the framework binds the 
   (re-frame.machines/dispatch-to-system system-id event)
   (re-frame.machines/dispatch-to-system system-id event frame-id)
   ```
-- **Description**: The direct-call twin of the `:rf.machine/dispatch-to-system` fx — sugar over `(when-let [m (machine-by-system-id system-id)] (dispatch [m event]))`, no-op when the `system-id` is unbound.
-    - The two-arity form resolves the frame from the carried scope it runs under; the three-arity form names the frame explicitly. There is no `:rf/default` fallback, and looking up under no scope raises `:rf.error/no-frame-context`.
-    - Implementation-tier helper; new app code should emit the `[:rf.machine/dispatch-to-system [system-id event]]` fx instead.
+- **Description**: The direct-call twin of the `:rf.machine/dispatch-to-system` fx. Sugar over `(when-let [m (machine-by-system-id system-id)] (dispatch [m event]))`; a no-op when the `system-id` is unbound.
+    - The two-arity form resolves the frame from the carried scope it runs under. The three-arity form names the frame explicitly. There is no `:rf/default` fallback; looking up under no scope raises `:rf.error/no-frame-context`.
+    - This is an implementation-tier helper. New app code should emit the `[:rf.machine/dispatch-to-system [system-id event]]` fx instead.
 - **Example**:
   ```clojure
   ;; Implementation-tier direct call (prefer the fx in app code); no-op when unbound.
@@ -381,13 +381,13 @@ When a child actor spawns declaratively under a parent, the framework binds the 
   (re-frame.machines/dispatch-to-system-fx fx-ctx [system-id event])
   ```
 - **Description**: The fx handler behind `:rf.machine/dispatch-to-system`.
-    - Resolves `system-id` through the emitting frame's `[:rf.runtime/machines :system-ids]` reverse index and dispatches `event` to the bound actor; no-op when the `system-id` is unbound (symmetric with the `dispatch-to-system` fn's no-op fall-through).
-    - The cascade-envelope frame is the fx-context `:frame`; a nil stamp is an invariant failure (`:rf.error/no-frame-context`), never a synthesised `:rf/default`.
+    - Resolves `system-id` through the emitting frame's `[:rf.runtime/machines :system-ids]` reverse index and dispatches `event` to the bound actor. A no-op when the `system-id` is unbound, symmetric with the `dispatch-to-system` fn's no-op fall-through.
+    - The cascade-envelope frame is the fx-context `:frame`. A nil stamp is an invariant failure (`:rf.error/no-frame-context`), never a synthesised `:rf/default`.
     - App code emits the `[:rf.machine/dispatch-to-system [system-id event]]` fx rather than calling this fn.
 
 ## Machine-tooling exports (JVM)
 
-The shipped machine-tooling exports are `re-frame.machines` aliases over `re-frame.machines.tooling`; the aliases are JVM-only (no `re-frame.core` facade export). CLJS tool consumers call `re-frame.machines.tooling/<name>` directly — the CLJS facade deliberately omits the tooling require so an app that attaches no tool DCEs the tooling body. They render the machine *algebra view* that Xray / re-frame-pair navigate. There is **no** framework-level `machine->xstate-json`, `machine->mermaid`, or Stately bridge — those exporters are owned by the separate post-v1 `day8/re-frame2-machines-viz` library, not the framework.
+The shipped machine-tooling exports are `re-frame.machines` aliases over `re-frame.machines.tooling`. The aliases are JVM-only; there is no `re-frame.core` facade export. CLJS tool consumers call `re-frame.machines.tooling/<name>` directly. The CLJS facade deliberately omits the tooling require, so an app that attaches no tool DCEs the tooling body. These exports render the machine *algebra view* that Xray and re-frame-pair navigate. There is **no** framework-level `machine->xstate-json`, `machine->mermaid`, or Stately bridge. Those exporters are owned by the separate post-v1 `day8/re-frame2-machines-viz` library, not the framework.
 
 ### `re-frame.machines/machine-algebra-view`
 
@@ -397,7 +397,7 @@ The shipped machine-tooling exports are `re-frame.machines` aliases over `re-fra
   (re-frame.machines/machine-algebra-view) → {machine-id node}
   (re-frame.machines/machine-algebra-view machine-id) → node (or nil)
   ```
-- **Description**: The static algebra view over a machine *definition* — the structure Xray's machine inspector and the docs/visualisation lane read. JVM-only. The zero-arity form returns `{machine-id node}` for every registered machine (`{}` when none); the one-arity form returns the single node for `machine-id`, or `nil` if it is not registered.
+- **Description**: The static algebra view over a machine *definition*. This is the structure Xray's machine inspector and the docs/visualisation lane read. JVM-only. The zero-arity form returns `{machine-id node}` for every registered machine, or `{}` when none are registered. The one-arity form returns the single node for `machine-id`, or `nil` if it is not registered.
 - **Example**:
   ```clojure
   ;; The whole registry, keyed by machine-id — or one node (nil if unregistered).
@@ -413,7 +413,10 @@ The shipped machine-tooling exports are `re-frame.machines` aliases over `re-fra
   (re-frame.machines/machine-instance-algebra-view) → {actor-id node}
   (re-frame.machines/machine-instance-algebra-view frame-id) → {actor-id node}
   ```
-- **Description**: The algebra view for a live machine *instance* — definition plus current snapshot, so the view can highlight the active state. JVM-only. The zero-arity form reads the ambient current frame; the one-arity form names a `frame-id`. Returns `{actor-id node}` (one node per live snapshot — singletons and spawned actors), `{}` for a frame with no live machines, and `nil` for a missing/destroyed frame or in production builds.
+- **Description**: The algebra view for a live machine *instance*: definition plus current snapshot, so the view can highlight the active state. JVM-only. The zero-arity form reads the ambient current frame; the one-arity form names a `frame-id`. Returns:
+    - `{actor-id node}` — one node per live snapshot, covering singletons and spawned actors.
+    - `{}` — the frame has no live machines.
+    - `nil` — the frame is missing or destroyed, or this is a production build.
 - **Example**:
   ```clojure
   ;; Live nodes — one per machine snapshot in the frame (singletons + spawned actors).
@@ -427,7 +430,7 @@ The shipped machine-tooling exports are `re-frame.machines` aliases over `re-fra
   ```clojure
   (re-frame.machines/machine-selector? sub-id) → boolean
   ```
-- **Description**: True iff the subscription registered under `sub-id` is a machine selector — an ordinary `reg-sub` whose static `:<-` inputs include a `[:rf/machine …]` (or `[:rf.machine/has-tag? …]`) query vector. Machine selectors stay ordinary ephemeral `:derivation` subscription nodes, not a second subscription system; this recognizer lets a graph tool flag the ones that read a machine. JVM-only.
+- **Description**: True iff the subscription registered under `sub-id` is a machine selector: an ordinary `reg-sub` whose static `:<-` inputs include a `[:rf/machine …]` (or `[:rf.machine/has-tag? …]`) query vector. Machine selectors stay ordinary ephemeral `:derivation` subscription nodes, not a second subscription system. This recognizer lets a graph tool flag the ones that read a machine. JVM-only.
 - **Example**:
   ```clojure
   (machines/machine-selector? :session/summary)  ;; => true / false
@@ -440,7 +443,7 @@ The shipped machine-tooling exports are `re-frame.machines` aliases over `re-fra
   ```clojure
   (re-frame.machines/machine-selector-targets sub-id) → #{machine-id …}
   ```
-- **Description**: The set of machine ids the subscription registered under `sub-id` reads as a machine selector — the second element of each accepted `[:rf/machine machine-id …]` / `[:rf.machine/has-tag? machine-id …]` static `:<-` input. Where `machine-selector?` answers only the boolean, this returns the actual target machine ids a graph tool needs to draw the edge. JVM-only.
+- **Description**: The set of machine ids the subscription registered under `sub-id` reads as a machine selector. Each id is the second element of an accepted `[:rf/machine machine-id …]` / `[:rf.machine/has-tag? machine-id …]` static `:<-` input. Where `machine-selector?` answers only the boolean, this returns the actual target machine ids a graph tool needs to draw the edge. JVM-only.
 - **Example**:
   ```clojure
   (machines/machine-selector-targets :session/summary)  ;; => #{:session}
@@ -448,7 +451,7 @@ The shipped machine-tooling exports are `re-frame.machines` aliases over `re-fra
 
 ## Implementation-tier effect handlers
 
-The fx handlers behind the reserved `:rf.machine/*` effect ids. They are registered by this namespace via `reg-fx` so an app that doesn't pull in `day8/re-frame2-machines` carries neither the trace strings nor the handler symbols on its production-elision bundle. **App code emits the effect tuple (Keyword surfaces, above) — it does not call these fns directly.** Each takes the standard `(handler fx-ctx args)` shape; the cascade-envelope frame is the fx-context `:frame`.
+The fx handlers behind the reserved `:rf.machine/*` effect ids. This namespace registers them via `reg-fx`, so an app that doesn't pull in `day8/re-frame2-machines` carries neither the trace strings nor the handler symbols on its production-elision bundle. **App code emits the effect tuple (Keyword surfaces, above) — it does not call these fns directly.** Each takes the standard `(handler fx-ctx args)` shape. The cascade-envelope frame is the fx-context `:frame`.
 
 ### `re-frame.machines/spawn-fx`
 
@@ -457,7 +460,7 @@ The fx handlers behind the reserved `:rf.machine/*` effect ids. They are registe
   ```clojure
   (re-frame.machines/spawn-fx fx-ctx spawn-spec)
   ```
-- **Description**: Installs the spawned actor's snapshot at `[:rf.runtime/machines :snapshots <spawned-id>]` in the spawning frame's runtime-db, stamping the revertible `:rf/machine-type` TYPE reference so the lazy resolver and epoch restore can rebuild the actor; the actor's liveness IS that snapshot's presence (there is no per-instance event-handler registration). Fails closed when `:machine-id` names an unregistered machine type and the spawn carries no inline `:definition` (emits the always-on `:rf.error/machine-spawn-unregistered-type` and installs nothing).
+- **Description**: Installs the spawned actor's snapshot at `[:rf.runtime/machines :snapshots <spawned-id>]` in the spawning frame's runtime-db. It stamps the revertible `:rf/machine-type` TYPE reference so the lazy resolver and epoch restore can rebuild the actor. The actor's liveness IS that snapshot's presence; there is no per-instance event-handler registration. Fails closed when `:machine-id` names an unregistered machine type and the spawn carries no inline `:definition`: it emits the always-on `:rf.error/machine-spawn-unregistered-type` and installs nothing.
 
 ### `re-frame.machines/spawn-all-init-fx`
 
@@ -466,7 +469,7 @@ The fx handlers behind the reserved `:rf.machine/*` effect ids. They are registe
   ```clojure
   (re-frame.machines/spawn-all-init-fx fx-ctx args)
   ```
-- **Description**: On entry to a `:spawn-all`-bearing state the runtime emits this fx (alongside per-child `:rf.machine/spawn` fxs) to seed the join state at `[:rf.runtime/machines :spawned <parent> <invoke-id>]` — `{:children {…} :done #{} :failed #{} :resolved? false :spec …}`. Subsequent `:on-child-done` / `:on-child-error` events resolve the join. Machine-internal — not for direct application use.
+- **Description**: On entry to a `:spawn-all`-bearing state, the runtime emits this fx alongside the per-child `:rf.machine/spawn` fxs. It seeds the join state at `[:rf.runtime/machines :spawned <parent> <invoke-id>]` with the shape `{:children {…} :done #{} :failed #{} :resolved? false :spec …}`. Subsequent `:on-child-done` / `:on-child-error` events resolve the join. Machine-internal — not for direct application use.
 
 ### `re-frame.machines/destroy-machine-fx`
 
@@ -475,7 +478,7 @@ The fx handlers behind the reserved `:rf.machine/*` effect ids. They are registe
   ```clojure
   (re-frame.machines/destroy-machine-fx fx-ctx args)
   ```
-- **Description**: Dispatches to the keyword-form / single-`:spawn` teardown or the `:spawn-all` children-iteration teardown per the `args` shape. Runs the actor's `:exit` cascade, clears its `[:rf.runtime/machines :snapshots <actor-id>]` slot, and drops its event-handler registration.
+- **Description**: Picks the teardown path from the `args` shape: the keyword-form / single-`:spawn` teardown, or the `:spawn-all` children-iteration teardown. It runs the actor's `:exit` cascade, clears its `[:rf.runtime/machines :snapshots <actor-id>]` slot, and drops its event-handler registration.
 
 ### `re-frame.machines/after-schedule-fx`
 
@@ -484,7 +487,7 @@ The fx handlers behind the reserved `:rf.machine/*` effect ids. They are registe
   ```clojure
   (re-frame.machines/after-schedule-fx fx-ctx args)
   ```
-- **Description**: On entry to an `:after`-bearing state node the runtime emits one of these per `:after` entry. Resolves the delay (literal `pos-int?` / subscription vector / `(fn [snapshot] ms)`), schedules a real wall-clock timer via the clock abstraction, and (for subscription delays) installs an add-watch that cancels-and-reschedules on sub-value change. The synthetic expiry event is `[<parent-id> [:rf.machine.timer/after-elapsed <delay-key> <epoch> <decl-path>]]` and fires only when the scheduling node is still active and the carried epoch matches. Machine-internal — not for direct application use.
+- **Description**: On entry to an `:after`-bearing state node, the runtime emits one of these per `:after` entry. It resolves the delay (a literal `pos-int?`, a subscription vector, or a `(fn [snapshot] ms)`) and schedules a real wall-clock timer via the clock abstraction. For subscription delays it also installs an add-watch that cancels and reschedules when the sub's value changes. The synthetic expiry event is `[<parent-id> [:rf.machine.timer/after-elapsed <delay-key> <epoch> <decl-path>]]`. It fires only when the scheduling node is still active and the carried epoch matches. Machine-internal — not for direct application use.
 
 ### `re-frame.machines/after-cancel-fx`
 
@@ -507,7 +510,7 @@ The registration-time and `:data`-schema-boundary validators. The three `:data` 
   (re-frame.machines/validate-machine! machine)
   ```
 - **Description**: Runs every registration-time check the machine grammar requires.
-    - Covers history-state placement / closed key-set / at-most-one-per-compound / `:default-target` resolution, `:type :parallel` region shape, and top-level dispatch + guard/action ref resolution.
+    - Covers history-state placement, the closed key-set, the at-most-one-per-compound rule, `:default-target` resolution, `:type :parallel` region shape, and top-level dispatch plus guard/action ref resolution.
     - Composed at the top of `make-machine-handler` so the registered handler fn's body is exclusively request processing.
     - Throws the `:rf.error/machine-*` taxonomy on a grammar violation (e.g. `:rf.error/machine-history-misplaced` / `-history-extra-keys` / `-history-duplicate` / `-history-bad-default-target`, `:rf.error/machine-unknown-node-key`, `:rf.error/machine-unresolved-guard` / `-unresolved-action`).
     - The conformance corpus's `:reg-machine` Mode-B op pins the registration-error taxonomy against this leaf fn.
@@ -520,9 +523,9 @@ The registration-time and `:data`-schema-boundary validators. The three `:data` 
   (re-frame.machines/validate-machine-data! runtime-db event-id frame-id) → boolean
   ```
 - **Description**: Walks every snapshot under `[:rf.runtime/machines :snapshots]` in `runtime-db` and validates its `:data` against the resolved machine's `[:schemas :data]` schema.
-    - Returns `true` iff every snapshot conformed (or carried no schema / no validator); `false` on the first failure, with the per-snapshot trace already emitted — the router then rolls back the whole transition (same mechanism as the `:where :app-db` rollback).
+    - Returns `true` iff every snapshot conformed, or carried no schema / no validator. Returns `false` on the first failure, with the per-snapshot trace already emitted. The router then rolls back the whole transition — the same mechanism as the `:where :app-db` rollback.
     - Schema resolution covers a SINGLETON (via `machine-meta`) AND a SPAWNED actor (via the snapshot's `:rf/machine-type`).
-    - The post-commit boundary the router AND-conjoins with `validate-app-schema!`.
+    - This is the post-commit boundary the router AND-conjoins with `validate-app-schema!`.
 
 ### `re-frame.machines/validate-spawn-data!`
 
@@ -531,7 +534,7 @@ The registration-time and `:data`-schema-boundary validators. The three `:data` 
   ```clojure
   (re-frame.machines/validate-spawn-data! spawned-id spec snapshot) → boolean
   ```
-- **Description**: Sibling of `validate-machine-data!` for the `:rf.machine/spawn` install path. Validates a freshly-built initial snapshot's `:data` against the spawned actor's machine `[:schemas :data]` schema BEFORE the snapshot lands in runtime-db. Returns `true` on conform / no schema / no validator; `false` on failure (the caller skips the install). A spawn failure does not commit, so there is nothing to roll back (`:phase :spawn` emits with `:rollback? false`).
+- **Description**: Sibling of `validate-machine-data!` for the `:rf.machine/spawn` install path. Validates a freshly-built initial snapshot's `:data` against the spawned actor's machine `[:schemas :data]` schema BEFORE the snapshot lands in runtime-db. Returns `true` on conform, no schema, or no validator. Returns `false` on failure, and the caller skips the install. A spawn failure does not commit, so there is nothing to roll back (`:phase :spawn` emits with `:rollback? false`).
 
 ### `re-frame.machines/validate-update-snapshot-data!`
 
@@ -540,7 +543,7 @@ The registration-time and `:data`-schema-boundary validators. The three `:data` 
   ```clojure
   (re-frame.machines/validate-update-snapshot-data! machine-id merged-snapshot) → boolean
   ```
-- **Description**: Sibling validator for the `:rf.machine/update-snapshot` escape-hatch fx. Validates the would-be-merged snapshot's `:data` against the actor's resolved `[:schemas :data]` schema BEFORE the fx writes the patch into runtime-db. Returns `true` on conform / no schema / no validator (the fx proceeds with the write); `false` on failure (the fx SKIPS the write so the invalid `:data` never installs). The escape hatch is therefore not exempt from the `:where :machine-data` boundary.
+- **Description**: Sibling validator for the `:rf.machine/update-snapshot` escape-hatch fx. Validates the would-be-merged snapshot's `:data` against the actor's resolved `[:schemas :data]` schema BEFORE the fx writes the patch into runtime-db. Returns `true` on conform, no schema, or no validator; the fx proceeds with the write. Returns `false` on failure; the fx SKIPS the write so the invalid `:data` never installs. The escape hatch is therefore not exempt from the `:where :machine-data` boundary.
 
 ## Runtime and lifecycle helpers
 
@@ -551,8 +554,8 @@ The registration-time and `:data`-schema-boundary validators. The three `:data` 
   ```clojure
   (re-frame.machines/install-machine-runtime!)
   ```
-- **Description**: Re-registers the machine runtime effects + subs into BOTH the regular registrar AND the framework-standard registry (so an image-loaded frame resolves `[:rf.machine/spawn …]` / `[:rf/machine …]` through its sealed generation). Idempotent.
-    - Re-registers from descriptors captured at ns-load, so it works even after a `registrar/clear-all!` has wiped the registrar slots — the machine analogue of the `:rf/set-db` standard re-seed.
+- **Description**: Re-registers the machine runtime effects and subs into BOTH the regular registrar AND the framework-standard registry. An image-loaded frame can therefore resolve `[:rf.machine/spawn …]` / `[:rf/machine …]` through its sealed generation. Idempotent.
+    - Re-registers from descriptors captured at ns-load, so it works even after a `registrar/clear-all!` has wiped the registrar slots. It is the machine analogue of the `:rf/set-db` standard re-seed.
     - Called at ns load, from the `:machines/install-runtime!` late-bind hook the reset fixture fires, and directly by tests that wipe the registrar.
 
 ### `re-frame.machines/reset-timers!`
@@ -564,8 +567,8 @@ The registration-time and `:data`-schema-boundary validators. The three `:data` 
   (re-frame.machines/reset-timers! frame-id)
   ```
 - **Description**: Cancel in-flight `:after` timers.
-    - The 0-arity form clears every frame's timers — the fixture-teardown shape used by `re-frame.test-support`'s `reset-runtime` and per-feature artefact test fixtures.
-    - The 1-arity form clears just the given frame's timers — the `frame/destroy-frame!` hook shape that releases a destroyed frame's host-clock handles and subscription watchers without touching siblings.
+    - The 0-arity form clears every frame's timers. This is the fixture-teardown shape used by `re-frame.test-support`'s `reset-runtime` and per-feature artefact test fixtures.
+    - The 1-arity form clears just the given frame's timers. This is the `frame/destroy-frame!` hook shape: it releases a destroyed frame's host-clock handles and subscription watchers without touching siblings.
     - Spawn-id counters reset automatically with the registrar snapshot/restore + frame reset, so this hook handles only the frame-scoped wall-clock timer table.
 
 ### `re-frame.machines/owning-actor-id`
@@ -576,14 +579,14 @@ The registration-time and `:data`-schema-boundary validators. The three `:data` 
   (re-frame.machines/owning-actor-id frame-id event-id) → actor-id (or nil)
   ```
 - **Description**: Resolve the spawned-actor-id that OWNS `event-id` in `frame-id`, or `nil`.
-    - Returns `event-id` (a keyword — the spawned actor's machine address) when a SPAWNED actor's snapshot is currently installed at `[:rf.runtime/machines :snapshots <event-id>]`, otherwise `nil` (the event came from an ordinary handler or a singleton machine).
-    - Set semantics are snapshot membership via the durable `:rf/machine-type`-at-root discriminator — declarative `:spawn` / `:spawn-all` AND imperative `[:rf.machine/spawn …]` actors.
-    - Published as the `:machines/owning-actor-id` late-bind hook so the http artefact can ask "who owns this request's originating event?" (to abort managed HTTP on actor-destroy) without statically requiring this artefact; http falls back to `nil` when machines is absent.
+    - Returns `event-id` (a keyword — the spawned actor's machine address) when a SPAWNED actor's snapshot is currently installed at `[:rf.runtime/machines :snapshots <event-id>]`. Otherwise returns `nil`: the event came from an ordinary handler or a singleton machine.
+    - Set semantics are snapshot membership via the durable `:rf/machine-type`-at-root discriminator. This covers declarative `:spawn` / `:spawn-all` actors AND imperative `[:rf.machine/spawn …]` actors.
+    - Published as the `:machines/owning-actor-id` late-bind hook. The http artefact uses it to ask "who owns this request's originating event?" (to abort managed HTTP on actor-destroy) without statically requiring this artefact. http falls back to `nil` when machines is absent.
 
 ## See also
 
 - [re-frame.core.md](re-frame.core.md) — `reg-machine` / `defmachine` / `machine-has-tag?` are reached on the `re-frame.core` facade; `dispatch` / `subscribe` / `reg-event` drive and read a machine.
 - [re-frame.schemas.md](re-frame.schemas.md) — machines declare schemas for their `:data` slot the same way ordinary handlers do; the `validate-*-data!` validators gate them.
-- [Machines concept guide](../machines/concepts.md) — the narrative walkthrough: the transition table, guards, actions, tags, `:after`, final states, and when to reach for a machine. The v1 transition-table grammar covers a specific subset of Statechart capabilities — sequencing, `:after` timers, internal-vs-external transitions, guards, action lists, hierarchical states, parallel regions, and final-state semantics — the exact subset and its rationale are covered there.
+- [Machines concept guide](../machines/concepts.md) — the narrative walkthrough: the transition table, guards, actions, tags, `:after`, final states, and when to reach for a machine. The v1 transition-table grammar covers a specific subset of Statechart capabilities: sequencing, `:after` timers, internal-vs-external transitions, guards, action lists, hierarchical states, parallel regions, and final-state semantics. The guide covers the exact subset and its rationale.
 - [Machines glossary](../machines/glossary.md) — the surface vocabulary in one place.
 - [Coming from XState](../machines/coming-from-xstate.md) — the v6 parity delta for XState users.

--- a/docs/api/re-frame.performance.md
+++ b/docs/api/re-frame.performance.md
@@ -1,9 +1,9 @@
 # re-frame.performance
 
-`re-frame.performance` is re-frame2's production timing instrumentation surface, separate from the dev-only trace channel. It brackets four hot paths — event dispatch, subscription recompute, fx walk, and view render — in options-bag `performance.measure` calls that any `PerformanceObserver` (including an APM's) can read.
+`re-frame.performance` is re-frame2's production timing instrumentation surface. It is separate from the dev-only trace channel. It brackets four hot paths — event dispatch, subscription recompute, fx walk, and view render — in options-bag `performance.measure` calls. Any `PerformanceObserver` (including an APM's) can read them.
 
 - Emits User-Timing measure entries named `rf:event:*`, `rf:sub:*`, `rf:fx:*`, `rf:render:*`. No `performance.mark` entries are allocated.
-- Delivery is observer-first: each measure is cleared by name immediately after emit, so the buffer read by `performance.getEntriesByType("measure")` stays empty unless `retain-entries?` is on.
+- Delivery is observer-first. Each measure is cleared by name immediately after emit, so the buffer read by `performance.getEntriesByType("measure")` stays empty unless `retain-entries?` is on.
 - The whole surface is two compile-time flags, `enabled?` and `retain-entries?`, both **off by default**. Under `:advanced` with the defaults, Closure DCE elides every call site, so a shipped binary carries zero User-Timing instrumentation.
 - CLJS-only: the JVM is a no-op (the Performance API is browser-only).
 
@@ -11,7 +11,7 @@
 (:require [re-frame.performance :as perf])
 ```
 
-> **Note** — there is nothing to call from this namespace at runtime. You opt timing in by referencing the flags fully-qualified in your build's `:closure-defines` (see below); the `:as perf` alias is shown only for consistency with the other API docs.
+> **Note** — there is nothing to call from this namespace at runtime. You opt timing in by referencing the flags fully-qualified in your build's `:closure-defines` (see below). The `:as perf` alias is shown only for consistency with the other API docs.
 
 See [Find and fix a slow view](../core/how-to/fix-a-slow-view.md) for turning this channel on and reading the entries.
 
@@ -22,10 +22,10 @@ See [Find and fix a slow view](../core/how-to/fix-a-slow-view.md) for turning th
 - **Kind**: Var (`^boolean`)
 - **Signature**: `goog-define`d (CLJS) / `^:const false` (JVM). Set via `:closure-defines {re-frame.performance/enabled? true}`.
 - **Description**: Gates the four `performance.measure` brackets (event dispatch / sub recompute / fx walk / view render).
-    - Emits `performance.measure(name, {start, end})` with numeric `performance.now()` timestamps; User-Timing measure entries `rf:event:*`, `rf:sub:*`, `rf:fx:*`, `rf:render:*`. No `performance.mark` entries are allocated.
+    - Emits `performance.measure(name, {start, end})` with numeric `performance.now()` timestamps. The User-Timing measure entries are named `rf:event:*`, `rf:sub:*`, `rf:fx:*`, `rf:render:*`. No `performance.mark` entries are allocated.
     - Each measure is emitted inside a `try/finally`, so the entry lands even when the bracketed body throws (the exception still propagates).
     - The entry is cleared by name (`performance.clearMeasures`) immediately after emit unless `retain-entries?` is on. A live `PerformanceObserver` still receives it — observer callbacks fire at `measure()` time, before the clear.
-    - **Compile-time only** — not a `(rf/configure! ...)` knob; runtime mutation has no effect. Default `false`; under `:advanced` with the default, every bracket DCEs. CLJS-only; the JVM is a no-op.
+    - **Compile-time only** — not a `(rf/configure! ...)` knob; runtime mutation has no effect. Default `false`. Under `:advanced` with the default, every bracket DCEs. CLJS-only; the JVM is a no-op.
 
 ```clojure
 ;; shadow-cljs.edn — flip the compile-time gate. Default off:
@@ -40,7 +40,7 @@ See [Find and fix a slow view](../core/how-to/fix-a-slow-view.md) for turning th
 - **Signature**: `goog-define`d (CLJS) / `^:const false` (JVM). Set via `:closure-defines {re-frame.performance/retain-entries? true}`.
 - **Description**: Skips the per-emit `performance.clearMeasures(name)` so measure entries persist in the host's retained User-Timing buffer.
     - Enables one-shot `performance.getEntriesByType("measure")` readers (DevTools / console workflows).
-    - Default `false`: each entry is delivered to any live `PerformanceObserver` at `measure()` time, then cleared, so the buffer does not grow across a long-running (RUM) session — with the default, `getEntriesByType` returns no `rf:*` entries.
+    - Default `false`: each entry is delivered to any live `PerformanceObserver` at `measure()` time, then cleared. The buffer therefore does not grow across a long-running (RUM) session, and `getEntriesByType` returns no `rf:*` entries.
     - No effect unless `enabled?` is also on.
     - **Compile-time only** — not a `(rf/configure! ...)` knob; runtime mutation has no effect. CLJS-only; the JVM is a no-op.
 

--- a/docs/api/re-frame.resources.md
+++ b/docs/api/re-frame.resources.md
@@ -1,8 +1,13 @@
 # re-frame.resources
 
-A resource is a named, cached read of remote state. Views read server state passively through subscriptions; route entry, events, and machines *cause* it to fetch; the cache lives in the framework-owned runtime partition, not `app-db`. You register a resource once with a scope policy, a params schema, and a request; the runtime then owns identity, cache scope, staleness, dedupe, invalidation, GC, in-flight ownership, SSR hydration, and the metadata Xray reads.
+A resource is a named, cached read of remote state. Views read server state passively through subscriptions. Route entry, events, and machines *cause* it to fetch. The cache lives in the framework-owned runtime partition, not `app-db`. You register a resource once with a scope policy, a params schema, and a request. The runtime then owns the rest:
 
-Resources are an optional, post-v1 capability. They ship in `day8/re-frame2-resources` (`re-frame.resources`), require `day8/re-frame2-http` for the transport, and are wired by one `(:require [re-frame.resources])` at app boot. An app that omits the artefact sees the `reg-resource` wrapper throw `:rf.error/resources-artefact-missing`. This page covers the registration shape, the events, the subs, and introspection. The tutorial is [Guide ch.27 — Server-state and resources](../resources/concepts.md).
+- identity and cache scope
+- staleness, dedupe, and invalidation
+- GC and in-flight ownership
+- SSR hydration and the metadata Xray reads
+
+Resources are an optional, post-v1 capability. They ship in `day8/re-frame2-resources` (`re-frame.resources`) and require `day8/re-frame2-http` for the transport. One `(:require [re-frame.resources])` at app boot wires them in. An app that omits the artefact sees the `reg-resource` wrapper throw `:rf.error/resources-artefact-missing`. This page covers the registration shape, the events, the subs, and introspection. The tutorial is [Guide ch.27 — Server-state and resources](../resources/concepts.md).
 
 Scope in this slice is HTTP-only:
 
@@ -28,9 +33,9 @@ Scope in this slice is HTTP-only:
   (reg-resource resource-id metadata request-fn)
   ```
 - **Description**: Register a resource as data. Returns `resource-id`.
-  - `metadata` (middle slot): the registration-metadata map — the fail-closed `:scope` policy, `:params-schema`, `:doc`, and so on. A non-map `metadata` raises `:rf.error/resource-bad-spec`.
+  - `metadata` (middle slot): the registration-metadata map. It carries the fail-closed `:scope` policy, `:params-schema`, `:doc`, and so on. A non-map `metadata` raises `:rf.error/resource-bad-spec`.
   - `request-fn` (third slot): returns the [managed-HTTP args map](re-frame.http.md).
-  - Validates the reconstructed spec — `:scope` first, then `:params-schema` — then writes a `:resource`-kind registrar entry.
+  - Validates the reconstructed spec (`:scope` first, then `:params-schema`), then writes a `:resource`-kind registrar entry.
   - The introspection spec stored for `resource-meta` reconstructs `:request` onto the metadata map.
 
 #### The resource spec
@@ -61,14 +66,23 @@ Scope in this slice is HTTP-only:
 | Key | Notes |
 |---|---|
 | `:params-schema` | Validates and canonicalizes params (the resource's identity). |
-| `:scope` | The scope **policy** — `:rf.scope/global`, a resolver, or `:rf.scope/from-caller`. Fail-closed — no policy is a loud `:rf.error/resource-missing-scope-policy`. There is no implicit default; a user-scoped read must say so. |
-| request fn (3rd positional arg) | For `:transport :rf.http/managed`, returns a [managed-HTTP args map](re-frame.http.md). MUST NOT supply `:request-id` / `:on-success` / `:on-failure` — the runtime supplies those from the scoped key + generation (supplying one raises `:rf.error/resource-reserved-request-key`). |
+| `:scope` | The scope **policy**: `:rf.scope/global`, a resolver, or `:rf.scope/from-caller`. Fail-closed: omitting the policy raises a loud `:rf.error/resource-missing-scope-policy`. There is no implicit default; a user-scoped read must say so. |
+| request fn (3rd positional arg) | For `:transport :rf.http/managed`, returns a [managed-HTTP args map](re-frame.http.md). It MUST NOT supply `:request-id` / `:on-success` / `:on-failure` — the runtime supplies those from the scoped key + generation. Supplying one raises `:rf.error/resource-reserved-request-key`. |
 
-These three (`:params-schema`, `:scope`, request fn) are the registration gate — a `reg-resource` missing any of them throws. `:data-schema` is not part of the gate: it validates successful data when present, but the gate does not enforce it.
+These three (`:params-schema`, `:scope`, request fn) are the registration gate. A `reg-resource` missing any of them throws. `:data-schema` is not part of the gate: it validates successful data when present, but the gate does not enforce it.
 
-**Optional keys**: `:doc`, `:data-schema` (validates successful data when present / transport decode supports it — not enforced by the gate), `:transport` (initial scope: `:rf.http/managed`), `:stale-after-ms`, `:gc-after-ms`, `:poll-interval-ms` (the active-owner poll interval — see [Polling](#polling)), `:infinite` plus the infinite-only keys (`:next-page-param`, `:prev-page-param`, `:page->items`, `:initial-page-param`, `:page-data-schema`, `:refetch` — see [Infinite resources](#infinite-resources)), `:tags`, `:sensitive?` / `:large?` / schema-based classification.
+**Optional keys**:
 
-**Not in the v1 registration surface** (the gate neither reads nor validates them): `:revalidate`, `:placeholder`, `:cache-key`, `:select`, transport extension protocols. (Interval polling is `:poll-interval-ms`; the load-more kind is `:infinite` — see [Infinite resources](#infinite-resources).) The mutation-only keys (`:invalidates`, `:patches`, `:populates`, `:removes`, `:optimistic`, `:optimistic-tags`, `:on-conflict`) are not resource-registration keys — they live on `reg-mutation`.
+- `:doc`
+- `:data-schema` — validates successful data when present and the transport decode supports it. Not enforced by the gate.
+- `:transport` — initial scope: `:rf.http/managed`.
+- `:stale-after-ms`, `:gc-after-ms`
+- `:poll-interval-ms` — the active-owner poll interval. See [Polling](#polling).
+- `:infinite`, plus the infinite-only keys `:next-page-param`, `:prev-page-param`, `:page->items`, `:initial-page-param`, `:page-data-schema`, and `:refetch`. See [Infinite resources](#infinite-resources).
+- `:tags`
+- `:sensitive?` / `:large?` / schema-based classification
+
+**Not in the v1 registration surface**: `:revalidate`, `:placeholder`, `:cache-key`, `:select`, and transport extension protocols. The gate neither reads nor validates them. (Looking for interval polling? That is `:poll-interval-ms`. The load-more kind is `:infinite` — see [Infinite resources](#infinite-resources).) The mutation-only keys (`:invalidates`, `:patches`, `:populates`, `:removes`, `:optimistic`, `:optimistic-tags`, `:on-conflict`) are not resource-registration keys. They live on `reg-mutation`.
 
 #### Scope policy
 
@@ -76,9 +90,9 @@ These three (`:params-schema`, `:scope`, request fn) are the registration gate �
 
 | Policy | Meaning |
 |---|---|
-| `:rf.scope/global` | The resource is explicitly global — a claim that the same params produce the same data for every user/tenant/permission/locale/impersonation state. Auditable, not a convenience default. |
+| `:rf.scope/global` | The resource is explicitly global: the same params produce the same data for every user/tenant/permission/locale/impersonation state. This is an auditable claim, not a convenience default. |
 | `<resolver>` | Derive the scope. A route-resource resolver is `(fn [route ctx] …)`; a sub-resolvable resolver is a pure data value or a fn-of-nothing. A reusable named resolver is registered with [`reg-resource-scope`](#reg-resource-scope) and referenced as `{:from-db <scope-id>}`. |
-| `:rf.scope/from-caller` | Scope required from the use site — every ensure / refetch / state call must supply `:scope` (or a route resolver must); reaching the resource without one raises `:rf.error/resource-scope-required-from-caller`. |
+| `:rf.scope/from-caller` | The use site must supply the scope: every ensure / refetch / state call passes `:scope` (or a route resolver does). Reaching the resource without one raises `:rf.error/resource-scope-required-from-caller`. |
 
 There is no `[:rf.scope/global]` fallthrough.
 
@@ -96,14 +110,20 @@ See [Guide ch.27 §Scope](../resources/concepts.md).
   ```
 - **Description**: Remove a registered resource. Returns `resource-id`.
   - A **registration-lifecycle** operation, NOT cache invalidation. For data lifecycle use `:rf.resource/invalidate-tags` / `:rf.resource/remove` / `:rf.resource/clear-scope`.
-  - Also disposes the resource-runtime state for the id in each affected frame: releases owner indexes, cancels timers/host handles, aborts in-flight where possible, suppresses late replies by generation, removes tag-index rows, and emits a trace.
+  - Also disposes the resource-runtime state for the id in each affected frame. That disposal:
+    - releases owner indexes
+    - cancels timers and host handles
+    - aborts in-flight work where possible
+    - suppresses late replies by generation
+    - removes tag-index rows
+    - emits a trace
 
 ```clojure
 ;; deregister a resource (registration-lifecycle — e.g. on hot-reload / teardown)
 (rf/clear-resource :feed/timeline)
 ```
 
-A mutation is the causal-WRITE counterpart of a resource: a named write to remote state that, on success, invalidates / patches / populates cached resource reads. The write lowers through the same `:rf.http/managed` transport as resources, and the runtime owns reply addressing + stale-suppression (work-id + generation) exactly as for reads. Runtime state is keyed by mutation **instance** id, so concurrent submissions of the same mutation never clobber each other. See [Guide ch.27 §Mutations](../resources/concepts.md).
+A mutation is the causal-WRITE counterpart of a resource: a named write to remote state. On success it invalidates, patches, or populates cached resource reads. The write lowers through the same `:rf.http/managed` transport as resources. The runtime owns reply addressing and stale-suppression (work-id + generation) exactly as for reads. Runtime state is keyed by mutation **instance** id, so concurrent submissions of the same mutation never clobber each other. See [Guide ch.27 §Mutations](../resources/concepts.md).
 
 ### `reg-mutation`
 
@@ -113,7 +133,7 @@ A mutation is the causal-WRITE counterpart of a resource: a named write to remot
   (reg-mutation mutation-id metadata request-fn)
   ```
 - **Description**: Register a mutation as data under `mutation-id`. Returns `mutation-id`. The causal-write counterpart of `:resource`.
-  - `metadata` (middle slot): the registration-metadata map — `:params-schema`, `:invalidates`, `:patches`, `:doc`, and so on. A non-map `metadata` raises `:rf.error/mutation-bad-spec`.
+  - `metadata` (middle slot): the registration-metadata map. It carries `:params-schema`, `:invalidates`, `:patches`, `:doc`, and so on. A non-map `metadata` raises `:rf.error/mutation-bad-spec`.
   - `request-fn` (third slot): the [managed-HTTP write](re-frame.http.md).
   - Validates the reconstructed spec and writes a `:mutation`-kind registrar entry.
   - An app that omits the resources artefact sees the wrapper throw `:rf.error/resources-artefact-missing`.
@@ -145,24 +165,24 @@ A mutation is the causal-WRITE counterpart of a resource: a named write to remot
 | Key | Notes |
 |---|---|
 | `:params-schema` | Validates and canonicalizes the write's params. |
-| request fn (3rd positional arg) | Returns a [managed-HTTP args map](re-frame.http.md) (the write). MUST NOT supply `:request-id` / `:on-success` / `:on-failure` — the runtime supplies those from the instance + generation (supplying one raises `:rf.error/resource-reserved-request-key`). Write retries are **opt-in** and live in this returned args map's own `:retry` (see the note below) — never a `reg-mutation` spec key. |
+| request fn (3rd positional arg) | Returns a [managed-HTTP args map](re-frame.http.md) (the write). It MUST NOT supply `:request-id` / `:on-success` / `:on-failure` — the runtime supplies those from the instance + generation. Supplying one raises `:rf.error/resource-reserved-request-key`. Write retries are **opt-in** and live in the returned args map's own `:retry` (see the note below), never in a `reg-mutation` spec key. |
 
 **Optional keys**:
 
-- `:invalidates` — `(fn [params result] → #{tag …})`, the tags made stale on success, composed with `:rf.resource/invalidate-tags`, scoped.
-- `:patches` / `:populates` — controlled resource-entry transforms / seeds applied on success **before** invalidation, keyed by scoped key, via the same durable entry shape + structural sharing the read path uses.
-- `:removes` — `(fn [params result] → [target …])`, controlled resource-entry removals applied on success; same map-form exact targets `{:resource :params :scope}`; a removed key's in-flight attempt is best-effort aborted.
+- `:invalidates` — `(fn [params result] → #{tag …})`, the tags made stale on success. The runtime composes them with `:rf.resource/invalidate-tags`, scoped.
+- `:patches` / `:populates` — controlled resource-entry transforms / seeds applied on success, **before** invalidation. They are keyed by scoped key and use the same durable entry shape and structural sharing as the read path.
+- `:removes` — `(fn [params result] → [target …])`, controlled resource-entry removals applied on success. Targets use the same map-form exact shape `{:resource :params :scope}`. A removed key's in-flight attempt is best-effort aborted.
 - `:scope` — the cache scope the invalidation / patch / populate targets.
 - `:invalidate-timing` — `:after-success` (default) | `:before-request` | `:after-failure` | `:after-settle`. A value outside the closed enum is rejected with `:rf.error/mutation-bad-spec`.
 - `:transport`, `:doc`.
 
-> **`:retry` is NOT a `reg-mutation` spec key.** Write retries are opt-in and ride the [managed-HTTP args](re-frame.http.md) your `:request` fn returns — put `:retry {…}` in *that* map. The runtime passes the `:request` args through to the transport unchanged and does not read or enforce a spec-level `:retry`; there is no `reg-mutation`-level retry to arm. (Reads inherit the same discipline — see [Managed HTTP reference §Retry](../async/http.md#retry-transport-retry-as-data): re-issuing a non-idempotent write because a reply was merely slow is the double-write bug, so retry stays explicit and per-request.)
+> **`:retry` is NOT a `reg-mutation` spec key.** Write retries are opt-in. They ride the [managed-HTTP args](re-frame.http.md) your `:request` fn returns — put `:retry {…}` in *that* map. The runtime passes the `:request` args through to the transport unchanged. It does not read or enforce a spec-level `:retry`, so there is no `reg-mutation`-level retry to arm. Reads inherit the same discipline — see [Managed HTTP reference §Retry](../async/http.md#retry-transport-retry-as-data). Re-issuing a non-idempotent write because a reply was merely slow is the double-write bug, so retry stays explicit and per-request.
 
-> **Mutation `:scope` is not fail-closed.** Unlike a resource read — whose `:scope` is required and fails closed — a mutation's `:scope` is optional and resolves payload `:scope` → spec `:scope` → `:rf.scope/global`. The scope decides which cache scope the success-time invalidate / patch / populate targets, so it MUST match the scope of the resources the write changes: a write against user/tenant/locale-scoped entries that omits `:scope` invalidates the `[:rf.scope/global]` cache instead and silently misses the scoped entries (stale reads, no error). Pass `:scope` on `[:rf.mutation/execute …]` when the principal is known only at the call site; the `:rf.scope/from-caller` *policy* is a resource-read concept, not a mutation one.
+> **Mutation `:scope` is not fail-closed.** A resource read's `:scope` is required and fails closed. A mutation's `:scope` is optional: it resolves payload `:scope` → spec `:scope` → `:rf.scope/global`. The scope decides which cache scope the success-time invalidate / patch / populate targets, so it MUST match the scope of the resources the write changes. A write against user/tenant/locale-scoped entries that omits `:scope` invalidates the `[:rf.scope/global]` cache instead. It silently misses the scoped entries — stale reads, no error. Pass `:scope` on `[:rf.mutation/execute …]` when the principal is known only at the call site. The `:rf.scope/from-caller` *policy* is a resource-read concept, not a mutation one.
 
 **Optimistic keys** (see [EP-0019](../EP/EP-0019-optimistic-mutation-rollback.md) and [Guide ch.27 §Optimistic writes](../resources/concepts.md#optimistic-writes-commit-roll-back-or-reconcile)):
 
-- `:optimistic` — a registration-level forward plan (the twin of `:patches`, signature `(fn [params] → {target patch-fn})` — no `result`; the reply does not exist yet) applied **before** the server confirms.
+- `:optimistic` — a registration-level forward plan applied **before** the server confirms. It is the twin of `:patches`, with signature `(fn [params] → {target patch-fn})`. There is no `result` arg; the reply does not exist yet.
 - `:optimistic-tags` — its tag-addressed twin for cross-view consistency.
 - `:on-conflict` — `:invalidate` (default) | `:force`, the contested-rollback policy.
 
@@ -184,7 +204,17 @@ The inverse is runtime-recorded: the author supplies no `:rollback` registration
 
 ## Named scope resolvers
 
-A resource-scope resolver is the third resources kind (alongside resources and mutations): a registrar entry under the `:resource-scope` kind that derives a cache scope from declared `app-db` inputs. It is the one scope-resolution currency the same named resolver carries to resource registration, route resources, event-side `ensure`, subscriptions, invalidation descriptors, populate/patch/remove targets, and `clear-scope`. A resource (or payload, or route) references a named resolver as `{:from-db <scope-id>}`; the reference is resolved at **use time** against the frame's `app-db`. A `nil` resolution is **fail-closed** at every scope-requiring site — never an implicit global read.
+A resource-scope resolver is the third resources kind, alongside resources and mutations. It is a registrar entry under the `:resource-scope` kind that derives a cache scope from declared `app-db` inputs. It is also the one scope-resolution currency: the same named resolver works at every site that needs a scope —
+
+- resource registration
+- route resources
+- event-side `ensure`
+- subscriptions
+- invalidation descriptors
+- populate/patch/remove targets
+- `clear-scope`
+
+A resource (or payload, or route) references a named resolver as `{:from-db <scope-id>}`. The reference is resolved at **use time** against the frame's `app-db`. A `nil` resolution is **fail-closed** at every scope-requiring site — never an implicit global read.
 
 ### `reg-resource-scope`
 
@@ -194,10 +224,10 @@ A resource-scope resolver is the third resources kind (alongside resources and m
   (reg-resource-scope scope-id metadata resolve-fn)
   (reg-resource-scope scope-id resolve-fn)           ;; whole-db sugar (no metadata)
   ```
-- **Description**: Register a **pure** named scope resolver under `scope-id` in the canonical 3-slot grammar. Returns `scope-id`. Ships in `day8/re-frame2-resources`; require `re-frame.resources` at boot — an app that omits the artefact sees the wrapper throw `:rf.error/resources-artefact-missing`.
+- **Description**: Register a **pure** named scope resolver under `scope-id` in the canonical 3-slot grammar. Returns `scope-id`. Ships in `day8/re-frame2-resources`; require `re-frame.resources` at boot. An app that omits the artefact sees the wrapper throw `:rf.error/resources-artefact-missing`.
   - `resolve-fn` (value/third slot): the resolver. Its first arg is ALWAYS the resolved inputs map. It MUST be pure — it MUST NOT fetch, dispatch, mutate state, or read ambient host state. The `ctx` arg is reserved and invoked as literal `nil` in this slice. A `nil` resolve result is fail-closed.
-  - `metadata` (middle slot): carries the declared `:inputs {name [:db <rf-path>]}` plus optional `:doc`. The only shipped input source is `[:db <rf-path>]` (a concrete `:rf/path`); `[:runtime …]` (route-derived scope) is reserved and rejected with `:rf.error/resource-scope-source-reserved`.
-  - Whole-db form: omitting `:inputs` (the 2-arg sugar, or a `:doc`-only metadata) makes the resolver read the whole db as its first arg (the one deliberate, documented exception).
+  - `metadata` (middle slot): carries the declared `:inputs {name [:db <rf-path>]}` plus optional `:doc`. The only shipped input source is `[:db <rf-path>]` (a concrete `:rf/path`). `[:runtime …]` (route-derived scope) is reserved and rejected with `:rf.error/resource-scope-source-reserved`.
+  - Whole-db form: omit `:inputs` — either the 2-arg sugar, or a `:doc`-only metadata — and the resolver reads the whole db as its first arg. This is the one deliberate, documented exception.
   - A non-map metadata, a malformed `:inputs` descriptor, a `:resolve` left inside the metadata map, or a non-fn value slot is rejected with `:rf.error/invalid-resource-scope-spec`.
   - Writes a `:resource-scope`-kind registrar entry carrying the canonical spec plus captured source coords.
 
@@ -217,7 +247,7 @@ A resource-scope resolver is the third resources kind (alongside resources and m
   ```clojure
   (clear-resource-scope scope-id)
   ```
-- **Description**: Remove a registered resource-scope resolver — a **registration-lifecycle** removal (the `clear-` counterpart of `reg-resource-scope`). A resolver holds no per-frame runtime state (it is a pure derivation consulted at use time), so nothing is disposed beyond the registrar entry. A no-op that returns `scope-id` when the id is not registered.
+- **Description**: Remove a registered resource-scope resolver. This is a **registration-lifecycle** removal — the `clear-` counterpart of `reg-resource-scope`. A resolver holds no per-frame runtime state (it is a pure derivation consulted at use time), so nothing is disposed beyond the registrar entry. When the id is not registered, the call is a no-op that returns `scope-id`.
 
 ```clojure
 ;; deregister a named scope resolver (registration-lifecycle — e.g. on hot-reload / teardown)
@@ -232,10 +262,10 @@ A resource-scope resolver is the third resources kind (alongside resources and m
   (resolve-resource-scope db scope-id) → scope or nil
   ```
 - **Description**: Resolver **helper**: resolve the named resolver `scope-id` against the supplied `db` value, returning a canonical concrete scope or nil.
-  - A pure function over the resolver registry, NOT an effect: no app-state / dispatch side effects, and no observability side effect (it does NOT emit a `:rf.resource/scope-resolved` trace; the causal `{:from-db …}` / route-entry / mutation-settle boundaries carry that evidence).
+  - A pure function over the resolver registry, NOT an effect. It has no app-state or dispatch side effects, and no observability side effect: it does NOT emit a `:rf.resource/scope-resolved` trace. The causal `{:from-db …}` / route-entry / mutation-settle boundaries carry that evidence.
   - Throws `:rf.error/resource-scope-not-registered` when no resolver is registered under `scope-id` (a typo'd reference is never a silent nil).
-  - A resolver that returns nil for the supplied db yields nil (the fail-closed unresolved condition; the use site interprets it — never an implicit global).
-  - Canonical use is the logout / account-switch idiom: resolve the concrete old scope from the handler's coeffect `db` (pre-transition by definition — the causal input) and pass it concretely to `[:rf.resource/clear-scope …]`.
+  - A resolver that returns nil for the supplied db yields nil. That is the fail-closed unresolved condition; the use site interprets it — never as an implicit global.
+  - Canonical use is the logout / account-switch idiom: resolve the concrete old scope from the handler's coeffect `db` — pre-transition by definition, the causal input — and pass it concretely to `[:rf.resource/clear-scope …]`.
 
 ```clojure
 ;; the logout idiom: resolve the concrete OLD scope off the coeffect db,
@@ -277,7 +307,7 @@ A resource-scope resolver is the third resources kind (alongside resources and m
 
 ## Revalidation listeners
 
-Active-stale revalidation is expressed as **resource events** (see [`[:rf.resource/window-focused]` / `[:rf.resource/network-reconnected]`](#rfresourcewindow-focused--rfresourcenetwork-reconnected)), never subscription-driven fetching. On window focus / tab-return / network reconnect, the frame's active-owner **stale** entries are rescanned and refetched by policy — a stale entry with no active owner is left alone (revalidation creates no liveness). The host-listener install/remove fns below wire and tear down the `window` listeners that dispatch those events.
+Active-stale revalidation is expressed as **resource events** (see [`[:rf.resource/window-focused]` / `[:rf.resource/network-reconnected]`](#rfresourcewindow-focused--rfresourcenetwork-reconnected)) — never subscription-driven fetching. On window focus, tab-return, or network reconnect, the runtime rescans the frame's active-owner **stale** entries and refetches them by policy. A stale entry with no active owner is left alone: revalidation creates no liveness. The host-listener install/remove fns below wire and tear down the `window` listeners that dispatch those events.
 
 ### `install-revalidation-listeners!` / `remove-revalidation-listeners!`
 
@@ -291,7 +321,7 @@ Active-stale revalidation is expressed as **resource events** (see [`[:rf.resour
   - `focus` (on `window`) and `visibilitychange`-to-visible (on `document`, its only valid event target) → `[:rf.resource/window-focused]`.
   - `online` (on `window`) → `[:rf.resource/network-reconnected]`.
 
-  Idempotent (re-installing replaces, never stacks — hot-reload safe); CLJS-only (the JVM/SSR arm is a no-op). Listeners are recorded in a host side table and cancelled on frame destroy via the single `:resources/on-frame-destroyed!` hook. `remove-revalidation-listeners!` tears them down (useful for test isolation and single-page hosts that rotate which frame owns revalidation); a no-op when none is installed.
+  Installation is idempotent: re-installing replaces, never stacks, so it is hot-reload safe. It is CLJS-only; the JVM/SSR arm is a no-op. Listeners are recorded in a host side table and cancelled on frame destroy via the single `:resources/on-frame-destroyed!` hook. `remove-revalidation-listeners!` tears them down — useful for test isolation, and for single-page hosts that rotate which frame owns revalidation. It is a no-op when none is installed.
 
 ```clojure
 ;; at boot, after the frame is live: wire focus / visibility / online revalidation
@@ -303,7 +333,7 @@ Active-stale revalidation is expressed as **resource events** (see [`[:rf.resour
 
 ## Polling
 
-A resource may declare an optional `:poll-interval-ms` policy: while an entry has at least one **active owner** and the document is **visible**, the runtime re-runs its load every N ms, with no component-side fetch call. Polling is owner-driven — it tracks the active-owner lease, not a component observer — so a route / machine / app-minted lease keeps it alive and polling stops the instant the last owner releases.
+A resource may declare an optional `:poll-interval-ms` policy. While an entry has at least one **active owner** and the document is **visible**, the runtime re-runs its load every N ms — no component-side fetch call needed. Polling is owner-driven: it tracks the active-owner lease, not a component observer. A route, machine, or app-minted lease keeps it alive, and polling stops the instant the last owner releases.
 
 ```clojure
 (rf/reg-resource :notifications/unread-count
@@ -323,11 +353,11 @@ Semantics (per [Guide ch.27 §Polling](../resources/concepts.md#polling-keep-thi
 - **Coalescing.** A tick that finds a live in-flight refetch skips (no overlap on a slow endpoint); focus + poll never double-fetch.
 - **Background-failure resilient.** A failed poll keeps prior `:data` + records `:refresh-error`, and the next poll still fires.
 
-A "just polling" view with no natural route/machine owner needs an app-minted `[:lease …]` owner (with a matching `[:rf.resource/release-owner {…}]`) to keep the poll alive — an owner-free entry never polls.
+A "just polling" view with no natural route/machine owner needs an app-minted `[:lease …]` owner to keep the poll alive, with a matching `[:rf.resource/release-owner {…}]`. An owner-free entry never polls.
 
 ## Infinite resources
 
-An infinite resource is the load-more / infinite-scroll feed kind (see [EP-0021](../EP/EP-0021-infinite-resources.md); tutorial in [Guide ch.27 §Infinite feeds](../resources/concepts.md#infinite-feeds-accumulate-pages-with-infinite)). It is a resource registered with `:infinite true` plus a pure `:next-page-param`; the user accumulates pages (1, then 1+2, then 1+2+3) rendered as one growing list, with the *next* page param derived from the last page's data. Numbered / cursor pagination (`:keep-previous?` + per-page entries) is untouched and orthogonal — an app picks per feed.
+An infinite resource is the load-more / infinite-scroll feed kind (see [EP-0021](../EP/EP-0021-infinite-resources.md); the tutorial is [Guide ch.27 §Infinite feeds](../resources/concepts.md#infinite-feeds-accumulate-pages-with-infinite)). It is a resource registered with `:infinite true` plus a pure `:next-page-param`. The user accumulates pages — 1, then 1+2, then 1+2+3 — rendered as one growing list. The *next* page param is derived from the last page's data. Numbered / cursor pagination (`:keep-previous?` + per-page entries) is untouched and orthogonal; an app picks per feed.
 
 ```clojure
 (rf/reg-resource :feed/timeline
@@ -350,10 +380,14 @@ An infinite resource is the load-more / infinite-scroll feed kind (see [EP-0021]
 
 Key semantics:
 
-- **`:infinite true` makes `:next-page-param` required** (a loud `:rf.error/infinite-missing-next-page-param` otherwise). It is pure `(last-page all-pages) → next-param-or-nil`; returning `nil` is the single canonical terminal, exposed as the derived `:has-next-page?`.
-- **One scoped entry per feed.** Pages accumulate as an ordered vector inside the one `:rf.runtime/resources` entry — not N per-page entries, not an app-db slice — so the feed has one owner set / freshness clock / GC clock / SSR-restore unit / Xray row. The per-page param is internal sequencing state, never part of the cache key; changing the identity params yields a different feed instance.
+- **`:infinite true` makes `:next-page-param` required.** Omitting it raises a loud `:rf.error/infinite-missing-next-page-param`. The fn is pure: `(last-page all-pages) → next-param-or-nil`. Returning `nil` is the single canonical terminal, exposed as the derived `:has-next-page?`.
+- **One scoped entry per feed.** Pages accumulate as an ordered vector inside the one `:rf.runtime/resources` entry — not N per-page entries, and not an app-db slice. The feed therefore has one owner set, one freshness clock, one GC clock, one SSR-restore unit, and one Xray row. The per-page param is internal sequencing state, never part of the cache key. Changing the identity params yields a different feed instance.
 - **`:page-data-schema` validates one page** and is the per-page egress/classification contract (applied per page on SSR/tool projection); `:data-schema` is not used for the accumulated vector.
-- **Other infinite-only keys**: `:prev-page-param` (the bidirectional derivation mirror — defined, but the `load-prev` prepend event is deferred; v1 ships next-direction load-more only), `:initial-page-param` (the first-page param, default `nil`), `:page->items` (required for non-vector pages), and `:refetch` (`{:refetch-all-pages? false}` by default — the conservative window-preserving refetch policy, with `:refetch-all-pages?` / `:refetch-window` opt-ins).
+- **Other infinite-only keys**:
+    - `:prev-page-param` — the bidirectional derivation mirror. Defined, but the `load-prev` prepend event is deferred; v1 ships next-direction load-more only.
+    - `:initial-page-param` — the first-page param. Default `nil`.
+    - `:page->items` — required for non-vector pages.
+    - `:refetch` — `{:refetch-all-pages? false}` by default, the conservative window-preserving refetch policy. `:refetch-all-pages?` / `:refetch-window` are the opt-ins.
 
 A view reads the merged list and dispatches the causal `[:rf.resource/load-more {…}]`:
 
@@ -366,7 +400,7 @@ A view reads the merged list and dispatches the causal `[:rf.resource/load-more 
 [:rf.resource/infinite-state {…}]   ;; combined view-model (the feed analogue of :rf/resource)
 ```
 
-`:rf.resource/items`, `:rf.resource/pages`, and `:rf.resource/infinite-state` are framework-owned memoised subscriptions; `:rf.resource/ensure` (and a route entry) loads **page 0 only**, and a mutation touching an item inside a feed **invalidates the whole feed** (coarse, correct; in-place item patching inside a feed's page vector is a distinct deferred axis — not the single-entry optimistic surface — homed at [spec/016 §Refetch and invalidation of an infinite feed](../../spec/016-Resources.md#refetch-and-invalidation-of-an-infinite-feed)).
+`:rf.resource/items`, `:rf.resource/pages`, and `:rf.resource/infinite-state` are framework-owned memoised subscriptions. `:rf.resource/ensure` (and a route entry) loads **page 0 only**. A mutation touching an item inside a feed **invalidates the whole feed** — coarse, but correct. In-place item patching inside a feed's page vector is a distinct deferred axis (not the single-entry optimistic surface), homed at [spec/016 §Refetch and invalidation of an infinite feed](../../spec/016-Resources.md#refetch-and-invalidation-of-an-infinite-feed).
 
 ## Introspection and projection (tool/test lane)
 
@@ -375,9 +409,9 @@ These direct functions are the tool/test projection lane, not an app-read API:
 - `resource-meta` / `mutation-meta` project the **registration** (the registered spec).
 - `resource-state` / `resources` / `mutation-state` / `mutations` project **runtime state** (the live entries) as a one-shot, non-reactive snapshot at an explicit frame.
 
-They serve Xray, unit tests, and SSR serialization — contexts with no reactive subscription. App views read runtime state through the passive [`:rf.resource/*` / `:rf.mutation/*` subscriptions](#resource-subscriptions-passive), never through these functions, which do not re-render on change. Registering a handler, dispatching a cause, projecting a snapshot, and subscribing are four distinct jobs; see [Guide ch.27 §Three lanes](../resources/concepts.md#three-lanes--registering-causing-projecting).
+They serve Xray, unit tests, and SSR serialization — contexts with no reactive subscription. App views read runtime state through the passive [`:rf.resource/*` / `:rf.mutation/*` subscriptions](#resource-subscriptions-passive), never through these functions — they do not re-render on change. Registering a handler, dispatching a cause, projecting a snapshot, and subscribing are four distinct jobs; see [Guide ch.27 §Three lanes](../resources/concepts.md#three-lanes--registering-causing-projecting).
 
-`:frame` is an explicit, app-registered frame id ([EP-0002](../EP/EP-0002-frame-target-resolution.md) — no ambient `:rf/default` fallback; a frameless call with no resolvable context fails closed).
+`:frame` is an explicit, app-registered frame id ([EP-0002](../EP/EP-0002-frame-target-resolution.md)). There is no ambient `:rf/default` fallback; a frameless call with no resolvable context fails closed.
 
 ### `resource-meta`
 
@@ -401,9 +435,9 @@ They serve Xray, unit tests, and SSR serialization — contexts with no reactive
   ```clojure
   (resource-state {:resource … :scope … :params … :frame …}) → entry or nil
   ```
-- **Description**: A resource instance's durable runtime entry for an explicit-frame target, resolving the scoped key the same way a subscription does (a `{:from-db <id>}` scope resolves against the frame's app-db).
+- **Description**: A resource instance's durable runtime entry for an explicit-frame target. The scoped key resolves the same way a subscription's does: a `{:from-db <id>}` scope resolves against the frame's app-db.
   - nil when no entry exists.
-  - An absent / nil `:frame` raises `:rf.error/no-frame-context` (fail-closed — a nil pass-through would be indistinguishable from a genuinely absent entry).
+  - An absent / nil `:frame` raises `:rf.error/no-frame-context`. This is fail-closed: a nil pass-through would be indistinguishable from a genuinely absent entry.
   - An explicit but unknown / destroyed `:frame` reads as nil.
 
 ```clojure
@@ -424,7 +458,7 @@ They serve Xray, unit tests, and SSR serialization — contexts with no reactive
   (resources {:frame …}) → {:resource-ids [...] :entries {<key-id> <entry>}}
   ```
 - **Description**: Resource introspection for a frame target — the static registry (every registered id) plus, with `:frame`, the live per-frame resource-instance entries.
-  - The `:entries` map is keyed on the CEDN-1 byte `key-id` string (the same key the runtime storage / SSR wire use; it cannot collapse CEDN-distinct sequential-params entries the way an `=`-keyed scoped-key vector would).
+  - The `:entries` map is keyed on the CEDN-1 byte `key-id` string — the same key the runtime storage and SSR wire use. Unlike an `=`-keyed scoped-key vector, it cannot collapse CEDN-distinct sequential-params entries.
   - Each entry carries its kind-preserving scoped-resource-key `[scope resource-id params]` under `:resource/key` for destructure / scope-and-resource filtering.
 
 ```clojure
@@ -509,7 +543,14 @@ They serve Xray, unit tests, and SSR serialization — contexts with no reactive
 ;; => [:article/save]
 ```
 
-Xray exposes the same shapes plus the tool accessors (`list-resources`, `list-resource-instances`, `get-resource-state`, `get-resource-history`, `list-resource-invalidations`), the route/resource graph, the work-ledger table, and the scope audit surface (the standing enumeration of every `:rf.scope/global` resource). Tool accessors prefer summaries over raw values; params/scopes get the same privacy/size elision as data.
+Xray exposes the same shapes, plus:
+
+- the tool accessors — `list-resources`, `list-resource-instances`, `get-resource-state`, `get-resource-history`, `list-resource-invalidations`
+- the route/resource graph
+- the work-ledger table
+- the scope audit surface — the standing enumeration of every `:rf.scope/global` resource
+
+Tool accessors prefer summaries over raw values. Params and scopes get the same privacy/size elision as data.
 
 ## Keyword surfaces
 
@@ -529,9 +570,9 @@ Resource events take a **map payload**, not a positional argument vector. The re
 - **Payload**: `{:resource :scope :params :owner :cause :keep-previous?}`
 - **Description**: Ensure the resource instance is loaded.
   - `ensure` while the same scoped key is already in flight **joins** the existing work (attaches the owner, records the cause, emits a dedupe trace).
-  - `ensure` of an already-`:loaded` entry still fresh-by-policy is a fresh-skip: serves the cached value, attaches the owner, emits `:rf.resource/cache-hit`, no fetch.
+  - `ensure` of an already-`:loaded` entry still fresh-by-policy is a fresh-skip: it serves the cached value, attaches the owner, and emits `:rf.resource/cache-hit` — no fetch.
   - `:owner` changes the active-owner set; `:cause` is recorded in trace/history.
-  - `:keep-previous?` on a first-loading key records a projection pointer to the prior loaded sibling key so `:rf.resource/previous-data` can show old data while the new key loads (never inserted into the new entry).
+  - `:keep-previous?` on a first-loading key records a projection pointer to the prior loaded sibling key. That lets `:rf.resource/previous-data` show old data while the new key loads. The pointer is never inserted into the new entry.
 
 ```clojure
 [:rf.resource/ensure
@@ -546,7 +587,7 @@ Resource events take a **map payload**, not a positional argument vector. The re
 
 - **Kind**: event
 - **Payload**: `{:resource :scope :params :owner :cause}`
-- **Description**: Force a refresh. Always starts a new generation (even when a request is already in flight) — a still-in-flight prior request is marked superseded, aborted when possible, otherwise suppressed by work-id + generation. A manual refresh is usually a `:cause`, not an `:owner`.
+- **Description**: Force a refresh. It always starts a new generation, even when a request is already in flight. A still-in-flight prior request is marked superseded, then aborted when possible, otherwise suppressed by work-id + generation. A manual refresh is usually a `:cause`, not an `:owner`.
 
 ```clojure
 ;; a "Refresh" button — a :cause, pointedly no :owner (the route keeps it alive)
@@ -560,9 +601,9 @@ Resource events take a **map payload**, not a positional argument vector. The re
 
 - **Kind**: event
 - **Payload**: `{:scope :tags :cause :cross-scope?}`
-- **Description**: Mark entries whose tags intersect `:tags` stale; refetch entries with active owners; leave inactive entries stale or GC-eligible.
+- **Description**: Mark every entry whose tags intersect `:tags` as stale. Entries with active owners are refetched. Inactive entries stay stale or become GC-eligible.
   - **Scoped by default** — a scoped invalidation with no `:scope` raises `:rf.error/resource-invalidate-scope-required` (never a silent nil-scope match).
-  - A cross-scope invalidation opts in explicitly with `:cross-scope? true` (ignores the scope filter, visible in Xray) and MUST carry `:cause` — omitting one raises `:rf.error/resource-cross-scope-cause-required`.
+  - A cross-scope invalidation opts in explicitly with `:cross-scope? true`. It ignores the scope filter, is visible in Xray, and MUST carry `:cause` — omitting one raises `:rf.error/resource-cross-scope-cause-required`.
   - On a successful load an entry's tags are *replaced* with the new data's tags.
 
 ```clojure
@@ -589,7 +630,14 @@ Resource events take a **map payload**, not a positional argument vector. The re
 
 - **Kind**: event
 - **Payload**: `{:scope :cause}`
-- **Description**: Causal scope teardown. Removes/marks-unusable every entry in the scope, releases owners, aborts in-flight requests with no owner outside the scope, suppresses late replies by scope + generation, emits explanatory trace rows. Required on logout / account / tenant / permission / locale / impersonation change.
+- **Description**: Causal scope teardown. It:
+  - removes (or marks unusable) every entry in the scope
+  - releases owners
+  - aborts in-flight requests with no owner outside the scope
+  - suppresses late replies by scope + generation
+  - emits explanatory trace rows
+
+  Required on logout / account / tenant / permission / locale / impersonation change.
 
 ```clojure
 ;; logout / tenant-switch — drop a whole scope's cache so the next principal
@@ -617,7 +665,7 @@ Resource events take a **map payload**, not a positional argument vector. The re
 
 - **Kind**: event (infinite resources only — see [Infinite resources](#infinite-resources))
 - **Payload**: `{:resource :scope :params :cause}` — **ownerless** (carries a `:cause`, never an `:owner`)
-- **Description**: Extend an `:infinite` feed by one page. Computes the next page param from the entry's tail via `:next-page-param`, fetches that page through the same managed transport, and appends it to the feed's accumulated page vector (the feed stays `:loaded`; the pages stay visible — a load-more in flight is the derived `:fetching-next?` sub, distinct from a whole-feed `:fetching?` refresh).
+- **Description**: Extend an `:infinite` feed by one page. The runtime computes the next page param from the entry's tail via `:next-page-param`, fetches that page through the same managed transport, and appends it to the feed's accumulated page vector. The feed stays `:loaded` and the pages stay visible. A load-more in flight shows as the derived `:fetching-next?` sub, distinct from a whole-feed `:fetching?` refresh.
   - A load-more with no next page (`:next-page-param` → `nil`) is a no-op trace.
   - A load-more while a page fetch is already in flight dedupes.
   - A supplied `:owner` is warn-and-ignored — the route (or whatever first-loaded the feed) already owns the one feed entry, and load-more never changes the active-owner set.
@@ -634,7 +682,7 @@ Resource events take a **map payload**, not a positional argument vector. The re
 #### `[:rf.resource/window-focused]` / `[:rf.resource/network-reconnected]`
 
 - **Kind**: event (no payload)
-- **Description**: Scan the frame's active-owner stale entries and refetch them by policy. The refetch carries cause `:focus` (window-focused) or `:reconnect` (network-reconnected) — never an owner (it creates no liveness); generation + stale-suppression protect any late reply. The host listeners ([Revalidation listeners](#revalidation-listeners)) dispatch these; user code MUST NOT dispatch them directly.
+- **Description**: Scan the frame's active-owner stale entries and refetch them by policy. The refetch carries cause `:focus` (window-focused) or `:reconnect` (network-reconnected). It never carries an owner — it creates no liveness. Generation + stale-suppression protect any late reply. The host listeners ([Revalidation listeners](#revalidation-listeners)) dispatch these; user code MUST NOT dispatch them directly.
 
 ```clojure
 ;; no payload — dispatched by the host listeners (see Revalidation listeners);
@@ -643,7 +691,7 @@ Resource events take a **map payload**, not a positional argument vector. The re
 [:rf.resource/network-reconnected]
 ```
 
-> **Internal replies — do not dispatch.** `:rf.resource.internal/succeeded` / `…/failed` / `…/page-succeeded` / `…/page-failed` / `…/aborted` / `…/stale-fired` / `…/gc-fired` / `…/poll-fired` / `…/stale-suppressed` / `…/refetch-page` are framework-internal and carry the verification payload (`:work/id`, `:resource/key`, `:scope`, `:generation`, `:rf.frame/id`). User code MUST NOT dispatch them; success/failure verify frame + work id + generation before writing (the mandatory stale-suppression boundary). (`:rf.resource.internal/stale-fired` is the stale-timer re-check tick — it arms the stale transition, not a fetch; `:rf.resource.internal/poll-fired` is the poll-timer re-check tick — it refetches an active-owner entry by the interval; `…/page-succeeded` / `…/page-failed` are the infinite-feed page replies; `…/refetch-page` is one leg of a multi-page refetch sweep.)
+> **Internal replies — do not dispatch.** `:rf.resource.internal/succeeded` / `…/failed` / `…/page-succeeded` / `…/page-failed` / `…/aborted` / `…/stale-fired` / `…/gc-fired` / `…/poll-fired` / `…/stale-suppressed` / `…/refetch-page` are framework-internal. They carry the verification payload (`:work/id`, `:resource/key`, `:scope`, `:generation`, `:rf.frame/id`). User code MUST NOT dispatch them. Success/failure verify frame + work id + generation before writing — the mandatory stale-suppression boundary. Of these: `:rf.resource.internal/stale-fired` is the stale-timer re-check tick (it arms the stale transition, not a fetch); `:rf.resource.internal/poll-fired` is the poll-timer re-check tick (it refetches an active-owner entry by the interval); `…/page-succeeded` / `…/page-failed` are the infinite-feed page replies; `…/refetch-page` is one leg of a multi-page refetch sweep.
 
 ### Resource subscriptions (passive)
 
@@ -682,7 +730,7 @@ Status invariants:
 
 `:stale?` / `:loading?` / `:fetching?` / `:has-data?` are derived sub values, never stored. See [Guide ch.27 §Status](../resources/concepts.md).
 
-> **Lifecycle trace ops (observability, not events you dispatch).** The runtime emits `:rf.resource/cache-hit` when a fresh `ensure` is served from cache with no fetch (a fresh-skip: an already-`:loaded` entry still fresh-by-policy serves the cached value, attaches the owner lease, and — for a blocking route resource — drains the blocking slot immediately, with no `:fetching` transition), and `:rf.resource/stale-fired` when a stale timer ticks (arming the stale transition, not a fetch). These are trace surfaces Xray reads — they are not `:status` values and not events user code dispatches.
+> **Lifecycle trace ops (observability, not events you dispatch).** The runtime emits two trace ops here. `:rf.resource/cache-hit` fires when a fresh `ensure` is served from cache with no fetch — a fresh-skip. The already-`:loaded` entry, still fresh-by-policy, serves the cached value and attaches the owner lease; for a blocking route resource it also drains the blocking slot immediately, with no `:fetching` transition. `:rf.resource/stale-fired` fires when a stale timer ticks — it arms the stale transition, not a fetch. These are trace surfaces Xray reads. They are not `:status` values, and user code never dispatches them.
 
 ### Mutation events (map payloads)
 
@@ -711,7 +759,7 @@ Status invariants:
 
 - **Kind**: event
 - **Payload**: `{:instance …}` (clear one instance) or `{:mutation …}` (clear every instance of a mutation id)
-- **Description**: The **causal** reset of runtime mutation-instance state — clears the addressed row(s) and best-effort aborts in-flight work (the work row settles `:cancelled`). Distinct from `clear-mutation` (which removes the *registration*).
+- **Description**: The **causal** reset of runtime mutation-instance state. It clears the addressed row(s) and best-effort aborts in-flight work; the work row settles `:cancelled`. Distinct from `clear-mutation`, which removes the *registration*.
 
 ```clojure
 ;; reset one runtime instance's row (e.g. in a completion continuation)
@@ -731,15 +779,15 @@ A `:rf.mutation/*` subscription is a pure passive read keyed by **instance** id 
 [:rf.mutation/error    {:instance :form/save-1}]
 ```
 
-`:optimistic?` (derived) is true while a live optimistic apply is showing (applied, not yet settled); `:affected-keys` carries the scoped resource keys the settle touched.
+`:optimistic?` (derived) is true while a live optimistic apply is showing — applied, not yet settled. `:affected-keys` carries the scoped resource keys the settle touched.
 
 A failure settles `:error` — there is no `:refresh-error` analogue (a write has no last-known-good to keep).
 
-> **Internal replies — do not dispatch.** The `:rf.mutation.internal/*` replies (`succeeded` / `failed`), and the `:rf.mutation/*` trace family — `started` / `succeeded` / `failed` / `cleared` / `replied` / `stale-suppressed` plus the optimistic rows (`optimistic-applied` / `optimistic-reconciled` / `optimistic-rolled-back`), carrying the instance id — are framework-internal; user code MUST NOT dispatch them.
+> **Internal replies — do not dispatch.** Two keyword families here are framework-internal, and user code MUST NOT dispatch them: the `:rf.mutation.internal/*` replies (`succeeded` / `failed`), and the `:rf.mutation/*` trace family — `started` / `succeeded` / `failed` / `cleared` / `replied` / `stale-suppressed`, plus the optimistic rows (`optimistic-applied` / `optimistic-reconciled` / `optimistic-rolled-back`). All carry the instance id.
 
 ## Reading resource and mutation state
 
-Resource and mutation state are read with the ordinary `subscribe` naming their framework sub vector — there is no named-read-sugar fn (a runtime-db framework read is a subscription vector, one grammar). `subscribe`'s `{:frame <target>}` opts form reads from an explicit frame. A sub never fetches.
+Read resource and mutation state with the ordinary `subscribe`, naming the framework sub vector. There is no named-read-sugar fn: a runtime-db framework read is a subscription vector, one grammar. `subscribe`'s `{:frame <target>}` opts form reads from an explicit frame. A sub never fetches.
 
 ```clojure
 ;; a view reads a resource passively — never fetches
@@ -759,9 +807,15 @@ Idle empty-state until the instance's first `:rf.mutation/execute`.
 
 ## Cache home
 
-Resource cache lives **only** at `:rf.runtime/resources` inside the runtime-db partition (`:rf.db/runtime`); the frame work ledger at `:rf.runtime/work-ledger`; mutation instance rows at `:rf.runtime/mutations`. All three are reserved runtime-db keys, framework-owned, per-frame isolated, allocated lazily. App code reads through the subs and accessors and never hand-edits the slice.
+Resource and mutation runtime state lives inside the runtime-db partition (`:rf.db/runtime`):
 
-Cache *entries* (durable facts) and work-ledger *attempts* (in-flight records) are separate; host handles (AbortControllers, timers, promises) live in side tables and are never serialized. The correctness rule: cancellation is opportunistic; stale-reply suppression (by work-id + generation) is **mandatory**. See [Guide ch.27 §Cache home and the work ledger](../resources/concepts.md).
+- the resource cache, **only** at `:rf.runtime/resources`
+- the frame work ledger, at `:rf.runtime/work-ledger`
+- mutation instance rows, at `:rf.runtime/mutations`
+
+All three are reserved runtime-db keys: framework-owned, per-frame isolated, and allocated lazily. App code reads through the subs and accessors and never hand-edits the slice.
+
+Cache *entries* (durable facts) and work-ledger *attempts* (in-flight records) are separate. Host handles (AbortControllers, timers, promises) live in side tables and are never serialized. The correctness rule: cancellation is opportunistic; stale-reply suppression (by work-id + generation) is **mandatory**. See [Guide ch.27 §Cache home and the work ledger](../resources/concepts.md).
 
 ## Examples and cross-references
 

--- a/docs/api/re-frame.routing.md
+++ b/docs/api/re-frame.routing.md
@@ -1,14 +1,23 @@
 # re-frame.routing
 
-Routes are data. A route is registered with a path and a metadata map (`:params`, `:query`, `:on-match`, `:on-error`, `:can-leave`, …), and URL changes become events. The current route lives in the frame's runtime-db at `[:rf.runtime/routing :current]`, read via the `:rf/route` sub; navigation is dispatching an event.
+Routes are data. You register a route with a path and a metadata map (`:params`, `:query`, `:on-match`, `:on-error`, `:can-leave`, …). URL changes become events. The current route lives in the frame's runtime-db at `[:rf.runtime/routing :current]` and is read via the `:rf/route` sub. Navigation is dispatching an event.
 
-This namespace is the public boot point and façade for the routing artefact. Requiring it wires every routing event, fx, cofx, and sub. The `reg-route` macro is published on the `re-frame.core` facade; the rest of the surface — URL helpers, registry introspection, scroll restoration, URL strategies, the browser URL-listener boot seam, and the multi-frame URL-ownership resolver — lives here. For motivation and narrative, see the [Routing guide](../routing/index.md).
+This namespace is the public boot point and façade for the routing artefact. Requiring it wires every routing event, fx, cofx, and sub. The `reg-route` macro is published on the `re-frame.core` facade. The rest of the surface lives here:
+
+- URL helpers
+- registry introspection
+- scroll restoration
+- URL strategies
+- the browser URL-listener boot seam
+- the multi-frame URL-ownership resolver
+
+For motivation and narrative, see the [Routing guide](../routing/index.md).
 
 ```clojure
 (:require [re-frame.routing :as routing])
 ```
 
-Throughout, `rf` denotes the `re-frame.core` facade alias (`[re-frame.core :as rf]`), where the `reg-route` macro and the `route-link` view live.
+Throughout, `rf` is the `re-frame.core` facade alias (`[re-frame.core :as rf]`). The `reg-route` macro and the `route-link` view live on that facade.
 
 ## Route registration
 
@@ -25,7 +34,13 @@ Throughout, `rf` denotes the `re-frame.core` facade alias (`[re-frame.core :as r
   - `metadata` — map of match events and guards (keys below).
   - `path` — the URL shape; colon-prefixed segments capture into `:params`.
 
-  Throws `:rf.error/route-bad-metadata` when `metadata` is not a map, carries `:path` (the pattern belongs in the third slot), or carries a bare (unqualified) key outside the reserved set below. Namespaced keys (`:myapp/analytics-id`) always pass. Emits `:rf.warning/route-shadowed-by-equal-score` when an already-registered route has an equal structural rank, and `:rf.route/registered` on first-time registration.
+  Throws `:rf.error/route-bad-metadata` when `metadata`:
+
+  - is not a map,
+  - carries `:path` (the path pattern belongs in the third slot), or
+  - carries a bare (unqualified) key outside the reserved set below. Namespaced keys (`:myapp/analytics-id`) always pass.
+
+  Emits `:rf.warning/route-shadowed-by-equal-score` when an already-registered route has an equal structural rank. Emits `:rf.route/registered` on first-time registration.
 
 #### A minimal route
 
@@ -46,20 +61,20 @@ Colon-prefixed path segments capture into `:params`. `:on-match` is the event ve
 | `:query` | Schemas for query-string keys. |
 | `:query-defaults` | Default values for query keys absent from the URL. |
 | `:query-retain` | Keys to preserve across navigations to other routes. |
-| `:tags` | Free-form classification — `#{:auth-required :admin-only :public}`. |
+| `:tags` | Free-form classification, e.g. `#{:auth-required :admin-only :public}`. |
 | `:parent` | Another route id; builds a chain readable via `:rf.route/chain`. |
 | `:on-match` | Event vector(s) to dispatch when the route activates. |
 | `:on-error` | Event vector dispatched if any `:on-match` event errors. |
-| `:can-leave` | Guard sub-query run before leaving the route. Closed boolean contract: `true` allows, `false` blocks; any non-boolean blocks and emits `:rf.error/can-leave-non-boolean`. The name reads positively, so `false` means "can NOT leave". The sub receives the pending target as an argument. See [Routing → Blocking a navigation](../routing/concepts.md#blocking-a-navigation). |
-| `:can-enter` | Guard sub-query run before entering the route (the auth-gate mirror of `:can-leave`). Closed boolean contract: `true` allows entry, `false` blocks; any non-boolean blocks and emits `:rf.error/can-enter-non-boolean`. On a block the runtime dispatches `:rf.route/entry-blocked`. See [Routing → Guarding entry](../routing/concepts.md#guarding-entry--can-enter). |
+| `:can-leave` | Guard sub-query run before leaving the route. Closed boolean contract: `true` allows, `false` blocks. Any non-boolean also blocks and emits `:rf.error/can-leave-non-boolean`. The name reads positively, so `false` means "can NOT leave". The sub receives the pending target as an argument. See [Routing → Blocking a navigation](../routing/concepts.md#blocking-a-navigation). |
+| `:can-enter` | Guard sub-query run before entering the route (the auth-gate mirror of `:can-leave`). Closed boolean contract: `true` allows entry, `false` blocks. Any non-boolean also blocks and emits `:rf.error/can-enter-non-boolean`. On a block the runtime dispatches `:rf.route/entry-blocked`. See [Routing → Guarding entry](../routing/concepts.md#guarding-entry--can-enter). |
 | `:scroll` | Scroll-restoration behaviour for this route. |
 | `:sensitive` | Slice paths (projection-relative, e.g. `[:query :token]`) redacted at egress while the route is active. See [Routing → Keeping tokens off the wire](../routing/concepts.md#keeping-tokens-off-the-wire). |
 | `:large` | Slice paths kept off the wire at egress (a size marker ships instead of the value). |
 
 Two cross-feature bare keys are also accepted:
 
-- `:head` — SSR's head-metadata contract; enumerated in the accepted set unconditionally.
-- `:resources` — the Resources artefact's route integration; late-bound via the `:routing/extra-route-keys` hook. In an app without the Resources artefact, `:resources` is rejected like any other unknown bare key.
+- `:head` — SSR's head-metadata contract. It is always in the accepted set.
+- `:resources` — the Resources artefact's route integration, late-bound via the `:routing/extra-route-keys` hook. In an app without the Resources artefact, `:resources` is rejected like any other unknown bare key.
 
 Canonical detail in [The metadata map, in full](../routing/concepts.md#the-metadata-map-in-full).
 
@@ -83,7 +98,7 @@ Canonical detail in [The metadata map, in full](../routing/concepts.md#the-metad
 
 ## URL and route matching
 
-The URL ↔ route mapping is a prism: `match-url` reads a URL to route data, `route-url` renders route data back to a URL, and `match-url(route-url(...))` round-trips the canonical route data. Both are pure and JVM-runnable.
+The URL ↔ route mapping is a prism. `match-url` reads a URL into route data. `route-url` renders route data back into a URL. `match-url(route-url(...))` round-trips the canonical route data. Both functions are pure and JVM-runnable.
 
 ### `match-url`
 
@@ -94,9 +109,9 @@ The URL ↔ route mapping is a prism: `match-url` reads a URL to route data, `ro
   ```
 - **Description**: Match a URL to route data. Pure; JVM-runnable.
 
-  - Returns `nil` when no route matches, and fails closed to `nil` on malformed percent-encoding anywhere in the URL.
+  - Returns `nil` when no route matches. Also fails closed to `nil` on malformed percent-encoding anywhere in the URL.
   - When the route declares `:params` / `:query` schemas and the parsed values fail them, `:validation-failed?` is `true` and the explanation rides under `:validation-error`.
-  - Query keys the route declares (via `:query` / `:query-defaults` / `:query-retain`) come back as keyword keys in deterministic canonical order; undeclared keys stay strings.
+  - Query keys the route declares (via `:query` / `:query-defaults` / `:query-retain`) come back as keyword keys, in a deterministic canonical order. Undeclared keys stay strings.
 - **Example**:
   ```clojure
   ;; with (rf/reg-route :user/show {} "/users/:id") registered:
@@ -120,8 +135,8 @@ The URL ↔ route mapping is a prism: `match-url` reads a URL to route data, `ro
 - **Description**: Render a route to a URL — the inverse of `match-url`. Pure; JVM-runnable.
 
   - The 4-arity appends `#fragment` when `fragment` is a non-empty string (`nil` / `""` append nothing).
-  - Nil-valued query keys are silently elided; a nil required path param is an error.
-  - Query keys are emitted percent-encoded in deterministic canonical order.
+  - Nil-valued query keys are silently elided. A nil required path param is an error.
+  - Query keys are emitted percent-encoded, in a deterministic canonical order.
 
   Throws:
   - `:rf.error/no-such-route` — `route-id` not registered.
@@ -144,9 +159,9 @@ The URL ↔ route mapping is a prism: `match-url` reads a URL to route data, `ro
   ```clojure
   (malformed-url? url) → boolean
   ```
-- **Description**: `true` when any percent-encoded portion of `url` (a non-empty path segment, a query key or value, or the `#fragment`) is malformed. Purely lexical — no route table is consulted.
+- **Description**: `true` when any percent-encoded portion of `url` is malformed — a non-empty path segment, a query key or value, or the `#fragment`. The check is purely lexical; no route table is consulted.
 
-  The `:rf.route/transitioned` / `:rf.route/handle-url-change` handlers use it to discriminate the bare route-miss case (`{:url url}`) from the malformed-URL fail-closed case (`{:url url :reason :malformed-url}`). Both end at `:rf.route/not-found`; the structured `:reason` lets per-route error UIs and SSR projections branch on the cause.
+  The `:rf.route/transitioned` / `:rf.route/handle-url-change` handlers use it to tell two cases apart: a plain route miss (`{:url url}`) and a malformed URL that failed closed (`{:url url :reason :malformed-url}`). Both cases end at `:rf.route/not-found`. The structured `:reason` lets per-route error UIs and SSR projections branch on the cause.
 
 ### `current-url`
 
@@ -155,11 +170,11 @@ The URL ↔ route mapping is a prism: `match-url` reads a URL to route data, `ro
   ```clojure
   (current-url) → app-relative URL string
   ```
-- **Description**: Read the current browser URL as an app-relative string (`pathname + search + hash`). Returns `"/"` when no `window.location` is available (JVM / SSR / Node). This is the history strategy's `:decode`; a hash app's listener decodes through its own strategy and never calls this directly. Public so apps that wire their own history listener can recover the same projection the framework's listener uses.
+- **Description**: Read the current browser URL as an app-relative string (`pathname + search + hash`). Returns `"/"` when no `window.location` is available (JVM / SSR / Node). This is the history strategy's `:decode`. A hash app's listener decodes through its own strategy and never calls this directly. It is public so apps that wire their own history listener can recover the same projection the framework's listener uses.
 
 ## Introspection and slice access
 
-The read-side surface over the route registry and the live route slice: static "which routes are registered, and what is route X's spec?" accessors plus live per-frame slice readers. The `*-algebra-view` helpers lower routes into the shared derivation/process-algebra node shape, so a tool can show subscriptions, flows, resources, route facts, and machine selectors as one family.
+This is the read-side surface over the route registry and the live route slice. The static accessors answer "which routes are registered, and what is route X's spec?". The live readers expose the per-frame slice. The `*-algebra-view` helpers lower routes into the shared derivation/process-algebra node shape, so a tool can show subscriptions, flows, resources, route facts, and machine selectors as one family.
 
 ### `route-ids`
 
@@ -168,7 +183,7 @@ The read-side surface over the route registry and the live route slice: static "
   ```clojure
   (route-ids) → vector of route ids
   ```
-- **Description**: Return a vector of every registered route id — the static-registry "enumerate" half of routing introspection (the live per-frame slice is read through the `:rf.route/*` subs). Mirrors the sibling `resource-ids` / machines `machines` accessors.
+- **Description**: Return a vector of every registered route id. This is the static-registry "enumerate" half of routing introspection; the live per-frame slice is read through the `:rf.route/*` subs instead. Mirrors the sibling accessors: `resource-ids` for resources, `machines` for machines.
 - **Example**:
   ```clojure
   (routing/route-ids)  ;; => [:route/cart :user/show]
@@ -181,7 +196,7 @@ The read-side surface over the route registry and the live route slice: static "
   ```clojure
   (route-meta route-id) → metadata map or nil
   ```
-- **Description**: Return the registered route's metadata map for `route-id`, or `nil` if none is registered under that id. The map carries `:path` pattern, `:on-match`, `:params`, `:query`, `:scroll`, `:can-leave`, the computed `:rf.route/rank` / `:rf.route/compiled` / coercion tables, and source coords. Mirrors the sibling `resource-meta` / machines `machine-meta` accessors.
+- **Description**: Return the metadata map registered for `route-id`, or `nil` if no route is registered under that id. The map carries the `:path` pattern, `:on-match`, `:params`, `:query`, `:scroll`, and `:can-leave`. It also carries the computed `:rf.route/rank` / `:rf.route/compiled` / coercion tables and the source coords. Mirrors the sibling accessors: `resource-meta` for resources, `machine-meta` for machines.
 
 ### `route-algebra-view`
 
@@ -191,7 +206,7 @@ The read-side surface over the route registry and the live route slice: static "
   (route-algebra-view) → {route-id route-fact-node}
   (route-algebra-view route-id) → route-fact-node or nil
   ```
-- **Description**: The STATIC derivation/process-algebra view of every registered route — pure data over the `:route` registrar kind (no app-db, no runtime-db, no live slice). Zero-arity returns the map for every route (`{}` when none); one-arity returns one node or `nil`. JVM-runnable; consumed by Xray and the conformance fixtures. No `re-frame.core` facade export.
+- **Description**: The STATIC derivation/process-algebra view of every registered route. It is pure data over the `:route` registrar kind — no app-db, no runtime-db, no live slice. The zero-arity form returns the map for every route (`{}` when none). The one-arity form returns one node, or `nil`. JVM-runnable; consumed by Xray and the conformance fixtures. There is no `re-frame.core` facade export.
 
   Each route lowers to a normalized node carrying:
   - `:id` `:rf/route` — the route FACT identity (every route materializes the one route slice; the per-route registration id is under `:source-form`).
@@ -209,7 +224,7 @@ The read-side surface over the route registry and the live route slice: static "
   ```clojure
   (route-slice-algebra-view frame-id) → route-fact-node or nil
   ```
-- **Description**: The LIVE counterpart to `route-algebra-view`: the route fact materialized in a frame's runtime-db at `[:rf.runtime/routing :current]` (the concrete matched route — its params, query, transition state, and nav-token; the live route owner). Returns a single `:route-fact` node, or `nil` for a missing / destroyed frame or when no route has been materialized yet (no navigation has committed). Adds `:route-id`, `:params`, `:query`, `:transition`, `:nav-token`, and `:owner` `[:route <route-id> <nav-token>]` to the same fixed classifications the static node carries. CLJS- and JVM-runnable (a single runtime-db container deref).
+- **Description**: The LIVE counterpart to `route-algebra-view`. It reads the route fact materialized in a frame's runtime-db at `[:rf.runtime/routing :current]` — the concrete matched route, with its params, query, transition state, and nav-token. Returns a single `:route-fact` node. Returns `nil` when the frame is missing or destroyed, or when no navigation has committed yet (so no route has been materialized). The node carries the same fixed classifications as the static node, plus `:route-id`, `:params`, `:query`, `:transition`, `:nav-token`, and `:owner` `[:route <route-id> <nav-token>]`. Runs on both CLJS and the JVM (a single runtime-db container deref).
 
 ### `route-sub-fn`
 
@@ -218,11 +233,11 @@ The read-side surface over the route registry and the live route slice: static "
   ```clojure
   (route-sub-fn db query-v) → route slice
   ```
-- **Description**: The layer-1 sub fn behind `:rf/route` — reads the route slice from `[:rf.runtime/routing :current]`. Exposed publicly so external callers (smoke tests, tooling) read the slice without re-deriving the path.
+- **Description**: The layer-1 sub fn behind `:rf/route`. It reads the route slice from `[:rf.runtime/routing :current]`. Exposed publicly so external callers (smoke tests, tooling) can read the slice without re-deriving the path.
 
 ### Reading the route and the pending-nav slot
 
-The route slice and the pending-navigation slot are read with the ordinary `subscribe` naming their framework sub vector — there is no named-read-sugar fn (a runtime-db framework read is a subscription vector, one grammar). Both are per-frame singletons, so no id argument is needed; `subscribe`'s `{:frame <target>}` opts form reads an explicit (e.g. non-default url-bound) frame.
+You read the route slice and the pending-navigation slot with ordinary `subscribe` calls naming their framework sub vectors. There is no named-read-sugar fn — a runtime-db framework read is a subscription vector, one grammar. Both are per-frame singletons, so no id argument is needed. To read an explicit frame (say, a non-default url-bound one), use `subscribe`'s `{:frame <target>}` opts form.
 
 ```clojure
 (:route-id @(rf/subscribe [:rf/route]))   ;; the active route id, or nil pre-navigation
@@ -236,7 +251,7 @@ The `:rf.route/*` granular subs (`:rf.route/id`, `:rf.route/params`, …) chain 
 
 ## Scroll restoration
 
-Saved scroll positions are a host-side, per-frame transient LRU cache keyed by frame-id — NOT runtime-db state. They are host-derived (read from `window.scrollX/Y`), meaningless server-side, and not needed to reconstitute a coherent frame on restore / SSR-hydration / time-travel, so they never ride the trace / epoch / SSR egress wire and cannot rewind on an epoch restore. The pure helpers operate on a plain per-frame cache map `{:positions {url [x y]} :order [url ...]}`; the `!`-suffixed wrappers read/write the host cache.
+Saved scroll positions live in a host-side, per-frame transient LRU cache keyed by frame-id. They are NOT runtime-db state. They are host-derived (read from `window.scrollX/Y`), meaningless server-side, and not needed to reconstitute a coherent frame on restore, SSR-hydration, or time-travel. So they never ride the trace / epoch / SSR egress wire, and they cannot rewind on an epoch restore. The pure helpers operate on a plain per-frame cache map `{:positions {url [x y]} :order [url ...]}`. The `!`-suffixed wrappers read and write the host cache.
 
 ### `scroll-positions-cap`
 
@@ -245,7 +260,7 @@ Saved scroll positions are a host-side, per-frame transient LRU cache keyed by f
   ```clojure
   scroll-positions-cap  ;; => 50
   ```
-- **Description**: Soft upper bound on tracked URLs in the per-frame scroll-positions cache. Large enough that real Back-button restoration hits saved positions, small enough that the per-frame host cache stays bounded over long sessions.
+- **Description**: Soft upper bound on tracked URLs in the per-frame scroll-positions cache. It is large enough that real Back-button restoration hits saved positions, and small enough that the per-frame host cache stays bounded over long sessions.
 
 ### `frame-scroll-cache`
 
@@ -254,7 +269,7 @@ Saved scroll positions are a host-side, per-frame transient LRU cache keyed by f
   ```clojure
   (frame-scroll-cache frame-id) → {:positions :order} or nil
   ```
-- **Description**: Read the per-frame cache map (`{:positions :order}`) for `frame-id` from the host scroll-position cache, or `nil` when none. The value threaded into the pure nav-planning seam.
+- **Description**: Read the per-frame cache map (`{:positions :order}`) for `frame-id` from the host scroll-position cache, or `nil` when none. This is the value threaded into the pure nav-planning seam.
 
 ### `lookup-scroll-position`
 
@@ -263,7 +278,7 @@ Saved scroll positions are a host-side, per-frame transient LRU cache keyed by f
   ```clojure
   (lookup-scroll-position cache url) → [x y] or nil
   ```
-- **Description**: Pure. Return the saved `[x y]` for `url` in `cache` (a per-frame cache map `{:positions {url [x y]} :order [...]}`, or `nil`), or `nil` if none.
+- **Description**: Pure. Return the saved `[x y]` for `url` in `cache`, or `nil` if none is saved. `cache` is a per-frame cache map `{:positions {url [x y]} :order [...]}`; it may itself be `nil`.
 
 ### `save-scroll-position`
 
@@ -272,7 +287,7 @@ Saved scroll positions are a host-side, per-frame transient LRU cache keyed by f
   ```clojure
   (save-scroll-position cache url xy) → cache'
   ```
-- **Description**: Pure. Return `cache` with the scroll position for `url` recorded under `:positions`. LRU-capped at `scroll-positions-cap`: re-saving an existing url promotes it to most-recent; new saves past the cap evict the least-recently-used entry. The `:order` vector is the recency anchor.
+- **Description**: Pure. Return `cache` with the scroll position for `url` recorded under `:positions`. The cache is LRU-capped at `scroll-positions-cap`. Re-saving an existing url promotes it to most-recent. A new save past the cap evicts the least-recently-used entry. The `:order` vector is the recency anchor.
 
 ### `save-scroll-position!`
 
@@ -294,7 +309,7 @@ Saved scroll positions are a host-side, per-frame transient LRU cache keyed by f
 
 ## Navigation counters and state classification
 
-The nav-token and pending-nav allocators are host-side, per-frame, monotonic high-water marks (not runtime-db), so an epoch restore — which replaces the runtime-db partition wholesale — cannot rewind them and recycle a token still carried by a slow in-flight continuation. `counter-snapshot` reads them; `routing-state-classification` is the canonical durable/transient map that SSR, docs, and schemas key off.
+The nav-token and pending-nav allocators are host-side, per-frame, monotonic high-water marks — not runtime-db state. An epoch restore replaces the runtime-db partition wholesale, so it cannot rewind these counters and recycle a token still carried by a slow in-flight continuation. `counter-snapshot` reads them. `routing-state-classification` is the canonical durable/transient map that SSR, docs, and schemas key off.
 
 ### `counter-snapshot`
 
@@ -303,7 +318,7 @@ The nav-token and pending-nav allocators are host-side, per-frame, monotonic hig
   ```clojure
   (counter-snapshot frame-id) → {:nav-token-counter N :pending-nav-counter M} or {}
   ```
-- **Description**: Read the per-frame counter snapshot for `frame-id` from the host nav-counters cache, or `{}` when none. The value the allocation-cofx generators mint the next nav-token / pending-nav id from.
+- **Description**: Read the per-frame counter snapshot for `frame-id` from the host nav-counters cache, or `{}` when none. This is the value the allocation-cofx generators mint the next nav-token / pending-nav id from.
 
 ### `routing-state-classification`
 
@@ -334,7 +349,7 @@ The nav-token and pending-nav allocators are host-side, per-frame, monotonic hig
 
 ## Multi-frame URL ownership
 
-At most one frame owns the browser URL at a time. A frame claims ownership by registering with `{:url-bound? true}`; the resolver below names the current owner, and the outbound `:rf.nav/push-url` fx and the inbound popstate listener both route through it — one owner, both directions.
+At most one frame owns the browser URL at a time. A frame claims ownership by registering with `{:url-bound? true}`. The resolver below names the current owner. The outbound `:rf.nav/push-url` fx and the inbound popstate listener both route through it — one owner, both directions.
 
 ### `url-owner-frame-id`
 
@@ -345,9 +360,9 @@ At most one frame owns the browser URL at a time. A frame claims ownership by re
   ```
 - **Description**: Return the single frame that has explicitly declared browser-history ownership via `(rf/reg-frame :id {:url-bound? true})`, or `nil` when none has.
 
-  - URL ownership is an explicit host/bootstrap policy, not an absence repair — the runtime never infers `:rf/default` as the owner. `:rf/default` owns the URL only when it carries an explicit `{:url-bound? true}` like any other frame.
+  - URL ownership is an explicit host/bootstrap policy, not an absence repair. The runtime never infers `:rf/default` as the owner. `:rf/default` owns the URL only when it carries an explicit `{:url-bound? true}`, like any other frame.
   - Ownership resolves to the first-claimed still-live `:url-bound? true` frame (the incumbent), so a later duplicate cannot steal the URL.
-  - `nil` means no owner is declared — outbound history fxs no-op and the inbound popstate listener skips.
+  - `nil` means no owner is declared. In that case outbound history fxs no-op and the inbound popstate listener skips.
 - **Example**:
   ```clojure
   ;; one frame opts into URL ownership at boot:
@@ -366,7 +381,7 @@ At most one frame owns the browser URL at a time. A frame claims ownership by re
 
 ## URL strategies
 
-A `:url-strategy` is a frame-level config map declared on the URL-owning frame — `(rf/reg-frame :app {:url-bound? true :url-strategy routing/hash-url-strategy})`. It is consulted at exactly four egress/ingress points (the two history fxs, the `route-link` href render, the URL-listener install); `route-url`, `match-url`, and the navigation cascade stay pure and path-form. A strategy map carries `{:encode :decode :push! :replace! :install-listener!}`; the side-effecting keys (`:push!` / `:replace!` / `:install-listener!`) are present on CLJS only. SSR ignores strategies — the server emits path-form hrefs and takes the request URL via `:rf.route/handle-url-change`.
+A `:url-strategy` is a frame-level config map declared on the URL-owning frame — `(rf/reg-frame :app {:url-bound? true :url-strategy routing/hash-url-strategy})`. The strategy is consulted at exactly four egress/ingress points: the two history fxs, the `route-link` href render, and the URL-listener install. `route-url`, `match-url`, and the navigation cascade stay pure and path-form. A strategy map carries `{:encode :decode :push! :replace! :install-listener!}`. The side-effecting keys (`:push!` / `:replace!` / `:install-listener!`) are present on CLJS only. SSR ignores strategies: the server emits path-form hrefs and takes the request URL via `:rf.route/handle-url-change`.
 
 ### `history-url-strategy`
 
@@ -406,7 +421,7 @@ A `:url-strategy` is a frame-level config map declared on the URL-owning frame �
   ```clojure
   (with-base-path strategy base) → strategy-map
   ```
-- **Description**: STRATEGY COMBINATOR (not a third shipped strategy) for an app deployed under a sub-path — a host mounting several demos side by side, so an app that would otherwise own `/` instead lives at `/realworld/`. Wraps `strategy` (either shipped strategy, or a custom one) so `:encode` / `:decode` / `:push!` / `:replace!` / `:install-listener!` all account for `base`: it is stripped off every inbound URL and re-added to every outbound one, underneath whichever address-bar form `strategy` already provides. `route-url` / `match-url` and the rest of the cascade stay path-form and base-agnostic. A blank/nil `base` returns `strategy` unchanged.
+- **Description**: A STRATEGY COMBINATOR, not a third shipped strategy. Use it when an app is deployed under a sub-path — say a host mounting several demos side by side, so an app that would otherwise own `/` instead lives at `/realworld/`. It wraps `strategy` (either shipped strategy, or a custom one) so that `:encode` / `:decode` / `:push!` / `:replace!` / `:install-listener!` all account for `base`. The base is stripped off every inbound URL and re-added to every outbound one, underneath whichever address-bar form `strategy` already provides. `route-url` / `match-url` and the rest of the cascade stay path-form and base-agnostic. A blank or nil `base` returns `strategy` unchanged.
 - **Example**:
   ```clojure
   (rf/reg-frame :app {:url-bound?   true
@@ -417,16 +432,16 @@ A `:url-strategy` is a frame-level config map declared on the URL-owning frame �
 
 ## Browser URL listener
 
-There is no imperative boot seam to call — the browser `popstate` / `hashchange` listener is wired by the **`:url-bound?` frame LIFECYCLE**, automatically (rf2-g8pbwg): a `:url-bound? true` frame's creation (or re-registration, when it resolves as the URL owner) installs the listener AND syncs the current URL into the owner's route slice in the same step; the frame's destroy removes it. The retired `install-url-listener!` / `remove-url-listener!` / `install-history-listener!` / `remove-history-listener!` exports are GONE (pre-alpha, no back-compat shim) — there is nothing to call.
+There is no imperative boot seam to call. The browser `popstate` / `hashchange` listener is wired automatically by the **`:url-bound?` frame LIFECYCLE** (rf2-g8pbwg). When a `:url-bound? true` frame is created (or re-registered) and resolves as the URL owner, that step installs the listener AND syncs the current URL into the owner's route slice. Destroying the frame removes the listener. The retired `install-url-listener!` / `remove-url-listener!` / `install-history-listener!` / `remove-history-listener!` exports are GONE (pre-alpha, no back-compat shim). There is nothing to call.
 
-- Each browser-driven change is decoded to a path-form URL by the strategy's `:decode` and dispatched synchronously as `:rf.route/handle-url-change` to `(url-owner-frame-id)` resolved at fire time; when no frame declares `:url-bound? true` the dispatch is skipped.
-- The listener kind (`popstate` vs `hashchange`) is resolved from the URL-owning frame's `:url-strategy` at install time; the owner (dispatch target) is re-resolved at every fire.
-- Idempotent — a re-registration that resolves as the owner tears down the prior listener before reinstalling. A losing duplicate `:url-bound? true` registration never installs.
-- CLJS-only — on the JVM there is nothing to install (SSR feeds the request URL via `:rf.route/handle-url-change`).
+- Each browser-driven change is decoded to a path-form URL by the strategy's `:decode`, then dispatched synchronously as `:rf.route/handle-url-change` to `(url-owner-frame-id)`, resolved at fire time. When no frame declares `:url-bound? true`, the dispatch is skipped.
+- The listener kind (`popstate` vs `hashchange`) is resolved from the URL-owning frame's `:url-strategy` at install time. The owner (the dispatch target) is re-resolved at every fire.
+- Installation is idempotent. A re-registration that resolves as the owner tears down the prior listener before reinstalling. A losing duplicate `:url-bound? true` registration never installs.
+- CLJS-only. On the JVM there is nothing to install; SSR feeds the request URL via `:rf.route/handle-url-change`.
 
 ## Route links
 
-The `:route/link` registered view renders an `<a href=...>` from a route id and intercepts plain left-clicks into `:rf.route/url-requested` dispatches. The authoring surface is also published as `rf/route-link` on the `re-frame.core` facade.
+The `:route/link` registered view renders an `<a href=...>` from a route id. It intercepts plain left-clicks and turns them into `:rf.route/url-requested` dispatches. The authoring surface is also published as `rf/route-link` on the `re-frame.core` facade.
 
 ### `route-link`
 
@@ -439,10 +454,10 @@ The `:route/link` registered view renders an `<a href=...>` from a route id and 
   ```
 - **Description**: The registered `:route/link` view.
 
-  - `:to` is the only required key; `:params`, `:query`, and `:fragment` are forwarded to `route-url` for href synthesis, and every other props key passes through to the `<a>` element.
-  - A plain primary-button click (no modifier keys, `defaultPrevented` false) is intercepted: `preventDefault`, then dispatch `[:rf.route/url-requested {:url ... :to ...}]` targeted at the frame that rendered the link.
+  - `:to` is the only required key. `:params`, `:query`, and `:fragment` are forwarded to `route-url` for href synthesis. Every other props key passes through to the `<a>` element.
+  - A plain primary-button click (no modifier keys, `defaultPrevented` false) is intercepted. The view calls `preventDefault`, then dispatches `[:rf.route/url-requested {:url ... :to ...}]` targeted at the frame that rendered the link.
   - Modifier-key / middle-button clicks, and anchors carrying native-handling attributes (`:target` other than `_self`, or `:download`), defer to the browser.
-  - A caller-supplied `:on-click` runs first; if it calls `preventDefault` the framework's interception is skipped.
+  - A caller-supplied `:on-click` runs first. If it calls `preventDefault`, the framework's interception is skipped.
   - The rendered href is encoded through the rendering frame's `:url-strategy`.
   - On the JVM the `:route/link` registration renders via [`route-link-render-ssr`](#route-link-render-ssr).
 - **Example**:
@@ -458,7 +473,7 @@ The `:route/link` registered view renders an `<a href=...>` from a route id and 
   ```clojure
   (route-link-render props & children) → hiccup
   ```
-- **Description**: The CLJS render fn behind `route-link`, exposed without the registry wrap so tests can call it directly. Same props contract and click rules as [`route-link`](#route-link). Must run inside a frame scope — raises `:rf.error/no-frame-context` when rendered outside one (the render-time frame is captured so the click dispatch targets it after the render scope has unwound).
+- **Description**: The CLJS render fn behind `route-link`, exposed without the registry wrap so tests can call it directly. Same props contract and click rules as [`route-link`](#route-link). It must run inside a frame scope, and raises `:rf.error/no-frame-context` when rendered outside one. The render-time frame is captured so the click dispatch still targets it after the render scope has unwound.
 
 ## Server-side rendering
 
@@ -469,11 +484,11 @@ The `:route/link` registered view renders an `<a href=...>` from a route id and 
   ```clojure
   (route-link-render-ssr props & children) → hiccup
   ```
-- **Description**: The JVM render fn for the `:route/link` view. Renders the `<a href=...>` shell without the click-interception logic — SSR has no DOM events to intercept, so the anchor is emitted as-is and clicks on the hydrated page run the CLJS render fn's on-click path. The href is emitted path-form regardless of `:url-strategy` (SSR ignores strategies); the hydrated CLJS render re-encodes it. The authoring surface is [`route-link`](#route-link), also published on the `re-frame.core` facade.
+- **Description**: The JVM render fn for the `:route/link` view. It renders the `<a href=...>` shell without the click-interception logic. SSR has no DOM events to intercept, so the anchor is emitted as-is; clicks on the hydrated page run the CLJS render fn's on-click path. The href is emitted path-form regardless of `:url-strategy` (SSR ignores strategies), and the hydrated CLJS render re-encodes it. The authoring surface is [`route-link`](#route-link), also published on the `re-frame.core` facade.
 
 ## Keyword surfaces
 
-The routing artefact registers a family of events, subscriptions, effects, and coeffects addressed by keyword; loading `re-frame.routing` wires them all. It also registers internal machinery — the `:rf.route.internal/*` runtime events, the recordable allocation cofx (`:rf.route/nav-allocation`, `:rf.route/pending-nav-allocation`), and the `:rf.route/commit-nav-counter` fx — which apps and tools never dispatch or declare; those are omitted from the tables below.
+The routing artefact registers a family of events, subscriptions, effects, and coeffects addressed by keyword. Loading `re-frame.routing` wires them all. It also registers internal machinery that apps and tools never dispatch or declare: the `:rf.route.internal/*` runtime events, the recordable allocation cofx (`:rf.route/nav-allocation`, `:rf.route/pending-nav-allocation`), and the `:rf.route/commit-nav-counter` fx. Those internals are omitted from the tables below.
 
 ### Events
 
@@ -481,8 +496,8 @@ Standard events the runtime dispatches (or you dispatch) around routing.
 
 | Event | Notes |
 |---|---|
-| `:rf.route/navigate` | Navigate to a registered route. Arities: `[:rf.route/navigate target]` / `[:rf.route/navigate target params]` / `[:rf.route/navigate target params opts]`. `target` is a route id, the reserved `:rf.route/self` (stay on the current route, reshape only the query), or a `{:url "..."}` map; `params` (2nd slot) are path params; `opts` (3rd slot) recognises `:query`, `:query-merge`, `:replace?`, `:scroll`, `:fragment`, `:bypass-guards?`. |
-| `:rf.route/handle-url-change` | URL-change handler for popstate / initial load / SSR (default scroll `:restore`). Co-equal sibling of `:rf.route/transitioned` — same slice-rewrite logic, not a delegate. Override for custom URL-change handling. |
+| `:rf.route/navigate` | Navigate to a registered route. Arities: `[:rf.route/navigate target]` / `[:rf.route/navigate target params]` / `[:rf.route/navigate target params opts]`. `target` is a route id, the reserved `:rf.route/self` (stay on the current route, reshape only the query), or a `{:url "..."}` map. `params` (2nd slot) are path params. `opts` (3rd slot) recognises `:query`, `:query-merge`, `:replace?`, `:scroll`, `:fragment`, `:bypass-guards?`. |
+| `:rf.route/handle-url-change` | URL-change handler for popstate / initial load / SSR (default scroll `:restore`). A co-equal sibling of `:rf.route/transitioned`: same slice-rewrite logic, not a delegate. Override it for custom URL-change handling. |
 | `:rf.route/transitioned` | URL-change handler for forward navigation — a link click or programmatic push (default scroll `:top`). The runtime dispatches this; you read it. |
 | `:rf.route/url-requested` | The user clicked a framework-owned link. `route-link` synthesises this event; you usually let the default handler take it. |
 | `:rf.route/navigation-blocked` | A `:can-leave` (leave) guard rejected a navigation. The pending nav slot carries the rejected navigation (`:direction :leave`). |
@@ -514,18 +529,18 @@ The full `:rf/route` slice is `{:route-id :params :query :fragment :transition :
 | `[:rf.nav/replace-url url-string]` | URL string | `:client` | Replace the current URL without adding a history entry. |
 | `[:rf.nav/scroll scroll-spec]` | scroll-spec map | `:client` | Restore or set scroll position. |
 | `[:rf.nav/capture-scroll {:url url-string}]` | `{:url ...}` map | `:client` | Capture the current scroll position into the host-side per-frame scroll-position cache (keyed by `url`) before leaving a route. |
-| `[:rf.route/with-nav-token {:rf/reply-to <reply-target> :nav-token <token>}]` | see notes | universal | Name an async-completion continuation by its canonical `:rf/reply-to` reply target and guard it with a navigation token. On match the target is completed with the `:status :ok` reply map; if the token has been superseded by a later navigation, the completion is suppressed and `:rf.route.nav-token/stale-suppressed` fires. Optional args keys: `:route-id` (the captured route id, for the work-id), `:value` (rides the `:status :ok` reply map), `:completed-at`. |
+| `[:rf.route/with-nav-token {:rf/reply-to <reply-target> :nav-token <token>}]` | see notes | universal | Name an async-completion continuation by its canonical `:rf/reply-to` reply target and guard it with a navigation token. On a token match, the target is completed with the `:status :ok` reply map. If the token has been superseded by a later navigation, the completion is suppressed and `:rf.route.nav-token/stale-suppressed` fires. Optional args keys: `:route-id` (the captured route id, for the work-id), `:value` (rides the `:status :ok` reply map), `:completed-at`. |
 
-The nav-token wrapper guards "user navigates away mid-load": the older load's reply carries the stale token, the runtime suppresses it, and the older page's data does not overwrite the newer page's state. Full semantics in [Routing → Loaders](../routing/concepts.md#loaders-declaring-a-pages-data).
+The nav-token wrapper guards against "user navigates away mid-load". The older load's reply carries the stale token. The runtime suppresses it, so the older page's data does not overwrite the newer page's state. Full semantics in [Routing → Loaders](../routing/concepts.md#loaders-declaring-a-pages-data).
 
 ### Coeffects (`cofx`)
 
-Declared on a handler via `:rf.cofx/requires`; each value is delivered flat under the cofx key in the coeffects map. Both are universal (client and server).
+Declare these on a handler via `:rf.cofx/requires`. Each value is delivered flat under the cofx key in the coeffects map. Both are universal (client and server).
 
 | Cofx | Delivers |
 |---|---|
-| `:rf.route/nav-token` | The current navigation epoch token, read from `[:rf.runtime/routing :current :nav-token]`. Declare `{:rf.cofx/requires [:rf.route/nav-token]}` on an `:on-match`-reached handler to capture the epoch live at scheduling time and thread it into an async continuation; `:rf.route/with-nav-token` validates it on receipt. |
-| `:rf.route/route-id` | The current route id, read from `[:rf.runtime/routing :current :route-id]`. The capture-side companion of `:rf.route/nav-token` — declare both (`{:rf.cofx/requires [:rf.route/nav-token :rf.route/route-id]}`) so the route-loader work-id `[:rf.work/route route-id nav-token loader-id]` carries its complete attempt identity. |
+| `:rf.route/nav-token` | The current navigation epoch token, read from `[:rf.runtime/routing :current :nav-token]`. Declare `{:rf.cofx/requires [:rf.route/nav-token]}` on an `:on-match`-reached handler to capture the epoch live at scheduling time and thread it into an async continuation. `:rf.route/with-nav-token` validates it on receipt. |
+| `:rf.route/route-id` | The current route id, read from `[:rf.runtime/routing :current :route-id]`. The capture-side companion of `:rf.route/nav-token`. Declare both (`{:rf.cofx/requires [:rf.route/nav-token :rf.route/route-id]}`) so the route-loader work-id `[:rf.work/route route-id nav-token loader-id]` carries its complete attempt identity. |
 
 ## See also
 

--- a/docs/api/re-frame.schemas.md
+++ b/docs/api/re-frame.schemas.md
@@ -1,8 +1,15 @@
 # re-frame.schemas
 
-Schema attachment, validation, and data-classification. Schemas are [Malli](https://github.com/metosin/malli) schemas attached to `app-db` paths via `reg-app-schema`. In dev builds the runtime validates `app-db` writes (and event / fx / subscription values carrying a `:schema`) against the matching schemas, emitting an `:rf.error/schema-validation-failure` trace on mismatch; production builds elide validation at the call sites.
+Schema attachment, validation, and data-classification. Schemas are [Malli](https://github.com/metosin/malli) schemas attached to `app-db` paths via `reg-app-schema`. In dev builds the runtime validates every `app-db` write against the matching schemas. It also validates event, fx, and subscription values that carry a `:schema`. A mismatch emits an `:rf.error/schema-validation-failure` trace. Production builds elide validation at the call sites.
 
-This namespace owns the read-side introspection surface, the pluggable validator / explainer / printer seams, the per-slot `:sensitive?` / `:large?` schema walkers that drive failure-trace redaction, and the test-support snapshot / restore / clear hooks. The registration macros `reg-app-schema` / `reg-app-schemas` are surfaced through the `re-frame.core` facade (called as `rf/reg-app-schema`); their full contract is here.
+This namespace owns four surfaces:
+
+- the read-side introspection functions
+- the pluggable validator / explainer / printer seams
+- the per-slot `:sensitive?` / `:large?` schema walkers that drive failure-trace redaction
+- the test-support snapshot / restore / clear hooks
+
+The registration macros `reg-app-schema` / `reg-app-schemas` are surfaced through the `re-frame.core` facade (called as `rf/reg-app-schema`). Their full contract lives here.
 
 ```clojure
 (:require [re-frame.schemas :as schemas])
@@ -12,7 +19,7 @@ Ships in artefact `day8/re-frame2-schemas`. Most app code touches only **Registr
 
 ## Registration
 
-The registration macros live in `re-frame.core` and route through the schemas artefact at registration time; consumers call them as `rf/reg-app-schema` / `rf/reg-app-schemas`. They are briefly rowed in [re-frame.core.md](re-frame.core.md); the full contract is here. `re-frame.schemas` also exports both names as plain functions for programmatic (HoF) registration — same contract, no call-site source-coord capture.
+The registration macros live in `re-frame.core` and route through the schemas artefact at registration time. Consumers call them as `rf/reg-app-schema` / `rf/reg-app-schemas`. [re-frame.core.md](re-frame.core.md) lists them briefly; the full contract is here. `re-frame.schemas` also exports both names as plain functions for programmatic (HoF) registration. The functions carry the same contract but do not capture call-site source coords.
 
 ### `reg-app-schema`
 
@@ -23,11 +30,16 @@ The registration macros live in `re-frame.core` and route through the schemas ar
   (reg-app-schema path metadata schema)
   ```
 - **Description**: Attach a Malli schema to an `app-db` path.
-  - The schema is the **positional value slot** (rf2-qm7k83 Part A), uniform with the rest of the `reg-*` family; the optional middle metadata map carries the frame target (a frame-id keyword or a frame value) under `:frame` (plus `:doc` / open `:my/*` keys).
-  - The **path is the registration id** — app-db schemas are path-keyed, live in the schemas artefact's per-frame side-table, and are NOT a registrar kind. `(app-schema-at [:user])` looks up by the same path vector.
-  - `path` is a sequential `get-in` path of concrete segments (`[]` registers a whole-`app-db` root schema), normalized to canonical vector form. Returns the normalized path.
-  - Raises: `:rf.error/app-schema-bad-metadata` (a non-map middle metadata arg in the 3-slot form); `:rf.error/app-schema-bad-path` (non-sequential path or non-concrete segment); `:rf.error/app-schema-runtime-path` (first segment reaches the runtime-db partition — `:rf.runtime/*`, `:rf.db/runtime`, or the legacy `:rf/runtime` root); `:rf.error/app-schemas-bad-arg` (a `:frame` target that does not resolve to a keyword frame id); `:rf.error/no-frame-context` (no `:frame` and no established frame scope).
-  - Dev-only diagnostics: re-registering a schema at a path whose live `app-db` value fails the new schema emits an `:rf.schema/violation` warning trace; registering an opaque compiled schema the per-slot walker cannot introspect warns once per process with `:rf.warning/schema-walker-opaque`.
+  - The schema is the **positional value slot** (rf2-qm7k83 Part A), uniform with the rest of the `reg-*` family. The optional middle metadata map carries the frame target under `:frame` (a frame-id keyword or a frame value), plus `:doc` and open `:my/*` keys.
+  - The **path is the registration id**. App-db schemas are path-keyed and live in the schemas artefact's per-frame side-table; they are NOT a registrar kind. `(app-schema-at [:user])` looks up by the same path vector.
+  - `path` is a sequential `get-in` path of concrete segments, normalized to canonical vector form. `[]` registers a whole-`app-db` root schema. Returns the normalized path.
+  - Raises:
+    - `:rf.error/app-schema-bad-metadata` — the middle metadata arg in the 3-slot form is not a map.
+    - `:rf.error/app-schema-bad-path` — a non-sequential path, or a non-concrete segment.
+    - `:rf.error/app-schema-runtime-path` — the first segment reaches the runtime-db partition (`:rf.runtime/*`, `:rf.db/runtime`, or the legacy `:rf/runtime` root).
+    - `:rf.error/app-schemas-bad-arg` — a `:frame` target that does not resolve to a keyword frame id.
+    - `:rf.error/no-frame-context` — no `:frame` and no established frame scope.
+  - Dev-only diagnostics: re-registering a schema at a path whose live `app-db` value fails the new schema emits an `:rf.schema/violation` warning trace. Registering an opaque compiled schema the per-slot walker cannot introspect warns once per process with `:rf.warning/schema-walker-opaque`.
 - **Example**:
   ```clojure
   (rf/reg-app-schema [:cells]
@@ -44,8 +56,8 @@ The registration macros live in `re-frame.core` and route through the schemas ar
   ```
 - **Description**: Bulk plural form of `reg-app-schema`.
   - Each entry routes through the singular form and is stamped with this call's source coords.
-  - The optional second arg names the frame for every entry — an opts map (`{:frame target}`), a bare frame-id keyword, or a frame value; one frame per call.
-  - Returns the vector of paths registered, in map-iteration order; `{}` is the documented empty no-op.
+  - The optional second arg names the frame for every entry: an opts map (`{:frame target}`), a bare frame-id keyword, or a frame value. One frame per call.
+  - Returns the vector of paths registered, in map-iteration order. `{}` is the documented empty no-op.
   - Every path is shape-checked before any store mutation, so a batch containing one invalid path (`:rf.error/app-schema-bad-path` / `:rf.error/app-schema-runtime-path`) registers nothing.
   - A `nil` / non-map first arg raises `:rf.error/app-schemas-bad-batch`.
 - **Example**:
@@ -60,7 +72,7 @@ See [re-frame.core.md](re-frame.core.md) for the `reg-*` return-value convention
 
 ## Introspection
 
-The introspection surfaces live in `re-frame.schemas` and are *not* re-exported from `re-frame.core`. Every `opts-or-frame-id` argument below accepts an opts map (`{:frame target}`), a bare frame-id keyword, or a frame value (normalized to its frame id). A malformed argument raises `:rf.error/app-schemas-bad-arg`; omitting the frame outside any frame scope raises `:rf.error/no-frame-context`.
+The introspection surfaces live in `re-frame.schemas` and are *not* re-exported from `re-frame.core`. Every `opts-or-frame-id` argument below accepts an opts map (`{:frame target}`), a bare frame-id keyword, or a frame value (normalized to its frame id). A malformed argument raises `:rf.error/app-schemas-bad-arg`. Omitting the frame outside any frame scope raises `:rf.error/no-frame-context`.
 
 ### `app-schemas`
 
@@ -128,8 +140,8 @@ The introspection surfaces live in `re-frame.schemas` and are *not* re-exported 
   ```
 - **Description**: Return a single hash over the frame's whole schema surface.
   - Canonical wire form: `"sha256:"` followed by the first 16 lowercase hex chars.
-  - Byte-deterministic across runtimes; the empty schema set produces a stable digest.
-  - Used by SSR hydration compatibility checks and by tools tracking whether the schema corpus changed without diffing schema-by-schema.
+  - Byte-deterministic across runtimes. The empty schema set produces a stable digest.
+  - SSR hydration compatibility checks use it. So do tools that want to know whether the schema corpus changed, without diffing schema-by-schema.
 - **Example**:
   ```clojure
   ;; one stable hash over the whole frame's schema surface
@@ -146,12 +158,21 @@ The introspection surfaces live in `re-frame.schemas` and are *not* re-exported 
   (frame-schema-entries frame-id) → {path schema-meta}
   ```
 - **Description**: Return the full `{path schema-meta}` map for a frame, or `{}`.
-  - Lower-level cross-artefact read seam (consumed by `re-frame.elision` / `re-frame.epoch` and the `validate-app-schema!` loop).
-  - Where `app-schemas` projects each entry down to `{path schema}`, this returns the whole per-path metadata map (`:schema`, `:path`, `:frame`, source-coords).
+  - The lower-level cross-artefact read seam. `re-frame.elision`, `re-frame.epoch`, and the `validate-app-schema!` loop consume it.
+  - `app-schemas` projects each entry down to `{path schema}`; this returns the whole per-path metadata map (`:schema`, `:path`, `:frame`, source-coords).
 
 ## Validation entry points
 
-The four dev-time `validate-*!` functions are the locked validation sites the framework calls for you — pre-handler (event), pre-fx, post-commit (`app-db`), and post-recompute (subscription). They are public and manifested (tools and conformance tests call them directly), but ordinary app code does not: you register a `:schema` and the runtime invokes these. Every body lives inside an `interop/debug-enabled?` gate, so the whole surface is dead-code-eliminated in production (each fn then returns `true`). On every surface a structurally malformed registered schema — one that makes the registered validator throw — emits the distinct `:rf.error/malformed-schema` trace (structural locator slots only, no value-bearing slots) and returns `false` (**fail closed**), never a silent pass.
+The four dev-time `validate-*!` functions are the locked validation sites the framework calls for you:
+
+- pre-handler (event)
+- pre-fx
+- post-commit (`app-db`)
+- post-recompute (subscription)
+
+They are public and manifested — tools and conformance tests call them directly. Ordinary app code does not: you register a `:schema` and the runtime invokes these. Every body lives inside an `interop/debug-enabled?` gate, so the whole surface is dead-code-eliminated in production. Each fn then returns `true`.
+
+On every surface, a structurally malformed registered schema (one that makes the registered validator throw) emits the distinct `:rf.error/malformed-schema` trace and returns `false` (**fail closed**), never a silent pass. That trace carries structural locator slots only — no value-bearing slots.
 
 ### `validate-app-schema!`
 
@@ -163,10 +184,11 @@ The four dev-time `validate-*!` functions are the locked validation sites the fr
   (validate-app-schema! db event-id frame-id)  ;; explicit frame
   ```
 - **Description**: After a handler commits `:db`, walk every registered app-schema for the named frame and validate the post-commit `app-db`. Only the named frame's schemas are walked.
-  - Failures emit `:rf.error/schema-validation-failure` (one trace per failing entry) with the registered explainer's output attached; value-bearing slots are redacted when the failing slot is `:sensitive?`.
+  - Failures emit `:rf.error/schema-validation-failure` (one trace per failing entry) with the registered explainer's output attached. Value-bearing slots are redacted when the failing slot is `:sensitive?`.
   - A malformed entry (the validator throws) emits `:rf.error/malformed-schema` for that entry, contributes `false`, and does not stop sibling schemas from validating.
   - `event-id` (optional) names the handler whose commit prompted the failure — surfaced as `:failing-id`.
-  - Returns `true` when every registered schema conformed (also when no validator is registered, no schemas are registered for the frame, or the build elided validation), `false` when at least one failed. The router consumes a `false` to roll the `:db` effect back to the pre-handler value.
+  - Returns `true` when every registered schema conformed. Also returns `true` when no validator is registered, no schemas are registered for the frame, or the build elided validation.
+  - Returns `false` when at least one schema failed. The router consumes a `false` to roll the `:db` effect back to the pre-handler value.
   - A hard no-op for every schema when `set-schema-validator!` has been called with `nil`.
 
 ### `validate-event!`
@@ -178,9 +200,9 @@ The four dev-time `validate-*!` functions are the locked validation sites the fr
   (validate-event! event-id event handler-meta frame)
   ```
 - **Description**: Before an event handler runs, validate the event vector against any `:schema` on the handler's registration metadata.
-  - On failure emits `:rf.error/schema-validation-failure :where :event`; the caller skips the handler (recovery `:no-recovery`).
-  - A `:sensitive?` slot anywhere in the event schema — commonly the `:cat` / `:catn` payload (e.g. a `:password` slot in a login schema) — redacts the value-bearing trace slots.
-  - The optional `frame` arg stamps a `:frame` tag so the violation is captured into the in-flight epoch's `:trace-events` (read by the Xray Issues / Schema-timeline lens); the runtime passes it, direct callers may omit it.
+  - On failure, emits `:rf.error/schema-validation-failure :where :event`. The caller skips the handler (recovery `:no-recovery`).
+  - A `:sensitive?` slot anywhere in the event schema redacts the value-bearing trace slots. The common case is a `:cat` / `:catn` payload slot, such as a `:password` slot in a login schema.
+  - The optional `frame` arg stamps a `:frame` tag so the violation is captured into the in-flight epoch's `:trace-events` (read by the Xray Issues / Schema-timeline lens). The runtime passes it; direct callers may omit it.
   - Returns `true`/`false`.
 
 ### `validate-fx!`
@@ -192,7 +214,7 @@ The four dev-time `validate-*!` functions are the locked validation sites the fr
   (validate-fx! fx-id event-id args fx-meta frame)
   ```
 - **Description**: Before an fx handler runs, validate its args against any `:schema` on the fx's registration metadata.
-  - On failure emits `:rf.error/schema-validation-failure :where :fx-args`; only the offending fx is skipped (recovery `:skipped`) — sibling fx in the same `:fx` vector still run and downstream queued events still drain.
+  - On failure, emits `:rf.error/schema-validation-failure :where :fx-args`. Only the offending fx is skipped (recovery `:skipped`). Sibling fx in the same `:fx` vector still run, and downstream queued events still drain.
   - The optional `frame` arg stamps a `:frame` tag for epoch capture.
   - Returns `true`/`false`.
 
@@ -205,13 +227,13 @@ The four dev-time `validate-*!` functions are the locked validation sites the fr
   (validate-sub! sub-id query-v value sub-meta frame)
   ```
 - **Description**: After a subscription recomputes, validate its return value against any `:schema` on the sub's registration metadata.
-  - On failure emits `:rf.error/schema-validation-failure :where :sub-return`; the caller replaces the value with the default (recovery `:replaced-with-default`).
+  - On failure, emits `:rf.error/schema-validation-failure :where :sub-return`. The caller replaces the value with the default (recovery `:replaced-with-default`).
   - The optional `frame` arg stamps a `:frame` tag for epoch capture.
   - Returns `true`/`false`.
 
 ## Boundary validation and redaction seams
 
-These three functions are the production-side and cross-artefact seams. `validate-with-registered-fn` / `explain-with-registered-fn` are the pure check surface the production boundary-validation interceptor (`validate-at-boundary-interceptor`, in [re-frame.core.md](re-frame.core.md)) reaches through the late-bind table; `redact-validation-tags` is the one schema-aware redactor every off-namespace validation-failure emit site routes through.
+These three functions are the production-side and cross-artefact seams. `validate-with-registered-fn` / `explain-with-registered-fn` are the pure check surface used by the production boundary-validation interceptor (`validate-at-boundary-interceptor`, in [re-frame.core.md](re-frame.core.md)), which reaches them through the late-bind table. `redact-validation-tags` is the one schema-aware redactor; every validation-failure emit site outside this namespace routes through it.
 
 ### `validate-with-registered-fn`
 
@@ -220,8 +242,10 @@ These three functions are the production-side and cross-artefact seams. `validat
   ```clojure
   (validate-with-registered-fn schema value) → boolean
   ```
-- **Description**: Apply the registered validator to `(schema, value)`. The public check seam the boundary-validation interceptor uses — it runs in production, outside the `debug-enabled?` gate the `validate-*!` hot path sits behind.
-  - Returns `true` on conform; `false` on fail (including a structurally malformed schema that makes the validator throw — **fail closed**); `true` when no validator is registered (no-validator means no-validation, mirroring the hot path).
+- **Description**: Apply the registered validator to `(schema, value)`. This is the public check seam the boundary-validation interceptor uses. It runs in production, outside the `debug-enabled?` gate the `validate-*!` hot path sits behind.
+  - Returns `true` on conform.
+  - Returns `false` on fail, including when a structurally malformed schema makes the validator throw (**fail closed**).
+  - Returns `true` when no validator is registered. No-validator means no-validation, mirroring the hot path.
   - Does NOT emit a trace (the interceptor owns the failure envelope) and does NOT consult `debug-enabled?`.
 
 ### `explain-with-registered-fn`
@@ -233,7 +257,7 @@ These three functions are the production-side and cross-artefact seams. `validat
   ```
 - **Description**: Apply the registered explainer to `(schema, value)`. Companion to `validate-with-registered-fn` for the boundary interceptor.
   - Returns the explanation map / data on fail.
-  - Returns `nil` when the value conforms, no explainer is registered, or the explainer throws (a throwing explainer degrades to `nil` — diagnostics must never change the verdict).
+  - Returns `nil` when the value conforms, when no explainer is registered, or when the explainer throws. A throwing explainer degrades to `nil` because diagnostics must never change the verdict.
 
 ### `redact-validation-tags`
 
@@ -242,11 +266,11 @@ These three functions are the production-side and cross-artefact seams. `validat
   ```clojure
   (redact-validation-tags schema tags) → tags
   ```
-- **Description**: The shared schema-aware redaction seam for every validation-failure trace emitted OUTSIDE this namespace (the production boundary interceptor, machine `:data` validation, the `:sub-override` path, flow-output validation, and the recordable-coeffect `:rf.error/cofx-value-invalid` emit). Given the `schema` the failing value was checked against and a failure-trace `tags` map, returns the tags with:
-  - a `:sensitive?` schema → value-bearing slots (`:value` / `:received` / `:explain` / `:explain-humanized` / `:rf.fx/args` / `:rf.sub/query-v`) scrubbed to `:rf/redacted`, and `:sensitive? true` stamped. Fails closed on an opaque compiled schema the walker cannot introspect.
-  - a `:large?` (non-sensitive) schema → those slots elided to the `:rf.size/large-elided` marker.
+- **Description**: The shared schema-aware redaction seam for every validation-failure trace emitted OUTSIDE this namespace. Its callers are the production boundary interceptor, machine `:data` validation, the `:sub-override` path, flow-output validation, and the recordable-coeffect `:rf.error/cofx-value-invalid` emit. Given the `schema` the failing value was checked against and a failure-trace `tags` map, it returns the tags with:
+  - a `:sensitive?` schema → the value-bearing slots (`:value` / `:received` / `:explain` / `:explain-humanized` / `:rf.fx/args` / `:rf.sub/query-v`) scrubbed to `:rf/redacted`, and `:sensitive? true` stamped. An opaque compiled schema the walker cannot introspect fails closed and is treated as sensitive.
+  - a `:large?` (non-sensitive) schema → those same slots elided to the `:rf.size/large-elided` marker.
   - otherwise → the tags ride back verbatim.
-  - Off-namespace callers reach it through the `:schemas/redact-validation-tags` late-bind hook and fall through verbatim when the schemas artefact is absent. Idempotent.
+  - Off-namespace callers reach it through the `:schemas/redact-validation-tags` late-bind hook. When the schemas artefact is absent, the tags fall through verbatim. Idempotent.
 
 ## Validator extension seams
 
@@ -283,9 +307,9 @@ The default validator ships Malli's `validate` / `explain` pair (plus an EDN can
   ```
 - **Description**: Atomically install any subset of the validator / explainer / printer bundle from a single map.
   - Each key is optional; an absent key leaves the existing registration in place.
-  - A `nil` `:print` coerces to the default EDN canonicaliser; `:validate` / `:explain` `nil` disable that fn.
-  - Last-write-wins per key; returns the installed bundle map `{:validate … :explain … :print …}` reflecting the live state of all three fns after the call.
-  - The one-call substitute-Malli boot pattern, so the three fns never drift mid-boot.
+  - A `nil` `:print` coerces to the default EDN canonicaliser. A `nil` `:validate` or `:explain` disables that fn.
+  - Last-write-wins per key. Returns the installed bundle map `{:validate … :explain … :print …}`, reflecting the live state of all three fns after the call.
+  - This is the one-call substitute-Malli boot pattern: the three fns never drift mid-boot.
 - **Example**:
   ```clojure
   ;; install validator + explainer together (e.g. a clojure.spec or Zod port)
@@ -344,8 +368,8 @@ The default validator ships Malli's `validate` / `explain` pair (plus an EDN can
   (snapshot-schema-fns) → {:validate fn|nil :explain fn|nil :print fn}
   ```
 - **Description**: Capture the currently-installed validator / explainer / printer bundle as one value, in the same shape `set-schema-fns!` accepts and returns.
-  - The bundle-level companion to `snapshot-schemas-by-frame`; the captured value round-trips losslessly through `restore-schema-fns!`.
-  - Unlike `reset-schema-validator!` (which restores the framework default), this captures whatever custom bundle is currently installed, so a test can restore the *prior* custom bundle.
+  - The bundle-level companion to `snapshot-schemas-by-frame`. The captured value round-trips losslessly through `restore-schema-fns!`.
+  - Unlike `reset-schema-validator!`, which restores the framework default, this captures whatever custom bundle is currently installed. A test can therefore restore the *prior* custom bundle.
   - `:validate` / `:explain` may be `nil`; `:print` is never `nil`.
 
 ### `restore-schema-fns!`
@@ -355,11 +379,15 @@ The default validator ships Malli's `validate` / `explain` pair (plus an EDN can
   ```clojure
   (restore-schema-fns! bundle) → bundle
   ```
-- **Description**: Reinstall a validator / explainer / printer bundle captured by `snapshot-schema-fns` — a full install of all three. Routes through `set-schema-fns!`, so a `nil` `:print` in the bundle coerces to the default printer (the printer-never-nil invariant holds). Returns the installed bundle map.
+- **Description**: Reinstall a validator / explainer / printer bundle captured by `snapshot-schema-fns`. This is a full install of all three. It routes through `set-schema-fns!`, so a `nil` `:print` in the bundle coerces to the default printer — the printer-never-nil invariant holds. Returns the installed bundle map.
 
 ## Schema classification walkers
 
-The pure-data per-slot flag extractors and predicates. They walk a Malli **vector-form** EDN schema and report which slots carry `:sensitive? true` or `:large? true` per-slot props. Consumed by the schema-validation-failure-trace redactor and by the owner-local schema-prop consumers (a machine's `:data-schema`, a resource's data/params schema, the HTTP body-privacy projector, story-mcp's tool-egress projector). They describe **shape**, not durable `app-db` egress policy — durable `app-db` classification is event-owned (a `reg-event` returns `:sensitive` / `:large` alongside `:db`). A compiled / opaque `m/schema` value is treated as an opaque leaf; register the vector form when per-slot flags need to be visible.
+The pure-data per-slot flag extractors and predicates. They walk a Malli **vector-form** EDN schema and report which slots carry `:sensitive? true` or `:large? true` per-slot props.
+
+Two kinds of consumers read them: the schema-validation-failure-trace redactor, and the owner-local schema-prop consumers — a machine's `:data-schema`, a resource's data/params schema, the HTTP body-privacy projector, and story-mcp's tool-egress projector.
+
+They describe **shape**, not durable `app-db` egress policy. Durable `app-db` classification is event-owned: a `reg-event` returns `:sensitive` / `:large` alongside `:db`. A compiled / opaque `m/schema` value is treated as an opaque leaf, so register the vector form when per-slot flags need to be visible.
 
 ### `extract-large-paths-from-schema`
 
@@ -370,7 +398,7 @@ The pure-data per-slot flag extractors and predicates. They walk a Malli **vecto
   ```
 - **Description**: Walk a Malli schema EDN form at `base-path` and return a `{path declaration}` map for every `:large? true` slot found.
   - Each declaration carries `:source :schema`, plus `:hint` propagated verbatim when the slot props carry one.
-  - The pure-data `:large?` extractor the owner-local size-elision consumers read directly; it does NOT feed the `app-db` egress registry (that is frame-owned).
+  - This is the pure-data `:large?` extractor the owner-local size-elision consumers read directly. It does NOT feed the `app-db` egress registry — that registry is frame-owned.
 - **Example**:
   ```clojure
   (schemas/extract-large-paths-from-schema
@@ -385,7 +413,7 @@ The pure-data per-slot flag extractors and predicates. They walk a Malli **vecto
   ```clojure
   (extract-sensitive-paths-from-schema schema base-path) → {path declaration}
   ```
-- **Description**: As `extract-large-paths-from-schema`, for the `:sensitive? true` per-slot flag. Drives the validation-failure-trace redactor's decision about which value-bearing slots to scrub. Memoised by `(schema, base-path)`; clearable for test isolation via `clear-sensitive-paths-cache!`.
+- **Description**: As `extract-large-paths-from-schema`, for the `:sensitive? true` per-slot flag. Drives the validation-failure-trace redactor's decision about which value-bearing slots to scrub. Memoised by `(schema, base-path)`. Clear the memo for test isolation via `clear-sensitive-paths-cache!`.
 
 ### `schema-has-sensitive?`
 
@@ -394,7 +422,7 @@ The pure-data per-slot flag extractors and predicates. They walk a Malli **vecto
   ```clojure
   (schema-has-sensitive? schema) → boolean
   ```
-- **Description**: `true` when the schema declares ANY slot sensitive — either the schema's container-level props carry `:sensitive? true`, or any nested `:sensitive? true` slot lives anywhere inside it. The conservative whole-schema check: when any slot is sensitive, the whole trace's value-bearing slots are redacted.
+- **Description**: `true` when the schema declares ANY slot sensitive. Two cases count: the schema's container-level props carry `:sensitive? true`, or a nested `:sensitive? true` slot lives anywhere inside it. This is the conservative whole-schema check: when any slot is sensitive, the whole trace's value-bearing slots are redacted.
 - **Example**:
   ```clojure
   (schemas/schema-has-sensitive?
@@ -408,7 +436,7 @@ The pure-data per-slot flag extractors and predicates. They walk a Malli **vecto
   ```clojure
   (schema-has-large? schema) → boolean
   ```
-- **Description**: `true` when the schema declares ANY slot `:large? true` — the mirror of `schema-has-sensitive?` on the other per-slot flag. When `true` the validation emit-site substitutes the `:rf.size/large-elided` size marker for the value-bearing slots (unless the slot is also sensitive — sensitive wins).
+- **Description**: `true` when the schema declares ANY slot `:large? true`. The mirror of `schema-has-sensitive?` on the other per-slot flag. When `true`, the validation emit-site substitutes the `:rf.size/large-elided` size marker for the value-bearing slots. When a slot is also sensitive, sensitive wins.
 
 ### `schema-sensitive-at?`
 
@@ -417,9 +445,9 @@ The pure-data per-slot flag extractors and predicates. They walk a Malli **vecto
   ```clojure
   (schema-sensitive-at? schema in-path) → boolean
   ```
-- **Description**: Path-targeted sensitivity check. `true` when the slot at `in-path` is sensitive — either an **ancestor** along the path is `:sensitive?` (the failing slot sits under a sensitive container) or a **descendant** of the slot is `:sensitive?` (the slot's value carries a sensitive child).
-  - `in-path` is the value-relative path Malli reports as `:in`; a `nil` or empty `in-path` is equivalent to `schema-has-sensitive?`.
-  - The leaf-precise check the `app-db` hot path uses for its narrowed `:value` slot, so a non-sensitive failing leaf whose *sibling* is sensitive is not over-redacted.
+- **Description**: Path-targeted sensitivity check. `true` when the slot at `in-path` is sensitive. Two cases count: an **ancestor** along the path is `:sensitive?` (the failing slot sits under a sensitive container), or a **descendant** of the slot is `:sensitive?` (the slot's value carries a sensitive child).
+  - `in-path` is the value-relative path Malli reports as `:in`. A `nil` or empty `in-path` is equivalent to `schema-has-sensitive?`.
+  - This is the leaf-precise check the `app-db` hot path uses for its narrowed `:value` slot. A non-sensitive failing leaf whose *sibling* is sensitive is therefore not over-redacted.
 
 ### `schema-opaque?`
 
@@ -428,11 +456,11 @@ The pure-data per-slot flag extractors and predicates. They walk a Malli **vecto
   ```clojure
   (schema-opaque? schema) → boolean
   ```
-- **Description**: `true` when `schema` is a compiled / opaque value the pure-data walker cannot introspect for per-slot flags — a non-vector, non-keyword form (a compiled `malli.core/schema` object, a map, a fn). A bare keyword (`:int`, `:string`, a registry ref) is NOT opaque. The redaction path fails closed on an opaque schema (redacts as if sensitive, since Malli may honour a `:sensitive?` slot the walker cannot see); the supported way to make per-slot flags visible is registering the vector form.
+- **Description**: `true` when `schema` is a compiled / opaque value the pure-data walker cannot introspect for per-slot flags. That means any non-vector, non-keyword form: a compiled `malli.core/schema` object, a map, a fn. A bare keyword (`:int`, `:string`, a registry ref) is NOT opaque. The redaction path fails closed on an opaque schema — it redacts as if sensitive, since Malli may honour a `:sensitive?` slot the walker cannot see. The supported way to make per-slot flags visible is registering the vector form.
 
 ## Test-support
 
-The per-frame registry and diagnostic-latch maintenance hooks. `re-frame.test-support`'s reset-runtime fixture drives the snapshot / restore / clear trio through late-bind hooks; the `clear-*` latch resetters and cache clearers let a test start each case from a clean diagnostic + cache slate. `on-frame-destroyed!` is the framework's own frame-teardown cleanup.
+The per-frame registry and diagnostic-latch maintenance hooks. `re-frame.test-support`'s reset-runtime fixture drives the snapshot / restore / clear trio through late-bind hooks. The `clear-*` latch resetters and cache clearers let a test start each case from a clean diagnostic + cache slate. `on-frame-destroyed!` is the framework's own frame-teardown cleanup.
 
 ### `snapshot-schemas-by-frame`
 
@@ -496,7 +524,7 @@ The per-frame registry and diagnostic-latch maintenance hooks. `re-frame.test-su
   (clear-edn-print-cache!)
   ```
 - **Description**: Reset the `app-schemas-digest` printer memo. Returns `nil`.
-  - Test-support only: the memo is process-lifetime and bounded by the registered-schema cardinality (schemas register once at boot), so production never needs this.
+  - Test-support only. The memo is process-lifetime and bounded by the registered-schema cardinality (schemas register once at boot), so production never needs this.
   - A test that registers many distinct fresh schemas clears it in fixture teardown so the cache doesn't grow unbounded across the suite.
 
 ### `clear-sensitive-paths-cache!`

--- a/docs/api/re-frame.ssr.md
+++ b/docs/api/re-frame.ssr.md
@@ -1,6 +1,11 @@
 # re-frame.ssr
 
-Server-side rendering and hydration. `re-frame.ssr` runs the same framework as the client — same registrations, cascade, `app-db`, and subs — with four differences: the request creates a per-request frame, the cascade runs to completion before the response is built, the resulting hiccup is emitted as an HTML string, and a hydration payload ships alongside so the client resumes without re-rendering.
+Server-side rendering and hydration. `re-frame.ssr` runs the same framework as the client: the same registrations, cascade, `app-db`, and subs. Four things differ on the server:
+
+- each request creates a per-request frame;
+- the cascade runs to completion before the response is built;
+- the resulting hiccup is emitted as an HTML string;
+- a hydration payload ships alongside, so the client resumes without re-rendering.
 
 Ships in a separate artefact (`day8/re-frame2-ssr`); add it to your deps and require the namespace. The Ring host-adapter lives in [`re-frame.ssr.ring`](re-frame.ssr.ring.md).
 
@@ -8,7 +13,7 @@ Ships in a separate artefact (`day8/re-frame2-ssr`); add it to your deps and req
 (:require [re-frame.ssr :as ssr])
 ```
 
-A curated set of render and head primitives is re-exported on the `re-frame.core` facade as late-bound wrappers: `rf/render-to-string`, `rf/render-tree-hash`, `rf/project-error`, the registration macros `rf/reg-head` / `rf/reg-error-projector`, and the head accessors `rf/render-head` / `rf/active-head` / `rf/head-model->html` / `rf/head-snapshot` (accessors documented in [`re-frame.core`](re-frame.core.md)). They resolve to this namespace at call time when the artefact is on the classpath, and throw a clear "SSR not loaded" error otherwise. Examples below use `rf/` at idiomatic call sites and `ssr/` for the host-adapter surface.
+The `re-frame.core` facade re-exports a curated set of render and head primitives as late-bound wrappers: `rf/render-to-string`, `rf/render-tree-hash`, `rf/project-error`, the registration macros `rf/reg-head` / `rf/reg-error-projector`, and the head accessors `rf/render-head` / `rf/active-head` / `rf/head-model->html` / `rf/head-snapshot` (accessors documented in [`re-frame.core`](re-frame.core.md)). When the artefact is on the classpath, these wrappers resolve to this namespace at call time. When it is not, they throw a clear "SSR not loaded" error. Examples below use `rf/` at idiomatic call sites and `ssr/` for the host-adapter surface.
 
 ## Rendering primitives
 
@@ -20,9 +25,17 @@ A curated set of render and head primitives is re-exported on the `re-frame.core
   (render-to-string view-or-hiccup opts) → HTML string
   ```
 - **Description**: The canonical server-side render. Walks the hiccup tree once and emits a string. Pure and JVM-runnable.
-  - Resolves registered views, `:tag#id.cls` shorthand, and HTML5 void elements; escapes text and attribute values.
-  - `opts` keys (all optional): `:doctype?` prefixes `<!DOCTYPE html>`; `:emit-hash?` injects `data-rf-render-hash` on the tree's first DOM-tag element (for client-side mismatch detection); `:render-hash` supplies a precomputed hash to stamp instead, avoiding a second canonical-EDN walk.
-  - Raises: `:rf.error/invalid-tag-name` (malformed tag name), `:rf.error/ssr-invalid-attribute-name` (malformed attribute key), `:rf.error/ssr-raw-text-in-body` (raw string child of a body-position `<script>` / `<style>`), `:rf.error/ssr-reagent-native-head` (a `:>` interop head), `:rf.error/ssr-suspense-boundary-outside-stream` (a `:rf/suspense-boundary` marker reaching this non-streaming emitter).
+  - It resolves registered views, `:tag#id.cls` shorthand, and HTML5 void elements. It escapes text and attribute values.
+  - `opts` keys (all optional):
+    - `:doctype?` — prefixes `<!DOCTYPE html>`.
+    - `:emit-hash?` — injects `data-rf-render-hash` on the tree's first DOM-tag element, for client-side mismatch detection.
+    - `:render-hash` — supplies a precomputed hash to stamp instead, avoiding a second canonical-EDN walk.
+  - Raises:
+    - `:rf.error/invalid-tag-name` — malformed tag name.
+    - `:rf.error/ssr-invalid-attribute-name` — malformed attribute key.
+    - `:rf.error/ssr-raw-text-in-body` — a raw string child of a body-position `<script>` / `<style>`.
+    - `:rf.error/ssr-reagent-native-head` — a `:>` interop head.
+    - `:rf.error/ssr-suspense-boundary-outside-stream` — a `:rf/suspense-boundary` marker reached this non-streaming emitter.
 - **Example**:
   ```clojure
   (rf/with-new-frame [f (rf/make-frame {:images [app-image]})]
@@ -37,7 +50,7 @@ A curated set of render and head primitives is re-exported on the `re-frame.core
   ```clojure
   (render-tree-hash render-tree) → 32-bit FNV-1a structural hash (lowercase hex)
   ```
-- **Description**: A deterministic structural fingerprint of a render tree. The same canonical-EDN representation produces the same hash on JVM and CLJS. Drives the hydration compatibility check — a server/client hash mismatch means hydration is unsafe.
+- **Description**: A deterministic structural fingerprint of a render tree. The same canonical-EDN representation produces the same hash on JVM and CLJS. This hash drives the hydration compatibility check: a server/client hash mismatch means hydration is unsafe.
 - **Example**:
   ```clojure
   ;; Capture the hash at render time; it rides the hydration payload as
@@ -54,7 +67,7 @@ A curated set of render and head primitives is re-exported on the `re-frame.core
   ```clojure
   (install-render-to-string! set-hiccup-emitter!-fn)
   ```
-- **Description**: Install this namespace's `render-to-string` into a substrate adapter's `:render-to-string` slot. For hosts wiring a custom (non-bundled) adapter directly. The bundled Reagent adapter wires itself via the `:reagent/set-hiccup-emitter!` late-bind hook, so app code rarely calls this.
+- **Description**: Install this namespace's `render-to-string` into a substrate adapter's `:render-to-string` slot. Use it when wiring a custom (non-bundled) adapter directly. The bundled Reagent adapter wires itself via the `:reagent/set-hiccup-emitter!` late-bind hook, so app code rarely calls this.
 
 ### `adapter`
 
@@ -63,9 +76,9 @@ A curated set of render and head primitives is re-exported on the `re-frame.core
   ```clojure
   ssr/adapter   ;; the SSR substrate adapter map
   ```
-- **Description**: The SSR substrate adapter map — the server-side / headless (JVM) substrate. Pass to `rf/init!` to install it.
-  - Carries this namespace's `render-to-string` directly in its `:render-to-string` slot, so no late-bind wiring is needed at the call site.
-  - Its `:render` slot throws `:rf.error/render-on-headless-adapter` — SSR renders via `render-to-string` exclusively.
+- **Description**: The SSR substrate adapter map: the server-side / headless (JVM) substrate. Pass it to `rf/init!` to install it.
+  - It carries this namespace's `render-to-string` directly in its `:render-to-string` slot, so no late-bind wiring is needed at the call site.
+  - Its `:render` slot throws `:rf.error/render-on-headless-adapter`. SSR renders exclusively via `render-to-string`.
 - **Example**:
   ```clojure
   (rf/init! ssr/adapter)
@@ -73,7 +86,7 @@ A curated set of render and head primitives is re-exported on the `re-frame.core
 
 ## Streaming render
 
-Streaming emits the shell HTML first, then continues rendering boundary subtrees as their data settles. The render tree marks boundaries with `:rf/suspense-boundary`; each becomes a continuation.
+Streaming emits the shell HTML first, then continues rendering boundary subtrees as their data settles. The render tree marks boundaries with `:rf/suspense-boundary`. Each boundary becomes a continuation.
 
 ### `streaming-render-shell`
 
@@ -83,7 +96,7 @@ Streaming emits the shell HTML first, then continues rendering boundary subtrees
   (streaming-render-shell root-hiccup)
     → {:shell-html "..." :continuations [{:id :subtree} ...]}
   ```
-- **Description**: Walk the tree once. At each `:rf/suspense-boundary`, emit a `<template …suspense-fallback>` placeholder and record a continuation. Returns the shell HTML (ready to flush) and the continuations to drain.
+- **Description**: Walk the tree once. At each `:rf/suspense-boundary`, it emits a `<template …suspense-fallback>` placeholder and records a continuation. Returns the shell HTML (ready to flush) and the continuations to drain.
 - **Example**:
   ```clojure
   ;; Host adapter: render the shell to flush immediately, keep the continuations.
@@ -102,9 +115,9 @@ Streaming emits the shell HTML first, then continues rendering boundary subtrees
     → {:id :html :delta :failed? :continuations}
   ```
 - **Description**: Drain one continuation against `frame-id`'s app-db.
-  - Snapshots before-db / after-db and computes the per-subtree delta.
-  - A nested `:rf/suspense-boundary` inside the subtree registers a new continuation, returned under `:continuations` for the host to append at the tail of its FIFO drain queue (`[]` when the subtree carries none).
-  - On a throw: emits `:rf.ssr/suspense-boundary-failed`, surfaces the original fallback HTML inline with `:failed? true`, omits `:delta`, and returns no nested continuations.
+  - It snapshots before-db / after-db and computes the per-subtree delta.
+  - A nested `:rf/suspense-boundary` inside the subtree registers a new continuation. New continuations come back under `:continuations`, for the host to append at the tail of its FIFO drain queue (`[]` when the subtree carries none).
+  - On a throw, it emits `:rf.ssr/suspense-boundary-failed`, surfaces the original fallback HTML inline with `:failed? true`, omits `:delta`, and returns no nested continuations.
 - **Example**:
   ```clojure
   ;; Drain the FIFO queue against fid's app-db, emitting each chunk;
@@ -125,8 +138,8 @@ Streaming emits the shell HTML first, then continues rendering boundary subtrees
   (streaming-build-final-payload frame-id render-hash opts)
     → canonical :rf/hydration-payload
   ```
-- **Description**: Populate the `__rf_payload` final chunk after all continuations drain.
-  - `opts` **MUST** carry the fail-closed `:payload` policy: a vector allowlist of top-level app-db keys, or `:rf.ssr.payload/whole-app-db` to ship the whole app-db. Absence throws `:rf.error/ssr-missing-payload-policy`.
+- **Description**: Build the `__rf_payload` final chunk. Call it after all continuations drain.
+  - `opts` **MUST** carry the fail-closed `:payload` policy: a vector allowlist of top-level app-db keys, or `:rf.ssr.payload/whole-app-db` to ship the whole app-db. Omitting it throws `:rf.error/ssr-missing-payload-policy`.
   - Optional `:version` overrides the `:rf2/runtime-version` late-bind hook as the payload's `:rf/version` source.
 - **Example**:
   ```clojure
@@ -136,7 +149,7 @@ Streaming emits the shell HTML first, then continues rendering boundary subtrees
       fid render-hash {:version 1 :payload :rf.ssr.payload/whole-app-db}))
   ```
 
-The following are the lower-level chunk-template builders the streaming host emits per boundary — host-adapter territory, rarely called by app code.
+The next four functions are the lower-level chunk-template builders the streaming host emits per boundary. They are host-adapter territory; app code rarely calls them.
 
 ### `streaming-fallback-template`
 
@@ -145,7 +158,7 @@ The following are the lower-level chunk-template builders the streaming host emi
   ```clojure
   (streaming-fallback-template id fallback-html) → HTML string
   ```
-- **Description**: The fallback chunk shape — the boundary's fallback markup wrapped in an inline `<template data-rf2-suspense-fallback>` placeholder in the shell HTML. A `<template>`'s content is inert (never painted), so it is the wire-carrier for the fallback markup; the client-side streaming runtime materialises each inert fallback into a live, visible mount.
+- **Description**: The fallback chunk shape: the boundary's fallback markup, wrapped in an inline `<template data-rf2-suspense-fallback>` placeholder in the shell HTML. A `<template>`'s content is inert (never painted), which makes it the wire-carrier for the fallback markup. The client-side streaming runtime materialises each inert fallback into a live, visible mount.
 
 ### `streaming-resolved-template`
 
@@ -154,7 +167,7 @@ The following are the lower-level chunk-template builders the streaming host emi
   ```clojure
   (streaming-resolved-template id resolved-html) → HTML string
   ```
-- **Description**: The resolved-subtree chunk shape — flushed when a continuation drains successfully. The client-side streaming runtime swaps the matching fallback placeholder for this resolved content in the DOM.
+- **Description**: The resolved-subtree chunk shape, flushed when a continuation drains successfully. The client-side streaming runtime swaps the matching fallback placeholder for this resolved content in the DOM.
 
 ### `streaming-failed-template`
 
@@ -163,7 +176,7 @@ The following are the lower-level chunk-template builders the streaming host emi
   ```clojure
   (streaming-failed-template id fallback-html) → HTML string
   ```
-- **Description**: The failed-continuation chunk shape — the same wire shape as `streaming-resolved-template` plus a `data-rf2-suspense-failed` marker. Inline-fallback failure semantics: the client-side runtime surfaces the failure observably without surfacing a 500.
+- **Description**: The failed-continuation chunk shape: the same wire shape as `streaming-resolved-template`, plus a `data-rf2-suspense-failed` marker. The failure semantics are inline-fallback: the client-side runtime surfaces the failure observably, without surfacing a 500.
 
 ### `streaming-hydrate-delta-script`
 
@@ -174,7 +187,7 @@ The following are the lower-level chunk-template builders the streaming host emi
   ```
 - **Description**: The per-subtree hydration delta chunk (`application/edn`). The client reads the EDN and merges the delta into `app-db` as the subtree streams in.
 
-The streaming surface is host-adapter territory — the SSR-aware host ([`re-frame.ssr.ring`](re-frame.ssr.ring.md) or equivalent) wires it. Most app code interacts via the host adapter and never touches `streaming-render-*` directly. The one app-facing piece is the client-side runtime, below.
+The streaming surface is host-adapter territory. The SSR-aware host ([`re-frame.ssr.ring`](re-frame.ssr.ring.md) or equivalent) wires it, so most app code never touches `streaming-render-*` directly. The one app-facing piece is the client-side runtime, below.
 
 ### `streaming-install!`
 
@@ -184,9 +197,12 @@ The streaming surface is host-adapter territory — the SSR-aware host ([`re-fra
   (streaming-install! opts) → stop! (0-arity fn)
   ```
 - **Description**: Install the client-side streaming runtime. Returns a 0-arity `stop!` fn that disconnects the observer early. Idempotent per chunk.
-  - Observes the document for arriving chunks: materialises each inert fallback `<template>` into a visible mount, swaps in resolved subtrees, and merges each per-subtree hydration delta into the `:frame`'s app-db.
-  - Disconnects itself once the final `__rf_payload` node lands (the bootstrap's `:rf/hydrate` is the canonical reconciliation).
-  - `opts`: `:frame` (**REQUIRED** — an absent frame emits + throws `:rf.error/no-frame-context`); `:root` (the DOM root to observe, default `js/document`); `:payload-id` (the final-payload `<script>` id, default `"__rf_payload"`).
+  - It observes the document for arriving chunks. As they land, it materialises each inert fallback `<template>` into a visible mount, swaps in resolved subtrees, and merges each per-subtree hydration delta into the `:frame`'s app-db.
+  - It disconnects itself once the final `__rf_payload` node lands. From there, the bootstrap's `:rf/hydrate` is the canonical reconciliation.
+  - `opts`:
+    - `:frame` — **REQUIRED**. An absent frame emits + throws `:rf.error/no-frame-context`.
+    - `:root` — the DOM root to observe; default `js/document`.
+    - `:payload-id` — the final-payload `<script>` id; default `"__rf_payload"`.
 - **Example**:
   ```clojure
   ;; Streaming-aware bootstrap: install BEFORE the first chunks can land
@@ -196,7 +212,7 @@ The streaming surface is host-adapter territory — the SSR-aware host ([`re-fra
 
 ## The head model
 
-The `<head>` is modelled separately from the body as a head-model — a data structure carrying `:title`, `:meta`, `:link`, `:json-ld`, `:html-attrs`, `:body-attrs`, registered per-route with `reg-head`. A registered head-fn is evaluated and rendered through the `re-frame.core` facade accessors `render-head` / `active-head` / `head-model->html` / `head-snapshot` (documented in [`re-frame.core`](re-frame.core.md)). The [`:rf/head`](#subscriptions) subscription returns the active route's head-model.
+The `<head>` is modelled separately from the body as a head-model: a data structure carrying `:title`, `:meta`, `:link`, `:json-ld`, `:html-attrs`, and `:body-attrs`. Head-models are registered per-route with `reg-head`. A registered head-fn is evaluated and rendered through the `re-frame.core` facade accessors `render-head` / `active-head` / `head-model->html` / `head-snapshot` (documented in [`re-frame.core`](re-frame.core.md)). The [`:rf/head`](#subscriptions) subscription returns the active route's head-model.
 
 ### `reg-head`
 
@@ -214,7 +230,7 @@ The `<head>` is modelled separately from the body as a head-model — a data str
        :meta  [{:name "description" :content (:summary db)}]}))
   ```
 
-*Exposed on the `re-frame.core` facade as `rf/reg-head` (there is no `re-frame.ssr/reg-head` alias); the brief facade entry in [`re-frame.core`](re-frame.core.md) points here for the full contract.*
+*Exposed on the `re-frame.core` facade as `rf/reg-head`; there is no `re-frame.ssr/reg-head` alias. The brief facade entry in [`re-frame.core`](re-frame.core.md) points here for the full contract.*
 
 ## Hydration
 
@@ -226,7 +242,7 @@ Three checks guard hydration, each with its own trace:
 - `:rf.ssr/version-mismatch` — the payload was produced by a different framework version.
 - `:rf.ssr/schema-digest-mismatch` — the app's schema set drifted since the payload was built.
 
-The latter two are payload-provenance checks the reference `:rf/hydrate` handler runs; `hydration-mismatch` guards the render-tree structural hash. See [the SSR tutorial §The client side](../ssr/concepts.md#the-client-side-hydrate-then-verify).
+The latter two are payload-provenance checks; the reference `:rf/hydrate` handler runs them. `hydration-mismatch` guards the render-tree structural hash. See [the SSR tutorial §The client side](../ssr/concepts.md#the-client-side-hydrate-then-verify).
 
 ### `hydrate!`
 
@@ -235,7 +251,7 @@ The latter two are payload-provenance checks the reference `:rf/hydrate` handler
   ```clojure
   (hydrate! opts) → applied-payload | nil
   ```
-- **Description**: Client-side boot helper — the symmetric counterpart of the server's `re-frame.ssr.ring/ssr-handler`. Returns the payload that was applied, or `nil` on a client-only first load. Fuses the three mandated client-flow steps:
+- **Description**: The client-side boot helper, and the symmetric counterpart of the server's `re-frame.ssr.ring/ssr-handler`. Returns the payload that was applied, or `nil` on a client-only first load. It fuses the three mandated client-flow steps:
   1. **read** the payload — supplied via `:payload`, or on CLJS read from the DOM's `__rf_payload` `<script>` via [`read-server-payload`](#read-server-payload).
   2. **hydrate** via `dispatch-sync [:rf/hydrate payload]` against the target `:frame` before the first render (locked `:replace-frame-state` semantics).
   3. **verify** by calling the supplied `:render-tree-fn` and comparing its hash against the server hash (omit `:render-tree-fn` to skip).
@@ -259,7 +275,7 @@ The latter two are payload-provenance checks the reference `:rf/hydrate` handler
   (read-server-payload)            → payload-map | nil
   (read-server-payload element-id) → payload-map | nil
   ```
-- **Description**: Read the EDN hydration payload from the DOM's `__rf_payload` `<script>` (the pinned default id; pass `element-id` to read a host-overridden slot). `hydrate!` calls this when `:payload` is omitted.
+- **Description**: Read the EDN hydration payload from the DOM's `__rf_payload` `<script>`. That id is the pinned default; pass `element-id` to read a host-overridden slot. `hydrate!` calls this when `:payload` is omitted.
   - Returns the parsed payload map, or `nil` when the page was not server-rendered (no payload script present).
   - Fails closed: a malformed payload script surfaces `:rf.error/malformed-hydration-payload` and returns `nil`, so the host falls back to a client-only first render.
 - **Example**:
@@ -277,10 +293,10 @@ The latter two are payload-provenance checks the reference `:rf/hydrate` handler
   (verify-hydration! frame-id render-tree)
   (verify-hydration! frame-id render-tree opts)
   ```
-- **Description**: Called by client code after the first render. Compares the post-render hash to the server hash stashed during `:rf/hydrate`; on disagreement emits `:rf.ssr/hydration-mismatch`. `hydrate!` calls this for you when given a `:render-tree-fn`; call it directly when the host must verify the actually-mounted tree.
+- **Description**: Called by client code after the first render. It compares the post-render hash to the server hash stashed during `:rf/hydrate`, and emits `:rf.ssr/hydration-mismatch` on disagreement. `hydrate!` calls this for you when given a `:render-tree-fn`. Call it directly when the host must verify the actually-mounted tree.
   - The second argument may be a render tree (it is hashed) or a pre-computed hash string.
   - `opts` may carry `:first-diff-path`, `:failing-id`, and `:server-hash` (the last overrides the stashed slot).
-  - Two per-frame `:ssr` knobs govern behaviour: `{:detect-mismatch? false}` skips the comparison; `{:on-mismatch :hard-error}` escalates a detected mismatch to a thrown structured exception (default `:warn` → `:warned-and-replaced`).
+  - Two per-frame `:ssr` knobs govern behaviour. `{:detect-mismatch? false}` skips the comparison. `{:on-mismatch :hard-error}` escalates a detected mismatch to a thrown structured exception; the default `:warn` resolves to `:warned-and-replaced`.
 - **Example**:
   ```clojure
   ;; Host that mounts first, then verifies the mounted tree explicitly.
@@ -289,7 +305,7 @@ The latter two are payload-provenance checks the reference `:rf/hydrate` handler
 
 ## Error projection
 
-A frame opts into SSR error projection via the `:ssr {:public-error-id ... :dev-error-detail? ...}` map on its `reg-frame` / `make-frame` metadata. This is **per-frame metadata**, not a `configure` key — different frames in the same process can carry different projector / dev-detail settings.
+A frame opts into SSR error projection via the `:ssr {:public-error-id ... :dev-error-detail? ...}` map on its `reg-frame` / `make-frame` metadata. This is **per-frame metadata**, not a `configure` key: different frames in the same process can carry different projector / dev-detail settings.
 
 ### `reg-error-projector`
 
@@ -316,9 +332,9 @@ A frame opts into SSR error projection via the `:ssr {:public-error-id ... :dev-
   ```clojure
   (project-error frame-id trace-event) → :rf/public-error
   ```
-- **Description**: Apply the named frame's active error-projector (selected by its `:ssr {:public-error-id ...}` metadata) to a trace event. The seam between an internal error trace event (full diagnostic detail) and a client-safe public-error projection.
+- **Description**: Apply the named frame's active error-projector to a trace event. The projector is selected by the frame's `:ssr {:public-error-id ...}` metadata. This is the seam between an internal error trace event (full diagnostic detail) and a client-safe public-error projection.
   - When the frame's `:ssr {:dev-error-detail? true}` metadata is set, the projection carries an extra `:details` key with the raw trace event (absent by default).
-  - If the projector throws or returns a non-conforming shape, emits `:rf.error/sanitised-on-projection` and returns the locked generic-500 [`fallback-public-error`](#fallback-public-error) — the boundary cannot be bypassed by a bug in the projector.
+  - If the projector throws or returns a non-conforming shape, this emits `:rf.error/sanitised-on-projection` and returns the locked generic-500 [`fallback-public-error`](#fallback-public-error). A bug in the projector cannot bypass the boundary.
   - `reg-error-projector` (above) registers the projector this applies.
 - **Example**:
   ```clojure
@@ -338,7 +354,7 @@ A frame opts into SSR error projection via the `:ssr {:public-error-id ... :dev-
 - **Description**: The runtime's built-in default projector, registered under `:rf.ssr/default-error-projector`. Maps trace events to public errors:
   - `:rf.error/no-such-handler`, `:rf.error/no-such-route` → `404 :not-found`.
   - `:rf.error/cofx-value-invalid` (a client-supplied coeffect rejected at the dispatch boundary) → `400 :bad-request`.
-  - `:rf.error/schema-validation-failure` → `400 :bad-request` only when the failure's `:where` tag is `:event` (a client-supplied event payload); server-side surfaces such as `:where :fx-args` fall through.
+  - `:rf.error/schema-validation-failure` → `400 :bad-request`, but only when the failure's `:where` tag is `:event` (a client-supplied event payload). Server-side surfaces such as `:where :fx-args` fall through.
   - Everything else → the locked generic `500 :internal-error` ([`fallback-public-error`](#fallback-public-error)).
 
 ### `apply-error-projection!`
@@ -349,10 +365,10 @@ A frame opts into SSR error projection via the `:ssr {:public-error-id ... :dev-
   (apply-error-projection! frame-id)
   (apply-error-projection! frame-id trace-event)
   ```
-- **Description**: Project an error trace event via `frame-id`'s active projector and stamp the resulting public-error's `:status` onto the response accumulator. Returns the public-error map, or `nil` on a no-op (frame missing / not a server frame / no pending trace).
+- **Description**: Project an error trace event via `frame-id`'s active projector, and stamp the resulting public-error's `:status` onto the response accumulator. Returns the public-error map. Returns `nil` on a no-op: the frame is missing, is not a server frame, or has no pending trace.
   - 1-arity: drains the frame's error-trace buffer and projects the LAST trace (last-write-wins).
   - 2-arity: projects the supplied trace directly (for hosts that catch errors outside the trace stream).
-  - When the response already carries a `:redirect`, its status is locked through — the projection returns the public-error map but does not overwrite `:status`.
+  - When the response already carries a `:redirect`, its status is locked through. The projection still returns the public-error map, but does not overwrite `:status`.
 
 ### `project-render-exception!`
 
@@ -361,10 +377,10 @@ A frame opts into SSR error projection via the `:ssr {:public-error-id ... :dev-
   ```clojure
   (project-render-exception! frame-id throwable) → :rf/public-error | nil
   ```
-- **Description**: Route a render-time `Throwable` through `frame-id`'s SSR error projector. Host adapters wrap their `render-to-string` call and route render-time throws through this. Returns the public-error map (the host's contract for rendering the wire error body), or `nil` when projection is not applicable.
-  - Synthesises a `:rf.error/ssr-render-failed` trace carrying the exception and drives the projector (via `apply-error-projection!`), stamping the response accumulator's `:status` with the projector's output.
-  - Also emits the trace so monitoring listeners see the rich internal detail.
-  - Per-frame dev escape-hatch `:ssr {:on-view-exception :throw}` re-throws unchanged instead of projecting.
+- **Description**: Route a render-time `Throwable` through `frame-id`'s SSR error projector. Host adapters wrap their `render-to-string` call with this. Returns the public-error map (the host's contract for rendering the wire error body), or `nil` when projection is not applicable.
+  - It synthesises a `:rf.error/ssr-render-failed` trace carrying the exception, then drives the projector via `apply-error-projection!`. The projector's output stamps the response accumulator's `:status`.
+  - It also emits the trace, so monitoring listeners see the rich internal detail.
+  - The per-frame dev escape-hatch `:ssr {:on-view-exception :throw}` re-throws unchanged instead of projecting.
 
 ### `public-error-keys`
 
@@ -383,13 +399,13 @@ A frame opts into SSR error projection via the `:ssr {:public-error-id ... :dev-
   fallback-public-error
   ;; => {:status 500 :code :internal-error :message "Something went wrong" :retryable? false}
   ```
-- **Description**: The locked generic-500 public-error shape. The runtime falls back to this whenever the active projector throws or returns a non-conforming shape — the boundary cannot be bypassed by a bug in the projector.
+- **Description**: The locked generic-500 public-error shape. The runtime falls back to this whenever the active projector throws or returns a non-conforming shape. A bug in the projector cannot bypass the boundary.
 
 Full rationale: [the SSR tutorial §When the server throws](../ssr/concepts.md#when-the-server-throws).
 
 ## The response accumulator
 
-Each per-request frame accumulates its HTTP response — status, headers, cookies, redirect — in a framework-private side-channel keyed by frame-id (not in `app-db`, so it never rides the hydration payload to the client). The server-only [`:rf.server/*` fx](#server-only-fx) write into it; these functions read the resolved value. `get-response` is the canonical host-adapter alias; `peek-response` and `flush-response!` split the pure read from the side-effecting drain.
+Each per-request frame accumulates its HTTP response (status, headers, cookies, redirect) in a framework-private side-channel keyed by frame-id. The accumulator lives outside `app-db`, so it never rides the hydration payload to the client. The server-only [`:rf.server/*` fx](#server-only-fx) write into it, and the functions below read the resolved value. `get-response` is the canonical host-adapter alias. `peek-response` and `flush-response!` split the pure read from the side-effecting drain.
 
 ### `default-response`
 
@@ -415,7 +431,7 @@ Each per-request frame accumulates its HTTP response — status, headers, cookie
   ```clojure
   (get-response frame-id) → response-map
   ```
-- **Description**: Read the resolved response accumulator for a frame — the canonical host-adapter alias for the drain-then-read sequence. Flushes any pending error projections before reading (so `:status` reflects the active projector's output), then strips the internal bookkeeping keys. Use `peek-response` for a pure read (no drain) and `flush-response!` for the explicit-side-effect spelling.
+- **Description**: Read the resolved response accumulator for a frame. This is the canonical host-adapter alias for the drain-then-read sequence: it flushes any pending error projections before reading, so `:status` reflects the active projector's output, and then strips the internal bookkeeping keys. Use `peek-response` for a pure read (no drain) and `flush-response!` for the explicit-side-effect spelling.
 - **Example**:
   ```clojure
   ;; Host adapter: after the drain settles, read the response to build the wire reply.
@@ -430,7 +446,7 @@ Each per-request frame accumulates its HTTP response — status, headers, cookie
   ```clojure
   (peek-response frame-id) → response-map
   ```
-- **Description**: A **pure** read of the resolved response accumulator — does NOT drain pending error projections. Use from debug paths or midpoint inspections where draining the projector buffer (the side-effect baked into `get-response`) would consume a trace the host had not yet observed.
+- **Description**: A **pure** read of the resolved response accumulator. It does NOT drain pending error projections. Use it from debug paths or midpoint inspections, where the drain baked into `get-response` would consume a trace the host had not yet observed.
 
 ### `flush-response!`
 
@@ -439,11 +455,11 @@ Each per-request frame accumulates its HTTP response — status, headers, cookie
   ```clojure
   (flush-response! frame-id) → response-map
   ```
-- **Description**: Drain any pending error projection for `frame-id`, then return the resolved response. Side-effecting — every call clears the projector buffer; the first call after an error trace wins (last-write-wins). This is the explicit-side-effect spelling; `get-response` is the canonical host-adapter alias, `peek-response` the pure-read counterpart.
+- **Description**: Drain any pending error projection for `frame-id`, then return the resolved response. This is side-effecting: every call clears the projector buffer, and the first call after an error trace wins (last-write-wins). This is the explicit-side-effect spelling. `get-response` is the canonical host-adapter alias; `peek-response` is the pure-read counterpart.
 
 ## Request context
 
-An SSR host adapter populates a per-frame request slot once per request (before the drain), and the [`:rf.server/request`](#coeffects) cofx surfaces it to server-side handlers. The slot is cleared as part of per-request frame teardown.
+An SSR host adapter populates a per-frame request slot once per request, before the drain. The [`:rf.server/request`](#coeffects) cofx surfaces it to server-side handlers. The slot is cleared as part of per-request frame teardown.
 
 ### `set-request!`
 
@@ -452,7 +468,7 @@ An SSR host adapter populates a per-frame request slot once per request (before 
   ```clojure
   (set-request! frame-id request) → frame-id
   ```
-- **Description**: Populate the per-frame request slot. Called by an SSR host adapter once per request, before kicking off the drain. The shape of `request` is host-defined (the Ring adapter passes the Ring request map; other adapters pass their native shape) — the runtime never inspects it.
+- **Description**: Populate the per-frame request slot. An SSR host adapter calls this once per request, before kicking off the drain. The shape of `request` is host-defined: the Ring adapter passes the Ring request map, and other adapters pass their native shape. The runtime never inspects it.
 - **Example**:
   ```clojure
   ;; Host adapter: stash the active request before driving the drain.
@@ -466,7 +482,7 @@ An SSR host adapter populates a per-frame request slot once per request (before 
   ```clojure
   (get-request frame-id) → request | nil
   ```
-- **Description**: Read the active request for `frame-id`. Returns `nil` when no host adapter has populated the slot. Public read surface — host adapters and tools may inspect the active request via this fn.
+- **Description**: Read the active request for `frame-id`. Returns `nil` when no host adapter has populated the slot. This is a public read surface: host adapters and tools may inspect the active request via this fn.
 
 ### `clear-request!`
 
@@ -484,7 +500,7 @@ An SSR host adapter populates a per-frame request slot once per request (before 
   ```clojure
   (on-frame-destroyed! frame-id)
   ```
-- **Description**: Per-request frame teardown hook. Drops the frame's entries in the pending-error-trace buffer, the request slot, and the response slot, and invokes the head-snapshot cleanup. Called during per-request frame teardown via the `:ssr/on-frame-destroyed` late-bind hook. Idempotent — a second call against the same frame-id is a no-op.
+- **Description**: The per-request frame teardown hook. It drops the frame's entries in the pending-error-trace buffer, the request slot, and the response slot, and it invokes the head-snapshot cleanup. It runs during per-request frame teardown via the `:ssr/on-frame-destroyed` late-bind hook. Idempotent: a second call against the same frame-id is a no-op.
 
 ## Blocking-resource drain
 
@@ -496,9 +512,12 @@ An SSR host adapter populates a per-frame request slot once per request (before 
   (drain-blocking-resources! frame-id)
   (drain-blocking-resources! frame-id opts)
   ```
-- **Description**: Drain the current nav-token's BLOCKING resources for SSR `frame-id` until they settle or the render deadline fires, so the render walk sees a settled resource state (never a hung `:loading`). The host render path calls this after frame setup + route resolution and before the render walk. Returns the drain result map `{:settled? :timed-out :route-blocking-failure}`.
-  - A no-op returning `{:settled? true}` when the resources artefact is absent — an SSR app without resources never blocks on them.
-  - `opts` keys (all optional): `:ssr-blocking-timeout-ms` (wall-clock budget, default `5000`); `:pump!` (a 1-arity `(fn [tick-ms] …)` event-pump thunk; defaults to a host-platform yield so an in-flight async reply lands between re-checks); `:tick-ms` (poll-granularity hint, default `5`).
+- **Description**: Drain the current nav-token's BLOCKING resources for SSR `frame-id` until they settle or the render deadline fires. This way the render walk sees a settled resource state, never a hung `:loading`. The host render path calls this after frame setup and route resolution, before the render walk. Returns the drain result map `{:settled? :timed-out :route-blocking-failure}`.
+  - When the resources artefact is absent, this is a no-op returning `{:settled? true}`. An SSR app without resources never blocks on them.
+  - `opts` keys (all optional):
+    - `:ssr-blocking-timeout-ms` — wall-clock budget; default `5000`.
+    - `:pump!` — a 1-arity `(fn [tick-ms] …)` event-pump thunk. Defaults to a host-platform yield, so an in-flight async reply lands between re-checks.
+    - `:tick-ms` — poll-granularity hint; default `5`.
 - **Example**:
   ```clojure
   ;; Host render path: settle blocking resources before walking the tree.
@@ -508,14 +527,14 @@ An SSR host adapter populates a per-frame request slot once per request (before 
 
 ## Keyword surfaces
 
-The events, server-only and client-only fx, subscriptions, coeffect, and the `:platforms` registration-metadata key that the SSR runtime owns. These are addressed by keyword, not imported as vars.
+The SSR runtime owns a set of keyword-addressed surfaces: events, server-only and client-only fx, subscriptions, one coeffect, and the `:platforms` registration-metadata key. These are addressed by keyword, not imported as vars.
 
 ### Events
 
 | Event | What it does |
 |---|---|
 | `:rf/server-init` | Per-request server-side initialisation. Reads request cofx; dispatches setup events. `:platforms #{:server}`. |
-| `:rf/hydrate` | Seed the client-side `app-db` from the server-supplied payload (locked `:replace-frame-state` semantics). Runs once on client bootstrap. Fails closed: a non-map payload or a present-but-non-map `:rf/app-db` / `:rf/runtime-db` slice is rejected with `:rf.error/malformed-hydration-payload`, and a payload `:rf/frame-id` naming a different frame than the dispatch target is rejected with `:rf.error/hydration-frame-id-mismatch` — the frame-state is left unchanged in both cases. |
+| `:rf/hydrate` | Seed the client-side `app-db` from the server-supplied payload (locked `:replace-frame-state` semantics). Runs once on client bootstrap. Fails closed. A non-map payload, or a present-but-non-map `:rf/app-db` / `:rf/runtime-db` slice, is rejected with `:rf.error/malformed-hydration-payload`. A payload `:rf/frame-id` naming a different frame than the dispatch target is rejected with `:rf.error/hydration-frame-id-mismatch`. In both cases the frame-state is left unchanged. |
 
 - **Example**:
   ```clojure
@@ -536,7 +555,7 @@ The events, server-only and client-only fx, subscriptions, coeffect, and the `:p
 
 ### Server-only fx
 
-All server-only — `:platforms #{:server}`. These build the response accumulator that the host adapter turns into the HTTP response.
+All seven fx are server-only (`:platforms #{:server}`). They build the response accumulator that the host adapter turns into the HTTP response.
 
 | Fx | Args |
 |---|---|
@@ -546,14 +565,14 @@ All server-only — `:platforms #{:server}`. These build the response accumulato
 | `[:rf.server/set-cookie :rf.server/cookie]` | structured cookie map |
 | `[:rf.server/delete-cookie {:name ?:path ?:domain}]` | — |
 | `[:rf.server/redirect {:location ?:status}]` | default `:status 302`; truncates HTML. **Caller-trusted** `:location`. |
-| `[:rf.server/safe-redirect {:location ?:relative-only? ?:allow ?:status}]` | The caller-untrusted variant — open-redirect mitigation for attacker-controlled `?next=` strings. Before setting `:redirect`, it parses `:location` (`:rf.error/safe-redirect-invalid-url`), rejects `javascript:` / `data:` / `vbscript:` schemes (`:rf.error/safe-redirect-scheme-rejected`), and enforces `:relative-only?` / `:allow` allowlist (`:rf.error/safe-redirect-host-disallowed`). |
+| `[:rf.server/safe-redirect {:location ?:relative-only? ?:allow ?:status}]` | The caller-untrusted variant: open-redirect mitigation for attacker-controlled `?next=` strings. Before setting `:redirect`, it parses `:location` (`:rf.error/safe-redirect-invalid-url`), rejects `javascript:` / `data:` / `vbscript:` schemes (`:rf.error/safe-redirect-scheme-rejected`), and enforces the `:relative-only?` / `:allow` allowlist (`:rf.error/safe-redirect-host-disallowed`). |
 
 Boundary validation (all seven):
 
-- A header name violating the RFC 7230 token grammar throws `:rf.error/header-invalid-name`; a header value carrying CR/LF/NUL throws `:rf.error/header-invalid-value`.
-- A cookie `:name` violating the RFC 6265 token grammar (or of an unsupported type) throws `:rf.error/cookie-invalid-name`; any other cookie attribute (`:value` / `:path` / `:domain` / `:max-age` / `:same-site` / `:expires`) carrying CR/LF/NUL throws the single `:rf.error/cookie-invalid-attribute`, naming the offending attribute in its `:attribute` payload slot.
-- A redirect `:location` carrying CR/LF/NUL throws `:rf.error/redirect-invalid-location`; the retired `:url` / `:to` target keys throw `:rf.error/redirect-retired-target-key`.
-- `:status` and `:redirect` are last-write-wins — a second write in the same drain emits `:rf.warning/multiple-status-set` / `:rf.warning/multiple-redirects`.
+- A header name violating the RFC 7230 token grammar throws `:rf.error/header-invalid-name`. A header value carrying CR/LF/NUL throws `:rf.error/header-invalid-value`.
+- A cookie `:name` violating the RFC 6265 token grammar, or of an unsupported type, throws `:rf.error/cookie-invalid-name`. Any other cookie attribute (`:value` / `:path` / `:domain` / `:max-age` / `:same-site` / `:expires`) carrying CR/LF/NUL throws the single `:rf.error/cookie-invalid-attribute`, which names the offending attribute in its `:attribute` payload slot.
+- A redirect `:location` carrying CR/LF/NUL throws `:rf.error/redirect-invalid-location`. The retired `:url` / `:to` target keys throw `:rf.error/redirect-retired-target-key`.
+- `:status` and `:redirect` are last-write-wins. A second write in the same drain emits `:rf.warning/multiple-status-set` / `:rf.warning/multiple-redirects`.
 
 - **Example**:
   ```clojure
@@ -586,12 +605,12 @@ Boundary validation (all seven):
 
 ### Client-only fx
 
-Both `:platforms #{:client}` — the payload-provenance compatibility checks the reference `:rf/hydrate` handler dispatches after installing the server slice. Best-effort: a mismatch emits a structured warning trace and hydration proceeds.
+Both fx are client-only (`:platforms #{:client}`). They are the payload-provenance compatibility checks that the reference `:rf/hydrate` handler dispatches after installing the server slice. They are best-effort: a mismatch emits a structured warning trace, and hydration proceeds.
 
 | Fx | Args |
 |---|---|
-| `[:rf.ssr/check-version server-value]` | A scalar (the payload's `:rf/version`) or `{:expected ?:actual}`. When `:actual` is absent the client value resolves via the `:rf2/runtime-version` late-bind hook. Mismatch emits `:rf.ssr/version-mismatch`; an unresolvable client value emits `:rf.ssr/compatibility-check-skipped`. |
-| `[:rf.ssr/check-schema-digest server-value]` | A scalar (the payload's `:rf/schema-digest`) or `{:expected ?:actual}`. When `:actual` is absent the client value resolves via the `:schemas/app-schemas-digest` late-bind hook (schemas artefact). Mismatch emits `:rf.ssr/schema-digest-mismatch`; an absent hook emits `:rf.ssr/compatibility-check-skipped`. |
+| `[:rf.ssr/check-version server-value]` | A scalar (the payload's `:rf/version`) or `{:expected ?:actual}`. When `:actual` is absent, the client value resolves via the `:rf2/runtime-version` late-bind hook. A mismatch emits `:rf.ssr/version-mismatch`. An unresolvable client value emits `:rf.ssr/compatibility-check-skipped`. |
+| `[:rf.ssr/check-schema-digest server-value]` | A scalar (the payload's `:rf/schema-digest`) or `{:expected ?:actual}`. When `:actual` is absent, the client value resolves via the `:schemas/app-schemas-digest` late-bind hook (schemas artefact). A mismatch emits `:rf.ssr/schema-digest-mismatch`. An absent hook emits `:rf.ssr/compatibility-check-skipped`. |
 
 ### Subscriptions
 
@@ -604,7 +623,7 @@ Both `:platforms #{:client}` — the payload-provenance compatibility checks the
 >
 > **NOT USED** — `:rf/public-error` is never subscribed (no `[:rf/public-error]` call sites, and no `reg-sub :rf/public-error`) in `implementation/`, `examples/`, or `tools/`. The `:rf/public-error` *map shape* is produced by `project-error`; only the **sub** is unused.
 
-The current request's **response accumulator** (status / headers / cookies / redirect) is *not* a registered subscription. It lives in a framework-private side-channel atom keyed by frame-id and is read exclusively by the runtime via `re-frame.ssr/get-response`; the host adapter consumes the resolved value to build the wire response.
+The current request's **response accumulator** (status / headers / cookies / redirect) is *not* a registered subscription. It lives in a framework-private side-channel atom keyed by frame-id, and the runtime reads it exclusively via `re-frame.ssr/get-response`. The host adapter consumes the resolved value to build the wire response.
 
 ### Coeffects
 
@@ -625,7 +644,7 @@ The current request's **response accumulator** (status / headers / cookies / red
 
 ### `:platforms` fx-gating metadata
 
-`reg-fx` accepts a `:platforms` metadata key — a set containing `:server` and / or `:client` — that gates fx execution by active platform. Default `#{:server :client}` (universal) when the key is absent.
+`reg-fx` accepts a `:platforms` metadata key: a set containing `:server` and / or `:client`. It gates fx execution by active platform. When the key is absent, the default is `#{:server :client}` (universal).
 
 ```clojure
 (rf/reg-fx :my/fx

--- a/docs/api/re-frame.ssr.ring.md
+++ b/docs/api/re-frame.ssr.ring.md
@@ -1,6 +1,6 @@
 # re-frame.ssr.ring
 
-The Ring/Pedestal host adapter for re-frame2 server-side rendering. It materialises the structured response produced by the SSR runtime in [`re-frame.ssr`](re-frame.ssr.md) into the wire format a Ring-compatible server expects; it never writes to a socket directly. The per-request lifecycle, rendering / head primitives, SSR events / subs / cofx, and the `:rf.server/*` fx all live in [`re-frame.ssr`](re-frame.ssr.md) (artefact `day8/re-frame2-ssr`), not here.
+The Ring/Pedestal host adapter for re-frame2 server-side rendering. It materialises the structured response produced by the SSR runtime in [`re-frame.ssr`](re-frame.ssr.md) into the wire format a Ring-compatible server expects. It never writes to a socket directly. The per-request lifecycle, the rendering and head primitives, the SSR events / subs / cofx, and the `:rf.server/*` fx all live in [`re-frame.ssr`](re-frame.ssr.md) (artefact `day8/re-frame2-ssr`), not here.
 
 Ships in the `day8/re-frame2-ssr-ring` artefact. See [Server-side rendering — the tutorial](../ssr/concepts.md) for the conceptual walkthrough.
 
@@ -19,20 +19,26 @@ Ships in the `day8/re-frame2-ssr-ring` artefact. See [Server-side rendering — 
   ```
 - **Description**: Returns a synchronous Ring handler that renders one re-frame2 SSR request per call.
 
-  The returned handler owns the whole per-request lifecycle: populate the per-frame request slot; register the per-request frame (draining `:initial-events` synchronously so the `:rf.server/request` cofx can resolve); read the resolved response accumulator; branch on `:redirect`; otherwise render `:root-view`, build the hydration payload, wrap it in the HTML shell, materialise structured cookies to `Set-Cookie` headers; and destroy the frame in a `finally`.
+  The returned handler owns the whole per-request lifecycle:
+
+  1. Populate the per-frame request slot.
+  2. Register the per-request frame, draining `:initial-events` synchronously so the `:rf.server/request` cofx can resolve.
+  3. Read the resolved response accumulator, and branch on `:redirect`.
+  4. Otherwise, render `:root-view`, build the hydration payload, wrap it in the HTML shell, and materialise structured cookies to `Set-Cookie` headers.
+  5. Destroy the frame in a `finally`.
 
   Required opts:
 
-  - `:initial-events` — an ordered vector of events dispatched synchronously, in order, into the per-request frame at creation; or a `(fn [request] → initial-events-vector)` that derives the vector from the Ring request. The fn form is the replay-safe seam for folding a request-derived fact into a boot event's payload, e.g. `(fn [req] [[:auth/server-init {:user (extract-user req)}]])`. For non-durable request reads inside a handler, declare `:rf.cofx/requires [:rf.server/request]` on the registration instead.
+  - `:initial-events` — an ordered vector of events, dispatched synchronously and in order into the per-request frame at creation. Alternatively, a `(fn [request] → initial-events-vector)` that derives the vector from the Ring request. The fn form is the replay-safe seam for folding a request-derived fact into a boot event's payload, e.g. `(fn [req] [[:auth/server-init {:user (extract-user req)}]])`. For non-durable request reads inside a handler, declare `:rf.cofx/requires [:rf.server/request]` on the registration instead.
     - Omission throws `:rf.error/ssr-ring-missing-initial-events` at construction.
     - A value that is neither a vector nor a fn, or a fn returning a non-vector, throws `:rf.error/invalid-initial-events` per request.
   - `:root-view` — a hiccup vector (e.g. `[:app/root]`) or a 0-arity fn returning hiccup, rendered against the per-request frame after the drain settles.
     - Omission throws `:rf.error/ssr-ring-missing-root-view` at construction.
     - Any other shape throws `:rf.error/invalid-root-view` at render time.
   - `:payload` — **REQUIRED, fail-closed.** The hydration-payload policy, one opt with two shapes:
-    - A non-empty vector of top-level app-db keys (keywords) is an allowlist (recommended): only the listed keys ship in `:rf/app-db`; every other key is dropped, including keys added later.
-    - The keyword `:rf.ssr.payload/whole-app-db` ships the whole `app-db` (use only when the app-db is structurally safe to expose).
-    - Absence or an empty allowlist throws `:rf.error/ssr-missing-payload-policy`; an unrecognised keyword throws `:rf.error/ssr-unknown-payload-policy`; an allowlist with non-keyword entries throws `:rf.error/ssr-malformed-payload-allowlist`. All three throw at construction.
+    - A non-empty vector of top-level app-db keys (keywords) is an allowlist (recommended). Only the listed keys ship in `:rf/app-db`. Every other key is dropped, including keys added later.
+    - The keyword `:rf.ssr.payload/whole-app-db` ships the whole `app-db`. Use it only when the app-db is structurally safe to expose.
+    - Absence or an empty allowlist throws `:rf.error/ssr-missing-payload-policy`. An unrecognised keyword throws `:rf.error/ssr-unknown-payload-policy`. An allowlist with non-keyword entries throws `:rf.error/ssr-malformed-payload-allowlist`. All three throw at construction.
 
   Optional opts:
 
@@ -44,13 +50,13 @@ Ships in the `day8/re-frame2-ssr-ring` artefact. See [Server-side rendering — 
   - `:html-shell` — `(body-html payload-edn opts) → string`; defaults to [`default-html-shell`](#default-html-shell).
   - `:content-type` — default `"text/html; charset=utf-8"`.
 
-  Error handling — `:error-view` vs `:on-error`. Two opts handle two different failures; a robust deployment wires both. A buggy `:error-view` falls back to the default template and a buggy `:on-error` falls back to `default-on-error` — neither bug bypasses the error boundary.
+  Error handling — `:error-view` vs `:on-error`. These two opts handle two different failures, and a robust deployment wires both. A buggy `:error-view` falls back to the default template; a buggy `:on-error` falls back to `default-on-error`. Neither bug bypasses the error boundary.
 
   | Aspect | `:error-view` | `:on-error` |
   |---|---|---|
-  | Which failure? | An exception inside the re-frame drain or the render walk — something the error projector catches. | A transport / Ring-layer failure the projector cannot see — per-request frame setup throw, render-time CLJ exception, header/cookie materialise throw, a thrown initial-event. |
-  | What does it produce? | The projected error-page body (hiccup) — a registered-view keyword (resolved as `[error-view public-error]`) or a `(public-error) → hiccup` fn, rendered through the standard SSR emitter. | A raw Ring response map `{:status … :headers … :body …}` returned verbatim to the server. |
-  | What is its input? | The public-error map (sanitised by the projector — safe to render). | The raw `(request throwable)` — the unsanitised throwable. The locked default never reads it. |
+  | Which failure? | An exception inside the re-frame drain or the render walk. The error projector catches these. | A transport / Ring-layer failure the projector cannot see: a per-request frame setup throw, a render-time CLJ exception, a header/cookie materialise throw, or a thrown initial-event. |
+  | What does it produce? | The projected error-page body (hiccup): a registered-view keyword (resolved as `[error-view public-error]`) or a `(public-error) → hiccup` fn. It renders through the standard SSR emitter. | A raw Ring response map `{:status … :headers … :body …}` returned verbatim to the server. |
+  | What is its input? | The public-error map, sanitised by the projector and safe to render. | The raw `(request throwable)`, carrying the unsanitised throwable. The locked default never reads it. |
   | Default when omitted? | Minimal default error template. | Minimal locked 500 ([`default-on-error`](#default-on-error), topology-leak-safe). |
 
   Trusted shell-hook string opts. Four optional strings cross the trust boundary into the rendered HTML envelope, split by injection position:
@@ -58,7 +64,7 @@ Ships in the `day8/re-frame2-ssr-ring` artefact. See [Server-side rendering — 
   - `:head` and `:body-end` — raw content hooks, injected verbatim with no escaping.
   - `:script-src` (default `"/main.js"`) and `:app-element-id` (default `"app"`) — escaped attribute hooks, escape-attr'd into a quoted attribute value.
 
-  Non-string non-nil values throw `:rf.error/ssr-trusted-shell-opt-invalid` at construction. Wiring the raw content hooks from untrusted input (CMS field, tenant-admin form, query-string parameter) is an arbitrary-script-injection XSS vector — use the structured alternatives ([`reg-head`](re-frame.ssr.md) for head fragments, registered views + the [`:rf.server/*` fx](re-frame.ssr.md) for body content) when content originates upstream of the trust boundary.
+  Non-string non-nil values throw `:rf.error/ssr-trusted-shell-opt-invalid` at construction. Wiring the raw content hooks from untrusted input (a CMS field, a tenant-admin form, a query-string parameter) is an arbitrary-script-injection XSS vector. When content originates upstream of the trust boundary, use the structured alternatives: [`reg-head`](re-frame.ssr.md) for head fragments, and registered views plus the [`:rf.server/*` fx](re-frame.ssr.md) for body content.
 - **Example**:
   ```clojure
   (require '[ring.adapter.jetty :as jetty]
@@ -88,24 +94,24 @@ Ships in the `day8/re-frame2-ssr-ring` artefact. See [Server-side rendering — 
   ```clojure
   (stream-handler opts) → (fn [ring-request] ring-response)
   ```
-- **Description**: The streaming counterpart of `ssr-handler` — returns a synchronous Ring handler that streams SSR responses via `Transfer-Encoding: chunked`.
+- **Description**: The streaming counterpart of `ssr-handler`. Returns a synchronous Ring handler that streams SSR responses via `Transfer-Encoding: chunked`.
 
   Streaming behaviour:
 
   - Flushes a shell on the first byte, then streams `:rf/suspense-boundary` subtrees as their data resolves.
-  - A boundary whose drain changed app-db also carries a speculative per-subtree hydration delta, projected through the same `:payload` policy as the final payload; an off-allowlist or empty delta emits no delta script.
+  - A boundary whose drain changed app-db also carries a speculative per-subtree hydration delta, projected through the same `:payload` policy as the final payload. An off-allowlist or empty delta emits no delta script.
   - The final chunk carries the canonical full hydration payload. If a speculative delta and the canonical payload ever disagree, the payload wins.
   - Failure isolation is per-boundary: a boundary whose render throws keeps its fallback (with a `:rf.ssr/suspense-boundary-failed` trace) while the rest of the page streams on.
-  - Non-streaming responses (no `:rf/suspense-boundary` in the tree) still ride the chunked path with zero continuations, collapsing the wire shape to shell-prefix + shell-html + final-payload + shell-suffix.
+  - Non-streaming responses (no `:rf/suspense-boundary` in the tree) still ride the chunked path, with zero continuations. The wire shape collapses to shell-prefix + shell-html + final-payload + shell-suffix.
   - A `:redirect` set during the drain short-circuits to a bodiless Location response before any chunk is written.
-  - The shell renders on the request thread before the chunked head commits: a root-view / shell-walk throw fails closed to a non-200 projected error page (`:rf.error/ssr-render-failed` via the projector) with no writer thread spawned.
+  - The shell renders on the request thread, before the chunked head commits. A root-view or shell-walk throw fails closed to a non-200 projected error page (`:rf.error/ssr-render-failed` via the projector), with no writer thread spawned.
   - Any `Content-Length` header accumulated during the drain is stripped (case-insensitively) so the host server owns chunked transfer framing.
 
   Opts mirror `ssr-handler`: `:initial-events` (both vector and `(fn [request] → …)` forms), `:root-view`, `:payload`, `:fx-overrides`, `:ssr`, `:on-error`, `:error-view`, `:emit-hash?`, `:version`, `:schema-digest`, `:content-type`, plus the four trusted shell-hook opts (`:head` / `:body-end` / `:script-src` / `:app-element-id`, honoured by [`default-streaming-prefix`](#default-streaming-prefix) / [`default-streaming-suffix`](#default-streaming-suffix)).
 
-  One exception: `:html-shell` is not supported and is rejected at construction (`:rf.error/ssr-streaming-unsupported-opt`). The streaming path flushes a split prefix/suffix straddling the continuation chunks, so a one-piece shell callback can never run — customise the streaming envelope through the trusted shell-hook opts, or use `ssr-handler` when a bespoke one-piece shell is required.
+  One exception: `:html-shell` is not supported and is rejected at construction (`:rf.error/ssr-streaming-unsupported-opt`). The streaming path flushes a split prefix/suffix straddling the continuation chunks, so a one-piece shell callback can never run. Customise the streaming envelope through the trusted shell-hook opts, or use `ssr-handler` when a bespoke one-piece shell is required.
 
-  Concurrency model: one raw daemon `java.lang.Thread` per in-flight streamed request — no framework pool and no framework in-flight cap. Every writer's `catch`/`finally` closes the pipe and tears the frame down on every exit path (no-leak). The in-flight ceiling is the host server's accept-queue / worker-thread limit (Jetty / http-kit / Aleph), which operators size as the one knob for high streaming concurrency or slow-client hardening.
+  Concurrency model: one raw daemon `java.lang.Thread` per in-flight streamed request. There is no framework pool and no framework in-flight cap. Every writer's `catch`/`finally` closes the pipe and tears the frame down on every exit path (no-leak). The in-flight ceiling is the host server's accept-queue / worker-thread limit (Jetty / http-kit / Aleph). Operators size that limit as the one knob for high streaming concurrency or slow-client hardening.
 - **Example**:
   ```clojure
   (require '[ring.adapter.jetty :as jetty]
@@ -132,7 +138,7 @@ Ships in the `day8/re-frame2-ssr-ring` artefact. See [Server-side rendering — 
   ```
 - **Description**: Returns Ring middleware that delegates to `ssr-handler` for requests its `:match?` predicate accepts, and to the wrapped handler otherwise. Curried: `(ssr-middleware opts)` returns a `(handler) → wrapped-handler` middleware.
 
-  Opts are `ssr-handler`'s opts (including the required, fail-closed `:payload`) plus `:match?` — a `(request) → boolean` predicate. When truthy, SSR renders; when falsy, the call falls through to the wrapped handler. `:match?` defaults to matching every GET request.
+  Opts are `ssr-handler`'s opts (including the required, fail-closed `:payload`) plus `:match?`, a `(request) → boolean` predicate. When it returns truthy, SSR renders. When it returns falsy, the call falls through to the wrapped handler. `:match?` defaults to matching every GET request.
 - **Example**:
   ```clojure
   ;; ssr-middleware is CURRIED: (ssr-middleware opts) returns a Ring
@@ -160,7 +166,7 @@ Ships in the `day8/re-frame2-ssr-ring` artefact. See [Server-side rendering — 
   ;;     :html-shell   default-html-shell
   ;;     :content-type "text/html; charset=utf-8"}
   ```
-- **Description**: The default `ssr-handler` opts merged under caller-supplied opts at construction (caller values win). A data var, not a fn — exposed so callers can read or extend the baseline. `:on-error` is deliberately absent: it is resolved separately so the defaults stay orthogonal to the on-error precedence.
+- **Description**: The default `ssr-handler` opts, merged under caller-supplied opts at construction (caller values win). This is a data var, not a fn. It is exposed so callers can read or extend the baseline. `:on-error` is deliberately absent: it is resolved separately, so the defaults stay orthogonal to the on-error precedence.
 - **Example**:
   ```clojure
   ;; Read the baseline the handler constructor merges under your opts.
@@ -185,9 +191,9 @@ Ships in the `day8/re-frame2-ssr-ring` artefact. See [Server-side rendering — 
 
   Behaviour:
 
-  - The hydration-payload `<script>` is stamped with the framework-pinned id `__rf_payload` (the client bootstrap reads it via `document.getElementById("__rf_payload")`), and its EDN body is escaped EDN-aware so a payload containing `</script>` cannot close the envelope. A custom shell must emit the payload `<script>` under this id (with equivalent escaping), or substitute its own bootstrap that reads a custom id.
-  - `<title>` is not emitted by the shell; the head fragment threaded in as `:head` is the canonical source.
-  - The two attribute-value hooks (`:script-src`, `:app-element-id`) are escape-attr'd; the two content hooks (`:head`, `:body-end`) are injected raw.
+  - The hydration-payload `<script>` is stamped with the framework-pinned id `__rf_payload`; the client bootstrap reads it via `document.getElementById("__rf_payload")`. Its EDN body is escaped EDN-aware, so a payload containing `</script>` cannot close the envelope. A custom shell must emit the payload `<script>` under this id, with equivalent escaping, or substitute its own bootstrap that reads a custom id.
+  - The shell does not emit `<title>`. The head fragment threaded in as `:head` is the canonical source.
+  - The two attribute-value hooks (`:script-src`, `:app-element-id`) are escape-attr'd. The two content hooks (`:head`, `:body-end`) are injected raw.
 - **Example**:
   ```clojure
   ;; The default envelope, invoked directly (the handler does this for you).
@@ -206,9 +212,9 @@ Ships in the `day8/re-frame2-ssr-ring` artefact. See [Server-side rendering — 
   ```clojure
   (default-on-error request throwable) → ring-response
   ```
-- **Description**: The minimal 500 response used when a handler caller omits `:on-error`. Shared by `ssr-handler` and `stream-handler` so the topology-leak contract lives in one place. Covers exceptions the SSR error projector can't see (Ring-layer throws, render-time CLJ exceptions, writer-thread-pre-spawn throws); trace-emitted drain errors are handled by the projector instead.
+- **Description**: The minimal 500 response used when a handler caller omits `:on-error`. Shared by `ssr-handler` and `stream-handler`, so the topology-leak contract lives in one place. It covers exceptions the SSR error projector can't see: Ring-layer throws, render-time CLJ exceptions, and writer-thread-pre-spawn throws. Trace-emitted drain errors are handled by the projector instead.
 
-  The body must not leak the throwable's message (`.getMessage` carries internal topology — JDBC URLs, deploy-root file paths, partial SQL, server-internal class names), so the fn ignores the throwable and emits a fixed generic plaintext body. Apps wanting a branded transport-failure body supply an explicit leak-safe `:on-error` fn that returns a fixed response and ignores the throwable. Exposed as a value — a 2-arity fn, not a `defn`, so it carries no `:arglists`.
+  The body must not leak the throwable's message: `.getMessage` carries internal topology, such as JDBC URLs, deploy-root file paths, partial SQL, and server-internal class names. So the fn ignores the throwable and emits a fixed generic plaintext body. Apps wanting a branded transport-failure body supply an explicit leak-safe `:on-error` fn that returns a fixed response and ignores the throwable. Exposed as a value: a 2-arity fn, not a `defn`, so it carries no `:arglists`.
 - **Example**:
   ```clojure
   ;; The host-locked transport-failure net (used when :on-error is omitted).
@@ -227,12 +233,12 @@ Ships in the `day8/re-frame2-ssr-ring` artefact. See [Server-side rendering — 
   ```clojure
   (default-streaming-prefix head-html opts) → HTML string
   ```
-- **Description**: The shell prefix flushed as the first streamed chunk — it mirrors `default-html-shell`'s open + `<head>` + body-open + app-div-open, and shares the `:html-attrs` / `:lang` fallback with the non-streaming shell so the two envelopes can't diverge.
+- **Description**: The shell prefix flushed as the first streamed chunk. It mirrors `default-html-shell`'s open + `<head>` + body-open + app-div-open. It also shares the `:html-attrs` / `:lang` fallback with the non-streaming shell, so the two envelopes can't diverge.
 
   - `head-html` — the resolved head fragment.
   - `opts` — honours `:html-attrs` / `:body-attrs` / `:lang` (default `"en"`) / `:app-element-id` (default `"app"`) / `:render-hash`.
 
-  When `:render-hash` is supplied (the handler passes it iff `:emit-hash?` is true), `data-rf-render-hash` is stamped on the `#app` div — the first DOM root of the streamed document — mirroring the non-streaming handler's root-element marker.
+  When `:render-hash` is supplied (the handler passes it iff `:emit-hash?` is true), `data-rf-render-hash` is stamped on the `#app` div, the first DOM root of the streamed document. This mirrors the non-streaming handler's root-element marker.
 - **Example**:
   ```clojure
   ;; The first streamed chunk — open + <head> + <body> + app-div-open.
@@ -251,7 +257,7 @@ Ships in the `day8/re-frame2-ssr-ring` artefact. See [Server-side rendering — 
   ```
 - **Description**: The shell suffix flushed after the final-payload chunk. It emits the bootstrap `<script>` (if `:script-src` is set; default `"/main.js"`, escape-attr'd), the raw `:body-end` HTML, and the document close (`</body></html>`).
 
-  The app root (`</div>`) is not closed here: it is closed at the end of the shell chunk, so the resolved templates, hydration-delta scripts, and the final `__rf_payload` script all stream outside `#app`. The suffix is therefore purely bootstrap script + raw `:body-end` + document close — all already outside `#app`, mirroring the non-streaming `default-html-shell`.
+  The app root (`</div>`) is not closed here. It is closed at the end of the shell chunk, so the resolved templates, hydration-delta scripts, and the final `__rf_payload` script all stream outside `#app`. The suffix is therefore purely bootstrap script + raw `:body-end` + document close. All of it is already outside `#app`, mirroring the non-streaming `default-html-shell`.
 - **Example**:
   ```clojure
   ;; The trailing chunk — bootstrap <script>, raw :body-end, document close.
@@ -268,7 +274,7 @@ Ships in the `day8/re-frame2-ssr-ring` artefact. See [Server-side rendering — 
   ```clojure
   (cookie->set-cookie-header cookie-map) → Set-Cookie header string
   ```
-- **Description**: Serialises one structured `re-frame.ssr` cookie map to a `Set-Cookie` header value per RFC 6265 §4.1. Re-exposed from the façade so tests, alternate host adapters (Pedestal, http-kit), and user code needing a one-off serialisation can reach it without an internal namespace.
+- **Description**: Serialises one structured `re-frame.ssr` cookie map to a `Set-Cookie` header value, per RFC 6265 §4.1. It is re-exposed from the façade so that tests, alternate host adapters (Pedestal, http-kit), and user code needing a one-off serialisation can reach it without an internal namespace.
 
   Fields:
 
@@ -278,9 +284,9 @@ Ships in the `day8/re-frame2-ssr-ring` artefact. See [Server-side rendering — 
 
   Validation is fail-loud:
 
-  - `:name` must be a string or keyword/symbol and match the RFC 6265 §4.1.1 token grammar; either violation throws `:rf.error/cookie-invalid-name`.
+  - `:name` must be a string or a keyword/symbol, and it must match the RFC 6265 §4.1.1 token grammar. Either violation throws `:rf.error/cookie-invalid-name`.
   - A missing `:name` throws `:rf.error/cookie-missing-name`.
-  - `:domain` / `:path` / `:max-age` / `:same-site` are checked for CR / LF / NUL before concatenation (throws `:rf.error/cookie-invalid-attribute`) to close header-splitting injection.
+  - `:domain` / `:path` / `:max-age` / `:same-site` are checked for CR / LF / NUL before concatenation; a violation throws `:rf.error/cookie-invalid-attribute`. This closes header-splitting injection.
   - A non-integer `:expires` throws `:rf.error/cookie-invalid-expires`.
 - **Example**:
   ```clojure

--- a/docs/api/re-frame.test-helpers.md
+++ b/docs/api/re-frame.test-helpers.md
@@ -1,8 +1,8 @@
 # re-frame.test-helpers
 
-`re-frame.test-helpers` is the view-tree assertion axis of the testing surface. A view is a function that returns [hiccup](../core/glossary.md#hiccup); these helpers walk that returned data structure — locate nodes by `:data-testid` (or any attribute), read their text, and pluck or invoke an attached event handler. The walk helpers are pure functions over hiccup data. The whole surface — single-frame fixture trio included — is JVM-runnable with no JSDOM, no React, and no `act()`.
+`re-frame.test-helpers` is the view-tree assertion axis of the testing surface. A view is a function that returns [hiccup](../core/glossary.md#hiccup). These helpers walk that returned data structure: they locate nodes by `:data-testid` (or any attribute), read their text, and pluck or invoke an attached event handler. The walk helpers are pure functions over hiccup data. The whole surface, single-frame fixture trio included, runs on the JVM with no JSDOM, no React, and no `act()`.
 
-Pairs with `render-to-string` in [re-frame.ssr.md](re-frame.ssr.md) (the HTML-string view-test path): use hiccup-walk when asserting on *structure* or *handlers*, `render-to-string` when asserting on rendered *markup*. The runtime-state axis (registrar fixtures, `dispatch-sequence`, the `assert-*-equals` family) lives in [re-frame.test-support.md](re-frame.test-support.md); a test needing both `:require`s both.
+This namespace pairs with `render-to-string` in [re-frame.ssr.md](re-frame.ssr.md), the HTML-string view-test path. Use the hiccup walkers when asserting on *structure* or *handlers*. Use `render-to-string` when asserting on rendered *markup*. The runtime-state axis (registrar fixtures, `dispatch-sequence`, the `assert-*-equals` family) lives in [re-frame.test-support.md](re-frame.test-support.md). A test that needs both axes `:require`s both namespaces.
 
 ```clojure
 (:require [re-frame.test-helpers :as th])
@@ -17,10 +17,10 @@ Pairs with `render-to-string` in [re-frame.ssr.md](re-frame.ssr.md) (the HTML-st
   ```clojure
   (expand-tree tree) → tree
   ```
-- **Description**: Recursively expand function components (including Form-2 fn-returning-fn components) and Form-3 class components inside a hiccup tree, invoking each with its args as Reagent's renderer would. After expansion every vector's first element is a keyword tag or a non-component value.
+- **Description**: Recursively expand the components inside a hiccup tree, invoking each with its args just as Reagent's renderer would. This covers function components, Form-2 fn-returning-fn components, and Form-3 class components. After expansion, every vector's first element is a keyword tag or a non-component value.
 
-  - Form-3 classes expand by calling the stashed `:reagent-render` fn directly — no React instantiation, no lifecycle methods (on the JVM, class detection is a no-op).
-  - The `find-*` / `text-content` walkers expand internally; call this directly only to re-expand a sub-tree mid-walk.
+  - Form-3 classes expand by calling the stashed `:reagent-render` fn directly. No React is instantiated and no lifecycle methods run. (On the JVM, class detection is a no-op.)
+  - The `find-*` and `text-content` walkers already expand internally. Call `expand-tree` directly only to re-expand a sub-tree mid-walk.
 - **Example**:
   ```clojure
   (th/expand-tree [parent-view {:n 5}])  ; => hiccup whose vectors all start
@@ -50,7 +50,7 @@ Pairs with `render-to-string` in [re-frame.ssr.md](re-frame.ssr.md) (the HTML-st
   ```clojure
   (children node) → vector
   ```
-- **Description**: Return everything after the tag (and optional attrs map). Always a vector — empty when the node has no children; `nil` for non-vector input.
+- **Description**: Return everything after the tag and the optional attrs map. The result is always a vector, and it is empty when the node has no children. Non-vector input returns `nil`.
 - **Example**:
   ```clojure
   (th/children [:div {:k 1} "a" "b"])  ; => ["a" "b"]
@@ -64,7 +64,7 @@ Pairs with `render-to-string` in [re-frame.ssr.md](re-frame.ssr.md) (the HTML-st
   ```clojure
   (text-content node) → string
   ```
-- **Description**: Recursively collect string leaves under `node` (expanding nested components) and join. Numbers coerce to strings; nils are skipped; empty result is `""`.
+- **Description**: Recursively collect the string leaves under `node`, expanding nested components along the way, and join them into one string. Numbers coerce to strings and nils are skipped. When nothing matches, the result is `""`.
 - **Example**:
   ```clojure
   (th/text-content [:div "Count: " [:b 5]])  ; => "Count: 5"
@@ -93,7 +93,7 @@ Pairs with `render-to-string` in [re-frame.ssr.md](re-frame.ssr.md) (the HTML-st
   ```clojure
   (find-by-attr tree attr val) → node
   ```
-- **Description**: First hiccup node whose attrs map carries `attr == val`, or `nil`. Generic over the attribute keyword (`:data-testid`, `:id`, `:data-test`, custom).
+- **Description**: Return the first hiccup node whose attrs map carries `attr == val`, or `nil` when nothing matches. It is generic over the attribute keyword: `:data-testid`, `:id`, `:data-test`, or anything custom.
 - **Example**:
   ```clojure
   ;; Generic over the attribute keyword.
@@ -108,7 +108,7 @@ Pairs with `render-to-string` in [re-frame.ssr.md](re-frame.ssr.md) (the HTML-st
   ```clojure
   (find-all-by-attr tree attr val) → vector
   ```
-- **Description**: Every matching node, in depth-first order.
+- **Description**: Return every matching node, in depth-first order.
 - **Example**:
   ```clojure
   (th/find-all-by-attr tree :data-test "row")  ; => every matching node
@@ -121,7 +121,7 @@ Pairs with `render-to-string` in [re-frame.ssr.md](re-frame.ssr.md) (the HTML-st
   ```clojure
   (find-by-attr-prefix tree attr prefix) → vector
   ```
-- **Description**: Every node whose `attr` value (a string) starts with `prefix`. Non-string attr values do not match.
+- **Description**: Return every node whose `attr` value is a string starting with `prefix`. Non-string attr values never match.
 - **Example**:
   ```clojure
   ;; Matches "row-1", "row-2", … — non-string attr values never match.
@@ -181,10 +181,10 @@ Pairs with `render-to-string` in [re-frame.ssr.md](re-frame.ssr.md) (the HTML-st
   ```clojure
   (invoke-handler node event-key & args) → any
   ```
-- **Description**: Find the handler under `event-key` on `node`, call it with `args`, and return its value. Throws (a missing handler is treated as a test bug):
+- **Description**: Find the handler under `event-key` on `node`, call it with `args`, and return its value. A missing handler is treated as a test bug, so this throws:
 
   - `:rf.error/invoke-handler-bad-node` — `node` is not a hiccup vector.
-  - `:rf.error/invoke-handler-missing` — no handler fn under `event-key` (including the no-attrs-map case).
+  - `:rf.error/invoke-handler-missing` — no handler fn exists under `event-key` (including when the node has no attrs map at all).
 - **Example**:
   ```clojure
   (let [btn (th/find-by-testid tree "counter-inc")]
@@ -201,7 +201,7 @@ Pairs with `render-to-string` in [re-frame.ssr.md](re-frame.ssr.md) (the HTML-st
   (testid id) → map
   (testid id extra) → map
   ```
-- **Description**: Build an attrs map carrying `:data-testid id`. The 2-arity merges `extra` into the map; `:data-testid` always wins on collision. Use at the view call site; pair with `find-by-testid` at the assertion site.
+- **Description**: Build an attrs map carrying `:data-testid id`. The 2-arity merges `extra` into that map, and `:data-testid` always wins on collision. Use it at the view call site. Pair it with `find-by-testid` at the assertion site.
 - **Example**:
   ```clojure
   [:button (th/testid "counter-inc" {:on-click #(rf/dispatch [:counter/inc])})
@@ -211,7 +211,7 @@ Pairs with `render-to-string` in [re-frame.ssr.md](re-frame.ssr.md) (the HTML-st
 
 ## Single-frame e2e fixture
 
-The trio below — `with-app-fixture`, `expect-text`, `wait-until` — covers the single-frame e2e pattern: create a frame, install handlers, dispatch, assert on the rendered view, destroy the frame. Multi-frame setups use `re-frame.core`'s frame primitives directly. The two dynamic vars carry the fixture-stashed root view that the 2-arity forms of `expect-text` / `wait-until` render against.
+The trio below — `with-app-fixture`, `expect-text`, and `wait-until` — covers the single-frame e2e pattern: create a frame, install handlers, dispatch, assert on the rendered view, then destroy the frame. Multi-frame setups use `re-frame.core`'s frame primitives directly. The two dynamic vars carry the fixture-stashed root view. The 2-arity forms of `expect-text` and `wait-until` render against it.
 
 ### `with-app-fixture`
 
@@ -221,11 +221,18 @@ The trio below — `with-app-fixture`, `expect-text`, `wait-until` — covers th
   (with-app-fixture opts-map frame-id body+)
   (with-app-fixture opts-map          body+)   ; anonymous gensym'd id
   ```
-- **Description**: Bracket `body` with a fresh single-frame fixture. Creates the frame (anonymous, or the supplied `frame-id` — a literal keyword, the discriminator between the two shapes), binds it as the current frame, stashes `:root-view` / `:root-view-args` for the body's dynamic extent, calls the opts' `:install` hook inside that scope, runs `body`, then destroys the frame on exit — success or exception.
+- **Description**: Bracket `body` with a fresh single-frame fixture. In order, the macro:
+
+  - creates the frame — anonymous, or under the supplied `frame-id` (a literal keyword; its presence is what selects between the two shapes);
+  - binds it as the current frame;
+  - stashes `:root-view` / `:root-view-args` for the body's dynamic extent;
+  - calls the opts' `:install` hook inside that scope;
+  - runs `body`;
+  - destroys the frame on exit, whether `body` succeeded or threw.
 
   `opts-map` keys (all optional):
 
-  - `:install` — zero-arg fn run with the frame already bound; typically the `reg-event` / `reg-sub` / `reg-view` calls the test relies on.
+  - `:install` — a zero-arg fn run with the frame already bound. Typically it holds the `reg-event` / `reg-sub` / `reg-view` calls the test relies on.
   - `:root-view` — a hiccup-returning view fn, stashed for the 2-arity assertion forms.
   - `:root-view-args` — args vector passed to `:root-view` (default `[]`).
   - `:frame-config` — extra map merged into the frame config.
@@ -250,11 +257,11 @@ The trio below — `with-app-fixture`, `expect-text`, `wait-until` — covers th
   (expect-text testid expected)
   (expect-text tree testid expected)
   ```
-- **Description**: Assert that the hiccup node carrying `:data-testid testid` has `text-content` equal to `expected`, reporting via `clojure.test/is`. Returns `true` on pass, `false` on fail (the `clojure.test` failure is reported either way).
+- **Description**: Assert that the hiccup node carrying `:data-testid testid` has `text-content` equal to `expected`. Failures report through `clojure.test/is`. Returns `true` on pass and `false` on fail; the `clojure.test` failure is reported either way.
 
-  - 2-arity — renders the fixture-stashed root view (`*current-root-view*`, set by `with-app-fixture`) with `*current-root-view-args*`. Raises `:rf.error/no-root-view` outside a fixture body, or when the fixture supplied no `:root-view`.
-  - 3-arity — walks an explicit `tree`; needs no fixture.
-  - `testid` may be a string (`"counter-display"`) or keyword (`:counter-display`, coerced via `name`); anything else raises `:rf.error/testid-bad-arg`.
+  - The 2-arity renders the fixture-stashed root view (`*current-root-view*`, set by `with-app-fixture`) with `*current-root-view-args*`. It raises `:rf.error/no-root-view` outside a fixture body, or when the fixture supplied no `:root-view`.
+  - The 3-arity walks an explicit `tree` and needs no fixture.
+  - `testid` may be a string (`"counter-display"`) or a keyword (`:counter-display`, coerced via `name`). Anything else raises `:rf.error/testid-bad-arg`.
 - **Example**:
   ```clojure
   ;; 2-arity — against the fixture's :root-view:
@@ -274,17 +281,17 @@ The trio below — `with-app-fixture`, `expect-text`, `wait-until` — covers th
   (wait-until testid expected)
   (wait-until testid expected opts)
   ```
-- **Description**: Bounded-deadline poll until a condition is truthy — the view-test counterpart to `re-frame.test-support/poll-until`. Use for async runs (HTTP, scheduled events, machine `:after` transitions) whose post-condition is observable in the rendered view; for sync runs, `expect-text` after `dispatch-sync` suffices.
+- **Description**: Poll until a condition is truthy, within a bounded deadline. This is the view-test counterpart to `re-frame.test-support/poll-until`. Use it for async runs (HTTP, scheduled events, machine `:after` transitions) whose post-condition shows up in the rendered view. For sync runs, `expect-text` after `dispatch-sync` suffices.
 
-  - Predicate form — polls `(pred)` until truthy or the deadline elapses.
-  - Testid form — polls the fixture-stashed root view until `(text-content (find-by-testid tree testid))` equals `expected`. `testid` may be a string or keyword (coerced via `name`; anything else raises `:rf.error/testid-bad-arg`).
-  - An exception thrown by the predicate/probe counts as a falsey poll, not a propagated error — so a missing fixture root view surfaces as the timeout, not as `:rf.error/no-root-view`.
+  - The predicate form polls `(pred)` until truthy or the deadline elapses.
+  - The testid form polls the fixture-stashed root view until `(text-content (find-by-testid tree testid))` equals `expected`. `testid` may be a string or a keyword (coerced via `name`); anything else raises `:rf.error/testid-bad-arg`.
+  - An exception thrown by the predicate or probe counts as a falsey poll, not a propagated error. So a missing fixture root view surfaces as the timeout, not as `:rf.error/no-root-view`.
   - `opts` (all optional): `:timeout-ms` (default 2000), `:interval-ms` (default 5), `:label`.
 
   Per-platform shape matches `poll-until`:
 
-  - JVM — synchronous; returns the truthy value; on timeout throws `ex-info` carrying `:rf.error/id` `:rf.error/wait-until-timeout` (the canonical discriminator).
-  - CLJS — returns a `js/Promise` resolving with the truthy value or rejecting on timeout (compose with `cljs.test/async`).
+  - JVM — synchronous. Returns the truthy value. On timeout it throws an `ex-info` carrying `:rf.error/id` `:rf.error/wait-until-timeout` (the canonical discriminator).
+  - CLJS — returns a `js/Promise` that resolves with the truthy value or rejects on timeout. Compose it with `cljs.test/async`.
 - **Example**:
   ```clojure
   ;; JVM — testid form; blocks until the display text settles.
@@ -298,12 +305,12 @@ The trio below — `with-app-fixture`, `expect-text`, `wait-until` — covers th
 ### `*current-root-view*`
 
 - **Kind**: dynamic var
-- **Description**: Root-view fn stashed by `with-app-fixture` for the body's dynamic extent. The 2-arity testid forms of `expect-text` and `wait-until` read this var to know which view-fn to call when assembling the hiccup tree. `nil` outside a fixture body; callers operating on an explicit tree use the 3-arity shapes instead.
+- **Description**: The root-view fn stashed by `with-app-fixture` for the body's dynamic extent. The 2-arity testid forms of `expect-text` and `wait-until` read this var to know which view-fn to call when assembling the hiccup tree. It is `nil` outside a fixture body. Callers operating on an explicit tree use the 3-arity shapes instead.
 
 ### `*current-root-view-args*`
 
 - **Kind**: dynamic var
-- **Description**: Args vector passed to `*current-root-view*` when rendering the tree. Defaults to `[]` (the common zero-arg view). `with-app-fixture` sets it from the fixture opts' `:root-view-args` key, so a root view taking arguments (e.g. a props map) is supplied once at the fixture site rather than at every `expect-text` call.
+- **Description**: The args vector passed to `*current-root-view*` when rendering the tree. Defaults to `[]`, the common zero-arg view. `with-app-fixture` sets it from the fixture opts' `:root-view-args` key. A root view that takes arguments (e.g. a props map) is therefore supplied once, at the fixture site, rather than at every `expect-text` call.
 
 ## See also
 

--- a/docs/api/re-frame.test-support.md
+++ b/docs/api/re-frame.test-support.md
@@ -1,6 +1,6 @@
 # re-frame.test-support
 
-`re-frame.test-support` is the **runtime-state** testing surface: test-only fixture machinery and test-flavoured helpers that drive and assert against a frame's `app-db`, the registrar, the dispatch drain, and the trace stream. Its sibling `re-frame.test-helpers` owns the view-tree axis (hiccup walkers plus the `testid` authoring helper).
+`re-frame.test-support` is the **runtime-state** testing surface. It holds test-only fixture machinery and test-flavoured helpers that drive and assert against a frame's `app-db`, the registrar, the dispatch drain, and the trace stream. Its sibling `re-frame.test-helpers` owns the view-tree axis: the hiccup walkers plus the `testid` authoring helper.
 
 This namespace does not re-export from `re-frame.core`, so a production build never picks up test-flavoured machinery by accident. A test file requires it alongside `[re-frame.core :as rf]` (and `[re-frame.test-helpers :as th]` for view assertions).
 
@@ -12,7 +12,7 @@ Examples below also use `[re-frame.core :as rf]` for the production primitives t
 
 ## Fixture machinery
 
-The fixture primitives follow one pattern: snapshot the registrar before the test mutates registrations; restore after, pass or fail. Framework-shipped registrations (captured in the snapshot) survive; per-test registrations are rolled back.
+The fixture primitives follow one pattern: snapshot the registrar before the test mutates registrations, then restore it afterwards, whether the test passes or fails. Framework-shipped registrations are captured in the snapshot, so they survive. Per-test registrations are rolled back.
 
 ### `snapshot-registrar`
 
@@ -51,13 +51,13 @@ The fixture primitives follow one pattern: snapshot the registrar before the tes
   ```clojure
   (merge-registrar-snapshots base overlay) → snapshot
   ```
-- **Description**: Two-level merge of two registrar snapshots (`kind → id → metadata`), returning a new snapshot.
+- **Description**: Merge two registrar snapshots two levels deep (`kind → id → metadata`) and return a new snapshot.
 
   - `overlay` wins on a per-`[kind id]` collision.
   - ids present only in `base` survive.
   - ids present only in `overlay` are added.
 
-  `make-reset-runtime-fixture` uses this to fold a stable ns-load baseline back over whatever the registrar currently holds, so a test namespace's own ns-load registrations are present regardless of run order.
+  `make-reset-runtime-fixture` uses this to fold a stable ns-load baseline back over whatever the registrar currently holds. That keeps a test namespace's own ns-load registrations present regardless of run order.
 - **Example**:
   ```clojure
   ;; `base` and `overlay` are each a value from `snapshot-registrar`.
@@ -72,7 +72,7 @@ The fixture primitives follow one pattern: snapshot the registrar before the tes
   ```clojure
   (with-fresh-registrar body-fn) → any
   ```
-- **Description**: Snapshot + body + restore, composed. Captures the registrar, runs `body-fn`, then restores the captured state in a `finally` — even if `body-fn` throws. Returns `body-fn`'s return value.
+- **Description**: Snapshot + body + restore, composed. Captures the registrar, runs `body-fn`, then restores the captured state in a `finally`. The restore runs even if `body-fn` throws. Returns `body-fn`'s return value.
 - **Example**:
   ```clojure
   ;; As a clojure.test / cljs.test :each fixture:
@@ -94,9 +94,9 @@ The fixture primitives follow one pattern: snapshot the registrar before the tes
 
   Around each test the fixture:
 
-  - reinstates the stable ns-load registrar and source-store baseline captured at fixture-build time (run-order independence inside a shared test bundle);
+  - reinstates the stable ns-load registrar and source-store baseline captured at fixture-build time, which makes tests independent of run order inside a shared test bundle;
   - snapshots the registrar;
-  - resets the frames registry, trace listeners, and per-artefact state (flows, schemas, machines, routing, resources, http, epoch — via late-bind hooks that no-op when an artefact is absent from the classpath);
+  - resets the frames registry, trace listeners, and per-artefact state (flows, schemas, machines, routing, resources, http, epoch). This runs via late-bind hooks that no-op when an artefact is absent from the classpath;
   - disposes then reinstalls the adapter;
   - restores everything in a `finally`.
 
@@ -104,7 +104,7 @@ The fixture primitives follow one pattern: snapshot the registrar before the tes
 
   | Key | Meaning |
   |-----|---------|
-  | `:adapter` | Substrate adapter to install; also ensures the `:rf/default` frame. Omitted: no adapter is installed. |
+  | `:adapter` | Substrate adapter to install; also ensures the `:rf/default` frame. When omitted, no adapter is installed. |
   | `:init-fn` | Zero-arg fn run after adapter install, before the test body, under the same ambient frame scope as the body. |
   | `:clear-kinds` | Collection of registrar kinds cleared after the snapshot capture and before the body (the snapshot restores them on the way out). |
   | `:clear-app-schemas?` | Boolean; clear the schemas artefact's per-frame side-table for the test's duration. |
@@ -130,7 +130,7 @@ The fixture primitives follow one pattern: snapshot the registrar before the tes
   (dispatch-sequence events)
   (dispatch-sequence events opts)
   ```
-- **Description**: Run a list of `events` end-to-end against the resolved frame. Each event is delivered synchronously and the queue drains to fixed point before the next, so observable state between events reflects committed effects. Returns the final `app-db`.
+- **Description**: Run a list of `events` end-to-end against the resolved frame. Each event is delivered synchronously, and the queue drains to fixed point before the next event runs. Observable state between events therefore reflects committed effects. Returns the final `app-db`.
 
   `opts`:
 
@@ -157,11 +157,11 @@ The fixture primitives follow one pattern: snapshot the registrar before the tes
   (assert-path-equals path expected-val)
   (assert-path-equals path expected-val opts)
   ```
-- **Description**: Assert `(get-in db path) == expected-val` against the resolved frame's `app-db`. Mismatch fires a `clojure.test/is`-style failure via `do-report`. Returns `true` on pass, `false` otherwise — the failure has already been reported either way.
+- **Description**: Assert `(get-in db path) == expected-val` against the resolved frame's `app-db`. A mismatch fires a `clojure.test/is`-style failure via `do-report`. Returns `true` on pass and `false` otherwise; the failure has already been reported either way.
 
   `opts`: `:frame` targets a non-default frame; frame resolution matches `dispatch-sequence` (`:frame` opt → `(current-frame)` → `:rf/default`).
 
-  The fn-side counterpart to the `:rf.assert/path-equals` story event-family — same name root, different runner channel.
+  This is the fn-side counterpart to the `:rf.assert/path-equals` story event-family: same name root, different runner channel.
 - **Example**:
   ```clojure
   (rf/dispatch-sync [:counter/inc])
@@ -178,7 +178,7 @@ The fixture primitives follow one pattern: snapshot the registrar before the tes
   (assert-db-equals expected-db)
   (assert-db-equals expected-db opts)
   ```
-- **Description**: Full-db sync assertion — `(= expected-db app-db)` against the resolved frame. Mismatch fires a `clojure.test/is`-style failure via `do-report`. Returns `true` on pass, `false` otherwise.
+- **Description**: A full-db sync assertion: `(= expected-db app-db)` against the resolved frame. A mismatch fires a `clojure.test/is`-style failure via `do-report`. Returns `true` on pass and `false` otherwise.
 
   `opts`: `:frame` targets a non-default frame; frame resolution matches `dispatch-sequence`.
 
@@ -201,10 +201,10 @@ The fixture primitives follow one pattern: snapshot the registrar before the tes
   (poll-until pred)
   (poll-until pred opts)
   ```
-- **Description**: Bounded-deadline poll of `pred`.
+- **Description**: Poll `pred` until it returns truthy, within a bounded deadline.
 
-  - **JVM**: synchronous — returns the truthy value; throws `ex-info` on timeout.
-  - **CLJS**: returns a `js/Promise` resolving with the truthy value, or rejecting on timeout. A `pred` that returns a `js/Promise` is awaited and its resolved value drives the truthy check.
+  - **JVM**: synchronous. Returns the truthy value, or throws `ex-info` on timeout.
+  - **CLJS**: returns a `js/Promise` that resolves with the truthy value, or rejects on timeout. A `pred` that returns a `js/Promise` is awaited; its resolved value drives the truthy check.
 
   The timeout error carries `:rf.error/id` `:rf.error/poll-until-timeout` (the canonical discriminator), plus `:elapsed-ms` and `:label` in its data.
 
@@ -230,7 +230,7 @@ The fixture primitives follow one pattern: snapshot the registrar before the tes
   (with-trace-recorder! [recs-sym] body+)
   (with-trace-recorder! [recs-sym opts] body+)
   ```
-- **Description**: Bracket `body` with a fresh trace-tooling listener that accumulates matching trace events into an atom bound to `recs-sym`. The listener is registered before `body` runs and unregistered in a `finally` on the way out — even if `body` throws. Returns the value of `body`'s final form.
+- **Description**: Bracket `body` with a fresh trace-tooling listener that accumulates matching trace events into an atom bound to `recs-sym`. The listener is registered before `body` runs and unregistered in a `finally` on the way out, even if `body` throws. Returns the value of `body`'s final form.
 
   `opts` (optional map literal; keys evaluated at macroexpansion):
 
@@ -241,7 +241,7 @@ The fixture primitives follow one pattern: snapshot the registrar before the tes
   Macro requires:
 
   - **JVM**: resolves alias-qualified through the normal `(:require [re-frame.test-support :as ts])`.
-  - **CLJS**: the namespace carries no self-`:require-macros` (unlike `re-frame.core`), so CLJS test files must require the macro explicitly — `(:require-macros [re-frame.test-support :refer [with-trace-recorder!]])`, or `:as ts` in `:require-macros` for alias-qualified use.
+  - **CLJS**: the namespace carries no self-`:require-macros` (unlike `re-frame.core`). CLJS test files must therefore require the macro explicitly: `(:require-macros [re-frame.test-support :refer [with-trace-recorder!]])`, or `:as ts` in `:require-macros` for alias-qualified use.
 - **Example**:
   ```clojure
   ;; Flat shape (default), default filter, simple read.


### PR DESCRIPTION
Editorial pass over all 17 documents in `docs/api/` for clarity and readability: simple, direct voice — not dense, not terse. Prose only; zero contract changes.

**What changed (~285 targeted edits, 16 files; README needed nothing):**
- Dense em-dash / semicolon chains split into short sentences — one idea per sentence.
- Long inline enumerations converted to bullet or numbered lists (e.g. the `re-frame.core` facade intro, `ssr-handler`'s seven-clause lifecycle → a 5-step list, per-keyword `Raises:` lists).
- Active voice with concrete subjects; verbless fragments given verbs.
- The three adapter docs (Reagent / UIx / Helix) made structurally parallel — equivalent sections now read equivalently.
- Contract-dense fragments deliberately left alone where rewording risked precision (arrow-chain precedence lines, identity-semantics guarantees, audit claims).

**What did not change (verified mechanically, not just by intent):**
- Token-inventory diff vs HEAD across every file: **zero removed tokens** — every keyword and inline code span present before is present after.
- All heading text byte-identical (anchor stability).
- No fenced code block touched; table id/name columns verbatim; relative links intact.
- `mkdocs build --strict` green.
