### PR TITLE
test(ssr,security): use the shared with-trace-recorder! throughout (rf2-nj0aw8, rf2-u8bw0l)

### DIFF
--- a/implementation/security/test/re_frame/security/error_slot_egress_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/error_slot_egress_security_cljs_test.cljc
@@ -78,13 +78,15 @@
             ;; fx, so a synthetic cofx suffices.
             [re-frame.routing.navigate :as navigate]
             [re-frame.routing.registry :as registry]
-            [re-frame.test-support :as test-support]
+            #?(:clj  [re-frame.test-support :as test-support :refer [with-trace-recorder!]]
+               :cljs [re-frame.test-support :as test-support :refer-macros [with-trace-recorder!]])
             ;; SITE 1 drives the REAL production emit (`trace/emit-error!`),
             ;; not direct `classification/project-trace-event` — so the test proves the
             ;; full envelope production actually ships, including the top-level
-            ;; `:sensitive?` hoist the MCP egress gate reads (rf2-md2wn0).
+            ;; `:sensitive?` hoist the MCP egress gate reads (rf2-md2wn0). The
+            ;; shared `with-trace-recorder!` brackets the trace-tooling listener
+            ;; the helpers capture off.
             [re-frame.trace :as trace]
-            [re-frame.trace.tooling :as trace-tooling]
             [re-frame.security.gen :as gen]))
 
 ;; Reset per-test so route + mark + app-schema registrations don't bleed.
@@ -187,12 +189,8 @@
   `:sensitive?` hoist. This is the production path; nothing routes around
   the reported gap."
   [tags]
-  (let [traces (atom [])
-        kw     (keyword "rf2-md2wn0" (name (gensym "machine-ex")))]
-    (trace-tooling/register-listener! kw (fn [ev] (swap! traces conj ev)))
-    (try
-      (trace/emit-error! :rf.error/machine-action-exception tags)
-      (finally (trace-tooling/unregister-listener! kw)))
+  (with-trace-recorder! [traces]
+    (trace/emit-error! :rf.error/machine-action-exception tags)
     (first (filter #(= :rf.error/machine-action-exception (:operation %))
                    @traces))))
 
@@ -437,17 +435,13 @@
   the `:params`-schema reject short-circuits before any push/scroll fx."
   [params-schema]
   (rf/reg-route :sec/route {:params params-schema} "/doc/:doc")
-  (let [traces (atom [])
-        kw     (keyword "rf2-zsm03" (name (gensym "nav")))]
-    (trace-tooling/register-listener! kw (fn [ev] (swap! traces conj ev)))
-    (try
-      ;; :doc must be a value the schema rejects (schema wants :int). The
-      ;; sentinel rides as the offending param value.
-      ;; The frame stamp reaches the event context under :rf.frame/id
-      ;; (rf2-1m6rf1 — the bare :frame coeffect is retired).
-      (navigate/navigate-handler {:db {} :rf.frame/id :rf/default}
-                                 [:rf.route/navigate :sec/route {:doc sentinel}])
-      (finally (trace-tooling/unregister-listener! kw)))
+  (with-trace-recorder! [traces]
+    ;; :doc must be a value the schema rejects (schema wants :int). The
+    ;; sentinel rides as the offending param value.
+    ;; The frame stamp reaches the event context under :rf.frame/id
+    ;; (rf2-1m6rf1 — the bare :frame coeffect is retired).
+    (navigate/navigate-handler {:db {} :rf.frame/id :rf/default}
+                               [:rf.route/navigate :sec/route {:doc sentinel}])
     (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                    @traces))))
 

--- a/implementation/security/test/re_frame/security/fail_closed_invariant_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/fail_closed_invariant_security_cljs_test.cljc
@@ -76,8 +76,8 @@
             [re-frame.schemas :as schemas]
             [re-frame.routing.url :as url]
             [re-frame.ssr.hydrate :as hydrate]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace.tooling :as trace-tooling]
+            #?(:clj  [re-frame.test-support :as test-support :refer [with-trace-recorder!]]
+               :cljs [re-frame.test-support :as test-support :refer-macros [with-trace-recorder!]])
             [re-frame.security.gen :as gen]))
 
 ;; Reset per-test so app-schema registrations / validator overrides don't
@@ -108,10 +108,8 @@
 
 (defn- capture
   [f]
-  (let [traces (atom [])
-        kw     (keyword "rf2-gro94" (name (gensym "listen")))]
-    (trace-tooling/register-listener! kw (fn [ev] (swap! traces conj ev)))
-    (try (f) (finally (trace-tooling/unregister-listener! kw)))
+  (with-trace-recorder! [traces]
+    (f)
     @traces))
 
 (defn- ops [traces op]

--- a/implementation/security/test/re_frame/security/schema_redaction_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/schema_redaction_security_cljs_test.cljc
@@ -40,8 +40,8 @@
             ;; it the default validator soft-passes and no failure fires.
             [re-frame.schemas.malli]
             [re-frame.schemas :as schemas]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace.tooling :as trace-tooling]
+            #?(:clj  [re-frame.test-support :as test-support :refer [with-trace-recorder!]]
+               :cljs [re-frame.test-support :as test-support :refer-macros [with-trace-recorder!]])
             [re-frame.security.gen :as gen]))
 
 ;; Reset per-test so app-schema registrations don't bleed across cases.
@@ -217,11 +217,8 @@
 (defn- failure-trace
   [schema db]
   (rf/reg-app-schema [:root] schema)
-  (let [traces (atom [])
-        kw     (keyword "rf2-3cfvt" (name (gensym "listen")))]
-    (trace-tooling/register-listener! kw (fn [ev] (swap! traces conj ev)))
+  (with-trace-recorder! [traces]
     (schemas/validate-app-schema! {:root db} :root/bad)
-    (trace-tooling/unregister-listener! kw)
     #?(:clj (schemas/clear-sensitive-paths-cache!))
     (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                    @traces))))

--- a/implementation/security/test/re_frame/security/validation_redaction_invariant_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/validation_redaction_invariant_security_cljs_test.cljc
@@ -72,8 +72,8 @@
             [re-frame.flows]
             [re-frame.late-bind :as late-bind]
             [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace.tooling :as trace-tooling]
+            #?(:clj  [re-frame.test-support :as test-support :refer [with-trace-recorder!]]
+               :cljs [re-frame.test-support :as test-support :refer-macros [with-trace-recorder!]])
             [re-frame.security.gen :as gen]))
 
 ;; Reset per-test so app-schema registrations don't bleed across cases.
@@ -119,10 +119,8 @@
   attached; return the first trace event whose `:operation` is `op` (or nil if
   none fired)."
   [op f]
