### PR TITLE
fix(examples): install RealWorld bearer-auth interceptor within frame scope — fixes no-frame-context (rf2-9ynwvx)

### DIFF
--- a/examples/real-apps/realworld_http/core.cljs
+++ b/examples/real-apps/realworld_http/core.cljs
@@ -540,8 +540,20 @@
   ;; `Authorization` header onto outbound managed requests. Order matters:
   ;; register it before the frame's `:initial-events` run, so it's already on
   ;; duty when session-restore fires its first authenticated request.
-  (rf/reg-http-interceptor :realworld/bearer-auth
-                           {:before bearer-auth-interceptor})
+  ;;
+  ;; HTTP-interceptor registration is context-required frame-local (EP-0002 /
+  ;; Spec 014 §Middleware): each frame owns its own middleware chain, so the
+  ;; registration has to name the frame it belongs to. A bare top-level
+  ;; `reg-http-interceptor` under no frame scope raises the always-on
+  ;; `:rf.error/no-frame-context` and installs nothing. We scope it to the app
+  ;; frame (`:rf/default` — the same id the `frame-provider` below ensures)
+  ;; with `with-frame`, so the interceptor lands on the chain the app's managed
+  ;; requests actually run under. The frame need not exist yet — the chain is
+  ;; keyed by frame-id and consulted when the first request fires. See the auth
+  ;; how-to: ../../../docs/core/how-to/add-auth.md#3-decorate-requests-once-at-the-frame-seam
+  (rf/with-frame :rf/default
+    (rf/reg-http-interceptor :realworld/bearer-auth
+                             {:before bearer-auth-interceptor}))
   ;; Hang the conformance accessor on the window for the external RealWorld
   ;; suite. Test seam, not a pattern — see install-conduit-debug! above.
   (install-conduit-debug! :rf/default)

--- a/examples/real-apps/realworld_resources/core.cljs
+++ b/examples/real-apps/realworld_resources/core.cljs
@@ -260,8 +260,20 @@
   ;; `:initial-events` dispatch. Timing matters: session-restore fires an
   ;; authenticated `GET /user` the moment the JWT is hydrated, so the header has
   ;; to be wired up before `:auth/initialise` runs at frame creation (below).
-  (rf/reg-http-interceptor :realworld/bearer-auth
-                           {:before bearer-auth-interceptor})
+  ;;
+  ;; HTTP-interceptor registration is context-required frame-local (EP-0002 /
+  ;; Spec 014 §Middleware): each frame owns its own middleware chain, so the
+  ;; registration must name the frame it belongs to. A bare top-level
+  ;; `reg-http-interceptor` under no frame scope raises the always-on
+  ;; `:rf.error/no-frame-context` and installs nothing. We scope it to
+  ;; `app-frame` (the same id the `frame-provider` below ensures) with
+  ;; `with-frame`, so the interceptor lands on the chain this app's resources /
+  ;; mutations actually lower onto. The frame need not exist yet — the chain is
+  ;; keyed by frame-id and consulted when the first managed request fires. See
+  ;; the auth how-to: ../../../docs/core/how-to/add-auth.md#3-decorate-requests-once-at-the-frame-seam
+  (rf/with-frame app-frame
+    (rf/reg-http-interceptor :realworld/bearer-auth
+                             {:before bearer-auth-interceptor}))
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))

--- a/implementation/http/test/re_frame/http_interceptors_cljs_test.cljs
+++ b/implementation/http/test/re_frame/http_interceptors_cljs_test.cljs
@@ -73,6 +73,45 @@
                (:rf.error/id (ex-data thrown)))
             "the throw is the always-on :rf.error/no-frame-context — no :rf/default floor")))))
 
