### PR TITLE
docs(epoch): clarify runtime contracts (rf2-jnnonn)

### DIFF
--- a/implementation/epoch/deps.edn
+++ b/implementation/epoch/deps.edn
@@ -1,126 +1,37 @@
-;; day8/re-frame2-epoch — epoch artefact (rf2-lt4e,
-;; seventh and final per-feature split per rf2-5vjj Strategy B).
+;; Optional debug-time epoch history and time-travel support. This artefact
+;; depends on core, while core reaches it only through `re-frame.late-bind`.
+;; Requiring `re-frame.epoch` publishes that hook contract; the publication
+;; map in that namespace is the authoritative hook inventory.
 ;;
-;; Per Tool-Pair §Time-travel and Spec-Schemas §`:rf/epoch-record` the
-;; epoch surface — the per-frame `:rf/epoch-record` ring buffer
-;; (`epoch-history`), the `(rf/configure! {:epoch-history {:depth N}})`
-;; knob, the `register-epoch-listener!` / `unregister-epoch-listener!` listener API, the
-;; `restore-epoch!` rewind with its seven documented failure modes
-;; (`:rf.epoch/restore-unknown-epoch`,
-;; `:rf.epoch/restore-non-ok-record`,
-;; `:rf.epoch/restore-schema-mismatch`,
-;; `:rf.epoch/restore-missing-handler`,
-;; `:rf.epoch/restore-version-mismatch`,
-;; `:rf.epoch/restore-during-drain`, plus `:rf.error/no-such-handler`
-;; for the unknown-frame case), the per-cascade trace-capture buffer
-;; the router and the trace surface feed via the `:epoch/capture-event`
-;; (per-trace emit), `:epoch/settle!` (per-event drain-settle), and
-;; `:epoch/commit-halt-record!` (per-event depth-halt boundary) late-bind hooks,
-;; the `:rf.epoch/snapshotted` and `:rf.epoch/restored`
-;; trace events, and the `:sub-runs` / `:renders` / `:effects`
-;; per-cascade projections — ships as a separate Maven artefact so apps
-;; that don't consume the time-travel / pair-tool surface don't drag
-;; the namespace, the per-frame ring buffer, the trace-capture path,
-;; the projection walker, the schema-validate / machine-version /
-;; missing-reference predicates, or any of the `:rf.epoch/*` trace
-;; strings onto the classpath.
+;; Keeping epoch separate excludes its ring buffers, capture path, restore
+;; validation, and projection machinery from applications that do not opt in.
+;; Its runtime paths are also gated by `interop/debug-enabled?`, allowing
+;; advanced production builds with `goog.DEBUG=false` to eliminate them.
 ;;