-  (let [traces (atom [])
-        kw     (keyword "rf2-o69h5" (name (gensym "listen")))]
-    (trace-tooling/register-listener! kw (fn [ev] (swap! traces conj ev)))
-    (try (f) (finally (trace-tooling/unregister-listener! kw)))
+  (with-trace-recorder! [traces]
+    (f)
     #?(:clj (schemas/clear-sensitive-paths-cache!))
     (first (filter #(= op (:operation %)) @traces))))
 
@@ -522,47 +520,44 @@
         (rf/reg-event :cofx/uses-generated-secret
           {:rf.cofx/requires [:cofx/generated-secret]}
           (fn [_ _] {}))
-        (let [thrown    (atom nil)
-              all       (atom [])
-              kw        (keyword "rf2-0mjgx6" (name (gensym "listen")))]
-          (trace-tooling/register-listener! kw (fn [ev] (swap! all conj ev)))
-          (try
-            ;; Do NOT supply the fact on the token — the generator runs at
-            ;; processing-start under the router's :live default, produces the
-            ;; failing value, and the schema check throws cofx-value-invalid.
-            (rf/dispatch-sync [:cofx/uses-generated-secret])
-            (catch #?(:clj clojure.lang.ExceptionInfo
-                      :cljs cljs.core/ExceptionInfo) e
-              (reset! thrown e))
-            (finally (trace-tooling/unregister-listener! kw)))
-          ;; (a) NO :rf.cofx/generated trace leaks the sentinel (the prior
-          ;;     pre-validation emit). It is acceptable for the op to be absent
-          ;;     entirely (validation aborts before the emit) — the invariant is
-          ;;     that NONE that DID fire carry the secret.
-          (let [generated (filter #(= :rf.cofx/generated (:operation %)) @all)]
-            (doseq [g generated]
-              (is (not (contains-sentinel? g))
-                  (str "the sentinel leaked on a :rf.cofx/generated trace BEFORE "
-                       "validation redacted it: " (pr-str (:tags g))))))
-          ;; (b) The redacted cofx-value-invalid trace IS present and clean.
-          (let [inv (first (filter #(= :rf.error/cofx-value-invalid (:operation %)) @all))]
-            (is (some? inv) ":rf.error/cofx-value-invalid trace fired")
-            (when inv
-              (is (true? (:sensitive? inv)) "cofx-value-invalid :sensitive? stamp")
-              (is (= :rf/redacted (-> inv :tags :value)) "cofx-value-invalid :value redacted")
-              (is (not (contains-sentinel? inv))
-                  (str "the sentinel leaked into the cofx-value-invalid trace: "
-                       (pr-str (:tags inv))))))
-          ;; (c) The thrown ex-data redacts too.
-          (is (some? @thrown) "dispatch threw cofx-value-invalid")
-          (when-let [d (some-> @thrown ex-data)]
-            (is (= :rf.error/cofx-value-invalid (:rf.error/id d)))
-            (is (= :rf/redacted (:value d)) "ex-data :value redacted")
-            (is (not (contains-sentinel? d))
-                (str "the sentinel leaked into the thrown ex-data: " (pr-str d))))
-          ;; (d) The sentinel appears NOWHERE across the WHOLE captured stream.
-          (is (not (contains-sentinel? @all))
-              "the generated sentinel must not appear anywhere in the trace stream"))))))
+        (let [thrown (atom nil)]
+          (with-trace-recorder! [all]
+            (try
+              ;; Do NOT supply the fact on the token — the generator runs at
+              ;; processing-start under the router's :live default, produces the
+              ;; failing value, and the schema check throws cofx-value-invalid.
+              (rf/dispatch-sync [:cofx/uses-generated-secret])
+              (catch #?(:clj clojure.lang.ExceptionInfo
+                        :cljs cljs.core/ExceptionInfo) e
+                (reset! thrown e)))
+            ;; (a) NO :rf.cofx/generated trace leaks the sentinel (the prior
+            ;;     pre-validation emit). It is acceptable for the op to be absent
+            ;;     entirely (validation aborts before the emit) — the invariant is
+            ;;     that NONE that DID fire carry the secret.
+            (let [generated (filter #(= :rf.cofx/generated (:operation %)) @all)]
+              (doseq [g generated]
+                (is (not (contains-sentinel? g))
+                    (str "the sentinel leaked on a :rf.cofx/generated trace BEFORE "
+                         "validation redacted it: " (pr-str (:tags g))))))
+            ;; (b) The redacted cofx-value-invalid trace IS present and clean.
+            (let [inv (first (filter #(= :rf.error/cofx-value-invalid (:operation %)) @all))]
+              (is (some? inv) ":rf.error/cofx-value-invalid trace fired")
+              (when inv
+                (is (true? (:sensitive? inv)) "cofx-value-invalid :sensitive? stamp")
+                (is (= :rf/redacted (-> inv :tags :value)) "cofx-value-invalid :value redacted")
+                (is (not (contains-sentinel? inv))
+                    (str "the sentinel leaked into the cofx-value-invalid trace: "
+                         (pr-str (:tags inv))))))
+            ;; (c) The thrown ex-data redacts too.
+            (is (some? @thrown) "dispatch threw cofx-value-invalid")
+            (when-let [d (some-> @thrown ex-data)]
+              (is (= :rf.error/cofx-value-invalid (:rf.error/id d)))
+              (is (= :rf/redacted (:value d)) "ex-data :value redacted")
+              (is (not (contains-sentinel? d))
+                  (str "the sentinel leaked into the thrown ex-data: " (pr-str d))))
+            ;; (d) The sentinel appears NOWHERE across the WHOLE captured stream.
+            (is (not (contains-sentinel? @all))
+                "the generated sentinel must not appear anywhere in the trace stream")))))))
 
 (deftest valid-recordable-cofx-schema-path-unaffected
   (testing "rf2-hdi6wr (c) — a recordable reg-cofx whose value CONFORMS to its

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_writer_trace_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_writer_trace_test.clj
@@ -51,17 +51,10 @@
             [re-frame.ssr.ring.pipeline :as pipeline]
             [re-frame.ssr.ring.streaming :as streaming]
             [re-frame.ssr.ring.test-support :as ts]
-            [re-frame.trace :as trace])
+            [re-frame.test-support :refer [with-trace-recorder!]])
   (:import [java.io InputStream OutputStream PipedInputStream PipedOutputStream]))
 
 (use-fixtures :each ts/reset-runtime)
-
-(defn- with-trace-capture
-  [coll-atom body-fn]
-  (let [k (str (gensym "ssr-writer-trace-cb"))]
-    (trace/register-listener! k (fn [ev] (swap! coll-atom conj ev)))
-    (try (body-fn)
-         (finally (trace/unregister-listener! k)))))
 
 ;; ===========================================================================
 ;; The trace emit itself — the gap streaming_robustness_test left open.
@@ -77,43 +70,42 @@
             the emit would pass every existing test."
     (let [pipe-in  (PipedInputStream. 1024)
           pipe-out (PipedOutputStream. pipe-in)
-          _        (.close pipe-in) ;; pre-broken pipe — every write throws
-          captured (atom [])]
+          _        (.close pipe-in)] ;; pre-broken pipe — every write throws
       ;; Drive the writer body directly against the pre-broken pipe.
       ;; rf2-r06pc — the writer no longer resolves/renders the shell
       ;; (that moved to the request thread); we hand it a PRE-RENDERED
       ;; shell. The first chunk write of the shell prefix hits the
       ;; pre-broken pipe → IOException → the catch arm runs and emits
       ;; the trace.
-      (with-trace-capture captured
-        #(@#'streaming/run-streaming-writer!
-           pipe-out :no-such-frame
-           {:hiccup [:div] :head-html "" :html-attrs nil :body-attrs nil
-            :shell-html "<div></div>" :continuations []}
-           {:root-view [:div]}))
-      (let [hits (filterv #(= :rf.error/ssr-streaming-writer-failed (:operation %))
-                          @captured)]
-        (is (= 1 (count hits))
-            (str "expected exactly one :rf.error/ssr-streaming-writer-
-                 failed trace; saw: " (count hits) " (all operations: "
-                 (pr-str (mapv :operation @captured)) ")"))
-        (when (seq hits)
-          (let [ev (first hits)]
-            (is (= :error (:op-type ev))
-                ":op-type is :error per Spec 009 — writer-failed is a
-                 hard failure, not a warning")
-            (is (some? (-> ev :tags :exception))
-                ":exception tag carries the throwable's message")
-            (is (some? (-> ev :tags :ex-class))
-                ":ex-class tag carries the throwable's class name")
-            (is (= :truncate-and-close (:recovery ev))
-                ":recovery is hoisted to top-level per Spec 009
-                 §Error event shape — names the failure-recovery
-                 policy (partial response on the wire, pipe closes)")
-            (is (= :no-such-frame (-> ev :tags :frame))
-                ":frame tag identifies which request failed — load-
-                 bearing for ops correlating writer failures to
-                 specific requests in JFR / log streams")))))))
+      (with-trace-recorder! [captured]
+        (@#'streaming/run-streaming-writer!
+          pipe-out :no-such-frame
+          {:hiccup [:div] :head-html "" :html-attrs nil :body-attrs nil
+           :shell-html "<div></div>" :continuations []}
+          {:root-view [:div]})
+        (let [hits (filterv #(= :rf.error/ssr-streaming-writer-failed (:operation %))
+                            @captured)]
+          (is (= 1 (count hits))
+              (str "expected exactly one :rf.error/ssr-streaming-writer-
+                   failed trace; saw: " (count hits) " (all operations: "
+                   (pr-str (mapv :operation @captured)) ")"))
+          (when (seq hits)
+            (let [ev (first hits)]
+              (is (= :error (:op-type ev))
+                  ":op-type is :error per Spec 009 — writer-failed is a
+                   hard failure, not a warning")
+              (is (some? (-> ev :tags :exception))
+                  ":exception tag carries the throwable's message")
+              (is (some? (-> ev :tags :ex-class))
+                  ":ex-class tag carries the throwable's class name")
+              (is (= :truncate-and-close (:recovery ev))
+                  ":recovery is hoisted to top-level per Spec 009
+                   §Error event shape — names the failure-recovery
+                   policy (partial response on the wire, pipe closes)")
+              (is (= :no-such-frame (-> ev :tags :frame))
+                  ":frame tag identifies which request failed — load-
+                   bearing for ops correlating writer failures to
+                   specific requests in JFR / log streams"))))))))
 
 ;; ===========================================================================
 ;; Shell-render-throw composition with frame destroy — when the shell
@@ -219,10 +211,9 @@
   write, capture the writer-failed trace, and return its first event (or
   nil). `rendered` is a genuine `render-streaming-shell!` result."
   [frame-id rendered opts throw-at-write]
-  (let [captured (atom [])]
-    (with-trace-capture captured
-      #(@#'streaming/run-streaming-writer!
-         (throw-on-nth-write-stream throw-at-write) frame-id rendered opts))
+  (with-trace-recorder! [captured]
+    (@#'streaming/run-streaming-writer!
+      (throw-on-nth-write-stream throw-at-write) frame-id rendered opts)
     (->> @captured
          (filterv #(= :rf.error/ssr-streaming-writer-failed (:operation %)))
          first)))

--- a/implementation/ssr/test/re_frame/ssr_compatibility_checks_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_compatibility_checks_test.clj
@@ -14,25 +14,13 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.late-bind :as late-bind]
-            [re-frame.ssr.test-fixture :as tf]))
+            [re-frame.ssr.test-fixture :as tf]
+            [re-frame.test-support :refer [with-trace-recorder!]]))
 
 ;; Shared reset fixture lives in `re-frame.ssr.test-fixture` (rf2-i3qc0).
 (use-fixtures :each tf/reset-runtime)
 
 ;; ---- helpers --------------------------------------------------------------
-
-(defn- capture-traces!
-  "Run f under a trace listener that captures every event; return the
-  captured vector after f returns."
-  [f]
-  (let [traces (atom [])
-        cb-id  (gensym "::capture-")]
-    (rf/register-listener! :trace cb-id (fn [ev] (swap! traces conj ev)))
-    (try
-      (f)
-      (finally
-        (rf/unregister-listener! :trace cb-id)))
-    @traces))
 
 (defn- traces-of [traces op]
   (filterv #(= op (:operation %)) traces))
@@ -56,15 +44,13 @@
         ;; check-version probes compare integers, not semver strings.
         {:fx [[:rf.ssr/check-version {:expected 1 :actual 1}]]}))
 
-    (let [f      (frame/make-anon-frame-record! {:platform :client})
-          traces (capture-traces!
-                   (fn []
-                     (rf/dispatch-sync [::probe-check-version-match]
-                                       {:frame f})))]
-      (is (empty? (traces-of traces :rf.ssr/version-mismatch))
-          "matching version → no mismatch trace")
-      (is (empty? (traces-of traces :rf.ssr/compatibility-check-skipped))
-          "both sides supplied → no skipped trace either"))))
+    (let [f (frame/make-anon-frame-record! {:platform :client})]
+      (with-trace-recorder! [traces]
+        (rf/dispatch-sync [::probe-check-version-match] {:frame f})
+        (is (empty? (traces-of @traces :rf.ssr/version-mismatch))
+            "matching version → no mismatch trace")
+        (is (empty? (traces-of @traces :rf.ssr/compatibility-check-skipped))
+            "both sides supplied → no skipped trace either")))))
 
 (deftest check-version-mismatch-emits-trace
   (testing "differing expected + actual → :rf.ssr/version-mismatch warning trace"
@@ -73,22 +59,20 @@
       (fn [_ _]
         {:fx [[:rf.ssr/check-version {:expected 1 :actual 2}]]}))
 
-    (let [f      (frame/make-anon-frame-record! {:platform :client})
-          traces (capture-traces!
-                   (fn []
-                     (rf/dispatch-sync [::probe-check-version-mismatch]
-                                       {:frame f})))
-          hits   (traces-of traces :rf.ssr/version-mismatch)]
-      (is (= 1 (count hits))
-          (str "expected one :rf.ssr/version-mismatch trace; saw: "
-               (pr-str (mapv :operation traces))))
-      (when (seq hits)
-        (let [ev (first hits)]
-          (is (= :warning              (:op-type ev)))
-          (is (= 1                     (-> ev :tags :expected)))
-          (is (= 2                     (-> ev :tags :actual)))
-          (is (= :warned-and-applied   (:recovery ev))
-              ":recovery rides at top-level per Spec 009"))))))
+    (let [f (frame/make-anon-frame-record! {:platform :client})]
+      (with-trace-recorder! [traces]
+        (rf/dispatch-sync [::probe-check-version-mismatch] {:frame f})
+        (let [hits (traces-of @traces :rf.ssr/version-mismatch)]
+          (is (= 1 (count hits))
+              (str "expected one :rf.ssr/version-mismatch trace; saw: "
+                   (pr-str (mapv :operation @traces))))
+          (when (seq hits)
+            (let [ev (first hits)]
+              (is (= :warning              (:op-type ev)))
+              (is (= 1                     (-> ev :tags :expected)))
+              (is (= 2                     (-> ev :tags :actual)))
+              (is (= :warned-and-applied   (:recovery ev))
+                  ":recovery rides at top-level per Spec 009"))))))))
 
 ;; ===========================================================================
 ;; :rf.ssr/check-schema-digest
@@ -111,15 +95,13 @@
                {:expected "sha256:deadbeefcafef00d"
                 :actual   "sha256:deadbeefcafef00d"}]]}))
 
-    (let [f      (frame/make-anon-frame-record! {:platform :client})
-          traces (capture-traces!
-                   (fn []
-                     (rf/dispatch-sync [::probe-check-digest-match]
-                                       {:frame f})))]
-      (is (empty? (traces-of traces :rf.ssr/schema-digest-mismatch))
-          "matching digest → no mismatch trace")
-      (is (empty? (traces-of traces :rf.ssr/compatibility-check-skipped))
-          "both sides supplied → no skipped trace either"))))
+    (let [f (frame/make-anon-frame-record! {:platform :client})]
+      (with-trace-recorder! [traces]
+        (rf/dispatch-sync [::probe-check-digest-match] {:frame f})
+        (is (empty? (traces-of @traces :rf.ssr/schema-digest-mismatch))
+            "matching digest → no mismatch trace")
+        (is (empty? (traces-of @traces :rf.ssr/compatibility-check-skipped))
+            "both sides supplied → no skipped trace either")))))
 
 (deftest check-schema-digest-mismatch-emits-trace
   (testing "differing expected + actual → :rf.ssr/schema-digest-mismatch warning trace"
@@ -130,21 +112,19 @@
                {:expected "sha256:deadbeefcafef00d"
                 :actual   "sha256:0000000000000000"}]]}))
 
-    (let [f      (frame/make-anon-frame-record! {:platform :client})
-          traces (capture-traces!
-                   (fn []
-                     (rf/dispatch-sync [::probe-check-digest-mismatch]
-                                       {:frame f})))
-          hits   (traces-of traces :rf.ssr/schema-digest-mismatch)]
-      (is (= 1 (count hits))
-          (str "expected one :rf.ssr/schema-digest-mismatch trace; saw: "
-               (pr-str (mapv :operation traces))))
-      (when (seq hits)
-        (let [ev (first hits)]
-          (is (= :warning                              (:op-type ev)))
-          (is (= "sha256:deadbeefcafef00d"             (-> ev :tags :expected)))
-          (is (= "sha256:0000000000000000"             (-> ev :tags :actual)))
-          (is (= :warned-and-applied                   (:recovery ev))))))))
+    (let [f (frame/make-anon-frame-record! {:platform :client})]
+      (with-trace-recorder! [traces]
+        (rf/dispatch-sync [::probe-check-digest-mismatch] {:frame f})
+        (let [hits (traces-of @traces :rf.ssr/schema-digest-mismatch)]
+          (is (= 1 (count hits))
+              (str "expected one :rf.ssr/schema-digest-mismatch trace; saw: "
+                   (pr-str (mapv :operation @traces))))
+          (when (seq hits)
+            (let [ev (first hits)]
+              (is (= :warning                              (:op-type ev)))
+              (is (= "sha256:deadbeefcafef00d"             (-> ev :tags :expected)))
+              (is (= "sha256:0000000000000000"             (-> ev :tags :actual)))
+              (is (= :warned-and-applied                   (:recovery ev))))))))))
 
 ;; ===========================================================================
 ;; SCALAR-form + missing-hook paths — rf2-ooj41
@@ -167,23 +147,21 @@
       (fn [_ _]
         {:fx [[:rf.ssr/check-version 1]]}))
 
