### PR TITLE
refactor(xray): shared runtime fixture + catalogue chrome + single project-root write (rf2-vj80u8, rf2-0vc122, rf2-dy02qs)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/static/flows/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/flows/panel.cljs
@@ -52,9 +52,10 @@
             [re-frame.core :as rf]
             [re-frame.flows :as flows]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
+            [day8.re-frame2-xray.static.shared.catalogue :as catalogue]
             [day8.re-frame2-xray.static.shared.search-box :as search-box]
             [day8.re-frame2-xray.theme.tokens
-             :refer [tokens type-scale mono-stack sans-stack]]
+             :refer [tokens sans-stack]]
             [day8.re-frame2-xray.views.edn-widget :as edn]))
 
 ;; ---- pure helpers --------------------------------------------------------
@@ -130,15 +131,6 @@
      :filtered? (not= (count rows) (count filtered))
      :query     query}))
 
-;; ---- header --------------------------------------------------------------
-
-(defn- header
-  []
-  ;; The header carries no panel-name heading — the L4 tab strip is the
-  ;; panel-name source-of-truth.
-  [:div {:data-testid "rf-xray-static-flows-header"
-         :style       {:padding "4px 16px"}}])
-
 ;; ---- search box ----------------------------------------------------------
 
 (defn- search-box
@@ -161,24 +153,13 @@
 ;; ---- row -----------------------------------------------------------------
 
 (defn- flow-row
+  ;; Non-interactive `li` chrome via the shared `catalogue-row`; the flow
+  ;; rows are catalogue entries (no row-level dispatch). The interactive
+  ;; Static surface that earns keyboard activation is the Routes list
+  ;; (whose rows toggle an expand surface — see static/routes/browse_list.cljs).
   [{:keys [flow-id frame inputs output-path doc] :as _row}]
-  ;; List semantics. Flow rows are non-interactive (no row-level
-  ;; dispatch), so `role=listitem` is the right shape — they are
-  ;; catalogue entries, not buttons. The interactive Static surface that
-  ;; earns keyboard activation is the Routes list (whose rows toggle an
-  ;; expand surface — see static/routes/browse_list.cljs).
-  [:li {:data-testid (str "rf-xray-static-flows-row-"
-                          (subs (pr-str flow-id) 1))
-        :role        "listitem"
-        :style       {:display       "block"
-                      :padding       "6px 12px"
-                      :font-family   mono-stack
-                      :font-size     "12px"
-                      :color         (:text-primary tokens)
-                      :background    "transparent"
-                      :border-left   "2px solid transparent"
-                      :border-radius "2px"
-                      :line-height   "18px"}}
+  (catalogue/catalogue-row
+   {:testid (str "rf-xray-static-flows-row-" (subs (pr-str flow-id) 1))}
    [:div {:style {:display     "flex"
                   :align-items "baseline"
                   :gap         "8px"}}
@@ -225,7 +206,7 @@
                        :color       (:text-secondary tokens)
                        :font-family sans-stack
                        :font-style  "italic"}}
-         doc])])])
+         doc])])))
 
 ;; ---- root view -----------------------------------------------------------
 
@@ -238,37 +219,16 @@
   []
   (let [data @(rf/subscribe [:rf.xray.static.flows/tab-data])
         {:keys [silent? flows total filtered? query]} data]
-    [:section {:data-testid "rf-xray-static-flows"
-               :style       {:height         "100%"
-                             :display        "flex"
-                             :flex-direction "column"
-                             :background     (:bg-2 tokens)
-                             :color          (:text-primary tokens)
-                             :font-family    sans-stack
-                             :font-size      (:body type-scale)}}
-     (header)
-     (cond
-       silent?
-       (search-box/empty-state "rf-xray-static-flows" "flow")
-
-       :else
-       [:<>
-        (search-box query total filtered?)
-        (if (empty? flows)
-          (search-box/empty-filtered "rf-xray-static-flows" "flow" query)
-          (into [:ul {:data-testid "rf-xray-static-flows-list"
-                      :role        "list"
-                      :style       {:list-style     "none"
-                                    :margin         "8px 0 0 0"
-                                    :padding        "0 8px"
-                                    :flex           1
-                                    :overflow       "auto"
-                                    :display        "flex"
-                                    :flex-direction "column"
-                                    :gap            "2px"}}]
-                (for [row flows]
-                  ^{:key (str (:frame row) "/" (:flow-id row))}
-                  [flow-row row])))])]))
+    (catalogue/catalogue-panel
+     {:testid     "rf-xray-static-flows"
+      :noun       "flow"
+      :query      query
+      :silent?    silent?
+      :rows       flows
+      :search     (search-box query total filtered?)
+      :row-render (fn [row]
+                    ^{:key (str (:frame row) "/" (:flow-id row))}
+                    [flow-row row])})))
 
 ;; ---- production value source ---------------------------------------------
 ;;

--- a/tools/xray/src/day8/re_frame2_xray/static/interceptors/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/interceptors/panel.cljs
@@ -57,9 +57,10 @@
             [re-frame.interceptor-registry :as icpt-reg]
             [day8.re-frame2-xray.host-registry :as host-registry]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
+            [day8.re-frame2-xray.static.shared.catalogue :as catalogue]
             [day8.re-frame2-xray.static.shared.search-box :as search-box]
             [day8.re-frame2-xray.theme.tokens
-             :refer [tokens type-scale mono-stack sans-stack]]))
+             :refer [tokens mono-stack sans-stack]]))
 
 ;; ---- pure helpers --------------------------------------------------------
 
@@ -206,14 +207,6 @@
      :filtered?    (not= (count rows) (count filtered))
      :query        query}))
 
