### PR TITLE
chore(epoch): single projected-egress contract + drop obsolete privacy smokes (rf2-5b3ao6, rf2-7gzg0y)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
+++ b/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
@@ -1651,146 +1651,36 @@
     :else :rf/redacted))
 
 (defn projected-record
-  "Project an `:rf/epoch-record` for off-box egress. Routes the
-  app-db-rooted full-value payload slots (`:frame-state-before`,
-  `:frame-state-after`, `:db-before`, `:db-after`, `:trace-events`) through
-  `re-frame.projection/project-egress` under the egress profile selected by
-  `opts` (default `:rf.egress/off-box-observability`) (EP-0015 §15 / §10)
-  against the record's frame, with the off-box defaults `:include-sensitive? false`
-  / `:include-large? false`. Sensitive paths land as `:rf/redacted`; large
-  paths land as `:rf.size/large-elided` markers per the §Composition rule.
+  "INTERNAL projection engine for off-box epoch egress (Phase-2 seam E,
+  rf2-0wi86). The complete PUBLIC contract — egress profiles, `:include-*`
+  overrides, frame-state / runtime-db policy, event/fx-arg redaction,
+  structured-row handling, and the single normative emission-site
+  requirement — lives on the facade `re-frame.epoch/projected-record`; this
+  docstring records only the implementation invariants.
 
-  The `:trigger-event` slot is NOT app-db-rooted — its event ARGS are
-  registration-owned transient payloads (Spec 015 §151), the same class as
-  the `:effects` `:args` — so it fails closed instead: the args are redacted
-  by default while the head event-id keyword (the non-payload summary) is
-  retained, and the trusted-local `:include-event-args?` opt keeps them raw
-  (rf2-nm611o — see `elide-trigger-event-slot`).
+  Two-stage projection (EP-0015 §15, open-issue 6 RULED):
 
-  ## Frame/profile projection then `:redact-fn` advanced override (EP-0015 §15)
+    1. Frame/profile projection. Each present tree-shaped slot is delegated
+       to its per-slot helper against the record's frame under the selected
+       `:rf.egress/profile` (default `:rf.egress/off-box-observability`):
+         :frame-state-before / :frame-state-after -> project-frame-state-slot
+         :db-before / :db-after                    -> project-payload-slot
+         :trigger-event                            -> elide-trigger-event-slot
+         :trace-events                             -> elide-trace-events-slot
+         :sub-runs                                 -> elide-sub-runs-slot
+         :effects                                  -> elide-effects-slot
+       Record-level bookkeeping, and any slot absent from the record, are
+       left untouched.
 
-  This is a TWO-STAGE projection (open-issue 6, RULED):
+    2. `:redact-fn` advanced override. `assembly/apply-redact-fn` runs LAST,
+       over the already-projected record — projection-side only, so the raw
+       ring (and thus `restore-epoch!` fidelity) is never touched. Identity
+       pass-through when no fn is installed; a throwing override emits
+       `:rf.warning/epoch-redact-fn-exception` and falls back to the
+       projected record.
 
