### PR TITLE
refactor(schemas): migrate conformance runner to shared core primitives (rf2-wy414k)

### DIFF
--- a/implementation/core/src/re_frame/conformance.cljc
+++ b/implementation/core/src/re_frame/conformance.cljc
@@ -1,9 +1,17 @@
 (ns re-frame.conformance
-  "DSL interpreter for the conformance fixture handler-body forms.
+  "DSL interpreter + shared harness primitives for the conformance fixtures.
 
   The conformance corpus represents handler bodies as data — a small DSL
   the harness interprets into native fns. Per
-  spec/conformance/README.md §Handler-body DSL ops.
+  spec/conformance/README.md §Handler-body DSL ops. This namespace ALSO
+  owns the stable, PURE primitives every conformance runner shares — the
+  handler/cofx realisation collapse (`normalize-event-handler`,
+  `collect-cofx-keys`, `realise-cofx-supplier`) and the expectation matchers
+  (`submap?`, `check-trace-emissions`, `resolve-sub`). It lives in `core/src`
+  (not `core/test`) precisely so per-feature artefacts' test suites reach it
+  cross-classpath without pulling core's test tree — a runner's fixture
+  discovery, capability claims, execution loop, and reporting stay LOCAL
+  (rf2-wy414k).
 
   Operator set:
 
@@ -710,6 +718,63 @@
     [:fx (realise-event-fx-handler steps)]
     [:db (realise-event-db-handler steps)]))
 
+(defn normalize-event-handler
+  "Collapse the `[body-shape handler]` pair `realise-event-handler` returns into
+  the single EP-0018 `reg-event` shape — a `(cofx-in → effects-map-or-nil)` fn —
+  so a registration site never branches on the DSL-internal body-shape.
+
+  `body-shape` is an interpreter distinction (does the body read cofx / emit fx),
+  NOT a public `:event/kind` (EP-0018 removed the public event sub-kind model). A
+  `:db` body `(fn [db event] new-db)` is lifted to `(fn [cofx event] {:db …})` —
+  read db from the coeffects, lower the returned db into a `{:db …}` effect (same
+  observable behaviour); an `:fx` body is already the single form and passes
+  through.
+
+  Shared harness primitive (rf2-wy414k) — the pair→single-form collapse lives
+  in exactly one place so every conformance runner registers events identically."
+  [[body-shape handler]]
+  (case body-shape
+    :db (fn [{:keys [db]} event] {:db (handler db event)})
+    :fx handler))
+
+(defn collect-cofx-keys
+  "Walk DSL body `steps` and return the SET of every cofx-id referenced via a
+  `[:cofx-key K]` form. A runner uses the result to auto-wire a consuming
+  event's `:rf.cofx/requires` declaration (EP-0017 model — rf2-mrp8jg / rf2-g25p).
+
+  Shared harness primitive (rf2-wy414k)."
+  [steps]
+  (let [out (atom #{})]
+    ((fn walk [form]
+       (cond
+         (and (vector? form) (= :cofx-key (first form)))
+         (swap! out conj (second form))
+
+         (coll? form)
+         (doseq [x form] (walk x))))
+     steps)
+    @out))
+
+(defn realise-cofx-supplier
+  "DSL body `steps` → a value-returning cofx supplier `(fn [] value)` (EP-0017
+  model — rf2-mrp8jg). Each `:set` step declares the value the supplier returns;
+  the runtime delivers it FLAT under the cofx-id when a handler declares it via
+  `:rf.cofx/requires`. The `:set` value passes through `eval-value*` (rf2-g25p)
+  so reflection forms resolve; multiple `:set` steps run in order and the last
+  wins (single-delivery convention).
+
+  Shared harness primitive (rf2-wy414k)."
+  [steps]
+  (fn []
+    (reduce (fn [v step]
+              (case (first step)
+                :set  (let [[_ _path value] step]
+                        (eval-value* value {}))
+                :noop v
+                v))
+            nil
+            steps)))
+
 ;; ---- sub interpreter ------------------------------------------------------
 ;;
 ;; Sub bodies in the corpus take a few shapes:
@@ -789,3 +854,87 @@
                      v))
                  nil
                  steps))})))
