### PR TITLE
refactor(mcp-conformance): one live-test inventory + dedup indicator conformance onto canonical owners; tighten indicator schema to pos-int? (rf2-phveub, rf2-tdn6oi)

### DIFF
--- a/tools/mcp-conformance/scripts/live-test-inventory.cjs
+++ b/tools/mcp-conformance/scripts/live-test-inventory.cjs
@@ -1,0 +1,99 @@
+// Single source of truth for the re-frame2-pair LIVE conformance gates.
+//
+// The live gates live in `test/live-re-frame2-pair-*.cjs`. Each is named in
+// TWO runners that used to declare the roster independently:
+//
+//   1. `scripts/run-re-frame2-pair-live-hermetic-suite.cjs` — the ONLY place
+//      the live path actually FIRES (boots shadow-cljs, sets
+//      `$SHADOW_CLJS_NREPL_PORT`, spawns each entry, asserts the sentinel).
+//   2. `scripts/test-all.cjs` — spawned by `npm test`, where they
+//      SKIP-by-default (no `$SHADOW_CLJS_NREPL_PORT`) and ride green.
+//
+// Two hand-maintained lists could drift from each other and from disk; the
+// old `live-list-completeness.test.cjs` existed mainly to ratchet the two
+// lists back into agreement. This module makes the roster a SINGLE owner:
+// each gate's basename, display name, and success sentinel are declared here
+// ONCE. Both runners DERIVE their rows from this array (the hermetic runner
+// resolves each `basename` to an absolute path; `test-all.cjs` derives a
+// SKIP-by-default live row), so they can no longer drift from each other —
+// the only remaining anti-drift check is disk-versus-this-inventory
+// (`test/live-list-completeness.test.cjs`).
+//
+// Side-effect-free: requiring this module boots nothing (no shadow-cljs, no
+// Chromium, no MCP server) — it is pure data, safe to import from the
+// completeness gate and both runners.
+//
+// Each entry's `sentinel` is the `... CONFORMANCE GREEN` line the gate prints
+// ONLY on a real (non-skipped) pass. The hermetic env guarantees
+// `$SHADOW_CLJS_NREPL_PORT` is set, so the gate's SKIP path MUST NOT fire
+// there — yet a SKIP still exits 0. The hermetic runner asserts the sentinel
+// (and the absence of a `SKIP ` banner) so a silent in-hermetic SKIP turns
+// the gate RED rather than riding green via the OTHER gates.
+'use strict';
+
+const LIVE_TESTS = [
+  {
+    basename: 'live-re-frame2-pair-overflow.cjs',
+    name: 'live overflow conformance',
+    sentinel: 'RE-FRAME2-PAIR-MCP LIVE OVERFLOW CONFORMANCE GREEN',
+  },
+  {
+    // Pins the `notifications/progress` streaming wire surface.
+    basename: 'live-re-frame2-pair-subscribe.cjs',
+    name: 'live subscribe / notifications/progress conformance',
+    sentinel: 'RE-FRAME2-PAIR-MCP LIVE SUBSCRIBE CONFORMANCE GREEN',
+  },
+  {
+    // Egress-protection regression net for the pull-mode epoch tools
+    // (trace-window / watch-epochs). Drives a declared-sensitive app-db
+    // slot through both tools across the MCP wire and asserts the
+    // sensitive epoch is WHOLE-DROPPED gate-OFF (the default) and shipped
+    // gate-ON. This is the gate that pins the whole-drop behaviour.
+    basename: 'live-re-frame2-pair-redaction.cjs',
+    name: 'live egress-protection conformance (pull-mode epoch tools)',
+    sentinel: 'RE-FRAME2-PAIR-MCP LIVE EGRESS-PROTECTION CONFORMANCE GREEN',
+  },
+  {
+    // Pin the universal `:ok? false ⇒ isError:true` contract on the
+    // read-family GENUINE error envelopes (read-dom/read-ui bad-selector).
+    // Drives a malformed CSS selector against the live runtime so
+    // `querySelectorAll` throws and the runtime fn returns a structured
+    // `{:ok? false :reason :rf.error/...-bad-selector}` — then asserts the
+    // SDK response is isError. This is the live SDK-boundary gate for the
+    // error path; the degraded walk only exercises the
+    // :nrepl-port-not-found shape, so the live runtime is required here.
+    basename: 'live-re-frame2-pair-iserror.cjs',
+    name: 'live isError-on-:ok?-false conformance (read-dom/read-ui bad selector)',
+    sentinel: 'RE-FRAME2-PAIR-MCP LIVE ISERROR-ON-OK-FALSE CONFORMANCE GREEN',
+  },
+  {
+    // EP-0017 recordable-coeffects (`cofx`) over the live MCP wire.
+    // Dispatches the fixture's [:counter/stamp] (a reg-event declaring
+    // `:rf.cofx/requires [:rf/time-ms]`) with a scripted
+    // `cofx "{:rf/time-ms <N>}"` and proves the supplied fact reaches the
+    // resulting app-db state (reproducible-dispatch determinism), the
+    // malformed-cofx refusals the degraded handler hides, and the EP-0017
+    // tooling visibility (`list-handlers`/`handler-meta` for the `cofx`
+    // kind + authored `:rf.cofx/requires` on the event). The degraded
+    // end-to-end only proves the `cofx` arg is ACCEPTED — this is the
+    // behaviour gate.
+    basename: 'live-re-frame2-pair-cofx.cjs',
+    name: 'live EP-0017 cofx conformance (reproducible dispatch + cofx tooling)',
+    sentinel: 'RE-FRAME2-PAIR-MCP LIVE COFX CONFORMANCE GREEN',
+  },
+  {
+    // EP-0018 unified event-registration metadata over the live MCP wire.
+    // Inspects a fixture `rf/reg-event` id (`:counter/inc`) via
+    // `list-handlers`/`handler-meta {kind "event"}` and pins the unified
+    // shape (`:ok? true`, `:kind :event`, `:id`, the `:rf/event-handler`
+    // wrapper) AND the absence of any of the markers that must not appear
+    // (`:event/kind`, `:rf/db-handler`/`:rf/fx-handler`/`:rf/ctx-handler`).
+    // The degraded gate only proves the descriptor/CallToolResult wiring —
+    // this proves the live event-metadata wire reflects EP-0018.
+    basename: 'live-re-frame2-pair-event-meta.cjs',
+    name: 'live EP-0018 event-metadata conformance (unified reg-event shape)',
+    sentinel: 'RE-FRAME2-PAIR-MCP LIVE EVENT-METADATA CONFORMANCE GREEN',
+  },
+];
+
+module.exports = { LIVE_TESTS };

--- a/tools/mcp-conformance/scripts/run-re-frame2-pair-live-hermetic-suite.cjs
+++ b/tools/mcp-conformance/scripts/run-re-frame2-pair-live-hermetic-suite.cjs
@@ -3,12 +3,12 @@
  * Hermetic orchestrator for the re-frame2-pair LIVE conformance SUITE.
  *
  * This is the CI entry point for the WHOLE hermetic live suite — it runs
