### PR TITLE
test(routing): extract shared browser-history fixture (rf2-y6e2zb)

### DIFF
--- a/implementation/routing/test/re_frame/routing_browser_test_support.cljs
+++ b/implementation/routing/test/re_frame/routing_browser_test_support.cljs
@@ -1,0 +1,182 @@
+(ns re-frame.routing-browser-test-support
+  "Shared node-runtime browser-history fixture for the routing CLJS test
+  suites (rf2-y6e2zb).
+
+  `routing_history_cljs_test` and `routing_url_strategy_cljs_test` each carried
+  their own copy of this jsdom-style history/location/document stub; this
+  namespace is the single owner of the SUPERSET fixture — the history suite's
+  version, which additionally exposes `go` alongside `back` / `forward`.
+
+  Node has no `window` / `document` globals, so `with-window-stub-fixture`
+  installs a minimal stub on `js/globalThis` and tears it down in `finally`. The
+  stub records `pushState` / `replaceState` onto an in-memory entry stack and
+  exposes `back` / `forward` / `go` so the popstate path can be driven without a
+  real DOM; it splits `location` into pathname / search / hash the way a real
+  browser does so a hash strategy that writes `#/active` and reads
+  `location.hash` round-trips. `*history-state*` holds the current in-memory
+  history state (entry stack + index + listener registry) for direct assertion,
+  and `current-url` reassembles the active URL string. It also mirrors
+  `scrollX` / `scrollY` on `scrollTo` (for `:rf.nav/scroll`) and returns nil
+  from `document.getElementById` (so the fragment branch falls through). The
+  fixture is scoped to the test target; production code is untouched.
+
+  Node-runtime only by design (rf2-6qclsc). This namespace deliberately ends in
+  `-test-support`, NOT `-cljs-test`, so the shadow-cljs `:node-test` discovery
+  regex (`cljs-test$`) never runs it as a test namespace (and the narrowed
+  `:browser-test` `-dom-cljs-test$` regex ignores it too). A real browser's
+  `Window` / `History` cannot be replaced, so the in-memory `*history-state*`
+  atom could not observe real `pushState` calls there anyway; a real-browser
+  harness would be a separate `*_dom_cljs_test.cljs` namespace.
+
+  Per Spec 012 §URL changes are events, §Navigation tokens, §Scroll
+  restoration, §URL strategies.")
+
+;; ---- window / history + location stub ------------------------------------
+;;
+;; jsdom-style minimal history + location mock. Sufficient for routing.cljc's
+;; `:rf.nav/push-url` / `:rf.nav/replace-url` / `:rf.nav/scroll` fx to run
+;; without throwing. The mock keeps the entry stack in *state* so tests can
+;; assert against it directly (no need to read js/window.history.length).
+
+(defn- new-history-stub []
+  (atom {:entries ["/"]     ;; stack of URLs, top = current
+         :index   0         ;; index into :entries for the current URL
+         :listeners {}}))   ;; event-type → vec of listeners
+
+(defn current-url
+  "Reassemble the active URL string from the history `state` atom."
+  [state]
+  (let [{:keys [entries index]} @state]
+    (nth entries index)))
+
+(defn- install-window-stub! []
+  (let [state (new-history-stub)
+        location #js {:origin   "https://app.example"
+                      :href     "https://app.example/"
+                      :pathname "/"
+                      :search   ""
+                      :hash     ""}
+        ;; Keep `location` in sync with the current history entry, the way a
+        ;; real browser updates `window.location` on pushState / back /
+        ;; forward. The automatically-installed popstate handler (rf2-g8pbwg —
+        ;; a `:url-bound? true` frame's lifecycle installs it) reads the new
+        ;; URL off `window.location` (not the test's state atom), so the stub
+        ;; MUST reflect the navigation here for the listener-driven
+        ;; Back/Forward tests (rf2-6qgbs.4). Splits the entry into pathname /
+        ;; search / hash so `current-url` reassembles the same string.
+        sync-location!
+        (fn []
+          (let [{:keys [entries index]} @state
+                url    (nth entries index)
+                [path+ hash]   (let [i (.indexOf url "#")]
+                                 (if (neg? i) [url ""]
+                                     [(subs url 0 i) (subs url i)]))
+                [path search]  (let [i (.indexOf path+ "?")]
+                                 (if (neg? i) [path+ ""]
+                                     [(subs path+ 0 i) (subs path+ i)]))]
+            (set! (.-pathname location) path)
+            (set! (.-search location) search)
+            (set! (.-hash location) hash)
+            (set! (.-href location) (str (.-origin location) url))))
+        ;; The stub history object — exposes the HTML5 History API surface
+        ;; routing.cljc actually calls into.
+        history #js {:pushState
+                     (fn [_state _title url]
+                       ;; Truncate the forward stack (any entries past the
+                       ;; current index get dropped on a fresh push, matching
+                       ;; real browser semantics) then append.
+                       (swap! state
+                              (fn [{:keys [entries index] :as s}]
+                                (let [kept (subvec entries 0 (inc index))]
+                                  (-> s
+                                      (assoc :entries (conj kept url))
+                                      (update :index inc)))))
+                       (sync-location!))
+                     :replaceState
+                     (fn [_state _title url]
+                       (swap! state assoc-in
+                              [:entries (:index @state)] url)
+                       (sync-location!))
+                     :back
+                     (fn []
+                       (swap! state
+                              (fn [{:keys [index] :as s}]
+                                (if (pos? index)
+                                  (assoc s :index (dec index))
+                                  s)))
+                       (sync-location!))
+                     :forward
+                     (fn []
+                       (swap! state
+                              (fn [{:keys [entries index] :as s}]
+                                (if (< index (dec (count entries)))
+                                  (assoc s :index (inc index))
+                                  s)))
+                       (sync-location!))
+                     :go
+                     (fn [delta]
+                       (swap! state
+                              (fn [{:keys [entries index] :as s}]
+                                (let [next (+ index delta)]
+                                  (if (and (>= next 0)
+                                           (< next (count entries)))
+                                    (assoc s :index next)
+                                    s))))
+                       (sync-location!))}
+        window  #js {:history history
+                     :location location
+                     :scrollX 0
+                     :scrollY 0
+                     :pageXOffset 0
+                     :pageYOffset 0
+                     :scrollTo
+                     ;; routing.cljc's `:rf.nav/scroll` fx calls
+                     ;; `(.scrollTo js/window 0 0)` on forward nav and
+                     ;; `(.scrollTo js/window x y)` on restore. Mirror browser
+                     ;; state by updating the scroll fields
+                     ;; `:rf.nav/capture-scroll` reads.
+                     (fn [x y]
+                       (set! (.-scrollX js/globalThis.window) x)
+                       (set! (.-scrollY js/globalThis.window) y)
+                       (set! (.-pageXOffset js/globalThis.window) x)
+                       (set! (.-pageYOffset js/globalThis.window) y))
+                     :addEventListener
+                     (fn [type listener]
+                       (swap! state update-in [:listeners type]
+                              (fnil conj []) listener))
+                     :removeEventListener
+                     (fn [type listener]
+                       (swap! state update-in [:listeners type]
+                              (fnil (fn [xs] (vec (remove #(= % listener) xs)))
+                                    [])))
+                     :dispatchEvent
+                     (fn [event]
+                       (doseq [l (get-in @state [:listeners (.-type event)] [])]
+                         (l event)))}
+        ;; routing.cljc's scroll fx also calls
+        ;; `(.getElementById js/document fragment)`. Provide a stub document
+        ;; that returns nil so the fragment branch falls through to
+        ;; `(.scrollTo js/window 0 0)`.
+        document #js {:getElementById (fn [_id] nil)}]
+    (set! (.-window js/globalThis) window)
+    (set! (.-document js/globalThis) document)
+    state))
+
+(defn- uninstall-window-stub! []
+  (js-delete js/globalThis "window")
+  (js-delete js/globalThis "document"))
+
+(def ^:dynamic *history-state* nil)
+
+(defn with-window-stub-fixture
+  "Per-test `use-fixtures` thunk: install the window/history/document stub, bind
+  `*history-state*` to it, run the test, and tear the stub down in `finally`
+  even on failure. Compose it FIRST (before the runtime-reset fixture) so the
+  stub exists before any routing fx fires."
+  [f]
+  (let [state (install-window-stub!)]
+    (try
+      (binding [*history-state* state]
+        (f))
+      (finally
+        (uninstall-window-stub!)))))

--- a/implementation/routing/test/re_frame/routing_history_cljs_test.cljs
+++ b/implementation/routing/test/re_frame/routing_history_cljs_test.cljs
@@ -44,173 +44,21 @@
             ;; non-string fail-closed test calls them directly.
             [re-frame.routing.url :as routing-url]
             [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]))
+            [re-frame.test-support :as test-support]
+            ;; rf2-y6e2zb: the browser history/location/document stub,
+            ;; `*history-state*`, `current-url`, and `with-window-stub-fixture`
+            ;; are the SUPERSET fixture shared with routing_url_strategy_cljs_test.
+            [re-frame.routing-browser-test-support
+             :refer [*history-state* current-url with-window-stub-fixture]]))
 
 ;; ---- window / history stub -----------------------------------------------
 ;;
