### PR TITLE
refactor(story): pure verdict leaf + centralized story-mcp lifecycle owner (rf2-o6toyw, rf2-iapjh7)

### DIFF
--- a/tools/story-mcp/src/re_frame/story_mcp/tools/dev.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/dev.cljc
@@ -10,10 +10,10 @@
   `(str ...)` shape, kept aligned so AI pairs reading
   both servers see one answer to the onboarding-text question."
   (:require [re-frame.story :as story]
-            [re-frame.story.async :as async]
             [re-frame.story-mcp.tools.args :as targs]
             [re-frame.story-mcp.tools.cljs-resolve :as cljs-resolve]
             [re-frame.story-mcp.tools.egress :as egress]
+            [re-frame.story-mcp.tools.lifecycle :as lifecycle]
             [re-frame.story-mcp.tools.result :as result]
             [re-frame.story-mcp.tools.schemas :as s]))
 
@@ -101,8 +101,9 @@
   "Dev: given a variant id, return the canvas state + share URL.
 
   Per IMPL-SPEC §7.2 'returns rendered hiccup for a variant + the
-  assertions list'. We invoke `run-variant`, deref the promise (JVM
-  side has `async/deref-blocking`), and serialise the result map.
+  assertions list'. We invoke the shared `tools.lifecycle` execution
+  owner (blocking `run-variant` deref + canonical exception
+  normalization), and serialise the result map.
 
   `preview-variant` runs the SAME `story/run-variant` lifecycle as
   `run-variant`, so it speaks the SAME unified run-result vocabulary —