+
+;; ---- expectation-matcher primitives --------------------------------------
+;;
+;; Pure, host-neutral matchers shared by every conformance runner (rf2-wy414k).
+;; A runner's fixture selection, capability claims, execution loop, and
+;; reporting stay LOCAL; only these stable comparison primitives are shared.
+
+(defn submap?
+  "True if every key of `expected` appears in `actual` with a matching value.
+  Recurses into nested maps so partial expectations on nested slices work (e.g.
+  a fixture asserting only a subset of an app-db slice or a trace-tag map).
+
+  Shared harness primitive (rf2-wy414k)."
+  [expected actual]
+  (cond
+    (and (map? expected) (map? actual))
+    (every? (fn [[k v]]
+              (let [a (get actual k)]
+                (cond
+                  (and (map? v) (map? a)) (submap? v a)
+                  :else                   (= v a))))
+            expected)
+
+    :else (= expected actual)))
+
+(defn check-trace-emissions
+  "Order-preserving SUBSET match of `expected-traces` against `actual-traces`
+  per spec/conformance/README.md §Fixture lifecycle: each expected trace must
+  appear in `actual-traces` in declaration order, matched partially by its
+  specified keys (absent keys ignored; nested-map keys matched submap-wise).
+  Extras between matches are tolerated (the runtime may emit bookkeeping traces
+  the fixture doesn't care about). Returns a vector of failure-message strings
+  (empty on full match).
+
+  Shared harness primitive (rf2-wy414k)."
+  [actual-traces expected-traces]
+  (loop [actual   actual-traces
+         expected expected-traces
+         failures []]
+    (cond
+      (empty? expected)
+      failures
+
+      (empty? actual)
+      (conj failures (str "expected trace not seen: " (pr-str (first expected))))
+
+      :else
+      (let [exp (first expected)
+            match-idx (->> actual
+                           (map-indexed vector)
+                           (some (fn [[i a]]
+                                   (when (every? (fn [[k v]]
+                                                   (let [actual-v (get a k)]
+                                                     (cond
+                                                       (map? v)
+                                                       (every? (fn [[kk vv]]
+                                                                 (= vv (get actual-v kk)))
+                                                               v)
+                                                       :else (= v actual-v))))
+                                                 exp)
+                                     i))))]
+        (if match-idx
+          (recur (drop (inc match-idx) actual) (rest expected) failures)
+          (recur actual (rest expected)
+                 (conj failures (str "expected trace not seen: " (pr-str exp)))))))))
+
+(defn resolve-sub
+  "Normalise a `:sub-values` query entry to `[frame-id query-v]`. An entry may
+  be `[query-v]` (an IMPLICIT-frame query, targeting `default-frame`) or
+  `[frame-id [query-v]]` (an explicit frame).
+
+  `default-frame` is a PARAMETER, not a baked-in frame keyword: this shared
+  owner sits in `core/src`, under the EP-0002 frame-floor lint (which exempts
+  `test/` but not `src/` — see `re-frame.no-rf-default-floor-lint-test`). The
+  implicit-frame default is a TEST-HARNESS query-normalisation convention, so
+  each runner passes its own default from its test tree — keeping this src/
+  primitive free of a positional frame-floor shape while still sharing the
+  query-shape normalisation itself (rf2-wy414k)."
+  [default-frame entry]
+  (if (and (vector? entry)
+           (= 2 (count entry))
+           (vector? (second entry)))
+    [(first entry) (second entry)]
+    [default-frame entry]))

--- a/implementation/core/test/re_frame/conformance_dsl_cljs_test.cljc
+++ b/implementation/core/test/re_frame/conformance_dsl_cljs_test.cljc
@@ -149,3 +149,104 @@
       (is (= {:db {:from-event 42}}
              (handler {:db {}} [:evt 42]))
           "[:event-arg n] resolves even inside a :return-raw literal"))))
