### PR TITLE
test(security): share the nested sensitive-schema generator (rf2-iu6fqv)

### DIFF
--- a/implementation/security/test/re_frame/security/gen.cljc
+++ b/implementation/security/test/re_frame/security/gen.cljc
@@ -219,3 +219,137 @@
   `:rf.size/large-elided`)."
   [v]
   (and (map? v) (contains? v :rf.size/large-elided)))
+
+;; ---------------------------------------------------------------------------
+;; Nested-sensitive schema generator (rf2-iu6fqv) - lifted verbatim from the
+;; two redaction-security suites (schema-redaction + validation-invariant),
+;; which each hand-copied a structurally identical recursive generator: it
+;; wraps a `:sensitive?` sentinel-bearing LEAF slot in a random tower of
+;; collection/map combinators and plants a TYPE MISMATCH at the leaf, forcing a
+;; validation failure that carries the sentinel. Every framework redaction
+;; boundary must then scrub the sentinel from the emitted trace. Consolidating
+;; here removes the maintenance-only risk of one copy gaining an arm (a new
+;; leak class) its sibling silently misses.
+;;
+;; The two callers differed ONLY in (1) the sentinel string, (2) the maximum
+;; nesting depth, and (3) the ORDER of two arms (`:tuple` / `:map-of-key`) in
+;; the wrapper vector - a harmless historical drift: the SET of eleven arms,
+;; each arm's built shape, and the leak-free property are identical; only the
+;; seed->shape draw mapping differs. So the generator takes `sentinel`, the
+;; `arms` vector, and `max-depth` as parameters and each caller passes its own,
+;; keeping each suite's generated shapes byte-identical (a failing draw still
+;; reproduces from its recorded seed).
+;;
+;; The eleven wrapper arms and WHY each exists (which egress leak class it pins):
+;;   :map          - name the sensitive slot under a random key
+;;   :vector       - element schema (value is a 1-element vector)
+;;   :sequential   - as :vector, over a sequential coll
+;;   :map-of       - string-keyed; the sensitive slot is the VALUE
+;;   :map-of-key   - rf2-gocef0 / rf2-6ijdgh: the sentinel is planted AS the key
+;;                   under a `:sensitive?` key schema. Malli reports the failing
+;;                   key VALUE verbatim as the :in segment, so the walker's
+;;                   :map-of key-scrub branch must scrub it from :path / :reason.
+;;                   inner-val ALSO carries the sentinel at the leaf, so BOTH the
+;;                   key AND the value must redact.
+;;   :tuple        - sensitive slot at element 1 (an int filler sits at 0)
+;;   :set          - rf2-ss06u.1: a :set wraps a navigable MAP carrying the
+;;                   sensitive slot; Malli reports the element VALUE as the :in
+;;                   segment, so the failing element would ride verbatim in :path
+;;                   absent the sanitiser.
+;;   :and :or :multi :orn - rf2-ss06u.2: transparent single-child wrappers
+;;                   align-in-path cannot resolve. The sensitivity sits on a
+;;                   CONSUMED ANCESTOR (the named :map slot); the failing leaf
+;;                   lives under the wrapper. Absent the prefix-carry fix the
+;;                   leftover subtree shows no sensitivity and the value leaks.
+;; The leaf is a `:sensitive? :string` slot whose value is the sentinel wrapped
+;; in a vector (WRONG type), so `:string` fails and the redaction path fires.
+;; ---------------------------------------------------------------------------
+
+(def ^:private gen-sensitive-key
+  "Random slot key for the nested-sensitive generator's `:map`-family arms."
+  (gen-elem [:auth :token :secret :pw :ssn :payload :inner :node :a :b]))
+
+(defn- sensitive-shape
+  "Generator returning `[schema db-value]` with a `sentinel`-bearing
+  `:sensitive?` leaf wrapped in up to `depth` random collection/map layers
+  drawn from `arms`. `depth` bounds recursion. See the block comment above for
+  each arm."
+  [sentinel arms depth]
+  (if (<= depth 0)
+    ;; Leaf: a sensitive :string slot whose value is the WRONG type (the
+    ;; sentinel wrapped in a vector - fails :string, so the failure trace
+    ;; would carry the sentinel verbatim absent redaction).
+    (fn [rng]
+      [[[:string {:sensitive? true}] [sentinel]] rng])
+    (fn [rng]
+      (let [[wrap rng1] (rand-nth rng arms)
+            [[inner-schema inner-val] rng2] ((sensitive-shape sentinel arms (dec depth)) rng1)]
+        (case wrap
+          :map
+          (let [[k rng3] (gen-sensitive-key rng2)]
+            [[[:map [k inner-schema]] {k inner-val}] rng3])
+
+          :vector
+          [[[:vector inner-schema] [inner-val]] rng2]
+
+          :sequential
+          [[[:sequential inner-schema] [inner-val]] rng2]
+
+          :map-of
+          [[[:map-of :string inner-schema] {"k" inner-val}] rng2]
+
+          ;; The sensitive slot is the :map-of KEY (not the value); the sentinel
+          ;; is planted AS the key. BOTH the key and the leaf value carry the
+          ;; sentinel; both must redact.
+          :map-of-key
+          [[[:map-of [:string {:sensitive? true}] inner-schema] {sentinel inner-val}] rng2]
+
+          :tuple
+          ;; sensitive slot is element 1; element 0 is an int filler.
+          [[[:tuple :int inner-schema] [0 inner-val]] rng2]
+
+          ;; A :set wraps a MAP carrying the sensitive inner slot (so the set
+          ;; element is a navigable map) under a random key.
+          :set
+          (let [[k rng3] (gen-sensitive-key rng2)]
+            [[[:set [:map [k inner-schema]]] #{{k inner-val}}] rng3])
+
+          ;; Transparent single-child wrappers: the WRAPPER slot is the
+          ;; sensitive container (props on the named :map slot) so the
+          ;; sensitivity is on a CONSUMED ANCESTOR; the failing leaf lives
+          ;; under the :and/:or/:multi/:orn.
+          :and
+          (let [[k rng3] (gen-sensitive-key rng2)]
+            [[[:map [k {:sensitive? true} [:and inner-schema]]] {k inner-val}] rng3])
+
+          :or
+          (let [[k rng3] (gen-sensitive-key rng2)]
+            [[[:map [k {:sensitive? true} [:or inner-schema]]] {k inner-val}] rng3])
+
+          :multi
+          (let [[k rng3] (gen-sensitive-key rng2)]
+            ;; :multi needs a dispatch; wrap the inner under a single branch
+            ;; keyed by a fixed dispatch value carried in the value map.
+            [[[:map [k {:sensitive? true}
+                     [:multi {:dispatch :rf2/d}
+                      [:x [:map [:rf2/d :keyword] [:v inner-schema]]]]]]
+              {k {:rf2/d :x :v inner-val}}] rng3])
+
+          :orn
+          (let [[k rng3] (gen-sensitive-key rng2)]
+            [[[:map [k {:sensitive? true} [:orn [:x inner-schema]]]] {k inner-val}] rng3]))))))
+
+(defn nested-sensitive-generator
+  "Generator drawing `[schema db-value]` where a `sentinel`-bearing
+  `:sensitive?` slot lives at a random `1..max-depth`-deep nesting built from
+  the wrapper keywords in `arms`. A type mismatch at the leaf forces a
+  validation failure carrying the sentinel; the redaction boundary under test
+  must scrub it from every emitted trace slot.
+
+  Parameterized (not hard-coded) so the two redaction-security suites share one
+  implementation while each keeps its own sentinel, wrapper-arm order, and depth
+  range - see the block comment above for the historical arm-order drift."
+  [sentinel arms max-depth]
+  (fn [rng]
+    (let [[depth rng1] (next-int rng max-depth)]
+      ((sensitive-shape sentinel arms (inc depth)) rng1))))

--- a/implementation/security/test/re_frame/security/schema_redaction_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/schema_redaction_security_cljs_test.cljc
@@ -89,125 +89,23 @@
 ;; ---------------------------------------------------------------------------
 ;; Recursive generator - build [schema db] where a :sensitive? scalar slot
 ;; lives at an arbitrary collection/map nesting depth, with the sentinel
-;; planted at that slot but a TYPE MISMATCH forcing a validation failure.
-;;
-;; Each layer wraps the inner [schema value] in one of:
-;;   :map     - name the slot with a random key
-;;   :vector  - element schema (value becomes a 1-or-2 element vector)
-;;   :sequential
-;;   :map-of  - string-keyed
-;;   :tuple   - sensitive slot at a random tuple index
-;; The leaf is a :sensitive? :string slot whose value is the sentinel as a
-;; NON-string (a vector wrapping it) so :string fails and the redaction path
-;; fires.
+;; planted at that slot but a TYPE MISMATCH forcing a validation failure. The
+;; recursive walk, the eleven wrapper arms, and the leaf are shared with the
+;; validation-invariant suite via `gen/nested-sensitive-generator` (rf2-iu6fqv;
+;; see that fn for each arm's rationale). This suite keeps its own sentinel and
+;; passes its own wrapper-arm order + a 1..6 depth, so its generated shapes are
+;; byte-identical to before (a failing draw still reproduces from its seed).
+;; The `:tuple`-before-`:map-of-key` order below is this suite's historical draw
+;; order, preserved deliberately - see the shared block comment on the drift.
 ;; ---------------------------------------------------------------------------
-
-(def ^:private gen-key
-  (gen/gen-elem [:auth :token :secret :pw :ssn :payload :inner :node :a :b]))
-
-(defn- gen-shape
-  "Generator returning `[schema db-value]`. `depth` bounds recursion."
-  [depth]
-  (if (<= depth 0)
-    ;; Leaf: a sensitive :string slot whose value is the WRONG type (the
-    ;; sentinel wrapped in a vector - fails :string, so the failure trace
-    ;; would carry the sentinel verbatim absent redaction).
-    (fn [rng]
-      [[[:string {:sensitive? true}] [sentinel]] rng])
-    (fn [rng]
-      (let [[wrap rng1] (gen/rand-nth rng [:map :vector :sequential :map-of :tuple
-                                           ;; rf2-gocef0 / rf2-6ijdgh — the
-                                           ;; sensitive :map-of KEY class. Every
-                                           ;; other :map-of shape here puts the
-                                           ;; sensitive slot in the VALUE; this
-                                           ;; arm plants the sentinel AS the key
-                                           ;; under a `:sensitive?` key schema, so
-                                           ;; Malli reports the secret verbatim as
-                                           ;; the :in KEY segment and the walker's
-                                           ;; :map-of key-scrub branch must scrub
-                                           ;; it from :path / :reason.
-                                           :map-of-key
-                                           ;; rf2-ss06u.1 / rf2-ss06u.2 — the
-                                           ;; set-element-value `:path` leak
-                                           ;; and the consumed-ancestor
-                                           ;; transparent-wrapper leaks. These
-                                           ;; reach align-in-path's :else
-                                           ;; fallback (or carry the element
-                                           ;; value into :path for :set).
-                                           :set :and :or :multi :orn])
-            [[inner-schema inner-val] rng2] ((gen-shape (dec depth)) rng1)]
-        (case wrap
-          :map
-          (let [[k rng3] (gen-key rng2)]
-            [[[:map [k inner-schema]] {k inner-val}] rng3])
-
-          :vector
-          [[[:vector inner-schema] [inner-val]] rng2]
-
-          :sequential
-          [[[:sequential inner-schema] [inner-val]] rng2]
-
-          :map-of
-          [[[:map-of :string inner-schema] {"k" inner-val}] rng2]
-
-          ;; rf2-gocef0 / rf2-6ijdgh — the sensitive slot is the :map-of KEY
-          ;; (not the value): [:map-of [:string {:sensitive? true}] inner], the
-          ;; sentinel planted AS the key. Malli reports the failing key VALUE
-          ;; verbatim as the :in segment, so `sanitize-sensitive-path`'s
-          ;; :map-of key-scrub branch must scrub it from :path / :reason — the
-          ;; one collection-navigation-segment-carries-the-secret sibling this
-          ;; tier pinned for its neighbours (:set element, :tuple) but not
-          ;; itself. inner-val ALSO carries the sentinel at the leaf, so BOTH
-          ;; the key AND the value must redact.
-          :map-of-key
-          [[[:map-of [:string {:sensitive? true}] inner-schema] {sentinel inner-val}] rng2]
-
-          :tuple
-          ;; sensitive slot is element 1; element 0 is an int filler.
-          [[[:tuple :int inner-schema] [0 inner-val]] rng2]
-
-          ;; rf2-ss06u.1 — a :set wraps a MAP carrying the sensitive inner
-          ;; slot (so the set element is a navigable map, mirroring the bead
-          ;; repro) under a random key. Malli reports the element VALUE as the
-          ;; :in segment, so the failing element (incl. the sentinel) would
-          ;; ride verbatim in :path absent the sanitiser.
-          :set
-          (let [[k rng3] (gen-key rng2)]
-            [[[:set [:map [k inner-schema]]] #{{k inner-val}}] rng3])
-
-          ;; rf2-ss06u.2 — transparent single-child wrappers that
-          ;; align-in-path cannot resolve. We make the WRAPPER slot the
-          ;; sensitive container (props on the named :map slot) so the
-          ;; sensitivity is on a CONSUMED ANCESTOR; the failing leaf lives
-          ;; under the :and/:or/:multi/:orn. Absent the prefix-carry fix the
-          ;; leftover subtree shows no sensitivity and the value leaks.
-          :and
-          (let [[k rng3] (gen-key rng2)]
-            [[[:map [k {:sensitive? true} [:and inner-schema]]] {k inner-val}] rng3])
-
-          :or
-          (let [[k rng3] (gen-key rng2)]
-            [[[:map [k {:sensitive? true} [:or inner-schema]]] {k inner-val}] rng3])
-
-          :multi
-          (let [[k rng3] (gen-key rng2)]
-            ;; :multi needs a dispatch; wrap the inner under a single branch
-            ;; keyed by a fixed dispatch value carried in the value map.
-            [[[:map [k {:sensitive? true}
-                     [:multi {:dispatch :rf2/d}
-                      [:x [:map [:rf2/d :keyword] [:v inner-schema]]]]]]
-              {k {:rf2/d :x :v inner-val}}] rng3])
-
-          :orn
-          (let [[k rng3] (gen-key rng2)]
-            [[[:map [k {:sensitive? true} [:orn [:x inner-schema]]]] {k inner-val}] rng3]))))))
 
 (def ^:private gen-nested-sensitive
   "Draw a `[schema db-value]` with a sentinel-bearing :sensitive? slot at a
   random 1..6-deep collection/map nesting."
-  (fn [rng]
-    (let [[depth rng1] (gen/next-int rng 6)]
-      ((gen-shape (inc depth)) rng1))))
+  (gen/nested-sensitive-generator
+    sentinel
+    [:map :vector :sequential :map-of :tuple :map-of-key :set :and :or :multi :orn]
+    6))
 
 ;; ---------------------------------------------------------------------------
 ;; End-to-end harness - register the schema, validate the failing db,

--- a/implementation/security/test/re_frame/security/validation_redaction_invariant_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/validation_redaction_invariant_security_cljs_test.cljc
@@ -673,52 +673,18 @@
 ;; generator idea but sweeps every callable validation entry point per draw.
 ;; ---------------------------------------------------------------------------
 
-(def ^:private gen-key
-  (gen/gen-elem [:auth :token :secret :pw :ssn :payload :inner :node :a :b]))
-
-(defn- gen-shape
-  "Generator returning `[schema db-value]` with a sentinel-bearing
-  :sensitive? leaf at a random collection/map nesting (the rf2-g5auo shape
-  space). `depth` bounds recursion."
-  [depth]
-  (if (<= depth 0)
-    (fn [rng]
-      [[[:string {:sensitive? true}] [sentinel]] rng])
-    (fn [rng]
-      (let [[wrap rng1] (gen/rand-nth rng [:map :vector :sequential :map-of :map-of-key :tuple
-                                           :set :and :or :multi :orn])
-            [[inner-schema inner-val] rng2] ((gen-shape (dec depth)) rng1)]
-        (case wrap
-          :map        (let [[k rng3] (gen-key rng2)]
-                        [[[:map [k inner-schema]] {k inner-val}] rng3])
-          :vector     [[[:vector inner-schema] [inner-val]] rng2]
-          :sequential [[[:sequential inner-schema] [inner-val]] rng2]
-          :map-of     [[[:map-of :string inner-schema] {"k" inner-val}] rng2]
-          ;; rf2-gocef0 / rf2-6ijdgh — sensitive :map-of KEY: the sentinel is
-          ;; planted AS the key under a `:sensitive?` key schema; the walker's
-          ;; :map-of key-scrub branch must scrub it from :path / :reason across
-          ;; every callable validation kind. Both key and value carry the
-          ;; sentinel; both must redact.
-          :map-of-key [[[:map-of [:string {:sensitive? true}] inner-schema] {sentinel inner-val}] rng2]
-          :tuple      [[[:tuple :int inner-schema] [0 inner-val]] rng2]
-          :set        (let [[k rng3] (gen-key rng2)]
-                        [[[:set [:map [k inner-schema]]] #{{k inner-val}}] rng3])
-          :and        (let [[k rng3] (gen-key rng2)]
-                        [[[:map [k {:sensitive? true} [:and inner-schema]]] {k inner-val}] rng3])
-          :or         (let [[k rng3] (gen-key rng2)]
-                        [[[:map [k {:sensitive? true} [:or inner-schema]]] {k inner-val}] rng3])
-          :multi      (let [[k rng3] (gen-key rng2)]
-                        [[[:map [k {:sensitive? true}
-                                 [:multi {:dispatch :rf2/d}
-                                  [:x [:map [:rf2/d :keyword] [:v inner-schema]]]]]]
-                          {k {:rf2/d :x :v inner-val}}] rng3])
-          :orn        (let [[k rng3] (gen-key rng2)]
-                        [[[:map [k {:sensitive? true} [:orn [:x inner-schema]]]] {k inner-val}] rng3]))))))
-
+;; The recursive walk, the eleven wrapper arms, and the leaf are shared with the
+;; schema-redaction suite via `gen/nested-sensitive-generator` (rf2-iu6fqv; see
+;; that fn for each arm's rationale). This suite keeps its own sentinel and
+;; passes its own wrapper-arm order + a 1..5 depth, so its generated shapes are
+;; byte-identical to before (a failing draw still reproduces from its seed). The
+;; `:map-of-key`-before-`:tuple` order below is this suite's historical draw
+;; order, preserved deliberately - see the shared block comment on the drift.
 (def ^:private gen-nested-sensitive
-  (fn [rng]
-    (let [[depth rng1] (gen/next-int rng 5)]
-      ((gen-shape (inc depth)) rng1))))
+  (gen/nested-sensitive-generator
+    sentinel
+    [:map :vector :sequential :map-of :map-of-key :tuple :set :and :or :multi :orn]
+    5))
 
 (defn- all-kinds-redact?
   "Given a `[schema value]` draw, run EVERY callable validation kind and


### PR DESCRIPTION
## What

`schema_redaction_security_cljs_test.cljc` and `validation_redaction_invariant_security_cljs_test.cljc` each hand-copied a structurally identical recursive generator (`gen-key`, `gen-shape`, `gen-nested-sensitive`): the same key corpus and the same eleven wrapper arms (`:map :vector :sequential :map-of :map-of-key :tuple :set :and :or :multi :orn`), differing only in the sentinel and the maximum nesting depth. That duplication carried the maintenance-only risk of one copy gaining an arm (a new leak class) the sibling silently missed.

This PR lifts the recursive walk into a single parameterized `re-frame.security.gen/nested-sensitive-generator [sentinel arms max-depth]` and **deletes both local implementations**. Each suite keeps its own **sentinel, seed, draw count, depth range, hostile corpus, and boundary assertions LOCAL** — only the shared generator body is consolidated.

- schema-redaction retains depth **1..6**, sentinel `S3CR3T-rf2-3cfvt-DO-NOT-LEAK`, seed 11 / 300 draws.
- validation-invariant retains depth **1..5**, sentinel `S3CR3T-rf2-o69h5-VALIDATION-DO-NOT-LEAK`, seed 17 / 120 draws.
- All named hostile-corpus tests and no-over-redaction tests remain fully independent and untouched.

## Stance

Pre-alpha, no back-compat. Redaction / sensitive-schema is an AI-egress privacy boundary — each suite's hostile corpus and boundary assertions are preserved exactly; only the duplicated generator is shared. Primary lenses: ELEGANCE + CLARITY + CORRECTNESS. No speculative arms added; the shared generator owns exactly the eleven arms both suites already had.

## Preflight confirmation

Confirmed both suites define the same `gen-key`, recursive `gen-shape`, and `gen-nested-sensitive` with the **same key corpus** and the **same eleven wrapper-arm bodies** (byte-identical shape construction, including `:map-of-key` planting the sentinel AS the key, and the `:and/:or/:multi/:orn` consumed-ancestor wrappers).

**One drift found beyond sentinel + depth:** the two suites ordered `:tuple` and `:map-of-key` differently in the wrapper vector (schema-redaction: `… :map-of :tuple :map-of-key :set …`; validation-invariant: `… :map-of :map-of-key :tuple :set …`). This is harmless historical drift — identical arm SET, identical arm bodies, identical leak-free property; only the seed→shape draw mapping differs. Rather than a lossy unification (which would change one suite's drawn shapes), `arms` is a generator parameter and **each suite passes its own order**, so generated shapes are byte-identical per suite and any failing draw still reproduces from its recorded seed. Flagging for a possible trivial follow-up if a single canonical arm order is preferred over preserving the drift.

## Quality gates

Both foreground, both green on the branch:

- `cd implementation/security && clojure -M:test` → **92 tests, 666 assertions, 0 failures, 0 errors**
- `cd implementation && npm run test:cljs` → **8466 tests, 39175 assertions, 0 failures, 0 errors**

Both redaction-security suites stay green with identical corpus/boundary behaviour through the shared generator; generated shapes + sentinel wiring unchanged per suite.

## Scope

Touches only:
- `implementation/security/test/re_frame/security/gen.cljc` (adds the shared generator)
- `implementation/security/test/re_frame/security/schema_redaction_security_cljs_test.cljc`
- `implementation/security/test/re_frame/security/validation_redaction_invariant_security_cljs_test.cljc`

No published source / bundle changes (test-only). Not hot-zone.