### PR TITLE
docs(resources): align explanations with current contracts (rf2-pxzlee)

### DIFF
--- a/implementation/resources/deps.edn
+++ b/implementation/resources/deps.edn
@@ -1,5 +1,4 @@
-;; day8/re-frame2-resources — resources artefact (rf2-p10npe, EP-0003
-;; slice 2; per-feature split per rf2-5vjj Strategy B).
+;; day8/re-frame2-resources — optional resources artefact.
 ;;
 ;; Per Spec 016 §Resources the declarative server-state grammar
 ;; (`reg-resource`, `clear-resource`, `resource-meta`, `resource-state`,
@@ -12,8 +11,7 @@
 ;; ledger machinery, or any of the `:rf.resource/*` / `:rf.scope/*` /
 ;; `:rf.work/*` trace strings onto the classpath.
 ;;
-;; The full runtime ships here (EP-0003 complete): the namespaces + the
-;; public surface, the work-ledger substrate, the resource runtime
+;; The artefact contains the public surface, work-ledger substrate, resource runtime
 ;; (entries, scopes, status transitions, dedupe), the managed-HTTP
 ;; transport, invalidation / GC / owners, focus/reconnect revalidation,
 ;; mutations, and the routing + SSR/hydration integrations.
@@ -28,8 +26,7 @@
 ;; loading the namespace registers its late-bind hooks, the `:resource`
 ;; registrar kind, and the `:rf.resource/*` reg-event / reg-sub family.
 ;;
-;; Per Spec 006 §Adapter shipping convention (and the rf2-p7va
-;; extension to per-feature splits): this artefact depends on core; core
+;; Per Spec 006 §Adapter shipping convention, this artefact depends on core; core
 ;; never depends on this artefact. The cross-references from core to
 ;; resources (e.g. `re-frame.core`'s `reg-resource` / `clear-resource`
 ;; / `resource-meta` / `resource-state` / `resources` re-exports) flow
@@ -46,7 +43,7 @@
 
  :aliases
  {:test {:extra-paths ["test"]
-         :extra-deps  {;; rf2-try1x — silent-on-success reporter.
+         :extra-deps  {;; Silent-on-success reporter.
                        day8/re-frame2-test-quiet {:local/root "../test-quiet"}
                        ;; Late-bound integration surfaces — pulled in as
                        ;; TEST-ONLY deps so the artefact's production
@@ -58,8 +55,8 @@
                        day8/re-frame2-routing    {:local/root "../routing"}
                        day8/re-frame2-ssr        {:local/root "../ssr"}
                        day8/re-frame2-http       {:local/root "../http"}
-                       ;; rf2-xw5t0y — TEST-ONLY machines dep for the
-                       ;; machine→resource lease-release integration test
+                       ;; TEST-ONLY machines dep for the machine→resource
+                       ;; lease-release integration test
                        ;; (`resources_machine_owner_release_cljs_test`): a
                        ;; machine that `ensure`s a resource under its
                        ;; `[:machine actor-id]` owner must release that lease on
@@ -73,7 +70,7 @@
                        {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
          :main-opts   ["-m" "re-frame.test-quiet.runner"]}
 
-  ;; Clojars deploy (rf2-r382). Modeled on re-frame v1's release flow.
+  ;; Clojars deploy. Modeled on re-frame v1's release flow.
   ;; The release workflow runs `clojure -M:clein deploy` from this
   ;; artefact's directory, which builds pom + jar and pushes to Clojars.
   ;;

--- a/implementation/resources/src/re_frame/resources.cljc
+++ b/implementation/resources/src/re_frame/resources.cljc
@@ -32,7 +32,7 @@
 
   ## Optionality + bundle isolation
 
-  Per Spec 016 §Implementation status this is a POST-V1 OPTIONAL artefact
+  This is an optional artefact
   (`day8/re-frame2-resources`). `re-frame.core` MUST NOT `:require` it; the
   public-API surface is published through the late-bind table, so an app
   that omits the artefact sees the wrappers throw a clean
@@ -41,14 +41,8 @@
   http), so an app that loads resources but not those optional artefacts
   carries none of their code. Nothing here `:require`s from `tools/`.
 
-  ## Runtime
-
-  The full runtime ships here (EP-0003 complete): the public surface, the
-  registrar kind, and the late-bind wiring sit alongside the live runtime
-  LOGIC — the entry transition function, work-ledger join/dedupe, stale
-  suppression, GC, invalidation, route-plan execution, and hydration
-  install. The `:rf.resource/*` event handlers carry the behaviour;
-  loading this namespace registers the whole family."
+  Loading this namespace registers the complete resource and mutation event,
+  subscription, effect, and integration surface."
   (:require [re-frame.cofx :as cofx]
             [re-frame.error :as error]
             [re-frame.events :as events]
@@ -68,7 +62,7 @@
             [re-frame.resources.state :as state]
             [re-frame.resources.subs :as resource-subs]
             [re-frame.resources.timers :as timers]
-            ;; rf2-8x0gfa (EP-0015): the OFF-BOX trace-row egress projector for
+            ;; The OFF-BOX trace-row egress projector for
             ;; the resource/mutation trace family's scoped-key slots. A
             ;; production-reachable ns (NOT the bundle-isolated tooling sibling)
             ;; so the `:resources/project-resource-trace-egress` hook below is
@@ -76,17 +70,14 @@
             ;; epoch tool-pair consults it on every off-box record projection.
             [re-frame.resources.trace-egress :as trace-egress]
             [re-frame.resources.work-ledger :as work-ledger]
-            ;; EP-0014 slice-4 (rf2-gn9juw): the JVM-only require of the
-            ;; resources tooling sibling that backs the `resource-algebra-view`
+            ;; JVM-only require of the resources tooling sibling that backs the
+            ;; `resource-algebra-view`
             ;; / `resource-cache-algebra-view` aliases at the foot of this ns.
             ;; CLJS deliberately OMITS this require so a CLJS app that loads the
             ;; resources artefact but never attaches a tool DCEs the tooling
             ;; body wholesale — the facade never reaches it. JVM has no bundle
             ;; to protect; the alias gives JVM tools / conformance fixtures the
-            ;; ergonomic `re-frame.resources/<name>` shape. Mirrors the
-            ;; `re-frame.flows` → `re-frame.flows.tooling` JVM-only require
-            ;; (rf2-s8w3nw slice-3) and `re-frame.subs` → `re-frame.subs.tooling`
-            ;; (rf2-bmzq0 slice-2).
+            ;; ergonomic `re-frame.resources/<name>` shape.
             #?@(:clj [[re-frame.resources.tooling :as resources-tooling]])))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -101,7 +92,7 @@
 (def resource-meta   registry/resource-meta)
 (def resource-ids    registry/resource-ids)
 
-;; EP-0014 slice-4 (rf2-gn9juw): the derivation/process algebra view of
+;; Derivation/process algebra views of
 ;; registered resources (`resource-algebra-view`, static) and of a frame's
 ;; live cache entries (`resource-cache-algebra-view`, live). A resource is the
 ;; canonical PROCESS member of the algebra (Derivations §Process). The static
@@ -112,15 +103,13 @@
 ;; but attaches no tool DCEs them (the CLJS facade never `:require`s the tooling
 ;; sibling — the require above is `#?@(:clj ...)`-gated). CLJS consumers (Xray +
 ;; conformance) call `re-frame.resources.tooling/<name>` directly. No
-;; `re-frame.core` facade export (EP-0014 issue-1 disposition). Mirrors the
-;; `re-frame.flows/flow-algebra-view` JVM alias (slice-3).
+;; `re-frame.core` facade export.
 #?(:clj
    (do
      (def resource-algebra-view       resources-tooling/resource-algebra-view)
      (def resource-cache-algebra-view resources-tooling/resource-cache-algebra-view)))
 
-;; Mutations (rf2-dwme29, Spec 016 §Deferred slices / EP-0003 §Mutations —
-;; the first public-beta gate). `reg-mutation` registers a causal-write
+;; Mutations (Spec 016 §Mutations). `reg-mutation` registers a causal-write
 ;; mutation; `:rf.mutation/execute` runs it over the SAME managed-HTTP
 ;; transport the resources use, with success-time resource invalidation /
 ;; patch / populate; `clear-mutation` is the registration-lifecycle removal.
@@ -129,15 +118,15 @@
 (def mutation-meta   mutation-registry/mutation-meta)
 (def mutation-ids    mutation-registry/mutation-ids)
 
-;; Named resource-scope resolvers (rf2-hls77w, Spec 016 §Named
-;; resource-scope resolvers / EP-0016 D3 slice 2). `reg-resource-scope`
+;; Named resource-scope resolvers (Spec 016 §Named resource-scope resolvers).
+;; `reg-resource-scope`
 ;; registers a PURE named scope resolver under the `:resource-scope`
 ;; registrar kind; `clear-resource-scope` is the registration-lifecycle
 ;; removal; `resolve-resource-scope` is a resolver helper that resolves a
 ;; named scope against a supplied db value (the logout coeffect-db idiom) —
 ;; a PURE function over the resolver registry: not an effect (no app-state /
-;; dispatch side effects) and (rf2-ru73k6) NO observability side effect
-;; either, so it does NOT emit `:rf.resource/scope-resolved` trace. The
+;; dispatch side effects) and has NO observability side effect, so it does NOT
+;; emit `:rf.resource/scope-resolved` trace. The
 ;; `:rf.resource/scope-resolved` evidence is emitted only at the CAUSAL
 ;; resolution boundaries (`{:from-db ...}` scope, route entry, mutation
 ;; settle), per Spec 016 §Named resource-scope resolvers.
@@ -147,16 +136,13 @@
 (def scope-resolver-meta    scope-registry/scope-resolver-meta)
 (def scope-resolver-ids     scope-registry/scope-resolver-ids)
 
-;; Focus / reconnect revalidation host-listener install (rf2-vtblcq, Spec 016
-;; §Deferred slices). An app calls `install-revalidation-listeners!` for each
+;; Focus / reconnect revalidation host-listener install (Spec 016
+;; §Stale and GC scheduling). An app calls `install-revalidation-listeners!` for each
 ;; frame that wants window-focus / network-reconnect active-stale
 ;; revalidation; the listeners dispatch `:rf.resource/window-focused` /
 ;; `:rf.resource/network-reconnected` at that frame and are cancelled on
 ;; frame destroy via the single `:resources/on-frame-destroyed!` hook.
-;; CLJS-only host listeners; the JVM arm is a no-op (the CLJS-only /
-;; JVM-no-op shape re-frame.routing.history's install-url-listener! also
-;; carries — though that seam is now driven automatically by the
-;; :url-bound? frame lifecycle rather than an app-facing import, rf2-g8pbwg).
+;; These are CLJS-only host listeners; the JVM arm is a no-op.
 (def install-revalidation-listeners! revalidate-listeners/install-revalidation-listeners!)
 (def remove-revalidation-listeners!  revalidate-listeners/remove-revalidation-listeners!)
 
@@ -165,15 +151,15 @@
   §Introspection). Returns `{:resource-ids [...] :entries {…}}` — the
   static registry (every registered resource id) plus, when `:frame` is
   supplied, the live per-frame resource-instance entries map
-  (`{<scoped-resource-key> <entry>}`). Without `:frame` only the static
-  registry is returned (no ambient frame fallback, EP-0002).
+  (`{<key-id> <entry>}`). Without `:frame` only the static
+  registry is returned; there is no ambient frame fallback.
 
   The `:entries` map is keyed on the CEDN-1 byte `key-id` STRING (the SAME
   key the internal runtime storage, the SSR wire, and the reverse indexes
   use — `state/entries-path`, `state/key-id`); each entry carries its
   kind-preserving public scoped-resource-key VECTOR
-  `[canonical-scope resource-id canonical-params]` under `:resource/key`
-  (rf2-jtlq7l / rf2-ka2nkx). Callers that need to destructure
+  `[canonical-scope resource-id canonical-params]` under `:resource/key`.
+  Callers that need to destructure
   `[scope resource-id params]`, filter by scope/resource, or compare
   against scoped keys read each entry's `:resource/key`; the byte string
   map key is purely an opaque distinct identity.
@@ -184,7 +170,7 @@
   is TRUE while their `canonical-bytes` differ (`v[…]` vs `l(…)`). Rekeying
   the byte-keyed runtime map onto the `=`-colliding vector would `assoc`
   one CEDN-distinct entry OVER the other, so the public read could report
-  ONE entry for TWO live cache entries (rf2-ka2nkx). Keying on the byte
+  ONE entry for TWO live cache entries. Keying on the byte
   `key-id` string (which compares by content, the exact CEDN-1 identity)
   keeps every live entry distinct. Internal storage stays byte-keyed."
   ([] {:resource-ids (resource-ids) :entries {}})
@@ -193,11 +179,9 @@
     :entries      (if frame
                     (let [entries (get-in (frame/frame-runtime-db-value frame)
                                           (state/entries-path))]
-                      ;; rf2-ka2nkx — the runtime `:entries` map is ALREADY keyed
-                      ;; on the CEDN-1 byte `key-id`; return it as-is (every entry
-                      ;; carries its kind-preserving `:resource/key` vector). Do
-                      ;; NOT rekey onto the `=`-colliding scoped-key vector — that
-                      ;; collapses CEDN-distinct sequential-params entries.
+                      ;; Preserve the byte-keyed map: re-keying on scoped-key
+                      ;; vectors can collapse CEDN-distinct sequential params
+                      ;; that compare equal under Clojure `=`.
                       (or entries {}))
                     {})}))
 
@@ -205,8 +189,8 @@
   "Return a resource instance's durable runtime ENTRY for an explicit
   `:frame` introspection target `{:resource :scope :params :frame}` (Spec
   016 §Introspection), or nil when no entry exists for that scoped key in
-  that frame. Per EP-0002 the frame target is carried explicitly; a
-  frameless call FAILS CLOSED (rf2-c8lgy3): an absent / nil `:frame` raises
+  that frame. The frame target is explicit; a frameless call FAILS CLOSED:
+  an absent / nil `:frame` raises
   the structured `:rf.error/no-frame-context` rather than passing nil through
   to a runtime-db lookup that returns nil — a nil that is INDISTINGUISHABLE
   from a genuinely absent entry. Resolves the scoped key the same way a
@@ -229,11 +213,11 @@
            "return nil — indistinguishable from a genuinely "
            "absent entry. Pass {:resource … :scope … "
            ":params … :frame <frame-id>}. Per Spec 016 "
-           "§Introspection / EP-0002.")
+           "§Introspection.")
       {:recovery :pass-frame
        :extra    {:opts (dissoc opts :frame)}}))
-  (let [;; EP-0016 D3 slice 3: a `{:from-db <id>}` scope on the introspection
-        ;; target resolves against the frame's app-db value (the same db the
+  (let [;; A `{:from-db <id>}` scope on the introspection target resolves
+        ;; against the frame's app-db value (the same db the
         ;; reactive sub resolves against), so `resource-state` and a live
         ;; `[:rf/resource …]` sub resolve the SAME scoped key.
         scoped-key (resource-subs/resolve-scoped-key
@@ -242,16 +226,16 @@
     (get-in runtime-db (state/entry-path scoped-key))))
 
 (defn mutations
-  "Return mutation introspection for a frame target (EP-0003 §Mutations /
+  "Return mutation introspection for a frame target (Spec 016 §Mutations /
   Xray). Returns `{:mutation-ids [...] :instances {…}}` — the static
   registry (every registered mutation id) plus, when `:frame` is supplied,
   the live per-frame mutation-INSTANCE map. That map is keyed on each
-  instance id's CEDN-1 byte `key-id` (`{<key-id> <instance>}`, per
-  rf2-8iciw8), NOT the raw instance id — each instance carries its
+  instance id's CEDN-1 byte `key-id` (`{<key-id> <instance>}`), NOT the raw
+  instance id — each instance carries its
   kind-preserving id alongside under `:instance/id`. Xray groups instances
   under their registered `:mutation/id` while showing each separately.
   Without `:frame` only the static registry is returned (no ambient frame
-  fallback, EP-0002)."
+  fallback)."
   ([] {:mutation-ids (mutation-ids) :instances {}})
   ([{:keys [frame]}]
    {:mutation-ids (mutation-ids)
@@ -262,14 +246,14 @@
 
 (defn mutation-state
   "Return a mutation INSTANCE's durable runtime row for an explicit
-  `:frame` introspection target `{:instance :frame}` (EP-0003 §Mutations),
-  or nil when no instance exists under that instance id in that frame. Per
-  EP-0002 the frame target is carried explicitly; a frameless call FAILS
-  CLOSED (rf2-a76921): an absent / nil `:frame` raises the structured
+  `:frame` introspection target `{:instance :frame}` (Spec 016 §Mutations),
+  or nil when no instance exists under that instance id in that frame. The
+  frame target is explicit; a frameless call FAILS CLOSED: an absent / nil
+  `:frame` raises the structured
   `:rf.error/no-frame-context` rather than passing nil through to a
   runtime-db lookup that returns nil — a nil that is INDISTINGUISHABLE from
   a genuinely absent instance. This mirrors `resource-state`'s explicit-frame
-  contract; the two introspection halves now fail closed symmetrically.
+  contract; the two introspection halves fail closed symmetrically.
 
   Frame existence is NOT a precondition: an explicit but unknown / destroyed
   `:frame` reads as `nil` runtime-db and returns `nil` (no instance) — the
@@ -286,16 +270,14 @@
            "pass nil through to the runtime-db lookup and "
            "return nil — indistinguishable from a genuinely "
            "absent instance. Pass {:instance … "
-           ":frame <frame-id>}. Per EP-0003 §Mutations / "
-           "EP-0002.")
+           ":frame <frame-id>}. Per Spec 016 §Mutations.")
       {:recovery :pass-frame
        :extra    {:opts (dissoc opts :frame)}}))
   (let [runtime-db (frame/frame-runtime-db-value frame)]
     (get-in runtime-db (mstate/instance-path instance))))
 
