### PR TITLE
docs(routing): align explanations with current contracts (rf2-5cv2rs)

### DIFF
--- a/implementation/routing/deps.edn
+++ b/implementation/routing/deps.edn
@@ -1,24 +1,22 @@
-;; day8/re-frame2-routing — routing artefact (rf2-k682,
-;; third per-feature split per rf2-5vjj Strategy B).
+;; day8/re-frame2-routing is the optional routing artefact.
 ;;
 ;; Per Spec 012 §Routing the route grammar (`reg-route`,
 ;; `:rf.route/navigate`, `:rf.route/transitioned`, `:rf.route/url-requested`,
 ;; `:rf.route/handle-url-change`, `:rf.route/continue` /
 ;; `:rf.route/cancel`, the `:rf.nav/push-url` / `:rf.nav/replace-url` /
 ;; `:rf.nav/scroll` fxs, `match-url` / `route-url`, the `:rf/route` /
-;; `:rf.route/{id,params,query,transition,error}` framework subs, and
-;; and the per-frame routing runtime-db keys — the durable route slice
-;; `:current` (subscribable via `:rf/route`) and the
-;; local-subscribable `:pending-navigation` (via `:rf/pending-navigation`),
-;; both under `[:rf.runtime/routing ...]`. (Scroll positions and the
-;; nav-token / pending-nav allocator counters are NOT runtime-db state —
-;; they live in module-level host-side transient caches keyed by frame-id;
-;; see `re-frame.routing.nav-counters/routing-state-classification`,
-;; rf2-1hncp2 / rf2-oosjmh.) (rf2-3ib8h, rf2-eguy4)) ships as a separate Maven
-;; artefact so apps that don't register any routes don't drag the
-;; namespace, the route-rank / pattern-compile / nav-token machinery,
+;; `:rf.route/{id,params,query,transition,error,fragment,chain}` and
+;; `:rf/pending-navigation` framework subs, and routing runtime-db state)
+;; ships as a separate Maven artefact so apps that don't register routes don't
+;; drag in the namespace, route-rank / pattern-compile / nav-token machinery,
 ;; or any of the `:rf.route/*` and `:rf.nav/*` trace strings onto the
 ;; classpath.
+;;
+;; Runtime routing state is rooted at `[:rf.runtime/routing]`. It contains
+;; `:current`, `:pending-navigation` when a guard blocks, and may contain
+;; resource-integration bookkeeping while the resources artefact is loaded.
+;; Scroll positions and allocator high-water marks are host-side transient
+;; caches keyed by frame id, not runtime-db state.
 ;;
 ;; Consumers add this artefact alongside the core artefact:
 ;;
@@ -31,8 +29,7 @@
 ;; hooks, the `:rf.route/*` events, the `:rf.nav/*` reserved fxs, and
 ;; the `:rf/route` reg-sub family.
 ;;
-;; Per Spec 006 §Adapter shipping convention (and the
-;; rf2-p7va extension to per-feature splits): this artefact depends on
+;; Per Spec 006 §Adapter shipping convention, this artefact depends on
 ;; core; core never depends on this artefact. The cross-references
 ;; from core to routing (e.g. `re-frame.core`'s `reg-route` /
 ;; `match-url` / `route-url` re-exports, the `:rf/route` reg-sub) flow
@@ -55,21 +52,20 @@
          :extra-deps  {day8/re-frame2-schemas    {:local/root "../schemas"}
                        day8/re-frame2-flows      {:local/root "../flows"}
                        day8/re-frame2-ssr        {:local/root "../ssr"}
-                       ;; rf2-try1x — silent-on-success reporter.
+                       ;; Silent-on-success test reporter.
                        day8/re-frame2-test-quiet {:local/root "../test-quiet"}
                        io.github.cognitect-labs/test-runner
                        {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
-         ;; rf2-bv2qqm — the default PR/local gate EXCLUDES the heavy
+         ;; The default PR/local gate excludes the heavy
          ;; `^:stress` tests in `routing_concurrency_stress_test`
          ;; (5000-iter × 8-thread cross-frame nav). These were tagged
-         ;; `^:stress` per rf2-q4twq but the exclude was never wired, so
-         ;; they ran on every PR. The runner passes `-e` through to
+         ;; `^:stress`; the runner passes `-e` through to
          ;; cognitect-test-runner verbatim. Coverage is NOT lost: the
          ;; `:slow-test` alias below runs them, invoked by the nightly
          ;; `expensive-tests.yml` job + `scripts/test-rigorous-local.sh`.
          :main-opts   ["-m" "re-frame.test-quiet.runner" "-e" ":slow" "-e" ":stress"]}
 
-  ;; rf2-bv2qqm — nightly/rigorous slow-test gate. INCLUDES ONLY the
+  ;; Nightly/rigorous gate. Includes only the
   ;; `^:slow` / `^:stress` tests, so `:test` + `:slow-test` together cover
   ;; every test once.
   :slow-test
@@ -82,7 +78,7 @@
                  {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
    :main-opts   ["-m" "re-frame.test-quiet.runner" "-i" ":slow" "-i" ":stress"]}
 
-  ;; Clojars deploy (rf2-r382). Modeled on re-frame v1's release flow.
+  ;; Clojars deploy. Modeled on re-frame v1's release flow.
   ;; The release workflow runs `clojure -M:clein deploy` from this
   ;; artefact's directory, which builds pom + jar and pushes to Clojars.
   ;;

--- a/implementation/routing/src/re_frame/routing.cljc
+++ b/implementation/routing/src/re_frame/routing.cljc
@@ -6,27 +6,24 @@
   `[:rf.runtime/routing :current]` carries
   `{:route-id :params :query :fragment :transition :error :nav-token}`.
 
-  This namespace is the **public boot point and façade** for the
-  routing artefact (per rf2-k682 + the skill docs): apps boot the
-  artefact with `(:require [re-frame.routing])`. Doing so transitively
-  loads every concern sibling under `re-frame.routing.*` (each owns
+  This namespace is the public boot point and facade for the routing
+  artefact: apps load it with `(:require [re-frame.routing])`. Doing so
+  transitively loads every runtime concern under `re-frame.routing.*` (each owns
   one cohesive concern, see below) and runs the registrations
   (`reg-event` / `reg-fx` / `reg-sub` / `add-registration-hook!` /
   `register-error-listener!` / `reg-view*`) at the bottom of this file.
 
-  The registrations live here (not in the siblings) so a
+  Registrations live here rather than in the concern namespaces so a
   `(require 're-frame.routing :reload)` on a fresh registrar
-  (`clear-all!` test fixture) re-wires every handler — the long-
-  established consumer-test pattern. Siblings expose handler fns +
+  (`clear-all!` test fixture) re-wires every handler. Siblings expose handler fns +
   metadata; this façade composes them.
 
-  Per the rf2-2yabr cohesion split, the implementation lives in
-  per-concern siblings:
+  The implementation lives in per-concern namespaces:
 
   - `re-frame.routing.url`            — URL %-encode / %-decode primitives
   - `re-frame.routing.match`          — pattern parsing + match-against
   - `re-frame.routing.registry`       — reg-route + match-url + route-url + route-table cache
-  - `re-frame.routing.classification` — EP-0025 route data classification (projection-relative :sensitive/:large, lowered into the per-frame elision registry at activation)
+  - `re-frame.routing.classification` — projection-relative route data classification
   - `re-frame.routing.scroll`         — scroll-restoration helpers + :rf.nav/scroll fxs
   - `re-frame.routing.events`         — shared nav-event helpers + :rf.route.internal/settle-transition
   - `re-frame.routing.plan`           — pure pre-commit navigation-planning seam (fragment/not-found/classification/telemetry/scroll) shared by both nav entry points
@@ -37,7 +34,7 @@
   - `re-frame.routing.url-change`     — :rf.route/transitioned + :rf.route/handle-url-change
   - `re-frame.routing.nav-fx`         — :rf.nav/push-url + :rf.nav/replace-url + url-owner-frame-id
   - `re-frame.routing.url-bound`      — :url-bound? exclusivity registration hook
-  - `re-frame.routing.history`        — popstate listener install/remove (driven automatically by the :url-bound? frame lifecycle, rf2-g8pbwg) + current-url
+  - `re-frame.routing.history`        — strategy listener lifecycle + current-url
   - `re-frame.routing.subs`           — framework-shipped subs over the slice
   - `re-frame.routing.link`           — :route/link registered view"
   (:require [re-frame.cofx :as cofx]
@@ -64,24 +61,14 @@
             [re-frame.routing.subs :as routing-subs]
             [re-frame.routing.url-bound :as url-bound]
             [re-frame.routing.url-change :as url-change]
-            ;; EP-0014 slice-5 (rf2-eiiifu): the JVM-only require of the
-            ;; routing tooling sibling that backs the `route-algebra-view` /
-            ;; `route-slice-algebra-view` aliases below. CLJS deliberately
-            ;; OMITS this require so a CLJS app that loads the routing
-            ;; artefact but never attaches a tool DCEs the tooling body
-            ;; wholesale — the facade never reaches it. JVM has no bundle to
-            ;; protect; the alias gives JVM tools / conformance fixtures the
-            ;; ergonomic `re-frame.routing/route-algebra-view` shape. Mirrors
-            ;; the `re-frame.flows` → `re-frame.flows.tooling` JVM-only
-            ;; require (rf2-s8w3nw slice-3) and `re-frame.subs` →
-            ;; `re-frame.subs.tooling` (rf2-bmzq0 / rf2-gge6mf slice-2).
+            ;; The JVM facade provides convenience aliases for tooling. CLJS
+            ;; consumers require the tooling namespace directly, keeping it
+            ;; out of applications that load routing but attach no tool.
             #?@(:clj  [[re-frame.routing.tooling :as routing-tooling]])
             #?@(:cljs [[re-frame.views :as views]])))
 
 ;; ---- public API re-exports ----------------------------------------------
-;; These deliberately match the pre-split surface so consumers
-;; (tests, conformance, examples, docs) continue to reach
-;; `routing/reg-route`, `routing/match-url`, etc. without import churn.
+;; The facade is the application-facing home for these operations.
 
 ;; Registry
 (def reg-route                  registry/reg-route)
@@ -91,15 +78,12 @@
 (def malformed-url?             registry/malformed-url?)
 (def reset-counters!            registry/reset-counters!)
 
-;; Static-registry introspection — the `<thing>-ids` + `<thing>-meta`
-;; enumerate pair every sibling registry carries (`resource-ids` /
-;; `resource-meta`, machines `machines` / `machine-meta`). Owned-ns surface
-;; only (no `re-frame.core` re-export), mirroring `route-algebra-view`'s
-;; disposition + the machines introspection home.
+;; Static-registry introspection. These are owned-namespace operations and
+;; are not re-exported from `re-frame.core`.
 (def route-ids                  registry/route-ids)
 (def route-meta                 registry/route-meta)
 
-;; Scroll (rf2-1hncp2: host-side transient cache, not runtime-db)
+;; Scroll positions are host-side transient state, not runtime-db state.
 (def scroll-positions-cap       scroll/scroll-positions-cap)
 (def lookup-scroll-position     scroll/lookup-scroll-position)
 (def save-scroll-position       scroll/save-scroll-position)
@@ -107,8 +91,8 @@
 (def save-scroll-position!      scroll/save-scroll-position!)
 (def reset-scroll-cache!        scroll/reset-cache!)
 
-;; Nav counters (rf2-oosjmh: host-side transient high-water marks, not
-;; runtime-db — so an epoch restore cannot rewind + recycle a token)
+;; Allocator high-water marks are host-side transient state so restoring an
+;; epoch cannot rewind and recycle a live token.
 (def counter-snapshot           nav-counters/counter-snapshot)
 (def routing-state-classification nav-counters/routing-state-classification)
 (def reset-nav-counters!        nav-counters/reset-cache!)
@@ -116,27 +100,9 @@
 ;; Subs
 (def route-sub-fn               routing-subs/route-sub-fn)
 
-;; The `sub-route` / `sub-pending-navigation` reactive-read sugar fns that
-;; once lived here were REMOVED (rf2-il99l3, reversing rf2-2cmcas). The route
-;; and pending-navigation reads are subscription VECTORS —
-;; `(subscribe [:rf/route])` / `(subscribe [:rf/pending-navigation])` — one
-;; read grammar; `subscribe`'s own frame-first arity carries the `{:frame …}`
-;; target for a non-default url-bound frame.
-
-;; EP-0014 slice-5 (rf2-eiiifu): the derivation/process algebra view of
-;; registered routes (`route-algebra-view`, static) and a frame's live route
-;; slice (`route-slice-algebra-view`, live). JVM-runnable (the route
-;; registry is partition-agnostic registration metadata; the live read is a
-;; single runtime-db container deref), so a JVM convenience alias lets tools /
-;; conformance fixtures reach them as `re-frame.routing/route-algebra-view` /
-;; `re-frame.routing/route-slice-algebra-view` without naming the sibling. The
-;; bodies live in `re-frame.routing.tooling` so a CLJS app that loads the
-;; routing artefact but attaches no tool DCEs them (the CLJS facade never
-;; `:require`s the tooling sibling — the require above is `#?@(:clj ...)`-
-;; gated). CLJS consumers (Xray + conformance) call
-;; `re-frame.routing.tooling/<name>` directly. No `re-frame.core` facade
-;; export (EP-0014 issue-1 disposition). Mirrors the
-;; `re-frame.flows/flow-algebra-view` JVM alias (slice-3).
+;; JVM tools get facade aliases for the static route algebra and a frame's
+;; live route-slice algebra. CLJS tools require `re-frame.routing.tooling`
+;; directly so production routing does not reach the tooling namespace.
 #?(:clj
    (do
      (def route-algebra-view       routing-tooling/route-algebra-view)
@@ -145,38 +111,28 @@
 ;; URL-owner resolution
 (def url-owner-frame-id         nav-fx/url-owner-frame-id)
 
-;; rf2-3l7xxz: the URL-ownership claim-order state (a process-global vector
-;; recording, in claim order, which frames carry :url-bound? true). Reset
-;; between tests so a prior test's claim cannot leak; the incumbent-protecting
-;; resolution in `url-owner-frame-id` reads it.
+;; Reset the process-global URL claim order between tests.
 (def reset-url-claims!          nav-fx/reset-url-claims!)
 
-;; URL strategies (rf2-aerrz5). The two shipped frame-level `:url-strategy`
+;; The two shipped frame-level `:url-strategy`
 ;; maps — `history-url-strategy` (default, path-form) + `hash-url-strategy`
-;; (`#`-prefixed) — plus the `with-base-path` combinator (rf2-g8pbwg) that
+;; (`#`-prefixed) — plus the `with-base-path` combinator that
 ;; wraps either one for an app deployed under a sub-path. Declared on the
 ;; URL-owning frame:
 ;;   (rf/reg-frame :app {:url-bound? true :url-strategy routing/hash-url-strategy})
 ;;   (rf/reg-frame :app {:url-bound? true
 ;;                       :url-strategy (routing/with-base-path
 ;;                                       routing/history-url-strategy "/realworld")})
-;; Routing-façade home (NOT re-frame.core) so a non-routing app's production
-;; bundle carries no strategy code — the routing bundle-isolation invariant.
-;; Per Spec 012 §URL strategies.
+;; These live on the routing facade, not `re-frame.core`; bundle-isolation
+;; tests enforce that applications which do not load routing carry none of
+;; the routing implementation. Per Spec 012 §URL strategies.
 (def history-url-strategy       strategy/history-url-strategy)
 (def hash-url-strategy          strategy/hash-url-strategy)
 (def with-base-path             strategy/with-base-path)
 
-;; Browser URL-change listener. rf2-g8pbwg: the imperative
-;; `install-url-listener!` / `remove-url-listener!` exports (and their
-;; retired `install-history-listener!` / `remove-history-listener!` aliases)
-;; are GONE — a `:url-bound? true` frame installs its strategy listener on
-;; create and removes it on destroy, automatically (see
-;; `re-frame.routing.history`'s ns docstring THE FOLD note and the
-;; `:routing/on-frame-registered!` / `:routing/on-frame-destroyed!` wiring
-;; below). `current-url` remains the one query-shaped export — reading the
-;; current browser URL is a legitimate direct call, not a coupled step of
-;; the URL-binding declaration.
+;; Listener installation/removal follows the `:url-bound?` frame lifecycle.
+;; `current-url` is the public query for the history strategy's current
+;; path-form URL.
 (def current-url                history/current-url)
 
 ;; Route-link render fns
@@ -188,22 +144,14 @@
 ;; `(require 're-frame.routing :reload)` to recover from `clear-all!`
 ;; re-run every wire here.
 
-;; EP-0001 (rf2-3939ig) — the general framework-authority minting key.
-;; Routing is one of the legitimate runtime-db writers Spec 002 §Write
-;; authority names: every nav / url-change / can-leave / settle handler
-;; below reads + returns the reserved `:rf.db/runtime` route slice. Stamping
-;; this reserved registration-meta key (Conventions §Reserved registration
-;; meta) mints framework-write authority so the runtime's
-;; `:rf.warning/app-handler-runtime-effect` ownership diagnostic recognises
-;; these as in-bounds writers (it is reserved BY CONVENTION, Mike ruling #4 —
-;; not a capability gate). Applied uniformly to every framework-shipped
-;; routing event handler so a new routing handler that touches the slice
-;; inherits authority by sitting in this façade.
+;; Routing handlers are legitimate runtime-db writers. This reserved
+;; registration marker keeps the app-handler ownership diagnostic from
+;; classifying their `:rf.db/runtime` effects as application writes.
 (def ^:private framework-authority-meta {:rf/framework-authority? true})
 
 ;; :rf.route.internal/settle-transition — Spec 012 §Per-route data
-;; loading §2 FIFO settle. EP-0001 (rf2-vzld77): the route slice is durable
-;; runtime-db state, so this is a runtime-db `reg-event` handler.
+;; loading §2 FIFO settle. The route slice is runtime-db state, so this is a
+;; runtime-db `reg-event` handler.
 (events/reg-event :rf.route.internal/settle-transition
                      framework-authority-meta
                      routing-events/settle-transition-handler)
@@ -221,21 +169,10 @@
   :rf.route/on-match-error-trap
   on-match-error/on-match-error-listener)
 
-;; :rf.route/nav-allocation + :rf.route/pending-nav-allocation cofx +
-;; :rf.route/commit-nav-counter fx — Spec 012 §Navigation tokens (rf2-oosjmh
-;; / rf2-vcop6y). The host-side nav-token / pending-nav allocators are minted
-;; through TWO RECORDABLE generator-backed coeffects (one per allocator): the
-;; generator mints the next id from the host high-water snapshot (READ) and
-;; the cofx machinery RECORDS the allocation `{:token/:id .. :counter ..}`
-;; onto the causal token, so replay re-presents the SAME id verbatim
-;; (rf2-vcop6y replay-determinism fix; the retired ambient
-;; `:rf.route/nav-counters` cofx was never recorded → replay re-minted
-;; different ids). The fx records the new high-water mark into the host cache
-;; with a `max` install (WRITE) so a restore/replay re-establishes the host
-;; high-water from the recorded `:counter` and can never rewind the allocator.
-;; The counters are host-side TRANSIENT state (`re-frame.routing.nav-counters`)
-;; so an epoch restore cannot rewind them and recycle a token (rf2-oosjmh).
-;; Registered in the façade so a `:reload` re-wires them on a fresh registrar.
+;; The two recordable allocation coeffects read host-side high-water marks and
+;; record the selected id on the causal token. The effect installs the
+;; recorded counter with `max`, preserving replay identity without allowing a
+;; restore to rewind an allocator. See Spec 012 §Navigation tokens.
 (cofx/reg-cofx :rf.route/nav-allocation
                nav-counters/nav-allocation-cofx-meta
                nav-counters/nav-allocation-cofx)
@@ -246,14 +183,10 @@
            nav-counters/commit-nav-counter-meta
            nav-counters/commit-nav-counter-handler)
 
-;; EP-0017 / rf2-vcop6y: each nav entry point DECLARES the recordable
-;; allocation cofx it consumes via `:rf.cofx/requires`. The generator runs at
-;; processing-start (router `:live` policy), mints from the host snapshot, and
-;; the value is recorded onto the token; strict replay re-presents it (and
-;; FAILS on a missing recorded allocation). A two-way nav handler (block vs
-;; commit) declares BOTH allocations — both generate eagerly, the not-taken
-;; branch's allocation is recorded-but-unused (harmless — the counters are
-;; monotone never-recycle allocators, gaps are a documented non-concern).
+;; Two-way handlers declare both recordable allocations. They are generated
+;; eagerly at processing start; the untaken branch is recorded but not
+;; committed to its host high-water mark. Gaps are harmless because allocator
+;; ids are monotone and never recycled.
 (def ^:private nav-commit-meta
   ;; navigate / transitioned / handle-url-change can BLOCK (pending-nav id)
   ;; OR COMMIT (nav-token) — declare both recordable allocations.
@@ -261,9 +194,8 @@
          :rf.cofx/requires [:rf.route/nav-allocation
                             :rf.route/pending-nav-allocation]))
 (def ^:private url-requested-meta
-  ;; :rf.route/url-requested only ever mints a pending-nav id (on a block); the
-  ;; forward push synthesises :rf.route/transitioned, which mints its own
-  ;; nav-token. Declare only the pending-nav allocation.
+  ;; A URL request can block here; its transitioned event owns any eventual
+  ;; nav-token allocation.
   (assoc framework-authority-meta
          :rf.cofx/requires [:rf.route/pending-nav-allocation]))
 
@@ -276,30 +208,16 @@
 (events/reg-event :rf.route/url-requested
                      url-requested-meta
                      can-leave/url-requested-handler)