-    1. **Frame/profile projection.** Each tree-shaped slot is projected
-       through `project-egress` with the `:rf.egress/off-box-observability`
-       profile — the ordinary redaction every off-box egress gets,
-       sourced from the frame's `:sensitive?` / `:large?` classification.
-       This is the normal answer; ordinary apps need nothing more.
-
-    2. **`:redact-fn` advanced override.** If the app installed a
-       `(rf/configure! {:epoch-history {:redact-fn …}})`, it is applied to
-       the already-projected record (`assembly/apply-redact-fn`) as the
-       rare advanced escape for material the frame/profile projection
-       cannot prove. It runs ONLY here, on the off-box egress copy — the
-       ring stays raw (post-EP-0010 causal replay material), so the fn can
-       never affect `restore-epoch!` fidelity.
-
-  ## Egress profile (rf2-1afn7q) + opts (rf2-5w06uu)
-
-  The 2-arity accepts an `opts` map. The PRIMARY public selector is the
-  named egress boundary — `:rf.egress/profile` — which answers *\"which
-  boundary is this?\"* against the shared closed `:rf.egress/*` enum
-  (`re-frame.projection/profiles`):
-
-      {:rf.egress/profile <profile>  ;; default :rf.egress/off-box-observability
-
-  The two off-box boundaries an epoch consumer selects:
-
-    - `:rf.egress/off-box-observability` (DEFAULT) — hosted monitoring /
-      log shippers / Story / pair recorders. Redact sensitive, elide large,
-      OMIT structural digests.
-    - `:rf.egress/off-box-tool` — the MCP / AI / tool wire. Same
-      redact/elide defaults, but turns ON `:rf.size/include-digests?`, so a
-      large owner-local app-db slot egresses as a `:rf.size/large-elided`
-      marker carrying the structural indicators / counters (`:digest`) the
-      tool needs to reason about shape without seeing content. This is the
-      profile an MCP / AI epoch consumer (Xray-MCP `watch-epochs`, the pair
-      tool) should pass. An unknown profile is rejected against the closed
-      enum (a typo is a loud error, never a silent permissive walk).
-
-  The unqualified `:include-*` keys are ADVANCED per-call overrides
-  composed OVER the selected profile (NOT the primary boundary selector):
-
-      {:include-sensitive?  <bool>   ;; reveal app-db sensitive values
-       :include-large?      <bool>   ;; reveal app-db large values
-       :include-runtime-db? <bool>   ;; reveal the frame-state runtime-db partition
-       :include-fx-args?    <bool>   ;; reveal the structured `:effects` `:args`
-       :include-event-args? <bool>}  ;; reveal the `:trigger-event` args (rf2-nm611o)
-
-  All default `false` — the 1-arity (`(projected-record record)`) is the
-  safe, fully-redacted off-box-observability path. `:include-sensitive?` /
-  `:include-large?` opt the APP-DB partition's privacy / size posture back
-  in across every payload slot. They are ORTHOGONAL to the runtime-db
-  partition boundary: the `:rf.db/runtime` side of the frame-state slots
-  stays `:rf/redacted` UNLESS the trusted-local caller ALSO passes
-  `:include-runtime-db? true` (which routes runtime-db through the same
-  value walk, where its own per-slot sensitive / large declarations still
-  apply). This closes the rf2-5w06uu bypass where a per-tool egress path
-  walked the raw record and lifted the runtime-db partition just because
-  the caller asked for sensitive / large APP-DB values. Extending the
-  normative projection (rather than per-tool reimplementation) keeps
-  Security.md §Off-box egress's single-emission-site contract.
-
-  EP-0001 (rf2-3aizt1, decision #2 + Mike ruling #14): the CANONICAL
-  `:frame-state-before` / `:frame-state-after` slots egress with their
-  `:rf.db/app` partition projected (the same projection the `:db-*` slots
-  get) and their `:rf.db/runtime` partition DEFAULT-REDACTED to
-  `:rf/redacted` off-box — machine snapshots / route slice / SSR metadata
-  do not egress to AI / log channels by default (see
-  `project-frame-state-slot`).
-
-  The structured `:sub-runs` rows are ALSO value-bearing (rf2-at60h):
-  each carries the sub's computed `:prev-value` / `:value`. Their
-  whole-output `:sensitive?` case is already redacted at the marks emit
-  site, but the whole-output `:large?` case leaves the raw value on the
-  row (the on-box ring keeps exact state), so this projection substitutes
-  the `:rf.size/large-elided` marker for those slots under the
-  `:include-large? false` default — see `elide-sub-runs-slot`. The
-  non-value row metadata (`:sub-id`, `:query-v`, `:value-changed?`,
-  `:cascade?`, `:cause-sub`, `:cause-event-id`) passes through unchanged.
-
-  The structured `:effects` rows are payload-bearing too (rf2-rlt3sv):
-  each carries `:args` — the RAW fx-handler argument, which fails closed to
-  `:rf/redacted` off-box under the `:include-fx-args? false` default (see
-  `elide-effects-slot`). The value-free row metadata (`:fx-id`, `:outcome`,
-  `:error-trace`) and the whole `:renders` projection pass through unchanged.
-
-  The `:trigger-event` slot is payload-bearing too (rf2-nm611o): the
-  dispatched event vector's ARGS are registration-owned transient payloads
-  (Spec 015 §151), not app-db-rooted, so the app-db classification walker
-  cannot prove them safe. It fails closed under the `:include-event-args?
-  false` default — the args are redacted while the head event-id keyword
-  (the non-payload summary, == the record's `:event-id` slot) is retained,
-  so `[:login \"topsecret\"]` egresses as `[:login :rf/redacted]` (see
-  `elide-trigger-event-slot`).
-
-  The record-level bookkeeping (`:epoch-id`, `:frame`, `:committed-at`,
-  `:event-id`, `:outcome`, `:halt-reason`, `:schema-digest`,
-  `:rf.epoch/sensitive?`, `:rf.epoch/redacted-modified-paths-count`)
-  also passes through unchanged — it carries no app-db material.
-
-  Per Security.md §Epoch privacy posture and rf2-mrsck: this is the
-  single normative projection emission site for off-box egress. Tools
-  that forward epoch records across a process boundary (Xray-MCP
-  `watch-epochs`, story / pair recorders, hosted post-mortem
-  forwarders) MUST route through this fn at the wire boundary; the
-  on-box ring buffer and `register-epoch-listener!` listener fan-out
-  continue to deliver the RAW record so on-box devtools (Xray diff,
-  REPL, `restore-epoch!`) can reason about exact state.
-
-  After the frame/profile projection lands, the installed `:redact-fn`
-  advanced override (`assembly/apply-redact-fn`) runs over the PROJECTED
-  record (EP-0015 §15 + open-issue 6, RULED) — the rare escape for
-  material the frame/profile projection cannot prove. A throwing override
-  emits `:rf.warning/epoch-redact-fn-exception` and falls back to the
-  projected record. When no `:redact-fn` is installed it is an identity
-  pass-through (the common case).
-
-  `record` may be `nil` (e.g. a missing epoch lookup) — the projection
-  returns `nil` in that case, nothing called. Production builds elide the
-  entire epoch surface; consumers gate any `register-epoch-listener!`
-  registration under `interop/debug-enabled?` per Spec 009 §User-side
-  listener registration."
+  Nil-preserving: a non-map `record` (e.g. a missing-epoch lookup) returns
+  nil, nothing projected."
   ([record] (projected-record record nil))
   ([record opts]
    (when (map? record)
@@ -1853,15 +1743,10 @@
        (assembly/apply-redact-fn projected)))))
 
 (defn projected-history
-  "Convenience: return the projected vector of records for a frame.
-  Equivalent to `(mapv #(projected-record % opts) (epoch-history frame-id))`.
-  Tools that egress the whole ring (an MCP `watch-epochs` initial
-  snapshot, a recorder dumping the full session) can call this once
-  rather than walking the raw ring and re-wrapping each record. The
-  2-arity threads the trusted-local egress `opts` (rf2-5w06uu —
-  `:include-sensitive?` / `:include-large?` / `:include-runtime-db?` /
-  `:include-fx-args?` / `:include-event-args?`) to every record; the
-  1-arity is the safe, fully-redacted off-box path."
+  "INTERNAL — the public contract lives on
+  `re-frame.epoch/projected-history`. Maps `projected-record` over the
+  frame's raw ring (`state/history-for`), threading `opts` to each record;
+  the 1-arity is the fully-redacted off-box path."
   ([frame-id] (projected-history frame-id nil))
   ([frame-id opts]
    (mapv #(projected-record % opts) (state/history-for frame-id))))

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -68,7 +68,6 @@
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
             [re-frame.trace :as trace]
-            [re-frame.elision :as elision]
             [re-frame.epoch :as epoch]
             [re-frame.epoch.assembly :as assembly]
             [re-frame.epoch.capture :as capture]
@@ -4680,118 +4679,6 @@
       (is (= :try-reset (:event-id (first @seen)))
           "the lone listener invocation is for the outer cascade, not
            a synthetic reset-rejection record"))))
-
-;; ---- rf2-mrsck: per-leaf smoke tests --------------------------------------
-;;
-;; Per the cluster prompt and Mike's 2026-05-16 convention: every impl
-;; commit ships per-leaf smoke tests in the same commit. The full
-;; coverage matrix lives in rf2-vq5o0; these smokes pin the
-;; load-bearing slot for each new piece (the rollup, the projected
-;; helper, the finite default) so a regression that nukes the
-;; mechanism fails this file rather than waiting for rf2-vq5o0's
-;; deeper sweep.
-
-(deftest smoke-sensitive-rollup-default-false
-  (testing "rf2-mrsck — :rf.epoch/sensitive? is false on records whose
-            cascade involves no sensitive paths and no sensitive handlers"
-    (rf/reg-frame :test/main {})
-    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
-    (rf/dispatch-sync [:seed] {:frame :test/main})
-
-    (let [r (last (rf/epoch-history :test/main))]
-      (is (false? (:rf.epoch/sensitive? r))
-          "non-sensitive cascade — rollup reads false"))))
-
-(deftest smoke-sensitive-rollup-false-from-handler-meta-removed
-  (testing "Handler-meta `:sensitive?` annotation has been removed —
-            the rollup no longer reflects a handler-level stamp.
-            Path-marked classification (schema-slot `:sensitive?`)
-            is the v2 mechanism."
-    (rf/reg-frame :test/main {})
-    (rf/reg-event :secret-write
-                     {:sensitive? true}   ;; stored, no longer consulted
-                     (fn [{:keys [db]} _] {:db (assoc db :token "shhh")}))
-    (rf/dispatch-sync [:secret-write] {:frame :test/main})
-
-    (let [r (last (rf/epoch-history :test/main))]
-      (is (false? (:rf.epoch/sensitive? r))
-          "rollup reads false — handler-meta annotation no longer stamps"))))
-
-(deftest smoke-projected-record-redacts-and-keeps-bookkeeping
-  (testing "rf2-mrsck — projected-record routes :db-before / :db-after /
-            :trigger-event / :trace-events through elide-wire-value with
-            off-box defaults; bookkeeping slots and structured projections
-            pass through unchanged"
-    (rf/reg-frame :test/main {})
-    ;; EP-0025: durable app-db classification rides the commit-plane
-    ;; classification effects. Declare the `[:auth :password]` sensitive path
-    ;; through `elision/apply-classification-effects` (`:source :effect`) — it
-    ;; populates [:rf.runtime/elision :sensitive-declarations] directly (the
-    ;; same registry write a `reg-event` returning `:sensitive` performs),
-    ;; pinning the smoke against the elision walker contract.
-    (frame/swap-runtime-db! :test/main
-      (fn [rt] (elision/apply-classification-effects rt {:sensitive [[:auth :password]]})))
-    (rf/reg-event :login
-                     (fn [{:keys [db]} [_ pw]]
-                       {:db (assoc-in db [:auth :password] pw)}))
-    (rf/dispatch-sync [:login "topsecret"] {:frame :test/main})
-
-    (let [raw       (last (rf/epoch-history :test/main))
-          projected (epoch/projected-record raw)]
-      (is (= "topsecret" (get-in raw [:db-after :auth :password]))
-          "raw record carries the unredacted password (in-process)")
-      (is (seq (re-frame.elision/sensitive-declarations :test/main))
-          "elision registry populated for :test/main")
-      (is (= :rf/redacted
-             (get-in projected [:db-after :auth :password]))
-          "projected record substitutes :rf/redacted for the sensitive slot")
-      (is (= (:epoch-id raw) (:epoch-id projected))
-          ":epoch-id passes through")
-      (is (= (:event-id raw) (:event-id projected))
-          ":event-id passes through")
-      (is (= (:outcome raw)  (:outcome projected))
-          ":outcome passes through")
-      (is (= (:sub-runs raw) (:sub-runs projected))
-          "structured :sub-runs slot passes through unchanged")
-      (is (= (:effects raw)  (:effects projected))
-          "structured :effects slot passes through unchanged")
-      (is (true? (:rf.epoch/sensitive? raw))
-          "schema-derived rollup also fires when a sensitive path
-           resolves to a non-nil leaf in :db-after"))))
-
-(deftest smoke-projected-history-projects-each-record
-  (testing "rf2-mrsck — projected-history walks the ring once and
-            returns the projected vector"
-    (rf/reg-frame :test/main {})
-    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
-    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
-    (rf/dispatch-sync [:seed] {:frame :test/main})
-    (rf/dispatch-sync [:inc]  {:frame :test/main})
-
-    (let [history (rf/epoch-history :test/main)
-          ph      (epoch/projected-history :test/main)]
-      (is (= (count history) (count ph))
-          "projected-history returns one element per ring record")
-      (is (every? map? ph) "each element is a map")
-      (is (= (mapv :epoch-id history) (mapv :epoch-id ph))
-          ":epoch-id ordering matches the raw ring"))))
-
-(deftest smoke-projected-record-handles-nil-input
-  (testing "rf2-mrsck — projected-record returns nil for non-map input
-            (a missing-epoch lookup)"
-    (is (nil? (epoch/projected-record nil)))
-    (is (nil? (epoch/projected-record :not-a-map)))))
-
-(deftest smoke-trace-events-keep-fixture-override
-  (testing "rf2-wmki8 — the TEST FIXTURE forces :trace-events-keep 5 (a
-            keep<depth OVERRIDE so the elision path is reachable with a
-            handful of dispatches), NOT the shipped runtime default. This
-            asserts the fixture's override value, deliberately distinct
-            from the shipped default of 50 (see
-            `shipped-trace-events-keep-default-is-50` for the real
-            default)."
-    (is (= 5 (:trace-events-keep (epoch/current-config)))
-        "fixture OVERRIDE — see the :init-fn configure! call; NOT the shipped default")))
 
 (deftest shipped-trace-events-keep-default-is-50
   (testing "rf2-wmki8 — the SHIPPED runtime default :trace-events-keep is


### PR DESCRIPTION
Two clustered P3 epoch-artefact cleanups (Mike-owned, ruled). Two logical commits, one per bead.

## rf2-5b3ao6 — single projected-egress public contract on the facade (commit 1, docstring-only)

The projected-record / projected-history **public** contract (egress profiles, `:include-*` overrides, frame-state / runtime-db policy, event/fx-arg redaction, structured-row handling, single normative emission-site requirement) was duplicated verbatim between the facade `re-frame.epoch/{projected-record,projected-history}` and the `re-frame.epoch.tool-pair` implementations. The facade already declares itself the canonical public API reference.

- Keep the complete public contract on the facade only.
- Reduce the tool-pair docstrings to concise **internal** implementation invariants: two-stage projection order + per-slot delegation table, the `:redact-fn` advanced override, nil behaviour, and a pointer to the facade.
- Signatures, delegation, late-bind hooks, and runtime behaviour unchanged. No abstraction / compatibility layer added.

## rf2-7gzg0y — drop obsolete privacy smoke duplicates (commit 2, test deletion)

Six legacy per-leaf smokes in `epoch_test.clj` duplicated (more weakly) coverage that `epoch_privacy_test.clj` now owns authoritatively. Deleted the six + their per-leaf-smoke preamble; each authoritative counterpart is a **strict superset**, so no unique assertion is lost:

| deleted smoke | authoritative owner (epoch_privacy_test.clj) |
|---|---|
| smoke-sensitive-rollup-default-false | rollup-false-on-non-sensitive-cascade |
| smoke-sensitive-rollup-false-from-handler-meta-removed | rollup-false-from-handler-meta-sensitive-removed |
| smoke-projected-record-redacts-and-keeps-bookkeeping | projected-record-redacts-sensitive-in-db-after + bookkeeping-passes-through + renders-and-subruns-pass-through-when-value-free |
| smoke-projected-history-projects-each-record | projected-history-walks-the-ring |
| smoke-projected-record-handles-nil-input | projected-record-nil-input-returns-nil (also covers `[:not :a :map]`) |
| smoke-trace-events-keep-fixture-override | retention-cap-fixture-override-five (asserts the same `5`, plus keep-window elision behaviour) |

- Preserved `shipped-trace-events-keep-default-is-50` (the unique shipped-default test immediately after the block).
- Removed the now-unused `[re-frame.elision :as elision]` require (referenced only inside the deleted redacts-and-keeps smoke).
- No shared test helpers introduced.

## Preflight confirmations (h1vqa4 lesson)

- **5b3ao6:** confirmed the facade (`epoch.cljc` ~761-874) and `tool_pair.cljc` (~1653-1867) both carry the full overlapping projected-egress contract. The one item in tool-pair not on the facade docstring is the `:redact-fn` two-stage ordering — a projection-order implementation invariant (kept in tool-pair per the DESIGN); its public knob is already documented on the facade `configure!` docstring, so no public contract is lost.
- **7gzg0y:** verified each of the six smokes is covered *more thoroughly* by its `epoch_privacy_test.clj` counterpart before deleting (nil-input counterpart covers a superset; fixture-override counterpart asserts the same value plus the windowing). No unique assertion found — nothing withheld.

## Quality gates

- `clojure -M:test` (epoch artefact, foreground): **376 tests, 1505 assertions, 0 failures, 0 errors** — proves no unique assertion was lost.
- clj-kondo (epoch src+test): **0 errors**; 95 warnings, all pre-existing "unused binding db" style smells (2 fewer than the 97 on `origin/main` — the deleted smokes carried 2; zero new warnings introduced).

## Stance

Pre-alpha, no back-compat / abstraction / compat layers. Primary lenses: ELEGANCE + CLARITY + CORRECTNESS + GOOD-PRACTICE. Docstring dedup and dead-test removal; no runtime behaviour touched.

Do NOT merge — for review.