### PR TITLE
docs(machines): align explanations with runtime contracts (rf2-yqstca)

### DIFF
--- a/implementation/machines/deps.edn
+++ b/implementation/machines/deps.edn
@@ -1,5 +1,4 @@
-;; day8/re-frame2-machines — state-machine artefact (rf2-xbtj,
-;; second per-feature split per rf2-5vjj Strategy B).
+;; day8/re-frame2-machines — optional state-machine artefact.
 ;;
 ;; Per Spec 005 §State machines the machine grammar
 ;; (`reg-machine`, `make-machine-handler`, `machine-transition`,
@@ -19,41 +18,26 @@
 ;; loading the namespace registers its late-bind hooks and the
 ;; `:rf.machine/spawn` / `:rf.machine/destroy` reserved fxs.
 ;;
-;; Per Spec 006 §Adapter shipping convention (and the
-;; rf2-p7va extension to per-feature splits): this artefact depends on
-;; core; core never depends on this artefact. The cross-references
-;; from core to machines (e.g. `re-frame.core`'s `reg-machine` /
-;; `make-machine-handler` / `machine-transition` re-exports,
-;; `re-frame.test-support`'s reset-runtime fixture's
-;; `(machines/reset-timers!)` step) flow through `re-frame.late-bind`
-;; exactly as the schemas / router / flows hooks already do.
+;; Per Spec 006 §Adapter shipping convention, this artefact depends on core;
+;; core never depends on this artefact. Core's `reg-machine` macro bridge and
+;; test-support lifecycle hooks reach machines through `re-frame.late-bind`.
 {:paths ["src"]
  :deps  {day8/re-frame2 {:local/root "../core"}}
 
  :aliases
  {:test {:extra-paths ["test"]
-         :extra-deps  {;; rf2-try1x — silent-on-success reporter.
-                       day8/re-frame2-test-quiet {:local/root "../test-quiet"}
+         :extra-deps  {day8/re-frame2-test-quiet {:local/root "../test-quiet"}
                        ;; `[:schemas :data]` validation tests reach the
                        ;; default Malli validator via `re-frame.schemas.malli`.
-                       ;; Test-only dep so the artefact's production
-                       ;; classpath stays schemas-free (machine core requires
-                       ;; no schema library — EP-0029 Non-goal / rf2-49zxkc).
+                       ;; Test-only: production remains schema-library agnostic.
                        day8/re-frame2-schemas    {:local/root "../schemas"}
                        io.github.cognitect-labs/test-runner
                        {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
-         ;; rf2-bv2qqm — the default PR/local gate EXCLUDES the heavy
-         ;; `^:stress` namespace (`machine_actor_concurrency_stress_test`,
-         ;; 5000-iter × 8-thread actor-spawn churn). The runner passes
-         ;; `-e` through to cognitect-test-runner verbatim. Coverage is NOT
-         ;; lost: the `:slow-test` alias below runs the excluded tests,
-         ;; invoked by the nightly `expensive-tests.yml` job +
-         ;; `scripts/test-rigorous-local.sh`.
+         ;; The default gate excludes slow and stress tests; `:slow-test`
+         ;; below selects exactly those tests for rigorous/nightly runs.
          :main-opts   ["-m" "re-frame.test-quiet.runner" "-e" ":slow" "-e" ":stress"]}
 
-  ;; rf2-bv2qqm — nightly/rigorous slow-test gate. INCLUDES ONLY the
-  ;; `^:slow` / `^:stress` tests, so `:test` + `:slow-test` together cover
-  ;; every test once.
+  ;; Together, `:test` and `:slow-test` cover every test once.
   :slow-test
   {:extra-paths ["test"]
    :extra-deps  {day8/re-frame2-test-quiet {:local/root "../test-quiet"}
@@ -62,7 +46,7 @@
                  {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
    :main-opts   ["-m" "re-frame.test-quiet.runner" "-i" ":slow" "-i" ":stress"]}
 
-  ;; Clojars deploy (rf2-r382). Modeled on re-frame v1's release flow.
+  ;; Clojars deploy. Modelled on re-frame v1's release flow.
   ;; The release workflow runs `clojure -M:clein deploy` from this
   ;; artefact's directory, which builds pom + jar and pushes to Clojars.
   ;;

--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -1,21 +1,17 @@
 (ns re-frame.machines
   "State machines. Per Spec 005.
 
-  Implements the v1 grammar:
+  Implements the Spec 005 grammar:
     - Transition tables with :on, :entry, :exit, :guard, :action.
     - Flat states (single keyword) AND hierarchical states (vector path)
       with deepest-wins resolution and LCA exit/entry cascade.
     - :always microsteps with bounded depth and atomic rollback on
       depth-exceeded.
-    - :after delayed transitions with per-scheduling-node :rf/after-epoch
-      tracking (a {<decl-path> <int>} map, so a parent's :after survives a
-      child-only sibling transition per Spec 005 §Hierarchy interaction);
-      the synthetic :rf.machine.timer/after-elapsed event carries the
-      node's epoch + decl-path and fires the transition only when the
-      scheduling node is still active and the carried epoch matches.
-      `:after` delays admit three forms — pos-int? literal, subscription vector
-      ([:sub-id & args]; re-resolves on sub change), and
-      (fn [snapshot] ms) computed once at state entry.
+    - :after delayed transitions with per-node epoch staleness checks;
+      delays may be positive integer literals, subscription vectors, or
+      functions computed at state entry.
+    - :timeout and :choice authoring forms lowered onto :after and :always.
+    - Declared :internal-events that only the machine's raise queue may drive.
     - Declarative :spawn that desugars into [:rf.machine/spawn args]
       on entry and [:rf.machine/destroy actor-id] on exit; deterministic
       actor ids via the in-snapshot :rf/spawn-counter (declarative) / the
@@ -24,9 +20,7 @@
     - Declarative :spawn-all — spawn-and-join sugar over N parallel
       :spawn's plus a closed two-member join condition (:all / :any).
     - The :raise reserved fx-id (machine-internal pre-commit dispatch).
-    - The :rf.machine/dispatch-to-system reserved fx-id — a machine
-      action sends a message to its spawned child actor by :system-id
-      (the fx counterpart to the dispatch-to-system FN).
+    - Named actor messaging through :rf.machine/dispatch-to-system.
     - Snapshot at [:rf.runtime/machines :snapshots <id>] in runtime-db.
     - Pure machine-transition fn (JVM- and CLJS-runnable, deterministic).
 
@@ -65,15 +59,8 @@
             [re-frame.machines.timer :as timer]
             [re-frame.registrar :as registrar]
             [re-frame.subs :as subs]
-            ;; The JVM-only require of the machines tooling sibling that backs
-            ;; the `machine-algebra-view` / `machine-instance-algebra-view` /
-            ;; `machine-selector?` aliases at the foot of this ns. CLJS
-            ;; deliberately OMITS this require so a CLJS app that loads the
-            ;; machines artefact but never attaches a tool DCEs the tooling body
-            ;; wholesale — the facade never reaches it. JVM has no bundle to
-            ;; protect; the aliases give JVM tools / conformance fixtures the
-            ;; ergonomic `re-frame.machines/<name>` shape. Mirrors the
-            ;; `re-frame.flows` → `re-frame.flows.tooling` JVM-only require.
+            ;; Keep tooling out of CLJS production bundles. CLJS tools require
+            ;; the tooling namespace directly; JVM callers get facade aliases.
             #?@(:clj [[re-frame.machines.tooling :as machines-tooling]])))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -85,12 +72,9 @@
 ;; bridge, the conformance corpus, the test fixtures, examples that
 ;; `:require [re-frame.machines :as machines]`) all see one surface.
 
-;; Declarative-`:spawn` spawns allocate ids inside the parent
-;; snapshot's `:rf/spawn-counter` slot via
-;; `re-frame.machines.transition/allocate-spawned-id`; hand-emitted
-;; spawn fxs allocate from the frame's app-db slot at
-;; `[:rf.runtime/machines :spawn-counter <machine-id>]` inside the
-;; spawn-fx db-swap (the single-reserved-root contract).
+;; Declarative spawns allocate ids in the parent snapshot's
+;; `:rf/spawn-counter`; hand-emitted spawns use the frame's runtime-db
+;; `[:rf.runtime/machines :spawn-counter <machine-id>]` slot.
 ;; `machine-transition` is a pure function — no module-level mutable
 ;; state, deterministic from its (machine snapshot event) arguments.
 
@@ -161,16 +145,10 @@
   scope (async callbacks / tools / cross-frame lookups); `target` is a
   frame-id keyword or a live frame value.
 
-  Per rf2-f28bno the 2-arity is SHAPE-DISCRIMINATED on the second arg,
-  mirroring `subscribe`'s frame-first arity `{:frame …}` opts form (and the
-  rf2-bfadc6 `subscribe-once` disposition): an OPTS MAP (a non-frame-value map) ⇒ the
-  public `(machine-by-system-id system-id {:frame target})` form (`:frame`
-  absent ⇒ ambient); anything else ⇒ the INTERNAL frame-last
-  `(machine-by-system-id system-id frame-target)` plumbing (a frame-id
-  keyword or a frame value), retired from the taught surface but retained
-  for implementation / test / tooling reach. A frame VALUE is itself a map
-  (carries `:rf.frame/object`), so the discriminator is `map? AND NOT
-  frame-value?` — a bare `{:frame f}` opts map, never a frame value.
+  The 2-arity distinguishes an opts map from the internal frame-last form.
+  Because a live frame value is also a map, only a map that is not a frame
+  value is treated as opts. An opts map without `:frame` uses the ambient
+  frame.
 
   Per Spec 005 §Named addressing via :system-id + Spec 002 §Resolver
   surface."
@@ -181,21 +159,12 @@
        :machine-by-system-id
        {:where 're-frame.machines/machine-by-system-id})))
   ([system-id frame-or-opts]
-   ;; rf2-f28bno: an OPTS MAP (non-frame-value map) is the PUBLIC
-   ;; `(machine-by-system-id system-id {:frame target})` form; lower it to
-   ;; the internal frame-last arity via the resolved `:frame` target
-   ;; (ambient when absent — a keyword/frame-value, never a bare opts map,
-   ;; so the recursive call lands in the frame-last branch below). Anything
-   ;; else is the INTERNAL frame-last plumbing: `frame-or-opts` is the frame
-   ;; target (a keyword id or a frame value).
+   ;; A live frame is map-shaped, so exclude frame values from the opts branch.
    (if (and (map? frame-or-opts) (not (frame/frame-value? frame-or-opts)))
      (if-some [target (:frame frame-or-opts)]
        (machine-by-system-id system-id target)
        (machine-by-system-id system-id))
-     ;; INTERNAL frame-last. The system-ids reverse index is durable machine
-     ;; runtime-db state — read it off the runtime-db partition. Normalize a
-     ;; frame VALUE target to its frame-id first (`frame-runtime-db-value` keys
-     ;; the registry by the bare id); a keyword id passes through unchanged.
+     ;; The reverse index is runtime-db state keyed by the bare frame id.
      (get-in (frame/frame-runtime-db-value (frame/frame-target->id frame-or-opts))
              (paths/system-id-path system-id)))))
 
@@ -227,9 +196,8 @@
 ;; `:system-id`: a machine ACTION addresses its spawned child actor by
 ;; `:system-id`. Actions can't read app-db and `:on-spawn`'s return is
 ;; dropped, so the fx form is the spec-blessed way an action sends a
-;; message to a named actor. This is the fx counterpart to the
-;; `dispatch-to-system` FN (`re-frame.core`); the fn is sugar for direct
-;; (queued) call sites, the fx is what a machine action emits from `:fx`.
+;; message to a named actor. The implementation-tier `dispatch-to-system` fn
+;; is sugar for direct queued call sites; actions emit the fx form.
 ;;
 ;; Args shape `[<system-id> <event-vector>]` — the framework fx contract
 ;; is a 2-element `[fx-id args]` pair (the `do-fx` walk drops arity-≥3
@@ -377,39 +345,14 @@
   (fn [runtime-db [_ machine-id tag]]
     (contains? (get-in runtime-db (paths/snapshot-path machine-id :tags)) tag)))
 
-;; ---- framework-standard registration (EP-0026 §Framework Standard Registrations)
+;; ---- framework-standard registration -------------------------------------
 ;;
-;; The machine runtime effects + subs above are FRAMEWORK STANDARDS: reserved
-;; `:rf.machine/*` / `:rf/machine*` ids encoding the execution invariants of the
-;; spec/005 machine subsystem (spawn / destroy / timed transitions / the
-;; snapshot reader subs). Like `:rf/set-db` + the standard `:rf.interceptor/*`
-;; interceptors, they must be UNIONED INTO EVERY resolved image generation —
-;; otherwise an image-loaded frame (one created with an explicit `:images`
-;; `:select-ns` scope, e.g. a Story variant frame scoped to its app namespace)
-;; resolving `[:rf.machine/spawn …]` / `[:rf/machine …]` under a bound
-;; `*generation*` could NOT resolve it (generation-routed `registrar/lookup`
-;; reads ONLY the generation's resolver — no fallback to the registrar atom), so
-;; the machine never spawns and any hosted machine (incl. the Story lifecycle
-;; machine) silently stalls. These ids register via the runtime `reg-fx` /
-;; `reg-runtime-sub` FNs (not the provenance-stamping macros), so they carry NIL
-;; `:rf.provenance/ns` and a `:select-ns` image cannot reach them by namespace —
-;; the framework-standard union is the ONLY mechanism that keeps them live in
-;; every generation.
-;;
-;; The standards are NON-replaceable (default): a public app image MUST NOT
-;; shadow a reserved machine id — a collision FAILS LOUD
-;; (`:rf.error/image-standard-replacement-forbidden`). The standard descriptor is
-;; the SAME runnable descriptor the regular registrar stores, so a
-;; generation-routed resolution returns a value byte-shape-identical to the
-;; registrar path.
-;;
-;; The descriptors are CAPTURED at ns-load (immediately after the `reg-fx` /
-;; `reg-runtime-sub` forms above wrote them) into `machine-runtime-descriptors`
-;; so `install-machine-runtime!` can re-register BOTH the regular registrar AND
-;; the standard registry AFTER a `registrar/clear-all!` — which wipes the
-;; registrar slots, so reading them back at re-install time would find nothing.
-;; This is the machine analogue of `events/register-set-db-standard!` (re-seeds
-;; both the registrar and the standard registry on every `init!` / reset).
+;; Reserved machine effects and subscriptions must resolve in every image
+;; generation. They have no namespace provenance, so image selection cannot
+;; discover them; the framework-standard union is their generation path.
+;; Standards are non-replaceable and use the same descriptors as the regular
+;; registrar. Capture those descriptors at namespace load so reset can restore
+;; both registries after `registrar/clear-all!`.
 
 (def ^:private machine-runtime-descriptors
   "Captured at ns-load: the `[kind id descriptor]` triples for every machine
@@ -432,24 +375,14 @@
            [:sub :rf.machine/has-tag?]])))
 
 (defn install-machine-runtime!
-  "Re-register the machine runtime effects + subs into BOTH the regular
-  registrar AND the EP-0023 framework-standard registry. Idempotent.
+  "Re-register machine runtime effects and subscriptions in both the regular
+  registrar and framework-standard registry. Idempotent.
 
-  - The REGULAR registrar registration is the no-generation / default-image
-    resolution path — `registrar/lookup` reads the atom directly, so a
-    no-generation caller (e.g. `rf/compute-sub [:rf/machine …]` in a test, or a
-    default-image frame) resolves the machine runtime here.
-  - The STANDARD registration is unioned into EVERY resolved image generation,
-    so an image-loaded frame (a Story variant frame scoped to its app namespace)
-    resolves `[:rf.machine/spawn …]` / `[:rf/machine …]` through its sealed
-    generation (which carries ONLY the standard union + the image selection — no
-    registrar fallback).
+  The regular registrar serves no-generation/default-image lookups. The
+  standard registry supplies the same handlers to sealed image generations.
 
-  Re-registers from the ns-load-captured `machine-runtime-descriptors` so it
-  works even after a `registrar/clear-all!` has wiped the registrar slots (the
-  machine analogue of `events/register-set-db-standard!`). Called at ns load
-  (below), from the `:machines/install-runtime!` late-bind hook the reset fixture
-  fires, and directly by tests that wipe the registrar with `clear-all!`."
+  Uses descriptors captured at namespace load, so it still works after the
+  registrar has been cleared."
   []
   (doseq [[kind id desc] machine-runtime-descriptors]
     (registrar/register! kind id desc)
@@ -471,60 +404,21 @@
 
 ;; ---- spawned-actor ownership ----------------------------------------------
 ;;
-;; Per Spec 014 §Abort on actor destroy: a managed `:rf.http/managed`
-;; request "belongs to" a spawned actor when its originating event-id is
-;; that actor's address. The ownership decision is MACHINES-OWNED and
-;; published through the `:machines/owning-actor-id` hook, so the structural
-;; read lives next to the runtime-db shape it depends on. http reaches it
-;; via `late-bind/get-fn` and falls back to nil when machines is absent.
-;;
-;; SET SEMANTICS: the owning set is SNAPSHOT MEMBERSHIP — `event-id` owns a
-;; request iff a SPAWNED actor's snapshot lives at
-;; `[:rf.runtime/machines :snapshots <event-id>]`, where "spawned" is the
-;; durable `:rf/machine-type`-at-root discriminator `install-spawn!` stamps
-;; on EVERY spawned actor (declarative `:spawn` / `:spawn-all` AND
-;; imperative `[:rf.machine/spawn ...]`), and a singleton's snapshot never
-;; carries it. Snapshot membership covers imperatively-spawned actors as
-;; well as declarative ones: imperative spawns install a snapshot WITHOUT a
-;; `:spawned` registry slot (the slot is gated on the declarative-desugar
-;; `:rf/parent-id` + `:rf/invoke-id`, per `lifecycle-fx.spawn/spawn-fx`'s
-;; `track?`), so keying on the snapshot rather than the registry catches
-;; them and their managed HTTP is aborted on destroy. The destroy side
-;; fires `:http/abort-on-actor-destroy` for imperative destroys (via
-;; `lifecycle-fx.finalize` / `lifecycle-fx.frame-destroy`, which key on the
-;; SAME `:rf/machine-type` marker); the recording side keys on the SAME
-;; discriminator `frame-destroy/spawned-snapshot?` uses, so recording and
-;; teardown agree on exactly which ids are actors.
+;; Managed HTTP ownership is machines-owned because it depends on the private
+;; snapshot shape. A request belongs to `event-id` exactly when that id has a
+;; live snapshot carrying `:rf/machine-type`. This includes declarative and
+;; imperative spawns, excludes singleton machines, and matches the destroy
+;; side's actor discriminator.
 
 (defn owning-actor-id
-  "Resolve the spawned-actor-id that OWNS `event-id` in `frame-id`, or nil.
+  "Return `event-id` when it names a live spawned actor in `frame-id`, else nil.
 
-  Returns `event-id` (a keyword — the spawned actor's machine address)
-  when a SPAWNED actor's snapshot is currently installed at
-  `[:rf.runtime/machines :snapshots <event-id>]`, otherwise nil — meaning
-  the event is NOT owned by a spawned actor (it came from an ordinary
-  event handler, or from a singleton machine whose snapshot carries no
-  `:rf/machine-type` marker).
+  Spawned actors are identified by `:rf/machine-type` on their live snapshot;
+  singleton machines do not carry that marker.
 
-  Published as the `:machines/owning-actor-id` late-bind hook so the http
-  artefact can ask machines \"who owns this request's originating event?\"
-  without statically `:require`ing this artefact or re-stating its private
-  runtime-db shape. When machines is absent the hook is unregistered and
-  http's caller falls back to nil.
-
-  Set semantics: SNAPSHOT MEMBERSHIP via the durable `:rf/machine-type`-at-
-  root discriminator — declarative `:spawn` / `:spawn-all` AND imperative
-  `[:rf.machine/spawn ...]` actors, since `install-spawn!` stamps that
-  marker on every spawned actor's snapshot and a singleton's snapshot never
-  carries it. This is the SAME discriminator the destroy side
-  (`frame-destroy/spawned-snapshot?`) keys on, so recording and teardown
-  classify ids identically (see the section comment above).
-
-  PERF: `frame/frame-runtime-db-value` is a substrate `deref` returning the
-  persistent runtime-db map BY REFERENCE (no copy, no scan), so the lookup
-  is a direct `get-in` to the candidate id's snapshot root — O(1), no scan
-  of the snapshot table. An app with no live spawned actors pays one
-  by-reference deref + one path descent that misses."
+  Published through late-bind so HTTP does not depend on this optional
+  artefact or duplicate its runtime-db shape. The lookup is a direct snapshot
+  path read; it does not scan the actor table."
   [frame-id event-id]
   (let [rt (frame/frame-runtime-db-value frame-id)]
     (when (map? rt)
@@ -594,7 +488,7 @@
 ;; `:rf.error/no-such-handler` BEFORE erroring:
 ;; given an unresolved event-id (a spawned actor-id with no per-instance
 ;; registration), the resolver materialises the actor's handler-meta from
-;; its (revertible) app-db snapshot, so `restore-epoch!` reverts actor
+;; its revertible runtime-db snapshot, so epoch restore reverts actor
 ;; liveness with ZERO registrar drift. Returns nil when no live snapshot
 ;; exists → core surfaces the genuine `:no-such-handler` (correct: the
 ;; actor is not alive in this frame value). The companion
@@ -624,10 +518,8 @@
 ;; the `:rf.runtime/machines` slice so each snapshot's `:data` is redacted /
 ;; elided per the per-frame elision registry's classified `:sensitive` /
 ;; `:large` paths under `:rf.egress/ssr-hydration` BEFORE it rides the wire —
-;; keeping classified machine data out of the hydration payload. EP-0025:
-;; machine `:data` classification rides the projection-relative subsystem
-;; declaration (lowered per actor under `:source :effect`); the commit-plane
-;; effects are the general app-db mechanism.
+;; keeping classified machine data out of the hydration payload. Machine
+;; declarations are lowered per actor under `:source :machine`.
 ;; Late-bound so SSR never statically requires the machines artefact.
 (late-bind/set-fn! :machines/project-ssr-runtime-db
                    machines-ssr/project-ssr-runtime-db)

--- a/implementation/machines/src/re_frame/machines/choice.cljc
+++ b/implementation/machines/src/re_frame/machines/choice.cljc
@@ -1,5 +1,5 @@
 (ns re-frame.machines.choice
-  "`:type :choice` transient / choice states (EP-0029 A5).
+  "`:type :choice` transient states.
 
   ## What a `:choice` state is
 
@@ -22,12 +22,11 @@
   DEFAULT / else branch (`{:target :rejected}`) so the choice state always
   resolves — see the registration rules below.
 
-  ## DIVERGENCE from XState — declarative candidate array, NOT a fn (A2 / C1)
+  ## Declarative candidates
 
-  XState v6 lets a `choice` state's routing be a `choice`-FUNCTION. re-frame2
-  REJECTS that (EP-0029 A2 \"a function may never be the edge\" / C1
-  \"opaque function-valued transitions\"). re-frame2's `:choice` is a
-  DECLARATIVE guarded-candidate array `[{:guard … :target …}]` — the edge
+  XState v6 lets a choice state's routing be a function. re-frame2 instead
+  requires a declarative guarded-candidate vector
+  `[{:guard … :target …}]`, so the edge
   topology stays data so diagrams, model tests, conformance fixtures, and AI
   tools can read it. A function-valued `:choice` (`:choice (fn …)`) fails
   LOUD at registration with `:rf.error/machine-bad-choice`.
@@ -49,7 +48,7 @@
   (`re-frame.machines.timeout`): a named-intent authoring concept lowering
   onto an existing mechanism.
 
-  ## Registration rules (fail-loud — EP-0029 A5 + Backwards Compatibility)
+  ## Registration rules
 
   Validated on the RAW (pre-desugar) spec so diagnostics name the
   `:type :choice` / `:choice` keys the author wrote:
@@ -69,9 +68,8 @@
     - the `:choice` vector MUST end with an unguarded DEFAULT / else
       candidate (a candidate with no `:guard`, an unconditional fallback).
       Without one the choice state could be ENTERED with every guard
-      failing and NO candidate to take — a stuck transient node. This is
-      the static \"no matching candidate + no default\" rejection (the EP's
-      fail-loud case); guards are runtime fns so the only registration-time
+      failing and NO candidate to take — a stuck transient node. Guards are
+      runtime functions, so the only registration-time
       guarantee that a choice always resolves is a present default
       (`:rf.error/machine-choice-no-default`).
     - a choice candidate that targets the choice state's OWN declaring
@@ -92,18 +90,18 @@
 
 (def reserved-choice-keys
   "The state-node keys a choice state MUST NOT declare alongside
-  `:type :choice` / `:choice` (EP-0029 A5: a choice state only routes — it
-  carries no ordinary waiting-state behaviour). A choice state declares
+  `:type :choice` / `:choice`. A choice state only routes and carries no
+  ordinary waiting-state behaviour. It declares
   EXACTLY `:type` + `:choice` (+ tooling `:meta` / `:source-coords`)."
   #{:entry :exit :on :always :after :timeout :on-timeout
     :spawn :spawn-all :initial :states :final? :output-key})
 
 ;; ---- desugaring `:choice` → `:always` -------------------------------------
 ;;
-;; `:choice` is a DISTINCT authoring concept that LOWERS onto the existing
-;; `:always` eventless-transition mechanism (EP-0029 A5 — "distinct intent,
-;; one mechanism"). The desugar runs at registration / transition
-;; normalisation time so the runtime never sees `:type :choice` / `:choice`
+;; `:choice` is a distinct authoring concept that lowers onto the existing
+;; `:always` eventless-transition mechanism. The desugar runs during
+;; registration and transition normalisation, so the runtime never sees
+;; `:type :choice` / `:choice`
 ;; directly — it sees the equivalent `:always` candidate vector. The grammar
 ;; (the `:type :choice` marker + the `:choice` slot, with its own validation)
 ;; is what the AUTHOR writes; the `:always` slot is what the ENGINE drives.
@@ -195,9 +193,8 @@
 ;; ---- registration-time validation -----------------------------------------
 ;;
 ;; Validation runs on the RAW (pre-desugar) machine so error messages name
-;; the `:type :choice` / `:choice` keys the author wrote. It enforces, per
-;; EP-0029 A5 + Backwards-Compatibility, the rules catalogued in the ns
-;; docstring.
+;; the `:type :choice` / `:choice` keys the author wrote. It enforces the
+;; rules catalogued in the namespace docstring.
 
 (defn- choice-error
   "Build a `:choice`-grammar validation ex-info with the canonical

--- a/implementation/machines/src/re_frame/machines/classification.cljc
+++ b/implementation/machines/src/re_frame/machines/classification.cljc
@@ -1,32 +1,10 @@
 (ns re-frame.machines.classification
-  "Machine-owned, PROJECTION-RELATIVE durable `:data` classification —
-  the EP-0025 §subsystems reversal of the rf2-398kql frame-owned model.
+  "Projection-relative classification for durable machine `:data`.
 
-  ## The reversal (EP-0025 B5, rf2-h3d8tf — authorised by Mike's B0 ruling)
-
-  rf2-398kql made the FRAME the sole owner of a machine's durable `:data`
-  classification: an app declared the ABSOLUTE runtime-db snapshot path
-  (`[:rf.runtime/machines :snapshots <actor-id> :data :token]`) on
-  `reg-frame` `:sensitive` / `:large {:app-db …}`. That is the
-  storage-position problem EP-0025 names: the author had to know the
-  framework's runtime-db storage shape AND name each spawned instance id by
-  hand, fail-open under refactor and on every generated `<type>#<n>`.
-
-  EP-0025 reverses it: the machine **definition** declares its sensitive /
-  large `:data` slots PROJECTION-RELATIVE to one actor snapshot's `:data`
-  (the matrix projection root), and the runtime lowers them PER ACTOR
-  INSTANCE — at spawn / singleton first-boot — into the SAME per-frame
-  elision registry (`[:rf.runtime/elision …]`, EP-0025 B3), dropping them on
-  destroy (by any cause). The declaration travels with the machine def and
-  applies to every instance, so a `:spawn`-generated `<type>#42` is
-  classified with zero per-instance author code — XState-v5-conformant
-  semantics (the classification rides the machine def like `context` shape,
-  applied per actor).
-
-  ## Projection root + lowering
-
-  The matrix projection root is **one actor snapshot's `:data`**, so an
-  author writes snapshot-relative `:data`-rooted paths:
+  A machine definition declares `:sensitive` and `:large` paths relative to
+  one actor snapshot. The runtime lowers them to absolute runtime-db paths for
+  each singleton or spawned actor, and removes the machine-owned declarations
+  when that actor is destroyed:
 
   ```clojure
   (rf/reg-machine :checkout/payment
@@ -35,34 +13,10 @@
      :schemas {:data …}, :initial …, :states …})
   ```
 
-  At spawn / first-boot the runtime LOWERS each declared path per actor by
-  prefixing the instance's absolute snapshot prefix
-  `[:rf.runtime/machines :snapshots <actor-id>]`, producing the absolute
-  runtime-db declaration the egress read path already consumes
-  (`re-frame.classification/frame-snapshot-classification` re-roots it snapshot-relative; the
-  SSR / trace / projection boundaries are UNCHANGED — the SOURCE of the
-  registry entry is `:source :machine`, a peer of the general commit-plane
-  `:source :effect` route).
-
-  ## Read path is untouched
-
-  The registry is the single source of truth for snapshot-`:data` egress
-  classification (`frame-snapshot-classification` reads `(keys decls)` from
-  `re-frame.elision/sensitive-declarations` / `declarations`, unioning ALL
-  sources). Lowering a machine declaration there at the absolute snapshot
-  path makes the existing trace-egress / SSR-hydration redaction fire with
-  NO change to those readers — the reversal is a write-source flip, not a
-  new read mechanism.
-
-  ## Failure posture (EP-0025)
-
-  Fail-LOUD on a malformed declaration AT REGISTRATION (a non-vector
-  `:sensitive` / `:large`, a non-path entry) — a hygiene helper declared
-  wrong is an author bug, surfaced at `reg-machine` like every other
-  registration-shape fault. Fail-OPEN on omission (an undeclared slot ships
-  raw — the hygiene bargain). The lowering itself is value-INDEPENDENT: the
-  declaration redacts whatever later occupies the snapshot `:data` slot, a
-  harmless no-op over an absent value."
+  Lowered declarations use `:source :machine` in the frame's elision registry,
+  so existing trace, SSR, and projection readers need no machine-specific path.
+  A malformed declaration fails at registration. Omitting classification leaves
+  the data unclassified."
   (:require [re-frame.elision :as elision]
             [re-frame.error :as error]
             [re-frame.machines.paths :as paths]
@@ -71,20 +25,16 @@
 #?(:clj (set! *warn-on-reflection* true))
 
 (def ^:private classification-axis-keys
-  "The two EP-0025 projection-relative declaration axes a `reg-machine`
-  spec may carry — `:sensitive` (redact at egress) and `:large` (size
-  marker at egress). The CLEAR tails (`:clear-sensitive` / `:clear-large`)
-  are handler-effect verbs, not registration declarations — a machine
-  declares standing classification, it does not un-classify at definition
-  time."
+  "The projection-relative declaration axes accepted by `reg-machine`."
   #{:sensitive :large})
 
 (defn- declaration-defect
   "PURE fail-loud-INPUT validator for one machine classification axis
   payload. Returns a human reason string for the FIRST defect, or nil when
   the payload is well-shaped. A payload is well-shaped iff it is a vector of
-  valid concrete `:rf/path` vectors (EP-0012 — the same shape the four
-  commit-plane effects validate, `re-frame.elision/classification-effect-defect`).
+  valid concrete `:rf/path` vectors, the same shape accepted by the four
+  commit-plane classification effects
+  (`re-frame.elision/classification-effect-defect`).
   Value-INDEPENDENT: validates the SHAPE of the declaration, never a runtime
   value."
   [k payload]
@@ -112,7 +62,6 @@
   "Fail LOUD at the `reg-machine` boundary when a machine spec's
   projection-relative `:sensitive` / `:large` declaration is malformed (a
   non-vector axis, a non-path entry, an invalid `:rf/path` segment) — the
-  EP-0025 fail-loud-input posture, surfaced as
   `:rf.error/invalid-machine-classification` at registration like every other
   registration-shape fault. A spec that declares NEITHER axis is a clean
   no-op (the common fail-open case — an undeclared machine ships its `:data`
@@ -168,9 +117,9 @@
   (`:sensitive-declarations` / `:declarations` — the SAME slots the four
   commit-plane effects and `reg-flow` outputs populate) WITHOUT clobbering a
   foreign-source standing entry (the registry is one-entry-per-path-per-axis;
-  an app-effect / flow / route claim on the SAME absolute path is left
-  standing — same posture as the commit-plane SET, rf2-p4spo4); DROP is
-  SOURCE-SCOPED — it dissocs a named absolute path ONLY when its standing entry
+  an app effect, flow, or route claim on the same absolute path is left
+  standing). DROP is SOURCE-SCOPED: it dissocs a named absolute path only when
+  its standing entry
   is the machine's own (`:source :machine`). A path ALSO claimed by another
   source (Spec 015 L149 explicitly permits an app to additionally classify a
   subsystem absolute path from a handler effect, `:source :effect`) is LEFT
@@ -178,8 +127,7 @@
   still classifies (a privacy fail-open). Mirrors the effect clear
   (`re-frame.elision/apply-classification-effects`, source-scoped) and the
   route lowering (`re-frame.routing.classification/without-route-sourced`,
-  which filters `:source :route`) — the sibling subsystems' source-scoped
-  drops (rf2-7bsyza). An emptied axis slot is pruned. Returns the new registry
+  which filters `:source :route`). An emptied axis slot is pruned. Returns the new registry
   value."
   [reg actor-id decls set?]
   (reduce
@@ -218,7 +166,7 @@
   declarations into `frame-id`'s per-frame elision registry, PER ACTOR
   INSTANCE — re-rooting each snapshot-relative `:data` path to the absolute
   snapshot path for `actor-id` and writing it `{:source :machine}` into the
-  registry (EP-0025 §subsystems). A no-op when the spec declares no
+  registry. A no-op when the spec declares no
   classification (the common fail-open case) or `actor-id` is nil. Runs at
   spawn / singleton first-boot, the instance-birth point — so a
   `:spawn`-generated `<type>#n` is classified the moment its snapshot
@@ -239,8 +187,7 @@
 (defn drop-at-destroy!
   "DROP the machine `spec`'s per-instance classification declarations for
   `actor-id` from `frame-id`'s elision registry — the teardown half of
-  `lower-at-spawn!` (EP-0025 §subsystems: a subsystem instance's
-  classification lives and dies with the instance). Dissocs exactly the
+  `lower-at-spawn!`. Dissocs exactly the
   absolute snapshot-rooted paths the spawn lowered (other-sourced entries
   for the same path survive); an emptied axis slot is pruned so a frame that
   destroys its last classified actor is left without a stray registry

--- a/implementation/machines/src/re_frame/machines/cofx_attach.cljc
+++ b/implementation/machines/src/re_frame/machines/cofx_attach.cljc
@@ -1,7 +1,6 @@
 (ns re-frame.machines.cofx-attach
   "Machine consumer-attachment for recordable coeffects. Per Spec 005
-  §Consumer attachment — declaring requirements on named entries + EP-0017
-  slice-B.9.
+  §Consumer attachment — declaring requirements on named entries.
 
   ## What this namespace does
 
@@ -47,7 +46,7 @@
        `:data`). Both are recommendations (Spec 005 §Consumer attachment /
        EP-0017 §9), emitted at registration and DCE'd in production.
 
-  ## Sub-valued recordable source (EP-0017 Option A rider, rf2-h6ggnt)
+  ## Sub-valued recordable source
 
   A machine named entry may declare the map form `{:rf/sub query-v :as
   fact-id}` in its `:rf.cofx/requires` — a sub-valued RECORDABLE coeffect
@@ -203,8 +202,8 @@
   declaration raises `:rf.error/cofx-request-invalid` / a duplicate id
   `:rf.error/cofx-name-collision` IDENTICALLY to a `reg-event` handler — but
   with `allow-sub?` TRUE, so a machine named entry may additionally declare
-  the sub-valued recordable source `{:rf/sub query-v :as fact-id}` (EP-0017
-  Option A rider, rf2-h6ggnt), which a `reg-event` handler cannot.
+  the sub-valued recordable source `{:rf/sub query-v :as fact-id}`, which a
+  `reg-event` handler cannot.
   `failing-id` is the `[machine-id-placeholder slot id]`-style label for the
   error payload. Returns `[]` for an entry with no requires."
   [slot entry-id v]
@@ -226,7 +225,7 @@
 
 (defn- always-entries
   "Normalise a state-node's `:always` slot to a vector of entry maps through
-  the SHARED `grammar/candidate-maps` (the ONE owner — rf2-tu5psi). Two
+  the shared `grammar/candidate-maps`. Two
   caller-specific policies stay HERE, not in the shared normaliser:
 
     1. the optional `:always` nil semantics — an absent `:always` (missing
@@ -241,7 +240,7 @@
   A `:type :choice` transient node carries its candidate vector under
   `:choice`, NOT `:always` — the choice lowers to `:always` only at
   `choice/desugar-node-choice`, and the index + ensure-set run on the RAW
-  pre-desugar machine (rf2-4y4bzq). Since a choice state routes through the
+  pre-desugar machine. Since a choice state routes through the
   IDENTICAL `:always` cascade the runtime settles it into, treat a choice
   node's `:choice` vector as its `:always` candidates here; validation
   guarantees a choice node never ALSO declares `:always` (a reserved key), so
@@ -275,8 +274,7 @@
   parsed by `index-ensure-sets`; this pass catches the ILLEGAL homes. A
   `:type :choice` node's candidates are swept via `always-entries` (which
   reads its `:choice` vector — the choice lowers to `:always`); the diagnostic
-  labels them `:choice` so the author sees the slot they actually wrote
-  (rf2-4y4bzq)."
+  labels them `:choice` so the author sees the slot they actually wrote."
   [machine]
   (let [roots (if (and (map? (:regions machine)) (seq (:regions machine)))
                 (cons machine (vals (:regions machine)))
@@ -330,8 +328,8 @@
 
 (defn- candidate-maps
   "Normalise a transition-slot value to its candidate maps (each carrying
-  `:guard` / `:action` / `:target`) via the SHARED `grammar/candidate-maps`
-  (the ONE owner — rf2-tu5psi), mapping the malformed form (grammar returns
+  `:guard` / `:action` / `:target`) via the shared `grammar/candidate-maps`,
+  mapping the malformed form (grammar returns
   nil) to NO candidates: `validation` is the designated throw surface, so a
   malformed shape contributes nothing to the static ensure-set here."
   [v]
@@ -534,9 +532,8 @@
   routes it to the SCHEDULING node at `decl-path` and selects the `:after`
   entry at `delay-key` (`transition/pick-after-transition`) — a slot separate
   from `:on`, so an `:after` guard/action declaring `:rf.cofx/requires` is
-  invisible to the `:on` walk. This adds it, mirroring how `parallel-root-diet`
-  handles the parallel-ROOT `:after` (rf2-iyrc9t: the per-state / per-region
-  `:after` had no such clause).
+  invisible to the `:on` walk. This adds it, mirroring how
+  `parallel-root-diet` handles the parallel-root `:after`.
 
   `region` is the region name when `states` is a parallel region's `:states`
   body, else nil. Within a region the carried decl-path is region-qualified
@@ -590,7 +587,7 @@
   (`[:rf.machine.timer/after-elapsed delay-key epoch decl-path]`), the
   scheduling node's `:after`-table transition at `decl-path` / `delay-key`
   joins the set (guard/action diet + the `:always` closure from its target) —
-  a slot separate from `:on`, so the `:on` walk misses it (rf2-iyrc9t).
+  a slot separate from `:on`, so the `:on` walk misses it.
   `region` is the region name when `states` is a parallel region's body (so the
   region-qualified decl-path can be stripped / declined), else nil.
 
@@ -665,7 +662,7 @@
     ;; scheduling node's `:after`-table transition at decl-path/delay-key — a
     ;; slot separate from `:on`. Add its candidates' guard/action diet + the
     ;; `:always` closure from each target, mirroring `parallel-root-diet`'s
-    ;; root-`:after` clause (rf2-iyrc9t).
+    ;; root-`:after` clause.
     (after-diet-for-event by-entry states event region add! add-always!)
     @acc))
 
@@ -961,8 +958,7 @@
   `re-frame.source-coords/walk-element-source` →
   `collocate-element-source`), so the scan must read it BACK to a form before
   `tree-seq` — a `tree-seq` over a raw string yields the string as a single
-  LEAF, finding zero keyword tokens, which left the diagnostic dead against
-  real macro output (rf2-wbh50l).
+  leaf, finding zero keyword tokens.
 
   A non-string `:source-code` (a pre-stringified FORM — the shape the scan's
   own contract documents and hand-built specs may carry directly) is returned
@@ -1001,7 +997,7 @@
 (defn lint-machine!
   "Run the dev-only consumer-attachment lints over `machine` (carrying the
   registration index), tagging diagnostics with `machine-id`. Per Spec 005
-  §Consumer attachment + EP-0017 §9. A no-op under `interop/debug-enabled?
+  §Consumer attachment. A no-op under `interop/debug-enabled?
   false` (production) and when the machine declares no requires.
 
   Recommendation-grade: emits `:rf.warning/*` diagnostics, never throws.
@@ -1023,9 +1019,8 @@
                     (emit-ambient-durable! machine-id slot entry-id id)))))
             ;; (1) consume-without-declaring — heuristic source scan. The
             ;; macro-captured `:source-code` is a `pr-str` STRING; parse it
-            ;; back to a form (rf2-wbh50l — a `tree-seq` over the raw string
-            ;; is a single LEAF, so the scan found nothing and the diagnostic
-            ;; never fired against real macro output) then scan it for
+            ;; back to a form (`tree-seq` treats the raw string as one leaf),
+            ;; then scan it for
             ;; `:rf.cofx`-record leaf reads not covered by `declared`. We
             ;; look for symbol/keyword tokens of the shape `<ns>/<name>`
             ;; destructured beside a `:rf.cofx`/`cofx` binding. Shallow by
@@ -1045,8 +1040,7 @@
                                    (some? (registrar/lookup :cofx t)))]
                   (emit-consume-undeclared! machine-id slot entry-id t))))))))))
 
-;; ---- sub-valued recordable source evaluator (EP-0017 Option A rider) -------
-;;    (rf2-h6ggnt)
+;; ---- sub-valued recordable source evaluator -------------------------------
 ;;
 ;; Core `re-frame.cofx/deliver-declared-cofx` delivers a machine sub-valued
 ;; recordable source (`{:rf/sub query-v :as fact-id}`) by reaching this

--- a/implementation/machines/src/re_frame/machines/data_validation.cljc
+++ b/implementation/machines/src/re_frame/machines/data_validation.cljc
@@ -3,12 +3,11 @@
   `:where :machine-output` boundaries.
 
   Per Spec 005 §Schema validation: a machine spec may declare its
-  data-context schema at `[:schemas :data]` (the machine-level `:schemas`
-  map, EP-0029 A3 — the clean-break successor to the retired EP-0005
-  `:data-schema` key). Its value validates the machine's `:data` slot. This
+  data-context schema at `[:schemas :data]`. Its value validates the machine's
+  `:data` slot. This
   namespace owns the boundary-validation call site.
 
-  Per Spec 005 §Final states + EP-0029 A8 the SAME machine `:schemas` map may
+  Per Spec 005 §Final states the same machine `:schemas` map may
   declare a `[:schemas :output]` schema. It validates the COMPLETION-OUTPUT
   payload — the `result` a finishing machine selects from its final state's
   `:data` via `:output-key` and delivers to the parent's `:on-done`
@@ -34,7 +33,7 @@
   `[:schemas :data]`, or for which `machine-meta` returns nil (spawned actor
   whose host spec is gone), pass silently.
 
-  Schema-library-agnostic (EP-0029 Non-goal + rf2-49zxkc). The `[:schemas
+  Schema-library-agnostic. The `[:schemas
   :data]` value is an OPAQUE schema — this namespace never `:require`s Malli
   (or any schema library) and never interprets the value itself. Validation
   goes ENTIRELY through the late-bound `:schemas/validate-with-registered-fn`
@@ -146,7 +145,7 @@
   Pure-ish — the emit is the side effect; the return value carries the
   conform decision for the caller's rollback / skip-install plumbing.
 
-  Per the bead's recovery posture:
+  Recovery depends on the write boundary:
     - `:phase :macrostep` and `:phase :bootstrap` → rollback? true
       (the snapshot is already in runtime-db at validation time; the
       router will restore the pre-handler db on a false return).
@@ -247,7 +246,7 @@
   in runtime-db. Returns true on conform / no schema / no validator; false on
   failure (caller skips the install).
 
-  Per the bead's recovery posture: a spawn failure does not commit, so
+  A spawn validation failure does not commit, so
   there is nothing to roll back — `:phase :spawn` emits with
   `:rollback? false`.
 
@@ -295,7 +294,7 @@
 
 (defn validate-completion-output!
   "Validate a finishing machine's COMPLETION-OUTPUT payload against its
-  `[:schemas :output]` schema (EP-0029 A8). `result` is the value the machine
+  `[:schemas :output]` schema. `result` is the value the machine
   selected from its final state's `:data` via `:output-key` — the payload the
   parent's `:on-done` receives. `spec` is the finishing actor's runtime-
   stamped machine spec (the finalize cascade holds it directly, so there is
@@ -305,7 +304,7 @@
   registered validator; false on failure (the boundary trace already
   emitted).
 
-  Per Spec 005 §Final states + EP-0029 A8 this is a BEST-EFFORT fail-loud
+  Per Spec 005 §Final states this is a best-effort fail-loud
   observation: the machine has ALREADY reached its final state when output is
   computed, so there is nothing to roll back (`:rollback? false`, the post-
   completion asymmetry — parity with the FX-atomicity post-commit best-effort

--- a/implementation/machines/src/re_frame/machines/error_emit.cljc
+++ b/implementation/machines/src/re_frame/machines/error_emit.cljc
@@ -1,98 +1,36 @@
 (ns re-frame.machines.error-emit
-  "Two-channel fan-out for the machine `:rf.error/machine-action-exception`
-  category — the fix for the broken production emit path (rf2-cprm0q).
+  "Always-on emission for `:rf.error/machine-action-exception`.
 
-  `:rf.error/machine-action-exception` is catalogued **always-on** (per
-  [009 §Error event catalogue](../../../../spec/009-Instrumentation.md)):
-  a machine action / guard body that throws is a production-reachable runtime
-  failure an off-box shipper (Sentry / Datadog) MUST still see on a
-  `:advanced` + `goog.DEBUG=false` build (a 2am machine throw). Every machine
-  emit site (`lifecycle_fx/registration.cljc`, `lifecycle_fx/finalize.cljc`,
-  `lifecycle_fx/traces.cljc`) previously called ONLY the dev-gated
-  `trace/emit-error!`, so the record was DCE'd out of production entirely —
-  an always-on-catalogued category silently swallowed. This ns is the single
-  home the three sites route through so the always-on channel can never be
-  forgotten again.
+  This namespace owns only the production-surviving structural record, routed
+  through the late-bound error-emission substrate because the optional machines
+  artefact cannot require core's emitter.
 
-  This ns owns AXIS 1 ONLY — the always-on corpus-wide error-emit substrate
-  (surface #4, production-survivable, NOT gated by
-  `re-frame.interop/debug-enabled?`): a tight, STRUCTURAL-ONLY union record,
-  fanned out through the `:error-emit/dispatch-error-record` late-bind hook —
-  the SAME axis + hook the machine fail-closed spawn reject
-  (`:rf.error/machine-spawn-unregistered-type`) uses (`machines` ships above
-  core's require graph, so it cannot static-require `re-frame.error-emit`).
+  Dev traces remain direct `trace/emit-error!` calls at each call site. Under
+  `goog.DEBUG=false` those calls and their diagnostic prose fold away; routing
+  their maps through this always-on helper would retain that prose in the
+  production bundle.
 
-  ## Why axis 2 (the dev trace) is NOT routed through this ns (rf2-cprm0q elision)
-
-  The dev-only `re-frame.trace/emit-error!` surface (DCE'd under CLJS
-  `:advanced` + `goog.DEBUG=false`) carries the FULL, rich `tags` — INCLUDING
-  the dev-only diagnostic PROSE (`:reason` / `:exception-message`) the 009
-  elision probe pins as an eliminated sentinel (e.g. the destroy-`:exit`
-  `\"An :exit action threw …\"` string). That prose MUST DCE in production.
-
-  `trace/emit-error!` is a DIRECT call whose body folds to `nil` under
-  `goog.DEBUG=false`, so Closure drops the map literal it is handed — prose and
-  all — AS DEAD, but ONLY when that map is a DIRECT argument to the folded
-  call. If the dev `tags` map were instead handed to THIS ns's fn (an INDIRECT,
-  non-folding call — it fans out on the always-on late-bind hook), Closure
-  would have to retain the whole opaque map, and every prose string literal
-  inside it would survive into the production bundle (the exact rf2-cprm0q
-  regression: rerouting a fold-elided direct emit through an always-on helper
-  resurrects its prose).
-
-  So each emit site (`registration.cljc`, `finalize.cljc`, `traces.cljc`) keeps
-  its dev trace as its OWN DIRECT `trace/emit-error!` call — the fold-elidable
-  form — and calls THIS ns only with the structural always-on record. The two
-  channels never share a map, and the prose has no non-folding referent.
-
-  ## Attribution (rf2-cprm0q defect 2)
-
-  The always-on record carries the machine attribution the bead adds:
-  `:failing-id` (the throwing action / guard's keyword) + `:state` (the active
-  state path). These are machine-local CODE identifiers in the same privacy
-  class as `:event-id`, so an off-box shipper learns WHICH action / guard in
-  WHICH state threw — not just the bare category (\"machine :auth/flow threw\").
-
-  ## Payload hygiene (production-surviving — STRUCTURAL-ONLY)
-
-  The always-on record is NOT privacy-gated like the dev trace (which redacts
-  value-bearing slots at the marks-projection egress chokepoint). Per the
-  `:rf.error/machine-action-exception` catalogue row
-  ([009 §Error event catalogue](../../../../spec/009-Instrumentation.md):
-  \"the always-on record is STRUCTURAL-ONLY\"), the caller builds it from
-  structural VALUES only — the machine-local identifiers `:actor-id` /
-  `:failing-id` / `:state`, the discriminator enums `:phase` / `:recovery`,
-  `:frame`, and the raw `:exception` cross. The value-bearing slots — `:event`,
-  `:input`, the developer's arbitrary `:exception-data` (which may embed the
-  same app secrets a `:sensitive` machine `:data` mark gates), the free-text
-  `:reason` / `:exception-message` PROSE — are DELIBERATELY EXCLUDED: they ride
-  the dev trace only. The raw `:exception` IS carried: off-box shippers need the
-  host exception + stack, exactly as every other always-on error record does."
+  The always-on record may carry `:actor-id`, `:failing-id`, `:state`, `:phase`,
+  `:recovery`, `:frame`, and the raw `:exception`. Value-bearing `:event`,
+  `:input`, `:exception-data`, and free-text diagnostics belong only in the
+  privacy-gated dev trace. Per Spec 009 §Error event catalogue."
   (:require [re-frame.interop   :as interop]
             [re-frame.late-bind :as late-bind]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
 (defn emit-machine-action-exception!
-  "Fan the STRUCTURAL-ONLY `:rf.error/machine-action-exception` record out on
-  the ALWAYS-ON axis (surface #4) ONLY. Returns nil.
+  "Emit the structural `:rf.error/machine-action-exception` record on the
+  always-on channel. Returns nil.
 
-  `always-on` is the caller-built structural record (see the ns docstring
-  §Payload hygiene): `:actor-id` / `:failing-id` / `:state` (the rf2-cprm0q
-  attribution — machine-local code identifiers), the discriminator enums
-  `:phase` / `:recovery`, `:frame`, and the raw `:exception`. This fn stamps
-  `:error` + `:time` and fans it out UNCHANGED. It carries NO free-text prose
-  and NO value-bearing slots.
+  `always-on` is caller-built from the structural fields described in the
+  namespace docstring. This function stamps `:error` and `:time` before
+  dispatch; it must not receive free-text prose or value-bearing slots.
 
-  Axis 2 (the dev `trace/emit-error!`) is NOT routed through here — each emit
-  site keeps its own DIRECT `trace/emit-error!` call so the dev-only prose
-  folds away under `:advanced` + `goog.DEBUG=false` (see the ns docstring §Why
-  axis 2 is NOT routed through this ns). This fn is the single always-on home,
-  so the production-survivable channel can never be forgotten."
+  Dev `trace/emit-error!` calls must remain direct at their call sites so their
+  maps can be eliminated from production bundles."
   [always-on]
-  ;; Always-on (surface #4). Late-bound: `machines` ships above core's require
-  ;; graph, so the hook is nil (no-op) until `re-frame.error-emit` loads — bound
-  ;; once at that ns-load, so the lookup never misses in a live runtime.
+  ;; Late-bound because this optional artefact cannot require the core emitter.
   (when-let [dispatch-record! (late-bind/get-fn :error-emit/dispatch-error-record)]
     (dispatch-record! (assoc always-on
                              :error :rf.error/machine-action-exception

--- a/implementation/machines/src/re_frame/machines/grammar.cljc
+++ b/implementation/machines/src/re_frame/machines/grammar.cljc
@@ -137,7 +137,7 @@
   "Normalise a transition-table slot value to the vector of canonical
   candidate transition maps it denotes — the ONE owner of the value-form →
   candidate-maps mapping the `:on` / `:after` / `:always` / `:on-done` /
-  `:on-error` slots all share (rf2-tu5psi). Discriminates on the shared
+  `:on-error` slots all share. Discriminates on the shared
   `transition-value-form` recogniser:
 
     :nil              -> [{}]              (forbidden / internal no-op — the

--- a/implementation/machines/src/re_frame/machines/internal_events.cljc
+++ b/implementation/machines/src/re_frame/machines/internal_events.cljc
@@ -1,5 +1,5 @@
 (ns re-frame.machines.internal-events
-  "Public / private `:internal-events` (EP-0029 A6).
+  "Public/private event boundaries for `:internal-events`.
 
   ## What an internal event is
 
@@ -22,15 +22,11 @@
   events ADD over an ordinary `:on` clause is the public / private
   BOUNDARY: an EXTERNAL dispatch of a declared internal event is REJECTED.
 
-  ## DIVERGENCE from XState — a Clojure SET, NOT an array (A6)
+  ## Declaration shape
 
-  XState v6's `internalEvents` is an ARRAY. re-frame2 declares them as a
-  Clojure SET form — `:internal-events #{:tick}` — a re-frame2 idiom: a set
-  is the natural membership collection (the runtime boundary check is one
-  `contains?`), order is irrelevant, and a duplicate is structurally
-  impossible. This is alpha-drift-confirmed against xstate v6 alpha.3 (no
-  grammar drift vs the EP basis). Behavioural parity (a private event
-  surface) without API-mimicry (the JavaScript array form).
+  re-frame2 uses a set, `:internal-events #{:tick}`: membership is the only
+  operation, ordering is irrelevant, and duplicates are impossible. This
+  deliberately differs from XState v6's array form.
 
   An internal event's HANDLER is an ordinary `:on` clause (`:on {:tick
   {:target :checking}}` above) — that is HOW the machine handles the raised
@@ -54,7 +50,7 @@
   internal event handled within the machine's own plumbing is unaffected;
   only the outside caller is refused.
 
-  ## Registration rules (fail-loud — EP-0029 A6 + Backwards Compatibility)
+  ## Registration rules
 
   Validated on the registered spec so a misdeclaration is caught BEFORE the
   runtime ever drives the machine:
@@ -73,7 +69,7 @@
       event — declaring one internal is the public-vs-private collision the
       grammar rejects (`:rf.error/machine-internal-event-reserved`).
 
-  This is a LEAF namespace (no require on `transition` / `validation` /
+  This is a leaf namespace (no require on `transition` / `validation` /
   `parallel` / `registration`) so the validators and the dispatch boundary
   can both require it without a load cycle — the sibling of
   `re-frame.machines.choice` / `re-frame.machines.timeout`."
@@ -113,9 +109,8 @@
 
 ;; ---- registration-time validation -----------------------------------------
 ;;
-;; Per EP-0029 A6 + Backwards-Compatibility: a malformed `:internal-events`
-;; declaration, or a name that is BOTH a declared internal event AND a
-;; public `:on` transition key, fails loud at registration.
+;; A declared internal event is expected to have an ordinary `:on` handler.
+;; Validation covers declaration shape and reserved framework names only.
 
 (defn- internal-events-error
   "Build an `:internal-events`-grammar validation ex-info with the canonical
@@ -137,8 +132,8 @@
     (boolean (and ns (or (= ns "rf") (str/starts-with? ns "rf."))))))
 
 (defn validate-internal-events!
-  "Validate the machine's `:internal-events` declaration at registration
-  (EP-0029 A6). A machine that declares no `:internal-events` is a no-op.
+  "Validate the machine's `:internal-events` declaration at registration.
+  A machine that declares no `:internal-events` is a no-op.
   Enforces every rule in the ns docstring:
 
     - `:internal-events` MUST be a SET of keywords (the re-frame2 set-form

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
@@ -4,8 +4,8 @@
 
   `apply-transition-once` emits `[:rf.machine/destroy actor-id]` into
   the fx vector whenever exit cascades cross a `:spawn`-bearing state.
-  Per Spec 005 §Spawning, destroy unregisters the spawned actor's event
-  handler, clears its snapshot at `[:rf.runtime/machines :snapshots <id>]` in the spawning
+  Per Spec 005 §Spawning, destroy clears the actor's runtime-db snapshot at
+  `[:rf.runtime/machines :snapshots <id>]` in the spawning
   frame's runtime-db, and (if the actor was system-id-bound) clears the
   `[:rf.runtime/machines :system-ids]` reverse index entry.
 
@@ -54,10 +54,9 @@
   `destroy-single-actor!` path. An actor with a resolved
   `actor-id` is live iff ANY of the following survive:
 
-    - **Handler still registered** at `actor-id` in the event
-      registrar (final-state auto-destroy + prior explicit destroys
-      both unregister; a still-registered handler reliably means
-      \"not yet destroyed\").
+    - **Registrar entry present** at `actor-id`. Normal spawned actors resolve
+      lazily without a per-instance entry, but teardown still recognises and
+      clears a stale or externally installed entry.
     - **Snapshot present** at `[:rf.runtime/machines :snapshots actor-id]`
       (covers the mid-drain handler-replaced window + hand-crafted call
       sites).
@@ -69,7 +68,7 @@
       `:fx` vector, where the snapshot swap may not yet have landed.
 
   A truly-already-destroyed actor has all three gone — the unified
-  teardown projection + `registrar/unregister!` + `spawn-order/forget!`
+  teardown projection, registrar cleanup, and `spawn-order/forget!`
   run atomically per `destroy-single-actor!` / `destroy-single!` /
   `finalize-machine`. See Spec 005 §Destroy is silent-idempotent
   for the normative paragraph.
@@ -116,9 +115,8 @@
        REGARDLESS of whether the runtime-db swap landed — by the time
        frame-destroy runs the container may already be nil but the
        spawn-order entry still needs clearing;
-    8. when the swap landed, emit `:rf.machine/system-id-released` and
-       unregister the live event handler (last, so an in-flight trace emit
-       against the actor still resolves before the slot disappears);
+    8. when the swap landed, emit `:rf.machine/system-id-released` and clear
+       any registrar entry (normal spawned actors have none);
     9. release the actor's resource leases — fire
        `:rf.resource/release-owner` for owner `[:machine actor-id]` (Spec 016
        §Release authority is per owner kind, 016:290) so a resource the actor
@@ -133,7 +131,7 @@
   [frame-id actor-id teardown-args emit-destroyed!-fn]
   (exit-cascade/run-child-exit! frame-id actor-id)
   (finalize/abort-actor-in-flight-http! actor-id)
-  ;; Step 3 (EP-0025 §subsystems, rf2-h3d8tf): DROP this actor's
+  ;; Drop this actor's
   ;; per-instance classification declarations from the per-frame elision
   ;; registry — the teardown half of `classification/lower-at-spawn!`. A
   ;; subsystem instance's classification lives and dies with the instance,
@@ -182,7 +180,7 @@
   unified teardown projection (per
   `re-frame.machines.lifecycle-fx.teardown`), abort in-flight
   `:rf.http/managed` requests, emit the
-  `:system-id-released` trace, unregister the live event handler, and
+  `:system-id-released` trace, clear any registrar entry, and
   forget the actor from the per-frame spawn-order channel.
   The ordered teardown pipeline is shared with `destroy-single!` via
   `teardown-live-actor!`.
@@ -276,8 +274,8 @@
   error.
 
   The liveness probe must distinguish *already-destroyed* (the actor
-  was alive, the teardown projection ran, the registrar slot was
-  cleared) from *not-yet-materialised-snapshot* (the actor IS alive
+  was alive and the teardown projection ran) from
+  *not-yet-materialised-snapshot* (the actor IS alive
   in this drain — a spawn + destroy back-to-back in the same `:fx`
   vector, before the snapshot swap landed — but its snapshot is not
   yet installed at `[:rf.runtime/machines :snapshots actor-id]`).
@@ -287,10 +285,9 @@
 
   `live?` is true iff ANY of the following hold:
 
-    - **Handler still registered** at `actor-id` in the event
-      registrar. Final-state auto-destroy (finalize.cljc) and prior
-      explicit destroys both unregister the handler; a still-
-      registered handler reliably means \"not yet destroyed.\"
+    - **Registrar entry present** at `actor-id`. Normal spawned actors have no
+      per-instance entry, but teardown recognises stale or externally installed
+      entries.
     - **Snapshot present** at `[:rf.runtime/machines :snapshots actor-id]`. Covers the
       narrow window where a singleton's handler has been replaced
       mid-drain but the snapshot still lives, plus belt-and-braces
@@ -307,7 +304,7 @@
       actor-id resolution above went via the slot lookup.
 
   A truly-already-destroyed actor has ALL FOUR gone — the unified
-  teardown projection + `registrar/unregister!` + `spawn-order/forget!`
+  teardown projection, registrar cleanup, and `spawn-order/forget!`
   run atomically per `destroy-single-actor!` and `finalize-machine`.
 
   See Spec 005 §Destroy is silent-idempotent for the normative paragraph."
@@ -320,7 +317,7 @@
                     (get-in old-db (paths/spawned-path parent-id invoke-id)))
         actor-id  (if tracked? slot-id args)
         ;; Silent-idempotent guard. `live?` is true iff ANY
-        ;; liveness signal survives. The first three (handler registered /
+        ;; liveness signal survives. The first three (registrar entry /
         ;; snapshot present / spawn-order entry) are the resolved-actor-id
         ;; signals shared with `destroy-single-actor!` via `actor-live?`
         ;; (both destroy paths apply the identical probe). The tracked-slot

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
@@ -18,13 +18,12 @@
     6. Tear down the child: dissoc snapshot, clear `[:rf.runtime/machines :spawned ...]`
        slot, clear `[:rf.runtime/machines :system-ids <sid>]` (D8 — AFTER `:on-done` ran),
        emit `:rf.machine/destroyed` with `:reason :rf.machine/finished`
-       (D6 enrichment), abort in-flight HTTP, unregister handler (D4).
+       (D6 enrichment), abort in-flight HTTP, and clear any registrar entry.
 
   For singleton machines (no `:rf/parent-id` on `:data`): skip steps 3-4
   and emit a `:rf.machine/done` with `:parent-id nil` (D7 — singleton
   symmetry). The teardown still runs — the snapshot is dissoc'd, the
-  `:system-id` reverse-index entry is cleared, and the handler is
-  unregistered.
+  `:system-id` reverse-index entry and any registrar entry are cleared.
 
   This namespace also owns `abort-actor-in-flight-http!` — the late-bind
   hook into the http-managed artefact — the single home for
@@ -32,7 +31,7 @@
   the spawn-destroy teardowns (`lifecycle-fx.destroy`), and the
   frame-destroy singleton-straggler pass (`lifecycle-fx.frame-destroy`).
 
-  The actor-teardown app-db dance lives in
+  The actor-teardown runtime-db projection lives in
   `re-frame.machines.lifecycle-fx.teardown` — one helper, three
   call-sites."
   (:require [re-frame.interop :as interop]
@@ -82,8 +81,8 @@
 ;; A machine's `[:schemas :data]` schema is validation-only; it does not produce
 ;; a per-instance marks table. There is therefore no schema-marks entry to
 ;; clear at destroy — a destroyed actor leaves no schema-marks residue by
-;; construction. A spawned actor's `:data` redaction (if any) rides the
-;; frame's declared paths, the sole app-db redaction mechanism.
+;; construction. A spawned actor's `:data` redaction rides the frame's merged
+;; classification registry, including per-actor `:source :machine` entries.
 
 ;; ---- final-state resolution -----------------------------------------------
 
@@ -245,7 +244,7 @@
                       parallel?                   (parallel-output-key machine (:state next-snapshot) frame-id machine-id)
                       :else                       (:output-key error-node))
         result      (when output-key (get child-data output-key))
-        ;; EP-0029 A8 — validate the COMPLETION-OUTPUT payload against the
+        ;; Validate the completion-output payload against the
         ;; finishing machine's `[:schemas :output]` schema, if declared. The
         ;; `result` selected from the final state's `:data` via `:output-key`
         ;; IS the completion-event payload (the value the parent's `:on-done`
@@ -466,8 +465,8 @@
                                   (catch #?(:clj Throwable :cljs :default) e
                                     ;; The `:on-done` callback IS a machine
                                     ;; action, so its throw rides the same
-                                    ;; always-on-plus-dev-trace fan-out
-                                    ;; (rf2-cprm0q): `:failing-id` is the
+                                    ;; always-on-plus-dev-trace fan-out;
+                                    ;; `:failing-id` is the
                                     ;; reserved `:rf.machine.spawn/on-done` slot id.
                                     ;; Axis 1 — STRUCTURAL-ONLY always-on
                                     ;; record (no prose; see error-emit).
@@ -523,9 +522,7 @@
                                   :parent-id parent-id
                                   :invoke-id invoke-id})
         ;; (5) Emit :rf.machine/destroyed with :reason :rf.machine/finished
-        ;; (D6 enrichment) BEFORE the registrar unregister so any in-flight
-        ;; trace consumers see the destroy signal while the handler still
-        ;; resolves.
+        ;; (D6 enrichment) before registrar cleanup.
         _ (traces/emit-destroyed! {:frame     frame-id
                                    :actor-id  machine-id
                                    :system-id released-sid
@@ -534,11 +531,11 @@
                                    :reason    :rf.machine/finished})]
     ;; (6) Synchronous side effects: abort in-flight HTTP, cancel
     ;; armed `:after` timers (`:reason :on-destroy`), emit
-    ;; system-id-released trace (when applicable), unregister handler.
+    ;; system-id-released trace (when applicable), and clear any registrar entry.
     (abort-actor-in-flight-http! machine-id)
     (timer/cancel-actor-timers! frame-id machine-id)
-    ;; EP-0025 §subsystems (rf2-h3d8tf): DROP this actor's per-instance
-    ;; classification declarations from the per-frame elision registry — the
+    ;; Drop this actor's per-instance classification declarations from the
+    ;; per-frame elision registry: the
     ;; teardown half of `classification/lower-at-spawn!`, on the final-state
     ;; AUTO-DESTROY path (which does NOT route through
     ;; `destroy/teardown-live-actor!`). `machine` is the finishing actor's

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/frame_destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/frame_destroy.cljc
@@ -13,11 +13,11 @@
     3. Abort that actor's in-flight `:rf.http/managed` requests
        (the `:http/abort-on-actor-destroy` contract holds
        across every destroy trigger including frame destroy).
-    4. Apply the unified app-db teardown projection — dissoc
+    4. Apply the unified runtime-db teardown projection — dissoc
        `[:rf.runtime/machines :snapshots <id>]`, release `[:rf.runtime/machines :system-ids <sid>]` when the
        actor was system-id-bound, prune `[:rf.runtime/machines :spawned]` slots.
-    5. Unregister the live actor event handler so subsequent dispatch
-       to the address surfaces `:rf.error/no-such-handler` cleanly.
+    5. Clear any stale registrar entry; normal spawned actors have no
+       per-instance registration.
     6. Emit `:rf.machine.lifecycle/destroyed` with
        `:reason :parent-frame-destroyed` per actor — the contract
        observable in `frame_lifecycle_test/destroy-frame-cascade-
@@ -47,8 +47,8 @@
   carries `:rf/machine-type` at its root (stamped by `install-spawn!`; a
   SINGLETON snapshot never carries it — actor_liveness_test:213). The
   straggler pass therefore SPLITS on that durable discriminator: spawned
-  stragglers run the FULL `destroy/destroy-single-actor!` teardown (handler
-  unregister, system-id release, timer cancel, snapshot dissoc) in
+  stragglers run the full `destroy/destroy-single-actor!` teardown (registrar
+  cleanup, system-id release, timer cancel, snapshot dissoc) in
   reverse-creation order DERIVED from the durable actor-id (the
   `#<n>` suffix), not the singleton straggler path that skips all of that.
   True singletons keep the exit-cascade-only straggler path."
@@ -76,8 +76,8 @@
     (or (get-in rt (paths/snapshot-path)) {})))
 
 (defn- spawned-snapshot?
-  "True iff `snapshot` is a SPAWNED actor's snapshot, not
-  a singleton's. The durable, app-db-derived discriminator is the presence
+  "True iff `snapshot` is a spawned actor's snapshot, not
+  a singleton's. The durable runtime-db discriminator is the presence
   of `:rf/machine-type` at the snapshot root: `install-spawn!` stamps it on
   every spawned actor (keyword TYPE or inline `:definition`), and a
   singleton's `build-initial-snapshot` snapshot never carries it
@@ -141,10 +141,10 @@
   "Singleton-machine destroy on frame teardown: run the actor's `:exit`
   cascade so Spec 005 §Final states §Composition with `:entry` /
   `:exit` symmetry holds, then abort in-flight HTTP. Does NOT
-  unregister the handler — singleton handlers live in the global
+  clear the registrar entry — singleton handlers live in the global
   registrar per Spec 005 §Spawning §v1-partial footnote: the handler
   outlives any particular frame. Snapshot dissoc is moot at this point
-  (the frame's app-db is about to be released).
+  (the frame's runtime-db is about to be released).
 
   The HTTP-abort fires the shared `:http/abort-on-actor-destroy`
   late-bind hook via `finalize/abort-actor-in-flight-http!` — the same
@@ -175,8 +175,8 @@
          not. Walked newest-first by `creation-rank` derived from the
          durable `<type>#<n>` actor-id, so reverse-creation order is
          reconstructed from durable state alone.
-      c. SINGLETON stragglers — snapshots with no `:rf/machine-type`
-         (registered via `reg-machine`, seeded directly). App-db iteration
+      c. Singleton stragglers — snapshots with no `:rf/machine-type`
+         (registered via `reg-machine`, seeded directly). Runtime-db iteration
          order — there is no reverse-creation contract for singletons.
    3. For each actor:
       a. Emit `:rf.machine.lifecycle/destroyed` BEFORE the destroy
@@ -186,7 +186,7 @@
       b. Spawned actors (recorded OR restored straggler): run the full
          single-actor destroy — exit-cascade → http-abort →
          timer cancel → unified teardown projection →
-         system-id-release trace → handler-unregister → spawn-order forget.
+         system-id-release trace → registrar cleanup → spawn-order forget.
       c. Singletons (registered via `reg-machine`, snapshot present but no
          `:rf/machine-type`): run the `:exit` cascade + HTTP abort, but
          DO NOT unregister the handler — singleton handlers live in the
@@ -229,7 +229,7 @@
              (catch #?(:clj Throwable :cljs :default) _ nil)))
       ;; (b') Restored spawned stragglers: SAME full destroy, newest-first
       ;; by durable creation rank. These get the complete spawned teardown
-      ;; (handler unregister / system-id release / timer cancel / snapshot
+      ;; (registrar cleanup / system-id release / timer cancel / snapshot
       ;; dissoc), not the exit-only singleton straggler path.
       (doseq [actor-id spawned-stragglers']
         (let [snapshot (get snapshots actor-id)]

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
@@ -18,8 +18,7 @@
    5. If `:resolved?` is already true, this is a post-resolution
       late-completion (it fires NO further parent event — the
       `:resolved?` latch already flipped). Surviving siblings are
-      UNCONDITIONALLY destroyed at resolution (rf2-w8gxxz cut the
-      `:cancel-on-decision? false` protocol), so a straggler with no live
+       unconditionally destroyed at resolution, so a straggler with no live
       join is a genuinely stale completion: the record stays frozen and
       the `:rf.machine.spawn-all/late-completion` trace fires (stale
       reply), with no `:done` / `:failed` fold.
@@ -29,7 +28,7 @@
         - unconditionally emits per-sibling `:rf.machine/destroy` fx and
           `:rf.machine.spawn/cancelled-on-join-resolution` traces,
         - dispatches the parent join event via `:fx [[:dispatch ...]]`.
-   7. Writes the new join state back into app-db.
+   7. Writes the new join state back into runtime-db.
 
   The interceptor's public entry point is `intercept-spawn-all-event`;
   the handler-factory in `re-frame.machines.lifecycle-fx.registration`
@@ -288,9 +287,8 @@
   `:rf.machine/destroy` (with one
   `:rf.machine.spawn/cancelled-on-join-resolution` trace each), followed by
   the join-event dispatch carrying the decisive child's forwarded payload.
-  Cancelling surviving siblings on the join decision is UNCONDITIONAL —
-  the removed `:cancel-on-decision? false` protocol let siblings run to
-  completion (rf2-w8gxxz cut it). Per Spec 005 §Spawn-and-join, the
+  Cancelling surviving siblings on the join decision is unconditional.
+  Per Spec 005 §Spawn-and-join, the
   dispatched event shape is:
 
       [<parent-id> [<resolution-event> <decisive-child-id> & <child-extra>]]
@@ -429,9 +427,8 @@
           ;; it is SUPPRESSED from RE-RESOLVING the join — exactly the
           ;; §Stale-suppression "fires no further parent event" rule.
           ;;
-          ;; Surviving siblings are UNCONDITIONALLY destroyed at resolution
-          ;; (rf2-w8gxxz cut the `:cancel-on-decision? false` protocol that
-          ;; let them run to completion), so a late completion is always a
+          ;; Surviving siblings are unconditionally destroyed at resolution,
+          ;; so a late completion is always a
           ;; genuinely stale straggler with no live join to fold into — the
           ;; record is left frozen at resolution. The public trace shape
           ;; (`:actor-id` / `:invoke-id` / `:child-id` / `:kind`) is

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
@@ -67,11 +67,10 @@
 ;;
 ;; The home runs exactly one `[:schemas :data]` side-effect: the
 ;; validation-stamp. The machine `[:schemas :data]` schema is VALIDATION-ONLY —
-;; per-slot props do not classify durable `:data` for snapshot egress. EP-0025:
-;; durable `:data` classification rides the projection-relative subsystem
-;; declaration (lowered per actor under `:source :effect`); the commit-plane
-;; `:sensitive` / `:large` effects are the general app-db data-classification
-;; mechanism.
+;; per-slot props do not classify durable `:data` for snapshot egress. Durable
+;; `:data` classification uses projection-relative machine declarations,
+;; lowered per actor under `:source :machine`; commit-plane
+;; `:sensitive` / `:large` effects are the general classification mechanism.
 (def ^:dynamic *in-registration-home?*
   "True while `make-machine-handler` is invoked from a registration site that
   ALSO stamps the `:rf/machine?` / `:rf/machine` meta (the single home, or the
@@ -142,7 +141,7 @@
   `:spawn :on-error`, route the failure to the parent's declarative
   `:on-error` transition via `spawn-error/dispatch-spawn-error!` — additive to
   (not a replacement for) the trace above, which still fires for every action
-  exception. `ctx` carries the failing actor's `:db` + `:snapshot` (whose
+  exception. `ctx` carries the failing actor's runtime-db and snapshot (whose
   `:data` was stamped with `:rf/parent-id` / `:rf/invoke-id` at spawn time);
   the exception envelope rides as the parent transition's `:event` payload so
   a guard / action can branch on it. Singletons (no parent) and parents that
@@ -155,17 +154,11 @@
         ex-data    (when ex (ex-data ex))
         action-ref (:action-ref info)
         state-path (:state-path info)
-        ;; `:failing-id` names the failing CODE identifier — uniform with the
-        ;; interceptor / cofx always-on categories (Spec 009 §What IS available
-        ;; §Attribution rule): the throwing action / guard's KEYWORD when it is
-        ;; a named `:actions` / `:guards` entry, else the live actor instance
-        ;; address (an anonymous inline fn has no keyword identity — the
-        ;; `:state` slot still attributes WHICH state's transition threw). It is
-        ;; ALWAYS a keyword. (Previously stamped `machine-id` unconditionally —
-        ;; the misattribution rf2-cprm0q defect 2 fixes: a machine throw
-        ;; arrived as \"machine :auth/flow threw\" with no action attribution.)
+        ;; `:failing-id` is always a keyword. A named action or guard uses its
+        ;; code identity; an anonymous callback falls back to the actor address.
+        ;; `:state` still attributes which state's transition threw.
         failing-id (if (keyword? action-ref) action-ref machine-id)]
-    ;; Fan out BOTH error channels (rf2-cprm0q defect 1): the always-on
+    ;; Fan out both error channels: the always-on
     ;; production-survivable record (surface #4, carrying `:failing-id` +
     ;; `:state`) AND the dev-only trace. Guard throws converge here too
     ;; (`transition/guard-threw->fail-info` projects the guard-ref onto
@@ -189,8 +182,8 @@
     ;; PROSE `:reason` / `:exception-message` and the value-bearing `:event` /
     ;; `:exception-data` (redacted downstream at the marks chokepoint) all
     ;; included — away under :advanced + goog.DEBUG=false. Leaving the direct
-    ;; call ungated beside the live always-on call above would leak the prose
-    ;; (rf2-cprm0q). `:state-path` is retained for the existing dev-trace shape.
+    ;; call ungated beside the live always-on call above would leak the prose.
+    ;; `:state-path` is retained for the dev-trace shape.
     (when interop/debug-enabled?
       (trace/emit-error! :rf.error/machine-action-exception
         {:actor-id          machine-id
@@ -268,7 +261,7 @@
 ;;      post-boot snapshot + inner event. Returns the Result from the
 ;;      pure engine.
 ;;   4. `commit-or-finalize`   — emit transition / snapshot-updated traces,
-;;      build new-db, route to `finalize-machine` if `finished?`.
+;;      build the new runtime-db, route to `finalize-machine` if `finished?`.
 ;;
 ;; The intercept-spawn-all-event short-circuit is the visible top-level
 ;; branch in `make-machine-handler` itself — it must short-circuit before
@@ -552,7 +545,7 @@
   signal Xray renders as the `[START]` badge in BOTH paths
   automatically. The trace is emitted only on success (a thrown `:entry`
   action short-circuits to `:fail` → `trace-action-failure!` instead).
-  Restoration paths (SSR / `restore-epoch!` / `replace-app-db`) install a
+  Restoration paths (SSR, epoch restore, or full frame-state replacement) install a
   present, non-pending snapshot, so `:needs-bootstrap?` is false and NO
   `:rf.machine/started` fires — the snapshot IS the state."
   [ctx]
@@ -625,7 +618,7 @@
 
 (defn- commit-or-finalize
   "Step 4 of 4. Emit `:rf.machine/transition` (and optional
-  `:rf.machine/snapshot-updated`) traces, build the new app-db, and
+  `:rf.machine/snapshot-updated`) traces, build the new runtime-db, and
   route to `finalize-machine` if the post-transition snapshot is on a
   final leaf / all regions final.
 
@@ -753,7 +746,7 @@
          :fx            merged-fx}))))
 
 (defn- reject-internal-event-external-dispatch
-  "The public / private `:internal-events` BOUNDARY (EP-0029 A6), checked at
+  "The public/private `:internal-events` boundary, checked at
   the machine dispatch boundary. If the routed `inner-event` names a
   declared INTERNAL event of `machine`, this is an EXTERNAL dispatch of a
   private event — reject it: emit `:rf.error/machine-internal-event-external-dispatch`
@@ -892,9 +885,7 @@
       ;; state. The handler reads the snapshot from the `:rf.db/runtime`
       ;; coeffect (a fresh frame's runtime-db is `nil` until first write —
       ;; default it to `{}` so the snapshot lookup / install paths see a map)
-      ;; and returns its snapshot write under `:rf.db/runtime`. `db` (app-db)
-      ;; is still threaded for the spawn-`:on-error` parent lookup +
-      ;; action-failure diagnostics.
+      ;; and returns its snapshot write under `:rf.db/runtime`.
       (let [runtime-db  (or rt {})
             ctx         (prepare-machine-ctx db runtime-db frame cofx mint-policy event machine base-initial)
             intercepted (join/intercept-spawn-all-event
@@ -902,7 +893,7 @@
                           (:machine-id ctx) (:inner-event ctx))]
         (if intercepted
           intercepted
-          ;; EP-0029 A6 — the public / private `:internal-events` BOUNDARY.
+          ;; Enforce the public/private `:internal-events` boundary.
           ;; If the routed inner event names a declared INTERNAL event, this
           ;; is an EXTERNAL dispatch of a private event: reject it (emit
           ;; `:rf.error/machine-internal-event-external-dispatch`, no-op `{}`
@@ -931,8 +922,7 @@
                                     "Machine initial-entry action threw."
                                     boot-result)
               (do
-                ;; EP-0025 §subsystems (rf2-h3d8tf): LOWER a SINGLETON's
-                ;; projection-relative `:sensitive` / `:large` `:data`
+                ;; Lower a singleton's projection-relative `:sensitive` / `:large` `:data`
                 ;; declarations into the per-frame elision registry at its
                 ;; birth (first-boot). A singleton's actor-id IS its
                 ;; machine-id, installed lazily on first dispatch rather than
@@ -1031,8 +1021,8 @@
 ;; validation contract only — its per-slot `:sensitive?` / `:large?` props do
 ;; NOT classify the machine's durable `:data` for trace / SSR egress.
 ;;
-;; EP-0025 §subsystems (rf2-h3d8tf): durable `:data` egress classification is
-;; MACHINE-OWNED and PROJECTION-RELATIVE — a machine declares its sensitive /
+;; Durable `:data` egress classification is machine-owned and projection-relative:
+;; a machine declares its sensitive /
 ;; large `:data` slots via top-level `:sensitive` / `:large` keys on the spec
 ;; (rooted at one actor snapshot's `:data`), validated for shape at registration
 ;; (`re-frame.machines.classification/validate-machine-classification!`, above)
@@ -1139,8 +1129,8 @@
   `:rf/machine?` / `:rf/machine` keys are stamped here and MUST NOT appear in
   `opts`.
 
-  The home runs the `[:schemas :data]` validation-stamp plus the EP-0025
-  projection-relative-classification shape check (rf2-h3d8tf). The
+  The home runs the `[:schemas :data]` validation stamp plus the
+  projection-relative classification shape check. The
   `[:schemas :data]` schema is validation-only — its per-slot props do not
   classify durable `:data` for egress; the machine's top-level `:sensitive` /
   `:large` projection-relative declarations are the classification surface
@@ -1178,8 +1168,7 @@
       {:recovery :drop-reserved-keys
        :extra    {:machine-id machine-id
                   :opts       opts}}))
-   ;; EP-0025 §subsystems (rf2-h3d8tf): fail LOUD at the registration
-   ;; boundary on a malformed projection-relative `:sensitive` / `:large`
+   ;; Fail at registration on malformed projection-relative `:sensitive` / `:large`
    ;; `:data`-classification declaration (a non-vector axis, a non-path
    ;; entry). The declaration travels with the machine def and is lowered
    ;; per actor instance at spawn / first-boot — so a shape fault must be
@@ -1211,8 +1200,9 @@
     ;; The `[:schemas :data]` schema VALIDATES `:data` (via the
     ;; `:where :machine-data` post-commit walker, resolved through the
     ;; `:rf/machine` meta stamped above); its per-slot props do not classify the
-    ;; machine's durable `:data` for trace / SSR egress — frame-declared
-    ;; `:sensitive` / `:large {:app-db …}` paths are the sole app-db mechanism.
+    ;; machine's durable `:data` for trace / SSR egress. Egress classification
+    ;; comes from the frame's merged classification registry, including
+    ;; per-actor `:source :machine` entries.
     ;; The dev-only consumer-attachment
     ;; lints (consume-without-declaring + ambient-durable). Run here in the
     ;; home (with the machine-id known) over a locally-indexed copy so the

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/resolver.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/resolver.cljc
@@ -72,7 +72,7 @@
       the snapshot; return it verbatim.
 
   Returns nil when the snapshot carries no `:rf/machine-type` (a
-  singleton snapshot, or a pre-resolver snapshot) or when a keyword type
+  singleton snapshot) or when a keyword type
   no longer names a registered machine (the type was cleared — a genuine
   missing reference)."
   [snapshot]
@@ -123,11 +123,9 @@
   non-empty vector, the path doesn't resolve, or the node declares no
   `:spawn`.
 
-  The single owner for the spawn-spec-at-invoke-id lookup shared by the
+  Shared owner for the spawn-spec-at-invoke-id lookup used by the
   finalize `:on-done` cascade (`finalize/finalize-machine`) and the
-  spawn-error `:on-error` routing (`spawn-error/parent-declares-on-error?`) —
-  the two carried byte-for-byte copies before this was hoisted here
-  (rf2-wm92kj), so a fix to the flat / region resolution had to land twice."
+  spawn-error `:on-error` routing (`spawn-error/parent-declares-on-error?`)."
   [parent-spec invoke-id]
   (when (and parent-spec (vector? invoke-id) (seq invoke-id))
     (let [[head & tail] invoke-id

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
@@ -4,19 +4,18 @@
 
   `apply-transition-once` emits `[:rf.machine/spawn args]` into the fx
   vector whenever entry cascades cross a `:spawn`-bearing state. Per
-  Spec 005 §Spawning, a spawned actor's liveness is
-  APP-DB-ONLY: `spawn-fx` seeds the actor's initial snapshot at
+  Spec 005 §Spawning, a spawned actor's liveness is runtime-db state:
+  `spawn-fx` seeds the actor's initial snapshot at
   `[:rf.runtime/machines :snapshots <spawned-id>]` in the spawning
-  frame's app-db, stamping the revertible TYPE reference at
+  frame's runtime-db, stamping the revertible type reference at
   `:rf/machine-type`. There is NO per-instance event-handler
   registration — the actor's liveness IS that snapshot's presence in the
   (revertible) frame value, and the snapshot's `:rf/machine-type` lets
   the lazy resolver (`lifecycle-fx.resolver`) re-materialise the actor's
-  handler on dispatch. Spawn is therefore a pure app-db write; destroy
-  removes only app-db, so `restore-epoch!` (app-db-only) reverts an
-  actor's liveness perfectly with zero registrar drift (the Goal-2
-  revertibility invariant). Frame isolation follows from the snapshot
-  living inside the spawning frame's app-db.
+  handler on dispatch. Spawn and destroy update runtime-db only. Epoch restore
+  replaces the whole captured frame state, so actor liveness rewinds without
+  registrar drift. Frame isolation follows from the snapshot living inside
+  the spawning frame's runtime-db.
 
   `spawn-all-init-fx` also lives here — the runtime
   emits `[:rf.machine/spawn-all-init args]` alongside per-child
@@ -50,7 +49,7 @@
   by the transition reducer (allocated from the parent snapshot's
   `:rf/spawn-counter`). Returns nil for hand-emitted
   `[:rf.machine/spawn args]` fxs that bypass the transition reducer —
-  the caller (`spawn-fx`) allocates such ids from the frame's app-db
+  the caller (`spawn-fx`) allocates such ids from the frame's runtime-db
   spawn-counter slot at `[:rf.runtime/machines :spawn-counter]` inside
   the spawn's db-swap so the allocation shares the same write."
   [args]
@@ -159,7 +158,7 @@
 (defn- machine-type-ref
   "The revertible TYPE reference stamped onto a spawned actor's snapshot root
   under `:rf/machine-type`, so the lazy resolver (`lifecycle-fx.resolver`)
-  can re-materialise the actor's handler purely from app-db. A `:machine-id`
+  can re-materialise the actor's handler purely from runtime-db. A `:machine-id`
   spawn stores the registered TYPE keyword (the type outlives every
   instance — registered like a singleton). An inline `:definition` spawn
   stores the spec map verbatim (there is no registered type; the snapshot is
@@ -214,14 +213,14 @@
   "Atomically install the spawned actor's `initial-snap` (with its
   revertible `:rf/machine-type` TYPE reference stamped at the root),
   system-id binding, and runtime-owned spawn registry slot
-  into the frame's app-db. Returns `:ok`. Emits the collision and
+  into the frame's runtime-db. Returns `:ok`. Emits the collision and
   system-id-bound traces when applicable.
 
   There is NO per-instance handler registration — the
   actor's liveness IS the presence of this snapshot in the (revertible)
   frame value, and the snapshot's `:rf/machine-type` lets the lazy
   resolver re-materialise the handler on dispatch. Spawn is therefore a
-  pure app-db write.
+  pure runtime-db write.
 
   Schema-rejection is decided by the caller (`spawn-fx`)
   via `spawn-rejected?` BEFORE this fn runs, so by the time
@@ -239,7 +238,7 @@
    {:keys [system-id parent-id invoke-id track? type-ref]}]
   (let [existing (when system-id (get-in rt-after-alloc (paths/system-id-path system-id)))
         ;; Stamp the revertible TYPE reference onto the snapshot root so the
-        ;; lazy resolver can re-materialise the handler from app-db alone. The
+        ;; lazy resolver can re-materialise the handler from runtime-db alone. The
         ;; spawn is known-accepted by the time `install-spawn!` runs (an
         ;; unregistered `:machine-id` was rejected fail-closed upstream), so
         ;; `spec` is always present; the `spec`/`type-ref` guards are
@@ -279,7 +278,7 @@
 (defn spawn-fx
   "fx handler for `:rf.machine/spawn`. Per Spec 005 §Spawning, the spawned
   actor's snapshot lives at `[:rf.runtime/machines :snapshots
-  <spawned-id>]` in the spawning frame's app-db, and its liveness IS that
+  <spawned-id>]` in the spawning frame's runtime-db, and its liveness is that
   snapshot's presence in the (revertible) frame value — there is NO
   per-instance event-handler registration.
 
@@ -299,7 +298,7 @@
       TYPE reference at `:rf/machine-type` (the `:machine-id` keyword, or
       the inline `:definition` map) so the lazy resolver
       (`lifecycle-fx.resolver`) can re-materialise the actor's handler
-      from app-db alone. The runtime stamps `:rf/self-id`
+      from runtime-db alone. The runtime stamps `:rf/self-id`
       (the spawned actor's own address) and, when applicable,
       `:rf/parent-id` + `:rf/invoke-id` into the actor's initial `:data`.
       Re-spawn under the same id replaces — last-write-wins.
@@ -317,10 +316,8 @@
       The first dispatch lazy-resolves the just-installed snapshot into a
       live handler (no registration step).
 
-  Eliminating the per-instance registration is what closes the Goal-2
-  revertibility leak: spawn writes only app-db, destroy removes only app-db,
-  so `restore-epoch!` (app-db-only) reverts an actor's liveness perfectly
-  with ZERO registrar drift."
+  Because no per-instance registration exists, replacing a captured frame
+  state also restores actor liveness without registrar drift."
   [{frame-id :frame} args]
   (let [;; EP-0002 carried invariant: `:rf.machine/spawn` runs inside a
         ;; pipeline run, so the fx context ALWAYS carries the envelope
@@ -401,7 +398,7 @@
         ;; `:rf.error/schema-validation-failure :phase :spawn` that
         ;; `validate-spawn-data!` already emitted). There is no per-instance
         ;; handler registration to gate — a rejected spawn simply writes
-        ;; nothing to app-db, so no liveness exists for the rejected actor
+        ;; nothing to runtime-db, so no liveness exists for the rejected actor
         ;; (the strongest form of atomicity: an actor's liveness IS its
         ;; snapshot, and the snapshot was never installed).
         rejected?  (spawn-rejected? spec'' spawned-id initial-snap)]
@@ -435,7 +432,7 @@
       ;; liveness IS its snapshot's presence in the (revertible) frame
       ;; value; the snapshot's `:rf/machine-type` (stamped by
       ;; `install-spawn!`) lets the lazy resolver re-materialise the
-      ;; handler on dispatch. Spawn is a pure app-db write.
+      ;; handler on dispatch. Spawn is a pure runtime-db write.
       ;;
       ;; (2) Initialise the snapshot + (3) bind :system-id + (4) bind the
       ;; runtime-owned spawn registry (atomically under one runtime-db swap
@@ -450,18 +447,17 @@
                          :invoke-id invoke-id
                          :track?    track?
                          :type-ref  type-ref})
-        ;; EP-0025 §subsystems (rf2-h3d8tf): LOWER the machine spec's
-        ;; PROJECTION-RELATIVE `:sensitive` / `:large` `:data` declarations
+        ;; Lower the machine spec's projection-relative `:sensitive` / `:large`
+        ;; `:data` declarations
         ;; into the per-frame elision registry PER ACTOR INSTANCE — re-rooting
         ;; each snapshot-relative `[:data …]` path to this instance's absolute
         ;; snapshot path. The classification travels with the machine def and
         ;; applies to every generated `<type>#n`, dropped on destroy
         ;; (`teardown-live-actor!`). The egress READ path
         ;; (`re-frame.classification/frame-snapshot-classification`, SSR, trace) is unchanged —
-        ;; this writes the registry-entry SOURCE `:source :machine` (a peer of
-        ;; the general commit-plane `:source :effect` route; EP-0025 removed
-        ;; the prior `:source :frame` annotation, rf2-398kql). A spec declaring
-        ;; no classification is a clean no-op (fail-open).
+        ;; this writes the registry-entry source `:source :machine`, a peer of
+        ;; the general commit-plane `:source :effect` route. A spec declaring
+        ;; no classification is a no-op.
         (classification/lower-at-spawn! frame-id spawned-id spec'')
         ;; Record the spawned actor in the frame's spawn-order channel so
         ;; frame-destroy can walk in reverse-creation order per Spec 005
@@ -472,14 +468,14 @@
         ;; `:rf.machine.lifecycle/created` (handler registered) and
         ;; `:rf.machine.lifecycle/destroyed` (handler/snapshot reaped).
         ;; The fx-substrate emit above (`:rf.machine.spawn/spawned`) says
-        ;; "the spawn fx ran"; THIS emit says "a spawned actor's snapshot
-        ;; landed in the registrar". Spec 009 §Two-axis machine
+        ;; "the spawn fx ran"; this emit says "a spawned actor's snapshot
+        ;; landed in runtime-db". Spec 009 §Two-axis machine
         ;; observation: tools that just want "did an actor appear?"
         ;; subscribe to the `:rf.machine.lifecycle/*` channel; causal-graph
         ;; builders subscribe to both and disambiguate by the naming axis.
         ;; The `:state` tag carries the actor's initial state so the Xray
-        ;; managed-fx INVOKE adapter can render it without re-reading
-        ;; app-db (`managed_fx_helpers/machine-invoke-adapter`).
+        ;; managed-fx invoke adapter can render it without re-reading
+        ;; runtime-db (`managed_fx_helpers/machine-invoke-adapter`).
         (trace/emit! :rf.machine.lifecycle/spawned :rf.machine.lifecycle/spawned
                      {:frame      frame-id
                       ;; `:machine-id` = spec-time registered TYPE;
@@ -519,7 +515,7 @@
   §Spawn-and-join via `:spawn-all`, on entry to a `:spawn-all`-bearing
   state the runtime emits this fx (alongside per-child `:rf.machine/spawn`
   fxs) to seed the join state at `[:rf.runtime/machines :spawned <parent> <invoke-id>]` in
-  the frame's app-db. The seed map shape is:
+  the frame's runtime-db. The seed map shape is:
 
     {:children {<child-id> <spawned-id>, ...}
      :done      #{}

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn_error.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn_error.cljc
@@ -34,7 +34,7 @@
   This namespace is a LEAF over the spawn-resolution helpers it needs
   (`resolver` + `paths` + `transition` + `late-bind`), so both `finalize` and
   `registration` may require it without a load cycle. The `:spawn`-at-invoke-id
-  lookup lives in `resolver/spawn-spec-at` (the shared owner — rf2-wm92kj);
+  lookup lives in `resolver/spawn-spec-at`;
   `transition` is retained only for the reserved `spawn-error-event-id`."
   (:require [re-frame.late-bind :as late-bind]
             [re-frame.machines.lifecycle-fx.resolver :as resolver]
@@ -58,7 +58,7 @@
 (defn parent-declares-on-error?
   "True iff the child identified by `parent-id` / `invoke-id` was spawned by a
   parent whose `:spawn` map at `invoke-id` declares `:on-error`. `db` is the
-  frame's app-db (used to resolve a nested-spawn parent's spec). Returns false
+  frame's runtime-db (used to resolve a nested-spawn parent's spec). Returns false
   when the actor is a singleton (no `parent-id`), the parent spec doesn't
   resolve, or the `:spawn` map carries no `:on-error`."
   [db parent-id invoke-id]

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/teardown.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/teardown.cljc
@@ -1,10 +1,10 @@
 (ns re-frame.machines.lifecycle-fx.teardown
-  "Unified app-db teardown projection for spawned-actor destruction.
+  "Unified runtime-db teardown projection for spawned-actor destruction.
 
   Per Spec 005 §Cancellation cascade — when a spawned actor is destroyed
   (final-state auto-destroy, exit-cascade declarative-`:spawn` destroy,
   iterated `:spawn-all` children-destroy, or keyword/imperative
-  destroy) the runtime applies a five-step app-db projection:
+  destroy) the runtime applies a five-step runtime-db projection:
 
     1. dissoc snapshot at `[:rf.runtime/machines :snapshots actor-id]`
     2. release `[:rf.runtime/machines :system-ids <sid>]` reverse-index
@@ -40,9 +40,7 @@
   This namespace is PURE — it does not unregister handlers, abort
   in-flight HTTP, or emit traces. Those are caller side effects whose
   ordering relative to db mutation is contract (Spec 005 §Cancellation
-  cascade D6-D8: emit `:rf.machine/destroyed` BEFORE db mutation so
-  in-flight trace consumers see the destroy signal while the handler
-  still resolves; unregister the handler LAST)."
+  cascade D6-D8)."
   (:require [re-frame.machines.paths :as paths]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -59,7 +57,7 @@
           (get-in db (paths/system-id-path)))))
 
 (defn teardown-actor
-  "Apply the unified app-db teardown projection to `db`. Returns a tuple
+  "Apply the unified runtime-db teardown projection to `db`. Returns a tuple
   `[new-db released-sid]` where `released-sid` is the `:system-id`
   keyword that was released (or nil — callers emit
   `:rf.machine/system-id-released` against it when non-nil).

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/traces.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/traces.cljc
@@ -4,13 +4,11 @@
   Per Spec 009 §`:op-type` vocabulary, `:rf.machine/destroyed` and
   `:rf.machine/system-id-released` ARE the contract surface that tools
   (Xray, story-mcp, re-frame-10x) key on for the actor-destroy signal.
-  Independent emission sites = independent chances to drift in the
-  argument-map keys; the three `:rf.machine/destroyed` sites and the two
-  `:rf.machine/system-id-released` sites emit through this single home so a
-  key rename is one-edit-touches-all.
+  All destroy sites emit through this namespace to keep their argument-map
+  keys and reply facts aligned.
 
   This namespace is the natural home (rather than `teardown.cljc`)
-  because `teardown.cljc` is the unified pure app-db projection — it
+  because `teardown.cljc` is the unified pure runtime-db projection; it
   deliberately emits NO traces so the projection stays a value→value
   function. These helpers ARE side effects, so they live separately."
   (:require [re-frame.interop :as interop]
@@ -106,8 +104,7 @@
   with a destroy-time discriminator. Fail-soft: the destroy proceeds with
   the pre-cascade snapshot."
   [actor-id frame-id result-info]
-  ;; A destroy-time `:exit` action throw is a machine action exception, so it
-  ;; rides the same always-on-plus-dev-trace fan-out (rf2-cprm0q). `:failing-id`
+  ;; A destroy-time `:exit` action throw uses both error channels. `:failing-id`
   ;; is the throwing `:exit` action's keyword when named (else the actor
   ;; instance); `:state` is the active state path off the failure info.
   (let [action-ref (:action-ref result-info)
@@ -128,10 +125,8 @@
     ;; dev-only diagnostic PROSE `:reason` — away under :advanced +
     ;; goog.DEBUG=false (009 elision probe: `emit-destroy-exit-failure!` prose
     ;; sentinel). The internal gate inside `trace/emit-error!` is not enough on
-    ;; its own here: this fn ALSO makes the live always-on call above, so the
-    ;; leaf fold that dropped the pre-rf2-cprm0q sole-statement body no longer
-    ;; applies; the call-site gate is the documented belt-and-braces the
-    ;; framework's own indirect-emit sites use (Spec 009 §Production builds).
+    ;; its own here because this function also contains the live always-on call;
+    ;; the explicit gate lets Closure eliminate the dev-only map and prose.
     (when interop/debug-enabled?
       (trace/emit-error! :rf.error/machine-action-exception
                          {:actor-id   actor-id

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
@@ -12,14 +12,14 @@
       placement, closed key-set, one-per-compound,
       `:default-target` resolution.
     - `validate-parallel!` — `:type :parallel` shape.
-    - `validate-schemas!` — machine-level `:schemas` map (EP-0029 A3):
+    - `validate-schemas!` — machine-level `:schemas` map:
       closed sub-key set (`:data` / `:events` / `:output` / `:tags` /
       `:meta`); `:input` and unknown keys fail loud.
     - `validate-spawn!` — single `:spawn` `:machine-id` xor
       `:definition`.
     - `validate-spawn-all!` — `:spawn-all` shape.
     - `validate-no-spawn-timeout-ms!` — rejects the unsupported
-      `:timeout-ms` / `:on-timeout` slots on `:spawn` / `:spawn-all`.
+      `:timeout-ms` slot on `:spawn` / `:spawn-all`.
     - `validate-final-state!` — `:final?` shape.
     - `validate-node-keys!` — reject unknown BARE state-node keys
       (`:rf.error/machine-unknown-node-key`); namespaced keys pass.
@@ -102,11 +102,8 @@
 (defn- validate-no-spawn-timeout-ms!
   "Per Spec 005 §`:timeout` / `:on-timeout` — the legacy `:timeout-ms` slot
   on `:spawn` / `:spawn-all` is REMOVED: registration throws
-  `:rf.error/spawn-timeout-ms-removed`. The wall-clock-spawn-timeout fact is
-  now expressed by the EP-0029 A4 spawn-level `:timeout` / `:on-timeout`
-  grammar (validated by `timeout/validate-timeouts!`); `:timeout-ms` was the
-  pre-EP draft spelling and never shipped. (`:on-timeout` is NO LONGER
-  rejected here — it is part of the accepted A4 spawn-timeout grammar.)"
+  `:rf.error/spawn-timeout-ms-removed`. Use the spawn-level `:timeout` /
+  `:on-timeout` grammar validated by `timeout/validate-timeouts!`."
   [state-key state-node]
   (doseq [[slot-key spec]
           [[:spawn     (:spawn state-node)]
@@ -150,11 +147,8 @@
   "The closed BARE key vocabulary a `:spawn-all` block map may declare. Any
   BARE key outside this set is rejected at registration with
   `:rf.error/machine-spawn-all-bad-shape` (no silent swallow). NAMESPACED
-  keys pass (the open extension carve-out). The `:cancel-on-decision?` key
-  is deliberately ABSENT — rf2-w8gxxz cut the `:cancel-on-decision? false`
-  protocol (sibling cancellation on the join decision is now
-  unconditional), so a `:cancel-on-decision?` on the block is correctly
-  rejected as unknown."
+  keys pass (the open extension carve-out). Sibling cancellation on a join
+  decision is unconditional, so `:cancel-on-decision?` is not accepted."
   #{:children :join
     :on-child-done :on-child-error
     :on-all-complete :on-some-complete :on-any-failed})
@@ -252,8 +246,8 @@
                  :rf.error/machine-spawn-all-bad-shape
                  ":on-child-error is required (event keyword)"
                  {:state state-key})))
-      ;; The join grammar is a CLOSED two-member enum — `:all` (default)
-      ;; and `:any` (rf2-w8gxxz cut the `{:n N}` and `{:fn pred}` modes).
+      ;; The join grammar is a closed two-member enum: `:all` (default)
+      ;; and `:any`.
       ;; Quorum cases use the data-only `:after` + `:done-guard` idiom
       ;; (Spec 005 §Composition with hierarchy and `:after`); re-adding
       ;; `{:n}` later is a compatible widening. Any other `:join` value —
@@ -328,8 +322,8 @@
                ":type :parallel requires a non-empty :regions map")))
     ;; The parallel root's `:on-done` must not carry an in-machine `:target`
     ;; in ANY form (root-only parallel has no flat sibling to land on).
-    ;; Normalise EVERY value-form `:on-done` admits via the SHARED
-    ;; `grammar/candidate-maps` (the ONE owner — rf2-tu5psi — the same grammar
+    ;; Normalise every value-form `:on-done` admits via
+    ;; `grammar/candidate-maps`, the same grammar
     ;; the runtime parallel-root `apply-on-done-action` resolves through), then
     ;; reject if any candidate declares `:target`.
     ;;
@@ -369,12 +363,12 @@
     ;; normalises each `:on` entry to its candidate map(s) and validates each
     ;; candidate's `:target`.
     ;;
-    ;; The SAME region-qualified target grammar governs a root-owned `:after`
+    ;; The same region-qualified target grammar governs a root-owned `:after`
     ;; transition (the timer-driven analog of the root `:on` ancestor
     ;; fallback), so a non-region-qualified root `:after` target is rejected
     ;; with the SAME `:rf.error/machine-parallel-root-on-bad-target` keyword.
     ;; `candidates-of` is the SHARED `:on` / `:after` value-form normaliser —
-    ;; the ONE owner `grammar/candidate-maps` (rf2-tu5psi), malformed → `[]`.
+    ;; the shared `grammar/candidate-maps`; malformed values produce `[]`.
     (let [region-names (set (keys (:regions machine)))
           declared?    (fn [t] (contains? region-names t))
           bad-target!  (fn [slot target]
@@ -450,7 +444,7 @@
                     (walk (conj path k) (:states n)))))]
         (walk [] (:states region-body))))))
 
-;; ---- non-parallel root `:after` / `:timeout` — reject loud (rf2-b6znpi) ---
+;; ---- non-parallel root `:after` / `:timeout` -------------------------------
 ;;
 ;; Per Spec 005 §Root-level `:after` — the timer-driven ancestor fallback:
 ;; the feature is scoped to a `:type :parallel` machine root. Its runtime
@@ -830,7 +824,7 @@
                    {:state    state-key
                     :on-error oe})))))))
 
-;; ---- `:on-spawn` keyword-ref resolution (rf2-b4qbx0) -----------------------
+;; ---- `:on-spawn` keyword-ref resolution -----------------------------------
 ;;
 ;; Per Spec 005 §Declarative `:spawn` §`:on-spawn`: a KEYWORD `:on-spawn`
 ;; resolves through the machine's `:on-spawn-actions` map, falling back to
@@ -917,7 +911,7 @@
 
 (defn- always-entries
   "Normalise a state-node's `:always` slot to a vector of entry maps through
-  the SHARED `grammar/candidate-maps` (the ONE owner — rf2-tu5psi). Absent
+  the shared `grammar/candidate-maps`. Absent
   `:always` — the key missing, OR present with an explicit nil value — yields
   the empty vector (no ancestor-blocking use case for `:always`, unlike `:on`
   / `:after`'s nil-is-forbidden-transition form), so the nil is gated BEFORE
@@ -1216,7 +1210,7 @@
   target would otherwise throw `:rf.error/machine-bad-state-form` and an
   unresolved one would commit an invalid snapshot).
 
-  Per Spec 005 §Transition resolution steps 6-7 (rf2-nvgolg): a NON-PARALLEL
+  Per Spec 005 §Transition resolution steps 6-7, a non-parallel
   (flat / compound) machine root's OWN `:on` is the ancestor-fallback
   transition slot `pick-transition` consults, at runtime, when no state-path
   node handles the event — stamped with decl-path `[]`, so a keyword
@@ -1255,38 +1249,34 @@
       (doseq [[_event v] (:on machine)]
         (check! v)))))
 
-;; ---- machine-level :schemas map (EP-0029 A3) -------------------------------
+;; ---- machine-level :schemas map --------------------------------------------
 ;;
 ;; The machine-level `:schemas` map is the single home for a machine's
-;; optional schema declarations (EP-0029 A3, the clean-break successor to the
-;; retired EP-0005 `:data-schema` key). The accepted sub-key vocabulary is
-;; closed: `:data` is the live, wired category this wave ships (it validates
+;; optional schema declarations. The accepted sub-key vocabulary is closed.
+;; `:data` validates
 ;; the machine's `:data` slot at the `:where :machine-data` boundary — see
-;; `re-frame.machines.data-validation`). The remaining A3 categories
-;; (`:events` / `:output` / `:tags` / `:meta`) are accepted as DECLARATION-ONLY
-;; surfaces — their values stay abstract and carry no wired behaviour yet (the
-;; `[:schemas :output]` → completion-payload binding is a separate EP-0029 wave,
-;; rf2-kgr3kk). `[:schemas :input]` is NOT accepted: state input (B1, "For
-;; Later Consideration") is not adopted, so declaring it must fail loud rather
-;; than no-op. Any other sub-key is unknown and fails loud — the closed set
+;; `re-frame.machines.data-validation`). `:output` validates the completion
+;; payload selected by a final state's `:output-key`. `:events`, `:tags`, and
+;; `:meta` are accepted as declaration-only surfaces. `:input` is not accepted
+;; because state input is not supported. Any other sub-key is unknown and fails
+;; loud rather than becoming a no-op; the closed set
 ;; keeps the machine contract discoverable and rejects typos / not-yet-adopted
 ;; categories at registration.
 (def ^:private accepted-schemas-keys
-  "The closed sub-key set the machine-level `:schemas` map may carry (EP-0029
-  A3). `:data` is wired this wave; `:events` / `:output` / `:tags` / `:meta`
-  are accepted declaration-only. `:input` is intentionally EXCLUDED (state
-  input is not adopted)."
+  "The closed sub-key set the machine-level `:schemas` map may carry. `:data`
+  and `:output` are wired; `:events`, `:tags`, and `:meta` are declaration-only.
+  `:input` is intentionally excluded."
   #{:data :events :output :tags :meta})
 
 (defn validate-schemas!
-  "Validate the machine-level `:schemas` map (EP-0029 A3). When present it
+  "Validate the machine-level `:schemas` map. When present it
   MUST be a map whose keys are all members of `accepted-schemas-keys`. An
   unknown sub-key — including `:input` (state input is not adopted) — fails
   loud with `:rf.error/machine-bad-schemas-key`; a non-map `:schemas` value
   fails loud with `:rf.error/machine-bad-schemas`. A machine with no
   `:schemas` key is unaffected. The sub-key VALUES are opaque schema values —
   this validator never interprets them (machine core requires no schema
-  library, EP-0029 Non-goal / rf2-49zxkc)."
+  library)."
   [machine]
   (when (contains? machine :schemas)
     (let [schemas (:schemas machine)]
@@ -1310,32 +1300,14 @@
 
 ;; ---- no-silent-swallow: unknown state-node / spawn-spec keys + :tags shape --
 ;;
-;; Per Conventions §No silent swallow + §Reserved state-node keys /
-;; §Spawn-spec keys, and the 2026-07-03 self-consistency design review
-;; (finding 2). Ordinary state nodes are the surface an app writes fifty of,
-;; yet — unlike the rare `:type :history` / `:type :choice` / `:schemas` nodes,
-;; which hard-reject unknown keys — an unknown BARE key on an ordinary node was
-;; silently ignored. An XState-trained author writes `:invoke` (XState's spelling
-;; of re-frame2's `:spawn`) or `:on-entry` (its `:entry`): registration succeeds,
-;; the machine runs, and the child silently never spawns / the action never runs.
-;; The `:tags` slot compounded the inconsistency by silently COERCING a vector /
-;; keyword to a set, while its sibling slot `:internal-events` HARD-REJECTS
-;; exactly that non-set shape.
-;;
-;; The fix walks every node + spawn-spec at registration and classifies each key
-;; three ways (the Conventions extension-key discriminator):
+;; Per Conventions §No silent swallow, classify every state-node and spawn-spec
+;; key at registration:
 ;;   - key ∈ the known bare set → accepted (parsed by the rest of validation);
 ;;   - key is NAMESPACED → open accretion, ignored (user metadata / extensions);
 ;;   - key is BARE and unknown → HARD `:rf.error/machine-unknown-node-key` /
 ;;     `:rf.error/machine-unknown-spawn-key` naming the key + the valid
-;;     vocabulary. A hard error (not a warning): `:meta` is the sanctioned bare
-;;     free slot and namespaced keys stay open, so a bare unknown key has ZERO
-;;     legitimate use — the cascade cannot continue with a misspelt lifecycle key
-;;     (the spawn never fires, the transition never runs), so it fails loud like
-;;     `:rf.error/machine-choice-extra-keys` and the `check-retired-keys!` family.
-;; And `:tags` non-set → HARD `:rf.error/machine-bad-tags`, mirroring
-;; `:rf.error/machine-bad-internal-events` (the schema pins `:tags` as strict
-;; `[:set :keyword]`).
+;;     vocabulary. `:meta` remains the sanctioned bare metadata slot.
+;; A non-set `:tags` value fails with `:rf.error/machine-bad-tags`.
 
 (def ^:private known-state-node-keys
   "The closed BARE key vocabulary a machine state-node may declare, projected
@@ -1371,15 +1343,12 @@
   "Keys legal ONLY on the machine ROOT (the registration-metadata that folds
   onto the machine body per `registration/reg-machine*`), beyond the universal
   `known-state-node-keys`. `:doc` is the registration doc string; `:sensitive` /
-  `:large` are the EP-0025 machine-level data-classification declarations
+  `:large` are the machine-level data-classification declarations
   (projection-relative `:data` classification); `:schema` is the event-vector
   boundary schema for the dispatched OUTER vector; `:raise-depth-limit` /
   `:always-depth-limit` are the per-machine cycle-detection depth overrides
-  (`transition/raise-depth-limit-default`). These are meaningless on a CHILD node
-  (the child-node walk uses the plain vocabulary, so a `:doc` on a nested state is
-  still a typo). The retired `:data-schema` key is deliberately ABSENT — it is a
-  clean pre-alpha break (superseded by `[:schemas :data]`), so a `:data-schema` on
-  the root is correctly rejected as unknown."
+  (`transition/raise-depth-limit-default`). These are meaningless on a child node
+  (the child-node walk uses the plain vocabulary)."
   #{:doc :sensitive :large :schema :raise-depth-limit :always-depth-limit})
 
 (def ^:private retired-spawn-spec-keys
@@ -1538,7 +1507,7 @@
   on a malformed or dangling target (a parallel root's region-qualified
   `:on` is validated separately by `validate-parallel!`).
 
-  Per Spec 005 §Schema validation / EP-0029 A3: the machine-level `:schemas`
+  Per Spec 005 §Schema validation, the machine-level `:schemas`
   map (when present) must be a map whose sub-keys are within the closed set
   `#{:data :events :output :tags :meta}`. An unknown sub-key — including
   `:input` (state input is not adopted) — throws
@@ -1555,8 +1524,8 @@
   `:rf.error/machine-spawn-bad-shape` (single `:spawn`) /
   `:rf.error/machine-spawn-all-bad-shape` (child) on both-set or neither-set.
 
-  Every `:spawn` / `:spawn-all` rejects the unsupported
-  `:timeout-ms` / `:on-timeout` slot (use parent `:after`).
+  Every `:spawn` / `:spawn-all` rejects the unsupported `:timeout-ms` slot;
+  spawn-level `:timeout` / `:on-timeout` is supported.
 
   Every `:on` / `:always` / `:entry` / `:exit` slot's guard
   and action keyword refs must resolve against the machine's `:guards` /
@@ -1567,10 +1536,8 @@
   keyword ref (a single `:spawn`, or a `:spawn-all` child) must resolve
   against the machine's `:on-spawn-actions` map, falling back to
   `:actions` — the SAME two-registry order the runtime resolves through.
-  Throws `:rf.error/machine-unresolved-on-spawn` on a dangling ref
-  (mirroring `:rf.error/machine-unresolved-action`'s fail-fast contract;
-  previously a dangling `:on-spawn` ref silently resolved to \"no
-  callback\" at runtime).
+  Throws `:rf.error/machine-unresolved-on-spawn` on a dangling ref,
+  mirroring `:rf.error/machine-unresolved-action`'s fail-fast contract.
 
   Per Spec 005 §Initial-state cascading: every compound state-node
   (declares `:states`) MUST declare `:initial`. Throws
@@ -1603,7 +1570,7 @@
   `:rf.error/machine-bad-tags` (the silent vector/keyword→set coercion is
   removed), mirroring `:rf.error/machine-bad-internal-events`."
   [machine]
-  ;; EP-0029 A4 — validate the `:timeout` / `:on-timeout` grammar on the RAW
+  ;; Validate the `:timeout` / `:on-timeout` grammar on the raw
   ;; spec FIRST, so diagnostics name the `:timeout` / `:on-timeout` keys the
   ;; author wrote (timeout-requires-on-timeout pairing, the integer-ms /
   ;; ISO-8601-only duration rule rejecting the "5s"/"10ms" shorthand, and
@@ -1614,7 +1581,7 @@
   ;; `:final?` state carrying a `:timeout` is rejected as it would be for an
   ;; `:after`, and the desugared form is exactly what the runtime drives.
   (timeout/validate-timeouts! machine)
-  ;; EP-0029 A5 — validate the `:type :choice` / `:choice` grammar on the
+  ;; Validate the `:type :choice` / `:choice` grammar on the
   ;; RAW spec (before BOTH desugars) so diagnostics name the `:type :choice`
   ;; / `:choice` keys the author wrote AND a choice state that also declares
   ;; a reserved key (incl. `:timeout`) is caught with that key still present.
@@ -1630,11 +1597,11 @@
   (when (parallel/parallel? machine)
     (doseq [[rn body] (:regions machine)]
       (choice/validate-node-choice! [rn] rn body)))
-  ;; EP-0029 A6 — validate the `:internal-events` declaration on the RAW
-  ;; spec: it must be a SET of keywords (the re-frame2 set-form divergence
-  ;; from XState's array), and no declared internal event may ALSO be a
-  ;; public `:on` transition key anywhere in the machine (the public /
-  ;; private split). Neither named-intent desugar touches `:internal-events`,
+  ;; Validate the `:internal-events` declaration on the raw
+  ;; spec: it must be a set of keywords, and reserved `:rf/*` lifecycle names
+  ;; are forbidden. A declared internal event is expected to have an ordinary
+  ;; `:on` handler; the visibility boundary rejects only external dispatch.
+  ;; Neither named-intent desugar touches `:internal-events`,
   ;; so the raw spec is the right basis.
   (internal-events/validate-internal-events! machine)
   ;; No-silent-swallow on state-node / spawn-spec keys + the `:tags` shape, on
@@ -1673,13 +1640,13 @@
   (let [machine (choice/desugar-choices (timeout/desugar-timeouts machine))]
   (validate-history! machine)
   (validate-parallel! machine)
-  ;; rf2-b6znpi — a non-parallel root's `:after` (hand-authored or lowered
+  ;; A non-parallel root's `:after` (hand-authored or lowered
   ;; from a root `:timeout` / `:on-timeout`) has no runtime scheduling /
   ;; resolution path; reject it loudly rather than silently registering a
   ;; whole-machine deadline that never fires. Runs on the DESUGARED machine
   ;; so a root `:timeout` is caught via its lowered `:after` form too.
   (validate-non-parallel-root-after! machine)
-  ;; The machine-level `:schemas` map (EP-0029 A3) — closed sub-key set; an
+  ;; The machine-level `:schemas` map has a closed sub-key set; an
   ;; unknown sub-key (incl. `:input`) or a non-map `:schemas` fails loud.
   (validate-schemas! machine)
   (doseq [[s n] (walk-state-nodes machine)]
@@ -1689,7 +1656,7 @@
     (validate-final-state! s n)
     (validate-spawn-on-error! s n)
     (validate-compound-initial! s n)
-    ;; rf2-b4qbx0 — every `:on-spawn` keyword ref (single `:spawn` or a
+    ;; Every `:on-spawn` keyword ref (single `:spawn` or a
     ;; `:spawn-all` child) must resolve against `:on-spawn-actions`,
     ;; falling back to `:actions`, at registration.
     (validate-on-spawn-refs! machine s n))

--- a/implementation/machines/src/re_frame/machines/parallel.cljc
+++ b/implementation/machines/src/re_frame/machines/parallel.cljc
@@ -1291,7 +1291,7 @@
   Flat / compound machines drop straight into the
   single-machine engine in `re-frame.machines.transition`.
 
-  ## Guard-throw → `result/fail` (XState v5 alignment, rf2-18mox0)
+  ## Guard-throw → `result/fail` (XState v5 alignment)
 
   A user GUARD body that throws during transition selection surfaces the
   error and ABORTS the macrostep (XState v5 does not swallow guard
@@ -1304,8 +1304,8 @@
   lifecycle handler emits the machine-scoped error trace and rolls back —
   the guard throw is never demoted to a lower-priority candidate."
   [machine snapshot event]
-  ;; Desugar `:timeout` / `:on-timeout` (EP-0029 A4) into the equivalent
-  ;; `:after` entries AND `:type :choice` / `:choice` (EP-0029 A5) into the
+  ;; Desugar `:timeout` / `:on-timeout` into equivalent `:after` entries and
+  ;; `:type :choice` / `:choice` into the
   ;; equivalent `:always` candidate vector BEFORE the engine sees the spec —
   ;; both are distinct authoring concepts that LOWER onto an existing
   ;; mechanism (`:timeout` → `:after`; `:choice` → `:always`). Idempotent,
@@ -1464,7 +1464,7 @@
   the post-cascade snapshot + the entry fx verbatim with the tag union
   re-stamped.
 
-  Guard-throw → `result/fail` (XState v5 alignment, rf2-18mox0): a guard
+  Guard-throw → `result/fail` (XState v5 alignment): a guard
   body that throws during the birth-time `:always` selection surfaces the
   error and aborts the birth macrostep through the SAME failed-macrostep
   surface a thrown initial-`:entry` action takes. The tagged guard-throw
@@ -1472,9 +1472,9 @@
   boundary — the second pure-engine entry point alongside
   `machine-transition` — and converted to a `result/fail`."
   [machine initial-snapshot]
-  ;; Desugar `:timeout` / `:on-timeout` (EP-0029 A4) so an INITIAL state's
+  ;; Desugar `:timeout` / `:on-timeout` so an initial state's
   ;; timeout arms at birth via the same `:after`-schedule fx the cascade
-  ;; emits, AND `:type :choice` / `:choice` (EP-0029 A5) so a TRANSIENT
+  ;; emits, and `:type :choice` / `:choice` so a transient
   ;; INITIAL choice leaf resolves on start via the birth-time `:always`
   ;; settle. Idempotent — a spec already desugared at registration is
   ;; unaffected. Mirrors the desugar at the `machine-transition` entry.

--- a/implementation/machines/src/re_frame/machines/paths.cljc
+++ b/implementation/machines/src/re_frame/machines/paths.cljc
@@ -23,9 +23,8 @@
   machines artefact, so any `re-frame.machines.*` namespace may require it
   without a cycle.
 
-  Scope is `src/` only. Test assertions read these slots off
-  `(:rf.db/runtime (rf/frame-state-value frame-id))` (rf2-t3lftq —
-  API-shrink #3 retired the dedicated `rf/runtime-db-value` reader).")
+  Scope is `src/` only. Test assertions read these slots from the
+  `:rf.db/runtime` partition of `rf/frame-state-value`.")
 
 #?(:clj (set! *warn-on-reflection* true))
 

--- a/implementation/machines/src/re_frame/machines/reply.cljc
+++ b/implementation/machines/src/re_frame/machines/reply.cljc
@@ -536,8 +536,8 @@
   `:on-restore` (epoch-restore host-timer cleanup — `timer/cancel-frame-
   timers-on-restore!` releases the orphaned host handles the unwound epochs
   left attached; Spec 005 §Root parallel `:after` trace catalogue). Matches
-  the closed `:reason` vocabulary spec/005's `:rf.machine.timer/cancelled`
-  catalogue enumerates (rf2-e3ryis)."
+  the closed `:reason` vocabulary in Spec 005's
+  `:rf.machine.timer/cancelled` catalogue."
   #{:on-exit :on-destroy :on-resolution :on-supersede :on-frame-destroy
     :on-restore})
 

--- a/implementation/machines/src/re_frame/machines/ssr.cljc
+++ b/implementation/machines/src/re_frame/machines/ssr.cljc
@@ -12,7 +12,7 @@
   re-materialises actors. `re-frame.ssr.payload-policy/project-runtime-db`
   consults this hook so a snapshot whose frame classifies a `:data` path
   `:sensitive` / `:large` has that field redacted / elided in the
-  hydration blob — frame-owned classification governs machine `:data`
+  hydration blob — the frame's classification registry governs machine `:data`
   egress. Like resources (which has `:ssr/extend-runtime-db-projection`),
   machines provides this SSR projection hook.
 
@@ -20,18 +20,18 @@
 
   `project-ssr-runtime-db` projects the `:rf.runtime/machines` slice for the
   SSR hydration boundary: each snapshot's `:data` is run through the merged
-  frame-owned `re-frame.projection/project-egress` under the
-  `:rf.egress/ssr-hydration` profile, so any `:data` path the FRAME classifies
+  frame's merged `re-frame.projection/project-egress` policy under the
+  `:rf.egress/ssr-hydration` profile, so any classified `:data` path
   redacts (`:rf/redacted`) / elides (`:rf.size/large-elided`) before it rides
   the wire. The projection uses SHARED frame-independent primitives — NEVER a
   family-private elider.
 
   Machine `:data` egress classification lives in the per-frame elision
-  registry like every other app-db / runtime-db path. EP-0025: a machine
-  definition declares its sensitive / large `:data` slots PROJECTION-RELATIVE
+  registry like every other app-db / runtime-db path. A machine definition
+  declares its sensitive / large `:data` slots projection-relative
   (`re-frame.machines.classification`), lowered per actor instance into the
-  registry under `:source :effect`; the commit-plane `:sensitive` / `:large`
-  effects are the general app-db mechanism. The `[:schemas :data]` schema
+  registry under `:source :machine`; the commit-plane `:sensitive` / `:large`
+  effects are the general classification mechanism. The `[:schemas :data]` schema
   VALIDATES `:data`; it does not classify it for egress.
 
   Snapshots whose frame classifies no matching `:data` path ride VERBATIM — the
@@ -56,15 +56,15 @@
 
   `actor-id` is the snapshot's key (the singleton machine-id OR a spawned
   instance id). `frame-id` is the SSR request frame whose runtime-db machine-
-  snapshot classification governs the projection (nil ⇒ no frame walk ⇒ `:data`
+  snapshot classification governs the projection (nil means no frame walk, so `:data`
   rides verbatim).
 
   Machine `:data` egress classification lives in the per-frame elision
-  registry. EP-0025: a machine definition declares its sensitive / large
-  `:data` slots PROJECTION-RELATIVE (`re-frame.machines.classification`),
+  registry. A machine definition declares its sensitive / large
+  `:data` slots projection-relative (`re-frame.machines.classification`),
   lowered per actor instance into the registry as the absolute runtime-db
   path `[:rf.runtime/machines :snapshots <actor-id> :data …]` under
-  `:source :effect`. `re-frame.classification/frame-snapshot-classification`
+  `:source :machine`. `re-frame.classification/frame-snapshot-classification`
   re-roots those declarations snapshot-relative (`[:data …]`); here we strip
   the leading `:data` segment to index into the snapshot's bare `:data` map
   and redact via
@@ -72,7 +72,7 @@
   walker — `:sensitive` slots to
   `:rf/redacted`, `:large` to the `:rf.size/large-elided` marker (sensitive
   wins). Snapshot egress does not consult per-slot `:sensitive?` / `:large?`
-  schema marks; frame-owned classification is the sole mechanism.
+  schema marks; the frame classification registry is the egress source of truth.
 
   The snapshot's NON-`:data` slots (`:state`, `:tags`, `:rf/machine-type`, the
   reserved spawn-counter slot, …) are durable structural facts the client needs
@@ -100,11 +100,11 @@
   hydration `:rf/runtime-db` payload (the body behind the
   `:machines/project-ssr-runtime-db` late-bind hook). Returns the
   `:rf.runtime/machines` value with every snapshot's `:data` projected per its
-  frame-owned `:sensitive` / `:large` classification (`project-snapshot-data`);
+  frame registry's `:sensitive` / `:large` classification (`project-snapshot-data`);
   or `runtime-db`'s `:rf.runtime/machines` value unchanged when it carries no
   snapshots.
 
-  `frame-id` is the SSR request frame (nil ⇒ owner marks only — see
+  `frame-id` is the SSR request frame (nil leaves snapshots unchanged; see
   `project-snapshot-data`). The `:snapshots` map is re-projected entry-by-entry
   keyed on actor-id; the sibling registry slots (`:system-ids`, `:spawned`,
   `:spawn-counter`) ride verbatim (durable reverse indexes + counters carrying

--- a/implementation/machines/src/re_frame/machines/timeout.cljc
+++ b/implementation/machines/src/re_frame/machines/timeout.cljc
@@ -1,5 +1,5 @@
 (ns re-frame.machines.timeout
-  "State-level + spawn-level `:timeout` / `:on-timeout` grammar (EP-0029 A4).
+  "State-level and spawn-level `:timeout` / `:on-timeout` grammar.
 
   ## What `:timeout` is
 
@@ -18,7 +18,7 @@
 
   ## Relationship to `:after` — distinct intent, ONE mechanism
 
-  Per EP-0029 A4: `:timeout` and the existing `:after` express DIFFERENT
+  `:timeout` and `:after` express different
   intent and MAY coexist on the same state node. `:after` is the general
   delayed-transition table (`{ms -> transition}`, possibly several entries
   with dynamic / sub-vector / fn delays); `:timeout` names the single
@@ -37,10 +37,10 @@
   Spawn-level `:timeout` desugars onto the SPAWN-BEARING STATE's `:after`
   (not the spawn spec) — the timer is anchored to that state's entry, so
   the child's whole lifetime (spanning any internal retries) is bounded,
-  exactly the wall-clock semantics A4 asks for; the standard exit cascade
+  for the child's whole lifetime; the standard exit cascade
   tears the child down when the timeout fires.
 
-  ## Duration grammar (DIVERGENCE from XState — operator-ruled, EP-0029 A4)
+  ## Duration grammar
 
   XState v6 accepts readable duration shorthand such as `\"10ms\"` / `\"5s\"`
   AND ISO-8601 durations such as `\"PT2M\"`. re-frame2 REJECTS the
@@ -139,8 +139,7 @@
 
 (defn resolve-duration-ms
   "Resolve a `:timeout` duration to a positive-integer ms, or nil if it is
-  not a valid duration. A valid duration (EP-0029 A4, operator-ruled
-  DIVERGENCE) is EXACTLY one of:
+  not a valid duration. A valid duration is exactly one of:
 
     - a POSITIVE INTEGER — literal ms;
     - an ISO-8601 duration STRING (`\"PT5S\"`, `\"PT2M\"`, …).
@@ -164,10 +163,10 @@
 
 ;; ---- desugaring `:timeout` / `:on-timeout` → `:after` ---------------------
 ;;
-;; `:timeout` / `:on-timeout` is a DISTINCT authoring concept that LOWERS
-;; onto the existing `:after` timer mechanism (EP-0029 A4 — "distinct
-;; intent, one mechanism"). The desugar runs at registration / transition
-;; normalisation time so the runtime never sees `:timeout` / `:on-timeout`
+;; `:timeout` / `:on-timeout` is a distinct authoring concept that lowers
+;; onto the existing `:after` timer mechanism. The desugar runs during
+;; registration and transition normalisation, so the runtime never sees
+;; `:timeout` / `:on-timeout`
 ;; directly — it sees the equivalent `:after` entry. The grammar (separate
 ;; keys, separate validation, separate duration rules) is what the AUTHOR
 ;; writes; the `:after` table is what the ENGINE drives.
@@ -310,8 +309,7 @@
 ;; ---- registration-time validation -----------------------------------------
 ;;
 ;; Validation runs on the RAW (pre-desugar) machine so error messages name
-;; the `:timeout` / `:on-timeout` keys the author wrote. It enforces, per
-;; EP-0029 A4 + Backwards-Compatibility:
+;; the `:timeout` / `:on-timeout` keys the author wrote. It enforces:
 ;;
 ;;   - a `:timeout` REQUIRES an `:on-timeout` (and vice-versa — an
 ;;     `:on-timeout` with no `:timeout` is meaningless);
@@ -443,8 +441,8 @@
             states)))
 
 (defn validate-timeouts!
-  "Registration-time validator for the `:timeout` / `:on-timeout` grammar
-  (EP-0029 A4). Walks every state-node (flat / compound / parallel-region)
+  "Registration-time validator for the `:timeout` / `:on-timeout` grammar.
+  Walks every state-node (flat / compound / parallel-region)
   PLUS the machine root and each parallel-region root, and enforces:
 
     - a `:timeout` requires an `:on-timeout` and vice-versa

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -350,8 +350,8 @@
 
 ;; ---- guard-throw signal (XState v5 alignment) -----------------------------
 ;;
-;; Per Spec 005 §`:rf.machine/guard-evaluated` (XState v5 alignment,
-;; rf2-18mox0): XState v5 does NOT swallow a guard exception. A throwing
+;; Per Spec 005 §`:rf.machine/guard-evaluated` (XState v5 alignment), XState
+;; does not swallow a guard exception. A throwing
 ;; guard SURFACES the error and ABORTS transition selection — it is never
 ;; silently demoted to a lower-priority candidate, a wildcard tier, or an
 ;; ancestor edge. re-frame2 aligns by routing a guard throw through the
@@ -417,7 +417,7 @@
   preserved), then RETHROW a tagged guard-throw signal (`ex-data` carries
   `guard-threw-key`, the `:guard-ref`, the original `:exception`, and the
   active `:state`). Per Spec 005 §`:rf.machine/guard-evaluated`
-  (rf2-18mox0): XState v5 SURFACES a guard error and aborts transition
+  XState v5 surfaces a guard error and aborts transition
   selection — it is never swallowed and demoted to a lower-priority
   candidate. The engine boundaries (`parallel/machine-transition` /
   `apply-initial-entry-cascade`) catch the tagged signal and convert it to
@@ -476,7 +476,7 @@
                         :outcome    :threw
                         :exception  e
                         :frame      frame-id})
-          ;; XState v5 alignment (rf2-18mox0): SURFACE the guard error and
+          ;; XState v5 alignment: surface the guard error and
           ;; abort selection — do NOT swallow it as `:fail` and walk to the
           ;; next candidate. Rethrow a TAGGED signal the engine boundary
           ;; converts to a `result/fail` (the same failed-macrostep surface
@@ -702,7 +702,7 @@
 (defn- normalise-candidates
   "Normalise a transition-table value into a vector of candidate
   transition maps. The single source of truth for the value-form grammar
-  shared by `:on`, `:after`, AND `:always` (rf2-0k0f3x) — `pick-always-
+  shared by `:on`, `:after`, and `:always`; `pick-always-
   transition` routes the raw `:always` slot value through this SAME
   normaliser, so the three slots' value-form grammar can never drift
   apart. Per Spec 005 §Transitions §Multiple-candidate
@@ -741,7 +741,7 @@
   `:always` → `machine-bad-always`).
 
   Delegates the value-form → candidate-maps mapping to the SHARED
-  `grammar/candidate-maps` (the ONE owner — rf2-tu5psi), which returns nil
+  `grammar/candidate-maps`, which returns nil
   for the malformed form so THIS runtime caller keeps its slot-specific error
   taxonomy (`bad-value-id`) while the static cofx / validation walkers degrade
   malformed input to `[]`. `grammar/candidate-maps` builds on the same
@@ -3492,7 +3492,7 @@
   an `:always` whose guard passes (the deepest-wins rule named in
   `path-walk/walk-path-leaf-to-root`). The raw `:always` slot value is
   normalised through `normalise-candidates` — the SAME shared candidate
-  grammar `:on` / `:after` use (rf2-0k0f3x) — so a bare keyword (sibling
+  grammar `:on` / `:after` use, so a bare keyword (sibling
   target), a vector-target (absolute path), a single transition map, and
   a guarded candidate-vector all resolve identically whichever of the
   three slots carries them. A malformed value (`:always 42`) throws the

--- a/implementation/machines/test/re_frame/after_fire_reap_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/after_fire_reap_cljs_test.cljc
@@ -1,31 +1,10 @@
 (ns re-frame.after-fire-reap-cljs-test
-  "rf2-8cndln — a guard-suppressed `:after` timer fire must REAP its own
-  registry entry at fire time, not leak it.
+  "A guard-suppressed `:after` timer fire reaps its registry entry at fire time.
 
-  Background. `machines.timer/schedule-after-timer!` arms a host-clock timer
-  whose fire thunk dispatches the synthetic
-  `[:rf.machine.timer/after-elapsed …]` event. Entries in the per-frame
-  `after-timers` table were previously reaped ONLY by a CANCELLATION path —
-  state exit (`:on-exit`), actor destroy, frame destroy, sub re-resolution.
-  Nothing reaped an entry whose timer actually FIRED.
-
-  That is invisible for a fire that drives a real transition: the state
-  exits, `after-cancel-fx` runs, and the entry is cleared as `:on-exit`. But a
-  GUARD-SUPPRESSED fire (the elapsed event is discarded, the state does NOT
-  exit) runs no cancel — so the entry is stranded:
-
-    (a) a live `add-watch` on the dynamic-delay reaction plus a held
-        subscription ref-count leak for as long as the machine stays in the
-        state; and — worse —
-    (b) if that sub value later changes, the still-installed watcher's
-        `on-sub-changed!` RE-ARMS a brand-new timer for a one-shot that
-        already fired-and-was-discarded.
-
-  XState v5 semantics: a delayed (`after`) transition's timer fires ONCE per
-  arming; a guard-rejected delayed transition does NOT re-schedule. The fix
-  reaps the firing entry (host handle + remove-watch + unsubscribe) at fire
-  time, epoch-guarded so a concurrent re-entry's fresh entry (strictly-greater
-  per-decl-path epoch) is not clobbered.
+  Reaping releases the host handle, subscription watch, and reference count,
+  preventing a later subscription change from rearming a spent one-shot. The
+  epoch guard prevents an old fire from removing a concurrent re-entry's fresh
+  timer.
 
   These tests exercise the REAL fire path — the host-clock thunk
   `machines.timer` installs — rather than dispatching the synthetic

--- a/implementation/machines/test/re_frame/choice_test.clj
+++ b/implementation/machines/test/re_frame/choice_test.clj
@@ -1,5 +1,5 @@
 (ns re-frame.choice-test
-  "EP-0029 A5 — `:type :choice` transient / choice states.
+  "`:type :choice` transient states.
 
   Covers:
     - desugaring `:type :choice` / `:choice` onto the existing `:always`
@@ -7,7 +7,7 @@
       mechanism);
     - registration-time fail-loud validation (the `:type` / `:choice`
       pairing; the declarative candidate-array shape, REJECTING the
-      function form — the operator-ruled A2 / C1 divergence; the
+      function form; the
       reserved-key exclusion; the required default candidate; the
       self-loop rejection);
     - the dispatch boundary — a choice state entered mid-macrostep resolves

--- a/implementation/machines/test/re_frame/handler_source_egress_strip_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/handler_source_egress_strip_cljs_test.cljc
@@ -1,5 +1,5 @@
 (ns re-frame.handler-source-egress-strip-cljs-test
-  "rf2-tlf4if — handler source-as-data does NOT leak across the frame-state
+  "Handler source-as-data does not leak across the frame-state
   egress boundary.
 
   The DEBUG-gated handler source-as-data (`:rf.handler/source` on an event's

--- a/implementation/machines/test/re_frame/internal_events_test.clj
+++ b/implementation/machines/test/re_frame/internal_events_test.clj
@@ -1,11 +1,11 @@
 (ns re-frame.internal-events-test
-  "EP-0029 A6 — public / private `:internal-events`.
+  "Public/private `:internal-events`.
 
   Covers:
     - the declaration shape — a Clojure SET of keywords (the re-frame2
       set-form divergence from XState's array);
-    - registration-time fail-loud validation (a malformed `:internal-events`;
-      a name declared BOTH internal AND as a public `:on` transition key);
+    - registration-time validation of declaration shape and reserved names;
+    - an internal event's ordinary `:on` handler is accepted;
     - the dispatch boundary — an EXTERNAL dispatch of a declared internal
       event is REJECTED (emits `:rf.error/machine-internal-event-external-dispatch`,
       no state change), while an internal `:raise` of the SAME event is

--- a/implementation/machines/test/re_frame/machine_action_exception_always_on_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/machine_action_exception_always_on_cljs_test.cljc
@@ -1,30 +1,10 @@
 (ns re-frame.machine-action-exception-always-on-cljs-test
-  "rf2-cprm0q — `:rf.error/machine-action-exception` is catalogued **always-on**
-  (Spec 009 §Error event catalogue), but every machine emit site
-  (`lifecycle_fx/registration.cljc`, `finalize.cljc`, `traces.cljc`) used to
-  call ONLY the dev-gated `trace/emit-error!`, so the record was DCE'd out of
-  `:advanced` + `goog.DEBUG=false` production entirely — an always-on category
-  SILENTLY SWALLOWED (a 2am machine throw never reached Sentry). And even the
-  dev record carried NO action/guard attribution.
+  "Always-on `:rf.error/machine-action-exception` coverage.
 
-  This is the ADVERSARIAL acceptance leg — it drives the ACTUAL failing paths
-  (a throwing ACTION and a throwing GUARD both converge on
-  `registration.cljc`'s `trace-action-failure!`) and asserts the record fans
-  out on the corpus-wide `register-error-listener!` substrate — the always-on
-  axis that is NOT gated by `interop/debug-enabled?`, so it is exactly the
-  surface that SURVIVES a production build. On main (pre-fix) the `:errors`
-  listener receives NOTHING, so every assertion below is RED.
-
-  Pins the two defects the bead fixes:
-    (1) the record ACTUALLY reaches the always-on `:errors` channel (both an
-        action throw AND a guard throw);
-    (2) it carries `:failing-id` (the action / guard KEYWORD) + `:state` (the
-        active state path) — machine-local code identifiers, same privacy
-        class as `:event-id` — so an off-box shipper learns WHICH action /
-        guard in WHICH state threw.
-    (3) the production-surviving record is STRUCTURAL-ONLY: the developer's
-        arbitrary `:exception-data` (which may embed app secrets) does NOT
-        ride it.
+  Drives throwing action and guard paths through the real handler boundary and
+  verifies that both reach `register-error-listener!` with `:failing-id` and
+  `:state` attribution. The production-surviving record must remain structural:
+  arbitrary `:exception-data` does not ride the always-on channel.
 
   Dual-runtime: named `*_cljs_test.cljc` so the shadow-cljs `:node-test`
   build (`cljs-test$`) AND the JVM `clojure -M:test` runner both pick it up —

--- a/implementation/machines/test/re_frame/machine_cofx_lint_test.clj
+++ b/implementation/machines/test/re_frame/machine_cofx_lint_test.clj
@@ -16,40 +16,9 @@
        `:source-code` filtered to qualified keywords that are REGISTERED cofx
        ids and NOT in the declared diet).
 
-  Pre-rf2-hh4069 both diagnostics shipped registration-wired with ZERO test
-  coverage. This suite pins them.
-
-  ## rf2-ful212 + rf2-wbh50l (fixed): consume-undeclared alive end-to-end
-
-  Driving the REAL path while writing rf2-hh4069's tests revealed the
-  consume-undeclared diagnostic was UNREACHABLE end-to-end — two interacting
-  bugs, both since fixed:
-
-    - rf2-wbh50l — the `reg-machine` macro stamps each entry's `:source-code`
-      as a `pr-str` STRING (`re-frame.source-coords/walk-element-source` →
-      `collocate-element-source`), but the scan treated `:source-code` as a
-      FORM (`(tree-seq coll? seq source-code)`). `tree-seq` over a STRING is a
-      leaf — no keyword tokens — so the scan found nothing. FIXED:
-      `lint-machine!` now parses the string back to a form (safe EDN reader,
-      `source-code->form`) before the scan. The `*-form` tests still exercise
-      the scan against form-shaped input; `consume-undeclared-fires-against-
-      macro-string-source` now asserts the STRING path FIRES.
-
-    - rf2-ful212 — a machine registered as an INLINE LITERAL (or via
-      `defmachine`) whose `:guards` / `:actions` entry is the named cofx form
-      `{:rf.cofx/requires [...] :fn (fn ...)}` was DOUBLE-WRAPPED by
-      `collocate-element-source` (`{:fn <the-whole-entry-map> :source-code
-      \"...\"}`), nesting `:rf.cofx/requires` under `:fn`. That emptied the
-      cofx-ensure index (`by-entry`) AND broke guard/action resolution (the
-      guard's `:fn` was a map, not a fn → the guard never fired). FIXED:
-      `collocate-element-source` / `wrap-element-fns` now merge source onto an
-      already-shaped entry-map without re-wrapping. (The regression proofs live
-      in `machine_cofx_attach_test`; `consume-undeclared-fires-end-to-end-
-      through-reg-machine` below proves the lint through the real macro path.)
-
-  The ambient cases still register via the `def`/symbol path (no macro
-  stamping); the `-form` consume cases drive `(lint-machine! id (index-ensure-
-  sets machine))` directly with a hand-built `:source-code`."
+  The suite exercises both form-shaped and macro-string `:source-code`, plus
+  the real `reg-machine` path where source metadata is merged onto named entry
+  maps."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.interop :as interop]

--- a/implementation/machines/test/re_frame/machine_cofx_sub_source_test.clj
+++ b/implementation/machines/test/re_frame/machine_cofx_sub_source_test.clj
@@ -1,6 +1,6 @@
 (ns re-frame.machine-cofx-sub-source-test
-  "Sub-valued recordable coeffect source `{:rf/sub query-v :as fact-id}`
-  (EP-0017 Option A rider, rf2-h6ggnt) — machines-only.
+  "Machines-only sub-valued recordable coeffect source
+  `{:rf/sub query-v :as fact-id}`.
 
   It is a RECORDED TOKEN FACT, not permission for a callback to read the sub
   cache: a named guard/action declares the source in its `:rf.cofx/requires`;

--- a/implementation/machines/test/re_frame/machine_doc_opts_prod_elision_test.clj
+++ b/implementation/machines/test/re_frame/machine_doc_opts_prod_elision_test.clj
@@ -1,5 +1,5 @@
 (ns re-frame.machine-doc-opts-prod-elision-test
-  "Per rf2-tfiutq: `reg-machine`'s LITERAL opts-map pure-documentation
+  "`reg-machine` literal opts-map pure-documentation
   (`:doc`) production-elision contract — the machines-artefact counterpart of
   `re-frame.doc-metadata-prod-elision-test` (which pins the splice-through
   reg-* surfaces but cannot exercise `reg-machine`, since that needs
@@ -20,7 +20,7 @@
       constant-folds, so the user-authored `:doc` STRING bytes DCE from the
       :advanced bundle (a runtime strip cannot DCE a call-site string). That
       half is pinned by the elision probe (`scripts/check-elision.cjs`, the
-      `rf2-tfiutq-machine-opts-doc-sentinel` sentinel), not this JVM suite.
+      machine opts doc sentinel), not this JVM suite.
 
   This file pins the SEMANTIC half for the machine surface."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]

--- a/implementation/machines/test/re_frame/machine_node_keys_test.clj
+++ b/implementation/machines/test/re_frame/machine_node_keys_test.clj
@@ -1,15 +1,5 @@
 (ns re-frame.machine-node-keys-test
-  "rf2-0gtjde — no-silent-swallow on machine state-node / spawn-spec keys, and
-  the `:tags` shape.
-
-  From the 2026-07-03 self-consistency design review (finding 2): unknown BARE
-  keys on ordinary state nodes and on spawn specs were silently IGNORED — an
-  XState-trained author writes `:invoke` (XState's `:spawn`) or `:on-entry` (its
-  `:entry`), registration succeeds, and the child silently never spawns / the
-  action never runs. Inconsistent with siblings: `:type :history` / `:type
-  :choice` / `:schemas` nodes already hard-reject unknown keys. And `:tags`
-  silently COERCED a vector / single keyword to a set while its sibling
-  `:internal-events` hard-rejects exactly that non-set shape.
+  "No-silent-swallow coverage for state-node/spawn-spec keys and `:tags`.
 
   This suite pins the fail-loud behaviour:
     - an unknown BARE key on a state node → `:rf.error/machine-unknown-node-key`;
@@ -18,10 +8,7 @@
     - a non-set `:tags` slot → `:rf.error/machine-bad-tags`;
     - a NAMESPACED user key passes (the open extension carve-out);
     - a valid machine still registers cleanly, and a valid set-form `:tags`
-      still round-trips through the runtime tag projection.
-
-  A NEW file (not sharing a namespace with any sibling fixture) per the
-  rf2-0gtjde worker-lane split."
+      still round-trips through the runtime tag projection."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             ;; Load the machines facade so `rf/reg-machine` routes through its

--- a/implementation/machines/test/re_frame/machine_output_schema_test.clj
+++ b/implementation/machines/test/re_frame/machine_output_schema_test.clj
@@ -1,7 +1,6 @@
 (ns re-frame.machine-output-schema-test
   "Verifies the `[:schemas :output]` completion-output schema on `reg-machine`
-  and the `:where :machine-output` validation boundary (EP-0029 A8,
-  rf2-kgr3kk).
+  and the `:where :machine-output` validation boundary.
 
   The contract under test:
 

--- a/implementation/machines/test/re_frame/machine_schemas_grammar_test.clj
+++ b/implementation/machines/test/re_frame/machine_schemas_grammar_test.clj
@@ -1,13 +1,10 @@
 (ns re-frame.machine-schemas-grammar-test
-  "The machine-level `:schemas` map grammar (EP-0029 A3, the clean-break
-  successor to the retired EP-0005 `:data-schema` key).
+  "The machine-level `:schemas` map grammar.
 
-  `:schemas` is a closed-sub-key map. `:data` is the live, wired category
+  `:schemas` is a closed-sub-key map. `:data` is wired
   (validated at the `:where :machine-data` boundary — pinned by
-  `machine-schema-test`). The remaining A3 categories (`:events` / `:output` /
-  `:tags` / `:meta`) are accepted as DECLARATION-ONLY surfaces — their values
-  stay abstract and carry no wired behaviour this wave (the
-  `[:schemas :output]` → completion-payload binding is a separate wave).
+  `machine-schema-test`), and `:output` validates completion payloads.
+  `:events`, `:tags`, and `:meta` are declaration-only surfaces.
   `[:schemas :input]` is NOT accepted (state input is not adopted). Any other
   sub-key — or a non-map `:schemas` — fails loud at registration.
 

--- a/implementation/machines/test/re_frame/machines_choice_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_choice_cljs_test.cljs
@@ -1,5 +1,5 @@
 (ns re-frame.machines-choice-cljs-test
-  "CLJS-side coverage for EP-0029 A5 `:type :choice` transient / choice
+  "CLJS-side coverage for `:type :choice` transient
   states under the Reagent reactive substrate.
 
   Confirms cross-host parity for:

--- a/implementation/machines/test/re_frame/machines_internal_events_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_internal_events_cljs_test.cljs
@@ -1,5 +1,5 @@
 (ns re-frame.machines-internal-events-cljs-test
-  "CLJS-side coverage for EP-0029 A6 public / private `:internal-events`
+  "CLJS-side coverage for public/private `:internal-events`
   under the Reagent reactive substrate.
 
   Confirms cross-host parity for:

--- a/implementation/machines/test/re_frame/machines_timeout_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_timeout_cljs_test.cljs
@@ -1,5 +1,5 @@
 (ns re-frame.machines-timeout-cljs-test
-  "CLJS-side coverage for EP-0029 A4 `:timeout` / `:on-timeout` under the
+  "CLJS-side coverage for `:timeout` / `:on-timeout` under the
   Reagent reactive substrate.
 
   Confirms cross-host parity for:

--- a/implementation/machines/test/re_frame/on_spawn_ref_validation_test.clj
+++ b/implementation/machines/test/re_frame/on_spawn_ref_validation_test.clj
@@ -1,16 +1,11 @@
 (ns re-frame.on-spawn-ref-validation-test
-  "rf2-b4qbx0 — an `:on-spawn` KEYWORD ref resolves through the machine's
+  "An `:on-spawn` keyword ref resolves through the machine's
   `:on-spawn-actions` map, falling back to `:actions`
   (`transition/apply-on-spawn`'s `(or (chase-ref (:on-spawn-actions
-  machine) aref) (chase-ref (:actions machine) aref))`). BEFORE this fix,
-  registration validated the `:spawn` / `:spawn-all` SHAPE (machine-id xor
-  definition, unknown keys, …) but never chased the `:on-spawn` ref itself
-  — a dangling ref (a typo, a retired action name, a broken multi-hop
-  indirection, a cycle) registered cleanly, and at runtime `apply-on-spawn`
-  treats the nil resolution EXACTLY like a genuinely-absent `:on-spawn`:
-  the spawn completes silently, and the intended callback just never runs.
+  machine) aref) (chase-ref (:actions machine) aref))`). Dangling references,
+  broken indirection, and cycles fail at registration.
 
-  `validate-on-spawn-ref!` closes the gap: it follows the FULL `chase-ref`
+  `validate-on-spawn-ref!` follows the full `chase-ref`
   indirection chain (through EITHER registry, in that order), exactly as
   the sibling `:guard` / `:action` registration-time checks already do.
 

--- a/implementation/machines/test/re_frame/root_after_non_parallel_test.clj
+++ b/implementation/machines/test/re_frame/root_after_non_parallel_test.clj
@@ -1,19 +1,12 @@
 (ns re-frame.root-after-non-parallel-test
-  "rf2-b6znpi — a non-parallel (flat / compound) machine root's `:after` has
+  "A non-parallel (flat/compound) machine root's `:after` has
   NO runtime scheduling / resolution path: `transition/schedule-root-after-
   fx` (the birth-time scheduler) is called ONLY from `parallel/run-initial-
   cascade`'s parallel branch, and there is no root resolver that would fire
   a flat root `:after` at the empty decl-path (`grammar/node-at` resolves
-  an empty path to nil). BEFORE this fix, `timeout/validate-timeouts!` +
-  `validate-after-delays!` happily accepted a well-formed root `:timeout` /
-  `:after` on a flat/compound machine — it registered cleanly and its
-  \"whole-machine deadline\" simply never fired, silently.
-
-  Per the bead's two offered remedies (schedule it for real, OR reject it
-  loud at registration), the operator-ruled fix is REJECT: Spec 005
+  an empty path to nil). Registration therefore rejects this shape. Spec 005
   §Root-level `:after` scopes the feature to a `:type :parallel` root only,
-  so accepting it on a flat/compound root was never a documented capability
-  — only a validation gap. `validate-non-parallel-root-after!` closes it.
+  so `validate-non-parallel-root-after!` enforces the supported scope.
 
   This suite pins:
    1. a hand-authored root `:after` on a flat machine is rejected;

--- a/implementation/machines/test/re_frame/root_on_target_validation_test.clj
+++ b/implementation/machines/test/re_frame/root_on_target_validation_test.clj
@@ -1,19 +1,13 @@
 (ns re-frame.root-on-target-validation-test
-  "rf2-nvgolg — a NON-parallel (flat / compound) machine root's own `:on` is
+  "A non-parallel (flat/compound) machine root's own `:on` is
   the ANCESTOR-FALLBACK transition slot: per Spec 005 §Transition resolution
   steps 6-7, `pick-transition` consults it, stamped with decl-path `[]`,
   when no state-path node handles the event. Target resolution at that
   decl-path is exactly like a state's `:on` — a keyword resolves as a
   TOP-LEVEL sibling (`target-path`'s `(drop-last [])` → `[]`).
 
-  BEFORE this fix, `validate-transition-targets!` walked ONLY nodes INSIDE
-  `:states` (`walk-state-nodes-with-scope`) — the root's OWN `:on` was never
-  checked. A machine like `{:initial :a :on {:go :missing} :states {:a
-  {}}}` registered cleanly and would only surface `:rf.error/machine-
-  unresolved-target` LATE, at the first dispatch that fell through to the
-  root fallback and tried to commit the unresolved `:missing` state —
-  rather than failing fast at registration like every other transition
-  slot's target.
+  `validate-transition-targets!` checks this root slot as well as nodes under
+  `:states`, so malformed or unresolved targets fail at registration.
 
   This suite pins:
    1. an unresolved keyword root :on target fails at REGISTRATION with

--- a/implementation/machines/test/re_frame/timeout_test.clj
+++ b/implementation/machines/test/re_frame/timeout_test.clj
@@ -1,11 +1,10 @@
 (ns re-frame.timeout-test
-  "EP-0029 A4 — state-level + spawn-level `:timeout` / `:on-timeout`
+  "State-level and spawn-level `:timeout` / `:on-timeout`
   (delayed transitions).
 
   Covers:
     - the duration grammar (integer-ms OR ISO-8601 only; the XState
-      `\"5s\"` / `\"10ms\"` shorthand is REJECTED — operator-ruled
-      divergence);
+      `\"5s\"` / `\"10ms\"` shorthand is rejected);
     - registration-time fail-loud validation (timeout requires on-timeout
       and vice-versa; bad duration; :after collision);
     - desugaring `:timeout` / `:on-timeout` onto the existing `:after`


### PR DESCRIPTION
## Summary
- align machine comments and docstrings with runtime-db lifecycle and lazy actor resolution
- correct internal-event, timeout, output-schema, classification, SSR, reply, and trace contract explanations
- remove issue-history and duplicate narration while retaining non-obvious bundle and lifecycle invariants

## Verification
- `cd implementation/machines && clojure -M:test` (922 tests, 2911 assertions)
- `cd implementation && npm run test:cljs` (8466 tests, 39169 assertions)
- `clj-kondo --parallel --fail-level error --lint implementation/machines` (0 errors; 92 existing warnings)
- `cd implementation && clojure -M:splint --fail-on-errors ../implementation/machines` (0 errors; 156 existing style warnings)
- `cd implementation && npm run test:elision`
- `cd implementation && npm run test:bundle-isolation`
- `git diff --check origin/main...HEAD`

Bead: `rf2-yqstca`