-;; ---- header --------------------------------------------------------------
-
-(defn- header
-  []
-  ;; Spacer only — the panel carries no name heading.
-  [:div {:data-testid "rf-xray-static-interceptors-header"
-         :style       {:padding "4px 16px"}}])
-
 ;; ---- search box ----------------------------------------------------------
 
 (defn- search-box
@@ -236,26 +229,16 @@
 ;; ---- row -----------------------------------------------------------------
 
 (defn- interceptor-row
+  ;; Non-interactive catalogue entry (no row-level dispatch); the shared
+  ;; `catalogue-row` owns the `role=listitem` `li` chrome.
   [{:keys [id ref? authored arg factory? before? after? default? chain-count
            doc] :as _row}]
   (let [id-text (pr-str id)
         row-id  (if (and (> (count id-text) 0) (= \: (first id-text)))
                   (subs id-text 1)
                   id-text)]
-    ;; List semantics. Interceptor rows are non-interactive catalogue
-    ;; entries (no row-level dispatch), so `role=listitem` is the right
-    ;; shape rather than `role=button`.
-    [:li {:data-testid (str "rf-xray-static-interceptors-row-" row-id)
-          :role        "listitem"
-          :style       {:display       "block"
-                        :padding       "6px 12px"
-                        :font-family   mono-stack
-                        :font-size     "12px"
-                        :color         (:text-primary tokens)
-                        :background    "transparent"
-                        :border-left   "2px solid transparent"
-                        :border-radius "2px"
-                        :line-height   "18px"}}
+    (catalogue/catalogue-row
+     {:testid (str "rf-xray-static-interceptors-row-" row-id)}
      [:div {:style {:display     "flex"
                     :align-items "baseline"
                     :gap         "8px"}}
@@ -329,7 +312,7 @@
                       :font-family sans-stack
                       :font-style  "italic"
                       :font-size   "11px"}}
-        doc])]))
+        doc]))))
 
 ;; ---- root view -----------------------------------------------------------
 
@@ -341,37 +324,16 @@
   []
   (let [data @(rf/subscribe [:rf.xray.static.interceptors/tab-data])
         {:keys [silent? interceptors total filtered? query]} data]
-    [:section {:data-testid "rf-xray-static-interceptors"
-               :style       {:height         "100%"
-                             :display        "flex"
-                             :flex-direction "column"
-                             :background     (:bg-2 tokens)
-                             :color          (:text-primary tokens)
-                             :font-family    sans-stack
-                             :font-size      (:body type-scale)}}
-     (header)
-     (cond
-       silent?
-       (search-box/empty-state "rf-xray-static-interceptors" "interceptor")
-
-       :else
-       [:<>
-        (search-box query total filtered?)
-        (if (empty? interceptors)
-          (search-box/empty-filtered "rf-xray-static-interceptors" "interceptor" query)
-          (into [:ul {:data-testid "rf-xray-static-interceptors-list"
-                      :role        "list"
-                      :style       {:list-style     "none"
-                                    :margin         "8px 0 0 0"
-                                    :padding        "0 8px"
-                                    :flex           1
-                                    :overflow       "auto"
-                                    :display        "flex"
-                                    :flex-direction "column"
-                                    :gap            "2px"}}]
-                (for [row interceptors]
-                  ^{:key (pr-str (:id row))}
-                  [interceptor-row row])))])]))
+    (catalogue/catalogue-panel
+     {:testid     "rf-xray-static-interceptors"
+      :noun       "interceptor"
+      :query      query
+      :silent?    silent?
+      :rows       interceptors
+      :search     (search-box query total filtered?)
+      :row-render (fn [row]
+                    ^{:key (pr-str (:id row))}
+                    [interceptor-row row])})))
 
 ;; ---- production value source ---------------------------------------------
 ;;

--- a/tools/xray/src/day8/re_frame2_xray/static/schemas/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/schemas/panel.cljs
@@ -58,9 +58,10 @@
             [day8.re-frame2-xray.host-registry :as host-registry]
             [day8.re-frame2-xray.open-in-editor :as open-in-editor]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
+            [day8.re-frame2-xray.static.shared.catalogue :as catalogue]
             [day8.re-frame2-xray.static.shared.search-box :as search-box]
             [day8.re-frame2-xray.theme.tokens
-             :refer [tokens type-scale mono-stack sans-stack]]
+             :refer [tokens mono-stack sans-stack]]
             [day8.re-frame2-xray.views.edn-widget :as edn]))
 
 ;; ---- pure helpers --------------------------------------------------------
@@ -158,15 +159,6 @@
      :filtered? (not= (count rows) (count filtered))
      :query     query}))
 
-;; ---- header --------------------------------------------------------------
-
-(defn- header
-  []
-  ;; The header carries no panel-name heading — the L4 tab strip is the
-  ;; panel-name source-of-truth.
-  [:div {:data-testid "rf-xray-static-schemas-header"
-         :style       {:padding "4px 16px"}}])
-
 ;; ---- search box ----------------------------------------------------------
 
 (defn- search-box
@@ -214,24 +206,14 @@
      letter]))
 
 (defn- schema-row
+  ;; Non-interactive catalogue entry (the only row-level affordance is the
+  ;; focusable `open-chip` jump-to-source); the shared `catalogue-row` owns
+  ;; the `role=listitem` `li` chrome.
   [{:keys [kind id frame schema doc source-coord] :as _row}]
   (let [id-text (pr-str id)
         row-id  (str (name kind) "-" id-text)]
-    ;; List semantics. Schema rows are non-interactive catalogue entries
-    ;; (the only row-level affordance is the `open-chip` jump-to-source,
-    ;; which is itself focusable), so `role=listitem` is the correct
-    ;; shape rather than `role=button`.
-    [:li {:data-testid (str "rf-xray-static-schemas-row-" row-id)
-          :role        "listitem"
-          :style       {:display       "block"
-                        :padding       "6px 12px"
-                        :font-family   mono-stack
-                        :font-size     "12px"
-                        :color         (:text-primary tokens)
-                        :background    "transparent"
-                        :border-left   "2px solid transparent"
-                        :border-radius "2px"
-                        :line-height   "18px"}}
+    (catalogue/catalogue-row
+     {:testid (str "rf-xray-static-schemas-row-" row-id)}
      [:div {:style {:display     "flex"
                     :align-items "baseline"
                     :gap         "8px"}}
@@ -269,7 +251,7 @@
                       :font-family sans-stack
                       :font-style  "italic"
                       :font-size   "11px"}}
-        doc])]))
+        doc]))))
 
 ;; ---- root view -----------------------------------------------------------
 