- * EVERY live inner test in the `INNER_TESTS` inventory (see ~:200), not
- * just the overflow gate. Overflow is one member of that inventory
- * alongside subscribe/progress, redaction, isError, EP-0017 cofx, and
- * EP-0018 event-metadata. The runner is named for the suite, not for the
- * overflow gate, so test selection / CI triage / future conformance work
- * find a suite-shaped name.
+ * EVERY live inner test in the shared inventory
+ * (`scripts/live-test-inventory.cjs`), not just the overflow gate.
+ * Overflow is one member of that inventory alongside subscribe/progress,
+ * redaction, isError, EP-0017 cofx, and EP-0018 event-metadata. The runner
+ * is named for the suite, not for the overflow gate, so test selection / CI
+ * triage / future conformance work find a suite-shaped name.
  *
  * Each live inner test (e.g. `test/live-re-frame2-pair-overflow.cjs`) is
  * gated on $SHADOW_CLJS_NREPL_PORT. Without that env var it exits 0 with
@@ -82,6 +82,7 @@ const {
   safeUnlinkInside,
   safeReadFileInside,
 } = require('../lib/exec-safety.cjs');
+const { LIVE_TESTS } = require('./live-test-inventory.cjs');
 
 // We use `cross-spawn` instead of Node's `child_process.spawn` for the
 // two Windows-toolchain spawn sites (`npm` install + `npx shadow-cljs
@@ -187,90 +188,29 @@ const CLEANUP_HARD_CAP_MS =
 // cold-cache load).
 const POLL_MS = 100;
 
-// Inner tests the orchestrator boots shadow-cljs for. Each runs with
-// the spawned `SHADOW_CLJS_NREPL_PORT` set so its SKIP gate flips off
-// and the live path fires. Run sequentially against the same booted
-// runtime — the cold-boot cost amortises across every test.
+// Inner tests the orchestrator boots shadow-cljs for, DERIVED from the
+// shared live-test inventory (`scripts/live-test-inventory.cjs` — the
+// single owner of each gate's basename / display name / sentinel). Each
+// runs with the spawned `SHADOW_CLJS_NREPL_PORT` set so its SKIP gate flips
+// off and the live path fires; they run sequentially against the same
+// booted runtime so the cold-boot cost amortises across every test.
 //
-// `live-re-frame2-pair-subscribe.cjs` pins the `notifications/progress`
-// streaming wire surface. The orchestrator's name keeps `overflow` to
-// match the workflow YAML's script reference; the `INNER_TESTS` list IS
-// the authoritative inventory.
+// The orchestrator's name keeps `overflow` to match the workflow YAML's
+// script reference; the inventory (not this derived list) is the
+// authoritative roster — `test-all.cjs` derives its SKIP-by-default live
+// rows from the same array, and `test/live-list-completeness.test.cjs`
+// cross-checks the inventory against the `test/live-re-frame2-pair-*.cjs`
+// files on disk.
 //
