### PR TITLE
docs(ssr): align explanations with current contracts (rf2-4cy0vj)

### DIFF
--- a/implementation/ssr/deps.edn
+++ b/implementation/ssr/deps.edn
@@ -1,6 +1,3 @@
-;; day8/re-frame2-ssr — ssr artefact (rf2-uo7v,
-;; sixth per-feature split per rf2-5vjj Strategy B).
-;;
 ;; Per Spec 011 the server-side rendering and hydration surface — the
 ;; pure hiccup → HTML emitter (`render-to-string`), the structural
 ;; render-tree hash (`render-tree-hash`), the `:rf/hydrate` event with
@@ -9,7 +6,7 @@
 ;; `:rf.server/set-cookie` / `:rf.server/delete-cookie` /
 ;; `:rf.server/redirect` server-only fx family, the per-request HTTP
 ;; response accumulator (a framework-private side-channel atom keyed on
-;; frame-id per rf2-jbcmt — Spec 011 §Response storage substrate), the
+;; frame-id), the
 ;; `reg-error-projector` surface plus its built-in
 ;; `:rf.ssr/default-error-projector`, the runtime's SSR error path, and
 ;; the `data-rf2-source-coord` annotation on registered-view roots —
@@ -33,8 +30,7 @@
 ;; late-bind hooks (`:ssr/render-tree-hash`) and the plain-atom adapter's
 ;; `:render-to-string` slot.
 ;;
-;; Per Spec 006 §Adapter shipping convention (and the
-;; rf2-p7va extension to per-feature splits): this artefact depends on
+;; Per Spec 006 §Adapter shipping convention, this artefact depends on
 ;; core; core never depends on this artefact. The cross-references
 ;; from core to ssr (`re-frame.core`'s `render-to-string` /
 ;; `render-tree-hash` / `reg-error-projector` / `project-error`
@@ -60,11 +56,11 @@
                        day8/re-frame2-flows      {:local/root "../flows"}
                        day8/re-frame2-routing    {:local/root "../routing"}
                        day8/re-frame2-machines   {:local/root "../machines"}
-                       ;; rf2-try1x — silent-on-success reporter.
+                       ;; Silent-on-success reporter.
                        day8/re-frame2-test-quiet {:local/root "../test-quiet"}
                        io.github.cognitect-labs/test-runner
                        {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
-         ;; rf2-bv2qqm — the default PR/local gate EXCLUDES the heavy
+         ;; The default PR/local gate excludes the heavy
          ;; `^:slow` / `^:stress` namespaces (here: the 2000-request
          ;; `ssr_teardown_load_test`). `re-frame.test-quiet.runner` passes
          ;; `-e` through verbatim to cognitect-test-runner, whose
@@ -74,7 +70,7 @@
          ;; job + `scripts/test-rigorous-local.sh` invoke it.
          :main-opts   ["-m" "re-frame.test-quiet.runner" "-e" ":slow" "-e" ":stress"]}
 
-  ;; rf2-bv2qqm — nightly/rigorous slow-test gate. INCLUDES ONLY the
+  ;; Nightly/rigorous slow-test gate. Includes only the
   ;; `^:slow` / `^:stress` tests (the `-i` union the default `:test`
   ;; alias excludes), so the default `:test` run plus this `:slow-test`
   ;; run together cover every test exactly once. Invoked by the nightly
@@ -91,7 +87,7 @@
                  {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
    :main-opts   ["-m" "re-frame.test-quiet.runner" "-i" ":slow" "-i" ":stress"]}
 
-  ;; Clojars deploy (rf2-r382). Modeled on re-frame v1's release flow.
+  ;; Clojars deployment.
   ;; The release workflow runs `clojure -M:clein deploy` from this
   ;; artefact's directory, which builds pom + jar and pushes to Clojars.
   ;;

--- a/implementation/ssr/src/re_frame/ssr.cljc
+++ b/implementation/ssr/src/re_frame/ssr.cljc
@@ -1,105 +1,44 @@
 (ns re-frame.ssr
-  "Server-side rendering and hydration. Per Spec 011.
+  "Server-side rendering and hydration façade.
 
-  Public façade for the day8/re-frame2-ssr artefact. Per Spec 006
-  §Adapter shipping convention — this artefact depends on core; core
-  never depends on this artefact. Cross-references from core to ssr
-  flow through `re-frame.late-bind`.
+  Requiring this namespace installs the SSR event, effect, coeffect, error
+  projector, and listener registrations. It also eagerly loads the head and
+  streaming server namespaces so their late-bound host hooks are available.
 
-  Façade over eight flat sub-namespaces (`emit`, `hash`, `substrate`,
-  `hydrate`, `response`, `error-projector`, `error-listener`,
-  `request`). All `reg-fx` / `reg-cofx` / `reg-event` /
-  `reg-error-projector` / `register-error-listener!` /
-  `register-listener!` side-effects fire HERE so
-  `(require 're-frame.ssr :reload)` after `(registrar/clear-all!)`
-  re-installs every registration. Sub-namespaces export pure handler
-  fns only.
-
-  Implements:
-    - Pure hiccup → HTML emitter (HTML5 void elements, doctype prefix,
-      attr/text escaping, `:tag#id.cls` parsing, registered-view
-      resolution). Per Spec 011 §The render-tree → HTML emitter.
-    - `:rf/hydrate` event with `:replace-frame-state` semantics; the server-
-      supplied payload's `:rf/app-db` replaces the client frame-state
-      (app-db + serializable runtime-db).
-    - The seven `:rf.server/*` response-shape fxs gated by `:platforms
-      #{:server}`; the response accumulator (a framework-private side-
-      channel atom keyed by frame-id, read via `get-response`, NOT an
-      `app-db` path) is consumed by the host adapter after drain. Per
-      §HTTP response contract.
-    - `reg-error-projector` + default `:rf.ssr/default-error-projector`,
-      plus the SSR error path that calls the active projector when an
-      error trace fires inside a server frame. Per §Server error
-      projection.
-    - `:rf.server/request` cofx + per-frame request slot
-      (`set-request!` / `get-request` / `clear-request!`). Per
-      §Server-only `reg-cofx` for request context.
-
-  Conformance fixtures cover all of the above (ssr/render-to-string,
-  ssr/hydrate, ssr/hydration-mismatch, ssr/head-emits, ssr/head-hydration,
-  ssr/error-known-mapping, ssr/error-sanitisation, ssr/cookie,
-  ssr/redirect, ssr/set-status, fx/platforms)."
+  The façade exposes pure HTML emission and hashing, client hydration,
+  per-frame request and response side channels, error projection, streaming
+  primitives, and the headless adapter. Core reaches this optional artefact
+  only through `re-frame.late-bind`; this artefact may depend on core."
   (:require [re-frame.cofx :as cofx]
             [re-frame.emit :as rf-emit]
             [re-frame.events :as events]
             [re-frame.fx :as fx]
             [re-frame.late-bind :as late-bind]
-            ;; rf2-lq2ou — client-side hydration boot helper. The
-            ;; symmetric counterpart of the server-side
-            ;; `re-frame.ssr.ring/ssr-handler`: reads `__rf_payload` →
-            ;; dispatches `:rf/hydrate` → verifies. Loaded eagerly so the
-            ;; `ssr/hydrate!` / `ssr/read-server-payload` re-exports
-            ;; resolve at the façade. Per Spec 011 §Client-side hydration
-            ;; boot helper.
+            ;; Loaded eagerly so both hydration boot re-exports resolve.
             [re-frame.ssr.boot :as boot]
             [re-frame.ssr.emit :as emit]
             [re-frame.ssr.error-listener :as error-listener]
             [re-frame.ssr.error-projector :as error-projector]
-            ;; rf2-4dra9 — head/meta contract surface (Spec 011 §Head/meta).
-            ;; The head ns publishes its late-bind hooks at ns-load time;
-            ;; static `:require` here ensures the hooks are available
-            ;; before any user code calls `rf/reg-head` / `rf/render-head`
-            ;; / `rf/active-head`. The dependency is acyclic — head.cljc
-            ;; only pulls re-frame.frame / re-frame.registrar.
+            ;; Publishes the head hooks at namespace load.
             re-frame.ssr.head
             [re-frame.ssr.hash :as hash]
             [re-frame.ssr.hydrate :as hydrate]
             [re-frame.ssr.request :as request]
             [re-frame.ssr.response :as response]
-            ;; rf2-kjf3m.2 — the standard `:rf.fx.server/*-args` /
-            ;; `:rf.server/cookie` Malli args schemas Spec 011 §Standard fx
-            ;; (line 438) + [Spec-Schemas §Standard fx args schemas] name as
-            ;; registered. Attached as the `:schema` key on the seven
-            ;; `:rf.server/*` reg-fx calls below so the Spec 010 §step-5
-            ;; fx-args `:schema` boundary check actually fires on the server
-            ;; fx args (it previously did not — the calls carried only :doc
-            ;; + :platforms).
+            ;; Plain-data schemas attached to the seven server effects.
             [re-frame.ssr.server-fx-schemas :as server-fx-schemas]
             [re-frame.ssr.substrate :as substrate]
-            ;; rf2-ojakd / rf2-olb64 (a) — streaming SSR primitive
-            ;; (:rf/suspense-boundary). Loaded eagerly so the three
-            ;; late-bind hooks (:ssr.streaming/render-shell!,
-            ;; :ssr.streaming/render-continuation!,
-            ;; :ssr.streaming/build-final-payload) land at ns-load time
-            ;; before any host adapter calls them.
+            ;; Publishes streaming server hooks at namespace load.
             re-frame.ssr.streaming
-            ;; rf2-3hhv5 — CLIENT-side streaming-SSR runtime
-            ;; (`install!`). CLJS-only (it installs a MutationObserver +
-            ;; swaps DOM); re-exported as `ssr/streaming-install!` so a
-            ;; streaming-aware bootstrap calls one façade fn. NOT eagerly
-            ;; needed server-side; required CLJS-only so a JVM lint of
-            ;; this `.cljc` does not pull a `.cljs`-only ns.
+            ;; CLJS-only DOM consumer for streamed boundary chunks.
             #?(:cljs [re-frame.ssr.streaming.client :as streaming-client])
-            ;; Per rf2-qwm0a SSR's error-projection trace listener
-            ;; targets the tooling sibling directly. The framework's
-            ;; `re-frame.trace` no longer re-exports the listener
-            ;; surface (production-DCE split).
+            ;; Listener registration lives on the tooling surface so production
+            ;; code that does not use SSR does not retain trace tooling.
             [re-frame.trace.tooling :as trace-tooling]))
 
 ;; ---- public-surface re-exports --------------------------------------------
 ;;
-;; `def`s expose the sub-namespace fns as `re-frame.ssr/<name>` so
-;; consumers see the same surface they did pre-split.
+;; `def`s expose the supported sub-namespace functions at the façade.
 
 (def render-to-string                emit/render-to-string)
 (def install-render-to-string!       emit/install-render-to-string!)
@@ -111,18 +50,13 @@
 (def ^:private fnv-1a-32             hash/fnv-1a-32)
 (def adapter                         substrate/adapter)
 (def verify-hydration!               hydrate/verify-hydration!)
-;; rf2-lq2ou — client-side hydration boot helper (symmetric with the
-;; server-side `re-frame.ssr.ring/ssr-handler`). `hydrate!` fuses the
-;; read → dispatch `:rf/hydrate` → `verify-hydration!` ordering Spec 011
-;; §Client flow mandates; `read-server-payload` (CLJS-only) is the DOM
-;; `__rf_payload` reader it builds on.
+;; `hydrate!` preserves read → hydrate → verify ordering. The DOM reader is
+;; CLJS-only.
 (def hydrate!                        boot/hydrate!)
 #?(:cljs (def read-server-payload    boot/read-server-payload))
 (def default-response                response/default-response)
-;; framework-private — Spec 011 §Response storage substrate (rf2-jbcmt).
-;; The accumulator lives in a side-channel atom keyed by frame-id, NOT
-;; in app-db, so it cannot ride the hydration payload to the client and
-;; per-fx writes are O(small-map) rather than a full app-db replacement.
+;; The response accumulator is a per-frame side channel, not application
+;; state, so it cannot enter the hydration payload.
 ;; Tests reach the var via `(resolve 're-frame.ssr/response-slots)`.
 (def ^:private response-slots        response/response-slots)
 (def public-error-keys               error-projector/public-error-keys)
@@ -131,16 +65,11 @@
 (def reg-error-projector             error-projector/reg-error-projector)
 (def project-error                   error-projector/project-error)
 (def apply-error-projection!         error-listener/apply-error-projection!)
-;; rf2-zwgsv — Spec 011 §Server error projection unification. Host
-;; adapters wrap their render pipeline call (`render-to-string`) in a
-;; try/catch and route render-time throws through this fn so the
-;; projector's status + body materialise on the wire — symmetric with
-;; the drain-time fx/handler-exception path that already flows through
-;; the trace-listener buffer.
+;; Host adapters route render-time exceptions through the same projector as
+;; drain-time errors so both paths materialise an equivalent wire response.
 (def project-render-exception!       error-listener/project-render-exception!)
 (def get-response                    error-listener/get-response)
-;; Audit rf2-asmj1 P5 / cluster rf2-sljs1 — split the side-effect from
-;; the pure read. `peek-response` is a pure read (no projector drain);
+;; `peek-response` is a pure read (no projector drain);
 ;; `flush-response!` drains pending error projections then reads.
 ;; `get-response` is kept as the drain-then-read host-adapter alias.
 (def peek-response                   error-listener/peek-response)
@@ -148,8 +77,7 @@
 ;; framework-private at the public surface — Spec 011 §Per-request
 ;; frame teardown. Tests reach the var via `(resolve ...)`.
 (def ^:private pending-error-traces  error-listener/pending-error-traces)
-;; rf2-i3qc0 — private at the façade so the public surface stays symmetric
-;; with `response-slots` and `pending-error-traces`. Tests reach via
+;; Private at the façade. Tests reach via
 ;; `re-frame.ssr.test-fixture/reset-runtime` (the canonical reset surface)
 ;; or by `:require`-ing `re-frame.ssr.request` directly. Production
 ;; consumers go through `set-request!` / `get-request` / `clear-request!`.
@@ -159,7 +87,7 @@
 (def clear-request!                  request/clear-request!)
 (def on-frame-destroyed!             request/on-frame-destroyed!)
 
-;; ---- streaming SSR public surface (rf2-ojakd / rf2-olb64 (a)) -------------
+;; ---- streaming SSR public surface -----------------------------------------
 ;;
 ;; Per Spec 011 §Streaming SSR — the `:rf/suspense-boundary` hiccup marker
 ;; ships through these three façade fns. Host adapters (ssr-ring/streaming)
@@ -171,7 +99,7 @@
 (def streaming-resolved-template    re-frame.ssr.streaming/resolved-template)
 (def streaming-failed-template      re-frame.ssr.streaming/failed-template)
 (def streaming-hydrate-delta-script re-frame.ssr.streaming/hydrate-delta-script)
-;; rf2-3hhv5 — CLIENT-side streaming runtime. CLJS-only (DOM consumer):
+;; Client-side streaming runtime. CLJS-only (DOM consumer):
 ;; `(ssr/streaming-install! {:frame …})` installs the MutationObserver
 ;; that swaps `<template>` fallbacks for resolved subtrees + merges the
 ;; per-subtree hydration deltas as chunks stream in, reconciling against
@@ -180,18 +108,12 @@
 ;; pages skip it.
 #?(:cljs (def streaming-install!    streaming-client/install!))
 
-;; ---- SSR blocking-resource drain (Spec 016 §SSR and hydration steps 3-4) --
+;; ---- SSR blocking-resource drain ------------------------------------------
 ;;
-;; rf2-er7qx2 — the resources artefact (optional) defines SSR blocking
-;; resources as SETTLED before render or TIMED OUT into a settled first-load
-;; failure. The drain LOOP + timeout POLICY live in the resources artefact
-;; (`re-frame.resources.ssr/drain-blocking-resources!`, published as the
-;; `:resources/drain-blocking-ssr!` late-bind hook); the SSR render path (Ring
-;; / streaming host adapters) consults it BEFORE rendering so the render walk
-;; never sees a hung `:loading` / skeleton an in-flight (or never-settling)
-;; blocking resource would otherwise leave. Late-bound BOTH ways — an SSR app
-;; without resources carries none of this code path (the hook is nil → no-op);
-;; a resources app that never SSRs never reaches it.
+;; The optional resources artefact owns the drain loop and timeout policy.
+;; SSR calls its late-bound hook before rendering so blocking resources are
+;; either settled or converted to a settled first-load failure. An application
+;; without resources resolves the absent hook as a no-op.
 
 (def ^:private default-ssr-blocking-timeout-ms
   "Default wall-clock render-deadline budget for the SSR blocking-resource
@@ -265,17 +187,15 @@
 
 ;; ---- :rf/hydrate event + :rf.ssr/check-* fxs ------------------------------
 ;;
-;; Spec 011 §The :rf/hydrate event + §Hydration-mismatch detection +
-;; rf2-69ad2 compatibility checks.
+;; Spec 011 §The :rf/hydrate event + §Hydration-mismatch detection.
 
-;; EP-0001 (rf2-3939ig): ssr is one of the legitimate runtime-db writers
-;; Spec 002 §Write authority names. The `:rf/hydrate` handler installs the
+;; SSR is a framework-authorised runtime-db writer. The `:rf/hydrate` handler installs the
 ;; hydration metadata into the reserved `[:rf.runtime/ssr :hydration]` slot
 ;; by returning a `:rf.db/runtime` effect, so it mints framework-write
 ;; authority via the general `:rf/framework-authority?` registration-meta key
 ;; (Conventions §Reserved registration meta) — without it, every hydrate
 ;; dispatch would trip the `:rf.warning/app-handler-runtime-effect`
-;; ownership diagnostic in dev (reserved BY CONVENTION, Mike ruling #4).
+;; ownership diagnostic in development.
 (events/reg-event :rf/hydrate
                      {:rf/framework-authority? true}
                      hydrate/hydrate-event-handler)
@@ -303,7 +223,7 @@ the client's registered app-schema digest. A mismatch emits a structured
   {:doc       "Set the HTTP response status. Last-write-wins. A second
 write in the same drain emits :rf.warning/multiple-status-set per
 [Spec 011 §Multiple-status policy]."
-   :schema    server-fx-schemas/set-status-args   ;; :rf.fx.server/set-status-args (rf2-kjf3m.2)
+   :schema    server-fx-schemas/set-status-args
    :platforms #{:server}}
   response/set-status-fx)
 
@@ -311,7 +231,7 @@ write in the same drain emits :rf.warning/multiple-status-set per
   {:doc       "Replace any existing header with the same name (case-
 insensitive) and write [name value]. Per Spec 011 §Header replacement
 vs append."
-   :schema    server-fx-schemas/set-header-args   ;; :rf.fx.server/set-header-args (rf2-kjf3m.2)
+   :schema    server-fx-schemas/set-header-args
    :platforms #{:server}}
   response/set-header-fx)
 
@@ -319,7 +239,7 @@ vs append."
   {:doc       "Append [name value] to headers — preserves any existing
 header with the same name. Required for Set-Cookie-style multi-valued
 headers. Per Spec 011 §Header replacement vs append."
-   :schema    server-fx-schemas/append-header-args ;; :rf.fx.server/append-header-args (rf2-kjf3m.2)
+   :schema    server-fx-schemas/append-header-args
    :platforms #{:server}}
   response/append-header-fx)
 
@@ -327,7 +247,7 @@ headers. Per Spec 011 §Header replacement vs append."
   {:doc       "Add a structured cookie to the :cookies vector. Cookie
 attributes are stored as a structured map (RFC 6265 wire-form
 serialisation is host-adapter business). Per Spec 011 §Cookie shape."
-   :schema    server-fx-schemas/set-cookie-args   ;; :rf.fx.server/set-cookie-args = [:ref :rf.server/cookie] (rf2-kjf3m.2)
+   :schema    server-fx-schemas/set-cookie-args
    :platforms #{:server}}
   response/set-cookie-fx)
 
@@ -335,7 +255,7 @@ serialisation is host-adapter business). Per Spec 011 §Cookie shape."
   {:doc       "Sugar over :rf.server/set-cookie with :max-age 0 and an
 empty :value. The host adapter materialises the delete-marker semantics
 on the wire. Per Spec 011 §Cookie shape."
-   :schema    server-fx-schemas/delete-cookie-args ;; :rf.fx.server/delete-cookie-args (rf2-kjf3m.2)
+   :schema    server-fx-schemas/delete-cookie-args
    :platforms #{:server}}
   response/delete-cookie-fx)
 
@@ -348,8 +268,8 @@ on the wire. Per Spec 011 §Cookie shape."
 Caller-trusted :location — accepts arbitrary URL strings without
 allowlist or relative-only gating. For caller-untrusted location strings
 (e.g. a `?next=` URL param), use :rf.server/safe-redirect (below).
-Per rf2-zfm8v."
-   :schema    server-fx-schemas/redirect-args     ;; :rf.fx.server/redirect-args (rf2-kjf3m.2)
+The trusted path still rejects header-splitting characters."
+   :schema    server-fx-schemas/redirect-args
    :platforms #{:server}}
   response/redirect-fx)
 
@@ -371,9 +291,8 @@ Validation order: (1) URL must parse — :rf.error/safe-redirect-invalid-url;
 :rf.error/safe-redirect-scheme-rejected; (3) :relative-only? + host —
 :rf.error/safe-redirect-host-disallowed (:reason :relative-only-violation);
 (4) :allow allowlist mismatch — :rf.error/safe-redirect-host-disallowed
-(:reason :not-in-allowlist); (5) pass — set Location header. Per
-rf2-zfm8v (Mike decision, Option A, 2026-05-14)."
-   :schema    server-fx-schemas/safe-redirect-args ;; :rf.fx.server/safe-redirect-args (rf2-wtd8z finding 1)
+(:reason :not-in-allowlist); (5) pass — set Location header."
+   :schema    server-fx-schemas/safe-redirect-args
    :platforms #{:server}}
   response/safe-redirect-fx)
 
