### PR TITLE
docs(security): tighten adversarial test explanations (rf2-20fenn)

### DIFF
--- a/implementation/security/deps.edn
+++ b/implementation/security/deps.edn
@@ -1,87 +1,27 @@
-;; re-frame2 adversarial-property SECURITY tier (rf2-3cfvt).
+;; Cross-artefact, cross-runtime security tests. This surface has no production
+;; source and is not published. Its own alias ensures the `.cljc` tests run on
+;; the JVM as well as through the CLJS security build.
 ;;
-;; This is NOT a published Maven artefact — it has no `src/`. It is a
-;; cross-artefact TEST surface that probes the security boundaries the
-;; pin-and-assert regime missed: SSR escaping (rf2-1uex4), schema
-;; redaction nested at arbitrary depth (rf2-g5auo), AI/MCP-boundary
-;; egress redaction (rf2-6wvh5), the fail-closed validation/redaction
-;; invariants (rf2-ih7g4 / rf2-el9sw), and the deterministic generator's
-;; cross-runtime byte-parity (rf2-h2yvs). The namespaces sit ABOVE several
-;; artefacts (core, schemas, machines, routing, flows, ssr) + a tool
-;; (mcp-base), so they live in their own top-level `security/` surface
-;; rather than any single artefact's test tree.
-;;
-;; ## Why this deps.edn exists (rf2-gj2ae)
-;;
-;; The security namespaces are `.cljc` and advertise a cross-runtime
-;; contract — e.g. `re-frame.security.gen`'s LCG is "byte-deterministic
-;; AND identical across JVM + JS" with separate `:clj` (full-precision
-;; `long` multiply) and `:cljs` (`Math.imul`) arithmetic, and
-;; `gen-parity-security-cljs-test` pins the JVM reference sequences and
-;; states it "runs in BOTH runtimes". Before this alias the ONLY named
-;; security runner was the CLJS-side `npm run test:security` (shadow
-;; `:node-test-security`) plus the always-on `:node-test` gate; the JVM
-;; side had no wiring at all — the top-level `implementation/deps.edn`
-;; `:test` alias (ad-hoc REPL convenience) omits `security/test` and
-;; `../tools/mcp-base/src`, and the canonical per-artefact JVM gate
-;; (`scripts/test-jvm-implementation.sh`) iterates each artefact's own
-;; `:test` alias, of which `security/` had none. So the `:clj` reader-
-;; conditional arms of the security tier — `gen.cljc`'s full-precision
-;; multiply, the `:clj`/`:cljs` egress/redaction helper branches, the
-;; `clojure.walk` deep-scan — were NEVER executed on the JVM. That is a
-;; false-green cross-runtime security contract: the `:clj` arithmetic
-;; could regress (e.g. drop the `long` coercion, reintroducing the
-;; 53-bit-mantissa divergence on a hypothetical JVM consumer of `gen`)
-;; while the tier stayed green on CLJS. This alias closes the gap: it
-;; runs the SAME `.cljc` namespaces under the JVM, so a divergence
-;; between the two reader-conditional arms now goes RED on the JVM gate.
-;;
-;; ## Why test-only deps, not :local/root in :deps
-;;
-;; This artefact ships nothing, so the top-level `:deps` is empty. The
-;; cross-artefact source the test namespaces `:require`
-;; (`re-frame.core`, `re-frame.schemas[.malli]`, `re-frame.machines.*`,
-;; `re-frame.routing.*`, `re-frame.flows`, `re-frame.ssr.*`, and the
-;; spec/009 §Privacy filter `re-frame.mcp-base.sensitive`) is pulled in
-;; under the `:test` alias only. `:extra-paths` is JUST `["test"]` so the
-;; cognitect test-runner scans ONLY the security test dir — the artefact
-;; `:local/root` deps contribute their `src` (never their `:test`), so no
-;; other artefact's tests run here.
-;;
-;; ## Bundle isolation (tools/README.md)
-;;
-;; The dependency arrow flows tool → implementation, never the reverse.
-;; The `tools/mcp-base` dep below is TEST-ONLY (this artefact has no
-;; production `src/` and ships no jar), and `re-frame.mcp-base.sensitive`
-;; is a framework-agnostic `.cljc` shape with no `:local/root` dep on
-;; `implementation/`. It mirrors the existing precedent in the top-level
-;; `implementation/shadow-cljs.edn`, whose cross-artefact `:node-test`
-;; classpath already lists `../tools/mcp-base/src` for exactly these
-;; egress tests. Nothing under `implementation/` `:require`s it from a
-;; production source path, so no production bundle is widened.
+;; All implementation and MCP dependencies are test-only. Local roots
+;; contribute production source, while `:extra-paths ["test"]` limits test
+;; discovery to this surface. The mcp-base dependency therefore does not create
+;; a production implementation-to-tool dependency or widen a shipped bundle.
 {:paths []
  :deps  {}
 
  :aliases
  {:test
   {:extra-paths ["test"]
-   ;; Artefacts whose namespaces the security tests `:require`. core
-   ;; carries `re-frame.test-support` + `re-frame.elision` /
-   ;; `re-frame.classification` (the EP-0025 marks-free projection engine) +
-   ;; `re-frame.privacy` + `re-frame.subs` + `re-frame.trace.tooling`;
-   ;; schemas brings metosin/malli transitively (so `re-frame.schemas.malli`
-   ;; resolves); machines/routing/flows/ssr supply their feature namespaces.
+   ;; Artefacts whose production namespaces the security tests require.
    :extra-deps  {day8/re-frame2          {:local/root "../core"}
                  day8/re-frame2-schemas  {:local/root "../schemas"}
                  day8/re-frame2-machines {:local/root "../machines"}
                  day8/re-frame2-routing  {:local/root "../routing"}
                  day8/re-frame2-flows    {:local/root "../flows"}
                  day8/re-frame2-ssr      {:local/root "../ssr"}
-                 ;; spec/009 §Privacy default-suppress egress filter
-                 ;; (`re-frame.mcp-base.sensitive`). TEST-ONLY tool dep —
-                 ;; see the bundle-isolation note above.
+                 ;; Default-suppress egress filter; test-only tool dependency.
                  day8/re-frame2-mcp-base {:local/root "../../tools/mcp-base"}
-                 ;; rf2-try1x — silent-on-success reporter.
+                 ;; Silent-on-success reporter.
                  day8/re-frame2-test-quiet {:local/root "../test-quiet"}
                  io.github.cognitect-labs/test-runner
                  {:git/tag "v0.5.1" :git/sha "dfb30dd"}}

--- a/implementation/security/test/re_frame/security/classification_fail_open_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/classification_fail_open_security_cljs_test.cljc
@@ -1,39 +1,14 @@
 (ns re-frame.security.classification-fail-open-security-cljs-test
-  "Adversarial-property SECURITY tier — the EP-0025 / Spec 015 fail-open
-  data-classification contract at the egress boundary.
+  "Adversarial tests for path-based classification at egress.
 
-  ## The contract under test
+  A `:sensitive` effect classifies an app-db path, not a value. The egress
+  walker redacts that path, but an identical value copied to an unclassified
+  path remains visible. Classification therefore provides egress hygiene, not
+  taint tracking or a secrecy guarantee.
 
-  Data classification is **path-based** and **fail-open**: the framework
-  redacts a value at a mediated-egress boundary IFF the app-db **PATH** it
-  occupies has been classified `:sensitive` (via the commit-plane
-  classification effect a handler returns alongside `:db`). The deliberate
-  corollary — ruled, per Spec 015 §The north star + §No propagation — is that
-  classification does NOT propagate and there is NO value-match / taint engine:
-
-    - a CLASSIFIED app-db path redacts to `:rf/redacted` at egress;
-    - an UNCLASSIFIED sibling at a different path ships RAW — even when it
-      holds a BYTE-IDENTICAL copy of the classified secret (the re-keyed /
-      rendered-copy fail-open case).
-
-  This is the security-relevant edge of the design: a team that relies on
-  classification as a SECRECY guarantee will leak a re-keyed secret. The
-  test pins the contract so a regression that quietly re-introduces value-match
-  redaction (which would mask the fail-open hazard) goes RED, and a regression
-  that fails to redact a genuinely-classified path ALSO goes RED.
-
-  ## Net property (verify-by-revert)
-
-  - Reverting the walker to redact by VALUE (any leaf `=` to a classified
-    leaf, anywhere) makes `unclassified-copy-of-secret-ships-raw` go RED — the
-    re-keyed copy would wrongly redact.
-  - Reverting the commit-plane `:sensitive` effect to a no-op makes
-    `classified-path-redacts-at-egress` go RED — the classified path would
-    ship raw.
-
-  Dual-runtime `.cljc` (JVM `clojure -M:test` + shadow `:node-test` / the
-  security `:test` alias). Uses the plain-atom substrate so a real
-  `dispatch-sync` cascade installs the commit-plane classification."
+  Event redaction has the same constraint: only paths in the event's argument
+  map are addressable. Positional arguments cannot be classified and pass
+  through unchanged."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [clojure.string :as str]
@@ -43,26 +18,17 @@
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as ts]))
 
-;; The reset fixture auto-registers + scope-pins a default frame (the
-;; carried-invariant equivalent of `(with-frame :rf/default …)`), so a bare
-;; `dispatch-sync` cascades into it and a zero-arity `elide-wire-value` /
-;; registry read resolves the frame.
+;; The fixture supplies the default frame required by dispatch and egress.
 (use-fixtures :each
   (ts/make-reset-runtime-fixture
     {:adapter plain-atom/adapter}))
 
-;; A distinctive secret so a deep substring scan is unambiguous.
 (def ^:private secret "S3CR3T-rf2-nk2h6m-DO-NOT-LEAK")
 
 (defn- contains-secret?
-  "Deep substring scan over the printed form — true when the raw secret
-  survives ANYWHERE in `x`."
+  "True when the raw secret survives anywhere in the printed form of `x`."
   [x]
   (str/includes? (pr-str x) secret))
-
-;; ---------------------------------------------------------------------------
-;; 1. A CLASSIFIED app-db path redacts at egress (the positive half).
-;; ---------------------------------------------------------------------------
 
 (deftest classified-path-redacts-at-egress
   (testing "a path classified :sensitive by the commit-plane effect redacts to
@@ -72,21 +38,13 @@
         {:db        (assoc-in db [:auth :token] secret)
          :sensitive [[:auth :token]]}))
     (rf/dispatch-sync [:auth/login])
-    ;; the application still sees the REAL value (classification is read
-    ;; only at egress)
     (is (= secret (get-in (frame/frame-app-db-value :rf/default) [:auth :token]))
-        "app-db holds the raw value — classification is read only at egress")
-    ;; ... but the egress projection redacts the classified path
+        "classification does not alter app-db")
     (let [wire (rf/elide-wire-value (frame/frame-app-db-value :rf/default))]
       (is (= privacy/redacted-sentinel (get-in wire [:auth :token]))
           "the classified path projects :rf/redacted at egress")
       (is (not (contains-secret? wire))
           "the raw secret does not survive anywhere in the projected value"))))
-
-;; ---------------------------------------------------------------------------
-;; 2. An UNCLASSIFIED re-keyed COPY of the secret ships RAW (the fail-open
-;;    half — the ruled, deliberate hazard). No value-match / taint.
-;; ---------------------------------------------------------------------------
 
 (deftest unclassified-copy-of-secret-ships-raw
   (testing "a byte-identical COPY of a classified secret at a DIFFERENT,
@@ -96,74 +54,47 @@
       (fn [{:keys [db]} _]
         {:db        (-> db
                         (assoc-in [:auth :token] secret)
-                        ;; the SAME secret copied to an UNCLASSIFIED path —
-                        ;; a re-keyed / rendered copy
                         (assoc-in [:ui :rendered-token] secret))
-         :sensitive [[:auth :token]]}))   ;; ONLY the durable path is classified
+         :sensitive [[:auth :token]]}))
     (rf/dispatch-sync [:auth/login-and-copy])
     (let [wire (rf/elide-wire-value (frame/frame-app-db-value :rf/default))]
-      ;; the classified path is redacted ...
       (is (= privacy/redacted-sentinel (get-in wire [:auth :token]))
           "the classified path is redacted")
-      ;; ... but the unclassified copy ships RAW (fail-open; no taint)
       (is (= secret (get-in wire [:ui :rendered-token]))
-          "the unclassified re-keyed copy ships RAW — fail-open, no value-match")
-      ;; so the secret DOES survive in the projected value, via the
-      ;; unclassified path — the design's documented hazard.
+          "the unclassified copy remains visible because values are not tracked")
       (is (contains-secret? wire)
           "the secret survives at the unclassified path (the fail-open contract)"))))
-
-;; ---------------------------------------------------------------------------
-;; 3. A wholly-UNCLASSIFIED secret ships raw (forgotten classification).
-;; ---------------------------------------------------------------------------
 
 (deftest forgotten-classification-ships-raw
   (testing "a secret written with NO classification at all ships raw —
             forgetting to classify is fail-open, not a guarded leak"
     (rf/reg-event :auth/login-unclassified
       (fn [{:keys [db]} _]
-        {:db (assoc-in db [:auth :token] secret)}))   ;; no :sensitive effect
+        {:db (assoc-in db [:auth :token] secret)}))
     (rf/dispatch-sync [:auth/login-unclassified])
     (let [wire (rf/elide-wire-value (frame/frame-app-db-value :rf/default))]
       (is (= secret (get-in wire [:auth :token]))
           "the unclassified path ships raw — fail-open on omission")
       (is (contains-secret? wire)))))
 
