### PR TITLE
fix(machines-viz): one definition-shape validator across AI/Mermaid/SCXML emitters (rf2-egupfk)

### DIFF
--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/ai_generate.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/ai_generate.cljc
@@ -56,6 +56,11 @@
   Per [`API.md`](../../spec/API.md) §AI-generate-a-machine."
   (:require [clojure.string :as str]
             [re-frame.error :as error]
+            ;; rf2-egupfk — the SHARED definition-shape validators + value-free
+            ;; summary (`valid-definition?` / `parallel-definition?` /
+            ;; `definition-summary`) + the EP-0029 desugar seam, so this emitter
+            ;; accepts EXACTLY the shapes the Mermaid + SCXML emitters do.
+            [day8.re-frame2-machines-viz.grammar :as g]
             #?(:clj  [clojure.edn :as edn]
                :cljs [cljs.reader :as edn])))
 
@@ -74,16 +79,10 @@
     {:type (cond (nil? s) :nil (keyword? s) :keyword (map? s) :map
                  (vector? s) :vector (sequential? s) :seq :else :value)}))
 
-(defn- spec-summary
-  "Value-FREE diagnostic for a parsed (but invalid) machine `spec`: the
-  type tag plus, for a map, the top-level key SET — never the values (a
-  parsed spec can embed LLM-returned strings / `:data` runtime values)."
-  [spec]
-  (cond
-    (map? spec)     {:type :map :keys (vec (sort-by str (keys spec)))}
-    (vector? spec)  {:type :vector :count (count spec)}
-    (nil? spec)     {:type :nil}
-    :else           {:type :value}))
+;; rf2-egupfk — the parsed-spec summary is the SHARED
+;; `grammar/definition-summary` (value-free structural facts only), so the AI
+;; emitter's invalid-spec diagnostic matches Mermaid + SCXML. Stashed under this
+;; surface's `:spec-summary` ex-data key.
 
 ;; ---------------------------------------------------------------------------
 ;; System prompt
@@ -181,41 +180,33 @@
 ;; either {:initial K :states {non-empty}} or {:type :parallel
 ;; :regions {non-empty maps each with :initial + :states}}.
 ;;
-;; We deliberately don't validate beyond that — the LLM may emit
-;; perfectly-valid machine shapes the substrate hasn't formally
-;; described. Letting through "anything reg-machine accepts" matches
-;; the framework's "regularity over cleverness" posture better than
-;; coercing to a narrower subset.
+;; rf2-egupfk — the shape check itself is the SHARED
+;; `grammar/valid-definition?` so this emitter accepts EXACTLY what Mermaid +
+;; SCXML do (keyword `:initial`, well-formed parallel regions). We desugar
+;; (`grammar/desugar-grammar`) first, exactly as the other two emitters do, so
+;; a `:timeout` / `:choice` authoring form validates on its lowered shape. We
+;; keep only the AI-surface reason strings (embedded in the thrown message) and
+;; return the ORIGINAL authored spec (the runtime desugars again at
+;; registration, so the author's `:timeout` / `:choice` intent is preserved).
 
-(defn- valid-state-tree? [{:keys [initial states]}]
-  (and (keyword? initial)
-       (map? states)
-       (seq states)))
-
-(defn- valid-parallel? [{:keys [regions] :as spec}]
-  (and (= :parallel (:type spec))
-       (map? regions)
-       (seq regions)
-       (every? valid-state-tree? (vals regions))))
-
-(defn- validate-spec
-  "Return `[:ok spec]` if `spec` is a recognised machine shape,
-  otherwise `[:err reason]`."
-  [spec]
+(defn- validate-definition
+  "Return `[:ok]` if the (desugared) `definition` is a recognised machine
+  shape, otherwise `[:err reason]` carrying an AI-surface reason string."
+  [definition]
   (cond
-    (not (map? spec))
+    (not (map? definition))
     [:err "spec must be a map"]
 
-    (= :parallel (:type spec))
-    (if (valid-parallel? spec)
-      [:ok spec]
-      [:err "parallel spec must carry non-empty :regions; each region must carry :initial + non-empty :states"])
+    (g/parallel-definition? definition)
+    (if (g/valid-definition? definition)
+      [:ok]
+      [:err "parallel spec must carry a non-empty :regions map; each region must carry a keyword :initial + non-empty :states"])
 
-    (valid-state-tree? spec)
-    [:ok spec]
+    (g/valid-definition? definition)
+    [:ok]
 
     :else
-    [:err "spec must carry :initial + non-empty :states (or :type :parallel + :regions)"]))
+    [:err "spec must carry a keyword :initial + non-empty :states (or :type :parallel + :regions)"]))
 
 ;; ---------------------------------------------------------------------------
 ;; Default resolver
