### PR TITLE
docs(flows): focus explanations on current contracts (rf2-xs9yuo)

### DIFF
--- a/implementation/flows/deps.edn
+++ b/implementation/flows/deps.edn
@@ -1,73 +1,35 @@
-;; day8/re-frame2-flows — flows artefact (rf2-tfw3,
-;; fourth per-feature split per rf2-5vjj Strategy B).
-;;
-;; Per Spec 013 the flow surface (`reg-flow`, `clear-flow`, the
-;; `:rf.fx/reg-flow` / `:rf.fx/clear-flow` runtime fxs, the per-frame
-;; flow registry, the topological sort, the dirty-check `last-inputs`
-;; map, and the outermost-`:after` `run-flows-on-db` walker) ships as a separate
-;; Maven artefact so apps that don't register any flows don't drag the
-;; namespace, the topo-sort engine, or any of the `:rf.flow/*`
-;; trace strings onto the classpath.
+;; Optional flows artefact. Core reaches this surface only through late-bound
+;; hooks, so applications that do not depend on flows do not carry its registry,
+;; topology engine, dirty-check cache, or trace vocabulary.
 ;;
 ;; Consumers add this artefact alongside the core artefact:
 ;;
 ;;   {:deps {day8/re-frame2       {:mvn/version "..."}
 ;;           day8/re-frame2-flows {:mvn/version "..."}}}
 ;;
-;; And require `re-frame.flows` in any namespace that calls
+;; Require `re-frame.flows` in any namespace that calls
 ;; `rf/reg-flow` / `rf/clear-flow` or relies on the `:rf.fx/reg-flow`
