### PR TITLE
refactor(mcp-base): centralize descriptor-manifest drift-report lines (rf2-cbgc40)

### DIFF
--- a/tools/mcp-base/spec/descriptor-manifest.md
+++ b/tools/mcp-base/spec/descriptor-manifest.md
@@ -18,12 +18,14 @@ A generated, CI-guarded manifest prevents the drift the way the keystone's `spec
 - The **catalogue-row projection** (`descriptor->row`): the stable shape one registry descriptor maps to.
 - The **deterministic, byte-stable, LF-pinned EDN serialiser** (`render-edn`) — one tool row per line for surgical diffs.
 - The **drift-check** (`check`): regenerate-in-memory vs committed, with an added / removed / **changed** name diff for the failure message. `:changed` (rf2-y3qpv) names every tool present in BOTH manifests whose catalogue row drifted (a changed `:description` / `:input-keys` / `:gated-input-keys` / `:required` / `:output?` / `:annotations` / `:typicalTokens`) and carries its `{:name :old :new}` rows, so a tool-set-identical-but-descriptor-changed drift is row-level actionable instead of forcing a manual whole-manifest diff.
+- The **drift-report formatter** (`drift-report-lines`, `row-slot-deltas`, `governed-slots`, rf2-cbgc40): the PURE diagnostic body both generators print when a drift-check trips. `governed-slots` is the canonical per-tool slot vector (every row slot except `:name`); `row-slot-deltas` names which of them moved between an old and new row; `drift-report-lines` turns a `check` result + the consumer's two wording strings into the printable added / removed / changed / malformed report lines. Centralised so the two servers report the SAME governed surface + the SAME body (they previously duplicated the vector and the whole traversal).
 - `build-rows` / `build-manifest` — the small assembly helpers between the two.
 
 `descriptor-manifest` does NOT own:
 
 - **Reading the registry.** Each server's generator reads its OWN registry on its OWN platform (story-mcp on the JVM, pair-mcp under Node — its registry is CLJS-only) and passes the descriptor seq in. The base never names a registry.
-- **File I/O.** Each server's generator does its own `spit`/`slurp` (JVM) or `fs.writeFileSync`/`readFileSync` (Node). The base is pure data-in / string-out.
+- **File I/O.** Each server's generator does its own `spit`/`slurp` (JVM) or `fs.writeFileSync`/`readFileSync` (Node). The base is pure data-in / string-out — `drift-report-lines` returns strings; the generator prints them on its own stdout/stderr and owns the process exit code.
+- **Per-server wording.** The two strings that legitimately differ per server — the `Regenerate with: <command>` hint and the missing-file header (which names each server's own regenerate command) — are passed INTO `drift-report-lines` by the generator; the shared body (added / removed / changed / malformed) is byte-identical across servers. The OK-path "in sync" wording likewise stays generator-side.
 - **CI wiring.** Each check is wired into the workflow that already has the right toolchain (story-mcp's JVM job; pair-mcp's Node + shadow-cljs job).
 
 ## The manifest row shape
@@ -61,6 +63,9 @@ The full descriptor maps carry deeply-nested JSON-Schema fragments whose exact s
 | `build-manifest` | `[server descriptors]` / `[server descriptors gated-keys]` | `{:meta {:server :tool-count} :tools [rows]}` |
 | `render-edn` | `[manifest]` | deterministic, LF-pinned EDN string |
 | `check` | `[generated-manifest generated-edn committed-string-or-nil]` | `{:ok? :added :removed :changed (:missing-file?)}` |
+| `governed-slots` | *(def)* | the canonical per-tool slot vector (row slots minus `:name`) |
+| `row-slot-deltas` | `[old-row new-row]` | seq of `[slot old new]` for the `governed-slots` that differ |
+| `drift-report-lines` | `[check-result {:keys [regenerate-line missing-file-line]}]` | vector of printable report lines (pure — no I/O, no exit) |
 
 The optional `gated-keys` arg (rf2-qo3wvp) is the SET of input-key strings the server's default `tools/list` profile gates off (story-mcp passes `#{"include-sensitive"}`; pair-mcp omits it → the empty default). It is config-independent — the static slot set the server knows it gates, not a read of the live gate — so the manifest stays deterministic. Each row's `:gated-input-keys` is the per-tool intersection of this set with the descriptor's actual input keys.
 
@@ -88,7 +93,7 @@ The committed manifest lives at each artefact's root: `tools/<server>/tool-descr
 
 ## Conformance posture
 
-- **Serialiser determinism + drift semantics** are pinned on the JVM by `tools/mcp-base/test/re_frame/mcp_base/descriptor_manifest_test.clj` (the algorithm is platform-agnostic `.cljc`).
+- **Serialiser determinism + drift semantics + the drift-report body** are pinned on the JVM by `tools/mcp-base/test/re_frame/mcp_base/descriptor_manifest_test.clj` (the algorithm is platform-agnostic `.cljc`). The report tests cover the added / removed / per-slot changed / structurally-broken / missing-file lines `drift-report-lines` emits, so a wording or slot-ordering regression trips the base suite rather than diverging silently between the two servers.
 - **The drift-check itself** runs in CI: story-mcp's check rides its JVM job (`clojure -M:gen --check`); pair-mcp's rides its Node + shadow-cljs job (`npm run check:descriptors`). Adding / removing / renaming a tool, or changing a tool's input-key / gated-input-key / required / output? / annotations / typicalTokens surface, turns the respective job red until the manifest is regenerated.
 
 ## See also

--- a/tools/mcp-base/src/re_frame/mcp_base/descriptor_manifest.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/descriptor_manifest.cljc
@@ -408,3 +408,102 @@
          :added   (vec (sort (set/difference gen-names com-names)))
          :removed (vec (sort (set/difference com-names gen-names)))
          :changed changed}))))
