### PR TITLE
fix(examples): add ^:dev/after-load mount! for HMR remount (rf2-fsf29e)

### DIFF
--- a/examples/capabilities/machines/state_machine_walkthrough/views.cljs
+++ b/examples/capabilities/machines/state_machine_walkthrough/views.cljs
@@ -115,10 +115,9 @@
 ;; defer DOM mount to `run`".
 (defonce react-root (atom nil))
 
-(defn run []
-  ;; Tell re-frame2 which substrate to render through by handing init! the
-  ;; Reagent adapter's spec map. One call, done.
-  (rf/init! reagent-adapter/adapter)
+;; DOM setup lives in `mount!`, tagged `^:dev/after-load` so shadow-cljs re-runs
+;; it after each hot reload — edited views re-render into the same root and frame.
+(defn ^:dev/after-load mount! []
   ;; `frame-provider {:id …}` is the do-everything entry point for the frame:
   ;; it creates it, configures it, and seeds it. First mount creates the
   ;; `:rf/default` frame, applies the config, and runs `:initial-events` once.
@@ -137,12 +136,19 @@
   ;; `[:auth :login-form :draft]`, and that slot has to already hold empty
   ;; strings — leave a nil there and React decides the inputs are uncontrolled,
   ;; which is a confusing afternoon you can skip by seeding up front.
-  (when (exists? js/document)
+  (when-let [el (and (exists? js/document)
+                     (js/document.getElementById "app"))]
     (when-not @react-root
-      (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+      (reset! react-root (rdc/create-root el)))
     (rdc/render @react-root
                 [rf/frame-provider {:id              :rf/default
                                     :doc             "State-machines walkthrough demo frame."
                                     :fx-overrides    {:rf.http/managed :walkthrough.login/canned-failure}
                                     :initial-events  [[:walkthrough.login/initialise-form]]}
                  [root-view]])))
+
+(defn run []
+  ;; Tell re-frame2 which substrate to render through by handing init! the
+  ;; Reagent adapter's spec map. One call, done.
+  (rf/init! reagent-adapter/adapter)
+  (mount!))

--- a/examples/capabilities/resources/infinite_feed/core.cljs
+++ b/examples/capabilities/resources/infinite_feed/core.cljs
@@ -350,11 +350,13 @@
 
 (def app-frame :rf/default)
 
-(defn run []
-  (rf/init! reagent-adapter/adapter)
-  (when (exists? js/document)
+;; DOM setup lives in `mount!`, tagged `^:dev/after-load` so shadow-cljs re-runs
+;; it after each hot reload — edited views re-render into the same root and frame.
+(defn ^:dev/after-load mount! []
+  (when-let [el (and (exists? js/document)
+                     (js/document.getElementById "app"))]
     (when-not @react-root
-      (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+      (reset! react-root (rdc/create-root el)))
     ;; The provider creates the app frame (config and all) on first mount and
     ;; reuses it on hot reload. Route entry ensures page 0, so there's no need
     ;; for `:initial-events`.
@@ -364,3 +366,7 @@
                                     :url-bound?   true
                                     :fx-overrides {:rf.http/managed :infinite-feed.demo/http-stub}}
                  [root-view]])))
+
+(defn run []
+  (rf/init! reagent-adapter/adapter)
+  (mount!))

--- a/examples/capabilities/resources/linearlite/core.cljs
+++ b/examples/capabilities/resources/linearlite/core.cljs
@@ -612,11 +612,13 @@
 
 (def app-frame :rf/default)
 
-(defn run []
-  (rf/init! reagent-adapter/adapter)
-  (when (exists? js/document)
+;; DOM setup lives in `mount!`, tagged `^:dev/after-load` so shadow-cljs re-runs
+;; it after each hot reload — edited views re-render into the same root and frame.
+(defn ^:dev/after-load mount! []
+  (when-let [el (and (exists? js/document)
+                     (js/document.getElementById "app"))]
     (when-not @react-root
-      (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+      (reset! react-root (rdc/create-root el)))
     ;; Frame created and configured right here. First mount builds it under
     ;; `app-frame` and applies the config; hot reload reuses it.
     (rdc/render @react-root
@@ -625,3 +627,7 @@
                                     :url-bound?   true
                                     :fx-overrides {:rf.http/managed :linearlite.demo/http-stub}}
                  [root-view]])))
+
+(defn run []
+  (rf/init! reagent-adapter/adapter)
+  (mount!))

--- a/examples/capabilities/resources/resources/core.cljs
+++ b/examples/capabilities/resources/resources/core.cljs
@@ -525,11 +525,13 @@
 ;; the frame happens to be called.
 (def app-frame :rf/default)
 
-(defn run []
-  (rf/init! reagent-adapter/adapter)
-  (when (exists? js/document)
+;; DOM setup lives in `mount!`, tagged `^:dev/after-load` so shadow-cljs re-runs
+;; it after each hot reload — edited views re-render into the same root and frame.
+(defn ^:dev/after-load mount! []
+  (when-let [el (and (exists? js/document)
+                     (js/document.getElementById "app"))]
     (when-not @react-root
-      (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+      (reset! react-root (rdc/create-root el)))
     ;; Here's the frame, created and configured by `frame-provider {:id …}`.
     ;; `:fx-overrides` is the trick that lets the demo stand alone: it reroutes
     ;; every `:rf.http/managed` ensure to the per-URL canned stub up above. The
@@ -542,3 +544,7 @@
                                     :url-bound?   true
                                     :fx-overrides {:rf.http/managed :resources.demo/http-stub}}
                  [root-view]])))
+
+(defn run []
+  (rf/init! reagent-adapter/adapter)
+  (mount!))

--- a/examples/capabilities/routing/routing/core.cljs
+++ b/examples/capabilities/routing/routing/core.cljs
@@ -178,13 +178,13 @@
 ;; ../../../docs/routing/concepts.md#the-browser-is-just-another-event-source
 (def app-frame :rf/default)
 
-(defn run []
-  ;; Tell re-frame2 to render through Reagent. Every adapter namespace exports
-  ;; an `adapter` var; hand it straight to `init!` and you're done.
-  (rf/init! reagent-adapter/adapter)
-  (when (exists? js/document)
+;; DOM setup lives in `mount!`, tagged `^:dev/after-load` so shadow-cljs re-runs
+;; it after each hot reload — edited views re-render into the same root and frame.
+(defn ^:dev/after-load mount! []
+  (when-let [el (and (exists? js/document)
+                     (js/document.getElementById "app"))]
     (when-not @react-root
-      (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+      (reset! react-root (rdc/create-root el)))
     ;; The frame provider is where the app frame actually comes to life — one
     ;; tidy spot for the whole setup. First mount: it creates the frame under
     ;; `app-frame`, flips on `:url-bound? true` so this frame owns the URL, and
@@ -206,3 +206,9 @@
                                     :url-bound? true
                                     :initial-events [[:routing.app/initialise]]}
                  [root-view]])))
+
+(defn run []
+  ;; Tell re-frame2 to render through Reagent. Every adapter namespace exports
+  ;; an `adapter` var; hand it straight to `init!` and you're done.
+  (rf/init! reagent-adapter/adapter)
+  (mount!))

--- a/examples/capabilities/ssr/resources_ssr/core.cljc
+++ b/examples/capabilities/ssr/resources_ssr/core.cljc
@@ -357,15 +357,24 @@
 ;; See docs/ssr/concepts.md#deploy-drift-checks-come-along-for-free.
 (def app-frame :rf/default)
 
+;; DOM setup lives in `mount!`, tagged `^:dev/after-load` so shadow-cljs re-runs
+;; it after each hot reload — edited views re-render into the same root and the
+;; already-hydrated frame. HYDRATE stays in `run` (once), so a reload never
+;; re-seeds over the interactive state.
+#?(:cljs
+   (defn ^:dev/after-load mount! []
+     (when-let [el (and (exists? js/document)
+                        (js/document.getElementById "app"))]
+       (when-not @react-root
+         (reset! react-root (rdc/create-root el)))
+       (rdc/render @react-root
+                   [rf/frame-provider {:frame app-frame}
+                    [(rf/view :app/root)]]))))
+
 #?(:cljs
    (defn run []
      (rf/init! reagent-adapter/adapter)
      (rf/reg-frame app-frame {:doc "resources-ssr client app-frame" :platform :client})
      (ssr/hydrate! {:frame          app-frame
                     :render-tree-fn (fn [] ((rf/view :app/root)))})
-     (when (exists? js/document)
-       (when-not @react-root
-         (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-       (rdc/render @react-root
-                   [rf/frame-provider {:frame app-frame}
-                    [(rf/view :app/root)]]))))
+     (mount!)))

--- a/examples/capabilities/ssr/ssr/core.cljc
+++ b/examples/capabilities/ssr/ssr/core.cljc
@@ -397,6 +397,23 @@
 ;; hydration target, plain and simple (see the note over in `handle-request`).
 (def app-frame :rf/default)
 
+;; DOM setup lives in `mount!`, tagged `^:dev/after-load` so shadow-cljs re-runs
+;; it after each hot reload — edited views re-render into the same root and the
+;; already-hydrated frame. HYDRATE stays in `run` (once), so a reload never
+;; re-seeds over the interactive state.
+#?(:cljs
+   (defn ^:dev/after-load mount! []
+     (when-let [el (and (exists? js/document)
+                        (js/document.getElementById "app"))]
+       (when-not @react-root
+         (reset! react-root (rdc/create-root el)))
+       ;; Mount inside the app-frame's `frame-provider`, so every `dispatch` and
+       ;; `subscribe` down in the view tree resolves to the frame we just
+       ;; hydrated.
+       (rdc/render @react-root
+                   [rf/frame-provider {:frame app-frame}
+                    [(rf/view :app/root)]]))))
+
 #?(:cljs
    (defn run []
      ;; First, point the runtime at the Reagent substrate. This is safe to call
@@ -432,15 +449,7 @@
          ;; app's own bootstrap against the frame; the page comes up showing the
          ;; empty-articles fallback.
          (rf/dispatch-sync [:ssr/client-bootstrap] {:frame app-frame})))