@@ -318,18 +309,21 @@
                      :stripped-summary (response-summary stripped)}})
 
        :else
-       (let [[stage2 ok-or-reason] (validate-spec spec-or-reason)]
+       ;; rf2-egupfk — validate the DESUGARED form (as Mermaid + SCXML do) but
+       ;; return the ORIGINAL authored spec so `:timeout` / `:choice` intent
+       ;; survives to `reg-machine`.
+       (let [[stage2 reason] (validate-definition (g/desugar-grammar spec-or-reason))]
          (if (= :ok stage2)
-           ok-or-reason
+           spec-or-reason
            (error/throw-error!
              :ai-generate/invalid-spec
              'machines-viz/generate-machine
              (str "AI machine generation: the resolver output parsed as EDN but "
-                  "is not a valid machine spec (" ok-or-reason "). Have the "
-                  "resolver return a spec with :initial + :states (or :type "
-                  ":parallel + :regions).")
+                  "is not a valid machine spec (" reason "). Have the "
+                  "resolver return a spec with a keyword :initial + :states (or "
+                  ":type :parallel + :regions).")
              {:recovery :return-a-valid-machine-spec
               ;; rf2-8nzxib — value-FREE; the response + parsed spec can
               ;; embed LLM-returned secrets / runtime :data.
               :extra    {:response-summary (response-summary response)
-                         :spec-summary     (spec-summary spec-or-reason)}})))))))
+                         :spec-summary     (g/definition-summary spec-or-reason)}})))))))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/grammar.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/grammar.cljc
@@ -256,6 +256,88 @@
   [definition]
   (-> definition desugar-timeouts desugar-choices))
 
