### PR TITLE
docs(adapters): focus explanations on shipped contracts (rf2-9yi939)

### DIFF
--- a/implementation/adapters/README.md
+++ b/implementation/adapters/README.md
@@ -11,7 +11,7 @@ This directory groups re-frame2's **substrate adapters** — implementations of 
 | [`reagent/`](reagent/) | Reagent adapter | `day8/re-frame2-reagent` | Reagent 2.x — the canonical CLJS reference adapter |
 | [`uix/`](uix/) | UIx adapter | `day8/re-frame2-uix` | UIx 2.x — modern hooks-based React layer |
 | [`helix/`](helix/) | Helix adapter | `day8/re-frame2-helix` | Helix 0.2.x — minimal React wrapper |
-| [`reagent-slim/`](reagent-slim/) | Reagent-slim adapter | `day8/reagent-slim` [^slim-coord] | Reagent rewrite for React 19 — Stage 4 landed (full `reagent2.*` rewrite) |
+| [`reagent-slim/`](reagent-slim/) | Reagent-slim adapter | `day8/reagent-slim` [^slim-coord] | Reagent-compatible `reagent2.*` implementation for React 19 |
 
 [^slim-coord]: The `re-frame2-` prefix is dropped on this coord (per IMPL-SPEC DECISION-1); it is the lone adapter artefact published as `day8/reagent-slim` rather than `day8/re-frame2-*`.
 
