### PR TITLE
refactor(pair-mcp): shared event-arg parser + nREPL port-file owner (rf2-tcp7za, rf2-y8aszh)

### DIFF
--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/nrepl.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/nrepl.cljs
@@ -51,9 +51,16 @@
    ".shadow-cljs/nrepl.port"
    ".nrepl-port"])
 
-(defn- read-port-file
+(defn read-port-file
   "Read + parse an nREPL port from a single file `path`. Returns an
-  integer or nil (file absent / unreadable / non-numeric content)."
+  integer or nil (file absent / unreadable / non-numeric content).
+
+  Public within the tool: this transport ns OWNS nREPL port-file parsing.
+  The discovery cascade above uses it, and `server.cljs/ensure-connection!`
+  calls it for the per-tool-call re-read of the cached port file (detecting
+  a shadow restart that rewrote the port) — rather than carrying its own
+  byte-for-byte copy. Connection lifecycle stays in server; the filesystem
+  read/trim/parse primitive lives here."
   [path]
   (try
     (let [content (str/trim (.toString (.readFileSync fs path)))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/server.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/server.cljs
@@ -64,7 +64,6 @@
             ["@modelcontextprotocol/sdk/server/index.js" :as mcp-server]
             ["@modelcontextprotocol/sdk/server/stdio.js" :as mcp-stdio]
             ["@modelcontextprotocol/sdk/types.js" :as mcp-types]
-            ["fs" :as fs]
             ["path" :as node-path]))
 
 (def ^:const server-name    "re-frame2-pair-mcp")
@@ -227,18 +226,6 @@
                      (js/Promise.reject
                        (js/Error. (str "elicitation returned unexpected action: " action))))))))))
 
-(defn- read-port-file*
-  "Read the port file at `path`. Returns an int or nil (missing /
-  unreadable / non-numeric content). Mirrors `nrepl/read-port-file` but
-  kept local so a future test seam doesn't have to thread through the
-  transport ns."
-  [path]
-  (try
-    (let [content (str/trim (.toString (.readFileSync fs path)))
-          n       (js/parseInt content 10)]
-      (when-not (js/isNaN n) n))
-    (catch :default _ nil)))
-
 (defn- new-conn-for-port [port]
   (log! "nREPL port =" port)
   (nrepl/make-conn port "127.0.0.1"))
@@ -381,7 +368,7 @@
                     (js/Promise.reject e))))
 
       :else