+
+;; ---- shared harness primitives (rf2-wy414k) -------------------------------
+;;
+;; `normalize-event-handler`, `collect-cofx-keys`, `realise-cofx-supplier`,
+;; `submap?`, `check-trace-emissions`, and `resolve-sub` moved OUT of the
+;; per-runner private copies (the core corpus runner + the schemas artefact
+;; runner both duplicated them) INTO this `.cljc` shared owner so they run once,
+;; identically, on both hosts. These target the primitives directly.
+
+(deftest normalize-event-handler-collapses-body-shape
+  (testing ":db body-shape is lifted to the single (cofx → effects-map) form"
+    (let [pair    [:db (fn [db event] (assoc db :seen event))]
+          handler (conformance/normalize-event-handler pair)]
+      (is (= {:db {:seen [:evt 7]}}
+             (handler {:db {}} [:evt 7]))
+          ":db handler reads db from coeffects and lowers the new db into {:db …}")))
+
+  (testing ":fx body-shape passes through unchanged (already the single form)"
+    (let [fx-handler (fn [_cofx _event] {:fx [[:noop {}]]})
+          pair       [:fx fx-handler]]
+      (is (identical? fx-handler (conformance/normalize-event-handler pair))
+          ":fx handler is returned verbatim — no wrapping"))))
+
+(deftest collect-cofx-keys-walks-nested-steps
+  (testing "pulls every [:cofx-key K] ref across nested body steps, as a set"
+    (is (= #{:app-version :user}
+           (conformance/collect-cofx-keys
+             [[:set [:v]  [:cofx-key :app-version]]
+              [:fx  :sink [:cofx-key :user]]]))))
+
+  (testing "no cofx refs → empty set"
+    (is (= #{} (conformance/collect-cofx-keys [[:noop]]))))
+
+  (testing "duplicate refs collapse (set semantics)"
+    (is (= #{:a}
+           (conformance/collect-cofx-keys
+             [[:set [:x] [:cofx-key :a]] [:set [:y] [:cofx-key :a]]])))))
+
+(deftest realise-cofx-supplier-returns-set-value
+  (testing "the supplier returns the :set step's value"
+    (is (= 7 ((conformance/realise-cofx-supplier [[:set [:v] 7]])))))
+
+  (testing "the LAST :set wins (single-delivery convention)"
+    (is (= 2 ((conformance/realise-cofx-supplier
+                [[:set [:v] 1] [:set [:v] 2]])))))
+
+  (testing ":set value passes through eval-value* (reflection forms resolve)"
+    (is (= 5 ((conformance/realise-cofx-supplier [[:set [:v] [:fn :+ 2 3]]])))))
+
+  (testing "no :set step → nil"
+    (is (nil? ((conformance/realise-cofx-supplier [[:noop]]))))))
+
+(deftest submap?-recursive-partial-match
+  (testing "flat subset matches"
+    (is (true?  (conformance/submap? {:a 1} {:a 1 :b 2})))
+    (is (false? (conformance/submap? {:a 2} {:a 1})))
+    (is (false? (conformance/submap? {:a 1} {}))
+        "a missing key is a mismatch (present-with-nil vs absent both fail = )"))
+
+  (testing "recurses into nested maps"
+    (is (true?  (conformance/submap? {:a {:b 1}} {:a {:b 1 :c 2}})))
+    (is (false? (conformance/submap? {:a {:b 2}} {:a {:b 1 :c 2}}))))
+
+  (testing "non-map values compare by ="
+    (is (true?  (conformance/submap? 5 5)))
+    (is (false? (conformance/submap? 5 6)))))
+
+(deftest check-trace-emissions-order-preserving-subset
+  (let [actual [{:op :a} {:op :b} {:op :c}]]
+    (testing "in-order subset with tolerated extras → no failures"
+      (is (empty? (conformance/check-trace-emissions actual [{:op :a} {:op :c}]))))
+
+    (testing "out-of-order expected → failure"
+      (is (seq (conformance/check-trace-emissions actual [{:op :c} {:op :a}]))))
+
+    (testing "missing expected trace → one failure"
+      (is (= 1 (count (conformance/check-trace-emissions actual [{:op :z}]))))))
+
+  (testing "partial key match (extra actual keys ignored)"
+    (is (empty? (conformance/check-trace-emissions
+                  [{:op :a :extra 99}] [{:op :a}]))))
+
+  (testing "nested-map keys are matched submap-wise"
+    (is (empty? (conformance/check-trace-emissions
+                  [{:op :x :tags {:id 1 :n 2}}] [{:tags {:id 1}}])))
+    (is (seq (conformance/check-trace-emissions
+               [{:op :x :tags {:id 1}}] [{:tags {:id 2}}])))))
+
+(deftest resolve-sub-frame-normalisation
+  (testing "bare query-v → the caller-supplied default frame"
+    (is (= [:rf/default [:count]]    (conformance/resolve-sub :rf/default [:count])))
+    (is (= [:rf/default [:count 5]]  (conformance/resolve-sub :rf/default [:count 5]))
+        "a 2-elt query whose 2nd elt is NOT a vector is a plain query-v, not [frame q]")
+    (is (= [:other-frame [:count]]   (conformance/resolve-sub :other-frame [:count]))
+        "default-frame is a parameter — no baked-in frame keyword"))
+
+  (testing "[frame-id [query-v]] → explicit frame (default ignored)"
+    (is (= [:frame-2 [:count]]
+           (conformance/resolve-sub :rf/default [:frame-2 [:count]])))
+    (is (= [:frame-2 [:count 5]]
+           (conformance/resolve-sub :rf/default [:frame-2 [:count 5]])))))

--- a/implementation/core/test/re_frame/conformance_runner.cljc
+++ b/implementation/core/test/re_frame/conformance_runner.cljc
@@ -294,40 +294,12 @@
     (or (nil? v) (contains? claimed-spec-versions v))))
 
 ;; ---- handler-body realisation ---------------------------------------------
-
-(defn- collect-cofx-keys
-  "Walk steps and pull every cofx-id referenced via `[:cofx-key K]`. Used by
-  `realise-handlers` to auto-wire the consuming event's `:rf.cofx/requires`
-  declaration (EP-0017 model — rf2-mrp8jg / rf2-g25p). Returns a set of K."
-  [steps]
-  (let [out (atom #{})]
-    ((fn walk [form]
-       (cond
-         (and (vector? form) (= :cofx-key (first form)))
-         (swap! out conj (second form))
-
-         (coll? form)
-         (doseq [x form] (walk x))))
-     steps)
-    @out))
-
-(defn- realise-cofx-supplier
-  "DSL → a value-returning cofx supplier `(fn [] value)` (EP-0017 model —
-  rf2-mrp8jg). The body's `:set` steps declare the value the supplier
-  returns directly; the runtime delivers it FLAT under the cofx-id when a
-  handler declares it via `:rf.cofx/requires`. The `:set` value passes
-  through `eval-value*` (rf2-g25p) so reflection forms resolve; the last
-  `:set` wins (single-injection convention)."
-  [steps]
-  (fn []
-    (reduce (fn [v step]
-              (case (first step)
-                :set  (let [[_ _path value] step]
-                        (conformance/eval-value* value {}))
-                :noop v
-                v))
-            nil
-            steps)))
+;;
+;; `collect-cofx-keys`, `realise-cofx-supplier`, and `normalize-event-handler`
+;; are the SHARED handler-realisation primitives owned by `re-frame.conformance`
+;; (core/src) — consumed here and by the per-feature artefact runners alike so
+;; the cofx-key walk / supplier lift / body-shape collapse live in one place
+;; (rf2-wy414k).
 
 ;; Forward declaration — realise-machine-handlers is defined below (alongside
 ;; the run-call :machine-transition path). Per rf2-msd4 the same realised
@@ -362,13 +334,20 @@
           ;; without one.
           (if (:provided? meta)
             (rf/reg-cofx cofx-id meta)
-            (rf/reg-cofx cofx-id meta (realise-cofx-supplier body))))))
+            (rf/reg-cofx cofx-id meta (conformance/realise-cofx-supplier body))))))
     ;; event registrations. A body that reads `[:cofx-key K]` declares the
     ;; consumed coeffect ids via `:rf.cofx/requires` (fx-only — a cofx-reading
     ;; body routes to an `:fx` handler).
