### PR TITLE
refactor(resources): one param-validation owner + canonical entry-stale? (rf2-7rbb7t, rf2-dv4uj1)

### DIFF
--- a/implementation/resources/src/re_frame/resources/mutation_registry.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_registry.cljc
@@ -19,10 +19,10 @@
   resolution reuse the resource registry's pluggable late-bound Malli
   validator and canonicalization."
   (:require [re-frame.error :as error]
-            [re-frame.late-bind :as late-bind]
             [re-frame.registrar :as registrar]
             [re-frame.resources.classification :as classification]
             [re-frame.resources.mutation-runtime :as mstate]
+            [re-frame.resources.params :as params]
             [re-frame.resources.state :as state]
             [re-frame.source-coords :as source-coords]))
 
@@ -371,31 +371,27 @@
   canonicalization — the schema, not a blanket `(or params {})`, decides
   whether nil conforms. The two registrars apply the SAME presence-aware
   policy so a validation boundary never performs an accidental API default
-  (EP-0012 §canonical-forms)."
+  (EP-0012 §canonical-forms).
+
+  A THIN wrapper over the shared `re-frame.resources.params/validate+
+  canonicalize` pipeline (rf2-7rbb7t) — the SAME leaf the resource registrar
+  wraps: this arm supplies ONLY the mutation-family error descriptor
+  (`:rf.error/mutation-invalid-params` with a `:mutation-id`); the
+  omitted-default, non-EDN rejection, late-bound schema validation,
+  invalid-param REDACTION (the shared classification seam), and canonicalization
+  are owned once there, so the two registrars can never drift again."
   [mutation-id spec params where]
