### PR TITLE
fix(xray): adopt :rf.reply/* in reply-envelope panel reads post-migration (rf2-6a0vyq)

### DIFF
--- a/tools/template/resources/day8/re_frame2_template/_shared/events.cljs
+++ b/tools/template/resources/day8/re_frame2_template/_shared/events.cljs
@@ -120,7 +120,7 @@
 ;; `:status` (`:ok` / `:error` / `:cancelled`; `:stale` is suppressed
 ;; before app delivery and never reaches this handler), the decoded
 ;; `:value` on `:ok`, the classified `:rf.http/*` failure map under
-;; `:error`, plus `:work/id` and `:completed-at`. There is NO separate
+;; `:error`, plus `:rf.reply/work-id` and `:completed-at`. There is NO separate
 ;; `{:kind :success/:failure}` HTTP dialect (rf2-ibksxg — retired).
 ;; `:on-success` / `:on-failure` are pure ROUTING sugar over the one
 ;; direct reply target `:rf/reply-to` — both receive this same canonical

--- a/tools/xray/spec/013-Trace-Consumer.md
+++ b/tools/xray/spec/013-Trace-Consumer.md
@@ -348,9 +348,12 @@ Every managed *async* family (HTTP, resources, mutations, route
 loaders, machine async work, future managed timers) completes through
 the ONE shape defined in [`spec/Managed-Effects.md` §The uniform reply
 envelope](../../../spec/Managed-Effects.md) (EP-0011): a single **reply
-map** carrying one closed `:status`, value/error data, `:work/id` work
-correlation, `:work/kind`, `:work/status`, `:attempt`, `:rf.frame/id`,
-the durable timestamps, and the cancellation/staleness facts. Property 9
+map** carrying one closed `:status`, value/error data, `:rf.reply/work-id`
+work correlation, `:rf.reply/work-kind`, `:rf.reply/work-status`, `:attempt`,
+`:rf.frame/id`, the durable timestamps, and the cancellation/staleness facts
+(the reply map single-roots the work identity under `:rf.reply/*` post-l7s7b7;
+the durable work-ledger row keeps the bare `:work/id` cross-record spelling).
+Property 9
 / §Tracing require each family to emit its trace rows **from those
 reply-envelope facts, not from private callback facts**.
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/reply_envelope.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reply_envelope.cljc
@@ -21,9 +21,9 @@
   shape for that: every managed-async family (HTTP / resources /
   mutations / route loaders / machine async work / future managed
   timers) completes through a single **reply map** carrying one closed
-  `:status`, value/error data, `:work/id` work correlation,
-  `:work/kind`, `:work/status`, `:attempt`, `:rf.frame/id`, the durable
-  timestamps, the cancellation/staleness facts, and a `:correlation`
+  `:status`, value/error data, `:rf.reply/work-id` work correlation,
+  `:rf.reply/work-kind`, `:rf.reply/work-status`, `:attempt`, `:rf.frame/id`,
+  the durable timestamps, the cancellation/staleness facts, and a `:correlation`
   side-bag (`re-frame.reply` is the framework substrate). Property 9 /
   §Tracing mandate that families emit their trace rows FROM those
   reply-envelope facts.
@@ -97,17 +97,19 @@
                      problems under `:error` (GraphQL is the motivating case).
     - `:error`     — completed with a failure, reply current; `:error` present.
     - `:cancelled` — intentionally cancelled while still correlated;
-                     `:cancel/reason` present.
+                     `:rf.reply/cancel-reason` present.
     - `:stale`     — completed/observed after correlation became obsolete;
-                     `:stale? true` + `:stale/reason`; NO app-state mutation."
+                     `:stale? true` + `:rf.reply/stale-reason`; NO app-state mutation."
   #{:ok :partial :error :cancelled :stale})
 
 (def work-statuses
-  "The operational `:work/status` vocabulary on a reply map / ledger row
-  (mirror of `re-frame.reply/work-statuses`). Narrower / more operational
-  than reply `:status`: `:timed-out` is an error work-status (timeout is an
-  error KIND + a work status, NOT a top-level reply status); `:suppressed`
-  is the stale terminal."
+  "The operational work-status vocabulary — `:rf.reply/work-status` on a reply
+  map (post-l7s7b7 single-root), the same values under the bare `:status` a
+  durable work-ledger row carries (the cross-record spelling — Managed-Effects
+  §The uniform reply envelope) (mirror of `re-frame.reply/work-statuses`).
+  Narrower / more operational than reply `:status`: `:timed-out` is an error
+  work-status (timeout is an error KIND + a work status, NOT a top-level reply
+  status); `:suppressed` is the stale terminal."
   #{:completed :failed :timed-out :suppressed :cancelled})
 
 (def work-kinds
@@ -135,10 +137,14 @@
 ;; Reply-map field readers (Managed-Effects §The reply map). A reply map is
 ;; the appended last-arg of a reply-target event, or the data-only trace
 ;; summary a family emits on completion. The work-correlation reads the
-;; canonical `:work/id` (EP-0011 one-name-per-fact: every family — HTTP,
-;; resources, mutations — emits the qualified `:work/id` on both the reply
-;; map and the trace row's `:tags`; no bare `:work-id` trace-tag spelling
-;; remains to tolerate). The frame reader still accepts either the canonical
+;; canonical `:rf.reply/work-id` (post-l7s7b7 the reply MAP single-roots the
+;; work identity there, EP-0011 one-name-per-fact — Managed-Effects §The
+;; uniform reply envelope; the trace row's `:tags` stamp the same
+;; `:rf.reply/work-id`, and no bare `:work-id` trace-tag spelling remains to
+;; tolerate). The bare `:work/id` fallback is the durable work-ledger row's
+;; cross-record spelling (Managed-Effects §The uniform reply envelope — a
+;; queryable status record vs a transient causal envelope), NOT a reply-map
+;; spelling. The frame reader still accepts either the canonical
 ;; `:rf.frame/id` or the bare `:frame-id` some trace rows stamp, so one
 ;; reader works on both the dispatched reply map and the trace row's `:tags`.
 ;; ---------------------------------------------------------------------------
@@ -157,20 +163,28 @@
 
   rf2-o6c2jr — the CANONICAL trace-tag spelling is `:rf.reply/work-id`; the
   bare `:work/id` trace-tag duplicate was dropped (one name per fact —
-  Conventions rule 1). Prefer `:rf.reply/work-id`; fall back to `:work/id`,
-  which is still the canonical key ON THE REPLY MAP itself (the durable
-  work-ledger identity — untouched by the tag-duplicate cull). nil when
-  absent (a non-ledger-backed managed async)."
+  Conventions rule 1). Post-l7s7b7 the reply MAP also single-roots its work
+  identity as `:rf.reply/work-id`. Prefer `:rf.reply/work-id`; fall back to
+  the bare `:work/id`, which is now the DURABLE work-ledger row's cross-record
+  spelling (Managed-Effects §The uniform reply envelope — a queryable status
+  record vs a transient causal envelope), NOT a reply-map key. nil when absent
+  (a non-ledger-backed managed async)."
   [m]
   (or (:rf.reply/work-id m) (:work/id m)))
 
 (defn work-kind-of
-  "Read the `:work/kind` family tag off a reply map or trace tags (one of
-  `work-kinds`), tolerating `:work/kind` or bare `:work-kind`/`:kind`. nil
-  when absent. When absent on a reply, `infer-work-kind` derives it from the
-  work-id tuple head."
+  "Read the work-kind family tag off a reply map or trace tags (one of
+  `work-kinds`). Prefer the migrated reply-envelope spelling
+  `:rf.reply/work-kind` (post-l7s7b7 the reply MAP single-roots the work
+  identity there — Managed-Effects §The uniform reply envelope; a family
+  trace row also stamps it additively). Fall back to the bare `:work/kind`
+  the durable work-ledger row keeps under the cross-record spelling rule,
+  then to `:work-kind`/`:kind`. nil when absent. When absent on a reply,
+  `infer-work-kind` derives it from the work-id tuple head — note a
+  `:mutation` reuses the `:rf.work/resource` head and so is only
+  distinguishable by an explicit `:rf.reply/work-kind`/`:work/kind`."
   [m]
-  (or (:work/kind m) (:work-kind m) (:kind m)))
+  (or (:rf.reply/work-kind m) (:work/kind m) (:work-kind m) (:kind m)))
 
 (defn infer-work-kind
   "Infer the `:work/kind` from a `:work/id` tuple head when the reply / row
@@ -197,8 +211,9 @@
       nil)))
 
 (defn resolve-work-kind
-  "The work-kind for a reply map / row: the explicit `:work/kind` when
-  present, else inferred from the `:work/id` tuple head. Pure."
+  "The work-kind for a reply map / row: the explicit work-kind when present
+  (`:rf.reply/work-kind` on a reply map / trace row, or the bare `:work/kind`
+  the ledger row keeps), else inferred from the work-id tuple head. Pure."
   [m]
   (or (work-kind-of m)
       (infer-work-kind (work-id-of m))))
@@ -258,7 +273,10 @@
     {:work-id       work-id
      :work-kind     (resolve-work-kind reply)
      :status        status
-     :work-status   (or (:work/status reply) (:work-status reply))
+     ;; Post-l7s7b7 the reply MAP single-roots the operational work status as
+     ;; `:rf.reply/work-status` (Managed-Effects §The uniform reply envelope);
+     ;; prefer it, tolerating the pre-migration bare `:work/status`/`:work-status`.
+     :work-status   (or (:rf.reply/work-status reply) (:work/status reply) (:work-status reply))
      :attempt       (:attempt reply)
      ;; The reply MAP's frame is the canonical EP-0002 carried-frame stamp
      ;; `:rf.frame/id` — UNIFORM across every family on the reply map
@@ -278,9 +296,12 @@
      :error-kind    (when (map? error) (:kind error))
      :correlation   (when (contains? reply :correlation) (rh/summarize (:correlation reply)))
      :stale?        (boolean (:stale? reply))
-     :stale-reason  (:stale/reason reply)
+     ;; Post-l7s7b7 reply-map spelling is `:rf.reply/stale-reason` /
+     ;; `:rf.reply/cancel-reason` (Managed-Effects §The uniform reply
+     ;; envelope); prefer them, tolerating the pre-migration bare keys.
+     :stale-reason  (or (:rf.reply/stale-reason reply) (:stale/reason reply))
      :cancelled?    (boolean (:cancelled? reply))
-     :cancel-reason (:cancel/reason reply)
+     :cancel-reason (or (:rf.reply/cancel-reason reply) (:cancel/reason reply))
      :delivered?    delivered?
      :meta          (when (contains? reply :meta) (rh/summarize (:meta reply)))}))
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/reply_envelope_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/reply_envelope_cljs_test.cljc
@@ -149,6 +149,50 @@
       (is (= :rf.graphql/partial-success (:error-kind row)))
       (is (true? (:delivered? row))))))
 
+(deftest migrated-reply-map-reads
+  ;; rf2-6a0vyq / rf2-l7s7b7 — the reply MAP single-roots its work identity /
+  ;; operational facts under `:rf.reply/*` (Managed-Effects §The uniform reply
+  ;; envelope): `:rf.reply/work-id` / `:rf.reply/work-kind` /
+  ;; `:rf.reply/work-status` / `:rf.reply/cancel-reason` / `:rf.reply/stale-reason`
+  ;; (the bare `:status` / `:cancelled?` / `:stale?` / `:rf.frame/id` / timestamps
+  ;; stay). This pins the panel's reply-map reads against that MIGRATED shape —
+  ;; the reads must PREFER the `:rf.reply/*` spelling, not just tolerate the
+  ;; pre-migration bare keys the other reply-row tests still exercise.
+  (testing "work-kind-of prefers the migrated :rf.reply/work-kind"
+    (is (= :http (re/work-kind-of {:rf.reply/work-kind :http})))
+    ;; the canonical spelling wins over a stray bare twin
+    (is (= :mutation (re/work-kind-of {:rf.reply/work-kind :mutation :work/kind :resource}))))
+  (testing "resolve-work-kind: a POST-migration :mutation reply map (reusing the
+            :rf.work/resource head) resolves :mutation off :rf.reply/work-kind —
+            inference alone would misclassify it as :resource"
+    (is (= :mutation
+           (re/resolve-work-kind
+             {:rf.reply/work-kind :mutation
+              :rf.reply/work-id   [:rf.work/resource [:rf.mutation :m1] 1]}))))
+  (testing "reply-row reads a fully migrated :rf.reply/* reply map — the exact
+            shape the substrate + families now emit (re-frame.reply/suppress,
+            re-frame.http.reply, re-frame.resources.reply)"
+    (let [ok  (re/reply-row {:status :ok :value {:title "W"}
+                             :rf.reply/work-id     [:rf.work/http :article 1]
+                             :rf.reply/work-kind   :http
+                             :rf.reply/work-status :completed
+                             :attempt 1 :rf.frame/id :frame-7 :completed-at 42})
+          can (re/reply-row {:status :cancelled :cancelled? true
+                             :rf.reply/cancel-reason :actor-destroyed
+                             :error {:kind :rf.http/aborted}
+                             :rf.reply/work-id [:rf.work/http :a 1]})
+          st  (re/reply-row {:status :stale :stale? true
+                             :rf.reply/stale-reason :rf.reply/correlation-mismatch
+                             :rf.reply/work-status  :suppressed
+                             :rf.reply/work-id [:rf.work/resource :k 3]})]
+      (is (= :http (:work-kind ok)))
+      (is (= [:rf.work/http :article 1] (:work-id ok)))
+      (is (= :completed (:work-status ok)))
+      (is (= :actor-destroyed (:cancel-reason can)))
+      (is (= :rf.reply/correlation-mismatch (:stale-reason st)))
+      (is (= :suppressed (:work-status st)))
+      (is (false? (:delivered? st))))))
+
 (deftest reply-map?-predicate
   (is (re/reply-map? {:status :ok :value 1}))
   (is (re/reply-map? {:status :stale :stale? true}))


### PR DESCRIPTION
## What

Post **rf2-l7s7b7** (#5424) the uniform reply **MAP** single-roots its work identity / operational facts under `:rf.reply/*` (Managed-Effects §The uniform reply envelope). `tools/xray/panels/reply_envelope.cljc`'s reply-MAP reads still read the pre-migration **bare** field keys. This makes them **prefer** the migrated `:rf.reply/*` spelling, keeping the bare fallback (matching the file's existing `work-id-of` precedent + tolerant-reader posture).

**Nothing was broken today** — the panel's primary input, the trace stream, is already `:rf.reply/*` (it tolerates it at `work-event-row`). This is a consistency/robustness fix, and it closes one real latent gap: a `:mutation` reply map reuses the `:rf.work/resource` work-id head, so kind-inference alone (the previous behaviour once the explicit key went unread) would misclassify it as `:resource`.

## Reads updated (prefer `:rf.reply/*`, tolerate bare)

| read | now prefers |
|---|---|
| `work-kind-of` | `:rf.reply/work-kind` |
| `reply-row :work-status` | `:rf.reply/work-status` |
| `reply-row :stale-reason` | `:rf.reply/stale-reason` |
| `reply-row :cancel-reason` | `:rf.reply/cancel-reason` |

`ledger-row` intentionally **stays bare** (`:work/id` / `:work/kind` / `:status`) — the durable work-ledger row keeps the **cross-record spelling** per `spec/Managed-Effects.md` §The uniform reply envelope (a queryable status record vs a transient causal envelope). Verified against the migrated `re-frame.reply`, `re-frame.http.reply`, `re-frame.resources.reply`.

## Doc comments

Corrected stale reply-envelope field spellings in the panel docstrings (intro reply-map enumeration, `reply-statuses`, `work-statuses`, `work-id-of`, `work-kind-of`, `resolve-work-kind`, the field-readers section comment) and one `tools/template` call-site comment (`:work/id` -> `:rf.reply/work-id`). Left `tools/mcp-conformance` alone: its fixtures already carry the additive `:rf.reply/*` vocab plus legitimate bespoke family facts, and its comments accurately describe the o6c2jr trace-tag-duplicate story (separate artefact + gate).

## xray-spec disposition

The panel's **runtime output contract** (the `reply-row` / `work-event-row` row shapes) is **unchanged** — this is tolerance-only on the input reads. I did update `tools/xray/spec/013-Trace-Consumer.md` §345: its reply-MAP field enumeration still listed the pre-migration bare `:work/id` / `:work/kind` / `:work/status`, corrected to `:rf.reply/*` to match the migrated normative `spec/Managed-Effects.md` (doc consistency, same fix as the panel docstrings).

## Quality gates (foreground)

- `tools/xray` `clojure -M:test` — **1235 tests / 5765 assertions, 0 failures, 0 errors**
- `implementation` `npm run test:cljs` — **8464 tests / 39101 assertions, 0 failures, 0 errors**
- New `migrated-reply-map-reads` deftest pins the panel against the post-l7s7b7 `:rf.reply/*` reply-map shape (incl. the `:mutation` case).

## Stance

Pre-alpha, no shims; CLARITY + CORRECTNESS + GOOD-PRACTICE. The retained bare fallback is not a new shim — it matches the panel's pre-existing tolerant-reader design and the `work-id-of` sibling; the change is purely additive `:rf.reply/*` preference.