### PR TITLE
docs(test-quiet): align runner explanations (rf2-nk9r6p)

### DIFF
--- a/implementation/test-quiet/deps.edn
+++ b/implementation/test-quiet/deps.edn
@@ -1,30 +1,28 @@
-;; day8/re-frame2-test-quiet — test-runtime quiet-reporter artefact
-;; (rf2-try1x).
+;; day8/re-frame2-test-quiet - test-runtime quiet-reporter artefact.
 ;;
 ;; A tiny, test-only library that overrides `clojure.test/report` (JVM)
-;; and `cljs.test/report` (CLJS) so a green run of any test alias in the
-;; repository REPORTS only the 3-line summary:
+;; and `cljs.test/report` (CLJS) so the reporter contributes one leading
+;; blank and the two summary lines to a green run:
 ;;
 ;;     Ran N tests containing M assertions.
 ;;     0 failures, 0 errors.
 ;;
-;; The cross-runtime quiet contract (rf2-nrk066) is pass-through stdout +
-;; red-replayed noise buffering. The buffering POLICY is symmetric across
-;; JVM / CLJS node / browser — buffer the noise channel, drop it on green,
-;; replay it on red — but the buffered SCOPE is runtime-specific: JVM
-;; buffers `*err*` / `System.err`; CLJS node buffers `console.warn` only;
-;; browser / Playwright diagnostics are owned by the browser harnesses:
+;; The JVM and CLJS node runners pass stdout through and buffer a bounded
+;; noise channel, dropping it on green and replaying it on red. Their scope
+;; differs: JVM buffers the test thread's `*err*` plus process-global
+;; `System.err`; CLJS node buffers `console.warn` only. Browser / Playwright
+;; diagnostics are owned by the browser harnesses.
 ;;
-;;   - STDOUT is PASS-THROUGH, not summary-only. The reporter makes the
+;;   - STDOUT is pass-through, not summary-only. The reporter makes the
 ;;     reporter's OWN green output the canonical summary, but the runner
 ;;     forwards every other stdout byte a test/fixture/CLI emits — `-H`
 ;;     usage, parse-error diagnostics, and bare `(println …)` — so runner
-;;     misuse and failure-time diagnostics stay visible (rf2-lbo79.2).
+;;     misuse and failure-time diagnostics stay visible.
 ;;     Only cognitect's own `Running tests in #{…}` discovery banner is
 ;;     dropped. A green run is therefore "summary + whatever a test chose
 ;;     to print", which under the repo's no-stray-println discipline is
 ;;     just the summary.
-;;   - STDERR/WARNINGS are BUFFERED, replayed on red, dropped on green —
+;;   - STDERR/WARNINGS are buffered, replayed on red, dropped on green.
 ;;     the JVM runner (`re-frame.test-quiet.runner`) buffers JVM stderr
 ;;     (`*err*` / `System.err`) while the CLJS node runner
 ;;     (`re-frame.test-quiet.shadow-node`) buffers `console.warn` warnings
@@ -33,12 +31,11 @@
 ;;     suites stay quiet on green WITHOUT ad-hoc local `*err*` sinks. The
 ;;     narrower CLJS scope keeps real error channels visible even on green.
 ;;
-;; Failures are unchanged — a failing namespace's banner + the failure
+;; Failures are unchanged: a failing namespace's banner, the failure
 ;; lines + the failure stack reach stdout exactly as before, and a red
 ;; run additionally replays the buffered stderr context.
 ;;
-;; Wired into every per-artefact `:test` alias by replacing
-;; `:main-opts ["-m" "cognitect.test-runner"]` with
+;; Wired into per-artefact `:test` aliases by using
 ;; `:main-opts ["-m" "re-frame.test-quiet.runner"]` and adding this
 ;; artefact as a `:local/root` extra-dep.  The shadow-cljs `:node-test`
 ;; build (top-level `implementation/shadow-cljs.edn`) wires the matching