+;; ---- 1b. rf2-9ynwvx — reg within with-frame installs; bare reg fails closed
+;;
+;; The RealWorld example apps (examples/real-apps/realworld_{http,resources})
+;; registered the bearer-auth interceptor with a BARE top-level
+;; `(reg-http-interceptor id {:before …})` in their boot `run` — no ambient
+;; frame scope, no `:frame` — which raises the always-on
+;; `:rf.error/no-frame-context` (EP-0002 context-required frame-local) and
+;; installs NOTHING, silently dropping the Authorization header from every
+;; authenticated request. The fix scopes the reg to the app frame with
+;; `with-frame`. This pins both halves of that contract on the registration
+;; surface (the fixture's ambient `*current-frame* :rf/default` masks the
+;; bare-call raise, so we strip it): (a) a bare reg under no scope fails
+;; closed and installs nothing; (b) `(with-frame f (reg-http-interceptor …))`
+;; installs on f's chain even when f was never `reg-frame`d — the example
+;; registers before the frame-provider ensures the frame.
+
+(deftest reg-http-interceptor-bare-fails-closed-with-frame-installs-rf2-9ynwvx
+  (testing "rf2-9ynwvx — a bare reg under no ambient scope raises
+            :rf.error/no-frame-context and installs nothing; a
+            (with-frame f …) reg installs on f's chain (the RealWorld fix)"
+    (binding [frame/*current-frame* nil]
+      ;; (a) reproduce the example bug: bare reg with no scope fails closed.
+      (let [thrown (try (rf/reg-http-interceptor :realworld/bearer-auth
+                          {:before (fn [c] c)})
+                        nil
+                        (catch :default e e))]
+        (is (some? thrown) "bare reg under no ambient scope must throw")
+        (is (= :rf.error/no-frame-context (:rf.error/id (ex-data thrown)))
+            "the throw is the always-on :rf.error/no-frame-context — nothing installed")
+        (is (empty? (http-managed/interceptors-snapshot :realworld/app))
+            "no slot landed on the app-frame chain"))
+      ;; (b) the fix: with-frame supplies the frame context, so the reg lands
+      ;; on :realworld/app's chain even though it was never `reg-frame`d.
+      (rf/with-frame :realworld/app
+        (rf/reg-http-interceptor :realworld/bearer-auth {:before (fn [c] c)}))
+      (is (= [:realworld/bearer-auth]
+             (mapv :id (http-managed/interceptors-snapshot :realworld/app)))
+          "with-frame scoped the reg onto the app frame's chain (the example fix)"))))
+
 ;; ---- 2. registration order is preserved -----------------------------------
 
 (deftest registration-order-preserved

--- a/implementation/http/test/re_frame/http_interceptors_test.clj
+++ b/implementation/http/test/re_frame/http_interceptors_test.clj
@@ -120,6 +120,72 @@
             "the server saw the Authorization header the interceptor injected")
         (finally (stop-server! srv))))))
 
+;; ---- 1a. rf2-9ynwvx — reg within with-frame installs; bare reg fails closed
+;;
+;; The RealWorld example apps (examples/real-apps/realworld_{http,resources})
+;; registered the bearer-auth interceptor with a BARE top-level
+;; `(reg-http-interceptor id {:before …})` in their boot `run` — no ambient
+;; frame scope, no `:frame` override — which raises the always-on
+;; `:rf.error/no-frame-context` (EP-0002 context-required frame-local) and
+;; installs NOTHING, so every authenticated request silently lost its
+;; `Authorization` header. The fix scopes the registration to the app frame
+;; with `(with-frame :rf/default …)`. This test pins BOTH halves of that
+;; contract end-to-end — the fixture's ambient `*current-frame* :rf/default`
+;; masks the bare-call raise, so we strip it with `binding … nil`:
+;;   (a) a bare reg under no scope fails closed and installs nothing;
+;;   (b) `(with-frame :rf/default …)` installs on the frame's chain AND the
+;;       `:before` reaches the wire — an authenticated request carries the
+;;       `Authorization` header the interceptor stamped.
+
+(deftest reg-within-with-frame-installs-and-header-reaches-wire-rf2-9ynwvx
+  (testing "rf2-9ynwvx — bare reg under no scope raises + installs nothing; a
+            (with-frame :rf/default …) registration lands the Authorization
+            header on the wire (the RealWorld example bearer-auth fix)"
+    (let [seen-auth (atom nil)
+          {:keys [port] :as srv}
+          (start-server!
+            (fn [^HttpExchange ex]
+              (reset! seen-auth (header-of ex "Authorization"))
+              (write-response! ex 200 "application/json" "{\"ok\":true}")))]
+      (try
+        ;; (a) reproduce the example bug: bare reg under NO ambient scope
+        ;; fails closed and installs nothing.
+        (binding [frame/*current-frame* nil]
+          (let [thrown (try (rf/reg-http-interceptor :realworld/bearer-auth
+                              {:before identity})
+                            nil
+                            (catch clojure.lang.ExceptionInfo e e))]
+            (is (some? thrown)
+                "a bare reg-http-interceptor under no frame scope must throw")
+            (is (= :rf.error/no-frame-context (:rf.error/id (ex-data thrown)))
+                "the throw is the always-on :rf.error/no-frame-context")
+            (is (empty? (http-managed/interceptors-snapshot :rf/default))
+                "nothing was installed on the :rf/default chain"))
+          ;; (b) the fix: with-frame supplies the frame context, so the reg
+          ;; installs on :rf/default even under no ambient scope.
+          (rf/with-frame :rf/default
+            (rf/reg-http-interceptor :realworld/bearer-auth
+              {:before (fn [ctx]
+                         (assoc-in ctx [:request :headers "Authorization"]
+                                   "Token stub.demo.jwt"))})))
+        (is (= [:realworld/bearer-auth]
+               (mapv :id (http-managed/interceptors-snapshot :rf/default)))
+            "with-frame scoped the reg onto the app frame's chain (the fix)")
+        ;; (c) an authenticated request from that frame carries the header the
+        ;; interceptor stamped — proving the fix actually decorates the wire.
+        (rf/reg-event :load
+          (fn [{:keys [db]} [_ msg reply]]
+            (if reply
+              {:db (assoc db :reply reply)}
+              {:fx [[:rf.http/managed
+                     {:reply-to [:load msg] :request {:url (str "http://127.0.0.1:" port "/secured")}
+                      :decode  :json}]]})))
+        (rf/dispatch-sync [:load])
+        (await-reply! #(some? (:reply %)) 5000)
+        (is (= "Token stub.demo.jwt" @seen-auth)
+            "the with-frame-registered interceptor stamped Authorization on the wire")
+        (finally (stop-server! srv))))))
+
 ;; ---- 2. multi-interceptor chain order -------------------------------------
 
 (deftest multi-interceptor-runs-in-registration-order


### PR DESCRIPTION
## What

Both RealWorld example apps registered the Bearer-auth HTTP interceptor with a **bare top-level** `(rf/reg-http-interceptor :realworld/bearer-auth {:before …})` in their boot `run` — no ambient frame scope, no `:frame` override.

Per **EP-0002 / Spec 014 §Middleware**, HTTP-interceptor registration is *context-required frame-local*: a bare call under no scope raises the always-on `:rf.error/no-frame-context` and installs **nothing**. Result: every authenticated request silently lost its `Authorization` header (a P1 correctness bug for any real Conduit backend).

## Fix

Scope each registration to the app frame with `with-frame` — the canonical shape from `docs/core/how-to/add-auth.md` §3:

- `examples/real-apps/realworld_http/core.cljs` — `(rf/with-frame :rf/default (rf/reg-http-interceptor …))`
- `examples/real-apps/realworld_resources/core.cljs` — `(rf/with-frame app-frame (rf/reg-http-interceptor …))`

Both target the same id the `frame-provider` ensures, so the interceptor lands on the chain the app's managed requests actually run under. **Interceptor logic is unchanged** — only its registration is scoped so it installs. The frame need not exist yet at boot: the chain is keyed by frame-id and consulted when the first request fires (registration precedes the frame-provider render, exactly as the apps intend for session-restore's first authenticated `GET /user`). Boot comments updated to explain the frame-scope requirement and cite the auth how-to.

## Reproduce → fix (evidence)

Executed the exact failing shape (`init!` then the bare/scoped reg) against the plain-atom substrate:

```
=== BARE call under no scope ===          result: :rf.error/no-frame-context   installed?: false
=== within (with-frame :rf/default …) === result: :installed-no-error          installed?: true   chain: [:realworld/bearer-auth]
```

`with-frame` installs on the frame-id chain **even when the frame does not yet exist** (verified: `frame exists before with-frame? false` → `installed? true`) — the example boot scenario.

## Regression coverage

Examples are test-free, so coverage was added to the **http artefact's contract tests**, exercising the real `reg-http-interceptor`-in-frame path (the fixture's ambient `*current-frame*` is stripped so the bare-call raise is not masked):

- `implementation/http/test/re_frame/http_interceptors_test.clj` (JVM) — bare reg fails closed + installs nothing; a `(with-frame :rf/default …)` reg installs **and the `Authorization` header reaches the wire** (real HTTP-server harness).
- `implementation/http/test/re_frame/http_interceptors_cljs_test.cljs` (CLJS) — registry-level: bare reg fails closed; `(with-frame f …)` installs on `f`'s chain.

## Quality gates

- `implementation/http` JVM contract test — **470 tests, 3674 assertions, 0 failures, 0 errors** (+5 new assertions).
- `npx shadow-cljs compile examples/realworld examples/realworld-resources` — **both builds completed, 0 warnings**. No `:rf.error/no-frame-context` at boot.
- `npm run test:cljs` — **8467 tests, 39163 assertions, 0 failures, 0 errors**.

## Stance

Pre-alpha, no back-compat; ELEGANCE + CLARITY + CORRECTNESS + GOOD-PRACTICE. Examples kept idiomatic (app-db + events + subs; no hacks) — the fix uses the framework's own documented frame-scope idiom.