@@ -134,26 +135,18 @@
           (let [opts       (targs/read-run-opts vk arguments)
                 base-url   (or (:base-url arguments) "")
                 share-url  (story/variant-share-url vk base-url opts)
-                outcome    (try
-                             (async/deref-blocking (story/run-variant vk opts)
-                                                   ;; Shared lifecycle ceiling:
-                                                   ;; tunable `:timeout-ms`
-                                                   ;; (default 10s, clamped to 30s),
-                                                   ;; the SAME knob `run-variant` uses
-                                                   ;; so the two cannot drift.
-                                                   (targs/resolve-timeout-ms arguments))
-                             (catch Throwable e
-                               ;; A throw never produced a unified result; mint the
-                               ;; :error verdict directly so preview speaks the SAME
-                               ;; unified shape a settled run emits.
-                               {:status     :error
-                                :lifecycle  :error
-                                :assertions [(story/assertion-record
-                                               {:assertion :rf.error/run-failed
-                                                :passed?   false
-                                                :error     true
-                                                :reason    (ex-message e)})]
-                                :checks     []}))
+                ;; Blocking invocation + timeout + canonical exception
+                ;; normalization are owned by `tools.lifecycle` — the ONE
+                ;; execution owner `run-variant` shares (same tunable ceiling
+                ;; via `targs/resolve-timeout-ms`, default 10s / 30s hard cap).
+                ;; A throw / timeout is normalized through `story/run-result`
+                ;; with `:lifecycle :error` stamped, so preview keeps the
+                ;; loader-state slot it reads AND speaks the SAME unified
+                ;; run-result vocabulary a settled run emits. The
+                ;; preview-specific projection / egress / wire shaping stays
+                ;; below.
+                outcome    (lifecycle/run-variant-blocking
+                             vk opts (targs/resolve-timeout-ms arguments))
                 incl?      (targs/include-sensitive? arguments)
                 raw-db     (:app-db outcome)
                 [assertions dropped] (egress/scrub-assertions+count (:assertions outcome) incl?)

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/lifecycle.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/lifecycle.cljc
@@ -1,0 +1,71 @@
+(ns re-frame.story-mcp.tools.lifecycle
+  "The ONE owner of the variant-lifecycle EXECUTION the two lifecycle
+  tools share — `run-variant` (`tools.testing`) and `preview-variant`
+  (`tools.dev`).
+
+  Both tools invoke the SAME `story/run-variant` lifecycle, block on it
+  with the SAME single-threaded-stdio ceiling, catch a synchronous throw /
+  timeout, and normalize that failure into a unified run-result. Their
+  catch paths had DRIFTED: `preview-variant` hand-built a partial error map
+  (`{:status :error :lifecycle :error :assertions […] :checks []}`) while
+  `run-variant` assembled the canonical shape through `story/run-result`.
+  A hand-mint omits the six `.4` evidence slots (`:schema-violations` /
+  `:warnings` / `:effects` / `:sub-runs` / `:renders` / `:narrative`),
+  which then read back as ABSENT → nil → a bare `nil` on the wire, failing
+  the frozen `[:sequential :any]` schema every settled run satisfies
+  (rf2-5r6j96).
+
+  This leaf owns the shared execution — blocking invocation, timeout
+  blocking, and ONE canonical exception normalization — so the two tools
+  cannot drift again. What stays in the caller namespaces (per the bead's
+  boundary) is everything AFTER the outcome: the preview / run-specific
+  projection, egress scrubbing, annotations, indicator counts, and wire
+  shaping. This leaf produces the settled-or-error OUTCOME; the callers
+  shape it."
+  (:require [re-frame.story       :as story]
+            [re-frame.story.async :as async]))
+
+(defn error-outcome
+  "Assemble the ONE canonical error run-result for a synchronous throw /
+  timeout out of `story/run-variant`, through the SAME `story/run-result`
+  boundary a settled run uses (spec/017 §Run result). Pure given the
+  variant key `vk` + the thrown `e`.
+
+  Routing the failure through `story/run-result` (rather than hand-minting
+  a partial map) fills every `.4` evidence slot to `[]` — so the wire
+  projection always has a sequential to walk and never ships a bare `nil`
+  for an absent slot (rf2-5r6j96). Two extra slots are stamped so BOTH
+  consumers keep the fields they read off the outcome:
+
+  - `:lifecycle :error` — the loader-lifecycle STATE `preview-variant`
+    surfaces (distinct from the `:status` verdict);
+  - `:frame vk` — the variant frame id `run-variant` surfaces (so the
+    canonical outcome is self-describing rather than relying on each
+    caller's `(:frame outcome vk)` fallback)."
+  [vk e]
+  (assoc (story/run-result
+           {:variant/id vk
+            :assertions [(story/assertion-record
+                           {:assertion :rf.error/run-failed
+                            :passed?   false
+                            :error     true
+                            :reason    (ex-message e)})]})
+         :lifecycle :error
+         :frame     vk))
+
+(defn run-variant-blocking
+  "Invoke `story/run-variant` for `vk` with `opts` and BLOCK for its
+  unified run-result, capped at `timeout-ms` (the single-threaded-stdio
+  ceiling both lifecycle tools share via `targs/resolve-timeout-ms`). A
+  synchronous throw or a timeout-elapsed deref is normalized into the ONE
+  canonical `error-outcome` — so `run-variant` and `preview-variant`
+  return the SAME settled-or-error vocabulary and can never drift in their
+  blocking / failure policy.
+
+  Returns the outcome map (a settled run-result, or the canonical error
+  outcome). The caller projects / scrubs / wire-shapes it."
+  [vk opts timeout-ms]
+  (try
+    (async/deref-blocking (story/run-variant vk opts) timeout-ms)
+    (catch Throwable e
+      (error-outcome vk e))))

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/testing.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/testing.cljc
@@ -26,10 +26,10 @@
   `:app-db` / `:assertions` slots through
   `re-frame.story-mcp.tools.egress`."
   (:require [re-frame.story :as story]
-            [re-frame.story.async :as async]
             [re-frame.story-mcp.tools.args :as targs]
             [re-frame.story-mcp.tools.cljs-resolve :as cljs-resolve]
             [re-frame.story-mcp.tools.egress :as egress]
+            [re-frame.story-mcp.tools.lifecycle :as lifecycle]
             [re-frame.story-mcp.tools.result :as result]
             [re-frame.story-mcp.tools.schemas :as s]))
 
@@ -93,35 +93,17 @@
     (fn [vk _body]
       (or (targs/run-opts-shape-error arguments)
           (let [opts     (targs/read-run-opts vk arguments)
-                timeout  (targs/resolve-timeout-ms arguments)
-                outcome  (try
-                           (async/deref-blocking (story/run-variant vk opts) timeout)
-                           (catch Throwable e
-                             ;; A throw / timeout never produced a unified
-                             ;; result; assemble ONE through the SAME canonical
-                             ;; `story/run-result` boundary a settled run emits
-                             ;; (spec/017 §Run result) rather than hand-mint a
-                             ;; partial map — a hand-mint omitting the six `.4`
-                             ;; evidence slots (`:schema-violations` / `:warnings`
-                             ;; / `:effects` / `:sub-runs` / `:renders` /
-                             ;; `:narrative`) reads them back as an ABSENT key,
-                             ;; i.e. nil, which then projects RAW through
-                             ;; `egress/scrub-rendered` below and ships a bare
-                             ;; `nil` on the wire — failing the frozen
-                             ;; `[:sequential :any]` schema every OTHER run
-                             ;; outcome satisfies (rf2-5r6j96). `run-result`
-                             ;; against an empty tape fills every evidence slot
-                             ;; to `[]`, so the projection always has a
-                             ;; sequential to walk — one vocabulary, no
-                             ;; special-case error-branch shape for agents OR
-                             ;; the schema to carve out.
-                             (story/run-result
-                               {:variant/id vk
-                                :assertions [(story/assertion-record
-                                               {:assertion :rf.error/run-failed
-                                                :passed?   false
-                                                :error     true
-                                                :reason    (ex-message e)})]})))
+                ;; Blocking invocation + timeout + canonical exception
+                ;; normalization are owned by `tools.lifecycle` — the ONE
+                ;; execution owner `preview-variant` shares, so their catch
+                ;; paths cannot drift (the error outcome always routes through
+                ;; `story/run-result`, filling the six `.4` evidence slots to
+                ;; `[]` so the wire projection never ships a bare nil for an
+                ;; absent slot, rf2-5r6j96). Everything AFTER the outcome —
+                ;; projection, egress, indicator counts, wire shaping — stays
+                ;; run-variant-specific, below.
+                outcome  (lifecycle/run-variant-blocking
+                           vk opts (targs/resolve-timeout-ms arguments))
                 incl?    (targs/include-sensitive? arguments)
                 raw-db   (:app-db outcome)
                 [assertions dropped] (egress/scrub-assertions+count (:assertions outcome) incl?)

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -30,6 +30,7 @@
             [re-frame.story-mcp.tools.wire-pipeline :as wire-pipeline]
             [re-frame.story-mcp.tools.dev :as dev]
             [re-frame.story-mcp.tools.egress :as egress]
+            [re-frame.story-mcp.tools.lifecycle :as lifecycle]
             [re-frame.story-mcp.tools.recorder :as recorder-tool]
             [re-frame.story-mcp.tools.registry :as registry]
             [re-frame.substrate.plain-atom :as plain-atom]))
@@ -3598,6 +3599,58 @@
                    (story/explain-run-result s)))
           (doseq [k [:schema-violations :warnings :effects :sub-runs :renders :narrative]]
             (is (= [] (get s k)) (str k " defaults to [] rather than nil"))))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-iapjh7: ONE lifecycle execution owner for both consumers
+;;
+;; `run-variant` (tools.testing) + `preview-variant` (tools.dev) share the
+;; `tools.lifecycle` execution owner — blocking invocation, timeout
+;; blocking, and ONE canonical exception normalization. A synchronous
+;; throw / timeout produces the SAME canonical error outcome for BOTH,
+;; routed through `story/run-result` (not a hand-mint), with the
+;; `:lifecycle :error` loader-state + `:frame` preserved.
+;; ---------------------------------------------------------------------------
+
+(deftest lifecycle-error-outcome-is-canonical
+  (testing "error-outcome routes a throw through story/run-result — canonical
+            shape, :status :error, every .4 evidence slot filled to [], plus
+            the preserved :lifecycle :error + :frame slots"
+    (let [outcome (lifecycle/error-outcome :story.some/variant
+                                           (ex-info "boom" {}))]
+      (is (= :error (:status outcome)) "the run-failed record aggregates to :error")
+      (is (= :error (:lifecycle outcome)) "loader-state :error is preserved (preview reads it)")
+      (is (= :story.some/variant (:frame outcome)) "the frame is preserved (run reads it)")
+      (is (story/valid-run-result? outcome)
+          (str "the error outcome conforms to the frozen RunResult schema; "
+               (story/explain-run-result outcome)))
+      (doseq [k [:schema-violations :warnings :effects :sub-runs :renders :narrative]]
+        (is (= [] (get outcome k)) (str k " is filled to [] — never an absent/nil slot")))
+      (is (= :error (-> outcome :assertions first :status))
+          "the run-failed assertion record itself carries :error"))))
+
+(deftest lifecycle-error-outcome-surfaced-by-both-consumers
+  ;; A synchronous throw out of `story/run-variant` must surface the SAME
+  ;; canonical :error outcome through BOTH tools' real wire pipelines — the
+  ;; drift-proofing this refactor buys (preview no longer hand-mints a
+  ;; partial map; it shares the owner). `preview-variant` additionally keeps
+  ;; the `:lifecycle :error` slot it projects.
+  (with-clean-frame [vid :story.button/primary]
+    ;; Prime a live frame — the throw is reachable only after phase-0
+    ;; allocation, which resolves unconditionally on every other internal error.
+    (invoke "run-variant" {:variant-id "story.button/primary"})
+    (with-redefs [story/run-variant
+                  (fn [& _] (throw (ex-info "simulated run-variant boom" {})))]
+      (doseq [tool ["run-variant" "preview-variant"]]
+        (testing (str tool " surfaces the canonical :error verdict via the shared owner")
+          (let [r (invoke tool {:variant-id "story.button/primary"})
+                s (:structuredContent r)]
+            (is (success? r))
+            (is (= :error (:status s)) (str tool " ⇒ :error"))
+            (is (= :error (-> s :assertions first :status))
+                (str tool " carries the :rf.error/run-failed record")))))
+      (testing "preview-variant additionally preserves the :lifecycle :error loader-state"
+        (let [s (:structuredContent (invoke "preview-variant" {:variant-id "story.button/primary"}))]
+          (is (= :error (:lifecycle s))))))))
 
 (deftest read-failures-strips-sensitive-assertion-records-by-default
   (testing "an assertion record stamped :sensitive? true is dropped at egress"

--- a/tools/story/src/re_frame/story/result.cljc
+++ b/tools/story/src/re_frame/story/result.cljc
@@ -58,22 +58,21 @@
   (:require [malli.core                   :as m]
             [re-frame.story.assertions    :as assertions]
             [re-frame.story.play.evidence :as evidence]
-            [re-frame.story.requirements  :as requirements]))
+            [re-frame.story.requirements  :as requirements]
+            [re-frame.story.verdict       :as verdict]))
 
 ;; ===========================================================================
 ;; STATUS — the four verdicts (spec/017 §Run result)
 ;; ===========================================================================
 