+    ;;
+    ;; EP-0018 Slice Z: there is ONE public `reg-event` (cofx-in, effects-map-out).
+    ;; `conformance/normalize-event-handler` collapses the DSL `[body-shape
+    ;; handler]` pair to that single form — a :db-kind body `(fn [db event]
+    ;; new-db)` is lifted to `(fn [cofx event] {:db …})`, an :fx-kind body passes
+    ;; through — so the registration site never branches on the body-shape.
     (doseq [[id steps] (get handlers-map :event)]
-      (let [[kind handler] (conformance/realise-event-handler steps)
-            ks             (collect-cofx-keys steps)
+      (let [handler        (conformance/normalize-event-handler
+                             (conformance/realise-event-handler steps))
+            ks             (conformance/collect-cofx-keys steps)
             cofx-ids       (vec
                              (mapcat (fn [k]
                                        (or (get cofx-by-key k)
@@ -376,18 +355,9 @@
                                      ks))
             event-meta     (cond-> (get event-registry id {})
                              (seq cofx-ids) (assoc :rf.cofx/requires cofx-ids))]
-        (case kind
-          ;; EP-0018 Slice Z: one public `reg-event` (cofx-in, effects-map-out).
-          ;; A :db-kind handler is `(fn [db event] new-db)`; adapt it to the
-          ;; single form by reading db from coeffects and lowering the returned
-          ;; db into a `{:db …}` effect — same observable behaviour.
-          :db (let [h (fn [{:keys [db]} ev] {:db (handler db ev)})]
-                (if (seq event-meta)
-                  (rf/reg-event id event-meta h)
-                  (rf/reg-event id h)))
-          :fx (if (seq event-meta)
-                (rf/reg-event id event-meta handler)
-                (rf/reg-event id handler)))))
+        (if (seq event-meta)
+          (rf/reg-event id event-meta handler)
+          (rf/reg-event id handler))))
     ;; sub registrations. Use the fn-form `subs/reg-sub` because the public
     ;; `rf/reg-sub` is a macro (source-coord capture) and a macro var isn't a
     ;; callable value; source-coord capture is intentionally bypassed for
@@ -578,20 +548,11 @@
                  (conj failures (str "expected error-emit record not seen: "
                                      (pr-str exp)))))))))
 