@@ -281,39 +263,19 @@
   []
   (let [data @(rf/subscribe [:rf.xray.static.schemas/tab-data])
         {:keys [silent? schemas total filtered? query]} data]
-    [:section {:data-testid "rf-xray-static-schemas"
-               :style       {:height         "100%"
-                             :display        "flex"
-                             :flex-direction "column"
-                             :background     (:bg-2 tokens)
-                             :color          (:text-primary tokens)
-                             :font-family    sans-stack
-                             :font-size      (:body type-scale)}}
-     (header)
-     (cond
-       silent?
-       (search-box/empty-state "rf-xray-static-schemas" "schema")
-
-       :else
-       [:<>
-        (search-box query total filtered?)
-        (if (empty? schemas)
-          (search-box/empty-filtered "rf-xray-static-schemas" "schema" query)
-          (into [:ul {:data-testid "rf-xray-static-schemas-list"
-                      :role        "list"
-                      :style       {:list-style     "none"
-                                    :margin         "8px 0 0 0"
-                                    :padding        "0 8px"
-                                    :flex           1
-                                    :overflow       "auto"
-                                    :display        "flex"
-                                    :flex-direction "column"
-                                    :gap            "4px"}}]
-                (for [row schemas]
-                  ^{:key (str (name (:kind row)) "/"
-                              (pr-str (:frame row)) "/"
-                              (pr-str (:id row)))}
-                  [schema-row row])))])]))
+    (catalogue/catalogue-panel
+     {:testid     "rf-xray-static-schemas"
+      :noun       "schema"
+      :query      query
+      :silent?    silent?
+      :rows       schemas
+      :gap        "4px"
+      :search     (search-box query total filtered?)
+      :row-render (fn [row]
+                    ^{:key (str (name (:kind row)) "/"
+                                (pr-str (:frame row)) "/"
+                                (pr-str (:id row)))}
+                    [schema-row row])})))
 
 ;; ---- public-surface registry read ----------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/static/shared/catalogue.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/shared/catalogue.cljs
@@ -1,0 +1,160 @@
+(ns day8.re-frame2-xray.static.shared.catalogue
+  "Shared root + list + row chrome for Xray's Static flat-catalogue tabs.
+
+  ## What it provides
+
+  Three Static sub-tabs are flat, non-interactive catalogues — Flows,
+  Interceptors, and Schemas. They each render the identical outer shell:
+
+    - a `:section` root (fixed height, flex column, themed background);
+    - a blank header spacer (`-header` testid — the L4 tab strip is the
+      panel-name source of truth, so the header carries no heading);
+    - the silent → search → no-match → list branching;
+    - a `:ul` list container (`role=list`, fixed padding / overflow /
+      flex layout, varying only on the inter-row `:gap`);
+    - and, per row, the identical non-interactive `:li` chrome
+      (`role=listitem`, block / mono / transparent style).
+
+  `search-box` already owns the filtering algebra, the count-chip text,
+  and the empty / no-match copy (see `static.shared.search-box`); this
+  ns owns the remaining shell + row chrome so those three panels have a
+  single owner rather than three copies.
+
+  Each panel keeps its own **projection**, **haystacks**,
+  **registrations**, **row keys**, and **domain row body** local — this
+  ns is a pure presentational shell over that domain content.
+
+  ## What is deliberately NOT here
+
+  The interactive **Routes** browse list (rows toggle an expand surface)
+  and the selectable **Machines** browse list (rows are a keyboard-
+  navigable selection) are NOT flat catalogues — they carry row-level
+  affordances this chrome does not model, so they keep their own shell.
+
+  ## Frame-correctness + keys
+
+  The interactive search box is frame-captured at each call-site and
+  handed in as the `:search` slot — this ns never dispatches. Row React
+  keys stay local too: the caller's `:row-render` fn attaches
+  `^{:key …}` to its row form, so identity computation is domain-shaped
+  and lives with the projection.
+
+  ## Pure hiccup
+
+  Same contract as every Xray view — pure hiccup, no Reagent / UIx /
+  Helix references."
+  (:require [day8.re-frame2-xray.static.shared.search-box :as search-box]
+            [day8.re-frame2-xray.theme.tokens
+             :refer [tokens type-scale mono-stack sans-stack]]))
+
+;; ---- shared style maps ---------------------------------------------------
+
+(def ^:private root-style
+  "The `:section` root chrome shared by every flat-catalogue tab."
+  {:height         "100%"
+   :display        "flex"
+   :flex-direction "column"
+   :background     (:bg-2 tokens)
+   :color          (:text-primary tokens)
+   :font-family    sans-stack
+   :font-size      (:body type-scale)})
+
+(defn- list-style
+  "The `:ul` list-container chrome. Every catalogue shares it; only the
+  inter-row `gap` varies (Flows / Interceptors use `\"2px\"`, Schemas
+  `\"4px\"`)."
+  [gap]
+  {:list-style     "none"
+   :margin         "8px 0 0 0"
+   :padding        "0 8px"
+   :flex           1
+   :overflow       "auto"
+   :display        "flex"
+   :flex-direction "column"
+   :gap            gap})
+
+(def ^:private row-style
+  "The identical non-interactive `:li` chrome shared by every catalogue
+  row (Flows / Interceptors / Schemas)."
+  {:display       "block"
+   :padding       "6px 12px"
+   :font-family   mono-stack
+   :font-size     "12px"
+   :color         (:text-primary tokens)
+   :background    "transparent"
+   :border-left   "2px solid transparent"
+   :border-radius "2px"
+   :line-height   "18px"})
+
+;; ---- row chrome ----------------------------------------------------------
+
+(defn catalogue-row
+  "The identical non-interactive `li` chrome shared by the flat-catalogue
+  Static tabs (Flows / Interceptors / Schemas). Owns the listitem wrapper
+  — `data-testid`, `role=listitem`, and the shared block / mono /
+  transparent style — and splices the caller's domain-specific row body
+  `children` in order.
+
+  Carries no React key: the caller attaches `^{:key …}` to the row form
+  it hands `catalogue-panel` as `:row-render`, so row identity stays
+  local + domain-shaped.
+
+  `opts`:
+    :testid — the full row `data-testid` (e.g.
+              `\"rf-xray-static-flows-row-user/full-name\"`).
+
+  Pure hiccup — no Reagent / UIx / Helix references."
+  [{:keys [testid]} & children]
+  (into [:li {:data-testid testid
+              :role        "listitem"
+              :style       row-style}]
+        children))
+
+;; ---- root + list chrome --------------------------------------------------
+
+(defn catalogue-panel
+  "Shared shell for a flat, non-interactive Static catalogue tab
+  (Flows / Interceptors / Schemas). Owns the `:section` root, the blank
+  header spacer, the silent / no-match / list branching, the search slot,
+  and the `:ul` list container. Domain code keeps its projection,
+  haystacks, registrations, row keys, and row body local.
+
+  `opts`:
+    :testid     — `data-testid` stem (e.g. `\"rf-xray-static-flows\"`).
+                  The section uses it bare; the header / list suffix
+                  `-header` / `-list`; empty states suffix `-empty` /
+                  `-empty-filtered`.
+    :noun       — singular count / empty-state noun (`\"flow\"` /
+                  `\"interceptor\"` / `\"schema\"`).
+    :query      — current search query (for the no-match copy).
+    :silent?    — true when the catalogue is cold-empty (no rows before
+                  filtering) → renders the empty-state, no search box.
+    :rows       — the post-filter row seq. Empty with `:silent? false`
+                  renders the no-match surface.
+    :search     — the caller's interactive search-box hiccup (frame-
+                  captured at the call-site; stays local).
+    :row-render — fn `row → keyed row hiccup` (typically wrapping
+                  `catalogue-row`); the caller attaches the React key so
+                  identity stays local.
+    :gap        — inter-row flex gap (`\"2px\"` default; Schemas `\"4px\"`).
+
+  Pure hiccup — no Reagent / UIx / Helix references."
+  [{:keys [testid noun query silent? rows search row-render gap]
+    :or   {gap "2px"}}]
+  [:section {:data-testid testid
+             :style       root-style}
+   [:div {:data-testid (str testid "-header")
+          :style       {:padding "4px 16px"}}]
+   (cond
+     silent?
+     (search-box/empty-state testid noun)
+
+     :else
+     [:<>
+      search
+      (if (empty? rows)
+        (search-box/empty-filtered testid noun query)
+        (into [:ul {:data-testid (str testid "-list")
+                    :role        "list"
+                    :style       (list-style gap)}]
+              (map row-render rows)))])])

