### PR TITLE
fix(template): HTTP exemplar uses :reply-to, not the retired co-located form (rf2-qnwy3q)

### DIFF
--- a/tools/template/resources/day8/re_frame2_template/_shared/events.cljs
+++ b/tools/template/resources/day8/re_frame2_template/_shared/events.cljs
@@ -111,24 +111,39 @@
 ;; [Spec 014 §`:rf.http/managed`](https://github.com/day8/re-frame2/blob/main/spec/014-HTTPRequests.md)).
 ;; Adopt it as-is when your app starts talking to an HTTP backend:
 ;;
-;; The `(:rf/reply msg)` payload this handler reads IS re-frame2's
-;; framework-wide
+;; The `reply` this handler reads IS re-frame2's framework-wide
 ;; [uniform reply envelope](https://github.com/day8/re-frame2/blob/main/spec/Managed-Effects.md#the-uniform-reply-envelope)
 ;; (Managed-Effects property 9; rationale record
 ;; [EP-0011](https://github.com/day8/re-frame2/blob/main/docs/EP/EP-0011-uniform-async-reply-envelope.md)) —
-;; one canonical reply map delivered verbatim, with a single closed
+;; one canonical reply map delivered verbatim, appended as this event's
+;; LAST argument, with a single closed
 ;; `:status` (`:ok` / `:error` / `:cancelled`; `:stale` is suppressed
 ;; before app delivery and never reaches this handler), the decoded
 ;; `:value` on `:ok`, the classified `:rf.http/*` failure map under
 ;; `:error`, plus `:rf.reply/work-id` and `:completed-at`. There is NO separate
 ;; `{:kind :success/:failure}` HTTP dialect (rf2-ibksxg — retired).
-;; `:on-success` / `:on-failure` are pure ROUTING sugar over the one
-;; direct reply target `:rf/reply-to` — both receive this same canonical
-;; map; the co-located `(:rf/reply msg)` form merges it under `:rf/reply`.
 ;; Every managed-async surface you build (HTTP or not) reports completion
 ;; through this same envelope's `:status` / `:value` / `:error` /
 ;; `:completed-at`, with mandatory stale suppression. See
 ;; [Spec 014 §Reply payload shape](https://github.com/day8/re-frame2/blob/main/spec/014-HTTPRequests.md#reply-payload-shape--the-one-canonical-envelope).
+;;
+;; Every `:rf.http/managed` request MUST address its reply — two authoring
+;; styles, both delivering the identical canonical envelope:
+;;
+;;   - `:reply-to` — the UNIFIED spelling: one event vector for BOTH the
+;;     success and the failure reply; the app branches on the envelope's
+;;     `:status`. It is the same authoring key resources / mutations use.
+;;     The exemplar below uses it — request and reply in one handler.
+;;   - `:on-success` / `:on-failure` — the split routing sugar over the one
+;;     `:reply-to` target: a named single-purpose handler per branch (an
+;;     explicit `nil` silences a branch). Reach for it by default; use the
+;;     unified `:reply-to` when the reply logic is trivial and tightly
+;;     coupled to the request, as here.
+;;
+;; Omitting ALL THREE fails loud at fx-call time with
+;; `:rf.error/http-no-reply-target` — there is no co-located default that
+;; silently routes the reply back to the dispatching event. See
+;; [Spec 014 §Reply addressing](https://github.com/day8/re-frame2/blob/main/spec/014-HTTPRequests.md#reply-addressing).
 ;;
 ;;   1. Require `[re-frame.http.managed]` at app boot — that's the load-
 ;;      time side-effect that registers the `:rf.http/managed` fx and
@@ -149,7 +164,7 @@
 ;; by construction** and the framework rejects them in `:retry :on` at
 ;; fx-call time with `:rf.error/http-bad-retry-on`.
 ;;
-;; The single `:on-failure` branch sees the resolved failure category
+;; The failure branch sees the resolved failure category
 ;; via `(:kind (:error reply))` — branch on the keyword to project
 ;; each error case onto the UI shape your app wants. Body-conditional
 ;; retry (e.g. "the server sent `:retry-after`, wait that long") is
@@ -158,37 +173,40 @@
 ;;
 #_(rf/reg-event
     :counter/load
-    (fn [{:keys [db]} [_ msg]]
-      (cond
-        ;; Success branch — `:status :ok`; server returned `{"delta": N}`
-        ;; (decoded per :decode :auto; see the :decode classification note
-        ;; on the request below). The decoded body rides at `:value`.
-        (some-> msg :rf/reply :status (= :ok))
-        {:db (-> db
-                 (update :counter/value + (:delta (:value (:rf/reply msg))))
-                 (assoc :counter/status :idle))}
+    (fn [{:keys [db]} [_ reply]]
+      (if reply
+        ;; Reply path — `reply` is the canonical envelope, delivered as this
+        ;; event's LAST argument. Branch on the closed `:status`.
+        (case (:status reply)
+          ;; Success — `:status :ok`; server returned `{"delta": N}` (decoded
+          ;; per :decode :auto; see the :decode classification note on the
+          ;; request below). The decoded body rides at `:value`.
+          :ok
+          {:db (-> db
+                   (update :counter/value + (:delta (:value reply)))
+                   (assoc :counter/status :idle))}
 
-        ;; Failure / cancel branch — `:status :error` (or `:cancelled` for
-        ;; an abort). Exactly one dispatch per request, even with retry,
-        ;; per Spec 014 §Retry × :on-failure semantics. The classified
-        ;; `:rf.http/*` category rides under `:error`; branch on its
-        ;; `:kind` to project each case onto a UI-facing message.
-        (some-> msg :rf/reply :status #{:error :cancelled})
-        (let [error (:error (:rf/reply msg))]
-          {:db (assoc db :counter/status :error
-                         :counter/error
-                         (case (:kind error)
-                           :rf.http/transport      "Network unavailable."
-                           :rf.http/cors           "Misconfigured CORS — check the server."
-                           :rf.http/timeout        "Server took too long to respond."
-                           :rf.http/http-4xx       "Client error — request rejected."
-                           :rf.http/http-5xx       "Server error — try again later."
-                           :rf.http/decode-failure "Bad response from server."
-                           :rf.http/aborted        "Request cancelled."
-                           "Something went wrong."))})
+          ;; Failure / cancel — `:status :error` (or `:cancelled` for an
+          ;; abort). Exactly one reply per request, even with retry, per
+          ;; Spec 014 §Retry × reply semantics. The classified `:rf.http/*`
+          ;; category rides under `:error`; branch on its `:kind` to project
+          ;; each case onto a UI-facing message.
+          (:error :cancelled)
+          (let [error (:error reply)]
+            {:db (assoc db :counter/status :error
+                           :counter/error
+                           (case (:kind error)
+                             :rf.http/transport      "Network unavailable."
+                             :rf.http/cors           "Misconfigured CORS — check the server."
+                             :rf.http/timeout        "Server took too long to respond."
+                             :rf.http/http-4xx       "Client error — request rejected."
+                             :rf.http/http-5xx       "Server error — try again later."
+                             :rf.http/decode-failure "Bad response from server."
+                             :rf.http/aborted        "Request cancelled."
+                             "Something went wrong."))}))
 
-        ;; Initial branch — issue the request.
-        :else
+        ;; Initial dispatch (no reply yet) — issue the request and address
+        ;; its reply back to this same event via `:reply-to`.
         {:db (assoc db :counter/status :loading :counter/error nil)
          :fx [[:rf.http/managed
                ;; `:decode :auto` is the simple, non-sensitive case — fine
@@ -201,10 +219,14 @@
                ;; is whole-sensitive (fail-closed) — off-box traces/captures
                ;; omit it unless classified projection is requested. See
                ;; [Spec 015 §HTTP response bodies](https://github.com/day8/re-frame2/blob/main/spec/015-Data-Classification.md#http-response-bodies).
-               {:request {:method :get :url "/api/counter"}
-                :decode  :auto
-                :retry   {:on           #{:rf.http/transport
-                                          :rf.http/http-5xx
-                                          :rf.http/timeout}
-                          :max-attempts 3
-                          :backoff      [200 1000 3000]}}]]})))
+               {:request  {:method :get :url "/api/counter"}
+                :decode   :auto
+                :reply-to [:counter/load]
+                :retry    {:on           #{:rf.http/transport
+                                           :rf.http/http-5xx
+                                           :rf.http/timeout}
+                           :max-attempts 3
+                           :backoff      {:base-ms 200
+                                          :factor  2
+                                          :max-ms  3000
+                                          :jitter  true}}}]]})))

--- a/tools/template/test/day8/re_frame2_template/template_test.clj
+++ b/tools/template/test/day8/re_frame2_template/template_test.clj
@@ -178,15 +178,20 @@
               "schema.cljs emits the canonical positional grammar
                (rf/reg-app-schema [] CounterDb)")
 
-          ;; -- EP-0011 / rf2-ibksxg: HTTP exemplar teaches the ONE canonical
-          ;;    uniform reply envelope (no compat dialect) --
+          ;; -- EP-0011 / rf2-ibksxg / rf2-et4c1s: HTTP exemplar teaches the
+          ;;    ONE canonical uniform reply envelope + the CURRENT reply-
+          ;;    addressing surface (no compat dialect, no retired co-located
+          ;;    form) --
           ;; The reply the exemplar reads IS the framework-wide uniform reply
-          ;; envelope delivered verbatim; there is no separate
-          ;; {:kind :success/:failure} HTTP dialect (retired). The exemplar
-          ;; must name the envelope, its canonical :status/:completed-at facts,
-          ;; and :rf/reply-to as the one direct reply target the
-          ;; :on-success/:on-failure routing sugar sits over — so a future
-          ;; edit cannot re-introduce the retired compat payload.
+          ;; envelope delivered verbatim (appended as the event's last arg);
+          ;; there is no separate {:kind :success/:failure} HTTP dialect
+          ;; (retired). The exemplar must name the envelope, its canonical
+          ;; :status/:completed-at facts, and address its reply with the
+          ;; app-facing :reply-to unified key (the :on-success/:on-failure
+          ;; routing sugar sits over it) — never the retired co-located
+          ;; :rf/reply read nor the internal :rf/reply-to descriptor as an
+          ;; app-facing spelling (rf2-et4c1s) — so a future edit cannot
+          ;; re-introduce the retired compat payload or co-located form.
           (is (.contains events-text "sugar over the one")
               "events.cljs HTTP exemplar marks :on-success/:on-failure as pure
                ROUTING sugar over the one direct reply target (rf2-ibksxg — no
@@ -197,10 +202,24 @@
           (is (.contains events-text "uniform reply envelope")
               "events.cljs HTTP exemplar names the framework-wide uniform
                reply envelope the reply IS (EP-0011 — rf2-rzsxrk)")
-          (is (.contains events-text ":rf/reply-to")
-              "events.cljs HTTP exemplar names :rf/reply-to as the one direct
-               reply target the :on-success/:on-failure sugar sits over
-               (EP-0011 / rf2-ibksxg — rf2-rzsxrk)")
+          (is (.contains events-text ":reply-to")
+              "events.cljs HTTP exemplar addresses its reply with the app-facing
+               :reply-to unified key — the one target the :on-success/:on-failure
+               routing sugar sits over (EP-0011 / rf2-et4c1s — rf2-rzsxrk)")
+          ;; The retired co-located `:rf/reply` read AND the retired
+          ;; :rf/reply-to-as-app-facing framing must both be gone. `:rf/reply`
+          ;; catches both — `:rf/reply-to` embeds `:rf/reply`, and the co-
+          ;; located envelope key is exactly `:rf/reply`. (The internal
+          ;; descriptor is a conformance surface, not consumer-template
+          ;; content — a user who uncomments the exemplar must hit neither
+          ;; :rf.error/http-no-reply-target nor a co-located read.) The
+          ;; correlation fact `:rf.reply/work-id` uses a dot, not a slash,
+          ;; so it does NOT trip this guard.
+          (is (not (.contains events-text ":rf/reply"))
+              "events.cljs HTTP exemplar must NOT read the retired co-located
+               :rf/reply envelope key NOR cite :rf/reply-to as an app-facing
+               spelling — the app-facing surface is :reply-to / :on-success /
+               :on-failure (rf2-et4c1s)")
           (is (.contains events-text ":completed-at")
               "events.cljs HTTP exemplar names the canonical :completed-at
                reply fact (EP-0011 — rf2-rzsxrk)")


### PR DESCRIPTION
## What

The `tools/template` HTTP failure-matrix exemplar (`_shared/events.cljs`, `#_`-commented/inert) still taught the **retired co-located reply form** — it read `(:rf/reply msg)` and framed `:rf/reply-to` as the app-facing reply target. A user who uncommented it hit `:rf.error/http-no-reply-target`, because et4c1s (#5449) retired the co-located default and made `:reply-to` the uniform authoring key (`:rf/reply-to` is now an internal descriptor only).

## The rewrite

`_shared/events.cljs` — rewrite the exemplar to the current shipped model:
- `:reply-to [:counter/load]` addresses the reply (the unified one-handler form). The canonical reply envelope is read from the handler's **appended last event argument** (`[_ reply]`), branching on the closed `:status` (`:ok` / `:error` / `:cancelled`).
- Comment now teaches the two authoring styles — `:reply-to` (unified) and `:on-success` / `:on-failure` (split routing sugar over the one target) — and the fail-loud `:rf.error/http-no-reply-target` when all three are omitted.
- Corrected the silently-ignored `:backoff [200 1000 3000]` vector to the documented map shape `{:base-ms :factor :max-ms :jitter}` (a vector destructures as an all-nil map → defaults, so the vector's values were never honoured). Same file, keeps the uncommented exemplar correct on the shipped API.

`template_test.clj` — updated in lockstep:
- Assert the app-facing `:reply-to` key (was `:rf/reply-to`).
- Added an anti-regression guard: `events.cljs` must contain **no** `:rf/reply` substring — catches both the co-located read and the retired `:rf/reply-to`-as-app-facing framing. (`:rf.reply/work-id` uses a dot, not a slash, so it does not trip the guard.)

The exemplar stays `#_`-commented (inert) in the shipped template; the fix guarantees it is correct **if a user uncomments it** — no `:rf.error/http-no-reply-target`, no retired co-located reads.

## Quality gates

- `cd tools/template && clojure -M:test` — **47 tests, 652 assertions, 0 failures, 0 errors** (foreground). Includes `template_emission_test.clj`, which statically reads the emitted `events.cljs` via `clojure.tools.reader` — so the rewritten `#_`-discarded form parses cleanly (balanced, well-formed).
- Verified against the implementation: `re-frame.http.handlers` accepts `:reply-to` and rejects a wholly-unaddressed request with `:rf.error/http-no-reply-target`; `re-frame.http.encoding/compute-backoff-ms` takes the `{:base-ms :factor :max-ms :jitter}` map.

## Follow-up (out of scope, flagged)

`root/README.md` (HTTP section, lines ~518/537) still narrates the co-located `(:rf/reply msg)` form and `:rf/reply-to` as app-facing. This bead scoped me strictly to the exemplar + its test; the README is a separate surface and its `template_test` assertions stay green. Recommend a follow-up bead to align the README prose.

## Stance

Pre-alpha, no back-compat. The template is a consumer-facing scaffold and must teach the CURRENT shipped API. ELEGANCE + CLARITY + CORRECTNESS.

Closes rf2-qnwy3q.