-;; ---------------------------------------------------------------------------
-;; 4. A secret in a POSITIONAL EVENT ARG ships RAW through `redact-event`
-;;    (the event-payload egress edge of the SAME fail-open contract — rf2-5n2clp
-;;    option (a): document + test the limitation as KNOWN, EXPECTED behavior).
-;; ---------------------------------------------------------------------------
-;;
-;; `privacy/redact-event` is the path-based event-vector redactor that feeds
-;; `:rf/redacted-event` → every `:event/*` trace, `:event/db-changed`, and the
-;; `:event` slot of a `:rf.error/handler-exception` record. It is map-key
-;; oriented: only `(second event)` — the arg-map — is path-addressable. A
-;; positional index has NO declarable `:sensitive` path, so a secret carried in
-;; a positional arg is structurally unreachable by the redactor and egresses
-;; RAW. This is a KNOWN STRUCTURAL LIMITATION of the EP-0025 fail-open model,
-;; not a bug; the test pins it so it is VISIBLE + tested rather than a silent
-;; false sense of safety, and so a future change cannot quietly regress it.
-;; The remediation is authorial: PREFER THE MAP PAYLOAD FORM for sensitive
-;; args (the positive half, exercised below for contrast).
+;; redact-event addresses paths relative to the event's argument map. A
+;; positional argument has no declarable path, so authors must use a map payload
+;; when an event argument needs classification.
 
 (deftest positional-event-arg-ships-raw
   (testing "a secret in a POSITIONAL event arg passes through redact-event
             UNCHANGED — positional indices are not path-addressable, so the
             path-based redactor cannot reach them (KNOWN fail-open limitation)"
-    ;; A path declared at `[:token]` indexes into the arg-map. With a positional
-    ;; payload there IS no arg-map at that slot, so redaction is a no-op and the
-    ;; secret survives RAW in the redacted event vector.
     (let [positional-event [:auth/login "alice" secret]
           redacted         (privacy/redact-event positional-event [[:token]])]
       (is (= positional-event redacted)
           "the positional-arg event passes through redact-event unchanged")
       (is (= secret (nth redacted 2))
-          "the secret survives RAW in the positional slot — fail-open: a
+          "the secret survives in the positional slot because a
            positional index is not path-redactable")
       (is (contains-secret? redacted)
-          "the secret egresses RAW through redact-event (the documented
-           positional-arg limitation — prefer the map payload form)")))
+           "the secret egresses through redact-event (the documented
+            positional-arg limitation — prefer the map payload form)")))
 
   (testing "the MAP payload form of the same event IS path-redactable — the
             authorial remediation: carry sensitive args in the arg-map and

--- a/implementation/security/test/re_frame/security/error_slot_egress_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/error_slot_egress_security_cljs_test.cljc
@@ -1,65 +1,14 @@
 (ns re-frame.security.error-slot-egress-security-cljs-test
-  "Security tier — non-schema-validation error-emit slots that carry
-  caller-supplied data the path-marks projection did NOT cover and the
-  shared schema-aware validation seam does NOT apply to (rf2-zsm03;
-  follow-up to the rf2-o69h5 class sweep).
+  "Adversarial tests for error slots containing caller-supplied data.
 
-  ## The two slots
+  Machine action `:exception-data` is redacted when the addressed machine is
+  sensitive, or when its frame cannot be resolved. Route navigation `:error`
+  is redacted when the route's params or query schema contains a sensitive
+  slot. Both projections stamp the resulting trace sensitive so default MCP
+  egress drops the whole event as defence in depth.
 
-  rf2-o69h5 closed the `:rf.error/schema-validation-failure` class: every
-  framework emission of that op routes its value-bearing slots through the
-  one shared schema-aware redactor. Two OTHER error-emit sites carry
-  caller-supplied data outside that class:
-
-    1. `:rf.error/machine-action-exception` `:exception-data` — the `ex-data`
-       of a thrown machine action (re-frame.machines.lifecycle-fx.registration).
-       The `:event` slot IS covered by the marks projection's
-       `project-event-tags`; `:before`/`:after`/`:snapshot` by
-       `project-machine-tags`. But `:exception-data` is the developer's
-       arbitrary exception payload — under a bare slot NO projection clause
-       reached (the op namespace is `:rf.error/*`, not `rf.machine`, so
-       `machine-op?` skips it). It can embed the same app secrets the
-       machine's `:data` marks gate.
-
-    2. `:rf.route/navigate` `:error` (re-frame.routing.navigate) — `(ex-data
-       ex)` of a `route-url` construction throw. On
-       `:rf.error/route-url-validation` / `:rf.error/missing-route-param` it
-       embeds the raw route-param value (document-ids / tokens) AND the Malli
-       explainer. Route-param validation is STRUCTURAL (the throw is from
-       `route-url`, not a per-slot Malli walk at this emit point), so the
-       shared `redact-validation-tags` seam cannot path-target it.
-
-  ## The fix (mirrors the rf2-o69h5 egress-chokepoint approach)
-
-  Both slots are elided at the trace egress chokepoint BEFORE the event
-  crosses the bus / epoch-capture / AI-MCP boundary or reaches a log sink:
-
-    1. the `re-frame.classification` machine-error projection clause (a NEW projection clause,
-       wired into `project-trace-event`) elides the WHOLE `:exception-data`
-       slot to `:rf/redacted` and stamps `:sensitive? true` when the machine
-       declares ANY `:sensitive` mark.
-    2. `re-frame.routing.navigate`'s `redact-route-error-tags` elides the
-       WHOLE `:error` slot and stamps `:sensitive? true` when the route's
-       `:params` / `:query` schema declares any `:sensitive?` slot (decided
-       through the SAME shared `:schemas/redact-validation-tags` seam).
-
-  Both stamp `:sensitive? true`, so the MCP egress filter
-  (`re-frame.mcp-base.sensitive/strip-sensitive`) ALSO drops the whole event
-  when `--allow-sensitive-reads` is disabled (`include? false`, the
-  restrictive default) — defence in depth (asserted below).
-
-  ## Net property (verify-by-revert)
-
-  Reverting the machine-error projection clause (or its dispatch clause) to a
-  pass-through makes the machine corpus + property go RED — the sentinel
-  surfaces in `:exception-data`. Reverting `redact-route-error-tags` makes
-  the navigate corpus go RED — the sentinel surfaces in `:error`. Confirmed
-  by temporary local revert + restore (see PR Quality gates).
-
-  ## Threat model
-
-  AI/MCP boundary + logs ONLY (per rf2-zsm03 / rf2-o69h5) — human-facing
-  egress is out of scope and not gold-plated."
+  These protections target AI/MCP and log egress. Plain machines and routes
+  remain unredacted when a known frame supplies no sensitive declaration."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core :as rf]
@@ -70,82 +19,37 @@
             [re-frame.classification :as classification]
             [re-frame.mcp-base.sensitive :as sens]
             [re-frame.routing :as routing]
-            ;; Call `navigate-handler` directly (the `reg-event` handler fn,
-            ;; `(cofx event) -> effects-map-or-nil`) so site 2 exercises the
-            ;; REAL redaction path headless — no reactive-substrate adapter /
-            ;; `dispatch-sync` machinery needed. A `:params`-schema validation
-            ;; reject short-circuits inside the handler before any push/scroll
-            ;; fx, so a synthetic cofx suffices.
+            ;; A validation reject short-circuits before browser effects, so
+            ;; the handler can be driven directly with synthetic coeffects.
             [re-frame.routing.navigate :as navigate]
             [re-frame.routing.registry :as registry]
             #?(:clj  [re-frame.test-support :as test-support :refer [with-trace-recorder!]]
                :cljs [re-frame.test-support :as test-support :refer-macros [with-trace-recorder!]])
-            ;; SITE 1 drives the REAL production emit (`trace/emit-error!`),
-            ;; not direct `classification/project-trace-event` — so the test proves the
-            ;; full envelope production actually ships, including the top-level
-            ;; `:sensitive?` hoist the MCP egress gate reads (rf2-md2wn0). The
-            ;; shared `with-trace-recorder!` brackets the trace-tooling listener
-            ;; the helpers capture off.
+            ;; Drive the production trace emitter so tests observe the top-level
+            ;; sensitivity stamp consumed by MCP egress.
             [re-frame.trace :as trace]
             [re-frame.security.gen :as gen]))
 
-;; Reset per-test so route + mark + app-schema registrations don't bleed.
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
     {:clear-app-schemas? true}))
 
-;; ---------------------------------------------------------------------------
-;; Sentinel — a value that must NEVER appear unredacted in either slot.
-;; ---------------------------------------------------------------------------
-
 (def ^:private sentinel "S3CR3T-rf2-zsm03-ERROR-SLOT-DO-NOT-LEAK")
 
 (defn- contains-sentinel?
-  "Deep-walk `x`; true when the sentinel string appears anywhere (as a
-  value - matched as a SUBSTRING - inside a collection, or inside a
-  stringified form). Thin wrapper over the shared `gen/contains-string?`
-  (rf2-n5bkm7); the sentinel is matched as a substring (`exact? false`)."
+  "True when the sentinel survives anywhere in `x`, including stringified data."
   [x]
   (gen/contains-string? x sentinel false))
