### PR TITLE
fix(adapters): centralize resource-lease owner mint + lifecycle — fixes mixed-adapter owner collision (rf2-qdkt8y)

### DIFF
--- a/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
+++ b/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
@@ -21,13 +21,14 @@
             [reagent2.impl.template    :as template]
             [re-frame.substrate.spine   :as spine]
             [re-frame.views            :as views]
-            ;; Resource-lease helper deps (rf2-zxxc9f). All CORE re-frame
-            ;; namespaces — no stock `reagent.*` edge, so bundle isolation
-            ;; (IMPL-SPEC §1.8) is preserved (the bridge adapter requires the
-            ;; same three). `re-frame.adapter.context` is already on the slim
-            ;; classpath transitively via `re-frame.views`.
-            [re-frame.frame            :as frame]
-            [re-frame.router           :as router]
+            ;; Resource-lease deps (rf2-zxxc9f, rf2-qdkt8y). Both are CORE
+            ;; re-frame namespaces — no stock `reagent.*` edge, so bundle
+            ;; isolation (IMPL-SPEC §1.8) is preserved (the bridge adapter
+            ;; requires the same pair). `re-frame.adapter.resource-lease` carries
+            ;; the shared lease identity + lifecycle + component factory;
+            ;; `re-frame.adapter.context` (already on the slim classpath via
+            ;; `re-frame.views`) supplies the frame React-context.
+            [re-frame.adapter.resource-lease :as resource-lease]
             [re-frame.adapter.context  :as adapter-context]))
 
 ;; ---- shared ratom-spine wiring --------------------------------------------