-// Each entry carries the test's success `sentinel` — the
-// `... CONFORMANCE GREEN` line it prints ONLY on a real (non-skipped)
-// pass. The hermetic env guarantees `$SHADOW_CLJS_NREPL_PORT` is set, so
-// the inner test's SKIP gate MUST NOT fire here — yet a SKIP still
-// exits 0. Without a sentinel check, a regression that broke the
-// orchestrator's SETUP path (port probe, bundle compile, runtime
-// sentinel) short of an inner-test FAILURE could leave the load-bearing
-// redaction gate SKIPping (exit 0) while CI shows the hermetic job green
-// via the OTHER inner tests. Asserting the sentinel (and the absence of
-// a `SKIP ` banner) makes a silent in-hermetic SKIP turn the gate RED.
-const INNER_TESTS = [
-  {
-    name: 'live overflow conformance',
-    path: path.join(MCP_CONFORMANCE_ROOT, 'test', 'live-re-frame2-pair-overflow.cjs'),
-    sentinel: 'RE-FRAME2-PAIR-MCP LIVE OVERFLOW CONFORMANCE GREEN',
-  },
-  {
-    name: 'live subscribe / notifications/progress conformance',
-    path: path.join(MCP_CONFORMANCE_ROOT, 'test', 'live-re-frame2-pair-subscribe.cjs'),
-    sentinel: 'RE-FRAME2-PAIR-MCP LIVE SUBSCRIBE CONFORMANCE GREEN',
-  },
-  {
-    // Egress-protection regression net for the pull-mode epoch tools
-    // (trace-window / watch-epochs). Drives a declared-sensitive app-db
-    // slot through both tools across the MCP wire and asserts the
-    // sensitive epoch is WHOLE-DROPPED gate-OFF (the default) and shipped
-    // gate-ON. This is the gate that pins the whole-drop behaviour.
-    name: 'live egress-protection conformance (pull-mode epoch tools)',
-    path: path.join(MCP_CONFORMANCE_ROOT, 'test', 'live-re-frame2-pair-redaction.cjs'),
-    sentinel: 'RE-FRAME2-PAIR-MCP LIVE EGRESS-PROTECTION CONFORMANCE GREEN',
-  },
-  {
-    // Pin the universal `:ok? false ⇒ isError:true` contract
-    // on the read-family GENUINE error envelopes (read-dom/read-ui
-    // bad-selector). Drives a malformed CSS selector against the live
-    // runtime so `querySelectorAll` throws and the runtime fn returns a
-    // structured `{:ok? false :reason :rf.error/...-bad-selector}` — then
-    // asserts the SDK response is isError. This is the live SDK-boundary
-    // gate for the error path; the degraded walk only exercises the
-    // :nrepl-port-not-found shape, so the live runtime is required here.
-    name: 'live isError-on-:ok?-false conformance (read-dom/read-ui bad selector)',
-    path: path.join(MCP_CONFORMANCE_ROOT, 'test', 'live-re-frame2-pair-iserror.cjs'),
-    sentinel: 'RE-FRAME2-PAIR-MCP LIVE ISERROR-ON-OK-FALSE CONFORMANCE GREEN',
-  },
-  {
-    // EP-0017 recordable-coeffects (`cofx`) over the live MCP
-    // wire. Dispatches the fixture's [:counter/stamp] (a reg-event
-    // declaring `:rf.cofx/requires [:rf/time-ms]`) with a scripted
-    // `cofx "{:rf/time-ms <N>}"` and proves the supplied fact reaches the
-    // resulting app-db state (reproducible-dispatch determinism), the
-    // malformed-cofx refusals the degraded handler hides, and the EP-0017
-    // tooling visibility (`list-handlers`/`handler-meta` for the `cofx`
-    // kind + authored `:rf.cofx/requires` on the event). The degraded
-    // end-to-end only proves the `cofx` arg is ACCEPTED — this is the
-    // behaviour gate.
-    name: 'live EP-0017 cofx conformance (reproducible dispatch + cofx tooling)',
-    path: path.join(MCP_CONFORMANCE_ROOT, 'test', 'live-re-frame2-pair-cofx.cjs'),
-    sentinel: 'RE-FRAME2-PAIR-MCP LIVE COFX CONFORMANCE GREEN',
-  },
-  {
-    // EP-0018 unified event-registration metadata over the
-    // live MCP wire. Inspects a fixture `rf/reg-event` id (`:counter/inc`)
-    // via `list-handlers`/`handler-meta {kind "event"}` and pins the
-    // unified shape (`:ok? true`, `:kind :event`, `:id`, the
-    // `:rf/event-handler` wrapper) AND the absence of any of the markers
-    // that must not appear (`:event/kind`,
-    // `:rf/db-handler`/`:rf/fx-handler`/`:rf/ctx-handler`).
-    // The degraded gate only proves the descriptor/CallToolResult wiring —
-    // this proves the live event-metadata wire reflects EP-0018.
-    name: 'live EP-0018 event-metadata conformance (unified reg-event shape)',
-    path: path.join(MCP_CONFORMANCE_ROOT, 'test', 'live-re-frame2-pair-event-meta.cjs'),
-    sentinel: 'RE-FRAME2-PAIR-MCP LIVE EVENT-METADATA CONFORMANCE GREEN',
-  },
-];
+// The inventory carries each gate's success `sentinel` (see its header for
+// why the sentinel assertion below is load-bearing against a silent
+// in-hermetic SKIP that would otherwise ride green via the OTHER gates).
+// Here we resolve each `basename` to the absolute path the spawn needs.
+const INNER_TESTS = LIVE_TESTS.map((t) => ({
+  name: t.name,
+  path: path.join(MCP_CONFORMANCE_ROOT, 'test', t.basename),
+  sentinel: t.sentinel,
+}));
 
 function recordLine(line, stream = 'stdout') {
   DIAGNOSTICS.add(line, stream);
@@ -1437,12 +1377,4 @@ module.exports = {
   waitForChildExit,
   spawnAndGradeInnerTest,
   wipeStalePortFileCandidate,
-  // The authoritative live-inner-test inventory the hermetic suite boots
-  // shadow-cljs for. Exported (require.main-guarded above, so importing this
-  // module does NOT boot shadow-cljs / Chromium) so the completeness guard
-  // `test/live-list-completeness.test.cjs` (rf2-79qmsw) can cross-check it
-  // against the `test/live-re-frame2-pair-*.cjs` files on disk — a live gate
-  // added to disk but forgotten here would SKIP under `npm test` and never
-  // launch on CI, riding perpetually green.
-  INNER_TESTS,
 };

--- a/tools/mcp-conformance/scripts/test-all.cjs
+++ b/tools/mcp-conformance/scripts/test-all.cjs
@@ -21,9 +21,23 @@
 
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
+const { LIVE_TESTS } = require('./live-test-inventory.cjs');
 
 const HERE = __dirname;
 const ROOT = path.resolve(HERE, '..');
+
+// The live re-frame2-pair gates, DERIVED from the shared inventory
+// (`scripts/live-test-inventory.cjs`) — the single owner of the roster — so
+// this file and the hermetic runner (`run-re-frame2-pair-live-hermetic-suite.cjs`)
+// can never declare a different set. Under `npm test` (no
+// `$SHADOW_CLJS_NREPL_PORT`) each SKIPs and rides green; the hermetic CI job
+// is the only place the live path fires. Spliced into `TESTS` below AFTER the
+// degraded end-to-end and BEFORE story-mcp so a green run reads as "real
+// conformance passed, the live gates gracefully skipped".
+const LIVE_ROWS = LIVE_TESTS.map((t) => ({
+  name: `re-frame2-pair-mcp ${t.name} (SKIPs without $SHADOW_CLJS_NREPL_PORT)`,
+  argv: [`test/${t.basename}`],
+}));
 
 // One row per conformance test. Order matters: cheap unit tests first
 // so a typo in the exec-safety helpers fails before we spawn an MCP
@@ -40,6 +54,10 @@ const ROOT = path.resolve(HERE, '..');
 // that runner DERIVES its set from this array, a new `--test` row added
 // here is automatically picked up by PR CI — no second list to keep in
 // sync.
+//
+// The LIVE re-frame2-pair rows are themselves DERIVED from the shared
+// live-test inventory (`LIVE_ROWS`, above) rather than re-listed here, so
+// they cannot drift from the hermetic runner's roster.
 const TESTS = [
   {
     name: 'exec-safety unit tests',
@@ -62,7 +80,7 @@ const TESTS = [
     argv: ['--test', 'test/inner-test-close-grading.test.cjs'],
   },
   {
-    name: 'live-gate list completeness — disk ⇄ INNER_TESTS ⇄ test-all rows (rf2-79qmsw)',
+    name: 'live-gate list completeness — disk ⇄ shared live-test inventory (rf2-79qmsw / rf2-phveub)',
     argv: ['--test', 'test/live-list-completeness.test.cjs'],
   },
   {
@@ -97,30 +115,9 @@ const TESTS = [
     name: 're-frame2-pair-mcp end-to-end',
     argv: ['test/end-to-end-re-frame2-pair.cjs'],
   },
-  {
-    name: 're-frame2-pair-mcp live-overflow (SKIPs without $SHADOW_CLJS_NREPL_PORT)',
-    argv: ['test/live-re-frame2-pair-overflow.cjs'],
-  },
-  {
-    name: 're-frame2-pair-mcp live-subscribe (SKIPs without $SHADOW_CLJS_NREPL_PORT)',
-    argv: ['test/live-re-frame2-pair-subscribe.cjs'],
-  },
-  {
-    name: 're-frame2-pair-mcp live-redaction (SKIPs without $SHADOW_CLJS_NREPL_PORT)',
-    argv: ['test/live-re-frame2-pair-redaction.cjs'],
-  },
-  {
-    name: 're-frame2-pair-mcp live-iserror — :ok? false ⇒ isError read-dom/read-ui (SKIPs without $SHADOW_CLJS_NREPL_PORT)',
-    argv: ['test/live-re-frame2-pair-iserror.cjs'],
-  },
-  {
-    name: 're-frame2-pair-mcp live-cofx — EP-0017 reproducible dispatch + cofx tooling (SKIPs without $SHADOW_CLJS_NREPL_PORT)',
-    argv: ['test/live-re-frame2-pair-cofx.cjs'],
-  },
-  {
-    name: 're-frame2-pair-mcp live-event-meta — EP-0018 unified event metadata (SKIPs without $SHADOW_CLJS_NREPL_PORT)',
-    argv: ['test/live-re-frame2-pair-event-meta.cjs'],
-  },
+  // Live re-frame2-pair gates, derived from the shared inventory (see
+  // `LIVE_ROWS` above). SKIP-by-default under `npm test`.
+  ...LIVE_ROWS,
   {
     name: 'story-mcp end-to-end',
     argv: ['test/end-to-end-story.cjs'],

--- a/tools/mcp-conformance/test/live-list-completeness.test.cjs
+++ b/tools/mcp-conformance/test/live-list-completeness.test.cjs
@@ -1,5 +1,6 @@
-// Completeness / anti-drift guard for the hermetic live-suite's
-// INNER_TESTS inventory and test-all.cjs's live rows (rf2-79qmsw).
+// Completeness / anti-drift guard for the shared live-test inventory
+// (`scripts/live-test-inventory.cjs`) against the live gate files on disk
+// (rf2-79qmsw, rf2-phveub).
 //
 // Uses Node's built-in `node:test` (same posture as
 // `inner-test-close-grading.test.cjs` — no extra dev-dependency). Runs in
@@ -9,34 +10,27 @@
 //
 // ## The drift this pins
 //
-// The live gates live in `test/live-re-frame2-pair-*.cjs`. They are named in
-// TWO separate, hand-maintained lists:
+// The live gates live in `test/live-re-frame2-pair-*.cjs`. They used to be
+// named in TWO separate, hand-maintained lists (the hermetic runner's
+// `INNER_TESTS` and `test-all.cjs`'s live rows), and nothing cross-checked
+// the two against each other or against disk — so a forgotten entry could
+// ride perpetually green (never launched on CI) or never be spawned at all.
 //
-//   1. `scripts/run-re-frame2-pair-live-hermetic-suite.cjs` `INNER_TESTS` —
-//      the ONLY place the live path actually FIRES (the hermetic suite boots
-//      shadow-cljs, sets `$SHADOW_CLJS_NREPL_PORT`, and spawns each entry).
-//   2. `scripts/test-all.cjs` `TESTS` live rows — spawned by `npm test`,
-//      where they SKIP-by-default (no `$SHADOW_CLJS_NREPL_PORT`) and ride
-//      green.
+// rf2-phveub collapsed those two lists onto ONE owner: the shared inventory
+// (`scripts/live-test-inventory.cjs`). BOTH runners now DERIVE their rows from
+// that array (the hermetic runner resolves each `basename` to an absolute
+// path; `test-all.cjs` derives a SKIP-by-default row), so they can no longer
+// disagree with each other. The only remaining drift is inventory-versus-disk:
+//   - a new `live-re-frame2-pair-<new>.cjs` added to disk but forgotten in the
+//     inventory → never spawned by `npm test`, never LAUNCHED on CI (the
+//     hermetic job is the only place the live path fires) — rides perpetually
+//     green as an un-exercised gate;
+//   - a rename/delete that left a dangling inventory entry → the hermetic
+//     suite would fail to spawn a file that no longer exists.
 //
-// Nothing derives either list from the files on disk, and nothing
-// cross-checks the two against each other. So a future
-// `live-re-frame2-pair-<new>.cjs` added to ONE list but forgotten in the
-// other:
-//   - forgotten in `test-all.cjs` → never spawned by `npm test` at all;
-//   - forgotten in `INNER_TESTS`  → never LAUNCHED on CI (the hermetic job is
-//     the only place the live path runs) — it rides perpetually green as an
-//     un-exercised gate.
-//
-// The `inner-test-close-grading` sentinel guard (rf2-6girz0) cannot catch
-// this: it only inspects tests already IN `INNER_TESTS`. This is the
-// silent-SKIP false-green class one meta-level up. The `test-unit.cjs`
-// derive-don't-re-list discipline is the fix, applied here as an assertion:
-// the DISK glob is the source of truth; both lists must cover it exactly.
-//
-// It requires both scripts AS MODULES (the orchestrator's auto-run is guarded
-// behind `require.main === module`, and `test-all.cjs` only runs `main()`
-// under the same guard, so requiring them boots nothing).
+// The DISK glob is the source of truth; the inventory must cover it exactly.
+// It requires only the inventory (a side-effect-free pure-data module — no
+// runner, no shadow-cljs, no Chromium boots).
 
 'use strict';
 
@@ -48,10 +42,9 @@ const path = require('node:path');
 const TEST_DIR = __dirname;
 const SCRIPTS_DIR = path.join(TEST_DIR, '..', 'scripts');
 
-const { INNER_TESTS } = require(
-  path.join(SCRIPTS_DIR, 'run-re-frame2-pair-live-hermetic-suite.cjs'),
+const { LIVE_TESTS } = require(
+  path.join(SCRIPTS_DIR, 'live-test-inventory.cjs'),
 );
-const { TESTS } = require(path.join(SCRIPTS_DIR, 'test-all.cjs'));
 
 // The on-disk source of truth: every live gate file.
 const LIVE_FILE_RE = /^live-re-frame2-pair-.*\.cjs$/;
@@ -63,17 +56,9 @@ function liveFilesOnDisk() {
     .sort();
 }
 
-// The live basenames each list references. `INNER_TESTS` entries carry an
-// absolute `.path`; `test-all.cjs` live rows are `{ argv: ['test/<file>'] }`
-// (no `--test`) — take the last argv element and keep only the live gates.
-function innerTestBasenames() {
-  return INNER_TESTS.map((t) => path.basename(t.path))
-    .filter((name) => LIVE_FILE_RE.test(name))
-    .sort();
-}
-
-function testAllLiveBasenames() {
-  return TESTS.map((t) => path.basename(t.argv[t.argv.length - 1]))
+// The live basenames the inventory declares.
+function inventoryBasenames() {
+  return LIVE_TESTS.map((t) => t.basename)
     .filter((name) => LIVE_FILE_RE.test(name))
     .sort();
 }
@@ -83,61 +68,37 @@ test('there is at least one live gate on disk (refuse to report green on an empt
   assert.ok(
     disk.length > 0,
     'no test/live-re-frame2-pair-*.cjs files found — either the glob broke or ' +
-      'the live gates were removed; refusing to certify the lists as complete ' +
-      'against an empty disk set',
+      'the live gates were removed; refusing to certify the inventory as ' +
+      'complete against an empty disk set',
   );
 });
 
-test('every live gate on disk appears in the hermetic INNER_TESTS inventory (rf2-79qmsw)', () => {
+test('every live gate on disk appears in the shared inventory (rf2-phveub / rf2-79qmsw)', () => {
   const disk = new Set(liveFilesOnDisk());
-  const inner = new Set(innerTestBasenames());
-  const missing = [...disk].filter((f) => !inner.has(f));
+  const inventory = new Set(inventoryBasenames());
+  const missing = [...disk].filter((f) => !inventory.has(f));
   assert.deepEqual(
     missing,
     [],
-    'live gate file(s) present on disk but MISSING from `INNER_TESTS` in ' +
-      'run-re-frame2-pair-live-hermetic-suite.cjs — the hermetic CI job is the ' +
-      'only place the live path fires, so a forgotten entry never launches and ' +
-      'rides perpetually green:\n  ' +
+    'live gate file(s) present on disk but MISSING from the inventory in ' +
+      'scripts/live-test-inventory.cjs — both runners derive their roster from ' +
+      'the inventory, so a forgotten entry is never spawned by `npm test` and ' +
+      'never LAUNCHED by the hermetic CI job (the only place the live path ' +
+      'fires), riding perpetually green:\n  ' +
       missing.join('\n  '),
   );
 });
 
-test('every live gate on disk appears in the test-all.cjs live rows (rf2-79qmsw)', () => {
+test('the inventory references no live gate that is absent from disk (dangling entry after a rename/delete)', () => {
   const disk = new Set(liveFilesOnDisk());
-  const testAll = new Set(testAllLiveBasenames());
-  const missing = [...disk].filter((f) => !testAll.has(f));
-  assert.deepEqual(
-    missing,
-    [],
-    'live gate file(s) present on disk but MISSING from the `TESTS` live rows ' +
-      'in test-all.cjs — a forgotten entry is never spawned by `npm test` at ' +
-      'all:\n  ' +
-      missing.join('\n  '),
-  );
-});
-
-test('INNER_TESTS references no live gate that is absent from disk (dangling entry after a rename/delete)', () => {
-  const disk = new Set(liveFilesOnDisk());
-  const dangling = innerTestBasenames().filter((f) => !disk.has(f));
+  const dangling = inventoryBasenames().filter((f) => !disk.has(f));
   assert.deepEqual(
     dangling,
     [],
-    '`INNER_TESTS` names live gate file(s) that no longer exist on disk — a ' +
-      'rename/delete left a dangling entry the hermetic suite would fail to ' +
-      'spawn:\n  ' +
-      dangling.join('\n  '),
-  );
-});
-
-test('test-all.cjs live rows reference no live gate that is absent from disk (dangling row after a rename/delete)', () => {
-  const disk = new Set(liveFilesOnDisk());
-  const dangling = testAllLiveBasenames().filter((f) => !disk.has(f));
-  assert.deepEqual(
-    dangling,
-    [],
-    'test-all.cjs names live gate file(s) that no longer exist on disk — a ' +
-      'rename/delete left a dangling row:\n  ' +
+    'the inventory in scripts/live-test-inventory.cjs names live gate file(s) ' +
+      'that no longer exist on disk — a rename/delete left a dangling entry ' +
+      'both runners would derive a row for and the hermetic suite would fail ' +
+      'to spawn:\n  ' +
       dangling.join('\n  '),
   );
 });

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/indicator_field_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/indicator_field_test.clj
@@ -1,5 +1,5 @@
 (ns re-frame.mcp-conformance.indicator-field-test
-  "Cross-MCP indicator-field conformance (rf2-6m8tq).
+  "Cross-MCP indicator-field ROUTING conformance (rf2-6m8tq, rf2-tdn6oi).
 
   Pins the MUST-level contract from
   [Spec 009 §Indicator field on tool responses][1] and
@@ -10,43 +10,46 @@
     `:dropped-sensitive` count. Both slots are unqualified keys. Omit
     when zero.
 
+  ## Scope — routing + no-inline-emission ONLY
+
+  This file pins that every tree-walking tool ROUTES its envelope through
+  the ONE centralised emit-path, and that no tool inlines the slot
+  literals to bypass it. It deliberately does NOT re-test the helper's
+  behaviour or re-declare the slot schemas — those have single owners
+  (rf2-tdn6oi deduplication):
+
+  - Helper SEMANTICS (the omit-when-zero `cond->`, value pass-through,
+    canonical vocab-key usage) — owned by
+    `re-frame.mcp-base.envelope/with-indicators` and its direct unit
+    tests in `tools/mcp-base/test/re_frame/mcp_base/envelope_test.clj`.
+  - Slot SCHEMAS (`DroppedSensitive` / `ElidedLarge`, `pos-int?`) plus
+    their positive-fixture conformance AND the present-zero rejection —
+    owned by `wire_vocab/schemas.clj` + `wire_vocab_test.clj`.
+
+  What this file OWNS — the centralised single-emit-path guarantee (per
+  audit `ai/findings/refactor-audit-tools-re-frame2-pair-mcp-2026-05-14.md`
+  §TE8):
+
+    Every re-frame2-pair-mcp tool that walks a tree-typed payload routes
+    its envelope through the centralised `wire/with-indicators` helper;
+    pair-mcp's `wire.cljs` re-exports and delegates to the mcp-base
+    canonical helper; and no re-frame2-pair-mcp source inlines the slot
+    literals outside the whitelisted helper/descriptor files.
+
   Sibling to [`wire_vocab_test.clj`](wire_vocab_test.clj) — that file
   pins the **wire MARKER** vocabulary (`:rf.mcp/*` / `:rf.size/*`
-  namespaced shapes). This file pins the **envelope SLOT** vocabulary
+  namespaced shapes) AND owns the **envelope SLOT** schemas
   (`:dropped-sensitive` / `:elided-large` unqualified scalar counters).
   The two vocabularies compose on every tool response: the markers
   populate values inside the payload, the slots summarise suppression
   totals on the envelope.
 
-  Coverage gap closed (per audit `ai/findings/refactor-audit-tools-re-frame2-pair-mcp-2026-05-14.md`
-  §TE8):
-
-  - (a) Every tool that walks a tree-typed payload routes its envelope
-        through a single emit-path (the centralised
-        `wire/with-indicators` helper). This file grep-pins the
-        catalogue of tree-walking tools and asserts each routes through
-        the helper.
-  - (b) The slot is omitted when the count is zero, included when the
-        count is positive. This file replicates the helper's semantics
-        as a pure-Clojure simulation (the helper itself is CLJS; the
-        same `cond->` shape is reproduced here, then exercised against
-        a fixture grid).
-  - (c) The slot's value matches the count handed in. The simulation
-        asserts identity-preservation.
-
-  ## Why pure-Clojure simulation (not live-server)
-
-  The helper (`tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire.cljs`)
-  is CLJS — it can't be `require`d from a JVM test. The contract is
-  tiny enough (one `cond->` with two arms) that a pure-Clojure
-  reproduction inside this test is the right shape: the test is the
-  contract's redundant copy, divergence trips the grep step (the
-  helper-source pin below).
+  ## Why source-text pins (not live-server)
 
   The alternative — exercising the contract through a live
   re-frame2-pair-mcp/story-mcp server — is the job of `test/end-to-end-*.js`
   (protocol conformance) and the live-re-frame2-pair-overflow path (runtime
-  cap-trigger conformance). This file's gate is at the wire-shape
+  cap-trigger conformance). This file's gate is at the wire-routing
   layer, same posture as `wire_vocab_test.clj`.
 
   [1]: ../../../spec/009-Instrumentation.md#size-elision-in-traces
@@ -54,7 +57,6 @@
   (:require [clojure.java.io :as io]
             [clojure.string  :as str]
             [clojure.test    :refer [deftest is testing]]
-            [malli.core      :as m]
             [re-frame.mcp-conformance.fixtures :as fx]))
 
 ;; ---------------------------------------------------------------------------
@@ -64,153 +66,7 @@
 ;; ---------------------------------------------------------------------------
 
 ;; ---------------------------------------------------------------------------
-;; Contract — the canonical envelope-slot vocabulary.
-;;
-;; Both slots are unqualified keywords (per Conventions §Cross-MCP
-;; indicator-field vocabulary — they ride alongside tool-shaped
-;; payloads where the tool's slot vocabulary is unqualified by
-;; convention). Values are non-negative integers (`0` never appears —
-;; the omit-when-zero rule turns 0 into "key absent").
-;; ---------------------------------------------------------------------------
-
-(def ^:private DroppedSensitive
-  "Envelope shape with the `:dropped-sensitive` slot present and
-  positive."
-  [:map {:closed false} [:dropped-sensitive pos-int?]])
-
-(def ^:private ElidedLarge
-  "Envelope shape with the `:elided-large` slot present and positive."
-  [:map {:closed false} [:elided-large pos-int?]])
-
-;; ---------------------------------------------------------------------------
-;; Helper simulation. Pure-Clojure mirror of
-;; `tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire.cljs/with-indicators`
-;; — byte-identical in semantics (the two-arm omit-when-zero `cond->`).
-;; The canonical CLJS source is pinned verbatim by
-;; `helper-source-shape-matches-simulation` below (the grep step), so it
-;; isn't re-pasted here. If the CLJS helper drifts, that grep trips; if
-;; the contract drifts (e.g. "omit when zero" → "always include"), the
-;; fixture grid below trips.
-;; ---------------------------------------------------------------------------
-
-(defn- with-indicators
-  "Pure-Clojure mirror of `wire/with-indicators`. Splice the two
-  indicator-field slots onto an envelope, honouring the omit-when-zero
-  rule."
-  [envelope {:keys [dropped elided]}]
-  (cond-> envelope
-    (pos? (or dropped 0)) (assoc :dropped-sensitive dropped)
-    (pos? (or elided  0)) (assoc :elided-large      elided)))
-
-;; ---------------------------------------------------------------------------
-;; Fixture grid. Pins the contract's three axes:
-;;
-;;   (b) omit when zero
-;;   (b) include when positive
-;;   (c) value passes through unchanged
-;;
-;; Each row is `[label dropped-in elided-in expected-envelope-delta]`.
-;; `expected-envelope-delta` is the EXACT map the slot-splice MUST
-;; produce on top of the empty envelope `{}`. Drift in the helper's
-;; semantics (e.g. a future "include zero as `:dropped-sensitive 0`"
-;; regression) trips this grid.
-;; ---------------------------------------------------------------------------
-
-(def ^:private fixture-grid
-  [;; --- both zero — no slots, envelope unchanged ----------------------
-   {:label    "neither slot present when both counts are zero"
-    :dropped  0
-    :elided   0
-    :expected {}}
-
-   ;; --- both nil — defensive — treated as zero -------------------------
-   {:label    "neither slot present when both counts are nil"
-    :dropped  nil
-    :elided   nil
-    :expected {}}
-
-   ;; --- dropped only ---------------------------------------------------
-   {:label    "only :dropped-sensitive present when only dropped > 0"
-    :dropped  3
-    :elided   0
-    :expected {:dropped-sensitive 3}}
-
-   {:label    "only :dropped-sensitive present when elided is nil"
-    :dropped  1
-    :elided   nil
-    :expected {:dropped-sensitive 1}}
-
-   ;; --- elided only ----------------------------------------------------
-   {:label    "only :elided-large present when only elided > 0"
-    :dropped  0
-    :elided   2
-    :expected {:elided-large 2}}
-
-   {:label    "only :elided-large present when dropped is nil"
-    :dropped  nil
-    :elided   7
-    :expected {:elided-large 7}}
-
-   ;; --- both positive --------------------------------------------------
-   {:label    "both slots present when both counts > 0"
-    :dropped  4
-    :elided   11
-    :expected {:dropped-sensitive 4 :elided-large 11}}
-
-   ;; --- large counts pass through verbatim -----------------------------
-   {:label    "counts preserved verbatim (no coercion / clamping)"
-    :dropped  10000
-    :elided   99999
-    :expected {:dropped-sensitive 10000 :elided-large 99999}}])
-
-;; ---------------------------------------------------------------------------
-;; Gate (b) + (c) — semantic contract: omit-when-zero AND
-;; value-passes-through.
-;; ---------------------------------------------------------------------------
-
-(deftest indicator-helper-semantics
-  (doseq [{:keys [label dropped elided expected]} fixture-grid]
-    (testing label
-      (let [result (with-indicators {} {:dropped dropped :elided elided})]
-        (is (= expected result)
-            (str "Helper result mismatch for " label
-                 " — got " (pr-str result)
-                 ", expected " (pr-str expected)))))))
-
-(deftest indicator-helper-preserves-envelope-shape
-  ;; The helper MUST be additive — it splices slots onto an existing
-  ;; envelope without dropping its own keys. Critical because every
-  ;; tool calls `(with-indicators <full-envelope> indicators)` where
-  ;; `<full-envelope>` carries the tool's own keys (`:ok?`,
-  ;; `:snapshot`, `:epochs`, ...).
-  (let [envelope {:ok? true :snapshot {:foo :bar} :extra "string"}
-        result   (with-indicators envelope {:dropped 1 :elided 2})]
-    (is (= true (:ok? result)))
-    (is (= {:foo :bar} (:snapshot result)))
-    (is (= "string" (:extra result)))
-    (is (= 1 (:dropped-sensitive result)))
-    (is (= 2 (:elided-large result)))))
-
-;; ---------------------------------------------------------------------------
-;; Schema gate — when present, the slots conform to the canonical
-;; envelope shape (open map, `pos-int?` value). A regression that
-;; serialised the count as a string or as `0` would trip here.
-;; ---------------------------------------------------------------------------
-
-(deftest indicator-fixtures-conform-to-canonical-schema
-  (doseq [{:keys [label expected]} fixture-grid
-          :when (contains? expected :dropped-sensitive)]
-    (testing (str "dropped-sensitive schema — " label)
-      (is (m/validate DroppedSensitive expected)
-          (str "Fixture " expected " failed DroppedSensitive schema"))))
-  (doseq [{:keys [label expected]} fixture-grid
-          :when (contains? expected :elided-large)]
-    (testing (str "elided-large schema — " label)
-      (is (m/validate ElidedLarge expected)
-          (str "Fixture " expected " failed ElidedLarge schema")))))
-
-;; ---------------------------------------------------------------------------
-;; Gate (a) — tree-walking-tool routing pin.
+;; Tree-walking-tool routing pin.
 ;;
 ;; The catalogue below lists every re-frame2-pair-mcp tool that walks a
 ;; tree-typed payload (per Spec 009:1411 — "one MUST-level row per
@@ -269,52 +125,27 @@
              "without indicator counts."))))
 
 ;; ---------------------------------------------------------------------------
-;; Helper-source pin — the simulation above MUST stay byte-faithful
-;; with the canonical helper. We grep the helper source for the
-;; canonical `cond->` shape; a rename / re-implementation surfaces here
-;; so the reviewer updates the simulation alongside the helper.
-;;
-;; The canonical helper was HOISTED out of pair-mcp into the shared
-;; `mcp-base.envelope` namespace (rf2-ee38b.19) so the single emit-path
-;; the spec mandates lives in one CLJC place the conformance gate can
-;; test directly, and so both servers in the pair re-export the same
-;; rule. The hoisted form keys the splice off `vocab/dropped-sensitive-key`
-;; / `vocab/elided-large-key` (the canonical keyword literals defined
-;; once in `mcp-base.vocab`) rather than re-spelling the bare keywords;
-;; that vocab pin is covered by `slot_name_test.clj`. pair-mcp's
-;; `wire.cljs` now keeps a thin re-export `with-indicators` so the
-;; per-tool call-sites still read `wire/with-indicators` (the
-;; `every-tree-walking-tool-routes-through-the-helper` pin above).
+;; Pair-mcp delegation pin — the per-tool call-sites read
+;; `wire/with-indicators` (the pair-local namespace the tools already
+;; require), but the RULE BODY lives ONCE in mcp-base. The canonical helper
+;; was HOISTED out of pair-mcp into the shared `mcp-base.envelope`
+;; namespace (rf2-ee38b.19) so the single emit-path the spec mandates lives
+;; in one CLJC place — and its semantics are unit-tested directly there
+;; (`envelope_test.clj`), not re-simulated here. pair-mcp's `wire.cljs`
+;; keeps a thin re-export `with-indicators` that delegates to the base, so
+;; the per-tool call-sites still read `wire/with-indicators` (the routing
+;; pin above) while the omit-when-zero MUST stays centralised. This pin
+;; asserts that re-export still exists and still delegates — a regression
+;; that re-inlined the rule (forking the emit-path across servers) trips
+;; here. The story-mcp delegation pin is the sibling
+;; `story-mcp-routes-envelope-through-the-centralised-helper` in
+;; `wire_vocab_test.clj`.
 ;; ---------------------------------------------------------------------------
-
-(def ^:private helper-source-rel
-  "tools/mcp-base/src/re_frame/mcp_base/envelope.cljc")
 
 (def ^:private pair-mcp-reexport-rel
   "tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire.cljs")
 
-(deftest helper-source-shape-matches-simulation
-  (let [src (fx/read-source helper-source-rel)]
-    (testing "canonical helper defines `with-indicators`"
-      (is (str/includes? src "(defn with-indicators")
-          (str "`with-indicators` defn missing from " helper-source-rel)))
-    (testing "helper guards :dropped-sensitive on pos? dropped"
-      (is (str/includes? src "(pos? (or dropped 0)) (assoc vocab/dropped-sensitive-key dropped)")
-          (str "Canonical omit-when-zero shape for `:dropped-sensitive` "
-               "drifted from the simulation in this file. If you changed "
-               "the helper, update the simulation here in lockstep.")))
-    (testing "helper guards :elided-large on pos? elided"
-      (is (str/includes? src "(pos? (or elided  0)) (assoc vocab/elided-large-key      elided)")
-          (str "Canonical omit-when-zero shape for `:elided-large` "
-               "drifted from the simulation in this file. If you changed "
-               "the helper, update the simulation here in lockstep.")))))
-
 (deftest pair-mcp-wire-re-exports-the-canonical-helper
-  ;; The per-tool call-sites read `wire/with-indicators` (the pair-local
-  ;; namespace they already require); the rule body lives in mcp-base.
-  ;; This pins that the re-export still exists and delegates to the base
-  ;; — a regression that re-inlined the rule (forking the emit-path)
-  ;; trips here.
   (let [src (fx/read-source pair-mcp-reexport-rel)]
     (testing "pair-mcp wire.cljs re-exports `with-indicators`"
       (is (str/includes? src "(defn with-indicators")
@@ -451,6 +282,6 @@
 ;; surface to pin here. If a future MCP server reintroduces a
 ;; tree-walking surface, extend `tree-walking-tool-sources` and
 ;; `inline-emit-whitelist` above (or add a parallel pair) to cover
-;; it; the helper-source pin and the re-frame2-pair-mcp gates are the live
-;; reference.
+;; it; the re-frame2-pair-mcp gates + the mcp-base helper unit tests are
+;; the live reference.
 ;; ---------------------------------------------------------------------------

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab/schemas.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab/schemas.clj
@@ -410,8 +410,9 @@
 ;; they are scalar envelope-level summaries of how many walker
 ;; suppressions happened per call. The conformance contract: both slots
 ;; ride alongside every tool that walks a tree-typed payload, the keys
-;; are unqualified (no namespace), and the values are non-negative
-;; integers.
+;; are unqualified (no namespace), and — because the omit-when-zero MUST
+;; turns a zero count into an ABSENT key — a PRESENT value is always a
+;; POSITIVE integer (`pos-int?`, never `0`).
 ;; ---------------------------------------------------------------------------
 
 (def DroppedSensitive
@@ -419,14 +420,22 @@
   the walker dropped because they matched `:sensitive? true`. Open map
   so it composes with any tool's envelope shape; the load-bearing
   claim is the slot KEY (`:dropped-sensitive`, unqualified) and the
-  value's `nat-int?` type."
-  [:map {:closed false} [:dropped-sensitive nat-int?]])
+  value's `pos-int?` type.
+
+  `pos-int?`, NOT `nat-int?`: the production emit-path
+  (`re-frame.mcp-base.envelope/with-indicators`) enforces the MUST-level
+  omit-when-zero rule — a zero count OMITS the slot entirely (the key is
+  absent), so a PRESENT `:dropped-sensitive 0` can only be a regression
+  that bypassed the helper. The schema rejects it (the present-zero
+  rejection lives next to the canonical fixtures in `wire_vocab_test.clj`)."
+  [:map {:closed false} [:dropped-sensitive pos-int?]])
 
 (def ElidedLarge
   "`{... :elided-large N}` envelope slot — integer count of leaves the
   walker replaced with the `:rf.size/large-elided` marker. Same
-  shape contract as `:dropped-sensitive`."
-  [:map {:closed false} [:elided-large nat-int?]])
+  shape contract as `:dropped-sensitive` — `pos-int?`, so a present zero
+  (which the omit-when-zero production path never emits) is rejected."
+  [:map {:closed false} [:elided-large pos-int?]])
 
 ;; ---------------------------------------------------------------------------
 ;; Canonical-marker index. The ordered set of cross-MCP markers; each

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
@@ -1195,8 +1195,11 @@
 ;; Conformance contract:
 ;;
 ;; 1. Schema-level: both envelope slots validate as
-;;    `[:map {:closed false} [<slot> nat-int?]]`. Fixtures sourced from
-;;    each emitting server.
+;;    `[:map {:closed false} [<slot> pos-int?]]` — a PRESENT slot is
+;;    always a positive count (the omit-when-zero MUST turns a zero into
+;;    an absent key, so a present `0` is a rejected regression, pinned by
+;;    `envelope-indicator-present-zero-rejected` below). Fixtures sourced
+;;    from each emitting server.
 ;; 2. Source-text pin: every server in `:envelope-emitters` carries
 ;;    BOTH the `:dropped-sensitive` literal AND the `:elided-large`
 ;;    literal (parity — one without the other is the round-2 audit
@@ -1277,6 +1280,29 @@
           (str "Fixture " fixture-name " for " slot
                " failed schema validation:\n"
                (me/humanize (m/explain schema fixture-value)))))))
+
+(deftest envelope-indicator-present-zero-rejected
+  ;; The negative counterpart to `envelope-indicator-fixtures-conform`
+  ;; (which pins that the positive fixtures are ACCEPTED). The
+  ;; omit-when-zero MUST (Conventions §Cross-MCP indicator-field
+  ;; vocabulary / Spec 009 §Indicator field on tool responses) says a ZERO
+  ;; count is OMITTED — the slot key never appears on the wire. The
+  ;; production emit-path (`re-frame.mcp-base.envelope/with-indicators`)
+  ;; enforces exactly that (`(pos? (or count 0))`), so a PRESENT
+  ;; `:dropped-sensitive 0` / `:elided-large 0` can only be a regression
+  ;; that bypassed the helper. The canonical schema is `pos-int?`
+  ;; (rf2-tdn6oi) precisely so it REJECTS the present-zero shape rather
+  ;; than blessing it — the schema must not be looser than the
+  ;; omit-when-zero production contract (the pre-fix `nat-int?` accepted a
+  ;; present zero, the accepts-zero bug this pins the fix for).
+  (doseq [{:keys [slot schema]} envelope-indicator-slots]
+    (testing (str "present-zero " slot " ⇒ schema REJECTS (omit-when-zero, not zero-emit)")
+      (is (not (m/validate schema {slot 0}))
+          (str "Canonical schema for " slot " ACCEPTED a present zero {" slot " 0} — "
+               "the omit-when-zero MUST means a zero count is OMITTED, never "
+               "emitted as `" slot " 0`. The schema must be `pos-int?` (not "
+               "`nat-int?`) so a helper-bypassing present-zero regression fails "
+               "conformance.")))))
 
 (def ^:private envelope-emitter-source-files
   "Source files that carry the envelope-slot emit sites per server.


### PR DESCRIPTION
Two clustered mcp-conformance dedup beads, disjoint files, one PR (two logical commits).

## rf2-phveub — one shared live-test inventory (Node)
`run-re-frame2-pair-live-hermetic-suite.cjs` and `test-all.cjs` independently declared the same six live gates, and `live-list-completeness.test.cjs` existed mainly to ratchet the two lists back into agreement.

- New side-effect-free `scripts/live-test-inventory.cjs` owns each live gate's basename + display name + success sentinel ONCE (rich per-gate rationale comments moved here).
- The hermetic runner resolves basenames to absolute `INNER_TESTS` paths; `test-all.cjs` derives its SKIP-by-default live rows from the same array. Both runners now DERIVE from the inventory — they can no longer drift from each other.
- `live-list-completeness.test.cjs` reduced to disk-versus-one-inventory, retaining the empty-glob, missing-file, and dangling-entry failure cases.
- Dropped the now-unused `INNER_TESTS` export.

## rf2-tdn6oi — dedup indicator conformance + schema bugfix (JVM)
`indicator_field_test.clj` mirrored the mcp-base `with-indicators` helper with a private pure-Clojure simulation, a duplicated fixture grid, duplicate `DroppedSensitive`/`ElidedLarge` schema records, and an exact-source-shape grep.

- Deleted the helper mirror, fixture grid, duplicate schema records, and source-shape grep. The file is now focused on cross-consumer ROUTING, the pair-mcp delegation pin, and the no-inline-emission checks.
- Single owners after dedup: helper semantics → mcp-base `envelope_test.clj`; slot schemas → `wire-vocab/schemas.clj` + `wire_vocab_test.clj`.

### Bug fix — accepts-zero
The canonical `DroppedSensitive`/`ElidedLarge` schemas in `wire-vocab/schemas.clj` used `nat-int?`, so they ACCEPTED a present `:dropped-sensitive 0` / `:elided-large 0` despite the documented omit-when-zero contract that the production `with-indicators` helper (`(pos? (or count 0))`) enforces. The duplicate copy in the conformance test already used `pos-int?`, so deleting the duplicate without tightening the canonical would have silently lost that strictness. Tightened the canonical to `pos-int?` and added an explicit present-zero REJECTION test next to the canonical fixtures. MCP is an AI-egress surface — the omit-when-zero indicator is a privacy/correctness boundary, so the schema must not be looser than production.

## Preflight (verified each duplication before deleting)
- Helper semantics (omit-when-zero / passthrough / vocab-keys) confirmed owned by mcp-base `envelope_test.clj` `with-indicators-omits-zero-counts` + `with-indicators-uses-vocab-keys`.
- Positive-fixture schema conformance confirmed owned by `wire_vocab_test.clj` `envelope-indicator-fixtures-conform`; all its fixtures are positive, so `pos-int?` is safe.
- Canonical schema symbols referenced only within the wire-vocab test tree; `INNER_TESTS` imported only by the completeness test being rewritten.
- One correction to the brief: the canonical indicator schemas live in `tools/mcp-conformance/wire-vocab`, NOT `tools/mcp-base`. mcp-base holds only the `with-indicators` helper and was not modified.

## Quality gates (foreground, 0 failures)
- `npm run test:unit` (mcp-conformance pure-Node cluster) — 88 tests, 79 pass, 0 fail, 9 pre-existing SKIP (Windows symlink); includes the 3 rewritten completeness tests. Require-sanity confirmed 6 inventory → 6 hermetic INNER_TESTS + 6 test-all live rows; a live row SKIPs cleanly.
- `clojure -M:test` in `tools/mcp-conformance/wire-vocab` — 100 tests, 1059 assertions, 0 failures (tightened schemas + present-zero rejection + trimmed indicator test).
- `clojure -M:test` in `tools/mcp-base` — 266 tests, 877 assertions, 0 failures (helper-semantics owner intact).
- Full `npm test`/live/hermetic gates are dedicated CI jobs (need built server bundles + shadow-cljs + Chromium); `test:unit` is the Node PR gate and covers all three modified Node modules.

## Stance
Pre-alpha, no back-compat shims; ELEGANCE + CLARITY + CORRECTNESS + GOOD-PRACTICE. Test-only changes — no production wire/descriptor touched, no MCP payload change.

Closes rf2-phveub, rf2-tdn6oi.