### PR TITLE
refactor(machines): one owner for transition candidate-maps + spawn-spec lookup (rf2-tu5psi, rf2-wm92kj)

### DIFF
--- a/implementation/machines/src/re_frame/machines/cofx_attach.cljc
+++ b/implementation/machines/src/re_frame/machines/cofx_attach.cljc
@@ -225,16 +225,18 @@
 ;; so an inline `:rf.cofx/requires` cannot hide on a slot value.
 
 (defn- always-entries
-  "Normalise a state-node's `:always` slot to a vector of entry maps
-  through the SAME shared candidate grammar `candidate-maps` below
-  resolves for `:on` / `:after` / `:on-done` (`grammar/transition-value-
-  form` — rf2-0k0f3x): a bare keyword desugars to `{:target <kw>}`, a
-  vector-target to `{:target <vec>}`, a single map is the one-element
-  case, a guarded candidate-vector passes through unchanged, and an
-  unrecognised shape degrades to `[]` (the runtime normaliser is the
-  throw's designated surface — `:rf.error/machine-bad-always`). Absent
-  `:always` (missing key, or present with nil) → `[]`. Mirrors
-  `validation/always-entries`.
+  "Normalise a state-node's `:always` slot to a vector of entry maps through
+  the SHARED `grammar/candidate-maps` (the ONE owner — rf2-tu5psi). Two
+  caller-specific policies stay HERE, not in the shared normaliser:
+
+    1. the optional `:always` nil semantics — an absent `:always` (missing
+       key, OR present with nil) yields `[]` (no ancestor-blocking, unlike
+       `:on` / `:after`'s nil-is-forbidden-transition form), so the nil is
+       gated BEFORE the shared normaliser (which would map nil to `[{}]`);
+    2. a malformed shape degrades to `[]` (the runtime normaliser is the
+       throw's designated surface — `:rf.error/machine-bad-always`).
+
+  Mirrors `validation/always-entries`.
 
   A `:type :choice` transient node carries its candidate vector under
   `:choice`, NOT `:always` — the choice lowers to `:always` only at
@@ -243,17 +245,13 @@
   IDENTICAL `:always` cascade the runtime settles it into, treat a choice
   node's `:choice` vector as its `:always` candidates here; validation
   guarantees a choice node never ALSO declares `:always` (a reserved key), so
-  there is no ambiguity."
+  there is no ambiguity. This choice-node source selection likewise stays at
+  the caller — the shared normaliser sees only the resolved slot value."
   [node]
   (let [a (if (choice/choice-node? node) (:choice node) (:always node))]
     (if (nil? a)
       []
-      (case (grammar/transition-value-form a)
-        :keyword          [{:target a}]
-        :candidate-vector a
-        :vec-target       [{:target a}]
-        :map              [a]
-        :other            []))))
+      (or (grammar/candidate-maps a) []))))
 
 (defn- walk-nodes-with-path
   "Yield `[absolute-path node]` pairs for every state node, recursing
@@ -332,18 +330,12 @@
 
 (defn- candidate-maps
   "Normalise a transition-slot value to its candidate maps (each carrying
-  `:guard` / `:action` / `:target`). Mirrors `transition/normalise-
-  candidates` shape-wise via the shared `grammar/transition-value-form`, but
-  does NOT throw — a malformed shape (caught by `validation`) contributes no
-  candidates here."
+  `:guard` / `:action` / `:target`) via the SHARED `grammar/candidate-maps`
+  (the ONE owner — rf2-tu5psi), mapping the malformed form (grammar returns
+  nil) to NO candidates: `validation` is the designated throw surface, so a
+  malformed shape contributes nothing to the static ensure-set here."
   [v]
