### PR TITLE
refactor(flows): drop stale reset-last-inputs! hook + migrate JVM suites to the standard fixture (rf2-ewk0z0, rf2-l25p48)

### DIFF
--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -257,9 +257,6 @@
     :producer-ns 're-frame.flows
     :design-bead "rf2-u0zz5"
     :description "Run the frame's flows over the pending frame-state, returning the flow-augmented APP-DB. Called `[frame db]` (app-db only) or `[frame db runtime-db]` (both pending partitions — EP-0001 §535-551, rf2-4eisfr). Bare `:inputs` resolve against app-db; `[:rf.db/runtime …]` inputs resolve against runtime-db (any flow may read runtime-db; only writes are reserved). Invoked by the router's outermost flows-after-interceptor to transform the handler's pending `:db` effect (after the rest of the `:after` chain, before the `:db` install)."}
-   {:key         :flows/reset-last-inputs!
-    :producer-ns 're-frame.flows
-    :description "Reset memoised last-input snapshots (test isolation)."}
    {:key         :flows/snapshot-last-inputs
     :producer-ns 're-frame.flows
     :design-bead "rf2-4wqu6"

--- a/implementation/core/src/re_frame/test_support.cljc
+++ b/implementation/core/src/re_frame/test_support.cljc
@@ -247,9 +247,10 @@
 
   Per-row rationale:
 
-    :flows/reset-flows!              — drop the per-frame flow registry.
-    :flows/reset-last-inputs!        — drop the dirty-check last-inputs
-                                       map paired with the flow registry.
+    :flows/reset-flows!              — drop ALL per-frame flow state: the
+                                       flow registry, the paired dirty-check
+                                       last-inputs containers, and the pending
+                                       abandoned-output-paths containers.
     :schemas/clear-by-frame!         — clear per-frame schema registrations.
                                        Paired with `:schemas/snapshot-by-frame`
                                        + `:schemas/restore-by-frame!` for
@@ -342,7 +343,6 @@
 
   Adding a new artefact's reset becomes a one-row addition here."
   [{:hook :flows/reset-flows!              :phase :pre-dispose}
-   {:hook :flows/reset-last-inputs!        :phase :pre-dispose}
    {:hook :schemas/clear-by-frame!         :phase :pre-dispose}
    {:hook :machines/reset-timers!          :phase :post-dispose}
    {:hook :fx/reset-dispatch-later-timers! :phase :post-dispose}

--- a/implementation/core/test/re_frame/test_support_test.clj
+++ b/implementation/core/test/re_frame/test_support_test.clj
@@ -221,7 +221,6 @@
   refactor that drops EITHER call site (or unifies them into one) is
   surfaced as a regression."
   {:flows/reset-flows!              2  ;; pre + finally (symmetry)
-   :flows/reset-last-inputs!        1
    :schemas/clear-by-frame!         1
    :machines/reset-timers!          1
    :routing/reset-counters!         1

--- a/implementation/flows/src/re_frame/flows.cljc
+++ b/implementation/flows/src/re_frame/flows.cljc
@@ -642,7 +642,6 @@
 (late-bind/set-fn! :flows/reg-flow           reg-flow)
 (late-bind/set-fn! :flows/clear-flow         clear-flow)
 (late-bind/set-fn! :flows/run-flows-on-db    run-flows-on-db)
-(late-bind/set-fn! :flows/reset-last-inputs! reset-last-inputs!)
 (late-bind/set-fn! :flows/reset-flows!       reset-flows!)
 ;; The dirty-check-rollback pair the router uses to keep this frame's
 ;; `last-inputs` bookkeeping aligned with the DURABLE app-db across a

--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -1559,12 +1559,18 @@
 (defn reset-last-inputs!
   "Test-only: clear ALL per-frame dirty-check `last-inputs` containers
   (drops the whole `frame-last-inputs` registry, discarding every frame's
-  inner atom). The flows reset-runtime fixture uses this to drop stale
-  per-flow state between tests so re-registration does not silently no-op
-  when new-inputs =-equal a stale entry from a sibling test. Published
-  through the late-bind hook table so `re-frame.test-support`'s
-  reset-runtime fixture can call it without statically requiring
-  `re-frame.flows`."
+  inner atom) WITHOUT touching the flow registrations or the pending
+  abandoned-output-paths. A TARGETED helper for a test that wants to force
+  the next drain to recompute every flow (so re-registration does not
+  silently no-op when new-inputs =-equal a stale entry) while keeping the
+  flows registered. Re-exported on the `re-frame.flows` facade for
+  direct in-artefact / cross-artefact test use.
+
+  This is NOT part of the standard reset-runtime fixture: that fixture
+  clears the SAME containers (and more) via `reset-flows!` through the
+  `:flows/reset-flows!` late-bind hook, which drops the registry,
+  last-inputs, AND abandoned-output-paths in lockstep. `reset-last-inputs!`
+  is the narrower, registrations-preserving cousin for targeted tests."
   []
   (reset! frame-last-inputs {})
   nil)

--- a/implementation/flows/test/re_frame/flow_algebra_view_test.clj
+++ b/implementation/flows/test/re_frame/flow_algebra_view_test.clj
@@ -24,33 +24,20 @@
   `re-frame.core/flow-algebra-view` public facade export."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
             [re-frame.flows.tooling :as flows-tooling]
             [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
             [re-frame.trace]))
 
-;; Mirrors the flows_test.clj fixture so each deftest starts from a clean
-;; registrar / frames / flows state, with a :rf/default frame established
-;; and `*current-frame*` pinned so the ambient `reg-flow` calls in the
-;; bodies below carry a scope stamp (EP-0002 — reg-flow is context-required
-;; frame-local).
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (flows/reset-last-inputs!)
-  (schemas/clear-schemas-by-frame!)
-  (rf/init! plain-atom/adapter)
-  (require 're-frame.routing :reload)
-  (require 're-frame.ssr :reload)
-  (frame/ensure-default-frame!)
-  (binding [frame/*current-frame* :rf/default]
-    (test-fn)))
+;; The standard runtime reset (registrar baseline + frames + flows/schemas +
+;; plain-atom adapter) is owned by `make-reset-runtime-fixture`, with a
+;; `:rf/default` frame established and bound as the ambient scope so the
+;; ambient `reg-flow` calls in the bodies below carry a scope stamp
+;; (EP-0002 — reg-flow is context-required frame-local).
 
-(use-fixtures :each reset-runtime)
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; The five fixed classifications EVERY flow algebra node carries
 ;; (Derivations §Worked equivalence — the flow column: the canonical

--- a/implementation/flows/test/re_frame/flows_concurrency_stress_test.clj
+++ b/implementation/flows/test/re_frame/flows_concurrency_stress_test.clj
@@ -90,41 +90,22 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.flows :as flows]
-            [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
-            [re-frame.schemas :as schemas]
             [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace :as trace])
+            [re-frame.test-support :as test-support])
   (:import [java.util.concurrent CountDownLatch]
            [java.util.concurrent.atomic AtomicLong]))
 
 ;; ---- per-test reset -------------------------------------------------------
 ;;
-;; Mirrors the `flows_test.clj` fixture so each deftest starts from a
-;; clean registrar / frames / flows / schemas / trace-cbs / last-inputs
-;; state. The flows ns keeps a private `last-inputs` atom for
-;; dirty-checking (per Spec 013 §Dirty-check semantics); we reset it
-;; via `flows/reset-flows!` (which clears BOTH `flows` and
-;; `last-inputs` in lockstep) so cross-test state cannot leak in either
-;; direction.
+;; The standard runtime reset is owned by `make-reset-runtime-fixture`. It
+;; clears BOTH the flow registry AND the paired `last-inputs` containers in
+;; lockstep through the `:flows/reset-flows!` hook (per Spec 013 §Dirty-check
+;; semantics), so cross-test state cannot leak in either direction, and binds
+;; `:rf/default` as the ambient scope (EP-0002) for the bodies below.
 
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (schemas/clear-schemas-by-frame!)
-  (trace/clear-listeners!)
-  (rf/init! plain-atom/adapter)
-  (require 're-frame.routing :reload)
-  (require 're-frame.ssr :reload)
-  ;; EP-0002: reg-flow is context-required frame-local — an ambient call
-  ;; under no scope raises :rf.error/no-frame-context. Pin :rf/default (an
-  ;; ordinary frame) as the established scope for the body.
-  (frame/ensure-default-frame!)
-  (binding [frame/*current-frame* :rf/default]
-    (test-fn)))
-
-(use-fixtures :each reset-runtime)
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; Per-thread iteration count. The standard 5000 keeps CI under ~60s
 ;; wall-clock with the default thread count. Operators dial up via the

--- a/implementation/flows/test/re_frame/flows_conformance_test.clj
+++ b/implementation/flows/test/re_frame/flows_conformance_test.clj
@@ -109,50 +109,45 @@
             [re-frame.flows :as flows]
             [re-frame.flows.topo :as topo]
             [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.schemas :as schemas]
             [re-frame.subs :as subs]
             [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
             [re-frame.trace :as trace]))
 
 ;; ---- runtime reset --------------------------------------------------------
 ;;
-;; Mirrors `re-frame.flows-test/reset-runtime` (and the sibling
-;; `flows_trace_test`'s reset). Each fixture in the corpus runs against a
-;; clean registrar / frame table / flow registry / last-inputs slot.
+;; The standard per-process runtime reset (registrar baseline + frames +
+;; flows/schemas + plain-atom adapter) is owned by
+;; `make-reset-runtime-fixture`. Two fixture-specific choices:
+;;
+;;   - `:ambient-frame nil` — the corpus's `run-fixture` calls `reg-frame`
+;;     itself and needs NO in-flight ambient scope so a frame's
+;;     `:initial-events` cascade fires SYNCHRONOUSLY (Spec 002 §reg-frame
+;;     from inside a handler async-queues initial-events when
+;;     `*current-frame*` is bound — EP-0002). The adapter install still
+;;     ensures `:rf/default`; `run-fixture` pins the scope itself, after
+;;     `reg-frame`, around `realise-flows!` + the dispatch loop.
+;;   - a small concern-specific fixture clears the always-on error-emit
+;;     listener registry before each test (the standard reset clears trace
+;;     and event listeners but not the error substrate), so an
+;;     `:error-emit-records` matcher listener a prior fixture registered
+;;     cannot leak into the next.
 
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (schemas/clear-schemas-by-frame!)
-  (flows/reset-last-inputs!)
-  ;; The error-emit listener registry is a `defonce` atom that survives test
-  ;; re-runs. Clear before each test so a listener registered by one fixture
-  ;; (the `:error-emit-records` matcher) doesn't leak into the next.
-  (error-emit/clear-error-listeners!)
-  (rf/init! plain-atom/adapter)
-  ;; Framework events / fx are registered at namespace-load time in
-  ;; routing.cljc / ssr.cljc; clear-all! wiped them. Re-eval those
-  ;; registrations so :rf.fx/reg-flow / :rf.fx/clear-flow (registered
-  ;; via late-bind from flows.cljc's ns-load body) and any cross-artefact
-  ;; framework events resolve.
-  (require 're-frame.routing :reload)
-  (require 're-frame.ssr :reload)
-  (require 're-frame.flows :reload)
-  ;; EP-0002: the conformance corpus registers flows and dispatches ambiently
-  ;; against :rf/default; reg-flow + dispatch are context-required (no
-  ;; :rf/default floor). Register :rf/default as an
-  ;; ordinary frame here so the scope is available — but do NOT pin
-  ;; `*current-frame*` around the whole body: `run-fixture`'s `reg-frame`
-  ;; must run with no in-flight scope so its `:initial-events` cascade fires
-  ;; SYNCHRONOUSLY (frame/reg-frame async-queues initial-events when
-  ;; `*current-frame*` is bound — Spec 002 §reg-frame from inside a
-  ;; handler). `run-fixture` pins the scope itself, after `reg-frame`,
-  ;; around `realise-flows!` + the dispatch loop.
-  (frame/ensure-default-frame!)
-  (test-fn))
+;; The composed per-fixture reset: the standard reset fixture (registrar
+;; baseline + frames + flows/schemas + plain-atom adapter; `:ambient-frame
+;; nil` per the rationale above) wrapping the always-on error-listener clear.
+;; Bound as the `:each` fixture AND called directly by
+;; `run-flows-conformance-corpus` to reset between the fixtures it iterates
+;; inside a single deftest.
+(def ^:private reset-runtime
+  (let [standard (test-support/make-reset-runtime-fixture
+                   {:adapter       plain-atom/adapter
+                    :ambient-frame nil})]
+    (fn [test-fn]
+      (standard (fn []
+                  (error-emit/clear-error-listeners!)
+                  (test-fn))))))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/flows/test/re_frame/flows_destroy_frame_teardown_test.clj
+++ b/implementation/flows/test/re_frame/flows_destroy_frame_teardown_test.clj
@@ -27,28 +27,18 @@
             [re-frame.frame :as frame]
             [re-frame.late-bind :as late-bind]
             [re-frame.registrar :as registrar]
-            [re-frame.schemas :as schemas]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
 
 ;; ---- per-test reset ------------------------------------------------------
+;;
+;; The standard runtime reset (registrar baseline + frames + flows/schemas +
+;; plain-atom adapter + ambient `:rf/default` scope) is owned by
+;; `make-reset-runtime-fixture`; EP-0002 — `:rf/default` is bound so the
+;; ambient `reg-flow` calls in the bodies below carry a frame stamp.
 
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (flows/reset-last-inputs!)
-  (schemas/clear-schemas-by-frame!)
-  (rf/init! plain-atom/adapter)
-  (require 're-frame.routing :reload)
-  (require 're-frame.ssr :reload)
-  ;; EP-0002: reg-flow is context-required frame-local — an ambient call
-  ;; under no scope raises :rf.error/no-frame-context. Pin :rf/default (an
-  ;; ordinary frame) as the established scope for the body.
-  (frame/ensure-default-frame!)
-  (binding [frame/*current-frame* :rf/default]
-    (test-fn)))
-
-(use-fixtures :each reset-runtime)
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; ---- hook publication ----------------------------------------------------
 

--- a/implementation/flows/test/re_frame/flows_lifecycle_drain_race_test.clj
+++ b/implementation/flows/test/re_frame/flows_lifecycle_drain_race_test.clj
@@ -48,32 +48,20 @@
             [re-frame.core :as rf]
             [re-frame.flows :as flows]
             [re-frame.flows.registry :as registry]
-            [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
-            [re-frame.schemas :as schemas]
             [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace :as trace])
+            [re-frame.test-support :as test-support])
   (:import [java.util.concurrent CountDownLatch TimeUnit]))
 
-;; ---- per-test reset (mirrors flows_concurrency_stress_test.clj) -----------
+;; ---- per-test reset -------------------------------------------------------
+;;
+;; The standard runtime reset (registrar baseline + frames + flows/schemas +
+;; plain-atom adapter + ambient `:rf/default` scope) is owned by
+;; `make-reset-runtime-fixture`; EP-0002 — `:rf/default` is bound so the
+;; ambient `reg-flow` calls in the bodies below carry a frame stamp.
 
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (schemas/clear-schemas-by-frame!)
-  (trace/clear-listeners!)
-  (rf/init! plain-atom/adapter)
-  (require 're-frame.routing :reload)
-  (require 're-frame.ssr :reload)
-  ;; EP-0002: reg-flow is context-required frame-local — an ambient call
-  ;; under no scope raises :rf.error/no-frame-context. Pin :rf/default (an
-  ;; ordinary frame) as the established scope for the body.
-  (frame/ensure-default-frame!)
-  (binding [frame/*current-frame* :rf/default]
-    (test-fn)))
-
-(use-fixtures :each reset-runtime)
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 (defn- await! [^CountDownLatch latch where]
   (is (.await latch 30 TimeUnit/SECONDS)

--- a/implementation/flows/test/re_frame/flows_path_overlap_test.clj
+++ b/implementation/flows/test/re_frame/flows_path_overlap_test.clj
@@ -30,31 +30,18 @@
             [re-frame.core :as rf]
             [re-frame.flows :as flows]
             [re-frame.flows.topo :as topo]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.schemas :as schemas]
             [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace :as trace]))
+            [re-frame.test-support :as test-support]))
 
-;; ---- per-test reset (mirrors flows_test.clj) ------------------------------
+;; ---- per-test reset -------------------------------------------------------
+;;
+;; The standard runtime reset (registrar baseline + frames + flows/schemas +
+;; plain-atom adapter + ambient `:rf/default` scope) is owned by
+;; `make-reset-runtime-fixture`; EP-0002 — `:rf/default` is bound so the
+;; ambient `reg-flow` calls in the bodies below carry a frame stamp.
 
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (schemas/clear-schemas-by-frame!)
-  (trace/clear-listeners!)
-  (rf/init! plain-atom/adapter)
-  (require 're-frame.routing :reload)
-  (require 're-frame.ssr :reload)
-  ;; EP-0002: reg-flow is context-required frame-local — an ambient call
-  ;; under no scope raises :rf.error/no-frame-context. Pin
-  ;; :rf/default (an ordinary frame) as the established scope for the body.
-  (frame/ensure-default-frame!)
-  (binding [frame/*current-frame* :rf/default]
-    (test-fn)))
-
-(use-fixtures :each reset-runtime)
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; ---------------------------------------------------------------------------
 ;; 1. topo/output-paths-overlap? — the prefix-relation predicate

--- a/implementation/flows/test/re_frame/flows_per_frame_last_inputs_test.clj
+++ b/implementation/flows/test/re_frame/flows_per_frame_last_inputs_test.clj
@@ -28,37 +28,23 @@
             [re-frame.core :as rf]
             [re-frame.flows :as flows]
             [re-frame.flows.registry :as registry]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.schemas :as schemas]
             [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
             [re-frame.trace :as trace])
   (:import [java.util.concurrent CountDownLatch]
            [java.util.concurrent.atomic AtomicLong]))
 
 ;; ---- per-test reset -------------------------------------------------------
 ;;
-;; Mirrors the flows_test.clj / flows_concurrency_stress_test.clj fixture so
-;; each deftest starts from a clean registrar / frames / flows / last-inputs
-;; state.
+;; The standard runtime reset (registrar baseline + frames + flows/schemas +
+;; plain-atom adapter + ambient `:rf/default` scope) is owned by
+;; `make-reset-runtime-fixture`; EP-0002 — `:rf/default` is bound so the
+;; ambient `reg-flow` calls in the bodies below carry a frame stamp. The
+;; bodies drive `run-flows-on-db` directly and manage their own trace
+;; listeners (the reset clears every listener first).
 
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (schemas/clear-schemas-by-frame!)
-  (trace/clear-listeners!)
-  (rf/init! plain-atom/adapter)
-  (require 're-frame.routing :reload)
-  (require 're-frame.ssr :reload)
-  ;; EP-0002: reg-flow is context-required frame-local — an
-  ;; ambient call under no scope raises :rf.error/no-frame-context. Pin
-  ;; :rf/default (an ordinary frame) as the established scope for the body.
-  (frame/ensure-default-frame!)
-  (binding [frame/*current-frame* :rf/default]
-    (test-fn)))
-
-(use-fixtures :each reset-runtime)
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; ---------------------------------------------------------------------------
 ;; 1. Deterministic unit-level repro — the rollback must touch ONLY the

--- a/implementation/flows/test/re_frame/flows_reg_flow_toctou_test.clj
+++ b/implementation/flows/test/re_frame/flows_reg_flow_toctou_test.clj
@@ -28,33 +28,20 @@
             [re-frame.core :as rf]
             [re-frame.flows :as flows]
             [re-frame.flows.topo :as topo]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.schemas :as schemas]
             [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace :as trace])
+            [re-frame.test-support :as test-support])
   (:import [java.util.concurrent CyclicBarrier]
            [java.util.concurrent.atomic AtomicLong]))
 
-;; ---- per-test reset (mirrors flows_concurrency_stress_test.clj) -----------
+;; ---- per-test reset -------------------------------------------------------
+;;
+;; The standard runtime reset (registrar baseline + frames + flows/schemas +
+;; plain-atom adapter + ambient `:rf/default` scope) is owned by
+;; `make-reset-runtime-fixture`; EP-0002 — `:rf/default` is bound so the
+;; ambient `reg-flow` calls in the bodies below carry a frame stamp.
 
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (schemas/clear-schemas-by-frame!)
-  (trace/clear-listeners!)
-  (rf/init! plain-atom/adapter)
-  (require 're-frame.routing :reload)
-  (require 're-frame.ssr :reload)
-  ;; EP-0002: reg-flow is context-required frame-local — an ambient call
-  ;; under no scope raises :rf.error/no-frame-context. Pin :rf/default (an
-  ;; ordinary frame) as the established scope for the body.
-  (frame/ensure-default-frame!)
-  (binding [frame/*current-frame* :rf/default]
-    (test-fn)))
-
-(use-fixtures :each reset-runtime)
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; Round count. Each round opens a fresh interleaving window on the
 ;; shared frame; the race needs only ONE round where both threads read

--- a/implementation/flows/test/re_frame/flows_rollback_dirty_check_test.clj
+++ b/implementation/flows/test/re_frame/flows_rollback_dirty_check_test.clj
@@ -28,39 +28,31 @@
   rollback path without pulling Malli onto the classpath."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.error-emit :as error-emit]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
             [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace :as trace]))
+            [re-frame.test-support :as test-support]))
 
-;; ---- per-test reset -------------------------------------------------------
+;; ---- per-test reset / schema-validator seam ------------------------------
+;;
+;; The standard runtime reset (registrar baseline + frames + flows/schemas +
+;; plain-atom adapter + ambient `:rf/default` scope) is owned by
+;; `make-reset-runtime-fixture`. Layered AROUND it, a concern-specific
+;; fixture resets the pluggable schema-validator seam (which the standard
+;; reset does not touch) before and after each test so the validator this
+;; suite installs cannot leak into a sibling suite.
 
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (schemas/clear-schemas-by-frame!)
+(defn- with-schema-validator-reset
+  [test-fn]
   (schemas/reset-schema-validator!)
-  (flows/reset-last-inputs!)
-  (error-emit/clear-error-listeners!)
-  (trace/clear-listeners!)
-  (rf/init! plain-atom/adapter)
-  (require 're-frame.routing :reload)
-  (require 're-frame.ssr :reload)
-  ;; EP-0002: reg-flow / reg-app-schema are context-required frame-local — an
-  ;; ambient call under no scope raises :rf.error/no-frame-context. Pin
-  ;; :rf/default (an ordinary frame) as the established scope for the body.
-  (frame/ensure-default-frame!)
   (try
-    (binding [frame/*current-frame* :rf/default]
-      (test-fn))
+    (test-fn)
     (finally
       (schemas/reset-schema-validator!))))
 
-(use-fixtures :each reset-runtime)
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  with-schema-validator-reset)
 
 ;; A pluggable predicate validator: a registered "schema" here is a 1-arg
 ;; predicate fn applied to the slice at its registered path. This exercises

--- a/implementation/flows/test/re_frame/flows_runtime_partition_input_test.clj
+++ b/implementation/flows/test/re_frame/flows_runtime_partition_input_test.clj
@@ -40,33 +40,27 @@
             [re-frame.elision :as elision]
             [re-frame.flows :as flows]
             [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.schemas :as schemas]
             [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
             [re-frame.trace :as trace]))
 
 ;; ---- per-test reset / trace recorder -------------------------------------
 ;;
-;; Mirrors `flows_trace_test.clj`'s fixture: clean registrar / frames / flows /
-;; last-inputs, a live plain-atom substrate, and a flow-only trace recorder.
+;; The standard runtime reset (registrar baseline + frames + flows/schemas +
+;; plain-atom adapter + ambient `:rf/default` scope) is owned by
+;; `make-reset-runtime-fixture`. Layered AROUND it, a small concern-specific
+;; fixture installs a flow-op-type trace recorder for the body to assert
+;; against — the standard reset already cleared every trace listener, so the
+;; recorder starts clean and is torn down in its own `finally`.
 
 (def ^:dynamic ^:private *captured* nil)
 
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (flows/reset-last-inputs!)
-  (schemas/clear-schemas-by-frame!)
-  (trace/clear-listeners!)
-  (rf/init! plain-atom/adapter)
-  ;; EP-0002: reg-flow is context-required frame-local — an ambient call under
-  ;; no scope raises :rf.error/no-frame-context. Pin :rf/default (an ordinary
-  ;; frame) as the established scope for the body.
-  (frame/ensure-default-frame!)
+(defn- with-flow-trace-recorder
+  "Bind `*captured*` and record every `:flow`-op-type trace event for the
+  duration of one test; unregister the recorder afterwards."
+  [test-fn]
   (let [captured (atom [])]
-    (binding [*captured*            captured
-              frame/*current-frame* :rf/default]
+    (binding [*captured* captured]
       (trace/register-listener!
         ::flow-trace-recorder
         (fn [ev]
@@ -77,7 +71,9 @@
         (finally
           (trace/unregister-listener! ::flow-trace-recorder))))))
 
-(use-fixtures :each reset-runtime)
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  with-flow-trace-recorder)
 
 (defn- by-op
   "Captured flow-trace events with `:operation` = `op`, in capture order."

--- a/implementation/flows/test/re_frame/flows_schema_validation_test.clj
+++ b/implementation/flows/test/re_frame/flows_schema_validation_test.clj
@@ -27,37 +27,36 @@
       silent (the whole surface DCEs in prod CLJS)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.error-emit :as error-emit]
-            [re-frame.frame :as frame]
             [re-frame.interop :as interop]
-            [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
-            [re-frame.flows :as flows]
+            ;; Loading `re-frame.flows` wires the flow late-bind hooks the
+            ;; `rf/reg-flow` bodies below drive (the flow-output validation
+            ;; path this suite pins).
+            [re-frame.flows]
             [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
             [re-frame.trace :as trace]))
 
-;; ---- per-test reset / error-trace recorder -------------------------------
+;; ---- per-test reset / schema-violation recorder --------------------------
+;;
+;; The standard runtime reset (registrar baseline + frames + flows/schemas +
+;; plain-atom adapter + ambient `:rf/default` scope) is owned by
+;; `make-reset-runtime-fixture`. Layered AROUND it, a concern-specific
+;; fixture resets the pluggable schema-validator seam (which the standard
+;; reset does not touch) and records `:rf.error/schema-validation-failure`
+;; traces for the body to assert against.
 
 (def ^:dynamic ^:private *captured* nil)
 
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (schemas/clear-schemas-by-frame!)
+(defn- with-schema-violation-recorder
+  "Reset the pluggable schema validator, bind `*captured*`, and record every
+  schema-validation-failure trace for the duration of one test; unregister
+  the recorder and reset the validator again afterwards so no validator
+  leaks into a sibling suite."
+  [test-fn]
   (schemas/reset-schema-validator!)
-  (flows/reset-last-inputs!)
-  (error-emit/clear-error-listeners!)
-  (rf/init! plain-atom/adapter)
-  (require 're-frame.routing :reload)
-  (require 're-frame.ssr :reload)
-  ;; EP-0002: reg-flow / reg-app-schema are context-required frame-local — an
-  ;; ambient call under no scope raises :rf.error/no-frame-context. Pin
-  ;; :rf/default (an ordinary frame) as the established scope for the body.
-  (frame/ensure-default-frame!)
   (let [captured (atom [])]
-    (binding [*captured*           captured
-              frame/*current-frame* :rf/default]
+    (binding [*captured* captured]
       (trace/register-listener!
         ::schema-violation-recorder
         (fn [ev]
@@ -69,7 +68,9 @@
           (trace/unregister-listener! ::schema-violation-recorder)
           (schemas/reset-schema-validator!))))))
 
-(use-fixtures :each reset-runtime)
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  with-schema-violation-recorder)
 
 ;; A trivial pluggable validator: a schema here is a 1-arg predicate fn.
 ;; This exercises the `:schemas/validate-with-registered-fn` seam without

--- a/implementation/flows/test/re_frame/flows_t2_trace_test.clj
+++ b/implementation/flows/test/re_frame/flows_t2_trace_test.clj
@@ -24,31 +24,21 @@
   boundary collapses repeated subtrees on egress."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.error-emit :as error-emit]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.schemas :as schemas]
-            [re-frame.flows :as flows]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            ;; Loading `re-frame.flows` wires the `:flows/run-flows-on-db`
+            ;; late-bind hook this test exercises (the post-flow t2 path);
+            ;; the tests register flows via the `rf/reg-flow` facade.
+            [re-frame.flows]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
 
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (schemas/clear-schemas-by-frame!)
-  (flows/reset-last-inputs!)
-  (error-emit/clear-error-listeners!)
-  (rf/init! plain-atom/adapter)
-  (require 're-frame.routing :reload)
-  (require 're-frame.ssr :reload)
-  ;; EP-0002: reg-flow is context-required frame-local — an ambient call
-  ;; under no scope raises :rf.error/no-frame-context. Pin :rf/default (an
-  ;; ordinary frame) as the established scope for the body.
-  (frame/ensure-default-frame!)
-  (binding [frame/*current-frame* :rf/default]
-    (test-fn)))
+;; The standard runtime reset (registrar baseline + frames + flows/schemas +
+;; plain-atom adapter + ambient `:rf/default` scope) is owned by
+;; `make-reset-runtime-fixture`; EP-0002 — `:rf/default` is bound so the
+;; ambient `reg-flow` / `dispatch-sync` calls in the bodies below carry a
+;; frame stamp.
 
-(use-fixtures :each reset-runtime)
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 (defn- collect-traces!
   [id]

--- a/implementation/flows/test/re_frame/flows_test.clj
+++ b/implementation/flows/test/re_frame/flows_test.clj
@@ -27,44 +27,25 @@
             [re-frame.flows :as flows]
             [re-frame.flows.registry :as registry]
             [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
             [re-frame.trace]))
 
 ;; ---- per-test reset -------------------------------------------------------
 ;;
-;; Mirrors the smoke_test.clj fixture so each deftest starts from a clean
-;; registrar / frames / flows state. Re-loading routing / ssr restores the
-;; framework events that clear-all! wiped (some smoke tests rely on
-;; :rf.route/navigate etc. resolving — keep the reset shape consistent so
-;; running these tests in any order works).
+;; The standard per-process runtime reset is owned by
+;; `re-frame.test-support/make-reset-runtime-fixture`: it folds the ns-load
+;; registrar baseline back over the live registrar (run-order independence),
+;; resets `frame/frames`, drops ALL flow state through the
+;; `:flows/reset-flows!` hook (registry + last-inputs +
+;; abandoned-output-paths, so a stale dirty-check entry from a sibling test
+;; can't make a re-registration silently no-op), clears the schemas
+;; per-frame side-table, (re)installs the plain-atom adapter + ensures
+;; `:rf/default`, and binds `:rf/default` as the carried-invariant ambient
+;; scope so the ambient `reg-flow` / `dispatch-sync` calls in the bodies
+;; below carry a frame stamp (EP-0002).
 
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (schemas/clear-schemas-by-frame!)
-  ;; flows.cljc keeps a private last-inputs atom for dirty-checking
-  ;; (per Spec 013 §Dirty-check semantics). The smoke-test fixture
-  ;; doesn't reset it; left alone, an entry from this namespace's tests
-  ;; can leak into a sibling namespace's identically-keyed flow and
-  ;; cause its first-evaluation to no-op (new-inputs would =-equal the
-  ;; stale last-inputs). Clear it here so cross-namespace test order
-  ;; can't introduce hidden flakiness.
-  (flows/reset-last-inputs!)
-  (rf/init! plain-atom/adapter)
-  (require 're-frame.routing :reload)
-  (require 're-frame.ssr :reload)
-  ;; EP-0002: `reg-flow` / `clear-flow` are context-required frame-local — an
-  ;; ambient call under NO established scope raises `:rf.error/no-frame-context`
-  ;; (there is no `:rf/default` floor; `init!` does not create `:rf/default`).
-  ;; Register it as an ordinary frame and pin `*current-frame*` so the ambient
-  ;; `reg-flow` / `dispatch-sync` calls in the bodies below carry a scope
-  ;; stamp. Fixture-level equivalent of wrapping each body in
-  ;; `(rf/with-frame :rf/default …)`.
-  (frame/ensure-default-frame!)
-  (binding [frame/*current-frame* :rf/default]
-    (test-fn)))
-
-(use-fixtures :each reset-runtime)
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; ---------------------------------------------------------------------------
 ;; 1. reg-flow / clear-flow lifecycle (registry side)

--- a/implementation/flows/test/re_frame/flows_trace_test.clj
+++ b/implementation/flows/test/re_frame/flows_trace_test.clj
@@ -13,39 +13,30 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.elision :as elision]
-            [re-frame.error-emit :as error-emit]
             [re-frame.frame :as frame]
             [re-frame.privacy :as privacy]
-            [re-frame.registrar :as registrar]
-            [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
             [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
             [re-frame.trace :as trace]))
 
 ;; ---- per-test reset / trace recorder -------------------------------------
+;;
+;; The standard runtime reset (registrar baseline + frames + flows/schemas +
+;; plain-atom adapter + ambient `:rf/default` scope) is owned by
+;; `make-reset-runtime-fixture`. Layered AROUND it, a small concern-specific
+;; fixture installs a flow-op-type trace recorder for the body to assert
+;; against — the standard reset already cleared every trace listener, so the
+;; recorder starts clean and is torn down in its own `finally`.
 
 (def ^:dynamic ^:private *captured* nil)
 
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (schemas/clear-schemas-by-frame!)
-  (flows/reset-last-inputs!)
-  ;; The error-emit listener registry is a `defonce` atom that survives test
-  ;; re-runs. Clear before each test so a listener registered by one test
-  ;; doesn't leak into the next.
-  (error-emit/clear-error-listeners!)
-  (rf/init! plain-atom/adapter)
-  (require 're-frame.routing :reload)
-  (require 're-frame.ssr :reload)
-  ;; EP-0002: reg-flow is context-required frame-local — an ambient call
-  ;; under no scope raises :rf.error/no-frame-context. Pin :rf/default (an
-  ;; ordinary frame) as the established scope for the body.
-  (frame/ensure-default-frame!)
+(defn- with-flow-trace-recorder
+  "Bind `*captured*` and record every `:flow`-op-type trace event for the
+  duration of one test; unregister the recorder afterwards."
+  [test-fn]
   (let [captured (atom [])]
-    (binding [*captured*           captured
-              frame/*current-frame* :rf/default]
+    (binding [*captured* captured]
       (trace/register-listener!
         ::flow-trace-recorder
         (fn [ev]
@@ -57,7 +48,9 @@
         (finally
           (trace/unregister-listener! ::flow-trace-recorder))))))
 
-(use-fixtures :each reset-runtime)
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  with-flow-trace-recorder)
 
 (defn- by-op
   "Filter the captured trace events by :operation, returning the matching

--- a/implementation/flows/test/re_frame/late_bind_missing_test.clj
+++ b/implementation/flows/test/re_frame/late_bind_missing_test.clj
@@ -118,21 +118,6 @@
           (is (= {:probe :ok} (rf/app-db-value :rf/default))
               ":db commit lands even though the outermost-`:after` flow walker is a no-op"))))))
 
-(deftest reset-last-inputs!-no-ops-when-flows-artefact-missing
-  (testing "test-support's reset-runtime fixture no-ops when :flows/reset-last-inputs! hook is nil"
-    ;; Consumer is `re-frame.test-support`'s reset-hook-table (row for
-    ;; `:flows/reset-last-inputs!`). The driver `run-reset-hooks!` walks
-    ;; the table and short-circuits rows whose hook is unregistered.
-    ;; With the hook nil, the fixture bracket fires its full cascade
-    ;; (snap/restore registrar, dispose adapter, reinstall, run test-fn)
-    ;; without touching the absent-flows machinery.
-    (with-hook-as-nil :flows/reset-last-inputs!
-      (fn []
-        (let [ran? (atom false)
-              fix  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})]
-          (fix (fn [] (reset! ran? true)))
-          (is @ran? "fixture invoked the test-fn without throwing on the absent hook"))))))
-
 (deftest reset-flows!-no-ops-when-flows-artefact-missing
   (testing "test-support's reset-runtime fixture no-ops when :flows/reset-flows! hook is nil"
     ;; Consumer is `re-frame.test-support`'s reset-hook-table (row for


### PR DESCRIPTION
Two clustered reset-fixture beads: fix the shared contract (rf2-ewk0z0), then adopt it (rf2-l25p48).

## rf2-ewk0z0 — make reset-flows! the sole full flow-state reset hook (commit 1)

`flows/registry.cljc` `reset-flows!` already clears the flow registry, the per-frame `last-inputs` containers, AND the abandoned-output-paths in lockstep — but the core test-support reset-runtime fixture still fired **both** `:flows/reset-flows!` and `:flows/reset-last-inputs!`, double-clearing last-inputs. The second late-bind hook was stale plumbing from before `reset-flows!` was expanded.

Removed the cross-artefact `:flows/reset-last-inputs!` hook only:
- core test-support reset-hook-table row + prose
- flows facade late-bind publication (`flows.cljc`)
- core late-bind directory row (`late_bind/directory.cljc`)
- hook-count expectation (`test_support_test.clj`)
- missing-hook fixture coverage deftest (`late_bind_missing_test.clj`)

**Retained** the direct `reset-last-inputs!` fn, its `re-frame.flows` facade re-export, its API-manifest entries, and every direct caller (it stays the narrower, registrations-preserving cousin for targeted dirty-check tests). Its now-stale "published through the late-bind hook table" docstring claim is corrected. `reset-flows!` behaviour is untouched.

## rf2-l25p48 — migrate flows JVM suites to the standard runtime fixture (commit 2)

Fourteen JVM namespaces under `implementation/flows/test` carried hand-written `reset-runtime` fixtures duplicating (and drifting from) the L3 contract `re-frame.test-support/make-reset-runtime-fixture` already owns. Replaced each with `make-reset-runtime-fixture` + the plain-atom adapter:

- **flows_conformance_test** uses `:ambient-frame nil` so the corpus's own `reg-frame` fires its `:initial-events` synchronously; the composed fixture value is reused as the per-fixture `reset-runtime` callable the corpus loop invokes between fixtures.
- Trace recorders (flows_trace, flows_runtime_partition_input) and the schema-validator seam (flows_schema_validation, flows_rollback_dirty_check) became small concern-specific fixtures composed **around** the standard one.
- The `(require '... :reload)` calls are gone — the standard fixture folds a stable ns-load registrar baseline back each test instead of `clear-all!`, so framework registrations survive without re-eval (which also removed the need for the per-test `error-emit/clear-error-listeners!` the reloads made necessary in the non-conformance suites). Imports used only by the deleted reset bodies were dropped; genuinely-consumed artefacts are required once at namespace load.

No `defn- reset-runtime` remains under `implementation/flows/test`; pure topology suites (flows_topo) stay fixture-free.

## Preflight confirmations

Both bead premises verified before editing:
- **ewk0z0**: `reset-flows!` clears flows + frame-last-inputs + frame-abandoned-output-paths (3 atoms in lockstep); core test-support invoked BOTH `:flows/reset-flows!` and `:flows/reset-last-inputs!` → last-inputs double-clear. Confirmed.
- **l25p48**: 14 JVM namespaces carried hand-written reset-runtime fixtures duplicating `make-reset-runtime-fixture`. Confirmed (exactly 14 `defn- reset-runtime`).

## Quality gates (foreground)

Stance: pre-alpha, no back-compat/shims; ELEGANCE + CLARITY + CORRECTNESS + GOOD-PRACTICE.

- `implementation/flows` `clojure -M:test` — **194 tests / 4787 assertions, 0 failures, 0 errors**
- `implementation/core` `clojure -M:test` (ewk0z0 touches core test_support + hook-count expectations) — **1761 tests / 7663 assertions, 0 failures, 0 errors**
- `implementation` `npm run test:cljs` — **8464 tests / 39101 assertions, 0 failures, 0 errors**