-;; The `sub-mutation` / `sub-resource` reactive-read sugar fns that once lived
-;; here were REMOVED (rf2-il99l3, reversing rf2-2cmcas). A resource / mutation
-;; state read is a subscription VECTOR — `(subscribe [:rf/resource
+;; A resource / mutation state read is a subscription VECTOR —
+;; `(subscribe [:rf/resource
 ;; <query>])` / `(subscribe [:rf/mutation {:instance <instance>}])` —
 ;; one read grammar; `subscribe`'s own frame-first arity carries the
 ;; `{:frame …}` target for an explicit frame.
@@ -316,7 +298,7 @@
 
 ;; :rf.resource/generation-allocation cofx + :rf.resource/commit-generation
 ;; fx — Spec 016 §Restore and replay part 1 + 002 §Durable join keys are
-;; recordable (rf2-abyycr). The host-side generation allocator is a monotone
+;; recordable. The host-side generation allocator is a monotone
 ;; high-water mark that never rewinds across epoch restore (so a pre-restore
 ;; in-flight reply's generation can never match a post-restore live entry).
 ;; The generation is also a DURABLE JOIN KEY (written onto the entry/instance
@@ -328,8 +310,7 @@
 ;; replay fails loud on a missing allocation rather than re-minting a
 ;; divergent generation). The ensure/refetch/execute handlers read the
 ;; recorded `:generation` flat and write only it durably; the fx advances the
-;; host high-water with `max`. Mirrors routing's nav-allocation seam
-;; (rf2-oosjmh / rf2-vcop6y). Registered in the façade so a `:reload`
+;; host high-water with `max`. Registered in the façade so a `:reload`
 ;; re-wires them.
 (cofx/reg-cofx :rf.resource/generation-allocation
                state/generation-allocation-cofx-meta
@@ -338,7 +319,7 @@
            state/commit-generation-meta
            state/commit-generation-handler)
 
-;; Work-ledger host-handle side-table write fx (rf2-afpdkn). The work-handle
+;; Work-ledger host-handle side-table write fx. The work-handle
 ;; side table is host-side transient state (NOT runtime-db), so its writes
 ;; ride fx exactly as the host-side generation high-water bump does. The
 ;; runtime emits :rf.resource/record-work-handle alongside the transport
@@ -352,7 +333,7 @@
            work-ledger/clear-work-handle-meta
            work-ledger/clear-work-handle-handler)
 
-;; Stale / GC timer side-table write fx (rf2-nbjewi). The stale / GC timer
+;; Stale / GC timer side-table write fx. The stale / GC timer
 ;; handles are host-side transient state (NOT runtime-db), so their writes
 ;; ride fx exactly as the generation high-water bump + work-handle side-table
 ;; writes do. The success reply handler emits :rf.resource/schedule-timers
@@ -369,7 +350,7 @@
 (fx/reg-fx :rf.resource/cancel-timers
            timers/cancel-timers-meta
            timers/cancel-timers-handler)
-;; EP-0020 §Polling: the poll-only cancel fx. `:rf.resource/release-owner`
+;; The poll-only cancel fx. `:rf.resource/release-owner`
 ;; emits it for each entry that became owner-free (polling stops the instant
 ;; the last owner releases — a poll never pins an owner-free entry; the stale
 ;; / GC timers stay armed because an owner-free entry still GCs).
@@ -377,9 +358,9 @@
            timers/cancel-poll-timers-meta
            timers/cancel-poll-timers-handler)
 
-;; EP-0017: a time-consuming resource / mutation handler DECLARES the
+;; A time-consuming resource / mutation handler DECLARES the
 ;; framework-stamped causal-time fact `:rf/time-ms` via `:rf.cofx/requires`
-;; (rf2-601ife). Under EP-0017 declared-only delivery the runtime stages
+;; through `:rf.cofx/requires`. Under declared-only delivery the runtime stages
 ;; EXACTLY the facts a handler declares, FLAT in the coeffects map — nothing
 ;; implicit, including `:rf/time-ms` (re-frame.cofx ns docstring; the router
 ;; stamps it on the dispatch envelope's `:rf.cofx`, but the handler only
@@ -396,9 +377,9 @@
   (assoc framework-authority-meta
          :rf.cofx/requires [:rf/time-ms]))
 
-;; EP-0017: the load-causing events (ensure / refetch / mutation execute)
-;; DECLARE the RECORDABLE generation-allocation cofx AND the framework-stamped
-;; `:rf/time-ms` via `:rf.cofx/requires` (rf2-abyycr / rf2-601ife). Their
+;; Load-causing events (ensure / refetch / mutation execute) DECLARE the
+;; RECORDABLE generation-allocation cofx AND the framework-stamped
+;; `:rf/time-ms` via `:rf.cofx/requires`. Their
 ;; handlers read the recorded allocation FLAT under `:coeffects
 ;; :rf.resource/generation-allocation` (`{:generation N :counter N}`) and the
 ;; causal time FLAT under `:coeffects :rf/time-ms` — the generation comes
@@ -413,11 +394,11 @@
          :rf.cofx/requires [:rf.resource/generation-allocation :rf/time-ms]))
 
 ;; Public resource events (map payloads). Per Spec 016 §Events.
-;; rf2-v8x9n8 — every entry-mutating handler is wrapped with
+;; Every entry-mutating handler is wrapped with
 ;; `resource-events/with-classification-lowering` so its durable `:rf.db/runtime`
 ;; transition LOWERS each live entry's projection-relative `:sensitive` /
 ;; `:large` classification into the per-frame elision registry under `:source
-;; :resource` (the EP-0025 standard model — the routing/machines lowering peer),
+;; :resource` (the routing/machines lowering peer),
 ;; instead of re-deriving it only at the family-private projectors. The
 ;; reconciliation is idempotent + self-dropping, so the registry's resource-
 ;; sourced set stays in step with `:entries` no matter which handler ran.
@@ -429,7 +410,7 @@
                      generation-meta
                      (resource-events/with-classification-lowering
                        resource-events/refetch-handler))
-;; EP-0021 R2 — `:rf.resource/load-more` extends an infinite feed by one page.
+;; `:rf.resource/load-more` extends an infinite feed by one page.
 ;; It mints a generation (the same host-side monotone allocator, for stale
 ;; suppression — the work-id derives from it) and records the work-ledger
 ;; `:started-at` from the causal `:rf/time-ms`, so it declares the recordable
@@ -438,7 +419,7 @@
                      generation-meta
                      (resource-events/with-classification-lowering
                        resource-events/load-more-handler))
-;; EP-0021 R6 (rf2-byl7bk.3.3) — `:rf.resource.internal/refetch-page` re-fetches
+;; `:rf.resource.internal/refetch-page` re-fetches
 ;; ONE page of a multi-page refetch sweep (`:refetch-all-pages?` /
 ;; `:refetch-window`). Chained by `page-succeeded-handler` one leg at a time; it
 ;; mints a fresh generation (the work-id derives from it, for per-leg stale
@@ -449,7 +430,7 @@
                      generation-meta
                      (resource-events/with-classification-lowering
                        resource-events/refetch-page-handler))
-;; EP-0017 (rf2-601ife): `invalidate-tags` writes the durable `:invalidated-at`
+;; `invalidate-tags` writes the durable `:invalidated-at`
 ;; fact from the event's causal `:rf/time-ms`, so it declares the time cofx.
 (events/reg-event :rf.resource/invalidate-tags
                      time-meta
@@ -468,8 +449,8 @@
                      (resource-events/with-classification-lowering
                        resource-events/remove-handler))
 
-;; Focus / reconnect revalidation events (rf2-vtblcq, Spec 016 §Stale and GC
-;; scheduling / §Deferred slices). The host focus / online listeners
+;; Focus / reconnect revalidation events (Spec 016 §Stale and GC scheduling).
+;; The host focus / online listeners
 ;; (`re-frame.resources.revalidate-listeners`) dispatch these; each scans the
 ;; frame's active-owner STALE entries and refetches them in the background
 ;; with cause `:focus` / `:reconnect` (a CAUSE, never an owner — the refetch
@@ -478,7 +459,7 @@
 ;; themselves (only `:rf.resource/refetch` dispatches), but carry the
 ;; framework-authority stamp for family uniformity. User code MUST NOT
 ;; dispatch them directly.
-;; EP-0017 (rf2-601ife): the focus / reconnect scans make a replay-relevant
+;; The focus / reconnect scans make a replay-relevant
 ;; active-stale SELECTION against the token's causal `:rf/time-ms`, so they
 ;; declare the time cofx (the scan writes nothing durable itself, but a
 ;; replayed signal must SELECT the same set the recorded time dictated).
@@ -491,11 +472,11 @@
 
 ;; Framework-internal reply handlers. Per Spec 016 §Events / §Transport.
 ;; User code MUST NOT dispatch these.
-;; EP-0017 (rf2-601ife / rf2-rl27r2): the reply + stale-timer handlers consume
+;; The reply + stale-timer handlers consume
 ;; the reply / timer token's causal `:rf/time-ms` — succeeded → durable
 ;; `:loaded-at` / `:stale-at`; failed + aborted → the canonical reply's
-;; `:completed-at` (rf2-rl27r2 — failure / cancellation replies now carry it,
-;; symmetric with success + mutation); stale-fired → a replay-stable freshness
+;; `:completed-at` (failure / cancellation replies carry it symmetrically with
+;; success + mutation); stale-fired → a replay-stable freshness
 ;; re-check. Each declares the time cofx so the fact is delivered flat.
 (events/reg-event :rf.resource.internal/succeeded
                      time-meta
@@ -505,7 +486,7 @@
                      time-meta
                      (resource-events/with-classification-lowering
                        resource-events/failed-handler))
-;; EP-0021 R1/R2 — the infinite-feed PAGE reply handlers. DISTINCT from the
+;; The infinite-feed PAGE reply handlers are DISTINCT from the
 ;; scalar succeeded / failed replies: a page success APPENDS / replaces-in-place
 ;; one page (`entry-replace-page`); a page failure is the THIRD error channel
 ;; (`entry-page-failed` keeps the feed + records `:page-error`). They reuse the
@@ -532,7 +513,7 @@
                      framework-authority-meta
                      (resource-events/with-classification-lowering
                        resource-events/gc-fired-handler))
-;; EP-0020 §Polling — an active-owner `:poll` timer fired. The handler
+;; An active-owner `:poll` timer fired. The handler
 ;; re-checks the live entry (present? owned? not hidden? not in-flight?) and
 ;; unconditionally refetches (cause `:poll`, never an owner) when polling
 ;; should continue, re-arming the next interval. The host `:poll` timer
@@ -548,16 +529,15 @@
 ;; Passive resource subs. Per Spec 016 §Subscriptions.
 (resource-subs/register-subs!)
 
-;; Mutations (rf2-dwme29, Spec 016 §Deferred slices / EP-0003 §Mutations —
-;; the first public-beta gate). The causal-write counterpart of the resource
+;; Mutations (Spec 016 §Mutations). The causal-write counterpart of the resource
 ;; events: `:rf.mutation/execute` mints an instance + work-ledger record and
 ;; lowers the write through the SAME managed-HTTP transport; on success it
-;; patches / populates resource entries then invalidates tags (composing with
-;; the landed `:rf.resource/invalidate-tags`); `:rf.mutation/clear` is the
+;; patches / populates resource entries then invalidates tags;
+;; `:rf.mutation/clear` is the
 ;; causal instance reset. `:rf.mutation/execute` mints a generation (the same
 ;; host-side monotone allocator the resources use, for stale suppression), so
 ;; it declares the recordable `:rf.resource/generation-allocation` cofx
-;; (rf2-abyycr) and reads the recorded `:generation` flat — the instance-id /
+;; and reads the recorded `:generation` flat — the instance-id /
 ;; work-id derive from it, so recording the generation makes them reproduce on
 ;; replay for free. The internal replies carry the verification payload
 ;; (instance id + work-id + generation). User code MUST NOT dispatch the
@@ -568,7 +548,7 @@
 (events/reg-event :rf.mutation/clear
                      framework-authority-meta
                      mutation-events/clear-handler)
-;; EP-0017 (rf2-601ife): the mutation reply handlers consume the reply token's
+;; The mutation reply handlers consume the reply token's
 ;; causal `:rf/time-ms` for the canonical reply's `:completed-at` → the durable
 ;; instance `:settled-at` + any patch / populate `:loaded-at`, so they declare
 ;; the time cofx (success + failure both, symmetric).
@@ -579,7 +559,7 @@
                      time-meta
                      mutation-events/failed-handler)
 