-     (when (exists? js/document)
-       (when-not @react-root
-         (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-       ;; Mount inside the app-frame's `frame-provider`, so every `dispatch` and
-       ;; `subscribe` down in the view tree resolves to the frame we just
-       ;; hydrated.
-       (rdc/render @react-root
-                   [rf/frame-provider {:frame app-frame}
-                    [(rf/view :app/root)]]))))
+     (mount!)))
 
 ;; No tests in this file — and that's deliberate. The example tree stays
 ;; test-free so the source reads as pure demonstration; the headless tests that

--- a/examples/capabilities/ssr/ssr_streaming/core.cljc
+++ b/examples/capabilities/ssr/ssr_streaming/core.cljc
@@ -282,6 +282,22 @@
 ;; [frames](../../../docs/core/glossary.md#frame-identity-is-carried-not-found).
 #?(:cljs (def app-frame :rf/default))
 
+;; DOM setup lives in `mount!`, tagged `^:dev/after-load` so shadow-cljs re-runs
+;; it after each hot reload — edited views re-render into the same root and the
+;; already-hydrated frame. HYDRATE + streaming install stay in `run` (once), so
+;; a reload never re-seeds over the interactive state.
+#?(:cljs
+   (defn ^:dev/after-load mount! []
+     (when-let [el (and (exists? js/document)
+                        (js/document.getElementById "app"))]
+       (when-not @react-root
+         (reset! react-root (rdc/create-root el)))
+       ;; Wrap the mount in `frame-provider` so every `dispatch` and
+       ;; `subscribe` inside the tree resolves to the frame we just hydrated.
+       (rdc/render @react-root
+                   [rf/frame-provider {:frame app-frame}
+                    [(rf/view :dashboard/root)]]))))
+
 #?(:cljs
    (defn run []
      ;; `init!` installs the Reagent adapter and nothing more — it creates no
@@ -313,14 +329,7 @@
      ;; every time. A real streaming server stamps the genuine hash and passes
      ;; `:render-tree-fn` to switch mismatch detection on.)
      (ssr/hydrate! {:frame app-frame})