--- a/tools/xray/src/day8/re_frame2_xray/test_support.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/test_support.cljs
@@ -34,7 +34,9 @@
 
   **Test-only — never call from production code.** Per rf2-kmhvg
   cluster item 3e (audit rf2-i0veg §3e)."
-  (:require [day8.re-frame2-xray.config :as config]
+  (:require [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as core-test-support]
+            [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.install :as install]
             [day8.re-frame2-xray.mount :as mount]
             [day8.re-frame2-xray.registry :as registry]
@@ -95,6 +97,67 @@
   (reset-all!)
   (config/reset-settings!)
   nil)
+
+;; ---- composed runtime fixture (rf2-vj80u8) ------------------------------
+
+(defn make-xray-runtime-fixture
+  "Build a `cljs.test` `:each` fixture that resets BOTH the per-process
+  re-frame runtime (via core
+  `re-frame.test-support/make-reset-runtime-fixture`) AND Xray's own
+  process-global reset tier, around each test.
+
+  Folds the two-step `(make-reset-runtime-fixture {… :init-fn xray-init!})`
+  boilerplate — repeated across the Xray suite as a bespoke private
+  `xray-init!` fn (often with a REDUNDANT trailing
+  `trace-collector/reset-for-test!` that `reset-all!` already folds in) —
+  into one owner. The core fixture rolls back the registrar / frames /
+  flows / schemas + installs the adapter; the Xray reset tier then clears
+  Xray's install + registry + mount sentinels, the trace-collector rings,
+  and (for `:runtime`) the persisted settings.
+
+  `opts` (all optional):
+    :adapter    — substrate adapter to install. Default
+                  `re-frame.substrate.plain-atom/adapter` (the node-CLJS
+                  default the Xray suite uses).
+    :tier       — which Xray reset tier runs after the runtime reset,
+                  before the test body:
+                    :sentinels — `reset-sentinels!` (idempotency flags
+                                 only; safe MID-setup — host frame already
+                                 registered).
+                    :all       — `reset-all!` (sentinels + trace rings).
+                                 DEFAULT — the clean-slate a
+                                 register-before-test fixture wants.
+                    :runtime   — `reset-runtime!` (all + persisted
+                                 settings / localStorage).
+    :post-reset — optional zero-arg fn run AFTER the Xray reset tier, still
+                  before the test body (both inside the core fixture's
+                  `:init-fn` — i.e. after adapter install + `:rf/default`).
+                  Use for per-suite cleanup that must run on the just-reset
+                  runtime (e.g. `(spine-filters/clear-raw!)`, seeding a
+                  clean localStorage, `(config/set-filters-storage-key!
+                  nil)`).
+    :async?     — forwarded to the core fixture (map-form for suites with
+                  `(async done …)` tests).
+
+  Other core `make-reset-runtime-fixture` options (`:clear-kinds`,
+  `:clear-app-schemas?`, `:ambient-frame`) are intentionally NOT threaded
+  — no Xray suite needs them; reach for the core fixture directly if you
+  do.
+
+  **Test-only — never call from production code.**"
+  ([] (make-xray-runtime-fixture {}))
+  ([{:keys [adapter tier post-reset async?]
+     :or   {adapter plain-atom/adapter
+            tier    :all}}]
+   (core-test-support/make-reset-runtime-fixture
+     {:adapter adapter
+      :async?  async?
+      :init-fn (fn []
+                 (case tier
+                   :sentinels (reset-sentinels!)
+                   :all       (reset-all!)
+                   :runtime   (reset-runtime!))
+                 (when post-reset (post-reset)))})))
 
 ;; ---- test-only override seam orchestrator (rf2-e8330v / xxo3zz F3) -------
 

--- a/tools/xray/test/day8/re_frame2_xray/static/flows/panel_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/flows/panel_cljs_test.cljs
@@ -26,62 +26,26 @@
             ;; registers real flows through `rf/reg-flow`.
             [re-frame.flows :as flows]
             [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
+            [re-frame.test-helpers :as th]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.static.flows.panel :as panel]
             [day8.re-frame2-xray.test-support :as xray-test-support]
-            [day8.re-frame2-xray.trace-collector :as trace-collector]
             [day8.re-frame2-xray.views.edn-inspector :as ei]))
 
 ;; ---- fixture ------------------------------------------------------------
 
