### PR TITLE
docs(core): clarify current runtime contracts (rf2-ytwltp)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -789,21 +789,9 @@
 
 ;; ---- frame management ----------------------------------------------------
 
-;; EP-0024 (rf2-tu2vr7): `rf/make-frame` is the ONE public frame constructor.
-;; It backs onto `re-frame.live-frame/make-frame` — the unified constructor over
-;; the ONE `frames` registry — which accepts BOTH image-selection opts
-;; (`:images` / `:id` / `:adapter`) AND
-;; record-config opts (`:initial-events` / `:fx-overrides` / `:platform` / `:ssr` /
-;; `:doc` / `:preset` / `:tags` / …) in ONE call, and returns the frame VALUE.
-;;
-;; EP-0024 adopts the previously-deferred option-(a) and REVERSES the
-;; rf2-32siq3.45 option-(b) fail-loud redirect (the
-;; `:rf.error/make-frame-record-only-key` guard that rejected record-config keys
-;; on the object constructor): the unified single frame value backed by the one
-;; registry removes the two-constructor split that motivated the redirect, so a
-;; record-config key is now honoured, not rejected. The advanced
-;; `re-frame.frame/make-anon-frame-record!` is demoted to an INTERNAL no-`:id` record helper —
-;; it is not facade-exported (`rf/make-frame` is the public path).
+;; `rf/make-frame` is the one public constructor. It accepts image-selection
+;; options and record configuration in the same map, registers id-bearing
+;; frames in the shared frame registry, and returns the live frame value.
 
 (defn make-frame
   "Create a live frame and return the frame VALUE — the ONE public constructor
@@ -829,8 +817,7 @@
                    policy). This IS re-construction — the Clojure re-def model
                    (there is no `redef!` / `reset-def!` / `reload-def!`): image
                    hot-reload is re-`make-frame`-ing the SAME `:id` with a NEW
-                   `:images` vector (rf2-lxwpob folded the dedicated
-                   `reload-images!` verb into this — diff the swap by reading
+                   `:images` vector. Diff the swap by reading
                    `frame-generation` before/after and comparing with
                    `generation-diff`). When ABSENT, the frame is LOCAL-ONLY —
                    keep the returned value and pass it (or its id) to
@@ -847,8 +834,7 @@
   app-db with `[[:rf/set-db {…}]]`; EP-0027), `:fx-overrides`, `:platform`,
   `:ssr`, `:doc`, `:preset`, `:tags`, the EP-0015 classification keys, etc. So
   `(rf/make-frame {:id :todo/left :images [todo-image] :fx-overrides {...}})`
-  configures the frame in one call (EP-0024 adopts option-(a) and reverses the
-  rf2-32siq3.45 option-(b) record-only-key fail-loud redirect).
+  configures the frame in one call.
 
   Returns the frame VALUE — the live lifecycle token (its representation is not
   an app-facing data contract). The frame is fully runnable: `dispatch` /
@@ -966,16 +952,12 @@
 
 ;; ---- dispatch and subscribe ----------------------------------------------
 ;;