-      (let [current-port (when port-file (read-port-file* port-file))]
+      (let [current-port (when port-file (nrepl/read-port-file port-file))]
         (cond
           ;; The cached file vanished — shadow shut down. Force re-discovery.
           (and port-file (nil? current-port))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/args.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/args.cljs
@@ -513,9 +513,10 @@
   Factors out the trim+read+sentinel core shared verbatim by
   `replace-app-db` (`:db`), `restore-epoch` (`:epoch-id`), and
   `handler-meta` (`:id`). The richer `dispatch` / `dispatch-dry-run`
-  event parsers are deliberately NOT routed through here — they layer a
-  vector-shape contract + parsed-type classification on top, and their
-  ns docstrings pin them as separate surfaces."
+  event-vector parse — the same trim+read core PLUS a vector-shape
+  contract and parsed-type classification — lives in its sibling
+  `parse-event-arg` below rather than here, so this single-value reader
+  stays minimal."
   [raw missing invalid]
   (let [trimmed (some-> raw str/trim)]
     (if (or (nil? trimmed) (str/blank? trimmed))
@@ -524,6 +525,71 @@
                         (catch :default _ ::reader-fail))]
         (if (= ::reader-fail parsed)
           [:err invalid]
+          [:ok parsed])))))
+
+(defn parse-event-arg
+  "Parse the `event` MCP arg as EDN, enforcing the vector-shape contract
+  shared by `dispatch` and `dispatch-dry-run`. Returns `[:ok parsed-vector]`
+  on success or `[:err err-map]` on any failure. Three failure modes carry
+  distinct reasons:
+
+  - `:missing-event`       — nil / blank value. `missing-hint` is the
+                             caller-specific usage string threaded in as
+                             DATA — `dispatch` and `dispatch-dry-run`
+                             advertise different opt sets, so the corrective
+                             example differs, but nothing else about the
+                             parse does.
+  - `:invalid-event-edn`   — `read-string` threw / returned nil.
+  - `:not-an-event-vector` — parsed cleanly but the shape is wrong (a map,
+                             a keyword, a symbol, a list, a scalar);
+                             `:parsed-type` classifies it.
+
+  ## Why the `event` arg is parsed as EDN, not spliced as source
+
+  Both `dispatch` and `dispatch-dry-run` are intentionally narrower than
+  `eval-cljs`: the contract is `{event '[:ev/id ...]'}` — an EDN event
+  VECTOR, nothing else. Inlining the caller's string verbatim into the
+  generated eval form (as a host-form expression rather than data) would
+  let any caller — or a prompt-injected agent — supply arbitrary CLJS
+  (`(println :pwn)` would run), defeating the boundary that gates
+  `eval-cljs` separately. Parsing as EDN and requiring a `vector?` shape
+  forces the payload to be DATA: a host-form source string reads as a list
+  and is rejected HERE, before the runtime is ever contacted — invalid
+  input short-circuits ahead of the nREPL eval and the permission/privacy
+  gates, so the ordering is security-load-bearing at the call site.
+
+  This is the single production event-parse seam: both tools route through
+  it and pass only their distinct missing-value hint. The exhaustive parse
+  matrix is pinned in `args-test`; the tool suites keep only the narrow
+  integration assertions (distinct hint + no-eval-on-error)."
+  [event-str missing-hint]
+  (let [trimmed (some-> event-str str/trim)]
+    (cond
+      (or (nil? trimmed) (str/blank? trimmed))
+      [:err {:ok? false :reason :missing-event
+             :hint missing-hint}]
+
+      :else
+      (let [parsed (try (cljs.reader/read-string trimmed)
+                        (catch :default _ ::reader-fail))]
+        (cond
+          (= ::reader-fail parsed)
+          [:err {:ok? false :reason :invalid-event-edn
+                 :event event-str
+                 :hint "event must be an EDN-readable vector, e.g. \"[:cart/checkout]\""}]
+
+          (not (vector? parsed))
+          [:err {:ok? false :reason :not-an-event-vector
+                 :event event-str
+                 :parsed-type (cond
+                                (map? parsed)        :map
+                                (keyword? parsed)    :keyword
+                                (symbol? parsed)     :symbol
+                                (sequential? parsed) :list
+                                :else                :scalar)
+                 :hint "event must be a vector, e.g. \"[:cart/checkout {:reason :user}]\""}]
+
+          :else
           [:ok parsed])))))
 
 ;; ---------------------------------------------------------------------------

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/dispatch.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/dispatch.cljs
@@ -136,9 +136,7 @@
   registration-owned transient payloads the classification walker cannot
   prove safe — rf2-nm611o / rf2-6klf02). Posture parity with
   `dispatch-dry-run` (signal-runtime! + projected egress, same gate)."
-  (:require [cljs.reader]
-            [clojure.string :as str]
-            [re-frame2-pair-mcp.tools.args :as args]
+  (:require [re-frame2-pair-mcp.tools.args :as args]
             [re-frame2-pair-mcp.tools.await-promise :as await-promise]
             [re-frame2-pair-mcp.tools.eval-form :as ef]
             [re-frame2-pair-mcp.tools.epoch-egress :as egress]
@@ -146,49 +144,15 @@
             [re-frame2-pair-mcp.tools.wire :as wire]
             [re-frame2-pair-mcp.tools.probe :as probe]))
 
