### PR TITLE
refactor(ssr): single-source ring envelope + compose flows-integration from canonical fixture (rf2-od9fet, rf2-kufxxe)

### DIFF
--- a/implementation/ssr-ring/src/re_frame/ssr/ring/shell.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/shell.clj
@@ -72,6 +72,107 @@
        (html/escape-edn-script-body payload-edn)
        "</script>"))
 
+;; ---- single-source document envelope (prefix + suffix) --------------------
+;;
+;; rf2-od9fet — the doctype / `<html>` / `<head>` / open-`<body>` /
+;; open-`#app-div` PREFIX and the bootstrap-`<script>` / `:body-end` /
+;; document-close SUFFIX are each assembled in EXACTLY ONE place here.
+;; Both the non-streaming `default-html-shell` (which sandwiches
+;; body-html + `</div>` + the shared `payload-script-tag` between them)
+;; and the streaming delegates (`re-frame.ssr.ring.streaming`'s
+;; `default-streaming-prefix` / `default-streaming-suffix`, which flush
+;; the two halves around the resolved-continuation chunks) compose these
+;; renderers, so the two response modes CANNOT drift on the doctype,
+;; `<html>`/`<body>` attribute bags, charset, head fragment, head-hash
+;; marker, `#app` id/escaping, bootstrap script, or closing tags. That
+;; matters because the envelope carries security-load-bearing escaping
+;; (the `escape-attr` attribute-value split, rf2-7x0qk) — a fix or shape
+;; change made in one mode would previously have to be mirrored by hand
+;; in the other.
+
+(defn document-prefix
+  "Render the document PREFIX shared by the non-streaming shell and the
+  streaming prefix (rf2-od9fet): `<!DOCTYPE html>` through the OPEN
+  `<div id=\"…\">` app-root element, inclusive.
+
+  `render-hash` is an EXPLICIT argument (not read from `opts`) because it
+  is the one piece the two modes disagree on: the non-streaming
+  `default-html-shell` passes `nil` (its `#app` root carries no
+  `data-rf-render-hash` — the marker is a streaming-only wire signal),
+  while the streaming prefix passes its body-only structural hash when
+  `:emit-hash?` is set, stamping `data-rf-render-hash` on the streamed
+  root. When `render-hash` is nil the attribute is omitted entirely (no
+  value needs no escaping — the hash is an 8-char hex FNV output).
+
+  `head-html` is the resolved `<head>` fragment (a content position,
+  injected raw). `opts` carries the `:html-attrs` / `:body-attrs` bags
+  (stamped via the shared `attr-string` serialiser), the `:lang`
+  fallback (resolved through `html-attr-bag`), the `:app-element-id`
+  (an attribute-value position, `escape-attr`'d per the rf2-7x0qk split),
+  and the optional `:head-hash` (the SEPARATE client-reconstructible
+  head-model hash stamped as `data-rf-head-hash` on `<head>`, omitted
+  when nil)."
+  [head-html render-hash
+   {:keys [html-attrs body-attrs lang app-element-id head-hash]
+    :or   {app-element-id "app"
+           lang           "en"}}]
+  (let [attr-bag (html-attr-bag html-attrs lang)]
+    (str "<!DOCTYPE html>"
+         "<html" (html/attr-string attr-bag) ">"
+         "<head"
+         ;; rf2-1oxjxk — the SEPARATE client-reconstructible head-model
+         ;; hash, distinct from the body's data-rf-render-hash on #app.
+         ;; Omitted when nil (no value needs no escaping — an 8-char hex
+         ;; FNV output, same shape as the render-hash marker).
+         (when head-hash (str " data-rf-head-hash=\"" head-hash "\""))
+         ">"
+         "<meta charset=\"utf-8\">"
+         (or head-html "")
+         "</head>"
+         "<body" (html/attr-string body-attrs) ">"
+         ;; rf2-7x0qk — `:app-element-id` lands INSIDE a double-quoted
+         ;; attribute value, so it is escaped through `html/escape-attr`
+         ;; (escapes `&` + `"`, lossless + position-correct). The
+         ;; trusted-string raw-injection contract applies only to the two
+         ;; CONTENT-position opts (`:head` / `:body-end`); an
+         ;; attribute-value position has a single correct escape, so even
+         ;; a benign quote-bearing value can't break out of the attribute.
+         ;; See `validate-trusted-shell-opts!` for the split.
+         "<div id=\"" (html/escape-attr app-element-id) "\""
+         ;; rf2-1oxjxk — the body-only structural `data-rf-render-hash`
+         ;; marker. Non-streaming passes nil (no marker on #app);
+         ;; streaming passes it when `:emit-hash?` is set. An 8-char hex
+         ;; FNV output, so it needs no escaping.
+         (when render-hash
+           (str " data-rf-render-hash=\"" render-hash "\""))
+         ">")))
+
+(defn document-suffix
+  "Render the document SUFFIX shared by the non-streaming shell and the
+  streaming suffix (rf2-od9fet): the bootstrap `<script src=…>` (when a
+  `:script-src` is in play), the raw `:body-end` content hook, and the
+  `</body></html>` document close.
+
+  The app-root `</div>` and the hydration-payload `<script>` are NOT
+  emitted here — they sit BEFORE the suffix (the non-streaming shell
+  writes `</div>` + `payload-script-tag` between the prefix and this
+  suffix; the streaming writer closes `</div>` at the end of the shell
+  chunk and streams the `__rf_payload` after the continuations,
+  rf2-z9dduj). `:script-src` is an attribute-value position, escaped
+  through `html/escape-attr` (the same rf2-7x0qk split as
+  `:app-element-id` in the prefix); `:body-end` stays raw (content
+  position)."
+  [{:keys [body-end script-src]
+    :or   {script-src "/main.js"}}]
+  (str (when script-src
+         ;; rf2-7x0qk — `:script-src` is an attribute-value position;
+         ;; escape through `html/escape-attr` (same split as the prefix's
+         ;; `:app-element-id`). `:body-end` stays raw (content position).
+         (str "<script src=\"" (html/escape-attr script-src) "\"></script>"))
+       (or body-end "")
+       "</body>"
+       "</html>"))
+
 (defn default-html-shell
   "The default HTML envelope. Returns a string wrapping the rendered
   body in a minimal-but-runnable document. Override via `:html-shell`
@@ -143,39 +244,16 @@
   `:rf.error/ssr-trusted-shell-opt-invalid`); the content trust
   itself is the caller's. Audit rf2-asmj1 R12 / cluster rf2-sljs1 /
   rf2-o6ndb."
-  [body-html payload-edn
-   {:keys [head html-attrs body-attrs body-end script-src app-element-id lang head-hash]
-    :or   {app-element-id  "app"
-           script-src      "/main.js"
-           lang            "en"}}]
-  (let [attr-bag (html-attr-bag html-attrs lang)]
-    (str "<!DOCTYPE html>"
-         "<html" (html/attr-string attr-bag) ">"
-         "<head"
-         ;; rf2-1oxjxk — the SEPARATE client-reconstructible head-model
-         ;; hash, distinct from the body's data-rf-render-hash on #app.
-         ;; Omitted when nil (no value needs no escaping — an 8-char hex
-         ;; FNV output, same shape as the render-hash marker).
-         (when head-hash (str " data-rf-head-hash=\"" head-hash "\""))
-         ">"
-         "<meta charset=\"utf-8\">"
-         (or head "")
-         "</head>"
-         "<body" (html/attr-string body-attrs) ">"
-         ;; rf2-7x0qk — `:app-element-id` and `:script-src` land INSIDE
-         ;; double-quoted attribute values, so they are escaped through
-         ;; `html/escape-attr` (escapes `&` + `"`, lossless + position-
-         ;; correct). The trusted-string raw-injection contract applies
-         ;; only to the two CONTENT-position opts (`:head` / `:body-end`);
-         ;; an attribute-value position has a single correct escape, so
-         ;; even a benign quote-bearing value can't break out of the
-         ;; attribute. See `validate-trusted-shell-opts!` for the split.
-         "<div id=\"" (html/escape-attr app-element-id) "\">" body-html "</div>"
-         ;; Shared id-pinned, `</script>`-escaped payload <script>
-         ;; (rf2-7ksyr) — same helper the streaming final chunk uses.
-         (payload-script-tag payload-edn)
-         (when script-src
-           (str "<script src=\"" (html/escape-attr script-src) "\"></script>"))
-         (or body-end "")
-         "</body>"
-         "</html>")))
+  [body-html payload-edn {:keys [head] :as opts}]
+  ;; rf2-od9fet — composed from the single-source `document-prefix` /
+  ;; `document-suffix` renderers (shared verbatim with the streaming
+  ;; delegates). The non-streaming `#app` root carries NO
+  ;; `data-rf-render-hash` marker, so `render-hash` is nil here; the
+  ;; body, its closing `</div>`, and the shared id-pinned,
+  ;; `</script>`-escaped `payload-script-tag` (rf2-7ksyr — same helper the
+  ;; streaming final chunk uses) sit between the prefix and the suffix.
+  (str (document-prefix head nil opts)
+       body-html
+       "</div>"
+       (payload-script-tag payload-edn)
+       (document-suffix opts)))

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
@@ -48,7 +48,6 @@
   (:require [re-frame.core :as rf]
             [re-frame.interop :as interop]
             [re-frame.ssr :as ssr]
-            [re-frame.ssr.html-helpers :as html]
             [re-frame.ssr.ring.lifecycle :as lifecycle]
             [re-frame.ssr.ring.pipeline :as pipeline]
             [re-frame.ssr.ring.shell :as shell]
@@ -94,28 +93,17 @@
   host/tool can verify the streamed root against the payload. `:head-hash`
   (optional) is the SEPARATE client-reconstructible head-model hash,
   stamped as `data-rf-head-hash` on `<head>` — omitted when nil."
-  [head-html {:keys [html-attrs body-attrs lang app-element-id render-hash head-hash]
-              :or   {lang "en" app-element-id "app"}}]
-  (let [attr-bag (shell/html-attr-bag html-attrs lang)]
-    (str "<!DOCTYPE html>"
-         "<html" (html/attr-string attr-bag) ">"
-         "<head"
-         (when head-hash (str " data-rf-head-hash=\"" head-hash "\""))
-         ">"
-         "<meta charset=\"utf-8\">"
-         (or head-html "")
-         "</head>"
-         "<body" (html/attr-string body-attrs) ">"
-         ;; rf2-7x0qk — `:app-element-id` is an attribute-value position;
-         ;; escape through `html/escape-attr` (same split as the non-
-         ;; streaming `default-html-shell`). `:head` stays raw (content
-         ;; position). rf2-9fw2de — the `data-rf-render-hash` value is an
-         ;; 8-char hex (canonical-EDN FNV) so it needs no escaping, but it
-         ;; only emits when supplied (`:emit-hash?` true).
-         "<div id=\"" (html/escape-attr app-element-id) "\""
-         (when render-hash
-           (str " data-rf-render-hash=\"" render-hash "\""))
-         ">")))
+  [head-html {:keys [render-hash] :as opts}]
+  ;; rf2-od9fet — a DELEGATE over the single-source `shell/document-prefix`
+  ;; (shared verbatim with the non-streaming `default-html-shell`). The
+  ;; streaming path preserves the optional `data-rf-render-hash` marker on
+  ;; the `#app` root — it passes `:render-hash` explicitly (the
+  ;; non-streaming shell passes nil, so its root carries no marker). Every
+  ;; other envelope decision (doctype, `<html>`/`<body>` attr bags,
+  ;; charset, head fragment, `:head-hash` marker, `:app-element-id`
+  ;; escaping) lives in the shared renderer, so the two response modes
+  ;; cannot silently diverge on the security-load-bearing escaping.
+  (shell/document-prefix head-html render-hash opts))
 
 (defn default-streaming-suffix
   "The shell suffix flushed after the final-payload chunk. Emits the
@@ -132,17 +120,14 @@
   all of which already belonged outside `#app`, mirroring the non-streaming
   `default-html-shell` (which emits the payload script + bootstrap + body-end
   after `</div>`)."
-  [{:keys [body-end script-src]
-    :or   {script-src "/main.js"}}]
-  (str (when script-src
-         ;; rf2-7x0qk — `:script-src` is an attribute-value position;
-         ;; escape through `html/escape-attr` (same split as the non-
-         ;; streaming `default-html-shell`). `:body-end` stays raw
-         ;; (content position).
-         (str "<script src=\"" (html/escape-attr script-src) "\"></script>"))
-       (or body-end "")
-       "</body>"
-       "</html>"))
+  [opts]
+  ;; rf2-od9fet — a DELEGATE over the single-source `shell/document-suffix`
+  ;; (shared verbatim with the non-streaming `default-html-shell`). The
+  ;; app-root `</div>` moved to the shell chunk (rf2-z9dduj), so this is
+  ;; purely the bootstrap `<script src=…>` (`:script-src`, escape-attr'd),
+  ;; the raw `:body-end` content hook, and the `</body></html>` close —
+  ;; all single-sourced with the non-streaming shell's suffix.
+  (shell/document-suffix opts))
 
 ;; ---- shell phase (request thread, BEFORE the head commits) --------------
 ;;

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
@@ -19,6 +19,7 @@
             [re-frame.ssr :as ssr]
             [re-frame.ssr.ring :as ssr-ring]
             [re-frame.ssr.ring.lifecycle :as lifecycle]