-;; EP-0015 (rf2-jfaucw): the runtime dispatches `[:rf.route/navigation-blocked
-;; pending-nav]` on every block, carrying the pending-nav map as the event
-;; arg. That map carries route CARRIERS — `:requested-url` (a target URL with
-;; potential `?token=…` / `#access_token=…`) and `:requested-by-event` (the
-;; full original nav event vector, whose args can carry params/query secrets).
-;; The dispatched-event TRACE (`:rf.event/dispatched` `:rf.event/v`, and the
-;; bare `:event` slot on any error trace) is an egress surface the
-;; per-registration marks chokepoint walks: declare those two carrier slots
-;; `:sensitive` (paths rooted at the arg-map — the pending-nav map) so
-;; `re-frame.classification/project-trace-event` redacts them to `:rf/redacted` on the
-;; trace egress copy. The handler / pending-nav sub still see the raw map
-;; in-process (marks touch only the trace tags), so continue/cancel resume
-;; behaviour is unaffected; the durable runtime-db slot's off-box epoch egress
-;; is already fail-closed by the redact-whole-runtime-db default (ruling #14).
+;; The pending map carries the requested URL and original event. Mark those
+;; argument paths sensitive so dispatched-event trace copies redact their
+;; carrier values; handlers and the pending-navigation sub still receive the
+;; original in-process map.
 (events/reg-event :rf.route/navigation-blocked
                      (assoc framework-authority-meta
                             :sensitive [[:requested-url] [:requested-by-event]])
                      can-leave/navigation-blocked-handler)
-;; rf2-p69yaz point 5: `:rf.route/entry-blocked` is the ENTER-block mirror
-;; of `:rf.route/navigation-blocked` — the runtime dispatches it (carrying
-;; the pending-nav map) when a target route's `:can-enter` guard rejects.
-;; It carries the SAME route carriers (`:requested-url`, `:requested-by-event`),
-;; so it declares the SAME `:sensitive` slots so `project-trace-event`
-;; redacts them on the trace egress copy (EP-0015 rf2-jfaucw).
+;; Enter blocks carry the same pending-map carriers and therefore use the
+;; same trace classification.
 (events/reg-event :rf.route/entry-blocked
                      (assoc framework-authority-meta
                             :sensitive [[:requested-url] [:requested-by-event]])
@@ -375,60 +293,21 @@
 (fx/reg-fx :rf.nav/capture-scroll scroll/capture-scroll-meta scroll/capture-scroll-handler)
 (fx/reg-fx :rf.nav/scroll         scroll/scroll-fx-meta      scroll/scroll-fx-handler)
 
-;; :url-bound? exclusivity check — Spec 012 §Multi-frame routing
-;; ("Only one frame can own the URL at a time").
-;;
-;; rf2-25i7r7 (finding 1 — reload idempotence): the registrar's
-;; `add-registration-hook!` appends to a process-`defonce` vector with
-;; no dedupe (re-frame.registrar §registration-hooks), and `clear-all!`
-;; does NOT clear that vector. So the unconditional top-level call this
-;; replaced stacked one identical hook per `(require 're-frame.routing
-;; :reload)` — the long-established `clear-all!` test-fixture recovery
-;; pattern and any REPL hot-reload. N stacked copies meant a single
-;; duplicate URL binding emitted N `:rf.error/duplicate-url-binding`
-;; diagnostics, and every `:frame` registration paid N× the hook work.
-;;
-;; The `defonce` guard makes installation idempotent across reloads:
-;; `:reload` re-runs every top-level form, but a `defonce` whose var
-;; already carries a root binding is a no-op, so the hook is installed
-;; exactly once per process. The registrar's hooks vector is itself
-;; `defonce` and survives `clear-all!`, so the single installed hook
-;; stays live across the fixture's `clear-all!` + `:reload` recovery —
-;; no re-install is needed. Mirrors the flows registry's
-;; `_hot-reload-hook` defonce wrapper over `add-replacement-hook!`
-;; (re-frame.flows.registry, rf2-94ol5) — the same "install a
-;; registrar hook once, survive hot-reload" pattern.
-;; rf2-68k8as — `add-registration-hook!` is an append-only FUTURE observer; it
-;; does NOT replay existing `:frame` registrations (re-frame.registrar
-;; §registration-hooks). So a frame that claimed `:url-bound? true` BEFORE this
-;; namespace loaded never recorded a claim in `url-claim-order`, leaving
-;; `url-owner-frame-id` to its claim-free fallback — which (before rf2-68k8as)
-;; id-sorted and let a later, alphabetically-earlier duplicate STEAL the URL
-;; from the true first-claimant (Spec 012 §Multi-frame routing forbids exactly
-;; this). After installing the hook we therefore reconcile the frames already
-;; in the registry: seed the unambiguous incumbent, or fail closed (no claim,
-;; one diagnostic per extra binding) when multiple url-bound frames pre-exist
-;; and claim order is unrecoverable from the unordered registrar map.
-;;
-;; The reconcile runs on every façade `:reload` (it is NOT inside the
-;; `defonce`, since the registrar's hooks vector + the `url-claim-order` atom
-;; survive `clear-all!` but a test's `reset-url-claims!` empties the claim
-;; vector — re-seeding the incumbent after reset keeps the resolver correct).
-;; It is idempotent: `record-url-claim!` appends-iff-absent and the
-;; multi-binding branch records no claim, so a redundant call is a no-op.
+;; The registration-hook collection survives reload, so install this hook
+;; once. Registration hooks observe only future registrations; reconcile the
+;; current frame registry on every facade load to seed an unambiguous existing
+;; owner. Reconciliation is idempotent and fails closed when multiple
+;; pre-existing bindings have no recoverable claim order.
 (defonce ^:private _url-bound-exclusivity-hook
   (registrar/add-registration-hook! url-bound/check-url-bound-exclusivity!))
 (url-bound/reconcile-existing-url-bindings!)
 
-;; Framework-shipped subs over the route slice — Spec 012.
-;; EP-0001 (rf2-vzld77): the route slice is durable framework runtime-db
-;; state, so `:rf/route` and `:rf/pending-navigation` are `:runtime-db` subs
-;; (read the runtime-db projection); the `:rf.route/*` derived subs chain off
-;; `:rf/route` unchanged.
+;; Framework-shipped subs over routing runtime-db state. The derived
+;; `:rf.route/*` subscriptions chain from `:rf/route`.
 (subs/reg-runtime-sub :rf/route
-  {:doc "Subscribe to the current route slice `{:route-id :params :query :transition :error :fragment :nav-token}`. Layer-1-shaped read of the route slice at `[:rf.runtime/routing :current]` in the runtime-db partition — the only sibling runtime-db key is `:pending-navigation` (its own `:rf/pending-navigation` sub), so the slice carries only the published shape and the sub returns it directly. The nav-token / pending-nav counters are NOT runtime-db siblings — like scroll positions they live in host-side transient caches (rf2-oosjmh / rf2-1hncp2). Per Spec 012."}
+  {:doc "Subscribe to the current route slice `{:route-id :params :query :transition :error :fragment :nav-token}` at `[:rf.runtime/routing :current]`. The sub returns that published map directly; sibling routing state such as `:pending-navigation` and optional resource-blocking bookkeeping is not included. Allocator counters and scroll positions are host-side transient caches, not runtime-db siblings. Per Spec 012."}
   route-sub-fn)
-(subs/reg-sub :rf.route/id   ;; sub-id stays `:rf.route/id`; reads the slice's `:route-id` key (rf2-3a5nk7)
+(subs/reg-sub :rf.route/id
   {:doc "Subscribe to the current route's id keyword (the slice's `:route-id` key). Per Spec 012."}
   :<- [:rf/route] (fn [route _] (:route-id route)))
 (subs/reg-sub :rf.route/params
@@ -475,75 +354,40 @@
                                :handler-fn link/route-link-render-ssr)))
 
 ;; ---- late-bind hook registration ------------------------------------------
-;; Per rf2-k682. `re-frame.core` MUST NOT `:require [re-frame.routing]` —
-;; the artefact is optional. Public-API re-exports are published through
-;; the late-bind table; consumers without the artefact see the hooks
-;; unregistered and the active surfaces throw cleanly.
+;; Core must not require this optional artefact. Late-bound hooks publish the
+;; integration points without reversing that dependency.
 
 (late-bind/set-fn! :routing/reg-route          reg-route)
 (late-bind/set-fn! :routing/clear-route        clear-route)
 (late-bind/set-fn! :routing/match-url          match-url)
 (late-bind/set-fn! :routing/route-url          route-url)
 (late-bind/set-fn! :routing/reset-counters!    reset-counters!)
-;; rf2-oosjmh: drop the host-side nav-token / pending-nav counter
-;; high-water marks. Published as a reset hook so the shared CLJS
-;; `make-reset-runtime-fixture` reset-hooks table clears them per test
-;; (they are host-side transient state now, not cleared by the `frames`
-;; reset). No-op when re-frame.routing is absent (the artefact is optional).
+;; Reset hooks clear host-side routing state that a raw frame-container reset
+;; cannot reach.
 (late-bind/set-fn! :routing/reset-nav-counters! reset-nav-counters!)
-;; rf2-3l7xxz: drop the process-global URL-ownership claim-order vector
-;; (re-frame.routing.nav-fx/url-claim-order). Like the nav-counters it is
-;; process-global state not touched by a runtime/frames reset, so the shared
-;; CLJS make-reset-runtime-fixture reset-hooks table fires this per test so a
-;; prior test's URL-ownership claim cannot leak into the next (test isolation).
-;; No-op when re-frame.routing is absent (the artefact is optional).
 (late-bind/set-fn! :routing/reset-url-claims!  reset-url-claims!)
 (late-bind/set-fn! :routing/route-sub-fn       route-sub-fn)
 (late-bind/set-fn! :routing/current-url        current-url)
 
-;; rf2-mtzv5m: route-sub egress projection. A route's projection-relative
-;; `:sensitive` / `:large` classification is lowered (re-rooted under
-;; `[:rf.runtime/routing :current …]`) into the per-frame elision registry at
-;; activation, but the BARE route slice the `:rf/route` / `:rf.route/query` /
-;; `:rf.route/params` subs return is walked at the WHOLE-VALUE root, so the
-;; re-rooted absolute decls never match and a classified query / param shipped
-;; RAW on the trace / off-box read surfaces. Publish the seed-path resolver +
-;; the projector so (a) the core wire walker re-seeds a route sub value at its
-;; runtime-db storage position (via `elide-wire-value`'s `:query-v` opt — the
-;; chokepoint the MCP read-sub / list-subscriptions / snapshot / Xray surfaces
-;; share) and (b) the trace `project-sub-tags` chokepoint redacts the
-;; `:rf.sub/run` `:rf.sub/value` / `:rf.sub/prev-value` slots. Core consults
-;; the hook keys with NO static `:require` on routing (rf2-k682); absent the
-;; artefact the hooks are unbound and there is no route slice to leak.
+;; Route classifications are stored at runtime-db-absolute paths, while route
+;; subscriptions return projections below those paths. These hooks let core's
+;; shared egress walker seed a route-sub value at its storage coordinate so
+;; the same declarations apply to trace, tool, and off-box reads.
 (late-bind/set-fn! :routing/route-sub-egress-path    sub-egress/route-sub-seed-path)
 (late-bind/set-fn! :routing/project-route-sub-egress sub-egress/project-route-sub-egress)
 
-;; rf2-1hncp2 + rf2-oosjmh: release the destroyed frame's host-side
-;; transient routing caches — the scroll-position cache AND the nav-counter
-;; high-water marks. `frame/destroy-frame!` invokes this single hook by key
-;; (no static dep on routing — the artefact is optional). Analogous to the
-;; ssr / machines / flows / schemas per-frame teardown hooks; without it a
-;; long-running multi-frame / per-request-frame process would leak one
-;; entry per destroyed frame in each host cache. Composed here (the single
-;; late-bind key carries one fn) so adding a new host cache is a one-line
-;; addition to this teardown.
+;; Frame teardown reaches all routing-owned host-side state through one
+;; optional late-bound hook.
 (defn- release-routing-host-caches!
-  "Release ALL of the destroyed frame's host-side transient routing caches
-  (scroll positions + nav-counter high-water marks), tear down its browser
-  URL-change listener (rf2-g8pbwg, when it held the URL), AND drop any
-  URL-ownership claim it held (rf2-3l7xxz — a destroyed owner relinquishes
-  the URL, so ownership re-resolves to the next live claimant). The
-  `:routing/on-frame-destroyed!` teardown body."
+  "Release a destroyed frame's scroll and allocator caches, remove the
+  browser listener when the frame owns it, and drop the frame's URL claim.
+  The `:routing/on-frame-destroyed!` teardown body."
   [frame-id]
   (scroll/release-frame! frame-id)
   (nav-counters/release-frame! frame-id)
-  ;; rf2-g8pbwg: tear down the browser URL-change listener BEFORE dropping
-  ;; the claim below — the equality check needs `url-owner-frame-id` to still
-  ;; resolve `frame-id` as the (about-to-be-former) owner; once the claim
-  ;; drops, ownership may already have moved to the next claimant. A
-  ;; non-owner frame's destroy is a no-op here (its `:url-bound? true`, if
-  ;; any, was a losing duplicate that never installed a listener). CLJS-only
-  ;; (the JVM build never installs a listener to remove).
+  ;; Remove before dropping the claim: the ownership check must still resolve
+  ;; the destroyed frame. Non-owners never installed a listener. A successor
+  ;; binding is installed by its frame-registration lifecycle, not by teardown.
   #?(:cljs
      (when (= frame-id (nav-fx/url-owner-frame-id))
        (history/remove-url-listener!)))
@@ -552,29 +396,16 @@
 
 (late-bind/set-fn! :routing/on-frame-destroyed! release-routing-host-caches!)
 
-;; Browser URL-change wiring (popstate / hashchange → url-owner frame),
-;; strategy-aware (rf2-aerrz5), driven automatically by the `:url-bound?`
-;; frame LIFECYCLE (rf2-g8pbwg) — there is no imperative
-;; install-url-listener! / install-history-listener! / remove-url-listener! /
-;; remove-history-listener! export; see `re-frame.routing.history`'s ns
-;; docstring THE FOLD note. CLJS-only; the JVM build has no `window` so
-;; `on-frame-registered!` is not defined there (SSR feeds the request URL via
-;; `:rf.route/handle-url-change`).
+;; Browser URL-change wiring is strategy-aware and follows the URL-owning
+;; frame's lifecycle. It is CLJS-only; SSR feeds request URLs through
+;; `:rf.route/handle-url-change`.
 ;;
-;; `:routing/on-frame-registered!` — invoked by `re-frame.frame/reg-frame`
-;; AFTER the frame container exists (first registration: after
-;; `:initial-events` ran; re-registration: after the surgical config update)
-;; — (re)installs the listener when the just-(re)registered frame is the
-;; resolved URL owner. A losing duplicate `:url-bound? true` registration
-;; never installs (Codex correction: fail loud via the existing
-;; `:rf.error/duplicate-url-binding`, never install the losing strategy).
+;; Registration runs after the frame container exists, so the listener's
+;; synchronous initial URL dispatch has a valid target. Only the resolved URL
+;; owner installs; a losing duplicate does not replace the incumbent listener.
 ;;
-;; `:routing/reset-url-listener!` — test-isolation hook consumed by the
-;; shared `make-reset-runtime-fixture` reset-hook table: a raw `frame/frames`
-;; reset does not run `destroy-frame!`'s teardown chain, so without this a
-;; leftover installed listener would survive into the next test. Reuses
-;; `remove-url-listener!` — unconditional teardown is exactly what a full
-;; reset needs.
+;; The reset hook covers test fixtures that reset frame containers without
+;; executing `destroy-frame!`.
 #?(:cljs (late-bind/set-fn! :routing/on-frame-registered! history/on-frame-registered!))
 #?(:cljs (late-bind/set-fn! :routing/reset-url-listener!  history/remove-url-listener!))
 

--- a/implementation/routing/src/re_frame/routing/can_leave.cljc
+++ b/implementation/routing/src/re_frame/routing/can_leave.cljc
@@ -3,7 +3,7 @@
   re-frame2 routing.
 
   Per Spec 012 §Navigation blocking — pending-nav protocol. `:can-enter`
-  is the first-class mirror of `:can-leave` (rf2-p69yaz Option A): ONE
+  is the first-class mirror of `:can-leave`: one
   gate consulted for EVERY entry door — `:rf.route/navigate`,
   `:rf.route/url-requested` (link clicks), and `:rf.route/transitioned` /
   `:rf.route/handle-url-change` (popstate / deep-links) — evaluates the
@@ -11,8 +11,8 @@
 
     - `guard-query` / `guard-id` / `guard?` — the shared `:can-leave` /
       `:can-enter` sub resolution + the closed-contract boolean check
-      (rf2-5pyyl / rf2-p69yaz). The guard sub receives the pending TARGET
-      appended as an argument (repairs the 012:1196 fragment-check hole);
+      boolean contract. The guard sub receives the pending target appended
+      as an argument;
     - `pending-target` — the `{:route-id :params :query :fragment :url}`
       map appended to both guard queries, derived from the requested URL
       via `match-url` (canonical, round-trips);
@@ -23,7 +23,7 @@
       entry point (preventDefault + pushState + :rf.route/transitioned);
     - `:rf.route/continue` / `:rf.route/cancel` — pending-nav protocol
       resolution events. `:rf.route/continue` bypasses `:leave` only and
