### PR TITLE
refactor(http): migrate JVM suites to canonical fixture + clear-http-interceptors reset hook (rf2-q14tde)

### DIFF
--- a/implementation/core/src/re_frame/test_support.cljc
+++ b/implementation/core/src/re_frame/test_support.cljc
@@ -322,6 +322,18 @@
                                        is absent (production builds).
     :http/clear-all-in-flight!       — drop the in-flight managed-request
                                        registry.
+    :http/clear-all-http-interceptors! — clear the per-frame request-side
+                                       HTTP interceptor chain registry
+                                       (internal to `re-frame.http.middleware`),
+                                       which lives OUTSIDE the registrar the
+                                       snapshot/restore covers. A `:before` /
+                                       `:after` interceptor registered in one
+                                       test would otherwise mutate every
+                                       subsequent test's outgoing request /
+                                       reply payload (rf2-q14tde). Published
+                                       for test isolation alongside
+                                       `:http/clear-all-in-flight!`; the row
+                                       no-ops when the http artefact is absent.
     :epoch/clear-history!            — drop the per-frame epoch ring buffer.
     :epoch/clear-epoch-listeners!          — drop the epoch-settled callback
                                        registry.
@@ -353,6 +365,7 @@
    {:hook :routing/reset-url-listener!     :phase :post-dispose}
    {:hook :resources/reset-resources!      :phase :post-dispose}
    {:hook :http/clear-all-in-flight!       :phase :post-dispose}
+   {:hook :http/clear-all-http-interceptors! :phase :post-dispose}
    {:hook :epoch/clear-history!            :phase :post-dispose}
    {:hook :epoch/clear-epoch-listeners!          :phase :post-dispose}
    {:hook :epoch/reset-config!             :phase :post-dispose}

--- a/implementation/core/test/re_frame/test_support_test.clj
+++ b/implementation/core/test/re_frame/test_support_test.clj
@@ -227,6 +227,7 @@
    :routing/reset-nav-counters!     1  ;; rf2-oosjmh — host-side counters
    :resources/reset-resources!      1  ;; rf2-yuc8o0 — host-side resources state
    :http/clear-all-in-flight!       1
+   :http/clear-all-http-interceptors! 1  ;; rf2-q14tde — interceptor-chain reset
    :epoch/clear-history!            1
    :epoch/clear-epoch-listeners!          1
    :epoch/reset-config!             1

--- a/implementation/http/test/re_frame/flows_http_integration_test.clj
+++ b/implementation/http/test/re_frame/flows_http_integration_test.clj
@@ -53,8 +53,10 @@
     says it's still pending — split-brain across the substrate."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.flows :as flows]
-            [re-frame.frame :as frame]
+            ;; load-bearing: this suite calls `rf/reg-flow`, which needs the
+            ;; flows artefact loaded (the canonical fixture's flows reset is
+            ;; late-bound and no-ops when the artefact is absent).
+            [re-frame.flows]
             [re-frame.http.managed :as http-managed]
             [re-frame.http.registry :as http-registry]
             ;; rf2-cdmle — required only to keep the test-support
@@ -64,44 +66,34 @@
             ;; in-flight registry with a recording abort-fn (mirrors
             ;; routing_http_composed_corners_test.clj's pattern).
             [re-frame.http.test-support]
-            [re-frame.registrar :as registrar]
-            [re-frame.schemas :as schemas]
             [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
             [re-frame.trace :as trace]))
 
 ;; ---- per-test reset / trace recorder -------------------------------------
 
 (def ^:dynamic ^:private *captured* nil)
 