-;; Each surface ships as a JVM-only macro (`dispatch` / `dispatch-sync` /
-;; `subscribe`, captures call-site coords) whose expansion reaches straight
-;; through to the OWNING ns fn (`re-frame.router/dispatch!` /
-;; `-dispatch-sync!`, `re-frame.subs/subscribe`) — Convention A (rf2-m90brg):
-;; on CLJS the SAME base name also carries a same-name `def`-alias to that
-;; owning fn (above, in the `#?(:cljs (do ...))` block) for HoF / programmatic
-;; callers, mirroring `reg-event` / `reg-sub` / etc. There is no `*`-suffixed
-;; twin — a with-redefs stub reaches `re-frame.router/dispatch!` /
-;; `-dispatch-sync!` / `re-frame.subs/subscribe` directly (the macro
-;; expansion's actual call target), not a `re-frame.core` indirection.
+;; Each surface has a JVM macro that captures call-site coordinates and a CLJS
+;; value alias for higher-order/programmatic calls. Macro expansions target
+;; the stable `^:no-doc` `dispatch-impl`, `dispatch-sync-impl`, or
+;; `subscribe-impl` alias. Those aliases point at the owning router/subs fn but
+;; prevent CLJS fixed-arity metadata from making differently shaped
+;; `with-redefs` test seams unsafe. There is no public `*`-suffixed twin.
 
 ;; API-shrink #1 (rf2-csbbwu): frame targeting is exactly THREE intents —
 ;; ambient SCOPE (no `:frame` opt; reads the carried `with-frame` /
@@ -1373,22 +1355,10 @@
 
 ;; ---- routing helpers ------------------------------------------------------
 ;;
-;; The routing URL-codec + lifecycle QUERY helpers `match-url` / `route-url`
-;; / `current-url` / `clear-route` are NO LONGER re-exported from
-;; `re-frame.core` (rf2-wad2fl — front-porch shrink). They are optional-
-;; routing-feature reads whose owned namespace is the better public home:
-;; reach them through `re-frame.routing` (which already publishes them). The
-;; `reg-route` REGISTRATION MACRO stays on the façade (above; source-coord
-;; capture, no owned-ns macro form). `route-link` (the view) stays on the
-;; façade for now — it has no classified owned-namespace peer (the routing-ns
-;; form is CLJS-only and unrowed).
-;;
-;; rf2-g8pbwg: the `install-url-listener!` / `remove-url-listener!` /
-;; `install-history-listener!` / `remove-history-listener!` boot seams are
-;; GONE from this façade (and from `re-frame.routing`'s) — a `:url-bound?
-;; true` frame installs its strategy listener on create and removes it on
-;; destroy, automatically. Pre-alpha, no back-compat shim; see
-;; `re-frame.routing.history`'s ns docstring THE FOLD note.
+;; `reg-route` remains on the facade for macro-time source-coordinate capture;
+;; `route-link` is its view counterpart. URL codec and lifecycle queries live
+;; in `re-frame.routing`. A `:url-bound? true` frame owns its strategy listener:
+;; construction installs it and frame destruction removes it.
 
 (def ^{:doc "Registered view at `:route/link` — renders an `<a href=...>`
   from a route-id and intercepts plain primary-button clicks to dispatch
@@ -1399,26 +1369,11 @@
 
 ;; ---- machine helpers ------------------------------------------------------
 ;;
-;; The machine REGISTRATION (`reg-machine*` plain fn), HANDLER-BUILD
-;; (`make-machine-handler`), pure-engine (`machine-transition`), and QUERY
-;; (`machines`, `machine-meta`, `machine-by-system-id`) helpers are NO LONGER
-;; re-exported from `re-frame.core` (rf2-wad2fl — front-porch shrink). They
-;; are optional-machines-feature surfaces whose owned namespace is the better
-;; public home: reach them through `re-frame.machines` (which already
-;; publishes them). The `reg-machine` / `defmachine` REGISTRATION MACROS stay
-;; on the façade (above; per-element source-coord stamping, no owned-ns macro
-;; form). The `machine-has-tag?` and `sub-machine` subscription-sugar fns
-;; were REMOVED (rf2-il99l3, reversing rf2-2cmcas): a runtime-db framework
-;; read is a subscription VECTOR — `(subscribe [:rf.machine/has-tag?
-;; machine-id tag])` / `(subscribe [:rf/machine machine-id])` — one read
-;; grammar, the same spelling `:<-` chained inputs and the machine-selector
-;; recognizer already require (a sugar fn can never ride inside a `:<-`
-;; vector, so it could only ever duplicate the vector, never replace it).
-;; The `dispatch-to-system` FN is DEMOTED off the façade (rf2-gkt25a /
-;; rf2-80mmlf — exactly one in-repo caller): the canonical action-side
-;; messaging surface is the reserved `[:rf.machine/dispatch-to-system
-;; [system-id event]]` fx tuple; the direct-call FN now lives in
-;; `re-frame.machines` as an implementation-tier helper.
+;; Machine registration macros stay on the facade for source-coordinate
+;; capture. Plain registration, engine, query, and implementation helpers live
+;; in `re-frame.machines`. Machine state reads use subscription vectors; the
+;; canonical action-side named-message surface is the
+;; `[:rf.machine/dispatch-to-system [system-id event]]` effect.
 
 ;; ---- resource helpers (Spec 016) ------------------------------------------
 ;;
@@ -1850,11 +1805,8 @@
   "Return the current `app-db` VALUE (a plain map) for the named frame,
   or `nil` if not registered. Value-form accessor (no deref, no
   container) — pairs with `app-db-container` (the container accessor).
-  Per Spec 002 §The public registrar query API.
-
-  EP-0023 (rf2-32siq3.32): the argument may be a frame-id KEYWORD or a live
-  frame OBJECT (`rf/make-frame`'s return value); an object is normalized to its
-  runnable-id address via `frame/frame-target->id`."
+  Accepts a frame-id keyword or a live frame value; values are normalized to
+  their runnable id. Per Spec 002 §The public registrar query API."
   [frame-id]
   (frame/frame-app-db-value (frame/frame-target->id frame-id)))
 
@@ -1864,39 +1816,21 @@
   unknown / destroyed frame. The full-frame read for SSR / epoch /
   time-travel / Xray.
 
-  EP-0001 (rf2-q4i9ko + rf2-adwcv6): reads the coherent two-partition
-  frame state off the one physical frame-state container. A fresh frame's
-  state is `{:rf.db/app {} :rf.db/runtime {}}`. The runtime-db partition
-  read (retired `runtime-db-value`, rf2-t3lftq — API-shrink #3) is
-  `(:rf.db/runtime (frame-state-value frame-id))`. Per Spec 002 §The
-  two-partition frame contract and API.md `frame-state-value`.
-
-  EP-0023 (rf2-32siq3.32): accepts a frame-id keyword or a live frame object."
+  Reads both partitions from the one physical frame-state container. A fresh
+  frame's state is `{:rf.db/app {} :rf.db/runtime {}}`; read the runtime-db
+  partition with `(:rf.db/runtime (frame-state-value frame-id))`. Accepts a
+  frame-id keyword or a live frame value. Per Spec 002 §The two-partition
+  frame contract."
   [frame-id]
   (frame/frame-state-value (frame/frame-target->id frame-id)))
-
-;; rf2-t3lftq (API-shrink #3): `snapshot-of` is REMOVED — an empirically
-;; zero-caller convenience over `(get-in (rf/app-db-value frame-id) path)`
-;; (or, under an established `with-frame` scope, `(get-in (rf/app-db-value
-;; (frame/require-current-frame!)) path)`). Pre-alpha — no back-compat alias.
-
-;; rf2-80mmlf: the `sub-topology` / `sub-cache` facade aliases are REMOVED.
-;; They are SUBSCRIPTION-TOOLING surfaces (static dependency-graph + runtime
-;; cache inspection), not app-author front-porch reads — their real callers
-;; are tests / REPLs / dev tooling, which address the owning
-;; `re-frame.subs.tooling` namespace (`sub-topology` / `sub-cache-snapshot`)
-;; directly (production counter bundles DCE the bodies). On JVM the
-;; convenience aliases in `re-frame.subs` (`subs/sub-topology` /
-;; `subs/sub-cache-snapshot`) remain for the legacy `subs/<name>` shape.
 
 ;; The public construction model is `rf/image` — the selected registration-set
 ;; value a frame loads — supplied to `make-frame` via `:images`. A feature
 ;; namespace registers ordinary `reg-*` forms and an image selects them by
-;; `:include-ns` provenance glob, so there is no separate module/app composition
-;; noun. The public model targets a FRAME (a process-local frame id, or a direct
-;; frame object for tests) whose image generation determines registration
-;; resolution; the public hot-reload path is re-`make-frame`-ing an `:id`-bearing
-;; frame target with a new `:images` vector (rf2-lxwpob).
+;; `:select-ns {:include [...] :exclude [...]}` provenance globs, so there is
+;; no separate module/app composition noun. The frame's image generation
+;; determines registration resolution; refresh an id-bearing frame by calling
+;; `make-frame` again with the same `:id` and a new `:images` vector.
 
 ;; ---- interceptors --------------------------------------------------------
 ;;

--- a/implementation/core/src/re_frame/core_call_site_macros.cljc
+++ b/implementation/core/src/re_frame/core_call_site_macros.cljc
@@ -1,15 +1,13 @@
 (ns re-frame.core-call-site-macros
   "Helpers for the call-site-capturing macros — `dispatch`,
-  `dispatch-sync`, `subscribe`. Each user-facing macro's expansion reaches
-  straight through to its OWNING ns fn — `re-frame.router/dispatch!`,
-  `re-frame.router/dispatch-sync!`, `re-frame.subs/subscribe` — no
-  `re-frame.core` `*`-suffixed twin (rf2-m90brg retired `dispatch*` /
-  `dispatch-sync*` / `subscribe*`; the CLJS same-name `def`-alias in
-  `re-frame.core` — Convention A, per that ns's docstring — covers the HoF /
-  programmatic case). (`->interceptor` / `->interceptor*` is a SEPARATE
-  internal-lowering pair, not part of this call-site-capturing family;
-  `inject-cofx` is REMOVED in EP-0017 — it survives only as a throwing stub
-  macro/fn pair, no longer a call-site-capturing surface.)
+  `dispatch-sync`, and `subscribe`. Each expansion calls a stable `^:no-doc`
+  alias in `re-frame.core`; those aliases point at the owning router or subs
+  function without introducing a second implementation. The alias prevents
+  the CLJS compiler from baking the owner's fixed arities into call sites, so
+  tools can safely replace the seam with a differently shaped test fn.
+
+  `->interceptor` is a separate definition-site-capturing macro. It shares the
+  coordinate and debug-gate machinery but is not part of the dispatch family.
 
   Carved out of `re-frame.core` so the public namespace stays a thin
   facade focused on user-visible Var resolution rather than macro
@@ -63,17 +61,11 @@
 ;; / `*ns*` / `*file*` through; we emit the same gated expansion the
 ;; original inlined `defmacro` body produced.
 
-;; API-shrink #1 (rf2-csbbwu): the 2-arity dispatch surface is `[event-vec
-;; opts]` ONLY — no runtime shape-discrimination, no frame-first sugar. The
-;; stamped path always keeps the 2-arity `(dispatch! event-vec (assoc opts
-;; :rf.trace/call-site cs))` shape (so a `(with-redefs [router/dispatch!
-;; (fn [ev _opts] …)])` tools-test stub reaches every real dispatch, macro or
-;; HoF alike — rf2-m90brg moved this stub target from the retired
-;; `re-frame.core/dispatch*` facade twin to the OWNING ns fn the macro always
-;; called) — the call-site keyword stays a macro-literal, never reaching the
-;; production-reachable owning-ns fn body. The debug-gate stays OUTERMOST so
-;; the whole stamped branch (the `cs` literal) DCEs under `:advanced` +
-;; `goog.DEBUG=false`. `arg1`/`arg2` are the user's two forms verbatim.
+;; The public dispatch shapes are `[event-vec]` and `[event-vec opts]`. The
+;; stamped branch always calls the stable alias with two args, keeping the
+;; call-site keyword literal inside the debug-only macro expansion. The gate
+;; stays outermost so Closure removes the whole stamped branch under
+;; `:advanced` + `goog.DEBUG=false`.
 
 #?(:clj
    (defn- build-stamped-2
@@ -139,34 +131,15 @@
                      `(re-frame.core/subscribe-impl ~arg1))]
        (gate stamped plain))))
 