+;; ---------------------------------------------------------------------------
+;; Definition-shape validation — the SINGLE shape gate all three emitters share
+;; ---------------------------------------------------------------------------
+;;
+;; rf2-egupfk — the AI-generate, Mermaid, and SCXML emitters each project a
+;; machine definition onto a different surface, but they must agree on which
+;; definitions are well-formed enough to project AT ALL. Pre-fix each emitter
+;; hand-rolled its own `valid-state-tree?` / parallel check and the copies had
+;; DRIFTED: SCXML accepted malformed parallel region bodies (regions with no
+;; `:initial` / `:states`) that AI + Mermaid rejected, and AI required a
+;; KEYWORD `:initial` per the machine contract (Spec 005 §Transition table
+;; grammar — state ids are keywords) while Mermaid + SCXML accepted any truthy
+;; `:initial`. Three copies = three chances to drift; a drift here means one
+;; emitter renders a spec the others reject (or vice-versa), and the three
+;; diagrams disagree on what the same input even IS.
+;;
+;; These are the ONE source of truth. Every emitter desugars (`desugar-grammar`)
+;; then routes its shape check + value-free error summary through here, keeping
+;; only its surface-specific error id / message. The STRICT reading wins — the
+;; machine contract wants a keyword `:initial` and well-formed parallel regions
+;; — so unifying tightens the lax emitters (SCXML) rather than loosening the
+;; strict one (AI).
+;;
+;; Kept LOCAL to machines-viz (bundle-isolated tooling): these do NOT depend on
+;; the runtime `machines` grammar (`re-frame.machines.validate`), they re-state
+;; the minimum projectable shape the emitters need.
+
+(defn valid-state-tree?
+  "True when `definition` is a well-formed flat / compound state tree: a map
+  carrying a KEYWORD `:initial` (a state id — Spec 005 §Transition table
+  grammar declares state ids are keywords) and a non-empty `:states` map.
+  The shared minimum-shape predicate the three emitters agree on."
+  [definition]
+  (and (map? definition)
+       (keyword? (:initial definition))
+       (map? (:states definition))
+       (seq (:states definition))))
+
+(defn parallel-definition?
+  "True when `definition` is a `:type :parallel` root (Spec 005 §Parallel
+  regions). nil-safe / non-map-safe."
+  [definition]
+  (and (map? definition)
+       (= :parallel (:type definition))))
+
+(defn valid-definition?
+  "True when `definition` is a machine shape every emitter can project: a
+  parallel root (`:type :parallel`) with a non-empty `:regions` map whose
+  region bodies are EACH a `valid-state-tree?`, OR a flat / compound
+  `valid-state-tree?`. The single shape gate the three emitters share so
+  they never drift on which definitions they accept — keyword `:initial`,
+  well-formed parallel regions."
+  [definition]
+  (if (parallel-definition? definition)
+    (let [regions (:regions definition)]
+      (and (map? regions)
+           (seq regions)
+           (every? valid-state-tree? (vals regions))))
+    (valid-state-tree? definition)))
+
+(defn definition-summary
+  "EP-0015 / Spec 015 §exception-path residual (rf2-8nzxib) — a value-FREE
+  structural diagnostic for a rejected `definition`. A definition can carry
+  a `:data` slot holding live runtime values, and projection cannot walk
+  `ex-data` after the fact, so the summary reports only STRUCTURAL facts —
+  the top-level key SET, parallel?, and child counts — never the values.
+  The single summary the three emitters share so their thrown-error
+  diagnostics agree (each stashes it under its own surface-specific ex-data
+  key: `:spec-summary` / `:definition-summary`)."
+  [definition]
+  (if (map? definition)
+    (cond-> {:type     :map
+             :keys     (vec (sort-by str (keys definition)))
+             :parallel (parallel-definition? definition)}
+      (map? (:states definition))  (assoc :state-count  (count (:states definition)))
+      (map? (:regions definition)) (assoc :region-count (count (:regions definition))))
+    (cond
+      (nil? definition)        {:type :nil}
+      (sequential? definition) {:type  (if (vector? definition) :vector :seq)
+                                :count (count definition)}
+      :else                    {:type :value})))
+
 (defn parent-path
   "The parent path of `path` (its `pop`); `[]` for an empty/top-level
   path."

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/mermaid.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/mermaid.cljc
@@ -1013,38 +1013,12 @@
                ;; only; no sibling target).
                (render-parallel-on-done-note on-done)))))
 