-(defn- submap?
-  "True if every key in expected appears in actual with a matching value.
-  Recurses into nested maps so partial expectations on nested slices work."
-  [expected actual]
-  (cond
-    (and (map? expected) (map? actual))
-    (every? (fn [[k v]]
-              (let [a (get actual k)]
-                (cond
-                  (and (map? v) (map? a)) (submap? v a)
-                  :else                   (= v a))))
-            expected)
-
-    :else (= expected actual)))
+;; `submap?` (recursive submap match), `check-trace-emissions` (order-preserving
+;; partial trace subset), and `resolve-sub` (`:sub-values` query-frame
+;; resolution) are the SHARED expectation-matcher primitives owned by
+;; `re-frame.conformance` (core/src) — consumed here and by the per-feature
+;; artefact runners alike (rf2-wy414k).
 
 (defn- normalise-effects-routed
   "Normalise `:effects-routed` entries (`{:fx-id F :args A}` map form OR
@@ -648,52 +609,6 @@
           (recur actual (rest expected)
                  (conj failures (str "expected effect not routed: " (pr-str exp)))))))))
 
-(defn- check-trace-emissions
-  "Per the conformance README §Fixture lifecycle: partial-match each expected
-  event by its specified keys (absent keys ignored, nested-map keys matched
-  submap-wise). Returns a vector of failure messages."
-  [actual-traces expected-traces]
-  (loop [actual   actual-traces
-         expected expected-traces
-         failures []]
-    (cond
-      (empty? expected)
-      failures
-
-      (empty? actual)
-      (conj failures (str "expected trace not seen: " (pr-str (first expected))))
-
-      :else
-      (let [exp (first expected)
-            match-idx (->> actual
-                           (map-indexed vector)
-                           (some (fn [[i a]]
-                                   (when (every? (fn [[k v]]
-                                                   (let [actual-v (get a k)]
-                                                     (cond
-                                                       (map? v)
-                                                       (every? (fn [[kk vv]]
-                                                                 (= vv (get actual-v kk)))
-                                                               v)
-                                                       :else (= v actual-v))))
-                                                 exp)
-                                     i))))]
-        (if match-idx
-          (recur (drop (inc match-idx) actual) (rest expected) failures)
-          (recur actual (rest expected)
-                 (conj failures (str "expected trace not seen: " (pr-str exp)))))))))
-
-(defn- resolve-sub
-  "A sub query in `:sub-values` may be `[query-v]` (implicit :rf/default
-  frame) or `[frame-id [query-v]]` (explicit frame). Returns `[frame-id
-  query-v]`."
-  [entry]
-  (if (and (vector? entry)
-           (= 2 (count entry))
-           (vector? (second entry)))
-    [(first entry) (second entry)]
-    [:rf/default entry]))
-
 (defn- check-epoch-records
   "Per rf2-v0jwt — `:epoch-records` asserts against the recorded
   `:rf/epoch-record` ring. Each entry (`{:frame <id> :record <partial>}` or
@@ -719,7 +634,7 @@
                     (str "expected epoch-record at position " i
                          " for frame " frame-id " but none recorded")
 
-                    (not (submap? record actual-record))
+                    (not (conformance/submap? record actual-record))
                     (str "epoch-record mismatch at position " i
                          " for frame " frame-id
                          " — expected (submap) " (pr-str record)
@@ -1526,7 +1441,7 @@
             sub-checks
             (doall
               (for [[query-v expected-val] (or (:sub-values expect) {})]
-                (let [[frame-id qv] (resolve-sub query-v)]
+                (let [[frame-id qv] (conformance/resolve-sub :rf/default query-v)]
                   {:query    query-v
                    :expected expected-val
                    :actual   (rf/subscribe-once qv {:frame frame-id})})))
@@ -1542,7 +1457,7 @@
                             (str "expected app-db path " (pr-str path)
                                  " to be ABSENT but found " (pr-str v)))))
                       expected-absent)))
-            trace-failures (check-trace-emissions @traces (:trace-emissions expect))
+            trace-failures (conformance/check-trace-emissions @traces (:trace-emissions expect))
             error-emit-failures (when (contains? expect :error-emit-records)
                                   (check-error-emit-records
                                     @err-records (:error-emit-records expect)))