-  (case (grammar/transition-value-form v)
-    :nil              [{}]
-    :keyword          [{:target v}]
-    :candidate-vector v
-    :vec-target       [{:target v}]
-    :map              [v]
-    :other            []))
+  (or (grammar/candidate-maps v) []))
 
 (defn- node-at
   "Root→leaf descent into `machine`'s `:states` (or a region body's).

--- a/implementation/machines/src/re_frame/machines/grammar.cljc
+++ b/implementation/machines/src/re_frame/machines/grammar.cljc
@@ -32,6 +32,8 @@
       (transition-value-form v)          ;; :keyword | :vec-target |
                                          ;;   :candidate-vector | :map |
                                          ;;   :nil | :other
+      (candidate-maps v)                 ;; [{:target/:guard/:action …} …] |
+                                         ;;   nil (malformed — caller decides)
       (candidate-targets v)              ;; [{:present? bool :target t} ...]
 
   `node-at` takes a `:states` map directly (NOT a machine) — the lowest
@@ -130,6 +132,50 @@
   spec-path discriminator."
   [v]
   (= :candidate-vector (transition-value-form v)))
+
+(defn candidate-maps
+  "Normalise a transition-table slot value to the vector of canonical
+  candidate transition maps it denotes — the ONE owner of the value-form →
+  candidate-maps mapping the `:on` / `:after` / `:always` / `:on-done` /
+  `:on-error` slots all share (rf2-tu5psi). Discriminates on the shared
+  `transition-value-form` recogniser:
+
+    :nil              -> [{}]              (forbidden / internal no-op — the
+                                            natural Clojure analogue of XState
+                                            `undefined`; unified with the empty
+                                            map `{}` single-candidate form)
+    :keyword          -> [{:target <kw>}]  (sibling target)
+    :candidate-vector -> the vector        (guarded candidates, first-pass wins)
+    :vec-target       -> [{:target <vec>}] (absolute path target)
+    :map              -> [<map>]           (a single candidate map)
+    :other            -> nil               (MALFORMED — the caller decides)
+
+  Returning `nil` (not a throw, not `[]`) for the malformed form is what lets
+  the two caller classes keep their own policy over ONE grammar:
+
+    - the runtime normaliser (`transition/normalise-candidates`) maps the nil
+      to a slot-specific throw (`:rf.error/machine-bad-on-clause` /
+      `-after-spec` / `-always` / …), preserving its taxonomy;
+    - the registration-time cofx / validation walkers map the nil to `[]`
+      (no candidates) — `validation` is the throw's designated surface, so a
+      static walker must not choke on a malformed shape.
+
+  The optional `:always` nil semantics (an ABSENT / explicit-nil `:always`
+  yields `[]`, not `[{}]`) stays at those callers — they gate the nil BEFORE
+  calling here.
+
+  This is the runtime-shaped sibling of `candidate-targets` (the shape the
+  registration TARGET validator consumes): both build on `transition-value-
+  form`, so the candidate-maps normaliser and the target walker can never
+  drift on the grammar they admit."
+  [v]
+  (case (transition-value-form v)
+    :nil              [{}]
+    :keyword          [{:target v}]
+    :candidate-vector v
+    :vec-target       [{:target v}]
+    :map              [v]
+    :other            nil))
 
 (defn candidate-targets
   "Normalise a transition slot value to the seq of `:target`s it

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
@@ -158,23 +158,6 @@
   (some (fn [[_ node]] (when (true? (:error? node)) node))
         (region-final-leaf-nodes machine state)))
 
