### PR TITLE
docs(schemas): focus comments on current contracts

### DIFF
--- a/implementation/schemas/deps.edn
+++ b/implementation/schemas/deps.edn
@@ -1,7 +1,4 @@
-;; day8/re-frame2-schemas — schema-attachment artefact (rf2-p7va,
-;; first per-feature split per rf2-5vjj Strategy B).
-;;
-;; Per Spec 010 §Schemas the schema-attachment surface
+;; Per Spec 010 §Schemas, the schema-attachment surface
 ;; (`reg-app-schema`, `app-schema-at`, `app-schemas`, the
 ;; validation hot-path entry points) ships as a separate Maven
 ;; artefact so apps that don't use schemas don't drag Malli (and
@@ -12,26 +9,21 @@
 ;;   {:deps {day8/re-frame2         {:mvn/version "..."}
 ;;           day8/re-frame2-schemas {:mvn/version "..."}}}
 ;;
-;; Schema implies validation (rf2-v96fh): requiring `re-frame.schemas`
+;; Requiring `re-frame.schemas`
 ;; itself `:require`s `re-frame.schemas.malli`, which publishes Malli's
 ;; validate / explain / humanize into the late-bind hook table at
-;; ns-load (rf2-t0hq). The default validator is therefore LIVE the moment
-;; a schema is registered — there is NO inert "registered a schema but it
-;; silently validates nothing" soft-pass state. An explicit
-;; `(:require [re-frame.schemas.malli])` at app-boot is harmless but no
-;; longer required. Same pattern on CLJS and the JVM — rf2-qyfie removed
-;; the JVM `requiring-resolve` fallback so the contract is symmetrical.
+;; namespace load. The default validator is therefore active when a schema
+;; is registered on both CLJS and the JVM.
 ;;
 ;; Apps that want schemas-as-inert-data without the Malli validation
 ;; surface call `(set-schema-validator! nil)` at boot, which disables every
 ;; validation site (Spec 010 §Worked example). The residual soft-pass arm
 ;; in `re-frame.schemas.validator` is the defensive fallback for a non-Malli
 ;; port that never bound the Malli hook (and for test harnesses that
-;; deliberately unbind it) — NOT the default state after a plain
+;; deliberately unbind it), not the default state after a plain
 ;; `(:require [re-frame.schemas])`.
 ;;