-;; Passive mutation subs. Per EP-0003 §Mutations.
+;; Passive mutation subs. Per Spec 016 §Mutations.
 (mutation-subs/register-subs!)
 
 ;; LATE-BOUND cross-feature integrations (Spec 016 §Route integration /
@@ -589,10 +569,10 @@
 (route/install-routing-integration!)
 (ssr/install-ssr-integration!)
 
-;; rf2-afpdkn / rf2-nbjewi: release the destroyed frame's host-side TRANSIENT
+;; Release the destroyed frame's host-side TRANSIENT
 ;; resource caches — the work-ledger host handles (AbortControllers,
 ;; `re-frame.resources.work-ledger/handle-table`), the stale / GC timer
-;; handles (`re-frame.resources.timers/timer-table`, rf2-nbjewi), AND the
+;; handles (`re-frame.resources.timers/timer-table`), AND the
 ;; generation high-water mark (`re-frame.resources.state/generation-cache`).
 ;; None is runtime-db state — all live in module-level atoms (host-derived,
 ;; ephemeral, off the epoch / SSR egress wire; the generation host-side so an
@@ -607,7 +587,7 @@
 (defn- release-resources-host-caches!
   "Release ALL of the destroyed frame's host-side transient resource caches
   (work-ledger host handles + stale / GC timer handles + generation
-  high-water mark + focus/reconnect revalidation listeners — rf2-vtblcq).
+  high-water mark + focus/reconnect revalidation listeners).
   The `:resources/on-frame-destroyed!` teardown body — one composed hook, no
   second teardown path."
   [frame-id]
@@ -630,8 +610,8 @@
 
 ;; The test-isolation reset hook (`:resources/reset-resources!`) is NOT
 ;; published here — it lives behind an explicit
-;; `re-frame.resources.test-support` require (the rf2-dbiv8 posture: keep
-;; test fixtures out of the always-on production façade), which publishes
+;; `re-frame.resources.test-support` require to keep test fixtures out of the
+;; always-on production façade; that namespace publishes
 ;; it from its own ns-load. The shared CLJS make-reset-runtime-fixture
 ;; reset-hooks table consults it by key and no-ops when test-support is
 ;; absent.
@@ -641,13 +621,12 @@
    :resources/resource-meta  resource-meta
    :resources/resource-state resource-state
    :resources/resources      resources
-   ;; rf2-vtblcq: the focus/reconnect revalidation host-listener install
-   ;; surface (CLJS-only host listeners; JVM no-op). Published so re-frame.core
+   ;; Focus/reconnect revalidation host-listener install surface (CLJS-only host
+   ;; listeners; JVM no-op). Published so re-frame.core
    ;; can reach it without a static :require.
    :resources/install-revalidation-listeners! install-revalidation-listeners!
    :resources/remove-revalidation-listeners!  remove-revalidation-listeners!
-   ;; rf2-dwme29 (EP-0003 §Mutations, first public-beta gate): the mutation
-   ;; registration + introspection surface, published through the same
+   ;; Mutation registration + introspection, published through the same
    ;; late-bind table so `re-frame.core`'s `reg-mutation` / `clear-mutation`
    ;; / `mutation-meta` / `mutation-state` / `mutations` wrappers reach the
    ;; producing impl without a static :require.
@@ -656,15 +635,15 @@
    :resources/mutation-meta  mutation-meta
    :resources/mutation-state mutation-state
    :resources/mutations      mutations
-   ;; rf2-hls77w (EP-0016 D3 slice 2): the named resource-scope resolver
-   ;; surface, published through the same late-bind table so
+   ;; Named resource-scope resolvers, published through the same late-bind
+   ;; table so
    ;; `re-frame.core`'s `reg-resource-scope` / `clear-resource-scope` /
    ;; `resolve-resource-scope` wrappers reach the producing impl without a
    ;; static :require.
    :resources/reg-resource-scope     reg-resource-scope
    :resources/clear-resource-scope   clear-resource-scope
    :resources/resolve-resource-scope resolve-resource-scope
-   ;; rf2-84l82t (EP-0015): the OFF-BOX trace egress projector for a
+   ;; OFF-BOX trace egress projector for a
    ;; `:rf.resource/scope-resolved` row — the central trace egress pipeline
    ;; (epoch tool-pair) consults it to redact the resolver's resolved
    ;; `:input-values` / `:scope` (a value-path walk is structurally blind to
@@ -672,7 +651,7 @@
    ;; epoch artefact reaches it without a static :require on resources.
    :resources/project-scope-resolved-egress
    scope-registry/project-scope-resolved-egress
-   ;; rf2-8x0gfa (EP-0015): the family-level OFF-BOX trace egress projector for
+   ;; Family-level OFF-BOX trace egress projector for
    ;; the rest of the resource/mutation trace family — projects the scoped-key
    ;; slots (`:resource/key` / `:resource/keys` / `:matched` / `:removed` /
    ;; `:keys` / `:exempt` / `:committed` / the rollback `:dispositions` + the

--- a/implementation/resources/src/re_frame/resources/classification.cljc
+++ b/implementation/resources/src/re_frame/resources/classification.cljc
@@ -1,37 +1,31 @@
 (ns re-frame.resources.classification
-  "Resource / mutation OWNER-classification — the EP-0015 §6 reconciliation
-  (bead-plan item 5). Graduated normatively into
-  [`spec/015-Data-Classification.md` §Resource and mutation durable
-  classification](../../../../../../spec/015-Data-Classification.md) +
-  [`spec/016-Resources.md` §SSR and hydration](../../../../../../spec/016-Resources.md).
+  "Resource and mutation owner classification. See Spec 015 §Resource and
+  mutation durable classification and Spec 016 §SSR and hydration.
 
-  ## The ownership rule (EP-0015 §6, ruled issue 11)
+  ## Ownership
 
   A `reg-resource` / `reg-mutation` declaration creates DURABLE
   runtime-subsystem state (cache entries under `:rf.runtime/resources`,
   scoped keys, params, data, errors, refresh errors, work-ledger summaries;
   mutation instances under `:rf.runtime/mutations` carrying params / result
-  / error). Those shapes are **owned by the resource or mutation
-  definition** — they are durable runtime-subsystem state, NOT transient
-  registration payloads classified merely because `reg-resource` /
-  `reg-mutation` declared them (EP-0015 §4 / Spec 015 §Registration-owned
-  transient classification).
+  / error). Those shapes are owned by the resource or mutation definition.
+  They are durable runtime-subsystem state, not transient registration
+  payloads.
 
-  The canonical fine-grained classification surface is **per-slot
-  `:sensitive?` / `:large?` props on the existing `:data-schema` /
-  `:params-schema`** — the SAME EP-0005 mechanism the machine `:data-schema`
-  surface uses (EP-0015 issue 11, ruled). There is **no new resource
-  path-map vocabulary** (that would be the fourth spelling EP-0007 exists to
-  prevent). The coarse whole-entry `:sensitive?` / `:large?` claims on the
-  resource spec remain as the degenerate **root-prop** case — the whole
-  resource is the classification unit.
+  Fine-grained durable classification is declared by projection-relative
+  `:sensitive` / `:large` paths on the resource or mutation spec. The runtime
+  lowers those paths per instance into the frame elision registry, and every
+  durable egress boundary reads that registry. Schema `:sensitive?` / `:large?`
+  props govern validation-failure redaction only; they do not classify durable
+  state. Coarse whole-entry `:sensitive?` / `:large?` claims remain the root
+  case, where the whole resource is the classification unit.
 
   ## Projection is registry-driven — the routing / machines standard model
 
   Classification NAMES the facts; the framework PROJECTS them at every
   egress boundary (SSR, tool, trace, epoch, observability) through the
   merged frame-owned `re-frame.projection/project-egress` over the shared
-  `re-frame.elision/elide-wire-value` walker (EP-0015 §10/§11) — NEVER a
+  `re-frame.elision/elide-wire-value` walker — NEVER a
   family-private resource elider. The fine-grained per-slot declarations
   are LOWERED per instance into the per-frame elision registry
   (`reconcile-registry`), and the egress boundaries READ THAT REGISTRY: the
@@ -44,13 +38,9 @@
   `project-snapshot-data` (the `frame-snapshot-classification` registry
   read) — one source of truth, all sources unioned at lookup.
 
-  rf2-d3pku1: this REMOVED the redundant family-private `project-data` /
-  `project-params` projectors, which re-derived `split-projection-paths
-  spec` at egress — the SAME fact `reconcile-registry` already lowered into
-  the registry (EP-0025: point the egress projection at the registry as
-  the single source). The COARSE whole-entry disposition
-  (`whole-entry-disposition`) remains the separate, frame-independent
-  authority that gates redact / omit / serialize on the WHOLE entry.
+  The coarse whole-entry disposition (`whole-entry-disposition`) remains the
+  separate, frame-independent authority that gates redact / omit / serialize
+  on the whole entry.
 
   ## Sensitive wins over large
 
@@ -62,16 +52,9 @@
   walker's sensitive-before-large ordering (`re-frame.elision/walk`) — the
   registry read inherits it.
 
-  ## What this slice does NOT touch
-
-  - It introduces NO new public API surface (no facade export) — it is the
-    internal owner-classification seam the SSR projection + the reply trace
-    egress consume. The public classification surface is the projection-
-    relative `:sensitive` / `:large` declarations on `reg-resource` /
-    `reg-mutation`.
-  - It does NOT change the Spec-Schemas schema-marker grammar (the
-    `:sensitive?` / `:large?` Malli props are owned by the schemas artefact
-    + Spec-Schemas — EP-0015 bead-plan item 9)."
+  This is an internal seam used by SSR, tooling, trace egress, and event-time
+  registry reconciliation. The public surface is the projection-relative
+  declaration on `reg-resource` / `reg-mutation`."
   (:require [re-frame.late-bind :as late-bind]
             [re-frame.classification :as classification]
             [re-frame.elision :as elision]
@@ -84,8 +67,8 @@
 ;; ---------------------------------------------------------------------------
 ;; Whole-entry disposition — the coarse root-prop owner classification.
 ;;
-;; EP-0015 issue 11 (ruled): the coarse whole-entry `:sensitive?` /
-;; `:large?` claims remain as the degenerate root-prop case (the WHOLE
+;; Coarse whole-entry `:sensitive?` / `:large?` claims are the degenerate
+;; root-prop case (the WHOLE
 ;; resource is the classification unit). They gate the metadata-only
 ;; redact / omit shape the durable entry / instance rides on SSR and in
 ;; tool / epoch projections; sensitive wins over large.
@@ -106,7 +89,7 @@
   Sensitive wins over large (the redaction sentinel is the more
   conservative shape — it still announces the entry exists). A nil spec
   (an unregistered id) is `:serialize` (no coarse claim). Pure. Per
-  EP-0015 §6 / Spec 015 §Resource and mutation durable classification."
+  Spec 015 §Resource and mutation durable classification."
   [spec]
   (cond
     (:sensitive? spec) :redact
@@ -114,35 +97,19 @@
     :else              :serialize))
 
 ;; ---------------------------------------------------------------------------
-;; No derived-sensitivity propagation (EP-0025, rf2-71dr8t).
+;; No derived-sensitivity propagation.
 ;;
-;; A resource whose `:scope` is a `{:from-db <id>}` reference derives its cache
-;; scope from the resolver's declared `:db` inputs. EARLIER (EP-0016 wave,
-;; rf2-fi6tda.1) that derivation was a sensitivity PROPAGATION arm: a `:db`
-;; input reading a frame-sensitive path made the derived scope (and the
-;; resource's WHOLE durable entry) INHERIT `:sensitive` even when the owning
-;; resource was not declared sensitive, honouring a closed
-;; `:rf.egress/output-sensitivity` declassification enum.
-;;
-;; EP-0025 REMOVED all sensitivity propagation (subs / flows / this resource-
-;; scope arm). Classification does not flow input -> output (Spec 015 §No
-;; propagation, no taint). The inheritance pass (`resolver-derived-sensitive?` /
-;; `scope-derived-sensitive?`) and the frame-aware `whole-entry-disposition-for`
-;; are GONE: a resource's durable-entry disposition is the OWNER's coarse
-;; root-prop claim ALONE (`whole-entry-disposition`), and its fine-grained
-;; classification rides its OWN projection-relative `:sensitive` / `:large`
-;; declarations (lowered per instance into the per-frame elision registry — see
-;; the lowering section below). A genuinely-sensitive derived scope is declared
-;; directly (`[:scope ...]` / `[:params ...]` sensitive); nothing is inherited
-;; from the paths the resolver read.
+;; Classification does not flow from a scope resolver's inputs to its output
+;; (Spec 015 §No propagation, no taint). A resource's whole-entry disposition
+;; comes only from its owner declaration. A sensitive derived scope must be
+;; declared directly with a projection-relative `[:scope ...]` or
+;; `[:params ...]` path.
 
 ;; ---------------------------------------------------------------------------
-;; EP-0025 §subsystems projection-relative declarations (rf2-h3d8tf).
-;;
 ;; A resource / mutation DEFINITION declares its sensitive / large slots
 ;; PROJECTION-RELATIVE to the instance projection (the matrix root: entry's
 ;; `:params` / `:data`), via top-level `:sensitive` / `:large` vectors on the
-;; `reg-resource` / `reg-mutation` spec — the EP-0025 example surface:
+;; `reg-resource` / `reg-mutation` spec:
 ;;
 ;;   (rf/reg-resource :user-profile
 ;;     {:sensitive [[:data :ssn]] :large [[:data :avatar-bytes]]})
@@ -151,14 +118,9 @@
 ;; at `reg-resource`, so it declares its own (statically-known) sensitive
 ;; fields there. The declaration is value-INDEPENDENT and standing: it redacts
 ;; whatever later occupies the slot on EVERY instance (the per-instance
-;; application the EP names — every minted scoped key / landed data value
-;; redacts under the one owner declaration, with no per-instance author code
-;; and no storage paths in app code). It supersedes EP-0015 issue 11's
-;; "schema-props are the only fine-grained surface, no resource path-map
-;; vocabulary" stance: the projection-relative path vocabulary IS the canonical
-;; surface (the same axis vocabulary the machine / app-db / transient cases
-;; use — one name per fact), and the schema-prop route is unioned with it
-;; (kept as the schema-natural co-declaration until the EP-0025 purge).
+;; application means every minted scoped key and landed data value is governed
+;; by the same owner declaration, with no per-instance author code or absolute
+;; runtime storage paths in app code.
 ;;
 ;; Lowering = re-rooting + axis-split. The declaration paths are rooted at the
 ;; instance projection (`[:data …]` → the data value; `[:params …]` → the
@@ -173,7 +135,7 @@
 ;; ---------------------------------------------------------------------------
 
 (def ^:private declaration-axis-keys
-  "The two EP-0025 projection-relative declaration axes a `reg-resource` /
+  "The two projection-relative declaration axes a `reg-resource` /
   `reg-mutation` spec may carry — `:sensitive` (redact at egress) / `:large`
   (size marker at egress)."
   #{:sensitive :large})
@@ -205,7 +167,7 @@
 
 (defn classification-declaration-defect
   "PURE fail-loud-INPUT validator for a resource / mutation `spec`'s
-  EP-0025 projection-relative `:sensitive` / `:large` declarations. Returns
+  projection-relative `:sensitive` / `:large` declarations. Returns
   `{:axis k :reason <string>}` for the FIRST defect, or nil when every present
   declaration is well-shaped (or none is declared). The caller
   (`reg-resource` / `reg-mutation`) throws `:rf.error/resource-bad-spec`
@@ -240,7 +202,7 @@
     (get spec k)))
 
 (defn spec-declaration-marks
-  "The EP-0025 projection-relative `:sensitive` / `:large` declarations a
+  "The projection-relative `:sensitive` / `:large` declarations a
   resource / mutation `spec` carries, lowered + axis-split into the SAME
   `{:sensitive {path decl} :large {path decl}}` shape the schema-prop marks
   use — keyed `:data` (the data projection) and `:params` (the scoped-key
@@ -257,7 +219,7 @@
      :params {:sensitive (->decl (:params s)) :large (->decl (:params l))}}))
 
 ;; ---------------------------------------------------------------------------
-;; Schemas validate; they do NOT classify durably (EP-0025 rf2-fuqcob).
+;; Schemas validate; they do NOT classify durably.
 ;;
 ;; A resource's `:data-schema` / `:params-schema` / per-page `:page-data-schema`
 ;; VALIDATES the value; it does NOT drive DURABLE egress classification. The
@@ -275,8 +237,7 @@
 ;; ---------------------------------------------------------------------------
 
 ;; ---------------------------------------------------------------------------
-;; Egress projection — registry-driven, the routing / machines standard model
-;; (EP-0025, rf2-d3pku1 — collapsing the redundant family-private re-derivation).
+;; Egress projection — registry-driven, the routing / machines standard model.
 ;;
 ;; A resource's projection-relative `:sensitive` / `:large` declarations are the
 ;; SINGLE source of truth, and `reconcile-registry` (below) LOWERS them per
@@ -294,12 +255,6 @@
 ;;   - machines' `re-frame.machines.ssr/project-snapshot-data`, which reads the
 ;;     lowered snapshot declarations back from the registry
 ;;     (`re-frame.classification/frame-snapshot-classification`).
-;;
-;; EP-0025 §"Point the egress projection at the registry as the single source":
-;; the prior resources family-private `project-data` / `project-params`
-;; projectors re-derived `split-projection-paths spec` at egress — the SAME fact
-;; `reconcile-registry` already lowered into the registry. That dual derivation
-;; (rf2-d3pku1) is REMOVED here in favour of the registry read.
 ;;
 ;; The registry-driven walk is frame-SCOPED (the registry lives in the live
 ;; frame's runtime-db). A nil / unresolvable / never-classified frame rides the
@@ -333,7 +288,7 @@
   "Project a resource entry's serialized DATA value for egress across
   `boundary-profile` (a `:rf.egress/*` profile, e.g. `:rf.egress/ssr-hydration`)
   against `frame-id`'s per-frame elision registry — the REGISTRY-DRIVEN egress
-  read (EP-0025, rf2-d3pku1). The resource's projection-relative `:data`
+  read. The resource's projection-relative `:data`
   declarations were lowered into the registry at the entry's absolute runtime-db
   `:data` path (`[:rf.runtime/resources :entries <key-id> :data …]`,
   `reconcile-registry`); here we walk the bare `:data` value through
@@ -371,7 +326,7 @@
 (defn project-entry-params
   "Project a resource entry's scoped-key PARAMS value for egress against
   `frame-id`'s per-frame elision registry — the CO-EQUAL params counterpart to
-  `project-entry-data` (EP-0025, rf2-d3pku1; Spec 016 clause 4 \"params, scopes,
+  `project-entry-data` (Spec 016 clause 4 \"params, scopes,
   and data carry the same classification\"). The resource's projection-relative
   `:params` (and `:scope`) declarations were lowered into the registry at the
   scoped key's absolute `:resource/key` carrier (`[… :resource/key 2 …]` for
@@ -403,7 +358,7 @@
       params)))
 
 ;; ---------------------------------------------------------------------------
-;; Invalid-params error-payload projection (rf2-99j4e4).
+;; Invalid-params error-payload projection.
 ;;
 ;; `validate+canonicalize-params` (resource + mutation registries) throws
 ;; `:rf.error/resource-invalid-params` / `:rf.error/mutation-invalid-params`
@@ -442,18 +397,11 @@
 ;; the seam falls through verbatim — consistent with the no-validator path that
 ;; never produced an `:error` in the first place.
 ;;
-;; EP-0025 (rf2-fuqcob): the `:params-schema` per-slot `:sensitive?` / `:large?`
-;; props no longer drive DURABLE classification (the durable wire/SSR/tool egress
-;; reads only the projection-relative declarations, lowered into the registry —
-;; `project-entry-params`). But the VALIDATION-FAILURE-TRACE redaction is the
-;; schema's OWN surviving egress product (Spec 015 §Schemas describe shape: "for
-;; a slot's own validation-failure-trace redaction the schema produces that
-;; record, so it owns its egress shape"). So this seam reads the schema PROPS
-;; directly (via the shared walker hooks) to redact the failing `:params`
-;; per-slot — distinct from the durable registry route. That keeps the schema-
-;; prop route alive exactly where it is legitimate (the validator's own product),
-;; while the durable wire/SSR/tool egress is governed solely by the projection-
-;; relative declarations.
+;; Schema props do not drive DURABLE classification. They do govern the
+;; validation-failure record that the schema produces, so this seam reads those
+;; props directly to redact failing params. Durable wire, SSR, and tool egress
+;; remain governed by projection-relative declarations lowered into the frame
+;; registry.
 ;; ---------------------------------------------------------------------------
 
 (defn- validation-failure-params-marks
@@ -461,8 +409,8 @@
   `{:sensitive {path decl} :large {path decl}}` rooted at the params root — the
   SCHEMA-PROP marks, read via the shared late-bound walker hooks. Used ONLY by
   `redact-invalid-params-error` to redact the failing params in the VALIDATION-
-  FAILURE-TRACE (the schema's own egress product, the surviving schema-prop
-  route per EP-0025 / Spec 015 §Schemas describe shape) — NOT a durable
+  FAILURE-TRACE (the schema's own egress product, per Spec 015 §Schemas
+  describe shape) — NOT a durable
   classification route. Empty maps when the schema is nil / unschematic / the
   walker hooks are unbound. Pure (modulo the memoised walker)."
   [schema]
@@ -476,7 +424,7 @@
 (defn redact-invalid-params-error
   "Project the `:params` + `:error` (explainer output) slots of an invalid-params
   failure error payload against the resource / mutation `spec`'s `:params-schema`
-  per-slot `:sensitive?` / `:large?` VALIDATION props (rf2-99j4e4). Returns
+  per-slot `:sensitive?` / `:large?` VALIDATION props. Returns
   `{:params <projected> :error <projected-or-nil>}`:
 
     - `:params` per-slot redaction reads the `:params-schema` `:sensitive?` /
@@ -490,11 +438,9 @@
       scrubs to `:rf/redacted` when `spec`'s `:params-schema` declares ANY
       `:sensitive?` slot, else rides verbatim.
 
-  EP-0025 (rf2-fuqcob): this is the schema's OWN VALIDATION-FAILURE-TRACE egress
-  product, the surviving schema-prop redaction route (Spec 015 §Schemas describe
-  shape) — distinct from the DURABLE wire/SSR/tool egress, which the registry-
-  driven `project-entry-params` governs via the projection-relative declarations
-  alone (schema props no longer classify durably). `error` may be nil (no
+  This is the schema's OWN VALIDATION-FAILURE-TRACE egress product (Spec 015
+  §Schemas describe shape), distinct from DURABLE wire/SSR/tool egress, which
+  `project-entry-params` governs through the frame registry. `error` may be nil (no
   explainer registered); the `:error` key is then nil. Pure (modulo the memoised walker + the late-bound redaction
   hook)."
   [params error spec]
@@ -516,9 +462,7 @@
      :error  redacted-e}))
 
 ;; ---------------------------------------------------------------------------
-;; Per-instance lowering into the per-frame elision registry (EP-0025
-;; §subsystems, rf2-v8x9n8 — aligning resources to the machines / routing
-;; standard model).
+;; Per-instance lowering into the per-frame elision registry.
 ;;
 ;; Per the EP-0025 subsystem matrix a resource declares its `:sensitive` /
 ;; `:large` PROJECTION-RELATIVE to the entry projection (its `:params` / `:data`)
@@ -529,17 +473,9 @@
 ;; (`re-frame.machines.classification/lower-at-spawn!` →
 ;; `[:rf.runtime/machines :snapshots <actor-id> :data …]`) and routes lower at
 ;; activation (`re-frame.routing.classification/lower-for-route` →
-;; `[:rf.runtime/routing :current …]`). BEFORE rf2-v8x9n8 resources DID NOT
-;; lower: the marks were applied DIRECTLY at the family-private
-;; `project-data` / `project-params` projectors, so a generic registry reader
-;; (Xray "what is classified", an MCP registry view, the SSR registry-projection
-;; defence-in-depth) never SAW resource classification. The lowering put it in
-;; the registry; rf2-d3pku1 then COLLAPSED the redundant family-private
-;; projectors into the registry read (`project-entry-data` /
-;; `project-entry-params` walk the entry value through `project-egress` seeded at
-;; the lowered absolute path), so the registry is now the SINGLE source the
-;; egress reads — the "union every source" model the spec sells, uniform across
-;; all four subsystems.
+;; `[:rf.runtime/routing :current …]`). The registry is the single source read
+;; by `project-entry-data` / `project-entry-params` and by generic classification
+;; tooling.
 ;;
 ;; The lowering is a PURE runtime-db transform (`reconcile-registry`, mirroring
 ;; routing's `apply-route-classification`) so the durable runtime-db transition
@@ -641,9 +577,9 @@
   resolver `(fn [resource-id] -> spec|nil)`, return the runtime-db with the
   `[:rf.runtime/elision …]` registry's `:source :resource` entries REPLACED by
   the declarations of EVERY current cache entry (re-rooted absolute per the
-  entry's byte `key-id`). The standard EP-0025 lowering — the resources peer of
+  entry's byte `key-id`). This is the resources peer of
   `re-frame.routing.classification/apply-route-classification` and
-  `re-frame.machines.classification/lower-at-spawn!` (rf2-v8x9n8).
+  `re-frame.machines.classification/lower-at-spawn!`.
 
   Operates on a VALUE so a resource handler's durable `:rf.db/runtime`
   transition folds the registry update into the SAME atomic commit that

--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -448,7 +448,7 @@
         owner-newly-attached? (and (some? owner)
                                    (not (contains? (:active-owners entry) owner)))
         ;; default the transport (a spec that declares none gets managed
-        ;; HTTP — the only initial-scope transport; the transport seam
+        ;; HTTP — the only built-in transport; the transport seam
         ;; defaults identically). The work record + side-table handle +
         ;; opportunistic-abort fx all key off the concrete transport id.
         transport-id (or (:transport spec) transport/default-transport)
@@ -765,7 +765,7 @@
                                                 work-id page-param page-index)})
             ;; rf2-rrcfwk — guard the declared transport (registration-time
             ;; misconfig throw), then lower directly into the only
-            ;; initial-scope transport. The one-arm dispatch indirection
+            ;; built-in transport. The one-arm dispatch indirection
             ;; (`transport/lower-ensure`) is folded into this guarded call;
             ;; a real dispatch table returns only when a second transport
             ;; lands (the guard becomes the dispatch).
@@ -1222,18 +1222,15 @@
   [cofx [_event-id payload]]
   (refetch-page-loaded cofx payload {:where 'rf.resource.internal/refetch-page}))
 
-;; ---- focus / reconnect revalidation (rf2-vtblcq) --------------------------
+;; ---- focus / reconnect revalidation ---------------------------------------
 ;;
-;; The first public-beta gate item (Spec 016 §Stale and GC scheduling: "on
-;; focus or reconnect, the first public-beta revalidation slice scans active
-;; stale entries and refetches by event"; §Deferred slices:
-;; `:rf.resource/window-focused` / `:rf.resource/network-reconnected`
-;; expressed as resource EVENTS, NOT subscription-driven fetching).
+;; Per Spec 016 §Stale and GC scheduling, focus/reconnect signals are resource
+;; EVENTS, not subscription-driven fetching.
 ;;
 ;; The host focus / online listeners (`re-frame.resources.revalidate-listeners`,
 ;; CLJS-only, registered per-frame, cancelled on frame-destroy via the existing
 ;; `:resources/on-frame-destroyed!` hook) dispatch these events; the algorithm
-;; reuses the landed v1 primitives wholesale:
+;; reuses the ordinary lifecycle primitives:
 ;;
 ;;   - ACTIVE OWNERS decide WHICH entries are worth refetching — only an entry
 ;;     with a live lease (`:active-owners` non-empty) is scanned (an inactive

--- a/implementation/resources/src/re_frame/resources/mutation_events.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_events.cljc
@@ -1,8 +1,7 @@
 (ns re-frame.resources.mutation-events
   "The mutation event handlers — the causal WRITE surface over managed
-  HTTP, with success-time resource invalidation / patch / populate. Per
-  Spec 016 §Deferred slices (mutations, first public-beta gate) and
-  EP-0003 §Mutations.
+  HTTP, with controlled resource invalidation / patch / populate and optional
+  optimistic application. Per Spec 016 §Mutations.
 
   The public mutation events take MAP payloads (mirroring the resource
   events):
@@ -35,8 +34,9 @@
     invalidation TIMING — `:after-success` by default — decides when).
   - On **failure**: settles the instance `:error`; optionally invalidates
     tags (`:after-failure` / `:after-settle` timing, when useful).
-  - **`:rf.mutation/clear`** clears a settled instance's runtime row (the
-    causal reset; clears registration+runtime, NOT a form-error reset).
+  - **`:rf.mutation/clear`** clears one instance, or every instance of a
+    mutation id, and best-effort aborts in-flight work. It does not remove the
+    mutation registration; `clear-mutation` owns that separate lifecycle.
 
   Every handler carries framework-write authority
   (`state/framework-authority-meta`) so a returned `:rf.db/runtime` effect
@@ -51,14 +51,13 @@
   a `:rf.mutation/clear`) is suppressed — it MUST NEVER mutate a newer
   instance. Cancellation is opportunistic; stale suppression is mandatory.
 
-  ## Optimistic rollback is DEFERRED
+  ## Optimistic settlement
 
-  This slice does NO optimistic update / snapshot / rollback. The instance
-  `:affected-keys` / `:patch-summary` slots and the success trace reserve
-  the shape (EP-0003 §Mutations: \"reserve room … affected resource keys,
-  patch summaries, snapshot ids, rollback result, and reconciliation
-  refetches\") so the later optimistic slice fills the symmetric rollback
-  half without a shape change."
+  An `:optimistic` / `:optimistic-tags` plan applies before transport lowering
+  and records a snapshot inverse plus entry revisions on the instance. Success
+  commits the apply. Failure or cancellation rolls it back; revision conflicts
+  follow `:on-conflict` (`:invalidate` by default, or explicit `:force`) and may
+  refetch authoritative data."
   (:require [clojure.set :as set]
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
@@ -1254,8 +1253,8 @@
                        ;; attempt (the ledger is named neutrally; the resource
                        ;; writer uses :resource, the mutation writer :mutation).
                        (assoc :work/kind :mutation))
-        ;; rf2-rrcfwk — guard the declared transport (registration-time
-        ;; misconfig throw), then lower directly into the only initial-scope
+        ;; Guard the declared transport (registration-time misconfig throw),
+        ;; then lower directly into the only built-in
         ;; transport. The one-arm dispatch indirection
         ;; (`transport/lower-ensure`) is folded into this guarded call.
         lower-fx   (do

--- a/implementation/resources/src/re_frame/resources/mutation_registry.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_registry.cljc
@@ -1,7 +1,6 @@
 (ns re-frame.resources.mutation-registry
   "Mutation registration — `reg-mutation` / `clear-mutation` and the
-  registry-side introspection accessors. Per Spec 016 §Deferred slices
-  (mutations, first public-beta gate) and EP-0003 §Mutations.
+  registry-side introspection accessors. Per Spec 016 §Mutations.
 
   A mutation is a registrar entry under the `:mutation` kind (the
   causal-write counterpart of the `:resource` kind). `reg-mutation`
@@ -14,10 +13,10 @@
   target), distinct from this process-level registration removal — see the
   `clear-mutation` docstring.
 
-  Mirrors `re-frame.resources.registry` (the resource registrar) so the two
-  registrars read as one family; the params-validation + (optional) scope
-  resolution reuse the resource registry's pluggable late-bound Malli
-  validator and canonicalization."
+  Mirrors `re-frame.resources.registry` so the two registrars read as one
+  family. Both delegate params validation and canonicalization to
+  `re-frame.resources.params`; mutation scope normalization uses the shared
+  concrete-scope boundary in `re-frame.resources.state`."
   (:require [re-frame.error :as error]
             [re-frame.registrar :as registrar]
             [re-frame.resources.classification :as classification]
@@ -60,7 +59,7 @@
 (defn- validate-mutation-spec!
   "Fail loudly at the authoring boundary when a mutation spec omits the
   REQUIRED keys (EP-0003 §Mutations). `:request` is REQUIRED (the Spec 014
-  managed-HTTP args map the write lowers into, the only initial-scope
+  managed-HTTP args map the write lowers into, the only built-in
   transport); `:params-schema` is REQUIRED (validates + canonicalizes the
   write's params). `:scope` is OPTIONAL for a mutation (unlike a resource):
   a mutation is a causal write, not a cached read, so it has no fail-closed
@@ -81,9 +80,9 @@
              :rf.error/mutation-bad-spec
              'rf/reg-mutation
              (str "mutation " mutation-id " declares no :request. For "
-                  ":transport :rf.http/managed (the only initial-scope "
+                  ":transport :rf.http/managed (the only built-in "
                   "transport) :request returns a Spec 014 managed-HTTP args "
-                  "map (the causal write). Per EP-0003 §Mutations.")
+                  "map (the causal write). Per Spec 016 §Mutations.")
              {:mutation-id mutation-id})))
   (when-not (contains? spec :params-schema)
     (throw (registration-error
@@ -92,7 +91,7 @@
              (str "mutation " mutation-id " declares no :params-schema. "
                   ":params-schema is REQUIRED — it validates and canonicalizes "
                   "the write's params (which the :request / :invalidates / "
-                  ":patches fns close over). Per EP-0003 §Mutations.")
+                  ":patches fns close over). Per Spec 016 §Mutations.")
              {:mutation-id mutation-id})))
   ;; :invalidate-timing is a CLOSED four-value enum (Spec 016 §Mutations). It
   ;; is OPTIONAL (nil defaults to :after-success at runtime), but a non-nil
@@ -248,7 +247,7 @@
     | `:after-failure` | `:after-settle`;
   - **`:retry`** — write retries are OPT-IN (EP-0003 §Mutations) and ride
     the Spec 014 managed-HTTP args' own `:retry`; nothing here forces them;
-  - **`:transport`** — initial scope: `:rf.http/managed` (the only built-in);
+  - **`:transport`** — `:rf.http/managed` (the only built-in);
   - **`:doc`**.
 
   Validates the reconstructed spec (the REQUIRED `:request` + `:params-schema`)
@@ -256,9 +255,9 @@
   source coords. Returns `mutation-id` per the `reg-*` return-value
   convention."
   [mutation-id metadata request-fn]
-  ;; rf2-t65lqt — the metadata MIDDLE slot must be a map BEFORE any
+  ;; The metadata MIDDLE slot must be a map BEFORE any
   ;; `assoc`/`contains?` runs against it. Reconstructing `:request` onto a
-  ;; non-map metadata (the slip after the rf2-wvh95f F1 grammar change) would
+  ;; non-map metadata would
   ;; otherwise leak a raw host `IllegalArgumentException` ("Key must be
   ;; integer") instead of the public `:rf.error/mutation-bad-spec`. Mirrors
   ;; reg-route's `route-bad-metadata` non-map guard. The catalogue row
@@ -268,19 +267,19 @@
              :rf.error/mutation-bad-spec
              'rf/reg-mutation
              (str "mutation " mutation-id "'s metadata (the MIDDLE slot) must "
-                  "be a map, got " (pr-str (type metadata)) ". Per rf2-wvh95f "
-                  "F1 the grammar is (reg-mutation " mutation-id " {…} "
+                  "be a map, got " (pr-str (type metadata)) ". The grammar is "
+                  "(reg-mutation " mutation-id " {…} "
                   "request-fn): the config metadata map is the SECOND slot, "
                   "the :request write fn is the THIRD.")
              {:mutation-id mutation-id :value metadata})))
-  ;; rf2-wvh95f F1 — `:request` is the 3-slot VALUE (the handler). A `:request`
+  ;; `:request` is the third-slot VALUE (the handler). A `:request`
   ;; left INSIDE the metadata map is a mislocated key; reject it loudly.
   (when (contains? metadata :request)
     (throw (registration-error
              :rf.error/mutation-bad-spec
              'rf/reg-mutation
              (str "mutation " mutation-id " declares :request inside its "
-                  "metadata map — per rf2-wvh95f F1 the request handler is the "
+                  "metadata map — the request handler is the "
                   "THIRD slot: (reg-mutation " mutation-id " {…} request-fn). "
                   "Move the write fn out of the metadata map into the value "
                   "slot.")
@@ -344,7 +343,7 @@
                where
                (str "no mutation is registered under " mutation-id
                     " — call rf/reg-mutation before :rf.mutation/execute. "
-                    "Per EP-0003 §Mutations.")
+                    "Per Spec 016 §Mutations.")
                {:mutation-id mutation-id}))))
 
 ;; ---- params validation + canonicalization --------------------------------
@@ -388,7 +387,7 @@
         :rf.error/mutation-invalid-params
         where
         (str "mutation " mutation-id " params do not conform to "
-             ":params-schema. Per EP-0003 §Mutations.")
+             ":params-schema. Per Spec 016 §Mutations.")
         {:mutation-id mutation-id
          :params      redacted-params
          :error       redacted-error}))))