-  (let [params (state/default-omitted-params params)
-        schema (:params-schema spec)]
-    (state/reject-non-edn! params where :params mutation-id)
-    (when schema
-      (let [validate (late-bind/get-fn-cached :schemas/validate-with-registered-fn)]
-        (when (and validate (not (validate schema params)))
-          (let [explain (late-bind/get-fn-cached :schemas/explain-with-registered-fn)
-                ;; rf2-99j4e4 — redact the thrown error payload identically to
-                ;; the resource registry (same shared classification seam): a
-                ;; `:sensitive?` params slot must not leak through public error
-                ;; data / logs when validation fails on a non-sensitive sibling,
-                ;; and a `:large?` slot elides consistently.
-                redacted (classification/redact-invalid-params-error
-                           params (when explain (explain schema params)) spec)]
-            (throw (registration-error
-                     :rf.error/mutation-invalid-params
-                     where
-                     (str "mutation " mutation-id " params do not conform to "
-                          ":params-schema. Per EP-0003 §Mutations.")
-                     {:mutation-id mutation-id
-                      :params      (:params redacted)
-                      :error       (:error redacted)}))))))
-    (state/canonicalize params)))
+  (params/validate+canonicalize
+    mutation-id spec params where
+    (fn [redacted-params redacted-error]
+      (registration-error
+        :rf.error/mutation-invalid-params
+        where
+        (str "mutation " mutation-id " params do not conform to "
+             ":params-schema. Per EP-0003 §Mutations.")
+        {:mutation-id mutation-id
+         :params      redacted-params
+         :error       redacted-error}))))
 
 (defn resolve-scope
   "Resolve the cache scope a mutation's invalidation / patch defaults to,

--- a/implementation/resources/src/re_frame/resources/params.cljc
+++ b/implementation/resources/src/re_frame/resources/params.cljc
@@ -1,0 +1,93 @@
+(ns re-frame.resources.params
+  "The single owner of the resource/mutation params validate+canonicalize
+  pipeline (rf2-7rbb7t). Both `re-frame.resources.registry` and
+  `re-frame.resources.mutation-registry` register a REQUIRED `:params-schema`
+  that validates + canonicalizes their family's params, and each family had
+  an independent, near-identical `validate+canonicalize-params`: default an
+  omitted slot, reject a non-EDN / host value at the cache-key boundary,
+  resolve the pluggable late-bound Malli validator/explainer, REDACT the
+  invalid params before they can ride an error payload, throw the
+  family-specific `:rf.error/*-invalid-params`, and canonicalize. The
+  nil/missing and invalid-param-redaction correctness/privacy fixes had to
+  land TWICE (a correctness + privacy-boundary duplication).
+
+  This leaf owns that pipeline ONCE, parameterized only by the family's error
+  descriptor — a `build-invalid-error` callback that shapes the family's
+  `:rf.error/resource-invalid-params` / `:rf.error/mutation-invalid-params`
+  throw. `registry` and `mutation-registry` keep THIN
+  `validate+canonicalize-params` wrappers so their call sites AND thrown error
+  shapes are unchanged.
+
+  LEAF, no new edge: it requires only `state` (the omitted-default /
+  EDN-rejection / canonicalization the two registrars already delegate to),
+  `classification` (the invalid-param redaction seam), and `late-bind` (the
+  pluggable Malli validator/explainer — NO static `schemas` dependency).
+  `registry` and `mutation-registry` already require all three, so hosting the
+  pipeline here introduces no require cycle; `mutation-registry` does NOT gain
+  a dependency on `registry`.
+
+  PRIVACY: the `classification/redact-invalid-params-error` step is a privacy
+  boundary — a `:sensitive?` params slot must never ride raw on the thrown
+  error payload / logs when validation fails on a non-sensitive sibling (and a
+  `:large?` slot elides). It is applied here ONCE, identically for both
+  families, before the family error is built."
+  (:require [re-frame.late-bind :as late-bind]
+            [re-frame.resources.classification :as classification]
+            [re-frame.resources.state :as state]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+(defn validate+canonicalize
+  "The shared validate+canonicalize params pipeline both the resource and the
+  mutation registrar delegate to (rf2-7rbb7t). Applies, in order:
+
+    1. the documented omitted-`:params` default (`state/default-omitted-params`)
+       — an ABSENT slot (`state/missing-params`) becomes `{}`; a PRESENT value
+       (INCLUDING an explicit `nil`) passes through unchanged so the
+       `:params-schema`, not a blanket `(or params {})`, decides whether nil
+       conforms (nil vs missing is schema-defined — Spec 016 §Resource
+       identity / EP-0012 §canonical-forms);
+    2. host / opaque value rejection at the cache-key boundary
+       (`state/reject-non-edn!`, throwing `:rf.error/resource-non-edn-params`);
+    3. schema conformance against the family `:params-schema` via the pluggable
+       late-bound Malli validator (`:schemas/validate-with-registered-fn`) — a
+       no-op when no validator is registered; NO static `schemas` dependency;
+    4. on a conformance failure, REDACT the failing params + explainer output
+       through the shared `classification/redact-invalid-params-error` privacy
+       seam (a `:sensitive?` slot never rides raw on the error payload; a
+       `:large?` slot elides), then throw the FAMILY error the
+       `build-invalid-error` callback shapes from the ALREADY-redacted values;
+    5. return the canonical params (`state/canonicalize`).
+
+  `id` is the resource / mutation id (named in the non-EDN boundary error).
+  `spec` carries the `:params-schema` + its per-slot classification marks.
+  `where` names the call-site public surface (threaded into the non-EDN error).
+  `build-invalid-error` is the family's error factory
+  `(fn [redacted-params redacted-error] -> ex-info-to-throw)` — the ONLY
+  difference between the two families (the
+  `:rf.error/resource-invalid-params` vs `:rf.error/mutation-invalid-params`
+  error id, the family message, and the `:resource-id` / `:mutation-id`
+  slot). It is invoked ONLY on a conformance failure, with the redacted params
+  + redacted explainer error, and its return value is thrown — so each family
+  keeps its exact thrown-error shape."
+  [id spec params where build-invalid-error]
+  (let [params (state/default-omitted-params params)
+        schema (:params-schema spec)]
+    ;; host / opaque values are rejected at the cache-key boundary
+    (state/reject-non-edn! params where :params id)
+    ;; schema conformance (pluggable; no-op when no validator is registered)
+    (when schema
+      (let [validate (late-bind/get-fn-cached :schemas/validate-with-registered-fn)]
+        (when (and validate (not (validate schema params)))
+          (let [explain  (late-bind/get-fn-cached :schemas/explain-with-registered-fn)
+                ;; rf2-99j4e4 — the thrown error data (and any downstream egress)
+                ;; must not leak a `:sensitive?` params slot (nor ride a `:large?`
+                ;; slot raw). Route `:params` + the explainer `:error` through the
+                ;; resources-family classification projection (the SAME per-slot
+                ;; owner surface SSR key egress uses + the shared schemas redaction
+                ;; seam), so the owner's `:params-schema` marks govern the error
+                ;; payload as they govern wire egress.
+                redacted (classification/redact-invalid-params-error
+                           params (when explain (explain schema params)) spec)]
+            (throw (build-invalid-error (:params redacted) (:error redacted)))))))
+    (state/canonicalize params)))

--- a/implementation/resources/src/re_frame/resources/registry.cljc
+++ b/implementation/resources/src/re_frame/resources/registry.cljc
@@ -26,9 +26,9 @@
   disposal surfaces."
   (:require [re-frame.error :as error]
             [re-frame.frame :as frame]
-            [re-frame.late-bind :as late-bind]
             [re-frame.registrar :as registrar]
             [re-frame.resources.classification :as classification]
+            [re-frame.resources.params :as params]
             [re-frame.resources.scope-registry :as scope-registry]
             [re-frame.resources.state :as state]
             [re-frame.resources.timers :as timers]
@@ -671,35 +671,26 @@
   decides whether nil conforms. This keeps the validation boundary from
   silently performing an accidental API default, so `{:params nil}` and an
   omitted `:params` stay distinct identities (Spec 016: \"nil vs missing MUST
-  be schema-defined, not accidental\"; EP-0012 §canonical-forms)."
+  be schema-defined, not accidental\"; EP-0012 §canonical-forms).
+
+  A THIN wrapper over the shared `re-frame.resources.params/validate+
+  canonicalize` pipeline (rf2-7rbb7t): this arm supplies ONLY the
+  resource-family error descriptor (`:rf.error/resource-invalid-params` with a
+  `:resource-id`); the omitted-default, non-EDN rejection, late-bound schema
+  validation, invalid-param REDACTION, and canonicalization are owned once in
+  that leaf (so the mutation registrar's identical pipeline can never drift)."
   [resource-id spec params where]
-  (let [params (state/default-omitted-params params)
-        schema (:params-schema spec)]
-    ;; host / opaque values are rejected at the cache-key boundary
-    (state/reject-non-edn! params where :params resource-id)
-    ;; schema conformance (pluggable; no-op when no validator is registered)
-    (when schema
-      (let [validate (late-bind/get-fn-cached :schemas/validate-with-registered-fn)]
-        (when (and validate (not (validate schema params)))
-          (let [explain (late-bind/get-fn-cached :schemas/explain-with-registered-fn)
-                ;; rf2-99j4e4 — the thrown error data + downstream egress must
-                ;; not leak a `:sensitive?` params slot (nor ride a `:large?`
-                ;; slot raw). Route `:params` + the explainer `:error` through
-                ;; the resources-family classification projection (the SAME
-                ;; per-slot owner surface SSR key egress uses + the shared
-                ;; schemas redaction seam), so the owner's `:params-schema`
-                ;; marks govern the error payload as they govern wire egress.
-                redacted (classification/redact-invalid-params-error
-                           params (when explain (explain schema params)) spec)]
-            (throw (registration-error
-                     :rf.error/resource-invalid-params
-                     where
-                     (str "resource " resource-id " params do not conform to "
-                          ":params-schema. Per Spec 016 §Resource identity.")
-                     {:resource-id resource-id
-                      :params      (:params redacted)
-                      :error       (:error redacted)}))))))
-    (state/canonicalize params)))
+  (params/validate+canonicalize
+    resource-id spec params where
+    (fn [redacted-params redacted-error]
+      (registration-error
+        :rf.error/resource-invalid-params
+        where
+        (str "resource " resource-id " params do not conform to "
+             ":params-schema. Per Spec 016 §Resource identity.")
+        {:resource-id resource-id
+         :params      redacted-params
+         :error       redacted-error}))))
 
 ;; ---- scope resolution (Spec 016 §Scope resolution) ------------------------
 ;;

--- a/implementation/resources/src/re_frame/resources/ssr.cljc
+++ b/implementation/resources/src/re_frame/resources/ssr.cljc
@@ -105,21 +105,13 @@
 ;;
 ;; Freshness is computed from the entry's DURABLE absolute timestamps
 ;; (`:stale-at` / `:invalidated-at`) against a supplied clock — never from
-;; trusting a timer fired on time (Spec 016 §Stale and GC scheduling). The
-;; SAME derivation the subs layer uses, lifted here so the server projection
-;; metadata and the client refetch decision agree.
-
-(defn entry-stale?
-  "True iff `entry` is stale against `clock-ms`: it has been explicitly
-  invalidated (`:invalidated-at` set) OR its `:stale-after-ms` window has
-  elapsed (`:stale-at` set and `clock-ms >= :stale-at`). Freshness is
-  ORTHOGONAL to load status (a `:loaded` entry may be stale). Per Spec 016
-  §Status semantics."
-  [entry clock-ms]
-  (boolean
-    (and entry
-         (or (some? (:invalidated-at entry))
-             (when-let [sa (:stale-at entry)] (>= clock-ms sa))))))
+;; trusting a timer fired on time (Spec 016 §Stale and GC scheduling). SSR
+;; reads the CANONICAL `state/entry-stale?` (which explicitly owns the
+;; staleness derivation for the subs projection, the SSR projection, AND the
+;; stale-timer re-check) so the server projection metadata and the client
+;; refetch decision agree with the subs layer — there is no SSR-private copy
+;; to drift (rf2-dv4uj1). SSR keeps only its own policy EXPLANATION of what a
+;; stale entry means for projection / hydration near each call site below.
 
 ;; ---- per-entry sensitivity / size classification (Spec 016 clause 4) ------
 ;;
@@ -344,7 +336,7 @@
         ;;     `:serialize` key rides verbatim and its per-slot params are
         ;;     registry-projected below.
         [projected-key disposition _spec] (disposition+project-key scoped-key frame-id)
-        stale?      (entry-stale? entry clock-ms)
+        stale?      (state/entry-stale? entry clock-ms)
         ;; metadata-only entries refetch on the client if a live route owner
         ;; needs them; serialized stale entries also refetch (background);
         ;; serialized fresh entries do NOT (no double-fetch).
@@ -1581,7 +1573,7 @@
   (let [usable? (hydrated-data-usable? entry)]
     (cond
       (not usable?)                true            ;; metadata-only / redacted / error
-      (entry-stale? entry clock-ms) true           ;; stale-while-revalidate
+      (state/entry-stale? entry clock-ms) true           ;; stale-while-revalidate
       :else                         false)))       ;; fresh + usable data → no dup-fetch
 
 (defn hydrate-refetch-plan
@@ -1629,7 +1621,7 @@
                                                  ;; large-omission one (rf2-fopuj9).
                                                  (= privacy/redacted-sentinel (:data entry)) :metadata-only
                                                  (nil? (:data entry))         :no-data
-                                                 (entry-stale? entry clock-ms) :stale
+                                                 (state/entry-stale? entry clock-ms) :stale
                                                  :else                         :metadata-only)})))
                        entries)]
      (doseq [{:keys [resource-id reason] resource-key :resource/key} plan]


### PR DESCRIPTION
Two clustered resource-artefact dedup refactors, isolated to `implementation/resources/src` + no public API. Pre-alpha stance: no back-compat shims, one internal leaf each, ELEGANCE + CLARITY + CORRECTNESS + GOOD-PRACTICE.

## rf2-7rbb7t — one owner for the params validate+canonicalize pipeline

The resource and mutation registrars each carried a near-identical `validate+canonicalize-params`: default an omitted slot, reject a non-EDN / host value at the cache-key boundary, resolve the pluggable late-bound Malli validator/explainer, REDACT the invalid params before they can ride an error payload, throw the family `:rf.error/*-invalid-params`, then canonicalize.

- New leaf `re-frame.resources.params` owns the pipeline once, parameterized only by a family error-descriptor callback `(fn [redacted-params redacted-error] -> ex-info)`.
- `registry`/`mutation-registry` keep **thin** `validate+canonicalize-params` wrappers — call sites and thrown error shapes unchanged (`:rf.error/resource-invalid-params` + `:resource-id`; `:rf.error/mutation-invalid-params` + `:mutation-id`).
- Leaf requires only `state` / `classification` / `late-bind` (all already required by both registrars): **no static `schemas` dependency, no cycle, and `mutation-registry` gains no dependency on `registry`.** The now-unused `late-bind` require is dropped from both registrars.
- The `classification/redact-invalid-params-error` **privacy step is preserved exactly** (invalid values redacted before egress).

## rf2-dv4uj1 — route SSR freshness through the canonical `state/entry-stale?`

`ssr.cljc` carried a byte-equivalent private `entry-stale?` alongside the canonical `state/entry-stale?`, which explicitly owns the derivation for subs / SSR / stale-timer rechecks.

- Deleted `ssr/entry-stale?`; routed its **three** call sites — SSR projection metadata (`project-entry`), hydration refetch planning (`entry-needs-refetch?`), refetch reason classification (`hydrate-refetch-plan`) — through `state/entry-stale?`. `ssr.cljc` already requires `state`, so no new edge/cycle. The freshness section comment is retained as SSR-specific policy explanation pointing at the canonical owner.

## Preflight confirmations (batch caution — sibling beads had false premises)

- **7rbb7t**: confirmed both pipelines are near-identical; the ONLY difference is the family error descriptor (error id + message + `:resource-id`/`:mutation-id` slot). The nil/omitted policy is *identical* (both `state/default-omitted-params`, explicit `nil` passes through). No hidden behavioural difference.
- **dv4uj1**: confirmed `ssr/entry-stale?` was byte-equivalent to `state/entry-stale?`; the public defn had no external callers (grep across `implementation` + tests). No behavioural difference to preserve.

## Quality gates (foreground)

- `implementation/resources` JVM (`clojure -M:test`): **622 tests, 6217 assertions, 0 failures, 0 errors**
- node CLJS (`npm run test:cljs`): **8464 tests, 39101 assertions, 0 failures, 0 errors**

Error shapes + redaction behaviour verified unchanged (resource param validation, mutation, SSR freshness/hydration paths all green on both hosts).