@@ -55,7 +52,7 @@
          {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
 
  :aliases
- {;; Self-test alias — drives the stdout-line-count pin
+ {;; Self-test alias - drives the stdout-line-count pin
   ;; (`re-frame.test-quiet-pin-test`) plus the trivial known-green
   ;; sub-suite the pin exercises.  Uses the quiet runner like every
   ;; other artefact so the pin is verified against the same code

--- a/implementation/test-quiet/src/re_frame/test_quiet.cljc
+++ b/implementation/test-quiet/src/re_frame/test_quiet.cljc
@@ -2,24 +2,22 @@
   "Silent-on-success test reporter.
 
   Loading this namespace installs `defmethod` overrides on
-  `clojure.test/report` (JVM) and `cljs.test/report` (CLJS) so the
-  REPORTER's own green-run output is exactly the canonical 3-line
-  summary:
+  `clojure.test/report` (JVM) and `cljs.test/report` (CLJS). The
+  reporter's green output is one leading blank followed by the two
+  canonical summary lines:
 
       Ran N tests containing M assertions.
       0 failures, 0 errors.
 
-  Per-namespace `Testing <ns>` banners are SUPPRESSED on the success
+  Per-namespace `Testing <ns>` banners are suppressed on the success
   path; per-`deftest` `Testing <var>` banners were already silent in
   both reporters by default and stay that way.
 
-  This reporter governs only the REPORTER's output.  The cross-runtime
-  quiet contract (rf2-nrk066) is completed by the runtime entry points
-  (`re-frame.test-quiet.runner` on the JVM,
-  `re-frame.test-quiet.shadow-node` on CLJS node): stdout is
-  PASS-THROUGH (a test's bare `(println …)` reaches stdout — only
-  cognitect's discovery banner is dropped), and stderr/warning noise is
-  BUFFERED and replayed only on RED.  So a green run shows the summary
+  This namespace governs only reporter output. The runtime entry points
+  (`re-frame.test-quiet.runner` on the JVM and
+  `re-frame.test-quiet.shadow-node` on CLJS node) pass stdout through. The
+  JVM runner filters cognitect's discovery banner. Each runner buffers its
+  runtime-specific warning channel and replays it only on red. A green run shows the summary
   plus whatever a test deliberately printed, and never the expected
   warnings warning-heavy suites emit.  See those namespaces' docstrings
   for the runtime side of the contract.
@@ -36,11 +34,6 @@
       Ran N tests containing M assertions.
       1 failures, 0 errors.
 
-  Output is therefore proportional to *failure count*, not test count —
-  agents that read test output burn context proportional to actionable
-  signal.  rf2-try1x is the parent bead; the rationale (~10-25K tokens
-  per agent run on green-path noise) is captured there.
-
   Dispatch:
 
    - JVM (`clojure.test/report`): single-key dispatch on `(:type m)`.
@@ -51,55 +44,33 @@
      `::cljs.test/default`.  Same set of method keys, prefixed with
      the reporter sentinel.
 
-  The *reporter* is bufferless for FAILURE TEXT — we don't capture
+  The reporter does not buffer failure text: we don't capture
   failure-message bytes and replay them (the runners separately buffer
   stderr/warning noise; that buffering lives in the runtime entry points,
   not here).  Instead, the first `:fail` / `:error` inside an
   unprinted namespace prints the namespace banner immediately, then
-  DELEGATES to the captured default `report` method.  This means the
+  delegates to the captured default `report` method. This means the
   failure output shape (the precise text clojure.test or cljs.test
   emits for `FAIL in (...)`, the `expected:` / `actual:` lines, the
   stack) is owned by the test library, not forked here — any upstream
   change to failure formatting, formatter handling, or stack-depth
   behaviour is inherited automatically.
 
-  Delegation mechanism: at namespace-load time — BEFORE we install our
-  own overrides — we capture the library's default `:fail` / `:error`
+  At namespace-load time, before installing the overrides, we capture the
+  library's default `:fail` / `:error`
   methods via `get-method`.  Our override then prints the withheld
   banner and invokes that captured method.  The default already wraps
   its body in `with-test-out` (JVM) / writes through `*out*` (CLJS), so
   the banner is emitted into the same stream by forcing it under the
   same `with-test-out` on the JVM and by a plain `println` on CLJS.
-  Capturing the methods rather than re-`defmethod`-ing inline keeps the
-  failure path a thin banner-prefix over the real reporter.
+  Capturing the methods keeps the failure path a thin banner prefix over
+  the real reporter. `defonce` protects those captures from reload-induced
+  self-recursion.
 
-  Loading this namespace MULTIPLE TIMES is idempotent — `defmethod`
-  silently replaces the existing dispatch entry.
-
-  Reload-friendly: dropping the `defmethod` overrides at the top of the
-  test runtime is fine.  The methods close over the namespace's
-  `printed-banners` atom (a set of namespaces whose banner has already
-  been flushed), which the failure path consults and grows.
-
-  Nested-run correctness (rf2-8n97n.1 / .2): the banner namespace is
-  derived from the FAILING var's metadata at `:fail` / `:error` time,
-  NOT from a single mutable \"current ns\" cell.  A nested
-  `run-tests` called from inside a `deftest` fires its own
-  `:begin-test-ns`; with a single-cell design that clobbers the
-  \"current ns\" to the inner namespace, so a subsequent outer failure
-  is mislabelled (prints the inner ns banner) or — once the inner run
-  flushed its banner — orphaned (no banner at all).  Reading the ns off
-  the var that actually failed makes the banner always match the
-  failure, regardless of nesting.
-
-  test-ns-hook fallback (rf2-g92dsm): a namespace's `test-ns-hook` runs
-  OUTSIDE `test-var`, so a bare failing assertion inside it reports with
-  an empty `*testing-vars*` — the var-derived ns is nil and the failure
-  would print with NO banner.  For that (and only that) no-var case,
-  `banner-ns` falls back to the innermost open namespace, tracked on a
-  begin/end-balanced `ns-stack` (a proper stack, NOT the clobberable
-  single cell above).  The failing var still wins whenever one exists, so
-  nested-run correctness is unchanged."
+  The failure banner comes from the failing var, so nested `run-tests`
+  calls cannot relabel an outer failure. A balanced namespace stack
+  supplies the fallback for `test-ns-hook` assertions, which run without
+  a current test var."
   (:require
     #?(:clj  [clojure.test]
        :cljs [cljs.test])))
@@ -107,39 +78,15 @@
 ;; ----------------------------------------------------------------------
 ;; Banner state.
 ;;
-;; A `clojure.test/run-tests` (or `cljs.test/run-tests`) call walks
-;; namespaces serially on the calling thread.  Every canonical test
-;; runner — cognitect-test-runner, shadow.test.node, shadow.test.browser
-;; — is single-threaded on the reporter callback, so a plain atom is
-;; sufficient: on the JVM the multi-method body runs on the test-driver
-;; thread, and under CLJS the single-threaded runtime makes it trivially
-;; safe.
+;; Reporter callbacks are serial in the supported runners, so plain atoms
+;; are sufficient for this process-local state.
 ;;
-;; We DON'T derive the failure banner from a single mutable "current ns"
-;; cell — that is the source of the nested-run mislabel / orphan bugs
-;; (rf2-8n97n.1 / .2), because a nested run's `:begin-test-ns` clobbers it.
-;; The PRIMARY banner ns is derived from the failing VAR itself (see
-;; `failing-ns`), which is always correct regardless of nesting.
+;; The primary banner namespace comes from the failing var, not mutable
+;; current-namespace state, so nested runs cannot clobber it.
 ;;
-;; We DO keep a STACK of the namespaces currently open — `:begin-test-ns`
-;; pushes, `:end-test-ns` pops — for two things:
-;;   - nesting depth: an EMPTY stack at `:begin-test-ns` means we are
-;;     entering an OUTERMOST namespace, which clears the printed-banner set
-;;     so a fresh `run-tests` (or the next sibling ns within one run)
-;;     re-flushes banners.  A NESTED run's `:begin-test-ns` fires while the
-;;     outer ns is still open (non-empty stack), so it does NOT clear: the
-;;     outer run's already-printed banners stay suppressed while the inner
-;;     ns can still print its own.  `:begin-test-ns`/`:end-test-ns` are
-;;     balanced per ns and never nested for sibling nses, so the stack is
-;;     non-empty only across a nested run-tests boundary.
-;;   - a FALLBACK banner ns: a `test-ns-hook` runs OUTSIDE `test-var`, so a
-;;     bare failing assertion inside it reports with an EMPTY
-;;     `*testing-vars*` — the var-derived `failing-ns` is then nil and the
-;;     failure would print with NO banner, violating the failure-banner
-;;     contract.  `banner-ns` falls back to the innermost open ns (the top
-;;     of this stack) when there is no failing var (rf2-g92dsm).  The stack
-;;     is only a FALLBACK; whenever a failing var exists it wins, so
-;;     nested-run correctness is unchanged.
+;; The balanced namespace stack distinguishes outermost from nested entry,
+;; resets the printed set between sibling namespaces, and supplies the
+;; fallback for `test-ns-hook` failures that have no current var.
 
 (def ^:private printed-banners
   (atom #{}))
@@ -149,8 +96,8 @@
 
 (defn- on-begin-test-ns!
   "Push `ns-sym` onto the open-namespace stack and clear the printed-banner
-  set on entry to an OUTERMOST namespace (empty stack) so each top-level
-  run — and each sibling ns within it — re-flushes its banner.  Nested-run
+  set on entry to an outermost namespace (empty stack) so each top-level
+  run and each sibling ns within it re-flushes its banner. Nested-run
   entries (non-empty stack) preserve the outer run's printed set."
   [ns-sym]
   (when (empty? @ns-stack)
@@ -163,7 +110,7 @@
 
 (defn- current-test-ns
   "The namespace of the innermost currently-open `test-ns` (top of the
-  begin/end stack), or nil if none is open.  The FALLBACK banner ns for a
+  begin/end stack), or nil if none is open. The fallback banner ns for a
   failure with no failing var in scope (see `banner-ns`)."
   []
   (peek @ns-stack))
@@ -194,9 +141,7 @@
      read off `clojure.test/*testing-vars*` (the same stack
      `testing-vars-str` renders).  Returns nil if no var is in scope.
 
-     This is what makes the banner nesting-correct: it is derived from
-     the var that actually failed, so a nested run-tests can never
-     mislabel or orphan the outer failure's banner (rf2-8n97n.1 / .2)."
+     The var-derived namespace remains correct across nested runs."
      []
      (when-let [v (first clojure.test/*testing-vars*)]
        (when-let [ns (:ns (meta v))]
@@ -215,9 +160,8 @@
 
 #?(:clj
    (defn- banner-ns
-     "The namespace to head the failure banner: the FAILING var's ns when a
-     var is in scope (nesting-correct, rf2-8n97n), else the innermost open
-     `test-ns` (the `test-ns-hook` no-var fallback, rf2-g92dsm)."
+     "The namespace to head the failure banner: the failing var's ns when a
+     var is in scope, otherwise the innermost open `test-ns`."
      []
      (or (failing-ns) (current-test-ns))))
 
@@ -283,7 +227,7 @@
      off the env's `:testing-vars` stack (the same stack
      `testing-vars-str` renders).  Derived from the var that actually
      failed so a nested run-tests can't mislabel/orphan the outer
-     banner (rf2-8n97n.1 / .2).  Returns nil if no var is in scope."
+     banner. Returns nil if no var is in scope."
      []
      (when-let [v (first (:testing-vars (cljs.test/get-current-env)))]
        (let [ns (:ns (meta v))]
@@ -300,9 +244,8 @@
 
 #?(:cljs
    (defn- banner-ns
-     "The namespace to head the failure banner: the FAILING var's ns when a
-     var is in scope (nesting-correct, rf2-8n97n), else the innermost open
-     `test-ns` (the no-current-var fallback, rf2-g92dsm)."
+     "The namespace to head the failure banner: the failing var's ns when a
+     var is in scope, otherwise the innermost open `test-ns`."
      []
      (or (failing-ns) (current-test-ns))))
 

--- a/implementation/test-quiet/src/re_frame/test_quiet/runner.clj
+++ b/implementation/test-quiet/src/re_frame/test_quiet/runner.clj
@@ -12,50 +12,36 @@
   load time.  By the time cognitect-test-runner discovers tests and
   starts dispatching reports, the overrides are in place.
 
-  ## The cross-runtime quiet contract (rf2-nrk066)
+  ## Quiet contract
 
-  re-frame2 runs the same silent-on-success policy on three runtimes —
-  JVM (this runner), CLJS node (`re-frame.test-quiet.shadow-node`), and
-  browser-test.  The contract is *documented pass-through stdout +
-  central noise buffering*.  The buffering POLICY is symmetric across
-  runtimes — buffer the noise channel, drop it on green, replay it on red
-  — but the buffered SCOPE differs by runtime (the asymmetry is called out
-  on the stderr bullet below): the JVM runner captures the WHOLE stderr
-  side (`*err*` + `System/err`), whereas the CLJS node runner captures only
-  `console.warn` (not `console.error` / `process.stderr`).
+  The JVM and CLJS node runners use pass-through stdout plus bounded noise
+  buffering. Both drop the buffer on green and replay it on red, but their
+  capture scopes differ. Browser diagnostics are owned by the browser
+  harness, not this runner.
 
    - STDOUT is pass-through, NOT summary-only.  The reporter
      (`re-frame.test-quiet`) makes a green run's stdout the canonical
      summary, but the runner forwards every OTHER byte a test, fixture,
      or the runner's own CLI emits — `-H`/`--test-help` usage,
      CLI parse-error diagnostics, and any bare `(println ...)` a test
-     makes.  This is deliberate (rf2-lbo79.2): a blanket stdout sink
-     made runner misuse opaque and lost failure-time diagnostics.  Only
-     cognitect's own discovery banner is dropped (see below).  The CLJS
+     makes. Only cognitect's own discovery banner is dropped (see below). The CLJS
      node runner forwards stdout the same way.
    - STDERR/WARNINGS are BUFFERED, replayed on red, dropped on green.
      A green run must not flood stdout/stderr with the expected
      warnings that warning-heavy suites emit (e.g.
      `re-frame.mcp-base.sensitive`'s fail-closed contract-drift WARN on
-     thousands of malformed `:sensitive?` stamps).  This runner binds
-     `*err*`/`System/err` to a bounded ring buffer for the duration of
-     the delegated run; the captured stderr is REPLAYED to the real
-     stderr only when the run is RED (so a failing run keeps the
-     diagnostic context that may explain it), and DROPPED on green.
-     This mirrors the buffer-drop-replay SHAPE of the CLJS node runner's
-     `console.warn` ring + red replay — so suites no longer need ad-hoc
-     `(binding [*err* <sink>] …)` workarounds to stay quiet on green
-     (rf2-80jyfk / rf2-nrk066).  The buffered SCOPE is asymmetric by
-     design, though: the JVM binds the WHOLE stderr side — both `*err*`
-     and a `System/err` bridge — so any Clojure or Java stderr write is
-     captured, whereas the CLJS node runner buffers ONLY `console.warn`
-     (a `console.warn` stub), NOT `console.error` or direct
+     thousands of malformed `:sensitive?` stamps). This runner binds the
+     test-driver thread's `*err*` and swaps the process-global `System/err`
+     to a bounded ring buffer. Captured stderr is replayed to the real
+     stderr only when the run is red and dropped on green.
+     The CLJS node runner uses the same policy for a narrower scope: a
+     `console.warn` stub, not `console.error` or direct
      `process.stderr` writes.  The asymmetry reflects what each runtime's
      noise actually is: CLJS first-run warnings come through
      `console.warn`, while a deliberate `console.error` stays a real error
      channel; the JVM has no comparable convention, so it buffers the
-     whole side.  Tests that ASSERT on captured warning text still capture
-     `*err*` locally; only the noise-suppression-only sinks are removed.
+     current-thread `*err*` plus process-global `System.err`. Tests that
+     assert on warning text still capture `*err*` locally.
 
   ## The discovery-banner contract
 
@@ -66,15 +52,9 @@
   *filtering* writer that drops the discovery banner and passes every
   other byte straight through to the real stdout.
 
-  This is a line-precise filter, NOT a global sink.  An earlier version
-  sank `*out*` for the entire delegated call, which silenced far more
-  than the banner: `-H`/`--test-help` usage text, CLI parse-error
-  diagnostics, and any bare `(println ...)` a test or fixture emits all
-  vanished — runner misuse went opaque and failure-time diagnostic stdout
-  was lost (rf2-lbo79.2).  cognitect's `help` and parse-error paths print
-  via the same `*out*` as the banner, so a blanket sink could not tell
-  them apart; the filter keys on the banner's exact text instead, so
-  those paths reach stdout while the banner stays quiet.
+  This is a line-precise filter, not a global sink. cognitect's help and
+  parse-error paths use the same `*out*` as the banner, so the filter keys
+  on the banner's exact shape and forwards every other line.
 
   Losing the banner on red costs nothing: it names only the directory
   set (constant across runs, recoverable from deps.edn).  The diagnostic
@@ -100,46 +80,41 @@
   "The literal text cognitect-test-runner's `test` fn prints via bare
   `println` before running tests: `(format \"\\nRunning tests in %s\" dirs)`.
 
-  `dirs` is ALWAYS a set — it defaults to `#{\"test\"}` and the `-d` CLI
-  option accumulates via `(fnil conj #{})` — so the banner renders as
-  `Running tests in #{...}`.  We match the prefix up to and including the
+  `dirs` is a set, so the banner renders as `Running tests in #{...}`. We
+  match the prefix up to and including the
   set-literal opener `#{` rather than the bare `Running tests in ` so that
   a legitimate diagnostic such as `Running tests in local fixture...`
   emitted by a test or fixture is forwarded, not silently swallowed: only
   the runner's own banner opens a set literal here.
 
-  The prefix is NECESSARY but not SUFFICIENT to confirm the banner (the
-  rf2-14nojy.2 overdrop): cognitect emits the banner via `println`, so it
-  is the WHOLE line — `(format \"Running tests in %s\" dirs)` and nothing
-  more — whereas a user/fixture line such as
+  The prefix is necessary but not sufficient: cognitect emits the banner
+  as the whole line, whereas a user/fixture line such as
   `Running tests in #{:fixture :phase} MARKER` shares the exact prefix but
-  carries trailing content after the closing `}`.  Dropping on the prefix
-  alone swallowed that trailing diagnostic.  `banner-filtering-writer`
-  therefore treats a full-prefix match only as a CANDIDATE: it buffers the
+  carries trailing content after the closing `}` and is a distinct
+  diagnostic. `banner-filtering-writer` therefore treats a
+  full-prefix match only as a candidate: it buffers the
   rest of the line and drops it only if the remainder is a balanced set
   literal followed by nothing but whitespace (`banner-line-remainder?`).
 
-  Note the leading `\\n` in cognitect's format string: the banner is
-  `\\nRunning tests in #{...}\\n` — it opens with a BLANK LINE.  That
-  leading newline is part of the banner artefact and is swallowed along
+  The banner is `\\nRunning tests in #{...}\\n`, so its leading blank line
+  is part of the banner artefact and is swallowed along
   with the `Running tests in #{...}` text (see the pending-blank handling
   in `banner-filtering-writer`); the text we *match* on is the
   non-blank-line portion below."
   "Running tests in #{")
 
 (defn- banner-line-remainder?
-  "True iff `remainder` — the text on a banner-candidate line AFTER the
-  `discovery-banner-prefix` (`Running tests in #{`) — completes the
-  cognitect discovery banner and NOTHING else.
+  "True iff `remainder`, the text after `discovery-banner-prefix`,
+  completes the cognitect discovery banner and nothing else.
 
   cognitect prints the banner with `println` as `(format \"Running tests
-  in %s\" dirs)` where `dirs` is the dir-string SET, so the whole line is
+  in %s\" dirs)` where `dirs` is the directory set, so the whole line is
   `Running tests in #{<set-body>}` and stops there.  This confirms that
   shape: the remainder must contain the set body, the closing `}` that
   balances the prefix's `#{`, and then only whitespace.  Anything after
   the closing brace — e.g. the ` MARKER` in a fixture's
   `Running tests in #{:fixture :phase} MARKER` — means it is NOT the
-  banner and must be forwarded (the rf2-14nojy.2 overdrop guard).
+  banner and must be forwarded.
 
   The scan tracks brace depth (the prefix already opened depth 1) and
   skips over Clojure string literals so a `}` inside a quoted dir name
@@ -174,7 +149,7 @@
   "A `java.io.Writer` that forwards every character to `target` EXCEPT
   cognitect's discovery banner line, which it drops.
 
-  Forwards eagerly, holding back only as much text as could still BECOME
+  Forwards eagerly, holding back only as much text as could still become
   the banner.  At the start of each line we are watching whether the
   incoming characters spell out `discovery-banner-prefix`:
 
@@ -183,7 +158,7 @@
    - the moment it diverges from the banner prefix we forward the whole
      run immediately and pass the rest of the line straight through;
    - the moment it reaches the full banner prefix the line is a banner
-     CANDIDATE, not a confirmed banner: cognitect prints the banner with
+     candidate, not a confirmed banner: cognitect prints the banner with
      `println`, so the banner is the WHOLE line and stops at the set
      literal's closing `}`.  We keep buffering the remainder and decide at
      the line's newline — drop the line only if the remainder is a
@@ -191,28 +166,28 @@
      (`banner-line-remainder?`), this line was preceded by the held
      leading blank, AND cognitect's one discovery banner has NOT already
      been dropped (`banner-dropped?`).  cognitect's banner is
-     `(format \"\\nRunning tests in %s\" dirs)`, so the genuine banner is
-     ALWAYS opened by a blank line; requiring that held blank means an
+      `(format \"\\nRunning tests in %s\" dirs)`, so the genuine banner is
+      always opened by a blank line; requiring that held blank means an
      exact-shape user/fixture line such as a bare
-     `(println \"Running tests in #{:fixture}\")` — same text, but no
-     leading blank — is forwarded rather than silently overdropped
-     (rf2-m8dbb9).  cognitect emits the banner exactly ONCE, before any
-     test runs, so the `banner-dropped?` latch means a LATER blank-led
+      `(println \"Running tests in #{:fixture}\")` - same text, but no
+      leading blank - is forwarded. cognitect emits the banner exactly
+      once, before any test runs, so the `banner-dropped?` latch means a
+      later blank-led
      banner-shaped line — a test that prints `(println)` then
      `(println \"Running tests in #{:fixture}\")` — is forwarded rather
-     than swallowed as a phantom second banner (rf2-6nrk8x).  Otherwise the
+      than swallowed as a phantom second banner. Otherwise the
      prefix was shared by a user/fixture diagnostic such as
      `Running tests in #{:fixture} MARKER` and the whole buffered line is
-     forwarded (the rf2-14nojy.2 overdrop guard).
+      forwarded.
 
-  cognitect's banner opens with a BLANK LINE — the format string is
+  cognitect's banner opens with a blank line: the format string is
   `\"\\nRunning tests in %s\"`, so the leading `\\n` renders an empty line
   immediately before the `Running tests in #{...}` text.  That blank line
   is part of the same artefact and must vanish too, else a green run leaks
-  one stray leading blank line (rf2-khecvs).  We can't know a blank line
+  one stray leading blank line. We can't know a blank line
   is the banner's lead-in until the NEXT line proves to be the banner, so
-  an empty line seen while still watching is held as a single PENDING
-  BLANK: dropped if the next line is confirmed the banner, emitted
+  an empty line seen while still watching is held as a single pending
+  blank: dropped if the next line is confirmed the banner, emitted
   otherwise (a divergent line, a short watched line, or a second blank).
   At most one blank is ever pending — it is resolved at the next line's
   first character.
@@ -225,12 +200,12 @@
   still reaches stdout before exit.  The only text that can sit unflushed
   at exit is a banner candidate (the full buffered line so far — a strict
   banner prefix, possibly extended into an as-yet-unterminated banner
-  remainder) or a single pending blank — all of which the `finally` flush
-  and the JVM shutdown hook forward (a genuine trailing blank line and a
-  bare `Running tests in #{...`-prefixed partial therefore both survive
-  exit), while the real banner itself completes and is dropped before any
-  exit because cognitect prints it with `println` and runs the suite
-  after.
+  remainder) or a single pending blank. The explicit flush on returning
+  paths and the JVM shutdown hook on `System/exit` forward those candidates,
+  so a genuine trailing blank line and a bare
+  `Running tests in #{...`-prefixed partial both survive exit. The real
+  banner completes and is dropped before exit because cognitect prints it
+  with `println` and runs the suite after.
 
   Help text, parse-error diagnostics, the reporter's failure output, and
   bare test stdout all pass through untouched; only the banner line is
@@ -250,7 +225,7 @@
         ;;   :watching         — buf is a viable prefix of the banner-so-far;
         ;;   :banner-candidate — buf reached the full prefix; keep buffering
         ;;                       the remainder, decide drop/forward at the
-        ;;                       line's newline (rf2-14nojy.2);
+        ;;                       line's newline;
         ;;   :passthrough      — this line diverged; forward chars verbatim.
         buf   (StringBuilder.)
         state (volatile! :watching)
@@ -260,7 +235,7 @@
         ;; stream.  Once we have dropped it, every later banner-shaped line is
         ;; genuine test/fixture stdout and must pass through: a test that
         ;; prints a blank line then banner-shaped text was otherwise
-        ;; over-dropped, violating the pass-through contract (rf2-6nrk8x).
+        ;; over-dropped, violating the pass-through contract.
         banner-dropped? (volatile! false)
         ;; `pending-blank?` holds back a single empty line that MIGHT be
         ;; the banner's leading newline (`\nRunning tests in #{...}`). It
@@ -314,7 +289,7 @@
                                                    (emit! (.toString buf))
                                                    (.write target (int \newline))))
                                 ;; Reached the full prefix — DECIDE now that
-                                ;; the line is complete (rf2-14nojy.2). The
+                                ;; the line is complete. The
                                 ;; remainder is everything buffered after the
                                 ;; prefix; if it is a balanced set literal +
                                 ;; only whitespace AND this line was preceded
@@ -325,7 +300,7 @@
                                 ;; by a real diagnostic → flush the pending
                                 ;; blank and forward the whole buffered line.
                                 ;;
-                                ;; The leading-blank requirement (rf2-m8dbb9)
+                                ;; The leading-blank requirement
                                 ;; distinguishes cognitect's banner — printed
                                 ;; via `(format "\nRunning tests in %s" dirs)`,
                                 ;; so ALWAYS opened by a blank line — from a
@@ -342,7 +317,7 @@
                                 ;; once, so once we have dropped it, a later
                                 ;; blank-led banner-shaped line is genuine test
                                 ;; stdout and must be forwarded, not swallowed
-                                ;; as a second "banner" (rf2-6nrk8x). Gate the
+                                ;; as a second "banner". Gate the
                                 ;; drop on `banner-dropped?` and latch it here.
                                 :banner-candidate
                                 (let [remainder (subs (.toString buf) prefix-len)]
@@ -425,17 +400,11 @@
         (.flush target)))))
 
 ;; ----------------------------------------------------------------------
-;; Central stderr buffer + red replay (rf2-nrk066).
+;; Central stderr buffer + red replay.
 ;;
 ;; The symmetric counterpart to the CLJS node runner's `console.warn`
-;; ring buffer (`re-frame.test-quiet.shadow-node`).  Warning-heavy JVM
-;; suites emit expected stderr noise on the green path (e.g.
-;; `re-frame.mcp-base.sensitive` logging a contract-drift WARN for every
-;; malformed `:sensitive?` stamp it fail-closes).  Pre-rf2-nrk066 the JVM
-;; runner had NO central stderr handling — it filtered only cognitect's
-;; stdout banner — so those warnings flooded a green run unless each
-;; namespace bound `*err*` to a private sink.  We now buffer stderr in a
-;; bounded ring for the delegated run and:
+;; ring buffer (`re-frame.test-quiet.shadow-node`). The runner buffers
+;; stderr in a bounded ring for the delegated run and:
 ;;   - GREEN: drop the buffer silently (quiet on success);
 ;;   - RED:   replay it to the real stderr from the `:summary` reporter
 ;;            hook below, BEFORE cognitect computes its exit code, so a
@@ -450,9 +419,8 @@
 (def ^:private stderr-buffer-cap
   "Bounded stderr ring capacity (characters).  Caps memory + replay
   volume on a red run while keeping enough recent context to explain a
-  failure — the newest `stderr-buffer-cap` characters are retained,
-  older ones dropped.  ~256 KB is generous for diagnostic warnings
-  without risking heap pressure on a pathologically chatty suite."
+  failure. The newest `stderr-buffer-cap` characters are retained and
+  older ones are dropped."
   (* 256 1024))
 
 (defn- buffering-stderr-writer
@@ -464,8 +432,8 @@
   ^java.io.Writer [^StringBuilder sb]
   (let [append! (fn [^String s]
                   (.append sb s)
-                  ;; Trim from the FRONT once past the cap so the ring
-                  ;; keeps the most-recent context (the bytes nearest a
+                   ;; Trim from the front once past the cap so the ring
+                   ;; keeps the most-recent context (the characters nearest a
                   ;; failure), matching the CLJS ring's newest-N policy.
                   (let [n (.length sb)]
                     (when (> n stderr-buffer-cap)
@@ -488,20 +456,20 @@
       (close []))))
 
 (defn- install-summary-replay-hook!
-  "Install a `clojure.test/report :summary` override that REPLAYS the
-  buffered stderr (`sb`) to `real-err` when the run is RED, then delegates
+  "Install a `clojure.test/report :summary` override that replays the
+  buffered stderr (`sb`) to `real-err` when the run is red, then delegates
   to whatever `:summary` method was installed before us so the canonical
   summary line still prints.
 
   `:summary` is the JVM-side counterpart to the CLJS `:end-run-tests`
   reporter: it fires once at the end of `run-tests` from the same
   fail/error counts cognitect reads to compute the exit code, and it runs
-  on the test-driver thread INSIDE the `binding` that rebinds `*err*` —
+  on the test-driver thread inside the `binding` that rebinds `*err*`,
   so it runs before cognitect's `System/exit` and can flush the captured
-  context.  A run is RED iff `(pos? (+ fail error))`, matching cognitect's
+  context. A run is red iff `(pos? (+ fail error))`, matching cognitect's
   `(zero? (+ fail error))` green test.
 
-  SCOPE — the replay is bounded to the TEST-RUN red path.  cognitect only
+  The replay is bounded to the test-run red path. cognitect only
   fires `:summary` once it has reached `run-tests`, so the buffered stderr
   is replayed only for a red run that actually executed tests.  The
   non-test exit-1 path — a CLI parse error
@@ -514,14 +482,13 @@
   noise was written before the parse failed (in practice none; arg parsing
   does not log to stderr).  A `finally`-flush in `-main` cannot widen the
   scope: cognitect `System/exit`s straight from the parse-error branch, so
-  `-main`'s `finally` never runs on that path (it runs only on the `-H`
-  help/return path).  Tightening this docstring rather than adding an
-  unreachable flush keeps the contract honest (rf2-22s58s).
+  `-main`'s `finally` never runs on that path; it runs on returning paths
+  such as `-H` help.
 
-  The replay goes to the REAL stderr (the `*err*` ring is still bound at
-  this point, so we must NOT use `*err*`/`println` here or the replay
-  would feed straight back into the buffer).  Each captured chunk is
-  written VERBATIM; a header marks it as a red-run replay so it is
+  The replay goes to the original stderr writer. The `*err*` ring is still
+  bound at this point, so using `*err*`/`println` here would feed the replay
+  straight back into the buffer. Each captured chunk is
+  written verbatim; a header marks it as a red-run replay so it is
   distinguishable from the reporter's own stdout, mirroring the CLJS
   replay's `[test-quiet]` prefix.  On green the buffer is simply dropped
   (never written)."
@@ -564,8 +531,8 @@
   ;; it most.  The hook makes flush-on-exit deterministic rather than
   ;; relying on the runtime or cognitect to flush before exiting.
   ;;
-  ;; We ALSO bind `*err*` (and `System/err`) to a bounded ring buffer for
-  ;; the delegated run (rf2-nrk066): expected stderr warnings are captured
+  ;; We also bind the test-driver thread's `*err*` and swap process-global
+  ;; `System/err` to a bounded ring buffer. Expected warnings are captured
   ;; rather than flooding a green run, and the `:summary` reporter hook
   ;; replays them to the real stderr only on RED — symmetric with the CLJS
   ;; node runner's `console.warn` buffer + red replay.  `*err*` is bound on
@@ -589,27 +556,28 @@
     (.addShutdownHook (Runtime/getRuntime)
                       (Thread. ^Runnable #(.flush filtering)))
     (install-summary-replay-hook! stderr-sb real-err)
-    ;; Route raw `System/err` bytes into the SAME ring as `*err*` so a
+    ;; Route raw `System/err` bytes into the same ring as `*err*` so a
     ;; library that writes `System.err` directly is buffered too. Each chunk
     ;; is decoded to a `String` and appended to the ring (this buffer is the
     ;; diagnostic/red-replay path only — never the green-run summary). Note
     ;; the encoding asymmetry between the two `write` proxy arities:
     ;;   - write(byte[],off,len): a chatty library prints via
     ;;     `PrintStream.print(...)`/`write(byte[])`, which the autoFlush
-    ;;     UTF-8 `PrintStream` below routes through THIS multi-byte arity, so
-    ;;     a whole encoded chunk is decoded as one unit and survives intact.
+    ;;     UTF-8 `PrintStream` below routes through this multi-byte arity. The
+    ;;     chunk is decoded as one unit using the JVM's default charset, so
+    ;;     non-ASCII fidelity depends on that default also being UTF-8.
     ;;   - write(int): the single-byte arity decodes that ONE byte on its
     ;;     own. A multi-byte UTF-8 sequence delivered one byte at a time —
     ;;     only a raw `System.err.write(int)` per byte hits this path; the
     ;;     `PrintStream` itself never splits a code point across single-byte
     ;;     writes — would decode each byte separately and mangle the
-    ;;     character. This arity is therefore BEST-EFFORT / ASCII-only by
+    ;;     character. This arity is therefore best-effort / ASCII-only by
     ;;     design: it preserves byte fidelity for the common ASCII diagnostic
     ;;     case and tolerates (does not guarantee) multi-byte text on the
     ;;     pathological raw per-byte path. Buffering raw bytes to decode once
     ;;     at replay is not a clean fit here — the ring is a shared char
     ;;     `Writer` that `*err*` also writes into directly, so there is no
-    ;;     single byte stream to defer-decode (rf2-22s58s).
+    ;;     single byte stream to defer-decode.
     (let [sys-bridge (proxy [java.io.OutputStream] []
                        (write
                          ([b]
@@ -627,5 +595,6 @@
         (apply cognitect.test-runner/-main args)
         (finally
           (.flush filtering)
-          ;; Restore the real System/err for any post-run / shutdown code.
+          ;; Returning paths (notably help) restore System/err. `System/exit`
+          ;; paths terminate without running this `finally`.
           (System/setErr sys-err))))))

--- a/implementation/test-quiet/src/re_frame/test_quiet/shadow_node.cljs
+++ b/implementation/test-quiet/src/re_frame/test_quiet/shadow_node.cljs
@@ -10,27 +10,26 @@
   CLJS `defmethod`s install at load time.  By the time shadow's
   `run-all-tests` walks namespaces, the overrides are in place.
 
-  Also installs a BUFFERING `js/console.warn` stub so first-time
+  Also installs a buffering `js/console.warn` stub so first-time
   runtime warnings (`reg-view non-DOM root`, `reagent-slim
-  keyword-on-non-HTML-prop`, etc.) don't leak to test stdout on the
-  SUCCESS path — but are NOT lost on a RED run.  The stub holds back
-  warning text in a bounded ring (`warn-buffer`) instead of discarding
+  keyword-on-non-HTML-prop`, etc.) don't leak to test output on the
+  success path but are not lost on a red run. The stub holds back
+  warning calls in a bounded-entry ring (`warn-buffer`) instead of discarding
   it; the `:end-run-tests` reporter replays that buffer to stderr when
   the run fails or errors, so a failing CLJS run keeps the diagnostic
   context that may explain the failure.  Green runs stay quiet (the
   buffer is simply dropped at the green exit).
 
-  BUFFER SCOPE — `console.warn` ONLY (and the asymmetry with the JVM).
+  Buffer scope: `console.warn` only.
   This stub captures `console.warn` and nothing else: `console.error` and
   direct `process.stderr.write` are NOT buffered and pass straight
   through.  That is deliberate — `console.warn` is the channel re-frame2's
   expected first-run warnings travel on, while a `console.error` is a real
   error worth surfacing immediately even on the green path.  This makes the
-  CLJS scope NARROWER than the JVM runner
-  (`re-frame.test-quiet.runner`), which buffers the WHOLE stderr side
-  (`*err*` + a `System/err` bridge).  The buffer/drop-on-green/
-  replay-on-red POLICY is the same on both runtimes; only the captured
-  scope differs (rf2-22s58s / rf2-nrk066).
+  CLJS scope narrower than the JVM runner (`re-frame.test-quiet.runner`),
+  which buffers the test thread's `*err*` plus a process-global `System/err`
+  bridge. The drop-on-green/replay-on-red policy is the same; only the
+  captured scope differs.
 
   Tests that assert warning content all use the local
   `with-captured-console-warn` pattern — they save `(.-warn js/console)`,
@@ -64,9 +63,9 @@
 (defn- buffer-warning!
   "Append `args` (one `console.warn` call's arguments) to the bounded
   ring via `warn-buffer/bound-conj`, which caps the ring to the newest
-  `warn-buffer/warn-buffer-cap` entries and MATERIALISES the trimmed
+  `warn-buffer/warn-buffer-cap` entries and materialises the trimmed
   window into a fresh vector — so discarded warnings are not retained via
-  a shared `subvec` backing (rf2-6emzlh)."
+  a shared `subvec` backing."
   [args]
   (swap! warn-buffer wb/bound-conj args))
 
@@ -76,9 +75,10 @@
   from the `:end-run-tests` reporter ONLY on a red run, restoring the
   diagnostic context the green-path quieting withheld.
 
-  Each buffered arg is replayed VERBATIM.
+  Buffered argument values are rendered through `println`, not replayed
+  through native `console.warn`; their formatting semantics therefore differ.
 
-  SYNCHRONOUS WRITE (rf2-4co7oo). The replay writes to fd 2 via
+  The replay writes synchronously to fd 2 via
   `fs.writeSync`, NOT `js/process.stderr.write`.  On POSIX a pipe-backed
   `process.stderr` is ASYNCHRONOUS, and the `:end-run-tests` reporter calls
   `js/process.exit 1` IMMEDIATELY after this returns — `process.exit` forces
@@ -87,9 +87,7 @@
   could be TRUNCATED before it reached captured CI output, dropping the tail
   of the diagnostic context the ns docstring promises a red run keeps.
   `fs.writeSync` blocks until the bytes reach the fd, so the exit cannot drop
-  them.  This matches the JVM runner, whose blocking `PrintWriter` over
-  `System.err` is likewise synchronous (Windows dev-box pipe writes are
-  synchronous too, which is why the bug is CI-only)."
+  them. This matches the JVM runner's blocking stderr replay."
   []
   (let [buffered @warn-buffer]
     (when (seq buffered)
@@ -101,15 +99,15 @@
           (doseq [args buffered]
             (apply println "[test-quiet] console.warn:" args)))))))
 
-;; The stub carries a `re-frame.test-quiet/silenced` marker property so it
-;; is IDENTIFIABLE: a contract test can assert the live `console.warn` is
+;; The stub carries an `rf-test-quiet-silenced` marker property so a
+;; contract test can assert the live `console.warn` is
 ;; this stub (and so fail if a regression leaves native `console.warn` —
 ;; which has no such marker — in place), without requiring this
 ;; `:dev/always` ns (which would form a compile cycle).
 (when (and (exists? js/console)
            (fn? (.-warn js/console)))
-  ;; Return `nil` (like native `console.warn`) so callers that observe the
-  ;; return value see no behavioural change from the buffering.
+  ;; `nil` is the local stub contract. Native `console.warn` returns
+  ;; JavaScript `undefined`; callers must not use either return value.
   (let [stub (fn [& args] (buffer-warning! (vec args)) nil)]
     (set! (.-rf-test-quiet-silenced stub) true)
     (set! (.-warn js/console) stub)))
@@ -121,14 +119,11 @@
 ;; buffered `console.warn` diagnostics (the green-path stub withheld
 ;; them) so a failing run keeps the context that may explain it.
 ;;
-;; EXIT-CODE INTEGRITY (rf2-jmrdhn). This defmethod is the ONLY thing that
+;; Exit-code integrity: this defmethod is the only thing that
 ;; turns a RED cljs.test summary into a non-zero node exit, so two hazards
-;; must never let a failing run go out the door GREEN:
-;;   1. The red replay is DIAGNOSTIC-ONLY. If `replay-buffered-warnings!`
-;;      threw, the old `(do (replay…) (js/process.exit 1))` never reached
-;;      the `exit 1` — the throw propagated out of the reporter and node
-;;      could unwind to a 0 exit. The replay is wrapped so a throw in it can
-;;      never SWALLOW the red exit.
+;; must never let a failing run exit green:
+;;   1. Red replay is diagnostic-only. It is wrapped so a replay exception
+;;      cannot prevent the nonzero exit.
 ;;   2. Reaching a GREEN exit is the ONLY way `main` clears the seeded
 ;;      failure exit code (`execute-cli` sets `process.exitCode = 1` before
 ;;      running). So a run that executes tests but never dispatches THIS
@@ -148,13 +143,13 @@
         (js/process.exit 1))))
 
 (defn- seed-failure-exit!
-  "Seed the node process's exit code to FAILURE just before a test run
-  begins.  The ONLY path that clears it back to 0 is a confirmed GREEN
+  "Seed the node process's exit code to failure just before a test run
+  begins. The only path that clears it back to 0 is a confirmed green
   `:end-run-tests` (which `js/process.exit 0`s — see that defmethod's
   EXIT-CODE INTEGRITY note).  So a run that starts tests but never reaches a
   green summary — a torn-down async run, or a reporter env that never
   dispatches our exit defmethod — drains the event loop and exits with this
-  seeded 1 rather than a silent false-green (rf2-jmrdhn).  It is a no-op on
+  seeded 1 rather than a silent false-green. It is a no-op on
   the normal green/red paths, where the `:end-run-tests` defmethod calls
   `js/process.exit` and overrides it."
   []
@@ -185,18 +180,12 @@
                          (contains? test-var-syms (symbol ns name)))))))))
 
 (defn execute-cli [{:keys [test-syms help list unknown-args] :as _opts}]
-  ;; Unknown args are a FATAL parse error (rf2-14nojy.1): the pure
+  ;; Unknown args are a fatal parse error. The pure
   ;; `cli/parse-args` collects them into `:unknown-args` (without printing,
   ;; so it can be unit-pinned without leaking a non-summary line on a green
-  ;; run; rf2-spzkgo). Pre-fix `execute-cli` merely PRINTED them and then
-  ;; fell through — so a mistyped focused-run such as the space-separated
-  ;; `--test missing.ns` (both tokens unknown, no `--test=` selector) or a
-  ;; misspelled flag like `--tests=foo` ran NO requested tests, dropped into
-  ;; the `:else` `run-all-tests` branch, and exited GREEN if the full suite
-  ;; was green — a focused-run false green of the same class the
-  ;; `--test=<missing>` guard (rf2-lbo79.1) closes. Reject unknown args here:
-  ;; print them and `js/process.exit` NONZERO before running anything. This
-  ;; runs ahead of `--help`/`--list`, so those stay clean successful
+  ;; run). Reject unknown args here: print them and `js/process.exit`
+  ;; nonzero before running anything. This check runs ahead of
+  ;; `--help`/`--list`, so those stay clean successful
   ;; non-test commands ONLY when no unknown arg accompanies them.
   (when (seq unknown-args)
     (doseq [arg unknown-args]
@@ -221,11 +210,9 @@
       (seq test-syms)
       (let [test-vars (find-matching-test-vars test-syms)
             unmatched (cli/unmatched-selectors test-syms test-vars)]
-        ;; A `--test=` selection that matches NO test var must NOT be a
-        ;; false green: shadow's `run-test-vars` over an empty set reports
-        ;; a 0-test SUCCESS and the `:end-run-tests` defmethod exits 0, so
-        ;; a typo in `--test=<selector>` would silently "pass" with zero
-        ;; tests run (rf2-lbo79.1).  Reject any unmatched selector — print
+        ;; A `--test=` selection that matches no test var must not be a
+        ;; false green: `run-test-vars` over an empty set reports a 0-test
+        ;; success. Reject any unmatched selector: print
         ;; the offenders and exit nonzero before running anything.
         (if (seq unmatched)
           (do

--- a/implementation/test-quiet/src/re_frame/test_quiet/shadow_node_cli.cljs
+++ b/implementation/test-quiet/src/re_frame/test_quiet/shadow_node_cli.cljs
@@ -1,6 +1,6 @@
 (ns re-frame.test-quiet.shadow-node-cli
   "Pure CLI-arg parsing for the `:node-test` runner
-  `re-frame.test-quiet.shadow-node` (rf2-vespg).
+  `re-frame.test-quiet.shadow-node`.
 
   Lives apart from the runner so it can be unit-pinned: the runner ns
   carries `{:dev/always true}` and expands `shadow.test.env/get-test-data`
@@ -17,7 +17,7 @@
 
 (defn parse-args
   "Parse shadow-node CLI args into
-  `{:test-syms [..] :help? :list? :unknown-args [..]}` (flags present
+  `{:test-syms [..] :help :list :unknown-args [..]}` (flags present
   only when set; `:unknown-args` present only when an arg was unknown).
 
    - `--help` / `--list` set their boolean flag.
@@ -28,8 +28,8 @@
    - any other arg is collected into `:unknown-args` (in input order)
      and otherwise ignored.  This parser is PURE — it does not print:
      the real CLI path (`shadow-node/execute-cli`) reports the
-     unknowns, so a contract test can pin the parse result without
-     leaking a non-summary line on a green run (rf2-spzkgo)."
+      unknowns, so a contract test can pin the parse result without
+      leaking a non-summary line on a green run."
   [args]
   (reduce
     (fn [opts arg]
@@ -52,7 +52,7 @@
     args))
 
 (defn unmatched-selectors
-  "The subset of `test-syms` that matched NO var in `matched-vars`.
+  "The subset of `test-syms` that matched no var in `matched-vars`.
 
   `matched-vars` is the seq `find-matching-test-vars` returns — each var
   carries `{:ns :name}` metadata.  A simple symbol (namespace selector)
@@ -63,9 +63,9 @@
 
   Pure (no `shadow.test.env` dependency) so it can be unit-pinned here
   rather than from the `:dev/always` runner ns, which forms a compile
-  cycle.  This is the guard against a `--test=<typo>` false green
-  (rf2-lbo79.1): a selection that matches nothing must be rejected, not
-  reported as a 0-test SUCCESS."
+  cycle. This guards against a `--test=<typo>` false green: a selection
+  that matches nothing must be rejected, not
+  reported as a 0-test success."
   [test-syms matched-vars]
   (let [matched-ns  (->> matched-vars (map (comp :ns meta)) set)
         matched-fqn (->> matched-vars

--- a/implementation/test-quiet/src/re_frame/test_quiet/warn_buffer.cljs
+++ b/implementation/test-quiet/src/re_frame/test_quiet/warn_buffer.cljs
@@ -8,12 +8,12 @@
   so a test ns requiring the runner directly forms a compile cycle — the
   same reason `re-frame.test-quiet.shadow-node-cli` is factored out.  This
   helper has no such dependency, so `re-frame.test-quiet-shadow-node-cljs-test`
-  can pin the memory bound directly.")
+  can pin the entry-count and backing-vector bound directly.")
 
 (def warn-buffer-cap
-  "Bounded warning ring size.  Caps memory + replay volume on a red run
-  while keeping enough recent context to explain a failure (the newest
-  `warn-buffer-cap` warnings are retained; older ones are dropped)."
+  "Bounded warning-call count. The newest `warn-buffer-cap` calls are
+  retained and older ones are dropped. Individual warning arguments remain
+  unbounded, so this is not a byte-size limit."
   256)
 
 (defn bound-conj
@@ -23,12 +23,12 @@
   The trimmed window is MATERIALISED into a fresh vector rather than
   returned as a `subvec`.  This is the whole point of the helper: a
   ClojureScript `Subvec` shares — and thereby RETAINS — its entire
-  underlying vector via `.-v`, and `conj`-ing onto a `Subvec` grows that
+  underlying vector via `.-v`, and `conj` on a `Subvec` grows that
   underlying vector rather than the window.  So trimming with `subvec`
   alone would keep every discarded warning (and its arg vectors) alive
-  until process exit, silently defeating the bound (rf2-6emzlh).  `into
+  until process exit, silently defeating the bound. `into
   []` copies only the window into a new `PersistentVector`, dropping the
-  discarded head so memory stays bounded to `cap` entries."
+  discarded head so retained entry count stays bounded to `cap`."
   ([buf x] (bound-conj buf x warn-buffer-cap))
   ([buf x cap]
    (let [buf' (conj buf x)

--- a/implementation/test-quiet/test/re_frame/test_quiet_green_fixture_cljs_test.cljs
+++ b/implementation/test-quiet/test/re_frame/test_quiet_green_fixture_cljs_test.cljs
@@ -1,7 +1,7 @@
 (ns re-frame.test-quiet-green-fixture-cljs-test
   "A deliberately minimal, always-GREEN CLJS suite used as the focused
   target for the process-level quiet-shape regression in
-  `re-frame.test-quiet-shadow-node-cljs-test` (rf2-spzkgo).
+  `re-frame.test-quiet-shadow-node-cljs-test`.
 
   The quiet-shape regression spawns the REAL built `out/node-test.js`
   shadow-node entry point with `--test=<this-ns>` and asserts the green

--- a/implementation/test-quiet/test/re_frame/test_quiet_pin_test.clj
+++ b/implementation/test-quiet/test/re_frame/test_quiet_pin_test.clj
@@ -1,18 +1,19 @@
 (ns re-frame.test-quiet-pin-test
-  "Stdout-line-count pin for the silent-on-success contract (rf2-try1x).
+  "Stdout-line-count pin for the silent-on-success contract.
 
   Drives a tiny known-green sub-suite (a single `is (= 1 1)` deftest
   in a sibling namespace) through `clojure.test/run-tests` while
   capturing stdout, then asserts the captured stdout has AT MOST 5
   non-blank lines.
 
-  The canonical green shape is 3 lines:
+  The reporter emits one leading blank and two non-blank summary lines:
 
       Ran 1 tests containing 1 assertions.
       0 failures, 0 errors.
 
-  The 5-line ceiling tolerates a single extra heading or marker
-  without making this pin flaky on slight reporter tweaks.  A future
+  The five-nonblank-line ceiling is deliberately looser than the exact
+  process-level shape test. It catches substantial output creep without
+  making this smoke pin sensitive to small reporter changes. A future
   `(println ...)` creep — in test bodies, fixture setups, the
   reporter itself, or any downstream code path the test traverses —
   immediately fails this pin with the captured stdout in the
@@ -27,7 +28,7 @@
   `.../test-quiet/test` — cognitect's test-runner cannot discover this
   ns from another artefact's suite.  The alias is wired into the JVM
   gate by `scripts/test-jvm-implementation.sh` and the `jvm-test-quiet`
-  CI job (`.github/workflows/test.yml`, added by rf2-jg1ag2)."
+  CI job (`.github/workflows/test.yml`)."
   (:require [clojure.test :refer [deftest is testing run-tests]]
             [clojure.string :as str]
             [re-frame.test-quiet]
@@ -49,11 +50,8 @@
     (.toString sw)))
 
 (deftest stdout-line-count-pin
-  ;; The pin: a known-green sub-suite (a single `is (= 1 1)` deftest
-  ;; in `re-frame.test-quiet-pin-passing-test`) emits AT MOST 5
-  ;; non-blank lines on stdout when run through `clojure.test/run-tests`.
-  ;; The canonical shape is 3 lines; the 5-line ceiling tolerates a
-  ;; single extra heading or marker without making this pin flaky.
+  ;; The exact process-level shape has two non-blank summary lines. This
+  ;; broader smoke pin allows at most five.
   (testing "known-green sub-suite emits the canonical silent-on-success shape"
     (let [captured  (with-captured-stdout
                       #(run-tests 're-frame.test-quiet-pin-passing-test))
@@ -62,6 +60,6 @@
       (is (<= (count non-blank) 5)
           (str "Green sub-suite stdout has " (count non-blank)
                " non-blank lines; the silent-on-success contract"
-               " caps it at 5 (canonical shape is 3). New println"
+               " caps it at 5 (canonical shape is 2). New println"
                " creep?  Captured stdout follows:\n"
                (str/join "\n" non-blank))))))

--- a/implementation/test-quiet/test/re_frame/test_quiet_red_warn_fixture_cljs_test.cljs
+++ b/implementation/test-quiet/test/re_frame/test_quiet_red_warn_fixture_cljs_test.cljs
@@ -1,6 +1,6 @@
 (ns re-frame.test-quiet-red-warn-fixture-cljs-test
   "A CLJS fixture suite for the warning-buffer red-replay regression in
-  `re-frame.test-quiet-shadow-node-cljs-test` (rf2-8dfq5j.2).
+  `re-frame.test-quiet-shadow-node-cljs-test`.
 
   The buffered-`console.warn` contract (quiet on green, replayed on red)
   can only be observed across a process boundary: the buffer is replayed
@@ -31,11 +31,11 @@
   (is (or (not armed?) (= :expected :actual))
       "armed fixture fails so the run is RED and the buffer replays"))
 
-;; ---- large-replay truncation fixture (rf2-4co7oo) ------------------------
+;; ---- large-replay truncation fixture -------------------------------------
 ;;
 ;; Fills the warn ring to its cap with LARGE warnings so the red replay far
 ;; exceeds a POSIX pipe buffer (~64 KiB), then fails RED. If the replay were
-;; written to the async `process.stderr` and followed immediately by
+;; written through asynchronous `process.stderr` and followed immediately by
 ;; `js/process.exit`, its TAIL — the newest warnings, replayed last — would be
 ;; dropped on POSIX before reaching captured output. The synchronous
 ;; `fs.writeSync` replay guarantees the tail survives. Gated on its OWN env

--- a/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
+++ b/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
@@ -1,6 +1,6 @@
 (ns re-frame.test-quiet-runner-contract-test
   "Subprocess contract pin for the JVM entry point
-  `re-frame.test-quiet.runner/-main` (rf2-vespg).
+  `re-frame.test-quiet.runner/-main`.
 
   The stdout-line-count pin in `re-frame.test-quiet-pin-test` drives a
   green sub-suite through `clojure.test/run-tests` directly — it never
@@ -27,12 +27,10 @@
    - RED:   exit 1; the per-ns `Testing <ns>` banner + the `FAIL`
      block + `expected:`/`actual:` lines are present (diagnostic
      output survives the `*out*` swap via `with-test-out`); the
-     discovery banner is STILL absent (swallowed unconditionally, not
-     replayed on red — the documented capture-and-replay was
-     unreachable and the docs now match this).
+     discovery banner is still absent.
    - ERROR: exit 1; the `ERROR in` block + the thrown message reach
      stdout.
-   - STDERR BUFFER (rf2-nrk066): a GREEN run that emits expected
+   - STDERR BUFFER: a green run that emits expected
      stderr warnings stays quiet (the warnings are buffered + dropped);
      a RED run REPLAYS the buffered stderr context so a failing run
      keeps it.  This is the JVM counterpart to the CLJS node runner's
@@ -77,36 +75,25 @@
   "Shared ceiling for a drained subprocess.  A correctly-exiting child
   returns in well under a second; this generous bound makes a wedged
   child FAIL with a structured `:timed-out?` diagnostic instead of
-  hanging the whole JVM suite (rf2-8dfq5j.3)."
+  hanging the whole JVM suite."
   60000)
 
 (def ^:private force-kill-reap-timeout-ms
-  "Bounded ceiling to wait for a force-killed child to actually be REAPED
-  after `destroyForcibly` (rf2-5m8ocd, porting rf2-16n94y).  `Process.
-  destroyForcibly` only *requests* forced termination — the JDK docs
-  explicitly allow the child to remain alive briefly after the call and
-  direct callers that need termination to have COMPLETED to `waitFor`.
-  Without this wait the timeout branch could return `:timed-out? true`
-  while the OS had not yet reaped the child, so a caller checking
-  `.isAlive` immediately (the `drain-process-kills-and-flags-a-hanging-child`
-  contract below) lost the reap race on a loaded CI runner — a residual
-  intermittent test-quiet flake.  A SIGKILLed child is normally reaped in
-  milliseconds; this generous bound only bites a pathologically
-  unkillable child, and even then keeps the helper bounded (well under
-  the outer 30s contract-test guard and the CI job timeout).  Reached
-  ONLY on the exceptional timeout branch — the fast `done?` path that the
-  ~24 real subprocesses take is untouched."
+  "Bounded wait after `destroyForcibly`. The JDK only requests forced
+  termination, so the timeout path gives the OS time to reap an ordinary
+  child before returning. A pathological child may still outlive this
+  secondary ceiling; the helper remains bounded either way."
   10000)
 
 (defn- drain-process
   "Drain `proc`'s stdout AND stderr concurrently, then `waitFor` UNDER A
   TIMEOUT.  Returns {:exit :out :err :timed-out?}.  The concurrent drain
-  is what `run-runner` relies on to avoid the pipe deadlock (rf2-spzkgo);
+  is what `run-runner` relies on to avoid a pipe deadlock;
   this helper is the shared primitive every subprocess path uses, so the
   deadlock regression proves the EXACT drain order the real harness
   ships.
 
-  The timeout/kill policy lives HERE (rf2-8dfq5j.3) so EVERY subprocess
+  The timeout/kill policy lives here so every subprocess
   test inherits fail-fast behaviour: on expiry the child is force-killed
   (`destroyForcibly`), the drain threads are interrupted, and the result
   carries `:timed-out? true` plus whatever stdout/stderr drained before
@@ -125,10 +112,8 @@
          ;; the drain threads so neither this helper nor the futures hang.
          (.destroyForcibly proc)
          ;; `destroyForcibly` only REQUESTS termination; block (bounded)
-         ;; until the OS has actually reaped the child before returning, so
-         ;; `:timed-out? true` never races ahead of the real kill and a
-         ;; caller's immediate `.isAlive` check is reliable (rf2-5m8ocd,
-         ;; porting rf2-16n94y).
+         ;; for the OS to reap an ordinary child before returning. The wait
+         ;; remains bounded for a pathological child.
          (.waitFor proc force-kill-reap-timeout-ms
                    java.util.concurrent.TimeUnit/MILLISECONDS)
          (future-cancel out-f)
@@ -158,7 +143,7 @@
         proc     (-> (ProcessBuilder. ^java.util.List cmd)
                      (.redirectErrorStream false)
                      (.start))]
-    ;; Drain stdout AND stderr CONCURRENTLY (rf2-spzkgo): with separate
+    ;; Drain stdout and stderr concurrently: with separate
     ;; pipes, slurping stdout fully and only THEN reading stderr can
     ;; deadlock — a child that fills the stderr pipe blocks on write (so
     ;; it never closes stdout / exits), while the parent blocks on stdout
@@ -205,19 +190,18 @@
               (str "green stdout must carry the summary line; got:\n" out)))))))
 
 ;; ----------------------------------------------------------------------
-;; Exact green stdout shape — no banner-leading-blank leak (rf2-khecvs).
+;; Exact green stdout shape.
 ;;
 ;; cognitect's banner is `\nRunning tests in #{...}\n` — it opens with a
 ;; BLANK LINE.  Dropping only the `Running tests in #{...}` text left that
 ;; leading newline behind, so a green real `-main` run started with TWO
-;; blank lines before the summary (the banner's leak + clojure.test's own
-;; leading `\n` on the `:summary` line). The line-count pins counted only
-;; NON-blank lines, so they were false-green for this.  This pin asserts
-;; the EXACT line shape: a single leading blank, then the two summary
+;; The filter must remove the banner's leading newline while preserving
+;; clojure.test's own leading `\n` on the `:summary` line. This pin asserts
+;; the exact line shape: a single leading blank, then the two summary
 ;; lines, and no `Running tests in` text anywhere.
 
 (deftest green-runner-exact-shape
-  (testing "a green real -main run has no leaked banner-leading blank line (rf2-khecvs)"
+  (testing "a green real -main run has no leaked banner-leading blank line"
     (with-fixture-dir
       (fn [dir]
         (write-fixture! dir "exact_green_fixture_test" "exact-green-fixture-test"
@@ -232,17 +216,15 @@
           (is (not (str/includes? out "Running tests in"))
               (str "no part of the discovery banner — not even its text —"
                    " may reach stdout; got:\n" out))
-          ;; The CORE of rf2-khecvs: the first line is the summary's own
-          ;; single leading blank; the SECOND line is already the `Ran`
-          ;; line. Pre-fix, line 0 AND line 1 were both blank (the banner's
-          ;; leaked leading newline sat above the summary's own).
+          ;; The first line is the summary's own leading blank; the second
+          ;; line is already the `Ran` line.
           (is (str/blank? (nth lines 0 nil))
               (str "the canonical summary opens with one leading blank;"
                    " got lines:\n" (pr-str lines)))
           (is (str/starts-with? (str (nth lines 1 "")) "Ran ")
               (str "the SECOND line must be the `Ran ...` summary — a"
                    " second leading blank means the banner's leading"
-                   " newline leaked (rf2-khecvs); got lines:\n"
+                   " newline leaked; got lines:\n"
                    (pr-str lines)))
           ;; And the full non-blank shape is exactly the canonical two.
           (let [non-blank (remove str/blank? lines)]
@@ -305,14 +287,13 @@
                    " captured stdout:\n" out)))))))
 
 ;; ----------------------------------------------------------------------
-;; Exit-code integrity for failures that ESCAPE clojure.test's counters —
-;; rf2-jmrdhn.
+;; Exit-code integrity for failures that escape clojure.test's counters.
 ;;
 ;; `red-runner-contract` / `error-runner-contract` above pin the COUNTED
 ;; paths (a failing `is`, a throwing `is`) — clojure.test tallies those and
-;; cognitect exits 1 from the tally.  But the false-green trap the bead
-;; closes is a failure that clojure.test NEVER counts, so a naive runner
-;; could print/emit the problem yet exit 0.  Two such cases exist on the JVM
+;; cognitect exits 1 from the tally. Failures that clojure.test never counts
+;; still propagate out of `-main` and must produce a nonzero process exit.
+;; Two such cases exist on the JVM
 ;; and MUST still exit non-zero:
 ;;   - a namespace that THROWS at load time (cognitect `require`s it during
 ;;     discovery, so the throw is outside any `is`/report);
@@ -322,7 +303,7 @@
 ;; pins that no counter-escaping failure can slip out GREEN.
 
 (deftest namespace-load-throw-exits-nonzero
-  (testing "a test ns that throws at LOAD time exits non-zero (uncounted failure; rf2-jmrdhn)"
+  (testing "a test ns that throws at load time exits nonzero"
     (with-fixture-dir
       (fn [dir]
         (write-raw-fixture! dir "load_throw_test"
@@ -342,7 +323,7 @@
           ;; failure, but it MUST still fail the process.
           (is (not (zero? exit))
               (str "a namespace that throws at load time must exit NON-ZERO"
-                   " even though clojure.test never counts it (rf2-jmrdhn);"
+                   " even though clojure.test never counts it;"
                    " got exit " exit "\n--- stdout ---\n" out
                    "\n--- stderr ---\n" err))
           (is (str/includes? (str out err) "LOAD-THROW-MARKER")
@@ -351,7 +332,7 @@
                    "\n--- stderr ---\n" err)))))))
 
 (deftest once-fixture-throw-exits-nonzero
-  (testing "a :once fixture that throws exits non-zero (uncounted failure; rf2-jmrdhn)"
+  (testing "a :once fixture that throws exits nonzero"
     (with-fixture-dir
       (fn [dir]
         (write-raw-fixture! dir "fixture_throw_test"
@@ -369,36 +350,29 @@
           (is (not (zero? exit))
               (str "a :once fixture that throws must exit NON-ZERO even though"
                    " its exception is never tallied as a test error"
-                   " (rf2-jmrdhn); got exit " exit "\n--- stdout ---\n" out
+                   "; got exit " exit "\n--- stdout ---\n" out
                    "\n--- stderr ---\n" err))
           (is (str/includes? (str out err) "FIXTURE-THROW-MARKER")
               (str "the fixture exception message must surface; got"
                    "\n--- stdout ---\n" out "\n--- stderr ---\n" err)))))))
 
 ;; ----------------------------------------------------------------------
-;; Nested-run banner correctness — rf2-8n97n.1 (mislabel) + .2 (orphan).
+;; Nested-run banner correctness.
 ;;
 ;; A `deftest` that nests a `run-tests` over a sibling namespace and then
 ;; fails must still print `Testing <OUTER-ns>` above its own FAIL block.
-;; Pre-fix, a single mutable "current ns" cell — clobbered by the nested
-;; run's `:begin-test-ns` — produced one of two broken outputs:
-;;   .1 MISLABEL: the OUTER failure printed under `Testing <INNER-ns>`;
-;;   .2 ORPHAN:   when the nested run was itself RED, the inner :fail set
-;;                the printed-flag, so the OUTER failure printed with NO
-;;                banner at all.
-;; The fix derives the banner ns from the FAILING var's metadata, so the
-;; banner always matches the var that failed regardless of nesting.
+;; Deriving the banner namespace from the failing var prevents the nested
+;; run's `:begin-test-ns` from mislabelling or orphaning the outer failure.
 ;;
 ;; These run through the REAL `-main` with source-ordered real deftest
 ;; vars (the inner suite nests BEFORE the outer assertion in source
-;; order), so they are immune to the ns-interns hashmap-ordering artifact
-;; that made an earlier ad-hoc repro look "correct".  The inner suite is
+;; order), so they do not depend on `ns-interns` hash-map ordering. The inner suite is
 ;; named `*-suite` (not `*-test`) so cognitect's default discovery skips
 ;; it as a top-level ns — it is exercised only via the outer's nested
 ;; `run-tests` — and the run is pinned to the outer ns with `-n`.
 
 (deftest nested-green-then-outer-fail-banner
-  (testing "outer fail after a GREEN nested run names the OUTER ns (rf2-8n97n.1)"
+  (testing "outer fail after a green nested run names the outer namespace"
     (with-fixture-dir
       (fn [dir]
         (write-raw-fixture! dir "nested_green_inner_suite"
@@ -421,19 +395,18 @@
                    "\n--- stdout ---\n" out "\n--- stderr ---\n" err))
           (is (str/includes? out "FAIL in (outer-fails-after-green)")
               (str "the outer FAIL block must reach stdout; got:\n" out))
-          ;; The CORE of rf2-8n97n.1: the banner above the OUTER failure
-          ;; must name the OUTER ns, not the inner one the nested run
-          ;; entered last.
+          ;; The outer failure must use the outer banner, not the namespace
+          ;; most recently entered by the nested run.
           (is (str/includes? out "Testing probe.nested-green-outer-test")
               (str "the outer FAIL must carry its OWN ns banner"
-                   " (rf2-8n97n.1 mislabel); got:\n" out))
+                   "; got:\n" out))
           (is (not (str/includes? out "Testing probe.nested-green-inner-suite"))
               (str "a GREEN nested run must stay silent — its inner ns"
                    " banner must NOT appear (and must not be borrowed by"
                    " the outer failure); got:\n" out)))))))
 
 (deftest nested-red-then-outer-fail-banner
-  (testing "outer fail after a RED nested run keeps BOTH banners correct (rf2-8n97n.2)"
+  (testing "outer fail after a red nested run keeps both banners correct"
     (with-fixture-dir
       (fn [dir]
         (write-raw-fixture! dir "nested_red_inner_suite"
@@ -465,12 +438,11 @@
           ;; reads for the banner ns.
           (is (str/includes? out "inner-fails) (nested_red_inner_suite.clj")
               (str "the inner FAIL block must reach stdout; got:\n" out))
-          ;; The CORE of rf2-8n97n.2: pre-fix the inner :fail set the
-          ;; printed-flag, orphaning the outer failure (NO banner). The
-          ;; outer FAIL must now carry its OWN ns banner.
+          ;; The inner failure must not mark the outer namespace's banner as
+          ;; already printed.
           (is (str/includes? out "Testing probe.nested-red-outer-test")
               (str "the outer FAIL must carry its OWN ns banner, not be"
-                   " orphaned (rf2-8n97n.2); got:\n" out))
+                   " orphaned; got:\n" out))
           (is (str/includes? out "FAIL in (outer-fails-after-red)")
               (str "the outer FAIL block must reach stdout; got:\n" out))
           ;; Order pin: the outer banner appears AFTER the inner FAIL
@@ -482,7 +454,7 @@
                    " the OUTER failure, not the inner); got:\n" out)))))))
 
 ;; ----------------------------------------------------------------------
-;; Nested-run failure-tally + exit-code soundness — rf2-8n97n.3.
+;; Nested-run failure tally and exit-code soundness.
 ;;
 ;; The behaviour is currently SOUND (the quiet layer never overrides
 ;; :summary/:pass and counts :fail/:error exactly once); this pins it so a
@@ -494,7 +466,7 @@
 ;; the whole propagation path.
 
 (deftest nested-green-outer-fail-is-counted
-  (testing "an outer FAIL after a GREEN nested run propagates to summary + exit 1 (rf2-8n97n.3a)"
+  (testing "an outer failure after a green nested run propagates to summary and exit 1"
     (with-fixture-dir
       (fn [dir]
         (write-raw-fixture! dir "tally_green_inner_suite"
@@ -521,7 +493,7 @@
                    " (the green nested run adds nothing); got:\n" out)))))))
 
 (deftest nested-inner-fail-does-not-leak-to-outer
-  (testing "an inner FAIL the outer IGNORES does not leak into the outer tally/exit (rf2-8n97n.3b)"
+  (testing "an ignored inner failure does not leak into the outer tally or exit"
     (with-fixture-dir
       (fn [dir]
         ;; The outer deftest nests a RED run but makes NO failing
@@ -552,7 +524,7 @@
                    " failure must not leak into it; got:\n" out)))))))
 
 ;; ----------------------------------------------------------------------
-;; test-ns-hook failure banner — rf2-g92dsm.
+;; test-ns-hook failure banner.
 ;;
 ;; The quiet reporter suppresses `:begin-test-ns` and derives the failure
 ;; banner ns from `*testing-vars*` (the failing var).  But a namespace's
@@ -560,13 +532,13 @@
 ;; place of `test-all-vars`) — runs OUTSIDE `test-var`, so a bare failing
 ;; assertion inside it reports with an EMPTY `*testing-vars*`: the
 ;; var-derived ns is nil and the failure printed with NO banner, violating
-;; the failure-banner contract.  The fix maintains a begin/end ns stack and
+;; the failure-banner contract. A begin/end namespace stack
 ;; falls back to the innermost open ns when no failing var is in scope.
 ;; This pin drives the REAL `-main` against a fixture whose `test-ns-hook`
 ;; fails, and asserts the ns banner is present above the FAIL block.
 
 (deftest test-ns-hook-failure-gets-ns-banner
-  (testing "a failing test-ns-hook (no test-var in scope) still prints its ns banner (rf2-g92dsm)"
+  (testing "a failing test-ns-hook with no test var still prints its namespace banner"
     (with-fixture-dir
       (fn [dir]
         ;; `test-ns-hook` TAKES PRECEDENCE over test-all-vars, so the bare
@@ -588,13 +560,12 @@
           (is (= 1 exit)
               (str "the failing test-ns-hook must exit 1; got " exit
                    "\n--- stdout ---\n" out "\n--- stderr ---\n" err))
-          ;; The CORE of rf2-g92dsm: pre-fix `failing-ns` was nil (no var in
-          ;; scope) so print-banner! no-op'd and the FAIL had no heading. The
-          ;; ns-stack fallback must now supply the banner.
+          ;; With no failing var in scope, the namespace stack supplies the
+          ;; banner.
           (is (str/includes? out "Testing probe.ns-hook-fail-test")
               (str "a failing test-ns-hook must still carry its ns banner —"
                    " the var-derived ns is nil, so the ns-stack fallback must"
-                   " supply it (rf2-g92dsm); got:\n" out))
+                   " supply it; got:\n" out))
           (is (str/includes? out "FAIL in")
               (str "the FAIL block must reach stdout; got:\n" out))
           (is (and (str/includes? out "expected:")
@@ -604,16 +575,10 @@
               (str "the failing summary must reach stdout; got:\n" out)))))))
 
 ;; ----------------------------------------------------------------------
-;; Diagnostics-survive contract — rf2-lbo79.2.
+;; Diagnostics-survive contract.
 ;;
-;; The wrapper used to bind `*out*` to a blanket SINK for the whole
-;; delegated `cognitect.test-runner/-main` call, which silenced far more
-;; than the discovery banner: `-H` usage text, CLI parse-error
-;; diagnostics, and bare `(println ...)` from tests/fixtures all
-;; vanished. The fix swaps the sink for a line-precise filter that drops
-;; ONLY the `Running tests in #{...}` banner; everything else reaches the
-;; real stdout. These subprocess pins prove the misuse paths are no
-;; longer opaque while the green-path banner stays quiet.
+;; The line-precise filter drops only `Running tests in #{...}`. Help,
+;; parse-error diagnostics, and test output must still reach stdout.
 
 (deftest help-flag-prints-usage
   (testing "-H prints cognitect usage and exits 0 (was swallowed by the old *out* sink)"
@@ -648,7 +613,7 @@
               (str "cognitect prints usage after the parse error; got:\n" out)))))))
 
 (deftest test-stdout-survives-on-green
-  (testing "bare (println ...) from a passing test reaches stdout; banner stays quiet (rf2-lbo79.2)"
+  (testing "bare test output reaches stdout while the banner stays quiet"
     (with-fixture-dir
       (fn [dir]
         (write-fixture! dir "stdout_green_fixture_test" "stdout-green-fixture-test"
@@ -669,7 +634,7 @@
               (str "the green summary must still print; got:\n" out)))))))
 
 ;; ----------------------------------------------------------------------
-;; Banner-prefix precision — rf2-pjlx6.1.
+;; Banner-prefix precision.
 ;;
 ;; The filter must drop ONLY cognitect's own banner, which always renders
 ;; as `Running tests in #{...}` (the directory set is always a set: it
@@ -680,7 +645,7 @@
 ;; line survives while the real discovery banner is still swallowed.
 
 (deftest banner-lookalike-diagnostic-survives
-  (testing "a test line beginning 'Running tests in ' but NOT the banner survives (rf2-pjlx6.1)"
+  (testing "a test line beginning 'Running tests in ' but not the banner survives"
     (with-fixture-dir
       (fn [dir]
         (write-fixture! dir "lookalike_fixture_test" "lookalike-fixture-test"
@@ -703,22 +668,18 @@
                    " must STILL be swallowed; got:\n" out)))))))
 
 ;; ----------------------------------------------------------------------
-;; Banner-prefix OVERDROP — rf2-14nojy.2.
+;; Banner-prefix overdrop guard.
 ;;
-;; The earlier prefix-precision fix (rf2-pjlx6.1) still dropped a line as
-;; soon as it reached the EXACT prefix `Running tests in #{`, swallowing
-;; everything to the newline.  cognitect prints the banner with `println`,
-;; so the real banner is the WHOLE line and stops at the set literal's
-;; closing `}` — but a user/fixture diagnostic that merely SHARES that
-;; prefix and carries trailing content, e.g.
+;; cognitect's banner is the whole line and stops at the set literal's
+;; closing `}`. A user/fixture diagnostic may share that prefix and carry
+;; trailing content, for example
 ;; `Running tests in #{:fixture :phase} MARKER`, was silently overdropped
-;; even though it is not the banner.  The fix treats a full-prefix match as
-;; a CANDIDATE and confirms it at the newline: drop only when the remainder
-;; is a balanced set literal followed by nothing but whitespace.  This pins
-;; that the overdrop line now SURVIVES while the real banner stays absent.
+;; The filter therefore treats a full-prefix match as a candidate and drops
+;; it only when the remainder is a balanced set literal followed by
+;; whitespace.
 
 (deftest banner-prefix-overdrop-survives
-  (testing "a line starting EXACTLY 'Running tests in #{' with trailing content survives (rf2-14nojy.2)"
+  (testing "a line starting exactly 'Running tests in #{' with trailing content survives"
     (with-fixture-dir
       (fn [dir]
         (write-fixture! dir "overdrop_fixture_test" "overdrop-fixture-test"
@@ -729,19 +690,18 @@
           (is (zero? exit)
               (str "the overdrop suite is green; must exit 0; got " exit
                    "\n--- stdout ---\n" out "\n--- stderr ---\n" err))
-          ;; The CORE of rf2-14nojy.2: a fixture line sharing the EXACT
-          ;; banner prefix but carrying trailing content after the set
-          ;; literal must NOT be swallowed.
+          ;; A fixture line with trailing content after the set literal is
+          ;; not the banner and must be forwarded.
           (is (str/includes? out "Running tests in #{:fixture :phase} OVERDROP-MARKER")
               (str "a fixture line that starts exactly 'Running tests in #{'"
                    " but has trailing content after the set literal is NOT"
-                   " the banner and must survive (rf2-14nojy.2 overdrop);"
+                   " the banner and must survive;"
                    " got:\n" out))
           (is (str/includes? out "0 failures, 0 errors.")
               (str "the green summary must still print; got:\n" out)))))))
 
 (deftest real-banner-still-dropped-alongside-overdrop-lookalike
-  (testing "the real `Running tests in #{...}` discovery banner is STILL dropped (rf2-14nojy.2 negative control)"
+  (testing "the real `Running tests in #{...}` discovery banner is still dropped"
     (with-fixture-dir
       (fn [dir]
         ;; A clean green fixture: the ONLY `Running tests in #{...}` line on
@@ -762,27 +722,21 @@
               (str "no part of the banner may reach stdout; got:\n" out)))))))
 
 ;; ----------------------------------------------------------------------
-;; Banner EXACT-SHAPE overdrop — rf2-m8dbb9.
+;; Exact-shape banner overdrop guard.
 ;;
-;; The rf2-14nojy.2 fix above forwards a banner-shaped line that carries
-;; TRAILING content after the set literal, but a user/fixture line whose
-;; WHOLE text exactly matches the banner — `Running tests in #{:fixture}`
-;; with no trailing marker — was still indistinguishable from cognitect's
-;; own banner and silently overdropped, contradicting the pass-through
-;; stdout contract.  cognitect prints its banner via
+;; A user/fixture line can exactly match `Running tests in #{:fixture}`.
+;; cognitect prints its banner via
 ;; `(format "\nRunning tests in %s" dirs)`, so the genuine banner is ALWAYS
 ;; opened by a leading blank line; a bare `(println "Running tests in
-;; #{:fixture}")` is not.  The fix requires that held leading blank before
-;; dropping a banner-shaped line, so an exact-shape user line printed with
-;; no preceding blank survives while the real banner stays absent.
+;; #{:fixture}")` is not. Requiring that held leading blank distinguishes
+;; the runner banner from an exact-shape user line.
 
 (deftest banner-exact-shape-user-line-survives
-  (testing "an exact-shape `Running tests in #{...}` user line (no trailing marker, no leading blank) survives (rf2-m8dbb9)"
+  (testing "an exact-shape banner user line without a leading blank survives"
     (with-fixture-dir
       (fn [dir]
-        ;; A bare `println` of the EXACT banner shape — no trailing content,
-        ;; no preceding blank line. Pre-fix this was swallowed wholesale; it
-        ;; must now reach stdout because it lacks the banner's leading blank.
+        ;; A bare `println` of the exact banner shape lacks the banner's
+        ;; leading blank and must reach stdout.
         (write-fixture! dir "exact_shape_fixture_test" "exact-shape-fixture-test"
                         (str "(deftest an-exact-shape-test"
                              " (println \"Running tests in #{:fixture}\")"
@@ -791,19 +745,17 @@
           (is (zero? exit)
               (str "the exact-shape suite is green; must exit 0; got " exit
                    "\n--- stdout ---\n" out "\n--- stderr ---\n" err))
-          ;; The CORE of rf2-m8dbb9: a fixture line whose WHOLE text matches
-          ;; the banner shape but is emitted with no leading blank is NOT the
-          ;; banner and must survive.
+          ;; Exact text without the held leading blank is not the banner.
           (is (str/includes? out "Running tests in #{:fixture}")
               (str "an exact-shape user line `Running tests in #{:fixture}`"
                    " printed via bare println (no leading blank) is NOT the"
-                   " cognitect banner and must survive (rf2-m8dbb9); got:\n"
+                   " cognitect banner and must survive; got:\n"
                    out))
           (is (str/includes? out "0 failures, 0 errors.")
               (str "the green summary must still print; got:\n" out)))))))
 
 (deftest real-banner-still-dropped-alongside-exact-shape-user-line
-  (testing "the real banner is STILL dropped even when a fixture also prints an exact-shape line (rf2-m8dbb9 negative control)"
+  (testing "the real banner is still dropped alongside an exact-shape user line"
     (with-fixture-dir
       (fn [dir]
         ;; The fixture prints an exact-shape line of its own; cognitect's
@@ -828,30 +780,20 @@
                    " dropped; got " hits " occurrences:\n" out)))))))
 
 ;; ----------------------------------------------------------------------
-;; Blank-led banner-shape OVER-DROP after the real banner — rf2-6nrk8x.
+;; Blank-led banner shape after the real banner.
 ;;
-;; The rf2-m8dbb9 fix drops a banner-shaped line only when it is preceded
-;; by a held leading blank — but it applied that rule to EVERY blank-led
-;; `Running tests in #{...}` line, not just cognitect's one discovery
-;; banner.  cognitect prints its banner exactly ONCE (via `println`, before
-;; any test runs), so a test that ITSELF prints a blank line then
-;; banner-shaped text — `(println)` then `(println "Running tests in
-;; #{:fixture}")` — matched the same shape and was silently swallowed as a
-;; phantom SECOND banner, losing valid diagnostic stdout and violating the
-;; pass-through contract.  The fix latches `banner-dropped?` when the real
-;; banner is dropped and forwards every later blank-led banner-shaped line.
-;; This pin drives the REAL `-main`: the fixture's blank-led banner-shape
-;; line must survive while cognitect's genuine banner is still dropped.
+;; cognitect prints its banner once, before tests run. `banner-dropped?`
+;; ensures a later user line with the same blank-led shape is forwarded
+;; rather than treated as a second discovery banner.
 
 (deftest blank-led-banner-shape-user-line-survives
-  (testing "a test's own blank-line-then-banner-shape stdout survives after the real banner is dropped (rf2-6nrk8x)"
+  (testing "a test's blank-led banner-shaped output survives after the real banner"
     (with-fixture-dir
       (fn [dir]
         ;; The fixture prints a blank line IMMEDIATELY followed by an
         ;; exact-shape banner line carrying a keyword-set body (distinct from
-        ;; cognitect's own `#{"<dir>"}` string-set banner). Pre-fix, the held
-        ;; leading blank + balanced-set shape made the filter overdrop it as a
-        ;; second banner; post-fix the `banner-dropped?` latch forwards it.
+        ;; cognitect's own `#{"<dir>"}` string-set banner). The latch forwards
+        ;; this later line.
         (write-fixture! dir "blank_led_banner_fixture_test" "blank-led-banner-fixture-test"
                         (str "(deftest a-blank-then-banner-test"
                              " (println)"
@@ -861,12 +803,12 @@
           (is (zero? exit)
               (str "the fixture is green; must exit 0; got " exit
                    "\n--- stdout ---\n" out "\n--- stderr ---\n" err))
-          ;; The CORE of rf2-6nrk8x: the test's OWN blank-led banner-shape
+          ;; The test's own blank-led banner-shape
           ;; line is genuine stdout and must reach the real stdout.
           (is (str/includes? out "Running tests in #{:user-diagnostic}")
               (str "a test's blank-line-then-banner-shape stdout must survive"
                    " once cognitect's one banner has already been dropped"
-                   " (rf2-6nrk8x over-drop); got:\n" out))
+                   "; got:\n" out))
           ;; cognitect's genuine banner renders the DIR set as a string set —
           ;; `#{\"<dir>\"}` — so `Running tests in #{\"` uniquely identifies
           ;; it. Its absence proves the real banner was STILL dropped (the
@@ -881,18 +823,17 @@
               (str "the green summary must still print; got:\n" out)))))))
 
 ;; ----------------------------------------------------------------------
-;; Unterminated-partial survival across System/exit — rf2-pjlx6.2.
+;; Unterminated partial survival across System/exit.
 ;;
 ;; cognitect exits straight from the computed fail/error counts, so the
 ;; wrapper's `finally` flush never runs on the test path.  A bare
 ;; `(print ...)` with no trailing newline AND no explicit flush must still
 ;; reach stdout: the filter forwards non-banner text eagerly (it only ever
 ;; holds back a live banner-prefix candidate) and `-main` registers a JVM
-;; shutdown hook that flushes the filtering writer.  Pre-fix, such a
-;; partial sat in the wrapper's line buffer and was lost at exit.
+;; shutdown hook that flushes any held candidate.
 
 (deftest unterminated-partial-survives-exit
-  (testing "a bare (print ...) with no newline/flush reaches stdout before System/exit (rf2-pjlx6.2)"
+  (testing "a bare print with no newline or flush reaches stdout before System/exit"
     (with-fixture-dir
       (fn [dir]
         ;; No trailing newline, no (flush) — the worst case the finding
@@ -913,7 +854,7 @@
               (str "the green summary must still print; got:\n" out)))))))
 
 ;; ----------------------------------------------------------------------
-;; Central stderr buffer + red replay — rf2-nrk066.
+;; Central stderr buffer + red replay.
 ;;
 ;; The JVM runner buffers everything written to `*err*` (and `System/err`)
 ;; during the delegated run into a bounded ring, then:
@@ -930,12 +871,11 @@
 ;; just before the runner exits).
 
 (deftest green-run-buffers-and-drops-expected-stderr
-  (testing "a GREEN run that writes expected stderr stays quiet — the warning is buffered, not leaked (rf2-nrk066)"
+  (testing "a green run that writes expected stderr stays quiet"
     (with-fixture-dir
       (fn [dir]
-        ;; A passing test that emits an expected warning to *err* — exactly
-        ;; the class warning-heavy suites used to wrap in a private *err*
-        ;; sink. With the central buffer it must be DROPPED on green.
+        ;; A passing test emits an expected warning to *err*. The central
+        ;; buffer must drop it on green.
         (write-fixture! dir "green_warn_fixture_test" "green-warn-fixture-test"
                         (str "(deftest a-warning-but-passing-test"
                              " (binding [*out* *err*]"
@@ -949,13 +889,13 @@
           ;; so it appears on NEITHER stdout NOR stderr.
           (is (not (str/includes? (str out err) "EXPECTED-WARN-MARKER-GREEN"))
               (str "an expected stderr warning on a GREEN run must be buffered"
-                   " and dropped — not leaked to stdout or stderr (rf2-nrk066);"
+                   " and dropped - not leaked to stdout or stderr;"
                    " got\n--- stdout ---\n" out "\n--- stderr ---\n" err))
           (is (str/includes? out "0 failures, 0 errors.")
               (str "the green summary must still print; got:\n" out)))))))
 
 (deftest red-run-replays-buffered-stderr
-  (testing "a RED run replays the buffered stderr context to real stderr (rf2-nrk066)"
+  (testing "a red run replays buffered stderr context to real stderr"
     (with-fixture-dir
       (fn [dir]
         ;; A test that emits a diagnostic to *err* and then FAILS. The
@@ -978,18 +918,18 @@
           ;; stderr) so the failing run keeps the diagnostic context.
           (is (str/includes? err "EXPECTED-WARN-MARKER-RED")
               (str "the buffered stderr must be REPLAYED on a RED run"
-                   " (rf2-nrk066); got\n--- stdout ---\n" out
+                   "; got\n--- stdout ---\n" out
                    "\n--- stderr ---\n" err))
           (is (str/includes? err "buffered stderr replayed because the run was RED")
               (str "the replay must be labelled so it is distinguishable from"
                    " the reporter's own output; got stderr:\n" err)))))))
 
 ;; ----------------------------------------------------------------------
-;; Subprocess-harness pipe-deadlock regression — rf2-spzkgo.
+;; Subprocess-harness pipe-deadlock guard.
 ;;
 ;; The harness drains a child's stdout and stderr on separate threads
-;; (see `drain-process` / `run-runner`).  Pre-fix it slurped stdout to
-;; EOF and only THEN read stderr: a child that fills the stderr pipe
+;; (see `drain-process` / `run-runner`). A sequential stdout-then-stderr
+;; drain deadlocks when a child fills the stderr pipe
 ;; buffer (~64 KB on most OSes) blocks on its stderr write before
 ;; closing stdout, so the parent — still blocked on stdout EOF — never
 ;; reaches the stderr drain or `waitFor`, and both hang forever.
@@ -1006,7 +946,7 @@
   (* 1024 1024))
 
 (deftest harness-does-not-deadlock-on-large-stderr
-  (testing "a child flooding stderr while exiting nonzero is drained without deadlock (rf2-spzkgo)"
+  (testing "a child flooding stderr while exiting nonzero is drained without deadlock"
     (with-fixture-dir
       (fn [dir]
         ;; The child program is written to a FILE rather than passed via
@@ -1043,7 +983,7 @@
             (is (not= ::timed-out result)
                 (str "the harness deadlocked: a >pipe-buffer stderr flood with a"
                      " sequential (stdout-then-stderr) drain hangs forever"
-                     " (rf2-spzkgo) — it must drain both streams concurrently"))
+                     " - it must drain both streams concurrently"))
             (when (not= ::timed-out result)
               (let [{:keys [exit out err timed-out?]} result]
                 (is (false? timed-out?)
@@ -1061,7 +1001,7 @@
                          " bytes, expected >= " big-stderr-bytes))))))))))
 
 ;; ----------------------------------------------------------------------
-;; Shared drain timeout/kill policy — rf2-8dfq5j.3.
+;; Shared drain timeout/kill policy.
 ;;
 ;; `drain-process` carries the timeout/kill policy so EVERY subprocess
 ;; path (the real `run-runner`, the deadlock regression, future helpers)
@@ -1072,7 +1012,7 @@
 ;; cannot silently reintroduce an unbounded hang.
 
 (deftest drain-process-kills-and-flags-a-hanging-child
-  (testing "a child that never exits is force-killed and flagged timed-out (rf2-8dfq5j.3)"
+  (testing "a child that never exits is force-killed and flagged timed out"
     (with-fixture-dir
       (fn [dir]
         ;; A child that blocks forever with no output and no exit path —
@@ -1095,7 +1035,7 @@
                 result   (deref result-f 30000 ::outer-timeout)]
             (is (not= ::outer-timeout result)
                 (str "the helper itself hung: `drain-process` must enforce its"
-                     " own `.waitFor` timeout and return promptly (rf2-8dfq5j.3)"))
+                     " own `.waitFor` timeout and return promptly"))
             (when (not= ::outer-timeout result)
               (is (true? (:timed-out? result))
                   (str "a never-exiting child must be flagged `:timed-out? true`;"
@@ -1108,7 +1048,7 @@
             (.destroyForcibly proc)))))))
 
 ;; ----------------------------------------------------------------------
-;; Stderr ring is BOUNDED — front-trim keeps the newest cap — rf2-hd3t77.
+;; Stderr ring is bounded: front trimming keeps the newest characters.
 ;;
 ;; `stderr-buffer-cap` is 256 KB and `buffering-stderr-writer` front-trims
 ;; (`(.delete sb 0 (- n cap))`) so the ring retains the NEWEST `cap`
@@ -1124,7 +1064,7 @@
 ;; marker happened to be absent.
 
 (deftest stderr-ring-front-trims-to-newest-cap-on-red
-  (testing "an *err* flood past the 256 KB cap keeps the NEWEST cap chars, drops the oldest (rf2-hd3t77)"
+  (testing "an *err* flood past the 256K-character cap keeps the newest characters"
     (with-fixture-dir
       (fn [dir]
         ;; ~600 KB of filler (2000 lines x ~300 chars) brackets a HEAD
@@ -1150,12 +1090,12 @@
           ;; NEWEST retained: the tail marker written last survives the ring.
           (is (str/includes? err "TAIL-MARKER-NEWEST-MUST-SURVIVE")
               (str "the NEWEST bytes must be retained by the front-trim ring"
-                   " (rf2-hd3t77); tail marker missing. stderr length="
+                   "; tail marker missing. stderr length="
                    (count err)))
           ;; OLDEST dropped: the head marker written first is trimmed away.
           (is (not (str/includes? err "HEAD-MARKER-OLDEST-MUST-BE-DROPPED"))
               (str "the OLDEST bytes must be front-trimmed once past the "
-                   cap "-char cap (rf2-hd3t77); the head marker leaked, so"
+                   cap "-char cap; the head marker leaked, so"
                    " the ring either did not trim or trimmed the WRONG end."
                    " stderr length=" (count err)))
           ;; BOUNDED: the replay is ~cap + the fixed label, NOT the full
@@ -1163,28 +1103,20 @@
           ;; front-trim, (count err) would be ~600 KB.
           (is (< (count err) (+ cap 4096))
               (str "the replayed stderr must be bounded to ~" cap " chars +"
-                   " the replay label (rf2-hd3t77); an unbounded ring would"
+                   " the replay label; an unbounded ring would"
                    " replay the whole ~600 KB flood. got " (count err)
                    " chars")))))))
 
 ;; ----------------------------------------------------------------------
-;; Raw `System.err` bridge is buffered too — rf2-hd3t77.
+;; Raw `System.err` bridge is buffered too.
 ;;
 ;; `-main` swaps `System/setErr` for a `PrintStream` over an
 ;; `OutputStream` proxy that routes raw `System.err` bytes into the SAME
-;; ring as `*err*` (runner.clj sys-bridge), with a documented restore in
-;; the `finally`.  Both existing stderr pins write via
-;; `(binding [*out* *err*] (println ...))` — i.e. through the `*err*`
-;; `PrintWriter`, NEVER raw `System/err` — so the bridge OutputStream and
-;; its `write(byte[],off,len)` decoding arity were entirely unexercised
-;; and the docstring claim "a library that writes System.err directly is
-;; buffered too" was unbacked.  These two pins write via
-;; `(.println System/err ...)` (the bridge's multi-byte arity) and assert
-;; the raw-`System.err` payload is buffered+dropped on green / replayed on
-;; red — exactly the `*err*`-path contract, now proven for the raw path.
+;; ring as `*err*`. These pins write via `(.println System/err ...)` and
+;; assert the raw payload is dropped on green and replayed on red.
 
 (deftest raw-system-err-buffered-and-dropped-on-green
-  (testing "a GREEN run that writes RAW System.err stays quiet — the bridge buffers + drops it (rf2-hd3t77)"
+  (testing "a green run drops raw System.err through the bridge"
     (with-fixture-dir
       (fn [dir]
         (write-fixture! dir "raw_syserr_green_fixture_test" "raw-syserr-green-fixture-test"
@@ -1200,13 +1132,13 @@
           ;; from BOTH streams (proving the bridge, not just the *err* path).
           (is (not (str/includes? (str out err) "RAW-SYSERR-MARKER-GREEN"))
               (str "a raw System.err write on a GREEN run must be buffered by"
-                   " the setErr bridge and dropped — not leaked (rf2-hd3t77);"
+                   " the setErr bridge and dropped - not leaked;"
                    " got\n--- stdout ---\n" out "\n--- stderr ---\n" err))
           (is (str/includes? out "0 failures, 0 errors.")
               (str "the green summary must still print; got:\n" out)))))))
 
 (deftest raw-system-err-replayed-on-red
-  (testing "a RED run replays RAW System.err context via the setErr bridge (rf2-hd3t77)"
+  (testing "a red run replays raw System.err through the bridge"
     (with-fixture-dir
       (fn [dir]
         (write-fixture! dir "raw_syserr_red_fixture_test" "raw-syserr-red-fixture-test"
@@ -1223,7 +1155,7 @@
           ;; bridge into the ring, is REPLAYED to real stderr on red.
           (is (str/includes? err "RAW-SYSERR-MARKER-RED")
               (str "a raw System.err write must be buffered by the setErr"
-                   " bridge and REPLAYED on a RED run (rf2-hd3t77); got"
+                   " bridge and replayed on a red run; got"
                    "\n--- stdout ---\n" out "\n--- stderr ---\n" err))
           (is (str/includes? err "buffered stderr replayed because the run was RED")
               (str "the replay must be labelled; got stderr:\n" err)))))))

--- a/implementation/test-quiet/test/re_frame/test_quiet_shadow_node_cljs_test.cljs
+++ b/implementation/test-quiet/test/re_frame/test_quiet_shadow_node_cljs_test.cljs
@@ -1,13 +1,11 @@
 (ns re-frame.test-quiet-shadow-node-cljs-test
   "Contract pin for the CLJS `:node-test` entry point
-  `re-frame.test-quiet.shadow-node` (rf2-vespg).
+  `re-frame.test-quiet.shadow-node`.
 
   The shadow-node runner carries custom CLI parsing, var-filtering, an
-  exit-code defmethod, and a global `console.warn` stub — none of which
-  had coverage.  This namespace pins the surfaces that can be exercised
-  in-process; the two that cannot (`st/run-all-tests` discovery and the
-  `js/process.exit` calls) are pinned at the level of the pure decision
-  they branch on, since calling them would tear down the node runner.
+  exit-code defmethod, and a global `console.warn` stub. This namespace
+  pins pure helpers in-process and uses child processes for discovery and
+  exit paths that would tear down the current node runner.
 
   Contracts pinned:
 
@@ -15,28 +13,26 @@
      namespace selectors and qualified symbols are single-var
      selectors; `--list` / `--help` flags; unknown args are COLLECTED by
      the pure parser (into `:unknown-args`) and rejected as a fatal parse
-     error by `execute-cli` (rf2-14nojy.1) — the process-level pins below
+     error by `execute-cli`; the process-level pins below
      prove that boundary.
    - FAILURE EXIT: the `:end-run-tests` defmethod exits 0 iff the
-     summary is `cljs.test/successful?`, 1 otherwise — pinned via the
-     predicate the defmethod branches on (calling the defmethod itself
-     would `process.exit` and kill this runner).
+     summary is `cljs.test/successful?`, 1 otherwise. The predicate is
+     unit-pinned and child-process tests cover the real exit boundary.
    - console.warn CAPTURE COMPAT: the ns-load `console.warn` stub does
      not break the local save/shim/restore capture pattern that
      warning-assertion tests use — a shim installed over the stub still
      records, and restore reverts to the stub.
 
-  NESTED-RUN BANNER (rf2-8n97n.1/.2) — JVM-ONLY SCOPE: the nested-run
-  banner-correctness regressions live in the JVM
+  Nested-run banner coverage is JVM-only. Those tests live in the JVM
   `re-frame.test-quiet-runner-contract-test`, not here.  A nested
   `cljs.test/run-tests` cannot be exercised in-process under this
   runner: `run-tests` is block-based/async and unconditionally fires
   `:end-run-tests`, which shadow-node overrides to `js/process.exit`
-  (see `end-run-tests-exit-decision` above) — a nested run would tear
-  down the node runner before the outer assertion. The FIX is shared
+  (see `end-run-tests-exit-decision` below) — a nested run would tear
+  down the node runner before the outer assertion. The implementation is shared
   CLJC (the banner ns is derived from the failing var's metadata, not a
   clobberable global cell), so the CLJS reporter benefits identically
-  for sequential runs; only the nesting REGRESSION is JVM-scoped."
+  for sequential runs; only the nesting test is JVM-scoped."
   ;; NB: must NOT require re-frame.test-quiet.shadow-node — that ns is
   ;; `:dev/always` and expands the test-ns-enumeration macro, so a test
   ;; requiring it forms a compile cycle. Pure CLI parsing lives in the
@@ -77,11 +73,11 @@
   (testing "unknown args are collected (not printed); the pure parser does not abort"
     ;; The pure parser must NOT print on an unknown arg — it collects
     ;; them into `:unknown-args` and the real CLI path (`execute-cli`)
-    ;; reports them and exits NONZERO (rf2-14nojy.1, pinned at the process
-    ;; boundary below). Keeping the PARSER pure-and-silent is what keeps
+    ;; reports them and exits nonzero, pinned at the process boundary below.
+    ;; Keeping the parser pure and silent is what keeps
     ;; the green-run contract gate truly silent-on-success: a
     ;; `(println \"Unknown arg: ...\")` here would leak a non-summary line
-    ;; into every consolidated `npm run test:cljs` run (rf2-spzkgo).
+    ;; into every consolidated `npm run test:cljs` run.
     (is (= {:test-syms '[ok.ns] :unknown-args ["--bogus"]}
            (cli/parse-args ["--bogus" "--test=ok.ns"]))
         "an unknown flag is collected; later valid flags still parse")
@@ -92,21 +88,19 @@
         "a clean arg set carries no :unknown-args key at all")))
 
 ;; ----------------------------------------------------------------------
-;; Warning-ring memory bound — rf2-6emzlh.
+;; Warning-ring entry-count and backing-vector bound.
 ;;
-;; The buffered-`console.warn` ring claims to cap memory to the newest
-;; `warn-buffer-cap` warnings.  The pre-fix trim used `subvec`, which in
-;; ClojureScript shares — and thereby RETAINS — its entire underlying
+;; The buffered-`console.warn` ring retains the newest `warn-buffer-cap`
+;; calls. Individual arguments are not byte-bounded. A `subvec` in
+;; ClojureScript shares and retains its underlying
 ;; vector via `.-v` (and `conj`-ing onto a `Subvec` grows that underlying
-;; vector), so every discarded warning stayed alive until process exit and
-;; the "bound" leaked without limit.  `warn-buffer/bound-conj` now
-;; materialises the trimmed window into a fresh `PersistentVector`.  This
-;; is an in-memory STRUCTURAL property (the backing must not be a growing
+;; vector), so the helper materialises the trimmed window into a fresh
+;; `PersistentVector`. This is a structural property (the backing must not be a growing
 ;; `Subvec`), so it can only be pinned as a pure unit test — not across the
 ;; process boundary the other shadow-node pins use.
 
 (deftest warn-buffer-is-bounded-and-materialised
-  (testing "bound-conj retains only the newest cap entries as a fresh vector (rf2-6emzlh)"
+  (testing "bound-conj retains only the newest cap entries as a fresh vector"
     ;; Fill FAR past a tiny cap: the ring must report exactly `cap` entries,
     ;; hold the NEWEST ones, and — the core pin — its backing must NOT be a
     ;; Subvec (which would retain the full discarded history via its shared
@@ -120,7 +114,7 @@
       (is (not (instance? cljs.core/Subvec buf))
           (str "the trimmed ring must NOT be a Subvec — a Subvec shares and"
                " retains its full underlying vector, so the bound would leak"
-               " every discarded warning until process exit (rf2-6emzlh)"))
+               " every discarded warning until process exit"))
       (is (instance? cljs.core/PersistentVector buf)
           "the trimmed ring is a materialised PersistentVector, not a view")))
   (testing "below the cap the ring is a plain growing vector (no trim, no Subvec)"
@@ -181,15 +175,11 @@
       (is (= '[] (select '[absent.ns]))))))
 
 ;; ----------------------------------------------------------------------
-;; Unmatched-selector guard (rf2-lbo79.1) — a `--test=<selector>` that
+;; Unmatched-selector guard: a `--test=<selector>` that
 ;; matches NO test var must be rejected, not reported as a 0-test SUCCESS.
 ;;
-;; Pre-fix, `execute-cli` ran `st/run-test-vars` over an empty matched-var
-;; set whenever `test-syms` was non-empty; shadow's runner then reported a
-;; 0-test successful summary and the `:end-run-tests` defmethod exited 0,
-;; so a typo in `npm run test:cljs -- --test=<selector>` silently "passed"
-;; with ZERO tests. The fix computes the unmatched selectors and, when any
-;; exist, prints them and `js/process.exit`s NONZERO before running.
+;; `run-test-vars` over an empty set reports a 0-test success. The runner
+;; must reject unmatched selectors before running.
 ;;
 ;; `cli/unmatched-selectors` is the pure decision `execute-cli` branches
 ;; on — `(seq unmatched) -> exit 1`. It is pinned directly here (the
@@ -208,9 +198,8 @@
       ;; fqn selector matches: my.ns/a-test is in the matched set.
       (is (= '() (cli/unmatched-selectors '[my.ns/a-test] [a-test]))))
     (testing "--test=missing.ns (absent namespace) is reported unmatched -> guard exits nonzero"
-      ;; The CORE false-green case: a typo'd namespace matches zero vars.
-      ;; Pre-fix this ran 0 tests and exited 0; the guard now sees a
-      ;; non-empty unmatched set and the `(seq unmatched)` branch exits 1.
+      ;; A typo'd namespace produces a non-empty unmatched set, which the
+      ;; process-level branch rejects.
       (let [unmatched (cli/unmatched-selectors '[missing.ns] [])]
         (is (= '[missing.ns] unmatched)
             "an absent namespace selector matches nothing -> unmatched")
@@ -303,21 +292,14 @@
         "the silencing stub must accept a bare call without throwing")))
 
 ;; ----------------------------------------------------------------------
-;; Process-level quiet-shape regression (rf2-spzkgo).
+;; Process-level quiet shape.
 ;;
-;; The pure-parser pins above lock that `parse-args` no longer PRINTS on
-;; an unknown arg — but the slice's core promise is that the REAL
-;; shadow-node entry point is silent-on-success.  That promise lived only
-;; in the JVM contract test (`re-frame.test-quiet-runner-contract-test`);
-;; the CLJS process path could regress without any test catching it (a
-;; stray `println`, a dropped console.warn stub, a banner leak).
-;;
-;; This regression spawns the SAME built `out/node-test.js` shadow-node
+;; This test spawns the same built `out/node-test.js` shadow-node
 ;; runner this very process is executing, focused on a known-GREEN suite
 ;; (`re-frame.test-quiet-green-fixture-cljs-test`, a single `is (= 1 1)`),
 ;; captures its stdout, and fails if any green line other than the
-;; allowed canonical summary appears — `Unknown arg`, a `Testing <ns>`
-;; banner, leaked warnings, or any other non-summary text.
+;; allowed canonical summary appears. The `console.warn` stub itself is
+;; pinned separately above because this fixture deliberately emits no warning.
 
 (def ^:private node-child-process (js/require "child_process"))
 
@@ -330,7 +312,7 @@
   "Hard ceiling for a spawned focused runner.  A correctly-exiting child
   returns in well under a second; this generous bound makes a child that
   stops exiting FAIL with a structured `:timed-out?` diagnostic instead
-  of hanging the whole CLJS suite (rf2-8dfq5j.3)."
+  of hanging the whole CLJS suite."
   60000)
 
 (def ^:private spawn-max-buffer-bytes
@@ -355,9 +337,8 @@
      child runs with;
   A shared `:timeout`/`:maxBuffer` policy is applied to EVERY spawn so a
   wedged or runaway child fails fast with a diagnostic rather than
-  stranding the suite (rf2-8dfq5j.3).  On a `spawnSync` timeout the child
-  is sent SIGTERM and `res.signal` is `\"SIGTERM\"`; `:timed-out?`
-  surfaces that for assertions."
+  stranding the suite. `:timed-out?` is derived from a SIGTERM result; callers
+  inspect `:error` to distinguish timeout and output-buffer failures."
   ([argv] (spawn-runner argv {}))
   ([argv {:keys [env]}]
    (let [self     (aget js/process.argv 1)
@@ -381,11 +362,12 @@
       ;; on res.error.
       :error      (.-error res)
       :signal     signal
-      ;; spawnSync kills the child with SIGTERM on a :timeout expiry.
+       ;; A timeout normally yields SIGTERM. This flag is intentionally only
+       ;; a signal shorthand; `:error` carries the precise spawn failure.
       :timed-out? (= signal "SIGTERM")})))
 
 (deftest real-shadow-node-green-run-is-quiet
-  (testing "the real out/node-test.js entry point emits ONLY the canonical summary on a focused green run (rf2-spzkgo)"
+  (testing "the real out/node-test.js entry point emits only the canonical summary on green"
     ;; Re-running the runner focused on the green fixture exercises the real
     ;; CLI path end-to-end.
     (let [green-ns "re-frame.test-quiet-green-fixture-cljs-test"
@@ -399,17 +381,16 @@
       (let [non-blank (->> (str/split-lines stdout)
                            (map str/trim)
                            (remove str/blank?))]
-        ;; The CORE pin: NOT ONE non-summary line. This is what `Unknown
-        ;; arg: --bogus` used to violate before the parser was made pure.
+        ;; No non-summary stdout line is allowed.
         (is (every? #(re-matches allowed-green-line-re %) non-blank)
             (str "a green run must emit ONLY the canonical summary lines —"
                  " any other stdout line (e.g. `Unknown arg`, a `Testing`"
                  " banner, a leaked warning) breaks silent-on-success"
-                 " (rf2-spzkgo). Got non-blank lines:\n"
+                 ". Got non-blank lines:\n"
                  (str/join "\n" non-blank)))
         (is (not (str/includes? stdout "Unknown arg"))
-            (str "the specific rf2-spzkgo regression: `Unknown arg` must"
-                 " NEVER reach a green run's stdout; got:\n" stdout))
+            (str "`Unknown arg` must never reach a green run's stdout; got:\n"
+                 stdout))
         (is (not (str/includes? stdout "Testing "))
             (str "no per-ns banner may leak on green; got:\n" stdout))
         (is (some #(str/starts-with? % "Ran ") non-blank)
@@ -419,28 +400,16 @@
             (str "the green tally line must be present; got:\n" stdout))))))
 
 ;; ----------------------------------------------------------------------
-;; Unknown-arg FALSE-GREEN guard (rf2-14nojy.1) — process-level.
+;; Process-level unknown-arg false-green guard.
 ;;
-;; The pure-parser pins above lock that `parse-args` COLLECTS unknown args
-;; into `:unknown-args` (it no longer prints; rf2-spzkgo).  But the real
-;; FALSE-GREEN lived past the parser, in `execute-cli`: pre-fix it merely
-;; PRINTED the unknowns and then fell through to the `:else`
-;; `run-all-tests` branch whenever no `--test=` selector survived.  A
-;; mistyped focused run — the space-separated `--test missing.ns` (both
-;; tokens unknown, no `--test=` form), or a misspelled flag like
-;; `--tests=foo` — therefore ran the FULL suite and exited GREEN, silently
-;; ignoring the requested selection.  The fix makes unknown args a fatal
-;; parse error: print them and `js/process.exit` NONZERO before running
-;; anything.  These pins drive the REAL runner across a process boundary
-;; (the only place the exit code is observable) and prove the false-green
-;; is closed — with the green-fixture-still-passes negative control that a
-;; correct invocation continues to exit 0.
+;; `parse-args` collects unknown args, and `execute-cli` must reject them
+;; before falling through to `run-all-tests`. These tests exercise the real
+;; process boundary where the exit code is observable.
 
 (deftest unknown-arg-is-fatal-not-false-green
-  (testing "a misspelled selector flag (--tests=...) is fatal, NOT a green full-suite run (rf2-14nojy.1)"
+  (testing "a misspelled selector flag is fatal, not a green full-suite run"
     ;; `--tests=` (note the typo'd plural) is an unknown arg, not the
-    ;; `--test=` selector. Pre-fix it printed `Unknown arg: --tests=...`
-    ;; then ran the whole suite and exited 0. It must now exit NONZERO.
+    ;; `--test=` selector and must exit nonzero without running tests.
     (let [{status :status stdout :stdout stderr :stderr err :error}
           (spawn-runner ["--tests=re-frame.test-quiet-green-fixture-cljs-test"])]
       (is (nil? err)
@@ -456,10 +425,10 @@
           (str "the suite must NOT have run on an unknown-arg parse error —"
                " a `Ran ...` summary means it fell through to run-all-tests"
                " (the false green); got:\n" stdout))))
-  (testing "space-separated --test <selector> (both tokens unknown) is fatal, NOT a green run (rf2-14nojy.1)"
+  (testing "space-separated --test and selector tokens are fatal unknown args"
     ;; The plausible space-separated form: `--test` and `missing.ns` are
     ;; BOTH unknown args (the parser only recognises the `--test=` glued
-    ;; form), so no selector survives. Pre-fix this ran the full suite green.
+    ;; form), so no selector survives.
     (let [{status :status stdout :stdout stderr :stderr err :error}
           (spawn-runner ["--test" "missing.ns"])]
       (is (nil? err)
@@ -488,10 +457,9 @@
           (str "a clean invocation must emit no `Unknown arg`; got:\n" stdout)))))
 
 (deftest unmatched-selector-is-fatal-at-real-runner
-  (testing "--test=<missing> (a parsed-but-unmatched selector) exits NONZERO at the REAL runner, not just the pure helper (rf2-lbo79.1 boundary)"
-    ;; The unmatched-selector guard was previously pinned only via the pure
-    ;; `cli/unmatched-selectors` helper. This drives it across the REAL
-    ;; process boundary: a well-formed `--test=` selector that matches NO
+  (testing "a parsed but unmatched selector exits nonzero at the real runner"
+    ;; This drives the guard across the process boundary: a well-formed
+    ;; `--test=` selector that matches no
     ;; test var must print the ERROR + exit NONZERO, never a 0-test green.
     (let [{status :status stdout :stdout stderr :stderr err :error}
           (spawn-runner ["--test=definitely.absent.namespace"])]
@@ -510,11 +478,10 @@
                " green; got:\n" stdout)))))
 
 ;; ----------------------------------------------------------------------
-;; console.warn buffer red-replay (rf2-8dfq5j.2).
+;; console.warn buffer red replay.
 ;;
-;; The shadow-node `console.warn` stub no longer DISCARDS warnings on the
-;; success path — it buffers them in a bounded ring and the
-;; `:end-run-tests` reporter replays the buffer to stderr ONLY on a RED
+;; The shadow-node `console.warn` stub buffers warnings in a bounded ring.
+;; The `:end-run-tests` reporter replays the buffer to stderr only on a red
 ;; run, restoring the diagnostic context a failing CLJS run needs.  This
 ;; can only be observed across a process boundary (the replay fires just
 ;; before `js/process.exit`).  We drive the REAL runner against
@@ -525,7 +492,7 @@
 ;; same fixture is green and emits no warning.
 
 (deftest red-run-replays-buffered-console-warn
-  (testing "a RED run replays the buffered console.warn diagnostic (rf2-8dfq5j.2)"
+  (testing "a red run replays the buffered console.warn diagnostic"
     (let [red-ns "re-frame.test-quiet-red-warn-fixture-cljs-test"
           {status :status stdout :stdout stderr :stderr err :error
            timed-out? :timed-out?}
@@ -543,7 +510,7 @@
       ;; output (the replay targets stderr).
       (is (str/includes? (str stdout stderr) "RED-WARN-FIXTURE-MARKER")
           (str "the buffered console.warn must be replayed on a RED run"
-               " (rf2-8dfq5j.2); got\n--- stdout ---\n" stdout
+               "; got\n--- stdout ---\n" stdout
                "\n--- stderr ---\n" stderr))
       (is (str/includes? (str stdout stderr) "[test-quiet] console.warn:")
           (str "the replay must label the buffered warnings; got\n"
@@ -572,7 +539,7 @@
                  " got:\n" (str/join "\n" non-blank)))))))
 
 ;; ----------------------------------------------------------------------
-;; Large red-replay is not truncated by js/process.exit (rf2-4co7oo).
+;; Large red replay is not truncated by js/process.exit.
 ;;
 ;; The red-replay writes to fd 2 synchronously (`fs.writeSync`), NOT the
 ;; async `js/process.stderr.write`, so `js/process.exit 1` fired immediately
@@ -584,12 +551,11 @@
 ;; lost. This drives the REAL runner across a process boundary against the
 ;; ring-cap-filling volume fixture and asserts the NEWEST warning (replayed
 ;; LAST — the exact byte range the async bug drops) survives to the output.
-;; Windows dev-box pipe writes are synchronous, so the pre-fix bug would not
-;; reproduce here, but this pin locks the fix and catches a POSIX (CI)
-;; regression back to the async write.
+;; Synchronous fd writes make the guarantee independent of whether Node's
+;; stderr stream is synchronous for the current host and destination.
 
 (deftest large-red-replay-is-not-truncated
-  (testing "a RED replay that fills the ring to cap with large warnings keeps its TAIL (rf2-4co7oo)"
+  (testing "a red replay that fills the ring with large warnings keeps its tail"
     (let [red-ns "re-frame.test-quiet-red-warn-fixture-cljs-test"
           {status :status stdout :stdout stderr :stderr err :error
            timed-out? :timed-out?}
@@ -611,32 +577,24 @@
       ;; The CORE pin: the NEWEST warning — replayed LAST — is the exact tail
       ;; that an async `process.stderr` + `process.exit` truncation would drop.
       ;; Its presence proves the synchronous `fs.writeSync` replay is not
-      ;; truncated (rf2-4co7oo).
+      ;; truncated.
       (is (str/includes? combined "RED-REPLAY-TAIL-MARKER")
           (str "the TAIL of a large red replay must NOT be truncated by"
                " js/process.exit — fs.writeSync makes the write synchronous"
-               " (rf2-4co7oo); got\n--- stdout ---\n" stdout
+               "; got\n--- stdout ---\n" stdout
                "\n--- stderr ---\n" stderr)))))
 
 ;; ----------------------------------------------------------------------
-;; Exit-code integrity — a printed failure MUST exit non-zero (rf2-jmrdhn).
+;; Exit-code integrity: a printed failure must exit nonzero.
 ;;
-;; The false-green trap the bead closes: the runner PRINTS a failing
-;; assertion but exits 0, so a local gate reads green while CI goes red.
-;; This drives the REAL runner across a process boundary (the only place the
-;; exit code is observable) against a deliberately-failing suite and asserts
-;; BOTH halves at once — the FAIL block reaches stdout AND the process exits
-;; non-zero — so a regression that decouples the two (a swallowed red exit, a
-;; run torn down before the `:end-run-tests` exit fires) is caught. The
-;; negative control proves the exit is tied to the ACTUAL failure, not always
-;; non-zero.
+;; This drives the real runner across a process boundary and asserts both
+;; halves: the failure block reaches stdout and the process exits nonzero.
+;; The negative control proves the exit tracks the actual result.
 
 (deftest deliberately-failing-test-exits-nonzero
-  (testing "a real failing test PRINTS its FAIL block AND exits non-zero (rf2-jmrdhn)"
+  (testing "a real failing test prints its failure block and exits nonzero"
     ;; The armed red fixture runs a genuine `(is (= :expected :actual))` that
-    ;; fails — the ordinary counted-failure path, not an edge case. The whole
-    ;; point of rf2-jmrdhn is that this must NOT be able to print a failure
-    ;; while exiting 0.
+    ;; fails through the ordinary counted-failure path.
     (let [red-ns "re-frame.test-quiet-red-warn-fixture-cljs-test"
           {status :status stdout :stdout stderr :stderr err :error
            timed-out? :timed-out?}
@@ -650,7 +608,7 @@
       (is (and (number? status) (not (zero? status)))
           (str "a deliberately-failing test must exit NON-ZERO — a printed"
                " failure with a 0 exit is the local-green≠CI-red trap"
-               " (rf2-jmrdhn); got status " status
+               "; got status " status
                "\n--- stdout ---\n" stdout "\n--- stderr ---\n" stderr))
       ;; It genuinely RAN (not a false green from running nothing)…
       (is (str/includes? stdout "Ran ")
@@ -661,7 +619,7 @@
       ;; now agree with.
       (is (str/includes? stdout "FAIL in")
           (str "the FAIL block must reach stdout AND the exit must be"
-               " non-zero — the two must never disagree (rf2-jmrdhn); got:\n"
+               " non-zero - the two must never disagree; got:\n"
                stdout))))
   (testing "the SAME fixture is GREEN + exits 0 when unarmed (negative control)"
     ;; Proving the non-zero exit is tied to the ACTUAL failure, not a runner
@@ -680,7 +638,7 @@
           (str "the unarmed fixture prints no failure; got:\n" stdout)))))
 
 ;; ----------------------------------------------------------------------
-;; Shared spawn timeout/output policy (rf2-8dfq5j.3).
+;; Shared spawn timeout/output policy.
 ;;
 ;; The process-level pins above all route through `spawn-runner`, which
 ;; applies a single `:timeout` + `:maxBuffer` policy to every spawn so a
@@ -693,7 +651,7 @@
 ;; the test stays fast.
 
 (deftest spawn-timeout-kills-a-hanging-child
-  (testing "spawnSync timeout terminates a child that never exits (rf2-8dfq5j.3)"
+  (testing "spawnSync timeout terminates a child that never exits"
     (let [;; A child that blocks forever: an idle interval keeps the event
           ;; loop alive with no exit path.
           res (.spawnSync node-child-process
@@ -708,7 +666,7 @@
       ;; forever (the child never exits on its own).
       (is (= "SIGTERM" (.-signal res))
           (str "a hanging child must be SIGTERM-killed on the spawnSync"
-               " timeout (rf2-8dfq5j.3); got signal " (pr-str (.-signal res))
+               " timeout; got signal " (pr-str (.-signal res))
                " status " (pr-str (.-status res))))
       (is (some? (.-error res))
           "spawnSync must surface an ETIMEDOUT-class error on the timeout"))))


### PR DESCRIPTION
## Summary

- tighten comments and docstrings across `implementation/test-quiet`
- remove tracker/history narration and duplicate explanations
- correct reporter, warning-buffer, subprocess, and exit-code claims without changing behavior

## Why

The slice had accumulated long incident histories and several inaccurate statements. In particular, the reporter emits one leading blank plus two nonblank summary lines; browser diagnostics are outside these JVM/node runners; JVM `*err*` capture is thread-bound while `System.err` is process-global; `System.exit` bypasses the restore `finally`; the CLJS warning ring bounds call count rather than bytes; and the `console.warn` stub returns ClojureScript `nil`, not native JavaScript `undefined`.

## Impact

Explanation-only change. Runtime forms and test assertions are unchanged; test descriptions and failure-message prose are shorter and describe current contracts.

## Checks

- `cd implementation/test-quiet && clojure -M:test` (30 tests, 110 assertions)
- `cd implementation && npm run test:cljs -- --test=re-frame.test-quiet-shadow-node-cljs-test` (14 tests, 87 assertions)
- `git diff --check`

The CLJS compile still reports three unrelated pre-existing undeclared-var warnings under `implementation/resources` and `tools/story`.