--- a/implementation/resources/src/re_frame/resources/mutation_runtime.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_runtime.cljc
@@ -1,23 +1,23 @@
 (ns re-frame.resources.mutation-runtime
   "Mutation runtime-db paths + the durable mutation-INSTANCE shape, plus
   the pure controlled resource patch / populate helpers. Per Spec 016
-  §Deferred slices (mutations, first public-beta gate) and EP-0003
   §Mutations.
 
   A mutation is a named, causal WRITE to remote state that, on success,
   invalidates / patches / populates cached resource reads. `reg-mutation`
   registers it; `:rf.mutation/execute` runs it. Mutation runtime state is
   keyed by mutation **INSTANCE** id, NOT only by mutation id, so two
-  concurrent `:comment/add` submissions never clobber each other's
-  pending / error / result state (EP-0003 §Mutations).
+  concurrent `:comment/add` submissions never clobber each other's pending /
+  error / result state.
 
   Mutation instances live ONLY at `:rf.runtime/mutations` inside the
   runtime-db partition (`:rf.db/runtime`) — a reserved runtime-db key
   (per [Conventions §Reserved runtime-db keys]), allocated lazily,
   per-frame isolated, never an app-db location. The map is keyed by
-  instance id `{<instance-id> <instance>}`; Xray groups instances under
-  their registered `:mutation/id` while showing each request /
-  invalidation / patch / result separately (EP-0003 §Mutations).
+  the CEDN-1 byte identity of the instance id `{<key-id> <instance>}`; each row
+  retains the kind-preserving id under `:instance/id`. Xray groups instances
+  under their registered `:mutation/id` while showing each request / invalidation
+  / patch / result separately.
 
   ## Two-level identity (mirrors the resource entry ↔ work-record split)
 

--- a/implementation/resources/src/re_frame/resources/mutation_subs.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_subs.cljc
@@ -1,7 +1,6 @@
 (ns re-frame.resources.mutation-subs
   "The passive mutation-INSTANCE subscriptions — the read API over a
-  mutation's pending / result / error state. Per Spec 016 §Deferred slices
-  (mutations, first public-beta gate) and EP-0003 §Mutations.
+  mutation's pending / result / error state. Per Spec 016 §Mutations.
 
   A view reads a mutation instance through `[:rf/mutation {:instance
   …}]` (or a narrower projection); `:rf.mutation/execute` causes the write.
@@ -14,15 +13,15 @@
   computed here from the durable instance facts, NOT stored on the instance
   (Spec 016 §Status semantics, the same posture as resource subs).
 
-  ## `:result` is the instance-layer spelling of the decoded result (kh9jz6)
+  ## Result naming
 
   The mutation INSTANCE stores the decoded write result under `:result` —
   the durable, queryable status-record spelling. The transient causal reply
   map (the uniform reply envelope, Managed-Effects §The reply map) carries
   the SAME decoded result under `:value` — the reply-map spelling, which is
   `:value` for EVERY managed-async family with no per-family synonym
-  (EP-0007 one-name-per-fact). These are two NAMES for two FACTS in two
-  LAYERS: `:value` is the transient continuation; `:result` is the durable
+  (Managed Effects §The reply map). These are two names for facts in different
+  layers: `:value` is the transient continuation; `:result` is the durable
   instance status record (`{:pending? :success? :error? :settled? :result
   :error}`) a view subscribes to long after the reply was consumed. The
   events layer reads `(:value reply)` from the canonical reply and installs
@@ -68,8 +67,7 @@
   instance: the stored facts (`:status` / `:result` / `:error` /
   `:affected-keys`) plus the DERIVED booleans (`:pending?` / `:success?` /
   `:error?` / `:settled?` / `:optimistic?`) computed here, never stored.
-  Empty-state shape (idle, no instance) when none. Per EP-0003 §Mutations /
-  EP-0019 Rider 1 (the `:optimistic?` derived flag)."
+  Empty-state shape (idle, no instance) when none. Per Spec 016 §Mutations."
   [runtime-db sub-v]
   (let [i (instance-for runtime-db sub-v)]
     (if (nil? i)
@@ -88,12 +86,12 @@
 
 (defn status-sub-fn
   "Project `:rf.mutation/status` — the instance's `:status` keyword
-  (:idle / :pending / :success / :error). Per EP-0003 §Mutations."
+  (:idle / :pending / :success / :error). Per Spec 016 §Mutations."
   [runtime-db sub-v]
   (or (:status (instance-for runtime-db sub-v)) :idle))
 
 (defn pending?-sub-fn
-  "Project `:rf.mutation/pending?` — the write is in flight. Per EP-0003
+  "Project `:rf.mutation/pending?` — the write is in flight. Per Spec 016
   §Mutations."
   [runtime-db sub-v]
   (= :pending (:status (instance-for runtime-db sub-v))))
@@ -101,35 +99,35 @@
 (defn result-sub-fn
   "Project `:rf.mutation/result` — the decoded success result (or nil). The
   durable instance-layer spelling of the decoded write result; the transient
-  reply envelope carries the same fact as `:value` (kh9jz6 / EP-0007 — see
-  the ns docstring). Per EP-0003 §Mutations."
+  reply envelope carries the same fact as `:value` (see the ns docstring). Per
+  Spec 016 §Mutations."
   [runtime-db sub-v]
   (:result (instance-for runtime-db sub-v)))
 
 (defn error-sub-fn
   "Project `:rf.mutation/error` — the failure envelope (or nil; the closed
-  `:rf.http/*` shape). Per EP-0003 §Mutations."
+  `:rf.http/*` shape). Per Spec 016 §Mutations."
   [runtime-db sub-v]
   (:error (instance-for runtime-db sub-v)))
 
 (defn register-subs!
   "Register the `:rf.mutation/*` passive sub family. Called from the
   `re-frame.resources` façade so a `(require … :reload)` on a fresh
-  registrar re-wires them. Per EP-0003 §Mutations."
+  registrar re-wires them. Per Spec 016 §Mutations."
   []
   (subs/reg-runtime-sub :rf/mutation
-    {:doc "Passive read of a mutation instance's full view-model `{:status :result :error :affected-keys :pending? :success? :error? :settled? :optimistic?}`, keyed by :instance id. The `:optimistic?` flag (EP-0019 Rider 1) is true while a live optimistic apply is showing (phase 1.5) and not yet settled. Per EP-0003 §Mutations."}
+    {:doc "Passive read of a mutation instance's full view-model `{:status :result :error :affected-keys :pending? :success? :error? :settled? :optimistic?}`, keyed by :instance id. The `:optimistic?` flag is true while a live optimistic apply is showing and not yet settled. Per Spec 016 §Mutations."}
     state-sub-fn)
   (subs/reg-runtime-sub :rf.mutation/status
-    {:doc "Passive read of a mutation instance's :status keyword (:idle / :pending / :success / :error). Per EP-0003 §Mutations."}
+    {:doc "Passive read of a mutation instance's :status keyword (:idle / :pending / :success / :error). Per Spec 016 §Mutations."}
     status-sub-fn)
   (subs/reg-runtime-sub :rf.mutation/pending?
-    {:doc "Passive read: true iff a mutation instance's write is in flight. Per EP-0003 §Mutations."}
+    {:doc "Passive read: true iff a mutation instance's write is in flight. Per Spec 016 §Mutations."}
     pending?-sub-fn)
   (subs/reg-runtime-sub :rf.mutation/result
-    {:doc "Passive read of a mutation instance's decoded success result (or nil). Per EP-0003 §Mutations."}
+    {:doc "Passive read of a mutation instance's decoded success result (or nil). Per Spec 016 §Mutations."}
     result-sub-fn)
   (subs/reg-runtime-sub :rf.mutation/error
-    {:doc "Passive read of a mutation instance's failure envelope (or nil). Per EP-0003 §Mutations."}
+    {:doc "Passive read of a mutation instance's failure envelope (or nil). Per Spec 016 §Mutations."}
     error-sub-fn)
   nil)

--- a/implementation/resources/src/re_frame/resources/params.cljc
+++ b/implementation/resources/src/re_frame/resources/params.cljc
@@ -1,36 +1,28 @@
 (ns re-frame.resources.params
   "The single owner of the resource/mutation params validate+canonicalize
-  pipeline (rf2-7rbb7t). Both `re-frame.resources.registry` and
-  `re-frame.resources.mutation-registry` register a REQUIRED `:params-schema`
-  that validates + canonicalizes their family's params, and each family had
-  an independent, near-identical `validate+canonicalize-params`: default an
-  omitted slot, reject a non-EDN / host value at the cache-key boundary,
-  resolve the pluggable late-bound Malli validator/explainer, REDACT the
-  invalid params before they can ride an error payload, throw the
-  family-specific `:rf.error/*-invalid-params`, and canonicalize. The
-  nil/missing and invalid-param-redaction correctness/privacy fixes had to
-  land TWICE (a correctness + privacy-boundary duplication).
+  pipeline. Both registries require a `:params-schema` and delegate here to
+  default an omitted slot, reject non-EDN host values at the identity boundary,
+  invoke the late-bound validator/explainer, redact invalid params before they
+  enter an error payload, and canonicalize the accepted value.
 
-  This leaf owns that pipeline ONCE, parameterized only by the family's error
+  The pipeline is parameterized only by the family's error
   descriptor — a `build-invalid-error` callback that shapes the family's
   `:rf.error/resource-invalid-params` / `:rf.error/mutation-invalid-params`
-  throw. `registry` and `mutation-registry` keep THIN
-  `validate+canonicalize-params` wrappers so their call sites AND thrown error
-  shapes are unchanged.
+  throw. `registry` and `mutation-registry` keep thin wrappers so each public
+  surface retains its own error id and data shape.
 
   LEAF, no new edge: it requires only `state` (the omitted-default /
   EDN-rejection / canonicalization the two registrars already delegate to),
   `classification` (the invalid-param redaction seam), and `late-bind` (the
   pluggable Malli validator/explainer — NO static `schemas` dependency).
-  `registry` and `mutation-registry` already require all three, so hosting the
-  pipeline here introduces no require cycle; `mutation-registry` does NOT gain
-  a dependency on `registry`.
+  Hosting the pipeline here introduces no require cycle; `mutation-registry`
+  does not depend on `registry`.
 
   PRIVACY: the `classification/redact-invalid-params-error` step is a privacy
-  boundary — a `:sensitive?` params slot must never ride raw on the thrown
-  error payload / logs when validation fails on a non-sensitive sibling (and a
-  `:large?` slot elides). It is applied here ONCE, identically for both
-  families, before the family error is built."
+  boundary: a `:sensitive?` params slot must never ride raw on the thrown error
+  payload or downstream logs when validation fails on a non-sensitive sibling;
+  a `:large?` slot is elided. Projection happens before the family error is
+  built."
   (:require [re-frame.late-bind :as late-bind]
             [re-frame.resources.classification :as classification]
             [re-frame.resources.state :as state]))
@@ -38,15 +30,15 @@
 #?(:clj (set! *warn-on-reflection* true))
 
 (defn validate+canonicalize
-  "The shared validate+canonicalize params pipeline both the resource and the
-  mutation registrar delegate to (rf2-7rbb7t). Applies, in order:
+  "The shared validate+canonicalize params pipeline used by both registrars.
+  Applies, in order:
 
     1. the documented omitted-`:params` default (`state/default-omitted-params`)
        — an ABSENT slot (`state/missing-params`) becomes `{}`; a PRESENT value
        (INCLUDING an explicit `nil`) passes through unchanged so the
        `:params-schema`, not a blanket `(or params {})`, decides whether nil
        conforms (nil vs missing is schema-defined — Spec 016 §Resource
-       identity / EP-0012 §canonical-forms);
+       identity and Conventions §Canonical EDN identity);
     2. host / opaque value rejection at the cache-key boundary
        (`state/reject-non-edn!`, throwing `:rf.error/resource-non-edn-params`);
     3. schema conformance against the family `:params-schema` via the pluggable
@@ -80,8 +72,8 @@
       (let [validate (late-bind/get-fn-cached :schemas/validate-with-registered-fn)]
         (when (and validate (not (validate schema params)))
           (let [explain  (late-bind/get-fn-cached :schemas/explain-with-registered-fn)
-                ;; rf2-99j4e4 — the thrown error data (and any downstream egress)
-                ;; must not leak a `:sensitive?` params slot (nor ride a `:large?`
+                 ;; Thrown error data and downstream egress must not leak a
+                 ;; `:sensitive?` params slot (nor ride a `:large?`
                 ;; slot raw). Route `:params` + the explainer `:error` through the
                 ;; resources-family classification projection (the SAME per-slot
                 ;; owner surface SSR key egress uses + the shared schemas redaction

--- a/implementation/resources/src/re_frame/resources/registry.cljc
+++ b/implementation/resources/src/re_frame/resources/registry.cljc
@@ -16,7 +16,7 @@
   write/read (so an app can register a resource and Xray can enumerate the
   static registry) PLUS, for `clear-resource`, the per-frame runtime
   disposal of that resource id's live cache state. Per Spec 016
-  §clear-resource MUST-dispose (rf2-m9h5iq) `clear-resource` removes the
+  §clear-resource MUST-dispose, `clear-resource` removes the
   registrar entry AND disposes every live `:rf.runtime/resources` entry for
   the id across registered frames (entries + reverse indexes recomputed,
   stale / GC timers cancelled, in-flight work marked terminal + best-effort
@@ -293,24 +293,23 @@
                   "params (the resource's identity). Per Spec 016 §Resource "
                   "registration spec.")
              {:resource-id resource-id})))
-  ;; `:request` is REQUIRED for the only initial-scope transport.
+  ;; `:request` is REQUIRED for the built-in transport.
   (when-not (contains? spec :request)
     (throw (registration-error
              :rf.error/resource-bad-spec
              'rf/reg-resource
              (str "resource " resource-id " declares no :request. For "
-                  ":transport :rf.http/managed (the only initial-scope "
+                  ":transport :rf.http/managed (the only built-in "
                   "transport) :request returns a Spec 014 managed-HTTP args "
                   "map. Per Spec 016 §Resource registration spec.")
              {:resource-id resource-id})))
-  ;; `:poll-interval-ms` is OPTIONAL (EP-0020 §Polling). When present it MUST
+  ;; `:poll-interval-ms` is OPTIONAL (Spec 016 §Polling). When present it MUST
   ;; be a number of milliseconds — a non-positive / absent value means NO
   ;; polling (the disarm rule `timers/schedule!` applies to a non-positive
-  ;; delay), parallel to `:stale-after-ms` (still infinite-by-default,
-  ;; Spec 016 §Freshness clock contract). `:gc-after-ms` is NO LONGER
-  ;; parallel here (rf2-bbpu11): absent now normalizes to a finite default
-  ;; and any other non-positive/non-`:never` value is a loud registration
-  ;; error — see `normalize-gc-after-ms` below. A non-numeric
+  ;; delay), parallel to `:stale-after-ms` (infinite-by-default, Spec 016
+  ;; §Freshness clock contract). Absent `:gc-after-ms` normalizes to a finite
+  ;; default; any other non-positive/non-`:never` value is a loud registration
+  ;; error. A non-numeric
   ;; `:poll-interval-ms` (a string, keyword, etc.) is a typo in a
   ;; freshness-policy key — fail-closed loudly at the authoring boundary
   ;; rather than silently never poll.
@@ -352,48 +351,32 @@
              {:resource-id resource-id :axis axis :value (get spec axis)})))
   nil)
 
