### PR TITLE
refactor(examples): one asset/exception manifest for staging + scanner (rf2-phpbo8)

### DIFF
--- a/examples/scripts/check-examples-assets.cjs
+++ b/examples/scripts/check-examples-assets.cjs
@@ -20,7 +20,10 @@
  * contract was review-only: nothing failed when a non-exempt page omitted an
  * asset, and the one real exception (TodoMVC uses the official TodoMVC CSS
  * packages instead of the shared stylesheet) was not encoded as an explicit
- * allowlisted exception anywhere.
+ * allowlisted exception anywhere. That exception now lives — once — in the
+ * shared examples asset/exception manifest (examples-asset-manifest.cjs), which
+ * this gate consumes via ALLOWLIST and the staging helper consumes for the same
+ * entry.
  *
  * What this gate does (STATIC — no browser, no Playwright)
  * -------------------------------------------------------
@@ -92,11 +95,12 @@
  *
  *   2. Asserts the REQUIRED _shared asset contract: every example must
  *      reference _shared/img/favicon.svg, _shared/img/og.png, and
- *      _shared/css/style.css — UNLESS the page is allowlisted out of a
- *      specific asset (see ALLOWLIST). The TodoMVC stylesheet opt-out is
- *      encoded there: it is exempt from style.css (it links the vendored
- *      TodoMVC base.css + index.css) but STILL required to carry the shared
- *      favicon + OG card.
+ *      _shared/css/style.css — UNLESS the page is exempt from a specific
+ *      asset (see ALLOWLIST, the page-opt-out projection of the shared
+ *      examples asset/exception manifest). The TodoMVC stylesheet opt-out is
+ *      encoded in that manifest: it is exempt from style.css (it links the
+ *      vendored TodoMVC base.css + index.css) but STILL required to carry the
+ *      shared favicon + OG card.
  *
  *   3. Asserts the social-preview (og:image) target is a RASTER, never an SVG:
  *      link-preview scrapers (Facebook / X / LinkedIn / Slack / Discord) do