-     (when (exists? js/document)
-       (when-not @react-root
-         (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-       ;; Wrap the mount in `frame-provider` so every `dispatch` and
-       ;; `subscribe` inside the tree resolves to the frame we just hydrated.
-       (rdc/render @react-root
-                   [rf/frame-provider {:frame app-frame}
-                    [(rf/view :dashboard/root)]]))))
+     (mount!)))
 
 ;; The JVM headless test that walks the server stream end to end (shell →
 ;; per-card resolved chunks → final payload) lives over in

--- a/examples/patterns/boot/core.cljs
+++ b/examples/patterns/boot/core.cljs
@@ -132,13 +132,13 @@
 ;; own frame — the runtime never conjures one for you.
 (def app-frame :rf/default)
 
-(defn run []
-  ;; Hand the adapter's spec map straight to `init!`.
-  (rf/init! reagent-adapter/adapter)
-
-  (when (exists? js/document)
+;; DOM setup lives in `mount!`, tagged `^:dev/after-load` so shadow-cljs re-runs
+;; it after each hot reload — edited views re-render into the same root and frame.
+(defn ^:dev/after-load mount! []
+  (when-let [el (and (exists? js/document)
+                     (js/document.getElementById "app"))]
     (when-not @react-root
-      (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+      (reset! react-root (rdc/create-root el)))
     ;; One frame-provider does three things — create the frame, configure it,
     ;; seed it:
     ;;
@@ -154,3 +154,8 @@
                                     :fx-overrides   {:rf.http/managed :boot.demo/http-stub}
                                     :initial-events [[:boot/initialise]]}
                  [boot.views/root-view]])))
+
+(defn run []
+  ;; Hand the adapter's spec map straight to `init!`.
+  (rf/init! reagent-adapter/adapter)
+  (mount!))