-;; ---- :gc-after-ms normalization (rf2-bbpu11 Option A) --------------------
+;; ---- :gc-after-ms normalization ------------------------------------------
 
 (def default-gc-after-ms
-  "The framework default for an ABSENT `:gc-after-ms` policy (rf2-bbpu11
-  Option A, ruled 2026-07-07): 300000ms (5 minutes). An owner-free cache
-  entry is the memory half of the same leak-boundary story `:scope` polices
-  on the identity half; leaving retention unbounded-by-default was the
-  defect (Run-2 design review, long-run-ops finding 3) — the corpus's own
-  revealed preference is a unanimous ~300000 in every in-tree registration,
-  and it matches TanStack Query's finite `gcTime` default (`:stale-after-ms`
-  deliberately keeps its own infinite default — see Spec 016 §Freshness
-  clock contract; the two knobs are philosophically distinct). Per Spec 016
-  §Resource registration spec / §Stale and GC scheduling."
+  "The framework default for an absent `:gc-after-ms` policy: 300000ms
+  (5 minutes). Owner-free entries therefore have bounded retention unless the
+  resource explicitly declares `:never`. `:stale-after-ms` retains its separate
+  infinite default. Per Spec 016 §Resource registration spec and §Stale and GC
+  scheduling."
   300000)
 
 (defn- normalize-gc-after-ms
-  "Normalize a `reg-resource` spec's `:gc-after-ms` declaration AT
-  REGISTRATION (rf2-bbpu11 Option A) so every other reader (the trace
-  emitted below, `registry/resource-meta`, the raw `positive-or-nil` read
-  sites in events.cljc / timers.cljc / mutation_events.cljc) sees one of
-  exactly three normalized shapes, never today's silent 'any non-number
-  becomes nil':
+  "Normalize a `reg-resource` spec's `:gc-after-ms` declaration at registration
+  so every downstream reader sees one of exactly three shapes:
 
     - ABSENT (the key is not in `spec`) -> `default-gc-after-ms` (300000ms) —
-      an owner-free entry now GCs by default instead of lingering forever.
+      an owner-free entry GCs by default;
     - `:never` -> itself, unchanged. The EXPLICIT, auditable, greppable
       opt-out for intentional unowned-entry pinning. `positive-or-nil`
-      already treats any non-number as 'arms no timer', so `:never` disarms
-      GC through the SAME mechanism an accidental bad value would have —
-      the difference is auditability: the stored spec (and the
-      `:rf.resource/registered` trace) now shows the caller's INTENT, not
-      an indistinguishable nil.
+      expresses an auditable opt-out;
     - a positive number -> itself, the caller's explicit policy, unchanged.
 
   Anything else — an explicit `nil`, zero, a negative number, a string, any
   keyword other than `:never` — is a typo in a freshness-policy key and
-  fails loudly (`:rf.error/resource-bad-spec`) rather than silently
-  reproducing the old infinite-by-default behaviour this bead closes.
-  Mirrors the `:poll-interval-ms` typo guard above, but stricter: GC's
-  silent-open failure mode (an unrecorded unbounded cache) is exactly the
-  defect being fixed, so an ambiguous value is never treated as an implicit
-  opt-out. Per Spec 016 §Resource registration spec."
+  fails loudly (`:rf.error/resource-bad-spec`); an ambiguous value is never
+  treated as an implicit unbounded-retention opt-out. Per Spec 016 §Resource
+  registration spec."
   [resource-id spec]
   (let [present? (contains? spec :gc-after-ms)
         v        (:gc-after-ms spec)]
@@ -408,7 +391,7 @@
                (str "resource " resource-id " declares a :gc-after-ms that is "
                     "neither absent, :never, nor a positive number of "
                     "milliseconds (got " (pr-str v) "). Absent defaults to "
-                    default-gc-after-ms "ms (5min, rf2-bbpu11); :never is the "
+                    default-gc-after-ms "ms (5min); :never is the "
                     "explicit, auditable opt-out for intentional "
                     "unowned-entry pinning; otherwise declare a positive "
                     "number of milliseconds. Per Spec 016 §Resource "
@@ -449,9 +432,9 @@
   Returns `resource-id` per the `reg-*` return-value convention
   ([Conventions §reg-* return-value convention])."
   [resource-id metadata request-fn]
-  ;; rf2-t65lqt — the metadata MIDDLE slot must be a map BEFORE any
+  ;; The metadata MIDDLE slot must be a map BEFORE any
   ;; `assoc`/`contains?` runs against it. Reconstructing `:request` onto a
-  ;; non-map metadata (the slip after the rf2-wvh95f F1 grammar change) would
+  ;; non-map metadata would
   ;; otherwise leak a raw host `IllegalArgumentException` ("Key must be
   ;; integer") instead of the public `:rf.error/resource-bad-spec`. Mirrors
   ;; reg-route's `route-bad-metadata` non-map guard + reg-app-schema's
@@ -462,12 +445,12 @@
              :rf.error/resource-bad-spec
              'rf/reg-resource
              (str "resource " resource-id "'s metadata (the MIDDLE slot) must "
-                  "be a map, got " (pr-str (type metadata)) ". Per rf2-wvh95f "
-                  "F1 the grammar is (reg-resource " resource-id " {…} "
+                  "be a map, got " (pr-str (type metadata)) ". The grammar is "
+                  "(reg-resource " resource-id " {…} "
                   "request-fn): the reflection/config metadata map is the "
                   "SECOND slot, the :request handler is the THIRD.")
              {:resource-id resource-id :value metadata})))
-  ;; rf2-wvh95f F1 — `:request` is the 3-slot VALUE (the handler). A `:request`
+  ;; `:request` is the third-slot VALUE (the handler). A `:request`
   ;; left INSIDE the metadata map is a mislocated key; reject it loudly so the
   ;; grammar change cannot be half-applied (a stray fused `:request` would
   ;; otherwise silently win or lose against the value-slot one).
@@ -476,7 +459,7 @@
              :rf.error/resource-bad-spec
              'rf/reg-resource
              (str "resource " resource-id " declares :request inside its "
-                  "metadata map — per rf2-wvh95f F1 the request handler is the "
+                  "metadata map — the request handler is the "
                   "THIRD slot: (reg-resource " resource-id " {…} request-fn). "
                   "Move the fetch fn out of the metadata map into the value "
                   "slot.")

--- a/implementation/resources/src/re_frame/resources/scope_registry.cljc
+++ b/implementation/resources/src/re_frame/resources/scope_registry.cljc
@@ -291,12 +291,12 @@
              :rf.error/invalid-resource-scope-spec
              'rf/reg-resource-scope
              (str "resource-scope " scope-id "'s metadata (the MIDDLE slot) must "
-                  "be a map, got " (pr-str (type metadata)) ". Per rf2-bqstzr the "
-                  "grammar is (reg-resource-scope " scope-id " {…} resolve-fn): "
+                  "be a map, got " (pr-str (type metadata)) ". The grammar is "
+                  "(reg-resource-scope " scope-id " {…} resolve-fn): "
                   "the :inputs / :doc reflection-config metadata map is the "
                   "SECOND slot, the :resolve fn is the THIRD.")
              {:scope-id scope-id :value metadata})))