-    (let [f      (frame/make-anon-frame-record! {:platform :client})
-          traces (capture-traces!
-                   (fn []
-                     (rf/dispatch-sync [::probe-check-version-scalar-no-hook]
-                                       {:frame f})))
-          hits   (traces-of traces :rf.ssr/compatibility-check-skipped)]
-      (is (= 1 (count hits))
-          (str "expected one :rf.ssr/compatibility-check-skipped trace; saw: "
-               (pr-str (mapv :operation traces))))
-      (when (seq hits)
-        (let [ev (first hits)]
-          (is (= :warning              (:op-type ev)))
-          (is (= :rf.ssr/check-version (-> ev :tags :check))
-              ":check tag identifies which compatibility fx skipped")
-          (is (= 1                     (-> ev :tags :expected))
-              "scalar value is the :expected (server-side) value")
-          (is (= :skipped              (:recovery ev))))))))
+    (let [f (frame/make-anon-frame-record! {:platform :client})]
+      (with-trace-recorder! [traces]
+        (rf/dispatch-sync [::probe-check-version-scalar-no-hook] {:frame f})
+        (let [hits (traces-of @traces :rf.ssr/compatibility-check-skipped)]
+          (is (= 1 (count hits))
+              (str "expected one :rf.ssr/compatibility-check-skipped trace; saw: "
+                   (pr-str (mapv :operation @traces))))
+          (when (seq hits)
+            (let [ev (first hits)]
+              (is (= :warning              (:op-type ev)))
+              (is (= :rf.ssr/check-version (-> ev :tags :check))
+                  ":check tag identifies which compatibility fx skipped")
+              (is (= 1                     (-> ev :tags :expected))
+                  "scalar value is the :expected (server-side) value")
+              (is (= :skipped              (:recovery ev))))))))))
 
 (deftest check-version-scalar-with-hook-runs-comparison
   (testing "scalar form + registered :rf2/runtime-version hook → compare; mismatch fires"
@@ -196,23 +174,21 @@
         (fn [_ _]
           {:fx [[:rf.ssr/check-version 1]]}))
 
-      (let [f      (frame/make-anon-frame-record! {:platform :client})
-            traces (capture-traces!
-                     (fn []
-                       (rf/dispatch-sync [::probe-check-version-scalar-with-hook]
-                                         {:frame f})))
-            hits   (traces-of traces :rf.ssr/version-mismatch)]
-        (is (empty? (traces-of traces :rf.ssr/compatibility-check-skipped))
-            "hook present → no skipped trace; the comparison ran")
-        (is (= 1 (count hits))
-            (str "expected one :rf.ssr/version-mismatch trace; saw: "
-                 (pr-str (mapv :operation traces))))
-        (when (seq hits)
-          (let [ev (first hits)]
-            (is (= 1 (-> ev :tags :expected))
-                "scalar arg is :expected (server side)")
-            (is (= 2 (-> ev :tags :actual))
-                ":actual sourced via the late-bind hook"))))
+      (let [f (frame/make-anon-frame-record! {:platform :client})]
+        (with-trace-recorder! [traces]
+          (rf/dispatch-sync [::probe-check-version-scalar-with-hook] {:frame f})
+          (let [hits (traces-of @traces :rf.ssr/version-mismatch)]
+            (is (empty? (traces-of @traces :rf.ssr/compatibility-check-skipped))
+                "hook present → no skipped trace; the comparison ran")
+            (is (= 1 (count hits))
+                (str "expected one :rf.ssr/version-mismatch trace; saw: "
+                     (pr-str (mapv :operation @traces))))
+            (when (seq hits)
+              (let [ev (first hits)]
+                (is (= 1 (-> ev :tags :expected))
+                    "scalar arg is :expected (server side)")
+                (is (= 2 (-> ev :tags :actual))
+                    ":actual sourced via the late-bind hook"))))))
       (finally
         (swap! late-bind/hooks dissoc :rf2/runtime-version)))))
 
@@ -229,18 +205,16 @@
           (fn [_ _]
             {:fx [[:rf.ssr/check-schema-digest "sha256:deadbeefcafef00d"]]}))
 
-        (let [f      (frame/make-anon-frame-record! {:platform :client})
-              traces (capture-traces!
-                       (fn []
-                         (rf/dispatch-sync [::probe-check-digest-scalar-no-hook]
-                                           {:frame f})))
-              hits   (traces-of traces :rf.ssr/compatibility-check-skipped)]
-          (is (= 1 (count hits)))
-          (when (seq hits)
-            (let [ev (first hits)]
-              (is (= :rf.ssr/check-schema-digest (-> ev :tags :check)))
-              (is (= "sha256:deadbeefcafef00d"   (-> ev :tags :expected)))
-              (is (= :skipped                    (:recovery ev))))))
+        (let [f (frame/make-anon-frame-record! {:platform :client})]
+          (with-trace-recorder! [traces]
+            (rf/dispatch-sync [::probe-check-digest-scalar-no-hook] {:frame f})
+            (let [hits (traces-of @traces :rf.ssr/compatibility-check-skipped)]
+              (is (= 1 (count hits)))
+              (when (seq hits)
+                (let [ev (first hits)]
+                  (is (= :rf.ssr/check-schema-digest (-> ev :tags :check)))
+                  (is (= "sha256:deadbeefcafef00d"   (-> ev :tags :expected)))
+                  (is (= :skipped                    (:recovery ev))))))))
         (finally
           (when prior-hook
             (late-bind/set-fn! :schemas/app-schemas-digest prior-hook)))))))

--- a/implementation/ssr/test/re_frame/ssr_hydration_mismatch_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_hydration_mismatch_test.clj
@@ -45,7 +45,8 @@
             [re-frame.frame :as frame]
             [re-frame.subs :as subs]
             [re-frame.ssr :as ssr]
-            [re-frame.ssr.test-fixture :as tf]))
+            [re-frame.ssr.test-fixture :as tf]
+            [re-frame.test-support :refer [with-trace-recorder!]]))
 
 (use-fixtures :each tf/reset-runtime)
 
@@ -72,14 +73,6 @@
   (rf/reg-sub :count     (fn [db _] (or (:count db) 0)))
   ;; EP-0001 (rf2-vzld77): the SSR hydration metadata is durable runtime-db state.
   (subs/reg-runtime-sub :hydrated? (fn [rt _] (boolean (get-in rt [:rf.runtime/ssr :hydration])))))
-
-(defn- capture-traces!
-  [f]
-  (let [traces (atom [])
-        cb-id  (gensym "::ssr-hydration-mismatch-capture-")]
-    (rf/register-listener! :trace cb-id (fn [ev] (swap! traces conj ev)))
-    (try (f) (finally (rf/unregister-listener! :trace cb-id)))
-    @traces))
 
 (def ^:private hex-8-pattern #"^[0-9a-f]{8}$")
 
@@ -126,33 +119,30 @@
     (let [client-frame   (frame/make-anon-frame-record! {:doc "ssr-mismatch client frame"
                                          :platform :client})
           ;; A second 8-hex string — anything other than \"deadbeef\".
-          client-hash    "0badf00d"
-          _              (rf/dispatch-sync [:rf/hydrate mismatch-payload]
-                                           {:frame client-frame})
-          traces         (capture-traces!
-                           (fn []
-                             (ssr/verify-hydration! client-frame
-                                                    client-hash)))
-          mismatches     (filter #(= :rf.ssr/hydration-mismatch (:operation %))
-                                 traces)]
-      (is (= 1 (count mismatches))
-          (str "expected exactly one :rf.ssr/hydration-mismatch trace; saw: "
-               (pr-str (mapv :operation traces))))
-      (when (seq mismatches)
-        (let [ev (first mismatches)]
-          (is (= "deadbeef" (-> ev :tags :server-hash))
-              ":tags :server-hash echoes the payload's known-wrong literal")
-          (is (= client-hash (-> ev :tags :client-hash))
-              ":tags :client-hash echoes the value we passed to
-               verify-hydration!")
-          (is (= :rf/hydrate (-> ev :tags :failing-id))
-              ":tags :failing-id discriminator per Spec 011 v1
-               (body-mismatch; runtime head-mismatch reserved for the
-               still-deferred post-v1 head-only-hash extension —
-               reg-head itself has already shipped)")
-          (is (= :warned-and-replaced (:recovery ev))
-              ":recovery hoisted onto the envelope top-level
-               (Spec 009 §Error event shape)"))))))
+          client-hash    "0badf00d"]
+      (rf/dispatch-sync [:rf/hydrate mismatch-payload] {:frame client-frame})
+      (with-trace-recorder! [traces]
+        (ssr/verify-hydration! client-frame client-hash)
+        (let [mismatches (filter #(= :rf.ssr/hydration-mismatch (:operation %))
+                                 @traces)]
+          (is (= 1 (count mismatches))
+              (str "expected exactly one :rf.ssr/hydration-mismatch trace; saw: "
+                   (pr-str (mapv :operation @traces))))
+          (when (seq mismatches)
+            (let [ev (first mismatches)]
+              (is (= "deadbeef" (-> ev :tags :server-hash))
+                  ":tags :server-hash echoes the payload's known-wrong literal")
+              (is (= client-hash (-> ev :tags :client-hash))
+                  ":tags :client-hash echoes the value we passed to
+                   verify-hydration!")
+              (is (= :rf/hydrate (-> ev :tags :failing-id))
+                  ":tags :failing-id discriminator per Spec 011 v1
+                   (body-mismatch; runtime head-mismatch reserved for the
+                   still-deferred post-v1 head-only-hash extension —
+                   reg-head itself has already shipped)")
+              (is (= :warned-and-replaced (:recovery ev))
+                  ":recovery hoisted onto the envelope top-level
+                   (Spec 009 §Error event shape)"))))))))
 
 (deftest mismatch-trace-client-hash-is-8-char-lowercase-hex
   (testing "Migrated from testbeds/ssr_hydration_mismatch/spec.cjs
@@ -172,34 +162,31 @@
           ;; invariant, not the literal.
           render-tree  [:div {:data-testid "counter-panel"}
                         [:p "count=" [:span {:data-testid "count"} 0]]]
-          client-hash  (rf/render-tree-hash render-tree)
-          _            (rf/dispatch-sync [:rf/hydrate mismatch-payload]
-                                         {:frame client-frame})
-          traces       (capture-traces!
-                         (fn []
-                           (ssr/verify-hydration! client-frame
-                                                  render-tree)))
-          mismatch     (first (filter #(= :rf.ssr/hydration-mismatch
+          client-hash  (rf/render-tree-hash render-tree)]
+      (rf/dispatch-sync [:rf/hydrate mismatch-payload] {:frame client-frame})
+      (with-trace-recorder! [traces]
+        (ssr/verify-hydration! client-frame render-tree)
+        (let [mismatch (first (filter #(= :rf.ssr/hydration-mismatch
                                           (:operation %))
-                                      traces))]
-      (is (some? mismatch)
-          ":rf.ssr/hydration-mismatch fires when the resolved tree
-           hashes to anything other than 'deadbeef'")
-      (when mismatch
-        (let [observed (-> mismatch :tags :client-hash)]
-          (is (and (string? observed) (= 8 (count observed)))
-              (str "computed client-hash is exactly 8 chars; got "
-                   (pr-str observed)))
-          (is (re-matches hex-8-pattern observed)
-              (str "computed client-hash is 8-char lowercase hex; got "
-                   (pr-str observed)))
-          (is (= client-hash observed)
-              "the trace echoes the same hash render-tree-hash
-               computes when called directly on the input")
-          (is (not= "deadbeef" observed)
-              "client-hash never equals the (deliberately wrong)
-               server-hash — that would be a hash-collision spec
-               violation"))))))
+                                      @traces))]
+          (is (some? mismatch)
+              ":rf.ssr/hydration-mismatch fires when the resolved tree
+               hashes to anything other than 'deadbeef'")
+          (when mismatch
+            (let [observed (-> mismatch :tags :client-hash)]
+              (is (and (string? observed) (= 8 (count observed)))
+                  (str "computed client-hash is exactly 8 chars; got "
+                       (pr-str observed)))
+              (is (re-matches hex-8-pattern observed)
+                  (str "computed client-hash is 8-char lowercase hex; got "
+                       (pr-str observed)))
+              (is (= client-hash observed)
+                  "the trace echoes the same hash render-tree-hash
+                   computes when called directly on the input")
+              (is (not= "deadbeef" observed)
+                  "client-hash never equals the (deliberately wrong)
+                   server-hash — that would be a hash-collision spec
+                   violation"))))))))
 
 ;; ===========================================================================
 ;; spec.cjs §(3) → the trace's :op-type is :error
@@ -214,19 +201,17 @@
             `re-frame.ssr.hydrate/verify-hydration!`)."
     (register-handlers!)
     (let [client-frame (frame/make-anon-frame-record! {:doc "ssr-mismatch client frame"
-                                       :platform :client})
-          _            (rf/dispatch-sync [:rf/hydrate mismatch-payload]
-                                         {:frame client-frame})
-          traces       (capture-traces!
-                         (fn []
-                           (ssr/verify-hydration! client-frame "0badf00d")))
-          mismatch     (first (filter #(= :rf.ssr/hydration-mismatch
+                                       :platform :client})]
+      (rf/dispatch-sync [:rf/hydrate mismatch-payload] {:frame client-frame})
+      (with-trace-recorder! [traces]
+        (ssr/verify-hydration! client-frame "0badf00d")
+        (let [mismatch (first (filter #(= :rf.ssr/hydration-mismatch
                                           (:operation %))
-                                      traces))]
-      (is (some? mismatch))
-      (when mismatch
-        (is (= :error (:op-type mismatch))
-            ":op-type is :error — Spec 009 categorisation")))))
+                                      @traces))]
+          (is (some? mismatch))
+          (when mismatch
+            (is (= :error (:op-type mismatch))
+                ":op-type is :error — Spec 009 categorisation")))))))
 
 ;; ===========================================================================
 ;; spec.cjs §(4) → page is still interactive post-mismatch
@@ -254,8 +239,8 @@
       ;; Fire the mismatch trace (otherwise this test would pass
       ;; vacuously — we want to assert the dispatch survives
       ;; the recovery, not just that it works without one).
-      (capture-traces!
-        (fn [] (ssr/verify-hydration! client-frame "0badf00d")))
+      (with-trace-recorder! [_traces]
+        (ssr/verify-hydration! client-frame "0badf00d"))
 
       (rf/dispatch-sync [::inc] {:frame client-frame})
       (is (= 1 (rf/subscribe-once [:count] {:frame client-frame}))
@@ -317,16 +302,15 @@
                                        :platform :client
                                        :ssr {:on-mismatch :hard-error}})]
       (rf/dispatch-sync [:rf/hydrate mismatch-payload] {:frame client-frame})
-      (let [traces (capture-traces!
-                     (fn []
-                       (try (ssr/verify-hydration! client-frame "0badf00d")
-                            (catch clojure.lang.ExceptionInfo _ nil))))
-            mismatch (first (filter #(= :rf.ssr/hydration-mismatch (:operation %))
-                                    traces))]
-        (is (some? mismatch)
-            "the mismatch trace fires even in strict mode")
-        (is (= :hard-error (:recovery mismatch))
-            "the trace's :recovery reflects strict mode")))))
+      (with-trace-recorder! [traces]
+        (try (ssr/verify-hydration! client-frame "0badf00d")
+             (catch clojure.lang.ExceptionInfo _ nil))
+        (let [mismatch (first (filter #(= :rf.ssr/hydration-mismatch (:operation %))
+                                      @traces))]
+          (is (some? mismatch)
+              "the mismatch trace fires even in strict mode")
+          (is (= :hard-error (:recovery mismatch))
+              "the trace's :recovery reflects strict mode"))))))
 
 (deftest mismatch-detection-disabled-skips-comparison
   (testing "rf2-ee38b.10 — a frame with :ssr {:detect-mismatch? false}
@@ -337,14 +321,13 @@
                                        :platform :client
                                        :ssr {:detect-mismatch? false}})]
       (rf/dispatch-sync [:rf/hydrate mismatch-payload] {:frame client-frame})
-      (let [traces (capture-traces!
-                     (fn []
-                       (is (nil? (ssr/verify-hydration! client-frame "0badf00d"))
-                           "verify-hydration! is a no-op when detection is off")))
-            mismatches (filter #(= :rf.ssr/hydration-mismatch (:operation %))
-                               traces)]
-        (is (empty? mismatches)
-            "no mismatch trace fires when :detect-mismatch? is false")))))
+      (with-trace-recorder! [traces]
+        (is (nil? (ssr/verify-hydration! client-frame "0badf00d"))
+            "verify-hydration! is a no-op when detection is off")
+        (let [mismatches (filter #(= :rf.ssr/hydration-mismatch (:operation %))
+                                 @traces)]
+          (is (empty? mismatches)
+              "no mismatch trace fires when :detect-mismatch? is false"))))))
 
 (deftest mismatch-detection-defaults-on-when-knob-absent
   (testing "rf2-ee38b.10 — absence of the :detect-mismatch? knob (the
@@ -355,10 +338,10 @@
     (let [client-frame (frame/make-anon-frame-record! {:doc "ssr default frame"
                                        :platform :client})]
       (rf/dispatch-sync [:rf/hydrate mismatch-payload] {:frame client-frame})
-      (let [traces (capture-traces!
-                     (fn [] (ssr/verify-hydration! client-frame "0badf00d")))
-            mismatch (first (filter #(= :rf.ssr/hydration-mismatch (:operation %))
-                                    traces))]
-        (is (some? mismatch) "detection defaults on")
-        (is (= :warned-and-replaced (:recovery mismatch))
-            "the default recovery is warn-and-replace (not hard-error)")))))
+      (with-trace-recorder! [traces]
+        (ssr/verify-hydration! client-frame "0badf00d")
+        (let [mismatch (first (filter #(= :rf.ssr/hydration-mismatch (:operation %))
+                                      @traces))]
+          (is (some? mismatch) "detection defaults on")
+          (is (= :warned-and-replaced (:recovery mismatch))
+              "the default recovery is warn-and-replace (not hard-error)"))))))