-(defn- valid-state-tree?
-  [{:keys [initial states]}]
-  (and initial
-       (map? states)
-       (seq states)))
-
-(defn- parallel-definition?
-  [definition]
-  (= :parallel (:type definition)))
-
-(defn- valid-parallel-definition?
-  [{:keys [regions] :as definition}]
-  (and (parallel-definition? definition)
-       (map? regions)
-       (seq regions)
-       (every? valid-state-tree? (vals regions))))
-
-(defn- definition-summary
-  "EP-0015 / Spec 015 §exception-path residual (rf2-8nzxib) — a
-  value-FREE diagnostic for an invalid `definition`. A definition can
-  carry a `:data` slot holding live runtime values, and projection
-  cannot walk `ex-data` after the fact, so the thrown error reports only
-  STRUCTURAL facts: the top-level key SET, parallel?, and child counts —
-  never the `:data` values."
-  [definition]
-  (if (map? definition)
-    (cond-> {:type     :map
-             :keys     (vec (sort-by str (keys definition)))
-             :parallel (parallel-definition? definition)}
-      (map? (:states definition))  (assoc :state-count  (count (:states definition)))
-      (map? (:regions definition)) (assoc :region-count (count (:regions definition))))
-    {:type (cond (nil? definition) :nil (vector? definition) :vector :else :value)}))
+;; rf2-egupfk — the definition-shape validators + value-free summary are the
+;; SHARED grammar helpers (`grammar/valid-definition?` / `parallel-definition?`
+;; / `definition-summary`), so all three emitters agree on which definitions
+;; are projectable (keyword `:initial`, well-formed parallel regions) and on
+;; the value-free error diagnostic. Mermaid keeps only its surface-specific
+;; error id (`:mermaid/invalid-definition`) + message below.
 
 (defn emit
   "Emit a Mermaid `stateDiagram-v2` string for `definition`.
@@ -1080,23 +1054,21 @@
    ;; candidate edges). Bind once so BOTH the validation block and the
    ;; render below see the lowered form.
    (let [definition (g/desugar-grammar definition)
-         parallel?  (parallel-definition? definition)]
-     (when-not (if parallel?
-                 (valid-parallel-definition? definition)
-                 (valid-state-tree? definition))
+         parallel?  (g/parallel-definition? definition)]
+     (when-not (g/valid-definition? definition)
        (error/throw-error!
          :mermaid/invalid-definition
          'machines-viz.mermaid/emit
          (if parallel?
            (str "Mermaid export: a parallel definition must carry a non-empty "
-                ":regions map, and each region must carry :initial + a "
-                "non-empty :states map. Provide those.")
-           (str "Mermaid export: a definition must carry :initial + a "
-                "non-empty :states map. Provide those."))
+                ":regions map, and each region must carry a keyword :initial + "
+                "a non-empty :states map. Provide those.")
+           (str "Mermaid export: a definition must carry a keyword :initial + "
+                "a non-empty :states map. Provide those."))
          {:recovery :supply-a-valid-definition
           ;; rf2-8nzxib — value-FREE; never the raw definition (its
           ;; :data slot can hold live runtime values).
-          :extra    {:definition-summary (definition-summary definition)}}))
+          :extra    {:definition-summary (g/definition-summary definition)}}))
      (let [body (if parallel?
                   (render-parallel-body definition header-comment?)
                   (render-flat-or-compound-body definition header-comment?))]

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
@@ -161,17 +161,10 @@
 ;; so the assembly site names the SHAPE (type tag, key SET, length) —
 ;; never the values.
 
-(defn- spec-summary
-  "Value-FREE diagnostic for a rejected machine `spec`: type tag plus —
-  for a map — the top-level key SET, parallel?, and child counts."
-  [spec]
-  (if (map? spec)
-    (cond-> {:type     :map
-             :keys     (vec (sort-by str (keys spec)))
-             :parallel (= :parallel (:type spec))}
-      (map? (:states spec))  (assoc :state-count  (count (:states spec)))
-      (map? (:regions spec)) (assoc :region-count (count (:regions spec))))
-    {:type (cond (nil? spec) :nil (vector? spec) :vector :else :value)}))
+;; rf2-egupfk — the rejected-spec summary is the SHARED
+;; `grammar/definition-summary` (value-free structural facts only), so all
+;; three emitters emit the same diagnostic shape. SCXML stashes it under its
+;; own `:spec-summary` ex-data key.
 
 (defn- input-summary
   "Value-FREE diagnostic for a rejected SCXML `input`: type + length."
@@ -822,37 +815,34 @@
   ;; `<transition>`) and `:type :choice` / `:choice` → `:always` (A5,
   ;; surfaces the candidate `<transition>`s). The runtime drives the same
   ;; lowered forms. Idempotent + nil-safe.
-  (let [machine-spec (g/desugar-grammar machine-spec)]
-  (cond
-    (= :parallel (:type machine-spec))
-    (let [{:keys [regions]} machine-spec]
-      (when-not (and (map? regions) (seq regions))
-        (error/throw-error!
-          :scxml/invalid-spec
-          'machines-viz/spec->scxml
+  ;; rf2-egupfk — route the shape check through the SHARED
+  ;; `grammar/valid-definition?` so SCXML agrees with the AI-generate + Mermaid
+  ;; emitters: a KEYWORD `:initial` per the machine contract, and parallel
+  ;; region bodies each a valid state tree (pre-fix SCXML accepted malformed
+  ;; regions the other two rejected). SCXML keeps its own `:scxml/invalid-spec`
+  ;; id + the parallel-vs-flat message / recovery split below.
+  (let [machine-spec (g/desugar-grammar machine-spec)
+        parallel?    (g/parallel-definition? machine-spec)]
+    (when-not (g/valid-definition? machine-spec)
+      (error/throw-error!
+        :scxml/invalid-spec
+        'machines-viz/spec->scxml
+        (if parallel?
           (str "SCXML export: a parallel machine spec requires a non-empty "
-               ":regions map; add :regions to the parallel spec.")
-          {:recovery :supply-non-empty-regions
-           ;; rf2-8nzxib — value-FREE; never the raw spec (its :data
-           ;; slot can carry live runtime values).
-           :extra    {:spec-summary (spec-summary machine-spec)}}))
-      (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-           (str/join "\n" (emit-parallel machine-spec 0))))
-
-    (and (:initial machine-spec) (map? (:states machine-spec)) (seq (:states machine-spec)))
+               ":regions map, and each region must carry a keyword :initial + "
+               "a non-empty :states map; fix the parallel spec.")
+          (str "SCXML export: a machine spec must carry a keyword :initial + a "
+               "non-empty :states map, or :type :parallel + :regions. Provide "
+               "one of those shapes."))
+        {:recovery (if parallel? :supply-non-empty-regions :supply-a-valid-machine-spec)
+         ;; rf2-8nzxib — value-FREE; never the raw spec (its :data slot can
+         ;; carry live runtime values).
+         :extra    {:spec-summary (g/definition-summary machine-spec)}}))
     (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-         (str/join "\n" (emit-flat-or-compound machine-spec 0)))
-
-    :else
-    (error/throw-error!
-      :scxml/invalid-spec
-      'machines-viz/spec->scxml
-      (str "SCXML export: a machine spec must carry :initial + a non-empty "
-           ":states map, or :type :parallel + :regions. Provide one of "
-           "those shapes.")
-      {:recovery :supply-a-valid-machine-spec
-       ;; rf2-8nzxib — value-FREE; never the raw spec.
-       :extra    {:spec-summary (spec-summary machine-spec)}}))))
+         (str/join "\n"
+                   (if parallel?
+                     (emit-parallel machine-spec 0)
+                     (emit-flat-or-compound machine-spec 0))))))
 
 ;; ---------------------------------------------------------------------------
 ;; XML parse — minimal regex-based reader for the SCXML subset we

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/cross_emitter_agreement_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/cross_emitter_agreement_cljs_test.cljc
@@ -24,6 +24,7 @@
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test    :refer-macros [deftest is testing]])
             [clojure.string :as str]
