### PR TITLE
docs(http): clarify current contracts (rf2-3gsdtv)

### DIFF
--- a/implementation/http/deps.edn
+++ b/implementation/http/deps.edn
@@ -1,64 +1,28 @@
-;; day8/re-frame2-http — http artefact (rf2-5kpd,
-;; fifth per-feature split per rf2-5vjj Strategy B).
+;; day8/re-frame2-http — optional managed-HTTP artefact.
 ;;
-;; Per Spec 014 the managed-HTTP surface (`:rf.http/managed`,
-;; `:rf.http/managed-abort`, the in-flight request registry, the Fetch /
-;; `java.net.http.HttpClient` transport adapters, the encode / decode
-;; pipeline, the retry-with-backoff machinery, and the eight-category
-;; `:rf.http/*` failure taxonomy) ships as a separate Maven artefact so
-;; apps that don't issue any managed-HTTP requests don't drag the
-;; namespace, the transport adapters, or any of the `:rf.http/*` trace
-;; strings onto the classpath.
+;; Spec 014's request handlers, registries, transports, codecs, retry loop,
+;; and failure vocabulary ship separately from core. Apps that do not require
+;; this artefact do not carry that code or its `:rf.http/*` trace keywords.
 ;;
-;; Test surfaces — both the canned-stub fxs
-;; (`:rf.http/managed-canned-success`, `:rf.http/managed-canned-failure`)
-;; AND the stub macros (`with-managed-request-stubs` /
-;; `with-managed-request-stubs*` / `install-managed-request-stubs!` /
-;; `uninstall-managed-request-stubs!`) — ship in this same artefact
-;; under the sibling `re-frame.http.test-support` namespace per
-;; rf2-lwmgw (consolidates audit-of-audits #15; the prior split that
-;; left the macros in `re-frame.http.managed` is closed). Production /
-;; SSR code paths MUST NOT `:require` that namespace; tests opt in. See
-;; Spec 014 §Test-support require for the gate rationale.
+;; Canned effects and request-stub helpers live in
+;; `re-frame.http.test-support`. Tests opt into that namespace explicitly;
+;; production and SSR namespaces must not require it.
 ;;
 ;; Consumers add this artefact alongside the core artefact:
 ;;
 ;;   {:deps {day8/re-frame2      {:mvn/version "..."}
 ;;           day8/re-frame2-http {:mvn/version "..."}}}
 ;;
-;; And require `re-frame.http.managed` in any namespace that issues
-;; `:rf.http/managed` requests — loading registers the production-
-;; eligible `:rf.http/*` fxs and publishes the production late-bind
-;; hooks (`:http/clear-all-in-flight!`, `:http/reg-http-interceptor`,
-;; etc.). Tests / dev demos additionally require
-;; `re-frame.http.test-support`, which registers the canned-stub fxs
-;; and publishes the `:http/with-managed-request-stubs*` late-bind hook.
-;; (The raw `install-managed-request-stubs!` /
-;; `uninstall-managed-request-stubs!` pair is NOT a `re-frame.core`
-;; re-export — rf2-ntwwyt — and publishes no late-bind hook; tests call
-;; it directly through `re-frame.http.test-support`.)
+;; Requiring `re-frame.http.managed` registers the production effects and
+;; publishes their late-bind hooks. Requiring `re-frame.http.test-support`
+;; additionally registers canned effects and publishes the scoped-stub hook;
+;; its raw install/uninstall helpers are called through that namespace.
 ;;
-;; Per Spec 006 §Adapter shipping convention (and the
-;; rf2-p7va extension to per-feature splits): this artefact depends on
-;; core; core never depends on this artefact. The cross-references
-;; from core to http (`re-frame.core`'s `with-managed-request-stubs*` /
-;; `with-managed-request-stubs` re-exports; the raw
-;; `install-managed-request-stubs!` / `uninstall-managed-request-stubs!`
-;; pair is NOT re-exported — rf2-ntwwyt — and is reached directly through
-;; `re-frame.http.test-support`) flow through
-;; `re-frame.late-bind` exactly as the schemas / machines / routing /
-;; flows hooks already do.
+;; The dependency arrow is HTTP -> core. Core reaches the optional surface
+;; only through `re-frame.late-bind`; it never depends on this artefact.
 {:paths ["src"]
  :deps  {day8/re-frame2 {:local/root "../core"}
-         ;; rf2-dgsu1 — Cheshire is a hard JVM dependency. Spec 014's
-         ;; managed-HTTP slice issues JSON request bodies and decodes
-         ;; JSON responses; on JVM we use Cheshire for both. Earlier
-         ;; the slice resolved Cheshire via `requiring-resolve` and
-         ;; fell back to a hand-rolled pure-Clojure JSON reader/writer
-         ;; — slow path, no warning, no signal that the operator was
-         ;; running on the fallback indefinitely. Per pre-alpha
-         ;; posture: ship one path, the fast path. CLJS uses the
-         ;; browser `JSON` builtin and ignores this dep.
+         ;; The JVM codec uses Cheshire; CLJS uses the host `JSON` object.
          cheshire/cheshire {:mvn/version "5.13.0"}}
 
  :aliases
@@ -76,19 +40,16 @@
                        day8/re-frame2-flows      {:local/root "../flows"}
                        day8/re-frame2-routing    {:local/root "../routing"}
                        day8/re-frame2-ssr        {:local/root "../ssr"}
-                       ;; rf2-wvkn — cancellation-cascade tests need the
-                       ;; machines artefact at test-time so a :spawn
-                       ;; spawn can drive the abort path. Production builds
-                       ;; do not depend on machines (the artefact graph
-                       ;; is unchanged); machines is test-only here.
+                       ;; Cancellation-cascade tests drive actor destruction;
+                       ;; machines remains a test-only dependency.
                        day8/re-frame2-machines   {:local/root "../machines"}
-                       ;; rf2-try1x — silent-on-success reporter.
+                       ;; Silent-on-success reporter.
                        day8/re-frame2-test-quiet {:local/root "../test-quiet"}
                        io.github.cognitect-labs/test-runner
                        {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
          :main-opts   ["-m" "re-frame.test-quiet.runner"]}
 
-  ;; Clojars deploy (rf2-r382). Modeled on re-frame v1's release flow.
+  ;; Clojars deploy, modeled on the other optional artefacts.
   ;; The release workflow runs `clojure -M:clein deploy` from this
   ;; artefact's directory, which builds pom + jar and pushes to Clojars.
   ;;

--- a/implementation/http/src/re_frame/http/decode.cljc
+++ b/implementation/http/src/re_frame/http/decode.cljc
@@ -1,11 +1,6 @@
 (ns re-frame.http.decode
   "Response-body decoding for `:rf.http/managed`. Per Spec 014 §Decoding
-  / §`:auto` (rf2-5ijhk split).
-
-  Extracted from `re-frame.http.encoding` per rf2-5ijhk — the original
-  encoding namespace mixed five concerns; this sibling isolates the
-  decode pipeline (`content-type-of`, `sniff-decoder`, `malli-decode`,
-  `decode-response-body`).
+  and §`:auto`.
 
   Decoding maps the response `body-text` + `headers` + user-supplied
   `:decode` to a Clojure value. The user's `:decode` can be:
@@ -23,7 +18,7 @@
   Malli decode requires `malli.core/decode` + optionally
   `malli.transform/json-transformer` + `malli.core/validate`. They are
   looked up via `requiring-resolve` (JVM) / `resolve` (CLJS) and
-  memoised in `defonce`d delays (rf2-tja2y) — the http artefact does
+  memoised in `defonce`d delays. The HTTP artefact does
   NOT depend on Malli at production-classpath time, so Malli-absent
   apps still load the namespace; the decode call falls through to a
   no-op (returns the parsed value) when Malli isn't on the classpath.
@@ -67,30 +62,15 @@
       headers)))
 
 (defn- empty-2xx-json-body?
-  "rf2-upexd.1 — cross-host parity (the oyw04 contract) for an empty /
-  whitespace-only 2xx JSON body. An empty `200`/`204`-shaped body is a
-  NORMAL HTTP outcome (the common PUT/DELETE/POST-with-no-content reply),
-  NOT a programmer error — so the managed-cascade decode altitude must
-  classify it IDENTICALLY on both hosts.
-
-  Without this guard the two `util-json/json-parse` branches diverge: the
-  JVM Cheshire reader surfaces an empty document as end-of-stream → nil,
-  while the CLJS `js/JSON.parse(\"\")` THROWS a `SyntaxError` that the
-  transport reclassifies as `:rf.http/decode-failure`. The helper-level
-  divergence is DELIBERATELY pinned at the `util-json` unit altitude
-  (util_json_cljs_test.cljs / util_json_test.clj — an empty hand-passed
-  helper arg is a transport-layer programmer error). That reasoning is
-  sound for the bare helper but WRONG at the `:rf.http/managed` cascade
-  altitude. We therefore short-circuit the empty/blank case HERE, at the
-  decode altitude, returning nil on BOTH hosts before `json-parse` is
-  reached — so the helper keeps its pinned per-host semantics while the
-  managed path stays host-symmetric (the canonical `{:status :ok :value
-  nil …}` success reply)."
+  "True for an empty or whitespace-only successful JSON body. Normalize it
+  to nil before parsing because Cheshire already treats an empty document as
+  nil while `JSON.parse` throws; managed HTTP promises the same outcome on
+  both hosts."
   [body-text]
   (and (string? body-text) (str/blank? body-text)))
 
 (defn- json-media-type?
-  "rf2-houkno — RFC 6839 / IANA structured-syntax-suffix aware JSON
+  "RFC 6839 structured-syntax-suffix aware JSON
   media-type predicate. Strips parameters (the `;charset=…` tail) and the
   type prefix, then accepts a subtype of exactly `json` OR any subtype
   carrying the `+json` structured-syntax suffix. This recognises mainstream
@@ -170,12 +150,11 @@
     (when (contains? binary-decode-kinds resolved)
       resolved)))
 