--- a/implementation/ssr/test/re_frame/ssr_hydration_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_hydration_test.clj
@@ -48,7 +48,8 @@
             [re-frame.subs :as subs]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.payload-policy :as payload-policy]
-            [re-frame.ssr.test-fixture :as tf]))
+            [re-frame.ssr.test-fixture :as tf]
+            [re-frame.test-support :refer [with-trace-recorder!]]))
 
 (use-fixtures :each tf/reset-runtime)
 
@@ -111,15 +112,6 @@
   (cond-> payload
     (and (map? payload) (:rf/response payload))
     (update :rf/app-db assoc :server-response (:rf/response payload))))
-
-(defn- capture-traces!
-  "Run f under a trace listener; return the captured event vector."
-  [f]
-  (let [traces (atom [])
-        cb-id  (gensym "::ssr-hydration-capture-")]
-    (rf/register-listener! :trace cb-id (fn [ev] (swap! traces conj ev)))
-    (try (f) (finally (rf/unregister-listener! :trace cb-id)))
-    @traces))
 
 ;; ===========================================================================
 ;; spec.cjs §(2)+(3) → hydrated marker + seeded state from payload
@@ -233,24 +225,22 @@
     (register-baseline-handlers!)
     (let [client-frame (frame/make-anon-frame-record! {:doc "ssr-basic client frame"
                                        :platform :client})
-          payload      (materialise-response baseline-payload)
-          traces       (capture-traces!
-                         (fn []
-                           (rf/dispatch-sync [:rf/hydrate payload]
-                                             {:frame client-frame})))
-          skipped      (filter #(= :rf.ssr/compatibility-check-skipped
-                                   (:operation %))
-                               traces)]
-      (is (seq skipped)
-          (str "expected at least one :rf.ssr/compatibility-check-skipped "
-               "trace (the baseline surface registers no "
-               ":rf2/runtime-version hook); saw operations: "
-               (pr-str (mapv :operation traces))))
-      (let [ev (first skipped)]
-        (is (= :rf.ssr/check-version (-> ev :tags :check))
-            "tag :check identifies the originating compatibility-check fx")
-        (is (= 1 (-> ev :tags :expected))
-            "tag :expected carries the payload's :rf/version verbatim")))))
+          payload      (materialise-response baseline-payload)]
+      (with-trace-recorder! [traces]
+        (rf/dispatch-sync [:rf/hydrate payload] {:frame client-frame})
+        (let [skipped (filter #(= :rf.ssr/compatibility-check-skipped
+                                  (:operation %))
+                              @traces)]
+          (is (seq skipped)
+              (str "expected at least one :rf.ssr/compatibility-check-skipped "
+                   "trace (the baseline surface registers no "
+                   ":rf2/runtime-version hook); saw operations: "
+                   (pr-str (mapv :operation @traces))))
+          (let [ev (first skipped)]
+            (is (= :rf.ssr/check-version (-> ev :tags :check))
+                "tag :check identifies the originating compatibility-check fx")
+            (is (= 1 (-> ev :tags :expected))
+                "tag :expected carries the payload's :rf/version verbatim")))))))
 
 ;; ===========================================================================
 ;; spec.cjs §(7) → NO mismatch trace on the baseline
@@ -278,26 +268,24 @@
           ;; from "absent because no schema-digest".
           payload      (-> baseline-payload
                            (assoc :rf/schema-digest "test-digest-abc")
-                           materialise-response)
-          traces       (capture-traces!
-                         (fn []
-                           (rf/dispatch-sync [:rf/hydrate payload]
-                                             {:frame server-frame})))
-          skipped-checks
-          (filter (fn [ev]
-                    (and (= :rf.fx/skipped-on-platform (:operation ev))
-                         (#{:rf.ssr/check-version :rf.ssr/check-schema-digest}
-                          (-> ev :tags :rf.fx/id))))
-                  traces)]
-      (is (empty? skipped-checks)
-          (str "expected zero :rf.fx/skipped-on-platform traces for the two "
-               ":rf.ssr/check-* fxs on a :server-platform :rf/hydrate; saw: "
-               (pr-str (mapv (juxt :operation #(-> % :tags :rf.fx/id))
-                             skipped-checks))))
-      ;; Sanity: the handler still landed the app-db swap + metadata —
-      ;; the gate skipped only the check-fx dispatches, not the rest.
-      (is (= 7 (rf/subscribe-once [:count] {:frame server-frame}))
-          ":rf/app-db still applied on the server-side run"))))
+                           materialise-response)]
+      (with-trace-recorder! [traces]
+        (rf/dispatch-sync [:rf/hydrate payload] {:frame server-frame})
+        (let [skipped-checks
+              (filter (fn [ev]
+                        (and (= :rf.fx/skipped-on-platform (:operation ev))
+                             (#{:rf.ssr/check-version :rf.ssr/check-schema-digest}
+                              (-> ev :tags :rf.fx/id))))
+                      @traces)]
+          (is (empty? skipped-checks)
+              (str "expected zero :rf.fx/skipped-on-platform traces for the two "
+                   ":rf.ssr/check-* fxs on a :server-platform :rf/hydrate; saw: "
+                   (pr-str (mapv (juxt :operation #(-> % :tags :rf.fx/id))
+                                 skipped-checks))))
+          ;; Sanity: the handler still landed the app-db swap + metadata —
+          ;; the gate skipped only the check-fx dispatches, not the rest.
+          (is (= 7 (rf/subscribe-once [:count] {:frame server-frame}))
+              ":rf/app-db still applied on the server-side run"))))))
 
 (deftest hydration-on-client-platform-still-dispatches-check-fxs
   (testing "Per rf2-7bcn0 (counter-test to the server-side skip): on a
@@ -310,23 +298,21 @@
     (register-baseline-handlers!)
     (let [client-frame (frame/make-anon-frame-record! {:doc "ssr-basic client frame"
                                        :platform :client})
-          payload      (materialise-response baseline-payload)
-          traces       (capture-traces!
-                         (fn []
-                           (rf/dispatch-sync [:rf/hydrate payload]
-                                             {:frame client-frame})))
-          skipped (filter #(= :rf.ssr/compatibility-check-skipped
-                              (:operation %))
-                          traces)]
-      ;; Same trace as hydration-baseline-emits-compatibility-check-skipped-trace —
-      ;; the fx STILL fires on the client frame because no
-      ;; :rf2/runtime-version hook is registered. Asserts the
-      ;; rf2-7bcn0 gate did NOT over-skip on :client.
-      (is (seq skipped)
-          (str "on :client the :rf.ssr/check-version fx still fires and "
-               "emits :rf.ssr/compatibility-check-skipped (no runtime-"
-               "version hook registered); saw operations: "
-               (pr-str (mapv :operation traces)))))))
+          payload      (materialise-response baseline-payload)]
+      (with-trace-recorder! [traces]
+        (rf/dispatch-sync [:rf/hydrate payload] {:frame client-frame})
+        (let [skipped (filter #(= :rf.ssr/compatibility-check-skipped
+                                  (:operation %))
+                              @traces)]
+          ;; Same trace as hydration-baseline-emits-compatibility-check-skipped-trace —
+          ;; the fx STILL fires on the client frame because no
+          ;; :rf2/runtime-version hook is registered. Asserts the
+          ;; rf2-7bcn0 gate did NOT over-skip on :client.
+          (is (seq skipped)
+              (str "on :client the :rf.ssr/check-version fx still fires and "
+                   "emits :rf.ssr/compatibility-check-skipped (no runtime-"
+                   "version hook registered); saw operations: "
+                   (pr-str (mapv :operation @traces)))))))))
 
 (deftest hydration-baseline-no-mismatch-trace-when-server-hash-nil
   (testing "Migrated from testbeds/ssr_basic/spec.cjs assertion #13.
@@ -341,21 +327,20 @@
           payload      (materialise-response baseline-payload)]
       (rf/dispatch-sync [:rf/hydrate payload] {:frame client-frame})
 
-      (let [traces (capture-traces!
-                     (fn []
-                       ;; Simulate the testbed's post-render
-                       ;; verify-hydration! call. The resolved tree is
-                       ;; opaque here — we pass a synthetic 8-hex
-                       ;; "client hash" to mirror the call shape; the
-                       ;; nil server-hash on the metadata block makes
-                       ;; the call a no-op regardless of the client
-                       ;; value (Spec 011 — `(when (and server-hash
-                       ;; client-hash ...) ...)` short-circuits).
-                       (ssr/verify-hydration! client-frame "abcdef01")))]
-        (is (not-any? #(= :rf.ssr/hydration-mismatch (:operation %)) traces)
+      (with-trace-recorder! [traces]
+        ;; Simulate the testbed's post-render
+        ;; verify-hydration! call. The resolved tree is
+        ;; opaque here — we pass a synthetic 8-hex
+        ;; "client hash" to mirror the call shape; the
+        ;; nil server-hash on the metadata block makes
+        ;; the call a no-op regardless of the client
+        ;; value (Spec 011 — `(when (and server-hash
+        ;; client-hash ...) ...)` short-circuits).
+        (ssr/verify-hydration! client-frame "abcdef01")
+        (is (not-any? #(= :rf.ssr/hydration-mismatch (:operation %)) @traces)
             (str "no :rf.ssr/hydration-mismatch on the baseline (server-"
                  "hash was nil); saw: "
-                 (pr-str (mapv :operation traces))))))))
+                 (pr-str (mapv :operation @traces))))))))
 
 ;; ===========================================================================
 ;; rf2-gro94 — fail CLOSED on a malformed / untrusted hydration payload
@@ -391,10 +376,8 @@
         ;; it SURVIVES (was not replaced by the malformed payload).
         (rf/dispatch-sync [::set-title "pre-hydration"] {:frame client-frame})
         (rf/dispatch-sync [::inc] {:frame client-frame})  ;; count 0 → 1