@@ -1574,13 +1489,13 @@
         ;; rf2-wxe9t — drop just this fixture's error-emit recorder.
         (error-emit/unregister-error-listener! [fid ::records])
         {:fixture-id   fid
-         :passed?      (and (or (nil? expected-db) (submap? expected-db final-db))
+         :passed?      (and (or (nil? expected-db) (conformance/submap? expected-db final-db))
                             (or (nil? expected-dbs)
-                                (every? (fn [[fid db]] (submap? db (get final-dbs fid)))
+                                (every? (fn [[fid db]] (conformance/submap? db (get final-dbs fid)))
                                         expected-dbs))
-                            (or (nil? expected-rt) (submap? expected-rt final-rt))
+                            (or (nil? expected-rt) (conformance/submap? expected-rt final-rt))
                             (or (nil? expected-rts)
-                                (every? (fn [[fid rt]] (submap? rt (get final-rts fid)))
+                                (every? (fn [[fid rt]] (conformance/submap? rt (get final-rts fid)))
                                         expected-rts))
                             (empty? absent-failures)
                             (empty? @dispatch-error-failures)

--- a/implementation/schemas/test/re_frame/schemas_conformance_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_conformance_test.clj
@@ -240,67 +240,15 @@
                 (frame/swap-frame-db! frame-id (constantly new-db)))
    :dispatch! (fn [event frame-id] (rf/dispatch event {:frame frame-id}))})
 
-(defn- collect-cofx-keys
-  "Walk DSL body steps and collect every cofx-id referenced via
-  `[:cofx-key K]`. Used to auto-wire generated cofx interceptors under
-  event metadata `:interceptors` per the rf2-g25p convention.
-
-  Per Spec 010 §Where schemas attach §On every reg-*, the cofx-id is
-  the slot key — so a handler body that reads `[:cofx-key :app-version]`
-  declares its dependency on a cofx whose namespace-or-bare key is
-  `:app-version`. The runner uses that declaration to auto-inject the
-  matching namespaced cofx-ids (e.g. `:app-version/bad`)."
-  [steps]
-  (let [out (atom #{})]
-    ((fn walk [form]
-       (cond
-         (and (vector? form) (= :cofx-key (first form)))
-         (swap! out conj (second form))
-
-         (coll? form)
-         (doseq [x form] (walk x))))
-     steps)
-    @out))
-
-(defn- realise-cofx-supplier
-  "DSL → a value-returning cofx supplier `(fn [] value)` (EP-0017 model,
-  rf2-hqwki4). Mirrors core's runner: a `:set` step's value IS the value the
-  supplier returns; the runtime delivers it FLAT under the cofx-id when a
-  handler declares it via `:rf.cofx/requires`. The ctx→ctx `inject-cofx` form
-  that placed the value at `[:coeffects cofx-id]` is RETIRED with
-  `inject-cofx`.
-
-  Per rf2-g25p the `:set` value passes through `eval-value*`; multiple `:set`
-  steps run in order and the final step wins (single-delivery convention)."
-  [steps]
-  (fn []
-    (let [eval-value (requiring-resolve 're-frame.conformance/eval-value*)]
-      (reduce (fn [v step]
-                (case (first step)
-                  :set  (let [[_ _path value] step]
-                          (eval-value value {}))
-                  :noop v
-                  v))
-              nil
-              steps))))
-
-(defn- normalize-event-handler
-  "Collapse the DSL `[body-shape handler]` pair `conformance/realise-event-
-  handler` returns into the single EP-0018 `reg-event` shape — a
-  `(cofx-in → effects-map-or-nil)` fn.
-
-  `body-shape` is a DSL-INTERNAL interpreter distinction, NOT a public
-  `:event/kind` (EP-0018 removed the public event sub-kind model: a registered
-  event is just kind `:event`). An `:event-db` body is `(fn [db event] new-db)`;
-  it is lifted to `(fn [cofx event] {:db (handler db event)})` — read db from
-  the coeffects, lower the returned db into a `{:db …}` effect (same observable
-  behaviour). An `:event-fx` body is already the single form and passes
-  through. Registering through this normaliser keeps the registration site free
-  of any kind branch."
-  [[body-shape handler]]
-  (case body-shape
-    :db (fn [{:keys [db]} event] {:db (handler db event)})
-    :fx handler))
+;; Handler-body realisation reuses the SHARED primitives owned by
+;; `re-frame.conformance` (core/src, already on this artefact's classpath):
+;;   - `collect-cofx-keys`       — walk steps, pull `[:cofx-key K]` refs
+;;   - `realise-cofx-supplier`   — DSL body → value-returning cofx supplier
+;;   - `normalize-event-handler` — collapse the `[body-shape handler]` pair
+;;                                 into the single `reg-event` form
+;; Migrated off private copies per rf2-wy414k. Only the schemas-specific
+;; wiring below (adapter helpers, app-schema registration, fixture discovery,
+;; capability claims, the execution loop, reporting) stays local.
 
 (defn- realise-handlers
   "Register every handler the fixture declares (events / subs / cofx /
@@ -341,7 +289,7 @@
               meta (get cofx-registry cofx-id {})]
           (if (:provided? meta)
             (rf/reg-cofx cofx-id meta)
-            (rf/reg-cofx cofx-id meta (realise-cofx-supplier body))))))
+            (rf/reg-cofx cofx-id meta (conformance/realise-cofx-supplier body))))))
     ;; ---- events --------------------------------------------------------
     ;; Per Spec 010 §step 1 (rf2-jwm4): event meta carries :schema; the
     ;; runtime calls `:schemas/validate-event!` before the handler runs.
@@ -363,10 +311,10 @@
     ;; returned db into a `{:db …}` effect — same observable behaviour); an
     ;; event-fx body is already the single form and passes through.
     (doseq [[id steps] (:event hmap)]
-      (let [handler  (normalize-event-handler
+      (let [handler  (conformance/normalize-event-handler
                        (conformance/realise-event-handler steps))
             meta     (get event-meta id {})
-            ks       (collect-cofx-keys steps)
+            ks       (conformance/collect-cofx-keys steps)
             cofx-ids (vec (mapcat (fn [k]
                                     (or (get cofx-by-key k)
                                         (when (contains? cofx-registry k) [k])))
@@ -433,57 +381,13 @@
     (rf/reg-app-schema path schema)))
 
 ;; ---- matchers ------------------------------------------------------------
-
-(defn- submap?
-  "True if every key of `expected` is present in `actual` with a
-  matching value. Recurses into nested maps so partial expectations on
-  nested slices work the same way (e.g. a fixture asserting only a
-  subset of trace tags)."
-  [expected actual]
-  (cond
-    (and (map? expected) (map? actual))
-    (every? (fn [[k v]]
-              (let [a (get actual k)]
-                (if (and (map? v) (map? a))
-                  (submap? v a)
-                  (= v a))))
-            expected)
-
-    :else (= expected actual)))
-
-(defn- trace-matches?
-  "Partial match — every key of `exp` appears in `act` with a matching
-  value. Nested-map keys partial-match the same way."
-  [exp act]
-  (every? (fn [[k v]]
-            (let [a (get act k)]
-              (cond
-                (and (map? v) (map? a))
-                (every? (fn [[kk vv]] (= vv (get a kk))) v)
-                :else (= v a))))
-          exp))
-
-(defn- check-trace-emissions
-  "Order-preserving subset match — every expected trace must appear in
-  `actual` in declaration order. Extras tolerated (the runtime may
-  emit bookkeeping traces the fixture doesn't care about)."
-  [actual expected]
-  (loop [actual   actual
-         expected expected
-         failures []]
-    (cond
-      (empty? expected) failures
-      (empty? actual)
-      (conj failures (str "expected trace not seen: " (pr-str (first expected))))
-      :else
-      (let [exp (first expected)
-            i   (->> actual
-                     (map-indexed vector)
-                     (some (fn [[i a]] (when (trace-matches? exp a) i))))]
-        (if i
-          (recur (drop (inc i) actual) (rest expected) failures)
-          (recur actual (rest expected)
-                 (conj failures (str "expected trace not seen: " (pr-str exp)))))))))
+;;
+;; The expectation matchers are the SHARED primitives owned by
+;; `re-frame.conformance` (core/src) — `submap?` (recursive submap match on
+;; `:final-app-db` / trace tags) and `check-trace-emissions` (order-preserving
+;; partial trace subset). Migrated off private copies per rf2-wy414k; the
+;; schemas-specific expectation wiring (which matchers to run against which
+;; fixture slice) stays local in `run-fixture` below.
 
 ;; ---- :fixture/dispatches runner ------------------------------------------
 
@@ -528,18 +432,10 @@
     (rf/dispatch-sync ev)))
 
 ;; ---- single-fixture execution -------------------------------------------
-
-(defn- resolve-sub
-  "A `:sub-values` query may be either:
-    [query-v]                 — implicit :rf/default frame
-    [frame-id [query-v]]      — explicit frame
-  Returns `[frame-id query-v]`. Mirrors core's runner."
-  [entry]
-  (if (and (vector? entry)
-           (= 2 (count entry))
-           (vector? (second entry)))
-    [(first entry) (second entry)]
-    [:rf/default entry]))
+;;
+;; `:sub-values` query resolution (`[query-v]` implicit-frame vs
+;; `[frame-id [query-v]]` explicit-frame) is the shared `conformance/resolve-sub`
+;; primitive (core/src) — migrated off a private copy per rf2-wy414k.
 
 (defn- run-fixture
   "Run one fixture; return a result map shaped like the core runner's."
@@ -584,14 +480,14 @@
               sub-checks
               (doall
                 (for [[query-v expected-val] (or (:sub-values expect) {})]
-                  (let [[frame-id qv] (resolve-sub query-v)]
+                  (let [[frame-id qv] (conformance/resolve-sub :rf/default query-v)]
                     {:query    query-v
                      :expected expected-val
                      :actual   (rf/subscribe-once qv {:frame frame-id})})))
-              trace-failures (check-trace-emissions @traces
-                                                    (:trace-emissions expect))]
+              trace-failures (conformance/check-trace-emissions
+                               @traces (:trace-emissions expect))]
           {:fixture-id     fid
-           :passed?        (and (or (nil? expected-db) (submap? expected-db final-db))
+           :passed?        (and (or (nil? expected-db) (conformance/submap? expected-db final-db))
                                 (every? #(= (:expected %) (:actual %)) sub-checks)
                                 (empty? trace-failures)
                                 (empty? @dispatch-error-failures))


### PR DESCRIPTION
## What

The schemas conformance runner (`implementation/schemas/test/re_frame/schemas_conformance_test.clj`) carried private copies of six stable, pure harness primitives that were **also** duplicated in the core corpus runner (`implementation/core/test/re_frame/conformance_runner.cljc`). This lifts them into the cross-artefact shared owner `re-frame.conformance` (`core/src`) and migrates **both** runners to consume them.

### Why `core/src` (not `conformance_runner.cljc`)
The bead framed the shared owner as xurchk's `conformance_runner.cljc` — but that lives in `core/test`, which is **not** on the schemas artefact's classpath (`{:local/root "../core"}` only exports core's `:paths ["src"]`). The reachable cross-artefact shared owner is `re-frame.conformance` in `core/src` — the same namespace schemas already consumes (`realise-event-handler` / `realise-sub` / `realise-fx-handler` / `eval-value*`). The primitives went there, and both runners now consume them (single source of truth — no competing runner abstraction).

### Shared (moved into `re-frame.conformance`, `core/src`)
- `collect-cofx-keys` — walk steps, pull `[:cofx-key K]` refs
- `realise-cofx-supplier` — DSL body → value-returning cofx supplier
- `normalize-event-handler` — collapse `[body-shape handler]` → single `reg-event` form
- `submap?` — recursive submap match
- `check-trace-emissions` — order-preserving partial trace subset
- `resolve-sub` — `:sub-values` query-frame resolution

### Kept LOCAL to the schemas runner
Fixture discovery, capability claims, schemas-specific registrations (app-schemas + cofx/event/sub/fx wiring), the execution loop, and reporting. **No configurable universal runner was built** (explicitly out of scope).

### Notable design point — `resolve-sub`'s frame default
`resolve-sub` now takes its implicit default frame as a **parameter** rather than a baked-in `:rf/default`. The shared owner is in `core/src`, under the EP-0002 frame-floor lint (`re-frame.no-rf-default-floor-lint-test`), which exempts `test/` but not `src/`. A positional `[:rf/default entry]` default in `src/` trips that lint (and no other `core/src` file carries that shape). Making the default a parameter lets each runner pass `:rf/default` from its own (lint-exempt) test tree — sharing the query-shape normalisation while keeping `src/` free of the floor shape. This is the one primitive that couldn't be moved verbatim; the logic is still shared.

Core-runner event registration also collapses to a single `reg-event` path via `normalize-event-handler` (both body-shapes register identically).

Focused CLJ/CLJS coverage for all six primitives added to the host-neutral `conformance_dsl_cljs_test.cljc` (runs on both hosts).

## Quality gates
All foreground, on the worktree:
- `cd implementation/schemas && clojure -M:test` → **341 tests, 18950 assertions, 0 failures, 0 errors**
- `cd implementation/core && clojure -M:test` → **1769 tests, 7694 assertions, 0 failures, 0 errors** (incl. the EP-0002 frame-floor lint + the new focused primitive tests)
- `cd implementation && npm run test:cljs` → **8467 tests, 39091 assertions, 0 failures, 0 errors**

## Stance
Pre-alpha, no back-compat. ELEGANCE + CLARITY + CORRECTNESS + GOOD-PRACTICE: single source of truth for the shared primitives, both runners de-duplicated (schemas −130 lines, core runner −130 lines), no universal-runner over-engineering. Public APIs / production bundles unchanged (`re-frame.conformance` is tree-shaken test-support, never required by production code).