### PR TITLE
docs(ssr-ring): focus comments on current contracts (rf2-zo1c9e)

### DIFF
--- a/implementation/ssr-ring/deps.edn
+++ b/implementation/ssr-ring/deps.edn
@@ -1,34 +1,7 @@
-;; day8/re-frame2-ssr-ring — Ring/Pedestal host adapter (rf2-ny6v7).
-;;
-;; Per Spec 011 §HTTP response contract: "the host adapter is
-;; responsible for materialising :response into the wire format its
-;; server framework expects (Ring map, Express response, Fastify reply,
-;; etc.). The runtime never writes to a network socket directly — the
-;; response shape is the contract; transport is the host's concern."
-;;
-;; This artefact is that host adapter for Ring. It supplies the
-;; `ssr-handler` fn — a Ring-shaped (req → resp) handler that per
-;; request:
-;;
-;;   1. Creates a per-request frame via re-frame.core/make-frame with
-;;      :platform :server and the :initial-events vector the caller supplies.
-;;   2. Awaits the dispatch-queue drain (synchronous on the JVM —
-;;      `make-frame` returns post-drain per Spec 002 §dispatch).
-;;   3. Reads the resolved response accumulator via
-;;      re-frame.ssr/get-response (which flushes pending error
-;;      projections before reading).
-;;   4. Short-circuits when :redirect is set (no body; Location header).
-;;   5. Otherwise renders the root view to HTML via render-to-string,
-;;      builds the hydration payload, and wraps in an HTML envelope.
-;;   6. Materialises :cookies → Set-Cookie wire form per RFC 6265.
-;;   7. Destroys the per-request frame in a `finally` block.
-;;
-;; Plus an `ssr-middleware` fn for composing with other Ring middlewares.
-;; Per Spec 011 §Request storage substrate, the adapter populates the
-;; per-frame request slot via `re-frame.ssr/set-request!` before the
-;; drain so the `:rf.server/request` cofx (rf2-e825b) surfaces the
-;; Ring request to handlers that declare
-;; `{:rf.cofx/requires [:rf.server/request]}`.
+;; Ring host adapter for re-frame2 SSR. It creates a server frame per
+;; request, makes the Ring request available before the synchronous initial
+;; event drain, renders or redirects from the resolved response accumulator,
+;; materialises headers and cookies, and always tears the frame down.
 ;;
 ;; Consumers add this artefact alongside core and ssr:
 ;;
@@ -39,26 +12,16 @@
 ;; And require `re-frame.ssr.ring` in any namespace that wires the
 ;; runtime up to a Ring server (Jetty, HttpKit, Pedestal, Reitit-ring).
 ;;