-        (let [traces (capture-traces!
-                       (fn []
-                         (rf/dispatch-sync [:rf/hydrate bad-payload]
-                                           {:frame client-frame})))]
+        (with-trace-recorder! [traces]
+          (rf/dispatch-sync [:rf/hydrate bad-payload] {:frame client-frame})
           (is (= "pre-hydration" (rf/subscribe-once [:title] {:frame client-frame}))
               (str (pr-str bad-payload)
                    " must NOT replace the client :title (fail closed)"))
@@ -404,10 +387,10 @@
           (is (false? (rf/subscribe-once [:hydrated?] {:frame client-frame}))
               (str (pr-str bad-payload)
                    " must NOT stash hydration metadata (rejected, not applied)"))
-          (is (some #(= :rf.error/malformed-hydration-payload (:operation %)) traces)
+          (is (some #(= :rf.error/malformed-hydration-payload (:operation %)) @traces)
               (str (pr-str bad-payload)
                    " must emit :rf.error/malformed-hydration-payload; saw: "
-                   (pr-str (mapv :operation traces)))))))))
+                   (pr-str (mapv :operation @traces)))))))))
 
 (deftest wellformed-hydration-payload-still-applies-through-router
   (testing "rf2-gro94 — the fail-closed guard is precise: a well-formed
@@ -417,25 +400,22 @@
             neither emits the malformed diagnostic."
     (register-baseline-handlers!)
     ;; (a) full server slice → replaces app-db, no diagnostic.
-    (let [client-frame (frame/make-anon-frame-record! {:doc "client frame a" :platform :client})
-          traces       (capture-traces!
-                         (fn []
-                           (rf/dispatch-sync [:rf/hydrate {:rf/app-db {:count 7 :title "seeded"}}]
-                                             {:frame client-frame})))]
-      (is (= 7 (rf/subscribe-once [:count] {:frame client-frame})) "server slice installed")
-      (is (= "seeded" (rf/subscribe-once [:title] {:frame client-frame})))
-      (is (not-any? #(= :rf.error/malformed-hydration-payload (:operation %)) traces)
-          "no malformed diagnostic on a well-formed payload"))
+    (let [client-frame (frame/make-anon-frame-record! {:doc "client frame a" :platform :client})]
+      (with-trace-recorder! [traces]
+        (rf/dispatch-sync [:rf/hydrate {:rf/app-db {:count 7 :title "seeded"}}]
+                          {:frame client-frame})
+        (is (= 7 (rf/subscribe-once [:count] {:frame client-frame})) "server slice installed")
+        (is (= "seeded" (rf/subscribe-once [:title] {:frame client-frame})))
+        (is (not-any? #(= :rf.error/malformed-hydration-payload (:operation %)) @traces)
+            "no malformed diagnostic on a well-formed payload")))
     ;; (b) map payload with no app-db slice → existing client data survives.
     (let [client-frame (frame/make-anon-frame-record! {:doc "client frame b" :platform :client})]
       (rf/dispatch-sync [::set-title "kept"] {:frame client-frame})
-      (let [traces (capture-traces!
-                     (fn []
-                       (rf/dispatch-sync [:rf/hydrate {:rf/version 1}]
-                                         {:frame client-frame})))]
+      (with-trace-recorder! [traces]
+        (rf/dispatch-sync [:rf/hydrate {:rf/version 1}] {:frame client-frame})
         (is (= "kept" (rf/subscribe-once [:title] {:frame client-frame}))
             "no-slice payload preserves the existing client slice")
-        (is (not-any? #(= :rf.error/malformed-hydration-payload (:operation %)) traces)
+        (is (not-any? #(= :rf.error/malformed-hydration-payload (:operation %)) @traces)
             "a no-slice map payload is the legitimate client-only fallback, not malformed")))))
 
 ;; ===========================================================================
@@ -486,40 +466,38 @@
         (rf/dispatch-sync [::inc] {:frame client-frame})       ;; count 0 → 1
         (rf/dispatch-sync [::seed-runtime] {:frame client-frame})
         (let [bad-payload {:rf/app-db   {:count 99 :title "would-replace"}
-                           :rf/runtime-db bad-rt}
-              traces (capture-traces!
-                       (fn []
-                         (rf/dispatch-sync [:rf/hydrate bad-payload]
-                                           {:frame client-frame})))]
-          ;; app-db partition unchanged — the valid :rf/app-db slice must
-          ;; NOT land because the runtime-db slice made the payload malformed.
-          (is (= "pre-hydration" (rf/subscribe-once [:title] {:frame client-frame}))
-              (str (pr-str bad-rt)
-                   " runtime-db slice must NOT let the app-db slice replace :title"))
-          (is (= 1 (rf/subscribe-once [:count] {:frame client-frame}))
-              (str (pr-str bad-rt)
-                   " runtime-db slice must NOT let the app-db slice replace :count"))
-          ;; runtime-db partition unchanged — seeded machine snapshot survives.
-          (is (= {:m {:value :idle}}
-                 (rf/subscribe-once [:machine-snapshots] {:frame client-frame}))
-              (str (pr-str bad-rt)
-                   " must leave the runtime-db partition (machine snapshot) unchanged"))
-          ;; no hydration metadata stashed (rejected, not applied).
-          (is (false? (rf/subscribe-once [:hydrated?] {:frame client-frame}))
-              (str (pr-str bad-rt)
-                   " must NOT stash hydration metadata (rejected, not applied)"))
-          ;; the malformed diagnostic fires.
-          (is (some #(= :rf.error/malformed-hydration-payload (:operation %)) traces)
-              (str (pr-str bad-rt)
-                   " must emit :rf.error/malformed-hydration-payload; saw: "
-                   (pr-str (mapv :operation traces))))
-          ;; no compatibility-check fxs fire on the rejected path.
-          (is (not-any? #(#{:rf.ssr/version-mismatch
-                            :rf.ssr/schema-digest-mismatch
-                            :rf.ssr/compatibility-check-skipped}
-                          (:operation %)) traces)
-              (str (pr-str bad-rt)
-                   " must NOT fire compatibility-check fxs on the rejected path")))))))
+                           :rf/runtime-db bad-rt}]
+          (with-trace-recorder! [traces]
+            (rf/dispatch-sync [:rf/hydrate bad-payload] {:frame client-frame})
+            ;; app-db partition unchanged — the valid :rf/app-db slice must
+            ;; NOT land because the runtime-db slice made the payload malformed.
+            (is (= "pre-hydration" (rf/subscribe-once [:title] {:frame client-frame}))
+                (str (pr-str bad-rt)
+                     " runtime-db slice must NOT let the app-db slice replace :title"))
+            (is (= 1 (rf/subscribe-once [:count] {:frame client-frame}))
+                (str (pr-str bad-rt)
+                     " runtime-db slice must NOT let the app-db slice replace :count"))
+            ;; runtime-db partition unchanged — seeded machine snapshot survives.
+            (is (= {:m {:value :idle}}
+                   (rf/subscribe-once [:machine-snapshots] {:frame client-frame}))
+                (str (pr-str bad-rt)
+                     " must leave the runtime-db partition (machine snapshot) unchanged"))
+            ;; no hydration metadata stashed (rejected, not applied).
+            (is (false? (rf/subscribe-once [:hydrated?] {:frame client-frame}))
+                (str (pr-str bad-rt)
+                     " must NOT stash hydration metadata (rejected, not applied)"))
+            ;; the malformed diagnostic fires.
+            (is (some #(= :rf.error/malformed-hydration-payload (:operation %)) @traces)
+                (str (pr-str bad-rt)
+                     " must emit :rf.error/malformed-hydration-payload; saw: "
+                     (pr-str (mapv :operation @traces))))
+            ;; no compatibility-check fxs fire on the rejected path.
+            (is (not-any? #(#{:rf.ssr/version-mismatch
+                              :rf.ssr/schema-digest-mismatch
+                              :rf.ssr/compatibility-check-skipped}
+                            (:operation %)) @traces)
+                (str (pr-str bad-rt)
+                     " must NOT fire compatibility-check fxs on the rejected path"))))))))
 
 (deftest wellformed-runtime-db-slice-still-installs-through-router
   (testing "rf2-g00l2t — the runtime-db guard is precise: a well-formed map
@@ -532,24 +510,21 @@
     ;; (a) map runtime-db slice → installs the runtime-db partition.
     (let [client-frame (frame/make-anon-frame-record! {:doc "rt-ok client frame" :platform :client})
           payload {:rf/app-db     {:count 7 :title "seeded"}
-                   :rf/runtime-db {:rf.runtime/routing {:current {:route-id :home}}}}
-          traces  (capture-traces!
-                    (fn []
-                      (rf/dispatch-sync [:rf/hydrate payload] {:frame client-frame})))]
-      (is (= 7 (rf/subscribe-once [:count] {:frame client-frame})) "app-db slice installed")
-      (is (= {:route-id :home} (rf/subscribe-once [:route-current] {:frame client-frame}))
-          "the runtime-db route slice rode the payload and installed")
-      (is (not-any? #(= :rf.error/malformed-hydration-payload (:operation %)) traces)
-          "no malformed diagnostic on a well-formed two-partition payload"))
+                   :rf/runtime-db {:rf.runtime/routing {:current {:route-id :home}}}}]
+      (with-trace-recorder! [traces]
+        (rf/dispatch-sync [:rf/hydrate payload] {:frame client-frame})
+        (is (= 7 (rf/subscribe-once [:count] {:frame client-frame})) "app-db slice installed")
+        (is (= {:route-id :home} (rf/subscribe-once [:route-current] {:frame client-frame}))
+            "the runtime-db route slice rode the payload and installed")
+        (is (not-any? #(= :rf.error/malformed-hydration-payload (:operation %)) @traces)
+            "no malformed diagnostic on a well-formed two-partition payload")))
     ;; (b) wholly-absent :rf/runtime-db key → no-server-runtime fallback.
-    (let [client-frame (frame/make-anon-frame-record! {:doc "rt-absent client frame" :platform :client})
-          traces (capture-traces!
-                   (fn []
-                     (rf/dispatch-sync [:rf/hydrate {:rf/app-db {:count 3}}]
-                                       {:frame client-frame})))]
-      (is (= 3 (rf/subscribe-once [:count] {:frame client-frame})) "app-db slice installed")
-      (is (not-any? #(= :rf.error/malformed-hydration-payload (:operation %)) traces)
-          "an absent :rf/runtime-db key is the no-server-runtime fallback, not malformed"))))
+    (let [client-frame (frame/make-anon-frame-record! {:doc "rt-absent client frame" :platform :client})]
+      (with-trace-recorder! [traces]
+        (rf/dispatch-sync [:rf/hydrate {:rf/app-db {:count 3}}] {:frame client-frame})
+        (is (= 3 (rf/subscribe-once [:count] {:frame client-frame})) "app-db slice installed")
+        (is (not-any? #(= :rf.error/malformed-hydration-payload (:operation %)) @traces)
+            "an absent :rf/runtime-db key is the no-server-runtime fallback, not malformed")))))
 
 ;; ===========================================================================
 ;; rf2-1qem4q — the retired plain :app-db hydration alias stays DEAD
@@ -580,11 +555,10 @@
       ;; SURVIVES (was not replaced by the :app-db-keyed payload).
       (rf/dispatch-sync [::set-title "pre-hydration"] {:frame client-frame})
       (rf/dispatch-sync [::inc] {:frame client-frame})  ;; count 0 → 1
-      (let [traces (capture-traces!
-                     (fn []
-                       (rf/dispatch-sync
-                         [:rf/hydrate {:app-db {:count 99 :title "legacy"}}]
-                         {:frame client-frame})))]
+      (with-trace-recorder! [traces]
+        (rf/dispatch-sync
+          [:rf/hydrate {:app-db {:count 99 :title "legacy"}}]
+          {:frame client-frame})
         (is (= 1 (rf/subscribe-once [:count] {:frame client-frame}))
             "the plain :app-db key did NOT replace :count (alias stays dead —
              the 99 from {:app-db {…}} must not land)")
@@ -594,10 +568,10 @@
         (is (false? (rf/subscribe-once [:hydrated?] {:frame client-frame}))
             "no hydration metadata stashed — the :rf/render-hash / :rf/version
              keys are absent, so the no-slice payload installs no metadata")
-        (is (not-any? #(= :rf.error/malformed-hydration-payload (:operation %)) traces)
+        (is (not-any? #(= :rf.error/malformed-hydration-payload (:operation %)) @traces)
             (str "a {:app-db {…}} payload is a map with no :rf/app-db key — the "
                  "legitimate client-only no-slice fallback, NOT malformed; saw: "
-                 (pr-str (mapv :operation traces))))))))
+                 (pr-str (mapv :operation @traces))))))))
 
 ;; ===========================================================================
 ;; rf2-lq2ou — client-side hydration boot helper (ssr/hydrate!)