-(defn- xray-init! []
-  (xray-test-support/reset-all!)
-  (trace-collector/reset-for-test!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `reset-all!` folds the trace-collector ring reset in, so the old
+  ;; bespoke `xray-init!` (reset-all! + a REDUNDANT direct trace reset) is
+  ;; gone (rf2-vj80u8). Default `:all` tier + plain-atom adapter.
+  (xray-test-support/make-xray-runtime-fixture))
 
-;; ---- hiccup walker ------------------------------------------------------
-
-(declare expand-tree)
-(defn- expand-tree [tree]
-  (cond
-    (and (vector? tree) (fn? (first tree)))
-    (let [result (apply (first tree) (rest tree))]
-      ;; Form-2 Reagent components return an inner fn; call it with
-      ;; the same args (per Reagent's re-render contract) to obtain
-      ;; the rendered hiccup. rf2-oqa60 — the edn-inspector widget is
-      ;; form-2 so the mount-id stays stable across re-renders.
-      (expand-tree
-        (if (fn? result)
-          (apply result (rest tree))
-          result)))
-    (vector? tree) (mapv expand-tree tree)
-    (seq? tree)    (map expand-tree tree)
-    :else          tree))
-
-(defn- hiccup-seq [tree]
-  (tree-seq (some-fn vector? seq?) seq (expand-tree tree)))
-
-(defn- find-by-testid [tree testid]
-  (some (fn [node]
-          (when (and (vector? node)
-                     (map? (second node))
-                     (= testid (:data-testid (second node))))
-            node))
-        (hiccup-seq tree)))
-
-(defn- find-all-by-testid-prefix [tree prefix]
-  (filterv (fn [node]
-             (and (vector? node)
-                  (map? (second node))
-                  (when-let [tid (:data-testid (second node))]
-                    (= 0 (.indexOf tid prefix)))))
-           (hiccup-seq tree)))
+;; ---- hiccup walkers ------------------------------------------------------
+;;
+;; The private expand-tree / hiccup-seq / find-by-testid* copies this file
+;; carried are semantically identical to `re-frame.test-helpers`; the tests
+;; below call `th/find-by-testid` / `th/find-by-testid-prefix` directly
+;; (rf2-vj80u8 — no Xray walker facade).
 
 (defn- setup-xray! []
   (registry/register-xray-handlers!)
@@ -257,7 +221,7 @@
     (rf/dispatch-sync
       [:rf.xray.static.flows/set-registered-flows-override-for-test {}])
     (let [tree (panel/Panel)]
-      (is (some? (find-by-testid tree "rf-xray-static-flows-empty"))
+      (is (some? (th/find-by-testid tree "rf-xray-static-flows-empty"))
           "empty-state surface mounts"))))
 
 (deftest panel-renders-rows-from-override
@@ -267,9 +231,9 @@
       [:rf.xray.static.flows/set-registered-flows-override-for-test
        sample-flows])
     (let [tree (panel/Panel)
-          rows (find-all-by-testid-prefix tree "rf-xray-static-flows-row-")]
+          rows (th/find-by-testid-prefix tree "rf-xray-static-flows-row-")]
       (is (= 2 (count rows)) "two row surfaces rendered")
-      (is (some? (find-by-testid tree "rf-xray-static-flows-search"))
+      (is (some? (th/find-by-testid tree "rf-xray-static-flows-search"))
           "search box rendered"))))
 
 (deftest panel-renders-filtered-state
@@ -280,20 +244,12 @@
        sample-flows])
     (rf/dispatch-sync [:rf.xray.static.flows/set-query "no-such-flow"])
     (let [tree (panel/Panel)]
-      (is (some? (find-by-testid tree "rf-xray-static-flows-empty-filtered"))
+      (is (some? (th/find-by-testid tree "rf-xray-static-flows-empty-filtered"))
           "empty-filtered surface mounts when query removes every row"))))
 
 ;; -------------------------------------------------------------------------
 ;; (4) a11y list semantics (rf2-mq8wk)
 ;; -------------------------------------------------------------------------
-
-(defn- find-by-role [tree role]
-  (some (fn [node]
-          (when (and (vector? node)
-                     (map? (second node))
-                     (= role (:role (second node))))
-            node))
-        (hiccup-seq tree)))
 
 (deftest panel-list-carries-list-semantics
   (testing "rf2-mq8wk — the flows <ul> is role=list, rows are role=listitem"
@@ -303,8 +259,8 @@
         [:rf.xray.static.flows/set-registered-flows-override-for-test
          sample-flows])
       (let [tree (panel/Panel)
-            list-node (find-by-testid tree "rf-xray-static-flows-list")
-            rows      (find-all-by-testid-prefix
+            list-node (th/find-by-testid tree "rf-xray-static-flows-list")
+            rows      (th/find-by-testid-prefix
                         tree "rf-xray-static-flows-row-")]
         (is (= "list" (:role (second list-node))) "<ul> carries role=list")
         (is (seq rows) "rows rendered")
@@ -326,7 +282,7 @@
         [:rf.xray.static.flows/set-registered-flows-override-for-test
          sample-flows])
       (let [tree (panel/Panel)
-            widget-nodes (find-all-by-testid-prefix
+            widget-nodes (th/find-by-testid-prefix
                            tree "rf-xray-edn-inspector-")]
         (is (seq widget-nodes)
             "at least one edn-inspector widget container present")))))

--- a/tools/xray/test/day8/re_frame2_xray/static/interceptors/panel_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/interceptors/panel_cljs_test.cljs
@@ -4,53 +4,25 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
+            [re-frame.test-helpers :as th]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.static.interceptors.panel :as panel]
-            [day8.re-frame2-xray.test-support :as xray-test-support]
-            [day8.re-frame2-xray.trace-collector :as trace-collector]))
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
 
 ;; ---- fixture ------------------------------------------------------------
 