-      RE-RUNS `:can-enter` (rf2-p69yaz point 6);
+      re-runs `:can-enter`;
     - `:rf.route/navigation-blocked` / `:rf.route/entry-blocked` — the
       default no-op user events runtime dispatches on a leave / enter
       block respectively (apps re-register with their own confirm-dialog
@@ -34,8 +34,7 @@
   (`events/reg-event :rf.route/url-requested`, `:rf.route/navigation-blocked`,
   `:rf.route/entry-blocked`, `:rf.route/continue`, `:rf.route/cancel`) so
   a `:reload` of the façade re-wires them on a fresh registrar (the
-  `clear-all!` test-fixture path). Per the rf2-2yabr cohesion split:
-  CAN-LEAVE + CAN-ENTER + PENDING-NAV seam."
+  `clear-all!` test-fixture path)."
   (:require [re-frame.frame :as frame]
             [re-frame.late-bind :as late-bind]
             [re-frame.registrar :as registrar]
@@ -79,15 +78,15 @@
   "Resolve and call a route's `:can-leave` / `:can-enter` sub against the
   live frame, passing the pending TARGET appended as an argument.
 
-  Per Spec 012 §Navigation blocking §Default flow (rf2-5pyyl /
-  rf2-p69yaz): the guard contract is closed — only the literals `true`
+  Per Spec 012 §Navigation blocking §Default flow, the guard contract is
+  closed — only the literals `true`
   (allow) and `false` (block) are accepted. Any non-boolean return BLOCKS
   and emits the structured `error-id`, forcing the author to write
   `(boolean ...)` / `(not ...)` rather than rely on truthiness (the
   classic polarity bug: a sub returning the dirty-flag value silently let
   the user navigate away and lose form state).
 
-  rf2-p69yaz point 2: the pending TARGET map (`{:route-id :params :query
+  The pending target map (`{:route-id :params :query
   :fragment :url}`) is appended to the guard query as an ARGUMENT — the
   guard-sub receives `[<guard-id> <pending-target>]`, so `:can-leave` can
   finally implement the 012:1196 fragment-check contract (compare the
@@ -105,27 +104,24 @@
   Returns `true` (proceed) when:
     - no guard is declared for `guard-key` (no guard);
     - the sub returns the literal value `true`;
-    - `:subs/subscribe-once` is unset (consumer opted out of the subs
-      artefact; the runtime has no way to evaluate the sub, so it cannot
-      fail the closed contract). The warning
+    - the internal `:subs/subscribe-once` hook is unavailable, so the
+      runtime cannot evaluate the declared guard. The warning
       `:rf.warning/can-leave-subs-artefact-missing` fires so tooling
-      surfaces the misconfiguration (shared across both guards — the
-      missing-artefact condition is guard-agnostic).
+      surfaces the degraded registration state. This fallback is shared by
+      both guard kinds.
 
   `route-id` is the guarded route's id keyword — threaded in so the
   non-boolean trace tags the real id rather than the route's `:path`
   pattern string.
 
-  rf2-dbmj6x — `frame` is BOTH the live frame the guard sub resolves
+  `frame` is both the live frame the guard sub resolves
   against AND the in-flight cascade's frame stamp the diagnostic traces
   tag under `:tags :frame`."
   [frame route-id route-meta guard-key target error-id]
   (if-let [query (guard-query route-meta guard-key)]
     (if-let [subscribe-once (late-bind/get-fn :subs/subscribe-once)]
-      ;; rf2-p69yaz point 2: append the pending target so the guard sub
-      ;; receives it as `(fn [inputs [_ target] ...])`. Repairs the
-      ;; 012:1196 unimplementable fragment-check hole for `:can-leave` and
-      ;; gives `:can-enter` the destination to branch on.
+      ;; Append the target so the guard sub receives it as
+      ;; `(fn [inputs [_ target] ...])`.
       (let [query-with-target (conj (vec query) target)
             v (subscribe-once query-with-target {:frame frame})]
         (cond
@@ -167,13 +163,14 @@
           :rf.error/can-enter-non-boolean))
 
 (defn- pending-target
-  "Resolve the pending TARGET the guards branch on, from the requested
-  URL string via `match-url` (rf2-p69yaz point 2). The URL is the
-  canonical, round-tripping representation every entry door shares —
+  "Resolve the pending target the guards branch on from the requested URL
+  via `match-url`. A URL is the common representation every entry door
+  shares —
   `:rf.route/url-requested` / `:rf.route/transitioned` / `:rf.route/
   handle-url-change` all carry a URL, and `:rf.route/navigate` passes its
-  BUILT url — so deriving the target here keeps ONE gate uniform across
-  all doors without each caller pre-computing a target shape.
+  built URL — so deriving the target here keeps one gate uniform across all
+  doors. The returned `:url` preserves the caller's spelling; `match-url`
+  normalizes the semantic route fields.
 
   Returns `{:route-id :params :query :fragment :url}`. On a URL that
   matches no route the `match-url` half is nil and only `:url` is
@@ -182,15 +179,15 @@
   a dead link is still a leave). A `:can-enter` guard on a matched target
   reads its own route from the registry via `route-id`.
 
-  rf2-dqlfty: this runs on EVERY nav-guard evaluation — even when the
+  This runs on every nav-guard evaluation, even when the
   route declares no `:can-leave` / `:can-enter` at all, `maybe-block-
   navigation` calls `pending-target` unconditionally before checking
   whether a guard is declared. A raw `match-url` call here, left
   unhandled, would let any unexpected throw escape the guard phase and
-  crash the event drain (rf2-6t1xb) for `:rf.route/navigate`,
+  crash the event drain for `:rf.route/navigate`,
   `:rf.route/url-requested`, `:rf.route/transitioned`, and
   `:rf.route/handle-url-change` alike. `match-url-fail-closed` catches
-  ANY throw and yields a nil match instead, so a hostile/throwing URL
+  any throw and yields a nil match instead, so a hostile/throwing URL
   degrades to the same `:rf.route/not-found`-shaped target as a bare
   miss — exactly the fail-closed discipline `url-change-fx` and
   `:rf.route/navigate`'s `{:url ...}` target-form already apply at the
@@ -205,8 +202,8 @@
      :url      requested-url}))
 
 (defn- current-slice->url
-  "Rebuild the URL the current route slice represents, for restoring the
-  browser address bar on a blocked popstate (rf2-ede1h.3). Returns the
+  "Rebuild the URL the current route slice represents for restoring the
+  browser address bar on a blocked popstate. Returns the
   URL string, or nil when the slice cannot be rebuilt (no current route,
   a `:rf.route/not-found` slice with no registered pattern, or a
   `route-url` throw). Best-effort: a nil result simply omits the restore
@@ -214,9 +211,8 @@
   is skipped in the rare unbuildable case.
 
   Built from the slice's `:route-id` / `:params` / `:query` / `:fragment` via
-  the pure `route-url` builder — the exact inverse `match-url` used to
-  populate the slice in the first place, so the restored URL matches the
-  one the browser showed before the (rejected) Back/Forward."
+  `route-url`. The result is semantically equivalent to the URL that produced
+  the slice, but may use canonical query ordering or slash spelling."
   [current-route]
   (let [{:keys [route-id params query fragment]} current-route]
     (when (and route-id (keyword? route-id) (registrar/lookup :route route-id))
@@ -225,8 +221,8 @@
         (catch #?(:clj Throwable :cljs :default) _ nil)))))
 
 ;; ---------------------------------------------------------------------------
-;; The ONE navigation gate: `:can-leave` (current) THEN `:can-enter`
-;; (target), for every entry door. rf2-p69yaz Option A.
+;; The one navigation gate: `:can-leave` (current), then `:can-enter`
+;; (target), for every entry door.
 ;; ---------------------------------------------------------------------------
 
 (defn- event-opts
@@ -247,7 +243,7 @@
 
 (defn- loop-count
   "The number of times THIS resume chain has already re-run the enter gate
-  for the same target (rf2-p69yaz point 7 — loop detection). The count
+  for the same target. The count
   rides the re-issued event's `:rf.route/enter-attempts` opt, threaded
   forward by `:rf.route/continue` (which clears the pending slot BEFORE
   re-dispatching, so the count can't live only on the slot). Zero on a
@@ -256,7 +252,7 @@
   (long (or (:rf.route/enter-attempts (event-opts event-vec)) 0)))
 
 (def ^:private loop-guard-limit
-  "The enter-gate re-run ceiling (rf2-p69yaz point 7). A `:can-enter` that
+  "The enter-gate re-run ceiling. A `:can-enter` that
   blocks the SAME target this many times across resume attempts is a loop
   — the gate fails closed with `:rf.error/route-guard-loop` and STOPS
   re-issuing rather than spinning `continue → block → continue`."
@@ -265,7 +261,7 @@
 (defn maybe-block-navigation
   "Run the CURRENT route's `:can-leave` guard THEN the TARGET route's
   `:can-enter` guard before allowing a transition to `requested-url`
-  (rf2-p69yaz Option A — one gate, every door). Returns nil when the
+  (one gate for every door). Returns nil when the
   navigation should proceed (no guard, guards allow, or the relevant
   guard is bypassed); returns the effects map `{:rf.db/runtime ... :fx ...}`
   that writes the routing pending-navigation slot
@@ -279,7 +275,7 @@
   block result with its happy-path cofx so a single failure path
   collapses cleanly.
 
-  `bypass-guards` is the `:bypass-guards?` opt SET (rf2-p69yaz point 8):
+  `bypass-guards` is the `:bypass-guards?` option set:
   `#{:leave}` skips the leave gate, `#{:enter}` skips the enter gate,
   `#{:leave :enter}` skips both. A `:rf.route/continue` resume passes
   `#{:leave}` — the leave was already confirmed by the user, but the
@@ -287,11 +283,11 @@
 
   Per Spec 012 §Navigation blocking §Default flow step 4c — *the URL does
   not change* on a block. A POPSTATE leave block restores the address bar
-  (rf2-ede1h.3, see `current-slice->url`); an enter block through
+  (see `current-slice->url`); an enter block through
   popstate does the same (the browser already moved to the target the
   enter gate rejects).
 
-  rf2-vcop6y: `pending-nav-allocation` is the RECORDABLE allocation
+  `pending-nav-allocation` is the recordable allocation
   `{:id \"pn-N\" :counter N}` delivered by the generator-backed
   `:rf.route/pending-nav-allocation` cofx."
   [rdb frame-id event-vec requested-url bypass-guards pending-nav-allocation]
@@ -303,13 +299,13 @@
         current-meta   (registrar/lookup :route (:route-id current-route))
         target         (pending-target requested-url)
         target-meta    (registrar/lookup :route (:route-id target))
-        ;; rf2-p69yaz: current route's :can-leave FIRST, then target's
-        ;; :can-enter. The guard subs receive the pending target appended.
+        ;; The current route's :can-leave runs first; only a passing leave
+        ;; reaches the target route's :can-enter.
         leave-ok?      (or (contains? bypass :leave)
                            (can-leave? frame-id (:route-id current-route) current-meta target))
         ;; Only evaluate the enter gate when the leave gate passed (a
-        ;; blocked leave never reaches the target). rf2-p69yaz point 7:
-        ;; when the enter gate re-runs past the loop ceiling, it is a
+        ;; blocked leave never reaches the target). When the enter gate
+        ;; re-runs past the loop ceiling, it is a
         ;; guard loop — fail closed rather than re-issue forever.
         attempts       (loop-count event-vec)
         looping?       (and leave-ok?
@@ -430,8 +426,7 @@
   {})
 
 (defn entry-blocked-handler
-  "`:rf.route/entry-blocked` no-op default handler (ENTER block —
-  rf2-p69yaz point 5). The enter-block mirror of
+  "`:rf.route/entry-blocked` no-op default handler. The enter-block mirror of
   `navigation-blocked-handler`. Registered by the façade so a `:reload`
   re-wires it on a fresh registrar. Apps re-register with their own
   policy (the canonical shape is an auth redirect: read the pending-nav
@@ -440,16 +435,16 @@
   [_ _]
   {})
 
-;; rf2-cylse.4: the open-redirect classifier (`safe-in-app-url?` /
-;; `external-url?` / `request-url->app-url`) is now shared in
+;; The open-redirect classifier (`safe-in-app-url?` / `external-url?` /
+;; `request-url->app-url`) is shared in
 ;; `re-frame.routing.url` so the programmatic `:rf.route/navigate {:url}`
 ;; sink gates through the SAME fail-closed logic as `:rf.route/url-requested`.
 
 (defn- inject-bypass-guards
   "Re-issue the original navigation event with a `:bypass-guards?` SET
-  merged in (rf2-p69yaz point 8; rf2-yursn one-shot escape hatch) and the
+  merged in and the
   running `enter-attempts` loop-guard count threaded forward under
-  `:rf.route/enter-attempts` (point 7 — the count can't live only on the
+  `:rf.route/enter-attempts` (the count cannot live only on the
   pending slot, which `continue` clears before re-dispatching). A
   `:rf.route/continue` resume passes `#{:leave}` — the user already
   confirmed the leave, but the enter gate RE-RUNS (point 6), so `:enter`
@@ -480,8 +475,8 @@
 
 (defn url-requested-handler
   "`:rf.route/url-requested` event handler. Registered by the façade so a
-  `:reload` re-wires it on a fresh registrar. rf2-vcop6y: declares only the
-  RECORDABLE `:rf.route/pending-nav-allocation` cofx — its only allocation
+  `:reload` re-wires it on a fresh registrar. Declares only the recordable
+  `:rf.route/pending-nav-allocation` cofx — its only allocation
   is a pending-nav id minted on a guard block (it never mints a nav-token;
   the forward push synthesises `:rf.route/transitioned`, which mints its
   own)."
@@ -490,14 +485,13 @@
    [_ {:keys [url bypass-guards?] :as _request} :as event-vec]]
     ;; Per Spec 012 §Navigation blocking — pending-nav protocol the
     ;; runtime fires the leave-THEN-enter gate for every :rf.route/url-requested;
-    ;; a block writes [:rf.runtime/routing :pending-navigation]. EP-0001
-    ;; (rf2-vzld77): the pending-nav slot is durable routing runtime-db
-    ;; state — read it from the `:rf.db/runtime` coeffect.
+    ;; a block writes [:rf.runtime/routing :pending-navigation], read from
+    ;; and returned through the runtime-db coeffect/effect.
     ;;
-    ;; The :bypass-guards? request flag is the rf2-yursn one-shot escape
-    ;; hatch :rf.route/continue uses to re-issue the original navigation
+    ;; The :bypass-guards? request flag is the one-shot escape hatch
+    ;; :rf.route/continue uses to re-issue the original navigation
     ;; request without re-running the LEAVE guard (the enter guard still
-    ;; runs — rf2-p69yaz point 6).
+    ;; runs).
     (let [frame     (frame/require-frame-stamp!
                       frame :rf.route/url-requested
                       {:where 'rf.route/url-requested-handler})
@@ -536,27 +530,26 @@
   "`:rf.route/continue` event handler. Registered by the façade so a
   `:reload` re-wires it on a fresh registrar.
 
-  rf2-p69yaz point 6: continue RE-ISSUES the original navigation request,
+  Continue re-issues the original navigation request,
   bypassing the LEAVE guard for this one shot (the user confirmed the
   leave), but the ENTER guard RE-RUNS — an enter-pending that survived a
   committed navigation, or an auth gate whose condition has NOT changed,
   must not sail through on resume. So `inject-bypass-guards` merges
   `#{:leave}`, not `#{:leave :enter}`."
   [{rdb :rf.db/runtime} [_ pn-id]]
-    ;; EP-0001 (rf2-vzld77): the pending-nav slot is durable routing
-    ;; runtime-db state.
+    ;; The pending-navigation slot is runtime-db state.
     (let [db       (or rdb {})
           pending  (get-in db [:rf.runtime/routing :pending-navigation])
           original (:requested-by-event pending)
           url      (:requested-url pending)
-          ;; rf2-p69yaz point 7: thread the running enter-attempt count
+          ;; Thread the running enter-attempt count
           ;; forward so the re-run enter gate can detect a resume loop. The
           ;; slot's `:enter-attempts` was already incremented at block time;
           ;; carry it into the re-issued event's opts (the slot is cleared
           ;; below before the re-dispatch runs, so the count must ride the
           ;; event). Absent on a leave-block resume (no enter attempts).
           attempts (:enter-attempts pending)
-          ;; rf2-8zvajk: a blocked popstate that RESTORED the address bar
+          ;; A blocked popstate that restored the address bar
           ;; must re-move the browser URL on resume — see the leave-block
           ;; docstring above; identical for an enter block reached through
           ;; popstate.
@@ -579,8 +572,7 @@
   "`:rf.route/cancel` event handler. Registered by the façade so a
   `:reload` re-wires it on a fresh registrar."
   [{rdb :rf.db/runtime} [_ pn-id]]
-  ;; EP-0001 (rf2-vzld77): the pending-nav slot is durable routing runtime-db
-  ;; state.
+  ;; The pending-navigation slot is runtime-db state.
   (let [db (or rdb {})]
     (if (= pn-id (get-in db [:rf.runtime/routing :pending-navigation :id]))
       {:rf.db/runtime (update-in db [:rf.runtime/routing] dissoc :pending-navigation)}

--- a/implementation/routing/src/re_frame/routing/classification.cljc
+++ b/implementation/routing/src/re_frame/routing/classification.cljc
@@ -1,12 +1,11 @@
 (ns re-frame.routing.classification
-  "Route OWNER data-classification — the EP-0025 routes follow-on (B5 routes
-  arm, rf2-3r6k8i). Graduated normatively into
+  "Route-owned data classification, specified in
   [`spec/012-Routing.md` §Route data classification](../../../../../../spec/012-Routing.md).
 
-  ## The subsystem-declaration rule (EP-0025 §Subsystem matrix, `reg-route` row)
+  ## The subsystem-declaration rule
 
-  EP-0025 makes every runtime subsystem classify its own instance data
-  PROJECTION-RELATIVE, applied per-instance at creation and dropped at
+  Each runtime subsystem classifies its own instance data projection-relative,
+  applied per-instance at creation and dropped at
   teardown, lowered into the per-frame elision registry. The route arm is
   a PURE-OVER-VALUE lowering (`apply-route-classification` / `lower-for-route`
   below): given a base runtime-db value it returns the runtime-db with the
@@ -28,7 +27,7 @@
   navigation to a route that declares none clears the registry of route-sourced
   entries entirely.
 
-  ## Projection-relative authoring (EP-0025 §Subsystem declarations)
+  ## Projection-relative authoring
 
   A route declares `:sensitive` / `:large` paths RELATIVE to the route's
   current-state projection — the `{:query … :params …}` shape the route slice
@@ -43,29 +42,28 @@
   the route's current state lives in runtime-db — under
   `[:rf.runtime/routing :current …]` — so the declared `[:query :token]`
   classifies the runtime path `[:rf.runtime/routing :current :query :token]`.
-  The author never names the absolute runtime-db storage position (the
-  storage-position problem EP-0025 §Rationale calls out); they name the path
+  The author never names the absolute runtime-db storage position; they name
+  the path
   inside the route's own projection, and lowering re-roots it.
 
-  ## Validation is fail-LOUD at registration (EP-0025 §Failure posture)
+  ## Validation is fail-loud at registration
 
-  Per EP-0025's three-way failure posture, a MALFORMED declaration (a bad path,
+  A malformed declaration (a bad path,
   a wrong shape, a non-EDN-identity segment) FAILS LOUDLY at `reg-route` time —
   before any state mutates and before the route can ever activate — with the
   canonical thrown-error shape (Spec 009 §The thrown-error shape) carrying
   `:rf.error/id :rf.error/invalid-route-classification`. This mirrors the
   `reg-frame` classification's `:rf.error/bad-frame-classification` and the
   commit-plane effect's `:rf.error/classification-effect-shape`. A FORGOTTEN
-  classification is fail-open (the value ships raw — the hygiene bargain).
+  classification is fail-open (the value ships raw).
 
-  ## Sensitive wins over large (EP-0025 §Egress rules)
+  ## Sensitive wins over large
 
   A path declared BOTH `:sensitive` and `:large` lowers as sensitive ONLY — its
   large entry is dropped at lowering time, so no `:rf.size/large-elided` marker
   (which would leak path / byte size / digest) is ever emitted for it. This is
   the lowering-time complement of the elision walker's sensitive-before-large
-  ordering (`re-frame.elision/walk`), which is the single point where
-  sensitive-wins is enforced at egress (EP-0025).
+  ordering (`re-frame.elision/walk`), the final egress enforcement point.
 
   ## Lowering writes a runtime-db VALUE (not a live container swap)
 
@@ -78,14 +76,14 @@
   (including `[:rf.runtime/elision]`) is dropped, so the route-sourced entries
   vanish with the frame with no separate teardown hook.
 
-  ## The query-key promotion advisory (rf2-x1x5am, EP-0025 footgun closure)
+  ## The query-key promotion advisory
 
   A route declares classification paths PROJECTION-RELATIVE to its
   `{:query … :params …}` shape, so a `:sensitive [[:query :token]]` names the
   KEYWORD key `:token`. But the runtime query slice keys a query key as a
   KEYWORD only when the route PROMOTES it via its `:query` schema /
-  `:query-defaults` / `:query-retain` (`re-frame.routing.registry/coerce-query`,
-  rf2-5ifai); an undeclared key stays a STRING. So a `:sensitive [[:query
+  `:query-defaults` / `:query-retain` (`re-frame.routing.registry/coerce-query`);
+  an undeclared key stays a string. So a `:sensitive [[:query
   :token]]` path on a route that does NOT name `:token` in its query vocabulary
   SILENTLY FAILS OPEN — the re-rooted keyword decl never matches the runtime
   string key, and the value ships raw with zero signal.
@@ -100,8 +98,7 @@
   path and a deeper `[:query :token …]` path are advised on their `[:query k]`
   HEAD (the head key is what must promote).
 
-  Internal namespace; the public facade is `re-frame.routing`. Per the
-  rf2-2yabr cohesion split convention: ROUTE-CLASSIFICATION seam."
+  Internal namespace; the public facade is `re-frame.routing`."
   (:require [re-frame.elision :as elision]
             [re-frame.error :as error]
             [re-frame.path :as path]
@@ -112,8 +109,8 @@
 ;; ---- the classification keys --------------------------------------------
 
 (def ^:const classification-keys
-  "The two route-owned classification metadata keys (EP-0025, `reg-route`
-  subsystem-matrix row). A `reg-route` metadata map carrying either triggers
+  "The two route-owned classification metadata keys. A `reg-route` metadata
+  map carrying either triggers
   classification validation + lowering at activation; both are projection-
   relative `[[path] …]` declarations. Joined onto the routing-owned reserved
   metadata keys (`re-frame.routing.registry/reserved-route-keys`)."
@@ -143,7 +140,7 @@
     {:recovery :fix-route-classification
      :extra    (merge {:route-id route-id} extras)}))
 
-;; ---- path validation (EP-0012 :rf/path) ----------------------------------
+;; ---- path validation ------------------------------------------------------
 ;;
 ;; A `:sensitive` / `:large` declaration is a VECTOR of projection-relative
 ;; paths; each path is a sequential collection of CONCRETE EDN segments (the
@@ -155,6 +152,10 @@
 ;; non-sequential path OR any segment outside the concrete EDN domain. This is
 ;; a concrete declaration boundary, so it MUST use `normalize-concrete`, never
 ;; bare `normalize`.
+;;
+;; `[]` is deliberately legal and re-roots to `current-route-root`, thereby
+;; classifying the complete current-route slice rather than one query/params
+;; descendant.
 
 (defn- normalize-axis-paths
   "Validate + normalise the projection-relative paths of one classification
@@ -225,11 +226,11 @@
     (let [sens-paths  (normalize-axis-paths route-id :sensitive (:sensitive metadata))
           large-paths (normalize-axis-paths route-id :large     (:large metadata))
           sens-set    (set sens-paths)
-          ;; Sensitive wins over large (EP-0025 §Egress rules): a path that is
+          ;; Sensitive wins over large: a path that is
           ;; BOTH lowers as sensitive ONLY — drop it from large so no
           ;; `:rf.size/large-elided` marker (path / bytes / digest) can ever
           ;; leak for it. The walker's sensitive-before-large ordering is the
-          ;; authoritative runtime enforcement (EP-0025); this lowering-time
+          ;; authoritative runtime enforcement; this lowering-time
           ;; drop is a belt-and-braces complement for route declarations.
           large-only  (into [] (remove sens-set) large-paths)]
       {:sensitive sens-paths
@@ -330,19 +331,18 @@
 
 (defn lower-for-route
   "Resolve `route-meta`'s validated classification (`validate+extract`) and
-  lower it onto `runtime-db` (`apply-route-classification`). THE single
-  route-activation entry point the navigation commit calls — re-validating
-  here keeps the stored route-meta a pure reflection map (no derived
-  classification cached on it) and re-runs the fail-loud guard at the
-  authoring boundary at registration, so a malformed declaration never reaches
-  here. `route-meta` nil (an unregistered / not-found route) lowers an empty
+  lower it onto `runtime-db` (`apply-route-classification`). This is the single
+  route-activation entry point the navigation commit calls. Registration has
+  already validated ordinary metadata; re-validation keeps this function safe
+  when called with metadata supplied outside that path. `route-meta` nil (an
+  unregistered / not-found route) lowers an empty
   classification, which clears the prior route's `:source :route` entries — the
   leaving route's classification drops on a route-miss / not-found transition
   too. Pure over the runtime-db value."
   [runtime-db route-id route-meta]
   (apply-route-classification runtime-db (validate+extract route-id route-meta)))
 
-;; ---- query-key promotion advisory (rf2-x1x5am) ---------------------------
+;; ---- query-key promotion advisory ----------------------------------------
 ;;
 ;; A reg-route-time WARNING (never a throw) that closes the EP-0025 query-key
 ;; footgun: a `:sensitive` / `:large` `[:query k]` path on a route that does NOT
@@ -354,12 +354,11 @@
   "Return the set of query keys a route's `classification` (the
   `validate+extract` result) names under a `[:query k]` HEAD that the route's
   declared `promoted-keys` set does NOT promote to a keyword — the silent
-  fail-open footgun (rf2-x1x5am). Scans both axes' normalised paths; a path
+  fail-open mismatch. Scans both axes' normalised paths; a path
   whose first two segments are `[:query k]` contributes `k` when `k` is a
   keyword absent from `promoted-keys`. The whole-projection path `[]` and a
   bare `[:query]` carry no query KEY to advise on (no second segment). A
-  non-keyword head key (a string `[:query \"token\"]`) is the rf2-z07m4m
-  string-segment fail-open, separately documented — it is reported too, since a
+  non-keyword head key (a string `[:query \"token\"]`) is also reported, since a
   string key can never be a keyword-promoted slot key. Pure; returns `#{}` for
   nil classification."
   [classification promoted-keys]
@@ -376,7 +375,7 @@
 
 (defn advise-query-promotion!
   "Emit a `:rf.warning/route-classification-query-key-unpromoted` advisory
-  (rf2-x1x5am) when `route-meta`'s `:sensitive` / `:large` classification names
+  when `route-meta`'s `:sensitive` / `:large` classification names
   a `[:query k]` path whose query key `k` the route does NOT promote to a
   keyword via `:query` / `:query-defaults` / `:query-retain` (`promoted-keys`).
   Such a path silently FAILS OPEN at egress — the keyword decl never matches the

--- a/implementation/routing/src/re_frame/routing/egress.cljc
+++ b/implementation/routing/src/re_frame/routing/egress.cljc
@@ -1,40 +1,38 @@
 (ns re-frame.routing.egress
-  "Routing-owned URL-carrier EGRESS scrub (EP-0015 / Spec 015) for the
+  "Routing-owned URL-carrier egress scrub (Spec 015) for the
   diagnostic trace slots the per-registration marks chokepoint cannot reach.
 
-  EP-0015 treats trace/tool/log/epoch records as egress surfaces and requires
+  Trace/tool/log/epoch records are egress surfaces and require
   off-box defaults to FAIL CLOSED. The framework's marks chokepoint
   (`re-frame.classification/project-trace-event` via `re-frame.trace/build-event`)
   already projects the KNOWN trace slots — `:rf.fx/args` against fx marks,
   the dispatched-event vector against event marks, etc. — so the routing fx
   (`:rf.nav/scroll`, `:rf.nav/capture-scroll`, `:rf.nav/push-url`,
   `:rf.nav/replace-url`) and the dispatched `:rf.route/navigation-blocked`
-  event payload are covered by declaring `:sensitive` marks on their
-  registrations (rf2-1wmni6 / rf2-pbbo68 / rf2-jfaucw).
+  event payload are covered by `:sensitive` marks on their registrations.
 
   But routing also emits a few DIAGNOSTIC traces whose carrier rides a
   CUSTOM tag slot the marks chokepoint does not walk:
 
     - `:rf.warning/malformed-url` / `:rf.error/no-such-handler` carry the
-      requested URL under a bare `:url` slot (rf2-n1f4rh). These are the
+      requested URL under a bare `:url` slot. These are the
       route-MISS / malformed-URL diagnostics — there is NO matched route, so
       NO `:params` / `:query` schema to consult, yet an unmatched / malformed
       URL is the class most likely to carry secret material (`?token=…`,
       `?code=…`, `#access_token=…`) and `:rf.error/no-such-handler` is a
-      production-survivable / off-box-observable error category EP-0015
-      requires to fail closed.
+      production-survivable, off-box-observable error category that must
+      fail closed.
     - `:rf.route/navigation-blocked` (the trace, distinct from the dispatched
-      event) carries `:requested-url` under a custom slot (rf2-jfaucw).
+      event) carries `:requested-url` under a custom slot.
 
   This namespace owns the ONE URL-carrier redactor those emit sites route
   their URL slot through — keeping the structured PATH (the reason an app
   error handler / SSR projection needs to branch on) and redacting the
   query-string and `#fragment` carrier VALUES by default. It is the
   no-schema egress analogue of the schema-driven
-  `re-frame.routing.navigate/redact-route-error-tags` (rf2-zsm03).
+  `re-frame.routing.navigate/redact-route-error-tags`.
 
-  Internal namespace; the public facade is `re-frame.routing`. Per the
-  rf2-2yabr cohesion split: EGRESS-SCRUB seam."
+  Internal namespace; the public facade is `re-frame.routing`."
   (:require [clojure.string :as str]
             [re-frame.privacy :as privacy]))
 
@@ -45,13 +43,13 @@
 
 (defn redact-url-carriers
   "Project a raw URL string for off-box / log / tool egress on the
-  NO-SCHEMA route-miss / blocked-navigation diagnostic path (rf2-n1f4rh /
-  rf2-jfaucw): keep the PATH and redact the query-string and `#fragment`
+  no-schema route-miss / blocked-navigation diagnostic path: keep the path
+  and redact the query-string and `#fragment`
   carrier VALUES.
 
   An unmatched / malformed / blocked URL has no matched route → no
   `:params` / `:query` schema to path-target, yet it is the URL class most
-  likely to carry the secret material EP-0015 fails closed on. We apply the
+  likely to carry secret material. Apply the
   blanket carrier policy: redact query/hash VALUES by default.
 
   - Query KEYS are PRESERVED (they name the shape, not the secret — a

--- a/implementation/routing/src/re_frame/routing/events.cljc
+++ b/implementation/routing/src/re_frame/routing/events.cljc
@@ -71,15 +71,13 @@
   per-transition lifecycle signal independent of the underlying
   `:rf.route/transitioned` event.
 
-  rf2-dbmj6x — `frame` is the in-flight cascade's carried frame stamp
+  `frame` is the in-flight cascade's carried frame stamp
   (threaded from the nav handler's `:rf.frame/id` cofx via
   `commit-navigation`). Both lifecycle traces stamp it under `:tags
   :frame` so they enter the emitting frame's epoch (epoch-capture buffers
   only frame-tagged traces — `re-frame.epoch.capture` §168-221) and obey
-  the frame-level trace-disable gate (`re-frame.trace/emit!` §397-398);
-  pre-fix the untagged emits silently dropped from Xray and leaked past a
-  `:rf.trace/frame-no-emit?` tool frame. `(cond-> … frame (assoc …))`
-  mirrors the rf2-7d30s / rf2-w3qgc precedent — a nil stamp simply omits
+  the frame-level trace-disable gate (`re-frame.trace/emit!` §397-398).
+  A nil stamp simply omits
   the tag rather than synthesising `:rf/default`."
   [frame prev-id next-id]
   (when (and prev-id (not= prev-id next-id))
@@ -128,12 +126,11 @@
 ;; always nil on a successful commit; the error-trap path
 ;; (`re-frame.routing.on-match-error`) sets it independently.
 ;;
-;; The merge is targeted at `:current` (not at `:routing`), so the
-;; sibling routing-runtime key under `[:rf.runtime/routing ...]`
-;; (`:pending-navigation` — the only remaining runtime-db sibling) is
-;; untouched. The nav-token / pending-nav counters are NOT runtime-db
-;; siblings — they live in a host-side transient cache per rf2-oosjmh
-;; (mirroring the scroll-position cache, rf2-1hncp2).
+;; The merge targets `:current`, not the routing root, so sibling state is
+;; untouched. Siblings include `:pending-navigation` and, when the resources
+;; artefact is active, resource-blocking bookkeeping. Allocator counters and
+;; scroll positions are host-side transient caches rather than runtime-db
+;; siblings.
 (defn merge-route-slice
   "Pure slice-publish: merges the new slice fields over the existing
   `:current` map at `[:rf.runtime/routing :current]`. Returns the
@@ -192,12 +189,10 @@
   replay re-presents the same token) and the host high-water bump
   (`:counter`) rides a `:rf.route/commit-nav-counter` fx.
 
-  `app-db` is the navigation handler's app-db coeffect value (EP-0016 D3
-  slice 3): it is threaded UNCHANGED into the `:routing/on-route-entry`
-  hook so a cross-feature route-resource `{:from-db <id>}` `:scope` (the
-  Resources artefact) can resolve db-derived viewer scope at route entry,
-  BEFORE the resource work is planned. Routing itself never reads app-db;
-  it is a pure pass-through of the causal world input.
+  `app-db` is passed unchanged to the optional `:routing/on-route-entry`
+  hook. A resource scope declared with `{:from-db <id>}` can therefore resolve
+  against the same causal app-db value before resource work is planned;
+  routing itself does not inspect app-db.
 
   rf2-dbmj6x — `frame` is the in-flight cascade's carried frame stamp (the
   nav handler's `:rf.frame/id` cofx; both nav entry points already
@@ -219,10 +214,8 @@
                                           :fragment   fragment
                                           :transition transition
                                           :nav-token  token})
-        ;; rf2-vdyrls — cross-feature route `:resources` plan (Spec 016 §Route
-        ;; integration). The Resources artefact publishes the LATE-BOUND
-        ;; `:routing/on-route-entry` hook; routing consults it by key (no
-        ;; static dep — resources is optional) and gets back
+        ;; The optional Resources artefact publishes the late-bound
+        ;; `:routing/on-route-entry` hook and returns
         ;; `{:fx [...] :blocking #{<scoped-key> …} :plan-error err?}`. The
         ;; ensure dispatches + prior-owner release are spliced into the commit
         ;; fx; the blocking set is written into the nav-token's blocking slot
@@ -243,10 +236,8 @@
                                 :prev-id        prev-id
                                 :prev-nav-token prev-nav-token
                                 :ctx            {}
-                                ;; EP-0016 D3 slice 3: the route-entry app-db,
-                                ;; threaded from the nav handler's coeffect so a
-                                ;; `{:from-db …}` route-resource scope resolves
-                                ;; db-derived viewer identity at route entry.
+                                ;; Preserve the handler's causal app-db input for
+                                ;; any `{:from-db …}` resource-scope resolver.
                                 :app-db         app-db}))
         committed  (cond-> committed
                      (seq (:blocking plan))
@@ -261,16 +252,16 @@
                      (:plan-error plan)
                      (assoc-in [:rf.runtime/routing :current :error]
                                (:plan-error plan)))
-        ;; EP-0025 routes follow-on (rf2-3r6k8i): lower the activating route's
-        ;; projection-relative `:sensitive` / `:large` classification into the
+        ;; Lower the activating route's projection-relative `:sensitive` /
+        ;; `:large` classification into the
         ;; per-frame elision registry, RE-ROOTED under `[:rf.runtime/routing
         ;; :current …]`, ATOMICALLY with the slice publish (the same runtime-db
         ;; partition). Routes are a SINGLETON current-route, so this REPLACES the
         ;; prior route's `:source :route` entries — a route change drops the
         ;; leaving route's classification, and a route that declares none (incl.
         ;; `:rf.route/not-found`, whose `route-meta` may be nil) clears the
-        ;; route-sourced entries. The declared paths redact the slice's
-        ;; `:query` / `:params` at egress for as long as the route is active;
+        ;; route-sourced entries. The declared query/params paths redact those
+        ;; projections at egress for as long as the route is active;
         ;; frame teardown drops the whole runtime-db elision slot with the frame.
         committed (classification/lower-for-route committed route-id route-meta)]
     ;; rf2-dbmj6x — stamp the carried `:frame` so the nav-token-allocated
@@ -315,14 +306,12 @@
 ;; :nav-token, and the stale settle becomes a no-op so the new :loading
 ;; isn't clobbered.
 ;;
-;; Per Spec 012 §Per-route error handling: if any :on-match event errors
-;; the runtime flips :transition :error, populates :rf.route/error, and
-;; dispatches :on-error (when declared). The settle handler additionally
-;; guards on `(= :loading current-transition)` so a settle queued AFTER
-;; an :on-match throw does NOT clobber :error back to :idle — the throw's
-;; trap (`:rf.route.internal/on-match-error` in
-;; `re-frame.routing.on-match-error`) ran first and the slice now
-;; carries :error.
+;; Per Spec 012 §Per-route error handling, an :on-match throw queues the
+;; internal error event behind work already in the FIFO. The settle may run
+;; first and briefly write :idle; the later error event writes the final
+;; :error state. The transition guard matters when an earlier error event has
+;; already changed the slice, and also prevents redundant settles from
+;; rewriting a non-loading route.
 ;;
 ;; Per rf2-576on: this event is RUNTIME-INTERNAL — fired by the runtime
 ;; itself; never user-dispatched. The `:rf.route.internal/*` sub-

--- a/implementation/routing/src/re_frame/routing/history.cljc
+++ b/implementation/routing/src/re_frame/routing/history.cljc
@@ -4,52 +4,28 @@
 
   Per Spec 012 §URL changes are events / §Multi-frame routing. The
   runtime does not own a window `popstate` listener directly — a
-  `:url-bound? true` frame's LIFECYCLE owns it (rf2-g8pbwg): the
+  `:url-bound? true` frame's lifecycle owns it: the
   listener installs the moment the URL-owning frame is created (or
   re-registered) and is removed when that frame is destroyed. Nothing
-  imperative for an app to call. Historically an app hand-rolled
-
-    (.addEventListener js/window \"popstate\"
-      (fn [_] (rf/dispatch [:rf.route/handle-url-change (current-url)])))
-
-  which dispatches the URL-change event WITHOUT a `:frame`. Under Spec
-  002's no-fallback ladder there is no `:rf/default` floor: a frameless
-  ambient dispatch fails with `:rf.error/no-frame-context` — the runtime
-  never synthesises or selects a default frame. So a hand-rolled listener
-  has to name its target explicitly, and it must name the RIGHT one. When
-  a non-default frame opts into URL binding
-  (`(reg-frame :my-frame {:url-bound? true})`, with `:rf/default`
-  releasing ownership via `{:url-bound? false}` — the single-non-default
-  owner case, rf2-6qgbs.3), the PUSH side correctly routes through that
-  frame (`url-owner-frame-id` gates `:rf.nav/push-url`), but a popstate
-  dispatch targeted at the wrong (or defaulted) frame would update that
-  frame's slice instead of the owner's — so Back/Forward never restored
-  the visible route (rf2-6qgbs.4).
+  imperative for an application to call. Browser changes dispatch
+  synchronously to the explicitly declared URL owner; there is no default-
+  frame fallback for an absent owner.
 
   `on-frame-registered!` resolves the URL owner AT (RE-)REGISTRATION TIME
   via `url-owner-frame-id` and, when the just-(re)registered frame IS the
-  owner, (re)installs `install-url-listener!` — which itself resolves the
-  owner AT POP TIME so Back/Forward keeps tracking whichever frame
-  currently owns the URL. It is symmetric with `:rf.nav/push-url`: the
-  same single owner drives both directions. For the default-owned app the
-  owner resolves to `:rf/default`, so existing apps behave identically;
-  for a url-bound non-default frame Back/Forward restores its route slice
-  and body.
+  owner, (re)installs `install-url-listener!`. Each installed callback
+  resolves its dispatch target again when it fires. The strategy itself is
+  selected at install time, so changing URL ownership or strategy is a frame-
+  registration operation. This is symmetric with `:rf.nav/push-url`: the
+  same explicitly declared owner drives both directions.
 
-  rf2-aerrz5 (URL-strategy seam): the listener is one of the four
-  strategy consult points. `install-url-listener!` resolves the URL
-  owner's `:url-strategy` (default `history-url-strategy`, `popstate`) and
+  The listener is one of the URL-strategy consult points.
+  `install-url-listener!` resolves the URL owner's `:url-strategy` (default
+  `history-url-strategy`) and
   installs THAT strategy's browser listener — `popstate` for a history
   app, `hashchange` for a hash app — decoding each browser-driven change
-  to a PATH-FORM URL before dispatching `:rf.route/handle-url-change`. A
-  hash app's hand-rolled `hashchange` adapter deletes; it uses this seam
-  like every other app.
+  to a path-form URL before dispatching `:rf.route/handle-url-change`.
 
-  rf2-g8pbwg — the FOLD. `install-url-listener!` / `remove-url-listener!`
-  (and their retired `install-history-listener!` / `remove-history-listener!`
-  aliases) were an imperative pair of exports an app called by hand at boot
-  and (rarely) at teardown — two coupled steps for one declaration
-  (`:url-bound? true`). They are no longer part of the public facade:
   `on-frame-registered!` installs from `re-frame.frame/reg-frame`'s
   POST-CREATE lifecycle hook (`:routing/on-frame-registered!`, fired AFTER
   the frame container exists and, on first registration, after
@@ -65,24 +41,21 @@
   `:rf.error/duplicate-url-binding`) never reaches `install-url-listener!`
   at all — it must never install a second, wrong listener.
 
-  Internal namespace; the public facade is `re-frame.routing`. Per the
-  rf2-2yabr cohesion split: HISTORY-LISTENER seam."
+  Internal namespace; the public facade is `re-frame.routing`."
   (:require [re-frame.router :as router]
             [re-frame.routing.nav-fx :as nav-fx]
             [re-frame.routing.strategy :as strategy]))
 
 (defn current-url
   "Read the current browser URL as an app-relative string
-  `pathname + search + hash`. CLJS-only — returns `\"/\"` when no
-  `window.location` is available (SSR / node). Public so apps that wire
-  their own history listener can recover the same projection
-  `install-url-listener!` uses.
+  `pathname + search + hash`. Returns `\"/\"` on the JVM or when no
+  `window.location` is available. This is a public query, not a listener-
+  installation step.
 
   This is the PATH-FORM projection of a HISTORY-strategy app's URL (it is
   `history-url-strategy`'s `:decode`). A hash app decodes differently —
-  `install-url-listener!` uses the URL owner's strategy `:decode`, so a
-  hash app never calls this directly; it is retained as the history
-  default projection and for apps that wire their own history listener."
+  the lifecycle listener uses the URL owner's strategy `:decode`; this
+  function specifically exposes the history strategy's projection."
   []
   (strategy/history-decode))
 
@@ -96,8 +69,7 @@
 
 #?(:cljs
    (defn install-url-listener!
-     "INTERNAL (rf2-g8pbwg — no longer a public export; see the ns docstring's
-     THE FOLD note). Install the current URL owner's browser URL-change
+     "Install the current URL owner's browser URL-change
      listener, then sync the current URL into that frame's route slice at
      `[:rf.runtime/routing :current]`. This is the single strategy-aware
      engine `on-frame-registered!` drives automatically from the
@@ -113,13 +85,13 @@
 
      Per Spec 012 §Multi-frame routing the dispatch is targeted at
      `(url-owner-frame-id)` resolved AT FIRE TIME, so it tracks whichever
-     single frame currently owns the URL — `:rf/default` for the common case,
-     or a non-default `:url-bound? true` frame (rf2-6qgbs.4). This is the
+     single frame currently owns the URL, including `:rf/default` only when it
+     explicitly declares `:url-bound? true`. This is the
      inbound (browser → app) counterpart of the outbound `:rf.nav/push-url`
      gate: one owner, both directions. `url-owner-frame-id` returns nil when
      no frame declared `:url-bound? true`; the callback then skips the
      dispatch (installing a listener with no declared owner is a
-     routing-config no-op, not a default-frame write — EP-0002 rf2-nn0jqa).
+     routing-config no-op, not a default-frame write).
 
      The STRATEGY (which browser event, which decode) is resolved from the
      current URL owner's `:url-strategy` at install time; the OWNER (dispatch
@@ -145,7 +117,7 @@
            decode (:decode strat)
            install-listener! (:install-listener! strat)
            ;; The dispatch targets the EXPLICITLY-declared URL owner resolved
-           ;; AT FIRE TIME (EP-0002 rf2-nn0jqa) with the strategy-decoded
+           ;; AT FIRE TIME with the strategy-decoded
            ;; path-form URL. Skips when no owner is declared.
            dispatch-to-owner!
            (fn [path-url]
@@ -167,7 +139,7 @@
 
 #?(:cljs
    (defn remove-url-listener!
-     "INTERNAL (rf2-g8pbwg — no longer a public export). Tear down the
+     "Tear down the
      browser URL-change listener installed by `install-url-listener!`
      (whichever kind the strategy wired — `popstate` or `hashchange`), via
      the teardown thunk it returned. No-op when none is installed. Called by
@@ -186,7 +158,7 @@
 
 #?(:cljs
    (defn on-frame-registered!
-     "Post-(re-)registration frame-lifecycle hook (rf2-g8pbwg). When the
+     "Post-(re-)registration frame-lifecycle hook. When the
      just-(re)registered frame `id` is the RESOLVED URL owner
      (`url-owner-frame-id`), (re)install its `:url-strategy` browser
      listener via `install-url-listener!` — idempotent, so a re-registration

--- a/implementation/routing/src/re_frame/routing/link.cljc
+++ b/implementation/routing/src/re_frame/routing/link.cljc
@@ -8,8 +8,7 @@
 
   Internal namespace; the public facade is `re-frame.routing`. The
   facade owns the `views/reg-view*` (CLJS) / `registrar/register!`
-  (JVM/SSR) wiring so a `:reload` re-wires both on a fresh registrar.
-  Per the rf2-2yabr cohesion split: ROUTE-LINK seam."
+  (JVM/SSR) wiring so a `:reload` re-wires both on a fresh registrar."
   (:require [re-frame.router :as router]
             [re-frame.frame :as frame]
             [re-frame.routing.registry :as registry]
@@ -25,7 +24,7 @@
   place and cannot drift between the two halves of the Spec 011 render
   contract.
 
-  rf2-aerrz5 (URL-strategy seam): `route-url` builds the PATH-FORM URL
+  `route-url` builds the path-form URL
   (`/active`); `encode` maps it to the rendered `:href` — one of the four
   strategy consult points. The first return value is the PATH-FORM url
   (unencoded) — it is the behavioural navigation identity carried on the
@@ -57,8 +56,8 @@
 
 (defn- native-anchor?
   "Return true when `props` carry HTML anchor attributes whose semantics
-  the framework MUST NOT override with same-document SPA navigation, even
-  on a plain left-click. Per rf2-fwz29i — a `route-link` rendered with
+  the framework must not override with same-document SPA navigation, even
+  on a plain left-click. A `route-link` rendered with
   `{:target \"_blank\"}` or `{:download …}` looks like a normal anchor in
   the DOM and the user expects native new-tab / new-window / download
   behaviour; intercepting it into a `:rf.route/url-requested` dispatch silently
@@ -118,7 +117,7 @@
      apply: plain left-click → `preventDefault` + dispatch
      `:rf.route/url-requested`; modifier-key or middle-click → no interception.
 
-     rf2-fwz29i: anchors carrying native-handling attributes
+     Anchors carrying native-handling attributes
      (`:target` other than `_self`, or `:download`) are NOT intercepted on
      a plain left-click either — they look like a normal anchor in the DOM
      and the user expects native new-tab / download behaviour
@@ -145,13 +144,10 @@
            ;; `make-capture-frame` do for view bodies. `require-current-frame!`
            ;; raises at the RENDER site if a link is rendered outside any frame
            ;; scope — fail with the render stack, not a detached click.
-           ;; (rf2-afdlyr realm collapse: the former (realm, frame) address
-           ;; capture is now just the frame id — the realm substrate is a single
-           ;; default realm, so no `:realm` ever rode the envelope.)
            render-frame (frame/require-current-frame!
                           :route-link
                           {:where 're-frame.routing.link/route-link-render})
-           ;; rf2-aerrz5 (URL-strategy seam): the rendered `:href` is encoded
+           ;; The rendered `:href` is encoded
            ;; through the RENDER-TIME frame's `:url-strategy` (default
            ;; path-form). A hash app renders `#/active`; a history app renders
            ;; `/active`. `url` is the PATH-FORM navigation identity carried on
@@ -159,7 +155,7 @@
            ;; encode touches ONLY the href. One of the four consult points.
            encode (:encode (strategy/url-strategy-for-frame-id render-frame))
            [url base-attrs] (href-attrs props encode)
-           ;; rf2-fwz29i: anchors carrying native-handling attributes
+           ;; Anchors carrying native-handling attributes
            ;; (`target="_blank"`, `download`) must let the browser handle
            ;; the click — SPA interception would defeat new-tab / download.
            ;; Computed once at render against the resolved attrs (post
@@ -204,7 +200,7 @@
   Spec 011 the render tree is the contract; this is the JVM half of
   that contract for the `:route/link` view.
 
-  rf2-aerrz5: SSR IGNORES URL strategies — the server has no address bar,
+  SSR does not apply URL strategies: the server has no address bar,
   and a hash never reaches it. The href is emitted PATH-FORM (`encode` =
   `identity`); on hydration the CLJS `route-link-render` re-encodes it
   through the frame's strategy. So a hash app's server shell carries

--- a/implementation/routing/src/re_frame/routing/match.cljc
+++ b/implementation/routing/src/re_frame/routing/match.cljc
@@ -2,16 +2,12 @@
   "Route-pattern parsing, validation, and URL-against-pattern matching
   for re-frame.routing.
 
-  Per Spec 012 §Route ranking algorithm and §Bidirectional URL ↔ params.
-  Internal namespace; the public facade is `re-frame.routing` — direct
-  consumers should reach for that facade. This ns isolates pattern
-  compilation (validation + single-pass parse → rank/regex/names/groups)
-  and pattern matching (`match-against`) so the routing facade can
-  compose them without the implementations cluttering its cohesion
-  surface.
+  Pattern compilation validates and parses once to derive rank, regex,
+  capture names, and optional-group metadata. `match-against` applies that
+  compiled form and decodes captures. Per Spec 012 §Route ranking algorithm
+  and §Bidirectional URL ↔ params.
 
-  Per the rf2-icrxv cohesion-split audit (Phase-2 Option C): PATTERN
-  seam — template compile + match-against."
+  Internal namespace; the public facade is `re-frame.routing`."
   (:require [re-frame.error :as error]
             [re-frame.routing.url :as url]))
 
@@ -121,14 +117,11 @@
                 (clojure.string/includes? body "//")
                 (clojure.string/ends-with? body "/"))
         (route-pattern-error! route-id pattern "optional groups may not contain empty segments" start))
-      ;; CANONICAL SPELLING — slash-INSIDE the braces (rf2-av1, pinned by
-      ;; rf2-5u1r6a). The group wraps a *slash-prefixed* sub-pattern:
+      ;; The group owns a slash-prefixed sub-pattern:
       ;; `{/:slug}?`, `{/guide}?`, `{/:base}?`. The slash-OUTSIDE spelling
       ;; (`{:base}?`, a `{` directly after a `/` with a `:`-first body) is
-      ;; REJECTED — it was an accepted-but-undocumented drift that the
-      ;; production table, the normative `:rf/route-pattern` regex, and this
-      ;; validator disagreed on. One spelling now: the leading `/` lives
-      ;; inside the braces so the group is a self-contained optional segment
+      ;; rejected. The leading `/` lives inside the braces, making the group
+      ;; a self-contained optional segment
       ;; wherever it appears (leading, e.g. `{/:base}?/about`, or trailing,
       ;; e.g. `/articles/:id{/:slug}?`).
       (when-not (= \/ (.charAt ^String body 0))
@@ -163,7 +156,7 @@
   most one splat, which must be final; literal segments percent-encode
   the reserved chars (`: * { } ?`); and `{...}?` optional groups close
   with `}?`, are non-empty, non-nested, wrap a slash-prefixed sub-pattern
-  (the canonical slash-INSIDE spelling, `{/:id}?` — rf2-av1 / rf2-5u1r6a),
+  (the canonical slash-inside spelling, `{/:id}?`),
   and contain no splats. A pattern may also OPEN with a leading optional
   group (`{/:base}?/about`)."
   [route-id pattern]
@@ -176,8 +169,8 @@
 
     ;; A pattern must start with `/` (a segment) OR `{` (a LEADING optional
     ;; group — the canonical slash-inside form for an optional prefix, e.g.
-    ;; `{/:base}?/about`; per Spec 012 §Path-pattern grammar rule 2 and
-    ;; rf2-av1). The group carries its own leading slash INSIDE the braces,
+    ;; `{/:base}?/about`; per Spec 012 §Path-pattern grammar rule 2). The
+    ;; group carries its own leading slash inside the braces,
     ;; so a leading group needs no `/` before it.
     (not (or (= \/ (.charAt ^String pattern 0))
              (= \{ (.charAt ^String pattern 0))))
@@ -333,17 +326,12 @@
            ;; every other concrete route). For any two NON-catch-all
            ;; patterns the catch-all bit ties (both 1), so the comparison
            ;; falls through to total-length exactly as before — only
-           ;; rankings involving the bare `/*` change.
-           ;; rf2-dqlfty: rules 4 and 5 are BOOLEAN discriminators per
+           ;; rankings involving the bare `/*` change. Rules 4 and 5 are
+           ;; boolean discriminators per
            ;; Spec 012 §Route ranking algorithm — "named params beat rest
            ;; params" / "exact routes beat optional-group routes" — not a
-           ;; magnitude comparison. The pre-fix `(- splat)` / `(- optional)`
-           ;; ranked by the raw segment COUNT, so two routes tied by the
-           ;; spec (e.g. differing only in HOW MANY optional groups they
-           ;; declare) ranked differently — a cross-host divergence, since
-           ;; a conforming implementation following the spec pseudocode
-           ;; ties them. `(if (pos? n) 0 1)` collapses "any" vs "none" to
-           ;; the same two-value cascade the spec pseudocode uses.
+           ;; magnitude comparison. `(if (pos? n) 0 1)` therefore represents
+           ;; only "any" versus "none", as the spec pseudocode requires.
            :rank    [static
                      (if catch-all? 0 1)
                      total

--- a/implementation/routing/src/re_frame/routing/nav_counters.cljc
+++ b/implementation/routing/src/re_frame/routing/nav_counters.cljc
@@ -5,15 +5,14 @@
   Per Spec 012 §Navigation tokens — stale-result suppression and
   §Navigation blocking — pending-nav protocol.
 
-  ## Storage: host-side per-frame TRANSIENT high-water marks (rf2-oosjmh)
+  ## Storage: host-side per-frame transient high-water marks
 
   The two monotonic allocators — `:nav-token-counter` (mints
   `[:rf.runtime/routing :current :nav-token]` values) and
   `:pending-nav-counter` (mints `:pending-navigation` `:id`s) — are
   **host-side transient state**, NOT runtime-db state. They live in a
-  module-level `defonce` cache keyed by frame-id, mirroring the
-  rf2-1hncp2 scroll-position cache and the `re-frame.http.registry`
-  in-flight pattern.
+  module-level `defonce` cache keyed by frame-id, like the scroll-position
+  cache and other host-side registries.
 
   ### Why host-side is a CORRECTNESS fix, not a churn judgment
 
@@ -24,29 +23,24 @@
   result. The ALLOCATOR (the monotonic counter) therefore must never go
   backward.
 
-  When the counter lived at `[:rf.runtime/routing :nav-token-counter]`,
-  an epoch restore — which replaces the runtime-db partition WHOLESALE
-  (`frame/replace-runtime-db!`) — rewound the counter to its value at the
-  restored epoch. A pre-restore in-flight continuation returning after the
-  restore could then carry a token the post-restore timeline has already
-  re-allocated → the exact recycle the invariant forbids. Conflating the
-  allocator (a high-water mark whose property is *never rewind*) with the
-  active token (a durable slice fact that SHOULD restore coherently) in
-  one restorable partition is the category error.
+  An epoch restore replaces runtime-db wholesale. Storing the counter there
+  would allow restore to rewind it while a pre-restore continuation still
+  carries a published token. The active token is a durable route fact and may
+  restore; the allocator high-water mark must not.
 
   Held host-side the counter is a monotonic high-water mark that survives
-  epoch restore untouched, so every fresh allocation strictly exceeds any
+  epoch restore untouched, so every freshly published allocation exceeds any
   pre-restore in-flight token — token collision is structurally
   impossible. `:pending-nav-counter` is the same anti-recycling-allocator
   class (a recycled pn-id could mis-match a stale continue/cancel).
 
-  ### The pure seam (handlers stay pure) — RECORDABLE allocation (rf2-vcop6y)
+  ### The pure seam: recordable allocation
 
-  Mirroring rf2-1hncp2's rule — *thread the cache as an explicit arg, do
-  not reach an ambient global from a handler* — allocation is split into a
+  Handlers receive the cache-derived value explicitly rather than reaching an
+  ambient global. Allocation is split into a
   READ-via-cofx / WRITE-via-fx seam. The READ half is a pair of
   **recordable, generator-backed** coeffects (EP-0017 §5) — one per
-  allocator (rf2-oosjmh: two distinct allocators ⇒ two distinct facts):
+  allocator:
 
     - `:rf.route/nav-allocation`         → `{:token \"nav-N\" :counter N}`
     - `:rf.route/pending-nav-allocation` → `{:id    \"pn-N\"  :counter N}`
@@ -58,9 +52,7 @@
   record — so the epoch captures the allocation and **replay re-presents
   the SAME id verbatim** (no generator re-run; strict replay FAILS if the
   recorded allocation is missing — `:rf.error/missing-required-cofx`). This
-  is the replay-determinism fix: pre-rf2-vcop6y the allocation rode an
-  AMBIENT counter-snapshot cofx that was never recorded, so replay re-minted
-  DIFFERENT ids and recorded events referencing the originals mismatched.
+  This makes replay use the recorded id rather than rerunning the generator.
 
   The handler reads the recordable allocation flat under its id, writes ONLY
   the supplied/generated id into runtime-db, and emits the
@@ -79,34 +71,27 @@
   on frame destroy (the `:routing/on-frame-destroyed!` teardown hook,
   shared with the scroll cache).
 
-  ### Shape: generator-backed recordable (not provided-at-construction)
+  ### Why generator-backed
 
-  rf2-vcop6y step 7 prefers a routing-PROVIDED fact stamped onto the
-  navigation dispatch envelope at construction (slice-A). That shape fits a
-  fact with a single causal originator and a value independent of the
-  handler (the `:rf/time-ms` precedent). Navigation has neither: it arrives
+  Navigation arrives
   through many internal re-dispatch paths (popstate → `handle-url-change`,
   link-click → `:rf.route/url-requested` → `:rf.route/transitioned`, the resume
   chain `:rf.route/continue` → `:rf.route/url-requested`), each a fresh causal
-  token whose `:rf.cofx` is NOT inherited; and a pending-nav allocation's
-  very existence depends on the `:can-leave` guard result computed INSIDE
-  the handler against the live frame. A provided fact would therefore have
-  to be minted-and-stamped at every entry point, before the branch is known.
-  The generator-backed recordable shape resolves the hole uniformly via
+  token whose `:rf.cofx` is not inherited. Which candidate is published also
+  depends on the guard result computed inside the handler. A provided fact
+  would have to be stamped at every entry point before that branch is known.
+  The generator-backed recordable shape handles every door uniformly via
   `:rf.cofx/requires` on every entry point with no per-site stamping —
-  rf2-vcop6y step 7 blesses it as the slice-B consumer alternative. The
-  generators run EAGERLY for every declared fact, so a two-way nav handler
-  (block vs commit) that declares both allocations advances both monotone
-  counters even on the branch it does not publish; that is harmless — the
-  counters' only invariant is never-recycle, gaps are a documented
-  non-concern (the unbounded f64 / `long` range), and the not-published
-  allocation is recorded + replay-stable like any declared-but-unused fact.
+  the generators run eagerly for every declared fact, so a two-way handler
+  records both candidate allocations. Only the taken branch emits the
+  `:rf.route/commit-nav-counter` effect and advances its host high-water mark;
+  the other recorded candidate is never published and may be selected again
+  by a later event without violating token uniqueness.
 
-  Internal namespace; the public facade is `re-frame.routing`. Per the
-  rf2-2yabr cohesion split: NAV-COUNTERS seam."
+  Internal namespace; the public facade is `re-frame.routing`."
   (:require [re-frame.frame :as frame]))
 
-;; ---- host-side per-frame transient cache (rf2-oosjmh) ---------------------
+;; ---- host-side per-frame transient cache ----------------------------------
 
 (defonce nav-counters-cache
   ;; frame-id → {:nav-token-counter N :pending-nav-counter M}.
@@ -114,10 +99,10 @@
   ;; Host-side TRANSIENT high-water marks for the two monotonic routing
   ;; allocators. NOT runtime-db state — held here so an epoch restore (which
   ;; replaces the runtime-db partition wholesale) cannot rewind them, which
-  ;; would recycle an authority token (rf2-oosjmh). Keyed by frame-id so
+  ;; would recycle an authority token. Keyed by frame-id so
   ;; multi-frame apps keep isolated per-frame counters; the entry is dropped
-  ;; on frame destroy via `release-frame!`. Mirrors the rf2-1hncp2
-  ;; scroll-position cache + `re-frame.http.registry`'s `in-flight` defonce
+  ;; on frame destroy via `release-frame!`. Like the scroll-position cache
+  ;; and `re-frame.http.registry`'s `in-flight` defonce
   ;; atom — host-owned ephemeral state, not in the reactive db.
   (atom {}))
 

--- a/implementation/routing/src/re_frame/routing/nav_fx.cljc
+++ b/implementation/routing/src/re_frame/routing/nav_fx.cljc
@@ -2,7 +2,7 @@
   "Standard navigation fxs (`:rf.nav/push-url`, `:rf.nav/replace-url`)
   + URL-owner resolution for re-frame2 routing.
 
-  Per Spec 012 §Multi-frame routing and EP-0002 (rf2-nn0jqa): URL
+  Per Spec 012 §Multi-frame routing, URL
   ownership is **explicit only**. `:rf.nav/push-url` / `:rf.nav/replace-url`
   MUST consult the calling frame's `:url-bound?` metadata before touching
   the browser history. A frame is URL-bound only when it carries an
@@ -15,7 +15,7 @@
 
   Internal namespace; the public facade is `re-frame.routing`. The
   facade owns the two `fx/reg-fx` calls so a `:reload` re-wires them on
-  a fresh registrar. Per the rf2-2yabr cohesion split: NAV-FX seam."
+  a fresh registrar."
   (:require [re-frame.registrar :as registrar]
             [re-frame.routing.strategy :as strategy]
             [re-frame.trace :as trace]))
@@ -27,7 +27,7 @@
   (when (map? config)
     (:url-bound? config)))
 
-;; ---- URL-ownership claim order (rf2-3l7xxz) --------------------------------
+;; ---- URL-ownership claim order --------------------------------------------
 ;;
 ;; The browser URL has exactly ONE owner; the spec (Spec 012 §Multi-frame
 ;; routing) says when a SECOND `:url-bound? true` frame registers, the
@@ -36,13 +36,9 @@
 ;; must resolve to the frame that claimed `:url-bound? true` FIRST — the
 ;; incumbent — never to whichever id happens to sort earlier.
 ;;
-;; The registrar's `kind->id->metadata` is an UNORDERED map (`re-frame.
-;; registrar`), so registration order is not recoverable from it. The prior
-;; resolver sorted the `:url-bound? true` frames by `(str id)` and took the
-;; first — which let a LATER duplicate whose id sorts BEFORE the incumbent
-;; STEAL ownership (rf2-3l7xxz): outbound history pushes and inbound popstate
-;; would then target the wrong frame, the exact thrash the "existing owner is
-;; unchanged" rule forbids.
+;; The registrar's `kind->id->metadata` is unordered, so registration order is
+;; not recoverable from it. A separate claim-order vector is required; sorting
+;; frame ids would allow a later duplicate to displace the incumbent.
 ;;
 ;; The fix records claim ORDER in this process-global vector. The url-bound
 ;; exclusivity registration hook (`re-frame.routing.url-bound`, which already
@@ -61,11 +57,11 @@
 ;; `:url-bound? true`, in claim order. Fail-closed: a frame never owns the URL
 ;; unless it is the first-claimed live `:url-bound? true` frame.
 ;;
-;; rf2-68k8as — the hook is a FUTURE observer (`add-registration-hook!` does not
-;; replay), so a frame that claimed `:url-bound? true` BEFORE routing loaded has
-;; no entry here. The façade calls `reconcile-existing-url-bindings!` right after
+;; The hook observes only future registrations, so a frame that claimed
+;; `:url-bound? true` before routing loaded has no entry here. The facade calls
+;; `reconcile-existing-url-bindings!` right after
 ;; installing the hook to seed the unambiguous pre-existing incumbent. The
-;; claim-free resolver fallback below NEVER picks by id sort (the old steal bug):
+;; claim-free resolver fallback below never picks by id sort:
 ;; a sole bound frame owns, but 2+ bound frames with unrecoverable claim order
 ;; fail closed to nil.
 
@@ -82,7 +78,7 @@
   `url-claim-order` iff not already present (so a hot-reload re-registration of
   an existing owner keeps its claim position — it does NOT jump to the back,
   and a later duplicate never displaces it). Returns nil. Called by the
-  url-bound exclusivity registration hook (rf2-3l7xxz)."
+  url-bound exclusivity registration hook."
   [frame-id]
   (swap! url-claim-order
          (fn [order]
@@ -95,14 +91,14 @@
   "Drop `frame-id` from `url-claim-order` — called when a frame re-registers
   WITHOUT `:url-bound? true` (it relinquished the binding) or is torn down, so
   a stale claim cannot keep a non-bound frame at the head of the order.
-  Idempotent. Returns nil (rf2-3l7xxz)."
+  Idempotent. Returns nil."
   [frame-id]
   (swap! url-claim-order (fn [order] (filterv #(not= frame-id %) order)))
   nil)
 
 (defn reset-url-claims!
   "Test-time helper: drop the whole `url-claim-order` vector so a prior test's
-  URL-ownership claim does not leak into the next (test isolation, rf2-3l7xxz).
+  URL-ownership claim does not leak into the next test.
   Wired into the shared `make-reset-runtime-fixture` reset-hook table via the
   `:routing/reset-url-claims!` late-bind key. Returns nil."
   []
@@ -114,39 +110,35 @@
   ownership via `(reg-frame :id {:url-bound? true})`, or `nil` when no
   frame has declared it.
 
-  EP-0002 (rf2-nn0jqa) — URL ownership is an explicit host/bootstrap
-  policy, NOT an absence repair. The prior contract anchored ownership on
-  `:rf/default` (the default frame owned the URL unless it opted out);
-  under the carried invariant the runtime must NOT infer `:rf/default` as
+  URL ownership is an explicit host/bootstrap policy, not an absence repair.
+  The runtime must not infer `:rf/default` as
   the owner. An app declares its one URL-owning frame explicitly; `nil`
   here means no owner is declared (a routing-config state, surfaced by the
   callers — outbound history mutations no-op, the inbound popstate listener
   skips). `:rf/default` may still BE the owner, but only when it carries an
   explicit `{:url-bound? true}` like any other frame.
 
-  rf2-3l7xxz — ownership resolves to the FIRST-CLAIMED still-live
+  Ownership resolves to the first-claimed still-live
   `:url-bound? true` frame (the incumbent), NOT the alphabetically-first.
   When a second `:url-bound? true` frame registers, Spec 012 §Multi-frame
   routing says the existing owner is UNCHANGED and the duplicate's
   history-mutation fxs no-op — so a later duplicate whose id sorts before the
-  incumbent must NOT steal the URL (the bug the prior `(sort-by (str id))`
-  resolver had). Claim order is tracked in `url-claim-order` (recorded by the
+  incumbent must not steal the URL. Claim order is tracked in
+  `url-claim-order` (recorded by the
   url-bound exclusivity hook); this resolver walks it in claim order and
   returns the first id that STILL carries a live `:url-bound? true` binding in
   the registry — so the incumbent always wins, and ownership self-heals to the
   next claimant if the incumbent later drops its binding or is unregistered.
 
-  rf2-68k8as — when no claim is recorded yet (frames registered before the
+  When no claim is recorded yet (frames registered before the
   hook installed AND before the façade's `reconcile-existing-url-bindings!`
   seeded them), the claim-free fallback NEVER steals: a sole bound frame owns
   (order is trivially known), but TWO OR MORE bound frames with unknowable
-  claim order FAIL CLOSED to nil rather than id-sorting. The old id-sort
-  fallback was the URL-owner-steal bug — a later duplicate that sorted before
-  the true first-claimant won the alphabetical tiebreak and stole the URL.
+  claim order fails closed to nil rather than id-sorting.
 
   Public (rather than `defn-`) so the ownership-resolution contract is
   directly assertable — the single declared-owner case the step-deck
-  testbed relies on (rf2-6qgbs.3). A reimplemented gate cannot catch a
+  testbed relies on. A reimplemented gate cannot catch a
   regression in THIS resolution; the test must reach the real fn."
   []
   (let [frames (registrar/registrations :frame)
@@ -156,19 +148,15 @@
     ;; the URL. A claimed-but-since-relinquished/destroyed frame is skipped
     ;; (self-healing).
     ;;
-    ;; rf2-68k8as — when NO claim is recorded yet but `:url-bound? true`
-    ;; frame(s) exist in the registry (frames registered before the hook was
+    ;; When no claim is recorded yet but `:url-bound? true` frame(s) exist in
+    ;; the registry (frames registered before the hook was
     ;; installed and before the façade's `reconcile-existing-url-bindings!`
     ;; seeded them, or a raw programmatic path), fall back to claim-free
     ;; resolution that NEVER steals:
     ;;   - exactly ONE bound frame → it owns (order is trivially known);
     ;;   - TWO OR MORE bound frames → claim order is genuinely unknowable
     ;;     (the registrar map is unordered), so FAIL CLOSED to nil rather than
-    ;;     picking by id sort. The prior `(sort-by (str id))` fallback WAS the
-    ;;     URL-owner-steal bug: a later duplicate whose id sorted before the
-    ;;     true first-claimant won the alphabetical tiebreak and stole the URL,
-    ;;     exactly what Spec 012 §Multi-frame routing forbids ('resolving by id
-    ;;     ordering would have let it'). nil here means 'no deterministic owner
+    ;;     picking by id sort. nil here means 'no deterministic owner
     ;;     for this ambiguous load-order' — outbound pushes no-op and popstate
     ;;     skips until one binding is re-registered/removed through the live
     ;;     hook, which re-establishes a deterministic claim order.
@@ -189,8 +177,8 @@
   owner. Per Spec 012 §Multi-frame routing, duplicate `:url-bound? true`
   declarations are reported AND non-owners are prevented from pushing.
 
-  EP-0002 — `nil` frame-id (or no declared owner) is never the owner: the
-  runtime no longer synthesises `:rf/default` ownership from absence."
+  `nil` frame-id (or no declared owner) is never the owner; the runtime does
+  not synthesise `:rf/default` ownership from absence."
   [frame-id]
   (and (some? frame-id)
        (= frame-id (url-owner-frame-id))))
@@ -203,10 +191,10 @@
 ;; body lives once in `history-mutation-handler` and each handler closes
 ;; over its strategy-op key + fx-id.
 ;;
-;; rf2-aerrz5 (URL-strategy seam): the URL-owning frame's `:url-strategy`
+;; The URL-owning frame's `:url-strategy`
 ;; (default `history-url-strategy`, path-form) is consulted HERE — one of
 ;; the four egress/ingress consult points. The pushed URL arrives PATH-FORM
-;; (`route-url`/the cascade never encode). rf2-irygd6 — this fx is the SINGLE
+;; (`route-url` and the cascade never encode). This fx is the single
 ;; outbound encoding authority: it encodes the path-form URL to its final href
 ;; ONCE via the strategy's `:encode`, then hands that href to the RAW
 ;; `:push!`/`:replace!` leg, which drives `window.history` WITHOUT re-encoding
@@ -223,13 +211,11 @@
      `SecurityError` when asked to push/replace an absolute cross-origin
      URL (or on other history-API misuse) — left uncaught that crashes
      the fx drain (a DoS, worse than the redirect it would otherwise be).
-     The `url/external-url?` gate at the nav-event sinks (rf2-cylse.4)
+     The `url/external-url?` gate at the nav-event sinks
      already fails such URLs closed before they reach these fxs, so this
      catch is a second line of defence: any residual throw is downgraded
      to a structured `:rf.fx/<fx-id>-failed` trace, keeping the drain
-     alive. Factoring it here means BOTH `:rf.nav/push-url` and
-     `:rf.nav/replace-url` share one mutation-safety boundary, rather than
-     push having a catch and replace running bare (rf2-u8qe7y finding 2)."
+     alive. Both history effects share this mutation-safety boundary."
      [failed-trace-id fx-id frame url mutate!]
      (try
        (mutate!)
@@ -245,8 +231,7 @@
   is that pre-built `:rf.fx/<fx-id>-failed` keyword. `strategy-op` is the
   strategy-map key naming the history drive (`:push!` or `:replace!`).
 
-  rf2-aerrz5 (URL-strategy seam) / rf2-irygd6 (single outbound-encoding
-  authority): on CLJS the URL-owning frame's `:url-strategy` is resolved, its
+  On CLJS the URL-owning frame's `:url-strategy` is resolved, its
   `:encode` maps the PATH-FORM `url` to the final href ONCE (identity for
   history, `#`-prefix for hash, base-OUTSIDE-fragment for a based hash app),
   and that href is handed to the RAW `strategy-op` leg (`:push!` / `:replace!`)
@@ -262,7 +247,7 @@
   (if (url-bound-frame? frame)
     #?(:cljs (let [strat  (strategy/url-strategy-for-frame-id frame)
                    drive! (get strat strategy-op)
-                   ;; Single outbound-encoding authority (rf2-irygd6): encode
+                   ;; Single outbound-encoding authority: encode
                    ;; the path-form url to its final href ONCE here, then hand
                    ;; it to the RAW :push!/:replace! leg (which drives
                    ;; window.history without re-encoding). The failure/skip

--- a/implementation/routing/src/re_frame/routing/navigate.cljc
+++ b/implementation/routing/src/re_frame/routing/navigate.cljc
@@ -4,13 +4,12 @@
   Per Spec 012 §Navigation is an event. Programmatic navigation entry
   point: accepts a route-id (`[:rf.route/navigate :route/cart]`), a
   target-map (`{:url ...}` form), or the URL-string form. Honours
-  :can-leave, :params/:query validation, scroll-strategy resolution,
+  :can-leave and :can-enter, :params/:query validation, scroll resolution,
   :query-retain merge, and the rule-3 no-op short-circuit.
 
   Internal namespace; the public facade is `re-frame.routing`. The
   facade owns the `events/reg-event :rf.route/navigate` call so a
-  `:reload` re-wires it on a fresh registrar. Per the rf2-2yabr cohesion
-  split: NAVIGATE-EVENT seam."
+  `:reload` re-wires it on a fresh registrar."
   (:require [clojure.string :as str]
             [re-frame.frame :as frame]
             [re-frame.late-bind :as late-bind]
@@ -28,8 +27,8 @@
 ;;   [:rf.route/navigate target]              ;; no path-params, no opts
 ;;   [:rf.route/navigate target params]       ;; params 2nd, opts absent
 ;;   [:rf.route/navigate target params opts]  ;; params 2nd, OPTS THIRD
-;; The two trailing maps are positionally ambiguous to a reader
-;; (rf2-1os1c): the likely mistake is dropping an OPTS-shaped map into
+;; The two trailing maps are positionally ambiguous: the likely mistake is
+;; dropping an options-shaped map into
 ;; the PARAMS slot — `[:rf.route/navigate :route/x {:replace? true}]`
 ;; reads as "navigate with these path-params" but the author meant opts.
 ;; `opts-only-keys` names the keys that ONLY ever belong in the opts map.
@@ -37,10 +36,9 @@
   "Keys the trailing `opts` map recognises (Spec 012 §Navigation is an
   event) that are NOT path-param names. An occurrence of one of these in
   the PARAMS slot — and not as a declared path-param of the target route
-  — is the classic params/opts swap and is rejected (rf2-1os1c).
-  `:bypass-guards?` (rf2-p69yaz point 8) is the SET-valued rename of the
-  former single `:bypass-leave-guard?` opt — it skips `:leave` / `:enter`
-  / both guards for one navigation."
+  — is the classic params/opts swap and is rejected.
+  `:bypass-guards?` carries a set and skips `:leave`, `:enter`, or both
+  guards for one navigation."
   #{:replace? :scroll :fragment :bypass-guards?})
 
 (defn- misplaced-opts-keys

--- a/implementation/routing/src/re_frame/routing/on_match_error.cljc
+++ b/implementation/routing/src/re_frame/routing/on_match_error.cljc
@@ -1,10 +1,8 @@
 (ns re-frame.routing.on-match-error
   "`:on-match` error trap for re-frame2 routing.
 
-  Per Spec 012 §Per-route error handling: if any :on-match event errors
-  (a handler throws, a registered fx errors, or a downstream handler
-  errors during the drain — per Spec 009's structured error contract),
-  the runtime:
+  When a declared `:on-match` event produces an attributed
+  `:rf.error/handler-exception` record, the runtime:
     1. Sets `[:rf.runtime/routing :current :transition]` to `:error`.
     2. Populates `[:rf.runtime/routing :current :error]` with the
        structured error map (schema `:rf/error` per Spec 009 §error-contract).
@@ -13,29 +11,29 @@
        the error context.
 
   Mechanism: a corpus-wide listener on the always-on error-emit
-  substrate (per rf2-bacs4 / Spec 009 §What IS available in production)
+  substrate (Spec 009 §What IS available in production)
   receives every `:rf.error/handler-exception` record. The listener
   discriminates 'is this exception from an :on-match dispatch?' by:
     - reading the failing record's `:frame`
     - reading that frame's route slice at [:rf.runtime/routing :current]
     - checking `:transition` is `:loading` (the slice is mid-drain)
     - checking the failing record's full `:event` vector IS one of the
-      active route's declared `:on-match` vectors (rf2-cgh8q —
-      full-vector identity, not bare event-id membership; falls back to
+      active route's declared `:on-match` vectors (full-vector identity,
+      not bare event-id membership; falls back to
       id-membership only when the event was wire-elided)
 
   All four together identify the error as originating from an :on-match
   cascade for the currently-loading route. The listener then dispatches
   `:rf.route.internal/on-match-error` with the structured error map;
   that event flips `:transition`, populates the slice's `:error`, and
-  chains `:on-error`. Per rf2-576on the trap event is runtime-internal —
+  chains `:on-error`. The trap event is runtime-internal,
   sub-namespaced under `:rf.route.internal/*` so the user-facing
   `:rf.route/*` surface stays tidy.
 
   ## Failure semantics — later :on-match events + first-error-wins
 
-  Per rf2-25i7r7 (finding 3) + Spec 012 §Per-route error handling
-  §Failure semantics. The navigation cascade runs inside re-frame2's
+  Per Spec 012 §Per-route error handling §Failure semantics, the navigation
+  cascade runs inside re-frame2's
   locked FIFO run-to-completion drain (Spec 002 §Run-to-completion),
   which does NOT cancel events already queued. `commit-navigation`
   queues every `:on-match` dispatch (and the FIFO `settle-transition`)
@@ -68,8 +66,7 @@
   Internal namespace; the public facade is `re-frame.routing`. The
   facade owns the `events/reg-event` + `error-emit/register-error-listener!`
   calls so a `(require 're-frame.routing :reload)` on a fresh registrar
-  (`clear-all!` test fixture) re-wires both. Per the rf2-2yabr cohesion
-  split: ON-MATCH-ERROR-TRAP seam."
+  (`clear-all!` test fixture) re-wires both."
   (:require [re-frame.registrar :as registrar]
             [re-frame.frame :as frame]
             [re-frame.router :as router]))
@@ -100,9 +97,8 @@
   "True when the failing handler-exception `record` should be attributed
   to the active route's `:on-match` drain.
 
-  rf2-cgh8q — the attribution discriminator. Earlier this was bare
-  event-id MEMBERSHIP: `(contains? (on-match-event-ids meta) event-id)`.
-  That mis-attributes a NON-routing throw to the loading route whenever
+  Bare event-id membership would mis-attribute a non-routing throw to the
+  loading route whenever
   the app concurrently dispatches an event whose id happens to coincide
   with one of the route's `:on-match` ids during the loading window — the
   healthy route is then forced to `:error` and a spurious `:on-error`
@@ -113,7 +109,7 @@
   The tighter, still-always-on discriminator is full event-VECTOR
   identity against the route's declared `:on-match` vectors: a button
   dispatch carrying different args (or a bare `[:app/load-x]` versus the
-  route's `[:app/load-x 42]`) no longer collides. The full `:event`
+  route's `[:app/load-x 42]`) does not collide. The full `:event`
   vector rides the always-on error record (Spec 009 §Record shape), so
   this survives `:advanced` + `goog.DEBUG=false` like the rest of the
   trap.
@@ -166,8 +162,8 @@
         (not= nav-token current-token)
         {}
 
-        ;; rf2-25i7r7 (finding 3 — route failure semantics): FIRST-error-
-        ;; wins. The locked FIFO run-to-completion drain (Spec 002) does
+        ;; First error wins. The locked FIFO run-to-completion drain (Spec 002)
+        ;; does
         ;; not cancel already-queued events, so when a route declares
         ;; `:on-match [[:load/fail1] [:load/fail2]]` and BOTH throw, two
         ;; `:rf.route.internal/on-match-error` events land for the same
@@ -204,11 +200,11 @@
   `:rf.error/handler-exception` record; when the failing event-id was
   dispatched as part of the active route's `:on-match` (per the
   discrimination logic in this ns's docstring),
-  dispatches `:rf.route.internal/on-match-error` (rf2-576on) to the
+  dispatches `:rf.route.internal/on-match-error` to the
   offending frame so the slice flips to `:error` and `:on-error`
   chains.
 
-  Per Spec 012 §Per-route error handling and rf2-ye7sh."
+  Per Spec 012 §Per-route error handling."
   [{:keys [error event-id frame exception] :as record}]
   (when (= :rf.error/handler-exception error)
     ;; EP-0001 (rf2-vzld77): the route slice is durable routing runtime-db state.

--- a/implementation/routing/src/re_frame/routing/plan.cljc
+++ b/implementation/routing/src/re_frame/routing/plan.cljc
@@ -3,18 +3,15 @@
   (`:rf.route/navigate`) and URL-driven (`:rf.route/transitioned` /
   `:rf.route/handle-url-change`) entry points.
 
-  Per the rf2-u8qe7y best-practice review: before this seam each entry
-  point re-encoded the SAME pre-commit policy — fragment normalisation,
+  Both entry points share the same pre-commit policy: fragment normalisation,
   the `:rf.route/not-found` fallback shape + `:reason` vocabulary, the
   identical-/fragment-only/no-op classification, the telemetry the
   hostile-URL / missing-not-found-route streams must surface, and the
-  scroll-fx args — and only `commit-navigation` (the final commit
-  assembler in `re-frame.routing.events`) was actually shared. The
+  scroll-fx args, and `commit-navigation` (the final commit assembler in
+  `re-frame.routing.events`). The
   invariant is \"one navigation policy with entry-point-specific
   inputs\", so the shared pre-commit policy lives here, in ONE place,
-  rather than as two parallel policy bodies whose parity depends on
-  maintainers remembering to patch both and adding a regression test
-  after drift is discovered.
+  rather than as parallel policy bodies.
 
   Everything here is PURE (or returns telemetry as DATA). The two entry
   points resolve their target differently — the programmatic path has
@@ -27,8 +24,7 @@
   classification flags are resolved, BOTH feed the shared helpers below
   and then `commit-navigation`.
 
-  Internal namespace; the public facade is `re-frame.routing`. Per the
-  rf2-2yabr cohesion split convention: NAVIGATION-PLAN seam."
+  Internal namespace; the public facade is `re-frame.routing`."
   (:require [re-frame.routing.egress :as egress]
             [re-frame.routing.events :as routing-events]
             [re-frame.routing.scroll :as scroll]
@@ -37,7 +33,7 @@
 ;; ---- fragment normalisation ----------------------------------------------
 
 (defn normalize-fragment
-  "Collapse an explicit empty-string fragment to nil (rf2-zmcq6).
+  "Collapse an explicit empty-string fragment to nil.
 
   `route-url` (the URL builder) treats `:fragment \"\"` as NO fragment
   (emits no trailing `#`), but `\"\"` is truthy, so an un-normalised
@@ -143,13 +139,9 @@
 ;; ---- pre-commit telemetry intents ----------------------------------------
 
 ;; Per Spec 009 + Spec 012: a fail-closed navigation must surface the same
-;; structured telemetry regardless of WHICH entry point the hostile /
-;; unmatched URL arrived on. Before this seam each path emitted the
-;; `:rf.warning/malformed-url` + `:rf.warning/no-not-found-route` pair
-;; inline with subtly parallel `cond->` bodies, and the programmatic path
-;; once SHIPPED missing the URL-driven path's hostile-URL warning
-;; (navigate.cljc:426-437 documents the drift). Returning the intents as
-;; DATA — a vector of `[kind level-or-op op-or-tags tags?]` triples — and
+;; structured telemetry regardless of which entry point the hostile or
+;; unmatched URL arrived on. Returning the intents as data — a vector of
+;; `[kind level-or-op op-or-tags tags?]` tuples — and
 ;; running them through one `emit-intents!` driver makes the parity
 ;; structural: both callers build the same intent list from the same
 ;; inputs, so they cannot drift without changing this one fn.
@@ -168,13 +160,13 @@
                     (`:match-error`); emits `:rf.warning/malformed-url`
                     carrying `{:url :reason}`.
     :malformed?   — the URL's percent-encoding failed to decode; emits
-                    `:rf.warning/malformed-url` carrying `{:url}` (rf2-4ic0f).
+                    `:rf.warning/malformed-url` carrying `{:url}`.
                     Mutually exclusive with `:throw-reason` (a throw
                     pre-empts the malformed scan).
     :no-not-found? — the fallback resolved to `:rf.route/not-found` AND no
                     such route is registered; emits
                     `:rf.warning/no-not-found-route` carrying `{:url}`
-                    (rf2-0zr2o / Spec 012 §Route-not-found §3).
+                    (Spec 012 §Route-not-found §3).
     :url          — the requested URL.
     :frame        — the active frame; threaded onto every tag map when
                     present so the trace lands in the emitting frame's epoch

--- a/implementation/routing/src/re_frame/routing/registry.cljc
+++ b/implementation/routing/src/re_frame/routing/registry.cljc
@@ -1370,7 +1370,7 @@
 (defn route-url
   "Per Spec 012 §Bidirectional URL ↔ params. Build a URL string from a
   route-id + path-params (+ optional query-params + optional fragment).
-  Inverse of match-url.
+  Canonical inverse of `match-url` over values accepted by the route schema.
 
   Optional groups ({...}?) are emitted only when ALL their inner params
   are supplied in path-params; otherwise the group is silently elided.
@@ -1385,16 +1385,13 @@
   route's `:query` schema (caller bug — not user input). The exception
   carries `{:route-id :slot :error}` ex-data (rf2-ug2m1).
 
-  NIL-POLICY ASYMMETRY between PATH params and QUERY params (rf2-b3rzz —
-  deliberate, documented here so the split never costs a debugging
-  session):
+  Path and query values intentionally use different nil policies:
 
   - PATH params: a `nil` (or absent) value for a required `:name` /
     `*name` segment is a HARD ERROR — throws
     `:rf.error/missing-route-param`. The URL cannot be built without it.
-    A present-but-FALSY value (`false`, `0`, `\"\"`) is legitimate and
-    round-trips (the `if-some` discipline below discriminates falsy from
-    absent).
+    `false` and `0` round-trip. The empty string is also rejected because it
+    would emit a zero-length segment erased by trailing-slash normalization.
   - QUERY params: a `nil`-valued key is SILENTLY ELIDED — `{:page nil}`
     omits the key entirely rather than emitting a bare `?page=` or
     throwing. This is the useful default for absent OPTIONAL query keys
@@ -1402,45 +1399,41 @@
     chosen). A present-but-FALSY query value (`false`, `0`, `\"\"`) is a
     legitimate value and round-trips, same as the path side.
 
-  So `nil` means \"hard error\" on the path side and \"omit this key\" on
-  the query side — same function, two nil-policies. Authors relying on a
-  query key being present must supply a non-nil value.
+  Thus `nil` means \"hard error\" on the path side and \"omit this key\" on
+  the query side. Authors relying on a query key being present must supply a
+  non-nil value.
 
-  Performance (rf2-r1in4): this fn sits on the render path through
+  This function sits on the render path through
   `route-link-render` / `route-link-render-ssr` — large link lists
   re-render at navigation rate, and each link calls `route-url`. The
   pattern body and `:groups` lookup are read from `:rf.route/compiled`
   (precomputed at registration time by `parse-pattern`), so the inner
-  loop runs over a fixed-cost lookup table rather than re-walking the
-  pattern source. If a future profile shows `route-url` dominating the
-  render budget, the next step is to precompute URL-emission metadata
-  at `reg-route` time (analogous to `:rf.route/query-coerce`)."
+  loop uses the compiled group lookup rather than re-walking the pattern
+  source."
   ([route-id path-params] (route-url route-id path-params {} nil))
   ([route-id path-params query-params] (route-url route-id path-params query-params nil))
   ([route-id path-params query-params fragment]
    (let [query-params (or query-params {})
-         ;; rf2-w3qgc: elide nil-valued query keys BEFORE :query-schema
-         ;; validation (and reuse the elided map for emission below). Per
+         ;; Elide nil-valued query keys before schema validation, and reuse
+         ;; that same map for emission. Per
          ;; Spec 012 §Bidirectional URL ↔ params a nil-valued query key is
          ;; SILENTLY OMITTED — `{:page nil}` emits no key and never throws —
          ;; so a route declaring e.g. `:query [:map [:sort {:optional true}
          ;; :string]]` must accept `{:sort nil}` to mean "omit :sort" and
          ;; return `/search`, NOT raise `:rf.error/route-url-validation`.
-         ;; Validating the raw map first contradicted that policy (nil
-         ;; failed the `:string` branch). A present-but-falsy value
+         ;; A present-but-falsy value
          ;; (`false`, `0`, `""`) is a legitimate value and is preserved —
          ;; only `nil` is elided — so non-nil invalid values STILL fail
          ;; validation against the elided map.
          ;;
-         ;; rf2-wgutc2 (EP-0012 correctness review item 2): after nil
-         ;; elision the surviving entries are sorted into DETERMINISTIC
-         ;; CANONICAL KEY ORDER by their keys' shared CEDN-1 bytes
+         ;; Surviving entries are sorted into deterministic canonical key
+         ;; order by their keys' shared CEDN-1 bytes
          ;; (`re-frame.identity/canonical-bytes`), NOT the caller's
          ;; insertion order. Per Conventions §The `:rf/path` algebra
          ;; (route-url/match-url prism): "query keys are emitted in
          ;; deterministic canonical order". Two callers that pass the same
-         ;; query map spelled in different key orders now build the
-         ;; BYTE-IDENTICAL URL — a stable href for caching / dedupe /
+         ;; query map spelled in different key orders build the byte-identical
+         ;; URL — a stable href for caching / dedupe /
          ;; identical-route-target? no-op detection / SSR-hydration parity,
          ;; rather than a URL that varies with map literal order. The sort
          ;; is by the key's canonical EDN identity (the same order the
@@ -1453,9 +1446,8 @@
                                               query-params)))
          route-meta   (registrar/lookup :route route-id)
          pattern      (:path route-meta)
-         ;; rf2-dcmkke: the precompiled coercion tables (the SAME tables
-         ;; `match-url` decodes against) let the emission side run the
-         ;; INVERSE of the enum-keyword decode — a declared keyword-enum
+         ;; The same precompiled coercion tables `match-url` uses let the
+         ;; emission side invert enum-keyword decode: a declared keyword-enum
          ;; value emits its token name (`:asc` -> `asc`) so the prism
          ;; round-trips. Nil-safe: an undeclared route has empty tables and
          ;; `enum-keyword-token` is a passthrough for every key.
@@ -1483,7 +1475,7 @@
                    :slot     :params
                    :value    path-params
                    :error    p-error}))))
-     ;; rf2-w3qgc: validate the NIL-ELIDED query map (`emitted-query`), not
+     ;; Validate the nil-elided query map (`emitted-query`), not
      ;; the raw `query-params` — a nil-valued optional key is omitted per
      ;; Spec 012 and must not be presented to the schema (where it would
      ;; fail an optional non-nil branch). `:value` reports the elided map
@@ -1501,7 +1493,7 @@
      (let [n      (count pattern)
            ;; Per Spec 012 §Bidirectional URL ↔ params: optional groups
            ;; are emitted only when every inner param is supplied. The
-           ;; `:groups` map produced by `parse-pattern` (rf2-uovh5) maps
+           ;; `:groups` map produced by `parse-pattern` maps
            ;; each opening '{' index to `{:inner-names [...] :close-end
            ;; <pos-after-}?>}` — `route-url` consults it instead of
            ;; re-walking the pattern body.
@@ -1515,8 +1507,8 @@
            ;; mis-classify falsy as absent). `kind` ("path"/"splat") only
            ;; flavours the diagnostic message.
            ;;
-           ;; rf2-ede1h.2: an EMPTY-STRING value is rejected the same way
-           ;; as absent/nil. `false`/`0` stringify to non-empty segments
+           ;; An empty-string value is rejected like absent/nil. `false` and
+           ;; `0` stringify to non-empty segments
            ;; (`/page/false`, `/items/0`) that round-trip cleanly, but `""`
            ;; emits a ZERO-LENGTH segment (`/articles/` for `{:slug ""}`)
            ;; which `match-url`'s trailing-slash normalisation erases
@@ -1525,9 +1517,7 @@
            ;; segment has no representation for the empty string; rejecting
            ;; it on EMISSION (rather than silently emitting an
            ;; un-round-trippable URL) keeps the bidirectional contract
-           ;; honest. This narrows the spec's "present-but-falsy round-trips"
-           ;; to the values that actually CAN (`false`, `0`); `""` is the
-           ;; one falsy value with no legitimate segment form.
+           ;; honest. `""` is the one falsy value with no path-segment form.
            ;; A PRESENT value for a path segment must be non-empty. Shared
            ;; by `require-param` (top-level segments) and `emit-group`
            ;; (optional-group inner segments): the empty-string-segment
@@ -1584,13 +1574,13 @@
                    ;; URL the top-level path rejects. Spec 012's nil-policy
                    ;; table makes `""` a hard error for ANY path segment, so
                    ;; reject it here too (`false`/`0` still round-trip).
-                   ;; rf2-94o54l.1: same fail-closed identity gate as the
-                   ;; top-level path — an optional-group inner segment must
+                   ;; The same fail-closed identity gate as the top-level path:
+                   ;; an optional-group inner segment must
                    ;; not host-stringify a host value into the URL either.
                    (or (= ch \:) (= ch \*))
                    (let [splat?  (= ch \*)
                          [end k] (param-seg-bounds pattern n i)
-                         ;; rf2-dcmkke: map a declared keyword-enum value to
+                         ;; Map a declared keyword-enum value to
                          ;; its token name (`:asc` -> `asc`) before encoding
                          ;; so the path-side enum round-trips through match-url.
                          v       (->> (get path-params k)
@@ -1614,29 +1604,13 @@
                      (if all-present?
                        (let [[i' parts'] (emit-group (inc i) parts)]
                          (recur i' parts'))
-                       ;; ELIDE the group. Per rf2-5u1r6a the ONLY accepted
-                       ;; optional-group spelling is slash-INSIDE (`{/:id}?`,
-                       ;; `{/:base}?` — rf2-av1): the group OWNS its leading
-                       ;; slash inside the body, so eliding the whole group
-                       ;; drops that slash cleanly and can never orphan a
-                       ;; bracketing literal `/`. The slash-OUTSIDE inline
-                       ;; spelling (`{:base}?` between literal `/`s, e.g.
-                       ;; `/{:base}?/about`) — which rf2-8zvajk once accepted
-                       ;; and which is what produced the `//about`
-                       ;; protocol-relative-URL footgun on elision — is now
-                       ;; REJECTED at registration by `validate-optional-group!`,
-                       ;; so it can no longer reach this emitter.
+                       ;; Elide the group. Valid route patterns put the leading
+                       ;; slash inside the group, so removing the group also
+                       ;; removes its separator.
                        ;;
-                       ;; The separator-elision guard below is retained as
-                       ;; defence-in-depth: for a slash-INSIDE group the char
-                       ;; before `{` is a NON-slash (`...articles{` → last part
-                       ;; `"articles"`), so `prev-slash?` is false and the
-                       ;; guard is a no-op — the clean body elision stands. It
-                       ;; only ever fires for a would-be slash-outside shape,
-                       ;; which is now unreachable; a global `//`→`/` collapse
-                       ;; is still deliberately NOT used because a splat value
-                       ;; legitimately carries embedded `//` (`{:rest "a//b"}`
-                       ;; → `/files/a//b`) and must survive.
+                       ;; The separator guard is defensive for metadata installed
+                       ;; outside `reg-route`; never collapse `//` globally because
+                       ;; a splat may legitimately contain empty segments.
                        (let [prev-slash? (= "/" (peek parts))
                              next-slash? (and (< close-end n)
                                               (= \/ (.charAt ^String pattern close-end)))
@@ -1653,13 +1627,13 @@
 
                    ;; `:name` / `*name` in the top-level pattern — the
                    ;; value is REQUIRED; `require-param` throws on absent.
-                   ;; rf2-94o54l.1: a host value fails closed via
+                   ;; A host value fails closed via
                    ;; `assert-url-value!` BEFORE `encode-param` host-stringifies
                    ;; it into a fabricated route identity (EP-0012).
                    (or (= ch \:) (= ch \*))
                    (let [splat?  (= ch \*)
                          [end k] (param-seg-bounds pattern n i)
-                         ;; rf2-dcmkke: a declared keyword-enum path param
+                         ;; A declared keyword-enum path param
                          ;; emits its token name (`:desc` -> `desc`), the
                          ;; inverse of match-url's enum decode, so it
                          ;; round-trips rather than emitting `%3Adesc`.
@@ -1670,23 +1644,22 @@
 
                    :else
                    (recur (inc i) (conj parts (str ch)))))))
-           ;; rf2-5u1r6a: a pattern whose ENTIRE path is a leading optional
+           ;; A pattern whose entire path is a leading optional
            ;; group (`{/:base}?`) elides to the empty string when the param
            ;; is absent — but the empty string is not a URL. Normalise it to
            ;; the root `/` (the group's own leading slash is the only slash
            ;; the pattern carries, so its absence lands at root). This is the
-           ;; slash-INSIDE analogue of the old slash-outside `root-only?`
-           ;; guard; `{/:base}?` absent → `/`, present → `/x`.
+           ;; group; `{/:base}?` absent → `/`, present → `/x`.
            path-out (let [s (apply str parts)]
                       (if (= "" s) "/" s))
-           ;; rf2-w3qgc: `emitted-query` (the nil-elided query map) is
+           ;; The nil-elided query map is
            ;; computed once at the top of the fn so the SAME elided map
            ;; both feeds `:query`-schema validation AND drives URL emission.
            ;; `{:page nil}` omits the key rather than emitting a bare
            ;; `?page=`; a present-but-falsy value (`false`, `0`, `""`) is a
            ;; legitimate query value and round-trips, but `nil` means
            ;; "absent" and is elided.
-           ;; rf2-94o54l.1: query KEYS are already CEDN-guarded by the
+           ;; Query keys are already CEDN-guarded by the
            ;; canonical-order sort that built `emitted-query` (it runs each
            ;; surviving key through `identity/canonical-bytes`, which throws
            ;; on a host key). The VALUES went straight to `url/url-encode`'s
@@ -1694,15 +1667,14 @@
            ;; the URL. Guard each non-nil value through `assert-url-value!`
            ;; (nil values are already elided out of `emitted-query`) so the
            ;; value side fails closed the same way the key side does.
-           ;; rf2-jlufhn: emit a keyword key via the REVERSIBLE
+           ;; Emit a keyword key via the reversible
            ;; `query-key->url-token` (namespace-preserving) so `:user/id`
            ;; emits `user/id` (percent-encoded `user%2Fid`) and round-trips
            ;; back to `:user/id` on the match side — `(name :user/id)` =>
-           ;; `"id"` dropped the namespace, collapsing `:user/id` and
-           ;; `:account/id` into one `id=` URL key and breaking the EP-0012
-           ;; route-prism law. A string key (an undeclared caller-supplied
+           ;; `"id"` would drop the namespace and collapse `:user/id` and
+           ;; `:account/id` into one `id=` URL key. A string key
            ;; query key the route did not name) is emitted verbatim.
-           ;; rf2-dcmkke: a declared keyword-enum query VALUE emits its token
+           ;; A declared keyword-enum query value emits its token
            ;; name (`:asc` -> `asc`), the inverse of match-url's enum decode,
            ;; so the value round-trips back to the canonical keyword instead
            ;; of `(str :asc)` -> `%3Aasc` (which match-url reads as the string
@@ -1724,8 +1696,8 @@
            ;; fragments: the 4-arity emits `#fragment` when non-nil and
            ;; non-empty. Empty-string fragments collapse to no fragment.
            ;;
-           ;; The fragment is PERCENT-ENCODED on emission (rf2-ede1h.1) —
-           ;; symmetric with `match-url`/`split-fragment`, which decode the
+           ;; Percent-encode the fragment symmetrically with
+           ;; `match-url`/`split-fragment`, which decode the
            ;; `#fragment` portion through `url/safe-url-decode`
            ;; (decodeURIComponent semantics). `url/url-encode` is the exact
            ;; inverse, so the round-trip is byte-exact: a fragment value
@@ -1734,8 +1706,8 @@
            ;; the raw value instead produced `#50% done`, which `match-url`
            ;; then read as malformed (`safe-url-decode` throws on the bare
            ;; `%`) → nil — breaking the bidirectional URL contract for any
-           ;; fragment with a `%` or other %-significant character.
-           ;; rf2-jlufhn: validate the fragment is a string-or-nil BEFORE
+           ;; fragment with a `%` or other %-significant character. Validate
+           ;; that the fragment is a string or nil before
            ;; the truthiness/empty gate, so a non-string fragment (a number,
            ;; keyword, boolean, function, host object) FAILS CLOSED rather
            ;; than being host-stringified into a bogus URL identity or

--- a/implementation/routing/src/re_frame/routing/reply.cljc
+++ b/implementation/routing/src/re_frame/routing/reply.cljc
@@ -1,19 +1,18 @@
 (ns re-frame.routing.reply
-  "Spec 012 — lower route-loader async work onto the uniform reply
-  envelope (EP-0011 §Route Loader Completion; the canonical contract is
-  `spec/Managed-Effects.md` §The uniform reply envelope).
+  "Lower route-loader async work onto the uniform reply envelope. The
+  canonical contract is `spec/Managed-Effects.md` §The uniform reply envelope.
 
   ## What this namespace is
 
-  The internal seam that expresses route-loader stale suppression as an
-  ORDINARY reply-envelope `:suppress` gate rather than a bespoke
+  This internal seam expresses route-loader stale suppression as an ordinary
+  reply-envelope `:suppress` gate rather than a bespoke
   per-family token mechanism. A route loader's async completion is keyed
   by the route work-id `[:rf.work/route route-id nav-token loader-id]`
   and gated by the data-only suppression map `{:route/nav-token
   nav-token}`, validated against the live `[:rf.runtime/routing :current
   :nav-token]` before the app reply target runs. The PUBLIC routing API
   (the `:rf.route/nav-token` cofx, `:rf.route/with-nav-token`, `:on-match` /
-  loaders) is PRESERVED — this is internal lowering only.
+  loaders) is unchanged; this is internal lowering only.
 
   Two concerns, both consuming the shared `re-frame.reply` substrate:
 
@@ -22,15 +21,15 @@
       (Managed-Effects §Work-id correlation). The nav-token is NOT a
       second stale-suppression key in its own right — it is the value of
       the ONE suppression gate (`:route/nav-token`) AND a component of
-      the work-id tuple; the same fact, named once. Per EP-0007 there is
-      no `:stale-key`-style synonym.
+      the work-id tuple; the same fact has no `:stale-key`-style synonym.
 
    2. **Stale-suppression gate** (`gate` / `current-gate` / `suppress?`
       / `suppress`). The carried gate `{:route/nav-token <captured>}` is
       matched against the current gate `{:route/nav-token <live>}` via
       `re-frame.reply/stale?` — the shared correctness boundary. On
-      mismatch `re-frame.reply/suppress` produces the `:status :stale`
-      reply (no app mutation) and the data-only trace facts joined to
+      mismatch `re-frame.reply/suppress` produces an unqualified
+      `:status :stale` reply (the canonical reply-map vocabulary, with no
+      app mutation) and data-only trace facts joined to
       `:rf.reply/work-id`; the app reply target does NOT run. On match the live
       reply (`:ok` / `:error`, and `:cancelled` for an explicit user
       cancel) flows through to the handler unchanged.
@@ -50,8 +49,8 @@
 ;; ---------------------------------------------------------------------------
 ;; Work-id correlation (Managed-Effects §Work-id correlation).
 ;;
-;; Route head: `[:rf.work/route route-id nav-token loader-id]`. One ATTEMPT
-;; has one `:rf.reply/work-id` (the EP-0007 rule): a distinct nav-token (a fresh
+;; Route head: `[:rf.work/route route-id nav-token loader-id]`. One attempt
+;; has one `:rf.reply/work-id`: a distinct nav-token (a fresh
 ;; navigation epoch) is a distinct attempt, so the nav-token rides IN the
 ;; work-id tuple. The nav-token is the same fact named once — it is the
 ;; component that discriminates a superseded attempt AND the value of the
@@ -76,8 +75,8 @@
 ;; ---------------------------------------------------------------------------
 ;; The stale-suppression gate (Managed-Effects §Stale suppression). The
 ;; nav-token is lowered to the ONE data-only suppression gate
-;; `{:route/nav-token <token>}` — exactly the gate shape EP-0011
-;; §Specification and the §The reply target descriptor example use
+;; `{:route/nav-token <token>}` — the gate shape the reply target descriptor
+;; example uses
 ;; (`:suppress {:route/nav-token "nav-7"}`). The carried gate is captured at
 ;; scheduling time; the current gate is read from the live route slice at
 ;; completion. They are compared by the shared `re-frame.reply/stale?` — no
@@ -129,7 +128,7 @@
   :rf.route/nav-token-stale)
 
 ;; ---------------------------------------------------------------------------
-;; Live completion (rf2-2avo53). When the carried nav-token is STILL current,
+;; Live completion. When the carried nav-token is still current,
 ;; the route-loader completion is a LIVE reply (`:status :ok` — `:partial` is
 ;; not a route-loader case; HTTP decode lands `:ok`/`:error` and the route
 ;; gate runs on top). The route wrapper lowers the live continuation onto the
@@ -139,18 +138,18 @@
 ;; is appended as the final argument of the target event and the target's
 ;; accumulated `::post` transform is applied. The route surface therefore
 ;; exercises `re-frame.reply/complete` at the ACTUAL navigation wrapper, not
-;; only in the pure unit helper.
+;; only in a pure helper.
 ;; ---------------------------------------------------------------------------
 
 (defn live-reply
   "Build the LIVE `:status :ok` route-loader reply map for a completion whose
   carried nav-token is still current (Managed-Effects §The reply map / §Status
   taxonomy). Carries the route `:rf.reply/work-id` + `:rf.reply/work-kind :route`, the loader's
-  decoded result `:value` (the reply-result spelling EVERYWHERE — EP-0007;
+  decoded result under the canonical unqualified `:value` slot;
   `nil` for a loader that produced no payload — `:ok` REQUIRES `:value`
   present, so it rides even when nil rather than being omitted), the carried
-  frame stamp, and the causal `:completed-at` (EP-0010 — the reply token's
-  reading, never a fresh ambient clock read). Frame / completed-at are omitted
+  frame stamp, and the causal `:completed-at` (the reply token's reading,
+  never a fresh ambient clock read). Frame / completed-at are omitted
   when absent.
 
   `ctx` is `{:route-id … :nav-token <carried> :loader-id … :frame …
@@ -174,12 +173,12 @@
   build the `:status :ok` reply map (`live-reply`) and append it to the
   target's event via the shared `re-frame.reply/complete` — the pure functor
   the EP-0011 mapping law (`complete (map-completed-event f t) == f (complete t)`) is
-  stated over. Returns the dispatchable completed event vector (the target
+  states. Returns the dispatchable completed event vector (the target
   event with the reply map appended, then the target's `::post` transform
   applied), or nil when `target` is nil (no continuation).
 
   This is the production lowering the route wrapper drives on the live branch
-  (rf2-2avo53): the route surface normalizes + completes a `:rf/reply-to`
+  The route surface normalizes and completes a `:rf/reply-to`
   target through the shared substrate, rather than running an ad-hoc `:do` fx
   entry that never touches the reply envelope."
   ([ctx target] (complete-live ctx target nil))

--- a/implementation/routing/src/re_frame/routing/scroll.cljc
+++ b/implementation/routing/src/re_frame/routing/scroll.cljc
@@ -4,22 +4,21 @@
 
   Per Spec 012 §Scroll restoration §Multi-frame routing.
 
-  ## Storage: host-side per-frame TRANSIENT cache (rf2-1hncp2)
+  ## Storage: host-side per-frame transient cache
 
   Saved scroll positions are a **host-side transient cache** keyed by
   frame-id — NOT runtime-db state. They are host-derived (read from
   `window.scrollX/Y`), bounded LRU caches, meaningless server-side, and
   not needed to reconstitute a coherent frame-state on restore /
-  SSR-hydration / time-travel (Mike ruling, EP-0001 decision #13:
-  runtime-db = serializable facts NEEDED for restore; host handles +
-  dirty caches stay TRANSIENT). Holding them in a module-level `defonce`
-  atom keeps them OFF the trace / epoch / snapshot egress wire entirely
-  — the storage location, not an egress filter, is what keeps them local.
+  SSR hydration or time-travel. Holding the cache in a module-level
+  `defonce` atom keeps the stored cache out of runtime-db snapshots and
+  hydration. Individual positions may still flow through registered effect
+  arguments, whose trace copies use the ordinary effect classification.
 
   The cache lives in `scroll-positions-cache` below: a
   `{frame-id {:positions {url [x y]} :order [url ...]}}` atom, mirroring
-  the HTTP in-flight registry pattern (`re-frame.http.registry`, EP-0001
-  ~line 901). It is LRU-capped per-frame by `scroll-positions-cap` with
+  other host-side registries. It is LRU-capped per-frame by
+  `scroll-positions-cap`, with
   recency tracked by the per-frame `:order` vector. A frame's entry is
   released by `release-frame!` on frame destroy (analogous to the other
   transient teardown hooks).
@@ -31,7 +30,7 @@
 
   Internal namespace; the public facade is `re-frame.routing`. The
   facade owns the two `fx/reg-fx` calls so a `:reload` re-wires them on
-  a fresh registrar. Per the rf2-2yabr cohesion split: SCROLL seam."
+  a fresh registrar."
   (:require [re-frame.frame :as frame]
             [re-frame.routing.registry :as registry]
             [re-frame.trace :as trace]))
@@ -43,7 +42,7 @@
   per-frame host cache stays bounded over long sessions."
   50)
 
-;; ---- host-side per-frame transient cache (rf2-1hncp2) ---------------------
+;; ---- host-side per-frame transient cache ----------------------------------
 
 (defonce scroll-positions-cache
   ;; frame-id → {:positions {url [x y]} :order [url ...]}.
@@ -51,8 +50,7 @@
   ;; Host-side TRANSIENT cache: scroll positions are host-derived
   ;; (window.scrollX/Y), bounded LRU, and meaningless on the server /
   ;; after a restore to a different route — NOT runtime-db state and NOT
-  ;; serialized into epochs / SSR payloads (per EP-0001 decision #13 +
-  ;; the rf2-1hncp2 ruling). Keyed by frame-id so multi-frame apps keep
+  ;; serialized into epochs / SSR payloads. Keyed by frame-id so multi-frame apps keep
   ;; isolated per-frame caches; the entry is dropped on frame destroy via
   ;; `release-frame!`. Mirrors `re-frame.http.registry`'s `in-flight`
   ;; defonce atom — host-owned ephemeral state, not in the reactive db.

--- a/implementation/routing/src/re_frame/routing/strategy.cljc
+++ b/implementation/routing/src/re_frame/routing/strategy.cljc
@@ -1,17 +1,12 @@
 (ns re-frame.routing.strategy
-  "URL-strategy seam for re-frame2 routing (rf2-aerrz5).
+  "URL-strategy seam for re-frame2 routing.
 
   Per Spec 012 §URL strategies. The router is PATH-FORM on the write
   side: `route-url` builds `/active`, `match-url` reads `/active`, and
   the standard history fxs `pushState`/`replaceState` a path-form URL.
-  A hash-URL app (`#/active`) — the shape most secretary-era v1 apps
-  actually are — therefore had to hand-roll a `hashchange` adapter and
-  hand-build `#/active` hrefs, forfeiting `route-link` / `route-url` /
-  `:rf.route/navigate` wholesale.
-
   A **`:url-strategy`** is a frame-level config map consulted at exactly
-  FOUR egress/ingress points — the two history fxs, the `route-link`
-  href render, and the URL-change listener install. Everything else —
+  four integration surfaces — the two history fxs, the `route-link` href
+  render, and the URL-change listener. Everything else —
   `route-url`, `match-url`, the whole navigation cascade — stays PURE
   and PATH-FORM. The strategy is the thin skin between the router's
   path-form model and the browser's chosen address-bar form.
@@ -25,17 +20,18 @@
      :install-listener! (fn [on-change] teardown)}
 
   - `:encode` maps a path-form app URL (`/active?q=milk`) to the browser
-    href form (`#/active?q=milk` for hash; unchanged for history). PURE.
+    href form (`#/active?q=milk` for hash; unchanged for history). Pure and
+    host-agnostic.
   - `:decode` reads the CURRENT browser URL and returns its path-form
-    (`#/active` → `/active`; `pathname+search+hash` → itself for
-    history). Side-reading (touches `window.location`), CLJS-only.
+    (`#/active` → `/active`; `pathname+search+hash` → itself for history).
+    It reads `window.location` on CLJS and returns `/` without a browser.
   - `:push!` / `:replace!` drive `window.history` with the ENCODED href
     — `:push!` adds a history entry, `:replace!` overwrites the current
     one. They are RAW window.history legs: `:encode` is the SINGLE
     outbound encoding authority (the nav fxs encode the path-form URL to
-    its final href ONCE and hand it here), so `:push!` / `:replace!` MUST
-    NOT re-encode — a custom strategy's legs receive the already-encoded
-    href verbatim (rf2-irygd6). Side-effecting, CLJS-only.
+    its final href once and hand it here), so `:push!` / `:replace!` must
+    not re-encode. A custom strategy's legs receive the already-encoded href
+    verbatim. Side-effecting, CLJS-only.
   - `:install-listener!` installs the browser URL-change listener and
     returns a 0-arg teardown thunk. `on-change` is a 1-arg fn the
     listener calls with the DECODED path-form URL on every browser-driven
@@ -54,18 +50,15 @@
   `:url-bound? true` is already URL-free (Spec 012 §Multi-frame routing),
   so a non-url-bound frame IS the 'memory' case, spec-free.
 
-  SSR IGNORES STRATEGIES. On the server there is no `window` and no
+  SSR does not execute strategy side effects. On the server there is no
   address bar: the request URL is fed in path-form via
   `:rf.route/handle-url-change`, the view renders against the slice, and
-  `route-link` emits its path-form `<a href>` shell (the CLJS render fn's
-  strategy-encoded href takes over on hydration). A hash never reaches
-  the server. So every strategy key here is CLJS-only (the JVM/SSR half
-  is a no-op), and the four consult points fall back to path-form when no
-  `window` is present.
+  `route-link` emits its path-form `<a href>` shell. A hash never reaches the
+  server. The pure `:encode` and fallback `:decode` functions remain present
+  on the JVM; `:push!`, `:replace!`, and `:install-listener!` are CLJS-only.
 
   Internal namespace; the public facade is `re-frame.routing`, which
-  re-exports the two shipped strategies. Per the rf2-2yabr cohesion
-  split: URL-STRATEGY seam."
+  re-exports the two shipped strategies."
   (:require [re-frame.registrar :as registrar]))
 
 ;; ---- history strategy (default) ------------------------------------------
@@ -171,7 +164,7 @@
 #?(:cljs
    (defn hash-push!
      "Hash strategy `:push!` — push a NEW history entry carrying the
-     already-encoded hash href. RAW (rf2-irygd6): `:encode` is the single
+     already-encoded hash href. `:encode` is the single
      outbound encoding authority — the nav fxs encode the path-form URL to
      `#/active` ONCE and hand it here — so this leg pushes the href
      UNCHANGED and must NOT re-encode, or a base-path deploy would
@@ -185,7 +178,7 @@
    (defn hash-replace!
      "Hash strategy `:replace!` — overwrite the current history entry with
      the already-encoded hash href via `replaceState` (no new entry). RAW,
-     like `hash-push!` (rf2-irygd6): `:encode` is the single outbound
+     like `hash-push!`: `:encode` is the single outbound
      encoding authority, so this leg replaces with the href UNCHANGED — no
      internal `hash-encode`."
      [href]
@@ -222,7 +215,7 @@
                    :install-listener! hash-install-listener!}
             :clj  {})))
 
-;; ---- base-path combinator (rf2-g8pbwg) ------------------------------------
+;; ---- base-path combinator -------------------------------------------------
 ;;
 ;; A frame served from a deployment SUB-PATH — a host mounting several demos
 ;; side by side, so an app that owns `/` on its own instead lives at
@@ -232,12 +225,14 @@
 ;; href / history URL (so the address bar and `route-link` hrefs carry the
 ;; real mount-point path).
 ;;
-;; `with-base-path` is a COMBINATOR over an existing strategy, not a third
+;; `with-base-path` is a combinator over an existing strategy, not a third
 ;; shipped strategy: base-path handling is orthogonal to address-bar FORM
 ;; (history vs hash). It wraps the four egress/ingress consult points —
 ;; `:encode` / `:decode` / `:push!` / `:replace!` / `:install-listener!` —
 ;; so the wrapped strategy's own form (identity vs `#`-prefix) is preserved
-;; underneath the base-path prefix/strip.
+;; underneath the base-path prefix/strip. It wraps `:encode`, `:decode`, and
+;; listener ingress; the already-encoded `:push!` / `:replace!` legs pass
+;; through unchanged.
 
 (defn- normalize-base-path
   "Normalize a base-path string: nil / blank -> `\"\"` (no base); else
@@ -258,8 +253,8 @@
   bare string-prefix test would mis-slice a prefix-sharing SIBLING (base `/app`
   must NOT strip `/application`, `/apple`, `/app-admin`). A `url` that is not
   under the base — including such a sibling, or a fully unrelated URL — is
-  returned UNCHANGED (defensive: fails safe rather than mis-slicing the path).
-  A blank `base` is a no-op. Pure. (rf2-vuv84a)"
+  returned unchanged (defensive: fails safe rather than mis-slicing the path).
+  A blank `base` is a no-op. Pure."
   [base url]
   (if (and (seq base)
            (or (= url base)
@@ -278,8 +273,8 @@
     - `:decode`            strips `base` off the wrapped strategy's decoded
                            path-form URL.
     - `:encode`            re-adds `base` to the wrapped strategy's encoded
-                           href — the SINGLE outbound base-composition point
-                           (rf2-irygd6). `route-link` renders this href and the
+                           href — the single outbound base-composition point.
+                           `route-link` renders this href and the
                            nav fxs push it, so the mount-point prefix sits
                            OUTSIDE the address-bar form (`/demos#/active` for a
                            hash app, `/demos/active` for a history app).
@@ -318,7 +313,7 @@
       (merge strategy
              {:encode (fn [path] (str b ((:encode strategy) path)))
               :decode (fn [] (strip-base-path b ((:decode strategy))))}
-             ;; :push! / :replace! are deliberately NOT wrapped (rf2-irygd6):
+             ;; :push! / :replace! are deliberately not wrapped:
              ;; `:encode` is the single outbound encoding authority — the nav
              ;; fxs encode once and hand these RAW legs the final base-prefixed
              ;; href — so the inner strategy's :push!/:replace! pass through via
@@ -345,8 +340,7 @@
 (defn url-strategy-from-config
   "Read `:url-strategy` from a frame's stored `reg-frame` config map,
   defaulting to `history-url-strategy` when unset (or when `config` is not
-  a map). The default is the identity/path-form strategy, so a frame that
-  declares nothing behaves exactly as before this seam existed."
+  a map). The default is the identity/path-form strategy."
   [config]
   (or (when (map? config) (:url-strategy config))
       history-url-strategy))

--- a/implementation/routing/src/re_frame/routing/sub_egress.cljc
+++ b/implementation/routing/src/re_frame/routing/sub_egress.cljc
@@ -1,6 +1,6 @@
 (ns re-frame.routing.sub-egress
-  "Route-sub egress projection — the EP-0025 sub-egress complement of the
-  route-classification lowering (`re-frame.routing.classification`, rf2-mtzv5m).
+  "Route-sub egress projection, complementing the route-classification
+  lowering in `re-frame.routing.classification`.
 
   ## The problem
 
@@ -8,9 +8,8 @@
   `{:query … :params …}` current-state projection. At route activation those
   declarations are RE-ROOTED to runtime-db-absolute paths under
   `[:rf.runtime/routing :current …]` and lowered into the per-frame elision
-  registry (`:source :route`). The SSR hydration egress already honours that
-  re-rooting (`re-frame.ssr.payload-policy/project-routing-egress`, seeded at
-  `:path [:rf.runtime/routing]`, rf2-4xut98).
+  registry (`:source :route`). SSR hydration honours that re-rooting by
+  seeding its routing projection at `:path [:rf.runtime/routing]`.
 
   But the DIRECT-READ egress surfaces of the bare route slice do NOT. The
   `:rf/route` sub returns the BARE slice (`{:route-id :params :query …}`) read
@@ -27,7 +26,7 @@
   (\"only the trace bus / Xray / MCP / off-box / SSR egress copies are
   redacted\").
 
-  ## The fix (Mike-ruled (a), rf2-mtzv5m — NARROW)
+  ## Direct-read projection
 
   Apply the route classification at the direct-read egress of the route's read
   surfaces, by re-seeding the egress walk at the route slice's runtime-db
@@ -54,19 +53,19 @@
     | `:rf.route/params`| the `:params` map            | `[:rf.runtime/routing :current :params]`  |
 
   The other `:rf.route/*` derived subs (`:rf.route/id`, `:transition`,
-  `:error`, `:fragment`, `:chain`) carry no classifiable secret (the route id /
-  transition keyword / fragment string / parent chain are structural), so they
-  are NOT in the table — they ride verbatim.
+  `:error`, `:fragment`, `:chain`) are not projections covered by the route
+  classification contract, so they are not in this table. This makes no
+  general sensitivity claim about a fragment or error value; those surfaces
+  use their own trace/egress policies.
 
   Core stays DECOUPLED: routing publishes the seed-path resolver and the
   projector through the late-bind table (`:routing/route-sub-egress-path` /
   `:routing/project-route-sub-egress`); core consults the hook keys without a
-  static `:require` on routing (rf2-k682). Absent the routing artefact the hooks
+  static `:require` on routing. Absent the routing artefact the hooks
   are unbound and the egress surfaces walk the value with NO route re-seeding —
   there is no route slice to leak anyway.
 
-  Internal namespace; the public facade is `re-frame.routing`. Per the
-  rf2-2yabr cohesion split convention: SUB-EGRESS seam."
+  Internal namespace; the public facade is `re-frame.routing`."
   (:require [re-frame.elision :as elision]))
 
 #?(:clj (set! *warn-on-reflection* true))

--- a/implementation/routing/src/re_frame/routing/subs.cljc
+++ b/implementation/routing/src/re_frame/routing/subs.cljc
@@ -3,24 +3,25 @@
 
   Per Spec 012. Subs live in this artefact (not re-frame.core) so apps
   that don't pull day8/re-frame2-routing carry no `:rf.route/*` strings
-  on their production-elision bundle (rf2-k682).
+  in their production bundle.
 
   The route slice lives at `[:rf.runtime/routing :current]` per
   Spec-Schemas §`:rf/runtime-db` — `{:route-id :params :query :transition
   :error :fragment :nav-token}`. (`:route-id` is the slice key; the
-  consumer-facing sub-id stays `:rf.route/id`, rf2-3a5nk7.) The only other routing-runtime sub-key is
-  `:pending-navigation` (its own `:rf/pending-navigation` sub), a flat
-  sibling under `[:rf.runtime/routing ...]`, so the slice carries ONLY the
+  consumer-facing sub-id stays `:rf.route/id`.) `:pending-navigation` has its
+  own `:rf/pending-navigation` sub, and the optional Resources integration may
+  add resource-blocking bookkeeping as another sibling. Because all of these
+  sit beside `:current` under `[:rf.runtime/routing ...]`, the slice carries only the
   published fields and the layer-1 `:rf/route` sub reads it directly — no
   projection needed (views that deref `[:rf/route]` are isolated from the
   pending-nav slot by structure, not by `select-keys`). The nav-token /
   pending-nav COUNTERS are NOT runtime-db siblings — like the scroll
-  positions they live in host-side transient caches (rf2-oosjmh /
-  rf2-1hncp2), off the reactive db, so no counter tick ever reaches a sub.
+  positions they live in host-side transient caches, off the reactive db, so
+  no counter tick ever reaches a sub.
 
   Internal namespace; the public facade is `re-frame.routing`. The
   facade owns the `subs/reg-sub` calls so a `:reload` re-wires them on a
-  fresh registrar. Per the rf2-2yabr cohesion split: SUBS seam."
+  fresh registrar."
   (:require [re-frame.registrar :as registrar]))
 
 (defn route-sub-fn

--- a/implementation/routing/src/re_frame/routing/test_support.cljc
+++ b/implementation/routing/src/re_frame/routing/test_support.cljc
@@ -1,7 +1,7 @@
 (ns re-frame.routing.test-support
   "Test-support namespace for the routing artefact (Spec 012).
 
-  ## What lives here (rf2-dbiv8 — keep test fixtures out of the production façade)
+  ## What lives here
 
   This namespace is the **sole home** for the routing test-only fixture
   event:
@@ -18,23 +18,11 @@
   fixtures, so it lives behind an explicit test-support require rather
   than in the always-on production registry.
 
-  ## Why this exists at all (rf2-dbiv8, mirrors rf2-cdmle / rf2-zk08x)
+  ## Loading boundary
 
-  `:rf.test/simulate-http-resolution` was previously registered
-  UNCONDITIONALLY in the `re-frame.routing` façade — so a test-runner-
-  internal `:rf.test/*` event (reserved by Spec 008 / Conventions.md per
-  the `:rf.test/*` namespace) was registered into the registry of EVERY
-  app that did `(:require [re-frame.routing])`, and the keyword string
-  survived into production bundles. The managed-HTTP artefact already
-  solved the identical posture mismatch for its canned-stub fxs by
-  gating registration on an explicit `re-frame.http.test-support` require
-  (rf2-cdmle, follow-up to rf2-zk08x); this namespace applies the same
-  pattern to routing.
-
-  Production posture: this namespace is unreferenced from any production
-  module, so CLJS `:advanced` trims it wholesale (fx-id keyword string
-  fragments and all) and JVM/SSR sees classpath absence through the
-  normal artefact require boundary.
+  No production namespace requires this one, so CLJS `:advanced` can trim it
+  wholesale. The namespace remains present in the routing artefact on JVM;
+  its fixture event is registered only when a consumer explicitly requires it.
 
   ## Adoption
 

--- a/implementation/routing/src/re_frame/routing/tooling.cljc
+++ b/implementation/routing/src/re_frame/routing/tooling.cljc
@@ -1,26 +1,24 @@
 (ns re-frame.routing.tooling
-  "Routing tooling sibling of `re-frame.routing` — carries the EP-0014
-  slice-5 derivation/process algebra view of registered routes
+  "Routing tooling sibling of `re-frame.routing`. It carries the
+  derivation/process algebra view of registered routes
   (`route-algebra-view`, the static graph) and of a frame's live route
   slice (`route-slice-algebra-view`, the live graph) that pair tools (Xray,
   re-frame2-pair-mcp) and the conformance fixtures query, but no production
-  application code reads.
+  application runtime code reads.
 
-  Mirrors the rf2-s8w3nw `re-frame.flows.tooling` split (and the rf2-bmzq0
-  `re-frame.subs.tooling` / rf2-qwm0a `re-frame.trace.tooling` splits before
-  it):
+  Loading contract:
     - CLJS consumers needing the surface call
       `re-frame.routing.tooling/<name>` directly. Apps that load the
-      routing artefact but never attach a tool DCE the body wholesale (the
+      routing artefact but never attach a tool can DCE the body wholesale (the
       sibling ns is loaded only when a test fixture, tool, or dev preload
       requires it; the `re-frame.routing` facade never `:require`s it).
     - JVM consumers keep an ergonomic `re-frame.routing/<name>` alias (gated
-      under `#?(:clj ...)`). The JVM has no bundle to protect; the alias
-      costs nothing. The whole routing artefact is already bundle-isolated
+      under `#?(:clj ...)`). The alias adds no browser bundle surface. The
+      whole routing artefact is already bundle-isolated
       from production builds (the counter example never `:require`s
       `re-frame.routing`), so this sibling can never reach a no-routing
       app's bundle; the explicit sentinel at the foot of this ns
-      additionally proves no stray `:require` ever pulled the body in.
+      is checked by the sentinel at the foot of this namespace.
 
   READ-ONLY over the registry. Like slice-2's subs.tooling read the sub
   registrar and slice-3's flows.tooling read the flow registry, this ns
@@ -39,7 +37,7 @@
 
 #?(:clj (set! *warn-on-reflection* true))
 
-;; ---- algebra views (EP-0014 slice-5) -------------------------------------
+;; ---- algebra views --------------------------------------------------------
 ;;
 ;; Per [Derivations.md] §Routes expose algebra views — a route is the
 ;; canonical `:runtime-db` / `:on-route` / `:frame` PROCESS-LIKE member of
@@ -48,7 +46,7 @@
 ;; loaders/resources, and suppresses stale continuations by navigation token
 ;; (Derivations §Process). The route FACT it materializes is named `:rf/route`
 ;; — the one consumer-facing name Spec 012 already gives the route slice (one
-;; name per fact, per EP-0007).
+;; name per fact).
 ;;
 ;; This is the *registrar-derived* slice (Derivations §The EP-0013 relocation
 ;; seam): the algebra view is assembled from the route registrar metadata at
@@ -342,18 +340,10 @@
 
 ;; ---- bundle-isolation sentinel ------------------------------------------
 ;;
-;; Per rf2-s8w3nw / rf2-bmzq0 / rf2-qwm0a (the flows.tooling + subs.tooling +
-;; trace.tooling split pattern): `implementation/scripts/check-bundle-isolation.cjs`
-;; greps the counter bundle for this exact string. The string lives ONLY in
-;; this file's source body — no other namespace, no docstring, no test fixture
-;; references it — so its presence in the production counter bundle proves the
-;; tooling sibling's body got pulled in (most likely via a stray `:require`
-;; from a production-reachable ns). The whole routing artefact is already
-;; bundle-isolated from counter (counter never `:require`s `re-frame.routing`),
-;; so this sentinel is the belt-and-braces guard the sibling pattern
-;; standardises. The string survives `:advanced` because string literals are
-;; not renamed; it sits outside any gate so DCE cannot drop the literal
-;; independently of the surrounding ns body.
+;; `implementation/scripts/check-bundle-isolation.cjs` rejects the production
+;; counter bundle if this exact string appears. Keep the literal unique to this
+;; namespace and in lockstep with the checker; its presence means the tooling
+;; namespace reached a production bundle that should not load routing tools.
 
 (defonce ^:private bundle-isolation-sentinel
   "rf.routing.tooling/sentinel:rf2-eiiifu-2026-06-12:do-not-rename")

--- a/implementation/routing/src/re_frame/routing/url.cljc
+++ b/implementation/routing/src/re_frame/routing/url.cljc
@@ -78,7 +78,7 @@
   "Wrap `url-decode` in try/catch; returns nil (sentinel for malformed
   `%`) on decode failure.
 
-  Per Spec 012 §Routing failure semantics (rf2-wbvme + rf2-4ic0f): both
+  Per Spec 012 §Routing failure semantics, both
   `URLDecoder/decode` (JVM) and `decodeURIComponent` (CLJS) throw on
   malformed percent-encoded sequences (`%`, `%a`, `%XX`, …). Hostile
   URLs, partner integrations with broken escaping, or back-button to a
@@ -86,11 +86,8 @@
   request-handler crash. Callers propagate the nil sentinel uniformly:
   `match-against` returns nil for the whole match (path captures);
   `match-url`'s query-parse loop short-circuits to a malformed sentinel
-  the moment any key or value fails to decode (rf2-4ic0f — the prior
-  rf2-wbvme branch dropped just the offending pair, which silently let
-  hostile URLs into the routing slice when the host route had no
-  required keys); `split-fragment` reports its decode result the same
-  way so a malformed `#fragment` also fails closed."
+  the moment any key or value fails to decode; `split-fragment` reports its
+  decode result the same way so a malformed `#fragment` also fails closed."
   [s]
   (try (url-decode s)
        (catch #?(:clj Throwable :cljs :default) _ nil)))
@@ -105,8 +102,8 @@
   `:rf.route/not-found` but the structured `:reason` lets per-route
   error UIs and SSR projections branch on the cause.
 
-  Per Spec 012 §Routing failure semantics §Malformed percent-encoding
-  (rf2-4ic0f). The scan is purely lexical and pattern-agnostic: the URL
+  Per Spec 012 §Routing failure semantics §Malformed percent-encoding, the
+  scan is purely lexical and pattern-agnostic: the URL
   is split into path segments (on `/`), query pairs (on `&`, then `=`),
   and the `#fragment`, and each piece is run through `safe-url-decode`.
   Any piece that won't decode flips the predicate — no route table or
@@ -140,12 +137,10 @@
                            (nil? (safe-url-decode fragment))))]
     (or path-bad? query-bad? fragment-bad?)))
 
-;; ---- open-redirect classifier (rf2-3bv8o + rf2-cylse.4) ------------------
+;; ---- open-redirect classifier ---------------------------------------------
 ;; The shared lexical/origin gate that classifies a URL-string nav target
-;; as same-origin in-app vs external. Hoisted here from
-;; `re-frame.routing.can-leave` (rf2-cylse.4) so EVERY url-string nav sink
-;; — the gated `:rf.route/url-requested` link-click path AND the previously
-;; ungated `:rf.route/navigate {:url ...}` programmatic path — fails closed
+;; as same-origin in-app vs external. Every URL-string navigation sink
+;; (`:rf.route/url-requested` and `:rf.route/navigate {:url ...}`) fails closed
 ;; through ONE classifier rather than each entry point re-deciding (and
 ;; only one of three being wired). Per Spec 012 §Target form — URL-string:
 ;; the `{:url ...}` escape hatch is precisely for untrusted input
@@ -156,19 +151,12 @@
   "Fail-CLOSED lexical classifier for the no-browser-origin path (JVM /
   SSR, and CLJS when `js/window` is unavailable). Returns true ONLY when
   `url` is PROVABLY a same-origin in-app reference; everything ambiguous
-  or absolute returns false -> classed external (rf2-3bv8o).
+  or absolute returns false and is classed external.
 
   Without a browser `Location` to resolve and origin-compare against
   (the robust CLJS path in `external-url?`), the runtime cannot prove a
-  URL is same-origin. The pre-rf2-3bv8o JVM path was fail-OPEN: it
-  returned the URL verbatim and classed in-app anything that did not
-  lexically look absolute -- a default-ALLOW that let open-redirect
-  bypass vectors (leading whitespace before a scheme, backslash-prefixed
-  authorities a browser normalises to `//`, embedded tab/newline in the
-  scheme) slip through as in-app pushes. This flips to fail-CLOSED,
-  consistent with the routing fail-closed posture established by
-  rf2-6t1xb (a hostile or ambiguous URL resolves to the safe outcome,
-  not the permissive one).
+  URL is same-origin. Hostile or ambiguous forms resolve to the external
+  outcome rather than relying on a permissive lexical guess.
 
   A URL is accepted as in-app only when, after rejecting any whitespace
   or ASCII control character (browsers strip tab/CR/LF mid-URL before
@@ -205,8 +193,7 @@
   in-app same-origin reference. On CLJS with a live `js/window.location`
   the URL is resolved against the document origin and compared (the
   robust path); otherwise (JVM / SSR, or any resolution failure) it falls
-  back to the fail-closed lexical `safe-in-app-url?`. rf2-3bv8o +
-  rf2-cylse.4."
+  back to the fail-closed lexical `safe-in-app-url?`."
   [url]
   #?(:cljs
      (try

--- a/implementation/routing/src/re_frame/routing/url_bound.cljc
+++ b/implementation/routing/src/re_frame/routing/url_bound.cljc
@@ -5,7 +5,7 @@
   Per Spec 012 §Multi-frame routing — 'Only one frame can own the URL at
   a time': registering a second `:url-bound? true` frame emits
   `:rf.error/duplicate-url-binding` per Spec 009 §error event catalogue.
-  The check runs from a registrar registration-hook (rf2-w50qm) so it
+  The check runs from a registrar registration hook so it
   fires on BOTH first-time and re-registration paths.
 
   The recovery is `:no-recovery` per Spec 009. The registry remains
@@ -14,26 +14,25 @@
   non-owner `:rf.nav/push-url` / `:rf.nav/replace-url` calls no-op. The
   error surfaces the conflict; resolving it is the app's concern.
 
-  rf2-3l7xxz — the hook also maintains the URL-ownership CLAIM ORDER in
+  The hook also maintains URL-ownership claim order in
   `re-frame.routing.nav-fx` (recording a `:url-bound? true` claim, dropping it
   when a frame opts out), so `url-owner-frame-id` resolves the FIRST-CLAIMED
   incumbent and a later duplicate cannot steal the browser URL even if its id
   sorts before the incumbent.
 
-  rf2-68k8as — `add-registration-hook!` is an append-only FUTURE observer; it
+  `add-registration-hook!` observes only future registrations; it
   does not replay existing registrations. So frames that claimed `:url-bound?
   true` BEFORE `(require 're-frame.routing)` never recorded a claim, and the
-  resolver's old id-sort fallback let a later, alphabetically-earlier duplicate
-  steal the URL from the true first-claimant. The façade now calls
-  `reconcile-existing-url-bindings!` right after installing the hook to seed the
+  claim order cannot be inferred from the registry map. The facade calls
+  `reconcile-existing-url-bindings!` after installing the hook to seed the
   unambiguous incumbent (and fail closed on an unrecoverable multi-binding
   load-order), so first-claim-wins holds regardless of frame-vs-routing load
   order.
 
   Internal namespace; the public facade is `re-frame.routing`. The
-  facade owns the `registrar/add-registration-hook!` call so a
-  `:reload` re-wires it on a fresh registrar. Per the rf2-2yabr
-  cohesion split: URL-BOUND-EXCLUSIVITY seam."
+  facade owns the `registrar/add-registration-hook!` call. The hook is
+  process-lifetime state and survives reload; facade loads rerun the
+  idempotent reconciliation."
   (:require [re-frame.registrar :as registrar]
             [re-frame.routing.nav-fx :as nav-fx]
             [re-frame.trace :as trace]))
@@ -43,7 +42,7 @@
   that currently carries an explicit `:url-bound? true`. Returns the
   offending frame-id or nil.
 
-  EP-0002 (rf2-nn0jqa): URL ownership is an EXPLICIT declaration — there is
+  URL ownership is an explicit declaration; there is
   no `:rf/default`-owns-by-default floor. `:rf/default` is counted here only
   when it carries an explicit `:url-bound? true` like any other frame; an
   un-annotated `:rf/default` is NOT an implicit owner."
@@ -67,7 +66,7 @@
   browser history. The app resolves the conflict by removing one of the
   bindings.
 
-  rf2-3l7xxz — this hook ALSO maintains the URL-ownership CLAIM ORDER
+  This hook also maintains URL-ownership claim order
   (`re-frame.routing.nav-fx/url-claim-order`): a `:url-bound? true`
   registration records the frame's claim (appended iff not already present, so
   a hot-reload re-registration of the incumbent keeps its position and a later
@@ -84,7 +83,7 @@
     (if (true? (nav-fx/url-bound?-from-config now))
       (do
         ;; Record the claim FIRST so the incumbent keeps its claim position; a
-        ;; duplicate appends after it and never steals ownership (rf2-3l7xxz).
+        ;; duplicate appends after it and never steals ownership.
         (nav-fx/record-url-claim! id)
         (when-let [other (frame-id-of-existing-url-binding id)]
           (trace/emit-error! :rf.error/duplicate-url-binding
@@ -95,24 +94,22 @@
       ;; A `:frame` registration that does NOT carry `:url-bound? true`
       ;; relinquished any prior URL claim (e.g. `:rf/default {:url-bound?
       ;; false}` opting out): drop it so a stale claim cannot keep a now-unbound
-      ;; frame at the head of the claim order (rf2-3l7xxz). Idempotent.
+      ;; frame at the head of the claim order. Idempotent.
       (nav-fx/drop-url-claim! id))))
 
 (defn reconcile-existing-url-bindings!
   "Reconcile `:url-bound? true` frames ALREADY in the registry when the
-  url-bound exclusivity hook is installed (rf2-68k8as). Called ONCE by the
-  façade immediately after `add-registration-hook!`, so frames registered
+  url-bound exclusivity hook is installed. Called by the facade after
+  `add-registration-hook!` and on reload, so frames registered
   BEFORE `(require 're-frame.routing)` are not silently invisible to URL-
   ownership resolution.
 
-  The hazard (rf2-68k8as): `add-registration-hook!` is an append-only FUTURE
-  observer — it does NOT replay existing registrations (re-frame.registrar
+  `add-registration-hook!` observes only future registrations; it does not
+  replay existing registrations (re-frame.registrar
   §registration-hooks). So a frame that claimed `:url-bound? true` before
   routing loaded never recorded a claim in `url-claim-order`, leaving the
-  resolver to fall back to id-sorting — which let a later, alphabetically-
-  earlier duplicate STEAL the URL from the true first-claimant (Spec 012
-  §Multi-frame routing forbids exactly this: 'the existing owner is unchanged …
-  resolving by id ordering would have let it').
+  resolver without claim order. Choosing by frame id would violate Spec 012's
+  rule that the existing owner remains unchanged.
 
   Why this can't simply replay in true claim order: the registrar's
   `(kind, id) → metadata` table is UNORDERED (re-frame.registrar), so the

--- a/implementation/routing/src/re_frame/routing/url_change.cljc
+++ b/implementation/routing/src/re_frame/routing/url_change.cljc
@@ -9,12 +9,11 @@
   `url-change-fx`. The fragment-only branch (Spec 012 §Fragments rules
   3-4) ALSO lives in `url-change-fx`, so both events honour it —
   popstate / Back-Forward to a same-page anchor must not allocate a new
-  nav-token or re-fire `:on-match` (rf2-8oxj6).
+  nav-token or re-fire `:on-match`.
 
   Internal namespace; the public facade is `re-frame.routing`. The
   facade owns the two `events/reg-event` calls so a `:reload`
-  re-wires them on a fresh registrar. Per the rf2-2yabr cohesion split:
-  URL-CHANGE-EVENTS seam."
+  re-wires them on a fresh registrar."
   (:require [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
             [re-frame.routing.can-leave :as can-leave]
@@ -28,7 +27,7 @@
 (defn- fragment-only-fx
   "Spec 012 §Fragments rules 1-4: the new URL differs from the current
   route slice ONLY in its `#fragment`. Update `:fragment`, emit the
-  `:rf.route/fragment-changed` op trace (rf2-cj9fn), and return the cofx
+  `:rf.route/fragment-changed` op trace, and return the cofx
   map — WITHOUT allocating a fresh nav-token (rule 3) or re-firing
   `:on-match` (rule 4). The canonical op-name says what fires it (only a
   `#fragment` differed) and disambiguates from the runtime event
@@ -58,32 +57,32 @@
   "Pure helper: given runtime-db + url + default scroll strategy (+ the
   `frame` to carry on the no-such-handler trace + the RECORDABLE
   `nav-allocation`), return the effects map `{:rf.db/runtime :fx}` for
-  a URL-driven full slice rewrite. Performs the match-url lookup, publishes
-  the nav-token from the recordable `nav-allocation` (rf2-vcop6y — recorded +
-  replay-stable; the `:counter` high-water bump rides a
+  a URL-driven full slice rewrite. Performs the `match-url` lookup and
+  publishes the nav-token from the recordable, replay-stable
+  `nav-allocation`; the `:counter` high-water bump rides a
   `:rf.route/commit-nav-counter` fx), computes the scroll fx
   entry, and emits the trace events (:rf.warning/no-not-found-route,
   :rf.warning/malformed-url, :rf.error/no-such-handler,
   :rf.route.nav-token/allocated).
 
   Per Spec 012 §URL changes are events §Route-not-found §Per-route data
-  loading §Scroll restoration §Multi-frame routing. The slice always
-  carries the full seven-key shape (rf2-d60go).
+  loading §Scroll restoration §Multi-frame routing. The current slice always
+  carries the full seven-key published shape.
 
-  Three fallback shapes feed `:rf.route/not-found` (rf2-4ic0f):
+  Three fallback shapes feed `:rf.route/not-found`:
 
    - bare miss (`{:url url}`) — `match-url` returned nil and the URL
      percent-encoding decoded cleanly;
    - validation fail (`{:url url :reason :validation}`) — a route's
      pattern matched but its `:params` / `:query` schema rejected the
-     parsed values (rf2-ug2m1);
+     parsed values;
    - malformed URL (`{:url url :reason :malformed-url}`) — any of the
      URL's path captures, query keys/values, or `#fragment` failed to
      %-decode. The `:reason` discriminator lets per-route error UIs
      and SSR projections branch on the cause.
 
-   `app-db` (EP-0016 D3 slice 3) is the navigation handler's app-db
-   coeffect value, threaded UNCHANGED into `commit-navigation` → the
+   `app-db` is the navigation handler's causal app-db coeffect, threaded
+   unchanged into `commit-navigation` and the
    `:routing/on-route-entry` hook so a cross-feature `{:from-db …}`
    route-resource scope resolves db-derived viewer identity at route
    entry. Routing never reads it."

--- a/implementation/routing/test/re_frame/routing_history_cljs_test.cljs
+++ b/implementation/routing/test/re_frame/routing_history_cljs_test.cljs
@@ -521,10 +521,10 @@
   (testing "rf2-g8pbwg / rf2-6qgbs.4: the automatically-installed listener
             drives :rf/default when it is the owner (no regression)"
     (register-routes!)
-    ;; Default-owned app: url-owner-frame-id resolves to :rf/default, so
-    ;; register-routes!'s reg-frame auto-installed the listener for it.
+    ;; register-routes! explicitly declares :rf/default as URL-bound, so its
+    ;; frame registration installed the listener.
     (is (= :rf/default (routing/url-owner-frame-id))
-        ":rf/default owns the URL by default")
+        ":rf/default is the explicitly declared URL owner")
 
     (rf/dispatch-sync [:rf.route/url-requested {:url "/cart"}])
     (rf/dispatch-sync [:rf.route/url-requested {:url "/checkout"}])
@@ -534,7 +534,7 @@
     (.back (.-history js/globalThis.window))
     (.dispatchEvent js/globalThis.window #js {:type "popstate"})
     (is (= :hist/cart (:route-id (get-in (:rf.db/runtime (rf/frame-state-value :rf/default)) [:rf.runtime/routing :current])))
-        "Back restored :rf/default's slice to /cart — default-owned routing unregressed")))
+        "Back restored the explicitly owned :rf/default slice to /cart")))
 
 ;; =========================================================================
 ;; rf2-g8pbwg: the :url-bound? frame LIFECYCLE installs/removes the listener


### PR DESCRIPTION
## Summary

- remove stale issue-history and duplicated specification narration from the routing artefact
- correct comments and docstrings for runtime-db topology, guard URL normalization, FIFO error handling, URL ownership/listener lifecycle, route emission, and nav-counter publication
- clarify classification, trace, resource/reply, host-cache, tooling, and bundle-isolation boundaries without changing runtime behavior

Tracks rf2-5cv2rs.

## Notable corrections

- optional resources integration can add routing runtime bookkeeping alongside `:current` and `:pending-navigation`
- queued on-match error attribution runs after settle and establishes the final error state
- guarded navigation preserves the requested URL spelling in its target, while route reconstruction may canonicalize it
- untaken eager navigation candidates do not commit allocator high-water marks
- URL strategy side effects are CLJS-only, while pure encode/decode behavior remains available on the JVM
- empty path-parameter strings are rejected because they cannot round-trip through the emitted path grammar

## Verification

- `clojure -M:test` from `implementation/routing`: 391 tests, 1,748 assertions, 0 failures/errors
- `npm run test:cljs` from `implementation`: 8,466 tests, 39,175 assertions, 0 failures/errors (3 unrelated existing compiler warnings)
- `clj-kondo --parallel --fail-level error --lint implementation/routing`: 0 errors (46 warnings)
- `clojure -M:splint --fail-on-errors routing` from `implementation`: 0 errors (56 style warnings)
- `npm run test:bundle-isolation` from `implementation`: PASS for counter, UIx, and Helix production bundles