-  ;; rf2-bqstzr — `:resolve` is the 3-slot VALUE (the resolver handler). A
+  ;; `:resolve` is the third-slot VALUE (the resolver handler). A
   ;; `:resolve` left INSIDE the metadata map is a mislocated key; reject it
   ;; loudly so the grammar change cannot be half-applied.
   (when (contains? metadata :resolve)
@@ -304,7 +304,7 @@
              :rf.error/invalid-resource-scope-spec
              'rf/reg-resource-scope
              (str "resource-scope " scope-id " declares :resolve inside its "
-                  "metadata map — per rf2-bqstzr the resolver fn is the THIRD "
+                  "metadata map — the resolver fn is the THIRD "
                   "slot: (reg-resource-scope " scope-id " {…} resolve-fn). Move "
                   "the resolver out of the metadata map into the value slot.")
              {:scope-id scope-id :value (:resolve metadata)})))

--- a/implementation/resources/src/re_frame/resources/ssr.cljc
+++ b/implementation/resources/src/re_frame/resources/ssr.cljc
@@ -13,11 +13,12 @@
   preserved, fresh ones avoid a duplicate fetch, stale ones
   background-refetch by event, and hydration NEVER crosses scopes.
 
-  ## What lives here (the SSR slice, rf2-ctk2av)
+  ## What lives here
 
-  This namespace is PURE / host-agnostic. SSR runs on the JVM, so the
-  whole body is reader-conditional CLJC and the heavy lifting is plain
-  data transforms the host adapter / route slice drives:
+  Most projection and reconciliation helpers are plain data transforms. The
+  integration surface also emits lifecycle traces, clears resource-owned host
+  transients during restore, and offers a direct frame-targeted hydration
+  installer, so the namespace as a whole is not pure.
 
   - **Server projection** — `project-resources-runtime-db` (the body
     behind the `:ssr/extend-runtime-db-projection` hook) projects the
@@ -45,13 +46,13 @@
 
   Resource hydration uses an EXPLICIT projection hook — the
   allowlist-by-subsystem-child `project-runtime-db` of [011-SSR]. Rather
