### PR TITLE
docs(skill/base): design+inputs sole normative source; SKILL.md router; orchestration-only setup prompt (rf2-rpkspz, rf2-ks0who, rf2-5d56o6)

### DIFF
--- a/scripts/check_skill_re_frame2_drift.py
+++ b/scripts/check_skill_re_frame2_drift.py
@@ -1,15 +1,21 @@
 #!/usr/bin/env python3
-"""No-bead-id + verification-posture drift guard for the re-frame2 (authoring)
-skill.
+"""No-bead-id + verification-posture + launcher-canonical drift guard for the
+re-frame2 (authoring) skill.
 
-A senior review of `skills/re-frame2` caught two regressions that the existing
-automated guards did not protect (the no-bead-id guard was scoped to
+`spec/design.md` is the single normative source for the skill's locked
+decisions (L1–L11), file structure, cardinal rules, and verification posture;
+`spec/inputs.md` owns the canonical inputs and update procedure. The
+`spec/authoring-prompt.md` launcher orchestrates a reauthoring pass by
+*pointing at* those two files — it must not carry a second, drift-prone copy of
+the tree, the rules, or the locks. This guard protects three regressions the
+existing automated guards did not catch (the no-bead-id guard was scoped to
 `skills/re-frame2-implementor` only):
 
   1. **Bead-id leaks in user-facing leaves.** Two leaves carried
      `EP-0008 (rf2-hhutya)` — an internal `bd` tracker id. The skill's own
-     authoring spec locks this out (`spec/design.md` L10, `spec/authoring-
-     prompt.md`): `SKILL.md` + `references/` + `patterns/` + `decision-trees/`
+     design locks this out (`spec/design.md` L10 — the normative source; the
+     `spec/authoring-prompt.md` launcher references it but no longer restates
+     it): `SKILL.md` + `references/` + `patterns/` + `decision-trees/`
      carry NO `rf2-XXXX` ids. Bead ids are monorepo-internal workflow noise; a
      consumer app author has no `bd` and no bead corpus, so a leaked id is
      unexplained context. Use public, stable evidence instead — an EP number, a
@@ -18,8 +24,9 @@ automated guards did not protect (the no-bead-id guard was scoped to
      (authoring / internal context) and are out of scan scope; `evals/` is also
      out of scope (eval harness, not user-facing teaching).
 
-  2. **Verification-posture drift.** `spec/design.md` (Q14 / L3), `spec/
-     authoring-prompt.md`, and `skills/README.md` all lock the posture: this is
+  2. **Verification-posture drift.** `spec/design.md` (Q14 / L3) is the
+     normative lock on the posture (the `spec/authoring-prompt.md` launcher and
+     `skills/README.md` both reference it, they do not re-hold it): this is
      an authoring-only skill — the AUTHOR runs the tests, the compiler, the app;
      the skill stops at writing the code. Running gates is general software
      practice (Pillar 4), not a re-frame2 binding the skill teaches. The skill
@@ -31,12 +38,24 @@ automated guards did not protect (the no-bead-id guard was scoped to
      unlocked by Mike, the design/index rationale flips first — and this guard's
      posture rules are retired in the same change.)
 
+  3. **Launcher regrowth.** `spec/authoring-prompt.md` is a launcher, not a
+     second normative source. It MUST point at both canonical files
+     (`design.md` AND `inputs.md`) so a reauthoring session reads the design
+     before writing, and it MUST NOT regrow the copied file-structure tree or
+     the copied locks/cardinal-rules block — the exact duplication that drifted
+     (the launcher had over-generalised the runtime `*` suffixes and still
+     named a default frame, both contradicting current design). This guard
+     fails if the launcher stops citing a canonical file or grows a box-drawing
+     tree / a "Locks to preserve verbatim" (or "Cardinal rules to bake in")
+     block back.
+
 Scanned leaves (globbed, so a new leaf is covered automatically):
     SKILL.md, README.md, references/**/*.md, patterns/**/*.md,
     decision-trees/**/*.md.
-Out of scope (deliberately): spec/ (L10 permits bead ids; carries the Q14 lock
-    *statements* themselves), evals/ (harness, not teaching), examples-map.md is
-    in scope (it is a user-facing leaf).
+Out of scope of the line-by-line scan (deliberately): spec/ (L10 permits bead
+    ids; `design.md` carries the normative lock *statements*; `authoring-
+    prompt.md` is the launcher, checked separately by Rule 3), evals/ (harness,
+    not teaching). examples-map.md is in scope (it is a user-facing leaf).
 
 Exit code:
     0  no drift detected
@@ -70,6 +89,9 @@ for _stream in (sys.stdout, sys.stderr):
         pass
 
 SKILL_DIR = REPO_ROOT / "skills" / "re-frame2"
+# The launcher: a reauthoring wrapper that must POINT at the canonical files
+# (design.md + inputs.md), never re-hold their tree / rules / locks (Rule 3).
+AUTHORING_PROMPT = SKILL_DIR / "spec" / "authoring-prompt.md"
 
 
 def scanned_files() -> list[Path]:
@@ -113,6 +135,60 @@ VERIFY_PROSE_RE = re.compile(
     r"|verifying\b.{0,40}\bis in scope",
     re.IGNORECASE,
 )
+
+# --- Rule 3: launcher points at BOTH canonical files, without regrowing the
+#     tree / locks sections. Operates on the whole authoring-prompt.md body
+#     (not the line-by-line leaf scan). `design.md` / `inputs.md` are the
+#     normative source; the launcher must cite each so a reauthoring session
+#     reads them first, and must not paste a second copy of the material they
+#     own.
+DESIGN_REF_RE = re.compile(r"\bdesign\.md\b")
+INPUTS_REF_RE = re.compile(r"\binputs\.md\b")
+# A regrown file-structure tree: box-drawing branch glyphs (├── / └── / │) —
+# the only reason they appear in this prose is a copied directory listing.
+TREE_REGROWTH_RE = re.compile(r"[├└]──")
+# A regrown normative block: the copied "Locks to preserve verbatim" or
+# "Cardinal rules to bake in" heading/label the launcher used to carry.
+LOCKS_REGROWTH_RE = re.compile(
+    r"(?im)^\s*[>*#\s-]*\**\s*(?:locks to preserve verbatim"
+    r"|cardinal rules to bake in)\b"
+)
+
+
+def launcher_problems(text: str) -> list[str]:
+    """Rule 3 — the authoring-prompt.md launcher must point at both canonical
+    files and must not regrow the tree / locks sections. Takes the raw body so
+    the self-test can pass fixtures directly."""
+    problems: list[str] = []
+    if not DESIGN_REF_RE.search(text):
+        problems.append(
+            "LAUNCHER-CANONICAL: spec/authoring-prompt.md no longer points at "
+            "spec/design.md — the normative source for the locked decisions "
+            "(L1–L11), the file structure, and the cardinal rules. A "
+            "reauthoring session must be told to read design.md first."
+        )
+    if not INPUTS_REF_RE.search(text):
+        problems.append(
+            "LAUNCHER-CANONICAL: spec/authoring-prompt.md no longer points at "
+            "spec/inputs.md — the normative source for the canonical inputs and "
+            "the §6 update procedure. Cite it in the ordered reads."
+        )
+    if TREE_REGROWTH_RE.search(text):
+        problems.append(
+            "LAUNCHER-REGROWTH: spec/authoring-prompt.md regrew the file-"
+            "structure tree (box-drawing ├── / └── glyphs). The locked layout "
+            "lives ONLY in design.md §5 — link it, do not paste a second copy "
+            "(a duplicate is exactly what drifts)."
+        )
+    if LOCKS_REGROWTH_RE.search(text):
+        problems.append(
+            "LAUNCHER-REGROWTH: spec/authoring-prompt.md regrew a normative "
+            "block (a 'Locks to preserve verbatim' / 'Cardinal rules to bake "
+            "in' section). The L1–L11 locks and the cardinal rules live ONLY in "
+            "design.md §3 / SKILL.md §Cardinal rules — reference them, don't "
+            "restate a divergent copy."
+        )
+    return problems
 
 
 def beadid_problems(line: str) -> list[str]:
@@ -167,6 +243,18 @@ def find_drift(files: list[Path]) -> tuple[list[str], int]:
             rel = path.relative_to(REPO_ROOT)
             for label in beadid_problems(line) + posture_problems(line):
                 problems.append(f"{rel}:{lineno}: {label}\n    {line.strip()}")
+
+    # Rule 3 — the launcher (authoring-prompt.md) is checked as a whole body,
+    # not line-by-line, and lives under spec/ (out of the leaf scan above).
+    if not AUTHORING_PROMPT.is_file():
+        problems.append(
+            "SETUP: skills/re-frame2/spec/authoring-prompt.md missing — the "
+            "launcher-canonical check (Rule 3) has no anchor."
+        )
+    else:
+        rel = AUTHORING_PROMPT.relative_to(REPO_ROOT)
+        for label in launcher_problems(_slurp(AUTHORING_PROMPT)):
+            problems.append(f"{rel}: {label}")
     return problems, lines_checked
 
 
@@ -184,15 +272,17 @@ def run(*, verbose: bool, ci: bool) -> int:
 
     if verbose:
         print(
-            f"re-frame2 no-bead-id + verify-posture guard: scanned "
-            f"{len(files)} user-facing leaves ({lines_checked} lines)."
+            f"re-frame2 no-bead-id + verify-posture + launcher-canonical guard: "
+            f"scanned {len(files)} user-facing leaves ({lines_checked} lines) "
+            "plus the spec/authoring-prompt.md launcher."
         )
 
     if not problems:
         if verbose:
             print(
-                "re-frame2-drift: no bead-id leaks and no agent-run "
-                "verification-posture drift found."
+                "re-frame2-drift: no bead-id leaks, no agent-run verification-"
+                "posture drift, and the launcher points at design.md + inputs.md "
+                "without regrowing the tree / locks."
             )
         return 0
 
@@ -201,9 +291,10 @@ def run(*, verbose: bool, ci: bool) -> int:
         print(f"{err_prefix}{p}")
     print(
         f"\nre-frame2-drift: {len(problems)} drift issue(s) — keep internal "
-        "bead ids out of the user-facing leaves (L10), and keep the "
-        "authoring-only verification posture (Q14 / L3): the author runs the "
-        "gates, the skill names them."
+        "bead ids out of the user-facing leaves (L10), keep the "
+        "authoring-only verification posture (Q14 / L3: the author runs the "
+        "gates, the skill names them), and keep the launcher pointing at the "
+        "canonical design.md + inputs.md instead of re-holding the tree / locks."
     )
     return 1
 
@@ -314,6 +405,44 @@ def _self_test() -> int:
         posture_problems,
         "The skill writes the test; the author runs the suite.",
         dirty=False, label="F2 author-runs-suite wording",
+    )
+
+    # --- Rule 3: launcher points at both canonical files without regrowing the
+    # tree / locks. `launcher_problems` takes the WHOLE body, so these fixtures
+    # are multi-line prose, not single lines.
+    clean_launcher = (
+        "Read spec/design.md (the normative locks + file structure) then "
+        "spec/inputs.md (the canonical inputs). Write the skill to the layout "
+        "locked in design.md §5; honour the L1-L11 locks in design.md §3."
+    )
+    expect(
+        launcher_problems, clean_launcher,
+        dirty=False, label="G1 launcher cites both canonical files, no regrowth",
+    )
+    expect(
+        launcher_problems,
+        "Read spec/design.md then write the skill.",  # no inputs.md ref
+        dirty=True, label="G2 launcher drops the inputs.md pointer",
+    )
+    expect(
+        launcher_problems,
+        "Read spec/inputs.md then write the skill.",  # no design.md ref
+        dirty=True, label="G3 launcher drops the design.md pointer",
+    )
+    expect(
+        launcher_problems,
+        clean_launcher + "\n```\nskills/re-frame2/\n├── SKILL.md\n```",
+        dirty=True, label="G4 launcher regrew the file-structure tree",
+    )
+    expect(
+        launcher_problems,
+        clean_launcher + "\n\n> *Locks to preserve verbatim:*\n> *- L3 …*",
+        dirty=True, label="G5 launcher regrew the locks block",
+    )
+    expect(
+        launcher_problems,
+        clean_launcher + "\n\n*Cardinal rules to bake in (these go in SKILL.md):*",
+        dirty=True, label="G6 launcher regrew the cardinal-rules block",
     )
 
     if failures:

--- a/skills/re-frame2-setup/spec/authoring-prompt.md
+++ b/skills/re-frame2-setup/spec/authoring-prompt.md
@@ -4,101 +4,23 @@
 
 A self-contained prompt that re-authors the `re-frame2-setup` skill from this `spec/` folder alone. Drop into a fresh Claude Code session in the re-frame2 repo root.
 
-## The prompt
+**This prompt is an execution wrapper** — an ordered set of reads plus a write/run step. Everything normative is owned elsewhere and linked, never restated (a second copy is what drifts): the locked decisions, file structure, and discovery surface live in [`design.md`](design.md); the canonical inputs, mappings, and reauthor triggers live in [`inputs.md`](inputs.md); the family conventions (leaf-size discipline, single-source routing, the published-skill `allowed-tools` baseline) live in [`skills/README.md`](../../README.md); the user-facing six-step workflow the skill teaches lives in [`SKILL.md`](../SKILL.md).
 
-> *I'm re-authoring the `re-frame2-setup` skill at `skills/re-frame2-setup/`. The skill helps an author **bootstrap a fresh re-frame2 ClojureScript project** from nothing (or close to it) — adds the artefact deps, writes a minimal `shadow-cljs.edn`, lays down a canonical entry namespace with `rf/init!` + the Reagent adapter, and walks the author through their first mounted counter. After the counter mounts, the author switches to `skills/re-frame2/` for code-writing or `skills/re-frame2-pair/` for live pair-programming.*
+## The reauthoring procedure
+
+> *I'm re-authoring the `re-frame2-setup` skill at `skills/re-frame2-setup/` — the greenfield-bootstrap skill that walks an author from an empty directory to a mounted first counter, then hands off to `re-frame2` (code-writing) / `re-frame2-pair` (live pair-programming). Read these in order, then write the skill to match what each source owns — do not paste a copy of any of it into this prompt or the leaves:*
 >
-> *Read these first (in this order):*
+> *1. **[normative — decisions]** `skills/re-frame2-setup/spec/design.md` — the goal, the four pillars (§2, Q14 lock), the locked decisions L1–L10 (cardinal rules, day-one shape, exit hand-off), the locked file structure (§5), the discovery surface (§6), and the drift-guard map (§9a). Sole source for the layout, the rules, and the locks.*
+> *2. **[normative — inputs & triggers]** `skills/re-frame2-setup/spec/inputs.md` — the canonical greenfield artefacts and mappings the leaves derive from, and the §6 update procedure (the when-to-reauthor triggers).*
+> *3. **[family conventions]** `skills/README.md` — the leaf-size discipline (§Leaf size discipline: the numeric ceiling every leaf obeys), the single-source skill-routing table (§Skill routing: the exit hand-off points here, no per-skill routing table), and the published-skill `allowed-tools` baseline (§Published-skill `allowed-tools` baseline, including the nREPL-localhost reminder).*
+> *4. **[user workflow]** `skills/re-frame2-setup/SKILL.md` (current) — the six-step canonical path the skill teaches, to preserve/refresh rather than re-derive.*
+> *5. **[canonical sources]** `examples/core/counter/{core.cljs,index.html}`; `implementation/core/src/re_frame/core.cljc` (the `rf/init!` contract) + `implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs` (the adapter spec map); the generator template under `tools/template/resources/day8/re_frame2_template/{_reagent,_shared,_uix,_helix,root}/` (the day-one deps, the hot-reload lifecycle, the CSP, and the UIx/Helix greenfield the leaves must stay in lockstep with); and `skills/re-frame-migration/SKILL.md` + `spec/` for voice / shape.*
 >
-> *1. `skills/re-frame2-setup/spec/design.md` — the locked design decisions (L1 through L10). Pillars 1-4 in §2 are non-negotiable. Q14 lock applies (NO verification module).*
-> *2. `skills/re-frame2-setup/spec/inputs.md` — the canonical inputs the skill leans on.*
-> *3. `examples/core/counter/` — the canonical first-counter shape (`core.cljs`, `index.html`; the examples share a single repo-level build, so there is no per-example `shadow-cljs.edn` — derive the greenfield build from the generator template, per `inputs.md`). `references/first-counter.md` is a trimmed version of this example.*
-> *4. `implementation/core/src/re_frame/core.cljc` (for the `rf/init!` contract) + `implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs` (for the adapter spec map shape).*
-> *5. `skills/re-frame-migration/SKILL.md` + `skills/re-frame-migration/spec/` — the closest structural sibling with an existing `spec/` triad. Voice / shape mirror this.*
-> *6. `skills/re-frame2/SKILL.md` — the parent skill the author switches to once setup is done. SKILL.md's exit hand-off points here; cross-skill routing is single-sourced in `skills/README.md`.*
->
-> *Then write the skill at `skills/re-frame2-setup/` with this exact file structure:*
->
-> ```
-> skills/re-frame2-setup/
-> ├── SKILL.md                       (router + canonical greenfield path)
-> ├── README.md                      (human-facing intro)
-> ├── LICENSE                        (MIT)
-> ├── package.json                   (npm metadata)
-> ├── .claude-plugin/plugin.json     (Claude Code plugin metadata)
-> ├── references/
-> │   ├── deps-versions.md           (lockstep VERSION; pay-as-you-go artefact table; deps.edn / package.json)
-> │   ├── shadow-cljs.md             (minimal build shape, index.html, CSP)
-> │   ├── entry-namespace.md         (rf/init! + Reagent root contract + UIx/Helix greenfield)
-> │   └── first-counter.md           (end-to-end worked example)
-> ├── spec/
-> │   ├── design.md
-> │   ├── inputs.md
-> │   └── authoring-prompt.md
-> ├── tests/
-> │   └── setup_drift_test.clj       (structural drift guard; Babashka)
-> └── evals/
->     └── evals.json                 (trigger-accuracy fixture)
-> ```
->
-> *Every reference leaf follows the family leaf-size discipline — ≤250 lines AND ≤16 KB (target ~150 lines / ~10 KB; see `skills/README.md` §Leaf size discipline). `entry-namespace.md` runs slightly over on bytes because it carries the CI-pinned UIx/Helix greenfield recipe (the `check_skill_setup_counter_drift.py` guard pins those snippets to that file, so it can't be split). SKILL.md is the router (under Anthropic's 500-line ceiling). All leaves are one level deep.*
->
-> *SKILL.md walks the six canonical steps:*
->
-> *1. Discover the current artefact VERSION.*
-> *2. Add deps to `deps.edn`.*
-> *3. Add npm deps to `package.json`.*
-> *4. Write `shadow-cljs.edn`.*
-> *5. Write `core.cljs` — the whole counter in one file: `(rf/init! reagent-adapter/adapter)` before any render, exported `init` entry symbol (matches the generator template), and schema + event + sub + reg-view + mount (the whole-app-db schema attaches frame-locally at boot under `with-frame`, matching the generator). first-counter.md is the sole copy-complete source; entry-namespace.md explains the boot lifecycle.*
-> *6. Run it and verify.*
->
-> *Cardinal rules to bake in (these go in SKILL.md):*
->
-> *1. **Never hardcode the re-frame2 artefact VERSION in suggestions written to disk.** Look it up first; leave it as `<VERSION>`. (Concrete Clojure/CLJS/Reagent pins matching the template are fine.) Also: the framework coordinate branches on publication state — pre-publish is `:git/sha` / `:local/root`, `:mvn/version` is the labelled post-publish destination.*
-> *2. **All eleven artefacts ship at the same VERSION** (and `day8/re-frame2-xray` rides the same line). Mixing is unsupported. Lockstep is a build-time discipline, not a boot-time runtime check.*
-> *3. **The day-one shape matches the generator template:** core + Reagent adapter + `-schemas` + `-xray` + explicit `reagent/reagent`. The remaining per-feature artefacts (`-machines`/`-routing`/`-flows`/`-http`/`-ssr`/`-epoch`) are pay-as-you-go.*
-> *4. **The Reagent adapter is the default reference substrate.** Unless the author says UIx or Helix, scaffold Reagent; UIx/Helix greenfield is a documented two-substitution delta → the entry-namespace leaf.*
-> *5. **The generator template is a USER-RUN route, not one this skill executes.** The `allowed-tools` cover the manual scaffold (`clojure -Stree`, npm, `shadow-cljs watch/compile`) but **not** `clojure -Tnew create` — hand the author the command to run.*
-> *6. **Don't write tests for the author.** This skill stops at "the counter mounts".*
-> *7. **nREPL is dev-only and bound to localhost.** Anywhere the skill mentions nREPL (shadow-cljs's default REPL, `re-frame2-pair` attachment), remind the author never to expose it on `0.0.0.0` / a public interface.*
->
-> *Locks to preserve verbatim:*
->
-> *- **L6 — NO verification module.** No `references/verify.md`; no "verify before claiming done" hard rule. Done checklist lists conditions; author confirms.*
-> *- **L7 — No bead-ids in user-facing skill content.***
-> *- **L8 — Findings stay local.** Don't commit `ai/` or `findings/`.*
-> *- **L10 — Clean exit hand-off; no per-skill routing table.** SKILL.md ends with a hand-off paragraph to the next skill (`re-frame2` / `re-frame2-xray` / `re-frame2-pair`); cross-skill routing is single-sourced in `skills/README.md` §Skill routing, which the hand-off points at.*
->
-> *Frontmatter — the `description` is "pushy" per Anthropic best practice. List the greenfield-trigger phrases: "start a re-frame2 project", "scaffold re-frame2", "hello-world re-frame2 app", "new re-frame2 app", plus a build failure on a freshly-scaffolded project tracing to missing `re-frame.core` / `re-frame.adapter.reagent` wiring. Do **not** list the ambiguous "add re-frame2 to my repo" — it also matches the non-trivial-existing-app case the skill routes away. The description explicitly carves out the exit routes (after setup → `re-frame2` for code-writing, `re-frame2-pair` for pair-programming) and points at `skills/README.md` §Skill routing for the disqualifiers.*
->
-> *Voice: tight, declarative, recipe-shaped. Use tables for routing; use code blocks for canonical shapes (deps.edn, shadow-cljs.edn, core.cljs). Inline Troubleshooting at the end of SKILL.md for the common build failures (missing `.cljs` namespace vs missing npm React — distinct layers, missing `rf/init!`, missing `<div id="app">`, `:init-fn` mismatch, Xray host missing).*
->
-> *Don't:*
->
-> *- Don't hardcode versions in the leaves — point at `references/deps-versions.md` for lookup.*
-> *- Don't teach re-frame2's API beyond what the first counter requires.*
-> *- Don't turn UIx/Helix into a full multi-substrate decision tree — Reagent is the default. But **do** ship the UIx/Helix greenfield recipe in `references/entry-namespace.md` §UIx / Helix greenfield: the deps swap, the entry-ns root-API substitution, and the substrate `defui`/`defnc` views reading subs via `use-subscribe` and dispatching via `(:dispatch (rf/capture-frame))`. The drift-test locks (UIx/Helix template-pin parity + substrate views) require it, and the counter-vocabulary guard pins those snippets to that leaf.*
-> *- Don't write `*.md` documentation outside `skills/re-frame2-setup/`.*
-> *- Don't commit `ai/` or `findings/` content.*
-> *- Don't claim AI authorship anywhere — commits and PR title/body read as Mike Thompson's work.*
-> *- Don't write a verification leaf or verify-before-done hard rule.*
-> *- Don't include bead-ids in user-facing leaves.*
->
-> *Open the PR with title `feat(skills): re-frame2-setup — greenfield bootstrap skill`. PR body lists: the skill structure, the file LoC table, the cardinal rules, the relationship to the adjacent skills (`re-frame2` for code-writing, `re-frame2-pair` for pair-programming, `re-frame-migration` for v1→v2 migrants, `re-frame2-implementor` for porters).*
+> *Then write the skill to the file structure and cardinal rules locked in `design.md`, the discovery surface in `design.md` §6, and the family leaf-size discipline in `skills/README.md` — honouring the L1–L10 locks in `design.md` §3 without restating them. Preserve the six-step user workflow `SKILL.md` owns. Open a PR following the repo's conventions; commits and PR title/body read as the maintainer's own work, and the commit set touches only `skills/re-frame2-setup/**`.*
 
 ## Notes on the reauthoring contract
 
 - The prompt above is a one-shot — feed it to a fresh session, it produces the skill.
-- The prompt assumes the session has read access to the repo and access to `examples/core/counter/`.
-- The prompt does **not** ask the session to verify the resulting skill — Mike reads the PR and comments.
-- If the canonical `examples/core/counter/` shape has changed between authoring passes, `references/first-counter.md` needs re-derivation.
-
-## When to re-author
-
-- A new mandatory artefact ships in lockstep (the eleven-artefact set grows) → update `references/deps-versions.md` and the SKILL.md framing.
-- The `re-frame.adapter.reagent` contract changes materially → `references/entry-namespace.md` and `references/first-counter.md` need updates.
-- `rf/init!`'s signature changes → all four reference leaves need a sweep.
-- Reagent v3 lands and supplants v2 → re-derive against the v3 counter example.
-- Anthropic skill conventions change materially → reauthor against the new conventions.
-
-Otherwise, edit existing leaves directly; reauthoring is for major-version updates.
+- The prompt assumes read access to the repo, including `examples/core/counter/` and the generator template.
+- The prompt does **not** ask the session to verify the resulting skill — the author runs the build; Mike reads the PR (`design.md` L6 / Q14).
+- When to re-author (major-version updates) and the per-surface update procedure are owned by [`inputs.md`](inputs.md) §6 — consult it there rather than restating the triggers in this wrapper.

--- a/skills/re-frame2/decision-trees/pick-a-pattern.md
+++ b/skills/re-frame2/decision-trees/pick-a-pattern.md
@@ -1,36 +1,13 @@
 # Decision tree — which Pattern-* fits this task?
 
 > **Audience:** authors writing re-frame2 ClojureScript application code.
-> **Use when:** the task description hints at a recurring shape — fetching, submitting, booting, processing, streaming, rendering lifecycle states — and you need to pick the canonical leaf to load.
+> **Use when:** two neighbouring patterns both look plausible and you need the rule that picks between them, or you've picked a pattern and need the two follow-on decisions (verify against the example, then slice-vs-machine).
 
-Patterns compose: most real screens combine two or three of them. This tree picks the *primary* pattern — the one whose shape the feature is built around. Secondary patterns get loaded in their own pass after the primary one is in place.
+The canonical shape → leaf inventory lives **once** in [`../SKILL.md`](../SKILL.md) §Decision shortcuts (the *Which pattern fits* table) — every shipped pattern, including ResourcesMutations, is reachable from there. This tree does **not** restate that inventory; it carries the value the router can't: the **disambiguation rules** for patterns that share vocabulary, plus the two follow-on decisions. Worked examples are indexed in [`../examples-map.md`](../examples-map.md).
 
-The canonical routing matrix (shape → leaf) is [`../SKILL.md`](../SKILL.md) §Decision: which pattern fits?; this tree restates it once with a worked-example column (Step 1) and adds the disambiguation rules (Step 2) that are its real value. Each leaf below names the file under [`patterns/`](../patterns) and the worked example under `examples/` (when one exists).
+Patterns compose: most real screens combine two or three of them. Pick the *primary* pattern — the one whose shape the feature is built around — from SKILL.md's table; the secondary patterns get loaded in their own pass after the primary one is in place. **Load at most two pattern leaves at a time**; if three or more seem necessary, the request spans features — author each pattern's leaf in its own pass.
 
-## Step 1 — name the shape
-
-Read the prompt for **one** of the following shape-tells. They are mutually exclusive at the level of *primary* role; the third column names the leaf to load and its worked example.
-
-| Shape-tell in the prompt | Pattern (leaf) | Worked example |
-|---|---|---|
-| "Fetch / GET / load / refresh / reload" — a request whose response writes to `app-db` | RemoteData — [`patterns/remote-data.md`](../patterns/remote-data.md) | `examples/real-apps/realworld_http/` (articles.cljs slice · tags.cljs machine) |
-| "Query cache / server-state / TanStack-Query / React-Query / SWR / shared cached read / invalidate after a write / refetch on focus / `reg-resource`" | Resources — [`patterns/resources.md`](../patterns/resources.md) | `examples/capabilities/resources/resources/` (read) · `examples/real-apps/realworld_resources/` (mutations) |
-| "Submit / save / form / validation / required / draft / dirty" — user-edited input crossing a server boundary | Forms — [`patterns/forms.md`](../patterns/forms.md) | `examples/core/login/` |
-| "Boot / init / hydrate / startup / first-load / splash" — the initial-load sequence before the app is interactive | Boot — [`patterns/boot.md`](../patterns/boot.md) | `examples/patterns/boot/` |
-| "WebSocket / SSE / EventSource / live / push / subscribe / channel / heartbeat / reconnect" — long-lived connection | WebSocket — [`patterns/websocket.md`](../patterns/websocket.md) | `examples/patterns/websocket/` |
-| "Retry / backoff / circuit-breaker / 4xx vs 5xx / abort / cancel an in-flight request" — a request with status-aware policy | ManagedHTTP — [`patterns/managed-http.md`](../patterns/managed-http.md) | `examples/core/managed_http_counter/` |
-| "Empty state / no-results / one-result / too-many / not-found / forbidden / nine UI states" — render every legal lifecycle distinctly | NineStates — [`patterns/nine-states.md`](../patterns/nine-states.md) | `examples/patterns/nine_states/` |
-| "Fire-and-forget / log / analytics / telemetry / external side-effect with no observable reply" | AsyncEffect — [`patterns/async-effect.md`](../patterns/async-effect.md) | (inline mini-example) |
-| "CPU-bound / heavy / parses / hashes / pegs the main thread / chunked / yields / progress bar" | LongRunningWork — [`patterns/long-running-work.md`](../patterns/long-running-work.md) | `examples/patterns/long_running_work/` |
-| "Async-result arrives after state moved on / ignore stale results / don't apply old data after navigating away" | StaleDetection — [`patterns/stale-detection.md`](../patterns/stale-detection.md) | (inline mini-example) |
-| "Reusable / parameterised widget / customer-card / renders N of the same / works against any X / compare two side by side" | ReusableComponents — [`patterns/reusable-components.md`](../patterns/reusable-components.md) | (inline mini-example) |
-| "Wrap a JS library / D3 / Mapbox / CodeMirror / Three.js / ag-grid / chart / map / editor / `:ref` + lifecycle / `.setData`" | StatefulComponents — [`patterns/stateful-components.md`](../patterns/stateful-components.md) | (per-adapter README) |
-| "SSR form POST / progressive enhancement / works without JavaScript / server `action` / POST-redirect-GET / CSRF on submit" | FormAction — [`patterns/form-action.md`](../patterns/form-action.md) | (inline mini-example) |
-| "SSR parallel fetch / `Promise.all` server-side / fan-out N requests before render / per-page loader" | SSR-Loaders — [`patterns/ssr-loaders.md`](../patterns/ssr-loaders.md) | `examples/patterns/boot/` |
-
-If you see **two** shape-tells, the dominant one is the one the user names first or the one that owns the data. Pattern composition (e.g. "managed-HTTP retries inside a form submit") is normal — pick the primary, plan the secondary as a follow-up. **Load at most two pattern leaves at a time**; if three or more seem necessary, the request spans features — author each pattern's leaf in its own pass.
-
-## Step 2 — the disambiguation pairs
+## Step 1 — the disambiguation pairs
 
 A few neighbouring patterns share enough vocabulary to get confused. These rules pick the right leaf when both look plausible.
 
@@ -51,6 +28,15 @@ Both model "the result of a fetch". The difference is **who owns the cache bookk
 - **Resources** — the framework owns identity, **cache scope** (fail-closed tenant/user boundary), **staleness/TTL**, dedupe, **tag invalidation** (so a write refreshes related reads), GC, in-flight ownership, route-declared loading, and SSR preload. Choose it when the same fetch is **shared across views**, needs freshness/fresh-skip, must be **invalidated after a mutation**, wants auditable scoping, or needs a **write-completion workflow continuation** (navigate / toast / fold errors after a save — call-site `:reply-to`, the `onSuccess` shape). It is the TanStack-Query-shaped layer; it lowers onto the same managed HTTP underneath.
 
 Rule of thumb: a single feature's private fetch → RemoteData; a server-state cache several features read and a write must invalidate → Resources.
+
+### Resources vs ResourcesMutations
+
+Both live in the `day8/re-frame2-resources` layer; the split is **read vs write** — do not fold mutations into the Resources leaf.
+
+- **Resources** — the *read / cache lifecycle*. `reg-resource` declares a cached, scoped, revalidated server-state **read**: identity, cache scope, staleness/TTL, dedupe, tag invalidation, GC, route-declared loading, SSR preload. Views read it **passively** through a `[:rf/resource {...}]` subscription; the fetch is *caused* by a route `:resources` entry or a dispatched `[:rf.resource/ensure {...}]` — never from render. Choose it when the question is "how is this cached read shared, kept fresh, and scoped?" (→ [`../patterns/resources.md`](../patterns/resources.md)).
+- **ResourcesMutations** — the *write + post-write workflow*. `reg-mutation` declares a server **write** dispatched via `[:rf.mutation/execute {...}]`: declarative cache consequences (`:invalidates` tags, `:populates` authoritative seed), optimistic apply/rollback (`:optimistic` / `:optimistic-tags`, the runtime records the inverse), per-submission `:instance` keying so concurrent writes never clobber, and a **call-site** `:reply-to` handler for the app workflow (navigate / toast / fold field errors — a causal event target, not a callback). Choose it when the question is "what happens *after* a write settles, and how do the caches it touched refresh?" (→ [`../patterns/resources-mutations.md`](../patterns/resources-mutations.md)).
+
+Rule of thumb: reading and caching server-state → Resources; changing server-state and orchestrating the consequences → ResourcesMutations. A screen that lists then edits uses **both** — the list is a Resource, the save is a Mutation whose `:invalidates` refreshes that list. Keep the two axes apart: cache consequences are declarative on `reg-mutation`; app workflow lives in the `:reply-to` handler — never drive navigation/toast off `:populates`/`:invalidates`, and never watch `[:rf/mutation ...]` from a component lifecycle hook.
 
 ### Forms vs RemoteData
 
@@ -108,22 +94,22 @@ The LongRunningWork leaf's own decision tree picks between (a) a Web Worker (pre
 
 StaleDetection is rarely the *primary* pattern for a task. It is the **epoch idiom** that overlays RemoteData, WebSocket, or any state-machine that initiates async work which might be superseded before its reply arrives. Choose StaleDetection as a primary pattern only when the explicit task is *"add stale detection to an existing feature"*. Otherwise the relevant pattern leaf (RemoteData, WebSocket, the machine) names where the epoch attaches; StaleDetection is the reference for *how*.
 
-## Step 3 — verify against the example app
+## Step 2 — verify against the example app
 
-Every pattern has a worked example app (the `examples/` tree is test-free; patterns are regression-covered by CLJS contract/unit tests + adapter smokes, not per-example Playwright). After picking the pattern leaf, point at the example named in [`examples-map.md`](../examples-map.md) and confirm: the slice shape matches; the event names scale to the example's `:feature/<verb>` naming; the `reg-app-schema` attachment points cover the same boundaries.
+Every pattern has a worked example app (the `examples/` tree is test-free; patterns are regression-covered by CLJS contract/unit tests + adapter smokes, not per-example Playwright). After picking the pattern leaf, point at the example named in [`../examples-map.md`](../examples-map.md) and confirm: the slice shape matches; the event names scale to the example's `:feature/<verb>` naming; the `reg-app-schema` attachment points cover the same boundaries.
 
 If the example contradicts the leaf, **the example wins** (implementation is ground truth). Report the divergence upstream as a `day8/re-frame2` GitHub issue against the spec; don't silently work around.
 
-## Step 4 — the state-shape question (separate decision)
+## Step 3 — the state-shape question (separate decision)
 
 After picking the pattern, a second question applies independently: *should the state behind this pattern live as a slice in `app-db`, as a region inside an existing machine, or as a top-level `reg-machine`?* That question is its own decision tree — see [`slice-or-machine.md`](slice-or-machine.md). Pattern choice and state-shape choice are orthogonal: WebSocket is always a machine; AsyncEffect is usually a slice; RemoteData is a slice unless its retry policy needs a machine.
 
 ## Cross-references
 
-- [`slice-or-machine.md`](slice-or-machine.md) — when to lift state into a machine.
+- [`../SKILL.md`](../SKILL.md) §Decision shortcuts — the *Which pattern fits* table: the canonical shape → leaf inventory this tree disambiguates (owned there, never restated here).
 - [`../examples-map.md`](../examples-map.md) — one-paragraph index of every worked example.
-- [`../SKILL.md`](../SKILL.md) §Decision: which pattern fits? — the canonical routing matrix this tree's Step 1 restates.
+- [`slice-or-machine.md`](slice-or-machine.md) — when to lift state into a machine.
 
 ---
 
-*Derived from the canonical patterns in the spec (`SKILL-REDIRECT.md` → Pattern entries) and the worked examples under `examples/` @ main `89bd9c3`.*
+*Derived from the canonical patterns in the spec (`SKILL-REDIRECT.md` → Pattern entries) and the worked examples under `examples/`.*

--- a/skills/re-frame2/spec/authoring-prompt.md
+++ b/skills/re-frame2/spec/authoring-prompt.md
@@ -4,139 +4,42 @@
 
 A self-contained prompt that re-authors the `re-frame2` skill from this `spec/` folder alone. Drop into a fresh Claude Code session in the re-frame2 repo root.
 
+**Everything normative lives in [`design.md`](design.md) and [`inputs.md`](inputs.md).** The locked decisions (L1–L11), the file structure, the cardinal rules, the line budgets, and the discovery surface are owned by `design.md`; the canonical inputs and the per-surface update procedure are owned by `inputs.md`. This prompt orchestrates the reauthoring pass — it does **not** restate the tree, the rules, or the locks (a second copy is exactly what drifts).
+
 ## The prompt
 
 > *I'm re-authoring the `re-frame2` skill at `skills/re-frame2/`. The skill teaches an AI to write working re-frame2 ClojureScript application code while spending as little context as possible. It is **authoring-only** — writing new code on the CLJS reference. Adjacent skills handle setup (`re-frame2-setup`), v1→v2 migration (`re-frame-migration`), live-app inspection (`re-frame2-pair`), and porting re-frame2 itself (`re-frame2-implementor`).*
 >
-> *Read these first (in this order):*
+> *Read these first, in order. The first two are **normative** — the design and inputs I must reproduce, not re-derive — and I must not paste a divergent copy of anything they own into this prompt or the skill:*
 >
-> *1. `skills/re-frame2/spec/design.md` — the locked design decisions (L1 through L11). Pillars 1-4 in §2 are non-negotiable. Q14 lock applies (NO verification module).*
-> *2. `skills/re-frame2/spec/inputs.md` — the canonical inputs the skill leans on (`implementation/**`, `examples/**`, `spec/**` for design rationale).*
-> *3. `implementation/core/src/re_frame/core.cljc` + `frame.cljc` + `fx.cljc` + `events.cljc` + `subs.cljc` + `test_support.cljc` — the surfaces the skill teaches. Every code snippet in a leaf is verified against these.*
-> *4. `examples/core/{counter,login,managed_http_counter}/` + `examples/patterns/{boot,nine_states}/` — the worked examples. The pattern leaves match these shapes.*
-> *5. `skills/re-frame-migration/SKILL.md` + `skills/re-frame2-implementor/SKILL.md` — the voice / density / load-bearing-rules style to mirror. SKILL.md cardinal-rules framing comes from these.*
-> *6. `spec/000-Vision.md` + `spec/Conventions.md` — the AI-first design principles and naming conventions.*
+> *1. **[normative]** `skills/re-frame2/spec/design.md` — the locked design decisions (L1–L11), the four pillars (§2, non-negotiable; Q14 lock applies), the locked file structure and line budgets (§3 Pillar 3 / §5), and the discovery surface (§6). Sole source for the layout, the cardinal rules, and the locks.*
+> *2. **[normative]** `skills/re-frame2/spec/inputs.md` — the canonical inputs the leaves lean on (`implementation/**`, `examples/**`, `spec/**` for rationale) and the §6 per-surface update procedure.*
+> *3. `skills/README.md` — the family conventions the skill obeys: the single-source skill-routing table (§Skill routing) that SKILL.md's "When NOT to use" points at, the leaf-size discipline (§Leaf size discipline), and the published-skill `allowed-tools` baseline.*
+> *4. `implementation/core/src/re_frame/core.cljc` + `frame.cljc` + `fx.cljc` + `events.cljc` + `subs.cljc` + `test_support.cljc` — the surfaces the skill teaches. Every code snippet in a leaf is verified against these (L1 — implementation is ground truth).*
+> *5. `examples/core/{counter,login,managed_http_counter}/` + `examples/patterns/{boot,nine_states}/` — the worked examples the pattern leaves match (L2).*
+> *6. `skills/re-frame-migration/SKILL.md` + `skills/re-frame2-implementor/SKILL.md` — the voice / density / load-bearing-rules style to mirror.*
+> *7. `spec/000-Vision.md` + `spec/Conventions.md` — the AI-first design principles and naming conventions.*
 >
-> *Then write the skill at `skills/re-frame2/` with this exact file structure:*
+> *Then write the skill at `skills/re-frame2/` to the locked file structure in `design.md` §5, baking the cardinal rules into `SKILL.md` and honouring the L1–L11 locks verbatim (`design.md` §3) — do not restate the tree, the rules, or the locks here. Match the line budgets and the one-level-deep routing locked in `design.md` (§3 Pillar 3 / §5; no `SKILL → A → B` chains) and the "pushy" discovery `description` specified in `design.md` §6.*
 >
-> ```
-> skills/re-frame2/
-> ├── SKILL.md                     (~180 lines; the router + cardinal rules)
-> ├── README.md                    (human-facing intro)
-> ├── LICENSE                      (MIT)
-> ├── package.json                 (npm metadata; mirror re-frame-migration pattern)
-> ├── .claude-plugin/plugin.json   (Claude Code Plugin packaging metadata)
-> ├── examples-map.md              (pattern → worked-example table)
-> ├── references/
-> │   ├── fundamentals/
-> │   │   ├── events.md            (reg-event — the one public event registrar)
-> │   │   ├── fx.md                (reg-fx, :fx vector shape)
-> │   │   ├── cofx.md              (reg-cofx value-returning, :rf.cofx/requires)
-> │   │   ├── subs.md              (reg-sub, layered subs, dynamic args, machine subs)
-> │   │   ├── views.md             (reg-view, injected dispatch/subscribe, reg-view*)
-> │   │   ├── flows.md             (reg-flow, materialised computed state, flow-vs-sub)
-> │   │   ├── schemas.md           (reg-app-schema, boundary validation)
-> │   │   ├── frames.md            (frame ids, default frame, per-frame config)
-> │   │   ├── images.md            (rf/image, image-order composition, EP-0023)
-> │   │   ├── event-state-cycle.md (the 12-step walk)
-> │   │   └── project-structure.md (source-tree conventions)
-> │   ├── state-machines/
-> │   │   ├── reg-machine.md       (states, initial, guards, actions)
-> │   │   ├── xstate-translation.md (the full xstate→re-frame2 translation catalogue)
-> │   │   ├── machine-schemas.md   (:schemas :data/:output + snapshot-egress redaction)
-> │   │   ├── regions.md           (single-region + :type :parallel)
-> │   │   ├── tags.md              (state tags, machine-has-tag?)
-> │   │   ├── spawn.md             (:spawn, :spawn-all, child-machine result)
-> │   │   ├── history.md           (:type :history — shallow/deep/default re-entry)
-> │   │   └── cancellation.md      (destroy cascade, cleanup contract)
-> │   ├── tooling/
-> │   │   ├── stories.md           (reg-story, story frames)
-> │   │   ├── routing.md           (reg-route, :can-leave?, navigation)
-> │   │   ├── story-recorder.md    (record canvas interactions as a :script body)
-> │   │   ├── story-mcp-loop.md    (story-mcp author/refine side; run-side handoff)
-> │   │   └── xray.md              (devtools panel — mount, launch modes, popout)
-> │   └── cross-cutting/
-> │       ├── testing.md           (make-reset-runtime-fixture, dispatch-sync, compute-sub)
-> │       ├── api-cheatsheet.md    (one-page reg-* signature index)
-> │       ├── privacy-and-elision.md      (sensitive/large classification, egress profiles)
-> │       ├── production-observability.md (register-listener! production sinks)
-> │       ├── ssr-authoring.md            (reg-head, hydrate, SSR check fxs)
-> │       └── path-and-identity.md        (:rf/path algebra, canonical EDN identity)
-> ├── patterns/
-> │   ├── remote-data.md
-> │   ├── resources.md
-> │   ├── resources-mutations.md
-> │   ├── forms.md
-> │   ├── boot.md
-> │   ├── websocket.md
-> │   ├── nine-states.md
-> │   ├── managed-http.md
-> │   ├── async-effect.md
-> │   ├── long-running-work.md
-> │   ├── stale-detection.md
-> │   ├── reusable-components.md
-> │   ├── stateful-components.md
-> │   ├── form-action.md
-> │   └── ssr-loaders.md
-> ├── decision-trees/
-> │   ├── pick-a-pattern.md        ("I want to build X — which pattern?")
-> │   └── slice-or-machine.md      ("Should this be a slice, region, or top-level machine?")
-> ├── evals/
-> │   ├── README.md                (how to run the behavioural evals)
-> │   └── evals.json               (the eval fixtures)
-> └── spec/
->     ├── design.md
->     ├── inputs.md
->     └── authoring-prompt.md
-> ```
+> *Voice: tight, declarative, recipe-shaped — mirror the sibling skills in read 6. Tables for routing; code blocks for canonical shapes; cite `implementation/<file>:<line>` where a surface claim might surprise an AI working from training memory. Quote spec text for rationale only, never for API surface (L1).*
 >
-> *Every reference / pattern / decision-tree leaf is ≤250 lines (target ~150). SKILL.md is ~180 lines (under Anthropic's 500-line ceiling). All leaves are one level deep — no SKILL → A → B chains.*
+> *Constraints (`design.md` §3 owns the full lock text — honour it, don't restate a divergent copy): implementation is ground truth over spec (L1); no issue-tracker ids in the user-facing leaves (L10); findings stay local — the skill's commits contain only `skills/re-frame2/**`, never `ai/` or `findings/` (L11); no verification leaf and no verify-before-done hard rule (L3 / Q14 — the author runs the tests). Repo git convention: commits and PR title/body read as Mike Thompson's work — no AI-authorship attribution.*
 >
-> *Cardinal rules to bake in (these go in SKILL.md):*
->
-> *1. **Implementation is ground truth.** When `spec/` and `implementation/**` disagree, the implementation wins. Recipes are verified against `implementation/**` + `examples/**`.*
-> *2. **Recipes over explanations.** The AI reaches for a canonical shape; doesn't derive from first principles.*
-> *3. **Distinguish orchestration from state.** Machines when "what can happen next" depends on mode; slices when state is a field.*
-> *4. **Schemas at boundaries, not everywhere.** `reg-app-schema` for trust-boundary paths.*
-> *5. **Examples in `examples/**` are canonical.** When a pattern has a worked example, match its shape.*
-> *6. **Frames before globals.** Code talks to a frame; never bypasses `dispatch` / `subscribe`.*
-> *7. **Reserved namespaces are reserved.** `:rf/*` is framework-owned.*
-> *8. **`reg-*` macros over the `*`-suffixed runtime fns** (`reg-view*`, `reg-machine*`, …). Macros capture source-coords.*
-> *9. **Pillar 4 — assume training knowledge.** Teach only the re-frame2-specific binding.*
->
-> *Locks to preserve verbatim:*
->
-> *- **L3 — NO verification module.** No `references/verify.md`; no "verify before claiming done" hard rule. The author runs tests.*
-> *- **L10 — No issue-tracker ids in user-facing skill content.** `SKILL.md` + `references/` + `patterns/` + `decision-trees/` carry no issue-tracker ids.*
-> *- **L11 — Findings stay local.** Don't commit `ai/` or `findings/` content.*
->
-> *Frontmatter — the `description` is "pushy" per Anthropic best practice. List every re-frame2 surface that should trigger discovery: `reg-event` (the one event form — EP-0018), `reg-sub`, `reg-fx`, `reg-cofx`, `reg-view`, `reg-machine`, `reg-route`, `reg-story`, `reg-app-schema`, `dispatch`, `subscribe`, `app-db`, frames, regions, tags, managed HTTP, RemoteData lifecycles. Plus natural-language phrases: "writing tests for a re-frame2 app", "state-machine-for-HTTP shapes". Carve out the adjacent skills (`re-frame2-pair`, `re-frame2-setup`) explicitly so the AI routes correctly.*
->
-> *Voice: tight, declarative, recipe-shaped. Use tables for routing; use code blocks for canonical shapes. Cite `implementation/<file>:<line>` in leaves where a surface claim might surprise an AI working from training memory.*
->
-> *Don't:*
->
-> *- Don't quote spec text for API surface — that's L1.*
-> *- Don't write `*.md` documentation outside `skills/re-frame2/`.*
-> *- Don't commit `ai/` or `findings/` content.*
-> *- Don't claim AI authorship anywhere — commits and PR title/body read as Mike Thompson's work.*
-> *- Don't write a verification leaf or a verify-before-done hard rule.*
-> *- Don't include issue-tracker ids in user-facing leaves.*
->
-> *Open the PR with title `feat(skills): re-frame2 — authoring-only skill for writing re-frame2 CLJS code`. PR body lists: the skill structure, the file LoC table, the locks applied, the relationship to the adjacent skills (setup / migration / re-frame2-pair / implementor).*
+> *Open the PR with title `feat(skills): re-frame2 — authoring-only skill for writing re-frame2 CLJS code`. PR body lists: the skill structure, the file LoC table, the locks applied, and the relationship to the adjacent skills (setup / migration / re-frame2-pair / implementor).*
 
 ## Notes on the reauthoring contract
 
 - The prompt above is a one-shot — feed it to a fresh session, it produces the skill.
 - The prompt assumes the session has read access to the repo. It does not assume any out-of-repo context.
-- The prompt does **not** ask the session to verify the resulting skill — Mike reads the PR and comments.
-- If `implementation/**` has changed significantly between authoring passes, the leaves' code snippets need re-verification. A reauthoring session walks the implementation afresh.
+- The prompt does **not** ask the session to verify the resulting skill — Mike reads the PR and comments (`design.md` L3 / Q14).
+- If `implementation/**` has changed significantly between passes, the leaves' code snippets need re-verification. A reauthoring session walks the implementation afresh; `inputs.md` §6 owns the per-surface update procedure for incremental changes.
 
 ## When to re-author
 
 - A new registry kind ships in re-frame2 (e.g. a new `reg-X` surface) → the existing leaves' organisation may be wrong; rebuild the routing.
-- A new canonical pattern is named in `spec/Pattern-*.md` → add to `patterns/` and `decision-trees/pick-a-pattern.md`.
-- The Q14 lock or any of L1-L11 changes → the design itself changes; this `spec/` folder needs updating first, then the skill.
+- A new canonical pattern is named in `spec/Pattern-*.md` → add to `patterns/` and `decision-trees/pick-a-pattern.md`; add the row to SKILL.md's pattern table and to `examples-map.md` if a worked example exists.
+- The Q14 lock or any of L1–L11 changes → the design itself changes; update `design.md` first, then the skill.
 - Anthropic skill conventions change materially → reauthor against the new conventions.
 
-Otherwise, edit the existing leaves directly; reauthoring from scratch is for major-version updates.
+Otherwise, edit the existing leaves directly (`inputs.md` §6 is the per-surface procedure); reauthoring from scratch is for major-version updates.


### PR DESCRIPTION
Unified restructure of the **base `re-frame2` skill family**: make `design.md` + `inputs.md` the sole normative source, `SKILL.md` the router, and the reauthoring prompts orchestration-only. Three clustered beads that share the base skill's `SKILL.md` / `design.md` / `inputs.md` — sequential commits, one PR.

## The three collapses

- **rf2-rpkspz — `SKILL.md` is the sole pattern router** (commit 1). Removed the duplicated 14-row pattern inventory from `decision-trees/pick-a-pattern.md`. The leaf had drifted from `SKILL.md`'s canonical matrix — it omitted the `patterns/resources-mutations.md` route and folded mutations into Resources, contradicting the resource-routing evals (9–11). The leaf now backlinks the sole shape→leaf inventory in `SKILL.md` §Decision shortcuts and keeps only its real value: the disambiguation pairs + the verify / slice-vs-machine follow-ons. Added a focused **Resources vs ResourcesMutations** pair (read/cache lifecycle `reg-resource` vs write + optimistic/post-write workflow `reg-mutation`, keep-the-two-axes-apart rule). Worked examples stay owned by `examples-map.md`.
- **rf2-ks0who — base authoring-prompt reduced to a launcher** (commit 2). The prompt recopied the full skill tree, the nine cardinal rules, and the three locks after telling authors to read `design.md`/`inputs.md`; the copies had drifted (over-generalised runtime `*` suffixes; still named a default frame). Normative decisions, the L1–L11 layout, the locks, and the inventories now live **only** in `design.md`/`inputs.md`; the prompt is reduced to task intent + ordered canonical reads (design/inputs first, normative) + preserve/update instructions + outputs/PR constraints + reauthor triggers. Removing the copied tree + cardinal-rules block eliminates both drifts. `scripts/check_skill_re_frame2_drift.py`: docstring/citations updated so `design.md` is the normative source, plus a new **Rule 3 launcher-canonical** check — the launcher must cite BOTH `design.md` and `inputs.md` and must not regrow the box-drawing tree or a "Locks to preserve verbatim" / "Cardinal rules to bake in" block (self-test cases G1–G6 added).
- **rf2-5d56o6 — setup reauthoring prompt is orchestration-only** (commit 3). `skills/re-frame2-setup/spec/authoring-prompt.md` repeated the design-owned file tree, family numeric leaf-size limit, seven cardinal rules/locks, seven-step workflow, discovery triggers, maintenance list, and stale original-PR text. Reduced to an execution wrapper: ordered reads of `design.md` (decisions + file structure + discovery surface), `inputs.md` (inputs + mappings + reauthor triggers), `skills/README.md` (family conventions + leaf-size discipline), `SKILL.md` (the user-facing seven-step workflow), and the canonical sources — then a single write/PR step. Every owner linked; no normative rule, file tree, numeric size limit, or update trigger restated.

## Preflight (duplication confirmed real before collapsing)

- **rf2-rpkspz**: `pick-a-pattern.md` explicitly called `SKILL.md`'s matrix canonical (line 8) then restated a second 14-row inventory (Step 1) — confirmed genuine duplication, and confirmed the drift (Resources row folded `realworld_resources/ (mutations)` in, omitting the `resources-mutations.md` route that `SKILL.md` carries).
- **rf2-ks0who**: base `authoring-prompt.md` restated `design.md` §5 (file tree), `SKILL.md`/`design.md` §3 (cardinal rules L1–L11), and the L3/L10/L11 locks verbatim — confirmed against `design.md` before removal.
- **rf2-5d56o6**: setup `authoring-prompt.md` restated `design.md` §3 (locks/rules), §5 (tree), §6 (discovery), `skills/README.md` §Leaf size discipline (the ≤250-line / ≤16 KB ceiling), `SKILL.md` (seven steps), and `inputs.md` §6 (update triggers) — each owner verified present before collapse.

## Stance

Pre-alpha; no back-compat shims. Skill content kept **generic to any consumer re-frame2 app**. Primary lenses **ELEGANCE + CLARITY**: one canonical home per fact, everything else links. Constraints honoured — the reauthoring `spec/` is repo-maintenance-only and **unshipped** (both `package.json` `files[]` arrays exclude `spec/`; shipped skill content unchanged); **no tracker ids** added to any user-facing skill prose (bead ids appear only in commit messages + this PR); self-contained packaged links preserved (`design.md` / `inputs.md` / `../SKILL.md` / `../../README.md` all resolve).

## Quality gates (foreground; 0 failures)

- `python scripts/check_skill_re_frame2_drift.py --self-test` → all cases pass (incl. new G1–G6 launcher cases)
- `python scripts/check_skill_re_frame2_drift.py` → clean (no bead-ids, no verify-posture drift, launcher points at design.md + inputs.md without regrowing tree/locks)
- `python scripts/check_skill_setup_counter_drift.py --self-test` + real scan → clean
- `bb tests/setup_drift_test.clj` (from `skills/re-frame2-setup/`) → 27 tests, 78 assertions, **0 failures, 0 errors**
- `python scripts/check_skill_eval_docs.py`, `check_skill_package_refs.py`, `check_skill_redirect_anchors.py`, `check_skill_eval_packaging.py` → clean
- `python scripts/check_doc_slugs.py` → clean (used as the fallback; `mkdocs` not installed locally, and no `docs/` files were touched)

No hot-zone files touched (all drift guards live under `scripts/`, not `.github/workflows/`). Rebased onto latest `origin/main`.