-;; `build-inject-cofx-form` was retired with `inject-cofx` (EP-0017 slice
-;; A.3): there was no call-site interceptor to build, so the dedicated builder
-;; is gone. rf2-w9xyx1 then removed the `inject-cofx` macro / `inject-cofx*`
-;; fn from the public facade entirely (the migration alarm survives on the
-;; private thrower `re-frame.cofx/inject-cofx`).
-
-;; ---- ->interceptor (definition-site coord capture, rf2-siheh) ------------
+;; ---- ->interceptor definition-site coordinate capture --------------------
 ;;
 ;; `->interceptor` is the only interceptor constructor with a USER
 ;; definition site to jump to (the std interceptor `path` and
 ;; the cofx injector are framework-built; the reg-event handler-wrappers
-;; carry the event's own coord). Before rf2-siheh it was a plain fn, so an
-;; interceptor map carried NO source-coord and the Xray Epoch INTERCEPTOR
-;; row could render no jump-to-source chip (yz57h assumed a coord that
-;; didn't exist — `handler-meta :interceptor` resolves nothing, interceptors
-;; not being a registrar kind).
-;;
-;; The fix mirrors the (historical) macro / `*`-fn pair pattern this facade
-;; used across `dispatch` / `subscribe` before rf2-m90brg retired those
-;; twins: `->interceptor` becomes a macro that captures `(meta &form)` →
-;; `:source-coord` (riding the SAME `coords-form` / `prod-coords-form`
-;; absolutise path — rf2-wvsxg — as every other reg-* / call-site coord)
-;; and bakes it into the `:source-coord` kwarg of `->interceptor*`. The
-;; coord then rides the interceptor map, the chain runner's error-record,
-;; and the `:rf.error/interceptor-exception` trace, so the Epoch row gets
-;; parity with EVENT HANDLER / SUBSCRIPTIONS / VIEWS. Unlike a registrar
-;; lookup, the coord stays bound to the exact interceptor instance that
-;; threw.
+;; carry the event's own coord). The macro captures `(meta &form)` and bakes
+;; the result into `->interceptor*`'s `:source-coord` kwarg. The coordinate
+;; stays on the exact interceptor instance through chain errors and
+;; `:rf.error/interceptor-exception`; it is not resolved through the registrar.
 ;;
 ;; The gate is OUTERMOST so the whole `:source-coord` literal DCEs under
 ;; `:advanced` + `goog.DEBUG=false`: the prod branch omits the kwarg
@@ -180,7 +153,7 @@
      gated `(if interop/debug-enabled? <with-coord> <plain>)` around
      `re-frame.core/->interceptor*` — the dev branch splices the
      captured `:source-coord` kwarg in, the prod branch is the bare
-     fn-call so the coord literal DCEs. Per rf2-siheh."
+     fn-call so the coord literal DCEs."
      [form-meta ns-sym file kwargs]
      (let [cs-form (call-site-form form-meta ns-sym file)
            stamped `(re-frame.core/->interceptor* ~@kwargs :source-coord ~cs-form)

--- a/implementation/core/src/re_frame/core_machines.cljc
+++ b/implementation/core/src/re_frame/core_machines.cljc
@@ -5,12 +5,9 @@
 
   `reg-machine` / `reg-machine*` keep a bespoke shape (they share the
   `:where`-symbol parameter via `reg-machine-impl` so the macro and the
-  plain-fn surface raise with their own faithful `:where` symbol). (The
-  `dispatch-to-system` FN was demoted off the facade and relocated to
-  `re-frame.machines` — rf2-gkt25a / rf2-80mmlf. The `machine-has-tag?` /
-  `sub-machine` subscription-sugar fns were removed — rf2-il99l3, reversing
-  rf2-2cmcas — leaving the `[:rf.machine/has-tag? …]` / `[:rf/machine …]`
-  subscription vectors as the one machine-read grammar.)"
+  plain-fn surface raise with their own faithful `:where` symbol). Machine
+  reads use the `[:rf.machine/has-tag? …]` and `[:rf/machine …]`
+  subscription vectors."
   (:require [re-frame.core-artefact #?@(:clj  [:refer        [defwrapper]]
                                         :cljs [:refer-macros [defwrapper]])]
             [re-frame.interop :as interop]
@@ -61,8 +58,8 @@
   Pass the public opts form `(machine-by-system-id system-id {:frame
   target})` to name a frame explicitly (async callbacks / tools /
   cross-frame lookups); `target` is a frame-id keyword or a live frame
-  value. Per rf2-f28bno the 2-arity is SHAPE-DISCRIMINATED on the second
-  arg (mirroring `subscribe`'s frame-first arity): an opts map ⇒ the public
+  value. The 2-arity is shape-discriminated on the second arg, mirroring
+  `subscribe`'s trailing opts-map form: an opts map ⇒ the public
   form; a bare frame target ⇒ the internal frame-last plumbing.
 
   Per Spec 005 §Named addressing via :system-id + Spec 002 §Resolver
@@ -209,18 +206,4 @@
    (reg-machine-impl 'rf/reg-machine machine-id machine))
   ([machine-id opts machine]
    (reg-machine-impl 'rf/reg-machine machine-id opts machine)))
-
-;; ---- dispatch-to-system relocation note ----------------------------------
-;;
-;; The `dispatch-to-system` FN was DEMOTED off the `re-frame.core` facade
-;; (rf2-gkt25a / rf2-80mmlf — exactly one in-repo caller) and RELOCATED to
-;; `re-frame.machines` (the optional machines artefact ns) as an
-;; implementation-tier helper. The canonical action-side surface is the
-;; reserved `[:rf.machine/dispatch-to-system [system-id event]]` fx tuple.
-;;
-;; The `machine-has-tag?` / `sub-machine` subscription-sugar fns that once
-;; lived here were REMOVED (rf2-il99l3, reversing rf2-2cmcas). A machine read
-;; is a subscription VECTOR — `(subscribe [:rf.machine/has-tag? machine-id
-;; tag])` / `(subscribe [:rf/machine machine-id])` — one read grammar; the
-;; `{:frame …}` target is carried by `subscribe`'s own frame-first arity.
 

--- a/implementation/core/src/re_frame/core_reg_view_macro.cljc
+++ b/implementation/core/src/re_frame/core_reg_view_macro.cljc
@@ -289,8 +289,3 @@
               (pr-str bindings) ".")
          {:recovery :fix-registration
           :extra    {:got bindings}}))))
-
-;; `expand-frame-bound-fn` (the `frame-bound-fn` macro's expansion helper) is
-;; REMOVED — API-shrink #1, rf2-csbbwu deleted `frame-bound-fn` from the
-;; facade. Its dynamic-rebinding semantics survive internally as
-;; `re-frame.frame/bind-fn`.

--- a/implementation/core/src/re_frame/std_interceptors.cljc
+++ b/implementation/core/src/re_frame/std_interceptors.cljc
@@ -2,46 +2,22 @@
   "Standard interceptors. Per Spec 002 / API.md §Standard interceptors and
   Spec 001 §Hot-reload semantics M-21.
 
-  Ships ONE framework-standard interceptor plus the ->interceptor primitive:
+  Ships one framework-standard interceptor plus the ->interceptor primitive:
     :rf.interceptor/path — focus a handler on an app-db sub-slice, referenced
                            as `[:rf.interceptor/path <path-vector>]` (this ns)
 
-  (The legacy `unwrap-interceptor` VALUE is REMOVED — EP-0022 / rf2-3qeu38 —
-  the framework ships no standard unwrap; the canonical spelling is
-  handler-payload destructuring, or a project-registered `:app/unwrap`. A
-  stale `rf/unwrap-interceptor` reference hits the `^:no-doc` throwing stub
-  `unwrap-removed!` below, which names those replacements.)
-
-  (Coeffects are no longer wired by a `inject-cofx` interceptor — they
-  are declared via `:rf.cofx/requires` on the handler and delivered flat;
-  EP-0017, no interceptor surface.)
-
-  The principle: keep helpers that do specific, non-trivial work; drop
-  those that are just (->interceptor :before f) or (->interceptor :after f)
-  with no other logic. Custom before/after work uses ->interceptor directly.
-
-  EP-0022 (Slice C, rf2-0adhqs.3): this ns registers the framework-standard
-  `:rf.interceptor/path` interceptor as a `:factory`, referenced as
-  `[:rf.interceptor/path <path-vector>]`. Its `:factory` builds the FULL
-  standard-path interceptor (`standard-path-interceptor`) implementing the
-  normative rules 1-5 of [Spec 002 §Standard
-  `:rf.interceptor/path`](../../../spec/002-Frames.md), notably **rule 4**:
-  when the handler emits a `:db` effect whose focused value is `identical?`
+  The registered `:factory` builds `standard-path-interceptor`, implementing
+  the rules in [Spec 002 §Standard
+  `:rf.interceptor/path`](../../../spec/002-Frames.md). In particular, when
+  the handler emits a `:db` effect whose focused value is `identical?`
   to the original focused slice, the interceptor widens back to the
-  ORIGINAL full app-db OBJECT (not an `assoc-in` allocation), preserving
-  the frame-commit `identical?` no-op (rf2-ekq28v). A non-vector / malformed
+  original full app-db object rather than allocating with `assoc-in`. This
+  preserves the frame commit's identity-based no-op. A non-vector or malformed
   path argument is `:rf.error/path-interceptor-bad-path`.
 
-  EP-0022 removed the public `rf/path` VALUE constructor (EP-0022:552/932):
-  there is no public path value-builder, only the `[:rf.interceptor/path
-  <path-vector>]` ref. The legacy `path` fn that the removed facade var aliased
-  is gone (rf2-dgtdna); a stale `(rf/path …)` call hits the `^:no-doc` throwing
-  stub `path-removed!` below, which names the ref form as the replacement. The
-  legacy value also had WEAKER semantics — its `:after` always re-spliced via
-  `assoc-in` when a `:db` effect was present, allocating a fresh top-level map
-  even for an UNCHANGED slice and defeating the rule-4 commit no-op
-  (rf2-ekq28v). The surviving `standard-path-interceptor` (the factory's
-  consumer) is the one path surface and is the carrier of that no-op."
+  `rf/path` and `rf/unwrap-interceptor` survive only as `^:no-doc` throwing
+  stubs that provide migration guidance. Coeffects are declared with
+  `:rf.cofx/requires`, not represented as interceptors."
   (:require [re-frame.interceptor :as interceptor]
             [re-frame.interceptor-registry :as icpt-reg]
             [re-frame.image-assembly :as image-assembly]
@@ -49,47 +25,15 @@
 
 #?(:clj (set! *warn-on-reflection* true))
 
-;; ---- path: the removed value constructor (EP-0022, rf2-dgtdna) -------------
-;;
-;; EP-0022 (accepted) removed the public `rf/path` VALUE constructor: there is
-;; NO public path value-builder, only the framework-registered factory ref
-;; `[:rf.interceptor/path <path-vector>]` (EP-0022:552 "There is no public
-;; rf/path value constructor."; :932 lists the removal). The implementation had
-;; DRIFTED — it kept exporting `rf/path` aliased to a legacy `path` fn here —
-;; and that fn was a footgun: its `:after` always re-spliced via `assoc-in`
-;; when a `:db` effect was present, allocating a fresh top-level map even for an
-;; UNCHANGED slice, defeating the rf2-ekq28v frame-commit `identical?` no-op
-;; the canonical `standard-path-interceptor` (below) preserves. rf2-dgtdna
-;; removes the legacy fn and replaces the facade var with a `^:no-doc` throwing
-;; stub (the project's actionable-removed-API pattern, like
-;; `:rf.error/inject-cofx-removed` / `reg-event-db-removed`).
-;;
-;; The stub throws the canonical `re-frame.error/throw-error!` hard error
-;; naming the replacement ref, so a stale `(rf/path …)` call fails LOUDLY and
-;; actionably rather than as an opaque "no such var" or a working footgun. It
-;; does NOT fan out onto the always-on error-emit channel: unlike the
-;; reg-event / inject-cofx removed stubs (whose Spec 009 §Error event catalogue
-;; rows + always-on conformance pins were authored alongside them), this is an
-;; implementation-only drift fix (API.md + EP-0022 already correct) and rides
-;; no catalogued category — just the actionable throw.
-
-;; ---- data-driven removed std-interceptor values (rf2-ne2uk8) ---------------
+;; ---- removed standard values ---------------------------------------------
 ;;
 ;; The two removed standard interceptor values (`path` / `unwrap-interceptor`)
-;; are described ONCE in this table, not as two bespoke throwers. Unlike the
-;; EP-0018 reg-event removed names (which fan out on the always-on error
-;; channel + dev trace bus, per their Spec 009 catalogue rows), these are
-;; implementation-only drift fixes (API.md + EP-0022 were already correct) that
-;; ride no catalogued 009 category — they JUST throw the actionable
-;; `re-frame.error/throw-error!` hard error. The table holds each row's
-;; behavioural facts; the per-name stubs below are thin lookups, so adding /
-;; retiring a removed standard value is a one-row edit and the audit surface is
-;; one literal vector. `:msg` / `:extra` are `(fn [args] …)` so a row can weave
-;; the call args into its message + ex-data (only `path` needs the path vec).
+;; are described once in this table. They raise actionable hard errors but do
+;; not fan out through the always-on error channel. `:msg` and `:extra` are fns
+;; so the path row can include the supplied path in its diagnostic.
 
 (def ^:private removed-std-interceptor-values
-  "The EP-0022 removed standard interceptor VALUES, one row each — the audit
-  surface for the removed std-interceptor names (rf2-ne2uk8). A row is
+  "The removed standard interceptor values, one row each. A row is
   `{:sym :error-kw :where :msg :extra}`:
     - `:sym`      the bare var symbol exported `^:no-doc` from this ns and
                   aliased onto the `re-frame.core` facade;
@@ -114,8 +58,8 @@
     :msg      (fn [_args]
                 (str "`rf/unwrap-interceptor` is REMOVED in EP-0022 (no "
                      "framework-standard unwrap value). Destructure the "
-                     "`[<id> <payload-map>]` payload in the handler arglist — "
-                     "`(fn [_ {:keys [a b]}] …)` — or register a project "
+                     "`[<id> <payload-map>]` event in the handler arglist — "
+                     "`(fn [_ [_ {:keys [a b]}]] …)` — or register a project "
                      "`:app/unwrap` interceptor with your own `:before` / "
                      "`:after` for genuine chain-wide reshaping."))
     :extra    (fn [_args] nil)}])
@@ -156,29 +100,6 @@
   [& path-segs]
   (raise-removed-std-interceptor! (get removed-std-interceptor-by-sym 'path) path-segs))
 
-;; ---- unwrap: the removed standard value (EP-0022, rf2-3qeu38) --------------
-;;
-;; EP-0022 (accepted) ships NO framework-standard unwrap value
-;; (docs/EP/EP-0022-registered-interceptors.md:53-55 "no standard unwrap";
-;; :555-578 §"No standard unwrap"; :881/:932 list the removal). The canonical
-;; spelling for the M-19 `[<id> <payload-map>]` shape is handler-payload
-;; destructuring in the handler arglist; a project that genuinely needs
-;; chain-wide event reshaping registers its OWN `:app/unwrap` interceptor with
-;; project `:before` / `:after`. The implementation had DRIFTED — it kept an
-;; `unwrap-interceptor` VALUE here and exported it from the facade — so
-;; rf2-3qeu38 removes the value (the stash/restore-`:event`-in-`:after`
-;; machinery and its `:rf.error/unwrap-bad-event-shape` emit site go with it)
-;; and replaces the facade var with the `^:no-doc` throwing stub below (the
-;; `rf/path` twin under rf2-dgtdna; the project's actionable-removed-API
-;; pattern, like the EP-0018 `reg-event-db` / EP-0017 `inject-cofx` stubs).
-;;
-;; Like `path-removed!`, the stub throws the canonical
-;; `re-frame.error/throw-error!` hard error naming the replacement, so a stale
-;; `(rf/unwrap-interceptor …)` reference fails LOUDLY and actionably. It does
-;; NOT fan out onto the always-on error-emit channel and rides no catalogued
-;; 009 category — just the actionable throw (API.md + EP-0022 already correct;
-;; this is an implementation-only drift fix).
-
 (defn ^:no-doc unwrap-removed!
   "REMOVED in EP-0022 (no alias). The framework ships no standard `unwrap`
   value; the canonical spelling for the M-19 `[<id> <payload-map>]` shape is
@@ -191,23 +112,12 @@
   (raise-removed-std-interceptor!
     (get removed-std-interceptor-by-sym 'unwrap-interceptor) _args))
 
-;; ---- standard :rf.interceptor/path (EP-0022 Slice C — FULL contract) -------
+;; ---- standard :rf.interceptor/path ----------------------------------------
 ;;
-;; The framework-standard `:rf.interceptor/path` interceptor, referenced as
-;; `[:rf.interceptor/path <path-vector>]` and built by the registered
-;; `:factory` (`path-factory`). It implements the FULL normative contract of
-;; Spec 002 §Standard `:rf.interceptor/path` (rules 1-5), notably RULE 4: an
-;; unchanged focused slice widens back to the ORIGINAL full app-db OBJECT so
-;; the frame-commit `identical?` no-op (rf2-ekq28v) is preserved.
-;;
-;; This is the ONE path surface (the removed legacy `path` fn / `rf/path` value
-;; builder only short-circuited the no-`:db` case; it still did
-;; `(assoc-in original-db path slice)` when a `:db` effect was present,
-;; allocating a fresh top-level map even for an unchanged slice — which defeated
-;; the commit no-op, and is why EP-0022 removed it; rf2-dgtdna). The standard
-;; interceptor knows BOTH the original full app-db object AND the original
-;; focused slice, so it can detect the unchanged-slice case and re-emit the
-;; original object.
+;; The registered factory builds this interceptor from
+;; `[:rf.interceptor/path <path-vector>]`. It retains both the original full
+;; app-db object and the focused slice so an unchanged slice can widen back to
+;; the original object, preserving the commit boundary's identity no-op.
 
 (defn- throw-bad-path!
   "Throw the canonical `:rf.error/path-interceptor-bad-path` error (Spec 002

--- a/implementation/core/src/re_frame/trace/cascade.cljc
+++ b/implementation/core/src/re_frame/trace/cascade.cljc
@@ -1,5 +1,5 @@
 (ns re-frame.trace.cascade
-  "Per-epoch cascade-DAG aggregator (rf2-931pm).
+  "Per-epoch cascade-DAG aggregator.
 
   The raw trace stream emits `:sub/run` (recomputed), `:rf.sub/skip`
   (input value-equal → no recompute), `:rf.flow/computed`,
@@ -18,8 +18,8 @@
   returns truthy. Off-focus epochs pay nothing beyond one predicate
   call.
 
-  The capture is **bounded** at 50 subs and 100 views per epoch (per
-  panel design rf2-931pm and Xray's Reactive panel rendering budget).
+  The capture is **bounded** at 50 subs and 100 views per epoch to match
+  Xray's Reactive panel rendering budget.
   Cascades exceeding either cap retain the first N entries and stamp
   `:truncated? true` so the panel can render a 'rest elided' affordance.
 
@@ -29,7 +29,7 @@
       :op-type   :rf.cascade
       :tags
         {:frame                 <frame-id>          ;; bare carve-out routing tag
-         :rf.epoch/id           <epoch-id>          ;; canonical epoch-identity tag (rf2-ifdsar)
+         :rf.epoch/id           <epoch-id>          ;; canonical epoch-identity tag
          :rf.trace/event-id     <event-id>          ;; canonical trace event-id tag
          :subs-recomputed       [{:sub-id :query-v} ...]
          :subs-skipped          [{:sub-id :query-v
@@ -40,10 +40,9 @@
          :sub-cap-truncated?    <bool>
          :view-cap-truncated?   <bool>}
 
-  Per pre-alpha posture (rf2-931pm): no transitional shims; the
-  aggregator publishes through a single late-bind seam and the
-  bundle-isolation gate verifies the namespace stays out of production
-  CLJS bundles via the existing `interop/debug-enabled?` gate."
+  The aggregator publishes through one late-bind seam. The bundle-isolation
+  gate verifies that this namespace and its capture literals stay out of
+  production CLJS bundles through the `interop/debug-enabled?` gate."
   (:require [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.trace :as trace
@@ -78,7 +77,7 @@
   (reset! focus-predicate (fn [_frame-id _epoch-id _event-id] false))
   nil)
 
-;; ---- bounds (per rf2-931pm panel design) --------------------------------
+;; ---- bounds --------------------------------------------------------------
 
 (def ^:const sub-cap
   "Maximum number of subs (recomputed + skipped together) captured per

--- a/implementation/core/src/re_frame/views/source_coord_annotation.cljs
+++ b/implementation/core/src/re_frame/views/source_coord_annotation.cljs
@@ -1,26 +1,19 @@
 (ns re-frame.views.source-coord-annotation
-  "Source-coord + view-id DOM annotation walk for the Reagent-side views
-  ns. Per rf2-lh7p — split out of `re-frame.views` so the views file
-  stays focused on registration orchestration. Re-frame.views re-exports
-  the `format-source-coord` helper so the existing test that references
-  `#'re-frame.views/format-source-coord` continues to resolve.
+  "Source-coordinate and view-id DOM annotation for Reagent views.
 
-  Per Spec 006 §Source-coord annotation (rf2-z7f7 / rf2-z9n1) the
-  Reagent substrate adapter MUST inject
+  Per Spec 006 §Source-coord annotation, the Reagent substrate injects
   `data-rf2-source-coord=\"<ns>:<sym>:<line>:<col>\"` on each registered
   view's root DOM element when `interop/debug-enabled?` is true. The
   annotation lets pair-shaped tools (re-frame-pair, re-frame-10x, IDE
   jump-to-source) map a clicked DOM node back to the reg-view call
   site.
 
-  Per Spec 006 §View tagging contract (rf2-01il5) the same wrapper also
+  Per Spec 006 §View tagging contract, the same wrapper also
   stamps `data-rf-view=\":rf.foo/bar\"` on the same root element — the
   value is `(str id)` (a printed keyword, leading colon included; see the
-  shared `format-view-id`), NOT the colon-less `<ns>/<sym>` form. The
-  fallback for the runtime view-hierarchy walker when the Fiber-reading
-  primary path (Spec View-Hierarchy-Capture, rf2-mxkq7) is unavailable.
-  Both attributes ride the same wrapper, the same hiccup walk, and the
-  same `interop/debug-enabled?` elision gate.
+  shared `format-view-id`), not the colon-less `<ns>/<sym>` form. It is
+  the view-hierarchy fallback when Fiber inspection is unavailable. Both
+  attributes ride the same Hiccup walk and debug-elision gate.
 
   Contract details:
 
@@ -52,12 +45,9 @@
           is to wrap the returned fn so the inner output gets walked
           too.
 
-    - CRITICAL constraint (rf2-01il5 Comment 5): the wrapper MUST
-      mutate the existing first element's attribute map. NEVER wrap
-      with a synthetic `[:div]`. Wrapping breaks flexbox, CSS Grid,
-      table layouts, `:nth-child` selectors, positioning ancestors,
-      stacking contexts, and CSS containment. The wrap-with-div
-      approach is a non-starter.
+    - The wrapper MUST annotate the existing root element. It never
+      introduces a synthetic `[:div]`, which would change layout and
+      selector semantics.
 
     - Production elision: every annotation site sits inside
       `(when interop/debug-enabled? ...)` so the closure compiler
@@ -65,24 +55,7 @@
       `goog.DEBUG=false`. Per Spec 009 §Production builds. Both
       `data-rf2-source-coord` and `data-rf-view` literals are part of
       the production-bundle elision sentinel set (see
-      `scripts/check-elision.cjs`).
-
-  ## History: JSX source-coord props (rf2-fa4ly, removed by rf2-rohdn)
-
-  An earlier version of this wrapper also injected the JSX-shaped
-  source-coord props (`:_jsxFileName` / `:_jsxLineNumber` /
-  `:_jsxColumnNumber`) intended for React DevTools' \"View source\"
-  gesture. The feature never worked: Reagent passed the props through
-  as DOM attributes (triggering React's \"unrecognised prop on a DOM
-  element\" warnings), and DevTools does not read \"View source\" from
-  element props anyway — it reads `__source` off the third arg of
-  `React.createElement`, which is set by `@babel/plugin-transform-
-  react-jsx-source` at JSX-compile time and is not accessible via
-  hiccup. Net effect: dev-console noise with no DevTools benefit.
-  Option A from rf2-rohdn dropped the injection cleanly. The
-  `data-rf2-source-coord` + `data-rf-view` DOM attributes (which DO
-  work and are read by re-frame-pair, the view-walker, IDE jump-to-
-  source tooling) ride the same wrapper unchanged."
+      `scripts/check-elision.cjs`)."
   (:require [re-frame.adapter.context :as adapter-context]
             [re-frame.views.warn-once :as warn-once]))
 
@@ -91,9 +64,8 @@
 ;; `re-frame.adapter.context` so the Reagent hiccup walk here and the
 ;; React-element-clone walk in `re-frame.substrate.spine` produce byte-
 ;; identical `data-rf2-source-coord` / `data-rf-view` values across
-;; substrates (rf2-t9s6p6). Re-exported under their historical names here
-;; so `re-frame.views/format-source-coord` (and the parity test referencing
-;; `#'re-frame.views/format-source-coord`) keep resolving.
+;; substrates. Re-exported here for the `re-frame.views` facade and its
+;; parity tests.
 (def format-source-coord adapter-context/format-source-coord)
 (def format-view-id       adapter-context/format-view-id)
 
@@ -115,10 +87,8 @@
   Non-DOM roots are returned unchanged after a one-shot warning per
   Spec 006 §Source-coord annotation.
 
-  CRITICAL: this fn MUST mutate the existing first element's attrs.
-  NEVER wrap with a synthetic `[:div]` — wrapping breaks flexbox /
-  CSS Grid / table layouts / `:nth-child` selectors / positioning
-  ancestors / stacking contexts / CSS containment.
+  This fn annotates the existing root element; it never wraps the output
+  with a synthetic element that would alter layout or selector semantics.
 
   Form-2: when `out` is a fn, return a fn that recurses on the inner
   output — Reagent's renderer will call our returned fn just like
@@ -154,20 +124,10 @@
     ;; nil). Skip with a one-shot warning. Pair tools fall back to :rf/id;
     ;; view-walker falls back to the Fiber-walker primary path.
     ;;