-  than statically `:require`ing SSR (which would drag the SSR body into
+  than statically `:require`ing the separate SSR artefact (which would drag it into
   every resources app), resources publishes the LATE-BOUND
   `:ssr/extend-runtime-db-projection` hook (server projection) and the
   `:resources/hydrate-runtime-db` hook (client reconcile); SSR consults
-  them. The wiring is late-bound BOTH ways — an app that loads resources
-  but does not SSR carries none of this code path, and an SSR app without
-  resources sees no behaviour change.
+  them. The resources artefact always carries these resource-owned projection
+  helpers, but does not pull in `day8/re-frame2-ssr`. An SSR app without
+  resources sees no resource hook or behaviour change.
 
   Only the durable resource projection (`:rf.runtime/resources` →
   `:entries`) rides the wire; `:tag-index` / `:owner-index` are
@@ -75,9 +76,9 @@
 
 ;; `hydrate-runtime-db` (the reconcile) computes the client refetch plan via
 ;; `hydrate-refetch-plan` (defined below) on the `:rf/hydrate` install path
-;; (rf2-fopuj9), so the latter is forward-declared. It also settles a hydrated
+;; so the latter is forward-declared. It also settles a hydrated
 ;; non-terminal entry whose `:current-work` was stripped on the wire to its last
-;; stable status via `settle-entry-to-last-stable` (rf2-bg6qah), shared with the
+;; stable status via `settle-entry-to-last-stable`, shared with the
 ;; restore path — forward-declared for the same file-order reason.
 (declare hydrate-refetch-plan)
 (declare settle-entry-to-last-stable)
@@ -247,21 +248,20 @@
 (defn disposition+project-key
   "Resolve a scoped key's resource OWNER spec, compute its whole-entry
   disposition, and project the key accordingly — the shared
-  disposition+project-key pipeline (rf2-366u0g). Returns
+  disposition+project-key pipeline. Returns
   `[projected-key disposition spec]`:
 
     1. `spec`        ← `registry/resource-meta` of `scoped-key`'s resource-id;
     2. `disposition` ← `classification/whole-entry-disposition spec`
-       (the coarse owner `:sensitive?` / `:large?` root-prop claim). EP-0025
-       (rf2-71dr8t) removed the named-scope-resolver derived-sensitivity
-       inheritance arm, so the disposition no longer depends on `frame-id`;
+       (the coarse owner `:sensitive?` / `:large?` root-prop claim; scope
+       resolver inputs never propagate classification to the output);
     3. projected key ← `project-scoped-key scoped-key disposition spec`
        (`:redact` / `:omit` replace scope + params with opaque content-addressed
        `{:rf/redacted <digest>}` tokens; `:serialize` rides VERBATIM — the
        resource-id always survives. A `:serialize` key's per-slot `:params` /
        `:scope` projection-relative declarations are the registry-driven concern
        of the SSR `project-entry` caller, `classification/project-entry-params`,
-       which has the entry's `key-id` + the live frame — rf2-d3pku1).
+       which has the entry's `key-id` + the live frame).
 
   The single home for the pipeline the SSR durable-egress projection
   (`project-entry`), the TOOL-egress algebra view (`tooling/project-key-for-
@@ -277,8 +277,7 @@
   it in `classification` would introduce a require cycle. `ssr` already
   requires both `classification` and `registry`, and the trace / tool egress
   callers already require `ssr`. The `frame-id` arg is retained for caller
-  signature stability (it no longer affects the disposition — EP-0025
-  rf2-71dr8t removed the derived-sensitivity inheritance arm)."
+  signature stability; whole-entry disposition is frame-independent."
   [scoped-key _frame-id]
   (let [resource-id (second scoped-key)
         spec        (registry/resource-meta resource-id)
@@ -288,8 +287,8 @@
 (defn- project-entry
   "Project a single durable cache `entry` (under `scoped-key`) to its wire
   shape per its classification, against the SSR `frame-id` (so the shared
-  elision walker resolves the resource's declared sensitive / large schema
-  paths). Returns `[wire-entry metadata]` where `metadata` records the
+  elision walker resolves the resource's projection-relative declarations from
+  the frame registry). Returns `[wire-entry metadata]` where `metadata` records the
   per-entry projection decision (Spec 016 §SSR and hydration step 7):
 
     {:resource/key   scoped-key
@@ -446,7 +445,8 @@
 
   Resolves the SSR frame from the in-effect carried-frame scope (the shared
   `rf/elide-wire-value` walker reads it) so the resource's declared
-  sensitive / large schema paths govern the per-entry projection. The
+  projection-relative sensitive / large declarations in the frame registry
+  govern the per-entry projection. The
   projection NEVER ships all of `:rf.db/runtime` — only the
   `:rf.runtime/resources` `:entries` (Spec 016 §SSR and hydration: \"Do not
   serialize all of `:rf.db/runtime` by default\").
@@ -1528,7 +1528,7 @@
 ;;   - metadata-only (redacted /   -> refetch ONLY if the route still needs
 ;;     omitted; no usable data)       it (a live owner / the route's plan).
 ;;
-;; The load-bearing correctness boundary (rf2-fopuj9): a REDACTED entry rides
+;; A REDACTED entry rides
 ;; the wire with its `:data` REPLACED by the redaction sentinel
 ;; (`privacy/redacted-sentinel` = `:rf/redacted`) — it is METADATA ONLY, NOT
 ;; usable data. A naive `(some? (:data entry))` would see the sentinel as
@@ -1568,7 +1568,7 @@
   route still NEEDS the entry; this predicate answers \"is the hydrated value
   sufficient on its own?\"). A REDACTED entry's sentinel `:data` is NOT usable
   (`hydrated-data-usable?`), so it is treated as metadata-only — never as
-  fresh-with-data (rf2-fopuj9)."
+  fresh-with-data."
   [entry clock-ms]
   (let [usable? (hydrated-data-usable? entry)]
     (cond

--- a/implementation/resources/src/re_frame/resources/test_support.cljc
+++ b/implementation/resources/src/re_frame/resources/test_support.cljc
@@ -4,8 +4,7 @@
   This namespace is the home for resources test-only fixtures and reset
   helpers — kept OUT of the always-on `re-frame.resources` production
   façade so a test-runner-internal surface never reaches a production
-  registry (the rf2-dbiv8 / rf2-cdmle posture: test fixtures live behind
-  an explicit test-support require, mirroring
+  registry. Test fixtures live behind an explicit test-support require, mirroring
   `re-frame.routing.test-support` and `re-frame.http.test-support`).
 
   Production posture: this namespace is unreferenced from any production
@@ -47,34 +46,34 @@
   CLJS `make-reset-runtime-fixture` reset-hooks table via the
   `:resources/reset-resources!` late-bind hook this namespace publishes
   at ns-load (kept behind this explicit test-support require so the
-  production façade carries no test-fixture surface — rf2-dbiv8). Per
+  production façade carries no test-fixture surface). Per
   Spec 016 (test isolation)."
   []
   (registrar/clear-kind! registry/resource-kind)
-  ;; clear the :mutation registrar kind too (rf2-dwme29) — the mutation
+  ;; Clear the mutation registrar kind too; the mutation
   ;; registry is the causal-write counterpart of the resource registry.
   (registrar/clear-kind! mutation-registry/mutation-kind)
-  ;; and the :resource-scope registrar kind (rf2-hls77w) — the named
-  ;; scope-resolver registry (EP-0016 D3). Pure resolvers hold no per-frame
+  ;; Also clear the named resource-scope resolver registry. Pure resolvers hold
+  ;; no per-frame
   ;; runtime state, so clearing the registrar kind is the whole reset.
   (registrar/clear-kind! scope-registry/scope-kind)
   (state/reset-cache!)
-  ;; drop the host-side work-ledger handles too (rf2-afpdkn) — also
+  ;; Drop the host-side work-ledger handles too; they are
   ;; host-side transient state not cleared by the runtime / frames reset.
   (work-ledger/reset-cache!)
-  ;; and the host-side stale / GC timer handles (rf2-nbjewi) — likewise
+  ;; Cancel and drop host-side stale / GC timer handles; likewise
   ;; host-side transient state; cancels any armed timers so a leftover timer
   ;; cannot fire into a later test's frame.
   (timers/reset-cache!)
-  ;; and the host-side focus/reconnect revalidation listeners (rf2-vtblcq) —
+  ;; Remove host-side focus/reconnect revalidation listeners;
   ;; likewise host-side transient state; detaches any installed window
   ;; listeners so a leftover listener cannot dispatch into a later test's frame.
   (revalidate-listeners/reset-cache!)
-  ;; and the host-side scope-mismatch dev-warning dedupe set (rf2-rsmiru) —
+  ;; Clear the host-side scope-mismatch dev-warning dedupe set;
   ;; host-side transient dev state; clearing it lets each test observe the
   ;; one-shot warning freshly without a prior test's emission masking it.
   (subs/reset-scope-mismatch-warnings!)
-  ;; and the framework-owned `:rf.resource/items` merge memo (EP-0021 R3) —
+  ;; Clear the framework-owned `:rf.resource/items` merge memo;
   ;; host-side transient derivation cache (the infinite-feed merged-list
   ;; projection), not runtime-db; cleared so a prior test's feed merge cannot
   ;; be served for a later test's `=`-equal page vector.

--- a/implementation/resources/src/re_frame/resources/tooling.cljc
+++ b/implementation/resources/src/re_frame/resources/tooling.cljc
@@ -1,13 +1,12 @@
 (ns re-frame.resources.tooling
-  "Resources tooling sibling of `re-frame.resources` — carries the EP-0014
-  slice-4 derivation/process algebra view of registered resources
+  "Resources tooling sibling of `re-frame.resources` — carries the
+  derivation/process algebra view of registered resources
   (`resource-algebra-view`, the STATIC view) and of a frame's live cache
   entries (`resource-cache-algebra-view`, the LIVE view) that pair tools
   (Xray, re-frame2-pair-mcp) and the conformance fixtures query, but no
   production application code reads.
 
-  Mirrors the rf2-s8w3nw `re-frame.flows.tooling` split (slice-3) and the
-  rf2-bmzq0 `re-frame.subs.tooling` split (slice-2) before it:
+  Bundle boundary:
     - CLJS consumers needing the surface call
       `re-frame.resources.tooling/<name>` directly. An app that loads the
       resources artefact but never attaches a tool DCEs the body wholesale
@@ -25,8 +24,7 @@
   READ-ONLY over the registry + runtime. This ns touches NEITHER the
   resource registrar write-path (`reg-resource` / `clear-resource`,
   `re-frame.resources.registry`) NOR the resource events / mutation
-  write-path (`re-frame.resources.events`) — exactly as slice-3's
-  flows.tooling read the flow registry without touching its registrar.
+  write-path (`re-frame.resources.events`).
   The STATIC view reads the `:resource` registry through the existing
   `resource-meta` / `resource-ids` introspection seams; the LIVE view reads
   the per-frame `:rf.runtime/resources` entries + `:rf.runtime/work-ledger`
@@ -34,7 +32,7 @@
   same seam `re-frame.resources/resources` + the SSR drain read).
 
   Per [Derivations.md](../../../../../../spec/Derivations.md) §Resources
-  expose process nodes (graduated from EP-0014) and the projected Malli
+  expose process nodes and the projected Malli
   shapes in [Spec-Schemas §`:rf/derivation-node`](../../../../../../spec/Spec-Schemas.md)."
   (:require [re-frame.derivation.node :as node]
             [re-frame.frame :as frame]
@@ -48,10 +46,10 @@
 
 #?(:clj (set! *warn-on-reflection* true))
 
-;; ---- algebra views (EP-0014 slice-4) -------------------------------------
+;; ---- algebra views --------------------------------------------------------
 ;;
-;; Per [Derivations.md] §Resources expose process nodes (graduated from
-;; EP-0014) and the projected Malli shapes in [Spec-Schemas
+;; Per [Derivations.md] §Resources expose process nodes and the projected Malli
+;; shapes in [Spec-Schemas
 ;; §`:rf/derivation-node`]. A resource is the canonical PROCESS member of
 ;; the derivation/process algebra (Derivations §Process — "Resources and
 ;; machines are processes"), distinct from the subscription / flow
@@ -62,16 +60,11 @@
 ;; derived read facts (the `:rf.resource/*` selectors) over that entry —
 ;; the latter are surfaced under `:selectors` on the process node, not
 ;; minted as separate nodes here (they are ordinary subscriptions, already
-;; covered by slice-2's sub view).
+;; covered by the subscription algebra view).
 ;;
-;; This is the *registrar-derived* slice (Derivations §The EP-0013
-;; relocation seam): the static algebra view is assembled from the
-;; resource-spec metadata at the surface that registered it, NOT (yet) from
-;; an EP-0013 app value. It feeds the later internal graph-inspection helper
-;; (EP-0014 bead-plan item 7); slice-4 ships NO public accessor — these
-;; functions live in the bundle-isolated tooling sibling, consumed by Xray +
-;; the conformance fixtures (the two named first consumers). No
-;; `re-frame.core` facade export (EP-0014 issue-1 disposition).
+;; The static algebra view is assembled from registered resource metadata.
+;; These functions live in the bundle-isolated tooling sibling and have no
+;; `re-frame.core` facade export.
 ;;
 ;; The fixed classifications for EVERY resource process node (Derivations
 ;; §Resources expose process nodes):
@@ -84,7 +77,7 @@
 ;; the OUTPUT runtime-db address, the `:authority` transport, and (for a
 ;; `{:from-db <id>}` scope) the named-resolver enrichment.
 ;;
-;; A resource consumes the slice-1 vocabulary verbatim — it does NOT
+;; A resource consumes the shared vocabulary verbatim — it does NOT
 ;; redefine the `:rf/storage-class` / `:rf/evaluation-policy` / `:rf/lifecycle`
 ;; enums or the `:rf/derivation-node` shape (those are owned by Spec-Schemas /
 ;; Derivations).
@@ -106,8 +99,7 @@
   "The LOCAL storage class of a resource process node (Derivations
   §Resources expose process nodes): the cache entry lives in the
   framework-owned `runtime-db` partition. The REMOTE authority is the
-  separate `:authority` axis — `:remote` is NOT a storage class (EP-0014
-  issue-2 split)."
+  separate `:authority` axis — `:remote` is NOT a storage class."
   :runtime-db)
 
 (def resource-lifecycle
@@ -168,7 +160,7 @@
   (`:kind :remote`, `:system :server`); `:transport` MIRRORS the registered
   transport (a recomputable PROJECTION of the Spec 016 registration fact —
   never a second authoritative home). `transport-id` is the spec's
-  `:transport`, defaulting to the only initial-scope transport
+  `:transport`, defaulting to the only built-in transport
   (`transport/default-transport`, `:rf.http/managed`)."
   [transport-id]
   {:kind      :remote
@@ -566,16 +558,15 @@
 
 ;; ---- bundle-isolation sentinel ------------------------------------------
 ;;
-;; Per rf2-s8w3nw / rf2-bmzq0 / rf2-qwm0a (the flows.tooling + subs.tooling +
-;; trace.tooling split pattern): `implementation/scripts/check-bundle-isolation.cjs`
-;; greps the counter bundle for this exact string. The string lives ONLY in
+;; `implementation/scripts/check-bundle-isolation.cjs` greps the counter bundle
+;; for this exact string. The string lives ONLY in
 ;; this file's source body — no other namespace, no docstring, no test
 ;; fixture references it — so its presence in the production counter bundle
 ;; proves the tooling sibling's body got pulled in (most likely via a stray
 ;; `:require` from a production-reachable ns). The whole resources artefact is
 ;; already bundle-isolated from counter (counter never `:require`s
-;; `re-frame.resources`), so this sentinel is the belt-and-braces guard the
-;; sibling pattern standardises. The string survives `:advanced` because
+;; `re-frame.resources`); this sentinel independently catches a stray
+;; production-reachable require. The string survives `:advanced` because
 ;; string literals are not renamed; it sits outside any gate so DCE cannot
 ;; drop the literal independently of the surrounding ns body.
 

--- a/implementation/resources/src/re_frame/resources/trace_egress.cljc
+++ b/implementation/resources/src/re_frame/resources/trace_egress.cljc
@@ -1,11 +1,10 @@
 (ns re-frame.resources.trace-egress
-  "OFF-BOX trace-row egress projection for the resource + mutation trace family
-  (rf2-8x0gfa / EP-0015).
+  "OFF-BOX trace-row egress projection for the resource + mutation trace family.
 
   ## Why this namespace exists
 
-  `re-frame.resources.scope-registry/project-scope-resolved-egress` (rf2-84l82t)
-  projects ONE row — `:rf.resource/scope-resolved` — redacting the resolver's
+  `re-frame.resources.scope-registry/project-scope-resolved-egress` projects
+  `:rf.resource/scope-resolved`, redacting the resolver's
   resolved `:input-values` / `:scope`. But the broader resource/mutation trace
   family (`:rf.resource/*` + `:rf.mutation/*` rows emitted from
   `re-frame.resources.events` / `…timers` / `…mutation-events`) copies the SAME
@@ -22,13 +21,13 @@
       `revalidate-scan` / the `:rf.mutation/succeeded` settlement / the
       `:rf.mutation/optimistic-rolled-back` rollback);
     - `:dispositions` — the optimistic-rollback per-key maps each embedding a
-      `:resource/key` (EP-0019 §Surfacing to tooling).
+      `:resource/key`.
 
   A generic value-path egress walk (the central trace-egress chokepoint) is
   STRUCTURALLY BLIND to these once copied into trace tags — a frame's declared
   `:sensitive`/`:large` app-db PATHS do not match a resolver-owned scoped key's
-  embedded scope/params (EP-0015; the resource trace family is an egress record
-  set, Spec 015 §10 / Derivations §Resources expose process nodes). So the
+  embedded scope/params (Spec 015 §10 / Derivations §Resources expose process
+  nodes). So the
   resource family owns ONE family-level trace-row egress projector — the
   slot-keyed analogue of `project-scope-resolved-egress` — consumed off-box
   through the late-bound `:resources/project-resource-trace-egress` hook the
@@ -58,10 +57,9 @@
   cannot read is not provably safe, so this projector REDACTS an
   unregistered-owner key (and stamps `:sensitive? true`). The unregistered arm
   fails closed independently of any frame. Structural attribution survives every
-  case: the resource-id (position 1 of the projected key) and every NON-key tag
-  ride verbatim, so a tool still attributes the row to its resource and reads the
-  structural facts; only the identity-bearing scope + params components are
-  tokenized.
+  case: the resource-id (position 1 of the projected key) and recognized
+  structural scalar tags ride verbatim, so a tool can still attribute the row.
+  Unknown map-valued tags fail closed rather than bypassing projection.
 
   The redaction is the off-box DEFAULT; the trusted-local `:include-sensitive?`
   opt-in lifts it at the epoch consumer (the `local-raw` boundary — the same
@@ -76,7 +74,7 @@
 
 (defn- project-trace-scoped-key
   "Fail-closed projection of one trace-row `scoped-key`
-  `[scope resource-id params]` for OFF-BOX trace egress (rf2-8x0gfa). Returns
+  `[scope resource-id params]` for OFF-BOX trace egress. Returns
   `[projected-key sensitive?]`. For a REGISTERED owner the scope + params
   tokenize per the owner's `whole-entry-disposition` classification (a
   `:sensitive?` / `:large?` key redacts to opaque content-addressed
@@ -98,7 +96,7 @@
     ;; fail closed — owner unreadable, redact scope + params, keep the id. This
     ;; nil-spec fail-closed-to-`:redact` (and the idempotent-token guard above)
     ;; is the OUTER wrapper the trace-egress family keeps around the shared
-    ;; disposition+project-key pipeline (rf2-366u0g): tooling / SSR egress treat
+    ;; disposition+project-key pipeline: tooling / SSR egress treat
     ;; an unregistered owner as `:serialize` (the algebra read), but a TRACE row
     ;; whose owner we cannot read is not provably safe.
     (nil? (registry/resource-meta (second scoped-key)))
@@ -135,12 +133,12 @@
     ;; keys (Spec 016 §Mutation completion continuations). A vector of scoped
     ;; keys exactly like `:matched` / `:removed`, so it is PER-KEY projected
     ;; here (preserving a tool's per-key joins) rather than falling to the
-    ;; fail-closed default below as one coarse digest (rf2-7qbxbm).
+    ;; fail-closed default below as one coarse digest.
     :affected-keys})
 
 (def ^:private error-envelope-slot
   "Tag slots that carry an HTTP FAILURE ENVELOPE — the `:rf.http/*` reply's
-  `{:status :body :body-text :detail …}` map (rf2-7qbxbm). The
+  `{:status :body :body-text :detail …}` map. The
   `:rf.resource/failed` first-load row + the `:rf.mutation/failed` settlement
   row stamp the envelope under `:error`; the `:rf.resource/page-failed`
   load-more row stamps it under `:page-error`. The raw response body
@@ -167,7 +165,7 @@
   enum), so the sibling always redacts `:input-values` / `:scope` to
   `:rf/redacted`. They must therefore PASS THROUGH this projector's fail-closed
   map default unchanged — they were already classified upstream (an already-
-  redacted token re-redacts to itself; rf2-7qbxbm)."
+  redacted token re-redacts to itself)."
   #{:input-values :scope})
 
 (def ^:private cursor-slot
@@ -216,7 +214,7 @@
   `:rf.mutation/succeeded` `:patch-summary` (embeds `:removed` / `:committed` /
   `:rollback` / …) + its descriptor-level `:invalidation` evidence (embeds the
   `:populate-exempt` key union). Projected recursively through the SAME slot
-  vocabulary so a row's nested scoped keys never leak (rf2-8x0gfa)."
+  vocabulary so a row's nested scoped keys never leak."
   #{:patch-summary :invalidation})
 
 (declare project-tags*)
@@ -224,7 +222,7 @@
 (defn- project-disposition-row
   "Project one optimistic-rollback disposition row
   `{:resource/key <scoped-key> :restored … :conflict … :on-conflict …}` for
-  off-box egress (rf2-8x0gfa / EP-0019 §Surfacing to tooling): the scoped key
+  off-box egress: the scoped key
   is fail-closed-projected; the boolean disposition facts ride verbatim.
   Returns `[projected-row sensitive?]`. A non-map row rides unchanged. Pure."
   [row frame-id]
@@ -343,7 +341,7 @@
 
 (defn project-resource-trace-egress
   "Project a resource / mutation trace row's `tags` for OFF-BOX egress against
-  the `frame-id` classification (rf2-8x0gfa / EP-0015). The family-level
+  the `frame-id` classification. The family-level
   analogue of `re-frame.resources.scope-registry/project-scope-resolved-egress`,
   keyed on the resource trace family's scoped-key-bearing tag VOCABULARY rather
   than per-operation: every `:resource/key` (single scoped key), every
@@ -359,9 +357,9 @@
   values stay distinct, so a tool's per-key joins survive); a plain owner's key
   rides verbatim; an UNREGISTERED owner FAILS CLOSED (redacted — the
   trace-egress default). The resource-id (position 1 of every projected key) and
-  every NON-key tag (`:rf.frame/id`, `:cause`, `:tags`, `:decision`,
-  `:generation`, `:owner`, `:work/id`, `:delay-ms`, counts, …) ride verbatim —
-  structural attribution is preserved. When ANY projected slot redacted a
+  recognized structural scalar tags (`:rf.frame/id`, `:cause`, `:decision`,
+  `:generation`, `:owner`, `:work/id`, `:delay-ms`, counts, …) ride verbatim;
+  unknown map-valued tags fail closed. When ANY projected slot redacted a
   sensitive / unregistered key, the row is stamped `:sensitive? true`.
 
   The load-more PAGINATION CURSOR — `:page-param` (on `:rf.resource/load-more`)
@@ -372,7 +370,7 @@
   sibling `:resource/key`): tokenized to a content-addressed `{:rf/redacted
   <digest>}` when that owner is non-`:serialize` (sensitive / large /
   unregistered fail-closed), riding verbatim for a plain feed (no
-  over-redaction) — rf2-3tysyj.
+  over-redaction).
 
   Nested-map slots (`:patch-summary` / `:invalidation`) are projected
   RECURSIVELY through the same vocabulary so a row's nested scoped keys never

--- a/implementation/resources/src/re_frame/resources/transport.cljc
+++ b/implementation/resources/src/re_frame/resources/transport.cljc
@@ -2,12 +2,12 @@
   "Transport-neutral seam between the resource runtime and the concrete
   read transport. Per Spec 016 §Transport.
 
-  The initial scope ships a SINGLE built-in transport — `:rf.http/managed`
+  The artefact ships a SINGLE built-in transport — `:rf.http/managed`
   (Spec 014). The resource lifecycle, cache identity, owner model,
   stale/fresh policy, invalidation, SSR hydration, and Xray surfaces are
   nonetheless transport-NEUTRAL: the core assumes no URL, HTTP method,
-  status code, or body, so the deferred GraphQL transport (and any later
-  transport) can plug in without weakening the core semantics. This
+  status code, or body, so another transport can be added without weakening
+  the core semantics. This
   namespace owns the neutral surface the runtime depends on: the
   `default-transport` constant the registration path defaults to, and the
   `assert-managed-transport!` registration-time misconfig guard. The HTTP
@@ -17,29 +17,28 @@
   There is intentionally NO dispatch table here: with a single built-in
   transport a dispatch indirection has exactly one live arm, so the runtime
   guards the declared transport at the call site and lowers into
-  `transport.http/lower`. A real dispatch table is reintroduced only when a
-  second transport (the deferred GraphQL one) lands — at which point the
-  guard becomes the dispatch."
+  `transport.http/lower`. A dispatch table is warranted only when a second
+  transport exists."
   (:require [re-frame.error :as error]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
 (def managed-http-transport
-  "The only initial-scope transport id (`:rf.http/managed`, Spec 014).
+  "The only built-in transport id (`:rf.http/managed`, Spec 014).
   Per Spec 016 §Transport."
   :rf.http/managed)
 
 (def default-transport
   "The default `:transport` for a resource that does not declare one —
   managed HTTP. Per Spec 016 §Resource registration spec (optional
-  `:transport`, initial scope: `:rf.http/managed`, the only built-in)."
+  `:transport`; `:rf.http/managed` is the only built-in)."
   managed-http-transport)
 
 (defn assert-managed-transport!
   "Registration-time misconfig guard: the runtime call sites
   (`events`/`mutation-events`) invoke this with a resource/mutation's
   declared `:transport` (defaulted to `default-transport`) BEFORE lowering
-  into `transport.http/lower`. The only initial-scope transport is
+  into `transport.http/lower`. The only built-in transport is
   `:rf.http/managed`; any other declared transport is a loud
   `:rf.error/resource-unknown-transport` misconfig (`:recovery
   :fix-registration`). Returns `transport` on success.
@@ -49,14 +48,13 @@
   `:rf.frame/id`, `:work/id`, `:resource/key`, `:scope`, and
   `:generation`, and success/failure handlers MUST verify frame + work-id
   + generation before writing (cancellation is an optimization; stale
-  suppression is the correctness boundary). When a second transport lands
-  this guard becomes a real dispatch over the declared transport."
+  suppression is the correctness boundary)."
   [transport where]
   (when-not (= transport managed-http-transport)
     (error/throw-error!
       :rf.error/resource-unknown-transport (or where 're-frame.resources.transport/assert-managed-transport!)
       (str "unknown resource transport " transport
-           " — the only initial-scope transport is "
+           " — the only built-in transport is "
            managed-http-transport
            " (Spec 016 §Transport).")
       {:recovery :fix-registration

--- a/implementation/resources/src/re_frame/resources/transport/http.cljc
+++ b/implementation/resources/src/re_frame/resources/transport/http.cljc
@@ -1,6 +1,6 @@
 (ns re-frame.resources.transport.http
   "The managed-HTTP read transport for resources — the single built-in
-  transport in the initial scope. Per Spec 016 §Transport.
+  transport. Per Spec 016 §Transport.
 
   The resource runtime first creates or joins a work-ledger record, then
   lowers an ensure/refetch into managed HTTP (`:rf.http/managed`, Spec
@@ -23,11 +23,10 @@
   one work id, one name). It is NOT `:work-id`.
 
   The managed-HTTP artefact (`day8/re-frame2-http`, `re-frame.http.managed`)
-  is reached LATE-BOUND — resources never statically `:require`s it, so an
-  app that loads resources but issues no HTTP-backed reads (or supplies a
-  later transport) does not drag the HTTP body. The runtime emits the
-  `:rf.http/managed` fx through the ordinary effect path; this namespace
-  builds the args map (request-id + reply addressing).
+  is reached LATE-BOUND — resources never statically `:require`s that artefact.
+  This namespace contains only the resources-owned lowering and args-map
+  construction; the app must load the HTTP artefact to register the emitted
+  `:rf.http/managed` effect.
 
   The lowering ships here: `lower` mints the request-id and stamps the
   work-ledger correlation (`:work/id` / `:resource/key` / `:scope` /

--- a/implementation/resources/src/re_frame/resources/work_ledger.cljc
+++ b/implementation/resources/src/re_frame/resources/work_ledger.cljc
@@ -737,7 +737,7 @@
 
 (def managed-abort-fx-transport
   "The transport id whose opportunistic abort rides `:rf.http/managed-abort`
-  (managed HTTP). Per Spec 016 §Transport (the single initial-scope
+  (managed HTTP). Per Spec 016 §Transport (the single built-in
   transport)."
   :rf.http/managed)
 

--- a/implementation/resources/test/re_frame/resources_infinite_ssr_restore_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_infinite_ssr_restore_cljs_test.cljc
@@ -1,9 +1,8 @@
 (ns re-frame.resources-infinite-ssr-restore-cljs-test
-  "ACCEPTANCE: an infinite feed rides the EXISTING SSR projection + epoch-restore
-  paths with ZERO new runtime code (EP-0021 build wave 5; Spec 016 §Durable
-  cache shape (R1) / §SSR and hydration / §Restore and replay).
+  "An infinite feed rides the ordinary SSR projection and epoch-restore paths
+  (Spec 016 §Durable cache shape, §SSR and hydration, §Restore and replay).
 
-  The wave-1..4 design claim is structural: an infinite feed is the SAME
+  The contract is structural: an infinite feed is the SAME
   `:rf/resource-entry` whose `:data` is an ordered PAGE VECTOR, living in one
   `:rf.runtime/resources :entries` slot (R1 — no new entry kind, no new
   runtime-db subsystem). So it MUST ride the projection + reconcile the scalar
@@ -30,9 +29,8 @@
         correctly to FALSE — the in-flight load-more does NOT dangle as a phantom
         `fetching-next?` against the restored feed.
 
-  Test-only (rf2-878m79): NO runtime / spec change. If a durable page fact did
-  NOT ride a path, that is a runtime gap to file, not patch here. The whole suite
-  rides existing fns — that it passes IS the acceptance."
+  The suite uses the production projection and reconciliation functions; any
+  lost durable page fact is a runtime regression."
   (:require
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])

--- a/implementation/resources/test/re_frame/resources_infinite_subs_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_infinite_subs_cljs_test.cljc
@@ -1,10 +1,8 @@
 (ns re-frame.resources-infinite-subs-cljs-test
-  "The infinite-feed subscription family (EP-0021 wave 4, Spec 016
-  §Subscription contract — the merged list and page metadata (R3)).
+  "The infinite-feed subscription family (Spec 016 §Subscription contract).
 
-  Waves 1-3 landed the durable feed entry (`:data` = the ordered page vector),
-  the `:rf.resource/load-more` event, and the page reply handlers. This slice
-  is the READ side — the framework-owned, MEMOISED projection family:
+  The durable feed entry stores `:data` as an ordered page vector. This suite
+  covers the framework-owned, memoised read projections:
 
     - `:rf.resource/items` — the merged / flattened list (the HEADLINE read);
     - `:rf.resource/pages` — the raw ordered page vector;

--- a/implementation/resources/test/re_frame/resources_invalid_params_redaction_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_invalid_params_redaction_cljs_test.cljc
@@ -1,23 +1,18 @@
 (ns re-frame.resources-invalid-params-redaction-cljs-test
-  "rf2-99j4e4 — resource / mutation params-schema validation FAILURE error data
-  must not leak a `:sensitive?` params slot (nor ride a `:large?` slot raw).
+  "Resource / mutation params-schema validation failure data must not leak a
+  `:sensitive?` params slot or ride a `:large?` slot raw.
 
   `validate+canonicalize-params` (resource registry + mutation registry) runs
   the pluggable Malli validator against the resource / mutation `:params-schema`
-  and, on a conformance failure, THROWS `:rf.error/resource-invalid-params` /
-  `:rf.error/mutation-invalid-params`. Before this fix the thrown `ex-data`
-  carried the RAW params under `:params` AND the registered explainer's output
-  under `:error` (whose Malli `:value` slots carry the raw params too). A params
-  schema marking a sibling slot `{:sensitive? true}` therefore leaked the secret
-  through public thrown error data and any error-capture / logging path whenever
-  validation failed on a DIFFERENT (non-sensitive) field.
+  and, on a conformance failure, throws `:rf.error/resource-invalid-params` /
+  `:rf.error/mutation-invalid-params`. Both the raw `:params` and the explainer's
+  `:error` can contain conforming sensitive siblings of the field that failed.
 
-  The fix routes the error payload through the existing resources-family
-  classification projection (`project-params` — the per-slot `:sensitive?`
-  redacts / `:large?` elides surface that resource params egress already uses)
-  for `:params`, and through the shared schemas redaction seam
-  (`:schemas/redact-validation-tags`) for the explainer `:error`, so the same
-  owner-declared marks govern the error payload as govern SSR / wire egress.
+  The validation-failure projector reads schema props for per-slot `:params`
+  redaction and routes explainer output through the shared schemas seam
+  (`:schemas/redact-validation-tags`) for the explainer `:error`. The schema
+  therefore owns both projections of its validation-failure record. Durable
+  SSR/wire classification is a separate projection-relative owner declaration.
 
   Threat model is the AI-boundary + logs (the thrown ex-data is public error
   data + the trace egress) — NOT in-process correctness; the canonical
@@ -50,14 +45,14 @@
 ;; A params schema with a CONFORMING sensitive sibling (`:token`) and a FAILING
 ;; non-sensitive field (`:age` declared `:int`, supplied a string). The failure
 ;; is on `:age`, but the raw params + explainer carry the conforming sensitive
-;; `:token` alongside it — exactly the rf2-99j4e4 sibling-leak shape.
+;; `:token` alongside it — the sibling-leak shape this suite prevents.
 (def ^:private sensitive-params-schema
   [:map
    [:token {:sensitive? true} :string]
    [:age :int]])
 
 ;; A params schema marking a sibling `:large?`; the failing field is again the
-;; non-sensitive `:age`. The bead names `:large?` should elide consistently.
+;; non-sensitive `:age`; the large sibling should elide consistently.
 (def ^:private large-params-schema
   [:map
    [:blob {:large? true} :string]

--- a/implementation/resources/test/re_frame/resources_machine_owner_release_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_machine_owner_release_cljs_test.cljc
@@ -1,31 +1,23 @@
 (ns re-frame.resources-machine-owner-release-cljs-test
-  "Per rf2-xw5t0y — a destroyed state-machine actor MUST release its resource
-  leases (Spec 016 §Release authority is per owner kind, 016:291:
+  "A destroyed state-machine actor MUST release its resource leases (Spec 016
+  §Release authority is per owner kind):
 
     | Machine | [:machine actor-id] | Actor destroy — when the
     owning machine instance is stopped/destroyed, its resource leases are
     released. |
 
-  ). The owner key the machine runtime owns is `[:machine actor-id]` — the
+  The owner key the machine runtime owns is `[:machine actor-id]` — the
   runtime-derivable machine-owner key the derivation algebra names (Spec
   Derivations §Lifecycle: `[:machine :upload/main]`; machines
   `tooling/node-for` emits `:owner [:machine id]`), `id` being the registered
   machine-id for a singleton and the `<type>#<n>` for a spawned actor.
 
-  THE BUG (rf2-xw5t0y, surfaced by the rf2-na0j8r conceptual audit): the
-  machine teardown NEVER dispatched `:rf.resource/release-owner`. A machine
-  that `ensure`d a resource under its `[:machine actor-id]` owner LEAKED the
-  lease on destroy — the entry stayed owner-pinned and kept refetching /
-  polling forever (a slow leak). The spec leaned on \"machine liveness is a
-  pure function of frame-state\" as if release were automatic, but resource
-  liveness is a SEPARATE durable owner-set, not derived from machine state.
-
-  THE FIX: machine teardown fires the EXISTING `:rf.resource/release-owner`
-  effect for owner `[:machine actor-id]`, by KEYWORD dispatch (machines never
+  Resource liveness is a separate durable owner set, not derived from machine
+  state. Machine teardown therefore fires `:rf.resource/release-owner` for
+  owner `[:machine actor-id]`, by keyword dispatch (machines never
   `:require`s resources — sibling artefact; guarded on the handler being
-  registered so a no-resources app is a clean no-op). This is the CROSS-
-  ARTEFACT integration pin: a real machine, a real resource entry, real
-  release — proving the leak is closed end-to-end.
+  registered so a no-resources app is a clean no-op). This is the cross-artefact
+  integration pin: a real machine, a real resource entry, and a real release.
 
   Both destroy CAUSES are covered observably on a surviving frame:
     1. explicit `[:rf.machine/destroy <id>]` (routes through

--- a/implementation/resources/test/re_frame/resources_optimistic_settle_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_optimistic_settle_cljs_test.cljc
@@ -1,11 +1,10 @@
 (ns re-frame.resources-optimistic-settle-cljs-test
-  "EP-0019 slice 3 — the optimistic SETTLE protocol (commit / rollback /
-  reconcile + the `:on-conflict` conflict rule), rf2-byl7bk.1.
+  "The optimistic settlement protocol: commit, rollback, reconciliation, and
+  the `:on-conflict` conflict rule.
 
-  Slice 2 applied the FORWARD optimistic patch at phase 1.5 and recorded the
-  truthful snapshot-inverse on the instance row. This slice consumes that
-  recorded inverse + slice-1's `revision-conflict?` to DETERMINISTICALLY dispose
-  each optimistic apply when its mutation reply settles:
+  Execute applies the forward patch and records a truthful snapshot inverse on
+  the instance row. Settlement consumes that inverse and `revision-conflict?`
+  to deterministically dispose each optimistic apply:
 
     1. SUCCESS-COMMIT — an accepted `:ok` reply settles the optimistic value
        authoritatively (`:populates` / `:patches` overwrite it); the recorded


### PR DESCRIPTION
## Summary

- align resource and mutation lifecycle explanations with current registration, runtime-instance, cache, and optimistic-settlement behavior
- document projection-relative durable classification, SSR hydration, trace egress, and optional-artefact bundle boundaries without stale rollout history
- correct byte-keyed resource and mutation introspection shapes and remove tracker-specific wording from public registration diagnostics

## Validation

- `clojure -M:test` from `implementation/resources`: 622 tests, 6,217 assertions, 0 failures/errors
- `npm run test:cljs` from `implementation`: 8,466 tests, 39,175 assertions, 0 failures/errors
- `clj-kondo --fail-level error --lint implementation/resources`: 0 errors (29 existing warnings)
- `clojure -M:splint --fail-on-errors resources`: 0 errors (existing style warnings)
- `npm run test:bundle-isolation`: PASS (22 artefacts, 41 internal sentinels, 3 budgets)

Bead: `rf2-pxzlee`