@@ -695,17 +669,16 @@
           payload       (build-server-payload
                           client-frame {:count 7 :title "seeded"}
                           "server00"                 ;; != the client tree hash
-                          {:version 1 :payload [:count :title]})
-          traces        (capture-traces!
-                          (fn []
-                            (ssr/hydrate!
-                              {:frame          client-frame
-                               :payload        payload
-                               :render-tree-fn (fn [] [:div.app [:span "client-render"]])})))]
-      (is (some #(= :rf.ssr/hydration-mismatch (:operation %)) traces)
-          (str "verify step fired a :rf.ssr/hydration-mismatch (server hash "
-               "'server00' != client render-tree hash); saw: "
-               (pr-str (mapv :operation traces)))))))
+                          {:version 1 :payload [:count :title]})]
+      (with-trace-recorder! [traces]
+        (ssr/hydrate!
+          {:frame          client-frame
+           :payload        payload
+           :render-tree-fn (fn [] [:div.app [:span "client-render"]])})
+        (is (some #(= :rf.ssr/hydration-mismatch (:operation %)) @traces)
+            (str "verify step fired a :rf.ssr/hydration-mismatch (server hash "
+                 "'server00' != client render-tree hash); saw: "
+                 (pr-str (mapv :operation @traces))))))))
 
 (deftest boot-hydrate-verify-step-silent-on-matching-render
   (testing "rf2-lq2ou: when the client render-tree hash MATCHES the server
@@ -724,19 +697,18 @@
           payload       (build-server-payload
                           client-frame {:count 7 :title "seeded"}
                           matched-hash
-                          {:version 1 :payload [:count :title]})
-          traces        (capture-traces!
-                          (fn []
-                            (ssr/hydrate!
-                              {:frame          client-frame
-                               :payload        payload
-                               :render-tree-fn (fn [] client-tree)})))]
-      (is (not-any? #(= :rf.ssr/hydration-mismatch (:operation %)) traces)
-          (str "matching hashes → no :rf.ssr/hydration-mismatch; saw: "
-               (pr-str (mapv :operation traces))))
-      ;; Sanity: the seed still landed (the verify step doesn't gate hydrate).
-      (is (= 7 (rf/subscribe-once [:count] {:frame client-frame}))
-          ":rf/hydrate still applied the seeded slice"))))
+                          {:version 1 :payload [:count :title]})]
+      (with-trace-recorder! [traces]
+        (ssr/hydrate!
+          {:frame          client-frame
+           :payload        payload
+           :render-tree-fn (fn [] client-tree)})
+        (is (not-any? #(= :rf.ssr/hydration-mismatch (:operation %)) @traces)
+            (str "matching hashes → no :rf.ssr/hydration-mismatch; saw: "
+                 (pr-str (mapv :operation @traces))))
+        ;; Sanity: the seed still landed (the verify step doesn't gate hydrate).
+        (is (= 7 (rf/subscribe-once [:count] {:frame client-frame}))
+            ":rf/hydrate still applied the seeded slice")))))
 
 ;; ===========================================================================
 ;; rf2-acjknb — EP-0002: hydrate! requires :frame; payload :rf/frame-id is
@@ -828,35 +800,33 @@
       (let [payload {:rf/frame-id    :some/other-frame
                      :rf/app-db      {:count 42 :title "wrong-frame slice"}
                      :rf/runtime-db  {:rf.runtime/machines {:snapshots {:m :installed}}}
-                     :rf/render-hash "deadbeef"}
-            traces  (capture-traces!
-                      (fn []
-                        (rf/dispatch-sync [:rf/hydrate payload]
-                                          {:frame client-frame})))]
-        ;; app-db partition untouched (fail closed).
-        (is (= 1 (rf/subscribe-once [:count] {:frame client-frame}))
-            "app-db :count survives — the wrong-frame slice was NOT installed")
-        (is (= "pre-hydration" (rf/subscribe-once [:title] {:frame client-frame}))
-            "app-db :title survives — the wrong-frame slice was NOT installed")
-        ;; runtime-db partition untouched (no hydration metadata, no machine
-        ;; snapshots from the rejected payload).
-        (is (false? (rf/subscribe-once [:hydrated?] {:frame client-frame}))
-            "no hydration metadata stashed — the runtime-db partition is left unchanged")
-        (is (nil? (get-in (:rf.db/runtime (rf/frame-state-value client-frame))
-                          [:rf.runtime/machines :snapshots]))
-            "the payload's runtime-db slice did NOT land — runtime-db untouched")
-        ;; the structured mismatch surfaced, carrying the two frames.
-        (let [mismatch (first (filter #(= :rf.error/hydration-frame-id-mismatch
-                                          (:operation %))
-                                      traces))]
-          (is (some? mismatch)
-              (str "must emit :rf.error/hydration-frame-id-mismatch; saw: "
-                   (pr-str (mapv :operation traces))))
-          (when mismatch
-            (is (= client-frame (-> mismatch :tags :target-frame))
-                ":target-frame is the dispatch target frame")
-            (is (= :some/other-frame (-> mismatch :tags :payload-frame-id))
-                ":payload-frame-id is the payload's (server) frame stamp")))))))
+                     :rf/render-hash "deadbeef"}]
+        (with-trace-recorder! [traces]
+          (rf/dispatch-sync [:rf/hydrate payload] {:frame client-frame})
+          ;; app-db partition untouched (fail closed).
+          (is (= 1 (rf/subscribe-once [:count] {:frame client-frame}))
+              "app-db :count survives — the wrong-frame slice was NOT installed")
+          (is (= "pre-hydration" (rf/subscribe-once [:title] {:frame client-frame}))
+              "app-db :title survives — the wrong-frame slice was NOT installed")
+          ;; runtime-db partition untouched (no hydration metadata, no machine
+          ;; snapshots from the rejected payload).
+          (is (false? (rf/subscribe-once [:hydrated?] {:frame client-frame}))
+              "no hydration metadata stashed — the runtime-db partition is left unchanged")
+          (is (nil? (get-in (:rf.db/runtime (rf/frame-state-value client-frame))
+                            [:rf.runtime/machines :snapshots]))
+              "the payload's runtime-db slice did NOT land — runtime-db untouched")
+          ;; the structured mismatch surfaced, carrying the two frames.
+          (let [mismatch (first (filter #(= :rf.error/hydration-frame-id-mismatch
+                                            (:operation %))
+                                        @traces))]
+            (is (some? mismatch)
+                (str "must emit :rf.error/hydration-frame-id-mismatch; saw: "
+                     (pr-str (mapv :operation @traces))))
+            (when mismatch
+              (is (= client-frame (-> mismatch :tags :target-frame))
+                  ":target-frame is the dispatch target frame")
+              (is (= :some/other-frame (-> mismatch :tags :payload-frame-id))
+                  ":payload-frame-id is the payload's (server) frame stamp"))))))))
 
 ;; ===========================================================================
 ;; rf2-7qbxbm / rf2-mrtis6 census B5 — the always-on corpus leg of the
@@ -892,39 +862,40 @@
           ;; the corpus-listener stand-in (the off-box shipper) records the
           ;; ALWAYS-ON union record.
           corpus       (atom [])
-          _            (rf/register-listener! :errors ::b5-corpus
-                         (fn [record] (swap! corpus conj record)))
           payload      {:rf/frame-id    :secret/other-frame
                         :rf/app-db      {:count 42}
-                        :rf/render-hash "deadbeef"}
-          dev-traces   (capture-traces!
-                         (fn []
-                           (rf/dispatch-sync [:rf/hydrate payload]
-                                             {:frame client-frame})))]
+                        :rf/render-hash "deadbeef"}]
+      ;; The :errors (always-on) corpus listener is a DIFFERENT observation
+      ;; stream from the :trace bus the shared recorder brackets — it stays a
+      ;; direct register/unregister (this test exercises that surface).
+      (rf/register-listener! :errors ::b5-corpus
+        (fn [record] (swap! corpus conj record)))
       (try
-        (let [record   (first (filter #(= :rf.error/hydration-frame-id-mismatch
-                                          (:error %))
-                                      @corpus))
-              dev-trace (first (filter #(= :rf.error/hydration-frame-id-mismatch
-                                           (:operation %))
-                                       dev-traces))]
-          (is (some? record)
-              (str "the frame-id-mismatch fanned out on the ALWAYS-ON axis; "
-                   "saw: " (pr-str (mapv :error @corpus))))
-          (when record
-            (testing "the ALWAYS-ON corpus record redacts the untrusted payload value"
-              (is (= :rf/redacted (:payload-frame-id record))
-                  (str ":payload-frame-id is redacted on the always-on record "
-                       "(routed through project-egress); got "
-                       (pr-str (:payload-frame-id record))))
-              (is (not= :secret/other-frame (:payload-frame-id record))
-                  "the raw deserialised payload frame-id does NOT ride the corpus record")
-              (is (not (re-find #"secret/other-frame" (pr-str record)))
-                  "no raw :secret/other-frame value survives anywhere in the corpus record")))
-          (when dev-trace
-            (testing "the dev trace (DCE'd in production) keeps the raw value for local fidelity"
-              (is (= :secret/other-frame (-> dev-trace :tags :payload-frame-id))
-                  "the dev-trace tags carry the raw payload frame-id (the leak is off-box, not local)"))))
+        (with-trace-recorder! [dev-traces]
+          (rf/dispatch-sync [:rf/hydrate payload] {:frame client-frame})
+          (let [record   (first (filter #(= :rf.error/hydration-frame-id-mismatch
+                                            (:error %))
+                                        @corpus))
+                dev-trace (first (filter #(= :rf.error/hydration-frame-id-mismatch
+                                             (:operation %))
+                                         @dev-traces))]
+            (is (some? record)
+                (str "the frame-id-mismatch fanned out on the ALWAYS-ON axis; "
+                     "saw: " (pr-str (mapv :error @corpus))))
+            (when record
+              (testing "the ALWAYS-ON corpus record redacts the untrusted payload value"
+                (is (= :rf/redacted (:payload-frame-id record))
+                    (str ":payload-frame-id is redacted on the always-on record "
+                         "(routed through project-egress); got "
+                         (pr-str (:payload-frame-id record))))
+                (is (not= :secret/other-frame (:payload-frame-id record))
+                    "the raw deserialised payload frame-id does NOT ride the corpus record")
+                (is (not (re-find #"secret/other-frame" (pr-str record)))
+                    "no raw :secret/other-frame value survives anywhere in the corpus record")))
+            (when dev-trace
+              (testing "the dev trace (DCE'd in production) keeps the raw value for local fidelity"
+                (is (= :secret/other-frame (-> dev-trace :tags :payload-frame-id))
+                    "the dev-trace tags carry the raw payload frame-id (the leak is off-box, not local)")))))
         (finally
           (rf/unregister-listener! :errors ::b5-corpus))))))
 

--- a/implementation/ssr/test/re_frame/ssr_request_cofx_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_request_cofx_test.clj
@@ -28,18 +28,11 @@
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
             [re-frame.ssr :as ssr]
-            [re-frame.ssr.test-fixture :as tf]))
+            [re-frame.ssr.test-fixture :as tf]
+            [re-frame.test-support :refer [with-trace-recorder!]]))
 
 ;; Shared reset fixture lives in `re-frame.ssr.test-fixture` (rf2-i3qc0).
 (use-fixtures :each tf/reset-runtime)
-
-(defn- collect-traces!
-  "Register a trace listener under `id`, returning the atom that
-  accumulates events. Tests must (rf/unregister-listener! :trace id) to detach."
-  [id]
-  (let [acc (atom [])]
-    (rf/register-listener! :trace id (fn [ev] (swap! acc conj ev)))
-    acc))
 
 ;; ---- registration -----------------------------------------------------------
 ;;
@@ -137,35 +130,34 @@
   (testing ":rf.server/request is skipped on a :platform :client frame
             and emits :rf.cofx/skipped-on-platform"
     (let [client-frame (frame/make-anon-frame-record! {:platform :client})
-          traces       (collect-traces! ::req-client)
           observed     (atom :unset)]
-      (rf/reg-event :req-test/read-on-client
-        {:rf.cofx/requires [:rf.server/request]}
-        (fn [{:keys [rf.server/request] :as ctx} _]
-          (reset! observed
-                  (if (contains? ctx :rf.server/request)
-                    [:present request]
-                    [:absent  request]))
-          {}))
-      (rf/dispatch-sync [:req-test/read-on-client] {:frame client-frame})
-      (rf/unregister-listener! :trace ::req-client)
+      (with-trace-recorder! [traces]
+        (rf/reg-event :req-test/read-on-client
+          {:rf.cofx/requires [:rf.server/request]}
+          (fn [{:keys [rf.server/request] :as ctx} _]
+            (reset! observed
+                    (if (contains? ctx :rf.server/request)
+                      [:present request]
+                      [:absent  request]))
+            {}))
+        (rf/dispatch-sync [:req-test/read-on-client] {:frame client-frame})
 
-      (is (= [:absent nil] @observed)
-          "the cofx did NOT run — :rf.server/request is absent from coeffects")
+        (is (= [:absent nil] @observed)
+            "the cofx did NOT run — :rf.server/request is absent from coeffects")
 
-      (let [skips (filter #(= :rf.cofx/skipped-on-platform (:operation %))
-                          @traces)]
-        (is (= 1 (count skips))
-            "exactly one :rf.cofx/skipped-on-platform trace was emitted")
-        (let [t (first skips)]
-          (is (= :rf.server/request (get-in t [:tags :rf.cofx/id]))
-              ":rf.cofx/id identifies the gated cofx")
-          (is (= :client (get-in t [:tags :rf.cofx/platform]))
-              ":rf.cofx/platform carries the active platform that excluded the cofx")
-          (is (= #{:server} (get-in t [:tags :rf.cofx/registered-platforms]))
-              ":rf.cofx/registered-platforms surfaces the cofx's declared set")
-          (is (= :skipped (:recovery t))
-              ":recovery is :skipped — the runtime declined to act"))))))
+        (let [skips (filter #(= :rf.cofx/skipped-on-platform (:operation %))
+                            @traces)]
+          (is (= 1 (count skips))
+              "exactly one :rf.cofx/skipped-on-platform trace was emitted")
+          (let [t (first skips)]
+            (is (= :rf.server/request (get-in t [:tags :rf.cofx/id]))
+                ":rf.cofx/id identifies the gated cofx")
+            (is (= :client (get-in t [:tags :rf.cofx/platform]))
+                ":rf.cofx/platform carries the active platform that excluded the cofx")
+            (is (= #{:server} (get-in t [:tags :rf.cofx/registered-platforms]))
+                ":rf.cofx/registered-platforms surfaces the cofx's declared set")
+            (is (= :skipped (:recovery t))
+                ":recovery is :skipped — the runtime declined to act")))))))
 
 ;; ---- frame isolation -------------------------------------------------------
 ;;