--- a/examples/patterns/long_running_work/core.cljs
+++ b/examples/patterns/long_running_work/core.cljs
@@ -103,14 +103,20 @@
 ;; scope. See the frame glossary (docs/core/glossary.md#frame).
 (def app-frame :rf/default)
 
-(defn run []
-  ;; Install the Reagent adapter, then mount the provider that stands
-  ;; the frame up (see above).
-  (rf/init! reagent-adapter/adapter)
-  (when (exists? js/document)
+;; DOM setup lives in `mount!`, tagged `^:dev/after-load` so shadow-cljs re-runs
+;; it after each hot reload — edited views re-render into the same root and frame.
+(defn ^:dev/after-load mount! []
+  (when-let [el (and (exists? js/document)
+                     (js/document.getElementById "app"))]
     (when-not @react-root
-      (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+      (reset! react-root (rdc/create-root el)))
     (rdc/render @react-root
                 [rf/frame-provider {:id app-frame
                                     :initial-events [[:app/initialise]]}
                  [views/root-view]])))
+
+(defn run []
+  ;; Install the Reagent adapter, then mount the provider that stands
+  ;; the frame up (see above).
+  (rf/init! reagent-adapter/adapter)
+  (mount!))

--- a/examples/patterns/nine_states/core.cljs
+++ b/examples/patterns/nine_states/core.cljs
@@ -784,10 +784,9 @@
 
 (defonce react-root (atom nil))
 
-(defn run []
-  ;; Tell the runtime which substrate to render through. Just the adapter —
-  ;; no frame yet.
-  (rf/init! reagent-adapter/adapter)
+;; DOM setup lives in `mount!`, tagged `^:dev/after-load` so shadow-cljs re-runs
+;; it after each hot reload — edited views re-render into the same root and frame.
+(defn ^:dev/after-load mount! []
   ;; The `frame-provider {:id …}` below is what actually owns the frame. On
   ;; the first mount it creates `:rf/default`, applies the config, and fires
   ;; `:initial-events` once; on a hot reload it finds the frame already
@@ -801,12 +800,19 @@
   ;; `dispatch`/`subscribe` injected into each `reg-view` (and `root-view`'s
   ;; subs) find `:rf/default`. Same `:rf/default` the `reg-app-schema` up top
   ;; attached to.
-  (when (exists? js/document)
+  (when-let [el (and (exists? js/document)
+                     (js/document.getElementById "app"))]
     (when-not @react-root
-      (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+      (reset! react-root (rdc/create-root el)))
     (rdc/render @react-root
                 [rf/frame-provider {:id             :rf/default
                                     :doc            "Nine-states demo frame."
                                     :fx-overrides   {:rf.http/managed :nine-states.http/managed-demo}
                                     :initial-events [[:nine-states.app/initialise]]}
                  [root-view]])))
+
+(defn run []
+  ;; Tell the runtime which substrate to render through. Just the adapter —
+  ;; no frame yet.
+  (rf/init! reagent-adapter/adapter)
+  (mount!))

--- a/examples/patterns/websocket/core.cljs
+++ b/examples/patterns/websocket/core.cljs
@@ -109,12 +109,18 @@
 ;; different frame than the app. See docs/core/frames.md.
 (def app-frame :rf/default)
 
-(defn run []
-  (rf/init! reagent-adapter/adapter)
-  (when (exists? js/document)
+;; DOM setup lives in `mount!`, tagged `^:dev/after-load` so shadow-cljs re-runs
+;; it after each hot reload — edited views re-render into the same root and frame.
+(defn ^:dev/after-load mount! []
+  (when-let [el (and (exists? js/document)
+                     (js/document.getElementById "app"))]
     (when-not @react-root
-      (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+      (reset! react-root (rdc/create-root el)))
     (rdc/render @react-root
                 [rf/frame-provider {:id app-frame
                                     :initial-events [[:ws.app/initialise]]}
                  [views/root-view]])))
+
+(defn run []
+  (rf/init! reagent-adapter/adapter)
+  (mount!))

--- a/examples/real-apps/realworld_http/core.cljs
+++ b/examples/real-apps/realworld_http/core.cljs
@@ -531,35 +531,13 @@
                                                  :anonymous)))
                :getCurrentUser (fn [] (clj->js (some-> (rf/app-db-value frame-id) :auth :user)))})))
 
-(defn run []
-  ;; Tell re-frame2 to render through Reagent. This is the one genuinely
-  ;; frameworky step, and it has to come before any frame mounts; everything
-  ;; below it is just this app wiring itself up.
-  (rf/init! reagent-adapter/adapter)
-  ;; Register the Bearer-auth interceptor (defined above) so it stamps the
-  ;; `Authorization` header onto outbound managed requests. Order matters:
-  ;; register it before the frame's `:initial-events` run, so it's already on
-  ;; duty when session-restore fires its first authenticated request.
-  ;;
-  ;; HTTP-interceptor registration is context-required frame-local (EP-0002 /
-  ;; Spec 014 §Middleware): each frame owns its own middleware chain, so the
-  ;; registration has to name the frame it belongs to. A bare top-level
-  ;; `reg-http-interceptor` under no frame scope raises the always-on
-  ;; `:rf.error/no-frame-context` and installs nothing. We scope it to the app
-  ;; frame (`:rf/default` — the same id the `frame-provider` below ensures)
-  ;; with `with-frame`, so the interceptor lands on the chain the app's managed
-  ;; requests actually run under. The frame need not exist yet — the chain is
-  ;; keyed by frame-id and consulted when the first request fires. See the auth
-  ;; how-to: ../../../docs/core/how-to/add-auth.md#3-decorate-requests-once-at-the-frame-seam
-  (rf/with-frame :rf/default
-    (rf/reg-http-interceptor :realworld/bearer-auth
-                             {:before bearer-auth-interceptor}))
-  ;; Hang the conformance accessor on the window for the external RealWorld
-  ;; suite. Test seam, not a pattern — see install-conduit-debug! above.
-  (install-conduit-debug! :rf/default)
-  (when (exists? js/document)
+;; DOM setup lives in `mount!`, tagged `^:dev/after-load` so shadow-cljs re-runs
+;; it after each hot reload — edited views re-render into the same root and frame.
+(defn ^:dev/after-load mount! []
+  (when-let [el (and (exists? js/document)
+                     (js/document.getElementById "app"))]
     (when-not @react-root
-      (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+      (reset! react-root (rdc/create-root el)))
     ;; Here's where the frame is born. A single `frame-provider {:id …}` at
     ;; the render root creates, configures, and seeds the app frame all in one
     ;; place. The first mount conjures `:rf/default` and applies its config:
@@ -615,3 +593,31 @@
                                                       [:app/initialise]]
                                     :fx-overrides    {:rf.http/managed :realworld.demo/http-stub}}
                  [root-view]])))
+
+(defn run []
+  ;; Tell re-frame2 to render through Reagent. This is the one genuinely
+  ;; frameworky step, and it has to come before any frame mounts; everything
+  ;; below it is just this app wiring itself up.
+  (rf/init! reagent-adapter/adapter)
+  ;; Register the Bearer-auth interceptor (defined above) so it stamps the
+  ;; `Authorization` header onto outbound managed requests. Order matters:
+  ;; register it before the frame's `:initial-events` run, so it's already on
+  ;; duty when session-restore fires its first authenticated request.
+  ;;
+  ;; HTTP-interceptor registration is context-required frame-local (EP-0002 /
+  ;; Spec 014 §Middleware): each frame owns its own middleware chain, so the
+  ;; registration has to name the frame it belongs to. A bare top-level
+  ;; `reg-http-interceptor` under no frame scope raises the always-on
+  ;; `:rf.error/no-frame-context` and installs nothing. We scope it to the app
+  ;; frame (`:rf/default` — the same id the `frame-provider` in `mount!` ensures)
+  ;; with `with-frame`, so the interceptor lands on the chain the app's managed
+  ;; requests actually run under. The frame need not exist yet — the chain is
+  ;; keyed by frame-id and consulted when the first request fires. See the auth
+  ;; how-to: ../../../docs/core/how-to/add-auth.md#3-decorate-requests-once-at-the-frame-seam
+  (rf/with-frame :rf/default
+    (rf/reg-http-interceptor :realworld/bearer-auth
+                             {:before bearer-auth-interceptor}))
+  ;; Hang the conformance accessor on the window for the external RealWorld
+  ;; suite. Test seam, not a pattern — see install-conduit-debug! above.
+  (install-conduit-debug! :rf/default)
+  (mount!))

--- a/examples/real-apps/realworld_resources/core.cljs
+++ b/examples/real-apps/realworld_resources/core.cljs
@@ -254,29 +254,15 @@
 ;; so doing it again here would be belt-and-braces noise. And the session-scope
 ;; key ([:auth :user :username]) is identity, not a secret — redacting it would
 ;; only blur the cache-leak boundary this whole example is here to show.
-(defn run []
-  (rf/init! reagent-adapter/adapter)
-  ;; Register the bearer-auth interceptor at boot, before the frame's
-  ;; `:initial-events` dispatch. Timing matters: session-restore fires an
-  ;; authenticated `GET /user` the moment the JWT is hydrated, so the header has
-  ;; to be wired up before `:auth/initialise` runs at frame creation (below).
-  ;;
-  ;; HTTP-interceptor registration is context-required frame-local (EP-0002 /
-  ;; Spec 014 §Middleware): each frame owns its own middleware chain, so the
-  ;; registration must name the frame it belongs to. A bare top-level
-  ;; `reg-http-interceptor` under no frame scope raises the always-on
-  ;; `:rf.error/no-frame-context` and installs nothing. We scope it to
-  ;; `app-frame` (the same id the `frame-provider` below ensures) with
-  ;; `with-frame`, so the interceptor lands on the chain this app's resources /
-  ;; mutations actually lower onto. The frame need not exist yet — the chain is
-  ;; keyed by frame-id and consulted when the first managed request fires. See
-  ;; the auth how-to: ../../../docs/core/how-to/add-auth.md#3-decorate-requests-once-at-the-frame-seam
-  (rf/with-frame app-frame
-    (rf/reg-http-interceptor :realworld/bearer-auth
-                             {:before bearer-auth-interceptor}))
-  (when (exists? js/document)
+;; DOM setup lives in `mount!`, tagged `^:dev/after-load` so shadow-cljs re-runs
+;; it after each hot reload — edited views re-render into the same root and frame.
+;; Frame-created listeners here (`install-revalidation-listeners!`) are
+;; teardown-then-reinstall idempotent, so re-running on reload never stacks them.
+(defn ^:dev/after-load mount! []
+  (when-let [el (and (exists? js/document)
+                     (js/document.getElementById "app"))]
     (when-not @react-root
-      (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+      (reset! react-root (rdc/create-root el)))
     ;; Create + configure + seed the app frame, all in one place (see the block
     ;; above). The frame is created synchronously during render, so by the time
     ;; this call returns it's live and seeded.
@@ -316,3 +302,25 @@
     ;; The conformance surface — NOT a re-frame2 pattern; see install-conduit-debug!
     ;; above. The external RealWorld suite may read it.
     (install-conduit-debug! app-frame)))
+
+(defn run []
+  (rf/init! reagent-adapter/adapter)
+  ;; Register the bearer-auth interceptor at boot, before the frame's
+  ;; `:initial-events` dispatch. Timing matters: session-restore fires an
+  ;; authenticated `GET /user` the moment the JWT is hydrated, so the header has
+  ;; to be wired up before `:auth/initialise` runs at frame creation (in `mount!`).
+  ;;
+  ;; HTTP-interceptor registration is context-required frame-local (EP-0002 /
+  ;; Spec 014 §Middleware): each frame owns its own middleware chain, so the
+  ;; registration must name the frame it belongs to. A bare top-level
+  ;; `reg-http-interceptor` under no frame scope raises the always-on
+  ;; `:rf.error/no-frame-context` and installs nothing. We scope it to
+  ;; `app-frame` (the same id the `frame-provider` in `mount!` ensures) with
+  ;; `with-frame`, so the interceptor lands on the chain this app's resources /
+  ;; mutations actually lower onto. The frame need not exist yet — the chain is
+  ;; keyed by frame-id and consulted when the first managed request fires. See
+  ;; the auth how-to: ../../../docs/core/how-to/add-auth.md#3-decorate-requests-once-at-the-frame-seam
+  (rf/with-frame app-frame
+    (rf/reg-http-interceptor :realworld/bearer-auth
+                             {:before bearer-auth-interceptor}))
+  (mount!))

--- a/examples/substrates/helix/counter/core.cljs
+++ b/examples/substrates/helix/counter/core.cljs
@@ -98,14 +98,13 @@
 ;; `docs/core/glossary.md#frame-identity-is-carried-not-found`.
 (def app-frame :rf/default)
 
-(defn run []
-  ;; `init!` installs the reactive adapter for the process. Each adapter ns
-  ;; exports an `adapter` var; require the ns and pass that var. Call once at
-  ;; startup. See `docs/core/glossary.md#init`.
-  (rf/init! helix-adapter/adapter)
-  (when (exists? js/document)
+;; DOM setup lives in `mount!`, tagged `^:dev/after-load` so shadow-cljs re-runs
+;; it after each hot reload — edited views re-render into the same root and frame.
+(defn ^:dev/after-load mount! []
+  (when-let [el (and (exists? js/document)
+                     (js/document.getElementById "app"))]
     (when-not @react-root
-      (reset! react-root (react-dom-client/createRoot (js/document.getElementById "app"))))
+      (reset! react-root (react-dom-client/createRoot el)))
     ;; The whole frame lifecycle lives in one spot: this provider. The first
     ;; mount creates the app frame and runs its `:initial-events` once to seed
     ;; app-db. A later mount under the same `:id` — a hot reload — reuses the
@@ -115,3 +114,10 @@
              ($ helix-adapter/frame-provider {:id app-frame
                                               :initial-events [[:counter/initialise]]}
                 ($ counter-app)))))
+
+(defn run []
+  ;; `init!` installs the reactive adapter for the process. Each adapter ns
+  ;; exports an `adapter` var; require the ns and pass that var. Call once at
+  ;; startup. See `docs/core/glossary.md#init`.
+  (rf/init! helix-adapter/adapter)
+  (mount!))

--- a/examples/substrates/helix/login/core.cljs
+++ b/examples/substrates/helix/login/core.cljs
@@ -547,12 +547,13 @@
 ;; co-loaded example namespaces don't race `createRoot` onto the shared `#app`.
 (defonce react-root (atom nil))
 
-(defn run []
-  ;; Install the Helix adapter once, before the first render.
-  (rf/init! helix-adapter/adapter)
-  (when (exists? js/document)
+;; DOM setup lives in `mount!`, tagged `^:dev/after-load` so shadow-cljs re-runs
+;; it after each hot reload — edited views re-render into the same root and frame.
+(defn ^:dev/after-load mount! []
+  (when-let [el (and (exists? js/document)
+                     (js/document.getElementById "app"))]
     (when-not @react-root
-      (reset! react-root (react-dom-client/createRoot (js/document.getElementById "app"))))
+      (reset! react-root (react-dom-client/createRoot el)))
     ;; Frame setup in one spot. The `frame-provider`'s `{:id …}` shape creates
     ;; the `:rf/default` frame on first mount and applies the config below
     ;; (`:doc`, and `:fx-overrides` routing `:rf.http/managed` to the demo
@@ -579,3 +580,8 @@
                  :fx-overrides   {:rf.http/managed :auth.login.demo/managed-stub}
                  :initial-events [[:auth.login/initialise-form]]}
                 ($ root-view)))))
+
+(defn run []
+  ;; Install the Helix adapter once, before the first render.
+  (rf/init! helix-adapter/adapter)
+  (mount!))

--- a/examples/substrates/helix/process_monitor/core.cljs
+++ b/examples/substrates/helix/process_monitor/core.cljs
@@ -347,13 +347,13 @@
 ;; the EVENTS block above for why that's the one arming site).
 (def app-frame :rf/default)
 
-(defn run []
-  ;; `init!` tells re-frame2 which substrate to render through — here, Helix.
-  ;; It installs the adapter and nothing more; it does not create a frame.
-  (rf/init! helix-adapter/adapter)
-  (when (exists? js/document)
+;; DOM setup lives in `mount!`, tagged `^:dev/after-load` so shadow-cljs re-runs
+;; it after each hot reload — edited views re-render into the same root and frame.
+(defn ^:dev/after-load mount! []
+  (when-let [el (and (exists? js/document)
+                     (js/document.getElementById "app"))]
     (when-not @react-root
-      (reset! react-root (react-dom-client/createRoot (js/document.getElementById "app"))))
+      (reset! react-root (react-dom-client/createRoot el)))
     ;; `frame-provider` creates the app frame on first mount; a hot reload
     ;; reuses the existing frame. From here on the `monitor` component owns
     ;; both the seed and the loop (see its `use-effect`) — mount dispatches
@@ -363,3 +363,9 @@
     (.render @react-root
              ($ helix-adapter/frame-provider {:id app-frame}
                 ($ monitor)))))
+
+(defn run []
+  ;; `init!` tells re-frame2 which substrate to render through — here, Helix.
+  ;; It installs the adapter and nothing more; it does not create a frame.
+  (rf/init! helix-adapter/adapter)
+  (mount!))

--- a/examples/substrates/reagent_slim/counter/core.cljs
+++ b/examples/substrates/reagent_slim/counter/core.cljs
@@ -85,6 +85,20 @@
 ;; See docs/core/frames.md.
 (def app-frame :rf/default)
 
+;; DOM setup lives in `mount!`, tagged `^:dev/after-load` so shadow-cljs re-runs
+;; it after each hot reload — edited views re-render into the same root and
+;; frame. `boot!` (below) calls it after `init!`, so both the teaching `run` and
+;; the gate-owned bundle-isolation entry share that one mount path.
+(defn ^:dev/after-load mount! []
+  (when-let [el (and (exists? js/document)
+                     (js/document.getElementById "app"))]
+    (when-not @react-root
+      (reset! react-root (rdc/create-root el)))
+    (rdc/render @react-root
+                [rf/frame-provider {:id app-frame
+                                    :initial-events [[:counter/initialise]]}
+                 [counter-app]])))
+
 (defn boot!
   "Stand the example up. Two steps: install the slim adapter, then lazily
    mount `counter-app` into `#app` under a `frame-provider {:id app-frame …}`.
@@ -111,13 +125,7 @@
      ;; so it never touches the app frame the provider creates below.
      (rf/with-new-frame [_ (rf/make-frame {})]
        (on-frame)))
-   (when (exists? js/document)
-     (when-not @react-root
-       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-     (rdc/render @react-root
-                 [rf/frame-provider {:id app-frame
-                                     :initial-events [[:counter/initialise]]}
-                  [counter-app]]))))
+   (mount!)))
 
 (defn run []
   (boot!))

--- a/examples/substrates/uix/counter/core.cljs
+++ b/examples/substrates/uix/counter/core.cljs
@@ -96,17 +96,23 @@
 ;; `docs/core/glossary.md#frame-identity-is-carried-not-found`.
 (def app-frame :rf/default)
 
+;; DOM setup lives in `mount!`, tagged `^:dev/after-load` so shadow-cljs re-runs
+;; it after each hot reload — edited views re-render into the same root and frame.
+(defn ^:dev/after-load mount! []
+  (when-let [el (and (exists? js/document)
+                     (js/document.getElementById "app"))]
+    (when-not @react-root
+      (reset! react-root (uix-dom/create-root el)))
+    (uix-dom/render-root
+      ($ uix-adapter/frame-provider {:id app-frame
+                                     :initial-events [[:counter/initialise]]}
+         ($ counter-app))
+      @react-root)))
+
 (defn run []
   ;; `init!` tells the runtime which reactive substrate to render through —
   ;; once, for the whole process. Every adapter ns exports an `adapter` var;
   ;; require the ns and hand that var over. Call it once at startup and
   ;; forget about it. See `docs/core/glossary.md#init`.
   (rf/init! uix-adapter/adapter)
-  (when (exists? js/document)
-    (when-not @react-root
-      (reset! react-root (uix-dom/create-root (js/document.getElementById "app"))))
-    (uix-dom/render-root
-      ($ uix-adapter/frame-provider {:id app-frame
-                                     :initial-events [[:counter/initialise]]}
-         ($ counter-app))
-      @react-root)))
+  (mount!))

--- a/examples/substrates/uix/dashboard/core.cljs
+++ b/examples/substrates/uix/dashboard/core.cljs
@@ -349,13 +349,13 @@
 ;; covers frame-provider (../../../docs/core/glossary.md#frame-provider).
 (def app-frame :rf/default)
 
-(defn run []
-  ;; `init!` installs the UIx adapter — this is how re-frame2 learns which
-  ;; substrate to render through.
-  (rf/init! uix-adapter/adapter)
-  (when (exists? js/document)
+;; DOM setup lives in `mount!`, tagged `^:dev/after-load` so shadow-cljs re-runs
+;; it after each hot reload — edited views re-render into the same root and frame.
+(defn ^:dev/after-load mount! []
+  (when-let [el (and (exists? js/document)
+                     (js/document.getElementById "app"))]
     (when-not @react-root
-      (reset! react-root (uix-dom/create-root (js/document.getElementById "app"))))
+      (reset! react-root (uix-dom/create-root el)))
     ;; Passing `{:id …}` creates the app frame on the first mount and fires
     ;; `:initial-events` once to seed app-db. Save and hot-reload, and it
     ;; reuses the same frame untouched — no re-seeding, so your state sticks.
@@ -364,3 +364,9 @@
                                      :initial-events [[:dashboard/initialise]]}
          ($ dashboard))
       @react-root)))