-(defn- xray-init! []
-  (xray-test-support/reset-all!)
-  (trace-collector/reset-for-test!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `reset-all!` folds the trace-collector ring reset in, so the old
+  ;; bespoke `xray-init!` (reset-all! + a REDUNDANT direct trace reset) is
+  ;; gone (rf2-vj80u8). Default `:all` tier + plain-atom adapter.
+  (xray-test-support/make-xray-runtime-fixture))
 
-;; ---- hiccup walker ------------------------------------------------------
-
-(declare expand-tree)
-(defn- expand-tree [tree]
-  (cond
-    (and (vector? tree) (fn? (first tree)))
-    (expand-tree (apply (first tree) (rest tree)))
-    (vector? tree) (mapv expand-tree tree)
-    (seq? tree)    (map expand-tree tree)
-    :else          tree))
-
-(defn- hiccup-seq [tree]
-  (tree-seq (some-fn vector? seq?) seq (expand-tree tree)))
-
-(defn- find-by-testid [tree testid]
-  (some (fn [node]
-          (when (and (vector? node)
-                     (map? (second node))
-                     (= testid (:data-testid (second node))))
-            node))
-        (hiccup-seq tree)))
-
-(defn- find-all-by-testid-prefix [tree prefix]
-  (filterv (fn [node]
-             (and (vector? node)
-                  (map? (second node))
-                  (when-let [tid (:data-testid (second node))]
-                    (= 0 (.indexOf tid prefix)))))
-           (hiccup-seq tree)))
+;; ---- hiccup walkers ------------------------------------------------------
+;;
+;; The private expand-tree / hiccup-seq / find-by-testid* copies this file
+;; carried are semantically identical to `re-frame.test-helpers`; the tests
+;; below call `th/find-by-testid` / `th/find-by-testid-prefix` directly
+;; (rf2-vj80u8 — no Xray walker facade).
 
 (defn- setup-xray! []
   (registry/register-xray-handlers!)
@@ -230,7 +202,7 @@
     (rf/dispatch-sync
       [:rf.xray.static.interceptors/set-registry-override-for-test {}])
     (let [tree (panel/Panel)]
-      (is (some? (find-by-testid tree "rf-xray-static-interceptors-empty"))))))
+      (is (some? (th/find-by-testid tree "rf-xray-static-interceptors-empty"))))))
 
 (deftest panel-renders-rows-from-override
   (setup-xray!)
@@ -239,7 +211,7 @@
       [:rf.xray.static.interceptors/set-registry-override-for-test
        sample-events-with-chains])
     (let [tree (panel/Panel)
-          rows (find-all-by-testid-prefix tree "rf-xray-static-interceptors-row-")]
+          rows (th/find-by-testid-prefix tree "rf-xray-static-interceptors-row-")]
       (is (= 3 (count rows)) "three collapsed interceptor rows rendered"))))
 
 (deftest panel-renders-filtered-state-on-no-match
@@ -250,7 +222,7 @@
        sample-events-with-chains])
     (rf/dispatch-sync [:rf.xray.static.interceptors/set-query "no-such-id"])
     (let [tree (panel/Panel)]
-      (is (some? (find-by-testid tree "rf-xray-static-interceptors-empty-filtered"))))))
+      (is (some? (th/find-by-testid tree "rf-xray-static-interceptors-empty-filtered"))))))
 
 ;; -------------------------------------------------------------------------
 ;; (4) a11y list semantics (rf2-mq8wk)
@@ -264,8 +236,8 @@
         [:rf.xray.static.interceptors/set-registry-override-for-test
          sample-events-with-chains])
       (let [tree (panel/Panel)
-            list-node (find-by-testid tree "rf-xray-static-interceptors-list")
-            rows (find-all-by-testid-prefix
+            list-node (th/find-by-testid tree "rf-xray-static-interceptors-list")
+            rows (th/find-by-testid-prefix
                    tree "rf-xray-static-interceptors-row-")]
         (is (= "list" (:role (second list-node))) "<ul> carries role=list")
         (is (seq rows) "rows rendered")

--- a/tools/xray/test/day8/re_frame2_xray/static/schemas/panel_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/schemas/panel_cljs_test.cljs
@@ -4,60 +4,25 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
+            [re-frame.test-helpers :as th]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.static.schemas.panel :as panel]
-            [day8.re-frame2-xray.test-support :as xray-test-support]
-            [day8.re-frame2-xray.trace-collector :as trace-collector]))
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
 
 ;; ---- fixture ------------------------------------------------------------
 
-(defn- xray-init! []
-  (xray-test-support/reset-all!)
-  (trace-collector/reset-for-test!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `reset-all!` folds the trace-collector ring reset in, so the old
+  ;; bespoke `xray-init!` (reset-all! + a REDUNDANT direct trace reset) is
+  ;; gone (rf2-vj80u8). Default `:all` tier + plain-atom adapter.
+  (xray-test-support/make-xray-runtime-fixture))
 
-;; ---- hiccup walker ------------------------------------------------------
-
-(declare expand-tree)
-(defn- expand-tree [tree]
-  (cond
-    (and (vector? tree) (fn? (first tree)))
-    (let [result (apply (first tree) (rest tree))]
-      ;; Form-2 Reagent components return an inner fn; re-call with
-      ;; the same args (Reagent's re-render contract). rf2-oqa60 —
-      ;; edn-inspector is form-2 to stabilise mount-id.
-      (expand-tree
-        (if (fn? result)
-          (apply result (rest tree))
-          result)))
-    (vector? tree) (mapv expand-tree tree)
-    (seq? tree)    (map expand-tree tree)
-    :else          tree))
-
-(defn- hiccup-seq [tree]
-  (tree-seq (some-fn vector? seq?) seq (expand-tree tree)))
-
-(defn- find-by-testid [tree testid]
-  (some (fn [node]
-          (when (and (vector? node)
-                     (map? (second node))
-                     (= testid (:data-testid (second node))))
-            node))
-        (hiccup-seq tree)))
-
-(defn- find-all-by-testid-prefix [tree prefix]
-  (filterv (fn [node]
-             (and (vector? node)
-                  (map? (second node))
-                  (when-let [tid (:data-testid (second node))]
-                    (= 0 (.indexOf tid prefix)))))
-           (hiccup-seq tree)))
+;; ---- hiccup walkers ------------------------------------------------------
+;;
+;; The private expand-tree / hiccup-seq / find-by-testid* copies this file
+;; carried are semantically identical to `re-frame.test-helpers`; the tests
+;; below call `th/find-by-testid` / `th/find-by-testid-prefix` directly
+;; (rf2-vj80u8 — no Xray walker facade).
 
 (defn- setup-xray! []
   (registry/register-xray-handlers!)
@@ -243,7 +208,7 @@
       [:rf.xray.static.schemas/set-registry-override-for-test
        {:schemas-by-frame {} :events {} :subs {}}])
     (let [tree (panel/Panel)]
-      (is (some? (find-by-testid tree "rf-xray-static-schemas-empty"))))))
+      (is (some? (th/find-by-testid tree "rf-xray-static-schemas-empty"))))))
 
 (deftest panel-renders-rows-from-override
   (setup-xray!)
@@ -252,7 +217,7 @@
       [:rf.xray.static.schemas/set-registry-override-for-test
        sample-registry])
     (let [tree (panel/Panel)
-          rows (find-all-by-testid-prefix tree "rf-xray-static-schemas-row-")]
+          rows (th/find-by-testid-prefix tree "rf-xray-static-schemas-row-")]
       (is (= 3 (count rows)) "three row surfaces rendered"))))
 
 (deftest panel-renders-jump-to-source-chips
@@ -262,7 +227,7 @@
       [:rf.xray.static.schemas/set-registry-override-for-test
        sample-registry])
     (let [tree (panel/Panel)
-          chips (find-all-by-testid-prefix tree "xray-open-in-editor")]
+          chips (th/find-by-testid-prefix tree "xray-open-in-editor")]
       ;; Every fixture row carries a :file slot, so every row should
       ;; have an open chip resolved through the editor config.
       (is (pos? (count chips))
@@ -280,8 +245,8 @@
         [:rf.xray.static.schemas/set-registry-override-for-test
          sample-registry])
       (let [tree (panel/Panel)
-            list-node (find-by-testid tree "rf-xray-static-schemas-list")
-            rows (find-all-by-testid-prefix tree "rf-xray-static-schemas-row-")]
+            list-node (th/find-by-testid tree "rf-xray-static-schemas-list")
+            rows (th/find-by-testid-prefix tree "rf-xray-static-schemas-row-")]
         (is (= "list" (:role (second list-node))) "<ul> carries role=list")
         (is (seq rows) "rows rendered")
         (is (every? #(= "listitem" (:role (second %))) rows)
@@ -303,6 +268,6 @@
         [:rf.xray.static.schemas/set-registry-override-for-test
          sample-registry])
       (let [tree (panel/Panel)
-            widget (find-all-by-testid-prefix
+            widget (th/find-by-testid-prefix
                      tree "rf-xray-edn-inspector-")]
         (is (seq widget) "schema values render through the edn-inspector widget")))))