-
-;; ===========================================================================
-;; SITE 1 — :rf.error/machine-action-exception :exception-data
-;;
-;; Driven through the REAL production emit `trace/emit-error!` — the exact
-;; call `re-frame.machines.lifecycle-fx.registration/trace-action-failure!`
-;; makes (registration.cljc) — NOT direct `classification/project-trace-event`
-;; (rf2-md2wn0). `emit-error!` runs the full production pipeline:
-;; `build-event` → marks projection (the machine-error projection clause, which
-;; stamps `[:tags :sensitive?]`) → the top-level `:sensitive?` hoist
-;; (`hoist-projected-sensitive`) → delivery. We capture the delivered
-;; envelope off a trace-tooling listener and assert what production ACTUALLY
-;; ships, including the TOP-LEVEL `:sensitive?` flag the MCP egress gate
-;; (`mcp-base.sensitive/sensitive-event?`) reads.
-;;
-;; Why the old shape was a false green: it projected an event directly and
-;; asserted `:sensitive?` only under `:tags`. Production hoists `:sensitive?`
-;; to the TOP LEVEL during `build-event` — but for machine exceptions the
-;; sensitivity is decided LATER (during marks projection), so the top-level
-;; flag was never set and MCP egress treated the event as non-sensitive. The
-;; direct-projection test proved a shape production did not emit.
-;; ===========================================================================
 
 (def ^:private sensitive-machine-id :sec/sensitive-machine)
 (def ^:private plain-machine-id     :sec/plain-machine)
 
 (defn- declare-machine-marks!
-  "Install the marks a `reg-machine` with `:sensitive` machine-data paths would
-  install (machine marks key under the `:event` kind because a machine IS an
-  event handler). Post-rf2-ehexnw the marks are DERIVED from the registrar
-  `:event` meta, so we register each id as an event carrying the author marks
-  (the snapshot analogue the machine-error projection clause keys off) rather than
-  poking a deleted side-table."
+  "Register the event metadata from which machine classification is derived."
   []
-  ;; Sensitive machine — declares a sensitive `:data` path on its reg meta.
   (rf/reg-event sensitive-machine-id
                 {:sensitive [[:data :token]]}
                 (fn [_ _] nil))
-  ;; Plain machine — no marks at all.
   (rf/reg-event plain-machine-id (fn [_ _] nil)))
 
 (defn- machine-action-exception-tags
@@ -153,23 +57,8 @@
   `trace/emit-error!` (registration.cljc), carrying the sentinel-bearing
   `:exception-data`, with the addressed id keyed under `id-key`.
 
-  the machine-error projection clause resolves the schema lookup via
-  `(or (:actor-id tags) (:machine-id tags))` (rf2-yyvtk5): a LIVE actor's
-  exception row addresses the throwing instance under `:actor-id` (the
-  preferred branch every production emit site now hits —
-  registration.cljc), while `:machine-id` is the legacy fallback. We
-  parameterise `id-key` so BOTH branches of that `or` are exercised
-  (rf2-sxmeqs — the `:actor-id` branch had zero coverage).
-
-  Note: the emit site does NOT stamp `:sensitive?` here — the production
-  bug rf2-md2wn0 hinges on that. The flag is decided downstream by marks
-  projection, and the top-level hoist must lift it from `:tags`.
-
-  Carries an explicit `:frame :rf/default` — a KNOWN (non-nil) frame — so
-  the projector takes the resolved-frame branch and these precision fixtures
-  exercise the non-redacting plain-machine path (rf2-xmnlvc: with the
-  nil-frame fail-closed arm a missing `:frame` now redacts; the nil-frame
-  regression below intentionally omits it)."
+  Live actors use `:actor-id`; `:machine-id` is the fallback. The explicit
+  frame lets plain-machine tests exercise the resolved, non-redacting path."
   [id-key machine-id]
   {id-key             machine-id
    :frame             :rf/default
@@ -182,12 +71,8 @@
    :recovery          :no-recovery})
 
 (defn- emit-machine-action-exception
-  "Drive the REAL production emit: register a trace-tooling listener, call
-  `trace/emit-error! :rf.error/machine-action-exception` with the given
-  tags (exactly as `trace-action-failure!` does), and return the delivered
-  envelope — post-`build-event`, post-marks-projection, post-top-level
-  `:sensitive?` hoist. This is the production path; nothing routes around
-  the reported gap."
+  "Emit a machine exception through the production trace path and return the
+  delivered envelope after projection and sensitivity hoisting."
   [tags]
   (with-trace-recorder! [traces]
     (trace/emit-error! :rf.error/machine-action-exception tags)
@@ -200,54 +85,44 @@
   (emit-machine-action-exception (machine-action-exception-tags id-key machine-id)))
 
 (defn- emit-machine-action-exception-for
-  "The legacy `:machine-id`-keyed emit (the `:machine-id` FALLBACK branch of
-  the `(or (:actor-id …) (:machine-id …))` lookup)."
+  "Emit through the `:machine-id` fallback lookup."
   [machine-id]
   (emit-machine-action-exception* :machine-id machine-id))
 
 (deftest machine-exception-data-redacted-for-sensitive-machine
-  (testing "rf2-zsm03 / rf2-md2wn0 — a sensitive machine's :exception-data
-            is elided to :rf/redacted on the REAL emit path, the TOP-LEVEL
-            :sensitive? flag is hoisted (what MCP egress reads), and the
+  (testing "a sensitive machine's :exception-data is redacted on the
+            production emit path, the top-level :sensitive? flag is hoisted, and the
             sentinel never survives"
     (declare-machine-marks!)
     (let [out  (emit-machine-action-exception-for sensitive-machine-id)
           tags (:tags out)]
       (is (some? out) "the machine-action-exception trace was delivered")
       (is (= :rf/redacted (:exception-data tags)) ":exception-data redacted")
-      ;; rf2-md2wn0 — the production-critical assertion: TOP-LEVEL, not :tags.
       (is (true? (:sensitive? out)) "top-level :sensitive? hoisted")
       (is (not (contains? tags :sensitive?))
           ":sensitive? stripped from :tags after the hoist (no double-stamp)")
       (is (not (contains-sentinel? out))
           (str "the sentinel leaked into the machine-action-exception trace: "
                (pr-str tags)))
-      ;; Structural slots survive — consumers locate the failure.
+      ;; Structural slots remain available to locate the failure.
       (is (= sensitive-machine-id (:machine-id tags)) ":machine-id kept")
       (is (= :do/thing (:action-id tags)) ":action-id kept")
       (is (= "boom" (:exception-message tags)) ":exception-message kept"))))
 
 (deftest machine-exception-sensitive-event-drops-at-mcp-egress
-  (testing "rf2-md2wn0 — the production fail-closed contract: a sensitive
-            machine's exception event is DROPPED by sens/strip-sensitive
-            when --allow-sensitive-reads is disabled (include? false, the
-            whole-event defence-in-depth layer, not just per-slot redaction).
-            This is the assertion the old direct-projection test could never
-            make — it only proved the tag-level stamp, which MCP egress does
-            not read."
+  (testing "a sensitive machine's exception event is dropped when MCP
+            sensitive reads are disabled"
     (declare-machine-marks!)
     (let [out          (emit-machine-action-exception-for sensitive-machine-id)
           [kept dropped] (sens/strip-sensitive [out] false)]
       (is (some? out) "the machine-action-exception trace was delivered")
-      ;; The event production actually emits IS classified sensitive by the
-      ;; egress filter, so the allow-sensitive-disabled path drops it.
       (is (true? (sens/sensitive-event? out))
           "MCP egress classifies the emitted event as sensitive (top-level flag)")
       (is (= 1 dropped) "the sensitive machine exception event dropped")
       (is (empty? kept) "nothing egressed with --allow-sensitive-reads disabled"))))
 
 (deftest machine-exception-data-verbatim-for-plain-machine
-  (testing "rf2-zsm03 — a machine with NO :sensitive mark rides
+  (testing "a machine with no :sensitive mark keeps
             :exception-data verbatim (the seam is precise, not a blanket
             scrub) and is NOT classified sensitive at egress"
     (declare-machine-marks!)
@@ -260,8 +135,7 @@
       (is (false? (sens/sensitive-event? out)) "MCP egress treats it as non-sensitive"))))
 
 (deftest machine-exception-data-verbatim-for-unregistered-machine
-  (testing "rf2-zsm03 — a machine with no marks entry at all (never
-            registered marks) rides :exception-data verbatim"
+  (testing "an unregistered machine keeps :exception-data verbatim"
     ;; No declare-machine-marks! call — the id is unregistered, so the
     ;; registrar carries no :event meta and `registration-classification` derives nil.
     (let [out  (emit-machine-action-exception-for :sec/unregistered)
@@ -271,16 +145,13 @@
       (is (not (:sensitive? out)) "no top-level :sensitive? stamp"))))
 
 (deftest machine-exception-data-redacted-for-nil-frame
-  (testing "rf2-xmnlvc — a machine-action-exception whose trace carries NO
+  (testing "a machine-action-exception whose trace carries no
             :frame (nil / unresolvable frame) FAILS CLOSED: :exception-data is
             elided to :rf/redacted and the TOP-LEVEL :sensitive? flag is
-            hoisted — matching the sibling project-flow-failed-tags and Spec
-            015 §Failure-posture (unknown frame => fail closed). Even a PLAIN
+            hoisted. Even a plain
             machine (no author :sensitive mark) redacts here, because the
             author-shaped :exception-data cannot be path-walked safely without
-            a resolved frame. Confirm-by-revert: dropping the (nil? frame-id)
-            arm in project-machine-error-tags makes this RED — the sentinel
-            leaks raw."
+            a resolved frame."
     (declare-machine-marks!)
     (let [tags-no-frame (dissoc (machine-action-exception-tags
                                   :actor-id plain-machine-id)
@@ -296,22 +167,12 @@
           (str "the sentinel leaked into the nil-frame exception trace: "
                (pr-str tags))))))
 
-;; ---------------------------------------------------------------------------
-;; SITE 1 — :actor-id PREFERRED branch (rf2-sxmeqs).
-;;
-;; Every production emit of :rf.error/machine-action-exception addresses the
-;; throwing LIVE actor instance under :actor-id (registration.cljc:99); the
-;; schema lookup `(or (:actor-id tags) (:machine-id tags))` (marks.cljc:1419)
-;; PREFERS that branch. The fixtures above only exercise the :machine-id
-;; FALLBACK; these mirror them on the :actor-id key so the privacy-critical
-;; preferred branch is proven to redact identically.
-;; ---------------------------------------------------------------------------
-
+;; Production emits address live instances by :actor-id; :machine-id remains a
+;; fallback. Both paths must apply the same classification.
 (deftest machine-exception-data-redacted-for-sensitive-actor
-  (testing "rf2-sxmeqs / rf2-md2wn0 — an :actor-id-keyed sensitive-machine
-            exception (the PREFERRED lookup branch, the one production emits)
+  (testing "an :actor-id-keyed sensitive-machine exception
             redacts :exception-data, hoists the TOP-LEVEL :sensitive? flag,
-            and the sentinel never survives — on the real emit path"
+            and never exposes the sentinel"
     (declare-machine-marks!)
     (let [out  (emit-machine-action-exception* :actor-id sensitive-machine-id)
           tags (:tags out)]
@@ -321,13 +182,13 @@
       (is (not (contains-sentinel? out))
           (str "the sentinel leaked into the :actor-id-keyed exception trace: "
                (pr-str tags)))
-      ;; The :actor-id structural slot survives — consumers locate the failure.
+      ;; The structural actor id remains available to locate the failure.
       (is (= sensitive-machine-id (:actor-id tags)) ":actor-id kept")
       (is (= :do/thing (:action-id tags)) ":action-id kept")
       (is (= "boom" (:exception-message tags)) ":exception-message kept"))))
 
 (deftest machine-exception-data-verbatim-for-plain-actor
-  (testing "rf2-sxmeqs — an :actor-id-keyed machine with NO :sensitive mark
+  (testing "an :actor-id-keyed machine with no :sensitive mark
             rides :exception-data verbatim on the preferred branch (the seam
             is precise, not a blanket scrub)"
     (declare-machine-marks!)
@@ -339,7 +200,7 @@
           "no top-level :sensitive? when the machine declares nothing sensitive"))))
 
 (deftest actor-id-takes-precedence-over-machine-id
-  (testing "rf2-sxmeqs — when BOTH keys are present the schema lookup PREFERS
+  (testing "when both keys are present the classification lookup prefers
             :actor-id: an :actor-id pointing at the SENSITIVE machine redacts
             even though :machine-id points at the PLAIN one (proves the
             `(or (:actor-id …) (:machine-id …))` precedence, not the fallback)"
@@ -354,11 +215,6 @@
       (is (true? (:sensitive? out)) "top-level :sensitive? hoisted from the :actor-id machine")
       (is (not (contains-sentinel? out))
           "the sentinel never survives when :actor-id wins the lookup"))))
-
-;; ---------------------------------------------------------------------------
-;; SITE 1 PROPERTY — across arbitrary collection/map nestings of the
-;; sentinel inside :exception-data, a sensitive machine NEVER egresses it.
-;; ---------------------------------------------------------------------------
 
 (defn- gen-ex-data
   "Generator: a sentinel-bearing ex-data value at a random collection/map
@@ -381,14 +237,13 @@
       ((gen-ex-data (inc depth)) rng1))))
 
 (deftest sensitive-machine-redacts-ex-data-at-arbitrary-nesting
-  (testing "rf2-zsm03 / rf2-sxmeqs / rf2-md2wn0 — across arbitrary nestings of
+  (testing "across arbitrary nestings of
             the sentinel inside :exception-data, a sensitive machine elides
             the WHOLE slot and hoists the TOP-LEVEL :sensitive?; the sentinel
             never survives AND sens/strip-sensitive drops the event with
             --allow-sensitive-reads disabled. Run over BOTH id-keys so the
-            preferred :actor-id branch
-            (production) AND the :machine-id fallback both get property
-            coverage — on the REAL emit path."
+            preferred :actor-id branch and the :machine-id fallback both get
+            property coverage."
     (declare-machine-marks!)
     (doseq [id-key [:actor-id :machine-id]]
       (let [result (gen/for-all
@@ -410,43 +265,27 @@
                  "at egress) for a generated nesting under " id-key ": "
                  (pr-str (when result (dissoc result :threw)))))))))
 
-;; ===========================================================================
-;; SITE 2 — :rf.route/navigate :error
-;; Driven END-TO-END through the REAL navigate-handler: a validation-reject
-;; short-circuits BEFORE any push/scroll fx, so no window stub is needed.
-;; ===========================================================================
-
 (def ^:private sensitive-params-schema
-  ;; A route :params schema marking the doc-id slot sensitive. A navigate
-  ;; with a non-conforming :doc value throws :rf.error/route-url-validation
-  ;; whose ex-data carries the failing value (the sentinel) under :value AND
-  ;; the Malli explainer.
+  ;; The rejected value appears in route-url's exception data.
   [:map [:doc {:sensitive? true} :int]])
 
 (def ^:private plain-params-schema
   [:map [:doc :int]])
 
 (defn- capture-navigate-failure
-  "Register `:sec/route` with `params-schema`, invoke the REAL
-  `navigate-handler` with a sentinel-bearing (non-:int) :doc param so
-  `route-url` throws inside the handler, and return the emitted
-  `:rf.error/schema-validation-failure` trace event. Calling the handler
-  fn directly (rather than `dispatch-sync`) keeps the test substrate-free:
-  the `:params`-schema reject short-circuits before any push/scroll fx."
+  "Invoke navigation with a sentinel-bearing invalid param and return the
+  emitted schema-validation trace. The reject precedes all browser effects."
   [params-schema]
   (rf/reg-route :sec/route {:params params-schema} "/doc/:doc")
   (with-trace-recorder! [traces]
-    ;; :doc must be a value the schema rejects (schema wants :int). The
-    ;; sentinel rides as the offending param value.
-    ;; The frame stamp reaches the event context under :rf.frame/id
-    ;; (rf2-1m6rf1 — the bare :frame coeffect is retired).
+    ;; :doc must be rejected by the integer schema.
     (navigate/navigate-handler {:db {} :rf.frame/id :rf/default}
                                [:rf.route/navigate :sec/route {:doc sentinel}])
     (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                    @traces))))
 
 (deftest navigate-error-redacted-for-sensitive-route
-  (testing "rf2-zsm03 — a navigate whose route :params schema is :sensitive?
+  (testing "a navigate whose route :params schema is :sensitive?
             elides the :error slot (carrying the failing param value) to
             :rf/redacted, stamps :sensitive?, and never egresses the sentinel"
     (let [trace (capture-navigate-failure sensitive-params-schema)
@@ -454,11 +293,7 @@
       (is (some? trace) "a schema-validation-failure trace fired for the reject")
       (when trace
         (is (= :rf/redacted (:error tags)) ":error slot redacted")
-        ;; The redaction stamps tags-level `:sensitive?`; this emit goes
-        ;; through the real `trace/emit-error!` → `build-event`, which hoists
-        ;; the flag to the TOP LEVEL of the envelope (and strips it from
-        ;; `:tags`). The top-level stamp is exactly what the MCP egress gate
-        ;; reads (`mcp-base.sensitive/sensitive-event?`).
+        ;; The trace builder hoists the tags-level stamp for MCP egress.
         (is (true? (:sensitive? trace)) "top-level :sensitive? stamped")
         (is (not (contains-sentinel? trace))
             (str "the sentinel leaked into the navigate :error trace: "
@@ -468,7 +303,7 @@
         (is (= :event (:where tags)) ":where kept")))))
 
 (deftest navigate-error-verbatim-for-plain-route
-  (testing "rf2-zsm03 — a navigate whose route :params schema has NO
+  (testing "a navigate whose route :params schema has no
             :sensitive? slot rides :error verbatim (no over-redaction)"
     (let [trace (capture-navigate-failure plain-params-schema)
           tags  (:tags trace)]
@@ -479,20 +314,10 @@
         (is (not (contains? tags :sensitive?))
             "no :sensitive? stamp on a non-sensitive route")))))
 
-;; ===========================================================================
-;; REDACTION IS AT-SOURCE — the scrub happens at the trace egress chokepoint,
-;; so the sentinel is gone from the event REGARDLESS of the --allow-sensitive-
-;; reads opt-in. Unlike the MCP whole-event drop (which would also hide the
-;; useful "an action threw" / "a navigate rejected" signal from the agent),
-;; per-slot redaction lets the agent SEE the structural error while the secret
-;; stays off-box. So we pass the redacted events through the MCP egress with
-;; --allow-sensitive-reads ENABLED (include? true — the MOST permissive, fully
-;; opted-in path) and confirm the sentinel STILL never reaches the boundary:
-;; the protection is the source scrub, not an opt-in decision.
-;; ===========================================================================
-
+;; Per-slot projection happens before MCP filtering. The explicit raw-event
+;; opt-in therefore retains the structural error without restoring scrubbed data.
 (deftest redaction-survives-even-the-opt-in-mcp-egress
-  (testing "rf2-zsm03 — the per-slot scrub is at-source: even with
+  (testing "even with
             --allow-sensitive-reads fully ENABLED (include? true), neither the
             machine :exception-data nor the navigate :error egresses the
             sentinel"
@@ -506,13 +331,8 @@
           (str "the sentinel reached the MCP boundary even after redaction: "
                (pr-str kept))))))
 
-;; ===========================================================================
-;; UNIT — the route-url throw genuinely carries the sentinel in its ex-data
-;; (pins the pre-redaction leak vector so the redaction is not vacuous).
-;; ===========================================================================
-
 (deftest route-url-throw-ex-data-carries-the-sentinel
-  (testing "rf2-zsm03 — the route-url validation throw's ex-data DOES embed
+  (testing "the route-url validation throw's ex-data embeds
             the failing param value (the sentinel); without redaction the
             navigate :error slot would ship it"
     (rf/reg-route :sec/raw-route {:params sensitive-params-schema} "/doc/:doc")
@@ -523,5 +343,4 @@
       (is (some? ex) "route-url threw on the non-conforming sensitive param")
       (when ex
         (is (contains-sentinel? (ex-data ex))
-            "pre-redaction: the throw's ex-data embeds the sentinel — the leak
-             vector the :error redaction closes")))))
+            "the throw's ex-data embeds the value protected by :error redaction")))))

--- a/implementation/security/test/re_frame/security/fail_closed_invariant_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/fail_closed_invariant_security_cljs_test.cljc
@@ -1,70 +1,11 @@
 (ns re-frame.security.fail-closed-invariant-security-cljs-test
-  "Class-invariant security tier — EVERY boundary that accepts external /
-  untrusted / malformed input fails CLOSED, never OPEN (rf2-gro94).
+  "Adversarial tests for untrusted-input boundaries that must fail closed.
 
-  ## The class
-
-  rf2-a5kzs#2/#3 and w3qgc#2 recurred the SAME fail-OPEN class the app-db
-  schema sweep had already closed once: a malformed schema / throwing
-  validator / throwing explainer at the event / cofx / fx / sub / boundary
-  call sites was COERCED TO SUCCESS (the runtime `(catch … true)` swallow),
-  and a non-string URL handed to `js/URL` was classed same-origin and
-  pushed as an in-app nav (`external-url?` fail-open). The fix did NOT
-  generalise — each boundary re-decided fail-open vs fail-closed ad hoc.
-
-  This is the FAIL-CLOSED counterpart to the Class-sweep A redaction
-  invariant (`validation_redaction_invariant_security_cljs_test`): where
-  that one proves no sensitive value ever LEAKS, this one proves no
-  malformed / untrusted input ever PASSES.
-
-  ## The invariant (the deliverable)
-
-  Across the framework's untrusted-input boundaries, a malformed / hostile
-  input MUST be REJECTED (fail-closed) — never coerced to a success:
-
-    - SCHEMA metadata (event / cofx / fx / sub-return / app-db) + the
-      production boundary seam: a childless `[:vector]` / unknown-op
-      schema (the validator throws at validate-time) and a throwing
-      registered validator MUST yield `false` (reject + recovery), NEVER
-      `true` and NEVER a propagated throw. (rf2-a5kzs#2/#3.)
-
-    - URL / same-origin classification (routing `external-url?` /
-      `safe-in-app-url?`): a non-string / empty / whitespace / control-char
-      / protocol-relative / scheme-bearing target MUST classify EXTERNAL
-      (fail-closed) so it is never pushed as a fabricated in-app URL.
-      (w3qgc#2 + rf2-3bv8o.)
-
-    - SSR HYDRATION payload (`ssr.hydrate/hydrate-event-handler`): a
-      deserialised, untrusted payload that is not a map — or whose
-      `:rf/app-db` OR `:rf/runtime-db` slice is present-but-not-a-map —
-      MUST be REJECTED (the existing client frame-state left unchanged + a
-      `:rf.error/malformed-hydration-payload` diagnostic), NEVER installed
-      as the whole partition under the locked `:replace-frame-state`
-      policy. EP-0001 (rf2-vzld77 / rf2-g00l2t) made `:rf/runtime-db` an
-      equally load-bearing frame-state slice; the corpus exercises BOTH
-      partitions so a regression dropping either branch trips this gate
-      (rf2-gro94, rf2-kzhcv3).
-
-  This namespace fails RED if ANY boundary coerces a malformed / untrusted
-  input to success. A new boundary that forgets to fail closed (or an
-  existing one regressed to a `(catch … true)`) re-opens the class and
-  trips this gate.
-
-  ## Why property-style + a per-boundary corpus
-
-  Each boundary is swept with BOTH a hostile-input corpus (the named
-  regression cases pinned exactly) AND a deterministic fuzzer over the
-  shape space (the rf2-3cfvt gen substrate), so broad casing/shape
-  coverage rides alongside the regression pins. One boundary that passes a
-  malformed input on ANY draw = one fail-open.
-
-  ## Net property (verify-by-revert)
-
-  Reverting any one boundary to its pre-fix fail-OPEN shape (a
-  `(catch … true)` validator swallow; `external-url?` skipping its
-  non-string guard; `hydrate-event-handler` installing the slice without
-  the shape guard) makes that boundary's assertion go RED. Confirmed by
-  temporary local revert + restore (see PR Quality gates)."
+  Malformed schemas and throwing validators reject rather than validate;
+  ambiguous or non-string navigation targets classify as external; and
+  malformed SSR hydration payloads leave both frame-state partitions unchanged.
+  Each boundary combines named hostile inputs with deterministic generated
+  coverage."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core :as rf]
@@ -80,31 +21,14 @@
                :cljs [re-frame.test-support :as test-support :refer-macros [with-trace-recorder!]])
             [re-frame.security.gen :as gen]))
 
-;; Reset per-test so app-schema registrations / validator overrides don't
-;; bleed across cases.
-;;
-;; EP-0002 (rf2-gjq3ow): `reg-app-schema` is context-required frame-local
-;; (no `:rf/default` floor). The adapter-less reset fixture establishes no
-;; ambient scope, so the outer fixture below pins `:rf/default` as the
-;; carried scope for the test body — the carried-invariant equivalent of
-;; `(with-frame :rf/default …)`. Without it the BOUNDARY 1
-;; `app-db-validation-never-passes-a-malformed-schema` case raises
-;; `:rf.error/no-frame-context` at `reg-app-schema`. (The BOUNDARY 3
-;; hydration cases already pass an explicit `{:frame :rf/default}` to the
-;; pure handler, so they carry their own stamp.) Binding the dynamic var is
-;; sufficient: the scope reader reads the var and `reg-app-schema` keys only
-;; the schemas side-table — no registered frame / container needed (so no
-;; adapter, and not `ensure-default-frame!`, which would require one).
+;; App schemas are frame-local. Bind a scope for registration without creating
+;; an adapter-backed frame; hydration tests carry their own explicit stamp.
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
     {:clear-app-schemas? true})
   (fn [test-fn]
     (binding [frame/*current-frame* :rf/default]
       (test-fn))))
-
-;; ---------------------------------------------------------------------------
-;; Trace capture — register a listener, run `f`, return the captured events.
-;; ---------------------------------------------------------------------------
 
 (defn- capture
   [f]
@@ -115,22 +39,9 @@
 (defn- ops [traces op]
   (filter #(= op (:operation %)) traces))
 
-;; ===========================================================================
-;; BOUNDARY 1 — schema metadata + the production boundary seam.
-;;   A malformed schema (childless `[:vector]` / unknown op) makes the
-;;   registered validator THROW at validate-time; a throwing registered
-;;   validator throws on every call. Either MUST fail CLOSED (`false`),
-;;   never coerce to `true`, never propagate the throw. (rf2-a5kzs#2/#3.)
-;; ===========================================================================
-
 (def ^:private malformed-schemas
-  "Schemas that REGISTER fine but make the Malli validator THROW at
-  validate-time (Malli validates schema FORMS lazily). The hostile-input
-  corpus for the schema boundary. Each form below is a childless
-  collection schema (Malli REQUIRES the element child) or an unknown op —
-  both throw on the first validate call. (`[:tuple]` / `[:cat]` / `[:and]`
-  are deliberately EXCLUDED: Malli accepts their zero-child form as a
-  degenerate-but-valid schema, so they do not throw and are not malformed.)"
+  "Schemas that register but make Malli throw when first validated. Tuple,
+  cat, and and are absent because Malli accepts their zero-child forms."
   [[:vector]                    ;; childless — no element schema
    [:map-of]                    ;; childless map-of
    [:set]                       ;; childless set
@@ -139,9 +50,8 @@
    [:not-a-real-op :int]])      ;; unknown op
 
 (deftest boundary-seam-never-passes-a-malformed-schema
-  (testing "rf2-a5kzs#2 — `validate-with-registered-fn` (the production
-            boundary seam) returns FALSE for every malformed schema; it
-            NEVER returns true and NEVER throws. A `true` here would run
+  (testing "validate-with-registered-fn returns false for every malformed
+            schema and never propagates the validator throw. A true result would run
             the boundary handler on an unvalidated untrusted payload."
     (doseq [schema malformed-schemas]
       (let [verdict (try (schemas/validate-with-registered-fn schema [:anything])
@@ -151,8 +61,8 @@
                  " must fail CLOSED (false), got " (pr-str verdict)))))))
 
 (deftest meta-bearing-surfaces-never-pass-a-malformed-schema
-  (testing "rf2-a5kzs#2 — the three meta-bearing validate-*! fns return
-            FALSE (reject) for a malformed schema, emitting
+  (testing "the three meta-bearing validation functions reject a malformed
+            schema, emitting
             :rf.error/malformed-schema. None coerces to true; none throws."
     (doseq [schema malformed-schemas]
       ;; :where :event
@@ -169,7 +79,7 @@
           (str "sub / " (pr-str schema) " → false")))))
 
 (deftest app-db-validation-never-passes-a-malformed-schema
-  (testing "rf2-ss06u.3 / rf2-a5kzs — validate-app-schema! fails CLOSED
+  (testing "validate-app-schema! fails closed
             (returns false → the router rolls back) for a malformed
             registered app-schema, and emits :rf.error/malformed-schema."
     (doseq [schema malformed-schemas]
@@ -181,7 +91,7 @@
             (str "app-db / " (pr-str schema) " emits :rf.error/malformed-schema"))))))
 
 (deftest throwing-validator-never-coerces-to-pass
-  (testing "rf2-a5kzs#2 — a registered validator that THROWS on every call
+  (testing "a registered validator that throws on every call
             (a buggy / hostile custom validator) fails CLOSED at the
             boundary seam, not OPEN. The throw is isolated; the verdict is
             false (reject), never true."
@@ -192,13 +102,11 @@
           "throwing validator → false (fail closed), not a propagated throw, not true")
       (finally (schemas/reset-schema-validator!)))))
 
-;; ---- property: any malformed schema fails closed across every kind --------
-
 (def ^:private gen-malformed-schema
   (gen/gen-elem malformed-schemas))
 
 (deftest every-schema-kind-rejects-every-malformed-schema
-  (testing "rf2-a5kzs#2 — property: across the malformed-schema corpus,
+  (testing "across the malformed-schema corpus,
             EVERY callable schema-validation kind returns FALSE. One kind
             that returns true (or throws) for any draw = one fail-open."
     (let [result
@@ -215,13 +123,6 @@
       (is (nil? result)
           (str "a schema kind coerced a malformed schema to success: "
                (pr-str (when result (dissoc result :threw))))))))
-
-;; ===========================================================================
-;; BOUNDARY 2 — URL / same-origin classification (routing url.cljc).
-;;   A non-string / empty / whitespace / control-char / protocol-relative /
-;;   scheme-bearing target MUST classify EXTERNAL (fail-closed) so it is
-;;   never pushed as a fabricated in-app URL. (w3qgc#2 + rf2-3bv8o.)
-;; ===========================================================================
 
 (def ^:private untrusted-url-inputs
   "Hostile / malformed URL-sink inputs. Each MUST classify EXTERNAL
@@ -249,12 +150,12 @@
    "/path\u0000null"])         ;; embedded NUL
 
 (deftest untrusted-url-inputs-never-classify-in-app
-  (testing "w3qgc#2 + rf2-3bv8o — every untrusted URL-sink input fails
+  (testing "every untrusted URL-sink input fails
             CLOSED: safe-in-app-url? is false (the no-window lexical gate)
             and external-url? is true (classed external). A non-string or
             ambiguous target must never be canonicalised + pushed as an
-            in-app URL. (Node test → no js/window → external-url? takes the
-            fail-closed lexical fallback, the host-uniform contract.)"
+            in-app URL. Without a window, external-url? uses the same
+            fail-closed lexical fallback."
     (doseq [input untrusted-url-inputs]
       (is (false? (url/safe-in-app-url? input))
           (str (pr-str input) " must NOT pass the in-app lexical gate"))
@@ -262,7 +163,7 @@
           (str (pr-str input) " must classify EXTERNAL (fail closed)")))))
 
 (deftest legitimate-in-app-urls-still-pass
-  (testing "w3qgc#2 — the URL gate is precise, not a blanket reject: a
+  (testing "the URL gate is precise, not a blanket reject: a
             genuine rooted same-origin path / pure query / pure fragment
             still classifies in-app, so fail-closed didn't break real nav."
     (doseq [ok-url ["/" "/dashboard" "/users/42" "/a/b/c" "?q=1" "#frag"
@@ -272,15 +173,13 @@
       (is (false? (url/external-url? ok-url))
           (str (pr-str ok-url) " classifies in-app (not external)")))))
 
-;; ---- property: non-string inputs always fail closed -----------------------
-
 (def ^:private gen-non-string
   (gen/gen-one-of
     (gen/gen-elem [nil true false :kw 'sym {} [] #{}])
     (gen/gen-int -1000 1000)))
 
 (deftest non-string-url-inputs-always-fail-closed
-  (testing "w3qgc#2 — property: ANY non-string URL-sink input classifies
+  (testing "any non-string URL-sink input classifies
             external and never passes the in-app gate. JavaScript would
             stringify it (`new URL(x, base)`); the guard rejects it first."
     (let [result (gen/for-all
@@ -291,14 +190,6 @@
       (is (nil? result)
           (str "a non-string URL input was not failed closed: "
                (pr-str (when result (dissoc result :threw))))))))
-
-;; ===========================================================================
-;; BOUNDARY 3 — SSR hydration payload (ssr.hydrate/hydrate-event-handler).
-;;   A deserialised, untrusted payload that is not a map — or whose app-db
-;;   slice is present-but-not-a-map — MUST be REJECTED (existing app-db
-;;   unchanged + diagnostic), NEVER installed as the whole partition under the
-;;   locked `:replace-frame-state` policy. (rf2-gro94.)
-;; ===========================================================================
 
 (def ^:private existing-db {:client/seeded true :count 0})
 
@@ -319,16 +210,9 @@
   a map whose `:rf/app-db` slice is present-but-not-a-map, OR a map whose
   `:rf/runtime-db` slice is present-but-not-a-map.
 
-  EP-0001 (rf2-vzld77 / rf2-g00l2t) made `:rf/runtime-db` an equally
-  load-bearing frame-state slice: the production guard
-  (`re-frame.ssr.hydrate/malformed-hydration-payload!`) fails closed when
-  EITHER partition slice is present-but-non-map. The cross-surface
-  security corpus must therefore exercise BOTH partitions, else a
-  regression that drops the `:rf/runtime-db` branch from the production
-  guard would slip past this fail-closed invariant (rf2-kzhcv3). The
-  malformed-runtime-db cases are paired with a VALID `:rf/app-db` so the
-  invariant proves the WHOLE payload is rejected (app-db left unchanged),
-  not partially installed."
+  Both slices are load-bearing frame state. Malformed runtime-db cases include
+  a valid app-db slice to prove the payload is rejected atomically rather than
+  partially installed."
   [nil
    "a string payload"
    42
@@ -336,16 +220,12 @@
    :keyword
    ["a" "vector"]
    #{:a :set}
-   ;; --- present-but-non-map :rf/app-db slice ---
+   ;; Present-but-non-map app-db slices.
    {:rf/app-db "not-a-map"}      ;; slice present but a string
    {:rf/app-db 42}               ;; slice present but a number
    {:rf/app-db [:not :a :map]}   ;; slice present but a vector
    {:rf/app-db true}             ;; slice present but a boolean
-   ;; --- present-but-non-map :rf/runtime-db slice (rf2-kzhcv3) ---
-   ;;     each paired with a VALID app-db slice, so the only thing that
-   ;;     can fail the payload is the malformed runtime-db — proving the
-   ;;     whole payload is rejected rather than installing the good
-   ;;     app-db and dropping the bad runtime-db.
+   ;; Malformed runtime-db slices paired with valid app-db slices.
    {:rf/app-db {:ok 1} :rf/runtime-db "not-a-map"}    ;; runtime-db a string
    {:rf/app-db {:ok 1} :rf/runtime-db 42}             ;; runtime-db a number
    {:rf/app-db {:ok 1} :rf/runtime-db [:not :a :map]} ;; runtime-db a vector
@@ -357,7 +237,7 @@
    {:rf/runtime-db [:not :a :map]}])
 
 (deftest malformed-hydration-payload-never-installs
-  (testing "rf2-gro94 — a malformed / untrusted hydration payload is
+  (testing "a malformed or untrusted hydration payload is
             REJECTED: the handler leaves the existing client app-db
             unchanged (`{:db existing-db}`), fires NO compatibility-check
             fxs, and emits :rf.error/malformed-hydration-payload. The
@@ -376,22 +256,18 @@
                  " must emit :rf.error/malformed-hydration-payload"))))))
 
 (deftest wellformed-hydration-payload-still-installs
-  (testing "rf2-gro94 — the guard is precise: a well-formed payload (a map
+  (testing "the guard is precise: a well-formed payload (a map
             with a map app-db slice, OR a map with NO slice — the documented
             client-only fallback) still hydrates. Fail-closed didn't break
             the real path."
-    ;; (a) full server slice → installed
+    ;; A full server slice installs.
     (let [{:keys [result traces]} (hydrate-with {:rf/app-db {:count 7 :title "seeded"}})]
       (is (= 7 (get-in result [:db :count])) "server app-db slice installed")
       (is (= "seeded" (get-in result [:db :title])))
       (is (zero? (count (ops traces :rf.error/malformed-hydration-payload)))
           "no malformed diagnostic on a well-formed payload"))
-    ;; (b) map payload with NO app-db slice → falls back to existing db
-    ;;     (client-only / no-server-slice shape — NOT malformed). The
-    ;;     existing user data survives; the runtime hydration-metadata block
-    ;;     (`:version`) is additively stashed in the runtime-db partition
-    ;;     (EP-0001 rf2-vzld77 — SSR hydration metadata is durable runtime-db
-    ;;     state, returned under the handler's `:rf.db/runtime` effect).
+    ;; A client-only payload preserves app-db and adds hydration metadata to
+    ;; runtime-db.
     (let [{:keys [result traces]} (hydrate-with {:rf/version 1})]
       (is (true? (get-in result [:db :client/seeded]))
           "no-slice payload preserves the existing client data (not replaced/rejected)")
@@ -401,12 +277,10 @@
           "version metadata is additively stashed in runtime-db (the legitimate no-slice path)")
       (is (zero? (count (ops traces :rf.error/malformed-hydration-payload)))
           "a no-slice map payload is the legitimate client-only fallback, not malformed"))
-    ;; (c) empty map → fallback, no diagnostic
+    ;; An empty map also takes the client-only fallback.
     (let [{:keys [result traces]} (hydrate-with {})]
       (is (= existing-db (:db result)))
       (is (zero? (count (ops traces :rf.error/malformed-hydration-payload)))))))
-
-;; ---- coherent-frame-state: malformed runtime-db leaves BOTH partitions ----
 
 (def ^:private existing-runtime-db
   {:rf.runtime/ssr {:hydration {:version 7}}
@@ -427,14 +301,12 @@
     {:result @out :traces traces}))
 
 (deftest malformed-runtime-db-leaves-both-partitions-unchanged
-  (testing "rf2-kzhcv3 — coherent-frame-state contract: a payload whose
+  (testing "a payload whose
             :rf/runtime-db slice is present-but-non-map (even alongside a
-            VALID :rf/app-db slice) is rejected as a WHOLE — the existing
+            valid :rf/app-db slice) is rejected as a whole — the existing
             app-db (:db) AND the existing runtime-db (:rf.db/runtime) are
             both left unchanged, the diagnostic fires, and the good app-db
-            slice is NOT partially installed. Mirrors the SSR-artefact
-            pin (re_frame/ssr_hydration_test.clj) at the cross-surface
-            security boundary."
+            slice is not partially installed."
     (doseq [payload [{:rf/app-db {:would-install 1} :rf/runtime-db "not-a-map"}
                      {:rf/app-db {:would-install 1} :rf/runtime-db [:bad]}
                      {:rf/app-db {:would-install 1} :rf/runtime-db 42}
@@ -444,9 +316,7 @@
             (str "payload " (pr-str payload)
                  " must leave app-db unchanged (the good app-db slice must"
                  " NOT be partially installed), got " (pr-str (:db result))))
-        ;; A rejection returns {:db db} — no :rf.db/runtime effect — so the
-        ;; runtime-db partition rides through unchanged (the effect is
-        ;; absent, leaving the seeded runtime-db in place).
+        ;; Omitting the runtime-db effect leaves the seeded partition unchanged.
         (is (nil? (:rf.db/runtime result))
             (str "payload " (pr-str payload)
                  " must emit NO :rf.db/runtime effect (runtime-db partition"
@@ -458,34 +328,27 @@
             (str "payload " (pr-str payload)
                  " must fire no compatibility-check fxs"))))))
 
-;; ---- property: non-map payloads + non-map slices always fail closed -------
-
 (def ^:private gen-non-map
   (gen/gen-one-of
     (gen/gen-elem [nil true false :kw "str" 'sym [] #{} [:a :b]])
     (gen/gen-int -100 100)))
 
 (deftest non-map-hydration-inputs-always-fail-closed
-  (testing "rf2-gro94 / rf2-kzhcv3 — property: a non-map payload, OR a map
+  (testing "a non-map payload, or a map
             carrying a non-map :rf/app-db slice, OR a map carrying a non-map
             :rf/runtime-db slice, is ALWAYS rejected — app-db unchanged +
             the diagnostic fires. One installed-garbage case = one
-            fail-open. Both load-bearing partition slices (:rf/app-db AND
-            :rf/runtime-db, per EP-0001) are exercised."
+            fail-open. Both load-bearing partition slices are exercised."
     (let [result
           (gen/for-all
             gen-non-map 200 23
             (fn [bad]
-              (let [;; (i) the whole payload is the non-map `bad`
+              (let [;; The whole payload is the non-map `bad`.
                     p1 (hydrate-with bad)
-                    ;; (ii) a map payload whose :rf/app-db slice is `bad`
-                    ;;      (skip the maps — a map slice is the valid case)
+                    ;; A map payload whose app-db slice is `bad`.
                     p2 (when-not (map? bad)
                          (hydrate-with {:rf/app-db bad}))
-                    ;; (iii) a map payload carrying a VALID :rf/app-db but a
-                    ;;       non-map :rf/runtime-db slice — must reject the
-                    ;;       WHOLE payload (app-db left unchanged), not
-                    ;;       partially install the good app-db (rf2-kzhcv3).
+                    ;; A valid app-db plus malformed runtime-db rejects as a unit.
                     p3 (when-not (map? bad)
                          (hydrate-with {:rf/app-db {:ok 1} :rf/runtime-db bad}))
                     failed-closed?

--- a/implementation/security/test/re_frame/security/gen_parity_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/gen_parity_security_cljs_test.cljc
@@ -1,33 +1,9 @@
 (ns re-frame.security.gen-parity-security-cljs-test
-  "Cross-runtime parity pin for the security-tier deterministic generator
-  (`re-frame.security.gen`) — rf2-h2yvs finding 2.
+  "Cross-runtime parity tests for the security tier's deterministic generator.
 
-  ## Why this exists
-
-  `gen.cljc` advertises a 32-bit LCG that is byte-deterministic AND identical
-  across JVM + JS: `for-all` reports a failing draw as `{:seed :index}`, and
-  the contract is that the SAME seed/index reproduces the SAME draw on either
-  host. That only holds if the LCG arithmetic agrees bit-for-bit across
-  runtimes.
-
-  Before rf2-h2yvs, `next-state` used `unchecked-multiply`, which on CLJS
-  compiles to JS `*` on a double. The LCG product `s * 1103515245` is ~2^62
-  for a 32-bit state, exceeding the 53-bit double mantissa, so the low bits
-  were lost and the JS sequence diverged from the JVM sequence after the first
-  step (seed 1 / bound 100: JVM `54 24 56 …` vs the double path `54 25 12 …`).
-  The fix routes the multiply through `js/Math.imul` (exact low-32 product) on
-  CLJS, keeps the full-precision `long` multiply on CLJ, and carries an
-  unsigned-32 state on both.
-
-  ## What this pins
-
-  The expected sequences below are the JVM reference (computed under
-  `:clj`). The test runs in BOTH runtimes; on CLJS it now reproduces these
-  exact values via `Math.imul`. A regression to the double-multiply path makes
-  the very first multi-step draw RED on CLJS. The test is named
-  `…-security-cljs-test` so it rides `npm run test:security` AND the always-on
-  `npm run test:cljs` node gate; as `.cljc` it also pins the contract for any
-  JVM run of the security tier."
+  A reported seed and index must reproduce the same draw on JVM and
+  JavaScript. The LCG therefore uses exact low-32 multiplication on CLJS and
+  carries an unsigned 32-bit state on both hosts."
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test :refer-macros [deftest is testing]])
             [re-frame.security.gen :as gen]))
@@ -43,13 +19,10 @@
 
 (deftest next-int-sequence-is-cross-runtime-deterministic
   (testing "the LCG reproduces the JVM reference draw sequence on this runtime
-            (rf2-h2yvs finding 2 — proves the Math.imul portable-multiply fix
-            keeps CLJS bit-identical to JVM)"
-    ;; Reference sequences computed under :clj with the portable next-state.
+            and keeps CLJS bit-identical to JVM"
     (is (= [54 24 56 95 79 28 42 38 60 29 94 96]
            (draws 1 100 12))
-        "seed 1, bound 100 must match the JVM reference (was 54 25 12 … on the
-         pre-fix CLJS double-multiply path)")
+        "seed 1, bound 100 must match the JVM reference")
     (is (= [60 245 28 134 20 3 216 219 7 245 13 25]
            (draws 23 256 12))
         "seed 23, bound 256 must match the JVM reference")))
@@ -57,18 +30,13 @@
 (deftest sample-and-for-all-reproduce-from-seed
   (testing "the documented `(seed, g, n)` reproducibility holds on this runtime"
     (let [g (gen/gen-int 0 1000)]
-      ;; Same seed ⇒ same sample, and a different seed ⇒ a different sample
-      ;; (so the seed actually threads through the host-specific multiply).
+      ;; The second assertion ensures the seed participates in the draw.
       (is (= (gen/sample g 20 7) (gen/sample g 20 7)))
       (is (not= (gen/sample g 20 7) (gen/sample g 20 8))))
-    ;; `for-all`'s counter-example seed/index must reproduce the failing draw:
-    ;; assert "every drawn int < 5" over a [0,1000) generator; the first draw
-    ;; that is >= 5 is the counter-example, and re-drawing at that seed/index
-    ;; must yield the same value on either host.
+    ;; Re-drawing through the reported index must reproduce the counterexample.
     (let [g    (gen/gen-int 0 1000)
           {:keys [fail index seed]} (gen/for-all g 50 99 (fn [n] (< n 5)))]
       (is (some? fail) "a [0,1000) draw should exceed 5 within 50 draws")
       (is (= 99 seed))
-      ;; Re-draw `index+1` values from the same seed; the last equals `fail`.
       (is (= fail (last (gen/sample g (inc index) seed)))
           "the reported seed/index must reproduce the failing draw exactly"))))

--- a/implementation/security/test/re_frame/security/mcp_egress_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/mcp_egress_security_cljs_test.cljc
@@ -1,114 +1,30 @@
 (ns re-frame.security.mcp-egress-security-cljs-test
-  "Adversarial-property security tier - AI/MCP-boundary egress redaction
-  (rf2-3cfvt, surface 3; the rf2-6wvh5 / rf2-j90sb / rf2-f1ose class).
+  "Adversarial tests for AI/MCP trace egress.
 
-  ## The boundary
-
-  `re-frame.mcp-base.sensitive` is the framework-published default-suppress
-  filter every MCP forwarder (re-frame2-pair-mcp, story-mcp, Sentry/
-  Honeybadger forwarders) MUST route trace-like data through before it
-  crosses the trust boundary into the agent surface. Per Spec 009 Privacy:
-  a trace event stamped top-level `:sensitive? true` MUST be DROPPED when
-  the caller has not opted in (`include? = false`, the published default -
-  `--allow-sensitive-reads` disabled). NOTE the polarity: the restrictive
-  default is the *disabled* opt-in, which is the most protective posture
-  (sensitive events are dropped); enabling `--allow-sensitive-reads` is the
-  operator's deliberate raw-egress choice. The pull-mode epoch tools
-  (`trace-window`, `watch-epochs`) and the snapshot tool feed their
-  trace / epoch slices through `strip-sensitive` / `scrub-snapshot`; a
-  miss here ships a declared-sensitive event off-box.
-
-  rf2-6wvh5/j90sb/f1ose were exactly this leak class at the egress seam.
-
-  ## Two complementary egress checks
-
-  1. **`strip-sensitive`** - the trace-event vector filter. With
-     `--allow-sensitive-reads` disabled (`include? false`), every
-     `:sensitive?`-stamped event (including the fail-closed malformed-truthy
-     variants per rf2-ih7g4) MUST be removed.
-  2. **`scrub-snapshot`** - the per-frame snapshot walker. With
-     `--allow-sensitive-reads` disabled, no sensitive event may survive in
-     any frame's `:traces` / `:epochs` slice, at any frame-map shape.
-
-  ## Why property-style
-
-  The pin-and-assert tests cover a fixed event list. This tier GENERATES
-  event vectors that interleave sensitive / non-sensitive / malformed-
-  stamp events at arbitrary positions and counts, and snapshot maps with
-  arbitrary frame counts + arbitrary sensitive/clean mixes - then asserts
-  the SENTINEL-bearing sensitive events never survive the
-  allow-sensitive-disabled egress.
-  A hostile corpus pins the fail-closed malformed-stamp variants
-  (string `\"true\"`, keyword, number, non-empty coll) that the rf2-ih7g4
-  fail-CLOSED posture must drop.
-
-  ## Net property (verify-by-revert)
-
-  Reverting `sensitive-event?` to match only the literal `true`
-  (the pre-rf2-ih7g4 fail-OPEN check) makes the malformed-stamp property
-  go RED - a `:sensitive? \"true\"` event survives the
-  allow-sensitive-disabled egress.
-  Reverting the `scrub-snapshot` `:traces`/`:epochs` scrub makes the
-  snapshot property go RED. Confirmed by temporary local revert + restore
-  (see PR Quality gates)."
+  With sensitive reads disabled, `strip-sensitive` removes every trace event
+  carrying a truthy `:sensitive?` stamp and `scrub-snapshot` applies that rule
+  to each frame's trace and epoch slices. Truthy non-boolean stamps are treated
+  as sensitive because malformed metadata must fail closed. Enabling sensitive
+  reads is the operator's explicit raw-egress opt-in."
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test :refer-macros [deftest is testing]])
             [re-frame.mcp-base.sensitive :as sens]
             [re-frame.security.gen :as gen]))
 
-;; ---------------------------------------------------------------------------
-;; Expected-warning quieting (rf2-80jyfk → rf2-nrk066)
-;; ---------------------------------------------------------------------------
-;;
-;; These property tests INTENTIONALLY drive thousands of malformed
+;; These property tests intentionally drive thousands of malformed
 ;; `:sensitive?` stamps through `sens/strip-sensitive` / `scrub-snapshot` /
-;; `sensitive-event?` (the rf2-ih7g4 fail-closed corpus). Each malformed
-;; stamp fires `re-frame.mcp-base.sensitive`'s contract-drift warning to
-;; stderr (JVM `*err*`) / `console.warn` (CLJS).
-;;
-;; Quieting these EXPECTED warnings on a green run is now the SHARED
-;; responsibility of the quiet runners on BOTH runtimes, so this namespace
-;; needs NO local `*err*` sink (rf2-nrk066): the CLJS node runner buffers
-;; `console.warn` and the JVM runner (`re-frame.test-quiet.runner`) buffers
-;; `*err*`/`System/err` into a bounded ring, dropping it on green and
-;; replaying it only on red. Pre-rf2-nrk066 the JVM runner had no central
-;; stderr handling, so this suite wrapped its whole run in a private `*err*`
-;; sink (the rf2-80jyfk workaround) — that ad-hoc sink is removed now that
-;; the runner owns the policy symmetrically.
-;;
-;; The warning's having FIRED is still asserted structurally — the
-;; `malformed-count` counter is the framework's observability hook, pinned by
-;; `allow-sensitive-disabled-malformed-stamp-counts-as-dropped` — so the
-;; fail-closed log path
-;; stays exercised + verified. A RED run keeps these diagnostics (the runner
-;; replays the buffer), and clojure.test routes FAIL/ERROR/summary output
-;; through `*test-out*` (the real `*out*`), so failure reporting is untouched.
+;; `sensitive-event?`. The quiet JVM and CLJS runners buffer the expected
+;; contract-drift warnings and replay them on failure. The malformed counter
+;; below independently proves that the warning path ran.
 
 (def ^:private sentinel "S3CR3T-rf2-3cfvt-EGRESS-DO-NOT-SHIP")
 
 (defn- contains-sentinel?
-  "Deep-walk `x`; true when the sentinel string appears ANYWHERE — as a
-  value, inside a collection, in a secondary slot (`:tags :received`), or
-  inside a stringified form. Thin wrapper over the shared
-  `gen/contains-string?` (rf2-n5bkm7).
-
-  Why a deep scan and not just `:tags :value` + `sensitive-event?`
-  (rf2-h2yvs finding 1): the allow-sensitive-disabled contract is \"the
-  sentinel never survives,\" not merely \"no survivor is still classified
-  sensitive in its
-  primary slot.\" The generated sensitive event also plants the sentinel in
-  `:tags :received`; a survivor with its `:sensitive?` stamp stripped (so it
-  no longer classifies sensitive) and the sentinel only in `:received` would
-  slip past the narrow checks while this property stayed green. A deep scan
-  catches that secondary-slot leak class. The sentinel is matched as an EXACT
-  string leaf (`exact? true`); the shared `pr-str` fallback still substring-
-  scans the stringified form."
+  "True when the sentinel survives anywhere in `x`, including secondary or
+  stringified slots. The exact-leaf match prevents unrelated substrings from
+  satisfying the check."
   [x]
   (gen/contains-string? x sentinel true))
-
-;; ---------------------------------------------------------------------------
-;; Event generators.
-;; ---------------------------------------------------------------------------
 
 (def ^:private gen-clean-event
   "A non-sensitive trace event - no :sensitive? stamp (or explicit false)."
@@ -133,7 +49,7 @@
     (gen/gen-elem [:event/run-start :sub/recompute :fx/run])))
 
 (def ^:private malformed-stamps
-  ;; rf2-ih7g4 fail-CLOSED: any truthy non-boolean stamp must DROP.
+  ;; Truthy non-booleans indicate contract drift and fail closed.
   ["true" :yes 1 [:non-empty] {:a 1} "1"])
 
 (def ^:private gen-malformed-sensitive-event
@@ -154,14 +70,8 @@
   "A vector of 0..12 mixed events."
   (gen/gen-vec (gen/gen-int 0 13) gen-event))
 
-;; ---------------------------------------------------------------------------
-;; PROPERTY 1 - allow-sensitive-reads DISABLED: strip-sensitive removes every
-;; sensitive + malformed-stamp event; the sentinel never survives.
-;; ---------------------------------------------------------------------------
-
 (deftest allow-sensitive-disabled-strips-every-sensitive-event
-  (testing "rf2-6wvh5 - with include? false (--allow-sensitive-reads disabled,
-            the restrictive default), strip-sensitive drops every
+  (testing "with sensitive reads disabled, strip-sensitive drops every
             :sensitive?-stamped (and malformed-truthy) event across 400
             generated mixed event vectors; the sentinel never survives"
     (let [result (gen/for-all
@@ -169,13 +79,8 @@
                    (fn [events]
                      (sens/reset-malformed-count!)
                      (let [[kept _dropped] (sens/strip-sensitive events false)]
-                       ;; Deep-scan EVERY kept event for the sentinel in ANY
-                       ;; slot (`:tags :value` AND the secondary `:tags
-                       ;; :received` slot) — the contract is "the sentinel
-                       ;; never survives," not "no primary-slot survivor is
-                       ;; still classified sensitive" (rf2-h2yvs finding 1).
-                       ;; The `not-any? sensitive-event?` check is retained as
-                       ;; the complementary classification assertion.
+                       ;; Check both content and classification: stripping a
+                       ;; stamp alone must not hide a secondary-slot leak.
                        (and (not-any? contains-sentinel? kept)
                             (not-any? sens/sensitive-event? kept)))))]
       (is (nil? result)
@@ -183,55 +88,34 @@
                (pr-str (when result (dissoc result :threw))))))))
 
 (deftest deep-scan-catches-secondary-slot-sentinel-survivor
-  (testing "rf2-h2yvs finding 1 (non-vacuity) — a SURVIVING non-sensitive
-            event that nonetheless carries the sentinel in the SECONDARY
-            `:tags :received` slot is caught by the deep `contains-sentinel?`
-            scan, even though it is NOT classified sensitive and has no
-            sentinel in `:tags :value`. This is the leak class the prior
-            (`:tags :value` + `sensitive-event?`) assertion missed; the
-            negative fixture proves the hardened assertion is non-vacuous."
-    ;; Construct the exact survivor: no :sensitive? stamp (so strip-sensitive
-    ;; KEEPS it), sentinel ONLY in :tags :received (not :value).
+  (testing "the deep scan catches a sentinel in :tags :received even when the
+            surviving event is not classified sensitive"
     (let [survivor       {:operation :sub/recompute
                           :tags {:value "public-data"
                                  :received [sentinel]}}
           [kept dropped] (sens/strip-sensitive [survivor] false)]
-      ;; strip-sensitive keeps it (it is not classified sensitive) ...
       (is (= [survivor] kept))
       (is (zero? dropped))
-      ;; ... so the OLD narrow checks would BOTH read clean (vacuous green):
       (is (not-any? #(= sentinel (-> % :tags :value)) kept)
-          "old `:tags :value` check is blind to the :received slot")
+          "a primary-slot check is blind to :received")
       (is (not-any? sens/sensitive-event? kept)
-          "old classification check is blind: the survivor is non-sensitive")
-      ;; ... but the NEW deep scan catches the secondary-slot leak:
+          "classification alone is blind because the survivor is not stamped")
       (is (some contains-sentinel? kept)
-          "the deep scan MUST catch the sentinel hiding in :tags :received")
+          "the deep scan catches the sentinel in :tags :received")
       (is (contains-sentinel? survivor)))))
 
 (deftest allow-sensitive-disabled-malformed-stamp-counts-as-dropped
-  (testing "rf2-ih7g4 fail-closed - a malformed truthy stamp is dropped AND
-            bumps the observability counter (not silently passed)"
+  (testing "a malformed truthy stamp is dropped and increments the
+            observability counter exactly once"
     (doseq [stamp malformed-stamps]
       (sens/reset-malformed-count!)
       (let [ev {:operation :x :sensitive? stamp :tags {:value sentinel}}
             [kept dropped] (sens/strip-sensitive [ev] false)]
         (is (= [] kept) (str "malformed stamp " (pr-str stamp) " was NOT dropped"))
         (is (= 1 dropped))
-        ;; rf2-el9sw: `strip-sensitive` now classifies each event EXACTLY
-        ;; ONCE (single-pass), so the malformed counter is a faithful
-        ;; per-event metric. (Pre-fix it ran `sensitive-event?` twice —
-        ;; `some` pre-scan + `filterv` drop-scan — so one event bumped the
-        ;; counter ~2×; the assertion then could only check `(pos? ...)`.)
         (is (= 1 (sens/malformed-count))
             (str "malformed stamp " (pr-str stamp)
                  " must bump the counter exactly once per event"))))))
-
-;; ---------------------------------------------------------------------------
-;; PROPERTY 2 - allow-sensitive-reads ENABLED (opt-in): include? true ships
-;; everything verbatim (the operator's deliberate raw-egress choice). Confirms
-;; the opt-in is the single control point - not an unconditional scrub.
-;; ---------------------------------------------------------------------------
 
 (deftest allow-sensitive-enabled-opt-in-passes-through-verbatim
   (testing "with include? true (operator opted in via --allow-sensitive-reads),
@@ -242,12 +126,6 @@
                      (let [[kept dropped] (sens/strip-sensitive events true)]
                        (and (= events kept) (zero? dropped)))))]
       (is (nil? result) (str "opt-in egress altered the events: " (pr-str result))))))
-
-;; ---------------------------------------------------------------------------
-;; Snapshot generators + PROPERTY 3 - scrub-snapshot leaves no sensitive
-;; event in any frame's :traces / :epochs slice with --allow-sensitive-reads
-;; disabled.
-;; ---------------------------------------------------------------------------
 
 (def ^:private gen-frame
   "A per-frame snapshot map with mixed-sensitivity :traces + :epochs slices
@@ -271,17 +149,9 @@
           [acc rng])))))
 
 (defn- snapshot-leaks-sentinel?
-  "True when any frame's scrubbed :traces / :epochs slice still carries the
-  sentinel ANYWHERE (deep scan), or still carries an event classified
-  sensitive. Deep-scans ONLY the `:traces` / `:epochs` slices — `:app-db` is
-  left alone by design (read-time scrubbing is trace/epoch-only), so a deep
-  scan of the whole frame map would over-reach into the deliberately-kept
-  app-db.
-
-  rf2-h2yvs finding 1: the prior helper only re-ran `sensitive-event?` over
-  the slices, so a survivor whose `:sensitive?` stamp was stripped but whose
-  `:tags :received` still carried the sentinel would read as clean. The deep
-  `contains-sentinel?` scan closes that secondary-slot gap."
+  "True when a frame's scrubbed trace or epoch slices still contain the
+  sentinel or an event classified sensitive. `:app-db` is deliberately outside
+  this low-level trace/epoch scrub."
   [scrubbed]
   (some (fn [[_frame fm]]
           (when (map? fm)
@@ -291,8 +161,8 @@
         scrubbed))
 
 (deftest allow-sensitive-disabled-scrub-snapshot-leaves-no-sensitive-event
-  (testing "rf2-6wvh5 - with include? false (--allow-sensitive-reads disabled),
-            scrub-snapshot strips sensitive events from EVERY frame's
+  (testing "with sensitive reads disabled, scrub-snapshot strips sensitive
+            events from every frame's
             :traces/:epochs across 300 generated multi-frame snapshots;
             :app-db is left untouched"
     (let [result (gen/for-all
@@ -311,15 +181,10 @@
                (pr-str (when result (dissoc result :threw))))))))
 
 (deftest snapshot-deep-scan-catches-secondary-slot-survivor
-  (testing "rf2-h2yvs finding 1 (non-vacuity, snapshot path) — a frame whose
-            scrubbed `:traces` carries a NON-sensitive event with the sentinel
-            in `:tags :received` is flagged by the hardened
-            `snapshot-leaks-sentinel?` deep scan, while `:app-db` (which carries
-            no sentinel) is left alone by design."
+  (testing "the snapshot deep scan catches a non-sensitive trace carrying the
+            sentinel in :tags :received without inspecting :app-db"
     (let [survivor   {:operation :sub/recompute
                       :tags {:value "public-data" :received [sentinel]}}
-          ;; Model a post-scrub snapshot where a secondary-slot survivor
-          ;; remained in a frame slice (the leak class the old check missed).
           leaked     {:frame-0 {:traces [survivor]
                                 :epochs []
                                 :app-db {:public "kept"}}}
@@ -327,23 +192,15 @@
                                           :tags {:value "public-data"}}]
                                 :epochs []
                                 :app-db {:public "kept"}}}]
-      ;; The old check (sensitive-event? over the slices) is blind here —
-      ;; the survivor is non-sensitive — so it would read this as clean.
       (is (not (some sens/sensitive-event? (-> leaked :frame-0 :traces)))
-          "old classification check is blind: the survivor is non-sensitive")
-      ;; The hardened deep scan flags the secondary-slot leak ...
+          "classification alone is blind because the survivor is not stamped")
       (is (snapshot-leaks-sentinel? leaked)
-          "deep scan MUST flag the sentinel hiding in a frame's :tags :received")
-      ;; ... and does NOT false-positive on a genuinely clean snapshot.
+          "deep scan flags the sentinel in a frame's :tags :received")
       (is (not (snapshot-leaks-sentinel? clean))
           "deep scan must not flag a sentinel-free snapshot"))))
 
-;; ---------------------------------------------------------------------------
-;; HOSTILE CORPUS - the named fail-closed stamp variants, pinned.
-;; ---------------------------------------------------------------------------
-
 (deftest malformed-stamp-corpus-fail-closed
-  (testing "rf2-ih7g4 - each named truthy non-boolean stamp drops (fail-CLOSED)"
+  (testing "each truthy non-boolean stamp classifies as sensitive"
     (doseq [stamp malformed-stamps]
       (is (true? (sens/sensitive-event? {:sensitive? stamp}))
           (str "stamp " (pr-str stamp) " must classify as sensitive (drop)")))

--- a/implementation/security/test/re_frame/security/public_profile_projection_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/public_profile_projection_security_cljs_test.cljc
@@ -1,66 +1,21 @@
 (ns re-frame.security.public-profile-projection-security-cljs-test
-  "Security tier — EP-0015 PUBLIC egress projection model (the rf2-3cfvt
-  adversarial regime, applied to the graduated public projection surface).
+  "Adversarial tests for the public egress projection boundary.
 
-  ## Why this surface
+  `project-egress` applies a frame's durable path classifications to direct
+  reads and record values. Redacted profiles replace sensitive leaves and
+  structurally elide large leaves; sensitive classification wins when both
+  apply. Missing or unknown frame policy fails closed unless the caller uses
+  the explicit trusted-local raw opt-in.
 
-  The sibling `mcp-egress-security` namespace exercises the LOW-LEVEL mark /
-  elision PLUMBING (`re-frame.mcp-base.sensitive/strip-sensitive` +
-  `scrub-snapshot`) — the trace-event drop filter and the per-frame snapshot
-  walker. Those are necessary but NOT the EP-0015 public egress model: an
-  MCP / direct-read / tool snapshot that ships RAW frame-owned app-db data
-  would still pass the `strip-sensitive` gate (it only drops top-level
-  `:sensitive?`-stamped trace EVENTS) and the `scrub-snapshot` walker (which
-  leaves `:app-db` verbatim BY DESIGN — read-time scrubbing is trace/epoch-
-  only). The full off-box boundary is `re-frame.core/project-egress`
-  (EP-0015 §10/§11) over a frame's `reg-frame` durable classification
-  (EP-0015 §3). Without a security-tier guard on THAT surface, the tier can
-  stay green while a tool / direct read leaks raw owner-local data through
-  the projected boundary.
-
-  ## What this drives (the PUBLIC EP-0015 surfaces)
-
-    - `reg-frame` `:sensitive`/`:large` `{:app-db …}` durable frame policy
-      (EP-0015 §3 — frame-owned, NOT schema-declared live-value redaction);
-    - `re-frame.core/project-egress` under the off-box-tool / off-box-
-      observability / local-redacted profiles (the AI-tool + hosted-
-      monitoring + on-box-redacted boundaries) — sensitive → `:rf/redacted`,
-      large → a structural marker, unmarked siblings pass;
-    - FAIL-CLOSED: a no-frame / unknown-frame egress redacts the WHOLE value
-      (no `:rf/default` synthesis), the deliberate `:rf.size/include-
-      sensitive? true` opt-out being the single control point;
-    - large elision + the install-time sensitive-WINS-over-large rule (a
-      both-marked path redacts, never large-elides — so no path / byte size /
-      digest can leak);
-    - the SNAPSHOT boundary: alongside the low-level `scrub-snapshot`
-      `:app-db`-stays-raw plumbing assertion, a HIGHER-LEVEL test that
-      `project-egress` of the same snapshot's `:app-db` DOES redact — so the
-      security tier cannot false-green the full boundary on the back of the
-      intentionally-narrow plumbing helper.
-
-  ## Threat model
-
-  AI/MCP boundary + logs ONLY (the rf2-3cfvt / rf2-o69h5 / rf2-zsm03 scope).
-  The redaction boundary anchored here is the off-box `project-egress` site
-  over frame-owned classification. Human-facing on-box egress is out of scope.
-
-  ## Net property (verify-by-revert)
-
-  Reverting the commit-plane classification write (so the durable
-  `:source :effect` sensitive declarations are no longer installed) makes the
-  framed projection tests go RED — `project-egress` ships the sensitive leaf
-  raw. Reverting the walker's sensitive-wins-over-large ordering makes
-  `sensitive-wins-over-large-at-projection` go RED (a large marker, leaking
-  path/size/digest, surfaces for a sensitive path). Confirmed by temporary
-  local revert + restore (see PR Quality gates)."
+  This boundary is distinct from MCP trace plumbing: `strip-sensitive` drops
+  stamped trace events and `scrub-snapshot` walks trace and epoch slices, but
+  neither projects snapshot `:app-db` values."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core :as rf]
             [re-frame.elision :as elision]
             [re-frame.frame :as frame]
-            ;; The low-level plumbing helper, exercised ONLY in the labelled
-            ;; narrow plumbing test below — NOT as a stand-in for the public
-            ;; EP-0015 boundary.
+            ;; Used only to contrast trace plumbing with public projection.
             [re-frame.mcp-base.sensitive :as sens]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as ts]
@@ -73,10 +28,7 @@
 (def ^:private sentinel "S3CR3T-rf2-3cfvt-PUBLIC-PROFILE-DO-NOT-SHIP")
 
 (defn- contains-sentinel?
-  "Deep-walk `x`; true when the sentinel appears ANYWHERE (value, nested,
-  stringified). The contract is \"the sentinel never survives the boundary.\"
-  Thin wrapper over the shared `gen/contains-string?` (rf2-n5bkm7); the
-  sentinel is matched as an EXACT string leaf (`exact? true`)."
+  "True when the exact sentinel survives anywhere in `x`."
   [x]
   (gen/contains-string? x sentinel true))
 
@@ -84,8 +36,7 @@
 
 (defn- mk-frame! [frame-id]
   (rf/reg-frame frame-id {})
-  ;; EP-0025: durable app-db classification rides the commit-plane effect
-  ;; path (:source :effect) — no longer a frame annotation.
+  ;; Install the durable app-db classification through the commit-plane path.
   (frame/swap-runtime-db! frame-id
     (fn [rt] (elision/apply-classification-effects rt
                {:sensitive [[:auth :token]]
@@ -96,16 +47,10 @@
    :docs   {:blob big-string}
    :public {:count 3}})
 
-;; ---------------------------------------------------------------------------
-;; PROPERTY 1 — the public off-box profiles redact frame-owned sensitive app-db
-;; data and elide frame-owned large app-db data. THIS is the EP-0015 boundary,
-;; over reg-frame durable classification, NOT a low-level mark helper.
-;; ---------------------------------------------------------------------------
-
 (deftest off-box-profiles-redact-frame-owned-app-db
   (testing "project-egress under each off-box / redacted profile redacts the
             reg-frame :sensitive :app-db leaf and elides the :large :app-db
-            leaf — frame-owned durable classification, EP-0015 §3 + §10"
+            leaf under frame-owned durable classification"
     (mk-frame! :pub/offbox)
     (doseq [profile [:rf.egress/off-box-tool
                      :rf.egress/off-box-observability
@@ -130,15 +75,9 @@
       (is (= sentinel (get-in out [:auth :token])) "trusted-local sees sensitive")
       (is (= big-string (get-in out [:docs :blob])) "trusted-local sees large raw"))))
 
-;; ---------------------------------------------------------------------------
-;; PROPERTY 2 — FAIL-CLOSED. No frame and unknown/destroyed frame both redact
-;; the WHOLE value (no :rf/default synthesis, no borrowing another frame's
-;; policy). The deliberate include-sensitive? opt-out is the single control.
-;; ---------------------------------------------------------------------------
-
 (deftest no-frame-egress-fails-closed
   (testing "project-egress with no live frame redacts the whole value — no
-            :rf/default synthesis (EP-0002 / Spec 015 §Direct reads)"
+            :rf/default synthesis"
     ;; Rebind the ambient frame AWAY so the egress is genuinely frameless.
     (binding [frame/*current-frame* nil]
       (let [out (rf/project-egress (app-db-value)
@@ -155,7 +94,7 @@
 (deftest unknown-frame-egress-fails-closed
   (testing "project-egress naming an UNREGISTERED frame fails closed — an
             unresolvable frame's empty registry must NOT fall through to a
-            permissive identity walk (EP-0015 issue 1, rf2-t55hxg.18)"
+            permissive identity walk"
     ;; :pub/never-registered is never reg-frame'd — its registry is unreachable.
     (binding [frame/*current-frame* nil]
       (let [out (rf/project-egress (app-db-value)
@@ -164,12 +103,6 @@
         (is (gen/redacted? out)
             "an unknown / destroyed frame fails closed, identically to frameless")
         (is (not (contains-sentinel? out)))))))
-
-;; ---------------------------------------------------------------------------
-;; PROPERTY 3 — large elision + sensitive-WINS-over-large. A both-marked path
-;; redacts (never large-elides), so no path / byte-size / digest / handle can
-;; leak for a sensitive path (EP-0015 §3, install-time complement).
-;; ---------------------------------------------------------------------------
 
 (deftest large-app-db-elides-to-structural-marker
   (testing "a classified :large :app-db leaf elides to a structural marker —
@@ -198,12 +131,6 @@
       (is (not (gen/large-marker? (:secret out)))
           "NO large marker — no path/size/digest can leak for a sensitive path"))))
 
-;; ---------------------------------------------------------------------------
-;; PROPERTY 4 (generated) — across frames classifying a RANDOM app-db path
-;; sensitive, project-egress under an off-box profile never ships the sentinel
-;; planted at that path.
-;; ---------------------------------------------------------------------------
-
 (def ^:private gen-path
   "A 1..3-segment keyword app-db path."
   (gen/gen-vec (gen/gen-int 1 4)
@@ -218,12 +145,8 @@
                      (let [path  (vec path)
                            fid   :pub/gen
                            value (assoc-in {} path sentinel)]
-                       ;; EP-0025: classify this draw's sensitive path via the
-                       ;; commit-plane effect path. Each draw reuses :pub/gen,
-                       ;; so clear the prior draw's declarations (dissoc the
-                       ;; elision slot) before applying — the effect APPENDS, so
-                       ;; a fresh slot per draw preserves the original
-                       ;; re-registration-REPLACES semantics.
+                        ;; Each draw reuses the frame, so clear the append-only
+                        ;; classification slot before installing the new path.
                        (rf/reg-frame fid {})
                        (frame/swap-runtime-db! fid
                          (fn [rt]
@@ -238,24 +161,15 @@
           (str "a declared-sensitive path leaked the sentinel: "
                (pr-str (when result (dissoc result :threw))))))))
 
-;; ---------------------------------------------------------------------------
-;; PROPERTY 5 — the SNAPSHOT boundary, BOTH layers. The low-level plumbing
-;; (scrub-snapshot) leaves :app-db raw BY DESIGN; the PUBLIC EP-0015 boundary
-;; (project-egress) over the SAME app-db DOES redact. Asserting both alongside
-;; each other means the security tier cannot false-green the full boundary on
-;; the back of the intentionally-narrow plumbing helper.
-;; ---------------------------------------------------------------------------
-
 (deftest snapshot-app-db-plumbing-vs-public-boundary
   (testing "scrub-snapshot leaves :app-db raw (narrow plumbing) BUT
             project-egress of that :app-db redacts under the frame policy
-            (the public EP-0015 boundary) — the tier guards the full boundary"
+            at the public boundary"
     (mk-frame! :pub/snap)
     (let [snapshot {:pub/snap {:traces []
                                :epochs []
                                :app-db (app-db-value)}}
-          ;; (a) NARROW PLUMBING — scrub-snapshot is a trace/epoch-only walker;
-          ;; it intentionally leaves :app-db verbatim (NOT the public boundary).
+          ;; scrub-snapshot is a trace/epoch-only walker.
           [scrubbed _dropped] (sens/scrub-snapshot snapshot false)
           raw-app-db (get-in scrubbed [:pub/snap :app-db])]
       (is (= sentinel (get-in raw-app-db [:auth :token]))
@@ -263,8 +177,7 @@
       (is (contains-sentinel? raw-app-db)
           "PLUMBING: the snapshot :app-db still carries the sentinel — this is
            NOT the public egress boundary")
-      ;; (b) PUBLIC BOUNDARY — the tool/direct-read MUST run project-egress on
-      ;; the :app-db before it crosses off-box. That DOES redact.
+      ;; Tool and direct-read consumers project :app-db before off-box egress.
       (let [projected (rf/project-egress raw-app-db
                         {:frame :pub/snap
                          :rf.egress/profile :rf.egress/off-box-tool})]
@@ -275,25 +188,17 @@
         (is (not (contains-sentinel? projected))
             "PUBLIC: no sentinel crosses the projected boundary")))))
 
-;; ---------------------------------------------------------------------------
-;; NARROW PLUMBING TEST (labelled) — the low-level mark / strip helpers are
-;; NOT the EP-0015 public boundary; they remain pinned only as plumbing.
-;; ---------------------------------------------------------------------------
-
 (deftest narrow-plumbing-strip-sensitive-is-trace-event-only
   (testing "PLUMBING ONLY — strip-sensitive drops top-level :sensitive?-stamped
             trace EVENTS, but it is NOT the durable app-db egress boundary: a
             raw app-db-shaped map with no :sensitive? stamp passes UNTOUCHED.
-            (Durable app-db egress is frame-owned project-egress, above.)"
-    ;; A top-level :sensitive?-stamped trace event drops (the gate's job).
+            Durable app-db egress uses frame-owned project-egress."
     (let [[kept dropped] (sens/strip-sensitive
                            [{:operation :x :sensitive? true :tags {:value sentinel}}]
                            false)]
       (is (= [] kept) "PLUMBING: a stamped trace event is dropped")
       (is (= 1 dropped)))
-    ;; But an app-db-shaped map WITHOUT a :sensitive? stamp is NOT a trace
-    ;; event the gate classifies — it passes through raw. This is precisely
-    ;; why the public boundary (project-egress, frame-owned) is the real guard.
+    ;; An unstamped app-db-shaped map is not a trace event the filter can classify.
     (let [raw {:auth {:token sentinel}}
           [kept _dropped] (sens/strip-sensitive [raw] false)]
       (is (= [raw] kept)

--- a/implementation/security/test/re_frame/security/reply_envelope_egress_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/reply_envelope_egress_security_cljs_test.cljc
@@ -1,66 +1,19 @@
 (ns re-frame.security.reply-envelope-egress-security-cljs-test
-  "Security tier — EP-0011 managed-async reply-envelope egress + redaction
-  (the rf2-3cfvt adversarial regime, applied to the uniform reply envelope).
+  "Adversarial tests for managed-async reply egress.
 
-  ## The boundary
+  `trace-summary` projects the wire-bearing `:value`, `:error`, `:correlation`,
+  and `:meta` slots through the shared elision walker before AI/MCP or log
+  egress. Structural reply facts remain available for correlation.
 
-  Every managed *async* family (HTTP, resources / mutations, machine async
-  work, route loaders, and future managed timer / background-job surfaces)
-  lowers its completion onto the SHARED reply substrate
-  (`re-frame.reply`, Managed-Effects §The uniform reply envelope). A reply
-  map can carry decoded user values (`:value`), structured family errors
-  (`:error`), correlation / request metadata (`:correlation` / `:meta`),
-  cancellation / staleness reasons, and durable causal completion
-  timestamps. Property 9 of Managed-Effects requires the reply substrate to:
-
-    - emit trace rows FROM the reply-envelope facts (`trace-summary`), with
-      every WIRE-BEARING slot (`:value` / `:error` / `:correlation` /
-      `:meta`) routed through the shared `re-frame.elision/elide-wire-value`
-      walker — never a family-private elider — so `:sensitive?` / `:large?`
-      compose uniformly with the rest of the trace stream;
-    - keep the CLOSED status taxonomy (`:ok` / `:partial` / `:error` /
-      `:cancelled` / `:stale`) and the closed `:rf.reply/work-status` vocabulary;
-    - suppress STALE app deliveries by default (the correctness boundary):
-      a superseded completion produces `:status :stale` WITHOUT dispatching
-      the app target and WITHOUT carrying `:value`;
-    - keep reply maps + durable targets DATA-ONLY: no host handle
-      (fn / Promise / AbortController / DOM node / Date / …) survives into
-      an egressed reply or a persisted target.
-
-  The pin-and-assert substrate suite (`re-frame.reply-test`) and the
-  cross-family vocab gate (`re-frame.reply-vocab-conformance-cljs-test`)
-  prove the SHAPES; this tier drives the SECURITY-egress properties — that
-  a sentinel-bearing reply value / error / correlation / meta never crosses
-  the AI-tool / log boundary raw, and the stale / data-only invariants hold
-  under a generated corpus.
-
-  ## Threat model
-
-  AI/MCP boundary + logs ONLY (the rf2-3cfvt / rf2-o69h5 / rf2-zsm03 scope).
-  The redaction boundary anchored here is the off-box trace egress site
-  (`trace-summary` → `elide-wire-value`) and the off-box record projection
-  (`project-egress`). Human-facing on-box egress is out of scope and not
-  gold-plated.
-
-  ## Net property (verify-by-revert)
-
-  - Reverting `trace-summary` to keep the wire slots verbatim (drop the
-    `elide-wire-value` route) makes `framed-trace-summary-elides-declared-slots`
-    and `frameless-trace-summary-fails-closed` go RED — the sentinel rides a
-    `:value` / `:error` / `:correlation` / `:meta` slot off-box.
-  - Reverting `suppress` to thread the natural `:value` / non-stale status
-    makes `stale-suppression-never-delivers-app-target-or-value` go RED.
-  - Reverting the `validate-reply` / `durable-target` host-handle walk makes
-    `host-handle-never-egresses-in-reply-or-target` go RED.
-  Confirmed by temporary local revert + restore (see PR Quality gates)."
+  The suite also pins two independent correctness boundaries: stale replies do
+  not deliver an app target or retain a value, and replies plus durable targets
+  contain data rather than host handles."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core :as rf]
             [re-frame.elision :as elision]
             [re-frame.frame :as frame]
-            ;; EP-0011 reply substrate (INTERNAL — no `re-frame.core` façade
-            ;; export; families consume these helpers directly to build the
-            ;; uniform envelope, so the security tier exercises them directly).
+            ;; Families use the internal reply substrate directly.
             [re-frame.reply :as reply]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as ts]
@@ -73,32 +26,16 @@
 (def ^:private sentinel "S3CR3T-rf2-3cfvt-REPLY-EGRESS-DO-NOT-SHIP")
 
 (defn- contains-sentinel?
-  "Deep-walk `x`; true when the sentinel string appears ANYWHERE — as a
-  value, inside a collection, nested in a secondary slot, or inside a
-  stringified form. The contract is \"the sentinel never survives,\" not
-  merely \"the primary slot reads clean.\" Thin wrapper over the shared
-  `gen/contains-string?` (rf2-n5bkm7); the sentinel is matched as an EXACT
-  string leaf (`exact? true`)."
+  "True when the exact sentinel survives anywhere in `x`."
   [x]
   (gen/contains-string? x sentinel true))
 
-;; ---------------------------------------------------------------------------
-;; A frame classifying the reply-VALUE-relative paths the wire slots carry.
-;;
 ;; `trace-summary` elides each wire slot rooted at its OWN value (not at the
-;; reply-map root), so the frame's declared `:sensitive` / `:large` :app-db
-;; paths are stated relative to the slot value. The same frame policy the
-;; durable app-db egress reads (EP-0015 §3) is the one the reply trace egress
-;; reads — one classification, one path-based walker — so the declarations
-;; must name where each secret sits WITHIN its slot value:
+;; reply-map root), so classification paths are relative to each slot value:
 ;;   :value slot value       {:token <secret> :doc <big>}        → [:token] / [:doc]
 ;;   :error slot value       {:kind … :detail {:token <secret>}} → [:detail :token]
 ;;   :correlation slot value {:partner-key <secret>}             → [:partner-key]
 ;;   :meta slot value        {:token <secret>}                   → [:token]
-;; (A re-keyed copy at a NON-declared slot path is the path-walker's known
-;; structural blind spot — `value-elide`'s value-based dual covers that case
-;; for derived trees; here the frame correctly declares each slot path.)
-;; ---------------------------------------------------------------------------
 
 (def ^:private big-string
   ;; > the 16384-byte default large floor so the marker is deterministic.
@@ -106,24 +43,17 @@
 
 (defn- mk-frame! [frame-id]
   (rf/reg-frame frame-id {})
-  ;; EP-0025: durable app-db classification rides the commit-plane effect
-  ;; path (:source :effect) — no longer a frame annotation.
+  ;; Install durable classification through the commit-plane path.
   (frame/swap-runtime-db! frame-id
     (fn [rt] (elision/apply-classification-effects rt
                {:sensitive [[:token] [:partner-key] [:detail :token]]
                 :large     [[:doc]]}))))
 
-;; ---------------------------------------------------------------------------
-;; PROPERTY 1 — framed trace egress: every wire-bearing slot routes through
-;; the shared walker; the declared sensitive leaf redacts, the declared large
-;; leaf elides, the framework identity facts ride verbatim.
-;; ---------------------------------------------------------------------------
-
 (deftest framed-trace-summary-elides-declared-slots
   (testing "trace-summary routes :value/:error/:correlation/:meta through the
             shared elide-wire-value walker under the frame's classification —
             declared-sensitive leaf → :rf/redacted, declared-large leaf →
-            marker, identity facts verbatim (Managed-Effects property 9)"
+            marker, and identity facts remain verbatim"
     (mk-frame! :reply/framed)
     (let [reply-map {:status       :partial
                      :value        {:token sentinel :doc big-string :public 7}
@@ -139,8 +69,6 @@
                 {:frame :reply/framed
                  :rf.size/include-sensitive? false
                  :rf.size/include-large?     false})]
-      ;; Wire-bearing slots: the declared-sensitive token leaf redacts,
-      ;; everywhere it surfaces (value / error / correlation / meta).
       (is (gen/redacted? (get-in out [:value :token])) ":value sensitive leaf redacted")
       (is (gen/large-marker? (get-in out [:value :doc])) ":value large leaf elided")
       (is (= 7 (get-in out [:value :public])) "unmarked sibling rides through")
@@ -148,13 +76,11 @@
       (is (gen/redacted? (get-in out [:correlation :partner-key])) ":correlation sensitive leaf redacted")
       (is (= "t-1" (get-in out [:correlation :trace-id])) "non-sensitive correlation fact rides")
       (is (gen/redacted? (get-in out [:meta :token])) ":meta sensitive leaf redacted")
-      ;; No sentinel survives ANY wire slot.
       (is (not (contains-sentinel? (:value out))))
       (is (not (contains-sentinel? (:error out))))
       (is (not (contains-sentinel? (:correlation out))))
       (is (not (contains-sentinel? (:meta out))))
-      ;; Identity / correlation FACTS ride verbatim (framework data, not wire
-      ;; data) — the trace summary must keep them for tool correlation.
+      ;; Framework identity facts remain available for tool correlation.
       (is (= :partial (:status out)))
       (is (= [:rf.work/http :article/by-id 1] (:work/id out)) "canonical :work/id verbatim")
       (is (= :failed (:rf.reply/work-status out)))
@@ -174,19 +100,11 @@
       (is (= (:value out) (elision/elide-wire-value value opts))
           ":value slot is exactly elide-wire-value under the resolved opts"))))
 
-;; ---------------------------------------------------------------------------
-;; PROPERTY 2 — frameless trace egress FAILS CLOSED: with no live frame and
-;; no opt-out, the shared walker redacts the WHOLE wire slot rather than
-;; borrow another frame's policy (EP-0002 / Spec 015 §Direct reads). The
-;; identity facts still ride verbatim (they are framework data, not walked).
-;; ---------------------------------------------------------------------------
-
 (deftest frameless-trace-summary-fails-closed
   (testing "a reply trace summary built with NO live frame redacts every
             wire-bearing slot to :rf/redacted (fail-closed; no :rf/default
             synthesis) — the sentinel never rides off-box"
-    ;; Rebind the ambient frame AWAY so the egress is genuinely frameless
-    ;; (the posture an off-box forwarder reading outside any frame scope sees).
+    ;; Remove ambient scope so no other frame's policy can be borrowed.
     (binding [frame/*current-frame* nil]
       (let [reply-map {:status      :error
                        :error       {:kind :rf.http/cors :detail sentinel}
@@ -195,29 +113,20 @@
                        :work/id     [:rf.work/http :y 2]
                        :rf.reply/work-status :failed}
             out (reply/trace-summary reply-map nil)]
-        ;; Every wire slot fails closed to the whole-value sentinel.
         (is (gen/redacted? (:error out)) ":error fails closed (whole slot redacted)")
         (is (gen/redacted? (:correlation out)) ":correlation fails closed")
         (is (gen/redacted? (:meta out)) ":meta fails closed")
         (is (not (contains-sentinel? out)) "no sentinel survives frameless egress")
-        ;; Identity facts still ride (framework data is not walked).
         (is (= :error (:status out)))
         (is (= [:rf.work/http :y 2] (:work/id out)))
         (is (= :failed (:rf.reply/work-status out))))
-      ;; The deliberate opt-out is the single control point: include-sensitive?
-      ;; true gets an identity walk against the empty no-frame policy.
+      ;; Explicit sensitive inclusion is the trusted-local opt-out.
       (let [out (reply/trace-summary {:status :ok :value {:token sentinel}
                                       :work/id [:rf.work/http :z 3]
                                       :rf.reply/work-status :completed}
                   {:rf.size/include-sensitive? true})]
         (is (= sentinel (get-in out [:value :token]))
             "explicit include-sensitive? true is the deliberate frameless opt-out")))))
-
-;; ---------------------------------------------------------------------------
-;; PROPERTY 3 (generated) — across a corpus of mixed-status reply maps, the
-;; framed trace egress NEVER ships the sentinel and ALWAYS preserves the
-;; closed status / work-status taxonomy.
-;; ---------------------------------------------------------------------------
 
 (def ^:private gen-status (gen/gen-elem (vec reply/statuses)))
 
@@ -271,21 +180,13 @@
           (str "a reply trace summary shipped the sentinel / left the closed "
                "taxonomy: " (pr-str (when result (dissoc result :threw))))))))
 
-;; ---------------------------------------------------------------------------
-;; PROPERTY 4 — stale suppression is the correctness boundary: a superseded
-;; completion produces :status :stale, does NOT deliver the app target, and
-;; carries NO :value (no app mutation). A natural success/error reply threaded
-;; as `extra` cannot smuggle a :value or a non-stale status through.
-;; ---------------------------------------------------------------------------
-
 (deftest stale-suppression-never-delivers-app-target-or-value
   (testing "suppress on a superseded completion yields :deliver? false,
             :status :stale, :rf.reply/work-status :suppressed, and STRIPS any :value —
             even when a natural success reply is threaded as `extra`"
     (let [carried {:work/id [:rf.work/http :a 1] :generation 1}
           current {:work/id [:rf.work/http :a 1] :generation 2}
-          ;; A caller accidentally threads a full natural success reply
-          ;; (carrying the secret :value) as `extra`.
+          ;; Model a caller threading a full natural success reply as `extra`.
           natural {:status :ok :value {:token sentinel}
                    :rf.reply/work-status :completed :work/id [:rf.work/http :a 1]
                    :rf.frame/id :reply/stale :completed-at 1781078400456}
@@ -296,14 +197,11 @@
       (is (= :suppressed (:rf.reply/work-status reply)) ":rf.reply/work-status forced to :suppressed")
       (is (not (contains? reply :value)) ":value is STRIPPED — no app mutation can ride")
       (is (not (contains-sentinel? reply)) "the secret value never rides the stale reply")
-      ;; Identity facts threaded via `extra` survive (work id / frame / time).
       (is (= [:rf.work/http :a 1] (:work/id reply)) "carried :work/id survives")
       (is (= :reply/stale (:rf.frame/id reply)))
       (is (= 1781078400456 (:completed-at reply)) "causal completion time survives")
-      ;; The stale reply itself validates against the shared contract.
       (is (reply/valid-reply? reply) "the suppression reply is contract-valid")
-      ;; The suppression trace joins carried + current correlation to the
-      ;; canonical :work/id without leaking the sentinel.
+      ;; Suppression traces retain correlation without carrying the value.
       (let [trace (:trace outcome)]
         (is (true? (:rf.reply/suppressed? trace)))
         (is (= carried (:rf.reply/carried trace)))
@@ -324,24 +222,16 @@
       (is (= :rf.error/reply-unauthorized-stale-delivery (:rf.error/id data))
           "an app target overreaching for stale delivery is rejected"))))
 
-;; ---------------------------------------------------------------------------
-;; PROPERTY 5 — data-only invariant: a host handle (fn / Promise /
-;; AbortController / DOM node / Date) never survives into an egressed reply
-;; or a persisted (durable) target. validate-reply flags it; durable-target
-;; fails loud.
-;; ---------------------------------------------------------------------------
-
 (deftest host-handle-never-egresses-in-reply-or-target
   (testing "validate-reply flags a host handle anywhere in the reply map, and
             durable-target fails loud on a handle in a persisted target"
-    ;; A fn is a host handle on BOTH runtimes (no host-specific object needed).
+    ;; A function is a host handle on both runtimes.
     (let [handle (fn [] :callback)
           reply-with-handle {:status :ok :value {:on-done handle}
                              :work/id [:rf.work/http :h 1] :rf.reply/work-status :completed}
           problems (reply/validate-reply reply-with-handle)]
       (is (some #(= :rf.reply/host-handle (:rf.reply/problem %)) problems)
           "validate-reply flags the host handle in the reply :value"))
-    ;; A durable target carrying a host handle in a PUBLIC field fails loud.
     (let [bad-target {:event [:app/on-reply (fn [] :smuggled)] :delivery :append}
           data (try (reply/durable-target bad-target)
                     nil
@@ -349,22 +239,14 @@
                       (ex-data e)))]
       (is (= :rf.error/reply-non-data-target (:rf.error/id data))
           "a host handle in a durable target's public field fails loud"))
-    ;; A clean data-only reply / target passes.
     (is (reply/valid-reply? {:status :ok :value {:public 1}
                              :work/id [:rf.work/http :h 2] :rf.reply/work-status :completed}))
     (is (reply/data-only-target? {:event [:app/on-reply] :delivery :append}))))
 
-;; ---------------------------------------------------------------------------
-;; PROPERTY 6 — the off-box record projection (project-egress) of a reply
-;; VALUE redacts the declared-sensitive leaf and elides the declared-large
-;; leaf under the frame's classification (the EP-0015 boundary primitive the
-;; reply-bearing observability records cross), and fails closed frameless.
-;; ---------------------------------------------------------------------------
-
 (deftest reply-value-projects-through-project-egress
   (testing "project-egress of a reply value under an off-box profile redacts
             the declared-sensitive leaf, elides large, and fails closed when
-            no frame is known (the EP-0015 reply-bearing-record boundary)"
+            no frame is known"
     (mk-frame! :reply/proj)
     (let [value {:token sentinel :doc big-string :public 7}
           out (rf/project-egress value

--- a/implementation/security/test/re_frame/security/ssr_escaping_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/ssr_escaping_security_cljs_test.cljc
@@ -1,59 +1,15 @@
 (ns re-frame.security.ssr-escaping-security-cljs-test
-  "Adversarial-property security tier - SSR static-markup escaping
-  boundary (rf2-3cfvt, surface 1; the rf2-1uex4 class).
+  "Adversarial tests for SSR static-markup escaping.
 
-  ## The boundary
+  Event-handler attributes are removed for every HTML-equivalent casing, and
+  attribute names containing grammar-breakout characters are rejected. Separate
+  generated corpora exercise canonical handlers caught by the allowlist and
+  non-canonical camelCase or kebab handlers caught only by the structural
+  matcher.
 
-  `re-frame.ssr.html-helpers/attr-string` is the single emit seam that
-  serialises a hiccup attribute map to wire HTML. Two MUSTs protect it:
-
-    1. **Event-handler props never reach the wire.** Any `on*` event-
-       handler attribute - across EVERY casing a case-insensitive HTML
-       parser fires (`onclick` / `ONCLICK` / `OnClick` / `onLoad` /
-       `on-click`) - MUST be stripped (`strip-prop?`  drop), never
-       serialised as a live `onX=` attribute. rf2-1uex4 was exactly
-       this: the matcher missed lowercase/uppercase canonical spellings,
-       so `:onclick` rode through as a live handler.
-
-    2. **Grammar-breakout attribute KEYS are rejected.** A key carrying
-       `=`, quotes, whitespace, `<`, `>`, or `/` (the chars that escape
-       attribute-name context to inject a sibling `onclick=` attribute)
-       MUST throw `:rf.error/ssr-invalid-attribute-name` at
-       `validate-attr-name!` - never silently serialise.
-
-  ## Why property-style
-
-  The pin-and-assert regime (rf2-ynjts) tested a fixed handful of casings
-  and MISSED the lowercase-canonical leak. This tier sweeps the casing
-  space generatively: a generator mints handler names by independently
-  case-folding each character of a canonical WHATWG handler name (plus
-  camelCase/kebab structural spellings), so hundreds of distinct casings
-  per run probe the matcher. A curated hostile corpus pins the named
-  payloads (the rf2-1uex4 lowercase set, grammar-breakout keys, the
-  `<script>`-body breakout) exactly.
-
-  ## Net property (verify-by-revert)
-
-  Two INDEPENDENT generative properties pin the two `event-handler-name?`
-  matcher arms so a revert of EITHER goes RED (each canonical handler is
-  also in the allowlist, so a canonical-casing sweep alone leaves the
-  regex vacuously covered — rf2-q0a81.1):
-
-    1. Reverting the `event-handler-allowlist` lower-case lookup makes
-       `no-recased-canonical-handler-serialises` go RED — the all-
-       lowercase / mixed-lowercase canonical spellings the regex's
-       `[A-Z]`/`-` discriminator CANNOT catch leak as live `onX=`
-       attributes.
-    2. Reverting (or weakening) the camelCase/kebab `event-handler-name-re`
-       makes `no-custom-structural-handler-serialises` go RED — the
-       NON-allowlist structural handlers (`onCustomEvent` / `on-foo-bar`,
-       recased across the `on` prefix) that ONLY the regex catches leak.
-       The canonical sweep never exercises this arm because every
-       canonical handler is in the allowlist.
-
-  Reverting `validate-attr-name!`'s grammar throw makes the breakout-key
-  test go RED. Confirmed by temporary local revert + restore (see PR
-  Quality gates)."
+  Script-body tests ensure HTML closing tags are neutralised. EDN script bodies
+  additionally preserve reader round trips: string-literal breakouts can be
+  escaped, while breakout precursors in token positions must fail loudly."
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test :refer-macros [deftest is testing]])
             #?(:clj  [clojure.edn :as edn]
@@ -63,21 +19,13 @@
             [re-frame.ssr.emit :as emit]
             [re-frame.security.gen :as gen]))
 
-;; ---------------------------------------------------------------------------
-;; Canonical WHATWG event-handler names browsers actually fire. A leak of
-;; ANY of these as a live attribute is an XSS vector.
-;; ---------------------------------------------------------------------------
-
 (def ^:private canonical-handlers
   ["onclick" "onload" "onerror" "onmouseover" "onmouseout" "onsubmit"
    "onfocus" "onblur" "onkeydown" "onkeyup" "onkeypress" "onchange"
    "oninput" "onwheel" "onscroll" "ondrag" "ondrop" "onpaste" "oncopy"
    "oncut" "onbeforeunload" "onunload" "onhashchange" "onpopstate"
    "onmessage" "onanimationstart" "ontransitionend" "onpointerdown"
-   ;; W3C Touch Events Level 2 §8 GlobalEventHandlers (rf2-cv165). The
-   ;; structural regex only catches the camelCase/kebab spellings, so the
-   ;; lower-case canonical touch names are caught by the allowlist alone —
-   ;; an XSS-equivalent gap of the same class as `:onclick`.
+   ;; Lower-case touch names rely on the allowlist, not the structural matcher.
    "ontouchstart" "ontouchmove" "ontouchend" "ontouchcancel"])
 
 (defn- live-handler-attr?
@@ -92,12 +40,6 @@
     (and (str/includes? s "=")
          (let [nm (str/lower-case (subs s 0 (str/index-of s "=")))]
            (str/starts-with? (str/trim nm) "on")))))
-
-;; ---------------------------------------------------------------------------
-;; Generator - independently case-fold each character of a canonical handler
-;; name, so a single canonical name explodes into 2^len casings. Also fold in
-;; the structural camelCase / kebab spellings.
-;; ---------------------------------------------------------------------------
 
 (defn- recase
   "Apply a per-character case mask `bits` (vector of 0/1) to `s`."
@@ -122,12 +64,8 @@
             [bits rng2] ((gen/gen-vec (count base) (gen/gen-elem [0 1])) rng1)]
         [[base bits] rng2]))))
 
-;; ---------------------------------------------------------------------------
-;; PROPERTY 1 - no recased canonical handler ever serialises as a live attr.
-;; ---------------------------------------------------------------------------
-
 (deftest no-recased-canonical-handler-serialises
-  (testing "rf2-1uex4 - across 600 randomly-recased canonical handler names,
+  (testing "across 600 randomly-recased canonical handler names,
             attr-string strips every one (empty output, no live on*= attr)"
     (let [result (gen/for-all
                    gen-handler-casing 600 1
@@ -140,18 +78,8 @@
           (str "a recased handler leaked as a live attribute: "
                (pr-str result))))))
 
-;; ---------------------------------------------------------------------------
-;; PROPERTY 1b - no NON-ALLOWLIST structural handler ever serialises as a live
-;; attr. This independently exercises `event-handler-name-re` (rf2-q0a81.1):
-;; PROPERTY 1's generator only mints recasings of CANONICAL handlers, and every
-;; canonical handler is in `event-handler-allowlist`, whose lookup lower-cases
-;; the candidate - so the allowlist arm alone strips all 600 draws there and a
-;; revert of the regex leaves PROPERTY 1 GREEN (vacuous w.r.t. the regex). The
-;; framework-shaped CUSTOM handlers below (`:onCustomEvent` / `:on-foo-bar`)
-;; are NOT in the allowlist; ONLY the camelCase/kebab regex strips them, so
-;; reverting/weakening `event-handler-name-re` makes THIS property go RED.
-;; ---------------------------------------------------------------------------
-
+;; Canonical names exercise the allowlist. These generated custom names are not
+;; in it, so they independently exercise the camelCase/kebab structural matcher.
 (def ^:private structural-tail-letters
   (vec "abcdefghijklmnopqrstuvwxyz"))
 
@@ -159,8 +87,8 @@
   "Recase ONLY the leading `on` (2 chars) per a 2-bit mask `[b0 b1]`; the rest
   of the name is kept verbatim so the regex's structural discriminator (the
   upper-case tail char for camelCase, the `-` for kebab) survives every draw.
-  This sweeps the `[Oo][Nn]` case-insensitivity of the prefix - exactly the
-  rf2-1uex4 casing axis - while keeping the name NON-canonical."
+  This sweeps the `[Oo][Nn]` case-insensitivity while keeping the name
+  non-canonical."
   [s [b0 b1]]
   (str (if (= 1 b0) (str/upper-case (subs s 0 1)) (str/lower-case (subs s 0 1)))
        (if (= 1 b1) (str/upper-case (subs s 1 2)) (str/lower-case (subs s 1 2)))
@@ -193,10 +121,9 @@
         [[form [pb0 pb1] tail] rng4]))))
 
 (deftest no-custom-structural-handler-serialises
-  (testing "rf2-q0a81.1 - across 600 NON-allowlist structural handler names
+  (testing "across 600 non-allowlist structural handler names
             (camelCase / kebab, recased prefix), attr-string strips every one
-            via event-handler-name-re alone - the allowlist cannot catch these.
-            Reverting/weakening the regex makes this go RED."
+            via event-handler-name-re alone"
     (let [result (gen/for-all
                    gen-custom-structural-handler 600 5
                    (fn [[k v]]
@@ -204,32 +131,23 @@
                        (and (= "" out)
                             (not (live-handler-attr? out))))))]
       (is (nil? result)
-          (str "a custom structural handler leaked as a live attribute "
-               "(event-handler-name-re regression): " (pr-str result))))))
-
-;; ---------------------------------------------------------------------------
-;; HOSTILE CORPUS - the exact rf2-1uex4 casings + structural spellings.
-;; Each MUST strip to "".
-;; ---------------------------------------------------------------------------
+          (str "a custom structural handler leaked as a live attribute: "
+               (pr-str result))))))
 
 (def ^:private hostile-handler-keys
-  ;; The rf2-1uex4 named misses: all-lowercase + ALL-UPPERCASE + Title-case
-  ;; canonical handlers, plus the camelCase / kebab structural spellings.
+  ;; Canonical casings plus camelCase and kebab structural spellings.
   [:onclick :ONCLICK :OnClick :onClick :oNcLiCk
    :onload :ONLOAD :OnLoad :onLoad
    :onerror :ONERROR :OnError
    :onmouseover :ONMOUSEOVER :OnMouseOver :onMouseOver
    :on-click :ON-CLICK :on-mouse-over :onCustomEvent :on-custom-event
    :onsubmit :ONSUBMIT :onfocus :onFocus :onkeydown :onKeyDown
-   ;; rf2-cv165 — the lower-case W3C Touch Events L2 GlobalEventHandlers.
-   ;; The structural regex CANNOT catch these (no upper-case tail char, no
-   ;; hyphen), so the allowlist must strip them; `:ontouchstart 'alert`
-   ;; previously rode through as a live ` ontouchstart="alert"` attribute.
+   ;; The structural matcher cannot catch these lower-case touch names.
    :ontouchstart :ontouchmove :ontouchend :ontouchcancel
    :ONTOUCHSTART :OnTouchStart :onTouchStart])
 
 (deftest hostile-handler-corpus-all-stripped
-  (testing "rf2-1uex4 corpus - every named hostile handler key strips to \"\""
+  (testing "every hostile handler key strips to an empty attribute string"
     (doseq [k hostile-handler-keys]
       (let [out (h/attr-string {k "javascript:alert(1)"})]
         (is (= "" out)
@@ -239,20 +157,15 @@
             (str "handler key " (pr-str k) " produced a live on*= attribute"))))))
 
 (deftest touch-handler-payload-never-reaches-wire-html
-  (testing "rf2-cv165 - rendering a hiccup element whose attrs splat a
-            lower-case W3C touch GlobalEventHandler key (the realistic
-            attacker-controlled-key path) MUST emit an element with NO live
-            on* attribute and NO trace of the JS payload. The structural
-            regex cannot catch these lower-case names; the allowlist must."
+  (testing "lower-case touch handler keys emit no live on* attribute and no
+            trace of the JavaScript payload"
     (doseq [k [:ontouchstart :ontouchmove :ontouchend :ontouchcancel]]
       (let [payload "alert(document.cookie)"
             html    (emit/emit-element [:div {k payload :id "ok"} "child"])]
-        ;; The element renders (id survives, child text emitted) ...
         (is (str/includes? html "id=\"ok\"")
             (str "the benign attr should survive for key " (pr-str k)))
         (is (str/includes? html "child")
             (str "the child text should survive for key " (pr-str k)))
-        ;; ... but the handler name and its JS payload are gone from the wire.
         (is (not (str/includes? (str/lower-case html) (name k)))
             (str "touch handler name " (pr-str k) " leaked into wire HTML: "
                  html))
@@ -267,10 +180,6 @@
       (let [out (h/attr-string {k "v"})]
         (is (str/includes? out (name k))
             (str "innocuous key " (pr-str k) " was wrongly stripped"))))))
-
-;; ---------------------------------------------------------------------------
-;; PROPERTY 2 - grammar-breakout attribute KEYS throw, never serialise.
-;; ---------------------------------------------------------------------------
 
 (def ^:private breakout-chars [\= \" \space \< \> \/ \tab \newline \'])
 
@@ -298,18 +207,14 @@
          (:rf.error/id (ex-data e))))))
 
 (deftest grammar-breakout-keys-throw
-  (testing "rf2-vl8ir - across 400 generated grammar-breakout keys,
+  (testing "across 400 generated grammar-breakout keys,
             attr-string throws :rf.error/ssr-invalid-attribute-name; never
             silently serialises a key that escapes attribute-name context"
     (let [result (gen/for-all
                    gen-breakout-key 400 7
                    (fn [k]
-                     ;; The key carries a non-handler prefix so strip-prop?
-                     ;; does not pre-empt the grammar gate - the breakout
-                     ;; char must trigger the throw. Use the RAW STRING as
-                     ;; the attr key (attr-string calls `(name k)`); routing
-                     ;; through `(keyword k)` would mangle the breakout `/`
-                     ;; into a keyword-namespace separator and hide it.
+                      ;; A raw string preserves `/`; keyword conversion would
+                      ;; reinterpret it as a namespace separator.
                      (throws-invalid-attr-name? {k "v"})))]
       (is (nil? result)
           (str "a grammar-breakout key did NOT throw (would serialise): "
@@ -325,11 +230,6 @@
       (is (throws-invalid-attr-name? {k "v"})
           (str "breakout key " (pr-str k) " did not throw")))))
 
-;; ---------------------------------------------------------------------------
-;; PROPERTY 3 - <script>-body breakout: escape-script-body-string must break
-;; every casing of the </script closing-tag the HTML tokenizer recognises.
-;; ---------------------------------------------------------------------------
-
 (def ^:private gen-script-breakout
   "Draws a hostile string embedding a randomly-recased `</script...>`
   payload that would prematurely close a <script> body."
@@ -342,15 +242,14 @@
         [[bits tail] rng2]))))
 
 (deftest script-body-breakout-neutralised
-  (testing "rf2-7ksyr/rf2-m5u23 - escape-script-body-string escapes EVERY `<`
+  (testing "escape-script-body-string escapes every `<`
             so no `</script` (any casing) survives in a script body; sweep
             500 recased closing-tag payloads"
     (let [result (gen/for-all
                    gen-script-breakout 500 3
                    (fn [payload]
                      (let [escaped (h/escape-script-body-string payload)]
-                       ;; No literal `<` may remain - `</script` in any casing
-                       ;; is impossible once every `<` becomes <.
+                        ;; Without a literal `<`, no closing tag can begin.
                        (and (not (str/includes? escaped "<"))
                             (str/includes? escaped "\\u003c")))))]
       (is (nil? result)
@@ -369,28 +268,11 @@
         (is (not (str/includes? out ">")) (str "raw > survived: " (pr-str out)))
         (is (not (str/includes? out "\"")) (str "raw \" survived: " (pr-str out)))))))
 
-;; ---------------------------------------------------------------------------
-;; PROPERTY 4 - EDN script-body breakout: escape-edn-script-body must break
-;; every `</script` (any casing) inside an EDN <script type="application/edn">
-;; body WITHOUT corrupting the document's readability. The naive whole-string
-;; `<`->`<` replacement (escape-script-body-string) is XSS-safe but
-;; CORRUPTS the EDN: `<` is only a valid reader escape INSIDE a string
-;; literal, so a keyword/symbol token carrying `<` (`:<`, `:a<b`) becomes the
-;; unreadable token `:<` / `:a<b` and the EDN reader throws -
-;; breaking hydration / silently dropping a streaming delta (rf2-rdxxa).
-;;
-;; The fix's two MUSTs:
-;;   (a) no literal `</script` (any casing) survives in the emitted body;
-;;   (b) every VALID EDN payload round-trips through the reader unchanged -
-;;       `<` in string literals AND `<` in keyword/symbol tokens that do not
-;;       form a `</` / `<!` breakout precursor.
-;;   (c) a `</` / `<!` breakout precursor in a TOKEN position (no readable
-;;       in-token escape) fails loud with :rf.error/ssr-edn-script-breakout
-;;       rather than corrupting the document.
-;;
-;; verify-by-revert: restoring the callers to escape-script-body-string makes
-;; the token round-trip assertions go RED (the reader throws on `:a<b`).
-;; ---------------------------------------------------------------------------
+;; EDN script escaping must preserve reader semantics. A `<` can be escaped
+;; inside a string literal, but the same escape is invalid inside a keyword or
+;; symbol. Safe token-position `<` characters remain literal; token-position
+;; `</` and `<!` precursors fail loudly because EDN has no readable in-token
+;; escape for them.
 
 (defn- no-script-breakout?
   "True when `s` carries no literal `</script` closing-tag (any casing) -
@@ -412,7 +294,7 @@
         [[bits tail] rng2]))))
 
 (deftest edn-script-string-breakout-neutralised-and-round-trips
-  (testing "rf2-rdxxa - escape-edn-script-body neutralises EVERY recased
+  (testing "escape-edn-script-body neutralises every recased
             `</script` in an EDN string literal so none survives in the body,
             AND the reader recovers the original document verbatim; sweep 500
             recased closing-tag payloads"
@@ -421,8 +303,7 @@
                    (fn [edn-doc]
                      (let [escaped (h/escape-edn-script-body edn-doc)]
                        (and (no-script-breakout? escaped)
-                            ;; round-trips: reading the escaped body yields the
-                            ;; same value as reading the original EDN doc.
+                            ;; Reading the escaped body must recover the same value.
                             (= (edn/read-string edn-doc)
                                (edn/read-string escaped))))))]
       (is (nil? result)
@@ -430,9 +311,7 @@
                "document failed to round-trip: " (pr-str result))))))
 
 (def ^:private edn-token-with-angle-corpus
-  ;; VALID EDN documents carrying `<` in keyword/symbol TOKENS that are NOT
-  ;; breakout precursors (no `</` or `<!`). These are exactly what the naive
-  ;; whole-string escape corrupted - they MUST round-trip unchanged.
+  ;; Valid token-position `<` characters that are not breakout precursors.
   [{:a<b 1}
    {:k :<}
    {:< :>}
@@ -440,14 +319,12 @@
    {:k 'sym<tail}
    {:vec [:< :a<b "<starts-with-angle"]}
    {:nested {:deep<key {:and<more "v"}}}
-   ;; `<` adjacent to a quote-bearing string value plus a token key
    {:tok<key "value with </script> inside a string"}])
 
 (deftest edn-tokens-with-angle-round-trip
-  (testing "rf2-rdxxa - keyword/symbol tokens containing a non-breakout `<`
-            round-trip through the EDN reader unchanged (the regression the
-            whole-string `<`->`\\u003c` escape broke), and the body carries no
-            `</script` breakout"
+  (testing "keyword and symbol tokens containing a non-breakout `<` round-trip
+            through the EDN reader unchanged, and the body carries no closing-tag
+            breakout"
     (doseq [doc edn-token-with-angle-corpus]
       (let [edn-doc (pr-str doc)
             escaped (h/escape-edn-script-body edn-doc)]
@@ -458,7 +335,7 @@
                  escaped))))))
 
 (deftest edn-token-breakout-precursor-fails-loud
-  (testing "rf2-rdxxa - a `</` or `<!` breakout precursor in a TOKEN position
+  (testing "a `</` or `<!` breakout precursor in a token position
             has no readable in-token EDN escape, so it fails loud with
             :rf.error/ssr-edn-script-breakout rather than corrupting the doc"
     (doseq [edn-doc ["{:a</script>b 1}"
@@ -475,7 +352,7 @@
                  " did not fail loud; got " (pr-str thrown)))))))
 
 (deftest edn-string-with-breakout-precursor-is-escaped-not-rejected
-  (testing "rf2-rdxxa - a `</` / `<!` breakout INSIDE a string literal is
+  (testing "a `</` or `<!` breakout inside a string literal is
             escaped (it has the `\\u003c` reader escape) and round-trips - it
             must NOT trip the token-position fail-loud path"
     (doseq [doc [{:html "<!-- comment --></script>"}


### PR DESCRIPTION
## Summary

- replace issue-history and verify-by-revert narratives with the current security contracts
- distinguish MCP trace filtering from frame-owned app-db projection and keep the AI/MCP plus log threat model explicit
- preserve the non-obvious adversarial rationale for fail-closed inputs, host parity, at-source error redaction, and independent SSR matcher coverage
- reduce the security test surface by 958 net lines without changing test behavior

## Ownership

Reviewed the complete `implementation/security` surface. PR #5482 currently owns `gen.cljc`, `schema_redaction_security_cljs_test.cljc`, and `validation_redaction_invariant_security_cljs_test.cljc`; this branch deliberately leaves those files untouched to avoid overlapping its generator consolidation.

## Quality Gates

- `cd implementation/security && clojure -M:test` (92 tests, 666 assertions)
- `cd implementation && npm run test:security` (93 tests, 673 assertions; 0 warnings)
- `git diff --check`

Bead: rf2-20fenn