+(def ^:private reset-runtime-fixture
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
 (defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (schemas/clear-schemas-by-frame!)
-  (flows/reset-last-inputs!)
-  (rf/init! plain-atom/adapter)
-  ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`, and
-  ;; the managed-HTTP / flow fxs now require a carried frame stamp. Register
-  ;; `:rf/default` explicitly and pin it as the established scope for the body.
-  (frame/ensure-default-frame!)
-  ;; clear-all! wiped the ns-load-time registrations of these artefacts;
-  ;; :reload re-evaluates each ns body so its registrations resurrect.
-  (require 're-frame.routing :reload)
-  (require 're-frame.ssr     :reload)
-  (require 're-frame.machines :reload)
-  (require 're-frame.http.managed :reload)
-  (require 're-frame.http.test-support :reload)
-  (http-managed/clear-all-in-flight!)
-  (rf/with-frame :rf/default
-    (let [captured (atom [])]
-      (binding [*captured* captured]
-        (trace/register-listener!
-          ::flows-http-recorder
-          (fn [ev] (swap! captured conj ev)))
-        (try
-          (test-fn)
-          (finally
-            (trace/unregister-listener! ::flows-http-recorder)))))))
+  ;; Canonical runtime reset (registrar snapshot/restore + frames / flows /
+  ;; schemas / adapter / http in-flight + interceptor-chain reset, ambient
+  ;; `:rf/default` scope) composed with this suite's trace recorder: register
+  ;; the ::flows-http-recorder listener around the body and tear it down on
+  ;; exit (rf2-q14tde).
+  (reset-runtime-fixture
+    (fn []
+      (let [captured (atom [])]
+        (binding [*captured* captured]
+          (trace/register-listener!
+            ::flows-http-recorder
+            (fn [ev] (swap! captured conj ev)))
+          (try
+            (test-fn)
+            (finally
+              (trace/unregister-listener! ::flows-http-recorder))))))))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/http/test/re_frame/http_abort_config_validation_test.clj
+++ b/implementation/http/test/re_frame/http_abort_config_validation_test.clj
@@ -36,13 +36,10 @@
   single-outcome."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.schemas :as schemas]
-            [re-frame.flows :as flows]
-            [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.http.handlers :as handlers]
             [re-frame.http.managed :as http-managed]
+            [re-frame.test-support :as test-support]
             [re-frame.trace :as trace])
   (:import [com.sun.net.httpserver HttpExchange HttpHandler HttpServer]
            [java.net InetSocketAddress]
@@ -50,27 +47,8 @@
 
 ;; ---- per-test reset --------------------------------------------------------
 
-(defn- reset-runtime [t]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (schemas/clear-schemas-by-frame!)
-  (rf/init! plain-atom/adapter)
-  ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`, and
-  ;; the managed-HTTP fxs now require a carried frame stamp. This suite
-  ;; exercises the ambient dispatch path against a single conventional app
-  ;; frame, so register `:rf/default` explicitly and pin it as the
-  ;; established scope for the whole body via `with-frame`.
-  (frame/ensure-default-frame!)
-  (require 're-frame.routing :reload)
-  (require 're-frame.ssr     :reload)
-  (require 're-frame.http.managed :reload)
-  (http-managed/clear-all-in-flight!)
-  (http-managed/clear-all-http-interceptors!)
-  (rf/with-frame :rf/default
-    (t)))
-
-(use-fixtures :each reset-runtime)
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; ---- helpers ---------------------------------------------------------------
 

--- a/implementation/http/test/re_frame/http_abort_precedence_test.clj
+++ b/implementation/http/test/re_frame/http_abort_precedence_test.clj
@@ -36,39 +36,20 @@
    3. abort-via-actor-destroy-wins-over-decode-failure"
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.flows :as flows]
-            [re-frame.frame :as frame]
             [re-frame.http.managed :as http-managed]
             [re-frame.http.registry :as http-registry]
             [re-frame.http.transport :as http-transport]
-            [re-frame.machines :as machines]
-            [re-frame.registrar :as registrar]
-            [re-frame.schemas :as schemas]
-            [re-frame.substrate.plain-atom :as plain-atom])
+            [re-frame.machines]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support])
   (:import [com.sun.net.httpserver HttpExchange HttpHandler HttpServer]
            [java.net InetSocketAddress]
            [java.util.concurrent CountDownLatch TimeUnit]))
 
 ;; ---- per-test reset --------------------------------------------------------
 