+
+(defn run []
+  ;; `init!` installs the UIx adapter — this is how re-frame2 learns which
+  ;; substrate to render through.
+  (rf/init! uix-adapter/adapter)
+  (mount!))

--- a/examples/substrates/uix/login/core.cljs
+++ b/examples/substrates/uix/login/core.cljs
@@ -525,13 +525,13 @@
 ;; on the shared `#app`.
 (defonce react-root (atom nil))
 
-(defn run []
-  ;; Tell the runtime to render through UIx. (This installs the adapter; it does
-  ;; not create a frame — the frame-provider below does that.)
-  (rf/init! uix-adapter/adapter)
-  (when (exists? js/document)
+;; DOM setup lives in `mount!`, tagged `^:dev/after-load` so shadow-cljs re-runs
+;; it after each hot reload — edited views re-render into the same root and frame.
+(defn ^:dev/after-load mount! []
+  (when-let [el (and (exists? js/document)
+                     (js/document.getElementById "app"))]
     (when-not @react-root
-      (reset! react-root (uix-dom/create-root (js/document.getElementById "app"))))
+      (reset! react-root (uix-dom/create-root el)))
     ;; Frame setup, all in one spot. The `frame-provider` at the render root
     ;; owns the frame: on the first mount it creates the `:rf/default` frame,
     ;; applies the config (`:fx-overrides` points `:rf.http/managed` at our demo
@@ -553,3 +553,9 @@
                                      :initial-events  [[:auth.login/initialise-form]]}
          ($ root-view))
       @react-root)))