--- a/implementation/ssr/test/re_frame/ssr_request_durable_fact_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_request_durable_fact_test.clj
@@ -27,14 +27,9 @@
             [re-frame.frame :as frame]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.test-fixture :as tf]
-            [re-frame.trace :as trace]))
+            [re-frame.test-support :refer [with-trace-recorder!]]))
 
 (use-fixtures :each tf/reset-runtime)
-
-(defn- collect-traces! [id]
-  (let [acc (atom [])]
-    (rf/register-listener! :trace id (fn [ev] (swap! acc conj ev)))
-    acc))
 
 ;; ---- shape 1: event payload (the sanitized fact rides :event) -------------
 
@@ -88,29 +83,28 @@
   (testing "a PROVIDED recordable request fact absent from the token fails
             LOUDLY with :rf.error/missing-required-cofx — NOT a silent
             fall-back to get-request / nil (the strict-replay contract)"
-    (let [server-frame (frame/make-anon-frame-record! {:platform :server})
-          traces       (collect-traces! ::missing)]
-      (rf/reg-cofx :auth.session/user
-        {:recordable? true :provided? true
-         :doc "Sanitized session user, stamped by the SSR host adapter."})
-      (rf/reg-event :auth/server-init-strict
-        {:platforms        #{:server}
-         :rf.cofx/requires [:auth.session/user]}
-        (fn [{:keys [db auth.session/user]} _]
-          {:db (assoc db :auth/user user)}))
-      ;; Host did NOT stamp :auth.session/user — the provided fact is absent.
-      (let [ex (try (rf/dispatch-sync [:auth/server-init-strict] {:frame server-frame})
-                    nil
-                    (catch clojure.lang.ExceptionInfo e e))]
-        (rf/unregister-listener! :trace ::missing)
-        (is (some? ex) "dispatch threw rather than silently delivering nil")
-        (is (= :rf.error/missing-required-cofx (:rf.error/id (ex-data ex)))
-            "the throw is :rf.error/missing-required-cofx (fail-closed)")
-        (is (seq (filter #(= :rf.error/missing-required-cofx (:operation %)) @traces))
-            "a :rf.error/missing-required-cofx error trace was emitted")
-        ;; And no durable write landed.
-        (is (nil? (:auth/user (frame/frame-app-db-value server-frame)))
-            "no durable app-db slice was written from a missing provided fact")))))
+    (let [server-frame (frame/make-anon-frame-record! {:platform :server})]
+      (with-trace-recorder! [traces]
+        (rf/reg-cofx :auth.session/user
+          {:recordable? true :provided? true
+           :doc "Sanitized session user, stamped by the SSR host adapter."})
+        (rf/reg-event :auth/server-init-strict
+          {:platforms        #{:server}
+           :rf.cofx/requires [:auth.session/user]}
+          (fn [{:keys [db auth.session/user]} _]
+            {:db (assoc db :auth/user user)}))
+        ;; Host did NOT stamp :auth.session/user — the provided fact is absent.
+        (let [ex (try (rf/dispatch-sync [:auth/server-init-strict] {:frame server-frame})
+                      nil
+                      (catch clojure.lang.ExceptionInfo e e))]
+          (is (some? ex) "dispatch threw rather than silently delivering nil")
+          (is (= :rf.error/missing-required-cofx (:rf.error/id (ex-data ex)))
+              "the throw is :rf.error/missing-required-cofx (fail-closed)")
+          (is (seq (filter #(= :rf.error/missing-required-cofx (:operation %)) @traces))
+              "a :rf.error/missing-required-cofx error trace was emitted")
+          ;; And no durable write landed.
+          (is (nil? (:auth/user (frame/frame-app-db-value server-frame)))
+              "no durable app-db slice was written from a missing provided fact"))))))
 
 ;; ---- contrast: the ambient :rf.server/request value is NOT recorded -------
 

--- a/implementation/ssr/test/re_frame/ssr_streaming_corner_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_streaming_corner_test.clj
@@ -27,7 +27,7 @@
             [re-frame.frame :as frame]
             [re-frame.ssr.streaming :as streaming]
             [re-frame.ssr.test-fixture :as tf]
-            [re-frame.trace :as trace]))
+            [re-frame.test-support :refer [with-trace-recorder!]]))
 
 (defn- reset+reg
   [test-fn]
@@ -38,14 +38,6 @@
       (test-fn))))
 
 (use-fixtures :each reset+reg)