-(defn- parse-event-edn
-  "Parse the `event` MCP arg as EDN. Returns
-  `[:ok parsed-vector]` on success or `[:err err-map]` on any failure.
-  Two failure modes carry distinct reasons:
+;; The `event`-arg EDN/vector parse — the security gate that keeps
+;; host-form source out of the runtime call — lives in the shared
+;; `args/parse-event-arg` seam (byte-identical for dispatch and
+;; dispatch-dry-run bar the missing-value hint). See its docstring for the
+;; why-EDN-not-source rationale. The call site below preserves the parse's
+;; position ahead of the nREPL eval and the permission/privacy gates.
 
-  - `:invalid-event-edn`     — `read-string` threw / returned nil.
-  - `:not-an-event-vector`   — parsed cleanly but the shape is wrong
-                                (e.g. a map, a symbol, a bare keyword).
-
-  The hint repeats the documented usage shape so an agent that
-  fat-fingers the call gets a corrective example without an extra
-  round-trip."
-  [event-str]
-  (let [trimmed (some-> event-str str/trim)]
-    (cond
-      (or (nil? trimmed) (str/blank? trimmed))
-      [:err {:ok? false :reason :missing-event
-             :hint "usage: dispatch {event '[:ev/id ...]' [sync true] [trace true] [frame :foo] [fx-overrides {...}] [interceptor-overrides {...}]}"}]
-
-      :else
-      (let [parsed (try
-                     (cljs.reader/read-string trimmed)
-                     (catch :default e
-                       ::reader-fail))]
-        (cond
-          (= ::reader-fail parsed)
-          [:err {:ok? false :reason :invalid-event-edn
-                 :event event-str
-                 :hint "event must be an EDN-readable vector, e.g. \"[:cart/checkout]\""}]
-
-          (not (vector? parsed))
-          [:err {:ok? false :reason :not-an-event-vector
-                 :event event-str
-                 :parsed-type (cond
-                                (map? parsed)      :map
-                                (keyword? parsed)  :keyword
-                                (symbol? parsed)   :symbol
-                                (sequential? parsed) :list
-                                :else              :scalar)
-                 :hint "event must be a vector, e.g. \"[:cart/checkout {:reason :user}]\""}]
-
-          :else
-          [:ok parsed])))))
+(def ^:private missing-event-hint
+  "usage: dispatch {event '[:ev/id ...]' [sync true] [trace true] [frame :foo] [fx-overrides {...}] [interceptor-overrides {...}]}")
 
 (defn- runtime-envelope->result
   "Translate the runtime dispatch fn's return into the wire envelope.
@@ -461,7 +425,7 @@
         incl?        (if (raw-state/raw-state-allowed?)
                        (args/parse-bool-arg args :include-sensitive)
                        false)
-        [tag payload] (parse-event-edn event-str)]
+        [tag payload] (args/parse-event-arg event-str missing-event-hint)]
     (cond
       ;; A malformed `:timeout-ms` short-circuits to an honest
       ;; isError BEFORE the dispatch eval, rather than threading a value

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/dispatch_dry_run.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/dispatch_dry_run.cljs
@@ -109,51 +109,21 @@
   dispatch/replay would supply. A malformed `cofx` (non-map / unreadable
   / non-integer `:rf/time-ms`) short-circuits to an honest isError before
   the eval, the same `args/parse-cofx` gate `dispatch` carries."
-  (:require [cljs.reader]
-            [clojure.string :as str]
-            [re-frame2-pair-mcp.tools.args :as args]
+  (:require [re-frame2-pair-mcp.tools.args :as args]
             [re-frame2-pair-mcp.tools.elision :as elision]
             [re-frame2-pair-mcp.tools.eval-form :as ef]
             [re-frame2-pair-mcp.tools.probe :as probe]
             [re-frame2-pair-mcp.tools.raw-state :as raw-state]
             [re-frame2-pair-mcp.tools.wire :as wire]))
 
-(defn- parse-event-edn
-  "Mirror `dispatch.cljs/parse-event-edn` — same vector contract, same
-  failure reasons. Kept inline here so the dry-run surface owns its
-  parser; cross-tool sharing of the parser would entangle two
-  separately-evolving surfaces."
-  [event-str]
-  (let [trimmed (some-> event-str str/trim)]
-    (cond
-      (or (nil? trimmed) (str/blank? trimmed))
-      [:err {:ok? false :reason :missing-event
-             :hint "usage: dispatch-dry-run {event '[:ev/id ...]' [frame :foo] [fx-overrides {...}] [cofx '{:rf/time-ms ...}']}"}]
+;; The `event`-arg EDN/vector parse is the shared `args/parse-event-arg`
+;; seam — byte-identical to `dispatch` bar the missing-value hint (dry-run
+;; advertises a different opt set). See its docstring for the
+;; why-EDN-not-source security rationale; the call site below preserves the
+;; parse's position ahead of the nREPL eval and the privacy gates.
 
-      :else
-      (let [parsed (try
-                     (cljs.reader/read-string trimmed)
-                     (catch :default _e
-                       ::reader-fail))]
-        (cond
-          (= ::reader-fail parsed)
-          [:err {:ok? false :reason :invalid-event-edn
-                 :event event-str
-                 :hint "event must be an EDN-readable vector, e.g. \"[:cart/checkout]\""}]
-
-          (not (vector? parsed))
-          [:err {:ok? false :reason :not-an-event-vector
-                 :event event-str
-                 :parsed-type (cond
-                                (map? parsed)      :map
-                                (keyword? parsed)  :keyword
-                                (symbol? parsed)   :symbol
-                                (sequential? parsed) :list
-                                :else              :scalar)
-                 :hint "event must be a vector, e.g. \"[:cart/checkout {:reason :user}]\""}]
-
-          :else
-          [:ok parsed])))))
+(def ^:private missing-event-hint
+  "usage: dispatch-dry-run {event '[:ev/id ...]' [frame :foo] [fx-overrides {...}] [cofx '{:rf/time-ms ...}']}")
 
 (defn- redact-fx-args-src
   "CLJS source for a fn that FAIL-CLOSES the `:would-fire-effects[*]
@@ -304,7 +274,7 @@
         frame-edn    (if frame
                        (pr-str frame)
                        (ef/emit (ef/rt-call 'current-frame)))
-        [tag payload] (parse-event-edn event-str)]
+        [tag payload] (args/parse-event-arg event-str missing-event-hint)]
     (cond
       ;; Reject an invalid fx-overrides target up front so a
       ;; string stub can't silently defeat the no-fx-execute guarantee.

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/args_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/args_test.cljs
@@ -169,6 +169,99 @@
   (is (= [:ok 'nope] (args/read-edn-arg "nope(" :missing :invalid))))
 
 ;; ---------------------------------------------------------------------------
+;; parse-event-arg — the shared event-vector parse seam (rf2-tcp7za).
+;;
+;; `dispatch` and `dispatch-dry-run` used to each carry a byte-for-byte copy
+;; of this parser; they now both route through `args/parse-event-arg`,
+;; passing only their distinct missing-value hint. This is where the
+;; EXHAUSTIVE parse matrix lives — nil / blank / unreadable / map / keyword
+;; / list / symbol / scalar / vector inputs and the parsed-type
+;; classification. The tool suites keep only the narrow integration
+;; assertions (distinct hint + no-eval-on-error).
+;;
+;; The parser is the SECURITY GATE: a host-form source string
+;; (`"(println :pwn)"`) reads as a list and is rejected as
+;; `:not-an-event-vector` — never spliced into the runtime eval as code.
+;; ---------------------------------------------------------------------------
+
+(def ^:private dispatch-hint
+  "usage: dispatch {event '[:ev/id ...]' [sync true] [trace true] [frame :foo] [fx-overrides {...}] [interceptor-overrides {...}]}")
+
+(deftest parse-event-arg-missing-uses-caller-hint-verbatim
+  ;; nil / blank / whitespace → :missing-event, and the caller-specific
+  ;; hint rides through as DATA. This is the ONLY arm that consults the
+  ;; hint — the distinct dispatch / dispatch-dry-run usage strings differ
+  ;; here and nowhere else.
+  (doseq [blank [nil "" "   " "\t\n"]]
+    (let [[tag env] (args/parse-event-arg blank dispatch-hint)]
+      (is (= :err tag) (str (pr-str blank) " is a missing event"))
+      (is (false? (:ok? env)))
+      (is (= :missing-event (:reason env)))
+      (is (= dispatch-hint (:hint env))
+          "the caller's missing-value hint is threaded through verbatim"))))
+
+(deftest parse-event-arg-missing-hint-is-caller-data
+  ;; Two callers with two hints get two envelopes that differ ONLY in the
+  ;; hint — proving the hint is caller-supplied data, not baked into the
+  ;; parser. (This is what lets dispatch and dispatch-dry-run keep distinct
+  ;; missing-event hints from one shared parser.)
+  (let [[_ a] (args/parse-event-arg nil "hint-A")
+        [_ b] (args/parse-event-arg nil "hint-B")]
+    (is (= "hint-A" (:hint a)))
+    (is (= "hint-B" (:hint b)))
+    (is (= (dissoc a :hint) (dissoc b :hint))
+        "everything but the hint is identical across callers")))
+
+(deftest parse-event-arg-unreadable-is-invalid-event-edn
+  ;; A reader failure (unbalanced brackets, lone reader macro) → the
+  ;; :invalid-event-edn reason, distinct from :missing / :not-a-vector.
+  (doseq [bad ["[:foo" "{:k" "#" "(((" "]"]]
+    (let [[tag env] (args/parse-event-arg bad dispatch-hint)]
+      (is (= :err tag) (str (pr-str bad) " fails to read"))
+      (is (= :invalid-event-edn (:reason env)))
+      (is (= bad (:event env)) "the offending raw string is echoed for a corrective retry"))))
+
+(deftest parse-event-arg-non-vector-shapes-classified
+  ;; Valid EDN of the WRONG shape → :not-an-event-vector with a
+  ;; :parsed-type classification the agent can act on. Host-form source is
+  ;; the headline case (`"(println :pwn)"` reads as a list) — the security
+  ;; gate that keeps arbitrary CLJS out of the runtime eval.
+  (doseq [[in kind] [["{:id :foo}"       :map]
+                     [":cart/checkout"   :keyword]
+                     ["(println :pwn)"   :list]
+                     ["some-symbol"      :symbol]
+                     ["42"               :scalar]
+                     ["\"a string\""     :scalar]]]
+    (let [[tag env] (args/parse-event-arg in dispatch-hint)]
+      (is (= :err tag) (str (pr-str in) " is not a vector"))
+      (is (= :not-an-event-vector (:reason env)))
+      (is (= kind (:parsed-type env)) (str (pr-str in) " classified as " kind))
+      (is (= in (:event env))))))
+
+(deftest parse-event-arg-accepts-vectors
+  ;; The happy path — a vector reads back as DATA (not source). Bare,
+  ;; with-payload, and the empty vector all pass; whitespace is trimmed
+  ;; before the read.
+  (is (= [:ok [:cart/checkout]] (args/parse-event-arg "[:cart/checkout]" dispatch-hint)))
+  (is (= [:ok [:cart/add {:sku "abc"}]]
+         (args/parse-event-arg "[:cart/add {:sku \"abc\"}]" dispatch-hint)))
+  (is (= [:ok []] (args/parse-event-arg "[]" dispatch-hint)))
+  (is (= [:ok [:cart/checkout]] (args/parse-event-arg "  [:cart/checkout]  " dispatch-hint))
+      "leading/trailing whitespace trimmed before read"))
+
+(deftest parse-event-arg-non-missing-envelope-independent-of-hint
+  ;; Byte-equivalence: for every NON-missing input the envelope is
+  ;; IDENTICAL regardless of the missing-hint (the hint is consulted only
+  ;; on the missing arm). This is precisely why dispatch and
+  ;; dispatch-dry-run yield byte-equivalent envelopes for unreadable / map
+  ;; / keyword / list / vector inputs even though they advertise different
+  ;; usage hints.
+  (doseq [in ["(println :pwn)" ":kw" "{:a 1}" "[:foo" "[:ok]" "42"]]
+    (is (= (args/parse-event-arg in "hint-A")
+           (args/parse-event-arg in "hint-B"))
+        (str "envelope for " (pr-str in) " is independent of the missing-hint"))))
+
+;; ---------------------------------------------------------------------------
 ;; parse-filter-arg — the streaming filter map. Returns the tagged
 ;; `[:ok m]` / `[:err :invalid-filter-edn]` shape (mirroring
 ;; `read-edn-arg`) so a bad filter EDN surfaces as an honest

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dispatch_dry_run_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dispatch_dry_run_test.cljs
@@ -79,37 +79,52 @@
         (.finally (fn [] (raw-state/set-allow-raw-state! prev))))))
 
 ;; ---------------------------------------------------------------------------
-;; Arg parsing — mirrors dispatch's event-vector gate exactly.
+;; Arg parsing — the exhaustive event-parse matrix now lives in `args_test`
+;; against the shared `args/parse-event-arg` seam (rf2-tcp7za). Dispatch and
+;; dispatch-dry-run route through the SAME parser, so here we keep only the
+;; two narrow tool-level invariants: no-eval-on-error and the DISTINCT
+;; dry-run missing-event hint.
 ;; ---------------------------------------------------------------------------
 
-(deftest rejects-arbitrary-cljs-source
-  ;; Host-form source like `(println :pwn)` must NEVER reach the
-  ;; runtime — the parser rejects non-vector EDN before the eval
-  ;; round-trip.
+(deftest rejects-arbitrary-cljs-source-without-eval
+  ;; Host-form source like `(println :pwn)` must NEVER reach the runtime —
+  ;; it reads as a list, the vector-check fails, and we PROVE the no-eval by
+  ;; capturing every form the tool would send and asserting none fired
+  ;; (neither the configure-raw-state! signal nor the dispatch-dry-run eval).
   (async done
-    (-> (dry-run/dispatch-dry-run-tool (fresh-conn) #js {:event "(println :pwn)"})
-        (.then (fn [r]
-                 (is (err? r))
-                 (let [edn (read-result-text r)]
-                   (is (= :not-an-event-vector (:reason edn)))
-                   (is (= :list (:parsed-type edn))))
-                 (done))))))
+    (let [forms (atom [])]
+      (-> (with-captured-eval! forms (wrap {:ok? true} 0)
+            (fn []
+              (dry-run/dispatch-dry-run-tool (fresh-conn) #js {:event "(println :pwn)"})))
+          (.then (fn [r]
+                   (is (err? r))
+                   (let [edn (read-result-text r)]
+                     (is (= :not-an-event-vector (:reason edn)))
+                     (is (= :list (:parsed-type edn))))
+                   (is (empty? @forms)
+                       "no-eval-on-error — the runtime was never contacted; no signal / dispatch form fired")
+                   (done)))))))
 
-(deftest rejects-missing-event
+(deftest rejects-missing-event-with-dry-run-hint
+  ;; The DISTINCT-hint invariant: a missing event surfaces :missing-event
+  ;; carrying DISPATCH-DRY-RUN's own usage string (its opt set — frame /
+  ;; fx-overrides / cofx), NOT dispatch's. Same shared parser, distinct
+  ;; caller data. Also confirms no-eval on the missing path.
   (async done
-    (-> (dry-run/dispatch-dry-run-tool (fresh-conn) #js {})
-        (.then (fn [r]
-                 (is (err? r))
-                 (is (= :missing-event (:reason (read-result-text r))))
-                 (done))))))
-
-(deftest rejects-unreadable-edn
-  (async done
-    (-> (dry-run/dispatch-dry-run-tool (fresh-conn) #js {:event "[:foo"})
-        (.then (fn [r]
-                 (is (err? r))
-                 (is (= :invalid-event-edn (:reason (read-result-text r))))
-                 (done))))))
+    (let [forms (atom [])]
+      (-> (with-captured-eval! forms (wrap {:ok? true} 0)
+            (fn []
+              (dry-run/dispatch-dry-run-tool (fresh-conn) #js {})))
+          (.then (fn [r]
+                   (is (err? r))
+                   (let [edn (read-result-text r)]
+                     (is (= :missing-event (:reason edn)))
+                     (is (str/includes? (:hint edn) "dispatch-dry-run {")
+                         "the missing-event hint is dispatch-dry-run's own usage string")
+                     (is (str/includes? (:hint edn) "cofx")
+                         "carries the dry-run-specific opts — distinct from dispatch's hint"))
+                   (is (empty? @forms) "no eval on the missing-event path")
+                   (done)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Runtime call shape — emits `(re-frame2-pair.runtime/dispatch-dry-run

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dispatch_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dispatch_test.cljs
@@ -119,57 +119,36 @@
 (def ^:private err? tu/error?)
 
 ;; ---------------------------------------------------------------------------
-;; Rejection arms — the security gate.
+;; Narrow integration arms — the exhaustive event-parse matrix (nil / blank
+;; / unreadable / map / keyword / list / symbol / scalar / vector, with the
+;; parsed-type classification) now lives in `args_test` against the shared
+;; `args/parse-event-arg` seam (rf2-tcp7za). Here we pin only the two
+;; tool-level invariants:
+;;   1. no-eval-on-error — a bad event short-circuits to an :isError WITHOUT
+;;      contacting the runtime (host-form source never rides into the eval);
+;;   2. the DISTINCT dispatch missing-event hint.
 ;; ---------------------------------------------------------------------------
 
-(deftest rejects-arbitrary-cljs-source
-  ;; The headline case: an attacker / a prompt-injected agent supplies
-  ;; host-form source instead of an event vector. The parser reads it as
-  ;; a list, the vector-check fails, the runtime is never contacted —
-  ;; `(println :pwned)` never runs inside the runtime eval.
+(deftest rejects-arbitrary-cljs-source-without-eval
+  ;; The headline security case: an attacker / a prompt-injected agent
+  ;; supplies host-form source instead of an event vector. It reads as a
+  ;; list, the vector-check fails, and the runtime is NEVER contacted —
+  ;; `(println :pwned)` never rides into the eval. We PROVE the no-eval by
+  ;; capturing every form the tool would send and asserting none fired
+  ;; (neither the configure-raw-state! signal nor the dispatch eval).
   (async done
-    (-> (dispatch/dispatch-tool (fresh-conn) #js {:event "(println :pwned)"})
-        (.then (fn [r]
-                 (is (err? r))
-                 (let [edn (read-result-text r)]
-                   (is (= :not-an-event-vector (:reason edn)))
-                   (is (= :list (:parsed-type edn))))
-                 (done))))))
-
-(deftest rejects-bare-keyword
-  ;; `:cart/checkout` is valid EDN but not a vector — agents that
-  ;; forget the brackets get a corrective error.
-  (async done
-    (-> (dispatch/dispatch-tool (fresh-conn) #js {:event ":cart/checkout"})
-        (.then (fn [r]
-                 (is (err? r))
-                 (let [edn (read-result-text r)]
-                   (is (= :not-an-event-vector (:reason edn)))
-                   (is (= :keyword (:parsed-type edn))))
-                 (done))))))
-
-(deftest rejects-map
-  ;; A map is valid EDN but the wrong shape.
-  (async done
-    (-> (dispatch/dispatch-tool (fresh-conn) #js {:event "{:id :foo}"})
-        (.then (fn [r]
-                 (is (err? r))
-                 (let [edn (read-result-text r)]
-                   (is (= :not-an-event-vector (:reason edn)))
-                   (is (= :map (:parsed-type edn))))
-                 (done))))))
-
-(deftest rejects-unreadable-edn
-  ;; Mismatched brackets / a lone `#` / any reader failure surfaces as
-  ;; `:invalid-event-edn` so the caller can distinguish "didn't parse"
-  ;; from "wrong shape".
-  (async done
-    (-> (dispatch/dispatch-tool (fresh-conn) #js {:event "[:foo"})
-        (.then (fn [r]
-                 (is (err? r))
-                 (let [edn (read-result-text r)]
-                   (is (= :invalid-event-edn (:reason edn))))
-                 (done))))))
+    (let [captured (atom nil)]
+      (-> (with-captured-eval! captured {:ok? true}
+            (fn []
+              (dispatch/dispatch-tool (fresh-conn) #js {:event "(println :pwned)"})))
+          (.then (fn [r]
+                   (is (err? r))
+                   (let [edn (read-result-text r)]
+                     (is (= :not-an-event-vector (:reason edn)))
+                     (is (= :list (:parsed-type edn))))
+                   (is (nil? @captured)
+                       "no-eval-on-error — the runtime was never contacted; no signal / dispatch form fired")
+                   (done)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; `:timeout-ms` (the `:await-render` deadline) is validated as a
@@ -210,23 +189,27 @@
                    (is (= "timeout-ms" (:arg edn))))
                  (done))))))
 
-(deftest rejects-blank-event
+(deftest rejects-missing-event-with-dispatch-hint
+  ;; The DISTINCT-hint invariant: a missing event surfaces :missing-event
+  ;; carrying DISPATCH's own usage string (its opt set — sync / trace /
+  ;; interceptor-overrides), NOT dispatch-dry-run's. Same shared parser,
+  ;; distinct caller data. Also confirms no-eval on the missing path — the
+  ;; error returns without the runtime being contacted.
   (async done
-    (-> (dispatch/dispatch-tool (fresh-conn) #js {:event "   "})
-        (.then (fn [r]
-                 (is (err? r))
-                 (let [edn (read-result-text r)]
-                   (is (= :missing-event (:reason edn))))
-                 (done))))))
-
-(deftest rejects-missing-event
-  (async done
-    (-> (dispatch/dispatch-tool (fresh-conn) #js {})
-        (.then (fn [r]
-                 (is (err? r))
-                 (let [edn (read-result-text r)]
-                   (is (= :missing-event (:reason edn))))
-                 (done))))))
+    (let [captured (atom nil)]
+      (-> (with-captured-eval! captured {:ok? true}
+            (fn []
+              (dispatch/dispatch-tool (fresh-conn) #js {})))
+          (.then (fn [r]
+                   (is (err? r))
+                   (let [edn (read-result-text r)]
+                     (is (= :missing-event (:reason edn)))
+                     (is (str/includes? (:hint edn) "dispatch {")
+                         "the missing-event hint is dispatch's own usage string")
+                     (is (str/includes? (:hint edn) "interceptor-overrides")
+                         "carries the dispatch-specific opts — distinct from dry-run's hint"))
+                   (is (nil? @captured) "no eval on the missing-event path")
+                   (done)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Acceptance arm — the EDN vector reaches the runtime as data.

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/nrepl_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/nrepl_test.cljs
@@ -228,6 +228,31 @@
         (is (nil? (nrepl/read-port-from-fs)))))))
 
 ;; ---------------------------------------------------------------------------
+;; `read-port-file` — the single transport-owned port-file primitive
+;; (rf2-y8aszh). `server.cljs/ensure-connection!` re-reads the cached port
+;; file through THIS fn (its byte-for-byte `read-port-file*` copy was
+;; deleted). Pin the primitive's contract directly: an int for numeric
+;; content (whitespace-trimmed), nil for missing / non-numeric.
+;; ---------------------------------------------------------------------------
+
+(deftest read-port-file-parses-trims-and-fails-soft
+  (testing "the public transport primitive: int on numeric content, trimmed; nil on missing / non-numeric"
+    (with-fs-stub! nil
+      (read-returning "the/port" "  6789  \n")
+      (fn []
+        (is (= 6789 (nrepl/read-port-file "the/port"))
+            "numeric content read + trimmed to an int")))
+    (with-fs-stub! nil
+      (read-returning "the/port" "not-a-number")
+      (fn []
+        (is (nil? (nrepl/read-port-file "the/port"))
+            "non-numeric content → nil (isNaN guard), never a NaN port")))
+    (with-fs-stub! nil throwing-read
+      (fn []
+        (is (nil? (nrepl/read-port-file "gone/port"))
+            "a missing / unreadable file → nil, not a throw")))))
+
+;; ---------------------------------------------------------------------------
 ;; --port-file explicit override. The 1-arity `read-port-from-fs` takes an
 ;; explicit, cwd-independent path that wins over BOTH the env var and the
 ;; relative file-scan candidates. nil/blank ⇒ falls through to the normal


### PR DESCRIPTION
Two clustered internal-dedup refactors inside `tools/re-frame2-pair-mcp` (disjoint files). Pre-alpha stance: no back-compat shims; ELEGANCE + CLARITY + CORRECTNESS + GOOD-PRACTICE. MCP is an AI-egress surface, so the permission/privacy gates and the no-eval-on-error boundary were preserved exactly.

## rf2-tcp7za — centralize dispatch event-arg parsing

`dispatch.cljs` and `dispatch_dry_run.cljs` each carried a byte-for-byte copy of the event EDN/vector parser (trim → `read-string` → `vector?` check → parsed-type classification → failure envelopes), differing only in the missing-event usage hint; both suites duplicated the parse behaviour matrix.

- Added `tools.args/parse-event-arg` beside `read-edn-arg`, taking the caller-specific **missing-value hint as data**.
- Deleted both private `parse-event-edn` copies and their now-unused `cljs.reader` / `clojure.string` requires.
- **Position preserved**: the parse stays at its exact call-site slot, ahead of the nREPL eval and the permission/privacy gates, so invalid input still short-circuits before the runtime is contacted (the EDN-not-source security gate is unchanged).
- Moved the exhaustive PURE parse matrix (nil/blank/unreadable/map/keyword/list/symbol/scalar/vector + parsed-type + hint-independence/byte-equivalence) into `args_test`; each tool suite retains only the narrow integration assertions: the **distinct missing-event hint** and **no-eval-on-error** (a bad event fires neither the `configure-raw-state!` signal nor a dispatch form).

## rf2-y8aszh — nREPL transport owns port-file parsing

`server.cljs/read-port-file*` was a byte-for-byte copy of `nrepl.cljs/read-port-file` (fs read → trim → `parseInt` → isNaN guard); server even labelled its copy a mirror.

- Made `nrepl/read-port-file` public within the tool; deleted `server/read-port-file*`; `ensure-connection!` now calls the transport primitive for its per-tool-call cached-port re-read.
- Dropped server's now-unused `fs` require.
- **Unchanged**: same-port reuse, changed-port reconnect, vanished-file rediscovery, discovery order, and the sticky-build cache lifecycle all live in `server.cljs` as before.
- Added a focused `nrepl_test` case pinning the public primitive's contract; the port-file-stability + ensure-connection retry suites already drive it through `ensure-connection!`.

## Preflight confirmations

- **tcp7za**: confirmed the two private parsers are identical except the `:missing-event` hint — the hint is now caller-supplied data; no other caller-specific behaviour was present to preserve.
- **y8aszh**: confirmed `server/read-port-file*` is byte-identical to `nrepl/read-port-file` (both direct `fs` reads). The separate `roots_discovery/read-port-from*` was left untouched — it takes an **injected reader** (a distinct test-seam behaviour), so it is out of scope, not a duplicate to fold.

## Quality gates

- `npm run test` (server-test build → node): **1205 tests, 4095 assertions, 0 failures, 0 errors, 0 warnings** (re-run green after rebase onto latest `origin/main`).
- `npm run check:descriptors`: **OK — tool-descriptors.edn in sync (30 tools)** (no descriptor surface changed).
- Permission/privacy gate ordering and no-eval-on-error verified intact by the retained integration assertions.