+
+;; ---------------------------------------------------------------------------
+;; Drift-report formatting — PURE, platform-neutral report lines.
+;;
+;; The two server generators previously each carried a byte-identical
+;; `row-slot-deltas` (with a copy of the governed-slot vector) and an
+;; identical added / removed / changed / malformed traversal over a
+;; `check` result — the diagnostic body the maintainer reads when a
+;; drift-check trips. That duplication drifts: a governed slot added to
+;; `descriptor->row` had to be mirrored into two report vectors, and any
+;; wording tweak had to be applied twice or the two servers would report
+;; the same drift differently. This section centralises the shared
+;; diagnostic: the governed-slot vector, the per-row slot-delta helper,
+;; and a pure formatter that turns a `check` result + the consumer's
+;; wording into the report lines. It adds NO I/O — no file lookup, no
+;; output channel, no process exit. Each server keeps its own file
+;; lookup, stdout/stderr binding, OK-path wording, and exit codes, and
+;; supplies the two strings that legitimately differ per server (the
+;; regenerate command + the missing-file header).
+;; ---------------------------------------------------------------------------
+
+(def governed-slots
+  "The catalogue-row slots (every row slot EXCEPT `:name`, whose entering
+  / leaving the catalogue is the `:added` / `:removed` diff) whose
+  per-tool drift the manifest governs, in canonical report order. A tool
+  present in BOTH the committed and regenerated manifests but differing
+  in any of these is a `:changed` row; `row-slot-deltas` names which of
+  them moved. Shared so the two server generators report the SAME
+  governed surface (they previously duplicated this vector)."
+  [:description :input-keys :gated-input-keys :required :output? :annotations :typicalTokens])
+
+(defn row-slot-deltas
+  "Seq of `[slot old-val new-val]` for the `governed-slots` that differ
+  between a tool's committed `old` row and regenerated `new` row — names
+  exactly which governed slots drifted so a descriptor-only change is
+  actionable without a manual whole-manifest diff."
+  [old new]
+  (for [slot governed-slots
+        :let [o (get old slot)
+              n (get new slot)]
+        :when (not= o n)]
+    [slot o n]))
+
+(defn drift-report-lines
+  "PURE formatter — no I/O, no file lookup, no process exit. Given a
+  `check` result map for a DRIFTED manifest (the `:added` / `:removed` /
+  `:changed` / `:missing-file?` shape `check` returns) and the two
+  consumer-specific wording strings, return the vector of printable
+  report lines. The caller prints them on its own stdout/stderr channel
+  and owns the OK path + exit code — this fn is side-effect-free.
+
+  `wording` supplies the two strings that legitimately differ per server:
+
+      :regenerate-line   — the `Regenerate with: <command>` hint (each
+                           server names its own regenerate command).
+      :missing-file-line — the header printed when the committed file is
+                           absent (`:missing-file?` true); each server
+                           names its own regenerate command inline.
+
+  When the file exists but drifted, the header is the shared
+  `manifest differs` line. The added / removed / changed / malformed
+  body is byte-identical across servers, so it lives here verbatim:
+
+  - `:added`   — tools the registry has that the committed file lacks
+                 (a new / renamed tool). A missing-file result reports
+                 EVERY generated tool as added (the whole catalogue is
+                 absent), so the added block also renders the full tool
+                 list under the missing-file header.
+  - `:removed` — tools in the committed file the registry no longer has.
+  - `:changed` — existing tools whose catalogue row drifted; each row is
+                 named, then its `row-slot-deltas` are printed one per
+                 line as `<slot>: <old> -> <new>`.
+  - malformed  — when all three are empty the tool set is identical but
+                 the committed file is structurally broken or its
+                 banner / meta drifted (regenerate)."
+  [{:keys [added removed changed missing-file?]}
+   {:keys [regenerate-line missing-file-line]}]
+  (vec
+   (concat
+    [(if missing-file?
+       missing-file-line
+       "DRIFT: generated manifest differs from tool-descriptors.edn.")
+     regenerate-line]
+    (when (seq added)
+      (cons "  Tools the registry has that the committed file lacks (new/renamed tool):"
+            (map #(str "    + " %) added)))
+    (when (seq removed)
+      (cons "  Tools in the committed file the registry no longer has (removed/renamed tool):"
+            (map #(str "    - " %) removed)))
+    (when (seq changed)
+      (cons "  Existing tools whose descriptor catalogue row changed (input-keys / gated-input-keys / required / output? / annotations / description / typicalTokens):"
+            (mapcat (fn [{nm :name :keys [old new]}]
+                      (cons (str "    ~ " nm)
+                            (map (fn [[slot o n]]
+                                   (str "        " (name slot) ": " (pr-str o) " -> " (pr-str n)))
+                                 (row-slot-deltas old new))))
+                    changed)))
+    (when (and (empty? added) (empty? removed) (empty? changed))
+      ["  (tool set identical; the committed file is structurally broken or its provenance banner/meta drifted — regenerate)"]))))

--- a/tools/mcp-base/test/re_frame/mcp_base/descriptor_manifest_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/descriptor_manifest_test.clj
@@ -355,3 +355,136 @@
           crlf    (str/replace lf-edn "\n" "\r\n")
           res     (dm/check m lf-edn crlf)]
       (is (true? (:ok? res)) "LF-normalised comparison ignores line-ending style"))))
+
+;; ---------------------------------------------------------------------------
+;; Drift-report formatting — the shared, pure diagnostic body both server
+;; generators print when a drift-check trips (rf2-cbgc40). Previously each
+;; generator carried a byte-identical copy of the governed-slot vector +
+;; the added / removed / changed / malformed traversal; centralising it
+;; here pins the ONE report surface both servers share, with the two
+;; per-server strings (regenerate command + missing-file header) injected.
+;; ---------------------------------------------------------------------------
+
+(def ^:private wording
+  {:regenerate-line   "Regenerate with: <server command>"
+   :missing-file-line "DRIFT: <file> does not exist. Run: <server command>"})
+
+(deftest governed-slots-is-every-row-slot-except-name
+  ;; The governed-slot vector must stay in lockstep with the row shape:
+  ;; every slot descriptor->row emits EXCEPT :name (whose add/remove is
+  ;; the :added/:removed diff). A slot added to the row but not here would
+  ;; silently escape :changed reporting.
+  (let [row-slots (set (keys (dm/descriptor->row (first sample-descriptors))))]
+    (is (= (disj row-slots :name) (set dm/governed-slots))
+        "governed-slots = row slots minus :name")
+    (is (= [:description :input-keys :gated-input-keys :required :output? :annotations :typicalTokens]
+           dm/governed-slots)
+        "canonical report order is stable")))
+
+(deftest row-slot-deltas-names-only-drifting-slots-in-canonical-order
+  (let [old {:description "d" :input-keys ["event"] :gated-input-keys []
+             :required ["event"] :output? false :annotations [] :typicalTokens 300}
+        new (assoc old :input-keys ["event" "force"] :typicalTokens 999)]
+    (is (= [[:input-keys ["event"] ["event" "force"]]
+            [:typicalTokens 300 999]]
+           (dm/row-slot-deltas old new))
+        "only the two drifting slots, in governed-slots order")
+    (is (= [] (dm/row-slot-deltas old old))
+        "identical rows → no deltas")))
+
+(deftest drift-report-lines-missing-file
+  ;; A missing committed file: check reports EVERY generated tool as
+  ;; :added; the report leads with the consumer's missing-file header,
+  ;; then the regenerate line, then the full tool list.
+  (let [res   {:ok? false :added ["alpha" "beta"] :removed [] :changed [] :missing-file? true}
+        lines (dm/drift-report-lines res wording)]
+    (is (= ["DRIFT: <file> does not exist. Run: <server command>"
+            "Regenerate with: <server command>"
+            "  Tools the registry has that the committed file lacks (new/renamed tool):"
+            "    + alpha"
+            "    + beta"]
+           lines))))
+
+(deftest drift-report-lines-added
+  (let [res   {:ok? false :added ["beta"] :removed [] :changed []}
+        lines (dm/drift-report-lines res wording)]
+    (is (= ["DRIFT: generated manifest differs from tool-descriptors.edn."
+            "Regenerate with: <server command>"
+            "  Tools the registry has that the committed file lacks (new/renamed tool):"
+            "    + beta"]
+           lines)
+        "an existing (non-missing) file uses the shared differs header")))
+
+(deftest drift-report-lines-removed
+  (let [res   {:ok? false :added [] :removed ["beta"] :changed []}
+        lines (dm/drift-report-lines res wording)]
+    (is (= ["DRIFT: generated manifest differs from tool-descriptors.edn."
+            "Regenerate with: <server command>"
+            "  Tools in the committed file the registry no longer has (removed/renamed tool):"
+            "    - beta"]
+           lines))))
+
+(deftest drift-report-lines-changed-per-slot
+  ;; A changed row prints the tool name, then one line per drifting
+  ;; governed slot as `<slot>: <pr-str old> -> <pr-str new>`.
+  (let [old   {:description "d" :input-keys ["event"] :gated-input-keys []
+               :required ["event"] :output? false :annotations [] :typicalTokens 300}
+        new   (assoc old :input-keys ["event" "force"] :typicalTokens 999)
+        res   {:ok? false :added [] :removed []
+               :changed [{:name "alpha" :old old :new new}]}
+        lines (dm/drift-report-lines res wording)]
+    (is (= ["DRIFT: generated manifest differs from tool-descriptors.edn."
+            "Regenerate with: <server command>"
+            "  Existing tools whose descriptor catalogue row changed (input-keys / gated-input-keys / required / output? / annotations / description / typicalTokens):"
+            "    ~ alpha"
+            "        input-keys: [\"event\"] -> [\"event\" \"force\"]"
+            "        typicalTokens: 300 -> 999"]
+           lines))))
+
+(deftest drift-report-lines-structurally-broken-committed
+  ;; An unparseable committed file: check cannot read its rows, so every
+  ;; generated tool is reported as :added (whole catalogue absent) with no
+  ;; :changed — the report lists them all under the differs header.
+  (let [m     (dm/build-manifest :test sample-descriptors)
+        edn   (dm/render-edn m)
+        res   (dm/check m edn "this is not { valid edn")
+        lines (dm/drift-report-lines res wording)]
+    (is (false? (:ok? res)))
+    (is (= ["DRIFT: generated manifest differs from tool-descriptors.edn."
+            "Regenerate with: <server command>"
+            "  Tools the registry has that the committed file lacks (new/renamed tool):"
+            "    + alpha"
+            "    + beta"]
+           lines))))
+
+(deftest drift-report-lines-malformed-fallback
+  ;; Tool set identical but the byte comparison failed (banner / meta
+  ;; drift): added / removed / changed are all empty, so the fallback
+  ;; hint fires instead of an empty body.
+  (let [res   {:ok? false :added [] :removed [] :changed []}
+        lines (dm/drift-report-lines res wording)]
+    (is (= ["DRIFT: generated manifest differs from tool-descriptors.edn."
+            "Regenerate with: <server command>"
+            "  (tool set identical; the committed file is structurally broken or its provenance banner/meta drifted — regenerate)"]
+           lines))))
+
+(deftest drift-report-lines-end-to-end-from-check
+  ;; The formatter consumes a real `check` result unchanged: alpha gains
+  ;; an input key, beta is dropped → one :changed + one :removed reported
+  ;; together in canonical block order (added, removed, changed).
+  (let [committed-m   (dm/build-manifest :test sample-descriptors)
+        committed-edn (dm/render-edn committed-m)
+        alpha+        (assoc-in (second sample-descriptors)
+                                [:inputSchema :properties :force] {:type "boolean"})
+        gen-m         (dm/build-manifest :test [alpha+]) ; alpha changed, beta removed
+        gen-edn       (dm/render-edn gen-m)
+        res           (dm/check gen-m gen-edn committed-edn)
+        lines         (dm/drift-report-lines res wording)]
+    (is (= ["DRIFT: generated manifest differs from tool-descriptors.edn."
+            "Regenerate with: <server command>"
+            "  Tools in the committed file the registry no longer has (removed/renamed tool):"
+            "    - beta"
+            "  Existing tools whose descriptor catalogue row changed (input-keys / gated-input-keys / required / output? / annotations / description / typicalTokens):"
+            "    ~ alpha"
+            "        input-keys: [\"event\"] -> [\"event\" \"force\"]"]
+           lines))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/descriptor_manifest_gen.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/descriptor_manifest_gen.cljs
@@ -99,49 +99,27 @@
     (println (str "Wrote " p " (" (-> manifest :meta :tool-count) " tools)."))
     manifest))
 
-(defn- row-slot-deltas
-  "Seq of `[slot old-val new-val]` for the catalogue slots that differ
-  between a tool's committed `old` row and regenerated `new` row. Names
-  exactly which of the manifest's governed slots drifted so a descriptor-
-  only change is actionable without a manual whole-manifest diff."
-  [old new]
-  (for [slot [:description :input-keys :gated-input-keys :required :output? :annotations :typicalTokens]
-        :let [o (get old slot)
-              n (get new slot)]
-        :when (not= o n)]
-    [slot o n]))
-
 (defn check! []
   (let [manifest  (build)
         edn       (dm/render-edn manifest)
         p         (manifest-path)
         committed (when (.existsSync fs p)
                     (.toString (.readFileSync fs p)))
-        {:keys [ok? added removed changed missing-file?]} (dm/check manifest edn committed)]
+        {:keys [ok?] :as result} (dm/check manifest edn committed)]
     (if ok?
       (do (println (str "OK: tool-descriptors.edn in sync ("
                         (-> manifest :meta :tool-count) " tools)."))
           true)
+      ;; The drift report body (added / removed / changed / malformed) is
+      ;; formatted by the shared `dm/drift-report-lines`; this fn owns only
+      ;; the file lookup, the OK-path wording, its *print-err-fn* channel,
+      ;; the two consumer wording strings, and the exit code (via `-main`).
       (do (binding [*print-fn* *print-err-fn*]
-            (if missing-file?
-              (println "DRIFT: tool-descriptors.edn does not exist. Run the generator.")
-              (println "DRIFT: generated manifest differs from tool-descriptors.edn."))
-            (println "Regenerate with: node scripts/descriptor-manifest-gen.cjs")
-            (when (seq added)
-              (println "  Tools the registry has that the committed file lacks (new/renamed tool):")
-              (doseq [n added] (println "    +" n)))
-            (when (seq removed)
-              (println "  Tools in the committed file the registry no longer has (removed/renamed tool):")
-              (doseq [n removed] (println "    -" n)))
-            (when (seq changed)
-              (println "  Existing tools whose descriptor catalogue row changed (input-keys / gated-input-keys / required / output? / annotations / description / typicalTokens):")
-              (doseq [{:keys [name old new]} changed]
-                (println "    ~" name)
-                (doseq [[slot o n] (row-slot-deltas old new)]
-                  (println (str "        " (cljs.core/name slot) ": "
-                                (pr-str o) " -> " (pr-str n))))))
-            (when (and (empty? added) (empty? removed) (empty? changed))
-              (println "  (tool set identical; the committed file is structurally broken or its provenance banner/meta drifted — regenerate)")))
+            (doseq [line (dm/drift-report-lines
+                          result
+                          {:regenerate-line   "Regenerate with: node scripts/descriptor-manifest-gen.cjs"
+                           :missing-file-line "DRIFT: tool-descriptors.edn does not exist. Run the generator."})]
+              (println line)))
           false))))
 
 (defn -main [& args]

--- a/tools/story-mcp/src/re_frame/story_mcp/descriptor_manifest_gen.clj
+++ b/tools/story-mcp/src/re_frame/story_mcp/descriptor_manifest_gen.clj
@@ -75,55 +75,29 @@
                      (-> manifest :meta :tool-count)))
     manifest))
 