-;; Per Spec 006 §Adapter shipping convention (and the
-;; rf2-p7va extension to per-feature splits): this artefact depends
+;; Per Spec 006 §Adapter shipping convention, this artefact depends
 ;; on core; core never depends on this artefact. The cross-reference
 ;; from core to schemas (e.g. `re-frame.test-support`'s reset
 ;; fixture, `re-frame.core`'s `reg-app-schema` re-export) is wired
@@ -46,18 +38,16 @@
          ;; The schemas JVM test's reset-runtime fixture touches
          ;; `re-frame.flows/flows` (the reset matrix is defensive;
          ;; flows might not be on the classpath in production but is
-         ;; during development). Pull flows in as a test-only dep so
-         ;; the fixture loads cleanly. Per rf2-tfw3 — flows ships in
-         ;; `day8/re-frame2-flows`. Mirrors the pattern in
-         ;; core/deps.edn and routing/deps.edn.
+         ;; during development). Pull flows in as a test-only dependency so
+         ;; the fixture loads cleanly.
          :extra-deps  {day8/re-frame2-flows      {:local/root "../flows"}
-                       ;; rf2-try1x — silent-on-success reporter.
+                       ;; Silent-on-success reporter.
                        day8/re-frame2-test-quiet {:local/root "../test-quiet"}
                        io.github.cognitect-labs/test-runner
                        {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
          :main-opts   ["-m" "re-frame.test-quiet.runner"]}
 
-  ;; Clojars deploy (rf2-r382). Modeled on re-frame v1's release flow.
+  ;; Clojars deployment.
   ;; The release workflow runs `clojure -M:clein deploy` from this
   ;; artefact's directory, which builds pom + jar and pushes to Clojars.
   ;;

--- a/implementation/schemas/src/re_frame/schemas.cljc
+++ b/implementation/schemas/src/re_frame/schemas.cljc
@@ -1,68 +1,23 @@
 (ns re-frame.schemas
-  "Schema attachment and dev-only validation. Per Spec 010.
+  "Schema registration, validation, classification, and digest façade.
 
-  Schemas attach to registrations under :schema metadata; the validation
-  fires at locked points (event vector before handler runs; sub return
-  after compute; app-db after each handler completes). In dev builds
-  only — production builds elide.
+  App-db schemas are frame-scoped. A registration without an explicit
+  `:frame` uses the carried frame scope and fails when no scope exists.
+  Validation runs at the event, effect, subscription, and post-commit
+  boundaries in development builds; the boundary interceptor can also
+  invoke the registered validator in production.
 
-  Per Spec 010 §Per-frame schemas, `app-db` schemas are **frame-scoped**:
-  registered against the active frame at registration time and looked
-  up per frame at validation time. Stories, multi-instance widgets,
-  per-test fixtures need shape-flexibility — a stripped-down schema
-  registered against `:story.foo/empty` does NOT bleed into another
-  frame's contract. EP-0002 — context-required frame-local: `(reg-app-schema
-  path schema)` resolves the frame through the carried-invariant scope
-  chain (a `with-frame` / frame-provider scope, or a frame `:initial-events`
-  step) and raises `:rf.error/no-frame-context` under no scope; `(reg-app-schema
-  path {:frame frame-id} schema)` names the frame explicitly (the *override*).
+  Loading this artefact also loads the Malli adapter, so registering a
+  schema enables validation by default. Applications can install a
+  different validator bundle, or set the validator to nil to make schemas
+  inert data. The latter disables validation but does not remove Malli from
+  a statically compiled bundle; applications that do not require this
+  optional artefact remain Malli-free.
 
-  Per Spec 010 §Non-Malli validators the validator/explainer fns are
-  pluggable via `set-schema-validator!` / `set-schema-explainer!`. The
-  default validator delegates to Malli; apps drop Malli by registering
-  a different fn (or `nil` for a hard no-op).
-
-  **Schema implies validation (rf2-v96fh).** Loading this artefact
-  `:require`s `re-frame.schemas.malli`, which publishes Malli's
-  `validate` / `explain` / `humanize` into the late-bind hook table at
-  ns-load time. The CLJS reference therefore validates against the
-  default Malli validator the moment a schema is registered — there is
-  no inert \"registered a schema but it silently validates nothing\"
-  state. (Pre-rf2-v96fh the adapter had to be required *separately* at
-  app boot; an app that forgot the require registered schemas that
-  soft-passed every value — a footgun where \"I registered a schema\"
-  did NOT imply \"it validates.\")
-
-  Because Malli is now wired by *the schemas artefact* (not by core),
-  bundle isolation is preserved at the artefact boundary: an app that
-  never `:require`s `re-frame.schemas` (the no-feature counter
-  reference app) pays nothing for Malli. An app that DOES use schemas
-  pays the Malli surface (~24 KB gzipped, Spec 010 §Bundle cost) — the
-  deliberate tradeoff Ruling A accepts so registration always implies
-  validation. Apps that want schemas-as-inert-data without the Malli
-  surface call `(set-schema-validator! nil)` at boot to disable every
-  validation site (Spec 010 §Worked example — installing a no-op
-  validator); note that under static CLJS compilation requiring the
-  artefact still loads Malli's body, so the nil opt-out disables
-  validation *behaviour* but does not remove Malli from the bundle —
-  the only Malli-free posture is not requiring the schemas artefact.
-
-  Public façade over `re-frame.schemas.{validator,storage,walker,
-  digest,validate}` — re-exports the symbols external consumers reach
-  through (tests, `re-frame.core-schemas`, the late-bind hook table)
-  and owns the late-bind hook publication."
+  This namespace re-exports the supported entry points and publishes the
+  hooks used by core and other optional artefacts."
   (:require [re-frame.late-bind :as late-bind]
-            ;; rf2-v96fh — schema implies validation. Requiring the
-            ;; schemas artefact pulls the Malli adapter so the default
-            ;; validator is LIVE (publishes `:schemas/malli-validate`
-            ;; etc. at ns-load); `reg-app-schema` then validates rather
-            ;; than soft-passing into a silent no-op. The adapter ns
-            ;; requires only `malli.core` + `malli.error` + late-bind —
-            ;; no cycle back to this facade. Malli becomes a dependency
-            ;; of the schemas artefact, NOT of core: an app that never
-            ;; requires `re-frame.schemas` stays Malli-free (Spec 010
-            ;; §Bundle cost; verified by the counter bundle-isolation
-            ;; gate). Loaded for its ns-load side effect only.
+            ;; Publishes the default validator bundle at namespace load.
             [re-frame.schemas.malli]
             [re-frame.schemas.digest :as digest]
             [re-frame.schemas.storage :as storage]
@@ -70,76 +25,25 @@
             [re-frame.schemas.validator :as validator]
             [re-frame.schemas.walker :as walker]))
 
-;; ---- raw schema atoms are NOT re-exported (encapsulated-only posture) ------
-;;
-;; The four authoritative atoms — `storage/schemas-by-frame` (the per-frame
-;; registry) and `validator/{validator-fn,explainer-fn,printer-fn}` (the
-;; pluggable validation bundle) — are deliberately NOT re-exported onto this
-;; facade. The supported public surface is the encapsulated snapshot / restore
-;; / clear API below; tests and fixtures go through it rather than reaching the
-;; raw atoms.
-;;
-;; Posture (rf2-l5r974 ruling, option (a) end-state — reverses the earlier
-;; rf2-1gm0o "public-by-design fixture primitive" framing). Exposing the atoms
-;; as Vars was an encapsulation leak that is worse than aesthetic:
-;;   1. `schemas-by-frame` is the authoritative store; consumers must go
-;;      through the encapsulated snapshot / restore / clear API so the
-;;      representation can evolve (a map-shape change, or a future
-;;      companion side-table) without breaking ad-hoc raw-atom consumers.
-;;   2. The public `printer-fn` atom bypassed the never-nil invariant
-;;      `run-printer` relies on with NO read guard — `(reset! printer-fn nil)`
-;;      NPEs the digest path; the setters exist precisely to coerce
-;;      nil → default.
-;;
-;; The supported encapsulated replacements (all below):
-;;   - REGISTRY:  `snapshot-schemas-by-frame` / `restore-schemas-by-frame!` /
-;;                `clear-schemas-by-frame!`.
-;;   - BUNDLE:    `snapshot-schema-fns` / `restore-schema-fns!` (rf2-l4ljvr) +
-;;                `set-schema-fns!` / `set-schema-{validator,explainer,printer}!`
-;;                / `reset-schema-validator!`.
-;;
-;; The schemas artefact's OWN white-box tests (implementation/schemas/test/…)
-;; may still reach `storage/schemas-by-frame` / `validator/validator-fn` via
-;; those home namespaces directly — that is legitimate internal testing, not
-;; public-facade use. Everything outside the schemas artefact uses the
-;; encapsulated API; a re-export of any of the four atoms is a public-facade
-;; change a reviewer catches at diff-time.
+;; Raw registry and validator atoms stay private to their owning namespaces.
+;; Snapshot, restore, clear, and setter functions preserve representation and
+;; never-nil printer invariants across the public boundary.
 
-;; Validator / explainer / printer (rf2-froe + rf2-wla45). `set-schema-fns!`
-;; is the PREFERRED schema-fns configuration path (rf2-13meg — the honest
-;; bundle name): it installs any subset of the validator / explainer / printer
-;; bundle atomically from one map and returns the installed bundle map
-;; `{:validate … :explain … :print …}` (rf2-qdtcx2 — a bundle setter returns
-;; its bundle, not just the validator), so a substitute-Malli port installs all
-;; three together and they never drift mid-boot. The three per-fn singletons
-;; below are RETAINED as lower-level convenience setters for adjusting one fn in
-;; isolation (each returns the single fn it installs); they are not the
-;; preferred boot path — reach for the bundle. `reset-schema-validator!`
-;; restores the default Malli validator.
+;; Prefer the bundle setter when installing a validator port so validate,
+;; explain, and print functions change together. Per-function setters remain
+;; available for isolated adjustments.
 (def set-schema-fns!         validator/set-schema-fns!)
 (def set-schema-validator!   validator/set-schema-validator!)
 (def set-schema-explainer!   validator/set-schema-explainer!)
 (def set-schema-printer!     validator/set-schema-printer!)
 (def reset-schema-validator! validator/reset-schema-validator!)
 
-;; Bundle-level snapshot / restore (rf2-l4ljvr). The validator/explainer/
-;; printer companion to the registry's `snapshot-schemas-by-frame` /
-;; `restore-schemas-by-frame!` (below). `snapshot-schema-fns` captures the
-;; live bundle as one opaque value; `restore-schema-fns!` reinstalls it
-;; (coercing a nil `:print` to the default like `set-schema-fns!`, so the
-;; printer-never-nil invariant holds). Together with the registry pair they
-;; let test-support capture+restore the WHOLE schema runtime through the
-;; encapsulated API rather than reaching the raw `validator-fn` /
-;; `explainer-fn` / `printer-fn` atoms.
+;; Bundle-level snapshot and restore for runtime-isolating fixtures.
 (def snapshot-schema-fns     validator/snapshot-schema-fns)
 (def restore-schema-fns!     validator/restore-schema-fns!)
 
-;; Printer / walker memo clear hooks (rf2-17sqc). Test-support: the
-;; printer + sensitive-walker memos are process-lifetime caches bounded
-;; by the registered-schema cardinality (schemas register once at boot).
-;; Tests that register many distinct fresh schemas clear them in fixture
-;; teardown so the caches don't grow unbounded across the suite. See
-;; [010 §Schema digest].
+;; Production caches are bounded by boot-time schema cardinality. Fixtures
+;; that generate fresh schemas clear them between tests.
 (def clear-edn-print-cache!       validator/clear-edn-print-cache!)
 (def clear-sensitive-paths-cache! walker/clear-sensitive-paths-cache!)
 
@@ -161,81 +65,40 @@
 (def clear-walker-opaque-warned!
   storage/clear-walker-opaque-warned!)
 
-;; Per-slot flag walker (rf2-nwv63 / rf2-kj51z / rf2-oghml). The
-;; parameterised `walk-flagged-schema` recursion primitive stays internal
-;; to `re-frame.schemas.walker`; the public surface is the two single-flag
-;; entry points below (the late-bind hooks the machine `:data-schema`
-;; bridge + story-mcp consume — NOT the app-db egress registry, which is
-;; frame-owned per EP-0015 §8) plus the two sensitivity predicates (the
-;; schema-validation-failure-trace redactor) — not the raw flag-key-
-;; parameterised walker (rf2-7gclb: dead re-export dropped).
+;; Per-slot flag extractors support schema-local validation and tool egress.
+;; Durable app-db classification is owned by frame commit effects, not schemas.
 (def extract-large-paths-from-schema  walker/extract-large-paths-from-schema)
 (def extract-sensitive-paths-from-schema walker/extract-sensitive-paths-from-schema)
 (def schema-has-sensitive?            walker/schema-has-sensitive?)
 (def schema-sensitive-at?             walker/schema-sensitive-at?)
-;; rf2-vmhu4i — the `:large?` whole-schema predicate (mirror of
-;; `schema-has-sensitive?` on the other per-slot flag) the validation
-;; emit-site consults to elide a `:large?` slot's value to the
-;; `:rf.size/large-elided` marker. rf2-u9bjgr — `schema-opaque?` is the
-;; fail-closed predicate for a compiled / opaque `m/schema` value the
-;; walker cannot introspect (its failure redacts as sensitive).
+;; Opaque schemas cannot be inspected for flags and therefore take the
+;; conservative failure-redaction path.
 (def schema-has-large?                walker/schema-has-large?)
 (def schema-opaque?                   walker/schema-opaque?)
-;; rf2-hi0tf8 — the RECURSIVE sibling of `schema-opaque?`: true when the
-;; schema itself is opaque OR embeds a nested opaque child at any depth
-;; (a compiled `m/schema` value used as, say, a `:map` slot's tail inside
-;; an otherwise-walkable vector-form schema). `schema-opaque?` alone only
-;; classifies the root, which under-redacts a nested opaque child; every
-;; fail-closed redaction / registration-warning gate consults this one
-;; instead.
+;; Redaction and registration warnings use the recursive opaque check because
+;; a walkable vector can contain an opaque descendant.
 (def schema-has-opaque-child?         walker/schema-has-opaque-child?)
-;; rf2-ss06u.1 — `walker/sanitize-sensitive-path` (the `:path`-tag sanitiser
-;; that scrubs value-bearing `:set`-element segments so a sensitive `:set`
-;; element never ships verbatim in the structural `:path` tag) is an INTERNAL
-;; redaction helper consumed only by `validate-app-schema!`; it is NOT a
-;; public facade export, so it is deliberately not re-exported here.
 
 ;; Schema digest (Spec 010 §Digest algorithm).
 (def app-schemas-digest digest/app-schemas-digest)
 
-;; Validation entry points (Spec 010 §Validation order).
-;; Per rf2-s2jgz the family is named on the kind axis —
-;; validate-event! / validate-fx! / validate-sub! /
-;; validate-app-schema!. The earlier validate-app-db! /
-;; validate-sub-return! names were renamed for symmetry.
-;;
-;; The injection-time `validate-cofx!` fn was RETIRED per rf2-nkf4l3.
-;; EP-0017 removed the ctx-mutating `inject-cofx` injection point its
-;; `:where :cofx` trace described; the live cofx schema contract is
-;; `re-frame.cofx/validate-recordable-value!` (a production hard error →
-;; `:rf.error/cofx-value-invalid`), not a dev-only
-;; `:rf.error/schema-validation-failure :where :cofx`. See Spec 010
-;; §Validation order step 2.
+;; Validation entry points in the order defined by Spec 010. Recordable cofx
+;; values are validated by `re-frame.cofx`, not by this dev-time family.
 (def validate-app-schema! validate/validate-app-schema!)
 (def validate-event!      validate/validate-event!)
 (def validate-fx!         validate/validate-fx!)
 (def validate-sub!        validate/validate-sub!)
 
-;; Production-side boundary-validation seam (rf2-r2uh).
+;; Production-side boundary-validation seam.
 (def validate-with-registered-fn validate/validate-with-registered-fn)
 (def explain-with-registered-fn  validate/explain-with-registered-fn)
-;; rf2-a5kzs / rf2-o69h5 — THE shared schema-aware redaction seam for
-;; every validation-failure trace emitted outside the schemas artefact:
-;; the boundary interceptor (`re-frame.spec`), machine `:data` validation,
-;; the `:sub-override` path, and flow-output validation each build their
-;; own failure tags and route them through this fn so a `:sensitive?`-marked
-;; schema redacts the value-bearing slots identically to the dev-time
-;; `validate-*!` hot path.
+;; Shared schema-aware redaction for validation failures emitted by callers
+;; outside this artefact.
 (def redact-validation-tags      validate/redact-validation-tags)
 
 ;; ---- late-bind hook registration ------------------------------------------
 ;;
-;; re-frame.router, re-frame.cofx, re-frame.subs, re-frame.elision,
-;; re-frame.epoch, re-frame.test-support, and re-frame.core-schemas
-;; need to call into schema validation but cannot `:require` this
-;; namespace without forcing the schemas artefact onto every consumer's
-;; classpath (per rf2-p7va — schemas is optional). Publish entry points
-;; through the late-bind hook registry. See re-frame.late-bind.
+;; Core and sibling artefacts use late-bound hooks so schemas remains optional.
 ;;
 ;; Calls are written as literal `set-fn!` invocations with a literal
 ;; keyword (one per line) rather than collapsed into a data-driven
@@ -245,11 +108,7 @@
 ;; publication block (flows / machines / routing / http / ssr).
 
 ;; Validation hot-path hooks (consumed by router / subs / epoch).
-;; NB there is no `:schemas/validate-cofx!` hook — the injection-time cofx
-;; validator was retired per rf2-nkf4l3 (EP-0017). The live cofx schema path
-;; is `re-frame.cofx/validate-recordable-value!` →
-;; `:rf.error/cofx-value-invalid`, which routes redaction through the
-;; `:schemas/redact-validation-tags` hook below.
+;; Recordable cofx validation owns its own production error contract.
 (late-bind/set-fn! :schemas/validate-app-schema! validate-app-schema!)
 (late-bind/set-fn! :schemas/validate-event!      validate-event!)
 (late-bind/set-fn! :schemas/validate-sub!        validate-sub!)
@@ -259,11 +118,10 @@
 ;; mirrors :machines/on-frame-destroyed! and :ssr/on-frame-destroyed).
 (late-bind/set-fn! :schemas/on-frame-destroyed!  on-frame-destroyed!)
 
-;; Boundary-validation seam (rf2-r2uh integration).
+;; Boundary-validation seam.
 (late-bind/set-fn! :schemas/validate-with-registered-fn validate-with-registered-fn)
 (late-bind/set-fn! :schemas/explain-with-registered-fn  explain-with-registered-fn)
-;; rf2-a5kzs / rf2-o69h5 — shared schema-aware validation-failure redaction
-;; hook (boundary interceptor + machine-data + sub-override + flow-output).
+;; Shared validation-failure redaction hook.
 (late-bind/set-fn! :schemas/redact-validation-tags      redact-validation-tags)
 
 ;; Public-API re-export hooks (consumed by re-frame.core-schemas).
@@ -278,14 +136,8 @@
 (late-bind/set-fn! :schemas/set-schema-printer!   set-schema-printer!)
 (late-bind/set-fn! :schemas/set-schema-fns!       set-schema-fns!)
 
-;; Schema-walker hooks: the pure-data per-slot `:large?` / `:sensitive?`
-;; extractors. Per rf2-ynnq0 Option A — schemas owns the deep walker.
-;;
-;; EP-0015 §8 (rf2-d2r3um): these NO LONGER feed the app-db egress registry
-;; (`re-frame.elision`) — schemas describe shape, not durable app-db egress
-;; policy, which is now frame-owned. The hooks remain for the surviving
-;; schema-prop owners: the machine `:data-schema` redaction bridge
-;; (`re-frame.machines`, EP-0005) and story-mcp's tool-egress projector.
+;; Pure-data per-slot extractors. These do not populate durable app-db
+;; classification; frame commit effects own that policy.
 (late-bind/set-fn! :schemas/extract-large-paths-from-schema     extract-large-paths-from-schema)
 (late-bind/set-fn! :schemas/extract-sensitive-paths-from-schema extract-sensitive-paths-from-schema)
 

--- a/implementation/schemas/src/re_frame/schemas/cache.cljc
+++ b/implementation/schemas/src/re_frame/schemas/cache.cljc
@@ -1,5 +1,5 @@
 (ns re-frame.schemas.cache
-  "Clearable memo cache primitive (rf2-17sqc shape, consolidated rf2-mse54).
+  "Clearable memo cache primitive.
 
   Two schemas-slice memos — the digest printer (`validator/default-edn-print`)
   and the sensitive-path walker (`walker/extract-sensitive-paths-from-schema`)
@@ -9,14 +9,12 @@
   harness) could never reset the process-lifetime cache; both memos hand-
   rolled the same atom-backed lookup-or-compute + reset! clear pair.
 
-  `clearable-memo` is that pair, parameterised on the underlying fn.
-
-  ## Boot-once invariant (Mike ruled rf2-17sqc, option B)
+  `clearable-memo` supplies that pair for an arbitrary function.
 
   App schemas are registered ONCE at boot, so each memo is bounded by the
   registered-schema cardinality and is intentionally NOT evicted — no
   bounded LRU. The only scenario that violates boot-once is a test that
-  deliberately registers many distinct fresh schemas; such tests call the
+  deliberately generates many distinct schemas; such tests call the
   returned `clear!` fn in fixture teardown so the cache doesn't grow
   unbounded across the suite. See [010 §Schema digest].")
 

--- a/implementation/schemas/src/re_frame/schemas/digest.cljc
+++ b/implementation/schemas/src/re_frame/schemas/digest.cljc
@@ -3,13 +3,13 @@
 
   A stable, cross-runtime hash over a frame's registered `app-db`
   schema set. The wire form is `\"sha256:\" + first-16-hex-chars`. Two
-  frames produce equal digests iff their `{path → schema-value}` maps
-  serialise byte-for-byte identically.
+  Equal serialized schema maps produce equal digests. The 64-bit truncated
+  result is a drift fingerprint, not an injective identity.
 
   Per Spec 010 §Schema digest line 491 the per-schema serialisation
   step routes through the registered validator's `schema-print`
-  companion fn — pluggable via `re-frame.schemas.validator/printer-fn`
-  (rf2-wla45). The default is `validator/default-edn-print` (the
+  companion fn, pluggable via `re-frame.schemas.validator/printer-fn`.
+  The default is `validator/default-edn-print` (the
   Malli-EDN canonical `pr-str`); non-Malli ports register their own
   serialiser via `set-schema-printer!` so the digest reflects the
   registered validator's serialisation contract rather than the
@@ -72,11 +72,10 @@
   "Per Spec 010 §Digest algorithm step 3 — emit one line per
   `(path, schema-value)` of the form `<path-key-bytes> <hex-of-sha256>\\n`.
   The per-schema serialisation routes through the registered
-  `schema-print` companion (rf2-wla45) so non-Malli ports compute
+  `schema-print` companion so non-Malli ports compute
   digests against their own canonical bytes.
 
-  EP-0012 §Path shape + §Canonical EDN identity (rf2-94o54l.2 + rf2-ujmc3u):
-  the path key is encoded through the shared CEDN-1
+  The path key is encoded through the shared CEDN-1
   `re-frame.identity/canonical-bytes`, NOT `pr-str`. Conventions §Canonical
   EDN identity lists \"schema digest path keys\" among the canonical-identity
   surfaces — `pr-str` is host-divergent for the non-keyword segments a
@@ -101,8 +100,7 @@
   "Lexicographic comparison of two strings as UTF-8 byte sequences, per
   Spec 010 §Digest algorithm step 4 (\"sort the lines lexicographically
   as byte sequences (UTF-8) … identical across hosts\"). Bytes are
-  compared unsigned (0..255) so the order matches a byte-sort on any
-  port (rf2-ee38b.6).
+  compared unsigned (0..255) so the order matches a byte-sort on any port.
 
   Host-native string `compare` (JVM `String.compareTo` / JS string
   comparison) is UTF-16 code-unit order, which diverges from UTF-8 byte

--- a/implementation/schemas/src/re_frame/schemas/malli.cljc
+++ b/implementation/schemas/src/re_frame/schemas/malli.cljc
@@ -1,53 +1,26 @@
 (ns re-frame.schemas.malli
-  "Malli adapter for the schemas artefact (rf2-t0hq).
+  "Malli adapter for the schemas artefact.
 
   Per Spec 010 §Default validator the CLJS reference's default validator
   delegates to Malli (`malli.core/validate` / `malli.core/explain`).
-  Historically `re-frame.schemas.validator/default-malli-validate` reached
-  Malli via runtime `resolve` on CLJS:
-
-      :cljs
-      (try
-        (if-let [v (resolve 'malli.core/validate)]
-          (v schema value)
-          true)
-        (catch :default _ true))
-
-  CLJS has no runtime `resolve` (the symbol is a compile-time analyzer
-  affordance only); the `if-let`'s `nil` branch always fired and the
-  default validator returned `true` for every value. Malli was never
-  consulted on CLJS — `(rf/reg-app-schema [:user :age] :int)` then a
-  commit of `\"twenty-three\"` produced no
-  `:rf.error/schema-validation-failure` trace.
-
-  The fix follows the rf2-froe / rf2-p7va substitute-validator
-  precedent: this namespace exists only to publish Malli's `validate`
-  and `explain` fns into the framework's late-bind hook table.
+  This namespace publishes Malli's `validate`, `explain`, and `humanize`
+  functions into the framework's late-bind hook table.
   `re-frame.schemas.validator/default-malli-validate` and
   `re-frame.schemas.validator/default-malli-explain` consult the table
-  at call time and delegate to whatever's published; absent any
-  publisher they soft-pass per the Spec 010 §Recommended soft-pass rule.
+  at call time. An absent validator hook soft-passes; an absent explainer
+  or humanizer produces no diagnostic value.
 
-  Post-rf2-v96fh (schema implies validation) apps do NOT require this
-  namespace explicitly: the `re-frame.schemas` facade `:require`s it for
+  Applications do not require this namespace explicitly: the
+  `re-frame.schemas` facade requires it for
   its ns-load side effect, so loading the schemas artefact publishes the
-  Malli hooks automatically and the default validator is LIVE the moment
-  a schema is registered — same on both CLJS and the JVM (rf2-qyfie
-  removed the JVM `requiring-resolve` fallback so the contract is
-  symmetrical):
+  Malli hooks automatically on both CLJS and the JVM:
 
       (ns my-app.core
         (:require [re-frame.core :as rf]
                   [re-frame.schemas])) ;; transitively loads this adapter
 
-  (A standalone `(:require [re-frame.schemas.malli])` still works and is
-  harmless — the hook publication is idempotent — but is no longer
-  required. Pre-v96fh it WAS the opt-in: the adapter had to be required
-  separately or schemas soft-passed silently.)
-
   Because the facade pulls Malli in, the only Malli-FREE posture is to
-  not require `re-frame.schemas` at all (per rf2-qnxf bundle audit — the
-  no-feature counter reference app). An app that DOES use schemas but
+  not require `re-frame.schemas` at all. An app that uses schemas but
   wants to drop Malli's validation *behaviour* (it still pays the bundle
   cost under static CLJS compilation, since requiring the facade loads
   this ns's body) either:
@@ -56,8 +29,7 @@
       install a custom validator, or
     - Calls `(schemas/set-schema-validator! nil)` for a hard no-op.
 
-  See the `re-frame.schemas` ns docstring (rf2-v96fh) for the full
-  bundle-isolation tradeoff."
+  See the `re-frame.schemas` namespace docstring for the bundle boundary."
   (:require [malli.core]
             [malli.error]
             [re-frame.late-bind :as late-bind]))
@@ -66,24 +38,17 @@
 
 ;; ---- publish Malli into the late-bind hook table -------------------------
 ;;
-;; Per rf2-t0hq the two hooks `:schemas/malli-validate` and
+;; The hooks `:schemas/malli-validate` and
 ;; `:schemas/malli-explain` are read by
 ;; `re-frame.schemas.validator/default-malli-validate` /
 ;; `default-malli-explain` on every validate call. Both
 ;; sides of the seam are in this artefact so the contract is local;
 ;; the seam is published as a hook key so future ports
-;; (`re-frame.schemas.zod` / `.pydantic` / ...) can register their own
-;; default validator pair without a code change to the schemas
+;; can register their own default validator pair without changing this
 ;; namespace.
 
 (late-bind/set-fn! :schemas/malli-validate  malli.core/validate)
 (late-bind/set-fn! :schemas/malli-explain   malli.core/explain)
 
-;; rf2-2ek7t — also publish the canonical :schemas/humanize-explain!
-;; hook so consumers (Xray's violation block, future tools) read
-;; through ONE seam regardless of which validator's adapter is
-;; loaded. When malli is the registered validator + this adapter ns
-;; is loaded, the canonical hook routes to malli.error/humanize.
-;; Non-Malli adapters (e.g. .zod / .pydantic) register their own
-;; humanizer under the same canonical hook key.
+;; Consumers use the same humanize hook regardless of validator adapter.
 (late-bind/set-fn! :schemas/humanize-explain! malli.error/humanize)

--- a/implementation/schemas/src/re_frame/schemas/storage.cljc
+++ b/implementation/schemas/src/re_frame/schemas/storage.cljc
@@ -1,15 +1,9 @@
 (ns re-frame.schemas.storage
   "Per-frame storage + registration surface for app-db schemas.
 
-  Per Spec 010 §Per-frame schemas. The registry shape is
-    {frame-id {path schema-meta}}
-  mirroring `re-frame.flows`'s frame-scoping (rf2-lvwr). The per-frame
-  atom is the **single source of truth** for `app-db` schemas — app-db
-  schemas are NOT a registrar kind (resolved rf2-0frdi, finalised
-  rf2-cq1ak). Source-coords / hot-reload / pair-tool introspection
-  reads through `app-schema-meta-at`, which returns the per-frame
-  metadata map (including the registration's `:ns` / `:line` / `:file`
-  source-coords).
+  The authoritative registry has shape `{frame-id {path schema-meta}}`.
+  App-db schemas are not registrar entries; source coordinates, hot reload,
+  and tools read the metadata stored here.
 
   Owns:
     - `schemas-by-frame` atom (the authoritative store).
@@ -42,32 +36,10 @@
   (atom {}))
 
 (defn resolve-frame
-  "Resolve the frame a schema registration / read targets. EP-0002 —
-  app-db schemas are CONTEXT-REQUIRED FRAME-LOCAL: the explicit `:frame`
-  opt (the *override*) wins, else the carried-invariant scope chain via
-  `frame/require-current-frame!` (a `with-frame` / frame-provider scope, or
-  a frame `:initial-events` step). Called under no established scope and no
-  explicit `:frame`, it raises the always-on `:rf.error/no-frame-context`
-  (per Spec 002 §Frame target resolution) rather than resolving to a
-  synthesised `:rf/default` floor — namespace-load time is not a reason to
-  pick a default frame. `operation` (optional) names the surface for the
-  error payload's `:operation` slot.
-
-  rf2-7pllal — the explicit `(:frame opts)` override is a frame TARGET, not
-  necessarily a frame-id keyword: EP-0024 made frame VALUES first-class, so
-  `{:frame frame-value}` is a legal shape. The override is normalized through
-  `frame/frame-target->id` (a keyword id passes byte-identically; a frame
-  value yields its runnable id) — the SAME pattern `re-frame.core/dispatch`
-  uses for its `:frame` opt — so a schema registered under a frame VALUE is
-  keyed by the SAME id a read-by-id later resolves. Before the fix a
-  `{:frame frame-value}` registration stored under the frame-value MAP itself
-  and a read-by-id silently missed it.
-
-  The resolved target is then asserted to be a keyword frame-id: the
-  `schemas-by-frame` registry is keyed by it, so an arbitrary non-keyword
-  `:frame` (a string, a non-frame map, a vector) must fail loud at the
-  resolution boundary rather than silently becoming a registry key that no
-  keyword-id read can ever reach (the no-silent-swallow principle)."
+  "Resolve a schema operation's frame id. An explicit `:frame` target wins;
+  otherwise the carried frame scope is required. Frame values normalize to
+  runnable ids, and the result must be a keyword so reads and registrations
+  cannot create unreachable registry keys. `operation` labels context errors."
   ([opts] (resolve-frame opts :reg-app-schema))
   ([opts operation]
    (let [override (:frame opts)
@@ -91,40 +63,14 @@
 
 (defn coerce-opts
   "Permit the keyword-only sugar `(app-schemas frame-id)` and the
-  opts-map form `(app-schemas {:frame frame-id})`.
+  opts-map form `(app-schemas {:frame frame-id})`. Nil means no override.
 
-  rf2-iszpyg — a `nil` argument coerces to `{}` (the empty-opts shape),
-  identical to the no-arg arity's behaviour: it means \"no override —
-  resolve the frame from the carried-invariant scope\". Every read /
-  registration entry point already passes `{}` in its zero-arity
-  (`app-schema-at`, `app-schema-meta-at`, `app-schemas`,
-  `app-schemas-digest`, `reg-app-schemas`), so `nil` only arrives from an
-  explicit `(app-schemas nil)` by a trusted in-process caller. Unlike the
-  nil-PATH hazard (a non-sequential path poisons the `get-in` validation
-  hot path), a nil OPTS has no downstream hazard — it just delegates frame
-  resolution to scope, exactly as the no-arg arity does — so accepting it
-  removes a footgun rather than masking a defect.
-
-  rf2-7pllal — a bare frame VALUE (`rf/make-frame`'s return token) is itself
-  a map (it carries `:rf.frame/object` / `:rf.frame/runnable-id`), so the
-  `frame/frame-value?` discriminator MUST be checked BEFORE the generic
-  `map?` opts-map branch. Otherwise a bare frame value is misclassified as an
-  opts map with no `:frame` key and silently falls back to the ambient frame
-  (or throws `:rf.error/no-frame-context` outside a scope). A bare frame
-  value coerces to `{:frame <frame-value>}` so the frame the value names is
-  the registration / read target — the value's id is then resolved by
-  `resolve-frame` (via `frame/frame-target->id`), mirroring how the keyword-
-  sugar arity names a frame."
+  A frame value is itself a map, so it must be recognized before the generic
+  opts-map branch or it would lose its target."
   [opts-or-frame-id]
   (cond
     (nil? opts-or-frame-id) {}
-    ;; A keyword frame-id is the `{:frame kw}` sugar; a bare frame VALUE is the
-    ;; `{:frame value}` sugar — both are frame TARGETS naming a frame. The
-    ;; frame-value? check MUST come before the generic `map?` branch below: a
-    ;; frame value IS a map, so without this it would be misclassified as an
-    ;; opts map with no `:frame` key and silently fall back to the ambient
-    ;; frame (rf2-7pllal). resolve-frame later normalizes the target (keyword
-    ;; or value) to its frame id via frame/frame-target->id.
+    ;; A frame value is a map; keep this branch before the generic map branch.
     (or (keyword? opts-or-frame-id)
         (frame/frame-value? opts-or-frame-id)) {:frame opts-or-frame-id}
     (map? opts-or-frame-id) opts-or-frame-id
@@ -141,40 +87,20 @@
                   :expected "keyword frame-id, frame value, or opts map"}})))
 
 (defn frame-target->opts
-  "Lift a `reg-app-schema` metadata `:frame` value — a frame TARGET — into the
-  `{:frame <target>}` opts shape `resolve-frame` consumes, so the singular
-  registration path resolves a target IDENTICALLY to the read surface.
-
-  rf2-5429ec — the bug this closes: the singular `reg-app-schema` previously
-  passed the bare `(:frame metadata)` value straight through `coerce-opts` as
-  if it were the WHOLE opts arg. For a frame-id keyword / frame value that
-  happens to work (coerce-opts lifts both to `{:frame target}`), but for a
-  NON-frame MAP target (e.g. `{:not :a-frame}`, or a raw frame-record-shaped
-  map) `coerce-opts` classifies it as an OPTS map and returns it verbatim —
-  with no `:frame` key — so `resolve-frame` saw no override and silently
-  borrowed the AMBIENT frame, registering the schema against the wrong frame
-  with no error. That contradicts spec/010-Schemas.md §Per-frame schemas and
-  spec/API.md §Schemas, which require an explicit `:frame` resolving to a
-  non-keyword target (a string, a vector, a non-frame map) to FAIL LOUD with
-  `:rf.error/app-schemas-bad-arg` (the no-silent-swallow principle).
-
-  The metadata `:frame` value is a frame TARGET (not an opts map), so we wrap
-  it back into `{:frame target}` and let `resolve-frame` apply the SAME
-  `frame/frame-target->id` + keyword-frame-id assertion the read surface uses.
-  A non-frame map target then resolves to itself (frame-target->id leaves a
-  non-frame map unchanged) and trips the keyword-frame-id guard → loud throw.
-  A `nil` target (no `:frame` in the metadata) yields `{}` — resolve from the
-  carried-invariant scope. Pure."
+  "Lift registration metadata's `:frame` target into the opts shape consumed
+  by `resolve-frame`. Wrapping matters for invalid map-shaped targets: they
+  must be validated as targets, not mistaken for an opts map. Nil selects the
+  carried frame scope."
   [frame-target]
   (if (some? frame-target)
     {:frame frame-target}
     {}))
 
 (defn- best-effort-frame
-  "Resolve the registration frame for an error payload WITHOUT throwing —
+  "Resolve the registration frame for an error payload without throwing:
   the explicit `:frame` opt if present, else the carried-invariant scope
   frame, else `nil` when no scope is established. Used only to enrich the
-  `:rf.error/app-schema-runtime-path` payload (rf2-k0ew8n): the path-gate
+  `:rf.error/app-schema-runtime-path` payload. The path gate
   runs before the registration's own (throwing) frame resolution, so we
   must not let a missing scope (or a malformed opts shape) mask the
   runtime-path rejection.
@@ -183,7 +109,7 @@
   or the singular path's `(frame-target->opts (:frame metadata))` lift) — i.e.
   the same shape `resolve-frame` consumes — so this is the non-throwing twin of
   the registration's own resolution and they never disagree on which frame the
-  error payload names (rf2-5429ec)."
+  error payload names."
   [opts]
   (try
     (resolve-frame (coerce-opts opts))
@@ -191,10 +117,10 @@
 
 (defn- normalize-app-schema-metadata
   "Validate + normalize the OPTIONAL middle registration-metadata map of the
-  3-slot `(reg-app-schema path metadata schema)` grammar (rf2-qm7k83 Part A).
+  3-slot `(reg-app-schema path metadata schema)` grammar.
 
-  Per Part A the schema is an ordinary POSITIONAL value slot — the last arg —
-  uniform with every other 3-slot `reg-*` surface (Spec 001 §The metadata map):
+  The schema is the final positional value, matching other 3-slot `reg-*`
+  surfaces:
 
       (reg-app-schema [:user] UserSchema)                ;; 2-slot
       (reg-app-schema [:user] {:frame :session} UserSchema) ;; 3-slot
@@ -215,42 +141,13 @@
       'rf/reg-app-schema
       (str "reg-app-schema's middle arg must be a registration-metadata map — "
            "e.g. (reg-app-schema " (pr-str path) " {:frame :session} MySchema). "
-           "Got " (pr-str metadata) ". Per rf2-qm7k83 Part A the grammar is "
+           "Got " (pr-str metadata) ". The grammar is "
            "(reg-app-schema path schema) / (reg-app-schema path metadata schema); "
            "the schema is the positional value slot, not a :schema metadata key.")
       {:recovery :pass-metadata-map-then-schema
        :extra    {:path path :received metadata}})))
 
-;; ---- registration-time path-shape validation (rf2-sk0ql) ------------------
-;;
-;; A `reg-app-schema` `path` is a `get-in`/`assoc-in`-shaped path: a
-;; SEQUENTIAL collection of keys, or the empty vector `[]` for the whole
-;; `app-db` root (Spec 010 §`app-db` schemas — path-based / §A schema for
-;; the whole `app-db` / §Digest algorithm "path is a vector of keywords
-;; (or the empty vector for the root schema)").
-;;
-;; Before rf2-sk0ql `reg-app-schema` / `reg-app-schemas` stored the `path`
-;; verbatim with no shape check. A non-sequential scalar — a bare keyword
-;; (`:n`), a string, a number, nil — registered successfully and surfaced
-;; through introspection, but `validate-app-schema!` later evaluates
-;; `(get-in db reg-path)` over every stored path, and `get-in` with a
-;; non-sequential `ks` throws `IllegalArgumentException` ("Don't know how
-;; to create ISeq from: …"). The live router's `run-post-commit-validation!`
-;; wraps that call in a defensive try/catch (a buggy validator must not
-;; mask app-db state) and treats the throw as `true` — so an invalid `:db`
-;; commit is installed permanently with NO `:rf.error/schema-validation-
-;; failure` trace and NO rollback. Worse, the poisoned entry persists in
-;; the frame's registry and makes EVERY subsequent commit's validation
-;; throw, silently disabling post-commit validation for the whole frame —
-;; a correctness- and privacy-relevant bypass (the redaction-bearing
-;; failure traces never fire).
-;;
-;; Fix: fail loud at registration time, BEFORE writing `schemas-by-frame`,
-;; with a framework error id (`:rf.error/app-schema-bad-path`). An invalid
-;; shape never lands, so the validation hot path can never be poisoned.
-;; Always-on (NOT gated by `interop/debug-enabled?`): a malformed
-;; registration is a programming error that must surface in every build,
-;; and the cost is one cheap predicate per `reg-app-schema` call.
+;; ---- registration-time path validation -----------------------------------
 
 (defn valid-app-schema-path?
   "True when `path` is a valid `reg-app-schema` path: a sequential
@@ -259,15 +156,15 @@
   scalars — a bare keyword, string, number, nil, map, set — are rejected:
   they break the `(get-in db path)` the validation hot path runs.
 
-  `sequential?` (not `vector?`) is deliberate — APIs MAY accept any
-  sequential collection for migration ergonomics (Conventions §The
+  `sequential?` (not `vector?`) is deliberate: APIs accept any
+  sequential collection (Conventions §The
   `:rf/path` algebra §Path shape). The accepted seq is then NORMALIZED to
   its canonical vector form before it becomes a stored declaration / digest
   path key, so a list path and the equivalent vector path are ONE identity
   (EP-0012 §Path shape — \"all stored declarations MUST normalize to a
   vector\").
 
-  rf2-ujmc3u: each SEGMENT must additionally be a concrete `:rf/path`
+  Each segment must additionally be a concrete `:rf/path`
   segment (`re-frame.path/segment?` — a portable EDN identity value:
   keyword, string, symbol, safe-range integer, boolean, UUID, instant, or
   nil). Schema paths are full `:rf/path` citizens (Conventions §The
@@ -282,38 +179,10 @@
   (and (sequential? path)
        (every? path/segment? path)))
 
-;; ---- runtime-db first-segment rejection (rf2-k0ew8n) ----------------------
-;;
-;; Per Spec 010 §`app-db` schemas, app schemas validate ONLY app-db: the
-;; `validate-app-schema!` hot path reads `(get-in app-db path)`. After
-;; EP-0001 the durable machine / routing / SSR / elision state moved OUT
-;; of app-db into the SEPARATE runtime-db partition, reached through the
-;; reserved `:rf.runtime/*` namespace (and the now-retired legacy app-db
-;; `:rf/runtime` root). A path whose FIRST segment reaches into runtime-db
-;; is a CATEGORY error for `reg-app-schema`:
-;;
-;;   - a normal `[:map …]` schema registered there validates `(get-in
-;;     app-db [:rf.runtime/… …])`, which is `nil` (the state lives in
-;;     runtime-db, not app-db), so EVERY dev commit fails validation /
-;;     detonates, or
-;;   - the author falsely believes they have installed a guard over
-;;     runtime-db state when nothing of the sort happened.
-;;
-;; Either way there is NOTHING to soft-land: no legitimate caller registers
-;; an app schema against a runtime path. So — unlike the `:rf.db/runtime`
-;; EFFECT seam, where a warning teaches because the misuse still executes
-;; as intended — this is a HARD REJECT at the existing pre-mutation gate
-;; (RULING (b), rf2-k0ew8n). The runtime-db partition is framework-owned —
-;; the framework validates it (machine `:snapshots` refined per-machine from
-;; each machine's `:data-schema`); it is NOT a user schema-registration
-;; surface (per Conventions §Reserved runtime-db keys — "user code MUST NOT
-;; register against it"). So the error tells the user the honest remedy
-;; (drop the runtime path), NOT to call a non-public, framework-owned API
-;; (rf2-sklyam — the prior `:reason` pointed users at `reg-runtime-schema`,
-;; which has no public export and is framework-owned). EP-0001 line ~484
-;; said "warn"; that predates the fail-closed hardening campaign
-;; (rf2-sk0ql, rf2-naihn1, the legacy-root hard error) and is the artefact
-;; under repair here, not a constraint.
+;; ---- runtime-db first-segment rejection -----------------------------------
+;; App schemas validate app-db only. Runtime-db is framework-owned, so a
+;; runtime path is rejected before registration rather than installing a
+;; contract over a value this validator never reads.
 
 (defn runtime-app-schema-path?
   "True when `path`'s FIRST segment reaches into the runtime-db partition
@@ -321,8 +190,7 @@
   machines`, `:rf.runtime/routing`, `:rf.runtime/elision`, …), the
   runtime-db CONTAINER root `:rf.db/runtime` (the epoch / restore path
   prefix), OR the retired legacy app-db `:rf/runtime` root. Such a path is
-  a category error for `reg-app-schema`, which validates ONLY app-db
-  (rf2-k0ew8n).
+  a category error for `reg-app-schema`, which validates only app-db.
 
   Mirrors the canonical runtime-path detection used across the core
   conformance reader (`(= \"rf.runtime\" (namespace (first path)))`) and
@@ -347,16 +215,14 @@
 
     - `:rf.error/app-schema-bad-path` — the SHAPE is wrong (a
       non-sequential scalar), which would poison the `validate-app-schema!`
-      hot path's `(get-in db path)` (rf2-sk0ql).
+      hot path's `(get-in db path)`.
     - `:rf.error/app-schema-runtime-path` — the shape is fine but the
       FIRST segment reaches into the runtime-db partition (`:rf.runtime/*`
       or the legacy `:rf/runtime` root). App schemas validate only app-db;
       the runtime-db partition is framework-owned (the framework validates
       it — machine `:snapshots` refined per-machine from each machine's
       `:data-schema`) and is NOT a user schema-registration surface, so the
-      honest remedy is to drop the runtime path (rf2-k0ew8n, RULING (b);
-      rf2-sklyam — the reason no longer points users at a non-public,
-      framework-owned API).
+      remedy is to drop the runtime path.
 
   `frame` (optional) names the resolved registration frame for the
   runtime-path error payload; callers pass the frame they resolved. It is
@@ -398,27 +264,14 @@
         :extra    {:received path
                    :frame    frame}}))))
 
-;; ---- bulk first-argument shape validation (rf2-naihn1) --------------------
-;;
-;; `reg-app-schemas` documents its first argument as a `{path -> schema}`
-;; MAP (Spec 010 §`reg-app-schemas` / API.md). Before this fix the plural
-;; API never checked that shape: in Clojure `(keys nil)` is `nil` and
-;; iterating `nil` yields no entries, so `(reg-app-schemas nil)` ran the
-;; up-front `(run! assert-app-schema-path! (keys nil))` (no-op), registered
-;; nothing, and returned `[]` — INDISTINGUISHABLE from the documented `{}`
-;; no-op. A boot/config/schema-loader bug that passes `nil` (or any non-map
-;; — a vector, a string, a seq of pairs) instead of a schema map then gets
-;; a FALSE GREEN: no schemas registered, no validation contract installed,
-;; no error surfaced. That silently disables schema enforcement for the
-;; whole batch. Fix: reject nil / non-map FIRST, before any mutation, with
-;; an explicit error id; keep the empty map `{}` as the documented no-op.
+;; ---- bulk argument validation ---------------------------------------------
 
 (defn valid-bulk-schemas-arg?
   "True when `path->schema` is an acceptable `reg-app-schemas` first
   argument: a map (INCLUDING the empty map `{}`, the documented no-op).
   nil, vectors, strings, seqs of pairs, and every other non-map shape are
   rejected — they would silently register nothing and hand back `[]`,
-  masking a malformed-input bug (rf2-naihn1)."
+  masking a malformed-input bug."
   [path->schema]
   (map? path->schema))
 
@@ -426,7 +279,7 @@
   "Throw `:rf.error/app-schemas-bad-batch` when `reg-app-schemas`'
   first argument is not a `{path -> schema}` map. Called BEFORE any
   store mutation so a nil / non-map batch rejects atomically rather than
-  silently no-op'ing to `[]` (rf2-naihn1). `{}` is accepted (the
+  silently no-op'ing to `[]`. `{}` is accepted (the
   documented empty no-op)."
   [path->schema]
   (when-not (valid-bulk-schemas-arg? path->schema)
@@ -452,39 +305,11 @@
   [opts-or-frame-id]
   (resolve-frame (coerce-opts opts-or-frame-id)))
 
-;; ---- validator-unavailable warning (rf2-fq7d2) ----------------------------
-;;
-;; Per Spec 010 §Recommended soft-pass, the schemas artefact ships with a
-;; Malli-delegating default validator that returns true ("pass") when the
-;; `:schemas/malli-validate` late-bind hook is unbound — i.e. when nothing
-;; has published Malli's `validate` into the late-bind table. This is
-;; intentional (apps that swap in a non-Malli validator must work), but a
-;; `reg-app-schema` call WITH the default validator AND that hook unbound
-;; validates nothing — boundary-validated handlers silently accept
-;; untrusted input. This warning is the dev-time nudge for that state.
-;;
-;; Post-rf2-v96fh (schema implies validation) the *common* path can no
-;; longer reach it: the `re-frame.schemas` facade now `:require`s
-;; `re-frame.schemas.malli` itself, so loading the schemas artefact binds
-;; `:schemas/malli-validate` at ns-load and the default validator is LIVE
-;; the moment a schema is registered. The warning therefore fires only in
-;; the two residual cases — symmetric with `validator.cljc`'s soft-pass
-;; fallback doc:
-;;   (1) a non-Malli port / app that installed its own validator via
-;;       `set-schema-validator!` but left the Malli hook unbound (it
-;;       opted out of Malli, so condition 2 below is false — NO warning;
-;;       see the closing note), or
-;;   (2) a test harness that deliberately unbinds `:schemas/malli-validate`
-;;       to exercise the absent-validator path.
-;;
-;; The warning fires once per process from `reg-app-schema` /
-;; `reg-app-schemas` when BOTH hold:
-;;   1. `:schemas/malli-validate` late-bind hook is unbound, AND
-;;   2. `validator-fn` is still the framework default.
-;;
-;; Apps that registered a non-default validator (a Zod port, clojure.spec
-;; bridge, etc.) opted out of Malli explicitly — condition 2 is false, so
-;; no warning.
+;; ---- validator-unavailable warning ----------------------------------------
+;; The default validator deliberately soft-passes when its Malli hook is
+;; absent. Loading the facade normally installs that hook, so warn only when
+;; the default remains selected and the hook is nevertheless unavailable.
+;; Custom validators are an explicit opt-out and do not warn.
 
 (defonce ^:private validator-unavailable-warned
   ;; Process-lifecycle one-shot. Reset by `clear-validator-unavailable-warned!`
@@ -497,43 +322,12 @@
   []
   (reset! validator-unavailable-warned false))
 
-;; ---- walker-opaque warning (rf2-jsokn / rf2-ycqtv finding #12) ------------
-;;
-;; Per Spec 010 §The `:schema` value is opaque to re-frame, the framework's
-;; schema walker (`re-frame.schemas.walker`) is pure data — it handles
-;; vector-form Malli EDN and treats compiled `m/schema` values as opaque
-;; leaves. A user that registers a compiled `m/schema` value and puts
-;; `:sensitive?` / `:large?` per-slot flags inside the compiled value will
-;; see the walker **silently skip** them — the validation-failure trace
-;; won't redact the sensitive slot and the size-elision walker won't see
-;; the `:large?` declarations.
-;;
-;; This warning fires once per process from `reg-app-schema` /
-;; `reg-app-schemas` when the registered schema is a genuinely opaque
-;; NON-keyword value (compiled `m/schema` object, etc.) the walker
-;; cannot introspect. Symmetric with the
-;; `:rf.warning/schema-validator-unavailable` warn-once-per-process
-;; pattern above. Cost is one boot-time predicate per `reg-app-schema`
-;; call; the warning is the discoverability nudge for the one workable
-;; shape — registering the vector form so the walker can introspect the
-;; per-slot flags (the registration-meta `:sensitive?` fallback has been
-;; removed; sensitivity is path-targeted — rf2-k0ew8n).
-;;
-;; Keyword schemas DO NOT warn (rf2-ee38b.6 — correctness P2). A bare
-;; keyword is non-vector but is a valid, idiomatic Malli schema in two
-;; flavours: a primitive type (`:int` / `:string` / `:boolean` / `:any`)
-;; and a registry reference (`:my/user-schema`). The walker's keyword
-;; clause returns `acc` with no declarations because a bare keyword
-;; CANNOT carry per-slot props — for a primitive there is provably
-;; nothing to skip, so the warning was a pure false positive on the
-;; common case. The predicate cannot cheaply distinguish a primitive
-;; keyword from a registry-ref keyword without a Malli registry consult
-;; (which would violate Spec 010 §The `:schema` value is opaque to
-;; re-frame). Rather than warn on every keyword — a frequent
-;; false-positive to catch a rare registry-ref true-positive — we
-;; suppress the keyword case entirely. Registry refs that hide per-slot
-;; flags are an advanced shape covered by the walker docstring's
-;; discoverability caveat (rf2-yaioz).
+;; ---- walker-opaque warning -------------------------------------------------
+;; The pure-data walker can inspect vector-form Malli EDN but not compiled
+;; schema objects. Warn once when any opaque descendant could hide per-slot
+;; flags. Bare keywords do not warn: primitive keywords cannot carry props,
+;; and distinguishing them from registry references would require the
+;; framework to interpret the validator's schema language.
 
 (defonce ^:private walker-opaque-warned
   ;; Process-lifecycle one-shot. Reset by `clear-walker-opaque-warned!`
@@ -551,11 +345,11 @@
   introspect for per-slot `:sensitive?` / `:large?` flags — the root is
   vector-form Malli EDN or a bare keyword (primitive type or registry
   ref — a keyword cannot carry per-slot props, so the walker provably
-  skips nothing and there is nothing to warn about, rf2-ee38b.6) AND no
+  skips nothing and there is nothing to warn about) AND no
   NESTED child anywhere beneath it is itself opaque.
 
-  Per rf2-hi0tf8: a schema whose ROOT is walkable vector-form EDN can
-  still embed an opaque child at a deeper slot (e.g. `[:map [:token
+  A schema whose root is walkable vector-form EDN can still embed an opaque
+  child at a deeper slot (e.g. `[:map [:token
   (m/schema [:string {:sensitive? true}])]]`) — a root-only check would
   call that schema introspectable even though the nested compiled
   value's per-slot flags are exactly as invisible to the walk as a
@@ -632,7 +426,7 @@
                      " `set-schema-validator!` with a non-default fn"
                      " to suppress this warning.")})))))
 
-;; ---- hot-reload :rf.schema/violation trace (rf2-ee38b.6) ------------------
+;; ---- hot-reload :rf.schema/violation trace --------------------------------
 ;;
 ;; Per Spec 010 §Schema migration on hot-reload + Spec 009 error catalogue
 ;; row `:rf.schema/violation`: when a `(frame-id, path)` schema is
@@ -653,17 +447,13 @@
 ;; place of `:mismatching-value` when the new schema declares the slot
 ;; sensitive, mirroring the `:rf.error/schema-validation-failure`
 ;; redaction posture so the hot-reload trace never re-leaks a credential.
-;; rf2-qe237 — refer to the canonical core def rather than a local copy so
-;; the keyword can never drift across artefacts.
-;;
-;; rf2-u9bjgr / rf2-kzghnz — the sensitivity decision below ALSO fails CLOSED
-;; on an OPAQUE schema (a compiled `m/schema` object the pure-data walker
-;; cannot introspect): `schema-has-sensitive?` returns false on an opaque
+;; The sensitivity decision also fails closed on an opaque schema the walker
+;; cannot introspect: `schema-has-sensitive?` returns false on an opaque
 ;; value even though Malli may honour a `{:sensitive? true}` slot inside it for
 ;; the violation. Without the fail-closed arm a hot-reload violation against an
 ;; opaque schema carrying a sensitive slot leaked `:mismatching-value` verbatim
-;; — the SAME asymmetry the `:rf.error/schema-validation-failure` redactor
-;; closed for the validate-*! egress (`re-frame.schemas.validate`, the
+;; — the same asymmetry the validation-failure redactor closes
+;; (`re-frame.schemas.validate`, the
 ;; `(or schema-has-sensitive? schema-opaque?)` posture). This is the redaction
 ;; half of the same fail-closed posture for the hot-reload egress edge.
 (def ^:private redacted-sentinel privacy/redacted-sentinel)
@@ -694,7 +484,7 @@
                            (catch #?(:clj Throwable :cljs :default) _ true))]
         (when-not passes?
           (when-let [emit! (late-bind/get-fn :trace/emit!)]
-            ;; rf2-u9bjgr / rf2-kzghnz — fail CLOSED on an OPAQUE schema. The
+            ;; Fail closed on an opaque schema. The
             ;; pure-data walker cannot see a `{:sensitive? true}` slot inside a
             ;; compiled `m/schema` value, so `schema-has-sensitive?` alone would
             ;; return false and `:mismatching-value` would egress the live value
@@ -702,8 +492,8 @@
             ;; (`re-frame.schemas.validate` uses the same
             ;; `(or schema-has-sensitive? schema-has-opaque-child?)` posture). A
             ;; bare keyword is provably flag-free and is NOT opaque
-            ;; (`schema-opaque?`). Per rf2-hi0tf8 the opaque check is the
-            ;; RECURSIVE `schema-has-opaque-child?`, not the root-only
+            ;; (`schema-opaque?`). Use recursive `schema-has-opaque-child?`,
+            ;; not the root-only
             ;; `schema-opaque?` — a vector-form `new-schema` can embed a nested
             ;; opaque child the root-only check would miss.
             (let [sensitive? (or (walker/schema-has-sensitive? new-schema)
@@ -719,38 +509,9 @@
                       :recovery           :logged-and-skipped
                       :sensitive?         sensitive?}))))))))
 
-;; ---- schema-attached app-db egress markers REMOVED (EP-0015 §8, rf2-d2r3um)
-;;
-;; A `reg-app-schema` `{:large? true}` / `{:sensitive? true}` slot prop used
-;; to be walked into the frame's `[:rf.runtime/elision …]` registry at
-;; registration time (and re-walked per-dispatch by the router) via the
-;; `:elision/populate-from-schemas!` hook — a SECOND route to classify a
-;; durable app-db path. EP-0015 §8 abolishes that route: schemas describe
-;; shape, validation, and explainability, NOT durable app-db egress policy.
-;; Durable app-db classification rides the EP-0025 commit-plane classification
-;; effects — a `reg-event` returns `:sensitive` / `:large` alongside `:db`
-;; (`re-frame.elision/apply-classification-effects`, `:source :effect`).
-;;
-;; With population gone, so is the registration-time population call, its
-;; relevance pre-check (`populate-relevant?` / `schema-contributes-elision?`),
-;; and the per-frame registration linearization lock (rf2-naihn1) — that lock
-;; existed ONLY to make the side-table write + the elision refresh atomic per
-;; frame, closing an off-box-redaction-loss race in the two-step population.
-;; A bare `(swap! schemas-by-frame assoc-in …)` is atomic on its own, so the
-;; side-table write needs no lock now.
-;;
-;; The schema's `{:sensitive? true}` slot prop still drives
-;; schema-validation-failure-trace redaction (`re-frame.schemas.validate`),
-;; and the per-slot extractors still serve their surviving owner-local
-;; consumers (the resource `:data-schema` classification, the HTTP body-privacy
-;; projector, story-mcp's tool-egress projector) — each consults the schema
-;; directly, never this registry. The machine `:data-schema`→MARKS redaction
-;; bridge (EP-0005) is NOT among them: EP-0025 (rf2-398kql) reversed it —
-;; durable machine `:data` classification now rides the SAME commit-plane
-;; classification effects as every other app-db path, not a schema→marks walk.
-;; (The machine `:data-schema` still VALIDATES and its props still drive the
-;; machine-data validation-FAILURE-trace redactor — only the schema→marks
-;; CLASSIFICATION bridge is gone; see `re-frame.schemas.walker` ns-doc.)
+;; Schemas describe shape and validation-failure egress. They do not populate
+;; durable app-db classification, which is owned by commit-plane effects.
+;; Schema props remain available to owner-local transient egress projectors.
 
 ;; ---- app-db schema registration -------------------------------------------
 
@@ -759,7 +520,7 @@
   dev whenever an event handler returns a new app-db; failures emit
   :rf.error/schema-validation-failure.
 
-  ## Grammar — the schema is the positional value slot (rf2-qm7k83 Part A)
+  The schema is the positional value slot:
 
       (rf/reg-app-schema [:user] UserSchema)                   ;; 2-slot
       (rf/reg-app-schema [:user] {:frame :session} UserSchema) ;; 3-slot
@@ -773,147 +534,40 @@
   `:my/*` extension key). Omit it for the 2-slot form. A non-map middle arg
   throws `:rf.error/app-schema-bad-metadata` at the authoring boundary.
 
-  Per Spec 010 §Per-frame schemas this registration is frame-scoped.
-  EP-0002 — context-required frame-local: the frame comes from the
-  explicit :frame metadata key (the *override*), else the carried-invariant
-  scope chain (a (with-frame ...) wrapper, a frame-provider, or a frame
-  :initial-events step). Registering under no established scope and no
-  explicit :frame raises :rf.error/no-frame-context — namespace-load time
-  is not a reason to register against a synthesised :rf/default.
-
-  Per rf2-0frdi / rf2-cq1ak the schemas artefact owns its own per-frame
-  side-table (`schemas-by-frame`) — app-db schemas are NOT a registrar
-  kind. The authoritative store is keyed by `(frame-id, path)` so that
-  registrations against frame A and frame B against the same path are
-  independent entries. Pair-tools and source-coord tests read via
-  `app-schema-meta-at`.
-
-  Per rf2-52dfy the `:frame` value is coerced through `coerce-opts`,
-  the SAME contract the read surface (`app-schema-at` /
-  `app-schema-meta-at` / `app-schemas`) uses for a frame TARGET: a frame-id
-  keyword or a frame value names the registration frame, and a malformed
-  target throws `:rf.error/app-schemas-bad-arg`.
-
-  Per rf2-sk0ql the `path` must be a `get-in`/`assoc-in`-shaped path: a
-  SEQUENTIAL collection of keys, or the empty vector `[]` for the whole-
-  `app-db` root (Spec 010 §`app-db` schemas — path-based / §A schema for
-  the whole `app-db`). A non-sequential scalar (a bare keyword, string,
-  number, nil) throws `:rf.error/app-schema-bad-path` at registration —
-  BEFORE the store mutation — so it can never land. Previously such a
-  shape registered fine but made `validate-app-schema!`'s `(get-in db
-  path)` throw, which the router silently swallowed as a validation pass,
-  installing an invalid commit with no failure trace and no rollback and
-  poisoning every subsequent commit's validation for the frame."
+  Registration is frame-scoped. The `:frame` metadata value may be a frame-id
+  keyword or frame value; without it the carried frame scope is required.
+  The path must be a sequential collection of concrete path segments, with
+  `[]` naming the whole app-db root. Path and frame validation happen before
+  the registry mutation. Returns the canonical vector path."
   ([path schema] (reg-app-schema path nil schema))
   ([path metadata schema]
   (let [metadata (normalize-app-schema-metadata path metadata)
-        ;; The frame TARGET (if any) rides under `:frame` in the metadata map.
-        ;; rf2-5429ec — it is a frame TARGET, NOT the whole opts arg, so lift it
-        ;; back into the `{:frame target}` opts shape `resolve-frame` consumes
-        ;; (via `frame-target->opts`). This makes the singular registration path
-        ;; resolve a target IDENTICALLY to the read surface: a keyword / frame
-        ;; value resolves to its frame id; a non-keyword target (a string, a
-        ;; vector, or a NON-frame MAP like `{:not :a-frame}`) FAILS LOUD with
-        ;; `:rf.error/app-schemas-bad-arg` rather than (the old bug) being read
-        ;; as a key-less opts map and silently borrowing the ambient frame.
+        ;; Metadata carries a frame target, not the whole opts map.
         frame-opts (frame-target->opts (:frame metadata))]
-   ;; Per rf2-sk0ql — reject a malformed `path` shape BEFORE the store
-   ;; mutation. A non-sequential scalar (bare keyword / string / number /
-   ;; nil) would register fine but make `validate-app-schema!`'s
-   ;; `(get-in db path)` throw, which the router silently swallows as a
-   ;; validation pass (a correctness- + privacy-relevant bypass). Always-on
-   ;; — a malformed registration is a programming error in every build.
-   ;; Per rf2-k0ew8n — the SAME gate also hard-rejects a runtime-db path
-   ;; (`:rf.runtime/*` / legacy `:rf/runtime` first segment) with the
-   ;; distinct `:rf.error/app-schema-runtime-path`. The frame is resolved
-   ;; best-effort for the payload so a missing scope cannot mask it.
+   ;; Reject malformed and runtime-db paths before the store mutation. Frame
+   ;; context is best-effort here so a missing scope cannot mask a path error.
    (assert-app-schema-path! path (best-effort-frame frame-opts))
    (let [frame-id     (resolve-frame frame-opts)
-         ;; EP-0012 §Path shape (rf2-94o54l.2 + rf2-ujmc3u): a
-         ;; `reg-app-schema` path is accepted as any sequential collection
-         ;; but NORMALIZED to its canonical vector form before it becomes
-         ;; the stored key / digest path key, so a list path `(list :a :b)`
-         ;; and the equivalent vector `[:a :b]` are ONE identity — the
-         ;; side-table key, the `schema-meta` `:path`, the prior-schema
-         ;; lookup, and the digest line all derive from the same canonical
-         ;; vector. `normalize-concrete` (not bare `normalize`) routes the
-         ;; path through the SHARED concrete-segment boundary so a schema
-         ;; path is a full `:rf/path` citizen — composite / function / host
-         ;; / float / unsafe-integer segments fail closed rather than riding
-         ;; into a stored declaration and digest key. The up-front
-         ;; `assert-app-schema-path!` already validated the same segment
-         ;; domain (and the runtime-db first-segment category); this is the
-         ;; canonical-vector producer + a defense-in-depth re-check.
+         ;; Storage, lookup, and digesting share one canonical vector identity.
          path         (path/normalize-concrete path)
-         ;; The per-frame schema-metadata map (the {path → schema-meta}
-         ;; entry value) — `:schema` + `:path` + `:frame` + source-coords.
-         ;; Named `schema-meta` to match the slice vocabulary
-         ;; (`frame-schema-entries`, `app-schema-meta-at`, the
-         ;; `validate-app-schema!` destructure) and to avoid shadowing
-         ;; `clojure.core/meta`.
-         ;; rf2-qm7k83 Part A — the stored schema-meta IS the author's optional
-         ;; RegistrationMetadata map (`:doc`, `:tags`, `:platforms`, … and any
-         ;; open `:my/*` extension keys) with the runtime-stamped `:schema`
-         ;; (from the positional value slot) / `:path` / `:frame` overlaid.
-         ;; rf2-5429ec (Evidence 2) — previously only `:doc` + `:tags` were
-         ;; copied through, silently DROPPING every other RegistrationMetadata
-         ;; key (`:platforms`, …) AND any additive / open metadata key, which
-         ;; contradicts Spec-Schemas §`AppSchemaMeta` (`[:merge
-         ;; RegistrationMetadata [:map :path :schema :frame]]`) and spec/API.md
-         ;; §`app-schema-meta-at` ("returns :path, :schema, :frame, source
-         ;; coords, and the rest of :rf/registration-metadata"). Start from the
-         ;; metadata map minus the two slots whose stored value is the RESOLVED
-         ;; form (`:schema` = the positional schema arg; `:frame` = the resolved
-         ;; frame-id, not the original frame TARGET), then overlay the resolved
-         ;; `:schema` / `:path` / `:frame`. Open-map / future-additive keys ride
-         ;; through. Source-coords merge per the production-elision contract.
+         ;; Preserve open registration metadata, but stamp the positional
+         ;; schema and resolved path/frame over caller-supplied values.
          schema-meta  (source-coords/merge-coords
                         (assoc (dissoc metadata :schema :frame)
                                :schema schema :path path :frame frame-id))
-         ;; Capture the path's prior schema BEFORE the swap so the
-         ;; hot-reload `:rf.schema/violation` check (rf2-ee38b.6) can
-         ;; compare pre- vs post-reload shapes. nil on first registration.
-         ;;
-         ;; EP-0015 §8 (rf2-d2r3um): the side-table write is a bare atomic
-         ;; `swap!` — no per-frame linearization lock and no schema→elision
-         ;; population. Schemas no longer feed the app-db egress registry
-         ;; (frame policy owns it), so the two-step off-box-redaction-loss
-         ;; race the lock guarded (rf2-naihn1) no longer exists.
+         ;; Capture before replacement for the dev-only hot-reload check.
          prior-schema (get-in @schemas-by-frame [frame-id path :schema])]
      (swap! schemas-by-frame assoc-in [frame-id path] schema-meta)
-     ;; Per rf2-fq7d2: dev-time nudge when `:schemas/malli-validate` is
-     ;; unbound AND the framework-default validator is still installed —
-     ;; the default soft-passes per Spec 010 §Recommended soft-pass, so a
-     ;; reg-app-schema with no validator wired up validates nothing. Note
-     ;; that post-rf2-v96fh the facade auto-requires the Malli adapter, so
-     ;; this only fires for a substitute-validator port or a test that
-     ;; unbinds the hook (see the warning block above). Production elides
-     ;; via the outer `interop/debug-enabled?` gate (Spec 009 §Production
-     ;; builds). Read-only dev side effects (warnings + a violation trace).
+     ;; Read-only diagnostics are absent from production builds.
      (when interop/debug-enabled?
        (maybe-warn-validator-unavailable!)
-       ;; Per rf2-jsokn: dev-time nudge when the registered schema is
-       ;; an opaque non-vector, non-keyword form (compiled m/schema
-       ;; object, etc.) — the schema walker can only introspect vector
-       ;; Malli EDN, so a per-slot `:sensitive?` flag inside an opaque
-       ;; value is silently skipped by the schema-validation-failure
-       ;; redactor (EP-0015 §8: `:large?` / `:sensitive?` no longer feed
-       ;; the app-db egress registry, but `:sensitive?` still drives
-       ;; validation-failure-trace redaction). Production elides via the
-       ;; outer `interop/debug-enabled?` gate.
        (maybe-warn-walker-opaque! schema path)
-       ;; Per rf2-ee38b.6 / Spec 010 §Schema migration on hot-reload:
-       ;; emit `:rf.schema/violation` when a re-registration changes the
-       ;; schema and the live app-db value at `path` fails the new shape.
-       ;; O(1) — reads the prior schema (captured above) + one validation
-       ;; of the live value at this path.
        (maybe-emit-schema-violation! frame-id path prior-schema schema))
      path))))
 
 (defn reg-app-schemas
   "Bulk-register a map of `{path -> schema}` against the active frame
-  (or the frame named in `opts`). Per rf2-jzs9 — the plural form of
-  `reg-app-schema`, designed for feature-modular apps (per Conventions
+  (or the frame named in `opts`). Designed for feature-modular apps (per Conventions
   §Feature-modularity prefix convention) where a single feature module
   registers 5–20 schemas under a common path prefix like `[:cart …]` or
   `[:auth …]`.
@@ -927,8 +581,7 @@
 
     (rf/reg-app-schemas {[:foo] FooSchema} {:frame :tenant/a})
 
-  Per Spec 010 §Per-frame schemas registration is frame-scoped; EP-0002 —
-  context-required frame-local: the `:frame` opt (the *override*) names
+  The `:frame` opt names
   the frame for every entry in the map (you cannot mix frames in a single
   call), else the carried-invariant scope chain resolves it. Registering
   under no scope and no explicit `:frame` raises
@@ -938,58 +591,16 @@
   internally for each entry — every entry stamps its own per-frame side-
   table entry with source-coords captured from this call site.
 
-  Returns the vector of paths registered, in iteration order. Last-
-  write-wins on duplicate paths inside the same map (map iteration
-  order in Clojure is small-map literal-order, large-map hash order;
-  callers that rely on deterministic order should use a singular
-  `reg-app-schema` chain instead)."
+  Returns the vector of canonical paths registered, in map iteration order."
   ([path->schema] (reg-app-schemas path->schema {}))
   ([path->schema opts-or-frame-id]
-   ;; EP-0015 §8 (rf2-d2r3um): schemas no longer feed the app-db egress
-   ;; registry, so there is no per-entry elision repopulation to defer and
-   ;; no O(n²) bulk-registration hazard (the rf2-ee38b.6 / rf2-utdxg perf
-   ;; machinery is gone). Each delegated `reg-app-schema` does only its own
-   ;; atomic side-table `swap!` and its O(1) dev-side checks.
-   ;;
-   ;; Per rf2-52dfy — `opts` is coerced through the same `coerce-opts`
-   ;; contract the read surface uses (bare keyword → `{:frame kw}`
-   ;; sugar; bad shape → `:rf.error/app-schemas-bad-arg`). Write/read
-   ;; agree; the singular `reg-app-schema` call re-coerces the
-   ;; already-coerced map (idempotent — a map passes through verbatim).
-   ;; Per rf2-naihn1 — reject a nil / non-map first argument BEFORE any
-   ;; mutation (and before the path sweep, which `(keys nil)` would
-   ;; silently no-op through). `(reg-app-schemas nil)` previously
-   ;; registered nothing and returned `[]` — indistinguishable from the
-   ;; `{}` no-op — so a schema-loader bug passing nil got a false green
-   ;; with schema enforcement silently disabled. `{}` stays the
-   ;; documented empty no-op.
+   ;; Reject a malformed batch before path iteration can silently no-op.
    (assert-bulk-schemas-arg! path->schema)
-   ;; Per rf2-sk0ql — validate EVERY path shape up front, before any
-   ;; store mutation, so a single malformed key cannot half-register the
-   ;; batch (the earlier-iterated entries would otherwise land before the
-   ;; bad key's delegated `reg-app-schema` throws). Reject the whole call
-   ;; atomically. (`reg-app-schema` re-asserts per entry — cheap and
-   ;; idempotent — but this up-front sweep is what guarantees the
-   ;; all-or-nothing contract.) Per rf2-k0ew8n the same sweep also rejects
-   ;; a runtime-db path key (`:rf.error/app-schema-runtime-path`) before
-   ;; any mutation, so a batch with one runtime path lands NOTHING.
+   ;; Validate every path before mutating so an invalid entry cannot leave a
+   ;; partially registered batch.
    (let [batch-frame (best-effort-frame opts-or-frame-id)]
      (run! #(assert-app-schema-path! % batch-frame) (keys path->schema)))
-   ;; EP-0015 §8 (rf2-d2r3um): no per-frame registration lock and no
-   ;; deferred elision repopulation. Schemas no longer feed the app-db
-   ;; egress registry (frame policy owns it), so each delegated
-   ;; `reg-app-schema` is just its own atomic side-table `swap!` plus its
-   ;; O(1) dev-side checks (validator nudge, walker-opaque nudge, hot-reload
-   ;; `:rf.schema/violation`). The opts pass through unchanged.
-   ;; rf2-qm7k83 Part A — the singular `reg-app-schema` takes the schema in the
-   ;; positional value slot (2-slot `(path schema)` / 3-slot `(path metadata
-   ;; schema)`). The bulk plural keeps its natural `{path -> schema}` shape (the
-   ;; map value IS the schema); each entry is delegated positionally — the
-   ;; shared `:frame` (when present) rides the 3-slot metadata map, else the
-   ;; 2-slot form. `opts-or-frame-id` is coerced through the SAME `coerce-opts`
-   ;; contract the read surface uses (bare keyword / frame value / `{:frame …}`
-   ;; opts map all normalise to `{:frame <target>}`), so the per-entry `:frame`
-   ;; is the resolved target regardless of which opts shape the caller passed.
+   ;; Delegate each map value through the singular positional schema slot.
    (let [frame-target (:frame (coerce-opts opts-or-frame-id))]
      (mapv (fn [[path schema]]
              (if (some? frame-target)
@@ -1008,13 +619,7 @@
   Per Spec 010 §Schemas as a tooling and agent surface."
   ([path] (app-schema-at path {}))
   ([path opts-or-frame-id]
-   ;; EP-0012 §Path shape (rf2-94o54l.2 + rf2-ujmc3u): normalize the lookup
-   ;; path to its canonical vector THROUGH the shared concrete-segment
-   ;; boundary so a `(list :a :b)` read finds the entry stored under the
-   ;; equivalent `[:a :b]` key (registration normalizes the same way) —
-   ;; storage and lookup AGREE on one canonical-vector identity — and a
-   ;; bad-segment lookup (composite / host / float / unsafe-integer) fails
-   ;; closed loudly rather than silently missing.
+   ;; Lookup uses the same canonical concrete path identity as registration.
    (let [frame-id (coerce->frame-id opts-or-frame-id)
          path     (path/normalize-concrete path)]
      (when-let [m (get-in @schemas-by-frame [frame-id path])]
@@ -1029,8 +634,8 @@
   `:frame`. Used by pair-tools, 10x panels, and source-coord tests that
   need to introspect where a schema was registered.
 
-  Per rf2-0frdi / rf2-cq1ak this is the canonical read surface for
-  app-db schema metadata — app-db schemas are NOT a registrar kind;
+  This is the canonical read surface for app-db schema metadata. App-db
+  schemas are not a registrar kind;
   the per-frame side-table is the single source of truth.
 
   Arities:
@@ -1039,10 +644,7 @@
                                       ;; (keyword sugar also accepted)"
   ([path] (app-schema-meta-at path {}))
   ([path opts-or-frame-id]
-   ;; EP-0012 §Path shape (rf2-94o54l.2 + rf2-ujmc3u): normalize the lookup
-   ;; path THROUGH the shared concrete-segment boundary so a non-vector seq
-   ;; read resolves to the canonically-stored vector entry (registration
-   ;; normalizes the key the same way) and a bad-segment lookup fails closed.
+   ;; Lookup uses the same canonical concrete path identity as registration.
    (let [frame-id (coerce->frame-id opts-or-frame-id)
          path     (path/normalize-concrete path)]
      (get-in @schemas-by-frame [frame-id path]))))
@@ -1078,22 +680,20 @@
 
 ;; ---- hot-reload semantics ------------------------------------------------
 ;;
-;; Per rf2-0frdi the schemas artefact no longer participates in the
-;; registrar's replacement-hook stream — `reg-app-schema` writes only to
-;; `schemas-by-frame`. Re-registering a `(frame-id, path)` entry is an
+;; `reg-app-schema` writes only to `schemas-by-frame`. Re-registering a
+;; `(frame-id, path)` entry is an
 ;; ordinary `swap!`: the new meta replaces the prior entry atomically, and
 ;; the validation hot path (`frame-schema-entries`) picks up the new
 ;; schema on its next read. The per-frame map IS the validation cache.
 ;;
-;; One dev-only side effect accompanies a re-registration (rf2-ee38b.6):
+;; One dev-only side effect accompanies a re-registration:
 ;;   `:rf.schema/violation` — emitted when the schema CHANGED and the live
 ;;   `app-db` value at the path fails the new shape (Spec 010 §Schema
 ;;   migration on hot-reload). See `maybe-emit-schema-violation!`. Gated on
 ;;   `interop/debug-enabled?` and DCE'd in production.
 ;;
-;; EP-0015 §8 (rf2-d2r3um): a re-registration no longer refreshes any
-;; schema-derived app-db elision declarations — schemas do not feed the
-;; app-db egress registry; durable app-db classification is frame-owned.
+;; Re-registration does not refresh durable app-db classification; schemas
+;; do not own that registry.
 
 ;; ---- test-support snapshot / restore -------------------------------------
 ;;
@@ -1116,10 +716,8 @@
 (defn clear-schemas-by-frame!
   "Reset the per-frame schema registry to `{}`. Used by test fixtures
   and by `make-reset-runtime-fixture`'s `:clear-app-schemas? true`
-  path (rf2-cq1ak). The per-frame registry is the schemas artefact's
-  only mutable registration state — there is no companion side-table to
-  clear (the registration linearization lock was removed with the
-  schema→elision population, EP-0015 §8, rf2-d2r3um)."
+  path. The per-frame registry is the artefact's only mutable registration
+  state."
   []
   (reset! schemas-by-frame {}))
 
@@ -1131,11 +729,8 @@
   (mirrors the `:machines/on-frame-destroyed!` /
   `:ssr/on-frame-destroyed` cleanup contract).
 
-  Without this cleanup, schemas registered against a destroyed
-  frame would persist and re-fire when the frame is re-registered
-  — under the rf2-wkxng / rf2-6m0se rollback contract that
-  manifests as spurious rollbacks against orphan paths the new
-  frame's :initial-events never wrote. Idempotent — a missing frame
-  entry is a no-op `dissoc`."
+  Without this cleanup, reusing a frame id would revive schemas from the
+  destroyed frame and could cause rollback against orphan paths. Idempotent:
+  a missing frame entry is a no-op `dissoc`."
   [frame-id]
   (swap! schemas-by-frame dissoc frame-id))

--- a/implementation/schemas/src/re_frame/schemas/validate.cljc
+++ b/implementation/schemas/src/re_frame/schemas/validate.cljc
@@ -1,5 +1,5 @@
 (ns re-frame.schemas.validate
-  "Validation entry points (Spec 010 §Validation order steps 1-6).
+  "Validation entry points and failure-trace projection (Spec 010).
 
   Owns the four dev-time validate-*! fns the framework calls at the
   locked validation sites:
@@ -9,33 +9,13 @@
     - validate-app-schema!   — post-handler-commit (frame's app-schemas)
     - validate-sub!          — post-sub-recompute (return value vs sub :schema)
 
-  The metadata key is `:schema` (canonical per rf2-ieu0i).
+  Event, effect, and subscription validation share `run-validation`.
+  App-db validation iterates every schema registered for a frame and keeps
+  per-entry verdicts isolated. Recordable cofx validation belongs to
+  `re-frame.cofx` because it is an always-on production contract.
 
-  Per rf2-s2jgz (audit-of-audits #20) the family is named on the
-  kind axis — validate-event!, validate-fx!,
-  validate-sub! and validate-app-schema!. The earlier
-  validate-app-db! / validate-sub-return! names were renamed for
-  symmetry with their siblings. The cofx surface used to live here
-  too (validate-cofx!) but was retired per rf2-nkf4l3 — EP-0017 made
-  the live cofx schema check the recordable-value contract in
-  `re-frame.cofx/validate-recordable-value!` (a production hard error
-  emitting `:rf.error/cofx-value-invalid`), not a dev-only
-  `:rf.error/schema-validation-failure :where :cofx` trace.
-
-  Also owns the production-side boundary-validation seam
-  (`validate-with-registered-fn` / `explain-with-registered-fn`) that
-  the boundary-validation interceptor (`re-frame.spec`, rf2-r2uh)
-  reaches via the schemas-side late-bind hook.
-
-  Per rf2-s7s6j the three meta-bearing validate-*! fns (event /
-  fx / sub) share a single core via the private
-  `run-validation` primitive — each public fn is a thin wrapper that
-  contributes only its registration-meta source, its checked value,
-  its sensitivity-source check, its tag shape (`:where`,
-  `:reason`, etc.), and any fx-specific post-redaction step.
-  `validate-app-schema!` stays a sibling of the four; it walks N schemas
-  via doseq (no single :schema lookup, no true/false return contract)
-  and so doesn't share the wrapper's shape.
+  This namespace also owns the production boundary seams reached through
+  late binding by `re-frame.spec`.
 
   Per Spec 009 §Production builds every dev-time validate-*! body lives
   inside an `(if interop/debug-enabled? ...)` gate as the OUTERMOST
@@ -46,22 +26,17 @@
   the primitive itself, along with every literal reason string passed
   through it.
 
-  Per Spec 010 §Non-Malli validators the validator/explainer
-  are pluggable via the registered atoms in `re-frame.schemas.validator`;
-  when none is registered every fn here returns true (pass) without
-  inspecting the schema.
+  Validator and explainer functions are pluggable. An absent validator means
+  pass without inspection; an absent explainer means no diagnostic value.
 
   Per Spec 010 §`:sensitive?` — privacy in schema-validation error
   traces. The emit-sites redact the failing value before
   stamping a trace event when the schema slot at the failing path
   (or a containing slot) carries `:sensitive? true` in its Malli
-  props. Sensitivity is path-marked at the schema slot only — the
-  removed handler-meta `:sensitive?` registration-metadata fallback
-  no longer applies (see the NOTE below).
+  props. Sensitivity is path-marked at the schema slot.
   The substitution sentinel is `:rf/redacted` (the framework-reserved
   keyword per Spec 009 §Privacy). The trace event's `:tags`
-  map is stamped with `:sensitive? true` so consumers can route on it
-  (until rf2-isdwf's top-level hoisting lands in core).
+  map is stamped with `:sensitive? true` so consumers can route on it.
 
   The value-bearing slots are redacted (`:value`, `:received`,
   `:explain`, `:explain-humanized`, plus `:rf.fx/args` on
@@ -69,42 +44,34 @@
   `:where :sub-return` emissions — see `redact-tags`); the structural /
   categorical slots (`:path`, `:failing-id`, `:schema-id`, `:reason`)
   are kept — consumers need them to locate the broken slot without
-  leaking user data. Per rf2-qhq3f `:explain-humanized` (the
+  leaking user data. `:explain-humanized` (the
   operator-readable decomposition of the explainer's output) is
   value-bearing too — it carries the failing value verbatim under
   Malli's path-shaped humanize output — so it redacts symmetrically
   with `:explain` (present as the `:rf/redacted` sentinel on sensitive
   failures, not omitted).
 
-  Per rf2-ss06u.1 / rf2-612mri the `:path` tag's normally-structural
-  segments have several value-bearing carve-outs that
+  A `:path` tag's normally structural segments have several value-bearing
+  cases that
   `walker/sanitize-sensitive-path` scrubs to `:rf/redacted` on a sensitive
   failure (the same scrubbed path also feeds `:reason`, so neither slot
   leaks): a `:set` failure's segment is the failing ELEMENT VALUE itself
   (Malli has no positional index for a set); a `:map-of` key whose KEY
   SCHEMA declares `:sensitive?` is the secret used AS the key
-  (rf2-612mri); and any scalar in the FAIL-CLOSED tail past an ambiguous
-  wrapper (`:orn` / `:multi`) cannot be proven a locator and may be a
-  value-bearing `:set` scalar element (rf2-612mri). Navigable `:vector` /
+  and any scalar in the fail-closed tail past an ambiguous wrapper
+  (`:orn` / `:multi`) cannot be proven a locator and may be a value-bearing
+  `:set` scalar element. Navigable `:vector` /
   `:tuple` / `:map` segments and NON-sensitive `:map-of` keys stay intact
   so `:path` remains a `get-in` locator for those shapes.
 
-  Per rf2-ss06u.3 a structurally MALFORMED registered schema (childless
+  A structurally malformed registered schema (childless
   `[:vector]`, unknown op) makes the registered validator THROW at
   validate-time (Malli validates schema forms lazily). `validate-app-schema!`
   isolates that throw PER-ENTRY, emits the distinct
   `:rf.error/malformed-schema` category, fails CLOSED (in-band `false` →
   the router rolls back; it does NOT install the unvalidated commit), and
-  keeps validating the frame's sibling schemas — so one bad schema can
-  never masquerade as a clean validate (the prior router `(catch … true)`
-  swallow) nor disable post-commit validation frame-wide.
-
-  Per rf2-4fbsd the emit-sites carry two slots for the failing value
-  (`:value` and `:received`, per Spec 010 §`:sensitive?`) and one slot
-  for the registered explainer's output (`:explain`). The earlier
-  `:event` (duplicate of `:received`) and `:malli-error` (duplicate of
-  `:explain`) tags have been dropped — consumers reach for `:received`
-  / `:value` / `:explain`."
+  keeps validating the frame's sibling schemas so one bad registration
+  cannot disable frame-wide post-commit validation."
   (:require [re-frame.elision :as elision]
             [re-frame.error :as error]
             [re-frame.frame :as frame]
@@ -118,17 +85,8 @@
 
 #?(:clj (set! *warn-on-reflection* true))
 
-;; The `:rf/redacted` privacy sentinel emitted by validation traces for
-;; slots matching the `:sensitive?` predicate. Per Spec 009 §Privacy —
-;; the framework-reserved keyword that cannot collide with an app-defined
-;; value. rf2-qe237 — refer to the canonical core def rather than a local
-;; copy so the keyword can never drift across artefacts.
+;; Canonical privacy sentinel for value-bearing trace slots.
 (def ^:private redacted-sentinel privacy/redacted-sentinel)
-
-;; NOTE: the handler-meta `:sensitive?` annotation has been removed.
-;; Sensitivity is now path-marked at the schema slot — `walk-schema?`
-;; consults `walker/schema-has-sensitive?` to drive the failure-trace
-;; redaction.
 
 ;; The canonical value-bearing tag slots — the ones that carry the failing
 ;; value (or a value-bearing lookup key) verbatim and so must be scrubbed
@@ -136,8 +94,7 @@
 ;; `:rf.error/malformed-schema` trace (where the validator never proved
 ;; sensitivity, so we cannot redact path-targeted — omitting the value is
 ;; fail-closed, mirroring `validate-app-schema!`'s malformed-schema emit).
-;; Per Spec 010 §`:sensitive?` redaction-shape list (rf2-nijom / rf2-adtp2
-;; / rf2-qhq3f). Three are per-surface conditional names carried only on a
+;; Three are per-surface conditional names carried only on a
 ;; subset of emit-sites (`:rf.fx/args` on `:where :fx-args`;
 ;; `:rf.sub/query-v` on `:where :sub-return`; `:explain-humanized` only when
 ;; the humanize hook is installed); `contains?` guards keep the clauses
@@ -145,7 +102,7 @@
 (def ^:private value-bearing-slots
   [:value :received :explain :explain-humanized :rf.fx/args :rf.sub/query-v])
 
-;; ---- :large? size-elision of validation-failure value slots (rf2-vmhu4i) --
+;; ---- :large? size-elision of validation-failure value slots ---------------
 ;;
 ;; A `:large?`-flagged slot inside the checked value ships the whole blob into
 ;; the validation-failure trace's value-bearing slots unless the emit-site
@@ -155,28 +112,17 @@
 ;; schema declares any `:large?` slot and NO `:sensitive?` slot governs the
 ;; redaction — a sensitive failure already scrubs to `:rf/redacted`, and a
 ;; sensitive marker would itself leak the secret's `:path` / `:bytes` size
-;; signature. The marker is built by the canonical `re-frame.elision/->marker`
-;; (core, NOT the `marks` ns) so the shape physically cannot drift from the
-;; `:rf/elision-marker` contract again (rf2-9wvwpa). `re-frame.elision` lives in
-;; core — the artefact the schemas surface already depends on (cf.
-;; `re-frame.frame` above) — and carries no concrete substrate-adapter
-;; dependency (it `:require`s only the `re-frame.substrate.adapter` *contract*
-;; ns, a sibling of `re-frame.frame`).
+;; signature. The canonical `re-frame.elision/->marker` owns the wire shape.
 
 (defn- large-marker
   "Build the `:rf.size/large-elided` marker for the whole failing value `v`.
   Conforms to Spec-Schemas §`:rf/elision-marker` / Spec 009 §Wire marker by
   delegating to the canonical `re-frame.elision/->marker` — the marker shape
   (`:path`, `:bytes`, `:type`, `:reason`, `:hint`, `:handle`) is therefore
-  identical to every other framework emission and cannot drift (rf2-9wvwpa).
+  identical to every other framework emission.
 
-  `:reason :effect` — EP-0025 removed the durable `:sensitive` / `:large`
-  *frame annotation* (and the imperative marks API); the canonical
-  declarative classification provenance is now `:effect` (the commit-plane
-  classification effects), the default in `->marker`. The validation-failure
-  provenance is already on the enclosing trace envelope (`:operation
-  :rf.error/schema-validation-failure` + `:where` + `:tags :large? true`), so
-  the marker carries no `:reason :schema` carve-out — it rides the default.
+  `:reason :effect` is the canonical classification provenance. The enclosing
+  trace already identifies the validation-failure source.
 
   `:hint nil` — the slot is REQUIRED by the contract (Spec 009 §Wire marker
   permits a nil value); the whole-value substitution has no human-facing
@@ -192,7 +138,7 @@
   "Substitute the `:rf.size/large-elided` marker (for `v`, the whole checked
   value) into each `value-bearing-slots` entry present in `tags`, and stamp
   `:large? true`. `contains?`-guarded so a slot a surface doesn't carry is a
-  no-op. Per Spec 010 §`:large?` validation size-safety arm (rf2-vmhu4i).
+  no-op. Per Spec 010 §`:large?` validation size-safety arm.
 
   Called ONLY on the non-sensitive branch (sensitive wins — see
   `redact-tags` / `redact-tags-per-slot`): a slot already scrubbed to
@@ -206,40 +152,11 @@
                 value-bearing-slots)
         (assoc :large? true))))
 
-;; ---- PER-SLOT DECISION SCOPING (rf2-3qam7b / the rf2-me69cb principle) ----
-;;
-;; THE PRINCIPLE: the SCOPE of a slot's `:sensitive?` redaction decision MUST
-;; MATCH the SCOPE of the value that slot actually carries.
-;;
-;;   - A slot that carries a LEAF-NARROWED value (only the failing leaf — e.g.
-;;     `:value` on the app-db path, which is `(get-in reg-slice in-path)`) may
-;;     use the LEAF-PRECISE check `walker/schema-sensitive-at?`: a sensitive
-;;     SIBLING of the failing leaf is genuinely not present in the carried
-;;     value, so it must not force redaction (the rf2-oh4se / rf2-k0ew8n
-;;     precise-narrowing win).
-;;
-;;   - A slot that carries the WHOLE PAYLOAD verbatim (`:explain` /
-;;     `:explain-humanized` / `:received` / `:rf.fx/args` / `:rf.sub/query-v`,
-;;     and `:value` on every surface EXCEPT the app-db leaf) MUST use the
-;;     ROOT / whole-schema check `walker/schema-has-sensitive?`. The whole
-;;     payload carries every CONFORMING sibling too, so a conforming
-;;     `:sensitive?` sibling (e.g. a valid `:jwt` next to a failing `:name`)
-;;     rides INSIDE that slot — a leaf-precise decision keyed on the failing
-;;     `:name` would (wrongly) clear it and the jwt would egress to Xray /
-;;     pair-MCP unredacted. This was the rf2-3qam7b leak: a leaf-precise
-;;     decision was gating whole-payload slots (sibling-blind).
-;;
-;; `schema-sensitive-at?` is a SUBSET of `schema-has-sensitive?` — a sensitive
-;; leaf ancestor/descendant implies the schema declares something sensitive —
-;; so the whole-payload decision (`schema-has-sensitive?`) also governs the
-;; `:sensitive?` top-level stamp (a redaction of ANY value-bearing slot stamps
-;; the trace so Xray routing + the MCP egress gate see it).
-;;
-;; The app-db path is the ONLY surface that narrows a slot (`:value` to the
-;; failing leaf); every meta-bearing surface (event / fx / sub) carries
-;; the WHOLE checked value in EVERY value-bearing slot, so its whole decision
-;; is the root check. The off-namespace seam `redact-validation-tags` is
-;; already whole-only (the coarse root check; rf2-me69cb=(a)) and is unchanged.
+;; ---- per-slot decision scope ----------------------------------------------
+;; A redaction decision must match the value a tag carries. App-db `:value`
+;; is narrowed to the failing leaf and can use `schema-sensitive-at?`. Whole
+;; payload slots can still contain sensitive siblings, so they must use the
+;; broader `schema-has-sensitive?` decision.
 (def ^:private app-db-narrowed-slots
   "The value-bearing slots the app-db hot path NARROWS to the failing leaf
   (`:value` = `(get-in reg-slice in-path)`). These — and ONLY these — use the
@@ -266,7 +183,7 @@
   carrying the whole checked value, so it is the correct shape for the
   meta-bearing surfaces (event / fx / sub via `run-validation`, where
   no slot is leaf-narrowed) and for the off-namespace seam
-  `redact-validation-tags` (already coarse + root-checked, rf2-me69cb=(a)). The
+  `redact-validation-tags` (coarse and root-checked). The
   app-db hot path, which DOES narrow `:value` to the failing leaf, uses
   `redact-tags-per-slot` below to apply the leaf-precise decision to that one
   slot while keeping the root decision on the whole-payload slots.
@@ -280,14 +197,14 @@
   installed); the `contains?` guards make those clauses no-ops on the surfaces
   whose tag maps don't carry the slot.
 
-  Per rf2-adtp2 / rf2-p2adl Q2 — `:rf.sub/query-v` (the caller-supplied
+  `:rf.sub/query-v` (the caller-supplied
   subscription query vector on `:where :sub-return` emissions) is the lookup
   key, not just an id, and on `:sensitive?`-marked subs typically carries the
   same secret material the registered schema is gating (user ids, auth tokens,
   document ids). Without redaction the failure trace re-leaks it alongside the
   failing return value the other clauses just scrubbed.
 
-  Per rf2-qhq3f — `:explain-humanized` (the operator-readable decomposition of
+  `:explain-humanized` (the operator-readable decomposition of
   the explainer's output, per Spec 010 §Humanize-hook) is itself value-bearing:
   Malli's `malli.error/humanize` carries the failing value verbatim under its
   path-shaped output. Spec 010 §Humanize-hook §Composition with `:sensitive?`
@@ -305,8 +222,7 @@
       (assoc :sensitive? true)))
 
 (defn- redact-tags-per-slot
-  "PER-SLOT DECISION SCOPING (rf2-3qam7b). Scrub value-bearing slots under TWO
-  decisions matched to the scope of the value each slot carries:
+  "Scrub value-bearing slots under two decisions matched to their value scope:
 
     - `whole-sensitive?`    the ROOT / whole-schema decision
                             (`walker/schema-has-sensitive?`) — governs every
@@ -319,9 +235,8 @@
 
   A WHOLE-PAYLOAD slot carries every conforming sibling, so a conforming
   `:sensitive?` sibling rides inside it; gating it on the leaf-precise decision
-  (sibling-blind) leaked the sibling (rf2-3qam7b). A leaf-narrowed slot carries
-  ONLY the failing leaf, so the leaf-precise decision is exact there — keeping
-  the rf2-oh4se no-sibling-taint precision for that one slot.
+  would leak the sibling. A leaf-narrowed slot carries only the failing leaf,
+  so the leaf-precise decision is exact there.
 
   Because `schema-sensitive-at?` ⊆ `schema-has-sensitive?` (a sensitive leaf
   ancestor/descendant implies the schema declares something sensitive),
@@ -351,8 +266,8 @@
       (persistent! acc))))
 
 (defn- failing-in-path
-  "Per rf2-oh4se — derive the failing leaf value-path from the registered
-  explainer's output. Returns a vector path (possibly empty when the
+  "Derive the failing leaf value path from the registered explainer's output.
+  Returns a vector path (possibly empty when the
   failure is at the schema root) or nil when the explanation carries
   no extractable `:in` path (e.g. non-Malli explainer, malformed
   output, or no explainer registered).
@@ -380,55 +295,23 @@
           (reduce common-prefix (first paths) (rest paths)))))))
 
 (defn- reason-string
-  "Build the human-readable `:reason` slot for a schema-validation
-  failure trace. Single template covering every emit-site:
-
-    - `subject`: subject phrase up to (but not including) the id —
-      \"Event \" / \"Coeffect \" / \"Subscription \" / \"Effect \" /
-      \"App-db at path \". Built per-call-site as a string literal
-      so the elision-probe grep (`scripts/check-elision.cjs`) can
-      pin a distinctive substring per surface.
-    - `id-or-path`: the id (event-id, sub-id, ...) or the app-db
-      path; rendered via `str` so keywords print with the colon.
-    - `slot-tail`: distinctive per-surface tail starting with
-      \" failed schema \" — e.g. \" payload failed schema \" /
-      \" injected value failed schema \" / \", failed schema \"
-      (app-db has no slot label so the tail starts with \" failed
-      schema \" directly). Pinned per-site so DCE analysis can see
-      the literal substring inside each gated branch — the
-      elision-probe asserts every surface's distinctive tail is
-      ABSENT under :advanced + goog.DEBUG=false.
-    - `schema`: the registered schema (Malli EDN form or other
-      validator's schema value); rendered via `pr-str` (no special-
-      casing of `[:int]` etc. — `pr-str` already reads fine).
-    - `value`: the value that failed.
-
-  Shape: \"<subject><id-or-path><slot-tail><pr-str schema>, got
-  <error/type-of-value>.\""
+  "Build the human-readable reason for a validation failure. Each caller
+  supplies a distinctive literal tail so the production-elision gate can
+  prove every dev-only surface absent from optimized bundles."
   [subject id-or-path slot-tail schema value]
   (str subject id-or-path slot-tail (pr-str schema)
        ", got " (error/type-of-value value) "."))
 
 (defn- humanize-explain
   "Compute the operator-readable `:explain-humanized` payload from a
-  RAW explainer output (per Spec 010 §Humanize-hook, rf2-2ek7t).
+  raw explainer output (per Spec 010 §Humanize-hook).
   Returns the humanized shape when the `:schemas/humanize-explain!`
   late-bind hook is installed and `explanation` is non-nil; nil
   otherwise (no hook installed — non-Malli validator / adapter ns not
   required — or the explainer produced nothing).
 
-  Per rf2-qhq3f this MUST be called on the explainer's output BEFORE
-  any privacy redaction is applied to the tag map. The earlier design
-  humanized inside the central emit seam, AFTER `redact-tags` had
-  already overwritten `:explain` with `:rf/redacted`; on a sensitive
-  failure the humanizer was then handed the sentinel keyword, returned
-  nil, and `:explain-humanized` was silently OMITTED — a shape drift
-  against Spec 010 §Humanize-hook §Composition with `:sensitive?`,
-  which requires the slot present and redacted to the sentinel
-  (symmetric with `:explain`). Computing here, from the raw
-  explanation, lets the emit-sites stamp the slot into base-tags so
-  the shared `redact-tags` cond-> scrubs it on sensitive surfaces and
-  leaves the real payload on non-sensitive ones.
+  Call this before privacy redaction so sensitive failures retain a present
+  but redacted `:explain-humanized` slot rather than losing the slot entirely.
 
   Failures inside the humanizer degrade silently (humanize is a
   cosmetic enrichment; a thrown humanizer can't suppress the
@@ -442,7 +325,7 @@
   "Single emit seam for `:rf.error/schema-validation-failure` traces.
   A thin wrapper over `trace/emit-error!` — the `:explain-humanized`
   augmentation now happens at the call-sites (via `humanize-explain`
-  folded into base-tags BEFORE redaction, per rf2-qhq3f) so the
+  folded into base-tags before redaction) so the
   privacy redaction in `redact-tags` can scrub the humanized slot
   symmetrically with `:explain`. Centralising the bare emit keeps the
   category keyword in one place; future cross-cutting tag shaping
@@ -451,19 +334,12 @@
   (trace/emit-error! :rf.error/schema-validation-failure tags))
 
 (defn- emit-malformed-schema!
-  "Single emit seam for `:rf.error/malformed-schema` traces (rf2-ss06u.3).
+  "Single emit seam for `:rf.error/malformed-schema` traces.
 
   A malformed REGISTERED schema (a childless `[:vector]`, an unknown op,
   etc.) registers without error — Malli validates schema FORMS lazily, at
-  validate-time — then makes the registered validator THROW on the first
-  post-commit validation. Before this fix the throw aborted the whole
-  `validate-app-schema!` loop and was swallowed by the router's defensive
-  `(catch ... true)` as a validation PASS: the offending commit installed
-  unvalidated with no trace and no rollback, AND every OTHER registered
-  schema for the frame went unvalidated for as long as the bad schema
-  stayed registered (the privacy-bearing redaction traces never fired
-  frame-wide). Same fail-open class as the rf2-sk0ql path bypass, via the
-  SCHEMA vector instead of the PATH vector.
+  validate-time. The throw must not escape to a caller's defensive pass or
+  abort validation of sibling registrations.
 
   This emit surfaces the structural error as its OWN distinct category so
   it can never masquerade as a clean validate. `:path` / `:registered-path`
@@ -475,34 +351,15 @@
   isolation closes (the validator never proved sensitivity, so we cannot
   redact path-targeted; omitting the value is fail-closed).
 
-  Per rf2-a5kzs the SAME emit now serves the three meta-bearing surfaces
-  (event / fx / sub) via `run-validation`: a malformed `:schema`
-  on a handler / fx / sub registration makes the validator throw
-  identically, and the runtime call-sites (`router` / `fx` /
-  `subs`) coerce that throw to a validation PASS via their defensive
-  `(catch … true)` — the same fail-open class. Those surfaces stamp the
-  structural slots they carry (`:where`, the surface id, `:frame`) plus
-  `:schema` / `:reason`, never a value-bearing slot."
+  The same emit serves event, effect, and subscription validation. Those
+  surfaces retain structural locator tags but never include a value-bearing
+  slot because the validator did not establish sensitivity."
   [tags]
   (trace/emit-error! :rf.error/malformed-schema tags))
 
 (defn- safe-explain
-  "Per rf2-a5kzs (finding 3) — invoke the registered explainer inside a
-  try/catch so a throwing custom explainer (or an explainer that itself
-  fails on a structurally degenerate schema) can never abort failure-trace
-  construction. A propagated explainer throw would unwind PAST the
-  legitimate `false` return, and the runtime call-sites
-  (`router` / `fx` / `subs`, and `validate-app-schema!`'s router
-  caller) coerce that throw to a validation PASS via their defensive
-  `(catch … true)` — turning a real validation FAILURE into a silent
-  catch-as-pass (for app-db: the swallowed-backstop returns true / no
-  rollback, so the invalid commit installs).
-
-  The explainer is diagnostic-only enrichment for the `:explain` slot;
-  its failure must NOT change the validation verdict. On a throw this
-  degrades to nil (the failure trace then omits / nil-fills `:explain`,
-  exactly as when no explainer is registered) and the caller continues
-  the original `false`."
+  "Invoke the diagnostic-only explainer without allowing it to change the
+  validation verdict. A throwing explainer degrades to nil."
   [schema value]
   (try
     (validator/run-explainer schema value)
@@ -510,18 +367,14 @@
 
 (defn- validate-entry-result
   "Run the registered validator for one `(schema, value)` entry, isolating
-  a malformed-schema throw (rf2-ss06u.3). Returns:
+  a malformed-schema throw. Returns:
     - `true`               — the value conformed.
     - `false`              — a legitimate validation failure.
     - `[:malformed ex]`    — the validator THREW (a malformed registered
                              schema: childless `[:vector]`, unknown op, …).
 
-  Per rf2-ss06u.3 the throw MUST be caught HERE (per-entry) rather than
-  propagate to the router's `(catch ... true)` — otherwise one malformed
-  schema aborts the whole frame's validation loop and is swallowed as a
-  silent commit-PASS. Catching per-entry lets the caller emit a distinct
-  `:rf.error/malformed-schema` trace, fail CLOSED (roll back — do not
-  install blind), AND continue validating the frame's sibling schemas."
+  Catching per entry lets callers emit `:rf.error/malformed-schema`, fail
+  closed, and continue validating sibling registrations."
   [vf schema value]
   (try
     (boolean (vf schema value))
@@ -540,14 +393,13 @@
                      fx) — its `:schema` slot, if any, is the schema.
     - `value`        the value being checked (event vector, sub
                      return value, fx args).
-    - `walk-schema?` boolean — when true AND the validator fails,
+    - `walk-schema?` boolean — when true and the validator fails,
                      consult the schema's per-slot `:sensitive?` walker
-                     before emitting. Per rf2-a5kzs (finding 1) all three
-                     meta-bearing surfaces now pass `true`: an event vector
+                     before emitting. An event vector
                      isn't itself `:map`-shaped but its `:cat`/`:catn` payload
                      commonly is (a login schema marks `:password` sensitive),
                      and fx / sub-return validate a map value directly.
-                     Per rf2-3qam7b the decision here is the WHOLE-schema
+                     The decision here is the whole-schema
                      `schema-has-sensitive?` (NOT the leaf-precise
                      `schema-sensitive-at?`): every value-bearing slot on these
                      surfaces carries the WHOLE checked value, so a conforming
@@ -558,14 +410,12 @@
                      the per-fn tag map (`:where`, `:reason`, etc.)
                      EXCLUDING any sensitivity stamping. Also the source
                      of the structural locator slots for the malformed-
-                     schema trace (rf2-a5kzs): called with a nil
+                     schema trace: called with a nil
                      explanation, then stripped of the value-bearing slots,
                      so the malformed-schema trace reuses the surface's own
                      `:where` / id / `:frame` shape without duplicating it.
 
-  Per rf2-a5kzs (findings 2 + 3) this primitive isolates BOTH failure
-  modes that previously fell open through the runtime call-sites'
-  defensive `(catch … true)`:
+  This primitive isolates two diagnostic failure modes:
 
     - A malformed registered `:schema` (childless `[:vector]`, unknown op)
       makes the validator THROW. Caught per-call via `validate-entry-result`;
@@ -582,18 +432,13 @@
   finds every call-site dead and DCEs this fn — along with every
   literal reason string and tag keyword passed through it.
 
-  Per rf2-1o6ax the registered validator-fn is deref'd ONCE at the
-  gate and invoked directly — `validator/run-validator` would deref
-  the same atom a second time on every pass, which is wasted work
-  on a path that runs per-event / per-fx / per-sub-return.
-
-  Per rf2-nijom this primitive no longer carries an `extra-redact`
-  escape hatch — the canonical redacted slots
+  The registered validator is dereferenced once at the gate. The canonical
+  redacted slots
   (`:value`, `:received`, `:explain`, `:explain-humanized`,
   `:rf.fx/args`, `:rf.sub/query-v`) all live on the central
   `redact-tags` cond->. The per-surface clauses are no-ops on the
   surfaces whose base-tags don't contain the slot, so a single
-  redactor covers every meta-bearing emit site. Per rf2-qhq3f the
+  redactor covers every meta-bearing emit site. The
   `:explain-humanized` slot is folded into base-tags here (from the
   RAW explanation via `humanize-explain`, before redaction) so the
   redactor scrubs it symmetrically with `:explain` on sensitive
@@ -602,8 +447,7 @@
   [reg-meta value walk-schema? build-base-tags]
   (if-let [vf @validator/validator-fn]
     (if-let [schema (:schema reg-meta)]
-      ;; Per rf2-a5kzs (finding 2) — isolate a malformed-schema throw HERE
-      ;; rather than let it propagate to the call-site `(catch … true)`.
+      ;; Isolate malformed schemas before a caller can treat a throw as pass.
       (let [result (validate-entry-result vf schema value)]
         (cond
           ;; Conformed.
@@ -632,7 +476,7 @@
                      :reason   (str "Registered schema " (pr-str schema)
                                     " is malformed and could not be "
                                     "evaluated: " reason)
-                     ;; Per rf2-mxs7a — preserve the surface-specific
+                     ;; Preserve the surface-specific
                      ;; recovery the caller's build-base-tags supplied
                      ;; (validate-fx! → :skipped, validate-sub! →
                      ;; :replaced-with-default; event →
@@ -649,11 +493,9 @@
 
           ;; Legitimate validation failure — the existing emit path.
           :else
-          (let [;; Per rf2-a5kzs (finding 3) — explainer through
-                ;; `safe-explain` so a throwing explainer can't unwind past
-                ;; this false and become a catch-as-pass at the call-site.
+          (let [;; A diagnostic explainer cannot change the false verdict.
                 explanation (safe-explain schema value)
-                ;; PER-SLOT DECISION SCOPING (rf2-3qam7b). The meta-bearing
+                ;; Meta-bearing
                 ;; surfaces (event / fx / sub) carry the WHOLE checked
                 ;; value in EVERY value-bearing slot — `:value` / `:received` /
                 ;; `:explain` / `:explain-humanized` / `:rf.fx/args` /
@@ -662,28 +504,24 @@
                 ;; failing leaf the way the app-db path narrows `:value`). So
                 ;; the redaction decision MUST be scoped to the WHOLE schema
                 ;; (`schema-has-sensitive?`), NOT the leaf-precise
-                ;; `schema-sensitive-at?`. A leaf-precise decision was the
-                ;; rf2-3qam7b leak: a failing NON-sensitive sibling (e.g.
+                ;; `schema-sensitive-at?`. A failing non-sensitive sibling (e.g.
                 ;; `:age`) cleared redaction while a CONFORMING sensitive
                 ;; sibling (e.g. `:password` / `:jwt`) rode unredacted inside
-                ;; every whole-payload slot, egressing to Xray + pair-MCP. The
-                ;; earlier rf2-k0ew8n / rf2-4q681i "don't over-redact a
-                ;; non-sensitive failing sibling" win does NOT apply here
-                ;; precisely because there is no narrowed slot to apply it to —
+                ;; every whole-payload slot. Leaf precision does not apply here
+                ;; because there is no narrowed slot:
                 ;; the whole payload carries the sibling. (It DOES still apply
                 ;; to the app-db `:value` slot, which is genuinely leaf-narrowed
                 ;; — see `validate-app-schema!`.) `walk-schema?` stays the knob
                 ;; for whether to consult the walker at all.
-                ;; Per rf2-u9bjgr — a COMPILED / OPAQUE schema (a non-vector,
+                ;; A compiled or opaque schema (a non-vector,
                 ;; non-keyword `m/schema` object) cannot be walked, so the
                 ;; per-slot `:sensitive?` flag Malli honoured for the failure
                 ;; is INVISIBLE to the walker. Fail CLOSED: redact as if
                 ;; sensitive. Otherwise an opaque schema carrying a
                 ;; `{:sensitive? true}` slot leaks the failing value verbatim
-                ;; while the equivalent vector form redacts (the bead's
-                ;; asymmetry). A bare keyword is provably flag-free, so it is
-                ;; NOT opaque here (`walker/schema-opaque?`). Per rf2-hi0tf8
-                ;; — `schema-opaque?` only classifies the ROOT form; a
+                ;; while the equivalent vector form redacts. A bare keyword is
+                ;; flag-free and not opaque. `schema-opaque?` only classifies
+                ;; the root form; a
                 ;; vector-form schema with a NESTED opaque child (e.g. a
                 ;; `:cat`/`:map` element that is itself a compiled `m/schema`
                 ;; value) is just as unintrospectable, so the whole-payload
@@ -691,7 +529,7 @@
                 sensitive?  (and walk-schema?
                                  (or (walker/schema-has-sensitive? schema)
                                      (walker/schema-has-opaque-child? schema)))
-                ;; Per rf2-vmhu4i — when the schema declares any `:large?`
+                ;; When the schema declares any `:large?`
                 ;; slot AND the failure is not sensitive (sensitive wins),
                 ;; elide the value-bearing slots to the `:rf.size/large-elided`
                 ;; marker. An opaque schema is already handled fail-closed
@@ -700,7 +538,7 @@
                 large?      (and walk-schema?
                                  (not sensitive?)
                                  (walker/schema-has-large? schema))
-                ;; Per rf2-qhq3f — humanize from the RAW explanation here,
+                ;; Humanize from the raw explanation here,
                 ;; before redaction, and fold the slot into base-tags so
                 ;; `redact-tags` scrubs it symmetrically with `:explain`
                 ;; on sensitive failures (sentinel present, not omitted).
@@ -724,8 +562,8 @@
   Per Spec 010 §Per-frame schemas only the named frame's schemas are
   walked — schemas registered against sibling frames are ignored.
 
-  Validation routes through the registered validator/explainer fns
-  (rf2-froe). When `set-schema-validator!` has been called with `nil`
+  Validation routes through the registered validator/explainer functions.
+  When `set-schema-validator!` has been called with `nil`
   this fn is a hard no-op for every schema in the frame.
 
   Arities:
@@ -741,9 +579,7 @@
              no schemas registered for the frame / debug elided).
     false  — at least one schema failed; a trace event was emitted
              for every failing entry. The router consumes this signal
-             to roll back the :db effect to the pre-handler value
-             (per Spec 010 §Per-step recovery row 4 / rf2-wkxng /
-             rf2-6m0se).
+              to roll back the :db effect to the pre-handler value.
 
   Structurally distinct from the three meta-bearing validate-*! fns
   (event / fx / sub): walks N schemas via doseq, has no
@@ -765,10 +601,7 @@
    ;; check is a runtime atom deref and must NOT be combined into the
    ;; gate predicate (the deref defeats Closure's reachability proof).
    ;;
-   ;; Per rf2-1o6ax the validator-fn is deref'd ONCE outside the doseq
-   ;; and invoked directly per entry; `validator/run-validator` would
-   ;; re-deref the atom on every iteration (2N derefs for N entries),
-   ;; which is wasted work on the post-handler-commit hot path.
+   ;; Dereference the validator once outside the per-schema loop.
    (if interop/debug-enabled?
      (if-let [vf @validator/validator-fn]
        ;; reduce + atomic short-circuit replaced doseq so we can emit
@@ -780,11 +613,8 @@
          (if-let [[reg-path schema-meta] (first entries)]
            (let [reg-slice (get-in db reg-path)
                  schema    (:schema schema-meta)
-                 ;; Per rf2-ss06u.3 — isolate a malformed-schema throw per
-                 ;; entry so it can never abort the loop (which would skip
-                 ;; every sibling schema) NOR propagate to the router's
-                 ;; `(catch ... true)` (which swallows a throw as a silent
-                 ;; validation PASS — installing an unvalidated commit).
+                  ;; A malformed schema cannot abort sibling validation or
+                  ;; escape to a caller that treats defensive throws as pass.
                  result    (validate-entry-result vf schema reg-slice)]
              (cond
                ;; Conformed — carry the running pass-state forward.
@@ -817,9 +647,6 @@
                ;; Legitimate validation failure — the existing emit path.
                :else
                (do
-                 ;; Per rf2-oh4se — make the failure path precise and
-                 ;; the sensitivity decision path-targeted.
-                 ;;
                  ;; The registered explainer is invoked exactly once
                  ;; on the failure branch; its output feeds BOTH the
                  ;; trace's `:explain` slot (verbatim) and the
@@ -832,17 +659,15 @@
                  ;; the leaf — the slot a consumer can `get-in`
                  ;; against on a NON-failed copy of app-db.
                  ;;
-                 ;; Conservative fallback: when no leaf path is
-                 ;; extractable (non-Malli explainer, missing
-                 ;; explanation), keep the old behaviour — emit the
+                 ;; Conservative fallback: when no leaf path is extractable
+                 ;; (non-Malli explainer or missing explanation), emit the
                  ;; registered root as `:path` and consult
                  ;; `schema-has-sensitive?` for the redaction decision.
                  ;; The `:registered-path` tag always carries the
                  ;; registration root so tooling can reach it
                  ;; regardless of whether path narrowing succeeded.
                  ;;
-                 ;; Per Spec 010 §`:sensitive?` — privacy in schema-
-                 ;; validation error traces (rf2-kj51z / rf2-3qam7b).
+                 ;; Per Spec 010 §`:sensitive?`, the redaction decision is
                  ;; The redaction decision is PER-SLOT-SCOPED (see the
                  ;; `let` below): the path-targeted check
                  ;; (`schema-sensitive-at?`) governs only the slots this
@@ -854,32 +679,22 @@
                  ;; counts). The WHOLE-PAYLOAD slots (`:explain` /
                  ;; `:explain-humanized`, which carry the whole reg-slice)
                  ;; stay under the coarse `schema-has-sensitive?` root
-                 ;; check, because a conforming sensitive sibling rides
-                 ;; inside them — gating them on the leaf decision was the
-                 ;; rf2-3qam7b leak.
+                 ;; check because a conforming sensitive sibling rides inside
+                 ;; them.
                  ;;
-                 ;; Per rf2-wkxng / rf2-6m0se the trace's tag carries
-                 ;; `:rollback? true` (consistent with depth-exceeded;
+                 ;; The trace carries `:rollback? true` (consistent with depth-exceeded;
                  ;; reuses the existing `:recovery :no-recovery`
                  ;; vocabulary rather than minting a new enum value).
                  ;; The router consumes the loop's final boolean to
                  ;; perform the actual container restoration.
-                 ;; Per rf2-a5kzs (finding 3) — the explainer is invoked
-                 ;; through `safe-explain` so a throwing custom explainer
-                 ;; (or an explainer that fails on a degenerate schema)
-                 ;; cannot abort this branch and unwind past the `false`
-                 ;; this entry contributes to the loop's conjoined result.
-                 ;; A propagated throw would reach the router's
-                 ;; swallowed-backstop `(catch … true)` and the invalid
-                 ;; commit would install with no rollback. The explainer is
-                 ;; diagnostic-only; on a throw `:explain` degrades to nil
-                 ;; and the failure verdict is preserved.
+                 ;; Explainer failure is diagnostic only and cannot change the
+                 ;; false verdict contributed by this entry.
                  (let [explanation (safe-explain schema reg-slice)
                        in-path     (failing-in-path explanation)
                        leaf-value  (if in-path
                                      (get-in reg-slice in-path)
                                      reg-slice)
-                       ;; PER-SLOT DECISION SCOPING (rf2-3qam7b). The app-db
+                       ;; The app-db
                        ;; hot path is the ONLY surface that NARROWS a slot:
                        ;; `:value` is `(get-in reg-slice in-path)` — just the
                        ;; failing leaf. So it carries TWO redaction decisions
@@ -888,8 +703,7 @@
                        ;;   - `leaf-sensitive?` — the LEAF-PRECISE check
                        ;;     (`schema-sensitive-at?` at the failing `:in`;
                        ;;     whole-schema fallback when no `:in` extractable).
-                       ;;     Per rf2-oh4se / rf2-kj51z a failure at a
-                       ;;     non-sensitive leaf whose SIBLING is sensitive is
+                       ;;     A failure at a non-sensitive leaf whose sibling is sensitive is
                        ;;     NOT redacted — the leaf value genuinely doesn't
                        ;;     contain the sibling. This decision governs the
                        ;;     NARROWED `:value` slot AND the `:path` / `:reason`
@@ -902,16 +716,14 @@
                        ;;     `reg-slice` verbatim (Malli's explanation root
                        ;;     `:value` is the whole input map / the humanized
                        ;;     decomposition is path-shaped over it). A
-                       ;;     CONFORMING sensitive sibling (the rf2-3qam7b leak:
-                       ;;     `[:name]` fails, `[:jwt {:sensitive?}]` conforms)
+                       ;;     Conforming sensitive siblings such as a valid jwt
                        ;;     rides inside `:explain`; gating `:explain` on the
                        ;;     leaf-precise `[:name]` decision (sibling-blind)
-                       ;;     leaked the live jwt to Xray + pair-MCP. The root
-                       ;;     check catches it because the schema declares the
-                       ;;     jwt slot sensitive. `whole-sensitive?` also stamps
+                       ;;     would leak through a leaf-only decision. The root
+                       ;;     check catches them. `whole-sensitive?` also stamps
                        ;;     the top-level `:sensitive?` (it is the broader
                        ;;     decision — `leaf-sensitive?` ⊆ `whole-sensitive?`).
-                       ;; Per rf2-u9bjgr — a COMPILED / OPAQUE schema (a
+                       ;; A compiled or opaque schema (a
                        ;; non-vector, non-keyword `m/schema` object) cannot be
                        ;; walked, so a per-slot `:sensitive?` Malli honoured is
                        ;; invisible. Fail CLOSED on BOTH the whole-payload and
@@ -919,7 +731,7 @@
                        ;; sensitive. (`reg-app-schema` also warns once via
                        ;; `:rf.warning/schema-walker-opaque` at registration;
                        ;; this is the redaction half of the same fail-closed
-                       ;; posture.) Per rf2-hi0tf8 — a schema whose ROOT is
+                       ;; posture.) A schema whose root is
                        ;; walkable vector-form EDN can still embed a NESTED
                        ;; opaque child (e.g. `[:map [:token (m/schema
                        ;; [:string {:sensitive? true}])]]`); `schema-opaque?`
@@ -933,12 +745,11 @@
                        ;; same whole-schema scope `schema-has-sensitive?`
                        ;; already used). Scoping `leaf-sensitive?` to the
                        ;; failing path (rather than "opaque anywhere in the
-                       ;; schema") preserves the rf2-oh4se / rf2-3qam7b
-                       ;; leaf-precision contract — an opaque SIBLING must
+                       ;; schema") preserves leaf precision: an opaque sibling must
                        ;; not taint an unrelated non-opaque leaf's `:value`.
                        leaf-sensitive?  (walker/schema-sensitive-at? schema in-path)
                        whole-sensitive? (walker/schema-sensitive-at? schema nil)
-                       ;; Per rf2-vmhu4i — a `:large?` (non-sensitive) schema
+                       ;; A `:large?` non-sensitive schema
                        ;; elides the value-bearing slots to the size marker
                        ;; (sensitive wins; opaque is fail-closed sensitive,
                        ;; subsuming large). `whole-large?` governs every
@@ -947,7 +758,7 @@
                        ;; failing leaf) and the whole-payload `:explain`.
                        whole-large?     (and (not whole-sensitive?)
                                              (walker/schema-has-large? schema))
-                       ;; Per rf2-ss06u.1 / rf2-612mri — some `:in`
+                       ;; Some `:in`
                        ;; segments are value-bearing, not structural: a
                        ;; `:set` failure's segment is the failing ELEMENT
                        ;; VALUE (Malli has no positional index for a set), a
@@ -967,14 +778,14 @@
                        ;; `:path` via `sanitize-sensitive-path` (navigable
                        ;; `:vector` / `:tuple` / `:map` segments + NON-sensitive
                        ;; `:map-of` keys are kept so `:path` stays a useful
-                       ;; locator for those shapes — the bead regression).
+                       ;; locator for those shapes).
                        path-in     (if (and in-path leaf-sensitive?)
                                      (walker/sanitize-sensitive-path schema in-path)
                                      in-path)
                        leaf-path   (if path-in
                                      (vec (concat reg-path path-in))
                                      reg-path)
-                       ;; Per rf2-qhq3f — humanize from the RAW
+                       ;; Humanize from the raw
                        ;; explanation, before redaction, so the
                        ;; `:explain-humanized` slot is scrubbed
                        ;; symmetrically with `:explain` on sensitive
@@ -997,8 +808,8 @@
                                      (some? humanized) (assoc :explain-humanized humanized))
                        ;; PER-SLOT DECISION SCOPING: `:value` (narrowed) under
                        ;; the leaf decision; `:explain` / `:explain-humanized`
-                       ;; (whole reg-slice) under the root decision. Per
-                       ;; rf2-vmhu4i, when the schema is `:large?` (and not
+                       ;; (whole reg-slice) under the root decision. When the
+                       ;; schema is `:large?` and not
                        ;; sensitive) the value-bearing slots elide to the size
                        ;; marker (built from the whole `reg-slice`) — sensitive
                        ;; wins, so this arm only fires when neither the leaf nor
@@ -1021,31 +832,14 @@
   :event`; the caller skips the handler (recovery: `:no-recovery`).
   Returns true/false per the `run-validation` contract.
 
-  The optional 4-arity `frame` (rf2-lo28u) stamps a `:frame` tag onto
-  the failure trace. Without it the trace carries no `:frame`, so
-  `re-frame.epoch.capture/capture-event!` — which buffers a trace into
-  the in-flight cascade ONLY when the trace's tags carry the cascade's
-  `:frame` — silently DROPS the violation from the epoch's
-  `:trace-events`. The violation still reaches the global trace stream
-  (so `register-listener!` consumers see it) but never lands in the
-  per-frame epoch record, so the Xray Issues / Schema-timeline lens
-  (which reads off `:trace-events`) shows nothing. This is the
-  asymmetry against `validate-app-schema!`, which always tags `:frame`
-  and so is correctly captured. The router passes the in-flight frame
-  so the `:where :event` trace is captured in the same epoch as the
-  dispatch that triggered it, exactly like the `:where :app-db` trace.
-  The 3-arity stays for direct (non-router) callers (the elision probe,
-  unit tests) where there is no in-flight cascade to attribute to.
+  The optional frame is stamped on the trace so runtime calls are captured in
+  the same epoch as their dispatch. Direct callers may omit it.
 
-  Per rf2-a5kzs (finding 1) — event validation DOES consult the schema's
-  per-slot `:sensitive?` walker (`walk-schema? true`). An event schema is
+  Event validation consults per-slot `:sensitive?` declarations. An event schema is
   not itself `:map`-shaped, but its payload commonly IS: a login schema
   `[:cat [:= :auth/login] [:map [:password {:sensitive? true} :string]]]`
-  marks the password slot sensitive. The previous `false` ignored those
-  annotations, so a failing sensitive event payload leaked verbatim via
-  `:received` / `:value` / `:explain` to trace listeners / off-box
-  consumers — contradicting Spec 010's redaction contract. `walker/
-  schema-has-sensitive?` walks the WHOLE schema form (the `:cat` container
+  marks the password slot sensitive. `walker/schema-has-sensitive?` walks
+  the whole schema form (the `:cat` container
   descends into its `:map` payload child), so a per-slot `:sensitive?`
   anywhere in the event schema (incl. container-level props) now drives
   redaction; non-sensitive event failures still ride verbatim (the walker
@@ -1080,17 +874,8 @@
   per the `:replaced-with-default` recovery. Returns true/false per
   the `run-validation` contract.
 
-  The optional 5-arity `frame` (rf2-9cm27) stamps a `:frame` tag onto
-  the failure trace — the reaction's frame. Without it the trace carries
-  no `:frame`, so `re-frame.epoch.capture/capture-event!` — which buffers
-  a trace into the in-flight cascade ONLY when the trace's tags carry the
-  cascade's `:frame` — silently DROPS the violation from the epoch's
-  `:trace-events`, leaving the Xray Issues / Schema-timeline lens (which
-  reads off `:trace-events`) blind to it. Mirrors `validate-event!`'s
-  `:frame` fix (rf2-lo28u) so every per-step validation trace is captured
-  uniformly. The 4-arity stays for direct (non-runtime) callers (the
-  elision probe, unit tests) where there is no reaction frame to
-  attribute to."
+  The optional frame is stamped on the trace so runtime calls join the
+  in-flight epoch. Direct callers may omit it."
   ([sub-id query-v value sub-meta] (validate-sub! sub-id query-v value sub-meta nil))
   ([sub-id query-v value sub-meta frame]
    (if interop/debug-enabled?
@@ -1114,13 +899,7 @@
            frame (assoc :frame frame))))
      true)))
 
-;; NB the injection-time `validate-cofx!` fn was RETIRED per rf2-nkf4l3.
-;; EP-0017 removed the ctx-mutating `inject-cofx` injection point this fn's
-;; `:where :cofx` trace described; the live cofx schema contract is the
-;; recordable-value check in `re-frame.cofx/validate-recordable-value!` — a
-;; PRODUCTION hard error emitting `:rf.error/cofx-value-invalid` (and throwing),
-;; not a dev-only `:rf.error/schema-validation-failure :where :cofx` trace. See
-;; Spec 010 §Validation order step 2 and §Per-step recovery row 2.
+;; Recordable cofx values use the always-on contract in `re-frame.cofx`.
 
 (defn validate-fx!
   "Per Spec 010 §Validation order step 5 — before an fx handler runs,
@@ -1131,22 +910,14 @@
   continue to run, and downstream queued events still drain. Returns
   true/false per the `run-validation` contract.
 
-  Per rf2-nijom the per-surface `:rf.fx/args` slot is redacted by the
-  central `redact-tags` cond->; the lambda escape hatch that used to
-  do this here is gone, and Spec 010 §`:sensitive?` now lists
+  The per-surface `:rf.fx/args` slot is redacted by the central
+  `redact-tags` path. Spec 010 §`:sensitive?` lists
   `:rf.fx/args` alongside `:value` / `:received` / `:explain` as the
   canonical redacted slots (and `:rf.sub/query-v` on the sub-return
-  surface, per rf2-adtp2).
+  surface).
 
-  The optional 5-arity `frame` (rf2-9cm27) stamps a `:frame` tag onto
-  the failure trace — the in-flight cascade's frame. Without it the
-  trace carries no `:frame`, so `re-frame.epoch.capture/capture-event!`
-  silently DROPS the violation from the epoch's `:trace-events` (it
-  buffers a trace into the in-flight cascade ONLY when the trace's tags
-  carry the cascade's `:frame`), leaving the Xray Schema-timeline lens
-  blind to it. Mirrors `validate-event!`'s `:frame` fix (rf2-lo28u). The
-  4-arity stays for direct (non-runtime) callers (the elision probe,
-  unit tests)."
+  The optional frame is stamped on the trace so runtime calls join the
+  in-flight epoch. Direct callers may omit it."
   ([fx-id event-id args fx-meta] (validate-fx! fx-id event-id args fx-meta nil))
   ([fx-id event-id args fx-meta frame]
    (if interop/debug-enabled?
@@ -1171,10 +942,10 @@
            frame    (assoc :frame frame))))
      true)))
 
-;; ---- public boundary-validation entry point (rf2-r2uh integration) -------
+;; ---- public boundary-validation entry points ------------------------------
 ;;
 ;; The boundary-validation interceptor (`re-frame.spec/validate-at-boundary-interceptor`,
-;; interceptor id `:rf.schema/at-boundary` per rf2-ieu0i; rf2-r2uh)
+;; interceptor id `:rf.schema/at-boundary`)
 ;; runs `:schema` validation on a handler at production-build time —
 ;; outside the `interop/debug-enabled?` gate that guards the
 ;; hot-path validate-*! fns above. Per Spec 010 §Production builds the
@@ -1183,7 +954,7 @@
 ;; surfaces). This namespace publishes `validate-with-registered-fn` as
 ;; the call the interceptor reaches for via the
 ;; `:schemas/validate-with-registered-fn` late-bind hook (the schemas
-;; artefact is optional per rf2-p7va so the interceptor cannot
+;; artefact is optional, so the interceptor cannot
 ;; statically `:require [re-frame.schemas]`).
 ;;
 ;; Contract: returns true on conform; false on fail (incl. a malformed
@@ -1194,13 +965,13 @@
 
 (defn validate-with-registered-fn
   "Apply the registered validator to `(schema, value)`. Public seam for
-  the boundary-validation interceptor (rf2-r2uh). Returns true on
+  the boundary-validation interceptor. Returns true on
   conform; false on fail; true when no validator is registered (the
   call-site treats no-validator as no-validation, mirroring the hot
   path).
 
-  Per rf2-a5kzs (finding 2, boundary seam) — a structurally MALFORMED
-  registered schema makes the validator THROW. This seam isolates that
+  A structurally malformed registered schema makes the validator throw.
+  This seam isolates that
   throw and returns `false` (fail CLOSED — the boundary interceptor then
   skips the handler) rather than letting it propagate to the interceptor's
   defensive `(catch … true)`, which would coerce the throw to a validation
@@ -1219,58 +990,53 @@
 (defn explain-with-registered-fn
   "Apply the registered explainer to `(schema, value)`. Companion to
   `validate-with-registered-fn` for the boundary-validation
-  interceptor (rf2-r2uh). Returns the explanation map / data on fail;
+  interceptor. Returns the explanation map / data on fail;
   nil when the schema conforms or no explainer is registered.
 
-  Per rf2-a5kzs (finding 3, boundary seam) — a throwing explainer
-  degrades to nil here rather than propagating; the boundary interceptor
-  already wraps the call in its own try/catch, so this is belt-and-braces
-  symmetry with the dev-time `safe-explain` (the explainer is diagnostic-
-  only and must never change the verdict)."
+  A throwing explainer degrades to nil because diagnostic enrichment must
+  never change the verdict."
   [schema value]
   (try
     (validator/run-explainer schema value)
     (catch #?(:clj Throwable :cljs :default) _ nil)))
 
 (defn redact-validation-tags
-  "THE shared schema-aware redaction seam for EVERY validation-failure
-  trace emitted OUTSIDE this namespace (rf2-o69h5). Given the registered
+  "Shared schema-aware redaction seam for validation-failure
+  trace emitted outside this namespace. Given the registered
   `schema` the failing value was checked against and the failure-trace
   `tags` a caller built, return the tags with the value-bearing slots
   (`:value` / `:received` / `:explain` / `:explain-humanized` /
   `:rf.fx/args` / `:rf.sub/query-v` — the canonical `value-bearing-slots`)
-  scrubbed to `:rf/redacted` and `:sensitive? true` stamped WHEN the
+  scrubbed to `:rf/redacted` and `:sensitive? true` stamped when the
   schema declares ANY slot `:sensitive?` (e.g. a payload map
   `[:map [:password {:sensitive? true} :string]]`); otherwise the tags
   ride back verbatim.
 
-  This is the ONE redactor the class-sweep (rf2-o69h5) routes every
-  framework-side validation-failure emit site through, so the
+  Framework-side validation-failure emit sites route through this redactor so
   `:sensitive?` redaction logic lives in a single place rather than
   being re-derived ad-hoc per surface. The dev-time hot-path emits
   (`validate-event!` / `-fx!` / `-sub!` / `validate-app-schema!`)
-  reach the SAME `redact-tags` core directly via `run-validation`; the
+  reach the same `redact-tags` core directly via `run-validation`; the
   off-namespace emit sites — the production boundary interceptor
   (`re-frame.spec`), machine `:data` validation
   (`re-frame.machines.data-validation`), the `:sub-override` validation
   path (`re-frame.subs`), flow-output validation (`re-frame.flows`), and
-  the EP-0017 recordable-coeffect `:rf.error/cofx-value-invalid` emit
-  (`re-frame.cofx` — the live cofx schema surface; the injection-time
-  `validate-cofx!` was retired per rf2-nkf4l3)
+  the recordable-coeffect `:rf.error/cofx-value-invalid` emit
+  (`re-frame.cofx`)
   — reach it through the `:schemas/redact-validation-tags` late-bind
   hook and fall through verbatim when the hook is unbound (schemas
   artefact absent → no schema to redact against).
 
-  Per rf2-u9bjgr the decision FAILS CLOSED on a COMPILED / OPAQUE schema (a
+  The decision fails closed on a compiled or opaque schema (a
   non-vector, non-keyword `m/schema` object the walker cannot introspect):
   it redacts as if sensitive, because Malli may have honoured a
   `{:sensitive? true}` slot the walker cannot see — without this an opaque
-  schema's failure leaks verbatim while the vector form redacts. Per
-  rf2-hi0tf8 the same fail-closed posture applies when the opaque value is
-  NESTED inside an otherwise-walkable vector-form schema (`schema-opaque?`
+  schema's failure leaks verbatim while the vector form redacts. The same
+  fail-closed posture applies when the opaque value is
+  nested inside an otherwise-walkable vector-form schema (`schema-opaque?`
   alone only sees the root) — `schema-has-opaque-child?` catches both.
 
-  Per rf2-vmhu4i a `:large?`-flagged (and non-sensitive) schema elides the
+  A `:large?`-flagged, non-sensitive schema elides the
   value-bearing slots to the `:rf.size/large-elided` marker (sensitive wins;
   the opaque fail-closed branch is sensitive, which subsumes large). `tags`
   carries the whole checked value under `:value` (the shared off-box slot),

--- a/implementation/schemas/src/re_frame/schemas/validator.cljc
+++ b/implementation/schemas/src/re_frame/schemas/validator.cljc
@@ -1,13 +1,11 @@
 (ns re-frame.schemas.validator
-  "Pluggable validator / explainer / printer fns (rf2-froe + rf2-wla45).
+  "Pluggable validator, explainer, and schema-printer functions.
 
   Per Spec 010 §Non-Malli validators — the validator-fn extension point.
   The framework never inspects the value stored in `:schema` directly;
   every validation site routes through the registered validator fn.
-  This is the seam Malli plugs into by default; apps that want to drop
-  the ~24 KB gzipped Malli surface (rf2-qnxf) call
-  `(schemas/set-schema-validator! some-other-fn)` (or `nil` for no-op) at
-  boot before any reg-app-schema / :schema metadata lands.
+  This is the seam Malli plugs into by default. Applications may install a
+  different validator bundle, or nil for no validation.
 
   Three fns are registered separately so the validate hot path stays
   cheap (validate returns truthy/falsey; explain is only invoked on
@@ -35,33 +33,13 @@
               EDN canonicaliser, which is the cross-runtime contract
               every Malli-EDN-compatible port shares.
 
-  Each fn has a dedicated single-purpose setter — `set-schema-validator!`
-  / `set-schema-explainer!` / `set-schema-printer!`. `set-schema-fns!`
-  installs any subset of the three as one atomic bundle for callers
-  (a port's boot, a substitute-Malli swap) who want all three to land
-  together. The bundle setter is named for what it does — it does NOT
-  pretend to set only the validator (rf2-13meg).
+  Dedicated setters change one function. `set-schema-fns!` installs any
+  subset as a bundle so a schema-language port can keep validation,
+  explanations, and digest serialization aligned.
 
-  Per rf2-t0hq the CLJS default validator used to reach Malli through
-  runtime `resolve` — but CLJS has no runtime resolve (the symbol is
-  a compile-time analyzer affordance only). The fix is the rf2-froe /
-  rf2-p7va substitute-validator pattern: the `re-frame.schemas.malli`
-  adapter namespace publishes Malli's `validate` and `explain` into the
-  late-bind hook table on ns-load. The default fns below consult the
-  table on every call.
-
-  Per rf2-v96fh (schema implies validation) the `re-frame.schemas`
-  facade now `:require`s `re-frame.schemas.malli` itself, so loading the
-  schemas artefact wires the Malli hooks automatically — the default
-  validator is LIVE the moment a schema is registered. The soft-pass
-  branch below (return `true` when `:schemas/malli-validate` is unbound)
-  is therefore the defensive fallback for two residual cases, NOT the
-  default state: (1) a non-Malli port / app that installed its own
-  validator via `set-schema-fns!` and never bound the Malli hook, and
-  (2) test harnesses that deliberately unbind the hook to exercise the
-  absent path. Per Spec 010 §Recommended soft-pass an unbound default
-  validator passes rather than failing, so a substitute-validator
-  app is never blocked by Malli's absence."
+  The Malli adapter publishes its functions through late binding. The façade
+  loads that adapter automatically; the absent-hook soft-pass remains a
+  defensive contract for substitute ports and isolated tests."
   (:require [re-frame.late-bind :as late-bind]
             [re-frame.schemas.cache :as cache]))
 
@@ -70,7 +48,7 @@
 (defn- default-malli-validate
   "The default validator — delegates to `malli.core/validate` via the
   late-bind hook `:schemas/malli-validate` published by
-  `re-frame.schemas.malli` (rf2-t0hq). Soft-passes (returns true) when
+  `re-frame.schemas.malli`. Soft-passes (returns true) when
   the adapter ns is not loaded, per Spec 010 §Recommended soft-pass.
 
   Apps that want Malli-absent behaviour to be a hard fail register
@@ -83,7 +61,7 @@
 (defn- default-malli-explain
   "The default explainer — delegates to `malli.core/explain` via the
   late-bind hook `:schemas/malli-explain` published by
-  `re-frame.schemas.malli` (rf2-t0hq). Returns nil when the adapter
+  `re-frame.schemas.malli`. Returns nil when the adapter
   ns is not loaded — the failure trace then omits the `:explain` key."
   [schema value]
   (when-let [e (late-bind/get-fn :schemas/malli-explain)]
@@ -120,9 +98,7 @@
 (defn- compute-edn-print
   "The pure serialisation step behind `default-edn-print` — `pr-str`
   over a canonicalised EDN form with the digest pipeline's print-flag
-  bindings. Extracted so the memo wrapper can be swapped for an
-  atom-backed cache (rf2-17sqc) without disturbing the serialisation
-  contract. Same `schema-value` always returns byte-identical bytes."
+  bindings. Same `schema-value` always returns byte-identical bytes."
   [schema-value]
   (binding [*print-meta*           false
             *print-readably*       true
@@ -130,18 +106,12 @@
             *print-namespace-maps* false]
     (pr-str (canonicalise-schema-form schema-value))))
 
-;; `default-edn-print` is the clearable-memo wrapper over
-;; `compute-edn-print` (rf2-17sqc shape; the factory lives in
-;; `re-frame.schemas.cache`, consolidated rf2-mse54). The cache is
-;; *clearable* (`clojure.core/memoize` exposes no clear hook) so a test
-;; that registers many distinct fresh schemas (the concurrency-stress
-;; harness) can reset the process-lifetime cache in fixture teardown.
-;; Behaviour for callers is byte-identical to the prior `memoize` form.
-;; See `re-frame.schemas.cache` for the boot-once invariant.
+;; The process-lifetime print cache is bounded by boot-time schema
+;; cardinality and can be cleared by test fixtures that generate schemas.
 (let [[memo clear!] (cache/clearable-memo compute-edn-print)]
 
   (def
-    ^{:doc "The default schema-print companion (rf2-wla45). Per Spec 010
+    ^{:doc "The default schema-print companion. Per Spec 010
             §Schema digest line 491 — serialise a schema value to the
             stable UTF-8 byte-source string the digest pipeline hashes.
             The default uses `pr-str` over a canonicalised EDN form:
@@ -154,29 +124,14 @@
             the registered validator's serialisation contract rather than
             the framework's Malli-EDN default.
 
-            Memoised by `schema-value` (rf2-y29nf): the digest pipeline
-            (`re-frame.schemas.digest/compute-digest`) calls this once per
-            registered schema per digest call, and the digest is invoked
-            on the SSR hydrate handshake, the epoch-restore schema-
-            mismatch trace, and pair-tool drift detection — repeat calls
-            against the same registered schema values dominate. Pure over
-            immutable schema values, so the cache is bounded by the
-            registered-schema cardinality.
-
-            The memo is **clearable** for test isolation via
-            `clear-edn-print-cache!` (rf2-17sqc)."
+            Memoised by immutable schema value and clearable for test
+            isolation via `clear-edn-print-cache!`."
       :arglists '([schema-value])}
     default-edn-print memo)
 
   (def
-    ^{:doc "Reset the `default-edn-print` memo cache (rf2-17sqc). Test-
-            support hook: the printer memo is process-lifetime and bounded
-            by the registered-schema cardinality in real apps (schemas
-            register once at boot), so production never needs this — but a
-            test that registers many distinct fresh schemas
-            (`schemas_concurrency_stress_test`) calls it in fixture
-            teardown so the cache doesn't grow unbounded across the suite.
-            Returns nil."
+    ^{:doc "Reset the `default-edn-print` memo cache. Intended for test
+            fixtures that generate fresh schemas. Returns nil."
       :arglists '([])}
     clear-edn-print-cache! clear!))
 
@@ -213,11 +168,8 @@
 
 (defn set-schema-validator!
   "Register the validator fn that every dev-time validation site routes
-  through. Per Spec 010 §Non-Malli validators the seam is
-  the substitute-Malli extension point — apps that want to drop Malli
-  (the ~24 KB gzipped surface measured in the rf2-qnxf bundle audit)
-  swap in their own validator at boot, before the first `reg-app-schema`
-  or `:schema`-bearing `reg-*` lands.
+  through. Install substitute validators at boot, before schema-bearing
+  registrations land.
 
     (set-schema-validator! validate-fn)
       validate-fn :: (fn [schema value] truthy?)
@@ -228,8 +180,7 @@
   This setter swaps ONLY the validator. The explainer and printer are
   left untouched — apps that also want to swap those call
   `set-schema-explainer!` / `set-schema-printer!`, or use
-  `set-schema-fns!` to install all three as one atomic bundle
-  (rf2-13meg).
+  `set-schema-fns!` to install all three as one bundle.
 
   Per Spec 010 §Non-Malli validators the validator-fn must be pure
   (same `(schema, value)` returns the same result) and must be
@@ -245,10 +196,8 @@
   @validator-fn)
 
 (defn set-schema-fns!
-  "Atomically install any subset of the validator / explainer / printer
-  bundle from a single map (rf2-13meg). The honest bundle setter — its
-  name says it sets all three schema-language fns, not just the
-  validator.
+  "Install any subset of the validator / explainer / printer bundle from
+  a single map.
 
     (set-schema-fns! {:validate validate-fn
                       :explain  explain-fn
@@ -264,17 +213,16 @@
                validation (every site soft-passes).
     :explain   (fn [schema value] explanation) | nil — nil omits the
                failure trace's `:explain` key.
-    :print     (fn [schema-value] canonical-string) | nil — per
-               rf2-wla45 the schema-print companion the digest pipeline
-               hashes (Spec 010 §Schema digest line 491). nil coerces
+    :print     (fn [schema-value] canonical-string) | nil — the schema-print
+               companion the digest pipeline hashes. nil coerces
                to the default EDN canonicaliser (the digest is never
                undefined for a present schema set) — identical to
                `set-schema-printer!`'s nil fallback, so `printer-fn` is
-               never nil after any write (rf2-ee38b.6).
+               never nil after any write.
 
   Last-write-wins per key. Returns the installed bundle as a map —
   `{:validate @validator-fn :explain @explainer-fn :print @printer-fn}`
-  — reflecting the live state of ALL THREE fns after this call (rf2-qdtcx2).
+  — reflecting the live state of all three functions after this call.
   A bundle setter returns its bundle: the return mirrors `set-schema-fns!`'s
   own input shape, so a caller can atomically observe everything that is now
   installed — including keys it did NOT touch and the nil-printer coercion of
@@ -285,18 +233,11 @@
   [{:keys [validate explain print] :as m}]
   (when (contains? m :validate) (reset! validator-fn validate))
   (when (contains? m :explain)  (reset! explainer-fn explain))
-  ;; Per rf2-ee38b.6 (clarity P2): coerce `nil` to the default
-  ;; identically to the dedicated `set-schema-printer!` setter, so
-  ;; "printer-fn is never nil" is a true invariant established at the
-  ;; write site — not re-asserted defensively in `run-printer`.
+  ;; Establish the printer-never-nil invariant at every write site.
   (when (contains? m :print)
     (reset! printer-fn (or print default-edn-print)))
-  ;; rf2-qdtcx2 — return the installed BUNDLE, not just the validator.
-  ;; A bundle setter named for setting all three fns should let the
-  ;; caller observe all three atomically; the old `@validator-fn`-only
-  ;; return left a `{:print …}`-only call handing back a value unrelated
-  ;; to what it set. Read each atom under no lock — these are framework-
-  ;; wide defonce atoms and this is the boot-time install path.
+  ;; Return the full installed bundle, including untouched keys and any
+  ;; nil-printer coercion. This is a boot-time configuration path.
   {:validate @validator-fn
    :explain  @explainer-fn
    :print    @printer-fn})
@@ -316,7 +257,7 @@
 (defn set-schema-printer!
   "Register the schema-print companion — `(fn [schema-value]
   canonical-string)` — the digest pipeline hashes per Spec 010
-  §Schema digest line 491 (rf2-wla45). Parallel to
+  §Schema digest line 491. Parallel to
   `set-schema-validator!` / `set-schema-explainer!`: the validator
   surface is fully pluggable, and the digest contract is too —
   non-Malli ports register their own serialiser so the digest
@@ -352,28 +293,19 @@
   (reset! printer-fn   default-edn-print))
 
 (defn snapshot-schema-fns
-  "Capture the currently-installed validator / explainer / printer bundle
-  as one opaque value (rf2-l4ljvr). The bundle-level companion to the
-  registry's `snapshot-schemas-by-frame` (storage.cljc) — together they
-  let a test capture+restore the WHOLE schema runtime (the per-frame
-  registry AND the pluggable validation bundle) through the encapsulated
-  API, never reaching the raw `validator-fn` / `explainer-fn` /
-  `printer-fn` atoms.
+  "Capture the installed validator, explainer, and printer as one opaque
+  bundle. Together with `snapshot-schemas-by-frame`, this lets fixtures
+  preserve the complete schema runtime through the encapsulated API.
 
   Returns a map in the SAME shape `set-schema-fns!` accepts and returns
-  (rf2-13meg / rf2-qdtcx2):
+  accepted by `set-schema-fns!`:
 
     {:validate @validator-fn   ;; may be nil (validation disabled)
      :explain  @explainer-fn   ;; may be nil (no explanation)
      :print    @printer-fn}    ;; never nil (always at least default-edn-print)
 
-  so the value round-trips losslessly through `restore-schema-fns!`.
-  This is the missing capture half: before rf2-l4ljvr only
-  `reset-schema-validator!` existed (resets to the framework DEFAULT),
-  so a test that wanted to install a custom bundle and later restore the
-  PRIOR custom bundle had to hand-roll the snapshot via raw `@validator-fn`
-  derefs. Reads each atom under no lock — these are framework-wide defonce
-  atoms read at the test seam, mirroring `set-schema-fns!`'s own returns."
+  so the value round-trips through `restore-schema-fns!`. Reads are not a
+  transactional snapshot; configuration is expected to be quiescent here."
   []
   {:validate @validator-fn
    :explain  @explainer-fn
@@ -381,15 +313,15 @@
 
 (defn restore-schema-fns!
   "Reinstall a validator / explainer / printer bundle captured by
-  `snapshot-schema-fns` (rf2-l4ljvr). The bundle-level companion to the
+  `snapshot-schema-fns`. The bundle-level companion to the
   registry's `restore-schemas-by-frame!` (storage.cljc).
 
   Restoring is a FULL bundle install — all three atoms are reset from the
   snapshot map's `:validate` / `:explain` / `:print` keys. Delegates to
   `set-schema-fns!` so a snapshot's keys land through the SAME write path
   the public setter uses: in particular a `nil` `:print` coerces to
-  `default-edn-print` exactly like `set-schema-fns!` / `set-schema-printer!`
-  (rf2-ee38b.6), so the printer-never-nil invariant `run-printer` relies on
+  `default-edn-print` exactly like `set-schema-fns!` / `set-schema-printer!`,
+  so the printer-never-nil invariant `run-printer` relies on
   holds after a restore without a read-site guard — a `snapshot-schema-fns`
   value always carries a non-nil `:print`, but routing the restore through
   the coercing setter keeps the invariant true even for a hand-built bundle
@@ -400,8 +332,8 @@
 (defn using-default-validator?
   "True when `validator-fn` is still the framework-default
   `default-malli-validate`. Used by the
-  `:rf.warning/schema-validator-unavailable` registration-time check
-  (rf2-fq7d2) to distinguish 'app hasn't opted out of Malli' from
+  `:rf.warning/schema-validator-unavailable` registration-time check to
+  distinguish 'app hasn't opted out of Malli' from
   'app installed its own validator and knows what it's doing'."
   []
   (identical? @validator-fn default-malli-validate))
@@ -428,10 +360,10 @@
 (defn run-printer
   "Hot-path entry — invoke the registered schema-print companion against
   a single schema value. Per Spec 010 §Schema digest line 491 the digest
-  pipeline (`re-frame.schemas.digest`) hashes this fn's UTF-8 bytes
-  (rf2-wla45). `printer-fn` is never nil: both write sites
+  pipeline (`re-frame.schemas.digest`) hashes this fn's UTF-8 bytes.
+  `printer-fn` is never nil: both write sites
   (`set-schema-printer!` and `set-schema-fns!`'s `:print` key) coerce
-  a nil `:print` to `default-edn-print` (rf2-ee38b.6), so the
+  a nil `:print` to `default-edn-print`, so the
   cross-runtime digest contract holds without a read-site guard."
   [schema-value]
   (@printer-fn schema-value))

--- a/implementation/schemas/src/re_frame/schemas/walker.cljc
+++ b/implementation/schemas/src/re_frame/schemas/walker.cljc
@@ -1,146 +1,26 @@
 (ns re-frame.schemas.walker
-  "Per-slot flag walker for Malli EDN schemas (rf2-nwv63 / rf2-kj51z / rf2-oghml).
+  "Pure-data extractor for per-slot flags in Malli EDN schemas.
 
-  Per Spec 009 §Size elision in traces and Spec 010 §`:sensitive?`, the
-  schema-driven nomination path: any Malli slot carrying a per-slot flag
-  (`:large? true` or `:sensitive? true`) in its per-slot properties
-  (per Spec-Schemas §`:rf/app-schema-meta` — the per-slot metadata
-  vocabulary) is walked to a `{path declaration}` map with `:source
-  :schema`. Flags compose orthogonally — a slot may carry either or both,
-  and the consumer resolves the conflict at use time.
+  `:large?` and `:sensitive?` slot props are projected to
+  `{path declaration}` maps with `:source :schema`. Owner-local consumers use
+  these declarations for validation-failure and transient egress projection.
+  Schemas do not populate durable app-db classification; commit-plane effects
+  own that policy.
 
-  This file owns the **walker** that maps a registered schema's EDN form
-  to a `{path declaration}` map. It is a **pure-data extractor**; the
-  walker itself performs no runtime-db write.
+  The walker does not depend on Malli and does not ask the registered
+  validator to interpret a schema. It recognizes vector forms shaped as
+  `[op props? children...]`. Compiled schema values and registry references
+  are opaque, so their internal flags cannot be extracted. Registration warns
+  once for compiled or nested opaque values. Keyword registry references stay
+  silent because the framework cannot distinguish them from primitive keyword
+  schemas without violating the opaque-schema boundary.
 
-  ## EP-0015 §8 (rf2-d2r3um) — schema props do NOT feed app-db egress
-
-  These extractors NO LONGER populate the frame's app-db egress registry
-  under `[:rf.runtime/elision :declarations]` /
-  `[:rf.runtime/elision :sensitive-declarations]`. App-db egress
-  classification is declared by the **EP-0025 commit-plane classification
-  effects** — a `reg-event` returns `:sensitive` / `:large` alongside `:db`,
-  written `:source :effect` (Spec 015 §Data classification). The former
-  durable `:sensitive` / `:large {:app-db …}` *frame annotation* and the
-  public `add-marks` / `set-marks` app-db path-mark API are both REMOVED
-  (Spec 015 §3 / Privacy.md §Removed surfaces). Schemas describe **shape**,
-  not durable app-db egress policy, and the old
-  `re-frame.elision/populate-{,sensitive-}from-schemas!` bridge + its
-  `:elision/populate-from-schemas!` late-bind seam are REMOVED (see
-  `re-frame.schemas` §schema-walker hooks; Spec-Schemas §`:rf/runtime-db`
-  `:rf.runtime/elision`).
-
-  The extractors survive for their **owner-local** schema-prop consumers,
-  which read the `{path declaration}` map directly (NOT via the elision
-  runtime-db registry):
-
-    - the resource `:data-schema` classification
-      (`re-frame.resources.classification`, EP-0015 §6);
-    - the HTTP body-privacy projector
-      (`re-frame.http.privacy-body`);
-    - story-mcp's tool-egress projector;
-    - the schema-validation-FAILURE-trace redactor
-      (`re-frame.schemas.validate`, via `schema-sensitive-at?` /
-      `schema-has-sensitive?` / `schema-opaque?` / `sanitize-sensitive-path`)
-      — `:sensitive?` redacts the failing value before the
-      `:rf.error/schema-validation-failure` trace ships.
-
-  EP-0025 (rf2-398kql) — the machine `:data-schema`→marks redaction bridge
-  (EP-0005) is GONE. A machine's `:sensitive?` / `:large?` `:data`-slot props
-  no longer classify the machine's durable `:data` for trace / SSR egress;
-  durable machine `:data` classification rides the commit-plane classification
-  effects like every other app-db path (a `reg-event` returns `:sensitive` /
-  `:large` alongside `:db`, EP-0025, the sole durable app-db mechanism). The
-  `:data-schema` still VALIDATES, and its props
-  still drive the machine-data validation-FAILURE-trace redactor via the
-  `:where :machine-data` validation path — only the schema→MARKS classification
-  bridge is reversed.
-
-  The surviving consumers call the per-flag late-bind hooks
-  (`:schemas/extract-large-paths-from-schema` /
-  `:schemas/extract-sensitive-paths-from-schema`) registered by the outer
-  façade and apply the result within their own owner-local scope.
-
-  The walker is **pure data** — it doesn't import malli.core. Malli EDN
-  forms are vectors of the shape `[op props? children...]`; we pattern-
-  match on shape. Per Spec 010 §The `:schema` value is opaque to re-frame,
-  the framework MUST NOT call into the registered validator to introspect
-  schema structure — we walk the EDN ourselves. This means the walker
-  handles the **vector form** (`[:map [:k :string]]`) — the form
-  `(rf/reg-app-schema ...)` users write. Non-vector Malli forms (schema
-  objects, registry refs) are treated as opaque leaves; their internal
-  per-slot declarations are invisible to the walker (the same caveat
-  applies to Malli's own schema-walking when introspection goes through
-  `m/schema` ↔ raw EDN — round-tripping a registry ref loses the slot
-  metadata).
-
-  ## Discoverability caveat — non-vector forms (rf2-yaioz / rf2-mxs7a)
-
-  A user that registers a schema via a compiled `m/schema` value or a
-  registry reference and adds per-slot `:sensitive?` / `:large?` flags
-  inside that opaque value will see the walker **silently skip** them —
-  the validation-failure trace will not redact the sensitive slot. The
-  two opaque shapes differ in diagnostics:
-
-    - **Compiled / non-keyword opaque values** (a compiled `m/schema`
-      object, a map, any non-vector non-keyword form) **warn once per
-      process at registration time.** `reg-app-schema` /
-      `reg-app-schemas` emit `:rf.warning/schema-walker-opaque` (the
-      one-shot warn-once nudge owned by `re-frame.schemas.storage`,
-      pinned by `schemas_walker_opaque_warning_test`) naming the two
-      workable shapes below.
-
-    - **Keyword registry refs** (`:my/user-schema`) stay **silent by
-      design.** A bare keyword is a valid Malli schema in two flavours
-      — a primitive (`:int` / `:string`) and a registry ref — and the
-      predicate cannot cheaply tell them apart without a registry
-      consult, which Spec 010 §The `:schema` value is opaque to
-      re-frame forbids. A primitive keyword provably carries no
-      per-slot flags, so warning on every keyword would be a frequent
-      false positive to catch a rare registry-ref true positive
-      (rf2-ee38b.6); the keyword case is suppressed entirely.
-
-  The workable shape when per-slot flags need to apply:
-
-    1. **Register the vector form, not the compiled one.** Pass the
-       raw EDN `[op props? children...]` to `reg-app-schema` — the
-       walker can introspect the per-slot `:sensitive?` / `:large?`
-       flags directly.
-
-  > **No registration-meta fallback.** Earlier drafts named a
-  > handler/cofx/sub registration-level `:sensitive?` annotation as a
-  > coarse fallback for opaque schemas. That annotation has been REMOVED
-  > (per Spec 010 §`:sensitive?` and Spec 009 §`:sensitive?` registration
-  > metadata key, rf2-k0ew8n): sensitivity is path-targeted — a property
-  > of the data value at a path, not of the handler that touched it — and
-  > the validation redaction now consults ONLY the per-slot schema
-  > declaration. Registering an opaque value and adding handler-meta
-  > `:sensitive?` does NOT redact; the supported route is registering the
-  > vector form (or, for durable app-db egress, the EP-0025 commit-plane
-  > `:sensitive` / `:large` classification effects — a `reg-event` returns
-  > them alongside `:db`).
-
-  Example — vector form vs registry ref:
-
-    ;; Vector form — walker sees :sensitive? per-slot.
-    (rf/reg-app-schema [:user]
-      [:map
-       [:id    :int]
-       [:token {:sensitive? true} :string]])
-
-    ;; Registry ref — walker treats the schema as an opaque leaf;
-    ;; the per-slot :sensitive? inside `:my/user-schema` is invisible.
-    ;; The supported route is registering the vector form so the walker
-    ;; can introspect it (handler-meta :sensitive? is NOT a fallback).
-    (rf/reg-app-schema [:user] :my/user-schema)
-
-  The walker is parameterised on the per-slot flag key (`:large?` /
-  `:sensitive?`); both flags share identical structural recognition
-  (`:map` name-bearing, `:multi`/`:orn`/`:catn`/`:altn` dispatch-bearing,
-  positional combinators descend at the same base-path) so a single
-  traversal serves every per-slot annotation under
-  `:rf/app-schema-meta`. Future per-slot annotations (Spec-Schemas
-  reserves additional slots) compose as one-line registrations."
+  Register vector-form EDN when per-slot flags must be visible. Compiled and
+  nested opaque schemas fail closed in validation redaction; keyword registry
+  references remain flag-invisible and therefore require the vector form for
+  precise privacy declarations.
+  The traversal is parameterized by flag key so both supported flags share the
+  same operator and path semantics."
   (:require [re-frame.schemas.cache :as cache]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -155,7 +35,7 @@
   element of a child entry is a dispatch value, not an app-db path
   segment).
 
-  `:catn` is NOT here (rf2-4q681i): although its children carry NAME
+  `:catn` is not here: although its children carry name
   slots like `:orn`/`:altn`, Malli reports a `:catn` failure's `:in`
   segment as the element's INTEGER POSITION (`[1 :age]`), not the name —
   identical to `:cat`. So `:catn` is position-bearing (see
@@ -171,8 +51,8 @@
   per-element sibling precision: a per-position flag claims that exact
   index, not the shared base-path.
 
-    - `:tuple` (rf2-ss06u.4) — element `i` is `children[i]`, a bare schema.
-    - `:cat` / `:catn` (rf2-4q681i) — the regex sequence combinators that
+    - `:tuple` — element `i` is `children[i]`, a bare schema.
+    - `:cat` / `:catn` — regex sequence combinators that
       root event schemas (`[:cat [:= :id] PayloadSchema]`). `:cat`
       elements are bare schemas (`children[i]`); `:catn` elements are
       NAME-bearing entries (`[name props? schema]`) but Malli still
@@ -213,8 +93,8 @@
   and omitted when absent so the marker shape stays minimal. The
   `:source :schema` slot records schema provenance for the owner-local
   consumer (machine / resource `:data-schema`, HTTP body-privacy,
-  story-mcp) that reads the extracted map — NOT the (removed, EP-0015 §8)
-  app-db egress registry."
+  story-mcp) that reads the extracted map, not the durable app-db
+  classification registry."
   [flag-key props]
   (when (true? (get props flag-key))
     (cond-> {flag-key true
@@ -242,8 +122,7 @@
       slot props claims the parent path (the op's `base-path`), not a
       child path; dispatch values aren't path segments.
 
-    - `:tuple` / `:cat` / `:catn` children are POSITION-bearing
-      (`:tuple` rf2-ss06u.4; `:cat`/`:catn` rf2-4q681i) — each element
+    - `:tuple` / `:cat` / `:catn` children are position-bearing: each element
       has its OWN heterogeneous schema, so element `i` descends at
       `(conj base-path i)`, the integer index being the discriminating
       segment (the positional analogue of a `:map` key). A `:sensitive?`
@@ -391,20 +270,13 @@
   Returned declarations carry `:source :schema` per Spec 009 so the
   owner-local consumer (machine / resource `:data-schema`, HTTP
   body-privacy, story-mcp) that reads this map can report schema
-  provenance for its wire-boundary elision. EP-0015 §8: this map does
-  NOT feed the app-db egress registry under `[:rf.runtime/elision
-  :declarations]` — app-db egress is frame-owned."
+  provenance for its wire-boundary elision. This map does not feed durable
+  app-db classification."
   [schema base-path]
   (walk-flagged-schema :large? schema base-path {}))
 
-;; `extract-sensitive-paths-from-schema` is the clearable-memo wrapper
-;; over the `:sensitive?` walk (rf2-17sqc shape; the factory lives in
-;; `re-frame.schemas.cache`, consolidated rf2-mse54). The cache is
-;; *clearable* (`clojure.core/memoize` exposes no clear hook) so a test
-;; that registers many distinct fresh schemas (the concurrency-stress
-;; harness) can reset the process-lifetime cache in fixture teardown.
-;; Behaviour for callers is byte-identical to the prior `memoize` form.
-;; See `re-frame.schemas.cache` for the boot-once invariant.
+;; The sensitive-path walk is memoized for boot-time schema reuse and
+;; clearable by fixtures that generate many distinct schemas.
 (let [[memo clear!]
       (cache/clearable-memo
         (fn [schema base-path]
@@ -423,22 +295,22 @@
             `redact-validation-tags`) to decide whether the failing slot's
             value MUST be redacted before the trace event ships.
 
-            Memoised by `(schema, base-path)` (rf2-y29nf): the failure-
-            branch call site (`schema-sensitive-at?`) re-walks the same
+            Memoised by `(schema, base-path)`: the failure branch
+            (`schema-sensitive-at?`) re-walks the same
             registered schema on every consecutive failure, and the walk
             is pure over immutable schema values. The cache is bounded by
             the (registered-schema, base-path) cardinality — schemas are
             registered once at app-boot, so steady-state cache size equals
             the registry size.
 
-            The memo is **clearable** for test isolation via
-            `clear-sensitive-paths-cache!` (rf2-17sqc)."
+            The memo is clearable for test isolation via
+            `clear-sensitive-paths-cache!`."
       :arglists '([schema base-path])}
     extract-sensitive-paths-from-schema memo)
 
   (def
-    ^{:doc "Reset the `extract-sensitive-paths-from-schema` memo cache
-            (rf2-17sqc). Test-support hook: the walker memo is process-
+    ^{:doc "Reset the `extract-sensitive-paths-from-schema` memo cache.
+            The walker memo is process-
             lifetime and bounded by the (registered-schema, base-path)
             cardinality in real apps (schemas register once at boot), so
             production never needs this — but a test that registers many
@@ -455,11 +327,9 @@
   schema. Per Spec 010 §`:sensitive?` — privacy in schema-validation
   error traces.
 
-  The schema-validation emit-sites ship the WHOLE registered slot's
-  value (not just a failing leaf) in the trace's `:value` / `:received`
-  / `:explain` slots; a sensitive child slot still leaks if the value
-  rides verbatim. Conservative redaction — when any slot in the schema
-  is sensitive, the whole trace's value-bearing slots are redacted.
+  Whole-payload trace slots can contain a conforming sensitive sibling, so
+  their redaction uses this schema-wide predicate. The app-db leaf value uses
+  the narrower `schema-sensitive-at?` decision.
 
   Returns boolean. Pure; same input always produces the same output."
   [schema]
@@ -471,14 +341,11 @@
   "True when the registered schema declares ANY slot `:large? true` —
   either the schema's container-level props, or a nested slot anywhere
   inside the schema. Per Spec 010 §`:large?` — schema-driven
-  size-elision nomination, the validation-failure size-safety arm
-  (rf2-vmhu4i).
+  size-elision nomination and validation-failure size-safety arm.
 
-  The mirror of `schema-has-sensitive?` on the OTHER per-slot flag. The
-  schema-validation emit-sites ship the WHOLE registered slot's value
-  verbatim in the value-bearing trace slots; a `:large?`-flagged slot
-  inside that value would ride the whole blob into a validation-failure
-  trace (an egress surface) unless the emit-site elides it. When this
+  The mirror of `schema-has-sensitive?` for size classification. Validation
+  traces include whole-payload slots, so a nested large value could make the
+  failure payload itself large. When this
   returns true the emit-site substitutes the `:rf.size/large-elided`
   size marker for the value-bearing slots — UNLESS the slot is ALSO
   sensitive, in which case sensitive wins (Spec 010 §Composition with
@@ -498,25 +365,21 @@
   §The `:schema` value is opaque to re-frame the walker MUST NOT call
   into the registered validator to introspect structure, so it walks the
   vector-form Malli EDN itself; a compiled `m/schema` value is an opaque
-  leaf and its internal per-slot `:sensitive?` / `:large?` flags are
-  invisible to the walk (rf2-u9bjgr).
+  leaf and its internal per-slot flags are invisible to the walk.
 
   A bare KEYWORD (`:int` / `:string` / a registry ref) is NOT opaque
   here: a primitive keyword provably carries no per-slot props, so the
   walker provably skips nothing — treating every keyword failure as
   fail-closed-sensitive would over-redact every plain scalar failure for
-  the rare registry-ref true positive (the same rf2-ee38b.6 false-positive
-  tradeoff the `:rf.warning/schema-walker-opaque` nudge already makes by
-  staying silent on keywords). Only genuinely opaque compiled values
+  the rare registry-ref true positive. Only genuinely opaque compiled values
   (which Malli DOES honour `:sensitive?` on for validation, but the
   walker cannot see) fail closed.
 
   Used by the validation-failure redaction path: an opaque schema's
   validation failure redacts FAIL-CLOSED (the walker cannot prove the
   value is non-sensitive, and an opaque compiled schema may carry a
-  `{:sensitive? true}` slot Malli honoured for the failure), per EP-0015's
-  central projection / fail-closed expectation for schema-validation
-  egress. The supported route to make per-slot flags VISIBLE (and avoid
+  `{:sensitive? true}` slot Malli honoured for the failure). The supported
+  route to make per-slot flags visible (and avoid
   the coarse whole-value fail-closed redaction) is registering the vector
   form, per the `:rf.warning/schema-walker-opaque` nudge.
 
@@ -542,78 +405,17 @@
     :else true))
 
 (defn schema-has-opaque-child?
-  "True when `schema` is itself opaque (`schema-opaque?`) OR contains, at
-  any depth BENEATH the root, a nested opaque child — a compiled
-  `m/schema` value, map, or other form the pure-data walker cannot
-  introspect for per-slot props — reachable by descending through
-  vector-form Malli EDN structure.
+  "True when the root is opaque or a vector-form schema contains an opaque
+  descendant at any depth. Redaction and registration warnings use this
+  recursive predicate so a compiled child cannot hide inside a walkable root.
 
-  Per rf2-hi0tf8: `schema-opaque?` alone classifies only the ROOT form.
-  A schema whose root IS introspectable vector-form EDN can still embed
-  an opaque child at a deeper slot — e.g. `[:map [:token (m/schema
-  [:string {:sensitive? true}])]]` — and the per-slot `:sensitive?` /
-  `:large?` flags Malli honours inside that nested compiled value are
-  exactly as invisible to `walk-flagged-schema` as a top-level opaque
-  schema's flags are (the walk's terminal `:else acc` bailout silently
-  skips it, contributing NO declaration). Every fail-closed
-  redaction / warning gate that used to OR in `schema-opaque?` to catch a
-  top-level opaque schema must use this recursive predicate instead, or
-  the nested case leaks fail-OPEN while the equivalent top-level shape
-  redacts.
+  Root functions and symbols are opaque and fail closed. The same values used
+  as nested schema tails are considered flag-free because their enclosing
+  entry is the only place slot props can occur, and the walker inspects that
+  entry before its tail. Treating ordinary predicate tails as opaque would
+  conservatively redact every schema that uses Malli's predicate shorthand.
 
-  BARE FUNCTIONS (`pos-int?`, `string?`, a `(fn [v] …)` literal, …) AND
-  BARE SYMBOLS (a `'pos-int?` reader form — Malli resolves a symbol
-  schema to the named fn/var, e.g. an EDN-sourced fixture that cannot
-  embed a live fn literal) are opaque to `schema-opaque?` and stay
-  opaque HERE too when they are the schema being checked directly — a
-  bare fn/symbol used AS THE WHOLE registered `:schema` (no wrapper at
-  all, e.g. `re-frame.flows`' `{:schema (fn [v] …)}`) has no sibling
-  `{props}` position anywhere in its registration shape, so there is
-  genuinely no way it could carry a `:sensitive?`/`:large?` flag except
-  by wrapping (`[:fn {:sensitive? true} pred]`, itself vector-form and
-  walkable) — `schema-opaque?`'s fail-closed root treatment is correct
-  and stays UNCHANGED here
-  (`flows_schema_validation_test/non-conforming-output-emits-violation-
-  but-still-writes` pins exactly this).
-
-  A bare fn/symbol reached as a NESTED TAIL, however — `[:map [:n
-  pos-int?]]`, the idiomatic Malli shorthand exercised throughout this
-  codebase's own conformance corpus and machine/resource schemas — IS
-  the deliberate divergence: it cannot itself carry a `{props}` map, but
-  unlike the root case it DOES have a sibling props position one level
-  up — the entry `[:n {:sensitive? true} pos-int?]` — which
-  `walk-flagged-schema` ALREADY captures before ever looking at the
-  tail (same provably-flag-free reasoning as the walker's keyword
-  exception, rf2-ee38b.6). Without this root/nested split, every
-  ordinary `pos-int?`/`string?`-style leaf anywhere in a schema would
-  fail closed and over-redact (confirmed against the
-  `:machine/data-schema-rollback` conformance fixture, whose EDN-sourced
-  `[:map [:n pos-int?]]` data-schema — `pos-int?` reads as a bare SYMBOL
-  via `clojure.edn/read-string`, Malli resolves it at validate-time —
-  must NOT redact `{:n 0}`); collapsing the two positions the OTHER way
-  (treating a nested fn/symbol as opaque too) would have been the
-  simpler implementation but breaks that corpus fixture, and collapsing
-  them by making the ROOT case non-opaque instead would break the flows
-  fixture above — the split is load-bearing, not incidental.
-
-  Descends via `children-of` — the same child-extraction `walk-flagged-
-  schema` uses for every op category. This works uniformly without
-  per-op branching because both the outer `[op props? children...]` form
-  and every child ENTRY shape it produces (`:map`/`:multi`/`:orn`/`:altn`
-  `[k props? tail]` pairs, `:catn` `[name props? schema]` triples,
-  `:tuple`/`:cat`/`:vector`/`:set`/… bare positional children) share the
-  identical position-0-discriminator / optional-position-1-props-map /
-  trailing-payload convention — `children-of` always peels off exactly
-  the props-carrying wrapper and hands back the descendable tail(s),
-  regardless of which op produced the entry. A pure existence check
-  doesn't need per-op path bookkeeping the way the flag walk does.
-
-  Not memoised (unlike `extract-sensitive-paths-from-schema`): every call
-  site is a validation-FAILURE emit path, not the per-dispatch hot path,
-  so re-walking on each failure is the same cost profile as the sibling
-  `schema-has-sensitive?` / `schema-has-large?` checks already pay there.
-
-  Returns boolean. Pure; same input always produces the same output."
+  Returns boolean. Pure."
   [schema]
   (or (schema-opaque? schema)
       (and (vector? schema) (pos? (count schema))
@@ -621,9 +423,8 @@
 
 (defn- prefix?
   "True when `prefix` is a prefix of `path` (or equal). Both are
-  indexed vectors compared element-wise. Single-pass: counts each
-  input once, no lazy-seq allocation (rf2-ikxb5 — call-site is the
-  hot `schema-sensitive-at?` `some` over `(keys decls)`)."
+  indexed vectors compared element-wise. Single-pass with no lazy-seq
+  allocation."
   [prefix path]
   (let [pn (count prefix)]
     (and (<= pn (count path))
@@ -643,12 +444,10 @@
 ;; app-db slot. Aligning the two coordinate systems means dropping the
 ;; collection-navigation segment that these ops contribute. `:map-of`
 ;; descends into its VALUE schema (child index 1); the homogeneous
-;; positional ops descend into their single element schema. Per rf2-g5auo
-;; — without this alignment a `:sensitive?` slot nested in a collection
-;; leaks verbatim.
+;; positional ops descend into their single element schema. Without this
+;; alignment a sensitive slot nested in a collection would not match.
 ;;
-;; `:tuple` / `:cat` / `:catn` are the membership outliers (`:tuple`
-;; rf2-ss06u.4; `:cat`/`:catn` rf2-4q681i): they are kept in this set so
+;; `:tuple` / `:cat` / `:catn` are membership outliers: they are kept here so
 ;; `sanitize-sensitive-path` treats their integer index as a navigable
 ;; locator (KEEP, not scrub), but `align-in-path` handles them in their
 ;; OWN position-KEEPING branch ABOVE the generic index-drop branch — each
@@ -665,8 +464,7 @@
   indices / map-of keys) into the walker's index-free declaration-path
   coordinate system, walking `schema` in lockstep with `in-path`.
 
-  Per rf2-g5auo: the `:sensitive?` redaction lookup
-  (`schema-sensitive-at?`) compares `:in` against the walker's decl
+  `schema-sensitive-at?` compares `:in` against the walker's declaration
   paths via `prefix?`, but a collection index segment (`1` in
   `[1 :token]`, `\"a\"` in `[\"a\" :secret]`) blocks the element-wise
   match because the walker never emits index segments. Dropping each

--- a/implementation/schemas/test/re_frame/schemas_concurrency_stress_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_concurrency_stress_test.clj
@@ -1,9 +1,5 @@
 (ns re-frame.schemas-concurrency-stress-test
-  "Per rf2-utdxg — JVM concurrency stress coverage for the schemas
-  artefact's parallel-region invariants. Mirrors the rf2-1gpx8
-  (`machine_actor_concurrency_stress_test.clj`) and rf2-35rgj
-  (`concurrency_stress_test.clj`) shape but targets the schemas
-  artefact's three contention surfaces:
+  "JVM stress coverage for three schemas contention surfaces:
 
     1. **Hot-reload race** — N threads concurrently `reg-app-schemas`
        against a shared frame's per-frame side-table
@@ -34,8 +30,8 @@
        and every captured snapshot MUST be re-digestible without error
        (no torn-read fragment that breaks the serialisation pass).
 
-    3. **Sensitive-path resolution under contention** (rf2-ay2kp's
-       deep walker) — `extract-sensitive-paths-from-schema` walks a
+    3. **Sensitive-path resolution under contention** —
+       `extract-sensitive-paths-from-schema` walks a
        Malli EDN schema vector, threading an accumulator map through
        a recursive descent. The walker is pure — same input ALWAYS
        produces the same output — so under N concurrent calls against
@@ -45,7 +41,7 @@
        silently corrupt between threads; pure recursion with local
        accumulators does not).
 
-  Invariants asserted (mirrors the rf2-q4twq audit shape):
+  Invariants asserted:
 
     1. **No event dropped.** Every `reg-app-schemas` call from every
        thread lands in the final per-frame side-table — total entry
@@ -73,12 +69,11 @@
        `walk-cross-check` that re-runs the walker once on the main
        thread post-stress and asserts every parallel result equals it.
 
-  Threads start in lockstep via `CountDownLatch.countDown` — same
-  shape as rf2-35rgj scenario 2 / rf2-1gpx8 — so contention on the
+  Threads start in lockstep via `CountDownLatch.countDown` so contention on the
   shared `schemas-by-frame` atom is maximised.
 
-  Per-thread iters default to 5000 (rf2-ynk7 / rf2-35rgj / rf2-1gpx8
-  standard); env-overridable via `RF2_UTDXG_STRESS_ITERS`. Default
+  Per-thread iterations default to 5000 and are overridable via
+  `RF2_UTDXG_STRESS_ITERS`. Default
   thread count is 8 (matches the sibling concurrency stress files).
 
   CLJS is single-threaded; the JVM is the only runtime where the
@@ -88,14 +83,7 @@
             [re-frame.schemas :as schemas]
             [re-frame.schemas.digest :as digest]
             [re-frame.schemas.storage :as storage]
-            ;; Per rf2-t0hq the default validator routes through the
-            ;; late-bind hook `:schemas/malli-validate`, which the
-            ;; `re-frame.schemas.malli` adapter ns publishes at load
-            ;; time. The reset-runtime fixture restores the default
-            ;; validator between tests, but loading the adapter once
-            ;; here ensures the digest's `run-printer` path resolves
-            ;; the canonical Malli-EDN serialiser rather than the
-            ;; soft-pass fallback.
+            ;; Explicit test dependency; the facade also loads this adapter.
             [re-frame.schemas.malli]
             [re-frame.schemas.test-fixture :as tf])
   (:import [java.util.concurrent CountDownLatch]

--- a/implementation/schemas/test/re_frame/schemas_conformance_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_conformance_test.clj
@@ -1,6 +1,5 @@
 (ns re-frame.schemas-conformance-test
-  "Per rf2-2l08g (audit rf2-x8x4p §TE5). Drives every
-  `spec/conformance/fixtures/schema-*.edn` fixture (plus
+  "Drives every `spec/conformance/fixtures/schema-*.edn` fixture (plus
   `error-schema-failure.edn`) through the live runtime — `reg-app-schema`,
   `validate-app-schema!`, the `:schemas/validate-event!` /
   `:schemas/validate-sub!` late-bind hooks, the EP-0017 recordable-cofx
@@ -9,24 +8,8 @@
   the conformance-corpus's recorded outcome against what the artefact
   actually produces.
 
-  This is the schemas artefact's own conformance gate. Pre-rf2-2l08g
-  the schema fixtures rode the CORE artefact's
-  `re-frame.conformance-test` only (rf2-d0wem patterned for machines,
-  rf2-i3qc0 for ssr; analogous gap for schemas). Two drawbacks:
-
-    1. The gate ran at the wrong artefact. A schemas-touching PR
-       could break a schema fixture and only surface at core's gate —
-       at which point the failure has to be triaged across two
-       artefacts. Now it surfaces here, alongside the elision-toggle
-       and validator-table tests in the same gate.
-    2. The schemas artefact's per-artefact test suite did NOT
-       exercise the corpus that defines its public contract. The
-       unit tests in `schemas_test` cover the elision toggle and the
-       projector mapping; the corpus covers the dispatch-time
-       behaviour (event-payload rejection skips the handler, cofx
-       rejection skips the handler, sub-return rejection replaces
-       with default, app-db slice violation emits with :where :app-db).
-       Both surfaces need running for every schemas-touching change.
+  This is the schemas artefact's conformance gate. It keeps fixture failures
+  local to the artefact while unit tests cover elision and validator details.
 
   ## What this runner does
 
@@ -42,9 +25,8 @@
        (a re-use of core's pre-existing helpers; the interpreter is
        in `core/src` so the schemas artefact has it on the classpath
        without pulling core's test tree).
-    3. Wires `:fixture/registry :app-schemas` into `reg-app-schema`
-       (rf2-cq1ak — the fixture key is plural; app-db schemas are NOT
-       a registrar kind).
+    3. Wires `:fixture/registry :app-schemas` into `reg-app-schema`;
+       app-db schemas are not registrar entries.
     4. Registers the default frame with the fixture's
        `:fixture/frame-config` (e.g. `:initial-events [[:init]]`).
     5. Drives `:fixture/dispatches` through `rf/dispatch-sync`.
@@ -77,8 +59,7 @@
   fixtures (e.g. those that combine schemas with routing or SSR) and
   the FSM / ssr / routing / flows fixtures live at their respective
   artefact gates (or at core's full-corpus gate). Running them here
-  would be redundant and slow the gate; missing them would re-create
-  the gap rf2-2l08g closes."
+  would be redundant and slow the gate."
   (:require [clojure.test :refer [deftest is use-fixtures]]
             [clojure.edn :as edn]
             [clojure.java.io :as io]
@@ -87,13 +68,7 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.schemas :as schemas]
-            ;; Per rf2-v96fh (schema implies validation) requiring
-            ;; `re-frame.schemas` above already loads `re-frame.schemas.malli`
-            ;; for its ns-load side effect (publishes the validate/explain
-            ;; late-bind hooks), so the default validator is LIVE — the
-            ;; conformance corpus's Malli-backed outcomes hold without this
-            ;; explicit require. The require is kept as a harmless, explicit
-            ;; statement of the Malli dependency (rf2-a5kzs finding 4).
+            ;; Explicit test dependency; the facade also loads this adapter.
             [re-frame.schemas.malli]
             [re-frame.schemas.test-fixture :as tf]
             [re-frame.subs :as subs]

--- a/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
@@ -1,6 +1,6 @@
 (ns re-frame.schemas-sensitive-test
   "JVM tests for the `:sensitive?` redaction contract in schema-validation
-  error traces (rf2-kj51z).
+  error traces.
 
   Per Spec 010 §`:sensitive?` — privacy in schema-validation error
   traces, the validation hot path MUST consult the registered schema's
@@ -15,8 +15,7 @@
     2. The Malli explainer output (`:explain`) is redacted — it
        carries the failing value verbatim.
     3. The trace event's TOP-LEVEL `:sensitive?` field is stamped
-       `true` so consumers route on it. (Per Spec 009 §Trace-event
-       field: `:sensitive?` at the top level, rf2-isdwf — the
+       `true` so consumers route on it. (Per Spec 009 §Trace-event field, the
        schemas-side emit-site stamps `:tags :sensitive? true`; the
        runtime's `emit-error!` promotes it to the top-level slot per
        Spec 009 line 1175 'hoisted to top-level, not :tags'.)
@@ -33,34 +32,21 @@
        bearing combinators).
     2. **Redaction substitution** — direct invocation of
        `validate-app-schema!` / `validate-event!` /
-       `validate-sub!` against a `:sensitive?`-bearing schema
-       fires a trace with the redaction shape pinned. (The cofx surface's
-       redaction now rides the EP-0017 `:rf.error/cofx-value-invalid` path
-       in the core artefact — the injection-time `validate-cofx!` was
-       retired per rf2-nkf4l3.)
-    3. **Backward-compat** — non-sensitive validation failures emit
+       `validate-sub!` against a `:sensitive?`-bearing schema fires a trace
+       with the redaction shape pinned. Recordable cofx validation uses the
+       `:rf.error/cofx-value-invalid` path in core.
+    3. **Non-sensitive failures** — values and explanations emit
        unchanged (`:value`, `:explain` ride verbatim; no top-level
        `:sensitive?` stamp on the event)."
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.schemas :as schemas]
-            ;; Per rf2-v96fh (schema implies validation) requiring
-            ;; `re-frame.schemas` above already loads `re-frame.schemas.malli`
-            ;; for its ns-load side effect (publishes the validate/explain
-            ;; late-bind hooks the default validator routes through), so the
-            ;; validator is LIVE without this explicit require — kept as a
-            ;; harmless, explicit statement of the Malli dependency
-            ;; (rf2-a5kzs finding 4).
+            ;; Explicit test dependency; the facade also loads this adapter.
             [re-frame.schemas.malli]
-            ;; rf2-u9bjgr — compiled `m/schema` objects exercise the
-            ;; opaque-schema fail-closed redaction arm. Malli is on the
-            ;; schemas test classpath (the artefact deps on metosin/malli).
+            ;; Compiled schemas exercise fail-closed opaque handling.
             [malli.core :as m]
-            ;; rf2-jqx2at — direct unit tests on the internal `:path`-tag
-            ;; sanitiser (`sanitize-sensitive-path`) which is NOT re-exported
-            ;; through the `re-frame.schemas` facade (validate-app-schema!'s
-            ;; private redaction helper).
+            ;; White-box tests cover the internal path sanitizer.
             [re-frame.schemas.walker :as walker]
             [re-frame.schemas.test-fixture :as tf]
             [re-frame.test-support :refer [with-trace-recorder!]]))

--- a/implementation/schemas/test/re_frame/schemas_storage_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_storage_test.clj
@@ -1,16 +1,9 @@
 (ns re-frame.schemas-storage-test
-  "JVM tests for the slice-local storage / introspection surface
-  (rf2-yv62u).
+  "JVM tests for frame-local schema storage and introspection.
 
-  The audit (rf2-yv62u) flagged a coverage gap: while the validation
-  hot path is well-pinned, the per-frame storage / introspection
-  surface had no direct slice-local tests for `app-schema-meta-at`,
-  `frame-schema-entries`, or the `coerce-opts` bad-arg branch.
-  Drift in these introspection helpers would silently break pair-
-  tools, 10x panels, and the late-bind seam between schemas and
-  elision / epoch.
-
-  This file pins the storage / introspection contract."
+  Pins registration metadata, canonical path and frame targeting, bulk
+  validation, snapshot/restore, hot reload, and the `frame-schema-entries`
+  seam consumed by tools and sibling artefacts."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]

--- a/implementation/schemas/test/re_frame/schemas_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_test.clj
@@ -15,10 +15,8 @@
        §Default projector, the runtime ships a default projector mapping
        internal trace events to the locked four-key public-error shape
        (`:status :code :message :retryable?`). The schema-validation
-       failure category maps to a 400 :bad-request. The default-projector
-       fn proper isn't yet wired into the registrar (tracked as rf2-6528);
-       we test the *mapping contract* here as a pure fn so the contract
-       is locked even before the registry-side wiring lands.
+       failure category maps to a 400 :bad-request. These tests pin the pure
+       mapping contract independently of trace emission.
 
   These tests exercise schemas on the JVM via the plain-atom adapter —
   the conformance fixtures cover the dispatch-time integration; this
@@ -31,31 +29,13 @@
             [re-frame.late-bind]
             [re-frame.interop :as interop]
             [re-frame.schemas :as schemas]
-            ;; rf2-pk8ur public-surface printer tests need run-printer
-            ;; to assert the hot path observes the registered fn.
-            ;;
-            ;; rf2-btdpqn — the raw validator/explainer/printer atoms and the
-            ;; per-frame `schemas-by-frame` registry are no longer re-exported
-            ;; from the `re-frame.schemas` facade (rf2-l5r974 encapsulated-only
-            ;; posture). These are the schemas artefact's OWN white-box tests,
-            ;; which are EXEMPT from the public-facade ban: they reach the
-            ;; authoritative atoms through their HOME namespaces
-            ;; (`validator/validator-fn`, `storage/schemas-by-frame`) to assert
-            ;; the encapsulated setters/snapshot fns actually mutate the
-            ;; underlying state. That is legitimate internal testing, not
-            ;; public-facade use.
+            ;; White-box tests reach raw state through its owning namespace;
+            ;; callers outside this artefact use the encapsulated facade.
             [re-frame.schemas.validator :as validator]
             [re-frame.schemas.storage :as storage]
-            ;; Per rf2-t0hq the default validator routes through the
-            ;; late-bind hook `:schemas/malli-validate`, which the
-            ;; `re-frame.schemas.malli` adapter ns publishes at load
-            ;; time. Per rf2-qyfie the JVM `requiring-resolve`
-            ;; fallback was removed — the require is now the canonical
-            ;; opt-in on both runtimes; without it the default
-            ;; validator soft-passes (Spec 010 §Recommended soft-pass).
+            ;; Explicit test dependency; the facade also loads this adapter.
             [re-frame.schemas.malli]
-            ;; rf2-rbbmt dedup D3 — single-source the empty-set digest
-            ;; literal from the parity fixtures rather than re-pinning it.
+            ;; Reuse the shared empty-set digest fixture.
             [re-frame.schemas.digest-parity-fixtures :as digest-fixtures]
             [re-frame.schemas.test-fixture :as tf]
             [re-frame.registrar :as registrar]


### PR DESCRIPTION
## Summary

- replace tracker and migration narration with current schemas contracts
- clarify frame-local storage, optional artefact loading, validation failure isolation, and schema classification ownership
- correct digest fingerprint, validator bundle, absent-hook, and opaque-schema explanations
- tighten test and artefact comments without changing executable behavior

## Validation

- `clojure -M:test` from `implementation/schemas`: 341 tests, 18,950 assertions, 0 failures
- `npm run test:cljs`: 8,466 tests, 39,175 assertions, 0 failures
- `npm run test:browser-schemas-boundary-prod`: 7 tests, 9 assertions, 0 failures
- `npm run test:elision`: 47/47 production sentinels absent and 47/47 control sentinels present
- `clj-kondo --fail-level error --lint schemas`: 0 errors
- `clojure -M:splint --fail-on-errors schemas`: 0 errors
- `npm run test:schemas-bundle`: builds and schema-implies-validation comparison pass; existing size budget fails because both probes are 115.7 KB against the 100 KB threshold

Bead: rf2-qt5d76