+;; The four-verdict set has ONE owner — the pure `re-frame.story.verdict`
+;; leaf (spec/017 §Run result). Re-exported here to preserve the public
+;; `re-frame.story.result/statuses` contract; the UI-state + test-mode
+;; pure helpers consume the leaf directly (no cycle through the runtime).
 (def statuses
-  "The four run / assertion / check verdicts (spec/017 §Run result):
-
-  - `:pass`       — every expectation the runner could attempt held;
-  - `:fail`       — at least one expectation failed (or the tape shows
-                    unconsumed failure evidence);
-  - `:cannot-run` — the ONLY unmet expectations were ones the runner could
-                    not even attempt (the distinct THIRD status, §`:cannot-run`);
-  - `:error`      — a handler / fx / step threw."
-  #{:pass :fail :cannot-run :error})
+  "The four run / assertion / check verdicts (spec/017 §Run result) —
+  re-exported from the `re-frame.story.verdict` leaf, the single owner."
+  verdict/statuses)
 
 ;; ===========================================================================
 ;; THE SCHEMA-BACKED CONTRACT  (API governance freeze)
@@ -198,26 +197,14 @@
   [result]
   (m/explain RunResult result))
 
-(defn record-status
-  "Derive the `:status` for ONE assertion record from its outcome fields.
-  Pure data → data. An explicit `:status` already on the record wins (the
-  record was minted by a status-aware path); otherwise:
-
-  - `:cannot-run?` true   → `:cannot-run` (the runner could not prove it);
-  - `:exception` / `:error` truthy → `:error`;
-  - `:passed?` true       → `:pass`;
-  - `:passed?` false      → `:fail`;
-  - `:passed?` nil        → `:pass` (a non-assertion / vacuous record does
-                            not fail the run — the /spec/007-Stories.md §Story-as-test duality)."
-  [{:keys [status passed? cannot-run? skipped? exception error] :as _record}]
-  (cond
-    (contains? statuses status) status
-    cannot-run?                 :cannot-run
-    skipped?                    :cannot-run   ; §`:cannot-run` generalizes the shipping :skipped?
-    (or exception error)        :error
-    (true? passed?)             :pass
-    (false? passed?)            :fail
-    :else                       :pass))
+;; `record-status` — the record-normalization rule — also has ONE owner
+;; (the `re-frame.story.verdict` leaf). Re-exported here to preserve the
+;; public `re-frame.story.result/record-status` contract.
+(def record-status
+  "Derive the `:status` for ONE assertion record from its outcome fields
+  (spec/017 §Run result) — re-exported from the `re-frame.story.verdict`
+  leaf, the single owner. Pure data → data."
+  verdict/record-status)
 
 ;; ===========================================================================
 ;; ASSERTION RECORD — the `.18` atom shape + a unified `:status`