+            [re-frame.ssr.ring.shell :as shell]
             [re-frame.ssr.ring.test-support :as ts]))
 
 ;; rf2-i3qc0 / rf2-09iktm — the canonical reset-runtime fixture is
@@ -1709,6 +1710,70 @@
           "streaming suffix escapes :script-src (parity with default-html-shell)")
       (is (not (str/includes? suffix "src=\"/main.js?v=\"x\"\""))
           "no raw quote breakout in the streaming suffix"))))
+
+;; ===========================================================================
+;; rf2-od9fet — single-source document envelope. `default-html-shell` and the
+;; streaming prefix/suffix compose the SAME `shell/document-prefix` /
+;; `shell/document-suffix` renderers, so the non-streaming shell is
+;; byte-identical to prefix + body + `</div>` + payload-script + suffix. A
+;; regression that let one response mode drift on the doctype / `<html>`-
+;; `<body>` attr bags / charset / `#app` escaping / closing tags would break
+;; this equality.
+;; ===========================================================================
+
+(deftest default-html-shell-composes-from-shared-envelope-renderers
+  (testing "rf2-od9fet: default-html-shell == default-streaming-prefix
+            (render-hash nil) + body + </div> + payload-script-tag +
+            default-streaming-suffix — the two response modes single-source
+            the envelope, so security-load-bearing escaping cannot diverge"
+    (let [opts      {:head           "<title>T</title><meta name=\"x\" content=\"y\">"
+                     :html-attrs     {:lang "fr" :data-theme "dark"}
+                     :body-attrs     {:class "page-article"}
+                     :head-hash      "deadbeef"
+                     :app-element-id "ro\"ot"           ; attribute-value escaping
+                     :script-src     "/boot.js?a=1&b=2" ; ampersand escaping
+                     :body-end       "<script>ga();</script>"}
+          body      "<main><h1>Hi</h1></main>"
+          payload   "{:rf/app-db {:x 1} :rf/version 1}"
+          shell-out (ssr-ring/default-html-shell body payload opts)
+          ;; The streaming prefix with NO :render-hash reproduces the
+          ;; non-streaming shell's prefix exactly (the #app root carries no
+          ;; data-rf-render-hash marker in the non-streaming mode). `:head`
+          ;; is threaded as the prefix's positional head-html arg.
+          composed  (str (ssr-ring/default-streaming-prefix (:head opts) opts)
+                         body
+                         "</div>"
+                         (shell/payload-script-tag payload)
+                         (ssr-ring/default-streaming-suffix opts))]
+      (is (= shell-out composed)
+          "the non-streaming shell is byte-identical to the composition of
+           the shared streaming prefix/suffix renderers")
+      ;; Spot-anchors so a future edit that breaks the equality gives a
+      ;; readable failure, not just a giant string diff.
+      (is (str/includes? shell-out "<div id=\"ro&quot;ot\">")
+          "app-element-id is escape-attr'd inside the composed div")
+      (is (str/includes? shell-out "src=\"/boot.js?a=1&amp;b=2\"")
+          "script-src ampersand is escape-attr'd in the composed suffix")
+      (is (not (str/includes? shell-out "data-rf-render-hash"))
+          "the non-streaming shell's #app root carries NO render-hash marker")
+      (is (str/includes? shell-out "data-rf-head-hash=\"deadbeef\"")
+          "the head-hash marker rides the shared prefix"))))
+
+(deftest streaming-prefix-render-hash-is-the-only-mode-divergence
+  (testing "rf2-od9fet: the ONLY prefix divergence between response modes is
+            the explicit render-hash arg — the streaming prefix stamps
+            data-rf-render-hash on #app when supplied; a render-hash-less
+            call matches the non-streaming shell's marker-free #app root"
+    (let [opts   {:app-element-id "app"}
+          hashed (ssr-ring/default-streaming-prefix "" (assoc opts :render-hash "cafebabe"))
+          plain  (ssr-ring/default-streaming-prefix "" opts)]
+      (is (str/includes? hashed "<div id=\"app\" data-rf-render-hash=\"cafebabe\">")
+          "streaming prefix stamps the marker when :render-hash is supplied")
+      (is (str/includes? plain "<div id=\"app\">")
+          "streaming prefix omits the marker when :render-hash is absent")
+      (is (not (str/includes? plain "data-rf-render-hash"))
+          "no marker without a render-hash — byte-identical #app-root open to
+           the non-streaming shell"))))
 
 ;; ===========================================================================
 ;; default-html-shell — title is sourced from the head fragment, never the

--- a/implementation/ssr/test/re_frame/flows_integration_test.clj
+++ b/implementation/ssr/test/re_frame/flows_integration_test.clj
@@ -59,74 +59,48 @@
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.error-emit :as error-emit]
-            [re-frame.flows :as flows]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
             ;; Loading the Malli adapter publishes the
             ;; `:schemas/malli-validate` late-bind hook the default
             ;; validator routes through (Spec 010 §Recommended soft-pass /
             ;; rf2-t0hq); without it `reg-app-schema` validation soft-passes.
             [re-frame.schemas.malli]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.error-listener :as error-listener]
-            [re-frame.ssr.head :as head]
-            [re-frame.ssr.request :as request]
-            [re-frame.ssr.response :as response]
-            [re-frame.trace :as trace]))
+            [re-frame.ssr.test-fixture :as tf]
+            [re-frame.test-support :refer [with-trace-recorder!]]))
 
 ;; ---- per-test reset / trace recorder -------------------------------------
 ;;