@@ -21,11 +21,14 @@ A consumer picks one (or more) by adding the matching artefact to their `deps.ed
 
 | Directory | Adapter | Coordinate | Target |
 |---|---|---|---|
-| [`test-react/`](test-react/) | Test-React adapter | **none — local-test-only** | Pure-CLJC React class-3 lifecycle simulator — unit-testable lifecycle bug catching; carries ported regressions incl. the organic rf2-4l7t2 sync-unmount-during-render repro (rf2-gqyqv skeleton, broadened rf2-n2cuo) |
+| [`test-react/`](test-react/) | Test-React adapter | **none — local-test-only** | Pure-CLJC React class-3 lifecycle simulator for lifecycle-order and unmount-during-render tests |
 
 The **test-react** adapter is **not a published artefact**. It is a development/test fixture only: it has no Maven coordinate, no `:clein/build` descriptor, and is absent from the lockstep array, the release deploy matrix, and the CI JVM job set by design. Consumers never depend on it; it exists solely so the project's own unit tests can simulate React class-3 lifecycle on the JVM and Node-CLJS without a browser. Bundle isolation treats it as test-only — no example or production build should ever pull it in.
 
-The `reagent-slim` adapter has landed Stage 4 (the full `reagent2.*` rewrite — reactive primitives, render scheduler, hiccup translation, and pure-CLJS render-to-string). It now carries its own CLJS test suite (substrate-shape contract, container round-trip, derived-value tracking, the disposal-MUST list, render Root-API call sequence, and source-coord / view-id stamping under the slim adapter) alongside the `reagent2.*` internals tests.
+The `reagent-slim` adapter includes reactive primitives, a render scheduler,
+hiccup translation, and pure-CLJS render-to-string. Its test suite covers the
+adapter contract, React root calls, disposal, source coordinates, and the
+`reagent2.*` internals.
 
 ## What an adapter implements
 
@@ -59,7 +62,7 @@ adapters/
 │   └── test/...
 ├── reagent-slim/
 │   ├── deps.edn              ; declares day8/reagent-slim (no re-frame2- prefix per DECISION-1)
-│   ├── src/reagent2/...      ; the slim Reagent rewrite (Stage 4: full reagent2.* rewrite)
+│   ├── src/reagent2/...      ; the slim Reagent implementation
 │   ├── src/re_frame/adapter/reagent_slim.cljs
 │   └── test/...
 └── test-react/              ; local-test-only — NOT published (no Maven coord, no :clein/build)
@@ -72,7 +75,10 @@ All four published adapters declare `day8/re-frame2 {:local/root "../../core"}`;
 
 ## Where the substrate logic lives
 
-The four React-shaped adapters (Reagent, reagent-slim, UIx, Helix) are extremely thin (~100-130 lines each) because they all delegate into [`re-frame.substrate.spine`](../core/src/re_frame/substrate/spine.cljs) in the core artefact. Two factory families:
+The four React-shaped adapter namespaces are primarily configuration and
+substrate-specific public helpers because they delegate shared mechanics into
+[`re-frame.substrate.spine`](../core/src/re_frame/substrate/spine.cljs) in the
+core artefact. Two factory families:
 
 - **Ratom family** — [`make-ratom-spine`](../core/src/re_frame/substrate/spine.cljs) + [`make-ratom-adapter`](../core/src/re_frame/substrate/spine.cljs) (Reagent + reagent-slim).
 - **React-hook family** — [`make-react-spine`](../core/src/re_frame/substrate/spine.cljs) + [`make-react-adapter`](../core/src/re_frame/substrate/spine.cljs) (UIx + Helix).

--- a/implementation/adapters/helix/deps.edn
+++ b/implementation/adapters/helix/deps.edn
@@ -1,20 +1,14 @@
-;; day8/re-frame2-helix — Helix adapter (rf2-2qit).
+;; day8/re-frame2-helix — Helix adapter.
 ;;
-;; Per Spec 006 §Adapter shipping convention: each adapter ships in its
-;; own Maven artefact so a Helix-only app does not transitively pull
-;; in Reagent or UIx code (and vice versa). This artefact supplies the
-;; re-frame.adapter.helix ns and depends on the core artefact for
-;; everything else.
+;; Each adapter ships separately so consumers only add the selected adapter's
+;; implementation dependencies. Core still carries stock Reagent for its
+;; `reg-view` path; this boundary prevents Helix and UIx adapter dependencies
+;; from pulling one another in.
 ;;
-;; Per rf2-2qit Decision 2 (transferred from rf2-3yij) the React
-;; frame-context lives in re-frame.adapter.context (CLJS-only file in
-;; core); this Helix adapter, the UIx adapter, and the Reagent adapter
-;; all read the *same* createContext object so frame-provider chains
-;; compose across substrates in mixed-substrate apps.
+;; React-shaped adapters read the same frame context from core, allowing mixed
+;; Reagent, UIx, and Helix provider trees to compose.
 ;;
-;; Per rf2-2qit Decision 8 we target the Helix 0.2.x line (the latest
-;; published Helix release; helix-2.x has not shipped). Older Helix
-;; versions are explicitly out of scope.
+;; The supported product line is Helix 0.2.x.
 ;;
 ;; Helix itself is a CLJS-only library; this artefact is therefore
 ;; CLJS-only. The :test alias exists for classpath-probe parity with
@@ -26,13 +20,13 @@
 
  :aliases
  {:test {:extra-paths ["test"]
-         :extra-deps  {;; rf2-try1x — silent-on-success reporter.
+         :extra-deps  {;; Silent-on-success reporter.
                        day8/re-frame2-test-quiet {:local/root "../../test-quiet"}
                        io.github.cognitect-labs/test-runner
                        {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
          :main-opts   ["-m" "re-frame.test-quiet.runner"]}
 
-  ;; Clojars deploy (rf2-r382). Modeled on the Reagent / UIx adapters'
+  ;; Clojars deploy, modeled on the Reagent / UIx adapters'
   ;; flows. The release workflow runs `clojure -M:clein deploy` from
   ;; this artefact's directory, which builds pom + jar and pushes to
   ;; Clojars.

--- a/implementation/adapters/helix/src/re_frame/adapter/helix.cljs
+++ b/implementation/adapters/helix/src/re_frame/adapter/helix.cljs
@@ -1,21 +1,10 @@
 (ns re-frame.adapter.helix
-  "The Helix adapter — third canonical browser substrate, targeting the
-  Helix 0.2.x line. Per Spec 006 §CLJS reference: Helix as alternative
-  substrate. Ships in `day8/re-frame2-helix`; dependency flows adapter
-  → core.
+  "Helix 0.2.x adapter for the substrate contract in Spec 006.
 
-  Shares the React-shaped substrate machinery (container quartet,
-  derived value, render-root, render-to-string, use-subscribe, flush-
-  views!, source-coord wrapper, warn-once-cache) with the UIx adapter
-  via `re-frame.substrate.spine`. The frame-provider CORE
-  (`build-frame-provider-element`) is likewise shared, but the user-
-  facing `frame-provider` is a NATIVE Helix `defnc` in this ns
-  (rf2-z7hfp moved the seam up), NOT a spine re-export. Helix-specific
-  configuration: gensym prefixes, substrate name (used in warn-once
-  text), and helix.hooks `use-memo*` / `use-callback*` (the spine
-  passes JS-array deps unconditionally). The React frame-context
-  comes from `re-frame.adapter.context` so a mixed-substrate app's
-  frame-provider chain composes across substrates."
+  Helix and UIx share the React machinery in `re-frame.substrate.spine`.
+  This namespace supplies Helix's hooks and a native `defnc` frame-provider;
+  keeping that component native preserves Helix's CLJS prop and trailing-child
+  marshalling."
   (:require [helix.core          :refer-macros [defnc]]
             [helix.hooks         :as helix-hooks]
             [re-frame.frame             :as frame]
@@ -48,92 +37,47 @@
   "Helix hook returning the current frame keyword from the surrounding
   React context, or the no-provider sentinel
   (`re-frame.adapter.context/no-provider-sentinel`) when no frame-provider
-  sits above — NOT `:rf/default` (EP-0002 carried invariant: the React-
-  context default is a no-provider sentinel, never a synthesised default).
-  Decision 2 mandates every React-shaped adapter resolves the same
-  context, so a Helix subtree under a Reagent or UIx frame-provider
-  sees the right frame and vice versa.
+  sits above. All React-shaped adapters use the same context, so mixed
+  Reagent, UIx, and Helix provider trees compose.
 
-  React-context tier only — this is the NARROW raw `useContext` read; it
-  does not map the sentinel to nil. For the full resolution chain
-  (dynamic-var → React-context → nil) use `(rf/current-frame-id)`; the
-  routed `:adapter/current-frame` hook (registered via
-  `spine/make-react-adapter`) covers that chain and returns nil (not
-  `:rf/default`) when no scope is established, so a public frame-scoped op
-  fails loudly with `:rf.error/no-frame-context`. Per rf2-84myk."
+  This is the raw React-context read and does not map the sentinel to nil.
+  Use `(rf/current-frame-id)` for dynamic-var then React-context resolution."
   (:use-current-frame spine-fns))
 
 (defnc frame-provider
-  "User-facing component — the MERGED config-shaped frame-provider (EP-0024
-  §Scope, carry, and ownership, amended). ONE component, TWO config shapes,
-  dispatched on the prop map:
+  "Provide a frame to descendant Helix components. The prop map has two shapes:
 
-    - `{:frame existing-id}` → SCOPE-ONLY: provide an ALREADY-CREATED frame's
-      id to descendants; create / refresh / destroy NOTHING; FAIL LOUD when
-      the frame is absent (`:rf.error/frame-provider-frame-absent`).
-    - `{:id the-id …}` → ENSURE: CREATE the frame if absent, REUSE it WITHOUT
-      re-seeding if present, provide its id to descendants; NO
-      destroy-on-unmount.
+    - `{:frame existing-id}` scopes an existing frame and fails when it is absent.
+    - `{:id id ...}` creates the frame if absent and otherwise reuses it without
+      replaying `:initial-events`.
 
-  Helix call shape — the idiomatic `$` TRAILING-CHILDREN form, identical to
-  every other Helix component and mirroring Reagent's trailing-hiccup mental
-  model (rf2-7kii2):
+  Use Helix's normal trailing-children form:
 
-      ($ frame-provider {:frame :session}            ;; SCOPE-ONLY
+      ($ frame-provider {:frame :session}
          ($ header))
 
-      ($ frame-provider {:id :session :images [session-image] :initial-events []} ;; ENSURE
+      ($ frame-provider {:id :session :images [session-image]}
          ($ header)
          ($ main))
 
-  Children ride the native `$` trailing-args channel; there is no
-  `:children` prop-map key to remember (forgetting it used to drop the
-  subtree silently — that footgun is gone by construction). A single
-  child works too: `($ frame-provider {:id :session} ($ app))`.
+  The ensure shape accepts the frame-record options used by `rf/make-frame`;
+  `:id` is required and must be a keyword. Repeated mounts are intentionally
+  idempotent, including React StrictMode development mounts: they neither
+  destroy durable state nor replay initial events. The provider scopes or
+  ensures; explicit `rf/make-frame` and `rf/destroy-frame!` calls own teardown.
 
-  The SHAPE is selected by the presence of `:frame` vs `:id`. The ENSURE shape
-  takes the same `:id` / `:images` (plus record-config, incl.
-  `:initial-events` / `:url-bound?`) opts as `rf/make-frame`. `:id` is REQUIRED
-  and must be a KEYWORD: a missing / nil / non-keyword `:id` is a CONFIGURATION
-  ERROR — the ensure core emits + throws
-  `:rf.error/ensure-frame-provider-missing-id`. The three React-shaped adapters
-  share one React Context (the shared-context decision — rf2-3yij Decision 2,
-  carried into the Helix adapter as rf2-2qit Decision 2) so a subtree under any
-  frame-provider sees the right frame regardless of which substrate rendered
-  the provider.
-
-  Idempotent re-mount of the ENSURE shape (hot reload / React StrictMode dev
-  double-invoke / Story re-evaluation): re-mounting under the same `:id` MUST
-  NOT destroy durable state NOR re-run `:initial-events` — `make-frame` is
-  idempotent replacement and `reg-frame` RE-RECORDS but does NOT REPLAY
-  `:initial-events` (see `re-frame.views.owned-frame`). The owned
-  destroy-on-unmount of the pre-amendment provider is RETIRED; true ownership
-  stays expressible as `rf/make-frame` + `rf/destroy-frame!`.
-
-  Native shell above the prop-marshalling seam (rf2-z7hfp — Mike-ruled
-  C, MOVE THE SEAM UP). This is a NATIVE Helix `defnc` component, NOT a
-  re-export of a shared fn handed to `$`. Because it is a real `defnc`,
-  Helix's `$` routes its props through `extract-cljs-props`, which beans the
-  JS object back into a CLJS map with KEYWORD keys (and Helix's `-props`
-  preserves keyword VALUES — only keys are stringified) AND lifts the native
-  trailing children onto the `:children` key (Helix's `$`/`extract-cljs-
-  props` contract: `($ Comp props c1 c2)` arrives as `{... :children #js [c1
-  c2]}`). So the props destructure cleanly with namespaces intact. The body
-  DISPATCHES on `:frame` vs `:id` and delegates to the substrate-agnostic core
-  (`build-frame-provider-element` for SCOPE-ONLY, `ensure-frame-react-element`
-  for ENSURE). The prop-mangling class — Helix's `$` handing a plain fn a raw
-  JS object with string keys — is impossible by construction: there is no plain
-  fn under `$` for the element macro to mangle."
+  This must remain a native `defnc`. Helix then converts JS props back to a
+  CLJS map, preserving keyword values, and folds trailing children into
+  `:children` before this body delegates to the shared provider core."
   [props]
   (if (contains? props :frame)
-    ;; SCOPE-ONLY shape: validate the keyword `:frame` FIRST, then fail loud if
-    ;; the frame is absent, then scope via the spine's scope-only core.
+    ;; Validate before consulting the registry so malformed ids get the
+    ;; configuration error rather than the absent-frame error.
     (let [frame-kw (frame/require-keyword-frame-provider-arg!
                      (:frame props) 're-frame.adapter.helix/frame-provider)]
       (owned-frame/require-live-frame-for-scope!
         frame-kw 're-frame.adapter.helix/frame-provider)
       (spine/build-frame-provider-element frame-kw (:children props)))
-    ;; ENSURE shape: validate `:id` + build the ensure element.
     (owned-frame/ensure-frame-react-element
       props
       (:children props)
@@ -144,33 +88,23 @@
   "Helix hook that reads a re-frame subscription. Returns the current
   value; re-renders the calling component when the value changes.
 
-  Frame resolution: reads the surrounding frame-provider's keyword via
-  `use-context` (rf2-2qit Decision 2). Override via the 2-arg form to
-  pin to an explicit frame-id.
-
-  Per rf2-2qit Decision 1 the hook is named `use-subscribe` to match
-  the React/Helix idiom — symmetric ergonomics to Reagent's
-  `(rf/subscribe ...)` deref shape, asymmetric naming (hooks live in
-  hook-named space)."
+  Reads the surrounding frame-provider by default; the 2-arg form pins an
+  explicit frame id."
   (:use-subscribe spine-fns))
 
 (def use-resource-lease
-  "Helix hook that takes a resource liveness LEASE for the calling
-  component's mounted lifetime (rf2-cxozh4, EP-0020 §Open Issue #1). On
+  "Helix hook that takes a resource liveness lease for the calling
+  component's mounted lifetime. On
   mount it dispatches `:rf.resource/ensure` with an app-minted `[:lease …]`
   owner; on unmount it releases that lease via `:rf.resource/release-owner`.
-  Use it so a view declaratively OWNS a polled / cached resource for as long
-  as it is on screen — the mount-lifecycle half of resource ownership that
-  otherwise needs a hand-wired `use-effect`.
+  Use it when a view owns a polled or cached resource while mounted.
 
       (use-resource-lease {:resource :my/feed :scope :rf.scope/global
                            :params {:page 0}})
 
-  Pair it with `use-subscribe` on a `[:rf.resource/*]` query to READ the
-  data; this hook manages liveness only (returns nil). Frame resolution +
-  the `:cause` / `:frame` opts mirror `use-subscribe`; the shared
-  substrate-agnostic implementation lives in
-  `re-frame.adapter.resource-lease`."
+  Pair it with `use-subscribe` to read the data; this hook only manages
+  liveness and returns nil. `:cause` annotates the ensure, and `:frame` pins
+  ownership to an explicit frame."
   resource-lease/use-resource-lease)
 
 (def flush-views!
@@ -178,10 +112,7 @@
   intended for test code only. Calls (act f); with no arg, calls (act
   (fn [] nil)) to flush pending effects. Returns nil. Resolves React's
   act() across React 18 (in `react-dom/test-utils`) and React 19 (on
-  the React namespace directly).
-
-  Per rf2-2qit Decision 6: the canonical test-flush hook for
-  Helix-based apps."
+  the React namespace directly)."
   (:flush-views! spine-fns))
 
 (def wrap-view
@@ -197,8 +128,7 @@
   "Reset the warn-once cache for non-DOM-root warnings. Tests use this
   between cases (via `make-reset-runtime-fixture` and the chained
   `:adapter/clear-warn-once-caches!` hook) so a sibling test's
-  first-encounter warning cannot silently swallow a later test's same-id
-  warning. Per rf2-4edk."
+  first-encounter warning cannot suppress a later test's same-id warning."
   (:clear-warned-non-dom-roots! spine-fns))
 
 ;; ---- adapter Var ----------------------------------------------------------
@@ -209,25 +139,10 @@
       (require '[re-frame.adapter.helix :as helix])
       (rf/init! helix/adapter)
 
-  See Spec 006 §CLJS reference: Helix as alternative substrate.
-  Implements the same adapter contract as re-frame.adapter.reagent
-  and re-frame.adapter.uix (6 required + 3 optional + 1 lifecycle fn).
-  Per rf2-agql there is no default-adapter registry — adapter wiring
-  is explicit at the call site.
-
-  Assembled by `spine/make-react-adapter` (rf2-ee38b.1): the substrate
-  map, the five React-hook `route-hook!` calls, and the two
-  chained installs (warn-once clear + SSR emitter) all live once in the
-  spine — the Helix and UIx adapter wiring is byte-identical, so this
-  single call replaces the former hand-copied block (which had drifted in
-  prose against the UIx twin). The per-hook rationale lives at
-  `spine/make-react-adapter`.
-
-  The native `frame-provider` `defnc` component (rf2-z7hfp) is passed in
-  as `:frame-provider` so the spine wires it into the
-  `:register-context-provider` substrate slot — the component shell lives
-  in this ns, above where Helix's `$` marshals props; the spine carries
-  no Helix element-macro dependency."
+  Adapter installation is explicit; there is no default-adapter registry.
+  `spine/make-react-adapter` owns the shared UIx/Helix hook routing and
+  lifecycle wiring. The native provider stays in this namespace so the spine
+  has no dependency on Helix's element macro."
   (spine/make-react-adapter spine-fns
                             {:kind           :rf.adapter/helix
                              :frame-provider frame-provider}))

--- a/implementation/adapters/reagent-slim/DESIGN-RATIONALE.md
+++ b/implementation/adapters/reagent-slim/DESIGN-RATIONALE.md
@@ -1,16 +1,15 @@
 # reagent-slim — design rationale
 
-> Bead **rf2-kez3**. Audience: adopters evaluating `day8/reagent-slim` against the classic thin-bridge adapter.
+> Audience: adopters evaluating `day8/reagent-slim` against the classic
+> thin-bridge adapter.
 >
-> **Bridge naming (rf2-xcyaei).** Today the classic thin-bridge adapter ships as **`day8/re-frame2-reagent`** — that is the coordinate an adopter pins right now, and the one this document names throughout as the present-day fallback. `day8/reagent-classic` is a *possible post-1.0 rename* of that bridge (see `IMPL-SPEC.md` §11.4); it has **not** shipped, so it is deliberately not used as adoption guidance here.
+> **Bridge naming.** The classic thin-bridge adapter ships as
+> **`day8/re-frame2-reagent`**. `day8/reagent-classic` is only a possible
+> post-1.0 rename, so this document does not use it as adoption guidance.
 >
-> Sister docs:
-> - `IMPL-SPEC.md` (this directory) — Stage 3 engineering spec, written for implementers.
-> - `findings/re-frame2-reagent-stage1-api-surface.md` — Stage 1 surface analysis, eight RESOLVED decisions.
-> - `findings/reagent-slim-stage2-efficiency.md` — Stage 2 bundle and runtime estimates.
-> - `findings/recom-react19-readiness-audit.md` (rf2-cgcv) — re-com + 10x lifecycle inventory.
-> - `findings/dash8-rf8-react19-readiness-audit.md` (rf2-kfpf) — Dash8 + rf8 lifecycle and SSR inventory.
-> - `FORM-3.md` (rf2-pe4u, future) — Form-3 cap specifics with worked examples.
+> Companion docs:
+> - [`IMPL-SPEC.md`](IMPL-SPEC.md) — the engineering decisions and shipped disposition.
+> - [`FORM-3.md`](FORM-3.md) — the Form-3 cap with worked examples.
 
 This document explains, decision by decision, **why** reagent-slim is shaped the way it is. If you want to know **how** it was built, read `IMPL-SPEC.md`. If you want to know what changed in your code, read the migration corpus ([`migration/from-re-frame-v1/README.md`](../../../migration/from-re-frame-v1/README.md)) together with `IMPL-SPEC.md` §13 (bridge → rewrite migration path). If you want to know whether to adopt it, read this.
 
@@ -142,7 +141,8 @@ The cap also lets `create-class`'s validation be simple. The supported set is sm
 
 For the four audited codebases: zero changes. Their existing `create-class` calls work as-is. For codebases outside the audit using a banned key: rewrite the lifecycle into the supported set, or stay on `re-frame2-reagent`. The throw fires at first invocation with a clear message — no silent breakage.
 
-The companion document `FORM-3.md` (rf2-pe4u, future) covers Form-3 worked examples in detail.
+The companion document [`FORM-3.md`](FORM-3.md) covers Form-3 worked examples
+in detail.
 
 ---
 
@@ -410,10 +410,15 @@ Adoption shape:
 
 ## §12 What this doc is not
 
-This doc is for adopters. It is not the implementation spec — see `IMPL-SPEC.md` for that. It is not the Form-3 worked-examples doc — see `FORM-3.md` (rf2-pe4u, future) for that. It is not a benchmark report — Stage 4's build-comparison harness produces that. And it is not a marketing pitch — the "fast" claim was dropped because the runtime story did not support it, and the doc you just read flags every claim that depends on Stage 4 validation.
+This doc is for adopters. It is not the implementation spec — see
+[`IMPL-SPEC.md`](IMPL-SPEC.md) for that. It is not the Form-3 worked-examples
+doc — see [`FORM-3.md`](FORM-3.md). It is not a benchmark report or a marketing
+pitch; estimated claims remain labelled as estimates.
 
-Read the audits if you want the empirical underpinning. Read Stage 1 if you want the surface enumeration. Read Stage 2 if you want the size and runtime estimates. Read this doc to decide whether the rewrite fits your codebase.
+Read this document to decide whether the rewrite fits your codebase, then use
+the implementation spec and current test gates for the binding engineering
+contract.
 
 ---
 
-*Cross-references: Stage 1 (`findings/re-frame2-reagent-stage1-api-surface.md`), Stage 2 (`findings/reagent-slim-stage2-efficiency.md`), rf2-cgcv audit, rf2-kfpf audit, IMPL-SPEC.md (this directory), FORM-3.md (rf2-pe4u, future).*
+*Cross-references: [`IMPL-SPEC.md`](IMPL-SPEC.md), [`FORM-3.md`](FORM-3.md).*

--- a/implementation/adapters/reagent-slim/FORM-3.md
+++ b/implementation/adapters/reagent-slim/FORM-3.md
@@ -39,13 +39,10 @@ concern only.
 
 ## §2 Why these seven keys
 
-The cap is what the four production Day8 codebases use, plus nothing else. Two
-audits established this empirically (2026-05-10):
-
-- **`findings/recom-react19-readiness-audit.md`** (bead rf2-cgcv) — surveyed
-  re-com (master) and re-frame-10x (master).
-- **`findings/dash8-rf8-react19-readiness-audit.md`** (bead rf2-kfpf) — surveyed
-  Dash8 and rf8 (Day8 internal apps).
+The cap is what four production Day8 codebases use, plus nothing else. Audits
+of re-com, re-frame-10x, Dash8, and rf8 established this empirically in May
+2026; the relevant results are summarized below so this document is
+self-contained.
 
 ### What the audits found
 
@@ -543,18 +540,10 @@ idioms.
 
 ## §7 Cross-references
 
-- **Stage 1 findings doc** (rf2-ui6g) — `findings/re-frame2-reagent-stage1-api-surface.md`,
-  §6 DECISION-3 (the cap decision rationale) and §1.10 (Form-1/2/3 conventions).
-- **re-com + re-frame-10x audit** (rf2-cgcv) —
-  `findings/recom-react19-readiness-audit.md`, §4 (six-key cap recommendation
-  including `:get-snapshot-before-update`) and §3 (10x per-site key sets).
-- **Dash8 + rf8 audit** (rf2-kfpf) —
-  `findings/dash8-rf8-react19-readiness-audit.md`, §6 (seven-key cap recommendation
-  including `:component-did-catch`) and §4 (per-site key sets).
-- **IMPL-SPEC** — `IMPL-SPEC.md` §6 (Form-3 implementation: validation throw
-  shape, React-class wrapper, lifecycle key → method mapping).
-- **DESIGN-RATIONALE** — `DESIGN-RATIONALE.md` §4 (the 7-key Form-3 cap — design
-  rationale and re-frame2-fit framing).
-- **Views spec** — `spec/004-Views.md` §"Form-3 (class — out of scope for the
+- **[IMPL-SPEC](IMPL-SPEC.md)** §6 — Form-3 implementation: validation throw
+  shape, React-class wrapper, and lifecycle key → method mapping.
+- **[DESIGN-RATIONALE](DESIGN-RATIONALE.md)** §4 — the seven-key Form-3 cap: design
+  rationale and re-frame2-fit framing.
+- **[Views spec](../../../spec/004-Views.md)** §"Form-3 (class — out of scope for the
   macro)" — Form-3 is intentionally not supported by the `reg-view` macro; use
   `re-frame.core/reg-view*` (the plain-fn surface) for Form-3 components.

--- a/implementation/adapters/reagent-slim/IMPL-SPEC.md
+++ b/implementation/adapters/reagent-slim/IMPL-SPEC.md
@@ -1,18 +1,15 @@
-# reagent-slim — Stage 3 implementation spec
+# reagent-slim — implementation spec
 
-> Stage 3 of rf2-5djt (parent epic). Bead **rf2-60le**.
-> The artefact is `day8/reagent-slim`; the classic thin-bridge adapter ships today as `day8/re-frame2-reagent` (`day8/reagent-classic` is a possible post-1.0 rename of that bridge — see §11.4 — and is used in this spec only where the discussion is explicitly about that future rename).
-> Stage 1 (rf2-ui6g) closed the surface; Stage 2 (rf2-142b) sized the wins. This
-> document is the engineering spec Stage 4 (rf2-6hyy) implements against.
+> The artefact is `day8/reagent-slim`; the classic thin-bridge adapter ships as
+> `day8/re-frame2-reagent`. This document preserves the implementation decisions
+> and records their shipped disposition. Where planning text and current code
+> differ, an "as shipped" disposition calls out the result; the current source,
+> Spec 006, and test gates are authoritative.
 >
-> Inputs (binding):
-> - `findings/re-frame2-reagent-stage1-api-surface.md` — bounded surface, eight RESOLVED decisions.
-> - `findings/reagent-slim-stage2-efficiency.md` — bundle + runtime estimates, top-3 commitments, R-001..R-007 risk register, S3-001..S3-008 inputs.
-> - `findings/recom-react19-readiness-audit.md` (rf2-cgcv) — re-com + 10x lifecycle inventory.
-> - `findings/dash8-rf8-react19-readiness-audit.md` (rf2-kfpf) — Dash8 + rf8 lifecycle + SSR inventory.
-> - `findings/reagent-rewrite-analysis.md` §2 — friction inventory (kept per DECISION-8); §8 recommendation overruled.
-> - `implementation/adapters/reagent/` — current thin bridge (147 LoC); rewrite folds it in.
-> - `implementation/core/src/re_frame/views.cljs` (541 LoC) — reg-view wrapper + source-coord injector + plain-fn warn-once. Significant chunks fold into the renderer.
+> Current companion references:
+> - [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md) — adopter-facing rationale.
+> - [`FORM-3.md`](FORM-3.md) — supported class-component surface.
+> - [`../reagent/`](../reagent/) — the coexisting classic adapter.
 >
 > Hard constraints (settled):
 > 1. React 19 floor (DECISION-5; Stage 1 §2.3a) — no `reagent.dom`; that namespace and its React-19-removed surfaces are absent (rf2-jif0qp; not throw-on-call stubs).
@@ -1223,4 +1220,6 @@ A child component throws a Promise (Suspense's standard pattern); the parent's `
 
 *Word count: ~7 100.*
 
-*This spec is the binding input for Stage 4 (rf2-6hyy). Cross-references to Stage 1 (`findings/re-frame2-reagent-stage1-api-surface.md`) and Stage 2 (`findings/reagent-slim-stage2-efficiency.md`) are inline throughout. The current thin-bridge adapter at `implementation/adapters/reagent/` is the reference for unchanged-public-path elements (the adapter Var, the late-bind hook wiring, the cache-disposal contract).*
+*This document is an engineering record. The current thin-bridge adapter at
+[`../reagent/`](../reagent/) is the reference for unchanged public-path elements
+such as the adapter Var, late-bind hook wiring, and cache-disposal contract.*

--- a/implementation/adapters/reagent-slim/deps.edn
+++ b/implementation/adapters/reagent-slim/deps.edn
@@ -1,12 +1,7 @@
-;; day8/reagent-slim — re-frame2's Reagent rewrite (rf2-5djt; Stage 4 rf2-6hyy).
+;; day8/reagent-slim — re-frame2's Reagent-compatible implementation.
 ;;
-;; Stage 4-A scope: the reactive primitives (reagent2.ratom). Subsequent
-;; sub-stages add the render scheduler (4-B), component-shape detection
-;; (4-C), hiccup translation (4-D), pure-CLJS render-to-static-markup
-;; (4-E), throw-on-call shims (4-F), examples + MIGRATION (4-G).
-;;
-;; Per the IMPL-SPEC §1: this artefact is the "slim" rewrite of stock
-;; Reagent for React 19. It replaces (does not depend on) stock Reagent.
+;; This is the slim rewrite of stock Reagent for React 19. It replaces, and
+;; does not depend on, stock Reagent.
 ;; The bridge `day8/re-frame2-reagent` continues to ship in parallel so
 ;; consumers that need the dropped surfaces (`track`, `cursor`, `wrap`,
 ;; `with-let`, etc.) keep a path to the React-19-stable React API.
@@ -22,7 +17,7 @@
 
  :aliases
  {:test {:extra-paths ["test"]
-         :extra-deps  {;; rf2-try1x — silent-on-success reporter.
+         :extra-deps  {;; Silent-on-success reporter.
                        day8/re-frame2-test-quiet {:local/root "../../test-quiet"}
                        io.github.cognitect-labs/test-runner
                        {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
@@ -33,7 +28,7 @@
                         :git/sha "2b83503246e8291fc023d688574640a9b23d8c50"}}
           :main-opts  ["-m" "noahtheduke.clein"]}
 
-  ;; :main is the in-tree adapter ns (rf2-xcyaei). NOTE the published jar
+  ;; :main is the in-tree adapter ns. The published jar
   ;; ships the adapter at the CANONICAL `re-frame.adapter.reagent` ns, not
   ;; this `-slim` ns: at publication the release workflow's "Rename adapter
   ;; ns at publication (reagent-slim only)" step (.github/workflows/

--- a/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
+++ b/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
@@ -1,66 +1,36 @@
 (ns re-frame.adapter.reagent-slim
-  "The day8/reagent-slim adapter — emits the substrate map for
-  `re-frame.substrate.adapter` (6 required + 3 optional + 1 lifecycle
-  fn). Shape-compatible with the bridge adapter `re-frame.adapter.reagent`;
-  internals route through the `reagent2.*` rewrite of Reagent (no
-  stock-Reagent dep).
+  "Reagent-compatible adapter backed by the `reagent2.*` rewrite, with no
+  stock-Reagent dependency.
 
   A downstream app requires this adapter at its PUBLISHED namespace
   `re-frame.adapter.reagent` — the slim jar ships its adapter there (the
-  in-tree `-slim` ns is renamed at publication; IMPL-SPEC §13.1), so the
-  usage example is rename-stable both in-tree and post-publish:
+  in-tree `-slim` namespace is renamed during publication):
 
       (require '[re-frame.adapter.reagent :as ra])
       (rf/init! ra/adapter)
 
-  See IMPL-SPEC.md §2.1 (adapter map contract), §9 (late-bind hook table),
-  §13.1 (artefact-publication shape) and DESIGN-RATIONALE.md."
+  See IMPL-SPEC.md §13.1 for the publication transform."
   (:require [reagent2.core             :as r]
             [reagent2.ratom            :as ratom]
             [reagent2.dom.client       :as rdc]
             [reagent2.impl.template    :as template]
             [re-frame.substrate.spine   :as spine]
             [re-frame.views            :as views]
-            ;; Resource-lease deps (rf2-zxxc9f, rf2-qdkt8y). Both are CORE
-            ;; re-frame namespaces — no stock `reagent.*` edge, so bundle
-            ;; isolation (IMPL-SPEC §1.8) is preserved (the bridge adapter
-            ;; requires the same pair). `re-frame.adapter.resource-lease` carries
-            ;; the shared lease identity + lifecycle + component factory;
-            ;; `re-frame.adapter.context` (already on the slim classpath via
-            ;; `re-frame.views`) supplies the frame React-context.
+            ;; Both dependencies are in core and introduce no stock-Reagent
+            ;; edge. The lease factory owns shared lifecycle semantics; context
+            ;; supplies the React frame context.
             [re-frame.adapter.resource-lease :as resource-lease]
             [re-frame.adapter.context  :as adapter-context]))
 
 ;; ---- shared ratom-spine wiring --------------------------------------------
 ;;
-;; The container quartet, the React-root renderer, the dispose body and
-;; the SSR emitter helpers are the SAME shape as the bridge adapter
-;; `re-frame.adapter.reagent`, modulo the reactive-atom impl (`reagent2.*`
-;; here, stock `reagent.*` there). They live in
-;; `re-frame.substrate.spine/make-ratom-spine` (rf2-rzex9) — one
-;; implementation, two adapters, zero drift, mirroring the React-hook
-;; `make-react-spine` that backs UIx/Helix.
-;;
-;; CRITICAL — bundle isolation (IMPL-SPEC §1.8 / the
-;; `test:reagent-slim:bundle-isolation` gate). The spine MUST NOT
-;; `:require` stock `reagent.*`; the reactive-atom ops are INJECTED here
-;; as a flat set of bare fns so this adapter's `reagent2.*` requires stay
-;; confined to this ns and the spine never names a reactive-atom ns.
-;; deps.edn carries zero direct `reagent.*` requires (the slim framing: a
-;; re-implementation, not a thin wrapper).
-;;
-;; rf2-0u5em6: the spine assembles its internal ratom-ops map from these
-;; bare fns. This adapter passes ~7 bare fns (flat config keys, mirroring
-;; `make-react-spine`'s bare hook fns) instead of a hand-shaped keyword
-;; map — earlier this adapter and the bridge one each built a structurally-
-;; identical 7-key `:ratom-ops` map differing only by ns-alias, a "keep two
-;; maps in lockstep" hazard the flat-bare-fn shape removes.
+;; Reagent and reagent-slim share the ratom spine but inject different
+;; reactive implementations. The spine must not require either ratom namespace:
+;; stock `reagent.*` is structurally absent from the slim dependency graph.
 
 (def ^:private spine-fns
   (spine/make-ratom-spine
-    {;; Substrate-scoped gensym prefix (rf2-l4dmr) so a cross-substrate
-     ;; test bundle / log / inspector can attribute a watch to the slim
-     ;; adapter rather than confusing it with a stock-Reagent watch.
+    {;; Keep generated watch ids attributable in mixed-adapter test bundles.
      :gensym-prefix-sub "rf-reagent-slim-sub-"
      ;; Each op is a thin call-through lambda rather than the bare Var
      ;; value so the spine resolves the namespaced fn at CALL time. This
@@ -74,30 +44,16 @@
      :render-root   (fn [root tree] (rdc/render root tree))
      :hydrate-root  (fn [mount-point tree] (rdc/hydrate-root mount-point tree))
      :unmount-root  (fn [root] (rdc/unmount root))
-     ;; rf2-40a84 / rf2-0bz5ah — synchronous render-commit
-     ;; op. Runs `f` (which may mutate a ratom / dispatch),
-     ;; then drains the rea-queue + forceUpdates every dirty
-     ;; component via `reagent2.impl.batching/flush!`, INSIDE
-     ;; a `react-dom/flushSync` boundary so the forced
-     ;; re-renders COMMIT TO THE DOM synchronously before the
-     ;; op returns. Under React 19 `createRoot` a bare
-     ;; `forceUpdate` from outside React's batching is
-     ;; auto-batched (scheduled, not committed), so the
-     ;; boundary is load-bearing — see
-     ;; `reagent2.dom.client/flush-render!` for the full
-     ;; rationale + the empirical proof
-     ;; (`reagent_slim_flush_render_dom_cljs_test`). The
-     ;; commit is NOT microtask/rAF-deferred and fires even
-     ;; in a backgrounded / headless tab. (Distinct from
-     ;; `reagent2.dom.client/flush-views!`, the goog.DEBUG-
-     ;; gated act()-composing TEST primitive.)
+     ;; This is the production synchronous commit primitive. The React
+     ;; `flushSync` boundary is required because React 19 otherwise batches
+     ;; forceUpdate; `reagent2.dom.client/flush-views!` is the separate test
+     ;; primitive that composes with act and Suspense.
      :flush-render! rdc/flush-render!}))
 
 (def set-hiccup-emitter!
   "Install the hiccup → HTML fn used by render-to-string. Last call wins.
-  Per rf2-uo7v / IMPL-SPEC §2.1: published through the late-bind hook
-  `:reagent/set-hiccup-emitter!` so the SSR seam at re-frame.ssr
-  resolves it at load time without a static :require."
+  Published through a late-bound hook so `re-frame.ssr` can install it
+  without a static adapter-to-SSR dependency."
   (:set-hiccup-emitter! spine-fns))
 
 (def flush-views!
@@ -105,39 +61,21 @@
   intended for test code only. Calls (act (fn [] (batching/flush!)));
   with `f`, runs `f` then the synchronous render drain inside act.
   Returns nil. No-op when act() is unreachable in the current React build.
-
-  Per rf2-3yij Decision 6 / rf2-b6nm5: the canonical test-flush hook,
-  surfaced identically (same name, same ADAPTER-ns location, same
-  nil-return shape) across all four substrates — Reagent, reagent-slim,
-  UIx, Helix — so a test suite ports across substrates touching only the
-  init! Var. This is the canonical convergence: previously the only slim
-  flush-views! lived in the SUBSTRATE ns `reagent2.dom.client` and RETURNED
-  A PROMISE (the goog.DEBUG-gated microtask→act→microtask Suspense-ordering
-  primitive, IMPL-SPEC §4.6), which diverged in both location and return
-  type. That substrate-level primitive remains for Suspense-deterministic
-  callers; this adapter-ns Var is the cross-substrate canonical surface."
+  The promise-returning `reagent2.dom.client/flush-views!` remains available
+  when callers need deterministic Suspense ordering."
   (:flush-views! spine-fns))
 
-;; ---- resource-lease mount-lifecycle helper (rf2-zxxc9f, EP-0020 §Open Issue #1) --
+;; ---- resource-lease mount-lifecycle helper -------------------------------
 ;;
-;; The slim counterpart of `re-frame.adapter.reagent/with-resource-lease`. The
-;; lease's IDENTITY (owner mint) + LIFECYCLE semantics live ONCE in
-;; `re-frame.adapter.resource-lease` (rf2-qdkt8y), shared with the bridge
-;; Reagent adapter + the React-hook `use-resource-lease` (UIx / Helix), so a
-;; mixed-adapter process cannot collide two families' lease owners. At
-;; publication the slim ns is renamed to the canonical `re-frame.adapter.reagent`,
-;; so an app swapping `day8/re-frame2-reagent` → `day8/reagent-slim` finds the
-;; same `with-resource-lease` Var. This adapter supplies ONLY its `reagent2.*`
-;; substrate ops + the slim context-type wiring: the slim 7-key create-class cap
-;; (IMPL-SPEC §6.1) excludes `:context-type`, so contextType is set on the
-;; returned class AFTER `create-class` — never crossing into stock Reagent
-;; (bundle isolation). (The shared factory names the canonical
-;; `re-frame.adapter.reagent/with-resource-lease` marker for any
-;; `:rf.error/no-frame-context`, rename-stable post-publish — rf2-gjvu84.)
+;; Lease identity and ordering are shared across adapter families so mixed
+;; trees cannot mint colliding owners. The published namespace matches the
+;; stock adapter, so both artefacts expose the same Var. Slim's restricted
+;; create-class map cannot carry `:context-type`; contextType is attached to
+;; the returned class without introducing a stock-Reagent dependency.
 
 (def with-resource-lease
-  "reagent-slim component that takes a resource liveness LEASE for its mounted
-  lifetime (rf2-zxxc9f, EP-0020 §Open Issue #1) — the slim (Form-3)
+  "reagent-slim component that takes a resource liveness lease for its mounted
+  lifetime. It is the slim Form-3
   counterpart of the UIx / Helix `use-resource-lease` hook and the shape-twin
   of `re-frame.adapter.reagent/with-resource-lease`. On mount it dispatches
   `:rf.resource/ensure` with an app-minted `[:lease …]` owner; on unmount it
@@ -164,7 +102,7 @@
     :frame  — pin the lease to an explicit frame id, bypassing ambient
               frame-provider / dynamic-var resolution.
 
-  Frame resolution + timing (EP-0002 tier precedence): the lease frame is
+  Frame resolution and timing: the lease frame is
   resolved in `:reagent-render` via `resolve-lease-frame` — explicit `:frame`
   opt, else `frame/require-current-frame!` (dynamic-var FIRST, then the
   React-context tier). Resolving at RENDER time keeps the dynamic-var tier
@@ -182,13 +120,11 @@
   Under SSR (`render-to-string`) lifecycle methods do not run, so the
   acquire/release is a natural no-op — a client-lifetime concern.
 
-  The lease identity + lifecycle live once in
-  `re-frame.adapter.resource-lease/make-resource-lease-component` (rf2-qdkt8y);
-  this Var supplies only slim's `reagent2.*` `current-component` reader + the
-  slim context-type wiring below."
+  The shared factory owns lease identity and lifecycle; this Var only supplies
+  slim's current-component reader and context wiring."
   (resource-lease/make-resource-lease-component
     {:current-component r/current-component
-     ;; The slim 7-key create-class cap (IMPL-SPEC §6.1) excludes
+     ;; The slim create-class cap (IMPL-SPEC §6.1) excludes
      ;; `:context-type`, so React contextType is wired directly on the returned
      ;; class AFTER `create-class` — mirroring `reagent2.impl.template/
      ;; fn-to-class`'s `:contextType` threading and the reg-view
@@ -209,42 +145,19 @@
       (require '[re-frame.adapter.reagent :as ra])
       (rf/init! ra/adapter)
 
-  Drop-in shape-compatible with `re-frame.adapter.reagent/adapter` per
-  IMPL-SPEC §2.1 — the only difference is the substrate, not the keys.
-  Per Spec 006 §CLJS reference + rf2-agql: there is no default-adapter
-  registry; adapter wiring is explicit at the call site.
+  Shape-compatible with `re-frame.adapter.reagent/adapter`; only the substrate
+  implementation differs. Adapter installation is explicit.
 
-  The container quartet, renderer, render-to-string and dispose body
-  come from `spine/make-ratom-spine` (rf2-rzex9, shared with the bridge
-  Reagent adapter under an injected `reagent2.*` bare-fn set); the adapter
-  map + the nine-call ratom-family `route-hook!` table + the chained
-  SSR-emitter install are assembled by `spine/make-ratom-adapter`
-  (rf2-ee38b.1, also shared with the bridge adapter under an injected
-  `reagent2.*` bare-fn hook set). `register-context-provider` is passed in
-  (NOT spine-built) because it is the Reagent-component-shaped frame-
-  provider from `re-frame.views`, distinct from the React-hook spine's
-  hook-shaped one — keeping the core spine free of a spine→views edge.
-  CRITICAL: bundle isolation is preserved — the hook ops are injected
-  `reagent2.*` impls (flat bare-fn config keys, rf2-0u5em6), so the spine
-  names no reactive-atom ns (the `test:reagent-slim:bundle-isolation` gate
-  by construction). Per-hook rationale lives at `spine/make-ratom-adapter`."
+  The shared ratom spine owns rendering, disposal, hook routing, and SSR
+  publication. It receives only injected `reagent2.*` operations, preserving
+  the invariant that stock Reagent is absent from slim bundles."
   (spine/make-ratom-adapter
     spine-fns
     {:kind :rf.adapter/reagent-slim
-     ;; The frame-keyword arg is ignored — `build-frame-provider` is
-     ;; 0-arity (rf2-4y60); the returned component takes the frame keyword
-     ;; at render time. Per IMPL-SPEC §9.4: views.cljs continues to back
-     ;; the frame-provider; the rewrite doesn't replace it.
+     ;; The returned component receives the frame keyword at render time.
      :register-context-provider (fn [_frame-keyword] (views/build-frame-provider))
-     ;; Injected reagent2.* ops for the ratom-family late-bind hooks (flat
-     ;; bare-fn config keys, rf2-0u5em6 — the spine assembles the route-hook
-     ;; table from them). Wiring reagent2.* impls is load-bearing (rf2-s36l):
-     ;; without this seam the first (interop/add-on-dispose! ...) under the
-     ;; slim adapter threw because reagent2.ratom/Reaction does NOT reify
-     ;; stock Reagent's IDisposable. rf2-jicu2: the dual-IDisposable dispatch
-     ;; (re-frame-owned first, then reagent2's) is handled inside
-     ;; make-ratom-adapter — this adapter supplies the substrate-side
-     ;; `disposable?` predicate + `add-on-dispose!` / `dispose!` impls.
+     ;; reagent2 reactions do not implement stock Reagent's IDisposable; the
+     ;; spine handles re-frame-owned disposal before these substrate ops.
      :current-frame     views/current-frame
      :current-component r/current-component
      :atom              r/atom
@@ -256,26 +169,12 @@
      :reactive?         ratom/reactive?
      :after-render      r/after-render}))
 
-;; ---- warn-once cache reset wiring (rf2-qy6cl) -----------------------------
+;; ---- warn-once cache reset wiring -----------------------------------------
 ;;
-;; The slim hiccup interpreter carries a second warn-once cache beyond the
-;; spine's source-coord/non-DOM-root one: `reagent2.impl.template`'s
-;; `warned-keyword-prop` defonce (the §7.2 D2 keyword-on-non-HTML-prop
-;; notice). The source-coord cache is already chained into
-;; `:adapter/clear-warn-once-caches!` by `make-ratom-adapter` (rf2-4edk);
-;; the keyword-prop cache was left behind. Chain its clear-step here too —
-;; via the same `spine/install-clear-warn-once-step!` helper — so
-;; `make-reset-runtime-fixture` re-arms BOTH slim caches between tests and
-;; a sibling test cannot silently swallow a later same-pair warning. This
-;; lives in the adapter ns (not in reagent2.impl.template) to keep the
-;; vendored `reagent2.*` tree free of any `re-frame.*` edge — bundle
-;; isolation by construction.
-;;
-;; rf2-z79p8: enrol with an explicit label but NO arm/armed? probes — the
-;; cache atom is `^:private` in reagent2.impl.template and reaching into it
-;; from here would breach the same bundle-isolation rule. The empirical
-;; governance assertion skips probe-less entries; the source-enumeration
-;; assertion and the dedicated template_keyword_prop re-arm test cover this
-;; cache.
+;; The slim template interpreter has its own keyword-prop warning cache in
+;; addition to the spine cache. Enrol its public reset function here so test
+;; fixtures re-arm both caches. Keeping this wiring in the adapter avoids a
+;; `reagent2.*` to `re-frame.*` dependency; the private cache intentionally has
+;; no arm-state probe.
 (spine/install-clear-warn-once-step! template/clear-warned-keyword-prop!
                                      {:label :reagent-slim/warned-keyword-prop})

--- a/implementation/adapters/reagent/deps.edn
+++ b/implementation/adapters/reagent/deps.edn
@@ -1,32 +1,24 @@
-;; day8/re-frame2-reagent — Reagent adapter (rf2-0hxm).
+;; day8/re-frame2-reagent — stock Reagent adapter.
 ;;
-;; Per Spec 006 §Adapter shipping convention: each adapter ships in its
-;; own Maven artefact so a Reagent-only app does not transitively pull
-;; in UIx or Helix code (and vice versa). This artefact supplies the
-;; re-frame.adapter.reagent ns and depends on the core artefact for
-;; everything else.
+;; Each adapter ships separately so consumers only add the selected adapter's
+;; implementation dependencies. This artefact supplies
+;; re-frame.adapter.reagent and depends on core for the substrate contract.
 ;;
-;; The core artefact already carries Reagent as a runtime dep because the
-;; CLJS-side re-frame.views layer (the reg-view path) is Reagent-coupled
-;; per the rf2-0hxm decision; the adapter split here ships the adapter map
-;; separately, which is the slice the bundle-isolation argument needs.
-;; That coupling at views.cljs is preserved by design: the UIx adapter
-;; (rf2-3yij, shipped) added a parallel reg-view-uix (`defui`) rather than
-;; decoupling re-frame.views, and the React-hook substrates compose this
-;; ns's frame-aware-view wrapper around their own render-fns. See
-;; ../../core/deps.edn for the matching core-side note.
+;; Core itself still carries stock Reagent because the CLJS `reg-view` path is
+;; Reagent-backed. The artefact boundary isolates adapter code; it does not
+;; claim that a UIx or Helix consumer has a Reagent-free core classpath.
 {:paths ["src"]
  :deps  {day8/re-frame2 {:local/root "../../core"}}
 
  :aliases
  {:test {:extra-paths ["test"]
-         :extra-deps  {;; rf2-try1x — silent-on-success reporter.
+         :extra-deps  {;; Silent-on-success reporter.
                        day8/re-frame2-test-quiet {:local/root "../../test-quiet"}
                        io.github.cognitect-labs/test-runner
                        {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
          :main-opts   ["-m" "re-frame.test-quiet.runner"]}
 
-  ;; Clojars deploy (rf2-r382). Modeled on re-frame v1's release flow.
+  ;; Clojars deploy, modeled on re-frame v1's release flow.
   ;; The release workflow runs `clojure -M:clein deploy` from this
   ;; artefact's directory, which builds pom + jar and pushes to Clojars.
   ;;

--- a/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
+++ b/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
@@ -1,8 +1,6 @@
 (ns re-frame.adapter.reagent
-  "The Reagent adapter — browser default. Implements the substrate
-  contract; see `re-frame.substrate.adapter` for the contract itself
-  (canonical home: `core/src/re_frame/substrate/adapter.cljc`) and
-  Spec 006 §CLJS reference for the per-slot semantics."
+  "Default browser adapter, implementing the Spec 006 substrate contract
+  with stock Reagent."
   (:require [reagent.core :as r]
             [reagent.ratom :as ratom]
             [reagent.dom.client :as rdc]
@@ -13,30 +11,13 @@
 
 ;; ---- shared ratom-spine wiring --------------------------------------------
 ;;
-;; The container quartet, the React-root renderer, the dispose body and
-;; the SSR emitter helpers are the SAME shape as reagent-slim, modulo the
-;; reactive-atom impl (stock `reagent.*` here, `reagent2.*` there). They
-;; live in `re-frame.substrate.spine/make-ratom-spine` (rf2-rzex9) — one
-;; implementation, two adapters, zero drift, mirroring the React-hook
-;; `make-react-spine` that backs UIx/Helix. The reactive-atom ops are
-;; INJECTED here as a flat set of bare fns so the spine never `:require`s a
-;; reactive-atom ns: this adapter passes its stock `reagent.*` impls; the
-;; slim adapter passes `reagent2.*`. (Load-bearing for reagent-slim bundle
-;; isolation — the slim adapter's deps.edn carries zero direct `reagent.*`
-;; requires.)
-;;
-;; rf2-0u5em6: the spine assembles its internal ratom-ops map from these
-;; bare fns. Each adapter passes ~7 bare fns (flat config keys, mirroring
-;; `make-react-spine`'s bare hook fns) instead of a hand-shaped keyword
-;; map — earlier this adapter and the slim one each built a structurally-
-;; identical 7-key `:ratom-ops` map differing only by ns-alias, a "keep two
-;; maps in lockstep" hazard the flat-bare-fn shape removes.
+;; Reagent and reagent-slim share the ratom spine but inject different
+;; reactive implementations. The spine must not require either ratom namespace:
+;; that dependency direction keeps stock Reagent out of slim bundles.
 
 (def ^:private spine-fns
   (spine/make-ratom-spine
-    {;; Substrate-scoped gensym prefix (rf2-l4dmr) so a cross-substrate
-     ;; test bundle / log / inspector can attribute a watch to the
-     ;; Reagent adapter rather than confusing it with a slim watch.
+    {;; Keep generated watch ids attributable in mixed-adapter test bundles.
      :gensym-prefix-sub "rf-reagent-sub-"
      ;; Each op is a thin call-through lambda rather than the bare Var
      ;; value so the spine resolves the namespaced fn at CALL time. This
@@ -50,21 +31,14 @@
      :render-root   (fn [root tree] (rdc/render root tree))
      :hydrate-root  (fn [mount-point tree] (rdc/hydrate-root mount-point tree))
      :unmount-root  (fn [root] (rdc/unmount root))
-     ;; rf2-40a84 — synchronous render-flush op. Run `f`
-     ;; (which may mutate a ratom / dispatch), then
-     ;; `reagent.core/flush` drains Reagent's render queue
-     ;; SYNCHRONOUSLY — bypassing the rAF-scheduled
-     ;; `next-tick` drain — and (on React 19) commits the
-     ;; forced component re-renders to the DOM via
-     ;; react-dom/flushSync. NOT rAF-scheduled ⇒ fires even
-     ;; in a backgrounded / headless tab.
+     ;; Drain Reagent synchronously after `f`; unlike its normal next-tick path,
+     ;; this works in backgrounded and headless tabs.
      :flush-render! (fn [f] (f) (r/flush))}))
 
 (def set-hiccup-emitter!
   "Install the hiccup → HTML fn used by render-to-string. Last call wins.
-  Per rf2-uo7v / IMPL-SPEC §2.1: published through the late-bind hook
-  `:reagent/set-hiccup-emitter!` so the SSR seam at re-frame.ssr
-  resolves it at load time without a static :require."
+  Published through a late-bound hook so `re-frame.ssr` can install it
+  without a static adapter-to-SSR dependency."
   (:set-hiccup-emitter! spine-fns))
 
 (def flush-views!
@@ -73,34 +47,21 @@
   with `f`, runs `f` then the synchronous render drain inside act. Returns
   nil. When act() is unreachable in the current React build it degrades to
   a plain synchronous flush (still runs `f` and drains the render queue),
-  so a `:node-test` runner with no real React render path still flushes.
-
-  Per rf2-3yij Decision 6 / rf2-b6nm5: the canonical test-flush hook,
-  surfaced identically (same name, same adapter-ns location, same
-  nil-return shape) across all four substrates — Reagent, reagent-slim,
-  UIx, Helix — so a test suite ports across substrates touching only the
-  init! Var. Previously stock Reagent surfaced no adapter-level flush-views!
-  and tests reached for reagent.core/flush or react/act directly."
+  so a `:node-test` runner with no real React render path still flushes."
   (:flush-views! spine-fns))
 
-;; ---- resource-lease mount-lifecycle helper (rf2-cxozh4, EP-0020 §Open Issue #1) --
+;; ---- resource-lease mount-lifecycle helper -------------------------------
 ;;
-;; The lease's IDENTITY (owner mint) + LIFECYCLE semantics live ONCE in
-;; `re-frame.adapter.resource-lease` (rf2-qdkt8y) — shared with reagent-slim and
-;; the React-hook `use-resource-lease` (UIx / Helix), so a mixed-adapter process
-;; cannot collide two families' lease owners. This adapter supplies ONLY its
-;; stock-`reagent.*` substrate ops + the stock-Reagent context-type wiring
-;; (create-class copies a `:context-type` map key to the static `contextType`).
+;; Lease identity and ordering are shared across adapter families so mixed
+;; trees cannot mint colliding owners. This namespace supplies only stock
+;; Reagent's component and context wiring.
 
 (def with-resource-lease
-  "Reagent component that takes a resource liveness LEASE for its mounted
-  lifetime (rf2-cxozh4, EP-0020 §Open Issue #1) — the Reagent (Form-3)
-  counterpart of the UIx / Helix `use-resource-lease` hook. On mount it
+  "Reagent component that takes a resource liveness lease for its mounted
+  lifetime. It is the Form-3 counterpart of the UIx and Helix
+  `use-resource-lease` hook. On mount it
   dispatches `:rf.resource/ensure` with an app-minted `[:lease …]` owner; on
-  unmount it releases that lease via `:rf.resource/release-owner`. Use it so
-  a view declaratively OWNS a polled / cached resource for as long as it is
-  mounted — the mount-lifecycle half of resource ownership that otherwise
-  needs a hand-wired Form-3.
+  unmount it releases that lease via `:rf.resource/release-owner`.
 
   Call it as a Reagent component with the resource descriptor and a body
   thunk (a 0-arg fn returning hiccup — the children rendered while the lease
@@ -124,50 +85,15 @@
     :frame  — pin the lease to an explicit frame id, bypassing ambient
               frame-provider / dynamic-var resolution.
 
-  A single Form-3 `create-class` (NOT a Form-2 returning one — that would
-  mint a fresh component type per render and remount). It declares
-  `:context-type` = the shared frame-context (via
-  `re-frame.adapter.context/frame-context`) so the instance receives the
-  surrounding `frame-provider`'s frame — the same wiring `reg-view` uses.
-
-  Frame resolution + timing (EP-0002 tier precedence): the lease frame is
-  resolved in `:reagent-render` via `resolve-lease-frame` — the explicit
-  `:frame` opt, else the canonical `frame/require-current-frame!` reader
-  (dynamic-var `*current-frame*` FIRST, then the React-context tier, else the
-  loud `:rf.error/no-frame-context`). Resolving at RENDER time (not in a
-  commit-phase lifecycle method) keeps the dynamic-var tier able to win and
-  mirrors the React-hook twin's render-time resolution. The resolved frame +
-  descriptor + cause are stashed on the instance so the commit-phase methods
-  act on the render-time target even after the render scope unwinds.
-
-  Re-lease on change: a `:component-did-update` diffs the render-time
-  `[frame descriptor cause]` against the currently-held lease and, on any
-  change, RELEASES the old lease (into its old frame) then ENSURES the new
-  target — mirroring the twin's `deps-key`-keyed effect. So a descriptor
-  whose `:params` change across re-renders releases the old resource and
-  ensures the new one WITHOUT waiting for unmount; a value-equal descriptor
-  holds ONE lease with no churn. (React does not re-run
-  `:component-did-mount` on a props change, so re-leasing must live here.)
-
-  Idempotency: the lease owner is minted ONCE per instance (in `did-mount`)
-  and reused across re-leases, so a hot-reload re-mount settles to exactly
-  one held lease (ensure re-attaches the same lease; Spec 016 §Active
-  owners). Under SSR (`render-to-string`) lifecycle methods do not run, so
-  the acquire/release is a natural no-op — the lease is a client-lifetime
-  concern.
-
-  The lease identity + lifecycle live once in
-  `re-frame.adapter.resource-lease/make-resource-lease-component` (rf2-qdkt8y);
-  this Var supplies only stock Reagent's `current-component` reader + the
-  stock-Reagent context-type wiring (create-class copies a `:context-type` map
-  key to the static `contextType`, read via the `:adapter/current-frame` hook
-  during frame resolution)."
+  The component is one stable Form-3 class, not a Form-2 that creates a new
+  class on every render. It resolves the target frame during render, then uses
+  that captured target in commit-phase callbacks. On `[frame descriptor
+  cause]` changes it releases the old target before ensuring the new one while
+  retaining the same owner token. Value-equal inputs do not churn the lease.
+  SSR runs no lifecycle methods, so ownership is client-only."
   (resource-lease/make-resource-lease-component
     {:current-component r/current-component
-     ;; Reagent's create-class copies `:context-type` (camelCased to the React
-     ;; static `contextType`) onto the class, so the in-flight component's
-     ;; context carries the enclosing frame-provider's value — the class-
-     ;; component parity of the reg-view `{:contextType frame-context}` wiring.
+     ;; Reagent promotes `:context-type` to React's static `contextType`.
      :build-class (fn [class-map]
                     (r/create-class
                       (assoc class-map :context-type adapter-context/frame-context)))}))
@@ -178,44 +104,16 @@
       (require '[re-frame.adapter.reagent :as reagent])
       (rf/init! reagent/adapter)
 
-  See Spec 006 §CLJS reference: Reagent as default adapter for the
-  bridging pseudocode. Per rf2-agql there is no default-adapter
-  registry — adapter wiring is explicit at the call site.
-
-  The container quartet, renderer, render-to-string and dispose body
-  come from `spine/make-ratom-spine` (rf2-rzex9, shared with
-  reagent-slim); the adapter map + the nine-call ratom-family
-  `route-hook!` table + the chained SSR-emitter install are assembled by
-  `spine/make-ratom-adapter` (rf2-ee38b.1, also shared with reagent-slim).
-  `register-context-provider` is passed in (NOT spine-built) because it
-  is the Reagent-component-shaped frame-provider from `re-frame.views`,
-  distinct from the React-hook spine's hook-shaped one — keeping the core
-  spine free of a spine→views dependency edge. That provider keeps
-  children as trailing-positional hiccup (`[provider frame-kw & children]`)
-  — Reagent's idiomatic shape and the cross-substrate baseline the UIx /
-  Helix `$`-trailing-children providers were aligned toward (rf2-7kii2,
-  which moved only those React-hook adapters; the Reagent shape is
-  unchanged).
-
-  The hook ops are injected stock-`reagent.*` impls (flat bare-fn config
-  keys, rf2-0u5em6) so the spine never names a reactive-atom ns (bundle
-  isolation, identical to `make-ratom-spine`'s bare-fn contract). Per-hook
-  rationale lives at `spine/make-ratom-adapter`."
+  Adapter installation is explicit; there is no default-adapter registry.
+  `make-ratom-spine` and `make-ratom-adapter` own the logic shared with
+  reagent-slim. The Reagent-shaped frame-provider remains injected from
+  `re-frame.views`, keeping the spine independent of that component layer."
   (spine/make-ratom-adapter
     spine-fns
     {:kind :rf.adapter/reagent
-     ;; The frame-keyword arg is ignored — `build-frame-provider` is
-     ;; 0-arity (rf2-4y60); the returned component takes the frame keyword
-     ;; at render time. The arg stays in the substrate signature per
-     ;; Spec 006 §Frame-provider via React context.
+     ;; The returned component receives the frame keyword at render time.
      :register-context-provider (fn [_frame-keyword] (views/build-frame-provider))
-     ;; Injected stock-Reagent ops for the ratom-family late-bind hooks
-     ;; (flat bare-fn config keys, rf2-0u5em6 — the spine assembles the
-     ;; route-hook table from them). rf2-jicu2: the dual-IDisposable
-     ;; dispatch (re-frame-owned first, then the substrate's) is handled
-     ;; inside make-ratom-adapter — this adapter supplies only the
-     ;; substrate-side `disposable?` predicate + `add-on-dispose!` /
-     ;; `dispose!` impls.
+     ;; The spine handles re-frame-owned disposal before these substrate ops.
      :current-frame     views/current-frame
      :current-component r/current-component
      :atom              r/atom

--- a/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
@@ -754,35 +754,23 @@
 ;; ============================================================================
 
 ;; ----------------------------------------------------------------------------
-;; APP-LEVEL request/reply boundary (rf2-eygytk)
+;; APP-LEVEL request/reply boundary
 ;;
 ;; This request/reply path uses the Pattern-WebSocket APP-LEVEL correlation
 ;; shape — a per-message `:request-id`, a registered `:reply` event target,
 ;; and an `:in-flight` correlation map on the connection machine's `:data`
 ;; — and it is INTENTIONALLY OUTSIDE the EP-0011 uniform reply envelope.
 ;;
-;; Why this is not a divergent second vocabulary: [Managed-Effects §The
-;; uniform reply envelope] (the EP-0011 normative home) rules property 9
-;; (the uniform async-reply envelope) to apply to framework-SHIPPED managed
-;; async surfaces (HTTP, resources/mutations, machine async work, route
-;; loaders, timers). re-frame2 deliberately does NOT ship a managed
-;; WebSocket (Mike-ruled) — there is no `:rf.ws/*` fx, no reserved
-;; `:rf.ws/*` namespace, and no framework contract. [Pattern-WebSocket] is
-;; the canonical worked example of an APP/LIBRARY-built long-lived
-;; connection, and it explicitly recommends THIS correlation shape:
-;; "Treat individual messages over an open WebSocket as Pattern-AsyncEffect
-;; interactions when they are request-reply (correlation-id keyed)" and
-;; "Pattern-WebSocket's `:in-flight` map is the worked example of that
-;; [correlation] step." Pattern-AsyncEffect leaves correlation to the
-;; caller; it is NOT property 9. So `:request-id`/`:reply`/`:in-flight` is
-;; the SPEC-BLESSED app convention here, not a competing reply envelope.
+;; The uniform envelope applies to framework-shipped managed async surfaces.
+;; re-frame2 ships no managed WebSocket effect or reserved `:rf.ws/*`
+;; namespace, so this application-owned connection also owns its correlation
+;; vocabulary. Pattern-WebSocket uses this `:in-flight` shape as its worked
+;; example.
 ;;
-;; The assertions below pin the boundary explicitly so this scaffold stops
-;; teaching a second reply vocabulary by silent omission: the reply is the
-;; app's own message body, and it carries NONE of the EP-0011 reply-map
+;; The assertions below make the boundary explicit: the reply is the app's own
+;; message body, and it carries none of the framework reply-map
 ;; vocabulary (`:rf/reply-to`, `:status`, `:work/id`, `:work/kind`,
-;; `:completed-at`). If a future ruling folds this into the uniform
-;; envelope, these assertions are the canary that flips.
+;; `:completed-at`).
 (defn- request-reply-correlation-test []
   (with-sync-mock!
     (fn []

--- a/implementation/adapters/test-react/README.md
+++ b/implementation/adapters/test-react/README.md
@@ -1,10 +1,14 @@
 # Test-React adapter
 
-Packaging: **local-test-only — not a published artefact** (no Maven coordinate, no `:clein/build`; absent from the lockstep array, release matrix, and CI JVM job set by design — see this directory's `deps.edn` header). Public ns: `re-frame.adapter.test-react`. Status: **carries ported lifecycle regressions** (rf2-gqyqv skeleton, broadened under rf2-n2cuo). The headline rf2-4l7t2 sync-unmount-during-render bug is now reproduced *organically* (a child/sibling render body trips the guard), not via fabricated in-flight state.
+Packaging: **local-test-only — not a published artefact**. It has no Maven
+coordinate or `:clein/build` descriptor. Its public namespace is
+`re-frame.adapter.test-react`.
 
 A substrate adapter that simulates React class-3 lifecycle (constructor → did-mount → did-update → will-unmount) in pure CLJC. **No React, no DOM, no jsdom** — runs on the JVM and on Node-CLJS at unit-test speed.
 
-Purpose: catch React-lifecycle-driven bugs at unit-test speed without spinning up a browser. The seminal example is the rf2-4l7t2 bug class — *"Attempted to synchronously unmount a root while React was already rendering"* — which was caught at the Playwright + console-error gate but would be cheaper to catch as a unit test.
+Use it to catch React-lifecycle failures at unit-test speed. In particular, it
+can reproduce synchronous unmount while another root is rendering without
+starting a browser.
 
 ## When to reach for this adapter
 
@@ -13,14 +17,13 @@ Purpose: catch React-lifecycle-driven bugs at unit-test speed without spinning u
 | Stale closures in event handlers | yes (sub computation) | yes | yes |
 | Unbalanced subscribe / dispose | partial | **yes** (live-mount / ref-count imbalance) | yes |
 | Double-render | no | **yes** (extra `:render` / `:did-update` on the log) | yes |
-| Sync unmount during render (rf2-4l7t2) | no | **yes** (organic — see note) | yes (slow) |
+| Sync unmount during render | no | **yes** (organic — see note) | yes (slow) |
 | Real DOM measurement / event listeners | no | no | yes |
 | Real React reconciler quirks | no | no | yes |
 
-The three **bold** rows carry living regressions in
-`test/re_frame/adapter/test_react_cljs_test.cljc` (ported under rf2-n2cuo) — each
-asserts the bug's *symptom* (the error raised / the imbalance / the extra
-render), so a future regression in that class fails the unit test. If your bug
+The three **bold** rows have regression coverage in
+`test/re_frame/adapter/test_react_cljs_test.cljc`. Each asserts the observable
+symptom: the raised error, lifecycle imbalance, or extra render. If your bug
 class lives in the leftmost four rows and the seminal symptom is "React threw /
 logged a warning during a lifecycle transition," reach for the Test-React
 adapter. If the bug only manifests with a real DOM, real React, or real browser
@@ -30,17 +33,10 @@ timing, stay on Playwright.
 > **organically** — no fabricated in-flight state. A render tree may declare an
 > imperative body via the node shape `{:rf/component (fn [mount] ...)}`; the
 > body runs while a render is in flight and can mount children (via
-> `mount-child!`) or issue an `unmount!`. The regression
-> `organic-sync-unmount-during-render-rf2-4l7t2` models the real Story senbl
-> panel-host: a host re-renders to switch panels and, *from inside that render
-> body*, synchronously unmounts the previous panel's separately-tracked root.
-> The guard fires because React (the global render depth) is rendering
-> somewhere — the same condition React 18+ keys off, and the cross-root case
-> a per-mount render flag could not see. The companion
-> `deferred-unmount-after-render-is-safe-rf2-4l7t2-fix` proves the guard
-> discriminates in-render from after-render (the microtask-defer fix), so it is
-> not a blunt always-throw. The "**yes**" above now means "the bug condition is
-> reproduced," not merely "the guard logic is verified."
+> `mount-child!`) or issue an `unmount!`. The guard uses global render depth,
+> so a render body that unmounts a separately tracked root fails in the same
+> way as React. A paired regression verifies that the same unmount succeeds
+> after render, ensuring the guard is scoped to the unsafe ordering.
 
 ## Why a separate adapter instead of extending plain-atom
 
@@ -71,10 +67,10 @@ The `mount!` / `trigger-update!` / `unmount!` trio drive the simulator. The test
 A render tree may be plain opaque data (`[:div "hi"]` — most tests) *or* declare an imperative render body via the node shape `{:rf/component (fn [mount] ...)}`. The body runs during the render phase, while a render is in flight. From inside it you can:
 
 - **Mount children** with `(test-react/mount-child! child-tree)` — the child runs its own `constructor → render → did-mount` lifecycle, is recorded under the parent (`test-react/children`), and is torn down children-first when the parent unmounts.
-- **Issue an `unmount!`** of any root — and if you unmount an ancestor or a separately-tracked sibling while the render is in flight, the guard fires `:rf.error/sync-unmount-during-render` *organically*. This is the rf2-4l7t2 reproducer.
+- **Issue an `unmount!`** of any root — and if you unmount an ancestor or a separately-tracked sibling while the render is in flight, the guard fires `:rf.error/sync-unmount-during-render`.
 
 ```clojure
-;; The rf2-4l7t2 shape, organically:
+;; Cross-root unmount during render:
 (let [panel-a (test-react/mount! [:div.panel "A"])]
   (is (thrown-with-msg? ExceptionInfo #":rf.error/sync-unmount-during-render"
         (test-react/mount! {:rf/component
@@ -96,16 +92,17 @@ A render tree may be plain opaque data (`[:div "hi"]` — most tests) *or* decla
 | `:will-unmount` | The unmount thunk fires. |
 | `:forced-teardown` | `dispose-adapter!` drained a still-mounted root. |
 
-The simulator throws `:rf.error/sync-unmount-during-render` if `unmount!` is called while a render is in flight **anywhere in the tree** (tracked by a global render-depth counter, not a per-mount flag) — the rf2-4l7t2 production manifestation. Keying off the global depth is what lets the cross-root organic case (a parent re-render unmounting a separate sibling root) trip the guard, mirroring React's actual "while React was already rendering" condition.
+The simulator throws `:rf.error/sync-unmount-during-render` if `unmount!` is
+called while a render is in flight **anywhere in the tree**. A global counter,
+rather than a per-mount flag, is what catches a parent render unmounting a
+separately tracked sibling root.
 
 ## What this adapter does NOT cover
 
-- **No automatic re-render on app-db change.** Tests drive re-renders explicitly via `trigger-update!`. Children re-render only when a test re-runs the parent's render body or drives the child directly; there is no automatic propagation from a `subscribe-container` change. A follow-on bead may wire watchers into automatic `trigger-update!` calls if the use case warrants it.
+- **No automatic re-render on app-db change.** Tests drive re-renders explicitly via `trigger-update!`. Children re-render only when a test re-runs the parent's render body or drives the child directly; there is no automatic propagation from a `subscribe-container` change.
 - **No React context provider.** Frame-routing under this adapter is via the dynamic-var tier (`re-frame.frame/current-frame`); the React-context tier is degenerate.
 - **No `data-rf2-source-coord` annotation.** Spec 006 makes source-coord injection a normative entry on the adapter contract, but it lives "on the rendered root DOM element." This adapter has no DOM root — the render tree is opaque data — so per the spec's non-DOM-root exemption the annotation is N/A here.
 - **No real reconciliation.** Children declared by `mount-child!` are imperative mounts, not a diffed child list. The simulator does not reconcile a render tree's child vector across updates — that fidelity belongs to a real React adapter / Playwright. The class-3 invariants (constructor/render/did-mount ordering, children-before-parent teardown, the sync-unmount-during-render guard) are what this adapter verifies.
-
-If those gaps prove costly, file a follow-on bead with a concrete reproducer.
 
 ## Where this adapter sits in the family
 
@@ -117,9 +114,5 @@ If those gaps prove costly, file a follow-on bead with a concrete reproducer.
 | `re-frame.substrate.plain-atom` | `clojure.core/atom` | JVM / SSR / headless | No React; render throws |
 | **`re-frame.adapter.test-react`** | **Lifecycle simulator** | **JVM + CLJS unit tests** | **Pure-data class-3 lifecycle** |
 
-## Cross-references
-
-- [Spec 006 — Reactive substrate](../../../spec/006-ReactiveSubstrate.md) — the contract this adapter implements.
-- rf2-4l7t2 — the seminal sync-unmount-during-render bug; the motivating example for this adapter's existence, now reproduced organically as a unit regression.
-- rf2-gqyqv — the original skeleton bead.
-- rf2-n2cuo — broadened the skeleton: recursive child mounting + render bodies, the organic rf2-4l7t2 repro, and ported lifecycle regressions (unbalanced subscribe/dispose, double-render).
+The adapter implements the contract in
+[Spec 006 — Reactive substrate](../../../spec/006-ReactiveSubstrate.md).

--- a/implementation/adapters/test-react/deps.edn
+++ b/implementation/adapters/test-react/deps.edn
@@ -1,10 +1,10 @@
-;; Test-React adapter (rf2-gqyqv) — LOCAL-TEST-ONLY, NOT a published artefact.
+;; Test-React adapter — LOCAL-TEST-ONLY, NOT a published artefact.
 ;;
 ;; A substrate adapter that simulates React class-3 lifecycle
 ;; (constructor → didMount → didUpdate → willUnmount) in pure CLJC.
 ;; No React, no DOM, no jsdom — runs on the JVM and on Node-CLJS at
-;; unit-test speed. Purpose: catch React-lifecycle-driven bugs (the
-;; rf2-4l7t2 unmount-during-render class) without browser machinery.
+;; unit-test speed. Its purpose is to catch lifecycle ordering and synchronous
+;; unmount-during-render failures without browser machinery.
 ;;
 ;; Packaging status: this is a development/test fixture, NOT a published
 ;; Maven artefact. It deliberately carries NO Maven coordinate and NO

--- a/implementation/adapters/test-react/src/re_frame/adapter/test_react.cljc
+++ b/implementation/adapters/test-react/src/re_frame/adapter/test_react.cljc
@@ -1,48 +1,20 @@
 (ns re-frame.adapter.test-react
-  "The Test-React adapter — simulates the React class-3 lifecycle in pure
-  CLJC (no React, no DOM, no jsdom) so React-lifecycle-driven bugs (stale
-  closures, unbalanced subscribe/dispose, sync unmount inside render — the
-  rf2-4l7t2 class) can be caught at unit-test speed.
+  "Test-only adapter that simulates the React class-3 lifecycle in pure CLJC.
+  It catches lifecycle ordering, unbalanced mount/disposal, and synchronous
+  unmount-during-render failures without React, a DOM, or jsdom.
 
-  Implements the Spec 006 adapter contract: the 6 required fns, 2 of the
-  3 optional (`subscribe-container`, `register-context-provider` — no
-  `flush-render!`, since the test owns the clock via `trigger-update!`),
-  and the 1 lifecycle fn. The atom-backed
-  container quartet is shared with plain-atom via
-  `re-frame.substrate.atom-container`; the render half is the novel surface
-  — a `class-3` lifecycle simulator that records every transition into a
-  per-mount log and enforces the sync-unmount-during-render invariant (it
-  throws on a synchronous `unmount!` while a render is in flight ANYWHERE in
-  the tree, mirroring React 18+).
+  The atom-backed container operations are shared with plain-atom. Tests own
+  the render clock through `trigger-update!`, so this adapter intentionally
+  provides no `flush-render!`. Every lifecycle transition is recorded in a
+  per-mount log. `unmount!` throws while any render is in flight, matching
+  React's cross-root guard.
 
-  Render bodies + recursive children: a render tree may declare an imperative
-  body via the node shape `{:rf/component (fn [mount] ...)}`. The body runs
-  during the render phase (while the global render depth is non-zero) and can
-  mount children via `mount-child!` (which recurse through their own
-  lifecycle) or issue an `unmount!`. An `unmount!` of an ancestor/sibling from
-  inside such a body trips the guard ORGANICALLY — no hand-fabricated
-  in-flight state — which is exactly the rf2-4l7t2 shape (the senbl panel-host
-  unmounting the previous panel's root on a chip-row re-render).
+  A render tree may declare `{:rf/component (fn [mount] ...)}`. That body runs
+  during render and may call `mount-child!`, allowing tests to exercise nested
+  lifecycle and cross-root unmount ordering. There is no automatic rerender on
+  app-db change, React context traversal, or DOM source annotation.
 
-  Status: carries ported lifecycle regressions (rf2-n2cuo broadened the
-  rf2-gqyqv skeleton): organic sync-unmount-during-render, unbalanced
-  mount/unmount ref-count, and double-render.
-
-  Out of scope (deferred to follow-on beads):
-    - Auto-re-render on app-db change: tests drive re-renders explicitly
-      via `trigger-update!`. Children re-render only when a test re-runs the
-      parent's render body (via `trigger-update!` with the same body) or
-      drives the child directly; there is no automatic propagation.
-    - React-context provider traversal (frame-routing is via the
-      dynamic-var tier; the React-context tier is degenerate — no React).
-    - Source-coord annotation (Spec 006 §Source-coord annotation): N/A —
-      there is no DOM root to annotate, the render tree is opaque data, and
-      the spec exempts non-DOM roots.
-    - CLJS derived-value disposal / ref-count symmetry (rf2-pyp3n): see the
-      `make-derived-value` comment for the JVM-works / CLJS-silent split.
-
-  See README.md for the family table, the bug-class matrix, and the full
-  scope-boundary narrative. Usage:
+  Usage:
 
       (require '[re-frame.core :as rf]
                '[re-frame.adapter.test-react :as test-react])
@@ -76,18 +48,9 @@
   ;; Recompute on every deref. No caching: the test surface only runs a sub
   ;; a handful of times per case.
   ;;
-  ;; rf2-pyp3n: IDeref ONLY — deliberately no IWatchable / no disposal
-  ;; protocol. The sub-cache's per-reaction dispose path therefore works on
-  ;; the JVM (interop.clj implements dispose by reaction identity) but is a
-  ;; SILENT no-op under CLJS (this adapter withholds the :adapter/dispose! /
-  ;; :adapter/add-on-dispose! late-bind hooks — see the routing block at the
-  ;; foot of this ns — and interop.cljs routes through them, so unregistered
-  ;; hooks no-op). The derived value holds no host resources, so the
-  ;; PER-REACTION dispose has nothing to release. But the CACHE ENTRY itself
-  ;; (the `{:reaction … :ref-count n}` slot held on the frame) DOES survive a
-  ;; reaction that never auto-disposes — so `dispose-adapter!` MUST reset
-  ;; every live frame's sub-cache to clear stale entries + ref-counts across
-  ;; a dispose/reinstall cycle (rf2-ghfkkk). See `dispose-adapter!`.
+  ;; IDeref only: the value owns no host resource and has no CLJS disposal
+  ;; protocol. Frame sub-cache entries still retain reactions and ref-counts,
+  ;; so adapter disposal clears every live frame cache.
   (reify
     #?(:clj clojure.lang.IDeref :cljs IDeref)
     (#?(:clj deref :cljs -deref) [_]
@@ -102,8 +65,8 @@
 ;;   :lifecycle-log   — atom holding a vector of {:phase ... :seq n} entries;
 ;;                      the test driver inspects this to assert ordering (`:seq`
 ;;                      is the monotonic order-key — see `phase-seq`).
-;;   :mounted?        — atom<boolean>; false after unmount. The simulator
-;;                      THROWS on trigger-update! / unmount! after teardown.
+;;   :mounted?        — atom<boolean>; false after unmount. Updates then throw;
+;;                      repeated unmounts are no-ops.
 ;;   :children        — atom<vector<MountedComponent>>; child roots this mount
 ;;                      mounted from inside its own render body via
 ;;                      `mount-child!`. Unmounting a parent cascades to its
@@ -117,16 +80,9 @@
 ;; All live mounts; `dispose-adapter!` walks this to drain.
 (defonce ^:private active-mounts (atom #{}))
 
-;; Global render depth — "React is rendering somewhere in the tree." React's
-;; sync-unmount-during-render guard fires whenever ANY render is in flight, not
-;; only when the root being unmounted is itself mid-render. The rf2-4l7t2 shape
-;; is exactly this cross-root case: a parent re-renders and, from inside that
-;; render body, synchronously unmounts a SEPARATELY-tracked sibling/child root
-;; (the senbl panel-host unmounting the previous panel's root on a chip-row
-;; switch). A per-mount "am I rendering?" boolean could not see that — it would
-;; be false on the sibling being torn down — so the guard keys off this global
-;; counter. A counter (not a boolean) so nested child renders restore it
-;; correctly on unwind.
+;; React rejects synchronous unmount while any root is rendering. A global
+;; counter catches cross-root unmounts and restores correctly across nested
+;; child renders; a per-mount flag would miss sibling-root failures.
 (defonce ^:private render-depth (atom 0))
 
 ;; The mount whose render body is currently executing, if any. `mount-child!`
@@ -142,16 +98,8 @@
   []
   (pos? @render-depth))
 
-;; A process-global monotonic order-key stamped on every logged phase. A
-;; wall-clock timestamp is the wrong tool for teardown-ORDER assertions here:
-;; a whole cascade completes sub-millisecond, so `now-ms`-style timestamps
-;; collapse to the SAME integer and a `<=`-on-ms ORDER check is vacuous — it
-;; stays green even on a reversed (root-downward) teardown, the exact bug the
-;; check exists to catch. This counter increments once per logged phase, so a
-;; strict `<` over two phases' `:seq` values discriminates their REAL firing
-;; order and fails deterministically on a reversal. `dispose-adapter!` resets
-;; it per test (only relative order within a cascade matters, so the reset is
-;; hygiene — keeping the numbers small + deterministic across the suite).
+;; A counter, rather than millisecond timestamps, gives deterministic ordering
+;; when an entire teardown cascade completes within one clock tick.
 (defonce ^:private phase-seq (atom 0))
 
 (defn- log-phase! [mount phase & {:as extras}]
@@ -196,7 +144,7 @@
   already-unmounted mount is a no-op). Cascades to children first (React tears
   children down before their parent). Throws
   `:rf.error/sync-unmount-during-render` if called while a render is in flight
-  ANYWHERE in the tree (the rf2-4l7t2 class) — keyed off the global
+  anywhere in the tree — keyed off the global
   `render-depth`, so a parent re-render that synchronously unmounts a separate
   sibling/child root trips the guard just as React does.
 
@@ -314,9 +262,8 @@
       (str "Test-React adapter has no built-in hiccup emitter; call "
            "set-hiccup-emitter! (or require re-frame.ssr) before "
            "render-to-string if a test needs HTML output.")
-      ;; EP-0015 (rf2-uwqale): carry an EP-0015-safe SUMMARY of the
-      ;; render-tree, never the raw tree (a thrown render diagnostic is
-      ;; captured off-box before path-based projection can classify it).
+      ;; Diagnostics may be captured before path-based classification, so never
+      ;; attach the raw render tree.
       {:recovery :call-set-hiccup-emitter
        :extra    {:render-tree/summary (error/diag-value-summary render-tree)}})))
 
@@ -333,11 +280,8 @@
 
 (defn- dispose-adapter! []
   ;; Drain any still-mounted components so a test fixture that forgets to
-  ;; unmount doesn't leak across cases. Per the rf2-4l7t2 lesson the drain
-  ;; MUST tolerate the sync-unmount-during-render guard — we set mounted? false
-  ;; WITHOUT routing through the public `unmount!` (which would throw on a
-  ;; non-zero render-depth) and log a :forced-teardown phase so the
-  ;; test surface can spot drift.
+  ;; unmount does not leak across cases. Forced teardown bypasses the public
+  ;; render-depth guard and records a distinct lifecycle phase.
   ;;
   ;; The hiccup-emitter is deliberately NOT cleared: it holds no host
   ;; resource, is re-derivable infrastructure installed once via the
@@ -347,23 +291,9 @@
   ;; cycle. Matches plain-atom's dispose-adapter! (a no-op that leaves the
   ;; emitter alone).
   ;;
-  ;; rf2-ghfkkk: this ALSO walks every live frame's per-frame sub-cache and
-  ;; resets it, the externally-visible counterpart of the React adapters'
-  ;; `spine/dispose-frame-sub-caches!` (Spec 006 §Adapter disposal lifecycle
-  ;; MUST 1 + §Lifetime contract — frame disposal §Adapter symmetry). The
-  ;; React-adapter walk is CLJS-only (the spine is CLJS-only); test-react is
-  ;; CLJC, so it routes through the CLJC-safe shared helper
-  ;; `subs-cache/clear-all-frame-sub-caches!` instead. Why this matters even
-  ;; though `make-derived-value` holds no host resource (plain IDeref reify,
-  ;; so the per-reaction dispose is a CLJS no-op): the CACHE ENTRIES + REF-
-  ;; COUNTS live on the FRAME, not the reaction, and a reaction that never
-  ;; auto-disposes leaves its `{:reaction … :ref-count n}` slot in the frame's
-  ;; sub-cache. Without this reset a test process carries stale slots + stale
-  ;; ref-counts across a dispose/reinstall cycle — a later subscribe reads the
-  ;; stale cached value instead of recomputing from fresh state, breaking
-  ;; isolation. The reset clears the slots so the next subscribe is a fresh
-  ;; cache miss that recomputes. (The helper fires BEFORE the active-mounts
-  ;; drain below, but order is immaterial — they touch disjoint state.)
+  ;; Derived values have no CLJS disposal protocol, but their cache entries and
+  ;; ref-counts live on frames. Clear every frame cache so reinstalling the
+  ;; adapter cannot read a stale subscription value.
   ;;
   ;; Drain flat over active-mounts: children are themselves registered in
   ;; active-mounts (mount-tree! adds every mount, parent or child), so a flat
@@ -372,9 +302,6 @@
   ;; render-depth guard) — forced teardown is the
   ;; escape hatch the guard deliberately cannot block.
   ;;
-  ;; rf2-ghfkkk — dispose every live frame's sub-cache (the reactive-
-  ;; subscription MUST). CLJC-safe shared helper, equal semantics to the
-  ;; React adapters' spine walk.
   (subs-cache/clear-all-frame-sub-caches!)
   (doseq [mount @active-mounts]
     (when @(:mounted? mount)
@@ -382,15 +309,10 @@
       (reset! (:mounted? mount) false)
       (reset! (:render-tree mount) nil)))
   (reset! active-mounts #{})
-  ;; Reset the global render depth. `run-render!`'s `finally` already restores
-  ;; it on the normal + guard-throw paths; this is belt-and-braces so a test
-  ;; that bypassed run-render! by hand cannot leak a stuck "rendering" state
-  ;; into the next case.
+  ;; Normal renders restore this in finally; disposal also repairs test code
+  ;; that bypassed the public driver.
   (reset! render-depth 0)
-  ;; Reset the monotonic phase order-key so each test's lifecycle log starts
-  ;; from a small, deterministic sequence. Only relative order within a single
-  ;; cascade is load-bearing, so this is hygiene, not correctness — it mirrors
-  ;; the render-depth reset above.
+  ;; Only relative phase order within a case matters.
   (reset! phase-seq 0)
   nil)
 
@@ -401,12 +323,9 @@
       (require '[re-frame.adapter.test-react :as test-react])
       (rf/init! test-react/adapter)
 
-  Per Spec 006 §The adapter API contract — implements the 6 required +
-  2-of-3 optional (no `flush-render!`) + 1 lifecycle fn. The
-  reactive-container half is shared with plain-atom; the
-  render half is the novel surface (class-3 lifecycle simulation with the
-  global-render-depth sync-unmount-during-render invariant). See `mount!` / `trigger-update!` /
-  `unmount!` for the test driver helpers."
+  The reactive-container half is shared with plain-atom; this adapter adds the
+  class-3 lifecycle simulator and its global unmount-during-render guard. See
+  `mount!`, `trigger-update!`, and `unmount!` for the test driver."
   {:kind                      :rf.adapter/test-react
    :make-state-container      atom-container/make-state-container
    :read-container            atom-container/read-container
@@ -443,8 +362,8 @@
   `MountedComponent` record carrying the lifecycle log and the unmount
   thunk. Throws if a non-test-react adapter is installed.
 
-  The installed-adapter check is `substrate-adapter/same-adapter?`
-  (stable-token routing, rf2-dkl5z1), NOT raw object identity — so a copied
+  The installed-adapter check uses the stable adapter kind, not raw object
+  identity, so a copied
   or wrapped Test-React adapter map (same canonical `:rf.adapter/test-react`
   `:kind`, e.g. one `assoc`'d with an instrumentation wrapper) is still
   accepted, matching the routed hooks' acceptance of the same copy."
@@ -481,7 +400,7 @@
   "Unmount `mount`, cascading to its children first (React tears children down
   before their parent). Records a `:will-unmount` phase entry per torn-down
   mount. Throws `:rf.error/sync-unmount-during-render` if called while a render
-  is in flight anywhere in the tree (the rf2-4l7t2 class) — including the
+  is in flight anywhere in the tree, including the
   organic case where a parent's render body synchronously unmounts a separate
   sibling/child root. Idempotent: a second call on the same mount is a no-op."
   [mount]

--- a/implementation/adapters/uix/deps.edn
+++ b/implementation/adapters/uix/deps.edn
@@ -1,63 +1,39 @@
-;; day8/re-frame2-uix — UIx adapter (rf2-3yij).
+;; day8/re-frame2-uix — UIx adapter.
 ;;
-;; Per Spec 006 §Adapter shipping convention: each adapter ships in its
-;; own Maven artefact so a UIx-only app does not transitively pull in
-;; Reagent or Helix code (and vice versa). This artefact supplies the
-;; re-frame.adapter.uix ns and depends on the core artefact for
-;; everything else.
+;; Each adapter ships separately so consumers only add the selected adapter's
+;; implementation dependencies. Core still carries stock Reagent for its
+;; `reg-view` path; this boundary prevents UIx and Helix adapter dependencies
+;; from pulling one another in.
 ;;
-;; Per rf2-3yij Decision 2 the React frame-context lives in
-;; re-frame.adapter.context (CLJS-only file in core); both this UIx
-;; adapter and the Reagent adapter read that *same* createContext
-;; object so frame-provider chains compose across substrates in
-;; mixed-substrate apps.
+;; React-shaped adapters read the same frame context from core, allowing mixed
+;; Reagent, UIx, and Helix provider trees to compose.
 ;;
-;; Per rf2-3yij Decision 8 we target UIx 2.x (hooks-based). UIx 1.x
-;; back-compat is explicitly out of scope.
-;;
-;; PRODUCT-VERSION vs MAVEN-VERSION (rf2-xcyaei). "UIx 2.x" is the
-;; product/API-family name (the hooks-based generation hosted at
-;; github.com/pitch-io/uix), NOT the Maven coordinate version. UIx 2 is
-;; published on Clojars as `com.pitch/uix.core` with version numbers in
-;; the 1.x.x series — so the `com.pitch/uix.core {:mvn/version "1.4.4"}`
-;; pin below IS UIx 2.x. The legacy UIx 1 generation (roman01la/uix) is
-;; a different, pre-hooks codebase and is the surface ruled out of scope
-;; above. Do not "upgrade" this coordinate to a 2.x.y Maven version — no
-;; such version exists; that would be a non-resolving coordinate.
+;; "UIx 2.x" names the hooks-based product/API family, not its Maven version.
+;; That family is published as com.pitch/uix.core 1.x.x; there is no 2.x.y
+;; Maven coordinate.
 ;;
 ;; UIx itself is a CLJS-only library; this artefact is therefore
 ;; CLJS-only. The :test alias exists for classpath-probe parity with
 ;; the other per-adapter artefacts (Reagent's :test alias is also
 ;; classpath-probe-only).
-;; rf2-sl7ml — the SHIPPING :deps declare only what the PUBLISHED src
-;; requires: re-frame.adapter.uix requires `uix.core` + `uix.hooks.alpha`
-;; only. `uix.dom` is NOT required by the shipped adapter (the spine owns
-;; the DOM mount path via react-dom/client directly — see
-;; `re-frame.substrate.spine/make-render`), so it must not land in the
-;; published day8/re-frame2-uix pom and force every downstream consumer to
-;; resolve it. (Helix's deps.edn already declares only lilactown/helix —
-;; no helix.dom — for the same reason.) The ONLY consumer of `uix.dom` is
-;; the non-shipped testbed, which builds from the top-level
-;; implementation/shadow-cljs.edn (that build supplies com.pitch/uix.dom
-;; via its own :dependencies); the :test alias below also carries it for
-;; the per-artefact classpath probe.
+;; Shipping source requires only uix.core; the shared spine mounts through
+;; react-dom/client. uix.dom therefore stays test-only and out of the published
+;; pom.
 {:paths ["src"]
  :deps  {day8/re-frame2 {:local/root "../../core"}
          com.pitch/uix.core {:mvn/version "1.4.4"}}
 
  :aliases
  {:test {:extra-paths ["test"]
-         ;; rf2-sl7ml — uix.dom lives here (test/testbed classpath), NOT in
-         ;; the shipping :deps, because the published adapter src never
-         ;; requires it (only the testbed does).
+         ;; uix.dom is used by tests and the testbed, not shipped adapter source.
          :extra-deps  {com.pitch/uix.dom {:mvn/version "1.4.4"}
-                       ;; rf2-try1x — silent-on-success reporter.
+                       ;; Silent-on-success reporter.
                        day8/re-frame2-test-quiet {:local/root "../../test-quiet"}
                        io.github.cognitect-labs/test-runner
                        {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
          :main-opts   ["-m" "re-frame.test-quiet.runner"]}
 
-  ;; Clojars deploy (rf2-r382). Modeled on the Reagent adapter's flow.
+  ;; Clojars deploy, modeled on the Reagent adapter's flow.
   ;; The release workflow runs `clojure -M:clein deploy` from this
   ;; artefact's directory, which builds pom + jar and pushes to Clojars.
   ;;

--- a/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
+++ b/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
@@ -1,19 +1,10 @@
 (ns re-frame.adapter.uix
-  "The UIx adapter — second canonical browser substrate, targeting UIx
-  2.x (hooks-based). Per Spec 006 §CLJS reference: UIx as alternative
-  substrate. Ships in `day8/re-frame2-uix`; dependency flows adapter
-  → core.
+  "UIx 2.x adapter for the substrate contract in Spec 006.
 
-  Shares the React-shaped substrate machinery (container quartet,
-  derived value, render-root, render-to-string, use-subscribe, flush-
-  views!, source-coord wrapper, warn-once-cache) with the Helix adapter
-  via `re-frame.substrate.spine`. The frame-provider CORE
-  (`build-frame-provider-element`) is likewise shared, but the user-
-  facing `frame-provider` is a NATIVE UIx `defui` in this ns (rf2-z7hfp
-  moved the seam up), NOT a spine re-export. UIx-specific
-  configuration: gensym prefixes, substrate name (used in warn-once
-  text), and the runtime hook fns from `uix.hooks.alpha` (the
-  `uix.core` macros expand to these)."
+  UIx and Helix share the React machinery in `re-frame.substrate.spine`.
+  This namespace supplies UIx's hooks and a native `defui` frame-provider;
+  keeping that component native preserves UIx's CLJS prop and trailing-child
+  marshalling."
   (:require [uix.core          :as uix :refer-macros [defui]]
             [uix.hooks.alpha   :as uix-hooks]
             [re-frame.frame             :as frame]
@@ -45,95 +36,47 @@
   "UIx hook returning the current frame keyword from the surrounding
   React context, or the no-provider sentinel
   (`re-frame.adapter.context/no-provider-sentinel`) when no frame-provider
-  sits above — NOT `:rf/default` (EP-0002 carried invariant: the React-
-  context default is a no-provider sentinel, never a synthesised default).
-  Decision 2 mandates every React-shaped adapter resolves the same
-  context, so a UIx subtree under a Reagent frame-provider sees the
-  right frame and vice versa.
+  sits above. All React-shaped adapters use the same context, so mixed
+  Reagent, UIx, and Helix provider trees compose.
 
-  React-context tier only — this is the NARROW raw `useContext` read; it
-  does not map the sentinel to nil. For the full resolution chain
-  (dynamic-var → React-context → nil) use `(rf/current-frame-id)`; the
-  routed `:adapter/current-frame` hook (registered below) covers that
-  chain and returns nil (not `:rf/default`) when no scope is established,
-  so a public frame-scoped op fails loudly with
-  `:rf.error/no-frame-context`. Per rf2-84myk."
+  This is the raw React-context read and does not map the sentinel to nil.
+  Use `(rf/current-frame-id)` for dynamic-var then React-context resolution."
   (:use-current-frame spine-fns))
 
 (defui frame-provider
-  "User-facing component — the MERGED config-shaped frame-provider (EP-0024
-  §Scope, carry, and ownership, amended). ONE component, TWO config shapes,
-  dispatched on the prop map:
+  "Provide a frame to descendant UIx components. The prop map has two shapes:
 
-    - `{:frame existing-id}` → SCOPE-ONLY: provide an ALREADY-CREATED frame's
-      id to descendants; create / refresh / destroy NOTHING; FAIL LOUD when
-      the frame is absent (`:rf.error/frame-provider-frame-absent`).
-    - `{:id the-id …}` → ENSURE: CREATE the frame if absent, REUSE it WITHOUT
-      re-seeding if present, provide its id to descendants; NO
-      destroy-on-unmount.
+    - `{:frame existing-id}` scopes an existing frame and fails when it is absent.
+    - `{:id id ...}` creates the frame if absent and otherwise reuses it without
+      replaying `:initial-events`.
 
-  UIx call shape — the idiomatic `$` TRAILING-CHILDREN form, identical to
-  every other UIx component and mirroring Reagent's trailing-hiccup mental
-  model (rf2-7kii2):
+  Use UIx's normal trailing-children form:
 
-      ($ frame-provider {:frame :session}            ;; SCOPE-ONLY
+      ($ frame-provider {:frame :session}
          ($ header))
 
-      ($ frame-provider {:id :session :images [session-image] :initial-events []} ;; ENSURE
+      ($ frame-provider {:id :session :images [session-image]}
          ($ header)
          ($ main))
 
-  Children ride the native `$` trailing-args channel; there is no
-  `:children` prop-map key to remember (forgetting it used to drop the
-  subtree silently — that footgun is gone by construction). A single
-  child works too: `($ frame-provider {:id :session} ($ app))`.
+  The ensure shape accepts the frame-record options used by `rf/make-frame`;
+  `:id` is required and must be a keyword. Repeated mounts are intentionally
+  idempotent, including React StrictMode development mounts: they neither
+  destroy durable state nor replay initial events. The provider scopes or
+  ensures; explicit `rf/make-frame` and `rf/destroy-frame!` calls own teardown.
 
-  The SHAPE is selected by the presence of `:frame` vs `:id`. The ENSURE shape
-  takes the same `:id` / `:images` (plus record-config, incl.
-  `:initial-events` / `:url-bound?`) opts as `rf/make-frame`. `:id` is REQUIRED
-  and must be a KEYWORD: a missing / nil / non-keyword `:id` is a CONFIGURATION
-  ERROR — the ensure core emits + throws
-  `:rf.error/ensure-frame-provider-missing-id`. The three React-shaped adapters
-  share one React Context (the shared-context decision — rf2-3yij Decision 2,
-  carried into the Helix adapter as rf2-2qit Decision 2) so a subtree under any
-  frame-provider sees the right frame regardless of which substrate rendered
-  the provider.
-
-  Idempotent re-mount of the ENSURE shape (hot reload / React StrictMode dev
-  double-invoke / Story re-evaluation): re-mounting under the same `:id` MUST
-  NOT destroy durable state NOR re-run `:initial-events` — `make-frame` is
-  idempotent replacement and `reg-frame` RE-RECORDS but does NOT REPLAY
-  `:initial-events` (see `re-frame.views.owned-frame`). The owned
-  destroy-on-unmount of the pre-amendment provider is RETIRED; true ownership
-  stays expressible as `rf/make-frame` + `rf/destroy-frame!`.
-
-  Native shell above the prop-marshalling seam (rf2-z7hfp — Mike-ruled
-  C, MOVE THE SEAM UP). This is a NATIVE UIx `defui` component, NOT a
-  re-export of a shared fn handed to `$`. Because it is a real `defui`,
-  UIx's `$` stamps it `.-uix-component?` and routes its props through the
-  LOSSLESS `uix-component-element` (`argv`) path — `glue-args` reconstructs
-  the original CLJS props map with keyword values intact (namespace
-  preserved) AND folds the native trailing children into the `:children` key
-  (UIx's `$`/`glue-args` contract: `($ Comp props c1 c2)` arrives as `{...
-  :children #js [c1 c2]}`). The body reads the clean CLJS props map, DISPATCHES
-  on `:frame` vs `:id`, and delegates to the substrate-agnostic core
-  (`build-frame-provider-element` for SCOPE-ONLY, `ensure-frame-react-element`
-  for ENSURE). The prop-mangling class — UIx's `react-component-element` →
-  `interpret-attrs` stringifying keyword prop values and dropping the
-  namespace — is impossible by construction: there is no plain fn under `$`
-  for the element macro to mangle."
+  This must remain a native `defui`. UIx then reconstructs the original CLJS
+  prop map, preserving namespaced keyword values, and folds trailing children
+  into `:children` before this body delegates to the shared provider core."
   [props]
   (if (contains? props :frame)
-    ;; SCOPE-ONLY shape: validate the keyword `:frame` (nil →
-    ;; :rf.error/no-frame-context, non-keyword → :rf.error/bad-frame-provider-arg)
-    ;; FIRST, then fail loud if the frame is absent, then scope via the spine's
-    ;; scope-only core.
+    ;; Validate before consulting the registry so malformed ids get the
+    ;; configuration error rather than the absent-frame error.
     (let [frame-kw (frame/require-keyword-frame-provider-arg!
                      (:frame props) 're-frame.adapter.uix/frame-provider)]
       (owned-frame/require-live-frame-for-scope!
         frame-kw 're-frame.adapter.uix/frame-provider)
       (spine/build-frame-provider-element frame-kw (:children props)))
-    ;; ENSURE shape: validate `:id` + build the ensure element.
     (owned-frame/ensure-frame-react-element
       props
       (:children props)
@@ -143,33 +86,23 @@
   "UIx hook that reads a re-frame subscription. Returns the current
   value; re-renders the calling component when the value changes.
 
-  Frame resolution: reads the surrounding frame-provider's keyword via
-  `use-context` (rf2-3yij Decision 2). Override via the 2-arg form to
-  pin to an explicit frame-id.
-
-  Per rf2-3yij Decision 1 the hook is named `use-subscribe` to match
-  the React/UIx idiom — symmetric ergonomics to Reagent's
-  `(rf/subscribe ...)` deref shape, asymmetric naming (hooks live in
-  hook-named space)."
+  Reads the surrounding frame-provider by default; the 2-arg form pins an
+  explicit frame id."
   (:use-subscribe spine-fns))
 
 (def use-resource-lease
-  "UIx hook that takes a resource liveness LEASE for the calling
-  component's mounted lifetime (rf2-cxozh4, EP-0020 §Open Issue #1). On
+  "UIx hook that takes a resource liveness lease for the calling
+  component's mounted lifetime. On
   mount it dispatches `:rf.resource/ensure` with an app-minted `[:lease …]`
   owner; on unmount it releases that lease via `:rf.resource/release-owner`.
-  Use it so a view declaratively OWNS a polled / cached resource for as long
-  as it is on screen — the mount-lifecycle half of resource ownership that
-  otherwise needs a hand-wired `use-effect`.
+  Use it when a view owns a polled or cached resource while mounted.
 
       (use-resource-lease {:resource :my/feed :scope :rf.scope/global
                            :params {:page 0}})
 
-  Pair it with `use-subscribe` on a `[:rf.resource/*]` query to READ the
-  data; this hook manages liveness only (returns nil). Frame resolution +
-  the `:cause` / `:frame` opts mirror `use-subscribe`; the shared
-  substrate-agnostic implementation lives in
-  `re-frame.adapter.resource-lease`."
+  Pair it with `use-subscribe` to read the data; this hook only manages
+  liveness and returns nil. `:cause` annotates the ensure, and `:frame` pins
+  ownership to an explicit frame."
   resource-lease/use-resource-lease)
 
 (def flush-views!
@@ -177,10 +110,7 @@
   intended for test code only. Calls (act f); with no arg, calls (act
   (fn [] nil)) to flush pending effects. Returns nil. Resolves React's
   act() across React 18 (in `react-dom/test-utils`) and React 19 (on
-  the React namespace directly).
-
-  Per rf2-3yij Decision 6: the canonical test-flush hook for UIx-based
-  apps."
+  the React namespace directly)."
   (:flush-views! spine-fns))
 
 (def wrap-view
@@ -196,8 +126,7 @@
   "Reset the warn-once cache for non-DOM-root warnings. Tests use this
   between cases (via `make-reset-runtime-fixture` and the chained
   `:adapter/clear-warn-once-caches!` hook) so a sibling test's
-  first-encounter warning cannot silently swallow a later test's same-id
-  warning. Per rf2-4edk."
+  first-encounter warning cannot suppress a later test's same-id warning."
   (:clear-warned-non-dom-roots! spine-fns))
 
 ;; ---- adapter Var ----------------------------------------------------------
@@ -208,23 +137,10 @@
       (require '[re-frame.adapter.uix :as uix])
       (rf/init! uix/adapter)
 
-  See Spec 006 §CLJS reference: UIx as alternative substrate.
-  Implements the same adapter contract as re-frame.adapter.reagent
-  (6 required + 3 optional + 1 lifecycle fn). Per rf2-agql there is no
-  default-adapter registry — adapter wiring is explicit at the call site.
-
-  Assembled by `spine/make-react-adapter` (rf2-ee38b.1): the substrate
-  map, the five React-hook `route-hook!` calls, and the two
-  chained installs (warn-once clear + SSR emitter) all live once in the
-  spine — the UIx and Helix adapter wiring is byte-identical, so this
-  single call replaces the former hand-copied block. The per-hook
-  rationale lives at `spine/make-react-adapter`.
-
-  The native `frame-provider` `defui` component (rf2-z7hfp) is passed in
-  as `:frame-provider` so the spine wires it into the
-  `:register-context-provider` substrate slot — the component shell lives
-  in this ns, above where UIx's `$` marshals props; the spine carries no
-  UIx element-macro dependency."
+  Adapter installation is explicit; there is no default-adapter registry.
+  `spine/make-react-adapter` owns the shared UIx/Helix hook routing and
+  lifecycle wiring. The native provider stays in this namespace so the spine
+  has no dependency on UIx's element macro."
   (spine/make-react-adapter spine-fns
                             {:kind           :rf.adapter/uix
                              :frame-provider frame-provider}))


### PR DESCRIPTION
## What changed

- Replaced implementation-era bead and decision narration in the shipped Reagent, reagent-slim, UIx, Helix, and Test-React adapter surfaces with concise current-contract explanations.
- Kept the non-obvious invariants: native UIx/Helix prop marshalling, shared frame context, StrictMode-safe frame ensuring, resource-lease ordering, Test-React teardown ordering, and structural reagent-slim isolation.
- Repaired reagent-slim documentation that presented deleted `findings/` files and a completed Form-3 guide as live or future inputs.
- Corrected two misleading claims: core still carries stock Reagent for `reg-view`, and Test-React repeated unmounts are no-ops while post-unmount updates throw.

## Why

The adapter surface mixed current API guidance with implementation history, issue ids, retired alternatives, and missing references. That made the actual adapter differences and lifecycle constraints harder to find and left some prose inconsistent with shipped behavior.

## Impact

Comments, docstrings, and explanatory Markdown only. Runtime behavior, public names, dependency coordinates, and test assertions are unchanged.

## Checks

- `clojure -M:test` in `implementation/adapters/reagent` (0 tests, clean)
- `clojure -M:test` in `implementation/adapters/uix` (0 tests, clean)
- `clojure -M:test` in `implementation/adapters/helix` (0 tests, clean)
- `clojure -M:test` in `implementation/adapters/reagent-slim` (11 tests, 12 assertions)
- `clojure -M:test` in `implementation/adapters/test-react` (24 tests, 87 assertions)
- `npx shadow-cljs compile node-test` (1,488 files; 3 pre-existing unrelated undeclared-var warnings)
- `node out/node-test.js` (8,466 tests, 39,159 assertions)
- `npm run test:reagent-slim:bundle-isolation` (6 contracts, 25 sentinel checks)