--- a/tools/story/src/re_frame/story/ui/state/tests.cljc
+++ b/tools/story/src/re_frame/story/ui/state/tests.cljc
@@ -29,7 +29,8 @@
   `re-frame.story.ui.state` proper — splitting honors the leaf-size
   ceiling without losing locality. The parent ns re-exports the
   public defs so existing consumer requires (`re-frame.story.ui.state`)
-  keep working.")
+  keep working."
+  (:require [re-frame.story.verdict :as verdict]))
 
 ;; ---- test-runs -----------------------------------------------------------
 ;;
@@ -64,40 +65,6 @@
   [state variant-id]
   (assoc-in state [:tests :runs variant-id] {:status :running}))
 
-(defn- record-status
-  "The unified verdict for ONE assertion record: the record's own
-  `:status` when it is one of the four verdicts (the unified shape),
-  else derived from the outcome fields. Pure data →
-  data — a local mirror so this leaf needs no require into
-  `re-frame.story.result` (which would loop through the runtime via
-  `result` → `runtime`).
-
-  This MUST track `re-frame.story.result/record-status` verdict-for-
-  verdict — it cannot delegate (the cycle above) so the rule is copied
-  by hand. The canonical ordering (and the one reproduced here) is:
-
-  - an explicit `:status` that is one of the four verdicts wins;
-  - `:cannot-run?` / `:skipped?` truthy → `:cannot-run`;
-  - `:exception` / `:error` truthy → `:error` (a thrown handler / fx /
-    step — a derived record carrying `:exception`/`:error` but no
-    explicit `:status` must count as `:error`, not a false-green `:pass`);
-  - `:passed?` true → `:pass`; `:passed?` false → `:fail`;
-  - otherwise `:pass` (a non-assertion / vacuous record does not fail
-    the run — the /spec/007-Stories.md §Story-as-test duality).
-
-  A parity test (`record-status-mirrors-canonical`) runs a table of
-  record shapes through BOTH this mirror and the canonical, asserting
-  identical verdicts, so the two can never silently drift again."
-  [{:keys [status passed? skipped? cannot-run? exception error] :as _record}]
-  (cond
-    (contains? #{:pass :fail :cannot-run :error} status) status
-    cannot-run?          :cannot-run
-    skipped?             :cannot-run
-    (or exception error) :error
-    (true? passed?)      :pass
-    (false? passed?)     :fail
-    :else                :pass))
-
 (defn aggregate-summary
   "Walk `assertions` (the vector pulled off a `run-variant` result map)
   and produce the aggregated pass/fail/cannot-run counts:
@@ -126,7 +93,7 @@
         legacy-skip? (fn [r] (= :rf.assert/skipped (:assertion r)))
         skipped    (count (filter legacy-skip? items))
         active     (remove legacy-skip? items)
-        buckets    (frequencies (map record-status active))
+        buckets    (frequencies (map verdict/record-status active))
         passed     (get buckets :pass 0)
         cannot-run (get buckets :cannot-run 0)
         ;; :fail + :error both count as failures for the headline tally.
@@ -157,7 +124,7 @@
   (let [{:keys [total passed failed cannot-run skipped all-passed?
                 ran-at-ms elapsed-ms status]} (or summary {})
         status (cond
-                 (contains? #{:pass :fail :cannot-run :error} status)
+                 (contains? verdict/statuses status)
                  (if (= :error status) :fail status)   ; :error reads as :fail on the dot
                  (zero? (or total 0)) :pending
                  all-passed?          :pass

--- a/tools/story/src/re_frame/story/ui/test_mode/pure.cljc
+++ b/tools/story/src/re_frame/story/ui/test_mode/pure.cljc
@@ -16,7 +16,8 @@
   (:require [clojure.string            :as str]
             [re-frame.story.assertions :as assertions]
             [re-frame.story.predicates :as pred]
-            [re-frame.story.registrar  :as registrar]))
+            [re-frame.story.registrar  :as registrar]
+            [re-frame.story.verdict    :as verdict]))
 
 ;; ---- aliases on the leaf predicates ns ----------------------------------
 ;;
@@ -30,14 +31,10 @@
 
 ;; ---- the unified run-result verdicts (spec/017 §Run result) -------------
 ;;
-;; The four verdicts every assertion record / check / run carries
-;; (`re-frame.story.result/statuses`). Mirrored here as a local set so the
-;; pure helpers can recognise a stamped `:status` without a require into
-;; `re-frame.story.result` (which loops through the runtime).
-
-(def statuses
-  "The unified run / check / assertion verdicts (spec/017 §Run result)."
-  #{:pass :fail :cannot-run :error})
+;; The four verdicts every assertion record / check / run carries are owned
+;; by the pure `re-frame.story.verdict` leaf (`verdict/statuses`) — consumed
+;; directly here (no require into `re-frame.story.result`, which loops
+;; through the runtime; no local mirror to drift).
 
 ;; ---- pure: variant-has-tests? -------------------------------------------
 
@@ -137,7 +134,7 @@
                    (= :rf.assert/skipped aid)          :skip
                    ;; The unified `:status` wins; the :passed?-only
                    ;; derivation is the fallback.
-                   (contains? statuses st)             st
+                   (contains? verdict/statuses st)     st
                    (:cannot-run? rec)                  :cannot-run
                    (or (:error rec) (:exception rec))  :error
                    passed?                             :pass
@@ -397,8 +394,8 @@
   [result summary]
   (let [st (:status result)]
     (cond
-      (nil? result)             :pending
-      (contains? statuses st)   st
+      (nil? result)                   :pending
+      (contains? verdict/statuses st) st
       :else
       (let [{:keys [total failed cannot-run all-passed?]} (or summary {})]
         (cond
@@ -701,7 +698,7 @@
         status-of (fn [rec]
                     (let [st (:status rec)]
                       (cond
-                        (contains? statuses st)            st
+                        (contains? verdict/statuses st)    st
                         (:cannot-run? rec)                 :cannot-run
                         (or (:error rec) (:exception rec)) :error
                         (:passed? rec)                     :pass

--- a/tools/story/src/re_frame/story/verdict.cljc
+++ b/tools/story/src/re_frame/story/verdict.cljc
@@ -1,0 +1,68 @@
+(ns re-frame.story.verdict
+  "The ONE cycle-free owner of the Story run-result verdicts (spec/017
+  §Run result). A pure leaf: it depends on `clojure.core` ONLY, so any
+  sibling — the runtime-coupled `re-frame.story.result`, the pure
+  shell-state helpers in `re-frame.story.ui.state.tests`, and the
+  test-mode pure helpers in `re-frame.story.ui.test-mode.pure` — can
+  `:require` it without a cycle.
+
+  ## Why a leaf
+
+  `re-frame.story.result` is the canonical assembly, but it pulls in
+  `re-frame.story.assertions` (and through it `re-frame.core`, the
+  runtime). A pure UI-state / test-mode helper cannot require `result`
+  without dragging the runtime onto its require path, so the four-verdict
+  set and the record-normalization rule used to be COPIED by hand into
+  those leaves — a copy that had already drifted once and mis-classified
+  a thrown-handler record as a false-green `:pass` (rf2-fslmh /
+  rf2-o6toyw).
+
+  This ns lifts those two things — `statuses` and `record-status` — to a
+  single owner every side can consume directly. `result` re-exports the
+  vars to preserve its public contract; the UI-state + test-mode helpers
+  consume the leaf. One implementation, no mirror, no parity test.")
+
+;; ===========================================================================
+;; STATUS — the four verdicts (spec/017 §Run result)
+;; ===========================================================================
+
+(def statuses
+  "The four run / assertion / check verdicts (spec/017 §Run result):
+
+  - `:pass`       — every expectation the runner could attempt held;
+  - `:fail`       — at least one expectation failed (or the tape shows
+                    unconsumed failure evidence);
+  - `:cannot-run` — the ONLY unmet expectations were ones the runner could
+                    not even attempt (the distinct THIRD status, §`:cannot-run`);
+  - `:error`      — a handler / fx / step threw."
+  #{:pass :fail :cannot-run :error})
+
+;; ===========================================================================
+;; RECORD NORMALIZATION — derive ONE assertion record's verdict
+;; ===========================================================================
+
+(defn record-status
+  "Derive the `:status` for ONE assertion record from its outcome fields.
+  Pure data → data. An explicit `:status` already on the record wins (the
+  record was minted by a status-aware path); otherwise:
+
+  - `:cannot-run?` true   → `:cannot-run` (the runner could not prove it);
+  - `:skipped?` true      → `:cannot-run` (§`:cannot-run` generalizes the
+                            shipping `:skipped?`);
+  - `:exception` / `:error` truthy → `:error` (a thrown handler / fx / step
+                            — a derived record carrying `:exception`/`:error`
+                            but no explicit `:status` counts as `:error`,
+                            never a false-green `:pass`);
+  - `:passed?` true       → `:pass`;
+  - `:passed?` false      → `:fail`;
+  - `:passed?` nil        → `:pass` (a non-assertion / vacuous record does
+                            not fail the run — the /spec/007-Stories.md §Story-as-test duality)."
+  [{:keys [status passed? cannot-run? skipped? exception error] :as _record}]
+  (cond
+    (contains? statuses status) status
+    cannot-run?                 :cannot-run
+    skipped?                    :cannot-run   ; §`:cannot-run` generalizes the shipping :skipped?
+    (or exception error)        :error
+    (true? passed?)             :pass
+    (false? passed?)            :fail
+    :else                       :pass))

--- a/tools/story/test/re_frame/story/ui/test_widget_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/test_widget_cljs_test.cljc
@@ -21,14 +21,7 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.story :as story]
             [re-frame.story.registrar :as story-registrar]
-            [re-frame.story.result :as result]
             [re-frame.story.ui.state :as state]
-            ;; rf2-fslmh — reach the PRIVATE local mirror to assert parity
-            ;; with the canonical `result/record-status`. The mirror is a
-            ;; copy-by-hand of the canonical rule (it can't require `result`,
-            ;; which loops through the runtime); the test CAN require both,
-            ;; tests aren't on that production cycle path.
-            [re-frame.story.ui.state.tests :as state.tests]
             #?@(:cljs [[re-frame.story.ui.sidebar :as sidebar]])))
 
 ;; ---- fixtures ------------------------------------------------------------
@@ -354,67 +347,27 @@
                    from sibling variants)"
            (is (nil? (:cell-overrides opts-c))))))))
 
-;; ---- rf2-fslmh: the local mirror tracks the canonical verdict-for-verdict
+;; ---- rf2-o6toyw: aggregate-summary counts :error records as failures
+;;
+;; `aggregate-summary` folds each record through the single verdict owner
+;; (`re-frame.story.verdict/record-status`, consumed by `ui.state.tests`) —
+;; a derived record with `:exception`/`:error` truthy and NO explicit
+;; `:status` resolves to `:error`, and `:error` counts in the `:failed`
+;; tally (tests.cljc `:failed = :fail + :error`). This is the aggregation
+;; guard against a thrown-handler record reading false-green; the
+;; verdict-for-verdict derivation itself is covered by
+;; `re-frame.story.result-test/record-status-derivation` against the leaf.
 
-(def ^:private record-status-parity-cases
-  "A table of assertion-record shapes covering every branch of the
-  verdict rule (rf2-fslmh). The load-bearing rows are the `:exception`/
-  `:error`-truthy ones (5 + 6): pre-fix the mirror dropped through to
-  `:else :pass` — a thrown handler counted as a false-green. The mixed
-  rows assert precedence holds identically on both sides (an explicit
-  verdict wins; cannot-run/skipped beat error; error beats pass/fail)."
-  [;; explicit verdicts win, even against contradicting outcome fields
-   {:status :pass}
-   {:status :fail :passed? true}
-   {:status :cannot-run}
-   {:status :error :passed? true}
-   ;; derived: a thrown handler / fx / step — the missing branch
-   {:exception (ex-info "boom" {})}
-   {:error "boom"}
-   ;; error beats a contradicting passed? true (canonical ordering)
-   {:exception (ex-info "boom" {}) :passed? true}
-   ;; cannot-run / skipped beat error (checked earlier in the cond)
-   {:cannot-run? true :exception (ex-info "boom" {})}
-   {:skipped? true :error "boom"}
-   ;; the plain pass / fail / refusal / vacuous rows
-   {:passed? true}
-   {:passed? false}
-   {:cannot-run? true}
-   {:skipped? true}
-   {}
-   {:passed? nil}
-   ;; a non-verdict keyword in :status does NOT win — it falls through
-   ;; (the canonical guards on the four-verdict set, not `keyword?`)
-   {:status :running :passed? false}
-   {:status :running :exception (ex-info "boom" {})}])
-
-(deftest record-status-mirrors-canonical
-  (testing "rf2-fslmh — `ui.state.tests`' private `record-status` mirror
-            returns the SAME verdict as `result/record-status` for every
-            record shape. The mirror is a copy-by-hand of the canonical
-            rule (it can't require `result` — that loops through the
-            runtime). This parity guard is the trip-wire against the
-            drift that mis-counted a thrown-handler record as :pass."
-    (doseq [record record-status-parity-cases]
-      (is (= (result/record-status record)
-             (#'state.tests/record-status record))
-          (str "verdict mismatch for record " (pr-str record))))))
-
-(deftest record-status-error-branch-is-reachable
-  (testing "rf2-fslmh — a derived record with :exception/:error truthy and
-            NO explicit :status now resolves to :error (was :pass — the
-            false-green). This is what makes aggregate-summary's :error
-            accounting (tests.cljc :failed = :fail + :error) reachable."
-    (is (= :error (#'state.tests/record-status {:exception (ex-info "boom" {})})))
-    (is (= :error (#'state.tests/record-status {:error "boom"})))
-    (testing "and the :error bucket lands in the :failed tally"
-      (let [summary (state/aggregate-summary
-                      [{:passed? true}
-                       {:exception (ex-info "boom" {})}
-                       {:error "boom"}])]
-        (is (= 1 (:passed summary)))
-        (is (= 2 (:failed summary)) ":error records count as failures")
-        (is (false? (:all-passed? summary)))))))
+(deftest aggregate-summary-counts-error-records-as-failed
+  (testing "a derived record carrying :exception / :error (no explicit
+            :status) lands in aggregate-summary's :failed tally"
+    (let [summary (state/aggregate-summary
+                    [{:passed? true}
+                     {:exception (ex-info "boom" {})}
+                     {:error "boom"}])]
+      (is (= 1 (:passed summary)))
+      (is (= 2 (:failed summary)) ":error records count as failures")
+      (is (false? (:all-passed? summary))))))
 
 #?(:clj
    (deftest jvm-only-summary-from-fixture


### PR DESCRIPTION
Two clustered Story-area refactors, each a distinct tool with disjoint files. Each is one logical commit.

## rf2-o6toyw — one cycle-free owner for Story verdict normalization (tools/story)

`result.cljc` owned `statuses` + `record-status`, but `ui.state.tests` hand-copied `record-status` (a `record-status` mirror + an inline verdict-set in `record-test-run`) and `test-mode.pure` hand-copied the verdict set — because those pure helpers cannot require `result` without dragging the runtime (`assertions` → `re-frame.core`) onto their path. The copy had already drifted once (a thrown-handler record read false-green).

- Add pure leaf `re-frame.story.verdict` (depends on `clojure.core` only) owning `statuses` + `record-status`.
- `result.cljc` re-exports both vars — public `result/statuses` + `result/record-status` contracts preserved.
- `ui.state.tests` + `test-mode.pure` now consume the leaf directly (no mirror, no cycle).
- Deleted the hand-copied algorithm/set and the copy-parity test (`record-status-mirrors-canonical`).
- UI lifecycle `test-run-statuses` (`:running`/`:pending`) stays local — a different set.

Retained coverage: `result-test/record-status-derivation` (verdict rule, via the re-export = the leaf); the widget test keeps the `aggregate-summary` :error-accounting assertion.

## rf2-iapjh7 — centralize Story-MCP lifecycle execution (tools/story-mcp)

`tool-run-variant` (tools.testing) and `tool-preview-variant` (tools.dev) independently invoked `story/run-variant`, blocked with the same timeout, caught `Throwable`, and normalized failure — but their catch paths had drifted: preview hand-built a partial error map, run used the canonical `story/run-result`.

- Add leaf `re-frame.story-mcp.tools.lifecycle` owning blocking invocation + timeout blocking + ONE canonical exception normalization (`run-variant-blocking` / `error-outcome`).
- Both tools consume it. `error-outcome` routes every throw/timeout through `story/run-result` (six `.4` evidence slots fill to `[]`, never absent→nil→raw-nil-on-wire, rf2-5r6j96) and stamps `:lifecycle :error` (preview reads it) + `:frame` (run reads it).
- Per the boundary, preview/run-specific projection, egress, annotations, indicator counts, and wire shaping stay in their current namespaces — the leaf produces the outcome, callers shape it. `async` require drops from both tools.

Added coverage: `lifecycle-error-outcome-is-canonical` (direct shape) + `lifecycle-error-outcome-surfaced-by-both-consumers` (parameterized over both tools' real wire pipeline). Existing projection tests remain local.

## Preflight confirmations

- Verified BOTH duplications before extracting: `record-status`/`statuses` copies in `ui.state.tests` + `test-mode.pure` (rf2-o6toyw); the drifted throw/timeout catch paths in `tool-run-variant` + `tool-preview-variant` (rf2-iapjh7). Different tools, disjoint files.
- The cycle rf2-o6toyw fixes is real: `result` → `assertions` → `re-frame.core`; the new `verdict` leaf has zero requires.

## Stance

Pre-alpha, no back-compat beyond the re-export aliases the bead asked for. ELEGANCE + CLARITY + CORRECTNESS: one owner per concept, public contracts preserved via re-export, drift-proof by construction.

## Quality gates

- `cd tools/story && clojure -M:test` — 1774 tests, 6504 assertions, 0 failures, 0 errors
- `cd tools/story-mcp && clojure -M:test` — 284 tests, 1477 assertions, 0 failures, 0 errors
- `cd implementation && npm run test:cljs` — 8465 tests, 39156 assertions, 0 failures, 0 errors

Rebased clean onto origin/main; no upstream commits touched the story trees.