-;; Memoised resolves (per rf2-tja2y). The Malli vars never rebind at
-;; runtime; resolving once per JVM / once per CLJS runtime is enough,
-;; and the deref asymmetry (JVM `requiring-resolve` returns a Var,
+;; Malli vars do not rebind at runtime, so resolve once per host. The deref
+;; asymmetry (JVM `requiring-resolve` returns a Var,
 ;; CLJS `resolve` returns the value directly) is normalised behind
 ;; the delays so the call sites in `malli-decode` invoke the cached
-;; fn directly (per rf2-exycf).
+;; fn directly.
 ;;
 ;; CLJS `resolve` is a compile-time macro that requires a literal
 ;; quoted symbol — we cannot factor the symbol behind a runtime fn
@@ -201,7 +180,7 @@
                        (catch :default _ nil)))))
 
 (defonce ^:private malli-absent-warned?
-  ;; rf2-ee38b.7 — one-shot latch so the "schema supplied but Malli
+  ;; One-shot latch so the "schema supplied but Malli
   ;; absent" warning fires once per runtime, not once per response. The
   ;; degraded path is steady-state for a Malli-less app, so a per-request
   ;; trace would be noise; the single warning makes the silent no-op
@@ -229,11 +208,10 @@
   validate-or-throw if the transformer pipeline is unavailable. Throws
   on failure so the caller can classify as `:rf.http/decode-failure`.
 
-  Per rf2-ee38b.7: when Malli is absent entirely (decode AND validate
+  When Malli is absent entirely (decode and validate
   both nil), the parsed value is returned UNVALIDATED — but a one-shot
   `:rf.warning/http-malli-absent` trace fires so the degraded path is
-  visible (it was previously a silent no-op, the anti-pattern §JSON
-  decoder hardening calls out)."
+  visible."
   [schema value]
   (let [decode      @malli-decode-fn
         transformer @malli-transformer-fn
@@ -259,7 +237,7 @@
   "Per Spec 014 §Decoding. Returns the decoded value or throws an
   ex-info that the caller maps to `:rf.http/decode-failure`.
 
-  Per rf2-wu1n5 the JSON path enforces a per-call keyword-cap; the
+  The JSON path enforces a per-call keyword cap; the
   `:max-decoded-keys` slot (from the request args' `:rf.http/max-decoded-keys`,
   defaulted at the handler) is threaded into `util-json/json-parse`.
   The Malli-schema branch propagates the cap-throw rather than
@@ -286,7 +264,7 @@
       (requested-decode body-text headers)
 
       (= :json resolved)
-      ;; rf2-upexd.1 — an empty/whitespace-only 2xx JSON body is a normal
+      ;; An empty/whitespace-only 2xx JSON body is a normal
       ;; HTTP outcome (empty-success-envelope); classify it as nil on BOTH
       ;; hosts before `json-parse` (which throws on CLJS for `""`). See
       ;; `empty-2xx-json-body?`.
@@ -297,60 +275,41 @@
       (= :text resolved)
       body-text
 
-      ;; rf2-5zj6t — binary decode modes (`:blob` / `:array-buffer` /
+      ;; Binary decode modes (`:blob` / `:array-buffer` /
       ;; `:form-data`, the `binary-decode-kinds` set) return the native
       ;; binary body the transport already read: the CLJS transport rides
       ;; it under `:body-binary` via `.blob()` / `.arrayBuffer()` /
-      ;; `.formData()`, and (per rf2-a3wxe) the JVM transport rides the
+      ;; `.formData()`, and the JVM transport rides the
       ;; raw `byte[]` it read via `BodyHandlers/ofByteArray` under the
       ;; SAME `:body-binary` key — so on BOTH real-transport hosts a
       ;; binary 2xx response arrives here with `body-binary` PRESENT and
       ;; this arm returns it verbatim (no lossy text fallback). The
       ;; `body-text` fallback fires only when `body-binary` is genuinely
-      ;; absent — e.g. a synthetic / test ctx that populated only
-      ;; `:body-text` — so the value is at least the payload, not nil.
-      ;; (Pre-rf2-a3wxe the JVM read `.body` as a String and this arm
-      ;; ALWAYS fell through to the lossy text fallback for binary modes;
-      ;; a3wxe eliminated that — see `jvm-fetch`'s ofByteArray read.)
-      ;; rf2-jkake.9 — the three modes collapse onto the shared
+      ;; absent — e.g. a synthetic/test ctx that populated only
+      ;; `:body-text`. The three modes share the
       ;; `binary-decode-kinds` set (the same set `binary-read-kind`
       ;; consults) rather than three identical cond arms.
       (contains? binary-decode-kinds resolved)
       (if (some? body-binary) body-binary body-text)
 
       ;; Malli schema (or anything keyword-like that isn't recognised above).
-      ;; rf2-wu1n5 / rf2-5a5qwp — re-raise EVERY `json-parse` throw, tagged
+      ;; Re-raise every `json-parse` throw, tagged
       ;; or not. Per Spec 014 §Decoding the schema branch must JSON-parse
       ;; first and classify a malformed 2xx payload as a decode failure;
       ;; there is no "tolerant of non-JSON" text fallback here (that
       ;; concern is already handled up-front by the `json-content-type?`
-      ;; guard below, which rejects a DECLARED non-JSON Content-Type before
-      ;; parsing is ever attempted). A prior revision caught the parse
-      ;; exception and fell back to the raw `body-text` for any throw NOT
-      ;; tagged `:rf.error/malformed-json` — but only the keyword-cap
-      ;; overflow (rf2-wu1n5) is tagged; an ordinary JSON syntax error is
-      ;; an untagged host exception (Cheshire `JsonParseException` / CLJS
-      ;; `SyntaxError`), so THAT was the common case hitting the fallback.
-      ;; The raw text then rode into `malli-decode`, so malformed JSON
-      ;; could spuriously VALIDATE under a string-like schema, or surface
-      ;; as a misleading `:schema-validation-failure?` under a map schema
-      ;; instead of a plain decode failure. Removing the catch restores
-      ;; symmetry with the plain `:json` branch above (which never caught
-      ;; parse exceptions either) — any throw here propagates untouched to
+      ;; guard below, which rejects a declared non-JSON Content-Type before
+      ;; parsing is attempted). Any throw propagates untouched to
       ;; the transport's decode try/catch, which classifies it as
       ;; `:rf.http/decode-failure`.
       (some? resolved)
-      ;; rf2-upexd.2 — the schema decode path is JSON-ONLY: the only
+      ;; The schema decode path is JSON-only: the only
       ;; Malli transformer the decoder wires is the `json-transformer`,
       ;; so a schema rides a JSON body by construction (Spec 014
-      ;; §Decoding §Schema-driven, tightened by this bead). A response
+      ;; §Decoding §Schema-driven). A response
       ;; that DECLARES a non-JSON Content-Type (e.g. `application/edn`,
       ;; `text/plain`) under a schema `:decode` is a contract mismatch.
-      ;; Previously the body was JSON-parsed unconditionally; a non-JSON
-      ;; body's parse failure fell through to the raw text, then Malli
-      ;; validated the STRING against the schema and almost always failed
-      ;; — surfacing a confusing `:schema-validation-failure?` instead of
-      ;; the real cause (the MIME mismatch). Reject up-front with a clear
+      ;; Reject a MIME mismatch up front with a clear
       ;; tagged ex-info that the transport classifies as
       ;; `:rf.http/decode-failure` (NOT a schema-validation failure), so
       ;; the diagnostic names the actual problem. A nil/absent Content-
@@ -365,7 +324,7 @@
                ":rf.http/decode-failure.")
           {:extra {:content-type content-type
                    :schema       resolved}})
-        ;; rf2-upexd.1 — an empty/whitespace-only 2xx body parses to nil on
+        ;; An empty/whitespace-only 2xx body parses to nil on
         ;; BOTH hosts (the JVM Cheshire reader already yields nil for an
         ;; empty document; CLJS would throw inside `json-parse`). Short-
         ;; circuit to nil before the parse so the schema sees the same value

--- a/implementation/http/src/re_frame/http/encoding.cljc
+++ b/implementation/http/src/re_frame/http/encoding.cljc
@@ -1,36 +1,24 @@
 (ns re-frame.http.encoding
   "Pure-fn helpers for the `:rf.http/managed` request/response pipeline.
 
-  Extracted from `re-frame.http.managed` per rf2-3i9b. The fns here are
-  fully pure — they touch no atoms and dispatch no events — so they are
-  trivially testable and shared by the unified Fetch (CLJS) +
+  The functions here touch no atoms and dispatch no events. They are shared
+  by the Fetch (CLJS) and
   `HttpClient` (JVM) transport in `re-frame.http.transport`.
 
-  Surfaces (post-rf2-5ijhk split):
+  Surfaces:
 
   - URL / query-string encoding: `url-encode`, `params->query`,
     `merge-params`.
   - Request body encoding: `encode-body` (handles
     `:request-content-type` :json / :form / :text / explicit string,
-    plus heuristics for raw Clojure colls; the single thunk-realisation
-    site is inlined into `run-attempt!` per rf2-sz4n0).
+    plus heuristics for raw Clojure collections).
   - `:accept` normalisation: `run-accept` (and the inline default).
   - Reply addressing: `resolve-origin-event`, `build-reply-event`,
     `dispatch-reply-via-late-bind!`.
   - Backoff: `compute-backoff-ms`.
 
-  Per rf2-sz4n0 (round-2 http audit, findings 1.1, 1.2): two thin
-  one-liner helpers from the earlier split — `failure-map` (just
-  `(assoc tags :kind kind)`) and `realise-body` (just `(if (fn? body)
-  (body) body)`) — were inlined into their call sites. The earlier
-  shape required readers to trace into the helper to confirm it was a
-  plain `assoc` / `if`; the inline form reads as ordinary Clojure with
-  no behaviour loss. The third audit-flagged closure, `default-accept-
-  fn`, is folded into `run-accept` (see the docstring on `run-accept`).
-
   The response-side decode pipeline (`content-type-of`, `sniff-decoder`,
-  `malli-decode`, `decode-response-body`) lives in `re-frame.http-
-  decode` per rf2-5ijhk.
+  `malli-decode`, `decode-response-body`) lives in `re-frame.http.decode`.
 
   Per Spec 014 §Body encoding, §`:accept`, §Failure categories,
   §Reply addressing, §Retry and backoff."
@@ -62,7 +50,7 @@
   Scalar values (string / number / keyword / boolean) encode to a single
   `k=v` pair. A sequential value (vector / seq / list) encodes as one
   repeated `k=v` pair per element — `{:tag [\"a\" \"b\"]}` → `tag=a&tag=b`
-  (rf2-mag59). Repeat-key is the conventional HTTP-client idiom for
+  Repeat-key is the conventional HTTP-client idiom for
   multi-valued query params; Spec 012 §Query strings and fragments does
   not normatively pin a multi-valued shape, so the client picks the most
   interoperable one. An empty sequential value contributes no pair. A
@@ -80,7 +68,7 @@
   "Merge `:params` onto `:url`, returning the URL with the encoded query
   string spliced in BEFORE any `#fragment`.
 
-  Two correctness rules a naive append breaks (rf2-rznrz):
+  Two correctness rules a naive append breaks:
 
   1. **Fragment-aware splice.** Query params after a `#` are fragment
      text — real HTTP clients send the fragment to nobody, so a naive
@@ -108,7 +96,7 @@
 
 (defn normalize-header-pairs
   "Flatten a request-headers map into an ordered seq of `[name value]`
-  wire pairs (rf2-rznrz).
+  wire pairs.
 
   Per Spec 014 §Request envelope a request header value is `string` for
   the single-value case or `vector-of-strings` (more generally any

--- a/implementation/http/src/re_frame/http/handlers.cljc
+++ b/implementation/http/src/re_frame/http/handlers.cljc
@@ -1,11 +1,9 @@
 (ns re-frame.http.handlers
   "The `:rf.http/managed` + `:rf.http/managed-abort` fx handler bodies.
 
-  Extracted from `re-frame.http.managed` per rf2-0eyp2 — the façade now
-  re-exports these and wires them into `fx/reg-fx` at load time, but
-  the handler logic lives here alongside the other per-concern siblings
-  (`http-encoding`, `http-registry`, `http-middleware`, `http-transport`,
-  `http-machine-wrapper`, `http-privacy`).
+  `re-frame.http.managed` is the registration facade; lifecycle logic lives
+  here and delegates encoding, middleware, registry, privacy, and transport
+  work to their owning siblings.
 
   Two public fns:
 
@@ -18,9 +16,8 @@
                               `http-transport`.
   - `managed-abort-handler` — `:rf.http/managed-abort` body. Resolves
                               the abort-fn through the in-flight
-                              registry and fires it; cleanup belongs
-                              to the abort-fn → `finalise-failure!`
-                              cascade per rf2-plngk."
+                              registry and fires it; the abort closure owns
+                              transport cancellation and registry cleanup."
   (:require [clojure.string]
             [re-frame.error          :as error]
             [re-frame.frame          :as frame]
@@ -32,20 +29,16 @@
             [re-frame.http.transport :as transport]
             [re-frame.http.transport-jvm :as transport-jvm]))
 
-;; ---- rf2-apwkm — closed-set `:retry :on` validation ----------------------
+;; ---- closed-set `:retry :on` validation ----------------------------------
 ;;
 ;; Per Spec 014 §Closed-set `:retry :on` validation: `:retry :on` is
 ;; restricted to the *retryable* subset of the failure-category vocabulary.
 ;; The other `:rf.http/*` categories (`:rf.http/aborted`,
 ;; `:rf.http/decode-failure`, `:rf.http/accept-failure`) are
-;; non-retryable by construction and rejected at fx-call time — the
-;; runtime previously rejected only `:rf.http/aborted` and only at
-;; retry-attempt time, letting useless members ride for the request's
-;; lifetime. The closed-set tighten catches misuse at the dispatch site.
+;; non-retryable by construction and rejected at the effect boundary.
 (def retryable-categories
   "The closed set of `:rf.http/*` failure categories permitted in
-  `:retry :on`. Per Spec 014 §Closed-set `:retry :on` validation
-  (rf2-apwkm)."
+  `:retry :on`. Per Spec 014 §Closed-set `:retry :on` validation."
   #{:rf.http/transport
     :rf.http/cors
     :rf.http/timeout
@@ -53,22 +46,15 @@
     :rf.http/http-5xx})
 
 (defn- validate-retry!
-  "Per Spec 014 §Closed-set `:retry :on` validation (rf2-apwkm): a
+  "Per Spec 014 §Closed-set `:retry :on` validation, a
   `:retry :on` value, when present and non-nil, MUST be a SET drawn
   exclusively from `retryable-categories`. Two failure shapes both throw
   `:rf.error/http-bad-retry-on` at fx-call time (before `run-attempt!`),
   so the misuse surfaces at the dispatch site rather than downstream:
 
-  - SHAPE (rf2-4zldh): a non-set `:on` (keyword, vector, list, string,
-    map, …). Spec 014:372 types `:on` as a *set* of category keywords
-    and the transport loop's membership gate is `(contains? on-set kind)`.
-    `contains?` on a vector/list/string tests INDEX/range membership, not
-    value membership, so a non-set `:on` would silently DISABLE retry for
-    every category — exactly the useless-policy-rides-for-the-lifetime
-    misuse the dispatch-time guard exists to prevent. A bare keyword `:on`
-    was even worse: it threw a raw `IllegalArgumentException` from the
-    `(remove …)` ISeq coercion instead of the canonical error. We reject
-    every non-set non-nil `:on` here, before any of that can happen.
+  - SHAPE: a non-set `:on` (keyword, vector, list, string, map, …).
+    `contains?` on sequential values tests indexes rather than category
+    membership, so accepting those values would silently disable retries.
 
   - MEMBERSHIP: a set `:on` carrying a non-retryable `:rf.http/*` category
     (`:rf.http/aborted`, `:rf.http/decode-failure`,
@@ -111,9 +97,9 @@
 (defn validate-url!
   "Per Spec 014 §Request envelope `:url` is the only REQUIRED key in the
   request envelope; per Spec 009 §Error catalogue a missing/blank `:url`
-  surfaces as `:rf.error/http-bad-request` (rf2-93bck).
+  surfaces as `:rf.error/http-bad-request`.
 
-  Public (rf2-azrcs) so the canned-stub override target
+  Public so the canned-stub override target
   (`http-test-support`'s route-map stub) validates
   the FINAL post-`:before` url with the same canonical error the real
   `:rf.http/managed` handler emits — a `:before` that blanks the url must
@@ -123,13 +109,7 @@
   because a `:before` interceptor may legitimately SET the url (e.g. a
   base-URL-prefix interceptor). Throwing here — at the dispatch site —
   rather than letting a nil url fall through to the transport gives a
-  clear at-source error: without this guard a nil url surfaces as an
-  opaque `:rf.http/transport` failure (JVM `(URI/create nil)` NPE / CLJS
-  `(js/fetch nil)` vendor error), inconsistent with the rest of the
-  surface, which DOES validate shape at dispatch (`validate-retry!` →
-  `:rf.error/http-bad-retry-on`; `build-reply-event` →
-  `:rf.error/http-bad-reply-target`). The required field had weaker
-  guarding than the optional ones.
+  clear at-source error instead of a host-specific transport exception.
 
   A non-blank string passes; anything else (nil, non-string, or a
   blank/whitespace-only string) throws."

--- a/implementation/http/src/re_frame/http/json.cljc
+++ b/implementation/http/src/re_frame/http/json.cljc
@@ -1,10 +1,8 @@
 (ns re-frame.http.json
   "Tiny shared JSON helpers.
 
-  Extracted from `re-frame.http.managed` per rf2-p7da. The decode path
-  in `re-frame.http.encoding` needs a JSON reader; on CLJS that is the
-  browser's `js/JSON.parse`, on the JVM it is Cheshire (a hard dep
-  since rf2-dgsu1 — see the artefact's `deps.edn` for the rationale).
+  The decode path needs a JSON reader: CLJS uses `js/JSON.parse`; the JVM
+  uses the artefact's hard Cheshire dependency.
 
   ## Why this lives in the http artefact for now
 
@@ -23,11 +21,11 @@
   - `json-parse`     — string → Clojure data with keyword keys for
     objects. Uses Cheshire's `parse-string` on JVM; CLJS uses
     `js/JSON.parse` + `js->clj :keywordize-keys true`. Accepts an
-    optional `opts` map (`:max-decoded-keys` — per rf2-wu1n5).
+    optional `opts` map with `:max-decoded-keys`.
 
-  ## Keyword-interning cap (rf2-wu1n5)
+  ## Keyword-interning cap
 
-  Per security audit 2026-05-14 §P1.4: JVM keywords are interned and
+  JVM keywords are interned and
   never GC'd. An attacker-controlled JSON response with N unique keys
   permanently burns N keyword slots — a long-running SSR JVM is the
   worst case. Both readers enforce a per-call cap on the number of
@@ -39,18 +37,12 @@
   (:require [re-frame.error :as error]
             #?(:clj [cheshire.core :as cheshire])))
 
-;; rf2-b45uc — reflection warnings ON. This ns carries the other
-;; non-trivial JVM interop in the http surface (Cheshire's
-;; `generate-string` / `parse-string` and the `java.util.HashSet`
-;; keyword-cap counter). The HashSet calls are type-hinted; the flag
-;; keeps the tripwire on so a future un-hinted interop call surfaces as
-;; a compile-time reflection warning rather than silent reflective
-;; dispatch. CLJS ignores the form.
+;; Reflection warnings catch unhinted calls in the Cheshire/HashSet JVM path.
 #?(:clj (set! *warn-on-reflection* true))
 
 (def ^:const default-max-decoded-keys
   "Default cap on the number of unique object keys a single `json-parse`
-  call may decode. Per rf2-wu1n5 — a defensive ceiling against the
+  call may decode. A defensive ceiling against the
   keyword-interning DoS surface on long-running JVMs. Generous enough
   not to false-positive on legitimate large responses while finite
   enough to bound an attacker-controlled payload."
@@ -64,7 +56,7 @@
      :cljs (js/JSON.stringify (clj->js v))))
 
 (defn- too-many-keys-ex
-  "rf2-wu1n5 — the keyword-interning DoS-cap overflow ex-info. Platform-
+  "Build the keyword-interning cap overflow ex-info. Platform-
   agnostic (plain Clojure data), so the two host branches of `json-parse`
   share one definition rather than carrying byte-identical copies that
   could drift (`:cause` / `:limit` / `:reason` are security-relevant and
@@ -86,11 +78,11 @@
   `js->clj :keywordize-keys true`.
 
   `opts` (optional) — currently a single key:
-   - `:max-decoded-keys` — cap on unique object keys (rf2-wu1n5).
+   - `:max-decoded-keys` — cap on unique object keys.
      Default: `default-max-decoded-keys`. Overflow throws
      `:rf.error/id :rf.error/malformed-json` with `:cause :too-many-keys`.
 
-  Per rf2-wu1n5, both branches enforce the keyword-cap. The JVM
+  Both branches enforce the keyword cap. The JVM
   Cheshire branch installs a `:key-fn` callback that counts distinct
   keys in a HashSet and throws on overflow; the CLJS branch walks the
   parsed JS tree counting unique object-keys BEFORE

--- a/implementation/http/src/re_frame/http/machine_wrapper.cljc
+++ b/implementation/http/src/re_frame/http/machine_wrapper.cljc
@@ -1,8 +1,7 @@
 (ns re-frame.http.machine-wrapper
-  "Machine-shape wrapper for `:rf.http/managed` (rf2-ijm7).
+  "Machine-shape wrapper for `:rf.http/managed`.
 
-  Extracted from `re-frame.http.managed` per rf2-3i9b. Per Spec 014
-  §Machine-shape wrapper: `:rf.http/managed` ALSO registers as a child-
+  Per Spec 014 §Machine-shape wrapper, `:rf.http/managed` also registers as a child-
   invokable state machine, so a parent machine can write
 
     {:spawn {:machine-id :rf.http/managed
@@ -16,14 +15,11 @@
     3. dispatches `[<parent-id> [:succeeded value]]` (or
        `[<parent-id> [:failed failure]]`) back to the parent, where
        `<parent-id>` and `<self-id>` come from spawn-fx's framework-
-       reserved injection into the actor's initial `:data` per
-       rf2-ijm7 (`:rf/parent-id`, `:rf/self-id`).
+       reserved injection into the actor's initial `:data`
+       (`:rf/parent-id`, `:rf/self-id`).
 
   The wrapper machine is registered via the `:machines/reg-machine`
-  late-bind hook: re-frame.http.managed must NOT statically `:require`
-  re-frame.machines (per rf2-xbtj the machines artefact is optional)
-  and re-frame.machines must NOT statically `:require`
-  re-frame.http.managed (per rf2-5kpd the http artefact is optional).
+  late-bind hook: neither optional artefact statically requires the other.
   When the machines artefact is absent the wrapper registration is
   skipped; the existing `:rf.http/managed` fx continues to work
   unchanged (the wrapper is purely additive on top of the fx surface).
@@ -34,23 +30,18 @@
   AND `{:spawn {:machine-id :rf.http/managed ...}}` resolves to the
   machine.
 
-  ## Where the canned-stub handlers live (rf2-w59es5)
+  ## Test support
 
   The canned-stub handler bodies (`canned-success-handler` /
   `canned-failure-handler` and their `emit-canned-*!` / `run-request-
   chain` / `dispatch-canned-reply!` helpers) are TEST scaffolding — they
   live in `re-frame.http.test-support` alongside the canned-stub fx
   registrations and the `with-managed-request-stubs*` helper that
-  composes against them. They used to share this production-loaded
-  namespace (so the stub macros could reach them without a circular
-  require); that constraint no longer holds now that the stub macros and
-  the stub fx registrations have consolidated into `http-test-support`
-  (rf2-lwmgw), so the stub bodies moved there. This namespace is
-  production-loaded (by `re-frame.http.managed`) and now carries ONLY the
-  machine-shape wrapper."
+  composes against them. This production-loaded namespace carries only the
+  machine wrapper."
   (:require [re-frame.late-bind :as late-bind]))
 
-;; ---- machine-shape wrapper spec (rf2-ijm7) --------------------------------
+;; ---- machine-shape wrapper spec -------------------------------------------
 
 (defn http-managed-machine-spec
   "Return the machine-shape wrapper spec for `:rf.http/managed`.
@@ -66,8 +57,7 @@
      to spawns without an explicit `:start`; per Spec 005 §Spawning).
    - The wrapper's `:data` carries the args map for the underlying
      `:rf.http/managed` fx PLUS the framework-reserved
-     `:rf/parent-id` / `:rf/self-id` keys (stamped by spawn-fx, per
-     rf2-ijm7).
+     `:rf/parent-id` / `:rf/self-id` keys stamped by spawn-fx.
    - `:fire-request` builds an args map for the underlying fx,
      overriding `:on-success` / `:on-failure` so the reply lands back
      at the wrapper actor as `[:rf.http/succeeded value]` /

--- a/implementation/http/src/re_frame/http/managed.cljc
+++ b/implementation/http/src/re_frame/http/managed.cljc
@@ -11,8 +11,7 @@
   - `:rf.http/managed-abort`            — abort by `:request-id`
   - `:rf.fx/reg-http-interceptor`       — register an HTTP interceptor
                                           (data-shaped fx for EDN fixtures;
-                                          see §Middleware below). Per
-                                          rf2-uheqq the args map carries
+                                          see §Middleware below). The map carries
                                           `:before` / `:after` alongside
                                           the standard registration slots.
   - `:rf.fx/clear-http-interceptor`     — clear an HTTP interceptor
@@ -20,18 +19,14 @@
 
   Plus the registry / middleware / privacy re-exports detailed below.
 
-  ## HTTP test surfaces live elsewhere (rf2-lwmgw)
+  ## Test support
 
   The stubbing macros and the canned-stub fxs live in
   `re-frame.http.test-support`. A test reaching for `with-managed-request-stubs`
   / `install-managed-request-stubs!` / `uninstall-managed-request-stubs!` /
-  `with-managed-request-stubs*` — or the `:rf.http/managed-canned-success`
-  / `:rf.http/managed-canned-failure` fx ids via `:fx-overrides` — requires
-  `re-frame.http.test-support` for both surfaces in one shot. Earlier the
-  macros lived here and the canned-stub fx ids registered from
-  `re-frame.http.test-support`; per rf2-lwmgw (audit-of-audits #15) the
-  split is dropped and the namespace name now matches its content.
-  Production / SSR code paths MUST NOT `:require` `re-frame.http.test-support`.
+  `with-managed-request-stubs*` — or the canned effect ids via
+  `:fx-overrides` — requires `re-frame.http.test-support`. Production and SSR
+  code must not require that namespace.
 
   ## Hosts
 
@@ -40,13 +35,12 @@
     (`:abort-signal`, `:mode`, `:cache`, `:referrer`, `:integrity`) are
     no-ops on JVM with a one-line trace per occurrence.
 
-  ## HTTP carriers (EP-0025 §HTTP carriers)
+  ## HTTP carriers
 
   App-specific sensitive HTTP carrier NAMES (secret-bearing header /
   query-param names beyond the immutable built-in denylists) are declared on
-  THIS registration's metadata — the `:carriers` block — the EP-0025
-  transient-payload case (a managed-HTTP effect declares its own sensitive
-  carriers on its `reg-fx` registration). An app extends the denylists by
+  the `:rf.http/managed` registration's `:carriers` metadata. An app extends
+  the denylists by
   re-registering `:rf.http/managed` with a `:carriers` block:
 
   ```clojure
@@ -63,9 +57,8 @@
   (effective policy `(defaults − except) ∪ include`; `:include` wins for a
   name in both). The names lower-case and UNION onto the immutable built-in
   carrier denylists at trace-emit time (`re-frame.http.privacy/managed-carriers`).
-  Carriers are process-global (one registration); a malformed `:carriers`
-  block fails loud. The earlier frame `:sensitive {:http …}` block is
-  REMOVED.
+  Carriers are process-global because there is one effect registration; a
+  malformed `:carriers` block fails loudly.
 
   ## Production elision
 
@@ -73,23 +66,17 @@
   the `:rf.error/*` from failures) gate on `interop/debug-enabled?`. The
   `:rf.http/managed` fx itself is dev+prod (user-facing).
 
-  ## Artefact (rf2-5kpd, fifth per-feature split per rf2-5vjj Strategy B)
+  ## Optional artefact
 
   This namespace ships in `day8/re-frame2-http`, separate from the core
   artefact (`day8/re-frame2`). The core artefact's `re-frame.core`
-  re-exports of HTTP surface (`reg-http-interceptor`,
-  `clear-http-interceptor`, plus the `with-managed-request-stubs` macro and
-  its `with-managed-request-stubs*` plumbing, which live in
-  `re-frame.http.test-support` per rf2-lwmgw) look the entry points up via
-  the `re-frame.late-bind` hook table. Loading THIS namespace publishes the
-  middleware / registry hooks AND registers the `:rf.http/managed` and
-  `:rf.http/managed-abort` fxs. The stub-surface hook publishes from
-  `re-frame.http.test-support` per rf2-lwmgw — a test calling
+  re-exports look entry points up through `re-frame.late-bind`. Loading this
+  namespace publishes the middleware and registry hooks and registers the
+  production effects. The scoped-stub hook is published only by
+  `re-frame.http.test-support`; calling
   `rf/with-managed-request-stubs*` without requiring `re-frame.http.test-support`
-  surfaces `:rf.error/http-artefact-missing`, the same shape every
-  other test-support entry point uses. The raw `install-managed-request-stubs!`
-  / `uninstall-managed-request-stubs!` pair is NOT a `re-frame.core` re-export
-  (rf2-ntwwyt) — tests call it directly from `re-frame.http.test-support`.
+  raises `:rf.error/http-artefact-missing`. The raw install/uninstall pair is
+  available only from the test-support namespace.
 
   Apps that don't issue any managed-HTTP requests don't drag the
   in-flight request registry, the Fetch / HttpClient transport
@@ -97,50 +84,37 @@
   machinery, the eight-category `:rf.http/*` failure taxonomy, or any
   of the `:rf.http/*` keyword strings onto the classpath.
 
-  ## File split (rf2-3i9b, rf2-p7da, rf2-0eyp2)
+  ## Ownership
 
-  This namespace was 1790 LoC pre-split; it's now a thin public façade.
-  The implementation is in per-concern sibling namespaces (flat
-  dash-form naming, NOT dot-form — per rf2-2vbm `re-frame.http.X` would
-  collide with `goog.provide('re_frame.http')` on CLJS):
+  This namespace is the public facade and load-time registration anchor. The
+  implementation lives in per-concern sibling namespaces:
 
    - `re-frame.http.encoding`       — URL/query/body encoding, decode
                                       pipeline, `:accept` normalisation,
                                       build-reply-event /
                                       `dispatch-reply-via-late-bind!`,
-                                      backoff. All pure fns. (The earlier
-                                      `failure-map` / `realise-body` /
-                                      `default-accept-fn` helpers were
-                                      inlined into their call sites per
-                                      rf2-sz4n0.)
+                                      backoff. All pure fns.
    - `re-frame.http.registry`       — in-flight request + actor-id
                                       indexes, supersede semantics,
-                                      `abort-on-actor-destroy` (rf2-wvkn),
+                                      actor-destroy cancellation,
                                       spawned-actor detection.
    - `re-frame.http.middleware`     — per-frame request-side interceptor
-                                      chain (rf2-6y3q).
+                                      chain.
    - `re-frame.http.transport`     — shared Fetch (CLJS) + HttpClient
                                       (JVM) transport + attempt loop;
                                       platform-specific fragments are
-                                      gated with reader conditionals
-                                      (rf2-921qy).
+                                      selected at the host boundary.
    - `re-frame.http.handlers`      — `:rf.http/managed` /
                                       `:rf.http/managed-abort` fx
-                                      handler bodies (rf2-0eyp2).
-   - `re-frame.http.machine-wrapper`— machine-shape wrapper (rf2-ijm7).
+                                      handler bodies.
+   - `re-frame.http.machine-wrapper`— machine-shape wrapper.
    - `re-frame.http.test-support`   — test-only surface: stub macros
                                       + canned-stub handler bodies
-                                      (rf2-w59es5) + canned-stub fx
-                                      registrations + late-bind hook
-                                      publication for the stub family
-                                      (rf2-lwmgw).
-   - `re-frame.http.json`           — JSON reader extracted per rf2-p7da
-                                      (Cheshire on the JVM, native
+                                      + canned-stub fx registrations +
+                                      late-bind hook publication.
+   - `re-frame.http.json`           — JSON reader (Cheshire on the JVM, native
                                       `JSON.parse` on CLJS); shared by
-                                      the decode
-                                      pipeline. (Currently shipped in
-                                      the http artefact; lift to core
-                                      if a second consumer appears.)
+                                      the decode pipeline.
 
   This façade re-exports the public surface of those sub-namespaces
   AND performs the artefact's load-time side-effects: the
@@ -160,37 +134,34 @@
 ;; `re-frame.http.managed/<name>` so consumers (the `re-frame.core` late-
 ;; bind bridge, the test fixtures, examples that
 ;; `:require [re-frame.http.managed :as http-managed]`) see the same
-;; surface they did pre-split.
+;; public surface while storage and lifecycle ownership stay in the sibling.
 
 ;; Registry surface — the in-flight indexes are internal storage. Tests
 ;; observe them through the immutable snapshot helpers and seed test state
 ;; through `seed-in-flight-for-test!` (which preserves both-index invariants
 ;; via `record-in-flight!`); the raw `in-flight` / `actor-in-flight` atoms
-;; are NOT re-exported (rf2-hp772l — turning test convenience into accidental
-;; mutable API let app code bypass `record-in-flight!` / `clear-in-flight!`
-;; and the actor-index cleanup).
+;; are not re-exported because direct mutation would bypass the two-index
+;; cleanup invariant.
 (def clear-all-in-flight!        registry/clear-all-in-flight!)
 (def in-flight-snapshot          registry/in-flight-snapshot)
 (def actor-in-flight-snapshot    registry/actor-in-flight-snapshot)
 (def seed-in-flight-for-test!    registry/seed-in-flight-for-test!)
 (def abort-on-actor-destroy      registry/abort-on-actor-destroy)
 
-;; Middleware surface — per rf2-6y3q. The per-frame interceptor chain is
+;; The per-frame interceptor chain is
 ;; internal storage; tests observe it through the immutable
 ;; `interceptors-snapshot` helper rather than deref'ing the `interceptors`
-;; atom (which is NOT re-exported — rf2-hp772l). Registration / clearing
+;; atom. Registration and clearing
 ;; route through `reg-http-interceptor` / `clear-http-interceptor`.
 (def reg-http-interceptor        middleware/reg-http-interceptor)
 (def clear-http-interceptor      middleware/clear-http-interceptor)
 (def clear-all-http-interceptors! middleware/clear-all-http-interceptors!)
 (def interceptors-snapshot       middleware/interceptors-snapshot)
 
-;; Privacy surface — Spec 014 §Privacy (rf2-bma05). Header denylist lives
+;; Privacy surface — Spec 014 §Privacy. Header denylist lives
 ;; in `re-frame.http.privacy-headers`; the orchestrating composers
 ;; (request-sensitive?, prepare-emit-*) stay in `re-frame.http.privacy`.
-;; EP-0025 §HTTP carriers — the app-specific `declare-sensitive-header!` /
-;; `clear-sensitive-headers!` mutators and the frame `:sensitive {:http …}`
-;; block are REMOVED: app carrier names are declared on the `:rf.http/managed`
+;; App carrier names are declared on the `:rf.http/managed`
 ;; `reg-fx` registration metadata via the `:carriers {:headers [..]
 ;; :query-params [..]}` block (the transient-payload case — see the
 ;; ## HTTP carriers section in the ns docstring). The immutable built-in
@@ -213,12 +184,12 @@
 ;; ---- registration ---------------------------------------------------------
 ;;
 ;; The `:rf.http/managed` and `:rf.http/managed-abort` fx handler bodies
-;; live in `re-frame.http.handlers` (per rf2-0eyp2). The façade only
+;; live in `re-frame.http.handlers`. The facade only
 ;; performs the `(fx/reg-fx ...)` registrations for the production-eligible
 ;; managed-HTTP fxs. Apps that don't load `re-frame.http.managed` don't
 ;; carry the handlers either — the registration site is the load-time
 ;; anchor. The two canned-stub fxs register from
-;; `re-frame.http.test-support` per rf2-cdmle.
+;; `re-frame.http.test-support`.
 
 (fx/reg-fx :rf.http/managed
            {:doc "Spec 014 — managed HTTP request."}
@@ -228,11 +199,11 @@
            {:doc "Spec 014 — abort an in-flight :rf.http/managed by request-id."}
            handlers/managed-abort-handler)
 
-;; ---- middleware fx wrappers (rf2-yhfgf) -----------------------------------
+;; ---- middleware fx wrappers -----------------------------------------------
 ;;
 ;; `reg-http-interceptor` / `clear-http-interceptor` are direct fn-call APIs
 ;; — load-time registration of cross-cutting HTTP interceptors (Spec 014
-;; §Middleware, rf2-6y3q + rf2-uheqq). Most apps register at app bootstrap
+;; §Middleware). Most apps register at app bootstrap
 ;; and never call again. But the conformance corpus (Spec 011 §Conformance)
 ;; is pure-data EDN, has no fn-call seam, and drives behaviour exclusively
 ;; through `:fx` ops + `:fx-overrides`. The two fxs below let portable
@@ -240,10 +211,8 @@
 ;; use for everything else — `[:fx [[:rf.fx/reg-http-interceptor {...}]]]`
 ;; / `[:fx [[:rf.fx/clear-http-interceptor {...}]]]`.
 ;;
-;; Args shapes (data-shape, EDN-friendly — per rf2-uheqq the fn-form's
-;; second argument is already a single interceptor-map, so the fx and
-;; fn-form take the same shape; the fx body just routes `:id` into the
-;; positional arg):
+;; The fx and fn forms use the same data shape; the fx body routes `:id` into
+;; the fn's positional argument:
 ;;   :rf.fx/reg-http-interceptor   {:id <kw> :before <fn> :after <fn>?
 ;;                                  :frame <id>? :doc ... :tags ... }
 ;;   :rf.fx/clear-http-interceptor {:id <kw> :frame <id>?}
@@ -254,13 +223,13 @@
 ;; bootstrap through the dispatch surface.
 
 (fx/reg-fx :rf.fx/reg-http-interceptor
-           {:doc "Spec 014 §Middleware (rf2-6y3q + rf2-uheqq) — register an
+           {:doc "Spec 014 §Middleware — register an
                   HTTP interceptor as an fx. Args is a map carrying
                   `:id` (kw), at least one of `:before` / `:after`,
                   optional `:frame` (id), plus any
                   `:rf/registration-metadata` slots. The fx body splits
                   `:id` off and passes the remaining map straight through
-                  to the fn-form (per rf2-uheqq shape iii).
+                   to the fn-form.
 
                   EP-0002 — the carried frame is the fx-context `:frame`
                   (the cascade envelope stamp); the args `:frame` is the
@@ -275,59 +244,45 @@
                       (update :frame #(or % ctx-frame))))))
 
 (fx/reg-fx :rf.fx/clear-http-interceptor
-           {:doc "Spec 014 §Middleware (rf2-6y3q) — clear a request-side
+           {:doc "Spec 014 §Middleware — clear a request-side
                   interceptor by id as an fx. Args is the map
                   `{:frame <id> :id <kw>}` (NOT positional, matching the
                   fx-convention shape — sibling to `:rf.fx/reg-http-interceptor`
                   which also takes a map). The fn-form `clear-http-interceptor`
                   is the call-site surface (public opts form `(id {:frame f})`,
                   or the internal frame-first plumbing this fx threads through);
-                  this fx is the data-shaped surface for EDN-driven callers
-                  (conformance fixtures, event handlers at boot — rf2-k7tlm).
+                   this fx is the data-shaped surface for EDN-driven callers.
 
                   EP-0002 — the carried frame is the fx-context `:frame`
                   (the cascade envelope stamp); the args `:frame` is the
                   per-call *override*. The args frame wins, else the
                   fx-context frame, threaded explicitly into the fn-form's
-                  INTERNAL frame-first arity (rf2-f28bno) so it never repairs
-                  to a synthesised `:rf/default`."}
+                   internal frame-first arity so it never repairs
+                   to a synthesised `:rf/default`."}
            (fn [{ctx-frame :frame} {:keys [frame id]}]
              (middleware/clear-http-interceptor (or frame ctx-frame) id)))
 
-;; The two canned-stub fxs (`:rf.http/managed-canned-success` /
-;; `:rf.http/managed-canned-failure`) used to register here inside a
-;; `(when interop/debug-enabled? ...)` gate. Per rf2-cdmle (follow-up to
-;; rf2-zk08x) they moved to the sibling `re-frame.http.test-support`
-;; namespace because the prior gate was JVM-permissive: `debug-enabled?`
-;; is unconditionally true on the JVM, so canned-stub fx ids stayed
-;; registered as production-default API on JVM/SSR. The gate is now the
-;; require boundary — see `re-frame.http.test-support` for the canned-stub
-;; fx registrations AND the stub macros (per rf2-lwmgw the macros
-;; consolidated alongside the canned-stub fxs).
+;; The canned effects and stub helpers are registered only when
+;; `re-frame.http.test-support` is explicitly required. The namespace boundary,
+;; not the debug flag, keeps test effects out of JVM/SSR production loads.
 
 ;; ---- late-bind hook registration ------------------------------------------
 ;;
-;; re-frame.core needs to call into the http artefact's fn surface but
-;; per rf2-5kpd ships in the core artefact — it cannot `:require` this
-;; namespace because the http artefact is optional. Publish entry
+;; Core cannot require this namespace because the HTTP artefact is optional.
+;; Publish entry
 ;; points through the late-bind hook registry; consumers look the fns
 ;; up at call time.
 ;;
 ;; The stub-family late-bind hook (`:http/with-managed-request-stubs*`)
-;; publishes from `re-frame.http.test-support` per rf2-lwmgw — the stub
-;; macros and the canned-stub fxs share one require gate, symmetric with
-;; the test-support naming. The raw `install-managed-request-stubs!` /
-;; `uninstall-managed-request-stubs!` pair is NOT a `re-frame.core` re-export
-;; (rf2-ntwwyt) and publishes no late-bind hook — tests call it directly from
-;; `re-frame.http.test-support`.
+;; publishes from `re-frame.http.test-support`, so stub helpers and canned
+;; effects share one require gate. Raw install/uninstall helpers publish no
+;; hook and are called directly from that namespace.
 
 (late-bind/set-fn! :http/abort-in-flight!                 registry/abort-in-flight!)
 (late-bind/set-fn! :http/abort-on-actor-destroy           abort-on-actor-destroy)
-;; rf2-u5kmf8 — epoch-restore host-transient quiesce. The epoch restore boundary
-;; fires this AFTER a successful install to abort every non-resource managed HTTP
-;; request the restored frame had in flight, suppressing the app reply + emitting
-;; the EP-0011 stale-suppression facts (Managed-Effects §restore: "epoch restore
-;; MUST NOT revive host work"). Late-bound so epoch never statically requires http.
+;; Epoch restore aborts pre-restore host work after installing the epoch. The
+;; abort suppresses app replies and records stale-suppression facts. This remains
+;; late-bound so the epoch artefact does not acquire an HTTP dependency.
 (late-bind/set-fn! :http/abort-in-flight-for-frame!       registry/abort-in-flight-for-frame!)
 (late-bind/set-fn! :http/clear-all-http-interceptors!     clear-all-http-interceptors!)
 (late-bind/set-fn! :http/clear-all-in-flight!             clear-all-in-flight!)

--- a/implementation/http/src/re_frame/http/middleware.cljc
+++ b/implementation/http/src/re_frame/http/middleware.cljc
@@ -1,22 +1,16 @@
 (ns re-frame.http.middleware
   "Per-frame request- AND response-side interceptor chain for `:rf.http/managed`.
 
-  Extracted from `re-frame.http.managed` per rf2-3i9b. Per rf2-6y3q
-  (Spec 014 §Middleware): each frame has an ordered chain of HTTP
+  Per Spec 014 §Middleware, each frame has an ordered chain of HTTP
   interceptors. Each interceptor is an interceptor-map carrying an
   optional `:before` (request-side transform, fired in registration
   order before `:rf.http/managed` issues the request) and an optional
   `:after` (response-side transform, fired in REVERSE registration order
   on the response BEFORE `:on-success` / `:on-failure` are dispatched).
 
-  Per rf2-uheqq (Mike decision 2026-05-28, rf2-omwua option b + shape
-  (iii)): the public surface is `(reg-http-interceptor id interceptor-map)`
-  — a single map carrying `:before`, `:after`, `:frame`, and any
-  `:rf/registration-metadata` keys. Pre-alpha clean break: the prior
-  positional `(reg-http-interceptor id opts? before)` shape is retired
-  outright. The reshape aligns with the event-interceptor
-  `{:id :before :after}` mental model the rest of the framework already
-  uses (Spec 002).
+  The public surface is `(reg-http-interceptor id interceptor-map)`, where the
+  map carries `:before`, `:after`, `:frame`, and standard registration
+  metadata.
 
   ## ctx contract
 
@@ -40,7 +34,7 @@
                    start mark and the `:after`'s read), per-request
                    header parsing, auth-token refresh keyed off the
                    originating event, …
-    - `response` — the canonical reply envelope (rf2-ibksxg):
+    - `response` — the canonical reply envelope:
                    `{:status :ok :value <decoded> …}` or
                    `{:status :error :error <failure-map> …}` (an abort is
                    `{:status :cancelled :error <aborted-map> …}`). The
@@ -91,8 +85,7 @@
   (atom {}))
 
 (defn- valid-args?
-  "rf2-uheqq — shape (iii) validates id (positional keyword) and the
-  interceptor-map: must be a map, must carry at least one of
+  "Validate the positional id and interceptor map. The map must carry at least one of
   `:before` / `:after` (each, if present, must be a fn), and
   if `:frame` is present it must be a keyword."
   [id interceptor-map]
@@ -111,7 +104,7 @@
 
 (defn reg-http-interceptor
   "Register an HTTP interceptor on a frame's `:rf.http/managed` middleware
-  chain. Per Spec 014 §Middleware + rf2-uheqq.
+  chain. Per Spec 014 §Middleware.
 
   Signature: `(reg-http-interceptor id interceptor-map)` — `id` is a
   keyword; `interceptor-map` carries:

--- a/implementation/http/src/re_frame/http/privacy.cljc
+++ b/implementation/http/src/re_frame/http/privacy.cljc
@@ -1,5 +1,5 @@
 (ns re-frame.http.privacy
-  "Spec 014 §Privacy — sensitive-data honouring for `:rf.http/managed` (rf2-bma05).
+  "Spec 014 §Privacy for `:rf.http/managed`.
 
   HTTP is the canonical privacy surface: passwords ride request bodies,
   auth tokens ride request headers, user PII rides response bodies. The
@@ -26,14 +26,14 @@
 
   1. **Header denylist** (`re-frame.http.privacy-headers`) — a canonical
      set of always-sensitive header names. Redacted in trace events
-     regardless of the handler / request `:sensitive?` flag, because
+     regardless of the request's `:sensitive?` flag, because
      the headers' names themselves declare them sensitive.
 
-  2. **Query-param denylist** (`re-frame.http.url`, rf2-2p8wr) — a
+  2. **Query-param denylist** (`re-frame.http.url`) — a
      canonical set of always-sensitive query-string parameter names
      (e.g. `api_key`, `access_token`, `auth`). URLs carrying these
      params are redacted **inline** in every `:rf.http/*` trace event
-     that carries a `:url` slot, regardless of the handler / request
+     that carries a `:url` slot, regardless of the request
      `:sensitive?` flag. Same rationale as the header denylist: the
      param name itself is the signal.
 
@@ -47,28 +47,25 @@
      of path-marked / per-call classification.
 
   The runtime stamps `:sensitive? true` on the emitted trace event's
-  `:tags` (and at the top level when the core runtime stamp lands per
-  rf2 G1) so consumers consult one keyword to decide ship / drop /
-  redact. When ANY query param is redacted by the denylist alone (no
+  `:tags` so consumers consult one keyword to decide ship, drop, or redact.
+  When any query param is redacted by the denylist alone (no
   per-call sensitivity), the trace event still stamps `:sensitive? true`
   — the presence of a denylisted query param is itself a signal that
   the request carries an auth secret.
 
-  ## Managed-HTTP carriers (EP-0025 §HTTP carriers)
+  ## Managed-HTTP carriers
 
   Beyond the immutable built-in header / query-param denylists, an app may
   extend each with its own app-specific carrier names via the
   `:rf.http/managed` `reg-fx` registration metadata — the `:carriers
-  {:headers [..] :query-params [..]}` block (the EP-0025 transient-payload
-  case). The composers resolve the registration's extension sets ONCE per
+  {:headers [..] :query-params [..]}` block. The composers resolve the
+  registration's extension sets once per
   emit (`managed-carriers`, reading `re-frame.registrar/handler-meta :fx
   :rf.http/managed`) and thread them to the header / URL redactors, which
   union them onto the built-in defaults. Carriers are process-global (one
   `:rf.http/managed` registration), so resolution needs no frame id; when
   no app re-registered `:rf.http/managed` with a `:carriers` block, only the
-  built-in defaults apply. The old frame `:sensitive {:http …}` block (and,
-  earlier, the process-global `declare-sensitive-*!` surface) are removed:
-  app-specific carriers ride the managed-HTTP registration now.
+  built-in defaults apply.
 
   ## Production elision
 
@@ -83,15 +80,11 @@
             [re-frame.http.url :as url]
             [re-frame.registrar :as registrar]))
 
-;; rf2-m00e7p — internal alias for terse composer call sites below; the
-;; canonical home is the sibling leaf `re-frame.http.url` (carries no
-;; privacy deps, so no leaf→parent cycle). Private — `http-privacy` no
-;; longer carries a public re-export of the sentinel (the public surface
-;; is `re-frame.http.url/redacted-sentinel`, itself a re-export of the
-;; canonical `re-frame.privacy/redacted-sentinel` in core).
+;; The URL leaf owns the public HTTP alias so privacy composers can share the
+;; core sentinel without creating a leaf-to-parent cycle.
 (def ^:private redacted-sentinel url/redacted-sentinel)
 
-;; ---- managed-HTTP carrier resolution (EP-0025 §HTTP carriers) --------------
+;; ---- managed-HTTP carrier resolution --------------------------------------
 ;;
 ;; App-specific carrier names ride the `:rf.http/managed` `reg-fx`
 ;; registration metadata — the `:carriers {:headers [..] :query-params [..]}`
@@ -117,8 +110,7 @@
 ;; closed (only `:headers` / `:query-params`, and a query-param policy map
 ;; only `:include` / `:except`). A malformed block FAILS LOUD with
 ;; `:rf.error/bad-classification` (the canonical thrown-error shape) — the
-;; same posture the prior frame `:sensitive {:http …}` block had at
-;; reg-frame.
+;; same fail-loud posture as other classification metadata.
 
 (defn- carrier-error
   [reason extras]
@@ -255,18 +247,18 @@
   on the trace event (a denylisted param name is itself a signal that
   the request carries a secret) without re-walking the URL.
 
-  `param-extras` is the emitting frame's frame-local query-param carrier
-  extension set (EP-0015 §3), or `nil` for defaults-only.
+  `param-extras` is the registration-owned query-param carrier policy, or
+  `nil` for defaults only.
 
-  rf2-1u9dja — a self-identifying failure map (debugging-dx finding 3)
-  ALSO carries the request echo `:request {:method :url}`; its nested
+  A self-identifying failure map also carries the request echo
+  `:request {:method :url}`; its nested
   `:url` is an egress surface too, so it is walked through the SAME
   redactor. On-box the app reply carries the raw url (the caller's own
   data); this redaction fires only on the trace egress path the
   `prepare-emit-*` composers drive.
 
-  Per rf2-02vzz — fuses the redact + denylist-hit lookups so the URL's
-  query string is parsed exactly once per trace emit."
+  Redaction and denylist-hit detection share one walk, so the query string is
+  parsed once per trace emit."
   [m sensitive? param-extras]
   (let [[m top-any?]
         (if (string? (:url m))
@@ -284,15 +276,15 @@
 (defn redact-request-tags-with-flag
   "Like `redact-request-tags` but returns `[tags url-redacted?]` so
   callers (`prepare-emit-tags`) can decide whether to stamp
-  `:sensitive?` without re-walking the URL. Per rf2-02vzz.
+  `:sensitive?` without re-walking the URL.
 
-  `carriers` is the emitting frame's frame-local carrier extension map
-  `{:headers #{..} :query-params #{..}}` (EP-0015 §3), or `nil`."
+  `carriers` is the registration-owned carrier extension map
+  `{:headers #{..} :query-params #{..}}`, or `nil`."
   ([tags sensitive?] (redact-request-tags-with-flag tags sensitive? nil))
   ([tags sensitive? carriers]
    (let [[tags url-hit?] (redact-url-in tags sensitive? (:query-params carriers))
          tags' (cond-> tags
-                 ;; Always-on header redaction (built-in defaults ∪ frame extras).
+                 ;; Always-on header redaction (built-in defaults plus extensions).
                  (map? (:headers tags))
                  (update :headers headers/redact-headers (:headers carriers))
 
@@ -310,12 +302,12 @@
   the request-side payload when `sensitive?` is true. Always redacts
   denylisted headers regardless of `sensitive?` — the header denylist
   is unconditional. URL query-string values whose param name is in the
-  query-param denylist (rf2-2p8wr) are always redacted regardless of
+  query-param denylist are always redacted regardless of
   `sensitive?` — denylisted param names are themselves the signal.
 
   Idempotent and total: missing slots are left alone.
 
-  rf2-ee38b.7 — public for direct test assertion only; production reaches
+  Public for direct test assertion; production reaches
   redaction via the `prepare-emit-*` composers (which use the `*-with-flag`
   forms). No production caller invokes this non-flag wrapper."
   ([tags sensitive?] (first (redact-request-tags-with-flag tags sensitive? nil)))
@@ -325,10 +317,9 @@
 (defn redact-failure-with-flag
   "Like `redact-failure` but returns `[failure url-redacted?]` so callers
   (`prepare-emit-failure`, `prepare-emit-tags`) can decide whether to
-  stamp `:sensitive?` without re-walking the URL. Per rf2-02vzz.
+  stamp `:sensitive?` without re-walking the URL.
 
-  `carriers` is the emitting frame's frame-local carrier extension map
-  (EP-0015 §3), or `nil`."
+  `carriers` is the registration-owned carrier extension map, or `nil`."
   ([failure sensitive?] (redact-failure-with-flag failure sensitive? nil))
   ([failure sensitive? carriers]
    (when failure
@@ -414,9 +405,8 @@
 
   Returns `true` if any source declares sensitivity; `false` otherwise.
 
-  NOTE: handler-level `:sensitive?` registration metadata is no longer
-  consulted. Sensitive data marking is path-based per the upcoming
-  data-classification mechanism (separate spec doc; in progress)."
+  Handler registration metadata is not consulted; request sensitivity is a
+  per-call decision."
   [args-map _origin-event]
   (or (true? (:sensitive? args-map))
       (true? (get-in args-map [:request :sensitive?]))))
@@ -429,10 +419,10 @@
   `:rf.warning/cljs-only-key-ignored-on-jvm`).
   Returns a tags map ready for `trace/emit!`.
 
-  Two distinct decisions per rf2-2p8wr:
+  Two distinct decisions:
 
-  - **What to redact in `:url`** uses the `sensitive?` arg (handler /
-    per-call). When `sensitive?` true, ALL query-string param values
+  - **What to redact in `:url`** uses the per-call `sensitive?` arg. When
+    true, all query-string param values
     are scrubbed; when false, only denylisted param values are scrubbed.
     The denylist-only redaction does NOT promote the URL scrub to ALL
     params — denylisted names are signals, not licenses to scrub
@@ -443,13 +433,10 @@
     param name alone is enough to stamp the event — the name is the
     signal that the request carries a secret.
 
-  Per rf2-02vzz the redact + denylist-hit are computed in a single URL
-  walk: `redact-request-tags-with-flag` and `redact-failure-with-flag`
-  return the redacted shape paired with a flag telling us whether any
-  query-string value was scrubbed. Earlier the helpers ran two walks
-  per trace emit (denylist-hit then redact).
+  Redaction and denylist-hit detection share one URL walk; the helpers return
+  the redacted shape paired with a flag reporting whether any value changed.
 
-  Per EP-0025 §HTTP carriers the app-declared carrier extension sets ride
+  App-declared carrier extension sets ride
   the `:rf.http/managed` `reg-fx` registration (`:carriers` block); they
   are resolved ONCE here (`managed-carriers`) and threaded to the header /
   URL redactors so app-specific carriers redact alongside the built-in
@@ -474,15 +461,15 @@
   event (`emit-error!` on a `:rf.http/*` failure kind). The whole
   failure map is the tags map for `emit-error!`.
 
-  Two distinct decisions per rf2-2p8wr — same split as `prepare-emit-
+  Two distinct decisions, matching `prepare-emit-
   tags`: URL redaction uses the explicit `sensitive?` arg; `:sensitive?`
   stamping OR-combines that arg with a query-param denylist hit on the
   failure's `:url`.
 
-  Per rf2-02vzz the URL walk happens once: `redact-failure-with-flag`
+  The URL walk happens once: `redact-failure-with-flag`
   returns `[failure url-hit?]` so we don't re-parse the query string.
 
-  Per EP-0025 §HTTP carriers the app-declared carrier extension sets ride
+  App-declared carrier extension sets ride
   the `:rf.http/managed` `reg-fx` registration (`:carriers` block), resolved
   once (`managed-carriers`) and threaded to the header / URL redactors.
   Carriers are process-global, so the optional third arg (kept for call-site

--- a/implementation/http/src/re_frame/http/privacy_body.cljc
+++ b/implementation/http/src/re_frame/http/privacy_body.cljc
@@ -1,15 +1,11 @@
 (ns re-frame.http.privacy-body
-  "HTTP response-body classification — EP-0015 §8 / Spec 015 §HTTP response
-  bodies, ruled issue 5 (rf2-ppkh3v). Graduated into
-  [`spec/014-HTTPRequests.md` §Privacy — response-body classification].
+  "HTTP response-body classification for Spec 014 §Privacy.
 
-  ## The model (EP-0015 issue 5, ruled)
+  ## Model
 
   A managed HTTP response body is a **registration-owned transient
   payload**, classified per-slot via `:sensitive?` / `:large?` props on the
-  request's `:decode` SCHEMA — the EP-0005 mechanism reused (the `:decode`
-  schema lives on the owning call / resource / mutation declaration). This
-  is the SAME shared schema-walker hook
+  request's `:decode` schema. This uses the shared schema-walker hooks
   (`:schemas/extract-sensitive-paths-from-schema` /
   `:schemas/extract-large-paths-from-schema`) the resource `:data-schema`
   surface (`re-frame.resources.classification`) and the app-schema elision
@@ -57,16 +53,14 @@
   the shared `re-frame.elision/walk` ordering and the frame-classification
   install-time rule.
 
-  ## Per-slot `:sensitive?` and `:large?` (rf2-jhyccs)
+  ## Per-slot `:sensitive?` and `:large?`
 
   `classify-decoded` applies BOTH the `:decode` schema's `:sensitive?` and
   `:large?` per-slot marks via the shared `re-frame.classification/redact-with-paths`
-  walker (sensitive → `:rf/redacted`, large → `:rf.size/large-elided`,
-  sensitive wins over large) — the SAME walker the resource / app-schema
-  surfaces use, never a body-private walker. `decode-schema-marks` extracts
-  both `:sensitive` and `:large` path maps; both are now consumed.
+  walker: sensitive becomes `:rf/redacted`, large becomes
+  `:rf.size/large-elided`, and sensitive wins at the same path.
 
-  ## On-box dev trace vs off-box egress (rf2-t55hxg.6)
+  ## On-box dev trace vs off-box egress
 
   `classify-decoded` is the IN-PROCESS dev-trace projection — it applies the
   per-slot marks but does NOT omit an unschematized body (the local operator
@@ -118,7 +112,7 @@
   actually INTROSPECT for per-slot marks — i.e. the raw EDN VECTOR form
   (`[op props? children...]`, the shape `(rf/reg-app-schema …)` users write).
 
-  This is NARROWER than `schema-decode?` (rf2-y1pgdl). `schema-decode?` is
+  This is narrower than `schema-decode?`, which is
   true for ANY non-mode/non-fn `:decode`, including OPAQUE schema values the
   walker treats as a leaf and returns `{}` marks for:
 
@@ -132,7 +126,7 @@
   An opaque-leaf decode returns NO `:sensitive?` / `:large?` paths even when
   the underlying schema DOES mark slots sensitive. Treating it as
   `schema-decode?` → `:classify` would ride the body UNCHANGED off-box — the
-  EP-0015 issue 5 fail-OPEN leak. The off-box egress therefore gates on this
+  fail-open egress. The off-box projection therefore gates on this
   predicate (fail-CLOSED to `:omit` for an opaque schema); only an
   introspectable vector form earns `:classify`. The on-box dev-trace
   per-slot classification (`classify-decoded`) still keys on `schema-decode?`

--- a/implementation/http/src/re_frame/http/privacy_headers.cljc
+++ b/implementation/http/src/re_frame/http/privacy_headers.cljc
@@ -1,10 +1,10 @@
 (ns re-frame.http.privacy-headers
-  "HTTP header denylist for Spec 014 §Privacy (rf2-bma05).
+  "HTTP header denylist for Spec 014 §Privacy.
 
   HTTP request / response headers are the canonical bearer-token surface
   (Authorization, Cookie, Set-Cookie, X-API-Key, …). The header denylist
   defined here is unconditional: matching headers are redacted in every
-  `:rf.http/*` trace event regardless of the handler / request
+  `:rf.http/*` trace event regardless of the request
   `:sensitive?` flag, because the header names themselves declare them
   sensitive (an `Authorization` header leaking would be a leak even if
   the surrounding handler was not declared sensitive).
@@ -12,12 +12,11 @@
   `default-header-denylist` covers the canonical surface. These built-in
   names are an **immutable framework default** — no frame can remove one.
 
-  ## App-specific carriers ride the :rf.http/managed registration (EP-0025)
+  ## App-specific carriers
 
   An app extends the denylist with its own sensitive header names (e.g.
   `X-Honeycomb-Team`, `X-Stripe-Signature`) on the `:rf.http/managed`
-  `reg-fx` registration metadata — the `:carriers` block (the EP-0025
-  transient-payload case), not through a process-global mutation or a frame
+  `reg-fx` registration metadata, not through a mutable global or frame
   annotation:
 
       (rf/reg-fx :rf.http/managed
@@ -27,10 +26,7 @@
   `re-frame.http.privacy/managed-carriers` reads the registration metadata
   and lowers the `:carriers` names to a lower-cased extension set, which
   `redact-headers` / `sensitive-header?` UNION onto the immutable built-in
-  defaults. The earlier frame `:sensitive {:http {:headers […]}}` block and
-  the process-global `declare-sensitive-header!` / `clear-sensitive-headers!`
-  surface are both removed — the managed-HTTP registration owns app-specific
-  carriers now (EP-0025 §HTTP carriers).
+  defaults. The managed-HTTP registration owns app-specific carriers.
 
   ## Production elision
 
@@ -41,18 +37,13 @@
   (:require [clojure.string :as str]
             [re-frame.http.url :as url]))
 
-;; rf2-ee38b.7 — the framework-reserved redaction sentinel per Spec 009
-;; §Privacy now has a single canonical home in the sibling leaf
-;; `re-frame.http.url` (which carries no privacy deps, so there is no
-;; leaf→parent cycle). Previously this namespace held its own private
-;; copy AND `http-url` held the string form AND `http-privacy` held the
-;; keyword — three coordinated edits to change one value. Refer to the
-;; canonical def instead.
+;; Keep the sentinel in the dependency-leaf URL namespace so every HTTP
+;; redactor can share it without creating a privacy dependency cycle.
 (def ^:private redacted-sentinel url/redacted-sentinel)
 
 (def default-header-denylist
   "Canonical always-sensitive HTTP header names, lower-cased. These are
-  redacted in `:rf.http/*` trace events regardless of the handler's
+  redacted in `:rf.http/*` trace events regardless of the request's
   `:sensitive?` flag — the header names themselves are the signal.
 
   Drawn from the OWASP Authentication Cheatsheet plus common bearer-
@@ -76,18 +67,16 @@
 
 (defn sensitive-header?
   "Predicate: is `header-name` in the merged denylist (built-in defaults ∪
-  the emitting frame's `frame-extras`)? Case-insensitive.
+  the supplied carrier extensions)? Case-insensitive.
 
   `frame-extras` is the app-declared carrier extension set — a set of
   lower-cased header names resolved from the `:rf.http/managed`
-  `reg-fx` registration's `:carriers {:headers [..]}` block (EP-0025), or
-  `nil` when no carrier is declared. The built-in defaults always apply; the
-  extension set EXTENDS them. (The `frame-extras` parameter name is retained
-  for the leaf API + conformance-fixture contract; the extension set no
-  longer comes from a frame.)
+  `reg-fx` registration's `:carriers {:headers [..]}` block, or `nil` when no
+  carrier is declared. The parameter name is retained for the leaf API and
+  fixture contract; the extension set is not frame state.
 
-  Per rf2-ydp66 — the predicate short-circuits via `contains?` lookups on
-  the source sets rather than building a fresh union per call. `redact-headers`
+  The predicate checks the source sets directly rather than building a fresh
+  union per call. `redact-headers`
   calls this once per header (`reduce-kv` over the request's headers map).
   With trace/privacy permanently on under JVM (`interop/debug-enabled?` is
   constant `true` there), a merged-set rebuild would compound across every
@@ -109,7 +98,7 @@
   header names.
 
   `frame-extras` is the app-declared header carrier extension set from the
-  `:rf.http/managed` `:carriers {:headers [..]}` block (EP-0025), or `nil`
+  `:rf.http/managed` `:carriers {:headers [..]}` block, or `nil`
   for defaults-only. (Param name retained for the leaf API contract.)"
   ([headers-map] (redact-headers headers-map nil))
   ([headers-map frame-extras]

--- a/implementation/http/src/re_frame/http/registry.cljc
+++ b/implementation/http/src/re_frame/http/registry.cljc
@@ -1,8 +1,7 @@
 (ns re-frame.http.registry
   "In-flight request registries for `:rf.http/managed`.
 
-  Extracted from `re-frame.http.managed` per rf2-3i9b. Two indexes
-  coexist:
+  Two indexes coexist:
 
    - `in-flight`        — request-id → request-handle. Per Spec 014
                          §Aborts: a `:rf.http/managed-abort` resolves
@@ -10,15 +9,15 @@
                          request with the same `:request-id` supersedes
                          the previous one.
    - `actor-in-flight`  — actor-id → [request-handle ...]. Per Spec 014
-                         §Abort on actor destroy (rf2-wvkn): requests
+                         §Abort on actor destroy, requests
                          whose originating event-id is a spawned state-
                          machine actor's address are ALSO indexed by
                          that actor-id so a `:rf.machine/destroy`
                          cascade can abort every in-flight request the
                          actor had issued.
 
-  Handles carry `:abort-fn` (the no-arg fn the runtime calls to
-  cancel), `:url`, plus the framework-stamped `:request-id` and
+  Handles carry `:abort-fn` (the fn the runtime calls with an abort reason),
+  `:url`, plus the framework-stamped `:request-id` and
   `:actor-id` when applicable so subsequent `clear-in-flight!` calls
   can locate them in either index by identity.
 
@@ -45,7 +44,7 @@
   ;;
   ;; Index by actor-id — populated when a managed request's originating
   ;; event-id is a spawned actor's address (per Spec 014 §Abort on actor
-  ;; destroy, rf2-wvkn). Each entry carries the same :abort-fn the
+  ;; destroy). Each entry carries the same :abort-fn the
   ;; request-id index would carry; the actor-destroy hook walks the
   ;; vector, fires each :abort-fn, and clears the index slot. Multiple
   ;; in-flight requests from the same actor accumulate as separate
@@ -62,14 +61,7 @@
   sites can hold a reference for the 2-arg `clear-in-flight!` cleanup
   path. `request-id` and `actor-id` are both optional (pass nil). When
   both are nil the handle is unindexed and only reachable via natural
-  completion.
-
-  rf2-ee38b.7 — `record-in-flight!`'s own convenience 2-arity
-  `[request-id handle]` was dropped (this is distinct from
-  `clear-in-flight!`'s live 2-arity below, which is retained); it had no
-  production caller (the single call site in
-  `http-transport/run-attempt!` always passes the 3-arity with an
-  actor-id, possibly nil) and no test depended on it."
+  completion."
   [request-id actor-id handle]
   (let [stamped (cond-> handle
                   request-id (assoc :request-id request-id)
@@ -328,13 +320,13 @@
 
 (defn actor-in-flight-snapshot
   "Test-time helper: read the current value of the actor-id-keyed
-  in-flight map (per rf2-wvkn). Inspecting state in tests; not part
+  in-flight map. Inspecting state in tests; not part
   of the user-facing API."
   []
   @actor-in-flight)
 
 (defn seed-in-flight-for-test!
-  "Test-time helper (rf2-hp772l): register a fabricated in-flight handle
+  "Register a fabricated in-flight handle for tests
   through the SAME `record-in-flight!` path production uses, so both the
   request-id and actor-id indexes stay consistent (the actor-index slot,
   the `:request-id` / `:actor-id` stamps) rather than a raw `swap!` of the
@@ -343,7 +335,7 @@
   For fixtures that need an in-flight slot present WITHOUT issuing a real
   request (e.g. asserting that a navigation-cancel does not abort an
   active-route request). `handle` is the abort-handle map — it MUST carry
-  an `:abort-fn` (the no-arg/one-arg fn the abort path fires) and typically
+  an `:abort-fn` accepting an abort reason and typically
   `:url`. `request-id` / `actor-id` are optional (pass nil for an
   unindexed / anonymous handle). Returns the stamped handle.
 

--- a/implementation/http/src/re_frame/http/test_support.cljc
+++ b/implementation/http/src/re_frame/http/test_support.cljc
@@ -1,89 +1,21 @@
 (ns re-frame.http.test-support
-  "Test-support namespace for the managed-HTTP artefact (Spec 014).
+  "Test-only support for the managed-HTTP artefact (Spec 014).
 
-  ## What lives here (rf2-lwmgw — single discoverable home)
+  This namespace owns the scoped stubbing helpers, raw install/uninstall
+  functions, canned success/failure effects, and the late-bind hook used by
+  `re-frame.core/with-managed-request-stubs`. The raw install/uninstall pair
+  is called directly through this namespace and is not a core facade export.
 
-  Per [rf2-lwmgw](#) (audit-of-audits #15) the namespace is now the **sole
-  home** for every HTTP test-machinery surface:
-
-   - the stubbing macros / fns:
-      - `with-managed-request-stubs`        — body-bracketing macro
-      - `with-managed-request-stubs*`       — plain-fn surface
-      - `install-managed-request-stubs!`    — multi-`deftest` installer
-      - `uninstall-managed-request-stubs!`  — idempotent teardown
-   - load-time registration of the two canned-stub fxs:
-      - `:rf.http/managed-canned-success`
-      - `:rf.http/managed-canned-failure`
-   - the late-bind hook publication the `re-frame.core` re-export
-     `rf/with-managed-request-stubs` (and its `with-managed-request-stubs*`
-     plumbing) resolves through.
-
-  The ergonomic `with-managed-request-stubs` macro is the `re-frame.core`
-  façade surface. The raw `install-managed-request-stubs!` /
-  `uninstall-managed-request-stubs!` pair is NOT a façade export (rf2-ntwwyt
-  — test-support infrastructure, not app-facing core surface): tests call
-  these two defns directly from this namespace, so they carry no late-bind
-  hook.
-
-  The previous arrangement split these across two namespaces — the macros
-  lived in `re-frame.http.managed`, and `re-frame.http.test-support` was a
-  bare \"registration gate\" for the canned-stub fxs. A test author reaching
-  for the HTTP stub helper had to know which surface lived where. The
-  consolidation (rf2-lwmgw, Mike-confirmed option (a) on audit-of-audits
-  #15) drops that split: one namespace, one require, every HTTP test
-  surface.
-
-  The production fx surface (`:rf.http/managed`, `:rf.http/managed-abort`,
-  the middleware family) continues to live in `re-frame.http.managed`.
-  Production / SSR app code must NOT `:require` this namespace.
-
-  ## Adoption
-
-  Test files / dev demos that exercise any HTTP stub surface — the
-  `with-managed-request-stubs` macro, the raw install/uninstall pair, or the
-  canned-stub fx ids via `:fx-overrides` — add this namespace to their
-  require closure:
+  Requiring this namespace is the test-effect registration gate. Production
+  and SSR code must not require it; the production effects and middleware
+  remain in `re-frame.http.managed`. A test using any stub surface requires
+  both namespaces:
 
   ```clojure
   (ns my-app.tests
-    (:require [re-frame.http.managed]        ;; production fx surface
-              [re-frame.http.test-support])) ;; stub macros + canned fxs
-  ```
-
-  ## Why this exists at all (rf2-cdmle, follow-up to rf2-zk08x)
-
-  The canned-stub fxs
-
-    - `:rf.http/managed-canned-success`
-    - `:rf.http/managed-canned-failure`
-
-  are test-only affordances per Spec 014 §Testing. Earlier they registered
-  at `re-frame.http.managed` namespace load, gated on
-  `re-frame.interop/debug-enabled?`. That gate works on CLJS — under
-  `:advanced + goog.DEBUG=false` the entire `(when ...)` body DCEs, fx-id
-  keyword string fragments and all. On the JVM, however, `debug-enabled?`
-  is unconditionally true; the canned-stub fxs were therefore registered
-  in JVM/SSR production builds too — discoverable via
-  `:fx-overrides {:rf.http/managed :rf.http/managed-canned-success}` from
-  any handler.
-
-  rf2-zk08x's audit flagged this as a security-surface posture mismatch:
-  test stubs ought not be production-default API. Per the operator decision
-  the gate moved from \"`when debug-enabled?`\" to **\"explicit test-support
-  import\"**: loading this namespace registers the two fxs against the same
-  handler bodies the prior gate used. Production posture: this namespace
-  is unreferenced from any production module, so CLJS `:advanced` trims it
-  wholesale and JVM/SSR sees classpath absence through the normal artefact
-  require boundary.
-
-  ## Public surface (registered at ns-load)
-
-  - `:rf.http/managed-canned-success` — synthesised success reply.
-  - `:rf.http/managed-canned-failure` — synthesised failure reply.
-
-  Plus the four stub macros / fns listed above (and the matching late-bind
-  hook publication under `:http/with-managed-request-stubs*` for the façade
-  `with-managed-request-stubs` macro)."
+    (:require [re-frame.http.managed]
+              [re-frame.http.test-support]))
+  ```"
   (:require [re-frame.events               :as events]
             [re-frame.frame                :as frame]
             [re-frame.fx                   :as fx]
@@ -97,29 +29,25 @@
 
 #?(:clj (set! *warn-on-reflection* true))
 
-;; ---- canned-stub handler bodies (rf2-w59es5) ------------------------------
+;; ---- canned-stub handler bodies -------------------------------------------
 ;;
 ;; These synthesise a managed-HTTP reply WITHOUT a real transport, for the
 ;; canned-stub fxs (`:rf.http/managed-canned-*`) and the route-map stub
-;; (`stub-handler`) below. They are TEST scaffolding — they used to live in
-;; the production-loaded `re-frame.http.machine-wrapper` so the (then-split)
-;; stub macros could reach them without a circular require. Now that the
-;; macros and the canned-stub fx registrations both live HERE (rf2-lwmgw),
-;; the constraint is gone and the bodies moved here too, leaving
-;; `http-machine-wrapper` to carry only the production machine spec.
+;; (`stub-handler`) below. Keeping them here prevents production namespaces
+;; from owning or registering test behavior.
 ;;
-;; rf2-2utlm / rf2-k67u3 — the canned path delegates to
+;; The canned path delegates to
 ;; `middleware/run-after-then-dispatch!`, the shared run-`:after`-then-late-
 ;; bind reply tail `http-transport/dispatch-reply!` also uses, so the
 ;; `:after`-chain + build-reply-event + late-bind lookup pattern lives in one
 ;; place.
 ;;
-;; rf2-622e3 — origin-event resolution lives in
+;; Origin-event resolution lives in
 ;; `encoding/resolve-origin-event` (single source of truth shared with
 ;; `http-managed/managed-handler`).
 
 (defn run-request-chain
-  "Per rf2-yhfgf — the request-side middleware chain (Spec 014 §Middleware)
+  "The request-side middleware chain (Spec 014 §Middleware)
   fires for every issued request, not just real-transport ones. The canned
   stub fxs replace the TRANSPORT, not the entire managed pipeline, so they
   walk the chain before synthesising the reply. The chain's `:before` fns
@@ -133,8 +61,8 @@
   Returns the post-`:before` middleware-ctx so the caller can thread it
   through `run-after-chain!` — the same ctx the `:after` chain sees on
   the real-transport path (carried forward by `managed-handler` as the
-  normalised ctx's `:middleware-ctx`). The route-map stub (`stub-handler`,
-  rf2-azrcs) ALSO reads the post-`:before` `:request` back off this ctx to
+  normalised ctx's `:middleware-ctx`). The route-map stub (`stub-handler`)
+  also reads the post-`:before` `:request` back off this ctx to
   key its match against the url the managed pipeline would actually issue,
   and runs `handlers/validate-url!` on it — the final-url validation belongs
   to the `:rf.http/managed` OVERRIDE-TARGET role (the stub), not to this

--- a/implementation/http/src/re_frame/http/transport.cljc
+++ b/implementation/http/src/re_frame/http/transport.cljc
@@ -2,16 +2,15 @@
   "Shared (platform-neutral) attempt-and-retry lifecycle for
   `:rf.http/managed`.
 
-  The platform transports live in per-platform sibling adapter
-  namespaces (rf2-hp772l): `re-frame.http.transport-cljs` owns the Fetch
+  Platform transports live in sibling adapters: `re-frame.http.transport-cljs` owns the Fetch
   path (`cljs-fetch` + `classify-cljs-error`); `re-frame.http.transport-jvm`
   owns the `java.net.http.HttpClient` path (`jvm-fetch` +
   `classify-jvm-error`) and the per-row CLJS-only-key degradation tracing
   (`check-cljs-only-keys!`). This namespace owns everything else —
   `dispatch-reply!`, `finalise-success!`, `finalise-failure!`,
   `maybe-retry!`, the 4xx/5xx/2xx/else response cascade, the in-flight
-  registry interaction, the retry-trace emission, the rf2-bma05 privacy
-  redaction, and the rf2-lxd3 supersede suppression — as platform-neutral
+  registry interaction, retry tracing, privacy redaction, and supersession
+  suppression as platform-neutral
   Clojure. `run-attempt!` is the one site that selects the platform
   adapter under a reader conditional; the rest of the lifecycle carries
   no platform interop.
@@ -50,8 +49,8 @@
   `:on-failure` reply target — the cancellation replaces the original outcome,
   so delivering the old reply would race / corrupt the post-cancel state.
 
-  `:request-id-superseded` (rf2-lxd3) — a fresh request with the same
-  `:request-id` replaced this one. `:epoch-restored` (rf2-u5kmf8) — epoch
+  `:request-id-superseded` means a fresh request with the same
+  `:request-id` replaced this one. `:epoch-restored` means epoch
   restore unwound the timeline this request belonged to; per EP-0011 /
   Managed-Effects §restore (\"epoch restore MUST NOT revive host work\") a
   pre-restore completion MUST NOT deliver to its original `:rf/reply-to` target.
@@ -78,7 +77,7 @@
   chain (REVERSE registration order) BEFORE handing off to the
   late-bind router for `:on-success` / `:on-failure` dispatch.
 
-  Per rf2-uheqq + Spec 014 §Middleware: each `:after` sees `(ctx,
+  Per Spec 014 §Middleware, each `:after` sees `(ctx,
   response)` — `ctx` is the SAME middleware-ctx the `:before` chain
   produced for this request (carried forward via the normalised ctx's
   `:middleware-ctx` slot, populated by `managed-handler`). The
@@ -96,9 +95,7 @@
   (let [explicit (case kind
                    :success explicit-on-success
                    :failure explicit-on-failure)]
-    ;; rf2-uheqq — `:after` chain + late-bind dispatch. Shared with the
-    ;; canned-stub reply path (`http-test-support/dispatch-canned-
-    ;; reply!`) via `middleware/run-after-then-dispatch!` (rf2-k67u3): the
+    ;; Live and canned replies share this `:after` + late-bind path. The
     ;; `:after` chain is skipped when no middleware-ctx is present
     ;; (synthetic / test-path callers).
     (middleware/run-after-then-dispatch!
@@ -113,20 +110,18 @@
        ;; reads it as causal data, never a fresh clock.
        :completed-at   completed-at})))
 
-;; rf2-zqefg3.2 / rf2-ibksxg — the canonical-reply lowering seam (EP-0011).
-;; Every completion (success / failure / abort) flows through ONE canonical
+;; Every completion (success, failure, or abort) flows through one canonical
 ;; reply map built in `re-frame.http.reply` — `:status` (`:ok` / `:error` /
 ;; `:cancelled`), `:value` on `:ok`, the classified `:rf.http/*` failure map
 ;; verbatim under `:error`, `:rf.reply/work-id` `[:rf.work/http logical-id issuance
-;; attempt]` (rf2-azcmd3), `:rf.reply/work-kind :http`, `:rf.reply/work-status`, `:attempt`,
+;; attempt]`, `:rf.reply/work-kind :http`, `:rf.reply/work-status`, `:attempt`,
 ;; `:rf.frame/id`, `:completed-at`, and `:correlation {:request-id …}` (the
 ;; `:request-id` is correlation metadata, NOT a second stale-suppression key).
-;; rf2-ibksxg — that canonical reply is the SINGLE public artefact too: it is
-;; delivered to the app reply target verbatim. `:on-success` / `:on-failure`
+;; The same canonical reply is delivered to the app target verbatim.
+;; `:on-success` / `:on-failure`
 ;; are pure ROUTING sugar (both receive the canonical map) and the co-located
 ;; `(:rf/reply msg)` merge carries the canonical map under `:rf/reply`. The old
-;; `{:kind :success/:failure}` reshape (`reply->public-payload`) is DELETED —
-;; there is no compat dialect.
+;; reply addressing is routing sugar; it does not select a second payload dialect.
 
 (defn- reply-ctx
   "Project the transport ctx onto the data-only correlation/identity facts
@@ -135,19 +130,18 @@
   `:completed-at` (the reply handler MUST NOT re-read the clock —
   Managed-Effects §Causal completion metadata).
 
-  EP-0010 §Time (rf2-2elcw3): `:completed-at` is DURABLE causal time — it
+  `:completed-at` is durable causal time: it
   flows through `:rf.cofx` `:rf/time-ms` into resource `:loaded-at` /
   `:stale-at` and mutation `:settled-at`, which freshness readers compare
   against `js/Date.now`. It MUST therefore be wall-clock epoch ms
   (`epoch-now-ms`), NOT `now-ms` — on CLJS `now-ms` is `performance.now()`
   (origin-relative), so a `now-ms`-stamped `:stale-at` reads stale
-  immediately against `js/Date`. This is the transport boundary the
-  router's fresh-token fix (427f260d3 / rf2-n1rh0f) deliberately preserves
-  as the host-clock read; converting it here completes that fix."
+  immediately against `js/Date`. This transport boundary is the single
+  host-clock read for completion."
   [ctx]
   {:request-id   (:request-id ctx)
    :origin-event (:origin-event ctx)
-   ;; rf2-azcmd3 — the per-request-id issuance discriminator rides into the
+   ;; The per-request-id issuance discriminator rides into the
    ;; work-id so a superseded attempt and its superseder carry distinct ids.
    :issuance     (:issuance ctx)
    :attempt      (:attempt ctx)
@@ -155,7 +149,7 @@
    :completed-at (interop/epoch-now-ms)})
 
 (defn- self-identify
-  "rf2-1u9dja — stamp the four self-identifying fields (`:request
+  "Stamp the four self-identifying fields (`:request
   {:method :url}`, `:request-id`, `:attempt` / `:max-attempts`, `:work/id`)
   onto a classified `:rf.http/*` failure map from the request ctx, so the
   PUBLIC failure reply (and the trace that inherits it) names WHICH request
@@ -185,7 +179,7 @@
 ;; concurrency comments stay at the call sites.
 
 (defonce ^:private failure-swallowed-warned?
-  ;; rf2-rl5tt — one-shot latch so the "real failure swallowed by
+  ;; One-shot latch so the "real failure swallowed by
   ;; `:on-failure nil`" warning fires once per runtime, not once per
   ;; swallowed request. Fire-and-forget telemetry beacons (`:on-failure
   ;; nil`) are a legitimate steady-state pattern, so a per-request trace
@@ -195,10 +189,10 @@
   (atom false))
 
 (defn- warn-failure-swallowed!
-  "rf2-rl5tt — surface a swallowed REAL failure once per runtime.
+  "Surface a swallowed real failure once per runtime.
 
   When a request fails and its failure reply has no target — an explicit
-  `:on-failure nil`, or (post-rf2-et4c1s, the co-located default retired) a
+  `:on-failure nil`, or an
   failure branch left unaddressed — `build-reply-event` silences the reply
   (fire-and-forget). But a NON-aborted failure (transport / 5xx / decode /
   accept / timeout) routed into that silence is a real error the app never
@@ -232,7 +226,7 @@
 (defn- on-failure-silenced?
   "True when the ctx's failure reply has NO delivery target — `build-reply-
   event` produces no event, so a NON-aborted failure routed here is dropped
-  with no handler. Two shapes silence a failure (rf2-et4c1s), mirroring
+  with no handler. Two shapes silence a failure, mirroring
   `build-reply-event`'s nil-producing branches so the swallow-warning fires
   for precisely the replies that get dropped:
 
@@ -249,7 +243,7 @@
         (nil? (:value explicit)))))
 
 (defn- emit-reply-trace!
-  "rf2-zqefg3.2 — emit a managed-async completion trace row built from the
+  "Emit a managed-async completion trace row built from the
   CANONICAL reply-envelope facts (Managed-Effects §Tracing), not the
   private callback payload. The wire-bearing slots (`:value` / `:error` /
   `:correlation`) route through the shared `http-reply/trace-reply` →
@@ -260,8 +254,8 @@
   `:rf.http/*` trace rows."
   [ctx reply]
   (when interop/debug-enabled?
-    ;; rf2-ppkh3v — RESPONSE-BODY classification (EP-0015 §8, issue 5). The
-    ;; success reply's `:value` IS the decoded response body — a registration-
+    ;; The success reply's decoded body is classified through its schema
+    ;; before it reaches the trace stream. It is a registration-
     ;; owned transient payload classified per-slot via `:sensitive?` props on
     ;; the request's `:decode` SCHEMA (the EP-0005 mechanism). Apply those
     ;; per-slot marks to the value BEFORE it rides the trace, so a body slot
@@ -273,7 +267,7 @@
     ;; Only the success status carries a decoded body; failure / cancel carry
     ;; `:error`, untouched here. The schema's per-slot marks now cover BOTH
     ;; `:sensitive?` (→ `:rf/redacted`) and `:large?` (→ `:rf.size/large-elided`)
-    ;; (rf2-jhyccs — `classify-decoded` routes through the shared marks walker).
+    ;; through the shared marks walker.
     (let [reply' (if (and (= :ok (:status reply))
                           (contains? reply :value)
                           (privacy-body/schema-decode? (:decode ctx)))
@@ -287,7 +281,7 @@
       ;; sensitive request redacts its payload slots wholesale, matching the
       ;; existing `:rf.http/*` trace posture.
       ;;
-      ;; rf2-t55hxg.6 — OFF-BOX FAIL-CLOSED (EP-0015 disposition 5). The
+      ;; Off-box egress fails closed. The
       ;; on-box `:value` above is the dev-operator view (an unschematized body
       ;; rides raw — the local operator sees their own process). For OFF-BOX
       ;; egress an unschematized body is whole-sensitive and MUST be omitted.
@@ -304,7 +298,7 @@
                             (privacy-body/off-box-body-disposition (:decode ctx))))))))
 
 (defn emit-superseded-stale-trace!
-  "rf2-azcmd3 — emit the canonical EP-0011 `:status :stale` /
+  "Emit the canonical `:status :stale` /
   `:rf.reply/work-status :suppressed` reply-envelope trace for a SUPERSEDED HTTP
   attempt, WITHOUT dispatching any app target (Managed-Effects §Stale
   suppression — clauses 2/3/4: the superseded attempt's reply outcome becomes
@@ -358,16 +352,15 @@
 (defn- dispatch-failure!
   "Dispatch a `:failure` reply carrying `failure` as its `:failure` slot.
 
-  rf2-zqefg3.2 / rf2-ibksxg — the failure lowers through the canonical
-  reply envelope: the `:rf.http/*` failure map becomes a `:status :error`
+  The `:rf.http/*` failure map lowers through the canonical reply envelope as
+  `:status :error`
   (or `:status :cancelled` for an abort, `:rf.reply/work-status :timed-out` for a
   timeout) canonical reply (`http-reply/failure-reply`), a completion trace
   row is emitted from those canonical facts, and the SAME canonical reply is
   delivered to the app target — it threads through the `:after` chain +
-  late-bind dispatch verbatim (no `{:kind :failure}` reshape; the compat
-  layer was deleted).
+  late-bind dispatch verbatim.
 
-  rf2-rl5tt — when the reply is silenced by an explicit `:on-failure nil`
+  When the reply is silenced by an explicit `:on-failure nil`
   AND the failure is not an abort, surface it once via
   `warn-failure-swallowed!` before the (no-op) dispatch."
   [ctx failure]
@@ -383,12 +376,11 @@
 (defn- dispatch-success!
   "Dispatch a `:success` reply carrying `value` as its `:value` slot.
 
-  rf2-zqefg3.2 / rf2-ibksxg — the success lowers through the canonical
-  reply envelope: `value` becomes a `:status :ok` / `:rf.reply/work-status
+  `value` lowers through the canonical reply envelope as `:status :ok` /
+  `:rf.reply/work-status
   :completed` canonical reply (`http-reply/success-reply`), a completion
   trace row is emitted from those canonical facts, and the SAME canonical
-  reply is delivered to the app target verbatim (no `{:kind :success}`
-  reshape; the compat layer was deleted)."
+  reply is delivered to the app target verbatim."
   [ctx value]
   (let [reply (http-reply/success-reply (reply-ctx ctx) value)]
     (emit-reply-trace! ctx reply)
@@ -398,7 +390,7 @@
                             :completed-at  (:completed-at reply)))))
 
 (defn emit-actor-destroy-stale-trace!
-  "rf2-yrrpe2 — emit the canonical EP-0011 `:status :stale` /
+  "Emit the canonical `:status :stale` /
   `:rf.reply/work-status :suppressed` reply-envelope trace for an actor-destroy abort
   whose reply target is OBSOLETE (it addressed the destroyed actor itself),
   WITHOUT dispatching the app target (Managed-Effects §Cancellation /
@@ -435,7 +427,7 @@
   "The head (event-id) of the reply event an abort would dispatch: the
   explicit `:on-failure` vector's head when supplied, else the originating
   event-id (`resolve-origin-event`'s head). Used to decide whether an
-  actor-destroy abort's reply target is OBSOLETE (rf2-yrrpe2)."
+  actor-destroy abort's reply target is obsolete."
   [ctx]
   (let [explicit (:explicit-on-failure ctx)
         value    (:value explicit)]
@@ -445,10 +437,10 @@
 
 (defn- dispatch-aborted!
   "Emit the `:rf.http/aborted` trace + dispatch the abort reply for a
-  cancelled request, honouring rf2-lxd3 supersede suppression and the
-  rf2-yrrpe2 actor-destroy obsolete-target stale suppression.
+  cancelled request, honouring supersession and obsolete actor-target
+  suppression.
 
-  Shared by BOTH cancellation states (rf2-wj8vv):
+  Shared by both cancellation states:
    - the in-flight-fetch abort-fn in `run-attempt!` (a fetch / future is
      live), and
    - the backoff-sleeping abort-fn in `maybe-retry!` (no fetch is live;
@@ -465,7 +457,7 @@
   through `maybe-retry!` → `finalise-failure!`, never here. `ctx` must
   carry `:request-id`, `:actor-id`, `:url`, `:sensitive?`.
 
-  Per Managed-Effects §Cancellation (rf2-yrrpe2): an `:actor-destroyed`
+  Per Managed-Effects §Cancellation, an `:actor-destroyed`
   abort whose reply target is OBSOLETE — its event-id names the destroyed
   actor itself (the machine-shape wrapper's `[self-id [:rf.http/failed]]`
   default, or any request whose default reply addresses its own actor) — does
@@ -475,7 +467,7 @@
   `:actor-destroyed` abort whose target is an ORDINARY (still-meaningful)
   event keeps the live failure delivery, as do explicit `:user` aborts."
   [ctx reason]
-  ;; rf2-1u9dja — the aborted failure is self-identifying too (`:request` /
+  ;; The aborted failure is self-identifying too (`:request` /
   ;; `:request-id` / `:attempt` / `:max-attempts` / `:work/id`), so both the
   ;; `:rf.http/aborted` trace and the delivered `:status :cancelled` reply name
   ;; which request was cancelled. `:rf.http/aborted` is the eighth category.
@@ -492,7 +484,7 @@
                          sensitive?
                          {:frame (:frame ctx)})]
         (trace/emit-error! :rf.http/aborted redacted)))
-    ;; rf2-k47b3d — an abort is TERMINAL for this request-id (this is the
+    ;; An abort is terminal for this request-id (this is the
     ;; direct abort-fn choke: user / actor-destroy / supersede / epoch-restore
     ;; all land here). Evict the issuance counter so an unbounded distinct-id
     ;; space does not accumulate a permanent entry. Conditional-atomic: a
@@ -501,7 +493,7 @@
     ;; genuinely-quiescent id is dropped.
     (registry/evict-issuance-on-completion! (:request-id ctx) (:issuance ctx))
     (cond
-      ;; Per rf2-lxd3 (supersede) / rf2-u5kmf8 (epoch-restore) — these reasons
+      ;; Supersede and epoch-restore reasons
       ;; suppress the reply (the cancellation replaces the original outcome; the
       ;; superseded attempt's canonical stale trace is emitted by
       ;; `emit-superseded-stale-trace!` at supersede time, the restore-suppressed
@@ -509,7 +501,7 @@
       (reply-suppressing-abort-reason? reason)
       nil
 
-      ;; Per rf2-yrrpe2 — an actor-destroy abort whose reply target is
+      ;; An actor-destroy abort whose reply target is
       ;; OBSOLETE (it addresses the destroyed actor itself) suppresses the app
       ;; delivery as a canonical `:status :stale` / `:rf.reply/work-status :suppressed`
       ;; outcome (Managed-Effects §Cancellation). The app target MUST NOT run.
@@ -525,7 +517,7 @@
       (dispatch-failure! ctx failure))))
 
 (defn- already-replied?
-  "rf2-on7sj — the once-only reply guard. The handle carries a
+  "The once-only reply guard. The handle carries a
   `:finalised?` atom stamped at `record-in-flight!` time; the abort
   path AND the natural-completion paths both reach `finalise-*` and
   must NOT both dispatch a reply for the same request. CAS the flag
@@ -542,9 +534,8 @@
     (not (compare-and-set! flag false true))))
 
 (defn- aborted-snapshot
-  "rf2-wez75 — abort-always-wins precedence (Mike decision a, aligned with
-  Fetch AbortController / Node HTTP / JVM HttpClient / gRPC universal
-  convention). Returns the abort-state map `{:reason :actor-id}` if the
+  "Abort-always-wins precedence. Returns the abort-state map
+  `{:reason :actor-id}` if the
   handle's `:aborted?` atom has been flipped (by either `:rf.http/managed-
   abort` user-aborts OR `abort-on-actor-destroy` per Spec 014 §Abort on
   actor destroy), else nil. Read once at finalise-* entry so the late-
@@ -564,13 +555,13 @@
    :actor-id   (or (:actor-id abort-state) (:actor-id ctx))})
 
 (defn- emit-and-dispatch-failure!
-  "rf2-sixs3 — the failure-finalise TAIL: rf2-bma05 redaction →
-  `trace/emit-error!` → supersede-suppressed `dispatch-failure!`.
+  "Shared failure-finalisation tail: privacy composition, trace emission,
+  then suppression-aware reply dispatch.
 
   PRECONDITION: the caller already holds the once-only `:finalised?`
   token (won the CAS / no handle) AND has already cleared the in-flight
   registry. This helper deliberately does NEITHER — it is the shared
-  source of truth for the rf2-bma05 redaction shape + the supersede-
+  source of truth for the redaction shape and supersede-
   suppression guard, called from BOTH:
     - `finalise-failure!` (the canonical site), and
     - `finalise-success!`'s sample-(2) abort path (which has already won
@@ -578,16 +569,11 @@
       `finalise-failure!` — that would double-clear + re-check
       `already-replied?`).
 
-  Before this extraction the prepare-emit-failure / emit-error! /
-  suppress sequence was duplicated inline at both sites and could drift
-  (e.g. a future privacy slot added to one but not the other). Now the
-  redaction contract exists once.
-
-  Per rf2-lxd3: a supersede (`:rf.http/aborted` with
+  A supersede (`:rf.http/aborted` with
   `:reason :request-id-superseded`) emits to the trace bus but does NOT
   dispatch the `:on-failure` reply — the new request replaces the old.
 
-  rf2-1u9dja — the failure map is made SELF-IDENTIFYING (`:request
+  The failure map is made self-identifying (`:request
   {:method :url}` / `:request-id` / `:attempt` / `:max-attempts` /
   `:work/id`) here, ONCE, so both the emitted trace AND the dispatched
   reply carry the identity — the trace inherits it for free and the app
@@ -595,7 +581,7 @@
   [ctx failure]
   (let [failure (self-identify failure ctx)]
   (when interop/debug-enabled?
-    ;; rf2-bma05 — redact response-side payload slots (body, body-text,
+    ;; Redact response-side payload slots (body, body-text,
     ;; decoded, detail) and the headers denylist before the trace surface
     ;; sees them; stamp :sensitive? when applicable. The CLJS and JVM
     ;; transports share the same contract.
@@ -1294,7 +1280,7 @@
         ;; CompletableFuture so the work actually stops (not just the
         ;; reply path).
         finalised? (atom false)
-        ;; rf2-wez75 — abort-precedence cell. The abort-fn flips this
+        ;; The abort closure flips this precedence cell
         ;; BEFORE racing the once-only `:finalised?` CAS, so even if a
         ;; synchronously-completing decode wins the CAS, the finalise-*
         ;; entry sees the abort snapshot and reclassifies the reply as
@@ -1304,13 +1290,13 @@
         ;; actor-destroy was the source) is reconstructable inside
         ;; finalise-failure! without re-deriving from `failure`.
         aborted?   (atom nil)
-        ;; rf2-on7sj (JVM) — the abort-fn closure must `.cancel cf true`
+        ;; On the JVM the abort closure must `.cancel cf true`
         ;; on the underlying CompletableFuture, but cf only exists AFTER
         ;; this binding (built inside the try-body below). Forward via a
         ;; one-cell atom that the JVM body fills after construction; the
         ;; abort-fn reads it lazily through `@cf-holder`.
         #?@(:clj  [cf-holder (atom nil)])
-        ;; rf2-lz7se — forward-reference cell for the stamped handle.
+        ;; Forward-reference cell for the stamped handle.
         ;; The abort-fn's registry cleanup must pass the handle to the
         ;; 2-arg `clear-in-flight!` so the actor-in-flight slot is cleared
         ;; by identity regardless of whether `request-id` is non-nil
@@ -1325,12 +1311,11 @@
         handle-holder (atom nil)
         ;; Register the abort handle. The handle ref is stamped into ctx
         ;; so finalise-* can clear it from both indexes without needing
-        ;; the request-id (handles anonymous-from-actor requests too —
-        ;; rf2-wvkn).
+        ;; the request-id, including anonymous actor-owned requests.
         handle   (registry/record-in-flight!
                    request-id actor-id
                    {:abort-fn (fn [reason]
-                                ;; rf2-wez75 — flip `:aborted?` BEFORE the
+                                ;; Flip `:aborted?` before the
                                 ;; once-only CAS so that a concurrently-
                                 ;; running finalise-* (decode-failure,
                                 ;; transport, http-5xx, success) that wins
@@ -1350,7 +1335,7 @@
                                 ;; of which side flipped first.
                                 (reset! aborted? {:reason   reason
                                                   :actor-id actor-id})
-                                ;; rf2-on7sj — single-shot CAS guard.
+                                ;; Single-shot CAS guard.
                                 ;; A re-entrant abort (e.g. supersede +
                                 ;; actor-destroy firing in rapid
                                 ;; succession against the same handle)
@@ -1362,7 +1347,7 @@
                                          (.abort internal-controller (clj->js reason)))
                                        (catch :default _ nil))
                                      :clj
-                                     ;; rf2-on7sj — cancel the underlying
+                                     ;; Cancel the underlying
                                      ;; future so it stops running. The
                                      ;; CompletableFuture's whenComplete
                                      ;; will still fire (with a
@@ -1374,7 +1359,7 @@
                                      (when-let [^CompletableFuture cf @cf-holder]
                                        (try (.cancel cf true)
                                             (catch Throwable _ nil))))
-                                  ;; rf2-lz7se — Registry cleanup happens
+                                  ;; Registry cleanup happens
                                   ;; here once; finalise-failure! is
                                   ;; bypassed. Pass the stamped handle (via
                                   ;; `@handle-holder`) so the 2-arg form
@@ -1386,17 +1371,9 @@
                                   ;; actor-destroy) AND for anonymous
                                   ;; (request-id-less) requests, whose
                                   ;; handle is indexed ONLY in
-                                  ;; actor-in-flight. The earlier 1-arg
-                                  ;; form resolved by request-id and
-                                  ;; no-op'd on a nil id — correct only
-                                  ;; under the implicit, load-bearing
-                                  ;; invariant that an anonymous request
-                                  ;; can be aborted solely via
-                                  ;; actor-destroy (which pre-clears the
-                                  ;; actor slot). Passing the handle drops
-                                  ;; that fragility: the 2-arg
-                                  ;; remove-from-actor-index! is an
-                                  ;; identity-based vector remove that
+                                  ;; actor-in-flight. The 2-arg
+                                  ;; `clear-in-flight!` performs an
+                                  ;; identity-based actor-index remove that
                                   ;; no-ops against an already-cleared
                                   ;; (or absent) slot, so it is a safe
                                   ;; idempotent no-op on the actor-destroy
@@ -1405,8 +1382,7 @@
                                   ;; any future trigger that does not
                                   ;; pre-clear.
                                   (registry/clear-in-flight! request-id @handle-holder)
-                                  ;; rf2-on7sj / rf2-wj8vv — the abort-fn
-                                  ;; dispatches a synthesised reply directly
+                                  ;; The abort closure dispatches a synthesised reply directly
                                   ;; (no finalise-failure! re-entry). The
                                   ;; shared `dispatch-aborted!` reuses the
                                   ;; same trace-emit + reply shape the
@@ -1419,12 +1395,12 @@
                                   ;; owner.
                                   (dispatch-aborted! ctx-no-handle reason)))
                     :url url
-                    ;; rf2-on7sj — once-only reply guard, see comment above.
+                    ;; Once-only reply guard, see comment above.
                     :finalised? finalised?
-                    ;; rf2-wez75 — abort-precedence cell read at finalise-*
+                    ;; Abort-precedence cell read at finalise-*
                     ;; entry. See the `aborted?` binding above.
                     :aborted?   aborted?
-                    ;; rf2-bma05 — propagate the :sensitive? flag onto
+                    ;; Propagate the :sensitive? flag onto
                     ;; the in-flight handle so the actor-destroy abort
                     ;; emit (lives in the registry ns) can stamp the
                     ;; trace event without re-resolving registration
@@ -1432,24 +1408,24 @@
                     :sensitive? (true? (:sensitive? ctx))
                     ;; Carry the originating frame for the actor-destroy abort
                     ;; trace's frame stamp. HTTP carrier redaction is
-                    ;; process-global now (the :rf.http/managed `:carriers`
-                    ;; registration, EP-0025) — no longer frame-resolved.
+                    ;; process-global through the `:rf.http/managed`
+                    ;; registration; the frame is for trace attribution.
                     :frame      (:frame ctx)
-                    ;; rf2-azcmd3 — carry the superseded attempt's reply-ctx
+                    ;; Carry the superseded attempt's reply context
                     ;; identity facts on the handle so `supersede!` can build
                     ;; this (now-stale) attempt's canonical `:status :stale`
                     ;; reply-envelope trace when a fresh request replaces it.
                     :origin-event (:origin-event ctx)
                     :issuance     (:issuance ctx)
                     :attempt      (:attempt ctx)})
-        ;; rf2-lz7se — publish the stamped handle so the abort-fn closure
+        ;; Publish the stamped handle so the abort closure
         ;; (defined above, before `handle` was bound) can pass it to the
         ;; 2-arg `clear-in-flight!` via `@handle-holder`. The reset!
         ;; happens synchronously here, before any fetch is issued, so the
         ;; cell is always populated by the time any abort can fire.
         _        (reset! handle-holder handle)
         ctx'     (assoc ctx-no-handle :handle handle)
-        ;; rf2-065xo — managed request-preparation PHASE. Runs AFTER the
+        ;; Request preparation runs after the
         ;; handle is registered (so abort precedence, the once-only reply
         ;; guard, and registry cleanup all apply to a prep failure exactly
         ;; as they do to a network failure) but BEFORE the platform fetch is
@@ -1479,25 +1455,25 @@
                             :timeout-ms          timeout-ms
                             :abort-signal        abort-signal
                             :internal-controller internal-controller
-                            ;; rf2-5zj6t — the transport picks the Fetch
+                            ;; The transport picks the Fetch
                             ;; body-reader (`.text()` vs `.blob()` /
                             ;; `.arrayBuffer()` / `.formData()`) from the
                             ;; resolved decode mode; pass it through.
                             :decode              (:decode ctx)
-                            ;; rf2-f5pguu — thread `:sensitive?` + `:frame` so a
+                            ;; Thread `:sensitive?` and `:frame` so a
                             ;; Fetch `Headers.append` validation throw surfaces
                             ;; as a redacted `:rf.warning/http-header-invalid`
-                            ;; trace (URL privacy-composed, frame-local carriers
-                            ;; honoured) instead of escaping as a generic
+                            ;; trace (with registration-owned carriers applied)
+                            ;; instead of escaping as a generic
                             ;; `:rf.error/fx-handler-exception`. Same shape the
                             ;; JVM branch threads into `jvm-fetch` below.
                             :sensitive?          (true? (:sensitive? ctx))
                             :frame               (:frame ctx)})
                (.then (fn [result] (handle-response! ctx' result)))
-               ;; rf2-r40km — pass `url` so `classify-cljs-error` can
+               ;; Pass `url` so `classify-cljs-error` can
                ;; distinguish `:rf.http/cors` from `:rf.http/transport`
                ;; via the cross-origin heuristic.
-               ;; rf2-on7sj — when the abort-fn fired and dispatch-aborted!
+               ;; When the abort closure fired and dispatch-aborted!
                ;; already replied, the Fetch promise still rejects (because
                ;; `.abort internal-controller` rejects the underlying
                ;; fetch); this .catch would call `maybe-retry!` →
@@ -1509,7 +1485,7 @@
                (.catch (fn [err]
                          (maybe-retry! ctx' (transport-cljs/classify-cljs-error err url)))))
            :clj
-           ;; rf2-a3wxe — monotonic start mark for the per-host timeout
+           ;; Monotonic start mark for the per-host timeout
            ;; `:elapsed-ms`. `System/nanoTime` is the JDK's monotonic clock
            ;; (immune to wall-clock adjustments); the delta is converted to
            ;; whole milliseconds at the failure site. Captured BEFORE the
@@ -1524,30 +1500,29 @@
                                  :headers    headers
                                  :body       enc-body
                                  :timeout-ms timeout-ms
-                                 ;; rf2-a3wxe — thread the resolved `:decode`
+                                 ;; Thread the resolved `:decode`
                                  ;; so `jvm-fetch` can read the response body
                                  ;; with `ofByteArray` for binary decode modes
                                  ;; (`:blob` / `:array-buffer` / `:form-data`)
                                  ;; and ride the raw bytes under `:body-binary`
                                  ;; instead of the lossy String fallback.
                                  :decode     (:decode ctx)
-                                 ;; rf2-ee38b.7 — honour the spec's `:redirect`
+                                 ;; Honour the spec's `:redirect`
                                  ;; envelope key on the JVM (default `:follow`).
                                  ;; Selects the redirect-policy-specific client.
                                  :redirect   (:redirect request)
                                  :sensitive? (true? (:sensitive? ctx))
-                                 ;; rf2-ppkh3v — the originating frame so the
-                                 ;; per-header validation warning's URL
-                                 ;; redaction consults the frame's frame-local
-                                 ;; HTTP carriers (EP-0015 §3).
+                                 ;; The originating frame stamps the warning and
+                                 ;; supplies its general elision policy; HTTP
+                                 ;; carrier names come from effect registration.
                                  :frame      (:frame ctx)})]
-                 ;; rf2-on7sj — publish cf to the abort-fn closure's holder
+                 ;; Publish cf to the abort closure's holder
                  ;; BEFORE wiring whenComplete. A racing abort that arrives
                  ;; between `jvm-fetch` returning and `.whenComplete`
                  ;; registering still finds cf in the holder and can cancel
                  ;; it.
                  (reset! cf-holder cf)
-                 ;; rf2-on7sj — the whenComplete callback fires even after
+                 ;; The whenComplete callback fires even after
                  ;; `.cancel cf true`: the cancel completes-exceptionally
                  ;; with a CancellationException, which routes through this
                  ;; BiConsumer as `throwable`. `maybe-retry!` →

--- a/implementation/http/src/re_frame/http/transport_cljs.cljc
+++ b/implementation/http/src/re_frame/http/transport_cljs.cljc
@@ -1,8 +1,7 @@
 (ns re-frame.http.transport-cljs
   "CLJS (Fetch-API) platform adapter for `:rf.http/managed`.
 
-  Extracted from `re-frame.http.transport` per rf2-hp772l — the platform
-  transports were extracted into per-platform sibling namespaces so the
+  Platform transport details live here so the
   shared attempt-and-retry lifecycle (`re-frame.http.transport`) reads as
   platform-neutral Clojure and each platform's reader-conditional code has
   a named home.
@@ -17,7 +16,7 @@
   Everything here is `#?(:cljs …)` — on the JVM this namespace loads as
   effectively empty (the shared lifecycle only calls these fns under its
   `:cljs` reader branch). Keeping the conditionals local to the adapter is
-  the rf2-hp772l contract: the shared loop carries no CLJS interop."
+  this boundary keeps CLJS interop out of the shared loop."
   (:require [clojure.string         :as str]
             [re-frame.error         :as error]
             [re-frame.http.decode   :as decode]
@@ -32,10 +31,10 @@
    (defn- fetch-headers->map
      "Flatten a Fetch `Headers` object into a plain Clojure map, matching
      the JVM transport's `jvm-headers->map` response-headers SHAPE
-     contract (rf2-0xvm1 / Spec 014 §Request envelope: `string → string`,
+     contract (Spec 014 §Request envelope: `string → string`,
      or `string → vector of strings` for a multi-valued header).
 
-     rf2-wmdmou — cross-host `Set-Cookie` parity. `Headers.forEach`
+     `Headers.forEach`
      iterates ONE pair per (case-folded) name with multi-valued headers
      COMMA-FOLDED into a single string — and for `Set-Cookie` specifically
      the Fetch spec keeps it OUT of the combined view (`forEach` yields
@@ -45,9 +44,8 @@
      response decoded to a 2-element `[\"session=…\" \"csrf=…\"]` vector on
      the JVM but a single (last-cookie-only) string on CLJS, silently
      LOSING the first `Set-Cookie` and comma-folding any other repeated
-     header. Comma-folding `Set-Cookie` is itself an RFC 6265 §3 violation
-     (cookie attribute values legally embed commas — `Expires=Wed, 21 Oct
-     …`), the exact hazard rf2-0xvm1 fixed on the JVM.
+     header. Comma-folding `Set-Cookie` is invalid because cookie attribute
+     values may themselves contain commas.
 
      The Fetch API exposes `Headers.getSetCookie()` precisely to recover
      the unfolded `Set-Cookie` lines (browser + Node 18.7+ / undici). We
@@ -63,7 +61,7 @@
        (.forEach fetch-headers
                  (fn [v k] (aset out k v)))
        (let [m (js->clj out)
-             ;; rf2-wmdmou — recover the unfolded `Set-Cookie` lines so the
+             ;; Recover the unfolded `Set-Cookie` lines so the
              ;; shape matches the JVM (single → string, multi → vector of
              ;; the verbatim wire lines, every line preserved).
              set-cookies (when (fn? (.-getSetCookie fetch-headers))
@@ -79,64 +77,46 @@
      to `{:ok? bool :status N :status-text S :headers M :body-text S}` on
      transport-OK, or rejects with an ex-info classified by the caller.
 
-     Per rf2-1jcpm — the per-attempt timeout fires regardless of whether
+     The per-attempt timeout fires regardless of whether
      the caller supplied `:abort-signal`. We always own
      `internal-controller`; when the caller also supplies `:abort-signal`,
      its `abort` event is forwarded to our controller, so:
 
      - the caller can still cancel via their own signal, AND
-     - the timeout still arms (previously the timeout was silently
-       disabled the moment a caller signal arrived, even when the args
-       map carried a `:timeout-ms` and/or the security default — round-2
-       security audit finding 2).
+     - the timeout still arms.
 
      The single `signal` Fetch accepts is always our internal one; any
      caller signal funnels through `addEventListener` for cancellation.
 
-     Per rf2-f5pguu — `:sensitive?` + `:frame` are carried only so an
+     `:sensitive?` and `:frame` are carried only so an
      invalid request header (a `Headers.append` `TypeError` on a bad name
      or a CR/LF value) can be surfaced as a redacted `:rf.warning/http-
      header-invalid` trace (omit the bad pair, continue) rather than
      ESCAPING the managed path as `:rf.error/fx-handler-exception` — the
      same managed-error contract `jvm-build-request` already honours on
-     the JVM (rf2-9lun0 / rf2-1jcpm)."
+     the JVM."
      [{:keys [method url headers body credentials mode redirect cache referrer
               integrity timeout-ms abort-signal internal-controller decode
               sensitive? frame]}]
      (let [init     #js {}
            _        (do (aset init "method" (str/upper-case (name method)))
                         (when (seq headers)
-                          ;; rf2-rznrz — build a Fetch `Headers` object and
+                          ;; Build a Fetch `Headers` object and
                           ;; `.append` each normalised wire pair. A scalar
                           ;; header value yields one pair; a vector/seq value
                           ;; yields one pair per element (`encoding/normalize-
                           ;; header-pairs`), and `.append` ACCUMULATES repeated
                           ;; names into the multi-valued wire form (`Accept: a`
-                          ;; + `Accept: b`) rather than overwriting. The prior
-                          ;; shape assigned the vector straight into a plain JS
-                          ;; object via `aset`, so a documented multi-valued
-                          ;; request header serialised as a single malformed
-                          ;; `[\"a\" \"b\"]` wire value.
+                          ;; + `Accept: b`) rather than overwriting.
                           ;;
-                          ;; rf2-f5pguu — surface a Fetch `Headers.append`
+                          ;; Surface a Fetch `Headers.append`
                           ;; validation throw via a `:rf.warning/http-header-
                           ;; invalid` trace rather than letting it ESCAPE the
                           ;; managed HTTP path. The Fetch `Headers` `.append`
                           ;; rejects an invalid header name (empty, control
                           ;; chars, separators) or a value carrying `\r`/`\n`
                           ;; (the response-splitting guard) by throwing a
-                          ;; `TypeError`. Pre-fix that throw fired SYNCHRONOUSLY
-                          ;; inside `cljs-fetch` — AFTER the in-flight handle was
-                          ;; registered (rf2-065xo records it before transport
-                          ;; setup) but BEFORE any Promise existed to `.catch`,
-                          ;; so it propagated up through `run-attempt!`'s CLJS
-                          ;; branch (which — unlike the JVM branch — has no
-                          ;; try/catch around the transport call) and surfaced
-                          ;; as a generic `:rf.error/fx-handler-exception`,
-                          ;; bypassing `:on-failure`, retry, abort precedence,
-                          ;; trace privacy, and in-flight registry cleanup. This
-                          ;; now mirrors the JVM `jvm-build-request` (rf2-9lun0 /
-                          ;; rf2-1jcpm): catch PER `.append`, emit the redacted
+                          ;; `TypeError`. Catch per `.append` and emit the redacted
                           ;; warning naming the offending header (value omitted —
                           ;; values may carry secrets; URL routed through
                           ;; `privacy/prepare-emit-tags` so a denylisted query
@@ -171,7 +151,7 @@
                         (when integrity    (aset init "integrity"   integrity))
                         (when internal-controller
                           (aset init "signal" (.-signal internal-controller)))
-                        ;; rf2-1jcpm — forward caller's abort-signal into
+                         ;; Forward the caller's abort-signal into
                         ;; our internal controller so the timeout still
                         ;; fires when a caller signal is present.
                         (when (and abort-signal internal-controller)

--- a/implementation/http/src/re_frame/http/transport_jvm.cljc
+++ b/implementation/http/src/re_frame/http/transport_jvm.cljc
@@ -1,8 +1,7 @@
 (ns re-frame.http.transport-jvm
   "JVM (`java.net.http.HttpClient`) platform adapter for `:rf.http/managed`.
 
-  Extracted from `re-frame.http.transport` per rf2-hp772l — the platform
-  transports were extracted into per-platform sibling namespaces so the
+  Platform transport details live here so the
   shared attempt-and-retry lifecycle (`re-frame.http.transport`) reads as
   platform-neutral Clojure and each platform's reader-conditional code has
   a named home.
@@ -24,8 +23,7 @@
 
   The JDK-interop forms are `#?(:clj …)` — on CLJS this namespace loads as
   effectively empty save the `check-cljs-only-keys!` no-op. Keeping the
-  conditionals local to the adapter is the rf2-hp772l contract: the shared
-  loop carries no JDK interop."
+  conditionals local to the adapter keeps JDK interop out of the shared loop."
   (:require [clojure.string         :as str]
             [re-frame.http.decode   :as decode]
             [re-frame.http.encoding :as encoding]
@@ -41,12 +39,7 @@
                    [java.time Duration]
                    [java.util.concurrent CompletableFuture])))
 
-;; rf2-b45uc — reflection warnings ON in the densest JVM-interop ns of
-;; the http surface (HttpClient, HttpRequest, BodyPublishers, HttpHeaders,
-;; CompletableFuture). The code is type-hinted today; the flag is the
-;; tripwire that catches a future un-hinted interop call compiling to
-;; reflective dispatch — exactly where interop is densest. CLJS ignores
-;; the form.
+;; Reflection warnings catch unhinted calls in this interop-heavy namespace.
 #?(:clj (set! *warn-on-reflection* true))
 
 ;; ---- platform transport: JVM java.net.http.HttpClient ---------------------
@@ -88,7 +81,7 @@
      fails fast instead of leaning on the per-request timeout. The
      redirect policy is a per-CLIENT setting on the JDK (not per-request),
      so we memoise one client per distinct policy (`jvm-http-clients`)
-     to preserve connection pooling per rf2-ee38b.7."
+     to preserve connection pooling."
      [^HttpClient$Redirect policy]
      (-> (HttpClient/newBuilder)
          (.connectTimeout (Duration/ofSeconds 10))
@@ -128,11 +121,11 @@
      opt-out — see the inline note), and sets each header individually
      so a JDK header-validation throw can be isolated to the offending
      header (surfaced as a `:rf.warning/http-header-invalid` trace rather
-     than sinking the whole request — rf2-9lun0). `sensitive?` is carried
+     than sinking the whole request). `sensitive?` is carried
      only so that warning's `:url` can be routed through the privacy
-     composer (rf2-1jcpm).
+     composer.
 
-     rf2-4y04lq — a RELATIVE `url` (e.g. `\"/api/items\"`) is rejected here
+     A relative `url` (e.g. `\"/api/items\"`) is rejected here
      with a clear `ex-info` before the JDK ever sees it. The browser Fetch
      transport resolves a relative url against the page's document base;
      the JVM has no such base. Left unchecked, `HttpRequest/newBuilder`
@@ -175,7 +168,7 @@
        (when (and timeout-ms (pos? timeout-ms))
          (.timeout b (Duration/ofMillis (long timeout-ms))))
        (doseq [[k v] (encoding/normalize-header-pairs headers)]
-         ;; rf2-9lun0 — surface JDK HttpClient header-validation throws
+         ;; Surface JDK HttpClient header-validation throws
          ;; via a `:rf.warning/http-header-invalid` trace rather than
          ;; silently dropping. Stray `\r`/`\n` / control chars / empty
          ;; name / forbidden header (`Host`, `Connection`, …) all hit
@@ -185,20 +178,16 @@
          ;; the offending header so a stray bad header doesn't sink
          ;; an otherwise-valid request; the trace is the alarm.
          ;;
-         ;; rf2-rznrz — `encoding/normalize-header-pairs` expands a
+         ;; `encoding/normalize-header-pairs` expands a
          ;; documented multi-valued request header (string → vector of
          ;; strings) into one `[name value]` pair per element, so we call
          ;; `.header` ONCE PER VALUE — the JDK accumulates repeated names
          ;; into the multi-valued wire form (`Accept: a` + `Accept: b`).
-         ;; The prior `(str v)` on the whole value stringified a vector
-         ;; into a single malformed `[\"a\" \"b\"]` header line.
          ;;
-         ;; rf2-1jcpm — the `:url` slot on the warning event is routed
+         ;; The warning's `:url` is routed
          ;; through `privacy/prepare-emit-tags` so a denylisted query
          ;; param (`?api_key=…`) is scrubbed and `:sensitive?` is
-         ;; stamped when the request is sensitive. Previously the raw
-         ;; URL rode the trace surface even when the handler / request
-         ;; was declared sensitive.
+          ;; stamped when the request is sensitive.
          (try (.header b k v)
               (catch Throwable t
                 (when interop/debug-enabled?
@@ -381,13 +370,11 @@
 #?(:clj
    (defn- emit-cljs-only-skipped! [k url sensitive? frame]
      (when interop/debug-enabled?
-       ;; rf2-1jcpm — route through the privacy composer so a denylisted
+       ;; Route through the privacy composer so a denylisted
        ;; query param in the URL is scrubbed and `:sensitive?` is stamped
-       ;; on the warning event when the originating handler / request is
-       ;; sensitive. Previously the raw URL rode the trace surface.
-       ;; rf2-ppkh3v — the originating frame is threaded so the URL
-       ;; redaction also honours the frame's frame-local query-param
-       ;; carriers (EP-0015 §3).
+       ;; on the warning event when the request is
+       ;; sensitive. The frame supplies general trace attribution and elision;
+       ;; HTTP carrier names come from the effect registration.
        (trace/emit! :warning :rf.http/cljs-only-key-ignored-on-jvm
                     (privacy/prepare-emit-tags
                       {:key k :url url}
@@ -399,7 +386,7 @@
      ([args sensitive?] (check-cljs-only-keys! args sensitive? nil))
      ([{:keys [request abort-signal decode]} sensitive? frame]
      (let [url (:url request)]
-       ;; rf2-ee38b.7 — `:credentials` joins the JVM-degraded set. Unlike
+       ;; `:credentials` is a JVM-degraded key. Unlike
        ;; `:redirect` (now honoured on JVM via the redirect-policy client),
        ;; the browser same-origin/include cookie model has no faithful
        ;; `HttpClient` analogue — the shared client configures no
@@ -407,14 +394,13 @@
        ;; of the value. Rather than silently no-op, emit the standard
        ;; `:rf.http/cljs-only-key-ignored-on-jvm` trace so the dropped key
        ;; is visible to off-box monitors. Spec 014 §JVM degradation table
-       ;; carries the `:credentials` row (rf2-t5mzx) so the table and the
-       ;; shipped behaviour agree.
+       ;; carries the corresponding row so the table and runtime agree.
        (doseq [k [:mode :cache :referrer :integrity :credentials]]
          (when (contains? request k)
            (emit-cljs-only-skipped! k url sensitive? frame)))
        (when abort-signal
          (emit-cljs-only-skipped! :abort-signal url sensitive? frame))
-       ;; rf2-a3wxe — binary decode SHAPE-degradation notice on JVM.
+       ;; Binary decode has a host-specific result shape on the JVM.
        ;; A `:blob` / `:array-buffer` / `:form-data` decode is now HONOURED
        ;; on the JVM (jvm-fetch reads `ofByteArray` and rides the raw bytes
        ;; — no more lossy String fallback), but the returned value is a

--- a/implementation/http/src/re_frame/http/url.cljc
+++ b/implementation/http/src/re_frame/http/url.cljc
@@ -1,38 +1,34 @@
 (ns re-frame.http.url
-  "URL handling for the http artefact — query-string redaction surface
-  (Spec 014 §Privacy, rf2-2p8wr) plus the query-param denylist.
+  "URL handling for the HTTP artefact: query-string redaction and the
+  query-param denylist (Spec 014 §Privacy).
 
   This namespace owns URL *redaction / scrubbing* for the http artefact
   (split, walk, redact, denylist). URL *building* — `url-encode`,
-  `params->query`, `merge-params` — lives in `re-frame.http.encoding`
-  (the rf2-5ijhk encoding split). The two halves stay separate: redaction
+  `params->query`, `merge-params` — lives in `re-frame.http.encoding`.
+  The two halves stay separate: redaction
   is a privacy-leaf surface, building is an encoding concern.
 
-  ## Query-param denylist (rf2-2p8wr)
+  ## Query-param denylist
 
   `default-query-param-denylist` covers the canonical query-string-auth
   surface (api_key, apikey, access_token, auth, token, key, secret,
   password, session, signature, sig). These built-in names are an
   **immutable framework default** — no frame can remove one.
 
-  ## App-specific carriers ride the :rf.http/managed registration (EP-0025)
+  ## App-specific carriers
 
   An app extends the denylist with its own sensitive query-param names
   (e.g. `shop_token`, webhook `signature` variants) on the
-  `:rf.http/managed` `reg-fx` registration metadata — the `:carriers` block
-  (the EP-0025 transient-payload case), not through a process-global
-  mutation or a frame annotation:
+  `:rf.http/managed` `reg-fx` registration metadata, not through a mutable
+  global or frame annotation:
 
       (rf/reg-fx :rf.http/managed
         {:carriers {:query-params [\"shop_token\"]}}
         http-managed/managed-handler)
 
   `re-frame.http.privacy/managed-carriers` lowers the `:carriers` names to a
-  lower-cased extension set, which the redactors UNION onto the immutable
-  built-in defaults. The earlier frame `:sensitive {:http {:query-params […]}}`
-  block and the process-global `declare-sensitive-query-param!` /
-  `clear-sensitive-query-params!` surface are both removed — the managed-HTTP
-  registration owns app-specific carriers now (EP-0025 §HTTP carriers).
+  lower-cased extension set, which the redactors union onto the immutable
+  built-in defaults.
 
   ## Redaction shape
 
@@ -59,23 +55,23 @@
 ;; it as a payload value. Consumers wanting "was this redacted?" check
 ;; `(= :rf/redacted v)`.
 ;;
-;; rf2-qe237 — the single source of truth is now `re-frame.privacy/
-;; redacted-sentinel` in core (already consumed by elision / marks). Core is
+;; `re-frame.privacy/redacted-sentinel` in core is the single source of truth.
+;; Core is
 ;; on the http classpath, so this artefact refers to the canonical def
 ;; rather than re-declaring the keyword literal. `http-url` remains the
 ;; http-side re-export anchor — it is the privacy leaf with no intra-privacy
 ;; dependencies, so `http-privacy` and `http-privacy-headers` can both refer
-;; to it without creating a leaf→parent cycle (rf2-ee38b.7 intra-http shape).
+;; to it without creating a leaf-to-parent cycle.
 
 (def redacted-sentinel
   "The framework-reserved redaction sentinel keyword per Spec 009 §Privacy.
   Re-exported from the canonical `re-frame.privacy/redacted-sentinel` in
-  core (rf2-qe237). This is the http-side public anchor — `http-privacy`
-  and `http-privacy-headers` both refer to it privately (rf2-m00e7p), so
+  core. This is the HTTP-side public anchor; `http-privacy`
+  and `http-privacy-headers` both refer to it privately, so
   the keyword cannot drift across the http privacy cluster."
   privacy/redacted-sentinel)
 
-;; ---- query-param denylist (rf2-2p8wr) -------------------------------------
+;; ---- query-param denylist -------------------------------------------------
 
 (def default-query-param-denylist
   "Canonical always-sensitive HTTP query-string parameter names, lower-
@@ -88,7 +84,7 @@
   webhook receivers, and signed-URL schemes. An **immutable framework
   default** — no app can remove one. Apps extend with their own carrier
   names on the `:rf.http/managed` `reg-fx` registration via
-  `:carriers {:query-params [\"shop_token\"]}` (EP-0025); the carrier
+  `:carriers {:query-params [\"shop_token\"]}`; the carrier
   extension set UNIONS onto these defaults."
   #{"api_key"
     "apikey"
@@ -116,9 +112,9 @@
 
   `frame-policy` is the app-declared query-param carrier policy resolved from
   the `:rf.http/managed` `reg-fx` registration's `:carriers {:query-params
-  ..}` block (EP-0025), or `nil` when no carrier is declared. (Param name
+  ..}` block, or `nil` when no carrier is declared. (Param name
   retained for the leaf API contract; the policy no longer comes from a
-  frame.) Two shapes are accepted (rf2-4wqxq8):
+  frame.) Two shapes are accepted:
 
    - a **set** of lower-cased names — the include-only extension set
      (`:query-params [\"shop_token\"]`). The built-in defaults always apply;
@@ -136,8 +132,8 @@
   its OWN local trace. The immutable header denylist and the on-by-default
   query defaults are unchanged — `:except` is opt-in per name.
 
-  Per rf2-ydp66 — short-circuits via `contains?` lookups on the source sets
-  rather than building a fresh union per call."
+  Uses `contains?` lookups on the source sets rather than building a fresh
+  union per call."
   ([param-name] (sensitive-query-param? param-name nil))
   ([param-name frame-policy]
    (boolean

--- a/implementation/http/test/re_frame/http_abort_precedence_test.clj
+++ b/implementation/http/test/re_frame/http_abort_precedence_test.clj
@@ -1,5 +1,5 @@
 (ns re-frame.http-abort-precedence-test
-  "Per rf2-wez75 (Mike decision a, 2026-05-17): abort always wins over
+  "Abort always wins over
   decode-failure / transport / accept-failure / success classification
   in `:rf.http/managed`. Aligned with Fetch AbortController / Node HTTP
   / JVM HttpClient / gRPC universal convention.
@@ -7,7 +7,7 @@
   Spec references:
    - Spec 014 §Abort precedence (abort always wins)
    - Spec 014 §Aborts (`:request-id` (internal), `:abort-signal` (external))
-   - Spec 014 §Abort on actor destroy (rf2-wvkn)
+   - Spec 014 §Abort on actor destroy
 
   Test strategy: each test deterministically interleaves the abort with a
   late-classifying failure / success by gating the contended side rather
@@ -32,8 +32,7 @@
    2b. transport-classification-loses-to-recorded-abort-precedence-seam
        (deterministic unit-level: drives `finalise-failure!` with a
        `:rf.http/transport` failure on a handle whose `:aborted?` is
-       ALREADY flipped — pins the exact reclassification the flaky
-       same-dispatch-vs-async race (rf2-12r1dn) was probing by timing)
+       already flipped, pinning reclassification without timing races)
    3. abort-via-actor-destroy-wins-over-decode-failure"
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
@@ -58,11 +57,7 @@
   (flows/reset-flows!)
   (schemas/clear-schemas-by-frame!)
   (rf/init! plain-atom/adapter)
-  ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`,
-  ;; and the managed-HTTP / machine / routing fxs now require a carried
-  ;; frame stamp. This suite exercises the ambient dispatch path against
-  ;; a single conventional app frame, so register `:rf/default` explicitly
-  ;; and pin it as the established scope for the whole body via with-frame.
+  ;; The suite uses one explicit default frame for ambient dispatch.
   (frame/ensure-default-frame!)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr     :reload)

--- a/implementation/http/test/re_frame/http_actor_destroy_cancellation_test.clj
+++ b/implementation/http/test/re_frame/http_actor_destroy_cancellation_test.clj
@@ -1,5 +1,5 @@
 (ns re-frame.http-actor-destroy-cancellation-test
-  "Per rf2-wvkn — the cross-feature contract that destroying a spawned
+  "Cross-feature contract: destroying a spawned
   state-machine actor aborts every in-flight `:rf.http/managed` request
   the actor had issued.
 
@@ -22,24 +22,17 @@
    3. Sibling actors are NOT affected when one is destroyed
    4. Direct event-handler dispatch (no spawned-actor) → no cancellation
    5. Parent state's :after firing destroys the child + aborts its HTTP
-   6. Anonymous (request-id-less) child request → actor-destroy abort
-      cleans the actor-in-flight index (rf2-lz7se)
+   6. Anonymous child request → actor-destroy cleans the actor index
    6b. Registry-level: 2-arg clear-in-flight! empties an anonymous
        handle's actor slot without a pre-clear (the unconditional-
-       correctness guarantee); 1-arg form leaks it (rf2-lz7se)
+       correctness guarantee); 1-arg lookup cannot address it
    6c. `schedule-backoff-handle!`'s abort-fn cleans an anonymous
        (request-id-less) backoff handle's actor slot when fired by a
-       trigger that does NOT pre-clear the actor slot — the sibling of
-       (6b) at the second abort-fn site (rf2-meq28)
+       trigger that does not pre-clear the actor slot
    7.  IMPERATIVELY-spawned actor (`[:rf.machine/spawn …]` from an
        ordinary event handler — NO `:spawned` registry slot) → its managed
-       request is aborted on imperative `[:rf.machine/destroy …]`. This is
-       the rf2-n877mb widening test: step 1's registry-membership
-       `owning-actor-id` classified such a request as unowned (the actor is
-       absent from `[:rf.runtime/machines :spawned]`); step 2 switches
-       ownership to the durable snapshot `:rf/machine-type` marker, so
-       imperative spawns are now owners. Tests 1–6c cover declarative
-       `:spawn` only and cannot catch this widening (rf2-n877mb)"
+       request is aborted on imperative `[:rf.machine/destroy …]`; ownership
+       is recognized from the durable `:rf/machine-type` snapshot marker"
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.flows :as flows]
@@ -65,11 +58,7 @@
   (flows/reset-flows!)
   (schemas/clear-schemas-by-frame!)
   (rf/init! plain-atom/adapter)
-  ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`,
-  ;; and the managed-HTTP / machine / routing fxs now require a carried
-  ;; frame stamp. This suite exercises the ambient dispatch path against
-  ;; a single conventional app frame, so register `:rf/default` explicitly
-  ;; and pin it as the established scope for the whole body via with-frame.
+  ;; The suite uses one explicit default frame for ambient dispatch.
   (frame/ensure-default-frame!)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr     :reload)

--- a/implementation/http/test/re_frame/http_backoff_cancellation_test.clj
+++ b/implementation/http/test/re_frame/http_backoff_cancellation_test.clj
@@ -1,26 +1,15 @@
 (ns re-frame.http-backoff-cancellation-test
-  "Per rf2-wj8vv — the retry backoff WINDOW must be cancellable.
+  "The retry backoff window remains cancellable.
 
-  Defect (closed by this test): when `maybe-retry!` schedules a retry it
-  cleared the prior attempt's handle from BOTH in-flight indexes BEFORE
-  arming the backoff timer, leaving the request invisible to every
-  cancellation path for the whole backoff window. A
-  `:rf.http/managed-abort`, an `abort-on-actor-destroy` cascade, or a
-  same-`:request-id` supersede issued DURING the backoff all resolved to
-  `nil` and silently no-op'd — the retry timer kept running and a fresh
-  HTTP attempt fired after the backoff elapsed, against a request the
-  caller had already cancelled.
-
-  Fix: the request stays registered for the whole backoff window under a
+  A sleeping request stays registered under a
   handle whose `:abort-fn` cancels the pending retry timer and clears the
-  registry. The three cancellation paths converge on the one `:abort-fn`
-  dispatch, so a sleeping request is cancellable through each with no
-  path-specific code.
+  registry. User abort, actor destruction, and same-id supersession converge
+  on that closure.
 
   Spec references:
    - Spec 014 §Retry and backoff
    - Spec 014 §Aborts (`:request-id` (internal), supersede)
-   - Spec 014 §Abort on actor destroy (rf2-wvkn)
+   - Spec 014 §Abort on actor destroy
 
   Test strategy: a tiny in-process server that always returns 500 and
   COUNTS its hits. A `:retry {:on #{:rf.http/http-5xx} :max-attempts 5
@@ -35,7 +24,7 @@
    1. :rf.http/managed-abort during backoff   → no retry, registry clear
    2. abort-on-actor-destroy during backoff   → no retry, registry clear
    3. supersede (same request-id) during backoff → old retry suppressed
-   3b. supersede during backoff (rf2-hbus90)  → the stale-suppressed trace
+   3b. supersede during backoff               → the stale-suppressed trace
        carries the SLEEPING retry attempt's work-id (issuance/attempt
        preserved), not a default `1 1`
    4. GUARD: an uncancelled backoff still retries (no regression)"
@@ -63,11 +52,7 @@
   (flows/reset-flows!)
   (schemas/clear-schemas-by-frame!)
   (rf/init! plain-atom/adapter)
-  ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`,
-  ;; and the managed-HTTP / machine / routing fxs now require a carried
-  ;; frame stamp. This suite exercises the ambient dispatch path against
-  ;; a single conventional app frame, so register `:rf/default` explicitly
-  ;; and pin it as the established scope for the whole body via with-frame.
+  ;; The suite uses one explicit default frame for ambient dispatch.
   (frame/ensure-default-frame!)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr     :reload)

--- a/implementation/http/test/re_frame/http_cljs_test.cljs
+++ b/implementation/http/test/re_frame/http_cljs_test.cljs
@@ -1,5 +1,5 @@
 (ns re-frame.http-cljs-test
-  "CLJS-side smoke for the `re-frame.http` call-site helpers (rf2-pf4k).
+  "CLJS-side coverage for HTTP helpers and the Fetch adapter.
 
   The JVM `re-frame.http-test` covers the full shape contract. This
   smoke just confirms the helpers compile clean under CLJS (the file
@@ -7,53 +7,48 @@
   fastest way to catch a regression that would otherwise only surface
   in shadow-cljs builds).
 
-  Also covers rf2-r40km — the CLJS-only `:rf.http/cors` classification
-  branch of `re-frame.http.transport-cljs/classify-cljs-error`."
+  Also covers the CLJS-only `:rf.http/cors` classification branch."
   (:require [cljs.reader :as edn]
             [cljs.test :refer-macros [deftest is testing async]]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.http :as rf.http]
-            ;; rf2-wj8vv — drive the full `:rf.http/managed` pipeline (fx
+            ;; Drive the full `:rf.http/managed` pipeline (fx
             ;; registration + in-flight registry) for the backoff-window
             ;; cancellation test below.
             [re-frame.http.managed :as http-managed]
             [re-frame.http.registry :as registry]
             [re-frame.http.transport-cljs :as transport-cljs]
-            ;; rf2-f5pguu — assert the redacted `:rf.warning/http-header-invalid`
+            ;; Assert the redacted `:rf.warning/http-header-invalid`
             ;; trace fires (instead of an escaping `:rf.error/fx-handler-
             ;; exception`) when an invalid request header hits the managed
-            ;; CLJS path. `re-frame.trace.tooling` owns the listener surface
-            ;; (rf2-qwm0a); `re-frame.http.url` carries the canonical redaction
-            ;; sentinel for the denylist-scrub assertion (rf2-m00e7p).
+            ;; CLJS path. `re-frame.trace.tooling` owns the listener surface;
+            ;; `re-frame.http.url` carries
+            ;; the canonical HTTP redaction sentinel.
             [re-frame.http.url :as http-url]
             [re-frame.test-support :as test-support]
             [re-frame.trace.tooling :as trace-tooling]))
 
-;; rf2-hp772l — the CLJS Fetch transport + classifier now live in the
-;; per-platform adapter ns `re-frame.http.transport-cljs` and are public
-;; (named seams), so no `@#'` reach-through is needed.
+;; Fetch transport and classification are named adapter seams.
 (def ^:private classify-cljs-error
   transport-cljs/classify-cljs-error)
 
-;; rf2-xu0sl — tolerance band for the MEASURED `:elapsed-ms` wall-clock
+;; Tolerance band for measured `:elapsed-ms` wall-clock
 ;; assertions below. `js/setTimeout(…, limit)` is NOT a hard floor: under
 ;; rounding and CI scheduling jitter a 40ms timer can be observed firing at
 ;; a measured ~39ms, so an exact `(>= elapsed limit)` flakes by ~1ms. We
 ;; assert `elapsed` lands within this band of `limit` instead, which still
-;; proves `:elapsed-ms` is a genuine measured value (not the old synthetic
-;; constant `== :limit-ms`, and not absent) without being jitter-fragile.
+;; proves `:elapsed-ms` is measured and present without being jitter-fragile.
 (def ^:private elapsed-jitter-ms 10)
 
-;; rf2-5zj6t — the CLJS Fetch transport (`transport-cljs/cljs-fetch`,
-;; now a public named seam) so we can assert it reads the correct
-;; response body type per `:decode` (a Fetch Response body may be
+;; Assert that Fetch reads the correct response body type per `:decode`. A
+;; Fetch Response body may be
 ;; consumed only once, so the reader is chosen up front).
 (def ^:private cljs-fetch
   transport-cljs/cljs-fetch)
 
-;; rf2-u5xwa — `cross-origin?` (the load-bearing half of the CORS
+;; `cross-origin?` (the load-bearing half of the CORS
 ;; classification) reads `js/globalThis.location.origin`, which is ABSENT
 ;; under the node-runtime CLJS gate (`npm run test:cljs`). Inject a known
 ;; origin so the cross-origin heuristic runs deterministically in node and

--- a/implementation/http/test/re_frame/http_decode_test.clj
+++ b/implementation/http/test/re_frame/http_decode_test.clj
@@ -1,14 +1,9 @@
 (ns re-frame.http-decode-test
   "Direct unit coverage for the response-body decode pipeline in
-  `re-frame.http.decode` (rf2-ohwgm; follow-on from the http test-coverage
-  audit `ai/findings/2026-05-21-testcov-http.md`).
+  `re-frame.http.decode`.
 
-  Per Spec 014 §Decoding / §`:auto`, schema-driven decode is the
-  canonical form. Before this file the entire Malli decode + coerce +
-  validate path (`malli-decode`, the schema branch of
-  `decode-response-body`) had ZERO test coverage, and the keyword-cap was
-  never threaded through the decoder end-to-end as a thrown
-  `:too-many-keys`.
+  Per Spec 014 §Decoding / §`:auto`, these tests cover Malli decode,
+  coercion and validation, plus end-to-end keyword-cap propagation.
 
   These fns are pure / host-agnostic, so they belong on the fast JVM
   `clojure -M:test` layer. Malli is on the http test classpath via the
@@ -32,7 +27,7 @@
 ;; the coerce / validation-failure assertions would mislead. This guard
 ;; turns that into an explicit failure.
 (deftest malli-is-on-the-test-classpath
-  (testing "rf2-ohwgm — the schema-decode tests below require Malli to be
+  (testing "the schema-decode tests below require Malli to be
             resolvable; assert the precondition so a deps regression that
             removes it fails loudly rather than degrading to the no-op
             Malli-absent branch"
@@ -40,10 +35,10 @@
     (is (some? (requiring-resolve 'malli.core/validate)))
     (is (some? (requiring-resolve 'malli.transform/json-transformer)))))
 
-;; ---- G1: malli-decode — coerce success ------------------------------------
+;; ---- malli-decode: coerce success -----------------------------------------
 
 (deftest malli-decode-coerces-with-json-transformer
-  (testing "rf2-ohwgm — malli-decode runs the schema's decode with the
+  (testing "malli-decode runs the schema's decode with the
             JSON transformer, applying the canonical JSON coercions (the
             classic case is string→keyword and string→enum, since JSON
             has no keyword type) — proving the transformer arg is actually
@@ -65,13 +60,13 @@
            already parsed it to a number)"))))
 
 (deftest malli-decode-passes-through-already-valid-value
-  (testing "rf2-ohwgm — a value that already matches the schema decodes to
+  (testing "a value that already matches the schema decodes to
             itself and validates clean"
     (is (= {:title "hello" :id 42}
            (malli-decode [:map [:title :string] [:id :int]]
                          {:title "hello" :id 42})))))
 
-;; ---- G1: malli-decode — validation failure --------------------------------
+;; ---- malli-decode: validation failure -------------------------------------
 
 (deftest malli-decode-throws-canonical-ex-info-on-validation-failure
   (testing "rf2-ohwgm — when the coerced value still fails the schema,

--- a/implementation/http/test/re_frame/http_managed_test.clj
+++ b/implementation/http/test/re_frame/http_managed_test.clj
@@ -21,14 +21,10 @@
             [re-frame.http.managed :as http-managed]
             [re-frame.http.registry :as registry]
             [re-frame.late-bind :as late-bind]
-            ;; rf2-cdmle — the canned-stub fxs no longer register at
-            ;; `re-frame.http.managed` load time. This test file uses
+            ;; This suite uses
             ;; `:fx-overrides {:rf.http/managed :rf.http/managed-canned-success}`
             ;; throughout, so it opts in by requiring the test-support ns.
-            ;; Loading registers `:rf.http/managed-canned-success` and
-            ;; `:rf.http/managed-canned-failure` against the same handler
-            ;; bodies the earlier `(when interop/debug-enabled? ...)` gate
-            ;; wired up.
+            ;; Requiring test support registers both canned effect ids.
             [re-frame.http.test-support]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
@@ -45,24 +41,20 @@
   (flows/reset-flows!)
   (schemas/clear-schemas-by-frame!)
   (rf/init! plain-atom/adapter)
-  ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`,
-  ;; and the managed-HTTP / machine / routing fxs now require a carried
-  ;; frame stamp. This suite exercises the ambient dispatch path against
-  ;; a single conventional app frame, so register `:rf/default` explicitly
-  ;; and pin it as the established scope for the whole body via with-frame.
+  ;; The suite uses one explicit default frame for ambient dispatch.
   (frame/ensure-default-frame!)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr     :reload)
   (require 're-frame.machines :reload)
   (require 're-frame.http.managed :reload)
-  ;; rf2-cdmle — clear-all! above wipes the canned-stub fx registrations
+  ;; `clear-all!` above wipes the canned-stub fx registrations
   ;; that re-frame.http.test-support put into the registrar at first
   ;; load. Reload the test-support ns so its registration body fires
   ;; again for the next test (mirrors the http-managed reload above).
   (require 're-frame.http.test-support :reload)
   ((requiring-resolve 're-frame.machines/reset-timers!))
   (http-managed/clear-all-in-flight!)
-  ;; rf2-r5m22 — the per-frame HTTP interceptor chain lives in a separate
+  ;; The per-frame HTTP interceptor chain lives in a separate
   ;; registry (internal to `re-frame.http.middleware`; observe via
   ;; `http-managed/interceptors-snapshot`), NOT the registrar `clear-all!`
   ;; wipes above. Tests that register `:before` / `:after` interceptors

--- a/implementation/http/test/re_frame/http_privacy_test.clj
+++ b/implementation/http/test/re_frame/http_privacy_test.clj
@@ -1,6 +1,6 @@
 (ns re-frame.http-privacy-test
   "Unit tests for `re-frame.http.privacy` and its sibling leaves —
-  Spec 014 §Privacy (rf2-bma05).
+  Spec 014 §Privacy.
 
   Covers:
    - Header denylist (default set, case-insensitive, app-extensible) —
@@ -60,7 +60,7 @@
     (is (not (headers/sensitive-header? "X-Request-Id")))))
 
 (deftest carrier-extras-extend-header-denylist
-  (testing "app-declared header carriers (EP-0025) compose with defaults"
+  (testing "app-declared header carriers compose with defaults"
     (let [extras #{"x-honeycomb-team"}]
       (is (headers/sensitive-header? "X-Honeycomb-Team" extras))
       (is (headers/sensitive-header? "x-honeycomb-team" extras))

--- a/implementation/http/test/re_frame/http_trace_emit_elision_prod_test.cljs
+++ b/implementation/http/test/re_frame/http_trace_emit_elision_prod_test.cljs
@@ -1,6 +1,8 @@
 (ns re-frame.http-trace-emit-elision-prod-test
-  "Per Spec 009 §Production builds (bead rf2-xxd6z) — RUNTIME prod-elision
-  contract for the `re-frame.http.managed` trace surface. Companion to
+  "Runtime production-elision coverage for the managed-HTTP trace surface.
+
+  Per Spec 009 §Production builds, registered listeners observe no HTTP or
+  warning events from `re-frame.http.managed`. Companion to
   the string-grep sentinel sweep in `scripts/check-elision.cjs`: the
   grep catches keyword-literal survival in the bundle blob; this file
   pins the BEHAVIOUR — under `:advanced` + `goog.DEBUG=false`, a
@@ -15,7 +17,7 @@
 
   Surfaces exercised:
 
-  - `:rf.http/aborted-on-actor-destroy`  (rf2-wvkn — emitted by
+  - `:rf.http/aborted-on-actor-destroy`  (emitted by
                                           `abort-on-actor-destroy`
                                           when handles exist)
   - `:rf.http/retry-attempt`              (Spec 014 §Retry — emit site
@@ -41,7 +43,7 @@
             [re-frame.http.registry :as http-registry]
             [re-frame.http.transport]
             [re-frame.http.decode]
-            ;; rf2-qwm0a — listener surface lives in `re-frame.trace.tooling`.
+            ;; Listener mutation belongs to the tooling namespace.
             [re-frame.trace.tooling :as trace-tooling]))
 
 (use-fixtures :each

--- a/implementation/http/test/re_frame/http_transport_security_test.clj
+++ b/implementation/http/test/re_frame/http_transport_security_test.clj
@@ -1,12 +1,6 @@
 (ns re-frame.http-transport-security-test
-  "Unit tests for `re-frame.http.transport` security-relevant guards.
-
-  Beads:
-   - rf2-9lun0 — invalid headers surface as `:rf.warning/http-header-invalid`
-                 trace events rather than being silently dropped.
-   - rf2-it1cd — the JVM request builder honours the args-map timeout-ms
-                 (defaulted to 30000 at the handler) so the JDK
-                 HttpClient applies a wall-clock read timeout."
+  "Security-relevant JVM transport guards: invalid-header warnings,
+  privacy composition, timeout application, and host degradation."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.http.handlers]
             [re-frame.http.privacy :as privacy]
@@ -18,11 +12,8 @@
            [java.time Duration]
            [java.util Optional]))
 
-;; rf2-hp772l — the JVM platform transport (request building, client
-;; memoisation, classification, CLJS-only-key degradation tracing) lives
-;; in the per-platform adapter ns `re-frame.http.transport-jvm`. The
-;; public seams are reached directly; the genuinely-internal helpers
-;; (`redirect->policy`) via `#'` against that named adapter.
+;; Public seams live in the JVM adapter; tests reach genuinely private helpers
+;; there with `#'` rather than widening production API.
 (def ^:private jvm-build-request
   re-frame.http.transport-jvm/jvm-build-request)
 
@@ -35,7 +26,7 @@
       (finally
         (trace/unregister-listener! cb-id)))))
 
-;; ---- rf2-9lun0 — header validation surfaces a trace ----------------------
+;; ---- header validation surfaces a trace ----------------------------------
 
 (deftest invalid-header-value-emits-warning-not-silent-drop
   (testing "rf2-9lun0 — a stray \\r in a header value fires

--- a/implementation/http/test/re_frame/http_url_percent_encoded_redaction_cljs_test.cljc
+++ b/implementation/http/test/re_frame/http_url_percent_encoded_redaction_cljs_test.cljc
@@ -1,23 +1,13 @@
 (ns re-frame.http-url-percent-encoded-redaction-cljs-test
-  "rf2-065xo finding 2 — percent-encoded query-param NAMES must be
-  redacted (Spec 014 §Privacy). Cross-host `*-cljs-test.cljc` so BOTH
+  "Percent-encoded query-param names must still match privacy policy.
+
+  This is a cross-host `*-cljs-test.cljc` so both
   cognitect.test-runner (JVM `clojure -M:test`) and shadow-cljs
   (`npm run test:cljs`, `cljs-test$` ns-regexp) discover it — the
   percent-decode-for-comparison logic is reader-conditional
   (`java.net.URLDecoder` on JVM, `js/decodeURIComponent` on CLJS) and is
-  host-symmetric by design, so one source asserted on both runtimes is
-  the right shape.
-
-  Defect (closed by this test): `redact-query-param` compared the RAW
-  query-param name to the denylist, so a percent-encoded denylisted name
-  — `api%5Fkey` (= `api_key`), `%61ccess_token` (= `access_token`), an
-  app-declared `shop%5Ftoken` (= `shop_token`) — read as a
-  non-sensitive raw string and leaked its VALUE into `:rf.http/*` trace
-  events unless the whole request was marked `:sensitive?`. Encoded auth
-  tokens reached logs/tooling — squarely the AI/MCP + logs/traces
-  threat model.
-
-  Fix: the redactor consults `sensitive-query-param-name?`, which
+  host-symmetric by design. The redactor consults
+  `sensitive-query-param-name?`, which
   compares both the RAW spelling AND the percent-DECODED spelling
   (case-insensitively). Decode is comparison-only — the rebuilt URL
   preserves the original raw param spelling; only the value becomes
@@ -28,10 +18,8 @@
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.http.url :as url]))
 
-;; rf2-ppkh3v — app-specific carriers moved to FRAME policy (EP-0015 §3);
-;; the process-global `clear-sensitive-query-params!` fixture is gone. The
-;; frame-extension cases below pass the carrier set explicitly as the
-;; `frame-extras` arg, so no per-test cleanup is needed.
+;; App-specific carrier policy is passed explicitly to this leaf API, so no
+;; registration or process cleanup is needed here.
 
 ;; ---------------------------------------------------------------------------
 ;; sensitive-query-param-name? — raw + percent-decoded comparison
@@ -49,14 +37,14 @@
     (is (url/sensitive-query-param-name? "access_token"))))
 
 (deftest encoded-frame-extra-denylist-name-matches
-  (testing "rf2-065xo / rf2-ppkh3v — a frame-declared carrier name matches when percent-encoded"
+  (testing "a registration-declared carrier name matches when percent-encoded"
     (let [extras #{"shop_token"}]
       ;; shop%5Ftoken decodes to shop_token.
       (is (url/sensitive-query-param-name? "shop%5Ftoken" extras))
       (is (url/sensitive-query-param-name? "shop_token" extras))
-      ;; absent frame-extras → the frame carrier no longer matches (decoded or raw)
+      ;; Without extensions the app carrier no longer matches.
       (is (not (url/sensitive-query-param-name? "shop%5Ftoken"))
-          "without frame-extras the frame carrier does not match")
+          "without extensions the app carrier does not match")
       ;; defaults are immutable — they match regardless of frame-extras.
       (is (url/sensitive-query-param-name? "api%5Fkey")))))
 
@@ -111,7 +99,7 @@
       (is (true? any?)))))
 
 (deftest redact-url-encoded-frame-extra-name-value-redacted
-  (testing "rf2-065xo / rf2-ppkh3v — a frame-declared carrier name, percent-encoded, has its value redacted"
+  (testing "a registration-declared carrier name, percent-encoded, has its value redacted"
     (let [extras #{"shop_token"}
           [redacted any?] (url/redact-url-query-string
                             "https://api.example.com/x?shop%5Ftoken=SECRET&page=2"


### PR DESCRIPTION
## Summary

- replace issue-history and migration narration with current HTTP ownership, lifecycle, retry, cancellation, privacy, and host contracts
- correct stale explanations that described registration-owned HTTP carriers as frame-local and abort closures as no-arg
- clarify the optional artefact/test-support require boundary and production trace-elision behavior

This is behavior-neutral: only comments, docstrings, test descriptions, and effect metadata documentation changed. `re-frame.http.reply` and reply-lowering tests were left untouched because PR #5462 currently owns that surface.

## Verification

- `cd implementation/http && clojure -M:test` - 470 tests, 3,674 assertions, 0 failures
- `cd implementation && npm run test:cljs` - 8,473 tests, 39,190 assertions, 0 failures
- `cd implementation && npm run test:browser-prod-elision` - 74 tests, 230 assertions, 0 failures
- `clj-kondo --lint http/src http/test` - 33 existing warnings, matching the untouched baseline; 0 errors
- `clojure -M:splint http/src http/test` - 310 existing style warnings, matching the untouched baseline
- `git diff --check`