-    ;; Warn on ANY non-nil un-annotatable root (rf2-9ex1i9), not just
-    ;; vectors. A reg-view'd component returning a STRING (or number) is
-    ;; equally un-annotatable as a fn-headed vector — there is no root DOM
-    ;; element to stamp `data-rf2-source-coord` / `data-rf-view` onto. The
-    ;; React-hook walk (`re-frame.substrate.spine/inject-source-coord-attr`)
-    ;; already warns on any non-nil non-element output; this side formerly
-    ;; warned only on vectors, so a string-returning view was SILENT under
-    ;; Reagent but WARNED under UIx/Helix — an observable cross-adapter
-    ;; divergence on a pair-tool warning surface. Both walks now share the
-    ;; warn-on-any-non-nil-non-element predicate (the message TEXT was
-    ;; already shared via adapter/context to prevent drift; the TRIGGER
-    ;; condition is unified here). nil stays silent on both sides (a view
-    ;; legitimately renders nothing). The diagnostic head is the hiccup head
-    ;; for a vector, else the value itself.
+    ;; Warn for every non-nil unannotatable root, matching the React-hook
+    ;; adapters. nil is silent because a view may legitimately render nothing.
+    ;; The diagnostic carries the Hiccup head for vectors and the value itself
+    ;; for scalar output.
     :else
     (do
       (when (some? out)

--- a/implementation/core/src/re_frame/views/warn_once.cljs
+++ b/implementation/core/src/re_frame/views/warn_once.cljs
@@ -5,12 +5,10 @@
 
   One warn-once cache lives here: the non-DOM-root warning (Spec 006
   §Source-coord annotation, documented exemption). When a reg-view'd
-  component returns a non-DOM root (fn/class component or React Fragment)
-  the source-coord walk skips the annotation and emits a one-shot
-  console.warn per id. The `warned-non-dom-roots` defonce holds the
-  per-process set; `make-reset-runtime-fixture` clears it via the chained
-  `:adapter/clear-warn-once-caches!` hook (enrolled through the governance
-  chokepoint `register-warn-once-clear-fn!`, rf2-z79p8)."
+  component returns any non-nil root that cannot carry DOM attributes, the
+  source-coordinate walk skips annotation and emits one console warning per
+  id. `make-reset-runtime-fixture` clears the process-wide cache through the
+  chained `:adapter/clear-warn-once-caches!` hook."
   (:require [re-frame.adapter.context :as adapter-context]
             [re-frame.late-bind :as late-bind]))
 
@@ -32,38 +30,25 @@
 
 (defn warn-non-dom-root!
   "Emit a one-shot warning per id that the reg-view'd component returned
-  a non-DOM root (a fn/class component, or a React Fragment). Pair tools
-  fall back to the registry's `:rf/id`; documented exemption per Spec 006
-  §Source-coord annotation."
+  a non-DOM root. Pair tools fall back to the registry's `:rf/id`;
+  documented exemption per Spec 006 §Source-coord annotation."
   [id head]
   (when-not (contains? @warned-non-dom-roots id)
     (swap! warned-non-dom-roots conj id)
     (when (exists? js/console)
-      ;; Shared builder (rf2-t9s6p6); nil substrate-name = the Reagent
-      ;; hiccup-walk path carries no substrate qualifier, so the message
-      ;; text is byte-identical to the pre-extraction inline string.
+      ;; nil substrate-name marks the Reagent Hiccup-walk path, which carries
+      ;; no substrate qualifier in the shared warning text.
       (.warn js/console
         (adapter-context/non-dom-root-warning id head nil)))))
 
 ;; Enrol the `warned-non-dom-roots` cache into the chained
 ;; `:adapter/clear-warn-once-caches!` hook, via the canonical governance
-;; chokepoint `late-bind/register-warn-once-clear-fn!` (rf2-z79p8). Each
+;; chokepoint `late-bind/register-warn-once-clear-fn!`. Each
 ;; adapter (helix, uix), the slim hiccup interpreter, re-frame.views, and
 ;; this ns contribute a clear-step; `make-reset-runtime-fixture` invokes
 ;; the top of the chain and every contributor's reset runs. The chokepoint
 ;; also records the cache in the warn-once-clear governance registry so the
 ;; governance assertion proves the chain wipes it.
-;;
-;; (The retired `warned-plain-fn-frame-pairs` suppression cache — the
-;; rf2-z79p8 4th straggler — was removed in rf2-k4xous: its warning
-;; `:rf.warning/plain-fn-under-non-default-frame-once` is RETIRED per
-;; EP-0002 (rf2-7yqn39 deleted the emit site, helper, hook, call site and
-;; re-export, superseding it with the always-on `:rf.error/no-frame-context`
-;; error). It was kept SOLELY as a governance test subject; the three live
-;; probe-carrying caches — `warned-non-dom-roots` here, `seen-render-keys`
-;; in re-frame.views, and the spine's per-adapter source-coord cache — still
-;; exercise the arm/fire/assert-empty governance proof, so removing it loses
-;; zero coverage.)
 (late-bind/register-warn-once-clear-fn!
   {:label    :views/warned-non-dom-roots
    :clear-fn clear-warned-non-dom-roots!

--- a/implementation/core/test/re_frame/trace_test.clj
+++ b/implementation/core/test/re_frame/trace_test.clj
@@ -498,16 +498,10 @@
           (is (has-op? events :error :rf.route.nav-token/stale-suppressed)
               "expected :error :rf.route.nav-token/stale-suppressed"))
 
-        ;; ---- Spec 009 ops never emitted by the implementation --------------
-        ;; These op-types appear in Spec 009 §:op-type vocabulary but the
-        ;; implementation never emits them. Filed as rf2-hyxg. The
-        ;; assertions below intentionally fail loudly so closing rf2-hyxg
-        ;; (either by tightening the spec or by adding the emit) re-greens
-        ;; the regression dashboard.
-        ;;
-        ;; Each is wrapped with `is-strict?` set to false so this test
-        ;; documents the gap without blocking other assertions; flip
-        ;; `is-strict?` to true once rf2-hyxg lands to enforce.
+        ;; ---- Spec 009 required operation pairs ------------------------------
+        ;; Keep these assertions together so the vocabulary cannot drift from
+        ;; the emitters one operation at a time. `is-strict?` is a local
+        ;; diagnostic switch; committed tests keep it true.
         (let [is-strict? true
               gap-check  (fn [op-type operation]
                            (if is-strict?
@@ -517,8 +511,8 @@
                              ;; non-strict: report status but pass.
                              (when-not (has-op? events op-type operation)
                                (println "  [trace-test] note:" op-type operation
-                                        "not emitted (rf2-hyxg)"))))]
-          (testing "Spec 009 documented ops not yet emitted (rf2-hyxg)"
+                                        "not emitted"))))]
+          (testing "Spec 009 documented operations are emitted"
             (gap-check :rf.sub                        :rf.sub/run)
             (gap-check :rf.sub                        :rf.sub/create)
             (gap-check :rf.machine.lifecycle/created  :rf.machine.lifecycle/created)


### PR DESCRIPTION
## What

- replace migration-history narration in the core facade, macro builders, machine wrappers, standard interceptors, trace cascade, and view annotation helpers with current contracts
- correct the facade description of the stable macro call seams and the image-selection spelling from retired `:include-ns` to `:select-ns`
- correct the removed-unwrap diagnostic to show nested event-vector destructuring
- align the trace vocabulary test explanation with its already-strict assertions

## Why

The implementation/core commentary had accumulated implementation history that obscured current ownership and lifecycle rules. Three passages were materially misleading: macro expansions were described as bypassing their intentional facade seams, image composition taught a retired option, and the unwrap replacement example destructured the handler event at the wrong level.

## Impact

Comments, docstrings, and diagnostic guidance only. Runtime control flow and data behavior are unchanged. The revised text keeps the non-obvious DCE, frame lifecycle, identity-preserving commit, host annotation, and optional-artefact boundaries explicit.

## Checks

- `clj-kondo --fail-level error` on all touched files: 0 errors (39 existing macro-analysis warnings)
- `scripts/test-core-jvm-windows.ps1`: 1,763 tests, 7,667 assertions, 0 failures, 0 errors
- `npx shadow-cljs compile node-test`: build completed, 1,488 files (3 warnings in untouched resources/Story tests)
- `node out/node-test.js`: 8,466 tests, 39,159 assertions, 0 failures, 0 errors
- `git diff --check`
