### PR TITLE
docs(scripts): align explanations with current contracts (rf2-j945p1)

### DIFF
--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -223,15 +223,14 @@ test('machines-viz deps.edn change fires cljs + cljs-browser (rf2-z0cw6s)', () =
   assert.equal(result.cljs_browser, 'true');
 });
 
-// rf2-4ka7c2.1 — API-manifest probe routing false-green fix. The CLJS-only
+// The CLJS-only
 // adapter / Xray / pair-MCP public surfaces live in the sidecar
 // (spec/api-manifest-metadata.edn) under :cljs-only and are carried into
 // spec/api-manifest.edn verbatim. Their ONLY live runtime verifier is the
 // CLJS enumeration probe in the consolidated :node-test build, gated on
 // cljs_node_test. A sidecar / generated-manifest / API.md change must
-// therefore light cljs_node_test so the probe reconciles those rows — else a
-// stale/missing CLJS-only row ships with green CI (lint.yml runs only the JVM
-// generator + projection checks, never the CLJS probe).
+// therefore light cljs_node_test so the probe reconciles those rows. lint.yml
+// runs the JVM generator and projection checks, not the CLJS probe.
 
 test('API-manifest sidecar change lights cljs_node_test (CLJS probe routing) (rf2-4ka7c2)', () => {
   const result = classify('spec/api-manifest-metadata.edn');
@@ -417,17 +416,11 @@ test('implementation/scripts/* does NOT arm template_expensive (no emitted npm p
   assert.equal(result.template_expensive, 'false');
 });
 
-// rf2-rcepku — Xray PR-smoke launcher false-green fix, mirroring the
-// rf2-y9o5e3 examples/scripts launcher routing. The
-// serve-and-run-xray-feature-gate.cjs launcher IS the executable
-// orchestration for `npm run test:xray-feature-gate:smoke`, the command
-// the story-xray-browser PR job runs (test.yml). Editing it must fire the
-// story_xray_browser gate it drives — else a PR can break the launcher
-// while avoiding the very PR-smoke job it orchestrates. The static-script
-// surfaces it shares with the generic implementation/scripts/* case stay
-// armed (this widens coverage; it does not narrow it).
+// serve-and-run-xray-feature-gate.cjs implements the Xray smoke command used by
+// the story-xray-browser PR job. Editing the launcher must arm that job while
+// retaining the generic implementation/scripts gates.
 
-test('implementation/scripts/serve-and-run-xray-feature-gate.cjs fires story_xray_browser (rf2-rcepku)', () => {
+test('implementation/scripts/serve-and-run-xray-feature-gate.cjs fires story_xray_browser', () => {
   const result = classify('implementation/scripts/serve-and-run-xray-feature-gate.cjs');
   assert.equal(
     result.story_xray_browser,
@@ -436,7 +429,7 @@ test('implementation/scripts/serve-and-run-xray-feature-gate.cjs fires story_xra
   );
 });
 
-test('implementation/scripts/serve-and-run-xray-feature-gate.cjs still arms the generic static-script gates (regression) (rf2-rcepku)', () => {
+test('implementation/scripts/serve-and-run-xray-feature-gate.cjs still arms the generic static-script gates', () => {
   const result = classify('implementation/scripts/serve-and-run-xray-feature-gate.cjs');
   assert.equal(result.cljs_node_test, 'true');
   assert.equal(result.cljs_browser, 'true');
@@ -445,7 +438,7 @@ test('implementation/scripts/serve-and-run-xray-feature-gate.cjs still arms the 
   assert.equal(result.reagent_slim_bundle, 'true');
 });
 
-test('an UNRELATED implementation/scripts/* file does NOT fire story_xray_browser (scope discipline) (rf2-rcepku)', () => {
+test('an unrelated implementation/scripts/* file does not fire story_xray_browser', () => {
   // Only the Xray launcher drives the Xray browser gate; a generic
   // implementation/scripts/* edit must not be broadened onto it.
   const result = classify('implementation/scripts/build-foo.cjs');

--- a/implementation/scripts/_impl-browser-runners-pageerror-policy.test.cjs
+++ b/implementation/scripts/_impl-browser-runners-pageerror-policy.test.cjs
@@ -133,7 +133,7 @@ test('check-story-static: the smoke throws on a captured pageerror even when ass
 // ---- serve-and-run-tenant-switcher-testbed.cjs (rf2-h5e3v7) ----
 // The tenant-switcher testbed smoke is now CI-wired
 // (tenant-switcher-testbed-smoke job), so its verdict path joins the
-// pinned set: the bead explicitly called out pageerror handling specific
+// pinned set: pageerror handling is specific
 // to this runner as a maskable failure. Same discipline as the siblings —
 // pageerrors go into a dedicated array and flip the verdict to fail before
 // `passed = true`.

--- a/implementation/scripts/_lint-workflow-policy.test.cjs
+++ b/implementation/scripts/_lint-workflow-policy.test.cjs
@@ -1,21 +1,14 @@
 #!/usr/bin/env node
 /*
- * Workflow-policy guard for `.github/workflows/lint.yml` (rf2-nlnd9y.3).
+ * Workflow-policy guard for `.github/workflows/lint.yml`.
  *
  * `.splint.edn` at repo root is the Splint gate's per-project config — Splint
- * reads it live once the job runs. But the lint workflow's ROUTING omitted
- * it: the `push` path filter and the PR `detect` classifier both listed
- * implementation/tools/examples/testbeds/.clj-kondo but NOT `.splint.edn`. So
- * a PR (or push) that changed ONLY `.splint.edn` — broken syntax, disabled
- * rules, a removed exclude — left `lint_surface=false`, the Splint job
- * skipped, and the required `Lint required` aggregator passed (all-skipped is
- * OK). A bad Splint config could ship behind a green gate.
- *
- * This guard pins that `.splint.edn` is wired into BOTH routing surfaces and
+ * reads it live once the job runs. This guard pins that `.splint.edn` is wired
+ * into both routing surfaces and
  * that the Splint job stays gated on `lint_surface` (so the routing is what
  * decides whether Splint runs). It is a TEXT/policy assertion over the
  * committed workflow — no Actions runtime needed — mirroring the
- * test.yml-shape assertions in `_changed-surfaces.test.cjs`. Wired into
+ * test.yml shape assertions in `_changed-surfaces.test.cjs`. Wired into
  * `test:script-policy`.
  */
 

--- a/implementation/scripts/_local-browser-harness.test.cjs
+++ b/implementation/scripts/_local-browser-harness.test.cjs
@@ -102,7 +102,7 @@ test('terminateProcessTree stops a managed child process', async () => {
   assert.notEqual(exit, null);
 });
 
-// rf2-ogpeq regression (the core race). The async cleanup() kills tracked
+// The async cleanup() kills tracked
 // children sequentially (last-tracked first), awaiting each. If
 // process.exit() fires the 'exit' handler -> cleanupSync() while cleanup()
 // is still mid-flight — it has reached child[last] and is awaiting its
@@ -111,16 +111,12 @@ test('terminateProcessTree stops a managed child process', async () => {
 // resume the async cleanup's pending awaits once the process is exiting,
 // so anything cleanupSync skips is ORPHANED.
 //
-// The old code shared a single `cleaned` flag: the async cleanup set it at
-// the start, so cleanupSync saw `cleaned===true` and returned immediately,
-// skipping the un-reached children.
-//
 // We model this deterministically via the injectable terminator seam: the
-// async terminator NEVER resolves (modelling a hard exit that abandons the
+// async terminator never resolves (modelling a process exit that abandons the
 // in-flight cleanup), and the sync terminator records which children it
 // swept. The invariant: after cleanupSync(), EVERY tracked child has been
 // synchronously swept — regardless of the async cleanup being mid-flight.
-test('cleanupSync sweeps every child when async cleanup() is mid-flight (rf2-ogpeq)', async () => {
+test('cleanupSync sweeps every child when async cleanup() is mid-flight', async () => {
   const childA = { id: 'A' };
   const childB = { id: 'B' };
   const sweptSync = [];
@@ -139,7 +135,7 @@ test('cleanupSync sweeps every child when async cleanup() is mid-flight (rf2-ogp
 
   // Start the async cleanup. Its IIFE runs synchronously up to the first
   // `await terminateAsync(...)`, which never resolves — cleanup() is now
-  // permanently mid-flight (modelling abandonment by a hard exit).
+  // permanently mid-flight (modelling abandonment during process exit).
   cleanup.cleanup();
 
   // The 'exit' handler fires. With the bug this returns without sweeping;
@@ -150,7 +146,7 @@ test('cleanupSync sweeps every child when async cleanup() is mid-flight (rf2-ogp
     [...sweptSync].sort(),
     ['A', 'B'],
     'cleanupSync must synchronously terminate every tracked child even when ' +
-      'an async cleanup() is mid-flight (otherwise children are orphaned on hard exit)',
+      'an async cleanup() is mid-flight (otherwise children are orphaned on exit)',
   );
 });
 

--- a/implementation/scripts/_orchestrator-teardown-integration.test.cjs
+++ b/implementation/scripts/_orchestrator-teardown-integration.test.cjs
@@ -3,14 +3,12 @@
 'use strict';
 
 /*
- * Runtime integration smoke for the orchestrator teardown (rf2-c3hffe).
+ * Runtime integration smoke for orchestrator teardown.
  *
  * The static gate (_orchestrator-teardown-policy.test.cjs) proves every
  * serve-and-run-*.cjs orchestrator is WIRED to the shared teardown helper.
- * This test proves the wiring actually REAPS a long-lived grandchild when
- * the orchestrator is signalled — the behaviour the bead's "verify the
- * teardown helper works (spawn a dummy child, send a signal, assert it's
- * reaped) on at least the Node path" gate asks for.
+ * This test proves the wiring actually reaps a long-lived grandchild when
+ * the orchestrator is terminated.
  *
  * Shape:
  *   parent (this test)
@@ -23,16 +21,13 @@
  *
  * We let the orchestrator come up, capture the grandchild PID, then
  * terminate the orchestrator and assert the grandchild is gone. That
- * exercises the exact path that, when missing, orphaned the 27h-old
- * stranded server: parent dies → tracked child must die too.
+ * exercises the ownership invariant: a tracked child must not outlive its
+ * orchestrator.
  *
- * Cross-platform termination: we drive the orchestrator's teardown via the
- * `'exit'` handler path (process.once('exit', cleanupSync)), which fires on
- * BOTH POSIX and Windows. On POSIX we ALSO assert the SIGINT/SIGTERM signal
- * path (installSignalHandlers registers process.once('SIGINT'/'SIGTERM')).
- * On Windows, Node maps `child.kill('SIGTERM')` to a hard TerminateProcess
- * (no JS signal handler fires), so the JS-signal arm is POSIX-only — the
- * exit-handler arm (always run) is what covers Windows.
+ * The first case verifies the observable process-tree result on every
+ * platform without depending on which termination hook Node uses. POSIX also
+ * gets a dedicated SIGINT case for the installed JavaScript signal handler;
+ * reliable SIGINT delivery to a detached child is not available on Windows.
  */
 
 const assert = require('assert/strict');
@@ -128,7 +123,7 @@ async function spawnOrchestrator() {
 // on POSIX the SIGTERM handler runs cleanup() then exits; on Windows
 // child.kill maps to TerminateProcess and the 'exit' handler's cleanupSync
 // reaps the tracked grandchild. Either way the grandchild MUST NOT survive.
-test('orchestrator teardown reaps its tracked grandchild on termination (rf2-c3hffe)', async () => {
+test('orchestrator teardown reaps its tracked grandchild on termination', async () => {
   const { child, grandchildPid, cleanupDir } = await spawnOrchestrator();
   try {
     assert.ok(isAlive(grandchildPid), 'grandchild should be alive after spawn');
@@ -150,8 +145,7 @@ test('orchestrator teardown reaps its tracked grandchild on termination (rf2-c3h
     assert.ok(
       dead,
       `grandchild ${grandchildPid} was orphaned — the teardown sweep did ` +
-        `not reap the tracked server when the orchestrator was terminated. ` +
-        `This is exactly the rf2-c3hffe orphan-lock-holder class.`,
+        `not reap the tracked server when the orchestrator was terminated.`,
     );
   } finally {
     if (isAlive(grandchildPid)) {
@@ -167,10 +161,10 @@ test('orchestrator teardown reaps its tracked grandchild on termination (rf2-c3h
 
 // POSIX-only: assert the SIGINT signal-handler arm specifically. On Windows
 // there is no JS SIGINT delivery to a non-console child, so this arm is
-// skipped (the exit-handler arm above covers Windows).
-test('orchestrator teardown reaps its grandchild on SIGINT (POSIX) (rf2-c3hffe)', async () => {
+// skipped; the platform-neutral termination case above covers the outcome.
+test('orchestrator teardown reaps its grandchild on SIGINT (POSIX)', async () => {
   if (process.platform === 'win32') {
-    console.log('  SKIP (Windows: JS SIGINT delivery to a child is not reliable; exit-handler arm covers it)');
+    console.log('  SKIP (Windows: JS SIGINT delivery to a child is not reliable)');
     return;
   }
   const { child, grandchildPid, cleanupDir } = await spawnOrchestrator();

--- a/implementation/scripts/_orchestrator-teardown-policy.test.cjs
+++ b/implementation/scripts/_orchestrator-teardown-policy.test.cjs
@@ -3,35 +3,33 @@
 'use strict';
 
 /*
- * Source-policy gate (rf2-c3hffe): every `serve-and-run-*.cjs` test
+ * Source-policy gate: every `serve-and-run-*.cjs` test
  * orchestrator that spawns a long-lived child server (http-server /
  * shadow-cljs watch / an inner orchestrator) MUST tear that child down on
  * its own exit AND on SIGINT/SIGTERM, via the shared teardown helper in
  * implementation/scripts/lib/local-browser-harness.cjs.
  *
- * WHY THIS EXISTS. On Windows, Node does NOT kill a spawned child when the
+ * On Windows, Node does not kill a spawned child when the
  * parent exits, and `spawnSync` does not forward SIGINT/SIGTERM to its
  * child. An orchestrator that spawns a long-lived server and exits (or is
- * Ctrl-C'd / killed by a CI runner) without explicit teardown therefore
+ * interrupted through a handled signal) without explicit teardown can
  * orphans the server. Orphaned shadow-cljs/Node/http-server processes hold
  * file locks on the worktree (`implementation/`, `tools/`, `out/`), and
- * those stale lock-holders are what deadlock the cross-spec `clojure
- * -M:test` from implementation/core on Windows (rf2-c3hffe; the observed
- * 27h-old stranded xray-feature-gate server). Stopping the leak at source
- * is the durable fix; this gate keeps it stopped.
+ * stale lock-holders can block later test and cleanup work. This gate keeps
+ * teardown ownership explicit at the spawn site.
  *
- * THE HARDENED POSTURE. The shared `createHarnessCleanup()` provides:
+ * The shared `createHarnessCleanup()` provides:
  *   - `installSignalHandlers()` — registers process.once('SIGINT'),
  *     process.once('SIGTERM') and process.once('exit', cleanupSync), so a
- *     signal OR a hard exit reaps the tracked children.
+ *     handled signal or synchronous Node exit reaps the tracked children.
  *   - `trackProcess(child)` — registers a spawned child for teardown.
  *   - cross-platform tree-kill (`taskkill /T /F` on Windows; POSIX
  *     process-group kill on Mac/Linux — see the lib).
  * Every spawning orchestrator must (a) import createHarnessCleanup, (b)
  * call installSignalHandlers(), and (c) spawn its long-lived child through
  * `trackProcess(spawnHarnessProcess(...))` — OR, for its http-server
- * specifically, through the shared `startLocalHttpServer(...)` owner
- * (rf2-slapfs), which performs that tracked spawn internally against the
+ * specifically, through the shared `startLocalHttpServer(...)` owner, which
+ * performs that tracked spawn internally against the
  * cleanup handle you pass it — so the child is reaped on exit/signal.
  *
  * SHORT-LIVED, SELF-EXITING COMPILE STEPS ARE FINE. Most orchestrators run
@@ -39,11 +37,8 @@
  * ...])` for the testbed compile. That child exits on its own (nothing to
  * orphan) and the orchestrator BLOCKS on it, so it needs no teardown — the
  * leak class is the LONG-LIVED server, which must go through the tracked
- * harness. This gate therefore does NOT ban spawnSync outright; it requires
- * the tracked-harness posture for the long-lived server. (Until rf2-hmgwk2
- * it also banned spawnSync outright in the two prod-mode wrappers that
- * spawned an inner orchestrator; those wrappers were collapsed into direct
- * `--root`/`--port` calls on the shared runner, so that special case is gone.)
+ * harness. This gate therefore does not ban spawnSync; it requires the
+ * tracked-harness posture for long-lived children.
  *
  * This is a STATIC text gate — it reads the orchestrator sources and
  * asserts on their text; no process is spawned by this suite. The runtime
@@ -56,8 +51,7 @@
 const assert = require('assert/strict');
 const fs = require('fs');
 const path = require('path');
-// Shared stripComments (EXECUTABLE-source-only matching) + framework-free
-// test harness (rf2-j552l2).
+// Shared executable-source filtering and framework-free test harness.
 const { stripComments, createPolicyTestSuite } = require('./_policy-test-util.cjs');
 
 const IMPL_SCRIPTS_DIR = __dirname;
@@ -104,8 +98,7 @@ const TRACK_PROCESS_RE = /\.trackProcess\(/;
 // harness primitive: `trackProcess(spawnHarnessProcess(...))`. Whitespace/
 // newlines between the call and its argument are tolerated.
 const TRACKED_SPAWN_RE = /trackProcess\(\s*spawnHarnessProcess\(/;
-// rf2-slapfs — starting the http-server via the shared startLocalHttpServer
-// owner is the tracked-long-lived-spawn posture too: it does
+// startLocalHttpServer is also a tracked-long-lived-spawn posture: it calls
 // `cleanup.trackProcess(spawnHarnessProcess(...))` internally against the
 // cleanup handle the caller passes (functionally covered in
 // _local-browser-harness.test.cjs), so a caller that delegates to it still
@@ -118,7 +111,7 @@ const ORCHESTRATORS = orchestratorFiles();
 // Inventory floor: the two scripts dirs hold the known serve-and-run
 // orchestrators. If discovery returns far fewer than expected, the gate
 // would be vacuously green — fail loud instead.
-test('orchestrator inventory is non-trivial (rf2-c3hffe)', () => {
+test('orchestrator inventory is non-trivial', () => {
   assert.ok(
     ORCHESTRATORS.length >= 6,
     `expected at least 6 serve-and-run-*.cjs orchestrators across ` +
@@ -131,7 +124,7 @@ for (const file of ORCHESTRATORS) {
   const base = path.basename(file);
   const code = stripComments(fs.readFileSync(file, 'utf8'));
 
-  test(`${base}: uses the shared createHarnessCleanup teardown helper (rf2-c3hffe)`, () => {
+  test(`${base}: uses the shared createHarnessCleanup teardown helper`, () => {
     assert.match(
       code,
       CREATE_CLEANUP_RE,
@@ -139,62 +132,51 @@ for (const file of ORCHESTRATORS) {
         `helper. Use createHarnessCleanup() from ` +
         `./lib/local-browser-harness.cjs (or the ../../implementation/scripts ` +
         `copy for examples/scripts) so the spawned child is reaped on ` +
-        `exit/SIGINT/SIGTERM. An orphaned server holds worktree file locks ` +
-        `and deadlocks the cross-spec JVM suite on Windows (rf2-c3hffe).`,
+        `exit/SIGINT/SIGTERM. An orphaned server can retain ports and worktree ` +
+        `file locks.`,
     );
   });
 
-  test(`${base}: installs exit/SIGINT/SIGTERM teardown handlers (rf2-c3hffe)`, () => {
+  test(`${base}: installs exit/SIGINT/SIGTERM teardown handlers`, () => {
     assert.match(
       code,
       INSTALL_SIGNALS_RE,
       `${base} must call cleanup.installSignalHandlers() so a SIGINT/` +
         `SIGTERM (Ctrl-C, CI runner kill) or a hard process exit tree-kills ` +
-        `the spawned server. Without it the server is orphaned on signal ` +
-        `(rf2-c3hffe).`,
+        `the spawned server.`,
     );
   });
 
-  test(`${base}: tracks its long-lived child for teardown (rf2-c3hffe)`, () => {
+  test(`${base}: tracks its long-lived child for teardown`, () => {
     assert.ok(
       TRACK_PROCESS_RE.test(code) || START_LOCAL_HTTP_SERVER_RE.test(code),
       `${base} must register its long-lived child for teardown — either via ` +
         `cleanup.trackProcess(...) directly, or by starting its http-server ` +
         `through the shared startLocalHttpServer(...) owner, which tracks the ` +
-        `server in the cleanup handle you pass it (rf2-slapfs). A spawn that ` +
-        `is not tracked is not reaped (rf2-c3hffe).`,
+        `server in the cleanup handle you pass it. An untracked spawn is not ` +
+        `reaped.`,
     );
   });
 
-  test(`${base}: spawns its long-lived child via the tracked shared harness (rf2-c3hffe)`, () => {
+  test(`${base}: spawns its long-lived child via the tracked shared harness`, () => {
     assert.ok(
       TRACKED_SPAWN_RE.test(code) || START_LOCAL_HTTP_SERVER_RE.test(code),
       `${base} must spawn its long-lived child (http-server / shadow-cljs ` +
         `watch / inner orchestrator) via trackProcess(spawnHarnessProcess(...)) ` +
         `— or, for the http-server specifically, via the shared ` +
         `startLocalHttpServer(...) owner, which performs that tracked spawn ` +
-        `internally (rf2-slapfs). That is the only spawn posture the teardown ` +
+        `internally. That is the only spawn posture the teardown ` +
         `sweep reaps cross-platform. A short-lived, self-exiting shadow-cljs ` +
-        `compile via spawnSync is fine and is NOT what this checks (rf2-c3hffe).`,
+        `compile via spawnSync is fine and is not what this checks.`,
     );
   });
 }
-
-// The two prod-mode gates (test:browser-prod-elision,
-// test:browser-schemas-boundary-prod) used to route through mirrored
-// serve-and-run-{prod-elision,schemas-boundary-prod}-tests.cjs wrappers that
-// only set BROWSER_TEST_ROOT/PORT before spawning the inner
-// serve-and-run-browser-tests.cjs orchestrator. rf2-hmgwk2 collapsed those
-// wrappers: the gates now call the shared runner directly with `--root` /
-// `--port`, so there is no longer an extra process whose teardown posture
-// needs pinning here — the shared runner's own tracked-harness teardown
-// (guarded by the dynamic sweep above) is the whole story.
 
 // stripComments sanity: it must remove a required-symbol mention that
 // appears only in a comment, but keep one in real code. Guards the gate
 // against false-positives (a comment satisfying a positive assertion) and
 // false-negatives (a comment masking a forbidden spawnSync).
-test('stripComments removes comment text but preserves code (rf2-c3hffe)', () => {
+test('stripComments removes comment text but preserves code', () => {
   assert.doesNotMatch(
     stripComments('// createHarnessCleanup()\nconst x = 1;'),
     CREATE_CLEANUP_RE,

--- a/implementation/scripts/_path-policy.cjs
+++ b/implementation/scripts/_path-policy.cjs
@@ -1,5 +1,5 @@
 /*
- * Shared path-policy helper (rf2-o38lb, policy-confirmed by rf2-21rfv).
+ * Shared path-policy helper for script-controlled filesystem paths.
  *
  * The implementation root carries several scripts that accept env-var
  * overrides for filesystem paths they then read or write:
@@ -10,13 +10,9 @@
  *     `STORY_BUILD_INDEX_HTML`, then writes `${OUTPUT_DIR}/index.html`
  *     and `${OUTPUT_DIR}/manifest.json`.
  *
- * Per rf2-21rfv (pragmatic stance, 2026-05-14): these env vars are
- * **CI-internal knobs**, not a stable public configuration surface.
- * re-frame2 reserves the right to rename / drop them between releases.
- * The path-policy check below is a safety net against accidents — a
- * mistyped path or unset env var that would otherwise turn a normal
- * build run into a `rm -rf` outside the repo — not a hardened sandbox.
- * The devs running these scripts already control the process.
+ * These are CI-internal knobs, not stable public configuration. The policy is
+ * an accident guard for destructive or misplaced I/O, not a security boundary:
+ * the developer running the scripts already controls the process.
  *
  * Policy:
  *
@@ -51,8 +47,7 @@ const REPO_ROOT = path.resolve(IMPL_ROOT, '..');
 const DEFAULT_OUT_ROOT = path.join(IMPL_ROOT, 'out');
 const DEFAULT_HTML_ROOTS = [
   path.join(REPO_ROOT, 'examples'),
-  // rf2-p8f2s — tool-owned testbeds may host index.html templates
-  // (e.g. tools/story/testbeds/counter_with_stories/story_static.index.html).
+  // Tool-owned testbeds may host index.html templates.
   path.join(REPO_ROOT, 'tools'),
   IMPL_ROOT,
 ];
@@ -77,8 +72,8 @@ function isInside(candidate, root) {
   return true;
 }
 
-// Resolve symlinks/junctions on an absolute path WITHOUT requiring the
-// full path to exist (rf2-l9upzf). A lexical `path.resolve` alone lets a
+// Resolve symlinks/junctions on an absolute path without requiring the
+// full path to exist. A lexical `path.resolve` alone lets a
 // symlink/junction under an allowed root point outside the approved
 // boundary while still passing the lexical prefix check — the writing
 // scripts then follow the link and escape. To close this, walk up to the
@@ -111,9 +106,9 @@ function realpathExistingPrefix(abs) {
   try {
     realExisting = fs.realpathSync(existing);
   } catch (_) {
-    // realpath can fail on a broken link / permission edge — fall back to
-    // the lexical absolute path (fail-closed: the lexical check still
-    // applies, we just couldn't canonicalise further).
+    // realpath can fail on a broken link or permission edge. Preserve the
+    // lexical containment guard in that case; this helper is an accident
+    // guard, not a hardened sandbox against a hostile filesystem layout.
     return abs;
   }
   return tail.length === 0 ? realExisting : path.join(realExisting, ...tail);
@@ -127,7 +122,7 @@ function enforcePolicy(label, candidate, opts) {
   // callers see the path they passed (lexically normalised), not a
   // surprise canonical rewrite.
   const lexicalAbs = path.resolve(candidate);
-  // CONTAINMENT CHECK runs on REALPATHS (rf2-l9upzf): collapse any
+  // Containment normally runs on real paths: collapse any
   // existing symlink/junction in BOTH the candidate and the allowed
   // roots before comparing, so a link that resolves outside an approved
   // root is rejected even though its lexical path looked inside. Roots
@@ -153,7 +148,7 @@ function enforcePolicy(label, candidate, opts) {
     `${label}: refusing to use '${lexicalAbs}' — path is outside the approved ` +
       `roots (${allowed.map((r) => `'${r}'`).join(', ')}). ` +
       `To allow out-of-tree paths (downstream-consumer use), set ` +
-      `${OPT_IN_VAR}=1 in the environment. Per rf2-o38lb security audit.`,
+      `${OPT_IN_VAR}=1 in the environment.`,
   );
 }
 

--- a/implementation/scripts/_reagent-slim-smoke-policy.test.cjs
+++ b/implementation/scripts/_reagent-slim-smoke-policy.test.cjs
@@ -209,10 +209,9 @@ it('`test:script-policy` runs THIS policy test', () => {
   );
 });
 
-// ---- 5b) PR CI ACTUALLY RUNS the smoke gate (rf2-5v0dg7) ------------------
-// Teeth beyond "the npm script exists": the workflow must EXECUTE it, and a
-// reagent-slim surface change must ARM the job that runs it. Without these,
-// the smoke can silently stop running in PR CI (the exact rf2-5v0dg7 bug).
+// ---- 5b) PR CI runs the smoke gate ---------------------------------------
+// The workflow must execute the npm script, and reagent-slim changes must arm
+// its job; declaring an unreferenced script is not CI coverage.
 
 const WORKFLOW_SRC = fs.existsSync(WORKFLOW) ? read(WORKFLOW) : '';
 const CHANGED_SURFACES_SRC = fs.existsSync(CHANGED_SURFACES) ? read(CHANGED_SURFACES) : '';

--- a/implementation/scripts/_rigorous-local-inventory.test.cjs
+++ b/implementation/scripts/_rigorous-local-inventory.test.cjs
@@ -22,7 +22,7 @@
  *     implementation browser and bundle gates" step also runs in the local
  *     script (lockstep — the local mirror must not drift BEHIND the nightly
  *     sweep for implementation browser/bundle commands).
- *  2. The two commands the bead names — `test:examples-compile` and
+ *  2. The two inventory commands — `test:examples-compile` and
  *     `test:story-play-scripts` — are present in the local script (a direct
  *     pin, independent of the parse, so neither can silently drop out again).
  *  3. Every command the local script invokes is a real `package.json` script

--- a/implementation/scripts/_script-spawn-policy.test.cjs
+++ b/implementation/scripts/_script-spawn-policy.test.cjs
@@ -49,8 +49,7 @@
 const assert = require('assert/strict');
 const fs = require('fs');
 const path = require('path');
-// Shared stripComments (EXECUTABLE-source-only matching) + loopbackBindRe
-// factory + framework-free test harness (rf2-j552l2).
+// Shared executable-source filtering, loopback matcher, and test harness.
 const {
   stripComments,
   loopbackBindRe,
@@ -58,13 +57,7 @@ const {
 } = require('./_policy-test-util.cjs');
 
 const SCRIPTS_DIR = __dirname;
-// rf2-y9o5e3 — the executable browser-gate launchers under
-// examples/scripts/ run the SAME shadow-cljs compile + http-server spawn
-// posture as the implementation/scripts launchers, and `npm run
-// test:adapter-smokes` / `test:story-feature-load` / `test:story-play-scripts`
-// drive them on Windows local runs. They were previously OUTSIDE this
-// policy gate (it scanned only implementation/scripts/), so a forbidden
-// npx.cmd/cmd.exe/shell posture survived there. Pull them in here.
+// Examples browser-gate launchers share the same shell-free spawn policy.
 const EXAMPLES_SCRIPTS_DIR = path.resolve(
   __dirname,
   '..',
@@ -72,10 +65,8 @@ const EXAMPLES_SCRIPTS_DIR = path.resolve(
   'examples',
   'scripts',
 );
-// The adapter-smoke harness (orchestrator + runner + manifest) moved here,
-// colocated with the adapters it drives. It runs the SAME shadow-cljs
-// compile + http-server spawn posture, so it must stay under this shell-free
-// spawn policy.
+// The adapter-smoke harness is colocated with the adapters it drives and is
+// subject to the same policy.
 const ADAPTERS_SCRIPTS_DIR = path.resolve(__dirname, '..', 'adapters', 'scripts');
 
 const { test, run } = createPolicyTestSuite('script-spawn-policy');
@@ -90,11 +81,8 @@ function cjsFilesIn(dir) {
     .map((f) => path.join(dir, f));
 }
 
-// implementation/scripts/** (the original rf2-wn4o1 scope) PLUS the
-// executable launchers under examples/scripts/** (rf2-y9o5e3). The
-// examples/scripts dir holds the three browser-gate launchers, their
-// Playwright runners, port resolvers, helpers, and static scanners; none
-// may carry a shell:true/npx.cmd posture, so the whole dir is scanned.
+// Scan every executable launcher in the implementation, examples, and adapter
+// script surfaces.
 function gateScriptFiles() {
   return [
     ...cjsFilesIn(SCRIPTS_DIR),
@@ -104,13 +92,9 @@ function gateScriptFiles() {
 }
 
 // Any `shell:` option whose RHS is NOT the literal `false` is a
-// violation. The earlier `(true|isWin)` enumeration only caught the two
-// forms the audit happened to see, so a future `shell: process.platform
-// === 'win32'` / `shell: useShell` / `shell: 1` + a bare-name exe would
-// slip the rf2-33vvc command-hijack class. Forbid every truthy/dynamic
-// RHS; only `shell: false` (and absence of the option) is allowed
-// (rf2-8ng3e1). The `(?!false\b)` negative lookahead lets `false` pass
-// while rejecting any other non-whitespace RHS token.
+// violation. Only `shell: false` (or omission) is allowed; dynamic values can
+// hide a platform-specific shell spawn. The negative lookahead lets the literal
+// `false` pass while rejecting any other non-whitespace token.
 const SHELL_OPT_RE = /\bshell\s*:\s*(?!false\b)\S/;
 // A `.cmd`-suffixed npx literal — `'npx.cmd'` / `"npx.cmd"`. Always a
 // violation: the Windows `.cmd` shim only ever needs naming when you
@@ -123,24 +107,14 @@ const NPX_CMD_LITERAL_RE = /(['"])npx\.cmd\1/;
 const NPX_BARE_LITERAL_RE = /(['"])npx\1/;
 const TRUSTED_EXE_RE = /resolveTrustedExe/;
 const CROSS_SPAWN_RE = /cross-spawn|crossSpawn/;
-// The bare-'npx' exemption is name-whitelisted to the single blessed
-// launcher. The exemption was previously earned file-WIDE by any file
-// merely MENTIONING resolveTrustedExe + cross-spawn, so a file routing
-// ONE spawn through the blessed posture won a blanket bare-'npx' pass for
-// a SEPARATE, unrouted spawn elsewhere in the same file. Pinning the
-// exemption to the audited file (test-mcp-conformance.cjs, which routes
-// every spawn through resolveTrustedExe + crossSpawn.sync) closes that
-// cross-file slip: any other launcher that grows a bare 'npx' is now a
-// violation regardless of which helpers it imports (rf2-8ng3e1).
+// The bare-'npx' exemption is limited to the one launcher whose whole spawn
+// path uses trusted resolution and cross-spawn.
 const TRUSTED_RESOLUTION_FILES = new Set(['test-mcp-conformance.cjs']);
 
 for (const file of gateScriptFiles()) {
   const base = path.basename(file);
   const code = stripComments(fs.readFileSync(file, 'utf8'));
-  // The exemption is gated on the file NAME (the audited, whole-file-
-  // routed launcher) AND on it still carrying the trusted-resolution
-  // posture — so even the blessed file loses the pass if it ever drops
-  // resolveTrustedExe / cross-spawn (rf2-8ng3e1).
+  // Both the audited filename and the trusted-resolution calls are required.
   const usesTrustedResolution =
     TRUSTED_RESOLUTION_FILES.has(base) &&
     TRUSTED_EXE_RE.test(code) &&
@@ -179,9 +153,7 @@ for (const file of gateScriptFiles()) {
   });
 }
 
-// Positive guards: the three scripts the audit (rf2-wn4o1) hardened must
-// keep their resolved-entry-point + process.execPath posture. These pin
-// the fix so a future edit can't quietly regress to npx-under-a-shell.
+// Pin resolved entry points and process.execPath for representative launchers.
 test('serve-and-run-browser-tests.cjs resolves http-server + spawns under process.execPath', () => {
   const src = fs.readFileSync(
     path.join(SCRIPTS_DIR, 'serve-and-run-browser-tests.cjs'),
@@ -207,13 +179,8 @@ test('serve-and-run-xray-feature-gate.cjs resolves shadow-cljs runner + spawns i
   assert.match(src, /spawnSync\(\s*process\.execPath,\s*args/);
 });
 
-// rf2-y9o5e3 — positive guards for the browser-gate launchers. Each must
-// resolve the shadow-cljs JS entry-point and spawn it shell-free under
-// process.execPath (the same hardened posture as the implementation/scripts
-// launchers above), so a future edit can't quietly regress to the
-// npx.cmd/cmd.exe/shell posture this bead removed. The adapter-smoke
-// orchestrator lives under implementation/adapters/scripts/ now; the two
-// Story launchers stay under examples/scripts/.
+// Browser-gate launchers resolve shadow-cljs and spawn it under the current
+// Node executable.
 const GATE_LAUNCHERS = [
   ['serve-and-run-adapter-smokes.cjs', ADAPTERS_SCRIPTS_DIR],
   ['serve-and-run-story-feature-load-tests.cjs', EXAMPLES_SCRIPTS_DIR],
@@ -235,28 +202,25 @@ for (const [base, dir] of GATE_LAUNCHERS) {
   });
 }
 
-// Loopback-bind policy (rf2-utvst): every implementation http-server
+// Every implementation http-server
 // launcher only ever serves a loopback consumer (the readiness probe +
 // the headless browser both hit 127.0.0.1), so each must spawn
 // http-server with an explicit `-a 127.0.0.1` rather than relying on
 // http-server's broad 0.0.0.0 default — otherwise the generated app
 // bundle and the per-run `.rf-harness-token` endpoint are reachable on
-// non-loopback interfaces during a test run. This mirrors the examples-
-// side guard in _story-script-runners-policy.test.cjs (rf2-wf5al.2). The
+// non-loopback interfaces during a test run. The
 // regex matches the http-server bin token followed (within a short
 // window) by the `'-a', '127.0.0.1'` pair. NB `[\s\S]{0,80}?` not `[^]`
 // (the JS-regex `[^]`-any-char gotcha).
 const LOOPBACK_BIND_RE = loopbackBindRe('HTTP_SERVER_BIN');
-// [base, dir] — the ownership-token-handshake launchers that still compose the
+// Ownership-token launchers compose the http-server argv inline
 // http-server argv inline (they publish + verify a per-run /.rf-harness-token
 // via waitForOwnedHttpReady, a handshake startLocalHttpServer does not yet
 // own). Each serves its bundle on loopback only (readiness probe + headless
 // browser both hit 127.0.0.1), so a future edit dropping the explicit
 // `-a 127.0.0.1` would silently re-expose the bundle on 0.0.0.0 and trip no
-// test. The tokenless four (the two Story launchers, serve-example, the
-// adapter-smoke orchestrator) NO LONGER appear here: they delegate the
-// loopback bind to startLocalHttpServer and are pinned by the
-// startLocalHttpServer caller-use guard below (rf2-slapfs).
+// test. Tokenless launchers delegate this policy to startLocalHttpServer and
+// are covered by the caller-use guard below.
 const IMPL_LOOPBACK_LAUNCHERS = [
   ['serve-and-run-browser-tests.cjs', SCRIPTS_DIR],
   ['check-story-static.cjs', SCRIPTS_DIR],
@@ -276,19 +240,10 @@ for (const [base, dir] of IMPL_LOOPBACK_LAUNCHERS) {
   });
 }
 
-// rf2-slapfs — startLocalHttpServer consolidation guard. The four launchers
-// that serve a local static tree behind a PLAIN (tokenless) readiness
-// handshake — the two Story launchers, serve-example, and the adapter-smoke
-// orchestrator — now delegate their http-server spawn / teardown-track /
-// early-exit-abort / readiness composition to the single startLocalHttpServer
-// owner in local-browser-harness.cjs (whose loopback `-a 127.0.0.1` bind +
-// static/no-cache flags are verified functionally in
-// _local-browser-harness.test.cjs). Pin the two that live under a dir this
-// suite already scans; the two Story launchers are pinned in
-// _story-script-runners-policy.test.cjs. A launcher re-inlining a bespoke
-// http-server spawn — the composition drift rf2-slapfs removed — trips here.
-// (Scanned over stripped source so a comment naming the helper is not a false
-// positive.)
+// Tokenless launchers delegate spawn, tracking, early-exit detection, and
+// readiness to startLocalHttpServer. Its loopback/static/no-cache behavior is
+// covered functionally in _local-browser-harness.test.cjs; Story callers are
+// pinned by _story-script-runners-policy.test.cjs.
 const START_LOCAL_HTTP_SERVER_CALLERS = [
   ['serve-and-run-adapter-smokes.cjs', ADAPTERS_SCRIPTS_DIR],
   ['serve-example.cjs', EXAMPLES_SCRIPTS_DIR],
@@ -296,7 +251,7 @@ const START_LOCAL_HTTP_SERVER_CALLERS = [
 const HARNESS_IMPORT_RE = /require\(\s*['"][^'"]*local-browser-harness\.cjs['"]\s*\)/;
 const START_LOCAL_HTTP_SERVER_RE = /\bstartLocalHttpServer\s*\(/;
 for (const [base, dir] of START_LOCAL_HTTP_SERVER_CALLERS) {
-  test(`${base}: delegates http-server startup to the shared startLocalHttpServer owner (rf2-slapfs)`, () => {
+  test(`${base}: delegates http-server startup to the shared startLocalHttpServer owner`, () => {
     const code = stripComments(fs.readFileSync(path.join(dir, base), 'utf8'));
     assert.match(
       code,
@@ -307,23 +262,13 @@ for (const [base, dir] of START_LOCAL_HTTP_SERVER_CALLERS) {
       code,
       START_LOCAL_HTTP_SERVER_RE,
       `${base} must start its http-server via the shared startLocalHttpServer(...) ` +
-        `owner rather than re-inlining a bespoke http-server spawn (rf2-slapfs).`,
+        `owner rather than re-inlining a bespoke http-server spawn.`,
     );
   });
 }
 
-// rf2-vtp2er — runner-consolidation guard. The browser-test and
-// story-static launchers were migrated off their bespoke copies of the
-// ownership-token / port-fallback protocol onto the shared
-// local-browser-harness.cjs primitives (the same API the Xray gate
-// consumes). Pin that: each must (a) import resolveServePort +
-// waitForOwnedHttpReady from the shared helper, and (b) NOT redefine the
-// local copies that previously lived inline (`function fetchToken`,
-// `function waitForReady`, `function isPortFree`, `function findFreePort`,
-// `function probe`). A future edit re-introducing a bespoke copy — the
-// exact three-implementations-in-one-surface drift the bead removed —
-// trips here. (Scanned over stripped source so a comment mentioning the
-// old names is not a false positive.)
+// Browser-test and Story-static launchers must consume the shared port and
+// ownership-token primitives without redefining them locally.
 const CONSOLIDATED_LAUNCHERS = [
   'serve-and-run-browser-tests.cjs',
   'check-story-static.cjs',
@@ -339,7 +284,7 @@ const LOCAL_HARNESS_DEFN_RES = [
   /function\s+probe\b/,
 ];
 for (const base of CONSOLIDATED_LAUNCHERS) {
-  test(`${base}: consumes the shared local-browser-harness port/token primitives (rf2-vtp2er)`, () => {
+  test(`${base}: consumes the shared local-browser-harness port/token primitives`, () => {
     const code = stripComments(
       fs.readFileSync(path.join(SCRIPTS_DIR, base), 'utf8'),
     );
@@ -351,7 +296,7 @@ for (const base of CONSOLIDATED_LAUNCHERS) {
       `${base} must wait for owned readiness via the shared waitForOwnedHttpReady.`);
   });
 
-  test(`${base}: does NOT redefine the consolidated harness primitives (rf2-vtp2er)`, () => {
+  test(`${base}: does not redefine the consolidated harness primitives`, () => {
     const code = stripComments(
       fs.readFileSync(path.join(SCRIPTS_DIR, base), 'utf8'),
     );
@@ -359,22 +304,14 @@ for (const base of CONSOLIDATED_LAUNCHERS) {
       assert.doesNotMatch(code, re,
         `${base} redefines a harness primitive that now lives in ` +
           `./lib/local-browser-harness.cjs — import it instead of keeping ` +
-          `a bespoke copy (rf2-vtp2er consolidation).`);
+          `a bespoke copy.`);
     }
   });
 }
 
-// rf2-pgppmu — ownership-token lifecycle consolidation guard. All five
-// browser-harness launchers that publish a per-run /.rf-harness-token now
-// delegate the token generate/write + idempotent, concurrency-safe cleanup
-// to the shared publishOwnershipToken(root) in local-browser-harness.cjs
-// (which already owns the read side: fetchToken + waitForOwnedHttpReady).
-// Pin that: none may keep a bespoke writeOwnershipToken/removeOwnershipToken
-// pair or a token-only `require('crypto')`, and each must consume the shared
-// helper. A future edit re-introducing a local copy — the exact
-// five-implementations-in-one-surface drift the bead removed — trips here.
-// (Scanned over stripped source so a comment naming the old symbols is not a
-// false positive.)
+// Ownership-token launchers delegate nonce creation, publication, and
+// concurrency-safe cleanup to publishOwnershipToken. They must not retain a
+// local token lifecycle or token-only crypto import.
 const TOKEN_LIFECYCLE_LAUNCHERS = [
   'serve-and-run-browser-tests.cjs',
   'check-story-static.cjs',
@@ -389,7 +326,7 @@ const LOCAL_TOKEN_DEFN_RES = [
 ];
 const CRYPTO_REQUIRE_RE = /require\(\s*['"]crypto['"]\s*\)/;
 for (const base of TOKEN_LIFECYCLE_LAUNCHERS) {
-  test(`${base}: delegates its ownership-token lifecycle to the shared helper (rf2-pgppmu)`, () => {
+  test(`${base}: delegates its ownership-token lifecycle to the shared helper`, () => {
     const code = stripComments(
       fs.readFileSync(path.join(SCRIPTS_DIR, base), 'utf8'),
     );
@@ -400,12 +337,12 @@ for (const base of TOKEN_LIFECYCLE_LAUNCHERS) {
       assert.doesNotMatch(code, re,
         `${base} defines a local ownership-token lifecycle fn that now lives ` +
           `in ./lib/local-browser-harness.cjs (publishOwnershipToken) — import ` +
-          `it instead of keeping a bespoke copy (rf2-pgppmu consolidation).`);
+          `it instead of keeping a bespoke copy.`);
     }
     assert.doesNotMatch(code, CRYPTO_REQUIRE_RE,
       `${base} still imports 'crypto' — the per-run token nonce now comes ` +
         `from the shared publishOwnershipToken; drop the token-only crypto ` +
-        `import (rf2-pgppmu).`);
+        `import.`);
   });
 }
 

--- a/implementation/scripts/_story-script-runners-policy.test.cjs
+++ b/implementation/scripts/_story-script-runners-policy.test.cjs
@@ -70,7 +70,7 @@ test('computeExitCode: clean run (no failures, no pageerrors) → 0', () => {
 });
 
 test('computeExitCode: a pageerror fails the gate even when all play rows matched (rf2-wf5al.1)', () => {
-  // The false-green case the bead describes: every play row reported its
+  // False-green case: every play row reported its
   // expected pass/fail status (failures empty) but the shell threw an
   // uncaught exception. Must be RED.
   assert.equal(
@@ -199,8 +199,8 @@ test('both wait loops gate on isTerminalStatus (rf2-wf5al.3)', () => {
 
 // The seeded inventory shape: eight discovered rows, five classified
 // expected-pass and three expected-fail (the `failing` / `-expected-fail`
-// markers below) — the 8 / 5-pass / 3-fail shape the bead pins as the
-// healthy gate. Mirrors the counter-with-stories testbed's seeded
+// markers below) — the 8 / 5-pass / 3-fail healthy inventory shape.
+// Mirrors the counter-with-stories testbed's seeded
 // fixtures and the runner's `expectedStatusFor` classification.
 const SEEDED_ROWS = [
   // 5 expected-pass:

--- a/implementation/scripts/api-manifest/deps.edn
+++ b/implementation/scripts/api-manifest/deps.edn
@@ -1,4 +1,4 @@
-;; Public-API manifest generator (rf2-3nbl5.2 — API-governance keystone).
+;; Public-API manifest generator and projection checks.
 ;;
 ;; Self-contained classpath that pulls BOTH the implementation artefacts
 ;; (core + every optional feature artefact) AND the JVM-loadable tool
@@ -14,7 +14,7 @@
 ;; namespaces, the Xray `mount-*!` family, the pair-MCP server) cannot
 ;; be `require`d on the JVM — their rows are carried in the curated
 ;; sidecar and passed through verbatim. The CLJS-side enumeration probe
-;; (rf2-2mtte, ../api-manifest/probe/, run by `npm run test:cljs`)
+;; (`probe/`, run by `npm run test:cljs` from `implementation/`)
 ;; runtime-verifies the covered namespaces; each row carries its own
 ;; `:runtime-verified?` flag (true once the probe covers it).
 ;;
@@ -37,11 +37,8 @@
          ;; Tool artefacts with JVM-loadable (.cljc) public namespaces.
          day8/re-frame2-story    {:local/root "../../../tools/story"}
          day8/re-frame2-mcp-base {:local/root "../../../tools/mcp-base"}}
- ;; Projection-check unit tests (rf2-0u8kz). Same quiet-runner shape as the
- ;; per-artefact :test aliases. The tests reconcile synthetic + live inputs
- ;; through the pure reconcilers so the namespace-qualified resolution
- ;; contract (a fully-qualified panel symbol must match its EXACT [ns var],
- ;; never merely share a bare var name) is regression-locked.
+ ;; Projection-check unit tests. A qualified symbol must match its exact
+ ;; [namespace var] row, never merely share a bare var name.
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps  {day8/re-frame2-test-quiet {:local/root "../../test-quiet"}

--- a/implementation/scripts/api-manifest/probe/src/re_frame/api_manifest/cljs_probe.cljc
+++ b/implementation/scripts/api-manifest/probe/src/re_frame/api_manifest/cljs_probe.cljc
@@ -39,7 +39,7 @@
   curated `:kind :fn` on those rows is the correct human assertion; the
   analyzer simply cannot reproduce it. Reconciling `:kind` here would
   fail on an analyzer limitation, not a real drift — so the probe checks
-  EXISTENCE (the contract the bead asks for: added / removed / renamed),
+  EXISTENCE (added / removed / renamed),
   not `:kind`. The JVM-loadable kind derivation stays authoritative on
   the JVM side; for CLJS-only value-defs the sidecar's curated `:kind`
   stands.

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/api_md_check.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/api_md_check.clj
@@ -1,5 +1,5 @@
 (ns re-frame.api-manifest.api-md-check
-  "spec/API.md projection check (rf2-3nbl5.2).
+  "spec/API.md projection check.
 
   spec/API.md is the most-important PROJECTION of the public-API manifest
   — the human-readable reference whose every var-row carries a Tier
@@ -19,12 +19,11 @@
   Keyword rows (`:rf.http/managed`, `:rf/route`, …) and prose-celled rows
   are skipped — they are not vars and carry no Tier-for-a-var.
 
-  QUALIFIER RESOLUTION (rf2-41j0a). API.md writes some var names
+  QUALIFIER RESOLUTION. API.md writes some var names
   namespace-qualified (`helix-adapter/adapter`, `re-frame.http/get`,
   `re-frame.interop/debug-enabled?`) and others bare (`reg-event`). The
   two SHAPES resolve against DIFFERENT manifest indexes, because they carry
-  different identity — exactly the rf2-0u8kz lesson the Xray-spec check
-  already pins:
+      different identity:
 
     - A QUALIFIED row names BOTH a namespace (or its documented `:as`
       alias) AND a var. It resolves STRICTLY against the `[namespace var]`
@@ -261,27 +260,6 @@
   [extracted]
   (projection/vacuity-floor-problem "spec/API.md" extracted min-var-rows))
 
-;; ---------------------------------------------------------------------------
-;; Positive prose-phrase pins REMOVED (rf2 toomuch trimming review).
-;;
-;; Two positive content pins used to live here: a `reg-cofx` contract pin
-;; (`reg-cofx-required-phrases`, requiring literal English like "value-
-;; returning supplier" verbatim on the spec/API.md row) and an `:rf.egress/*`
-;; closed-enum pin (`egress-closed-enum`, requiring all ten members named on
-;; one spec/Conventions.md row). Both were over-strict: a legitimate reword
-;; or table reorganisation — with NO var/API change — went RED, so the gate
-;; punished prose churn rather than catching real drift.
-;;
-;; The load-bearing protections stay: the var-resolution reconcile + tier
-;; allowlists (above) catch a renamed/removed/retiered var; the same-line
-;; keyword-drift scans (`projection/ep00{17,11,15}-…-problems`, wired into
-;; `kw-probs` below) hard-fail a RETIRED keyword form reappearing as live
-;; vocabulary (`:rf.world/inputs`, `:stale-key` / bare `:work-id`, retired
-;; `:rf.egress/*` profile spellings); and the non-vacuous floors refuse a
-;; green when the extractor collapses. A keyword-form retirement is a code
-;; reference (settled, closed, drift-bearing); a prose phrase is not.
-;; ---------------------------------------------------------------------------
-
 (defn check!
   "Validate spec/API.md var-rows against the manifest. Returns true when
    every API.md var-row resolves to a manifest row with a MATCHING tier;
@@ -306,15 +284,12 @@
                                :aliases            adapter-aliases})
         api-md-lines (with-open [r (io/reader @api-md-file)]
                        (vec (map-indexed (fn [i line] [(inc i) line]) (line-seq r))))
-        ;; EP-0017 keyword-drift guard (rf2-tawage): the var-row reconcile is
-        ;; blind to stale `:rf.world/inputs` keyword vocabulary creeping into
-        ;; API.md prose outside an explicit retirement/rename mention.
-        ;; EP-0011 (rf2-uhew69) + EP-0015 (rf2-1zjkn8) add the reply-envelope
+        ;; Var-row reconciliation cannot see retired keyword vocabulary in
+        ;; API.md prose. The reply-envelope
         ;; (`:stale-key` / bare `:work-id`) and egress-profile (retired
         ;; `:rf.egress/on-box-*` / `trusted-local-*`) keyword guards over the
         ;; same API.md prose, all on the same retirement-marker discipline.
-        ;; These fire only on RETIRED keyword FORMS (code references), not on
-        ;; prose — the positive prose-phrase pins were removed as over-strict.
+        ;; These fire only on retired keyword forms, not prose phrasing.
         kw-probs   (concat
                      (projection/ep0017-keyword-drift-problems "spec/API.md" api-md-lines)
                      (projection/ep0011-reply-vocab-drift-problems "spec/API.md" api-md-lines)

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/doc_api_check.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/doc_api_check.clj
@@ -1,31 +1,19 @@
 (ns re-frame.api-manifest.doc-api-check
-  "Human-doc API-reference projection check (rf2-vzupmg).
+  "Human-documentation API-reference projection check.
 
-  THE GAP THIS CLOSES. The keystone manifest drift-check (rf2-3nbl5.2) and
-  its `spec/API.md` projection (`api-md-check`) plus the four secondary
-  projection checks (`doc-guide-check`, `story-spec-check`, `xray-spec-check`,
-  `skills-check`) between them scan `spec/API.md`, `docs/core/**`, the two
-  tool API specs, and `skills/`. They do NOT scan the three human-facing API
-  REFERENCE trees:
+  The check owns these human-facing API reference surfaces:
 
     * `spec/Privacy.md`   — the EP-0015 cross-artefact privacy inventory;
     * `docs/core/api/**` — the per-chapter human API reference;
     * `docs/story/api/**` — the Story human API reference.
 
-  EP-0025 stale prose slipped into exactly those trees and passed EVERY CI
-  check because nothing reconciled their public-var references against the
-  manifest. This check extends the SAME call-position discipline the
-  doc-guide check uses to those three trees: every call-position
+  It uses the same call-position discipline as the guide check: every
+  call-position
   `(rf/<var>` / `(story/<var>` reference must resolve to a manifest row, so a
   reference to a renamed / removed / never-manifested public surface goes RED.
 
-  CAPABILITY API DOCS (rf2-earvtz). The #4961 docs reorg moved each
-  capability's API REFERENCE out of the flat top-level API tree into
-  per-capability `docs/<cap>/api.md` files (machines / resources / routing /
-  ssr). Those API docs are the same projection class — they name public vars
-  in call position — and so are scanned here via the `docs/*/api.md` glob
-  (which auto-covers a future capability dir). Without this, a removed /
-  renamed public surface named in a moved API doc would slip through CI.
+  Per-capability `docs/<cap>/api.md` files are scanned by a one-level glob that
+  also discovers future capability docs.
 
   SCOPE — call-position discipline (same as doc-guide / skills checks).
   References are anchored on the leading `(` so the `:rf/*` reserved keyword

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/doc_guide_check.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/doc_guide_check.clj
@@ -1,5 +1,5 @@
 (ns re-frame.api-manifest.doc-guide-check
-  "Doc-guide projection check (rf2-gkp0t).
+  "Documentation-guide projection check.
 
   The human guide (`docs/core/**/*.md`) teaches re-frame2 through worked
   code. Every code sample names front-porch / advanced vars through the
@@ -7,19 +7,14 @@
   no longer resolves. This check extracts every call-position `(rf/<var>`
   reference and asserts each resolves to a manifest `re-frame.core` row.
 
-  CAPABILITY CONCEPT DOCS (rf2-earvtz). The #4961 docs reorg moved each
-  capability's CONCEPT doc out of the flat `docs/core/` tree into
-  per-capability `docs/<cap>/concepts.md` files (machines / resources /
-  routing / ssr). Those concept docs teach the same worked code and so are
-  scanned by this gate alongside `docs/core/` — the `docs/*/concepts.md`
-  glob folds them in (and auto-covers a future capability dir). Without this,
-  a broken `(rf/<var>` reference in a moved concept doc would slip through CI.
+  Per-capability `docs/<cap>/concepts.md` files are scanned alongside
+  `docs/core/`; the one-level glob also discovers future capability docs.
 
   SCOPE — same call-position discipline as the skills check (anchor on the
   leading `(` so the `:rf/*` reserved keyword namespace is excluded, not
   swept in as bogus var references).
 
-  V1-MIGRATION CHAPTER. `docs/core/25-from-re-frame-v1.md` names removed
+  V1-MIGRATION CHAPTER. The migration guide names removed
   re-frame v1 APIs (`on-changes`, …) as the left-hand side of migration
   guidance, exactly as the migration SKILL does. Its old-name mentions are
   carried on the `:doc-guide-known-unmanifested-scoped` allowlist rather
@@ -28,19 +23,9 @@
   syntax table (`set-x!` / `install-x!` — `<x>` stand-ins, not real vars)
   ride the same allowlist.
 
-  FILE-SCOPED ALLOWLIST (rf2-hk6wd2). The removed-name allowlist used to be
-  a BARE-NAME set: a name listed there was silenced ANYWHERE in the guide
-  tree. EP-0017 removed `inject-cofx`, and live teaching prose must use
-  `:rf.cofx/requires` — but a bare allowlist would let a future live
-  `(rf/inject-cofx …)` in any teaching chapter pass green, since the bare
-  name `inject-cofx` was unconditionally silenced. The allowlist is now
-  `:doc-guide-known-unmanifested-scoped` — `{removed-name -> #{approved
-  repo-relative file paths}}`. A call-position reference to a removed name
-  is silenced ONLY in its approved migration file(s); the SAME reference in
-  any other guide file is RED (it leaked into live teaching prose). This is
-  the negative check the bead asks for: live guide chapters cannot call
-  removed EP-0017 (or EP-0015/EP-0018) APIs outside approved migration
-  contexts."
+  FILE-SCOPED ALLOWLIST. `:doc-guide-known-unmanifested-scoped` maps each
+  removed name to the repo-relative migration files allowed to mention it in
+  call position. The same reference in live teaching prose remains an error."
   (:require [clojure.string :as str]
             [re-frame.api-manifest.gen :as gen]
             [re-frame.api-manifest.projection :as proj]))
@@ -112,13 +97,9 @@
         guide-files  (->> (proj/require-markdown-files "docs/core/" dir)
                           (remove #(str/starts-with? (proj/repo-relative %)
                                                      "docs/core/api/")))
-        ;; Per-capability CONCEPT docs (rf2-earvtz). The #4961 docs reorg moved
-        ;; each capability's concept doc out of the flat docs/core/ tree into
-        ;; docs/<cap>/concepts.md (machines/resources/routing/ssr). The
-        ;; docs/*/concepts.md glob folds those moved files back under this
-        ;; gate's scan so a broken `(rf/<var>` reference in them goes RED; it
-        ;; auto-covers a future capability dir with no gate edit, and fails
-        ;; loudly (require-*) if the layout moves again.
+        ;; Capability concept docs are a required one-level docs/* surface;
+        ;; discovery covers new capabilities and fails loudly if the surface
+        ;; disappears.
         concept-files (proj/require-capability-doc-files
                         "docs/*/concepts.md" "concepts.md")
         files        (concat guide-files concept-files)
@@ -128,8 +109,7 @@
         var-problems (reconcile {:references   references
                                  :core-vars    core-vars
                                  :scoped-allow scoped-allow})
-        ;; Keyword-drift guards (rf2-tawage / rf2-uhew69 / rf2-1zjkn8): the
-        ;; var-resolution reconcile above cannot see stale EP-0017
+        ;; Var resolution cannot see stale EP-0017
         ;; `:rf.world/inputs`, EP-0011 reply-envelope (`:stale-key` / bare
         ;; `:work-id`), or EP-0015 egress-profile keyword vocabulary creeping
         ;; back into teaching prose. Fold the keyword scan in so a

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/gen.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/gen.clj
@@ -1,6 +1,5 @@
 (ns re-frame.api-manifest.gen
-  "Public-API manifest generator + drift-check (rf2-3nbl5.2 — the
-  API-governance keystone).
+  "Public-API manifest generator and drift check.
 
   THE PROBLEM. re-frame2 has one truth — the public API — with many
   projections (spec/API.md, the per-tool specs, the docs, the MCP tool
@@ -42,7 +41,7 @@
   and cannot be `require`d on the JVM. Their rows live in the sidecar
   under `:cljs-only` and are carried through verbatim. The JVM
   existence-check does not reach them; instead a CLJS-side enumeration
-  probe (rf2-2mtte, implementation/scripts/api-manifest/probe/, run by
+  probe (`implementation/scripts/api-manifest/probe/`, run by
   `npm run test:cljs`) reconciles each covered namespace's live public
   vars against its rows. A `:cljs-only` row carries its own
   `:runtime-verified?` flag — `true` once the probe covers its

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/projection.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/projection.clj
@@ -1,31 +1,23 @@
 (ns re-frame.api-manifest.projection
-  "Shared scaffolding for the SECONDARY projection drift-checks (rf2-gkp0t,
-  follow-on to the rf2-3nbl5.2 keystone + its PRIMARY `spec/API.md`
-  projection check `re-frame.api-manifest.api-md-check`).
+  "Shared scaffolding for public-API projection drift checks.
 
-  THE SHAPE. `spec/api-manifest.edn` is the one machine-readable truth for
-  the public API; every human-facing surface that NAMES a public var is a
-  PROJECTION of that truth and can drift. The keystone guards the most
-  important projection (spec/API.md). This namespace carries the reusable
-  parser+reconciler scaffolding the four SECONDARY projection checks share
-  (Story API spec, Xray API spec, skills, doc-guide), each modelled on
-  `api-md-check`: parse a surface's public-var references, resolve each to
-  a manifest row, and go RED on a reference the manifest does not carry
-  (a renamed / removed / never-manifested var) unless it is on a curated
-  knowingly-unmanifested allowlist.
+  `spec/api-manifest.edn` is the machine-readable public API. Human-facing
+  surfaces that name public vars are projections of it. The projection checks
+  parse those references, resolve each to a manifest row, and fail on an
+  unresolved reference unless the sidecar explicitly allows it.
 
   WHY AN ALLOWLIST. A surface legitimately names vars the manifest does
   not (and cannot) carry — CLJS-only facade surfaces the JVM generator
   cannot `ns-publics`, sub-namespace surfaces outside the manifest's
-  whole-namespace introspection set, and (for the v1-migration surfaces)
-  DELIBERATE mentions of removed old names. Each check carries its own
+  whole-namespace introspection set, and deliberate migration references to
+  removed names. Each check carries its own
   curated allowlist in the sidecar (`spec/api-manifest-metadata.edn`) so
   the legitimate references are silenced ONCE, by name, and any OTHER
   unresolved reference still turns the check red. This mirrors the
-  keystone's `:api-md-known-unmanifested` set exactly.
+  `:api-md-known-unmanifested` set.
 
-  SCOPE DISCIPLINE (the bead's caution). A naive grep over backticked
-  prose tokens false-positives on every keyword, fx-id, and English word.
+  SCOPE DISCIPLINE. A naive grep over backticked prose tokens false-positives
+  on every keyword, fx-id, and English word.
   Each check scopes to an ACTUAL public-var reference pattern — a
   call-position `(rf/<var>` form for the alias-qualified surfaces, a
   backticked single-identifier var-row in a typed API table for the spec
@@ -129,27 +121,9 @@
    capability directories directly under `docs/` — i.e. the `docs/*/<filename>`
    glob (`docs/machines/concepts.md`, `docs/routing/api.md`, …).
 
-   THE SHAPE (rf2-earvtz). The #4961 docs reorg moved each capability's
-   CONCEPT and API reference out of the flat `docs/core/` and top-level
-   API trees into per-capability directories `docs/<cap>/{concepts,api}.md`. The
-   doc-guide / doc-api projection gates scanned only the old flat trees, so
-   the moved files went UNSCANNED — a broken `(rf/<var>` reference in them
-   would slip through CI. This resolves the moved files by glob so the gates
-   cover them, and AUTO-COVERS future capability dirs (a new
-   `docs/<cap>/concepts.md` is picked up with no gate edit).
-
-   SCOPE DISCIPLINE. The glob is anchored on a SINGLE path segment between
-   `docs/` and the filename, so it matches ONLY immediate-child capability
-   files. It never sweeps in the flat trees the gates already own
-   (`docs/core/` / `docs/core/api/` are directories, not `docs/api.md` files) nor
-   nested API trees (`docs/story/api/` is a directory; `docs/story/api.md`
-   does not exist). The match excludes directories defensively.
-
-   NON-VACUOUS FLOOR (rf2-utvst discipline, mirroring
-   `require-markdown-files`). These capability files are an EXPECTED surface
-   today, so a zero-match result — a further reorg that renames or relocates
-   them — throws loudly rather than silently scanning nothing and turning the
-   gate into a vacuous green. `label` names the surface for the error.
+   The one-segment scope excludes flat and nested API trees owned by other
+   checks. Because capability files are expected, zero matches throw instead
+   of allowing a vacuous pass. `label` names the surface in that error.
 
    Returns the matched files as an `io/file` seq, sorted by path for
    deterministic reporting."
@@ -262,34 +236,12 @@
     (vec (map-indexed (fn [i line] [(inc i) line]) (line-seq r)))))
 
 ;; ---------------------------------------------------------------------------
-;; EP-0017 keyword-drift guard (rf2-tawage).
+;; EP-0017 keyword-drift guard.
 ;;
-;; The projection checks above all scope to PUBLIC-VAR references and
-;; deliberately exclude the `:rf/*` reserved keyword namespace (the leading
-;; `(` discriminator drops `:rf/…` keywords so a `(rf/<var>` sweep does not
-;; drown in `:rf/default` etc.). That scoping is correct for var-rename
-;; drift, but it means a projection can reintroduce STALE EP-0017 KEYWORD
-;; vocabulary — `:rf.world/inputs` (renamed to the flat `:rf.cofx` map),
-;; grouped/non-flat `:rf.cofx` sub-maps, or coeffect prose missing the
-;; `:rf.cofx/requires` declaration — and every var-resolution check stays
-;; green.
-;;
-;; This guard closes that gap with a targeted KEYWORD-level scan. EP-0017's
-;; keyword surface is a small closed set:
-;;   - `:rf.world/inputs` is RETIRED (renamed to `:rf.cofx`, no alias). Its
-;;     only legitimate appearance is a retirement / rename / migration
-;;     mention — a line that ALSO names the `:rf.cofx` replacement or the
-;;     words retired/renamed/removed/superseded/migration. (It is a draft-only
-;;     name, so it earns no dedicated retired-name error id — it rides the
-;;     generic `:rf.warning/unknown-dispatch-opt` surface.) A
-;;     `:rf.world/inputs` mention WITHOUT such a marker is fresh stale
-;;     vocabulary and is RED.
-;;
-;; The scan is per-line and prose-level (these surfaces are markdown), and
-;; intentionally CONSERVATIVE: it only fires on the retired keyword absent a
-;; same-line retirement marker, so historical/migration prose — which always
-;; names the replacement on the same line — stays green, while a fresh
-;; reintroduction in teaching prose goes red.
+;; Public-var extraction deliberately ignores the `:rf/*` keyword namespace.
+;; Scan `:rf.world/inputs` separately and allow it only on a line that marks the
+;; reference as retirement or migration prose. The same-line rule keeps the
+;; prose scan conservative.
 ;; ---------------------------------------------------------------------------
 
 (def ^:private world-inputs-retirement-markers
@@ -311,7 +263,7 @@
    rename / migration marker (see `world-inputs-retirement-markers`).
 
    Pure over the supplied lines so the contract is unit-testable with
-   synthetic inputs (rf2-tawage)."
+   synthetic inputs."
   [file lines]
   (keep (fn [[n text]]
           (when (str/includes? text ":rf.world/inputs")
@@ -327,30 +279,11 @@
         lines))
 
 ;; ---------------------------------------------------------------------------
-;; EP-0011 reply-envelope vocabulary-drift guard (rf2-uhew69).
+;; EP-0011 reply-envelope vocabulary-drift guard.
 ;;
-;; The var-resolution projection checks scope to PUBLIC-VAR references and
-;; cannot see the EP-0011 reply-envelope KEYWORD vocabulary at all (`rg` over
-;; the scripts surface found no `:work/id`, `:stale-key`, or reply-status
-;; vocabulary). EP-0011 settled one canonical attempt identity — namespaced
-;; `:work/id` — and explicitly RETIRED two near-duplicate spellings
-;; ([EP-0007] one-name-per-fact):
-;;
-;;   - `:stale-key` — the retired second stale-suppression key. EP-0011 keys
-;;     stale suppression on `:work/id`; `:stale-key` is dropped (no synonym).
-;;   - bare hyphenated `:work-id` — the unqualified spelling that survived in
-;;     resource / mutation internal reply events; EP-0011 lowered them all to
-;;     the qualified `:work/id`. (`:work-id` legitimately survives ONLY inside
-;;     an `:rf.observe/*` correlation example, where it is a string-valued
-;;     correlation-id projection, not the reply-map attempt identity.)
-;;
-;; A teaching/spec surface that reintroduces `:stale-key` or bare `:work-id`
-;; as live reply-envelope vocabulary has drifted, while every var-resolution
-;; check stays green. This guard closes that gap with a targeted KEYWORD scan,
-;; mirroring the EP-0017 guard above: a stale keyword is flagged UNLESS the
-;; line ALSO carries a retirement/rename/migration marker (the spec's own
-;; retirement prose always names `:work/id` as the canonical replacement) or,
-;; for `:work-id`, an `:rf.observe`/`:correlation` context marker.
+;; `:work/id` is the canonical attempt identity. Flag `:stale-key` and bare
+;; `:work-id` unless the line marks a retirement/migration reference. A
+;; `:work-id` in an `:rf.observe` correlation context is also legitimate.
 ;; ---------------------------------------------------------------------------
 
 (def ^:private work-id-retirement-markers
@@ -378,7 +311,7 @@
    `:work/id`, not `:work-id`).
 
    Pure over the supplied lines so the contract is unit-testable with
-   synthetic inputs (rf2-uhew69)."
+   synthetic inputs."
   [file lines]
   (let [;; `:work-id` (hyphen) but NOT `:work/id` (slash). Trailing boundary
         ;; keeps `:work-id-foo` from matching as the bare identity key.
@@ -402,29 +335,19 @@
           lines)))
 
 ;; ---------------------------------------------------------------------------
-;; EP-0015 privacy / egress vocabulary-drift guard (rf2-1zjkn8).
+;; EP-0015 privacy / egress vocabulary-drift guard.
 ;;
-;; The var-resolution projection checks are blind to EP-0015's keyword
-;; vocabulary. EP-0015 renamed two early `:rf.egress/*` profile spellings for
-;; axis consistency and the OLD keyword forms must never reappear as live
-;; vocabulary:
+;; Var-resolution checks cannot see keywords. Two retired `:rf.egress/*`
+;; spellings must not reappear as live vocabulary:
 ;;
 ;;   - `:rf.egress/on-box-hidden-sensitive` → renamed to `:rf.egress/local-redacted`
 ;;   - `:rf.egress/trusted-local-raw`       → renamed to `:rf.egress/local-raw`
 ;;
-;; These retired keyword profile forms appear only in the superseded EP-0015
-;; proposal doc (not a scanned surface); reintroducing either into a teaching
-;; / spec / skills surface is drift while the var-resolution checks stay green.
-;;
-;; SCOPE DISCIPLINE. The match is on the RETIRED `:rf.egress/`-prefixed
+;; The match is on the retired `:rf.egress/`-prefixed
 ;; keyword FORMS only — NOT the bare English adjectives "on-box" /
 ;; "trusted-local", which remain current trust-boundary descriptors
 ;; (`:rf.egress/local-raw` IS "trusted local operator"). A mention carrying a
-;; retirement/rename marker on the same line (the proposal-doc rename rows
-;; name the replacement) is approved. (The earlier positive closed-enum pin
-;; over the spec/Conventions.md owner row was removed as over-strict — see
-;; the rf2 toomuch trimming review note in api-md-check; this retired-form
-;; scan stands.)
+;; retirement/rename marker on the same line is approved.
 ;; ---------------------------------------------------------------------------
 
 (def ^:private egress-profile-retirement-markers
@@ -449,7 +372,7 @@
    `egress-profile-retirement-markers`).
 
    Pure over the supplied lines so the contract is unit-testable with
-   synthetic inputs (rf2-1zjkn8)."
+   synthetic inputs."
   [file lines]
   (keep (fn [[n text]]
           (let [lc       (str/lower-case text)
@@ -473,12 +396,12 @@
    vocabulary reintroduction goes RED alongside any var-resolution drift.
 
    Folds in three guards over the same scanned surfaces:
-     - EP-0017 `:rf.world/inputs` keyword drift (rf2-tawage);
+     - EP-0017 `:rf.world/inputs` keyword drift;
      - EP-0011 reply-envelope vocabulary drift — retired `:stale-key` /
-       bare `:work-id` attempt-identity spellings (rf2-uhew69);
+       bare `:work-id` attempt-identity spellings;
      - EP-0015 egress-profile vocabulary drift — retired
        `:rf.egress/on-box-hidden-sensitive` / `:rf.egress/trusted-local-raw`
-       profile keyword forms (rf2-1zjkn8)."
+       profile keyword forms."
   [files]
   (mapcat (fn [^java.io.File f]
             (let [rel   (repo-relative f)

--- a/implementation/scripts/api-manifest/test/re_frame/api_manifest/api_md_check_test.clj
+++ b/implementation/scripts/api-manifest/test/re_frame/api_manifest/api_md_check_test.clj
@@ -192,17 +192,6 @@
     (is (nil? (c/floor-violation (count (c/parse-api-md-var-rows))))
         "the real spec/API.md extraction must clear the floor")))
 
-;; ---------------------------------------------------------------------------
-;; Positive prose-phrase pins removed (rf2 toomuch trimming review).
-;;
-;; The over-strict `reg-cofx` contract pin and `:rf.egress/*` closed-enum pin
-;; (both required literal prose / a full member list verbatim on one markdown
-;; row, so a legitimate reword went RED with no var/API change) were removed.
-;; The load-bearing var-resolution reconcile, the non-vacuous floors, and the
-;; same-line keyword-drift scans (which fire only on RETIRED keyword FORMS,
-;; tested above) remain.
-;; ---------------------------------------------------------------------------
-
 (deftest live-api-md-check-passes
   (testing "the committed tree passes the full api-md-check including the
             EP-0011/EP-0015 keyword-drift guards (no false +)"

--- a/implementation/scripts/api-manifest/test/re_frame/api_manifest/gen_test.clj
+++ b/implementation/scripts/api-manifest/test/re_frame/api_manifest/gen_test.clj
@@ -68,7 +68,7 @@
 
 (defn- live-sidecar-with-duplicate-cljs-only
   "The REAL committed sidecar with one of its `:cljs-only` rows DUPLICATED
-   (the bead's injected-duplicate probe shape). Using the real sidecar keeps
+   (the injected-duplicate probe shape). Using the real sidecar keeps
    the missing/stale classification checks passing (the live JVM vars are all
    classified) so the duplicate check is what fires — exactly how a hand-added
    duplicate `:cljs-only` entry would behave in production. We pick the first

--- a/implementation/scripts/check-perf-bundle.cjs
+++ b/implementation/scripts/check-perf-bundle.cjs
@@ -112,7 +112,7 @@ function checkBundle(label, bundlePath, mustContain) {
 
 // Count `performance.measure|clearMeasures|re-frame.performance` for
 // the report. The PR body wants the raw count number for both bundles,
-// per the bead's bundle-grep contract. The actual global-match count is
+// per the bundle-grep contract. The actual global-match count is
 // delegated to the shared `countMatches` (lib/read-release-bundle.cjs —
 // it resets the /g RegExp's lastIndex defensively); this wrapper keeps
 // the patterns-array → alternation construction and the null-blob → null
@@ -139,7 +139,7 @@ function main() {
   const on  = checkBundle('perf-on  (counter-perf,  enabled?=true) ',
                           onDir,  true);
 
-  // Report the counts the bead asks for. classifyReleaseBundle returns
+  // Report the counts used by the gate. classifyReleaseBundle returns
   // blob=null for a missing dir (countOccurrences guards null) and the
   // real blob otherwise; the off/on checks above already fail the gate
   // on a missing/empty dir, so these counts are only ever consulted for

--- a/implementation/scripts/lib/local-browser-harness.cjs
+++ b/implementation/scripts/lib/local-browser-harness.cjs
@@ -12,14 +12,12 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-// A "usable explicit port" is an integer in 1..65535 — a port a caller
+// A usable explicit port is an integer in 1..65535: a port a caller
 // can pin, advertise in a BASE_URL, and probe. Port 0 is excluded: it
 // binds (the OS assigns an ephemeral port) but the assigned port is only
 // knowable by reading it back off the bound socket, so advertising :0 is
 // never what a caller wants. Out-of-range (<1, >65535) and non-integers
 // are excluded because net.listen throws ERR_SOCKET_BAD_PORT on them.
-// (rf2-0u8kz — matches the strict 1..65535 contract the example/Story
-// port resolvers already enforce in examples/scripts/port-resolver.cjs.)
 function isValidExplicitPort(port) {
   return Number.isInteger(port) && port >= 1 && port <= 65535;
 }
@@ -31,9 +29,7 @@ function isValidExplicitPort(port) {
 // free" WITHOUT touching net.listen — port 0 would otherwise bind an
 // ephemeral port (a false "free" for an unusable advertised port), and
 // negative / overflow values would throw ERR_SOCKET_BAD_PORT instead of
-// the controlled fall-through. (rf2-84gzw / rf2-0u8kz — the shared
-// resolveServePort below routes serve-and-run-browser-tests and
-// check-story-static through this single implementation.)
+// the controlled fall-through.
 function isPortFree(port) {
   if (!isValidExplicitPort(port)) return Promise.resolve(false);
   return new Promise((resolve) => {
@@ -64,10 +60,7 @@ function findFreePort() {
 // invoked (if provided) on EITHER fallback trigger — a busy preferred
 // port OR an invalid one (0, negative, overflow, NaN, non-integer) — so
 // callers log the substitution rather than advertising an unusable :0 or
-// crashing net.listen with ERR_SOCKET_BAD_PORT. (rf2-0u8kz centralised
-// the explicit-port validation here; callers that derive preferredPort
-// from an env var — e.g. `Number(process.env.XRAY_FEATURE_GATE_PORT)` —
-// no longer leak 0/out-of-range values into the listen path.)
+// crashing net.listen with ERR_SOCKET_BAD_PORT.
 async function resolveServePort(preferredPort, opts = {}) {
   if (isValidExplicitPort(preferredPort) && (await isPortFree(preferredPort))) {
     return preferredPort;
@@ -82,19 +75,18 @@ async function resolveServePort(preferredPort, opts = {}) {
 // Fetch the body of a path (default `/.rf-harness-token`) from a local
 // server, trimmed. Resolves null on non-200, error, or timeout — the
 // caller treats "no token yet" as "keep polling" and a present-but-wrong
-// token as a foreign server. (rf2-84gzw / rf2-gkf9 ownership handshake.)
+// token as a foreign server.
 const TOKEN_FILE_BASENAME = '.rf-harness-token';
 
-// Publish a per-run server-ownership token under `root` (rf2-gkf9 /
-// rf2-pgppmu). Writes a fresh 16-byte hex nonce to
+// Publish a per-run server-ownership token under `root`. Writes a fresh
+// 16-byte hex nonce to
 // `${root}/.rf-harness-token` so http-server publishes it the moment it
 // starts serving `root`, and the readiness handshake (waitForOwnedHttpReady
 // + fetchToken) can positively distinguish THIS run's server from a
 // port-squatter or a stale server from an aborted run.
 //
-// Owns the WRITE side of the handshake (fetchToken/waitForOwnedHttpReady own
-// the read side), so the five browser-harness launchers no longer each carry
-// a bespoke crypto/write/unlink copy of this lifecycle.
+// This owns the write side of the handshake; fetchToken and
+// waitForOwnedHttpReady own the read side.
 //
 // Returns `null` when `root` does not exist yet — the caller decides how to
 // report the missing asset root (each launcher prints its own diagnostic and
@@ -158,7 +150,7 @@ function fetchToken(port, opts = {}) {
   });
 }
 
-// Readiness wait WITH ownership-token verification (rf2-84gzw). Resolves
+// Readiness wait with ownership-token verification. Resolves
 // `{ ok: true }` only once the server on `port` answers AND serves a
 // `/.rf-harness-token` body equal to `expectedToken`. Otherwise resolves
 // `{ ok: false, reason }`:
@@ -197,7 +189,7 @@ function probeHttp(port, opts = {}) {
   const host = opts.host || '127.0.0.1';
   const path = opts.path || '/';
   const timeout = opts.timeout || 1000;
-  // rf2-rcepku — honour the caller's scheme. The default loopback
+  // Honour the caller's scheme. The default loopback
   // readiness probes (and the ownership-token handshake) only ever speak
   // http, so http stays the default; the XRAY_FEATURE_GATE_BASE_URL
   // escape hatch can point at an https external server, in which case the
@@ -223,21 +215,11 @@ function probeHttp(port, opts = {}) {
   });
 }
 
-// rf2-rcepku — derive a full readiness-probe target {host, port, path,
-// protocol} from a base URL, honouring its host, scheme, explicit-or-
-// default port, and base path. Used by the Xray feature gate's
-// XRAY_FEATURE_GATE_BASE_URL escape hatch (serve-and-run-xray-feature-
-// gate.cjs): the previous code extracted ONLY a port and the probe
-// defaulted to host 127.0.0.1 + path `/`, so a base URL with a
-// non-loopback host, an https scheme, or a meaningful base path could be
-// reported unreachable while valid — or (worse) pass readiness against an
-// UNRELATED local listener on the same port before the browser then
-// navigated to the real external URL (a false-green). On a malformed or
-// non-http(s) URL we THROW rather than silently falling back to a
-// loopback port: that earlier fallback is exactly how an invalid value
-// could probe an unrelated local server and still send the browser at the
-// (broken) external URL. The returned object is shaped to spread straight
-// into probeHttp/waitForHttpReady opts (host + path + protocol).
+// Derive the complete readiness target from a base URL. Host, scheme, port,
+// and base path must all match the URL the browser will open; probing only a
+// coincidentally equal local port could otherwise produce a false green. Invalid
+// and non-HTTP(S) URLs fail instead of falling back to loopback. The result can
+// be spread directly into probeHttp/waitForHttpReady options.
 function probeTargetFromBaseUrl(baseUrl, opts = {}) {
   const label = opts.envName || 'base URL';
   let parsed;
@@ -351,19 +333,14 @@ function createHarnessCleanup(opts = {}) {
     if (err) console.error(err && err.stack ? err.stack : err);
   });
   const exit = opts.exit || ((code) => process.exit(code));
-  // Injectable terminators (default: the real process-tree killers).
-  // The seam exists so the rf2-ogpeq race can be unit-tested
-  // deterministically — a test can supply a synchronous terminator that
-  // records which children were swept and an async one that never
-  // resolves (modelling an in-flight cleanup that a hard exit abandons),
-  // without depending on real (and, on Windows, multi-second) taskkill
+  // Injectable terminators make cleanup races testable without real taskkill
   // latency.
   const terminateSync = opts.terminateSync || terminateProcessTreeSync;
   const terminateAsync = opts.terminateAsync || terminateProcessTree;
-  // Two independent guards (rf2-ogpeq). The synchronous kill-sweep over
-  // the tracked children and the cleanupFns each gate on their OWN flag,
-  // so the async `cleanup()` setting one cannot suppress the other on a
-  // hard-exit race:
+  // Child termination and cleanup callbacks need independent idempotence
+  // guards. A process exit racing async cleanup must still synchronously sweep
+  // children that the async path has not reached, without running callbacks
+  // twice.
   //
   //   - `killed` guards the child-process kill-sweep. cleanupSync() will
   //     ALWAYS run the synchronous sweep unless a previous sweep already
@@ -415,10 +392,10 @@ function createHarnessCleanup(opts = {}) {
     }
   }
 
-  // The process 'exit' handler. Node cannot await here, so a hard exit
+  // The process 'exit' handler. Node cannot await here, so a synchronous exit
   // racing an in-flight async cleanup() MUST still synchronously kill
   // any children that cleanup() has not yet reached — otherwise they are
-  // orphaned (rf2-ogpeq). killChildrenSync gates on its own `killed`
+  // orphaned. killChildrenSync gates on its own `killed`
   // flag, never on the async path's state, so this always sweeps unless
   // a sync sweep already completed.
   function cleanupSync() {
@@ -480,17 +457,9 @@ function createHarnessCleanup(opts = {}) {
   };
 }
 
-// Compose the canonical local-http-server lifecycle every browser-gate
-// launcher needs (rf2-slapfs). Before this, the two Story launchers,
-// serve-example, and the adapter-smoke orchestrator EACH re-derived the
-// identical sequence — spawn `http-server` shell-free under process.execPath
-// with the loopback/static/no-cache argv, track it for teardown, wire an
-// early-exit abort flag + the "exited unexpectedly" diagnostic, optionally
-// capture a bounded output tail, wait for readiness, and print the canonical
-// unreachable diagnostic (plus the captured tail) on failure. This owns that
-// composition on top of the spawn/readiness/cleanup primitives above; each
-// caller keeps only its command-specific compile/staging/runner/watch and
-// post-readiness work.
+// Compose the canonical local-http-server lifecycle: shell-free spawn, tracked
+// teardown, early-exit detection, optional bounded output capture, readiness,
+// and failure diagnostics. Callers retain only command-specific work.
 //
 // The argv is fixed policy: `-a <host>` (loopback by default, NOT
 // http-server's 0.0.0.0), `-p <port>`, `-s` (silent), `-c-1` (no cache) —

--- a/implementation/scripts/serve-and-run-browser-tests.cjs
+++ b/implementation/scripts/serve-and-run-browser-tests.cjs
@@ -4,15 +4,10 @@
  * wait for it to be reachable, then run the Playwright runner.
  * Always tear the server down (success or failure).
  *
- * Why this wrapper exists: the bead suggested a shell one-liner of
- * `http-server ... & sleep 2 && node ...`. That works on POSIX but not
- * on Windows, and `sleep 2` is a brittle race. This script is the same
- * idea but cross-platform and with a real readiness probe.
- *
- * Port selection (rf2-nuv7):
+ * Port selection:
  *   1. If $BROWSER_TEST_PORT is set, try that port. If it's busy, fall
  *      back to a free port chosen by the OS.
- *   2. If unset, default to 8021 (historical behaviour). If 8021 is
+ *   2. If unset, default to 8021. If 8021 is
  *      busy, fall back to a free port chosen by the OS.
  *   3. Either way, log clearly which port was used and thread it
  *      through to the Playwright runner via $BROWSER_TEST_URL.
@@ -36,13 +31,9 @@ const {
   waitForOwnedHttpReady,
 } = require('./lib/local-browser-harness.cjs');
 
-// Strict CLI options (rf2-hmgwk2). The two production browser gates
-// (test:browser-prod-elision, test:browser-schemas-boundary-prod) call this
-// shared runner DIRECTLY with `--root <dir> --port <n>` rather than routing
-// through a per-gate wrapper that only set the BROWSER_TEST_ROOT/PORT env
-// vars. CLI options take precedence over those env vars, which in turn take
-// precedence over the historical defaults — so env-var and default behaviour
-// are preserved when no CLI option is given. Parsing is strict: an unknown
+// The production browser gates call this runner with `--root` and `--port`.
+// CLI options take precedence over environment variables, then defaults.
+// Parsing is strict: an unknown
 // flag, a flag missing its value, or a `--port` that is not a 1..65535
 // integer fails fast with a clear message rather than being silently coerced
 // or ignored. A CLI `--root` is routed through the SAME path policy as the
@@ -101,18 +92,17 @@ try {
 const DEFAULT_PORT = 8021;
 // `--root` (or $BROWSER_TEST_ROOT) lets a caller point the orchestrator at a
 // different shadow-cljs :browser-test output directory — used by the two
-// prod-mode gates (Spec 009/010 §Production builds, rf2-2zdu / rf2-uwg5 /
-// rf2-r2uh / rf2-84e9), whose `:advanced + goog.DEBUG=false` bundles land in
+// production-mode gates (Spec 009/010, Production builds), whose
+// `:advanced + goog.DEBUG=false` bundles land in
 // `out/browser-test-prod-elision/` and `out/browser-test-schemas-boundary-prod/`
 // rather than the default `out/browser-test/`.
 //
-// Per rf2-o38lb (security audit): the override MUST land inside
+// The override must land inside
 // `implementation/out` unless `RE_FRAME_ALLOW_OUT_OF_TREE_PATHS=1` is
 // set in the environment. The orchestrator writes `${ROOT}/index.html`
 // and `${ROOT}/.rf-harness-token`; an unconstrained override would otherwise
-// become an arbitrary file-write primitive in CI or downstream environments
-// inheriting parent env state. The CLI `--root` (rf2-hmgwk2) routes through
-// this SAME enforcePolicy check — a CLI root cannot bypass the path policy.
+// direct writes outside the script-owned output tree. CLI roots pass through
+// the same policy as environment roots.
 const ROOT_OVERRIDE = CLI.root || process.env.BROWSER_TEST_ROOT;
 const ROOT = enforcePolicy(
   CLI.root ? '--root' : 'BROWSER_TEST_ROOT',
@@ -150,14 +140,9 @@ const POLL_MS = 200;
 const cleanup = createHarnessCleanup();
 cleanup.installSignalHandlers();
 
-// shadow-cljs's :browser-test target generates an index.html with an empty
-// <body>. Some example namespaces (e.g. examples/patterns/nine_states/core.cljs)
-// historically did `(rdc/create-root (js/document.getElementById "app"))` at
-// namespace-load time. Per rf2-gkf9 the example mounts now defer `create-root`
-// to their `run` fn, but the test harness still needs a single `#app` host so
-// a future regression doesn't crash the runner before cljs.test prints its
-// summary. Patch the generated index.html to include a hidden mount point.
-// Idempotent.
+// shadow-cljs generates an empty body for this target. Provide a hidden mount
+// host so loading an example namespace cannot fail before cljs.test reports its
+// summary. The patch is idempotent.
 function ensureMountPoint() {
   if (!fs.existsSync(INDEX)) return;
   const html = fs.readFileSync(INDEX, 'utf8');
@@ -172,9 +157,7 @@ function ensureMountPoint() {
   }
 }
 
-// Server ownership token (rf2-gkf9). The readiness probe and the teardown
-// path both verify that the server reachable on `port` is the one this
-// orchestrator spawned:
+// The ownership token binds readiness to this run's served asset tree:
 //
 //   1. publishOwnershipToken(ROOT) generates a per-run nonce and writes it
 //      to a sentinel file under the served root BEFORE spawning http-server
@@ -186,10 +169,10 @@ function ensureMountPoint() {
 //      it still holds THIS run's token (so an overlapping run's newer token
 //      is never destroyed).
 //
-// This positively defeats two failure modes:
+// This defeats two failure modes:
 //   - An unrelated http-server (or any HTTP listener) on the same port
-//     gives a 200 to `/` but does NOT have our sentinel — we fail fast
-//     instead of running tests against the wrong asset tree.
+//     gives a 200 to `/` but does not have our sentinel. A mismatched token
+//     fails immediately; an absent token is polled until the readiness deadline.
 //   - A stale http-server child from a previous aborted run that re-bound
 //     the port between resolveServePort() and our spawn — same detection:
 //     its sentinel won't match this run's nonce.
@@ -202,9 +185,9 @@ function ensureMountPoint() {
 
 // Resolve the port to use via the shared harness primitive
 // (local-browser-harness.cjs), honouring `--port` first, then
-// $BROWSER_TEST_PORT, then the historical default 8021, then a free
+// $BROWSER_TEST_PORT, then the default 8021, then a free
 // OS-chosen port. The shared `resolveServePort` carries the strict 1..65535
-// explicit-port contract and the busy-port fallback (rf2-0u8kz / rf2-84gzw);
+// numeric explicit-port contract and the busy-port fallback;
 // this wrapper keeps the launcher-specific diagnostics (distinguishing an
 // explicitly-set but unusable BROWSER_TEST_PORT from a busy default). A CLI
 // `--port` is already validated to be a usable 1..65535 integer by


### PR DESCRIPTION
## Summary

- replace tracker and migration narratives in `implementation/scripts` with current orchestration, path, teardown, ownership-token, manifest, and CI contracts
- correct the path-policy realpath fallback description: it preserves lexical containment but is an accident guard, not a hardened fail-closed sandbox
- distinguish immediate ownership-token mismatch from an absent token that is polled until the readiness deadline
- describe teardown in terms of observable process-tree ownership without claiming that Windows hard termination runs a JavaScript `exit` handler
- remove deleted manifest-check history and duplicated policy-test narration while retaining non-obvious vacuity, scope, concurrency, and ownership invariants

All changes are explanation-only; launcher and gate logic is unchanged.

## Verification

- `npm run test:script-policy`
- `node scripts/_local-browser-harness.test.cjs` (34 passed)
- `node scripts/_orchestrator-teardown-integration.test.cjs` (2 passed; Windows SIGINT arm skipped by design)
- `clojure -M:test` in `implementation/scripts/api-manifest` (53 tests, 105 assertions)
- `clojure -M -m re-frame.api-manifest.gen --check`
- `clojure -M -m re-frame.api-manifest.api-md-check`
- `clojure -M -m re-frame.api-manifest.doc-guide-check`
- `clojure -M -m re-frame.api-manifest.doc-api-check`

Tracks rf2-j945p1.