-(defn- find-spawn-spec-at
-  "Walk `parent-spec`'s state tree to the node at `invoke-id` (the
-  absolute prefix-path stamped at spawn time) and return that node's
-  `:spawn` map. For a parallel-region parent, the first element of
-  `invoke-id` is the region name; strip and descend
-  into that region's body. Returns nil if the path doesn't resolve
-  or the node doesn't declare `:spawn`."
-  [parent-spec invoke-id]
-  (when (and parent-spec (vector? invoke-id) (seq invoke-id))
-    (let [[head & tail] invoke-id
-          [tree path]   (if (and (parallel/parallel? parent-spec)
-                                 (contains? (:regions parent-spec) head))
-                          [(get-in parent-spec [:regions head]) (vec tail)]
-                          [parent-spec invoke-id])
-          node          (transition/node-at tree path)]
-      (:spawn node))))
-
 ;; ---- the orchestrator ------------------------------------------------------
 
 (defn finalize-machine
@@ -336,7 +319,7 @@
                         (:rf/machine? parent-reg) (:rf/machine parent-reg)
                         :else                     (resolver/spec-from-snapshot parent-snap)))
         spawn-spec  (when (and parent-meta invoke-id)
-                      (find-spawn-spec-at parent-meta invoke-id))
+                      (resolver/spawn-spec-at parent-meta invoke-id))
         on-done-fn  (:on-done spawn-spec)
         ;; `:on-error` is a transition spec (not a fn) — its PRESENCE on the
         ;; resolved `:spawn` map decides whether the error-leaf trigger routes

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/resolver.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/resolver.cljc
@@ -26,13 +26,20 @@
       snapshot — there is no registered type, so the snapshot is the only
       source of truth (and it is fully revertible).
 
-  This namespace is a LEAF — it requires only `registrar` + `paths`, so
-  the destroy-path consumers (`exit-cascade`, `finalize`) may require it
-  without a load cycle through `registration`. The handler-MATERIALISING
-  side of the resolver (which needs `make-machine-handler`) lives in
+  This namespace is a LEAF over the machine-core grammar — it requires
+  `registrar` + `paths` plus the pure `grammar` (state-tree descent) and
+  `parallel` (the `:type :parallel` predicate) for `spawn-spec-at`. None of
+  those require any `lifecycle-fx` namespace (`grammar` is require-free;
+  `parallel` requires only engine-core `choice` / `result` / `timeout` /
+  `transition` / `trace`), so the destroy-path consumers (`exit-cascade`,
+  `finalize`, `spawn-error`) may require it without a load cycle through
+  `registration`. The handler-MATERIALISING side of the resolver (which needs
+  `make-machine-handler`) lives in
   `lifecycle-fx.registration/resolve-actor-handler-meta`, the late-bound
   `:machines/resolve-actor-handler-meta` hook body."
-  (:require [re-frame.machines.paths :as paths]
+  (:require [re-frame.machines.grammar :as grammar]
+            [re-frame.machines.parallel :as parallel]
+            [re-frame.machines.paths :as paths]
             [re-frame.registrar :as registrar]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -105,3 +112,27 @@
   (boolean
     (some-> (get-in db (paths/snapshot-path actor-id))
             (spec-from-snapshot))))
+
+(defn spawn-spec-at
+  "Walk `parent-spec`'s state tree to the `:spawn`-bearing node at `invoke-id`
+  (the absolute prefix-path stamped at spawn time) and return that node's
+  `:spawn` map, resolving flat AND region-prefixed invoke paths through
+  `grammar/node-at`. For a parallel-region parent the first element of
+  `invoke-id` is the region name; strip it and descend into that region's
+  body. Returns nil if `parent-spec` is absent, `invoke-id` is not a
+  non-empty vector, the path doesn't resolve, or the node declares no
+  `:spawn`.
+
+  The single owner for the spawn-spec-at-invoke-id lookup shared by the
+  finalize `:on-done` cascade (`finalize/finalize-machine`) and the
+  spawn-error `:on-error` routing (`spawn-error/parent-declares-on-error?`) —
+  the two carried byte-for-byte copies before this was hoisted here
+  (rf2-wm92kj), so a fix to the flat / region resolution had to land twice."
+  [parent-spec invoke-id]
+  (when (and parent-spec (vector? invoke-id) (seq invoke-id))
+    (let [[head & tail] invoke-id
+          [tree path]   (if (and (parallel/parallel? parent-spec)
+                                 (contains? (:regions parent-spec) head))
+                          [(get-in parent-spec [:regions head]) (vec tail)]
+                          [parent-spec invoke-id])]
+      (:spawn (grammar/node-at (:states tree) path)))))

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn_error.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn_error.cljc
@@ -32,11 +32,12 @@
   hatch is the lower-level form.
 
   This namespace is a LEAF over the spawn-resolution helpers it needs
-  (`resolver` + `paths` + `transition` + `late-bind` + `registrar`), so both
-  `finalize` and `registration` may require it without a load cycle."
+  (`resolver` + `paths` + `transition` + `late-bind`), so both `finalize` and
+  `registration` may require it without a load cycle. The `:spawn`-at-invoke-id
+  lookup lives in `resolver/spawn-spec-at` (the shared owner — rf2-wm92kj);
+  `transition` is retained only for the reserved `spawn-error-event-id`."
   (:require [re-frame.late-bind :as late-bind]
             [re-frame.machines.lifecycle-fx.resolver :as resolver]
-            [re-frame.machines.parallel :as parallel]
             [re-frame.machines.paths :as paths]
             [re-frame.machines.transition :as transition]))
 