@@ -164,6 +168,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { pageExemptions } = require('./examples-asset-manifest.cjs');
 
 // __dirname is <repo>/examples/scripts. REPO_ROOT is <repo>.
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
@@ -190,33 +195,23 @@ const SOCIAL_PREVIEW_RASTER_EXTS = new Set(['.png', '.jpg', '.jpeg', '.webp', '.
 const SOCIAL_PREVIEW_REQUIRED = '_shared/img/og.png';
 
 // ---------------------------------------------------------------------------
-// Allowlisted exceptions — the ONE encoded place that names a page's opt-out
-// from a required shared asset, with the reason. A reviewer (human or the
-// gate) reads this to know an omission is intentional, not a regression.
+// Allowlisted exceptions — the page-opt-out PROJECTION of the single examples
+// asset/exception manifest (examples-asset-manifest.cjs), the shared owner the
+// STAGING helper (examples-staging.cjs) also consumes for the same TodoMVC
+// entry. This is the ONE encoded place — read here, declared once there — that
+// names a page's opt-out from a required shared asset, with the reason, so a
+// reviewer (human or the gate) knows an omission is intentional, not a
+// regression.
 //
-// `assetExemptions` lists the required-asset hrefs a page is allowed to
-// OMIT. `localAssets` lists the page's NON-_shared local references that are
-// staged from somewhere other than the repo source tree (so the resolver
-// must not flag them as missing files on disk).
+// Keyed by page relIndex -> { reason, assetExemptions, localAssets }:
+// `assetExemptions` are the required-asset hrefs a page may OMIT; `localAssets`
+// are the page's NON-_shared local references staged from OUTSIDE the repo
+// source tree (so the resolver must not flag them missing). The manifest
+// derives `localAssets` from the SAME staged-asset declaration the staging
+// projection reads (TodoMVC's html-linked base.css + index.css), so the staged
+// destinations and the scanner's accepted page-local refs cannot drift.
 // ---------------------------------------------------------------------------
-const ALLOWLIST = {
-  // TodoMVC links the official TodoMVC CSS packages (todomvc-common's
-  // base.css + todomvc-app-css's index.css, pinned in
-  // implementation/package.json and staged from node_modules/) instead of
-  // the shared stylesheet — see examples/core/todomvc/README.md
-  // §Official assets. It is therefore exempt from _shared/css/style.css but
-  // STILL required to carry the shared favicon + OG card, and its two
-  // vendored CSS links are not repo-source files (they're npm-staged), so
-  // they're declared here rather than flagged as missing.
-  'examples/core/todomvc/index.html': {
-    reason:
-      'TodoMVC uses the official TodoMVC CSS packages (base.css + ' +
-      'index.css, staged from node_modules/) instead of the shared ' +
-      'stylesheet — see examples/core/todomvc/README.md §Official assets.',
-    assetExemptions: ['_shared/css/style.css'],
-    localAssets: ['base.css', 'index.css'],
-  },
-};
+const ALLOWLIST = pageExemptions();
 
 // ---------------------------------------------------------------------------
 // External CSS network allowlist (rf2-vou5mm + rf2-o18ava) — the ONE encoded
@@ -1095,14 +1090,16 @@ function scanPage(io, indexAbsPath, opts = {}) {
       errors.push(
         `${relIndex}: missing required shared asset reference '${need}'. ` +
           `Either add it to the page's <head>, or (if intentional) encode ` +
-          `the exception in ALLOWLIST in check-examples-assets.cjs with a reason.`,
+          `the exemption for this page in the examples asset/exception ` +
+          `manifest (examples/scripts/examples-asset-manifest.cjs) with a reason.`,
       );
     }
     if (present && isExempt) {
       errors.push(
         `${relIndex}: allowlisted as exempt from '${need}' but the page ` +
-          `DOES reference it — remove the stale exemption from ALLOWLIST ` +
-          `in check-examples-assets.cjs.`,
+          `DOES reference it — remove the stale exemption from this page's ` +
+          `entry in the examples asset/exception manifest ` +
+          `(examples/scripts/examples-asset-manifest.cjs).`,
       );
     }
   }
@@ -1527,10 +1524,13 @@ if (require.main === module) {
       `\nA missing/renamed _shared asset, a broken @import, an unallowlisted ` +
         `EXTERNAL CSS @import, an unallowlisted direct-HTML remote asset ref ` +
         `(remote <script>/<link>/<img>), or a page that drops a required ` +
-        `shared asset without an encoded ALLOWLIST exception fails this gate. ` +
-        `Fix the reference, restore the asset, drop the remote dependency, or ` +
-        `encode the exception (with a reason) in ALLOWLIST / ` +
-        `EXTERNAL_IMPORT_ALLOWLIST / EXTERNAL_HTML_REF_ALLOWLIST in ` +
+        `shared asset without an encoded exemption fails this gate. ` +
+        `Fix the reference, restore the asset, drop the remote dependency, ` +
+        `encode a shared-asset exemption (with a reason) in the examples ` +
+        `asset/exception manifest ` +
+        `(examples/scripts/examples-asset-manifest.cjs), or allowlist an ` +
+        `intentional remote ref in EXTERNAL_IMPORT_ALLOWLIST / ` +
+        `EXTERNAL_HTML_REF_ALLOWLIST in ` +
         `examples/scripts/check-examples-assets.cjs.`,
     );
     process.exit(1);

--- a/examples/scripts/examples-asset-manifest.cjs
+++ b/examples/scripts/examples-asset-manifest.cjs
@@ -1,0 +1,171 @@
+'use strict';
+
+/*
+ * ONE owner for every examples EXTERNAL-ASSET EXCEPTION (rf2-phpbo8).
+ *
+ * The problem this closes
+ * -----------------------
+ * A handful of examples depart from the "index.html + _shared, nothing else"
+ * staging baseline: they stage an extra static asset (TodoMVC's official CSS,
+ * managed-http-counter's success fixture, the RealWorld fallback avatar) and/or
+ * opt out of a required _shared asset (TodoMVC links the vendored TodoMVC CSS
+ * instead of the shared stylesheet). Before this manifest each such exception
+ * was declared INDEPENDENTLY in up to three places with no cross-consistency:
+ *
+ *   - examples/scripts/examples-staging.cjs  PER_EXAMPLE_ASSETS  (what to STAGE)
+ *   - examples/scripts/check-examples-assets.cjs  ALLOWLIST       (what the
+ *                                                                  SCANNER accepts)
+ *   - the two implementation script test suites, each pinning its side with a
+ *     LITERAL list that restated the production data.
+ *
+ * TodoMVC's base.css/index.css lived as BOTH staged destinations AND scanner
+ * `localAssets`, redeclared verbatim — so the two could drift with nothing to
+ * catch it. This module is the single side-effect-free owner. Each entry binds
+ * a build id (staging's key) to a source page (the scanner's key), the assets
+ * to stage, the shared-asset exemptions the page may omit, and one reason. Both
+ * consumers PROJECT their view out of it (stagedAssetsByBuild / pageExemptions),
+ * so the staged destinations and the scanner's accepted page-local refs are
+ * derived from ONE declaration and cannot diverge.
+ *
+ * Loading this module touches no filesystem and runs no I/O — it is pure data
+ * plus two pure projections, safe to require from both the staging helper (which
+ * serves browser-gate output) and the static asset scanner.
+ */
+
+// ---------------------------------------------------------------------------
+// The manifest. Each entry declares ONE example's departure from the
+// index.html + _shared staging baseline.
+//
+//   build           — the shadow-cljs build id (colon-stripped coord, as
+//                      listStandaloneExamples() returns) the STAGING consumer
+//                      keys assets by.
+//   page            — the source index.html the SCANNER keys shared-asset
+//                      exemptions by (REPO_ROOT-relative, forward-slashed).
+//                      Recorded for every entry; only entries with a
+//                      scanner-relevant exception (a shared-asset exemption or
+//                      an html-linked staged asset) surface in pageExemptions().
+//   reason          — one human-readable justification for the exception.
+//   assetExemptions — required _shared asset hrefs this page may OMIT (it
+//                      references something else instead). Empty for a
+//                      staging-only exception.
+//   assets          — static assets staged into the output dir beyond
+//                      index.html + _shared. Each: { from, src, dest, htmlLinked }.
+//                        from       — 'node-modules' (under implementation/
+//                                     node_modules) or 'src' (colocated under
+//                                     the example's own source folder).
+//                        src        — source path relative to that root
+//                                     (forward-slashed; consumers path.join it).
+//                        dest       — destination path under the output dir.
+//                        htmlLinked — true iff the page references dest DIRECTLY
+//                                     via a flat href (so the SCANNER must accept
+//                                     it as a page-local ref rather than flag it
+//                                     missing). An asset fetched/referenced from
+//                                     app code (not the HTML) leaves it false.
+// ---------------------------------------------------------------------------
+const EXAMPLE_ASSET_MANIFEST = [
+  {
+    build: 'examples/todomvc',
+    page: 'examples/core/todomvc/index.html',
+    reason:
+      'TodoMVC uses the official TodoMVC CSS packages (todomvc-common base.css ' +
+      '+ todomvc-app-css index.css, pinned in implementation/package.json and ' +
+      'staged from node_modules/ by `npm install`, NOT vendored in-repo) ' +
+      'instead of the shared stylesheet — see examples/core/todomvc/README.md ' +
+      '§Official assets. It is therefore exempt from _shared/css/style.css but ' +
+      'STILL carries the shared favicon + OG card, and its two npm-staged CSS ' +
+      'links are not repo-source files (they are staged, not flagged as missing).',
+    assetExemptions: ['_shared/css/style.css'],
+    assets: [
+      { from: 'node-modules', src: 'todomvc-common/base.css', dest: 'base.css', htmlLinked: true },
+      { from: 'node-modules', src: 'todomvc-app-css/index.css', dest: 'index.css', htmlLinked: true },
+    ],
+  },
+  {
+    build: 'examples/managed-http-counter',
+    page: 'examples/core/managed_http_counter/index.html',
+    reason:
+      'managed-http-counter fetches api/inc.json on its success path; the ' +
+      'fixture lives colocated under the example source api/ folder. Without ' +
+      'it the success path 404s and the example exercises only its failure ' +
+      'branch. Fetched from app code, not linked in the HTML — no scanner ' +
+      'exemption, staging-only.',
+    assetExemptions: [],
+    assets: [
+      { from: 'src', src: 'api/inc.json', dest: 'api/inc.json', htmlLinked: false },
+    ],
+  },
+  {
+    build: 'examples/realworld',
+    page: 'examples/real-apps/realworld_http/index.html',
+    reason:
+      'RealWorld falls a nil/blank avatar back to default-avatar.svg served ' +
+      'from the app asset root (realworld_shared.avatar); the asset lives ' +
+      'colocated in the RealWorld source folder. Without it every fallback ' +
+      'avatar is a broken image. Referenced from app code, not linked in the ' +
+      'HTML — no scanner exemption, staging-only.',
+    assetExemptions: [],
+    assets: [
+      { from: 'src', src: 'default-avatar.svg', dest: 'default-avatar.svg', htmlLinked: false },
+    ],
+  },
+  {
+    build: 'examples/realworld-resources',
+    page: 'examples/real-apps/realworld_resources/index.html',
+    reason:
+      'The RealWorld resources variant falls a nil/blank avatar back to ' +
+      'default-avatar.svg served from the app asset root ' +
+      '(realworld_shared.avatar); the asset lives colocated in the source ' +
+      'folder. Without it every fallback avatar is a broken image. Referenced ' +
+      'from app code, not linked in the HTML — no scanner exemption, staging-only.',
+    assetExemptions: [],
+    assets: [
+      { from: 'src', src: 'default-avatar.svg', dest: 'default-avatar.svg', htmlLinked: false },
+    ],
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Projection for the STAGING consumer (examples-staging.cjs): build id ->
+// [{ from, src, dest }]. EVERY declared asset is staged (staging copies them
+// all regardless of htmlLinked; htmlLinked only concerns the scanner). Mirrors
+// the old PER_EXAMPLE_ASSETS shape so the staging helper is a drop-in consumer.
+// ---------------------------------------------------------------------------
+function stagedAssetsByBuild(manifest = EXAMPLE_ASSET_MANIFEST) {
+  const out = {};
+  for (const entry of manifest) {
+    if (!entry.assets || entry.assets.length === 0) continue;
+    out[entry.build] = entry.assets.map(({ from, src, dest }) => ({ from, src, dest }));
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Projection for the SCANNER consumer (check-examples-assets.cjs): page
+// relIndex -> { reason, assetExemptions, localAssets }. `localAssets` is
+// DERIVED as the dest of every html-linked asset (the page-local refs the
+// scanner must accept as staged-from-outside-repo-source rather than flag as
+// missing) — so TodoMVC's base.css/index.css are the SAME declaration the
+// staging projection reads, never a second literal list. Only entries with a
+// scanner-relevant exception (a shared-asset exemption OR an html-linked asset)
+// are emitted, so a staging-only entry adds no empty ALLOWLIST noise. Mirrors
+// the old ALLOWLIST shape so the scanner is a drop-in consumer.
+// ---------------------------------------------------------------------------
+function pageExemptions(manifest = EXAMPLE_ASSET_MANIFEST) {
+  const out = {};
+  for (const entry of manifest) {
+    if (!entry.page) continue;
+    const localAssets = (entry.assets || [])
+      .filter((a) => a.htmlLinked)
+      .map((a) => a.dest);
+    const assetExemptions = entry.assetExemptions || [];
+    if (assetExemptions.length === 0 && localAssets.length === 0) continue;
+    out[entry.page] = { reason: entry.reason, assetExemptions, localAssets };
+  }
+  return out;
+}
+
+module.exports = {
+  EXAMPLE_ASSET_MANIFEST,
+  stagedAssetsByBuild,
+  pageExemptions,
+};

--- a/examples/scripts/examples-staging.cjs
+++ b/examples/scripts/examples-staging.cjs
@@ -23,6 +23,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { stagedAssetsByBuild } = require('./examples-asset-manifest.cjs');
 
 // __dirname is <repo>/examples/scripts. REPO_ROOT is <repo>.
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
@@ -81,27 +82,17 @@ function stageShared(outDir) {
 //     colocated in each RealWorld source folder. Without it every fallback
 //     avatar is a broken image.
 //
-// Each asset declares WHERE its source lives (`:src` = colocated under the
-// example's source folder, the default; `:node-modules` = under
-// implementation/node_modules) and the destination name under the output dir.
-// Keyed by shadow-cljs build id (the colon-stripped coord, as listStandalone-
-// Examples() returns). An example with no entry stages only index.html +
-// _shared (the common case).
-const PER_EXAMPLE_ASSETS = {
-  'examples/todomvc': [
-    { from: 'node-modules', src: 'todomvc-common/base.css', dest: 'base.css' },
-    { from: 'node-modules', src: 'todomvc-app-css/index.css', dest: 'index.css' },
-  ],
-  'examples/managed-http-counter': [
-    { from: 'src', src: path.join('api', 'inc.json'), dest: path.join('api', 'inc.json') },
-  ],
-  'examples/realworld': [
-    { from: 'src', src: 'default-avatar.svg', dest: 'default-avatar.svg' },
-  ],
-  'examples/realworld-resources': [
-    { from: 'src', src: 'default-avatar.svg', dest: 'default-avatar.svg' },
-  ],
-};
+// These per-example assets are NOT declared here: they are one facet of the
+// single examples asset/exception manifest (examples-asset-manifest.cjs), the
+// shared owner the STATIC scanner (check-examples-assets.cjs) also consumes for
+// TodoMVC's shared-stylesheet exemption. `PER_EXAMPLE_ASSETS` is the staging
+// PROJECTION of that manifest: build id (the colon-stripped coord, as
+// listStandaloneExamples() returns) -> [{ from, src, dest }]. Each asset
+// declares WHERE its source lives (`src` = colocated under the example's source
+// folder; `node-modules` = under implementation/node_modules) and its
+// destination under the output dir. An example with no manifest entry stages
+// only index.html + _shared (the common case).
+const PER_EXAMPLE_ASSETS = stagedAssetsByBuild();
 
 const NODE_MODULES_ROOT = path.join(IMPL_ROOT, 'node_modules');
 
@@ -118,9 +109,10 @@ function assetSourcePath(entry, asset) {
 // silently-absent asset (an unstyled TodoMVC, a 404ing success path, a broken
 // avatar) is a correctness bug, not a no-op. node_modules assets carry an
 // `npm install` hint because they are fetched, not vendored. No-op for an
-// example with no declared assets.
-function stagePerExampleAssets(entry) {
-  const assets = PER_EXAMPLE_ASSETS[entry.build];
+// example with no declared assets. `perExampleAssets` defaults to the manifest
+// projection but is injectable so a test can drive a synthetic manifest.
+function stagePerExampleAssets(entry, { perExampleAssets = PER_EXAMPLE_ASSETS } = {}) {
+  const assets = perExampleAssets[entry.build];
   if (!assets) return;
   for (const asset of assets) {
     const srcPath = assetSourcePath(entry, asset);
@@ -209,15 +201,16 @@ function cleanStageDirs(dirs, outRoot, { io = fs } = {}) {
 //
 // `entry` shape: { build, outDir, htmlSrc, srcDir } — as produced by
 // listStandaloneExamples() (and compatible with the orchestrator's EXAMPLES
-// entries, which also carry outDir + htmlSrc + srcDir).
-function stageExample(entry) {
+// entries, which also carry outDir + htmlSrc + srcDir). `opts` is forwarded to
+// stagePerExampleAssets (so a test can inject a synthetic per-example manifest).
+function stageExample(entry, opts = {}) {
   if (!fs.existsSync(entry.htmlSrc)) {
     throw new Error(`HTML source missing: ${entry.htmlSrc}`);
   }
   fs.mkdirSync(entry.outDir, { recursive: true });
   fs.copyFileSync(entry.htmlSrc, path.join(entry.outDir, 'index.html'));
   stageShared(entry.outDir);
-  stagePerExampleAssets(entry);
+  stagePerExampleAssets(entry, opts);
 }
 
 // ---------------------------------------------------------------------------

--- a/implementation/scripts/_examples-staging.test.cjs
+++ b/implementation/scripts/_examples-staging.test.cjs
@@ -39,6 +39,35 @@ const {
   EXAMPLES_ROOT,
 } = require('../../examples/scripts/examples-staging.cjs');
 
+const {
+  EXAMPLE_ASSET_MANIFEST,
+  stagedAssetsByBuild,
+} = require('../../examples/scripts/examples-asset-manifest.cjs');
+
+// A SYNTHETIC manifest, injected so the staging projection + consumer are pinned
+// without restating the production data (rf2-phpbo8). It carries a vendored-CSS
+// entry (both assets html-linked, node_modules-sourced) and a staging-only
+// colocated-fixture entry (not html-linked).
+const SYNTHETIC_MANIFEST = [
+  {
+    build: 'examples/synth-vendored',
+    page: 'examples/synth/vendored/index.html',
+    reason: 'synthetic: links vendored CSS instead of the shared stylesheet',
+    assetExemptions: ['_shared/css/style.css'],
+    assets: [
+      { from: 'node-modules', src: 'synth-common/base.css', dest: 'base.css', htmlLinked: true },
+      { from: 'node-modules', src: 'synth-app/index.css', dest: 'index.css', htmlLinked: true },
+    ],
+  },
+  {
+    build: 'examples/synth-fixture',
+    page: 'examples/synth/fixture/index.html',
+    reason: 'synthetic: fetches a colocated fixture from app code (not the HTML)',
+    assetExemptions: [],
+    assets: [{ from: 'src', src: 'api/data.json', dest: 'api/data.json', htmlLinked: false }],
+  },
+];
+
 let failed = 0;
 
 function it(label, f) {
@@ -374,30 +403,80 @@ it('decideRunnerExit treats a teardown-signal kill during interrupt as expected 
 // stage and that a missing source fails LOUD (not a silent skip that ships an
 // unstyled / 404ing / broken-image page).
 
-it('PER_EXAMPLE_ASSETS declares the documented per-example assets (rf2-cq6va5)', () => {
-  // TodoMVC's official CSS (from node_modules), managed-http-counter's success
-  // fixture, and both RealWorld variants' fallback avatar.
-  assert.deepStrictEqual(
-    PER_EXAMPLE_ASSETS['examples/todomvc'].map((a) => a.dest).sort(),
-    ['base.css', 'index.css'],
-    'TodoMVC must stage base.css + index.css',
+// ---- manifest projection: staging consumer (rf2-phpbo8) ------------------
+//
+// The staging PER_EXAMPLE_ASSETS map is no longer a literal declaration — it is
+// the projection of the single examples asset/exception manifest, the shared
+// owner the static scanner also consumes. These pin the projection against a
+// SYNTHETIC manifest (so the logic is exact, not a restated copy of production
+// data) plus a real-manifest NON-VACUITY + cross-consistency check.
+
+it('stagedAssetsByBuild projects a synthetic manifest to build -> [{from,src,dest}], dropping htmlLinked (rf2-phpbo8)', () => {
+  const projected = stagedAssetsByBuild(SYNTHETIC_MANIFEST);
+  // EVERY declared asset is staged regardless of htmlLinked (a scanner concern);
+  // the staging view carries only from/src/dest.
+  assert.deepStrictEqual(projected['examples/synth-vendored'], [
+    { from: 'node-modules', src: 'synth-common/base.css', dest: 'base.css' },
+    { from: 'node-modules', src: 'synth-app/index.css', dest: 'index.css' },
+  ]);
+  assert.ok(
+    !('htmlLinked' in projected['examples/synth-vendored'][0]),
+    'the staging projection must drop the scanner-only htmlLinked flag',
   );
+  assert.deepStrictEqual(projected['examples/synth-fixture'], [
+    { from: 'src', src: 'api/data.json', dest: 'api/data.json' },
+  ]);
+});
+
+it('stagePerExampleAssets stages from an INJECTED synthetic-manifest projection (rf2-phpbo8)', () => {
+  // Drive the real staging consumer with a synthetic manifest projection: a
+  // colocated (:src) fixture must land under outDir/api/data.json after staging.
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'rf2-synth-'));
+  try {
+    const srcDir = path.join(tmpRoot, 'src');
+    fs.mkdirSync(path.join(srcDir, 'api'), { recursive: true });
+    fs.writeFileSync(path.join(srcDir, 'api', 'data.json'), '{"ok":true}');
+    const outDir = path.join(tmpRoot, 'out');
+    fs.mkdirSync(outDir, { recursive: true });
+    const entry = { build: 'examples/synth-fixture', outDir, srcDir };
+
+    stagePerExampleAssets(entry, {
+      perExampleAssets: stagedAssetsByBuild(SYNTHETIC_MANIFEST),
+    });
+
+    const staged = path.join(outDir, 'api', 'data.json');
+    assert.ok(fs.existsSync(staged), `the synthetic fixture must be staged at ${staged}`);
+    assert.strictEqual(fs.readFileSync(staged, 'utf8'), '{"ok":true}');
+  } finally {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
+it('the LIVE staging PER_EXAMPLE_ASSETS IS the real manifest projection, non-vacuously (rf2-phpbo8)', () => {
+  // Cross-consistency: the exported staging map is exactly the real manifest's
+  // staging projection (no second, drift-prone literal declaration).
+  assert.deepStrictEqual(
+    PER_EXAMPLE_ASSETS,
+    stagedAssetsByBuild(EXAMPLE_ASSET_MANIFEST),
+    'PER_EXAMPLE_ASSETS must be the manifest projection, not an independent copy',
+  );
+  // Non-vacuity: the real manifest declares the documented per-example builds,
+  // and TodoMVC's official CSS is fetched from node_modules (not vendored).
+  for (const build of [
+    'examples/todomvc',
+    'examples/managed-http-counter',
+    'examples/realworld',
+    'examples/realworld-resources',
+  ]) {
+    assert.ok(
+      Array.isArray(PER_EXAMPLE_ASSETS[build]) && PER_EXAMPLE_ASSETS[build].length > 0,
+      `the manifest must declare staged assets for ${build}`,
+    );
+  }
   assert.ok(
     PER_EXAMPLE_ASSETS['examples/todomvc'].every((a) => a.from === 'node-modules'),
     'TodoMVC CSS is fetched into node_modules, not vendored',
   );
-  assert.ok(
-    PER_EXAMPLE_ASSETS['examples/managed-http-counter'].some((a) =>
-      /inc\.json$/.test(a.dest),
-    ),
-    'managed-http-counter must stage its api/inc.json success fixture',
-  );
-  for (const build of ['examples/realworld', 'examples/realworld-resources']) {
-    assert.ok(
-      PER_EXAMPLE_ASSETS[build].some((a) => a.dest === 'default-avatar.svg'),
-      `${build} must stage default-avatar.svg`,
-    );
-  }
 });
 
 it('stageExample stages a colocated per-example asset after a clean stage (rf2-cq6va5)', () => {

--- a/implementation/scripts/check-examples-assets.test.cjs
+++ b/implementation/scripts/check-examples-assets.test.cjs
@@ -64,6 +64,38 @@ const {
   RETIRED_OG_SOURCE_COLORS,
 } = scanner;
 
+// The shared examples asset/exception manifest — the single owner the scanner's
+// ALLOWLIST is now the page-opt-out projection of (rf2-phpbo8). Imported here so
+// the scanner-consumer tests can inject a SYNTHETIC manifest and pin the real
+// manifest's cross-consistency, rather than hand-writing allowlist literals.
+const manifest = require('../../examples/scripts/examples-asset-manifest.cjs');
+const { pageExemptions, stagedAssetsByBuild, EXAMPLE_ASSET_MANIFEST } = manifest;
+
+// A SYNTHETIC manifest with a vendored-CSS page (both assets html-linked, so the
+// scanner must accept them as page-local refs) and a staging-only fixture entry
+// (not html-linked and no shared-asset exemption, so it must NOT surface in the
+// scanner projection). Keyed to a `examples/reagent/todomvc/...` page so it lines
+// up with the synthetic TodoMVC page the scanPage tests below build.
+const SYNTHETIC_MANIFEST = [
+  {
+    build: 'examples/synth-todomvc',
+    page: 'examples/reagent/todomvc/index.html',
+    reason: 'synthetic: vendored TodoMVC CSS instead of the shared stylesheet',
+    assetExemptions: ['_shared/css/style.css'],
+    assets: [
+      { from: 'node-modules', src: 'todomvc-common/base.css', dest: 'base.css', htmlLinked: true },
+      { from: 'node-modules', src: 'todomvc-app-css/index.css', dest: 'index.css', htmlLinked: true },
+    ],
+  },
+  {
+    build: 'examples/synth-fixture',
+    page: 'examples/reagent/fixture/index.html',
+    reason: 'synthetic: staging-only fixture (fetched from app code, not the HTML)',
+    assetExemptions: [],
+    assets: [{ from: 'src', src: 'api/data.json', dest: 'api/data.json', htmlLinked: false }],
+  },
+];
+
 // A real, decodable 1200x630 PNG (signature + IHDR + IDAT + IEND), used wherever
 // a fixture's _shared tree must scan clean — the gate now validates the og.png
 // BYTES, so an opaque 'PNGDATA' string no longer passes checkSharedTree
@@ -204,6 +236,54 @@ it('LIVE: TodoMVC is the encoded style.css opt-out (allowlist, not a regression)
   assert.ok(
     entry.reason && entry.reason.length > 0,
     'the exemption must carry a human-readable reason',
+  );
+});
+
+// ---- manifest projection: scanner consumer (rf2-phpbo8) ------------------
+//
+// ALLOWLIST is no longer a literal — it is the page-opt-out projection of the
+// single examples asset/exception manifest, the shared owner examples-staging.cjs
+// also consumes. These pin the projection against a SYNTHETIC manifest (exact
+// logic, no restated production data) plus a real-manifest cross-consistency
+// check that the very base.css/index.css TodoMVC STAGES are the same refs the
+// scanner accepts as page-local — the drift the two independent declarations
+// used to permit.
+
+it('LIVE: the scanner ALLOWLIST IS the real manifest page-opt-out projection (rf2-phpbo8)', () => {
+  assert.deepStrictEqual(
+    ALLOWLIST,
+    pageExemptions(EXAMPLE_ASSET_MANIFEST),
+    'ALLOWLIST must be the manifest projection, not an independent copy',
+  );
+});
+
+it('LIVE: TodoMVC staged CSS destinations == the scanner-accepted page-local refs (one owner) (rf2-phpbo8)', () => {
+  // The whole point of the unification: base.css + index.css are declared ONCE
+  // and appear in BOTH projections. What staging COPIES is exactly what the
+  // scanner ACCEPTS as page-local — they cannot diverge.
+  const staged = stagedAssetsByBuild(EXAMPLE_ASSET_MANIFEST)['examples/todomvc']
+    .map((a) => a.dest)
+    .sort();
+  const scannerLocal = [
+    ...ALLOWLIST['examples/core/todomvc/index.html'].localAssets,
+  ].sort();
+  assert.deepStrictEqual(staged, ['base.css', 'index.css']);
+  assert.deepStrictEqual(scannerLocal, staged);
+});
+
+it('pageExemptions projects a synthetic manifest: exemption + derived localAssets, staging-only entry excluded (rf2-phpbo8)', () => {
+  const projected = pageExemptions(SYNTHETIC_MANIFEST);
+  // The vendored-CSS page surfaces with its exemption + html-linked localAssets.
+  assert.deepStrictEqual(projected['examples/reagent/todomvc/index.html'], {
+    reason: 'synthetic: vendored TodoMVC CSS instead of the shared stylesheet',
+    assetExemptions: ['_shared/css/style.css'],
+    localAssets: ['base.css', 'index.css'],
+  });
+  // The staging-only fixture entry (no exemption, no html-linked asset) is NOT
+  // projected into the scanner allowlist — it adds no empty ALLOWLIST noise.
+  assert.ok(
+    !('examples/reagent/fixture/index.html' in projected),
+    'a staging-only entry must not surface as a scanner exemption',
   );
 });
 
@@ -1250,13 +1330,10 @@ it('a page allowlisted out of style.css with vendored CSS scans clean', () => {
     // base.css / index.css intentionally absent on disk (npm-staged) — the
     // allowlist's localAssets must keep them from being flagged.
   });
-  const allowlist = {
-    'examples/reagent/todomvc/index.html': {
-      reason: 'vendored TodoMVC CSS',
-      assetExemptions: ['_shared/css/style.css'],
-      localAssets: ['base.css', 'index.css'],
-    },
-  };
+  // Build the allowlist the scanner consumes from a SYNTHETIC manifest — the
+  // same projection production uses — so this pins the manifest-consuming path,
+  // not a hand-written allowlist literal (rf2-phpbo8).
+  const allowlist = pageExemptions(SYNTHETIC_MANIFEST);
   const { errors } = scanPage(io, todoPage, { allowlist });
   assert.deepStrictEqual(
     errors,
@@ -1278,13 +1355,10 @@ it('TEETH: an allowlisted page still REQUIRES favicon + OG (opt-out is styleshee
     [todoPage]: todoHtml,
     [OG]: 'PNGDATA',
   });
-  const allowlist = {
-    'examples/reagent/todomvc/index.html': {
-      reason: 'vendored TodoMVC CSS',
-      assetExemptions: ['_shared/css/style.css'],
-      localAssets: ['base.css', 'index.css'],
-    },
-  };
+  // Build the allowlist the scanner consumes from a SYNTHETIC manifest — the
+  // same projection production uses — so this pins the manifest-consuming path,
+  // not a hand-written allowlist literal (rf2-phpbo8).
+  const allowlist = pageExemptions(SYNTHETIC_MANIFEST);
   const { errors } = scanPage(io, todoPage, { allowlist });
   assert.ok(
     errors.some((e) =>


### PR DESCRIPTION
## What

TodoMVC's two staged CSS assets (`base.css` + `index.css`) and its shared-style exemption were declared independently in three places — `examples-staging.cjs` `PER_EXAMPLE_ASSETS`, `check-examples-assets.cjs` `ALLOWLIST`, and the page's HTML `<link>`s — then separately pinned by **literal-list tests** in two script suites with **no cross-consistency assertion**. `base.css`/`index.css` lived as both staged destinations AND scanner `localAssets`, redeclared verbatim and free to drift.

This adds **one side-effect-free owner**, `examples/scripts/examples-asset-manifest.cjs`, keyed by source page + build id, carrying:
- staged source/destination specs (`{ from, src, dest, htmlLinked }`),
- shared-asset exemptions (`assetExemptions`),
- one `reason` each.

Both consumers now **project** their view out of it:
- **staging** reads `stagedAssetsByBuild()` → `PER_EXAMPLE_ASSETS` (build id → `[{from,src,dest}]`),
- **scanner** reads `pageExemptions()` → `ALLOWLIST` (page → `{reason, assetExemptions, localAssets}`).

TodoMVC's page-local `base.css`/`index.css` are **derived** from the same `htmlLinked` assets staging copies — so what is staged is exactly what the scanner accepts; they cannot diverge. The managed-http + RealWorld staged entries move into the same owner for completeness (**no new exemptions invented**). The HTML `<link>`s and `README` teaching material are unchanged. The competing production declarations + literal-list tests are removed, replaced by synthetic-manifest injection tests for both consumers plus real-manifest non-vacuity + cross-consistency checks.

## Preflight confirmation

Premise confirmed as described: TodoMVC's two staged CSS assets + shared-style exemption were independently declared across `examples/core/todomvc/index.html` (`<link>`s), `examples-staging.cjs` `PER_EXAMPLE_ASSETS`, and `check-examples-assets.cjs` `ALLOWLIST`, and separately pinned by literal-list tests in `implementation/scripts/_examples-staging.test.cjs` + `check-examples-assets.test.cjs` with no cross-consistency assertion. Staging determines what can exist; the scanner separately decides which generated locals are allowed.

## Stance

Pre-alpha, no back-compat shims. Primary lenses ELEGANCE + CLARITY + CORRECTNESS + GOOD-PRACTICE. No new exemptions invented — the manifest carries exactly the four pre-existing per-example entries and the single TodoMVC shared-style exemption.

## Quality gates (foreground, 0 failures)

- `node scripts/_examples-staging.test.cjs` — all passed (incl. synthetic-manifest staging projection + injected-consumer stage + real-manifest non-vacuity/cross-consistency).
- `node scripts/check-examples-assets.test.cjs` — all passed (incl. synthetic-manifest scanner projection, `ALLOWLIST == pageExemptions(real)`, and "staged dests == scanner-accepted page-local refs" cross-consistency).
- `node examples/scripts/check-examples-assets.cjs` — scanned 35 host pages + `_shared` tree, all resolve, exemptions honoured.
- Staging dry-run — `stageExample` for a colocated build stages `index.html` + `_shared` + the per-example asset from the manifest projection.
- `npm run test:script-policy` — full always-on gate, `EXIT=0`, no failures.

## Note (out of scope)

A change touching ONLY the new `examples-asset-manifest.cjs` falls through to the generic `examples/*` case in `.github/scripts/report-changed-surfaces.sh` (fires `cljs_browser` + `cljs_node_test`, not the browser gates). Since the manifest underpins `examples-staging.cjs` (which fires both browser gates via rf2-eqjxya), a follow-up could add a dedicated case mirroring it. Not done here: the classifier script is CI infra outside this bead's touch-list, no `classify()` test regresses, and the manifest's correctness is fully covered by the always-on `test:script-policy` suites.