-(defn- reset-runtime [t]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (schemas/clear-schemas-by-frame!)
-  (rf/init! plain-atom/adapter)
-  ;; The suite uses one explicit default frame for ambient dispatch.
-  (frame/ensure-default-frame!)
-  (require 're-frame.routing :reload)
-  (require 're-frame.ssr     :reload)
-  (require 're-frame.machines :reload)
-  (require 're-frame.http.managed :reload)
-  (machines/reset-timers!)
-  (http-managed/clear-all-in-flight!)
-  (rf/with-frame :rf/default
-    (t)))
-
-(use-fixtures :each reset-runtime)
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; ---- helpers --------------------------------------------------------------
 

--- a/implementation/http/test/re_frame/http_actor_destroy_cancellation_test.clj
+++ b/implementation/http/test/re_frame/http_actor_destroy_cancellation_test.clj
@@ -35,14 +35,10 @@
        is recognized from the durable `:rf/machine-type` snapshot marker"
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.flows :as flows]
-            [re-frame.frame :as frame]
             [re-frame.http.managed :as http-managed]
             [re-frame.http.registry :as http-registry]
             [re-frame.http.transport :as http-transport]
-            [re-frame.machines :as machines]
-            [re-frame.registrar :as registrar]
-            [re-frame.schemas :as schemas]
+            [re-frame.machines]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
             [re-frame.trace :as trace])
@@ -52,24 +48,8 @@
 
 ;; ---- per-test reset --------------------------------------------------------
 
-(defn- reset-runtime [t]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (schemas/clear-schemas-by-frame!)
-  (rf/init! plain-atom/adapter)
-  ;; The suite uses one explicit default frame for ambient dispatch.
-  (frame/ensure-default-frame!)
-  (require 're-frame.routing :reload)
-  (require 're-frame.ssr     :reload)
-  (require 're-frame.machines :reload)
-  (require 're-frame.http.managed :reload)
-  (machines/reset-timers!)
-  (http-managed/clear-all-in-flight!)
-  (rf/with-frame :rf/default
-    (t)))
-
-(use-fixtures :each reset-runtime)
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; ---- in-process latch server ----------------------------------------------
 

--- a/implementation/http/test/re_frame/http_actor_destroy_stale_test.clj
+++ b/implementation/http/test/re_frame/http_actor_destroy_stale_test.clj
@@ -25,12 +25,8 @@
   snapshot teardown)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.flows :as flows]
-            [re-frame.frame :as frame]
             [re-frame.http.managed :as http-managed]
-            [re-frame.machines :as machines]
-            [re-frame.registrar :as registrar]
-            [re-frame.schemas :as schemas]
+            [re-frame.machines]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
             [re-frame.trace :as trace])
@@ -40,23 +36,8 @@
 
 ;; ---- per-test reset (mirrors http_actor_destroy_cancellation_test.clj) ----
 
-(defn- reset-runtime [t]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (schemas/clear-schemas-by-frame!)
-  (rf/init! plain-atom/adapter)
-  (frame/ensure-default-frame!)
-  (require 're-frame.routing :reload)
-  (require 're-frame.ssr     :reload)
-  (require 're-frame.machines :reload)
-  (require 're-frame.http.managed :reload)
-  (machines/reset-timers!)
-  (http-managed/clear-all-in-flight!)
-  (rf/with-frame :rf/default
-    (t)))
-
-(use-fixtures :each reset-runtime)
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; ---- in-process latch server ----------------------------------------------
 

--- a/implementation/http/test/re_frame/http_backoff_cancellation_test.clj
+++ b/implementation/http/test/re_frame/http_backoff_cancellation_test.clj
@@ -30,13 +30,9 @@
    4. GUARD: an uncancelled backoff still retries (no regression)"
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.flows :as flows]
-            [re-frame.frame :as frame]
             [re-frame.http.managed :as http-managed]
             [re-frame.http.registry :as registry]
-            [re-frame.machines :as machines]
-            [re-frame.registrar :as registrar]
-            [re-frame.schemas :as schemas]
+            [re-frame.machines]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
             [re-frame.trace :as trace])
@@ -46,24 +42,8 @@
 
 ;; ---- per-test reset --------------------------------------------------------
 
-(defn- reset-runtime [t]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (schemas/clear-schemas-by-frame!)
-  (rf/init! plain-atom/adapter)
-  ;; The suite uses one explicit default frame for ambient dispatch.
-  (frame/ensure-default-frame!)
-  (require 're-frame.routing :reload)
-  (require 're-frame.ssr     :reload)
-  (require 're-frame.machines :reload)
-  (require 're-frame.http.managed :reload)
-  (machines/reset-timers!)
-  (http-managed/clear-all-in-flight!)
-  (rf/with-frame :rf/default
-    (t)))
-
-(use-fixtures :each reset-runtime)
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; ---- hit-counting always-500 server ---------------------------------------
 

--- a/implementation/http/test/re_frame/http_body_prep_failure_test.clj
+++ b/implementation/http/test/re_frame/http_body_prep_failure_test.clj
@@ -28,37 +28,14 @@
   through the router on `dispatch-sync`."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.flows :as flows]
-            [re-frame.frame :as frame]
             [re-frame.http.managed :as http-managed]
             [re-frame.http.registry :as registry]
-            [re-frame.registrar :as registrar]
-            [re-frame.schemas :as schemas]
             [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
             [re-frame.trace :as trace]))
 
-(defn- reset-runtime [t]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (schemas/clear-schemas-by-frame!)
-  (rf/init! plain-atom/adapter)
-  ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`,
-  ;; and the managed-HTTP / machine / routing fxs now require a carried
-  ;; frame stamp. This suite exercises the ambient dispatch path against
-  ;; a single conventional app frame, so register `:rf/default` explicitly
-  ;; and pin it as the established scope for the whole body via with-frame.
-  (frame/ensure-default-frame!)
-  (require 're-frame.routing :reload)
-  (require 're-frame.ssr     :reload)
-  (require 're-frame.machines :reload)
-  (require 're-frame.http.managed :reload)
-  ((requiring-resolve 're-frame.machines/reset-timers!))
-  (http-managed/clear-all-in-flight!)
-  (rf/with-frame :rf/default
-    (t)))
-
-(use-fixtures :each reset-runtime)
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; ---- a throwing body thunk -------------------------------------------------
 

--- a/implementation/http/test/re_frame/http_helpers_integration_test.clj
+++ b/implementation/http/test/re_frame/http_helpers_integration_test.clj
@@ -9,10 +9,6 @@
   and `re-frame.http-managed-test` (fx contract end-to-end)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.flows :as flows]
-            [re-frame.schemas :as schemas]
-            [re-frame.registrar :as registrar]
             [re-frame.http :as rf.http]
             [re-frame.http.managed :as http-managed]
             ;; rf2-cdmle — canned-stub fxs gate on explicit test-support
@@ -24,32 +20,8 @@
 
 ;; ---- per-test reset (mirrors http-managed-test) ---------------------------
 
-(defn- reset-runtime [t]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (schemas/clear-schemas-by-frame!)
-  (rf/init! plain-atom/adapter)
-  ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`,
-  ;; and the managed-HTTP / machine / routing fxs now require a carried
-  ;; frame stamp. This suite exercises the ambient dispatch path against
-  ;; a single conventional app frame, so register `:rf/default` explicitly
-  ;; and pin it as the established scope for the whole body via with-frame.
-  (frame/ensure-default-frame!)
-  (require 're-frame.routing :reload)
-  (require 're-frame.ssr     :reload)
-  (require 're-frame.machines :reload)
-  (require 're-frame.http.managed :reload)
-  ;; rf2-cdmle — re-fire the test-support load-time registrations after
-  ;; clear-all! / http-managed reload so the canned-stub fx ids are
-  ;; available for the next test.
-  (require 're-frame.http.test-support :reload)
-  ((requiring-resolve 're-frame.machines/reset-timers!))
-  (http-managed/clear-all-in-flight!)
-  (rf/with-frame :rf/default
-    (t)))
-
-(use-fixtures :each reset-runtime)
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; ---- helpers --------------------------------------------------------------
 

--- a/implementation/http/test/re_frame/http_interceptors_test.clj
+++ b/implementation/http/test/re_frame/http_interceptors_test.clj
@@ -24,8 +24,6 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.schemas :as schemas]
-            [re-frame.flows :as flows]
             [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.http.managed :as http-managed]
@@ -36,27 +34,17 @@
 
 ;; ---- per-test reset --------------------------------------------------------
 
-(defn- reset-runtime [t]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (schemas/clear-schemas-by-frame!)
-  (rf/init! plain-atom/adapter)
-  (require 're-frame.routing :reload)
-  (require 're-frame.ssr     :reload)
-  (require 're-frame.http.managed :reload)
-  (http-managed/clear-all-in-flight!)
-  (http-managed/clear-all-http-interceptors!)
-  ;; EP-0002 (rf2-5q7um6): reg-http-interceptor / clear-http-interceptor are
-  ;; context-required frame-local, and these tests dispatch managed HTTP to
-  ;; exercise the chain — both raise :rf.error/no-frame-context under no
-  ;; scope. Pin :rf/default (an ordinary frame) as the established scope for
-  ;; the body; tests that target an explicit frame pass {:frame …}.
-  (frame/ensure-default-frame!)
-  (binding [frame/*current-frame* :rf/default]
-    (t)))
-
-(use-fixtures :each reset-runtime)
+;; EP-0002 (rf2-5q7um6): reg-http-interceptor / clear-http-interceptor are
+;; context-required frame-local, and these tests dispatch managed HTTP to
+;; exercise the chain — a bare call raises :rf.error/no-frame-context. The
+;; canonical fixture's default `:ambient-frame :rf/default` pins :rf/default
+;; as the established scope, so frameless registrations land there and
+;; managed-HTTP dispatches drain; tests targeting an explicit frame pass
+;; {:frame …}, and the fails-closed test rebinds *current-frame* to nil
+;; locally. The canonical post-dispose reset now also clears the per-frame
+;; HTTP interceptor chain (rf2-q14tde), so no explicit clear-all is needed.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; ---- in-process server harness --------------------------------------------
 

--- a/implementation/http/test/re_frame/http_jvm_binary_decode_test.clj
+++ b/implementation/http/test/re_frame/http_jvm_binary_decode_test.clj
@@ -25,10 +25,6 @@
   the pre-fix code (which UTF-8-decoded the bytes / left elapsed-ms nil)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.schemas :as schemas]
-            [re-frame.flows :as flows]
-            [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.http.managed :as http-managed]
             [re-frame.http.transport-jvm :as transport-jvm]
@@ -38,27 +34,8 @@
 
 ;; ---- per-test reset --------------------------------------------------------
 
-(defn- reset-runtime [t]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (schemas/clear-schemas-by-frame!)
-  (rf/init! plain-atom/adapter)
-  ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`,
-  ;; and the managed-HTTP / machine / routing fxs now require a carried
-  ;; frame stamp. This suite exercises the ambient dispatch path against
-  ;; a single conventional app frame, so register `:rf/default` explicitly
-  ;; and pin it as the established scope for the whole body via with-frame.
-  (frame/ensure-default-frame!)
-  (require 're-frame.routing :reload)
-  (require 're-frame.ssr     :reload)
-  (require 're-frame.http.managed :reload)
-  (http-managed/clear-all-in-flight!)
-  (http-managed/clear-all-http-interceptors!)
-  (rf/with-frame :rf/default
-    (t)))
-
-(use-fixtures :each reset-runtime)
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; ---- a tiny in-process HTTP server (raw-bytes capable) --------------------
 

--- a/implementation/http/test/re_frame/http_jvm_relative_url_test.clj
+++ b/implementation/http/test/re_frame/http_jvm_relative_url_test.clj
@@ -31,36 +31,15 @@
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.flows :as flows]
-            [re-frame.frame :as frame]
             [re-frame.http.managed :as http-managed]
             [re-frame.http.transport-jvm :as transport-jvm]
-            [re-frame.registrar :as registrar]
-            [re-frame.schemas :as schemas]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]))
 
 ;; ---- per-test reset --------------------------------------------------------
 
-(defn- reset-runtime [t]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (schemas/clear-schemas-by-frame!)
-  (rf/init! plain-atom/adapter)
-  ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`,
-  ;; and the managed-HTTP fx now requires a carried frame stamp. Register
-  ;; `:rf/default` explicitly and pin it as the established scope.
-  (frame/ensure-default-frame!)
-  (require 're-frame.routing :reload)
-  (require 're-frame.ssr     :reload)
-  (require 're-frame.http.managed :reload)
-  (http-managed/clear-all-in-flight!)
-  (http-managed/clear-all-http-interceptors!)
-  (rf/with-frame :rf/default
-    (t)))
-
-(use-fixtures :each reset-runtime)
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; ---- helpers ---------------------------------------------------------------
 

--- a/implementation/http/test/re_frame/http_managed_machine_test.clj
+++ b/implementation/http/test/re_frame/http_managed_machine_test.clj
@@ -29,12 +29,8 @@
   uses the same wrapper registration via Fetch."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.flows :as flows]
-            [re-frame.frame :as frame]
             [re-frame.http.managed :as http-managed]
-            [re-frame.machines :as machines]
-            [re-frame.registrar :as registrar]
-            [re-frame.schemas :as schemas]
+            [re-frame.machines]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
             [re-frame.trace :as trace])
@@ -44,28 +40,8 @@
 
 ;; ---- per-test reset --------------------------------------------------------
 
-(defn- reset-runtime [t]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (schemas/clear-schemas-by-frame!)
-  (rf/init! plain-atom/adapter)
-  ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`,
-  ;; and the managed-HTTP / machine / routing fxs now require a carried
-  ;; frame stamp. This suite exercises the ambient dispatch path against
-  ;; a single conventional app frame, so register `:rf/default` explicitly
-  ;; and pin it as the established scope for the whole body via with-frame.
-  (frame/ensure-default-frame!)
-  (require 're-frame.routing :reload)
-  (require 're-frame.ssr     :reload)
-  (require 're-frame.machines :reload)
-  (require 're-frame.http.managed :reload)
-  (machines/reset-timers!)
-  (http-managed/clear-all-in-flight!)
-  (rf/with-frame :rf/default
-    (t)))
-
-(use-fixtures :each reset-runtime)
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; ---- helpers --------------------------------------------------------------
 

--- a/implementation/http/test/re_frame/http_managed_test.clj
+++ b/implementation/http/test/re_frame/http_managed_test.clj
@@ -12,9 +12,6 @@
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.http.json :as util-json]
-            [re-frame.frame :as frame]
-            [re-frame.schemas :as schemas]
-            [re-frame.flows :as flows]
             [re-frame.registrar :as registrar]
             [re-frame.http.decode :as http-decode]
             [re-frame.http.encoding :as http-encoding]
@@ -35,36 +32,16 @@
 
 ;; ---- per-test reset --------------------------------------------------------
 
-(defn- reset-runtime [t]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (schemas/clear-schemas-by-frame!)
-  (rf/init! plain-atom/adapter)
-  ;; The suite uses one explicit default frame for ambient dispatch.
-  (frame/ensure-default-frame!)
-  (require 're-frame.routing :reload)
-  (require 're-frame.ssr     :reload)
-  (require 're-frame.machines :reload)
-  (require 're-frame.http.managed :reload)
-  ;; `clear-all!` above wipes the canned-stub fx registrations
-  ;; that re-frame.http.test-support put into the registrar at first
-  ;; load. Reload the test-support ns so its registration body fires
-  ;; again for the next test (mirrors the http-managed reload above).
-  (require 're-frame.http.test-support :reload)
-  ((requiring-resolve 're-frame.machines/reset-timers!))
-  (http-managed/clear-all-in-flight!)
-  ;; The per-frame HTTP interceptor chain lives in a separate
-  ;; registry (internal to `re-frame.http.middleware`; observe via
-  ;; `http-managed/interceptors-snapshot`), NOT the registrar `clear-all!`
-  ;; wipes above. Tests that register `:before` / `:after` interceptors
-  ;; (the canned-path `:after` coverage) must clear it between tests, or
-  ;; a leaked `:after` mutates every subsequent test's reply payload.
-  (http-managed/clear-all-http-interceptors!)
-  (rf/with-frame :rf/default
-    (t)))
-
-(use-fixtures :each reset-runtime)
+;; The canonical runtime fixture snapshot/restores the registrar (so the
+;; ns-load-time canned-stub fx registrations from `re-frame.http.test-support`
+;; survive without a per-test `:reload`), resets frames / flows / schemas /
+;; adapter, and now clears BOTH the in-flight managed-request registry AND the
+;; per-frame HTTP interceptor chain on each post-dispose reset (rf2-q14tde) —
+;; the interceptor registry lives outside the registrar (internal to
+;; `re-frame.http.middleware`), so a leaked `:before` / `:after` would
+;; otherwise mutate every subsequent test's reply payload.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; ---- a tiny in-process HTTP server ----------------------------------------
 ;;

--- a/implementation/http/test/re_frame/http_privacy_body_test.clj
+++ b/implementation/http/test/re_frame/http_privacy_body_test.clj
@@ -20,17 +20,14 @@
 
   The schemas artefact is a test-only dep here, so requiring it binds the
   shared walker hooks (`:schemas/extract-sensitive-paths-from-schema` etc.)."
-  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+  (:require [clojure.test :refer [deftest is testing]]
             [re-frame.http.privacy-body :as body]
-            [re-frame.registrar :as registrar]
             ;; load-bearing: binds the shared schema walker hooks.
             [re-frame.schemas]))
 
-(defn- reset-runtime [t]
-  (registrar/clear-all!)
-  (t))
-
-(use-fixtures :each reset-runtime)
+;; No per-test fixture: every test here is a pure `re-frame.http.privacy-body`
+;; call — nothing touches the registrar / frames / app-db, so there is no
+;; per-test runtime state to reset (rf2-q14tde).
 
 ;; ---- 1. schema-decode? ----------------------------------------------------
 

--- a/implementation/http/test/re_frame/http_privacy_integration_test.clj
+++ b/implementation/http/test/re_frame/http_privacy_integration_test.clj
@@ -9,9 +9,6 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.string :as str]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.schemas :as schemas]
-            [re-frame.flows :as flows]
             [re-frame.registrar :as registrar]
             [re-frame.http.managed :as http-managed]
             [re-frame.substrate.plain-atom :as plain-atom]
@@ -22,32 +19,13 @@
 
 ;; ---- per-test reset --------------------------------------------------------
 
-(defn- reset-runtime [t]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (schemas/clear-schemas-by-frame!)
-  (rf/init! plain-atom/adapter)
-  ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`,
-  ;; and the managed-HTTP / machine / routing fxs now require a carried
-  ;; frame stamp. This suite exercises the ambient dispatch path against
-  ;; a single conventional app frame, so register `:rf/default` explicitly
-  ;; and pin it as the established scope for the whole body via with-frame.
-  (frame/ensure-default-frame!)
-  (require 're-frame.routing :reload)
-  (require 're-frame.ssr     :reload)
-  (require 're-frame.machines :reload)
-  (require 're-frame.http.managed :reload)
-  ((requiring-resolve 're-frame.machines/reset-timers!))
-  (http-managed/clear-all-in-flight!)
-  ;; rf2-ppkh3v — app-specific carriers are FRAME policy now (EP-0015 §3);
-  ;; the process-global clear-* fixtures are gone. Frame-extension cases
-  ;; reg-frame their carriers and registrar/clear-all! resets between tests.
-  (trace/clear-listeners!)
-  (rf/with-frame :rf/default
-    (t)))
-
-(use-fixtures :each reset-runtime)
+;; rf2-ppkh3v — app-specific carriers are FRAME policy now (EP-0015 §3); the
+;; process-global clear-* fixtures are gone. Frame-extension cases reg-frame
+;; their carriers and the canonical fixture's registrar snapshot/restore resets
+;; them between tests (it also clears trace listeners, so no explicit
+;; clear-listeners! is needed).
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; ---- a tiny in-process HTTP server ----------------------------------------
 

--- a/implementation/http/test/re_frame/http_privacy_test.clj
+++ b/implementation/http/test/re_frame/http_privacy_test.clj
@@ -24,13 +24,18 @@
             [re-frame.http.privacy :as privacy]
             [re-frame.http.privacy-headers :as headers]
             [re-frame.http.url :as url]
-            [re-frame.registrar :as registrar]))
+            [re-frame.registrar :as registrar]
+            [re-frame.test-support :as test-support]))
 
-(defn- reset-runtime [t]
-  (registrar/clear-all!)
-  (t))
-
-(use-fixtures :each reset-runtime)
+;; The privacy suite is pure-fn (no dispatch), but registers events / fx
+;; directly and asserts against a DELIBERATELY clean event + fx registry
+;; (e.g. `managed-carriers` resolves nil until a test installs
+;; `:rf.http/managed`). `:clear-kinds [:event :fx]` gives that clean slate for
+;; each test body, while the canonical registrar snapshot/restore rolls the
+;; per-test registrations back on the way out. No adapter is installed — the
+;; suite needs no app-db / frame.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:clear-kinds [:event :fx]}))
 
 ;; ---- 1. header denylist ---------------------------------------------------
 

--- a/implementation/http/test/re_frame/http_reply_lowering_test.clj
+++ b/implementation/http/test/re_frame/http_reply_lowering_test.clj
@@ -28,15 +28,11 @@
   envelope; EP-0011; rf2-ibksxg (one canonical async-reply envelope)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.flows :as flows]
             [re-frame.http.managed :as http-managed]
             [re-frame.http.reply :as http-reply]
             [re-frame.http.test-support]
             [re-frame.late-bind :as late-bind]
-            [re-frame.registrar :as registrar]
             [re-frame.reply :as reply]
-            [re-frame.schemas :as schemas]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
             [re-frame.trace :as trace])
@@ -45,25 +41,14 @@
 
 ;; ---- per-test reset (mirrors http_managed_test.clj) -----------------------
 
-(defn- reset-runtime [t]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (schemas/clear-schemas-by-frame!)
-  (rf/init! plain-atom/adapter)
-  (frame/ensure-default-frame!)
-  ;; `clear-all!` wipes the framework's built-in `:rf/time-ms` reg-cofx
-  ;; (registered at `re-frame.cofx` ns-load). Reload it so the provided
-  ;; recordable coeffect is present for the EP-0017 reply-time tests
-  ;; (rf2-5vdfrm) — a reply handler declaring `:rf.cofx/requires [:rf/time-ms]`
-  ;; needs its supplier registered.
-  (require 're-frame.cofx :reload)
-  (require 're-frame.http.managed :reload)
-  (require 're-frame.http.test-support :reload)
-  (rf/with-frame :rf/default
-    (t)))
-
-(use-fixtures :each reset-runtime)
+;; The canonical fixture snapshot/restores the registrar, so the framework's
+;; built-in `:rf/time-ms` reg-cofx (registered at `re-frame.cofx` ns-load) and
+;; the `re-frame.http.test-support` canned-stub fx ids survive between tests
+;; without a per-test `:reload` — the EP-0017 reply-time tests (rf2-5vdfrm)
+;; need `:rf/time-ms` present for a reply handler declaring
+;; `:rf.cofx/requires [:rf/time-ms]`.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; ---- real-transport server harness ---------------------------------------
 

--- a/implementation/http/test/re_frame/http_restore_quiesce_test.clj
+++ b/implementation/http/test/re_frame/http_restore_quiesce_test.clj
@@ -23,14 +23,10 @@
   to prove the late completion delivers nothing to the app target."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.flows :as flows]
-            [re-frame.frame :as frame]
             [re-frame.http.managed :as http-managed]
             [re-frame.http.registry :as http-registry]
             [re-frame.http.transport :as http-transport]
             [re-frame.late-bind :as late-bind]
-            [re-frame.registrar :as registrar]
-            [re-frame.schemas :as schemas]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
             [re-frame.trace :as trace])
@@ -38,19 +34,8 @@
            [java.net InetSocketAddress]
            [java.util.concurrent CountDownLatch TimeUnit]))
 
-(defn- reset-runtime [t]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (schemas/clear-schemas-by-frame!)
-  (rf/init! plain-atom/adapter)
-  (frame/ensure-default-frame!)
-  (require 're-frame.http.managed :reload)
-  (http-managed/clear-all-in-flight!)
-  (rf/with-frame :rf/default
-    (t)))
-
-(use-fixtures :each reset-runtime)
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 (defn- start-blocking-server!
   [^CountDownLatch latch status content-type body]

--- a/implementation/http/test/re_frame/http_retry_on_validation_test.clj
+++ b/implementation/http/test/re_frame/http_retry_on_validation_test.clj
@@ -17,36 +17,15 @@
   absent `:on`, and an empty `:on` set, all pass through cleanly."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.schemas :as schemas]
-            [re-frame.flows :as flows]
-            [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.http.handlers :as handlers]
-            [re-frame.http.managed :as http-managed]))
+            [re-frame.http.managed :as http-managed]
+            [re-frame.test-support :as test-support]))
 
 ;; ---- per-test reset --------------------------------------------------------
 
-(defn- reset-runtime [t]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (schemas/clear-schemas-by-frame!)
-  (rf/init! plain-atom/adapter)
-  ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`,
-  ;; and the managed-HTTP / machine / routing fxs now require a carried
-  ;; frame stamp. This suite exercises the ambient dispatch path against
-  ;; a single conventional app frame, so register `:rf/default` explicitly
-  ;; and pin it as the established scope for the whole body via with-frame.
-  (frame/ensure-default-frame!)
-  (require 're-frame.routing :reload)
-  (require 're-frame.ssr     :reload)
-  (require 're-frame.http.managed :reload)
-  (http-managed/clear-all-in-flight!)
-  (rf/with-frame :rf/default
-    (t)))
-
-(use-fixtures :each reset-runtime)
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; ---- closed-set assertion --------------------------------------------------
 

--- a/implementation/http/test/re_frame/http_source_coords_test.clj
+++ b/implementation/http/test/re_frame/http_source_coords_test.clj
@@ -21,34 +21,18 @@
      keys win over framework auto-capture)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.flows :as flows]
             [re-frame.http.managed :as http-managed]
-            [re-frame.registrar :as registrar]
-            [re-frame.schemas :as schemas]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
 
-(defn- reset-runtime [t]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (schemas/clear-schemas-by-frame!)
-  (rf/init! plain-atom/adapter)
-  (require 're-frame.routing :reload)
-  (require 're-frame.ssr     :reload)
-  (require 're-frame.http.managed :reload)
-  (http-managed/clear-all-in-flight!)
-  (http-managed/clear-all-http-interceptors!)
-  ;; EP-0002 (rf2-5q7um6): reg-http-interceptor is context-required
-  ;; frame-local — an ambient call under no scope raises
-  ;; :rf.error/no-frame-context. Pin :rf/default as the established scope so
-  ;; the frameless registrations land there; the :rf/api case passes
-  ;; {:frame :rf/api} explicitly.
-  (frame/ensure-default-frame!)
-  (binding [frame/*current-frame* :rf/default]
-    (t)))
-
-(use-fixtures :each reset-runtime)
+;; EP-0002 (rf2-5q7um6): reg-http-interceptor is context-required frame-local —
+;; an ambient call under no scope raises :rf.error/no-frame-context. The
+;; canonical fixture's default `:ambient-frame :rf/default` pins :rf/default as
+;; the established scope so the frameless registrations land there; the :rf/api
+;; case passes {:frame :rf/api} explicitly. The post-dispose reset now clears
+;; the per-frame HTTP interceptor chain too (rf2-q14tde).
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 (defn- slot-for
   "Locate the stored slot for `id` on `frame-id` in (http-managed/interceptors-snapshot)."

--- a/implementation/http/test/re_frame/http_synthetic_4xx_test.clj
+++ b/implementation/http/test/re_frame/http_synthetic_4xx_test.clj
@@ -31,13 +31,9 @@
    - Spec 014 §Retry and backoff / §Request envelope (`:redirect`)"
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.flows :as flows]
-            [re-frame.frame :as frame]
             [re-frame.http.managed :as http-managed]
             [re-frame.http.registry :as registry]
-            [re-frame.machines :as machines]
-            [re-frame.registrar :as registrar]
-            [re-frame.schemas :as schemas]
+            [re-frame.machines]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support])
   (:import [com.sun.net.httpserver HttpExchange HttpHandler HttpServer]
@@ -46,23 +42,8 @@
 
 ;; ---- per-test reset (mirrors http_backoff_cancellation_test) ---------------
 
-(defn- reset-runtime [t]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (schemas/clear-schemas-by-frame!)
-  (rf/init! plain-atom/adapter)
-  (frame/ensure-default-frame!)
-  (require 're-frame.routing :reload)
-  (require 're-frame.ssr     :reload)
-  (require 're-frame.machines :reload)
-  (require 're-frame.http.managed :reload)
-  (machines/reset-timers!)
-  (http-managed/clear-all-in-flight!)
-  (rf/with-frame :rf/default
-    (t)))
-
-(use-fixtures :each reset-runtime)
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; ---- hit-counting always-302 server ----------------------------------------
 

--- a/implementation/http/test/re_frame/http_url_validation_test.clj
+++ b/implementation/http/test/re_frame/http_url_validation_test.clj
@@ -19,37 +19,15 @@
   had weaker guarding than the optional ones."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.schemas :as schemas]
-            [re-frame.flows :as flows]
-            [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.http.handlers :as handlers]
-            [re-frame.http.managed :as http-managed]))
+            [re-frame.http.managed :as http-managed]
+            [re-frame.test-support :as test-support]))
 
 ;; ---- per-test reset --------------------------------------------------------
 
-(defn- reset-runtime [t]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (schemas/clear-schemas-by-frame!)
-  (rf/init! plain-atom/adapter)
-  ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`,
-  ;; and the managed-HTTP / machine / routing fxs now require a carried
-  ;; frame stamp. This suite exercises the ambient dispatch path against
-  ;; a single conventional app frame, so register `:rf/default` explicitly
-  ;; and pin it as the established scope for the whole body via with-frame.
-  (frame/ensure-default-frame!)
-  (require 're-frame.routing :reload)
-  (require 're-frame.ssr     :reload)
-  (require 're-frame.http.managed :reload)
-  (http-managed/clear-all-in-flight!)
-  (http-managed/clear-all-http-interceptors!)
-  (rf/with-frame :rf/default
-    (t)))
-
-(use-fixtures :each reset-runtime)
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; ---- helpers ---------------------------------------------------------------
 

--- a/implementation/http/test/re_frame/routing_http_composed_corners_test.clj
+++ b/implementation/http/test/re_frame/routing_http_composed_corners_test.clj
@@ -26,46 +26,22 @@
       precedence."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.flows :as flows]
-            [re-frame.frame :as frame]
             [re-frame.http.managed :as http-managed]
             [re-frame.http.test-support]
-            [re-frame.registrar :as registrar]
-            [re-frame.routing :as routing]
-            [re-frame.schemas :as schemas]
+            [re-frame.routing]
             [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace :as trace]))
+            [re-frame.test-support :as test-support]))
 
 ;; ---- fixture --------------------------------------------------------------
 
-(defn- reset-runtime [t]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (schemas/clear-schemas-by-frame!)
-  (trace/clear-listeners!)
-  (rf/init! plain-atom/adapter)
-  ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`,
-  ;; and the managed-HTTP / machine / routing fxs now require a carried
-  ;; frame stamp. This suite exercises the ambient dispatch path against
-  ;; a single conventional app frame, so register `:rf/default` explicitly
-  ;; and pin it as the established scope for the whole body via with-frame.
-  (frame/ensure-default-frame!)
-  (require 're-frame.routing :reload)
-  (require 're-frame.ssr     :reload)
-  (require 're-frame.machines :reload)
-  (require 're-frame.http.managed :reload)
-  (require 're-frame.http.test-support :reload)
-  (routing/reset-counters!)
-  ;; rf2-oosjmh — nav-token / pending-nav counters are host-side now; the
-  ;; `frames` reset above no longer clears them, so reset the host cache
-  ;; explicitly to keep "nav-1" / "nav-2" stable across tests.
-  (routing/reset-nav-counters!)
-  (http-managed/clear-all-in-flight!)
-  (rf/with-frame :rf/default
-    (t)))
-
-(use-fixtures :each reset-runtime)
+;; The canonical fixture fires the routing reset hooks in its post-dispose
+;; phase: `:routing/reset-counters!` (deterministic reg-index) and
+;; `:routing/reset-nav-counters!` (rf2-oosjmh — host-side nav-token /
+;; pending-nav counters the `frames` reset no longer clears, keeping "nav-1" /
+;; "nav-2" stable across tests). It also clears trace listeners and, per
+;; rf2-q14tde, the per-frame HTTP interceptor chain.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; ---- helpers --------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Migrates the HTTP JVM test suites off their hand-rolled `reset-runtime`
fixtures onto the canonical `make-reset-runtime-fixture`, and fixes a
missing reset hook so interceptor-chain isolation is uniform across every
suite.

**Core (`test_support.cljc`):** the published `:http/clear-all-http-interceptors!`
hook — documented for test isolation — was omitted from the fixture's
post-dispose reset hook table. The canonical fixture reset the in-flight
managed-request registry but NOT the per-frame HTTP interceptor chain (which
lives outside the registrar the snapshot/restore covers), so a `:before` /
`:after` interceptor registered in one test could leak into the next. Added
the row beside `:http/clear-all-in-flight!` and pinned it in the hook-cascade
coverage test so **both** HTTP reset hooks are proven to fire.

**HTTP (23 namespaces):** 21 repeated the same
registrar/frame/flows/schema/adapter/`:reload` sequence; 2 repeated
registrar-only cleanup. Replaced with `make-reset-runtime-fixture` (plain-atom
adapter), composing only suite-specific setup:

- `flows-http-integration` keeps its trace-recorder bracket wrapped around the
  canonical fixture (+ a load-only `re-frame.flows` require, since it calls
  `rf/reg-flow`).
- the privacy suite uses `:clear-kinds [:event :fx]` for its deliberately
  clean event/fx registry (no adapter — pure-fn).
- the pure `http-privacy-body` suite drops its fixture entirely.
- `http_interceptors_test` (added by #5457) migrated consistently — its
  bare-call-fails-closed assertions rebind `*current-frame*` locally, so the
  canonical default `:ambient-frame :rf/default` preserves them.

Deleted the dead `:reload` calls and the requires used only by the old reset
bodies; `machines` / `routing` kept as load-only requires where the suite
needs the artefact loaded. Net **-416 lines**.

## Preflight confirmation

Confirmed before starting: 23 HTTP JVM namespaces defined local reset-runtime
fixtures (21 repeating the full registrar/frame/flows/schema/adapter/reload
sequence, 2 registrar-only), and core test-support's canonical
`make-reset-runtime-fixture` omitted the published
`:http/clear-all-http-interceptors!` hook despite it being documented for test
isolation.

## Quality gates

Run in the worktree (foreground), post-rebase on latest `origin/main`:

- `cd implementation/http && clojure -M:test` → **470 tests, 3674 assertions, 0 failures, 0 errors**
- `cd implementation/core && clojure -M:test` → **1769 tests, 7695 assertions, 0 failures, 0 errors**
- `cd implementation && npm run test:cljs` → **8466 tests, 39169 assertions, 0 failures, 0 errors**

No new production dependency or bundle edge introduced — the change is a
late-bind keyword row in test-support plus test-file edits.

## Stance

Pre-alpha, no back-compat shims. Primary lenses: ELEGANCE + CLARITY +
CORRECTNESS + GOOD PRACTICE.

rf2-q14tde