+            [day8.re-frame2-machines-viz.ai-generate :as ai]
             [day8.re-frame2-machines-viz.chart.layout :as layout]
             [day8.re-frame2-machines-viz.mermaid :as mermaid]
             [day8.re-frame2-machines-viz.scxml :as scxml]))
@@ -524,3 +525,172 @@
           "the error terminal reconstructs :error? true")
       (is (nil? (get-in back [:states :ok :error?]))
           "the success terminal carries no :error? bit"))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-egupfk — the three emitters agree on DEFINITION-SHAPE VALIDATION.
+;;
+;; Pre-fix each emitter hand-rolled its own `valid-state-tree?` / parallel
+;; check and the copies had DRIFTED:
+;;
+;;   - SCXML accepted MALFORMED PARALLEL REGION BODIES (a region with no
+;;     `:initial` / `:states`, or a nil region) that AI + Mermaid rejected —
+;;     it checked only `(and (map? regions) (seq regions))`, never that each
+;;     region was itself a valid state tree.
+;;   - AI required a KEYWORD `:initial` (the machine contract — Spec 005
+;;     §Transition table grammar: state ids are keywords) while Mermaid +
+;;     SCXML accepted ANY TRUTHY `:initial` (a string / number slipped
+;;     through).
+;;
+;; The fix routes all three through the SHARED `grammar/valid-definition?`
+;; (adopting the STRICT reading: keyword `:initial`, well-formed regions), so
+;; a definition is accepted by ALL THREE or rejected by ALL THREE. Each keeps
+;; its surface-specific error id (`:ai-generate/invalid-spec` /
+;; `:mermaid/invalid-definition` / `:scxml/invalid-spec`).
+
+(defn- ai-rejects?
+  "True when the AI emitter rejects `definition` (its resolver returns the
+  definition verbatim as EDN, so the parse succeeds and only the shape
+  validation can reject)."
+  [definition]
+  (try
+    (ai/generate-machine "x" {:resolver (constantly (pr-str definition))})
+    false
+    (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) _ true)))
+
+(defn- mermaid-rejects? [definition]
+  (try (mermaid/emit definition) false
+       (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) _ true)))
+
+(defn- scxml-rejects? [definition]
+  (try (scxml/spec->scxml definition) false
+       (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) _ true)))
+
+(def malformed-parallel-region-body-machine
+  "THE SCXML drift repro: a parallel root whose region :a carries NO
+  `:initial` / `:states` (an empty region body). Pre-fix SCXML emitted it
+  happily; AI + Mermaid rejected it. Now all three reject."
+  {:type :parallel :regions {:a {}}})
+
+(def nil-parallel-region-machine
+  "A parallel root with a nil region body — the more degenerate SCXML-drift
+  shape."
+  {:type :parallel :regions {:a nil}})
+
+(def region-missing-states-machine
+  {:type :parallel :regions {:a {:initial :x}}})
+
+(def region-non-keyword-initial-machine
+  {:type :parallel :regions {:a {:initial "x" :states {:x {}}}}})
+
+(def non-keyword-initial-machine
+  "THE AI drift repro: a flat machine whose `:initial` is a STRING, not a
+  keyword. Pre-fix AI rejected it (keyword? guard) while Mermaid + SCXML
+  accepted it (truthy `:initial`). Now all three reject."
+  {:initial "a" :states {:a {}}})
+
+(def numeric-initial-machine
+  {:initial 42 :states {:a {}}})
+
+(def invalid-definitions
+  "Definitions EVERY emitter must reject (post-fix agreement)."
+  [nil
+   42
+   "not-a-machine"
+   [:a :b]
+   {:not-a-machine 42}
+   {:initial :a}                                   ;; missing :states
+   {:initial :a :states {}}                        ;; empty :states
+   non-keyword-initial-machine                     ;; AI-drift
+   numeric-initial-machine
+   {:type :parallel}                               ;; missing :regions
+   {:type :parallel :regions {}}                   ;; empty :regions
+   malformed-parallel-region-body-machine          ;; SCXML-drift
+   nil-parallel-region-machine
+   region-missing-states-machine
+   region-non-keyword-initial-machine])
+
+(def valid-definitions
+  "Definitions EVERY emitter must accept (post-fix agreement)."
+  [{:initial :a :states {:a {}}}
+   {:initial :a :states {:a {:on {:go :b}} :b {:final? true}}}
+   {:type :parallel :regions {:a {:initial :x :states {:x {}}}}}
+   {:type :parallel :regions {:a {:initial :x :states {:x {}}}
+                              :b {:initial :y :states {:y {}}}}}])
+
+(deftest all-three-emitters-reject-the-same-invalid-definitions
+  (testing "rf2-egupfk — AI, Mermaid, AND SCXML reject every malformed
+            definition identically (the previously-divergent shapes now
+            agree)"
+    (doseq [d invalid-definitions]
+      (let [a (ai-rejects? d)
+            m (mermaid-rejects? d)
+            s (scxml-rejects? d)]
+        (is (true? a) (str "AI must reject "      (pr-str d)))
+        (is (true? m) (str "Mermaid must reject " (pr-str d)))
+        (is (true? s) (str "SCXML must reject "   (pr-str d)))
+        (is (= a m s) (str "all three must AGREE on rejecting " (pr-str d)))))))
+
+(deftest all-three-emitters-accept-the-same-valid-definitions
+  (testing "rf2-egupfk — AI, Mermaid, AND SCXML accept every well-formed
+            definition identically"
+    (doseq [d valid-definitions]
+      (let [a (ai-rejects? d)
+            m (mermaid-rejects? d)
+            s (scxml-rejects? d)]
+        (is (false? a) (str "AI must accept "      (pr-str d)))
+        (is (false? m) (str "Mermaid must accept " (pr-str d)))
+        (is (false? s) (str "SCXML must accept "   (pr-str d)))
+        (is (= a m s) (str "all three must AGREE on accepting " (pr-str d)))))))
+
+(deftest scxml-now-rejects-malformed-parallel-region-bodies
+  (testing "rf2-egupfk — SCXML (the pre-fix LAX emitter) now rejects a
+            parallel region body with no :initial/:states, matching AI +
+            Mermaid (pre-fix SCXML emitted it)"
+    (is (scxml-rejects? malformed-parallel-region-body-machine)
+        "SCXML rejects the empty region body it used to accept")
+    (is (scxml-rejects? nil-parallel-region-machine))
+    (is (scxml-rejects? region-missing-states-machine))
+    (is (scxml-rejects? region-non-keyword-initial-machine))
+    ;; Still throws the SCXML-surface id (not the AI/Mermaid ids).
+    (let [d (try (scxml/spec->scxml malformed-parallel-region-body-machine) nil
+                 (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e (ex-data e)))]
+      (is (= :scxml/invalid-spec (:rf.error/id d))
+          "SCXML keeps its surface-specific error id"))))
+
+(deftest all-three-now-reject-non-keyword-initial
+  (testing "rf2-egupfk — Mermaid + SCXML (the pre-fix LAX emitters) now
+            reject a non-keyword :initial, matching AI (the machine contract:
+            state ids are keywords)"
+    (doseq [d [non-keyword-initial-machine numeric-initial-machine]]
+      (is (mermaid-rejects? d) (str "Mermaid now rejects " (pr-str d)))
+      (is (scxml-rejects? d)   (str "SCXML now rejects "   (pr-str d)))
+      (is (ai-rejects? d)      (str "AI still rejects "    (pr-str d))))
+    ;; Each keeps its surface-specific error id.
+    (let [md (try (mermaid/emit non-keyword-initial-machine) nil
+                  (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e (ex-data e)))
+          sd (try (scxml/spec->scxml non-keyword-initial-machine) nil
+                  (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e (ex-data e)))]
+      (is (= :mermaid/invalid-definition (:rf.error/id md)))
+      (is (= :scxml/invalid-spec (:rf.error/id sd))))))
+
+(deftest invalid-definition-summaries-stay-value-free-across-emitters
+  (testing "rf2-egupfk — the shared value-free summary excludes the raw
+            :data slot in every emitter's thrown error (a malformed
+            definition can carry live runtime values under :data)"
+    (let [secret "cross-emitter-secret-42"
+          ;; Malformed (empty :states) but carries a secret :data slot.
+          bad    {:initial :a :states {} :data {:token secret}}
+          leaks? (fn [d] (some #(and (string? %) (str/includes? % secret))
+                               (tree-seq coll? seq d)))
+          md     (try (mermaid/emit bad) nil
+                      (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e (ex-data e)))
+          sd     (try (scxml/spec->scxml bad) nil
+                      (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e (ex-data e)))
+          ad     (try (ai/generate-machine "x" {:resolver (constantly (pr-str bad))}) nil
+                      (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e (ex-data e)))]
+      (is (some? (:definition-summary md)) "mermaid carries a value-free summary")
+      (is (some? (:spec-summary sd))       "scxml carries a value-free summary")
+      (is (some? (:spec-summary ad))       "ai carries a value-free summary")
+      (is (not (leaks? md)) "mermaid summary omits the :data secret")
+      (is (not (leaks? sd)) "scxml summary omits the :data secret")
+      (is (not (leaks? ad)) "ai summary omits the :data secret"))))