-;; The entire surface is gated on `interop/debug-enabled?` (per
-;; Tool-Pair §Time-travel §Production elision) — production builds
-;; (`:advanced` + `goog.DEBUG=false`) elide every recorded shape,
-;; the projection walker, and the restore predicates whether or not
-;; the artefact is on the classpath. Keeping it a separate artefact is
-;; *also* a dev-time bundle-shape win: development builds that don't opt
-;; into the pair-tool surface carry none of the namespace at all.
-;;
-;; Consumers add this artefact alongside the core artefact:
-;;
-;;   {:deps {day8/re-frame2       {:mvn/version "..."}
-;;           day8/re-frame2-epoch {:mvn/version "..."}}}
-;;
-;; And require `re-frame.epoch` in any namespace that calls
-;; `rf/epoch-history`, `rf/restore-epoch!`, `rf/register-epoch-listener!`,
-;; `rf/unregister-epoch-listener!`, or `(rf/configure! {:epoch-history ...})` —
-;; loading the namespace publishes the artefact's late-bind contract via
-;; a single `(late-bind/set-fns! { ... })` map in `re-frame.epoch`.
-;;
-;; The authoritative, always-current hook list is that publication map
-;; (see `re-frame.epoch`'s `set-fns!` call) cross-referenced against the
-;; `re-frame.late-bind.directory/hooks` entries (the `:epoch/*` rows) —
-;; the `re-frame.late-bind-drift-test` gate pins the two in sync, so this
-;; comment intentionally does NOT maintain a parallel list that would
-;; silently drift. The hooks span: per-run lifecycle (router + trace
-;; capture seam — `:epoch/settle!`, `:epoch/commit-halt-record!`,
-;; `:epoch/capture-event`, `:epoch/run-cause`, the post-settle
-;; back-fill family `:epoch/record-render!` / `record-sub-run!` /
-;; `record-unmount!`, `:epoch/on-frame-destroyed`); introspection + the
-;; Tool-Pair write surface (`:epoch/epoch-history`, `:epoch/restore-epoch!`,
-;; the `replace-*` / `reset-app-db!` injection hooks); the listener +
-;; config surface (`:epoch/register-epoch-listener!` /
-;; `unregister-epoch-listener!`, `:epoch/configure!`, the test-isolation
-;; `:epoch/clear-history!` / `clear-epoch-listeners!` / `reset-config!`
-;; hooks); and the off-box egress projection (`:epoch/projected-record`
-;; / `projected-history`). `:epoch/discard-buffer!` is intentionally
-;; ABSENT — there is no whole-drain rollback hook under per-event
-;; epochs; already-settled siblings are durable.
-;;
-;; Per Spec 006 §Adapter shipping convention (and the
-;; rf2-p7va extension to per-feature splits): this artefact depends on
-;; core; core never depends on this artefact. The cross-references
-;; from core to epoch (`re-frame.core`'s `epoch-history` /
-;; `restore-epoch!` / `register-epoch-listener!` / `unregister-epoch-listener!` re-exports
-;; and the `(rf/configure! {:epoch-history ...})` knob) flow through
-;; `re-frame.late-bind` exactly as the schemas / machines / routing /
-;; flows / http / ssr hooks already do.
+;; Consumers add `day8/re-frame2-epoch` beside `day8/re-frame2` and require
+;; `re-frame.epoch` before using the core facade's epoch functions.
 {:paths ["src"]
  :deps  {day8/re-frame2 {:local/root "../core"}}
 
  :aliases
  {:test {:extra-paths ["test"]
-         ;; The epoch JVM tests use the canonical capture/restore
-         ;; fixture (`re-frame.test-support/make-reset-runtime-fixture`,
-         ;; rf2-yw1w1u): it snapshots the registrar at each test ns's
-         ;; load and restores around every test, so the schemas /
-         ;; routing / machines registrations those test ns `:require`
-         ;; chains bring live survive across tests WITHOUT a
-         ;; `clear-all!` + `re-frame.routing` reload dance. The
-         ;; schema-mismatch failure-mode test exercises the schemas
-         ;; surface (a registered app-schema the recorded db-after no
-         ;; longer satisfies), the version-mismatch test exercises the
-         ;; machines surface (a registered machine whose snapshot-version
-         ;; drifted), and the routing tests register routes via
-         ;; `rf/reg-route`. Pull schemas / flows / routing / machines in
-         ;; as test-only deps so the fixture + those test bodies load
-         ;; cleanly. Mirrors the pattern in core/deps.edn,
-         ;; routing/deps.edn, flows/deps.edn, http/deps.edn, and
-         ;; ssr/deps.edn. None of these is required for production epoch
-         ;; builds.
+         ;; Restore precondition and integration tests exercise registrations
+         ;; published by these optional artefacts. They remain test-only so
+         ;; production epoch does not acquire those dependencies.
          :extra-deps  {day8/re-frame2-schemas    {:local/root "../schemas"}
                        day8/re-frame2-flows      {:local/root "../flows"}
                        day8/re-frame2-routing    {:local/root "../routing"}
                        day8/re-frame2-machines   {:local/root "../machines"}
-                       ;; rf2-84l82t — TEST-ONLY: the resources artefact
-                       ;; publishes the `:resources/project-scope-resolved-egress`
-                       ;; hook the off-box `:trace-events` projection consults; an
-                       ;; integration test loads it to prove the wiring fires
-                       ;; (production epoch never deps resources — the hook is
-                       ;; nil-safe / no-op when absent).
+                       ;; Publishes the resource egress hooks used by projection
+                       ;; integration tests; production lookup is nil-safe.
                        day8/re-frame2-resources  {:local/root "../resources"}
-                       ;; rf2-try1x — silent-on-success reporter.
                        day8/re-frame2-test-quiet {:local/root "../test-quiet"}
                        io.github.cognitect-labs/test-runner
                        {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
          :main-opts   ["-m" "re-frame.test-quiet.runner"]}
 
-  ;; Clojars deploy (rf2-r382). Modeled on re-frame v1's release flow.
-  ;; The release workflow runs `clojure -M:clein deploy` from this
-  ;; artefact's directory, which builds pom + jar and pushes to Clojars.
-  ;;
-  ;; IMPORTANT: when this artefact is published, the `day8/re-frame2`
-  ;; core dep above is replaced by an :mvn/version coordinate — clein
-  ;; reads :deps and writes them into pom.xml, and a :local/root entry
-  ;; would resolve to nothing for downstream consumers. The release
-  ;; workflow swaps :local/root → :mvn/version before invoking clein.
+  ;; The release workflow replaces the core `:local/root` with its Maven
+  ;; coordinate before Clein builds the published POM and jar.
   :clein {:extra-deps {io.github.noahtheduke/clein
                        {:git/url "https://github.com/day8/clein.git"
                         :git/sha "2b83503246e8291fc023d688574640a9b23d8c50"}}

--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -1,10 +1,9 @@
 (ns re-frame.epoch
-  "Per-frame epoch history. Per Tool-Pair §Time-travel and Spec-Schemas
-  §`:rf/epoch-record`.
+  "Per-frame epoch history and time-travel support.
 
   Every DEQUEUED EVENT's run-to-completion marks an epoch boundary — one
-  `:rf/epoch-record` per event, NOT per drain (per Spec 002 §Drain versus
-  event, rf2-u6jsj/rf2-nj6p7). A drain that processes a parent event and
+  `:rf/epoch-record` per event, not per drain. A drain that processes a
+  parent event and
   the `:fx [[:dispatch …]]` child it queued commits TWO records. A machine
   macrostep (`:raise` / `:always` microsteps) runs inside one event and
   stays ONE epoch. The runtime records, per frame, an `:rf/epoch-record`
@@ -12,14 +11,11 @@
 
     :epoch-id       opaque, unique within a frame's history
     :frame          frame keyword
-    :committed-at   the committing event's CAUSAL time — its envelope's
-                    `:rf.cofx` `:rf/time-ms`, stamped at the router's
-                    causal boundary (rf2-bh56rc / EP-0010 §Time), NOT an
-                    ambient assembly-time clock read; replayable
+    :committed-at   the committing event's causal `:rf/time-ms`
     :event-id       the event keyword that triggered the cascade
     :trigger-event  the full event vector
-    :db-before      app-db snapshot before the cascade
-    :db-after       app-db snapshot after the drain settled
+    :db-before      app-db snapshot before the event ran
+    :db-after       app-db snapshot after that event settled
     :trace-events   the raw trace stream that produced this epoch
     :sub-runs       structured projection of subscription activity
     :renders        structured projection of render activity
@@ -31,22 +27,19 @@
 
   The entire epoch-history machinery is gated on `interop/debug-enabled?`,
   the same compile-time goog-define as the trace surface. Production
-  builds elide; no allocation, no storage, no overhead.
+  builds elide the epoch implementation and its recorded data.
 
-  Listener API (`register-epoch-listener!` / `unregister-epoch-listener!`) mirrors the
-  raw-trace listener API in `re-frame.trace`. Listeners receive the
-  fully-assembled record after it lands in the ring buffer.
+  Listeners receive each raw assembled record after the storage attempt.
+  With history depth 0, listeners still receive records while the ring stays
+  empty.
 
   Restore (`restore-epoch!`) rewinds a frame to the named epoch's
   canonical `:frame-state-after` — the WHOLE frame-state, with app-db
   and runtime-db as two separate partitions reinstalled in ONE atomic
-  write (EP-0001 rf2-3aizt1; Tool-Pair §Time-travel). The retained
+  write. The retained
   `:db-before` / `:db-after` are OPTIONAL app-db projections of that
-  frame-state, not the restore target itself. Seven documented failure
-  modes (Tool-Pair §Time-travel restore-failure-modes table) each emit
-  a structured trace and leave the frame's frame-state unchanged — six
-  under the reserved `:rf.epoch/*` namespace, plus the registry-lookup
-  `:rf.error/no-such-handler` (kind `:frame`) for an unknown frame-id."
+  frame-state, not the restore target itself. Refused restores emit a
+  structured trace and leave the frame state unchanged."
   (:require [re-frame.epoch.assembly :as assembly]
             [re-frame.epoch.capture :as capture]
             [re-frame.epoch.listeners :as listeners]
@@ -59,33 +52,7 @@
 
 ;; ---- configuration --------------------------------------------------------
 ;;
-;; Atoms, defaults, and config-merge validation live in `re-frame.epoch.state`.
-;; The facade keeps the public docstrings and the late-bind hook publication.
-;;
-;; Design provenance (kept out of the public `configure!` docstring per the
-;; rf2-ee38b clarity review):
-;;   * `:trace-events-keep` defaults to a FINITE fixed 50 — chosen to equal
-;;     the shipped `:depth` DEFAULT (see
-;;     `re-frame.epoch.state/default-trace-events-keep`; rf2-mrsck /
-;;     Security.md §Epoch privacy posture). It does NOT track a configured
-;;     `:depth` — the two are independent slots. With the default the most-recent
-;;     `:depth` records per frame retain raw `:trace-events`; when an epoch
-;;     evicts from the ring its raw trace evicts with it, so trace + epoch
-;;     stay atomic (Mike pair-debug 2026-05-27 — the prior finite-5 default
-;;     created the discrepancy of 50 retained records but only 5 with their
-;;     `:trace-events`). Older records (beyond the keep-window, when an app
-;;     configures a keep < depth) keep only the cheap structured projections.
-;;     Memory-conscious hosts pass a smaller value (e.g.
-;;     `{:trace-events-keep 5}`); `0` drops every record's `:trace-events`.
-;;     `(rf/configure! {:epoch-history {:trace-events-keep nil}})` is a no-op
-;;     against the explicit-value validation; use a numeric value or omit the
-;;     slot.
-;;   * Keys are validated at the boundary (refactor-audit r2 rf2-lwn4t
-;;     §rf2-douii): a `:depth` / `:trace-events-keep` that isn't a
-;;     non-negative integer is silently dropped rather than stored, so a
-;;     nil / non-numeric value can't survive into `record!` and explode at
-;;     the next `pos?` / `nat-int?`. Mirrors `re-frame.trace/configure-trace-
-;;     buffer!`'s own config-boundary validation.
+;; Defaults, state, and boundary validation live in `re-frame.epoch.state`.
 
 (defn configure!
   "Update the epoch-history configuration. Supported keys:
@@ -105,21 +72,21 @@
                         `:depth`: set `{:depth 100}` and `:trace-events-keep`
                         stays 50 unless you also set it. Pass a smaller value
                         (e.g. 5) to bound dev-session heap more aggressively.
-    :redact-fn          fn? or nil. The ADVANCED PROJECTION-SIDE override
-                        (EP-0015 §15 + open-issue 6, RULED). When non-nil the
+    :redact-fn          fn? or nil. An advanced projection-side override.
+                        When non-nil the
                         framework invokes the fn ONCE per record at the
                         OFF-BOX EGRESS boundary — inside `projected-record`,
                         AFTER the frame/profile `project-egress` projection —
                         NOT at storage time. The ring buffer and every
                         `register-epoch-listener!` listener receive the RAW
-                        record: post-EP-0010 epoch records are causal replay
-                        material, and mutating them at rest would corrupt the
+                        record. Epoch records are causal replay material, and
+                        mutating them at rest would corrupt the
                         replay contract. The fn is the rare advanced escape
                         for an app that records material the declaration-driven
                         projection cannot prove (a sensitive slot no frame /
                         schema declaration covers); ordinary redaction needs
                         only the frame's `:sensitive` / `:large` classification
-                        (EP-0015 §3) plus the per-slot schema props machine /
+                        plus the per-slot schema properties machine /
                         resource data carry, which `projected-record` already
                         applies. A throwing
                         fn emits `:rf.warning/epoch-redact-fn-exception` and
@@ -127,13 +94,11 @@
                         record. Passing `nil` clears any previously-installed
                         fn. CAVEAT: the fn runs only on the projected egress
                         copy; it cannot affect `restore-epoch!` fidelity (the
-                        ring stays raw) — that hazard is gone by construction.
+                        ring stays raw).
 
   Invalid `:depth` / `:trace-events-keep` (not a non-negative integer) and
   malformed `:redact-fn` (not `fn?` / `nil`) are silently dropped at the
-  boundary. See EP-0015 §15 (Epoch Redaction) + open-issue 6 disposition,
-  Tool-Pair §Time-travel §Redaction hook + Security.md §Epoch privacy posture
-  for the full contract."
+  boundary."
   [opts]
   (state/merge-config! opts))
 
@@ -142,18 +107,6 @@
   and tools that want to display the current depth."
   []
   (state/current-config))
-
-;; The test-support config-isolation seam (`:epoch/reset-config!`,
-;; rf2-yw1w1u) points straight at `state/reset-config!` from the late-bind
-;; map below (rf2-c0rv4v — no facade wrapper; `state/reset-config!`'s
-;; docstring is the canonical pin and there is no distinct public docstring
-;; to keep here).
-
-;; The record-assembly helpers — `current-schema-digest`, the
-;; sensitive-rollup family, and `build-record` itself — live in
-;; `re-frame.epoch.assembly`. The `:redact-fn` advanced override
-;; (`apply-redact-fn`) is projection-side only (EP-0015 §15 + open-issue
-;; 6, RULED) — invoked from `projected-record`, never at storage time.
 
 ;; ---- the per-frame ring buffer --------------------------------------------
 ;;
@@ -172,13 +125,8 @@
 (defn clear-history!
   "Drop every recorded epoch for every frame. Test fixtures use this.
 
-  Per rf2-v0jwt: also drops any in-flight per-frame capture buffer.
-  Conformance / unit-test fixtures that sequence runs need a fresh
-  capture state per fixture so the halted-cascade record commits
-  observe THIS fixture's drain only — a buffer left over from a
-  previous fixture's mid-flight emit (e.g. a `:frame/created` event
-  whose drain didn't fire `harvest-buffer!`) would otherwise be
-  picked up by the next fixture's first cascade."
+  Also drop in-flight capture buffers so a later event cannot harvest traces
+  left by an interrupted test or run."
   []
   (state/reset-histories!)
   (state/reset-capture-buffers!)
@@ -191,15 +139,14 @@
 ;; fan-out / failure-isolation policy.
 
 (defn register-epoch-listener!
-  "Register a callback fired once per drain-settle with the assembled
-  `:rf/epoch-record`. The id can be any comparable value; passing the
-  same id twice replaces. Per Spec 009 §`register-epoch-listener!` —
-  assembled-epoch listener.
+  "Register a callback fired for each assembled event epoch record.
+  The id can be any comparable value; passing the
+  same id twice replaces the callback.
 
   The callback receives a fully-formed record with `:db-after`,
   `:sub-runs`, `:renders`, `:effects`, and `:trace-events` populated.
-  The record has already been appended to the frame's `epoch-history`
-  ring buffer when the callback runs.
+  Storage is attempted before the callback runs. At depth 0 the callback
+  still receives the record even though the ring remains empty.
 
   Listener exceptions are caught and isolated; one broken listener
   cannot break the runtime or block other listeners.
@@ -217,14 +164,6 @@
   []
   (state/reset-listeners!))
 
-;; `notify-listeners!` (the fan-out + failure-isolation policy) and
-;; `on-frame-destroyed!` (the four-step destroy contract that
-;; straddles state, capture, and assembly) live in
-;; `re-frame.epoch.listeners` (Phase-2 seam C, rf2-0wi86). The
-;; `:epoch/on-frame-destroyed` late-bind slot points straight at
-;; `listeners/on-frame-destroyed!` (rf2-c0rv4v — no facade wrapper; that
-;; seam carries no public docstring distinct from the listeners pin).
-
 ;; ---- per-cascade trace capture --------------------------------------------
 ;;
 ;; The drain runs traces through `re-frame.trace/emit!` which fans out to
@@ -236,168 +175,62 @@
 ;; The buffer is keyed by frame-id so concurrent drains across frames
 ;; don't co-mingle. Within a frame, drain-execution is single-threaded
 ;; (per Spec 002 §Run-to-completion) so no further locking is needed.
-;; The atom + buffer-CRUD live in `re-frame.epoch.state` (Phase-2
-;; seam A, rf2-0wi86).
-
-;; The skip-ops catalogue, the late-bind `:epoch/capture-event` entry
-;; point, and the two read-only walks (`project-all`,
-;; `find-trigger-event`) live in `re-frame.epoch.capture` (Phase-2
-;; seam B, rf2-0wi86).
+;; Buffer storage lives in `re-frame.epoch.state`; capture and projection
+;; helpers live in `re-frame.epoch.capture`.
 
 ;; ---- per-event settle hook ------------------------------------------------
 
 (defn- commit-record!
-  "Build, ring-append, and fan out one RAW `:rf/epoch-record`. Shared
-  by the per-event clean settle (`settle!`) and the per-event halt commit
-  (`commit-halt-record!`). `events` is the harvested cascade buffer (may
-  be empty for a halt whose event never ran); `trigger-event` is an
-  explicit `[event-id …]` vector to pin the record's trigger when the
-  buffer carries no `:event/run-start` (the depth-exceed halting event,
-  per rf2-nj6p7), or nil to let `build-record` derive the trigger from
-  the buffer (the normal `:ok` path).
+  "Build, store, and fan out one raw `:rf/epoch-record`.
 
-  Per EP-0015 §15 + open-issue 6 (RULED, hardened): the ring buffer and
-  every `register-epoch-listener!` listener receive the RAW record.
-  Epoch records are causal replay material (per EP-0010), and mutating
-  them at rest would corrupt the replay contract (not merely restore
-  fidelity), so storage is always raw. The app-supplied `:redact-fn` is a
-  PROJECTION-SIDE-ONLY advanced override, applied at the off-box egress
-  boundary inside `projected-record` (never at storage time). The
-  `:rf.epoch/sensitive?` rollup inside `build-record` reflects raw signals
-  so off-box consumers can branch on it before projecting.
+  `events` is the harvested capture buffer. `trigger-event` supplies the
+  trigger for a halt whose event never ran and therefore has no
+  `:event/run-start`; normal settles derive it from `events`.
 
-  `committed-at` is the record's durable causal time — per EP-0010 §Time
-  and Spec 002 §The World-Input Rule (rf2-bh56rc) the committing causal
-  token's `:rf.cofx` `:rf/time-ms`, threaded down from the router's
-  per-event settle / depth-halt seam, NOT an ambient host-clock read at
-  assembly time. This makes `:committed-at` replayable."
+  Raw storage is required for replay. Projection, including the configured
+  `:redact-fn`, happens only at off-box egress. `committed-at` is the causal
+  token's `:rf/time-ms`, not an assembly-time clock read."
   [frame-id frame-state-before frame-state-after events committed-at outcome halt-reason trigger-event]
-  ;; EP-0001 (rf2-3aizt1, decision #2): the canonical snapshot unit is the
-  ;; whole frame-state (both partitions); `build-record` stores it as
-  ;; `:frame-state-before` / `:frame-state-after` and derives the
-  ;; `:db-before` / `:db-after` app-db projections.
+  ;; Whole-frame snapshots are restore units; app-db slots are projections.
   (let [base   (assembly/build-record frame-id frame-state-before frame-state-after
                                       events committed-at outcome halt-reason)
-        ;; Pin the explicit trigger when supplied AND the buffer didn't
+        ;; Pin the explicit trigger only when the buffer did not resolve one.
         ;; already resolve one (the halting event never ran, so no
-        ;; `:event/run-start` was buffered). Per Spec-Schemas
-        ;; §:rf/epoch-record the slots are :keyword / vector — never nil.
+        ;; `:event/run-start` was buffered). Omit rather than store nil.
         record (cond-> base
                  (and trigger-event (not (:event-id base)))
                  (assoc :event-id      (first trigger-event)
                         :trigger-event trigger-event))]
     (state/record! record)
-    ;; Per rf2-qs6dl: mark this as the frame's most-recently-settled
-    ;; epoch so post-settle async render emits (which fire at React
-    ;; commit time, after this event settled) are attributed back to
-    ;; THIS event rather than buffered into the next one. Set after
-    ;; `record!` so the record is in the ring before any render can
-    ;; back-fill into it.
+    ;; Async render/sub emits use this anchor after the event has settled.
+    ;; Set it after storage so back-fill can find the record immediately.
     (state/set-last-settled-epoch! frame-id (:epoch-id record))
-    ;; Per rf2-931pm — focused-event-only cascade-DAG capture. Sticky
-    ;; hook (rf2-f72pd) published by `re-frame.trace.cascade` at ns-load;
-    ;; when the trace.cascade ns has not been loaded (e.g. tooling-
-    ;; stripped JVM consumers) the lookup returns nil and the call
-    ;; short-circuits. The aggregator's own focus-predicate gate decides
-    ;; whether to emit `:rf.cascade/captured` — off-focus epochs pay just
-    ;; the predicate call (default predicate returns false).
+    ;; The optional cascade aggregator applies its own focus predicate.
     (when-let [capture (late-bind/get-fn-cached
                          :trace.cascade/capture-for-epoch!)]
       (try
         (capture frame-id (:epoch-id record) (:event-id record) events)
         (catch #?(:clj Throwable :cljs :default) _ nil)))
-    ;; Per rf2-18g1w / rf2-jppad — the cascade-trailer pair: the detailed
-    ;; `:rf.epoch/snapshotted` (tools that want the CAUSE read its
-    ;; `:outcome` tag) plus the consumer-facing `:rf.epoch/outcome`
-    ;; (`{:ok :blocked :error}` — the Xray Trace panel close-row §13 and
-    ;; Story outcome chips read this op's tag directly). The shared
-    ;; `emit-snapshotted+outcome!` keeps the trailer shape identical to
-    ;; the mid-drain destroy commit's.
+    ;; Emit both the detailed close cause and its consumer-facing tier.
     (assembly/emit-snapshotted+outcome! frame-id (:epoch-id record)
                                         (:event-id record) outcome)
     (listeners/notify-listeners! record)
     record))
 
 (defn settle!
-  "Hook called by the router once per DEQUEUED EVENT — at each event's
-  run-to-completion boundary, NOT once per drain. Per Spec 002
-  §Drain versus event — the epoch unit (rf2-u6jsj/rf2-nj6p7) and
-  Tool-Pair §Time-travel and rf2-v0jwt §Outcomes.
+  "Settle one dequeued event, not an entire drain.
 
-  Per rf2-nj6p7: the epoch boundary is the dequeued event, not the
-  drain-settle. A drain that processes a parent event and an
-  `:fx [[:dispatch …]]` child it queued therefore produces TWO records
-  (one per event), each with its OWN `:db-before` / `:db-after` snapshot
-  pair and its own harvested trace buffer. The router calls this after
-  each `process-event!` returns, so the capture buffer it harvests holds
-  exactly that one event's six-domino cascade (within a frame, execution
-  is single-threaded run-to-completion, so the buffer is cleanly the
-  in-flight event's). A machine macrostep — `:raise` sub-events and
-  `:always` microsteps — runs INSIDE a single `process-event!`, so its
-  emits ride the triggering event's buffer and settle as ONE epoch (per
-  Spec 005 §macrostep); they do not allocate a new epoch.
+  Parent and child events in one drain produce separate records; machine
+  microsteps within one handler remain in that handler's record. The two
+  frame-state arguments are whole-frame snapshots, and `committed-at` is the
+  event envelope's causal time.
 
-  `committed-at` is the record's durable causal time — per EP-0010 §Time
-  (epoch record causal time) and Spec 002 §The World-Input Rule
-  (rf2-bh56rc) the committing causal token's `:rf.cofx` `:rf/time-ms`,
-  read ONCE at the causal boundary (envelope construction) and threaded
-  down here by the router's per-event settle seam (`settle-event-epoch!`),
-  NOT an ambient host-clock read at assembly time. This makes the record's
-  `:committed-at` replayable: the same event log replayed with the same
-  supplied `:rf/time-ms` values yields records with equal `:committed-at`.
-
-  Arities:
-    (settle! frame-id frame-state-before frame-state-after committed-at)
-      Clean per-event settle. `:outcome` is `:ok`. Equivalent to passing
-      `:ok` as `outcome` explicitly. Skips recording when the captured
-      buffer is empty (a truly empty cascade — likely a rejected
-      dispatch — is degenerate and would emit a misleading record).
-    (settle! frame-id frame-state-before frame-state-after committed-at settling-dispatch-id)
-      Clean per-event settle threading the settling ENVELOPE's dispatch-id —
-      the arity the ROUTER's per-event seam (`settle-event-epoch!`) calls.
-      `settling-dispatch-id` scopes the NO-RUN-START harvest (rf2-erczwd): a
-      rejected / aborted dispatch (no-handler / frame-destroyed) emits a
-      frame-stamped, dispatch-id-bearing error trace that buffers but fired no
-      `:event/run-start`; the harvest drops THAT dispatch's own traces so the
-      empty-buffer skip suppresses the misleading `:ok` epoch, while an
-      unrelated buffered child marker survives for its own settle. `:outcome`
-      is `:ok`.
-    (settle! frame-id frame-state-before frame-state-after committed-at outcome halt-reason)
-      Drain-boundary commit with explicit outcome. The runtime commits
-      one of three outcomes: `:ok` / `:halted-depth` / `:halted-destroy`
-      (`:halted-handler-exception` is a schema-reserved value the
-      reference runtime never emits — handler exceptions ride the
-      interceptor error-capture seam and the drain settles `:ok` with the
-      error trace under `:trace-events`; see Spec-Schemas §`:rf/epoch-record`
-      §Outcomes and Spec 009 §register-epoch-listener!). `halt-reason` is
-      a structured descriptor populated on halt paths (nil on `:ok`). On a buffer
-      with no recoverable trigger (no `:event/run-start` and no
-      `:event-id` tag — e.g. a destroy that races a registration-time
-      emit) `build-record` omits `:event-id` / `:trigger-event`
-      entirely; the schema admits absent slots, rejects nil values
-      (per rf2-kl5p1 / audit r3 §F1).
-
-  `frame-state-before` is the whole frame-state value (both partitions)
-  snapshotted before the cascade began; `frame-state-after` is the value
-  the runtime settled to — equal to `frame-state-before` for atomic-rollback
-  halts (`:halted-depth`), the live frame-state for the destroy path
-  (`:halted-destroy`), the post-drain value for `:ok`. EP-0001 (rf2-3aizt1,
-  decision #2): the canonical snapshot unit is the whole frame-state;
-  `build-record` derives the `:db-before` / `:db-after` app-db projections
-  from it. The captured trace buffer is harvested here and projected into
-  the record.
-
-  Emits `:rf.epoch/snapshotted` with a `:outcome` tag so trace listeners
-  can discriminate clean from halted boundaries without inspecting the
-  epoch-history vector. Listeners (`register-epoch-listener!`) receive every
-  record regardless of outcome.
-
-  See also `commit-halt-record!` — the sibling commit path for the
-  depth-exceed halt whose halting event never ran, so the buffer is empty
-  at halt and `settle!`'s empty-buffer skip would suppress the record.
-  Both fns share the private `commit-record!` helper; `commit-halt-record!`
-  synthesises the halting event's trigger explicitly while `settle!` lets
-  `build-record` derive it from the harvested buffer."
+  The router arity includes `settling-dispatch-id`, allowing capture to discard
+  a rejected dispatch's traces without consuming a queued child's marker. An
+  empty harvest produces no misleading `:ok` record. A depth halt whose event
+  never ran uses `commit-halt-record!`, which can commit an explicit trigger
+  despite an empty buffer. Explicit outcomes carry a structured halt reason;
+  when no trigger can be recovered, trigger slots are omitted rather than nil."
   ([frame-id frame-state-before frame-state-after committed-at]
    (settle! frame-id frame-state-before frame-state-after committed-at :ok nil nil))
   ([frame-id frame-state-before frame-state-after committed-at settling-dispatch-id]
@@ -406,84 +239,32 @@
    (settle! frame-id frame-state-before frame-state-after committed-at outcome halt-reason nil))
   ([frame-id frame-state-before frame-state-after committed-at outcome halt-reason settling-dispatch-id]
    (when interop/debug-enabled?
-     ;; Per rf2-nj6p7: scoped harvest — take only the settling event's
-     ;; traces (its `:dispatch-id` + pre-cascade tagalongs), LEAVING any
-     ;; child's `:event/dispatched` marker (emitted during THIS event's
-     ;; do-fx, carrying the child's id) in the buffer for the child's own
-     ;; settle. Keeps each epoch's `:trace-events` to one `:dispatch-id`
-     ;; (Spec 009 §Dispatch correlation: one dispatch-id = one epoch).
-     ;; rf2-erczwd: `settling-dispatch-id` (the router-threaded envelope id)
-     ;; scopes the NO-RUN-START branch so a rejected/aborted dispatch's own
+     ;; Take only the settling event's traces, leaving a queued child's
+     ;; marker in the buffer for its own settle. The envelope id also scopes
+     ;; the no-run-start branch so a rejected or aborted dispatch's own
      ;; error trace is dropped (not returned) rather than committed as a fake
      ;; `:ok` epoch.
      (let [events (state/harvest-buffer-for-event! frame-id settling-dispatch-id)]
-       ;; Empty-buffer policy (consistent across outcomes): an empty
-       ;; capture buffer means no cascade context was recorded for
-       ;; this event — skip emission rather than commit a record with
-       ;; no :event-id / :trigger-event. A rejected/aborted dispatch
-       ;; (no `:event/run-start` ever fired) reaches this seam with an
-       ;; empty harvest (its own traces dropped by the scoped no-run-start
-       ;; branch, rf2-erczwd) and is correctly suppressed. Halt paths whose
-       ;; halting event never ran (the per-event depth-exceed boundary,
-       ;; per rf2-nj6p7) use `commit-halt-record!` instead, which
-       ;; synthesises the halting event's trigger explicitly.
+       ;; An empty capture has no event context. Rejected dispatches are
+       ;; suppressed here; never-run depth halts use `commit-halt-record!`.
        (when (seq events)
          (commit-record! frame-id frame-state-before frame-state-after events
                          committed-at outcome halt-reason nil))))))
 
 (defn- commit-halt-record!
-  "Commit a `:halted-*` epoch record for a drain halt whose halting event
-  never ran to completion — the per-event depth-exceed boundary
-  (rf2-nj6p7). Unlike `settle!`, this does NOT skip on an empty capture
-  buffer: under per-event epochs the events that ALREADY ran each
-  harvested their own buffer and committed their own `:ok` epoch, so the
-  buffer is empty when the depth limit trips. The halting event (the next
-  one that would have been dequeued) never ran, so it has no cascade
-  trace; this seam synthesises its `:halted-depth` record from the
-  explicit `trigger-event` so devtools (Xray, re-frame2-pair) get a
-  clear 'drain halted here' marker following the runaway `:ok` epochs.
+  "Commit a halt record for an event that never ran.
 
-  `frame-state-before` / `frame-state-after` are equal — the halting event
-  made no write (it never ran). Per rf2-nj6p7 the already-settled sibling events are
-  DURABLE (their `:ok` epochs and db writes survive); there is no
-  whole-drain rollback under per-event epochs — see the router's
-  `handle-depth-exceeded!` and the report note on the rule-3 reconcile.
-
-  PRINCIPLED SOURCE (rf2-bhu3a0): the halted-depth record's frame-state
-  is the durable LAST-SETTLED value, so this seam sources both
-  `frame-state-before` and `frame-state-after` from the most-recently-
-  settled epoch record's canonical `:frame-state-after` — the same value
-  `restore-epoch!` rewinds to — NOT from the live re-read the router
-  passes. The two coincide today (the halting event makes no write, so the
-  live frame-state still equals the last-settled value), so this is a
-  correctness-hardening, not a behaviour change: it removes the latent
-  dependence on the live container still holding the last-settled value at
-  the halt seam. When there is no last-settled record yet (a depth-exceed
-  on the very first cascade, before any `:ok` epoch landed), the
-  router-passed `frame-state-after` is the fallback.
-
-  Harvests-and-clears any residual buffer first so a stray pre-halt emit
-  (there should be none under per-event settling) can't leak into the
-  next cascade for this frame.
-
-  `committed-at` is the record's durable causal time — per EP-0010 §Time
-  and Spec 002 §The World-Input Rule (rf2-bh56rc) the halting causal
-  token's `:rf.cofx` `:rf/time-ms`, threaded down from the router's
-  `handle-depth-exceeded!` seam, NOT an ambient host-clock read. The
-  halting event never ran, but its envelope carries a `:time-ms` stamped
-  at its dispatch (the causal boundary); using it keeps even this
-  synthesised `:halted-depth` marker replayable.
-
-  See also `settle!` — the clean-path sibling that handles every per-
-  event `:ok` settle. Both fns share the private `commit-record!`
-  helper; `settle!` lets `build-record` derive the trigger from the
-  harvested buffer (an `:event/run-start` is always present on the
-  clean path) and skips on an empty buffer."
+  Earlier events in the drain already committed and remain durable. Because
+  the halting event has no run trace, this path uses its explicit event vector
+  and does not skip an empty capture. Both frame-state snapshots use the last
+  settled record's `:frame-state-after`; the router's live value is only the
+  fallback when no record has settled. The snapshots are equal because the
+  halted event made no write. Residual capture is cleared before commit, and
+  `committed-at` comes from the halted event's already-stamped envelope."
   [frame-id frame-state-before frame-state-after committed-at outcome halt-reason trigger-event]
   (when interop/debug-enabled?
     (let [events (state/harvest-buffer! frame-id)
-          ;; rf2-bhu3a0 — source the durable last-settled value from the
-          ;; canonical epoch record (the `:frame-state-after` restore uses)
+          ;; Source the durable value from the same snapshot restore uses,
           ;; rather than trusting the router's live re-read. Fall back to
           ;; the router-passed value when no `:ok` epoch has landed yet
           ;; (depth-exceed on the first cascade).
@@ -499,16 +280,10 @@
 
 ;; ---- restore --------------------------------------------------------------
 ;;
-;; Precondition validators, schema/handler/version probes, and
-;; `perform-restore!` live in `re-frame.epoch.tool-pair` (Phase-2 seam E,
-;; rf2-0wi86). The orchestrator below stays in the facade — it wires
-;; the precondition check + the trace emission + the perform step into
-;; a four-line case-match.
-
 (defn restore-epoch!
   "Rewind the frame to the named epoch's canonical `:frame-state-after`
   — the WHOLE frame-state, reinstalling app-db AND runtime-db as two
-  separate partitions in ONE atomic write (EP-0001 rf2-3aizt1: reviving
+  separate partitions in one atomic write (reviving
   machine snapshots, the route slice, elision declarations, and SSR
   metadata, not just the app-db partition). `:frame-state-after` is the
   only restore source — every record `build-record` emits carries it; the
@@ -522,8 +297,7 @@
     :rf.epoch/restore-during-drain     — called while drain is in flight
     :rf.epoch/restore-unknown-epoch    — epoch-id not in current history
     :rf.epoch/restore-non-ok-record    — target epoch's :outcome is not :ok
-                                         (per rf2-v0jwt — halted-cascade
-                                         records carry partial state and
+                                         (halted records carry partial state and
                                          are not valid restore targets)
     :rf.epoch/restore-schema-mismatch  — db-after no longer validates
     :rf.epoch/restore-missing-handler  — referenced registration absent
@@ -541,78 +315,17 @@
 
 ;; ---- replace-frame-state! (Tool-Pair §Pair-tool writes) -------------------
 ;;
-;; Per Tool-Pair §Pair-tool writes: the ONE public Tool-Pair write surface
-;; that installs a PARTIAL frame-state map into a frame's frame-state,
-;; bypassing the dispatch loop (rf2-t3lftq — API-shrink #3 consolidated the
-;; former four-mutator family — `replace-app-db!` / `reset-app-db!` /
-;; `replace-runtime-db!` / `replace-frame-state!` — into this). Used by
-;; pair-shaped tools for state injection (evolved-state-shape probes after a
-;; handler hot-swap), story tools, conformance harnesses, and time-travel
-;; from JSON-loaded bug repros. A present partition key replaces that
-;; partition; an absent key is preserved unchanged — a db-shaped key never
-;; silently touches the OTHER partition (Mike ruling #10, preserved and
-;; generalised).
-;;
-;; App-only injection is `(replace-frame-state! id {:rf.db/app v})`; the
-;; former `reset-app-db!` is `(replace-frame-state! id {:rf.db/app {}})`;
-;; runtime-only injection is `(replace-frame-state! id {:rf.db/runtime v})`;
-;; a both-partition install supplies both keys.
-;;
-;; The surface is dev-only — gated on `interop/debug-enabled?`, the same
-;; gate as `restore-epoch!` / `register-epoch-listener!` / the rest of the
-;; epoch-history machinery. Production builds (`:advanced` +
-;; goog.DEBUG=false) elide the body via Closure DCE; the surface is not
-;; available in shipped binaries.
-;;
-;; Failure modes (each is a no-op on the frame-state and returns `false`):
-;;   :rf.error/replace-frame-state-bad-keys — no recognized partition key, or
-;;                                              an unrecognized key — checked
-;;                                              before frame resolution
-;;   :rf.error/no-such-handler              (kind :frame) — frame not registered
-;;   :rf.epoch/replace-during-drain  — called while drain is in flight
-;;   :rf.epoch/replace-schema-mismatch — a PRESENT app-db partition fails the
-;;                                              frame's registered app-schema
-;;                                              set, or a PRESENT runtime-db
-;;                                              partition fails the
-;;                                              framework-owned validator
-;;   :rf.epoch/replace-history-disabled — epoch ring disabled (depth 0); the
-;;                                              synthetic undo-anchor cannot land
-;;                                              so the undo invariant is
-;;                                              unsatisfiable (rf2-unpldn)
-;;
-;; On success: records a synthetic `:rf/epoch-record` (so undo via
-;; `restore-epoch!` works against the previous state), emits
-;; `:rf.epoch/db-replaced`, replaces the container, and fires registered
-;; epoch listeners with the assembled record.
+;; Dev-only state injection outside the dispatch loop. Present partition keys
+;; replace their partition; absent keys preserve it. Every successful write
+;; records a synthetic epoch so it can be undone, which is why depth 0 refuses
+;; the operation rather than installing state without an undo anchor.
 
 (defn- record-synthetic-replace-epoch!
-  "Record a synthetic `:rf.epoch/db-replaced` epoch for a pair-tool
-  injection and fan it out. Called by the partial-frame-state-patch perform
-  helper (`perform-replace-frame-state!`) — the single lockstep-maintained
-  site for the synthetic-record / committed-at / redaction contract. `fs-before` /
-  `fs-after` are the pre- and post-replace coherent frame-state values;
-  restore of this synthetic record reinstalls `fs-after`, and restore of a
-  PRIOR epoch rewinds past the injection.
+  "Record and fan out one synthetic pair-tool epoch.
 
-  Per EP-0015 §15 + open-issue 6 (RULED): the synthetic record is stored
-  RAW (the ring is causal replay material); the `:redact-fn` advanced
-  override runs projection-side only, inside `projected-record`. Per
-  rf2-qs6dl: stamps the synthetic epoch as
-  the frame's last-settled so post-settle re-renders attribute back to it
-  rather than the next real cascade.
-
-  rf2-bh56rc: a pair-tool injection — no application event / causal token
-  is in flight, so `:committed-at` is the tool action's own wall-clock; the
-  ambient read happens HERE rather than inside the pure `build-record`
-  builder (per EP-0010 §Time — ambient time stays allowed for a tool
-  action's wall-clock).
-
-  rf2-czwwf4: `:committed-at` is a DURABLE epoch field, so the ambient read
-  uses `interop/epoch-now-ms` (wall-clock epoch ms, `js/Date.now()` on
-  CLJS) — NOT `interop/now-ms`, which on CLJS is `performance.now()`
-  (origin-relative, NOT for durable facts). This keeps a tool-injected
-  epoch's `:committed-at` in the same wall-clock CLASS as the
-  router-stamped epochs (EP-0010 §Time durable-timestamp rule)."
+  The record remains raw for replay and becomes the frame's last-settled
+  attribution anchor. With no application event in flight, `:committed-at`
+  uses `epoch-now-ms`: a durable wall-clock value, not the elapsed-time clock."
   [frame-id fs-before fs-after]
   (let [record (assoc (assembly/build-record frame-id fs-before fs-after []
                                              (interop/epoch-now-ms))
@@ -627,54 +340,21 @@
     record))
 
 (defn- perform-replace!
-  "Carry out a frame-state patch once preconditions have passed — the body
-  behind `perform-replace-frame-state!` (rf2-c0rv4v; formerly shared across
-  the three now-consolidated `perform-replace-app-db!` /
-  `perform-replace-runtime-db!` / `perform-replace-frame-state!` helpers).
-  `write-fn` is a 0-arg thunk that performs the `frame/replace-frame-state!`
-  partition write (the wrapper binds the frame-id + new partial map into
-  it); `fs-after-fn` builds the coherent post-replace frame-state from the
-  pre-replace `fs-before` (so restore of the synthetic epoch reinstalls the
-  right two-partition value). Returns `true` on a real write.
+  "Carry out a frame-state patch after preconditions pass.
 
-  Per rf2-7i872 (validate-then-destroy race): re-resolves the container at
-  the write boundary via `tool-pair/live-container-or-fail`. If the frame was
-  destroyed between the precondition pass and now, the container is nil and
-  `replace-container!` would silently no-op — so instead of recording a
-  synthetic epoch for a destroyed frame, fanning it out to listeners,
-  emitting `:rf.epoch/db-replaced`, and returning `true` (a FALSE success
-  against a frame that no longer exists), this emits the canonical
-  `:rf.error/no-such-handler` (kind `:frame`) failure trace and returns
-  `false`, matching the destroyed-frame contract.
-
-  Per rf2-s93722 (post-liveness teardown race): the liveness check closes
-  only HALF the window — a frame destroyed AFTER `live-container-or-fail`
-  passes but BEFORE the `frame/replace-*!` write actually lands still slips
-  through. The partition writers return `nil` for a destroyed frame (a
-  non-nil — possibly EMPTY — changed-key-set for a live frame, even a no-op
-  write), so we check that return: a `nil` return is the destroyed-frame
-  signal, surfaced as the same `:rf.error/no-such-handler` (kind `:frame`)
-  failure / `false` return BEFORE any synthetic epoch, listener fanout, or
-  success telemetry. On a real write records a synthetic epoch via
-  `record-synthetic-replace-epoch!` (single lockstep-maintained site for the
-  synthetic-record / committed-at / redaction contract — see that fn's
-  docstring for the rf2-bh56rc / rf2-czwwf4 / qs6dl rationale).
-
-  EP-0001 (rf2-adwcv6): the partition writes go through the `frame/replace-*!`
-  writers because `frame/app-db-container` / `runtime-db-container` are now
-  READ-ONLY projections, so a direct `replace-container!` on them throws."
+  Liveness is checked again at the write boundary. The write result closes the
+  remaining teardown race: nil means the frame disappeared before the write
+  landed, while any non-nil changed-key set, including empty, is a successful
+  live-frame write. Failure is reported before telemetry, listener fan-out, or
+  a synthetic epoch can claim success."
   [frame-id fs-after-fn write-fn]
   (let [{:keys [outcome op tags]} (tool-pair/live-container-or-fail frame-id)]
     (if (= :fail outcome)
       (do (tool-pair/emit-precondition-failure! op tags)
           false)
-      (let [;; EP-0001 (rf2-3aizt1): the canonical snapshot unit is the whole
-            ;; frame-state; `fs-after-fn` builds the coherent post-replace
-            ;; value (app-db-only / runtime-db-only / both-partition per the
-            ;; calling wrapper). Restore of the synthetic epoch reinstalls it.
-            ;; rf2-s93722: capture the write return — `nil` means the frame was
-            ;; destroyed in the post-liveness window (no write happened); a
-            ;; non-nil changed-key-set (even empty) means the write landed.
+      (let [;; Record the same coherent whole-frame value the write installs.
+            ;; Nil means teardown won the post-liveness race; an empty set is
+            ;; still a successful no-op write against a live frame.
             fs-before (frame/frame-state-value frame-id)
             fs-after  (fs-after-fn fs-before)
             changed   (write-fn)]
@@ -689,10 +369,8 @@
   "Carry out the partial frame-state patch once preconditions have passed.
   `new-frame-state` is a PARTIAL frame-state map (any subset of
   `{:rf.db/app … :rf.db/runtime …}`); a present key replaces that
-  partition, an absent key is carried forward unchanged from `fs-before`
-  (rf2-t3lftq — API-shrink #3; see `frame/replace-frame-state!`, which
-  already implements the present-replaces / absent-preserves contract via
-  `commit-frame-transition!`). The recorded after-state (`merge fs-before
+  partition, an absent key is carried forward unchanged from `fs-before`.
+  The recorded after-state (`merge fs-before
   new-frame-state`) mirrors that same contract so the synthetic epoch's
   `:frame-state-after` matches exactly what the write installed."
   [frame-id new-frame-state]
@@ -703,13 +381,9 @@
 (defn replace-frame-state!
   "Atomically install `new-frame-state` — a PARTIAL frame-state map (any
   subset of `{:rf.db/app … :rf.db/runtime …}`) — into `frame-id`'s
-  frame-state, bypassing the dispatch loop: a PRESENT key replaces that
-  partition, an ABSENT key is preserved unchanged (rf2-t3lftq — API-shrink
-  #3, consolidating the former `replace-app-db!` / `reset-app-db!` /
-  `replace-runtime-db!` / `replace-frame-state!` four-mutator family into
-  this ONE surface). A db-shaped key never silently touches the other
-  partition — the partition is named explicitly at every call site (Mike
-  ruling #10, preserved and generalised): app-only injection is
+  frame-state, bypassing the dispatch loop: a present key replaces that
+  partition, and an absent key is preserved. A db-shaped key never silently
+  touches the other partition: app-only injection is
   `{:rf.db/app v}`; runtime-only is `{:rf.db/runtime v}`; both-partition
   install supplies both keys. Per Tool-Pair §Pair-tool writes.
 
@@ -738,7 +412,7 @@
                                                    validator
     :rf.epoch/replace-history-disabled   — epoch ring disabled (depth 0);
                                                    the synthetic undo-anchor
-                                                   cannot land (rf2-unpldn)
+                                                    cannot land
 
   Dev-only — gated on `interop/debug-enabled?`. Production builds elide.
 
@@ -753,163 +427,64 @@
                   false)))))
 
 ;; ---- projected egress -----------------------------------------------------
-;;
-;; The projection helpers live in `re-frame.epoch.tool-pair` (Phase-2
-;; seam E, rf2-0wi86); the public docstrings stay here so the facade
-;; remains the canonical API reference.
 
 (defn projected-record
-  "Project an `:rf/epoch-record` for off-box egress. Routes the
-  app-db-rooted full-value payload slots (`:frame-state-before`,
-  `:frame-state-after`, `:db-before`, `:db-after`, `:trace-events`) through
-  the record-level egress boundary `re-frame.projection/project-egress`
-  under the selected `:rf.egress/profile` (default
-  `:rf.egress/off-box-observability`; tools pass `:rf.egress/off-box-tool`
-  — see §Egress profile below) against the record's frame, with the
-  off-box defaults `:include-sensitive? false` / `:include-large? false`.
-  `project-egress` resolves the named profile to the `:rf.size/*` opt set
-  and delegates each tree-shaped slot to the low-level walker
-  `re-frame.elision/elide-wire-value` (the walker is the delegated
-  primitive, NOT the egress boundary — name and validate the profile, not
-  the walker). Sensitive paths land as `:rf/redacted`; large paths land as
-  `:rf.size/large-elided` markers per the §Composition rule.
+  "Project an `:rf/epoch-record` for off-box egress.
 
-  The `:trigger-event` slot is NOT app-db-rooted (rf2-nm611o): the
-  dispatched event vector's ARGS are registration-owned transient payloads
-  (Spec 015 §151), the same class as the `:effects` `:args` — so it fails
-  closed instead. The args are redacted while the head event-id keyword
-  (the non-payload summary, == the record's `:event-id` slot) is retained,
-  so `[:login \"topsecret\"]` egresses as `[:login :rf/redacted]`. The same
-  event-args also ride the `:rf.event/v` / `:event` tags of every
-  `:trace-events` entry; they fail closed there too. The trusted-local
-  `:include-event-args? true` opt keeps the raw args.
+  This is the required boundary for forwarding records across a process,
+  logging, or tool wire. The in-process ring and listeners remain raw so
+  restore and local inspection retain exact state.
 
-  EP-0001 (rf2-3aizt1, decision #2 + Mike ruling #14): the CANONICAL
-  `:frame-state-before` / `:frame-state-after` slots egress with their
-  `:rf.db/app` partition elided (the same projection the `:db-*` app-db
-  projections get) and their `:rf.db/runtime` partition DEFAULT-REDACTED
-  to `:rf/redacted` off-box — machine snapshots / route slice / SSR
-  metadata do not egress to AI / log channels by default.
+  App-db-rooted slots are projected under the selected closed
+  `:rf.egress/profile`. Sensitive values become `:rf/redacted`; large values
+  become `:rf.size/large-elided` markers. Whole-frame slots project their
+  app-db partition and redact runtime-db by default.
 
-  The structured `:sub-runs` rows are ALSO value-bearing (rf2-at60h):
-  each carries the sub's computed `:prev-value` / `:value`, which respect
-  the projection contract (whole-output `:large?` rows have their value
-  slots substituted with the `:rf.size/large-elided` marker under the
-  `:include-large? false` default). The non-value row metadata (`:sub-id`,
-  `:query-v`, `:value-changed?`, `:cascade?`, `:cause-sub`,
-  `:cause-event-id`) passes through unchanged.
+  Payloads that are not app-db-rooted fail closed independently:
 
-  The structured `:effects` rows are payload-bearing too (rf2-rlt3sv):
-  each carries `:args` — the RAW fx-handler argument captured verbatim from
-  the `:rf.fx/args` trace tag, NOT routed through the marks-projection
-  chokepoint and NOT app-db-rooted, so the schema-path walker cannot prove
-  it safe. Off-box egress FAILS CLOSED: `:args` lands as `:rf/redacted` for
-  every outcome row under the `:include-fx-args? false` default. The
-  value-free `:fx-id` / `:outcome` / `:error-trace` row metadata and the
-  whole `:renders` projection pass through unchanged. The trusted-local
-  `:include-fx-args? true` opt keeps the raw `:args`. The record-level
-  bookkeeping (`:epoch-id`, `:frame`, `:committed-at`, `:event-id`,
-  `:outcome`, `:halt-reason`, `:schema-digest`, `:rf.epoch/sensitive?`,
-  `:rf.epoch/redacted-modified-paths-count`) also passes through
-  unchanged — it carries no app-db material.
+    - trigger and trace-event arguments retain only the event id;
+    - effect `:args` are redacted;
+    - sub-run values respect sensitive and large classification;
+    - unschematized HTTP bodies and resource-owned identities are redacted by
+      their dedicated projectors.
 
-  Per Security.md §Epoch privacy posture and rf2-mrsck: this is the
-  single normative projection emission site for off-box egress. Tools
-  that forward epoch records across a process boundary (Xray-MCP
-  `watch-epochs`, story / pair recorders, hosted post-mortem
-  forwarders) MUST route through this fn at the wire boundary; the
-  on-box ring buffer and `register-epoch-listener!` listener fan-out
-  continue to deliver the RAW record so on-box devtools (Xray diff,
-  REPL, `restore-epoch!`) can reason about exact state.
+  The configured `:redact-fn` runs once, after these built-in projections,
+  and never mutates the raw record.
 
-  `record` may be `nil` (e.g. a missing epoch lookup) — the projection
-  returns `nil` in that case, no elision called. Production builds
-  elide the entire epoch surface; consumers gate any
-  `register-epoch-listener!` registration under `interop/debug-enabled?`
-  per Spec 009 §User-side listener registration.
-
-  ## Egress profile (rf2-1afn7q) + opts (rf2-5w06uu)
-
-  The 2-arity accepts an `opts` map. The PRIMARY public selector is the
-  named egress boundary `:rf.egress/profile` (the shared closed
-  `re-frame.projection/profiles` enum) — it answers *\"which boundary is
-  this?\"* rather than assembling boolean combinations:
-
-    - `:rf.egress/off-box-observability` (DEFAULT) — hosted monitoring /
-      log shippers / Story / pair recorders (redact sensitive, elide large,
-      omit structural digests).
-    - `:rf.egress/off-box-tool` — the MCP / AI / tool wire. Same
-      redact/elide defaults but includes structural marker indicators
-      (`:digest`) so a tool can reason about an elided large slot's shape.
-      An MCP / AI epoch consumer (Xray-MCP `watch-epochs`, pair tool)
-      should pass this. An unknown profile is rejected against the closed
-      enum.
-
-  The unqualified `:include-*` keys are ADVANCED per-call overrides
-  composed OVER the selected profile (NOT the primary boundary selector) —
-  `{:include-sensitive? :include-large? :include-runtime-db?
-  :include-fx-args? :include-event-args?}`, all defaulting `false`.
-  `:include-sensitive?` / `:include-large?` opt the APP-DB partition's
-  privacy / size posture back in across every payload slot; they do NOT
-  lift the frame-state `:rf.db/runtime` partition boundary, which stays
-  `:rf/redacted` unless `:include-runtime-db? true` is also passed, NOR the
-  structured `:effects` `:args` (a different keyspace), which stay
-  `:rf/redacted` unless `:include-fx-args? true` is passed (rf2-rlt3sv),
-  NOR the `:trigger-event` / trace-event `:rf.event/v` args (another
-  keyspace), which stay redacted unless `:include-event-args? true` is
-  passed (rf2-nm611o). The 1-arity is the safe, fully-redacted off-box
-  path."
+  The default profile is `:rf.egress/off-box-observability`. MCP and AI tools
+  use `:rf.egress/off-box-tool`, which also includes structural marker
+  digests. Advanced trusted-local overrides are `:include-sensitive?`,
+  `:include-large?`, `:include-runtime-db?`, `:include-fx-args?`, and
+  `:include-event-args?`; each lifts only its own boundary. The 1-arity uses
+  safe defaults. Nil input returns nil."
   ([record] (tool-pair/projected-record record))
   ([record opts] (tool-pair/projected-record record opts)))
 
 (defn projected-history
   "Convenience: return the projected vector of records for a frame.
   Equivalent to `(mapv #(projected-record % opts) (epoch-history frame-id))`.
-  Tools that egress the whole ring (an MCP `watch-epochs` initial
-  snapshot, a recorder dumping the full session) can call this once
-  rather than walking the raw ring and re-wrapping each record. The
-  2-arity threads the trusted-local egress `opts` (rf2-5w06uu) to every
-  record; the 1-arity is the safe, fully-redacted off-box path."
+  The 2-arity threads egress `opts` to every record; the 1-arity uses the
+  safe off-box defaults."
   ([frame-id] (tool-pair/projected-history frame-id))
   ([frame-id opts] (tool-pair/projected-history frame-id opts)))
 
 ;; ---- late-bind hook registration ------------------------------------------
 ;;
-;; The router calls into settle! at drain-empty; the trace surface calls
-;; into capture-event! on every emit. Publishing through the late-bind
-;; registry keeps router.cljc / trace.cljc free of a require on this ns.
-;;
-;; Per rf2-lt4e (the seventh and final per-feature split per rf2-5vjj
-;; Strategy B), this namespace ships in `day8/re-frame2-epoch`; the
-;; core artefact MUST NOT statically `:require` it. Core's public
-;; re-exports (`rf/epoch-history`, `rf/restore-epoch!`) and the
-;; `:epoch` listener stream (`(rf/register-listener! :epoch …)` /
-;; `(rf/unregister-listener! :epoch …)`) and the
-;; `(rf/configure! {:epoch-history ...})` knob look the producing fns up
-;; through the hook table at call time; when this artefact is not on
-;; the classpath those queries return nil / empty / false and the
-;; (rf/configure! {:epoch-history ...}) call is a silent no-op — the
-;; epoch surface is dev-tier so an absent artefact degrades quietly
-;; rather than throwing.
-
-;; Per rf2-rtk2e: a single map-form publication reads as 'the late-bind
-;; contract for this artefact' rather than a column of identical
-;; imperative side-effects. Each entry is identical to a standalone
-;; `(late-bind/set-fn! key fn)` call; the drift gate
-;; (`re-frame.late-bind-drift-test`) walks both call shapes.
+;; The router calls `settle!` after each dequeued event, and trace emission
+;; calls `capture-event!`. Late binding keeps core independent of this optional
+;; artefact. Most absent-artefact reads degrade to empty/false/no-op; the state
+;; replacement facade raises because it cannot preserve its undo invariant
+;; without epoch storage.
 (late-bind/set-fns!
   {;; ---- per-cascade lifecycle (router + trace capture seam) -------
    :epoch/settle!             settle!
-   ;; rf2-nj6p7: per-event halt commit — the depth-exceed boundary whose
-   ;; halting event never ran (so the buffer is empty and `settle!` would
-   ;; skip). Synthesises the halting event's `:halted-depth` record.
+   ;; Per-event halt commit for a depth-exceeded event that never ran, so
+   ;; `settle!` would otherwise skip its empty buffer.
    :epoch/commit-halt-record! commit-halt-record!
    :epoch/capture-event       capture/capture-event!
-   ;; rf2-25zo2: in-flight run-cause lookup for :rf.view/rendered.
-   ;; Views consume this via `:epoch/run-cause` at render-emit time
-   ;; to stamp :cause-event-id + :cause-subs onto the per-render trace.
+   ;; In-flight cause lookup used to attribute render traces.
    :epoch/run-cause           capture/run-cause
-   ;; rf2-qs6dl: post-settle render back-fill. `capture-event!` routes a
+   ;; Post-settle render back-fill. `capture-event!` routes a
    ;; view-render op that fires with no in-flight cascade (a React-
    ;; commit-time async re-render) here so it is attributed to the
    ;; cascade that CAUSED it (the frame's most-recently-settled epoch)
@@ -918,11 +493,10 @@
    ;; publishing it through late-bind keeps `capture` free of a require
    ;; on `listeners` (which would close the assembly→capture cycle).
    :epoch/record-render!      listeners/record-render!
-   ;; rf2-wi900: post-settle sub-run back-fill — the subs sibling of
-   ;; `:epoch/record-render!`. Same React-deref-time async recompute
-   ;; problem; same attribution fix.
+   ;; Post-settle sub-run back-fill, parallel to render back-fill for the
+   ;; same React-deref-time attribution case.
    :epoch/record-sub-run!     listeners/record-sub-run!
-   ;; rf2-59hx3: post-settle view-unmount back-fill — the teardown sibling
+   ;; Post-settle view-unmount back-fill, the teardown sibling
    ;; of the two above. A `:rf.view/unmounted` fires at React teardown time,
    ;; after the cascade that removed the view settled — too late for the
    ;; capture seam. Back-fills it into the causing (most-recently-settled)
@@ -939,19 +513,14 @@
    :epoch/register-epoch-listener!   register-epoch-listener!
    :epoch/unregister-epoch-listener! unregister-epoch-listener!
    :epoch/configure!                 configure!
-   ;; rf2-yw1w1u: test-support config-isolation hook. `re-frame.test-
+   ;; Test-support config-isolation hook. `re-frame.test-
    ;; support`'s reset-hook table fires this to restore epoch config to
    ;; the shipped default between tests, keeping the private `state/config`
-   ;; var out of test namespaces. rf2-c0rv4v: points straight at the
-   ;; `state/reset-config!` seam (no facade wrapper).
+   ;; var out of test namespaces.
    :epoch/reset-config!              state/reset-config!
    :epoch/clear-history!             clear-history!
    :epoch/clear-epoch-listeners!     clear-epoch-listeners!
 
-   ;; ---- off-box egress projection (rf2-mrsck) ----------------------
-   ;; Per Security.md §Epoch privacy posture: off-box egress projection
-   ;; helpers, parallel to elide-wire-value for direct reads. Tools that
-   ;; forward records over a process boundary use these (Xray-MCP
-   ;; `watch-epochs`, story / pair recorders).
+   ;; ---- off-box egress projection ---------------------------------
    :epoch/projected-record    projected-record
    :epoch/projected-history   projected-history})

--- a/implementation/epoch/src/re_frame/epoch/assembly.cljc
+++ b/implementation/epoch/src/re_frame/epoch/assembly.cljc
@@ -1,35 +1,22 @@
 (ns re-frame.epoch.assembly
-  "Record assembly — the pure-data builder that takes a frame-id, the
-  before/after app-db snapshots, and the harvested cascade trace
-  events, and yields a fully-formed `:rf/epoch-record` map.
+  "Pure assembly of raw `:rf/epoch-record` values.
 
   Three responsibilities live here:
 
-    1. `build-record`   — produces the record (one allocation per
-                          DEQUEUED EVENT — per rf2-nj6p7 the epoch
-                          boundary is the event, not the drain).
-                          Delegates the cascade-buffer walks to
+    1. `build-record`   — produces one record per dequeued event and delegates
+                          capture-buffer walks to
                           `re-frame.epoch.capture`.
     2. `sensitive-rollup` — computes `:rf.epoch/sensitive?` from raw
                           signals (trace-event stamps + frame-declared
                           sensitive paths).
     3. `apply-redact-fn` — runs the installed `:redact-fn` advanced
-                          override at the OFF-BOX EGRESS boundary only
-                          (EP-0015 §15 + open-issue 6, RULED). The ring
-                          buffer + listener fan-out deliver the RAW
-                          record (causal replay material); redaction
-                          happens projection-side, inside
+                           override at off-box egress only. The ring and
+                           listeners retain raw replay material; redaction
+                           happens inside
                           `re-frame.epoch.tool-pair/projected-record`.
 
-  Plus the `current-schema-digest` accessor that both `build-record`
-  (digest pinned on the record) and the restore-preconditions seam
-  (`re-frame.epoch.tool-pair`) consume.
-
-  Per rf2-0wi86 Phase-2 seam D: this namespace is dependency-free
-  beyond state (atoms + counter), capture (cascade walks), and the
-  shared `re-frame.elision` / `re-frame.late-bind` / `re-frame.privacy`
-  / `re-frame.trace` libs. No upstream seam consumes it; downstream
-  seams (write, listeners, facade orchestrators) call into it."
+  `current-schema-digest` pins the schema identity later compared by restore
+  preconditions."
   (:require [re-frame.elision :as elision]
             [re-frame.epoch.capture :as capture]
             [re-frame.epoch.state :as state]
@@ -38,22 +25,11 @@
             [re-frame.privacy :as privacy]
             [re-frame.trace :as trace]))
 
-;; ---- consumer-facing outcome enum (rf2-18g1w) -----------------------------
+;; ---- consumer-facing outcome enum ----------------------------------------
 ;;
-;; The runtime's `:rf/epoch-record :outcome` enum carries the detailed CAUSE
+;; The record outcome carries the detailed close cause
 ;; of an epoch's close — `:ok` / `:halted-depth` / `:halted-destroy` /
-;; `:halted-handler-exception` (per Spec-Schemas §`:rf/epoch-record`
-;; §Outcomes, rf2-v0jwt). Consumers (Xray's Trace panel close-row, Story
-;; outcome chips) usually want a coarser tier: "did this epoch land
-;; cleanly, was it stopped, or did it error?". Per rf2-jppad / rf2-18g1w
-;; the runtime emits the consumer-facing tier directly as the separate
-;; trace op `:rf.epoch/outcome` (Spec 009) so the consuming spec
-;; (`tools/xray/spec/023-Trace-Panel.md` §13) doesn't have to re-derive
-;; the projection. The cause-enum on the epoch record stays; the new op
-;; is additive.
-;;
-;; Mapping (pinned in `epoch-test/outcome-enum-projection-pins-mapping`;
-;; load-bearing — devtools and trace-stream consumers depend on it):
+;; `:halted-handler-exception`. Trace consumers also receive a coarse tier:
 ;;
 ;;     :ok                       → :ok       (the cascade settled cleanly)
 ;;     :halted-depth             → :blocked  (the drain hit the depth limit;
@@ -72,12 +48,7 @@
 ;;                                            that aborts the drain on a
 ;;                                            handler throw.)
 (defn outcome->consumer-facing
-  "Project the detailed `:outcome` cause from the `:rf/epoch-record` enum
-  (`:ok` / `:halted-depth` / `:halted-destroy` / `:halted-handler-exception`,
-  per Spec-Schemas §`:rf/epoch-record` §Outcomes, rf2-v0jwt) onto the
-  three-tier consumer-facing summary (`:ok` / `:blocked` / `:error`, per
-  `tools/xray/spec/023-Trace-Panel.md` §13). Pure; total over the four
-  schema-pinned cause values. Per rf2-jppad / rf2-18g1w."
+  "Project the detailed record outcome onto `:ok`, `:blocked`, or `:error`."
   [outcome]
   (case outcome
     :ok                       :ok
@@ -91,7 +62,7 @@
   `:rf.epoch/outcome` carrying the consumer-facing `{:ok :blocked :error}`
   tier (via `outcome->consumer-facing`). Both ops share the same
   `:frame` / `:rf.epoch/id` / `:rf.trace/event-id` so consumers correlate
-  the detailed cause with the coarse summary (rf2-18g1w / rf2-jppad).
+  the detailed cause with the coarse summary.
 
   Shared by the per-event clean/halt settle (`re-frame.epoch/commit-record!`)
   and the mid-drain destroy commit (`re-frame.epoch.listeners/on-frame-
@@ -111,46 +82,16 @@
                 :rf.trace/event-id event-id
                 :outcome           (outcome->consumer-facing outcome)}))
 
-;; ---- projection-side redaction override (EP-0015 §15 / open-issue 6) ------
+;; ---- projection-side redaction override ----------------------------------
 
 (defn apply-redact-fn
-  "Apply the installed `:redact-fn` advanced override against an
-  already-projected `record` and return its result. nil `record` and
-  nil `redact` are pass-throughs (no invocation, no try/catch
-  overhead). A throwing fn emits `:rf.warning/epoch-redact-fn-exception`
-  carrying `:frame`, `:epoch-id`, and `:ex-msg`, then falls back to the
-  projected record so the egress itself is not broken. The warning's
-  epoch-identity tag is the canonical qualified `:rf.epoch/id` (rf2-ifdsar);
-  `:frame` is the bare-carve-out routing tag.
+  "Apply the configured advanced override to an already-projected record.
 
-  Per EP-0015 §15 (Epoch Redaction) + open-issue 6 disposition (RULED,
-  hardened): `:redact-fn` is the PROJECTION-SIDE-ONLY advanced override.
-  Epoch records are causal replay material (per EP-0010); mutating them at
-  rest would corrupt the replay contract, so storage stays raw. This
-  helper runs ONLY at the off-box egress boundary,
-  inside `re-frame.epoch.tool-pair/projected-record`, AFTER the
-  frame/profile `re-frame.projection/project-egress` projection. The ring
-  buffer + every `register-epoch-listener!` listener deliver the RAW
-  record so on-box devtools (Xray diff, REPL, `restore-epoch!`) reason
-  about exact state.
-
-  The fn is the rare advanced escape for material the declaration-driven
-  projection cannot prove (a sensitive slot no frame / schema declaration
-  covers); the ordinary case needs only the frame's `:sensitive` / `:large`
-  classification (EP-0015 §3) plus the per-slot schema props machine /
-  resource data carry, which `project-egress` already applies. Because it runs
-  on the projected egress COPY (the off-box record), it cannot affect
-  `restore-epoch!` fidelity — that hazard the §15 'may affect restore
-  fidelity' warning flagged is gone by construction.
-
-  Per Tool-Pair §Time-travel §Redaction hook (spec/Tool-Pair.md:101):
-  the warning MUST carry both `:frame` and `:rf.epoch/id` so a tool can
-  correlate the failure to the specific projected record that fell back.
-
-  Caller MUST wrap invocations in `(when interop/debug-enabled? ...)`
-  — the whole epoch surface shares that gate; this helper carries no
-  separate production gate. Cost when no fn is installed is a single
-  keyword lookup on the config map and an identity return."
+  Nil record or nil override is an identity operation. A throwing override
+  emits `:rf.warning/epoch-redact-fn-exception`, including frame and qualified
+  epoch identity, then returns the built-in projected record. This runs only at
+  egress; raw replay storage and listener delivery are never changed. Callers
+  own the shared debug gate."
   [record]
   (if-let [f (state/redact-fn)]
     (if (some? record)
@@ -163,11 +104,7 @@
           ;; (the projection helper is itself gated), so Closure DCE
           ;; elides the warning emit + literals under :advanced +
           ;; goog.DEBUG=false.
-          ;; Identity tag is the canonical qualified `:rf.epoch/id` (rf2-ifdsar):
-          ;; the trace-tag layer spells the epoch id `:rf.epoch/id` everywhere.
-          ;; The bare `:epoch-id` is the RECORD-field spelling we read FROM
-          ;; (`(:epoch-id record)`); it stays bare as part of the deliberate
-          ;; record/projection vocabulary — see Conventions §Trace/epoch identity.
+          ;; Trace identity is qualified; the record field read below is bare.
           (trace/emit! :warning :rf.warning/epoch-redact-fn-exception
                        {:frame       (:frame record)
                         :rf.epoch/id (:epoch-id record)
@@ -192,11 +129,11 @@
 
 ;; ---- sensitive rollup -----------------------------------------------------
 ;;
-;; Per Security.md §Epoch privacy posture and rf2-mrsck: every assembled
-;; record carries a top-level boolean `:rf.epoch/sensitive?` rollup so
+;; Every assembled record carries a top-level boolean
+;; `:rf.epoch/sensitive?` rollup so
 ;; listener fan-out, off-box egress, and recorder consumers can branch
 ;; on one slot per record (parallel to the trace-event-level
-;; `:sensitive?` stamp per rf2-isdwf). Two cheap signals:
+;; `:sensitive?` stamp). Two signals contribute:
 ;;
 ;;   1. The captured trace stream already stamps `:sensitive?` per
 ;;      handler-meta scope — if any event in `:trace-events` carries the
@@ -213,8 +150,7 @@
 
 (defn- any-sensitive-event?
   "True when any captured trace event carries a top-level `:sensitive?
-  true` stamp. Per privacy/sensitive? — the trace surface hoists the
-  boolean from handler-scope-meta to the event top level (rf2-isdwf)."
+  true` stamp. The trace surface hoists this boolean from handler scope."
   [events]
   (boolean (some privacy/sensitive? events)))
 
@@ -232,7 +168,7 @@
   `db`. nil-leaf paths do NOT count — the path is declared sensitive
   but the slot is empty, so the record carries no actual sensitive
   material from this signal. `db` is `:db-before` or `:db-after`; both
-  may be nil on halted paths (rf2-v0jwt :halted-destroy)."
+  may be nil on halted paths."
   [db sensitive-paths]
   (and (some? db)
        (boolean
@@ -248,7 +184,7 @@
   recorded db. Returns `false` otherwise (always a strict boolean —
   consumers branch on `(true? ...)` / `(false? ...)`).
 
-  HOT PATH: fires once per dequeued event (rf2-nj6p7). `sensitive-paths-for` derefs
+  Runs once per dequeued event. `sensitive-paths-for` derefs
   the elision registry once; the leaf check short-circuits at the
   first non-nil hit; the trace-event check short-circuits at the first
   stamped event. For the common case (no frame-declared sensitive
@@ -262,76 +198,22 @@
                (or (any-sensitive-leaf? db-before sensitive-paths)
                    (any-sensitive-leaf? db-after  sensitive-paths)))))))
 
-;; ---- redacted-modified-paths-count (rf2-dl3gx) ---------------------------
+;; ---- redacted-modified-paths-count ----------------------------------------
 ;;
-;; Per Security.md §Epoch privacy posture and rf2-dl3gx (follow-on to
-;; rf2-bz1cl's Xray-side heuristic chip): the record carries a
-;; top-level integer count of frame-declared sensitive paths
-;; (`[:rf.runtime/elision :sensitive-declarations]`) whose value differs between
-;; `:db-before` and `:db-after`. Computed inside `build-record` from RAW
-;; values BEFORE the installed `:redact-fn` runs — parallel to the
-;; `:rf.epoch/sensitive?` rollup pattern just above.
-;;
-;; ## Why the count exists
-;;
-;; When an app `:redact-fn` substitutes the `:rf/redacted` sentinel into
-;; both `:db-before` and `:db-after` at the same path (the standard
-;; pattern for keeping sensitive material out of recorded records), and
-;; the underlying value at that path actually changed across the
-;; cascade, the structural diff sees `:rf/redacted` on both sides and
-;; (correctly per the elision contract) emits no row. The developer
-;; sees an empty diff body and no signal that anything happened.
-;;
-;; The count closes that gap by recording, on the raw record, exactly
-;; how many frame-declared sensitive paths mutated this cascade.
-;; Downstream consumers (Xray's `redacted-paths-modified` chip per
-;; `tools/xray/spec/004-App-DB-Diff.md`, MCP wire pipeline, story
-;; recorders) read the integer directly rather than re-deriving from
-;; the post-redaction shape (which is heuristic — see the Xray helper
-;; for the heuristic's tightness and approximation notes).
-;;
-;; ## What counts
-;;
-;; A path P counts when:
-;;   1. P appears in `sensitive-paths-for frame-id`
-;;      (declared via the commit-plane `:sensitive` effect a handler
-;;      returns — EP-0025; the app-db elision registry
-;;      `[:rf.runtime/elision :sensitive-declarations]` is written by
-;;      those effects, not by a frame `:sensitive {:app-db …}` annotation
-;;      and not from schema `{:sensitive? true}` props).
-;;   2. `(not= (get-in db-before P) (get-in db-after P))`.
-;;
-;; The check uses **value-equality** on the raw (pre-redact-fn) dbs.
-;; Pointer-equality would over-count under `assoc-in` rewrites that
-;; produce a fresh subtree whose leaves are value-equal; `=` is the
-;; precise predicate for "did this leaf actually change."
-;;
-;; ## What this does NOT cover
-;;
-;; - `:redact-fn` substitutions at NON-frame-declared paths. The
-;;   redact-fn is opaque (record-in, record-out); the framework cannot
-;;   inspect "would the fn redact this leaf?" without running it. The
-;;   frame-declared sensitive-paths set is the framework's authoritative
-;;   "what would be redacted" oracle — apps that install a redact-fn
-;;   pointing at non-declared paths get the frame-declared count, not a
-;;   superset. (In practice apps either declare sensitive paths on the
-;;   frame or run a redact-fn covering the same paths; the two surfaces
-;;   compose at the frame-declaration site.)
-;; - Paths nominated as sensitive but with no live leaf (`nil` on both
-;;   sides) — `(= nil nil)` is true, so the path doesn't count. A
-;;   transition from non-nil to nil (or vice versa) counts as a value
-;;   change.
-;; - Production builds. The entire epoch surface elides under
-;;   `interop/debug-enabled?` false; the count is dev-only by
-;;   construction.
+;; A post-projection diff cannot reveal a sensitive change when both sides are
+;; the same redaction sentinel. The raw record therefore carries the number of
+;; classified sensitive app-db paths whose values differ between before and
+;; after. It uses value equality and counts nil/non-nil transitions. An opaque
+;; `:redact-fn` may redact additional undeclared paths; those cannot be inferred
+;; here and are deliberately outside this count.
 
 (defn redacted-modified-paths-count
   "Compute the record-level `:rf.epoch/redacted-modified-paths-count`
   rollup for the assembled record. Returns the integer count of
   frame-declared sensitive paths whose value differs between
-  `db-before` and `db-after` (per rf2-dl3gx).
+  `db-before` and `db-after`.
 
-  HOT PATH: fires once per dequeued event (rf2-nj6p7). `sensitive-paths-for` derefs
+  Runs once per dequeued event. `sensitive-paths-for` derefs
   the elision registry once and the walk is O(P) where P is the
   declared-sensitive-path count for the frame — typically a small
   constant (apps declare a handful of `[:auth :password]`-shaped
@@ -344,7 +226,7 @@
     - No classified-sensitive path's value differs across the cascade.
 
   Halted records: `db-before` and/or `db-after` may be `nil` on the
-  `:halted-destroy` path (per rf2-v0jwt). `(get-in nil P)` is `nil`;
+  `:halted-destroy` path. `(get-in nil P)` is `nil`;
   the predicate `(not= a b)` handles the nil/non-nil edge correctly
   (counts as a change when one side is nil and the other isn't)."
   [frame-id db-before db-after]
@@ -364,11 +246,9 @@
 
 (defn build-record
   "Assemble a `:rf/epoch-record`. `committed-at` is the record's durable
-  causal time — per EP-0010 §Time (epoch record causal time) and Spec 002
-  §The World-Input Rule it MUST be the committing causal token's
-  `:rf.cofx` `:rf/time-ms`, threaded down from the router's settle /
-  halt seam, NOT an ambient host-clock read at assembly time. Threading
-  the token's `:rf/time-ms` makes `:committed-at` replayable: replaying the
+  causal time: the committing token's `:rf/time-ms`, threaded from the
+  router rather than read from the host during assembly. This makes it
+  replayable: replaying the
   same event log with the same supplied `:rf/time-ms` values produces records
   with equal `:committed-at`, and a restored frame-state's recorded
   timestamps are not silently reinterpreted against a new ambient clock.
@@ -378,16 +258,13 @@
   to nil; both arities require `committed-at` (callers without a token — the
   pair-tool synthetic db-replace injections, which run with no application
   event in flight — pass `(interop/epoch-now-ms)` explicitly at the call
-  site, where the ambient wall-clock read is the honest answer for a tool
-  action, per EP-0010 §Time `Ambient time remains allowed for ...`. It is
+  site, where the ambient wall-clock read describes the tool action. It is
   the wall-clock surface, NOT `interop/now-ms` — `:committed-at` is a
-  durable field, kept wall-clock-class for cross-epoch comparison;
-  rf2-czwwf4)."
+  durable field, kept wall-clock-class for cross-epoch comparison)."
   ([frame-id frame-state-before frame-state-after events committed-at]
    (build-record frame-id frame-state-before frame-state-after events committed-at :ok nil))
   ([frame-id frame-state-before frame-state-after events committed-at outcome halt-reason]
-   ;; EP-0001 (rf2-3aizt1, decision #2): the CANONICAL snapshot unit is the
-   ;; whole frame-state (`{:rf.db/app … :rf.db/runtime …}`) — both partitions.
+   ;; The canonical snapshot is the whole frame state: both partitions.
    ;; `restore-epoch!` rewinds to `:frame-state-after`, reviving machines /
    ;; routes / elision / SSR runtime-db state, not just app-db. The
    ;; `:db-before` / `:db-after` slots are kept as the OPTIONAL app-db
@@ -395,11 +272,11 @@
    ;; app-db diffs cheaply without re-projecting (Spec-Schemas
    ;; §`:rf/epoch-record`). The two `db-*` projections are also what the
    ;; sensitive-path rollup + redacted-modified count read — frame-declared
-   ;; sensitive declarations target app-db paths (EP-0015 §3/§8), so the rollup
+   ;; sensitive declarations target app-db paths, so the rollup
    ;; reasons over the app-db projection, not the whole frame-state.
    ;;
-   ;; Per rf2-v0jwt §Outcomes — :outcome is required and pins the
-   ;; drain-boundary outcome. The reference runtime commits one of three:
+   ;; `:outcome` is required and pins the event-boundary result. The runtime
+   ;; commits one of three:
    ;; :ok / :halted-depth / :halted-destroy. (:halted-handler-exception
    ;; is a schema-reserved value the runtime never emits — handler
    ;; exceptions ride the interceptor error-capture seam and the drain
@@ -408,8 +285,7 @@
    ;; structured descriptor populated on halt paths, absent on :ok. The
    ;; schema in Spec-Schemas §:rf/epoch-record is the canonical pin.
    ;;
-   ;; Per rf2-kl5p1 (audit r3 §F1): `:event-id` and `:trigger-event`
-   ;; are emitted only when `find-trigger-event` resolves them. The
+   ;; Emit trigger slots only when `find-trigger-event` resolves them. The
    ;; schema declares `:event-id :keyword` (required, non-maybe) per
    ;; Spec-Schemas §`:rf/epoch-record` — emitting `:event-id nil` on a
    ;; halt path where no `:event/run-start` trace was buffered would
@@ -429,20 +305,13 @@
          {:keys [event-id event dispatch-id fx-overrides interceptor-overrides]
           trigger-cofx :rf.cofx}
          (capture/find-trigger-event events)
-         ;; Per rf2-ecu37: one fused walk producing all three
-         ;; projections, replacing three independent transducer
-         ;; passes over the same buffer. Mirrors `find-trigger-event`'s
-         ;; rf2-txrq9 single-walk pattern.
+         ;; One fused walk produces all structured projections.
          {:keys [sub-runs renders effects]} (capture/project-all events)
-         ;; Per rf2-mrsck and Security.md §Epoch privacy posture:
-         ;; the record-level boolean rollup mirrors the trace-event
-         ;; `:sensitive?` stamp (rf2-isdwf) so listener consumers and
-         ;; the projected-record helper branch on one slot per record.
+         ;; Listener and egress consumers can branch on one record-level slot.
          ;; Sensitive declarations target app-db paths, so it reasons over
          ;; the app-db projection (`db-before` / `db-after`).
          sensitive? (sensitive-rollup frame-id db-before db-after events)
-         ;; Per rf2-dl3gx and Security.md §Epoch privacy posture: the
-         ;; record-level integer counter of frame-declared sensitive
+         ;; Count frame-declared sensitive
          ;; paths whose value differs between :db-before / :db-after.
          ;; Closes Xray's "redact-fn ⇒ empty diff but something changed"
          ;; gap by surfacing the suppressed signal directly on the
@@ -452,27 +321,18 @@
                                    frame-id db-before db-after)]
      (cond-> {:epoch-id           (state/next-epoch-id)
               :frame              frame-id
-              ;; EP-0010 §Time (epoch record causal time) + Spec 002 §The
-              ;; World-Input Rule (rf2-bh56rc): the durable causal-time fact
-              ;; is the committing token's `:rf.cofx` `:rf/time-ms`,
-              ;; threaded in via `committed-at` — NOT an ambient
-              ;; `interop/now-ms` read at assembly time. The one `now-ms`
-              ;; read happens ONCE at the causal boundary (envelope
-              ;; construction, `re-frame.router/build-envelope`); it is not
-              ;; re-read in the commit path. This makes the record replayable:
-              ;; the same token replays to the same `:committed-at`.
+              ;; Durable causal time is supplied from envelope construction;
+              ;; assembly never re-reads the host clock.
               :committed-at       committed-at
-              ;; CANONICAL (decision #2): the whole frame-state both before
-              ;; and after — restore rewinds to `:frame-state-after`.
+              ;; Whole frame state before and after; restore uses the latter.
               :frame-state-before frame-state-before
               :frame-state-after  frame-state-after
               ;; OPTIONAL app-db projection — cheap tool diffs.
               :db-before          db-before
               :db-after           db-after
               :outcome            outcome
-              ;; Per Spec 010 §Schema digest — pinned at record time so a later
-              ;; restore can compare 'recorded vs current' digests in the
-              ;; :rf.epoch/restore-schema-mismatch trace tags. Optional per
+              ;; Pin schema identity so restore can compare recorded vs current.
+              ;; Optional per
               ;; Spec-Schemas §:rf/epoch-record (a host without a schema layer
               ;; produces nil; consumers tolerate the absent slot).
               :schema-digest      (current-schema-digest frame-id)
@@ -484,22 +344,21 @@
               :effects            effects}
        event-id    (assoc :event-id event-id)
        event       (assoc :trigger-event event)
-       ;; Per rf2-1xdotm — pin the POST-GENERATION flat `:rf.cofx` replay
+       ;; Pin the post-generation flat `:rf.cofx` replay
        ;; token (the causal cofx as it was after the router's declared-only
        ;; delivery ran: every generator-backed recordable fact minted at
        ;; processing-start written back into the in-flight `:rf.cofx`, plus
        ;; the framework `:rf/time-ms`). It is the slot a Tool-Pair replay
        ;; supplies alongside `:rf.cofx/mint-policy :strict` to re-present the
-       ;; EXACT facts the original run consumed (EP-0017 §Recordable coeffects
-       ;; + Tool-Pair §Replay-mint-policy). Spelled bare per the record-layer
-       ;; vocabulary (Spec-Schemas §`:rf/epoch-record`). Conditional `cond->`
-       ;; (rf2-kl5p1 shape): a halt path with no `:event/run-start` buffered,
+       ;; exact facts the original run consumed. Spelled bare per record-layer
+       ;; vocabulary (Spec-Schemas §`:rf/epoch-record`). A halt path with no
+       ;; `:event/run-start` buffered,
        ;; or a production build whose dev-only run-start cofx tag is elided,
        ;; omits the slot — which the open-map schema admits. The marks
        ;; chokepoint redacts declared-sensitive recordable facts at the emit
        ;; site, so the value pinned here is already projection-safe.
        trigger-cofx (assoc :rf.cofx trigger-cofx)
-       ;; Per rf2-rly4a — pin the settling cascade's `:dispatch-id` as a
+       ;; Pin the settling event's `:dispatch-id` as a
        ;; first-class record slot. It is the stable cross-counter-space
        ;; link between the epoch ring (epoch-id space) and the raw trace
        ;; stream's cascade list (dispatch-id space) that Xray's
@@ -513,7 +372,7 @@
        ;; omits the slot, matching `:event-id` / `:trigger-event`.
        dispatch-id (assoc :dispatch-id dispatch-id)
        halt-reason (assoc :halt-reason halt-reason)
-       ;; Per rf2-yigokd — pin the envelope's serializable per-call + lexical
+       ;; Pin the envelope's serializable per-call and lexical
        ;; `:fx-overrides` (fn-valued entries already marker-ized to
        ;; `:rf/fn-override` at the router's emission site) and per-call
        ;; `:interceptor-overrides` (EDN by construction — EP-0022) as

--- a/implementation/epoch/src/re_frame/epoch/capture.cljc
+++ b/implementation/epoch/src/re_frame/epoch/capture.cljc
@@ -1,6 +1,5 @@
 (ns re-frame.epoch.capture
-  "Per-cascade trace-buffer write/read and the two read-only walks the
-  drain-settle assembly path runs against the harvested events:
+  "Trace capture and read-only projection over one event's harvested buffer:
 
     capture-event!     -- the late-bind seam `re-frame.trace` invokes
                           on every emit, gated on `:frame`-tag presence
@@ -12,12 +11,7 @@
                           first `:rf.event/run-start`, with a `:event-id`-only
                           fallback.
 
-  Per rf2-0wi86 Phase-2 seam B: this namespace owns the cascade-buffer
-  *behaviour*; the buffer atom itself and the low-level
-  buffer-event! / harvest-buffer! mutators live in
-  `re-frame.epoch.state` (seam A). Splitting the catalogue + capture
-  + projection trio out of the facade keeps the cascade pipeline a
-  single grep target."
+  Buffer storage and low-level mutation live in `re-frame.epoch.state`."
   (:require [re-frame.epoch.state :as state]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]))
@@ -44,13 +38,9 @@
 ;; (`:rf.epoch.cb`) and emits AFTER the frame's ring buffer has been
 ;; dropped, so it can never race a future cascade for that frame.
 (def skip-ops
-  #{;; Drain-settle emit (after harvest-buffer! has emptied the buffer).
+  #{;; Event-settle emit, after harvest emptied the buffer.
     :rf.epoch/snapshotted
-    ;; rf2-18g1w — consumer-facing `{:ok :blocked :error}` outcome op.
-    ;; Emitted at the same cascade-trailer point as `:rf.epoch/snapshotted`
-    ;; (immediately after, with the buffer already harvested). Must be
-    ;; skipped for the same reason: re-buffering it would leak it into
-    ;; the next cascade's record.
+    ;; Consumer-facing outcome emitted beside `:rf.epoch/snapshotted`.
     :rf.epoch/outcome
     ;; restore-epoch! success + the six documented failure modes.
     :rf.epoch/restored
@@ -61,34 +51,25 @@
     :rf.epoch/restore-during-drain
     :rf.epoch/restore-non-ok-record
     ;; replace-frame-state! success (`:rf.epoch/db-replaced`) + all three of
-    ;; its precondition failure modes (Tool-Pair §Pair-tool writes). All fire
+    ;; its precondition failure modes. All fire
     ;; after the synthetic record has been built and the cascade-buffer (if
     ;; any) has been harvested — outside any cascade, each with a :frame tag.
-    ;; (The third failure op, `:rf.epoch/replace-history-disabled`, was added
-    ;; to skip-ops by rf2-gba3ou — see its dedicated note below; it was
-    ;; previously tracked-but-unskipped per rf2-f38xvb.)
     :rf.epoch/db-replaced
     :rf.epoch/replace-during-drain
     :rf.epoch/replace-schema-mismatch
-    ;; rf2-gba3ou / rf2-unpldn — depth-0 (history disabled) reject. The
+    ;; Depth-0 reject: the synthetic undo anchor cannot be stored.
     ;; synthetic undo-anchor cannot land in the disabled ring, so
     ;; replace-frame-state! rejects loudly with this op + a false return
-    ;; (`tool_pair/check-replace-frame-state-preconditions!`). It fires
-    ;; out-of-cascade with a :frame tag exactly like its two siblings
-    ;; above, so it must be skipped for the same reason. (Benign today —
-    ;; the orphan-drop branch backstops it — but skip-ops is the
-    ;; deliberate defense and the catalogue test now derives from the
-    ;; emit sites, so a forgotten op fails loudly.)
+    ;; It fires out of cascade with a frame tag like its siblings.
     :rf.epoch/replace-history-disabled
-    ;; Redact-fn exception warning (EP-0015 §15 + open-issue 6, RULED /
-    ;; Tool-Pair §Time-travel §Redaction hook). Emitted by
+    ;; Projection-time redact-fn exception warning. Emitted by
     ;; `assembly/apply-redact-fn` at PROJECTION time (`projected-record`),
     ;; which runs outside any cascade; if left un-skipped, the
     ;; `:frame`-tagged emit could accrete into a cascade's harvested
     ;; record for this frame.
     :rf.warning/epoch-redact-fn-exception})
 
-;; ---- render ops (rf2-qs6dl) -----------------------------------------------
+;; ---- render ops ------------------------------------------------------------
 ;;
 ;; The three view-render ops that fire at React COMMIT time — AFTER the
 ;; causing cascade settled (Reagent batches re-renders onto a later tick
@@ -102,7 +83,7 @@
     :rf.view/rendered
     :rf.view/rendered-cap-reached})
 
-;; ---- sub-run ops (rf2-wi900) ----------------------------------------------
+;; ---- sub-run ops -----------------------------------------------------------
 ;;
 ;; The subs sibling of render-ops. A `:rf.sub/run` (reactive recompute) or
 ;; `:rf.sub/skip` (memo hit) fires when a reaction is derefed — and reactions
@@ -120,7 +101,7 @@
   #{:rf.sub/run
     :rf.sub/skip})
 
-;; ---- unmount op (rf2-59hx3) -----------------------------------------------
+;; ---- unmount op ------------------------------------------------------------
 ;;
 ;; The view-teardown sibling of render-ops. `:rf.view/unmounted`
 ;; (`re-frame.views/emit-view-unmounted!`) fires when a registered-view
@@ -167,11 +148,7 @@
         (state/buffer-for frame-id)))
 
 (defn capture-event!
-  "Internal trace-capture entry point published through `re-frame.late-bind`
-  under `:epoch/capture-event`. `re-frame.trace/emit!` and
-  `re-frame.trace/emit-error!` invoke this for every event so the
-  cascade buffer is populated regardless of which user listeners are
-  registered.
+  "Capture one trace event through the `:epoch/capture-event` late-bind hook.
 
   Going through late-bind (rather than registering as a listener via
   `register-listener!`) ensures the user-facing `clear-listeners!`
@@ -185,41 +162,25 @@
   also skipped, so a snapshotted/restored/db-replaced emit cannot leak
   into the next cascade's harvested record.
 
-  Per rf2-qs6dl: a view-render op (`:rf.view/render` / `:rf.view/rendered`
-  / `:rf.view/rendered-cap-reached`) that arrives with no in-flight
+  A view-render op that arrives with no in-flight
   cascade for its frame is a post-settle async re-render — it fired at
   React commit time, AFTER the causing cascade settled. Routing it into
-  the now-empty buffer would mis-attribute it to the NEXT cascade (the
-  one-epoch lag the bead documents). Instead it is back-filled into the
+  the now-empty buffer would misattribute it to the next event. Instead it is
+  back-filled into the
   cascade that caused it via the `:epoch/record-render!` hook. A render
   that fires WITH a cascade in flight (synchronous flush) belongs to
   that cascade and is buffered as before.
 
-  Per rf2-wi900: the identical post-settle timing applies to reactive
-  sub-runs (`:rf.sub/run` / `:rf.sub/skip`) — reactions recompute lazily at
-  React deref time, AFTER the causing cascade settled, so a sub-run with
-  no in-flight cascade is back-filled into the causing epoch via the
-  `:epoch/record-sub-run!` hook (sibling of `:epoch/record-render!`). An
-  in-flight sub-run (a handler that subscribes, an SSR render) belongs to
-  the in-flight cascade and is buffered like any other in-flight emit.
-
-  Per rf2-59hx3: the same post-settle timing applies to a view UNMOUNT
-  (`:rf.view/unmounted`) — it fires at React teardown time, AFTER the
-  cascade that removed the view settled. With no in-flight cascade and no
-  `:dispatch-id` it would otherwise fall through the orphan-drop branch and
-  leave a view teardown with no signal, so it is back-filled into the
-  causing cascade (the most-recently-settled epoch) via the
-  `:epoch/record-unmount!` hook (sibling of the two above), where it rides
-  the epoch's `:trace-events` so Xray's VIEWS step can surface it. An
-  in-flight unmount (a synchronous teardown inside a drain) belongs to that
-  cascade and is buffered like any other in-flight emit."
+  The same timing applies to reactive sub-runs and view unmounts. They are
+  back-filled through their dedicated hooks when no event is in flight, while
+  synchronous occurrences stay in the current buffer."
   [event]
   (when interop/debug-enabled?
     (let [op       (:operation event)
           tags     (:tags event)
           frame-id (or (:frame tags)
                        (:frame event))]
-      ;; rf2-vh1k3 — learn which subs each view reads from the
+      ;; Learn which subscriptions each view reads from the
       ;; `:reader-render-key` stamp the runtime sets on a `:rf.sub/run`
       ;; that recomputes SYNCHRONOUSLY inside a view's render (the mount /
       ;; first-paint deref). A post-settle reactive recompute fires
@@ -248,7 +209,7 @@
             (record-render! frame-id event)
             (state/buffer-event! frame-id event))
 
-          ;; Post-settle sub-run — the subs sibling (rf2-wi900). Same
+          ;; Post-settle sub-run. Same
           ;; back-fill shape, distinct hook. Falls through to the normal
           ;; buffer path during the pre-facade-install load-order window.
           (and (contains? sub-run-ops op)
@@ -257,7 +218,7 @@
             (record-sub-run! frame-id event)
             (state/buffer-event! frame-id event))
 
-          ;; Post-settle view unmount — the teardown sibling (rf2-59hx3).
+          ;; Post-settle view unmount.
           ;; A `:rf.view/unmounted` fires at React teardown time, AFTER the
           ;; cascade that removed the view settled, so it carries a `:frame`
           ;; tag but no `:dispatch-id` and arrives with an empty buffer.
@@ -276,7 +237,7 @@
             (record-unmount! frame-id event)
             (state/buffer-event! frame-id event))
 
-          ;; Out-of-cascade orphan — drop from the capture buffer (rf2-avvwm).
+          ;; Drop an out-of-cascade orphan from the epoch capture buffer.
           ;; An emit with NO cascade context (no in-flight cascade for the
           ;; frame AND no `:dispatch-id` on its tags) belongs to no cascade:
           ;; a frame-lifecycle emit (`:rf.frame/created` / `:rf.frame/re-registered`)
@@ -304,12 +265,11 @@
           :else
           (state/buffer-event! frame-id event))))))
 
-;; ---- run-cause (for :rf.view/rendered attribution, rf2-25zo2) --------
+;; ---- run-cause for render attribution -------------------------------------
 ;;
-;; SENSE (rf2-p4cd9c): event-pipeline-run — this attributes a render/sub to
+;; This attributes a render/sub to
 ;; the EVENT RUN (one event's traversal) that drove it, keyed off the buffer's
-;; `:rf.event/run-start` marker. Renamed cascade-cause -> run-cause per the
-;; glw1bh event-pipeline vocabulary; NOT the reactive-graph sense.
+;; `:rf.event/run-start` marker, not to a reactive-graph run.
 ;;
 ;; The Xray Reactive panel needs to attribute each view re-render to the
 ;; run that drove it: which event kicked off this run, and which
@@ -331,7 +291,7 @@
   "Walk the frame's in-flight run buffer and return a small map
   attributing the current render to the dispatching run. Used by
   `:rf.view/rendered` emission (per [Spec 009 §`:rf.view/rendered`]
-  (009-Instrumentation.md#rfviewrendered) and rf2-25zo2). One pass
+  (009-Instrumentation.md#rfviewrendered)). One pass
   over the buffer; bounded `sub-cap` distinct sub-ids (default 100,
   matching the per-run view-render cap).
 
@@ -342,13 +302,11 @@
                       trigger event).
     :cause-subs     — distinct sub-ids that ran in the run so far,
                       in first-seen order, capped at sub-cap.
-    :value-changed-subs — the SUBSET of subs whose :rf.sub/run reported
-                      :rf.sub/value-changed? true (rf2-8wrzz.1). A `set`
+    :value-changed-subs — the subset of subs whose :rf.sub/run reported
+                      :rf.sub/value-changed? true. A `set`
                       of sub-ids, independently bounded by sub-cap: the
                       walk gates value-changed accumulation on its own
-                      count, mirroring the first-seen scan's cap on :subs
-                      (rf2-7n0kf — the value-changed scan is independent
-                      of the first-seen scan, so it needs its own guard).
+                      count, mirroring the first-seen scan's cap on :subs.
                       Used by the views.cljs emit site to derive
                       :rf.view/triggered-by — the first sub in THIS view's
                       own read-set whose value changed (the precise
@@ -386,12 +344,12 @@
                            (-> (update :subs conj (:rf.sub/id tags))
                                (update :seen conj (:rf.sub/id tags)))
 
-                           ;; rf2-8wrzz.1 — accumulate the value-changed
+                           ;; Accumulate the value-changed
                            ;; subset (a set, deduped) so the views.cljs emit
                            ;; site can derive :rf.view/triggered-by. A sub
                            ;; that ran multiple times in the cascade
-                           ;; contributes once (set semantics). rf2-7n0kf —
-                           ;; independently bounded by `sub-cap`: this scan
+                           ;; contributes once (set semantics). This scan is
+                           ;; independently bounded by `sub-cap` and
                            ;; gates value-changed accumulation on its OWN
                            ;; count, just as the first-seen scan above caps
                            ;; `:subs`. Without this guard a pathological
@@ -442,19 +400,19 @@
   row, or nil for any non-`:rf.sub/run` op (a `:rf.sub/skip` memo hit
   projects no `:sub-runs` row — it rides only `:trace-events`).
 
-  Per rf2-l1jz8 the reactive recompute path enriches the `:rf.sub/run` tag
+  The reactive recompute path enriches the `:rf.sub/run` tag
   with value-change + cascade attribution (`:value-changed?` /
   `:prev-value` / `:value` / `:cascade?` / `:cause-sub`); they are
   threaded onto the structured projection so Xray's Reactive panel reads
   them off the epoch record (not the raw trace). `compute-sub`'s base-
   shape emit omits them — the slots are simply absent there, which the
   panel's `sub-changed?` / `sub-cascaded?` predicates tolerate (false /
-  not-cascaded). The `:sensitive?` stamp on the trace event (rf2-isdwf)
+  not-cascaded). The `:sensitive?` stamp on the trace event
   governs whether `:prev-value` / `:value` already carry the
   `:rf/redacted` sentinel — they ride elide-wire-value at the emit site.
 
-  Per rf2-okz1u / rf2-1cc03 the reactive recompute path additionally
-  stamps `:rf.sub/cause-event-id` — the event-id (head keyword of the
+  The recompute path also stamps `:rf.sub/cause-event-id` — the event-id
+  (head keyword of the
   dispatching cascade's trigger event vector) of the cascade whose
   handler-body invalidated this sub's reactive input. The tag is
   OMITTED at the emit site (key absent, not nil) when the sub runs
@@ -465,9 +423,9 @@
   see nil and treat as no-attribution, parity with the OMITTED-vs-nil
   semantics of the trace tag.
 
-  PAYLOAD-BEARING value slots (rf2-at60h): `:prev-value` and `:value`
+  Payload-bearing value slots: `:prev-value` and `:value`
   carry the sub's computed app-data, so this row is NOT value-free. The
-  whole-output `:sensitive?` stamp (rf2-isdwf) is already honoured at the
+  whole-output `:sensitive?` stamp is already honoured at the
   marks emit site (`re-frame.classification/project-sub-tags`) — `:value` /
   `:prev-value` arrive carrying the `:rf/redacted` sentinel, so no further
   projection is needed for the sensitive case. The whole-output `:large?`
@@ -502,7 +460,7 @@
   the render-START marker — and `:rf.view/rendered-cap-reached` ride
   only `:trace-events`).
 
-  Per rf2-8wrzz.1 the projection sources from the POST-render
+  The projection sources from the post-render
   `:rf.view/rendered` op rather than the render-START `:rf.view/render`,
   because only the post-render op carries the per-view cause + timing the
   Xray Views panel needs — `:triggered-by` (the sub-id that caused this
@@ -518,15 +476,13 @@
                     bypassing reg-view (plain Reagent fns) use
                     `[:rf.view/anonymous nil]` as the documented fallback
                     (Spec-Schemas §`:rf/epoch-record`).
-    :mount?       — `true` on the instance's first render (rf2-9hoos).
+    :mount?       — `true` on the instance's first render.
     :triggered-by — (when derivable) the single sub-id that caused this
-                    re-render (rf2-8wrzz.1); absent on a structural render.
-    :elapsed-ms   — (when present) the render duration in fractional ms
-                    (rf2-8wrzz.1).
+                    re-render; absent on a structural render.
+    :elapsed-ms   — (when present) the render duration in fractional ms.
     :cause-event-id — (when present) the event-id of the cascade whose
                     handler-body invalidated a reactive input this view
-                    deref'd, triggering the re-render (rf2-1cc03 /
-                    rf2-9gquv). The `:rf.view/rendered` op stamps
+                    deref'd, triggering the re-render. The `:rf.view/rendered` op stamps
                     `:rf.view/cause-event-id` (views.cljs) under the same
                     OMITTED-vs-nil semantics as the sub-row's
                     `:rf.sub/cause-event-id`: absent (not nil) for a render
@@ -562,19 +518,17 @@
 
   Fusing the three projections into one reducer pass keeps the buffer walk
   to N operation reads for an N-event drain (three independent `into []`
-  transducer walks would cost 3·N). Mirrors `find-trigger-event`'s style
-  (rf2-txrq9): one traversal, multiple accumulators, single allocation
-  budget.
+  transducer walks would cost 3·N): one traversal, multiple accumulators,
+  and a single allocation budget.
 
   Per-projection contracts preserved verbatim (no schema change):
 
     :sub-runs — Spec-Schemas §`:rf/epoch-record`. One entry per
-      `:rf.sub/run` trace event. Cache-hit subs (rf2-719e fast-path) do
+      `:rf.sub/run` trace event. Cache-hit subs do
       NOT emit `:rf.sub/run` and are correctly absent.
 
     :renders — Spec-Schemas §`:rf/epoch-record` and Spec 004 §Render-tree
-      primitives (rf2-t5tx Option C / rf2-piag). One entry per
-      `:rf.view/rendered` op (the POST-render marker, rf2-8wrzz.1).
+      primitives. One entry per `:rf.view/rendered` post-render marker.
       `:render-key` is the `[<view-id> <instance-token>]` tuple; renders
       bypassing reg-view (plain Reagent fns) use `[:rf.view/anonymous nil]`
       as the documented fallback. Each row also carries the per-view
@@ -606,7 +560,7 @@
                 (let [op   (:operation ev)
                       tags (:tags ev)]
                   (cond
-                    ;; Per rf2-l1jz8 — the reactive recompute path enriches
+                    ;; The reactive recompute path enriches
                     ;; the `:rf.sub/run` tag with value-change + cascade
                     ;; attribution; `sub-run-row` threads them onto the
                     ;; structured projection (shared with the post-settle
@@ -614,7 +568,7 @@
                     (= :rf.sub/run op)
                     (assoc! acc :s (conj! (get acc :s) (sub-run-row ev)))
 
-                    ;; rf2-8wrzz.1: source the :renders projection from the
+                    ;; Source the :renders projection from the
                     ;; POST-render :rf.view/rendered op (carries per-view
                     ;; cause + timing), not the render-START :rf.view/render.
                     (= :rf.view/rendered op)
@@ -662,93 +616,19 @@
 ;; ---- trigger-event resolution --------------------------------------------
 
 (defn find-trigger-event
-  "Walk the buffered events to find the first :rf.event/run-start trace.
-  That carries the `:event`, `:event-id`, `:dispatch-id`, the
-  post-generation `:rf.cofx` replay token, AND (rf2-yigokd) the envelope's
-  serializable `:fx-overrides` / `:interceptor-overrides` for the cascade.
+  "Resolve replay and identity data from one event's buffered traces.
 
-  Per rf2-yigokd: `:fx-overrides` (already marker-ized for fn-valued entries
-  at the router's emission site) and `:interceptor-overrides` are the
-  envelope's OWN per-call + lexical override maps (never the per-frame tier)
-  — surfaced here so `build-record` can pin them as first-class epoch-record
-  slots beside `:rf.cofx`, letting a Tool-Pair strict replay re-supply the
-  exact overrides the original run had active.
+  The first `:rf.event/run-start` supplies event identity, dispatch id,
+  post-generation coeffects, and serializable per-call/lexical overrides.
+  Dispatch id is pinned independently of raw trace retention. Without a
+  run-start, the first event-id is a limited fallback; no event vector or
+  dispatch id is fabricated when its source tag is absent.
 
-  Per rf2-1xdotm: the run-start's `:rf.event/cofx` tag is the POST-
-  GENERATION flat `:rf.cofx` map (the causal cofx as it was after the
-  router's declared-only delivery ran — every generator-backed recordable
-  fact minted at processing-start written back into the in-flight
-  `:rf.cofx`, plus the framework `:rf/time-ms`). It is surfaced here so
-  `build-record` can pin it as a first-class `:rf.cofx` slot, and a
-  Tool-Pair replay can re-present the EXACT facts the original run consumed
-  under `:rf.cofx/mint-policy :strict` (EP-0017 §Recordable coeffects +
-  Tool-Pair §Replay-mint-policy). The slot is dev-only at the source (the
-  run-start emit is gated on `interop/debug-enabled?`) and absent on the
-  fallback arm (a no-run-start cascade carried no delivered cofx).
-
-  When the cascade had no successful event handler (e.g. an unknown
-  event id or a frame-destroyed dispatch), no :run-start fires; fall
-  back to the first event we can find with an `:event-id` tag. Per
-  rf2-7kxxx (audit r3 §F2): if that fallback event carries no `:event`
-  tag we DO NOT synthesise `[eid]` — that would misrepresent an event
-  that originally carried payload as payload-less. `build-record`'s
-  conditional `cond->` (rf2-kl5p1) omits the `:trigger-event` slot
-  when `:event` is nil, which the schema's open map admits.
-
-  Per rf2-rly4a: the run-start's `:dispatch-id` is surfaced here so
-  `build-record` can pin it as a first-class `:dispatch-id` slot on the
-  epoch record. The settling cascade's id is the record's stable
-  cross-counter-space link to the raw trace stream's cascade list — and
-  must NOT depend on `:trace-events` (which `:trace-events-keep` elides
-  on older records and the post-settle reactive back-fill pads with
-  nil-`:dispatch-id` events). Xray's `:rf.xray/focus` epoch-id
-  correlation walks this slot rather than `:trace-events` tags, which
-  return nil whenever the focused cascade's epoch has its raw stream
-  elided — that would starve the epoch-scoped Views + Trace panels.
-
-  Per rf2-txrq9: single-walk reduction over `events`. We accumulate the
-  first `:rf.event/run-start`, the first fallback `:event-id`, AND
-  (rf2-cheez6.1, below) the cascade's mid-drain machine-minted generator
-  facts in one traversal and prefer the run-start.
-
-  Per rf2-cheez6.1 / rf2-08br0v — augment the run-start's `:rf.cofx`
-  replay token with generator facts MINTED MID-DRAIN. The run-start
-  token (`:rf.event/cofx`) is the cofx as it was after the router's
-  PRE-handler declared-only delivery — every fact `assemble-initial-ctx`
-  minted for the OUTER event's declared `:rf.cofx/requires`. But a state
-  machine declares no requires on its outer event; its guard/action
-  facts are minted INSIDE the handler (`ensure-ctx-cofx` pre-drain,
-  `ensure-raised-cofx` in-drain for a raise-selected guard), AFTER
-  run-start was emitted, and are written onto the engine-local machine
-  def — they never flow back to the ctx coeffects the run-start read.
-  Without this merge the token would carry only externally-supplied facts,
-  and a `:strict` replay (mint-policy-aware, rf2-n0myjq) of a machine
-  decision gated on such a fact would diverge: the missing fact →
-  missing-required while the live run minted a value.
-
-  Every actual recordable mint — pre-handler in `assemble-initial-ctx`
-  AND mid-drain in the machine ensure steps — emits a dev-only
-  `:rf.cofx/generated` trace (`re-frame.cofx/run-generator`) carrying
-  `:rf.cofx/id` + the marks-PROJECTED `:rf.cofx/value` (sensitive slots
-  already `:rf/redacted` at the emit site, rf2-0mjgx6). Those emits ride
-  the SAME in-flight cascade buffer this walks. So we collect them and
-  merge `{id → value}` onto the run-start token. Properties:
-
-    - LIVE behaviour is untouched — this is the read-only epoch-assembly
-      walk; nothing in the dispatch path changes.
-    - No OVER-capture — only facts a generator ACTUALLY minted emit
-      `:rf.cofx/generated` (an ambient supplier emits `:rf.cofx/run`, NOT
-      generated; a replayed/supplied recordable fact emits nothing). The
-      recordability + redaction contract is honoured at the trace source.
-    - IDEMPOTENT for the ordinary event path: a fact minted pre-handler
-      is ALREADY in the run-start token verbatim AND re-presented here
-      with the identical value, so the merge is a no-op there. The merge
-      adds value only for the mid-drain machine mints the token missed.
-
-  On `:strict` replay a token that now carries the minted fact short-
-  circuits `deliver-declared-cofx`'s present-on-token branch (delivers
-  the recorded value verbatim, no host read) — so the replayed machine
-  decision matches the live one. Determinism restored."
+  The same walk collects `:rf.cofx/generated` traces that occur after
+  run-start, notably generator facts minted inside machine guards/actions.
+  Merging those projected values into the initial token makes strict replay
+  re-present every fact the run consumed. Pre-handler mints merge
+  idempotently; later same-id mints win in event order."
   [events]
   (let [result
         (reduce
@@ -763,16 +643,11 @@
                 ;; the same buffer is impossible (one per cascade), so the
                 ;; first-seen guard keeps the slot stable.
                 ;;
-                ;; Tag-key reads use the :rf.* namespaced scheme
-                ;; (rf2-y4qpy.2); the run-start's :dispatch-id is surfaced
-                ;; as a first-class return slot (rf2-rly4a) read off the
-                ;; namespaced :rf.trace/dispatch-id tag. Per rf2-1xdotm the
-                ;; post-generation `:rf.cofx` replay token rides the run-start
-                ;; under `:rf.event/cofx` (dev-only at source) and is surfaced
-                ;; here so `build-record` pins it as a first-class slot.
+                ;; Surface dispatch id and post-generation replay coeffects
+                ;; from their namespaced run-start tags.
                 ;;
-                ;; Per rf2-yigokd: the envelope's serializable
-                ;; `:fx-overrides` / `:interceptor-overrides` ride the SAME
+                ;; Serializable `:fx-overrides` / `:interceptor-overrides` ride
+                ;; the same
                 ;; run-start emit under `:rf.event/fx-overrides` /
                 ;; `:rf.event/interceptor-overrides` (dev-only at source,
                 ;; already marker-ized for fn-valued fx entries at the
@@ -792,8 +667,8 @@
                                        :interceptor-overrides
                                        (:rf.event/interceptor-overrides tags)})
 
-                ;; rf2-cheez6.1 / rf2-08br0v — accumulate every generator-
-                ;; minted recordable fact in cascade order. `:rf.cofx/value`
+                ;; Accumulate every generator-minted recordable fact in event
+                ;; order. `:rf.cofx/value`
                 ;; is the marks-projected produced value (redaction already
                 ;; applied at the emit site). A later same-id mint (a raise
                 ;; that re-mints) wins last-write — the LAST value the cascade
@@ -805,19 +680,18 @@
                   (assoc-in [:minted (:rf.cofx/id tags)] (:rf.cofx/value tags)))
 
                 ;; Capture the first :event-id we see as the fallback.
-                ;; Per rf2-7kxxx: do NOT fabricate `:event` — when the
+                ;; Do not fabricate `:event`; when the
                 ;; tag is absent we leave the field nil so downstream
                 ;; build-record omits a misleading synthesised vector.
                 ;;
-                ;; Per rf2-ee38b (§correctness): the fallback arm does NOT
-                ;; pin `:dispatch-id`. Spec-Schemas §`:rf/epoch-record`
+                ;; The fallback arm does not pin `:dispatch-id`. The record schema
                 ;; documents `:dispatch-id` as "pinned from the
                 ;; `:rf.event/run-start` tag … absent when the cascade carried
                 ;; no dispatch-id (rejected dispatch / pre-run-start halt)"
                 ;; — the strictly-spec shape for a no-run-start cascade is
                 ;; ABSENT. Pinning `:dispatch-id` here would surface the id
                 ;; of an arbitrary non-run-start trace (e.g. an error trace
-                ;; from a rejected dispatch); the run-start arm (rf2-rly4a)
+                ;; from a rejected dispatch); the run-start arm
                 ;; is the canonical source for it, so only that arm above
                 ;; pins `:dispatch-id`.
                 (and (nil? (:fallback acc)) (some? (:rf.trace/event-id tags)))
@@ -827,7 +701,7 @@
                 :else acc)))
           {}
           events)
-        ;; rf2-cheez6.1 — merge the cascade's minted facts onto the run-start
+        ;; Merge generated facts onto the run-start
         ;; replay token. Token base, minted overlaid: the ordinary event path
         ;; already carries pre-handler mints verbatim (no-op merge), while a
         ;; machine's mid-drain mints — absent from the token — fill in. Only

--- a/implementation/epoch/src/re_frame/epoch/listeners.cljc
+++ b/implementation/epoch/src/re_frame/epoch/listeners.cljc
@@ -1,43 +1,30 @@
 (ns re-frame.epoch.listeners
-  "Epoch-listener fan-out + frame-destroy hook.
+  "Epoch listener fan-out and frame teardown.
 
   Two responsibilities live here:
 
     1. `notify-listeners!` — fan a built record out to every registered
        `register-epoch-listener!` callback. Each invocation is wrapped in a
        try/catch so one broken listener cannot break the runtime or
-       block other listeners (Spec 009 §Listener invocation rules); a
+       block other listeners; a
        failing cb emits `:rf.epoch.cb/listener-exception` so devtools
-       can surface the broken consumer (rf2-i5khp).
+       can surface the broken consumer.
 
     2. `on-frame-destroyed!` — the late-bind hook
        `re-frame.frame/destroy-frame!` invokes against the
        `:epoch/on-frame-destroyed` slot. Coordinates the four-step
-       destroy contract (rf2-d656 + rf2-v0jwt + rf2-zzper):
+       destroy contract:
 
          (a) mid-drain destroy detection → commit a `:halted-destroy`
              partial record (carrying the real pre-cascade `:db-before`
-             + destroy-time `:db-after` snapshots threaded by
-             `destroy-frame!`, per rf2-9neiq) to listeners (NOT to the
-             ring buffer — `epoch-history` is read-empty post-destroy
-             per rf2-d656).
+              and destroy-time snapshots) to listeners, not the ring.
          (b) emit `:rf.epoch.cb/silenced-on-frame-destroy` once per cb
              whose observed-frames set contained `frame-id`.
          (c) drop the per-frame ring buffer.
          (d) drop the in-flight capture buffer.
 
-  Per the Phase-1 finding (rf2-0wi86): on-frame-destroyed straddles
-  state (the three atoms it clears), capture (its mid-drain detection
-  reads the cascade buffer), and assembly (it builds a partial
-  record). This namespace is the rightful home — the destroy contract
-  IS the listener-side surface for frame teardown, and the
-  cross-cutting calls are now explicit cross-namespace requires
-  rather than forward-declares within a single 1500-LoC file.
-
-  Public re-frame.epoch facade fns (register-epoch-listener!,
-  unregister-epoch-listener!, clear-epoch-listeners!, on-frame-destroyed!) delegate
-  here; the listener-registry atom + record-observation bookkeeping
-  live in `re-frame.epoch.state` (seam A)."
+  Listener registry and observation bookkeeping live in
+  `re-frame.epoch.state`."
   (:require [re-frame.epoch.assembly :as assembly]
             [re-frame.epoch.capture :as capture]
             [re-frame.epoch.state :as state]
@@ -48,8 +35,7 @@
   "Fan `record` out to every registered `:rf/epoch-record` listener.
 
   Each cb is invoked once per record, wrapped in failure isolation:
-  Per Spec 009 §Listener invocation rules listener failures don't
-  stop the loop; per rf2-i5khp a failing cb emits a structured
+  Listener failures do not stop the loop. A failing callback emits a structured
   `:rf.epoch.cb/listener-exception` trace so devtools can surface
   the broken listener (silently swallowing the throw left tool
   authors with no signal that their callback failed).
@@ -68,12 +54,7 @@
       (try
         (f record)
         (catch #?(:clj Throwable :cljs :default) ex
-          ;; Identity tag is the canonical qualified `:rf.epoch/id` (rf2-ifdsar):
-          ;; the trace-tag layer spells the epoch id `:rf.epoch/id` everywhere
-          ;; (matching the `:rf.epoch/restore-*` rows + `emit-snapshotted+outcome!`).
-          ;; The bare `:epoch-id` is the RECORD-field spelling we read FROM
-          ;; (`(:epoch-id record)`), kept bare as part of the deliberate
-          ;; record/projection vocabulary — see Conventions §Trace/epoch identity.
+          ;; Trace identity is qualified; the source record field is bare.
           (trace/emit-error! :rf.epoch.cb/listener-exception
                              {:frame       frame-id
                               :cb-id       id
@@ -82,26 +63,24 @@
                                               :cljs (.-message ex))
                               :recovery    :no-recovery}))))))
 
-;; ---- post-settle render back-fill (rf2-qs6dl) -----------------------------
+;; ---- post-settle render back-fill -----------------------------------------
 
 (defn record-render!
-  "Attribute a post-settle render emit to the cascade that CAUSED it
-  (rf2-qs6dl), refined for the mount-render case (rf2-vh1k3).
+  "Attribute a post-settle render emit to the event that caused it.
 
   A `:view/render` / `:rf.view/rendered` trace fires at React commit
   time — AFTER the causing cascade settled — so it cannot ride the
-  in-flight cascade buffer (there is none). rf2-qs6dl back-filled it into
+  in-flight cascade buffer. Back-filling it into
   the frame's most-recently-settled epoch; that is right for a genuine
   reactive re-render but wrong for a MOUNT render whose commit lands late
   (React batches a freshly-mounted component's render onto a later tick,
   so it can commit AFTER the first user cascade settles). Attributed to
   last-settled, a mount render leaks spuriously into the first post-mount
-  cascade's `:renders` (the rf2-vh1k3 defect: parallel-frames' title-view
-  appearing in the first counter-inc epoch though its subs never changed).
+  cascade's `:renders`.
 
   `state/resolve-render-epoch` picks the right anchor: the newest epoch
   where the rendering view's OWN inputs changed (a real re-render rides
-  its causing cascade exactly as rf2-qs6dl intends), else the view's
+  its causing cascade), else the view's
   MOUNT epoch (a mount / mount-burst tail anchors where the instance
   first rendered), else the most-recently-settled epoch (a brand-new
   instance whose first render commits post-settle — the settling cascade
@@ -139,16 +118,8 @@
                        (not= target default-epoch)
                        (state/render-key-already-in-epoch?
                          frame-id target render-key))
-          ;; EP-0015 §15 + open-issue 6 (RULED, hardened): the back-fill
-          ;; appends the RAW render event (to `:trace-events`) + the RAW
-          ;; projected row (to `:renders`). The ring is causal replay
-          ;; material, so it stays raw; the `:redact-fn` advanced override
-          ;; runs projection-side only, inside
-          ;; `projected-record`, so the off-box egress (Xray-MCP
-          ;; `watch-epochs`, recorders) sees the redacted shape while the
-          ;; ring + this listener fan-out deliver the raw record. No
-          ;; per-back-fill redact invocation means no storage-side leak to
-          ;; close and no non-idempotent-fn hazard.
+          ;; Back-fill stores the raw event and row; egress projection remains
+          ;; the only redaction boundary.
           (when-let [updated (state/back-fill-render! frame-id target event
                                                       (capture/render-row event))]
             ;; Re-fan the corrected record so snapshot consumers re-read
@@ -159,11 +130,10 @@
             ;; loop back into this path.
             (notify-listeners! updated)))))))
 
-;; ---- post-settle sub-run back-fill (rf2-wi900) ----------------------------
+;; ---- post-settle sub-run back-fill ----------------------------------------
 
 (defn record-sub-run!
-  "Attribute a post-settle sub-run emit to the cascade that CAUSED it
-  (rf2-wi900). The subs sibling of `record-render!`: a `:sub/run` /
+  "Attribute a post-settle sub-run to the event that caused it. A `:sub/run` /
   `:rf.sub/skip` trace fires when a reaction recomputes, and reactions
   recompute lazily at React deref time — AFTER the causing cascade settled
   — so it cannot ride the in-flight cascade buffer (there is none). This
@@ -179,12 +149,7 @@
   [frame-id event]
   (when interop/debug-enabled?
     (when-let [epoch-id (state/last-settled-epoch-id frame-id)]
-      ;; EP-0015 §15 + open-issue 6 (RULED): the back-fill appends the RAW
-      ;; sub-event (to `:trace-events`) + the RAW `:sub-runs` row. The ring
-      ;; + listener fan-out deliver the raw record; the `:redact-fn`
-      ;; advanced override runs projection-side only (inside
-      ;; `projected-record`), so the off-box egress sees the redacted shape
-      ;; (see `record-render!`).
+      ;; Store raw; projection remains the egress boundary.
       (when-let [updated (state/back-fill-sub-run! frame-id epoch-id event
                                                    (capture/sub-run-row event))]
         ;; Re-fan the corrected record so snapshot consumers re-read the
@@ -192,11 +157,11 @@
         ;; render back-fill above.
         (notify-listeners! updated)))))
 
-;; ---- post-settle view-unmount back-fill (rf2-59hx3) -----------------------
+;; ---- post-settle view-unmount back-fill -----------------------------------
 
 (defn record-unmount!
-  "Attribute a post-settle view-unmount emit to the cascade that CAUSED the
-  teardown (rf2-59hx3). The view-teardown sibling of `record-sub-run!`: a
+  "Attribute a post-settle view-unmount emit to the event that caused the
+  teardown. A
   `:rf.view/unmounted` trace fires at React `componentWillUnmount` /
   `useEffect`-cleanup time — AFTER the cascade that removed the view settled
   — so it cannot ride the in-flight cascade buffer (there is none).
@@ -217,7 +182,7 @@
   updated record is re-fanned to epoch listeners so snapshot consumers
   (Xray's Views panel, which caches `epoch-history` at settle time) re-sync.
 
-  PRUNE-ON-UNMOUNT (rf2-bgapd): after the back-fill, evict the unmounting
+  After back-fill, evict the unmounting
   instance's `mount-attribution` entry (the `:epoch-id` anchor + learned
   `:deps` read-set keyed by this `render-key`). Each mount mints a FRESH
   `instance-token` → a fresh render-key, so without per-instance eviction the
@@ -238,20 +203,13 @@
   [frame-id event]
   (when interop/debug-enabled?
     (when-let [epoch-id (state/last-settled-epoch-id frame-id)]
-      ;; EP-0015 §15 + open-issue 6 (RULED): the back-fill appends the RAW
-      ;; unmount event to `:trace-events`. The ring + listener fan-out
-      ;; deliver the raw record; the `:redact-fn` advanced override runs
-      ;; projection-side only (inside `projected-record`), so the off-box
-      ;; egress (where Xray's VIEWS-step `unmounted-views-rows` consumes
-      ;; the projected record) sees the redacted shape (see
-      ;; `record-render!`). An unmount carries no structured projection row,
-      ;; so only `:trace-events` is back-filled.
+      ;; Unmount has no structured row, so only retained raw trace is updated.
       (when-let [updated (state/back-fill-unmount! frame-id epoch-id event)]
         ;; Re-fan the corrected record so snapshot consumers re-read the
         ;; ring. Same failure-isolated fan-out + no-loop contract as the
         ;; render / sub-run back-fill above.
         (notify-listeners! updated)))
-    ;; rf2-bgapd — prune the unmounting instance's mount-attribution entry so
+    ;; Prune the unmounting instance's mount-attribution entry so
     ;; the map stays bounded across instance churn (NOT retained until
     ;; whole-frame destroy). Runs whether or not the back-fill found a live
     ;; epoch — the entry is dead once the instance unmounts.
@@ -259,107 +217,30 @@
       frame-id (-> event :tags :rf.view/render-key))))
 
 (defn on-frame-destroyed!
-  "Per Tool-Pair §Surface behaviour against destroyed frames (rf2-d656)
-  and rf2-v0jwt / rf2-9neiq §Outcomes (`:halted-destroy`):
+  "Handle epoch state when a frame is destroyed.
 
-    1. Mid-drain destroy detection — if `capture-buffers[frame-id]`
-       holds buffered events at destroy time, this is a mid-drain
-       destroy (the handler that called `destroy-frame!` was running
-       inside the drain; its trace events were captured into the
-       in-flight buffer). Notify epoch listeners with a partial
-       `:halted-destroy` record carrying the run's traces AND the
-       real `:frame-state-before` / `:frame-state-after` snapshots threaded
-       by `destroy-frame!` (rf2-9neiq / rf2-3aizt1): `fs-before` is the
-       pre-run snapshot (the whole frame-state — both partitions — the
-       frame held before the in-flight event's run began, from the
-       router-bound `frame/*run-frame-state-before*`); `fs-after` is the
-       destroy-time state (the live frame-state value read at the top of
-       `destroy-frame!`, before teardown — the partial run's
-       already-committed writes survive in it). `build-record` derives the
-       `:db-before` / `:db-after` app-db projections from them. This
-       conforms the record to Spec-Schemas §`:rf/epoch-record` §Outcomes,
-       which documents `:halted-destroy` as carrying the pre-run
-       snapshot as `:frame-state-before` and the destroy-time/partial state
-       as `:frame-state-after`. The record is delivered
-       to LISTENERS ONLY — it is NOT appended to the ring buffer, because
-       step 3 drops the destroyed frame's ring and `(rf/epoch-history
-       destroyed)` returns `[]` per the rf2-d656 read-empty contract.
-       Listeners (`register-epoch-listener!`) receive every record
-       regardless of `:outcome` (Spec-Schemas §`:rf/epoch-record`
-       §Restore semantics), so the listener fan-out IS the documented
-       devtools-introspection channel for the destroyed-mid-drain halt.
-    2. Emit `:rf.epoch.cb/silenced-on-frame-destroy` once per cb whose
-       observed-frames set contains `frame-id`, then drop `frame-id`
-       from each cb's entry so a re-registration of a same-keyed frame
-       re-arms the silencing trace for a future destroy.
-    3. Drop the destroyed frame's per-frame ring buffer so subsequent
-       `(rf/epoch-history frame-id)` calls return the empty vector
-       (the read-empty shape the contract commits to).
-    4. Drop any in-flight capture buffer entry for `frame-id`
-       (rf2-zzper) so a mid-drain destroy can't leak its pre-destroy
-       events into the first cascade of the next same-keyed frame.
+  If a run-start is still buffered, listeners receive a raw
+  `:halted-destroy` record containing the pre-run and destroy-time whole-frame
+  snapshots plus the destroying event's causal time. The record is not stored:
+  destroyed frames have empty history, so listener delivery is the only channel
+  for this terminal partial record.
 
-  `fs-before` / `fs-after` are the two frame-state snapshots `destroy-frame!`
-  captured before the frame was removed (see `re-frame.frame/notify-epoch-
-  listeners!`). Both are nil for an out-of-run destroy (no in-flight
-  run → no `:halted-destroy` record committed at all). EP-0001
-  (rf2-3aizt1, decision #2): the canonical snapshot unit is the whole
-  frame-state; `build-record` derives the `:db-*` app-db projections.
-
-  `committed-at` (rf2-bh56rc) is the destroying event's causal `:rf/time-ms`
-  (the router-bound `frame/*run-time-ms*`, threaded through
-  `destroy-frame!`), used for the `:halted-destroy` record's
-  `:committed-at` so it is replayable per EP-0010 §Time rather than an
-  ambient host-clock read at assembly time. nil outside a drain (no
-  `:halted-destroy` record is committed there, so the value is moot).
-
-  Called from `re-frame.frame/destroy-frame!` via the
-  `:epoch/on-frame-destroyed` late-bind hook. Idempotent across
-  repeated destroys of the same frame — once a cb's entry no longer
-  contains the frame-id, no further trace fires for that pair, and
-  the (already-cleared) ring-buffer / capture-buffer entries stay
-  absent."
+  Each listener that observed the frame receives one silencing trace. The
+  observation, history, capture, last-settled, and mount-attribution entries are
+  then removed so a same-keyed replacement frame starts clean. Repeated destroys
+  are idempotent."
   [frame-id fs-before fs-after committed-at]
   (when interop/debug-enabled?
-    ;; Step 1: mid-drain destroy detection. The capture-buffer holds
-    ;; every emit tagged with this frame, including non-cascade emits
-    ;; that fire OUTSIDE a drain (e.g. `:frame/created` at reg-frame
-    ;; time). Distinguish a real mid-drain destroy from
-    ;; registration-time tagalongs by gating on the presence of an
-    ;; `:event/run-start` emit — that is the canonical "a cascade
-    ;; started inside this drain" signal. When present, commit a
-    ;; partial `:halted-destroy` record so devtools (Xray,
-    ;; re-frame2-pair) receive the cascade context for the destroyed-
-    ;; mid-drain case. Per rf2-9neiq the `:db-before` / `:db-after`
-    ;; slots carry the real pre-cascade + destroy-time snapshots
-    ;; `destroy-frame!` threaded (captured before the container was
-    ;; torn down), so the record matches the documented contract. The
-    ;; record is delivered to listeners
-    ;; only — the ring buffer gets dropped in step 3 (rf2-d656).
-    ;; Mid-drain detection reuses the canonical
-    ;; `capture/in-flight-cascade?` gate (the same predicate the
-    ;; post-settle render / sub-run back-fill routing uses) so the
-    ;; 'is a cascade in flight?' question lives in one place. The
-    ;; buffered events are read separately for the partial-record build.
+    ;; A run-start distinguishes a real in-flight event from unrelated
+    ;; frame-tagged emits. The partial record goes to listeners only.
     (let [buffered-events (state/buffer-for frame-id)]
       (when (capture/in-flight-cascade? frame-id)
-        ;; Per EP-0015 §15 + open-issue 6 (RULED, hardened): the
-        ;; halted-destroy partial record is delivered RAW to listeners
-        ;; (the same posture as the :ok / :halted-depth ring records).
-        ;; Epoch records are causal replay material, so they stay raw; the
-        ;; `:redact-fn` advanced override runs projection-side only, inside
-        ;; `projected-record`. A listener
-        ;; that forwards off-box projects at its egress boundary.
+        ;; Listener delivery is raw; off-box forwarders project at egress.
         (let [record (assembly/build-record frame-id fs-before fs-after buffered-events
                                             committed-at
                                             :halted-destroy
                                             {:operation :rf.frame/destroyed-mid-drain})]
-          ;; Per rf2-18g1w / rf2-jppad — the cascade-trailer pair (detailed
-          ;; `:rf.epoch/snapshotted` `:outcome :halted-destroy` plus the
-          ;; consumer-facing `:rf.epoch/outcome :blocked`). Shared with the
-          ;; clean/halt settle via `assembly/emit-snapshotted+outcome!` so
-          ;; the two-op trailer shape stays identical across both commit
-          ;; paths.
+          ;; Use the same detailed/coarse trailer pair as normal commits.
           (assembly/emit-snapshotted+outcome! frame-id (:epoch-id record)
                                               (:event-id record) :halted-destroy)
           (notify-listeners! record))))
@@ -372,26 +253,11 @@
                      {:frame  frame-id
                       :cb-id  cb-id})))
     (state/drop-frame-observation! frame-id)
-    ;; Drop the per-frame ring buffer; epoch-history returns [] from
-    ;; here on. (A full reset composes destroy-frame! then reg-frame
-    ;; (no dedicated verb, rf2-lxwpob), so the ring buffer for the new
-    ;; same-keyed frame starts empty per Spec 002 §Resetting a frame.)
+    ;; A destroyed frame reads as empty history; a replacement starts clean.
     (state/drop-frame-history! frame-id)
-    ;; Per rf2-zzper: also drop any in-flight capture buffer. A
-    ;; mid-drain destroy that surfaces a halted record above leaves
-    ;; the buffer behind (the partial-record commit doesn't harvest);
-    ;; explicitly clear here so the next cascade against a same-keyed
-    ;; frame starts from an empty buffer. Symmetric to the ring-buffer
-    ;; drop above.
+    ;; Drop in-flight capture so a same-keyed replacement cannot inherit it.
     (state/drop-frame-buffer! frame-id)
-    ;; Per rf2-qs6dl: forget the last-settled epoch-id so a post-destroy
-    ;; render emit (a torn-down component's final flush) can't back-fill
-    ;; into a record belonging to the destroyed frame's history — which
-    ;; was just dropped above anyway.
+    ;; Forget attribution anchors so teardown emits cannot back-fill old state.
     (state/drop-last-settled-epoch! frame-id)
-    ;; Per rf2-vh1k3 + rf2-dq2b7: forget every render-key's mount-epoch
-    ;; anchor AND read-set for the destroyed frame so a re-registration
-    ;; of a same-keyed frame (e.g. a destroy-frame! + re-reg-frame reset
-    ;; of :app/main) re-mints both from scratch. Both signals share the
-    ;; single `mount-attribution` atom; one wipe replaces the former two.
+    ;; Mount anchors and learned read sets are frame-lifetime state.
     (state/drop-frame-mount-attribution! frame-id)))

--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -1,64 +1,24 @@
 (ns re-frame.epoch.state
-  "Shared state for the epoch surface — the eight defonce atoms plus the
-  low-level CRUD against them, and the config knob accessors. Per
-  rf2-0wi86 (cohesion split): every other seam (`capture`, `assembly`,
-  `write`, `listeners`) and the `re-frame.epoch` facade reach the
-  shared atoms through this namespace; the atoms themselves stay
-  `^:private` so cross-seam access is exclusively through the named
-  helpers below.
+  "Private storage and low-level state operations for epoch history.
 
-  The atoms in question:
+  State is split by access pattern:
 
     config                  per-frame ring-buffer config + redact-fn
     epoch-counter           monotonically-increasing :epoch-id source
     histories               frame-id → vector<:rf/epoch-record>
     last-settled-epoch      frame-id → epoch-id of the most-recently-
-                            settled `:ok` epoch (rf2-qs6dl back-fill
-                            anchor)
+                            settled epoch (async back-fill anchor)
     mount-attribution       frame-id → {render-key → {:epoch-id E
                                                        :deps #{sub-id…}}}
-                            (rf2-vh1k3 + rf2-dq2b7 — the mount-anchor
-                            and the view's learned read-set share one
-                            entry; per Phase-1 finding they never
-                            diverge in usage)
+                            (mount anchor and learned view read-set)
     capture-buffers         frame-id → vector<trace-event> (in-flight)
     listeners               cb-id    → fn
     observed-frames-by-cb   cb-id    → #{frame-id ...}
 
-  Per Phase-1 finding (rf2-0wi86): no two atoms are ever held in a
-  single critical section, so a tiny state ns owns all of them with
-  zero locking/ordering subtleties — the cross-cutting coupling is
-  cosmetic, not structural.
-
-  Per rf2-33lpr decision review: the eight-atom shape (post the
-  rf2-dq2b7 mount-attribution merge) is the right resting point.
-  Two further consolidations were considered and rejected:
-
-    * Per-frame cluster (`histories` + `last-settled-epoch` +
-      `mount-attribution` + `capture-buffers` → one `frame-state`
-      atom keyed by frame-id). REJECTED: `capture-buffers` is the
-      hottest atom (one swap per trace emit, potentially many per
-      event); co-locating it with the rarely-touched back-fill atoms
-      forces every hot-path swap! to operate on a larger map and
-      adds cross-drain contention through a shared swap site (every
-      frame's drain now races every other frame's drain on the
-      single per-frame-state atom). The per-atom decomposition lets
-      the JIT specialise each swap's hot loop, keeps each map small
-      (one key class per atom), and isolates contention by signal
-      class.
-
-    * Listener cluster (`listeners` + `observed-frames-by-cb` → one
-      atom keyed by cb-id). REJECTED: `listeners-snapshot` reads on
-      every settle (fan-out target); `observed-frames-by-cb` updates
-      lazily on first-sighting only. Co-locating means every settle's
-      snapshot deref pulls the larger map, and per-cb writes flow
-      through the same swap! site as the registry. The Phase-1
-      invariant (rf2-0wi86, no shared critical section) lets the two
-      atoms stay separate at zero cost.
-
-  The singletons `config` and `epoch-counter` are irreducible (the
-  former is configuration state, the latter a counter source — both
-  read/written by ALL frames, so frame-id keying would be artificial)."
+  Capture buffers stay separate from rarely-written back-fill state because
+  every trace emit updates them. Listener observations likewise stay separate
+  from the registry snapshot read on every fan-out. No operation requires an
+  atomic update across two of these stores."
   (:require [re-frame.privacy :as privacy]))
 
 ;; ---- configuration --------------------------------------------------------
@@ -70,31 +30,12 @@
 
 (def ^:private default-trace-events-keep
   ;; Matches `default-depth` so by default trace is retained for every
-  ;; retained epoch — when an epoch evicts, its trace evicts too. Per
-  ;; Mike pair-debug 2026-05-27 (the previous default of 5 created a
-  ;; discrepancy where 50 epoch records were retained but only the
-  ;; most recent 5 had their `:trace-events` — operator's mental model
-  ;; expects atomic relationship between epoch + trace).
-  ;;
-  ;; Production builds elide the trace machinery via
-  ;; `interop/debug-enabled? false` so this only affects dev sessions.
-  ;; Heap cost of 50 trace-events is modest (~thousands of small
-  ;; entries; well within browser tolerance).
-  ;;
-  ;; Memory-conscious hosts can still set a lower cap via
-  ;; `(rf/configure! {:epoch-history {:trace-events-keep N}})`. Setting
-  ;; the slot to `0` drops every record's `:trace-events`.
+  ;; retained epoch: record and trace evict together. Hosts may configure a
+  ;; lower cap; zero drops the raw trace from every stored record.
   50)
 
 (def ^:private default-config
-  ;; The shipped baseline config. Three keys today (:depth,
-  ;; :trace-events-keep, :redact-fn). Map shape kept open so future
-  ;; (rf/configure! {:epoch-history {...}}) extensions don't break the
-  ;; shape. Per rf2-wp70d / Tool-Pair §Time-travel §Redaction hook +
-  ;; Security.md §Epoch privacy posture: :redact-fn defaults to nil —
-  ;; apps that record sensitive material into app-db opt in by
-  ;; installing a fn. `reset-config!` restores exactly this map, and
-  ;; the `defonce` below initialises from it.
+  ;; `:redact-fn` is an optional projection-side override, not a storage hook.
   {:depth             default-depth
    :trace-events-keep default-trace-events-keep
    :redact-fn         nil})
@@ -115,10 +56,7 @@
   `:trace-events-keep` must be non-negative integers; `:redact-fn`
   accepts `fn?` or `nil` for explicit-clear; anything else is dropped).
 
-  Per refactor-audit r2 (rf2-lwn4t) §rf2-douii: validation at the
-  boundary keeps stored config sane — a `nil` or non-numeric value
-  would otherwise survive into `record!` and explode at the next
-  `pos?` / `nat-int?` call."
+  Validation at this boundary keeps numeric assumptions out of the hot path."
   [opts]
   (when (map? opts)
     (let [numeric (select-keys opts [:depth :trace-events-keep])
@@ -148,20 +86,8 @@
 (defn reset-config!
   "Restore the live config atom to the shipped `default-config`
   baseline (`:depth` 50, `:trace-events-keep` 50, `:redact-fn` nil).
-  Returns nil.
-
-  Test-support seam (rf2-yw1w1u): `re-frame.test-support`'s reset-hook
-  table fires this — via the `:epoch/reset-config!` late-bind hook —
-  once per fixture invocation so a prior test's `(rf/configure!
-  :epoch-history ...)` (which MERGES) can't leak `:trace-events-keep`,
-  `:depth`, or an installed `:redact-fn` into the next test. Resetting
-  to the WHOLE default map (rather than merging) is what clears a
-  previously-installed `:redact-fn` without the test ns reaching into
-  the private `config` var directly. Suites that intentionally want a
-  non-default value (e.g. `:trace-events-keep 5` to make the
-  keep<depth elision path reachable cheaply) re-apply it through the
-  public `configure!` boundary in their `:init-fn`, which runs AFTER
-  this reset."
+  Replacing the whole map ensures test fixtures also clear an installed
+  projection override. Returns nil."
   []
   (reset! config default-config)
   nil)
@@ -204,15 +130,14 @@
   `:renders` / `:effects`) but lose the raw trace stream. nil `keep`
   means 'keep every record's :trace-events'.
 
-  HOT PATH: invoked from `append-record` on every drain settle (every
-  user-facing event). Under steady state only one record per append
+  Invoked from `append-record` for every event epoch. Under steady state only
+  one record per append
   actually transitions out of the keep-window, so touching just that
   record (rather than walking the whole history vector) is all that is
   needed. The steady-state invariant holds because every prior append
   already elided its own just-crossed record; runtime reductions of `keep`
   via `(rf/configure! {:epoch-history ...})` will take full effect on
-  subsequent appends rather than retroactively rewriting the buffer
-  (pre-alpha posture)."
+  subsequent appends rather than retroactively rewriting the buffer."
   [history keep]
   (let [n (count history)]
     (if (and (some? keep) (nat-int? keep) (> n keep))
@@ -293,7 +218,7 @@
             i))
         (range (count history))))
 
-;; ---- post-settle render back-fill (rf2-qs6dl) -----------------------------
+;; ---- post-settle render back-fill -----------------------------------------
 ;;
 ;; A `:view/render` / `:rf.view/rendered` trace fires at React COMMIT
 ;; time, which lands AFTER the causing cascade's run-to-completion has
@@ -301,8 +226,7 @@
 ;; `re-frame.interop/after-render`). By commit time `settle!` has already
 ;; harvested the cascade buffer and committed the record, so the render
 ;; emit lands in a now-empty buffer; left to the ordinary harvest it would
-;; be vacuumed by the NEXT cascade's settle and mis-attributed to cascade
-;; N+1 (a one-epoch lag).
+;; be harvested by the next event and misattributed by one epoch.
 ;;
 ;; Instead the render is attributed to the cascade that CAUSED it: when a
 ;; render fires with no in-flight cascade for the frame, it is back-filled
@@ -318,9 +242,9 @@
 (defn set-last-settled-epoch!
   "Record `epoch-id` as the most-recently-settled epoch for `frame-id`.
   Called from `settle!` after the record lands in the ring so post-settle
-  render emits can be attributed back to this cascade (rf2-qs6dl).
+  render emits can be attributed back to this cascade.
 
-  rf2-unpldn (companion): gated on a POSITIVE configured depth. The anchor
+  Gated on a positive depth. The anchor
   is the back-fill target the post-settle render / sub-run / unmount readers
   resolve (`last-settled-epoch-id`); it must only ever name an epoch that is
   actually retained in the ring. Under `(rf/configure! {:epoch-history
@@ -356,9 +280,9 @@
   (reset! last-settled-epoch {})
   nil)
 
-;; ---- mount-epoch tracking + render-attribution resolution (rf2-vh1k3) ----
+;; ---- mount-epoch tracking + render-attribution resolution -----------------
 ;;
-;; rf2-qs6dl back-fills a post-settle render to the frame's most-recently-
+;; Post-settle rendering normally back-fills to the frame's most-recently-
 ;; settled epoch — the cascade that ran just before the React commit. That
 ;; is correct for a genuine reactive re-render, but WRONG for a MOUNT
 ;; render whose commit lands late: React/Reagent batch a freshly-mounted
@@ -368,9 +292,8 @@
 ;; RENDERED list (e.g. parallel-frames' title-view appearing in the first
 ;; counter-inc epoch even though its subs never changed).
 ;;
-;; The discriminator is the rf2-l1jz8 `:value-changed?` attribution
-;; already on the reactive `:sub/run` trace, plus the rf2-vh1k3
-;; `:reader-render-key` stamp naming the view whose render deref'd the
+;; The discriminator combines the `:value-changed?` attribution on the
+;; reactive `:sub/run` trace with the `:reader-render-key` naming the view that
 ;; sub. A render of view K belongs to epoch N iff N's cascade actually
 ;; drove K's re-render — i.e. some `:sub/run` with `:reader-render-key K`
 ;; AND `:value-changed? true` landed in N. When no recent epoch shows a
@@ -378,23 +301,6 @@
 ;; attributed to K's MOUNT epoch (its first-ever attribution) rather than
 ;; whatever cascade happens to be settling.
 
-;; Per rf2-dq2b7: the two former atoms (`mount-epoch-by-render-key` ::
-;; `{frame-id {render-key epoch-id}}` and `render-deps-by-render-key` ::
-;; `{frame-id {render-key #{sub-id…}}}`) were merged into a single
-;; `mount-attribution` atom keyed identically (frame-id × render-key)
-;; carrying both signals under one entry. The two atoms NEVER diverged
-;; in usage: both pruned in lockstep by `drop-frame-mount-attribution!`,
-;; both wiped together by `reset-mount-attribution!`. Collapsing them
-;; halves the defonce count (Phase-1 finding rf2-0wi86 §two atoms) and
-;; halves the swap! count on frame teardown without changing any
-;; observable semantic.
-;;
-;; The four accessor names (`mount-epoch-for` / `record-mount-epoch!`
-;; and `render-deps-for` / `record-render-deps!`) survive as the public
-;; surface — each is semantically distinct (one reads/writes the
-;; mount-anchor, the other the read-set) — but they project from one
-;; underlying map.
-;;
 ;; Per-entry shape:
 ;;
 ;;   {frame-id {render-key {:epoch-id <epoch-id-or-nil>
@@ -410,8 +316,8 @@
 (defn record-render-deps!
   "Union `sub-id` into `render-key`'s read-set for `frame-id`. Called for
   every `:sub/run` that arrives stamped with a `:reader-render-key`
-  (rf2-vh1k3) — the synchronous in-render deref that names the reading
-  view. Idempotent; the set only grows."
+  by the synchronous in-render deref that names the reading view.
+  Idempotent; the set only grows."
   [frame-id render-key sub-id]
   (when (and frame-id render-key sub-id)
     (swap! mount-attribution
@@ -446,7 +352,7 @@
 
 (defn drop-render-key-mount-attribution!
   "Forget the mount-anchor + read-set for a SINGLE `render-key` in
-  `frame-id` (rf2-bgapd) — the per-instance eviction tied to a view
+  `frame-id` — the per-instance eviction tied to a view
   instance's UNMOUNT. Without it `mount-attribution` accreted one
   permanent entry per ever-mounted instance (a fresh `instance-token`
   per mount → a fresh render-key), pruned ONLY on whole-frame destroy:
@@ -474,16 +380,13 @@
 
 (defn drop-frame-mount-attribution!
   "Forget every render-key's mount-anchor + read-set for `frame-id`
-  (frame teardown). Replaces the four-wiper pair
-  `drop-frame-mount-epochs!` + `drop-frame-render-deps!` (rf2-dq2b7)."
+  during frame teardown."
   [frame-id]
   (swap! mount-attribution dissoc frame-id)
   nil)
 
 (defn reset-mount-attribution!
-  "Wipe the mount-attribution map across all frames (fixture reset).
-  Replaces the two-reset pair `reset-mount-epochs!` +
-  `reset-render-deps!` (rf2-dq2b7)."
+  "Wipe the mount-attribution map across all frames for fixture reset."
   []
   (reset! mount-attribution {})
   nil)
@@ -501,7 +404,7 @@
        reactive recompute, which carries no render-key). This is the richer
        source — it can match by render-key even before the read-set is learned.
 
-    2. The structured `:sub-runs` projection (rf2-bhglx) — consulted ONLY when
+    2. The structured `:sub-runs` projection — consulted only when
        the record's raw `:trace-events` were elided (the `:trace-events-keep 0`
        memory/privacy posture drops every record's raw stream while RETAINING
        the structured rows). A `:sub-runs` row carries `:value-changed?` and
@@ -524,7 +427,7 @@
                    (or (= render-key (:rf.sub/reader-render-key tags))
                        (and deps (contains? deps (:rf.sub/id tags)))))))
           (:trace-events record))
-    ;; rf2-bhglx — `:trace-events` elided (keep-0, or this record below the
+    ;; `:trace-events` elided (keep-0, or this record below the
     ;; elision boundary). The structured `:sub-runs` rows are retained for
     ;; every record; match a value-changed row by the view's learned read-set.
     (and deps
@@ -547,7 +450,7 @@
   the stamped synchronous derefs; a view's sub set is stable across its life,
   so mount-time learning suffices.
 
-  EVIDENCE WINDOW (rf2-bhglx). Each record is matched against its raw
+  Evidence window: each record is matched against its raw
   `:trace-events` when retained (within `:trace-events-keep`), else against its
   structured `:sub-runs` projection — which is retained for EVERY record
   regardless of `:trace-events-keep`. The scan therefore reaches index 0:
@@ -559,7 +462,7 @@
       render-key precision; older trace-elided records fall back to the
       `:sub-runs` `deps`-only match (harmless — they predate the re-render).
 
-    * keep = 0 (rf2-bhglx) — no record retains raw traces, so EVERY record is
+    * keep = 0 — no record retains raw traces, so every record is
       matched via its structured `:sub-runs`. The scan must NOT break at the
       first trace-elided record (the NEWEST one under keep-0): a genuine
       value-changing sub-run sitting in the newest epoch's `:sub-runs` must
@@ -567,8 +470,8 @@
       mount/default epoch. Consulting `:sub-runs` lets the newest-first scan
       find it and short-circuit on the current epoch.
 
-  The scan never treats the elision boundary as a hard stop (rf2-3rg4j /
-  rf2-b2c02): a trace-elided record can still match via its structured
+  The scan never treats the elision boundary as a hard stop: a trace-elided
+  record can still match via its structured
   `:sub-runs` fallback. Under keep-0 the scan is O(depth) to a
   miss; that is the necessary cost of attribution when no trace window exists,
   and it still short-circuits on the first (newest) value-change for the common
@@ -587,15 +490,13 @@
 
 (defn resolve-render-epoch
   "Resolve the epoch a post-settle render of `render-key` should be
-  attributed to in `frame-id` (rf2-vh1k3). Falls back to
-  `default-epoch-id` (the rf2-qs6dl most-recently-settled epoch) when no
-  better anchor is found, preserving the qs6dl behaviour for genuine
-  reactive re-renders and for the degenerate no-render-key case.
+  attributed to in `frame-id`. Falls back to `default-epoch-id`, the most
+  recently settled epoch, when no better anchor is found.
 
   Resolution order:
     1. The newest epoch in which the view's OWN inputs changed
        (`value-changed-epoch-for`) — a genuine reactive re-render rides
-       its causing cascade exactly as rf2-qs6dl intends.
+       its causing cascade.
     2. Otherwise the view's MOUNT epoch (`mount-epoch-for`) — a mount
        render, or a mount-burst tail that re-deref'd unchanged subs, is
        anchored to where the instance first rendered rather than leaking
@@ -612,8 +513,8 @@
 (defn render-key-already-in-epoch?
   "True when `frame-id`'s epoch `epoch-id` record already carries a
   `:renders` row for `render-key` — used to de-dup a mount-burst tail
-  that resolves back to the mount epoch where the render already landed
-  (rf2-vh1k3). Reads the structured `:renders` projection (always
+  that resolves back to the mount epoch where the render already landed.
+  Reads the structured `:renders` projection (always
   present on a built record), not the optional `:trace-events`."
   [frame-id epoch-id render-key]
   (let [history (history-for frame-id)
@@ -623,13 +524,13 @@
         (some (fn [row] (= render-key (:render-key row)))
               (:renders (nth history idx)))))))
 
-;; ---- post-settle event back-fill (rf2-qs6dl render / rf2-wi900 sub-run) ----
+;; ---- post-settle event back-fill ------------------------------------------
 ;;
-;; A `:view/render` (rf2-qs6dl) and a reactive `:sub/run` (rf2-wi900) both
+;; A `:view/render` and a reactive `:sub/run` both
 ;; fire at React COMMIT / DEREF time, which Reagent batches onto a later
 ;; tick AFTER the causing cascade settled. So each lands in the now-empty
 ;; capture buffer post-settle; left to the ordinary harvest it would be
-;; vacuumed by the NEXT cascade's settle and mis-attributed to cascade N+1
+;; harvested by the next event and misattributed to epoch N+1
 ;; (a one-epoch lag: a phantom render in the wrong cascade's `:renders`, a
 ;; phantom sub-run + `:value-changed?` in the wrong cascade's `:sub-runs` /
 ;; Xray Views subs table).
@@ -644,76 +545,27 @@
 ;; pinning the slot.
 
 (defn- back-fill-event!
-  "Append the RAW `event` and its projected `row` (into the `slot`
-  projection) on the already-committed epoch record identified by
-  `frame-id` + `epoch-id`, then write THAT back to the ring. Returns the
-  updated record (so the caller re-notifies listeners with the same shape
-  the ring now holds), or nil when the target epoch is no longer in the
-  ring (evicted, or the event fired before any cascade settled).
+  "Append a raw post-settle event and optional structured row to an existing
+  epoch. Returns the updated record for listener re-notification, or nil when
+  the target was evicted or never stored.
 
-  `row` is the structured projection entry, or nil — a render op that
-  carries no `:renders` row (`:rf.view/rendered`) or a `:sub/skip` that
-  carries no `:sub-runs` row rides only the `:trace-events` slot, exactly
-  as `capture/project-all` projects no structured row for it. The
-  mutation rewrites the matching record in the frame's history vector
-  under a single `swap!`; the record stays at its original ring position
-  so epoch ordering is preserved.
+  Raw trace is appended only when that record retained `:trace-events`; a
+  non-nil row is appended independently to `slot`. Sensitive evidence is ORed
+  into the record-level rollup. Projection never runs on this storage path.
 
-    * `:trace-events` is back-filled only when the record retained its raw
-      trace stream (within `:trace-events-keep`) so raw-trace consumers
-      (the Reactive panel's flow tally) see the post-settle event in the
-      right cascade.
-    * the structured `slot` projection — the primary consumer surface
-      (Xray Views / Reactive panel) — is always present on a built
-      record; the projected row is appended when non-nil.
-
-  Per EP-0015 §15 + open-issue 6 (RULED, hardened): the back-fill appends
-  the RAW delta. The ring is causal replay material, so it stays raw; the
-  `:redact-fn` advanced override runs projection-side only (inside
-  `projected-record`), so the off-box egress sees the redacted shape while
-  the ring keeps the exact raw delta. Because no redaction runs on the
-  storage path, there is no per-back-fill leak to close and no
-  non-idempotent-fn hazard inside the swap.
-
-  rf2-c0rv4v: the splice is a single PURE `swap!` update fn. It invokes no
-  injected fn — `privacy/sensitive?` is a pure predicate, and the only
-  remaining recompute is the rf2-j1ec6.1 sensitivity OR-rollup — so a CAS
-  retry re-runs it (re-reading the retried record's real slots) with no
-  side effects. (Post-EP-0015 §15 the prior two-phase `compute-delta` →
-  `splice-delta` split was vestigial: it existed to keep an injected
-  storage-side redact-fn OUT of the CAS-retried swap, and that redact
-  invocation is gone — the split was inlined here, rf2-c0rv4v.) Conjes the
-  raw delta element onto a vector (or absent) real slot; a slot already
-  collapsed to a non-vector scalar (an unusual shape) is left untouched
-  (the delta is subsumed).
-
-  rf2-qh13yf — SNAPSHOT CONSISTENCY. The index AND the spliced record are
-  resolved from ONE `@histories` value, INSIDE the `swap!` update fn, which
-  re-derives the index from the CAS-retried map on every attempt. The prior
-  code resolved the index against one `@histories` deref (`history-for`),
-  then read the record off a SECOND deref, then `update-in`'d at the
-  up-front index — three reads of a mutable atom. Its docstring justified
-  the single up-front resolution by 'within-frame drain is single-threaded
-  so no append can shift it', but that premise is FALSE for the back-fill:
-  it fires at React COMMIT / DEREF / TEARDOWN time, OUTSIDE any drain (see
-  the §post-settle back-fill design note), so a real cascade `record!` for
-  the SAME frame can append between the two derefs. At ring cap that append
-  EVICTS the front record and shifts every index down by one — the stale
-  up-front `idx` then named (and `update-in` spliced) the WRONG record. By
-  finding the index from the map the `swap!` is actually CAS-committing
-  against (`epoch-index` on the retried frame-vector), the splice always
-  lands on the record whose `:epoch-id` matches, regardless of any
-  interleaved append/eviction. nil when the epoch is absent from the ring
-  (evicted before the splice, or fired before any cascade settled)."
+  Back-fill runs outside the frame drain and can race ring append/eviction.
+  Therefore the epoch index must be resolved inside the CAS-retried `swap!`
+  update from the same history map being rewritten. Resolving it earlier could
+  splice the wrong record after a capped-ring eviction shifts indices. The
+  update function remains pure so retries are safe."
   [frame-id epoch-id slot event row]
-  (let [;; rf2-j1ec6.1 (Security.md:109 §Sensitive rollup): the record-level
-        ;; `:rf.epoch/sensitive?` rollup MUST consider :trace-events overlap,
+  (let [;; The record-level rollup must include post-settle trace evidence,
         ;; but `build-record` computes it ONCE at settle time over the
         ;; SETTLE-TIME events; a post-settle back-fill of a `:sensitive?`-
         ;; stamped trace event would otherwise leave the rollup stale-false.
         ;; `privacy/sensitive?` is pure and depends only on `event` (not on any
         ;; @histories snapshot), so it is hoisted out of the swap; the swap fn
-        ;; OR's it into the rollup fail-CLOSED (mayor-ruled option a). The OR is
+        ;; ORs it into the rollup fail closed. The OR is
         ;; monotonic/idempotent (only flips false→true, never clears a
         ;; settle-time true), so it rides safely inside the CAS-retried swap.
         sens?   (privacy/sensitive? event)
@@ -728,7 +580,7 @@
 
                         :else            ; real slot already a scalar
                         rec))            ; delta subsumed
-        ;; rf2-qh13yf: operate on the WHOLE @histories map so the index is
+        ;; Operate on the whole histories map so the index is
         ;; re-derived from the SAME (CAS-retried) value the splice rewrites —
         ;; never against a separate, possibly-shifted deref. When the epoch is
         ;; no longer in the frame's ring (evicted, or never landed) the map is
@@ -770,37 +622,18 @@
       (nth history idx'))))
 
 (defn back-fill-render!
-  "Back-fill the RAW `render-event` and its projected `:renders`
-  `render-row` into the already-committed epoch `epoch-id` for `frame-id`
-  (rf2-qs6dl). Thin wrapper over `back-fill-event!` pinning the `:renders`
-  slot. The appended delta is stored RAW (EP-0015 §15 + open-issue 6,
-  RULED — the ring is causal replay material; the `:redact-fn` advanced
-  override runs projection-side only, inside `projected-record`)."
+  "Back-fill a raw render event and its structured row into `:renders`."
   [frame-id epoch-id render-event render-row]
   (back-fill-event! frame-id epoch-id :renders render-event render-row))
 
 (defn back-fill-sub-run!
-  "Back-fill the RAW `sub-event` and its projected `:sub-runs`
-  `sub-run-row` into the already-committed epoch `epoch-id` for `frame-id`
-  (rf2-wi900). Thin wrapper over `back-fill-event!` pinning the `:sub-runs`
-  slot. Symmetric with `back-fill-render!`. The appended delta is stored
-  RAW (EP-0015 §15 + open-issue 6, RULED — the ring is causal replay
-  material; redaction is projection-side, inside `projected-record`)."
+  "Back-fill a raw subscription event and its structured row into `:sub-runs`."
   [frame-id epoch-id sub-event sub-run-row]
   (back-fill-event! frame-id epoch-id :sub-runs sub-event sub-run-row))
 
 (defn back-fill-unmount!
-  "Back-fill a RAW `:rf.view/unmounted` `unmount-event` into the already-
-  committed epoch `epoch-id` for `frame-id` (rf2-59hx3). Thin wrapper over
-  `back-fill-event!` — an unmount produces NO structured projection row (it
-  is neither a `:renders` nor a `:sub-runs` entry), so `row` is nil and the
-  event rides ONLY the `:trace-events` slot. That is exactly where Xray's
-  VIEWS-step `unmounted-views-rows` reads view teardowns. The `:slot`
-  argument is irrelevant when `row` is nil; `:renders` is passed for
-  documentary parity with the render sibling. Symmetric with
-  `back-fill-render!` / `back-fill-sub-run!`. The appended delta is stored
-  RAW (EP-0015 §15 + open-issue 6, RULED — the ring is causal replay
-  material; redaction is projection-side, inside `projected-record`)."
+  "Back-fill a raw unmount event. Unmounts have no structured row, so they
+  affect only a retained `:trace-events` slot."
   [frame-id epoch-id unmount-event]
   (back-fill-event! frame-id epoch-id :renders unmount-event nil))
 
@@ -848,138 +681,50 @@
   `:rf.event/run-start` emit in the buffer. nil when no run-start fired (a
   rejected / aborted dispatch, or a halt path whose event never ran) — the
   no-run-start branch of `harvest-buffer-for-event!` then falls back to the
-  settling ENVELOPE's dispatch-id (rf2-erczwd) to scope its drop."
+  settling envelope's dispatch-id to scope its drop."
   [events]
   (some (fn [ev]
           (when (= :rf.event/run-start (:operation ev))
             (-> ev :tags :rf.trace/dispatch-id)))
         events))
 
-;; rf2-bhglx — claim-based `theirs` retention. A `:event/dispatched` marker
-;; that rides a DIFFERENT dispatch-id ("theirs") is a CHILD's queue-time
-;; dispatch row: it fires during the PARENT's do-fx (so it lands in the
-;; parent's window) but carries the CHILD's `:dispatch-id`. Under per-event
-;; epochs it must ride the CHILD's epoch, not the parent's (Spec 009 §Dispatch
-;; correlation: one `:dispatch-id` = one epoch), so it is LEFT in the buffer
-;; for the child's own `harvest-buffer-for-event!`, where the child's
-;; run-start makes the settling-id match and the marker is CLAIMED as "mine".
-;;
-;; The marker is retained until that claim — NOT for a fixed number of
-;; harvests. The earlier rf2-fxowr fix dropped an unclaimed marker after it had
-;; survived ONE intervening harvest as theirs, on the theory that the very next
-;; harvest is always the child's own settle. That theory is FALSE for a valid
-;; router interleaving: ordinary `:dispatch` fx children go to the router FIFO
-;; TAIL (`router/enqueue-envelope!` — `conj` on the PersistentQueue), so a
-;; SIBLING event already queued behind the parent settles BEFORE the child.
-;; That sibling's harvest consumed the child's one retained pass and dropped
-;; the marker before the child ever ran — the delayed child epoch then lost its
-;; queue-time dispatch/source row (parent-dispatch-id, source, source-detail,
-;; origin, call-site) and parent-child causality. The harvest-count heuristic
-;; conflated "a sibling ran ahead of the child" (legitimate — must retain) with
-;; "the child never ran" (a strand). Retaining until the matching run-start
-;; claims the marker is correct for ANY number of intervening sibling settles.
-;;
-;; The memory bound rf2-fxowr guarded is preserved WITHOUT the count: a child
-;; that NEVER runs to a settle has its marker cleared by the same terminal path
-;; that ends the child's life — `on-frame-destroyed!` drops
-;; the whole frame buffer (frame destroyed / drain-interrupted), the per-event
-;; depth-halt `commit-halt-record!` reads-and-CLEARS the whole buffer
-;; (`harvest-buffer!`), and a rejected/aborted child dispatch reaches the
-;; no-run-start branch below which — given the settling ENVELOPE's dispatch-id
-;; (rf2-erczwd) — drops THAT dispatch's OWN traces (the child's marker is "mine"
-;; when the child itself is the rejected settling event) plus orphans, while
-;; retaining any UNRELATED sibling's marker for its own settle. Each terminal
-;; path drops the stranded marker at the point its own dispatch is rejected /
-;; the frame torn down; none leaves it to accrete. The
-;; nil-id orphan self-cleaning rf2-ee38b established at this same seam (an
-;; orphan has no settle to ever claim it AND rides no terminal clear of its own)
-;; is unchanged — orphans are still dropped here on every harvest.
+;; A child's queue-time `:event/dispatched` trace is emitted while its parent
+;; runs but carries the child's dispatch id. Keep it until the child's matching
+;; run-start claims it, even when FIFO siblings settle first. Fixed-harvest
+;; retention is incorrect because the child may be arbitrarily far behind its
+;; parent. Terminal rejection, halt, and frame teardown clear stranded markers;
+;; nil-id orphans are dropped because no event can ever claim them.
 
 (defn harvest-buffer-for-event!
-  "Per rf2-nj6p7 — per-event harvest. Atomically read the frame's in-flight
+  "Atomically split the frame's buffer for one settling event.
   buffer and split it by the settling event's `:dispatch-id`:
 
     * RETURN the events that belong to the settling event — those whose
-      `:tags :dispatch-id` matches the buffer's first `:event/run-start`
-      id. Per rf2-avvwm an out-of-cascade ORPHAN (no `:dispatch-id` — e.g.
-      a `:frame/created` emit fired between the last settled event and the
-      next dequeue) is NOT folded in: Spec 009 §Dispatch correlation keeps
-      an emit outside any cascade uncorrelated (neither a new epoch nor part
-      of another epoch's record). Orphans are dropped upstream at the capture
-      seam (`re-frame.epoch.capture/capture-event!`) so they never reach this
-      buffer; the `did = sid` predicate below is the matching guard.
+      `:tags :dispatch-id` matches the buffer's first `:event/run-start` id.
     * LEAVE in the buffer the events that belong to a DIFFERENT dequeued
       event — a child's `:event/dispatched` marker fires during the
       PARENT's do-fx (so it lands in the parent's window) but carries the
       CHILD's `:dispatch-id`; under per-event epochs it must ride the
-      child's epoch, not the parent's (Spec 009 §Dispatch correlation:
-      one `:dispatch-id` = one epoch). It stays buffered for the child's
+      child's epoch, not the parent's. It stays buffered for the child's
       own `harvest-buffer-for-event!` at the child's settle.
 
-  Per rf2-bhglx a theirs marker is RETAINED until its child's own run-start
-  claims it (any number of intervening sibling settles), not for a fixed
+  A marker is retained until its child's own run-start claims it, not for a fixed
   harvest count. A child that never runs is bounded by the terminal paths that
   clear the whole buffer (frame destroy / drain-interrupt / depth-halt /
   rejected dispatch); see the design note above this defn.
 
-  NO-RUN-START (rejected / aborted dispatch — rf2-erczwd). When the buffer
-  carries no `:event/run-start`, no cascade ran to completion, so there is
-  NOTHING legitimate to commit — a no-handler / frame-destroyed dispatch still
-  emits a frame-stamped, dispatch-id-bearing ERROR trace that lands in this
-  buffer, and returning it made `settle!` commit a misleading `:ok` epoch
-  (the no-run-start / no-epoch invariant was violated). So:
-
-    * 2-arity — given the settling ENVELOPE's `settling-dispatch-id` (threaded
-      from the router's per-event settle seam), DROP this dispatch's OWN traces
-      (`:dispatch-id` = `settling-dispatch-id`, e.g. its `:no-such-handler`
-      error trace) AND orphans (nil id), RETAIN any UNRELATED child marker
-      (`:dispatch-id` ≠ settling, non-nil) for its own settle, and RETURN [].
-      `settle!`'s empty-buffer skip then commits no epoch — the rejection's
-      own trace is dropped while a legitimately-buffered sibling marker
-      survives. Symmetric with the run-start branch's claim-based retention.
-    * 1-arity — no envelope id to scope by (a direct low-level test call);
-      falls back to a full read-and-clear returning the whole buffer, and
-      `settle!`'s empty-buffer / no-trigger policy handles the degenerate
-      record."
+  With no run-start, no event ran to completion. The two-arity uses the
+  settling envelope id to drop that rejected dispatch's own traces and nil-id
+  orphans while retaining unrelated child markers. It returns `[]`, preventing
+  `settle!` from recording a false `:ok` epoch. The low-level one-arity has no
+  envelope id and therefore falls back to a full read-and-clear."
   ([frame-id] (harvest-buffer-for-event! frame-id nil))
   ([frame-id settling-dispatch-id]
   (let [buffer (get @capture-buffers frame-id [])]
     (if-let [settling-id (run-start-dispatch-id buffer)]
-      ;; Three-way partition by the event's :rf.trace/dispatch-id:
-      ;;   * MINE   (= event-dispatch-id settling-id)
-      ;;       — the settling event's own traces; returned to ride this epoch.
-      ;;   * THEIRS (non-nil, ≠ settling-id)
-      ;;       — a child's `:event/dispatched` marker fired during THIS event's
-      ;;         do-fx carrying the CHILD's id; LEFT in the buffer for the
-      ;;         child's own settle (Spec 009 §Dispatch correlation: one
-      ;;         dispatch-id = one epoch). RETAINED across every intervening
-      ;;         sibling harvest until the child's own run-start claims it as
-      ;;         mine (rf2-bhglx — siblings queued ahead of a FIFO-tail child
-      ;;         settle first, so the child's claim can be many harvests away).
-      ;;   * ORPHAN (nil event-dispatch-id)
-      ;;       — an out-of-cascade emit (e.g. `:frame/created`) with no
-      ;;         cascade to ride. DISCARDED here.
-      ;;
-      ;; Per rf2-avvwm orphans are dropped at the capture seam
-      ;; (capture/capture-event! out-of-cascade branch) so in normal
-      ;; operation none arrive. This seam is the defensive backstop: a
-      ;; nil-dispatch-id orphan that slips past the upstream guard has no
-      ;; settle event to ever reclaim it, so retaining it would leave it in
-      ;; the buffer indefinitely — re-grouped into `theirs` and re-retained
-      ;; on every subsequent harvest. Discarding
-      ;; it makes the harvest self-cleaning and removes reliance on the
-      ;; upstream guard being perfect (rf2-ee38b §correctness). The
-      ;; `event-dispatch-id = settling-id` predicate already guarantees an
-      ;; orphan never folds into an epoch's `:trace-events`; this only changes
-      ;; whether it lingers in the buffer (no) vs. is dropped (yes).
-      ;;
-      ;; Per rf2-bhglx a stranded non-nil child (one that never runs to a
-      ;; settle) is bounded WITHOUT a per-marker survival counter: the
-      ;; terminal path that ends the child's life clears the whole buffer (see
-      ;; the design note above this defn). A harvest-count reclaim would have
-      ;; dropped a LEGITIMATE child whose sibling merely ran ahead of it on the
-      ;; FIFO, losing the child's queue-time dispatch row — so the marker is
-      ;; retained here on every sibling harvest.
+      ;; Return matching traces, retain non-nil ids for later events, and drop
+      ;; nil-id orphans. The capture seam normally removes orphans first; this
+      ;; partition is the defensive bound if one reaches storage.
       (let [mine   (filterv (fn [ev] (= (-> ev :tags :rf.trace/dispatch-id) settling-id))
                             buffer)
             ;; Other-event markers: a non-nil dispatch-id that isn't the
@@ -995,8 +740,7 @@
           (swap! capture-buffers assoc frame-id theirs)
           (swap! capture-buffers dissoc frame-id))
         mine)
-      ;; No run-start — rejected/aborted dispatch (no-handler / frame-destroyed).
-      ;; No cascade ran, so nothing legitimate to commit (rf2-erczwd).
+      ;; No run-start means no event ran, so nothing can be committed.
       (if settling-dispatch-id
         ;; Scope the drop to THIS dispatch: drop its own traces (the rejection's
         ;; frame-stamped error trace, `:dispatch-id` = settling) + orphans, RETAIN
@@ -1024,20 +768,16 @@
 
 (defn reset-capture-buffers!
   "Wipe every in-flight capture buffer across all frames. Test fixtures
-  use this in lockstep with `reset-histories!`.
-
-  Per rf2-v0jwt: fixtures that sequence runs need a fresh capture
-  state per fixture; a stale buffer from a previous fixture would
-  otherwise be harvested into the next fixture's first cascade."
+  use this in lockstep with `reset-histories!` so stale traces cannot be
+  harvested by the next test's first event."
   []
   (reset! capture-buffers {})
   nil)
 
 (defn reset-histories!
   "Wipe every frame's recorded epochs. Also clears the last-settled-epoch
-  map (rf2-qs6dl) and the mount-attribution map (rf2-vh1k3, rf2-dq2b7)
-  so a fixture's first cascade can't back-fill a render into a previous
-  fixture's record nor inherit a stale render-key → {mount-epoch +
+  and mount-attribution maps so a fixture's first cascade cannot back-fill
+  a render into the previous fixture's record nor inherit a stale render-key → {mount-epoch +
   read-set} anchor."
   []
   (reset! histories {})
@@ -1049,8 +789,7 @@
 
 (defonce ^:private listeners (atom {}))
 
-;; Per Tool-Pair §Surface behaviour against destroyed frames (rf2-d656):
-;; track which frames each cb has been delivered records for. When a
+;; Track which frames each callback has observed. When a
 ;; frame is destroyed, every cb whose observed-frames set contains
 ;; that frame receives a one-shot :rf.epoch.cb/silenced-on-frame-destroy
 ;; trace. The frame is then dropped from the cb's entry so a
@@ -1104,8 +843,8 @@
   long-lived listener observing the same frame on every cascade,
   this is a single deref + membership check with no swap.
 
-  Per rf2-7i872 (unregister-mid-fan-out race): `notify-listeners!`
-  iterates a listener SNAPSHOT, then calls this fn per cb-id BEFORE
+  `notify-listeners!` iterates a listener snapshot, then calls this function
+  before
   invoking the callback. If `unregister-epoch-listener!` removed the cb
   between the snapshot and now, recording an observation would
   RE-INTRODUCE bookkeeping for a cb that no longer exists — the stale

--- a/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
+++ b/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
@@ -1,15 +1,7 @@
 (ns re-frame.epoch.tool-pair
-  "Tool-Pair boundary surfaces — the preconditions, restore-perform, and
+  "Tool boundary surfaces: preconditions, restore, state injection, and
   off-box projection helpers behind `restore-epoch!`, `replace-frame-state!`,
   `projected-record`, and `projected-history`.
-
-  The name (rf2-dga99) covers BOTH halves of the seam: the WRITE-in
-  boundary (precondition validators + `perform-restore!` behind the
-  Tool-Pair time-travel surfaces) AND the off-box egress READ boundary
-  (`projected-record` / `projected-history`, the privacy projection per
-  Security.md §Epoch privacy posture). The former `write` name accurately
-  named the first half but undersold the projection egress — both are
-  Tool-Pair-contract surfaces, so `tool-pair` names the seam honestly.
 
   Responsibilities:
 
@@ -23,8 +15,7 @@
     * **Schema / handler / version probes** — `failing-schema-paths`,
       `missing-references`, `machine-version-mismatch`. Each is a
       single walk over the recorded db; callers bind the result so
-      the failure path walks each substrate exactly once per check
-      (rf2-081zk).
+       the failure path walks each substrate exactly once per check.
 
     * **Perform-restore** — `perform-restore!` carries out the
       container replace + `:rf.epoch/restored` emit once preconditions
@@ -35,18 +26,17 @@
       for off-box egress (Xray-MCP `watch-epochs`, story / pair
       recorders). That is: the canonical `:frame-state-before` /
       `:frame-state-after` slots (app-db partition elided, runtime-db
-      partition default-redacted per EP-0001 ruling #14), the derived
+       partition default-redacted), the derived
       `:db-before` / `:db-after` app-db projections, `:trigger-event`,
       `:trace-events`, the value-bearing structured `:sub-runs` rows
-      (their `:prev-value` / `:value` slots — rf2-at60h), AND the structured
+       (their `:prev-value` / `:value` slots), and the structured
       `:effects` rows' payload-bearing `:args` (fail-closed to `:rf/redacted`
-      off-box — rf2-rlt3sv). The value-free `:renders` metadata, the
+       off-box). The value-free `:renders` metadata, the
       `:effects` rows' `:fx-id` / `:outcome` / `:error-trace`, and the
       record-level bookkeeping pass through unchanged. `projected-record`'s
       own docstring is the authoritative per-slot contract.
 
-  Per rf2-0wi86 Phase-2 seam E. The orchestrators `restore-epoch!` and
-  `replace-frame-state!` live in the `re-frame.epoch` facade — they wire
+  The orchestrators live in the `re-frame.epoch` facade and wire
   the precondition check + the trace emission + the perform / listener
   fan-out steps together. Pure-data shape of the preconditions makes
   the orchestrators a four-line case-match."
@@ -68,14 +58,11 @@
   "Return the malli validate fn or nil.
 
   Looks up the late-bind hook `:schemas/malli-validate`, published by
-  `re-frame.schemas.malli` when loaded — the only lookup step, on both
-  CLJ and CLJS. Per rf2-qyfie, `re-frame.schemas.validator` dropped its
-  JVM-only `(requiring-resolve 'malli.core/validate)` fallback for
-  contract symmetry between runtimes; this fn mirrors that shape rather
-  than the pre-rf2-qyfie two-step lookup.
+  `re-frame.schemas.malli` when loaded. This is the only lookup step on both
+  CLJ and CLJS, so validation has the same contract in both runtimes.
 
-  Returning nil (hook unbound) is treated as soft-pass by callers —
-  'cannot disprove, treat as valid' — unchanged from before rf2-qyfie."
+  Callers treat an unbound hook as a soft pass: without a validator they
+  cannot disprove validity."
   []
   (late-bind/get-fn :schemas/malli-validate))
 
@@ -121,9 +108,8 @@
   and `:rf/machine` (the spec map). Returns the registration map
   when machine-id names a registered machine, nil otherwise.
 
-  Per rf2-ocg1: epoch restore validates against this public surface,
-  not against the internal `:head` registrar kind that machines
-  never used."
+  Epoch restore validates against this public surface, not the unrelated
+  internal `:head` registrar kind."
   [machine-id]
   (let [reg (registrar/lookup :event machine-id)]
     (when (:rf/machine? reg)
@@ -156,12 +142,12 @@
           :rf/machine
           spec-snapshot-version))
 
-;; EP-0001 (rf2-vzld77 / rf2-3aizt1 / rf2-k4xe7u) — the machine snapshots
-;; and route slice are DURABLE runtime-db partition state, addressed at the
+;; Machine snapshots and the route slice are durable runtime-db partition
+;; state, addressed at the
 ;; namespaced runtime-db root keys `:rf.runtime/machines` /
 ;; `:rf.runtime/routing`. The restore-precondition readers below take the
 ;; runtime-db PARTITION value (`(:rf.db/runtime frame-state)`) and walk those
-;; namespaced paths. The epoch captures the whole frame-state (decision #2),
+;; namespaced paths. Each epoch captures the whole frame-state,
 ;; so `check-restore-preconditions!` passes the runtime-db partition here,
 ;; against which the missing-handler-machine + version-drift preconditions
 ;; fire.
@@ -220,14 +206,10 @@
   reference a registered :route).
 
   `runtime-db` is the `:rf.db/runtime` partition of the epoch-recorded
-  frame-state (EP-0001 rf2-3aizt1 / rf2-k4xe7u — machine snapshots + route
-  slice are runtime-db partition state).
+  frame-state. Machine lookup goes through the public event registry, not
+  the unrelated internal `:head` registrar kind.
 
-  Per rf2-ocg1: machine lookup goes through the event registry, NOT
-  the internal `:head` registrar kind. The latter is unrelated to
-  the public machine contract.
-
-  Per rf2-a2sn1: a DYNAMICALLY-SPAWNED actor carries no per-instance
+  A dynamically spawned actor carries no per-instance
   registrar entry — its liveness is derived from its (revertible)
   snapshot. Such a snapshot is a VALID restore target iff its TYPE still
   resolves (registered TYPE keyword, or inline `:definition` carried on
@@ -237,8 +219,8 @@
   snapshot whose id is not directly registered. A SINGLETON whose
   registration was cleared (a `reg-machine`'d machine, no `:rf/machine-type`
   on its snapshot) still surfaces as missing — `actor-resolvable?` returns
-  false for it. Absent the machines artefact the hook is nil and the prior
-  registrar-only check stands.
+  false for it. When the machines artefact is absent the hook is nil and the
+  registrar-only check applies.
 
   Returns a vector of {:kind <kind> :id <id>} entries. Empty when
   every reference resolves."
@@ -246,7 +228,7 @@
   (let [actor-resolvable? (late-bind/get-fn :machines/actor-resolvable?)
         ;; Machines under [:rf.runtime/machines :snapshots]: a singleton
         ;; references a registered machine (`:rf/machine? true`, per Spec
-        ;; 005 §Registration); a spawned actor (rf2-a2sn1) has no
+        ;; 005 §Registration); a spawned actor has no
         ;; per-instance registration but is restorable when its
         ;; `:rf/machine-type` resolves through `actor-resolvable?` (which
         ;; reads the runtime-db partition).
@@ -264,8 +246,8 @@
     (vec (concat missing-machines missing-route))))
 
 (defn- current-definition-version
-  "Resolve the CURRENT definition `:rf/snapshot-version` for one recorded
-  snapshot the SAME way dispatch resolves the live spec (rf2-rlt3sv):
+  "Resolve the current definition `:rf/snapshot-version` for one recorded
+  snapshot the same way dispatch resolves the live spec:
 
     - SINGLETON snapshots — the snapshot key IS the registered machine-id, so
       `singleton-definition-version` resolves the live spec by key.
@@ -307,20 +289,13 @@
   nil when no mismatch is found.
 
   `runtime-db` is the `:rf.db/runtime` partition of the epoch-recorded
-  frame-state (EP-0001 rf2-3aizt1 / rf2-k4xe7u).
-
-  The current definition is resolved the SAME way dispatch resolves the live
-  spec (rf2-rlt3sv): a SINGLETON by its snapshot key (the key IS the registered
+  frame-state. The current definition is resolved the same way dispatch
+  resolves the live spec: a singleton by its snapshot key (the key is the registered
   machine-id), a SPAWNED ACTOR by its snapshot's `:rf/machine-type` (registered
-  TYPE keyword or inline `:definition` map — `current-definition-version`).
-  Before the fix the version probe compared the snapshot KEY against the
-  registrar for EVERY snapshot, so a spawned actor's instance-id key never
-  resolved and a hot-reloaded actor TYPE's version drift silently passed — an
-  older, incompatible spawned-actor snapshot could be installed by
-  `restore-epoch!` reporting success.
+  type keyword or inline `:definition` map — `current-definition-version`).
 
-  Per rf2-ocg1: the recorded version is read through the public Spec 005
-  §Snapshot shape contract — the snapshot's `[:meta :rf/snapshot-version]`;
+  The recorded version is read through the public Spec 005 §Snapshot shape
+  contract — the snapshot's `[:meta :rf/snapshot-version]`;
   the current version through the resolved spec's `[:meta :rf/snapshot-version]`."
   [runtime-db]
   (some (fn [[machine-id snapshot]]
@@ -338,10 +313,8 @@
 
 (defn- find-epoch-in
   "Search a resolved history vector for the record matching `epoch-id`.
-  Caller has already paid the `@histories` deref — `check-restore-
-  preconditions!` reads history once at the top and reuses the vector
-  for both the lookup and the `:history-size` count on the
-  unknown-epoch failure path (rf2-3g7x3 — was two derefs)."
+  `check-restore-preconditions!` reads history once and reuses the vector for
+  both this lookup and the `:history-size` count on the unknown-epoch path."
   [history epoch-id]
   (some (fn [record] (when (= epoch-id (:epoch-id record)) record))
         history))
@@ -379,7 +352,7 @@
 ;; ---- restore preconditions + perform --------------------------------------
 
 (defn check-restore-preconditions!
-  "Validate the seven documented preconditions for restoring `frame-id`
+  "Validate the documented preconditions for restoring `frame-id`
   to `epoch-id`. Returns a result map:
 
     {:outcome :ok :epoch <epoch>}
@@ -392,9 +365,7 @@
                    emission is the caller's job so the
                    precondition test stays a pure data check.
 
-  Failure modes preserve the exact operation keywords and tag shapes
-  the public surface has always emitted (see `restore-epoch!`'s
-  docstring for the catalogue)."
+  See `restore-epoch!` for the refusal catalogue."
   [frame-id epoch-id]
   (let [frame-result (frame-exists-or-fail frame-id)]
     (cond
@@ -421,10 +392,8 @@
                      :rf.epoch/id  epoch-id
                      :history-size (count history)}}
 
-          ;; (3a) Halted-cascade target? Per rf2-v0jwt: an epoch whose
-          ;; :outcome is not :ok records partial state the cascade
-          ;; never settled to, so it is not a valid restore target.
-          ;; Refuse before the schema / handler / version checks so
+          ;; Halted records contain partial state and are not restore targets.
+          ;; Refuse before schema, handler, and version checks so
           ;; the failure surfaces with the actual halt context, not
           ;; a downstream consequence of the partial db.
           (not= :ok (get epoch :outcome :ok))
@@ -436,11 +405,10 @@
                      :halt-reason (:halt-reason epoch)}}
 
           :else
-          (let [;; EP-0001 (rf2-3aizt1, decision #2): the canonical restore
-                ;; target is the whole frame-state. The app-db partition
+          (let [;; The canonical restore target is the whole frame state.
+                ;; The app-db partition
                 ;; feeds the schema check; the runtime-db partition feeds
-                ;; the machine / route reference + version checks (rf2-k4xe7u
-                ;; — snapshots + route slice are runtime-db state). Both are
+                ;; machine/route reference and version checks. Both are
                 ;; read off the canonical `:frame-state-after` — the only
                 ;; restore target `build-record` ever emits (the `:db-after`
                 ;; slot is a retained app-db PROJECTION for tool diffs, never
@@ -449,9 +417,9 @@
                 frame-state-target (:frame-state-after epoch)
                 db-target          (get frame-state-target frame/app-partition-key)
                 runtime-target     (get frame-state-target frame/runtime-partition-key)]
-            ;; Each helper is called once and its result bound, so the
+            ;; Bind each probe once so each substrate is walked once.
             ;; failure path walks the recorded db / schema set / machine
-            ;; map exactly once per check (rf2-081zk).
+            ;; map exactly once per check.
             (if-let [failing-paths (seq (failing-schema-paths frame-id db-target))]
               ;; (4) Schema mismatch?
               ;; Per Spec 010 §Schema digest + Tool-Pair §Time-travel:
@@ -478,7 +446,7 @@
 
                 (if-let [{:keys [machine-id machine-type recorded current]} (machine-version-mismatch runtime-target)]
                   ;; (6) Machine snapshot version drift?
-                  ;; rf2-rlt3sv: `:machine-type` identifies a SPAWNED actor's
+                  ;; `:machine-type` identifies a spawned actor's
                   ;; TYPE (keyword or inline-definition map) alongside its
                   ;; instance `:machine-id`; nil/omitted for a singleton whose
                   ;; key is its own type. Spawned-actor drift is now caught:
@@ -495,7 +463,7 @@
 
                   {:outcome :ok :epoch epoch})))))))))
 
-;; ---- write-boundary liveness guard (rf2-7i872) ----------------------------
+;; ---- write-boundary liveness guard ----------------------------------------
 ;;
 ;; Precondition validation (`check-restore-preconditions!` /
 ;; `check-replace-frame-state-preconditions!`) resolves the frame, but a frame
@@ -520,7 +488,7 @@
   the canonical no-such-handler precondition-failure result
   (`{:outcome :fail :op :rf.error/no-such-handler :tags {:kind :frame
   :frame frame-id}}`) when the frame was destroyed between precondition
-  validation and now (the validate-then-destroy race, rf2-7i872). Mirrors
+  validation and now. Mirrors
   `frame-exists-or-fail`'s failure shape so the destroyed-frame write race
   surfaces identically to a frame-miss caught at validate-time."
   [frame-id]
@@ -531,7 +499,7 @@
      :tags    {:kind  :frame
                :frame frame-id}}))
 
-;; ---- runtime-db subsystem reconcile on restore (rf2-7r5mc2) ---------------
+;; ---- runtime-db subsystem reconcile on restore ----------------------------
 ;;
 ;; Epoch restore installs the captured frame-state WHOLESALE — it does not run
 ;; ordinary `:db`-effect semantics, so a runtime SUBSYSTEM whose durable
@@ -562,7 +530,7 @@
   resources-first extension point, mirroring SSR hydration's single
   `:resources/hydrate-runtime-db` consult.
 
-  Per rf2-obi8rr the reconcile is invoked with `{:defer-traces? true}` so it does
+  Reconcile uses `{:defer-traces? true}` so it does
   NOT emit its `:rf.resource/restored` / `:rf.resource/owner-released` success
   rows inline — the reconcile runs BEFORE the atomic install, which can still
   fail (a destroyed-frame install returns nil). The deferred trace intents ride
@@ -570,7 +538,7 @@
   `:resources/commit-restore-reconcile!` only AFTER a successful install, so a
   failed restore leaks no resource success traces.
 
-  Per rf2-wshzsp the restore's CAUSAL time — `restore-time-ms`, the restored
+  The restore's causal time — `restore-time-ms`, the restored
   epoch's `:committed-at` (the committing token's `:rf.cofx` `:rf/time-ms`,
   replay-stable per EP-0010 §Time) — is threaded through `:restore-time-ms` so
   the reconcile stamps a dangled-on-restore mutation instance's DURABLE
@@ -590,10 +558,9 @@
        frame-state)
      frame-state)))
 
-;; ---- restore-time host-transient quiesce (rf2-u5kmf8) ---------------------
+;; ---- restore-time host-transient quiesce ----------------------------------
 ;;
-;; EP-0011 / Managed-Effects §SSR, preload, hydration, and restore: "Hydration
-;; and epoch restore MUST NOT revive host work." A restore installs the captured
+;; Restore must not revive host work. It installs the captured
 ;; durable frame-state WHOLESALE, but the ASYNC HOST WORK the unwound epochs
 ;; spawned — machine `:after` host-clock timers (re-frame.machines.timer's
 ;; frame-scoped handle table) and non-resource managed-HTTP AbortControllers /
@@ -603,7 +570,7 @@
 ;; orphaned host handles so a late pre-restore completion is stale-suppressed and
 ;; never delivers to its original `:rf/reply-to` target.
 ;;
-;; The `:resources/reconcile-on-restore` hook (rf2-7r5mc2) reconciles the
+;; The resources restore hook reconciles its
 ;; Resources subsystem's runtime-db slice + clears its host transients. This is
 ;; the restore counterpart for the OTHER managed async subsystems — the mirror
 ;; of destroy-frame!'s `:machines/on-frame-destroyed!` /
@@ -638,7 +605,7 @@
 
 (defn quiesce-orphaned-async-host-work!
   "Fire the restore-time host-transient quiesce hook chain for `frame-id`
-  (rf2-u5kmf8). Invoked by `perform-restore!` ONLY AFTER a successful
+  after a successful
   `replace-frame-state!` install — a destroyed-frame install (which wrote
   nothing) returns before this point, so a restore that never landed never
   cancels a live frame's host work. Each `restore-quiesce-hooks` entry is a
@@ -660,7 +627,7 @@
 
 (defn commit-resources-restore-traces!
   "Emit the resources restore-reconcile trace rows DEFERRED by
-  `reconcile-runtime-db-on-restore` (rf2-obi8rr), consulting the late-bound
+  `reconcile-runtime-db-on-restore`, consulting the late-bound
   `:resources/commit-restore-reconcile!` hook with the reconciled runtime-db
   partition of `frame-state`. Invoked by `perform-restore!` ONLY AFTER a
   successful `replace-frame-state!` install, so the `:rf.resource/restored` /
@@ -676,90 +643,40 @@
   nil)
 
 (defn perform-restore!
-  "Carry out the actual frame-state rewind once preconditions have passed.
-  Replaces the frame's whole frame-state with `epoch`'s `:frame-state-after`
-  (BOTH partitions — app-db AND runtime-db) and emits `:rf.epoch/restored`.
-  Returns `true` on a real write.
+  "Install the target epoch's whole `:frame-state-after` after validation.
 
-  EP-0001 (rf2-3aizt1, decisions #2 + #9): restore rewinds to the canonical
-  `:frame-state-after` via `replace-frame-state!`, reviving machine
-  snapshots, the route slice, elision declarations, and SSR metadata
-  (runtime-db state) — not just the app-db partition. Without this, a
-  rewind past a machine spawn / destroy left the actor's snapshot un-reverted
-  (the Goal-2 revertibility leak the actor-revertibility tests pin).
-  `:frame-state-after` is the only restore source — every record
-  `build-record` emits carries it. The `:db-after` slot is a retained
-  app-db PROJECTION for tool diffs, never a restore source; a record with
-  no `:frame-state-after` is malformed/unreachable on the current build path.
+  App-db and runtime-db are restored atomically; `:db-after` is only a tool
+  projection. Optional subsystems reconcile captured durable state against
+  current host state before install, deferring success traces until the write
+  lands.
 
-  Per rf2-7i872 (validate-then-destroy race): re-resolves the container at
-  the write boundary via `live-container-or-fail`. If the frame was
-  destroyed between the precondition pass and now, the container is nil and
-  `replace-frame-state!` would silently no-op — so instead of emitting
-  `:rf.epoch/restored` and returning `true` (a FALSE success), this emits
-  the canonical `:rf.error/no-such-handler` (kind `:frame`) failure trace
-  and returns `false`, matching the destroyed-frame contract.
-
-  Per rf2-s93722 (post-liveness teardown race): the liveness check above
-  closes only HALF the window — a frame destroyed AFTER `live-container-or-
-  fail` passes but BEFORE `replace-frame-state!` actually writes still slips
-  through. `frame/replace-frame-state!` returns `nil` for a destroyed frame
-  (a non-nil — possibly EMPTY — changed-key-set for a live frame, even a
-  no-op write), so we check that return: a `nil` return is the destroyed-
-  frame signal, surfaced as the same `:rf.error/no-such-handler` (kind
-  `:frame`) failure / `false` return BEFORE any success telemetry.
-
-  Per rf2-7r5mc2 (resources runtime-db reconcile on restore): a runtime-db
-  partition carrying a runtime SUBSYSTEM whose durable snapshot is not safe to
-  install verbatim must be reconciled against the live transient world BEFORE
-  the install (Spec 016 §Restore and replay — restore shares the SSR-hydration
-  install path). Resources is the first such subsystem: `reconcile-runtime-db-on-
-  restore` consults the late-bound `:resources/reconcile-on-restore` hook, which
-  settles mid-flight `:loading` / `:fetching` entries to last-stable, clears each
-  entry's vanished `:current-work`, orphans SSR / stale-nav owners, recomputes
-  the reverse indexes from `:entries`, and records restored non-terminal
-  work-ledger rows as dangling so a pre-restore in-flight reply is suppressed.
-  No-op (passes the runtime-db through) when no resources artefact is loaded.
-
-  Per rf2-obi8rr (defer restore trace rows until install succeeds): the resources
-  reconcile above runs BEFORE the atomic install but its `:rf.resource/restored` /
-  `:rf.resource/owner-released` SUCCESS trace rows must fire only once the restore
-  TRULY installs. So the reconcile defers those rows (it is called with
-  `:defer-traces? true`, riding the intents back as metadata); they are emitted
-  via `commit-resources-restore-traces!` ONLY on the success branch below — never
-  for a destroyed-frame install that returns nil and writes nothing."
+  Frame liveness is checked again at the write boundary, and the write's return
+  closes the remaining teardown race: nil means no write, while a non-nil set,
+  including empty, is success. Only the success branch emits restore telemetry,
+  re-anchors post-settle attribution, commits deferred subsystem traces, and
+  cancels host-transient work from the abandoned timeline."
   [frame-id epoch]
   (let [{:keys [outcome op tags]} (live-container-or-fail frame-id)]
     (if (= :fail outcome)
       (do (emit-precondition-failure! op tags)
           false)
-      (let [;; EP-0001 (rf2-3aizt1): the canonical, only restore source is
-            ;; the whole `:frame-state-after`. The `:db-after` slot is a
-            ;; retained app-db projection for tool diffs, never installed —
-            ;; a record with no `:frame-state-after` is malformed/unreachable
-            ;; on the current build path.
+      (let [;; Whole `:frame-state-after` is the only restore source.
             frame-state-target (:frame-state-after epoch)
-            ;; rf2-7r5mc2: reconcile the runtime-db partition's runtime
-            ;; subsystems (Resources, first writer) BEFORE the atomic install,
+            ;; Reconcile runtime subsystems before the atomic install,
             ;; the same way SSR hydration reconciles its installed slice — so a
             ;; mid-flight captured snapshot does not install stranded
             ;; `:loading` / `:fetching` entries pointing at vanished attempts,
             ;; and a pre-restore reply cannot write stale data into a restored
             ;; entry.
-            ;; rf2-wshzsp: thread the restored epoch's CAUSAL time
+            ;; Thread the restored epoch's causal time
             ;; (`:committed-at` = the committing token's `:rf.cofx`
             ;; `:rf/time-ms`) so the reconcile stamps a dangled-on-restore
             ;; mutation instance's durable `:settled-at` from a replay-stable
             ;; causal input, not the live install clock (EP-0010 §Restore/Replay).
             frame-state-target (reconcile-runtime-db-on-restore
                                  frame-id frame-state-target (:committed-at epoch))
-            ;; EP-0001 (rf2-3aizt1): write the WHOLE frame-state — both
-            ;; partitions in ONE atomic install through the one physical
-            ;; frame-state container. `frame/app-db-container` /
-            ;; `runtime-db-container` are READ-ONLY projections, so the write
-            ;; goes through `replace-frame-state!`.
-            ;; rf2-s93722: capture the return — `nil` means the frame was
-            ;; destroyed in the post-liveness window (no write happened); a
+            ;; Write both partitions through the one physical frame container.
+            ;; Nil means the frame was destroyed after the liveness check; a
             ;; non-nil changed-key-set (even empty) means the write landed.
             changed (frame/replace-frame-state! frame-id frame-state-target)]
         (if (nil? changed)
@@ -769,56 +686,21 @@
           (do (trace/emit! :rf.epoch :rf.epoch/restored
                            {:frame       frame-id
                             :rf.epoch/id (:epoch-id epoch)})
-              ;; rf2-w4q9gt — RE-ANCHOR the post-settle back-fill attribution to
-              ;; the RESTORED-TARGET epoch. A successful restore rewinds the
-              ;; frame's state but runs no ordinary cascade, so it never updates
-              ;; `last-settled-epoch` on its own. Left untouched, the anchor keeps
-              ;; pointing at whatever event settled most recently BEFORE the
-              ;; restore — so the repaint / subscription / unmount activity a
-              ;; restore triggers (these fire post-settle at React commit / deref
-              ;; / teardown time) back-fills into that unrelated stale epoch
-              ;; (`state/last-settled-epoch-id` is the anchor `record-render!` /
-              ;; `record-sub-run!` / `record-unmount!` read — listeners.cljc),
-              ;; corrupting a later epoch's historical `:renders` / `:sub-runs` /
-              ;; `:trace-events` AFTER the frame has been rewound. The replace-*
-              ;; injection siblings already re-anchor to their synthetic epoch
-              ;; (`set-last-settled-epoch!` in `record-synthetic-replace-epoch!` /
-              ;; `perform-replace!`); restore was the one mutating write
-              ;; that did not. The restored target IS the epoch whose state is now
-              ;; installed, so restore-induced repaint belongs to it — restored-
-              ;; target attribution. Set ONLY on the success branch: a failed /
-              ;; destroyed-frame install returns above with the anchor (and frame
-              ;; state, history, listeners) unchanged.
+              ;; Restore triggers no ordinary event, so explicitly anchor its
+              ;; repaint/subscription/unmount back-fill to the restored epoch.
               (state/set-last-settled-epoch! frame-id (:epoch-id epoch))
-              ;; rf2-obi8rr — the install succeeded, so it is now safe to emit
-              ;; the resources restore-reconcile success rows the reconcile
-              ;; deferred. A destroyed-frame install (nil branch above) returns
-              ;; before this point, so those rows never fire for a no-op write.
+              ;; Deferred subsystem success traces are valid only after install.
               (commit-resources-restore-traces! frame-state-target)
-              ;; rf2-u5kmf8 — quiesce the orphaned async host work the unwound
-              ;; epochs spawned (machine :after host-clock timers + non-resource
-              ;; managed-HTTP in-flight handles). These are host transients, not
-              ;; frame-state, so the wholesale install left them attached to the
-              ;; pre-restore timeline; cancelling/clearing them now keeps a late
-              ;; pre-restore completion from delivering to its original
-              ;; :rf/reply-to target (EP-0011 / Managed-Effects §restore: "epoch
-              ;; restore MUST NOT revive host work"). Fired ONLY on the success
-              ;; branch, like commit-resources-restore-traces! above — a
-              ;; destroyed-frame install returns before this point.
+              ;; Host timers and HTTP handles are not frame state; cancel the
+              ;; abandoned timeline only after the new state is installed.
               (quiesce-orphaned-async-host-work! frame-id)
               true))))))
 
 ;; ---- replace-frame-state! preconditions ------------------------------------
 ;;
-;; rf2-t3lftq (API-shrink #3): the former four-mutator family
-;; (`replace-app-db!` / `reset-app-db!` / `replace-runtime-db!` /
-;; `replace-frame-state!`) is consolidated to ONE partial-map write —
-;; `replace-frame-state!` — differing single-partition callers now compose a
-;; one-key map. `check-replace-frame-state-preconditions!` validates: (0) bad
+;; `replace-frame-state!` accepts a partial map. Preconditions validate: bad
 ;; keys? (1) frame registered? (2) in-flight drain? (3) history disabled?
-;; (4) schema mismatch on the PRESENT partitions only. Per Tool-Pair §Pair-tool
-;; writes (Spec 009 §Trace events lists `:rf.epoch/replace-*` under this
-;; surface).
+;; (4) schema mismatch on present partitions only.
 
 (def ^:private frame-state-partition-keys
   "The two recognized `replace-frame-state!` partition keys — the closed
@@ -828,7 +710,7 @@
 
 (defn- replace-frame-state-bad-keys
   "Validate `frame-state`'s key set against the closed
-  `frame-state-partition-keys` vocabulary (rf2-t3lftq — API-shrink #3).
+  `frame-state-partition-keys` vocabulary.
   Returns nil when the map is well-formed (at least one recognized
   partition key, no unrecognized ones), otherwise a
   `{:reason <kw> :keys <vec>}` map describing the problem:
@@ -864,8 +746,7 @@
 
 (defn check-replace-frame-state-preconditions!
   "Validate the documented preconditions for `replace-frame-state!`, the
-  ONE frame-state write surface (rf2-t3lftq — API-shrink #3 consolidated
-  `replace-app-db!` / `reset-app-db!` / `replace-runtime-db!` into this).
+  frame-state write surface.
   `frame-state` is a PARTIAL frame-state map (any subset of
   `{:rf.db/app … :rf.db/runtime …}`). Returns `{:outcome :ok}` when every
   check passes, otherwise `{:outcome :fail :op <kw> :tags <map>}` matching
@@ -884,8 +765,7 @@
     (2) In-flight drain?
     (3) History disabled (depth 0)? The synthetic undo-anchor cannot land
         in the (disabled) ring, so the undo-works-after invariant is
-        unsatisfiable — reject loudly rather than return a false success
-        (rf2-unpldn).
+        unsatisfiable, so reject rather than return a false success.
     (4) Schema mismatch? Validates ONLY the PRESENT partitions — an absent
         key is preserved, not written, so it is not walked: the app-db
         partition (when present) against the frame's app-schema set
@@ -895,8 +775,8 @@
         UNION of failing paths — a failure on EITHER rejects the whole
         atomic install.
 
-  Per rf2-unpldn: `replace-frame-state!` records a synthetic
-  `:rf.epoch/db-replaced` epoch so that `restore-epoch!` can rewind PAST
+  `replace-frame-state!` records a synthetic `:rf.epoch/db-replaced` epoch so
+  that `restore-epoch!` can rewind past
   the injection — the caller's invariant is \"undo works after this call\"
   (Tool-Pair §Pair-tool writes, the same invariant the artefact-missing
   wrapper raises to honour at `core-epoch.cljc`). Under
@@ -931,8 +811,7 @@
 
         ;; (3) History disabled (depth 0)? The synthetic undo-anchor cannot
         ;; land in the (disabled) ring, so the undo-works-after invariant is
-        ;; unsatisfiable — reject loudly rather than return a false success
-        ;; (rf2-unpldn).
+        ;; unsatisfiable, so reject rather than return a false success.
         (not (pos? (state/depth)))
         {:outcome :fail
          :op      :rf.epoch/replace-history-disabled
@@ -956,81 +835,16 @@
 
 ;; ---- projected egress -----------------------------------------------------
 ;;
-;; Per Security.md §Epoch privacy posture, EP-0015 §15 (Epoch Redaction) +
-;; open-issue 6 (RULED), and rf2-mrsck: the framework's single normative
-;; projection emission site for off-box epoch egress. The in-process ring
-;; buffer (`epoch-history`) and `register-epoch-listener!` listener fan-out
-;; deliver RAW records — restore-epoch! and on-box devtools (Xray diff,
-;; REPL inspection) need them, and post-EP-0010 those raw records are
-;; causal replay material. Tools that egress an epoch record across a
-;; process boundary (Xray-MCP `watch-epochs`, story / pair recorders,
-;; hosted forwarders) MUST route through `projected-record` first.
-;;
-;; FRAME/PROFILE PROJECTION (EP-0015 §15). Each tree-shaped payload slot is
-;; projected through `re-frame.projection/project-egress` under the
-;; `:rf.egress/off-box-observability` profile — the named export boundary
-;; for hosted-monitoring / log-shipper / recorder egress (EP-0015 §10
-;; default-behaviour table: redact sensitive, elide large, omit digests).
-;; `project-egress` resolves that profile to the `:rf.size/*` opt-set
-;; `elide-wire-value` consumes; the trusted-local plain opts
-;; (`:include-sensitive?` / `:include-large?`) compose on top as explicit
-;; `:rf.size/*` overrides (the override wins). The epoch record is not one
-;; of `project-egress`'s `:rf.observe/*` record kinds, so each tree slot is
-;; handed to `project-egress` as a KINDLESS tree value (the direct-read
-;; path), which delegates to `elide-wire-value` against the frame's
-;; classification. Routing every slot through the frame/profile projection
-;; primitive (EP-0015 bead-plan item 10) keeps elision in one place.
-;;
-;; Two slots are value-bearing and need the same projection walk:
-;;
-;;   - The CANONICAL frame-state slots `:frame-state-before` /
-;;     `:frame-state-after` (EP-0001 rf2-3aizt1 decision #2 + ruling #14):
-;;     their `:rf.db/app` partition is projected through the same
-;;     frame/profile walk the `:db-*` projections receive, while their
-;;     `:rf.db/runtime` partition is DEFAULT-REDACTED to `:rf/redacted`
-;;     off-box (see `project-frame-state-slot`).
-;;   - The structured `:sub-runs` rows (rf2-at60h): each carries the
-;;     sub's computed `:prev-value` / `:value`, so the rows DO carry
-;;     app-db material and the whole-output `:large?` case is projected
-;;     through the `:rf.size/large-elided` marker (see
-;;     `elide-sub-runs-slot`). Their non-value metadata (`:sub-id`,
-;;     `:query-v`, `:value-changed?`, `:cascade?`, `:cause-sub`,
-;;     `:cause-event-id`) passes through.
-;;
-;; The remaining full-value slots — the derived `:db-before` /
-;; `:db-after` app-db projections, `:trigger-event`, and `:trace-events`
-;; — also route through `project-egress`. The structured `:effects`
-;; rows carry payload-bearing `:args` (raw fx-handler arguments) that fail
-;; closed to `:rf/redacted` off-box (rf2-rlt3sv, `elide-effects-slot`); the
-;; `:renders` slot carries no app-db material (render-keys + timing +
-;; cause), so the projection leaves it as-is. The record-level bookkeeping
-;; (`:epoch-id`,
-;; `:frame`, `:committed-at`, `:event-id`, `:outcome`, `:halt-reason`,
-;; `:schema-digest`, `:rf.epoch/sensitive?`,
-;; `:rf.epoch/redacted-modified-paths-count`) is structurally
-;; non-sensitive and passes through. `projected-record`'s docstring is
-;; the authoritative per-slot contract.
-;;
-;; APP-SUPPLIED `:redact-fn` ADVANCED OVERRIDE (EP-0015 §15 + open-issue 6,
-;; RULED). After the frame/profile projection lands, `projected-record`
-;; applies the installed `:redact-fn` (`assembly/apply-redact-fn`) to the
-;; PROJECTED record — the rare advanced escape for material the
-;; declaration-driven projection cannot prove (a slot no frame / schema
-;; declaration covers). It runs ONLY here, on the off-box
-;; egress copy; the ring stays raw, so it can never affect `restore-epoch!`
-;; fidelity (the §15 hazard is gone by construction).
-;;
-;; Per-tool reimplementation of the projection is prohibited (the
-;; same posture as the wire-elision walker). New egress tools call
-;; `projected-record` and trust the contract.
+;; Raw records are replay material and remain in-process. Every off-box consumer
+;; uses `projected-record`: app-db-rooted trees go through the named egress
+;; profile, runtime-db and unclassifiable transient payloads fail closed, and the
+;; optional advanced override runs last on the projected copy. The facade
+;; docstring is the public per-slot contract.
 
 (def ^:private default-egress-profile
-  "The DEFAULT named export boundary for epoch off-box egress (EP-0015 §10)
-  when the caller names none. The hosted-monitoring consumers (log shippers
-  / Story / pair recorders) want `:rf.egress/off-box-observability` (redact
-  sensitive, elide large, omit digests), so it stays the floor.
+  "The default named export boundary for epoch off-box egress.
 
-  An MCP / AI / tool consumer (rf2-1afn7q) selects the
+  An MCP or AI tool selects the
   `:rf.egress/off-box-tool` boundary instead via `projected-record`'s
   `:rf.egress/profile` opt — that profile keeps the same redact/elide
   defaults but turns on `:rf.size/include-digests?`, so a large owner-local
@@ -1039,8 +853,8 @@
   :rf.egress/off-box-observability)
 
 (defn- resolve-egress-profile
-  "Resolve the named `:rf.egress/profile` an epoch egress call walks under
-  (rf2-1afn7q). The off-box egress boundary is named — the caller answers
+  "Resolve the named `:rf.egress/profile` an epoch egress call walks under.
+  The caller names
   *\"which boundary is this?\"* (hosted observability vs. MCP/AI tool wire)
   rather than assembling boolean combinations. The default is
   `:rf.egress/off-box-observability` (hosted monitoring), so the bare
@@ -1054,17 +868,14 @@
   [profile]
   (let [profile (or profile default-egress-profile)]
     (when-not (contains? projection/profiles profile)
-      ;; ONE shared builder for both closed-enum guards (rf2-krrv87) — the
-      ;; in-file `re-frame.projection/resolve-elision-opts` guard and this
-      ;; epoch-boundary guard route through `unknown-egress-profile-ex`, so
-      ;; the human sentence + the `[:rf.error/unknown-egress-profile]` token
-      ;; cannot drift. This site passes its own `:where 'epoch/projected-record`.
+      ;; Share the projection layer's closed-enum error builder so wording and
+      ;; the machine-readable token cannot drift.
       (throw (projection/unknown-egress-profile-ex 'epoch/projected-record profile)))
     profile))
 
 (defn- egress-opts
   "Build the `project-egress` opts map from a `projected-record` egress
-  opts map (rf2-5w06uu, rf2-1afn7q). The named `:rf.egress/profile`
+  opts map. The named `:rf.egress/profile`
   selects the boundary (default `:rf.egress/off-box-observability`); MCP /
   AI / tool consumers pass `:rf.egress/off-box-tool` to receive the
   structural marker indicators / counters the tool profile enables. The
@@ -1074,7 +885,7 @@
   explicit `:rf.size/*` overrides (the override wins — see
   `re-frame.projection/resolve-elision-opts`). The record frame is stamped
   so the frame's declared sensitive / large paths (keyed by absolute app-db
-  path, installed frame-owned per EP-0015 §3) match the projected value."
+  path) match the projected value."
   [frame-id {:keys [include-sensitive? include-large?] :rf.egress/keys [profile]}]
   {:rf.egress/profile          (resolve-egress-profile profile)
    :frame                      frame-id
@@ -1086,12 +897,11 @@
   profile selected by `opts` (default `:rf.egress/off-box-observability`),
   rooted at the named frame.
   Off-box defaults (`:include-sensitive? false`, `:include-large? false`)
-  hold unless `opts` opts back in (rf2-5w06uu). The epoch record is not a
+  hold unless `opts` opts back in. The epoch record is not a
   `:rf.observe/*` record kind, so the slot VALUE is projected as a kindless
   tree (the direct-read path → `elide-wire-value` against the frame's
   classification). Returns the projected value; `nil` slots are preserved
-  as nil (a halted-destroy record's `:db-before` / `:db-after` are nil per
-  rf2-v0jwt; the schema admits the absent / nil slot — the projection
+  as nil (halted records may have nil app-db slots; the projection
   MUST NOT fabricate a value)."
   [v frame-id opts]
   (when (some? v)
@@ -1099,7 +909,7 @@
 
 (defn- project-frame-state-slot
   "Project a `:frame-state-before` / `:frame-state-after` slot for off-box
-  egress (EP-0001 rf2-3aizt1, Mike ruling #14). The frame-state value is
+  egress. The frame-state value is
   `{:rf.db/app <app-db> :rf.db/runtime <runtime-db>}`; the two partitions
   egress under DIFFERENT default policies:
 
@@ -1108,16 +918,15 @@
       large paths → markers), the SAME projection the `:db-before` /
       `:db-after` app-db projections receive. `opts` `:include-sensitive?` /
       `:include-large?` opt the app-db partition's privacy / size posture
-      back in (rf2-5w06uu).
+      back in.
 
-    - `:rf.db/runtime` — the framework runtime-db. REDACTED by default off-box
-      (Mike ruling #14 — Spec 011 §Off-box redaction + Security.md §Epoch
-      privacy posture): the runtime-db side is substituted with the
+    - `:rf.db/runtime` — the framework runtime-db. Redacted by default off-box;
+      the runtime-db side is substituted with the
       `:rf/redacted` sentinel rather than walked, so machine snapshots /
       route slice / SSR metadata do not egress to AI / log channels by
       default. The runtime-db partition boundary is ORTHOGONAL to the
       app-db `:include-sensitive?` / `:include-large?` opt-ins — those do
-      NOT lift it (the rf2-5w06uu bypass). A TRUSTED-LOCAL caller that
+      NOT lift it. A trusted-local caller that
       genuinely needs runtime-db diagnostics opts in explicitly with
       `:include-runtime-db? true`; the runtime-db value is then projected
       through the same frame/profile walk (its own per-slot sensitive /
@@ -1130,10 +939,10 @@
     (cond-> fs
       (contains? fs :rf.db/app)
       (update :rf.db/app projection/project-egress (egress-opts frame-id opts))
-      ;; Default-redact the runtime-db side off-box (ruling #14). The
+      ;; Default-redact runtime-db off-box. The
       ;; trusted-local `:include-runtime-db? true` opt-in lifts the
       ;; partition redaction; the value still rides the value walk so its
-      ;; own sensitive / large declarations apply (rf2-5w06uu).
+      ;; own sensitive / large declarations apply.
       (and (contains? fs :rf.db/runtime) (not include-runtime-db?))
       (assoc :rf.db/runtime :rf/redacted)
 
@@ -1141,7 +950,7 @@
       (update :rf.db/runtime projection/project-egress (egress-opts frame-id opts)))))
 
 (defn- reroot-trace-event-db-slots
-  "Per rf2-ta0y7: the `:rf.event/db-pending` (t1) and
+  "The `:rf.event/db-pending` (t1) and
   `:rf.event/db-pending-post-flow` (t2) trace events each carry the
   FULL pending `:db` value under `:tags :rf.event/db`. The bulk
   `project-payload-slot` above walks `:trace-events` as a single root —
@@ -1157,9 +966,8 @@
   the frame's app-db so the sensitive / large declarations match
   natively. Symmetric with how `flows.cljc` elides `:rf.flow/computed`'s
   `:result` / `:before` at emit-time using the flow's `:path`; here we
-  do it at egress because the t1/t2 stamps are stored raw on the
-  ring (Mike's ruling — store the value plain, PDS keeps the cost
-  pointer-sized; the egress projection is the privacy boundary).
+  do it at egress because the t1/t2 stamps are stored raw and the egress
+  projection is the privacy boundary.
 
   Returns the trace-events vector with the inner `:rf.event/db` slots
   re-projected; non-t1/t2 events pass through untouched, and events
@@ -1188,7 +996,7 @@
                     ev))))
             trace-events))))
 
-;; ---- off-box HTTP response-body fail-closed (rf2-t55hxg.6, rf2-t55hxg.10) --
+;; ---- off-box HTTP response-body fail-closed -------------------------------
 ;;
 ;; EP-0015 disposition 5: a managed HTTP response body is a
 ;; registration-owned transient payload; an UNSCHEMATIZED body (no Malli
@@ -1208,7 +1016,7 @@
 ;; on-box emit, so it rides as-is. No HTTP-artefact dependency — only the
 ;; stamped keyword + the per-operation body-slot path(s) are read.
 ;;
-;; rf2-t55hxg.10 — the SAME disposition-5 rule for the RAW error-response
+;; The same disposition-5 rule applies to a raw error-response
 ;; body: `:rf.http/http-4xx` / `:rf.http/http-5xx` carry the raw response
 ;; body at `:body`, `:rf.http/decode-failure` carries the raw text at
 ;; `:body-text`, and `:rf.http/retry-attempt` nests the intermediate failure
@@ -1230,17 +1038,16 @@
    - `:rf.http/replied`        — the decoded body at `[:value]`;
    - `:rf.http/accept-failure` — the pre-`:accept` decoded body at `[:decoded]`;
    - `:rf.http/http-4xx` / `:rf.http/http-5xx` — the raw response body at
-     `[:body]` (rf2-t55hxg.10);
-   - `:rf.http/decode-failure` — the raw response text at `[:body-text]`
-     (rf2-t55hxg.10);
+     `[:body]`;
+   - `:rf.http/decode-failure` — the raw response text at `[:body-text]`;
    - `:rf.http/retry-attempt`  — the intermediate failure's raw body nested at
-     `[:failure :body]` / `[:failure :body-text]` (rf2-t55hxg.10).
+     `[:failure :body]` / `[:failure :body-text]`.
 
   A vector of slot PATHS (each a `get-in`/`assoc-in` path) so an operation
   whose body can ride in more than one slot (retry-attempt) is covered with
   one general rule rather than a per-slot special case.
 
-  Elision (rf2-t55hxg.10): the table is the tool-pair OFF-BOX ENFORCEMENT,
+  The table is the tool-pair off-box enforcement,
   not the on-box stamp — it lives behind the same `interop/debug-enabled?`
   boundary that elides the whole epoch off-box projection surface in
   production (`epoch/projected-record` — \"Production builds elide the
@@ -1266,8 +1073,8 @@
      :rf.http/retry-attempt  [[:failure :body] [:failure :body-text]]}))
 
 (defn- omit-off-box-http-bodies
-  "Per rf2-t55hxg.6 + rf2-t55hxg.10: enforce the EP-0015 disposition-5 off-box
-  fail-closed rule on `:rf.http/*` trace events. For each event whose emit
+  "Enforce the fail-closed rule for off-box HTTP body trace events. For each
+  `:rf.http/*` event whose emit
   site stamped `:tags :rf.http/off-box-body :omit` (an UNSCHEMATIZED response
   body — whole-sensitive off-box, including every RAW error-response body),
   substitute the `:rf/redacted` sentinel for each of the operation's body-slot
@@ -1301,8 +1108,8 @@
           trace-events)))
 
 (def ^:private event-arg-tag-slots
-  "The trace-event tag slots that carry the DISPATCHED EVENT VECTOR
-  `[<event-id> <arg> …]` (rf2-nm611o). The same registration-owned
+  "The trace-event tag slots that carry the dispatched event vector
+  `[<event-id> <arg> …]`. The same registration-owned
   transient event args the `:trigger-event` record slot carries ride here,
   on EVERY `:rf.event/*` op of a cascade (`:rf.event/dispatched`,
   `:rf.event/run-start`, `:rf.event/db-pending`, `:rf.event/db-changed`,
@@ -1318,7 +1125,7 @@
   [:rf.event/v :event])
 
 (defn- omit-off-box-event-args
-  "Per rf2-nm611o: enforce the EP-0015 §151 registration-owned-transient
+  "Enforce the registration-owned-transient
   fail-closed rule on the dispatched-event-vector tag slots
   (`event-arg-tag-slots`) of every trace event. For each slot present whose
   value is the event vector `[<id> <arg> …]`, retain the head event-id
@@ -1354,7 +1161,7 @@
           trace-events)))
 
 (defn- omit-off-box-resource-scope-values
-  "Per rf2-84l82t (EP-0015): redact the resolver-owned VALUES on a
+  "Redact the resolver-owned values on a
   `:rf.resource/scope-resolved` trace row for off-box egress. The row carries
   the resolved `:input-values` (the concrete db reads) and the derived `:scope`
   (which embeds them) — owner-local identity-bearing values the generic
@@ -1390,10 +1197,10 @@
 (defn- resource-family-op?
   "Whether a trace op belongs to the resource / mutation egress-record family —
   a `:rf.resource/*` or `:rf.mutation/*` keyword whose tags may embed
-  owner-local scoped keys (rf2-8x0gfa). ALSO covers the resources-family
+  owner-local scoped keys. Also covers the resources-family
   DIAGNOSTICS that ride the `:rf.warning/*` namespace but carry the same
   owner-local scoped-key / scope tags — `:rf.warning/resource-*` (e.g.
-  `:rf.warning/resource-load-more-owner-ignored` per rf2-bi8vg1, which carries a
+  `:rf.warning/resource-load-more-owner-ignored`, which carries a
   `:resource/key`, and `:rf.warning/resource-clear-scope-unresolved`, which
   carries a `:scope`). Those rows must take the SAME fail-closed family egress
   projection as the `:rf.resource/*` rows, not slip through the
@@ -1407,7 +1214,7 @@
                   (str/starts-with? (name op) "resource-"))))))
 
 (defn- omit-off-box-resource-trace-keys
-  "Per rf2-8x0gfa (EP-0015): redact the owner-local SCOPED KEYS embedded in the
+  "Redact the owner-local scoped keys embedded in the
   BROADER resource/mutation trace family's tag slots for off-box egress — the
   family-level companion to `omit-off-box-resource-scope-values`. The
   `:rf.resource/*` + `:rf.mutation/*` rows copy scoped keys into `:resource/key`
@@ -1452,18 +1259,18 @@
       trace-events)))
 
 (defn- elide-trace-events-slot
-  "The `:trace-events` projection chain (rf2-ta0y7): first re-root the
+  "Project `:trace-events`: first re-root the
   per-event `:rf.event/db` slots on the t1 / t2 trace events so the
   sensitive / large declarations match natively, then fail closed on the
-  dispatched-event-vector args (rf2-nm611o — `:rf.event/v` / `:event`
+  dispatched-event-vector args (`:rf.event/v` / `:event`
   carry the same registration-owned transient args as `:trigger-event`,
   which the app-db walker cannot prove safe), then enforce the off-box
-  HTTP response-body fail-closed rule (rf2-t55hxg.6 — omit unschematized
-  bodies), then run the bulk frame/profile `project-egress` walk over the
+  HTTP response-body fail-closed rule, then run the bulk
+  frame/profile `project-egress` walk over the
   whole vector to handle the other payload-bearing tag values
   (`:rf.cofx/value`, etc.) with their own per-tag paths. `opts`
   `:include-sensitive?` / `:include-large?` / `:include-event-args?` opt
-  the per-call posture back in (rf2-5w06uu / rf2-nm611o). Idempotent (a
+  the per-call posture back in. Idempotent (a
   second pass walks already-redacted scalars). Nil-preserving."
   [v frame-id opts]
   (when (some? v)
@@ -1471,11 +1278,9 @@
         (reroot-trace-event-db-slots frame-id opts)
         (omit-off-box-event-args opts)
         (omit-off-box-http-bodies opts)
-        ;; rf2-84l82t — redact the resolver-owned `:input-values` / `:scope`
-        ;; on `:rf.resource/scope-resolved` rows (fail-closed; the generic
-        ;; walk below cannot classify resolver-owned values copied into tags).
+        ;; Redact resolver-owned values copied into resource trace tags.
         (omit-off-box-resource-scope-values opts)
-        ;; rf2-8x0gfa — redact the owner-local SCOPED KEYS embedded in the
+        ;; Redact owner-local scoped keys embedded in the
         ;; broader `:rf.resource/*` / `:rf.mutation/*` trace family's tag slots
         ;; (`:resource/key` / `:resource/keys` / `:matched` / `:removed` /
         ;; rollback `:dispositions` / …) — the family-level companion to the
@@ -1484,9 +1289,8 @@
         (projection/project-egress (egress-opts frame-id opts)))))
 
 (defn- elide-sub-run-row
-  "Project a single structured `:sub-runs` row for off-box egress
-  (rf2-at60h). The row carries value-bearing `:prev-value` / `:value`
-  slots holding the sub's computed app-data — so, unlike the non-value
+  "Project a structured `:sub-runs` row. Its `:prev-value` / `:value`
+  slots hold computed app data, so unlike the non-value
   metadata (`:sub-id`, `:query-v`, `:value-changed?`, `:cascade?`,
   `:cause-sub`, `:cause-event-id`), they MUST respect the projection
   contract.
@@ -1504,25 +1308,13 @@
   marker value rebuilt through a second pass would be wrong-sized, so a
   slot already carrying a marker is left untouched.
 
-  The structured `:effects` rows are ALSO payload-bearing (rf2-rlt3sv):
-  each carries `:args` — the RAW fx-handler argument captured verbatim from
-  the `:rf.fx/args` trace tag, NOT routed through the marks-projection
-  chokepoint and NOT rooted at the frame's app-db, so the schema-path walker
-  cannot prove it safe. Off-box egress FAILS CLOSED: `:args` lands as
-  `:rf/redacted` for every outcome row (`:ok` / `:skipped-on-platform` /
-  `:error`) under the `:include-fx-args? false` default — see
-  `elide-effects-slot`. The value-free row metadata (`:fx-id`, `:outcome`,
-  `:error-trace`) passes through unchanged. The trusted-local
-  `:include-fx-args? true` opt keeps the raw `:args` (orthogonal to the
-  app-db `:include-sensitive?` / `:include-large?` opt-ins).
-
   Per-PATH large declarations (a sub with `:large [<path>]` marks but no
   whole-output `:large?` stamp) are already substituted INTO the value
   at the marks emit site (`redact-with-paths`), so they ride the row
   pre-marked and need no projection here.
 
   `opts` `:include-large? true` opts the whole-output large value back in
-  (rf2-5w06uu): a trusted-local caller keeps the raw `:value` /
+  so a trusted-local caller keeps the raw `:value` /
   `:prev-value`; the `:large?` flag is still stripped so the projected
   row's shape matches the on-box base shape's metadata."
   [row {:keys [include-large?]}]
@@ -1550,7 +1342,7 @@
     (mapv #(elide-sub-run-row % opts) sub-runs)))
 
 (defn- elide-effect-row
-  "Project one structured `:effects` row for off-box egress (rf2-rlt3sv).
+  "Project one structured `:effects` row for off-box egress.
 
   Each row carries `:args` — the RAW fx-handler argument payload captured
   verbatim from the `:rf.fx/args` trace tag (`re-frame.fx/handle-one-fx`).
@@ -1567,8 +1359,7 @@
   `:fx-id`, `:outcome`, and `:error-trace` are value-free metadata and pass
   through unchanged.
 
-  `opts` `:include-fx-args? true` is the trusted-local opt-in (rf2-5w06uu
-  family) — a developer's own Xray panel inspecting their own running app
+  `opts` `:include-fx-args? true` is the trusted-local opt-in; it
   keeps the raw `:args`. It is ORTHOGONAL to the app-db `:include-sensitive?`
   / `:include-large?` opt-ins (fx args are a different keyspace, not app-db
   values), so those do NOT lift it.
@@ -1582,7 +1373,7 @@
     (assoc row :args :rf/redacted)))
 
 (defn- elide-effects-slot
-  "Project the structured `:effects` vector for off-box egress (rf2-rlt3sv):
+  "Project the structured `:effects` vector for off-box egress:
   walk each row through `elide-effect-row`, fail-closed-redacting the
   payload-bearing `:args` slot. Nil- and non-sequential-preserving (a
   `:redact-fn` may have already replaced the whole slot with a scalar
@@ -1593,16 +1384,14 @@
     (mapv #(elide-effect-row % opts) effects)))
 
 (defn- elide-trigger-event-slot
-  "Project the `:trigger-event` slot for off-box egress (rf2-nm611o).
+  "Project the `:trigger-event` slot for off-box egress.
 
   `:trigger-event` is the FULL dispatched event vector — `[<event-id>
   <arg> …]` (e.g. `[:login \"topsecret\"]`, `[:auth/login {:password p}]`).
   Per EP-0015 / Spec 015 §Registration-owned transient classification
   (`015-Data-Classification.md` §151) the event ARGS are
   registration-owned transient payloads, NOT frame-app-db-owned data — the
-  exact same class as the `:effects` `:args` slot (`elide-effect-row`,
-  rf2-rlt3sv, whose docstring even names `[:login pw]` dispatch vectors as
-  payload-bearing user data). They are captured verbatim from the
+  same class as the `:effects` `:args` slot. They are captured verbatim from the
   `:rf.event/v` trace tag (`capture/find-trigger-event`); they are NOT
   routed through the marks-projection chokepoint at emit time, NOR are they
   rooted at the frame's app-db, so the schema-path-keyed `elide-wire-value`
@@ -1627,9 +1416,8 @@
   schema admits (Spec-Schemas §`:rf/epoch-record` — consumers MUST tolerate
   `:rf/redacted` at `:trigger-event`).
 
-  `opts` `:include-event-args? true` is the trusted-local opt-in (the
-  rf2-5w06uu / `:include-fx-args?` family) — a developer's own Xray panel
-  inspecting their own running app keeps the raw args. It is ORTHOGONAL to
+  `opts` `:include-event-args? true` is the trusted-local opt-in that keeps
+  raw args. It is orthogonal to
   the app-db `:include-sensitive?` / `:include-large?` opt-ins (event args
   are a different keyspace, not app-db values), so those do NOT lift it,
   matching the `:effects` `:args` / runtime-db boundaries.
@@ -1651,48 +1439,21 @@
     :else :rf/redacted))
 
 (defn projected-record
-  "INTERNAL projection engine for off-box epoch egress (Phase-2 seam E,
-  rf2-0wi86). The complete PUBLIC contract — egress profiles, `:include-*`
-  overrides, frame-state / runtime-db policy, event/fx-arg redaction,
-  structured-row handling, and the single normative emission-site
-  requirement — lives on the facade `re-frame.epoch/projected-record`; this
-  docstring records only the implementation invariants.
+  "Internal projection engine for off-box epoch egress. The public contract
+  lives on `re-frame.epoch/projected-record`.
 
-  Two-stage projection (EP-0015 §15, open-issue 6 RULED):
-
-    1. Frame/profile projection. Each present tree-shaped slot is delegated
-       to its per-slot helper against the record's frame under the selected
-       `:rf.egress/profile` (default `:rf.egress/off-box-observability`):
-         :frame-state-before / :frame-state-after -> project-frame-state-slot
-         :db-before / :db-after                    -> project-payload-slot
-         :trigger-event                            -> elide-trigger-event-slot
-         :trace-events                             -> elide-trace-events-slot
-         :sub-runs                                 -> elide-sub-runs-slot
-         :effects                                  -> elide-effects-slot
-       Record-level bookkeeping, and any slot absent from the record, are
-       left untouched.
-
-    2. `:redact-fn` advanced override. `assembly/apply-redact-fn` runs LAST,
-       over the already-projected record — projection-side only, so the raw
-       ring (and thus `restore-epoch!` fidelity) is never touched. Identity
-       pass-through when no fn is installed; a throwing override emits
-       `:rf.warning/epoch-redact-fn-exception` and falls back to the
-       projected record.
-
-  Nil-preserving: a non-map `record` (e.g. a missing-epoch lookup) returns
-  nil, nothing projected."
+  Each present payload slot is delegated to its own helper under the selected
+  frame/profile. Record bookkeeping and absent slots remain unchanged. The
+  configured advanced override runs last over the built-in projection, never
+  the raw ring. A throwing override falls back to the built-in result.
+  Non-map input returns nil."
   ([record] (projected-record record nil))
   ([record opts]
    (when (map? record)
      (let [frame-id  (:frame record)
            projected (cond-> record
-                       ;; EP-0001 (rf2-3aizt1, decision #2 + ruling #14): the
-                       ;; CANONICAL frame-state slots egress with the app-db
-                       ;; partition projected and the runtime-db partition
-                       ;; default-redacted off-box (see
-                       ;; `project-frame-state-slot`). rf2-5w06uu — `opts`
-                       ;; thread the trusted-local sensitive / large /
-                       ;; runtime-db overrides.
+                       ;; Whole-frame slots project app-db and redact runtime-db
+                       ;; unless the corresponding trusted-local opts lift them.
                        (contains? record :frame-state-before)
                        (update :frame-state-before project-frame-state-slot frame-id opts)
 
@@ -1705,18 +1466,7 @@
                        (contains? record :db-after)
                        (update :db-after      project-payload-slot frame-id opts)
 
-                       ;; rf2-nm611o: `:trigger-event` carries the dispatched
-                       ;; event vector `[<id> <arg> …]`. Its ARGS are
-                       ;; registration-owned transient payloads (Spec 015 §151),
-                       ;; NOT frame-app-db-owned data — the generic
-                       ;; `project-payload-slot` (rooted at the frame's app-db
-                       ;; classification) cannot prove them safe, so a positional
-                       ;; secret like `[:login "topsecret"]` egressed RAW. Off-box
-                       ;; egress now FAILS CLOSED: the args are redacted while the
-                       ;; head event-id keyword (the non-payload summary, == the
-                       ;; record's `:event-id` slot) is retained. The
-                       ;; trusted-local `:include-event-args? true` opt keeps the
-                       ;; raw args (the `:include-fx-args?` family).
+                       ;; Trigger args are not app-db-rooted and fail closed.
                        (contains? record :trigger-event)
                        (update :trigger-event elide-trigger-event-slot opts)
 
@@ -1726,20 +1476,10 @@
                        (contains? record :sub-runs)
                        (update :sub-runs      elide-sub-runs-slot opts)
 
-                       ;; rf2-rlt3sv: the structured `:effects` rows carry
-                       ;; payload-bearing `:args` (the raw fx-handler argument).
-                       ;; They are NOT app-db-rooted, so the schema-path walker
-                       ;; cannot prove them safe — off-box egress fails closed,
-                       ;; redacting `:args` to `:rf/redacted` while preserving
-                       ;; the value-free `:fx-id` / `:outcome` / `:error-trace`
-                       ;; metadata. The trusted-local `:include-fx-args? true`
-                       ;; opt keeps the raw args.
+                       ;; Effect args are not app-db-rooted and fail closed.
                        (contains? record :effects)
                        (update :effects       elide-effects-slot opts))]
-       ;; EP-0015 §15 + open-issue 6 (RULED): apply the app `:redact-fn`
-       ;; advanced override to the already-projected record. Projection-side
-       ;; only — the ring stays raw, so restore fidelity is never affected.
-       ;; Identity pass-through when no fn is installed (the common case).
+       ;; Apply the advanced override only to the projected copy.
        (assembly/apply-redact-fn projected)))))
 
 (defn projected-history

--- a/implementation/epoch/test/re_frame/actor_revertibility_restore_test.clj
+++ b/implementation/epoch/test/re_frame/actor_revertibility_restore_test.clj
@@ -1,37 +1,14 @@
 (ns re-frame.actor-revertibility-restore-test
-  "Per rf2-a2sn1 — the genuine end-to-end `restore-epoch!` repros for the
-  dynamically-spawned-actor revertibility leak (Goal 2).
+  "End-to-end actor-liveness restore coverage.
 
-  These are the two live repros the bead pinned as the acceptance bar,
-  run against the REAL epoch `restore-epoch!` path (the epoch artefact
-  test-deps machines):
+  Machine snapshots live in the runtime-db partition, and actor liveness is
+  derived from snapshot presence. Restoring whole frame state must therefore:
 
-    rewind-past-spawn  — register/spawn an actor, restore-epoch! to BEFORE
-                         it existed; assert NO orphaned handler survives
-                         (the `{:handler-survived-restore? true}` leak is
-                         closed) and a dispatch to the gone actor is a
-                         clean :rf.error/no-such-handler.
+    - remove an actor when rewinding to before its spawn;
+    - revive lazy resolution when rewinding to before its destroy.
 
-    rewind-past-destroy (the key fix) — spawn → destroy → restore-epoch! to
-                         when it was alive; assert a dispatch to the actor
-                         now RESOLVES via the lazy resolver and drives a
-                         transition (NOT :rf.error/no-such-handler).
-
-  Before the fix, a spawned actor's liveness lived in the registrar
-  (outside the frame value), so `restore-epoch!` could not revert it. After
-  the fix (LAZY-RESOLVER), spawn/destroy are pure frame-state writes and an
-  actor's liveness IS its snapshot's presence in the (revertible) runtime-db
-  partition — so `restore-epoch!` reverts it perfectly.
-
-  EP-0001 (rf2-vzld77 / rf2-3aizt1): machine snapshots are runtime-db
-  partition state at `[:rf.runtime/machines :snapshots <id>]`; the epoch now
-  captures the whole frame-state (`:frame-state-before/-after`, decision #2)
-  and `restore-epoch!` reinstalls both partitions via `replace-frame-state!`,
-  so reverting a spawn / destroy reverts the runtime-db liveness. These three
-  end-to-end repros (deferred by rf2-vzld77) are re-enabled here.
-
-  Spec: [Spec 005 §Spawning §Liveness is derived from app-db] and
-  [000-Vision Goal 2 — Frame state revertibility]."
+  The tests use the public restore path and real machine dispatch so registrar
+  state cannot mask a non-revertible actor lifecycle."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.registrar :as registrar]
@@ -119,7 +96,7 @@
         (is (true? ok?) "restore-epoch! to the pre-spawn epoch succeeded")
         (is (nil? (snapshot :rev/child#1))
             "rewind-past-spawn: the actor's snapshot is gone")
-        ;; The repro's headline assertion — inverted to the post-fix value.
+        ;; Restore preserves the original child id.
         (is (nil? (registrar/lookup :event :rev/child#1))
             "{:handler-survived-restore? false} — NO orphaned handler
              survives the revert")

--- a/implementation/epoch/test/re_frame/epoch_attribution_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_attribution_test.clj
@@ -1,42 +1,18 @@
 (ns re-frame.epoch-attribution-test
-  "Standing epoch-attribution suite — the comprehensive guard for the
+  "Comprehensive guard for the
   per-cascade / per-mount attribution surface (Spec 009 §Instrumentation,
   Tool-Pair §Time-travel).
 
-  WHY THIS NS EXISTS — three near-identical attribution escapes shipped to
-  CI for the SAME structural reason: no test asserted per-cascade / per-mount
-  attribution across ≥2 distinct cascades. Each was caught in production
-  (Xray's Views / Reactive panels), fixed in isolation, and shipped with its
-  own inline test:
-
-    rf2-qs6dl (#1935) — a `:rf.view/render` (`:rf.view/rendered`) fired at React
-                        COMMIT time, AFTER its causing cascade settled, landed
-                        in the now-empty buffer, and was harvested by the NEXT
-                        cascade's settle — every render mis-attributed by one
-                        epoch. Xray showed a `counter-inc` epoch rendering
-                        `title-view`, which is impossible.
-    rf2-wi900 (#1938) — the SUBS sibling. A reactive `:rf.sub/run` recomputes
-                        lazily at React deref time, post-settle, same lag — so
-                        a `counter-inc 1→2` epoch reported the counter sub's
-                        PRIOR value. The `:rf.sub/value-changed?` / `:rf.sub/cause-sub`
-                        attribution landed on the wrong epoch.
-    rf2-vh1k3 (#1939) — a late MOUNT render whose commit lands AFTER the first
-                        user interaction settled was back-filled onto that
-                        first cascade (rf2-qs6dl's most-recently-settled
-                        anchor) — so a freshly-mounted view spuriously appeared
-                        in the first post-mount cascade's RENDERED list even
-                        though its subs never changed.
-
-  These three are ONE surface: \"which epoch does a post-settle async emit
-  (sub-run / render / mount render) belong to?\" This suite consolidates the
-  per-fix tests and generalizes them into invariant-keyed cases so the next
-  regression of the SAME class is caught by CI.
+  The central question is which epoch owns a post-settle async emit: reactive
+  sub-runs and renders belong to their causing event, while a late mount render
+  remains anchored to the mount epoch. Cases use multiple distinct events so a
+  one-epoch attribution lag cannot pass unnoticed.
 
   THE POST-SETTLE-EMIT SIMULATION TECHNIQUE — the bug is a TIMING bug: the
   emit fires OUTSIDE the in-flight cascade, after `settle!` already harvested
   + committed the record. In a synchronous JVM `dispatch-sync`, every trace
   emits INSIDE the cascade, so the lag is structurally unreproducible — which
-  is exactly why every prior test missed it. We reproduce the real
+  so the suite reproduces the real
   React-commit / React-deref timing directly: dispatch a cascade (it settles
   and commits its record), THEN emit a `:rf.sub/run` / `:rf.view/render` via
   `trace/emit!` with NO `*handler-scope*` and an empty in-flight buffer —
@@ -1882,9 +1858,8 @@
         (is (not= target-id (:epoch-id (nth history-after 1)))
             "a DIFFERENT epoch now occupies the stale index 1")
 
-        ;; NOW back-fill the target by id. The naive stale-index path would
-        ;; have spliced into index 1 (the wrong epoch); the fix re-derives the
-        ;; index inside the swap and lands on the target by id.
+        ;; Back-fill the target by id. The index is derived inside the swap, so
+        ;; eviction cannot redirect the row to a positional neighbour.
         (let [{:keys [event row]} (bf-sub-event :test/main :late-sub 99)]
           (state/back-fill-sub-run! :test/main target-id event row))
 
@@ -1930,4 +1905,4 @@
         (is (every? (fn [r] (not (contains? (sub-run-ids r) :ghost-sub)))
                     (rf/epoch-history :test/main))
             "no surviving epoch was mis-spliced with the evicted target's
-             back-fill (the stale-index wrong-record splice the fix kills)")))))
+             back-fill")))))

--- a/implementation/epoch/test/re_frame/epoch_cljs_test.cljs
+++ b/implementation/epoch/test/re_frame/epoch_cljs_test.cljs
@@ -1,11 +1,11 @@
 (ns re-frame.epoch-cljs-test
-  "Per rf2-5lvk6 (test-coverage sweep G3 from rf2-toib5) — CLJS smoke
-  for the epoch artefact. The JVM coverage in `re-frame.epoch-test` is
+  "CLJS smoke coverage for the epoch artefact. JVM coverage in
+  `re-frame.epoch-test` is
   dense, but the epoch surface ships through `re-frame.epoch.cljc` and
   the late-bind seam under CLJS too; this file pins the cross-target
   contract for the load-bearing behaviours:
 
-    1. Recording — every drain-settle commits one `:rf/epoch-record` and
+    1. Recording — every dequeued event commits one `:rf/epoch-record` and
        the record carries the canonical shape (`:event-id`, `:db-before`,
        `:db-after`, `:effects`, `:outcome :ok`).
     2. Restore happy path — `restore-epoch!` rewinds `app-db` to a named
@@ -14,7 +14,7 @@
        followed by five dispatches keeps the last three; the oldest two
        are dropped.
     4. Per-dispatch fan-out — `register-epoch-listener!` fires once per
-       drain-settle with the assembled record (the contract that
+       event epoch with the assembled record (the contract that
        Xray's preload routes through to dispatch
        `:rf.xray/epoch-recorded`; the per-dispatch signal is the
        epoch-cb fan-out itself, plus the `:rf.epoch/snapshotted`
@@ -22,7 +22,7 @@
     5. Production-elision DCE — runtime gate sanity. Under the
        `:node-test` build (`goog.DEBUG=true`) the surface is live;
        the framework-level grep
-       (`implementation/scripts/check-elision.cjs`, rf2-11hn) is the
+       (`implementation/scripts/check-elision.cjs`) is the
        authoritative `:advanced` + `goog.DEBUG=false` DCE assertion
        and already pins every `:rf.epoch/*` sentinel. This file's
        gate-state assertion locks the dev-side companion: under the
@@ -31,8 +31,7 @@
        vacuous (it asserts ABSENCE of strings that only enter the
        bundle when this gate is true).
 
-  Mirrors the smoke shape of `re-frame.schemas-cljs-test` (per
-  rf2-5b6x): one happy path, one ring-cap path, one listener path,
+  Covers one happy path, one ring-cap path, one listener path,
   one runtime-gate-on path. The JVM tests carry the conformance
   weight; this file locks the cross-substrate contract.
 
@@ -74,7 +73,7 @@
 
 ;; ---- 1. Recording — happy-path record shape -------------------------------
 
-(deftest record-on-drain-settle-cljs
+(deftest record-on-event-settle-cljs
   (testing "dispatch a single event under CLJS — exactly one record
             lands in the ring with the canonical shape (`:event-id`,
             `:db-before`, `:db-after`, `:effects`, `:outcome :ok`)"
@@ -86,7 +85,7 @@
 
     (let [history (rf/epoch-history :rf/default)]
       (is (= 2 (count history))
-          "one record per drain-settle under the CLJS plain-atom adapter")
+          "one record per dequeued event under the CLJS plain-atom adapter")
       (let [r (last history)]
         (is (= :n/inc      (:event-id r))
             ":event-id names the triggering event")
@@ -97,7 +96,7 @@
         (is (= {:n 1}      (:db-after r))
             ":db-after is the post-settle snapshot")
         (is (= :ok         (:outcome r))
-            ":outcome :ok pins the drain-settle outcome on the happy path")
+            ":outcome :ok pins the event-settle outcome on the happy path")
         (is (vector? (:effects r))
             ":effects is a vector projection from the trace stream")))))
 
@@ -121,7 +120,7 @@
 ;; the epoch record reproduces Mike's RED.
 ;;
 ;; RED (pre-fix): epoch `:trace-events` has NO :where :event violation.
-;; GREEN (post-fix): the violation is present in the triggering epoch.
+;; The violation belongs to the triggering epoch.
 
 (deftest event-args-violation-captured-in-epoch-trace-events-cljs
   (testing "rf2-lo28u — a plain reg-event :schema violation fires
@@ -147,11 +146,10 @@
             "the last epoch is the bad-event-args dispatch")
         (is (= 1 (count violations))
             "the :where :event violation is captured in THIS epoch's
-             :trace-events (RED pre-fix: dropped because the trace
-             carried no :frame tag)")
+             :trace-events")
         (when-let [v (first violations)]
           (is (= :rf/default (-> v :tags :frame))
-              "the captured violation carries the :frame tag the fix adds"))))))
+              "the captured violation carries its :frame tag"))))))
 
 ;; ---- 2. Restore happy path -------------------------------------------------
 
@@ -198,7 +196,7 @@
 ;; ---- 4. Per-dispatch fan-out — register-epoch-listener! + snapshotted trace ----
 
 (deftest epoch-cb-fires-per-dispatch-cljs
-  (testing "register-epoch-listener! fires once per drain-settle — the
+  (testing "register-epoch-listener! fires once per event epoch — the
             contract Xray's preload (`:rf.xray/epoch-recorded`)
             routes through. The companion `:rf.epoch/snapshotted`
             trace also fires once per dispatch."
@@ -234,7 +232,7 @@
       (is (every? #(= :rf.epoch (:op-type %)) @trace-seen)
           "the trace event's :op-type is :rf.epoch")
       (is (every? #(= :ok (-> % :tags :outcome)) @trace-seen)
-          "the trace's :outcome tag is :ok on clean drain-settle"))))
+          "the trace's :outcome tag is :ok on a clean event settle"))))
 
 ;; ---- 5. Production-elision DCE — runtime gate sanity ----------------------
 

--- a/implementation/epoch/test/re_frame/epoch_committed_at_clock_cljs_test.cljs
+++ b/implementation/epoch/test/re_frame/epoch_committed_at_clock_cljs_test.cljs
@@ -1,45 +1,12 @@
 (ns re-frame.epoch-committed-at-clock-cljs-test
-  "rf2-1t30y7 — LIVE-path regression: the durable epoch record `:committed-at`
-  must be WALL-CLOCK epoch ms (sourced from `interop/epoch-now-ms` =
-  `js/Date.now()` on CLJS, ~1.78e12), NOT the perf clock (`interop/now-ms` =
-  `performance.now()`, origin-relative ~1e4).
+  "CLJS coverage for the live clock feeding durable `:committed-at` values.
 
-  WHY A NEW SUITE: every existing `:committed-at` test
-  (`committed-at-comes-from-supplied-token-time-ms`,
-  `committed-at-replay-stable-across-wall-clock-drift`,
-  `committed-at-each-child-event-reads-its-own-token`, …) lives in
-  `re-frame.epoch-test` — a `.clj` (JVM-ONLY) file — and SCRIPTS the
-  committing token's `:rf.cofx` `:rf/time-ms` to an explicit sentinel
-  (pinning BOTH `now-ms` AND `epoch-now-ms` with `with-redefs`). That proves
-  the causal-time THREADING (token `:time-ms` -> `:committed-at`, replayable,
-  no ambient assembly-time read), but it deliberately bypasses the live
-  router clock read that decides WHICH clock surface feeds an UNSCRIPTED
-  dispatch's `:time-ms`.
-
-  On the JVM `now-ms` and `epoch-now-ms` are both wall-clock-ish, so a
-  regression that swaps `interop/epoch-now-ms` -> `interop/now-ms` at the
-  router's causal boundary (`re-frame.router/build-envelope`, the one read
-  that durable writes fold) stays GREEN on every JVM + scripted-token suite,
-  and only breaks CLJS — where `now-ms` is `performance.now()`
-  (origin-relative, ~1e4) and `epoch-now-ms` is `js/Date.now()` (~1.78e12).
-  This is EXACTLY the gap that let the resources `:completed-at` perf-clock
-  bug (rf2-2elcw3) slip through until a dedicated CLJS suite
-  (`resources_http_completed_at_clock_cljs_test.cljs`) was added.
-
-  This suite drives the REAL router: it dispatches an UNSCRIPTED event (no
-  `:rf.cofx` supplied), lets the genuine `build-envelope` stamp the
-  causal `:time-ms` from the host clock, and asserts the resulting durable
-  epoch record `:committed-at` is a wall-clock epoch value (within ~10s of
-  `js/Date.now()`), NOT a small perf-clock origin-relative number. A clock
-  swap would land `:committed-at` ~12 orders of magnitude low (~1e4 vs
-  ~1.78e12) and fail the band assertion on CLJS.
-
-  ns ends in `-cljs-test` so shadow-cljs `:node-test` picks it up via
-  `:ns-regexp \"cljs-test$\"`. The `:node-test` build has no DOM /
-  Reagent reactive context, so this uses the plain-atom adapter — matching
-  the JVM epoch fixture and `re-frame.epoch-cljs-test`. The clock read under
-  test lives at the router boundary and is adapter-independent, so the choice
-  of substrate does not weaken the pin."
+  Scripted JVM tests prove causal-time threading but cannot distinguish the
+  CLJS wall clock (`js/Date.now`) from the origin-relative performance clock.
+  This suite drives an unscripted event through the real router and asserts the
+  stored causal time is near wall-clock epoch milliseconds. The plain-atom
+  adapter is sufficient because the clock read occurs at envelope construction,
+  independently of rendering."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.interop :as interop]
@@ -82,7 +49,7 @@
             r            (last history)
             committed-at (:committed-at r)]
         (is (= 2 (count history))
-            "one record per drain-settle (sanity: the dispatches landed)")
+            "one record per dequeued event (sanity: the dispatches landed)")
         (is (= :clk/inc (:event-id r))
             "the last record is the :clk/inc dispatch")
         (is (number? committed-at)

--- a/implementation/epoch/test/re_frame/epoch_concurrency_stress_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_concurrency_stress_test.clj
@@ -1,17 +1,7 @@
 (ns re-frame.epoch-concurrency-stress-test
-  "Per rf2-rd7a7 — JVM concurrency stress coverage for the epoch surface.
-  Mirrors rf2-1gpx8's machine-actor stress pattern
-  (`machine_actor_concurrency_stress_test.clj`) and rf2-35rgj's router
-  stress pattern (`concurrency_stress_test.clj`) but targets the epoch
-  recorder / listener / ring-buffer paths.
-
-  The deterministic epoch suite (`epoch_test.clj`, including the recent
-  PR #1167 additions: rf2-1294f / rf2-i0rl9 / rf2-kl5p1 / rf2-7kxxx, plus
-  the multi-listener observed-frames pin rf2-s60jx, the capture-buffer
-  cross-contamination pin rf2-5qbus, the boundary-validation pin
-  rf2-douii, and the halted-cascade pin rf2-v0jwt) covers correctness
-  single-shot. None of those tests fires the epoch surface from multiple
-  threads — under contention the three documented hot paths
+  "JVM concurrency stress coverage for epoch recorder, listener, and ring paths.
+  Deterministic tests cover the same contracts in isolation. Under contention,
+  the three hot paths
   (`settle!`/`record!`, the `register-epoch-listener!`/`unregister-epoch-listener!`
   listener registry, and the per-frame ring buffer) are reached
   concurrently and must hold the same invariants.
@@ -99,19 +89,12 @@
 
   ## Stress dial
 
-  Defaults: 8 threads × 5000 iters per scenario (matches rf2-1gpx8 /
-  rf2-35rgj / rf2-ynk7). Env-overridable via `RF2_RD7A7_STRESS_ITERS`.
+  Defaults: 8 threads × 5000 iterations per scenario. Override with
+  `RF2_RD7A7_STRESS_ITERS`.
   Scenario 1's wall-clock at the default is ~10-20s on a 4-core CI box;
   scenarios 2 and 3 are similar (each pins one frame so the per-frame
-  drain serialisation throttles wall-clock). The 5x deflake the bead
-  mandates runs all three scenarios five times — total ~3-5 min for
-  the suite at default iters.
-
-  ## 5x deflake protocol
-
-  Per the bead, this file MUST pass 5 consecutive `clojure -M:test`
-  runs. The pinned wall-clock budget per run is ~60-90s; 5 runs ≈
-  5-7 min — viable for a green-gate check before pushing."
+  drain serialisation throttles wall-clock). Five consecutive runs take roughly
+  5-7 minutes."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.epoch :as epoch]
@@ -653,7 +636,7 @@
 ;;     real (currently-present) epoch-id, and `back-fill-sub-run!` a uniquely-
 ;;     tagged row onto it.
 ;;
-;; Invariant (snapshot consistency): EVERY back-filled row that the fix accepts
+;; Invariant (snapshot consistency): every accepted back-filled row
 ;; (the target was still present at splice time) lands on the epoch whose
 ;; `:epoch-id` matches the tag the row carries — NEVER on a positional
 ;; neighbour. After the run we walk the final ring and assert no surviving

--- a/implementation/epoch/test/re_frame/epoch_elision_prod_test.cljs
+++ b/implementation/epoch/test/re_frame/epoch_elision_prod_test.cljs
@@ -18,7 +18,7 @@
   - `restore-epoch!`           — `(if-not interop/debug-enabled? false ...)`
                                 — returns `false` and never invokes
                                 the restore machinery.
-  - `replace-app-db!`         — `(if-not interop/debug-enabled? false ...)`
+  - `replace-frame-state!`    — `(if-not interop/debug-enabled? false ...)`
                                 — Pair-tool write surface returns
                                 `false` without mutating app-db.
   - `on-frame-destroyed!`     — `(when interop/debug-enabled? ...)` —
@@ -108,11 +108,10 @@
     (is (false? (rf/restore-epoch! :rf.nonexistent/frame 0))
         "restore-epoch! returns false under prod even for an unknown frame")))
 
-;; ---- replace-app-db! is a no-op returning false under prod ---------------
+;; ---- replace-frame-state! is a no-op returning false under prod -----------
 
 (deftest replace-app-db-returns-false-under-prod
-  (testing "Per Spec 009 §Production builds: `replace-app-db!` (Tool-
-            Pair §Pair-tool writes) is gated on `interop/debug-enabled?`
+  (testing "In production, `replace-frame-state!` is gated on `interop/debug-enabled?`
             via an `(if-not …)` early-return. Under prod it returns
             `false` WITHOUT mutating app-db — the dev-only Pair-tool
             write surface is firewalled from production state."
@@ -123,7 +122,7 @@
            (rf/app-db-value :rf/default))
         "baseline: app-db has the seeded value")
     (is (false? (rf/replace-frame-state! :rf/default {:rf.db/app {:replaced :should-not-stick}}))
-        "replace-app-db! returns false under prod")
+        "replace-frame-state! returns false under prod")
     (is (= {:original true}
            (rf/app-db-value :rf/default))
         "app-db is UNCHANGED under prod — Pair-tool write firewalled

--- a/implementation/epoch/test/re_frame/epoch_jvm_prod_gate_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_jvm_prod_gate_test.clj
@@ -1,12 +1,12 @@
 (ns re-frame.epoch-jvm-prod-gate-test
-  "Per rf2-0la4f (security audit): the epoch artefact's dev-only
-  surfaces — `register-epoch-listener!`, `restore-epoch!`, `replace-app-db!`,
+  "The epoch artefact's dev-only surfaces — `register-epoch-listener!`,
+  `restore-epoch!`, `replace-frame-state!`,
   the per-frame ring buffer carrying `:db-before` / `:db-after` /
   raw `:trace-events` — MUST honour the JVM-side production gate
   `re-frame.interop/debug-enabled?`. When the gate reads `false`
-  (the SSR production posture per rf2-vnjfg / rf2-0la4f), the epoch
+  in production, the epoch
   surface drops to its no-op floor: no record lands in the ring, no
-  cb fires, `restore-epoch!` and `replace-app-db!` return `false`.
+  callback fires, and `restore-epoch!` / `replace-frame-state!` return `false`.
 
   The companion core gate vocabulary suite is
   `re-frame.interop-debug-gate-test`; the core integration suite is
@@ -37,7 +37,7 @@
 ;; ensures the conventional `:rf/default` frame and binds it as the body's
 ;; ambient scope — the carried-invariant equivalent of wrapping every test
 ;; in `(with-frame :rf/default …)`. So the bare framework-operation surfaces
-;; this suite drives (dispatch / epoch / restore-epoch! / replace-app-db!)
+;; this suite drives (dispatch / epoch / restore / frame-state replacement)
 ;; resolve a carried frame stamp without a hand-rolled `reg-frame` + `with-
 ;; frame` dance here. Explicit `{:frame …}` opts in the bodies still win.
 (use-fixtures :each
@@ -88,13 +88,13 @@
           "restore-epoch! returns false (refuses to operate)"))))
 
 (deftest replace-app-db-refuses-when-debug-disabled
-  (testing "Per rf2-0la4f: `replace-app-db!` MUST refuse to operate
+  (testing "`replace-frame-state!` must refuse to operate
             when the JVM debug gate is off. Same admin-surface
             concern as `restore-epoch!` — pair-tool writes (Tool-Pair
             §Pair-tool writes) are a dev-only surface."
     (with-redefs [interop/debug-enabled? false]
       (is (false? (rf/replace-frame-state! :rf/default {:rf.db/app {:any "db"}}))
-          "replace-app-db! returns false (refuses to operate)"))))
+          "replace-frame-state! returns false (refuses to operate)"))))
 
 (deftest epoch-still-records-with-default-gate
   (testing "Sanity: with the gate at its default `true` reading
@@ -142,7 +142,7 @@
 ;;
 ;; The `:redact-fn` is the PROJECTION-SIDE advanced override, never a
 ;; storage-side mutation. It is NEVER invoked by `settle!` /
-;; `replace-app-db!` / the back-fill (regardless of gate); it runs ONLY
+;; frame-state replacement / back-fill (regardless of gate); it runs only
 ;; inside `projected-record`, applied to the projected egress copy. The
 ;; ring is causal replay material, delivered raw.
 
@@ -191,7 +191,7 @@
       (rf/configure! {:epoch-history {:redact-fn nil}}))))
 
 (deftest redact-fn-not-invoked-on-replace-app-db-under-disabled-gate
-  (testing "`replace-app-db!` returns false under the disabled gate — the
+  (testing "`replace-frame-state!` returns false under the disabled gate — the
             gated arm that would record the synthetic epoch is elided. The
             :redact-fn (projection-side) is never reached on this path
             regardless; the early-return false is preserved."
@@ -201,7 +201,7 @@
                                     (swap! invocations inc)
                                     r)}})
         (is (false? (rf/replace-frame-state! :rf/default {:rf.db/app {:any "db"}}))
-            "replace-app-db! refuses under the disabled gate")
+            "replace-frame-state! refuses under the disabled gate")
         (is (zero? @invocations)
             ":redact-fn was never reached — no synthetic record recorded
              (and the fn is projection-side anyway)")

--- a/implementation/epoch/test/re_frame/epoch_mcp_egress_conformance_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_mcp_egress_conformance_test.clj
@@ -1,16 +1,7 @@
 (ns re-frame.epoch-mcp-egress-conformance-test
-  "rf2-xrlyi — MCP-style egress conformance for `projected-record` +
-  `projected-history`. Per Spec Security.md §Epoch privacy posture (line
-  104): 'Any tool that egresses an epoch record over an MCP wire, an HTTP
-  forwarder, a log shipper, or any process boundary MUST route the record
-  through the projected-record helper before egress.'
-
-  Coverage gap closed (rf2-kp835 Phase-1 audit): the `projected-record` and
-  `projected-history` public-surface symbols had 0 callers in `tools/`. The
-  MCP-side accessors (Xray-MCP `watch-epochs`, story / pair recorders)
-  haven't shipped end-to-end calls yet — Mike's Phase-2 decision (sibling
-  bead rf2-xrlyi) kept both symbols canonical and asked for a conformance
-  test exercising them via a representative MCP-style call path.
+  "MCP-style egress conformance for `projected-record` and
+  `projected-history`. Any process-boundary forwarder must project raw epoch
+  records before egress.
 
   This file pins the contract from the **forwarder perspective**: the
   per-leaf redaction matrix lives in `epoch_privacy_test.clj`; the
@@ -50,7 +41,7 @@
   the running app via the injected-runtime path
   (`day8.re-frame2-xray.runtime`), not the MCP-server bundle. The
   framework's epoch artefact owns the projection emission site (Spec
-  Security.md §Epoch privacy posture line 104); pinning conformance from
+  Security.md §Epoch privacy posture); pinning conformance from
   the artefact side keeps the test on the JVM next to the contract owner.
   An MCP-side end-to-end test is the job of the SDK-driven conformance
   `test/end-to-end-*.cjs` paths if and when MCP-server epoch tools ship."

--- a/implementation/epoch/test/re_frame/epoch_privacy_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_privacy_test.clj
@@ -1,6 +1,5 @@
 (ns re-frame.epoch-privacy-test
-  "Per rf2-vq5o0 — coverage for the epoch privacy contract introduced
-  by rf2-j1m7x (spec) and rf2-mrsck (impl). Three contract surfaces:
+  "Coverage for three epoch privacy surfaces:
 
     1. The record-level :rf.epoch/sensitive? rollup — true when any
        captured trace event carries the :sensitive? stamp OR any
@@ -19,11 +18,7 @@
        egress off-box opt INTO projection at the wire boundary via
        projected-record.
 
-  Plus retention-cap coverage and JVM debug-disabled false-path
-  coverage per the cluster prompt.
-
-  rf2-mrsck's per-leaf smokes live in epoch_test.clj alongside the
-  impl; this file is the deeper coverage matrix."
+  Also covers retention caps and the JVM debug-disabled path."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.elision :as elision]
@@ -580,9 +575,8 @@
     ;; The secret rides POSITIONALLY in the event vector — there is no
     ;; app-db sensitive declaration that could match the trigger-event
     ;; path (the frame-declared path is [:auth :password], rooted at
-    ;; app-db, not at the event vector). The prior projection routed this
-    ;; slot through the generic app-db-rooted walker, so the secret leaked
-    ;; raw. Fail-closed redaction is the fix.
+    ;; app-db, not at the event vector). The off-box event-argument boundary
+    ;; therefore has to fail closed independently.
     (rf/reg-event :login
                      (fn [{:keys [db]} [_ pw]] {:db (assoc-in db [:auth :password] pw)}))
     (rf/dispatch-sync [:login "topsecret"] {:frame :test/main})

--- a/implementation/epoch/test/re_frame/epoch_redact_fn_projection_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_redact_fn_projection_test.clj
@@ -1,10 +1,10 @@
 (ns re-frame.epoch-redact-fn-projection-test
   "Composition between the frame/profile projection (`projected-record` /
   `projected-history`) and the `:redact-fn` PROJECTION-SIDE advanced
-  override (EP-0015 §15 Epoch Redaction + open-issue 6 disposition, RULED).
+  override.
 
-  Per the ruling `:redact-fn` is projection-side only — storage was REMOVED
-  (the ring is causal replay material). `projected-record` is a TWO-STAGE
+  `:redact-fn` is projection-side only because the ring is causal replay
+  material. `projected-record` is a two-stage
   projection:
 
     1. frame/profile projection — each tree slot through

--- a/implementation/epoch/test/re_frame/epoch_redact_fn_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_redact_fn_test.clj
@@ -1,12 +1,9 @@
 (ns re-frame.epoch-redact-fn-test
   "Coverage for the `:redact-fn` PROJECTION-SIDE advanced override on
-  `:epoch-history` (EP-0015 §15 Epoch Redaction + open-issue 6 disposition,
-  RULED, hardened).
+  `:epoch-history`.
 
-  THE RULING (open-issue 6). `:redact-fn` is the projection-side-only
-  advanced override. Storage-side mutation was REMOVED — post-EP-0010
-  epoch records are causal replay material, and mutating them at rest
-  corrupts the replay contract. So:
+  `:redact-fn` is a projection-side-only advanced override. Storage mutation
+  would corrupt causal replay material, so
 
     * the in-process ring buffer (`epoch-history`) and every
       `register-epoch-listener!` listener deliver the RAW record;
@@ -426,11 +423,11 @@
           "no redact-fn — no synthetic slots added"))))
 
 ;; ============================================================================
-;;  Per-site wirings — settle! / replace-app-db! / halted-destroy store RAW
+;; Per-site wirings: event settle, frame-state replacement, and destroy store raw
 ;; ============================================================================
 
 (deftest wiring-settle-stores-raw-record
-  (testing "the settle! drain-settle commit path stores the RAW record —
+  (testing "the settle! event commit path stores the raw record —
             the :redact-fn does not run at this seam (it runs
             projection-side, in projected-record)."
     (rf/reg-frame :test/main {})
@@ -444,7 +441,7 @@
         "the override IS applied when the record is projected for egress")))
 
 (deftest wiring-replace-app-db-stores-raw-record
-  (testing "the perform-replace-app-db! synthetic-record commit path stores
+  (testing "the frame-state replacement synthetic-record path stores
             the RAW synthetic record (pair-tool injection / story tools land
             the synthetic :rf.epoch/db-replaced record through this seam);
             the override applies only on projection."
@@ -454,9 +451,9 @@
       (rf/configure! {:epoch-history {:redact-fn (fn [r] (assoc r :rf/test-tag :redacted))}})
       (rf/replace-frame-state! :test/main {:rf.db/app {:injected :state}})
       (is (not (contains? @synthetic :rf/test-tag))
-          "replace-app-db! path: listener received the RAW synthetic record")
+          "frame-state replacement: listener received the raw synthetic record")
       (is (not (contains? (last-record :test/main) :rf/test-tag))
-          "replace-app-db! path: ring received the RAW synthetic record")
+          "frame-state replacement: ring received the raw synthetic record")
       (is (= :redacted (:rf/test-tag (epoch/projected-record @synthetic)))
           "the override applies when the synthetic record is projected"))))
 

--- a/implementation/epoch/test/re_frame/epoch_run_cause_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_run_cause_test.clj
@@ -1,23 +1,19 @@
 (ns re-frame.epoch-run-cause-test
-  "Coverage for `re-frame.epoch.capture/run-cause` (rf2-ynjts.7
-  testing-review gap-fill).
+  "Coverage for `re-frame.epoch.capture/run-cause`.
 
   `run-cause` is the in-flight run-cause lookup published through
-  the `:epoch/run-cause` late-bind hook (epoch.cljc:634) and consumed
+  the `:epoch/run-cause` late-bind hook and consumed
   by `views.cljs` at `:rf.view/rendered` emit time to stamp the per-render
   trace's `:cause-event-id` / `:cause-subs` / `:value-changed-subs` and to
   enforce the per-run view-render cap via `:rendered-so-far`
   (rf2-25zo2 / rf2-8wrzz.1). It is a single-reduce walk over the frame's
   in-flight capture buffer with FOUR distinct accumulators, a `sub-cap`
-  bound, first-seen dedup, and a conditional output map — and before this
-  file it had ZERO direct test coverage. A regression in any accumulator
+  bound, first-seen dedup, and a conditional output map. A regression in any accumulator
   (cause-event-id capture, the dedup, the value-changed subset, the cap
   counter) or in the empty-buffer shape would have shipped green.
 
-  SENSE (rf2-p4cd9c): `run-cause` names the event-pipeline-RUN (one event's
-  traversal) that drove the render/sub, keyed off the buffer's
-  `:rf.event/run-start` marker — renamed cascade-cause -> run-cause per the
-  glw1bh event-pipeline vocabulary (NOT the reactive-graph sense).
+  `run-cause` names the event-pipeline run that drove the render/sub, keyed off
+  `:rf.event/run-start`, not a reactive-graph run.
 
   The fn reads the frame's in-flight buffer via `state/buffer-for`; the
   tests seed that buffer directly with synthetic trace events (the shape

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -1,16 +1,13 @@
 (ns re-frame.epoch-test
   "Tool-Pair §Time-travel — epoch recording, query, listener, restore.
 
-  Bead rf2-shjf coverage:
-
     1. Recording — each DEQUEUED EVENT commits its own record; a
        multi-event drain (an :fx-dispatched child) commits one record
-       PER EVENT, not one per drain (per rf2-nj6p7 / Spec 002 §Drain
-       versus event).
+       per event, not one per drain.
     2. Per-frame isolation — two frames, each gets its own ring.
     3. Ring depth cap — dispatch >depth events; oldest get evicted.
     4. Configurable depth — `(rf/configure! {:epoch-history {:depth N}})`.
-    5. Listener — `register-epoch-listener!` fires per drain-settle with the
+    5. Listener — `register-epoch-listener!` fires per event epoch with the
        assembled record; same-key replaces; remove unhooks; exception
        isolation.
     6. Restore happy path — `restore-epoch!` rewinds app-db.
@@ -20,12 +17,10 @@
        unknown frame-id; each leaves app-db unchanged.
     8. Sub-runs / renders / effects projection from the trace stream.
 
-  Per-cascade / per-mount POST-SETTLE attribution (rf2-qs6dl render lag,
-  rf2-wi900 sub-run lag, rf2-vh1k3 mount-render burst) lives in the dedicated
+  Per-event and per-mount post-settle attribution lives in the dedicated
   standing suite `re-frame.epoch-attribution-test` — those cases simulate the
   React-commit / React-deref timing the synchronous JVM cascade can't
-  reproduce. Consolidated there from this file (rf2-yp81r) so the whole
-  attribution surface is one cohesive, invariant-keyed grep target."
+  reproduce."
   (:require [clojure.java.io :as io]
             [clojure.set :as set]
             [clojure.string :as str]
@@ -152,8 +147,8 @@
 
 ;; ---- recording -------------------------------------------------------------
 
-(deftest record-on-drain-settle
-  (testing "every drain-settle commits exactly one :rf/epoch-record"
+(deftest record-on-event-settle
+  (testing "every dequeued event commits exactly one :rf/epoch-record"
     (rf/reg-frame :test/main {:doc "epoch test frame"})
     (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
@@ -163,7 +158,7 @@
     (rf/dispatch-sync [:inc]  {:frame :test/main})
 
     (let [history (rf/epoch-history :test/main)]
-      (is (= 3 (count history)) "one record per drain-settle")
+      (is (= 3 (count history)) "one record per dequeued event")
       (is (every? :epoch-id history))
       (is (every? :committed-at history))
       (is (= [[:seed] [:inc] [:inc]]
@@ -627,8 +622,8 @@
 
 ;; ---- listener --------------------------------------------------------------
 
-(deftest listener-fires-per-drain-settle
-  (testing "register-epoch-listener! fires once per drain-settle with the assembled record"
+(deftest listener-fires-per-event-settle
+  (testing "register-epoch-listener! fires once per event epoch with the assembled record"
     (rf/reg-frame :test/main {})
     (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
@@ -669,7 +664,7 @@
 ;; ---- rf2-s60jx: multi-listener observed-frames + re-register dissoc ------
 ;;
 ;; `notify-listeners!` invokes `record-observation!` once per listener per
-;; drain-settle, populating `observed-frames-by-cb[cb-id]` with each
+;; event settle, populating `observed-frames-by-cb[cb-id]` with each
 ;; frame the cb has seen. Two contracts that weren't pinned:
 ;;
 ;;   1. Two listeners both observing the same frame on the same drain
@@ -679,7 +674,7 @@
 ;;      `register-epoch-listener!`) resets BOTH the listener entry AND the
 ;;      observed-frames entry — so the new callback's silencing trace
 ;;      fires fresh against frames it observes. The `dissoc` at
-;;      epoch.cljc:158 is the non-obvious half of the contract; a
+;;      the fan-out path is the non-obvious half of the contract; a
 ;;      future regression that drops it would leave stale observed-
 ;;      frames bookkeeping under the new fn's id.
 
@@ -2478,11 +2473,9 @@
           "the scan reaches the still-trace-bearing value-change at idx 2,
            below (- n new-keep) = 5 — the post-reduction transient gap"))))
 
-(deftest value-changed-scan-stops-at-elision-boundary
-  (testing "rf2-b2c02 — the scan does NOT walk past the elision boundary: a
-            record whose :trace-events was elided (slot absent) terminates the
-            scan, and a value-change ONLY present in an elided (older) record is
-            correctly NOT found. This pins the O(keep) bound the fix preserves."
+(deftest value-changed-scan-needs-retained-evidence
+  (testing "a value-change present only in an elided raw trace, with no
+            structured :sub-runs evidence, is not attributed"
     (let [frame-id   :test/main
           render-key [:counter-view 0]
           ;; idx 0 carries a value-change but was ELIDED (no :trace-events slot);
@@ -2499,12 +2492,11 @@
       (reset! @#'state/histories {frame-id history})
       (reset! @#'state/config {:depth 50 :trace-events-keep 5 :redact-fn nil})
       (is (nil? (@#'state/value-changed-epoch-for frame-id render-key))
-          "the value-change lives only in an ELIDED record — the scan stops at
-           the boundary and reports no hit (the elided record cannot match)"))))
+          "the elided record carries no evidence the attribution scan can match"))))
 
-;; ---- restore-epoch! reactive surfaces (rf2-2fat) ---------------------------
+;; ---- restore-epoch! reactive surfaces -------------------------------------
 ;;
-;; Bead rf2-2fat coverage. Tool-Pair §Time-travel says restore "rewinds the
+;; Tool-Pair §Time-travel says restore "rewinds the
 ;; frame's app-db to the named epoch's :db-after value." Spec 006 §Subscription
 ;; cache pins invalidation to :replace-container! — and restore-epoch! goes
 ;; through the same adapter/replace-container! choke point used by the drain
@@ -2684,8 +2676,8 @@
           "flow recomputed correctly post-restore (6 * 1 = 6)"))))
 
 (deftest restore-rewinds-route-slice-and-route-sub
-  (testing "Per the bead: when a restored epoch changes the route slice, the
-  observable routing state follows. EP-0001 (rf2-tfepxu): the route slice
+  (testing "when a restored epoch changes the route slice, observable routing
+  state follows. The route slice
   lives in the runtime-db partition at [:rf.runtime/routing :current] — NOT
   under a legacy app-db :rf/runtime root (now a hard error) — and a
   full-frame-state restore (decision #2) rewinds runtime-db with app-db."
@@ -2693,8 +2685,7 @@
     (rf/reg-route :route/home    {} "/")
     (rf/reg-route :route/article {} "/articles/:id")
     ;; Framework-authority handlers write the route slice into the runtime-db
-    ;; partition via the reserved :rf.db/runtime effect (Mike ruling #4 — the
-    ;; routing subsystem is a framework/runtime-extension writer).
+    ;; partition via the reserved :rf.db/runtime effect.
     (rf/reg-event :go-home
       {:rf/machine? true}
       (fn [{:keys [rf.db/runtime]} _]
@@ -2728,9 +2719,9 @@
              (get-in (:rf.db/runtime (rf/frame-state-value :test/main)) [:rf.runtime/routing :current :route-id]))
           "the runtime-db route slice is rewound by the full-frame-state restore"))))
 
-;; ---- replace-app-db! (Tool-Pair §Pair-tool writes, rf2-zq55) -------------
+;; ---- replace-frame-state! app-db patches ---------------------------------
 ;;
-;; Per Tool-Pair §Pair-tool writes: replace-app-db! is the canonical
+;; Per Tool-Pair §Pair-tool writes, an app-db-only `replace-frame-state!` is the
 ;; Tool-Pair write surface for state injection. The invariants below
 ;; cover the contract the spec commits to:
 ;;
@@ -2745,7 +2736,7 @@
 ;; 7. Unknown frame: :rf.error/no-such-handler (kind :frame).
 
 (deftest replace-frame-state-app-only-replaces-container
-  (testing "replace-app-db! replaces the underlying app-db value"
+  (testing "an app-db-only replace-frame-state! patch replaces the app-db value"
     (rf/reg-frame :test/main {})
     (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/dispatch-sync [:seed] {:frame :test/main})
@@ -2756,10 +2747,8 @@
         "container holds the injected value")))
 
 (deftest replace-frame-state-app-reset-resets-app-db-only-preserving-runtime-db
-  (testing "reset-app-db! resets the app-db partition to {} while live
-            runtime-db (machines / routes) survives (EP-0001 rf2-tfepxu,
-            Mike ruling #10 — the app-db sibling of a full frame reset,
-            destroy-frame! + reg-frame)"
+  (testing "an empty app-db patch resets that partition while the live
+            runtime-db (machines and routes) survives"
     (rf/reg-frame :test/main {})
     (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 7 :cart {:items [1 2]}}}))
     (rf/dispatch-sync [:seed] {:frame :test/main})
@@ -2769,15 +2758,14 @@
     (is (= {:rf.runtime/machines {:m 1}} (:rf.db/runtime (rf/frame-state-value :test/main))))
 
     (is (true? (rf/replace-frame-state! :test/main {:rf.db/app {}}))
-        "reset-app-db! returns true on success")
+        "the empty app-db patch returns true on success")
     (is (= {} (rf/app-db-value :test/main))
         "app-db partition is reset to {}")
     (is (= {:rf.runtime/machines {:m 1}} (:rf.db/runtime (rf/frame-state-value :test/main)))
-        "runtime-db partition is PRESERVED — reset-app-db! never touches it")))
+        "the runtime-db partition is preserved")))
 
 (deftest replace-frame-state-app-reset-records-undo-epoch
-  (testing "reset-app-db! records a synthetic :rf.epoch/db-replaced epoch
-            (it delegates to replace-app-db! with {})"
+  (testing "an empty app-db patch records a synthetic :rf.epoch/db-replaced epoch"
     (rf/reg-frame :test/main {})
     (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 7}}))
     (rf/dispatch-sync [:seed] {:frame :test/main})
@@ -2791,7 +2779,7 @@
       (is (= {} (:db-after head)) "db-after is the {} reset value"))))
 
 (deftest replace-frame-state-app-only-records-undo-epoch
-  (testing "replace-app-db! records a synthetic epoch so restore-epoch!
+  (testing "an app-db-only patch records a synthetic epoch so restore-epoch!
             can rewind to the prior state"
     (rf/reg-frame :test/main {})
     (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 7}}))
@@ -2822,7 +2810,7 @@
             "restoring the seed epoch rewinds past the pair-tool injection")))))
 
 (deftest replace-frame-state-app-only-emits-trace
-  (testing "replace-app-db! emits :rf.epoch/db-replaced on success with
+  (testing "an app-db-only patch emits :rf.epoch/db-replaced on success with
             :frame and :epoch-id tags"
     (rf/reg-frame :test/main {})
     (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
@@ -2841,7 +2829,7 @@
           "trace carries the synthetic record's epoch-id"))))
 
 (deftest replace-frame-state-app-only-fires-listeners
-  (testing "replace-app-db! fans out the assembled synthetic record to
+  (testing "an app-db-only patch fans out the assembled synthetic record to
             register-epoch-listener! listeners"
     (rf/reg-frame :test/main {})
     (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
@@ -2862,7 +2850,7 @@
           (rf/unregister-listener! :epoch ::reset-listener))))))
 
 (deftest replace-frame-state-app-only-failure-unknown-frame
-  (testing "replace-app-db! on an unknown frame returns false and emits
+  (testing "an app-db-only patch on an unknown frame returns false and emits
             :rf.error/no-such-handler (kind :frame); no-op on app-db"
     (let [recorded (record-trace!)
           ok?      (rf/replace-frame-state! :no.such/frame {:rf.db/app {:any 'value}})]
@@ -2874,7 +2862,7 @@
         (is (= :no.such/frame (:frame (:tags ev))))))))
 
 (deftest replace-frame-state-app-only-failure-during-drain
-  (testing "replace-app-db! called from inside a drain returns false and
+  (testing "an app-db-only patch called from inside a drain returns false and
             emits :rf.epoch/replace-during-drain; app-db unchanged
             by the rejected call"
     (rf/reg-frame :test/main {})
@@ -2903,7 +2891,7 @@
         (is (= :test/main (:frame (:tags ev))))))))
 
 (deftest replace-frame-state-app-only-failure-schema-mismatch
-  (testing "replace-app-db! with a new-db that fails the frame's
+  (testing "an app-db-only patch whose value fails the frame's
             registered schemas returns false; emits
             :rf.epoch/replace-schema-mismatch; app-db unchanged"
     (rf/reg-frame :test/main {})
@@ -2931,7 +2919,7 @@
             "[:n] is the failing path")))))
 
 (deftest replace-frame-state-app-only-no-validation-when-no-schemas
-  (testing "When the frame has no registered schemas, replace-app-db!
+  (testing "when the frame has no registered schemas, an app-db-only patch
             accepts any new-db (the validation step is a no-op)"
     (rf/reg-frame :test/loose {})
     (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:anything 'goes}}))
@@ -2941,9 +2929,9 @@
     (is (= {:totally :different :shape true}
            (rf/app-db-value :test/loose)))))
 
-;; ---- rf2-unpldn: depth-0 undo-works-after invariant ----------------------
+;; ---- depth-0 undo-works-after invariant ----------------------------------
 ;;
-;; The four synthetic mutators each record a :rf.epoch/db-replaced undo-anchor
+;; Every partition shape records a :rf.epoch/db-replaced undo anchor
 ;; so restore-epoch! can rewind PAST the injection — their caller's invariant is
 ;; "undo works after this call" (Tool-Pair §Pair-tool writes). Under
 ;; (rf/configure! {:epoch-history {:depth 0}}) the ring buffer is DISABLED by
@@ -2956,10 +2944,10 @@
 ;; :rf.epoch/restore-unknown-epoch). The contract is therefore LOUD REJECT —
 ;; depth 0 means "history disabled", so force-appending the anchor would
 ;; contradict the spec; instead reject loudly via the in-artefact failure
-;; channel (the analogue of the artefact-missing throw at core_epoch.cljc:111).
+;; channel, analogous to the artefact-missing public wrapper failure.
 
 (deftest replace-frame-state-app-only-depth-0-rejects-no-false-undo
-  (testing "rf2-unpldn — under depth 0 (ring disabled) replace-app-db!
+  (testing "under depth 0 (ring disabled), an app-db-only patch
             returns FALSE and emits :rf.epoch/replace-history-disabled rather
             than a false success; app-db is unchanged and NO phantom
             last-settled anchor is left (the undo-works-after invariant is
@@ -2978,14 +2966,14 @@
     (let [recorded (record-trace!)
           ok?      (rf/replace-frame-state! :test/main {:rf.db/app {:n 999}})]
       (is (false? ok?)
-          "replace-app-db! is REJECTED under depth 0 — NOT a false true")
+          "the patch is rejected under depth 0 rather than returning false success")
       (is (= {:n 0} (rf/app-db-value :test/main))
           "app-db unchanged — the rejected injection is a no-op")
       (is (= [] (rf/epoch-history :test/main))
           "still no ring history — nothing force-appended")
       (is (nil? (state/last-settled-epoch-id :test/main))
           "NO phantom anchor left behind (would have named a non-ring epoch-id
-           pre-fix, breaking later back-fill / undo attribution)")
+           and broken later back-fill or undo attribution)")
       (let [ev (some (fn [ev]
                        (when (= :rf.epoch/replace-history-disabled (:operation ev))
                          ev))
@@ -2994,20 +2982,19 @@
         (is (= :error (:op-type ev)))
         (is (= :test/main (:frame (:tags ev))))))))
 
-(deftest four-mutators-all-reject-under-depth-0
-  (testing "rf2-unpldn — all four synthetic mutators (replace-app-db! /
-            reset-app-db! / replace-runtime-db! / replace-frame-state!) reject
-            uniformly under depth 0 via the shared precondition skeleton; none
-            leaves a phantom anchor"
+(deftest all-partition-shapes-reject-under-depth-0
+  (testing "every replace-frame-state! partition shape rejects uniformly under
+            depth 0 through the shared precondition path; none leaves a phantom
+            anchor"
     (rf/configure! {:epoch-history {:depth 0}})
     (rf/reg-frame :test/main {})
     (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/dispatch-sync [:seed] {:frame :test/main})
 
-    (is (false? (rf/replace-frame-state! :test/main {:rf.db/app {:n 1}}))   "replace-app-db! rejected")
-    (is (false? (rf/replace-frame-state! :test/main {:rf.db/app {}}))          "reset-app-db! rejected")
+    (is (false? (rf/replace-frame-state! :test/main {:rf.db/app {:n 1}})) "app-db patch rejected")
+    (is (false? (rf/replace-frame-state! :test/main {:rf.db/app {}})) "empty app-db patch rejected")
     (is (false? (rf/replace-frame-state! :test/main {:rf.db/runtime {:rf.runtime/machines {}}}))
-        "replace-runtime-db! rejected")
+        "runtime-db patch rejected")
     (is (false? (rf/replace-frame-state! :test/main
                                          {:rf.db/app {:n 2} :rf.db/runtime {}}))
         "replace-frame-state! rejected")
@@ -3324,7 +3311,7 @@
 ;; deliberate-enumeration choice right-by-construction.
 
 (deftest replace-frame-state-app-only-does-not-leak-into-next-cascade
-  (testing "after replace-app-db! on a frame, the NEXT cascade on that
+  (testing "after an app-db-only patch on a frame, the next cascade on that
             frame harvests a record whose :trace-events excludes the
             out-of-drain :rf.epoch/db-replaced emit, and whose
             :trigger-event is the actual next dispatched event (NOT
@@ -3357,7 +3344,7 @@
       (is (not-any? (fn [ev] (= :rf.epoch/db-replaced (:operation ev)))
                     (:trace-events post-reset))
           ":trace-events does NOT contain the out-of-drain :rf.epoch/db-replaced emit")
-      ;; project-all (rf2-ecu37, fused projection) emits no :effects
+      ;; The fused project-all pass emits no :effects
       ;; entry for :bump; the :sub-runs / :renders slots walking a
       ;; leaked event with op :rf.epoch/db-replaced would silently be
       ;; empty anyway — the strong signal is the trigger-event check
@@ -3366,12 +3353,12 @@
           "no leaked effects from the out-of-drain emit"))))
 
 (deftest replace-frame-state-app-only-failure-does-not-leak-into-next-cascade
-  (testing "the two replace-app-db! failure-mode emits
+  (testing "the two app-db-only patch failure-mode emits
             (:rf.epoch/replace-during-drain,
              :rf.epoch/replace-schema-mismatch) fire outside a
             cascade with :frame tags. They MUST be filtered out of
             capture-event!'s buffering — otherwise a failed
-            replace-app-db! attempt leaks a phantom event into the next
+            rejected patch leaks a phantom event into the next
             real cascade for that frame."
     ;; Use the schema-mismatch path — easier to drive than during-drain.
     (rf/reg-frame :test/sm {})
@@ -3940,23 +3927,24 @@
       (is (empty? @traces)
           "no traces emitted — nothing observed to silence"))))
 
-;; ---- rf2-5qbus: capture-buffer cross-contamination from out-of-drain emits ---
+;; ---- capture-buffer cross-contamination from out-of-drain emits -----------
 ;;
 ;; The `capture-event!` fn must skip every `:rf.epoch/*` op the namespace
 ;; emits OUTSIDE a cascade (catalogued in the `skip-ops` set). Without
-;; the skip, a `replace-app-db!` call (which emits `:rf.epoch/db-replaced`
+;; the skip, an app-db-only `replace-frame-state!` call (which emits
+;; `:rf.epoch/db-replaced`
 ;; after harvesting the cascade buffer) would buffer the db-replaced
 ;; trace event into `capture-buffers[frame-id]`, and the NEXT cascade
 ;; for the same frame would harvest it as the first event in the
 ;; buffer — treating it as belonging to that cascade. The
 ;; `find-trigger-event` fallback would pick its `:epoch-id` as the
-;; trigger; `project-all` (rf2-ecu37) would silently include the
-;; leaked entries. The skip-set carries these ops (rf2-htf28); this pins
+;; trigger; `project-all` would silently include the leaked entries. The
+;; skip-set carries these ops; this pins
 ;; the contract so a future regression that drops them surfaces loudly.
 
 (deftest capture-buffer-does-not-cross-contaminate-from-replace-frame-state-app-only
   (testing "an out-of-drain :rf.epoch/db-replaced emit from
-            replace-app-db! does NOT leak into the next cascade's
+            the app-db-only patch does not leak into the next cascade's
             harvested record for the same frame"
     (rf/reg-frame :test/main {})
     (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
@@ -3965,7 +3953,7 @@
     ;; 1. Drive one cascade — clean record lands.
     (rf/dispatch-sync [:seed] {:frame :test/main})
 
-    ;; 2. replace-app-db! out-of-drain — emits :rf.epoch/db-replaced,
+    ;; 2. An app-db-only patch outside a drain emits :rf.epoch/db-replaced,
     ;;    which must NOT buffer into capture-buffers.
     (is (true? (rf/replace-frame-state! :test/main {:rf.db/app {:n 99}})))
 
@@ -3975,7 +3963,7 @@
     (let [history    (rf/epoch-history :test/main)
           last-record (peek history)]
       ;; The history has 3 records: [:seed], the synthetic
-      ;; replace-app-db! record, and [:foo].
+      ;; synthetic db-replaced record, and [:foo].
       (is (= 3 (count history)))
 
       ;; The most-recent record (the [:foo] cascade) must be clean —
@@ -4011,7 +3999,7 @@
 
     ;; Synthesize a mid-flight capture-buffer entry directly. The
     ;; private capture-buffers atom holds frame-id → vector of trace
-    ;; events that were buffered between drain-start and drain-settle.
+    ;; events that were buffered between drain start and this event's settle.
     ;; A real-world race would have at least one event in this vector
     ;; when the destroy lands; pin the contract by inserting a
     ;; synthetic entry.
@@ -4392,7 +4380,7 @@
 ;; ---- rf2-eo4pr: record-observation! guards its swap -----------------------
 ;;
 ;; `notify-listeners!` invokes `record-observation!` once per listener per
-;; drain-settle. For the steady state — a long-lived listener observing the
+;; event settle. For the steady state — a long-lived listener observing the
 ;; same frame on every cascade — the cb's observed-frames set already
 ;; contains the frame-id, and an unconditional `swap!` would fire every
 ;; atom watcher N times per settle for ZERO semantic change. The guard
@@ -4405,7 +4393,7 @@
 (deftest record-observation-no-op-when-already-observed
   (testing "record-observation! does NOT swap! the observed-frames-by-cb
             atom when the (cb-id, frame-id) pair is already present —
-            repeated drain-settles for a stable listener-observing-frame
+            repeated event settles for a stable listener-observing-frame
             pairing leave the atom untouched (no watcher fires)"
     (rf/reg-frame :test/main {})
     (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
@@ -4447,9 +4435,9 @@
         (finally
           (remove-watch observed-atom ::swap-counter))))))
 
-;; ---- rf2-douii: configure! validates at the boundary ---------------------
+;; ---- configure! validates at the boundary -------------------------------
 ;;
-;; Per refactor-audit r2 (rf2-lwn4t) §rf2-douii: `configure!` validates
+;; `configure!` validates
 ;; `:depth` and `:trace-events-keep` at the boundary — invalid values (nil,
 ;; non-numeric) are silently dropped and the prior valid config survives.
 ;; Without that boundary check a bad value would survive configuration and
@@ -4520,9 +4508,9 @@
       (is (= 4 (:trace-events-keep cfg))
           "the invalid :trace-events-keep update was dropped"))))
 
-;; ---- rf2-douii: ring-eviction interaction with restore -------------------
+;; ---- ring-eviction interaction with restore -----------------------------
 ;;
-;; Per refactor-audit r2 (rf2-lwn4t) §rf2-douii: ring-buffer eviction and
+;; Ring-buffer eviction and
 ;; restore preconditions were each covered in isolation but never
 ;; together. A restore against an epoch-id that the ring has since evicted
 ;; must deterministically fail as :rf.epoch/restore-unknown-epoch with the
@@ -4569,9 +4557,9 @@
               "history-size tag reflects the post-eviction size, not
                the pre-eviction count"))))))
 
-;; ---- rf2-douii: depth 0 still fires listeners ----------------------------
+;; ---- depth 0 still fires listeners --------------------------------------
 ;;
-;; Per refactor-audit r2 (rf2-lwn4t) §rf2-douii: `configure!`'s docstring
+;; `configure!`'s docstring
 ;; documents that depth 0 'disables recording (assembled records can
 ;; still fire on listeners but nothing lands in the ring buffer)'. The
 ;; pre-existing `depth-zero-disables-recording` test covers only the
@@ -4593,7 +4581,7 @@
       (is (= [] (rf/epoch-history :test/main))
           "ring buffer is empty at depth 0")
       (is (= 2 (count @seen))
-          "listener still received an assembled record per drain-settle")
+          "listener still received an assembled record per event settle")
       (is (= [:seed :inc] (mapv :event-id @seen))
           "records carry the per-cascade trigger event-id")
       (is (every? #(contains? % :db-after) @seen)
@@ -4602,18 +4590,16 @@
       (is (every? #(contains? % :renders)  @seen))
       (is (every? #(contains? % :effects)  @seen)))))
 
-;; ---- rf2-douii: rejected restore/reset paths do not mutate history /
-;; ---- do not notify listeners --------------------------------------------
+;; ---- rejected restore/reset paths do not mutate history or notify listeners
 ;;
-;; Per refactor-audit r2 (rf2-lwn4t) §rf2-douii: the rejection tests
-;; (`restore-failure-*` / `replace-app-db!-failure-*`) verify the trace
+;; The rejection tests verify the trace
 ;; emission and app-db stability but do NOT explicitly pin the related
 ;; bookkeeping contracts:
 ;;
 ;;   1. A rejected restore does not append a new record to history.
 ;;   2. A rejected restore does not fire registered epoch listeners.
-;;   3. A rejected replace-app-db! does not append a new record.
-;;   4. A rejected replace-app-db! does not fire registered listeners.
+;;   3. A rejected replacement does not append a new record.
+;;   4. A rejected replacement does not fire registered listeners.
 ;;
 ;; A regression that swapped emission-on-failure for fanout-on-failure
 ;; (or appended a synthetic failure record) would slip through the
@@ -4641,7 +4627,7 @@
           "no listener fanout for the rejected restore"))))
 
 (deftest rejected-replace-frame-state-app-only-does-not-touch-history-or-listeners
-  (testing "a rejected replace-app-db! (during-drain rejection — the
+  (testing "a rejected app-db-only patch (during-drain rejection — the
             simplest rejection path that exercises the reset surface)
             leaves history untouched and does not fire listeners"
     (rf/reg-frame :test/main {})
@@ -4652,7 +4638,7 @@
           seen           (atom [])
           attempt        (atom nil)]
       (rf/register-listener! :epoch ::watcher (fn [r] (swap! seen conj r)))
-      ;; A handler that calls replace-app-db! synchronously during a
+      ;; A handler that calls replace-frame-state! synchronously during a
       ;; drain — the during-drain precondition fails. The reset itself
       ;; must not fan out, but the surrounding drain still settles
       ;; normally (which appends ONE record — the one for :try-reset).
@@ -4708,17 +4694,16 @@
         "current-config's :trace-events-keep resolves to the shipped 50")))
 
 ;; ============================================================================
-;;  rf2-7i872 — write-boundary liveness race (validate-then-destroy)
+;;  Write-boundary liveness race (validate, then destroy)
 ;; ============================================================================
 ;;
-;; restore-epoch! / replace-app-db! validate preconditions against a LIVE
+;; restore-epoch! and replace-frame-state! validate preconditions against a live
 ;; frame, then write the frame's container. A frame destroyed in the window
 ;; BETWEEN validation and the write (a tool gesture interleaving with the
 ;; owning component's teardown) leaves `frame/app-db-container` returning
 ;; nil, so the choke-point `adapter/replace-container!` silently no-ops the
-;; write. Pre-rf2-7i872 the epoch surfaces still emitted success and
-;; returned `true` (and `replace-app-db!` recorded + fanned out a SYNTHETIC
-;; epoch for the destroyed frame). Per Tool-Pair §Surface behaviour against
+;; write. The epoch surfaces must not emit success or return `true` after this
+;; race. Per Tool-Pair §Surface behaviour against
 ;; destroyed frames a destroyed-frame write is a STRUCTURAL FAILURE
 ;; (:rf.error/no-such-handler, kind :frame, returns false).
 ;;
@@ -4727,7 +4712,7 @@
 ;;       steps the public fn sequences, with the destroy injected between.
 ;;   (b) the PUBLIC surface — with-redefs the precondition check to destroy
 ;;       the frame after a real (live) validation, proving the public
-;;       restore-epoch! / replace-app-db! honour the write-boundary guard.
+;;       restore-epoch! and replace-frame-state! honour the write-boundary guard.
 
 (deftest restore-epoch-validate-then-destroy-reports-honest-failure-seam
   (testing "rf2-7i872 — perform-restore! against a frame destroyed AFTER a

--- a/implementation/epoch/test/re_frame/machine_minted_cofx_replay_token_test.clj
+++ b/implementation/epoch/test/re_frame/machine_minted_cofx_replay_token_test.clj
@@ -1,48 +1,14 @@
 (ns re-frame.machine-minted-cofx-replay-token-test
-  "Per rf2-cheez6.1 / rf2-08br0v — the STRUCTURAL fix + determinism proof for
-  the machine-minted-cofx replay-token gap.
+  "End-to-end replay coverage for coeffects minted inside a machine run.
 
-  ## The confirmed bug (rf2-08br0v)
+  Run-start contains only coeffects known before handler execution. Machine
+  guards and actions may mint recordable facts later, so epoch assembly also
+  folds `:rf.cofx/generated` traces into the replay token. Pre-handler mints
+  merge idempotently; mid-run mints supply facts absent from run-start.
 
-  A generator-backed recordable cofx MINTED by a state machine's guard/action
-  — `ensure-ctx-cofx` pre-drain, or `ensure-raised-cofx` in-drain for a
-  raise-selected guard — is written onto the engine-local machine def's
-  `:rf/cofx` and threads forward through the drain. But the value did NOT reach
-  the epoch's `:rf.cofx` replay token. The router emits `:rf.event/run-start`
-  carrying the cofx AS IT WAS after `assemble-initial-ctx`'s PRE-handler
-  declared-only delivery (every fact minted for the OUTER event's declared
-  `:rf.cofx/requires`). A machine's outer event declares NO requires — they live
-  on guards/actions — so the router minted nothing for it, and the machine's own
-  ensure steps run INSIDE the handler, AFTER run-start. Net: the run-start
-  replay token carried only externally-supplied facts (e.g. `:rf/time-ms`),
-  never the machine-minted ones. On `:strict` replay (mint-policy-aware,
-  rf2-n0myjq) the missing fact yielded `:rf.error/missing-required-cofx` and the
-  macrostep that advanced under `:live` FAILED — replay non-determinism.
-
-  ## The structural fix (this bead)
-
-  Every actual recordable mint — pre-handler in `assemble-initial-ctx` AND
-  mid-drain in the machine ensure steps — emits a dev-only `:rf.cofx/generated`
-  trace carrying `:rf.cofx/id` + the marks-projected `:rf.cofx/value`. Those
-  emits ride the SAME in-flight cascade buffer the epoch capture harvests. So
-  `re-frame.epoch.capture/find-trigger-event` now collects them and merges
-  `{id -> value}` onto the run-start replay token at epoch-assembly time. This
-  changes no LIVE behaviour (a read-only epoch-assembly walk), over-captures
-  nothing (only facts a generator ACTUALLY minted emit `:rf.cofx/generated`),
-  and is idempotent for the ordinary event path (a pre-handler mint is already
-  in the token verbatim). The augmentation matters only for the mid-drain
-  machine mints the token previously missed.
-
-  ## What this namespace proves
-
-  This is the EPOCH-side end-to-end test (the epoch test classpath carries
-  machines as a test-only dep): it drives the REAL machine dispatch path, reads
-  the assembled epoch record, and asserts the token NOW carries the mid-drain
-  minted fact (the assertion that FAILS without the fix), then proves a `:strict`
-  re-presentation of that exact captured token reproduces the live decision —
-  replay determinism, directly. The machines-side companion
-  (`re-frame.machine-raise-cofx-replay-test`) proves the end-to-end determinism
-  contract (token-fact necessary and sufficient) at the machines surface."
+  The tests drive real machine dispatch, assert that the captured token contains
+  the generated fact, and prove strict re-presentation reproduces the live
+  decision without another host read."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.epoch :as epoch]
@@ -109,10 +75,8 @@
       (is (= :done (machine-state :replay/mint))
           "the machine advanced to :done on the minted value")
 
-      ;; (2) THE FLIP (the fix): the assembled epoch record's :rf.cofx replay
-      ;; token now carries BOTH the external :rf/time-ms AND the mid-drain
-      ;; minted :replay/gen. WITHOUT the fix this token would be {:rf/time-ms
-      ;; 111} only and this assertion fails.
+      ;; The assembled epoch record's :rf.cofx replay token carries both the
+      ;; external :rf/time-ms and the mid-drain minted :replay/gen.
       (let [rec   (last-record)
             token (:rf.cofx rec)]
         (is (some? rec) "an epoch record was assembled for the machine cascade")
@@ -121,15 +85,14 @@
         (is (= 111 (:rf/time-ms token))
             "the external :rf/time-ms survives in the token")
         (is (= 100 (:replay/gen token))
-            "CONFIRMED FIX (rf2-cheez6.1): the mid-drain minted :replay/gen is
-             now captured in the run-start replay token (was absent pre-fix)")))))
+            "the run-start replay token captures the mid-drain minted :replay/gen")))))
 
 (deftest strict-replay-of-the-captured-token-is-deterministic
-  (testing "rf2-cheez6.1 — the captured token re-presented under :strict (the
+  (testing "the captured token re-presented under :strict (the
    replay mint policy) reproduces the live decision: the guard reads the
    recorded :replay/gen verbatim (no host re-mint) and the machine reaches
-   :done. This is replay determinism, directly — and it depends on the captured
-   token carrying the minted fact (the fix). A SECOND machine id (same spec) is
+   :done. This is replay determinism, directly, and depends on the captured
+   token carrying the minted fact. A second machine id (same spec) is
    the fresh :a instance the captured token replays against, so no whole-frame
    reset is needed."
     (let [live-seen   (atom ::unset)
@@ -159,9 +122,9 @@
              :done deterministically")))))
 
 (deftest strict-without-the-minted-fact-diverges-control
-  (testing "rf2-cheez6.1 CONTROL — the same :strict dispatch WITHOUT the minted
+  (testing "the same :strict dispatch without the minted
    fact in the token does NOT advance (strict refuses to mint). This proves the
-   captured token fact is LOAD-BEARING: without the fix's augmentation the
+   captured token fact is load-bearing: without it the
    replay token lacks :replay/gen and a :strict replay would diverge from the
    live :done."
     (let [seen (atom ::unset)]
@@ -169,7 +132,7 @@
       (rf/reg-cofx :replay/gen {:recordable? true} (fn [] 100))
       (rf/reg-machine :replay/mint (mint-machine seen))
 
-      ;; The PRE-FIX token shape: only :rf/time-ms, no :replay/gen.
+      ;; A token without the machine-minted replay generation.
       (rf/dispatch-sync [:replay/mint [:go]]
                         {:frame :test/main
                          :rf.cofx {:rf/time-ms 111}


### PR DESCRIPTION
## What changed

- clarified the public epoch lifecycle as one record and listener delivery per dequeued event, including depth-zero listener fan-out
- reduced issue-history and implementation-provenance commentary across the facade, state, capture, assembly, listeners, tool-pair, deps, and focused tests
- kept the current invariants for raw replay storage, restore refusal and liveness races, host cleanup, and fail-closed off-box projection
- updated test explanations to the current `replace-frame-state!` surface and per-event terminology

## Why

Epoch commentary had grown into historical issue reports, and some wording contradicted the per-event epoch model. The public listener docs also overstated depth-zero storage behavior. This pass keeps explanations close to the decisions readers need while removing stale provenance and retired API terminology.

## Impact

Explanation-only and behavior-neutral. Runtime forms and assertions are unchanged; test var names were updated only where they encoded stale lifecycle terminology.

## Checks

- `clj-kondo --lint src test --fail-level error`: 0 errors (170 existing warnings)
- `clojure -M:test`: 376 tests, 1,505 assertions, 0 failures, 0 errors
- `npm run test:cljs`: 8,472 tests, 39,186 assertions, 0 failures, 0 errors (3 existing warnings outside epoch)
- `git diff --check`