-;; jsdom-style minimal history mock. Sufficient for routing.cljc's
-;; `:rf.nav/push-url` / `:rf.nav/replace-url` / `:rf.nav/scroll` fx to
-;; run without throwing. The mock keeps the entry stack in *state* so
-;; tests can assert against it directly (no need to read js/window.history.length).
-
-(defn- new-history-stub []
-  (let [state (atom {:entries ["/"]   ;; stack of URLs, top = current
-                     :index   0       ;; index into :entries for the current URL
-                     :listeners {}})] ;; event-type → vec of listeners
-    state))
-
-(defn- current-url [state]
-  (let [{:keys [entries index]} @state]
-    (nth entries index)))
-
-(defn- install-window-stub! []
-  (let [state (new-history-stub)
-        location #js {:origin   "https://app.example"
-                      :href     "https://app.example/"
-                      :pathname "/"
-                      :search   ""
-                      :hash     ""}
-        ;; Keep `location` in sync with the current history entry, the way
-        ;; a real browser updates `window.location` on pushState / back /
-        ;; forward. The automatically-installed popstate handler (rf2-g8pbwg
-        ;; — a `:url-bound? true` frame's lifecycle installs it) reads
-        ;; the new URL off `window.location` (not the test's state atom),
-        ;; so the stub MUST reflect the navigation here for the
-        ;; listener-driven Back/Forward tests (rf2-6qgbs.4). Splits the
-        ;; entry into pathname / search / hash so `current-url` reassembles
-        ;; the same string.
-        sync-location!
-        (fn []
-          (let [{:keys [entries index]} @state
-                url    (nth entries index)
-                [path+ hash]   (let [i (.indexOf url "#")]
-                                 (if (neg? i) [url ""]
-                                     [(subs url 0 i) (subs url i)]))
-                [path search]  (let [i (.indexOf path+ "?")]
-                                 (if (neg? i) [path+ ""]
-                                     [(subs path+ 0 i) (subs path+ i)]))]
-            (set! (.-pathname location) path)
-            (set! (.-search location) search)
-            (set! (.-hash location) hash)
-            (set! (.-href location) (str (.-origin location) url))))
-        ;; Synthetic event factory the stub passes to listeners.
-        mk-event (fn [type]
-                   #js {:type type})
-        ;; The stub history object — exposes the HTML5 History API
-        ;; surface routing.cljc actually calls into.
-        history #js {:pushState
-                     (fn [_state _title url]
-                       ;; Truncate the forward stack (any entries past
-                       ;; the current index get dropped on a fresh push,
-                       ;; matching real browser semantics) then append.
-                       (swap! state
-                              (fn [{:keys [entries index] :as s}]
-                                (let [kept (subvec entries 0 (inc index))]
-                                  (-> s
-                                      (assoc :entries (conj kept url))
-                                      (update :index inc)))))
-                       (sync-location!))
-                     :replaceState
-                     (fn [_state _title url]
-                       (swap! state assoc-in
-                              [:entries (:index @state)] url)
-                       (sync-location!))
-                     :back
-                     (fn []
-                       (swap! state
-                              (fn [{:keys [index] :as s}]
-                                (if (pos? index)
-                                  (assoc s :index (dec index))
-                                  s)))
-                       (sync-location!))
-                     :forward
-                     (fn []
-                       (swap! state
-                              (fn [{:keys [entries index] :as s}]
-                                (if (< index (dec (count entries)))
-                                  (assoc s :index (inc index))
-                                  s)))
-                       (sync-location!))
-                     :go
-                     (fn [delta]
-                       (swap! state
-                              (fn [{:keys [entries index] :as s}]
-                                (let [next (+ index delta)]
-                                  (if (and (>= next 0)
-                                           (< next (count entries)))
-                                    (assoc s :index next)
-                                    s))))
-                       (sync-location!))}
-        window  #js {:history history
-                     :location location
-                     :scrollX 0
-                     :scrollY 0
-                     :pageXOffset 0
-                     :pageYOffset 0
-                     :scrollTo
-                     ;; routing.cljc's `:rf.nav/scroll` fx calls
-                     ;; `(.scrollTo js/window 0 0)` on forward nav and
-                     ;; `(.scrollTo js/window x y)` on restore. Mirror
-                     ;; browser state by updating the scroll position
-                     ;; fields that :rf.nav/capture-scroll reads.
-                     (fn [x y]
-                       (set! (.-scrollX js/globalThis.window) x)
-                       (set! (.-scrollY js/globalThis.window) y)
-                       (set! (.-pageXOffset js/globalThis.window) x)
-                       (set! (.-pageYOffset js/globalThis.window) y))
-                     :addEventListener
-                     (fn [type listener]
-                       (swap! state update-in [:listeners type]
-                              (fnil conj []) listener))
-                     :removeEventListener
-                     (fn [type listener]
-                       (swap! state update-in [:listeners type]
-                              (fnil (fn [xs] (vec (remove #(= % listener) xs)))
-                                    [])))
-                     :dispatchEvent
-                     (fn [event]
-                       (doseq [l (get-in @state [:listeners (.-type event)] [])]
-                         (l event)))}
-        ;; routing.cljc's scroll fx also calls
-        ;; `(.getElementById js/document fragment)`. Provide a stub
-        ;; document that returns nil so the fragment branch falls
-        ;; through to `(.scrollTo js/window 0 0)`.
-        document #js {:getElementById (fn [_id] nil)}]
-    (set! (.-window js/globalThis) window)
-    (set! (.-document js/globalThis) document)
-    state))
-
-(defn- uninstall-window-stub! []
-  (js-delete js/globalThis "window")
-  (js-delete js/globalThis "document"))
-
-;; Per-test fixture: install + tear down the stub, snapshot/restore the
-;; registrar (same shape as `route_link_cljs_test.cljs`). The window
-;; stub MUST be installed BEFORE the fx fire — both fixtures run :each
-;; so order is "compose-first then test-support-fixture-second" via
-;; cljs.test's :each composition.
-
-(def ^:dynamic *history-state* nil)
-
-;; Node-runtime only by design (rf2-6qclsc). This ns ends in `-cljs-test`,
-;; so shadow-cljs discovers it under the `:node-test` build (`:ns-regexp
-;; "cljs-test$"`) ONLY — the `:browser-test` build is narrowed to
-;; `-dom-cljs-test$` namespaces (rf2-2hrj8, implementation/shadow-cljs.edn).
-;; The fixture installs an in-memory `js/window` / history stub on
-;; `js/globalThis` (a real browser's `Window` / `History` cannot be
-;; replaced, so the in-memory `*history-state*` atom could not observe
-;; real pushState calls there anyway). A real-browser harness would be a
-;; separate `*_dom_cljs_test.cljs` namespace; until one exists there is no
-;; silent browser no-op to guard against — the gates never run this ns in
-;; a browser.
-(defn- with-window-stub-fixture
-  [f]
-  (let [state (install-window-stub!)]
-    (try
-      (binding [*history-state* state]
-        (f))
-      (finally
-        (uninstall-window-stub!)))))
+;; The jsdom-style history/location/document stub, `*history-state*`,
+;; `current-url`, and `with-window-stub-fixture` now live in the shared
+;; re-frame.routing-browser-test-support ns (rf2-y6e2zb) — the SUPERSET fixture
+;; this suite and routing_url_strategy_cljs_test both drive. This suite reads
+;; `*history-state*` / `current-url` directly and composes
+;; `with-window-stub-fixture` FIRST in `use-fixtures` below.
 
 (use-fixtures :each
   with-window-stub-fixture

--- a/implementation/routing/test/re_frame/routing_url_strategy_cljs_test.cljs
+++ b/implementation/routing/test/re_frame/routing_url_strategy_cljs_test.cljs
@@ -38,90 +38,24 @@
             [re-frame.routing :as routing]
             [re-frame.routing.strategy :as strategy]
             [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]))
+            [re-frame.test-support :as test-support]
+            ;; rf2-y6e2zb: the browser history/location/document stub,
+            ;; `*history-state*`, `current-url`, and `with-window-stub-fixture`
+            ;; are the SUPERSET fixture shared with routing_history_cljs_test.
+            [re-frame.routing-browser-test-support
+             :refer [*history-state* current-url with-window-stub-fixture]]))
 
 ;; ---- window / history + location stub ------------------------------------
-;; A minimal jsdom-style mock. `location` splits pathname / search / hash the
-;; way a real browser does, and pushState/replaceState re-sync it — so a
-;; hash strategy that writes `#/active` and reads `location.hash` round-trips.
-
-(defn- new-history-stub []
-  (atom {:entries ["/"] :index 0 :listeners {}}))
-
-(defn- current-url [state]
-  (let [{:keys [entries index]} @state] (nth entries index)))
-
-(defn- install-window-stub! []
-  (let [state    (new-history-stub)
-        location #js {:origin "https://app.example" :href "https://app.example/"
-                      :pathname "/" :search "" :hash ""}
-        sync-location!
-        (fn []
-          (let [{:keys [entries index]} @state
-                url           (nth entries index)
-                [path+ hash]  (let [i (.indexOf url "#")]
-                                (if (neg? i) [url ""] [(subs url 0 i) (subs url i)]))
-                [path search] (let [i (.indexOf path+ "?")]
-                                (if (neg? i) [path+ ""] [(subs path+ 0 i) (subs path+ i)]))]
-            (set! (.-pathname location) path)
-            (set! (.-search location) search)
-            (set! (.-hash location) hash)
-            (set! (.-href location) (str (.-origin location) url))))
-        history #js {:pushState
-                     (fn [_s _t url]
-                       (swap! state (fn [{:keys [entries index] :as s}]
-                                      (let [kept (subvec entries 0 (inc index))]
-                                        (-> s (assoc :entries (conj kept url))
-                                            (update :index inc)))))
-                       (sync-location!))
-                     :replaceState
-                     (fn [_s _t url]
-                       (swap! state assoc-in [:entries (:index @state)] url)
-                       (sync-location!))
-                     :back
-                     (fn []
-                       (swap! state (fn [{:keys [index] :as s}]
-                                      (if (pos? index) (assoc s :index (dec index)) s)))
-                       (sync-location!))
-                     :forward
-                     (fn []
-                       (swap! state (fn [{:keys [entries index] :as s}]
-                                      (if (< index (dec (count entries)))
-                                        (assoc s :index (inc index)) s)))
-                       (sync-location!))}
-        window #js {:history history :location location
-                    :scrollX 0 :scrollY 0 :pageXOffset 0 :pageYOffset 0
-                    :scrollTo (fn [x y]
-                                (set! (.-scrollX js/globalThis.window) x)
-                                (set! (.-scrollY js/globalThis.window) y)
-                                (set! (.-pageXOffset js/globalThis.window) x)
-                                (set! (.-pageYOffset js/globalThis.window) y))
-                    :addEventListener
-                    (fn [type listener]
-                      (swap! state update-in [:listeners type] (fnil conj []) listener))
-                    :removeEventListener
-                    (fn [type listener]
-                      (swap! state update-in [:listeners type]
-                             (fnil (fn [xs] (vec (remove #(= % listener) xs))) [])))
-                    :dispatchEvent
-                    (fn [event]
-                      (doseq [l (get-in @state [:listeners (.-type event)] [])]
-                        (l event)))}
-        document #js {:getElementById (fn [_id] nil)}]
-    (set! (.-window js/globalThis) window)
-    (set! (.-document js/globalThis) document)
-    state))
-
-(defn- uninstall-window-stub! []
-  (js-delete js/globalThis "window")
-  (js-delete js/globalThis "document"))
-
-(def ^:dynamic *history-state* nil)
-
-(defn- with-window-stub-fixture [f]
-  (let [state (install-window-stub!)]
-    (try (binding [*history-state* state] (f))
-         (finally (uninstall-window-stub!)))))
+;;
+;; The jsdom-style history/location/document stub, `*history-state*`,
+;; `current-url`, and `with-window-stub-fixture` now live in the shared
+;; re-frame.routing-browser-test-support ns (rf2-y6e2zb) — the SUPERSET fixture
+;; this suite and routing_history_cljs_test both drive. `location` splits
+;; pathname / search / hash the way a real browser does, and
+;; pushState/replaceState re-sync it, so a hash strategy that writes `#/active`
+;; and reads `location.hash` round-trips. This suite reads `*history-state*` /
+;; `current-url` directly and composes `with-window-stub-fixture` FIRST in
+;; `use-fixtures` below.
 
 (use-fixtures :each
   with-window-stub-fixture


### PR DESCRIPTION
## What

`routing_history_cljs_test` and `routing_url_strategy_cljs_test` each carried their own copy of the same jsdom-style browser history/location/document fixture. This extracts the single shared owner.

- **New** `re-frame.routing-browser-test-support` (`implementation/routing/test/re_frame/routing_browser_test_support.cljs`) owns the SUPERSET fixture: `install-window-stub!` / `uninstall-window-stub!` (private), `*history-state*` (dynamic current state), `current-url`, and `with-window-stub-fixture`.
- **`routing_history_cljs_test`** deletes its local browser-fixture implementation and `:refer`s `[*history-state* current-url with-window-stub-fixture]`; retains its own routing reset + route registrations.
- **`routing_url_strategy_cljs_test`** does the same.

Net: two duplicated ~85-line fixtures replaced by one shared ns (+210 / −246).

## Preflight confirmation

Confirmed the two fixtures independently implemented the SAME browser history/location/document/listener surface — `new-history-stub`, `current-url`, global window install/uninstall, dynamic `*history-state*`, and fixture lifecycle. The only divergence was the history suite's **superset `go` operation** (and a dead, never-referenced `mk-event` `let` binding). The extracted support ns carries the superset (`go` kept; dead `mk-event` dropped for clarity). No true divergence beyond the superset.

The ns deliberately ends in `-test-support`, NOT `-cljs-test`, so the shadow-cljs `:node-test` discovery regex (`cljs-test$`) never executes it as a test namespace (established `*_test_support.cljs` pattern, cf. `re-frame.adapter.react-test-support`).

## Quality gates

- `npm run test:cljs` (foreground) — **Ran 8462 tests containing 39065 assertions. 0 failures, 0 errors.** Both routing suites stay green through the shared fixture; the support ns compiled cleanly (a broken `:refer` would have failed the build). These routing browser tests are node-runtime CLJS by design (node-test only) — no separate routing browser gate exists.
- No production source or dependency changes.

## Stance

pre-alpha, no back-compat; ELEGANCE + CLARITY + CORRECTNESS + GOOD-PRACTICE — a single owner for the duplicated fixture, minimal public surface (install/uninstall/new-history-stub kept private), dead code removed.