### PR DESCRIPTION
## What

The AI-generate, Mermaid, and SCXML emitters each hand-rolled their own state-tree / parallel-region validation + value-free error summary, and the copies had drifted. This adds one shared validator set to machines-viz `grammar.cljc` and routes all three emitters through it, keeping each emitter's surface-specific error id/message.

New shared helpers in `grammar.cljc` (bundle-isolated, no runtime-engine dependency):

- `valid-state-tree?` — keyword `:initial` + non-empty `:states` map
- `parallel-definition?` — `:type :parallel` root (nil/non-map safe)
- `valid-definition?` — the single shape gate: parallel root with non-empty `:regions` whose bodies are each a `valid-state-tree?`, OR a flat/compound `valid-state-tree?`
- `definition-summary` — value-free structural diagnostic (top-level key SET, parallel?, child counts — never `:data` values)

Each emitter now desugars (`grammar/desugar-grammar`) then calls the shared validators. They keep their own error ids/messages/recovery keys (`:ai-generate/invalid-spec`, `:mermaid/invalid-definition`, `:scxml/invalid-spec`) and their own ex-data summary key (`:spec-summary` / `:definition-summary`).

## Preflight — drift confirmed

Both divergences named in the bead were reproduced in the source before the fix:

1. **SCXML accepted malformed parallel region bodies.** `spec->scxml`'s parallel branch checked only `(and (map? regions) (seq regions))` — it never verified each region was a valid state tree. AI (`valid-parallel?`) and Mermaid (`valid-parallel-definition?`) both did `(every? valid-state-tree? (vals regions))`. So `{:type :parallel :regions {:a {}}}` (and `{:a nil}`, region-missing-`:states`, region-non-keyword-`:initial`) emitted happily from SCXML but were rejected by AI + Mermaid.
2. **AI required keyword `:initial`; Mermaid + SCXML accepted any truthy value.** AI's `valid-state-tree?` used `(keyword? initial)`; Mermaid used `(and initial …)` and SCXML used `(:initial machine-spec)`. So `{:initial "a" …}` / `{:initial 42 …}` passed Mermaid + SCXML but failed AI.

