### PR TITLE
test(schemas): use the shared with-trace-recorder! throughout (rf2-bhh8my)

### DIFF
--- a/implementation/schemas/test/re_frame/schemas_boundary_prod_test.cljs
+++ b/implementation/schemas/test/re_frame/schemas_boundary_prod_test.cljs
@@ -42,11 +42,14 @@
             ;; at the boundary is to require the adapter ns at boot.
             [re-frame.schemas.malli]
             [re-frame.core :as rf]
-            ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
-            [re-frame.trace.tooling :as trace-tooling]
             [re-frame.schemas :as schemas]
             [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]))
+            [re-frame.test-support :as test-support])
+  ;; rf2-bhh8my: the shared trace recorder supersedes the per-test
+  ;; register-listener!/unregister-listener! capture bracket. The macro
+  ;; ships from the `#?(:clj ...)` arm of re-frame.test-support, so CLJS
+  ;; reaches it via :require-macros (mirrors re-frame.core's call-site macros).
+  (:require-macros [re-frame.test-support :refer [with-trace-recorder!]]))
 
 ;; Mirror schemas_cljs_test.cljs's fixture: snapshot/restore the
 ;; registrar (rf2-am9d) and clear the schemas artefact's per-frame
@@ -110,10 +113,8 @@
         {:schema [:cat [:= :api/strict] :int]
          :interceptors [:rf.schema/at-boundary]}
         (fn [_ _] (swap! calls inc) {}))
-      (let [traces (atom [])]
-        (trace-tooling/register-listener! ::prod-no-trace (fn [ev] (swap! traces conj ev)))
+      (with-trace-recorder! [traces]
         (rf/dispatch-sync [:api/strict "not-an-int"])
-        (trace-tooling/unregister-listener! ::prod-no-trace)
         (is (= 0 @calls)
             "handler skipped (boundary did its job)")
         ;; Under `:advanced` + `goog.DEBUG=false` the trace surface is

--- a/implementation/schemas/test/re_frame/schemas_cljs_test.cljs
+++ b/implementation/schemas/test/re_frame/schemas_cljs_test.cljs
@@ -24,12 +24,15 @@
             ;; §Recommended soft-pass) and no failure trace fires.
             [re-frame.schemas.malli]
             [re-frame.core :as rf]
-            ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
-            [re-frame.trace.tooling :as trace-tooling]
             [re-frame.late-bind :as late-bind]
             [re-frame.schemas :as schemas]
             [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]))