-;; Mirrors `re-frame.ssr.test-fixture/reset-runtime` (registrar wipe + all
-;; per-frame side-channel atoms + ns-load-time reloads of routing / ssr /
-;; ssr.head / machines so their registrations resurrect after clear-all!),
-;; and ADDS what the trace-order assertions here need: an error-listener
-;; clear (the error-emit registry is a `defonce` atom that survives test
-;; re-runs) and an all-trace recorder bound per test.
+;; rf2-kufxxe — COMPOSE from the canonical `re-frame.ssr.test-fixture/
+;; reset-runtime` (registrar wipe + every per-frame SSR side-channel atom +
+;; the ns-load-time reloads of routing / ssr / ssr.head / machines + the
+;; ambient `:rf/default` frame) rather than duplicate it. This suite adds
+;; only the three genuine deltas its trace-order assertions need:
+;;
+;;   1. schema-validator restoration — the flow-schema-rollback tests install
+;;      a Malli app-db validator (`reg-app-schema`); reset it before the test
+;;      AND in a `finally` so a validator from one test cannot leak into the
+;;      next (the canonical fixture clears per-frame schemas but not the
+;;      global validator fn).
+;;   2. error-emitter listener cleanup — the error-emit registry is a
+;;      `defonce` atom that survives test re-runs (rf2-bacs4); clear it so a
+;;      listener registered by one test does not leak into the next.
+;;   3. a fixture-wide all-trace recorder — bracketed by the canonical
+;;      `with-trace-recorder!` (rf2-64iuw) and bound to `*captured*` so the
+;;      `ops` / `by-op` helpers below read the full captured event stream.
 
 (def ^:dynamic ^:private *captured* nil)
 
 (defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (schemas/clear-schemas-by-frame!)
-  (schemas/reset-schema-validator!)
-  (reset! request/request-slots {})
-  (reset! response/response-slots {})
-  (reset! error-listener/pending-error-traces {})
-  (reset! head/head-snapshots {})
-  (flows/reset-last-inputs!)
-  ;; The error-emit listener registry is a `defonce` atom that survives
-  ;; test re-runs (per rf2-bacs4) — clear so a listener registered by one
-  ;; test does not leak into the next.
-  (error-emit/clear-error-listeners!)
-  (rf/init! ssr/adapter)
-  ;; clear-all! wiped the ns-load-time registrations of these artefacts;
-  ;; :reload re-evaluates the ns-body so the machine fxs, :rf.route/*
-  ;; handlers, :rf.server/* fxs, the head hooks, and the :rf/hydrate
-  ;; handler all resurrect between tests.
-  (require 're-frame.routing :reload)
-  (require 're-frame.ssr     :reload)
-  (require 're-frame.ssr.head :reload)
-  (require 're-frame.machines :reload)
-  ;; EP-0002 (rf2-9o48ih): `init!` no longer synthesises `:rf/default`;
-  ;; framework operation + registration surfaces require a carried frame
-  ;; stamp. Register `:rf/default` + pin it as the body's ambient scope
-  ;; (the carried-invariant equivalent of `(with-frame :rf/default …)`);
-  ;; explicit `{:frame …}` opts / inner `with-frame` still win.
-  (rf/reg-frame :rf/default {})
-  (let [captured (atom [])]
-    (binding [*captured* captured]
-      (trace/register-listener!
-        ::flow-integration-recorder
-        (fn [ev] (swap! captured conj ev)))
-      (try
-        (rf/with-frame :rf/default
-          (test-fn))
-        (finally
-          (trace/unregister-listener! ::flow-integration-recorder)
-          (schemas/reset-schema-validator!))))))
+  (tf/reset-runtime
+    (fn []
+      (schemas/reset-schema-validator!)
+      (error-emit/clear-error-listeners!)
+      (with-trace-recorder! [captured]
+        (binding [*captured* captured]
+          (try
+            (test-fn)
+            (finally
+              (schemas/reset-schema-validator!))))))))
 
 (use-fixtures :each reset-runtime)
 


### PR DESCRIPTION
Two clustered SSR-family dedup beads (disjoint files), one PR.

## rf2-od9fet — single-source the default Ring HTML document envelope

`re-frame.ssr.ring.shell` now owns internal `document-prefix` /
`document-suffix` renderers. `document-prefix` renders `<!DOCTYPE html>`
through the OPEN `#app` div (inclusive) and takes an **explicit
`render-hash` argument** — the one piece the two response modes disagree
on: the non-streaming `default-html-shell` passes `nil` (its `#app` root
carries no `data-rf-render-hash`), the streaming prefix preserves the
optional marker. `document-suffix` renders the bootstrap `<script>` +
raw `:body-end` + `</body></html>`.

`default-html-shell` is now composed from `document-prefix` + body +
`</div>` + the shared `payload-script-tag` + `document-suffix`. The
public streaming functions (`default-streaming-prefix` /
`default-streaming-suffix`) are documented DELEGATES over the shared
renderers — **docstrings/facade metadata unchanged** (they keep their
verbatim `:doc`; `import-fn` re-export contract intact). The now-unused
`html-helpers` require was dropped from `streaming.clj`.

Result: the doctype / `<html>`-`<body>` attr bags / charset / head-hash
marker / `#app` id-escaping / bootstrap / closing tags are single-sourced,
so security-load-bearing escaping (the rf2-7x0qk attribute-value split)
can no longer drift between response modes.

Adds focused parity/composition coverage in `ring_test.clj`:
`default-html-shell` is byte-identical to
`default-streaming-prefix` (render-hash nil) + body + `</div>` +
`payload-script-tag` + `default-streaming-suffix`, plus a test pinning
that the render-hash arg is the ONLY prefix divergence between modes.

## rf2-kufxxe — compose SSR flows-integration from the canonical fixture

`flows_integration_test.clj` no longer duplicates
`re-frame.ssr.test-fixture/reset-runtime`. The local fixture now calls
`tf/reset-runtime` and, inside its callback, retains only the three
genuine deltas: schema-validator restoration (before + `finally`),
error-emitter listener cleanup, and a fixture-wide all-trace recorder —
now bracketed by the canonical `with-trace-recorder!` and bound to
`*captured*`. Removed the fixture-only imports
(frame/registrar/request/response/error-listener/head/trace/flows/ssr),
the direct atom resets, and the namespace reloads. Trace-order
assertions are unchanged.

## Stance

Pre-alpha, no back-compat. Primary lenses ELEGANCE + CLARITY +
CORRECTNESS + GOOD PRACTICE. Public facade `:doc`/`:arglists` metadata
preserved for the streaming delegates; SSR envelope output byte-identical
in both response modes.

## Preflight (duplication verified before centralizing)

- **od9fet**: confirmed `shell.clj` `default-html-shell` and `streaming.clj`
  `default-streaming-prefix`/`suffix` independently assembled the SAME
  doctype/head/body/`#app`/payload/close markup line-for-line — a real
  duplication, now single-sourced.
- **kufxxe**: confirmed the local `reset-runtime` reproduced
  `test-fixture/reset-runtime` verbatim (registrar/frame/flows/schemas/
  side-channel clears + routing/ssr/ssr.head/machines reloads + ambient
  `:rf/default`), diverging only by the three retained deltas.

## Quality gates (foreground, 0 failures)

- `implementation/ssr-ring` `clojure -M:test` — 172 tests / 839 assertions, 0 failures/0 errors
- `implementation/ssr` `clojure -M:test` — 372 tests / 1535 assertions, 0 failures/0 errors
- `implementation` `npm run test:cljs` — 8466 tests / 39159 assertions, 0 failures/0 errors