**Correct behaviour** per the machine contract (Spec 005 §Transition table grammar — state ids are keywords; well-formed parallel regions): the STRICT reading. The unified validator therefore adopts the strict semantics, tightening the lax emitters (SCXML region-body check; Mermaid + SCXML keyword `:initial`) rather than loosening the strict one (AI).

## Emitter behaviours changed

- **SCXML** now rejects malformed parallel region bodies (empty `{}`, `nil`, missing `:states`, non-keyword region `:initial`) it previously emitted; now rejects a non-keyword top-level `:initial`. Same `:scxml/invalid-spec` id; parallel-vs-flat message/recovery split preserved.
- **Mermaid** now rejects a non-keyword `:initial` it previously accepted. Same `:mermaid/invalid-definition` id.
- **AI** behaviour unchanged in outcome (it was already the strict reference); it now shares the validators + summary and desugars before validating (returns the original authored spec so `:timeout`/`:choice` intent survives).

## Quality gates

Run in the foreground from the worktree, both green:

- `cd tools/machines-viz && clojure -M:test` → **605 tests, 2265 assertions, 0 failures, 0 errors**
- `cd implementation && npm run test:cljs` (node-test build covers machines-viz src+test) → **8477 tests, 39188 assertions, 0 failures, 0 errors**

New tests in `cross_emitter_agreement_cljs_test.cljc` prove the agreement: all three emitters reject the same 15 invalid definitions and accept the same 4 valid ones; SCXML now rejects the malformed parallel region bodies it used to accept; Mermaid + SCXML now reject non-keyword `:initial`; each keeps its surface-specific error id; the shared value-free summary omits a `:data` secret in every emitter.

Bundle isolation intact: changes are entirely within `tools/machines-viz`; no `implementation/` code touched, no new production dependency (the AI emitter's new require is machines-viz-internal `grammar`).

## Spec

Spec unchanged because the validator is an internal consistency fix, no contract surface change. The machines-viz `spec/` prose (`API.md` §AI-generate, §SCXML error modes) describes the accepted shape at the granularity "carries `:initial` + non-empty `:states` (or `:type :parallel` + `:regions`)", which remains accurate — it never documented the pre-fix divergence (any-truthy `:initial`, unvalidated region bodies).

## Stance

Pre-alpha, no back-compat shims. Primary lenses: ELEGANCE + CLARITY + CORRECTNESS + GOOD PRACTICE — one source of truth for definition-shape validation replaces three drifting copies.