@@ -382,56 +301,22 @@ rf2-zfm8v (Mike decision, Option A, 2026-05-14)."
 ;; Per Spec 011 §Server-only `reg-cofx` for request context.
 
 (cofx/reg-cofx :rf.server/request
-  {:doc       "The active HTTP request. Server only. AMBIENT value-returning
-coeffect (EP-0017 §2): surfaces the host-supplied request map (Ring shape
-under rf2-ny6v7's Ring adapter; host-defined for other adapters) so handlers
-can read URL, headers, session cookies, etc. without threading the request as
-an event arg.
+  {:doc       "The active host-supplied HTTP request. Server only.
 
-GRADE — AMBIENT, host-transient read. This cofx is for NON-DURABLE request
-reads: branching on `:request-method`, reading a header for a decision that
-does NOT fold into durable app-db / runtime-db. EP-0017 §1: the ambient grade
-is legal only where NO durable write depends on the value — its supplier
-re-runs on replay, so it never re-presents the value a recorded run actually
-saw (and after per-request frame teardown it reads nil). A handler that folds a
-request-derived fact into the hydration payload (durable app-db) through THIS
-cofx is the SSR analogue of the ambient-localStorage replay hole (rf2-aqwvhh /
-the rf2-16ck78 family).
+This is an ambient, per-frame read. It is suitable for transient decisions
+whose results do not enter app-db or runtime-db. Replay invokes the supplier
+again, after the request slot may have been cleared, so durable state must not
+depend directly on this value.
 
-DURABLE request-derived facts — the boundary pattern (rf2-aqwvhh). When a setup
-handler writes durable state from the request (auth user / session state read
-from a cookie, an `accept-language` folded into a locale slice, …), the host
-adapter SANITIZES the request at the boundary and supplies the derived fact as
-a recordable leaf, so it lands on the causal token and replay re-presents it
-verbatim. Two slice-A-legal shapes, both replayable:
+For a durable request-derived fact, the host sanitizes the request at the
+boundary and provides only the derived value in the event payload or in a
+provided, recordable coeffect leaf. Never record the whole request: it may
+contain credentials, personal data, streams, and other host handles.
 
-  - EVENT PAYLOAD — the host dispatches the setup event WITH the derived fact:
-    `[:auth/server-init {:user (extract-user request)}]`. The fact rides
-    `:event`, recorded as part of the dispatch.
-  - PROVIDED recordable `:rf.cofx` LEAF — register an app-owned
-    `{:recordable? true :provided? true}` cofx (e.g. `:auth.session/user`) and
-    the host adapter STAMPS the sanitized value onto the boot dispatch token
-    (`{:rf.cofx {:auth.session/user …}}`). The handler declares
-    `:rf.cofx/requires [:auth.session/user]`; a record missing it fails LOUDLY
-    with `:rf.error/missing-required-cofx` rather than silently re-reading the
-    host. NEVER stamp the whole request map onto the token — it carries
-    secrets / PII and is a host handle (Spec 011 §Request storage substrate);
-    stamp only the sanitized derived projection.
-
-The host adapter populates the per-frame slot via `re-frame.ssr/set-request!`
-once per request before the drain begins. A server-side event handler consumes
-the AMBIENT read by declaring `{:rf.cofx/requires [:rf.server/request]}` on its
-registration and reading the value FLAT under `:rf.server/request`. The supplier
-runs at context assembly, reading the active frame's slot; it is never recorded,
-and replay re-runs it.
-
-Tests and conformance harnesses that drive the drain without a host adapter
-`re-frame.ssr/set-request!` the target frame's slot before dispatching (the
-visible seam — there is no `inject-cofx` value override anymore: `inject-cofx`
-is removed in EP-0017).
-
-Per Spec 011 §Server-only `reg-cofx` for request context + §Durable
-request-derived facts."
+The host calls `set-request!` before draining the frame. Handlers declare
+`{:rf.cofx/requires [:rf.server/request]}` and read the value at
+`:rf.server/request`. Tests without a host adapter populate the same slot
+explicitly."
    :platforms #{:server}}
   request/request-cofx)
 
@@ -443,29 +328,23 @@ request-derived facts."
                      {:doc "Built-in default projector. Spec 011 §Default projector mapping."}
                      default-error-projector-fn)
 
-;; rf2-fb598 — primary install site: the always-on error-emit substrate.
-;; Per Spec 011 §Server error projection / Spec 009 §What IS available in
-;; production §Error-emit listener, this listener survives
-;; `interop/debug-enabled? = false` (production hardening per rf2-vnjfg)
+;; The always-on listener survives `interop/debug-enabled? = false`,
 ;; so the SSR `:rf/public-error` projection contract holds even when the
 ;; trace surface is gated off. Catches every `:rf.error/*` category that
 ;; flows through `re-frame.error-emit/dispatch-on-error!` —
 ;; `:rf.error/handler-exception` (router), `:rf.error/fx-handler-
 ;; exception` family (fx), `:rf.error/flow-eval-exception` (flows), and
-;; `:rf.error/sub-exception` (reactive sub-run — rf2-vvwmi routed it onto
-;; the always-on substrate so a sub that throws mid-`render-to-string`
+;; `:rf.error/sub-exception` (reactive sub-run). A sub that throws mid-render
 ;; projects a fail-closed 5xx under production hardening instead of
-;; recovering to nil → silent HTTP 200).
+;; recovering to nil and producing an HTTP 200.
 (rf-emit/register-error-listener! ::error-projection
                                   error-listener/error-emit-projection-listener)
 
-;; rf2-fb598 — secondary install site: the dev-only trace surface,
-;; preserved for `:rf.error/*` categories that emit ONLY via
+;; The development trace listener covers categories that emit only via
 ;; `trace/emit-error!` (no always-on emission path): `:rf.error/no-such-
 ;; handler`, `:rf.error/no-such-route`, `:rf.error/schema-validation-
 ;; failure`, `:rf.error/drain-depth-exceeded`. (`:rf.error/sub-exception`
-;; ALSO fires here for the dev trace surface, but its production status
-;; source of truth is now the always-on substrate above — rf2-vvwmi.)
+;; also fires here for the development trace surface.)
 ;; These categories DCE under `interop/debug-enabled? = false`; the
 ;; substrate-shipping projector relies on the dev gate for them. Both
 ;; listeners share id `::error-projection` to keep the contract surface
@@ -477,8 +356,7 @@ request-derived facts."
 
 ;; ---- late-bind hook registration ------------------------------------------
 ;;
-;; Per rf2-uo7v re-frame.ssr ships in `day8/re-frame2-ssr`. The core
-;; artefact's `re-frame.core/render-to-string`, `render-tree-hash`,
+;; Core's `render-to-string`, `render-tree-hash`,
 ;; `reg-error-projector`, and `project-error` re-exports look the
 ;; producing fns up through this hook table — core never statically
 ;; `:require`s `re-frame.ssr`. When the ssr artefact is not on the
@@ -489,16 +367,12 @@ request-derived facts."
 (late-bind/set-fn! :ssr/render-to-string    render-to-string)
 (late-bind/set-fn! :ssr/reg-error-projector reg-error-projector)
 (late-bind/set-fn! :ssr/project-error       project-error)
-;; rf2-fcj33 + rf2-jbcmt — per-request frame teardown. `frame/destroy-frame!`
-;; looks up this hook and clears the SSR side-channel atoms
+;; Frame teardown looks up this hook and clears the SSR side-channel atoms
 ;; (`pending-error-traces`, `request-slots`, `response-slots`) for the
-;; destroyed frame. `response-slots` joined the set under rf2-jbcmt when
-;; the `:rf/response` accumulator moved off `app-db` to plug the hydration-
-;; payload leak / per-fx full-app-db swap.
+;; destroyed frame.
 (late-bind/set-fn! :ssr/on-frame-destroyed  on-frame-destroyed!)
 