+
+(defn run []
+  ;; Tell the runtime to render through UIx. (This installs the adapter; it does
+  ;; not create a frame — the frame-provider below does that.)
+  (rf/init! uix-adapter/adapter)
+  (mount!))


### PR DESCRIPTION
Splits every runnable example's boot into a `^:dev/after-load mount!` (lazy `create-root` + the `frame-provider` render) separate from `run` (adapter install + any process/registration setup), matching the canonical shape in `docs/core/how-to/boot-and-mount-an-app.md` and `examples/core/counter` / `todomvc`. Previously these apps only exposed `run`, so shadow-cljs recompiled on save without ever re-rendering — the classic "my view change didn't show" HMR drift. Now shadow re-runs `mount!` after each reload, re-rendering edited views into the same React root and the same live frame (app-db preserved).

## Stance
Pre-alpha; examples are idiomatic re-frame2 and now match the canonical boot pattern uniformly. ELEGANCE + CLARITY + CORRECTNESS: one mount seam across all substrates; no app logic changed, only the boot split. `init!` / hydrate / interceptor-registration stay in `run` (once); only DOM work is in the after-load `mount!`, so ns-load stays DOM-free (mount-isolation preserved).

## Apps fixed (21)
Enumerated via `git grep -L 'dev/after-load'` over runnable example boots (the bead's list was non-exhaustive):

- **Reagent (capabilities/patterns):** resources, infinite_feed, linearlite, routing, boot, long_running_work, nine_states, websocket, state_machine_walkthrough (boot lives in its `views.cljs`)
- **Real-apps:** realworld_http, realworld_resources
- **Substrates:** helix/counter, helix/login, helix/process_monitor, uix/counter, uix/dashboard, uix/login, reagent_slim/counter (extracted `mount!` out of the shared `boot!` so both the teaching `run` and the gate-owned bundle-isolation entry remount)
- **SSR (`.cljc`, client `run`):** ssr, resources_ssr, ssr_streaming

Notes:
- SSR examples use the **borrow** `frame-provider {:frame …}` (the frame is created by `reg-frame` + `ssr/hydrate!` in `run`), so `mount!` re-renders into the already-hydrated frame; hydrate/streaming-install stay in `run` so a reload never re-seeds over interactive state.
- realworld_resources re-runs `install-revalidation-listeners!` inside `mount!`; that helper is teardown-then-reinstall idempotent, so hot reload never stacks listeners.
- `reagent_slim/counter/bundle_isolation_entry.cljs` is CI gate plumbing (not a demo) and correctly boots through `core/boot!` → `mount!` without its own hook.

## Quality gates
- `shadow-cljs compile` for all 21 touched example builds — **0 warnings** each; the `^:dev/after-load mount!` hook is present in the compiled bundles (verified `<ns>.core.mount_BANG_` registered in the reload hook).
- `npm run test:cljs` — **8466 tests / 39175 assertions, 0 failures, 0 errors.**
- Examples remain test-free (no `*.spec.cjs`).