@@ -54,24 +55,6 @@
       parent-id
       (get-in db (paths/snapshot-path parent-id)))))
 
-(defn- find-spawn-spec-at
-  "Walk `parent-spec`'s state tree to the `:spawn`-bearing node at `invoke-id`
-  (the absolute prefix-path stamped at spawn time) and return its `:spawn`
-  map. For a parallel-region parent the first element of `invoke-id` is the
-  region name; strip and descend into that region's body.
-  Returns nil if the path doesn't resolve or the node declares no `:spawn`.
-  (Same resolution as `finalize/find-spawn-spec-at` — duplicated here so this
-  leaf namespace stays independent of `finalize`, which depends on it.)"
-  [parent-spec invoke-id]
-  (when (and parent-spec (vector? invoke-id) (seq invoke-id))
-    (let [[head & tail] invoke-id
-          [tree path]   (if (and (parallel/parallel? parent-spec)
-                                 (contains? (:regions parent-spec) head))
-                          [(get-in parent-spec [:regions head]) (vec tail)]
-                          [parent-spec invoke-id])
-          node          (transition/node-at tree path)]
-      (:spawn node))))
-
 (defn parent-declares-on-error?
   "True iff the child identified by `parent-id` / `invoke-id` was spawned by a
   parent whose `:spawn` map at `invoke-id` declares `:on-error`. `db` is the
@@ -82,7 +65,7 @@
   (boolean
     (when (and parent-id invoke-id)
       (some-> (resolve-parent-spec db parent-id)
-              (find-spawn-spec-at invoke-id)
+              (resolver/spawn-spec-at invoke-id)
               :on-error
               some?))))
 

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
@@ -328,10 +328,10 @@
                ":type :parallel requires a non-empty :regions map")))
     ;; The parallel root's `:on-done` must not carry an in-machine `:target`
     ;; in ANY form (root-only parallel has no flat sibling to land on).
-    ;; Normalise EVERY value-form `:on-done` admits — mirroring
-    ;; `transition/normalise-candidates` (the runtime grammar the
-    ;; parallel-root `apply-on-done-action` resolves through) — to its
-    ;; candidate map(s), then reject if any candidate declares `:target`.
+    ;; Normalise EVERY value-form `:on-done` admits via the SHARED
+    ;; `grammar/candidate-maps` (the ONE owner — rf2-tu5psi — the same grammar
+    ;; the runtime parallel-root `apply-on-done-action` resolves through), then
+    ;; reject if any candidate declares `:target`.
     ;;
     ;; This covers every target-bearing form: a bare-keyword target
     ;; (`:on-done :next`), a vector-path target (`:on-done [:next]`), a map