-;; / `:rf.fx/clear-flow` runtime fxs — loading the namespace registers
-;; its late-bind hooks and wires `reg-flow` to clear the affected
-;; frame's `last-inputs` row directly on a same-frame hot-reload
-;; replacement, so a hot-reloaded flow re-evaluates on its next drain.
-;;
-;; The authoritative, always-current hook list is the `late-bind/set-fn!`
-;; calls in `re-frame.flows` (cross-referenced against the
-;; `re-frame.late-bind.directory/hooks` `:flows/*` rows, pinned in sync by
-;; the `re-frame.late-bind-drift-test` gate) — this comment intentionally
-;; does NOT maintain a parallel list that would silently drift.
-;;
-;; Per Spec 006 §Adapter shipping convention (and the
-;; rf2-p7va extension to per-feature splits): this artefact depends on
-;; core; core never depends on this artefact. The cross-references
-;; from core to flows (e.g. `re-frame.core`'s `reg-flow` / `clear-flow`
-;; re-exports, `re-frame.fx`'s `:rf.fx/reg-flow` / `:rf.fx/clear-flow`
-;; effect handlers, `re-frame.router`'s outermost-`:after` `run-flows-on-db` call,
-;; `re-frame.test-support`'s reset-runtime fixture's flows reset) flow
-;; through `re-frame.late-bind` exactly as the schemas / machines /
-;; routing hooks already do.
+;; / `:rf.fx/clear-flow` effects; loading the namespace publishes the hooks.
+;; The `late-bind/set-fn!` calls in that namespace are the authoritative hook
+;; list and are checked against `re-frame.late-bind.directory/hooks`.
 {:paths ["src"]
  :deps  {day8/re-frame2 {:local/root "../core"}}
 
  :aliases
  {:test {:extra-paths ["test"]
-         ;; The flows JVM test's reset-runtime fixture touches
-         ;; `re-frame.schemas/schemas-by-frame` and reloads
-         ;; `re-frame.routing` and `re-frame.ssr` (the reset matrix is
-         ;; defensive — none of these artefacts is required for
-         ;; production flows builds, but all are on the classpath
-         ;; during development). Pull schemas / routing / ssr in as
-         ;; test-only deps so the fixture loads cleanly. Mirrors the
-         ;; pattern in core/deps.edn and routing/deps.edn.
+         ;; The shared reset fixture reloads these optional artefacts when they
+         ;; are present. They remain test-only dependencies here.
          :extra-deps  {day8/re-frame2-schemas    {:local/root "../schemas"}
                        day8/re-frame2-routing    {:local/root "../routing"}
                        day8/re-frame2-ssr        {:local/root "../ssr"}
-                       ;; rf2-try1x — silent-on-success reporter.
                        day8/re-frame2-test-quiet {:local/root "../test-quiet"}
                        io.github.cognitect-labs/test-runner
                        {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
-         ;; rf2-bv2qqm — the default PR/local gate EXCLUDES the heavy
-         ;; `^:stress` namespace (`flows_concurrency_stress_test`,
-         ;; 5000-iter × 8-thread reg/eval/clear churn). The runner passes
-         ;; `-e` through to cognitect-test-runner verbatim. Coverage is NOT
-         ;; lost: the `:slow-test` alias below runs the excluded tests,
-         ;; invoked by the nightly `expensive-tests.yml` job +
-         ;; `scripts/test-rigorous-local.sh`.
+         ;; Keep the contention suite out of the default gate; `:slow-test`
+         ;; selects it for nightly and rigorous-local runs.
          :main-opts   ["-m" "re-frame.test-quiet.runner" "-e" ":slow" "-e" ":stress"]}
 
-  ;; rf2-bv2qqm — nightly/rigorous slow-test gate. INCLUDES ONLY the
-  ;; `^:slow` / `^:stress` tests, so `:test` + `:slow-test` together cover
-  ;; every test once.
+  ;; Nightly/rigorous gate: include only `^:slow` and `^:stress` tests.
   :slow-test
   {:extra-paths ["test"]
    :extra-deps  {day8/re-frame2-schemas    {:local/root "../schemas"}
@@ -78,15 +40,12 @@
                  {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
    :main-opts   ["-m" "re-frame.test-quiet.runner" "-i" ":slow" "-i" ":stress"]}
 
-  ;; Clojars deploy (rf2-r382). Modeled on re-frame v1's release flow.
+  ;; Clojars deploy.
   ;; The release workflow runs `clojure -M:clein deploy` from this
   ;; artefact's directory, which builds pom + jar and pushes to Clojars.
   ;;
-  ;; IMPORTANT: when this artefact is published, the `day8/re-frame2`
-  ;; core dep above is replaced by an :mvn/version coordinate — clein
-  ;; reads :deps and writes them into pom.xml, and a :local/root entry
-  ;; would resolve to nothing for downstream consumers. The release
-  ;; workflow swaps :local/root → :mvn/version before invoking clein.
+  ;; The release workflow replaces the core `:local/root` with an
+  ;; `:mvn/version` before clein writes the POM.
   :clein {:extra-deps {io.github.noahtheduke/clein
                        {:git/url "https://github.com/day8/clein.git"
                         :git/sha "2b83503246e8291fc023d688574640a9b23d8c50"}}

--- a/implementation/flows/src/re_frame/flows.cljc
+++ b/implementation/flows/src/re_frame/flows.cljc
@@ -1,29 +1,16 @@
 (ns re-frame.flows
   "Flows — registered, runtime-toggleable computed-state declarations.
-  Per Spec 013.
 
-  A flow says: 'when these app-db paths change, run this pure function
-  and write the result to that app-db path.' Flows evaluate on every
-  event — as the runtime's OUTERMOST `:after` interceptor, so they fire
-  LAST (after the handler and the rest of the `:after` chain, which
-  reshapes the `:db` effect) — transforming the handler's pending `:db`
-  effect, in topological order over their static dependency graph
-  (per Spec 013 §Drain integration).
+  Each event drain evaluates the frame's flows in dependency order against
+  the pending app-db and runtime-db. Changed inputs run the flow's pure
+  derivation and materialize its result in app-db before that db is committed.
 
-  Flows are deliberately a NICHE convenience — not a sub replacement,
-  not a new dataflow paradigm. Use a sub if the value is consumed by
-  views; use a flow only if it must live in app-db for SSR / time-travel
-  / inspector reasons.
+  Flows are for derived values that must be durable application state. Values
+  consumed only by views belong in subscriptions.
 
-  Ships in `day8/re-frame2-flows`; entry points are published through
-  `re-frame.late-bind` so the core artefact's `re-frame.core` re-exports
-  reach them. Apps that don't register any flows don't pull the per-
-  frame flow registry, the topological-sort engine, the dirty-check
-  `last-inputs` map, or the outermost-`:after` `run-flows-on-db` walker.
-
-  Public façade over `re-frame.flows.topo` (pure Kahn's + cycle-path
-  extraction) and `re-frame.flows.registry` (per-frame `flows` +
-  `last-inputs` atoms, `reg-flow` / `clear-flow`)."
+  This namespace is the public facade for the optional
+  `day8/re-frame2-flows` artefact. It publishes its core integration points
+  through `re-frame.late-bind`."
   (:require [re-frame.elision :as elision]
             [re-frame.error :as error]
             [re-frame.flows.registry :as registry]
@@ -31,42 +18,20 @@
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.trace :as trace]
-            ;; JVM-only require of the flows tooling sibling that backs the
-            ;; `flow-algebra-view` alias at the foot of this ns. CLJS
-            ;; deliberately OMITS this require so a CLJS app that loads the
-            ;; flows artefact but never attaches a tool DCEs the tooling body
-            ;; wholesale — the facade never reaches it. JVM has no bundle to
-            ;; protect; the alias gives JVM tools / conformance fixtures the
-            ;; ergonomic `re-frame.flows/flow-algebra-view` shape. Mirrors the
-            ;; `re-frame.subs` → `re-frame.subs.tooling` JVM-only require.
+            ;; Keep tooling unreachable from the CLJS facade so Closure can
+            ;; remove it when no tool requires the sibling namespace.
             #?@(:clj [[re-frame.flows.tooling :as flows-tooling]])))
 
 ;; ---- public-surface re-exports -------------------------------------------
 ;;
-;; The registry atoms are private. External consumers (test fixtures,
-;; conformance harnesses, cross-artefact integration tests) reach the
-;; registry shape through the read accessors
-;; (`flows-snapshot` / `last-inputs-snapshot`) and the reset fns
-;; (`reset-flows!` / `reset-last-inputs!`). The facade re-exports both
-;; pairs.
-;;
-;; `last-inputs-snapshot` returns the RAW cached input values (owner-local
-;; app-db / runtime-db slices, possibly sensitive / large). It is an
-;; internal / test / rollback seam — `^:no-doc`, NOT an egress boundary. The
-;; raw dirty-check cache is never shipped off-box; tools and direct reads
-;; that cross a trust boundary read the ELIDED trace path
-;; (`:rf.flow/computed` / `:rf.flow/failed`, which ride `elide-inputs`).
+;; `last-inputs-snapshot` exposes raw cached values for tests and rollback. It
+;; is not a tooling or egress surface; trace payloads use the elided path.
 
 (def flows-snapshot       registry/flows-snapshot)
 (def ^:no-doc last-inputs-snapshot registry/last-inputs-snapshot)
 
-;; The canonical per-frame flow introspection surface — the
-;; `(handler-meta :flow flow-id)` replacement (rf2-en00bk, applying the
-;; rf2-0frdi `schemas/app-schema-meta-at` precedent). The per-frame `flows`
-;; atom is the SINGLE source of truth; the registrar `:flow` kind is
-;; RESERVED-but-empty. Pair-tools / 10x panels / source-coord tests read
-;; `flow-meta-at` (frame-divergent-per-id correct) rather than the frame-blind
-;; registrar slot. Mirrors `re-frame.schemas/app-schema-meta-at`.
+;; Flow metadata is frame-scoped and therefore cannot use the frame-blind
+;; registrar metadata slot.
 (def flow-meta-at       registry/flow-meta-at)
 
 (def reg-flow           registry/reg-flow)
@@ -74,104 +39,38 @@
 (def reset-flows!       registry/reset-flows!)
 (def reset-last-inputs! registry/reset-last-inputs!)
 
-;; The derivation/process algebra view of registered flows. JVM-runnable
-;; (the flow registry is partition-agnostic registration metadata), so a JVM
-;; convenience alias lets tools / conformance fixtures reach it as
-;; `re-frame.flows/flow-algebra-view` without naming the sibling. The body
-;; lives in `re-frame.flows.tooling` so a CLJS app that loads the flows
-;; artefact but attaches no tool DCEs it (the CLJS facade never `:require`s
-;; the tooling sibling — the require above is `#?@(:clj ...)`-gated). CLJS
-;; consumers (Xray + conformance) call
-;; `re-frame.flows.tooling/flow-algebra-view` directly. There is no
-;; `re-frame.core` facade export. Mirrors the
-;; `re-frame.subs/sub-algebra-view` JVM alias.
+;; JVM tools get a convenience alias. CLJS tools require the bundle-isolated
+;; sibling directly.
 #?(:clj
    (def flow-algebra-view flows-tooling/flow-algebra-view))
 
-;; ---- evaluation ---------------------------------------------------------
-;;
-;; Called from the router's OUTERMOST `:after` interceptor — fires LAST
-;; (after the handler and the rest of the `:after` chain) — transforming
-;; the pending `:db` effect before install and before :fx (per Spec 013
-;; §Drain integration).
-
-;; ---- partition-qualified input resolution (EP-0001 §535-551) ------------
-;;
-;; Flows read runtime-db via EXPLICIT partition-qualified inputs (EP-0001
-;; normative text, §535-551). The binary syntax (no redundant
-;; `[:rf.db/app …]` explicit-app form):
+;; ---- partition-qualified input resolution -------------------------------
 ;;
 ;;   bare path            → app-db    e.g. [:user :first]
 ;;   [:rf.db/runtime …]   → runtime-db e.g. [:rf.db/runtime :rf.runtime/routing :current :route-id]
 ;;
-;; ANY flow — user or framework — may read runtime-db this way; only the
-;; WRITE side is reserved (flow outputs land in app-db only — see
-;; `evaluate-flow!`'s `assoc-in db (:output-path flow)`). The resolver reads
-;; the SETTLED post-transition / post-macrostep PENDING frame-state the flow
-;; transform was handed (app-db = the pending `:db` effect / current app-db;
-;; runtime-db = the pending `:rf.db/runtime` effect / current runtime-db) —
-;; so a runtime-only event (e.g. a pure `:rf.route/transitioned` with no
-;; app-db change) still presents the changed route value here.
-;;
-;; A qualified runtime input never creates a spurious topo dependency edge:
-;; `topo/depends-on?` compares a flow's `:inputs` against another flow's
-;; OUTPUT `:output-path`, and outputs are always app-db paths (writes are reserved),
-;; so a `[:rf.db/runtime …]`-rooted input can never prefix-match an output
-;; `:output-path`. The dirty-check `:input-values` vector includes the resolved
-;; runtime value, so the trigger keys on BOTH partitions by construction
-;; (EP-0001 §542-544): a runtime-db change makes `new-inputs` differ from
-;; the cached row, forcing recompute — it cannot be hidden merely because the
-;; app-db partition was value-identical.
-
-;; The partition-syntax primitives (`runtime-partition-key` / `runtime-input?`
-;; / the strip via `input-resolve-path`) live ONCE in `re-frame.flows.registry`:
-;; `registry` is required by both this facade and `re-frame.flows.tooling`
-;; and requires neither back (no cycle), so it is the natural shared home for
-;; the rule all three consumers key on.
+;; Both reads use the pending frame-state. Outputs always target app-db, so a
+;; runtime-qualified input cannot form a topology edge with another flow's
+;; output. Its resolved value still participates in the dirty check.
 
 (defn- resolve-input
-  "Resolve one flow `:inputs` path against the pending frame-state's two
-  partitions. A `[:rf.db/runtime …rest]` path reads `runtime-db` at `…rest`
-  (the partition key stripped via the shared `registry/input-resolve-path`);
-  a bare path reads `db` (app-db) verbatim."
+  "Read a bare input from app-db or a qualified input from runtime-db."
   [db runtime-db path]
   (if (registry/runtime-input? path)
     (get-in runtime-db (registry/input-resolve-path path))
     (get-in db path)))
 
 (defn- read-inputs
-  "Read a flow's `:inputs` against the pending frame-state — `db` is the
-  pending app-db partition, `runtime-db` the pending runtime-db partition.
-  Bare paths read app-db; `[:rf.db/runtime …]` paths read runtime-db
-  (EP-0001 §535-551)."
+  "Read a flow's inputs from the pending app-db and runtime-db."
   [db runtime-db flow]
   (mapv (fn [path] (resolve-input db runtime-db path)) (:inputs flow)))
 
 (defn- elide-inputs
-  "Walk a flow's just-read input values through `elision/elide-wire-value`,
-  each under its own declared input db-path so per-path `:sensitive` /
-  `:large` declarations apply (Spec 009 §Size elision in traces). The
-  single home for the input-value elision the `:rf.flow/computed` success
-  payload and the `:rf.flow/failed` failure payload both ride — the trace
-  bus is the wire boundary on both paths, so a flow reading a large or
-  sensitive input must not surface it raw on either.
+  "Elide input values for trace emission at their declaration coordinates.
 
-  The `:path` opt seeds which declaration `elide-wire-value` matches the
-  value against, so it MUST be the DECLARATION-COORDINATE path, not the raw
-  `:inputs` path. For a runtime-db-qualified input `[:rf.db/runtime …rest]` the
-  value is read from runtime-db at `…rest` and the elision registry keys its
-  declaration at that STRIPPED `…rest` path (the registry is partition-blind —
-  the frame / commit-plane-effect / flow sources store bare path vectors).
-  Seeding the walk with the raw `[:rf.db/runtime …]` path would never match the
-  declaration and would surface the input value RAW even though the same slot's
-  classified value is correctly redacted at its app-db path. We normalize each
-  input path through the SAME `registry/input-resolve-path` the flow-output
-  install path uses, so success and failure trace input values elide against the
-  stripped runtime declaration path. A bare app-db input is unchanged by the
-  resolver, so this is a no-op for the common (app-db) case.
-
-  Callers gate this behind their own outer `interop/debug-enabled?` so the
-  walk is DCE'd in CLJS production; this fn does not re-gate."
+  Runtime input paths drop the `:rf.db/runtime` qualifier because the elision
+  registry is keyed by paths within a partition. Callers keep this function
+  inside a `debug-enabled?` branch so Closure can remove the walk."
   [frame-id flow input-values]
   (mapv (fn [input-path v]
           (elision/elide-wire-value
@@ -180,51 +79,18 @@
         input-values))
 
 (defn- validate-output!
-  "Dev-only validation of a flow's computed `:derive`-output value against its
-  optional `:schema` (Spec 013 §The registration shape — \"Malli schema
-  for the output value (dynamic-host validation in dev)\"). This is what
-  makes the `:schema` flow-map key load-bearing rather than inert metadata.
+  "Validate a computed output through the optional schemas artefact.
 
-  Routes through the schemas artefact's `:schemas/validate-with-registered-fn`
-  / `:schemas/explain-with-registered-fn` late-bind seam — the SAME seam
-  the routing artefact validates `:params` / `:query` through. Flows
-  never statically `:require` re-frame.schemas (it is optional per Spec
-  Conventions §Feature modularity), so the validation soft-passes when:
-    - the flow declares no `:schema`;
-    - the schemas artefact is not loaded (hook absent);
-    - no validator is registered (the registered validator soft-passes).
-
-  Observational, NOT a rollback (Spec 013 §\"Observational, not a
-  rollback\"). A flow's output is materialised state that downstream
-  flows in the same drain may already have read as their input by the
-  time a violation could be observed, so retroactively unwinding one
-  flow's write mid-walk would leave an inconsistent pending `:db`
-  effect. So — like `validate-app-schema!`, which is also
-  dev-only — the value IS still written; the failure surfaces as a
-  diagnostic `:rf.error/schema-validation-failure :where :flow-output`
-  trace (`:recovery :no-recovery`, matching the category's documented
-  recovery) on the error path, and the flow proceeds. This is the
-  masterpiece choice over dropping the key: the examples Flows exemplar
-  and the schemas artefact both exist, so an inert spec'd key would be a
-  gap, not restraint.
-
-  Gated by the caller's outer `interop/debug-enabled?` so the whole
-  surface DCEs in CLJS production (Spec 009 §Production builds)."
+  Validation is diagnostic: it emits a schema failure but does not unwind the
+  pending flow cascade. The caller invokes this only in debug builds."
   [frame-id flow new-output]
   (when-let [schema (:schema flow)]
     (when-let [validate (late-bind/get-fn-cached :schemas/validate-with-registered-fn)]
       (when-not (validate schema new-output)
         (let [explain     (late-bind/get-fn-cached :schemas/explain-with-registered-fn)
               explanation (when explain (explain schema new-output))
-              ;; The SHARED schema-aware redaction seam. When the flow's output
-              ;; schema flags any slot `:sensitive?` this scrubs the
-              ;; value-bearing slots (`:value` / `:explain` /
-              ;; `:explain-humanized`) to `:rf/redacted` and stamps
-              ;; `:sensitive? true`. The `:value` elision-walk is the BASE
-              ;; (`:large?` handling, per-path declarations); the seam scrubs
-              ;; the rest — including `:explain`, which would otherwise carry
-              ;; the failing value verbatim under Malli's path-shaped output —
-              ;; when the schema declares sensitivity.
+              ;; Schema-aware redaction also covers values embedded in Malli's
+              ;; explanation, which path elision cannot inspect safely.
               redact      (late-bind/get-fn-cached :schemas/redact-validation-tags)
               tags        {:category   :rf.error/schema-validation-failure
                            :where      :flow-output
@@ -232,11 +98,8 @@
                            :failing-id (:id flow)
                            :schema-id  (:id flow)
                            :path       (:output-path flow)
-                           ;; Wire-bearing — ride through the elision
-                           ;; walker so a large / sensitive output value
-                           ;; does not surface raw on the trace bus
-                           ;; (symmetric with the `:rf.flow/computed`
-                           ;; `:result` slot).
+                           ;; Keep the value on the same elided path as the
+                           ;; successful `:rf.flow/computed` result.
                            :value      (elision/elide-wire-value
                                          new-output
                                          {:frame frame-id :path (:output-path flow)})
@@ -251,57 +114,24 @@
                                redact (->> (redact schema)))))))))
 
 (defn- evaluate-flow!
-  "Evaluate one flow against the pending frame-state. `db` is the pending
-  app-db partition (the cascade accumulator threaded through prior flows'
-  writes); `runtime-db` is the pending runtime-db partition (read-only — flow
-  WRITES are app-db only, EP-0001 §535-540). Returns `[new-db dirty?]` on
-  successful evaluation (skip or recompute); on the failure path the
-  exception re-throws after the `:rf.flow/failed` trace fires.
+  "Evaluate one flow against the pending frame-state.
 
-  Failed-flow contract (Spec 013 §Failure semantics — atomicity
-  contract): the failing flow's own output is NOT
-  written (the throw happened during `:derive`; there is no usable
-  new-output). This fn re-throws an ex-info carrying `:rf.flow/failed-id`
-  so the router can attribute the cascade-level
-  `:rf.error/flow-eval-exception` (Spec 009 §Error contract) to this
-  flow; the throw propagates straight out of `run-flows-on-db`. A flow
-  throw is a PRE-INSTALL throw: the router's flows-after-interceptor
-  DISCARDS the pending `:db` effect, so app-db is left UNCHANGED — no
-  partial commit, no prior-flow writes installed, no `:rf.event/db-changed`.
-  The cascade halts at the failing flow — downstream flows scheduled
-  later in topo order do NOT run on this drain; they re-attempt naturally
-  on the next drain.
+  Returns `[db dirty?]`. A thrown derivation is rethrown with the failing flow
+  id for router attribution; `run-flows-on-db` restores dirty-check state and
+  the router discards the pending db, so no partial output is committed.
 
-  Hot path — runs as part of the flow-transform `:after` at the outermost
-  position of every event's interceptor chain, before the deferred `:db`
-  install. Invoked once per registered flow per event.
-  Trace payload construction sits inside an `interop/debug-enabled?`
-  outer gate so the elision walker (`elide-wire-value`) is not invoked
-  in CLJS production builds (per Spec 009 §Production builds). Future
-  editors: keep the gate OUTERMOST on each emit
-  site and keep wire-value walks INSIDE it — Closure DCE folds the
-  whole branch under `:advanced` + `goog.DEBUG=false`."
+  Trace payloads and their elision walks stay inside `debug-enabled?` branches
+  so Closure removes them from production CLJS builds."
   [frame-id db runtime-db flow]
   (let [flow-id    (:id flow)
         new-inputs (read-inputs db runtime-db flow)
-        ;; Dirty-check storage is PER-FRAME: read this flow's last-seen
-        ;; inputs from THIS frame's own `last-inputs`
-        ;; container. Per-frame dirty-check windows stay independent by
-        ;; construction — the read can't observe a sibling frame's row.
+        ;; Dirty-check rows live in separate per-frame atoms.
         old-inputs (registry/get-frame-flow-last-inputs frame-id flow-id)]
     (if (= new-inputs old-inputs)
       (do
-        ;; Per Spec 009 §:op-type vocabulary: `:rf.flow/skip` records a
-        ;; value-equal recompute suppression. Tools use this to surface
-        ;; "flow ran but inputs were stable" — distinct from "flow
-        ;; didn't fire at all". Outer `debug-enabled?` gate elides the
-        ;; tag-map construction in prod.
+        ;; A skip means the flow was considered but its resolved inputs were
+        ;; value-equal to the previous run.
         (when interop/debug-enabled?
-          ;; `:input-paths-unchanged` names every input db-path whose value
-          ;; was `=` to the previous run — the cascade DAG
-          ;; consumer reads this to render the "considered, no recompute"
-          ;; branch dimmed. For a value-equal skip every input is by
-          ;; definition unchanged; we ship the full input-path vector.
           (trace/emit! :flow :rf.flow/skip
                        {:flow-id                flow-id
                         :reason                 :inputs-value-equal
@@ -309,66 +139,21 @@
                         :frame                  frame-id}))
         [db false])
       (try
-        ;; Wall-clock the flow's `:derive` recompute (dev-only) so
-        ;; `:rf.flow/computed` carries `:elapsed-ms` — the per-op
-        ;; duration the Trace panel's DURATION column reads. The `now-ms`
-        ;; brackets ride `interop/debug-enabled?` (nil t0 in prod) so
-        ;; Closure DCEs them under :advanced + `goog.DEBUG=false`.
+        ;; Timing is trace-only and disappears with the surrounding debug
+        ;; branches in production builds.
         (let [t0         (when interop/debug-enabled? (interop/now-ms))
               new-output (apply (:derive flow) new-inputs)
               flow-elapsed-ms (when interop/debug-enabled?
                                 (- (interop/now-ms) t0))
-              ;; Capture the pre-write value at the flow's `:output-path`
-              ;; BEFORE we assoc-in the new output.
-              ;; This becomes the `:before` slot on the `:rf.flow/computed`
-              ;; trace below, so consumers (Xray Event Detail, re-frame-10x
-              ;; flow panel) can render "wrote [:cart :total] 47.50 -> 52.50"
-              ;; without walking the epoch's `:db-before` snapshot. The read
-              ;; happens against `db` (the loop accumulator that includes prior
-              ;; flows' writes in this drain), so a flow that reads (via
-              ;; `:inputs`) a slot an UPSTREAM flow wrote sees that upstream
-              ;; write — the correct cascade-local semantics. The `:before` at
-              ;; the flow's OWN `:output-path`, however, can only ever reflect
-              ;; the handler's / pre-existing value, NEVER another flow's
-              ;; write: the disjoint-output-path invariant
-              ;; (`detect-output-path-overlap!`, wired into `reg-flow`) rejects
-              ;; any two same-frame flows whose output `:output-path`s stand in
-              ;; a prefix relationship, so no upstream flow can have written
-              ;; this flow's `:output-path` earlier in the drain (per Spec 013
-              ;; §Disjoint output paths). Gated to dev-only so the read is DCE'd
-              ;; under `:advanced` + `goog.DEBUG=false`.
+              ;; Read from the cascade accumulator so `:before` describes the
+              ;; value this write replaces. Output-path overlap validation means
+              ;; another flow cannot have written the same slot.
               old-output (when interop/debug-enabled?
                            (get-in db (:output-path flow)))
               new-db     (assoc-in db (:output-path flow) new-output)]
-          ;; Advance the dirty-check row in THIS frame's own `last-inputs`
-          ;; container — frame-local, can't touch a sibling.
           (registry/set-frame-flow-last-inputs! frame-id flow-id new-inputs)
-          ;; Per Spec 009 §:op-type vocabulary: `:rf.flow/computed`
-          ;; records a successful recompute. The dirty-check is
-          ;; `=`-equality so this only fires when inputs actually
-          ;; changed.
-          ;;
-          ;; Wire-bearing payloads (`:input-values`, `:result`,
-          ;; `:before`) ride through `elision/elide-wire-value` per
-          ;; Spec 009 §Size elision in traces — the walker is the
-          ;; single normative emission site for `:rf.size/large-
-          ;; elided` (and the `:rf/redacted` privacy sentinel) — so a
-          ;; flow reading or producing a large or sensitive value never
-          ;; surfaces raw on the trace bus, honouring the same elision
-          ;; contract every other wire-emitting surface does. Off-box
-          ;; defaults match `event-emit` / `error-emit`.
-          ;;
-          ;; The `:path` opt on each walker call names where in the
-          ;; slice's root the wrapped value lives — `:result` and
-          ;; `:before` BOTH live at the flow's output path; each
-          ;; `:input-values` entry is the value at the matching input
-          ;; path. The walker reads `[:rf.runtime/elision
-          ;; :declarations <path>]` and emits the marker for
-          ;; frame-declared large slots.
-          ;;
-          ;; Outer `interop/debug-enabled?` gate keeps the elision
-          ;; walker out of CLJS prod builds — Closure constant-folds the
-          ;; whole branch under `:advanced` + `goog.DEBUG=false`.
+          ;; Inputs and both output values are wire-bearing trace data, so each
+          ;; is elided at the path whose declaration governs it.
           (when interop/debug-enabled?
             (trace/emit! :flow :rf.flow/computed
                          {:flow-id      flow-id
@@ -382,50 +167,13 @@
                           :path         (:output-path flow)
                           :elapsed-ms   flow-elapsed-ms
                           :frame        frame-id})
-            ;; Dev-only output-schema validation. Runs AFTER the
-            ;; `:rf.flow/computed` emit so the computed value is
-            ;; already on the trace stream when a violation surfaces;
-            ;; observational (the write at `new-db` stands). Sits inside
-            ;; this outer `debug-enabled?` gate so the whole surface DCEs
-            ;; in CLJS prod alongside the trace emit.
+            ;; Validation is observational and follows the computed trace.
             (validate-output! frame-id flow new-output))
           [new-db true])
         (catch #?(:clj Throwable :cljs :default) e
-          ;; Per Spec 009 §:op-type vocabulary: :rf.flow/failed fires
-          ;; when the flow's :derive fn throws. last-inputs is NOT
-          ;; advanced — so the flow will retry on the next drain rather
-          ;; than silently caching a stale-or-missing output. We re-throw
-          ;; an ex-info carrying `:rf.flow/failed-id` (Spec 013 §Failure
-          ;; semantics — atomicity contract); it propagates through
-          ;; `run-flows-on-db` to the router's flows-after-interceptor,
-          ;; which DISCARDS the pending `:db` effect (no partial commit —
-          ;; app-db unchanged) and emits the cascade-level
-          ;; :rf.error/flow-eval-exception per Spec 009 §Error contract.
-          ;; The per-flow `:rf.flow/failed` trace emitted here adds the
-          ;; flow-attributed detail tools (10x flow panel) consume.
-          ;;
-          ;; The failure-path `:inputs` payload rides through the
-          ;; elision walker (`elide-inputs`) for the same reason as the
-          ;; success path — the value that triggered the throw may itself
-          ;; be a large or sensitive blob, and the trace bus is the wire
-          ;; boundary. Outer debug-enabled? gate elides the walk in CLJS
-          ;; prod.
-          ;; Emit a STRUCTURED, EDN-safe exception summary —
-          ;; `:exception-message` (the plain message string) + `:exception-data`
-          ;; (the ex-info ex-data map, or nil) — NEVER the raw Throwable. A bare
-          ;; Throwable is not EDN-serializable and the central trace projection
-          ;; switch (`re-frame.classification/project-trace-event`) has no branch for a
-          ;; bare `:ex` slot, so a raw object would reach trace delivery, epoch
-          ;; capture, and tooling listeners unprojected — and a flow `:derive`
-          ;; throwing `ex-info` with app secrets in `ex-data` (or an
-          ;; interpolated message) would leak them off-box. The summary shape
-          ;; matches every other `:rf.error/*` category in the Spec 009
-          ;; catalogue (`:exception-message`; machine adds `:exception-data`);
-          ;; `project-trace-event` redacts the `:exception-data` slot
-          ;; fail-closed when the flow's frame declares any sensitivity (the
-          ;; flows analogue of `project-machine-error-tags`). The cascade-level
-          ;; `:rf.error/flow-eval-exception` (router) retains the live
-          ;; `:exception` for stack-trace introspection on its OWN error row.
+          ;; Emit an EDN-safe summary rather than a host Throwable. Projection
+          ;; redacts author-controlled `:exception-data` when the frame carries
+          ;; sensitive declarations; the router's local error retains the cause.
           (when interop/debug-enabled?
             (trace/emit! :flow :rf.flow/failed
                          {:flow-id           flow-id
@@ -434,35 +182,8 @@
                           :exception-data    (ex-data e)
                           :inputs            (elide-inputs frame-id flow new-inputs)
                           :frame             frame-id}))
-          ;; Wrap the throw in an ex-info carrying the flow-attribution slot
-          ;; `:rf.flow/failed-id`.
-          ;; The router's `flows-after-interceptor` catch stashes the
-          ;; throw under `:rf/flow-error`, then `emit-flow-eval-exception!`
-          ;; reads `:rf.flow/failed-id` off the ex-data and stamps
-          ;; `:flow-id` into the substrate record's `:tags` so ops in
-          ;; CLJS production (where `:rf.flow/failed` DCEs) can attribute
-          ;; the cascade-level `:rf.error/flow-eval-exception` to a
-          ;; specific flow. Attribution is `:flow-id`-only: there is no
-          ;; real flow VALUE to carry, so the contract carries the id and
-          ;; nothing more (per Spec 013 §Failure semantics / §Resolved
-          ;; decisions). The failing frame is already in scope at the
-          ;; router boundary (it is the frame being drained), so it is not
-          ;; duplicated here. Symmetric with Spec 013 §Failure semantics
-          ;; rule 4: the per-flow trace fires first with flow attribution;
-          ;; the cascade-level error preserves the same attribution at the
-          ;; substrate boundary.
-          ;;
-          ;; Route through the canonical thrown-error builder
-          ;; (`error/throw-error!`, Spec 009 §The thrown-error shape) like
-          ;; every OTHER flows throw (`topo.cljc` cycle / overlap,
-          ;; `registry.cljc` frame-not-live). The builder DERIVES the human
-          ;; message from `:reason` + the `[:rf.error/<id>]` token and stamps
-          ;; the canonical `{:rf.error/id :where :recovery :reason}` ex-data,
-          ;; so a tool reading `(:rf.error/id (ex-data e))` gets the machine
-          ;; discriminator. The flow-attribution slot rides in `:extra`; the
-          ;; original exception rides in `:extra :cause` for stack-trace
-          ;; introspection (the router surfaces the rethrown ex-info ITSELF
-          ;; as the `:exception` slot of `:rf.error/flow-eval-exception`).
+          ;; Preserve flow attribution for the always-on router error, which is
+          ;; still emitted when the debug-only per-flow trace is absent.
           (error/throw-error!
             :rf.error/flow-eval-exception
             'rf/run-flows-on-db
@@ -477,127 +198,32 @@
                         :cause             e}}))))))
 
 (defn run-flows-on-db
-  "Per Spec 013 §Drain integration + EP-0001 §535-551: walk THIS FRAME'S
-  registered flows in topological order over the pending frame-state,
-  dirty-check each one, recompute and assoc-in the result into a transformed
-  APP-DB. Returns the flow-augmented APP-DB value.
+  "Transform a frame's pending app-db by evaluating its flows in dependency
+  order. Runtime-db is a read-only input; flow outputs always target app-db.
 
-  Signature `[frame-id db runtime-db]` — the full pending frame-state. `db`
-  is the pending app-db partition; `runtime-db` the pending runtime-db
-  partition (pass `nil` to resolve only bare app-db inputs). The router's
-  flows-after-interceptor always supplies both partitions.
-
-  EP-0001 §535-551: a flow reads app-db by default (bare `:inputs` paths) and
-  runtime-db only through EXPLICIT
-  partition-qualified inputs `[:rf.db/runtime …]` (binary syntax — there is
-  NO redundant `[:rf.db/app …]` form). ANY flow — user or framework — may
-  read runtime-db this way; only the WRITE side is reserved. Flow outputs
-  write ONLY app-db (the cascade threads and returns the APP-DB partition;
-  runtime-db is read-only for the whole pass). The trigger / dirty-check
-  keys on BOTH partitions: a runtime-db change shows up in the resolved
-  `:input-values`, so a runtime-only event (e.g. a pure
-  `:rf.route/transitioned`) recomputes a route-reading flow even when app-db
-  is value-identical (EP-0001 §542-544 — a runtime write cannot be hidden
-  from a flow merely because the app-db partition did not change).
-
-  This is the **outermost-`:after` flow transform**. The router installs
-  it as the OUTERMOST `:after` interceptor (re-frame.router/flows-after-
-  interceptor), so it fires LAST — after the event handler AND the rest
-  of the `:after` chain (which reshapes the `:db` effect, e.g. the `path`
-  std-interceptor splicing the handler's slice back into the full db) —
-  against the chain's PENDING `:db` effect (or the current app-db value
-  when the handler returned no `:db`), and BEFORE the `:db` install — NOT
-  against the already-installed app-db. The caller writes the returned
-  value back into the chain context's `:effects :db` slot so the eventual
-  `:db` install observes the flow-augmented db.
-
-  Flows are frame-scoped — only flows registered against frame-id run
-  here, leaving sibling frames' flows untouched.
-
-  Failed-flow contract (Spec 013 §Failure semantics — atomicity
-  contract): a flow throw is a PRE-INSTALL throw, so it aborts the WHOLE
-  event. There is NO partial commit — the pending `:db`
-  effect (the handler's write plus any prior successful flows' writes) is
-  DISCARDED by the router's `flows-after-interceptor` catch, so app-db is
-  left UNCHANGED. This fn therefore does NOT carry a partial-db on the
-  re-thrown ex-info: it would have no consumer. The cascade halts (flows
-  scheduled later in topo order do not run on this drain) and the router
-  surfaces the cascade-level `:rf.error/flow-eval-exception`.
-
-  Atomicity extends to the dirty-check bookkeeping: `evaluate-flow!`
-  advances THIS frame's `last-inputs` container for each flow it computes,
-  but on a throw NOTHING is installed — so a prior flow's advanced
-  `last-inputs` would (wrongly) suppress its recompute next drain even
-  though its output never reached app-db, silently losing the write
-  forever. So we SNAPSHOT this frame's `last-inputs` before the walk and
-  RESTORE it on a throw: every flow — prior-successful and failing alike —
-  re-attempts cleanly on the next drain, matching the all-or-nothing `:db`
-  install. The `:rf.flow/failed-id` slot (stamped by `evaluate-flow!`) is
-  preserved on the re-thrown ex-info so the router can attribute the
-  cascade-level error to the failing flow.
-
-  The snapshot / restore is scoped to the DRAINING frame's OWN
-  `last-inputs` container — `frame-id`'s atom, not a global. A sibling
-  frame draining concurrently on another JVM thread holds a different atom,
-  so this rollback cannot clobber its just-advanced dirty-check rows. The
-  per-frame-independence invariant (Spec 002 rule 1 / Spec 013
-  §Frame-scoping) holds by construction, not by careful keying."
+  The router calls this from its outermost `:after` interceptor, after other
+  interceptors have shaped the pending db and before commit. If a derivation
+  throws, this function restores the frame's dirty-check cache and pending path
+  vacations, then rethrows. The router discards the pending db, preserving
+  all-or-nothing event semantics."
   [frame-id db runtime-db]
   (let [flow-map (get (registry/flows-snapshot) frame-id)
-        ;; DRAIN (read-and-clear) this frame's pending abandoned output
-        ;; paths — recorded by an IN-DRAIN same-frame `reg-flow`
-        ;; `:output-path` move OR an IN-DRAIN `clear-flow` (either would have
-        ;; a direct app-db write clobbered by the deferred commit).
-        ;; `abandoned-before` is the snapshot the catch / post-commit
-        ;; rollback re-records (the move re-attempts next drain if the event
-        ;; aborts); `abandoned-paths` is the SAME set, consumed here exactly
-        ;; once.
-        ;;
-        ;; Computed and vacated from the pending `:db` UNCONDITIONALLY —
-        ;; BEFORE the empty-`flow-map` early return below. An in-drain
-        ;; `clear-flow` that removed the frame's LAST flow leaves `flow-map`
-        ;; empty here, but the abandoned path it recorded still must be
-        ;; dissoc'd from the pending `:db`: the early return has no flow
-        ;; walk to carry that dissoc, so skipping it would let the deferred
-        ;; commit publish the handler's returned `:db` — which still carries
-        ;; the cleared flow's stale value at the abandoned path —
-        ;; resurrecting it. Frame-scoped.
+        ;; In-drain lifecycle changes cannot write app-db directly because the
+        ;; deferred commit would overwrite them. Apply their queued vacations
+        ;; to the pending db even when the last flow was just cleared.
         abandoned-before (registry/abandoned-output-paths-snapshot frame-id)
         abandoned-paths  (registry/drain-abandoned-output-paths! frame-id)
-        ;; Each `vacate-path-in-db` is a pure `db → db` LEAF dissoc
-        ;; (no-op-safe). No-op set ⇒ `db` unchanged.
         db (reduce registry/vacate-path-in-db db abandoned-paths)]
     (if-not (seq flow-map)
       db
       (let [ordered (topo/topo-sort flow-map)
-            ;; Snapshot ONLY the draining frame's dirty-check container so a
-            ;; flow throw can roll back the frame's own advances — the event
-            ;; aborts, so prior flows' `last-inputs` advances must NOT
-            ;; survive (their outputs were never installed). Scoped to
-            ;; `frame-id` so a concurrently-draining sibling frame is
-            ;; structurally untouched. Restored in the catch below.
+            ;; Each frame owns a separate cache atom, so rollback cannot
+            ;; overwrite a sibling frame's concurrent advances.
             last-inputs-before (registry/frame-last-inputs-snapshot frame-id)]
-        ;; EP-0025: a flow's EXPLICIT output data-classification declarations are
-        ;; installed at `reg-flow` time (not drain time) and there is NO
-        ;; input->output propagation, so there is no drain-time mark-mutation
-        ;; refresh to run (or to roll back). The flow walk proceeds directly.
         (try
-          ;; The drain threads ONLY the transformed APP-DB `db` — the loop is
-          ;; a pure left-fold over the topo-ordered flows. `runtime-db` is the
-          ;; pending runtime-db partition, read-only for the WHOLE pass: flow
-          ;; outputs write app-db only (EP-0001 §539 — runtime writes
-          ;; reserved), and a flow's qualified `[:rf.db/runtime …]` inputs all
-          ;; resolve against the SAME pending runtime-db snapshot (no cascade-
-          ;; local runtime mutation to thread). `evaluate-flow!` returns a
-          ;; `[new-db dirty?]` tuple but the cascade has no consumer for the
-          ;; dirty flag: the router writes the returned db value straight into
-          ;; the `:db` effect slot regardless. So discard the second slot here
-          ;; (the per-flow `:rf.flow/skip` / `:rf.flow/computed` traces carry
-          ;; the dirty/clean signal tools actually read).
+          ;; Left-fold app-db writes through the topological order. Every flow
+          ;; reads the same pending runtime-db snapshot.
           (loop [remaining ordered
-                 ;; `db` already carries the abandoned-paths vacate applied
-                 ;; above (before any flow computes), so a flow newly owning
-                 ;; a moved-to slot recomputes onto a clean base.
                  db        db]
             (if (empty? remaining)
               db
@@ -605,83 +231,28 @@
                     [new-db _]   (evaluate-flow! frame-id db runtime-db flow)]
                 (recur (rest remaining) new-db))))
           (catch #?(:clj Throwable :cljs :default) e
-            ;; Atomicity contract: discard ALL flow side-effects of this
-            ;; aborted drain. The pending `:db` effect is dropped by the
-            ;; router; here we restore THIS frame's pre-drain `last-inputs`
-            ;; (its own container only) so every flow on this frame re-attempts
-            ;; next drain while sibling frames are untouched. EP-0025: there is no
-            ;; drain-time elision-declaration refresh to roll back (explicit flow
-            ;; declarations are installed at reg-flow time, not drain time). The
-            ;; throw (carrying `:rf.flow/failed-id` from `evaluate-flow!`)
-            ;; propagates unchanged for router attribution.
+            ;; Match the router's discarded pending db by restoring every
+            ;; eager side effect owned by this flow pass.
             (registry/reset-frame-last-inputs-to! frame-id last-inputs-before)
-            ;; Re-record the IN-DRAIN abandoned output paths drained above. A
-            ;; flow throw aborts the event — the pending `:db` (which carried
-            ;; the vacated state) is discarded — so the path move must
-            ;; re-attempt next drain rather than be silently lost. Frame-scoped.
-            ;; The post-COMMIT rollback mirror lives in `commit-frame-effects!`
-            ;; via `:flows/restore-abandoned-paths!`.
             (registry/restore-abandoned-output-paths! frame-id abandoned-before)
             (throw e)))))))
 
 ;; ---- late-bind hook registration ----------------------------------------
 ;;
-;; re-frame.core, re-frame.fx, re-frame.router and re-frame.test-support
-;; need to call into flows but ship in the core artefact — they cannot
-;; `:require` this namespace because the flows artefact is optional
-;; (apps that don't register flows don't carry it). Publish entry
-;; points through the late-bind hook registry; consumers look the fns
-;; up at call time.
-;;
-;; Calls are written as literal `set-fn!` invocations with a literal
-;; keyword (one per line) — the late-bind drift gate
-;; (`re-frame.late-bind-drift-test`) detects each publication via regex
-;; over `implementation/**/src/**`, matching every other artefact's
-;; publication block (schemas / machines / routing / http / ssr).
+;; Core cannot statically require this optional artefact. Keep each publication
+;; as a literal call so the late-bind drift gate can discover it.
 
 (late-bind/set-fn! :flows/reg-flow           reg-flow)
 (late-bind/set-fn! :flows/clear-flow         clear-flow)
 (late-bind/set-fn! :flows/run-flows-on-db    run-flows-on-db)
 (late-bind/set-fn! :flows/reset-flows!       reset-flows!)
-;; The dirty-check-rollback pair the router uses to keep this frame's
-;; `last-inputs` bookkeeping aligned with the DURABLE app-db across a
-;; POST-commit schema/machine-data rollback. The flow transform runs inside
-;; the chain and eagerly advances `last-inputs` for each computed flow; but
-;; the rollback decision lands AFTER the chain, in `commit-db-effect!`,
-;; OUTSIDE `run-flows-on-db`'s own throw-path snapshot/restore. Without these
-;; hooks a rolled-back commit restores app-db to `db-before` but leaves the
-;; advanced `last-inputs` rows, so the next clean drain sees `=`-equal inputs,
-;; SKIPS the flow, and the flow output never re-materialises — a deterministic
-;; dev/test failure path could permanently suppress a flow. The router
-;; snapshots the draining frame's rows BEFORE the flow transform and, on a
-;; rollback, restores them — the exact mirror of the in-`run-flows-on-db`
-;; throw-path rollback, just at the post-commit boundary the flows artefact
-;; cannot see. Both delegate to the SAME frame-scoped registry primitives the
-;; throw path uses: structurally incapable of touching a sibling frame's
-;; container.
+;; The router owns post-transform commit rollback. These pairs let it restore
+;; the eager dirty-check advances and consumed path vacations that this
+;; artefact cannot otherwise observe after returning.
 (late-bind/set-fn! :flows/snapshot-last-inputs registry/frame-last-inputs-snapshot)
 (late-bind/set-fn! :flows/restore-last-inputs!  registry/reset-frame-last-inputs-to!)
-;; The abandoned-output-paths rollback pair, the exact mirror of the
-;; `last-inputs` pair above but for the IN-DRAIN `reg-flow`
-;; `:output-path`-move vacate. `run-flows-on-db` DRAINS (read-and-clears) the
-;; pending abandoned paths and dissocs them from the pending `:db`; its OWN
-;; throw arm re-records them. But a POST-commit schema / machine-data rollback
-;; lands AFTER the chain, in `commit-frame-effects!`, OUTSIDE
-;; `run-flows-on-db` — and discards the pending `:db` (which carried the
-;; vacated state). Without these hooks the abandoned path would be
-;; drained-and-cleared yet never durably vacated, so the move is silently
-;; lost. The router snapshots the pending set BEFORE the flow transform and,
-;; on a rollback, re-records it — the same boundary the `last-inputs` mirror
-;; covers. Frame-scoped.
 (late-bind/set-fn! :flows/snapshot-abandoned-paths registry/abandoned-output-paths-snapshot)
 (late-bind/set-fn! :flows/restore-abandoned-paths!  registry/restore-abandoned-output-paths!)
-;; Frame-destroy teardown hook (symmetric with the machines
-;; `:machines/teardown-on-frame-destroy!` hook). `frame/destroy-frame!`
-;; invokes this hook so the destroyed frame's per-frame flow-registry entries
-;; and the matching `last-inputs` rows clear in one step. SINGLE-STORE
-;; (rf2-en00bk): the per-frame `flows` atom is the sole store, so there is no
-;; frame-blind registrar `:flow` slot to realign — dropping the frame's
-;; per-frame entries is the whole job. Without the hook a long-running SSR JVM
-;; (per-request frame churn) would leak flow state indefinitely.
+;; Frame destruction must release registry rows and caches owned by that frame.
 (late-bind/set-fn! :flows/teardown-on-frame-destroy!
                    registry/teardown-on-frame-destroy!)

--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -1,46 +1,11 @@
 (ns re-frame.flows.registry
-  "Per-frame flow registry — owns the `flows` registry atom and the
-  PER-FRAME `last-inputs` dirty-check containers, flow-map validation,
-  registration (`reg-flow` / `clear-flow`), and the per-frame dirty-check
-  invalidation a same-frame re-registration triggers.
+  "Frame-scoped flow registration and lifecycle state.
 
-  Per Spec 013 flows are FRAME-SCOPED: same flow-id can register against
-  two frames with different `:inputs` / `:derive` / `:output-path`, and
-  undo / time-travel semantics belong to one frame's history. The
-  registry shape is `{frame-id {flow-id flow-map}}`.
-
-  SINGLE-STORE (rf2-en00bk, applying the rf2-0frdi schemas precedent):
-  the per-frame `flows` atom is the SOLE authoritative store. Flows are
-  FRAME-DIVERGENT-PER-ID (the same flow-id can carry different
-  `:inputs` / `:derive` / `:output-path` per frame), so a frame-BLIND
-  `{flow-id metadata}` registrar slot is the wrong shape — it cannot hold
-  the authoritative state and had to be hand-REALIGNED to a surviving
-  owner on clear / frame-destroy. That double-write + realignment
-  workaround is GONE. The `:flow` registrar kind stays RESERVED in
-  `registrar/kinds` (Spec 001 §Registry model continuity) but the
-  registrar slot is intentionally **empty** — matching the `:app-schema`
-  (rf2-0frdi) and `:http-interceptor` precedents. Tools and source-coord
-  introspection read the frame-scoped `flow-meta-at` / `flows-snapshot`
-  surface, NOT `handler-meta :flow` / `registrations :flow`.
-
-  Dirty-check storage is PER-FRAME by construction. Each frame owns its
-  own `last-inputs` container (`atom {flow-id inputs}`), held in the
-  `frame-last-inputs` registry keyed by frame-id. A frame's drain reads
-  and writes ONLY its own atom; the failed-flow rollback snapshots and
-  restores ONLY the draining frame's atom. Cross-frame interference during
-  a concurrent drain is therefore impossible by construction — a frame can
-  no more touch a sibling's dirty-check rows than it can touch a sibling's
-  app-db.
-
-  The façade (`re-frame.flows`) re-exports the public surface — `reg-flow`,
-  `clear-flow`, `reset-flows!`, `reset-last-inputs!`, plus the read
-  accessors `flows-snapshot` / `last-inputs-snapshot`. The underlying atoms
-  themselves are PRIVATE to this artefact: external consumers (production
-  code, the late-bind directory, test fixtures across artefacts) reach the
-  registry state through the accessor seam rather than dereferencing the
-  atom Vars directly. `last-inputs-snapshot` re-aggregates the per-frame
-  atoms back into the canonical `{flow-id {frame-id inputs}}` observation
-  shape."
+  The authoritative registry is `{frame-id {flow-id flow-map}}`; the same id
+  may have a different definition in each frame. Dirty-check values and pending
+  output-path vacations also use per-frame containers so drain rollback cannot
+  interfere with a sibling frame. External consumers use the snapshot and
+  lifecycle functions rather than the private atoms."
   (:require [re-frame.elision :as elision]
             [re-frame.error :as error]
             [re-frame.flows.topo :as topo]
@@ -53,15 +18,6 @@
 
 ;; ---- state ---------------------------------------------------------------
 ;;
-;; The atoms below are PRIVATE to this artefact. External consumers reach the
-;; registry state through the public read accessors (`flows-snapshot` /
-;; `last-inputs-snapshot`) and the reset fns (`reset-flows!` /
-;; `reset-last-inputs!`) — the facade re-exports them at `re-frame.flows`. The
-;; atoms themselves are NOT a public surface; treating them as one couples
-;; consumers to the internal shape. The accessor seam keeps the flexibility on
-;; the framework side while giving tests the read-and-reset affordances they
-;; actually need.
-
 (defonce
   ^{:doc     "frame-id → flow-id → flow-map. Per-frame so undo / time-travel
               / clear semantics are unambiguous."
@@ -69,40 +25,17 @@
   flows
   (atom {}))
 
-;; PER-FRAME dirty-check storage. `frame-last-inputs` is a registry mapping
-;; `frame-id → (atom {flow-id last-seen-input-vec})`: each frame owns its OWN
-;; inner atom of dirty-check rows, mirroring how every other per-frame runtime
-;; cell (app-db container, router queue, sub-cache, drain-lock — see
-;; `re-frame.frame/new-frame-record`) is held independently per frame.
-;;
-;; A frame's drain reads / writes ONLY `(get @frame-last-inputs frame-id)`, and
-;; the failed-flow rollback in `re-frame.flows/run-flows-on-db` snapshots /
-;; restores ONLY that one atom. A frame can no more clobber a sibling's
-;; dirty-check rows than it can clobber a sibling's app-db — cross-frame
-;; interference is impossible BY CONSTRUCTION, not merely avoided.
-;;
-;; The outer `frame-last-inputs` atom is mutated only on frame-slot
-;; lifecycle (first touch creates the inner atom; teardown / reset removes
-;; it). The hot per-drain path mutates the INNER atom in place — so the
-;; per-frame container identity is stable across a frame's lifetime and the
-;; reader / writer never contend on the outer registry.
+;; The outer registry changes only when a frame's cache is created or removed.
+;; Drains mutate the frame's stable inner atom and never contend with sibling
+;; frames on cache updates.
 (defonce
-  ^{:doc     "frame-id → (atom {flow-id last-seen-input-vec}). Per-frame
-              dirty-check containers. Each frame's inner atom is read /
-              written only by that frame's drain; the failed-flow rollback
-              restores only the draining frame's own atom."
+  ^{:doc     "frame-id → (atom {flow-id last-seen-input-vec})."
     :private true}
   frame-last-inputs
   (atom {}))
 
 (defn- ^:no-doc ensure-frame-last-inputs-atom!
-  "Return the inner `last-inputs` atom for `frame-id`, creating (and
-  registering) it on first touch. The create-if-absent is done under a
-  single `swap!` over the outer `frame-last-inputs` registry so concurrent
-  first-touches on the JVM converge on ONE inner atom (the loser's freshly
-  allocated atom is discarded; both threads then read the winner via the
-  returned value). Idempotent for an already-present frame — returns the
-  existing atom without allocating."
+  "Return a frame's cache atom, creating it atomically on first touch."
   [frame-id]
   (or (get @frame-last-inputs frame-id)
       (get (swap! frame-last-inputs
@@ -114,38 +47,17 @@
 
 ;; ---- public read accessors -----------------------------------------------
 ;;
-;; `flows-snapshot` and `last-inputs-snapshot` are the public seam external
-;; consumers (test fixtures, conformance harnesses, the cross-artefact
-;; integration tests in http / epoch / routing / ssr / core) use to observe
-;; the registry shape without dereferencing the private atoms above. Reads
-;; only — mutation goes through `reg-flow` / `clear-flow` /
-;; `teardown-on-frame-destroy!` / `reset-flows!` / `reset-last-inputs!`.
-
 (defn flows-snapshot
-  "Return the per-frame flow registry value: `{frame-id {flow-id flow-map}}`.
-  Snapshot — observers MUST NOT mutate (the underlying atom is private)."
+  "Return `{frame-id {flow-id flow-map}}`."
   []
   @flows)
 
-;; ---- per-frame flow introspection (the `handler-meta :flow` replacement) ---
-;;
-;; SINGLE-STORE (rf2-en00bk): flows are FRAME-DIVERGENT-PER-ID, so the
-;; frame-blind registrar `:flow` slot is the wrong shape and is no longer
-;; written (the `:flow` registrar kind is RESERVED-but-empty, mirroring
-;; `:app-schema` per rf2-0frdi). The canonical introspection surface is
-;; `flow-meta-at` — the flows analogue of `schemas/app-schema-meta-at` — which
-;; resolves the frame the read targets and returns that frame's flow-map for
-;; the id (carrying the registration's `:ns` / `:line` / `:file` source-coords,
-;; `:inputs`, `:derive`, `:output-path`, …). Pair-tools, 10x panels and
-;; source-coord tests read THIS rather than `(handler-meta :flow flow-id)`.
+;; ---- per-frame flow introspection ----------------------------------------
 
 (defn- coerce-flow-opts
-  "Permit the keyword-only sugar `(flow-meta-at id frame-id)` and the opts-map
-  form `(flow-meta-at id {:frame frame-id})`. A `nil` arg coerces to `{}` (no
-  override — resolve the frame from the carried-invariant scope). A keyword or
-  a frame VALUE coerces to `{:frame target}`. Mirrors
-  `schemas.storage/coerce-opts`; the frame-value branch precedes the generic
-  `map?` branch because a frame value IS a map (rf2-7pllal)."
+  "Coerce a frame target or opts map to the `flow-meta-at` opts shape.
+
+  Test frame values before `map?` because frame values are maps."
   [opts-or-frame-id]
   (cond
     (nil? opts-or-frame-id) {}
@@ -155,15 +67,7 @@
     :else {:frame opts-or-frame-id}))
 
 (defn- resolve-read-frame
-  "Resolve the frame a flow READ targets. EP-0002 — the explicit `:frame` opt
-  (the *override*) wins, else the carried-invariant scope chain via
-  `frame/require-current-frame!`. Called under no scope and no explicit
-  `:frame`, it raises `:rf.error/no-frame-context` rather than defaulting to
-  `:rf/default`. The override is a frame TARGET (keyword id or frame value),
-  normalized to its frame-id via `frame/frame-target->id`. Per rf2-8mxnnk the
-  `reg-flow` / `clear-flow` WRITE paths normalize their explicit `:frame`
-  override the same way, so a frame VALUE keys / reads the same flow uniformly
-  across register, clear, and `flow-meta-at`."
+  "Resolve an explicit frame target or require an ambient frame."
   [opts]
   (let [override (:frame opts)]
     (if (some? override)
@@ -172,24 +76,10 @@
         :flow-meta-at {:where 'rf/flow-meta-at}))))
 
 (defn flow-meta-at
-  "Return the registration metadata map for `flow-id` in a frame, or nil.
+  "Return a flow's registration map in the selected frame, or nil.
 
-  The canonical per-frame introspection surface for flows — the
-  `(handler-meta :flow flow-id)` replacement (rf2-en00bk, applying the
-  rf2-0frdi `schemas/app-schema-meta-at` precedent). Returns the full flow-map
-  stamped at `reg-flow` — including source-coords (`:ns` / `:line` / `:file`),
-  `:inputs`, `:derive`, `:output-path`, and any output-classification keys —
-  for the `(frame-id, flow-id)` entry in the authoritative per-frame `flows`
-  atom. Frame-divergent by construction: the SAME flow-id registered against
-  two frames returns each frame's OWN definition, where the frame-blind
-  registrar slot could only ever show the most-recent registrant (the very
-  reason the realignment workaround existed).
-
-  Arities:
-    (flow-meta-at flow-id)         ;; frame from the carried-invariant scope
-    (flow-meta-at flow-id opts)    ;; opts map; :frame names the frame target
-                                   ;; (keyword id or frame value; keyword sugar
-                                   ;; `(flow-meta-at flow-id frame-id)` accepted)"
+  With one argument, use the ambient frame. The second argument accepts either
+  `{:frame target}` or a frame target directly."
   ([flow-id] (flow-meta-at flow-id {}))
   ([flow-id opts-or-frame-id]
    (let [opts     (coerce-flow-opts opts-or-frame-id)
@@ -197,22 +87,10 @@
      (get-in @flows [frame-id flow-id]))))
 
 (defn ^:no-doc last-inputs-snapshot
-  "Return the dirty-check value re-aggregated to the canonical observation
-  shape `{flow-id {frame-id inputs}}`. Reads every per-frame container and
-  inverts the `{frame-id {flow-id inputs}}` layout back to `flow-id`-outer.
-  Empty per-frame containers contribute nothing, so a frame whose dirty-check
-  rows all cleared leaves no key behind. Snapshot — observers MUST NOT mutate
-  (the underlying atoms are private).
+  "Return raw cached inputs as `{flow-id {frame-id inputs}}`.
 
-  RAW — NOT an egress boundary (Spec 015). The cached input vectors are the
-  OWNER-LOCAL app-db / runtime-db values just read for the dirty check, so
-  they can be sensitive or large. This accessor returns them verbatim and is
-  for INTERNAL / TEST / ROLLBACK use only (the failed-flow rollback snapshot,
-  conformance harnesses, dirty-check assertions). Any tool or direct read
-  that crosses a trust boundary MUST go through the elided trace path
-  (`:rf.flow/computed` `:input-values` / `:rf.flow/failed` `:inputs`, which
-  ride `re-frame.flows/elide-inputs`), NOT this raw accessor — the cached
-  dirty-check value is never shipped off-box."
+  This internal/test accessor is not an egress boundary; use projected flow
+  traces when values leave the owning runtime."
   []
   (reduce-kv
     (fn [acc frame-id inner-atom]
@@ -226,86 +104,44 @@
 
 ;; ---- intra-artefact-only mutation helpers --------------------------------
 ;;
-;; `re-frame.flows` (the facade evaluation path) reads / advances the
-;; draining frame's `last-inputs` on every successful flow recompute and
-;; snapshots / restores it across the drain. These helpers keep the mutation
-;; contained in this namespace — the atom never escapes — and are frame-
-;; scoped: every read / write / rollback names the frame it operates on, so
-;; no path can touch a sibling frame's container. NOT a public surface;
-;; ns-doc names the consumer.
-
 (defn ^:no-doc frame-last-inputs-snapshot
-  "Return the draining frame's dirty-check rows as a plain `{flow-id inputs}`
-  map (the drain-start snapshot for the failed-flow rollback). Empty map
-  when the frame has no container yet."
+  "Return a frame's dirty-check rows as `{flow-id inputs}`."
   [frame-id]
   (if-let [a (get @frame-last-inputs frame-id)]
     @a
     {}))
 
 (defn ^:no-doc get-frame-flow-last-inputs
-  "Read the last-seen input vec for `[frame-id flow-id]` — the dirty-check
-  skip-path read. `nil` when the frame has no container or the flow has no
-  row yet."
+  "Return the cached inputs for a flow in a frame, or nil."
   [frame-id flow-id]
   (when-let [a (get @frame-last-inputs frame-id)]
     (get @a flow-id)))
 
 (defn ^:no-doc set-frame-flow-last-inputs!
-  "Advance the dirty-check row for `[frame-id flow-id]` to `inputs` after a
-  successful recompute. Mutates only the frame's own inner atom (creating it
-  on first touch)."
+  "Store a flow's current inputs in its frame-local cache."
   [frame-id flow-id inputs]
   (swap! (ensure-frame-last-inputs-atom! frame-id) assoc flow-id inputs))
 
 (defn ^:no-doc reset-frame-last-inputs-to!
-  "Restore the draining frame's `last-inputs` container to `prior` (its
-  drain-start snapshot, a plain `{flow-id inputs}` map). Called by
-  `re-frame.flows/run-flows-on-db`'s catch arm to roll back the draining
-  frame's — and ONLY the draining frame's — dirty-check bookkeeping when a
-  flow throws mid-cascade. A concurrently-draining sibling's container is a
-  different atom and is untouched."
+  "Restore one frame's dirty-check cache from a prior snapshot."
   [frame-id prior]
   (reset! (ensure-frame-last-inputs-atom! frame-id) prior))
 
 ;; ---- pending abandoned output paths --------------------------------------
 ;;
-;; A same-frame `reg-flow` REPLACEMENT that MOVES the output to a new
-;; `:output-path` must vacate the OLD path from the frame's app-db (Spec 013
-;; §Re-registration — otherwise the previous definition's last write lingers
-;; at the abandoned slot as stale derived state). `vacate-output-path!`
-;; (below) does that with a DIRECT app-db write, which is correct for an
-;; OUT-of-drain call.
-;;
-;; When `reg-flow` runs IN-drain — reentrantly from inside an event handler or
-;; a `:rf.fx/reg-flow` effect — a direct write would be CLOBBERED: the drain
-;; runs flows over the PENDING `:db` (the handler's returned value, which still
-;; carries the old path) and the router's single deferred commit PUBLISHES that
-;; pending value AFTER the reentrant `reg-flow` returns, overwriting the direct
-;; vacate and RESURRECTING the old output. So in-drain, record the abandoned
-;; path here instead of writing app-db directly.
-;; `re-frame.flows/run-flows-on-db` drains this set at the START of the
-;; pending-`:db` transform (before the flow walk) and dissocs each path from
-;; the PENDING db — so the vacate participates in the SAME value the deferred
-;; commit publishes and the handler's returned `:db` cannot resurrect the old
-;; path. Per-frame: each frame owns its own inner atom; a sibling frame
-;; draining concurrently on another thread holds a different atom and is
-;; structurally untouched.
+;; Moving or clearing a flow must vacate its old app-db path. Outside a drain we
+;; can write app-db directly. Inside a drain that write would be overwritten by
+;; the pending commit, so lifecycle operations queue the path here and
+;; `run-flows-on-db` removes it from the pending db instead.
 
 (defonce
-  ^{:doc     "frame-id → (atom #{abandoned-output-path ...}). Per-frame set
-              of OLD output paths recorded by an IN-DRAIN same-frame
-              `reg-flow` `:output-path` move, pending vacate by the current
-              drain's `run-flows-on-db` pending-`:db` transform."
+  ^{:doc     "frame-id → (atom #{output-path ...}) pending in-drain vacation."
     :private true}
   frame-abandoned-output-paths
   (atom {}))
 
 (defn- ensure-frame-abandoned-paths-atom!
-  "Return `frame-id`'s inner abandoned-output-paths atom, creating (and
-  registering) it on first touch under a single `swap!` so concurrent
-  first-touches converge on ONE atom (mirrors
-  `ensure-frame-last-inputs-atom!`)."
+  "Return a frame's pending-path atom, creating it atomically."
   [frame-id]
   (or (get @frame-abandoned-output-paths frame-id)
       (get (swap! frame-abandoned-output-paths
@@ -316,17 +152,12 @@
            frame-id)))
 
 (defn ^:no-doc record-abandoned-output-path!
-  "Record `path` as a pending abandoned output path for `frame-id` — to be
-  vacated from the pending `:db` by the current drain's `run-flows-on-db`.
-  Called by `reg-flow`'s in-drain `:output-path`-move branch instead of the
-  direct app-db write the OUT-of-drain branch uses. Frame-local."
+  "Queue an output path for removal from this frame's pending db."
   [frame-id path]
   (swap! (ensure-frame-abandoned-paths-atom! frame-id) conj path))
 
 (defn ^:no-doc abandoned-output-paths-snapshot
-  "Return `frame-id`'s pending abandoned output paths as a plain set (the
-  drain-start snapshot for the failed-flow / post-commit rollback). Empty set
-  when the frame has no container yet. Frame-local."
+  "Return a frame's pending output-path vacations as a set."
   [frame-id]
   (if-let [a (get @frame-abandoned-output-paths frame-id)]
     @a
@@ -347,127 +178,41 @@
       @drained)))
 
 (defn ^:no-doc restore-abandoned-output-paths!
-  "Restore `frame-id`'s pending abandoned output paths to `prior` (its
-  drain-start snapshot). Called when a flow throws mid-cascade
-  (`run-flows-on-db`'s catch arm) or a POST-commit schema / machine-data
-  validation rolls the event back — the pending `:db` (carrying the vacated
-  state) was discarded, so the abandoned paths must re-attempt next drain.
-  Frame-local: a concurrently-draining sibling's container is a
-  different atom and is untouched."
+  "Restore one frame's pending output-path vacations from a prior snapshot."
   [frame-id prior]
   (reset! (ensure-frame-abandoned-paths-atom! frame-id) (set prior)))
 
 ;; ---- last-inputs row maintenance -----------------------------------------
 ;;
-;; With per-frame `last-inputs` containers, dropping one flow's dirty-check
-;; row for a frame is a plain `dissoc` on that frame's own inner atom — no
-;; two-level-map walk, and structurally incapable of touching a sibling
-;; frame's container. The clear-flow / frame-destroy / hot-reload-invalidate
-;; paths share this one helper so the "drop this flow's row for this frame"
-;; invariant lives in exactly one place. Per-frame storage makes the dissoc
-;; unconditional and frame-local.
-
 (defn- drop-frame-flow-row!
-  "Drop `flow-id`'s dirty-check row from `frame-id`'s `last-inputs`
-  container. No-op when the frame has no container. Frame-local by
-  construction."
+  "Drop a flow's frame-local dirty-check row, if present."
   [frame-id flow-id]
   (when-let [a (get @frame-last-inputs frame-id)]
     (swap! a dissoc flow-id)))
 
 ;; ---- validation ----------------------------------------------------------
 ;;
-;; Per Spec 013 §Flow shape: `:inputs` is a vector of app-db paths,
-;; `:output-path` is an app-db path. A path is a non-empty vector of scalar
-;; map keys. The validator enforces this fully up front rather than letting a
-;; malformed shape boom later in the topo / evaluator stack. Three
-;; representative malformations it catches:
-;;
-;;   - `:inputs [:foo :bar]` (vector of bare keywords) — topo's `prefix?`
-;;     would otherwise throw on `(count :foo)`.
-;;   - `:inputs [[:foo] :bar]` (mixed) — same problem one entry along.
-;;   - `:output-path []` — `(prefix? [] anything)` is true, so an empty-path
-;;     flow would silently become a depends-on prerequisite of EVERY other
-;;     flow in the frame (per Spec 013 §Dependency rule).
-;;
-;; Each malformation is rejected with a stable error id and ex-data that names
-;; the offending entries / elements so callers don't have to chase the failure
-;; into the topo / evaluator stack.
-;;
-;; The OPTIONAL output data-classification keys (`:sensitive` / `:large` /
-;; `:large?`, EP-0025) are validated in the same table. They are validated
-;; FAIL-CLOSED: a malformed declaration (`:sensitive [:token]`, `:large "blob"`)
-;; is rejected rather than silently installing no redaction — the worst failure
-;; for a safety feature. EP-0025 removed propagation: the boolean `:sensitive?`
-;; spelling and the `:rf.egress/output-sensitivity` enum are both REJECTED (a
-;; flow classifies its OWN output directly — no input inheritance).
+;; Validate paths before topology or evaluation sees them. Classification
+;; declarations fail closed so malformed safety metadata cannot silently
+;; install an unprotected output.
 
 (defn- valid-path-element?
-  "True iff `x` is admissible as a flow path segment — the SHARED
-  concrete-segment domain (`re-frame.path/segment?`, Conventions §Segment
-  domain). The shared domain is a keyword / string / symbol / boolean /
-  integer / UUID / instant / nil; composites (vectors / maps / sets / seqs)
-  and host handles are rejected. Collections are never the right value for a
-  `get-in` path step and almost always indicate a caller bug (e.g. passing a
-  bare keyword where a vector-of-paths was expected, then wrapping it one
-  level too many).
-
-  Flows DELEGATE the membership question to the shared `:rf/path` policy
-  rather than re-deriving it: a subsystem narrows from the shared upper bound
-  but never re-enumerates it. The shared domain admits UUID, instant, and nil
-  segments alongside keyword / string / integer / symbol / boolean — all valid
-  associative keys the algebra already focuses through. The flows-SPECIFIC
-  restriction (a `:output-path` / `:inputs` path must be NON-EMPTY — an empty
-  path is a root-output footgun that makes the flow a depends-on prerequisite
-  of every other flow, Spec 013 §Dependency rule) is layered ON TOP in
-  `valid-path?` below, NOT folded into the shared segment domain."
+  "True when `x` belongs to the shared concrete path-segment domain."
   [x]
   (path/segment? x))
 
 (defn- valid-path?
-  "A flow `:inputs` path or the flow `:output-path` is a NON-EMPTY vector of
-  valid path segments. The non-emptiness is the flows-specific root-output
-  policy (Spec 013 §Dependency rule — an empty path overlaps every path); the
-  per-element domain is the shared segment policy (`valid-path-element?`
-  → `re-frame.path/segment?`)."
+  "True for a non-empty vector of valid path segments."
   [x]
   (and (vector? x) (seq x) (every? valid-path-element? x)))
 
 (defn- valid-output-subpath?
-  "A flow output classification subpath (an entry of `:sensitive` / `:large`)
-  is a vector of valid path segments, AND — unlike a flow `:inputs` path or
-  the flow `:output-path` — the EMPTY vector `[]` is legal: it marks the whole
-  output value (the `[[]]` whole-value convention, Spec 015:81). So this is
-  `valid-path?` minus the non-empty requirement: a vector whose every element
-  (if any) is a shared-domain segment (`valid-path-element?`)."
+  "True for an output-relative path; `[]` denotes the whole output."
   [x]
   (and (vector? x) (every? valid-path-element? x)))
 
-;; Every validation throw shares the canonical thrown-error skeleton
-;; (per Spec 009 §The thrown-error shape):
-;;
-;;   {:rf.error/id <category-kw>    ;; CANONICAL DISCRIMINATOR — :rf.error/<category>
-;;    :where       'rf/reg-flow     ;; user-facing fn for greping the call site
-;;    :recovery    :fix-registration ;; "the caller fixes their flow map and retries"
-;;    :reason      "<diagnostic>"
-;;    :flow        <the supplied flow>}
-;;
-;; The `:rf.error/id` discriminator slot is read uniformly by every
-;; consumer (Xray's error widget, the pair-tool overlay, `:on-error`
-;; policies); the message string is the stringified kw so `.getMessage`
-;; pivots to the same category without ex-data. The `:where` / `:recovery`
-;; slots mirror the missing-artefact throw shape standardised by
-;; `re-frame.late-bind/require-fn!` and used by every
-;; `re-frame.core-<artefact>` wrapper. Per-clause extras (`:bad-entries`
-;; / `:bad-elements`) merge on top.
-
 (defn- flow-error
-  "Build the validate-flow ex-info via the central thrown-error builder
-  `re-frame.error/thrown-ex-info` (per Spec 009 §The thrown-error shape).
-  `error-kw` is the `:rf.error/id` discriminator slot; `reason` is the
-  human-readable diagnostic that LEADS the message (the message also
-  trails the `[:rf.error/<id>]` greppability token); `extras` merges
-  per-clause slots (e.g. `:bad-entries`)."
+  "Build a flow registration error with optional diagnostic data."
   ([error-kw reason flow] (flow-error error-kw reason flow nil))
   ([error-kw reason flow extras]
    (error/thrown-ex-info
@@ -475,40 +220,16 @@
      {:recovery :fix-registration
       :extra    (merge {:flow flow} extras)})))
 
-;; Forward reference: `runtime-partition-key` (the reserved `:rf.db/runtime`
-;; partition const) is defined below with the input-side partition primitives
-;; it co-documents. `validation-rules` only READS it at call time (when
-;; `validate-flow` runs a pred), by which point the ns is fully loaded; the
-;; `declare` also suppresses the CLJS undeclared-var warning. Same forward-ref
-;; idiom this ns already uses for `vacate-output-path!`.
+;; Defined with the other input partition primitives below.
 (declare runtime-partition-key)
 
-;; The validation rules, in evaluation order. Each rule has a predicate
-;; over the flow map (returns truthy to accept), a stable `:error-kw`
-;; discriminator, a `:reason` diagnostic, and optional `:extras` that
-;; build per-clause ex-data slots (`:bad-entries` / `:bad-elements`).
-;; `validate-flow` walks this vector and throws on the first failing
-;; predicate, so the rules are ordered most-fundamental-first (a flow with a
-;; broken required shape reports that before any classification-key clause).
-;;
-;; Data-driven so the rules are introspectable (a test or the spec can
-;; read the table) and adding a clause is a single conj.
+;; Ordered so callers receive the most fundamental shape error first.
 (def ^:private validation-rules
   [{:pred     (fn [flow] (some? (:id flow)))
     :error-kw :rf.error/flow-missing-id
     :reason   ":id is required (flow registration must name an id)"}
 
-   ;; A PRESENT `:id` must be a keyword. Spec-Schemas §FlowMeta requires
-   ;; `[:id :keyword]` and Spec 013 §The registration shape describes flow ids
-   ;; as namespaced feature identifiers; the public examples are all keywords,
-   ;; and the `:flow-id` slot is emitted unchanged into `:rf.flow/*` trace +
-   ;; error payloads, so a string / number / map id violates the public schema
-   ;; contract and would leak an arbitrary id shape downstream. Rejecting at
-   ;; the API boundary — resolving here, not by normalising in every consumer —
-   ;; is the masterpiece choice. Distinct from the absent-id case above
-   ;; (`flow-missing-id` fires first on nil); this rule fires only when an id
-   ;; is present but the wrong type — a member of the `:rf.error/flow-bad-*`
-   ;; family alongside bad-inputs / bad-output / bad-path.
+   ;; Trace and tooling schemas carry flow ids as keywords unchanged.
    {:pred     (fn [flow] (keyword? (:id flow)))
     :error-kw :rf.error/flow-bad-id
     :reason   ":id must be a keyword (flow ids are namespaced feature identifiers; the public FlowMeta schema requires :keyword and the :flow-id trace/error slot carries it unchanged)"}
@@ -517,11 +238,6 @@
     :error-kw :rf.error/flow-bad-inputs
     :reason   ":inputs must be a vector of paths"}
 
-   ;; One clause for both "entry isn't a vector" and "entry isn't a valid
-   ;; path" — `valid-path?` already requires `vector?`, so this single check
-   ;; subsumes both. The rejection message names what the entry must be; the
-   ;; `:bad-entries` slot points at the offending values so callers can fix
-   ;; them without a stack-trace dig.
    {:pred     (fn [flow] (every? valid-path? (:inputs flow)))
     :error-kw :rf.error/flow-bad-inputs
     :reason   ":inputs entries must each be a non-empty vector of path segments (the shared EP-0012 segment domain: keyword / string / symbol / boolean / integer / UUID / instant / nil)"
@@ -544,20 +260,7 @@
     :reason   ":output-path elements must each be a path segment (the shared EP-0012 segment domain: keyword / string / symbol / boolean / integer / UUID / instant / nil)"
     :extras   (fn [flow] {:bad-elements (vec (remove valid-path-element? (:output-path flow)))})}
 
-   ;; A well-formed `:output-path` may NOT be rooted at the reserved runtime-db
-   ;; partition key (`:rf.db/runtime`). That leading key is reserved for the
-   ;; INPUT side — `runtime-input?` opts a flow input into the runtime-db
-   ;; partition — whereas a flow OUTPUT is always an app-db write:
-   ;; `evaluate-flow!` (flows.cljc) `assoc-in`s the derived value into the
-   ;; app-db partition, so a `[:rf.db/runtime …]` output would write the
-   ;; reserved partition key INSIDE app-db. This enforces at the registration
-   ;; boundary the invariant asserted in prose at flows.cljc §output-path (an
-   ;; app-db output can never prefix-collide with a runtime-db input), closing
-   ;; the namespace-squat / spurious-topo-edge / false-cycle footguns. Distinct
-   ;; from the `:rf.error/flow-bad-path` shape family — the path is well-formed,
-   ;; it just names a reserved partition — so it carries its own discriminator.
-   ;; Fires AFTER the shape rules above confirm a non-empty vector of valid
-   ;; segments, so `(first (:output-path flow))` is a real leading segment.
+   ;; The runtime qualifier is input syntax. Outputs always write app-db.
    {:pred     (fn [flow] (not= runtime-partition-key (first (:output-path flow))))
     :error-kw :rf.error/flow-reserved-output-path
     :reason   (str ":output-path may not be rooted at the reserved runtime-db partition key "
@@ -566,27 +269,7 @@
                    "would write the reserved partition key inside app-db")
     :extras   (fn [flow] {:bad-elements [(first (:output-path flow))]})}
 
-   ;; The OPTIONAL output data-classification keys (`:sensitive` / `:large`
-   ;; per-path vectors; `:large?` whole-output boolean) are validated FAIL-FAST.
-   ;; A typo (`:sensitive [:token]`, `:large "blob"`, `:large? 1`) is rejected
-   ;; at the API boundary rather than silently installing no redaction /
-   ;; large-elision — the worst failure mode for a SAFETY feature is the author
-   ;; believing a slot is protected when it is not. Same fail-FAST posture as
-   ;; the core flow-path validation, and the same `:rf.error/flow-bad-*`
-   ;; family. These rules fire AFTER the core `:id` / `:inputs` / `:derive` /
-   ;; `:output-path` rules (a flow with a broken required shape reports that
-   ;; first), but BEFORE any registry / app-db / elision-declaration state
-   ;; mutates (validate-flow is the first call in `reg-flow`, before `frame-id`
-   ;; / the `swap!`), so a rejected registration installs NO flow row and NO
-   ;; elision declaration.
-   ;;
-   ;; Vector-of-subpaths rules: `:sensitive` / `:large`, when PRESENT, must be
-   ;; a vector whose every entry is a valid output subpath — a vector of
-   ;; scalar keys, with `[]` legal (the `[[]]` whole-output convention,
-   ;; Spec 015:81). `valid-output-subpath?` is `valid-path?` minus the
-   ;; non-empty requirement. The `vector?`-of-the-whole and
-   ;; every-entry-well-formed checks are split so the diagnostic distinguishes
-   ;; "you passed a non-vector" from "one of your entries is malformed".
+   ;; Split collection-shape and entry-shape checks for precise diagnostics.
    {:pred     (fn [flow] (or (not (contains? flow :sensitive))
                              (vector? (:sensitive flow))))
     :error-kw :rf.error/flow-bad-marks
@@ -613,13 +296,7 @@
     :extras   (fn [flow] {:bad-key     :large
                           :bad-entries (vec (remove valid-output-subpath? (:large flow)))})}
 
-   ;; EP-0025 — flow output sensitivity PROPAGATION is removed: a flow no
-   ;; longer inherits its inputs' classification, and there is no
-   ;; `:rf.egress/output-sensitivity` enum (`:inherit` / `:sensitive` /
-   ;; `:public`). A flow classifies its OWN output directly with per-path
-   ;; `:sensitive` / `:large` (`[[]]` = whole output) or the `:large?`
-   ;; whole-output size override. The boolean `:sensitive?` spelling stays
-   ;; rejected (use `:sensitive [[]]` for a whole-output mark).
+   ;; Reject legacy spellings rather than silently ignoring a safety mark.
    {:pred     (fn [flow] (not (contains? flow :sensitive?)))
     :error-kw :rf.error/flow-bad-marks
     :reason   (str "the boolean :sensitive? spelling is rejected on a flow output "
@@ -649,73 +326,22 @@
             (throw (flow-error error-kw reason flow (when extras (extras flow))))))
         validation-rules))
 
-;; ---- flow-output data classification (EP-0025) --------------------------
+;; ---- flow-output data classification ------------------------------------
 ;;
-;; A `reg-flow` registration may carry data-classification keys describing the
-;; SENSITIVITY / SIZE of the flow's OWN OUTPUT value:
+;; A flow classifies its own output; classifications do not propagate from its
+;; inputs. Paths below are relative to `:output-path`:
 ;;
 ;;   :large?     true   — the whole output is large
 ;;   :sensitive  [paths]— per-output-path sensitive sub-slots ([[]] = whole)
 ;;   :large      [paths]— per-output-path large sub-slots ([[]] = whole)
 ;;
-;; EP-0025 — there is NO flow input->output PROPAGATION. A flow does NOT inherit
-;; the data-classification of its input paths; the `:rf.egress/output-sensitivity`
-;; enum (`:inherit` / `:sensitive` / `:public`) is REMOVED. If you derive a
-;; secret into a flow's output, classify that output path EXPLICITLY (the same
-;; rule as subs: classify exactly what you mark, nothing is inherited). This
-;; keeps the helper lightweight (EP-0025 §"What is removed").
-;;
-;; The flow's output lands in app-db at `(:output-path flow)`, so a sensitive /
-;; large output value egresses through TWO observation channels:
-;;   1. the `:rf.flow/computed` `:result` / `:before` trace slots (and the
-;;      `:rf.flow/failed` failure path), and
-;;   2. the app-db destination slot itself — visible to App-DB-Diff style
-;;      observation, the `:rf.event/db` pending-db trace (the t2
-;;      `:rf.event/db-pending-post-flow` stamp), view render-arg egress, and any
-;;      downstream sub reading the slot.
-;;
-;; Rather than projecting the registration declarations at each flow emit site (a
-;; flow-id->declarations table is wrong for flows — Spec 013 lets the SAME
-;; flow-id carry DIFFERENT definitions, hence different declarations, in
-;; different frames), we make the declarations FIRST-CLASS through the SAME
-;; per-frame elision registry the schema-first wire walker
-;; (`elision/elide-wire-value`) already reads. We translate the registration's
-;; output-rooted EXPLICIT declarations into ABSOLUTE app-db declarations rooted
-;; at `(:output-path flow)` and write them into the frame's
-;; `[:rf.runtime/elision :sensitive-declarations]` / `:declarations` slots,
-;; stamped `{:source :flow :flow-id <id>}`.
-;;
-;; ONE walker then covers BOTH channels: the flow trace `:result` / `:before`
-;; ride `elide-wire-value` rooted at `(:output-path flow)`; `project-db-tags` /
-;; `project-view-rendered-tags` (re-frame.classification) elide the app-db
-;; destination slot through the SAME registry.
-;;
-;; The EXPLICIT declarations are known at `reg-flow` time and do not change with
-;; app-db mutation (no propagation), so they are installed ONCE at registration
-;; (`write-flow-output-marks!`) and dropped on `clear-flow` — there is no
-;; drain-time mark-mutation refresh (that machinery existed only to recompute
-;; propagated marks, now removed).
-;;
-;; Frame-scoping is structural: the declarations live in the FRAME's own app-db
-;; elision registry, so the same flow-id registered against two frames writes
-;; into two different registries — no cross-frame bleed. Entries are stamped
-;; `{:source :flow :flow-id <id>}` so lifecycle cleanup (clear-flow / path-change
-;; re-register / frame destroy) drops exactly this flow's contributions while
-;; leaving frame-, effect-, and other-flow-sourced entries untouched.
+;; Registration translates them to absolute app-db paths in the frame's elision
+;; registry. That one registry governs flow traces and observation of the
+;; materialized app-db slot. Source stamps let re-registration and clear remove
+;; only this flow's declarations.
 
 (defn- explicit-flow-output-mark-paths
-  "Translate a flow's EXPLICIT output-rooted classification keys into ABSOLUTE
-  app-db declaration paths rooted at the flow's `:output-path`. Returns
-  `[sensitive-paths large-paths]` (each a vector of absolute path vectors).
-
-  - `:large? true` => the `:output-path` itself (force-mark the whole output
-    large);
-  - per-path `:sensitive` / `:large` entries => `(:output-path flow)` ++ sub-path
-    (`[[]]` whole-value mark => the `:output-path` itself).
-
-  EP-0025: there is no `:rf.egress/output-sensitivity` whole-output force-mark —
-  classify the whole output with `:sensitive [[]]` (which lands here as the
-  `:output-path` itself via the per-path arm)."
+  "Return `[sensitive-paths large-paths]` as absolute app-db paths."
   [flow]
   (let [base       (vec (:output-path flow))
         abs        (fn [sub] (into base sub))
@@ -725,58 +351,28 @@
     [(vec per-sens)
      (vec (concat whole-lg per-large))]))
 
-;; ---- partition-qualified input primitives (EP-0001 §535-551) -------------
+;; ---- partition-qualified input primitives -------------------------------
 ;;
-;; The ONE home for the binary `:inputs`-path partition syntax shared across
-;; the flows artefact: a bare leading path element resolves against app-db; a
-;; leading `:rf.db/runtime` opts the input into the runtime-db partition and is
-;; stripped before the path is used. Two consumers ride these primitives:
-;;   - `re-frame.flows/resolve-input` — reads the input VALUE against the
-;;     pending app-db / runtime-db partitions (strips for the runtime read);
-;;   - `re-frame.flows.tooling/declared-input` — lowers to the algebra
-;;     `[:db …]` / `[:runtime …rest]` declared-input form.
-;; `registry` is required by both `re-frame.flows` and `re-frame.flows.tooling`
-;; and requires neither back (no cycle), so it is the natural shared home.
+;; Runtime evaluation, trace elision, and tooling projection share this syntax.
 
 (def ^:no-doc runtime-partition-key
-  "The reserved partition key that, as a leading `:inputs`-path element, opts a
-  flow input into the runtime-db partition (`:rf.db/runtime`). Bare paths (any
-  other leading element) resolve against app-db. The single const all flow-
-  artefact consumers key on so the rule, the resolver, and the doc stay in
-  lockstep."
+  "The leading input-path key that selects runtime-db."
   :rf.db/runtime)
 
 (defn ^:no-doc runtime-input?
-  "True iff `path` is a partition-qualified runtime-db input — a vector whose
-  FIRST element is `runtime-partition-key` (`:rf.db/runtime`). Everything else
-  is a bare app-db path (binary syntax — there is no third `[:rf.db/app …]`
-  explicit-app form)."
+  "True when `path` is qualified to read runtime-db."
   [path]
   (= runtime-partition-key (first path)))
 
 (defn ^:no-doc input-resolve-path
-  "Resolve one flow `:inputs` path to the absolute declaration-coordinate path
-  the elision registry is keyed by (plain path vectors, partition-blind). A bare
-  input is an app-db path verbatim; a runtime-db-qualified input
-  `[:rf.db/runtime …rest]` drops the partition key so its `…rest` matches a
-  declaration on that runtime-db slot. Partition-aware by construction.
-
-  Public so `re-frame.flows/resolve-input` (the runtime-db value read) and
-  `re-frame.flows.tooling/declared-input` (the algebra `[:runtime …rest]` /
-  `[:db …]` lowering) and `re-frame.flows/elide-inputs` (seeding
-  `elision/elide-wire-value`'s `:path` opt for a flow's per-input trace value)
-  all route partition stripping through this one fn."
+  "Strip the runtime qualifier, leaving the path within its partition."
   [input-path]
   (if (runtime-input? input-path)
     (subvec (vec input-path) 1)
     (vec input-path)))
 
 (defn- flow-declares-marks?
-  "True when the flow registration carries any output data-classification key
-  (`:sensitive` / `:large` / `:large?`). Used to gate the elision-registry write
-  at `reg-flow` time — a flow that declares no classification installs nothing
-  (EP-0025: no propagation, so a no-classification flow can never acquire an
-  inherited mark either)."
+  "True when the flow declares output classification."
   [flow]
   (or (contains? flow :sensitive)
       (contains? flow :large)
@@ -805,11 +401,7 @@
           paths))
 
 (defn- fold-flow-declarations
-  "Fold ONE flow's `:source :flow` EXPLICIT output declarations into the registry
-  `reg` (pure). Drops THIS flow's prior `:source :flow` entries first (so a
-  re-registration replaces cleanly), then overlays the flow's explicit absolute
-  declarations. EP-0025: explicit-only — no input->output propagation, no
-  resolution against the carried registry."
+  "Replace one flow's declarations in an elision registry value."
   [reg flow]
   (let [flow-id            (:id flow)
         [explicit-s explicit-l] (explicit-flow-output-mark-paths flow)
@@ -824,32 +416,16 @@
       (empty? new-l) (dissoc :declarations))))
 
 (defn- write-flow-output-marks!
-  "Install (or refresh) a SINGLE `flow`'s EXPLICIT output declarations into
-  `frame-id`'s app-db elision registry (the `reg-flow`-time path). Delegates to
-  `fold-flow-declarations`; shares `swap-elision-slot!` so the runtime-prune
-  semantics stay uniform."
+  "Install or refresh one flow's output declarations in its frame."
   [frame-id flow]
   (elision/swap-elision-slot! frame-id
     (fn [reg] (fold-flow-declarations reg flow))))
 
 (defn- clear-flow-output-marks!
-  "Drop `flow-id`'s `:source :flow` declarations from `frame-id`'s elision
-  registry. Called on `clear-flow` so a *single* deregistered flow leaves no
-  orphaned redaction declaration behind while its frame and the frame's other
-  flows live on. Other-sourced entries survive.
+  "Remove one flow's declarations while preserving other declaration sources.
 
-  NOT called on frame-destroy teardown (`teardown-on-frame-destroy!`),
-  and deliberately so: the elision registry lives in the frame's runtime-db
-  partition at `[:rf.runtime/elision]` (re-frame.elision §registry-of),
-  INSIDE the one physical `:frame-state` container held under the frame
-  record. `destroy-frame!` step 6 (`frame.cljc` §dissoc-frame!) drops that
-  whole frame record — container, runtime-db partition, and every
-  `:source :flow` declaration with it — so a per-flow registry scrub at
-  teardown would be redundant work over state that is about to be GC'd.
-  A reused frame-id starts from a FRESH empty container
-  (`frame.cljc` §new-frame-record), so a destroyed/reused frame can never
-  observe a prior incarnation's stale flow-sourced declaration. See
-  `flows_destroy_frame_teardown_test` §destroy-frame-drops-flow-output-marks."
+  Frame teardown needs no per-flow scrub because the elision registry belongs
+  to the frame-state container that destruction removes."
   [frame-id flow-id]
   (elision/swap-elision-slot! frame-id
     (fn [reg]
@@ -863,36 +439,16 @@
 
 ;; ---- registration --------------------------------------------------------
 
-;; `reg-flow`'s same-frame `:output-path`-change branch vacates the
-;; OLD output path via `vacate-output-path!`, which is defined alongside
-;; `clear-flow` further down (both share the app-db dissoc semantics).
-;; Forward-declare it so the registration path can reference it without
-;; reordering the large clear/teardown block above the hot registration
-;; surface.
+;; Defined with the shared path-vacation helpers below.
 (declare vacate-output-path!)
 
 (defn- reconstruct-flow
-  "Reconstruct the internal flow-map from the 3-slot grammar `(reg-flow
-  flow-id metadata derive-fn)` (rf2-bqstzr): the id moves back onto the map
-  under `:id`, and the pure `:derive` value slot is placed under `:derive`.
-  The `:frame` mounting key (if present in metadata) is pulled OUT — it is the
-  frame-mounting concern, not a flow-map key (per Conventions §The `:frame`
-  registration-metadata key). Returns `[flow frame]` where `flow` is the
-  internal flow-map (id + `:inputs` / `:output-path` / `:doc` / `:schema` /
-  classification keys + `:derive`) and `frame` is the extracted `:frame`
-  override (nil when absent). Mirrors reg-resource / reg-mutation / reg-route's
-  `(assoc metadata <value-key> value)` reconstruction (rf2-wvh95f F1).
+  "Build the stored flow map from `(reg-flow id metadata derive-fn)`.
 
-  Guards the MIDDLE slot is a map BEFORE any `assoc` / `contains?` runs (a
-  non-map metadata would otherwise leak a raw host exception), and rejects a
-  `:derive` left INSIDE the metadata map as a mislocated key with the loud
-  `:rf.error/invalid-flow-metadata` — the third slot is `:derive`'s one home."
+  Return `[flow frame-target]`; `:frame` controls mounting and is not stored as
+  flow metadata. Reject a misplaced `:derive` key before reconstruction."
   [flow-id metadata derive-fn]
-  ;; rf2-bqstzr — the metadata MIDDLE slot must be a map BEFORE any `assoc` /
-  ;; `contains?` / `dissoc` runs against it. A non-map metadata would otherwise
-  ;; leak a raw host exception instead of the public
-  ;; `:rf.error/invalid-flow-metadata`. Mirrors reg-route's `route-bad-metadata`
-  ;; / reg-resource's `resource-bad-spec` non-map guard.
+  ;; Validate before using map operations so callers receive a typed error.
   (when-not (map? metadata)
     (throw (error/thrown-ex-info
              :rf.error/invalid-flow-metadata
@@ -904,10 +460,6 @@
                   "is the SECOND slot, the pure :derive fn is the THIRD.")
              {:recovery :fix-registration
               :extra    {:id flow-id :value metadata}})))
-  ;; rf2-bqstzr — `:derive` is the 3-slot VALUE (the pure derivation). A
-  ;; `:derive` left INSIDE the metadata map is a mislocated key; reject it
-  ;; loudly so the grammar change cannot be half-applied (a stray metadata
-  ;; `:derive` would otherwise silently win or lose against the value-slot one).
   (when (contains? metadata :derive)
     (throw (error/thrown-ex-info
              :rf.error/invalid-flow-metadata
@@ -922,8 +474,7 @@
    (:frame metadata)])
 
 (defn reg-flow
-  "Register a flow against a frame. Per the canonical Spec 001 3-slot grammar
-  (rf2-bqstzr, completing the rf2-wvh95f F1 alignment of the fused registrars):
+  "Register a flow against a frame:
 
       (rf/reg-flow :rectangle/area
         {:inputs      [[:width] [:height]]
@@ -931,83 +482,26 @@
          :doc         \"Rectangle area from :width × :height.\"}
         (fn [w h] (* w h)))
 
-  The pure `:derive` fn — the flow's HANDLER (the derivation the input change
-  runs) — is the THIRD slot; the middle slot is the reflection-config metadata
-  map (`:inputs`, `:output-path`, `:doc`, `:schema`, the EP-0025 output
-  classification keys `:sensitive` / `:large` / `:large?`, and the `:frame`
-  mounting key). Splitting the derivation out of the fused flow-map restores
-  clean doc-DCE (the middle slot is now a pure metadata map) and brings flows
-  into line with reg-resource / reg-mutation / reg-route. A `:derive` left
-  INSIDE the metadata map is rejected loudly as a mislocated key
-  (`:rf.error/invalid-flow-metadata`).
-
-  Per Spec 013 — flows are frame-scoped: their lifecycle, evaluation, undo /
-  time-travel semantics all belong to one frame.
-
-  EP-0002 — flows are CONTEXT-REQUIRED FRAME-LOCAL registration. The frame to
-  register against is the explicit `:frame` metadata key (the *override*), else
-  the carried-invariant scope chain via `frame/require-current-frame!` (a
-  `with-frame` / frame-provider scope, or a frame `:initial-events` step). A
-  `reg-flow` issued under no established scope and no explicit `:frame` raises
-  the always-on `:rf.error/no-frame-context` (per Spec 002 §Frame target
-  resolution) rather than silently registering against `:rf/default` —
-  namespace-load time is not a reason to synthesise a default frame.
-
-  Returns the flow's id per the `reg-*` return-value convention
-  ([Conventions §reg-* return-value convention]).
-
-  A single 3-slot arity only — like its required-metadata siblings
-  `reg-route` / `reg-resource`, there is no 2-arity: `:inputs` /
-  `:output-path` are mandatory, so a metadata slot is always required."
+  The derive function is the third slot. Metadata contains the required
+  `:inputs` and `:output-path`, optional documentation/classification, and an
+  optional `:frame` target. Without a target, registration requires an ambient
+  frame. Returns `flow-id`."
   ([flow-id metadata derive-fn]
    (let [[flow frame] (reconstruct-flow flow-id metadata derive-fn)]
    (validate-flow flow)
-   (let [;; rf2-8mxnnk: normalize an EXPLICIT `:frame` target — a frame VALUE
-         ;; (make-frame's return token) or a frame-id keyword — to its frame-id
-         ;; BEFORE the liveness check / registry keying, mirroring the READ path
-         ;; (`resolve-read-frame` / `flow-meta-at`). Without this a frame VALUE
-         ;; keys `@flows` (and the `frame/frame` liveness probe) by the raw map,
-         ;; so a LIVE frame reads as not-live (`:rf.error/flow-frame-not-live`)
-         ;; and a later `flow-meta-at` — which normalizes — misses the flow. The
-         ;; scope-derived id is already a keyword, so only the explicit override
-         ;; is normalized (idempotent on a keyword).
+   (let [;; Normalize frame values before liveness checks and registry access.
          frame-id (or (some-> frame frame/frame-target->id)
                       (frame/require-current-frame!
                         :reg-flow
                         {:where    'rf/reg-flow
                          :event-id (:id flow)}))
          flow-id  (:id flow)
-         ;; SINGLE-STORE (rf2-en00bk): stamp source-coords (`:ns` / `:line` /
-         ;; `:file`, slim in CLJS prod) into the flow-map STORED in the
-         ;; authoritative per-frame `flows` atom — so `flow-meta-at` (the
-         ;; `handler-meta :flow` replacement) surfaces them, exactly as the old
-         ;; double-store stamped them onto the now-removed registrar `:flow`
-         ;; slot. `merge-coords` is idempotent for a same-source re-eval and
-         ;; adds only documentation keys (validation already ran on the bare
-         ;; `flow`; downstream `:derive` / `:inputs` / `:output-path` reads are
-         ;; unaffected by the extra coord keys). Mirrors how
-         ;; `schemas.storage/reg-app-schema` stamps coords into
-         ;; `schemas-by-frame`.
+         ;; Store coordinates with the frame-scoped definition so tooling reads
+         ;; them from the same authoritative value.
          flow     (source-coords/merge-coords flow)]
-     ;; Reject registration against a NON-LIVE frame BEFORE any state mutates.
-     ;; `frame/frame` returns nil when the frame record is absent (never
-     ;; registered, or `destroy-frame!`'s step-6 dissoc ran) OR
-     ;; present-but-`:destroyed?` (post-step-3, pre-step-6). Either way the
-     ;; frame is non-live and must not acquire flow state.
-     ;;
-     ;; `call-serialized-with-drain!` runs its thunk DIRECTLY for an
-     ;; absent/destroyed frame (frame.cljc §call-serialized-with-drain!), so
-     ;; without this guard the registration below would install a
-     ;; `flows[frame-id flow-id]` row and an elision declaration stamped with
-     ;; the dead `frame-id` — and a later `reg-frame` reusing that id would
-     ;; inherit the resurrected flow, breaking the frame-destroy isolation
-     ;; contract (Spec 013 §destroy-frame! releases every per-frame flow slot /
-     ;; last-inputs row).
-     ;;
-     ;; So REJECT with a stable structured error category rather than create
-     ;; dormant state for a typo'd or destroyed frame id. `clear-flow` keeps
-     ;; its permissive absent-frame no-op (teardown must be idempotent); only
-     ;; this MUTATING path rejects.
+     ;; The serialization helper intentionally tolerates absent frames, so the
+     ;; mutating registration path must reject them before creating dormant
+     ;; state that a reused frame id could inherit.
      (when (nil? (frame/frame frame-id))
        (error/throw-error!
          :rf.error/flow-frame-not-live
@@ -1021,61 +515,13 @@
          {:recovery :fix-registration
           :extra    {:frame frame-id
                      :flow  flow}}))
-     ;; ATOMIC check-and-insert. The cycle check and the commit are ONE
-     ;; `swap!` update fn over `@flows`: it reads the frame's
-     ;; CURRENTLY-COMMITTED flow-map, runs topo-sort on the prospective map,
-     ;; and — only if that passes — returns the map with the new flow assoc'd
-     ;; in. `swap!` re-invokes the update fn (re-reading committed state,
-     ;; re-running the cycle check) whenever a concurrent writer wins the
-     ;; compare-and-set, so a cycle can NEVER be admitted by interleaving:
-     ;; two threads reg-flow'ing on the same frame two flows that together
-     ;; form a cycle (T1: A reads B's path; T2: B reads A's path) cannot each
-     ;; pass against the OTHER's not-yet-committed flow and then both commit.
-     ;; The validation lives inside the update fn, so it re-runs against the
-     ;; winning CAS's view.
-     ;;
-     ;; The single-threaded path runs exactly one topo-sort: `swap!` invokes
-     ;; the update fn once with no contention. Only contended same-frame
-     ;; registration pays the retry (re-running the cheap Kahn sort over a
-     ;; handful of nodes), and only then to preserve correctness.
-     ;;
-     ;; The cycle-check throw propagates OUT of `swap!`, so on rejection the
-     ;; atom is left untouched and the prior registration survives — a
-     ;; rejected REPLACEMENT does not vacate the slot the prior entry shares.
-     ;;
-     ;; `prior-on-frame` captures THIS frame's currently-committed flow
-     ;; entry for `flow-id`, recorded from inside the update fn so it
-     ;; reflects the state the WINNING CAS observed (a contended retry
-     ;; re-records against the re-read map; the last invocation — the one
-     ;; whose return value commits — leaves the authoritative value). It
-     ;; drives two decisions below: per-frame first-vs-replacement for the
-     ;; `:rf.flow/registered` trace, the same-frame `:output-path`-change
-     ;; vacate, and the same-frame stale-`last-inputs` drop. `nil` ⇒ first-time
-     ;; registration of `flow-id` on THIS frame — an INDEPENDENT first-time
-     ;; registration per frame (Spec 013 §Frame-scoping), even if a SIBLING
-     ;; frame already registers the same id in the per-frame `flows` atom.
+     ;; Capture the prior value inside the retrying swap so lifecycle decisions
+     ;; use the state observed by the winning CAS.
      (let [prior-on-frame (volatile! nil)]
-       ;; A same-frame `reg-flow` REPLACEMENT publishes the new flow into
-       ;; `flows` (visible to a drain) in the `swap!` below, then drops the
-       ;; stale-`last-inputs` row DIRECTLY (the `drop-frame-flow-row!` call at
-       ;; the foot of the thunk) on a real same-frame replacement. Serializing
-       ;; publish → path-vacate → invalidation against the frame drain
-       ;; (`:drain-lock`) makes them one indivisible step: no drain can observe
-       ;; the new flow before its stale dirty-check row is dropped, so the new
-       ;; flow re-evaluates on the next event regardless of input equality
-       ;; (Spec 013's re-registration contract). The atomic check-and-insert
-       ;; `swap!` runs INSIDE the serialized region — its TOCTOU cycle guarantee
-       ;; composes with the outer drain-exclusion. Reentrant: a mid-drain
-       ;; `:rf.fx/reg-flow` runs directly inside the single-drainer window (see
-       ;; `frame/call-serialized-with-drain!`).
-       ;;
-       ;; SINGLE-STORE (rf2-en00bk): the invalidation is a DIRECT,
-       ;; FRAME-SCOPED `drop-frame-flow-row!` keyed on THIS `frame-id` —
-       ;; not the frame-blind registrar replacement-hook the old double-store
-       ;; relied on. The hook read `:frame` back off the registrar metadata to
-       ;; recover the frame; with the per-frame `flows` atom as the sole store
-       ;; the frame is already in hand (`frame-id`), so the drop is more direct
-       ;; and structurally sibling-safe (per-frame container).
+       ;; Publish, path vacation, mark replacement, and cache invalidation are
+       ;; serialized with the frame drain. The registry swap keeps topology
+       ;; validation inside the CAS retry, preventing concurrent registrations
+       ;; from jointly admitting a cycle or output overlap.
        (frame/call-serialized-with-drain!
          frame-id
          (fn []
@@ -1084,116 +530,33 @@
                     (let [prior-frame (get m frame-id)]
                       (vreset! prior-on-frame (get prior-frame flow-id))
                       (let [prospective (assoc prior-frame flow-id flow)]
-                        ;; Two registration-time rejections, both run on the
-                        ;; PROSPECTIVE map inside this update fn so they share
-                        ;; the cycle check's atomicity: a throw propagates out
-                        ;; of `swap!`, the CAS never fires, and the prior
-                        ;; registration survives untouched.
-                        ;;
-                        ;; 1. Throws :rf.error/flow-path-overlap if
-                        ;;    the new flow's output :path overlaps an already-
-                        ;;    registered sibling's :path (one a prefix of the
-                        ;;    other). The topo dependency rule compares :path vs
-                        ;;    :inputs only, so overlapping outputs get no edge
-                        ;;    and their eval order is undefined — reject before
-                        ;;    any state mutates (Spec 013 §Disjoint output
-                        ;;    paths). Checked BEFORE the cycle sort so a frame
-                        ;;    with overlapping outputs reports the more specific
-                        ;;    footgun rather than whatever (or no) cycle the topo
-                        ;;    walk happens to surface.
-                        ;; 2. Throws :rf.error/flow-cycle if the prospective map
-                        ;;    is cyclic; the update fn never returns and the CAS
-                        ;;    never fires, so the atom is unchanged.
+                        ;; Prefer the specific output-overlap diagnostic before
+                        ;; the dependency-cycle check.
                         (topo/detect-output-path-overlap! prospective)
                         (topo/topo-sort prospective)
                         (assoc m frame-id prospective)))))
-           ;; A same-frame re-registration that MOVES the output to a new
-           ;; `:output-path` must vacate the OLD path from this frame's app-db —
-           ;; otherwise the previous definition's last write lingers and
-           ;; downstream reads see stale derived state at the abandoned slot.
-           ;; Only fires on a real same-frame replacement (`prior-on-frame`
-           ;; non-nil) whose `:output-path` actually changed; the commit above
-           ;; already installed the new definition, so the new path recomputes
-           ;; on the next drain. First-time registration and same-path
-           ;; hot-reload leave app-db untouched.
-           ;;
-           ;; The vacate is routed by call shape:
-           ;;  - OUT of a drain (a top-level / `:rf.fx`-post-commit lifecycle
-           ;;    call): write app-db DIRECTLY — there is no pending commit to
-           ;;    clobber it and the change is durable immediately.
-           ;;  - IN a drain (reentrant from an event handler / `:rf.fx/reg-flow`
-           ;;    mid-cascade): a direct write would be OVERWRITTEN by the single
-           ;;    deferred commit that later publishes the handler's returned
-           ;;    `:db` (which still carries the old path) — resurrecting the old
-           ;;    output. So RECORD the abandoned path instead; the current
-           ;;    drain's `run-flows-on-db` dissocs it from the PENDING `:db`
-           ;;    before the flow walk, so the vacate rides the SAME value the
-           ;;    deferred commit publishes and the handler's `:db` cannot
-           ;;    resurrect it. (`call-serialized-with-drain!` already ran this
-           ;;    thunk reentrantly when in-drain, so `frame/in-drain?` here is
-           ;;    the matching discriminator.)
+           ;; A moved output must vacate the old path. Queue the vacation during
+           ;; a drain so it is applied to the pending db; otherwise write now.
            (when-let [prior @prior-on-frame]
              (let [old-path (:output-path prior)]
                (when (not= old-path (:output-path flow))
                  (if (frame/in-drain? frame-id)
                    (record-abandoned-output-path! frame-id old-path)
                    (vacate-output-path! frame-id old-path)))))
-           ;; EP-0025: install this flow's EXPLICIT output data-classification
-           ;; declarations into the frame's app-db elision registry, rooted at
-           ;; `(:output-path flow)`. `write-flow-output-marks!` drops THIS flow's
-           ;; prior `:source :flow` entries first, so a re-registration that
-           ;; changed `:output-path` or the declaration set replaces cleanly
-           ;; (covering the old-path declarations the value-vacate above does not
-           ;; touch). Inside the serialized region so a concurrent drain's
-           ;; `elide-wire-value` read cannot observe a half-updated registry.
-           ;;
-           ;; Gate: skip the registry write only for a FIRST registration that
-           ;; declares no classification key. Such a flow has nothing to install
-           ;; or clear (EP-0025: no propagation, so it can never acquire an
-           ;; inherited mark either). A re-registration (`prior-on-frame`
-           ;; non-nil) ALWAYS writes (even a now-unmarked replacement must CLEAR
-           ;; the prior definition's declarations).
+           ;; Replacements always refresh marks so removing a declaration also
+           ;; clears the previous one.
            (when (or (flow-declares-marks? flow)
                      (some? @prior-on-frame))
              (write-flow-output-marks! frame-id flow))
-           ;; Per Spec 001 §Hot-reload semantics + Spec 013 §Re-registration:
-           ;; a same-frame REPLACEMENT must (1) drop THIS frame's stale
-           ;; dirty-check row so the new flow re-evaluates on the next drain
-           ;; regardless of input equality (a hot-reloaded `:derive` with
-           ;; identical recent inputs would otherwise keep serving the previous
-           ;; result), and (2) emit the `:rf.registry/handler-replaced`
-           ;; hot-reload trace (Spec 001 §Hot-reload trace surface) the flow
-           ;; panel / 10x consume, carrying `:different-fn?` so tools can branch
-           ;; a real `:derive` body swap from an idempotent reload.
-           ;;
-           ;; SINGLE-STORE (rf2-en00bk): with the per-frame `flows` atom the
-           ;; SOLE store there is no registrar `:flow` write and no
-           ;; replacement-hook indirection — both effects run DIRECTLY here on a
-           ;; real same-frame replacement (`prior-on-frame` non-nil; a first-time
-           ;; registration has no stale row and emits `:rf.flow/registered`
-           ;; instead). The drop is frame-scoped (`drop-frame-flow-row!` keyed on
-           ;; `frame-id`) so a re-registration on frame `:left` never touches
-           ;; `:right`'s row for the same id (frame isolation; per-frame
-           ;; container makes this structural). The trace emit reuses the SAME
-           ;; B4 hot-reload dedup-by-shape seam the registrar consults
-           ;; (`:trace.tooling/dedup-allow?`, Spec 009 §Hot-reload dedup) so an
-           ;; idempotent reload (identical `:derive` identity) emits ZERO events
-           ;; and a real body swap emits exactly one — the contract the
-           ;; registrar slot used to drive now driven directly by the flows
-           ;; artefact. Kept INSIDE the serialized region so the publish above
-           ;; and these effects are indivisible to a concurrent drain.
+           ;; A replacement invalidates the cache even when inputs are equal.
+           ;; Hot-reload trace dedup uses the derive function as handler identity.
            (when (some? @prior-on-frame)
              (drop-frame-flow-row! frame-id flow-id)
              (when interop/debug-enabled?
                (let [prior      @prior-on-frame
                      different? (not= (:derive prior) (:derive flow))
-                     ;; The dedup shape keys on `:handler-fn` identity (Spec 009
-                     ;; B4 / `trace.tooling/handler-shape`). Stamp it = `:derive`
-                     ;; so the shape discriminates a real body swap from an
-                     ;; idempotent reload exactly as the registrar metadata used
-                     ;; to (the now-removed `:handler-fn` stamp on the registrar
-                     ;; `:flow` slot). Source-coords are stripped by the shape
-                     ;; computation, so the coords-stamped `flow` is fine here.
+                     ;; The shared dedup projector expects handler identity under
+                     ;; `:handler-fn`.
                      shape-meta (assoc flow :handler-fn (:derive flow))
                      dedup-ok?  (if-let [f (late-bind/get-fn-cached
                                              :trace.tooling/dedup-allow?)]
@@ -1204,264 +567,81 @@
                                 {:kind          :flow
                                  :id            flow-id
                                  :different-fn? different?})))))))
-       ;; Per Spec 009 §:op-type vocabulary: :rf.flow/registered fires on
-       ;; FIRST-TIME registration AGAINST THIS FRAME. The gate keys on the
-       ;; PER-FRAME prior slot (`prior-on-frame`), so registering the same
-       ;; flow-id against a SECOND frame — an INDEPENDENT first-time
-       ;; registration per Spec 013 §Frame-scoping line 102 — emits
-       ;; `:rf.flow/registered` with the correct `:frame` tag. A genuine
-       ;; same-frame re-registration (`prior-on-frame` non-nil) suppresses the
-       ;; `:rf.flow/registered` emit — its hot-reload signal rides the
-       ;; `:rf.registry/handler-replaced` trace the same-frame replacement
-       ;; branch above emits DIRECTLY (rf2-en00bk single-store; per Spec 001
-       ;; §Hot-reload trace surface) instead.
-       ;;
-       ;; The outer `debug-enabled?` gate matches the hot-path emits in
-       ;; flows.cljc (per Spec 009 §Production builds, "keep the gate
-       ;; OUTERMOST"); reg-flow is a cold path so the cost is negligible,
-       ;; but the gate keeps the tag-map literal out of CLJS prod and the
-       ;; convention uniform across every flow emit site.
+       ;; Registration is first-time per frame; replacements use the hot-reload
+       ;; trace above.
        (when (and interop/debug-enabled? (nil? @prior-on-frame))
          (trace/emit! :flow :rf.flow/registered
                       {:flow-id flow-id
                        :inputs  (:inputs flow)
                        :path    (:output-path flow)
                        :frame   frame-id})))
-     ;; Spec 015 §7. Flows — the output data-classification marks are
-     ;; installed FRAME-AWARE into the app-db elision registry via
-     ;; `write-flow-output-marks!` inside the serialized region above. They
-     ;; are deliberately NOT also stashed in a global side-table
-     ;; per-(kind, id) table: that table is keyed by
-     ;; flow-id ALONE, but Spec 013 lets the SAME flow-id carry DIFFERENT
-     ;; definitions (hence different marks) per frame, so a frame-blind
-     ;; `{flow-id marks}` entry is the wrong shape for flows. The
-     ;; frame-scoped elision-registry write is the single source of truth
-     ;; the wire walker, the db-diff projection, and the view-render-arg
-     ;; projection all read.
      flow-id))))
 
 (defn- dissoc-in-safe
-  "Like `dissoc-in` over `(butlast path) → (last path)` but robust against
-  the two unmaterialised-output failure modes:
-
-  - **Unmaterialised parent.** When a flow with `:path [:step-2 :result]`
-    is cleared BEFORE its first drain, the parent slot `:step-2` may not
-    exist. The naïve `(update-in db [:step-2] dissoc :result)` returns
-    `(dissoc nil :result)` ⇒ `nil`, producing `{:step-2 nil}` — a
-    spurious nil parent. Detect this case and leave `db` unchanged.
-  - **Non-map intermediate.** When an intermediate path step holds a
-    non-map value (a scalar already wrote past the flow's planned path),
-    the naïve `update-in` calls `(dissoc 1 :result)` and throws
-    `ClassCastException`. Treat this as a no-op — the flow's `:output-path`
-    never materialised, so there's nothing to clear.
-
-  Single-element paths and non-vector paths are handled by the caller's
-  earlier branches; this helper is only called for `(>= (count path) 2)`."
+  "Remove a nested leaf without creating nil parents or descending into a
+  non-map intermediate. Returns `db` unchanged when the path is absent."
   [db path]
   (let [parent-path (vec (butlast path))
         leaf        (last path)
         parent      (get-in db parent-path ::missing)]
     (cond
-      ;; Parent was never materialised — leave db as-is. Registering a
-      ;; nested-path flow then clearing before any drain would write
-      ;; `{<parent> nil}` otherwise.
       (or (= ::missing parent) (nil? parent)) db
-      ;; Parent is non-map (scalar / vector / set) — there's no
-      ;; meaningful "dissoc this leaf" on a non-map intermediate. Throwing
-      ;; ClassCastException for a cleanup operation is poor manners; leave
-      ;; the value untouched (it's not OUR flow's output anyway).
       (not (map? parent)) db
       :else (update-in db parent-path dissoc leaf))))
 
 (defn ^:no-doc vacate-path-in-db
-  "Pure `db → db` removal of a flow output `:output-path`'s LEAF — the value
-  transform shared by `vacate-output-path!` (which writes the result to the
-  live app-db) and `run-flows-on-db`'s in-drain pending-`:db` vacate
-  (which dissocs abandoned paths from the PENDING value the deferred commit
-  publishes). Returns `db` unchanged (often `identical?`) when the dissoc is a
-  no-op (missing key, unmaterialised parent, non-map intermediate).
+  "Pure leaf removal shared by immediate and in-drain path vacation.
 
-  `validate-flow` guarantees `:output-path` is a non-empty vector at
-  registration, so a `:output-path` read back out of the registry always
-  carries one. A single-element vector `[:k]` is dissoc'd directly
-  (`(update-in db [] dissoc :k)` would write `{... nil nil}`); a `(>= 2)` path
-  routes through `dissoc-in-safe` (unmaterialised-parent / non-map-intermediate
-  safe)."
+  Single-element paths require direct `dissoc`; `update-in` at `[]` does not
+  mean removal from the root."
   [db path]
   (if (= 1 (count path))
     (dissoc db (first path))
     (dissoc-in-safe db path)))
 
 (defn- vacate-output-path!
-  "Dissoc a flow's output `:output-path` from `frame-id`'s app-db (only that
-  frame's container). Shared by `clear-flow` (full deregistration) and the
-  same-frame `:output-path`-change branch of `reg-flow` (moving a flow's
-  output to a new path must vacate the OLD path so downstream reads don't see
-  stale derived state at the abandoned slot).
-
-  `validate-flow` guarantees `:output-path` is a non-empty vector at
-  registration (rejects non-vector and empty via :rf.error/flow-bad-path),
-  so a `:output-path` read back out of the registry always carries one — no
-  non-vector / empty-path arms are reachable here.
-
-  When :path is a single-element vector [:k], (butlast [:k]) is () and
-  (update-in db [] dissoc :k) does NOT dissoc — Clojure's update-in on the
-  empty path falls into (assoc {} nil (apply f val args)), producing
-  {... nil nil}. So length 1 is special-cased to dissoc the leaf directly. The
-  (>= 2) branch routes through `dissoc-in-safe`, which handles the
-  unmaterialised-parent / non-map-intermediate cases without writing nil
-  parents or throwing.
-
-  Skips the write when the dissoc branch was a no-op (missing key, or
-  `dissoc-in-safe` returning `db` literally on unmaterialised-parent /
-  non-map-intermediate) — otherwise a no-op write triggers reactive sub-cache
-  invalidation, a cheap-but-needless walk of the sub graph (`identical?` is
-  O(1)). No-op when the frame has no app-db container.
-
-  Writes the app-db PARTITION of the one physical frame-state container via
-  `frame/swap-frame-db!` (`app-db-container` is a READ-ONLY projection). Flow
-  OUTPUTS are app-db values, so vacating one is an app-db write. The
-  `identical?` no-op skip is preserved by computing `new-db` first and only
-  swapping when it changed."
+  "Remove an output path from a frame's app-db, skipping no-op writes."
   [frame-id path]
   (when-let [db (frame/frame-app-db-value frame-id)]
     (let [new-db (vacate-path-in-db db path)]
       (when-not (identical? new-db db)
         (frame/swap-frame-db! frame-id (constantly new-db))))))
 
-;; ---- registrar-slot owner maintenance: REMOVED (rf2-en00bk) ---------------
-;;
-;; The double-store's `realign-registrar-owner!` workaround is GONE. It kept a
-;; frame-BLIND registrar `:flow` slot (keyed by flow-id alone) pointing at a
-;; live owner whenever the slot's current writer was cleared / destroyed —
-;; necessary ONLY because flows are FRAME-DIVERGENT-PER-ID and the single-slot
-;; shape could not hold the authoritative per-frame state. With the per-frame
-;; `flows` atom as the SOLE store (applying the rf2-0frdi schemas precedent)
-;; there is no slot to realign: `clear-flow` / `teardown-on-frame-destroy!`
-;; simply drop the cleared frame's entry from the per-frame map, and any
-;; surviving frame's entry is already authoritative in place. The `:flow`
-;; registrar kind stays RESERVED-but-empty (Spec 001 §Registry model); tools
-;; introspect via `flow-meta-at` / `flows-snapshot`.
-
 (defn clear-flow
-  "Deregister a flow from a frame; dissoc its output path from that
-  frame's app-db (only that frame). EP-0002 — context-required
-  frame-local: the explicit `:frame` opt (the *override*) wins, else the
-  carried-invariant scope chain via `frame/require-current-frame!`. A
-  `clear-flow` issued under no established scope and no explicit `:frame`
-  raises `:rf.error/no-frame-context` rather than clearing against
-  `:rf/default`.
+  "Deregister a flow and remove its output leaf from the selected frame.
 
-  The nested-path dissoc is robust against the output path never having
-  been materialised (no spurious nil parent created) and against a non-map
-  intermediate (no ClassCastException thrown) — see `dissoc-in-safe` /
-  `vacate-output-path!` above.
-
-  Vacation contract: clearing a flow with `:path [:wizard :result]` removes
-  the LEAF (`:result`) only. If `:result`
-  was the sole key under `:wizard`, an empty parent map `{:wizard {}}`
-  remains — this is deliberate, not a leak. The flow's *value* is
-  fully gone (the spec's \"vacate the slot\" requirement); pruning empty
-  ancestor maps would risk deleting unrelated sibling slots that happen
-  to be empty and own ancestors this flow never created, so leaf-only
-  vacation is the correct contract. Downstream consumers read the leaf,
-  not the parent's emptiness. When the output path never materialised
-  (parent absent / nil / non-map), `dissoc-in-safe` returns `db`
-  unchanged and `vacate-output-path!` skips the swap entirely — a
-  deliberate no-op with no app-db write and no sub-cache invalidation
-  (cross-ref `dissoc-in-safe`)."
+  Without an explicit `:frame`, the ambient frame is required. Vacation is
+  leaf-only: empty ancestors remain because the flow does not own them."
   ([id] (clear-flow id {}))
   ([id {:keys [frame] :as _opts}]
-   (let [;; rf2-8mxnnk: normalize an EXPLICIT `:frame` target (frame VALUE or
-         ;; frame-id keyword) to its frame-id BEFORE the registry lookup /
-         ;; vacate — mirroring the READ path. Without this a frame VALUE keys
-         ;; the `@flows` lookup by the raw map, so the clear silently MISSES the
-         ;; flow (registered / read under the frame-id) and leaves it live. The
-         ;; scope-derived id is already a keyword; only the explicit override is
-         ;; normalized.
+   (let [;; Normalize frame values before registry access.
          frame-id (or (some-> frame frame/frame-target->id)
                       (frame/require-current-frame!
                         :clear-flow
                         {:where    'rf/clear-flow
                          :event-id id}))
-         ;; The flow lookup + `:output-path` capture happen INSIDE the
-         ;; drain-lock, not before it. On the JVM a competing same-frame
-         ;; same-id `reg-flow` replacement could otherwise win the lock after
-         ;; a stale read, install a NEW `:output-path`, a drain could
-         ;; materialise the replacement's new output, and this clear-flow
-         ;; would run under the lock using the OLD path — vacating a now-empty
-         ;; old path (a no-op) while removing the live registry row and
-         ;; leaving the replacement's new output stale in app-db (violating
-         ;; Spec 013's clear-flow cleanup contract), and emitting a misleading
-         ;; `:rf.flow/cleared` for the old path.
-         ;;
-         ;; So the lookup, path capture, app-db vacate, registry removal, and
-         ;; dirty-row drop fold into ONE serialized operation over the SAME live
-         ;; flow definition. The thunk returns the path it actually cleared (or
-         ;; nil when no flow was registered under the lock) so the
-         ;; `:rf.flow/cleared` emit below fires only on a real clear, with the
-         ;; path captured under the lock.
-         ;; Reentrant: a mid-drain `:rf.fx/clear-flow` runs directly inside
-         ;; the single-drainer window (see `frame/call-serialized-with-drain!`).
+         ;; Read the path inside the drain lock so a concurrent replacement
+         ;; cannot make us vacate stale metadata while clearing the new row.
          cleared-path
          (frame/call-serialized-with-drain!
            frame-id
            (fn []
              (when-let [flow (get-in @flows [frame-id id])]
                (let [path (:output-path flow)]
-                 ;; Same in-drain hazard `reg-flow`'s `:output-path`-move
-                 ;; branch guards against (see the comment above its
-                 ;; `record-abandoned-output-path!` call): a `clear-flow`
-                 ;; issued OUT of a drain can vacate `path` directly — there
-                 ;; is no pending commit to clobber it. But a `clear-flow`
-                 ;; issued IN a drain (reentrant from an event handler body /
-                 ;; `:rf.fx/clear-flow`) races the SAME deferred `:db`
-                 ;; commit: a direct write here would be overwritten by the
-                 ;; handler's returned `:db` (which still carries the
-                 ;; cleared flow's last value at `path`), resurrecting it.
-                 ;; So RECORD the abandoned path instead; the current
-                 ;; drain's `run-flows-on-db` dissocs it from the PENDING
-                 ;; `:db` before the flow walk, riding the same value the
-                 ;; deferred commit publishes.
+                 ;; In-drain vacation must modify the pending db, not the live
+                 ;; app-db that the deferred commit will replace.
                  (if (frame/in-drain? frame-id)
                    (record-abandoned-output-path! frame-id path)
                    (vacate-output-path! frame-id path))
-                 ;; Spec 015 §7: drop this flow's output data-classification
-                 ;; declarations from the frame's app-db elision registry so a
-                 ;; deregistered flow leaves no orphaned redaction behind.
-                 ;; Frame- / effect- / flow-sourced entries survive.
                  (clear-flow-output-marks! frame-id id)
-                 ;; Drop the flow from `frame-id`'s per-frame slot; when that was
-                 ;; the LAST flow on the frame, prune the now-empty `frame-id` key
-                 ;; entirely rather than leave a `{frame-id {}}` husk a naive
-                 ;; `flows-snapshot` consumer would iterate. Pruning keeps the
-                 ;; registry exactly symmetric with `teardown-on-frame-destroy!`'s
-                 ;; `(swap! flows dissoc frame-id)`.
+                 ;; Prune an empty frame row rather than expose `{frame-id {}}`.
                  (swap! flows (fn [m]
                                 (let [m' (update m frame-id dissoc id)]
                                   (cond-> m'
                                     (empty? (get m' frame-id)) (dissoc frame-id)))))
-                 ;; Drop the cleared flow's dirty-check row from THIS frame's own
-                 ;; `last-inputs` container. Frame-local — a sibling frame
-                 ;; registering the same id keeps its own row untouched.
                  (drop-frame-flow-row! frame-id id)
-                 ;; SINGLE-STORE (rf2-en00bk): no registrar-slot realignment.
-                 ;; The per-frame `flows` atom is the sole store — dropping this
-                 ;; frame's entry above is the whole job. Any SURVIVING frame
-                 ;; that registers the same id keeps its own authoritative entry
-                 ;; in place; there is no frame-blind slot to re-point.
                  path))))]
-     ;; Per Spec 009 §:op-type vocabulary: :rf.flow/cleared fires after
-     ;; clear-flow has removed the flow from the per-frame registry
-     ;; and dissoc-in'd its output path. Tools observe this to drop
-     ;; their per-flow display state. Only emit when a flow was ACTUALLY
-     ;; cleared (a no-op clear-flow for an unregistered id, or one that lost
-     ;; the race to a competing lifecycle op, emits nothing), carrying the
-     ;; path captured under the lock. The outer `debug-enabled?` gate matches
-     ;; the hot-path emits in flows.cljc (per Spec 009 §Production builds,
-     ;; "keep the gate OUTERMOST"); clear-flow is a cold path so the cost is
-     ;; negligible, but the gate keeps the tag-map literal out of CLJS prod and
-     ;; the convention uniform across every flow emit site.
+     ;; A no-op clear emits nothing.
      (when (and cleared-path interop/debug-enabled?)
        (trace/emit! :flow :rf.flow/cleared
                     {:flow-id id
@@ -1470,128 +650,29 @@
      nil)))
 
 ;; ---- frame-destroy teardown ---------------------------------------------
-;;
-;; Symmetric with the machines `:teardown-on-frame-destroy!` hook. On
-;; `destroy-frame!`, the flows registered against the destroyed frame and the
-;; per-frame `last-inputs` rows MUST clear — otherwise SSR-style per-request
-;; frame churn / pair-tool time-travel / `make-frame` ephemeral usage would
-;; leak flow definitions and cached input vectors indefinitely. SINGLE-STORE
-;; (rf2-en00bk): with the per-frame `flows` atom the sole store, this is
-;; PURELY dropping the destroyed frame's per-frame entries — there is no
-;; frame-blind registrar `:flow` slot to realign to a surviving owner.
 
 (defn teardown-on-frame-destroy!
-  "Drop every per-frame entry the flows artefact holds against `frame-id`:
+  "Release registry, dirty-check, and pending-vacation state for a frame.
 
-   1. Dissoc `frame-id` from the per-frame flow registry (`flows`) — the
-      SOLE authoritative store, so this is the whole job for the flow
-      definitions.
-   2. Dissoc the destroyed frame's `last-inputs` container from the
-      per-frame `frame-last-inputs` registry — one step, since per-frame
-      storage holds the destroyed frame's rows in its own inner atom and
-      removing the frame-keyed slot drops them all.
-   3. Dissoc the destroyed frame's pending abandoned-output-paths container
-      (same per-frame storage idiom).
-
-   SINGLE-STORE (rf2-en00bk): NO registrar-slot prune. The old double-store
-   kept a frame-blind registrar `:flow` slot that had to be unregistered (last
-   owner) or re-pointed to a surviving owner (the `realign-registrar-owner!`
-   workaround) on frame-destroy; that slot and workaround are GONE. A surviving
-   frame registering the same id keeps its own authoritative entry in the
-   per-frame `flows` atom in place — nothing to realign.
-
-   NO explicit flow-output elision-mark scrub. Unlike `clear-flow` — which
-   removes ONE flow's `:source :flow` declarations while its frame lives on
-   (hence its `clear-flow-output-marks!` call) — frame-destroy drops the
-   WHOLE frame. The elision registry lives in the frame's runtime-db
-   partition at `[:rf.runtime/elision]` (`re-frame.elision` §registry-of),
-   INSIDE the one physical `:frame-state` container held under the frame
-   record; `destroy-frame!` step 6 (`frame.cljc` §dissoc-frame!)
-   `(swap! frames dissoc id)` drops that whole record — container,
-   runtime-db, and every `:source :flow` declaration — so the marks are gone
-   with the frame and a per-flow scrub here would be redundant work over
-   about-to-be-GC'd state. The teardown hook runs BEFORE step 6, but that
-   ordering is moot: nothing observes the (still-live) elision slot between
-   the hook and the dissoc, and a reused frame-id gets a FRESH empty
-   container (`frame.cljc` §new-frame-record), so a destroyed/reused frame
-   can never observe a prior incarnation's stale flow-sourced declaration.
-   Pinned by
-   `flows_destroy_frame_teardown_test` §destroy-frame-drops-flow-output-marks.
-
-   Idempotent against a frame the registry never recorded (a frame
-   destroy before any `reg-flow`). Published via the
-   `:flows/teardown-on-frame-destroy!` late-bind hook so
-   `frame/destroy-frame!` reaches it without statically requiring the
-   flows artefact."
+  The frame owns its elision registry, so destroying the frame-state container
+  also removes flow declarations without a separate scrub. Idempotent."
   [frame-id]
   (when frame-id
     (swap! flows dissoc frame-id)
-    ;; Drop the destroyed frame's entire `last-inputs` container in one
-    ;; step — per-frame storage means the destroyed frame's rows ARE its
-    ;; inner atom, so removing the frame-keyed slot drops every row at once
-    ;; and cannot touch any sibling frame's container.
     (swap! frame-last-inputs dissoc frame-id)
-    ;; Drop the destroyed frame's pending abandoned-output-paths container
-    ;; too (same per-frame storage idiom). The frame is gone, so any
-    ;; recorded-but-undrained path move is moot.
     (swap! frame-abandoned-output-paths dissoc frame-id))
   nil)
-
-;; ---- hot-reload invalidation --------------------------------------------
-;;
-;; Per Spec 001 §Hot-reload semantics + Spec 013 §Re-registration: when a flow
-;; re-registers against a frame, that frame's `:last-inputs` row MUST clear so
-;; the new flow re-evaluates on the next drain regardless of whether inputs
-;; changed (a hot-reloaded `:derive` with identical recent inputs would
-;; otherwise keep serving the previous result), and the
-;; `:rf.registry/handler-replaced` hot-reload trace MUST fire (dedup-by-shape).
-;;
-;; SINGLE-STORE (rf2-en00bk): both effects are now driven DIRECTLY by `reg-flow`
-;; on a same-frame replacement (`prior-on-frame` non-nil), keyed on the frame
-;; already in hand — see the `drop-frame-flow-row!` + `:rf.registry/handler-
-;; replaced` emit in `reg-flow`. The former registrar replacement-hook
-;; (`invalidate-flow-on-replace!`, which recovered the frame from the registrar
-;; metadata's `:frame` slot) is GONE along with the registrar `:flow` write that
-;; fired it.
 
 ;; ---- test-only resets ----------------------------------------------------
 
 (defn reset-last-inputs!
-  "Test-only: clear ALL per-frame dirty-check `last-inputs` containers
-  (drops the whole `frame-last-inputs` registry, discarding every frame's
-  inner atom) WITHOUT touching the flow registrations or the pending
-  abandoned-output-paths. A TARGETED helper for a test that wants to force
-  the next drain to recompute every flow (so re-registration does not
-  silently no-op when new-inputs =-equal a stale entry) while keeping the
-  flows registered. Re-exported on the `re-frame.flows` facade for
-  direct in-artefact / cross-artefact test use.
-
-  This is NOT part of the standard reset-runtime fixture: that fixture
-  clears the SAME containers (and more) via `reset-flows!` through the
-  `:flows/reset-flows!` late-bind hook, which drops the registry,
-  last-inputs, AND abandoned-output-paths in lockstep. `reset-last-inputs!`
-  is the narrower, registrations-preserving cousin for targeted tests."
+  "Test-only: clear all dirty-check caches without clearing registrations."
   []
   (reset! frame-last-inputs {})
   nil)
 
 (defn reset-flows!
-  "Test-only: clear the per-frame flow registry AND the paired
-  dirty-check `last-inputs` map. Exposed via the late-bind hook table so
-  `re-frame.test-support` can reset state without a static require on this
-  namespace.
-
-  Resets BOTH atoms in lockstep: a test fixture / re-frame2-pair / Xray
-  harness calling `reset-flows!` standalone wants ALL flow state cleared, and
-  `last-inputs` is downstream cache for the same registry — leaving it
-  standing would silently no-op the first evaluation after a re-registration
-  when new-inputs `=`-equal a leftover entry. The dirty-check reset drops
-  every per-frame `last-inputs` container (the `frame-last-inputs` registry).
-
-  ALSO drops every per-frame pending abandoned-output-paths container — a
-  `reset-flows!` caller wants ALL flow-derived per-frame state cleared, and a
-  leftover undrained path move from a sibling test must not leak into the
-  next."
+  "Test-only: clear registrations, dirty-check caches, and pending vacations."
   []
   (reset! flows {})
   (reset! frame-last-inputs {})

--- a/implementation/flows/src/re_frame/flows/tooling.cljc
+++ b/implementation/flows/src/re_frame/flows/tooling.cljc
@@ -1,31 +1,9 @@
 (ns re-frame.flows.tooling
-  "Flows tooling sibling of `re-frame.flows` — carries the
-  derivation/process algebra view of registered flows (`flow-algebra-view`)
-  that pair tools (Xray, re-frame2-pair-mcp) and the conformance fixtures
-  query, but no production application code reads.
+  "Read-only tooling projections over the flow registry.
 
-  Mirrors the `re-frame.subs.tooling` / `re-frame.trace.tooling` split:
-    - CLJS consumers needing the surface call
-      `re-frame.flows.tooling/<name>` directly. Apps that load the flows
-      artefact but never attach a tool DCE the body wholesale (the sibling
-      ns is loaded only when a test fixture, tool, or dev preload requires
-      it; the `re-frame.flows` facade never `:require`s it).
-    - JVM consumers keep an ergonomic `re-frame.flows/<name>` alias (gated
-      under `#?(:clj ...)`). The JVM has no bundle to protect; the alias
-      costs nothing. The whole flows artefact is already bundle-isolated
-      from production builds (counter never `:require`s `re-frame.flows`),
-      so this sibling can never reach a no-flows app's bundle; the
-      explicit sentinel at the foot of this ns additionally proves no
-      stray `:require` ever pulled the body in.
-
-  READ-ONLY over the registry: this ns touches NEITHER the core registrar
-  write-path NOR the flow registration signatures, reading the per-frame flow
-  registry through the public accessor
-  `re-frame.flows.registry/flows-snapshot`.
-
-  Per [Derivations.md](../../../../../../spec/Derivations.md) and the
-  projected Malli shapes in [Spec-Schemas
-  §`:rf/derivation-node`](../../../../../../spec/Spec-Schemas.md)."
+  Kept separate from `re-frame.flows` so CLJS applications that attach no tool
+  can eliminate this namespace. JVM consumers receive a facade alias; CLJS
+  tools require this sibling directly."
   (:require [re-frame.derivation.node :as node]
             [re-frame.flows.registry :as registry]))
 
@@ -33,86 +11,33 @@
 
 ;; ---- algebra views -------------------------------------------------------
 ;;
-;; Per [Derivations.md] §Worked equivalence — the flow is the canonical
-;; `:app-db` / `:after-event` / `:frame` MATERIALIZED member of the
-;; derivation/process algebra (the subscription's policy twin: same
-;; whole-value function, different output / storage / evaluation /
-;; lifecycle). Every `reg-flow` registration is an instance of the algebra:
-;; a `:derivation` (subscriptions AND flows are derivations, never processes
-;; — Derivations §Derivation), whose output is MATERIALIZED into app-db,
-;; evaluated `:after-event` (inside the event drain, per Spec 013 §Drain
-;; integration), owned by the `:frame` it registered against.
-;;
-;; This is the *registrar-derived* slice (Derivations §The EP-0013
-;; relocation seam): the algebra view is assembled from the flow-map
-;; metadata at the surface that registered it. These functions live in the
-;; bundle-isolated tooling sibling, consumed by Xray + the conformance
-;; fixtures; there is no `re-frame.core` facade export.
-;;
-;; The five fixed classifications for EVERY flow node (Derivations §Worked
-;; equivalence — the flow column):
+;; Every flow has the same derivation policy:
 ;;   :kind          :derivation
-;;   :storage       :app-db               (materialized into the app-db partition)
-;;   :evaluation    :after-event          (evaluated inside the event drain)
-;;   :lifecycle     :frame                (the frame owns it; destroy-frame! releases it)
-;;   :materialized? true                  (the output has a durable app-db address)
-;; The per-flow axes that vary are the declared INPUTS and the OUTPUT path.
-;;
-;; A flow consumes the slice-1 vocabulary verbatim — it does NOT redefine
-;; the `:rf/storage-class` / `:rf/evaluation-policy` / `:rf/lifecycle` enums
-;; or the `:rf/derivation-node` shape (those are owned by Spec-Schemas /
-;; Derivations).
+;;   :storage       :app-db
+;;   :evaluation    :after-event
+;;   :lifecycle     :frame
+;;   :materialized? true
 
 (defn- declared-input
-  "Lower ONE flow `:inputs` path to its algebra declared-input form
-  (Derivations §Declared input). A bare path is an app-db read `[:db path]`;
-  a partition-qualified `[:rf.db/runtime …rest]` path is a runtime-db read
-  `[:runtime …rest]` (the partition key stripped). Flow inputs are always
-  concrete app-db / runtime-db paths — never `:sub` edges or the
-  `:parametric` marker — because a flow declares its dependency graph
-  statically as paths (Spec 013 §Flow shape).
-
-  Routes the partition test and the key strip through the SHARED
-  `registry/runtime-input?` / `registry/input-resolve-path` primitives
-  so the projection, the value resolver, and the elision declaration-path
-  resolver all key on the one home for the rule."
+  "Lower a flow input to `[:db path]` or `[:runtime path]`."
   [path]
   (if (registry/runtime-input? path)
     [:runtime (registry/input-resolve-path path)]
     [:db (registry/input-resolve-path path)]))
 
 (defn- declared-inputs
-  "Project a flow's `:inputs` vector into the algebra view's declared
-  inputs — each path lowered per `declared-input`, in declaration order
-  (so a downstream tool can reconstruct the dependency graph the `:derive`
-  fn's positional args expect)."
+  "Project inputs in the positional order expected by `:derive`."
   [flow]
   (mapv declared-input (:inputs flow)))
 
 (defn- flow-source-coords
-  "Return the `:ns` / `:line` / `:file` source-coordinate map for a flow-map,
-  or `nil` when none apply.
-
-  SINGLE-STORE (rf2-en00bk): `reg-flow` stamps `source-coords/merge-coords`
-  into the value stored in the per-frame `flows` registry — the SOLE store —
-  so coords are read straight off the frame-scoped flow-map. This is
-  frame-SAFE by construction: each `(frame-id, flow-id)` entry carries its OWN
-  registration's coords, so a different frame's same-id flow never inherits the
-  wrong source location. The previous frame-blind registrar `:flow` slot — and
-  the frame-matching dance it forced — are gone."
+  "Return a flow's source-coordinate map, or nil when absent."
   [flow]
   (let [source (node/source-coords flow)]
     (when (seq source) source)))
 
 (defn- with-metadata
-  "Attach source coordinates, the `:schema` fact, the `:doc`, and the opaque
-  `:derive` body token to a node when present. `:schema` / `:doc` / the
-  `:source` coords are ALL read straight off the frame-scoped flow-map
-  (frame-safe) — the per-frame `flows` store is the single source of truth
-  (rf2-en00bk), and `reg-flow` stamps the coords into it. The `:derive` fn
-  is the flow's whole-value derivation — surfaced under `:derive` as an
-  opaque token so a tool can show the function identity / source without it
-  being serialized."
+  "Attach optional registration metadata and the opaque derive token."
   [node _frame-id flow]
   (let [source (flow-source-coords flow)]
     (cond-> node
@@ -122,17 +47,7 @@
       (contains? flow :derive) (assoc :derive (:derive flow)))))
 
 (defn- node-for
-  "Build the derivation/process algebra view of one flow-map (Derivations
-  §The node shape; Spec-Schemas §`:rf/derivation-node`). `frame-id` is the
-  frame the flow registered against — flows are frame-scoped (Spec 013
-  §Frame-scoping), so the owning frame is part of the node's lifecycle
-  contract and is surfaced under `:owner`.
-
-  The fixed-classification spine — a `:derivation` whose materialized output
-  lands in app-db, evaluated `:after-event`, owned by its `:frame` — plus
-  the per-flow `:inputs` (lowered app-db / runtime-db paths), `:output`
-  (`[:db <:output-path>]`), `:source-form`, opaque `:derive` token, and source
-  coords / schema / doc."
+  "Build one frame-owned, app-db-materialized derivation node."
   [frame-id flow]
   (let [flow-id (:id flow)]
     (-> (node/node-base flow-id [:db (vec (:output-path flow))]
@@ -147,57 +62,12 @@
         (with-metadata frame-id flow))))
 
 (defn flow-algebra-view
-  "Return the STATIC derivation/process algebra view of every registered
-  flow ([Derivations.md], [Spec-Schemas §`:rf/derivation-node`]).
+  "Return normalized derivation nodes for registered flows.
 
-  Pure data over the per-frame flow registry — read through the public
-  `re-frame.flows.registry/flows-snapshot` seam, never touching the registrar
-  write-path or the flow registration signatures. The algebra
-  view companion to `flows-snapshot`: where `flows-snapshot` returns the raw
-  `{frame-id {flow-id flow-map}}` registry, this lowers every flow into the
-  normalized `:rf/derivation-node` shape the derivation/process algebra
-  names, so a tool can show subscriptions, flows, resources, route facts,
-  and machine selectors as ONE family.
-
-  Flows are FRAME-SCOPED (Spec 013 §Frame-scoping): the same flow-id can
-  register against two frames with different `:inputs` / `:derive` / `:output-path`,
-  so the view preserves the frame dimension — keyed the same way as
-  `flows-snapshot`.
-
-  Each node carries:
-
-  - `:id`          — the flow id (its canonical fact identity).
-  - `:kind`        — `:derivation` (flows are derivations, never processes —
-                     Derivations §Derivation).
-  - `:source-form` — `{:kind :reg-flow :id <flow-id>}`.
-  - `:inputs`      — the declared inputs (Derivations §Declared input): each
-                     `:inputs` path lowered to `[:db path]` (a bare app-db
-                     read) or `[:runtime …rest]` (a `[:rf.db/runtime …]`
-                     partition-qualified runtime-db read — EP-0001 §535-551),
-                     in declaration order.
-  - `:output`      — `[:db <:output-path>]` — the flow MATERIALIZES its whole value
-                     into the app-db partition at its `:output-path` (flow writes
-                     are app-db only — Spec 013 §Input partition).
-  - `:storage`     — `:app-db`.
-  - `:evaluation`  — `:after-event` (evaluated inside the event drain — Spec
-                     013 §Drain integration).
-  - `:lifecycle`   — `:frame`.
-  - `:owner`       — `[:frame <frame-id>]` (the frame the flow registered
-                     against; `destroy-frame!` releases it).
-  - `:materialized?` — `true`.
-  - `:derive`      — the opaque `:derive` body-fn token (never serialized).
-  - `:source` / `:schema` / `:doc` — present when the registration carried
-                     them (source coords auto-captured by `reg-flow` via
-                     `source-coords/merge-coords`).
-
-  Zero-arity returns `{frame-id {flow-id <node>}}` for every registered flow
-  (`{}` when none). The one-arity form returns `{flow-id <node>}` for a
-  single frame (`{}` when the frame has no flows). JVM-runnable — the flow
-  registry is partition-agnostic registration metadata.
-
-  Lives in the bundle-isolated tooling sibling and is consumed by Xray + the
-  conformance fixtures. There is no `re-frame.core/flow-algebra-view` facade
-  export."
+  Zero-arity preserves the registry shape
+  `{frame-id {flow-id derivation-node}}`; one-arity returns the selected
+  frame's `{flow-id derivation-node}` map. The projection is read-only and
+  preserves frame ownership for ids registered in more than one frame."
   ([]
    (let [snapshot (registry/flows-snapshot)]
      (reduce-kv
@@ -220,18 +90,9 @@
 
 ;; ---- bundle-isolation sentinel ------------------------------------------
 ;;
-;; Per the subs.tooling + trace.tooling split pattern:
-;; `implementation/scripts/check-bundle-isolation.cjs` greps the counter
-;; bundle for this exact string. The string lives ONLY in this
-;; file's source body — no other namespace, no docstring, no test fixture
-;; references it — so its presence in the production counter bundle proves
-;; the tooling sibling's body got pulled in (most likely via a stray
-;; `:require` from a production-reachable ns). The whole flows artefact is
-;; already bundle-isolated from counter (counter never `:require`s
-;; `re-frame.flows`), so this sentinel is the belt-and-braces guard the
-;; sibling pattern standardises. The string survives `:advanced` because
-;; string literals are not renamed; it sits outside any gate so DCE cannot
-;; drop the literal independently of the surrounding ns body.
+;; The bundle-isolation gate searches production output for this unique literal.
+;; Keep it in the namespace body and out of all other sources so its presence
+;; proves that the tooling sibling became reachable.
 
 (defonce ^:private bundle-isolation-sentinel
   "rf.flows.tooling/sentinel:rf2-s8w3nw-2026-06-12:do-not-rename")

--- a/implementation/flows/src/re_frame/flows/topo.cljc
+++ b/implementation/flows/src/re_frame/flows/topo.cljc
@@ -1,48 +1,16 @@
 (ns re-frame.flows.topo
-  "Topological sort over a per-frame flow map (Spec 013).
+  "Pure topology checks over one frame's flow map.
 
-  Pure-data input, pure-data output. No atoms, no side effects, no
-  trace emission — every call decides the evaluation order of one
-  frame's flows from the static `:inputs` / `:output-path` declarations alone.
-
-  The algorithm lives here in isolation so it is unit-testable on its
-  own. The registry calls `topo-sort` up-front on a prospective flow map
-  to spot cycles before mutating state; the outermost-`:after` walker
-  (`re-frame.flows/run-flows-on-db`) calls it on every drain to fix
-  evaluation order.
-
-  Per Spec 013 §Topological sort the rule is: flow B depends on flow
-  A iff A's `:output-path` and any of B's `:inputs` share a path prefix in
-  either direction. Kahn's algorithm produces the order; on cycle we
-  reconstruct a DFS path through the stuck nodes and throw
-  `:rf.error/flow-cycle` with a closing-repeat cycle vector
-  (e.g. `[:a :b :a]`) — tools like Xray render this directly.
-
-  This module also owns `detect-output-path-overlap!` — the symmetric
-  check the registry runs alongside the cycle check at `reg-flow` time
-  (Spec 013 §Disjoint output paths): two flows in one frame whose OUTPUT
-  `:output-path`s overlap (one a prefix of the other, identical included) have
-  no dependency edge between them (the edge rule compares `:output-path` vs
-  `:inputs`, never `:output-path` vs `:output-path`), so their relative evaluation
-  order is undefined and they would race for the shared slot under
-  last-write-wins. That is an authoring footgun, not a valid topology,
-  so it is rejected at registration with `:rf.error/flow-path-overlap`."
-  ;; The prefix / overlap relations are the SHARED `:rf/path` algebra
-  ;; (`re-frame.path`, Conventions §The :rf/path algebra), not a flows-private
-  ;; dialect: subsystems MUST NOT keep private ad hoc overlap / prefix logic —
-  ;; there is no tool-only path semantics. Flows is exactly such a consumer
-  ;; (the algebra's ns-doc names "flows" as a use site), so topo depends on
-  ;; `re-frame.path` rather than re-deriving `prefix?` / a bespoke overlap
-  ;; test. `re-frame.path` lives in core, which this artefact already depends
-  ;; on, so this drags no new dependency onto the classpath and the module
-  ;; stays .cljc-portable for the JVM test sweep.
+  Flow B depends on A when A's output path and one of B's input paths overlap
+  by prefix. Kahn's algorithm produces evaluation order; cycle errors include a
+  closing-repeat path for tools. Registration separately rejects overlapping
+  output paths because output/output overlap creates no dependency edge and
+  would otherwise leave write order undefined."
   (:require [re-frame.error :as error]
             [re-frame.path :as path]))
 
 (defn depends-on?
-  "Per Spec 013 §Topological sort: B depends on A iff A's :output-path and any
-  of B's :inputs share a path prefix in either direction. The prefix
-  relation is the shared `re-frame.path/prefix?`."
+  "True when B reads a path overlapping A's output path."
   [b-flow a-flow]
   (let [a-path (:output-path a-flow)]
     (boolean
@@ -52,39 +20,15 @@
             (:inputs b-flow)))))
 
 (defn output-paths-overlap?
-  "True iff two flows' OUTPUT `:output-path`s collide on the same app-db slot —
-  i.e. one path is a prefix of the other (identical paths included, since
-  every vector is a prefix of itself). Per Spec 013 §Disjoint output
-  paths: `[:x]` overlaps `[:x]` (identical), `[:x]` overlaps `[:x :y]`
-  (parent/child — writing `[:x]` clobbers everything under it, and writing
-  `[:x :y]` lands inside `[:x]`'s value), but `[:x :y]` and `[:x :z]` are
-  disjoint (siblings — neither is a prefix of the other).
-
-  This is the shared `re-frame.path/overlap?` relation — the SAME
-  prefix-in-either-direction test every path-shaped subsystem inherits.
-  `re-frame.path/overlap?` normalizes its inputs; flow paths are already
-  validated vectors, so the behaviour is identical."
+  "True when two output paths are equal or one is a prefix of the other."
   [a-path b-path]
   (path/overlap? a-path b-path))
 
 (defn- first-overlapping-pair
-  "Scan the prospective per-frame `flow-map` (`{flow-id flow-map}`) for the
-  first pair of DISTINCT flows whose output `:output-path`s overlap (one a prefix
-  of the other). Return `{:flow-ids [lo hi] :paths [lo-path hi-path]}` for
-  the offending pair, or `nil` if every pair is disjoint.
+  "Return a stable description of the first overlapping output pair, or nil.
 
-  Terminates by construction: a single `for` over the `(< i j)` upper
-  triangle of the entry vector (O(F²) prefix comparisons, F = the frame's
-  flow count — a handful of nodes at v1, same order as the graph build),
-  short-circuited by `(some ...)`. The reported pair is canonically
-  ordered by `(juxt hash str)` so the report is GENUINELY stable across
-  runs: `hash` alone leaves the order undefined on a hash
-  collision (distinct ids, equal hash) — `sort-by` is stable and would
-  fall back to map-iteration order there, a non-contract across JVM runs.
-  The `str` tie-break makes the lo/hi assignment depend only on the ids'
-  values, never on iteration order, while still avoiding the requirement
-  that flow-ids be mutually comparable (`sort` throws on mixed-type ids,
-  but `str` is total). Mirrors `extract-cycle-path`'s deterministic pick."
+  Scan each unordered pair once. `(juxt hash str)` gives deterministic reports
+  without requiring heterogeneous ids to be comparable."
   [flow-map]
   (let [entries (vec flow-map)
         n       (count entries)]
@@ -105,33 +49,10 @@
             [i j]))))
 
 (defn detect-output-path-overlap!
-  "Symmetric with `topo-sort`'s cycle check (Spec 013 §Disjoint output
-  paths). Given a prospective per-frame `flow-map` (`{flow-id flow-map}`),
-  throw `:rf.error/flow-path-overlap` if any two distinct flows have
-  overlapping output `:output-path`s — otherwise return `flow-map` unchanged so
-  the caller can thread it.
+  "Reject overlapping output paths in a prospective flow map.
 
-  WHY this is a registration error, not a topo edge: the dependency rule
-  (`depends-on?`) compares one flow's `:output-path` against another's `:inputs`,
-  never `:output-path` vs `:output-path`. Two same-frame flows whose outputs overlap but
-  whose inputs are disjoint therefore get NO edge — both are 'ready' at
-  topo-sort start and their relative order falls out of map-iteration
-  order, a non-contract. The loser of that undefined order silently loses
-  the shared slot under last-write-wins. Rejecting at `reg-flow` (inside
-  the atomic `swap!`, like the cycle check) closes the footgun before any
-  state mutates.
-
-  The `ex-info` carries the canonical thrown-error shape (per Spec 009
-  §The thrown-error shape) — `:rf.error/id` / `:where` / `:recovery`
-  `:fix-registration` (the caller fixes one flow's `:output-path` and retries,
-  exactly like the cycle / validate-flow rejections) / `:reason` — plus
-  `:overlap`, the offending `{:flow-ids [id-a id-b] :paths [path-a
-  path-b]}` pair, so tools (Xray's flow panel) name the colliding flows
-  directly.
-
-  Pure-data, no requires (the shape is inlined rather than reaching for
-  `registry.cljc`'s `flow-error` helper) — same posture as the cycle
-  throw in `topo-sort`."
+  Output/output overlap is not a topology edge, so accepting it would make
+  last-write order depend on map iteration. Returns `flow-map` when valid."
   [flow-map]
   (when-let [overlap (first-overlapping-pair flow-map)]
     (error/throw-error!
@@ -142,24 +63,12 @@
   flow-map)
 
 (defn- extract-cycle-path
-  "Given the dependency graph `id → #{deps...}` and the set of stuck
-  ids `remaining` (those Kahn's couldn't peel), return an ordered cycle
-  path with a CLOSING REPEAT — e.g. `[:a :b :a]` for the cycle
-  `:a → :b → :a`. Tools render this directly.
+  "Extract a closing-repeat cycle path from Kahn's unpeeled nodes.
 
-  DFS from an arbitrary stuck node, following dependency edges within
-  `remaining`. When a node is revisited along the current path stack,
-  the slice `[stack-from-revisit ... current]` plus the revisited node
-  closes the cycle.
-
-  `remaining` is a set of stuck ids (NOT the live `remaining` map from
-  Kahn's loop — its values have been mutated as deps were peeled away,
-  so we read fresh dep edges from `graph`)."
+  Follow the original graph because Kahn's working dependency sets have been
+  mutated while peeling acyclic nodes."
   [graph remaining]
-  ;; Deterministic pick: sort by hash so cycle reports are stable across
-  ;; runs without requiring flow-ids be mutually comparable (sort fails
-  ;; on mixed types). Hash collisions don't matter — we only need ONE
-  ;; cycle path, any pick produces a valid one.
+  ;; Hash ordering is deterministic enough here: any cycle path is valid.
   (let [stuck-sorted (vec (sort-by hash remaining))
         start        (first stuck-sorted)]
     (loop [stack [start]
@@ -170,14 +79,7 @@
             next-dep (first (sort-by hash (filter remaining (graph node))))]
         (cond
           (nil? next-dep)
-          ;; Dead end within `remaining` — by Kahn's algorithm every
-          ;; stuck node has at least one stuck dep (that's why Kahn
-          ;; couldn't peel it). Reaching this branch means the topo
-          ;; state is internally inconsistent: a stuck node found no
-          ;; stuck dep to follow. Fail loud rather than silently
-          ;; returning a malformed cycle path — a closing-repeat
-          ;; vector built from a dead end would lie to tools (Xray,
-          ;; the flow panel) about the offending chain.
+          ;; Every unpeeled node must have an unpeeled dependency.
           (error/throw-error!
             :rf.error/flow-cycle-extract-invariant 'rf/reg-flow
             "Cycle-path extraction reached a dead end: a stuck node found no stuck dependency to follow. Internal topo invariant violated — report with the :node / :stack / :seen / :remaining payload."
@@ -187,9 +89,7 @@
                      :remaining remaining}})
 
           (contains? seen next-dep)
-          ;; Cycle found. Slice the stack from the revisited node
-          ;; forward, then append the revisited node again to close.
-          ;; Pure-Clojure index search keeps this .cljc-portable.
+          ;; Slice from the revisited node and append it to close the cycle.
           (let [idx (loop [i 0]
                       (cond
                         (= i (count stack))      0
@@ -201,30 +101,17 @@
           (recur (conj stack next-dep) (conj seen next-dep)))))))
 
 (defn topo-sort
-  "Kahn's algorithm — pure `loop`/`recur` over immutable state. Returns
-  flows in evaluation order; throws `:rf.error/flow-cycle` if the graph
-  is cyclic. `ready` is a vector used as a LIFO stack
-  (`peek`/`pop`/`conj`); `remaining` is the live id→dep-set map; `order`
-  is the accumulating result.
+  "Return flow ids in Kahn topological order.
 
-  On cycle: ex-data carries `:cycle` — an ordered cycle path with a
-  closing repeat (e.g. `[:a :b :a]`) extracted via DFS through the
-  stuck nodes. Per Spec 013 §Cycle detection / Spec 009 §Error contract.
-  Tools (e.g. Xray) render this directly as the offending chain.
-
-  Note: callers re-run this on every drain via
-  `re-frame.flows/run-flows-on-db`, unmemoised. The per-frame flow map is
-  tiny (Kahn over a handful of nodes) and a memo keyed on the flow map
-  would need explicit invalidation on every reg-flow / clear-flow anyway.
-  The unmemoised call is the cheapest correct option."
+  Throws `:rf.error/flow-cycle` with a closing-repeat `:cycle` path. This is
+  intentionally unmemoized: frame flow maps are small and lifecycle changes
+  would require explicit cache invalidation."
   [flow-map]
   (let [ids (vec (keys flow-map))]
-    ;; 0/1 flows have no edges — order is trivial; skip the O(n²) graph
-    ;; build (the cost note lives once on `topo-sort`'s docstring above).
+    ;; Avoid the quadratic graph build for the trivial cases.
     (case (count ids)
       0 []
       1 ids
-      ;; ≥2 flows: build the full dep graph and run Kahn's algorithm.
       (let [graph (into {}
                         (map (fn [id]
                                (let [flow (flow-map id)]
@@ -252,28 +139,8 @@
                              remaining-without-node)]
               (recur ready' remaining' (conj order node-id)))
             (if (seq remaining)
-              ;; Cycle ex-info carries the canonical thrown-error shape
-              ;; (per Spec 009 §The thrown-error shape) every other flow
-              ;; ex-info uses (`:rf.error/id` / `:where` / `:recovery` /
-              ;; `:reason`) so tools (Xray, re-frame-10x,
-              ;; late-bind-missing wrappers) read the `:rf.error/id`
-              ;; discriminator uniformly across error surfaces.
-              ;; `topo.cljc` is the pure-data module — no `:require`s —
-              ;; so the shape is inlined rather than reaching for
-              ;; `registry.cljc`'s `flow-error` helper.
-              ;;
-              ;; `:recovery :fix-registration` — a cycle is the same class
-              ;; of error as the sibling `validate-flow` rejections:
-              ;; detected at `reg-flow` time on a PROSPECTIVE map BEFORE any
-              ;; state mutates, so the prior registration survives and the
-              ;; caller fixes their
-              ;; `:inputs` / `:output-path` and retries. Stamping `:no-recovery`
-              ;; would make an `:on-error` policy or tool that branches on
-              ;; `:recovery` to decide "is this user-fixable?" treat a
-              ;; fixable cycle as terminal — inconsistent with every other
-              ;; registration rejection. (The `extract-cycle-path`
-              ;; dead-end throw below stays `:no-recovery`; that one is a
-              ;; genuine internal-invariant violation, not caller-fixable.)
+              ;; Registration validates the prospective map before mutation,
+              ;; so callers can correct the graph and retry.
               (error/throw-error!
                 :rf.error/flow-cycle 'rf/reg-flow
                 "Cyclic flow dependency — at least one pair of flows' :output-path / :inputs overlap mutually (per Spec 013 §Dependency rule). The closing-repeat :cycle vector names the offending chain."


### PR DESCRIPTION
## Summary

- replace migration and tracker history with current flows contracts
- consolidate ownership explanations around per-frame caches, registration atomicity, in-drain path vacation, and rollback
- keep trace elision and tooling bundle boundaries explicit without repeating them at each call site

## Impact

Comments, docstrings, and dependency-file guidance only. No executable flow logic changed.

## Checks

- `clojure -M:test` from `implementation/flows` (194 tests, 4,787 assertions)
- `npm run test:cljs` from `implementation` (8,472 tests, 39,186 assertions)
- `clj-kondo --fail-level error --lint implementation/flows`
- `clojure -M:splint --fail-on-errors ../implementation/flows`
- `npm run test:bundle-isolation`