-(defn- row-slot-deltas
-  "Seq of `[slot old-val new-val]` for the catalogue slots that differ
-  between a tool's committed `old` row and regenerated `new` row. Names
-  exactly which of the manifest's governed slots drifted so a descriptor-
-  only change is actionable without a manual whole-manifest diff."
-  [old new]
-  (for [slot [:description :input-keys :gated-input-keys :required :output? :annotations :typicalTokens]
-        :let [o (get old slot)
-              n (get new slot)]
-        :when (not= o n)]
-    [slot o n]))
-
 (defn check!
   "Regenerate in memory + compare to the committed file. Returns true
-  when in sync, false (with a printed diff summary) when drifted."
+  when in sync, false (with a printed diff summary) when drifted. The
+  drift report body (added / removed / changed / malformed) is formatted
+  by the shared `dm/drift-report-lines`; this fn owns only the file
+  lookup, the OK-path wording, its *err* channel, the two consumer
+  wording strings, and the exit code (via `-main`)."
   []
   (let [manifest  (build)
         edn       (dm/render-edn manifest)
         f         (manifest-file)
         committed (when (.exists ^java.io.File f) (slurp f))
-        {:keys [ok? added removed changed missing-file?]} (dm/check manifest edn committed)]
+        {:keys [ok?] :as result} (dm/check manifest edn committed)]
     (if ok?
       (do (println (format "OK: tool-descriptors.edn in sync (%d tools)."
                            (-> manifest :meta :tool-count)))
           true)
       (do (binding [*out* *err*]
-            (if missing-file?
-              (println "DRIFT: tool-descriptors.edn does not exist. Run: clojure -M:gen")
-              (println "DRIFT: generated manifest differs from tool-descriptors.edn."))
-            (println "Regenerate with: clojure -M:gen (from tools/story-mcp/)")
-            (when (seq added)
-              (println "  Tools the registry has that the committed file lacks"
-                       "(new/renamed tool):")
-              (doseq [n added] (println "    +" n)))
-            (when (seq removed)
-              (println "  Tools in the committed file the registry no longer has"
-                       "(removed/renamed tool):")
-              (doseq [n removed] (println "    -" n)))
-            (when (seq changed)
-              (println "  Existing tools whose descriptor catalogue row changed"
-                       "(input-keys / gated-input-keys / required / output? / annotations / description / typicalTokens):")
-              (doseq [{:keys [name old new]} changed]
-                (println "    ~" name)
-                (doseq [[slot o n] (row-slot-deltas old new)]
-                  (println (format "        %s: %s -> %s" (clojure.core/name slot)
-                                   (pr-str o) (pr-str n))))))
-            (when (and (empty? added) (empty? removed) (empty? changed))
-              (println "  (tool set identical; the committed file is structurally"
-                       "broken or its provenance banner/meta drifted — regenerate)")))
+            (doseq [line (dm/drift-report-lines
+                          result
+                          {:regenerate-line   "Regenerate with: clojure -M:gen (from tools/story-mcp/)"
+                           :missing-file-line "DRIFT: tool-descriptors.edn does not exist. Run: clojure -M:gen"})]
+              (println line)))
           false))))
 
 (defn -main [& args]


### PR DESCRIPTION
## What

Both MCP descriptor-manifest generators — `story-mcp` (JVM) and `re-frame2-pair-mcp` (CLJS/Node) — carried a **byte-identical** `row-slot-deltas` (with a duplicated governed-slot vector) plus an **identical** added / removed / changed / malformed report traversal over a `dm/check` result. This centralizes that diagnostic in mcp-base, beside `descriptor-manifest/check`.

New shared surface in `re-frame.mcp-base.descriptor-manifest`:

- **`governed-slots`** — the canonical per-tool slot vector (every row slot except `:name`), so both servers report the SAME governed surface.
- **`row-slot-deltas`** — names which governed slots drifted between an old and new row.
- **`drift-report-lines`** — a **PURE** formatter: takes a `check` result + the consumer's two wording strings (`:regenerate-line`, `:missing-file-line`) and returns the printable report lines. **No I/O protocol added** — no file lookup, no output channel, no process exit, no side effects.

Both consumers delete their `row-slot-deltas` + duplicated traversal and call `dm/drift-report-lines`, **retaining** their own file lookup, output channel (`*out*/*err*` vs `*print-err-fn*`), OK-path wording, missing-file/regenerate wording, and exit codes.

**No descriptor data or MCP wire changes** — the manifests and the emitted report bytes are unchanged; only the source of the report body moved.

## Preflight confirmation

Confirmed the duplication is genuine before centralizing: `story_mcp/descriptor_manifest_gen.clj` (old lines 78–127) and `re-frame2-pair-mcp/descriptor_manifest_gen.cljs` (old lines 102–145) held identical `row-slot-deltas` + report traversals; the governed-slot vector `[:description :input-keys :gated-input-keys :required :output? :annotations :typicalTokens]` was copied in both. `mcp-conformance` does **not** consume this drift-check (verified by grep), so it is untouched.

## Scope

Touched only mcp-base src/test/spec + the two `*-mcp` consumer drift-check call sites. Did **not** touch `tools/story`, `tools/xray`, or `mcp-conformance`. No hot-zone files.

## Stance

Pre-alpha, no back-compat shims. ELEGANCE + CLARITY + CORRECTNESS + GOOD-PRACTICE: one shared report surface, per-server wording injected, the pure fn stays side-effect-free.

## Quality gates (foreground, 0 failures)

- `tools/mcp-base` `clojure -M:test` — **266 tests, 877 assertions, 0 failures/errors** (includes new formatter tests: added / removed / per-slot changed / structurally-broken / missing-file, governed-slots↔row-shape lockstep, end-to-end check→format)
- `tools/mcp-base` `npm run test:cljs` — **18 tests, 146 assertions, 0 failures** (`.cljc` compiles + passes under CLJS)
- `tools/story-mcp` `clojure -M:test` — **299 tests, 1495 assertions, 0 failures**
- `tools/story-mcp` `clojure -M:gen --check` — **OK: in sync (20 tools), exit 0**
- `tools/re-frame2-pair-mcp` `npm run check:descriptors` — compiles (0 warnings), **OK: in sync (30 tools), exit 0**
- `tools/re-frame2-pair-mcp` `npm run test` — **1203 tests, 4028 assertions, 0 failures**
