### PR TITLE
docs(async): coming-from-promises — then/catch/finally → re-frame2 reply model (rf2-mummu4)

### DIFF
--- a/docs/async/coming-from-promises.md
+++ b/docs/async/coming-from-promises.md
@@ -1,0 +1,60 @@
+# Coming from Promises
+
+You arrive with the Promise triad — `.then`, `.catch`, `.finally`. re-frame2 has all three jobs covered, but the shapes moved, because a settlement here is a **value delivered to a handler**, not a pair of callbacks. A managed effect — [HTTP](http.md), a [resource](../resources/concepts.md), a [machine](../machines/concepts.md) — never hands you a promise object to chain. It dispatches the outcome back into your app as an ordinary [event](../core/glossary.md#event), carrying a canonical reply map you branch on. So the question stops being "what do I chain onto the promise?" and becomes "which handler receives the settlement, and how does it read it?"
+
+This page is the translation. For the *why* underneath — why a continuation is data and not a closure — read [Why no await](continuations-are-data.md) once the mapping has landed.
+
+## The mapping
+
+| JS Promise | re-frame2 |
+|---|---|
+| `.then(onFulfilled)` | `:on-success [:ev]` (HTTP sugar), or the `:ok` branch of `(:status reply)` in one [`:reply-to`](http.md#one-handler-with-reply-to) handler |
+| `.catch(onRejected)` | `:on-failure [:ev]` ([split sugar](http.md#two-handlers-with-on-success--on-failure)), or the `:error` branch of `(:status reply)` |
+| `.finally(onFinally)` | shared code in **one** `:reply-to` handler — a `let` above the `case` ([example](#the-finally-shaped-example)) |
+| `AbortController` cancellation | a **status you read** — `:cancelled` — not an exception type ([cancellation](http.md#cancellation-supersession-and-abort)) |
+| a superseded / raced settlement | `:stale` — and it is **never delivered**, by design ([why](#why-there-is-no-on-finally)) |
+
+The bottom two rows are where the Promise model is quietly weaker, not just spelled differently. A promise has no first-class *cancelled* outcome — you bolt on an `AbortController` and catch a thrown `AbortError` — and no notion of a *stale* settlement at all: a superseded `fetch` still resolves, still runs your `.then`, and cheerfully overwrites fresher data (the search-box race). re-frame2 makes both a **status** in a closed reply set, and suppresses the stale one before it can reach your handler.
+
+??? info "Coming from `async/await`, not `.then`?"
+
+    Same story, hidden better. `await` doesn't remove the two callbacks — it lets the compiler write them for you as the suspended rest of your function (a closure). The success path is the code after the `await`; the failure path is the `catch` block; the `finally` block is `finally`. re-frame2 unbundles that closure back into a named event and a reply value you branch on — so everything below reads the same whether you were writing `.then` chains or `await`. [Why no await](continuations-are-data.md) is the full account.
+
+## The finally-shaped example
+
+The `.finally` job — cleanup that runs whichever way the work settled — needs no dedicated key. Because the settlement arrives as one value in one handler, a `let` above the `case` already sees every branch:
+
+```clojure
+(rf/reg-event :articles/replied
+  (fn [{:keys [db]} [_ reply]]
+    (let [db (assoc db :loading? false)]                     ;; runs for every outcome — this is your `finally`
+      (case (:status reply)
+        :ok        {:db (assoc db :articles (:value reply))}  ;; `.then`
+        :error     {:db (assoc db :error    (:error reply))}  ;; `.catch`
+        :cancelled {:db db}))))
+```
+
+The code before the `case` **is** your `finally`; the branches are `then` and `catch`. No third callback, no ordering question — a `let` does the job, because the settlement is data and both branches share its scope.
+
+## Where do the captured variables go?
+
+A `.then` closure sees the locals of the function that issued the request. A reply handler doesn't — it runs on a fresh stack against the *present* [app-db](../core/glossary.md#app-db), not a snapshot from issue time. So anything the reply branch needs — a slug, an id — you **ride on the reply vector**, ahead of the appended envelope:
+
+```clojure
+:reply-to [:articles/replied slug]   ;; the handler receives [:articles/replied slug <reply-map>]
+```
+
+The split sugar carries context the same way — `:on-success [:articles/loaded slug]`. This is deliberate, not a missing feature: a captured local is a snapshot of the past — the source of [the stale-world trap](continuations-are-data.md#the-bug-this-kills-the-stale-world-trap) — while a value ridden on the vector is explicit data that lands on the record.
+
+## Why there is no `:on-finally`
+
+A Promise needs `finally` because settlement splits into two disjoint closures — the `.then` and the `.catch` — with no shared scope; `finally` is the one place a line can run for both. When settlement is a single value delivered to a single handler, that shared scope is just the handler body. There is nothing for an `:on-finally` to reunite.
+
+And `finally` promises to **always run** — a guarantee re-frame2 deliberately breaks. A `:stale` reply is [suppressed, never delivered](continuations-are-data.md#one-envelope-under-every-async-surface): superseded work must not touch state, so its "finally" must *not* fire either. Cleanup like clearing the loading flag belongs to the **newer** attempt's lifecycle (generation-based cleanup), not to the older attempt's funeral (settlement-based cleanup). A faithful `:on-finally` would have to either resurrect the stale-race bug class — running cleanup on behalf of a request that was superseded — or lie about "always". re-frame2 records the refusal on the trace instead of shipping either.
+
+**Rule of thumb:** two callbacks (`:on-success` / `:on-failure`) when the branches share nothing; one `:reply-to` handler the moment they share cleanup.
+
+## Where to go next
+
+- [Why no await: continuations are data](continuations-are-data.md) — the deeper *why*: named continuations, and the stale-world trap the data model closes by construction.
+- [Managed HTTP reference](http.md) — the surface reference: every reply key, the closed `:status` set, and both addressing spellings side by side.

--- a/docs/async/continuations-are-data.md
+++ b/docs/async/continuations-are-data.md
@@ -4,6 +4,10 @@ You've met `:on-success` on [HTTP requests](http.md), `:reply-to` on mutations, 
 
 **The takeaway, up front: in re-frame2 a continuation is data, not a closure.** The rest of the page earns that sentence. We'll first see the one move that makes it true, then see — concretely — what `await` was quietly costing you, and finally what you get to do once the continuation is a value you can hold in your hand.
 
+!!! tip "Just want the `.then`/`.catch`/`.finally` translation?"
+
+    [Coming from Promises](coming-from-promises.md) is the quick mapping table — this page is the *why* it points back to.
+
 ## Start with the one move
 
 Here is the [effect map](../core/glossary.md#effect-map) an [event handler](../core/glossary.md#event-handler) returns to ask for an HTTP request. Watch where the *result* is supposed to go:

--- a/docs/async/http.md
+++ b/docs/async/http.md
@@ -103,6 +103,10 @@ So the *reply's* `:status` tells you which path (`:ok` / `:error` / `:cancelled`
 
 Every request **addresses its reply** — there is no implicit default. There are two **equal** ways to do it — pick by fit, not correctness.
 
+??? info "Coming from Promises?"
+
+    `:on-success` / `:on-failure` are `.then` / `.catch`; a single `:reply-to` handler that branches on `:status` is the `.finally`-plus-both-branches shape (a `let` above a `case`). [Coming from Promises](coming-from-promises.md) maps the whole triad — including why there is no `:on-finally`.
+
 ### Two handlers with :on-success / :on-failure
 
 Name `:on-success` and `:on-failure` and each outcome lands in its own handler, with the canonical reply appended as the last event argument — `[:article/loaded {:status :ok :value <decoded> …}]`. `:on-success` / `:on-failure` are pure routing sugar; both receive the identical envelope, they just route it to two named handlers:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -276,6 +276,7 @@ nav:
     - "Interceptors and secrets": async/http-going-further.md
     - "Your own async effect": async/custom-effects.md
     - "Why no await": async/continuations-are-data.md
+    - "Coming from Promises": async/coming-from-promises.md
     - "Examples": async/examples.md
 
   - Routing:


### PR DESCRIPTION
Completes the "coming-from" doc genre: async — the domain where JS priors are strongest (Promises) — was the one missing its entry page. Every sibling domain already has one (machines/coming-from-xstate, resources/coming-from-tanstack-query, routing/coming-from-react-router, ssr/coming-from-nextjs).

## What landed

New page `docs/async/coming-from-promises.md` (60 lines) mapping the Promise triad onto re-frame2's managed-effect reply model:

- **Mapping table** — `.then` → `:on-success` / `:ok` branch; `.catch` → `:on-failure` / `:error` branch; `.finally` → shared code in one `:reply-to` handler (a `let` above the `case`); cancellation → the `:cancelled` **status** (not a thrown `AbortError`); a superseded/raced settlement → `:stale`, **never delivered**.
- **The worked example** — the let-before-case idiom: code before the `case` *is* your `finally`; the branches are `then` and `catch`.
- **Where captured variables go** — a reply handler runs against the *present* app-db, so context rides on the reply vector (`:reply-to [:ev slug]`), not a captured closure local. Ties back to the stale-world trap.
- **Why there is no `:on-finally`** — two arguments: (1) `finally` reunites two disjoint closures with no shared scope; one handler already *is* the shared scope; (2) `finally` promises to *always run*, and re-frame2 deliberately breaks that — a `:stale` reply is suppressed, so cleanup belongs to the newer attempt's lifecycle, not the older attempt's funeral. Cross-links the recorded-suppression paragraph in continuations-are-data.md.
- **Rule of thumb** — two callbacks when the branches share nothing; one `:reply-to` handler the moment they share cleanup.

### Wiring
- mkdocs nav: "Coming from Promises" immediately after "Why no await" in the Async section.
- Reciprocal cross-links: a `??? info "Coming from Promises?"` pointer in `http.md`'s reply-addressing section, and a `!!! tip` pointer from `continuations-are-data.md`.

## Written against post-et4c1s addressing
Uniform bare `:reply-to` on every async effect; `:on-success` / `:on-failure` shown as HTTP-only sugar. The retired co-located `:rf/reply` default is **not** taught anywhere.

## Quality gates
- `python -m mkdocs build --strict` — **exit 0** (built in 20.1s; the INFO lines are pre-existing, about spec/ and migration/ files, none touched here).
- `python scripts/check_doc_slugs.py` — **exit 0** (all in-repo links and anchors resolve).

## Stance
Pre-alpha teaching material — frames the domain via the dominant JS-ecosystem tool (Promises), then maps onto re-frame2, flagging the deliberate divergence (continuations are data dispatched into the frame, not chained callbacks/microtasks; no promise object threads through; the envelope + reply addressing carry the outcome). Respectful of the prior model, precise about where it is weaker (no cancellation-as-data, no stale suppression), zero snark. ELEGANCE + CLARITY.