@@ -119,98 +120,20 @@
 
 ;; ---- resource-lease mount-lifecycle helper (rf2-zxxc9f, EP-0020 §Open Issue #1) --
 ;;
-;; The slim counterpart of `re-frame.adapter.reagent/with-resource-lease` — the
-;; fourth browser adapter's copy of EP-0020 leasing, which shipped on the
-;; bridge + UIx + Helix but was missed here (rf2-zxxc9f). At publication the
-;; slim ns is renamed to the canonical `re-frame.adapter.reagent`, so an app
-;; swapping `day8/re-frame2-reagent` → `day8/reagent-slim` MUST find the same
-;; `with-resource-lease` Var (else an unresolved-var compile error). Authored
-;; to avoid the two bridge-lease bugs FROM THE START: it re-leases on
-;; descriptor/frame/cause change via `:component-did-update` (rf2-04fky9) and
-;; resolves the frame at RENDER time honouring EP-0002 tier precedence —
-;; dynamic-var wins over the React-context tier (rf2-5bo24q). The substrate-
-;; agnostic helpers below are the shape of the bridge's; the divergences are
-;; the `reagent2.*` create-class + the 7-key-cap contextType wiring (below).
-
-(defonce ^:private lease-token-counter
-  ;; Monotone per-runtime counter minting a UNIQUE lease token per mounted
-  ;; instance, so two components leasing the same resource+scope hold
-  ;; INDEPENDENT leases (releasing one never drops the other).
-  (atom 0))
-
-(defn- lease-args
-  "Normalise `with-resource-lease` call args `[descriptor & args]` into
-  `{:descriptor :cause :frame :body}`. The optional `opts` map may sit
-  between the descriptor and the body thunk; a leading fn is the body."
-  [[descriptor & args]]
-  (let [[opts body] (if (fn? (first args))
-                      [nil (first args)]
-                      [(first args) (second args)])]
-    {:descriptor descriptor
-     :cause      (get opts :cause [:lease :mount])
-     :frame      (get opts :frame)
-     :body       body}))
-
-(defn- resolve-lease-frame
-  "Resolve the frame this instance leases into, at RENDER time, honouring the
-  EP-0002 carried-invariant tier precedence (Spec 002 §Frame target
-  resolution): an explicit `:frame` opt pins the target; otherwise delegate
-  to the canonical reader `frame/require-current-frame!` — dynamic-var tier
-  (`*current-frame*`) FIRST, React-context tier (the `:adapter/current-frame`
-  hook — here the class `contextType` read on the in-flight slim component)
-  SECOND, else the always-on `:rf.error/no-frame-context`.
-
-  Called from `:reagent-render` so the dynamic var is observed while the
-  render scope's `with-frame` binding is still in effect — the render-time,
-  single-sourced resolution the React-hook twin `use-resource-lease` uses,
-  authored correct here from the start (never carrying the bridge's
-  did-mount-resolution / React-context-first inversion, rf2-5bo24q)."
-  [explicit-frame]
-  (or explicit-frame
-      (frame/require-current-frame!
-        :with-resource-lease
-        ;; Canonical (post-publish-stable) ns marker: the publication
-        ;; ns-transform (.github/scripts/transform-reagent-slim-ns.sh)
-        ;; rewrites ONLY the leading `(ns …)` token, so a `-slim` symbol
-        ;; here would survive verbatim into the shipped day8/reagent-slim
-        ;; jar — pointing a `:rf.error/no-frame-context` reader at
-        ;; `re-frame.adapter.reagent-slim`, a namespace the jar ships as
-        ;; the canonical `re-frame.adapter.reagent`. Use the canonical ns
-        ;; (rename-stable in-tree AND post-publish; matches `:display-name`
-        ;; below), rf2-gjvu84.
-        {:where 're-frame.adapter.reagent/with-resource-lease})))
-
-(defn- ensure-lease!
-  "Dispatch `:rf.resource/ensure` for the render-time-resolved `desired`
-  target (`#js {:frame :descriptor :cause}`) under owner `lease`. Returns the
-  HELD-lease record (frame + owner + descriptor + cause snapshot) so a later
-  re-lease diff and the unmount release act on the SAME target the ensure
-  used, even after the render scope has unwound."
-  [^js desired lease]
-  (let [frame-id (.-frame desired)
-        {:keys [resource scope params]} (.-descriptor desired)]
-    (router/dispatch! [:rf.resource/ensure
-                       {:resource resource :scope scope :params params
-                        :owner lease :cause (.-cause desired)}]
-                      {:frame frame-id})
-    #js {:frame frame-id :lease lease
-         :descriptor (.-descriptor desired) :cause (.-cause desired)}))
-
-(defn- release-lease!
-  "Dispatch `:rf.resource/release-owner` for the `held` lease into the frame
-  it was ensured against."
-  [^js held]
-  (router/dispatch! [:rf.resource/release-owner {:owner (.-lease held)}]
-                    {:frame (.-frame held)}))
-
-(defn- lease-target-changed?
-  "True when the render-time `desired` target differs from the currently
-  `held` lease on frame, descriptor, or cause — the same
-  `[frame descriptor cause]` tuple the React-hook twin keys its effect on."
-  [^js held ^js desired]
-  (or (not= (.-frame held)      (.-frame desired))
-      (not= (.-descriptor held) (.-descriptor desired))
-      (not= (.-cause held)      (.-cause desired))))
+;; The slim counterpart of `re-frame.adapter.reagent/with-resource-lease`. The
+;; lease's IDENTITY (owner mint) + LIFECYCLE semantics live ONCE in
+;; `re-frame.adapter.resource-lease` (rf2-qdkt8y), shared with the bridge
+;; Reagent adapter + the React-hook `use-resource-lease` (UIx / Helix), so a
+;; mixed-adapter process cannot collide two families' lease owners. At
+;; publication the slim ns is renamed to the canonical `re-frame.adapter.reagent`,
+;; so an app swapping `day8/re-frame2-reagent` → `day8/reagent-slim` finds the
+;; same `with-resource-lease` Var. This adapter supplies ONLY its `reagent2.*`
+;; substrate ops + the slim context-type wiring: the slim 7-key create-class cap
+;; (IMPL-SPEC §6.1) excludes `:context-type`, so contextType is set on the
+;; returned class AFTER `create-class` — never crossing into stock Reagent
+;; (bundle isolation). (The shared factory names the canonical
+;; `re-frame.adapter.reagent/with-resource-lease` marker for any
+;; `:rf.error/no-frame-context`, rename-stable post-publish — rf2-gjvu84.)
 
 (def with-resource-lease
   "reagent-slim component that takes a resource liveness LEASE for its mounted
@@ -254,53 +177,29 @@
   resource and ensures the new one WITHOUT waiting for unmount; a value-equal
   descriptor holds ONE lease with no churn.
 
-  Idempotency: the lease token is minted ONCE per instance and reused across
+  Idempotency: the lease owner is minted ONCE per instance and reused across
   re-leases, so a hot-reload re-mount settles to exactly one held lease.
   Under SSR (`render-to-string`) lifecycle methods do not run, so the
-  acquire/release is a natural no-op — a client-lifetime concern."
-  ;; The slim 7-key create-class cap (IMPL-SPEC §6.1) excludes `:context-type`,
-  ;; so React contextType is wired directly on the returned class — mirroring
-  ;; `reagent2.impl.template/fn-to-class`'s `:contextType` threading and the
-  ;; reg-view `{:contextType frame-context}` wiring, so the in-flight
-  ;; component's `.-context` carries the enclosing frame-provider's frame for
-  ;; `resolve-lease-frame`'s React-context tier.
-  (let [klass
-        (r/create-class
-          {:display-name "re-frame.adapter.reagent/with-resource-lease"
-           :reagent-render
-           (fn [d & args]
-             (let [{:keys [cause descriptor frame body]} (lease-args (cons d args))
-                   frame-id (resolve-lease-frame frame)]
-               ;; Stash the render-time-resolved lease target so the commit-
-               ;; phase lifecycle methods take + re-lease against it.
-               (set! (.-rf2LeaseDesired ^js (r/current-component))
-                     #js {:frame frame-id :descriptor descriptor :cause cause})
-               (body)))
-           :component-did-mount
-           (fn [^js this]
-             ;; Mint the per-instance lease token ONCE (reused across
-             ;; re-leases, matching the twin's stable useRef token).
-             (let [lease [:lease (swap! lease-token-counter inc)]]
-               (set! (.-rf2ResourceLease this)
-                     (ensure-lease! (.-rf2LeaseDesired this) lease))))
-           ;; slim `:component-did-update` is invoked (this prev-argv snapshot)
-           ;; per IMPL-SPEC §6.6 — a 3-arity signature (the bridge's stock-
-           ;; Reagent path is 4-arity). We read the render-time stash, not the
-           ;; prev args, so the extra args are ignored.
-           :component-did-update
-           (fn [^js this _prev-argv _snapshot]
-             (let [held    (.-rf2ResourceLease this)
-                   desired (.-rf2LeaseDesired this)]
-               (when (and held desired (lease-target-changed? held desired))
-                 (release-lease! held)
-                 (set! (.-rf2ResourceLease this)
-                       (ensure-lease! desired (.-lease held))))))
-           :component-will-unmount
-           (fn [^js this]
-             (when-let [held (.-rf2ResourceLease this)]
-               (release-lease! held)))})]
-    (set! (.-contextType ^js klass) adapter-context/frame-context)
-    klass))
+  acquire/release is a natural no-op — a client-lifetime concern.
+
+  The lease identity + lifecycle live once in
+  `re-frame.adapter.resource-lease/make-resource-lease-component` (rf2-qdkt8y);
+  this Var supplies only slim's `reagent2.*` `current-component` reader + the
+  slim context-type wiring below."
+  (resource-lease/make-resource-lease-component
+    {:current-component r/current-component
+     ;; The slim 7-key create-class cap (IMPL-SPEC §6.1) excludes
+     ;; `:context-type`, so React contextType is wired directly on the returned
+     ;; class AFTER `create-class` — mirroring `reagent2.impl.template/
+     ;; fn-to-class`'s `:contextType` threading and the reg-view
+     ;; `{:contextType frame-context}` wiring, so the in-flight component's
+     ;; `.-context` carries the enclosing frame-provider's frame for the shared
+     ;; factory's React-context tier. Set post-hoc (never a `:context-type` map
+     ;; key crossing into stock Reagent) keeps slim bundle isolation intact.
+     :build-class (fn [class-map]
+                    (let [klass (r/create-class class-map)]
+                      (set! (.-contextType ^js klass) adapter-context/frame-context)
+                      klass))}))
 
 (def adapter
   "The reagent-slim adapter map. Pass to `(rf/init! ...)` to install, using

--- a/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
+++ b/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
@@ -6,9 +6,8 @@
   (:require [reagent.core :as r]
             [reagent.ratom :as ratom]
             [reagent.dom.client :as rdc]
-            [re-frame.router :as router]
-            [re-frame.frame :as frame]
             [re-frame.adapter.context :as adapter-context]
+            [re-frame.adapter.resource-lease :as resource-lease]
             [re-frame.substrate.spine :as spine]
             [re-frame.views :as views]))
 
@@ -85,84 +84,13 @@
   (:flush-views! spine-fns))
 
 ;; ---- resource-lease mount-lifecycle helper (rf2-cxozh4, EP-0020 §Open Issue #1) --
-
-(defonce ^:private lease-token-counter
-  ;; Monotone per-runtime counter minting a UNIQUE lease token per mounted
-  ;; `with-resource-lease` instance, so two components leasing the same
-  ;; resource+scope hold INDEPENDENT leases (releasing one never drops the
-  ;; other). The Reagent twin of the React-hook helper's counter.
-  (atom 0))
-
-(defn- lease-args
-  "Normalise `with-resource-lease` call args `[descriptor & args]` into
-  `{:descriptor :cause :frame :body}`. The optional `opts` map may sit
-  between the descriptor and the body thunk; a leading fn is the body."
-  [[descriptor & args]]
-  (let [[opts body] (if (fn? (first args))
-                      [nil (first args)]
-                      [(first args) (second args)])]
-    {:descriptor descriptor
-     :cause      (get opts :cause [:lease :mount])
-     :frame      (get opts :frame)
-     :body       body}))
-
-(defn- resolve-lease-frame
-  "Resolve the frame this instance leases into, at RENDER time, honouring the
-  EP-0002 carried-invariant tier precedence (Spec 002 §Frame target
-  resolution): an explicit `:frame` opt pins the target; otherwise delegate
-  to the canonical reader `frame/require-current-frame!`, which observes the
-  dynamic-var tier (`*current-frame*`) FIRST and the React-context tier (the
-  `:adapter/current-frame` hook — here the class `:context-type` read on the
-  in-flight component) SECOND, and raises the always-on
-  `:rf.error/no-frame-context` when neither names a frame.
-
-  Called from `:reagent-render` (NOT a commit-phase lifecycle method) so the
-  dynamic var is observed while the render scope's `with-frame` binding is
-  still in effect and the resolving component is the in-flight one — the same
-  render-time, single-sourced resolution the React-hook twin
-  `use-resource-lease` uses. Resolving in `:component-did-mount` would see
-  `*current-frame*` already unwound (so the dynamic-var tier could never win —
-  the EP-0002 inversion) and no in-flight component."
-  [explicit-frame]
-  (or explicit-frame
-      (frame/require-current-frame!
-        :with-resource-lease
-        {:where 're-frame.adapter.reagent/with-resource-lease})))
-
-(defn- ensure-lease!
-  "Dispatch `:rf.resource/ensure` for the render-time-resolved `desired`
-  target (`#js {:frame :descriptor :cause}`) under owner `lease`. Returns the
-  HELD-lease record (frame + owner + descriptor + cause snapshot) so a later
-  re-lease diff and the unmount release act on the SAME target the ensure
-  used, even after the render scope has unwound.
-
-  Direct owning-ns dispatch (not the `rf/dispatch` macro) — framework-
-  internal plumbing, not an application call site."
-  [^js desired lease]
-  (let [frame-id (.-frame desired)
-        {:keys [resource scope params]} (.-descriptor desired)]
-    (router/dispatch! [:rf.resource/ensure
-                       {:resource resource :scope scope :params params
-                        :owner lease :cause (.-cause desired)}]
-                      {:frame frame-id})
-    #js {:frame frame-id :lease lease
-         :descriptor (.-descriptor desired) :cause (.-cause desired)}))
-
-(defn- release-lease!
-  "Dispatch `:rf.resource/release-owner` for the `held` lease into the frame
-  it was ensured against."
-  [^js held]
-  (router/dispatch! [:rf.resource/release-owner {:owner (.-lease held)}]
-                    {:frame (.-frame held)}))
-
-(defn- lease-target-changed?
-  "True when the render-time `desired` target differs from the currently
-  `held` lease on frame, descriptor, or cause — the same
-  `[frame descriptor cause]` tuple the React-hook twin keys its effect on."
-  [^js held ^js desired]
-  (or (not= (.-frame held)      (.-frame desired))
-      (not= (.-descriptor held) (.-descriptor desired))
-      (not= (.-cause held)      (.-cause desired))))
+;;
+;; The lease's IDENTITY (owner mint) + LIFECYCLE semantics live ONCE in
+;; `re-frame.adapter.resource-lease` (rf2-qdkt8y) — shared with reagent-slim and
+;; the React-hook `use-resource-lease` (UIx / Helix), so a mixed-adapter process
+;; cannot collide two families' lease owners. This adapter supplies ONLY its
+;; stock-`reagent.*` substrate ops + the stock-Reagent context-type wiring
+;; (create-class copies a `:context-type` map key to the static `contextType`).
 
 (def with-resource-lease
   "Reagent component that takes a resource liveness LEASE for its mounted
@@ -221,54 +149,28 @@
   holds ONE lease with no churn. (React does not re-run
   `:component-did-mount` on a props change, so re-leasing must live here.)
 
-  Idempotency: the lease token is minted ONCE per instance (in `did-mount`)
+  Idempotency: the lease owner is minted ONCE per instance (in `did-mount`)
   and reused across re-leases, so a hot-reload re-mount settles to exactly
   one held lease (ensure re-attaches the same lease; Spec 016 §Active
   owners). Under SSR (`render-to-string`) lifecycle methods do not run, so
   the acquire/release is a natural no-op — the lease is a client-lifetime
-  concern."
-  (r/create-class
-    {:display-name "re-frame.adapter.reagent/with-resource-lease"
-     ;; Reagent's create-class copies `:context-type` (camelCased to the
-     ;; React static `contextType`) onto the class, so the in-flight
-     ;; component's context carries the enclosing frame-provider's value —
-     ;; the class-component parity of the reg-view `{:contextType
-     ;; frame-context}` wiring, read via the canonical `:adapter/current-frame`
-     ;; hook during `resolve-lease-frame`.
-     :context-type adapter-context/frame-context
-     :reagent-render
-     (fn [d & args]
-       (let [{:keys [cause descriptor frame body]} (lease-args (cons d args))
-             frame-id (resolve-lease-frame frame)]
-         ;; Stash the render-time-resolved lease target (dynamic-var-honouring
-         ;; frame + current descriptor/cause) so the commit-phase lifecycle
-         ;; methods take + re-lease against it after the render scope unwinds.
-         (set! (.-rf2LeaseDesired ^js (r/current-component))
-               #js {:frame frame-id :descriptor descriptor :cause cause})
-         (body)))
-     :component-did-mount
-     (fn [^js this]
-       ;; Mint the per-instance lease token ONCE (reused across re-leases,
-       ;; matching the twin's stable useRef token) + take the first lease.
-       (let [lease [:lease (swap! lease-token-counter inc)]]
-         (set! (.-rf2ResourceLease this)
-               (ensure-lease! (.-rf2LeaseDesired this) lease))))
-     :component-did-update
-     (fn [^js this _ _ _]
-       (let [held    (.-rf2ResourceLease this)
-             desired (.-rf2LeaseDesired this)]
-         (when (and held desired (lease-target-changed? held desired))
-           ;; Descriptor / frame / cause changed across re-render — release the
-           ;; old lease then re-ensure the new target under the SAME token, so
-           ;; neither is the old resource over-retained nor the new one
-           ;; under-provisioned until unmount.
-           (release-lease! held)
-           (set! (.-rf2ResourceLease this)
-                 (ensure-lease! desired (.-lease held))))))
-     :component-will-unmount
-     (fn [^js this]
-       (when-let [held (.-rf2ResourceLease this)]
-         (release-lease! held)))}))
+  concern.
+
+  The lease identity + lifecycle live once in
+  `re-frame.adapter.resource-lease/make-resource-lease-component` (rf2-qdkt8y);
+  this Var supplies only stock Reagent's `current-component` reader + the
+  stock-Reagent context-type wiring (create-class copies a `:context-type` map
+  key to the static `contextType`, read via the `:adapter/current-frame` hook
+  during frame resolution)."
+  (resource-lease/make-resource-lease-component
+    {:current-component r/current-component
+     ;; Reagent's create-class copies `:context-type` (camelCased to the React
+     ;; static `contextType`) onto the class, so the in-flight component's
+     ;; context carries the enclosing frame-provider's value — the class-
+     ;; component parity of the reg-view `{:contextType frame-context}` wiring.
+     :build-class (fn [class-map]
+                    (r/create-class
+                      (assoc class-map :context-type adapter-context/frame-context)))}))
 
 (def adapter
   "The Reagent adapter map. Pass to `(rf/init! ...)` to install:

--- a/implementation/adapters/reagent/test/re_frame/adapter/mixed_family_lease_owner_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/adapter/mixed_family_lease_owner_dom_cljs_test.cljs
@@ -1,0 +1,183 @@
+(ns re-frame.adapter.mixed-family-lease-owner-dom-cljs-test
+  "Mixed-adapter resource-lease OWNER regression (rf2-qdkt8y) — the P1 the
+  centralization fixes.
+
+  Before the fix each adapter family kept its OWN `(atom 0)` lease-token
+  counter (stock Reagent, reagent-slim, and the shared React-hook helper each
+  minted from zero), so the FIRST lease taken by any two families in one
+  mixed-adapter process collided on the identical owner `[:lease 1]`. Because
+  `:rf.resource/release-owner` drops an owner from EVERY indexed resource,
+  unmounting ONE family's component then cross-released ANOTHER family's
+  still-live resource — a silent liveness bug.
+
+  This test mounts BOTH families against ONE frame's REAL resources runtime and
+  proves the property directly on `:active-owners`:
+
+    1. SIMULTANEOUS mounts get DISTINCT owners — the Reagent-family
+       `with-resource-lease` and the React-hook-family `use-resource-lease`
+       leases carry different `[:lease …]` owners (under the old per-family
+       counters both would be `[:lease 1]`).
+    2. UNMOUNTING ONE preserves the OTHER's lease — after the Reagent component
+       unmounts (its `release-owner` fires against the REAL handler), the
+       React-hook component's resource still lists its owner as active (under
+       the old colliding owner, that same `release-owner [:lease 1]` would drop
+       the hook family's owner too, leaving its resource owner-free).
+
+  The React-hook family here is `re-frame.adapter.resource-lease/
+  use-resource-lease` called inside a bare React function component — the EXACT
+  Var UIx and Helix re-export verbatim (`uix.cljs` / `helix.cljs` bind
+  `use-resource-lease` to `resource-lease/use-resource-lease`), so this is a
+  faithful mixed Reagent/UIx regression without pulling the UIx library onto the
+  Reagent adapter's test classpath. Both leases pin an explicit `:frame` so the
+  test isolates the OWNER-identity bug from frame resolution.
+
+  Browser-only — the Reagent lifecycle methods + the hook effect only fire under
+  a real React mount. `-dom-cljs-test$` opts it into `:browser-test`;
+  `:node-test` loads it too and the DOM body gates on `(browser?)`."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            [reagent.core :as r]
+            [reagent.dom.client :as rdc]
+            ["react" :as React]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            ;; The shared React-hook lease Var — the very one UIx / Helix
+            ;; re-export. Exercised directly = the UIx/Helix family's behaviour.
+            [re-frame.adapter.resource-lease :as resource-lease]
+            [re-frame.substrate.adapter :as substrate-adapter]
+            [re-frame.test-support :as test-support]
+            ;; load-bearing side-effecting requires: register the
+            ;; :rf.resource/* events + the managed-HTTP fx surface (overridden
+            ;; by a no-op stub below so ensure never fetches) + schema support.
+            [re-frame.resources]
+            [re-frame.resources.state :as state]
+            [re-frame.http.managed]
+            [re-frame.schemas]))
+
+;; ---- fixture (MAP-form, async-safe) ---------------------------------------
+;; A function fixture would tear down mid-async (its `(f)` returns before the
+;; async body's `done`); the map `{:before :after}` form brackets the async
+;; completion. Installs the Reagent adapter + a REAL global resource whose
+;; transport is stubbed to a no-op, so ensure writes the :loading entry + owner
+;; deterministically without a live fetch.
+
+(def ^:private lease-frame :rf/default)
+(def ^:private resource-id :rf.mixed-lease/feed)
+
+(def ^:private registrar-snapshot (atom nil))
+
+(defn- before! []
+  (reset! registrar-snapshot (test-support/snapshot-registrar))
+  (reset! frame/frames {})
+  (substrate-adapter/dispose-adapter!)
+  (substrate-adapter/install-adapter! reagent-adapter/adapter)
+  (frame/ensure-default-frame!)
+  ;; No real fetch — ensure only needs to write the :loading entry + attach the
+  ;; owner for the owner-index / release-owner assertions.
+  (rf/reg-fx :rf.http/managed (fn [_ctx _args] nil))
+  (rf/reg-resource resource-id
+    {:scope         :rf.scope/global
+     :params-schema [:map [:page :int]]
+     :tags          (fn [_p _v] #{[:mixed-feed]})}
+    (fn [{:keys [page]} _ctx]
+      {:request {:method :get :url "/feed" :params {:page page}}})))
+
+(defn- after! []
+  (when-let [snap @registrar-snapshot]
+    (test-support/restore-registrar! snap)
+    (reset! registrar-snapshot nil))
+  (reset! frame/frames {}))
+
+(use-fixtures :each {:before before! :after after!})
+
+;; ---- descriptors + runtime readers ----------------------------------------
+
+(def ^:private reagent-descriptor
+  {:resource resource-id :scope :rf.scope/global :params {:page 0}})
+(def ^:private hook-descriptor
+  {:resource resource-id :scope :rf.scope/global :params {:page 1}})
+
+(defn- entry [scoped-key]
+  (get-in (:rf.db/runtime (rf/frame-state-value lease-frame))
+          (state/entry-path scoped-key)))
+
+(defn- active-owners
+  "The set of live lease owners on the resource entry for `params` (nil / #{} if
+  the entry is owner-free or GC'd)."
+  [params]
+  (:active-owners (entry (state/scoped-resource-key :rf.scope/global resource-id params))))
+
+;; ---- DOM helpers (mirroring the sibling with-resource-lease DOM suite) ------
+
+(defn- browser? []
+  (and (exists? js/document) (some? (.-createElement js/document))))
+
+(defn- get-act []
+  (or (when (exists? (.-act React)) (.-act React))
+      (try (.-act (js/require "react-dom/test-utils")) (catch :default _ nil))))
+
+;; Wait two macrotasks so the router's next-tick dispatch drain has run.
+(defn- after-drain [k] (js/setTimeout (fn [] (js/setTimeout k 0)) 0))
+
+(defn- make-hook-lease-component
+  "A bare React function component that takes a lease via the shared
+  `use-resource-lease` hook — the UIx / Helix family's exact code path.
+  Variadic arglist so React may invoke it with props (+ legacy 2nd arg)."
+  [descriptor frame-id]
+  (fn hook-lease [& _props]
+    (resource-lease/use-resource-lease descriptor {:frame frame-id})
+    (React/createElement "div" nil "hook-leased")))
+
+;; ---- the regression --------------------------------------------------------
+
+(deftest mixed-family-mounts-get-distinct-owners-and-are-independently-released
+  (testing "a Reagent-family lease and a React-hook-family (UIx/Helix) lease,
+            mounted simultaneously against one frame, get DISTINCT owners;
+            unmounting the Reagent one preserves the hook one's lease (rf2-qdkt8y)"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — :browser-test runner exercises the assertion")
+      (let [act-fn (get-act)]
+        (if (nil? act-fn)
+          (is true "act() not reachable from this runner; skipping")
+          (async done
+            (binding [frame/*current-frame* nil]
+              (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+              (let [reagent-node (.createElement js/document "div")
+                    hook-node    (.createElement js/document "div")
+                    reagent-root (rdc/create-root reagent-node)
+                    hook-root    (rdc/create-root hook-node)
+                    hook-comp    (make-hook-lease-component hook-descriptor lease-frame)]
+                ;; Mount BOTH families, each pinned to the same frame.
+                (act-fn
+                  (fn []
+                    (rdc/render reagent-root
+                      [reagent-adapter/with-resource-lease
+                       reagent-descriptor {:frame lease-frame}
+                       (fn [] [:div "reagent-leased"])])
+                    (rdc/render hook-root [:> hook-comp])))
+                (after-drain
+                  (fn []
+                    ;; ---- Phase 1: simultaneous mounts → DISTINCT owners ----
+                    (let [owner-r (first (active-owners {:page 0}))
+                          owner-h (first (active-owners {:page 1}))]
+                      (is (= 1 (count (active-owners {:page 0})))
+                          "the Reagent-family resource holds exactly its own lease")
+                      (is (= 1 (count (active-owners {:page 1})))
+                          "the hook-family resource holds exactly its own lease")
+                      (is (= :lease (first owner-r)) "Reagent owner is a [:lease …]")
+                      (is (= :lease (first owner-h)) "hook owner is a [:lease …]")
+                      (is (not= owner-r owner-h)
+                          "the two families minted DISTINCT owners (the core bug: old
+                           per-family counters both minted [:lease 1])")
+                      ;; ---- Phase 2: unmount Reagent → hook's lease survives ----
+                      (act-fn (fn [] (rdc/unmount reagent-root)))
+                      (after-drain
+                        (fn []
+                          (is (not (contains? (set (active-owners {:page 0})) owner-r))
+                              "the unmounted Reagent-family lease was released")
+                          (is (contains? (set (active-owners {:page 1})) owner-h)
+                              "the STILL-MOUNTED hook-family lease is PRESERVED — the
+                               Reagent release did NOT cross-release it (the rf2-qdkt8y
+                               fix; under the colliding [:lease 1] owner it would have)")
+                          (act-fn (fn [] (rdc/unmount hook-root)))
+                          (done))))))))))))))

--- a/implementation/core/src/re_frame/adapter/resource_lease.cljs
+++ b/implementation/core/src/re_frame/adapter/resource_lease.cljs
@@ -63,12 +63,220 @@
             [re-frame.frame  :as frame]
             [re-frame.router :as router]))
 
-(defonce ^:private lease-token-counter
-  ;; Monotone per-runtime counter minting a UNIQUE lease token per mounted
-  ;; helper instance, so two components leasing the same resource+scope hold
-  ;; INDEPENDENT leases (releasing one never drops the other). Mirrors the
-  ;; spine's `unmount-instance-counter`.
+;; ============================================================================
+;; Process-wide lease identity — the SINGLE owner mint (rf2-qdkt8y)
+;; ============================================================================
+;;
+;; ONE counter, ONE mint, for the WHOLE framework. Every adapter family — the
+;; ratom families (Reagent / reagent-slim, via `make-resource-lease-component`
+;; below) and the React-hook families (UIx / Helix, via `use-resource-lease`
+;; below) — draws its lease owner from HERE, so owners minted by two different
+;; adapter families in one mixed-adapter process are GUARANTEED DISTINCT.
+;;
+;; Before rf2-qdkt8y each adapter family kept its OWN `(atom 0)` counter, so the
+;; first lease from any two families collided on the identical owner `[:lease
+;; 1]`. Because `:rf.resource/release-owner` drops an owner from EVERY indexed
+;; resource, unmounting one family's component then cross-released another
+;; family's still-live resource. A single source of owner identity removes the
+;; collision by construction.
+
+(defonce ^:private lease-owner-counter
+  ;; Monotone per-runtime counter minting a globally-unique lease token — the
+  ;; SOLE lease-owner counter in the framework (mirrors the spine's
+  ;; `unmount-instance-counter`). Two components leasing the same resource+scope
+  ;; hold INDEPENDENT leases (releasing one never drops the other), AND two
+  ;; components from DIFFERENT adapter families can never collide on one owner.
   (atom 0))
+
+(defn mint-lease-owner!
+  "Mint a fresh, process-unique resource-lease OWNER in the framework-canonical
+  `[:lease <n>]` shape (Spec 016 §Active owners). THE single owner mint for
+  every adapter family (rf2-qdkt8y): two owners minted anywhere in one process
+  are always distinct, so a mixed-adapter process can never collide two
+  families' leases on one owner. Framework-internal — not part of the public
+  adapter surface."
+  []
+  [:lease (swap! lease-owner-counter inc)])
+
+;; ============================================================================
+;; Shared ensure / release dispatch (one implementation, all families)
+;; ============================================================================
+
+(defn- dispatch-ensure!
+  "Dispatch `:rf.resource/ensure` for `descriptor` under `owner` into `frame-id`,
+  recording `cause`. Direct owning-ns dispatch (not the `rf/dispatch` macro) —
+  framework-internal plumbing, not an application call site, so it deliberately
+  carries no `:rf.trace/call-site`."
+  [frame-id {:keys [resource scope params]} owner cause]
+  (router/dispatch! [:rf.resource/ensure
+                     {:resource resource
+                      :scope    scope
+                      :params   params
+                      :owner    owner
+                      :cause    cause}]
+                    {:frame frame-id}))
+
+(defn- dispatch-release!
+  "Dispatch `:rf.resource/release-owner` for `owner` into `frame-id` — the frame
+  the matching ensure targeted."
+  [frame-id owner]
+  (router/dispatch! [:rf.resource/release-owner {:owner owner}]
+                    {:frame frame-id}))
+
+;; ============================================================================
+;; Ratom-family (Reagent / reagent-slim) shared lifecycle + component factory
+;; ============================================================================
+;;
+;; The ratom families express the lease as a Form-3 component (mount / update /
+;; unmount lifecycle methods) rather than a React hook. Everything about the
+;; lease — arg normalization, render-time frame resolution, the desired/held
+;; diff, ensure / release, and the re-lease ORDERING (release-old then
+;; ensure-new under the SAME owner) — lives HERE, once. The two adapters differ
+;; ONLY in bare substrate ops (`create-class` / `current-component`) and how the
+;; frame React-context is wired onto the class (stock Reagent copies a
+;; `:context-type` map key; reagent-slim's create-class caps its key set and
+;; sets the static `contextType` afterwards) — supplied via
+;; `make-resource-lease-component`'s `build-class`, so those substrate specifics
+;; stay ISOLATED per adapter and never cross-leak.
+
+(defn lease-args
+  "Normalise a ratom `with-resource-lease` call `[descriptor & args]` into
+  `{:descriptor :cause :frame :body}`. The optional `opts` map may sit between
+  the descriptor and the body thunk; a leading fn is the body."
+  [[descriptor & args]]
+  (let [[opts body] (if (fn? (first args))
+                      [nil (first args)]
+                      [(first args) (second args)])]
+    {:descriptor descriptor
+     :cause      (get opts :cause [:lease :mount])
+     :frame      (get opts :frame)
+     :body       body}))
+
+(defn resolve-lease-frame
+  "Resolve the frame a lease targets, at RENDER time, honouring EP-0002 tier
+  precedence (Spec 002 §Frame target resolution): an explicit `explicit-frame`
+  pins the target; otherwise delegate to the canonical reader
+  `frame/require-current-frame!` — dynamic-var tier (`*current-frame*`) FIRST,
+  React-context tier SECOND, else the always-on `:rf.error/no-frame-context`.
+  `reader` / `where` name the caller for that error (the ratom families pass the
+  `with-resource-lease` marker; the hook passes the `use-resource-lease` one).
+
+  Resolving at RENDER time (not in a commit-phase lifecycle method) keeps the
+  dynamic-var tier able to win — resolving after the render scope unwound would
+  see `*current-frame*` already restored (the EP-0002 inversion)."
+  [explicit-frame reader where]
+  (or explicit-frame
+      (frame/require-current-frame! reader {:where where})))
+
+(defn- ensure-lease!
+  "Dispatch `:rf.resource/ensure` for the render-time-resolved `desired` target
+  (`#js {:frame :descriptor :cause}`) under `owner`. Returns the HELD-lease
+  record (frame + owner + descriptor + cause snapshot) so a later re-lease diff
+  and the unmount release act on the SAME target the ensure used, even after the
+  render scope has unwound."
+  [^js desired owner]
+  (let [frame-id   (.-frame desired)
+        descriptor (.-descriptor desired)
+        cause      (.-cause desired)]
+    (dispatch-ensure! frame-id descriptor owner cause)
+    #js {:frame frame-id :lease owner :descriptor descriptor :cause cause}))
+
+(defn- release-lease!
+  "Dispatch `:rf.resource/release-owner` for the `held` lease into the frame it
+  was ensured against."
+  [^js held]
+  (dispatch-release! (.-frame held) (.-lease held)))
+
+(defn lease-target-changed?
+  "True when the render-time `desired` target differs from the currently-`held`
+  lease on frame, descriptor, or cause — the same `[frame descriptor cause]`
+  tuple the React-hook twin keys its effect on."
+  [^js held ^js desired]
+  (or (not= (.-frame held)      (.-frame desired))
+      (not= (.-descriptor held) (.-descriptor desired))
+      (not= (.-cause held)      (.-cause desired))))
+
+;; The ratom families' frame-resolution error marker. reagent-slim is PUBLISHED
+;; as `re-frame.adapter.reagent` (its in-tree `-slim` ns is renamed at
+;; publication; a `-slim` symbol would survive verbatim into the shipped jar),
+;; so BOTH ratom adapters name the canonical `re-frame.adapter.reagent/
+;; with-resource-lease` here — rename-stable in-tree AND post-publish
+;; (rf2-gjvu84).
+(def ^:private ratom-lease-reader :with-resource-lease)
+(def ^:private ratom-lease-where  're-frame.adapter.reagent/with-resource-lease)
+
+(defn make-resource-lease-component
+  "Build a ratom-family (Reagent / reagent-slim) `with-resource-lease` Form-3
+  component. The lease IDENTITY (owner mint) and LIFECYCLE semantics (frame
+  resolution, ensure on mount, re-lease on descriptor/frame/cause change,
+  release on unmount) live here — ONE implementation shared by both ratom
+  adapters (rf2-qdkt8y). The substrate supplies ONLY:
+
+    :current-component  the substrate's `current-component` reader, called in
+                        `:reagent-render` to stash the render-time target.
+    :build-class        `(fn [class-map] -> class)` — runs the substrate's
+                        `create-class` on the lifecycle-method map AND wires the
+                        frame React-context onto the class. Kept per-adapter so
+                        stock Reagent's `:context-type` map key and reagent-
+                        slim's post-hoc static `contextType` stay ISOLATED (no
+                        cross-leak) — the ONLY substrate divergence.
+
+  A single Form-3 `create-class` (NOT a Form-2 returning one — that would mint a
+  fresh component type per render and remount). Frame resolution happens in
+  `:reagent-render` (render time, so the dynamic-var tier can win and the
+  in-flight component is the resolving one); the render-time-resolved frame +
+  descriptor + cause are stashed on the instance so the commit-phase methods act
+  on the render-time target even after the render scope unwinds.
+
+  Mount mints the per-instance owner ONCE (reused across re-leases, so a
+  hot-reload re-mount settles to exactly one held lease — ensure re-attaches the
+  same owner; Spec 016 §Active owners); `:component-did-update` diffs the
+  render-time `[frame descriptor cause]` against the held lease and, on any
+  change, RELEASES the old lease then ENSURES the new target under the SAME
+  owner (so neither is the old resource over-retained nor the new one
+  under-provisioned until unmount). Under SSR (`render-to-string`) lifecycle
+  methods do not run, so the acquire/release is a natural no-op."
+  [{:keys [current-component build-class]}]
+  (build-class
+    {:display-name "re-frame.adapter.reagent/with-resource-lease"
+     :reagent-render
+     (fn [d & args]
+       (let [{:keys [cause descriptor frame body]} (lease-args (cons d args))
+             frame-id (resolve-lease-frame frame ratom-lease-reader ratom-lease-where)]
+         ;; Stash the render-time-resolved lease target (dynamic-var-honouring
+         ;; frame + current descriptor/cause) so the commit-phase lifecycle
+         ;; methods take + re-lease against it after the render scope unwinds.
+         (set! (.-rf2LeaseDesired ^js (current-component))
+               #js {:frame frame-id :descriptor descriptor :cause cause})
+         (body)))
+     :component-did-mount
+     (fn [^js this]
+       ;; Mint the per-instance owner ONCE (reused across re-leases, matching
+       ;; the hook twin's stable useRef owner) + take the first lease.
+       (set! (.-rf2ResourceLease this)
+             (ensure-lease! (.-rf2LeaseDesired this) (mint-lease-owner!))))
+     :component-did-update
+     ;; Variadic to span both substrates: stock Reagent invokes did-update
+     ;; 4-arity (prev-argv, prev-children, snapshot), reagent-slim 3-arity
+     ;; (prev-argv, snapshot) per IMPL-SPEC §6.6. We read the render-time stash,
+     ;; not the prev args, so the extra positional args are ignored either way.
+     (fn [^js this & _]
+       (let [held    (.-rf2ResourceLease this)
+             desired (.-rf2LeaseDesired this)]
+         (when (and held desired (lease-target-changed? held desired))
+           ;; Descriptor / frame / cause changed across re-render — release the
+           ;; old lease then re-ensure the new target under the SAME owner.
+           (release-lease! held)
+           (set! (.-rf2ResourceLease this)
+                 (ensure-lease! desired (.-lease held))))))
+     :component-will-unmount
+     (fn [^js this]
+       (when-let [held (.-rf2ResourceLease this)]
+         (release-lease! held)))}))
+
+;; ============================================================================
+;; React-hook family (UIx / Helix) — `use-resource-lease`
+;; ============================================================================
 
 (defn use-resource-lease
   "React hook (UIx / Helix): take a resource liveness LEASE for the calling
@@ -113,40 +321,30 @@
    ;; React-context → loud `:rf.error/no-frame-context`. Resolving here (not
    ;; inside the effect) captures the render-time frame to close over, since
    ;; the effect runs after the render scope unwinds.
-   (let [frame-id (or frame
-                      (frame/require-current-frame!
-                        :use-resource-lease
-                        {:where 're-frame.adapter.resource-lease/use-resource-lease}))
-         ;; One stable lease token per mounted instance (survives re-renders
-         ;; AND React StrictMode's mount→cleanup→mount double-invoke).
-         token-ref (React/useRef nil)
-         token     (or (.-current token-ref)
-                       (let [t (swap! lease-token-counter inc)]
-                         (set! (.-current token-ref) t)
-                         t))
-         lease     [:lease token]
+   (let [frame-id (resolve-lease-frame
+                    frame :use-resource-lease
+                    're-frame.adapter.resource-lease/use-resource-lease)
+         ;; One stable lease OWNER per mounted instance (survives re-renders AND
+         ;; React StrictMode's mount→cleanup→mount double-invoke), drawn from the
+         ;; single framework owner mint so a mixed-adapter process can't collide.
+         owner-ref (React/useRef nil)
+         owner     (or (.-current owner-ref)
+                       (let [o (mint-lease-owner!)]
+                         (set! (.-current owner-ref) o)
+                         o))
          cause     (or cause [:lease :mount])
          {:keys [resource scope params]} descriptor
          ;; Stable primitive deps for React's `Object.is` comparison: the
          ;; descriptor / cause are value-equal but fresh JS objects per
          ;; render, so key the effect on a printed digest rather than the
          ;; live objects (the same stable-key discipline the spine's
-         ;; use-subscribe uses for its query vector).
-         deps-key  (pr-str [frame-id token resource scope params cause])]
+         ;; use-subscribe uses for its query vector). The owner is stable per
+         ;; instance, so it never triggers a re-lease.
+         deps-key  (pr-str [frame-id owner resource scope params cause])]
      (React/useEffect
        (fn arm-lease []
-         ;; Direct owning-ns dispatch (not the `rf/dispatch` macro) —
-         ;; this is framework-internal plumbing, not an application call
-         ;; site, so it deliberately carries no `:rf.trace/call-site`.
-         (router/dispatch! [:rf.resource/ensure
-                            {:resource resource
-                             :scope    scope
-                             :params   params
-                             :owner    lease
-                             :cause    cause}]
-                           {:frame frame-id})
+         (dispatch-ensure! frame-id descriptor owner cause)
          (fn release-lease []
-           (router/dispatch! [:rf.resource/release-owner {:owner lease}]
-                             {:frame frame-id})))
+           (dispatch-release! frame-id owner)))
        #js [deps-key])
      nil)))

--- a/implementation/core/test/re_frame/adapter/resource_lease_cljs_test.cljs
+++ b/implementation/core/test/re_frame/adapter/resource_lease_cljs_test.cljs
@@ -1,0 +1,87 @@
+(ns re-frame.adapter.resource-lease-cljs-test
+  "Unit coverage for the centralized resource-lease helpers
+  (`re-frame.adapter.resource-lease`, rf2-qdkt8y) — the SINGLE home for lease
+  identity + the shared ratom-family lifecycle logic that Reagent, reagent-slim,
+  UIx and Helix all draw from. Pinning the shared behaviour ONCE here means the
+  per-adapter DOM suites stay thin native-shell integration tests.
+
+  The mount/unmount lifecycle wiring (React effects / Reagent class methods)
+  needs a real DOM and is exercised by the per-adapter `*-dom-cljs-test`
+  suites and the mixed-family regression; here we pin the pure, substrate-free
+  pieces."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.adapter.resource-lease :as rl]))
+
+;; ---- the single owner mint (the core bug fix) ------------------------------
+
+(deftest mint-lease-owner-shape
+  (testing "mints the framework-canonical [:lease <n>] owner shape"
+    (let [owner (rl/mint-lease-owner!)]
+      (is (vector? owner))
+      (is (= :lease (first owner)))
+      (is (number? (second owner))))))
+
+(deftest mint-lease-owner-is-globally-unique
+  (testing "successive mints are always DISTINCT — the property that stops a
+            mixed-adapter process colliding two families' lease owners (every
+            family now draws from THIS one mint, rf2-qdkt8y)"
+    (let [owners (repeatedly 200 rl/mint-lease-owner!)]
+      (is (= 200 (count (set owners)))
+          "200 mints yield 200 distinct owners (no collision, no reuse)")
+      (is (apply distinct? (map second owners))
+          "the minted tokens are strictly distinct"))))
+
+;; ---- ratom-family arg normalization ----------------------------------------
+
+(deftest lease-args-body-only
+  (testing "a leading fn is the body; cause/frame take defaults"
+    (let [body (fn [] [:div "x"])
+          {:keys [descriptor cause frame body]} (rl/lease-args [{:resource :r} body])]
+      (is (= {:resource :r} descriptor))
+      (is (= [:lease :mount] cause) "cause defaults to [:lease :mount]")
+      (is (nil? frame) "no frame pin by default")
+      (is (fn? body)))))
+
+(deftest lease-args-opts-then-body
+  (testing "an opts map between descriptor and body supplies :cause / :frame"
+    (let [body (fn [] [:div "x"])
+          {:keys [descriptor cause frame body]}
+          (rl/lease-args [{:resource :r}
+                          {:cause :dashboard :frame :some/frame}
+                          body])]
+      (is (= {:resource :r} descriptor))
+      (is (= :dashboard cause) "explicit :cause is carried")
+      (is (= :some/frame frame) "explicit :frame is carried")
+      (is (fn? body)))))
+
+(deftest lease-args-opts-defaults
+  (testing "an opts map with no :cause still defaults the cause"
+    (let [{:keys [cause frame]} (rl/lease-args [{:resource :r} {:frame :f} (fn [])])]
+      (is (= [:lease :mount] cause))
+      (is (= :f frame)))))
+
+;; ---- render-time frame resolution precedence -------------------------------
+
+(deftest resolve-lease-frame-explicit-wins
+  (testing "an explicit frame is returned verbatim, never consulting the
+            carried-invariant reader (EP-0002: explicit :frame pins the target)"
+    (is (= :pinned/frame
+           (rl/resolve-lease-frame :pinned/frame :some-reader 'some/where)))))
+
+;; ---- desired/held re-lease diff --------------------------------------------
+;; The commit-phase methods diff #js target records; a change on frame,
+;; descriptor, OR cause triggers a re-lease.
+
+(defn- rec [frame descriptor cause]
+  #js {:frame frame :descriptor descriptor :cause cause})
+
+(deftest lease-target-changed-detects-each-axis
+  (let [held (rec :f {:resource :r :params {:page 0}} :c)]
+    (testing "an identical target is NOT a change (holds one lease, no churn)"
+      (is (false? (boolean (rl/lease-target-changed? held (rec :f {:resource :r :params {:page 0}} :c))))))
+    (testing "a frame change is a re-lease"
+      (is (rl/lease-target-changed? held (rec :g {:resource :r :params {:page 0}} :c))))
+    (testing "a descriptor change is a re-lease"
+      (is (rl/lease-target-changed? held (rec :f {:resource :r :params {:page 1}} :c))))
+    (testing "a cause change is a re-lease"
+      (is (rl/lease-target-changed? held (rec :f {:resource :r :params {:page 0}} :d))))))


### PR DESCRIPTION
## Summary

Fixes a **P1 correctness bug**: in a supported mixed-adapter process, resource-lease owners minted by two different adapter families collided.

Each adapter family kept its **own** `(atom 0)` lease-token counter — stock Reagent (`reagent.cljs`), reagent-slim (`reagent_slim.cljs`), and the shared React-hook helper (`resource_lease.cljs`, used by UIx + Helix) — and each minted `[:lease (swap! ... inc)]` from zero. So the **first** lease taken by any two families was the identical owner `[:lease 1]`. Because `:rf.resource/release-owner` drops an owner from **every** indexed resource, unmounting one family's component then cross-released another family's still-live resource — a silent liveness bug.

**Fix (per the bead DESIGN):** make `re-frame.adapter.resource-lease` the **sole** owner of process-wide lease identity + lifecycle semantics.

1. **One framework-qualified owner mint** — `mint-lease-owner!` drawing from a single counter, so owners from different families are guaranteed distinct.
2. **Centralized lifecycle** — arg normalization (`lease-args`), render-time frame resolution (`resolve-lease-frame`, parameterized reader/where), desired/held diff (`lease-target-changed?`), ensure/release dispatch (`dispatch-ensure!` / `dispatch-release!`), and the release-then-ensure re-lease ordering all live once in core.
3. **Ratom-family component factory** — `make-resource-lease-component`, parameterized **only** by bare substrate ops (`current-component`) + a `build-class` fn. Stock Reagent's `:context-type` map key and slim's post-hoc static `contextType` stay isolated per adapter (no cross-leak).
4. **Public adapter APIs unchanged** — `reagent/with-resource-lease`, `reagent-slim/with-resource-lease`, `uix|helix/use-resource-lease` keep their exact Vars + call shapes. The two per-adapter counters + duplicated helpers are removed; the now-unused `re-frame.router` / `re-frame.frame` requires are dropped from both adapters.

## Mixed-adapter regression (the core-bug proof)

`mixed_family_lease_owner_dom_cljs_test` mounts a Reagent-family `with-resource-lease` **and** a React-hook-family `use-resource-lease` (the exact Var UIx/Helix re-export) against one frame's **real** resources runtime, and proves against the **real** `release-owner-handler`:

- simultaneous mounts get **distinct** owners (old code: both `[:lease 1]`);
- unmounting the Reagent one **preserves** the hook one's active-owner lease (old code: the shared `[:lease 1]` release cross-drops it).

Plus `resource_lease_cljs_test` pins the centralized shared behaviour once (mint uniqueness, `lease-args`, `resolve-lease-frame` precedence, `lease-target-changed?`). The existing per-adapter DOM suites (frame precedence, explicit frame, cause, descriptor-change, no-frame, SSR, StrictMode) remain green as thin native-shell integration tests.

## Quality gates (all foreground, 0 failures)

- `npm run test:cljs` — 8472 tests / 39122 assertions, 0 failures, 0 errors
- `npm run test:browser` — 257 tests / 866 assertions, 0 failures, 0 errors (runs the mixed regression's real DOM assertions + all lease DOM suites)
- `npm run test:adapter-smokes` — 3 specs, 0 failures
- `npm run test:bundle-isolation` — PASS (+ uix-helix-reagent-free: no stock-Reagent leakage)
- `npm run test:reagent-slim:bundle-isolation` — PASS, 6 contracts / 25 sentinel checks, **no stock-Reagent/react-dom leakage** (slim now requires only core `re-frame.adapter.resource-lease`; the factory receives slim's `reagent2.*` `create-class` by injection so core never names a reactive-atom ns)

## Stance

Pre-alpha, no back-compat shims. Elegance + clarity + correctness + good practice; a single source of lease identity removes the collision by construction rather than papering over it. Not hot-zone; touches only the reagent + reagent-slim adapter src, `core/.../resource_lease.cljs`, and their tests.