-;; rf2-4dra9 — `re-frame.ssr.head` is required from the top-of-file ns
-;; form so its late-bind hooks (`:ssr/reg-head`, `:ssr/render-head`,
+;; `re-frame.ssr.head` is required above so its late-bind hooks (`:ssr/reg-head`, `:ssr/render-head`,
 ;; `:ssr/active-head`, `:ssr/head-snapshot`, `:ssr/head-model-html`) AND
 ;; the per-frame head-snapshot cleanup hook
 ;; (`:ssr.head/on-frame-destroyed`) land at ssr-ns load time on both JVM

--- a/implementation/ssr/src/re_frame/ssr/boot.cljc
+++ b/implementation/ssr/src/re_frame/ssr/boot.cljc
@@ -1,67 +1,14 @@
 (ns re-frame.ssr.boot
-  "Client-side hydration boot helper — the symmetric counterpart of the
-  server-side `re-frame.ssr.ring/ssr-handler`. Per Spec 011 §Client flow
-  and §Client-side hydration boot helper (rf2-lq2ou).
+  "Client-side hydration boot helpers.
 
-  ## The symmetry
+  `hydrate!` preserves the required read → hydrate → verify ordering. It
+  dispatches synchronously before the host mounts, then optionally hashes a
+  caller-supplied pure render-tree computation. It does not inspect or own the
+  DOM mount. Hosts that must verify a substrate-mutated or asynchronous tree
+  perform the hydrate and verify steps separately.
 
-  The server side ships ONE explicit handler-constructor:
-
-      (ssr-ring/ssr-handler {:initial-events … :root-view … :payload …})
-      ;; → a Ring handler that renders, builds the `__rf_payload`
-      ;;   `<script>`, and writes the wire response.
-
-  The client side now ships its mirror — ONE explicit boot call:
-
-      (ssr/hydrate! {:frame :app/main :render-tree-fn #(…hiccup…)})
-      ;; → reads `__rf_payload`, dispatches `:rf/hydrate`, then (still
-      ;;   synchronously, before the host's own render) computes the client
-      ;;   render-tree via `:render-tree-fn` and verifies its hash against
-      ;;   the server's.
-
-  The pair reads as one contract: the server emits the payload under the
-  `re-frame.ssr.constants/payload-script-id` id; the boot helper reads
-  that SAME id (`document.getElementById`), parses the EDN with the same
-  reader the server's `pr-str` round-trips through, and seeds the frame
-  via the framework's `:rf/hydrate` event (locked `:replace-frame-state`
-  policy, Spec 011 §The :rf/hydrate event).
-
-  Before this helper every host re-implemented the same read → dispatch →
-  (render) → verify dance (three testbeds + two worked examples carried
-  byte-identical `read-server-payload` fns). The helper makes the client
-  boot a one-liner and pins the read/dispatch/verify ordering the spec
-  mandates so a host can't get it subtly wrong (e.g. reading a stale id, or
-  seeding after the first render).
-
-  ## The verify contract — seed-and-synchronously-compute-tree
-
-  `hydrate!` is a SYNCHRONOUS convenience: after dispatching `:rf/hydrate`
-  it immediately calls the caller-supplied `:render-tree-fn` to compute the
-  client render-tree and hashes THAT — it does NOT wait for, or observe,
-  the host's DOM mount (it does not own the mount). This is sound because a
-  re-frame2 view is a pure function of app-db: `(rf/view :app/root)`
-  evaluated against the just-hydrated app-db is the SAME render-tree the
-  host is about to mount, so the pre-mount hash equals the mounted-tree
-  hash. `:render-tree-fn` is therefore a PURE client-tree computation, not
-  a \"read back what was mounted\" hook. A host that must verify the actual
-  mounted DOM tree (a substrate that mutates at mount, or an async mount)
-  splits the convenience — see `hydrate!`'s docstring. Per Spec 011
-  §Client-side hydration boot helper.
-
-  ## Platform split
-
-  - `read-server-payload` is `:cljs`-only — it reaches into the DOM.
-  - `hydrate!` is platform-neutral: it takes an explicit `:payload` (or
-    reads it from the DOM on CLJS when omitted), dispatches `:rf/hydrate`,
-    and runs the post-render `verify-hydration!` step. The JVM test
-    harness drives `hydrate!` with an explicit payload + a `:client`-
-    platform frame so the round-trip (server `build-payload` →
-    `hydrate!` → post-hydrate sub) is exercised without a browser.
-
-  Per the rf2-uo7v shipping convention this namespace lives in the
-  `day8/re-frame2-ssr` artefact alongside the rest of the SSR surface; it
-  is re-exported from the `re-frame.ssr` façade as `ssr/hydrate!` /
-  `ssr/read-server-payload`."
+  `read-server-payload` is CLJS-only and reads the pinned `__rf_payload`
+  element. `hydrate!` is platform-neutral when given an explicit payload."
   (:require [re-frame.error :as error]
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
@@ -78,19 +25,15 @@
 #?(:clj (set! *warn-on-reflection* true))
 
 (defn dispatch-malformed-hydration-frameless!
-  "EP-0008 (rf2-hhutya): surface the PRE-FRAME hydration-parse failure as a
-  FRAMELESS always-on `:rf.error/malformed-hydration-payload` record. The
+  "Surface a pre-frame hydration parse failure as a frameless, always-on
+  `:rf.error/malformed-hydration-payload` record. The
   `read-server-payload` DOM read runs BEFORE `hydrate!` resolves the target
   frame, so there is no `:frame` to carry (`:frame nil`) — exactly the
-  EP-0002 resolution-6 `:rf.error/no-frame-context` precedent that
-  established frameless always-on emission. Corrupt hydration INPUT is a
-  fail-closed boundary event, not a dev teaching diagnostic: an off-box
-  shipper on a `goog.DEBUG=false` client build (dev trace elided) must still
-  see it. Reaches the always-on axis via the `:error-emit/dispatch-error-
-  record` late-bind hook; UNGATED. Extracted as a `.cljc` helper (not inline
-  in the CLJS-only `read-server-payload`) so the JVM test runner can
-  exercise the frameless record shape without a DOM. No-op when the
-  `error-emit` producer hasn't loaded. Returns nil."
+  record carries `:frame nil`. Corrupt hydration input is a fail-closed
+  boundary event, so the record reaches the always-on error emitter even when
+  development tracing is disabled. The helper is platform-neutral so JVM
+  tests can exercise the record shape without a DOM. Returns nil when the
+  error-emitter hook is absent."
   [where element-id reason]
   (when-let [dispatch-error-record!
              (late-bind/get-fn :error-emit/dispatch-error-record)]
@@ -119,12 +62,10 @@
      unicode escape inside string literals before injection (the
      rf2-7ksyr `</script>` XSS gate, EDN-aware per rf2-rdxxa);
      `cljs.reader/read-string` accepts that escape so the payload
-     round-trips unchanged — including payloads carrying keyword/symbol
+     round-trips unchanged, including payloads carrying keyword/symbol
      tokens with `<`.
 
-     Per rf2-gro94 a MALFORMED payload script (truncated server output,
-     a hostile fragment that survives the `</script>` gate, mid-stream
-     corruption) fails CLOSED rather than crashing the whole client boot:
+     A malformed payload script fails closed rather than crashing client boot:
      `cljs.reader/read-string` THROWS on malformed EDN, and an unguarded
      throw here propagates out of `hydrate!` and aborts the mount. We
      isolate the parse, emit a `:rf.error/malformed-hydration-payload`
@@ -156,18 +97,15 @@
                                     :element-id element-id
                                     :reason     reason
                                     :recovery   :no-recovery}))
-              ;; EP-0008 (rf2-hhutya): the PRE-FRAME parse failure ALSO rides
-              ;; the always-on axis as a FRAMELESS record (`:frame nil`) so a
-              ;; goog.DEBUG=false client build (dev trace elided) still ships
-              ;; the rejected payload. See the extracted helper for the
-              ;; frameless-precedent rationale. UNGATED.
+              ;; Parsing precedes frame resolution, so the always-on record is
+              ;; intentionally frameless.
               (dispatch-malformed-hydration-frameless!
                 'rf.ssr/read-server-payload element-id reason))
             nil))))))
 
 (defn- validate-payload-frame-id!
-  "EP-0002 (rf2-acjknb): assert the explicit client hydration `target`
-  frame agrees with the payload's `:rf/frame-id` — the SSR-wire spelling
+  "Assert that the explicit client hydration `target` agrees with the
+  payload's `:rf/frame-id` — the SSR-wire spelling
   of the frame stamp the SERVER rendered under (built by
   `re-frame.ssr.payload-policy/build-payload`). Per Spec 011 §The
   hydration payload + Spec 002 §Frame target resolution: the payload
@@ -246,18 +184,16 @@
 
     :frame          — REQUIRED. The target frame id to hydrate into. The
                       same frame the host passes to the root provider,
-                      streaming `install!`, resource preload, and Xray
-                      (EP-0002 rf2-acjknb — one carried frame; the client
-                      target is supplied, not synthesised). An absent
+                      streaming `install!`, resource preload, and Xray. The
+                      client target is supplied, not synthesised. An absent
                       `:frame` emits + throws `:rf.error/no-frame-context`
-                      (the pre-EP `:rf/default` default is removed). Must
+                      rather than defaulting implicitly. Must
                       be a `:client`-platform frame for the compatibility-
-                      check fxs to fire (Spec 011 §The :rf/hydrate event;
-                      a `:server`-platform frame skips them per rf2-7bcn0).
+                      check fxs to fire; a `:server`-platform frame skips them.
                       The payload's `:rf/frame-id` is VALIDATED against
                       this explicit target: a conflict surfaces a
                       structured `:rf.error/hydration-frame-id-mismatch`
-                      (Spec 011 §The hydration payload, EP-0002) rather
+                      rather
                       than silently choosing either side. The payload
                       frame-id is payload metadata + validation evidence,
                       NOT a no-opts target resolver.
@@ -284,8 +220,7 @@
            (rf/init! reagent-adapter/adapter)
            ;; hydrate! seeds app-db AND verifies synchronously (computing
            ;; the client tree via render-tree-fn) BEFORE the host mounts.
-           ;; EP-0002 (rf2-acjknb): the hydration target is CARRIED —
-           ;; supplied explicitly via `:frame`, not synthesised.
+           ;; The hydration target is supplied explicitly via `:frame`.
            (let [payload (ssr/hydrate! {:frame          :app/main
                                         :render-tree-fn #((rf/view :app/root))})]
              (rdc/render react-root
@@ -302,16 +237,13 @@
   `hydrate!` is the convenience that fuses the common (pure-projection)
   ordering for the host whose render-tree is a pure function of app-db
   (the re-frame2 norm — Reagent / UIx / Helix all qualify)."
-  ;; EP-0002 (rf2-acjknb): NO `:or {frame :rf/default}` floor — a nil frame
-  ;; is an absent target that `require-frame-stamp!` (below) fails closed on
-  ;; with `:rf.error/no-frame-context`, never a synthesised `:rf/default`.
+  ;; A nil frame is an absent target, never an implicit `:rf/default`.
   [{:keys [frame payload render-tree-fn element-id]}]
   ;; `element-id` is consumed only by the CLJS DOM read; discard-bind it so
   ;; a JVM lint of this `.cljc` doesn't flag it as an unused
   ;; `:clj`-expansion binding (the read itself stays CLJS-only).
   (let [_       element-id
-        ;; EP-0002 (rf2-acjknb): the client hydration target is CARRIED —
-        ;; supplied explicitly via `:frame`. A nil stamp is an absent target,
+        ;; The client hydration target is supplied explicitly. A nil stamp is an absent target,
         ;; not a request to synthesise `:rf/default`; surface the always-on
         ;; `:rf.error/no-frame-context`. Per Spec 002 §Frame target resolution.
         frame   (frame/require-frame-stamp!
@@ -321,8 +253,7 @@
                                (or element-id constants/payload-script-id))
                        :clj nil))]
     (when payload
-      ;; EP-0002 (rf2-acjknb): the payload's `:rf/frame-id` is the SSR-wire
-      ;; spelling of the server's frame stamp — payload metadata + validation
+      ;; The payload's `:rf/frame-id` is metadata and validation
       ;; evidence, NOT a no-opts target resolver. Validate it against the
       ;; explicit client target: a conflict is a structured mismatch (the
       ;; server hydrated a different frame than the client is installing

--- a/implementation/ssr/src/re_frame/ssr/constants.cljc
+++ b/implementation/ssr/src/re_frame/ssr/constants.cljc
@@ -3,10 +3,7 @@
   bootstrap all reference. Pinning these in one ns (rather than scattered
   literal strings) makes the convention discoverable and renameable —
   tooling that searches for the convention reads one var, not a regex
-  pattern across the codebase.
-
-  Per Spec 011 §Hydration payload script id (audit rf2-cegm7 CQ-3 /
-  rf2-j54ee).")
+  pattern across the codebase. Per Spec 011 §Hydration payload script id.")
 
 (def ^:const payload-script-id
   "The literal `id` the host-adapter HTML shell stamps onto the

--- a/implementation/ssr/src/re_frame/ssr/emit.cljc
+++ b/implementation/ssr/src/re_frame/ssr/emit.cljc
@@ -8,19 +8,16 @@
   live in sibling namespaces (`re-frame.ssr.hash` /
   `re-frame.ssr.response`).
 
-  Source-coord annotation (Spec 006 §Source-coord annotation, rf2-z7f7
-  / rf2-z9n1) is applied here on registered-view roots — the emitter
+  Source-coordinate annotation is applied here on registered-view roots: the emitter
   injects `data-rf2-source-coord=\"<ns>:<sym>:<line>:<col>\"` on the
   view's root DOM element so pair-tool consumers can map server-rendered
   HTML back to the `reg-view` call site.
 
   HTML escape helpers (`escape-html`, `escape-attr`, `attr-string`) live
-  in `re-frame.ssr.html-helpers` — shared with the head/meta emitter per
-  rf2-x7g10. `attr-string` is re-exported below so consumers who
+  in `re-frame.ssr.html-helpers`, shared with the head/meta emitter.
+  `attr-string` is re-exported below so consumers who
   `:require [re-frame.ssr.emit :as emit]` keep seeing it at
-  `emit/attr-string`; the emitter calls `html/escape-html` directly.
-
-  Per the rf2-gxgo7 split of re-frame.ssr."
+  `emit/attr-string`; the emitter calls `html/escape-html` directly."
   (:require [clojure.string]
             [re-frame.error :as error]
             [re-frame.interop :as interop]
@@ -30,14 +27,14 @@
             [re-frame.ssr.html-helpers :as html]
             #?(:cljs [re-frame.substrate.plain-atom :as plain-atom-cljs])))
 
-;; ---- shared HTML helpers (rf2-x7g10) --------------------------------------
+;; ---- shared HTML helpers --------------------------------------------------
 ;;
 ;; Re-export `attr-string` so callers that `:require [re-frame.ssr.emit :as
 ;; emit]` still resolve `emit/attr-string`. The producing ns is
 ;; `re-frame.ssr.html-helpers` (shared with `re-frame.ssr.head.emit`); the
 ;; entity-escape rules live there once. `escape-html` / `escape-attr` are
 ;; consumed directly via the `html/` alias — they have no `emit/`-qualified
-;; consumers (rf2-1i3yea).
+;; consumers.
 
 (def attr-string html/attr-string)
 
@@ -50,12 +47,12 @@
 ;; `re-frame.ssr` — that's the whole point of the slim artefact), so
 ;; the set is duplicated by intent. If HTML5 ever extends the void
 ;; element list (extraordinarily unlikely), update both copies. Per
-;; rf2-6phn + reagent-slim IMPL-SPEC §14.3.
+;; reagent-slim IMPL-SPEC §14.3.
 (def void-elements
   #{:area :base :br :col :embed :hr :img :input :link :meta :param :source
     :track :wbr})
 
-;; ---- raw-text body tags (rf2-ee38b.10) ------------------------------------
+;; ---- raw-text body tags ---------------------------------------------------
 ;;
 ;; `<script>` and `<style>` are HTML "raw text" elements: their content is
 ;; NOT parsed as markup, so the body emitter's `escape-html` (which rewrites
@@ -81,19 +78,14 @@
 ;; raw string child.
 (def ^:private raw-text-tags #{"script" "style"})
 
-;; rf2-z7gor / security audit 2026-05-14 — tag-name injection gate.
-;; `parse-tag-name` historically split the keyword on `#` / `.` and handed
-;; the leading fragment straight to `<...>` / `</...>` emission with no
-;; grammar check. A keyword like `(keyword "img src=x onerror=alert(1)")`
-;; emitted `<img src=x onerror=alert(1)></img src=x onerror=alert(1)>` —
-;; the attribute-name validator was bypassed entirely. We gate the tag
+;; Tag-name injection gate. Gate the tag
 ;; component itself: HTML5 / SVG / MathML element names require an ASCII
 ;; letter start, then letters / digits / hyphens. Reject anything else.
 ;;
 ;; Decision: fail-fast (throw) rather than escape-and-emit. A tag-name
 ;; outside the grammar has no safe wire interpretation — escaping would
 ;; produce `<img&#x20;src=...>` which no browser parses as a tag, just a
-;; visible glyph. Same shape as the rf2-hbty2 header-value gate.
+;; visible glyph.
 ;;
 ;; `:<>` (React fragment) and `:>` (Reagent-native) are special heads
 ;; consumed by `emit-element` BEFORE this validator runs — they never
@@ -107,7 +99,7 @@
   ;; conservative grammar admits both standard elements and well-formed
   ;; custom-element names.
   ;;
-  ;; rf2-77l9w — XML-namespaced SVG/MathML tags carry a single colon-
+  ;; XML-namespaced SVG/MathML tags carry a single colon-
   ;; separated prefix (e.g. `:svg:rect`, `:xlink:href`-style elements).
   ;; Admit one optional `prefix:` segment where the prefix follows the
   ;; same element-name grammar. A single colon only — embedded `<`, `>`,
@@ -119,10 +111,7 @@
 (defn- validate-tag-name!
   "Throw `:rf.error/invalid-tag-name` if `tag-name` does not match the
   HTML5 / SVG / MathML element-name grammar (`[A-Za-z][A-Za-z0-9-]*`,
-  optionally prefixed by a single XML namespace segment `prefix:`).
-  Per rf2-z7gor — DOM tag-name component of a hiccup keyword was emitted
-  without validation, allowing tag-injection through hostile keywords
-  like `(keyword \"img src=x onerror=alert(1)\")`."
+  optionally prefixed by a single XML namespace segment `prefix:`)."
   [tag-name source-kw]
   (when-not (and (string? tag-name)
                  (re-matches tag-name-re tag-name))

--- a/implementation/ssr/src/re_frame/ssr/error_listener.cljc
+++ b/implementation/ssr/src/re_frame/ssr/error_listener.cljc
@@ -4,20 +4,16 @@
   runtime-side glue that ties trace events to the active projector and
   stamps the public-error's `:status` onto the response accumulator.
 
-  Buffered (rather than mutating `:rf/response` inline from the trace
-  listener) because the firing handler's `{:db ...}` return CLOBBERS
-  app-db (replace-container!) AFTER the trace fired — an inline write
-  would be silently overwritten. Buffering + applying at the drain's
-  settle-point (or via `get-response` on demand) sidesteps that race.
-
-  Per the rf2-gxgo7 split of re-frame.ssr."
+  Listeners buffer candidate errors instead of projecting inside the callback.
+  The settle-point drain then chooses the final error, respects redirect
+  precedence, and updates the per-frame response accumulator atomically."
   (:require [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.ssr.error-projector :as error-projector]
             [re-frame.ssr.response :as response]
             [re-frame.trace :as trace]))
 
-;; ---- always-on error-emit helper (EP-0008 rf2-hhutya) ---------------------
+;; ---- always-on error emission ---------------------------------------------
 ;;
 ;; The promoted SSR error categories ride the always-on error-emit axis
 ;; (surface #4) ALONGSIDE the existing dev-gated `trace/emit-error!`. The
@@ -35,31 +31,19 @@
 ;; gate that governs the wire (promotion changes what SHIPPERS see, never
 ;; what the WIRE does).
 ;;
-;; The `emit-always-on-error!` helper itself is SINGLE-SOURCED in
-;; `re-frame.ssr.error-projector` (rf2-50e82k — this ns already :requires
-;; it for the projector); call sites here go through
+;; The `emit-always-on-error!` helper lives in `re-frame.ssr.error-projector`;
+;; call sites here go through
 ;; `error-projector/emit-always-on-error!`.
 
 (defn- candidate-frame-for-error
   "Select the frame to project against for a trace-event: the frame named
   in `[:tags :frame]` when it names a registered server frame, else nil.
 
-  Returns nil when the trace carries no routable server `:frame` — an
-  explicit no-op rather than a guess. Per rf2-7d30s the former
-  single-active-server-frame fallback was REMOVED: under concurrent SSR
-  load many server frames are live simultaneously (the canonical shape —
-  see ssr-ring's concurrency stress test), so guessing the single frame
-  silently mis-attributed (or, with >1 frame live, dropped) the
-  projection — shipping a 200 for a request that should have been a
-  4xx/5xx. Every error-emit site reachable inside a server-frame drain
-  now stamps `[:tags :frame]` from the drain's known frame (audit under
-  rf2-7d30s: core/spec.cljc boundary validation, core/subs reactive
-  sub-exception + sub-override validation, routing navigate/url-change/
-  nav-token; the schemas-artefact validate-*! fns and router miss paths
-  already stamped it), so a trace that arrives here without `:frame` is
-  genuinely unroutable and correctly no-ops — no projector runs, no
-  stray response accumulator is written, and a client-platform error
-  never bleeds into a server response."
+  Returns nil when the trace carries no routable server `:frame`; it never
+  guesses from the set of live frames. Concurrent requests may have many
+  server frames, so fallback attribution could project one request's error
+  onto another response. Error sites inside a drain must stamp the known
+  frame."
   [trace-event]
   (let [tag-frame (get-in trace-event [:tags :frame])]
     (when (and tag-frame (error-projector/server-frame? tag-frame))
@@ -71,17 +55,16 @@
 ;; trace to user observability stacks) yet MUST NOT project a non-200
 ;; status — the request continues with a degraded fragment.
 ;;
-;; `:rf.error/ssr-head-resolution-failed` (rf2-bof8i Option B) is the
+;; `:rf.error/ssr-head-resolution-failed` is the
 ;; canonical member: `resolve-head` degrades a throwing `:head` fn to an
 ;; empty fragment so a buggy head fn "can't take down the request"
 ;; (Spec 011 §1070 + lifecycle/resolve-head docstring). This is the
-;; deliberate, spec-pinned counterpoint to the view/sub fail-closed
-;; posture (rf2-vvwmi / rf2-7d30s, Spec 011 §744/§748-751): a view or
+;; deliberate counterpoint to the view/sub fail-closed posture: a view or
 ;; reactive sub that throws mid-render projects a 5xx because the page is
 ;; unusable; a head fn that throws degrades to a 200 because only the
 ;; `<head>` metadata is missing — the body still renders and hydrates.
 ;;
-;; rf2-lia3i — ENFORCING the contract at the buffering chokepoint (both
+;; Enforcing the contract at the buffering choke point (both
 ;; the dev-only `error-projection-listener` and the always-on
 ;; `error-emit-projection-listener` route through here) makes the
 ;; degraded-200 outcome a PROPERTY OF THE PROJECTOR, not an incidental
@@ -93,7 +76,7 @@
 ;; trace project the default `:rf.error/*` → status and silently flip a
 ;; degraded 200 to a 4xx/5xx. The skip closes that hole by construction.
 ;;
-;; rf2-sccp5 — `:rf.error/ssr-ring-error-view-failed` (ssr-ring's
+;; `:rf.error/ssr-ring-error-view-failed` (ssr-ring's
 ;; `resolve-error-body`, pipeline.clj:228) is the SECOND member of the
 ;; same fragility class. It fires `:op-type :error` for observability
 ;; when a caller's `:error-view` itself throws, and the host falls back
@@ -115,9 +98,7 @@
 ;; and silently flip 4xx→5xx. Skipping it here closes that hole by
 ;; construction — symmetric with the head category, enforced at the same
 ;; chokepoint across both buffering listeners.
-;; EP-0008 (rf2-hhutya) extends the skip set with the two further NON-
-;; PROJECTING SSR categories promoted to the always-on axis (the RULED
-;; "keep categories 2/4/5/6 in the non-projection-eligible skip set"):
+;; Two further non-projecting categories also use the always-on axis:
 ;;
 ;;   `:rf.error/ssr-streaming-writer-failed` — POST-HEAD-COMMIT (the chunked
 ;;   200 is already on the wire on the daemon writer thread; the status can
@@ -141,8 +122,8 @@
   "True when `operation` names a recoverable-degradation error category
   that must NOT be buffered for status projection (it ships its trace for
   observability but the request continues with a degraded fragment).
-  Members: `:rf.error/ssr-head-resolution-failed` (rf2-lia3i) and
-  `:rf.error/ssr-ring-error-view-failed` (rf2-sccp5)."
+  Members include head-resolution, error-view, post-commit writer, and
+  projector-sanitisation failures."
   [operation]
   (contains? non-projection-eligible-errors operation))
 
@@ -158,25 +139,13 @@
 (defonce pending-error-traces (atom {}))
 
 (defn- buffer-error-trace!
-  ;; Keyed by the frame ADDRESS (rf2-bzw8gd) — the shared SSR side-channel
-  ;; keying seam `frame/frame-address` (the bare process-local frame id).
+  ;; All SSR side channels use the process-local frame address.
   [frame-id trace-event]
   (swap! pending-error-traces update (frame/frame-address frame-id)
          (fnil conj []) trace-event))
 
 (defn- consume-pending-traces!
   "Atomically pull and clear the pending error traces for frame-id.
-
-  rf2-hzttr finding 4 — the prior shape DEREF'd the atom, read the
-  frame's traces, then `swap! dissoc`'d the frame in a SEPARATE
-  transition. A `buffer-error-trace!` append for the same frame landing
-  between the deref and the dissoc (concurrent SSR / streaming error
-  paths run many server frames simultaneously — see ssr-ring's
-  concurrency stress test) was silently dropped: the deref missed it,
-  the dissoc then deleted the whole frame key including the just-appended
-  trace. A dropped error trace can lose a fail-closed status upgrade
-  (200 shipped where a 5xx was due) or incomplete diagnostics — exactly
-  the operational path this listener is meant to harden.
 
   `swap-vals!` performs the read and the clear in a SINGLE CAS-retried
   state transition: it returns the `[old new]` pair where `old` is the
@@ -327,10 +296,10 @@
 
 (defn error-projection-listener
   "Dev-only trace-cb listener — captures error trace events bound to a
-  server frame in the per-frame pending-error-traces buffer. Buffering
-  avoids the race where an in-flight handler's `{:db ...}` would clobber
-  an inline :rf/response write. Registered in the `re-frame.ssr` façade
-  under `::error-projection`.
+  server frame in the per-frame pending-error-traces buffer. Projection waits
+  until the settle point so the host observes one last-write-wins result and
+  redirect precedence is applied once. Registered in the `re-frame.ssr`
+  façade under `::error-projection`.
 
   This listener covers the `:rf.error/*` categories that fire through
   `trace/emit-error!`: `:rf.error/no-such-handler`,
@@ -339,18 +308,17 @@
   `interop/debug-enabled? = false`. The production-survivable channel for
   the 500-class errors is `error-emit-projection-listener` (below).
 
-  `:rf.error/sub-exception` ALSO arrives here (it still emits on the dev
-  trace surface), but as of rf2-vvwmi it ALSO rides the always-on
-  substrate below — that is its production status source of truth (a sub
+  `:rf.error/sub-exception` also arrives here and rides the always-on
+  substrate below, which is its production status source of truth (a sub
   throwing mid-`render-to-string` under production hardening must project
   a fail-closed 5xx, not recover to a silent 200). In dev both listeners
   fire for sub-exception — last-write-wins + idempotent projection makes
-  the duplicate benign (rf2-fb598)."
+  the duplicate benign."
   [event]
   (when (= :error (:op-type event))
     (let [op (:operation event)]
       ;; Skip our own sanitisation traces to avoid recursion, and skip
-      ;; recoverable-degradation categories (rf2-lia3i / rf2-sccp5 — e.g.
+      ;; recoverable-degradation categories (for example,
       ;; `:rf.error/ssr-head-resolution-failed`,
       ;; `:rf.error/ssr-ring-error-view-failed`) that must ship their
       ;; trace for observability without projecting a non-200 status.
@@ -360,21 +328,19 @@
           (buffer-error-trace! frame-id event))))))
 
 (defn error-emit-projection-listener
-  "Always-on error-emit-substrate listener (per rf2-fb598 / audit Finding
-  #3) — captures `:rf.error/*` records delivered via
+  "Always-on error-emission listener. Captures `:rf.error/*` records delivered via
   `register-error-listener!` and buffers them onto the per-frame
   pending-error-traces buffer in the same trace-event shape the
   projector consumes.
 
   The error-emit record arrives in the UNION shape `{:error <kw> :frame
-  <id-or-nil> :time <ms> + flat category-specific keys}` (rf2-hhutya /
-  rf2-ini4wr — the shared non-event always-on shape). The event-centric
+  <id-or-nil> :time <ms> + flat category-specific keys}`. The event-centric
   `dispatch-on-error!` path carries `:event` / `:event-id` / `:elapsed-ms`
-  / `:source-coord`; the EP-0008 SSR promotions carry `:exception` /
+  / `:source-coord`; other SSR records carry `:exception` /
   `:phase` / `:reason` / `:projector-id` / … instead. We synthesise the
   `{:operation :op-type :tags}` envelope the existing projector pipeline
   expects — symmetric with the trace-cb delivery — by lifting EVERY
-  non-`:error` slot onto `:tags` GENERICALLY (rf2-hhutya), so a custom
+  non-`:error` slot onto `:tags` generically, so a custom
   projector reading `(get-in event [:tags :exception])` sees the same keys
   on this always-on path as on the trace-cb path regardless of which
   category was promoted. `:operation` is the record's `:error`; `:recovery`
@@ -382,15 +348,14 @@
 
   Registered in the `re-frame.ssr` façade under `::error-projection`.
   Survives `interop/debug-enabled? = false` — Spec 011 §Server error
-  projection holds under production hardening (rf2-vnjfg)."
+  projection holds when development tracing is disabled."
   [record]
   (let [op (:error record)]
     ;; Symmetric with the trace-cb guard above — refuse our own
-    ;; sanitisation records to avoid recursion. (As of rf2-fb598
-    ;; `:rf.error/sanitised-on-projection` is not delivered through the
-    ;; error-emit substrate, but keep the guard so a future routing
+    ;; sanitisation records to avoid recursion. The record is not currently
+    ;; delivered through this substrate, but keep the guard so a future routing
     ;; change can't reintroduce a re-entrant projection.) Also refuse
-    ;; recoverable-degradation categories (rf2-lia3i / rf2-sccp5 —
+    ;; recoverable-degradation categories such as
     ;; `:rf.error/ssr-head-resolution-failed`,
     ;; `:rf.error/ssr-ring-error-view-failed`): if a future host-adapter
     ;; change routes a recoverable-degradation trace through the always-on
@@ -402,24 +367,18 @@
     (when-not (or (= :rf.error/sanitised-on-projection op)
                   (non-projection-eligible-error? op))
       (let [;; The error-emit record carries the frame on its flat `:frame`
-            ;; slot directly. Per rf2-7d30s every error-emit site reachable
-            ;; inside a server-frame drain stamps that slot from the
+            ;; slot directly. Every error site reachable inside a server-frame
+            ;; drain stamps that slot from the
             ;; drain's known frame; a record with no routable server frame
-            ;; correctly no-ops (no projector runs, no stray status). Per
-            ;; rf2-mn4rd the former `candidate-frame-for-error` fallback was
-            ;; dead: it read `[:tags :frame]` on the synthesised event,
-            ;; which IS `(:frame record)` re-applied through the same
-            ;; `server-frame?` predicate — so it could never yield a frame
-            ;; the direct check below had not already accepted.
+            ;; correctly no-ops (no projector runs, no stray status).
             direct-frame-id (:frame record)
             ;; Synthesise a trace-event-shaped envelope GENERICALLY
-            ;; (rf2-hhutya): the projector reads `(:operation event)` and
+            ;; The projector reads `(:operation event)` and
             ;; tag-shaped custom projectors read `(get-in event [:tags …])`.
             ;; Lift EVERY non-`:error` slot of the union record onto `:tags`
             ;; — both the event-centric `dispatch-on-error!` slots
             ;; (`:event` / `:event-id` / `:elapsed-ms` / `:source-coord`)
-            ;; AND the flat category-specific slots the EP-0008 SSR
-            ;; promotions carry (`:exception` / `:phase` / `:reason` /
+            ;; and flat category-specific slots (`:exception` / `:phase` / `:reason` /
             ;; `:projector-id` / …). `:recovery` defaults to `:no-recovery`
             ;; when the record didn't supply one. Generic-lift means a newly
             ;; promoted category's tags ride through without re-listing each
@@ -480,6 +439,6 @@
 (defn clear-pending-error-traces!
   "Drop frame-id's entry from the pending-error-traces buffer.
   Called from `re-frame.ssr.request/on-frame-destroyed!`. Keyed by the frame
-  ADDRESS (rf2-bzw8gd)."
+  address."
   [frame-id]
   (swap! pending-error-traces dissoc (frame/frame-address frame-id)))

--- a/implementation/ssr/src/re_frame/ssr/error_projector.cljc
+++ b/implementation/ssr/src/re_frame/ssr/error_projector.cljc
@@ -24,9 +24,7 @@
   The trace-listener side (buffer + drain + `get-response`) lives in
   `re-frame.ssr.error-listener`. This namespace stays effect-free
   (apart from registering the built-in default projector) so the
-  projector logic can be exercised standalone.
-
-  Per the rf2-gxgo7 split of re-frame.ssr."
+  projector logic can be exercised standalone."
   (:require [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
@@ -34,7 +32,7 @@
             [re-frame.source-coords :as source-coords]
             [re-frame.trace :as trace]))
 
-;; ---- always-on error-emit helper (EP-0008 rf2-hhutya) ---------------------
+;; ---- always-on error emission ---------------------------------------------
 ;;
 ;; `:rf.error/sanitised-on-projection` fires when the active projector
 ;; itself throws or returns a non-conforming shape and the runtime falls
@@ -45,7 +43,7 @@
 ;; the public boundary fell back to the generic-500 shape") TRUE under
 ;; `-Dre-frame.debug=false`, where it is currently undeliverable.
 ;;
-;; RE-ENTRY GUARD (rf2-hhutya RULED): this emit is the FALLBACK path itself.
+;; Re-entry guard: this emit is the fallback path itself.
 ;; It MUST be one-shot and MUST never re-enter projection. Two facts close
 ;; that by construction: (1) `error-emit-projection-listener` (the always-on
 ;; status-projection buffering listener) explicitly SKIPS
@@ -64,12 +62,9 @@
   `error-emit` producer hasn't loaded (the hook is nil) — the dev
   `trace/emit-error!` companion still fires. Returns nil.
 
-  SINGLE SOURCE within the ssr artefact (rf2-50e82k): both the projector
-  (`project-error`) and the listener (`re-frame.ssr.error-listener`, which
-  already :requires this ns) call this one definition, closing the drift
-  risk on the `:error-emit/dispatch-error-record` hook keyword + the
-  nil-return contract. (The ssr-ring artefact keeps its own local wrapper
-  in `re-frame.ssr.ring.lifecycle` — a deliberate artefact boundary.)"
+  Both the projector and listener call this definition so the hook keyword and
+  nil-return contract cannot drift. The ssr-ring artefact keeps a local wrapper
+  to preserve the artefact boundary."
   [record]
   (when-let [dispatch-error-record! (late-bind/get-fn :error-emit/dispatch-error-record)]
     (dispatch-error-record! record))
@@ -112,18 +107,15 @@
     anything else                              → 500 :internal-error
                                                  (fallback-public-error)
 
-  `:rf.error/cofx-value-invalid` is a CLIENT-INPUT fault (rf2-57ehvw): a
+  `:rf.error/cofx-value-invalid` is a client-input fault: a
   non-recordable / out-of-`:schema` `:rf.cofx` value that entered through
   the dispatch boundary — the surface through which client-supplied
-  coeffects arrive (EP-0017:386; per Spec 011 §Default projector). It is
-  the current category that replaced the retired
-  `:rf.error/schema-validation-failure :where :cofx` shape (the
-  injection-time cofx-validation path was retired), so it earns its own
+  coeffects arrive. It earns its own
   unconditional 400 arm — a bad client coeffect is bad client input, a
   400, never a server-fault 500.
 
   The `:rf.error/schema-validation-failure` 400 arm is GATED on the
-  failure's `:where` tag (rf2-37o5by). It is client-facing — a 400
+  failure's `:where` tag. It is client-facing — a 400
   `:bad-request` — only when the rejected value entered through the
   client-supplied EVENT payload surface (`:where :event`), per Spec 011
   §Default projector. Server-side schema surfaces — notably server-fx

--- a/implementation/ssr/src/re_frame/ssr/hash.cljc
+++ b/implementation/ssr/src/re_frame/ssr/hash.cljc
@@ -5,20 +5,18 @@
   the hash on first render and compares. Mismatch = the runtime emits
   `:rf.ssr/hydration-mismatch` with both hashes. FNV-1a 32-bit over the
   canonical-EDN traversal of the render tree, output as lowercase hex.
-  Same algorithm both sides → byte-identical hashes for byte-identical
-  canonical EDN.
-
-  Per the rf2-gxgo7 split of re-frame.ssr."
+  Same algorithm both sides means byte-identical hashes for byte-identical
+  canonical EDN."
   (:require [clojure.string]))
 
-;; Audit rf2-asmj1 P6 / cluster rf2-sljs1 — reflection-warning gate.
+;; Reflection warnings guard the primitive JVM hash loop against boxing.
 ;; The JVM-side `fnv-1a-32` uses `.getBytes` + an `aget` loop with
 ;; primitive math; a reflection warning here would flag accidental
 ;; boxing introduced by future refactors. CLJS has no reflection
 ;; concept — the directive is JVM-only.
 #?(:clj (set! *warn-on-reflection* true))
 
-;; ---- canonical-EDN walker (rf2-8otin / rf2-atmvj) -------------------------
+;; ---- canonical-EDN walker -------------------------------------------------
 ;;
 ;; Single-pass mutually-recursive walker (`canonical-edn-into`): each
 ;; canonical fragment appends into a per-call `StringBuilder` on JVM /
@@ -38,7 +36,7 @@
   "Cross-runtime-stable print form of a number — shared by the render-tree
   hash (`canonical-edn-into`'s numeric leaf) and the HTML emitter
   (`re-frame.ssr.emit`'s number branch) so the hash and the emitted markup
-  stay byte-consistent (rf2-0ypnnk).
+  stay byte-consistent.
 
   ClojureScript has only IEEE doubles: it unifies a whole-valued double to
   an integer (`1.0` IS the JS number 1, printing `\"1\"`) and has no ratio
@@ -49,8 +47,7 @@
 
     - a whole-valued double/float within IEEE exact-integer range prints as
       its integer form (no trailing `.0`), matching CLJS;
-    - a `Ratio` prints as its IEEE-double form (mirroring the head emitter's
-      rf2-8jl26 ratio coercion, and a CLJS view that computed the same value
+    - a `Ratio` prints as its IEEE-double form (mirroring a CLJS view that computed the same value
       by division);
     - every other number keeps its default `pr-str` form — integers and
       common decimals already agree across runtimes, and `pr-str`/`str`
@@ -283,7 +280,7 @@
          (canonical-edn-into sb x)
          (.join sb "")))))
 
-;; Per rf2-t7ktb: FNV-1a runs over a UTF-8 byte stream on BOTH sides.
+;; FNV-1a runs over a UTF-8 byte stream on both sides.
 ;; Why UTF-8 bytes, not UTF-16 code units?
 ;;
 ;;   - JVM uses primitive `byte[]` + `aget` — no boxing per step, ~3-5×
@@ -343,7 +340,7 @@
   of the render tree. Deterministic across JVM and CLJS for trees with
   identical canonical-EDN representation.
 
-  Single-pass (rf2-8otin) — feeds the canonical-EDN walker into one
+  Single-pass: feeds the canonical-EDN walker into one
   accumulator and byte-hashes the result once. The streaming walker
   emits byte-identical output to the prior tree-shaped-intermediates
   shape; the parity-pinned literals at `re-frame.ssr.hash-parity-fixtures`

--- a/implementation/ssr/src/re_frame/ssr/head.cljc
+++ b/implementation/ssr/src/re_frame/ssr/head.cljc
@@ -1,14 +1,11 @@
 (ns re-frame.ssr.head
   "Head/meta contract façade — `reg-head`, `render-head`, `active-head`,
-  `head-model->html`, `head-snapshot`. Per Spec 011 §Head/meta contract
-  (rf2-4dra9).
+  `head-model->html`, and `head-snapshot`.
 
   The server-rendered HTML must carry head metadata — `<title>`,
   `<meta>`, `<link>`, JSON-LD — on first byte; crawlers and link-
   unfurlers don't run JS. The pattern's commitment: **the head model
   is data derived from app-db**, not an imperative DOM API.
-
-  ---- file split (rf2-x7g10) ----
 
   The head module decomposes into three concern-per-file siblings + a
   shared HTML-helpers ns:
@@ -75,7 +72,7 @@
 ;;
 ;; `re-frame.ssr/on-frame-destroyed!` (under the `:ssr/on-frame-destroyed`
 ;; late-bind hook) clears `pending-error-traces`, `request-slots`, and
-;; `response-slots` per rf2-fcj33 + rf2-jbcmt. The head ns adds per-frame
+;; `response-slots`. The head namespace adds per-frame
 ;; head-snapshot cleanup; we surface our cleanup via a separate
 ;; `:ssr/head-on-frame-destroyed` hook that `re-frame.ssr`'s teardown
 ;; fn looks up and invokes.

--- a/implementation/ssr/src/re_frame/ssr/head/emit.cljc
+++ b/implementation/ssr/src/re_frame/ssr/head/emit.cljc
@@ -1,6 +1,5 @@
 (ns re-frame.ssr.head.emit
-  "Canonical-order head-model → HTML fragment emitter. Per Spec 011
-  §Default flow step 4 and the rf2-x7g10 split of `re-frame.ssr.head`.
+  "Canonical-order head-model → HTML fragment emitter.
 
   The emit half of the head/meta contract — pure functions that turn a
   `:rf/head-model` map into the inner-head HTML fragment in canonical
@@ -22,7 +21,7 @@
             [re-frame.error :as error]
             [re-frame.ssr.html-helpers :as html]))
 
-;; Audit rf2-asmj1 P6 / cluster rf2-sljs1 — reflection-warning gate.
+;; Reflection warnings guard the hand-rolled JVM JSON emitter.
 ;; The JVM-side `ld-json-string` is hand-rolled JSON emission; the
 ;; directive flags any accidental boxing introduced by future refactors.
 ;; CLJS has no reflection concept — the directive is JVM-only.
@@ -53,11 +52,9 @@
 
   On the JVM side, keyword keys and keyword values are both serialised
   to their fully-qualified name — `:my.app/foo` → `\"my.app/foo\"` — so
-  namespaces survive serialisation. The key and value handling are
-  symmetric; rf2-a50nz fixed an earlier asymmetry that quietly stripped
-  the namespace prefix off keys.
+  namespaces survive serialisation. Key and value handling are symmetric.
 
-  Script-body safety (rf2-m5u23, security audit 2026-05-14 §P1.1) —
+  Script-body safety:
   every `<` inside string contents is escaped as the JSON `\\u003c`
   Unicode escape via `html/escape-script-body-string`, so a string
   value containing `</script>` cannot close the surrounding
@@ -70,7 +67,7 @@
   #?(:cljs (-> (js/JSON.stringify (clj->js x))
                html/escape-script-body-string)
      :clj  (letfn [(emit-number [v]
-                     ;; rf2-8jl26 — `(str v)` produces non-JSON for two
+                     ;; `(str v)` produces non-JSON for two
                      ;; numeric shapes the JVM admits but JSON.parse rejects:
                      ;;   • Ratios print as `1/3` — coerce to a double so the
                      ;;     wire form is `0.3333333333333333`.
@@ -93,7 +90,7 @@
                           :extra    {:value v}})
                        :else (str v)))
                    (escape-json-control [^String s]
-                     ;; rf2-hzttr finding 1 — JSON requires every control
+                     ;; JSON requires every control
                      ;; char (U+0000..U+001F) inside a string literal to be
                      ;; escaped; a raw newline/tab/CR in a `<script
                      ;; type="application/ld+json">` body is INVALID JSON
@@ -129,13 +126,13 @@
                               (str/replace "\\" "\\\\")
                               (str/replace "\"" "\\\"")
                               escape-json-control
-                              ;; rf2-m5u23 — escape `<` so user-controlled
+                              ;; Escape `<` so user-controlled
                               ;; string contents can't close the
                               ;; surrounding <script>.
                               html/escape-script-body-string)
                           "\""))
                    (emit-key [k]
-                     ;; rf2-ee38b.10 — JSON object keys MUST be quoted
+                     ;; JSON object keys must be quoted
                      ;; strings. `js/JSON.stringify` (the CLJS branch)
                      ;; coerces every key to a string; the JVM branch must
                      ;; match or the two reader-conditional arms diverge on

--- a/implementation/ssr/src/re_frame/ssr/head/registry.cljc
+++ b/implementation/ssr/src/re_frame/ssr/head/registry.cljc
@@ -1,7 +1,5 @@
 (ns re-frame.ssr.head.registry
-  "Head/meta contract — registry, render, active, default, per-frame
-  snapshot. Per Spec 011 §Head/meta contract (rf2-4dra9) and the
-  rf2-x7g10 split of `re-frame.ssr.head`.
+  "Head/meta registry, rendering, defaults, and per-frame snapshots.
 
   Public surface (re-exported from the `re-frame.ssr.head` façade):
 
@@ -29,7 +27,7 @@
 ;;
 ;; A side-channel atom keyed by frame-id, mapping `head-id → last-produced
 ;; head-model`. Cleared on per-request frame destroy via the
-;; `:ssr/on-frame-destroyed` hook (rf2-fcj33). Storage shape mirrors the
+;; `:ssr/on-frame-destroyed` hook. Storage shape mirrors the
 ;; pattern used by `re-frame.ssr/pending-error-traces` and
 ;; `re-frame.ssr/request-slots` — the data is per-request bookkeeping
 ;; that has no place in app-db (and must not ride the hydration payload
@@ -45,8 +43,7 @@
 (defn- record-fragment!
   "Stash the just-produced head-model under (frame-address, head-id) so
   `head-snapshot` reflects the most recent render-head output. Keyed by the
-  frame ADDRESS (rf2-bzw8gd) — the shared SSR side-channel keying seam
-  `re-frame.frame/frame-address` (the bare process-local frame id)."
+  process-local frame address shared by all SSR side channels."
   [frame-id head-id head-model]
   (when frame-id
     (swap! head-snapshots assoc-in [(frame/frame-address frame-id) head-id]
@@ -57,16 +54,14 @@
   "Read the per-frame `{head-id → last-produced head-model}` snapshot.
   Useful for tests and introspection. Returns `{}` for a frame that has
   never seen a `render-head` call (or whose snapshot has been cleared
-  via the per-request frame teardown hook). Keyed by the frame ADDRESS
-  (rf2-bzw8gd)."
+  via the per-request frame teardown hook)."
   [frame-id]
   (get @head-snapshots (frame/frame-address frame-id) {}))
 
 (defn on-frame-destroyed!
   "Clear the head-snapshot entry for `frame-id`. Wired into the
   `:ssr/on-frame-destroyed` late-bind hook chain so per-request frames
-  release their head bookkeeping on destroy. Idempotent. Keyed by the frame
-  ADDRESS (rf2-bzw8gd)."
+  release their head bookkeeping on destroy. Idempotent."
   [frame-id]
   (swap! head-snapshots dissoc (frame/frame-address frame-id))
   nil)
@@ -113,7 +108,7 @@
   emitter elides empty strings), but a programmatic consumer reading
   the model sees a stable key shape.
 
-  Does NOT carry `{:charset \"utf-8\"}` (rf2-q78s1). Charset is an
+  Does not carry `{:charset \"utf-8\"}`. Charset is an
   envelope concern owned by the shell — the always-present document
   envelope (`re-frame.ssr.ring.shell/default-html-shell` and the
   streaming prefix) hardcodes `<meta charset=\"utf-8\">` as the first
@@ -130,8 +125,7 @@
 
 (defn- frame-route
   "Read the route slice from a frame's RUNTIME-DB at
-  `[:rf.runtime/routing :current]` (EP-0001 rf2-vzld77 — the route slice is
-  durable routing runtime-db state). nil-safe — a frame whose runtime-db has
+  `[:rf.runtime/routing :current]`. Nil-safe: a frame whose runtime-db has
   never been written resolves to nil."
   [frame-id]
   (when frame-id
@@ -143,7 +137,7 @@
   caller-facing `render-head` carries the documented two-shape contract
   on its signature and delegates the work here.
 
-  EP-0002 (rf2-acjknb): the head fn reads the frame's app-db (and, unless
+  The head fn reads the frame's app-db and, unless
   `:route` is supplied, the frame's runtime-db route slice), so a frame is
   the carried target — an absent `:frame` stamp emits + throws
   `:rf.error/no-frame-context` (no `:rf/default`-against-absence

--- a/implementation/ssr/src/re_frame/ssr/html_helpers.cljc
+++ b/implementation/ssr/src/re_frame/ssr/html_helpers.cljc
@@ -11,18 +11,14 @@
                                     emit double-quoted values, so only
                                     `&` and `\"` matter).
     - `escape-script-body-string`— escape `<` as `\\u003c` for strings
-                                    dropped inside `<script>` bodies
-                                    (security audit 2026-05-14 §P1.1,
-                                    rf2-7ksyr + rf2-m5u23). JSON bodies
+                                    dropped inside `<script>` bodies. JSON bodies
                                     only — every `<` is in a string.
     - `escape-edn-script-body`   — EDN-aware `<script>`-body escape for
                                     the hydration payload / streaming
                                     delta: `<` escaped only inside string
                                     literals (tokens with `<` round-trip;
-                                    `</`/`<!` token breakouts fail loud)
-                                    (rf2-rdxxa).
-    - `validate-attr-name!`      — HTML5-grammar gate on attribute keys
-                                    (security audit §P2.5, rf2-vl8ir).
+                                    `</`/`<!` token breakouts fail loud).
+    - `validate-attr-name!`      — HTML5-grammar gate on attribute keys.
     - `attr-string`              — render an attribute map as
                                     ` k1=\"v1\" k2=\"v2\"`. Boolean `true`
                                     → bare attribute name (`disabled`);
@@ -210,7 +206,7 @@
             :else
             (recur (inc i) false false (conj! acc c))))))))
 
-;; HTML5 attribute-name grammar (rf2-vl8ir / security audit §P2.5).
+;; Conservative HTML5 attribute-name grammar.
 ;; The spec's full production permits almost anything except whitespace,
 ;; `=`, quotes, `<`, `>`, `/`. We use a deliberately narrower form here:
 ;; first char is an ASCII letter, subsequent chars are letters / digits
@@ -244,15 +240,14 @@
         {:recovery :rename-the-attribute-key
          :extra    {:attribute k}}))))
 
-;; Prototype-pollution keys (rf2-dwds9 / security audit §XSS at output
-;; boundaries). These three names, if they reach the underlying host's
+;; Prototype-pollution keys. These three names, if they reach the host's
 ;; `createElement`-equivalent on the client at hydration, can poison
 ;; `Object.prototype`. They are dropped at static-markup emission before
 ;; they ever land in the wire props map.
 (def ^:private reserved-prop-keys
   #{"__proto__" "constructor" "prototype"})
 
-;; `on*` event-handler-prop matcher (rf2-dwds9 / rf2-1uex4). Two layers,
+;; `on*` event-handler-prop matcher. Two layers,
 ;; both applied to the attribute name, together covering every casing a
 ;; case-insensitive HTML parser fires:
 ;;
@@ -288,8 +283,8 @@
 ;; §"Event handlers on elements, Document objects, and Window objects",
 ;; plus the IDL `on*` attributes on Window/Document/Element), and the
 ;; W3C Touch Events Level 2 §8 `GlobalEventHandlers` touch attributes
-;; (`ontouchstart` / `ontouchmove` / `ontouchend` / `ontouchcancel` —
-;; rf2-cv165: the structural regex only catches the camelCase/kebab
+;; (`ontouchstart` / `ontouchmove` / `ontouchend` / `ontouchcancel`).
+;; The structural regex only catches the camelCase/kebab
 ;; spellings, so the lower-case canonical touch names MUST be enumerated
 ;; here or they ride through as live attributes on touch-capable
 ;; browsers — an XSS-equivalent gap of the same class as `:onclick`). All
@@ -329,7 +324,7 @@
 
 (defn- event-handler-name?
   "True when attribute name `nm` denotes an `on*` event-handler prop that
-  MUST be stripped at SSR static-markup emission (rf2-dwds9 / rf2-1uex4).
+  must be stripped at SSR static-markup emission.
 
   Matches either the structural camelCase/kebab handler spellings
   (`event-handler-name-re`, case-insensitive) — so framework-shaped
@@ -345,9 +340,8 @@
 
 ;; JSX source-coord props. React DevTools' "View source" gesture reads
 ;; `_jsxFileName` / `_jsxLineNumber` / `_jsxColumnNumber` off the
-;; rendered React element. The framework no longer emits these — see
-;; Spec 006 §Historical: JSX source-coord props (rf2-rohdn dropped the
-;; rf2-fa4ly injection) — but user code, JSX-compiled third-party
+;; rendered React element. The framework does not emit them, but user code,
+;; JSX-compiled third-party
 ;; libraries, or hand-stamped DevTools shims may still produce hiccup
 ;; carrying them. SSR MUST NOT serialise them as wire HTML attributes:
 ;; the leading underscore fails the conservative HTML5 attribute-name
@@ -365,7 +359,7 @@
 
 (defn strip-prop?
   "True when the attribute `[k v]` MUST be dropped at SSR static-markup
-  emission per Spec 011 rule rf2-dwds9:
+  emission:
 
     - `on*` event-handler props (`:on-click`, `:onMouseDown`,
       `:onclick`, `:ONLOAD`, …). The client-side substrate adapters

--- a/implementation/ssr/src/re_frame/ssr/http_validation.cljc
+++ b/implementation/ssr/src/re_frame/ssr/http_validation.cljc
@@ -4,18 +4,10 @@
   host adapter's Set-Cookie materialiser (`re-frame.ssr.ring.cookie`)
   both enforce.
 
-  Per the security audit 2026-05-14 (rf2-hbty2 header-value gate,
-  rf2-z7gor header-name + cookie gates at the fx boundary, rf2-rpedl
-  cookie-attribute gate at the materialiser): the same two grammars are
-  enforced at TWO boundaries — the SSR fx boundary (so non-Ring host
-  adapters get the gate with the dispatching event in scope) AND the Ring
-  materialiser (so the wire write is portable across servers whose own
-  CR/LF defences differ). Both boundaries are deliberate (defence in
-  depth); what is NOT deliberate is the regexes drifting apart. Before
-  this ns the two regexes lived as byte-identical copies in
-  `re-frame.ssr.response` and `re-frame.ssr.ring.cookie`, each carrying a
-  comment that a fix to one MUST track the other — a copy-paste security
-  surface. Single-sourcing them here removes that drift risk.
+  The same grammars are enforced at two boundaries: the SSR fx boundary,
+  where the dispatching event is still in scope, and the Ring materialiser,
+  immediately before bytes reach the host. Keeping the predicates here makes
+  that defence-in-depth policy portable without duplicating the grammars.
 
   Two grammars:
 
@@ -42,9 +34,8 @@
   `:rf.error/cookie-invalid-attribute` with
   `:where 'rf.ssr/cookie->set-cookie-header`. Both boundaries emit the SAME
   catalogued `:rf.error/cookie-invalid-attribute` for the injection class
-  (rf2-xrk4w1 — the offending attribute rides the `:attribute` payload slot,
-  not a per-attribute error id); the decision is shared, the diagnostics are
-  local."
+  with the offending attribute in the `:attribute` payload slot. The decision
+  is shared; the layer-specific diagnostics remain local."
   (:require [clojure.string]))
 
 #?(:clj (set! *warn-on-reflection* true))

--- a/implementation/ssr/src/re_frame/ssr/hydrate.cljc
+++ b/implementation/ssr/src/re_frame/ssr/hydrate.cljc
@@ -8,16 +8,14 @@
   can read it after the client's first render.
 
   Also defines the two `:rf.ssr/check-*` compatibility-check fxs the
-  hydrate handler dispatches (rf2-69ad2) — best-effort version +
+  hydrate handler dispatches — best-effort version and
   schema-digest comparison whose mismatch emits a structured warning
   trace without crashing the hydration path.
 
   All `reg-event` / `reg-fx` calls live in the `re-frame.ssr`
   façade so a `(require 're-frame.ssr :reload)` after
   `(registrar/clear-all!)` re-installs them. This namespace exports
-  the handler fns only.
-
-  Per the rf2-gxgo7 split of re-frame.ssr."
+  the handler fns only."
   (:require [clojure.string :as str]
             [re-frame.error :as error]
             [re-frame.frame :as frame]
@@ -35,7 +33,7 @@
   the hydrate handler to avoid dispatching `:rf.ssr/check-*` fxs on a
   server-side `:rf/hydrate` (test harness, isomorphic loopback), where
   the fx's own `:platforms #{:client}` gate would otherwise emit a
-  `:rf.fx/skipped-on-platform` warning per check (rf2-7bcn0)."
+  `:rf.fx/skipped-on-platform` warning per check."
   [frame-id]
   (let [resolved (or (some-> frame-id frame/frame :config :platform)
                      (interop/active-platform))]
@@ -55,7 +53,7 @@
        "); hydration rejected — the client frame-state is left unchanged"))
 
 (defn- malformed-hydration-payload!
-  "Fail-CLOSED guard for the `:rf/hydrate` boundary (rf2-gro94, rf2-g00l2t).
+  "Fail-closed guard for the `:rf/hydrate` boundary.
   The payload is a DESERIALISED, UNTRUSTED transport input (the server's
   `pr-str`'d EDN, round-tripped through `cljs.reader/read-string` at the
   boot site). `:replace-frame-state` is the locked merge policy (Spec 011
@@ -92,11 +90,10 @@
     (slice-malformed-reason :rf/app-db (:rf/app-db payload))
 
     ;; The `:rf/runtime-db` slice KEY is present but its value is not a
-    ;; map. EP-0001 (rf2-vzld77): hydration installs a coherent
-    ;; FRAME-STATE — `:rf/runtime-db` becomes the runtime-db partition
+    ;; map. Hydration installs a coherent frame state: `:rf/runtime-db`
+    ;; becomes the runtime-db partition
     ;; (machine snapshots, route slice, SSR metadata). A present-but-non-map
-    ;; runtime-db is rejected the same way as app-db (rf2-g00l2t closed the
-    ;; fail-OPEN where it was silently coerced to nil and dropped). A
+    ;; runtime-db is rejected the same way as app-db. A
     ;; wholly-absent key is the legitimate no-server-runtime fallback.
     (and (contains? payload :rf/runtime-db)
          (not (map? (:rf/runtime-db payload))))
@@ -105,13 +102,13 @@
     :else nil))
 
 (defn- frame-id-mismatch-reason
-  "Fail-CLOSED guard for the `:rf/hydrate` boundary (rf2-nv3mua). Returns a
+  "Fail-closed guard for the `:rf/hydrate` boundary. Returns a
   reason string when the payload's `:rf/frame-id` is PRESENT-and-DIFFERENT
   from the frame the dispatch is installing into (`target` — the
   `:rf.frame/id` coeffect), nil otherwise.
 
   The payload's `:rf/frame-id` is the SSR-wire spelling of the frame the
-  SERVER rendered under (Spec 011 §The hydration payload, EP-0002):
+  server rendered under:
   payload metadata + frame-isolation evidence, NOT a no-opts target
   resolver. The boot helper `re-frame.ssr.boot/hydrate!` validates it
   against the explicit `:frame` target BEFORE dispatching (and THROWS on a
@@ -120,8 +117,7 @@
   target}` as the split path for hosts that verify the mounted DOM
   themselves, so the boundary is not purely private: a direct dispatch
   bypassed the boot check and silently installed the payload into `target`
-  even when `:rf/frame-id` named a DIFFERENT frame — defeating the
-  frame-isolation evidence the payload carries (rf2-nv3mua). The check is
+  even when `:rf/frame-id` named a different frame. The check is
   therefore enforced HERE, at the handler boundary BOTH paths cross, so a
   manual boot / custom host cannot hydrate the wrong frame.
 
@@ -146,25 +142,23 @@
   "Emit a fail-closed `:rf/hydrate` rejection on BOTH the dev-trace axis
   (gated by `interop/debug-enabled?`) and the always-on error-emit axis
   (UNGATED, via the `:error-emit/dispatch-error-record` late-bind hook).
-  Factored out (rf2-nv3mua) so the malformed-payload guard
-  (`:rf.error/malformed-hydration-payload`) and the frame-id-mismatch guard
+  Shared by the malformed-payload guard and the frame-id-mismatch guard
   (`:rf.error/hydration-frame-id-mismatch`) surface identically — each is a
   fail-closed BOUNDARY rejection of an untrusted payload, not a dev teaching
   diagnostic, so an off-box shipper on a `goog.DEBUG=false` client build
-  (dev trace elided) must still see it (EP-0008 rf2-hhutya). `extra` is
+  (development trace elided) must still see it. `extra` is
   merged onto the always-on record (the frame-id guard carries
   `:target-frame` / `:payload-frame-id`, mirroring the boot helper's thrown
   ex-data); the dev-trace tags carry it too so Xray sees the same shape.
 
-  EGRESS CHOKE-POINT (rf2-7qbxbm / rf2-mrtis6 census B5): `extra` lifts
+  Egress choke point: `extra` lifts
   values OUT OF the DESERIALISED, UNTRUSTED hydration payload — the
   frame-id-mismatch guard stamps `:payload-frame-id (:rf/frame-id payload)`,
   a value the adversary-controllable wire put there. The always-on record
   fans out to corpus listeners (Sentry / Datadog) raw `by contract`, so a
   payload value placed in `extra` would egress off-box UNREDACTED — the
-  identical `forgot to route through the projector` gap the conformance
-  ratchet (rf2-mrtis6) governs, on the SSR no-bead leg the design census
-  surfaced. So the untrusted `extra` slots route THROUGH the centralized
+  same leakage class as any unprojected error payload. The untrusted `extra`
+  slots route through the centralized
   record-level boundary primitive `re-frame.projection/project-egress` (over
   the shared `elide-wire-value` walker — Security.md §The privacy surface:
   per-tool reimplementation prohibited; sinks consume already-projected
@@ -172,7 +166,7 @@
   rejected `frame`, BEFORE the record fans out. A frame that declares the
   `:payload-frame-id` path `:sensitive` redacts it; an unresolvable /
   FRAMELESS frame fails CLOSED (the whole `extra` value redacts to
-  `:rf/redacted` rather than ride raw — EP-0002 / EP-0015 issue 1). The
+  `:rf/redacted` rather than ride raw). The
   dev-trace axis (DCE'd in production) keeps the raw `extra` + raw `:reason`
   for local Xray fidelity — the leak is off-box, not the local trace.
 
@@ -194,8 +188,8 @@
                :recovery   :no-recovery}]
      (when interop/debug-enabled?
        (trace/emit-error! error-id (merge base extra)))
-     ;; EP-0008 (rf2-hhutya): the hydrate-handler shape-guard path
-     ;; (frame EXISTS) rides the always-on axis ALONGSIDE the dev trace.
+     ;; The frame-scoped shape guard rides the always-on axis alongside the
+     ;; development trace.
      ;; UNGATED. Union record shape via the late-bind hook. (The PRE-FRAME
      ;; parse failure in `boot/read-server-payload` is the FRAMELESS sibling
      ;; of this same category.)
@@ -235,11 +229,11 @@
   "Handler fn for the `:rf/hydrate` event. Replaces app-db with
   `(:rf/app-db payload)`, stashes server-hash + version under
   `[:rf.runtime/ssr :hydration]`, and dispatches the two
-  `:rf.ssr/check-*` fxs when the resolved platform is `:client` (per
-  rf2-7bcn0 — server-side `:rf/hydrate` skips them to avoid
+  `:rf.ssr/check-*` fxs when the resolved platform is `:client`; server-side
+  hydration skips them to avoid
   `:rf.fx/skipped-on-platform` noise).
 
-  Per rf2-gro94 the handler fails CLOSED on a malformed (deserialised,
+  The handler fails closed on a malformed, deserialised
   untrusted) payload: a non-map payload, or a present-but-non-map app-db
   slice, is REJECTED — the existing client app-db is left unchanged and a
   `:rf.error/malformed-hydration-payload` diagnostic is emitted (carrying
@@ -247,7 +241,7 @@
   :rf/hydrate event — degraded-but-running), so a corrupt payload must
   never silently install garbage as the whole app-db.
 
-  Per rf2-nv3mua the handler ALSO fails CLOSED on a frame-id MISMATCH: when
+  The handler also fails closed on a frame-id mismatch: when
   the payload's `:rf/frame-id` is present-and-different from the dispatch
   target (`:rf.frame/id`), the server's slice was rendered for a DIFFERENT
   frame, so installing it here would defeat the frame-isolation evidence the
@@ -261,7 +255,7 @@
   (let [new-db (or (:rf/app-db payload) db)
         ;; A frame-id mismatch is checked BEFORE the structural shape: a
         ;; payload rendered for a DIFFERENT frame is rejected outright,
-        ;; regardless of slice shape (rf2-nv3mua). Only fires for a PRESENT-
+        ;; regardless of slice shape. Only fires for a present-
         ;; and-DIFFERENT `:rf/frame-id` against a non-nil target — an absent
         ;; frame-id (or nil target) is no conflict.
         frame-mismatch (when (some? frame)
@@ -280,7 +274,7 @@
       :else
       ;; Fail CLOSED on a malformed (deserialised, untrusted) payload —
       ;; non-map payload, or present-but-non-map app-db / runtime-db slice
-      ;; (rf2-gro94, rf2-g00l2t). The slice would otherwise be coerced into
+      ;; The slice would otherwise be coerced into
       ;; the partition (a fail-OPEN).
       (if-let [reason (malformed-hydration-payload! payload)]
         (do
@@ -290,11 +284,10 @@
         (hydrate-event-handler* db rt frame payload new-db)))))
 
 (defn- hydrate-event-handler*
-  "The structurally-valid hydration path (rf2-gro94 extracted the
-  fail-closed guard into `hydrate-event-handler`). `new-db` is the
+  "The structurally valid hydration path. `new-db` is the
   resolved server slice (or the existing `db` when the payload carried no
   app-db slice — the client-only fallback). `runtime-db` is the
-  `:rf.db/runtime` coeffect — EP-0001 (rf2-vzld77): the hydration metadata
+  `:rf.db/runtime` coeffect; the hydration metadata
   is durable runtime-db state, written under `[:rf.runtime/ssr :hydration]`."
   ;; A cross-feature artefact may reconcile its OWN installed runtime-db
   ;; subtree via the late-bound `:resources/hydrate-runtime-db` hook (Spec
@@ -304,18 +297,17 @@
   [db runtime-db frame payload new-db]
   (let [version       (:rf/version payload)
         schema-digest (:rf/schema-digest payload)
-        ;; EP-0001 (rf2-vzld77): the server-settled durable runtime state
+        ;; Server-settled durable runtime state
         ;; (machine snapshots, route slice) rides the payload's `:rf/runtime-db`
         ;; slice — a coherent runtime-db value the hydrate handler installs into
         ;; the runtime-db partition so the framework subs (`:rf/machine`,
         ;; `[:rf.route/*]`) see the hydrated state, and it survives as durable
-        ;; frame-state. (The full epoch/SSR snapshot-restore PROJECTIONS are
-        ;; bead 7's surface — rf2-3aizt1; this is just the
-        ;; payload-runtime-db→partition install.) The base for the metadata
+        ;; frame-state. This path only installs the payload projection; the
+        ;; base for the metadata
         ;; merge is the payload slice when present, else the existing
         ;; runtime-db coeffect.
         ;; A present-but-non-map :rf/runtime-db is already REJECTED by the
-        ;; fail-closed guard (rf2-g00l2t), so by the time we get here `pr`
+        ;; fail-closed guard, so by the time we get here `pr`
         ;; is either absent (nil → no-server-runtime fallback) or a map.
         ;; The `(when (map? pr) pr)` is a belt-and-braces no-op on the
         ;; validated path.
@@ -328,8 +320,8 @@
                             (filter (comp some? val))
                             {:server-hash (:rf/render-hash payload)
                              :version     version})
-        ;; Per rf2-7bcn0: gate the compatibility-check dispatches at the
-        ;; HANDLER level (not at the fx-platform-gate level) so server-
+        ;; Gate compatibility checks at the handler rather than effect dispatch
+        ;; so server-
         ;; side `:rf/hydrate` runs (test harness, isomorphic loopback)
         ;; don't fire `:rf.fx/skipped-on-platform` per check. The fxs
         ;; themselves remain `:platforms #{:client}` so any direct
@@ -341,9 +333,9 @@
     ;; trace event without crashing the hydration path. Both fxs gate on
     ;; payload-key presence — the scalar form passed here is the
     ;; server's value (the "expected"); the fx looks up the client-side
-    ;; "actual" via late-bind. Per rf2-69ad2.
+    ;; "actual" via late-bind.
     ;;
-    ;; EP-0001 (rf2-vzld77): the SSR hydration metadata is DURABLE,
+    ;; SSR hydration metadata is durable,
     ;; serializable framework runtime state (it must survive epoch-restore /
     ;; reconstitution so `verify-hydration!` can compare against it after the
     ;; first client render), so it lives in the frame's RUNTIME-DB partition
@@ -378,7 +370,7 @@
                ;; SSR statically `:require`ing it. Absent hook (no resources
                ;; artefact) leaves `base` unchanged, so an SSR app without resources
                ;; sees no behaviour change. Resources is the first consumer
-               ;; (rf2-ctk2av): it reconciles `:rf.runtime/resources`. The
+               ;; reconciles `:rf.runtime/resources`. The
                ;; symmetric COUNTERPART of `:ssr/extend-runtime-db-projection`
                ;; (the server projection hook in `project-runtime-db`).
                (if-let [reconcile (late-bind/get-fn :resources/hydrate-runtime-db)]
@@ -387,15 +379,14 @@
 
 ;; ---- :rf.ssr/check-version + :rf.ssr/check-schema-digest fxs --------------
 ;;
-;; Per Spec 011 §The :rf/hydrate event (rf2-69ad2). The :rf/hydrate handler
+;; Per Spec 011 §The :rf/hydrate event, the handler
 ;; dispatches these two fxs after replacing the client app-db with the
 ;; server's authoritative slice. They are best-effort compatibility checks:
 ;; a mismatch emits a structured warning trace and the hydration proceeds.
 ;; The runtime never throws on a mismatch — degraded-but-running beats
 ;; a crashed boot.
 ;;
-;; Arg shape (clarified per rf2-69ad2 because Spec 011 only pinned the
-;; trace shape, not the fx-input shape):
+;; Argument shape:
 ;;
 ;;   - SCALAR — `[:rf.ssr/check-version <server-value>]` per the spec's
 ;;     reference :rf/hydrate handler. The fx treats the scalar as the
@@ -436,8 +427,7 @@
     {:expected arg :actual (actual-lookup-fn)}))
 
 (defn- runtime-version-lookup
-  "Look up the client-side runtime version. No constant is pinned in
-  re-frame.core today (per rf2-69ad2 scope); the value is sourced via
+  "Look up the client-side runtime version via
   the optional `:rf2/runtime-version` late-bind hook — a host that
   bundles a version-stamp registers it at boot. When the hook is
   absent, returns nil and the check emits
@@ -569,7 +559,7 @@
   ([frame-id tree-or-hash] (verify-hydration! frame-id tree-or-hash {}))
   ([frame-id tree-or-hash {:keys [first-diff-path failing-id server-hash]}]
    (when (detect-mismatch? frame-id)
-     ;; EP-0001 (rf2-vzld77): the SSR hydration metadata is durable runtime-db
+     ;; SSR hydration metadata is durable runtime-db
      ;; state at `[:rf.runtime/ssr :hydration]` — read it off the runtime-db
      ;; partition.
      (let [rt          (frame/frame-runtime-db-value frame-id)
@@ -585,8 +575,7 @@
                ;; strict-mode throw (the build-shared-payload-then-throw-and-emit
                ;; idiom error/ex-info-from-data was purpose-built for). It carries
                ;; the canonical thrown-error slots — :rf.error/id, :reason,
-               ;; :recovery, and :where (rf2-ya3iqg: :where was previously absent
-               ;; here while the frame/events sibling throws carry it).
+               ;; :recovery, and :where.
                payload  (cond-> {:rf.error/id :rf.ssr/hydration-mismatch
                                  :where       'rf/verify-hydration!
                                  :server-hash server-hash
@@ -610,8 +599,8 @@
            (when trace-fn
              (trace-fn :rf.ssr/hydration-mismatch payload))
            (when strict?
-             ;; rf2-ya3iqg: route the shared-payload throw through the
-             ;; purpose-built error/ex-info-from-data — it derives the human
+             ;; Route the shared-payload throw through error/ex-info-from-data;
+             ;; it derives the human
              ;; message from the payload's own :rf.error/id + :reason (LEADING
              ;; the sentence, TRAILING the [:rf.ssr/hydration-mismatch] token)
              ;; in ONE call, instead of re-deriving error/human-message inline.

--- a/implementation/ssr/src/re_frame/ssr/payload_policy.cljc
+++ b/implementation/ssr/src/re_frame/ssr/payload_policy.cljc
@@ -9,11 +9,8 @@
   feature flags, server-only working scratch) to every visitor of every
   page.
 
-  A fail-OPEN default (ship whole `app-db` when `:payload` is
-  nil/empty) would make the privacy decision implicit; the
-  `:rf/response`-accumulator-on-app-db trap is one branch of the same
-  family (rf2-jbcmt landed the side-channel storage substrate, rf2-gtgf9
-  closed the default).
+  Shipping whole `app-db` when `:payload` is absent would make the privacy
+  decision implicit, so missing policy fails closed.
 
   This namespace makes the policy:
 
@@ -22,14 +19,11 @@
        a license to ship everything.
     3. **Allowlist-shaped** — denylists go stale silently as new keys
        land in `app-db`; an allowlist requires a deliberate edit per
-       new wire-bound key. The masterpiece-bar choice for a security
-       contract.
+       new wire-bound key.
 
   ---- The contract ----
 
-  A SINGLE handler opt — `:payload` — carries the policy. It is one of
-  two shapes (rf2-pffil consolidated the prior two-opt `:payload-keys` +
-  `:payload-policy` surface into one — pre-alpha, no back-compat shim):
+  A single handler opt, `:payload`, carries one of two policy shapes:
 
     `:payload [<kw> <kw> ...]`
       An **allowlist** of top-level `app-db` keys to ship (a non-empty
@@ -38,8 +32,8 @@
       mechanism. A non-empty vector carrying a non-keyword element
       (a string typo, a stray `nil`, a nested coll) fails loud at boot with
       `:rf.error/ssr-malformed-payload-allowlist` rather than silently
-      shipping a wrong/empty slice (rf2-hzttr). The allowlist shape is a
-      vector specifically (rf2-d8vs9x — a list / seq is not an accepted
+      shipping a wrong or empty slice. The allowlist is specifically a
+      vector; a list or seq is not an accepted
       spelling); the vector-vs-keyword distinction IS the allowlist-vs-
       whole-app-db policy selector, so a single precise shape keeps the
       fail-closed security boundary unambiguous.
@@ -55,12 +49,8 @@
   Absence of `:payload` is a structural error
   (`:rf.error/ssr-missing-payload-policy`) — fail-closed.
 
-  The single-opt shape removes the prior surface's ambiguity. The two-opt
-  design had to define a precedence rule (`:payload-keys` wins over
-  `:payload-policy` when both are passed) AND a silent-ignore branch (a
-  `:payload-policy` passed alongside an allowlist was discarded without a
-  word). One opt can hold exactly one value, so there is nothing to
-  arbitrate: the allowlist-vs-whole-app-db choice is the value's SHAPE
+  One opt can hold exactly one value, so there is nothing to arbitrate: the
+  allowlist-vs-whole-app-db choice is the value's shape
   (vector vs keyword), not a contest between two opts. Empty `:payload`
   (`[]`) is treated as **no allowlist supplied**, since shipping zero
   keys is almost certainly a programmer error rather than an intent.
@@ -295,7 +285,7 @@
     ;; shape — tests can assert on one keyword and cover both surfaces.
     (validate-policy-opts! opts)))
 
-;; ---- ssr-hydration egress projection of the app-db slice (rf2-bt9kct) -----
+;; ---- app-db hydration egress projection -----------------------------------
 ;;
 ;; Per EP-0015 §14 + Spec 015 §Projection: SSR/hydration is ALLOWLIST-FIRST
 ;; (the `apply-policy` `:payload` contract above), and frame classification
@@ -335,7 +325,7 @@
     {:frame             frame-id
      :rf.egress/profile :rf.egress/ssr-hydration}))
 
-;; ---- ssr-hydration egress projection of the routing slice (rf2-4xut98) ----
+;; ---- routing hydration egress projection ----------------------------------
 ;;
 ;; EP-0025 §Subsystem matrix (`reg-route` row) + Spec 012 §Route data
 ;; classification + Spec 015 §SSR: a route declares `:sensitive` / `:large`
@@ -404,7 +394,7 @@
        :rf.egress/profile :rf.egress/ssr-hydration})
     slice))
 
-;; ---- runtime-db projection (EP-0001 rf2-30kzz2) --------------------------
+;; ---- runtime-db hydration projection --------------------------------------
 ;;
 ;; Per Spec 011 §The hydration payload (`:rf/runtime-db`) + §Off-box redaction
 ;; (Mike ruling #13): the optional `:rf/runtime-db` payload slice carries ONLY
@@ -430,7 +420,7 @@
   `:pending-navigation` sibling is a local-subscribable runtime-db key
   (per [002 §Durable vs transient]) and stays off the wire (fail-closed).
 
-  rf2-oosjmh — ONE source of truth: this list MUST equal the routing-owned
+  This list must equal the routing-owned
   `re-frame.routing.nav-counters/durable-runtime-db-routing-keys` (the
   `:durable-runtime-db` tier of `routing-state-classification`). It is held
   as a literal here rather than `:require`-d so production SSR builds do NOT
@@ -555,9 +545,7 @@
 ;; ---- version resolution + payload assembly -------------------------------
 ;;
 ;; Single home for the hydration-payload `:rf/version` resolution and the
-;; canonical four-key payload map, shared verbatim by the streaming and
-;; non-streaming SSR paths (rf2-8wrzz.4 — previously duplicated in
-;; `re-frame.ssr.ring.payload` and `re-frame.ssr.streaming`).
+;; Canonical payload assembly shared by streaming and non-streaming SSR.
 
 (def ^:private default-pattern-protocol-version
   "The v1 pattern-protocol version stamp (per Spec-Schemas

--- a/implementation/ssr/src/re_frame/ssr/request.cljc
+++ b/implementation/ssr/src/re_frame/ssr/request.cljc
@@ -1,63 +1,15 @@
 (ns re-frame.ssr.request
-  "Per-request request slot + the `:rf.server/request` cofx + the
-  per-request frame-teardown hook. Per Spec 011 §Server-only `reg-cofx`
-  for request context and §Per-request frame teardown contract (rf2-fcj33).
+  "Per-frame request storage and teardown.
 
-  The `:rf.server/request` cofx surfaces the active HTTP request map to
-  event handlers that declare `:rf.cofx/requires [:rf.server/request]`
-  (EP-0017 — `inject-cofx` is removed). It is an AMBIENT, host-transient
-  read — legal for NON-DURABLE request reads (branching on
-  `:request-method`, reading a header for a decision that does not fold
-  into durable app-db / runtime-db).
+  Host adapters populate a request slot before draining a frame. The
+  server-only `:rf.server/request` coeffect reads that slot for transient
+  decisions. Because the ambient value is not recorded, durable state must use
+  a sanitized request-derived value supplied in an event or recordable
+  coeffect leaf. The whole request must never enter a causal token or app-db.
 
-  DURABLE request-derived facts use the boundary pattern, NOT this ambient
-  read (rf2-aqwvhh). EP-0017 §1: an ambient supplier re-runs on replay, so a
-  durable write that folds a value read through `:rf.server/request` (an auth
-  user / session state folded into the hydration payload) is a replay hole —
-  replay re-runs the live supplier instead of re-presenting the value the
-  recorded run saw (and reads nil after per-request frame teardown). When a
-  setup handler writes durable state from the request, the host adapter
-  SANITIZES the request and supplies the derived fact as a recordable leaf so
-  it lands on the causal token: either as EVENT PAYLOAD
-  (`[:auth/server-init {:user (extract-user request)}]`) or as a PROVIDED
-  recordable `:rf.cofx` leaf (an app-owned
-  `{:recordable? true :provided? true}` cofx the host stamps onto the boot
-  token; a record missing it fails loudly with
-  `:rf.error/missing-required-cofx`). The whole request map NEVER rides the
-  token — only the sanitized projection (Spec 011 §Request storage
-  substrate). See `re-frame.ssr`'s `:rf.server/request` registration doc for
-  the full pattern.
-
-  The mechanism is a per-frame slot — NOT a single dynamic var — so two
-  simultaneous per-request frames (the common SSR shape under concurrent
-  load) carry independent request data without leaking into each other.
-  Host adapters (rf2-ny6v7's Ring adapter; future Pedestal / raw-HTTP /
-  edge-runtime adapters) populate the slot via `set-request!` before
-  kicking off the drain and clear it via `clear-request!` after the
-  response is built (typically inside `frame.cljc`'s `destroy-frame!`
-  teardown — but adapters that re-use a long-lived frame can clear
-  inline).
-
-  Storage shape: `defonce` side-channel atom keyed by frame-id. This
-  mirrors `pending-error-traces` rather than living in app-db because
-  the request map is HOST-CONTROLLED INPUT (the host's wire-shape data —
-  Ring request map, Pedestal context, etc.); the cofx surfaces it into
-  the handler's `:coeffects` map, but it has no place in the
-  application's serialisable app-db. Storing it outside app-db keeps it
-  out of the hydration payload (`:rf/app-db` ships to the client) —
-  server-side request data must never leak into the client's bootstrap
-  state.
-
-  The cofx is `:platforms #{:server}` so client-side dispatches that
-  reference it silently no-op via `:rf.cofx/skipped-on-platform` (the
-  standard cofx-gating contract per Spec 011 §634-642).
-
-  The `reg-cofx` registration for `:rf.server/request` lives in the
-  `re-frame.ssr` façade so a `(require 're-frame.ssr :reload)` after
-  `(registrar/clear-all!)` re-installs it. This namespace exports the
-  handler fn only.
-
-  Per the rf2-gxgo7 split of re-frame.ssr."
+  The slots live outside app-db so concurrent frames remain isolated and host
+  request data cannot enter the hydration payload. Frame teardown clears the
+  request, response, pending-error, and head-snapshot side channels."
   (:require [re-frame.frame :as frame]
             [re-frame.late-bind :as late-bind]
             [re-frame.ssr.error-listener :as error-listener]
@@ -76,9 +28,7 @@
 
 (defn set-request!
   "Populate the per-frame request slot. Called by an SSR host adapter
-  (rf2-ny6v7 ships the Ring adapter; future Pedestal / raw-HTTP / edge-
-  runtime adapters follow the same contract) once per request, before
-  kicking off the drain.
+  once per request, before kicking off the drain.
 
   The shape of `request` is host-defined: the Ring adapter passes the
   Ring request map (`:request-method`, `:uri`, `:headers`, `:cookies`,
@@ -88,8 +38,7 @@
 
   Returns `frame-id`."
   [frame-id request]
-  ;; Key by the frame ADDRESS (rf2-bzw8gd) — the shared SSR side-channel keying
-  ;; seam `frame/frame-address` (the bare process-local frame id).
+  ;; All SSR side channels use the process-local frame address.
   (swap! request-slots assoc (frame/frame-address frame-id) request)
   frame-id)
 
@@ -115,14 +64,14 @@
   (swap! request-slots dissoc (frame/frame-address frame-id))
   frame-id)
 
-;; ---- per-request frame teardown (rf2-fcj33) -------------------------------
+;; ---- per-request frame teardown -------------------------------------------
 ;;
 ;; Per Spec 011 §Per-request frame teardown contract. The SSR runtime owns
 ;; three side-channel `defonce` atoms keyed by frame-id —
 ;; `pending-error-traces` (per-frame buffer of captured error trace events,
 ;; in `re-frame.ssr.error-listener`), `request-slots` (per-frame HTTP-request
 ;; map, here), and `response-slots` (per-frame HTTP response accumulator,
-;; in `re-frame.ssr.response` — rf2-jbcmt moved this off `app-db`). All three
+;; in `re-frame.ssr.response`). All three
 ;; live outside app-db (see the rationale comments above each defonce) and
 ;; so are NOT cleared by the frame's app-db / sub-cache teardown in
 ;; `frame/destroy-frame!`.
@@ -135,27 +84,20 @@
 ;; in any of the three atoms.
 
 (defn on-frame-destroyed!
-  "Per Spec 011 §Per-request frame teardown contract (rf2-fcj33). Drop
+  "Drop
   the per-frame entries in `pending-error-traces`, `request-slots`, and
   `response-slots` for `frame-id`. Called from `frame/destroy-frame!`
   via the `:ssr/on-frame-destroyed` late-bind hook. Idempotent — a
   second call against the same frame-id sees the atoms already cleared
   and does nothing.
 
-  Per rf2-jbcmt the `response-slots` side-channel was added to plug the
-  `:rf/response` hydration-payload leak / per-fx full-app-db swap; this
-  hook releases that slot symmetrically with the request slot.
-
-  Per rf2-4dra9 (Spec 011 §Head/meta contract), also invokes any
+  Also invokes any
   registered `:ssr/head-on-frame-destroyed` hook so `re-frame.ssr.head`
   can release its per-frame head-snapshot bookkeeping. Hook lookup is
   late-bound so the call is a no-op when the head ns is absent.
 
-  Head-cleanup throws are caught + surfaced on the trace bus rather
-  than silently swallowed — mirrors the trace-on-catch pattern shipped
-  in `ssr-ring/lifecycle/destroy-frame-quietly!` (audit rf2-cegm7 CQ-2 /
-  rf2-j54ee). Vanishing destroy-time exceptions is exactly what the
-  R6 cluster was fixing; keep the symmetry."
+  Head-cleanup throws are surfaced on the trace bus while the remaining frame
+  teardown continues."
   [frame-id]
   (error-listener/clear-pending-error-traces! frame-id)
   (clear-request! frame-id)
@@ -176,7 +118,7 @@
   nil)
 
 (defn request-cofx
-  "Value-returning AMBIENT supplier for `:rf.server/request` (EP-0017 §2).
+  "Value-returning ambient supplier for `:rf.server/request`.
   Reads the per-frame request slot for the frame currently being dispatched
   (`frame/*current-frame*`, bound by the router during processing). Returns
   nil when no host adapter has populated the slot (e.g. JVM tests that drive
@@ -188,11 +130,11 @@
   delivered to handlers that declare `:rf.cofx/requires [:rf.server/request]`
   and never recorded — replay re-runs it (and reads nil after the per-request
   frame's slot is cleared). Because the read is unrecorded, this AMBIENT cofx
-  is for NON-DURABLE request reads only; a durable request-derived fact uses
+  is for non-durable request reads only; a durable request-derived fact uses
   the recordable boundary pattern (event payload or a provided recordable
-  `:rf.cofx` leaf the host stamps after sanitizing the request — rf2-aqwvhh).
+  `:rf.cofx` leaf the host stamps after sanitizing the request).
   Tests / conformance harnesses that drive the drain without a host adapter
   `set-request!` the slot for the target frame first (the visible seam),
-  exactly as before."
+  before dispatch."
   []
   (get-request frame/*current-frame*))

--- a/implementation/ssr/src/re_frame/ssr/response.cljc
+++ b/implementation/ssr/src/re_frame/ssr/response.cljc
@@ -1,7 +1,5 @@
 (ns re-frame.ssr.response
-  "HTTP response accumulator + handler fns for the seven `:rf.server/*`
-  server-side fxs (six original + `:rf.server/safe-redirect` per rf2-zfm8v).
-  Per Spec 011 §HTTP response contract.
+  "HTTP response accumulator and the seven `:rf.server/*` effect handlers.
 
   The runtime owns a per-request response accumulator in a
   framework-private side-channel atom keyed by frame-id — `response-slots`
@@ -9,9 +7,8 @@
   the host adapter consumes the resolved value after drain to build the
   wire response.
 
-  Storage substrate (rf2-jbcmt). Per Spec 011 §Response storage substrate
-  the accumulator MUST NOT ride `app-db`. The substrate symmetry with
-  `request-slots` is intentional:
+  The accumulator must not live in `app-db`. Keeping it symmetric with the
+  request side channel has two important consequences:
 
   - **Privacy.** `app-db` is the hydration payload's source (the
     `:rf/app-db` slice ships to the client on bootstrap). The response
@@ -21,14 +18,10 @@
     accumulator in `app-db` would default-leak that surface onto the
     wire and force every host adapter to remember a defensive
     `(dissoc :rf/response)` before serialising the payload — a privacy
-    boundary that's a constant caller-vigilance burden is a leak waiting
-    to happen. Side-channel storage makes the boundary self-enforcing.
-  - **Perf.** Each `:rf.server/*` fx writes the accumulator with an
-    O(small-map) atom CAS against the `{frame-id → response-map}` table.
-    Storing it in `app-db` would instead swap the WHOLE app-db container
-    per fx — for a typical 7-fx login flow (`set-status` + 2× `set-cookie`
-    + 3× `set-header` + `redirect`), seven full-app-db replacements per
-    request, each allocating a fresh container value for one changed key.
+    caller must remember to apply. Side-channel storage enforces the boundary.
+  - **Atomicity.** Each response effect swaps one per-frame accumulator.
+    Response writes never replace application state or expose partially built
+    response data through subscriptions.
 
   Default shape (Spec 011 §HTTP response contract):
 
@@ -52,11 +45,8 @@
   depends on the projector's drain — `response-of` here is the pure
   read used both internally and by the listener module.
 
-  `clear-response!` is called by `re-frame.ssr.request/on-frame-destroyed!`
-  via the `:ssr/on-frame-destroyed` late-bind hook (rf2-fcj33) so the
-  slot is released on per-request frame teardown.
-
-  Per the rf2-gxgo7 split of re-frame.ssr."
+  Frame teardown releases the response slot together with the other SSR side
+  channels."
   (:require [clojure.string]
             [re-frame.error :as error]
             [re-frame.frame :as frame]
@@ -70,20 +60,19 @@
   :redirect ...}` plus internal `:rf.server/_status-writes` /
   `:rf.server/_redirect-writes` bookkeeping). Framework-private —
   not stored in `app-db` so the accumulator never rides the hydration
-  payload to the client (Spec 011 §Response storage substrate, rf2-jbcmt).
-  Cleared per-frame by the `:ssr/on-frame-destroyed` hook (rf2-fcj33)."}
+  payload to the client. Cleared per-frame by the
+  `:ssr/on-frame-destroyed` hook."}
   response-slots
   (atom {}))
 
-;; rf2-hbty2 / security audit 2026-05-14 §P1.3 — header-value injection
-;; gate. set-header / append-header / redirect flow user-controlled
+;; Header-value injection gate. set-header / append-header / redirect flow
+;; caller-controlled
 ;; strings straight into the Ring response map; an attacker who controls
 ;; a header value with embedded CR/LF can split the header and forge
 ;; second-and-later headers on the wire (RFC 7230 §3.2.4 explicitly
 ;; bans CTLs in header values). We reject at the fx boundary rather
 ;; than the Ring materialiser so misuse surfaces with the dispatching
-;; event in scope rather than as a deep Ring exception. Same pattern as
-;; the cookie-attribute validator (rf2-rpedl).
+;; event in scope rather than as a deep host-adapter exception.
 ;;
 ;; Decision: fail-fast (throw) rather than strip-and-warn. A header
 ;; value with CR/LF has no safe interpretation — strip-and-warn would
@@ -127,7 +116,7 @@
   This is the SHARED CR/LF/NUL gate — both `:rf.server/redirect` (caller-
   trusted) and `:rf.server/safe-redirect` (caller-untrusted) run it as a
   defence-in-depth first step, and it is the ONLY structural gate on the
-  caller-trusted path (rf2-ziv4gd: no URL-shape check — a raw space or
+  caller-trusted path: no URL-shape check is applied, so a raw space or
   RFC 3986 shape quirk a browser accepts in a `Location` header passes
   through). It deliberately does NOT do any URL-shape / scheme / host
   validation: `safe-redirect-fx` does its own full parse + scheme + host
@@ -147,11 +136,8 @@
          :extra    {:location loc}}))
     s))
 
-;; rf2-z7gor / security audit 2026-05-14 — header-name + cookie-field
-;; gates at the fx boundary. The rf2-hbty2 work validated header
-;; VALUES; header NAMES and the structured cookie map were still trusted.
-;; The ring host adapter happens to re-validate at materialisation time
-;; (rf2-rpedl in ssr-ring/cookie.clj), but the SSR layer is also the
+;; Header-name and cookie-field gates run at the effect boundary. The Ring
+;; host adapter re-validates at materialisation time, but the SSR layer is also the
 ;; integration boundary for Pedestal / HttpKit / other custom adapters
 ;; that consume the response shape directly — so the fx boundary is the
 ;; right place to enforce the invariant once, with the dispatching event
@@ -168,8 +154,7 @@
 (defn- validate-header-name!
   "Throw `:rf.error/header-invalid-name` if the header name violates the
   RFC 7230 §3.2.6 token grammar — empty, contains CR / LF / NUL,
-  whitespace, or separators. Same gate as the cookie-name validator.
-  Per rf2-z7gor §security-audit-2026-05-14."
+  whitespace, or separators. Same gate as the cookie-name validator."
   [n]
   (let [s (str n)]
     (when-not (http-validation/valid-token-name? s)
@@ -187,9 +172,8 @@
 (defn- validate-cookie-name!
   "Throw `:rf.error/cookie-invalid-name` if the cookie name is nil, is not a
   string / keyword / symbol, or violates the RFC 6265 §4.1.1 token grammar.
-  Same shape as the rf2-rpedl validator in `ssr-ring/cookie.clj` — applied
-  here at the fx boundary so non-ring host adapters get the same gate. Per
-  rf2-z7gor + rf2-9t17id (the TYPE guard)."
+  Applied at the effect boundary so every host adapter receives the same
+  validation."
   [n]
   (when (nil? n)
     (error/throw-error!
@@ -198,7 +182,7 @@
       "cookie :name is required; supply a non-nil :name on the cookie map."
       {:recovery :supply-a-cookie-name
        :extra    {:name n}}))
-  ;; rf2-9t17id — type-guard BEFORE `(name n)`. A cookie `:name` is only a
+  ;; Type-guard before `(name n)`: a cookie `:name` is only a
   ;; string or a Named (keyword / symbol); anything else (a Long `42`, a
   ;; vector `[]`, a map `{}`, a boolean `true`, …) makes `name` throw a raw
   ;; host exception (`ClassCastException` on the JVM) with nil ex-data,
@@ -208,8 +192,8 @@
   ;; schema pins the type — when schemas are absent or soft-pass (Spec 010),
   ;; the fx boundary is the last line of defence, so reject the unsupported
   ;; TYPE loudly through the same structured error id. Mirrors the Ring
-  ;; materialiser's guard (rf2-d95o1y in `re-frame.ssr.ring.cookie`); the JVM
-  ;; branch matches Ring's `clojure.lang.Named` check exactly (the fx runs
+  ;; materialiser's guard; the JVM branch matches Ring's
+  ;; `clojure.lang.Named` check exactly (the fx runs
   ;; server-only, `:platforms #{:server}`).
   (when-not (or (string? n)
                 #?(:clj  (instance? clojure.lang.Named n)
@@ -244,7 +228,7 @@
   than implied by a call sequence, and every member on an injection-char
   failure throws the SINGLE catalogued `:rf.error/cookie-invalid-attribute`
   (Spec 009), carrying the offending attribute in the payload's `:attribute`
-  slot rather than in a per-attribute error id (rf2-xrk4w1). `:name` is NOT
+  slot rather than in a per-attribute error id. `:name` is not
   here — it carries its own RFC 6265 §4.1.1 token-grammar +
   type gate (`validate-cookie-name!` → `:rf.error/cookie-invalid-name`)."
   [:value :path :domain :max-age :same-site :expires])
@@ -258,11 +242,9 @@
   `:expires` as an epoch-millis long); the CR/LF/NUL ban applies to the
   serialised form a host adapter would emit. The offending attribute rides
   the payload's `:attribute` slot — the SAME error id + `{:attribute :value}`
-  emit shape the Ring materialiser throws (`re-frame.ssr.ring.cookie`,
-  rf2-rpedl), so the fx boundary and the wire serialiser share one catalogued
+  emit shape the Ring materialiser throws, so the fx boundary and the wire serialiser share one catalogued
   vocabulary: the injection class is one fact, and WHICH attribute carried the
-  injection char is data, not a distinct error id (rf2-xrk4w1). Per rf2-z7gor
-  (the fx-boundary gate) and rf2-kjf3m.1 (Spec 011 §CRLF fail-fast mandates
+  injection char is data, not a distinct error id. Spec 011 §CRLF fail-fast mandates
   checking EVERY attribute, not just :value — an attacker who controls any one
   attribute must not be able to re-enter the header line as CRLF-bearing
   payload)."
@@ -283,12 +265,12 @@
     s))
 
 (defn- validate-cookie!
-  "Run name + field validators across the cookie map. Per rf2-z7gor —
-  gate the structured cookie at the fx boundary so misuse surfaces with
+  "Run name and field validators across the cookie map. Gate the structured
+  cookie at the effect boundary so misuse surfaces with
   the dispatching event in scope rather than as a deep adapter exception.
 
   CRLF-checks EVERY attribute a host adapter serialises into the
-  Set-Cookie line, not just `:value` (rf2-kjf3m.1 / Spec 011 §CRLF
+  Set-Cookie line, not just `:value` (Spec 011 §CRLF
   fail-fast). The fx boundary is the single enforcement point for
   non-Ring host adapters (Pedestal / HttpKit / custom) that read the
   accumulator and serialise cookies themselves; the Ring materialiser
@@ -330,7 +312,7 @@
 (defn swap-response!
   "Mutate the response accumulator slot for `frame-id` with `f`. Returns
   the post-swap response map. The substrate is a side-channel atom keyed
-  on the frame ADDRESS (rf2-jbcmt; rf2-bzw8gd) — O(small-map) swap, no app-db
+  on the process-local frame address — O(small-map) swap, no app-db
   ping-pong. `frame-address` is the bare process-local frame id."
   [frame-id f]
   (let [addr      (frame/frame-address frame-id)
@@ -347,8 +329,8 @@
 (defn clear-response!
   "Drop `frame-id`'s response slot. Called from
   `re-frame.ssr.request/on-frame-destroyed!` via the
-  `:ssr/on-frame-destroyed` late-bind hook (rf2-fcj33). Idempotent —
-  tolerates a frame-id with no slot. Keyed by the frame ADDRESS (rf2-bzw8gd)."
+  `:ssr/on-frame-destroyed` late-bind hook. Idempotent — tolerates a frame-id
+  with no slot."
   [frame-id]
   (swap! response-slots dissoc (frame/frame-address frame-id))
   frame-id)
@@ -423,8 +405,8 @@
   "Handler fn for `:rf.server/set-header`. Replaces any existing header
   with the same name (case-insensitive). Throws
   `:rf.error/header-invalid-name` on a name violating the RFC 7230
-  §3.2.6 token grammar (rf2-z7gor), and `:rf.error/header-invalid-value`
-  on a value carrying CR/LF/NUL (rf2-hbty2)."
+  §3.2.6 token grammar, and `:rf.error/header-invalid-value` on a value
+  carrying CR/LF/NUL."
   [{:keys [frame]} {:keys [name value]}]
   (validate-header-name!  name)
   (validate-header-value! name value)
@@ -436,9 +418,8 @@
   "Handler fn for `:rf.server/append-header`. Preserves any existing
   header with the same name — required for Set-Cookie-style multi-valued
   headers. Throws `:rf.error/header-invalid-name` on a name violating the
-  RFC 7230 §3.2.6 token grammar (rf2-z7gor), and
-  `:rf.error/header-invalid-value` on a value carrying CR/LF/NUL
-  (rf2-hbty2)."
+  RFC 7230 §3.2.6 token grammar, and `:rf.error/header-invalid-value` on a
+  value carrying CR/LF/NUL."
   [{:keys [frame]} {:keys [name value]}]
   (validate-header-name!  name)
   (validate-header-value! name value)
@@ -466,7 +447,7 @@
 
 (defn delete-cookie-fx
   "Handler fn for `:rf.server/delete-cookie`. Sugar over set-cookie
-  with :max-age 0 and an empty :value. Same rf2-z7gor name + path +
+  with :max-age 0 and an empty :value. Applies the same name, path, and
   domain validation as `set-cookie-fx`."
   [{:keys [frame]} {:keys [name path domain]}]
   (let [cookie (cond-> {:name    name
@@ -479,26 +460,25 @@
       frame
       (fn [r] (update r :cookies (fnil conj []) cookie)))))
 
-;; rf2-vngir / EP-0007 one-name-per-fact. The redirect target key is
-;; canonically `:location` — this fx writes an HTTP `Location` response
+;; The redirect target key is `:location`, matching the HTTP `Location` response
 ;; header, so it uses header vocabulary (routing/navigation surfaces may
 ;; use `:url` / `:to`; HTTP-response redirect surfaces use `:location`).
-;; The pre-alpha synonym set (`:location` / `:url` / `:to`) was pruned to
-;; `:location` only; there is no back-compat alias. A retired spelling
+;; The unsupported `:url` and `:to` spellings have no compatibility alias. An
+;; unsupported spelling
 ;; (`:url` / `:to`) must fail with a CLEAR diagnostic naming `:location`
 ;; rather than silently fall through to the no-target warning path — that
 ;; would hide the API vocabulary error behind a malformed-redirect warning.
 (def ^:private retired-redirect-target-keys
-  "Redirect-target spellings retired in favour of the canonical
-  `:location` (rf2-vngir). Detected on a `:rf.server/redirect` /
+  "Redirect-target spellings unsupported in favour of canonical `:location`.
+  Detected on a `:rf.server/redirect` /
   `:rf.server/safe-redirect` args map so they fail loudly rather than
   degrade into the malformed-no-target path."
   [:url :to])
 
 (defn- reject-retired-redirect-keys!
   "Throw `:rf.error/redirect-retired-target-key` if `redirect-map` carries
-  a retired redirect-target spelling (`:url` / `:to`). The canonical key is
-  `:location` (rf2-vngir / EP-0007). The error NAMES `:location` so the
+  an unsupported redirect-target spelling (`:url` / `:to`). The canonical key
+  is `:location`. The error names `:location` so the
   programmer rewrites the spelling rather than seeing the generic
   no-target warning the host adapter emits for a target-less redirect."
   [redirect-map]
@@ -522,27 +502,27 @@
   "Handler fn for `:rf.server/redirect`. Defaults :status to 302 if
   absent. Multiple writes emit `:rf.warning/multiple-redirects`
   (last-write-wins). Throws `:rf.error/redirect-invalid-location` on a
-  location carrying CR/LF/NUL (rf2-hbty2) — a `?next=…` query-param
+  location carrying CR/LF/NUL — a `?next=…` query-param
   redirect would otherwise let an attacker forge headers — per Spec 011
   §CRLF fail-fast. The CR/LF/NUL header-splitting gate is the ONLY gate
   on this caller-trusted path: no URL-shape check is applied, so a raw
   space or other RFC 3986 shape quirk every browser accepts in a
   `Location` header passes through unchanged (URL-shape + origin
-  validation is `:rf.server/safe-redirect`'s job, rf2-ziv4gd).
+  validation is `:rf.server/safe-redirect`'s job).
 
-  **Canonical redirect target key is `:location`** (rf2-vngir). The
-  retired synonyms `:url` / `:to` throw `:rf.error/redirect-retired-
+  **Canonical redirect target key is `:location`.** The unsupported
+  synonyms `:url` / `:to` throw `:rf.error/redirect-retired-
   target-key` naming `:location` — there is no back-compat alias.
 
   **Caller-trusted `:location`** — accepts arbitrary URL strings without
   allowlist or relative-only gating. For caller-untrusted location
-  strings (e.g. a `?next=` URL param), use `:rf.server/safe-redirect`
-  (rf2-zfm8v) which parses the URL, rejects javascript:/data:/vbscript:
+  strings (e.g. a `?next=` URL param), use `:rf.server/safe-redirect`, which
+  parses the URL, rejects javascript:/data:/vbscript:
   schemes, and supports `:relative-only?` / `:allow [...]` policies.
   See Spec 011 §HTTP response contract §Standard fx."
   [{:keys [frame]} redirect-map]
   (reject-retired-redirect-keys! redirect-map)
-  (let [;; rf2-vngir: the canonical (and only) redirect target key.
+  (let [;; The canonical and only redirect target key.
         location  (:location redirect-map)
         _         (when (some? location)
                     ;; Shared CR/LF/NUL header-splitting gate only — the
@@ -550,7 +530,7 @@
                     ;; (Spec 011 §CRLF fail-fast). No URL-shape check:
                     ;; `:rf.server/redirect` is caller-trusted, so a raw
                     ;; space or RFC 3986 shape quirk a browser accepts
-                    ;; passes through (rf2-ziv4gd). safe-redirect-fx runs
+                    ;; passes through. safe-redirect-fx runs
                     ;; this same gate plus its own emit-based parse.
                     (validate-redirect-location! location))
         status    (or (:status redirect-map) 302)
@@ -571,7 +551,7 @@
     (warn-on-multiple-writes! resp redirect-writes-key
                               :rf.warning/multiple-redirects :final-redirect frame)))
 
-;; ---- :rf.server/safe-redirect (rf2-zfm8v) --------------------------------
+;; ---- :rf.server/safe-redirect ---------------------------------------------
 ;;
 ;; The caller-untrusted variant of :rf.server/redirect. Where redirect-fx
 ;; accepts arbitrary :location strings, safe-redirect-fx parses the URL
@@ -579,9 +559,8 @@
 ;; host — before populating the :redirect slot:
 ;;
 ;;   1. URL must parse — :rf.error/safe-redirect-invalid-url on failure.
-;;   2. Reject javascript: / data: / vbscript: schemes (no safe redirect
-;;      interpretation; consistent with the rf2-vwcsq custom-editor
-;;      scheme-rejection policy) — :rf.error/safe-redirect-scheme-rejected.
+;;   2. Reject javascript: / data: / vbscript: schemes —
+;;      :rf.error/safe-redirect-scheme-rejected.
 ;;   2b. Reject any scheme outside #{http https} outright — a redirect
 ;;      Location is only ever an http(s) absolute URL or a relative
 ;;      reference; mailto:, ftp:, and other schemes have no place as a
@@ -616,24 +595,19 @@
 ;; the response's :redirect stays unchanged, and the programmer sees
 ;; the specific :rf.error/safe-redirect-* category.
 ;;
-;; Mitigation for the open-redirect class (security audit 2026-05-14
-;; §P3.2; scheme-bypass hardening rf2-v3eg3 finding 1): an
-;; attacker-controlled ?next=... URL parameter cannot redirect off-origin
-;; when the app uses safe-redirect-fx instead of redirect-fx — including
-;; the scheme-bearing opaque-URI bypass (`http:evil.example.com`) that
-;; defeats a host-presence-only gate.
+;; This fail-closed shape prevents caller-controlled targets from redirecting
+;; off-origin, including opaque scheme-bearing forms such as
+;; `http:evil.example.com` that defeat a host-presence-only test.
 
 (def ^:private rejected-schemes
-  "Closed set of schemes the safe-redirect-fx rejects outright. Per
-  rf2-zfm8v decision step 2 and rf2-vwcsq's custom-editor scheme policy."
+  "Closed set of schemes the safe-redirect effect rejects outright."
   #{"javascript" "data" "vbscript"})
 
 (def ^:private allowed-schemes
   "Closed set of schemes a redirect Location may legitimately carry. A
   redirect target is either a relative reference (no scheme) or an
   absolute http(s) URL — every other scheme (mailto, ftp, file, tel, …)
-  is rejected outright as a redirect target. Per rf2-v3eg3 finding 1
-  (scheme-bypass hardening): the safe-redirect gate decides non-http(s)
+  is rejected outright as a redirect target. The safe-redirect gate decides non-http(s)
   schemes by rejecting them rather than by maintaining a per-app scheme
   allowlist — an opt-in scheme allowlist can be layered later if a real
   use case appears."
@@ -645,7 +619,7 @@
   / `+` / `-` / `.`). Used pre-parse so rejected schemes whose
   scheme-specific part is not URI-valid (e.g. `data:text/html,<script>`
   with illegal `<` in the opaque part) still surface as scheme-rejected
-  rather than as parse failures. Per rf2-zfm8v validation order."
+  rather than as parse failures."
   #"^\s*([A-Za-z][A-Za-z0-9+\-.]*):")
 
 (defn- detect-scheme
@@ -702,7 +676,7 @@
      :status         302}                  ;; defaults 302 if absent
 
   Validation order (per Spec 009 §Error event catalogue). The gate is on
-  the parsed URL SHAPE, not merely on host presence (rf2-v3eg3 finding 1):
+  the parsed URL shape, not merely on host presence:
 
     1.  URL parses → :rf.error/safe-redirect-invalid-url on failure
     2.  scheme ∈ #{javascript data vbscript} → :rf.error/safe-redirect-scheme-rejected
@@ -719,29 +693,23 @@
         (:reason :not-in-allowlist)
     5.  Pass → set :redirect (same shape as :rf.server/redirect)
 
-  Mitigation for the open-redirect class (audit 2026-05-14 §P3.2;
-  scheme-bypass hardening rf2-v3eg3 finding 1): an attacker-controlled
-  ?next=... URL parameter cannot redirect off-origin when the app uses
-  safe-redirect-fx — including scheme-bearing opaque URIs such as
-  `http:evil.example.com`.
-
-  Per rf2-zfm8v (Mike decision, Option A — ship safe-redirect-fx
-  alongside redirect-fx, 2026-05-14)."
+  An attacker-controlled `?next=...` parameter therefore cannot redirect
+  off-origin, including through opaque URIs such as `http:evil.example.com`."
   [{:keys [frame]} {:keys [location relative-only? allow status]
                     :as redirect-map}]
-  ;; rf2-vngir: reject the retired `:url` / `:to` spellings with a clear
+  ;; Reject the unsupported `:url` / `:to` spellings with a clear
   ;; diagnostic naming `:location` before anything else — a safe-redirect
   ;; keyed on a retired spelling would otherwise present as a missing
   ;; (nil) `:location` and fail as a generic parse error, hiding the
   ;; vocabulary mistake.
   (reject-retired-redirect-keys! redirect-map)
   ;; Run the CR/LF/NUL gate first — same defence-in-depth as the
-  ;; caller-trusted redirect-fx (rf2-hbty2). A safe-redirect caller
+  ;; caller-trusted redirect-fx. A safe-redirect caller
   ;; passing a CRLF-bearing location is presumably trying both vectors;
   ;; reject at the same fx boundary the trusted variant uses.
   (validate-redirect-location! location)
 
-  ;; Validation order per rf2-zfm8v / Spec 009 §Error event catalogue.
+  ;; Validation order follows Spec 009 §Error event catalogue.
   ;;
   ;; Scheme rejection (step 2) runs BEFORE URL parse (step 1) for the
   ;; rejected-schemes set because schemes like `data:text/html,<script>`
@@ -780,7 +748,7 @@
                 ;; and is NOT relative. A scheme-bearing opaque URI
                 ;; `http:evil.example.com` has a scheme and is NOT
                 ;; relative — even though Java reports its host as nil.
-                ;; (rf2-v3eg3 finding 1: shape, not host-presence.)
+                ;; The policy is based on URL shape, not host presence alone.
                 relative? (and (nil? scheme) (nil? authority))]
             (cond
               ;; Step 2: scheme rejection (post-parse path — covers
@@ -797,7 +765,6 @@
               ;; relative reference — mailto:, ftp:, file:, tel:, etc.
               ;; have no defensible redirect interpretation and would
               ;; otherwise slip the host-based gates (nil host).
-              ;; (rf2-v3eg3 finding 1.)
               (and scheme-lc (not (allowed-schemes scheme-lc)))
               (emit-safe-redirect-error! :rf.error/safe-redirect-scheme-rejected
                                          {:frame    frame
@@ -811,9 +778,7 @@
               ;; These parse cleanly with a nil host, so the host-based
               ;; gates below cannot see them, yet a browser navigates
               ;; off-origin on `Location: http:evil.example.com`. No
-              ;; defensible redirect interpretation. (rf2-v3eg3 finding 1
-              ;; — the scheme-bypass that defeated the host-presence-only
-              ;; open-redirect gate.)
+              ;; defensible redirect interpretation.
               (and scheme-lc (nil? host))
               (emit-safe-redirect-error! :rf.error/safe-redirect-invalid-url
                                          {:frame    frame

--- a/implementation/ssr/src/re_frame/ssr/server_fx_schemas.cljc
+++ b/implementation/ssr/src/re_frame/ssr/server_fx_schemas.cljc
@@ -17,18 +17,9 @@
   these vars are inert EDN that still travels with the registration so
   the `:schema` boundary EXISTS the moment a validator is present.
 
-  Why this closes a gap (rf2-kjf3m.2): Spec 011 §Standard fx (line 438)
-  and §Cookie shape (line 496) both assert these schemas are
-  *registered* and that 'args validation runs as part of the standard
-  `:schema` boundary check'. Pre-rf2-kjf3m.2 the six `:rf.server/*`
-  `reg-fx` calls carried only `:doc` + `:platforms` — no `:schema` — so
-  the Spec 010 §step-5 fx-args boundary never ran for them. A
-  `(rf/dispatch [:rf.server/set-status \"nope\"])` assoc'd the string
-  straight onto the response `:status` and emitted a non-integer status
-  on the wire. With these schemas attached the malformed arg surfaces
-  as `:rf.error/schema-validation-failure :where :fx-args` at the
-  dispatch site, with the event in scope — exactly what the spec
-  promises.
+  Attaching these schemas to the registrations makes malformed arguments
+  surface at the `:fx-args` boundary while the dispatching event is still in
+  scope, before response state is mutated.
 
   Spec ↔ var map (per [Spec-Schemas §Standard fx args schemas]):
 
@@ -60,12 +51,11 @@
   `:rf.server/set-cookie` / `:rf.server/delete-cookie` produce. Per
   Spec 011 §Cookie shape / [Spec-Schemas §`:rf.server/cookie`].
 
-  Ingress tolerance vs canonical shape (rf2-cwfy2, ruled by Mike
-  2026-06-05 — Spec-Schemas widened to match this contract; no divergence
-  remains). The `:max-age`, `:expires`, and `:same-site` attrs carry a
+  Ingress tolerance differs from the canonical wire shape. The `:max-age`,
+  `:expires`, and `:same-site` attrs carry a
   `[:or <canonical-type> :string]` shape rather than the bare canonical
-  type, because `re-frame.ssr.response/validate-cookie!` (rf2-kjf3m.1 /
-  rf2-z7gor) DELIBERATELY accepts and `str`-coerces non-canonical scalar
+  type, because `re-frame.ssr.response/validate-cookie!` accepts and
+  `str`-coerces non-canonical scalar
   forms for these three attrs — a string `:max-age`, a string/instant
   `:expires`, a string `:same-site` (\"Strict\"/\"Lax\") — because apps
   build cookie attrs from host-data that often arrives as strings, and the
@@ -157,17 +147,15 @@
   `re-frame.ssr.response`; this is the structural shape check.
 
   [Spec-Schemas §`:rf.fx.server/redirect-args`]'s `RedirectFxArgs`, Spec
-  011 §Standard fx, and `re-frame.ssr.response/redirect-fx` all agree:
-  the canonical (and only) target key is `:location` (rf2-vngir / EP-0007
-  one-name-per-fact — this fx writes an HTTP `Location` response header,
-  so it uses header vocabulary). The retired synonyms `:url` / `:to` are
+  011 §Standard fx, and `re-frame.ssr.response/redirect-fx` all use
+  `:location`, matching HTTP `Location` response-header vocabulary. The
+  unsupported synonyms `:url` / `:to` are
   NOT accepted: `redirect-fx` throws `:rf.error/redirect-retired-target-
   key` naming `:location` (no back-compat alias). The schema accepts the
   optional `:string` `:location` plus the optional `:int` `:status`.
 
-  PERMISSIVE on the no-target case (rf2-ee38b.11 contract, the live half
-  of decision rf2-cwfy2). `:location` is optional AND a redirect with NO
-  `:location` PASSES this shape gate — it is not a structural error. A
+  `:location` is optional, and a redirect with no `:location` passes this
+  shape gate because it is not a structural error. A
   target-less redirect is the established
   `:rf.ssr/ssr-redirect-no-target` graceful-degradation path: the
   redirect-fx accepts it (location is caller-trusted/optional at the fx
@@ -175,37 +163,30 @@
   Location header so the defect is observable rather than silently
   shipping a broken redirect. A `[:fn]` clause requiring a target key
   here would 400 the no-target redirect at the Spec 010 §step-5 boundary
-  BEFORE that warn→302 path runs, contradicting ee38b.11 — so the schema
+  before that warn→302 path runs, contradicting the graceful-degradation
+  contract. The schema therefore
   stays a pure shape check (key types only) and lets the no-target case
   fall through to the runtime's warning path."
   [:map
    [:status   {:optional true} :int]      ;; default 302
-   [:location {:optional true} :string]]) ;; canonical (and only) target key (rf2-vngir)
+   [:location {:optional true} :string]]) ;; canonical and only target key
 
 (def safe-redirect-args
   "Args of `:rf.server/safe-redirect` — `:rf.fx.server/safe-redirect-args`.
   `{:location <string> :status? <int> :relative-only? <boolean>
-    :allow? [<string> …]}` — the caller-UNtrusted redirect (open-redirect
-  mitigation, rf2-zfm8v). `:location` is the validation target, so unlike
+    :allow? [<string> …]}` — the caller-untrusted redirect. `:location` is
+  the validation target, so unlike
   the caller-trusted `:rf.server/redirect` (which has a documented no-
-  target graceful path, rf2-ee38b.11) safe-redirect REQUIRES a `:location`
+  target graceful path) safe-redirect requires a `:location`
   to validate — a target-less safe-redirect is a programmer error with no
   defensible interpretation. The five-step URL-parse / scheme / relative-
   only? / allowlist gate lives in `re-frame.ssr.response/safe-redirect-fx`
   and emits the specific `:rf.error/safe-redirect-*` categories; this is
   the structural SHAPE check, completing the `:schema` boundary the other
-  six `:rf.server/*` fxs already carry (rf2-kjf3m.2 / rf2-wtd8z finding 1).
+  six `:rf.server/*` fxs already carry. A malformed argument therefore
+  fails before the response accumulator is mutated.
 
-  The closed gap (rf2-wtd8z finding 1): pre-fix the reg-fx carried only
-  `:platforms` — no `:schema` — so the Spec 010 §step-5 fx-args boundary
-  never ran. A `{:location \"/ok\" :status \"not-int\"}` arg flowed its
-  string `:status` straight through `safe-redirect-fx`'s step-5 pass onto
-  the response accumulator (and onto the wire). With this schema attached
-  the malformed `:status` surfaces as `:rf.error/schema-validation-failure
-  :where :fx-args` at the dispatch site, the fx is skipped, and the
-  response is left unmodified — matching the sibling six.
-
-  PERMISSIVE where the spec intends optionality (the #3202 lesson): only
+  Only
   `:location` is required; `:status` / `:relative-only?` / `:allow` are
   optional. `:allow` is a SEQUENCE of host strings (the fx reads `:allow`,
   not a scalar `:allowlist`). Closed map is avoided — extra keys pass —

--- a/implementation/ssr/src/re_frame/ssr/streaming.cljc
+++ b/implementation/ssr/src/re_frame/ssr/streaming.cljc
@@ -1,7 +1,6 @@
 (ns re-frame.ssr.streaming
   "Streaming SSR — `:rf/suspense-boundary` walker, per-request continuations
-  registry, per-subtree hydration deltas. Per Spec 011 §Streaming SSR
-  (rf2-ojakd / rf2-olb64 (a)).
+  registry, and per-subtree hydration deltas.
 
   ## Chunk-ordering invariant (FIFO over registration)
 
@@ -52,9 +51,7 @@
 
   Host adapters consume these surfaces via late-bind hooks
   (`:ssr.streaming/render-shell!`, `:ssr.streaming/render-continuation!`,
-  `:ssr.streaming/build-final-payload`) registered at ns-load time below.
-
-  Per the rf2-ojakd / rf2-olb64 cluster."
+  `:ssr.streaming/build-final-payload`) registered at namespace load."
   (:require [clojure.data]
             [clojure.string]
             [re-frame.error :as error]
@@ -102,7 +99,7 @@
   inline `<template data-rf2-suspense-fallback>` placeholder in the shell
   HTML.
 
-  rf2-xzhf2a — a `<template>`'s content is INERT by the HTML spec (its
+  A `<template>`'s content is inert by the HTML spec (its
   `.content` is a detached `DocumentFragment`, never painted), so this is
   NOT first-byte-visible content: nothing paints until the client runtime
   (`re-frame.ssr.streaming.client/install!`) materialises each inert
@@ -142,7 +139,7 @@
   (str "<script " wire/attr-suspense-hydrate "=\""
        (html/escape-attr (str id))
        "\" type=\"application/edn\">"
-       ;; rf2-7ksyr / rf2-rdxxa — EDN-aware escape: `<` inside string
+       ;; EDN-aware escape: `<` inside string
        ;; literals becomes `<` so a delta carrying `</script>` from
        ;; a user-controlled string cannot close the envelope, while
        ;; keyword/symbol tokens with `<` (`:<`, `:a<b`) round-trip
@@ -191,7 +188,7 @@
             {}
             (keys only-in-after))))
 
-;; ---- streaming hydration-delta egress projection (rf2-uc3cs4) -------------
+;; ---- streaming hydration-delta egress projection --------------------------
 ;;
 ;; A per-boundary hydration delta is BROWSER-DELIVERED hydration state — it
 ;; arrives in the stream BEFORE the final `__rf_payload` and the client merges
@@ -223,7 +220,7 @@
 (defn project-delta
   "Project a streaming per-subtree hydration `delta` (from `render-continuation`)
   for browser egress before it serialises into the `data-rf2-suspense-hydrate`
-  EDN script (rf2-uc3cs4). Applies the handler's `:payload` allowlist
+  EDN script. Applies the handler's `:payload` allowlist
   (`payload-policy/apply-policy`) then the centralized `:rf.egress/ssr-hydration`
   projection under `frame-id` (`payload-policy/project-app-db-egress`) — the
   SAME allowlist-first-then-project boundary the final `__rf_payload` obeys, so
@@ -263,8 +260,7 @@
   declared `:fallback` hiccup is stored alongside the `:subtree` so the
   drain path (`render-continuation`) can re-materialise it when the
   subtree render throws (Spec 011 §Failure semantics — inline fallback).
-  Without it, a FAILED continuation would render `nil` → empty string,
-  silently dropping the author-declared loading state (rf2-405ld)."
+  A failed continuation therefore preserves the author-declared loading state."
   [acc id subtree fallback]
   (swap! acc conj {:id id :subtree subtree :fallback fallback}))
 
@@ -276,8 +272,7 @@
   `data-rf2-suspense-hydrate` (and matched by the client). Duplicate
   detection MUST key on this, not the raw `:id`, so ids that DIFFER as
   values but COLLIDE under `str` (`:a` keyword vs `\":a\"` string) are
-  treated as the same boundary — the client can only match them by the
-  one wire string (rf2-yvc0t7)."
+  treated as the same boundary because the client can match only the wire id."
   [id]
   (str id))
 
@@ -291,7 +286,7 @@
 
   Duplicates are detected on the canonical WIRE id (`wire-id`, i.e.
   `(str id)`) — the exact string stamped into the suspense attributes and
-  matched by the client (rf2-yvc0t7). Grouping on the raw `:id` would let
+  matched by the client. Grouping on the raw `:id` would let
   string-colliding ids (`:a` keyword vs `\":a\"` string) escape detection
   even though they share one `data-rf2-suspense-id` on the wire, leaving
   two chunks the client can only resolve against the same mount."
@@ -334,25 +329,10 @@
 
 (declare walk-shell)
 
-;; Per rf2-muasb (perf-sweep H2, ai/findings/perf-sweep-2026-05-15.md):
-;; the prior implementation called `(some-suspense-boundary? el)` —
-;; itself a recursive scan of the entire subtree — on every DOM-tag
-;; descent, then took a fast `emit/emit-element` path when the
-;; subtree was boundary-free. For a shell with N DOM nodes the
-;; ancestor-chain scans collectively walked O(N × tree-depth) nodes,
-;; quadratic on deep trees with a buried boundary, and the fast path
-;; saved only one fn-call boundary on a tree-walk that emit-element
-;; would do anyway.
-;;
-;; Replaced with the simplest correct shape: walk always recurses
-;; through DOM-tag children via `walk-dom-tag`. Single keyword check
-;; per node either way. A registered view resolved via `:view`
-;; lookup may itself contain boundaries (the conformance fixture
-;; root does); the recursion-always shape catches those without any
-;; pre-scan. The fast-path option (emit/emit-element on
-;; statically-clean subtrees) cannot see through view-refs and so
-;; cannot serve as a correct pre-filter without the per-descent
-;; cost the audit calls out.
+;; Walk DOM children once and handle suspense boundaries where encountered.
+;; A recursive pre-scan would revisit subtrees and become quadratic on a deep
+;; tree. It would also miss boundaries returned by registered views unless the
+;; view were resolved during both passes.
 
 (defn- walk-children [children acc]
   (clojure.string/join (mapv #(walk-shell % acc) children)))
@@ -360,10 +340,7 @@
 (defn- walk-dom-tag
   "Emit a DOM tag element while recursing into its children with the
   walker (so nested boundaries get caught). Mirrors the non-void branch
-  of `emit/emit-element` but threads `acc` through. Per rf2-muasb the
-  prior shape called `parse-tag-name` twice on `head` (once destructured
-  to `[tag-name _]`, then again to `[_ tag-attrs]`); collapsed to one
-  call here, the binding shape mirrors `emit/emit-element` exactly."
+  of `emit/emit-element`, threads `acc`, and reuses the parsed tag."
   [el acc]
   (let [head                  (first el)
         [tag-name tag-attrs]  (emit/parse-tag-name head)
@@ -371,7 +348,7 @@
                                 [(second el) (drop 2 el)]
                                 [{} (rest el)])
         merged-attrs          (emit/merge-class-attrs tag-attrs user-attrs)
-        ;; rf2-hzttr finding 3 — case-insensitive void classification,
+        ;; Void classification is case-insensitive,
         ;; mirroring the non-streaming emitter. A `[:BR]` admitted by
         ;; `validate-tag-name!` must be recognised as void here too, or the
         ;; shell walker emits a `<BR></BR>` open+close pair. The raw-text
@@ -382,7 +359,7 @@
     (if void?
       (str "<" tag-name (emit/attr-string merged-attrs) ">")
       (do
-        ;; rf2-ee38b.10 — mirror the non-streaming emitter's raw-text body
+        ;; Mirror the non-streaming emitter's raw-text body
         ;; guard so a body-position `<script>`/`<style>` with raw string
         ;; content fails loud in the shell walk too (rather than silently
         ;; `escape-html`-ing it via the standard emitter).
@@ -399,10 +376,8 @@
   `<template>` placeholder + register a continuation for the subtree."
   [el acc]
   (let [attrs    (second el)
-        ;; Per rf2-ezdwh — `children` was a `(drop 2 el)` lazy seq the
-        ;; cond branches below counted twice (`(zero? (count children))`
-        ;; then `(= 1 (count children))`). Realise to a vector once and
-        ;; bind `n` so the cond reads as a constant-time arity dispatch.
+        ;; Realise children once so arity checks and rendering share the same
+        ;; collection.
         children (vec (drop 2 el))
         n        (count children)]
     (when-not (suspense-attrs? attrs)

--- a/implementation/ssr/src/re_frame/ssr/streaming/client.cljs
+++ b/implementation/ssr/src/re_frame/ssr/streaming/client.cljs
@@ -1,8 +1,7 @@
 (ns re-frame.ssr.streaming.client
   "Client-side streaming-SSR runtime — the consumer of the server's
   `<template>` / `<script data-rf2-suspense-hydrate>` delta-chunk
-  protocol. Per Spec 011 §Streaming SSR — client-side hydration
-  semantics (rf2-3hhv5; folds rf2-bee5i part-2).
+  protocol. Per Spec 011 §Streaming SSR client-side hydration semantics.
 
   ## What this is
 
@@ -25,7 +24,7 @@
 
   WITHOUT a client consuming these chunks, the whole protocol is inert:
   the fallback `<template>`s never paint (a `<template>`'s content is a
-  detached `DocumentFragment` by the HTML spec — see chunk (1) / rf2-xzhf2a),
+  detached `DocumentFragment` by the HTML spec),
   the resolved `<template>`s never swap in, and the deltas never merge — the
   browser shows blank boundary regions until the final `__rf_payload` lands,
   then `:rf/hydrate` renders everything at once. Identical UX to
@@ -72,7 +71,7 @@
       body is `escape-edn-script-body`'d — `<` inside string literals
       becomes `\\u003c` (which `cljs.reader/read-string` decodes back),
       while `<` in keyword/symbol tokens (`:<`, `:a<b`) is left intact
-      so the delta round-trips (rf2-rdxxa). (Spec 011 §Hydration
+      so the delta round-trips. (Spec 011 §Hydration
       interleaving's wrapped-shape prose is corrected to this shipped
       contract.)
     - A `data-rf2-suspense-failed=\"1\"` marker on a resolved
@@ -91,11 +90,8 @@
   observer simply never matches a resolved chunk and disconnects on the
   final-payload node.
 
-  Per the rf2-uo7v shipping convention this namespace lives in the
-  `day8/re-frame2-ssr` artefact alongside the rest of the SSR surface
-  (it is NOT eagerly required by the `re-frame.ssr` façade — host
-  opt-in). CLJS-only (`.cljs`): it reaches into the DOM and installs a
-  `MutationObserver`."
+  This namespace is CLJS-only and host-opted-in: it reaches into the DOM and
+  installs a `MutationObserver`."
   (:require [cljs.reader :as reader]
             [re-frame.frame :as frame]
             [re-frame.ssr.constants :as constants]
@@ -107,7 +103,7 @@
 ;; The server↔client streaming wire attribute names live in
 ;; `re-frame.ssr.streaming.constants` so a rename is a one-edit change
 ;; there, not a grep-driven sweep across server, client, and tests
-;; (rf2-3w6dmy finding 2). These MUST match the attributes
+;; These must match the attributes
 ;; `re-frame.ssr.streaming/{suspense-template,hydrate-delta-script}` stamp —
 ;; they read from the SAME `wire` ns, so the agreement is enforced by the
 ;; shared source rather than a comment. Aliased here so the call sites read
@@ -130,7 +126,7 @@
 ;; resolved subtree swaps into) — the same model React 18 / Solid use,
 ;; expressed over the server's `<template>`-marker protocol. Client-owned
 ;; but pinned in the shared `wire` ns alongside the server-emitted
-;; attributes (rf2-3w6dmy finding 2).
+;; attributes.
 (def ^:private attr-suspense-mount     wire/attr-suspense-mount)
 (def ^:private mount-tag               wire/mount-tag)
 
@@ -148,7 +144,7 @@
   on the wire (a hiccup id is only ever a keyword or a string, never a
   symbol). So a SYMBOL parse is always a string id that lost its quotes in
   transit: coerce it back to its printed string, preserving the documented
-  contract that a string id stays a string in trace payloads (rf2-m96yhw).
+  contract that a string id stays a string in trace payloads.
   `(str sym)` faithfully reconstructs the original string for both a bare
   (`card-revenue`) and a slash-bearing (`card/revenue`) string id — `name`
   would drop the namespace segment. Keyword ids (and any other non-symbol
@@ -163,7 +159,7 @@
     (cond
       (= ::fail parsed) s
       ;; A bare-token parse is a symbol — the server emitted a STRING id via
-      ;; `(str id)`, dropping the quotes; recover the string (rf2-m96yhw).
+      ;; `(str id)`, dropping the quotes; recover the string.
       (symbol? parsed)  (str parsed)
       :else             parsed)))
 
@@ -202,7 +198,7 @@
   Spec 011 §Boundary nesting and recursion) and ships only that
   continuation's resolved chunk, so the resolved content must land in the
   last boundary's position; the earlier mounts keep showing their fallback
-  (rf2-8en9mu). For the common single-id case this is just that one mount."
+  For the common single-id case this is just that one mount."
   [root id-str]
   (last (mounts-for root id-str)))
 
@@ -219,7 +215,7 @@
   cannot re-encounter it. We therefore do NOT short-circuit on an existing
   same-id mount — doing so would collapse a DUPLICATE-id boundary's second
   fallback `<template>` into the first boundary's mount, leaving the second
-  template stranded inert in the DOM (rf2-8en9mu). Each declared boundary
+  template stranded inert in the DOM. Each declared boundary
   gets its OWN visible mount; the resolved chunk later targets the LAST one
   (`mount-for`).
 
@@ -248,7 +244,7 @@
   `<template>`'s parsed content, in-place. Targets `mount-for` — the LAST
   mount for the id, so a DUPLICATE-id boundary's single resolved chunk
   (the server's last-write-wins registration) lands in the LAST boundary's
-  position while earlier mounts keep their fallback (rf2-8en9mu). Returns
+  position while earlier mounts keep their fallback. Returns
   true if a mount was found + swapped, false otherwise (a resolved chunk
   with no matching fallback mount yet — e.g. a nested inner chunk racing
   ahead of its mount). The mount wrapper itself stays in the DOM carrying
@@ -308,8 +304,8 @@
     - a PARSEABLE-but-non-map value (`[…]`, `42`, `\"x\"`, `:k`) — a
       server/client wire-shape regression that `read-string` accepts but
       which `merge-delta!`'s `(map? delta)` guard would silently no-op,
-      swapping the resolved HTML + removing the script while leaving app-db
-      stale and emitting NO diagnostic (rf2-l3paoi).
+      swapping the resolved HTML and removing the script while leaving app-db
+      stale without a diagnostic.
 
   A nil parse (an empty / whitespace-only body) is the documented no-delta
   shape — NOT malformed — and returns nil without a trace, matching the
@@ -346,7 +342,7 @@
   sibling position. A malformed delta (unparseable EDN, or parseable but
   non-map) is skipped with a trace — a bad speculative chunk must not
   break hydration (the final payload is the correctness lock), but it must
-  also not silently pass for a successful hydration (rf2-l3paoi)."
+  also not silently pass for a successful hydration."
   [root frame-id id-str]
   (when-let [script (->> (query-by-attr root attr-suspense-hydrate)
                          (filter #(= id-str (.getAttribute % attr-suspense-hydrate)))
@@ -374,7 +370,7 @@
   same node (defensive — MutationObserver batching + the initial sweep
   can both surface the same node). Idempotent.
 
-  rf2-58zvy1 finding 4 — an id is marked `seen` ONLY after a successful
+  An id is marked `seen` only after a successful
   swap, and the swapped-in content is re-scanned for fallback templates
   before later resolved templates are processed. Two coupled corners for
   a NESTED boundary whose inner chunk is ALREADY present when the client
@@ -420,7 +416,7 @@
           ;; later in this same sweep has a mount to swap into (finding 4).
           (materialise-fallbacks! root))
         (cond
-          ;; rf2-8ymnem — the failed-boundary trace is gated on swap SUCCESS.
+          ;; The failed-boundary trace is gated on swap success.
           ;; The failed content (the author's fallback HTML) only lands when
           ;; `replace-mount-content!` finds a live mount, so emitting exactly
           ;; when the swap happens is both correct and exactly-once: `seen` is
@@ -450,8 +446,8 @@
   reports new nodes. Fallback materialisation runs FIRST so a resolved
   chunk in the same batch always finds a live mount to swap into.
 
-  rf2-58zvy1 finding 4 — the resolved-processing pass iterates to a
-  FIXPOINT. A nested boundary whose inner resolved chunk is already in
+  The resolved-processing pass iterates to a fixpoint. A nested boundary whose
+  inner resolved chunk is already in
   the DOM when the client installs late only gets its live mount AFTER
   the outer mount is swapped (the inner fallback was inert template
   content inside the outer resolved <template>). A single document-order
@@ -475,8 +471,8 @@
         (recur)))))
 
 (defn- element-by-id
-  "Find an element with id `id` under `root` WITHOUT building a raw `#id`
-  CSS selector. Per rf2-58zvy1 finding 3 — a `:payload-id` override that
+  "Find an element with id `id` under `root` without building a raw `#id`
+  CSS selector. A `:payload-id` override that
   is a VALID HTML id but contains CSS-selector-significant chars (`.`,
   `:`, `[`, space, …) makes `(.querySelector root (str \"#\" id))` either
   select the wrong element or throw a `SyntaxError`, breaking `install!`.
@@ -500,7 +496,7 @@
   disconnect (the final `:rf/hydrate` is the reconciliation point;
   deltas after it would race the canonical replace).
 
-  Per rf2-58zvy1 finding 3 — matches the payload by EXACT id string via
+  Matches the payload by exact id string via
   `element-by-id`, never a raw `#id` CSS selector, so a documented
   `:payload-id` override with CSS-special chars cannot throw or mis-match."
   [root payload-id]
@@ -520,8 +516,7 @@
 
     :frame      — REQUIRED. The target frame id whose app-db receives the
                   deltas — the SAME frame the bootstrap `ssr/hydrate!`s
-                  into and the root provider mounts (EP-0002 rf2-acjknb —
-                  one carried frame; the streaming target is supplied, not
+                  into and the root provider mounts. The streaming target is supplied, not
                   synthesised). An absent `:frame` emits + throws
                   `:rf.error/no-frame-context` (the pre-EP `:rf/default`
                   default is removed).
@@ -564,14 +559,14 @@
            ))"
   ([] (install! {}))
   ([{:keys [frame root payload-id]
-     ;; EP-0002 (rf2-acjknb): NO `:or {frame :rf/default}` floor — a nil
-     ;; frame is an absent target that `require-frame-stamp!` (below) fails
+     ;; No implicit default: a nil frame is an absent target that
+     ;; `require-frame-stamp!` fails
      ;; closed on, never a synthesised `:rf/default`. `payload-id` defaults
      ;; to the pinned `constants/payload-script-id` (main).
      :or   {root       (when (exists? js/document) js/document)
             payload-id constants/payload-script-id}}]
-   ;; EP-0002 (rf2-acjknb): the streaming delta-merge target is CARRIED —
-   ;; supplied explicitly via `:frame`. A nil stamp is an absent target,
+   ;; The streaming delta-merge target is supplied explicitly via `:frame`.
+   ;; A nil stamp is an absent target,
    ;; not a request to synthesise `:rf/default`; surface the always-on
    ;; `:rf.error/no-frame-context`. Per Spec 002 §Frame target resolution.
    (let [frame (frame/require-frame-stamp!

--- a/implementation/ssr/src/re_frame/ssr/streaming/constants.cljc
+++ b/implementation/ssr/src/re_frame/ssr/streaming/constants.cljc
@@ -13,13 +13,11 @@
   hydration-payload script id (per Spec 011 §Hydration payload script id),
   applied to the streaming surface.
 
-  A SIBLING of `re-frame.ssr.constants` rather than an extension of it:
+  This is a sibling of `re-frame.ssr.constants` rather than an extension:
   these strings are streaming-specific machinery (the `:rf/suspense-boundary`
   protocol, Spec 011 §Streaming SSR), so they co-locate with the streaming
   namespaces and stay off the lean `constants` ns that the non-streaming
-  boot helper (`re-frame.ssr.boot`) already depends on.
-
-  Per best-practice review rf2-3w6dmy finding 2. Renaming a constant here
+  boot helper (`re-frame.ssr.boot`) already depends on. Renaming a constant here
   changes the on-wire token — see the `attr-*` docstrings for the
   server↔client matching contract before changing a value.")
 
@@ -40,7 +38,7 @@
 (def ^:const attr-suspense-fallback
   "Marker on the inline fallback `<template>` the shell walk emits, so the
   client knows which templates to materialise into live, visible mounts.
-  rf2-xzhf2a — the `<template>` content is INERT (never painted) until the
+  The `<template>` content is inert until the
   client runtime runs; the marked template is the wire-carrier, the painted
   fallback is the client-materialised `<rf-suspense>` mount, NOT first-byte
   content."

--- a/implementation/ssr/src/re_frame/ssr/substrate.cljc
+++ b/implementation/ssr/src/re_frame/ssr/substrate.cljc
@@ -1,5 +1,5 @@
 (ns re-frame.ssr.substrate
-  "The SSR substrate adapter (rf2-agql). Per Spec 006 §Plain-atom adapter
+  "The SSR substrate adapter. Per Spec 006 §Plain-atom adapter
   and Spec 011 §init flow.
 
   Each adapter ns exports an `adapter` var that the consumer passes to
@@ -12,17 +12,13 @@
                '[re-frame.ssr :as ssr])
       (rf/init! ssr/adapter)
 
-  The render slot deliberately throws — SSR uses render-to-string
-  exclusively; see Spec 006 §Plain-atom adapter and rf2-z1ke (substrate
-  contract portability findings). Eight of the nine contract slots are
-  implemented cleanly; render is the deliberate exception.
+  The render slot deliberately throws because the adapter has no DOM host;
+  SSR callers use `render-to-string` exclusively.
 
   Internal implementation namespace. The public adapter remains
   re-frame.ssr/adapter; this ns deliberately avoids
   re-frame.ssr.adapter so CLJS does not see a child-namespace /
-  parent-var name clash.
-
-  Per the rf2-gxgo7 split of re-frame.ssr."
+  parent-var name clash."
   (:require [re-frame.error :as error]
             [re-frame.ssr.emit :as emit]))
 
@@ -51,8 +47,7 @@
 
 (defn- ssr-render [_ _ _]
   ;; SSR uses render-to-string exclusively. Calling render on the SSR
-  ;; adapter is a programmer error worth surfacing loudly. Per Spec 006
-  ;; §Plain-atom adapter and rf2-z1ke.
+  ;; adapter is a programmer error worth surfacing loudly.
   (error/throw-error!
     :rf.error/render-on-headless-adapter
     'rf/render
@@ -79,9 +74,9 @@
 
   Server-side and headless processes use this adapter — it carries
   re-frame.ssr's render-to-string directly in the :render-to-string
-  slot, no late-bind wiring required at the call site. The :render slot
+  slot, with no late-bind wiring required at the call site. The :render slot
   throws (`:rf.error/render-on-headless-adapter`) — SSR uses
-  render-to-string exclusively. Per rf2-agql and Spec 011 §init flow."
+  render-to-string exclusively."
   {:kind                      :rf.adapter/ssr
    :make-state-container      ssr-make-state-container
    :read-container            ssr-read-container

--- a/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
@@ -249,11 +249,11 @@
 ;;
 ;; Per Spec 011 §Multiple-status policy: two :rf.server/set-status fx in a
 ;; single drain → last write wins AND a :rf.warning/multiple-status-set trace
-;; fires. Accumulator lives in app-db at [:rf/response]; resolved view via
-;; re-frame.ssr/get-response.
+;; fires. The accumulator is a per-frame side channel read through
+;; `re-frame.ssr/get-response`; it never enters app-db.
 
 (defn- get-response
-  "Read the resolved :rf/response accumulator for a frame."
+  "Read the resolved response accumulator for a frame."
   [frame-id]
   (ssr/get-response frame-id))
 

--- a/implementation/ssr/test/re_frame/ssr_streaming_corner_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_streaming_corner_test.clj
@@ -542,13 +542,11 @@
 ;; Privacy boundary — request slot / response accumulator NOT readable
 ;; from app-db. The privacy contract is "MUST NOT ride app-db"
 ;; (Spec 011 §Request storage substrate + §Response storage substrate).
-;; Pre-rf2-jbcmt the response accumulator DID live on app-db; we pin
-;; the post-fix invariant so a regression that re-introduces an app-db
-;; backing fires loudly.
+;; Pin the side-channel invariant so an app-db-backed regression fails loudly.
 ;; ===========================================================================
 
 (deftest response-accumulator-not-on-app-db-privacy-invariant
-  (testing "rf2-u91hb: writing an :rf.server/* fx MUST NOT populate any
+  (testing "writing an :rf.server/* fx MUST NOT populate any
             key under app-db. Per Spec 011 §Response storage substrate
             (rf2-jbcmt) — privacy boundary: response accumulator data
             (Set-Cookie, internal X-* headers) MUST NOT default-leak
@@ -565,12 +563,11 @@
          :initial-events [[:test/server-write]]})
       (let [app-db (frame/frame-app-db-value fid)]
         ;; Spec 011 §Response storage substrate: NO app-db key may
-        ;; carry the accumulator. Pin both the published reserved key
-        ;; AND the sentinel key the pre-jbcmt path used.
+        ;; carry the accumulator. Pin both the published reserved key and the
+        ;; old sentinel spelling.
         (is (not (contains? app-db :rf/response))
-            "app-db MUST NOT carry :rf/response — pre-rf2-jbcmt this
-             was the storage path; the post-fix invariant is the
-             side-channel atom in re-frame.ssr.response/response-slots")
+            "app-db MUST NOT carry :rf/response; the accumulator lives in
+             re-frame.ssr.response/response-slots")
         ;; Defensive: also assert no key with substring "response" or
         ;; "cookie" in the keyword name (a sloppy refactor that picks
         ;; a different key name on app-db would still violate).


### PR DESCRIPTION
## Summary

- replace historical audit and bead narration with current SSR contracts
- clarify request/response side-channel privacy, hydration targeting, streaming chunk ordering, and fail-closed payload projection
- correct stale error-listener and test explanations that still described the response accumulator as app-db-backed

All changes are comments, namespace documentation, registration metadata documentation, or test descriptions. Runtime behavior is unchanged.

## Verification

- `clojure -M:test` from `implementation/ssr`: 372 tests, 1535 assertions, 0 failures/errors
- `npm run test:cljs` compile completed; `node out/node-test.js`: 8465 tests, 39156 assertions, 0 failures/errors
- `clj-kondo --lint implementation/ssr/src implementation/ssr/test`: 0 errors (34 existing warnings)
- `git diff --check`