-
-(defn- with-trace-capture
-  "Capture every emitted trace event into `coll-atom` during `(body-fn)`."
-  [coll-atom body-fn]
-  (let [k (str (gensym "streaming-corner-cb"))]
-    (trace/register-listener! k (fn [ev] (swap! coll-atom conj ev)))
-    (try (body-fn)
-         (finally (trace/unregister-listener! k)))))
 
 (defn- make-server-frame
   "Register a per-request server frame and seed its app-db via an
@@ -173,46 +165,47 @@
       ;; :fallback rides from `record-continuation!`.
       (let [fid    (make-server-frame)
             entry  (first continuations)
-            captured (atom [])
-            result (with-trace-capture captured
-                     #(streaming/render-continuation fid entry))]
-        (is (= [:p "outer loading"] (:fallback entry))
-            "record-continuation! stored the outer boundary's declared
-             :fallback on the entry")
-        (is (not (:failed? result))
-            "the outer continuation resolves cleanly — the streaming
-             walker recognises the buried :rf/suspense-boundary instead
-             of throwing on it (rf2-sgvn6 / rf2-b1v8v)")
-        (is (empty? (filter #(= :rf.ssr/suspense-boundary-failed (:operation %))
-                            @captured))
-            "NO suspense-boundary-failed trace — the nested boundary is
-             registered, not fail-soft'd")
-        ;; The inner boundary's resolved chunk is NOT in the outer's HTML;
-        ;; instead the outer HTML carries the inner's FALLBACK <template>.
-        (is (str/includes? (:html result) "data-rf2-suspense-id=\":inner\"")
-            "the outer's resolved HTML carries the inner boundary's
-             <template> placeholder (its fallback), stamped with the
-             inner id")
-        (is (str/includes? (:html result) "data-rf2-suspense-fallback=\"1\"")
-            "the inner placeholder is a fallback template (deferred), not
-             the resolved inner body")
-        (is (str/includes? (:html result) "inner loading")
-            "the inner's fallback hiccup materialised inline in the
-             outer's resolved chunk")
-        (is (not (str/includes? (:html result) "inner body"))
-            "the inner BODY is NOT in the outer chunk — it is deferred to
-             the inner continuation's own drain")
-        ;; The new continuation lands on :continuations for the host to
-        ;; append at the TAIL of its FIFO drain queue.
-        (is (= 1 (count (:continuations result)))
-            "render-continuation returns the ONE newly-registered inner
-             continuation for the host to append (FIFO tail)")
-        (is (= :inner (-> result :continuations first :id))
-            "the inner boundary's id propagates on the returned
-             continuation entry")
-        (is (= [:p "inner loading"] (-> result :continuations first :fallback))
-            "the inner continuation carries its declared :fallback")
+            result (with-trace-recorder! [captured]
+                     (let [result (streaming/render-continuation fid entry)]
+                       (is (= [:p "outer loading"] (:fallback entry))
+                           "record-continuation! stored the outer boundary's declared
+                            :fallback on the entry")
+                       (is (not (:failed? result))
+                           "the outer continuation resolves cleanly — the streaming
+                            walker recognises the buried :rf/suspense-boundary instead
+                            of throwing on it (rf2-sgvn6 / rf2-b1v8v)")
+                       (is (empty? (filter #(= :rf.ssr/suspense-boundary-failed (:operation %))
+                                           @captured))
+                           "NO suspense-boundary-failed trace — the nested boundary is
+                            registered, not fail-soft'd")
+                       ;; The inner boundary's resolved chunk is NOT in the outer's HTML;
+                       ;; instead the outer HTML carries the inner's FALLBACK <template>.
+                       (is (str/includes? (:html result) "data-rf2-suspense-id=\":inner\"")
+                           "the outer's resolved HTML carries the inner boundary's
+                            <template> placeholder (its fallback), stamped with the
+                            inner id")
+                       (is (str/includes? (:html result) "data-rf2-suspense-fallback=\"1\"")
+                           "the inner placeholder is a fallback template (deferred), not
+                            the resolved inner body")
+                       (is (str/includes? (:html result) "inner loading")
+                           "the inner's fallback hiccup materialised inline in the
+                            outer's resolved chunk")
+                       (is (not (str/includes? (:html result) "inner body"))
+                           "the inner BODY is NOT in the outer chunk — it is deferred to
+                            the inner continuation's own drain")
+                       ;; The new continuation lands on :continuations for the host to
+                       ;; append at the TAIL of its FIFO drain queue.
+                       (is (= 1 (count (:continuations result)))
+                           "render-continuation returns the ONE newly-registered inner
+                            continuation for the host to append (FIFO tail)")
+                       (is (= :inner (-> result :continuations first :id))
+                           "the inner boundary's id propagates on the returned
+                            continuation entry")
+                       (is (= [:p "inner loading"] (-> result :continuations first :fallback))
+                           "the inner continuation carries its declared :fallback")
+                       result))]
         ;; Draining the inner continuation now resolves the inner body.
+        ;; (post-capture: the inner render is not part of the outer's trace window)
         (let [inner-entry  (-> result :continuations first)
               inner-result (streaming/render-continuation fid inner-entry)]
           (is (not (:failed? inner-result)))
@@ -332,9 +325,10 @@
                 [:rf/suspense-boundary
                  {:id :triple :fallback [:p "third fallback"]}
                  [:p "third body"]]]
-          captured (atom [])
-          {:keys [continuations]}
-          (with-trace-capture captured #(streaming/render-shell tree))]
+          {:keys [continuations captured-traces]}
+          (with-trace-recorder! [captured]
+            (let [{:keys [continuations]} (streaming/render-shell tree)]
+              {:continuations continuations :captured-traces @captured}))]
       (is (= 1 (count continuations))
           "only one continuation survives dedup across three duplicates")
       ;; Drain it — the body should be the LAST registration's body
@@ -354,11 +348,11 @@
              recursion: 'the second registration overwrites the first'
              generalises to N-deep — every-but-last is dropped."))
       (is (some #(= :rf.error/suspense-boundary-duplicate-id (:operation %))
-                @captured)
+                captured-traces)
           "the duplicate-id trace still fires across N=3 duplicates")
       (let [dup-traces (filterv #(= :rf.error/suspense-boundary-duplicate-id
                                     (:operation %))
-                                @captured)]
+                                captured-traces)]
         (is (= 1 (count dup-traces))
             "one trace, not three — dedup groups all duplicates of
              the same id into a single trace event")
@@ -394,25 +388,24 @@
                   [throws-sub]]
           {:keys [continuations]} (streaming/render-shell tree)
           fid (make-server-frame)
-          entry (assoc (first continuations) :fallback [throws-fb])
-          captured (atom [])
-          result (with-trace-capture captured
-                   #(streaming/render-continuation fid entry))]
-      (is (:failed? result)
-          ":failed? is true when the subtree throws — even though
-           the fallback render also throws")
-      (is (= "" (:html result))
-          "fallback-render throw → empty html (the inner try/catch in
-           streaming.cljc renders fallback OR returns \"\" on its own
-           throw)")
-      (is (nil? (:delta result))
-          "delta still omitted on failure")
-      (is (some #(= :rf.ssr/suspense-boundary-failed (:operation %))
-                @captured)
-          "the suspense-boundary-failed trace still fires for the
-           subtree throw — even though the fallback also failed
-           (the trace describes the SUBTREE failure, which is what
-           the client cares about)"))))
+          entry (assoc (first continuations) :fallback [throws-fb])]
+      (with-trace-recorder! [captured]
+        (let [result (streaming/render-continuation fid entry)]
+          (is (:failed? result)
+              ":failed? is true when the subtree throws — even though
+               the fallback render also throws")
+          (is (= "" (:html result))
+              "fallback-render throw → empty html (the inner try/catch in
+               streaming.cljc renders fallback OR returns \"\" on its own
+               throw)")
+          (is (nil? (:delta result))
+              "delta still omitted on failure")
+          (is (some #(= :rf.ssr/suspense-boundary-failed (:operation %))
+                    @captured)
+              "the suspense-boundary-failed trace still fires for the
+               subtree throw — even though the fallback also failed
+               (the trace describes the SUBTREE failure, which is what
+               the client cares about)"))))))
 
 (deftest render-continuation-delta-captures-app-db-change-during-render
   (testing "rf2-u91hb: render-continuation snapshots app-db before
@@ -473,17 +466,16 @@
       ;; inline-fallback contract. Either is acceptable per Spec 011
       ;; §Failure semantics; what is NOT acceptable is an uncaught
       ;; throw.
-      (let [captured (atom [])
-            result (with-trace-capture captured
-                     #(streaming/render-continuation fid entry))]
-        (is (map? result)
-            "render-continuation returned a result map — did NOT
-             escape with an uncaught exception even though the frame
-             was destroyed before the call")
-        (is (contains? result :failed?)
-            ":failed? key is present")
-        (is (contains? result :html)
-            ":html key is present")))))
+      (with-trace-recorder! [captured]
+        (let [result (streaming/render-continuation fid entry)]
+          (is (map? result)
+              "render-continuation returned a result map — did NOT
+               escape with an uncaught exception even though the frame
+               was destroyed before the call")
+          (is (contains? result :failed?)
+              ":failed? key is present")
+          (is (contains? result :html)
+              ":html key is present"))))))
 
 ;; ===========================================================================
 ;; build-final-payload — allowlist projection composition

--- a/implementation/ssr/test/re_frame/ssr_streaming_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_streaming_test.clj
@@ -12,7 +12,7 @@
             [re-frame.ssr.streaming :as streaming]
             [re-frame.ssr.streaming.constants :as wire]
             [re-frame.ssr.test-fixture :as tf]
-            [re-frame.trace :as trace]))
+            [re-frame.test-support :refer [with-trace-recorder!]]))
 
 (defn- reset+reg-test-handlers
   "Reset the runtime via the canonical fixture, then re-register the
@@ -25,16 +25,6 @@
       (test-fn))))
 
 (use-fixtures :each reset+reg-test-handlers)
-
-(defn- with-trace-capture
-  "Capture every emitted trace event into `coll-atom` during `(body-fn)`.
-  Removes the listener on exit so test isolation holds."
-  [coll-atom body-fn]
-  (let [k (str (gensym "streaming-test-cb"))]
-    (trace/register-listener! k (fn [ev] (swap! coll-atom conj ev)))
-    (try (body-fn)
-         (finally
-           (trace/unregister-listener! k)))))
 
 (rf/reg-event :rf.test/noop (fn [{:keys [db]} _] {:db db}))
 (rf/reg-event :rf.test/seed-db (fn [{:keys [db]} [_ new-db]] {:db new-db}))
@@ -198,32 +188,30 @@
           ;; bug by manually `(assoc … :fallback [:p "Loading…"])`; with
           ;; the manual assoc removed, an empty fallback on failure (the
           ;; bug) would surface here as a "" :html.
-          entry  (first continuations)
-          captured (atom [])
-          result (with-trace-capture captured
-                   #(streaming/render-continuation fid entry))]
-      (is (= [:p "Loading…"] (:fallback entry))
-          "record-continuation! stored the declared :fallback on the entry")
-      (is (:failed? result) ":failed? truthy")
-      (is (nil? (:delta result)) "delta omitted on failure")
-      (is (= "<p>Loading…</p>" (:html result))
-          "declared fallback hiccup materialised in place (not empty)")
-      (is (some #(= :rf.ssr/suspense-boundary-failed (:operation %))
-                @captured)
-          ":rf.ssr/suspense-boundary-failed trace emitted"))))
+          entry  (first continuations)]
+      (with-trace-recorder! [captured]
+        (let [result (streaming/render-continuation fid entry)]
+          (is (= [:p "Loading…"] (:fallback entry))
+              "record-continuation! stored the declared :fallback on the entry")
+          (is (:failed? result) ":failed? truthy")
+          (is (nil? (:delta result)) "delta omitted on failure")
+          (is (= "<p>Loading…</p>" (:html result))
+              "declared fallback hiccup materialised in place (not empty)")
+          (is (some #(= :rf.ssr/suspense-boundary-failed (:operation %))
+                    @captured)
+              ":rf.ssr/suspense-boundary-failed trace emitted"))))))
 
 (deftest duplicate-id-emits-trace-and-keeps-last
   (testing "Two boundaries with the same :id emit :rf.error/suspense-boundary-duplicate-id"
     (let [tree [:div
                 [:rf/suspense-boundary {:id :dup :fallback [:p "first"]} [:p "first body"]]
-                [:rf/suspense-boundary {:id :dup :fallback [:p "second"]} [:p "second body"]]]
-          captured (atom [])
-          {:keys [continuations]}
-          (with-trace-capture captured #(streaming/render-shell tree))]
-      (is (= 1 (count continuations)) "only one continuation survives dedup")
-      (is (some #(= :rf.error/suspense-boundary-duplicate-id (:operation %))
-                @captured)
-          ":rf.error/suspense-boundary-duplicate-id trace emitted"))))
+                [:rf/suspense-boundary {:id :dup :fallback [:p "second"]} [:p "second body"]]]]
+      (with-trace-recorder! [captured]
+        (let [{:keys [continuations]} (streaming/render-shell tree)]
+          (is (= 1 (count continuations)) "only one continuation survives dedup")
+          (is (some #(= :rf.error/suspense-boundary-duplicate-id (:operation %))
+                    @captured)
+              ":rf.error/suspense-boundary-duplicate-id trace emitted"))))))
 
 ;; ===========================================================================
 ;; rf2-yvc0t7 — duplicate detection keys on the WIRE id, not the raw :id
@@ -247,58 +235,56 @@
             templates carry the same wire id attribute"
     (let [tree [:div
                 [:rf/suspense-boundary {:id :a :fallback [:p "first"]} [:p "first body"]]
-                [:rf/suspense-boundary {:id ":a" :fallback [:p "second"]} [:p "second body"]]]
-          captured (atom [])
-          {:keys [continuations shell-html]}
-          (with-trace-capture captured #(streaming/render-shell tree))]
-      ;; The wire surface: both boundaries stamp the SAME wire id, so the
-      ;; client cannot tell them apart — the collision is real.
-      (is (= 2 (count (re-seq (re-pattern (str wire/attr-suspense-id "=\":a\""))
-                              shell-html)))
-          "both fallback templates stamp the same wire id `:a` — the
-           collision the client would face")
-      ;; The fix: dedup collapses the colliding ids to a single
-      ;; continuation (the old raw-:id grouping left two).
-      (is (= 1 (count continuations))
-          "only one continuation survives dedup on the wire id")
-      ;; Last-write-wins: the surviving entry is the SECOND (string `:a`)
-      ;; registration.
-      (is (= ":a" (:id (first continuations)))
-          "last-write-wins keeps the LAST registration (the string id)")
-      (is (= [:p "second"] (:fallback (first continuations)))
-          "the surviving entry carries the last registration's :fallback")
-      ;; The documented programmer-error trace fires.
-      (let [dup-traces (filterv #(= :rf.error/suspense-boundary-duplicate-id
-                                    (:operation %))
-                                @captured)]
-        (is (= 1 (count dup-traces))
-            ":rf.error/suspense-boundary-duplicate-id fires once for the
-             colliding pair")
-        (when-let [ev (first dup-traces)]
-          (is (= ":a" (get-in ev [:tags :id]))
-              "the trace reports the colliding WIRE id")
-          (is (= 2 (get-in ev [:tags :count]))
-              ":count reports the colliding cardinality")
-          (is (= [:a ":a"] (get-in ev [:tags :raw-ids]))
-              ":raw-ids surfaces the distinct raw ids that collided")
-          (is (= :last-write-wins (:recovery ev))
-              ":recovery names the applied policy"))))))
+                [:rf/suspense-boundary {:id ":a" :fallback [:p "second"]} [:p "second body"]]]]
+      (with-trace-recorder! [captured]
+        (let [{:keys [continuations shell-html]} (streaming/render-shell tree)]
+          ;; The wire surface: both boundaries stamp the SAME wire id, so the
+          ;; client cannot tell them apart — the collision is real.
+          (is (= 2 (count (re-seq (re-pattern (str wire/attr-suspense-id "=\":a\""))
+                                  shell-html)))
+              "both fallback templates stamp the same wire id `:a` — the
+               collision the client would face")
+          ;; The fix: dedup collapses the colliding ids to a single
+          ;; continuation (the old raw-:id grouping left two).
+          (is (= 1 (count continuations))
+              "only one continuation survives dedup on the wire id")
+          ;; Last-write-wins: the surviving entry is the SECOND (string `:a`)
+          ;; registration.
+          (is (= ":a" (:id (first continuations)))
+              "last-write-wins keeps the LAST registration (the string id)")
+          (is (= [:p "second"] (:fallback (first continuations)))
+              "the surviving entry carries the last registration's :fallback")
+          ;; The documented programmer-error trace fires.
+          (let [dup-traces (filterv #(= :rf.error/suspense-boundary-duplicate-id
+                                        (:operation %))
+                                    @captured)]
+            (is (= 1 (count dup-traces))
+                ":rf.error/suspense-boundary-duplicate-id fires once for the
+                 colliding pair")
+            (when-let [ev (first dup-traces)]
+              (is (= ":a" (get-in ev [:tags :id]))
+                  "the trace reports the colliding WIRE id")
+              (is (= 2 (get-in ev [:tags :count]))
+                  ":count reports the colliding cardinality")
+              (is (= [:a ":a"] (get-in ev [:tags :raw-ids]))
+                  ":raw-ids surfaces the distinct raw ids that collided")
+              (is (= :last-write-wins (:recovery ev))
+                  ":recovery names the applied policy"))))))))
 
 (deftest distinct-wire-ids-are-not-deduped
   (testing "rf2-yvc0t7 guard: boundaries with genuinely distinct wire ids
             (the common keyword case) are NOT collapsed"
     (let [tree [:div
                 [:rf/suspense-boundary {:id :a :fallback [:p "fa"]} [:p "ba"]]
-                [:rf/suspense-boundary {:id :b :fallback [:p "fb"]} [:p "bb"]]]
-          captured (atom [])
-          {:keys [continuations]}
-          (with-trace-capture captured #(streaming/render-shell tree))]
-      (is (= 2 (count continuations))
-          "distinct wire ids both survive — no false collapse")
-      (is (empty? (filterv #(= :rf.error/suspense-boundary-duplicate-id
-                               (:operation %))
-                           @captured))
-          "no duplicate-id trace for distinct ids"))))
+                [:rf/suspense-boundary {:id :b :fallback [:p "fb"]} [:p "bb"]]]]
+      (with-trace-recorder! [captured]
+        (let [{:keys [continuations]} (streaming/render-shell tree)]
+          (is (= 2 (count continuations))
+              "distinct wire ids both survive — no false collapse")
+          (is (empty? (filterv #(= :rf.error/suspense-boundary-duplicate-id
+                                   (:operation %))
+                               @captured))
+              "no duplicate-id trace for distinct ids"))))))
 
 (deftest build-final-payload-shape
   (testing "Final payload carries the canonical :rf/hydration-payload shape"


### PR DESCRIPTION
Migrates the SSR and security test suites off their per-file trace-capture
helpers and onto `re-frame.test-support/with-trace-recorder!`, which already
owns the `atom` + `register-listener!` + `try/finally` cleanup.

## rf2-nj0aw8 — SSR tests (commit 1)
Deleted the local `capture-traces!` / `collect-traces!` / `with-trace-capture`
helpers and bracketed their call sites with `with-trace-recorder!`:

- `ssr_request_durable_fact_test.clj` — `collect-traces!` (1 call site)
- `ssr_request_cofx_test.clj` — `collect-traces!` (1)
- `ssr_compatibility_checks_test.clj` — `capture-traces!` (7)
- `ssr_streaming_test.clj` — `with-trace-capture` (4)
- `ssr_streaming_corner_test.clj` — `with-trace-capture` (4)
- `ssr_hydration_mismatch_test.clj` — `capture-traces!` (7)
- `ssr_hydration_test.clj` — `capture-traces!` (15)
- `ssr-ring/.../streaming_writer_trace_test.clj` — `with-trace-capture` (2)

The bead enumerated the seven `implementation/ssr` files; the eighth
(`ssr-ring`'s `streaming_writer_trace_test`) carries the identical
`with-trace-capture` pattern and is covered by the brief's "ssr-ring as
applicable", so it is migrated in the same commit.

Left as direct register/unregister (not part of the shared `:trace` bus):
- `ssr_hydration_test`'s always-on **`:errors`** corpus listener in
  `mismatch-always-on-record-redacts-sensitive-payload-frame-id` — a different
  observation stream `with-trace-recorder!` does not bracket; this test
  exercises that surface directly.

## rf2-u8bw0l — security tests (commit 2)
Replaced the six raw `trace-tooling/register-listener!` brackets across the
four dual-runtime namespaces:

- `error_slot_egress_...` — `emit-machine-action-exception`, `capture-navigate-failure`
- `fail_closed_invariant_...` — `capture`
- `schema_redaction_...` — `failure-trace` (this one **lacked try/finally** and
  could leave a listener registered after a throw; the macro's `finally` now
  guarantees cleanup)
- `validation_redaction_invariant_...` — `capture-op` (+ `capture-failure`
  delegate) and one inline capture block

Per-helper filtering, exception capture (validation's `thrown` atom), and the
`#?(:clj (schemas/clear-sensitive-paths-cache!))` schema-cache cleanup are
preserved. Direct `re-frame.trace.tooling` requires were removed where they
became unused (`re-frame.trace` stays where `emit-error!` is still called). The
macro is referred via the standard reader-conditional (`:refer` on JVM /
`:refer-macros` on CLJS), mirroring how these files already pull `clojure.test`
/ `cljs.test`.

## Stance
Pre-alpha, no back-compat. ELEGANCE + CLARITY + CORRECTNESS + GOOD-PRACTICE:
the change removes duplicated boilerplate and makes every capture window
exception-safe. Identical assertions run through the shared recorder — capture
windows, predicates, capture shape, keys, and listener-registration timing are
preserved. Only imports change; no production or CLJS bundle changes.

## Quality gates
All run in the foreground from the worktree:

- `cd implementation/ssr && clojure -M:test` → 372 tests, 1535 assertions, **0 failures, 0 errors**
- `cd implementation/ssr-ring && clojure -M:test` → 170 tests, 831 assertions, **0 failures, 0 errors**
- `cd implementation/security && clojure -M:test` → 92 tests, 666 assertions, **0 failures, 0 errors**
- `cd implementation && npm run test:cljs` → 8472 tests, 39093 assertions, **0 failures, 0 errors**