-;; Per Spec 006 §Adapter shipping convention and the rf2-p7va extension
-;; to per-feature splits: this artefact depends on core + ssr; neither
-;; depends on this artefact. Pedestal/HttpKit variants would be additive
-;; sibling artefacts (ssr-pedestal, ssr-httpkit) sharing the same
-;; per-request contract.
+;; Per Spec 006 §Adapter shipping convention, this optional artefact depends
+;; on core and SSR; neither depends on it.
 {:paths ["src"]
  :deps  {day8/re-frame2     {:local/root "../core"}
          day8/re-frame2-ssr {:local/root "../ssr"}}
 
  :aliases
- {:test {;; rf2-09iktm — the per-test reset is now artefact-local
-         ;; (`re-frame.ssr.ring.test-support/reset-runtime`), built on
-         ;; the published `re-frame.test-support/make-reset-runtime-
-         ;; fixture` (core/src) plus the four SSR per-request side-channel
-         ;; atom resets (reached through the existing `day8/re-frame2-ssr`
-         ;; production dep). The former `../ssr/test` source dir — which
-         ;; only hosted the shared `re-frame.ssr.test-fixture` ns — is
-         ;; removed: the Clojure CLI deprecates `:paths` external to the
-         ;; project, and nothing here reaches the sibling test tree any
-         ;; more.
+ {:test {;; The local fixture combines core's public reset fixture with the
+         ;; SSR per-request side-channel resets available through the
+         ;; production SSR dependency.
          :extra-paths ["test"]
          ;; Mirrors implementation/ssr/deps.edn :test alias — schemas /
          ;; flows / routing / machines load at ns-load time and the
@@ -67,41 +30,22 @@
                        day8/re-frame2-flows      {:local/root "../flows"}
                        day8/re-frame2-routing    {:local/root "../routing"}
                        day8/re-frame2-machines   {:local/root "../machines"}
-                       ;; rf2-p026f5 — the non-streaming resource-projection
-                       ;; regression seeds a frame-sensitive `{:from-db}`
-                       ;; resource and asserts the emitted `__rf_payload`
-                       ;; redacts it (the projection MUST run INSIDE the
-                       ;; request frame scope). Resources is a test-only dep
-                       ;; here, as in the sibling `implementation/ssr/deps.edn`.
+                       ;; Resource payload tests require the optional hooks
+                       ;; without adding them to the published adapter.
                        day8/re-frame2-resources  {:local/root "../resources"}
-                       ;; rf2-try1x — silent-on-success reporter.
+                       ;; Silent-on-success reporter.
                        day8/re-frame2-test-quiet {:local/root "../test-quiet"}
-                       ;; rf2-to8pm — JVM-side e2e validator coverage spins
-                       ;; up a real Jetty host on an ephemeral port and hits
-                       ;; it with java.net.http (built into the JDK) so the
-                       ;; validator failure-mode tests observe BYTES on the
-                       ;; wire rather than function-call return values.
-                       ;; Test-only — neither dep is in :paths and they do
-                       ;; not appear in the published clein/build artefact.
+                       ;; End-to-end tests observe bytes through a real Jetty
+                       ;; host. These test dependencies are not published.
                        ring/ring-jetty-adapter {:mvn/version "1.12.1"}
                        io.github.cognitect-labs/test-runner
                        {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
-         ;; rf2-bv2qqm — the default PR/local gate EXCLUDES the heavy
-         ;; `^:stress` namespace (here: `concurrency_stress_test`, three
-         ;; multi-thread Jetty + java.net.http burst tests). The runner
-         ;; passes `-e` through to cognitect-test-runner verbatim. Coverage
-         ;; is NOT lost: the `:slow-test` alias below runs the excluded
-         ;; tests, invoked by the nightly `expensive-tests.yml` job and
-         ;; `scripts/test-rigorous-local.sh`.
+         ;; The default gate excludes live-host stress tests; the nightly
+         ;; alias below runs only those excluded tests.
          :main-opts   ["-m" "re-frame.test-quiet.runner" "--dir" "test"
                        "-e" ":slow" "-e" ":stress"]}
 
-  ;; rf2-bv2qqm — nightly/rigorous slow-test gate. INCLUDES ONLY the
-  ;; `^:slow` / `^:stress` tests (the union the default `:test` alias
-  ;; excludes), so the default `:test` run plus this `:slow-test` run
-  ;; together cover every test exactly once. Invoked by the nightly
-  ;; `.github/workflows/expensive-tests.yml` job and the local
-  ;; `scripts/test-rigorous-local.sh` sweep.
+  ;; Nightly/rigorous gate: includes only tests excluded by `:test`.
   :slow-test
   {:extra-paths ["test"]
    :extra-deps  {day8/re-frame2-schemas    {:local/root "../schemas"}
@@ -116,7 +60,7 @@
    :main-opts   ["-m" "re-frame.test-quiet.runner" "--dir" "test"
                  "-i" ":slow" "-i" ":stress"]}
 
-  ;; Clojars deploy (rf2-r382). Modeled on the per-feature artefacts.
+  ;; Clojars deployment.
   ;; The release workflow swaps :local/root → :mvn/version before
   ;; invoking clein.
   :clein {:extra-deps {io.github.noahtheduke/clein

--- a/implementation/ssr-ring/src/re_frame/ssr/ring.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring.clj
@@ -1,145 +1,44 @@
 (ns re-frame.ssr.ring
-  "Ring/Pedestal host adapter for re-frame2 SSR. Per Spec 011 §HTTP
-  response contract and the rf2-ny6v7 host-adapter brief.
+  "Ring host adapter for re-frame2 SSR, per Spec 011.
 
-  Spec 011 §357–363 names the host adapter as the layer responsible for
-  materialising the runtime's `:response` accumulator into the wire
-  format its server framework expects. The SSR runtime never writes to
-  a network socket directly; it owns the request lifecycle (frame
-  create → drain → response read → frame destroy) and a structured
-  response shape; the host adapter wires that shape to a real HTTP
-  server.
+  Each synchronous request receives an isolated server frame. The adapter
+  stores the Ring request before the initial-event drain, reads the resolved
+  response accumulator, renders or redirects, materialises Ring headers and
+  cookies, and tears the frame down. Response metadata lives outside app-db,
+  so it cannot enter the hydration payload through app-db projection.
 
-  Privacy note (rf2-jbcmt): the response accumulator is **side-channel
-  storage** — Spec 011 §Response storage substrate locks it in a
-  framework-private atom keyed by frame-id, NOT in `app-db`. Consequence
-  for this adapter: the hydration payload built from `app-db` cannot
-  carry server-only response data (Set-Cookie auth tokens, internal
-  `X-*` headers, redirect targets) by accident — the boundary is
-  enforced at the storage layer rather than via `:payload` allowlist
-  filtering on every host endpoint. `build-payload` (in
-  `re-frame.ssr.ring.payload`) ships the app-db slice exactly because
-  the accumulator is structurally outside app-db.
-
-  This namespace ships that adapter for Ring (https://github.com/ring-clojure).
-  Ring is the canonical Clojure HTTP-server abstraction; the
-  request/response maps documented at the Ring Concepts wiki page
-  (`:status`, `:headers`, `:body` on responses; `:uri`,
-  `:request-method`, `:headers`, etc. on requests) are the wire shape
-  this adapter consumes and produces. Pedestal, HttpKit, Reitit-ring,
-  and Jetty all accept Ring-shaped handlers, so a single adapter covers
-  the bulk of the Clojure HTTP ecosystem.
-
-  ---- file split (rf2-pjsrc, rf2-zkca8.1) ----
-
-  This namespace is a thin façade over flat sub-namespaces, one concern
-  each (see the `:require` list): `cookie` (RFC 6265 Set-Cookie),
-  `headers` (pair-vec → Ring header-map collapse + content-type
-  default), `shell` (`default-html-shell` + shared envelope helpers),
-  `payload` (`build-payload` — the non-streaming wrapper over the
-  shared `re-frame.ssr.payload-policy` version-resolution + assembly),
-  `lifecycle` (frame teardown, root-view / head resolution, the
-  construction-time validation triple `validate-construction-opts!`, the
-  `:on-error` precedence `resolve-on-error`, and `default-on-error`),
-  `pipeline` (the 4-step request pipeline + accumulator → Ring-map
-  materialiser), `trust` (trusted-shell-hook contract), `streaming`
-  (chunked-HTTP counterpart). `handler-defaults` lives here so the
-  handler constructor reads top-down as one concept; the construction
-  validation + on-error resolution it composes are shared verbatim with
-  `stream-handler`, so they live in `lifecycle`.
-
-  This façade re-exposes the public surface (`ssr-handler`,
-  `ssr-middleware`, `stream-handler`, `cookie->set-cookie-header`,
-  `default-html-shell`) and wires the sub-namespaces into the request
-  lifecycle.
-
-  Public surface:
-
-    (ssr-handler opts)                     → ring-handler-fn
-    (ssr-middleware opts)                  → ((handler) → wrapped-handler)
-    (cookie->set-cookie-header cookie-map) → string
-    (default-html-shell body-html payload-edn opts) → string
-
-  Per-request flow inside `ssr-handler` (the four pipeline steps live
-  in `re-frame.ssr.ring.pipeline`):
-
-    1. `setup-request-frame!` — populate the per-frame request slot
-       via `ssr/set-request!` BEFORE registering the frame so the
-       synchronous `:initial-events` drain can resolve `:rf.server/request`
-       (Spec 011 §Request storage substrate).
-    2. `ssr/get-response` — read the resolved response accumulator
-       (flushes any pending error projection per Spec 011 §Server
-       error projection).
-    3. Branch on `:redirect` — emit a Ring response with status +
-       Location header only, no body, no payload (Spec 011 §Redirect
-       precedence). Otherwise `build-full-response` renders the
-       `:root-view`, builds the hydration payload, wraps in the
-       `:html-shell` envelope, and materialises structured cookies to
-       Set-Cookie headers per RFC 6265.
-    4. `destroy-frame!` in `finally` — the `:ssr/on-frame-destroyed`
-       hook clears the per-frame request slot in the same step
-       (rf2-fcj33).
-
-  Streaming counterpart: `stream-handler` (re-exported below from
-  `re-frame.ssr.ring.streaming`) is the chunked-HTTP sibling of
-  `ssr-handler` — it flushes a shell on first byte and streams
-  `:rf/suspense-boundary` subtrees as their data resolves (Spec 011
-  §Streaming SSR; rf2-ojakd / rf2-olb64). `ssr-handler` itself is
-  single-shot: it mirrors `render-to-string`.
-
-  Out of scope (deferred / other beads):
-
-    - Async Ring handler (3-arity) — synchronous-only in v1;
-      extension is additive."
+  This façade exposes the non-streaming handler and middleware, the streaming
+  handler, the default shell, and cookie serialization."
   (:require [re-frame.error :as error]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.ring.cookie :as cookie]
             [re-frame.ssr.ring.lifecycle :as lifecycle]
             [re-frame.ssr.ring.pipeline :as pipeline]
             [re-frame.ssr.ring.shell :as shell]
-            ;; rf2-ojakd / rf2-olb64 (a) — streaming SSR adapter. Loaded
-            ;; eagerly so `stream-handler` resolves at the façade. The
-            ;; streaming surface is the chunked-HTTP counterpart of
-            ;; `ssr-handler`; non-streaming consumers don't pay any
-            ;; per-request cost (the writer thread is only spawned on
-            ;; a `stream-handler` call site).
+            ;; Loaded eagerly for the façade; only stream-handler requests
+            ;; create writer threads.
             [re-frame.ssr.ring.streaming :as streaming]))
 
 (set! *warn-on-reflection* true)
 
 ;; ---- public-surface re-exports --------------------------------------------
 ;;
-;; The façade re-exposes sub-namespace fns at `re-frame.ssr.ring/<name>`
-;; so consumers see the same surface they did pre-split (rf2-pjsrc /
-;; rf2-zkca8.1). A plain `(def alias other-ns/fn)` copies the VALUE but
-;; NOT the var metadata, so REPL `doc`, editor hover, completion, and the
-;; JVM-introspected api-manifest all saw EMPTY docs + nil arglists at the
-;; very namespace users are told to require (rf2-l1qgjw issue 1). The
-;; `import-fn` macro below re-points the alias AND copies the source var's
-;; authored `:doc` / `:arglists` onto the façade var, so the canonical
-;; function contract surfaces at the façade boundary. `:added` /
-;; `:deprecated` ride along when present (forward-compatible); `:line` /
-;; `:file` are deliberately NOT copied (they point at the implementation
-;; ns, which is the correct source-navigation target — the façade docs
-;; name the sub-namespace for deeper detail).
+;; Bare defs lose source var metadata. Preserve public docs and arglists while
+;; leaving source-navigation metadata at the implementation var.
 
 (defmacro ^:private import-fn
   "Re-export `src-sym` (a fully-qualified var symbol) at this namespace
   under the same name, preserving its `:doc` + `:arglists` (and `:added`
   / `:deprecated` when present). Unlike a bare `(def alias src)` — which
   drops all metadata — the façade var carries the source var's authored
-  contract so REPL/editor/api-manifest tooling sees real docs + arglists
-  at `re-frame.ssr.ring/<name>` (rf2-l1qgjw).
+  contract for REPL, editor, and API-manifest tooling.
 
   The metadata is copied via `alter-meta!` AFTER the `def` (rather than
   attached to the def symbol literal) so the `:arglists` value — a list
   of param vectors — is treated as DATA, not evaluated as a form."
   [src-sym]
   (when-not (resolve src-sym)
-    ;; Internal compile-time author error: a typo'd source symbol in an
-    ;; `import-fn` re-export above. Routed through the canonical builder so
-    ;; even this build-time exception carries `:rf.error/id` + `:reason`
-    ;; (rf2-vvixub). It never reaches a runtime/app channel.
+    ;; Author error at namespace load; retain the canonical structured shape.
     (error/throw-error!
       :rf.error/ssr-ring-import-fn-unresolved
       'rf.ssr.ring/import-fn
@@ -159,22 +58,15 @@
 (import-fn cookie/cookie->set-cookie-header)
 (import-fn shell/default-html-shell)
 
-;; Streaming SSR surface (rf2-ojakd / rf2-olb64 (a)) — chunked-HTTP
-;; counterpart of `ssr-handler`. Per Spec 011 §Streaming SSR.
+;; Chunked-HTTP counterpart of `ssr-handler`.
 (import-fn streaming/stream-handler)
 (import-fn streaming/default-streaming-prefix)
 (import-fn streaming/default-streaming-suffix)
 
 ;; ---- handler defaults + re-exported construction helpers ------------------
 ;;
-;; Co-located with the handler constructor so the file reads top-down as
-;; one concept. `default-on-error` is re-exported from `lifecycle`
-;; (shared with `stream-handler` so the rf2-kzvwq topology-leak contract
-;; lives in one place). The construction-time validation triple
-;; (`validate-construction-opts!`) and the `:on-error` precedence
-;; (`resolve-on-error`) also live in `lifecycle` — shared verbatim with
-;; `stream-handler` so the fail-closed-at-boot + on-error contracts are
-;; single-sourced.
+;; Construction validation and error fallback live in lifecycle because both
+;; handlers use the same boot boundary.
 
 ;; `default-on-error` is a DATA var (a 2-arity fn VALUE held in a `def`,
 ;; not a `defn`), so it carries no `:arglists`. Re-export it copying the
@@ -193,14 +85,14 @@
   `lifecycle/resolve-on-error` so the defaults stay orthogonal to
   on-error precedence).
 
-  `:content-type` carries NO default (rf2-nncni3): the opt is a genuine
+  `:content-type` carries no default: the opt is a genuine
   override that force-replaces the response Content-Type when supplied.
   A default of `text/html; charset=utf-8` here would force-replace an
   app's own `:rf.server/set-header \"content-type\"` on every request; an
   absent (nil) opt instead leaves the runtime's default-seeded
   `text/html; charset=utf-8` (Spec 011 §Status defaults) — or the app's
   explicit Content-Type — in control. So the on-the-wire default is
-  unchanged; only its source moves from this map to the runtime seed."
+  unchanged."
   {:emit-hash? true
    :html-shell shell/default-html-shell})
 
@@ -212,31 +104,15 @@
 
   Required opts:
 
-    :initial-events — the EP-0027 construction setup: an ordered VECTOR of
-                   events dispatched synchronously, in order, into the
-                   per-request frame at creation. The adapter lowers it
-                   verbatim into the top-level `make-frame`'s `:initial-events`
-                   (EP-0027 §SSR — \"a server computes its `:initial-events`
-                   vector per request\"). Accepted in EITHER form:
-                     • a VECTOR of event-vectors (e.g. `[[:rf/server-init]]`),
-                       OR
-                     • a `(fn [request] -> initial-events-vector)` deriving the
-                       setup vector from the Ring request (rf2-kzns7l). The fn
-                       is called once per request, before the drain; its result
-                       must be an `:initial-events` vector. Use it to fold a
-                       request-derived fact into a boot event's PAYLOAD — the
-                       replay-safe recordable boundary, e.g.
-                       `(fn [req] [[:auth/server-init {:user (extract-user req)}]])`
-                       (Spec 011 §Request storage substrate, durable
-                       request-derived-fact pattern).
-                   For NON-durable request reads inside a handler, declare
-                   `:rf.cofx/requires [:rf.server/request]` on the
-                   registration (EP-0017 — `inject-cofx` is removed) — Spec
-                   011 §Request storage substrate (rf2-afxhv) names that cofx
-                   as the canonical ambient read surface.
-    :root-view   — either a hiccup vector (e.g. `[:app/root]`) OR a
-                   0-arity fn returning hiccup. Rendered against the
-                   per-request frame after the drain settles.
+    :initial-events — ordered event vector, or `(fn [request] events)` called
+                      once before the drain. Put durable request-derived facts
+                      in an event payload; use the `:rf.server/request` coeffect
+                      for ambient request reads.
+    :root-view      — hiccup vector or 0-arity fn returning hiccup, rendered
+                      against the settled request frame.
+    :payload        — non-empty allowlist of top-level app-db keys, or the
+                      explicit `:rf.ssr.payload/whole-app-db` opt-in. Missing
+                      and unknown policies fail at handler construction.
 
   Optional opts:
 
@@ -246,138 +122,39 @@
     :ssr            — per-frame `:ssr` config map (e.g.
                       `{:dev-error-detail? true
                         :public-error-id   :myapp/projector}`).
-    :emit-hash?     — embed `data-rf-render-hash` on the root element
-                      (default true).
+    :emit-hash?     — emit hydration hash markers (default true).
     :version        — hydration payload's `:rf/version` (default 1).
     :schema-digest  — hydration payload's `:rf/schema-digest`, when
                       the app participates in the digest check.
-    :payload        — Hydration-payload policy — REQUIRED, fail-closed
-                      (rf2-gtgf9; single-opt consolidation rf2-pffil).
-                      One opt, two shapes:
-                        • a non-empty VECTOR of top-level app-db keys —
-                          an allowlist (recommended). Only the listed
-                          keys ship in the payload's `:rf/app-db`; every
-                          other key is dropped, including keys added
-                          later as the app evolves.
-                        • the KEYWORD `:rf.ssr.payload/whole-app-db` —
-                          opts into shipping the whole `app-db`. Use only
-                          when the app's `app-db` is structurally safe to
-                          expose end-to-end.
-                      Absence throws `:rf.error/ssr-missing-payload-policy`
-                      at handler-construction time; an unrecognised
-                      keyword throws `:rf.error/ssr-unknown-payload-policy`.
-                      The single opt removes the prior surface's
-                      precedence/silent-ignore ambiguity — one value holds
-                      exactly one policy; the allowlist-vs-whole choice is
-                      the value's shape, not a contest between two opts.
     :html-shell     — (body-html payload-edn opts) → string. Defaults
                       to `default-html-shell`. Replace to inject custom
                       <head>, scripts, JSON-LD, etc.
-    :content-type   — Content-Type OVERRIDE for the successfully-rendered
-                      response body (rf2-nncni3). When supplied, it
-                      force-replaces the response Content-Type (any casing)
-                      — the surface for serving a non-HTML SSR body (XML
-                      feed / sitemap, `application/xhtml+xml`, …). OMIT it
-                      (the default) to leave the runtime's default-seeded
-                      \"text/html; charset=utf-8\" — or an app's own
-                      `:rf.server/set-header \"content-type\"` — in control.
-                      The override applies to the rendered body only; a
-                      projected error page keeps the HTML default.
+    :content-type   — successful-body Content-Type override. Omit it to retain
+                      the runtime or app header. Projected HTML errors do not
+                      inherit this override.
 
-  ---- :on-error vs :error-view — the error-handling division (rf2-s2ndr) ----
+    :error-view     — registered-view keyword or `(fn [public-error] hiccup)`
+                      for projected drain/render errors. A failing error view
+                      falls back to the host template.
+    :on-error       — `(fn [request throwable] ring-response)` for setup,
+                      materialisation, and transport failures outside the
+                      projector. Its default and fallback expose no throwable
+                      detail.
 
-  TWO error opts handle TWO different failures. They are NOT alternatives;
-  a robust deployment usually wires BOTH. Pick by asking \"which failure
-  am I handling?\":
+  Trusted shell opts are structurally checked at construction. `:head` and
+  `:body-end` are raw content hooks and must not contain untrusted input;
+  `:script-src` and `:app-element-id` are escaped attribute values.
 
-  | Question                          | :error-view             | :on-error                        |
-  |-----------------------------------|-------------------------|----------------------------------|
-  | WHICH failure?                    | An exception INSIDE the | A transport / Ring-layer failure |
-  |                                   | re-frame drain or the   | the projector CANNOT see —       |
-  |                                   | render walk — something | per-request frame setup throw,   |
-  |                                   | the error PROJECTOR     | a render-time CLJ exception,     |
-  |                                   | catches.                | a header/cookie materialise      |
-  |                                   |                         | throw, a thrown initial-event.   |
-  | WHAT does it produce?             | The PROJECTED ERROR     | A raw Ring response map          |
-  |                                   | PAGE body (hiccup) — a  | `{:status … :headers … :body …}` |
-  |                                   | view keyword or         | returned verbatim to the server. |
-  |                                   | `(public-error)→hiccup` |                                  |
-  |                                   | fn, rendered through    |                                  |
-  |                                   | the SSR emitter.        |                                  |
-  | WHAT is its INPUT?                | The PUBLIC-ERROR map    | The raw `(request throwable)` —  |
-  |                                   | (sanitised by the       | the UNSANITISED throwable. The   |
-  |                                   | projector — safe to     | locked default NEVER reads it    |
-  |                                   | render).                | (rf2-kzvwq `.getMessage` leak).  |
-  | WHICH HTTP path?                  | Normal response with    | Last-resort net OUTSIDE the      |
-  |                                   | the projector's status  | normal pipeline (the projector   |
-  |                                   | (typically 500) + the   | never ran / can't run).          |
-  |                                   | rendered page.          |                                  |
-  | DEFAULT when omitted?             | Minimal default error   | Minimal locked 500 (\"Internal   |
-  |                                   | template.               | error\", topology-leak-safe).    |
-
-  Mnemonic: `:error-view` is the PROJECTED page (drain-time, sanitised,
-  hiccup); `:on-error` is the TRANSPORT net (Ring-layer, raw throwable,
-  outside the projector). A buggy `:error-view` falls back to the default
-  error template; a buggy `:on-error` falls back to `default-on-error`
-  (`safe-on-error`, rf2-ljjh0) — NEITHER bypasses the error boundary.
-
-    :on-error       — (request throwable) → ring-response. The TRANSPORT/
-                      Ring-layer error net (see table above). Called when
-                      the per-request frame setup OR a Ring-layer /
-                      transport failure the projector can't see throws.
-                      Defaults to a minimal 500 response. NOTE: normal
-                      projected render/drain errors do NOT reach this
-                      hook — they flow through the error projector and
-                      render `:error-view` / the default error template
-                      (see below). `:on-error` is the last-resort
-                      transport-failure net. A caller wanting a branded
-                      transport-failure body writes an explicit leak-safe
-                      `:on-error` fn that returns a fixed response and
-                      ignores the throwable (the `default-on-error`
-                      shape, caller-owned). Use the `:error-view` opt
-                      below for caller-registered hiccup-rendered error
-                      pages on the projected (drain-time) path.
-    :error-view     — (optional) the projected-error page body (Spec 011
-                      §Server error projection step 5). Either a
-                      registered-view keyword (resolved as
-                      `[error-view public-error]` — the view receives
-                      the public-error map as its single prop) OR a
-                      1-arity fn `(public-error) → hiccup`. Rendered
-                      through the standard SSR emitter so the public-
-                      error map flows through position-appropriate
-                      escaping and the app's own styling. When absent,
-                      the host emits a minimal default error template.
-                      A buggy `:error-view` falls back to the default
-                      template (the error boundary cannot be bypassed
-                      by a bug in the caller's error page).
-
-  Trusted shell-hook string opts (per Spec 011 §Trusted shell hook
-  contract, rf2-o6ndb) — four optional strings that cross the trust
-  boundary into the rendered HTML envelope. They split by injection
-  position: `:head` / `:body-end` are RAW content hooks (injected
-  verbatim), while `:script-src` / `:app-element-id` are escaped
-  attribute hooks (`escape-attr`'d into a quoted attribute value,
-  rf2-7x0qk). The framework names them as TRUSTED-STRING surfaces; the
-  trust call itself is the caller's. Structural-shape-checked at
-  handler-construction time (non-string non-nil values throw
-  `:rf.error/ssr-trusted-shell-opt-invalid`); the RAW content hooks are
-  NOT escaped. Wiring any of these from untrusted input (CMS field,
-  tenant-admin form, query-string parameter) accepts an arbitrary-
-  script-injection XSS vector via the raw content hooks. Use the
-  structured alternatives (`reg-head` for head fragments, `reg-view*` +
-  `:rf.server/*` fx for body content) when the content originates
-  upstream of the trust boundary.
-
-    :head           — (string, RAW content hook) verbatim HTML inside
+    :head           — raw HTML inside
                       `<head>...</head>`. Default: route-resolved head
                       fragment.
-    :body-end       — (string, RAW content hook) verbatim HTML before
+    :body-end       — raw HTML before
                       `</body>` — the escape hatch for analytics /
                       third-party scripts. Default: nil (omitted).
-    :script-src     — (string, escaped attribute hook) the client-side
+    :script-src     — escaped client-side
                       bootstrap script URL written `escape-attr`'d into
                       `<script src=\"...\">`. Default: \"/main.js\".
-    :app-element-id — (string, escaped attribute hook) the id of the
+    :app-element-id — escaped id of the
                       `<div>` wrapping the rendered body, written
                       `escape-attr`'d into `<div id=\"...\">`. Default:
                       \"app\". The client-side hydrator reads this
@@ -410,9 +187,8 @@
     (def handler
       (ssr-ring/ssr-handler {:initial-events [[:rf/server-init]]
                              :root-view      [:app/root]
-                             ;; REQUIRED, fail-closed (rf2-gtgf9). A vector
-                             ;; is an allowlist of top-level app-db keys to
-                             ;; ship; `:rf.ssr.payload/whole-app-db` opts into
+                             ;; A vector allowlists top-level app-db keys;
+                             ;; `:rf.ssr.payload/whole-app-db` opts into
                              ;; the whole db. Omit it and construction throws
                              ;; `:rf.error/ssr-missing-payload-policy`.
                              :payload        [:articles :session-user]
@@ -424,11 +200,8 @@
   ;; (`setup-request-frame!`, `build-full-response`) can destructure
   ;; without re-stating the `:or` map. Caller-supplied values win.
   ;;
-  ;; `:on-error` resolution goes through `lifecycle/resolve-on-error`
-  ;; (shared with `stream-handler`): the caller's `:on-error` fn or the
-  ;; host-locked `default-on-error`. Resolution happens AFTER merge so
-  ;; handler-defaults can stay orthogonal to on-error (no `:on-error`
-  ;; slot in the defaults map).
+  ;; Resolve `:on-error` separately so handler-defaults stays orthogonal to
+  ;; the caller-or-locked-default precedence.
   (let [opts        (-> (merge handler-defaults raw-opts)
                         (assoc :on-error (lifecycle/resolve-on-error raw-opts)))
         {:keys [on-error]} opts]
@@ -447,14 +220,10 @@
                 (pipeline/ssr-response->ring-response resp nil)
                 (pipeline/build-full-response frame-id resp opts)))
             (catch Throwable t
-              ;; rf2-ljjh0 — `safe-on-error` contains a throwing
-              ;; caller `:on-error`: a bug in the caller's transport-
-              ;; failure handler falls back to the locked
-              ;; `default-on-error` rather than escaping as a raw 500.
+              ;; A failing caller hook falls back to the locked response.
               (lifecycle/safe-on-error on-error request t))
             (finally
-              ;; `destroy-frame!` invokes `:ssr/on-frame-destroyed`
-              ;; (rf2-fcj33), which clears the per-frame request slot.
+              ;; Frame teardown also clears its per-request side channels.
               (lifecycle/destroy-frame-quietly! frame-id))))))))
 
 ;; ---- ssr-middleware -------------------------------------------------------
@@ -475,10 +244,10 @@
 
   Example:
 
-    ;; `ssr-middleware` is CURRIED: `(ssr-middleware opts)` returns a
+    ;; `ssr-middleware` is curried: `(ssr-middleware opts)` returns a
     ;; Ring middleware `(handler) → wrapped-handler`. Apply it to the
     ;; fallback handler, then compose normally. `:payload` is REQUIRED
-    ;; (fail-closed, rf2-gtgf9) — the same allowlist-or-whole-db policy
+    ;; (fail-closed) — the same allowlist-or-whole-db policy
     ;; `ssr-handler` enforces.
     (def app
       (-> default-handler

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/cookie.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/cookie.clj
@@ -13,14 +13,12 @@
   host adapters (Pedestal, HttpKit), and user code that needs a one-off
   serialisation can reach it without depending on the internal ns.
 
-  Attribute-injection safety (rf2-rpedl, security audit 2026-05-14 §P1.2)
-  — every attribute string that flows into the wire shape is validated
+  Attribute-injection safety: every attribute string that flows into the
+  wire shape is validated
   for CR / LF / NUL before concatenation. A multi-tenant app that
   derives `:domain` (or any attribute) from tenant-controlled input
   would otherwise allow header-splitting via `\\r\\n` injection. Cookie
-  `:name` carries a separate RFC 6265 §4.1.1 token-grammar gate (no
-  CTLs, whitespace, or `( ) < > @ , ; : \\ \" / [ ] ? = { }`). Folds in
-  the §P2.4 cookie-name grammar finding."
+  `:name` carries a separate RFC 6265 §4.1.1 token-grammar gate."
   (:require [clojure.string :as str]
             [re-frame.error :as error]
             [re-frame.ssr.http-validation :as http-validation])
@@ -29,10 +27,6 @@
            [java.time Instant ZoneOffset ZonedDateTime]
            [java.time.format DateTimeFormatter]))
 
-;; Audit rf2-asmj1 P6 / cluster rf2-sljs1 — reflection-warning gate.
-;; The JVM-side `Instant/ofEpochMilli` in `cookie->set-cookie-header`
-;; has a primitive-long contract; surfacing reflection at compile time
-;; flags accidentally-Long-boxed args before they NPE in production.
 (set! *warn-on-reflection* true)
 
 (def ^:private ^DateTimeFormatter rfc1123-formatter
@@ -50,20 +44,9 @@
   (-> (URLEncoder/encode (str s) (.name StandardCharsets/UTF_8))
       (str/replace "+" "%20")))
 
-;; rf2-rpedl — every cookie attribute value (after :value, which is
-;; URL-encoded above) is concatenated verbatim into the Set-Cookie
-;; header. A CR / LF / NUL in :domain / :path / :max-age / :same-site /
-;; :expires would split the header and let an attacker who controls one
-;; of those fields forge a second header — RFC 7230 §3.2.4 explicitly
-;; bans CR/LF/NUL inside header values. We reject up front so the
-;; behaviour is portable across hosts (Jetty 11+ rejects, but earlier
-;; Jetty / HttpKit / Pedestal don't all defend the same way).
-;;
-;; The injection-char grammar is single-sourced in
-;; `re-frame.ssr.http-validation/contains-injection-char?` — the SAME
-;; predicate the SSR fx boundary (`re-frame.ssr.response`) enforces, so
-;; the materialiser and the fx-boundary gate can't drift on what counts
-;; as a header-splitting char.
+;; Cookie attributes are concatenated into a header value, so reject the
+;; CR/LF/NUL characters that can split headers. The shared predicate keeps
+;; the effect boundary and this last wire boundary on one grammar.
 
 (defn- validate-attribute-string!
   [attr-key v]
@@ -81,26 +64,12 @@
                     :value     v}}))
     s))
 
-;; rf2-rpedl / §P2.4 — RFC 6265 §4.1.1 cookie-name = token. The token
-;; grammar (RFC 7230 §3.2.6) is `1*tchar` where `tchar` is the set of
-;; visible US-ASCII chars MINUS the separators
-;; `( ) < > @ , ; : \ " / [ ] ? = { }` and whitespace. Single-sourced in
-;; `re-frame.ssr.http-validation/valid-token-name?` — the SAME predicate
-;; the SSR fx boundary (`re-frame.ssr.response`) enforces on cookie +
-;; header names, so the materialiser and the fx-boundary gate can't drift
-;; on the token grammar.
+;; RFC 6265 cookie names use the shared RFC 7230 token grammar.
 
 (defn- validate-cookie-name!
   [n]
-  ;; rf2-d95o1y — type-guard BEFORE `(clojure.core/name n)`. A cookie
-  ;; `:name` is only a string or a `Named` (keyword / symbol); anything
-  ;; else (a Long `42`, a vector `[]`, a map `{}`, …) would make
-  ;; `clojure.core/name` throw a raw `ClassCastException` with nil
-  ;; ex-data, bypassing the documented `:rf.error/cookie-invalid-name`
-  ;; contract and reaching `:on-error` / adapter code as a generic host
-  ;; exception. Reject the unsupported type loudly through the same
-  ;; structured error id so the validation contract holds for every
-  ;; name shape, not just bad strings.
+  ;; Guard the type before `name` so every invalid shape uses the structured
+  ;; cookie-name error instead of leaking a ClassCastException.
   (when-not (or (string? n) (instance? clojure.lang.Named n))
     (error/throw-error!
       :rf.error/cookie-invalid-name
@@ -145,7 +114,7 @@
   Public surface so tests, alt host adapters (Pedestal, HttpKit), and
   user code that needs a one-off serialisation can call it directly.
 
-  Validation (rf2-rpedl, security audit 2026-05-14 §P1.2 + §P2.4):
+  Validation:
     - `:name` is checked against the RFC 6265 §4.1.1 token grammar — no
       CTLs / whitespace / separators. Throws `:rf.error/cookie-invalid-name`.
     - `:domain` / `:path` / `:max-age` / `:same-site` are checked for
@@ -164,11 +133,7 @@
       "cookie map must carry :name; add a :name key to the cookie map."
       {:recovery :supply-a-cookie-name
        :extra    {:cookie cookie}}))
-  ;; rf2-rpedl §P2.4 — RFC 6265 §4.1.1 cookie-name token grammar.
-  ;; rf2-d95o1y — `validate-cookie-name!` returns the type-guarded,
-  ;; coerced name string; reuse it for the wire form so `(name …)` is
-  ;; not re-derived (and the type guard cannot be skipped on the wire
-  ;; path).
+  ;; Reuse the validated name string so the wire path cannot skip the guard.
   (let [name-str (validate-cookie-name! name)]
     ;; `Instant/ofEpochMilli` takes a primitive long; passing anything
     ;; else (a string-shaped epoch from a misconfigured projector, a
@@ -186,14 +151,8 @@
         {:recovery :supply-epoch-millis-long
          :extra    {:expires expires
                     :cookie  cookie}}))
-    ;; rf2-rpedl §P1.2 — gate every string-shaped attribute that gets
-    ;; concatenated into the Set-Cookie wire form. `:value` is URL-encoded
-    ;; (CR/LF/NUL come out as %0D/%0A/%00 — no injection path); `:expires`
-    ;; flows through `rfc1123-formatter` which only emits ASCII letters /
-    ;; digits / `, : SP`; `:secure` / `:http-only` are booleans. The
-    ;; remaining string-typed slots — `:domain`, `:path`, `:max-age`
-    ;; (callers sometimes pass strings), `:same-site` (string form
-    ;; tolerated by same-site-token) — are validated here.
+    ;; Validate the attributes that reach the wire as caller-shaped strings.
+    ;; Values are URL-encoded, expiry is formatter-owned, and flags are booleans.
     (when (some? domain)    (validate-attribute-string! :domain    domain))
     (when (some? path)      (validate-attribute-string! :path      path))
     (when (some? max-age)   (validate-attribute-string! :max-age   max-age))

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/headers.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/headers.clj
@@ -16,50 +16,12 @@
 
 (defn merge-pair-into-header-map
   "Fold a `[name value]` header pair into the accumulating Ring headers
-  map. The accumulator normally carries `nil`, `string`, or `vector`
-  values — the SSR runtime's `set-header`/`append-header` fxs gate
-  header NAMES (RFC 7230 token grammar) and VALUES (CR/LF/NUL) but do
-  NOT coerce a value to a string, so a non-string scalar (number,
-  keyword, boolean) can reach this fold verbatim. The first occurrence
-  `assoc`s the value in; a repeated name must still collapse it into a
-  multi-value vector. The `:else` arm handles that case the same way the
-  `vector?` arm does (existing scalar → `[existing v]`); without it the
-  `cond` would return `nil`, silently wiping the ENTIRE accumulated
-  header map mid-fold (Content-Type, Set-Cookie, everything folded so
-  far) — a silent-failure header-loss bug.
+  map. Repeated names preserve order in a vector.
 
-  ## Fail-closed non-string coercion (rf2-v0qbng)
-
-  Ring's `:headers` contract is value = string OR vector-of-strings. A
-  number / keyword / boolean reaching this fold is undefined behaviour at
-  the servlet layer — Jetty/http-kit may reject the response while
-  committing it, or serialise it incorrectly, AFTER the handler has
-  already returned a nominally-successful Ring map (so the `:on-error`
-  path can't recover). The fx-args `:schema` boundary would catch a
-  non-string value at dispatch time, but that boundary SOFT-PASSES when
-  the optional schemas artefact is not on the production classpath (Spec
-  010 §Recommended soft-pass) — which is the default ssr-ring runtime.
-  The adapter is therefore the last line: it MUST emit a host-serialisable
-  Ring value regardless of what slipped past the (optional) fx-args gate.
-
-  We coerce a non-nil non-string value to its string form (`str`) BEFORE
-  it lands in the accumulator, so every value the materialiser emits is a
-  string (or, for repeated names, a vector of strings). The coercion runs
-  on the production classpath — it is the correctness guarantee, not a
-  diagnostic. A `nil` value is left as-is (`assoc`d under the nil-existing
-  arm): an explicit nil header is dropped by Ring servers and carries no
-  injection risk, and `(str nil)` = \"\" would fabricate an empty header.
-
-  ## Dev-gated non-string warning (rf2-b0jlr)
-
-  A non-string value here is almost certainly a CALLER bug, so alongside
-  the production coercion we surface it: a dev-gated `:warning` trace
-  naming the offending header key and the value's pre-coercion type.
-  Production builds elide the whole check (the `interop/debug-enabled?`
-  gate + `trace/emit!`'s own Closure-DCE gate), keeping the diagnostic off
-  the hot path — but the coercion below is unconditional, so the wire shape
-  is correct with or without the warning. Aligns with the no-silent-swallow
-  posture (cf. the redirect-no-target warning in `pipeline`)."
+  Ring requires strings or vectors of strings. Because schema validation is
+  optional, this wire boundary unconditionally stringifies non-nil scalar
+  values and emits a development warning. Nil remains nil instead of being
+  fabricated into an empty header."
   [m [k v]]
   (when (and interop/debug-enabled? (and (some? v) (not (string? v))))
     (trace/emit! :warning :rf.ssr/ssr-non-string-header-value
@@ -112,47 +74,19 @@
 
 (defn strip-content-length
   "Remove any `Content-Length` header (case-insensitively) from a Ring
-  response header map. A re-frame2 SSR body is ALWAYS assembled by the
-  adapter AFTER the `:initial-events` drain — the non-streaming shell +
-  hydration payload, or the streaming chunk-producing `PipedInputStream` —
-  so app / server-init code CANNOT know the final byte count when it runs.
-  App / server init MAY nonetheless `:rf.server/set-header` (or
-  `append-header`) a `Content-Length` during the drain. Left in place, a
-  Ring server that honours that stale fixed length truncates the HTML (too
-  short) or blocks the client waiting for bytes (too long).
-
-  Stripping lets the Ring server own transfer framing — computing
-  `Content-Length` for the materialised String / empty body, or chunking the
-  streaming `InputStream` body (Spec 011 §Streaming SSR — chunked-transfer
-  framing).
-
-  rf2-d95m4i — single-sourced here and applied by BOTH materialiser paths:
-  the streaming head (rf2-h3dg0) AND the non-streaming
-  `pipeline/ssr-response->ring-response`, closing the asymmetry where only
-  the streaming path stripped a stale app-set length."
+  response header map. The adapter assembles bodies after the event drain,
+  so an app-supplied length cannot describe either the final string or the
+  streaming input. Let the Ring server own transfer framing."
   [headers-map]
   (strip-header headers-map "content-length"))
 
 (defn headers->ring-map+content-type-override
   "Collapse an ordered vec-of-[name value] pairs into Ring's
   `{name string-or-vec}` shape, then apply the handler's `:content-type`
-  OVERRIDE (rf2-nncni3): when `content-type` is non-nil, EVERY existing
-  Content-Type entry (any casing — RFC 7230 §3.2) is stripped from the
-  folded map and a single canonical `Content-Type` header carrying
-  `content-type` is assoc'd. A nil `content-type` leaves the folded map
-  untouched — the runtime's default-seeded (Spec 011 §Status defaults) or
-  app-`:rf.server/set-header`-set Content-Type flows to the wire verbatim.
-
-  Why an OVERRIDE, not the earlier default-when-absent (rf2-uj9z8): the SSR
-  runtime's `default-response` ALWAYS seeds
-  `[\"content-type\" \"text/html; charset=utf-8\"]` on the accumulator, so a
-  default-when-absent pass could NEVER fire for the ssr-ring runtime — the
-  Content-Type was unconditionally already present, so the handler's
-  documented `:content-type` opt was silently suppressed (rf2-nncni3). The
-  opt is now a genuine override; it defaults to nil (removed from
-  `handler-defaults` and `stream-handler`'s defaults merge), so an app's
-  explicit `:rf.server/set-header \"content-type\"` stays in control when
-  the caller does not pass the opt.
+  override. A non-nil override removes every case variant before associating
+  one canonical `Content-Type`; nil preserves the runtime- or app-supplied
+  header. The option must be an override because the runtime always seeds a
+  default Content-Type.
 
   Ordering / multi-value semantics of the fold are unchanged
   (`merge-pair-into-header-map`): per-name multi-value order preserved via

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
@@ -1,44 +1,10 @@
 (ns re-frame.ssr.ring.lifecycle
-  "Per-request frame lifecycle helpers for the Ring host adapter.
+  "Per-request frame lifecycle and shared handler-construction contracts.
 
-  Pure helpers used by the request pipeline:
-
-    - `destroy-frame-quietly!` — best-effort frame teardown
-    - `resolve-root-view`      — hiccup-vec OR 0-arity fn → hiccup
-    - `resolve-head`           — active route's `:head` → map carrying the
-                                 rendered fragment plus `:html-attrs` /
-                                 `:body-attrs` bags for the host shell
-
-  Plus the two construction-time contracts shared verbatim by BOTH
-  `re-frame.ssr.ring/ssr-handler` AND
-  `re-frame.ssr.ring.streaming/stream-handler`:
-
-    - `validate-construction-opts!` — the fail-closed-at-boot triple
-                                      (required opts + payload policy +
-                                      trusted-shell shape)
-    - `resolve-on-error`            — the `:on-error` / locked-default
-                                      precedence
-
-  Both lived twice (once in the `ring` façade, once inlined in
-  `streaming`) before — colocating them here, alongside the
-  `validate-required-opts!` / `default-on-error` pieces they already
-  compose, keeps the boot contract single-sourced.
-  Same sibling-placement rationale as `validate-required-opts!`:
-  `streaming` and the `ring` façade both already require `lifecycle`,
-  so hosting the shared checks here avoids any circular-require between
-  the streaming sub-namespace and the façade.
-
-  Per Spec 011 §Request storage substrate + §Head/meta contract.
-
-  Note (audit rf2-cegm7 A2 / rf2-j54ee): the prior `on-create-with-request`
-  helper conj'd the Ring request map onto the caller's setup
-  event vector as a fallback for handlers that pre-dated the
-  `:rf.server/request` cofx. The conj path is gone — Spec 011 names the
-  cofx as the canonical read surface; the positional-arg variant had a
-  subtle pitfall (a 1-vector `[:rf/server-init]` silently became
-  `[:rf/server-init {ring-request...}]` after the conj, so a handler that
-  forgot to destructure ended up with the request riding the unused-arg
-  slot). Pre-alpha: one canonical surface, no fallback."
+  Both Ring handlers use these helpers for required-option, payload-policy,
+  trusted-shell, and error-fallback decisions. Request data is exposed through
+  the frame-scoped `:rf.server/request` coeffect rather than being appended to
+  initial event vectors. Per Spec 011 §Request storage and §Head/meta."
   (:require [re-frame.core :as rf]
             [re-frame.error :as error]
             [re-frame.interop :as interop]
@@ -49,18 +15,13 @@
 
 (set! *warn-on-reflection* true)
 
-;; ---- always-on error-emit helper (EP-0008 rf2-hhutya) ---------------------
+;; ---- always-on error emission ---------------------------------------------
 ;;
-;; The promoted SSR error categories ride the always-on error-emit axis
-;; (surface #4) ALONGSIDE the dev-gated `trace/emit-error!`. The Ring host
-;; adapter ships above core's require graph, so it reaches
-;; `error-emit/dispatch-error-record!` through the published
-;; `:error-emit/dispatch-error-record` late-bind hook. UNGATED — fires on a
-;; `-Dre-frame.debug=false` JVM SSR host so off-box shippers see the
-;; structured record the dev trace surface would have elided.
+;; The optional late-bind hook keeps production error shipping independent of
+;; the development-gated trace surface.
 
 (defn emit-always-on-error!
-  "Fan a PRE-BUILT always-on SSR error record out through the corpus-wide
+  "Fan a pre-built always-on SSR error record through the
   error-emit registry via the `:error-emit/dispatch-error-record` late-bind
   hook. `record` is the union shape `{:error <kw> :frame <id-or-nil> :time
   <ms> + flat category keys}`. No-op when the producer hasn't loaded.
@@ -71,14 +32,12 @@
   nil)
 
 (def ^:const default-on-error-body
-  "The literal body emitted by `default-on-error`. Pinned to the
-  rf2-kzvwq topology-leak-safe shape: generic plaintext, no throwable
-  detail, no internal class names."
+  "The generic body emitted by `default-on-error`; it exposes no throwable
+  detail or internal class names."
   "Internal error")
 
 (def ^:const default-on-error-content-type
-  "The Content-Type emitted by `default-on-error` — plaintext UTF-8,
-  matching the locked default body shape (rf2-kzvwq §P2.1)."
+  "The plaintext UTF-8 Content-Type emitted by `default-on-error`."
   "text/plain; charset=utf-8")
 
 (def default-on-error
@@ -86,20 +45,9 @@
   `:on-error`. Shared by `ssr-handler` AND `stream-handler` so the
   topology-leak contract below lives in exactly one place.
 
-  The SSR runtime's error projector handles trace-emitted errors during
-  drain; this hook covers exceptions the projector can't see (Ring-layer
-  throws, render-time CLJ exceptions, writer-thread-pre-spawn throws).
-
-  rf2-kzvwq / security audit 2026-05-14 §P2.1 — the body MUST NOT leak
-  the throwable's message. `.getMessage` carries internal topology that
-  has no business reaching the wire: JDBC URLs (host, port, database
-  name), file paths under deploy roots, partial SQL fragments, server-
-  internal class names. We emit a fixed generic body matching the
-  projector's `fallback-public-error` shape. The fn ignores the
-  throwable so the topology-leak surface stays closed. Apps that want a
-  branded transport-failure body — plaintext or HTML — supply an
-  explicit leak-safe `:on-error` Ring fn that returns a fixed response
-  and ignores the throwable."
+  The projector handles drain and render errors. This hook covers setup,
+  materialisation, and transport exceptions outside it. The fixed body never
+  reads the throwable; custom hooks must preserve that no-detail boundary."
   (let [response {:status  500
                   :headers {"Content-Type" default-on-error-content-type}
                   :body    default-on-error-body}]
@@ -107,29 +55,8 @@
 
 (defn safe-on-error
   "Invoke the resolved `:on-error` Ring-fn under containment and return
-  its Ring response. Shared by `ssr-handler`, `stream-handler`, AND
-  `setup-request-frame!` so EVERY `:on-error` call site is protected.
-
-  rf2-ljjh0 — `:on-error` is the handler's last-resort transport-failure
-  net (Ring-layer / render-time / setup-failure throws the projector
-  can't see). A CALLER-supplied `:on-error` that itself throws must NOT
-  escape the handler: an uncaught throwable handed to the Ring server
-  (Jetty / http-kit) surfaces as a raw container 500 with a stack
-  trace, defeating the rf2-kzvwq topology-leak contract the boundary
-  otherwise upholds (`default-on-error` emits a fixed generic body,
-  never the throwable). When the caller's `:on-error` throws, we surface
-  the secondary throw on the trace bus and fall back to the host-locked
-  `default-on-error` — mirroring the `resolve-error-body` pattern (a
-  buggy `:error-view` must not bypass the error boundary either). The
-  boundary is not bypassable by a bug in the caller's transport-failure
-  handler, exactly as it is not bypassable by a bug in the caller's
-  `:error-view`.
-
-  `on-error` is the ALREADY-RESOLVED fn (precedence applied by
-  `resolve-on-error` at construction time): the caller's `:on-error` or
-  `default-on-error`. When `on-error` IS `default-on-error` it cannot
-  throw — the guard is then a free no-op — so this is cheap on the
-  common path."
+  its Ring response. A failing caller hook is traced and replaced by the
+  fixed, no-detail default so error handling cannot bypass the boundary."
   [on-error request t]
   (try
     (on-error request t)
@@ -163,22 +90,9 @@
 (defn resolve-root-view
   "Resolve the caller's `:root-view` opt to a hiccup vector. Accepts
   either a hiccup vector directly OR a 0-arity fn that returns hiccup.
-  Per rf2-6t36h this MUST run exactly once per request — the fn-form
-  branch is not guaranteed to be idempotent (unsorted-map iteration,
-  gensym'd keys, time-of-day props can all vary between calls) and any
-  variance between two invocations produces a hash mismatch on the wire
-  vs the payload, firing a spurious `:rf.ssr/hydration-mismatch` on a
-  perfectly successful hydration. Resolve once, thread the result.
-
-  rf2-t72b1c — the streaming handler (`re-frame.ssr.ring.streaming`)
-  honours this exactly-once contract for the common case (a request with
-  zero continuations, i.e. no `:rf/suspense-boundary` in the tree). It
-  calls through to a SECOND invocation only when at least one continuation
-  drained — the one case app-db can legitimately have changed since the
-  shell render — trading a documented, narrow exactly-once exception
-  (rf2-1kqvbx) for a correct post-drain `:rf/render-hash`. See
-  `re-frame.ssr.ring.streaming/run-streaming-writer!`'s final-payload
-  comment for the full rationale."
+  Resolve once per request so a non-idempotent function cannot make rendered
+  HTML and payload hashes describe different trees. Streaming re-resolves only
+  after at least one continuation, when post-drain state needs a fresh hash."
   [root-view]
   (cond
     (vector? root-view) root-view
@@ -199,46 +113,21 @@
     {:head-html  \"<title>…</title><meta …>…\"   ;; inner-head fragment
      :html-attrs {…} or nil                       ;; stamped on <html>
      :body-attrs {…} or nil                       ;; stamped on <body>
-     :head-model {…} or nil}                      ;; the RAW model (rf2-1oxjxk)
+     :head-model {…} or nil}                      ;; raw reconstructible model
 
   The two attribute bags ride alongside the rendered fragment because
   `head-model->html` deliberately drops them (Spec 011 §Default flow
   step 4: `:html-attrs` populate `<html>`; `:body-attrs` populate
   `<body>` — the host shell stamps them, not the head emitter).
 
-  `:head-model` (rf2-1oxjxk) is the RAW model `rf/active-head` returned —
-  BEFORE `head-model->html` renders it to a string. It is the input to
-  the separate `render-head-hash` channel (below): the client
-  reconstructs the SAME model by calling `(rf/active-head frame-id)`
-  itself against the just-hydrated state (Spec 011 §Default flow step
-  5), so hashing the model — never the emitted HTML — is what makes the
-  channel client-reconstructible at all. nil on the caught-throw fallback
-  below (a degraded empty head carries no reconstructible model either).
+  `:head-model` is the raw `rf/active-head` value used by the separately
+  client-reconstructible head hash; emitted HTML is not a stable shared input.
 
   Exceptions during resolution degrade gracefully — empty fragment,
   no attrs — so a buggy head fn can't take down the request. The trace
-  surface carries the throw via `:rf.error/ssr-head-resolution-failed`
-  (per Spec 009 §Error event catalogue) so production observability
-  stacks see the failing head fn even though the wire response continues.
-
-  Per Spec 011 §Head/meta contract (rf2-4dra9, rf2-h2ujj) and
-  rf2-bof8i (trace-emit on caught throw, Mike decision Option B over
-  silent fallback — the always-on error-emit substrate per rf2-vnjfg /
-  rf2-bacs4 carries the trace independent of the trace ring buffer's
-  dev-only gating).
-
-  Degrade-gracefully is the deliberate counterpoint to the view/sub
-  FAIL-CLOSED posture (rf2-vvwmi / rf2-7d30s, Spec 011 §744/§748-751):
-  a view or reactive sub that throws mid-render projects a non-200
-  (the page is unusable); a head fn that throws ships a 200 with an
-  empty `<head>` (only the metadata is missing — the body still
-  renders + hydrates). To make the degraded-200 outcome ENFORCED rather
-  than incidental to `ssr-handler`'s `get-response`-before-`resolve-head`
-  call ordering, `:rf.error/ssr-head-resolution-failed` is registered as a
-  recoverable-degradation category that the projection listeners skip by
-  design (`re-frame.ssr.error-listener/non-projection-eligible-errors`,
-  rf2-lia3i): the trace ships for observability but is never buffered for
-  status projection, so no call-ordering change can flip the 200."
+  surface and always-on emitter carry `:rf.error/ssr-head-resolution-failed`.
+  This category is deliberately non-projecting: losing metadata degrades to an
+  empty head while the usable body remains a 200."
   [frame-id]
   (try
     (let [model (rf/active-head frame-id)]
@@ -251,15 +140,8 @@
                          {:frame     frame-id
                           :exception t
                           :recovery  :no-recovery})
-      ;; EP-0008 (rf2-hhutya): ALSO ride the always-on axis. This EXECUTES
-      ;; the resolved Spec 011 §`resolve-head` emits …-failed Option-B
-      ;; ruling ("the always-on error-emit substrate carries the trace to
-      ;; user observability stacks") that the impl had drifted from (it
-      ;; emitted only via the dev-gated trace bus). NON-PROJECTING: a head
-      ;; fn that throws degrades to an empty `<head>` and ships a 200 — the
-      ;; always-on `error-emit-projection-listener` skips this category
-      ;; (`non-projection-eligible-error?`, rf2-lia3i), so promotion ships
-      ;; the off-box record WITHOUT flipping the degraded-200 wire outcome.
+      ;; Always-on but non-projecting: observability must not turn a degraded
+      ;; empty head into an error response.
       (emit-always-on-error!
         {:error     :rf.error/ssr-head-resolution-failed
          :frame     frame-id
@@ -273,30 +155,16 @@
   wire hash carried as the root element's `data-rf-render-hash` marker and
   the payload's `:rf/render-hash` (Spec 011 §Hydration-mismatch detection).
 
-  rf2-1oxjxk (Option B, reverting rf2-9fw2de): this hash is BODY-ONLY
-  again. rf2-9fw2de folded the resolved head fragment + `:html-attrs` /
-  `:body-attrs` into a `[:rf/ssr-document body head-bag]` wrapper so a
-  head-only divergence would move the hash too — but the CLIENT half of
-  that change was never made: the documented client boot
-  (`re-frame.ssr.boot/hydrate!`, `:render-tree-fn #((rf/view :app/root))`)
-  hashes the BARE body tree the view returns, never a document wrapper.
-  `render-tree-hash([:rf/ssr-document body {}])` never equals
-  `render-tree-hash(body)`, so every SSR page fired a spurious
-  `:rf.ssr/hydration-mismatch` under the unified channel. The wire hash
-  MUST match what the documented client actually hashes — body-only.
-
-  Head divergence is NOT silently dropped by the revert: it rides the
-  SEPARATE `:rf/head-hash` channel (`render-head-hash` below), which is
-  client-reconstructible (unlike a document wrapper straddling body +
-  head) because it hashes the same CANONICAL HEAD MODEL the client can
-  recompute via `(rf/active-head frame-id)`."
+  This channel is body-only because the client hashes the body tree returned
+  by its render function. Head divergence uses the separate, reconstructible
+  `:rf/head-hash` channel."
   [body-hiccup]
   (rf/render-tree-hash body-hiccup))
 
 (defn render-head-hash
   "The canonical structural hash for the CLIENT-RECONSTRUCTIBLE head
   model — a SEPARATE channel from the body's `render-document-hash`
-  (rf2-1oxjxk Option B). Carried as the `<head>` element's
+  and carried as the `<head>` element's
   `data-rf-head-hash` wire marker and the payload's optional
   `:rf/head-hash` key.
 
@@ -307,27 +175,23 @@
   (not emitted HTML) is what makes the channel client-reconstructible at
   all: the client calls the SAME `(rf/active-head frame-id)` against the
   just-hydrated app-db + the route slice carried in `:rf/runtime-db`
-  (Spec 011 §Default flow step 5) and hashes the resulting model the
-  identical way — `render-tree-hash`'s canonical-EDN walk is deterministic
-  and byte-identical across JVM/CLJS (`hash.cljc`).
+  (Spec 011 §Default flow step 5) and hashes the resulting model identically.
 
   Returns nil when `head-model` is nil — the explicit-`:head`-STRING
-  request shape (`resolve-head`'s caller-supplied-string branch, and the
+  request shape (the caller-supplied-string branch, and the
   degraded-empty-head fallback on a throwing head fn). In both cases the
   server knows the head is NOT client-reconstructible (an explicit string
   has no model to recompute; a degraded head's model was never produced),
   so the channel is OMITTED rather than shipping a hash the client could
-  never match — a graceful degrade that avoids a guaranteed false-positive
-  mismatch, mirroring the `resolve-head` docstring's degrade-gracefully
-  posture."
+  never match."
   [head-model]
   (when head-model
     (rf/render-tree-hash head-model)))
 
 (defn resolve-initial-events!
-  "Resolve the caller's `:initial-events` opt to the EP-0027 setup vector
+  "Resolve the caller's `:initial-events` opt to the setup vector
   (an ordered vector of events) dispatched at per-request frame creation,
-  given the live Ring `request`. Two accepted forms (rf2-kzns7l):
+  given the live Ring `request`. Two accepted forms:
 
     1. an `:initial-events` VECTOR — passed through verbatim (lowered into
        the per-request `make-frame`'s `:initial-events`).
@@ -343,21 +207,11 @@
 
       :initial-events (fn [req] [[:auth/server-init {:user (extract-user req)}]])
 
-  It is NOT a revival of the removed `on-create-with-request` positional-
-  conj helper (audit rf2-cegm7 A2 / rf2-j54ee): that silently appended the
-  WHOLE request to the caller's vector (`[:rf/server-init]` →
-  `[:rf/server-init {ring-request}]`), putting the request in the wrong
-  arg slot. Here the caller OWNS the shape of the resulting setup vector —
-  only the extracted, sanitised fact rides it. The ambient
-  `:rf.server/request` cofx remains the canonical surface for NON-durable
-  request reads and is unaffected.
+  The caller owns the derived event shape. Use the ambient
+  `:rf.server/request` coeffect for non-durable request reads.
 
-  `:initial-events` is required (per `validate-required-opts!`), which a
-  fn satisfies as a truthy value — so the form check happens here, inside
-  the per-request setup try/catch. A value that is neither a vector nor a
-  1-arity fn (or a fn whose result is not a vector) is a programmer
-  error: surface it as `:rf.error/invalid-initial-events` rather than
-  letting `reg-frame` produce an obscure failure downstream."
+  Invalid values and function results surface as
+  `:rf.error/invalid-initial-events` inside per-request setup."
   [initial-events request]
   (cond
     (vector? initial-events)
@@ -389,21 +243,8 @@
   "Throw a structured `:rf.error/ssr-ring-missing-*` ex-info when a
   caller omits a required handler opt (`:initial-events` / `:root-view`).
 
-  Shared by `re-frame.ssr.ring/ssr-handler` AND
-  `re-frame.ssr.ring.streaming/stream-handler` so both fail closed at
-  handler-construction time (boot) rather than at first request — the
-  canonical fail-closed pattern (rf2-gtgf9, extended here to the two
-  required opts). A streaming handler built without `:initial-events` would
-  otherwise fail per-request inside `setup-request-frame!`; one built
-  without `:root-view` would fail inside the writer thread, truncating
-  the chunked response. Both must refuse to construct, exactly as the
-  non-streaming handler does. Returns `opts` unchanged on success.
-
-  Sibling-validator placement (not in the `ring` façade): `streaming`
-  already requires `lifecycle` and the `ring` façade does too, so
-  hosting the check here avoids the circular-require between the
-  streaming sub-namespace and the façade — same rationale as
-  `trust`/`payload-policy`."
+  Both handlers fail at construction rather than on the first request or,
+  worse, inside an already-committed writer. Returns `opts` unchanged."
   [{:keys [initial-events root-view] :as opts}]
   (when-not initial-events
     (error/throw-error!
@@ -422,22 +263,17 @@
 
 (defn validate-construction-opts!
   "Run the full fail-closed-at-boot validation triple shared by
-  `re-frame.ssr.ring/ssr-handler` AND
+  `re-frame.ssr.ring/ssr-handler` and
   `re-frame.ssr.ring.streaming/stream-handler`. A misconfigured handler
-  MUST refuse to construct rather than fail per-request — the canonical
-  fail-closed pattern (rf2-gtgf9). The three checks:
+  refuses to construct rather than failing per request. The checks are:
 
     1. required-opt presence (`:initial-events` / `:root-view`) via
-       `validate-required-opts!` — a streaming handler built without
-       `:initial-events` would otherwise fail per-request inside
-       `setup-request-frame!`; one without `:root-view` would fail inside
-       the writer thread, truncating the chunked response (rf2-ee38b.11).
+       `validate-required-opts!`.
     2. hydration-payload policy (the single `:payload` opt — vector
        allowlist or whole-app-db keyword) via
        `payload-policy/validate-policy-opts!` — throws
        `:rf.error/ssr-missing-payload-policy` (or
-       `:rf.error/ssr-unknown-payload-policy` on a typo'd policy) per
-       rf2-gtgf9 / rf2-pffil.
+       `:rf.error/ssr-unknown-payload-policy` on an unknown policy).
     3. trusted-shell-hook shape (`:head` / `:body-end` / `:script-src` /
        `:app-element-id` are strings or nil) via
        `trust/validate-trusted-shell-opts!` — both shells route these
@@ -446,7 +282,7 @@
        hooks), so a structural mistake (map / vector / symbol / number)
        surfaces here as `:rf.error/ssr-trusted-shell-opt-invalid` at
        boot rather than as a `ClassCastException` deep in the rendering
-       path (rf2-o6ndb).
+       path.
 
   Returns `opts` unchanged on success — composes into a `let` /
   threading position cleanly."
@@ -461,7 +297,7 @@
   Run by `re-frame.ssr.ring.streaming/stream-handler` AFTER the shared
   `validate-construction-opts!` triple.
 
-  `:html-shell` (rf2-oq4m5). The non-streaming `ssr-handler` builds its
+  `:html-shell`: the non-streaming `ssr-handler` builds its
   response by calling a ONE-PIECE `:html-shell` fn `(body-html payload-edn
   opts) → string` — it has the full body + payload in hand before the
   envelope is composed, so a custom shell can wrap them arbitrarily. The
@@ -475,20 +311,14 @@
   streaming path ALWAYS writes the split default envelope and a passed
   `:html-shell` is silently dropped.
 
-  Accepting it silently is a fail-OPEN API-contract gap: a custom shell
-  commonly carries CSP nonces, asset URLs, analytics/script policy, root
-  markup, or host-specific document structure — a production app switching
-  from `ssr-handler` to `stream-handler` would lose all of it with no
-  construction error, warning, or test signal. We fail CLOSED at boot
-  instead: `stream-handler` refuses to construct when `:html-shell` is
+  Silently accepting it would discard security and document configuration.
+  `stream-handler` therefore refuses to construct when `:html-shell` is
   present (any non-nil value), pointing the caller at the streaming
   envelope surface (the split `default-streaming-prefix` /
   `default-streaming-suffix` plus the `:head` / `:body-end` /
   `:script-src` / `:app-element-id` trusted-shell hooks, which the
   streaming envelope DOES honour). A nil `:html-shell` passes (no
-  override requested) so the shared `handler-defaults` map — which does
-  NOT carry `:html-shell` for the streaming path — and an explicit
-  `{:html-shell nil}` both construct cleanly.
+  override requested).
 
   Returns `opts` unchanged on success."
   [opts]

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/payload.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/payload.clj
@@ -6,16 +6,15 @@
   plus the optional `:rf/runtime-db` and `:rf/schema-digest`.
 
   The `:rf/app-db` slice is projected per the explicit, fail-closed
-  policy in `re-frame.ssr.payload-policy/apply-policy` (rf2-gtgf9) —
+  policy in `re-frame.ssr.payload-policy/apply-policy` —
   see that namespace for the contract. The Ring host adapter validates
   the policy at handler-construction time via `validate-policy-opts!`
   so misconfigured deployments fail at boot, not at first request. The
-  `:rf/runtime-db` slice is projected per `project-runtime-db` (EP-0001
-  rf2-30kzz2 — the serializable durable runtime-db facts; transient side
-  channels excluded).
+  `:rf/runtime-db` slice contains serializable durable runtime facts;
+  transient side channels are excluded.
 
   Version resolution (`:rf/version`) and the canonical payload
-  assembly live once in `re-frame.ssr.payload-policy` (rf2-8wrzz.4),
+  assembly live once in `re-frame.ssr.payload-policy`,
   shared verbatim with the streaming SSR path
   (`re-frame.ssr.streaming/build-final-payload`). This namespace owns
   only the non-streaming wrapper: project the handed-in `app-db` +
@@ -28,10 +27,8 @@
   "Per Spec 011 §The hydration payload — emit the four canonical keys
   (`:rf/version`, `:rf/frame-id`, `:rf/app-db`, `:rf/render-hash`)
   plus the optional `:rf/runtime-db`, `:rf/schema-digest`, and
-  `:rf/head-hash` (rf2-1oxjxk — the separate client-reconstructible
-  head-model hash; pass it through `policy-opts`' `:head-hash` key,
-  computed via `re-frame.ssr.ring.lifecycle/render-head-hash`; nil
-  omits the key). Schema-digest is supplied
+  `:rf/head-hash`, the separately client-reconstructible head-model hash.
+  Pass it through `policy-opts`; nil omits the key. Schema-digest is supplied
   by the caller when their app participates in the schema-digest
   check; nil otherwise. Version source-of-truth:
   `re-frame.ssr.payload-policy/resolve-version` — caller opt wins,
@@ -39,8 +36,7 @@
   and client read from the same source.
 
   The `:rf/app-db` slice is projected per the explicit, fail-closed
-  policy in `re-frame.ssr.payload-policy/apply-policy` (rf2-gtgf9,
-  rf2-pffil single-opt consolidation): callers MUST declare `:payload`
+  policy in `re-frame.ssr.payload-policy/apply-policy`: callers MUST declare `:payload`
   as either a vector allowlist of top-level keys (recommended) or the
   keyword `:rf.ssr.payload/whole-app-db` (explicit opt-in to shipping
   the whole `app-db`). Absence throws
@@ -48,7 +44,7 @@
   at handler-construction time so misconfigured deployments fail at
   boot, not at first request.
 
-  EP-0001 (rf2-30kzz2): the optional `runtime-db` arg is the frame's live
+  The optional `runtime-db` arg is the frame's live
   runtime-db value; it is projected via `payload-policy/project-runtime-db`
   (the serializable durable slice — machine snapshots, route `:current` slice,
   elision declarations, SSR metadata) and rides the payload as
@@ -64,11 +60,8 @@
   ([frame-id app-db runtime-db render-hash {:as policy-opts}]
    (payload-policy/build-payload
     frame-id
-    ;; rf2-bt9kct — allowlist FIRST (`apply-policy`), THEN run the surviving
-    ;; slice through the centralized `:rf.egress/ssr-hydration` projection
-    ;; seeded at the request frame, so a frame-classified sensitive/large path
-    ;; inside an allowlisted (or whole-app-db) slice redacts/elides as
-    ;; defense-in-depth before it serializes into `:rf/app-db` (EP-0015 §14).
+    ;; Apply the allowlist before the frame-scoped hydration-egress projection,
+    ;; so classified values inside the surviving slice are still elided.
     (payload-policy/project-app-db-egress
      (payload-policy/apply-policy app-db policy-opts)
      frame-id)

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
@@ -14,26 +14,12 @@
        `ssr-response->ring-response`, OR `build-full-response` — render
        the root-view, build the hydration payload, wrap in the html-
        shell, materialise to Ring.
-    4. `destroy-frame-quietly!` in `finally` — `:ssr/on-frame-destroyed`
-       (rf2-fcj33) clears the per-frame request slot.
+    4. `destroy-frame-quietly!` in `finally` clears the frame and its
+       request-scoped side channels.
 
-  Per rf2-zkca8.1: `ssr-response->ring-response` (28 L, one fn) lives
-  here rather than in its own ns. Its only consumers were the redirect
-  short-circuit in `re-frame.ssr.ring` and `build-full-response` below;
-  it's a pipeline-stage helper and reads top-down with the rest of the
-  pipeline.
-
-  Per rf2-zwgsv (Mike decision rf2-i9f0g Option B): the render-time
-  failure path goes through the SSR error projector — same pipeline
-  as drain-time fx/handler exceptions. `build-full-response` catches
-  the render-side throw, calls `ssr/project-render-exception!` to
-  stamp the projector's `:status` onto the response accumulator,
-  then emits a minimal HTML error body driven by the projector's
-  public-error map (Spec 011 §Server error projection §View-time
-  exceptions). Render-time and drain-time exceptions thus share one
-  body contract on the wire — the projector's public-error map — and
-  no fixed `\"Internal error\"` fallback string ever reaches a client
-  (rf2-kzvwq)."
+  Render-time exceptions use the same projector and public-error wire body as
+  drain-time exceptions. Transport failures outside that projector use the
+  handler's fixed-detail fallback."
   (:require [re-frame.core :as rf]
             [re-frame.error :as error]
             [re-frame.interop :as interop]
@@ -47,17 +33,13 @@
 
 (defn ^:private fail-closed-status
   "Coerce a resolved response `:status` to a valid Ring status int,
-  defaulting to `fallback` when absent (rf2-v0qbng).
+  defaulting to `fallback` when absent.
 
   Ring requires `:status` to be an integer; Jetty/http-kit reject (or
   mis-serialise) a non-int status while committing the response, AFTER
-  the handler has returned a nominally-successful map — past the
-  `:on-error` recovery point. The fx-args `:schema` boundary
-  (`:rf.fx.server/set-status-args` = `:int`) would reject a non-int
-  `:rf.server/set-status` at dispatch time, but that boundary
-  SOFT-PASSES when the optional schemas artefact is absent from the
-  production classpath (Spec 010 §Recommended soft-pass) — the default
-  ssr-ring runtime. The adapter is the last line: a non-int status has
+  the handler has returned a nominally-successful map, past the `:on-error`
+  recovery point. Schema validation is optional, so this adapter is the last
+  line: a non-integer status has
   no faithful coercion (we will not guess that \"404\" means 404), so we
   fail closed to a 500 — a valid, fail-closed Ring response — and surface
   the defect on the trace bus rather than ship a malformed map."
@@ -87,40 +69,29 @@
   responses). `:redirect` short-circuits per Spec 011 §Redirect
   precedence — status + Location header, no body.
 
-  The optional 3-arg form accepts a `content-type` OVERRIDE (rf2-nncni3):
+  The optional 3-arg form accepts a `content-type` override:
   when non-nil it force-replaces any Content-Type on the accumulator (any
   casing) with a single canonical `Content-Type` header. A nil
   `content-type` leaves the accumulator's Content-Type (the runtime seed or
-  an app `:rf.server/set-header`) untouched. The override happens inside the
-  header fold (`headers->ring-map+content-type-override`). The earlier
-  default-when-absent form (rf2-uj9z8) was a silent no-op for the ssr-ring
-  runtime — `default-response` always seeds a Content-Type, so the passed
-  opt could never be applied (rf2-nncni3).
+  an app `:rf.server/set-header`) untouched. An override is necessary because
+  the runtime seeds a default Content-Type before the adapter runs.
 
-  Host-serialisability fail-closed (rf2-v0qbng): this materialiser is the
-  LAST line between the runtime accumulator and the wire, and the
-  `:rf.server/*` fx-args `:schema` boundary soft-passes off the optional
-  schemas classpath (the default ssr-ring runtime). So it must emit a
+  This materialiser is the last line between the runtime accumulator and the
+  wire, and schema validation is optional. It must emit a
   valid Ring response regardless of what slipped past that gate: `:status`
   is coerced to an int (`fail-closed-status` — non-int fails closed to
   500), the Location target is coerced to a string, and header values are
   coerced to strings in the fold (`headers/merge-pair-into-header-map`).
 
-  Content-Length is stripped from EVERY response (rf2-d95m4i): the body is
+  Content-Length is stripped from every response: the body is
   always adapter-assembled AFTER the drain (a String/empty body here, or the
   streaming InputStream that swaps in downstream), so an app-set
-  `Content-Length` can never match it. The streaming path hardened against
-  this (rf2-h3dg0); doing it in the shared materialiser closes the same
-  hazard on the non-streaming (and redirect) paths and lets the Ring server
-  own transfer framing (`headers/strip-content-length`)."
+  `Content-Length` can never match it. The Ring server owns transfer framing."
   ([resp body] (ssr-response->ring-response resp body nil))
   ([{:keys [status headers cookies redirect]} body default-content-type]
    (if redirect
      (let [{:keys [location] redirect-status :status} redirect
-           ;; rf2-vngir: the canonical (and only) redirect target key is
-           ;; `:location`. The materialiser back-door `(or location url to)`
-           ;; was pruned with the runtime synonyms; a direct / hand-built
-           ;; response map must also key its redirect target on `:location`.
+           ;; `:location` is the only redirect target key.
            target location]
        ;; A redirect with no target is a malformed wire response — a
        ;; 3xx with no `Location` leaves the browser nowhere to go. The
@@ -149,18 +120,15 @@
                      (cond-> target (assoc "Location" (if (string? target)
                                                         target
                                                         (str target))))
-                     ;; rf2-d95m4i — a bodiless redirect never matches a
-                     ;; stale app-set Content-Length either; strip it.
+                      ;; A bodiless redirect cannot honour an app-set length.
                      (headers/strip-content-length))
         :body    ""})
      {:status  (fail-closed-status status 200)
       :headers (-> (headers/headers->ring-map+content-type-override
                      headers default-content-type)
                    (headers/append-set-cookies cookies)
-                   ;; rf2-d95m4i — strip any app-set Content-Length: the body
-                   ;; is the adapter-assembled shell + hydration payload built
-                   ;; AFTER the drain, so a drain-time fixed length will not
-                   ;; match it; let the Ring server frame the String body.
+                    ;; The adapter assembles the body after the drain, so let
+                    ;; the Ring server frame it.
                    (headers/strip-content-length))
       :body    (or body "")})))
 
@@ -184,44 +152,17 @@
   frames` happens before `dispatch-sync`), so the best-effort destroy
   is required even though `reg-frame` threw."
   [{:keys [initial-events fx-overrides ssr on-error]} request]
-  ;; rf2-joibj: the gensym prefix MUST start with a non-numeric
-  ;; character. Per the EDN spec (https://github.com/edn-format/edn)
-  ;; symbol / keyword identifier names cannot begin with a digit, and
-  ;; spec-strict readers (`clojure.edn/read-string`,
-  ;; `cljs.tools.reader.edn/read-string`) reject `:rf.frame/<digits>`.
-  ;; The per-request frame-id rides into the wire payload (Spec 011
-  ;; §Hydration boot) where the browser's strict EDN reader pulls it
-  ;; back during hydration — a digit-only local-part would crash the
-  ;; first call to `cljs.reader/read-string` on the embedded payload.
-  ;; `(gensym "f")` keeps the id unique per request, still namespaced,
-  ;; AND spec-compliant. `clojure.core/keyword` does not validate, so
-  ;; the read-side enforcement is the only signal — this naming is
-  ;; load-bearing.
+  ;; The alphabetic prefix keeps the payload frame id valid for strict EDN
+  ;; readers; keyword construction itself does not validate local names.
   (let [frame-id (keyword "rf.frame" (str (gensym "f")))]
     (ssr/set-request! frame-id request)
     (try
       (rf/reg-frame frame-id
         (cond-> {:doc       "ssr-ring per-request frame"
                  :platform  :server
-                 ;; EP-0027 (rf2-7ae2to): the SSR-ring runtime LOWERS its
-                 ;; request-derived init into the `:initial-events` construction
-                 ;; vector — the frame-level on-create key is retired in
-                 ;; `reg-frame`. The public
-                 ;; `ssr-handler` `:initial-events` opt IS the EP-0027 setup
-                 ;; vector (see `resolve-initial-events!`); per request it
-                 ;; resolves to an `:initial-events` vector, passed verbatim into
-                 ;; the per-request frame's `:initial-events` (EP-0027 §SSR —
-                 ;; "a server computes its :initial-events vector per request").
-                 ;;
-                 ;; Audit rf2-cegm7 A2 / rf2-j54ee: a VECTOR `:initial-events`
-                 ;; passes through verbatim — handlers read the request via the
-                 ;; `:rf.server/request` cofx (the spec-documented canonical
-                 ;; surface for NON-durable reads). rf2-kzns7l (additive): a
-                 ;; `(fn [request] initial-events-vector)` is resolved HERE — the
-                 ;; request slot is already populated (set-request! above), so the
-                 ;; fn derives the setup vector from the live Ring request, baking
-                 ;; a request-derived fact into a boot event's PAYLOAD (the
-                 ;; replay-safe recordable boundary).
+                  ;; Resolve after `set-request!`: the function form can derive
+                  ;; durable event payloads while handlers use the request coeffect
+                  ;; for ambient reads.
                  :initial-events (lifecycle/resolve-initial-events! initial-events request)}
           fx-overrides (assoc :fx-overrides fx-overrides)
           ssr          (assoc :ssr           ssr)))
@@ -229,14 +170,8 @@
       (catch Throwable t
         (ssr/clear-request! frame-id)
         (lifecycle/destroy-frame-quietly! frame-id)
-        ;; rf2-ljjh0 — the short-circuit response goes through
-        ;; `safe-on-error` so a caller-supplied `:on-error` that THROWS
-        ;; during a setup failure is contained (trace + locked
-        ;; `default-on-error`) rather than escaping `setup-request-frame!`
-        ;; as a raw container 500 with internal topology in the stack
-        ;; trace. The setup-failure path runs OUTSIDE the handler's own
-        ;; try/catch, so without this guard it is the one `:on-error`
-        ;; call site not protected by the handler body's catch.
+        ;; Setup runs outside the handler body's catch, so contain a failing
+        ;; caller hook here as well.
         {:short-circuit (lifecycle/safe-on-error on-error request t)}))))
 
 (defn render-error-body
@@ -247,13 +182,10 @@
   thrown, so the host can no longer rely on the user's root-view to
   produce wire bytes.
 
-  Per rf2-uzjhl: built as hiccup then rendered via
+  Built as hiccup and rendered via
   `ssr/render-to-string` (with `:doctype? true`, `:emit-hash? false`)
   so the public-error map flows through position-appropriate escaping
-  the emitter already owns — same render path as the caller-supplied
-  `:error-view` (`resolve-error-body` below). Removes the `(str ...)`
-  concatenation + manual `escape-html` / `escape-attr` calls that
-  duplicated the emitter's escaping behaviour.
+  the emitter already owns — the same path as a caller-supplied error view.
 
   Carries no internal trace detail — the wire surface is locked to the
   public-error keys; the internal Throwable already rode the trace bus
@@ -321,14 +253,8 @@
                             :exception (.getMessage t)
                             :ex-class  (.getName (class t))
                             :recovery  :fell-back-to-default-error-template})
-        ;; EP-0008 (rf2-hhutya): ALSO ride the always-on axis. The
-        ;; recoverable-degradation sibling of head-resolution — a buggy
-        ;; error-view falls back to the locked default template (a degraded
-        ;; outcome on the ALREADY-error response, not a new failure).
-        ;; NON-PROJECTING: the always-on `error-emit-projection-listener`
-        ;; skips this category (`non-projection-eligible-error?`, rf2-sccp5),
-        ;; so promotion ships the off-box record WITHOUT re-projecting /
-        ;; flipping the status the render-time path already stamped.
+        ;; Always-on but non-projecting: this is degradation of an existing
+        ;; error response, not a second status transition.
         (lifecycle/emit-always-on-error!
           {:error     :rf.error/ssr-ring-error-view-failed
            :frame     frame-id
@@ -340,29 +266,16 @@
 
 (defn ^:private build-full-response*
   "The non-error path of `build-full-response`. Split into its own fn
-  so the outer try/catch (rf2-zwgsv render-time projector unification)
-  reads as a simple wrap of the rendering / payload / shell pipeline,
-  not as a 30-line body in the catch's scope.
+  so the outer projector catch reads as a simple wrapper.
 
-  Per rf2-5br2y: the frame-aware stages (`resolve-root-view`,
-  `render-to-string`, `resolve-head`) run inside a SINGLE outer
-  `with-frame` so the `current-frame` push/pop happens once per request,
-  not three times. `app-db-value` reads the named frame explicitly and
-  doesn't need the binding; it sits outside the block to keep that
-  explicitness visible."
+  Root, body, head, and hydration projection share one frame scope. This is
+  required for registered lookups and frame-sensitive egress classification."
   [frame-id resp
    {:keys [root-view emit-hash? version schema-digest payload
            html-shell content-type]
     :as   opts}]
-  ;; rf2-er7qx2 — SSR blocking-resource drain. AFTER the `:initial-events` drain
-  ;; (which resolved the route + enqueued the route's blocking resource
-  ;; ensures) and BEFORE the render walk, drain the current nav-token's
-  ;; blocking resources until they settle or the render deadline fires. A
-  ;; never-settling blocking resource is settled to a structured first-load
-  ;; failure in the frame's runtime-db, so the render walk below sees a
-  ;; settled `:error` rather than an unchecked `:loading` / skeleton (Spec 016
-  ;; §SSR and hydration steps 3-4). A no-op when the resources artefact is
-  ;; absent (the `:resources/drain-blocking-ssr!` hook is nil).
+  ;; Blocking route resources settle before rendering; absent resource hooks
+  ;; make this a no-op.
   (ssr/drain-blocking-resources! frame-id opts)
   (let [;; Single `with-frame` block covers the frame-aware stages:
         ;; root-view resolution (a 0-arity fn may close over subscribe-time
@@ -371,77 +284,28 @@
         ;; AND the hydration-payload build. One push/pop per request.
         explicit-head (:head opts)
         {:keys [head-html html-attrs body-attrs body-html head-hash rf-payload]}
-        ;; rf2-bzw8gd / rf2-tqjc7h: pin `*current-frame*` to the request frame
-        ;; for the whole render walk (`rf/with-frame`), established ONCE per
-        ;; request. The scope covers resolve-root-view, render-to-string's
-        ;; `:view` lookups, resolve-head's `:head` / `:route` lookups, AND the
-        ;; payload's resource-runtime projection (which reads `*current-frame*`
-        ;; via `frame/resolve-current-frame`).
+        ;; Pin the request frame across view/head lookups and payload projection.
         (rf/with-frame frame-id
           (let [hiccup    (lifecycle/resolve-root-view root-view)
-                ;; rf2-4dra9 / rf2-h2ujj: resolve the active route's
-                ;; :head (or default-head fallback). The head fragment
-                ;; goes through the shell as the :head opt; the
-                ;; :html-attrs / :body-attrs bags ride alongside so the
-                ;; shell can stamp them on <html> / <body> per Spec 011
-                ;; §Default flow step 4. Callers that supplied an
-                ;; explicit :head string take precedence — they chose to
-                ;; bypass route-driven head resolution, and an explicit
-                ;; string carries no attr-bag sidechannel (nor a
-                ;; reconstructible `:head-model` — rf2-1oxjxk).
+                ;; Explicit head HTML bypasses route-derived attributes and has
+                ;; no client-reconstructible model.
                 head-bag  (if explicit-head
                             {:head-html explicit-head
                              :html-attrs nil
                              :body-attrs nil}
                             (lifecycle/resolve-head frame-id))
-                ;; rf2-i15nh / rf2-atmvj: compute the structural hash ONCE
-                ;; per request. rf2-1oxjxk (Option B, reverting rf2-9fw2de):
-                ;; the wire hash is BODY-ONLY again — the documented client
-                ;; boot (`ssr/hydrate!`'s `:render-tree-fn`) only ever hashes
-                ;; the bare body tree, so folding the head fragment in here
-                ;; fired a spurious mismatch on EVERY page (the client half
-                ;; of rf2-9fw2de was never made). The same hex feeds the
-                ;; root-element `data-rf-render-hash` (via render-to-string's
-                ;; `:render-hash` opt) AND the payload's `:rf/render-hash`, so
-                ;; the canonical-EDN walk runs once per request. When
-                ;; `:emit-hash?` is false the hash is still needed for the
-                ;; payload slot.
+                ;; Compute the body hash once for both emitted marker and payload.
                 hash-str  (lifecycle/render-document-hash hiccup)
-                ;; Head divergence rides its OWN channel (rf2-1oxjxk): a
-                ;; separate structural hash over the CANONICAL HEAD MODEL
-                ;; (never emitted HTML), client-reconstructible via
-                ;; `(rf/active-head frame-id)` (Spec 011 §Default flow step
-                ;; 5). nil when the head is not client-reconstructible (an
-                ;; explicit `:head` string, or a degraded/failed head
-                ;; resolution) — `render-head-hash` OMITS the channel rather
-                ;; than ship a hash the client could never match.
+                ;; Hash the head model on its separate reconstructible channel.
                 head-hash (lifecycle/render-head-hash (:head-model head-bag))
                 body-html (ssr/render-to-string
                             hiccup
                             {:doctype?    false
                              :emit-hash?  emit-hash?
                              :render-hash (when emit-hash? hash-str)})
-                ;; rf2-p026f5 — build the hydration payload INSIDE the same
-                ;; `with-frame` scope. app-db-value / runtime-db-value read the
-                ;; named frame explicitly, but the runtime-db PROJECTION is NOT
-                ;; frame-blind: the resources SSR hook
-                ;; (`:ssr/extend-runtime-db-projection` →
-                ;; `re-frame.resources.ssr/project-resources-runtime-db`)
-                ;; resolves the CURRENT frame (`frame/resolve-current-frame`,
-                ;; the `*current-frame*` dynamic var) to apply frame-owned
-                ;; egress classification + named-scope DERIVED sensitivity
-                ;; (Spec 015 §Derived sensitivity / Spec 016 clause 4). Built
-                ;; OUTSIDE this scope (the prior shape) it ran FRAMELESS, so a
-                ;; resource under a frame-sensitive `{:from-db}` scope leaked
-                ;; its raw scope identity + data into the payload. Reading the
-                ;; snapshot here — AFTER the render walk, INSIDE the block — is
-                ;; load-bearing in BOTH dimensions: the post-walk value (a
-                ;; continuation drain may have mutated the frame-state) AND the
-                ;; frame scope the projection needs. This mirrors the streaming
-                ;; path, where `build-final-payload` runs inside the same
-                ;; `with-frame` rebinding (rf2-tbr67x / rf2-tqjc7h).
-                ;; EP-0001 (rf2-30kzz2): the runtime-db rides as the
-                ;; serializable `:rf/runtime-db` slice.
+                ;; Read after rendering and inside the frame scope. Optional
+                ;; resource projection uses the carried frame to apply derived
+                ;; sensitivity before serializing the durable runtime slice.
                 app-db     (rf/app-db-value frame-id)
                 runtime-db (:rf.db/runtime (rf/frame-state-value frame-id))
                 rf-payload (payload/build-payload frame-id app-db runtime-db hash-str
@@ -464,47 +328,19 @@
                            ;; — see `rf-payload` above).
                            :head-hash   (when emit-hash? head-hash))
         html        (html-shell body-html payload-edn shell-opts)
-        ;; rf2-c0bq1 — RE-FLUSH after the render walk. The `resp` arg was
-        ;; read by the single `get-response` in `ssr-handler` BEFORE the
-        ;; render ran, so it carries the pre-render status. A reactive
-        ;; sub that THROWS during `render-to-string` under production
-        ;; hardening (`interop/debug-enabled? = false`) recovers to nil —
-        ;; `render-to-string` does NOT throw, so the outer
-        ;; `build-full-response` catch never fires — but the always-on
-        ;; error-emit substrate (rf2-vvwmi) BUFFERS a fail-closed 500 onto
-        ;; pending-error-traces during the walk. Without this re-flush
-        ;; that buffered 500 sits unread until frame-destroy drops it, and
-        ;; the wire ships a silent 200 with the recovered-to-nil broken
-        ;; HTML — defeating the rf2-vvwmi fix end-to-end and breaking the
-        ;; Spec 011 §744/§750 "fail-closed, never a silent 200" contract.
-        ;;
-        ;; `flush-response!` drains the (post-render) buffer through the
-        ;; default projector and stamps the projector's :status onto the
-        ;; response accumulator (last-write-wins, redirect-guarded — see
-        ;; `apply-error-projection!` error_listener.cljc:139). The happy
-        ;; path is unaffected: no error buffered during render → empty
-        ;; buffer → the drain is a no-op → :status stays whatever the
-        ;; pre-render `resp` carried (default 200). A redirect set during
-        ;; render still wins (the projector refuses to overwrite a
-        ;; redirect response). We re-read the FULL response (not just
-        ;; merge :status) so any header / cookie the render walk
-        ;; accumulated also rides the wire.
+        ;; Re-flush after rendering. A hardened reactive subscription may recover
+        ;; to nil while buffering a projected failure; reading only the pre-render
+        ;; response would incorrectly ship that broken render as 200. Re-read the
+        ;; full accumulator so post-render headers and cookies also survive.
         post-render-resp (ssr/flush-response! frame-id)]
-    ;; Content-Type override (rf2-nncni3): the 3-arg form force-replaces
-    ;; the accumulator's Content-Type with the handler's `:content-type`
-    ;; opt when it is non-nil. The SSR runtime always seeds a Content-Type
-    ;; on [:rf/response :headers], so the earlier default-when-absent form
-    ;; could NEVER apply the opt — a caller `:content-type` was silently
-    ;; dropped. With the opt now defaulting to nil (removed from
-    ;; `handler-defaults`), a nil `content-type` leaves the runtime seed /
-    ;; app-`set-header` value in control; a non-nil opt overrides it.
+    ;; A non-nil construction option overrides the seeded/app Content-Type.
     (ssr-response->ring-response post-render-resp html content-type)))
 
 (defn project-render-throw->ring-response
   "Route a render-time `Throwable` through the SSR error projector and
   materialise the projected (fail-closed, non-200) Ring error response.
-  Shared by the non-streaming `build-full-response` catch arm AND the
-  streaming `stream-handler` shell phase (rf2-r06pc) so BOTH render-side
+  Shared by the non-streaming `build-full-response` catch arm and the
+  streaming `stream-handler` shell phase so both render-side
   failure surfaces emit one uniform projected-error body contract.
 
   Steps (Spec 011 §Server error projection §View-time exceptions):
@@ -527,9 +363,8 @@
   generic-500 public-error is substituted so the wire still carries a
   well-formed fail-closed body.
 
-  rf2-nu5w48 / rf2-tqjc7h: the WHOLE error-projection + error-body render path
-  runs inside the request frame's `with-frame` scope, mirroring the happy-path
-  `build-full-response*` binding (rf2-bzw8gd). `project-render-exception!`
+  The whole error projection and error-body render path runs inside the
+  request frame's scope, mirroring the happy path. `project-render-exception!`
   stamps the per-frame response accumulator, `peek-response` reads it, and a
   caller `:error-view` resolves through the registrar (`resolve-error-body`'s
   `[error-view public-error]` view lookup); `resolve-error-body` re-pins
@@ -543,15 +378,8 @@
                              :message "Something went wrong"
                              :retryable? false})
           body-html     (resolve-error-body frame-id (:error-view opts) public-error*)]
-      ;; rf2-nncni3 — do NOT apply the handler's `:content-type` override on
-      ;; the error path. That opt labels the SUCCESSFUL rendered body (an XML
-      ;; feed / bespoke type); the projected error body is always an HTML
-      ;; fallback, so it keeps the runtime's `text/html; charset=utf-8` seed
-      ;; (Spec 011 §Status defaults) — labelling an HTML error page as, say,
-      ;; `application/xml` would be a wire-content mismatch. An app that set a
-      ;; custom Content-Type via `:rf.server/set-header` before the throw
-      ;; still has it on `resp*` (unchanged behaviour); we only decline to
-      ;; force the construction-time opt here.
+      ;; The construction-time Content-Type labels only successful bodies. A
+      ;; projected error is HTML, so keep the response accumulator's header.
       (ssr-response->ring-response resp* body-html))))
 
 (defn build-full-response
@@ -559,14 +387,14 @@
   hydration payload, wrap in the html-shell, and materialise to a Ring
   response.
 
-  Per rf2-6t36h the root-view resolves EXACTLY ONCE per request — both
+  The root view resolves once per request: both
   the wire HTML (via `render-to-string` + its embedded
   `data-rf-render-hash`) and the payload's `:rf/render-hash` derive
   from the same hiccup tree, so a non-idempotent fn-form root-view
   cannot fire a spurious `:rf.ssr/hydration-mismatch` on a successful
   hydration.
 
-  Per rf2-zwgsv (Mike decision rf2-i9f0g Option B) — a render-time
+  A render-time
   throw (e.g. the `validate-tag-name!` rejection of
   `(keyword \"has space\")`, a view-fn `(throw (ex-info ...))`, a
   hiccup-walker structural error) is routed through the SAME error
@@ -588,24 +416,23 @@
        uses — so headers / cookies the drain DID accumulate before
        the render-time throw still ride the wire.
 
-  The try/catch is the unification point: render-time AND drain-time
+  The try/catch is the unification point: render-time and drain-time
   exceptions both go through the projector, so the wire body contract
-  is uniform regardless of where the failure originated (rf2-zwgsv).
+  is uniform regardless of where the failure originated.
 
   Note: the outer `ssr-handler`'s `:on-error` hook still wraps this
   call. The remaining exceptions it catches are Ring-layer / transport
   failures the projector can't see (e.g. an exception in the host's
   Content-Type negotiator, or a re-throw from the projector pipeline
-  itself when no server frame is registered). Those hit the fixed-
-  string default per rf2-kzvwq's topology-leak rule."
+  itself when no server frame is registered). Those use the fixed, no-detail
+  transport fallback."
   [frame-id resp opts]
   (try
     (build-full-response* frame-id resp opts)
     (catch Throwable t
       ;; The projector stamps :status onto the response accumulator and
       ;; the projected (fail-closed, non-200) error body is materialised
-      ;; through the SAME path the streaming shell phase now reuses
-      ;; (rf2-r06pc — `project-render-throw->ring-response`). Render-time
+      ;; through the same path the streaming shell phase reuses. Render-time
       ;; AND drain-time exceptions thus share one wire-body contract,
       ;; and the streaming + non-streaming shell-failure surfaces project
       ;; identically (Spec 011 §Server error projection §View-time

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/shell.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/shell.clj
@@ -7,20 +7,10 @@
   first-time user gets a working SSR endpoint without writing string
   concatenation glue.
 
-  Script-body safety (rf2-7ksyr, security audit 2026-05-14 §P1) — the
-  hydration payload's EDN string is dropped raw inside
-  `<script id=\"__rf_payload\" type=\"application/edn\">…</script>`. A
-  payload that contains `</script>` (from any user-controlled string
-  that round-tripped through app-db) would close the envelope and
-  expose an XSS vector. The shell pre-escapes the EDN through the
-  EDN-aware `html-helpers/escape-edn-script-body` — `<` inside EDN
-  string literals becomes the `\\u003c` Unicode escape, while `<` inside
-  keyword/symbol tokens (`:<`, `:a<b`) is left intact so the document
-  round-trips through `clojure.edn/read-string` unchanged; a `</` / `<!`
-  breakout precursor in a token position fails loud (rf2-rdxxa). Earlier
-  drafts ran the whole-EDN `escape-script-body-string`, which corrupted
-  such tokens into unreadable `\\u003c…` sequences. The streaming
-  delta path applies the same encoder."
+  The hydration EDN is escaped with the EDN-aware script-body encoder:
+  string content cannot close the script element, token content still
+  round-trips through the EDN reader, and unsafe token-position breakout
+  sequences fail loudly. The streaming path uses the same encoder."
   (:require [re-frame.ssr.constants :as constants]
             [re-frame.ssr.html-helpers :as html]))
 
@@ -41,32 +31,21 @@
       (not (contains? html-attrs :lang)) (assoc :lang lang))
     {:lang lang}))
 
-;; ---- shared hydration-payload <script> envelope (rf2-7ksyr) ---------------
+;; ---- shared hydration-payload <script> envelope ---------------------------
 ;;
-;; The id-pinned, `</script>`-escaped payload `<script>` is emitted in
-;; two places — the non-streaming `default-html-shell` and the streaming
-;; final chunk (`re-frame.ssr.ring.streaming`). The escape is security-
-;; load-bearing (rf2-7ksyr); a fix or id change to one path MUST track
-;; the other, so both call this single helper.
+;; Non-streaming and streaming responses use this helper so the pinned id and
+;; security-sensitive script-body escaping cannot diverge.
 
 (defn payload-script-tag
   "Build the id-pinned `<script type=\"application/edn\">` carrying the
   already-`pr-str`'d hydration payload EDN. `payload-edn` is escaped
-  through `html/escape-edn-script-body` so a payload containing
-  `</script>` (sourced from any user-controlled string round-tripped
-  through app-db) can't close the envelope — the XSS gate from
-  security audit 2026-05-14 §P1 (rf2-7ksyr / rf2-rdxxa). The EDN-aware
-  encoder escapes `<` to the `\\u003c` reader escape only inside EDN
-  string literals (where the reader decodes it back), so the payload
-  round-trips through `clojure.edn/read-string` on the client unchanged
-  even when it carries keyword/symbol tokens containing `<` (`:<`,
-  `:a<b`); a `</` / `<!` breakout in a token position fails loud rather
-  than corrupting the document.
+  through `html/escape-edn-script-body`: string content cannot close the
+  element, EDN token content remains readable, and unsafe token-position
+  breakout sequences fail loudly.
 
   The id is pinned in `re-frame.ssr.constants/payload-script-id`
-  (`\"__rf_payload\"`) — the contract between this server-side emit and
-  the client bootstrap's `document.getElementById(...)` read (Spec 011
-  §Hydration payload script id, rf2-cegm7 CQ-3 / rf2-j54ee)."
+  (`\"__rf_payload\"`) — the contract with the client bootstrap's
+  `document.getElementById(...)` read."
   [payload-edn]
   (str "<script id=\"" constants/payload-script-id "\" type=\"application/edn\">"
        (html/escape-edn-script-body payload-edn)
@@ -74,41 +53,19 @@
 
 ;; ---- single-source document envelope (prefix + suffix) --------------------
 ;;
-;; rf2-od9fet — the doctype / `<html>` / `<head>` / open-`<body>` /
-;; open-`#app-div` PREFIX and the bootstrap-`<script>` / `:body-end` /
-;; document-close SUFFIX are each assembled in EXACTLY ONE place here.
-;; Both the non-streaming `default-html-shell` (which sandwiches
-;; body-html + `</div>` + the shared `payload-script-tag` between them)
-;; and the streaming delegates (`re-frame.ssr.ring.streaming`'s
-;; `default-streaming-prefix` / `default-streaming-suffix`, which flush
-;; the two halves around the resolved-continuation chunks) compose these
-;; renderers, so the two response modes CANNOT drift on the doctype,
-;; `<html>`/`<body>` attribute bags, charset, head fragment, head-hash
-;; marker, `#app` id/escaping, bootstrap script, or closing tags. That
-;; matters because the envelope carries security-load-bearing escaping
-;; (the `escape-attr` attribute-value split, rf2-7x0qk) — a fix or shape
-;; change made in one mode would previously have to be mirrored by hand
-;; in the other.
+;; These renderers single-source the document envelope for both response
+;; modes, including attribute escaping and hash-marker placement.
 
 (defn document-prefix
-  "Render the document PREFIX shared by the non-streaming shell and the
-  streaming prefix (rf2-od9fet): `<!DOCTYPE html>` through the OPEN
-  `<div id=\"…\">` app-root element, inclusive.
+  "Render the shared document prefix through the open app-root element.
 
-  `render-hash` is an EXPLICIT argument (not read from `opts`) because it
-  is the one piece the two modes disagree on: the non-streaming
-  `default-html-shell` passes `nil` (its `#app` root carries no
-  `data-rf-render-hash` — the marker is a streaming-only wire signal),
-  while the streaming prefix passes its body-only structural hash when
-  `:emit-hash?` is set, stamping `data-rf-render-hash` on the streamed
-  root. When `render-hash` is nil the attribute is omitted entirely (no
-  value needs no escaping — the hash is an 8-char hex FNV output).
+  `render-hash` is explicit because the streaming prefix can stamp the
+  body-only hash on its app root while `default-html-shell` passes nil.
 
   `head-html` is the resolved `<head>` fragment (a content position,
   injected raw). `opts` carries the `:html-attrs` / `:body-attrs` bags
   (stamped via the shared `attr-string` serialiser), the `:lang`
-  fallback (resolved through `html-attr-bag`), the `:app-element-id`
-  (an attribute-value position, `escape-attr`'d per the rf2-7x0qk split),
+  fallback (resolved through `html-attr-bag`), the escaped `:app-element-id`,
   and the optional `:head-hash` (the SEPARATE client-reconstructible
   head-model hash stamped as `data-rf-head-hash` on `<head>`, omitted
   when nil)."
@@ -120,36 +77,23 @@
     (str "<!DOCTYPE html>"
          "<html" (html/attr-string attr-bag) ">"
          "<head"
-         ;; rf2-1oxjxk — the SEPARATE client-reconstructible head-model
-         ;; hash, distinct from the body's data-rf-render-hash on #app.
-         ;; Omitted when nil (no value needs no escaping — an 8-char hex
-         ;; FNV output, same shape as the render-hash marker).
+         ;; The head-model hash is separate from the body's render hash.
          (when head-hash (str " data-rf-head-hash=\"" head-hash "\""))
          ">"
          "<meta charset=\"utf-8\">"
          (or head-html "")
          "</head>"
          "<body" (html/attr-string body-attrs) ">"
-         ;; rf2-7x0qk — `:app-element-id` lands INSIDE a double-quoted
-         ;; attribute value, so it is escaped through `html/escape-attr`
-         ;; (escapes `&` + `"`, lossless + position-correct). The
-         ;; trusted-string raw-injection contract applies only to the two
-         ;; CONTENT-position opts (`:head` / `:body-end`); an
-         ;; attribute-value position has a single correct escape, so even
-         ;; a benign quote-bearing value can't break out of the attribute.
-         ;; See `validate-trusted-shell-opts!` for the split.
+         ;; Attribute values are escaped; raw trust applies only to the
+         ;; `:head` and `:body-end` content hooks.
          "<div id=\"" (html/escape-attr app-element-id) "\""
-         ;; rf2-1oxjxk — the body-only structural `data-rf-render-hash`
-         ;; marker. Non-streaming passes nil (no marker on #app);
-         ;; streaming passes it when `:emit-hash?` is set. An 8-char hex
-         ;; FNV output, so it needs no escaping.
+         ;; Only streaming supplies this body-only structural hash marker.
          (when render-hash
            (str " data-rf-render-hash=\"" render-hash "\""))
          ">")))
 
 (defn document-suffix
-  "Render the document SUFFIX shared by the non-streaming shell and the
-  streaming suffix (rf2-od9fet): the bootstrap `<script src=…>` (when a
+  "Render the shared document suffix: the bootstrap `<script src=…>` (when a
   `:script-src` is in play), the raw `:body-end` content hook, and the
   `</body></html>` document close.
 
@@ -157,17 +101,12 @@
   emitted here — they sit BEFORE the suffix (the non-streaming shell
   writes `</div>` + `payload-script-tag` between the prefix and this
   suffix; the streaming writer closes `</div>` at the end of the shell
-  chunk and streams the `__rf_payload` after the continuations,
-  rf2-z9dduj). `:script-src` is an attribute-value position, escaped
-  through `html/escape-attr` (the same rf2-7x0qk split as
-  `:app-element-id` in the prefix); `:body-end` stays raw (content
-  position)."
+  chunk and streams the payload after the continuations. `:script-src` is
+  escaped as an attribute value; `:body-end` stays raw content."
   [{:keys [body-end script-src]
     :or   {script-src "/main.js"}}]
   (str (when script-src
-         ;; rf2-7x0qk — `:script-src` is an attribute-value position;
-         ;; escape through `html/escape-attr` (same split as the prefix's
-         ;; `:app-element-id`). `:body-end` stays raw (content position).
+         ;; `:script-src` is an attribute value; `:body-end` is raw content.
          (str "<script src=\"" (html/escape-attr script-src) "\"></script>"))
        (or body-end "")
        "</body>"
@@ -182,19 +121,19 @@
   `re-frame.ssr.constants/payload-script-id` (`\"__rf_payload\"`). The
   CLJS bootstrap reads the payload via
   `document.getElementById(\"__rf_payload\")` — same constant, both
-  sides (Spec 011 §Hydration payload script id, rf2-cegm7 CQ-3 / rf2-j54ee).
+  sides (Spec 011 §Hydration payload script id).
   Custom `:html-shell` overrides MUST emit the payload `<script>` under
   this id (or substitute their own bootstrap that reads a custom id).
 
   `<title>` is NOT emitted by the shell — the head fragment is the
-  canonical source per Spec 011 §Head/meta contract (rf2-4dra9, rf2-3z841).
+  canonical source per Spec 011 §Head/meta contract.
   `default-head` rolls the frame's `:doc` into `:title` when a route does
   not declare `:head`, so a sensible title is always present in the
   resolved head fragment threaded in as the `:head` opt. Emitting one
   here would produce two `<title>` tags per document — malformed HTML.
 
   `<html>` / `<body>` attributes — the active head model's
-  `:html-attrs` / `:body-attrs` bags (Spec 011 §Head/meta — line 478)
+  `:html-attrs` / `:body-attrs` bags (Spec 011 §Head/meta)
   are threaded in through opts by the pipeline and stamped onto the
   opening tags via the shared `re-frame.ssr.html-helpers/attr-string`
   serialiser (boolean `true` → bare attribute name; `false` / `nil` →
@@ -209,49 +148,21 @@
     opts — the caller's adapter opts (merged with any per-request
            overrides); standard keys :head / :html-attrs / :body-attrs
            / :body-end / :script-src / :app-element-id / :lang
-           influence the envelope. `:head-hash` (rf2-1oxjxk, optional)
+           influence the envelope. Optional `:head-hash`
            stamps `data-rf-head-hash` on the `<head>` element — the
            SEPARATE client-reconstructible head-model hash channel
            (Spec 011 §Mismatch detection — head), distinct from the
            body's `data-rf-render-hash` on the `#app` root div. Omitted
            when nil (the explicit-`:head`-STRING / degraded-head shape).
 
-  Trusted-string contract — per Spec 011 §Trusted shell hook contract
-  (rf2-o6ndb, attribute/content split rf2-7x0qk), the four shell opts
-  split by injection position. `:head` and `:body-end` are TRUSTED
-  STRINGS injected RAW into CONTENT positions (no escaping — free-form
-  HTML content has no single-correct escape). `:script-src` and
-  `:app-element-id` land in ATTRIBUTE-VALUE positions (`<script src>` /
-  `<div id>`) and are `escape-attr`-escaped here (rf2-7x0qk): a
-  double-quoted attribute value has a single correct escape, so a stray
-  `\"` in an otherwise-benign id / URL can't break out of the attribute
-  and emit malformed markup. Escaping `&` + `\"` is lossless. This is
-  structural-correctness, not a sandbox — the content opts (`:head` /
-  `:body-end`) remain raw. The shell is caller-controlled config (app
-  boot decides what scripts/analytics tags / asset URLs / head
-  fragments to inject), so the trust-the-caller model is load-bearing
-  for the CONTENT opts. Hosts that route user-controlled content
-  through `:head` / `:body-end` (e.g. config-driven analytics blocks
-  sourced from a customer settings UI, a tenant-admin-editable head
-  fragment) MUST escape upstream — the shell will not. The
-  structured alternative for untrusted-customization use cases is
-  `reg-head` (for head fragments per Spec 011 §Head/meta) +
-  `reg-view*` + `:rf.server/*` fx (for body content), both of which
-  run through the standard SSR emitter and apply position-appropriate
-  escaping at every leaf. Construction-time structural validation
-  lives in `re-frame.ssr.ring.trust/validate-trusted-shell-opts!`
-  (rejects non-string non-nil values with
-  `:rf.error/ssr-trusted-shell-opt-invalid`); the content trust
-  itself is the caller's. Audit rf2-asmj1 R12 / cluster rf2-sljs1 /
-  rf2-o6ndb."
+  Trusted-string contract: `:head` and `:body-end` are raw content hooks;
+  `:script-src` and `:app-element-id` are escaped attribute values. Raw hooks
+  must never be populated from untrusted input. Construction validates shape,
+  not content trust; prefer structured views and head registrations for
+  untrusted content."
   [body-html payload-edn {:keys [head] :as opts}]
-  ;; rf2-od9fet — composed from the single-source `document-prefix` /
-  ;; `document-suffix` renderers (shared verbatim with the streaming
-  ;; delegates). The non-streaming `#app` root carries NO
-  ;; `data-rf-render-hash` marker, so `render-hash` is nil here; the
-  ;; body, its closing `</div>`, and the shared id-pinned,
-  ;; `</script>`-escaped `payload-script-tag` (rf2-7ksyr — same helper the
-  ;; streaming final chunk uses) sit between the prefix and the suffix.
+  ;; The non-streaming app root has no render-hash marker. Body content and
+  ;; the shared payload tag sit between the common prefix and suffix.
   (str (document-prefix head nil opts)
        body-html
        "</div>"

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
@@ -1,6 +1,5 @@
 (ns re-frame.ssr.ring.streaming
-  "Chunked Ring response for streaming SSR. Per Spec 011 §Streaming SSR
-  (rf2-ojakd / rf2-olb64 (a)).
+  "Chunked Ring response for streaming SSR, per Spec 011.
 
   Wire shape (the order the conformance fixture pins):
 
@@ -17,11 +16,9 @@
                               type=application/edn>full-payload</script>
     4. Closing chunk      — </body></html>
 
-  Transport: HTTP `Transfer-Encoding: chunked`. The Ring response we
-  return uses a `clojure.java.io/PipedOutputStream`-backed body
-  (Ring's `clojure.java.io/IOFactory`-compatible InputStream wrapper)
-  so the server (Jetty, http-kit, Aleph) flushes chunks as they're
-  written.
+  Transport: the Ring response carries an unknown-length `PipedInputStream`
+  body. The host server owns HTTP framing (for example chunked HTTP/1.1) and
+  reads bytes as the paired writer produces them.
 
   The lifecycle mirrors the non-streaming handler in
   `re-frame.ssr.ring.pipeline` but with the four-step chunk wiring
@@ -40,8 +37,8 @@
   Per the bundle-isolation contract, this ns is JVM-only (`.clj`) —
   shadow-cljs only picks up `.cljc` / `.cljs`. The client-side consumer
   of this wire shape is `re-frame.ssr.streaming.client/install!` (a
-  CLJS-only, host-opt-in runtime; re-exported as `ssr/streaming-install!`,
-  rf2-3hhv5): it swaps each `<template>` fallback for its resolved subtree
+  CLJS-only, host-opt-in runtime; re-exported as `ssr/streaming-install!`):
+  it swaps each `<template>` fallback for its resolved subtree
   in-place and merges the per-subtree `data-rf2-suspense-hydrate` delta as
   chunks arrive, reconciling against the final `__rf_payload`
   (`:replace-frame-state`) when it lands."
@@ -63,13 +60,13 @@
 ;; The non-streaming `default-html-shell` returns one finished string —
 ;; useful when everything renders synchronously. For streaming we need to
 ;; flush the prefix (open <html>, <head>, open <body>, open #app-div)
-;; immediately and emit the suffix (close #app-div, payload script,
+;; immediately and emit the suffix (payload script and document close)
 ;; close </body></html>) after the continuations have drained.
 ;;
 ;; The split mirrors the default shell's structure 1:1. A one-piece
 ;; `:html-shell` fn is the NON-STREAMING contract and cannot be honoured
 ;; here (it can't run after streaming has started) — `stream-handler`
-;; rejects `:html-shell` at construction (rf2-oq4m5). Streaming callers
+;; rejects `:html-shell` at construction. Streaming callers
 ;; customize the envelope through the four trusted shell-hook opts
 ;; (`:head` / `:body-end` / `:script-src` / `:app-element-id`, honoured by
 ;; the prefix/suffix below), or build a non-streaming `ssr-handler` when a
@@ -81,28 +78,15 @@
   the `:html-attrs`/`:lang` fallback with the non-streaming shell via
   `shell/html-attr-bag` so the two envelopes can't diverge.
 
-  rf2-1oxjxk (Option B, reverting rf2-9fw2de): when `:render-hash` is
-  supplied (the handler passes it iff `:emit-hash?` is true),
+  When `:render-hash` is supplied (iff `:emit-hash?` is true),
   `data-rf-render-hash` is stamped on the streaming root element — the
-  `#app` div, the first DOM root of the streamed document — mirroring the
-  non-streaming handler's root-element marker (Spec 011 §362-363). The
-  hash value is the BODY-ONLY structural hash shared with the final
-  payload's `:rf/render-hash` (rf2-9fw2de's full-document fold was
-  reverted — see `re-frame.ssr.ring.lifecycle/render-document-hash`), so
-  toggling `:emit-hash?` has an observable effect on the wire and a
-  host/tool can verify the streamed root against the payload. `:head-hash`
+  `#app` div. The value is the body-only structural hash shared with the
+  payload's `:rf/render-hash`. `:head-hash`
   (optional) is the SEPARATE client-reconstructible head-model hash,
   stamped as `data-rf-head-hash` on `<head>` — omitted when nil."
   [head-html {:keys [render-hash] :as opts}]
-  ;; rf2-od9fet — a DELEGATE over the single-source `shell/document-prefix`
-  ;; (shared verbatim with the non-streaming `default-html-shell`). The
-  ;; streaming path preserves the optional `data-rf-render-hash` marker on
-  ;; the `#app` root — it passes `:render-hash` explicitly (the
-  ;; non-streaming shell passes nil, so its root carries no marker). Every
-  ;; other envelope decision (doctype, `<html>`/`<body>` attr bags,
-  ;; charset, head fragment, `:head-hash` marker, `:app-element-id`
-  ;; escaping) lives in the shared renderer, so the two response modes
-  ;; cannot silently diverge on the security-load-bearing escaping.
+  ;; Delegate all envelope and escaping decisions to the shared renderer;
+  ;; streaming alone supplies the optional app-root render hash.
   (shell/document-prefix head-html render-hash opts))
 
 (defn default-streaming-suffix
@@ -110,7 +94,7 @@
   bootstrap script tag (if any), the body-end raw HTML, and the document
   close.
 
-  rf2-z9dduj — the app root (`</div>`) is NO LONGER closed here. It is
+  The app root (`</div>`) is closed
   closed at the END of the shell chunk (immediately after the shell HTML,
   see `run-streaming-writer!`), so the resolved templates, hydration-delta
   scripts, and the final `__rf_payload` script all stream OUTSIDE `#app`
@@ -121,41 +105,16 @@
   `default-html-shell` (which emits the payload script + bootstrap + body-end
   after `</div>`)."
   [opts]
-  ;; rf2-od9fet — a DELEGATE over the single-source `shell/document-suffix`
-  ;; (shared verbatim with the non-streaming `default-html-shell`). The
-  ;; app-root `</div>` moved to the shell chunk (rf2-z9dduj), so this is
-  ;; purely the bootstrap `<script src=…>` (`:script-src`, escape-attr'd),
-  ;; the raw `:body-end` content hook, and the `</body></html>` close —
-  ;; all single-sourced with the non-streaming shell's suffix.
+  ;; The shared suffix owns bootstrap escaping, raw body-end content, and the
+  ;; document close; the app root closes in the shell chunk.
   (shell/document-suffix opts))
 
-;; ---- shell phase (request thread, BEFORE the head commits) --------------
+;; ---- shell phase (request thread, before response materialisation) -------
 ;;
-;; rf2-r06pc — the shell render runs on the REQUEST thread, BEFORE the
-;; Ring response head is committed and BEFORE the writer thread is
-;; spawned. This is the streaming counterpart to the non-streaming
-;; handler's post-render re-flush (rf2-c0bq1, `pipeline.clj`):
-;;
-;;   - A root-view throw / shell-walk throw escalates to
-;;     `:rf.error/ssr-render-failed` via the projector and FAILS CLOSED
-;;     to a non-200 projected error page (Spec 011 §744/§748/§954) —
-;;     handled by the handler's outer try/catch on the request thread.
-;;   - A production reactive-sub throw during the shell render recovers
-;;     to nil (the walk does NOT throw) but BUFFERS a fail-closed 500 on
-;;     the always-on error-emit substrate (rf2-vvwmi). The handler
-;;     re-reads the response accumulator (`ssr/get-response`) AFTER the
-;;     shell render to pick that status up, exactly as `build-full-
-;;     response*` does — and a non-200 there fails closed to the
-;;     projected error page rather than streaming the broken HTML.
-;;
-;; Only once the shell is KNOWN-RENDERABLE (clean render AND a success
-;; status) does the handler commit the chunked response head and hand
-;; the already-rendered shell + continuations to the daemon writer. The
-;; writer's only remaining failure surface is continuation drains (which
-;; the inline-fallback contract already covers, Spec 011 §942-954) and
-;; the final-payload / suffix writes — and those happen AFTER the first
-;; chunk has committed, so they correctly degrade to a truncate-and-close
-;; rather than re-stamping a status the wire has already sent.
+;; Render the shell and re-read projected status on the request thread before
+;; committing the response head. Pre-commit failures can still return a
+;; projected non-200; after the writer starts, failures can only use inline
+;; continuation fallback or truncate-and-close.
 
 (defn- write-chunk! [^OutputStream out ^String s]
   (.write out (.getBytes s StandardCharsets/UTF_8))
@@ -175,9 +134,7 @@
      :shell-html    \"…\"                        ;; chunk 1 body
      :continuations [{:id … :subtree …} …]}     ;; drain queue (FIFO)
 
-  rf2-1oxjxk (Option B, reverting rf2-9fw2de): `:doc-hash` is the
-  BODY-ONLY structural hash (`lifecycle/render-document-hash`, body-hiccup
-  only — the full-document fold was reverted, see that fn's docstring). It
+  `:doc-hash` is the body-only structural hash. It
   describes the PRE-drain shell — the exact tree streamed in chunk 1 — and
   drives the streaming root-element `data-rf-render-hash` marker (when
   `:emit-hash?` is true). `:head-hash` is the SEPARATE client-
@@ -189,7 +146,7 @@
   daemon writer needs (`:head-model` was consumed here, for the hash,
   and does not itself ride the wire).
 
-  rf2-1kqvbx: when at least one continuation drains, `:doc-hash` no longer
+  When at least one continuation drains, `:doc-hash` no longer
   drives the FINAL-payload `:rf/render-hash`. The final payload ships the
   live POST-drain `app-db`, so its hash must describe the POST-drain render
   tree (the one a streaming hydrate re-renders + verifies against). The
@@ -200,14 +157,13 @@
   makes the streamed-shell marker (pre-drain) and the final-payload hash
   (post-drain) describe distinct moments — which they genuinely are.
 
-  rf2-t72b1c: when there are ZERO continuations (no `:rf/suspense-boundary`
+  When there are zero continuations (no `:rf/suspense-boundary`
   in the tree — the common case), nothing runs between the shell render and
   the final-payload build that could mutate app-db, so the writer does NOT
   re-resolve the root view a second time — it reuses `:doc-hash` verbatim.
   This keeps a fn-form `:root-view` invoked EXACTLY ONCE per request
-  (`lifecycle/resolve-root-view`'s rf2-6t36h contract) for the overwhelming
-  majority of streaming requests; only a request with at least one
-  continuation pays the documented rf2-1kqvbx re-resolution cost.
+  for the common streaming request; only a request with at least one
+  continuation re-resolves it.
   `:head-hash` needs no post-drain recompute in either case: the head is
   request-thread-resolved and drain-invariant in v1 (it derives from the
   route / explicit `:head` opt, never from continuation-mutated app-db), so
@@ -215,38 +171,22 @@
   marker and the final payload.
 
   Throws propagate to the caller (the handler's outer try/catch routes
-  them through the projector → fail-closed non-200, rf2-r06pc). The
+  them through the projector to a fail-closed non-200. The
   recovered-to-nil sub case does NOT throw here — its buffered fail-
   closed status is picked up by the handler's post-shell `get-response`
   re-read."
   [frame-id {:keys [root-view] :as opts}]
-  ;; rf2-er7qx2 — SSR blocking-resource drain (streaming counterpart of the
-  ;; non-streaming `build-full-response*` drain). AFTER the `:initial-events` drain
-  ;; resolved the route + enqueued the route's blocking resource ensures and
-  ;; BEFORE the shell render walk, drain the current nav-token's blocking
-  ;; resources until they settle or the render deadline fires; a never-settling
-  ;; blocking resource is settled to a first-load failure in the frame's
-  ;; runtime-db so the shell render sees a settled `:error`, never a hung
-  ;; `:loading` / skeleton (Spec 016 §SSR and hydration steps 3-4). A no-op
-  ;; when the resources artefact is absent. The streaming SUSPENSE-boundary
-  ;; deferral is a separate axis — blocking ROUTE resources still settle before
-  ;; the shell, exactly as in the non-streaming path.
+  ;; Blocking route resources settle before the shell; suspense continuation
+  ;; deferral is a separate axis. Absent resource hooks make this a no-op.
   (ssr/drain-blocking-resources! frame-id opts)
-  ;; rf2-bzw8gd / rf2-tqjc7h: pin `*current-frame*` to the request frame for the
-  ;; shell render walk (`rf/with-frame`), the streaming counterpart of the
-  ;; non-streaming `build-full-response*` binding. Covers the registered-view +
-  ;; head/route lookups. Runs on the REQUEST thread.
+  ;; Pin the frame on the request thread for registered view and head lookups.
   (rf/with-frame frame-id
     (let [hiccup     (lifecycle/resolve-root-view root-view)
           head-bag   (if (:head opts)
                        {:head-html (:head opts) :html-attrs nil :body-attrs nil}
                        (lifecycle/resolve-head frame-id))
           {:keys [head-html html-attrs body-attrs]} head-bag
-          ;; rf2-1oxjxk (Option B, reverting rf2-9fw2de): the streaming
-          ;; structural hash is BODY-ONLY, identically to the non-streaming
-          ;; handler. Computed once here on the request thread; drives the
-          ;; final-payload `:rf/render-hash` AND (when `:emit-hash?`) the
-          ;; streaming root-element marker.
+          ;; Compute the body-only shell hash once on the request thread.
           doc-hash   (lifecycle/render-document-hash hiccup)
           ;; The SEPARATE client-reconstructible head-model hash — nil when
           ;; the head is not client-reconstructible (explicit `:head`
@@ -257,25 +197,19 @@
        :head-html     head-html
        :html-attrs    html-attrs
        :body-attrs    body-attrs
-       ;; rf2-1kqvbx — `head-hash` rides to the daemon writer alongside
-       ;; `doc-hash`. The head is resolved once on the request thread and
-       ;; does not change across continuation drains (it derives from the
-       ;; route / explicit `:head` opt, never from continuation-mutated
-       ;; app-db in v1), so this SAME pre-drain value is reused verbatim
-       ;; for the POST-drain final payload — only the body tree re-renders
-       ;; against the drained state (rf2-1oxjxk).
+        ;; Head state is drain-invariant, so the writer reuses this pre-drain
+        ;; hash while only the body may be re-hashed after continuations.
        :head-hash     head-hash
        :doc-hash      doc-hash
        :shell-html    shell-html
        :continuations continuations})))
 
-;; ---- chunk writer (daemon thread, AFTER the head commits) ---------------
+;; ---- chunk writer (daemon thread, after response materialisation) --------
 ;;
 ;; The Ring response body is a `PipedInputStream` paired with a writer
 ;; thread that pushes chunks onto a `PipedOutputStream`. The writer
-;; thread receives the ALREADY-RENDERED shell + continuations from the
-;; request thread (rf2-r06pc) — it no longer resolves/renders the shell
-;; itself, so a shell failure can never reach this thread. It holds the
+;; thread receives the already-rendered shell and continuations from the
+;; request thread. It holds the
 ;; per-request frame open across continuation drains and is the place
 ;; where post-commit exceptions are caught — anything that throws there
 ;; gracefully closes the pipe so the client sees a clean EOF rather than
@@ -287,28 +221,15 @@
 ;; writer thread proceeds with the next boundary. Exceptions OUTSIDE a
 ;; continuation (e.g. a final-payload build throw, or a downstream pipe
 ;; broken-write) close the pipe with the partial response that was
-;; already flushed — the first chunk has already committed the success
-;; status to the wire, so a truncate-and-close is the only safe outcome
-;; (the status can no longer change). The server logs the trace via
-;; `:rf.error/ssr-streaming-writer-failed`, which carries WRITER-PHASE
-;; context (rf2-l1qgjw): a `:phase` tag (`:shell-prefix` / `:shell-html`
+;; already selected. The detached writer cannot replace the Ring response map,
+;; so truncate-and-close is the only safe outcome. The server logs the trace via
+;; `:rf.error/ssr-streaming-writer-failed`, which carries a `:phase` tag
+;; (`:shell-prefix` / `:shell-html`
 ;; / `:continuation-template` / `:continuation-delta` / `:final-payload`
 ;; / `:suffix`), a `:boundary-id` tag when the failure is inside a
 ;; continuation drain, and a coarse `:committed? true` — so ops can tell
 ;; a broken client pipe from a bad final payload from a specific
-;; boundary drain rather than seeing one undifferentiated event.
-
-;; rf2-l1qgjw issue 2 — writer-failure phase context. The writer drains
-;; several distinct chunk phases AFTER the response head has committed
-;; (Spec 011 §Failure semantics — once the first chunk lands the status
-;; is on the wire and can no longer change). When a write throws, the
-;; bare `:frame`/`:exception`/`:ex-class`/`:recovery` shape gave ops the
-;; SAME trace for a broken client pipe, a bad final payload, a bad suffix
-;; hook, or a specific continuation drain — turning incident triage into
-;; log archaeology. We track the active phase in a `volatile!` as the
-;; writer advances and stamp it (plus the continuation `:boundary-id` and
-;; a coarse `:committed?`) onto the trace so the recovery channel names
-;; WHERE the stream broke. The phases, in wire order:
+;; boundary drain rather than seeing one undifferentiated event. The phases are:
 ;;
 ;;   :shell-prefix          — chunk 1a, the <!DOCTYPE>…<div id=app> open
 ;;   :shell-html            — chunk 1b, the shell body with <template>s
@@ -317,29 +238,27 @@
 ;;   :final-payload         — the canonical __rf_payload <script>
 ;;   :suffix                — the </div>…</body></html> close
 ;;
-;; `:committed?` is true from the moment the FIRST byte is attempted
-;; (`:shell-prefix` onward) — i.e. for every phase here, since the writer
-;; only runs after the request thread committed the chunked head. It is
-;; carried explicitly (rather than inferred from `:phase`) so the contract
-;; is self-describing for log/observability consumers and stays correct if
-;; a future pre-commit phase is ever added to this thread.
+;; Every writer phase is adapter-committed: the Ring response map and status
+;; are fixed even if the host has not yet emitted bytes. Traces carry
+;; `:committed? true` explicitly rather than asking consumers to infer this.
 
 (defn- run-streaming-writer!
   "Run the streaming writer on the calling (daemon) thread. The caller
   supplies an open `OutputStream` (the pipe sink) and the pre-rendered
-  shell pieces from `render-streaming-shell!` (rf2-r06pc — the shell is
-  resolved/rendered on the request thread BEFORE the head commits, so
+  shell pieces from `render-streaming-shell!` (the shell is
+  resolved/rendered on the request thread before response materialisation, so
   shell failures fail closed there; this thread only drains the chunk
   stream). On any throw, the catch arm emits a
   `:rf.error/ssr-streaming-writer-failed` trace and closes the stream
   cleanly so the Ring server can EOF the response.
 
-  The trace carries WRITER-PHASE context (rf2-l1qgjw issue 2): a `:phase`
+  The trace carries writer-phase context: a `:phase`
   tag naming which chunk was in flight when the write threw (one of
   `:shell-prefix` / `:shell-html` / `:continuation-template` /
   `:continuation-delta` / `:final-payload` / `:suffix`), a `:boundary-id`
   tag when the failure happened inside a continuation drain, and a coarse
-  `:committed? true` (every writer phase runs post-head-commit). That
+  `:committed? true` (the detached writer cannot replace the selected response).
+  That
   shape lets ops distinguish a broken client pipe from a bad final payload
   from a specific boundary drain in JFR / log streams instead of seeing
   one undifferentiated writer-failed event."
@@ -350,67 +269,32 @@
   (let [phase (volatile! [:shell-prefix nil])]
    (try
     (let [{:keys [emit-hash? version schema-digest payload root-view]} opts
-          ;; rf2-1oxjxk (Option B, reverting rf2-9fw2de) — the writer no
-          ;; longer recomputes the hash from `hiccup`; `doc-hash` (BODY-ONLY,
-          ;; PRE-drain) was computed once on the request thread by
-          ;; `render-streaming-shell!`. `:hiccup` stays in the `rendered` map
-          ;; for diagnostics but is not destructured here. `head-hash` — the
-          ;; SEPARATE client-reconstructible head-model hash — is likewise
-          ;; PRE-drain and reused verbatim for the final payload (the head is
-          ;; drain-invariant in v1, rf2-1kqvbx).
+          ;; Body and head hashes were computed before the drain. The body may
+          ;; be recomputed for final payload state; the head is drain-invariant.
           {:keys [head-html html-attrs body-attrs
                   doc-hash head-hash shell-html continuations]} rendered
           shell-opts (merge opts
                             {:html-attrs  html-attrs
                              :body-attrs  body-attrs
-                             ;; rf2-9fw2de / rf2-1kqvbx — honour `:emit-hash?`
-                             ;; on the streaming path: stamp the PRE-drain
-                             ;; body-only hash onto the root `#app` div when
-                             ;; true, no marker when false (a true no-op was the
-                             ;; bug). This marks the tree ACTUALLY streamed in
-                             ;; chunk 1 (the shell, with fallbacks + pre-drain
-                             ;; root reads). The FINAL payload carries a
-                             ;; POST-drain hash (recomputed below); the two
-                             ;; coincide unless a continuation mutates a
-                             ;; root-read key — see the final-payload block.
+                             ;; Mark the body tree actually streamed in chunk 1.
                              :render-hash (when emit-hash? doc-hash)
-                             ;; rf2-1oxjxk — the SEPARATE head-model hash,
-                             ;; stamped as `data-rf-head-hash` on `<head>`.
-                             ;; Gated by the SAME `:emit-hash?` toggle as
-                             ;; `data-rf-render-hash` (the WIRE marker only;
-                             ;; the final payload's `:rf/head-hash` stays
-                             ;; unconditional — see the final-payload block).
+                             ;; Wire hash markers share the emit toggle; payload
+                             ;; hashes remain unconditional.
                              :head-hash   (when emit-hash? head-hash)})]
       ;; Chunk 1 — shell prefix + shell HTML (with template fallbacks) +
-      ;; the app-root close. rf2-l1qgjw — stamp the phase before each write
+      ;; the app-root close. Stamp the phase before each write
       ;; so the catch arm names the in-flight chunk. `:shell-prefix` is
       ;; already the initial volatile value, set explicitly here for
       ;; symmetry/readability.
       (vreset! phase [:shell-prefix nil])
       (write-chunk! out (default-streaming-prefix head-html shell-opts))
-      ;; rf2-z9dduj — CLOSE the app root (`</div>`) at the END of the shell
-      ;; chunk, immediately after the shell HTML and BEFORE any resolved
-      ;; template / hydration-delta / final `__rf_payload` chunk. Spec 011
-      ;; §Chunk-ordering contract pins chunk 1 as
-      ;; `…<div id="app"><shell-html/></div>` — the app root is CLOSED in the
-      ;; shell chunk, and the resolved chunks + final payload + bootstrap +
-      ;; body-end stream OUTSIDE it (chunks 2..N). The non-streaming
-      ;; `default-html-shell` already closes `</div>` right after the body and
-      ;; emits the payload script outside `#app`; the streaming path used to
-      ;; leave the close in `default-streaming-suffix` AFTER the protocol
-      ;; chunks, so resolved templates + the `__rf_payload` script landed
-      ;; INSIDE the application root — control/protocol nodes in the DOM a
-      ;; client renderer/hydrator owns, risking a hydration mismatch /
-      ;; replacement (Spec 011 §998-1001). The close is appended to the same
-      ;; `:shell-html` write (one flush) so a write throw is still attributed
-      ;; to the `:shell-html` phase, and the suffix is now purely the bootstrap
-      ;; script + body-end + `</body></html>`.
+      ;; Close the app root in chunk 1. Continuation templates, protocol
+      ;; scripts, payload, and bootstrap must remain outside the hydrated root.
       (vreset! phase [:shell-html nil])
       (write-chunk! out (str shell-html "</div>"))
       ;; Chunks 2..N+1 — one per continuation, FIFO over registration.
       ;;
-      ;; rf2-sgvn6 / rf2-b1v8v — drain a GROWABLE FIFO worklist, not a
-      ;; fixed (doseq) over the shell's initial vector. A nested
+      ;; Drain a growable FIFO: a nested
       ;; `:rf/suspense-boundary` inside a continuation's subtree registers
       ;; a NEW continuation when that continuation renders (Spec 011
       ;; §922-924/§966/§983); `streaming/render-continuation` returns those
@@ -422,8 +306,7 @@
       (loop [queue (into clojure.lang.PersistentQueue/EMPTY continuations)]
         (when-let [entry (peek queue)]
           (let [{:keys [id html delta failed? continuations]}
-                ;; rf2-bzw8gd / rf2-tqjc7h: pin `*current-frame*` on this DAEMON
-                ;; thread (the request thread's `*current-frame*` does not cross
+                ;; Pin `*current-frame*` on this daemon thread; bindings do not cross
                 ;; the thread boundary), so `render-continuation`'s frame lookups
                 ;; + registered-view resolution operate on the request frame.
                 (rf/with-frame frame-id
@@ -431,12 +314,12 @@
                 tmpl-fn (if failed?
                           streaming/failed-template
                           streaming/resolved-template)]
-            ;; rf2-l1qgjw — a write throw inside a continuation drain names
+            ;; A continuation write names
             ;; the boundary :id so ops correlate the failure to a specific
             ;; deferred subtree (not just "some continuation broke").
             (vreset! phase [:continuation-template id])
             (write-chunk! out (tmpl-fn id html))
-            ;; rf2-kjf3m.5 — emit the per-boundary hydration-delta <script>
+            ;; Emit the per-boundary hydration-delta script
             ;; ONLY when the delta carries something to hydrate. A
             ;; continuation that merely READS app-db (the common case —
             ;; deferred subtrees rarely mutate state) yields a delta of
@@ -446,10 +329,9 @@
             ;; script rather than an inert `<script …>{}</script>` chunk
             ;; the client would parse and discard. `failed?` continuations
             ;; carry `:delta nil` (also falsy here), so the `not failed?`
-            ;; arm is now redundant but kept for intent clarity.
-            ;; rf2-uc3cs4 — a streaming hydration delta is browser-delivered
-            ;; hydration state, so it obeys the SAME allowlist-first-then-
-            ;; project boundary the final `__rf_payload` does (EP-0015 §14): an
+            ;; arm remains for intent clarity. A streaming hydration delta is
+            ;; browser-delivered state, so it obeys the same allowlist-first,
+            ;; frame-project-second boundary as the final payload: an
             ;; off-allowlist changed key is DROPPED by the handler `:payload`
             ;; policy and a frame-sensitive child inside an allowed changed key
             ;; redacts under `:rf.egress/ssr-hydration`. `project-delta` runs
@@ -471,105 +353,20 @@
             (recur (into (pop queue) continuations)))))
       ;; Chunk N+2 — final canonical __rf_payload.
       ;;
-      ;; rf2-1kqvbx — the streaming final-payload `:rf/render-hash` must
-      ;; describe the POST-drain render state, NOT the pre-drain shell, when
-      ;; a continuation could have mutated app-db in between. `build-final-
-      ;; payload` reads the LIVE frame `app-db` AFTER every continuation has
-      ;; drained, so its `:rf/app-db` is the post-drain state; pairing it
-      ;; with the pre-drain `doc-hash` would ship a payload whose state and
-      ;; hash described different moments. When a continuation mutates
-      ;; app-db and the ROOT tree reads that key, a streaming hydrate
-      ;; re-renders the root tree against the payload's post-drain `:rf/app-db`,
-      ;; hashes it, and fires a spurious `:rf.ssr/hydration-mismatch` against
-      ;; a stale pre-drain hash (Spec 011 §Hydration equivalence rule).
+      ;; The final payload reads post-drain app-db. If any continuation ran,
+      ;; re-resolve the root under this daemon thread's frame scope so state and
+      ;; body hash describe the same moment. With no continuations, reuse the
+      ;; shell hash and preserve exactly-once root resolution. The shell marker
+      ;; remains pre-drain because it describes chunk 1; the head hash is
+      ;; drain-invariant. Server `:root-view` and client `:render-tree-fn` must
+      ;; use symmetric expanded or unexpanded forms.
       ;;
-      ;; rf2-t72b1c — but re-resolving `root-view` is only SAFE/NEEDED when a
-      ;; continuation actually ran. `resolve-root-view`'s contract (rf2-6t36h)
-      ;; promises a fn-form `:root-view` runs EXACTLY ONCE per request — a
-      ;; non-idempotent fn (unsorted-map iteration order / gensym'd keys /
-      ;; time-of-day props) hashes two DIFFERENT trees across two calls,
-      ;; producing a spurious mismatch that has NOTHING to do with app-db.
-      ;; `continuations` here is the shell's ORIGINAL (pre-loop) registration
-      ;; list — non-empty iff at least one continuation drained. With ZERO
-      ;; continuations nothing ran between the shell render and this block
-      ;; that could have mutated app-db, so re-resolving would be a needless
-      ;; SECOND invocation with no corresponding benefit: reuse the pre-drain
-      ;; `doc-hash` verbatim (TRUE exactly-once). Only when `continuations`
-      ;; is non-empty do we pay the documented, unavoidable cost of a second
-      ;; invocation — re-resolve the root view here, on this daemon thread,
-      ;; inside the `rf/with-frame` binding, AFTER the drain loop — and
-      ;; recompute the BODY-ONLY hash over the post-drain tree via the SAME
-      ;; `lifecycle/render-document-hash` mechanism. The streamed-shell
-      ;; `data-rf-render-hash` marker keeps the PRE-drain `doc-hash` (it marks
-      ;; the tree actually streamed in chunk 1); the two coincide when no
-      ;; continuation mutates a root-read key. `head-hash` needs no post-drain
-      ;; recompute (drain-invariant, see `render-streaming-shell!`'s docstring)
-      ;; — the pre-drain value rides the final payload verbatim.
-      ;;
-      ;; rf2-5knxf.2 / rf2-1oxjxk — the hash is still the BODY-ONLY structural
-      ;; hash via `lifecycle/render-document-hash` — the IDENTICAL mechanism
-      ;; the non-streaming `build-full-response*` uses (rf2-9fw2de's
-      ;; full-document fold was reverted; see that fn's docstring). This is
-      ;; the correct structural hash, NOT a streaming-specific divergence:
-      ;;
-      ;;   - `render-tree-hash` is a PURE structural FNV-1a over the
-      ;;     canonical-EDN of the hiccup (hash.cljc). It does NOT expand
-      ;;     view-refs or registered views, and it does NOT throw on a
-      ;;     `:rf/suspense-boundary` head — it just hashes the vector
-      ;;     structurally. So a `:rf/suspense-boundary` node hashes to the
-      ;;     same canonical-EDN bytes on the server AND on the client: the
-      ;;     marker is NOT a source of mismatch. A streaming-aware client
-      ;;     verifies via `verify-hydration!` against
-      ;;     `:render-tree-fn #((rf/view :app/root))` — whose result is the
-      ;;     SAME marker-bearing hiccup the server's `(rf/view :app/root)`
-      ;;     produces. Both sides hash the marker-bearing tree to the same
-      ;;     hex (empirically confirmed; see the
-      ;;     `streaming-final-hash-matches-client-resolved-tree` regression
-      ;;     in `ring_streaming_test`).
-      ;;
-      ;;   - The ONLY way server and client hashes diverge is the host
-      ;;     passing a NON-symmetric pair of forms: a view-REF `:root-view
-      ;;     [:app/root]` on the server (which `resolve-root-view` leaves
-      ;;     UNEXPANDED → the hash is over the 1-element `[:app/root]`
-      ;;     vector) vs an EXPANDED `:render-tree-fn #((rf/view :app/root))`
-      ;;     on the client. This view-ref-vs-expanded asymmetry is SHARED by
-      ;;     the non-streaming handler (identical `resolve-root-view` →
-      ;;     `render-tree-hash` shape) and is the host's responsibility to
-      ;;     avoid — pass `:root-view` and `:render-tree-fn` as matching
-      ;;     forms (both expanding, e.g. server `:root-view #((rf/view
-      ;;     :app/root))` / client `:render-tree-fn #((rf/view :app/root))`,
-      ;;     mirroring the non-streaming worked example's `((rf/view
-      ;;     :app/root))`). It is NOT a marker bug and NOT streaming-specific.
-      ;;     Spec 011 §Hydration equivalence rule (structural, not textual)
-      ;;     + §Hydration-mismatch detection.
-      ;; rf2-l1qgjw — the `:final-payload` phase spans BOTH the
-      ;; `build-final-payload` assembly (which can throw on a bad payload
-      ;; policy / serialise) AND its write, so a throw in either surfaces
-      ;; as `:phase :final-payload` rather than leaking out as the prior
-      ;; `:continuation-template`/`:shell-html` phase.
+      ;; Set phase before both payload construction and its write.
       (vreset! phase [:final-payload nil])
-      ;; rf2-tbr67x / rf2-nu5w48: pin `*current-frame*` on THIS daemon thread
-      ;; around the post-drain hash recompute + `build-final-payload` (the
-      ;; request thread's `*current-frame*` does not cross the thread boundary),
-      ;; the SAME `rf/with-frame` the continuation render uses above. The
-      ;; root-view re-resolution's registered-view / head lookups + the payload
-      ;; reads operate on the request frame.
+      ;; Dynamic frame bindings do not cross the request/writer thread boundary.
       (let [final-payload
             (rf/with-frame frame-id
-              ;; rf2-1kqvbx / rf2-t72b1c — re-resolve the root view against
-              ;; the POST-drain frame state and recompute the BODY-ONLY hash
-              ;; over it (rf2-1oxjxk) ONLY when a continuation drained
-              ;; (`(seq continuations)` — the pre-loop registration list, see
-              ;; the comment above): that's the one case app-db could have
-              ;; changed since the shell render, so the payload's
-              ;; `:rf/render-hash` needs to describe the SAME moment as its
-              ;; post-drain `:rf/app-db`. With zero continuations, reuse the
-              ;; pre-drain `doc-hash` verbatim — `root-view` is invoked
-              ;; EXACTLY ONCE per request (rf2-6t36h), the common case for a
-              ;; page with no `:rf/suspense-boundary`. Also falls back to
-              ;; `doc-hash` when no `:root-view` could be re-resolved
-              ;; (defensive — `validate-construction-opts!` requires
-              ;; `:root-view`, so this is belt-and-braces).
+              ;; Only continuations can mutate state between shell and payload.
               (let [post-drain-hash
                     (if (and root-view (seq continuations))
                       (lifecycle/render-document-hash
@@ -580,18 +377,15 @@
                   {:version       version
                    :schema-digest schema-digest
                    :payload       payload
-                   ;; rf2-1oxjxk — the pre-drain `head-hash` rides the final
-                   ;; payload verbatim (drain-invariant, see
-                   ;; `render-streaming-shell!`'s docstring).
+                   ;; Head state is drain-invariant.
                    :head-hash     head-hash})))]
-        ;; Shared id-pinned, `</script>`-escaped payload <script>
-        ;; (rf2-7ksyr) — same helper the non-streaming shell uses.
+        ;; Shared id-pinned, script-body-escaped payload element.
         (write-chunk! out (shell/payload-script-tag (pr-str final-payload))))
       ;; Chunk N+3 — shell suffix close.
       (vreset! phase [:suffix nil])
       (write-chunk! out (default-streaming-suffix opts)))
     (catch Throwable t
-      ;; rf2-l1qgjw — stamp the in-flight phase + (when inside a
+      ;; Stamp the in-flight phase and, inside a
       ;; continuation drain) the boundary id + a coarse `:committed?` so
       ;; the writer-failed trace names WHERE the post-commit stream broke.
       ;; `:recovery` is hoisted to top-level by `build-event` (Spec 009
@@ -608,16 +402,8 @@
                           :recovery   :truncate-and-close}
                    (some? boundary-id) (assoc :boundary-id boundary-id))]
         (trace/emit-error! :rf.error/ssr-streaming-writer-failed tags)
-        ;; EP-0008 (rf2-hhutya): ALSO ride the always-on axis. NON-
-        ;; PROJECTING — this fires on the daemon writer thread POST-head-
-        ;; commit (`:committed? true`); the chunked 200 is already on the
-        ;; wire and the status can no longer change, so this is pure off-box
-        ;; telemetry (the always-on `error-emit-projection-listener` never
-        ;; stamps a status from it — there is no response accumulator left to
-        ;; stamp). An off-box shipper on a `-Dre-frame.debug=false` host must
-        ;; still see a writer-phase failure (broken client pipe vs bad final
-        ;; payload). Union record: the trace `tags` ARE the flat category
-        ;; keys, so promote them onto the union shape verbatim.
+        ;; Post-commit writer errors are always-on, non-projecting telemetry;
+        ;; the status is already on the wire and cannot change.
         (lifecycle/emit-always-on-error!
           (assoc tags :error :rf.error/ssr-streaming-writer-failed
                       :time  (interop/now-ms)))))
@@ -628,8 +414,8 @@
 
 (defn- redirect-response!
   "Short-circuit a streaming request to a bodiless Location response and
-  destroy the per-request frame inline. Shared (rf2-tqjc7h) by BOTH redirect
-  branches in `stream-handler`: the early `:initial-events`-drain redirect and the
+  destroy the per-request frame inline. Shared by both redirect branches in
+  `stream-handler`: the early `:initial-events`-drain redirect and the
   post-shell `resp2` re-read redirect.
 
   A redirect short-circuits the stream — no chunked body, so the writer thread
@@ -650,8 +436,7 @@
 
 (defn- render-shell-or-projected-error
   "Render the streaming shell on THIS (request) thread, BEFORE the chunked
-  response head commits. rf2-r06pc — the streaming counterpart of the
-  non-streaming post-render re-flush (rf2-c0bq1). The shell render is the
+  response is materialised. The shell render is the
   request's structural foundation; its failure modes MUST fail closed to a
   non-200 (Spec 011 §744/§748/§954), NOT a silent 200 / truncated chunked body
   from a detached daemon thread that can no longer stamp the status.
@@ -669,7 +454,7 @@
 
   A production reactive-sub throw during the shell render does NOT throw here —
   it recovers to nil but buffers a fail-closed 500 on the always-on error-emit
-  substrate (rf2-vvwmi); the caller's post-shell `ssr/get-response` re-read
+  substrate; the caller's post-shell `ssr/get-response` re-read
   drains that buffer and stamps the 500 onto the response accumulator before
   the chunked head is materialised."
   [frame-id opts]
@@ -681,12 +466,12 @@
         (reduced err-resp)))))
 
 (defn- stream-rendered-response
-  "Materialise the chunked response head from the (post-shell re-read) response
+  "Materialise the streaming response head from the post-shell response
   accumulator `resp2`, wire the pipe, and spawn the daemon writer — the
   non-redirect leaf of `stream-handler` once the shell is known-renderable.
 
-  rf2-z5azc — MATERIALISE the head (status / headers / cookies) from `resp2`
-  BEFORE constructing the pipe or spawning the writer. Cookie / header
+  Materialise the head (status / headers / cookies) from `resp2` before
+  constructing the pipe or spawning the writer. Cookie / header
   serialisation CAN throw at materialise time on a value that escaped the fx
   boundary's partial validation — e.g. a `:max-age` carrying CR/LF, which
   `cookie->set-cookie-header` rejects but the runtime `validate-cookie!` does
@@ -697,7 +482,7 @@
   handler's outer catch BEFORE any thread or pipe exists → on-error, no detached
   writer, no orphaned pipe.
 
-  rf2-h3dg0 / rf2-d95m4i — any `Content-Length` header (case-insensitively) is
+  Any `Content-Length` header (case-insensitively) is
   stripped from the materialised head before wiring the chunk-writer body. App
   / server init can `:rf.server/set-header` (or `append-header`) a
   `Content-Length` during the `:initial-events` drain — a fixed length that is
@@ -705,19 +490,18 @@
   PipedInputStream of unknown final size. Left in place, a Ring server may
   honour that length instead of chunked transfer framing → truncated HTML /
   clients blocked on the wrong byte count / lost chunks, violating Spec 011's
-  chunked-transfer streaming contract. The strip now lives in the shared
-  `pipeline/ssr-response->ring-response` materialiser (rf2-d95m4i single-source
-  — the non-streaming path had the same exposure), so the head is already
+  chunked-transfer streaming contract. The shared materialiser strips it, so
+  the head is already
   Content-Length-free when it returns here.
 
-  rf2-ekwda — the writer runs on a DAEMON thread: one blocked on `.write` to the
+  The writer runs on a daemon thread: one blocked on `.write` to the
   bounded 16 KiB pipe of a slow-loris client must NOT keep the JVM alive at
   shutdown. Its `finally` tears the frame down (off the response-close path,
   via the slower destroy)."
   [frame-id rendered resp2 content-type opts]
   (let [;; No body default-stamp here (we pass our own InputStream); `:body` is
         ;; assoc'd after the writer is wired below. Content-Length is already
-        ;; stripped by the shared materialiser (rf2-d95m4i / rf2-h3dg0).
+        ;; stripped by the shared materialiser.
         resp-map (pipeline/ssr-response->ring-response resp2 "" content-type)
         ;; 16 KiB pipe buffer — large enough to absorb the shell chunk in one
         ;; write so the writer rarely blocks on a slow consumer, small enough
@@ -742,7 +526,8 @@
 
 (defn stream-handler
   "Return a synchronous Ring handler that streams SSR responses via
-  `Transfer-Encoding: chunked`. Per Spec 011 §Streaming SSR.
+  an unknown-length InputStream body. The Ring host chooses protocol framing.
+  Per Spec 011 §Streaming SSR.
 
   Opts mirror `re-frame.ssr.ring/ssr-handler` — same `:initial-events` /
   `:root-view` / `:payload` / `:on-error` /
@@ -755,8 +540,7 @@
   `default-streaming-suffix`). `:initial-events`
   accepts BOTH forms `ssr-handler` does — an `:initial-events` vector OR a
   `(fn [request] -> initial-events-vector)` deriving the setup vector from
-  the Ring request (rf2-kzns7l; both flow through the shared
-  `pipeline/setup-request-frame!`). One exception (rf2-oq4m5):
+  the Ring request; both flow through the shared setup pipeline. One exception:
 
     `:html-shell` is NOT supported by the streaming path and is REJECTED
     at handler-construction time (`:rf.error/ssr-streaming-unsupported-opt`).
@@ -764,17 +548,15 @@
     `:html-shell` fn `(body-html payload-edn opts) → string`; the streaming
     handler flushes the envelope as a SPLIT prefix/suffix straddling the
     continuation chunks (the wire shape below), so a one-piece shell
-    callback can never run after streaming starts. Rather than silently
-    drop a passed `:html-shell` (a fail-open contract gap — a custom shell
-    commonly carries CSP nonces / asset URLs / root markup an app would
-    lose when switching ssr-handler → stream-handler), the handler fails
-    closed at boot. Customize the streaming envelope through the four
+    callback can never run after streaming starts. The handler rejects it at
+    boot instead of discarding security or document configuration. Customize
+    the streaming envelope through the four
     trusted shell-hook opts, or use a non-streaming `ssr-handler` when a
     bespoke one-piece shell is required.
 
   Plus implicit streaming semantics on every request — non-streaming
   responses (no `:rf/suspense-boundary` in the tree) still ride the
-  chunked path but with zero continuations, so the wire shape collapses
+  streaming path but with zero continuations, so the wire shape collapses
   to shell-prefix + shell-html + final-payload + shell-suffix.
 
   The returned handler:
@@ -784,21 +566,20 @@
       circuits to a non-streamed Location response (Spec 011 §Redirect
       precedence) AND destroys the per-request frame inline (the writer
       thread is never spawned on this branch),
-    - otherwise RENDERS THE SHELL on the request thread BEFORE committing
-      the chunked response head (rf2-r06pc — the streaming counterpart
-      of the non-streaming post-render re-flush, rf2-c0bq1). A root-view
+    - otherwise renders the shell on the request thread before materialising
+      the response head. A root-view
       / shell-walk throw escalates to `:rf.error/ssr-render-failed` via
       the projector and a production reactive-sub throw during the shell
       render buffers a fail-closed status the post-shell `get-response`
-      re-read picks up — BOTH fail closed to a non-200 projected error
-      page (Spec 011 §744/§748/§954) on the request thread, with NO pipe
-      and NO writer thread spawned. The chunked response is committed
-      ONLY once the shell is known-renderable (clean render AND a success
+      re-read picks up — both fail closed to a non-200 projected error
+      page on the request thread, with no pipe or writer thread spawned. The
+      streaming response is selected only once the shell is known-renderable
+      (clean render and a success
       status),
     - then materialises the response head (status / headers / cookies)
       — so a header/cookie serialisation throw on a value that escaped
       the fx boundary's partial validation short-circuits to `:on-error`
-      with no pipe + no thread to orphan (rf2-z5azc) — and only then
+      with no pipe or thread to orphan — and only then
       spawns a streaming writer on a daemon thread that flushes the
       PRE-RENDERED shell → continuations → final payload → close,
       destroying the frame in that thread's finally so the per-frame
@@ -806,8 +587,7 @@
       without blocking the response close. The writer thread's only
       remaining failure surface is continuation drains (inline-fallback,
       Spec 011 §942-954) and the post-first-chunk final-payload / suffix
-      writes — never the shell, which already committed its status on
-      the request thread.
+      writes — never the shell, whose status was fixed on the request thread.
 
   The response body is a `PipedInputStream` Ring accepts directly; the
   pipe's writer side runs on a daemon thread so Jetty/http-kit/Aleph
@@ -815,8 +595,8 @@
   pump chunks. The pipe's sink-side close (in the writer's `finally`)
   signals EOF to the server.
 
-  Concurrency model (Spec 011 §Streaming SSR — Writer concurrency model;
-  rf2-fzew1): ONE raw daemon `java.lang.Thread` per in-flight streamed
+  Concurrency model (Spec 011 §Streaming SSR — Writer concurrency model): one
+  raw daemon `java.lang.Thread` per in-flight streamed
   request — no framework pool, no framework in-flight cap, by design.
   The model is no-LEAK (every writer's `catch Throwable`/`finally` closes
   the pipe and tears the frame down on every exit path; the live count
@@ -842,11 +622,10 @@
   ;; cross the same trust boundary as the non-streaming
   ;; `default-html-shell` — `:head` / `:body-end` injected RAW (content
   ;; positions), `:script-src` / `:app-element-id` escape-attr'd
-  ;; (attribute-value positions, rf2-7x0qk) by the streaming
-  ;; prefix/suffix. See `validate-construction-opts!` for the per-check
-  ;; rationale.
+  ;; (attribute-value positions) by the streaming
+  ;; prefix/suffix. See `validate-construction-opts!` for details.
   (lifecycle/validate-construction-opts! raw-opts)
-  ;; rf2-oq4m5 — reject opts the streaming path cannot honour (currently
+  ;; Reject opts the streaming path cannot honour (currently
   ;; `:html-shell`) at construction time. `ssr-handler` builds its response
   ;; from a one-piece `:html-shell` fn; the streaming path flushes a SPLIT
   ;; prefix/suffix straddling the continuation chunks, so a one-piece shell
@@ -858,9 +637,8 @@
   ;; Mirror ssr-handler's defaults so streaming and non-streaming
   ;; handlers feel symmetric to callers. `:on-error` resolves the same
   ;; way via the shared `lifecycle/resolve-on-error`: caller's
-  ;; `:on-error` wins, else the locked `default-on-error` (rf2-kzvwq
-  ;; topology-leak contract).
-  ;; rf2-nncni3 — `:content-type` carries NO default here (mirrors
+  ;; `:on-error` wins, else the locked no-detail default.
+  ;; `:content-type` carries no default here (mirrors
   ;; `ssr-ring/handler-defaults`): the opt is a genuine override that
   ;; force-replaces the streamed head's Content-Type when supplied. A
   ;; non-nil default would clobber an app's own `:rf.server/set-header
@@ -876,12 +654,12 @@
         (if short-circuit
           short-circuit
           (try
-            ;; rf2-r06pc — the request-thread body, top-down: read the response
+            ;; Request-thread flow: read the response
             ;; accumulator; on a `:redirect` short-circuit BEFORE any chunked
             ;; head / writer; otherwise render the shell on THIS thread (failing
             ;; closed to a projected non-200 on a render throw), re-read the
             ;; accumulator for a fail-closed status a recovered-to-nil sub
-            ;; buffered during the render (rf2-vvwmi), and stream — committing
+            ;; buffered during the render, and stream — fixing
             ;; the chunked head ONLY once the shell is known-renderable. The
             ;; helpers (`render-shell-or-projected-error`, `stream-rendered-
             ;; response`, `redirect-response!`) carry the per-step rationale.
@@ -895,10 +673,9 @@
                     ;; (frame already torn down inline).
                     @rendered
                     ;; Shell rendered cleanly. Re-read the accumulator to
-                    ;; surface any fail-closed status (rf2-vvwmi /
-                    ;; rf2-c0bq1) before materialising the chunked head.
+                    ;; surface any fail-closed status before materialising the head.
                     ;;
-                    ;; rf2-5knxf.1 — a `:redirect` here is defense-in-depth:
+                    ;; A redirect here is defense in depth:
                     ;; in v1 it cannot surface at the post-shell re-read
                     ;; (only the `:initial-events`-drain `:rf.server/redirect`
                     ;; sets it, caught by the early branch above; the error
@@ -913,12 +690,12 @@
                         (stream-rendered-response
                           frame-id rendered resp2 content-type opts)))))))
             (catch Throwable t
-              ;; get-response throw, redirect-materialise throw, OR (per
-              ;; rf2-z5azc) a head-materialisation throw raised BEFORE the
+              ;; A get-response, redirect-materialisation, or head-materialisation
+              ;; throw raised before the
               ;; writer thread is spawned — none happen under the
               ;; streaming writer's own catch arm. Destroy the frame
-              ;; inline and respond per on-error. rf2-ljjh0 —
-              ;; `safe-on-error` contains a throwing caller `:on-error`:
+              ;; inline and respond per on-error. `safe-on-error` contains a
+              ;; throwing caller `:on-error`:
               ;; it falls back to the locked `default-on-error` rather
               ;; than escaping as a raw container 500 with leaked
               ;; internals.

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/trust.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/trust.clj
@@ -1,6 +1,5 @@
 (ns re-frame.ssr.ring.trust
-  "Trusted-shell-hook contract — naming + structural validation
-  (rf2-o6ndb, attribute/content split rf2-7x0qk).
+  "Trusted-shell-hook naming and structural validation.
 
   Four shell-envelope opts cross the trust boundary into the rendered
   HTML response. They split by INJECTION POSITION:
@@ -11,9 +10,7 @@
     :head            — verbatim HTML inside `<head>...</head>`
     :body-end        — verbatim HTML before `</body>`
 
-  ATTRIBUTE-VALUE positions — `escape-attr`-escaped at the shell
-  (rf2-7x0qk; a double-quoted attribute value HAS a single correct
-  escape, and escaping `&` + `\"` is lossless):
+  ATTRIBUTE-VALUE positions — `escape-attr`-escaped at the shell:
 
     :script-src      — written into `<script src=\"...\">`, escape-attr'd
     :app-element-id  — written into `<div id=\"...\">`, escape-attr'd
@@ -30,7 +27,7 @@
   rejecting the structural shape mistake (a map / vector / symbol) at
   handler-construction time; the content trust itself is the caller's.
 
-  The attribute-value escaping (rf2-7x0qk) is structural-correctness,
+  Attribute-value escaping provides structural correctness,
   not a sandbox: it stops a stray `\"` in an otherwise-benign id / URL
   from breaking out of the attribute and emitting malformed markup. It
   does NOT make the content opts safe for untrusted input.
@@ -46,10 +43,7 @@
   Why a sibling namespace: both `re-frame.ssr.ring/ssr-handler` and
   `re-frame.ssr.ring.streaming/stream-handler` validate the same four
   opts at construction time — colocating the contract here avoids the
-  circular-require between the streaming sub-namespace and the ring
-  façade. Sibling to `re-frame.ssr.payload-policy` (the equivalent
-  consolidation of the fail-closed hydration-payload policy contract
-  per rf2-gtgf9)."
+  circular require between the streaming sub-namespace and the Ring façade."
   (:require [clojure.string :as str]
             [re-frame.error :as error]))
 
@@ -61,7 +55,7 @@
   injection position: `:head` / `:body-end` are RAW content hooks
   (injected verbatim), while `:script-src` / `:app-element-id` are
   escaped attribute hooks (`escape-attr`'d into a quoted attribute
-  value, rf2-7x0qk). Construction-time validation gates structural
+  value). Construction-time validation gates structural
   shape only; the trust + injection semantics are documented at the
   ns docstring above, the handler docstring, and Spec 011 §Trusted
   shell hook contract."
@@ -80,7 +74,7 @@
   Apps wiring these from untrusted input are responsible for upstream
   escaping; see Spec 011 §Trusted shell hook contract for the
   structured alternative (`reg-head` + `reg-view*` + `:rf.server/*` fx)
-  for untrusted-customization use cases. Per rf2-o6ndb.
+  for untrusted-customization use cases.
 
   Returns `opts` unchanged on success — composes into a `let` /
   threading position cleanly, like `payload-policy/validate-policy-opts!`."

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/facade_examples_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/facade_examples_test.clj
@@ -1,18 +1,11 @@
 (ns re-frame.ssr.ring.facade-examples-test
-  "Per rf2-09iktm — pin that the PUBLIC docstring EXAMPLES on the
-  `re-frame.ssr.ring` facade stay aligned with the runtime contract.
+  "Pin that public `re-frame.ssr.ring` docstring examples stay aligned with
+  the runtime contract.
 
   `facade-metadata-test` proves the facade vars carry a non-empty `:doc`
   + `:arglists`; it does NOT look INSIDE the docstring at the example
-  code. After the fail-closed `:payload` change (rf2-gtgf9) and the
-  curried-middleware shape, the worked examples drifted: the
-  `ssr-handler` example omitted `:payload` (a copy-paste would throw
-  `:rf.error/ssr-missing-payload-policy` at construction) and the
-  `ssr-middleware` example used the wrong, uncurried `(-> handler
-  (ssr-middleware opts) ...)` shape (the public surface is
-  `(ssr-middleware opts) -> (handler -> wrapped)`). REPL `doc`, editor
-  hover, and the JVM api-manifest surface these examples, so they are
-  user-facing.
+  code. These tests protect the required payload policy and curried middleware
+  shape surfaced through REPL, editor, and API-manifest documentation.
 
   This test is the drift tripwire. It reads the live docstring, extracts
   the worked example forms, and asserts the structural invariants a
@@ -72,7 +65,7 @@
     (some walk forms)))
 
 (deftest ssr-handler-docstring-example-includes-payload-and-constructs
-  (testing "rf2-09iktm: the ssr-handler facade example carries a :payload
+  (testing "the ssr-handler façade example carries a :payload
             policy and the example opts map passes
             validate-construction-opts! (so a copy-paste is constructible,
             not a fail-closed boot throw)"
@@ -84,7 +77,7 @@
       (is (map? opts) "the ssr-handler example passes a literal opts map")
       (is (contains? opts :payload)
           (str "the ssr-handler example opts map MUST include a :payload "
-               "policy (rf2-gtgf9 fail-closed) — saw keys: "
+                "policy — saw keys: "
                (pr-str (keys opts))))
       ;; Stronger than textual presence: the example opts map must pass
       ;; the live construction validator (with placeholder event/view
@@ -99,7 +92,7 @@
           "the ssr-handler example opts map passes validate-construction-opts!"))))
 
 (deftest ssr-middleware-docstring-example-is-curried-and-includes-payload
-  (testing "rf2-09iktm: the ssr-middleware facade example uses the correct
+  (testing "the ssr-middleware façade example uses the correct
             CURRIED composition shape — `((ssr-middleware opts) handler)` —
             and its opts map carries :payload"
     (let [doc   (-> #'ssr-ring/ssr-middleware meta :doc)
@@ -111,13 +104,11 @@
       (is (map? opts) "the ssr-middleware example passes a literal opts map")
       (is (contains? opts :payload)
           (str "the ssr-middleware example opts map MUST include a :payload "
-               "policy (rf2-gtgf9 fail-closed) — saw keys: "
+                "policy — saw keys: "
                (pr-str (keys opts))))
       ;; Curried-shape invariant: the `(ssr-middleware opts)` form must be
       ;; APPLIED — i.e. it appears in head (callee) position of an outer
-      ;; list, `((ssr-middleware opts) <handler>)`. The pre-fix, broken
-      ;; example used `(-> handler (ssr-middleware opts) ...)`, where the
-      ;; `(ssr-middleware opts)` form is an ARGUMENT, never a callee.
+      ;; list, `((ssr-middleware opts) <handler>)`.
       (letfn [(applied? [form]
                 (cond
                   (seq? form)

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/facade_metadata_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/facade_metadata_test.clj
@@ -1,16 +1,12 @@
 (ns re-frame.ssr.ring.facade-metadata-test
-  "Per rf2-l1qgjw issue 1 — pin that the canonical `re-frame.ssr.ring`
-  facade carries real `:doc` + `:arglists` metadata on its public
-  FUNCTION vars.
+  "Pin that the canonical `re-frame.ssr.ring` façade carries real `:doc`
+  and `:arglists` metadata on its public function vars.
 
   The facade re-exposes seven sub-namespace fns. A bare `(def alias
   other-ns/fn)` copies the value but DROPS the var metadata, so REPL
   `doc`, editor hover, completion, and the JVM-introspected api-manifest
-  all saw empty docs + nil arglists at the very namespace users are told
-  to require. `import-fn` (in `re-frame.ssr.ring`) now copies the source
-  var's authored `:doc`/`:arglists` onto the façade var. This test is the
-  regression tripwire: a future re-export that reverts to a bare `def`
-  (or forgets the metadata copy) re-opens the gap, and this fails.
+  would expose empty docs and nil arglists at the namespace users require.
+  `import-fn` copies the source var's authored metadata onto the façade var.
 
   Data vars are EXCLUDED — `handler-defaults` (a config map) and
   `default-on-error` (a 2-arity fn VALUE held in a `def`, not a `defn`,
@@ -43,7 +39,7 @@
   (ns-resolve 're-frame.ssr.ring sym))
 
 (deftest facade-public-fns-carry-doc-and-arglists
-  (testing "rf2-l1qgjw — every public re-frame.ssr.ring FUNCTION var has a
+  (testing "every public re-frame.ssr.ring function var has a
             non-empty :doc and a non-empty :arglists (the import-fn
             metadata-preserving re-export contract)"
     (doseq [sym public-fn-syms]
@@ -61,7 +57,7 @@
                  (pr-str (:arglists m))))))))
 
 (deftest facade-public-data-vars-carry-doc
-  (testing "rf2-l1qgjw — documented public DATA vars (handler-defaults,
+  (testing "documented public data vars (handler-defaults,
             default-on-error) carry a non-empty :doc; they are correctly
             excluded from the :arglists check (not fns)"
     (doseq [sym public-data-syms]
@@ -73,7 +69,7 @@
                  (pr-str (:doc m))))))))
 
 (deftest facade-doc-matches-implementation-contract
-  (testing "rf2-l1qgjw — the re-exported :doc/:arglists are the source
+  (testing "the re-exported :doc/:arglists are the source
             var's authored contract (not a stub), so the facade is the
             same documentation surface as the sub-namespace home var"
     ;; Spot-check two representative re-exports against their home vars:

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/test_support.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/test_support.clj
@@ -1,46 +1,27 @@
 (ns re-frame.ssr.ring.test-support
-  "Shared JVM test scaffolding for the ssr-ring suite (rf2-l1qgjw issue 3).
+  "Shared JVM test scaffolding for the ssr-ring suite.
 
-  Five live-host / streaming-thread test namespaces had grown
-  near-identical copies of: an ephemeral-port Jetty start/stop +
-  `with-jetty` macro, a `java.net.http` client + request builder + two
-  `http-get` result shapes, and a `rf2-ssr-streaming-*` daemon-thread
-  leak detector. Small drift had already crept in (request timeouts of
-  10s vs 30s, poll cadences of 10ms vs 50ms). This namespace single-
-  sources the MECHANISM; every intentional per-test difference (request
-  timeout, leak-poll cadence) stays an explicit PARAMETER so a caller
-  reads its own knobs at the call site rather than hiding them in a copy
-  edit.
-
-  This is the established local pattern: the artefact also single-sources
-  the per-test reset here (`reset-runtime`, rf2-09iktm — see the section
-  below), and `with-jetty` etc. are pure test plumbing with no
-  production-path coupling — so consolidating them here removes review
-  surface without introducing a new abstraction style.
+  This namespace single-sources ephemeral Jetty lifecycle, JDK HTTP requests,
+  streaming-thread leak detection, and per-test runtime reset. Timeouts and
+  polling cadence remain explicit at call sites.
 
   Independence note: requiring this ns does NOT co-load any test
   namespace (it depends only on production `re-frame.*` source +
   `ring.adapter.jetty` + JDK classes), so every test ns stays
   independently runnable under the artefact `:test` alias.
 
-  Contract smoke coverage for these helpers lives in
-  `test_support_contract_test.clj` (rf2-l1qgjw).
+  Contract smoke coverage lives in `test_support_contract_test.clj`.
 
-  ## Per-test reset fixture (rf2-09iktm)
+  ## Per-test reset fixture
 
   `reset-runtime` is the artefact-local `:each` reset for the ssr-ring
-  JVM suite. It WAS `re-frame.ssr.test-fixture/reset-runtime`, loaded by
-  putting the sibling `../ssr/test` source dir on the test classpath —
-  which the Clojure CLI now warns is a deprecated use of a path external
-  to the project. The reset is now sourced entirely from artefacts this
-  one already depends on: the published, substrate-agnostic
-  `re-frame.test-support/make-reset-runtime-fixture` (core/src) does the
+  JVM suite. The substrate-agnostic
+  `re-frame.test-support/make-reset-runtime-fixture` does the
   registrar / frames / flows / schemas / machines / routing reset and
   installs the SSR adapter; the four SSR per-request side-channel atoms
   (Spec 011 §Per-request frame teardown) live in `re-frame.ssr.*`
   production namespaces (ssr/src), reachable through the existing
-  `day8/re-frame2-ssr` dep with no test-path reach. The single source of
-  truth for the COMMON reset shape stays the published core fixture; only
+  `day8/re-frame2-ssr` dependency. The common reset remains in core; only
   the four SSR-specific atom resets are local, fired through the fixture's
   `:init-fn` seam (runs after adapter install, under the ambient
   `:rf/default` scope, before each test body)."
@@ -57,8 +38,7 @@
            [org.eclipse.jetty.server Server]))
 
 ;; ===========================================================================
-;; Per-test reset fixture (rf2-09iktm — supersedes the external
-;; `../ssr/test` path to `re-frame.ssr.test-fixture`)
+;; Per-test reset fixture
 ;; ===========================================================================
 
 (defn- reset-ssr-runtime!
@@ -81,20 +61,18 @@
      directly (the same atoms the private façade aliases hold) — no
      external test path needed.
 
-  2. Reinstate the ns-load-time LISTENER + late-bind registrations the
+  2. Reinstate the namespace-load listener and late-bind registrations the
      SSR / routing / head / machines namespaces install at load. The
      published fixture clears the trace-tooling + event-emit listener
      registries each test (`trace-tooling/clear-listeners!` /
      `event-emit/clear-event-listeners!`), which drops the always-on SSR
-     `::error-projection` error-emit listener and its dev-trace twin
-     (`re-frame.ssr` ns-load, rf2-fb598) — without them a render-/drain-
+     `::error-projection` error-emit listener and its dev-trace twin; without
+     them a render-/drain-
      time throw recovers to a silent HTTP 200 instead of the fail-closed
      5xx the SSR contract mandates. A `:reload` re-runs each ns body so
      those listeners — and the routing late-bind hooks `reg-route`
      resolves through (`:routing/reg-route`, Spec 012) — resurrect. This
-     is exactly what the former `re-frame.ssr.test-fixture/reset-runtime`
-     did; the only change is WHERE the registrar reset comes from (the
-     published core fixture, not a sibling-test-tree clear-all!)."
+     restores them."
   []
   (reset! request/request-slots {})
   (reset! response/response-slots {})
@@ -115,16 +93,14 @@
   side-channel resets on top, fired after adapter install and before the
   test body under the same ambient `:rf/default` scope. Built once at
   ns-load so the registrar baseline is pinned to THIS suite's ns-load
-  registrations (run-order independence, rf2-7hwnu)."
+  registrations for run-order independence."
   (test-support/make-reset-runtime-fixture
     {:adapter ssr/adapter
      :init-fn reset-ssr-runtime!}))
 
 (defn reset-runtime
-  "The canonical `:each` fixture for the ssr-ring JVM suite. Drop-in for
-  the former `re-frame.ssr.test-fixture/reset-runtime` (rf2-09iktm): same
-  `(use-fixtures :each reset-runtime)` and same callable
-  `(reset-runtime (fn [] …))` shapes. Wipes the registrar, every
+  "The canonical `:each` fixture for the ssr-ring JVM suite. Wipes the
+  registrar, every
   per-frame SSR side-channel atom, and installs the SSR adapter + ensures
   the ambient `:rf/default` frame."
   [test-fn]
@@ -192,8 +168,7 @@
 (defn http-get-request
   "Build a GET `HttpRequest` for `http://127.0.0.1:<port><path>` with a
   per-request `timeout-secs` read timeout. `timeout-secs` is the
-  load-bearing per-test knob (the old copies drifted 10s vs 30s), so it
-  is required — the caller states it explicitly at the call site."
+  required per-test knob, stated explicitly at the call site."
   ^HttpRequest [port path timeout-secs]
   (-> (HttpRequest/newBuilder)
       (.uri (URI/create (str "http://127.0.0.1:" port path)))
@@ -254,12 +229,9 @@
   elapses. RETURNS the final seq of live threads — empty on success,
   non-empty (the leaked threads) on timeout — so a caller's assertion
   can name the offenders in its failure message. Does NOT throw on
-  timeout (rf2-fun38: a deliberately different contract from a throwing
-  `poll-until`).
+  timeout rather than throwing.
 
-  `poll-ms` is the explicit poll cadence (the old copies used 10ms for
-  single-request tests and 50ms for the higher-peak concurrency burst;
-  keep it a parameter so each caller states its own cadence)."
+  `poll-ms` is explicit so each caller states its own cadence."
   [timeout-ms poll-ms]
   (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
     (loop []

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/test_support_contract_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/test_support_contract_test.clj
@@ -1,8 +1,6 @@
 (ns re-frame.ssr.ring.test-support-contract-test
-  "Per rf2-l1qgjw issue 3 — smoke coverage for the shared SSR/Ring test
-  scaffolding in `re-frame.ssr.ring.test-support`. The helpers are now
-  load-bearing for five live-host / streaming-thread test namespaces, so
-  pin their behaviour directly: an ephemeral Jetty round-trips a Ring
+  "Smoke coverage for the shared SSR/Ring test scaffolding. An ephemeral
+  Jetty round-trips a Ring
   handler over real `java.net.http`, the leak detector reports an empty
   set when no writer threads are alive, and `await-no-streaming-threads!`
   returns (rather than throws) the leaked set on timeout."
@@ -11,7 +9,7 @@
             [re-frame.ssr.ring.test-support :as ts]))
 
 (deftest with-jetty-round-trips-a-ring-handler
-  (testing "rf2-l1qgjw — ts/with-jetty stands up an ephemeral-port Jetty,
+  (testing "ts/with-jetty stands up an ephemeral-port Jetty,
             ts/new-http-client + ts/http-get observe the handler's
             response on the wire (status + body), and the server is torn
             down in the macro's finally"
@@ -26,7 +24,7 @@
           (is (= "ts-smoke-ok" body) "wire body is the handler's body"))))))
 
 (deftest http-get-with-headers-returns-multimap-headers
-  (testing "rf2-l1qgjw — :with-headers? true adds the {name -> [val ...]}
+  (testing ":with-headers? true adds the {name -> [val ...]}
             header multimap (the shape the CRLF-on-wire scan needs)"
     (let [handler (fn [_req]
                     {:status  200
@@ -44,7 +42,7 @@
                 "custom header surfaces as a single-element value vector")))))))
 
 (deftest leak-detector-reports-empty-when-no-writers
-  (testing "rf2-l1qgjw — with no streaming request in flight, the leak
+  (testing "with no streaming request in flight, the leak
             detector sees no rf2-ssr-streaming-* threads"
     (is (= "rf2-ssr-streaming-" ts/daemon-thread-name-prefix)
         "the prefix matches the writer thread's naming contract")
@@ -52,9 +50,8 @@
         "no streaming-writer daemon thread is alive in a quiescent JVM")))
 
 (deftest await-no-streaming-threads-returns-empty-fast-when-quiescent
-  (testing "rf2-l1qgjw — await-no-streaming-threads! returns [] immediately
-            when nothing is leaked, and does NOT throw (rf2-fun38 contract
-            — callers want the leaked vec, not an exception)"
+  (testing "await-no-streaming-threads! returns [] immediately when nothing
+            is leaked and does not throw"
     (let [result (ts/await-no-streaming-threads! 1000 10)]
       (is (= [] result)
           "returns an empty vector (no leak) rather than throwing"))))


### PR DESCRIPTION
## Summary

- replace issue-history and duplicated narration with current SSR Ring contracts
- keep frame scope, egress projection, shell trust, header/cookie validation, and post-render flush invariants explicit
- clarify that the adapter returns an unknown-length InputStream while the Ring host owns protocol framing
- define writer-phase commitment at the adapter boundary: the selected response/status cannot be replaced even if the host has not emitted bytes yet

## Scope

Explanation-only changes under `implementation/ssr-ring`; runtime and test behavior are unchanged.

## Verification

- `clojure -M:test` (172 tests, 839 assertions, 0 failures, 0 errors)
- `clj-kondo --lint src test --fail-level error` (0 errors; existing baseline warnings remain)
- `git diff --check`

Bead: rf2-zo1c9e