--- a/tools/xray/testbeds/panel_gallery/core.cljs
+++ b/tools/xray/testbeds/panel_gallery/core.cljs
@@ -95,26 +95,14 @@
   (:require [re-frame.core :as rf]
             [re-frame.story :as story]
             [re-frame.adapter.reagent :as reagent-adapter]
-            ;; Xray's `configure!` seeds `:project-root`
-            ;; so the source-coord chips on registered handlers /
-            ;; views / machines resolve their classpath-relative
-            ;; `:file` slot to an absolute on-disk URI. Without this
-            ;; the panel-gallery's `[open]` affordances ship the bare
-            ;; classpath-relative path (`panel_gallery/foo.cljs`) to
-            ;; the OS scheme handler, which rejects it.
-            ;;
-            ;; Story's parallel slot
-            ;; (`:rf.story/project-root`) is seeded via
-            ;; `story/configure!` below so the Story variant-toolbar
-            ;; 'Open' button (which reads `re-frame.story.config/
-            ;; project-root`, not Xray's slot) also ships an absolute
-            ;; on-disk path. The Story → Xray bridge in
-            ;; `xray-preset/propagate-project-root!` would otherwise
-            ;; mean the Story configure! call ALSO writes Xray's slot;
-            ;; we keep the explicit xray-config call so the load order
-            ;; is unambiguous (Xray seeded first; Story's idempotent
-            ;; re-seed of Xray is a no-op via `reset!`).
-            [day8.re-frame2-xray.config :as xray-config]
+            ;; Story is the SINGLE owner of the source-coord project-root
+            ;; (`:rf.story/project-root`, seeded via `story/configure!` in
+            ;; `run`). Story synchronously bridges that value into Xray's
+            ;; `:rf.xray/project-root` slot via
+            ;; `re-frame.story.xray-preset/propagate-project-root!`, so the
+            ;; Xray-as-RHS source-coord chips resolve against the same
+            ;; on-disk root without a separate `xray-config/configure!` call
+            ;; here (rf2-dy02qs).
             [day8.re-frame2-xray.registry :as xray-registry]
             ;; Xray's `:root` CSS-variable installer. Required
             ;; here because the panel-gallery embeds bare Xray widgets
@@ -219,7 +207,9 @@
 ;; to prepend — without it, the URI ships the bare relative path and the
 ;; OS-side editor handler rejects it ("Path does not exist").
 ;;
-;; Xray exposes `:rf.xray/project-root`. The
+;; The root is configured through Story (`:rf.story/project-root`), which
+;; synchronously bridges it into Xray's `:rf.xray/project-root` slot — so
+;; there is one resolution and one owner-level configure! call. The
 ;; panel-gallery boots with its known on-disk repo position by default; a
 ;; `?checkout-root=<path>` query string overrides for cross-machine portability
 ;; (mirroring the `standard_epochs` testbed's resolver).
@@ -258,25 +248,21 @@
 ;; hot-reload re-`run` never stacks a duplicate.
 
 (defn ^:export run []
-  ;; Seed `:rf.xray/project-root` BEFORE the Xray handlers
-  ;; register so the first chip render reads the configured root. The
-  ;; resolver reads only the configured atom; the URI build is independent
-  ;; of `window.location`, so the panel-gallery's source links resolve to
-  ;; the same on-disk paths regardless of which port shadow-cljs serves
-  ;; the testbed from.
-  (xray-config/configure! {:rf.xray/project-root (resolve-source-root)})
-  ;; Seed `:rf.story/project-root` for the SAME
-  ;; on-disk root so the Story shell's variant-toolbar 'Open' button
-  ;; (re-frame.story.ui.open-in-editor/open-chip) ships an absolute
-  ;; path. Story's own atom is independent of Xray's; without this
-  ;; call Story's project-root stays nil and the Open chip falls back
-  ;; to the bare classpath-relative `:file` (which the OS-side editor
-  ;; URI handler rejects). The Story → Xray bridge re-writes Xray's
-  ;; slot to the same value — idempotent under `set-project-root!`'s
-  ;; `reset!`. Mirrors the pattern in
-  ;; `tools/story/testbeds/login_form/core.cljs` and
-  ;; `tools/story/testbeds/counter_with_stories/core.cljs`.
-  (story/configure! {:rf.story/project-root (resolve-source-root)})
+  ;; Resolve the on-disk project root ONCE and hand it to Story — the
+  ;; single owner of the source-coord project-root. Story's `configure!`
+  ;; synchronously bridges the value into Xray's `:rf.xray/project-root`
+  ;; slot via `re-frame.story.xray-preset/propagate-project-root!`, so
+  ;; BOTH Story's own variant-toolbar 'Open' chips and the Xray-as-RHS
+  ;; source-coord chips resolve against the same root — one resolution,
+  ;; one owner-level configure! call, no duplicate `xray-config/configure!`
+  ;; write (rf2-dy02qs). Seeded BEFORE the Xray handlers register (below)
+  ;; so the first chip render reads the configured root. The resolver reads
+  ;; only the configured atom; the URI build is independent of
+  ;; `window.location`, so the panel-gallery's source links resolve to the
+  ;; same on-disk paths regardless of which port shadow-cljs serves the
+  ;; testbed from.
+  (let [project-root (resolve-source-root)]
+    (story/configure! {:rf.story/project-root project-root}))
   (rf/init! reagent-adapter/adapter)
   ;; Xray's :rf.xray/* events / subs / fxs land on the registry once.
   ;; The handlers operate on the current frame's app-db, so each


### PR DESCRIPTION
Three clustered Xray dedup beads on disjoint surfaces within `tools/xray`.

## rf2-vj80u8 — shared runtime fixture (COMMIT 1)
- Added `day8.re-frame2-xray.test-support/make-xray-runtime-fixture`, composing core `re-frame.test-support/make-reset-runtime-fixture` with a named Xray reset tier (`:sentinels` / `:all` / `:runtime`, default `:all`) + an optional `:post-reset` hook.
- Migrated the three Static flat-catalogue panel test suites (Flows, Interceptors, Schemas) onto the shared fixture and onto `re-frame.test-helpers` directly (`th/find-by-testid`, `th/find-by-testid-prefix`) — **no Xray walker facade**. Dropped their private `expand-tree` / `hiccup-seq` / `find-by-testid*` copies and the redundant `reset-all!` + direct `trace-collector/reset-for-test!` pair.
- **Preflight confirmed:** each private walker is semantically identical to the canonical helper (`find-by-testid` = attrs-map testid match; `find-all-by-testid-prefix` = `.indexOf = 0` ⟺ `starts-with?`; the private `expand-tree` is a strict form-2 subset of the canonical form-2+form-3 walker, and these trees carry no form-3). The `reset-all!` + trailing `trace-collector/reset-for-test!` is genuinely redundant — `reset-all!` already folds the trace-ring reset in.
- **Partial toward rf2-vj80u8:** this PR establishes the canonical fixture + the static-panel exemplar. The remaining ~50 bespoke `xray-init!` sites + private walker copies across the Xray test corpus are non-uniform (varied reset tiers + domain tails, differently-named walkers) and are left as a scoped follow-on. rf2-vj80u8 is **not** closed by this PR.

## rf2-0vc122 — one chrome owner for Static flat catalogues (COMMIT 2)
- Added `static/shared/catalogue.cljs`. `catalogue-panel` owns the `:section` root, blank header spacer, silent/no-match/list branching, search slot, and `:ul` list container (explicit `testid` / `noun` / `query` / `silent?` / `rows` / `search` / `row-render` / `gap` inputs). `catalogue-row` owns the identical non-interactive `:li` chrome.
- Flows / Interceptors / Schemas render through it; projection, haystacks, registrations, row keys, and domain body stay local.
- **Preflight confirmed:** the `:section` root style, header spacer (`-header`, `padding 4px 16px`), `:ul` list style, and `:li` row style are byte-identical across all three panels; only the inter-row gap differs (2px / 2px / 4px → `:gap` input). Interactive Routes + selectable Machines are excluded (row-level affordances, not flat catalogues).
- Rendered surface unchanged: same testids, list/listitem roles, ordering/keys, empty/no-match copy, domain content. No new dependency boundary.

## rf2-dy02qs — single project-root write (COMMIT 3)
- `panel_gallery/core.cljs` `run` resolves the root once and calls only `story/configure!` with `:rf.story/project-root` before `rf/init!`; Story's existing bridge (`re-frame.story.xray-preset/propagate-project-root!`) configures Xray. Removed the direct `xray-config` require/call + its duplicate-write comment. Early timing + mount ownership preserved.
- **Preflight confirmed:** `propagate-project-root!` fires synchronously inside `story/configure!` when `:rf.story/project-root` is present (idempotent via `reset!`), so the explicit Xray write was genuinely redundant.

## Quality gates
- `npm run test:cljs` — **8466 tests, 39159 assertions, 0 failures, 0 errors** (exercises the refactored panels, new fixture, migrated tests via the `:node-test` build's `tools/xray/src` + `tools/xray/test` paths).
- `npm run test:bundle-isolation` — **PASS** (0 warnings; 41 internal sentinels absent). The new `re-frame.test-support` + `plain-atom` requires on the (prod-absent) Xray test-support ns do not leak into production bundles.
- `tools/xray` `clojure -M:test` — **1233 tests, 5729 assertions, 0 failures, 0 errors**.
- `npm run test:xray-feature-gate` — could not complete in this environment: the headless browser closed mid-run (`Target page… has been closed`, `mounted=undefined`) on the **`routes-epochs` routing scenario**, which this PR does not touch. The refactored panels are DOM-identical and covered by the passing CLJS panel unit tests. Re-run in CI.

## Xray spec
Spec unchanged — no `tools/xray/spec/*` contract is affected: catalogue chrome + test fixtures are internal/test-scaffolding (`014-Registry-Catalogue.md` prescribes no `catalogue-row`/`li`/`role` structure; `017-Test-Coverage-Matrix.md` describes covered surfaces, not fixture internals), 0vc122 preserves the rendered DOM, and the project-root bridge contract is owned by `tools/story`.

## Stance
Pre-alpha, no back-compat shims, no facade beyond the beads. ELEGANCE + CLARITY + CORRECTNESS + GOOD-PRACTICE.

Do not merge (worker PR).