### PR TITLE
refactor(core): centralize derivation-graph egress redaction; Xray + conformance delegate (rf2-mm3y49)

### DIFF
--- a/implementation/core/src/re_frame/derivation/egress.cljc
+++ b/implementation/core/src/re_frame/derivation/egress.cljc
@@ -1,0 +1,464 @@
+(ns re-frame.derivation.egress
+  "The OFF-BOX EGRESS REDACTION algebra for a `DerivationGraph` — the single
+  owner of the projection a consuming tool applies at the wire boundary where
+  it ships the graph OFF the developer's box (rf2-mm3y49; EP-0014 tail-2
+  redaction ruling, rf2-yjarv6; [spec/Derivations.md] §Redaction metadata +
+  §Conformance 'Tool redaction').
+
+  ## Why this lives in `implementation/core`, gated as TOOLING
+
+  The redaction algorithm previously existed as TWO independent copies that
+  drifted: the named first-consumer Xray call site
+  (`day8.re-frame2-xray.panels.derivation-graph-helpers/redact-graph-for-egress`)
+  and the derivation-conformance suite's in-tree mirror
+  (`egress-project-graph`). A fix (canonical work-id / host-transient
+  projection, rf2-tmyfkn/rf2-qo1l8w) had to land in both, and Xray lagged.
+  This namespace is the ONE owner both delegate to: Xray's
+  `redact-graph-for-egress` is now a thin alias, and the conformance suite
+  tests THIS namespace directly.
+
+  It sits in core/src beside the graph COMPOSER (`re-frame.derivation.graph`)
+  because it is built ENTIRELY from `implementation/`-resident primitives —
+  `re-frame.elision/elide-wire-value` (the shared per-frame fail-closed value
+  walker, EP-0015 §11), `re-frame.identity/canonical-bytes` (the CEDN-1
+  canonical token, EP-0012), and `re-frame.privacy/redacted-sentinel` (the
+  `:rf/redacted` sentinel) — so both consumers can reach ONE owner without
+  the conformance surface reaching into `tools/` (the dependency arrow flows
+  tools → implementation, NEVER implementation → tools). It carries NO
+  dependency on any per-feature artefact or on `tools/`.
+
+  ## BUNDLE ISOLATION (load-bearing)
+
+  This is TOOLING, not production API. It is NOT exposed from the
+  `re-frame.core` facade and is NOT `:require`d by any production-reachable
+  namespace — it is loaded only by dev tools (Xray) + the conformance
+  fixtures, which `:require` it directly. A production application bundle
+  never loads this ns, so `:advanced` + `goog.DEBUG=false` DCE its body
+  wholesale. The bundle-isolation sentinel at the foot of this ns proves no
+  stray `:require` pulled it into the counter example's production bundle
+  (`implementation/scripts/check-bundle-isolation.cjs`).
+
+  ## The contract
+
+  Given a `DerivationGraph` (`{:mode :nodes :edges}`) and the observed
+  frame-id whose elision policy governs egress, `project-graph` returns the
+  graph with:
+
+    - **value-bearing node fields** (`:value` / `:params` / `:query` /
+      `:state` — `value-bearing-node-keys`) walked through
+      `elide-wire-value` under THAT frame's own declared `:sensitive` /
+      `:large` policy (passed as the explicit `:frame` opt so the named
+      frame's policy applies regardless of any ambient scope);
+    - **fail-closed** on a nil / unreachable frame — an unresolvable frame
+      stamps a dead-frame sentinel so `elide-wire-value` takes its
+      unresolvable-frame branch (whole value ⇒ `:rf/redacted`) rather than
+      borrowing an ambient dynamically-bound frame and shipping raw
+      (rf2-udkj69);
+    - **identity-embedded scoped keys** — the positions the value-path walk
+      is structurally blind to (node KEY, `:id`, `:output`, realized
+      `:inputs`, `:work-ledger` work-id + `:resource/key`, `:host-transient`
+      in-flight handle, and every edge endpoint) projected into STABLE OPAQUE
+      HANDLES; and
+    - **STRUCTURE PRESERVED** — a redacted value / param is still an edge;
+      the node is still present + classified; the projection is idempotent.
+
+  JVM-portable (`.cljc`) so the projection + redaction contracts are pinned
+  by the JVM test corpus without a CLJS runtime."
+  (:require [re-frame.elision :as elision]
+            [re-frame.frame :as frame]
+            [re-frame.identity :as identity]
+            [re-frame.privacy :as privacy]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+;; The value-bearing summary fields a LIVE node may carry — the value
+;; summaries [spec/Derivations.md] §Redaction metadata names as egress-bearing
+;; once shipped off-box: a sub-cache entry's `:value`, a route slice's
+;; `:params` / `:query`, a machine instance's `:state` summary. (Each is the
+;; in-process value summary the sibling live surface carries; the composer
+;; carries them verbatim.) Node IDs, edges, and the storage / evaluation /
+;; lifecycle classifications are STRUCTURE and are never touched by the value
+;; walk. Identity-embedded secrets ride the scoped-key projection below, NOT
+;; this list.
+(def value-bearing-node-keys
+  [:value :params :query :state])
+
+;; ---------------------------------------------------------------------------
+;; LIVE RESOURCE IDENTITY redaction (rf2-k0meap.1, extended rf2-qo1l8w).
+;;
+;; The `elide-wire-value` value-field walk redacts a sensitive VALUE sitting
+;; at a node's `:value` / `:params` / `:query` / `:state` summary — it matches
+;; by the FRAME's declared `:sensitive` `:app-db` PATH. But a LIVE resource
+;; node carries its sensitive scope/params in a place that walk can NEVER
+;; reach: the concrete SCOPED KEY `[cache-scope resource-id canonical-params]`
+;; is the node's IDENTITY — it is the node KEY (`[:resource <scoped-key>]`),
+;; the node's `:id`, it is embedded in the `:output` runtime path, in the
+;; `:work-ledger :record :resource/key`, and a route-owned activation surfaces
+;; it as the `:to` end of a `:param` edge. These are STRUCTURE positions, not
+;; value-bearing leaves — and the param/scope they carry are exactly the
+;; "sensitive params/scopes" [spec/Derivations.md] §Redaction metadata names
+;; as egress-bearing.
+;;
+;; A value-path walk is structurally blind to identity-embedded secrets, so
+;; egress must project the scoped-key's secret-bearing components into STABLE
+;; OPAQUE HANDLES: the same scoped key always maps to the same projected key
+;; (graph CONNECTIVITY survives — a redacted param is still an edge), but the
+;; raw scope/params never cross the wire. We mint the handle from the core
+;; CEDN-1 identity primitive (`identity/canonical-bytes`) so it is
+;; deterministic for a given value; a value outside the CEDN-1 domain (or any
+;; error) FAILS CLOSED to the `:rf/redacted` sentinel rather than risk
+;; shipping a host-stringified secret. The middle `resource-id` (a
+;; registration keyword, never sensitive) is PRESERVED so a tool still sees
+;; WHICH resource the node is.
+
+(defn scoped-resource-key?
+  "True when `v` is a live resource SCOPED KEY — a 3-tuple
+  `[cache-scope resource-id canonical-params]` (the resource's concrete
+  live fact identity, [spec/Derivations.md] §Fact identity): the MIDDLE
+  element is the registration `resource-id` keyword and the LAST is the
+  canonical-params MAP (resource params are validated by a `[:map …]`
+  `:params-schema`, so the concrete params are always a map). Requiring the
+  params map is what keeps this from misfiring on an unrelated 3-vector —
+  e.g. the `:output` runtime path `[:rf.runtime/resources :entries …]` has
+  a non-map last element. A static resource node's `:id` is a bare keyword
+  (not this shape), so only LIVE resource identities match. Already-projected
+  handles do NOT re-match (the projected scoped key's tail is an opaque
+  VECTOR, not a map), so re-projection is a no-op — see `opaque-handle`."
+  [v]
+  (and (vector? v)
+       (= 3 (count v))
+       (keyword? (nth v 1))
+       (map? (nth v 2))))
+
+(defn- already-projected?
+  "True when `v` is ALREADY an egress-projected handle — an opaque
+  `[:rf.resource/opaque <digest>]` token or the `:rf/redacted` fail-closed
+  sentinel. Re-projecting such a value MUST be the identity (idempotence): a
+  forwarder pipeline may run egress more than once (re-egress on re-render /
+  re-subscribe / event-bundle), and hashing an already-projected handle would
+  mint a NEW, different handle — silently changing the live node's identity
+  across the boundary and breaking stable graph connectivity."
+  [v]
+  (or (= v privacy/redacted-sentinel)
+      (and (vector? v)
+           (= 2 (count v))
+           (= :rf.resource/opaque (nth v 0)))))
+
+(defn- opaque-handle
+  "A STABLE, ONE-WAY opaque handle for one secret-bearing scoped-key
+  component. Deterministic from the value (same value ⇒ same handle, so
+  graph connectivity survives) but IRREVERSIBLE — it is a HASH of the value's
+  CEDN-1 canonical token, NOT the token itself (the token PRESERVES the raw
+  value, which would defeat redaction). FAILS CLOSED to the `:rf/redacted`
+  sentinel for any value outside the CEDN-1 identity domain or on any error
+  (never host-stringify a secret onto the wire). IDEMPOTENT: an already-
+  projected `[:rf.resource/opaque …]` handle / `:rf/redacted` sentinel is
+  returned UNCHANGED (hashing it again would mint a fresh, DIFFERENT handle
+  and silently change the projected identity on a second egress pass)."
+  [v]
+  (if (already-projected? v)
+    v
+    (try
+      ;; `canonical-bytes` is the deterministic CEDN-1 token (stable for a
+      ;; given value, cross-spelling-invariant); `hash` makes it one-way so the
+      ;; raw scope/params cannot be read back off the wire. Render unsigned hex
+      ;; so the handle is a compact, non-reversible, value-stable token.
+      (let [token  (identity/canonical-bytes v)
+            digest #?(:clj  (Integer/toHexString (hash token))
+                      :cljs (.toString (bit-and (hash token) 0xffffffff) 16))]
+        [:rf.resource/opaque digest])
+      (catch #?(:clj Throwable :cljs :default) _
+        privacy/redacted-sentinel))))
+
+(defn- project-scoped-key
+  "Project a live resource scoped key `[scope resource-id params]` into its
+  egress form `[<scope-handle> resource-id <params-handle>]` — the scope and
+  params replaced by stable opaque handles, the registration `resource-id`
+  preserved. Idempotent: a component already shaped `[:rf.resource/opaque …]`
+  / `:rf/redacted` re-projects to itself (the handle of a handle is stable,
+  and `:rf/redacted` is a non-secret scalar)."
+  [[scope resource-id params]]
+  [(opaque-handle scope) resource-id (opaque-handle params)])
+
+(defn- project-identity-in-path
+  "Replace any live resource scoped key embedded in `path` (e.g. the
+  `:output` runtime path `[:runtime [:rf.runtime/resources :entries
+  <scoped-key>]]`) with its projected form, so the secret-bearing scoped key
+  never egresses through a structure position. Walks the path vector and
+  projects any element that IS a scoped key."
+  [path]
+  (if (sequential? path)
+    (mapv (fn [el]
+            (cond
+              (scoped-resource-key? el) (project-scoped-key el)
+              (sequential? el)          (project-identity-in-path el)
+              :else                     el))
+          path)
+    path))
+
+(defn- project-resource-inputs
+  "Project the live resource node's realized `:inputs`
+  `[[:scope <scope>] [:param <params>]]` — opaque the `[:scope …]` /
+  `[:param …]` payloads (the realized scope + params edges carry the same
+  sensitive identity). Other input shapes ride through untouched. Idempotent:
+  the payload runs through `opaque-handle`, which returns an already-projected
+  handle / `:rf/redacted` UNCHANGED, so re-projecting an already-projected
+  inputs vector is the identity (rf2-g197ep — this is the one input position
+  projected unconditionally rather than gated by the scoped-key shape, so its
+  idempotence MUST come from the handle minter)."
+  [inputs]
+  (if (sequential? inputs)
+    (mapv (fn [in]
+            (if (and (vector? in) (= 2 (count in))
+                     (#{:scope :param} (first in)))
+              [(first in) (opaque-handle (second in))]
+              in))
+          inputs)
+    inputs))
+
+(defn- project-work-id
+  "Project the scoped key embedded in a resource work-id
+  `[:rf.work/resource <scoped-key> <generation>]` — a work-id of another
+  shape (e.g. a non-resource family's work-id, or the historical bare
+  scalar) rides through unchanged (rf2-qo1l8w/rf2-tmyfkn). Idempotent by
+  delegation: `project-scoped-key` already returns an already-projected
+  handle unchanged, regardless of whether the embedded key still LOOKS like
+  a raw `scoped-resource-key?` shape (an opaqued key's tail is a vector, not
+  a map)."
+  [work-id]
+  (if (and (vector? work-id) (= :rf.work/resource (first work-id)))
+    (update work-id 1 project-scoped-key)
+    work-id))
+
+(defn- project-host-transient
+  "Project the work-id embedded in a `:host-transient`
+  `[[:rf.http/in-flight <work-id>]]` in-flight handle address (rf2-qo1l8w)
+  — the abortable-handle address names the SAME work-id the work-ledger
+  link carries, so it must not leak the raw scoped key either. Other
+  shapes ride through untouched."
+  [host-transient]
+  (if (sequential? host-transient)
+    (mapv (fn [entry]
+            (if (and (vector? entry) (= 2 (count entry)) (= :rf.http/in-flight (first entry)))
+              (update entry 1 project-work-id)
+              entry))
+          host-transient)
+    host-transient))
+
+(def ^:private dead-frame-sentinel
+  "A frame id that can NEVER resolve to a live frame, used to FAIL CLOSED a
+  nil / unreachable egress frame WITHOUT borrowing the ambient scope.
+
+  `elide-wire-value` resolves its governing frame as `(or (:frame opts)
+  (frame/resolve-current-frame))` — so a nil `:frame` opt (or no `:frame` at
+  all) falls through to the AMBIENT dynamically-bound frame, applying that
+  frame's (possibly empty) policy and shipping value-bearing fields RAW. An
+  unreachable but NON-nil `:frame` opt instead takes the unresolvable-frame
+  fail-closed branch (`frame/frame` returns nil ⇒ whole value redacted to
+  `:rf/redacted`). We therefore stamp this sentinel as the `:frame` opt when
+  no live governing frame is known, so the walker fails closed on its own
+  dead-frame branch rather than resolving an ambient frame. The keyword is
+  namespaced into this ns so it can never collide with a real frame id."
+  ::no-egress-frame)
+
+(defn- project-resource-node-identity
+  "Project ONE live resource node's secret-bearing identity fields:
+  `:id` (the scoped key), `:output` (the scoped key embedded in the runtime
+  path), the realized `:inputs` `[:scope …]` / `[:param …]` payloads,
+  `:work-ledger :record :resource/key` (the scoped key on the work-ledger
+  summary), the resource work-id embedded in BOTH `:work-ledger :work/id`
+  and `:work-ledger :record :work/id` (rf2-qo1l8w — a THIRD identity
+  position, independent of `:resource/key`), and the `:host-transient`
+  in-flight handle address (which names that SAME work-id). Structure /
+  classification fields are untouched."
+  [node]
+  (cond-> node
+    (scoped-resource-key? (:id node))
+    (update :id project-scoped-key)
+
+    (contains? node :output)
+    (update :output project-identity-in-path)
+
+    (contains? node :inputs)
+    (update :inputs project-resource-inputs)
+
+    (scoped-resource-key? (get-in node [:work-ledger :record :resource/key]))
+    (update-in [:work-ledger :record :resource/key] project-scoped-key)
+
+    (contains? (:work-ledger node) :work/id)
+    (update-in [:work-ledger :work/id] project-work-id)
+
+    (contains? (get-in node [:work-ledger :record]) :work/id)
+    (update-in [:work-ledger :record :work/id] project-work-id)
+
+    (contains? node :host-transient)
+    (update :host-transient project-host-transient)))
+
+(defn- resource-node-key?
+  "True when `node-key` is a LIVE resource node id `[:resource <scoped-key>]`
+  whose scoped key embeds a secret-bearing scope/params. A static resource
+  node is `[:resource <bare-keyword>]`, which does NOT match."
+  [node-key]
+  (and (vector? node-key)
+       (= :resource (first node-key))
+       (scoped-resource-key? (second node-key))))
+
+(defn- project-resource-node-key
+  "Project a live resource node KEY `[:resource <scoped-key>]` to
+  `[:resource <projected-scoped-key>]`; other node keys ride through."
+  [node-key]
+  (if (resource-node-key? node-key)
+    [:resource (project-scoped-key (second node-key))]
+    node-key))
+
+(defn- project-resource-edge-endpoints
+  "Remap any `:from` / `:to` edge endpoint that names a live resource node
+  key to the projected key, so an edge naming a redacted resource node still
+  CONNECTS to it (structure preserved — the same projection applied to keys
+  applies to endpoints, so the remap stays consistent)."
+  [edges]
+  (mapv (fn [edge]
+          (cond-> edge
+            (resource-node-key? (:from edge)) (update :from project-resource-node-key)
+            (resource-node-key? (:to edge))   (update :to project-resource-node-key)))
+        edges))
+
+(defn project-graph
+  "Project a `DerivationGraph` through the FRAME's egress policy for the wire
+  boundary where a tool ships the graph OFF-BOX (rf2-mm3y49; rf2-yjarv6;
+  [spec/Derivations.md] §Redaction metadata; EP-0014 issue-1 disposition).
+
+  This is the egress redaction CALL SITE the tail-2 ruling locates in the
+  consuming tool — NOT in the registrar-derived composer (which composes
+  nodes verbatim, raw-on-box by design). Each node's value-bearing summary
+  field (`:value` / `:params` / `:query` / `:state` —
+  `value-bearing-node-keys`) is walked through the single shared
+  `elide-wire-value` walker under the named `frame-id`'s own elision policy:
+
+  - **per-frame** — the policy is the FRAME's declared `:sensitive` /
+    `:large` `:app-db` classifications (`re-frame.elision`, sourced from
+    the commit-plane classification effects), passed explicitly as the
+    `:frame` opt so the walk applies THAT frame's policy regardless of any
+    ambient scope;
+  - **fail-closed** — `elide-wire-value` redacts the whole value to the
+    `:rf/redacted` sentinel when no frame is reachable (frameless egress
+    under no `:rf.size/include-sensitive?` opt-out); a sensitive-declared
+    value is replaced by the sentinel; a large-declared value by the
+    `:rf.size/large-elided` marker.
+
+  STRUCTURE IS PRESERVED (the headline guarantee): a redacted value / param
+  is still an `:input` / `:param` edge, the node is still present and still
+  classified by its `:kind` superkind. The storage / evaluation / lifecycle
+  classifications, `:source-form`, and `:refinement` are structure, not
+  values, and are never touched.
+
+  LIVE RESOURCE IDENTITY redaction (rf2-k0meap.1, extended rf2-qo1l8w). A
+  live resource node carries its sensitive scope/params NOT in a
+  value-bearing field but in its IDENTITY — the concrete scoped key
+  `[cache-scope resource-id canonical-params]` that is the node KEY
+  (`[:resource <scoped-key>]`), the node's `:id`, and is embedded in the
+  `:output` runtime path, the realized `:inputs` `[:scope …]` / `[:param …]`
+  edges, `:work-ledger :record :resource/key`, the resource work-id
+  embedded in BOTH `:work-ledger :work/id` and `:work-ledger :record
+  :work/id` (a THIRD identity position, independent of `:resource/key`),
+  and the `:host-transient` in-flight handle address (which names that
+  SAME work-id). The `elide-wire-value` value-path walk is structurally
+  BLIND to these identity-embedded secrets. So this projection ALSO replaces
+  each scoped key's secret-bearing scope + params with STABLE OPAQUE HANDLES
+  (`identity/canonical-bytes`-derived, fail-closed to `:rf/redacted` outside
+  the CEDN-1 domain), preserving the registration `resource-id` so a tool
+  still sees WHICH resource the node is. The SAME projection is applied to
+  the `:nodes` keys AND every edge endpoint that names a resource node, so
+  the remap stays CONSISTENT — a redacted resource node is still a node, and
+  the edges naming it still connect (connectivity survives, the raw
+  scope/params never cross the wire).
+
+  `frame-id` is the frame whose elision policy governs egress (the observed
+  app's frame — typically the graph's `:frame` for a live graph). `opts`
+  (optional) ride through to `elide-wire-value` (e.g.
+  `:rf.size/threshold-bytes`); the `:frame` opt is set from `frame-id` and
+  overrides any caller-supplied one (egress redacts under the OBSERVED
+  frame's policy, never a borrowed one).
+
+  FAIL-CLOSED on a nil / UNREACHABLE frame: `elide-wire-value` resolves its
+  governing frame as `(or (:frame opts) (frame/resolve-current-frame))`, so
+  a nil `:frame` opt (or no `:frame` at all) falls through to the AMBIENT
+  dynamically-bound frame and would ship value-bearing fields RAW under that
+  borrowed frame's (possibly empty) policy. Egress must NOT borrow an ambient
+  frame. So this projection first checks the named frame is LIVE
+  (`frame/frame-ids`); when it is not (nil id, a destroyed / never-registered
+  frame), it stamps a DEAD-FRAME SENTINEL as the `:frame` opt — a non-nil id
+  that can never resolve to a live frame — so `elide-wire-value` takes its
+  unresolvable-frame fail-closed branch (`frame/frame` returns nil for it)
+  and redacts the whole value to `:rf/redacted` rather than borrow the
+  ambient frame's marks. This is the silent-leak this contract abolishes — a
+  graph egressing under no reachable policy redacts, never ships raw, even
+  when an ambient frame is dynamically bound (rf2-udkj69).
+
+  Returns the graph with redacted node value fields + projected live
+  resource identities; `:mode` / `:frame` unchanged. IDEMPOTENT — a value may
+  egress more than once (re-egress on re-render / re-subscribe / a forwarder
+  event-bundle), and re-projecting an already-projected graph is the IDENTITY:
+  `project-graph` ∘ `project-graph` == `project-graph` (rf2-g197ep).
+  `elide-wire-value` is a no-op over an already-`:rf/redacted` value (the
+  sentinel is a non-matchable scalar), and the opaque resource handle is
+  idempotent at the source: `opaque-handle` returns an already-
+  `[:rf.resource/opaque …]` handle / `:rf/redacted` sentinel UNCHANGED rather
+  than re-hash it into a fresh, different handle. (Pinned by the
+  derivation-conformance egress arms `g-*` — the cross-family witnesses — and
+  the focused Xray consumer/wiring tests.)"
+  ([graph frame-id] (project-graph graph frame-id nil))
+  ([graph frame-id opts]
+   ;; A reachable (live) frame governs egress under its own policy; a nil /
+   ;; unreachable frame stamps the dead-frame sentinel as the `:frame` opt so
+   ;; `elide-wire-value` takes its unresolvable-frame FAIL-CLOSED branch
+   ;; (whole value ⇒ `:rf/redacted`). We must NOT leave the `:frame` opt
+   ;; absent / nil here: that frameless path lets the walker fall through to
+   ;; the AMBIENT dynamically-bound frame (`frame/resolve-current-frame`) and
+   ;; ship value-bearing fields RAW under that frame's policy — the exact
+   ;; ambient-borrow leak this contract abolishes (rf2-udkj69).
+   (let [reachable? (and (some? frame-id) (contains? (frame/frame-ids) frame-id))
+         walk-opts  (assoc opts :frame (if reachable? frame-id dead-frame-sentinel))
+         redact-node
+         (fn [node]
+           (-> (reduce
+                (fn [n k]
+                  (if (contains? n k)
+                    (assoc n k (elision/elide-wire-value (get n k) walk-opts))
+                    n))
+                node
+                value-bearing-node-keys)
+               ;; the live resource scoped-key identity walk (rf2-k0meap.1) —
+               ;; the secrets the value-path walk above cannot reach.
+               project-resource-node-identity))]
+     (-> graph
+         ;; remap node KEYS so a live resource scoped key no longer carries
+         ;; raw scope/params in the node id (and the edge endpoints below
+         ;; stay consistent with the remapped keys).
+         (update :nodes (fn [nodes]
+                          (into {}
+                                (map (fn [[k node]]
+                                       [(project-resource-node-key k)
+                                        (redact-node node)]))
+                                nodes)))
+         (update :edges (fn [edges]
+                          (project-resource-edge-endpoints (or edges []))))))))
+
+;; ---- bundle-isolation sentinel ------------------------------------------
+;;
+;; Mirrors the algebra-view siblings / `re-frame.derivation.graph` composer
+;; pattern (rf2-6xm07h et al.): `implementation/scripts/check-bundle-
+;; isolation.cjs` greps the counter production bundle for this exact string.
+;; It lives ONLY in this file's source body — no other namespace, no
+;; docstring, no test fixture references it — so its presence in the
+;; production counter bundle proves this egress-redaction tooling ns's body
+;; got pulled in (most likely via a stray `:require` from a
+;; production-reachable ns). This ns is consumed only by dev tools (Xray) +
+;; the conformance fixtures, which `:require` it directly; the counter
+;; example never does. The string survives `:advanced` because string
+;; literals are not renamed; it sits outside any `interop/debug-enabled?`
+;; gate so DCE cannot drop the literal independently of the surrounding ns
+;; body.
+
+(defonce ^:private bundle-isolation-sentinel
+  "rf.derivation.egress/sentinel:rf2-mm3y49-2026-07-10:do-not-rename")

--- a/implementation/derivation-conformance/test/re_frame/derivation_algebra_conformance_cljs_test.cljc
+++ b/implementation/derivation-conformance/test/re_frame/derivation_algebra_conformance_cljs_test.cljc
@@ -110,15 +110,18 @@
             [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
             ;; EP-0015 / EP-0017 redaction conformance arms (rf2-zt5j96 /
-            ;; rf2-iormgq) — the in-tree egress primitives the umbrella egress
-            ;; arms compose: `re-frame.identity` mints the stable opaque
-            ;; scoped-key handle (the CEDN-1 canonical-bytes hash), and
-            ;; `re-frame.privacy` carries the `:rf/redacted` sentinel
-            ;; `rf/elide-wire-value` writes. These are `implementation/`-resident
-            ;; (NOT a `tools/` reach), so the cross-family conformance surface
-            ;; proves the egress LAW over the REAL composer output without
-            ;; importing the named first-consumer Xray (bundle isolation).
-            [re-frame.identity :as identity]
+            ;; rf2-iormgq): the OFF-BOX graph-egress projection is owned by the
+            ;; bundle-isolated core tooling ns `re-frame.derivation.egress`
+            ;; (rf2-mm3y49) — the ONE algorithm the named first-consumer Xray's
+            ;; `redact-graph-for-egress` ALSO delegates to. This suite tests
+            ;; that owner DIRECTLY over the REAL composer output, so the
+            ;; cross-family egress LAW and the Xray call site can never drift.
+            ;; `re-frame.privacy` carries the `:rf/redacted` sentinel the
+            ;; fail-closed arms assert. All `implementation/`-resident (NOT a
+            ;; `tools/` reach — the dependency arrow flows conformance →
+            ;; implementation, never conformance → tools; bundle isolation
+            ;; preserved).
+            [re-frame.derivation.egress :as egress]
             [re-frame.privacy :as privacy]
             ;; EP-0025: the derived-output sensitivity INHERITANCE conformance
             ;; (§H) is removed — classification no longer propagates input →
@@ -1177,284 +1180,29 @@
 ;; derived value leaving through an identity-embedded graph position, nor a
 ;; projection that drops graph connectivity. These arms close that gap.
 ;;
-;; ## Where the egress boundary lives, and why this surface re-composes it
+;; ## Where the egress boundary lives, and why this suite tests the owner
 ;;
-;; The graph-level egress CALL SITE is BORN in the named first consumer Xray
-;; (`day8.re-frame2-xray.panels.derivation-graph-helpers/redact-graph-for-egress`)
-;; — a `tools/` artefact this cross-family conformance surface MUST NOT
-;; `:require` (tools/README.md bundle isolation: the dependency arrow flows
-;; conformance → implementation, never conformance → tools). But that call
-;; site is built ENTIRELY from `implementation/`-resident primitives:
-;; `rf/elide-wire-value` (the single shared per-frame fail-closed value
-;; walker, EP-0015 §11) for value-bearing node fields, and
-;; `identity/canonical-bytes` (the CEDN-1 canonical token, EP-0012) hashed
-;; into a stable opaque handle for the identity-embedded scoped key the
-;; value-path walk is structurally blind to. So these arms re-compose the
-;; SAME egress projection from those in-tree primitives and run it over the
-;; REAL composer output (`graph/live-derivation-graph` over contributors that
-;; return the realized sensitive shapes) — proving the LAW holds against the
-;; actual assembled graph, with no tool reach. `egress-project-graph` below
-;; is the conformance surface's faithful mirror of the Xray call site's
-;; semantics; if the law it asserts ever diverges from the tool, the Xray
-;; redaction suite (`derivation-graph-redaction-cljs-test`) is the per-tool
-;; pin and this is the cross-family pin — two independent witnesses to one
-;; law.
+;; The graph egress redaction ALGORITHM is OWNED by the bundle-isolated core
+;; tooling ns `re-frame.derivation.egress/project-graph` (rf2-mm3y49). It was
+;; previously duplicated as this suite's own in-tree mirror AND the named
+;; first-consumer Xray call site
+;; (`day8.re-frame2-xray.panels.derivation-graph-helpers/redact-graph-for-egress`),
+;; which drifted; both now DELEGATE to the one core owner. This suite tests
+;; that owner DIRECTLY (`egress/project-graph`) — NOT the Xray consumer, a
+;; `tools/` artefact this cross-family conformance surface MUST NOT `:require`
+;; (tools/README.md bundle isolation: the dependency arrow flows conformance →
+;; implementation, never conformance → tools). Because the owner lives in
+;; `implementation/core` and is built entirely from `implementation/`-resident
+;; primitives (`elide-wire-value` value walker + `canonical-bytes` opaque
+;; handle), the suite reaches the SAME algorithm Xray runs, with no tool
+;; reach. These arms run it over the REAL composer output
+;; (`graph/live-derivation-graph` over contributors that return the realized
+;; sensitive shapes) — proving the LAW holds against the actual assembled
+;; graph. The Xray redaction suite
+;; (`derivation-graph-redaction-cljs-test`) keeps FOCUSED consumer/wiring
+;; pins over the same owner; this is the cross-family pin — two witnesses to
+;; one shared algorithm.
 ;; ===========================================================================
-
-;; ---- the in-tree egress projection (mirrors the Xray call site) ----------
-
-(defn- already-projected-handle?
-  "True when `v` is ALREADY an egress-projected handle — an opaque
-  `[:rf.resource/opaque <digest>]` token or the `:rf/redacted` fail-closed
-  sentinel. Re-projecting such a value MUST be the identity (idempotence):
-  the conformance mirror models the SAME forwarder-pipeline contract the Xray
-  call site does — a value may egress more than once, and hashing an
-  already-projected handle would mint a NEW handle and silently change the
-  live node identity across the boundary."
-  [v]
-  (or (= v privacy/redacted-sentinel)
-      (and (vector? v)
-           (= 2 (count v))
-           (= :rf.resource/opaque (nth v 0)))))
-
-(defn- opaque-scoped-key-handle
-  "A STABLE, ONE-WAY opaque handle for one secret-bearing scoped-key
-  component — the `implementation/`-resident analogue of the Xray
-  `opaque-handle`. Deterministic from the value (same value ⇒ same handle,
-  so connectivity survives) but IRREVERSIBLE: a HASH of the value's CEDN-1
-  canonical token (`identity/canonical-bytes`), never the token itself.
-  FAILS CLOSED to the `:rf/redacted` sentinel for any value outside the
-  CEDN-1 identity domain or on any error — never host-stringify a secret
-  onto the wire. IDEMPOTENT: an already-projected `[:rf.resource/opaque …]`
-  handle / `:rf/redacted` sentinel is returned UNCHANGED (hashing it again
-  would mint a fresh, DIFFERENT handle on a second egress pass)."
-  [v]
-  (if (already-projected-handle? v)
-    v
-    (try
-      (let [token  (identity/canonical-bytes v)
-            digest #?(:clj  (Integer/toHexString (hash token))
-                      :cljs (.toString (bit-and (hash token) 0xffffffff) 16))]
-        [:rf.resource/opaque digest])
-      (catch #?(:clj Throwable :cljs :default) _
-        privacy/redacted-sentinel))))
-
-(defn- scoped-resource-key?
-  "True when `v` is a live resource SCOPED KEY — a 3-tuple
-  `[cache-scope resource-id canonical-params]` (the resource's concrete live
-  fact identity, Derivations §Fact identity): the MIDDLE element is the
-  registration `resource-id` keyword and the LAST is the canonical-params
-  MAP. A static resource node's `:id` is a bare keyword (not this shape), so
-  only LIVE resource identities match; an already-projected scoped key keeps
-  the shape, so re-projection is well-defined."
-  [v]
-  (and (vector? v)
-       (= 3 (count v))
-       (keyword? (nth v 1))
-       (map? (nth v 2))))
-
-(defn- project-scoped-key
-  "Project a live resource scoped key `[scope resource-id params]` into its
-  egress form `[<scope-handle> resource-id <params-handle>]` — the scope and
-  params replaced by stable opaque handles, the registration `resource-id`
-  PRESERVED (a tool still sees WHICH resource). Idempotent."
-  [[scope resource-id params]]
-  [(opaque-scoped-key-handle scope) resource-id (opaque-scoped-key-handle params)])
-
-(defn- project-identity-in-path
-  "Replace any live resource scoped key embedded in `path` (e.g. the
-  `:output` runtime path `[:runtime [:rf.runtime/resources :entries
-  <scoped-key>]]`) with its projected form, so the secret-bearing scoped key
-  never egresses through a structure position."
-  [path]
-  (if (sequential? path)
-    (mapv (fn [el]
-            (cond
-              (scoped-resource-key? el) (project-scoped-key el)
-              (sequential? el)          (project-identity-in-path el)
-              :else                     el))
-          path)
-    path))
-
-(defn- project-resource-inputs
-  "Project a live resource node's realized `:inputs`
-  `[[:scope <scope>] [:param <params>]]` — opaque the `[:scope …]` /
-  `[:param …]` payloads (the realized scope + params edges carry the same
-  sensitive identity). Other input shapes ride through untouched. Idempotent:
-  the payload runs through `opaque-scoped-key-handle`, which returns an
-  already-projected handle / `:rf/redacted` UNCHANGED, so re-projecting an
-  already-projected inputs vector is the identity (rf2-g197ep — this is the
-  one input position projected unconditionally rather than gated by the
-  scoped-key shape, so its idempotence MUST come from the handle minter)."
-  [inputs]
-  (if (sequential? inputs)
-    (mapv (fn [in]
-            (if (and (vector? in) (= 2 (count in)) (#{:scope :param} (first in)))
-              [(first in) (opaque-scoped-key-handle (second in))]
-              in))
-          inputs)
-    inputs))
-
-(defn- project-work-id
-  "Project the scoped key embedded in a resource work-id
-  `[:rf.work/resource <scoped-key> <generation>]` — a work-id of another
-  shape (e.g. a non-resource family's work-id) rides unchanged. Mirrors
-  `re-frame.resources.tooling/project-work-id` (rf2-0t0l3w); re-composed here
-  from the in-tree primitives per this suite's egress-mirror contract
-  (rf2-tmyfkn). Idempotent by delegation: `project-scoped-key` /
-  `opaque-scoped-key-handle` already return an already-projected handle
-  unchanged, regardless of whether the embedded key still LOOKS like a raw
-  `scoped-resource-key?` shape (an opaqued key's tail is a vector, not a
-  map — see `opaque-scoped-key-handle`'s docstring)."
-  [work-id]
-  (if (and (vector? work-id) (= :rf.work/resource (first work-id)))
-    (update work-id 1 project-scoped-key)
-    work-id))
-
-(defn- project-host-transient
-  "Project the work-id embedded in a `:host-transient`
-  `[[:rf.http/in-flight <work-id>]]` in-flight handle address (rf2-tmyfkn) —
-  the abortable-handle address names the SAME work-id the work-ledger link
-  carries, so it must not leak the raw scoped key either. Other shapes ride
-  through untouched."
-  [host-transient]
-  (if (sequential? host-transient)
-    (mapv (fn [entry]
-            (if (and (vector? entry) (= 2 (count entry)) (= :rf.http/in-flight (first entry)))
-              (update entry 1 project-work-id)
-              entry))
-          host-transient)
-    host-transient))
-
-(defn- project-resource-node-identity
-  "Project ONE live resource node's secret-bearing IDENTITY fields — the
-  positions the value-path `rf/elide-wire-value` walk is structurally blind
-  to: `:id` (the scoped key), `:output` (the scoped key embedded in the
-  runtime path), the realized `:inputs` `[:scope …]` / `[:param …]` payloads,
-  `:work-ledger :record :resource/key`, the resource work-id embedded in
-  BOTH `:work-ledger :work/id` and `:work-ledger :record :work/id` (rf2-
-  tmyfkn — a THIRD identity position, independent of `:resource/key`), and
-  the `:host-transient` in-flight handle address (which names that SAME
-  work-id). Structure / classification fields are untouched."
-  [node]
-  (cond-> node
-    (scoped-resource-key? (:id node))
-    (update :id project-scoped-key)
-
-    (contains? node :output)
-    (update :output project-identity-in-path)
-
-    (contains? node :inputs)
-    (update :inputs project-resource-inputs)
-
-    (scoped-resource-key? (get-in node [:work-ledger :record :resource/key]))
-    (update-in [:work-ledger :record :resource/key] project-scoped-key)
-
-    (contains? (:work-ledger node) :work/id)
-    (update-in [:work-ledger :work/id] project-work-id)
-
-    (contains? (get-in node [:work-ledger :record]) :work/id)
-    (update-in [:work-ledger :record :work/id] project-work-id)
-
-    (contains? node :host-transient)
-    (update :host-transient project-host-transient)))
-
-(defn- resource-node-key?
-  "True when `node-key` is a LIVE resource node id `[:resource <scoped-key>]`
-  whose scoped key embeds a secret-bearing scope/params. A static resource
-  node key `[:resource <bare-keyword>]` does NOT match."
-  [node-key]
-  (and (vector? node-key)
-       (= :resource (first node-key))
-       (scoped-resource-key? (second node-key))))
-
-(defn- project-resource-node-key
-  "Project a live resource node KEY `[:resource <scoped-key>]` to
-  `[:resource <projected-scoped-key>]`; other node keys ride through."
-  [node-key]
-  (if (resource-node-key? node-key)
-    [:resource (project-scoped-key (second node-key))]
-    node-key))
-
-(def ^:private value-bearing-node-keys
-  "The value-bearing summary fields the egress walk runs through
-  `rf/elide-wire-value` under the frame's policy (Xray's
-  `value-bearing-node-keys`). Identity-embedded positions are handled by the
-  scoped-key projection, not this value walk."
-  [:value :params :query :state])
-
-(def ^:private dead-egress-frame-sentinel
-  "A frame id that can NEVER resolve to a live frame — the conformance
-  mirror's fail-closed stamp for a nil / unreachable egress frame, matching
-  the Xray helper's `dead-frame-sentinel`. Stamped as the `:frame` opt so
-  `rf/elide-wire-value` takes its unresolvable-frame branch (whole value ⇒
-  `:rf/redacted`) instead of resolving the ambient bound frame."
-  ::no-egress-frame)
-
-(defn- egress-project-graph
-  "Project a `DerivationGraph` through `frame-id`'s egress policy for the
-  off-box wire boundary — the conformance surface's faithful mirror of the
-  Xray `redact-graph-for-egress` call site, built from `implementation/`
-  primitives only (no tools reach).
-
-    - value-bearing node fields → `rf/elide-wire-value` under the named
-      frame's own policy (passed as the `:frame` opt so it applies THAT
-      frame's classification regardless of any ambient scope);
-    - FAIL-CLOSED on a nil / UNREACHABLE frame — `rf/elide-wire-value`
-      resolves its governing frame as `(or (:frame opts)
-      (frame/resolve-current-frame))`, so a nil `:frame` opt falls through to
-      the AMBIENT dynamically-bound frame and would ship the value RAW under
-      its (here `:rf/default`, empty) policy. A NON-nil but unreachable
-      `:frame` opt instead takes the unresolvable-frame fail-closed branch
-      (rf2-t55hxg.18: a frame-id alone is not policy-bearing — it must
-      resolve to a live frame via `frame/frame`, else the walker fails closed
-      to `:rf/redacted`). So when `frame-id` is nil or names no LIVE frame we
-      stamp a DEAD-FRAME SENTINEL as the `:frame` opt — a non-nil id that can
-      never resolve — so the walker takes its dead-frame fail-closed branch
-      rather than resolving an AMBIENT frame (which, unlike Xray's
-      `:ambient-frame nil` harness, this cross-family fixture binds to
-      `:rf/default`). A nil / absent `:frame` would let the frameless walk
-      resolve to that ambient frame and ship the value RAW (rf2-udkj69);
-    - identity-embedded scoped keys (node KEY, `:id`, `:output`, `:inputs`,
-      `:work-ledger :record :resource/key`, AND every edge endpoint) →
-      stable opaque handles, the SAME projection applied consistently so the
-      remap keeps connectivity.
-
-  `:mode` / `:frame` unchanged; STRUCTURE preserved (a redacted value/param
-  is still an edge; the node is still present + classified)."
-  [graph frame-id]
-  ;; Carry a NON-nil `:frame` opt so `rf/elide-wire-value` never falls through
-  ;; to the ambient frame. A LIVE frame applies its own policy; a nil /
-  ;; unreachable frame stamps the dead-frame sentinel so the walker takes its
-  ;; unresolvable-frame fail-closed branch (redact whole) — NEVER resolving
-  ;; the ambient `:rf/default` this fixture binds (rf2-udkj69).
-  (let [reachable? (and (some? frame-id) (contains? (rf/frame-ids) frame-id))
-        walk-opts  {:frame (if reachable? frame-id dead-egress-frame-sentinel)}
-        redact-node
-        (fn [node]
-          (-> (reduce
-                (fn [n k]
-                  (if (contains? n k)
-                    (assoc n k (rf/elide-wire-value (get n k) walk-opts))
-                    n))
-                node
-                value-bearing-node-keys)
-              project-resource-node-identity))]
-    (-> graph
-        (update :nodes (fn [nodes]
-                         (into {}
-                               (map (fn [[k node]]
-                                      [(project-resource-node-key k)
-                                       (redact-node node)]))
-                               nodes)))
-        (update :edges (fn [edges]
-                         (mapv (fn [edge]
-                                 (cond-> edge
-                                   (resource-node-key? (:from edge))
-                                   (update :from project-resource-node-key)
-                                   (resource-node-key? (:to edge))
-                                   (update :to project-resource-node-key)))
-                               (or edges [])))))))
 
 ;; ---- (g) resource identity egress redaction (rf2-zt5j96) -----------------
 ;;
@@ -1565,7 +1313,7 @@
   ;; SAME stable opaque scoped key, and edges still connect.
   (rf/reg-frame egress-frame {:doc "off-box egress conformance frame"})
   (let [raw      (graph/live-derivation-graph egress-frame (egress-live-contributors))
-        redacted (egress-project-graph raw egress-frame)]
+        redacted (egress/project-graph raw egress-frame)]
 
     (testing "PRECONDITION — the composer assembled the live sensitive resource
               node + its route-owned activation edge over the concrete scoped
@@ -1692,7 +1440,7 @@
     (testing "egress under an UNKNOWN frame fails closed: the value-bearing
               field is redacted to :rf/redacted (no reachable policy ⇒ no raw
               ship), and the identity scoped key is opaqued — NO secret survives"
-      (let [redacted (egress-project-graph raw :app/does-not-exist)
+      (let [redacted (egress/project-graph raw :app/does-not-exist)
             sub      (get-in redacted [:nodes [:sub [:cart/items]]])]
         (is (= privacy/redacted-sentinel (:value sub))
             "the whole value-bearing field is redacted under no reachable policy")
@@ -1709,7 +1457,7 @@
         (is (some? (frame/resolve-current-frame))
             "PRECONDITION — an ambient frame IS dynamically bound, so a frameless
              walk WOULD resolve it (the borrow this arm forbids)")
-        (let [redacted (egress-project-graph raw nil)
+        (let [redacted (egress/project-graph raw nil)
               sub      (get-in redacted [:nodes [:sub [:cart/items]]])]
           (is (= privacy/redacted-sentinel (:value sub))
               "nil frame ⇒ the whole value-bearing field is redacted, NOT shipped
@@ -1718,7 +1466,7 @@
               "no raw secret survives a nil-frame egress under an ambient binding"))))
     (testing "egress under the KNOWN frame redacts the frame-declared sensitive
               value path while keeping the structure"
-      (let [redacted (egress-project-graph raw egress-frame)
+      (let [redacted (egress/project-graph raw egress-frame)
             sub      (get-in redacted [:nodes [:sub [:cart/items]]])]
         (is (= privacy/redacted-sentinel (get-in sub [:value :cart :items]))
             "the frame-declared sensitive [:cart :items] leaf is redacted")
@@ -1743,8 +1491,8 @@
   ;; that catches it; it FAILS against the pre-fix unconditional re-hash.
   (rf/reg-frame egress-frame {})
   (let [raw   (graph/live-derivation-graph egress-frame (egress-live-contributors))
-        once  (egress-project-graph raw egress-frame)
-        twice (egress-project-graph once egress-frame)
+        once  (egress/project-graph raw egress-frame)
+        twice (egress/project-graph once egress-frame)
         node1 (-> once :nodes vals first)
         node2 (-> twice :nodes vals first)]
     (is (not (contains-secret? twice)) "still no secret after double projection")
@@ -1784,7 +1532,7 @@
 ;; (g+) THE REAL RESOURCE-CACHE GRAPH EGRESS PATH (rf2-uh2clr).
 ;;
 ;; Every (g) arm above proves the UMBRELLA egress-projection LAW
-;; (`egress-project-graph`, this suite's in-tree Xray-call-site mirror)
+;; (`egress/project-graph`, the core-owned algorithm Xray also delegates to)
 ;; against a hand-built SYNTHETIC contributor (`egress-live-contributors`) —
 ;; correct for pinning the projection HELPER in isolation, but it never
 ;; drives the PRODUCTION wiring: `re-frame.resources.tooling/

--- a/implementation/scripts/check-bundle-isolation.cjs
+++ b/implementation/scripts/check-bundle-isolation.cjs
@@ -435,6 +435,33 @@ const ARTEFACTS = [
     expectedAllowListHits: 0,
   },
 
+  // re-frame.derivation.egress (rf2-mm3y49 — the OFF-BOX graph-egress
+  // redaction ALGORITHM centralized out of the two drifting copies: the Xray
+  // call site (`derivation-graph-helpers/redact-graph-for-egress`) and the
+  // derivation-conformance suite's in-tree mirror. It lives in core/src beside
+  // the derivation-graph composer but is TOOLING: it is NOT exposed from the
+  // `re-frame.core` facade and NOT `:require`d by any production-reachable ns
+  // — only Xray (whose `redact-graph-for-egress` delegates to it) and the
+  // conformance fixtures `:require` it directly, so the counter example never
+  // loads it and Closure `:advanced` + goog.DEBUG=false DCE its body
+  // wholesale. A non-zero hit means the egress ns got dragged into the counter
+  // bundle (most likely a stray `:require` from a production-reachable ns, or
+  // an accidental re-export from the core facade). Sentinel mirrors the
+  // derivation-graph / algebra-view sibling shape: a unique string planted at
+  // the bottom of the namespace body, surviving `:advanced` (string literals
+  // are not renamed) and outside any DCE gate.
+  {
+    name: 'derivation-egress',
+    internalSentinels: [
+      // derivation/egress.cljc — explicit sentinel planted at the bottom
+      // of the namespace body (`bundle-isolation-sentinel`).
+      { source: 're-frame.derivation.egress (bundle-isolation-sentinel)',
+        sentinel: 'rf.derivation.egress/sentinel:rf2-mm3y49-2026-07-10:do-not-rename' },
+    ],
+    consumerAllowList: null,
+    expectedAllowListHits: 0,
+  },
+
   // re-frame.trace.cascade (rf2-931pm — focused-event-only cascade-DAG
   // aggregator). Same posture as `trace.tooling`: the namespace is
   // autoloaded from `re-frame.core` only via the JVM-only conditional

--- a/tools/xray/spec/025-Derivation-Graph-Panel.md
+++ b/tools/xray/spec/025-Derivation-Graph-Panel.md
@@ -179,7 +179,15 @@ The egress redaction **call site is born here** — the wire boundary where a
 tool ships the graph **off** the developer's box (an MCP surface streaming
 the graph to a remote agent, a serialized capture written to disk / posted
 to a service). `derivation-graph-helpers/redact-graph-for-egress` is that
-call site:
+call site. The redaction **algorithm** itself is owned by the
+bundle-isolated core tooling ns `re-frame.derivation.egress/project-graph`
+(rf2-mm3y49): `redact-graph-for-egress` is a thin **delegate** to it, so this
+panel and the derivation-conformance suite share **one** implementation
+rather than the two drifting copies they used to maintain. The owner lives in
+`implementation/core` and is built entirely from `implementation/`-resident
+primitives (`elide-wire-value` + `canonical-bytes`), so the delegation adds
+no `tools/` → `implementation/` dependency inversion. The call site behaves as
+follows:
 
 - each node's value-bearing summary field (`:value` / `:params` / `:query`
   / `:state`) is projected through the single shared `rf/elide-wire-value`
@@ -284,9 +292,11 @@ graph` with the override input layered on top.
 
 Same contract as every Xray panel — observing the graph pins nothing,
 dispatches nothing, mutates no host state. Pure hiccup; the projection
-algebra + the egress redaction call site live in
-`derivation_graph_helpers.cljc` (JVM-portable). Frame isolation comes from
-the enclosing `[rf/frame-provider {:frame :rf/xray}]` in `shell.cljs`.
+algebra + the egress redaction **call site** live in
+`derivation_graph_helpers.cljc` (JVM-portable), which **delegates** the
+redaction algorithm itself to the core-owned
+`re-frame.derivation.egress/project-graph` (rf2-mm3y49). Frame isolation comes
+from the enclosing `[rf/frame-provider {:frame :rf/xray}]` in `shell.cljs`.
 
 ## Test coverage
 
@@ -295,38 +305,29 @@ the enclosing `[rf/frame-provider {:frame :rf/xray}]` in `shell.cljs`.
   node degree; on-box `summarize` raw-permitting posture; `summarize-node`
   structure preservation; `graph-summary` tallies.
 - **`derivation_graph_redaction_cljs_test.cljc`** (JVM + node, runtime
-  fixture) — the **positive** off-box egress test (rf2-yjarv6): a sensitive
-  node value run through `rf/elide-wire-value` is elided **while** the node
-  + edge structure survives (the "redact value, keep edge" arm the EP-0014
+  fixture) — the **consumer/wiring** pin for the delegate (rf2-mm3y49). The
+  redaction algorithm is owned by `re-frame.derivation.egress` and its
+  COMPREHENSIVE coverage lives in the derivation-conformance egress arms
+  (`g-*`); this suite proves the Xray delegate wires that algorithm through,
+  across the frame-policy value walk and the resource-identity projection.
+  The **positive** off-box egress test (rf2-yjarv6): a sensitive node value
+  run through the frame's `elide-wire-value` is elided **while** the node +
+  edge structure survives (the "redact value, keep edge" arm the EP-0014
   testing-coverage audit flagged as missing); large elision → marker keeping
   structure; per-frame policy (a non-classifying frame ships the same value
   raw); frameless fail-closed — including the **nil-frame-under-an-ambient-
   binding** arm (rf2-udkj69): a nil frame-id while an ambient frame is bound
-  must still redact, never borrow that ambient frame and ship raw. Plus the
-  **adversarial** live resource
-  identity arm (rf2-k0meap.1): a live resource scoped key carrying a session
-  token in BOTH its cache scope and its canonical params, with an in-flight
-  work-ledger record and a route-owned `:param` edge naming it — asserting
-  NO raw secret survives anywhere in the egressed graph (node key, `:id`,
-  `:inputs`, `:output`, work-ledger, edges) while connectivity survives (the
-  node is still classified, the edge still connects to the projected key),
-  the projection is deterministic across all identity positions, and it is
-  **idempotent** — `project(project(x)) == project(x)`, asserted as full graph
-  equality across two (and three) passes plus per-position witnesses (node
-  keys, `:id`, `:inputs`, `:output`, work-ledger `:resource/key`, edges), so a
-  forwarder pipeline that re-egresses an already-projected graph cannot drift
-  the realized `:inputs` handles (rf2-g197ep). Plus the **work-id /
-  host-transient identity** arm (rf2-qo1l8w): a resource-shaped work-id
-  (`[:rf.work/resource <scoped-key> <generation>]`) embedding the same
-  session-token secret, planted directly into `:work-ledger :work/id`,
-  `:work-ledger :record :work/id`, and `:host-transient` (bypassing the
-  upstream `resources.tooling/project-work-id` pre-projection that masks this
-  gap in production) — asserting no raw secret survives in any of those three
-  positions, the resource work-id shape (`:rf.work/resource` head +
-  generation) survives projection, and the same opaque scoped-key handle is
-  consistent across all three positions (mirrors the derivation-conformance
-  egress mirror's `project-work-id` / `project-host-transient` fix,
-  rf2-tmyfkn/rf2-uh2clr, closing the same latent gap in the real call site).
+  must still redact, never borrow that ambient frame and ship raw. Plus one
+  **identity-projection wiring smoke**: a live resource scoped key carrying a
+  session token in BOTH its cache scope and canonical params (and inside its
+  canonical work-id / host-transient), with a route-owned `:param` edge naming
+  it — asserting NO raw secret survives anywhere in the egressed graph while
+  connectivity survives (the node stays classified, the edge remaps to the
+  projected key), the registration resource-id stays visible, and every
+  identity position projects to the SAME opaque scoped key. The exhaustive
+  per-position, work-id/host-transient, and idempotence depth is proven once,
+  in derivation-conformance, against the shared owner — Xray does not re-prove
+  the algorithm.
 - **`derivation_graph_consumer_cljs_test.cljs`** (node) — the **behavioral
   consumer** test (rf2-4wtllq): registers the panel handlers via
   `registry/register-xray-handlers!` + `test-support/install-test-overrides!`

--- a/tools/xray/src/day8/re_frame2_xray/panels/derivation_graph_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/derivation_graph_helpers.cljc
@@ -52,23 +52,30 @@
   a service). Per [Derivations.md] §Redaction metadata and the EP-0014
   issue-1 disposition, the graph SHOULD be useful WITHOUT exposing sensitive
   raw values: each node's value-bearing summary fields are projected through
-  the single shared `rf/elide-wire-value` walker
-  ([009 §Privacy], [015-Data-Classification], [Managed-Effects §5]) under
-  the FRAME's own elision policy (`re-frame.elision`, per-frame, fail-closed
-  when frameless). Redaction MUST NOT lose graph STRUCTURE — a redacted
-  param is still an edge; the node is still present + classified. The
-  composer itself stays RAW-ON-BOX by design; this projection is the
+  the frame's `elide-wire-value` walker under the FRAME's own elision policy
+  (per-frame, fail-closed when frameless), and identity-embedded resource
+  scope/params are opaqued. Redaction MUST NOT lose graph STRUCTURE — a
+  redacted param is still an edge; the node is still present + classified.
+  The composer itself stays RAW-ON-BOX by design; this projection is the
   consuming tool's egress obligation, not the composer's.
+
+  The redaction ALGORITHM itself is OWNED by the bundle-isolated core tooling
+  ns `re-frame.derivation.egress` (rf2-mm3y49) — `redact-graph-for-egress`
+  is a thin DELEGATE to `egress/project-graph`, so this call site and the
+  derivation-conformance suite share ONE implementation rather than drifting
+  copies. This panel remains the named CALL SITE; the projection lives in
+  core (built from `implementation/`-resident primitives only, so no
+  `tools/` → `implementation/` dependency inversion).
 
   JVM-portable (`.cljc`) so the projection + redaction contracts are pinned
   by the JVM test corpus without a CLJS runtime."
   (:require [clojure.string :as str]
-            [re-frame.core :as rf]
-            ;; Xray is a bundle-isolated dev tool (nothing in implementation/
-            ;; `:require`s here), so it may reach the core CEDN-1 identity
-            ;; primitive directly to mint the STABLE opaque handles the live
-            ;; resource scoped-key egress projection uses (rf2-k0meap.1).
-            [re-frame.identity :as identity]))
+            ;; Off-box egress redaction is owned by the bundle-isolated core
+            ;; tooling ns `re-frame.derivation.egress` (rf2-mm3y49); this panel
+            ;; DELEGATES to it. Xray is a dev tool, so reaching an
+            ;; implementation/ ns preserves the tools → implementation
+            ;; dependency arrow (nothing in implementation/ requires Xray).
+            [re-frame.derivation.egress :as egress]))
 
 ;; ---------------------------------------------------------------------------
 ;; Superkind classification (the contract axis).
@@ -208,16 +215,14 @@
              :redacted? redacted?}
       (coll? v) (assoc :size (count v)))))
 
-;; The value-bearing summary fields a LIVE node may carry — the value
-;; summaries [Derivations.md] §Redaction metadata names as egress-bearing
-;; once shipped off-box: a sub-cache entry's `:value`, a route slice's
-;; `:params` / `:query`, a machine instance's `:state` summary, a resource
-;; entry's `:work-ledger` summary. (Each is the in-process value summary the
-;; sibling lives surface; the composer carries them verbatim.) Node IDs,
-;; edges, and the storage/evaluation/lifecycle classifications are STRUCTURE
-;; and are never touched.
-(def value-bearing-node-keys
-  [:value :params :query :state])
+;; The value-bearing summary fields a LIVE node may carry (the `:value` /
+;; `:params` / `:query` / `:state` summaries [Derivations.md] §Redaction
+;; metadata names as egress-bearing off-box). ON-BOX `summarize-node` bounds
+;; them for display; OFF-BOX `redact-graph-for-egress` walks them through the
+;; frame's elision policy. ONE source of truth: the list is owned by the
+;; core egress algorithm ns (rf2-mm3y49) and aliased here for the on-box
+;; summary path so the two never drift.
+(def value-bearing-node-keys egress/value-bearing-node-keys)
 
 (defn summarize-node
   "Attach an ON-BOX `:summaries {<k> <summary>}` map to a node for any
@@ -239,368 +244,34 @@
   (update graph :nodes update-vals summarize-node))
 
 ;; ===========================================================================
-;; OFF-BOX EGRESS REDACTION (rf2-yjarv6) — the call site the EP-0014 tail-2
-;; redaction ruling says is BORN HERE.
+;; OFF-BOX EGRESS REDACTION (rf2-yjarv6, centralized rf2-mm3y49).
+;;
+;; The redaction ALGORITHM — scoped-key / work-id / host-transient /
+;; resource-node / edge-endpoint / dead-frame fail-closed / opaque-handle /
+;; idempotent whole-graph projection — is OWNED by the bundle-isolated core
+;; tooling ns `re-frame.derivation.egress`. It previously existed as two
+;; drifting copies (this call site + the derivation-conformance suite's
+;; in-tree mirror); a fix had to land in both and Xray lagged. Both now
+;; DELEGATE to the one owner (rf2-mm3y49). This panel is still the EGRESS
+;; CALL SITE the EP-0014 tail-2 ruling names — the wire boundary where a tool
+;; ships the graph OFF the developer's box (an MCP surface streaming to a
+;; remote agent, a serialized capture written to disk / posted to a service)
+;; — but the projection itself is `egress/project-graph`.
 ;; ===========================================================================
 
-;; ---------------------------------------------------------------------------
-;; LIVE RESOURCE IDENTITY redaction (rf2-k0meap.1).
-;;
-;; The `rf/elide-wire-value` value-field walk above redacts a sensitive
-;; VALUE sitting at a node's `:value` / `:params` / `:query` / `:state`
-;; summary — it matches by the FRAME's declared `:sensitive` `:app-db`
-;; PATH. But a LIVE resource node carries its sensitive scope/params in a
-;; place that walk can NEVER reach: the concrete SCOPED KEY
-;; `[cache-scope resource-id canonical-params]` is the node's IDENTITY —
-;; it is the node KEY (`[:resource <scoped-key>]`), the node's `:id`, it is
-;; embedded in the `:output` runtime path, in the `:work-ledger :record
-;; :resource/key`, and a route-owned activation surfaces it as the `:to`
-;; end of a `:param` edge. These are STRUCTURE positions, not value-bearing
-;; leaves — and the param/scope they carry are exactly the "sensitive
-;; params/scopes" [Derivations.md] §Redaction metadata names as
-;; egress-bearing.
-;;
-;; A value-path walk is structurally blind to identity-embedded secrets, so
-;; egress must project the scoped-key's secret-bearing components into
-;; STABLE OPAQUE HANDLES: the same scoped key always maps to the same
-;; projected key (graph CONNECTIVITY survives — a redacted param is still an
-;; edge), but the raw scope/params never cross the wire. We mint the handle
-;; from the core CEDN-1 identity primitive (`identity/canonical-bytes`) so
-;; it is deterministic for a given value; a value outside the CEDN-1 domain
-;; (or any error) FAILS CLOSED to the `:rf/redacted` sentinel rather than
-;; risk shipping a host-stringified secret. The middle `resource-id` (a
-;; registration keyword, never sensitive) is PRESERVED so a tool still sees
-;; WHICH resource the node is.
-
-(defn scoped-resource-key?
-  "True when `v` is a live resource SCOPED KEY — a 3-tuple
-  `[cache-scope resource-id canonical-params]` (the resource's concrete
-  live fact identity, [Derivations.md] §Fact identity): the MIDDLE element
-  is the registration `resource-id` keyword and the LAST is the
-  canonical-params MAP (resource params are validated by a `[:map …]`
-  `:params-schema`, so the concrete params are always a map). Requiring the
-  params map is what keeps this from misfiring on an unrelated 3-vector —
-  e.g. the `:output` runtime path `[:rf.runtime/resources :entries …]` has
-  a non-map last element. A static resource node's `:id` is a bare keyword
-  (not this shape), so only LIVE resource identities match. Already-projected
-  handles re-match (the projected scoped key keeps the 3-tuple-with-map-tail
-  shape), so re-projection is well-defined."
-  [v]
-  (and (vector? v)
-       (= 3 (count v))
-       (keyword? (nth v 1))
-       (map? (nth v 2))))
-
-(defn- already-projected?
-  "True when `v` is ALREADY an egress-projected handle — an opaque
-  `[:rf.resource/opaque <digest>]` token or the `:rf/redacted` fail-closed
-  sentinel. Re-projecting such a value MUST be the identity (idempotence): a
-  forwarder pipeline may run egress more than once (re-egress on re-render /
-  re-subscribe / event-bundle), and hashing an already-projected handle would mint
-  a NEW, different handle — silently changing the live node's identity across
-  the boundary and breaking stable graph connectivity."
-  [v]
-  (or (= v :rf/redacted)
-      (and (vector? v)
-           (= 2 (count v))
-           (= :rf.resource/opaque (nth v 0)))))
-
-(defn- opaque-handle
-  "A STABLE, ONE-WAY opaque handle for one secret-bearing scoped-key
-  component. Deterministic from the value (same value ⇒ same handle, so
-  graph connectivity survives) but IRREVERSIBLE — it is a HASH of the value's
-  CEDN-1 canonical token, NOT the token itself (the token PRESERVES the raw
-  value, which would defeat redaction). FAILS CLOSED to the `:rf/redacted`
-  sentinel for any value outside the CEDN-1 identity domain or on any error
-  (never host-stringify a secret onto the wire). IDEMPOTENT: an already-
-  projected `[:rf.resource/opaque …]` handle / `:rf/redacted` sentinel is
-  returned UNCHANGED (hashing it again would mint a fresh, DIFFERENT handle
-  and silently change the projected identity on a second egress pass)."
-  [v]
-  (if (already-projected? v)
-    v
-    (try
-      ;; `canonical-bytes` is the deterministic CEDN-1 token (stable for a
-      ;; given value, cross-spelling-invariant); `hash` makes it one-way so the
-      ;; raw scope/params cannot be read back off the wire. Render unsigned hex
-      ;; so the handle is a compact, non-reversible, value-stable token.
-      (let [token  (identity/canonical-bytes v)
-            digest #?(:clj  (Integer/toHexString (hash token))
-                      :cljs (.toString (bit-and (hash token) 0xffffffff) 16))]
-        [:rf.resource/opaque digest])
-      (catch #?(:clj Throwable :cljs :default) _
-        :rf/redacted))))
-
-(defn- project-scoped-key
-  "Project a live resource scoped key `[scope resource-id params]` into its
-  egress form `[<scope-handle> resource-id <params-handle>]` — the scope and
-  params replaced by stable opaque handles, the registration `resource-id`
-  preserved. Idempotent: a component already shaped `[:rf.resource/opaque …]`
-  / `:rf/redacted` re-projects to itself (the handle of a handle is stable,
-  and `:rf/redacted` is a non-secret scalar)."
-  [[scope resource-id params]]
-  [(opaque-handle scope) resource-id (opaque-handle params)])
-
-(defn- redact-resource-identity-in-path
-  "Replace any live resource scoped key embedded in `path` (e.g. the
-  `:output` runtime path `[:runtime [:rf.runtime/resources :entries
-  <scoped-key>]]`) with its projected form, so the secret-bearing scoped key
-  never egresses through a structure position. Walks the path vector and
-  projects any element that IS a scoped key."
-  [path]
-  (if (sequential? path)
-    (mapv (fn [el]
-            (cond
-              (scoped-resource-key? el) (project-scoped-key el)
-              (sequential? el)          (redact-resource-identity-in-path el)
-              :else                     el))
-          path)
-    path))
-
-(defn- redact-resource-inputs
-  "Project the live resource node's realized `:inputs`
-  `[[:scope <scope>] [:param <params>]]` — opaque the `[:scope …]` /
-  `[:param …]` payloads (the realized scope + params edges carry the same
-  sensitive identity). Other input shapes ride through untouched."
-  [inputs]
-  (if (sequential? inputs)
-    (mapv (fn [in]
-            (if (and (vector? in) (= 2 (count in))
-                     (#{:scope :param} (first in)))
-              [(first in) (opaque-handle (second in))]
-              in))
-          inputs)
-    inputs))
-
-(defn- redact-resource-work-id
-  "Project the scoped key embedded in a resource work-id
-  `[:rf.work/resource <scoped-key> <generation>]` — a work-id of another
-  shape (e.g. a non-resource family's work-id, or the historical bare
-  scalar) rides through unchanged. Mirrors the derivation-conformance
-  egress mirror's `project-work-id` (rf2-qo1l8w, closing the latent gap
-  rf2-tmyfkn/rf2-uh2clr fixed there but not here). Idempotent by
-  delegation: `project-scoped-key` already returns an already-projected
-  handle unchanged."
-  [work-id]
-  (if (and (vector? work-id) (= :rf.work/resource (first work-id)))
-    (update work-id 1 project-scoped-key)
-    work-id))
-
-(defn- redact-resource-host-transient
-  "Project the work-id embedded in a `:host-transient`
-  `[[:rf.http/in-flight <work-id>]]` in-flight handle address (rf2-qo1l8w)
-  — the abortable-handle address names the SAME work-id the work-ledger
-  link carries, so it must not leak the raw scoped key either. Other
-  shapes ride through untouched."
-  [host-transient]
-  (if (sequential? host-transient)
-    (mapv (fn [entry]
-            (if (and (vector? entry) (= 2 (count entry)) (= :rf.http/in-flight (first entry)))
-              (update entry 1 redact-resource-work-id)
-              entry))
-          host-transient)
-    host-transient))
-
-(def ^:private dead-frame-sentinel
-  "A frame id that can NEVER resolve to a live frame, used to FAIL CLOSED a
-  nil / unreachable egress frame WITHOUT borrowing the ambient scope.
-
-  `rf/elide-wire-value` resolves its governing frame as `(or (:frame opts)
-  (frame/resolve-current-frame))` — so a nil `:frame` opt (or no `:frame` at
-  all) falls through to the AMBIENT dynamically-bound frame, applying that
-  frame's (possibly empty) policy and shipping value-bearing fields RAW. An
-  unreachable but NON-nil `:frame` opt instead takes the unresolvable-frame
-  fail-closed branch (`frame/frame` returns nil ⇒ whole value redacted to
-  `:rf/redacted`). We therefore stamp this sentinel as the `:frame` opt when
-  no live governing frame is known, so the walker fails closed on its own
-  dead-frame branch rather than resolving an ambient frame. The keyword is
-  namespaced into this panel so it can never collide with a real frame id."
-  ::no-egress-frame)
-
-(defn- redact-resource-node-identity
-  "Project ONE live resource node's secret-bearing identity fields:
-  `:id` (the scoped key), `:output` (the scoped key embedded in the runtime
-  path), the realized `:inputs` `[:scope …]` / `[:param …]` payloads,
-  `:work-ledger :record :resource/key` (the scoped key on the work-ledger
-  summary), the resource work-id embedded in BOTH `:work-ledger :work/id`
-  and `:work-ledger :record :work/id` (rf2-qo1l8w — a THIRD identity
-  position, independent of `:resource/key`; mirrors the derivation-
-  conformance egress mirror's rf2-tmyfkn fix), and the `:host-transient`
-  in-flight handle address (which names that SAME work-id). Structure /
-  classification fields are untouched."
-  [node]
-  (cond-> node
-    (scoped-resource-key? (:id node))
-    (update :id project-scoped-key)
-
-    (contains? node :output)
-    (update :output redact-resource-identity-in-path)
-
-    (contains? node :inputs)
-    (update :inputs redact-resource-inputs)
-
-    (scoped-resource-key? (get-in node [:work-ledger :record :resource/key]))
-    (update-in [:work-ledger :record :resource/key] project-scoped-key)
-
-    (contains? (:work-ledger node) :work/id)
-    (update-in [:work-ledger :work/id] redact-resource-work-id)
-
-    (contains? (get-in node [:work-ledger :record]) :work/id)
-    (update-in [:work-ledger :record :work/id] redact-resource-work-id)
-
-    (contains? node :host-transient)
-    (update :host-transient redact-resource-host-transient)))
-
-(defn- resource-node-key?
-  "True when `node-key` is a LIVE resource node id `[:resource <scoped-key>]`
-  whose scoped key embeds a secret-bearing scope/params. A static resource
-  node is `[:resource <bare-keyword>]`, which does NOT match."
-  [node-key]
-  (and (vector? node-key)
-       (= :resource (first node-key))
-       (scoped-resource-key? (second node-key))))
-
-(defn- project-resource-node-key
-  "Project a live resource node KEY `[:resource <scoped-key>]` to
-  `[:resource <projected-scoped-key>]`; other node keys ride through."
-  [node-key]
-  (if (resource-node-key? node-key)
-    [:resource (project-scoped-key (second node-key))]
-    node-key))
-
-(defn- redact-resource-edge-endpoints
-  "Remap any `:from` / `:to` edge endpoint that names a live resource node
-  key to the projected key, so an edge naming a redacted resource node still
-  CONNECTS to it (structure preserved — the same projection applied to keys
-  applies to endpoints, so the remap stays consistent)."
-  [edges]
-  (mapv (fn [edge]
-          (cond-> edge
-            (resource-node-key? (:from edge)) (update :from project-resource-node-key)
-            (resource-node-key? (:to edge))   (update :to project-resource-node-key)))
-        edges))
-
-(defn redact-graph-for-egress
-  "Project a `DerivationGraph` through the FRAME's egress policy for the
-  wire boundary where a tool ships the graph OFF-BOX (rf2-yjarv6;
-  [Derivations.md] §Redaction metadata; EP-0014 issue-1 disposition).
-
-  This is the egress redaction CALL SITE the tail-2 ruling locates in the
-  consuming tool — NOT in the registrar-derived composer (which composes
-  nodes verbatim, raw-on-box by design). Each node's value-bearing summary
-  field (`:value` / `:params` / `:query` / `:state` —
-  `value-bearing-node-keys`) is walked through the single shared
-  `rf/elide-wire-value` walker under the named `frame-id`'s own elision
-  policy:
-
-  - **per-frame** — the policy is the FRAME's declared `:sensitive` /
-    `:large` `:app-db` classifications (`re-frame.elision`, sourced from
-    `reg-frame`), passed explicitly as the `:frame` opt so the walk applies
-    THAT frame's policy regardless of any ambient scope;
-  - **fail-closed** — `rf/elide-wire-value` redacts the whole value to the
-    `:rf/redacted` sentinel when no frame is reachable (frameless egress
-    under no `:rf.size/include-sensitive?` opt-out); a sensitive-declared
-    value is replaced by the sentinel; a large-declared value by the
-    `:rf.size/large-elided` marker.
-
-  STRUCTURE IS PRESERVED (the headline guarantee): a redacted value / param
-  is still an `:input` / `:param` edge, the node is still present and still
-  classified by its `:kind` superkind. The storage / evaluation / lifecycle
-  classifications, `:source-form`, and `:refinement` are structure, not
-  values, and are never touched.
-
-  LIVE RESOURCE IDENTITY redaction (rf2-k0meap.1, extended rf2-qo1l8w). A
-  live resource node carries its sensitive scope/params NOT in a
-  value-bearing field but in its IDENTITY — the concrete scoped key
-  `[cache-scope resource-id canonical-params]` that is the node KEY
-  (`[:resource <scoped-key>]`), the node's `:id`, and is embedded in the
-  `:output` runtime path, the realized `:inputs` `[:scope …]` / `[:param …]`
-  edges, `:work-ledger :record :resource/key`, the resource work-id
-  embedded in BOTH `:work-ledger :work/id` and `:work-ledger :record
-  :work/id` (a THIRD identity position, independent of `:resource/key`),
-  and the `:host-transient` in-flight handle address (which names that
-  SAME work-id). The `rf/elide-wire-value` value-path walk is structurally
-  BLIND to these identity-embedded secrets. So this projection ALSO replaces
-  each scoped key's secret-bearing scope + params with STABLE OPAQUE HANDLES
-  (`identity/canonical-bytes`-derived, fail-closed to `:rf/redacted` outside
-  the CEDN-1 domain), preserving the registration `resource-id` so a tool
-  still sees WHICH resource the node is. The SAME projection is applied to
-  the `:nodes` keys AND every edge endpoint that names a resource node, so
-  the remap stays CONSISTENT — a redacted resource node is still a node, and
-  the edges naming it still connect (connectivity survives, the raw
-  scope/params never cross the wire).
-
-  `frame-id` is the frame whose elision policy governs egress (the observed
-  app's frame — typically the graph's `:frame` for a live graph). `opts`
-  (optional) ride through to `rf/elide-wire-value` (e.g.
-  `:rf.size/threshold-bytes`); the `:frame` opt is set from `frame-id` and
-  overrides any caller-supplied one (egress redacts under the OBSERVED
-  frame's policy, never a borrowed one).
-
-  FAIL-CLOSED on a nil / UNREACHABLE frame: `rf/elide-wire-value` resolves
-  its governing frame as `(or (:frame opts) (frame/resolve-current-frame))`,
-  so a nil `:frame` opt (or no `:frame` at all) falls through to the AMBIENT
-  dynamically-bound frame and would ship value-bearing fields RAW under that
-  borrowed frame's (possibly empty) policy. Egress must NOT borrow an ambient
-  frame. So this projection first checks the named frame is LIVE
-  (`rf/frame-ids`); when it is not (nil id, a destroyed / never-registered
-  frame), it stamps a DEAD-FRAME SENTINEL as the `:frame` opt — a non-nil id
-  that can never resolve to a live frame — so `rf/elide-wire-value` takes its
-  unresolvable-frame fail-closed branch (`frame/frame` returns nil for it)
-  and redacts the whole value to `:rf/redacted` rather than borrow the
-  ambient frame's marks. This is the silent-leak this contract abolishes — a
-  graph egressing under no reachable policy redacts, never ships raw, even
-  when an ambient frame is dynamically bound (rf2-udkj69).
-
-  Returns the graph with redacted node value fields + projected live
-  resource identities; `:mode` / `:frame` unchanged. IDEMPOTENT — a value may
-  egress more than once (re-egress on re-render / re-subscribe / a forwarder
-  event-bundle), and re-projecting an already-projected graph is the IDENTITY:
-  `redact-graph-for-egress` ∘ `redact-graph-for-egress` == `redact-graph-for-
-  egress` (rf2-g197ep). `rf/elide-wire-value` is a no-op over an already-
-  `:rf/redacted` value (the sentinel is a non-matchable scalar), and the
-  opaque resource handle is idempotent at the source: `opaque-handle` returns
-  an already-`[:rf.resource/opaque …]` handle / `:rf/redacted` sentinel
-  UNCHANGED rather than re-hash it into a fresh, different handle. (Pinned by
-  `live-resource-identity-projection-is-idempotent` here and the cross-family
-  `g-graph-egress-is-idempotent` in derivation-conformance.)"
-  ([graph frame-id] (redact-graph-for-egress graph frame-id nil))
-  ([graph frame-id opts]
-   ;; A reachable (live) frame governs egress under its own policy; a nil /
-   ;; unreachable frame stamps the dead-frame sentinel as the `:frame` opt so
-   ;; `rf/elide-wire-value` takes its unresolvable-frame FAIL-CLOSED branch
-   ;; (whole value ⇒ `:rf/redacted`). We must NOT leave the `:frame` opt
-   ;; absent / nil here: that frameless path lets the walker fall through to
-   ;; the AMBIENT dynamically-bound frame (`frame/resolve-current-frame`) and
-   ;; ship value-bearing fields RAW under that frame's policy — the exact
-   ;; ambient-borrow leak this contract abolishes (rf2-udkj69).
-   (let [reachable? (and (some? frame-id) (contains? (rf/frame-ids) frame-id))
-         walk-opts  (assoc opts :frame (if reachable? frame-id dead-frame-sentinel))
-         redact-node
-         (fn [node]
-           (-> (reduce
-                (fn [n k]
-                  (if (contains? n k)
-                    (assoc n k (rf/elide-wire-value (get n k) walk-opts))
-                    n))
-                node
-                value-bearing-node-keys)
-               ;; the live resource scoped-key identity walk (rf2-k0meap.1) —
-               ;; the secrets the value-path walk above cannot reach.
-               redact-resource-node-identity))]
-     (-> graph
-         ;; remap node KEYS so a live resource scoped key no longer carries
-         ;; raw scope/params in the node id (and the edge endpoints below
-         ;; stay consistent with the remapped keys).
-         (update :nodes (fn [nodes]
-                          (into {}
-                                (map (fn [[k node]]
-                                       [(project-resource-node-key k)
-                                        (redact-node node)]))
-                                nodes)))
-         (update :edges (fn [edges]
-                          (redact-resource-edge-endpoints (or edges []))))))))
-
+(def redact-graph-for-egress
+  "Project a `DerivationGraph` through the observed FRAME's egress policy for
+  the off-box wire boundary — a thin DELEGATE to the core-owned algorithm
+  `re-frame.derivation.egress/project-graph` (rf2-mm3y49). See that ns for
+  the full contract: per-frame `elide-wire-value` value redaction; dead-frame
+  fail-closed (never borrowing an ambient frame and shipping raw); stable
+  opaque live-resource-identity handles across every identity position (node
+  key, `:id`, `:output`, realized `:inputs`, `:work-ledger` work-id +
+  `:resource/key`, `:host-transient`) and every edge endpoint; structure
+  preservation (a redacted param is still an edge); and idempotence.
+  `([graph frame-id] [graph frame-id opts])` — `opts` ride through to
+  `elide-wire-value`; the `:frame` opt is set from `frame-id`."
+  egress/project-graph)
 ;; ---------------------------------------------------------------------------
 ;; Header summary (counts + family/role tallies for the panel header).
 ;; ---------------------------------------------------------------------------

--- a/tools/xray/test/day8/re_frame2_xray/panels/derivation_graph_redaction_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/derivation_graph_redaction_cljs_test.cljc
@@ -19,19 +19,33 @@
   Per the EP-0014 tail-2 correctness ruling (rf2-6y7wnb): raw params/values
   on the live algebra views are NOT a defect — they are correct-as-designed
   raw-on-box projections. Redaction is an EGRESS concern owned by the FRAME
-  elision policy via the shared `rf/elide-wire-value` walker (per-frame,
+  elision policy via the shared `elide-wire-value` walker (per-frame,
   fail-closed), applied at the wire boundary where a consuming tool ships
   the graph OFF-BOX — NOT at the registrar-derived composer. The named first
   consumer Xray is where that egress call site is BORN
   (`derivation-graph-helpers/redact-graph-for-egress`), so the
-  redact-without-losing-structure test belongs HERE alongside the consumer
-  wiring (rf2-9ett2d).
+  redact-without-losing-structure wiring test belongs HERE alongside the
+  consumer wiring (rf2-9ett2d).
+
+  ## The algorithm is core-owned; this suite is the CONSUMER/WIRING pin
+
+  The redaction ALGORITHM is owned by the bundle-isolated core tooling ns
+  `re-frame.derivation.egress/project-graph` (rf2-mm3y49);
+  `derivation-graph-helpers/redact-graph-for-egress` is a thin DELEGATE to it,
+  and the derivation-conformance egress arms (`g-*`) carry the COMPREHENSIVE
+  algorithm coverage (no-secret-in-any-position, stable opaque identity,
+  connectivity, idempotence, work-id/host-transient, fail-closed, live
+  composition) over that same owner. So this suite keeps FOCUSED
+  consumer/wiring tests: the frame-policy value walk through Xray's real
+  registered frames (§1-4) and one live-resource identity-projection smoke
+  (§5) proving the delegate wires the full projection through — it does NOT
+  re-prove the algorithm.
 
   ## What's asserted
 
     1. **POSITIVE redact-value-keep-edge** — a node carries a sensitive
        value at a frame-declared sensitive path; egress projection runs it
-       through the frame's `rf/elide-wire-value`; the value is replaced by
+       through the frame's `elide-wire-value`; the value is replaced by
        `:rf/redacted` WHILE the node remains present + classified AND the
        edge that names it survives intact (structure preserved).
     2. **per-frame** — egress redacts under the OBSERVED frame's policy,
@@ -41,7 +55,12 @@
        must NOT borrow an AMBIENT dynamically-bound frame (rf2-udkj69): a nil
        frame-id under an ambient binding still redacts, never ships raw.
     4. **large elision** — a frame-declared `:large` value is replaced by
-       the `:rf.size/large-elided` marker, again keeping structure."
+       the `:rf.size/large-elided` marker, again keeping structure.
+    5. **identity-projection wiring smoke** — the delegate projects a live
+       resource node's scoped-key identity (no raw secret anywhere, the
+       registration resource-id preserved, connectivity preserved, one
+       opaque identity across every position); the per-position + idempotence
+       depth lives in derivation-conformance."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.elision :as elision]
@@ -273,23 +292,21 @@
           (is (= (set (keys (:nodes live-graph))) (set (keys (:nodes r))))))))))
 
 ;; ===========================================================================
-;; 5. THE ADVERSARIAL ARM — live resource scoped-key identity egress
-;;    (rf2-k0meap.1, the P1 correctness gap).
+;; 5. FOCUSED IDENTITY-PROJECTION WIRING SMOKE (rf2-mm3y49).
 ;;
-;; The §1-4 fixtures use a STATIC-style resource node (`:inputs :parametric`,
-;; `:id :article/by-slug`), which never exercised the LIVE case the gap
-;; names: a live resource node carries its sensitive scope/params NOT in a
-;; value-bearing field but in its IDENTITY — the concrete scoped key
-;; `[cache-scope resource-id canonical-params]` that is the node KEY, the
-;; `:id`, the `:output` runtime-path tail, the realized `:inputs` `[:scope …]`
-;; / `[:param …]`, AND the in-flight `:work-ledger :record :resource/key`.
-;; The frame-policy value-path walk is structurally BLIND to those positions.
-;;
-;; This adversarial fixture plants a session token as the cache SCOPE (a
-;; tenant/user-scoped activation) AND inside the canonical PARAMS, then
-;; asserts NO raw secret survives ANYWHERE in the egressed graph while the
-;; graph connectivity (node presence + the edge naming the resource node)
-;; survives.
+;; Tests 1-4 are the consumer/wiring pins over the frame-policy VALUE walk (a
+;; sensitive `:value` / `:params` field redacted under the observed frame's
+;; elision policy). They use a STATIC-style resource node and never exercise
+;; the LIVE resource IDENTITY path — a live resource node carries its
+;; sensitive scope/params NOT in a value-bearing field but in its scoped-key
+;; identity (node key / `:id` / `:output` / realized `:inputs` / work-ledger
+;; work-id + `:resource/key` / `:host-transient`), positions the value walk is
+;; structurally blind to. This ONE smoke proves the Xray delegate carries the
+;; core-owned identity projection through; the COMPREHENSIVE per-position +
+;; idempotence + work-id/host-transient coverage lives in the
+;; derivation-conformance egress arms (`g-*`), which test the same owner
+;; `re-frame.derivation.egress/project-graph` directly (rf2-mm3y49). Xray does
+;; not re-prove the algorithm — it proves the wiring.
 ;; ===========================================================================
 
 (def ^:private secret-token "tenant-jwt-9f3a-SECRET")
@@ -298,44 +315,44 @@
 (def ^:private live-scoped-key
   ;; [cache-scope resource-id canonical-params] — the live fact identity.
   [secret-scope :article/by-slug secret-params])
+(def ^:private live-work-id
+  ;; the REAL resource-family work-id — `[:rf.work/resource <scoped-key>
+  ;; <generation>]` (embeds the same secret-bearing scoped key).
+  [:rf.work/resource live-scoped-key 4])
 
 (def ^:private live-resource-node
   ;; mirrors `resource-cache-algebra-view`'s live-node-for shape: the scoped
   ;; key is the :id; the realized [:scope …]/[:param …] inputs; the concrete
   ;; :output entry address embeds the scoped key; the in-flight work-ledger
-  ;; record carries the scoped key under :resource/key.
-  {:id            live-scoped-key
-   :kind          :process
-   :refinement    :resource-process
-   :rf/family     :resources
-   :inputs        [[:scope secret-scope] [:param secret-params]]
-   :output        [:runtime [:rf.runtime/resources :entries live-scoped-key]]
-   :storage       :runtime-db
-   :authority     {:kind :remote :system :server}
-   :evaluation    #{:on-route}
-   :lifecycle     {:kind :scoped-resource-key
-                   :owners #{[:route :route/article 17]}}
-   :status        :loading
-   :work-ledger   {:work/id 99
-                   :record  {:work/id      99
-                             :work/kind    :rf.http/managed
-                             :status       :pending
-                             :resource/key live-scoped-key}}
-   :host-transient [[:rf.http/in-flight 99]]})
+  ;; record + host-transient carry the canonical work-id (which itself embeds
+  ;; the scoped key).
+  {:id             live-scoped-key
+   :kind           :process
+   :refinement     :resource-process
+   :rf/family      :resources
+   :inputs         [[:scope secret-scope] [:param secret-params]]
+   :output         [:runtime [:rf.runtime/resources :entries live-scoped-key]]
+   :storage        :runtime-db
+   :authority      {:kind :remote :system :server}
+   :evaluation     #{:on-route}
+   :lifecycle      {:kind :scoped-resource-key :owners #{[:route :route/article 17]}}
+   :status         :loading
+   :work-ledger    {:work/id live-work-id
+                    :record  {:work/id      live-work-id
+                              :status       :pending
+                              :resource/key live-scoped-key}}
+   :host-transient [[:rf.http/in-flight live-work-id]]})
 
 (def ^:private live-resource-graph
   {:mode  :live
    :frame secure-frame
    :nodes {[:resource live-scoped-key] live-resource-node}
-   ;; a route-owned activation edge naming the live resource node — the
-   ;; realized route→resource edge whose :to end embeds the scoped key.
+   ;; a route-owned activation edge naming the live resource node.
    :edges [{:from :rf/route :to [:resource live-scoped-key] :role :param
             :owner [:route :route/article 17]}]})
 
 (defn- contains-secret?
-  "Deep-walk `v` and return true iff the raw secret token string appears
-  ANYWHERE (as a leaf, a key, inside a scope/params, a work-ledger record,
-  an :output path — anywhere). Returns a strict boolean."
+  "Deep-walk `v`; true iff the raw secret token string appears ANYWHERE."
   [v]
   (boolean
     (cond
@@ -345,83 +362,34 @@
       :else              false)))
 
 (defn- projected-scoped-key?
-  "True when `v` keeps the 3-tuple scoped-key SHAPE after egress projection
-  — `[<scope-handle> resource-id <params-handle>]`: the registration
-  resource-id keyword is PRESERVED in the middle (so a tool still sees WHICH
-  resource), the scope + params replaced by opaque handles (structure
-  preserved, secrets withheld)."
+  "True when `v` keeps the 3-tuple scoped-key SHAPE after projection —
+  `[<scope-handle> resource-id <params-handle>]` (resource-id preserved)."
   [v]
-  (and (vector? v)
-       (= 3 (count v))
-       (keyword? (nth v 1))))
+  (and (vector? v) (= 3 (count v)) (keyword? (nth v 1))))
 
-(deftest live-resource-scoped-key-identity-is-redacted-at-egress
-  ;; NB the secure-frame declares [:current :params :token] sensitive — but
-  ;; the secret here lives in the resource scoped-key identity, NOT at a
-  ;; frame-declared app-db path. So this PROVES the identity projection, not
-  ;; the value-path walk: even under a frame whose policy does NOT name this
-  ;; path, the scoped-key scope/params must not egress raw.
+(deftest delegate-projects-live-resource-identity
   (let [redacted (h/redact-graph-for-egress live-resource-graph secure-frame)]
 
-    (testing "(a) NO raw secret token survives ANYWHERE in the egressed graph"
-      (is (contains-secret? live-resource-graph)
-          "sanity: the raw graph DOES carry the secret")
+    (testing "(a) NO raw secret survives ANYWHERE — node key, :id, :inputs,
+              :output, work-ledger work-id + :resource/key, host-transient, edges"
+      (is (contains-secret? live-resource-graph) "sanity: the raw graph carries the secret")
       (is (not (contains-secret? redacted))
-          "the secret must NOT appear anywhere in the egressed graph — not in
-           the node key, :id, :inputs, :output, work-ledger, or edges"))
+          "the delegate projects every identity position — no raw secret egresses"))
 
-    (testing "(b) the node KEY no longer carries the raw scoped key — it is
-              projected to [:resource [<scope-handle> resource-id <params-handle>]]"
+    (testing "(b) the resource-id stays VISIBLE + connectivity survives — the
+              node key is projected and the :param edge is remapped to it"
       (is (not (contains? (:nodes redacted) [:resource live-scoped-key]))
           "the raw-scoped-key node key is gone")
-      (let [[node-key _node] (first (:nodes redacted))
-            scoped           (second node-key)]
-        (is (= :resource (first node-key)) "still a :resource node key")
-        (is (projected-scoped-key? scoped) "still a 3-tuple scoped-key shape (structure preserved)")
-        (is (= :article/by-slug (nth scoped 1))
-            "the registration resource-id is PRESERVED (a tool still sees WHICH resource)")
-        (is (not= secret-scope (nth scoped 0)) "the scope component is opaqued")
-        (is (not= secret-params (nth scoped 2)) "the params component is opaqued")))
-
-    (testing "(c) graph CONNECTIVITY survives — the resource node is still
-              present + classified, and the edge naming it still CONNECTS to
-              the (projected) node key consistently"
-      (is (= 1 (count (:nodes redacted))) "the node is still present")
       (let [node     (-> redacted :nodes vals first)
             node-key (-> redacted :nodes keys first)
             edge     (first (:edges redacted))]
+        (is (projected-scoped-key? (second node-key)) "node key keeps the scoped-key shape")
+        (is (= :article/by-slug (nth (second node-key) 1)) "the registration resource-id is preserved")
         (is (= :process (h/superkind node)) "still classified by superkind")
-        (is (= :resource-process (:refinement node)))
-        (is (= :param (:role edge)) "the edge role survives")
-        (is (= node-key (:to edge))
-            "the edge :to is remapped to the SAME projected node key (consistent remap — connectivity preserved)")))
+        (is (= node-key (:to edge)) "the edge :to is remapped to the projected key (connectivity)")))
 
-    (testing "(d) the realized :inputs scope/params, the :output entry path,
-              and the work-ledger :resource/key all carry NO raw secret but
-              keep their structural shape"
-      (let [node (-> redacted :nodes vals first)]
-        ;; :inputs still [[:scope <h>] [:param <h>]] — the roles survive.
-        (is (= [:scope :param] (mapv first (:inputs node)))
-            "the [:scope …]/[:param …] input roles survive")
-        (is (not= secret-scope (second (first (:inputs node)))))
-        (is (not= secret-params (second (second (:inputs node)))))
-        ;; :output is still a runtime path of the same shape, scoped key projected.
-        (is (= :runtime (first (:output node))) ":output is still a runtime address")
-        (is (= [:rf.runtime/resources :entries] (take 2 (second (:output node))))
-            "the :output runtime path prefix survives")
-        ;; work-ledger record :resource/key projected; the other ledger fields ride through.
-        (let [rec (get-in node [:work-ledger :record])]
-          (is (= 99 (:work/id rec)) "the work id (non-secret) rides through")
-          (is (= :pending (:status rec)))
-          (is (projected-scoped-key? (:resource/key rec))
-              "the work-ledger :resource/key keeps the scoped-key shape")
-          (is (= :article/by-slug (nth (:resource/key rec) 1))
-              "and preserves the resource-id"))))
-
-    (testing "(e) the projection is DETERMINISTIC — the same scoped key
-              projects to the same handle in the node key, :id, :output, and
-              work-ledger (so all the identity positions stay mutually
-              consistent — one fact, one projected identity)"
+    (testing "(c) ONE fact, ONE identity — the same opaque scoped key appears in
+              the node key, :id, :output, and the work-ledger :resource/key"
       (let [node          (-> redacted :nodes vals first)
             node-key      (-> redacted :nodes keys first)
             key-scoped    (second node-key)
@@ -430,156 +398,3 @@
             ledger-scoped (get-in node [:work-ledger :record :resource/key])]
         (is (= key-scoped id-scoped output-scoped ledger-scoped)
             "every identity position projects to the SAME opaque scoped key")))))
-
-(deftest live-resource-identity-projection-is-idempotent
-  ;; A value may egress MORE THAN ONCE (re-egress on re-render / re-subscribe /
-  ;; a forwarder cascade), so re-projecting an already-egressed graph MUST be
-  ;; the identity — `project(project(x)) == project(x)`. The opaque handle of
-  ;; an already-opaque handle is the SAME handle, and `:rf/redacted` re-projects
-  ;; to itself.
-  ;;
-  ;; rf2-g197ep: the prior assertion checked ONLY node-key set + no-raw-secret.
-  ;; That MISSED the real non-idempotence — node-keys/`:id` are stable only
-  ;; because a projected scoped key no longer matches `scoped-resource-key?`
-  ;; (opaque-vector tail, not a map), so they are not re-projected; but the
-  ;; realized `:inputs` `[:scope …]`/`[:param …]` payloads were re-hashed
-  ;; UNCONDITIONALLY, minting fresh handles on the second pass. Full graph
-  ;; equality catches it; it FAILS against the pre-fix unconditional re-hash.
-  (testing "re-projecting an already-egressed graph is the IDENTITY — a
-            forwarder pipeline that double-projects does not corrupt the graph"
-    (let [once   (h/redact-graph-for-egress live-resource-graph secure-frame)
-          twice  (h/redact-graph-for-egress once secure-frame)
-          thrice (h/redact-graph-for-egress twice secure-frame)
-          node1  (-> once :nodes vals first)
-          node2  (-> twice :nodes vals first)]
-      (is (not (contains-secret? twice)) "still no secret after double projection")
-      ;; The headline idempotence law: a second (and third) egress pass changes
-      ;; NOTHING.
-      (is (= once twice)
-          "egress is idempotent — project(project(x)) == project(x)")
-      (is (= twice thrice)
-          "and stays the identity on every further pass")
-      ;; Spelled-out witnesses so a regression names WHICH position drifted.
-      (is (= (set (keys (:nodes once))) (set (keys (:nodes twice))))
-          "node keys are stable under re-projection")
-      (is (= (:id node1) (:id node2))
-          "the projected scoped-key :id is stable under re-projection")
-      (is (= (:inputs node1) (:inputs node2))
-          "the projected realized :inputs ([:scope …]/[:param …]) are stable — a
-           second pass must NOT re-hash the opaque handles into fresh handles")
-      (is (= (:output node1) (:output node2))
-          "the projected :output runtime path is stable under re-projection")
-      (is (= (get-in node1 [:work-ledger :record :resource/key])
-             (get-in node2 [:work-ledger :record :resource/key]))
-          "the projected work-ledger :resource/key is stable under re-projection")
-      (is (= (:edges once) (:edges twice))
-          "the projected edge endpoints are stable under re-projection"))))
-
-;; ===========================================================================
-;; 6. THE WORK-ID / HOST-TRANSIENT IDENTITY ARM (rf2-qo1l8w).
-;;
-;; §5's `live-resource-node` fixture uses a BARE INT (99) as its work-id,
-;; which never exercises the actual secret-bearing SHAPE a resource work-id
-;; takes: `[:rf.work/resource <scoped-key> <generation>]` (per
-;; `re-frame.resources.tooling/project-work-id`, rf2-0t0l3w). This gap is
-;; currently NOT exploitable in production because
-;; `re-frame.resources.tooling/live-node-for` already projects the work-id
-;; BEFORE the composer or Xray's redaction ever sees the node — but
-;; `redact-graph-for-egress` is documented as the wire-boundary
-;; defense-in-depth layer, and would silently leak the raw scope/params
-;; embedded in a canonical work-id if that upstream projection ever
-;; regressed. This fixture plants the REAL resource-shaped work-id directly
-;; (bypassing the upstream pre-projection) to prove the redaction layer
-;; closes the gap on its own — mirroring the derivation-conformance egress
-;; mirror's adversarial fixture (rf2-tmyfkn/rf2-uh2clr, PR #5291) that found
-;; this same gap already fixed there but latent in the real call site here.
-;; ===========================================================================
-
-(def ^:private work-id-scoped-key
-  ;; a DIFFERENT resource-id than §5's `live-scoped-key` — this fixture
-  ;; targets the work-id / host-transient identity positions specifically,
-  ;; reusing the §5 `secret-token`/`secret-scope`/`secret-params` fixture so
-  ;; the shared `contains-secret?` helper applies unchanged.
-  [secret-scope :article/checkout secret-params])
-
-(def ^:private resource-work-id
-  ;; the REAL resource-family work-id shape — embeds the scoped key
-  ;; directly, NOT pre-projected (rf2-0t0l3w's `project-work-id` runs
-  ;; upstream in production; this fixture bypasses it to test the
-  ;; defense-in-depth layer in isolation).
-  [:rf.work/resource work-id-scoped-key 3])
-
-(def ^:private work-id-resource-node
-  {:id             :article/checkout
-   :kind           :process
-   :refinement     :resource-process
-   :rf/family      :resources
-   :storage        :runtime-db
-   :authority      {:kind :remote :system :server}
-   :evaluation     #{:on-route}
-   :lifecycle      {:kind :static}
-   :status         :loading
-   :work-ledger    {:work/id resource-work-id
-                     :record {:work/id   resource-work-id
-                              :work/kind :rf.http/managed
-                              :status    :pending}}
-   :host-transient [[:rf.http/in-flight resource-work-id]]})
-
-(def ^:private work-id-resource-graph
-  {:mode  :live
-   :frame secure-frame
-   :nodes {[:resource :article/checkout] work-id-resource-node}
-   :edges []})
-
-(deftest live-resource-work-id-identity-is-redacted-at-egress
-  ;; rf2-qo1l8w: the SAME identity-projection gap the derivation-conformance
-  ;; mirror closed (rf2-tmyfkn/rf2-uh2clr, PR #5291) for `:work-ledger
-  ;; :work/id` / `:work-ledger :record :work/id` / `:host-transient` must
-  ;; ALSO close in the REAL `redact-graph-for-egress` — not just its test
-  ;; mirror. RED against the pre-fix `redact-resource-node-identity` (which
-  ;; only projected `:id` / `:output` / `:inputs` / `:work-ledger :record
-  ;; :resource/key`).
-  (let [redacted (h/redact-graph-for-egress work-id-resource-graph secure-frame)
-        node     (-> redacted :nodes vals first)]
-
-    (testing "(a) NO raw secret survives ANYWHERE in the egressed graph — not
-              in :work-ledger :work/id, :work-ledger :record :work/id, or
-              :host-transient"
-      (is (contains-secret? work-id-resource-graph)
-          "sanity: the raw graph DOES carry the secret inside the work-id")
-      (is (not (contains-secret? redacted))
-          "the secret must not survive in the work-id / host-transient
-           identity positions"))
-
-    (testing "(b) :work-ledger :work/id keeps the resource work-id SHAPE —
-              `[:rf.work/resource <projected-scoped-key> <generation>]`"
-      (let [wid (get-in node [:work-ledger :work/id])]
-        (is (= :rf.work/resource (first wid)) "the work-id family head survives")
-        (is (= 3 (nth wid 2)) "the generation (non-secret) rides through")
-        (is (projected-scoped-key? (nth wid 1))
-            "the embedded scoped key is projected to opaque-handle shape")
-        (is (= :article/checkout (nth (nth wid 1) 1))
-            "the registration resource-id inside the work-id is preserved")))
-
-    (testing "(c) :work-ledger :record :work/id is projected the SAME way"
-      (let [wid (get-in node [:work-ledger :record :work/id])]
-        (is (= :rf.work/resource (first wid)))
-        (is (projected-scoped-key? (nth wid 1)))))
-
-    (testing "(d) :host-transient's in-flight handle embeds the SAME work-id
-              — its scoped key is projected too"
-      (let [[tag wid] (first (:host-transient node))]
-        (is (= :rf.http/in-flight tag))
-        (is (= :rf.work/resource (first wid)))
-        (is (projected-scoped-key? (nth wid 1))
-            "the host-transient handle's embedded work-id scoped key is opaqued")))
-
-    (testing "(e) the SAME projected scoped key appears in :work-ledger
-              :work/id, :work-ledger :record :work/id, AND :host-transient —
-              consistent identity across all three positions"
-      (let [ledger-key    (nth (get-in node [:work-ledger :work/id]) 1)
-            record-key    (nth (get-in node [:work-ledger :record :work/id]) 1)
-            transient-key (nth (second (first (:host-transient node))) 1)]
-        (is (= ledger-key record-key transient-key)
-            "the same work-id scoped key projects to the identical opaque
-             handle everywhere it appears")))))


### PR DESCRIPTION
De-duplicates the OFF-BOX `DerivationGraph` egress-redaction algorithm, which
had drifted across two independent copies (a canonical work-id / host-transient
fix had to land in both, and Xray lagged the conformance mirror).

## What changed

- **New owner** `re-frame.derivation.egress` (`implementation/core`) owns the
  full algorithm: scoped-key, work-id, host-transient, resource-node,
  edge-endpoint, dead-frame fail-closed, opaque-handle, and idempotent
  whole-graph projection (`project-graph`, 2- and 3-arity).
- **Xray delegates** — `derivation-graph-helpers/redact-graph-for-egress` is now
  a thin `(def … egress/project-graph)`; `value-bearing-node-keys` is aliased
  from the core ns (one source of truth for the on-box summarize + off-box
  egress paths). Xray remains the named egress CALL SITE.
- **Conformance delegates** — the suite's in-tree `egress-project-graph` mirror
  and its private helpers are deleted; the cross-family `g-*` egress arms now
  test `egress/project-graph` directly.
- **Tests** — comprehensive algorithm coverage lives once in
  derivation-conformance (no-secret-in-any-position, stable opaque identity,
  connectivity, full-graph idempotence, nil/unknown-frame fail-closed, work-id
  in 3 positions + host-transient, live-resources composition). Xray keeps
  focused consumer/wiring tests (frame-policy value walk through real frames +
  one live-resource identity-projection smoke).
- **spec/025** updated to describe the delegation.

## Bundle isolation (load-bearing)

The egress ns is TOOLING: not exposed from the `re-frame.core` facade, not
required by any production-reachable ns, built only from `implementation/`-
resident primitives. A `derivation-egress` sentinel was added to
`check-bundle-isolation.cjs`. Proof — the gate now reports **22 artefact
entries; 41 internal sentinels absent** against the counter release bundle,
and the new sentinel `rf.derivation.egress/sentinel:rf2-mm3y49-…` is confirmed
absent from the counter/uix/helix production bundles.

## tools/ is NOT a dependency of any implementation artefact

The new ns requires only `re-frame.elision` / `re-frame.frame` /
`re-frame.identity` / `re-frame.privacy` (all core). Xray reaching a core ns
preserves the tools → implementation arrow; nothing in `implementation/`
requires anything under `tools/`. No hot-zone build files
(`shadow-cljs.edn`/`deps.edn`) were touched — the ns lives in `core/src`, on
every classpath that requires it already.

## Quality gates (all green, foreground)

- JVM derivation-conformance (`clojure -M:test`): **20 tests, 446 assertions, 0 failures**
- Xray JVM suite (`clojure -M:test`): **1233 tests, 5729 assertions, 0 failures**
- CLJS node gate (`npm run test:cljs`): **8462 tests, 39065 assertions, 0 failures**
- Bundle isolation (`npm run test:bundle-isolation`): **PASS** — 22 entries, 41 sentinels absent; uix/helix reagent-free PASS

## Stance

Pre-alpha, no shims. Primary lenses: ELEGANCE + CLARITY + CORRECTNESS +
GOOD-PRACTICE. One owner for one algorithm; two witnesses (conformance
cross-family pin + Xray consumer/wiring pin) over that owner rather than two
drifting implementations. Redaction threat model = AI/LLM egress + off-box
logs, not human-facing egress.