+            [re-frame.test-support :as test-support])
+  ;; rf2-bhh8my: the shared trace recorder supersedes the per-test
+  ;; register-listener!/unregister-listener! capture brackets. The macro
+  ;; ships from the `#?(:clj ...)` arm of re-frame.test-support, so CLJS
+  ;; reaches it via :require-macros (mirrors re-frame.core's call-site macros).
+  (:require-macros [re-frame.test-support :refer [with-trace-recorder!]]))
 
 ;; Snapshot/restore the registrar around each test (rf2-am9d). The earlier
 ;; (registrar/clear-all!) wiped framework registrations (routing,
@@ -58,11 +61,9 @@
     (rf/reg-app-schema [:n] [:int])
     (rf/reg-event :n/init  (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/reg-event :n/break (fn [{:keys [db]} _] {:db (assoc db :n "boom")}))
-    (let [traces (atom [])]
-      (trace-tooling/register-listener! ::cljs-live (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       (rf/dispatch-sync [:n/init])
       (rf/dispatch-sync [:n/break])
-      (trace-tooling/unregister-listener! ::cljs-live)
       (let [violations (filter #(= :rf.error/schema-validation-failure
                                    (:operation %))
                                @traces)]
@@ -83,12 +84,10 @@
     (rf/reg-app-schema [:n] [:int])
     (rf/reg-event :n/init (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/reg-event :n/inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
-    (let [traces (atom [])]
-      (trace-tooling/register-listener! ::cljs-ok (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       (rf/dispatch-sync [:n/init])
       (rf/dispatch-sync [:n/inc])
       (rf/dispatch-sync [:n/inc])
-      (trace-tooling/unregister-listener! ::cljs-ok)
       (is (empty? (filter #(= :rf.error/schema-validation-failure
                               (:operation %))
                           @traces))
@@ -121,10 +120,8 @@
     (rf/reg-app-schema [:user :age] :int)
     (rf/reg-event :user/set-age-bad
       (fn [{:keys [db]} _] {:db (assoc-in db [:user :age] "twenty-three")}))
-    (let [traces (atom [])]
-      (trace-tooling/register-listener! ::t0hq (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       (rf/dispatch-sync [:user/set-age-bad])
-      (trace-tooling/unregister-listener! ::t0hq)
       (let [violations (filter #(= :rf.error/schema-validation-failure
                                    (:operation %))
                                @traces)]
@@ -150,10 +147,8 @@
       (try
         (rf/reg-app-schema [:n] :int)
         (rf/reg-event :n/break (fn [{:keys [db]} _] {:db (assoc db :n "definitely-not-an-int")}))
-        (let [traces (atom [])]
-          (trace-tooling/register-listener! ::no-adapter (fn [ev] (swap! traces conj ev)))
+        (with-trace-recorder! [traces]
           (rf/dispatch-sync [:n/break])
-          (trace-tooling/unregister-listener! ::no-adapter)
           (is (empty? (filter #(= :rf.error/schema-validation-failure
                                   (:operation %))
                               @traces))
@@ -180,13 +175,11 @@
         (fn [{:keys [db]} _]
           (swap! calls inc)
           {:db db}))
-      (let [traces (atom [])]
-        (trace-tooling/register-listener! ::cljs-ev (fn [ev] (swap! traces conj ev)))
+      (with-trace-recorder! [traces]
         ;; Well-typed payload — handler runs.
         (rf/dispatch-sync [:user/register {:email "a@b.com" :age 30}])
         ;; Malformed — handler must NOT run.
         (rf/dispatch-sync [:user/register {:email "c@d.com" :age "no"}])
-        (trace-tooling/unregister-listener! ::cljs-ev)
         (is (= 1 @calls)
             "handler ran exactly once — the bad payload was rejected pre-handler")
         (let [violations (filter #(= :rf.error/schema-validation-failure
@@ -222,14 +215,12 @@
       (rf/reg-event :rf2-lo28u/bad-event-args
         {:schema [:cat [:= :rf2-lo28u/bad-event-args] pos-int?]}
         (fn [{:keys [db]} _ev] (swap! calls inc) {:db db}))
-      (let [traces (atom [])]
-        (trace-tooling/register-listener! ::lo28u (fn [ev] (swap! traces conj ev)))
+      (with-trace-recorder! [traces]
         ;; Well-typed arg (a pos-int) — handler runs.
         (rf/dispatch-sync [:rf2-lo28u/bad-event-args 7])
         ;; Bad arg (a string where a pos-int is required) — handler must
         ;; NOT run; a :where :event violation must fire.
         (rf/dispatch-sync [:rf2-lo28u/bad-event-args "not-a-number"])
-        (trace-tooling/unregister-listener! ::lo28u)
         (is (= 1 @calls)
             "handler ran exactly once — the bad arg was rejected pre-handler")
         (let [violations (filter #(= :rf.error/schema-validation-failure
@@ -253,10 +244,8 @@
       (rf/reg-event :rf2-lo28u/diag-bad-event-args
         {:schema [:cat [:= :rf2-lo28u/diag-bad-event-args] pos-int?]}
         (fn [{:keys [db]} _ev] (swap! calls inc) {:db db}))
-      (let [traces (atom [])]
-        (trace-tooling/register-listener! ::lo28u-diag (fn [ev] (swap! traces conj ev)))
+      (with-trace-recorder! [traces]
         (rf/dispatch-sync [:rf2-lo28u/diag-bad-event-args "not-a-number"])
-        (trace-tooling/unregister-listener! ::lo28u-diag)
         (let [event-violations (filter #(and (= :rf.error/schema-validation-failure (:operation %))
                                              (= :event (-> % :tags :where)))
                                        @traces)]
@@ -301,14 +290,12 @@
         {:schema [:cat [:= :rf2-lo28u/async-bad-event-args] pos-int?]}
         (fn [{:keys [db]} _ev] (swap! calls inc) {:db (assoc db :baseline 1)}))
       (rf/reg-event :rf2-lo28u/noop (fn [{:keys [db]} _] {:db db}))
-      (let [traces (atom [])]
-        (trace-tooling/register-listener! ::lo28u-async (fn [ev] (swap! traces conj ev)))
+      (with-trace-recorder! [traces]
         ;; (a) ASYNC dispatch — lands at the BACK of the queue (live button path).
         (rf/dispatch [:rf2-lo28u/async-bad-event-args "not-a-number"])
         ;; (b) Drain to fixed point: the queued bad event is dequeued by the
         ;; real drain through the same cascade the nextTick drain would use.
         (rf/dispatch-sync [:rf2-lo28u/noop])
-        (trace-tooling/unregister-listener! ::lo28u-async)
         (let [violations (filter #(= :rf.error/schema-validation-failure (:operation %)) @traces)
               event-violations (filter #(= :event (-> % :tags :where)) violations)]
           (is (= 0 @calls)
@@ -354,11 +341,9 @@
         (rf/reg-app-schema [:n] :int)
         (rf/reg-event :n/init  (fn [{:keys [db]} _] {:db {:n 42}}))
         (rf/reg-event :n/break (fn [{:keys [db]} _] {:db (assoc db :n 99)}))
-        (let [traces (atom [])]
-          (trace-tooling/register-listener! ::cv (fn [ev] (swap! traces conj ev)))
+        (with-trace-recorder! [traces]
           (rf/dispatch-sync [:n/init])
           (rf/dispatch-sync [:n/break])
-          (trace-tooling/unregister-listener! ::cv)
           (is (pos? @calls)
               "the custom validator was invoked through the live dispatch path")
           (let [violations (filter #(= :rf.error/schema-validation-failure
@@ -378,10 +363,8 @@
     (try
       (rf/reg-app-schema [:n] :int)
       (rf/reg-event :n/break (fn [{:keys [db]} _] {:db (assoc db :n "definitely-not-an-int")}))
-      (let [traces (atom [])]
-        (trace-tooling/register-listener! ::nv (fn [ev] (swap! traces conj ev)))
+      (with-trace-recorder! [traces]
         (rf/dispatch-sync [:n/break])
-        (trace-tooling/unregister-listener! ::nv)
         (is (empty? (filter #(= :rf.error/schema-validation-failure
                                 (:operation %))
                             @traces))
@@ -417,15 +400,13 @@
       {:schema [:cat [:= :api/strict] :int]
        :interceptors [:rf.schema/at-boundary]}
       (fn [_ _] {}))
-    (let [traces (atom [])]
-      (trace-tooling/register-listener! ::boundary-dev (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       ;; Direct :before invocation isolates the boundary's behaviour
       ;; from the surrounding router/step-1 path so we observe the
       ;; boundary's own dev-mode contract.
       (let [before    (:before rf/validate-at-boundary-interceptor)
             valid-ctx (before {:coeffects {:event [:api/strict 42]}})
             bad-ctx   (before {:coeffects {:event [:api/strict "not-an-int"]}})]
-        (trace-tooling/unregister-listener! ::boundary-dev)
         (is (not (:rf/skip-handler? valid-ctx))
             "valid event: boundary did not set :rf/skip-handler? (no-op)")
         (is (not (:rf/skip-handler? bad-ctx))
@@ -449,10 +430,8 @@
         {:schema [:cat [:= :api/strict] :int]
          :interceptors [:rf.schema/at-boundary]}
         (fn [_ _] (swap! calls inc) {}))
-      (let [traces (atom [])]
-        (trace-tooling/register-listener! ::dev-dispatch (fn [ev] (swap! traces conj ev)))
+      (with-trace-recorder! [traces]
         (rf/dispatch-sync [:api/strict "not-an-int"])
-        (trace-tooling/unregister-listener! ::dev-dispatch)
         (is (= 0 @calls)
             "handler was skipped — router's step-1 validation fired in dev")
         (let [boundary-violations (filter #(and (= :rf.error/schema-validation-failure (:operation %))

--- a/implementation/schemas/test/re_frame/schemas_conformance_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_conformance_test.clj
@@ -98,7 +98,7 @@
             [re-frame.schemas.test-fixture :as tf]
             [re-frame.subs :as subs]
             [re-frame.substrate.adapter :as substrate-adapter]
-            [re-frame.trace :as trace]))
+            [re-frame.test-support :refer [with-trace-recorder!]]))
 
 (use-fixtures :each tf/reset-runtime)
 
@@ -432,17 +432,6 @@
   (doseq [[path schema] (get-in fixture [:fixture/registry :app-schemas])]
     (rf/reg-app-schema path schema)))
 
-;; ---- trace capture -------------------------------------------------------
-
-(defn- collect-traces
-  "Register a trace listener for the fixture's run; the returned atom
-  accumulates every captured trace event."
-  [fixture-id]
-  (let [traces (atom [])]
-    (trace/register-listener! [fixture-id]
-                              (fn [ev] (swap! traces conj ev)))
-    traces))
-
 ;; ---- matchers ------------------------------------------------------------
 
 (defn- submap?
@@ -556,62 +545,61 @@
   "Run one fixture; return a result map shaped like the core runner's."
   [fixture]
   (try
-    (let [fid          (:fixture/id fixture)
-          traces       (collect-traces fid)
-          _            (realise-handlers fixture)
-          frame-config (or (:fixture/frame-config fixture) {})
-          ;; `reset-runtime` already created :rf/default WITHOUT any
-          ;; :initial-events. `reg-frame` against an existing id is a
-          ;; surgical update that does NOT re-fire :initial-events (Spec 002).
-          ;; Destroy first so the fixture's :initial-events cascade fires
-          ;; under its declared frame config.
-          _            (rf/destroy-frame! :rf/default)
-          ;; Per rf2-wkxng / rf2-6m0se: register app-db schemas
-          ;; AFTER the destroy step (the new
-          ;; `:schemas/on-frame-destroyed!` hook drops the frame's
-          ;; schemas on destroy, so registering them BEFORE the
-          ;; destroy would leak them through). Schemas must also
-          ;; precede `reg-frame` so the :initial-events cascade fires
-          ;; with the schemas in place — the initial-events' db commit
-          ;; will trigger validate-app-schema! against the new slate.
-          _            (realise-app-schemas fixture)
-          ;; EP-0002 (rf2-5q7um6): the shared `tf/reset-runtime` pins
-          ;; `*current-frame* :rf/default` for the body. Unbind it around
-          ;; `reg-frame` so the fixture's `:initial-events` cascade fires
-          ;; SYNCHRONOUSLY — `frame/reg-frame` async-queues initial-events when
-          ;; `*current-frame*` is bound (Spec 002 §reg-frame from inside a
-          ;; handler), which would land the seed AFTER the first dispatch.
-          _            (binding [frame/*current-frame* nil]
-                         (rf/reg-frame :rf/default frame-config))
-          dispatches   (or (:fixture/dispatches fixture) [])
-          ;; EP-0017 `:expect-error` mismatches (rf2-hqwki4) — a context-assembly
-          ;; throw the dispatch declared but did not raise (or raised wrong).
-          dispatch-error-failures (atom [])]
-      (doseq [ev dispatches]
-        (run-dispatch ev dispatch-error-failures))
-      (let [expect        (or (:fixture/expect fixture) {})
-            expected-db   (:final-app-db expect)
-            final-db      (rf/app-db-value :rf/default)
-            sub-checks
-            (doall
-              (for [[query-v expected-val] (or (:sub-values expect) {})]
-                (let [[frame-id qv] (resolve-sub query-v)]
-                  {:query    query-v
-                   :expected expected-val
-                   :actual   (rf/subscribe-once qv {:frame frame-id})})))
-            trace-failures (check-trace-emissions @traces
-                                                  (:trace-emissions expect))]
-        (trace/clear-listeners!)
-        {:fixture-id     fid
-         :passed?        (and (or (nil? expected-db) (submap? expected-db final-db))
-                              (every? #(= (:expected %) (:actual %)) sub-checks)
-                              (empty? trace-failures)
-                              (empty? @dispatch-error-failures))
-         :dispatch-error-failures @dispatch-error-failures
-         :final-db       final-db
-         :expected-db    expected-db
-         :sub-checks     sub-checks
-         :trace-failures trace-failures}))
+    (with-trace-recorder! [traces]
+      (let [fid          (:fixture/id fixture)
+            _            (realise-handlers fixture)
+            frame-config (or (:fixture/frame-config fixture) {})
+            ;; `reset-runtime` already created :rf/default WITHOUT any
+            ;; :initial-events. `reg-frame` against an existing id is a
+            ;; surgical update that does NOT re-fire :initial-events (Spec 002).
+            ;; Destroy first so the fixture's :initial-events cascade fires
+            ;; under its declared frame config.
+            _            (rf/destroy-frame! :rf/default)
+            ;; Per rf2-wkxng / rf2-6m0se: register app-db schemas
+            ;; AFTER the destroy step (the new
+            ;; `:schemas/on-frame-destroyed!` hook drops the frame's
+            ;; schemas on destroy, so registering them BEFORE the
+            ;; destroy would leak them through). Schemas must also
+            ;; precede `reg-frame` so the :initial-events cascade fires
+            ;; with the schemas in place — the initial-events' db commit
+            ;; will trigger validate-app-schema! against the new slate.
+            _            (realise-app-schemas fixture)
+            ;; EP-0002 (rf2-5q7um6): the shared `tf/reset-runtime` pins
+            ;; `*current-frame* :rf/default` for the body. Unbind it around
+            ;; `reg-frame` so the fixture's `:initial-events` cascade fires
+            ;; SYNCHRONOUSLY — `frame/reg-frame` async-queues initial-events when
+            ;; `*current-frame*` is bound (Spec 002 §reg-frame from inside a
+            ;; handler), which would land the seed AFTER the first dispatch.
+            _            (binding [frame/*current-frame* nil]
+                           (rf/reg-frame :rf/default frame-config))
+            dispatches   (or (:fixture/dispatches fixture) [])
+            ;; EP-0017 `:expect-error` mismatches (rf2-hqwki4) — a context-assembly
+            ;; throw the dispatch declared but did not raise (or raised wrong).
+            dispatch-error-failures (atom [])]
+        (doseq [ev dispatches]
+          (run-dispatch ev dispatch-error-failures))
+        (let [expect        (or (:fixture/expect fixture) {})
+              expected-db   (:final-app-db expect)
+              final-db      (rf/app-db-value :rf/default)
+              sub-checks
+              (doall
+                (for [[query-v expected-val] (or (:sub-values expect) {})]
+                  (let [[frame-id qv] (resolve-sub query-v)]
+                    {:query    query-v
+                     :expected expected-val
+                     :actual   (rf/subscribe-once qv {:frame frame-id})})))
+              trace-failures (check-trace-emissions @traces
+                                                    (:trace-emissions expect))]
+          {:fixture-id     fid
+           :passed?        (and (or (nil? expected-db) (submap? expected-db final-db))
+                                (every? #(= (:expected %) (:actual %)) sub-checks)
+                                (empty? trace-failures)
+                                (empty? @dispatch-error-failures))
+           :dispatch-error-failures @dispatch-error-failures
+           :final-db       final-db
+           :expected-db    expected-db
+           :sub-checks     sub-checks
+           :trace-failures trace-failures})))
     (catch Throwable e
       {:fixture-id (:fixture/id fixture)
        :passed?    false

--- a/implementation/schemas/test/re_frame/schemas_fail_open_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_fail_open_test.clj
@@ -40,17 +40,16 @@
             [re-frame.schemas :as schemas]
             [re-frame.schemas.malli]
             [re-frame.schemas.test-fixture :as tf]
-            [re-frame.schemas.validator :as validator]))
+            [re-frame.schemas.validator :as validator]
+            [re-frame.test-support :refer [with-trace-recorder!]]))
 
 (use-fixtures :each tf/reset-runtime)
 
 (defn- capture
   "Run `body-fn` while collecting trace events; return the captured vector."
   [body-fn]
-  (let [traces (atom [])
-        cb-id  (keyword (gensym "capture"))]
-    (rf/register-listener! :trace cb-id (fn [ev] (swap! traces conj ev)))
-    (try (body-fn) (finally (rf/unregister-listener! :trace cb-id)))
+  (with-trace-recorder! [traces]
+    (body-fn)
     @traces))
 
 (defn- malformed-traces [traces]

--- a/implementation/schemas/test/re_frame/schemas_failure_paths_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_failure_paths_test.clj
@@ -44,7 +44,8 @@
             [re-frame.schemas.malli]
             [re-frame.schemas.test-fixture :as tf]
             [re-frame.schemas.validate :as validate]
-            [re-frame.schemas.validator :as validator]))
+            [re-frame.schemas.validator :as validator]
+            [re-frame.test-support :refer [with-trace-recorder!]]))
 
 (use-fixtures :each tf/reset-runtime)
 
@@ -52,12 +53,8 @@
   "Run `body-fn` while collecting :rf.error/schema-validation-failure
   trace events; return the vector of captured events."
   [body-fn]
-  (let [traces (atom [])
-        cb-id  (keyword (gensym "capture"))]
-    (rf/register-listener! :trace cb-id (fn [ev] (swap! traces conj ev)))
-    (try
-      (body-fn)
-      (finally (rf/unregister-listener! :trace cb-id)))
+  (with-trace-recorder! [traces]
+    (body-fn)
     (filterv #(= :rf.error/schema-validation-failure (:operation %))
              @traces)))
 

--- a/implementation/schemas/test/re_frame/schemas_implies_validation_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_implies_validation_test.clj
@@ -47,15 +47,10 @@
             ;; `re-frame.schemas.malli`. The whole point of rf2-v96fh is
             ;; that requiring the facade is sufficient to wire Malli.
             [re-frame.schemas]
-            [re-frame.schemas.test-fixture :as tf]))
+            [re-frame.schemas.test-fixture :as tf]
+            [re-frame.test-support :refer [with-trace-recorder!]]))
 
 (use-fixtures :each tf/reset-runtime)
-
-(defn- record-traces!
-  [listener-id]
-  (let [a (atom [])]
-    (rf/register-listener! :trace listener-id (fn [ev] (swap! a conj ev)))
-    a))
 
 (defn- failures-of
   [recorded]
@@ -83,13 +78,12 @@
             explicit `re-frame.schemas.malli` require. Pre-fix this was a
             silent no-op (the default validator soft-passed)."
     (rf/reg-app-schema [:count] [:int])
-    (let [recorded (record-traces! ::bad-write)]
+    (with-trace-recorder! [recorded]
       (with-redefs [interop/debug-enabled? true]
         (rf/reg-event :count/break (fn [{:keys [db]} _] {:db (assoc db :count "not-an-int")}))
         ;; validate-app-schema! runs the registered app-db schema set over
         ;; the supplied db value, exactly as the post-handler step does.
         (re-frame.schemas/validate-app-schema! {:count "not-an-int"} :count/break))
-      (rf/unregister-listener! :trace ::bad-write)
       (let [violations (failures-of recorded)]
         (is (= 1 (count violations))
             "exactly one schema-validation-failure fired — schema implies validation")
@@ -103,9 +97,8 @@
             the validation is real (it accepts good values), not a blanket
             reject."
     (rf/reg-app-schema [:count] [:int])
-    (let [recorded (record-traces! ::good-write)]
+    (with-trace-recorder! [recorded]
       (with-redefs [interop/debug-enabled? true]
         (re-frame.schemas/validate-app-schema! {:count 7} :count/ok))
-      (rf/unregister-listener! :trace ::good-write)
       (is (empty? (failures-of recorded))
           "no failure trace — the well-typed value conforms"))))

--- a/implementation/schemas/test/re_frame/schemas_reg_side_effects_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_reg_side_effects_test.clj
@@ -37,7 +37,8 @@
             [re-frame.schemas :as schemas]
             [re-frame.schemas.malli]
             [re-frame.schemas.test-fixture :as tf]
-            [re-frame.substrate.adapter :as substrate-adapter]))
+            [re-frame.substrate.adapter :as substrate-adapter]
+            [re-frame.test-support :refer [with-trace-recorder!]]))
 
 (use-fixtures :each tf/reset-runtime)
 
@@ -54,11 +55,8 @@
   "Run `body-fn` collecting trace events whose `:operation` is
   `operation`; return the captured vector."
   [operation body-fn]
-  (let [traces (atom [])
-        cb-id  (keyword (gensym "capture"))]
-    (rf/register-listener! :trace cb-id (fn [ev] (swap! traces conj ev)))
-    (try (body-fn)
-         (finally (rf/unregister-listener! :trace cb-id)))
+  (with-trace-recorder! [traces]
+    (body-fn)
     (filterv #(= operation (:operation %)) @traces)))
 
 ;; ===========================================================================

--- a/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
@@ -62,7 +62,8 @@
             ;; through the `re-frame.schemas` facade (validate-app-schema!'s
             ;; private redaction helper).
             [re-frame.schemas.walker :as walker]
-            [re-frame.schemas.test-fixture :as tf]))
+            [re-frame.schemas.test-fixture :as tf]
+            [re-frame.test-support :refer [with-trace-recorder!]]))
 
 (use-fixtures :each tf/reset-runtime)
 
@@ -168,11 +169,9 @@
     ;; A schema where the WHOLE registered slot is marked sensitive
     ;; (container-level :sensitive?).
     (rf/reg-app-schema [:auth :token] [:string {:sensitive? true}])
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::redact (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       ;; The value at [:auth :token] is an int (42) — fails :string.
       (schemas/validate-app-schema! {:auth {:token 42}} :auth/init-bad)
-      (rf/unregister-listener! :trace ::redact)
       (let [violations (filter #(= :rf.error/schema-validation-failure
                                    (:operation %))
                                @traces)]
@@ -202,8 +201,7 @@
                        [:map
                         [:name     :string]
                         [:password {:sensitive? true} :string]])
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::slot (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       ;; password is an int — fails :string. Since validation is
       ;; per-registered-path, the whole [:user] value fails the schema.
       ;; But schema-sensitive-at? checks if [:user] is sensitive (no)
@@ -213,7 +211,6 @@
       ;; failure when ANY slot within is sensitive.
       (schemas/validate-app-schema! {:user {:name "alice" :password 99}}
                                 :user/bad)
-      (rf/unregister-listener! :trace ::slot)
       (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                              @traces))]
         (is (some? v) "a trace fired")
@@ -226,10 +223,8 @@
   (testing "Backward-compat — a schema with no :sensitive? props emits
             unchanged traces; :value and :explain ride verbatim"
     (rf/reg-app-schema [:count] [:int])
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::plain (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       (schemas/validate-app-schema! {:count "not-an-int"} :count/bad)
-      (rf/unregister-listener! :trace ::plain)
       (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                              @traces))]
         (is (some? v))
@@ -259,11 +254,8 @@
   the schema), and return the single schema-validation-failure trace."
   [path schema db failing-id]
   (rf/reg-app-schema path schema)
-  (let [traces (atom [])
-        kw     (keyword "rf2-g5auo" (name (gensym "listen")))]
-    (rf/register-listener! :trace kw (fn [ev] (swap! traces conj ev)))
+  (with-trace-recorder! [traces]
     (schemas/validate-app-schema! db failing-id)
-    (rf/unregister-listener! :trace kw)
     (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                    @traces))))
 
@@ -1092,10 +1084,8 @@
          :sensitive? true                                      ;; ignored — annotation removed
          :schema     [:cat [:= :auth/sign-in] :string :string]}
         (fn [{:keys [db]} _] (swap! calls inc) {:db db}))
-      (let [traces (atom [])]
-        (rf/register-listener! :trace ::ev (fn [ev] (swap! traces conj ev)))
+      (with-trace-recorder! [traces]
         (rf/dispatch-sync [:auth/sign-in "ada" 42])
-        (rf/unregister-listener! :trace ::ev)
         (is (= 0 @calls) "handler skipped — validation failed")
         (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                                @traces))]
@@ -1118,10 +1108,8 @@
       {:schema [:cat [:= :user/register]
                    [:map [:email :string] [:age :int]]]}
       (fn [{:keys [db]} [_ payload]] {:db (update db :users (fnil conj []) payload)}))
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::reg (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       (rf/dispatch-sync [:user/register {:email "carol@example.com" :age "no"}])
-      (rf/unregister-listener! :trace ::reg)
       (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                              @traces))]
         (is (some? v))
@@ -1160,10 +1148,8 @@
                    ;; :password is sensitive AND wrong type (int) → fails.
                    [:password {:sensitive? true} :int]]]}
         (fn [{:keys [db]} _] (swap! calls inc) {:db db}))
-      (let [traces (atom [])]
-        (rf/register-listener! :trace ::login (fn [ev] (swap! traces conj ev)))
+      (with-trace-recorder! [traces]
         (rf/dispatch-sync [:auth/login {:user "ada" :password secret}])
-        (rf/unregister-listener! :trace ::login)
         (is (= 0 @calls) "handler skipped — validation failed")
         (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                                @traces))]
@@ -1188,10 +1174,8 @@
         ;; int where :string is expected so it fails.
         {:schema [:cat [:= :auth/token] [:string {:sensitive? true}]]}
         (fn [{:keys [db]} _] {:db db}))
-      (let [traces (atom [])]
-        (rf/register-listener! :trace ::tok (fn [ev] (swap! traces conj ev)))
+      (with-trace-recorder! [traces]
         (rf/dispatch-sync [:auth/token 12345])
-        (rf/unregister-listener! :trace ::tok)
         (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                                @traces))]
           (is (some? v))
@@ -1206,10 +1190,8 @@
     (rf/reg-event :user/update
       {:schema [:cat [:= :user/update] [:map [:name :string] [:age :int]]]}
       (fn [{:keys [db]} _] {:db db}))
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::upd (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       (rf/dispatch-sync [:user/update {:name "bob" :age "old"}])
-      (rf/unregister-listener! :trace ::upd)
       (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                              @traces))]
         (is (some? v))
@@ -1264,8 +1246,7 @@
     (rf/reg-event :auth/use-ctx
       {:rf.cofx/requires [:auth/ctx]}
       (fn [_ _] {}))
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::ctx (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       ;; :token "SECRET-COFX-tok" CONFORMS (sensitive sibling); :count fails
       ;; (string, not int) — the failing slot is the NON-sensitive sibling.
       (try
@@ -1273,7 +1254,6 @@
                           {:rf.cofx {:auth/ctx {:token "SECRET-COFX-tok"
                                                 :count "not-an-int"}}})
         (catch clojure.lang.ExceptionInfo _))
-      (rf/unregister-listener! :trace ::ctx)
       (let [v (first (filter #(= :rf.error/cofx-value-invalid (:operation %))
                              @traces))]
         (is (some? v) "a recordable-cofx validation failure was traced")
@@ -1294,14 +1274,12 @@
     (rf/reg-event :auth/use-ctx2
       {:rf.cofx/requires [:auth/ctx2]}
       (fn [_ _] {}))
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::ctx2 (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       ;; :token fails (int, not string) — the FAILING slot IS sensitive.
       (try
         (rf/dispatch-sync [:auth/use-ctx2]
                           {:rf.cofx {:auth/ctx2 {:token 1234 :count 3}}})
         (catch clojure.lang.ExceptionInfo _))
-      (rf/unregister-listener! :trace ::ctx2)
       (let [v (first (filter #(= :rf.error/cofx-value-invalid (:operation %))
                              @traces))]
         (is (some? v))
@@ -1321,10 +1299,8 @@
                 [:token {:sensitive? true} :string]
                 [:count :int]]}
       (fn [_ _] {:token "SECRET-SUB-tok" :count "not-an-int"}))
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::view (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       @(rf/subscribe [:auth/view])
-      (rf/unregister-listener! :trace ::view)
       (let [v (first (filter #(and (= :rf.error/schema-validation-failure (:operation %))
                                    (= :sub-return (-> % :tags :where)))
                              @traces))]
@@ -1353,14 +1329,12 @@
                    [:password {:sensitive? true} :string]
                    [:age :int]]]}
         (fn [{:keys [db]} _] {:db db}))
-      (let [traces (atom [])]
-        (rf/register-listener! :trace ::prof (fn [ev] (swap! traces conj ev)))
+      (with-trace-recorder! [traces]
         ;; :password conforms (a string, the sensitive sibling); :age fails
         ;; (a string, not int). The failing slot is NON-sensitive, but the
         ;; whole event vector (carrying the conforming :password) rides every
         ;; value-bearing slot.
         (rf/dispatch-sync [:auth/profile {:password secret :age "old"}])
-        (rf/unregister-listener! :trace ::prof)
         (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                                @traces))]
           (is (some? v))
@@ -1385,11 +1359,9 @@
                    [:password {:sensitive? true} :string]
                    [:age :int]]]}
         (fn [{:keys [db]} _] {:db db}))
-      (let [traces (atom [])]
-        (rf/register-listener! :trace ::prof2 (fn [ev] (swap! traces conj ev)))
+      (with-trace-recorder! [traces]
         ;; :password fails (int, not string) — the FAILING slot IS sensitive.
         (rf/dispatch-sync [:auth/profile2 {:password secret :age 30}])
-        (rf/unregister-listener! :trace ::prof2)
         (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                                @traces))]
           (is (some? v))
@@ -1414,11 +1386,9 @@
                              [:password {:sensitive? true} :string]
                              [:age :int]]]]}
         (fn [{:keys [db]} _] {:db db}))
-      (let [traces (atom [])]
-        (rf/register-listener! :trace ::profn (fn [ev] (swap! traces conj ev)))
+      (with-trace-recorder! [traces]
         ;; :age fails (non-sensitive); :password conforms (sensitive sibling).
         (rf/dispatch-sync [:auth/profile-n {:password secret :age "old"}])
-        (rf/unregister-listener! :trace ::profn)
         (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                                @traces))]
           (is (some? v))
@@ -1555,13 +1525,11 @@
     (rf/reg-event :auth/use-creds
       {:rf.cofx/requires [:auth/credentials]}
       (fn [_ _] {}))
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::cf (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       (try
         (rf/dispatch-sync [:auth/use-creds]
                           {:rf.cofx {:auth/credentials 42}})  ;; int, fails :string
         (catch clojure.lang.ExceptionInfo _))
-      (rf/unregister-listener! :trace ::cf)
       (let [v (first (filter #(= :rf.error/cofx-value-invalid (:operation %))
                              @traces))]
         (is (some? v))
@@ -1581,13 +1549,11 @@
     (rf/reg-event :use-secret
       {:rf.cofx/requires [:secret-blob]}
       (fn [_ _] {}))
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::cb (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       (try
         (rf/dispatch-sync [:use-secret]
                           {:rf.cofx {:secret-blob 99}})  ;; int, fails :string
         (catch clojure.lang.ExceptionInfo _))
-      (rf/unregister-listener! :trace ::cb)
       (let [v (first (filter #(= :rf.error/cofx-value-invalid (:operation %))
                              @traces))]
         (is (some? v))
@@ -1607,15 +1573,13 @@
     (rf/reg-sub :secrets
       {:schema [:vector [:string {:sensitive? true}]]}
       (fn [db _] (:secrets db)))
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::sr (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       (rf/dispatch-sync [:secrets/init])
       ;; First subscribe materialises; well-typed.
       (rf/subscribe-once [:secrets])
       (rf/dispatch-sync [:secrets/break])
       ;; Resubscribe; malformed return — fails.
       (rf/subscribe-once [:secrets])
-      (rf/unregister-listener! :trace ::sr)
       (let [violations (filter #(= :rf.error/schema-validation-failure (:operation %))
                                @traces)]
         (is (pos? (count violations)))
@@ -1647,15 +1611,13 @@
     (rf/reg-sub :token-for
       {:schema [:string {:sensitive? true}]}
       (fn [db [_ token]] (get-in db [:tokens token])))
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::qv (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       (rf/dispatch-sync [:tokens/init])
       ;; Well-typed return on the first call — no validation failure.
       (rf/subscribe-once [:token-for "user-42-token"])
       (rf/dispatch-sync [:tokens/break])
       ;; Malformed return on the second call — fires the sub-return failure.
       (rf/subscribe-once [:token-for "user-42-token"])
-      (rf/unregister-listener! :trace ::qv)
       (let [violations (filter #(= :rf.error/schema-validation-failure (:operation %))
                                @traces)
             v (first violations)]
@@ -1682,13 +1644,11 @@
     (rf/reg-sub :widget
       {:schema :string}                                  ; no :sensitive?
       (fn [db [_ wid]] (get-in db [:widgets wid])))
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::plain (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       (rf/dispatch-sync [:widgets/init])
       (rf/subscribe-once [:widget :w1])
       (rf/dispatch-sync [:widgets/break])
       (rf/subscribe-once [:widget :w1])
-      (rf/unregister-listener! :trace ::plain)
       (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                              @traces))]
         (is (some? v))
@@ -1717,10 +1677,8 @@
             humanizer hook loaded) carries the real :explain-humanized
             payload alongside the raw :explain"
     (rf/reg-app-schema [:auth :token] [:string])
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::hum-plain (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       (schemas/validate-app-schema! {:auth {:token 42}} :auth/init-bad)
-      (rf/unregister-listener! :trace ::hum-plain)
       (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                              @traces))]
         (is (some? v) "a trace fired")
@@ -1739,10 +1697,8 @@
             :rf/redacted. The slot is PRESENT (the sentinel), not
             omitted — symmetric redaction per Spec 010 §Humanize-hook"
     (rf/reg-app-schema [:auth :token] [:string {:sensitive? true}])
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::hum-redact (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       (schemas/validate-app-schema! {:auth {:token 42}} :auth/init-bad)
-      (rf/unregister-listener! :trace ::hum-redact)
       (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                              @traces))]
         (is (some? v) "a trace fired")
@@ -1763,10 +1719,8 @@
       ;; Schema wants an :int; the secret is a string — fails. The value
       ;; itself is the sensitive material that must not surface.
       (rf/reg-app-schema [:auth :token] [:int {:sensitive? true}])
-      (let [traces (atom [])]
-        (rf/register-listener! :trace ::no-leak (fn [ev] (swap! traces conj ev)))
+      (with-trace-recorder! [traces]
         (schemas/validate-app-schema! {:auth {:token secret}} :auth/init-bad)
-        (rf/unregister-listener! :trace ::no-leak)
         (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                                @traces))]
           (is (some? v))
@@ -1786,13 +1740,11 @@
       (rf/reg-sub :secrets
         {:schema [:vector [:string {:sensitive? true}]]}
         (fn [db _] (:secrets db)))
-      (let [traces (atom [])]
-        (rf/register-listener! :trace ::sr-hum (fn [ev] (swap! traces conj ev)))
+      (with-trace-recorder! [traces]
         (rf/dispatch-sync [:secrets/init])
         (rf/subscribe-once [:secrets])          ;; well-typed first pass
         (rf/dispatch-sync [:secrets/break])
         (rf/subscribe-once [:secrets])          ;; malformed return — fails
-        (rf/unregister-listener! :trace ::sr-hum)
         (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                                @traces))]
           (is (some? v) "a sub-return failure fired")
@@ -1813,13 +1765,11 @@
     (rf/reg-sub :widget
       {:schema :string}                                  ;; no :sensitive?
       (fn [db [_ wid]] (get-in db [:widgets wid])))
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::sr-plain (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       (rf/dispatch-sync [:widgets/init])
       (rf/subscribe-once [:widget :w1])
       (rf/dispatch-sync [:widgets/break])
       (rf/subscribe-once [:widget :w1])
-      (rf/unregister-listener! :trace ::sr-plain)
       (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                              @traces))]
         (is (some? v))
@@ -1839,13 +1789,11 @@
     ;; Schema declares the slot BOTH large and sensitive.
     (rf/reg-app-schema [:user :secret-pdf]
                        [:string {:sensitive? true :large? true}])
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::both (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       ;; Value is a long string but is an int (42) here — actually let's
       ;; make it a wrong type to force a validation failure regardless
       ;; of how :large? would behave at runtime.
       (schemas/validate-app-schema! {:user {:secret-pdf 42}} :doc/bad)
-      (rf/unregister-listener! :trace ::both)
       (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                              @traces))]
         (is (some? v))
@@ -1868,11 +1816,9 @@
             redaction substitution) lives behind the
             interop/debug-enabled? gate. Production builds DCE both."
     (rf/reg-app-schema [:auth :token] [:string {:sensitive? true}])
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::prod (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       (with-redefs [re-frame.interop/debug-enabled? false]
         (schemas/validate-app-schema! {:auth {:token 42}} :auth/init-bad))
-      (rf/unregister-listener! :trace ::prod)
       (is (empty? (filter #(= :rf.error/schema-validation-failure (:operation %))
                           @traces))
           "no validation trace fires when debug-enabled? is false — redaction is moot"))))
@@ -1907,23 +1853,21 @@
             redacts via the walker"
     (let [secret  "OPAQUE-COMPILED-SECRET-u9bjgr"
           compiled (m/schema
-                     [:cat [:= :auth/login] [:map [:password {:sensitive? true} :string]]])
-          traces  (atom [])]
-      (rf/register-listener! :trace ::opq (fn [ev] (swap! traces conj ev)))
-      ;; The password value is a VECTOR where a :string is required, so it FAILS
-      ;; the schema; the failing value carries the sentinel.
-      (schemas/validate-event! :auth/login [:auth/login {:password [secret]}]
-                               {:schema compiled})
-      (rf/unregister-listener! :trace ::opq)
-      (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
-                             @traces))]
-        (is (some? v) "a validation-failure trace fired")
-        (is (true? (:sensitive? v)) "fail-closed: top-level :sensitive? stamp")
-        (is (= :rf/redacted (-> v :tags :value)) ":value redacted")
-        (is (= :rf/redacted (-> v :tags :received)) ":received redacted")
-        (is (= :rf/redacted (-> v :tags :explain)) ":explain redacted")
-        (is (not (str/includes? (pr-str v) secret))
-            "the secret survives nowhere in the opaque-schema failure trace")))))
+                     [:cat [:= :auth/login] [:map [:password {:sensitive? true} :string]]])]
+      (with-trace-recorder! [traces]
+        ;; The password value is a VECTOR where a :string is required, so it FAILS
+        ;; the schema; the failing value carries the sentinel.
+        (schemas/validate-event! :auth/login [:auth/login {:password [secret]}]
+                                 {:schema compiled})
+        (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
+                               @traces))]
+          (is (some? v) "a validation-failure trace fired")
+          (is (true? (:sensitive? v)) "fail-closed: top-level :sensitive? stamp")
+          (is (= :rf/redacted (-> v :tags :value)) ":value redacted")
+          (is (= :rf/redacted (-> v :tags :received)) ":received redacted")
+          (is (= :rf/redacted (-> v :tags :explain)) ":explain redacted")
+          (is (not (str/includes? (pr-str v) secret))
+              "the secret survives nowhere in the opaque-schema failure trace"))))))
 
 (deftest app-db-validation-opaque-schema-fails-closed
   (testing "rf2-u9bjgr — a compiled app-db schema with a :sensitive? slot
@@ -1931,11 +1875,9 @@
     (let [secret "OPAQUE-APPDB-SECRET-u9bjgr"]
       (rf/reg-app-schema [:user]
                          (m/schema [:map [:token {:sensitive? true} :string]]))
-      (let [traces (atom [])]
-        (rf/register-listener! :trace ::opqdb (fn [ev] (swap! traces conj ev)))
+      (with-trace-recorder! [traces]
         ;; :token is a VECTOR where a :string is required → fails the schema.
         (schemas/validate-app-schema! {:user {:token [secret]}} :user/bad)
-        (rf/unregister-listener! :trace ::opqdb)
         (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                                @traces))]
           (is (some? v) "a validation-failure trace fired")
@@ -2059,22 +2001,20 @@
             redacted."
     (let [secret        "NESTED-OPAQUE-EVENT-SECRET-hi0tf8"
           nested-opaque (m/schema [:map [:password {:sensitive? true} :string]])
-          schema        [:cat [:= :auth/login] nested-opaque]
-          traces        (atom [])]
-      (rf/register-listener! :trace ::nested-opq-evt (fn [ev] (swap! traces conj ev)))
-      ;; :password is a VECTOR where a :string is required -> fails the schema.
-      (schemas/validate-event! :auth/login [:auth/login {:password [secret]}]
-                               {:schema schema})
-      (rf/unregister-listener! :trace ::nested-opq-evt)
-      (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
-                             @traces))]
-        (is (some? v) "a validation-failure trace fired")
-        (is (true? (:sensitive? v)) "fail-closed: top-level :sensitive? stamp")
-        (is (= :rf/redacted (-> v :tags :value)) ":value redacted")
-        (is (= :rf/redacted (-> v :tags :received)) ":received redacted")
-        (is (= :rf/redacted (-> v :tags :explain)) ":explain redacted")
-        (is (not (str/includes? (pr-str v) secret))
-            "the secret survives nowhere in the nested-opaque event failure trace")))))
+          schema        [:cat [:= :auth/login] nested-opaque]]
+      (with-trace-recorder! [traces]
+        ;; :password is a VECTOR where a :string is required -> fails the schema.
+        (schemas/validate-event! :auth/login [:auth/login {:password [secret]}]
+                                 {:schema schema})
+        (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
+                               @traces))]
+          (is (some? v) "a validation-failure trace fired")
+          (is (true? (:sensitive? v)) "fail-closed: top-level :sensitive? stamp")
+          (is (= :rf/redacted (-> v :tags :value)) ":value redacted")
+          (is (= :rf/redacted (-> v :tags :received)) ":received redacted")
+          (is (= :rf/redacted (-> v :tags :explain)) ":explain redacted")
+          (is (not (str/includes? (pr-str v) secret))
+              "the secret survives nowhere in the nested-opaque event failure trace"))))))
 
 (deftest app-db-validation-nested-opaque-schema-fails-closed
   (testing "rf2-hi0tf8 — a VECTOR-FORM app-db schema (root introspectable)
@@ -2089,12 +2029,10 @@
     (let [secret "NESTED-OPAQUE-APPDB-SECRET-hi0tf8"]
       (rf/reg-app-schema [:token]
                          [:map [:token (m/schema [:string {:sensitive? true}])]])
-      (let [traces (atom [])]
-        (rf/register-listener! :trace ::nested-opq-db (fn [ev] (swap! traces conj ev)))
+      (with-trace-recorder! [traces]
         ;; :token's value is a VECTOR where the nested compiled schema
         ;; requires a :string -> fails exactly at the opaque leaf ([:token]).
         (schemas/validate-app-schema! {:token {:token [secret]}} :token/bad)
-        (rf/unregister-listener! :trace ::nested-opq-db)
         (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                                @traces))]
           (is (some? v) "a validation-failure trace fired")
@@ -2151,58 +2089,52 @@
             :reason :effect provenance (EP-0025 — the commit-plane
             classification default; NOT the removed :frame annotation, NOT the
             retired :reason :schema), with the REQUIRED :hint slot present"
-    (let [blob   (apply str (repeat 200 "X"))
-          traces (atom [])]
-      (rf/register-listener! :trace ::lgm (fn [ev] (swap! traces conj ev)))
-      (schemas/validate-event! :upload/save [:upload/save {:blob blob}]
-                               {:schema [:cat [:= :upload/save]
-                                         [:map [:blob {:large? true} :int]]]})
-      (rf/unregister-listener! :trace ::lgm)
-      (let [v      (first (filter #(= :rf.error/schema-validation-failure (:operation %))
-                                  @traces))
-            marker (-> v :tags :value :rf.size/large-elided)]
-        (is (some? v) "a validation-failure trace fired")
-        (is (map? marker) ":value carries a :rf.size/large-elided marker")
-        (is (= :effect (:reason marker))
-            ":reason :effect — the EP-0025 canonical classification provenance default")
-        (is (contains? marker :hint) ":hint slot present (REQUIRED by the contract)")
-        (is (integer? (:bytes marker)) ":bytes is a byte count")
-        (is (= [:rf.elision/at []] (:handle marker)) ":handle is the fetch handle")
-        (is (true? (-> v :tags :large?)) ":tags :large? stamped")
-        (is (not (str/includes? (pr-str v) blob))
-            "the large blob survives nowhere verbatim in the failure trace")))))
+    (let [blob (apply str (repeat 200 "X"))]
+      (with-trace-recorder! [traces]
+        (schemas/validate-event! :upload/save [:upload/save {:blob blob}]
+                                 {:schema [:cat [:= :upload/save]
+                                           [:map [:blob {:large? true} :int]]]})
+        (let [v      (first (filter #(= :rf.error/schema-validation-failure (:operation %))
+                                    @traces))
+              marker (-> v :tags :value :rf.size/large-elided)]
+          (is (some? v) "a validation-failure trace fired")
+          (is (map? marker) ":value carries a :rf.size/large-elided marker")
+          (is (= :effect (:reason marker))
+              ":reason :effect — the EP-0025 canonical classification provenance default")
+          (is (contains? marker :hint) ":hint slot present (REQUIRED by the contract)")
+          (is (integer? (:bytes marker)) ":bytes is a byte count")
+          (is (= [:rf.elision/at []] (:handle marker)) ":handle is the fetch handle")
+          (is (true? (-> v :tags :large?)) ":tags :large? stamped")
+          (is (not (str/includes? (pr-str v) blob))
+              "the large blob survives nowhere verbatim in the failure trace"))))))
 
 (deftest event-validation-large-slot-elides
   (testing "rf2-vmhu4i — a :large? slot's validation failure elides :value /
             :received / :explain to the size marker rather than shipping the
             raw blob"
-    (let [blob   (apply str (repeat 500 "Z"))
-          traces (atom [])]
-      (rf/register-listener! :trace ::lg (fn [ev] (swap! traces conj ev)))
-      (schemas/validate-event! :upload/save [:upload/save {:blob blob}]
-                               {:schema [:cat [:= :upload/save]
-                                         [:map [:blob {:large? true} :int]]]})
-      (rf/unregister-listener! :trace ::lg)
-      (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
-                             @traces))]
-        (is (some? v))
-        (is (not (contains? v :sensitive?))
-            "a :large?-only failure is NOT stamped sensitive")
-        (doseq [slot [:value :received :explain]]
-          (is (contains? (-> v :tags slot) :rf.size/large-elided)
-              (str slot " elided to the size marker")))
-        (is (not (str/includes? (pr-str v) blob))
-            "the raw blob never rides the trace")))))
+    (let [blob (apply str (repeat 500 "Z"))]
+      (with-trace-recorder! [traces]
+        (schemas/validate-event! :upload/save [:upload/save {:blob blob}]
+                                 {:schema [:cat [:= :upload/save]
+                                           [:map [:blob {:large? true} :int]]]})
+        (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
+                               @traces))]
+          (is (some? v))
+          (is (not (contains? v :sensitive?))
+              "a :large?-only failure is NOT stamped sensitive")
+          (doseq [slot [:value :received :explain]]
+            (is (contains? (-> v :tags slot) :rf.size/large-elided)
+                (str slot " elided to the size marker")))
+          (is (not (str/includes? (pr-str v) blob))
+              "the raw blob never rides the trace"))))))
 
 (deftest app-db-validation-large-slot-elides
   (testing "rf2-vmhu4i — a :large? app-db slot's post-commit validation
             failure elides the value-bearing slots to the size marker"
     (let [blob (apply str (repeat 500 "Y"))]
       (rf/reg-app-schema [:upload] [:map [:blob {:large? true} :int]])
-      (let [traces (atom [])]
-        (rf/register-listener! :trace ::lgdb (fn [ev] (swap! traces conj ev)))
+      (with-trace-recorder! [traces]
         (schemas/validate-app-schema! {:upload {:blob blob}} :upload/bad)
-        (rf/unregister-listener! :trace ::lgdb)
         (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                                @traces))]
           (is (some? v))
@@ -2216,23 +2148,21 @@
   (testing "rf2-vmhu4i / Spec 010 §Composition with `:large?` — a slot carrying
             BOTH :large? and :sensitive? redacts on sensitivity; NO
             :rf.size/large-elided marker is emitted (it would leak :bytes)"
-    (let [secret (apply str (repeat 100 "S"))
-          traces (atom [])]
-      (rf/register-listener! :trace ::ls (fn [ev] (swap! traces conj ev)))
-      (schemas/validate-event! :x [:x {:blob secret}]
-                               {:schema [:cat [:= :x]
-                                         [:map [:blob {:large? true :sensitive? true} :int]]]})
-      (rf/unregister-listener! :trace ::ls)
-      (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
-                             @traces))]
-        (is (some? v))
-        (is (true? (:sensitive? v)) "sensitive stamp wins")
-        (is (= :rf/redacted (-> v :tags :value)) ":value redacted (not a marker)")
-        (is (not (-> v :tags :large?)) "no :large? stamp on a sensitive failure")
-        (is (not (and (map? (-> v :tags :value))
-                      (contains? (-> v :tags :value) :rf.size/large-elided)))
-            "no size marker — would re-leak :bytes")
-        (is (not (str/includes? (pr-str v) secret)))))))
+    (let [secret (apply str (repeat 100 "S"))]
+      (with-trace-recorder! [traces]
+        (schemas/validate-event! :x [:x {:blob secret}]
+                                 {:schema [:cat [:= :x]
+                                           [:map [:blob {:large? true :sensitive? true} :int]]]})
+        (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
+                               @traces))]
+          (is (some? v))
+          (is (true? (:sensitive? v)) "sensitive stamp wins")
+          (is (= :rf/redacted (-> v :tags :value)) ":value redacted (not a marker)")
+          (is (not (-> v :tags :large?)) "no :large? stamp on a sensitive failure")
+          (is (not (and (map? (-> v :tags :value))
+                        (contains? (-> v :tags :value) :rf.size/large-elided)))
+              "no size marker — would re-leak :bytes")
+          (is (not (str/includes? (pr-str v) secret))))))))
 
 (deftest redact-validation-tags-large-slot-elides
   (testing "rf2-vmhu4i — the off-namespace seam elides value-bearing slots for
@@ -2252,11 +2182,9 @@
 (deftest non-large-non-sensitive-rides-verbatim
   (testing "rf2-vmhu4i — a plain (no :large? / :sensitive?) failure rides
             verbatim — the elision is precise, not a blanket marker"
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::plainv (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       (schemas/validate-event! :api/x [:api/x {:n "nope"}]
                                {:schema [:cat [:= :api/x] [:map [:n :int]]]})
-      (rf/unregister-listener! :trace ::plainv)
       (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                              @traces))]
         (is (some? v))

--- a/implementation/schemas/test/re_frame/schemas_storage_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_storage_test.clj
@@ -17,7 +17,8 @@
             [re-frame.schemas :as schemas]
             [re-frame.schemas.storage :as storage]
             [re-frame.schemas.test-fixture :as tf]
-            [re-frame.schemas.validate :as validate]))
+            [re-frame.schemas.validate :as validate]
+            [re-frame.test-support :refer [with-trace-recorder!]]))
 
 (use-fixtures :each tf/reset-runtime)
 
@@ -829,11 +830,8 @@
   swallow throws — a regression that re-introduces the throw fails the
   `:result` assertion loudly."
   [db failing-id frame]
-  (let [traces (atom [])
-        kw     (keyword "ss06u.3" (name (gensym "l")))]
-    (rf/register-listener! :trace kw (fn [ev] (swap! traces conj ev)))
+  (with-trace-recorder! [traces]
     (let [result (validate/validate-app-schema! db failing-id frame)]
-      (rf/unregister-listener! :trace kw)
       {:result result :traces @traces})))
 
 (deftest malformed-schema-no-silent-pass-childless-vector

--- a/implementation/schemas/test/re_frame/schemas_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_test.clj
@@ -60,6 +60,7 @@
             [re-frame.schemas.test-fixture :as tf]
             [re-frame.registrar :as registrar]
             [re-frame.spec :as spec]
+            [re-frame.test-support :refer [with-trace-recorder!]]
             [re-frame.trace :as trace]))
 
 (use-fixtures :each tf/reset-runtime)
@@ -69,13 +70,11 @@
 (deftest app-db-validation-fires-when-debug-enabled
   (testing "validate-app-schema! emits :rf.error/schema-validation-failure when debug-enabled? is true"
     (rf/reg-app-schema [:count] [:int])
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::dev (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       ;; Dev mode is the JVM default; validate-app-schema! should walk the
       ;; registered schemas and emit on a malformed value.
       (with-redefs [interop/debug-enabled? true]
         (schemas/validate-app-schema! {:count "not-an-int"} :test/handler))
-      (rf/unregister-listener! :trace ::dev)
       (let [violations (filter #(= :rf.error/schema-validation-failure
                                    (:operation %))
                                @traces)]
@@ -90,13 +89,11 @@
 (deftest app-db-validation-elides-when-debug-disabled
   (testing "validate-app-schema! is a no-op when debug-enabled? is false (production)"
     (rf/reg-app-schema [:count] [:int])
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::prod (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       ;; Production mode — the validation site elides; even with a
       ;; malformed value, no trace fires.
       (with-redefs [interop/debug-enabled? false]
         (schemas/validate-app-schema! {:count "not-an-int"} :test/handler))
-      (rf/unregister-listener! :trace ::prod)
       (is (empty? (filter #(= :rf.error/schema-validation-failure
                               (:operation %))
                           @traces))
@@ -105,11 +102,9 @@
 (deftest well-typed-value-passes-silently
   (testing "validate-app-schema! with a conforming value emits no trace"
     (rf/reg-app-schema [:count] [:int])
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::ok (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       (with-redefs [interop/debug-enabled? true]
         (schemas/validate-app-schema! {:count 42} :test/handler))
-      (rf/unregister-listener! :trace ::ok)
       (is (empty? (filter #(= :rf.error/schema-validation-failure
                               (:operation %))
                           @traces))
@@ -120,11 +115,9 @@
     (rf/reg-app-schema [:n] [:int])
     (rf/reg-event :n/init (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/reg-event :n/break (fn [{:keys [db]} _] {:db (assoc db :n "boom")}))
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::live (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       (rf/dispatch-sync [:n/init])
       (rf/dispatch-sync [:n/break])
-      (rf/unregister-listener! :trace ::live)
       (let [violations (filter #(= :rf.error/schema-validation-failure
                                    (:operation %))
                                @traces)]
@@ -186,6 +179,10 @@
     (rf/reg-app-schema [:n] [:int])
     (rf/reg-event :n/init  (fn [{:keys [db]} _]  {:db {:n 0}}))
     (rf/reg-event :n/break (fn [{:keys [db]} _] {:db (assoc db :n "boom")}))
+    ;; rf2-bhh8my: deliberately NOT migrated to `with-trace-recorder!` — this
+    ;; listener PROJECTS each event to an `[operation phase]` tuple on capture
+    ;; and `reset!`s the buffer mid-body (to drop :n/init's traces before
+    ;; :n/break), neither of which the raw-event recorder expresses.
     (let [events (atom [])]
       (rf/register-listener! :trace ::ord
         (fn [ev] (when (#{:rf.event/db-changed
@@ -238,13 +235,11 @@
         (fn [{:keys [db]} [_ payload]]
           (swap! calls inc)
           {:db (update db :users (fnil conj []) payload)}))
-      (let [traces (atom [])]
-        (rf/register-listener! :trace ::ev (fn [ev] (swap! traces conj ev)))
+      (with-trace-recorder! [traces]
         ;; Well-typed payload — passes; handler runs.
         (rf/dispatch-sync [:user/register {:email "alice@example.com" :age 30}])
         ;; Malformed payload — fails; handler must NOT run.
         (rf/dispatch-sync [:user/register {:email "carol@example.com" :age "no"}])
-        (rf/unregister-listener! :trace ::ev)
         (is (= 1 @calls)
             "handler ran exactly once — once for the well-typed payload, skipped for the bad one")
         (let [violations (filter #(= :rf.error/schema-validation-failure
@@ -278,11 +273,9 @@
         {:schema [:cat [:= :user/probe] :int]
          :interceptors [::after-probe]}
         (fn [{:keys [db]} _] (swap! handler-calls inc) {:db db}))
-      (let [traces (atom [])]
-        (rf/register-listener! :trace ::after-ev (fn [ev] (swap! traces conj ev)))
+      (with-trace-recorder! [traces]
         ;; Malformed payload — event-vector validation fails pre-handler.
         (rf/dispatch-sync [:user/probe "not-an-int"])
-        (rf/unregister-listener! :trace ::after-ev)
         (is (= 1 (count (filter #(= :rf.error/schema-validation-failure
                                     (:operation %))
                                 @traces)))
@@ -302,11 +295,9 @@
       (rf/reg-event :user/strict
         {:schema [:cat [:= :user/strict] :int]}
         (fn [{:keys [db]} _] (swap! calls inc) {:db db}))
-      (let [traces (atom [])]
-        (rf/register-listener! :trace ::ev2 (fn [ev] (swap! traces conj ev)))
+      (with-trace-recorder! [traces]
         (with-redefs [interop/debug-enabled? false]
           (rf/dispatch-sync [:user/strict "not-an-int"]))
-        (rf/unregister-listener! :trace ::ev2)
         (is (empty? (filter #(= :rf.error/schema-validation-failure
                                 (:operation %))
                             @traces))
@@ -325,15 +316,13 @@
     (rf/reg-sub :items
       {:schema [:vector :string]}
       (fn [db _] (:items db)))
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::sr (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       (rf/dispatch-sync [:items/init])
       ;; Well-typed: sub returns the vec.
       (is (= ["a" "b" "c"] (rf/subscribe-once [:items])))
       (rf/dispatch-sync [:items/break])
       ;; Malformed: sub yields nil per :replaced-with-default recovery.
       (is (nil? (rf/subscribe-once [:items])))
-      (rf/unregister-listener! :trace ::sr)
       (let [violations (filter #(= :rf.error/schema-validation-failure
                                    (:operation %))
                                @traces)]
@@ -357,12 +346,10 @@
     (rf/reg-sub :nums
       {:schema [:vector :int]}
       (fn [db _] (:nums db)))
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::cs (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       (is (= [1 2 3] (#'re-frame.subs/compute-sub [:nums] {:nums [1 2 3]})))
       (is (nil? (#'re-frame.subs/compute-sub [:nums] {:nums ["bad"]}))
           "compute-sub yields nil on validation failure")
-      (rf/unregister-listener! :trace ::cs)
       (let [violations (filter #(= :rf.error/schema-validation-failure
                                    (:operation %))
                                @traces)]
@@ -402,14 +389,12 @@
         (fn [_cofx _]
           (swap! calls inc)
           {:db {:app-version "should-not-stash"}}))
-      (let [traces (atom [])]
-        (rf/register-listener! :trace ::cf (fn [ev] (swap! traces conj ev)))
+      (with-trace-recorder! [traces]
         ;; The recordable-value failure throws out of dispatch-sync (a hard
         ;; error in dev AND prod); the trace fires BEFORE the throw.
         (try
           (rf/dispatch-sync [:cap/seed] {:rf.cofx {:app-version/v 42}})
           (catch clojure.lang.ExceptionInfo _))
-        (rf/unregister-listener! :trace ::cf)
         (is (= 0 @calls)
             "handler was skipped because the recordable cofx :schema failed")
         (let [violations (filter #(= :rf.error/cofx-value-invalid
@@ -435,10 +420,8 @@
         (fn [{:keys [app-version/well]} _]
           (reset! seen-version well)
           {}))
-      (let [traces (atom [])]
-        (rf/register-listener! :trace ::cf2 (fn [ev] (swap! traces conj ev)))
+      (with-trace-recorder! [traces]
         (rf/dispatch-sync [:cap/seed-good] {:rf.cofx {:app-version/well "1.4.5"}})
-        (rf/unregister-listener! :trace ::cf2)
         (is (= "1.4.5" @seen-version)
             "handler ran and saw the well-typed recordable cofx value")
         (is (empty? (filter #(= :rf.error/cofx-value-invalid (:operation %))
@@ -458,13 +441,11 @@
     (rf/reg-event :cap/seed-secret
       {:rf.cofx/requires [:auth/creds]}
       (fn [_ _] {}))
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::cfs (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       (try
         (rf/dispatch-sync [:cap/seed-secret]
                           {:rf.cofx {:auth/creds {:token 42}}})
         (catch clojure.lang.ExceptionInfo _))
-      (rf/unregister-listener! :trace ::cfs)
       (let [v (first (filter #(= :rf.error/cofx-value-invalid (:operation %))
                              @traces))]
         (is (some? v) "the recordable-cofx violation fired")
@@ -495,10 +476,8 @@
           {:fx [[:my/notify {:level "error"          ;; bad: needs keyword
                              :message "boom"}]
                 [:my/log    "anything"]]}))           ;; sibling — must still run
-      (let [traces (atom [])]
-        (rf/register-listener! :trace ::fxv (fn [ev] (swap! traces conj ev)))
+      (with-trace-recorder! [traces]
         (rf/dispatch-sync [:ui/announce])
-        (rf/unregister-listener! :trace ::fxv)
         (is (= 0 @bad-fx-calls)
             "the offending fx handler was skipped — its body did NOT run")
         (is (= 1 @good-fx-calls)
@@ -538,10 +517,8 @@
       (rf/reg-event :user/welcome
         (fn [_ _]
           {:fx [[:my/email {:to "alice@example.com"}]]}))
-      (let [traces (atom [])]
-        (rf/register-listener! :trace ::fxv2 (fn [ev] (swap! traces conj ev)))
+      (with-trace-recorder! [traces]
         (rf/dispatch-sync [:user/welcome])
-        (rf/unregister-listener! :trace ::fxv2)
         (is (= 1 @calls) "fx handler ran exactly once")
         (is (= {:to "alice@example.com"} @seen) "fx handler saw the well-typed args")
         (is (empty? (filter #(= :rf.error/schema-validation-failure
@@ -558,11 +535,9 @@
       (rf/reg-event :strict/trigger
         (fn [_ _]
           {:fx [[:strict/fx {:x "not-an-int"}]]}))
-      (let [traces (atom [])]
-        (rf/register-listener! :trace ::fxv3 (fn [ev] (swap! traces conj ev)))
+      (with-trace-recorder! [traces]
         (with-redefs [interop/debug-enabled? false]
           (rf/dispatch-sync [:strict/trigger]))
-        (rf/unregister-listener! :trace ::fxv3)
         (is (empty? (filter #(= :rf.error/schema-validation-failure
                                 (:operation %))
                             @traces))
@@ -573,8 +548,7 @@
 (deftest fx-args-validation-direct-call-shape
   (testing "validate-fx! returns true on pass, false on fail; emits the canonical
             :where :fx-args trace with the locked tag shape"
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::fxv4 (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       ;; Direct call — exercises the validate-fx! fn itself, not the integration.
       (is (true? (schemas/validate-fx! :my/fx :ev/origin {:x 1} {:schema [:map [:x :int]]}))
           "well-typed args pass")
@@ -582,7 +556,6 @@
           "malformed args fail")
       (is (true? (schemas/validate-fx! :my/fx :ev/origin {:x 1} {}))
           "no :schema → soft pass")
-      (rf/unregister-listener! :trace ::fxv4)
       (let [violations (filter #(= :rf.error/schema-validation-failure
                                    (:operation %))
                                @traces)]
@@ -637,14 +610,12 @@
     (rf/reg-event :probe/cofx-seed
       {:rf.cofx/requires [:probe/cofx]}
       (fn [_ _] {}))
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::cf-frame (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       (try
         (rf/dispatch-sync [:probe/cofx-seed]
                           {:frame :test/cofx-frame
                            :rf.cofx {:probe/cofx 42}})   ;; int, not string
         (catch clojure.lang.ExceptionInfo _))
-      (rf/unregister-listener! :trace ::cf-frame)
       (let [v (first (filter #(= :rf.error/cofx-value-invalid (:operation %))
                              @traces))]
         (is (some? v) "the recordable-cofx violation fired")
@@ -660,10 +631,8 @@
       (fn [_ctx _args] nil))
     (rf/reg-event :probe/fx-seed
       (fn [_ _] {:fx [[:probe/fx {:x "bad"}]]}))   ;; string, not int
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::fx-frame (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       (rf/dispatch-sync [:probe/fx-seed] {:frame :test/fx-frame})
-      (rf/unregister-listener! :trace ::fx-frame)
       (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                              @traces))]
         (is (some? v) "the fx-args violation fired")
@@ -679,13 +648,11 @@
     (rf/reg-sub :probe/items
       {:schema [:vector :string]}
       (fn [db _] (:items db)))
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::sr-frame (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       (rf/dispatch-sync [:probe/sub-break] {:frame :test/sub-frame})
       ;; Subscribe within the named frame so the reaction recomputes there.
       (is (nil? (rf/subscribe-once [:probe/items] {:frame :test/sub-frame}))
           "malformed sub yields nil per :replaced-with-default recovery")
-      (rf/unregister-listener! :trace ::sr-frame)
       (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                              @traces))]
         (is (some? v) "the sub-return violation fired")
@@ -707,8 +674,7 @@
   (testing "rf2-rbbmt — validate-event! returns true on pass, false on
             fail, true on the no-:schema soft-pass arm; emits the
             canonical :where :event trace with the locked tag shape"
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::evd (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       (is (true? (schemas/validate-event! :user/strict [:user/strict 7]
                                           {:schema [:cat [:= :user/strict] :int]}))
           "well-typed event vector passes")
@@ -717,7 +683,6 @@
           "malformed event vector fails")
       (is (true? (schemas/validate-event! :user/strict [:user/strict "bad"] {}))
           "no :schema on meta → soft pass (validate.cljc:250 true arm)")
-      (rf/unregister-listener! :trace ::evd)
       (let [violations (filter #(= :rf.error/schema-validation-failure
                                    (:operation %))
                                @traces)]
@@ -743,8 +708,7 @@
   (testing "rf2-rbbmt — validate-sub! returns true on pass, false on
             fail, true on the no-:schema soft-pass arm; emits the
             canonical :where :sub-return trace with the locked tag shape"
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::sbd (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       (is (true? (schemas/validate-sub! :items [:items] ["a" "b"]
                                         {:schema [:vector :string]}))
           "well-typed sub return passes")
@@ -753,7 +717,6 @@
           "malformed sub return fails")
       (is (true? (schemas/validate-sub! :items [:items] [1 2] {}))
           "no :schema on meta → soft pass (validate.cljc:250 true arm)")
-      (rf/unregister-listener! :trace ::sbd)
       (let [violations (filter #(= :rf.error/schema-validation-failure
                                    (:operation %))
                                @traces)]
@@ -779,14 +742,12 @@
 (deftest sub-return-validation-elides-when-debug-disabled
   (testing "rf2-rbbmt — validate-sub! is a no-op (returns true, emits
             nothing) when debug-enabled? is false (production)"
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::sbe (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       (with-redefs [interop/debug-enabled? false]
         (is (true? (schemas/validate-sub! :items [:items] [1 2]
                                           {:schema [:vector :string]}))
             "production gate returns true unconditionally — even on a
              value that would fail in dev"))
-      (rf/unregister-listener! :trace ::sbe)
       (is (empty? (filter #(= :rf.error/schema-validation-failure
                               (:operation %))
                           @traces))
@@ -798,8 +759,7 @@
             redaction it scrubs `:value`/`:received`/`:explain`/`:rf.fx/args`
             and stamps `:sensitive? true`. Per rf2-4fbsd the earlier
             `:malli-error` duplicate slot is gone."
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::fxv5 (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       ;; Sensitivity is now path-marked on the schema slot (the handler/
       ;; fx-meta `:sensitive?` annotation has been removed); a `:sensitive?
       ;; true` prop on the failing slot's schema drives redaction.
@@ -807,7 +767,6 @@
                                         :ev/origin
                                         {:token 42}
                                         {:schema [:map [:token {:sensitive? true} :string]]})))
-      (rf/unregister-listener! :trace ::fxv5)
       (let [violations (filter #(= :rf.error/schema-validation-failure
                                    (:operation %))
                                @traces)]
@@ -984,10 +943,8 @@
     ;; Schema only on :test/other; commit happens on :test/main.
     (rf/reg-app-schema [:n] {:frame :test/other} [:int])
     (rf/reg-event :n/break-on-main (fn [{:keys [db]} _] {:db (assoc db :n "not-an-int")}))
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::sib (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       (rf/dispatch-sync [:n/break-on-main] {:frame :test/main})
-      (rf/unregister-listener! :trace ::sib)
       (is (empty? (filter #(= :rf.error/schema-validation-failure (:operation %))
                           @traces))
           "no schema fires on :test/main because the schema lives on :test/other"))))
@@ -998,10 +955,8 @@
     (rf/reg-frame :test/main {})
     (rf/reg-app-schema [:n] {:frame :test/main} [:int])
     (rf/reg-event :n/break (fn [{:keys [db]} _] {:db (assoc db :n "not-an-int")}))
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::same (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       (rf/dispatch-sync [:n/break] {:frame :test/main})
-      (rf/unregister-listener! :trace ::same)
       (let [violations (filter #(= :rf.error/schema-validation-failure (:operation %))
                                @traces)]
         (is (= 1 (count violations))
@@ -1122,12 +1077,10 @@
             set-schema-validator! get the same behaviour they had
             before the seam landed."
     (rf/reg-app-schema [:n] [:int])
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::default-malli (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       ;; Malformed value triggers the default Malli validate to return
       ;; falsey -> trace fires.
       (schemas/validate-app-schema! {:n "not-an-int"} :test/handler)
-      (rf/unregister-listener! :trace ::default-malli)
       (let [violations (filter #(= :rf.error/schema-validation-failure (:operation %))
                                @traces)]
         (is (= 1 (count violations))
@@ -1146,11 +1099,9 @@
                    (not (and (string? value) (str/includes? value "bad"))))]
       (schemas/set-schema-validator! custom)
       (rf/reg-app-schema [:label] :string)
-      (let [traces (atom [])]
-        (rf/register-listener! :trace ::custom (fn [ev] (swap! traces conj ev)))
+      (with-trace-recorder! [traces]
         (schemas/validate-app-schema! {:label "hello"} :h/ok)        ;; passes
         (schemas/validate-app-schema! {:label "totally-bad"} :h/no)  ;; fails
-        (rf/unregister-listener! :trace ::custom)
         (is (= 2 (count @calls))
             "custom validator was invoked for both validation calls")
         (let [violations (filter #(= :rf.error/schema-validation-failure (:operation %))
@@ -1167,8 +1118,7 @@
             trace fires. Parameterised over the surfaces that previously
             duplicated the no-op assertion as separate deftests."
     (schemas/set-schema-validator! nil)
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::nilv (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       (rf/reg-app-schema [:n] [:int])
       ;; Each malformed value would fire a trace under the default
       ;; (Malli) validator; with nil installed every call short-circuits
@@ -1182,7 +1132,6 @@
           "sub-return: nil validator → true")
       (is (true? (schemas/validate-fx! :fx/x :ev/o {:x "bad"} {:schema [:map [:x :int]]}))
           "fx-args: nil validator → true")
-      (rf/unregister-listener! :trace ::nilv)
       (is (empty? (filter #(= :rf.error/schema-validation-failure (:operation %))
                           @traces))
           "nil validator: no validation, no trace, no surprise — on any surface"))))
@@ -1197,10 +1146,8 @@
       (rf/reg-event :user/strict
         {:schema [:cat [:= :user/strict] :int]}
         (fn [{:keys [db]} _] (swap! calls inc) {:db db}))
-      (let [traces (atom [])]
-        (rf/register-listener! :trace ::nile (fn [ev] (swap! traces conj ev)))
+      (with-trace-recorder! [traces]
         (rf/dispatch-sync [:user/strict "not-an-int"])
-        (rf/unregister-listener! :trace ::nile)
         (is (= 1 @calls)
             "handler ran — nil validator means no pre-handler check")
         (is (empty? (filter #(= :rf.error/schema-validation-failure (:operation %))
@@ -1218,11 +1165,9 @@
           e-fn (fn [s v]  (swap! explain-calls inc) {:my-explanation [s v]})]
       (schemas/set-schema-fns! {:validate v-fn :explain e-fn})
       (rf/reg-app-schema [:k] :keyword)
-      (let [traces (atom [])]
-        (rf/register-listener! :trace ::map (fn [ev] (swap! traces conj ev)))
+      (with-trace-recorder! [traces]
         (schemas/validate-app-schema! {:k :good}   :h/pass)
         (schemas/validate-app-schema! {:k :nope}   :h/fail)
-        (rf/unregister-listener! :trace ::map)
         (is (= 2 @validate-calls) "custom validate fn ran for both calls")
         (is (= 1 @explain-calls)  "custom explain fn ran only on the failure path")
         (let [violations (filter #(= :rf.error/schema-validation-failure (:operation %))
@@ -1272,10 +1217,8 @@
       ;; substituted.
       (schemas/set-schema-explainer! custom-e)
       (rf/reg-app-schema [:n] [:int])
-      (let [traces (atom [])]
-        (rf/register-listener! :trace ::eonly (fn [ev] (swap! traces conj ev)))
+      (with-trace-recorder! [traces]
         (schemas/validate-app-schema! {:n "broken"} :h/oops)
-        (rf/unregister-listener! :trace ::eonly)
         (is (= "broken" @explained) "custom explainer ran with the bad value")
         (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                                @traces))]
@@ -1299,8 +1242,7 @@
     (schemas/set-schema-validator! (fn [_ _] false))
     (schemas/set-schema-explainer! nil)
     (rf/reg-app-schema [:n] [:int])
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::nilexp (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       ;; app-db walk emit site.
       (is (false? (schemas/validate-app-schema! {:n "bad"} :h/app-db)))
       ;; the three meta-bearing emit sites (run-validation core).
@@ -1310,7 +1252,6 @@
                                          {:schema [:vector :string]})))
       (is (false? (schemas/validate-fx! :fx/x :ev/o {:x "bad"}
                                         {:schema [:map [:x :int]]})))
-      (rf/unregister-listener! :trace ::nilexp)
       (let [violations (filter #(= :rf.error/schema-validation-failure
                                    (:operation %))
                                @traces)]
@@ -1332,19 +1273,15 @@
     (schemas/set-schema-validator! (fn [_ _] true))
     (rf/reg-app-schema [:n] [:int])
     ;; First confirm the sabotage is in effect.
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::sab (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       (schemas/validate-app-schema! {:n "bad"} :h/sabotage)
-      (rf/unregister-listener! :trace ::sab)
       (is (empty? (filter #(= :rf.error/schema-validation-failure (:operation %))
                           @traces))
           "sabotage validator passes everything — no trace"))
     ;; Reset back to default Malli, retry the bad value, expect a trace.
     (schemas/reset-schema-validator!)
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::rst (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       (schemas/validate-app-schema! {:n "bad"} :h/back-to-default)
-      (rf/unregister-listener! :trace ::rst)
       (is (= 1 (count (filter #(= :rf.error/schema-validation-failure (:operation %))
                               @traces)))
           "default Malli validator is back in place — bad value catches"))))
@@ -1571,8 +1508,7 @@
         (fn [_ [_ payload]]
           (swap! calls inc)
           {:db {:last-response payload}}))
-      (let [traces (atom [])]
-        (rf/register-listener! :trace ::ok (fn [ev] (swap! traces conj ev)))
+      (with-trace-recorder! [traces]
         ;; Production build path — flip the boundary's gate without
         ;; killing the trace surface. The router's step-1
         ;; validation also fires (debug-enabled? still true on JVM)
@@ -1581,7 +1517,6 @@
         ;; passes silently.
         (with-redefs [spec/dev-mode? (constantly false)]
           (rf/dispatch-sync [:api/response {:status 200 :body "OK"}]))
-        (rf/unregister-listener! :trace ::ok)
         (is (= 1 @calls)
             "handler ran exactly once for the well-typed payload")
         (is (empty? (filter #(= :rf.error/schema-validation-failure (:operation %))
@@ -1627,15 +1562,13 @@
       {:schema [:cat [:= :api/strict] :int]
        :interceptors [:rf.schema/at-boundary]}
       (fn [_ _] {}))
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::tr (fn [ev] (swap! traces conj ev)))
+    (with-trace-recorder! [traces]
       ;; dev-mode? false → boundary takes its prod branch; but
       ;; debug-enabled? stays true on the JVM so emit-error! actually
       ;; fires its body and the trace is observable.
       (with-redefs [spec/dev-mode? (constantly false)]
         (let [before (:before rf/validate-at-boundary-interceptor)]
           (before {:coeffects {:event [:api/strict "not-an-int"]}})))
-      (rf/unregister-listener! :trace ::tr)
       (let [violations (filter #(= :rf.error/schema-validation-failure (:operation %))
                                @traces)]
         (is (= 1 (count violations))
@@ -1734,11 +1667,9 @@
         {:schema [:cat [:= :api/disabled] :int]
          :interceptors [:rf.schema/at-boundary]}
         (fn [_ _] (swap! calls inc) {}))
-      (let [traces (atom [])]
-        (rf/register-listener! :trace ::nil (fn [ev] (swap! traces conj ev)))
+      (with-trace-recorder! [traces]
         (with-redefs [spec/dev-mode? (constantly false)]
           (rf/dispatch-sync [:api/disabled "wildly-malformed"]))
-        (rf/unregister-listener! :trace ::nil)
         (is (= 1 @calls)
             "handler ran — nil validator means no boundary check")
         (is (empty? (filter #(and (= :rf.error/schema-validation-failure (:operation %))
@@ -1756,13 +1687,11 @@
         {:schema [:cat [:= :api/dev] :int]
          :interceptors [:rf.schema/at-boundary]}
         (fn [_ _] (swap! calls inc) {}))
-      (let [traces (atom [])]
-        (rf/register-listener! :trace ::dev (fn [ev] (swap! traces conj ev)))
+      (with-trace-recorder! [traces]
         ;; Dev mode (the JVM default). The router's step-1
         ;; validate-event! call fires for the malformed payload; the
         ;; boundary interceptor SHOULD NOT fire a second trace.
         (rf/dispatch-sync [:api/dev "not-an-int"])
-        (rf/unregister-listener! :trace ::dev)
         (is (= 0 @calls)
             "handler skipped — but by the dev-mode step-1 path, not the boundary")
         (let [boundary-violations (filter #(and (= :rf.error/schema-validation-failure (:operation %))
@@ -1896,11 +1825,9 @@
 
       ;; 4. Semantic faithfulness: validation against a restored
       ;;    schema fires exactly like it did before the round-trip.
-      (let [traces (atom [])]
-        (rf/register-listener! :trace ::rt (fn [ev] (swap! traces conj ev)))
+      (with-trace-recorder! [traces]
         ;; A malformed value under [:n] on :rf/default — should fire.
         (schemas/validate-app-schema! {:n "not-an-int"} :test.6lka/handler)
-        (rf/unregister-listener! :trace ::rt)
         (let [violations (filter #(= :rf.error/schema-validation-failure
                                      (:operation %))
                                  @traces)]

--- a/implementation/schemas/test/re_frame/schemas_validator_unavailable_warning_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_validator_unavailable_warning_test.clj
@@ -29,16 +29,10 @@
             [re-frame.late-bind :as late-bind]
             [re-frame.schemas :as schemas]
             [re-frame.schemas.test-fixture :as tf]
+            [re-frame.test-support :refer [with-trace-recorder!]]
             [re-frame.trace :as trace]))
 
 (use-fixtures :each tf/reset-runtime)
-
-(defn- record-traces!
-  "Attach a recording listener and return its atom."
-  [listener-id]
-  (let [a (atom [])]
-    (rf/register-listener! :trace listener-id (fn [ev] (swap! a conj ev)))
-    a))
 
 (defn- warnings-of
   "Filter the recorded events to the given operation keyword."
@@ -69,7 +63,7 @@
 (deftest warning-fires-when-hook-unbound-and-default-validator
   (testing "reg-app-schema with no Malli adapter loaded and the default
             validator still installed emits the warning exactly once"
-    (let [recorded (record-traces! ::unbound+default)]
+    (with-trace-recorder! [recorded]
       (with-unbound-malli-validate
         (fn []
           (rf/reg-app-schema [:user] [:map [:id :int]])))
@@ -81,7 +75,7 @@
 (deftest warning-fires-once-across-multiple-reg-app-schema-calls
   (testing "subsequent reg-app-schema calls within the same process do NOT
             re-emit the warning (process-lifecycle one-shot)"
-    (let [recorded (record-traces! ::dedup-rereg)]
+    (with-trace-recorder! [recorded]
       (with-unbound-malli-validate
         (fn []
           (rf/reg-app-schema [:user]    [:map [:id :int]])
@@ -95,7 +89,7 @@
   (testing "bulk reg-app-schemas registers many entries; the warning still
             fires once across all entries (each delegates to reg-app-schema
             but the warn-once cache dedupes)"
-    (let [recorded (record-traces! ::bulk)]
+    (with-trace-recorder! [recorded]
       (with-unbound-malli-validate
         (fn []
           (rf/reg-app-schemas {[:user]    [:map [:id :int]]
@@ -107,7 +101,7 @@
 (deftest warning-carries-actionable-reason
   (testing ":tags includes a :reason string that names the two fixes
             (require the Malli adapter ns OR install a custom validator)"
-    (let [recorded (record-traces! ::reason)]
+    (with-trace-recorder! [recorded]
       (with-unbound-malli-validate
         (fn [] (rf/reg-app-schema [:user] [:map])))
       (let [warns (warnings-of recorded
@@ -124,7 +118,7 @@
 (deftest warning-suppressed-when-explicit-validator-installed
   (testing "an app that called set-schema-validator! with a non-default fn
             has explicitly opted out of Malli — no warning fires"
-    (let [recorded (record-traces! ::opt-out)]
+    (with-trace-recorder! [recorded]
       (with-unbound-malli-validate
         (fn []
           (schemas/set-schema-validator! (fn [_schema _value] true))
@@ -137,7 +131,7 @@
   (testing "set-schema-fns! with a {:validate ...} bundle also counts as
             'explicit opt-out' — non-default validator-fn after the swap
             (rf2-13meg)"
-    (let [recorded (record-traces! ::opt-out-bundle)]
+    (with-trace-recorder! [recorded]
       (with-unbound-malli-validate
         (fn []
           (schemas/set-schema-fns! {:validate (fn [_ _] true)})
@@ -150,22 +144,22 @@
 (deftest warning-suppressed-when-malli-validate-hook-bound
   (testing "with the Malli adapter loaded (`:schemas/malli-validate`
             is bound) the validation hot path runs — no warning"
-    (let [recorded (record-traces! ::malli-loaded)
-          prior    (late-bind/get-fn :schemas/malli-validate)]
-      (late-bind/set-fn! :schemas/malli-validate (fn [_ _] true))
-      (try
-        (rf/reg-app-schema [:user] [:map])
-        (finally
-          ;; Restore the slot for sibling tests — the fixture restores the
-          ;; validator-fn but NOT the process-global late-bind hook table.
-          ;; Mirrors `with-unbound-malli-validate`'s prior-capture/restore so
-          ;; this stub does not leak a trivially-true validator process-wide
-          ;; (rf2-hydpaf).
-          (when prior
-            (late-bind/set-fn! :schemas/malli-validate prior))))
-      (is (empty? (warnings-of recorded
-                               :rf.warning/schema-validator-unavailable))
-          ":schemas/malli-validate bound -> warning suppressed"))))
+    (with-trace-recorder! [recorded]
+      (let [prior (late-bind/get-fn :schemas/malli-validate)]
+        (late-bind/set-fn! :schemas/malli-validate (fn [_ _] true))
+        (try
+          (rf/reg-app-schema [:user] [:map])
+          (finally
+            ;; Restore the slot for sibling tests — the fixture restores the
+            ;; validator-fn but NOT the process-global late-bind hook table.
+            ;; Mirrors `with-unbound-malli-validate`'s prior-capture/restore so
+            ;; this stub does not leak a trivially-true validator process-wide
+            ;; (rf2-hydpaf).
+            (when prior
+              (late-bind/set-fn! :schemas/malli-validate prior))))
+        (is (empty? (warnings-of recorded
+                                 :rf.warning/schema-validator-unavailable))
+            ":schemas/malli-validate bound -> warning suppressed")))))
 
 ;; ---- cache-clear semantics ------------------------------------------------
 
@@ -173,7 +167,7 @@
   (testing "clear-validator-unavailable-warned! resets the one-shot so a
             subsequent reg-app-schema fires the warning anew (test-fixture
             isolation)"
-    (let [recorded (record-traces! ::clear-cache)]
+    (with-trace-recorder! [recorded]
       (with-unbound-malli-validate
         (fn []
           (rf/reg-app-schema [:first] [:map])

--- a/implementation/schemas/test/re_frame/schemas_walker_opaque_warning_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_walker_opaque_warning_test.clj
@@ -26,16 +26,10 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.schemas :as schemas]
-            [re-frame.schemas.test-fixture :as tf]))
+            [re-frame.schemas.test-fixture :as tf]
+            [re-frame.test-support :refer [with-trace-recorder!]]))
 
 (use-fixtures :each tf/reset-runtime)
-
-(defn- record-traces!
-  "Attach a recording listener and return its atom."
-  [listener-id]
-  (let [a (atom [])]
-    (rf/register-listener! :trace listener-id (fn [ev] (swap! a conj ev)))
-    a))
 
 (defn- warnings-of
   "Filter the recorded events to the given operation keyword."
@@ -55,7 +49,7 @@
 (deftest warning-fires-when-schema-is-compiled-map-object
   (testing "reg-app-schema with a compiled m/schema-like map value
             (opaque to the walker) emits the warning exactly once"
-    (let [recorded (record-traces! ::compiled-map)]
+    (with-trace-recorder! [recorded]
       (rf/reg-app-schema [:cart] {:malli/schema :some-compiled-form})
       (let [warns (warnings-of recorded :rf.warning/schema-walker-opaque)]
         (is (= 1 (count warns))
@@ -67,7 +61,7 @@
   (testing "subsequent reg-app-schema calls with opaque (compiled-map)
             schemas within the same process do NOT re-emit the warning
             (process-lifecycle one-shot)"
-    (let [recorded (record-traces! ::dedup-rereg)]
+    (with-trace-recorder! [recorded]
       (rf/reg-app-schema [:a] {:malli/schema :a})
       (rf/reg-app-schema [:b] {:malli/schema :b})
       (rf/reg-app-schema [:c] {:malli/schema :c})
@@ -78,7 +72,7 @@
 (deftest warning-fires-once-from-reg-app-schemas-bulk
   (testing "bulk reg-app-schemas with opaque schemas fires the warning
             once across all entries"
-    (let [recorded (record-traces! ::bulk)]
+    (with-trace-recorder! [recorded]
       (rf/reg-app-schemas {[:user]    {:malli/schema :user}
                            [:cart]    {:malli/schema :cart}
                            [:session] {:malli/schema :session}})
@@ -89,7 +83,7 @@
   (testing "rf2-k0ew8n — :tags includes a :reason string that names the
             ONE supported shape (register the vector form) and does NOT
             recommend the REMOVED registration-meta `:sensitive?` fallback"
-    (let [recorded (record-traces! ::reason)]
+    (with-trace-recorder! [recorded]
       (rf/reg-app-schema [:user] {:malli/schema :user})
       (let [warns  (warnings-of recorded :rf.warning/schema-walker-opaque)
             tags   (-> warns first :tags)
@@ -114,7 +108,7 @@
             that embeds a compiled m/schema value as a NESTED child (a
             :map slot's tail) also emits the warning; the root-only
             `schema-opaque?` check used to miss this and stay silent"
-    (let [recorded (record-traces! ::nested-opaque-child)]
+    (with-trace-recorder! [recorded]
       (rf/reg-app-schema [:token]
                          [:map [:secret {} {:malli/schema :compiled}]])
       (let [warns (warnings-of recorded :rf.warning/schema-walker-opaque)]
@@ -127,7 +121,7 @@
 (deftest warning-suppressed-when-schema-is-vector-form
   (testing "reg-app-schema with a vector-form Malli schema (introspectable)
             does NOT emit the warning"
-    (let [recorded (record-traces! ::vector-form)]
+    (with-trace-recorder! [recorded]
       (rf/reg-app-schema [:user] [:map [:id :int] [:name :string]])
       (is (empty? (warnings-of recorded :rf.warning/schema-walker-opaque))
           "vector-form schema -> no warning"))))
@@ -137,7 +131,7 @@
             / `:boolean` / `:any`) are valid Malli schemas that cannot
             carry per-slot props; the walker provably skips nothing, so
             registering one does NOT emit the false-positive warning"
-    (let [recorded (record-traces! ::primitive-kw)]
+    (with-trace-recorder! [recorded]
       (rf/reg-app-schema [:age]    :int)
       (rf/reg-app-schema [:name]   :string)
       (rf/reg-app-schema [:active] :boolean)
@@ -153,7 +147,7 @@
             keyword case is suppressed entirely. The advanced registry-
             ref-hides-per-slot-flags shape is covered by the walker
             docstring's discoverability caveat (rf2-yaioz)"
-    (let [recorded (record-traces! ::registry-ref)]
+    (with-trace-recorder! [recorded]
       (rf/reg-app-schema [:user] :my/user-schema)
       (is (empty? (warnings-of recorded :rf.warning/schema-walker-opaque))
           "registry-ref keyword schema -> no warning"))))
@@ -164,7 +158,7 @@
   (testing "clear-walker-opaque-warned! resets the one-shot so a
             subsequent reg-app-schema fires the warning anew (test-fixture
             isolation)"
-    (let [recorded (record-traces! ::clear-cache)]
+    (with-trace-recorder! [recorded]
       (rf/reg-app-schema [:first] {:malli/schema :first})
       (is (= 1 (count (warnings-of recorded
                                    :rf.warning/schema-walker-opaque))))


### PR DESCRIPTION
Replaces the hand-rolled trace-capture boilerplate across the `implementation/schemas` test tree with `re-frame.test-support/with-trace-recorder!` — the shared recorder that supplies register-on-entry + exception-safe unregister-in-`finally` cleanup and folds the per-file collect/record/capture helpers into one bracket.

## Preflight (premise confirmed)
The bead's premise held: the schemas tests carried ~97 direct trace-listener registrations plus several local capture helpers rebuilding the `atom`/register/unregister-or-clear bracket. The macro supersedes all of them.

- **96 direct registrations migrated** to `with-trace-recorder!`.
- **1 registration deliberately left as-is** — `schemas_test` `::ord` — because its listener projects each event to an `[operation phase]` tuple on capture *and* `reset!`s the buffer mid-body between two dispatches; the raw-event recorder cannot express either. Documented inline.
- **4 pure-capture helpers deleted** (call sites converted to the macro): `record-traces!` in implies-validation / validator-unavailable / walker-opaque, and `collect-traces` in conformance.
- **5 body-fn capture helpers reimplemented on the shared recorder** (helper + all call sites + read-time predicates/shapes preserved): `capture` (fail-open), `capture` (reg-side-effects), `capture-trace` (failure-paths), `malformed-trace` (storage), `app-db-failure-trace` (sensitive).
- **conformance `run-fixture`** now brackets the fixture run with the recorder, dropping the happy-path-only `clear-listeners!` — the listener now unwinds in the macro's `finally` even when a fixture throws (`storage`'s helper likewise gains exception-safety it lacked).
- Dropped the now-unused `re-frame.trace.tooling` requires from the two CLJS files; added `:require-macros` / `:refer` imports for the macro. No production source touched.

Assertions, predicates, capture shapes, keys, and registration timing are unchanged — only the register/unregister brackets moved to the shared macro.

## Quality gates
- `cd implementation/schemas && clojure -M:test` → **341 tests, 18950 assertions, 0 failures, 0 errors**.
- `cd implementation && npm run test:cljs` → **8462 tests, 39065 assertions, 0 failures, 0 errors**.
- `shadow-cljs release browser-test-schemas-boundary-prod` (`:advanced` + `goog.DEBUG=false`) → **Build completed, 0 warnings** — confirms the macro + `:require-macros` compile under the production elision build (the sole Closure note is a pre-existing `@seen` JSDoc tag in `test_support.cljc`, unrelated).

## Stance
Pre-alpha, no back-compat shims; ELEGANCE + CLARITY + CORRECTNESS + GOOD-PRACTICE. Net −204 lines of capture boilerplate.