@@ -342,20 +342,10 @@
     ;; and moves nowhere — a SILENT STALL in the all-final configuration. Per
     ;; the loud-failure posture, every target-bearing form is rejected loudly
     ;; at registration. Action / fx-only `:on-done` (no `:target`) stays
-    ;; accepted.
+    ;; accepted. A malformed shape (grammar nil) degrades to no candidates.
     (when (contains? machine :on-done)
       (let [on-done (:on-done machine)
-            ;; Mirror transition/normalise-candidates: keyword → {:target kw};
-            ;; vector-of-maps → as-is; any other vector → {:target vec};
-            ;; map → [map]; nil/other → no target-bearing candidate.
-            cands   (cond
-                      (keyword? on-done) [{:target on-done}]
-                      (and (vector? on-done)
-                           (seq on-done)
-                           (every? map? on-done)) on-done
-                      (vector? on-done)  [{:target on-done}]
-                      (map? on-done)     [on-done]
-                      :else              [])]
+            cands   (or (grammar/candidate-maps on-done) [])]
         (when (some #(contains? % :target) cands)
           (throw (validation-error
                    :rf.error/machine-parallel-on-done-target
@@ -383,8 +373,8 @@
     ;; transition (the timer-driven analog of the root `:on` ancestor
     ;; fallback), so a non-region-qualified root `:after` target is rejected
     ;; with the SAME `:rf.error/machine-parallel-root-on-bad-target` keyword.
-    ;; `candidates-of` is the shared `:on` / `:after` value-form normaliser
-    ;; (mirroring `transition/normalise-candidates`).
+    ;; `candidates-of` is the SHARED `:on` / `:after` value-form normaliser —
+    ;; the ONE owner `grammar/candidate-maps` (rf2-tu5psi), malformed → `[]`.
     (let [region-names (set (keys (:regions machine)))
           declared?    (fn [t] (contains? region-names t))
           bad-target!  (fn [slot target]
@@ -416,14 +406,7 @@
                              (bad-target! slot target))
                            ;; bare keyword / any other shape — no flat sibling
                            :else (bad-target! slot target)))
-          candidates-of (fn [v]
-                          (cond
-                            (nil? v)                       [{}]
-                            (keyword? v)                   [{:target v}]
-                            (and (vector? v) (every? map? v) (seq v)) v
-                            (vector? v)                    [{:target v}]
-                            (map? v)                       [v]
-                            :else                          []))]
+          candidates-of (fn [v] (or (grammar/candidate-maps v) []))]
       (doseq [[_event v] (:on machine)
               cand        (candidates-of v)]
         (check-one! ":on" (:target cand)))
@@ -933,30 +916,20 @@
              {:state state-key}))))
 
 (defn- always-entries
-  "Normalise a state-node's `:always` slot to a vector of entry maps,
-  through the SAME shared candidate grammar `:on` / `:after` resolve
-  (`grammar/transition-value-form` — rf2-0k0f3x): a bare keyword desugars
-  to `{:target <kw>}`, a vector-target to `{:target <vec>}`, a single map
-  is the one-element case, and a guarded candidate-vector passes through
-  unchanged. Mirrors `transition/normalise-candidates`'s arms minus the
-  throw (a malformed value is caught elsewhere — the runtime normaliser
-  throws `:rf.error/machine-bad-always` at the first macrostep; this
-  validation-side walker just needs SOME vector to iterate, so an
-  unrecognised shape degrades to the empty vector rather than choking a
-  registration-time walk that isn't the throw's designated surface).
-  Absent `:always` — the key is missing, OR present with an explicit nil
-  value — yields the empty vector (no ancestor-blocking use case for
-  `:always`, unlike `:on` / `:after`'s nil-is-forbidden-transition form)."
+  "Normalise a state-node's `:always` slot to a vector of entry maps through
+  the SHARED `grammar/candidate-maps` (the ONE owner — rf2-tu5psi). Absent
+  `:always` — the key missing, OR present with an explicit nil value — yields
+  the empty vector (no ancestor-blocking use case for `:always`, unlike `:on`
+  / `:after`'s nil-is-forbidden-transition form), so the nil is gated BEFORE
+  the shared normaliser (which maps nil to `[{}]`). A malformed value degrades
+  to `[]` (the runtime normaliser throws `:rf.error/machine-bad-always` at the
+  first macrostep; this registration-side walker just needs SOME vector to
+  iterate — it is not the throw's designated surface)."
   [state-node]
   (let [a (:always state-node)]
     (if (nil? a)
       []
-      (case (grammar/transition-value-form a)
-        :keyword          [{:target a}]
-        :candidate-vector a
-        :vec-target       [{:target a}]
-        :map              [a]
-        :other            []))))
+      (or (grammar/candidate-maps a) []))))
 
 (defn- always-self-loop?
   "True iff an `:always` entry's `:target` resolves to its own declaring

--- a/implementation/machines/src/re_frame/machines/path_walk.cljc
+++ b/implementation/machines/src/re_frame/machines/path_walk.cljc
@@ -54,7 +54,8 @@
   ## Why not also root→leaf?
 
   The inverse direction (root→leaf descent to a known absolute path,
-  as in `find-spawn-spec-at`) is a different operation — it walks to
+  as in `grammar/node-at` / `resolver/spawn-spec-at`) is a different
+  operation — it walks to
   a known target rather than seeking a deepest match. Treating it as
   the same primitive with a direction flag obscured the unifying rule
   (deepest-wins isn't 'a walk'; it's 'a walk in a specific direction

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -740,31 +740,31 @@
   (`:on` → `machine-bad-on-clause`, `:after` → `machine-bad-after-spec`,
   `:always` → `machine-bad-always`).
 
-  Discriminates on `grammar/transition-value-form` — the SHARED form
-  recogniser the registration target validator (`validation/candidate-
-  targets`) also builds on — so the runtime normaliser and the
+  Delegates the value-form → candidate-maps mapping to the SHARED
+  `grammar/candidate-maps` (the ONE owner — rf2-tu5psi), which returns nil
+  for the malformed form so THIS runtime caller keeps its slot-specific error
+  taxonomy (`bad-value-id`) while the static cofx / validation walkers degrade
+  malformed input to `[]`. `grammar/candidate-maps` builds on the same
+  `grammar/transition-value-form` recogniser the registration target validator
+  (`grammar/candidate-targets`) also uses, so the runtime normaliser and the
   registration walker can never drift on what shapes the grammar admits."
   [v bad-value-id]
-  (case (grammar/transition-value-form v)
-    ;; A nil VALUE (the key is present with value nil) is the
-    ;; forbidden-transition / internal no-op form — unify
-    ;; with the empty-map single-candidate `[{}]`.
-    :nil              [{}]
-    :keyword          [{:target v}]
-    :candidate-vector v
-    :vec-target       [{:target v}]
-    :map              [v]
-    :other            (throw (machine-error
-                               bad-value-id
-                               (str "A transition slot carried a malformed value "
-                                    (pr-str v) " — a transition value must be a target "
-                                    "state keyword, a target vector path, a candidate map "
-                                    "(`{:target … :guard … :action …}`), a vector of "
-                                    "candidate maps, or nil (a forbidden / internal no-op). "
-                                    "Fix the offending `:on` / `:after` / `:always` / "
-                                    ":on-done` / :on-error` clause on the machine registration.")
-                               {:value v
-                                :slot  bad-value-id}))))
+  (or (grammar/candidate-maps v)
+      ;; `grammar/candidate-maps` returns nil ONLY for the malformed
+      ;; (`:other`) form — every recognised form (incl. the `:nil`
+      ;; forbidden-transition / internal no-op → `[{}]`) yields a candidate
+      ;; vector. This runtime caller maps that nil to its slot-specific throw.
+      (throw (machine-error
+               bad-value-id
+               (str "A transition slot carried a malformed value "
+                    (pr-str v) " — a transition value must be a target "
+                    "state keyword, a target vector path, a candidate map "
+                    "(`{:target … :guard … :action …}`), a vector of "
+                    "candidate maps, or nil (a forbidden / internal no-op). "
+                    "Fix the offending `:on` / `:after` / `:always` / "
+                    ":on-done` / :on-error` clause on the machine registration.")
+               {:value v
+                :slot  bad-value-id}))))
 
 (defn- candidate-vector-form?
   "True iff `v` is the multi-candidate VECTOR form (`[{…} {…}]`) — the


### PR DESCRIPTION
Two clustered machine-internal dedup refactors. No public API / facade change; both behavior-preserving. Not hot-zone.

## rf2-tu5psi — one owner for transition candidate-map normalization (commit 1)

Add an internal `grammar/candidate-maps` that maps every recognized transition-value-form to its canonical candidate maps and returns **nil** for the malformed (`:other`) form, so each caller keeps its own policy over ONE grammar:

- `transition/normalise-candidates` delegates, mapping the nil to its slot-specific throw (`:rf.error/machine-bad-on-clause` / `-after-spec` / `-always`) — runtime error taxonomy preserved.
- `cofx_attach/candidate-maps` + `cofx_attach/always-entries` delegate, malformed → `[]`.
- `validation/always-entries` **and** the two inline reimplementations in `validate-parallel!` (the `:on-done` `cands` cond + the root `:on`/`:after` `candidates-of` fn) delegate, malformed → `[]`.

Optional `:always` nil semantics (absent/explicit-nil → `[]`, not `[{}]`) and the choice-node `:choice`-vs-`:always` source selection stay AT their callers (gated before the shared normaliser), per the bead.

## rf2-wm92kj — one lifecycle owner for invoke-path spawn-spec lookup (commit 2)

`find-spawn-spec-at` was duplicated byte-for-byte in `lifecycle_fx/finalize` and `lifecycle_fx/spawn_error`. Hoisted into `lifecycle_fx/resolver` as internal `spawn-spec-at`, resolving flat + region-prefixed invoke paths through `grammar/node-at`. Both finalization (`:on-done` cascade) and spawn-error routing (`parent-declares-on-error?`) call the shared resolver. `resolver` gains `grammar` + `parallel` requires (neither pulls in any lifecycle-fx ns → no load cycle through `registration`); `spawn_error` drops its now-unused `parallel` require and keeps `transition` only for the reserved `spawn-error-event-id`.

## Preflight confirmations

Both duplication premises verified real before centralizing:
- **tu5psi**: the keyword / candidate-vector / vector-target / map arms genuinely repeat across `transition/normalise-candidates`, `cofx_attach` (`candidate-maps` + `always-entries`), and `validation` (`always-entries` **plus** two more inline reimplementations in `validate-parallel!` folded in for one owner). Caller-specific differences preserved: runtime slot-specific throws, static-caller malformed→`[]`, optional `:always` nil→`[]`, choice-node source selection.
- **wm92kj**: `find-spawn-spec-at` confirmed byte-for-byte identical in `finalize.cljc` and `spawn_error.cljc` (docstrings aside). `transition/node-at` was a thin wrapper over `grammar/node-at (:states m)`; the resolver now calls `grammar/node-at` directly (behaviorally identical).

## Quality gates (foreground)

- `cd implementation/machines && clojure -M:test` → **922 tests, 2911 assertions, 0 failures, 0 errors**
- `cd implementation && npm run test:cljs` → **8464 tests, 39101 assertions, 0 failures, 0 errors**

## Stance

Pre-alpha, no back-compat / abstraction layers beyond the one internal helper each bead asks for. ELEGANCE + CLARITY + CORRECTNESS + GOOD-PRACTICE. Do not merge (worker PR).
