### PR TITLE
refactor(scripts): one startLocalHttpServer harness owner (rf2-slapfs)

### DIFF
--- a/examples/scripts/serve-and-run-story-feature-load-tests.cjs
+++ b/examples/scripts/serve-and-run-story-feature-load-tests.cjs
@@ -17,7 +17,7 @@ const { cleanStageDirs } = require('./examples-staging.cjs');
 const {
   createHarnessCleanup,
   spawnHarnessProcess,
-  waitForHttpReady,
+  startLocalHttpServer,
 } = require('../../implementation/scripts/lib/local-browser-harness.cjs');
 
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
@@ -109,40 +109,23 @@ async function main() {
   compileAll();
   stageHtml();
 
-  // Bind 127.0.0.1 (not the http-server 0.0.0.0 default): the runner
-  // and resolveStoryFeatureLoadPort only ever touch loopback, so binding
-  // every interface is avoidable local-network surface. Matches the
-  // adapter-smoke orchestrator (serve-and-run-adapter-smokes.cjs).
-  // rf2-wf5al(2).
-  const server = cleanup.trackProcess(spawnHarnessProcess(process.execPath, [HTTP_SERVER_BIN, OUT_ROOT, '-a', '127.0.0.1', '-p', String(port), '-s', '-c-1'], {
+  // Serve implementation/out/examples on loopback. The shared harness owns
+  // the http-server spawn, teardown tracking, early-exit abort, bounded
+  // output capture (surfaced as the failure tail), and the readiness +
+  // unreachable diagnostics (rf2-slapfs). Bind 127.0.0.1 (not http-server's
+  // 0.0.0.0 default): the runner and resolveStoryFeatureLoadPort only ever
+  // touch loopback. Matches the adapter-smoke orchestrator. rf2-wf5al(2).
+  const { ready } = await startLocalHttpServer({
+    cleanup,
+    httpServerBin: HTTP_SERVER_BIN,
+    root: OUT_ROOT,
+    port,
     cwd: IMPL_ROOT,
-    stdio: ['ignore', 'pipe', 'pipe'],
-  }));
-
-  let serverDown = false;
-  const serverOutput = [];
-  const captureServerOutput = (chunk, stream) => {
-    const text = chunk.toString();
-    serverOutput.push(...text.split(/\r?\n/).filter(Boolean).map((line) => `[http-server:${stream}] ${line}`));
-    if (VERBOSE) process[stream].write(text);
-  };
-  server.stdout.on('data', (chunk) => captureServerOutput(chunk, 'stdout'));
-  server.stderr.on('data', (chunk) => captureServerOutput(chunk, 'stderr'));
-  server.on('exit', (code, signal) => {
-    serverDown = true;
-    if (code !== 0 && code !== null) {
-      console.error(`http-server exited unexpectedly (code=${code}, signal=${signal}).`);
-    }
+    readyTimeoutMs: READY_TIMEOUT_MS,
+    captureOutput: true,
+    verbose: VERBOSE,
   });
-
-  const ready = await waitForHttpReady(port, Date.now() + READY_TIMEOUT_MS, {
-    isAborted: () => serverDown,
-  });
-  if (!ready || serverDown) {
-    console.error(`http-server did not become reachable on :${port} within ${READY_TIMEOUT_MS}ms.`);
-    for (const line of serverOutput.slice(-40)) console.error(line);
-    return 1;
-  }
+  if (!ready) return 1;
 
   const runner = cleanup.trackProcess(spawnHarnessProcess(process.execPath, [RUNNER], {
     stdio: 'inherit',

--- a/examples/scripts/serve-and-run-story-play-scripts.cjs
+++ b/examples/scripts/serve-and-run-story-play-scripts.cjs
@@ -51,8 +51,7 @@ const fs = require('fs');
 const path = require('path');
 const {
   createHarnessCleanup,
-  spawnHarnessProcess,
-  waitForHttpReady,
+  startLocalHttpServer,
 } = require('../../implementation/scripts/lib/local-browser-harness.cjs');
 const { resolveStoryFeatureLoadPort } = require('./story-feature-load-port.cjs');
 const { cleanStageDirs } = require('./examples-staging.cjs');
@@ -748,60 +747,26 @@ async function main() {
   compileTestbed();
   stageTestbedHtml();
 
-  // Bind 127.0.0.1 (not the http-server 0.0.0.0 default): the runner
-  // only ever hits http://127.0.0.1:<port>, and resolveStoryFeatureLoadPort
-  // pre-flights loopback — so exposing implementation/out/examples on
-  // every interface is avoidable local-network surface. Matches the
-  // adapter-smoke orchestrator (serve-and-run-adapter-smokes.cjs).
-  // rf2-wf5al(2).
-  const server = cleanup.trackProcess(
-    spawnHarnessProcess(
-      process.execPath,
-      [httpServerBin(), OUT_ROOT, '-a', '127.0.0.1', '-p', String(port), '-s', '-c-1'],
-      {
-        cwd: IMPL_ROOT,
-        stdio: ['ignore', 'pipe', 'pipe'],
-      },
-    ),
-  );
-
-  let serverDown = false;
-  const serverOutput = [];
-  const captureServerOutput = (chunk, stream) => {
-    const text = chunk.toString();
-    serverOutput.push(
-      ...text
-        .split(/\r?\n/)
-        .filter(Boolean)
-        .map((line) => `[http-server:${stream}] ${line}`),
-    );
-    if (VERBOSE) process[stream].write(text);
-  };
-  server.stdout.on('data', (chunk) => captureServerOutput(chunk, 'stdout'));
-  server.stderr.on('data', (chunk) => captureServerOutput(chunk, 'stderr'));
-  server.on('exit', (code, signal) => {
-    serverDown = true;
-    // The server is forcefully terminated during cleanup, which makes
-    // this `exit` fire with a non-zero code after `main()` has already
-    // returned its own exit code. Suppress the noise in that path;
-    // surface real mid-run crashes loudly.
-    if (code !== 0 && code !== null && !exiting) {
-      console.error(
-        `http-server exited unexpectedly (code=${code}, signal=${signal}).`,
-      );
-    }
+  // Serve implementation/out/examples on loopback. The shared harness owns
+  // the http-server spawn, teardown tracking, early-exit abort, bounded
+  // output capture (surfaced as the failure tail), and the readiness +
+  // unreachable diagnostics (rf2-slapfs). Bind 127.0.0.1 (not http-server's
+  // 0.0.0.0 default): the runner only ever hits http://127.0.0.1:<port> and
+  // resolveStoryFeatureLoadPort pre-flights loopback. rf2-wf5al(2).
+  // `exiting` suppresses the forced-shutdown "exited unexpectedly" noise once
+  // main() has already returned its own verdict.
+  const { ready } = await startLocalHttpServer({
+    cleanup,
+    httpServerBin: httpServerBin(),
+    root: OUT_ROOT,
+    port,
+    cwd: IMPL_ROOT,
+    readyTimeoutMs: READY_TIMEOUT_MS,
+    captureOutput: true,
+    verbose: VERBOSE,
+    suppressExitDiagnostic: () => exiting,
   });
-
-  const ready = await waitForHttpReady(port, Date.now() + READY_TIMEOUT_MS, {
-    isAborted: () => serverDown,
-  });
-  if (!ready || serverDown) {
-    console.error(
-      `http-server did not become reachable on :${port} within ${READY_TIMEOUT_MS}ms.`,
-    );
-    for (const line of serverOutput.slice(-40)) console.error(line);
-    return 1;
-  }
+  if (!ready) return 1;
 
   const browser = await loadChromium().launch({ headless: true });
   cleanup.addCleanup(async () => {

--- a/examples/scripts/serve-example.cjs
+++ b/examples/scripts/serve-example.cjs
@@ -65,7 +65,7 @@ const { stageExample, listStandaloneExamples, cleanStageDirs } = require('./exam
 const {
   createHarnessCleanup,
   spawnHarnessProcess,
-  waitForHttpReady,
+  startLocalHttpServer,
 } = require('../../implementation/scripts/lib/local-browser-harness.cjs');
 
 // __dirname is <repo>/examples/scripts. REPO_ROOT is <repo>; IMPL_ROOT is
@@ -234,10 +234,11 @@ async function main() {
   }
   let watchOutcome = null;
   let serverOutcome = null;
-  // Tracks server reachability so a child crash aborts the readiness wait.
-  // Declared here (before the watch handler) so the watch-exit listener can
-  // flip it; the server-exit listener below also sets it.
-  let serverDown = false;
+  // Set true if the shadow-cljs watch dies unexpectedly, so the watch-exit
+  // handler below can abort the server readiness wait (the shared harness ORs
+  // this into its own server-exited abort). Declared before the watch handler
+  // so that listener can flip it.
+  let watchDied = false;
 
   if (watch) {
     const watchProc = cleanup.trackProcess(
@@ -255,7 +256,7 @@ async function main() {
       watchOutcome = { code, signal };
       if (!interrupted && !(typeof code === 'number' && code === 0)) {
         console.error(`shadow-cljs watch exited unexpectedly (code=${code}, signal=${signal}).`);
-        serverDown = true; // abort the readiness wait below if still pending
+        watchDied = true; // abort the server readiness wait below if still pending
         // Stop http-server too; the watch is the source of truth for a live
         // build. cleanup() is idempotent and safe to call alongside the
         // signal handlers.
@@ -264,33 +265,26 @@ async function main() {
     });
   }
 
-  // Serve the example's output dir on 127.0.0.1 (loopback-only — the dev
-  // browser hits localhost, and it sidesteps the Windows dual-stack EACCES
-  // surprise). `-c-1` disables caching so a recompiled main.js is picked up
-  // on reload.
-  const server = cleanup.trackProcess(
-    spawnHarnessProcess(
-      process.execPath,
-      [httpServerBin, entry.outDir, '-a', '127.0.0.1', '-p', String(PORT), '-s', '-c-1'],
-      { cwd: IMPL_ROOT, stdio: ['ignore', 'inherit', 'inherit'] },
-    ),
-  );
-
-  server.on('exit', (code, signal) => {
-    serverDown = true;
-    serverOutcome = { code, signal };
-    if (code !== 0 && code !== null && !interrupted) {
-      console.error(`http-server exited unexpectedly (code=${code}, signal=${signal}).`);
-    }
+  // Serve the example's output dir on loopback (127.0.0.1 — the dev browser
+  // hits localhost, which also sidesteps the Windows dual-stack EACCES
+  // surprise). The shared harness owns the http-server spawn (with `-c-1` so a
+  // recompiled main.js is picked up on reload), teardown tracking, early-exit
+  // abort, and the readiness + unreachable diagnostics (rf2-slapfs). It records
+  // the server outcome for decideRunnerExit via onExit, ORs a watch death into
+  // the readiness abort via isAborted, and suppresses the forced-shutdown
+  // "exited unexpectedly" noise while interrupted. Inherits stdio (no capture).
+  const { server, ready, isDown } = await startLocalHttpServer({
+    cleanup,
+    httpServerBin,
+    root: entry.outDir,
+    port: PORT,
+    cwd: IMPL_ROOT,
+    readyTimeoutMs: READY_TIMEOUT_MS,
+    isAborted: () => watchDied,
+    onExit: (code, signal) => { serverOutcome = { code, signal }; },
+    suppressExitDiagnostic: () => interrupted,
   });
-
-  const ready = await waitForHttpReady(PORT, Date.now() + READY_TIMEOUT_MS, {
-    isAborted: () => serverDown,
-  });
-  if (!ready || serverDown) {
-    console.error(`http-server did not become reachable on :${PORT} within ${READY_TIMEOUT_MS}ms.`);
-    return 1;
-  }
+  if (!ready) return 1;
 
   console.log(
     `\nserve-example: ${entry.build} is live at http://127.0.0.1:${PORT}/` +
@@ -303,7 +297,7 @@ async function main() {
   // process tree down). In watch mode an unexpected watch crash also tears the
   // server down (see the watch 'exit' handler), so this resolves either way.
   await new Promise((resolve) => {
-    if (serverDown) return resolve(); // already exited before we awaited
+    if (isDown()) return resolve(); // already exited before we awaited
     server.on('exit', resolve);
   });
 

--- a/implementation/adapters/scripts/serve-and-run-adapter-smokes.cjs
+++ b/implementation/adapters/scripts/serve-and-run-adapter-smokes.cjs
@@ -55,7 +55,7 @@ const { stageShared, cleanStageDirs } = require('../../../examples/scripts/examp
 const {
   createHarnessCleanup,
   spawnHarnessProcess,
-  waitForHttpReady,
+  startLocalHttpServer,
 } = require('../../scripts/lib/local-browser-harness.cjs');
 
 // Narrow filter. When set, only the ADAPTER_SMOKES entries the filter
@@ -246,29 +246,21 @@ async function main() {
   compileAll();
   stageHtml();
 
-  // Bind 127.0.0.1 (not 0.0.0.0): the Playwright specs only ever hit
-  // localhost, and the loopback-only bind sidesteps the Windows
-  // dual-stack EACCES surprise that made the old 8030 clash cryptic.
-  const server = cleanup.trackProcess(spawnHarnessProcess(process.execPath, [HTTP_SERVER_BIN, OUT_ROOT, '-a', '127.0.0.1', '-p', String(PORT), '-s', '-c-1'], {
+  // Serve out/examples on loopback (127.0.0.1, not 0.0.0.0): the Playwright
+  // specs only ever hit localhost, and the loopback-only bind sidesteps the
+  // Windows dual-stack EACCES surprise that made the old 8030 clash cryptic.
+  // The shared harness owns the http-server spawn, teardown tracking,
+  // early-exit abort, and the readiness + unreachable diagnostics
+  // (rf2-slapfs). This runner inherits the server's stdio (no capture).
+  const { ready } = await startLocalHttpServer({
+    cleanup,
+    httpServerBin: HTTP_SERVER_BIN,
+    root: OUT_ROOT,
+    port: PORT,
     cwd: IMPL_ROOT,
-    stdio: ['ignore', 'inherit', 'inherit'],
-  }));
-
-  let serverDown = false;
-  server.on('exit', (code, signal) => {
-    serverDown = true;
-    if (code !== 0 && code !== null) {
-      console.error(`http-server exited unexpectedly (code=${code}, signal=${signal}).`);
-    }
+    readyTimeoutMs: READY_TIMEOUT_MS,
   });
-
-  const ready = await waitForHttpReady(PORT, Date.now() + READY_TIMEOUT_MS, {
-    isAborted: () => serverDown,
-  });
-  if (!ready || serverDown) {
-    console.error(`http-server did not become reachable on :${PORT} within ${READY_TIMEOUT_MS}ms.`);
-    return 1;
-  }
+  if (!ready) return 1;
 
   const runner = cleanup.trackProcess(spawnHarnessProcess(process.execPath, [RUNNER], {
     stdio: 'inherit',

--- a/implementation/scripts/_local-browser-harness.test.cjs
+++ b/implementation/scripts/_local-browser-harness.test.cjs
@@ -19,6 +19,7 @@ const {
   publishOwnershipToken,
   resolveServePort,
   spawnHarnessProcess,
+  startLocalHttpServer,
   terminateProcessTree,
   waitForHttpReady,
   waitForOwnedHttpReady,
@@ -606,6 +607,207 @@ test('publishOwnershipToken remove() preserves a newer overlapping run\'s replac
     assert.equal(fs.existsSync(tokenPath), false);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// rf2-slapfs — startLocalHttpServer, the single owner of the local
+// http-server lifecycle the two Story launchers, serve-example, and the
+// adapter-smoke orchestrator used to each re-derive (spawn the loopback/
+// static/no-cache argv, track it for teardown, wire an early-exit abort +
+// bounded output capture, wait for readiness, print the canonical unreachable
+// diagnostic + captured tail on failure). These functional tests drive the
+// composition end-to-end with a FAKE http-server bin — so they exercise the
+// real argv/spawn/track/capture/abort/readiness behaviour without depending on
+// the http-server package. They are the "canonical-helper behaviour" coverage
+// that replaces the per-caller `-a 127.0.0.1` argv-regex policy checks.
+
+// A fake bin that parses the http-server-shaped argv (positional root, `-a`,
+// `-p`), binds the requested host+port, serves 200 on any path, and records
+// the FULL composed argv (once listening) so the loopback/static composition
+// can be asserted directly.
+const FAKE_HTTP_SERVER = `
+'use strict';
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const argv = process.argv.slice(2);
+const root = argv[0];
+let host = '0.0.0.0';
+let port = 0;
+for (let i = 0; i < argv.length; i++) {
+  if (argv[i] === '-a') host = argv[i + 1];
+  else if (argv[i] === '-p') port = Number(argv[i + 1]);
+}
+const server = http.createServer((_, res) => { res.writeHead(200); res.end('ok'); });
+server.listen(port, host, () => {
+  fs.writeFileSync(path.join(root, '.fake-argv.json'), JSON.stringify(argv));
+});
+`;
+
+// A fake that emits a known line synchronously (so the parent's bounded
+// capture holds it well before any verdict) then stays alive WITHOUT ever
+// listening — forcing a readiness TIMEOUT (never reachable) rather than an
+// early-exit abort.
+const FAKE_HTTP_SILENT = `
+'use strict';
+const fs = require('fs');
+fs.writeSync(2, 'fake http-server: staged output line\\n');
+setInterval(() => {}, 1000);
+`;
+
+// A fake that writes a line synchronously then exits non-zero immediately —
+// the early-exit path the readiness abort must catch fast.
+const FAKE_HTTP_CRASH = `
+'use strict';
+const fs = require('fs');
+fs.writeSync(2, 'fake http-server: refusing to bind\\n');
+process.exit(3);
+`;
+
+function mkFakeBin(source, name) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rf2-slh-'));
+  const binPath = path.join(dir, name);
+  fs.writeFileSync(binPath, source);
+  return { dir, binPath };
+}
+
+function rmTmp(dir) {
+  fs.rmSync(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+}
+
+test('startLocalHttpServer composes the canonical loopback/static argv and reaches readiness (rf2-slapfs)', async () => {
+  const { dir, binPath } = mkFakeBin(FAKE_HTTP_SERVER, 'fake-http-server.cjs');
+  const port = await findFreePort();
+  const cleanup = createHarnessCleanup({ onError: () => {} });
+  try {
+    const result = await startLocalHttpServer({
+      cleanup,
+      httpServerBin: binPath,
+      root: dir,
+      port,
+      cwd: dir,
+      readyTimeoutMs: 5000,
+      // Silence the incidental "exited unexpectedly" line the force-kill in
+      // cleanup() below emits on Windows (exit code 1) — not what this test
+      // asserts.
+      log: () => {},
+    });
+    assert.equal(result.ready, true, 'the composed server must become reachable on loopback');
+    assert.equal(result.isDown(), false, 'the server must still be running once ready');
+    // The fake recorded the EXACT argv startLocalHttpServer composed — the
+    // canonical behaviour that replaces each caller's inline argv regex:
+    // positional root, loopback `-a 127.0.0.1`, the resolved port, `-s`
+    // (silent), `-c-1` (no cache).
+    const argv = JSON.parse(fs.readFileSync(path.join(dir, '.fake-argv.json'), 'utf8'));
+    assert.deepEqual(argv, [dir, '-a', '127.0.0.1', '-p', String(port), '-s', '-c-1']);
+  } finally {
+    await cleanup.cleanup();
+    rmTmp(dir);
+  }
+});
+
+test('startLocalHttpServer tracks the server so process-tree cleanup terminates it (rf2-slapfs)', async () => {
+  const { dir, binPath } = mkFakeBin(FAKE_HTTP_SERVER, 'fake-http-server.cjs');
+  const port = await findFreePort();
+  const cleanup = createHarnessCleanup({ onError: () => {} });
+  try {
+    const { server, ready } = await startLocalHttpServer({
+      cleanup,
+      httpServerBin: binPath,
+      root: dir,
+      port,
+      cwd: dir,
+      readyTimeoutMs: 5000,
+      log: () => {}, // silence the force-kill teardown line (see above)
+    });
+    assert.equal(ready, true);
+    // The server must be a tracked child that cleanup() actually terminates —
+    // otherwise the harness would leak http-server processes between runs.
+    const exited = waitForExit(server, 30000);
+    await cleanup.cleanup();
+    await exited;
+    assert.ok(true);
+  } finally {
+    rmTmp(dir);
+  }
+});
+
+test('startLocalHttpServer times out with the unreachable diagnostic + captured failure tail (rf2-slapfs)', async () => {
+  const { dir, binPath } = mkFakeBin(FAKE_HTTP_SILENT, 'fake-http-silent.cjs');
+  const port = await findFreePort();
+  const cleanup = createHarnessCleanup({ onError: () => {} });
+  const logged = [];
+  try {
+    const { ready, isDown, output } = await startLocalHttpServer({
+      cleanup,
+      httpServerBin: binPath,
+      root: dir,
+      port,
+      cwd: dir,
+      readyTimeoutMs: 400,
+      captureOutput: true,
+      log: (m) => logged.push(m),
+    });
+    assert.equal(ready, false, 'a server that never listens must time out');
+    assert.equal(isDown(), false, 'the still-alive server did not exit — it just never served');
+    assert.ok(
+      output.some((l) => /staged output line/.test(l)),
+      `bounded capture must hold the server's output; got ${JSON.stringify(output)}`,
+    );
+    assert.ok(
+      logged.some((l) => /did not become reachable on :/.test(l)),
+      'the canonical unreachable diagnostic must be logged on timeout',
+    );
+    assert.ok(
+      logged.some((l) => /staged output line/.test(l)),
+      'the captured failure tail must be printed via the log sink',
+    );
+  } finally {
+    await cleanup.cleanup();
+    rmTmp(dir);
+  }
+});
+
+test('startLocalHttpServer aborts fast on an early server exit rather than burning the timeout (rf2-slapfs)', async () => {
+  const { dir, binPath } = mkFakeBin(FAKE_HTTP_CRASH, 'fake-http-crash.cjs');
+  const port = await findFreePort();
+  const cleanup = createHarnessCleanup({ onError: () => {} });
+  const logged = [];
+  let exitCode = null;
+  const started = Date.now();
+  try {
+    const { ready, isDown } = await startLocalHttpServer({
+      cleanup,
+      httpServerBin: binPath,
+      root: dir,
+      port,
+      cwd: dir,
+      readyTimeoutMs: 15000, // generous — the abort must beat this, not wait it out
+      // Capture (rather than inherit) the fake's stderr so its "refusing to
+      // bind" line doesn't leak into the test output; this test asserts the
+      // abort/onExit/diagnostic behaviour, not the captured tail.
+      captureOutput: true,
+      log: (m) => logged.push(m),
+      onExit: (code) => { exitCode = code; },
+    });
+    assert.equal(ready, false, 'a server that exits before readiness must not report ready');
+    assert.equal(isDown(), true, 'isDown() must reflect the exited server');
+    assert.ok(
+      Date.now() - started < 10000,
+      'the early-exit abort must not wait out the 15s readiness budget',
+    );
+    assert.equal(exitCode, 3, 'onExit must receive the server exit code');
+    assert.ok(
+      logged.some((l) => /exited unexpectedly \(code=3/.test(l)),
+      `the non-zero exit must be surfaced; got ${JSON.stringify(logged)}`,
+    );
+    assert.ok(
+      logged.some((l) => /did not become reachable on :/.test(l)),
+      'the unreachable diagnostic must still be logged on the abort path',
+    );
+  } finally {
+    cleanup.cleanupSync();
+    rmTmp(dir);
   }
 });
 

--- a/implementation/scripts/_orchestrator-teardown-policy.test.cjs
+++ b/implementation/scripts/_orchestrator-teardown-policy.test.cjs
@@ -29,7 +29,10 @@
  *     process-group kill on Mac/Linux — see the lib).
  * Every spawning orchestrator must (a) import createHarnessCleanup, (b)
  * call installSignalHandlers(), and (c) spawn its long-lived child through
- * `trackProcess(spawnHarnessProcess(...))` so it is reaped on exit/signal.
+ * `trackProcess(spawnHarnessProcess(...))` — OR, for its http-server
+ * specifically, through the shared `startLocalHttpServer(...)` owner
+ * (rf2-slapfs), which performs that tracked spawn internally against the
+ * cleanup handle you pass it — so the child is reaped on exit/signal.
  *
  * SHORT-LIVED, SELF-EXITING COMPILE STEPS ARE FINE. Most orchestrators run
  * a blocking `spawnSync(process.execPath, [shadow-cljs-runner, 'compile',
@@ -101,6 +104,13 @@ const TRACK_PROCESS_RE = /\.trackProcess\(/;
 // harness primitive: `trackProcess(spawnHarnessProcess(...))`. Whitespace/
 // newlines between the call and its argument are tolerated.
 const TRACKED_SPAWN_RE = /trackProcess\(\s*spawnHarnessProcess\(/;
+// rf2-slapfs — starting the http-server via the shared startLocalHttpServer
+// owner is the tracked-long-lived-spawn posture too: it does
+// `cleanup.trackProcess(spawnHarnessProcess(...))` internally against the
+// cleanup handle the caller passes (functionally covered in
+// _local-browser-harness.test.cjs), so a caller that delegates to it still
+// reaps its server on exit/signal without an inline trackProcess.
+const START_LOCAL_HTTP_SERVER_RE = /\bstartLocalHttpServer\s*\(/;
 const SPAWNSYNC_RE = /\bspawnSync\s*\(/;
 
 const ORCHESTRATORS = orchestratorFiles();
@@ -145,26 +155,27 @@ for (const file of ORCHESTRATORS) {
     );
   });
 
-  test(`${base}: tracks the spawned child for teardown (rf2-c3hffe)`, () => {
-    assert.match(
-      code,
-      TRACK_PROCESS_RE,
-      `${base} must register its spawned child via cleanup.trackProcess(...) ` +
-        `so the teardown sweep can tree-kill it. A spawn that is not tracked ` +
-        `is not reaped (rf2-c3hffe).`,
+  test(`${base}: tracks its long-lived child for teardown (rf2-c3hffe)`, () => {
+    assert.ok(
+      TRACK_PROCESS_RE.test(code) || START_LOCAL_HTTP_SERVER_RE.test(code),
+      `${base} must register its long-lived child for teardown — either via ` +
+        `cleanup.trackProcess(...) directly, or by starting its http-server ` +
+        `through the shared startLocalHttpServer(...) owner, which tracks the ` +
+        `server in the cleanup handle you pass it (rf2-slapfs). A spawn that ` +
+        `is not tracked is not reaped (rf2-c3hffe).`,
     );
   });
 
   test(`${base}: spawns its long-lived child via the tracked shared harness (rf2-c3hffe)`, () => {
-    assert.match(
-      code,
-      TRACKED_SPAWN_RE,
+    assert.ok(
+      TRACKED_SPAWN_RE.test(code) || START_LOCAL_HTTP_SERVER_RE.test(code),
       `${base} must spawn its long-lived child (http-server / shadow-cljs ` +
-        `watch / inner orchestrator) via ` +
-        `trackProcess(spawnHarnessProcess(...)) — that is the only spawn ` +
-        `posture the teardown sweep reaps cross-platform. A short-lived, ` +
-        `self-exiting shadow-cljs compile via spawnSync is fine and is NOT ` +
-        `what this checks (rf2-c3hffe).`,
+        `watch / inner orchestrator) via trackProcess(spawnHarnessProcess(...)) ` +
+        `— or, for the http-server specifically, via the shared ` +
+        `startLocalHttpServer(...) owner, which performs that tracked spawn ` +
+        `internally (rf2-slapfs). That is the only spawn posture the teardown ` +
+        `sweep reaps cross-platform. A short-lived, self-exiting shadow-cljs ` +
+        `compile via spawnSync is fine and is NOT what this checks (rf2-c3hffe).`,
     );
   });
 }

--- a/implementation/scripts/_script-spawn-policy.test.cjs
+++ b/implementation/scripts/_script-spawn-policy.test.cjs
@@ -247,20 +247,20 @@ for (const [base, dir] of GATE_LAUNCHERS) {
 // window) by the `'-a', '127.0.0.1'` pair. NB `[\s\S]{0,80}?` not `[^]`
 // (the JS-regex `[^]`-any-char gotcha).
 const LOOPBACK_BIND_RE = loopbackBindRe('HTTP_SERVER_BIN');
-// [base, dir] pairs — most launchers live under implementation/scripts/, but
-// the adapter-smoke orchestrator moved to implementation/adapters/scripts/.
-// It is the very exemplar every failure message here points authors to
-// ("Match serve-and-run-adapter-smokes.cjs") yet it was itself UNGUARDED
-// (rf2-vwydab): it serves the compiled adapter bundle on loopback only
-// (readiness probe + headless browser both hit 127.0.0.1), so a future edit
-// dropping its explicit `-a 127.0.0.1` would silently re-expose the bundle
-// on 0.0.0.0 and trip no test. Guard it alongside the others, reading from
-// ADAPTERS_SCRIPTS_DIR.
+// [base, dir] — the ownership-token-handshake launchers that still compose the
+// http-server argv inline (they publish + verify a per-run /.rf-harness-token
+// via waitForOwnedHttpReady, a handshake startLocalHttpServer does not yet
+// own). Each serves its bundle on loopback only (readiness probe + headless
+// browser both hit 127.0.0.1), so a future edit dropping the explicit
+// `-a 127.0.0.1` would silently re-expose the bundle on 0.0.0.0 and trip no
+// test. The tokenless four (the two Story launchers, serve-example, the
+// adapter-smoke orchestrator) NO LONGER appear here: they delegate the
+// loopback bind to startLocalHttpServer and are pinned by the
+// startLocalHttpServer caller-use guard below (rf2-slapfs).
 const IMPL_LOOPBACK_LAUNCHERS = [
   ['serve-and-run-browser-tests.cjs', SCRIPTS_DIR],
   ['check-story-static.cjs', SCRIPTS_DIR],
   ['serve-and-run-xray-feature-gate.cjs', SCRIPTS_DIR],
-  ['serve-and-run-adapter-smokes.cjs', ADAPTERS_SCRIPTS_DIR],
 ];
 for (const [base, dir] of IMPL_LOOPBACK_LAUNCHERS) {
   test(`${base}: http-server is bound to 127.0.0.1 explicitly (rf2-utvst)`, () => {
@@ -270,8 +270,44 @@ for (const [base, dir] of IMPL_LOOPBACK_LAUNCHERS) {
       LOOPBACK_BIND_RE,
       `${base} must spawn http-server with '-a', '127.0.0.1' (loopback only) — ` +
         `http-server's default is 0.0.0.0, and this launcher only ever serves ` +
-        `127.0.0.1 (readiness probe + headless browser). Match ` +
-        `serve-and-run-adapter-smokes.cjs.`,
+        `127.0.0.1 (readiness probe + headless browser). The canonical loopback ` +
+        `bind now lives in startLocalHttpServer (local-browser-harness.cjs).`,
+    );
+  });
+}
+
+// rf2-slapfs — startLocalHttpServer consolidation guard. The four launchers
+// that serve a local static tree behind a PLAIN (tokenless) readiness
+// handshake — the two Story launchers, serve-example, and the adapter-smoke
+// orchestrator — now delegate their http-server spawn / teardown-track /
+// early-exit-abort / readiness composition to the single startLocalHttpServer
+// owner in local-browser-harness.cjs (whose loopback `-a 127.0.0.1` bind +
+// static/no-cache flags are verified functionally in
+// _local-browser-harness.test.cjs). Pin the two that live under a dir this
+// suite already scans; the two Story launchers are pinned in
+// _story-script-runners-policy.test.cjs. A launcher re-inlining a bespoke
+// http-server spawn — the composition drift rf2-slapfs removed — trips here.
+// (Scanned over stripped source so a comment naming the helper is not a false
+// positive.)
+const START_LOCAL_HTTP_SERVER_CALLERS = [
+  ['serve-and-run-adapter-smokes.cjs', ADAPTERS_SCRIPTS_DIR],
+  ['serve-example.cjs', EXAMPLES_SCRIPTS_DIR],
+];
+const HARNESS_IMPORT_RE = /require\(\s*['"][^'"]*local-browser-harness\.cjs['"]\s*\)/;
+const START_LOCAL_HTTP_SERVER_RE = /\bstartLocalHttpServer\s*\(/;
+for (const [base, dir] of START_LOCAL_HTTP_SERVER_CALLERS) {
+  test(`${base}: delegates http-server startup to the shared startLocalHttpServer owner (rf2-slapfs)`, () => {
+    const code = stripComments(fs.readFileSync(path.join(dir, base), 'utf8'));
+    assert.match(
+      code,
+      HARNESS_IMPORT_RE,
+      `${base} must require local-browser-harness.cjs (the startLocalHttpServer owner).`,
+    );
+    assert.match(
+      code,
+      START_LOCAL_HTTP_SERVER_RE,
+      `${base} must start its http-server via the shared startLocalHttpServer(...) ` +
+        `owner rather than re-inlining a bespoke http-server spawn (rf2-slapfs).`,
     );
   });
 }

--- a/implementation/scripts/_story-script-runners-policy.test.cjs
+++ b/implementation/scripts/_story-script-runners-policy.test.cjs
@@ -38,8 +38,9 @@
 const assert = require('assert/strict');
 const fs = require('fs');
 const path = require('path');
-// Shared loopbackBindRe factory + framework-free test harness (rf2-j552l2).
-const { loopbackBindRe, createPolicyTestSuite } = require('./_policy-test-util.cjs');
+// Shared stripComments (EXECUTABLE-source-only matching) + framework-free
+// test harness (rf2-j552l2).
+const { stripComments, createPolicyTestSuite } = require('./_policy-test-util.cjs');
 
 const SCRIPTS_DIR = path.resolve(__dirname, '..', '..', 'examples', 'scripts');
 const PLAY_SCRIPTS_RUNNER = path.join(
@@ -118,26 +119,38 @@ test('play-scripts runner verdict is computed from BOTH failures and pageErrors 
   );
 });
 
-// ---- Finding 2: both Story orchestrators bind loopback explicitly ----
-
-// Match the http-server spawn argument array and assert it carries the
-// `-a 127.0.0.1` loopback flag adjacent to the http-server bin token
-// (the play-scripts runner resolves it lazily via httpServerBin(); the
-// feature-load runner uses the HTTP_SERVER_BIN constant — accept both).
-// NB `[\s\S]{0,80}?` (not `[^]]`): the latter is the JS-regex gotcha
-// `[^]` (any char) followed by a literal `]`, which would NOT match here.
-const LOOPBACK_BIND_RE = loopbackBindRe('(?:httpServerBin\\(\\)|HTTP_SERVER_BIN)');
+// ---- Finding 2: both Story launchers delegate server startup to the
+// shared startLocalHttpServer harness owner (rf2-wf5al.2 / rf2-slapfs) ----
+//
+// The `-a 127.0.0.1` loopback bind (never http-server's 0.0.0.0 default) plus
+// the static/no-cache flags are now composed EXACTLY ONCE, in
+// local-browser-harness.cjs's startLocalHttpServer, and verified functionally
+// (a fake bin binds per the composed argv and is reachable only on loopback)
+// in _local-browser-harness.test.cjs. Rather than re-scan each launcher's
+// inlined argv, pin that each Story launcher CONSUMES that owner: it must
+// import the shared harness and call startLocalHttpServer(...). A launcher
+// that re-inlines a bespoke http-server spawn — the exact composition drift
+// rf2-slapfs removed — no longer routes through the loopback-binding owner
+// and trips here. (Scanned over stripped source so a comment mentioning the
+// helper is not a false positive.)
+const SHARED_HARNESS_IMPORT_RE = /require\(\s*['"][^'"]*local-browser-harness\.cjs['"]\s*\)/;
+const START_LOCAL_HTTP_SERVER_RE = /\bstartLocalHttpServer\s*\(/;
 
 for (const runner of [PLAY_SCRIPTS_RUNNER, FEATURE_LOAD_RUNNER]) {
   const base = path.basename(runner);
-  test(`${base}: http-server is bound to 127.0.0.1 explicitly (rf2-wf5al.2)`, () => {
-    const src = fs.readFileSync(runner, 'utf8');
+  test(`${base}: delegates http-server startup to the shared startLocalHttpServer owner (rf2-wf5al.2 / rf2-slapfs)`, () => {
+    const code = stripComments(fs.readFileSync(runner, 'utf8'));
     assert.match(
-      src,
-      LOOPBACK_BIND_RE,
-      `${base} must spawn http-server with '-a', '127.0.0.1' (loopback only) — ` +
-        `the http-server default is 0.0.0.0, and the runner only ever hits ` +
-        `127.0.0.1. Match serve-and-run-adapter-smokes.cjs.`,
+      code,
+      SHARED_HARNESS_IMPORT_RE,
+      `${base} must require local-browser-harness.cjs (the startLocalHttpServer owner).`,
+    );
+    assert.match(
+      code,
+      START_LOCAL_HTTP_SERVER_RE,
+      `${base} must start its http-server via the shared startLocalHttpServer(...) ` +
+        `owner — which composes the loopback '-a 127.0.0.1' bind + static/no-cache ` +
+        `flags once — rather than re-inlining a bespoke http-server spawn.`,
     );
   });
 }

--- a/implementation/scripts/lib/local-browser-harness.cjs
+++ b/implementation/scripts/lib/local-browser-harness.cjs
@@ -480,6 +480,147 @@ function createHarnessCleanup(opts = {}) {
   };
 }
 
+// Compose the canonical local-http-server lifecycle every browser-gate
+// launcher needs (rf2-slapfs). Before this, the two Story launchers,
+// serve-example, and the adapter-smoke orchestrator EACH re-derived the
+// identical sequence — spawn `http-server` shell-free under process.execPath
+// with the loopback/static/no-cache argv, track it for teardown, wire an
+// early-exit abort flag + the "exited unexpectedly" diagnostic, optionally
+// capture a bounded output tail, wait for readiness, and print the canonical
+// unreachable diagnostic (plus the captured tail) on failure. This owns that
+// composition on top of the spawn/readiness/cleanup primitives above; each
+// caller keeps only its command-specific compile/staging/runner/watch and
+// post-readiness work.
+//
+// The argv is fixed policy: `-a <host>` (loopback by default, NOT
+// http-server's 0.0.0.0), `-p <port>`, `-s` (silent), `-c-1` (no cache) —
+// so a recompiled bundle is never served stale and the run's assets aren't
+// exposed on non-loopback interfaces. The host stays a parameter only so a
+// caller could serve elsewhere; every current caller uses the 127.0.0.1
+// default.
+//
+// Options:
+//   - cleanup    (required) — a createHarnessCleanup() handle; the spawned
+//                 server is registered via cleanup.trackProcess for
+//                 process-tree teardown.
+//   - httpServerBin (required) — the resolved http-server bin path. Callers
+//                 resolve it themselves (usually lazily) so this module never
+//                 hard-depends on the http-server package being installed.
+//   - root       (required) — the directory to serve.
+//   - port       (required) — the resolved, already-free port to bind.
+//   - host       — bind address (default '127.0.0.1').
+//   - cwd        — spawn cwd (where node_modules / http-server resolves).
+//   - execPath   — node binary to run http-server under (default
+//                 process.execPath, shell-free).
+//   - readyTimeoutMs — readiness budget (default 30000).
+//   - captureOutput — when true, pipe stdout/stderr and retain a bounded
+//                 line buffer surfaced as the failure tail (the Story
+//                 posture). When false (default), inherit the parent stdio
+//                 (the adapter-smoke / serve-example posture); `output` stays
+//                 empty and no tail prints.
+//   - verbose    — with captureOutput, also stream the server's output live.
+//   - isAborted  — an EXTRA abort predicate, OR'd with the internal
+//                 server-exited flag, so a caller whose OTHER child (e.g.
+//                 serve-example's shadow-cljs watch) can invalidate the run
+//                 aborts the readiness wait too.
+//   - onExit     — (code, signal) callback invoked on the server's exit, for
+//                 a caller that records the outcome for its own verdict (e.g.
+//                 serve-example's decideRunnerExit).
+//   - suppressExitDiagnostic — predicate; when it returns true the
+//                 "exited unexpectedly" line is suppressed (e.g. once the
+//                 caller is already tearing down / was interrupted, so the
+//                 forced-shutdown exit isn't reported as a crash).
+//   - log        — sink for the readiness/exit diagnostics (default
+//                 console.error, matching every caller's current output).
+//   - failureTailLines — how many trailing captured lines to print on a
+//                 readiness failure (default 40).
+//
+// Returns { server, ready, output, isDown }:
+//   - server  — the tracked ChildProcess (for the caller's own waits).
+//   - ready   — true once reachable; false on early-exit/timeout (the caller
+//               returns its non-zero verdict; the canonical diagnostics have
+//               already been printed).
+//   - output  — the captured line buffer (empty unless captureOutput).
+//   - isDown  — () => boolean; the live server-exited flag.
+async function startLocalHttpServer(opts = {}) {
+  const {
+    cleanup,
+    httpServerBin,
+    root,
+    port,
+    host = '127.0.0.1',
+    cwd,
+    execPath = process.execPath,
+    readyTimeoutMs = 30000,
+    captureOutput = false,
+    verbose = false,
+    isAborted,
+    onExit,
+    suppressExitDiagnostic = () => false,
+    log = (msg) => console.error(msg),
+    failureTailLines = 40,
+  } = opts;
+
+  const args = [
+    httpServerBin,
+    root,
+    '-a',
+    host,
+    '-p',
+    String(port),
+    '-s',
+    '-c-1',
+  ];
+  const stdio = captureOutput
+    ? ['ignore', 'pipe', 'pipe']
+    : ['ignore', 'inherit', 'inherit'];
+  const server = cleanup.trackProcess(
+    spawnHarnessProcess(execPath, args, { cwd, stdio }),
+  );
+
+  const output = [];
+  if (captureOutput) {
+    const capture = (chunk, stream) => {
+      const text = chunk.toString();
+      for (const line of text.split(/\r?\n/)) {
+        if (line) output.push(`[http-server:${stream}] ${line}`);
+      }
+      if (verbose) process[stream].write(text);
+    };
+    server.stdout.on('data', (chunk) => capture(chunk, 'stdout'));
+    server.stderr.on('data', (chunk) => capture(chunk, 'stderr'));
+  }
+
+  let down = false;
+  server.on('exit', (code, signal) => {
+    down = true;
+    if (typeof onExit === 'function') onExit(code, signal);
+    // The server is force-terminated during normal teardown, which fires
+    // this exit with a non-zero/null code AFTER the run has finished. A
+    // caller that is already exiting suppresses the noise via
+    // suppressExitDiagnostic; a genuine mid-run crash is surfaced loudly.
+    if (code !== 0 && code !== null && !suppressExitDiagnostic()) {
+      log(`http-server exited unexpectedly (code=${code}, signal=${signal}).`);
+    }
+  });
+
+  const isDown = () => down;
+  const aborted = () =>
+    down || (typeof isAborted === 'function' && isAborted());
+
+  const ready = await waitForHttpReady(port, Date.now() + readyTimeoutMs, {
+    isAborted: aborted,
+  });
+  if (!ready || aborted()) {
+    log(
+      `http-server did not become reachable on :${port} within ${readyTimeoutMs}ms.`,
+    );
+    for (const line of output.slice(-failureTailLines)) log(line);
+    return { server, ready: false, output, isDown };
+  }
+  return { server, ready: true, output, isDown };
+}
+
 module.exports = {
   TOKEN_FILE_BASENAME,
   createHarnessCleanup,
@@ -493,6 +634,7 @@ module.exports = {
   resolveServePort,
   sleep,
   spawnHarnessProcess,
+  startLocalHttpServer,
   terminateProcessTree,
   terminateProcessTreeSync,
   waitForHttpReady,


### PR DESCRIPTION
## What

Give local HTTP-server startup a single harness owner. The two Story launchers
(`serve-and-run-story-play-scripts.cjs`, `serve-and-run-story-feature-load-tests.cjs`),
`serve-example.cjs`, and the adapter-smoke orchestrator
(`serve-and-run-adapter-smokes.cjs`) each independently re-derived the same
local http-server lifecycle — shell-free spawn under `process.execPath` with
the loopback/static/no-cache argv (`-a 127.0.0.1 -p <port> -s -c-1`), teardown
tracking, early-exit abort + `exited unexpectedly` diagnostic, readiness wait,
and unreachable-timeout verdict (with the two Story copies also duplicating
bounded output capture + the `serverOutput.slice(-40)` failure tail).

`local-browser-harness.cjs` already owned the spawn/readiness/cleanup
primitives but not this composition. This adds **`startLocalHttpServer`** as the
single owner and migrates the four callers to it. Command-specific
compile/staging/runner/watch and diagnostics stay local:
- `serve-example` records the server outcome for `decideRunnerExit` (`onExit`)
  and ORs a shadow-cljs-watch death into the readiness abort (`isAborted`);
- `play-scripts` / `serve-example` suppress forced-shutdown noise
  (`suppressExitDiagnostic`); `adapter-smokes` / `feature-load` keep their
  prior un-suppressed exit line (unchanged behaviour).

Behaviour preserved: roots, ports, verbosity, exit codes, and the Story
failure-tail output are unchanged; early exit / readiness timeout stay
non-zero. The per-caller `-a 127.0.0.1` argv-regex policy is replaced by the
canonical-helper **behaviour** test plus **caller-use** checks in the
spawn/story-runner/teardown policy gates.

Net: **+527 / -189** across the harness + 4 callers + 4 unit/policy tests.

## Preflight confirmation

Confirmed the premise before editing: all four callers independently compose
the identical argv `[httpServerBin, root, '-a','127.0.0.1', '-p',String(port),
'-s','-c-1']` via `spawnHarnessProcess`, wrap it in `cleanup.trackProcess`,
wire a `serverDown` flag + `server.on('exit')` diagnostic, `waitForHttpReady(…,
{isAborted})`, and `return 1` on `!ready || serverDown`; the two Story copies
also duplicate the bounded capture + `slice(-40)` failure tail. The harness
owned the primitives but not the composition. (Three OTHER launchers —
browser-tests, check-story-static, xray-feature-gate — also compose the argv
but via the ownership-token handshake `waitForOwnedHttpReady` +
`publishOwnershipToken`; those are out of scope per the bead's explicit four,
and their inline loopback-bind policy checks are retained.)

## Quality gates (foreground, 0 failures)

- `npm run test:script-helpers` — green; `local-browser-harness tests: 34 passed`
  (+4 new functional tests: canonical argv/loopback bind, process-tree cleanup,
  readiness-timeout + captured failure tail, fast early-exit abort).
- `npm run test:script-policy` — green; `story-script-runners-policy 17`,
  `script-spawn-policy 120`, `orchestrator-teardown-policy 26`,
  `examples-staging all`, `serve-and-run-cli 5`.
- `npm run test:adapter-smokes` (launcher smoke) — `Ran 3 adapter-smoke specs.
  0 failures.`, process exit code **0**. Exercises the migrated
  `startLocalHttpServer` startup end-to-end (compile → stage → serve →
  readiness → Playwright).

## Stance

Pre-alpha, no back-compat shims; ELEGANCE + CLARITY + CORRECTNESS +
GOOD-PRACTICE. Scope held to `local-browser-harness.cjs` + the four caller
scripts + their unit/policy tests; `tools/story` src untouched.