### PR TITLE
docs(mcp-base): align comments with contracts

### DIFF
--- a/tools/mcp-base/deps.edn
+++ b/tools/mcp-base/deps.edn
@@ -1,135 +1,28 @@
-;; day8/re-frame2-mcp-base — shared primitives for the re-frame2 MCP
-;; tool pair (re-frame2-pair-mcp, story-mcp). Filed under rf2-vw4sq.
+;; Shared, framework-runtime-free CLJC primitives for
+;; re-frame2-pair-mcp and story-mcp. The base owns common wire
+;; vocabulary and pure transforms; each consumer owns its transport,
+;; registry, result-envelope adapter, and domain-specific cursor shape.
+;; See spec/README.md for the namespace contracts.
 ;;
-;; (Historical: a third server `xray-mcp` was envisaged as part of an
-;; MCP triplet; it was dropped per rf2-hvl1g — AI agent access to Xray
-;; state flows via re-frame2-pair-mcp against the framework-published
-;; Xray runtime API, so a dedicated xray-mcp is unnecessary.)
-;;
-;; ## Why this artefact exists
-;;
-;; The MCP servers in `tools/` consume the same Spec 009
-;; instrumentation API and emit the same Spec / Conventions wire
-;; vocabulary (`:rf.mcp/*` markers, `:rf.size/*` markers, JSON-RPC
-;; error codes, the spec/009 §Privacy `:sensitive?` default-suppress
-;; filter). Each was implementing those primitives privately; this
-;; jar lifts the genuinely-shared pieces into one place so the wire
-;; shapes stay byte-identical across the pair and the agent learns
-;; the vocabulary once.
-;;
-;; What lives here:
-;;   - `vocab.cljc`     — cross-MCP wire-vocabulary constants (the
-;;                        `:rf.mcp/*` and `:rf.size/*` namespaced
-;;                        keywords, JSON-RPC error codes).
-;;   - `sensitive.cljc` — spec/009 §Privacy fail-closed default-suppress
-;;                        filter.
-;;   - `elision.cljc`   — wire-boundary elision-marker walker
-;;                        (`count-elided-markers`, rf2-9fz64).
-;;   - `args.cljc`      — argument-coercion helpers (booleans, limits,
-;;                        keyword reading) used by every MCP tool.
-;;   - `diff_encode.cljc` — path-keyed structural diff for epoch
-;;                          records (rf2-1wdzp), projected into
-;;                          path-headed cluster sections (rf2-qeous).
-;;                          Pinned via Malli `patch-schema` /
-;;                          `patches-schema` / `section-schema` at both
-;;                          the encoder and decoder boundary (rf2-rgg7d)
-;;                          so a future grammar drift trips the gate.
-;;   - `section_grouping.cljc` — patch-list → path-headed cluster
-;;                          sections (rf2-qeous); consumed by
-;;                          diff-encode.
-;;   - `dedup.cljc`     — structural-dedup encode step at the wire
-;;                        boundary (`empty-payload?` / `dedup-value`,
-;;                        rf2-ttspi7). The byte-identical forward
-;;                        direction both servers shared; the inverse
-;;                        (`dedup-expand`) is test-only and stays local
-;;                        to each consumer (see the ns docstring for the
-;;                        placement RULE).
-;;   - `overflow.cljc`  — overflow-marker payload builder (rf2-rvyzy).
-;;   - `cap.cljc`       — two-stage wire-boundary token-budget cap
-;;                        pipeline + `ResultIO` protocol (rf2-eyelu /
-;;                        rf2-ih7g4).
-;;   - `cursor.cljc`    — shared cursor-pagination machinery: base64
-;;                        codec, opaque encode/decode with `::malformed`
-;;                        recovery, `:limit` clamp, `cursor-stale-result`
-;;                        envelope (rf2-ee38b.19). Parameterised by the
-;;                        consumer's payload-shape predicate so each
-;;                        server keeps its own cursor SHAPE.
-;;   - `envelope.cljc`  — indicator-field `with-indicators` splice
-;;                        (`:dropped-sensitive` / `:elided-large`
-;;                        omit-when-zero MUST) + wire-bounded
-;;                        `:rf.mcp/*` marker detection (rf2-ee38b.19).
-;;   - `descriptor_manifest.cljc` — shared tool-descriptor manifest
-;;                        generator + drift-check (rf2-sofwv). Projects
-;;                        each server's tool registry to a byte-stable
-;;                        `tool-descriptors.edn` catalogue and
-;;                        regenerate-and-compare `check` so an
-;;                        added/removed/renamed tool trips a CI gate.
-;;
-;; What deliberately does NOT live here:
-;;   - Wire-transport code (cheshire JSON for story-mcp's JVM-side;
-;;     applied-science.js-interop / npm MCP SDK for re-frame2-pair-mcp's
-;;     CLJS-side). Each consumer terminates its own transport.
-;;   - Tool registry — each MCP server's tools are domain-specific.
-;;
-;; ## Bundle isolation
-;;
-;; Per `tools/README.md` the dependency arrow flows tool →
-;; implementation (never the reverse). This artefact has no
-;; `:local/root` dep on `implementation/`: its sources are
-;; framework-agnostic `.cljc` shapes (the wire vocabulary, the
-;; predicate, the diff algorithm). Consumers add the impl-side dep
-;; themselves.
-;;
-;; The lone external runtime dep is `day8/de-dupe` (rf2-ttspi7) — the
-;; structural-dedup library `dedup.cljc` calls. It is framework-
-;; agnostic (a pure persistent-data-structure walker, `.cljc` both
-;; arms) so it sits cleanly inside the zero-impl-dep rule. Both
-;; consumers already pinned the SAME git tag (`v0.3.0`); the pin moves
-;; here so the two servers can't drift on a dedup-algorithm change.
-;;
-;; ## CLJC
-;;
-;; Sources are `.cljc` so they load identically into the JVM
-;; classpath (story-mcp) and the shadow-cljs CLJS build
-;; (re-frame2-pair-mcp). Most tests target Clojure (test runner via
-;; cognitect-labs/test-runner) — the algorithmic content is platform-
-;; agnostic, so a JVM round-trip is the cheapest gate. The canonical
-;; dedup suite (`dedup_test.cljc`, rf2-ywkiss) is the exception: it runs
-;; on BOTH hosts (JVM `:test` + shadow `cljs-test`) so the wire-boundary
-;; encode step both servers now consume DIRECTLY is proven on each
-;; server's actual runtime.
-;;
-;; ## Release
-;;
-;; Independent cadence from the consumers; ships as
-;; `day8/re-frame2-mcp-base` on Clojars (workflow rewrites
-;; `:local/root` → `:mvn/version` before invoking clein, mirroring
-;; the adapter jars).
+;; Runtime sources must load on both JVM and CLJS and must not depend on
+;; implementation/. `day8/de-dupe` is the only external runtime dep.
+;; The library ships independently as `day8/re-frame2-mcp-base`.
 {:paths ["src"]
  :deps  {org.clojure/clojure {:mvn/version "1.12.0"}
 
-         ;; day8/de-dupe — structural dedup of persistent data structures
-         ;; (rf2-ttspi7 lifts the wire-boundary encode step here from both
-         ;; consumers). The library substitutes repeated subtrees with
+         ;; Structural dedup of persistent data structures. The library
+         ;; substitutes repeated subtrees with
          ;; namespaced-symbol references (`de-dupe.cache/cache-N`); the
          ;; flat cache map round-trips back through `expand` on the agent
          ;; host. `.cljc` both arms, so it loads into story-mcp's JVM
          ;; classpath and re-frame2-pair-mcp's shadow-cljs build alike.
-         ;;
-         ;; Pinned to git-tag `v0.3.0` — the same tag both consumers
-         ;; previously pinned (rf2-obpa9 / rf2-90eft / rf2-nw6sj), so the
-         ;; base + both servers lockstep and can't drift on a dedup-
-         ;; algorithm change. The tag resolves to the peeled commit
-         ;; `367de784faf13c710a895bed867f36a36e594a2a` (tools.deps resolves
-         ;; `:git/tag` against the peeled commit, not the annotated tag
-         ;; object `e5d2465a855b9efbc27f71d508259e8d50da1168`).
          day8/de-dupe        {:git/url "https://github.com/day8/de-dupe.git"
                               :git/tag "v0.3.0"
                               :git/sha "367de784faf13c710a895bed867f36a36e594a2a"}}
 
  :aliases
- ;; metosin/malli is TEST-ONLY (rf2-rgg7d). mcp-base's runtime sources
- ;; stay Malli-free at the dep boundary; the encoder's validation gate
+ ;; Malli is test-only. mcp-base's runtime sources stay Malli-free at
+ ;; the dep boundary; the encoder's validation gate
  ;; (`diff-encode/validate-patches!`) resolves `malli.core/validate` at
  ;; runtime via `requiring-resolve` / `resolve` and soft-passes when
  ;; Malli is absent. The test alias here puts Malli on the classpath so
@@ -141,8 +34,7 @@
  ;; tools/mcp-conformance/wire-vocab so schema syntax stays aligned
  ;; across the conformance gates.
  {:test {:extra-paths ["test"]
-         :extra-deps  {;; rf2-try1x — silent-on-success reporter.
-                       day8/re-frame2-test-quiet
+         :extra-deps  {day8/re-frame2-test-quiet
                        {:local/root "../../implementation/test-quiet"}
                        io.github.cognitect-labs/test-runner
                        {:git/tag "v0.5.1" :git/sha "dfb30dd"}
@@ -150,37 +42,14 @@
                        {:mvn/version "0.16.4"}}
          :main-opts   ["-m" "re-frame.test-quiet.runner"]}
 
-  ;; CLJS test build classpath (rf2-80y2h). mcp-base is a `.cljc`
-  ;; library both MCP servers consume in CLJS (re-frame2-pair-mcp is a
-  ;; Node script), yet the JVM `:test` alias above can only exercise the
-  ;; `:clj` reader-conditional arms. Three `.cljc` branches were
-  ;; therefore NEVER executed on any platform: the `goog-define`
-  ;; `validate-patches?` toggle (`diff_encode.cljc`), the `:cljs` arm of
-  ;; `resolve-malli-validate`, and the soft-pass-when-Malli-absent no-op
-  ;; in `validate-patches!` / `validate-sections!`.
-  ;;
-  ;; This alias wires the shadow-cljs `:cljs-test` build (see
-  ;; shadow-cljs.edn) under `:deps true`. Note what is DELIBERATELY
-  ;; ABSENT: metosin/malli. The CLJS test build runs WITHOUT Malli on
-  ;; the classpath so `resolve-malli-validate` returns nil and the
-  ;; validation gates take their soft-pass branch — the exact CLJS-only
-  ;; path the JVM suite (Malli always present) can never reach. The
-  ;; goog-define `validate-patches?` rides its default `true` here
-  ;; (production CLJS bundles flip it to false via :closure-defines; the
-  ;; test build leaves the dev gate on).
-  ;; Classpath-only — shadow-cljs activates this alias via
-  ;; shadow-cljs.edn `:deps {:aliases [:cljs-test]}` and supplies its own
-  ;; `:main`; do NOT add `:main-opts` here or it leaks into the
-  ;; shadow-cljs `clojure` launch and shadows shadow's CLI entry point.
-  ;; Drive the build via `npm run test:cljs` (or `shadow-cljs compile
-  ;; cljs-test`).
+  ;; Classpath for the shadow-cljs tests. Malli is deliberately absent:
+  ;; the CLJS-only suite covers the runtime-optional validation branch.
+  ;; shadow-cljs supplies the main; keep this alias free of :main-opts.
   :cljs-test
   {:extra-paths ["test"]
    :extra-deps  {org.clojure/clojurescript {:mvn/version "1.12.145"}
                  thheller/shadow-cljs      {:mvn/version "3.4.10"}
-                 ;; rf2-try1x — silent-on-success reporter; provides the
-                 ;; `re-frame.test-quiet.shadow-node` :main for the
-                 ;; :node-test build.
+                 ;; Silent-on-success :node-test reporter.
                  day8/re-frame2-test-quiet
                  {:local/root "../../implementation/test-quiet"}}}
 

--- a/tools/mcp-base/package.json
+++ b/tools/mcp-base/package.json
@@ -2,7 +2,7 @@
   "name": "@day8/re-frame2-mcp-base",
   "version": "0.1.0",
   "private": true,
-  "description": "CLJS test harness for re-frame2-mcp-base — exercises the .cljc :cljs reader-conditional branches the JVM suite cannot reach (rf2-80y2h).",
+  "description": "CLJS test harness for re-frame2-mcp-base reader-conditional branches.",
   "license": "MIT",
   "scripts": {
     "test:cljs": "shadow-cljs compile cljs-test && node out/cljs-test.js"

--- a/tools/mcp-base/shadow-cljs.edn
+++ b/tools/mcp-base/shadow-cljs.edn
@@ -1,44 +1,13 @@
-;; tools/mcp-base — CLJS test build (rf2-80y2h).
-;;
-;; mcp-base is a `.cljc` library: its sources load identically into the
-;; JVM (story-mcp) and CLJS (re-frame2-pair-mcp, a Node script). The
-;; canonical test suite is JVM (`clojure -M:test`, cognitect-labs
-;; test-runner) — the algorithmic content is platform-agnostic and a JVM
-;; round-trip is the cheapest gate.
-;;
-;; But the `.cljc` reader-conditional `:cljs` arms were untested on ANY
-;; platform: the `goog-define`'d `validate-patches?` toggle, the `:cljs`
-;; branch of `resolve-malli-validate`, and the soft-pass no-op in the
-;; validation gates when Malli is absent. Both servers exercise these in
-;; CLJS; nothing pinned them. This build closes that gap.
-;;
-;; `:deps {:aliases [:cljs-test]}` routes classpath resolution through
-;; deps.edn and activates the `:cljs-test` alias (which adds
-;; clojurescript + shadow-cljs + the test-quiet reporter, and pointedly
-;; does NOT add Malli — see deps.edn). Without Malli on the classpath
-;; `resolve-malli-validate` returns nil and the validation gates take
-;; their soft-pass branch — the CLJS-only path the JVM suite cannot
-;; reach.
-;;
-;; The build runs the `.cljs` CLJS-only coverage ns
-;; (`re-frame.mcp-base.cljs-branches-cljs-test`) PLUS the canonical
-;; `.cljc` dedup suite (`re-frame.mcp-base.dedup-test`, rf2-ywkiss) so
-;; the wire-boundary dedup encode step is proven on the CLJS runtime
-;; re-frame2-pair-mcp ships on — not just the JVM. The remaining `.clj`
-;; JVM tests use `clojure.lang.ExceptionInfo` and a JVM Malli dep and
-;; cannot compile to CLJS, so they stay excluded.
+;; CLJS coverage for reader-conditional branches and the canonical
+;; cross-host dedup suite. The :cljs-test deps alias deliberately omits
+;; Malli so this build exercises the runtime-optional validation path.
 {:deps {:aliases [:cljs-test]}
  :builds
  {:cljs-test
   {:target    :node-test
    :output-to "out/cljs-test.js"
-   ;; Selects exactly two namespaces: the CLJS-only coverage file
-   ;; (ends `-cljs-test`) and the cross-host canonical dedup suite
-   ;; (ends `dedup-test`). No other `.clj` JVM `*_test.clj` namespace
-   ;; matches either suffix, so they stay excluded.
+   ;; Select the CLJS-only coverage ns and the .cljc dedup suite.
    :ns-regexp "(dedup-test|cljs-test)$"
    :autorun   true
-   ;; rf2-try1x — silent-on-success reporter (mirrors re-frame2-pair-mcp's
-   ;; :server-test build). Provided by day8/re-frame2-test-quiet on the
-   ;; :cljs-test alias classpath.
+   ;; Silent-on-success reporter from the :cljs-test classpath.
    :main      re-frame.test-quiet.shadow-node/main}}}

--- a/tools/mcp-base/spec/README.md
+++ b/tools/mcp-base/spec/README.md
@@ -7,26 +7,16 @@ the re-frame2 tool pair:
 - `tools/re-frame2-pair-mcp/` (CLJS / Node — runs over nREPL to a browser app)
 - `tools/story-mcp/` (JVM / Clojure — bridges to `tools/story/`)
 
-(Historical: a third server `xray-mcp` was envisaged, making this an
-MCP triplet; it was dropped per rf2-hvl1g — AI agent access to Xray
-state flows via re-frame2-pair-mcp against the framework-published
-Xray runtime API, so a dedicated xray-mcp is unnecessary.)
-
-The factoring landed under [rf2-vw4sq][bead]. The per-namespace
-contract expansion (rf2-643ia / rf2-0hs5t.5) splits each shipped
-namespace into its own one-shot-able spec doc; this README is the
-**index over those per-namespace contracts**, not the normative
-source for any namespace's surface.
-
-[bead]: https://github.com/day8/re-frame2/issues/rf2-vw4sq
+This README indexes the per-namespace contracts; it is not the
+normative source for an individual namespace's surface.
 
 ## Canonical home — external to `/spec`
 
 This spec/ folder is the **canonical home** for the cross-MCP shared
 primitives — a tool-shared contract that lives with the tool artefact
 rather than in the project-level [`/spec`](../../../spec/), per
-[`/spec/README.md` §Canonical homes outside `/spec`](../../../spec/README.md#canonical-homes-outside-spec)
-(rf2-0hs5t.3 (a)). The surface is indexed back to the framework via
+[`/spec/README.md` §Canonical homes outside `/spec`](../../../spec/README.md#canonical-homes-outside-spec).
+The surface is indexed back to the framework via
 a row in [`/spec/Ownership.md`](../../../spec/Ownership.md); the
 framework's normative contract surface (the `:sensitive?`
 substrate, the `:rf.size/*` markers, the wire-elision walker) lives
@@ -45,22 +35,22 @@ per-namespace contract doc; the table below indexes them:
 | `vocab` | `:rf.mcp/*` + `:rf.size/*` marker keys + envelope slots + JSON-RPC error codes. | [`vocab.md`](vocab.md) |
 | `sensitive` | spec/009 §Privacy fail-closed default-suppress filter (`sensitive-event?`, `strip-sensitive`, per-frame `scrub-snapshot`) + malformed-stamp counter. | [`sensitive.md`](sensitive.md) |
 | `egress` | Cross-MCP `:rf.egress/*` profile vocabulary + pure-data `profile-size-opts` resolver — the framework-runtime-free mirror of the closed six-member egress enum and its `:rf.size/*` floor (EP-0015 §10). | [`egress.md`](egress.md) |
-| `elision` | Wire-boundary `:rf.size/large-elided` walker (`count-elided-markers`, rf2-9fz64). | [`elision.md`](elision.md) |
+| `elision` | Wire-boundary `:rf.size/large-elided` marker counter (`count-elided-markers`). | [`elision.md`](elision.md) |
 | `args` | Argument coercion helpers (`parse-boolean`, `parse-positive-int`, `fresh-keyword`, `safe-keyword`, `parse-mode`, …). | [`args.md`](args.md) |
-| `diff-encode` | Path-keyed structural diff for epoch `:db-after` slots projected into path-headed cluster sections (rf2-1wdzp / rf2-qeous) + encoder/decoder Malli gate. | [`diff-encode.md`](diff-encode.md) |
-| `section-grouping` | Patch-list → path-headed cluster sections (`group-patches-into-sections` / `sections->patches`, rf2-qeous); consumed by `diff-encode`. | [`section-grouping.md`](section-grouping.md) |
-| `dedup` | Structural-dedup encode step at the wire boundary (`empty-payload?` / `dedup-value`, over `day8/de-dupe`'s equality walk; rf2-ttspi7). Forward direction only — the test-only inverse stays consumer-side. | [`dedup.md`](dedup.md) |
-| `overflow` | Overflow-marker payload SHAPE builder (`overflow-payload`) + `token-estimate` + fallback hint (rf2-rvyzy). | [`overflow.md`](overflow.md) |
-| `cap` | Wire-boundary two-stage token-budget cap pipeline + `max-tokens` resolver + `ResultIO` protocol (rf2-eyelu / rf2-ih7g4). | [`cap.md`](cap.md) |
-| `cursor` | Shared cursor-pagination machinery — base64 codec, opaque encode/decode with `::malformed` recovery, `:limit` clamp, `cursor-stale-result` envelope (rf2-ee38b.19). | [`cursor.md`](cursor.md) |
-| `envelope` | Indicator-field `with-indicators` splice (`:dropped-sensitive` / `:elided-large`, omit-when-zero MUST) + wire-bounded `:rf.mcp/*` marker detection (rf2-ee38b.19). | [`envelope.md`](envelope.md) |
-| `descriptor-manifest` | Shared MCP tool-descriptor manifest generator + drift-check — deterministic LF-pinned EDN serialiser (`render-edn`) + regenerate-vs-committed `check`, consumed by each server's registry-driven `tool-descriptors.edn` generator (rf2-sofwv). | [`descriptor-manifest.md`](descriptor-manifest.md) |
+| `diff-encode` | Path-keyed structural diff for epoch `:db-after` slots, projected into path-headed cluster sections, plus encoder/decoder Malli gates. | [`diff-encode.md`](diff-encode.md) |
+| `section-grouping` | Patch-list → path-headed cluster sections (`group-patches-into-sections` / `sections->patches`); consumed by `diff-encode`. | [`section-grouping.md`](section-grouping.md) |
+| `dedup` | Structural-dedup encode step at the wire boundary (`empty-payload?` / `dedup-value`, over `day8/de-dupe`'s equality walk). Forward direction only. | [`dedup.md`](dedup.md) |
+| `overflow` | Overflow-marker payload builder (`overflow-payload`) + `token-estimate` + fallback hint. | [`overflow.md`](overflow.md) |
+| `cap` | Wire-boundary two-stage token-budget cap pipeline + `max-tokens` resolver + `ResultIO` protocol. | [`cap.md`](cap.md) |
+| `cursor` | Shared cursor-pagination machinery — base64 codec, opaque encode/decode with `::malformed` recovery, `:limit` clamp, and `cursor-stale-result` envelope. | [`cursor.md`](cursor.md) |
+| `envelope` | Indicator-field `with-indicators` splice (`:dropped-sensitive` / `:elided-large`, omit-when-zero MUST) + wire-bounded `:rf.mcp/*` marker detection. | [`envelope.md`](envelope.md) |
+| `descriptor-manifest` | Shared MCP tool-descriptor manifest generator + drift-check — deterministic LF-pinned EDN serialiser (`render-edn`) + regenerate-vs-committed `check`. | [`descriptor-manifest.md`](descriptor-manifest.md) |
 
 All `.cljc`, so consumers compile them under their own platform —
 re-frame2-pair-mcp's shadow-cljs node build, story-mcp's JVM
 classpath. The library's `deps.edn` carries `org.clojure/clojure` plus
 the one framework-agnostic external dep `dedup` needs —
-`day8/de-dupe`, a pure persistent-data-structure walker (rf2-ttspi7);
+`day8/de-dupe`, a pure persistent-data-structure walker;
 no consumer-side transport runtime deps.
 
 ## Handler-arity divergence
@@ -70,13 +60,12 @@ pair-mcp is 3-arity `(fn [conn args extra])`, story-mcp is 1-arity
 `(fn [args])`. The divergence is deliberate (pair-mcp needs `conn`
 for nREPL and `extra` for streaming; story-mcp is single-process and
 needs neither) and is documented in full at
-[`handler-arity.md`](handler-arity.md). A future unification awaits a
-third server instance and lands as a separate bead.
+[`handler-arity.md`](handler-arity.md).
 
 ## What deliberately does NOT live here
 
-The bead's scope holds the line at primitives that are truly
-identical across the pair's wire / privacy / size surfaces.
+The base holds primitives that are shared across the pair's wire,
+privacy, and size surfaces.
 Two categories stay consumer-side:
 
 1. **Wire transport.** story-mcp uses Cheshire for JSON-RPC over
@@ -88,23 +77,15 @@ Two categories stay consumer-side:
    specific. The base provides building blocks; it does NOT
    prescribe how the registry is shaped.
 
-> **Note (rf2-ee38b.19):** the cursor base64 codec USED to be listed
-> here as consumer-side, on the premise that `js/Buffer` vs
-> `java.util.Base64` forced a per-platform helper. story-mcp's own
-> `.cljc` cursor codec refuted that — the codec lifts cleanly as a
-> reader-conditional — so the shared machinery (base64 codec, opaque
-> encode/decode + `::malformed` recovery, `:limit` clamp,
-> `cursor-stale-result` envelope) now lives in `cursor.cljc`,
-> parameterised by each consumer's cursor-payload SHAPE. The cursor
-> *resource controls* (concurrent-stream cap, token-bucket rate-limit,
-> abuse window) remain consumer-side — they live only in pair-mcp's
-> `resource_controls.cljs` and are not yet a candidate to lift (single
-> streaming consumer today).
+The shared cursor codec and recovery helpers live in `cursor.cljc`,
+parameterised by each consumer's cursor-payload shape. Cursor resource
+controls remain pair-mcp-specific.
 
 ## Cross-MCP vocabulary as a versioned contract
 
-The marker keys + envelope slots + JSON-RPC codes are a **wire-
-protocol contract**. A rename here breaks every connected agent.
+Marker keys, envelope slots, and emitted JSON-RPC numeric values are
+wire contracts. Changing a value requires updating its consumers and
+conformance fixtures together.
 Two layers of protection:
 
 1. **The cross-MCP conformance gate** at
@@ -113,11 +94,8 @@ Two layers of protection:
    `:rf.elision/at` marker and asserts that fixtures + source text
    from every emitting server conform. Any rename or shape drift
    fails the JVM test corpus.
-2. **The marker-key vars in `vocab.cljc`** are the single
-   reference point — every server reads them via `(:require ...)`
-   rather than re-typing the keyword literal. A grep for
-   `:rf.mcp/overflow` shows exactly one defining occurrence;
-   everywhere else is a `vocab/overflow-key` reference.
+2. **The vars in `vocab.cljc`** are the shared reference point for
+   executable consumers rather than consumer-local constant definitions.
 
 ## Adding to the base
 
@@ -130,7 +108,7 @@ Two rules:
 
 2. **It must be framework-runtime-free, with no consumer-side
    transport deps.** The base's `deps.edn` carries `org.clojure/clojure`
-   plus the framework-agnostic `day8/de-dupe` walker (rf2-ttspi7). If
+   plus the framework-agnostic `day8/de-dupe` walker. If
    your primitive needs cheshire / re-frame.trace / shadow-cljs /
    js-interop, it belongs in its consumer, not here. (re-frame2-pair-mcp
    keeps a thin local alias ns — `tools/sensitive.cljs` — that
@@ -149,12 +127,6 @@ sees the trap before falling in:
   consumer; nREPL transport is pair-mcp's domain. story-mcp does not
   speak nREPL; lifting would add a runtime concern the base does not
   need to know about.
-- **A token-cap algorithm shared with a hypothetical xray-mcp before
-  it ships** — NO. Speculative. The rule is "implemented somewhere
-  already"; a primitive lifted ahead of a real second consumer earns
-  the wrong shape for the consumer that eventually materialises (or
-  never materialises). Lift when the second consumer exists.
-
 A new shared primitive ships with:
 
 - A per-namespace spec doc in this folder (`<ns>.md`), at the
@@ -178,8 +150,7 @@ A new shared primitive ships with:
   §Size elision in traces — the framework primitive the `elision` ns
   counts the output of.
 - [`/spec/Conventions.md`](../../../spec/Conventions.md) §Cross-MCP
-  indicator-field vocabulary — the MUST-level parity between the
-  `:dropped-sensitive` and `:elided-large` envelope slots.
+  indicator-field vocabulary — the shared indicator and omit-when-zero rules.
 - [`/spec/Ownership.md`](../../../spec/Ownership.md) — the row that
   indexes this spec folder under the canonical-homes-outside-`/spec`
   rule.

--- a/tools/mcp-base/spec/args.md
+++ b/tools/mcp-base/spec/args.md
@@ -1,7 +1,7 @@
 # `args` — argument coercion helpers
 
 > **Type:** Reference (`tools/mcp-base/spec/`)
-> Parsers that take an ALREADY-RESOLVED raw value (extracted by the consumer from its platform-specific args object: a JS object for re-frame2-pair-mcp, a Clojure map for story-mcp) and normalise it into the Clojure-side type the tool body expects. Cross-MCP arg-vocabulary convention: an agent that learns `:dedup` defaults true on re-frame2-pair-mcp must see the same default everywhere.
+> Parsers that take an already-resolved raw value from a consumer's platform-specific argument object and normalize it for the tool body. Shared coercion semantics keep the JVM and CLJS consumers aligned; call sites supply policy defaults.
 
 This doc is one of thirteen per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`egress.md`](egress.md), [`elision.md`](elision.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`dedup.md`](dedup.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
 
@@ -11,7 +11,7 @@ This doc is one of thirteen per-namespace contracts indexed from [`README.md`](R
 
 - The cross-MCP parser catalogue (`parse-boolean`, `parse-positive-int`, `parse-non-negative-int`, `fresh-keyword`, `safe-keyword`, `parse-mode`).
 - The default-handling posture for each parser (call-sites supply the default; the parser is policy-free).
-- The keyword-interning safety rule (per rf2-ih7g4): unbounded inputs MUST route through `safe-keyword`; only operator-gated write paths may use `fresh-keyword`.
+- The keyword-interning safety rule: bounded lookups route through `safe-keyword`; only deliberate, operator-gated allocation paths use `fresh-keyword`.
 
 `args` does NOT own:
 
@@ -21,7 +21,7 @@ This doc is one of thirteen per-namespace contracts indexed from [`README.md`](R
 
 ## Cross-server convention
 
-Argument names and default postures are a cross-MCP convention. An agent that learns `:dedup` defaults true on re-frame2-pair-mcp must see the same default everywhere. These parsers encode the defaults so they can't drift across consumers.
+Argument names and default postures are a cross-MCP convention. These parsers share coercion semantics; each consumer supplies the documented default at its call site.
 
 The rejection posture (default-suppress vs default-allow) is named at the call-site by passing the appropriate `default` — the parser itself is policy-free.
 
@@ -30,31 +30,31 @@ The rejection posture (default-suppress vs default-allow) is named at the call-s
 | Parser | Accepts | Output | Notes |
 |---|---|---|---|
 | `parse-boolean` | bools, strings (`"true"`/`"false"`/`"1"`/`"0"`/`"yes"`/`"no"`/`"y"`/`"n"`/`"on"`/`"off"`, case-insensitive), keywords (`:true`/`:false`), nil | boolean | Unrecognised → `default`. Call-sites wrap to bake the default. |
-| `parse-positive-int` | ints, parsable strings | positive int or `default` | Strictly positive; zero clamps to 1. Out-of-domain numerics (`##Inf`/`##NaN`/past the safe-integer window) → `default`, never a crash or a real floor (rf2-ykv9a0). |
+| `parse-positive-int` | finite in-range numbers, integer strings | positive int or `default` | Numbers floor toward zero, then clamp to 1. Invalid or out-of-domain inputs return `default`. |
 | `parse-non-negative-int` | ints, parsable strings | non-negative int or `default` | Zero allowed. Out-of-domain numerics → `default` (same cross-runtime guard). |
-| `fresh-keyword` | keywords, strings (leading `:` optional), nil | keyword or `nil` | The `:` prefix is stripped on string input. **Positive-named intern (rf2-xxtrz)**: the name signals the call-site is ALLOCATING a new id, not resolving an existing one. INTERNS by design — reserved for operator-gated write paths whose registrar grammar bounds the per-id allocation cost (e.g. story-mcp's `register-variant`). For finite option sets, use `safe-keyword`. |
-| `fresh-keyword-checked` | keywords, strings (leading `:` optional), nil; a `[ns name] → bool` shape predicate; optional `:max-len` | keyword or `nil` | **Grammar-gated intern (rf2-tag30h).** Like `fresh-keyword` but validates the DECOMPOSED `[ns-part name-part]` string shape against `shape-ok?` and a length cap (default 512) BEFORE interning, so an id failing the caller's grammar leaves NO keyword in the table. The fix for "intern-then-reject" write paths: `fresh-keyword` interned first and let a downstream registrar reject on grammar, but the reject happened after the intern. Use this when the fresh id has a known grammar (e.g. `:story.<path>/<name>` via `re-frame.story.schemas/variant-id-shape?`). |
-| `safe-keyword` | keywords, strings, nil | keyword from `allowed` set, or `nil` | Bounded-allowlist gate — NEVER interns a fresh keyword on rejection. The right primitive for finite option sets and any input that doesn't go straight to a registry lookup with a bounded known set. Per rf2-ih7g4. |
-| `parse-mode` | enum-shaped strings / keywords | one of an allowed set, otherwise `default` | Bakes an `allowed-modes` set; rejected values fall to `default`. Routes through `safe-keyword` so unrecognised input never interns (rf2-ih7g4). |
+| `fresh-keyword` | keywords, strings (leading `:` optional), nil | keyword or `nil` | INTERNS by design — reserved for operator-gated paths that deliberately allocate a new id. It is not a registry lookup helper. |
+| `fresh-keyword-checked` | keywords, strings (leading `:` optional), nil; a `[ns name] → bool` shape predicate; optional `max-len` | keyword or `nil` | Validates a string's decomposed shape and length before interning. Keyword inputs are already interned, so they are shape-checked but not length-checked. |
+| `safe-keyword` | keywords, strings, nil | keyword from `allowed` set, or `nil` | Bounded-allowlist gate — never interns a fresh JVM keyword on rejection. Use for finite options and live registry lookups. |
+| `parse-mode` | enum-shaped strings / keywords | one of an allowed set, otherwise `default` | Routes through `safe-keyword`; rejected values fall to `default`. |
 
-## Keyword-interning safety (rf2-ih7g4)
+## Keyword-interning safety
 
 The same threat model that drives `:rf.http/max-decoded-keys` ([`../../../spec/014-HTTPRequests.md` §Keyword-interning cap](../../../spec/014-HTTPRequests.md)) applies to MCP argument parsing. An MCP server is a long-running process; every `(keyword raw-agent-string)` call against unbounded user input grows the host's interned-symbol table for the life of the process. A compromised agent submitting N-unique-string arguments-per-call would permanently burn N slots in the keyword table.
 
 The cross-MCP rule:
 
 1. **`safe-keyword` is the default primitive.** Every cross-MCP arg whose set of valid values is *bounded* — modes, enum-like opts, registered tool ids — uses `safe-keyword` with the allowlist passed in.
-2. **`fresh-keyword` / `fresh-keyword-checked` are reserved for operator-gated write paths.** When the arg's value is by design a NEW identifier (story-mcp's `register-variant` / `record-as-variant`), these are the positive-named primitives. The intern is bounded by an operator gate (`--allow-writes`). When the id has a known grammar (`:story.<path>/<name>`), use **`fresh-keyword-checked`** with the string-shape predicate so the grammar is enforced BEFORE the intern (rf2-tag30h) — `fresh-keyword`'s reliance on a downstream registrar `assert-id!` interned the keyword first, so an invalid id (correctly rejected) still grew the keyword table. The name carries the "I am allocating, not resolving" posture; no warning-laden docstring needed at the call site.
+2. **`fresh-keyword` / `fresh-keyword-checked` are reserved for operator-gated allocation paths.** When an argument is by design a new identifier, prefer `fresh-keyword-checked` so its grammar and string length are validated before interning. A grammar limits per-id shape, not the number of valid ids; the operator gate remains the allocation policy.
 3. **`parse-mode` routes through `safe-keyword`.** The convention's enum-shaped parser is internally safe; consumers should use it rather than rolling their own.
 
 The keyword-interning cap (`:rf.http/max-decoded-keys`) defends against the body-decode threat; this convention defends against the argument-parse threat. Both close the same DoS / keyword-table-poisoning vector.
 
-## Cross-runtime numeric domain (rf2-ykv9a0)
+## Cross-runtime numeric domain
 
 `parse-positive-int` / `parse-non-negative-int` (and, via `cursor/parse-limit-arg` and `cap/max-tokens`, every numeric MCP arg) coerce through one shared finite/range guard (`coerce-finite-long`) BEFORE `(long raw)`. The guard exists because `(long raw)` is unsafe at the arg boundary:
 
 - On the JVM `(long ##Inf)` and `(long 1.0E20)` THROW `IllegalArgumentException` — a crash at the wire boundary instead of a recoverable default; `(long ##NaN)` truncates to a real `0` (a real, non-sentinel value).
-- The string arm diverged across hosts: a digit string just past the JS safe-integer ceiling parsed on the JVM (`Long/parseLong`) but defaulted on CLJS (`Number.isSafeInteger`), so the SAME wire arg behaved differently per host.
+- The hosts have different numeric ranges and parsing behavior, so both arms enforce the JS safe-integer window before returning a value.
 
 The admissible domain is the JS safe-integer window `[-(2^53−1), 2^53−1]` — the strictest of the two hosts, and far wider than any real MCP arg (pagination limits, token caps). An out-of-domain value (non-finite, NaN, or past the window) is treated uniformly: the int parsers fall to `default`; `cap/max-tokens` rejects with `{:rf.mcp/invalid-arg}`. Never a crash, never a real `0`-cap, never a host-divergent result.
 
@@ -83,14 +83,11 @@ All six parsers are pure `.cljc`. They use:
 - A reader-conditional finite/range guard: `Double/isNaN`/`isInfinite` + the safe-integer window (JVM), `js/isFinite`/`isNaN` + `Number.isSafeInteger` (CLJS). The numeric string arm parses via `bigint` (JVM) / `js/parseInt` (CLJS) and clamps to the same window so the two hosts agree.
 - Standard collection ops; no host-specific machinery.
 
-`safe-keyword`'s rejection branch carries the bounded-allowlist check — a fresh keyword is created with `keyword` only after the allowlist passes.
+On the JVM, `safe-keyword` uses `find-keyword`, so a rejected string is never interned. CLJS constructs a keyword for membership testing but has no JVM-style permanent keyword table; both hosts return the same allowed value or `nil`.
 
 ## Conformance posture
 
-Per-parser fixture tests live in `tools/mcp-base/test/`. Cross-consumer convention checks live in `tools/mcp-conformance/`:
-
-- Every cross-MCP tool that accepts a finite-option arg uses `safe-keyword`. The conformance harness diffs argument schemas across consumers and asserts the same allowlist appears everywhere.
-- Default-handling parity: a sample arg that's unset on each consumer must produce identical observable behaviour across both servers. The harness drives each tool with `{}` (no args) and asserts the response envelope matches the convention's documented defaults.
+Per-parser fixture tests live in `tools/mcp-base/test/`. Consumer suites cover the call-site defaults and their advertised argument schemas.
 
 ## See also
 

--- a/tools/mcp-base/spec/cap.md
+++ b/tools/mcp-base/spec/cap.md
@@ -1,7 +1,7 @@
-# `cap` — wire-boundary token-budget cap pipeline (rf2-eyelu)
+# `cap` — wire-boundary token-budget cap pipeline
 
 > **Type:** Reference (`tools/mcp-base/spec/`)
-> Owns the ALGORITHM that drives the overflow marker into a result. Until rf2-eyelu this pipeline was duplicated near-identically in re-frame2-pair-mcp (CLJS, `#js {:content #js [...]}`-shaped results) and story-mcp (CLJ, `{:content [...] :structuredContent ...}`-shaped results). The only structural difference between the two implementations was the SHAPE of the result map and the platform-appropriate accessor used to read its `:text` slots — algorithm identical.
+> Owns the algorithm that measures a consumer's serialized payload slots and replaces an over-budget result with an overflow marker. `ResultIO` isolates each server's native result shape.
 
 This doc is one of thirteen per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`egress.md`](egress.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`dedup.md`](dedup.md), [`overflow.md`](overflow.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
 
@@ -10,9 +10,9 @@ This doc is one of thirteen per-namespace contracts indexed from [`README.md`](R
 `cap` owns:
 
 - The two-stage cap algorithm (sum tokens + chars in one pass → primary token gate OR secondary char gate → pass-through or replace).
-- The `max-tokens` per-call cap resolver (`0` resolves to `nil` = disabled; absent / non-number → `default-max-tokens`; **negative, fractional-in-(0,1), or non-finite / out-of-range → `{:rf.mcp/invalid-arg {...}}` rejection**, rf2-5rdit / rf2-li6y2.2 / rf2-ykv9a0).
+- The `max-tokens` per-call cap resolver (`0` resolves to `nil` = disabled; absent / non-number → `default-max-tokens`; negative, fractional-in-(0,1), or non-finite / out-of-range → `{:rf.mcp/invalid-arg {...}}` rejection).
 - The `ResultIO` protocol — the per-consumer specialisation hook.
-- The recursion-safety invariant (the overflow marker itself must fit under the cap).
+- The one-pass replacement invariant: an overflow result is built once and is not recursively capped by this function.
 
 `cap` does NOT own:
 
@@ -22,11 +22,11 @@ This doc is one of thirteen per-namespace contracts indexed from [`README.md`](R
 
 ## Algorithm
 
-The pipeline is a **two-stage** gate (rf2-ih7g4) that folds both sums in a **single pass** (rf2-hyp0z) over the content `:text` slots:
+The pipeline is a **two-stage** gate that folds both sums in a **single pass** over every string returned by `wire-payload-strings`:
 
-1. **Resolve the cap.** `max-tokens` turns the raw `:max-tokens` MCP arg into the per-call cap: `nil` (caller passed `0` → disabled), `default-max-tokens` (5000; absent or non-number), a positive integer (custom cap), or — for a **negative** number — an `{:rf.mcp/invalid-arg {...}}` rejection (rf2-5rdit; see [§Out-of-domain `:max-tokens` is rejected](#out-of-domain-max-tokens-is-rejected-rf2-5rdit--rf2-li6y22--rf2-ykv9a0)). When the resolved cap is `nil`, `apply-cap` short-circuits and returns the result untouched — **the disable mechanism is `max-tokens` resolving to `nil`, not the arg being `0` at the gate**.
-2. **Single-pass token + char sum.** One `transduce` over the `:text`-slot strings folds both `Σ token-estimate` and `Σ (count s)` in one walk (so a story-mcp `:structuredContent` is materialised once, not twice).
-3. **Two-stage over-budget decision** (`over-cap?`): trip when EITHER the token sum `> cap` (primary gate) OR the char sum `> cap * byte-cap-multiplier` (secondary byte gate — defence-in-depth against payloads where `(count s)/4` undercounts: CJK, emoji, base64, dense code). `reported-count` selects which count rides the marker's `:token-count` slot (the char count when the secondary gate is the one that tripped, else the token sum).
+1. **Resolve the cap.** `max-tokens` returns `nil` for `0`, the 5000 default for an absent/non-number value, a floored positive integer for an in-range number, or an invalid-arg marker for an out-of-domain number. Consumers reject the marker before calling `apply-cap`.
+2. **Single-pass token + character sum.** One `transduce` folds both `Σ token-estimate` and `Σ (count s)` across all measured payload strings, including a serialized `:structuredContent` slot when present.
+3. **Two-stage over-budget decision** (`over-cap?`): trip when either the token sum exceeds `cap` or the character sum exceeds `cap * byte-cap-multiplier`. The second gate bounds loss from flooring each short payload string independently. `reported-count` uses the character count when that gate trips, otherwise the token estimate.
 4. **Pass-through or replace.** Under-budget responses pass through unchanged; over-budget responses are replaced with a fresh result carrying the `:rf.mcp/overflow` marker (built via `overflow/overflow-payload`).
 
 ```clojure
@@ -53,7 +53,7 @@ The pipeline is a **two-stage** gate (rf2-ih7g4) that folds both sums in a **sin
 
 The algorithm runs synchronously at the wire boundary, after the response body has been assembled but before the consumer-side transport ships it. The cost is one walk over the consumer's measured wire payload strings (every serialized payload-bearing slot, not only `:content`) — O(measured payload strings).
 
-### Why the secondary char gate is load-bearing today (rf2-of2cd)
+### Why the secondary character gate is reachable
 
 A naive reading argues the char gate is structurally dominated: for a SINGLE string of length `L`, `chars = L` and `tokens = (quot L 4)`, so `chars > cap*8` ⇒ `tokens = (quot L 4) > 2*cap > cap` — the token gate would have already tripped. That single-string argument is real but does NOT generalise to the multi-slot sum the pipeline actually folds.
 
@@ -64,9 +64,9 @@ A naive reading argues the char gate is structurally dominated: for a SINGLE str
                                          ; per-string remainders are sub-4
 ```
 
-A content vector of MANY short strings drives the gap to its extreme: 3000 slots of 3 chars each give `tokens = Σ (quot 3 4) = 0` while `chars = 9000`. At `cap = 1` the token gate is quiet (`0 > 1` is false) yet the char gate fires (`9000 > 8`), and `apply-cap` correctly replaces the over-budget payload with the overflow marker. The `watch-epochs` / `trace-window` slices are exactly this shape — a long vector of small per-record text slots. So the secondary char gate is reachable through the **live** `apply-cap` path today, not merely future-proofing.
+A multipart result with many short strings drives the gap to its extreme: 3000 slots of 3 chars each give `tokens = 0` while `chars = 9000`. At `cap = 1` the token gate is quiet and the character gate fires. Shipping dual-coded envelopes normally expose only a few measured strings, but `ResultIO` permits multipart consumers and the shared algorithm covers them.
 
-The branch is doubly justified: load-bearing now AND defence-in-depth against a FUTURE `token-estimate` refinement (one recognising base64 / CJK at a lower per-char cost) that would decouple the sums further. `over-cap?` / `reported-count` are extracted as pure fns over already-summed counts so both disjuncts and the `reported` selector are exercised directly in isolation (`cap_test.clj`) AND through the live many-short-strings `apply-cap` path (`apply-cap-many-short-strings-trips-char-gate`).
+`over-cap?` and `reported-count` are pure functions over the two sums; tests exercise both branches directly and through `apply-cap`.
 
 ## Per-server specialisation hook — the `ResultIO` protocol
 
@@ -83,11 +83,11 @@ Each consumer reifies `ResultIO` with two methods:
 
 The cap pipeline calls these two methods; everything else is shared. Adding a third consumer is a single reify, not a code copy.
 
-### Contract: count every payload-bearing slot, not only `:content` (rf2-mzndx / rf2-13wbe)
+### Contract: count every payload-bearing slot, not only `:content`
 
-A consumer whose result envelope **duplicates** the payload into a second wire slot MUST surface a stable string representation of that slot from `wire-payload-strings` too. The common case is a `:structuredContent` JSON projection emitted **alongside** the `:content[*].text` EDN on **every** result — both re-frame2-pair-mcp's `wire/ok-text` / `err-text` and story-mcp's `text-result` do exactly this (the dual-coded envelope: agent hosts that understand `:structuredContent` read the typed object; the rest fall back to the text). Both copies ride the wire, so both count toward the one budget.
+A consumer whose result envelope duplicates a payload into `:content[*].text` and `:structuredContent` must surface stable string representations of both. The adapters include `:structuredContent` when it is present; single-slot results expose only their text slots.
 
-Omitting the second copy undercounts the response by **~50%**: a response whose `:content[*].text` slot is under budget but whose `:structuredContent` is large would slip past the overflow marker and bust the MCP token budget. story-mcp closed this (rf2-mzndx) by appending a `pr-edn`'d `:structuredContent` string to `wire-payload-strings`; any dual-coding consumer (pair-mcp's `result-io`) must mirror it (`JSON.stringify` / `pr-str` of the structured value). The unit suites pin the contract with **both** a dual-coding reify (`structured-io` — counts both slots and trips the cap) and a single-slot reify (`map-io` — counts one), so a regression that drops the second copy fails the dual-coding regression.
+Omitting a duplicated slot lets real wire bytes escape the budget. story-mcp serializes the structured value with `pr-edn`; pair-mcp uses `JSON.stringify` on the SDK-facing JS object. Unit tests cover both dual-coded and single-slot adapters.
 
 ### Example reify — minimal single-slot consumer (content-only envelope)
 
@@ -108,7 +108,7 @@ A consumer that ships ONLY `:content[*].text` (no duplicated slot) surfaces just
 
 ### Example reify — dual-coding consumer (story-mcp / pair-mcp, `:structuredContent` envelope)
 
-Both shipping servers emit `:structuredContent` alongside `:content[*].text` on every result, so `wire-payload-strings` MUST surface BOTH slots — the second as a stable string projection (`pr-str` / `JSON.stringify`) — or the cap undercounts by ~50%:
+Both server adapters account for `:structuredContent` whenever a result carries it. Dual-coded results must surface both slots — the second as a stable string projection (`pr-str` / `JSON.stringify`):
 
 ```clojure
 (deftype StoryResultIO []
@@ -125,13 +125,12 @@ Both shipping servers emit `:structuredContent` alongside `:content[*].text` on 
 
 Both reifies are ~10 lines each. The cap algorithm is unchanged.
 
-## Recursion safety
+## Replacement safety
 
-The overflow marker itself MUST fit under the cap. If the marker grew large enough to exceed `:max-tokens` it would trigger another cap, recursing infinitely.
-
-The conformance harness (`tools/mcp-conformance/test/live-re-frame2-pair-overflow.cjs`) asserts this on every cap-trigger; if a future bead grows the marker (a new slot, a longer hint, a verbose recovery message), the test surfaces the regression before it ships.
-
-The structural guarantee comes from the marker shape — `:limit`, `:token-count`, `:cap-tokens`, `:tool`, `:hint` are all small scalars; the marker can grow only by adding new keys. Adding a new key triggers the conformance test, which catches the regression before merge.
+`apply-cap` measures the original result once and returns
+`build-overflow-result` directly. It does not feed the marker back into
+itself, so even a deliberately tiny cap cannot recurse. The marker is
+kept compact to remain useful under ordinary caps.
 
 ## Disabling the cap
 
@@ -142,15 +141,15 @@ The structural guarantee comes from the marker shape — `:limit`, `:token-count
 
 The default-ON posture matches the agent-ergonomics threat model: a stock install never accidentally floods the agent's context.
 
-## Out-of-domain `:max-tokens` is rejected (rf2-5rdit / rf2-li6y2.2 / rf2-ykv9a0)
+## Out-of-domain `:max-tokens` is rejected
 
 An out-of-domain `:max-tokens` is neither a disable signal nor a valid cap. `max-tokens` rejects it with an `{:rf.mcp/invalid-arg {:arg :max-tokens :value <n> :hint "max-tokens must be an integer >= 1; 0 disables the cap"}}` marker; the consumer surfaces that as an `isError: true` tool-result (the agent reads it and corrects the arg). The handler is never dispatched and the rejection never reaches `apply-cap` as a `:cap`. The rejected domain:
 
-- **Negative** (rf2-5rdit) — `(long raw)` produced a negative ceiling; `over-cap?` (`(> tokens cap)`) is then true for ANY non-negative token count, so **every** response — even a 2-character one — was replaced by the `:rf.mcp/overflow` marker, locking the agent out and emitting a nonsensical `:cap-tokens -1`.
-- **Fractional positive in (0,1)** (rf2-li6y2.2) — e.g. `0.5` floored to a REAL `0` cap (non-nil, NOT the disable sentinel), reproducing the same lockout on every non-empty payload.
-- **Non-finite / out-of-range** (rf2-ykv9a0) — `##Inf` and a finite magnitude past the safe-integer window (`1.0E20`) THROW `IllegalArgumentException` on `(long raw)` (a crash at the wire boundary); `##NaN` truncated to a real `0` cap (the same lockout). The resolver routes through the shared `args/coerce-finite-long` guard BEFORE `(long raw)`, so each is rejected honestly and IDENTICALLY on JVM and CLJS rather than crashing the tool or minting a 0-cap.
+- **Negative** — would make every non-negative payload count exceed the cap.
+- **Fractional positive in (0,1)** — would floor to a real zero cap rather than the `nil` disable sentinel.
+- **Non-finite / out-of-range** — can throw or truncate differently at a host numeric conversion. The shared safe-integer guard rejects them consistently before conversion.
 
-Why reject rather than clamp / treat-as-default (Mike ruled A, 2026-06-01): an honest, recoverable rejection at the AI/MCP boundary is the masterpiece CORRECTNESS posture — a malformed cap is an agent error worth telling the agent about, not a value to silently paper over (or crash on).
+Rejecting these values gives the caller a recoverable argument error instead of silently changing its request or crashing at the boundary.
 
 Helpers (in `cap`):
 
@@ -161,19 +160,18 @@ The reserved key is `vocab/invalid-arg-key` (`:rf.mcp/invalid-arg`). The wire `:
 
 ## Conformance posture
 
-The conformance harness at `tools/mcp-conformance/test/live-re-frame2-pair-overflow.cjs` drives a real `:max-tokens 100` over-budget call on each server and asserts:
+The pair-mcp live harness drives an over-budget SDK call; story-mcp covers the same shared builder and JVM adapter in-process. Together the gates assert:
 
 1. The response carries the `:rf.mcp/overflow` marker.
 2. The marker's `:cap-tokens` slot equals 100.
 3. The marker's `:token-count` is greater than 100.
-4. The marker itself fits under 100 tokens (recursion-safety check).
+4. The marker remains compact under the fixture cap.
 5. The marker shape matches the conformance-gate Malli schema (per [`overflow.md` §Conformance posture](overflow.md#conformance-posture)).
 
-Parity across servers is asserted by running the same fixture against each consumer and diffing the resulting markers; shapes match modulo the `:tool` slot.
+Per-server fixtures validate the same marker schema, while shared-builder tests pin the common body shape; server markers differ in the `:tool` slot.
 
 ## See also
 
 - [`README.md`](README.md) — the per-namespace index this doc is part of.
 - [`overflow.md`](overflow.md) — the marker shape this algorithm produces.
 - [`vocab.md` §Marker catalogue (`:rf.mcp/*`)](vocab.md#marker-catalogue-rfmcp) — the `:rf.mcp/overflow` key.
-- rf2-eyelu — the bead that lifted this algorithm out of re-frame2-pair-mcp / story-mcp into the shared library.

--- a/tools/mcp-base/spec/cursor.md
+++ b/tools/mcp-base/spec/cursor.md
@@ -1,7 +1,7 @@
-# `cursor` — shared cursor-pagination machinery (rf2-ee38b.19)
+# `cursor` — shared cursor-pagination machinery
 
 > **Type:** Reference (`tools/mcp-base/spec/`)
-> Owns the cross-MCP cursor codec, the EDN-with-no-tagged-literals reader, the size cap, the `::malformed` recovery contract, the `:limit` clamp, and the `cursor-stale-result` envelope. The cursor PAYLOAD shape is consumer-side (story carries `{:offset :total :sig}`; pair carries `{:after-id :ms :until-ms :frame}`).
+> Owns the cross-MCP cursor codec, the EDN-with-no-tagged-literals reader, the size cap, the `::malformed` recovery contract, the `:limit` clamp, and the `cursor-stale-result` envelope. The cursor payload shape is consumer-side (story carries `{:v :offset :total :sig}`; pair carries `{:after-id :ms :until-ms :frame}`).
 
 This doc is one of thirteen per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`egress.md`](egress.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`dedup.md`](dedup.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
 
@@ -42,7 +42,7 @@ Inverse of `b64-encode`.
 
 Normalise the `:limit` MCP arg into an integer in `[1, max]`, defaulting to `default`. Caller-supplied values above `max` clamp DOWN (a legitimate large request still works, just capped). Delegates to `args/parse-positive-int` for the shared string/number coercion, then applies the ceiling.
 
-Each server bakes its own `default` (story 25, pair 50) and `max` (story's 200; pair's wire-cap is the implicit ceiling) — the convention is the CLAMP behaviour, not the numbers.
+Each server bakes its own `default` (story 25, pair 50) and `max` (story 200, pair 1000) — the convention is the clamp behavior, not the numbers.
 
 ### `encode-cursor payload` — payload map → base64 string
 
@@ -55,9 +55,9 @@ Decode an opaque base64 cursor back to its EDN payload map.
 Returns:
 
 - `nil` — the cursor arg is absent (nil / undefined) or blank. The caller treats this as "start from the beginning" (offset 0 / head).
-- `::malformed` — the cursor exists but is not a well-formed, `valid?`-passing payload map: it failed to base64/EDN-decode, carried a tagged literal, decoded to MORE THAN ONE EDN form (a trailing object after the payload map — rf2-ykv9a0), exceeded `max-cursor-bytes`, or its payload map failed the consumer's `valid?` predicate. Callers treat `::malformed` exactly like a STALE cursor — drop it and restart.
+- `::malformed` — the cursor exists but is not a well-formed, `valid?`-passing payload map: it failed to base64/EDN-decode, carried a tagged literal, decoded to more than one EDN form, exceeded `max-cursor-bytes`, or failed the consumer's `valid?` predicate. Callers treat `::malformed` like a stale cursor — drop it and restart.
 
-`valid?` is the consumer's payload-shape predicate (e.g. `#(and (map? %) (integer? (:offset %)) (string? (:sig %)))` for story; `#(and (map? %) (string? (:after-id %)))` for pair).
+`valid?` is the consumer's payload-shape predicate. Story validates `:v`, natural `:offset`/`:total`, and a string `:sig`. Pair requires a present, non-nil `:after-id` of any EDN-printable type because epoch ids are opaque.
 
 Hardened: non-string input → `::malformed`; oversize input → `::malformed` BEFORE parsing; the input is decoded exactly once.
 
@@ -86,11 +86,11 @@ The EDN reader inside `decode-cursor` rejects **every** tagged literal — custo
 - A `:default` data-reader throws `:rf.error/mcp-cursor-bad-edn-tag` on every **unregistered** tag (`#js`, `#foo/bar`, …).
 - `:readers` overrides throw on the **built-in** `#inst` / `#uuid` tags. These have registered readers (`clojure.edn` / `cljs.reader` resolve them from `*data-readers*` / the tag-table), so they **bypass `:default`** and would otherwise decode to a host `java.util.Date` / `UUID` (JVM) or `js/Date` / `cljs.core/UUID` (CLJS). Because `:readers` is consulted **before** `:default` on both platforms, the override wins and the built-in tag never materialises a host object.
 
-A hostile / corrupt cursor therefore cannot smuggle any tagged literal — or the host object it would decode to — past the reader. The throw is caught by the surrounding try in `decode-cursor` and surfaces as `::malformed`. (This closes the built-in-tag hole found in the rf2-13wbe correctness review: `pair-mcp`'s permissive `some? :after-id` predicate would have let `{:v 1 :after-id 1 :junk #inst "…"}` survive validation, carrying a `Date` through the MCP cursor boundary.)
+A hostile or corrupt cursor therefore cannot smuggle a tagged literal, or the host object it would decode to, past the reader. The surrounding `decode-cursor` catch maps the rejection to `::malformed` before the consumer's shape predicate runs.
 
-## One-form requirement (rf2-ykv9a0)
+## One-form requirement
 
-A cursor is **one** opaque EDN payload map. The reader (`read-edn-no-tags`) requires the decoded text to be **exactly one form** and rejects any trailing form as `::malformed`. A plain `read-string` reads only the FIRST form and never checks exhaustion, so before this a token whose decoded text was a valid map followed by a second form — e.g. `{:v 1 :offset 0 :sig "s"} #inst "2024-01-01"` or `{…} {:junk 1}` — decoded as the valid map, silently ignoring the trailing object and weakening the opacity / corruption guard.
+A cursor is **one** opaque EDN payload map. `read-edn-no-tags` requires the decoded text to be exactly one form and rejects any trailing form as `::malformed`; a plain `read-string` would read only the first form without proving exhaustion.
 
 ### Why not the naive one-element-vector wrap — the injected-`]` bypass
 
@@ -108,14 +108,9 @@ The sentinel is a qualified, unguessable keyword (`:re-frame.mcp-base.cursor/cur
 
 This is a pure-`read-string` technique that behaves identically on the JVM (`clojure.edn`) and CLJS (`cljs.reader`) without reaching into either host's pushback-reader internals; tagged literals anywhere inside the wrapped text still throw via the `:readers` / `:default` overrides above. The injected-`]` bypass and the reproduced-sentinel case are both pinned in `cursor_test`'s `decode-cursor-rejects-trailing-forms`.
 
-## Why this ns
+## Why this namespace
 
-Both servers previously hand-rolled the SAME machinery:
-
-- `tools/story-mcp/.../cursor.cljc` — offset/total/sig over append-mostly registries.
-- `tools/re-frame2-pair-mcp/.../cursor.cljs` — after-id/ms over the bounded epoch ring.
-
-The cursor PAYLOAD differs by domain, but the base64 codec, the EDN reader with tagged-literal rejection + size guard, the `::malformed` recovery contract, the `:limit` clamp, and the `cursor-stale-result` envelope are identical. Earlier the README argued the codec was consumer-side because `js/Buffer` vs `java.util.Base64` differ — story-mcp's `cursor.cljc` refuted that — the codec lifts cleanly as a `.cljc` reader-conditional.
+The payload differs by domain, but the base64 codec, tagged-literal rejection, size guard, malformed recovery, limit clamp, and stale-result vocabulary are shared. Reader conditionals isolate the `java.util.Base64` and `js/Buffer` host adapters.
 
 ## See also
 
@@ -123,4 +118,3 @@ The cursor PAYLOAD differs by domain, but the base64 codec, the EDN reader with 
 - [`vocab.md` §JSON-RPC error codes + cross-MCP error reasons](vocab.md) — the `cursor-stale-reason` key.
 - [`args.md`](args.md) — `parse-positive-int`, used by `parse-limit-arg`.
 - `spec/Tool-Pair.md` §Cursor pagination — the framework-level rule the codec implements.
-- rf2-ee38b.19 — the bead that landed this ns.

--- a/tools/mcp-base/spec/dedup.md
+++ b/tools/mcp-base/spec/dedup.md
@@ -1,4 +1,4 @@
-# `dedup` — structural-dedup encode step at the wire boundary (rf2-ttspi7)
+# `dedup` — structural-dedup encode step at the wire boundary
 
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > Owns the cross-MCP FORWARD (encode) half of wire-boundary structural dedup — `empty-payload?` and `dedup-value` over `day8/de-dupe`'s equality walk. The INVERSE (`dedup-expand`) is test-only and deliberately stays consumer-side. Diff-encode (the epoch `:db-after` transform that runs just before dedup) lives in [`diff-encode.md`](diff-encode.md); the wire-cap that runs just after lives in [`cap.md`](cap.md).
@@ -14,7 +14,7 @@ Both shipped servers emit the same kinds of duplicate-rich payloads:
 - **re-frame2-pair-mcp** — the `:epochs` slice (`:db-before` + a path-keyed `:db-after` diff against it) and the per-tick subscribe `:events` vector.
 - **story-mcp** — `run-variant` results (`:app-db` + `:snapshot` + `:rendered-hiccup`, the same sensitive values reappearing across three derived trees), assertion vectors, recorder replay tuples.
 
-The encode step (`empty-payload?` + `dedup-value`) was byte-identical across both servers. rf2-ttspi7 lifted it here so the two servers cannot drift on a dedup-algorithm change. rf2-ywkiss then removed the per-consumer pass-through `dedup` namespaces that had re-exported it: both servers now require `re-frame.mcp-base.dedup` **directly**, and the canonical behaviour is asserted once, cross-host (JVM + CLJS), in `re-frame.mcp-base.dedup-test` rather than duplicated in each consumer's suite.
+Both servers require `re-frame.mcp-base.dedup` directly. The shared `.cljc` transform and marker shape are exercised on JVM and CLJS by `re-frame.mcp-base.dedup-test`.
 
 ## Scope
 
@@ -53,7 +53,7 @@ True for values where dedup yields no win *without even running `de-dupe-eq`* �
        (contains? cache (de-dupe.core/make-cache-element 0))))
 ```
 
-True when a `de-dupe-eq` cache made **no** substitutions — it carries exactly the one root entry (`de-dupe.cache/cache-0`) and nothing else, because the payload had no repeated subtrees. `de-dupe-eq` always emits `cache-0` for the whole structure and adds a further `cache-N` entry per substituted subtree, so a **one-entry** cache is unambiguously root-only. Such a cache, once wrapped, is strictly LARGER than the raw input (the `{:rf.mcp/dedup-table {cache-0 …}}` envelope adds two map layers for zero sharing win), so `dedup-value` returns the original value instead — the documented no-repeat-payloads-stay-raw contract must hold for ordinary collections, not just the empty / scalar degenerate cases. The check is on cache SHAPE, not a re-walk of the value; the explicit `cache-0` key guard hedges a future `de-dupe` change that keyed the root differently.
+True when a `de-dupe-eq` cache contains only its `cache-0` root entry and therefore made no substitutions. Wrapping that cache would only grow the payload, so `dedup-value` returns the original collection. The explicit root-key check verifies the shape expected from the pinned dependency.
 
 ### `dedup-value v enabled?` → value
 
@@ -75,20 +75,20 @@ Values reaching the wire boundary are equality-shared, not identity-shared: re-f
 
 ## The inverse stays consumer-side
 
-`dedup-expand` (the inverse of `dedup-value`) is NOT lifted. It is never called by either MCP server at runtime, so it is test-only, and each consumer keeps it in ITS TEST corpus's shared test-helper ns (rf2-ywkiss):
+`dedup-expand` (the inverse of `dedup-value`) is not a production base API. Neither MCP server calls it at runtime; consumer tests keep small expansion helpers in their test-support namespaces:
 
 - **re-frame2-pair-mcp** keeps it in `re-frame2-pair-mcp.test-utils`.
 - **story-mcp** keeps it in `re-frame.story-mcp.test-support`.
 
-Lifting only the forward direction — and keeping each inverse test-side — means no production consumer namespace re-exports a base surface. This is the deliberate RULE recorded under rf2-ttspi7 (encode lifted) + rf2-ywkiss (facades removed, inverse moved test-side), not an oversight.
+Keeping the inverse test-side means no production consumer namespace re-exports a test-only base surface.
 
 ## Wire shape
 
-A deduped payload is wrapped in a top-level marker `{:rf.mcp/dedup-table <cache-map>}`, sourced from `vocab/dedup-table-key` so the slot is byte-identical across servers — an agent that learned the slot on one server recognises it on the other. Agents reconstruct by calling `de-dupe.core/expand` on the cache-map value.
+A deduped payload is wrapped in a top-level marker `{:rf.mcp/dedup-table <cache-map>}`, sourced from `vocab/dedup-table-key` so both servers use the same slot key — an agent that learned the slot on one server recognises it on the other. Agents reconstruct by calling `de-dupe.core/expand` on the cache-map value.
 
 ## The `day8/de-dupe` dep
 
-`dedup.cljc` is the one base namespace with an external runtime dep: `day8/de-dupe`, pinned to git-tag `v0.3.0` (the same tag both consumers previously pinned, rf2-obpa9 / rf2-90eft / rf2-nw6sj). It is framework-agnostic — a pure persistent-data-structure walker, `.cljc` both arms — so it sits cleanly inside the base's zero-impl-dep / no-consumer-transport-dep rule. Pinning it here keeps the base + both servers in lockstep.
+`dedup.cljc` is the one base namespace with an external runtime dep: `day8/de-dupe`, pinned to git-tag `v0.3.0`. It is a framework-agnostic `.cljc` persistent-data-structure walker, so it preserves the base's zero-implementation-dependency and no-transport-dependency rules.
 
 ## See also
 
@@ -96,5 +96,3 @@ A deduped payload is wrapped in a top-level marker `{:rf.mcp/dedup-table <cache-
 - [`diff-encode.md`](diff-encode.md) — the epoch `:db-after` transform that runs immediately before dedup in re-frame2-pair-mcp's pipeline.
 - [`cap.md`](cap.md) — the wire-cap that runs immediately after dedup (dedup shrinks first).
 - [`vocab.md`](vocab.md) — the `:rf.mcp/dedup-table` marker key.
-- rf2-obpa9 / rf2-90eft — the beads that landed dedup in re-frame2-pair-mcp and story-mcp respectively.
-- rf2-ttspi7 — the bead that lifted the byte-identical encode step here.

--- a/tools/mcp-base/spec/descriptor-manifest.md
+++ b/tools/mcp-base/spec/descriptor-manifest.md
@@ -1,13 +1,13 @@
 # `descriptor-manifest` — MCP tool-descriptor manifest generator + drift-check
 
 > **Type:** Reference (`tools/mcp-base/spec/`)
-> The shared, platform-agnostic serialiser + drift-check that lets BOTH MCP servers (`re-frame2-pair-mcp`, `story-mcp`) GENERATE / VALIDATE a committed `tool-descriptors.edn` manifest from their tool registry — so adding / removing / renaming an MCP tool goes RED in CI until the manifest is regenerated. Models the project's API-governance keystone (`rf2-3nbl5.2`, `spec/api-manifest.edn`) on the MCP descriptor surface (`rf2-sofwv`).
+> The shared, platform-agnostic serialiser and drift-check that lets both MCP servers generate and validate `tool-descriptors.edn` from their registries.
 
 This doc is one of thirteen per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`egress.md`](egress.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`dedup.md`](dedup.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md).
 
 ## The problem it solves
 
-Each MCP server has ONE truth — its tool registry (the ordered vector that bundles every tool's name, descriptor, handler, …). The `tools/list` wire surface is a projection of that registry; so were the hand-maintained `test/fixtures/tool-names.json` lists the Node stdio-roundtrip and the cross-server conformance harness compared against. Projections drift: a tool added / removed / renamed in the registry silently diverged from the committed projection until a same-language unit test (if one existed) caught it.
+Each MCP server's registry is the source for its `tools/list` surface. The committed manifest is a generated governance projection of that registry and its deterministic descriptor composition.
 
 A generated, CI-guarded manifest prevents the drift the way the keystone's `spec/api-manifest.edn` prevents public-API drift: the committed `tool-descriptors.edn` is regenerated in memory and compared; any difference fails the gate.
 
@@ -17,8 +17,8 @@ A generated, CI-guarded manifest prevents the drift the way the keystone's `spec
 
 - The **catalogue-row projection** (`descriptor->row`): the stable shape one registry descriptor maps to.
 - The **deterministic, byte-stable, LF-pinned EDN serialiser** (`render-edn`) — one tool row per line for surgical diffs.
-- The **drift-check** (`check`): regenerate-in-memory vs committed, with an added / removed / **changed** name diff for the failure message. `:changed` (rf2-y3qpv) names every tool present in BOTH manifests whose catalogue row drifted (a changed `:description` / `:input-keys` / `:gated-input-keys` / `:required` / `:output?` / `:annotations` / `:typicalTokens`) and carries its `{:name :old :new}` rows, so a tool-set-identical-but-descriptor-changed drift is row-level actionable instead of forcing a manual whole-manifest diff.
-- The **drift-report formatter** (`drift-report-lines`, `row-slot-deltas`, `governed-slots`, rf2-cbgc40): the PURE diagnostic body both generators print when a drift-check trips. `governed-slots` is the canonical per-tool slot vector (every row slot except `:name`); `row-slot-deltas` names which of them moved between an old and new row; `drift-report-lines` turns a `check` result + the consumer's two wording strings into the printable added / removed / changed / malformed report lines. Centralised so the two servers report the SAME governed surface + the SAME body (they previously duplicated the vector and the whole traversal).
+- The **drift-check** (`check`): regenerate-in-memory vs committed, with added, removed, and row-level changed details.
+- The **drift-report formatter** (`drift-report-lines`, `row-slot-deltas`, `governed-slots`): a pure, shared diagnostic body; consumers supply only their command-specific wording and I/O.
 - `build-rows` / `build-manifest` — the small assembly helpers between the two.
 
 `descriptor-manifest` does NOT own:
@@ -41,14 +41,14 @@ A generated, CI-guarded manifest prevents the drift the way the keystone's `spec
  :typicalTokens    <int response-payload token hint, or nil>}
 ```
 
-`:required` and `:typicalTokens` (rf2-cwhod2) guard the live API-semantics facets the original narrow projection missed:
+`:required` and `:typicalTokens` guard live API-semantics facets:
 
 - **`:required`** — the SORTED subset of `:input-keys` the descriptor's `:inputSchema :required` marks mandatory (empty when none). Surfaces an argument silently flipping required↔optional — a contract change a `:input-keys`-only gate (which sees only that the key *exists*) would miss. **This subset relation is ENFORCED, not assumed.** `:input-keys` (from `:inputSchema :properties`) and `:required` (from `:inputSchema :required`) are read from independent descriptor sources, so the raw shape does not force the relation. `descriptor->row` rejects a descriptor whose required keys are not a subset of its property keys — it throws an `ex-info` (`:tool` / `:required` / `:input-keys` / `:missing`) rather than emitting a self-inconsistent row (`:input-keys ["known"]` with `:required ["missing"]`) that would bless a mandatory argument the advertised input surface never declares and break the default/gate-open surface derivation.
 - **`:typicalTokens`** — the integer response-payload token-budget hint AI clients read to pick size-conscious args (`max-tokens` / `cache` / `cursor`). `nil` when a tool declares no hint (forward-compatible; the slot still renders so every row shares one shape). Surfaces a token-budget hint drifting.
 
-`:gated-input-keys` (rf2-qo3wvp) models the **two-profile** `tools/list` surface explicitly:
+`:gated-input-keys` models the **two-profile** `tools/list` surface explicitly:
 
-- **`:gated-input-keys`** — the SORTED subset of `:input-keys` the server's DEFAULT `tools/list` profile gates OFF behind an operator-only gate (empty when the tool gates no input — the slot still renders so every row shares one shape). `:input-keys` stays the FULL union of every input that can appear on any supported deterministic profile (the gate-OPEN surface), and `:gated-input-keys` names which of those the default profile hides. The default surface is therefore `:input-keys` *minus* `:gated-input-keys`; the gate-open surface is `:input-keys` verbatim — both derivable from one byte-stable row. The live case is story-mcp's `:include-sensitive` knob: six value-surfacing tools bake it into their static descriptor, and the default profile strips it whenever `--allow-sensitive-reads` is closed (the closed-by-default posture). Before this slot, projecting the raw descriptor put `:include-sensitive` in `:input-keys`, so the manifest advertised an input the default surface deliberately hid — the governance artefact disagreed with the surface it claims to guard. The set of gated keys is config-INDEPENDENT (the static slot set the server KNOWS it gates, not a read of the live gate atom), so the manifest stays deterministic. A drift in which inputs are gated — a tool newly gating an input, or a gate lifted — trips the drift gate as a `:changed` row.
+- **`:gated-input-keys`** — the sorted subset of `:input-keys` hidden by the server's default `tools/list` profile. `:input-keys` remains the full gate-open surface, so both profiles are derivable from one row. The gated-key set is static configuration, not a read of a live gate atom, which keeps generation deterministic.
 
 ### Why this shape, not the whole descriptor
 
@@ -67,7 +67,7 @@ The full descriptor maps carry deeply-nested JSON-Schema fragments whose exact s
 | `row-slot-deltas` | `[old-row new-row]` | seq of `[slot old new]` for the `governed-slots` that differ |
 | `drift-report-lines` | `[check-result {:keys [regenerate-line missing-file-line]}]` | vector of printable report lines (pure — no I/O, no exit) |
 
-The optional `gated-keys` arg (rf2-qo3wvp) is the SET of input-key strings the server's default `tools/list` profile gates off (story-mcp passes `#{"include-sensitive"}`; pair-mcp omits it → the empty default). It is config-independent — the static slot set the server knows it gates, not a read of the live gate — so the manifest stays deterministic. Each row's `:gated-input-keys` is the per-tool intersection of this set with the descriptor's actual input keys.
+The optional `gated-keys` arg is the set of input-key strings the server's default `tools/list` profile gates off (story-mcp passes `#{"include-sensitive"}`; pair-mcp uses the empty default). Each row records the intersection with its actual input keys.
 
 ## Determinism + byte-stability
 
@@ -84,10 +84,10 @@ The optional `gated-keys` arg (rf2-qo3wvp) is the SET of input-key strings the s
 | story-mcp | `re-frame.story-mcp.descriptor-manifest-gen` | JVM | `registry/tool-registry` | `clojure -M:gen [--check]` |
 | re-frame2-pair-mcp | `re-frame2-pair-mcp.descriptor-manifest-gen` | CLJS / Node | `registry/tool-descriptors` | `npm run gen:descriptors` / `npm run check:descriptors` |
 
-Each generator reads its registry descriptors WITHOUT consulting the **live operator gate** (story-mcp's `--allow-sensitive-reads` atom) so the manifest is deterministic and config-independent. The raw descriptor it reads carries the FULL gate-OPEN input surface; the manifest records which inputs the DEFAULT profile gates off in `:gated-input-keys` (below) rather than depending on the runtime gate state. It also projects the **deterministic** universal input splices that are part of the actual `tools/list` surface (rf2-cwhod2):
+Each generator reads registry descriptors without consulting the live operator gate. The manifest records the full gate-open input surface plus its default-hidden subset, and includes deterministic universal input splices that are part of `tools/list`:
 
 - **re-frame2-pair-mcp** splices the universal `max-tokens` / `cache` knobs onto every descriptor at `tools/list` time (`tools/descriptors.cljs` — `with-budget-knob` / `with-cache-knob`). The generator applies those SAME composers, in the same order, BEFORE projecting, so the manifest's `:input-keys` reflect the actual `tools/list` input surface. The splices are deterministic — they consult only the descriptor + the static `registry/cacheable?` predicate, not any operator flag — so the manifest stays byte-stable and config-independent. (Whether `cache` is spliced encodes a tool's read/action cacheability classification; a drift there now trips the gate.) pair-mcp gates NO input key off behind an operator flag (its `eval-cljs` gate is default-ON and gates a whole TOOL, not an input property), so it passes no gated-key set and every pair-mcp row carries `:gated-input-keys []`.
-- **story-mcp** bakes its universal `max-tokens` knob into each descriptor's `:inputSchema :properties` at def-time (`schemas/with-max-tokens`), so that knob already rides the raw registry descriptor — no generator-side splice needed. The raw descriptor also carries the operator-gated `:include-sensitive` knob (which the default profile strips when `--allow-sensitive-reads` is closed). So the raw descriptor is NOT the default `tools/list` surface — it is the gate-OPEN surface. The generator passes `registry/gated-input-keys` (`#{"include-sensitive"}` — the SAME set `registry/strip-include-sensitive` removes at `tools/list` time) to `build-manifest`, so each row's `:gated-input-keys` (rf2-qo3wvp) records the default-stripped subset. The default surface is `:input-keys` minus `:gated-input-keys`; the gate-open surface is `:input-keys` verbatim.
+- **story-mcp** bakes `max-tokens` into raw descriptors. It passes the static `registry/gated-input-keys` set so rows distinguish the gate-open surface from the default profile that hides `include-sensitive`.
 
 The committed manifest lives at each artefact's root: `tools/<server>/tool-descriptors.edn`.
 
@@ -99,5 +99,5 @@ The committed manifest lives at each artefact's root: `tools/<server>/tool-descr
 ## See also
 
 - [`README.md`](README.md) — the per-namespace index this doc is part of.
-- [`../../../spec/api-manifest.edn`](../../../spec/api-manifest.edn) + `implementation/scripts/api-manifest/` — the keystone (`rf2-3nbl5.2`) this generator models on the MCP descriptor surface.
+- [`../../../spec/api-manifest.edn`](../../../spec/api-manifest.edn) + `implementation/scripts/api-manifest/` — the analogous public API manifest machinery.
 - [`handler-arity.md`](handler-arity.md) — the cross-server registry-shape divergence; the two registries this manifest projects differ in handler arity but share the descriptor slots this gate reads.

--- a/tools/mcp-base/spec/diff-encode.md
+++ b/tools/mcp-base/spec/diff-encode.md
@@ -1,7 +1,7 @@
-# `diff-encode` — path-keyed structural diff (rf2-1wdzp)
+# `diff-encode` — path-keyed structural diff
 
 > **Type:** Reference (`tools/mcp-base/spec/`)
-> Each `:rf/epoch-record` carries `:db-before` and `:db-after` — near-identical full app-db snapshots. `pr-str` doesn't preserve structural sharing, so on the wire the pair is roughly 2× app-db per epoch; a 50-epoch default `:epochs` slice ⇒ up to 100× app-db. This ns replaces `:db-after` with a **path-headed cluster projection** (rf2-qeous) of a path-keyed structural diff against `:db-before` so the wire payload approaches the structural-sharing cost rather than the deep-copy cost. The patch list is grouped into path-breadcrumb sections via [`section-grouping.md`](section-grouping.md).
+> Each `:rf/epoch-record` carries near-identical `:db-before` and `:db-after` values. This namespace replaces `:db-after` with path-headed sections over a structural diff against `:db-before`, reducing repeated wire data while preserving lossless replay.
 
 This doc is one of thirteen per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`egress.md`](egress.md), [`elision.md`](elision.md), [`args.md`](args.md), [`section-grouping.md`](section-grouping.md), [`dedup.md`](dedup.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
 
@@ -19,13 +19,13 @@ The path-headed **cluster grouping** (the `:sections` projection) is owned by [`
 
 `diff-encode` does NOT own:
 
-- The `:rf/epoch-record` shape itself — that's framework-side per [`../../../spec/Tool-Pair.md`](../../../spec/Tool-Pair.md) (the time-travel slice) and the `day8/re-frame2-epoch` artefact (rf2-lt4e).
+- The `:rf/epoch-record` shape itself — that is framework-owned per [`../../../spec/Tool-Pair.md`](../../../spec/Tool-Pair.md).
 - The wire transport — diffed records ride on whatever the consumer's wire surface is.
 - The `:rf.mcp/diff-from` marker key — that lives in [`vocab.md`](vocab.md).
 
 ## What the transform does
 
-Replaces `:db-after` with a **path-headed cluster projection** (rf2-qeous) of a path-keyed structural diff against `:db-before`:
+Replaces `:db-after` with a path-headed cluster projection of a structural diff against `:db-before`:
 
 ```clojure
 {:db-before <full>
@@ -45,14 +45,14 @@ The flat patch list is grouped into **sections** — each headed by a `:section-
 
 | Form | Meaning | Example |
 |---|---|---|
-| `[<path> :assoc <new-value>]` | Set the value at `path` to `new-value` (creates the slot if it didn't exist). A **missing / `nil` intermediate parent auto-vivifies by the NEXT segment's type** — a non-integer segment (e.g. a map key) vivifies a **map** (`{} + [[[:a :b] :assoc 2]] ⇒ {:a {:b 2}}`); an **integer** segment (a vector index) vivifies a **vector**, at index `0` only (`{} + [[[:items 0 :qty] :assoc 2]] ⇒ {:items [{:qty 2}]}`, NOT `{:items {0 {:qty 2}}}` — an int-keyed map is a shape neither encoder side ever emits, rf2-x2vapx). `path` may end in a numeric **vector index** (`assoc-in` accepts integer indices). A **PRESENT non-associative intermediate parent** (a scalar, or a vector reached by a non-integer / out-of-range key), OR an **out-of-range integer segment against an absent parent** (anything but `0`, since a freshly-vivified vector is empty), is a base/patch mismatch and raises `:rf.error/bad-diff-replay` — see the replay-safety note below. | `[[:user :name] :assoc "alice"]` · `[[:items 0 :qty] :assoc 2]` |
+| `[<path> :assoc <new-value>]` | Set the value at `path`. A missing/nil parent vivifies according to the next segment: a map for a non-integer key, or a vector for index `0`. A present non-associative parent or impossible vector index raises `:rf.error/bad-diff-replay`. | `[[:user :name] :assoc "alice"]` · `[[:items 0 :qty] :assoc 2]` |
 | `[<path> :dissoc]` | Remove the key at `path`. A **no-op** when the key doesn't exist OR when the parent is not a map — vector-element `:dissoc` is unsupported (see vector section below). | `[[:user :temp-flag] :dissoc]` |
 
 Patches are applied **in order** within the flattened list; later patches see the state after earlier patches. The section grouping is deterministic (sorted by `:section-path`), so concatenating every section's `:patches` reproduces a stable, replayable patch list.
 
 The patch tuple grammar is pinned as a Malli schema (`patch-schema` / `patches-schema`) and validated at BOTH the encoder boundary (`diff-encode-db-after`) and the decoder boundary (`apply-patches`); the section grammar is pinned as `section-schema` / `sections-schema`. Validation soft-passes when Malli is not on the runtime classpath (mcp-base stays Malli-free at its own dep boundary; consumers bring Malli), and is `goog-define`-elidable on CLJS production builds via `validate-patches?`.
 
-## Vectors: same-length structural diff, length changes whole-leaf (rf2-cwhod2)
+## Vectors: same-length structural diff, length changes whole-leaf
 
 Maps recurse key-by-key; **same-length** vectors recurse element-by-element under numeric **index** paths. A single item update inside a large vector/list app-db value — a table row, a card, a queue/log entry — therefore yields an actionable item-level patch:
 
@@ -63,13 +63,13 @@ Maps recurse key-by-key; **same-length** vectors recurse element-by-element unde
 
 This preserves the token-budget premise for the dominant in-place-update app-db shapes. Integer index keys ride through the existing `assoc-in` replay (which accepts integer vector indices) and the path-generic section-grouping unchanged — **no decoder change is required**.
 
-A vector **length change** (an insert / delete) is emitted as a single whole-vector `[path :assoc <new-vector>]` replacement. Element-level vector insert/delete semantics are deliberately **not designed**: the grammar's numeric `:assoc` reaches an index via `assoc-in`, which only overwrites-in-place or grows by one at the tail (no shift primitive), and `[<index-path> :dissoc]` is a documented **no-op against a vector parent** (`dissoc-in` dissocs only into a MAP parent, rf2-ykv9a0). Same-length diffing is lossless for in-place updates; a length delta falls back to the unambiguous whole-vector replacement rather than ship a half-designed splice encoding. Non-vector sequentials (lists, lazy seqs) are also whole-leaf replaced — only `vector?` collections diff structurally, so the index-path replay always targets a vector.
+A vector length change is emitted as one whole-vector replacement. Numeric `:assoc` only overwrites an existing index (or index 0 on a newly vivified vector), and `:dissoc` is a no-op against vector parents; there is no splice grammar. Same-length vectors may diff by index. Other sequential types are whole-leaf replacements.
 
 ## Why patches, not `clojure.data/diff`
 
 `clojure.data/diff`'s parallel-vector sparse form (with `nil` placeholders meaning "common at this position") loses information once you only carry one half plus the original — you can't tell `nil` (the leaf value `nil`) apart from `nil` (the no-change sentinel). Path-keyed patches are unambiguous for any value the runtime can produce: a changed vector element rides under a numeric **index** path (`[[:items 0 :qty] :assoc 2]`), which carries the position explicitly and never relies on a positional `nil` sentinel.
 
-The encoder honours the same **no in-band sentinel** principle for the KEY side: added-key detection keys off key **presence** (`find`), never a marker value (rf2-znjqja). An earlier `(get a k ::absent)` conflated "key missing" with "key present holding a value equal to the marker", so an unchanged key whose app-db leaf happened to equal `:re-frame.mcp-base.diff-encode/absent` was mis-reported as `:added` — a spurious `[path :assoc value]` false patch (replay still reconstructs the value, but the wire diff lies to the agent). `find` returns the `[k v]` entry for any present key (including a present `nil`) and `nil` only for a genuinely absent key, so no runtime value can collide.
+Added-key detection uses key presence (`find`), never an in-band marker value. This distinguishes a missing key from a present key holding nil or any sentinel-shaped application value.
 
 ## Self-contained records
 
@@ -81,7 +81,7 @@ The alternative — diffing each `:db-after` against the *previous* epoch's `:db
 
 The `:rf.mcp/diff-from` marker key lives in [`vocab.md`](vocab.md); the same shape applies wherever an MCP tool ships an epoch-shaped record. Agents pattern-match on the marker to invoke their local decoder.
 
-`:diff-from` is the slot pointer — a keyword naming which sibling slot in the same record holds the base for the diff. Currently always `:db-before`; the indirection is preserved for forward compatibility (e.g. a future `:db-mid-microstep` slot).
+`:diff-from` is the slot pointer naming the sibling base. The closed marker grammar currently permits only `:db-before`.
 
 ## Decoder algorithm
 
@@ -104,15 +104,15 @@ The `:db-after` marker carries `:sections`, so the decoder first flattens the pe
       db-after)))   ; not diff-encoded; passthrough
 ```
 
-> **`:dissoc` is a no-op when the key does not exist (rf2-ykv9a0).** The decoder routes nested `:dissoc` through a `dissoc-in` helper that dissocs only when the parent path resolves to a map. A naive `(update-in acc parent dissoc k)` violated the spec contract two ways: a MISSING parent manufactured nil branches (`{} + [[[:missing :leaf] :dissoc]] ⇒ {:missing nil}`), and a SCALAR parent threw a host `ClassCastException` at the wire decoder boundary. `apply-patches` is the public decoder; a malformed / corrupt / third-party diff replayed against a mismatched base must neither corrupt the base into a shape neither side emitted nor crash — so the missing-/scalar-parent case is a no-op, honouring the contract below.
+> **`:dissoc` is a no-op when the key does not exist.** Nested dissociation only acts when the parent resolves to a map. Missing, scalar, and vector parents remain unchanged rather than manufacturing branches or leaking a host exception.
 
-> **`:assoc` raises a structured error on a non-associative intermediate parent (rf2-glybzz).** The `:assoc` peer of the `dissoc-in` guard. The decoder routes nested `:assoc` through an `assoc-in-safe` helper, which vivifies via `vivify-assoc-in`. A MISSING / `nil` intermediate parent auto-vivifies — the intended create-if-absent grammar — but the container shape follows the **next segment's type**, not a blanket map default: a non-integer segment (a map key) vivifies a map (`{} + [[[:a :b] :assoc 2]] ⇒ {:a {:b 2}}`), unchanged from before; an **integer** segment (a vector index) vivifies a **vector** (`{} + [[[:items 0 :qty] :assoc 2]] ⇒ {:items [{:qty 2}]}`), at index `0` only — any other integer against an absent parent is rejected below, since a freshly-vivified vector is empty. Before this fix (rf2-x2vapx), the naive `assoc-in`-based vivification always produced a map regardless of segment type, so an integer segment against a missing parent silently produced an **int-keyed map** (`{:items {0 {:qty 2}}}`) — a shape NEITHER encoder side ever emits (`collect-vector-patches-into` only reaches an index path via an already-present, same-length vector on both sides), reachable only via a malformed / corrupt / third-party diff replayed against an absent base. But a PRESENT non-associative intermediate parent — a SCALAR (`{:a 1} + [[[:a :b] :assoc 2]]`) or a vector reached by a non-integer / out-of-range key — is a base/patch **mismatch**: the naive `assoc-in` leaks a raw host `ClassCastException` / `IllegalArgumentException` with nil `ex-data` at the wire decoder boundary. Unlike `:dissoc` (where "remove a key from a non-map" is naturally a no-op), neither silent recovery is safe for `:assoc` — a no-op would drop the requested write (data loss), clobbering the scalar with a manufactured map would corrupt the base into a shape neither encoder side emitted (data corruption), and silently vivifying a map for an integer segment is the SAME corruption by another route. The decoder therefore surfaces the drift as a structured `:rf.error/bad-diff-replay` ex-info (`:where` the actual decode boundary, `:recovery :no-recovery`, the offending `:patch-path`, the `:at` prefix where traversal hit the non-associative node, and a value-free `:parent-type` tag — the base may carry sensitive payload, so we report shape, not content). This is a pure structural check during replay (NOT a Malli grammar gate), so it fires on both hosts independently of Malli presence and the `validate-patches?` `goog-define`. Both `apply-patches` (public, validating) and `decode-db-after` (section decoder) route their replay through `assoc-in-safe`, so both surface the structured failure.
+> **`:assoc` raises a structured error on an impossible intermediate shape.** Missing/nil parents vivify as a map or index-0 vector according to the next path segment. A present scalar, a non-integer key into a vector, or an out-of-range vector index is a base/patch mismatch and raises `:rf.error/bad-diff-replay`. Ex-data reports path and parent type, never the parent value. This structural guard runs on both hosts independently of Malli.
 
 The shipped decoder (`decode-db-after`) Malli-validates `:sections` at the decode boundary (`validate-sections!`, symmetric with the encoder's gate) then replays via the non-validating `apply-patches*` to avoid a redundant second Malli walk on the JVM decode hot path. Both story-mcp and re-frame2-pair-mcp consume this shape; the agent-host decoder is small.
 
-> **`decode-db-after` enforces the CLOSED marker-body contract before decoding (rf2-71kxvb).** A `:db-after` map is recognized as a diff marker on the **presence** of the `:rf.mcp/diff-from` key (intent), not on its value being exactly `:db-before`. The conformance contract (`tools/mcp-conformance/wire-vocab` `DiffFromBody`, a CLOSED map) is that a marker is EXACTLY `{:rf.mcp/diff-from :db-before, :sections [...]}` — two top-level keys, the marker value restricted to `:db-before`. The decoder runs a pure **structural** gate (`validate-diff-marker-body!`, no Malli, so it fires on both hosts regardless of Malli presence or the `validate-patches?` `goog-define`) that rejects any marker whose top-level key set is not exactly `#{:rf.mcp/diff-from :sections}` or whose marker value is not `:db-before`, surfacing a structured `:rf.error/bad-diff-marker` ex-info (`:where` the decode boundary, `:recovery :no-recovery`, value-free `:expected-keys` / `:actual-keys` / `:marker-ok?` only — never the app-db payload, EP-0015). This closes two pre-fix gaps the conformance schema forbids but the base decoder silently tolerated: an **extra sibling key** (`{:rf.mcp/diff-from :db-before :sections [] :sneaky :key}`) slipped past the `:sections`-only check, and an **unsupported marker value** (`{:rf.mcp/diff-from :db-later …}`) was treated as 'not a diff' and passed THROUGH unchanged — letting a corrupt / third-party marker survive the decoder. A `:db-after` map carrying NO `:rf.mcp/diff-from` key is an already-full epoch and still passes through to itself.
+> **`decode-db-after` enforces the closed marker-body contract before decoding.** A marker is exactly `{:rf.mcp/diff-from :db-before, :sections [...]}`. Extra keys or another source slot raise value-free `:rf.error/bad-diff-marker` data on both hosts, independent of Malli. A map without `:rf.mcp/diff-from` is a full value and passes through.
 
-The decoder then validates the **raw** `:sections` slot — it does NOT default a `nil` / `false` slot to `[]` (rf2-y3qpv). A diff marker always carries an explicit `:sections` vector; a `{:rf.mcp/diff-from :db-before :sections nil}` marker (present-but-falsey `:sections`) trips `:rf.error/bad-diff-sections` when Malli is present rather than decoding to a silent no-op that erases the epoch's real `:db-after` change. (A `{:rf.mcp/diff-from :db-before}` marker with `:sections` entirely **absent** fails the closed-key-set gate above first, as `:rf.error/bad-diff-marker`.) An explicit `:sections []` — a genuine no-change diff — stays valid and replays to `:db-before` unchanged.
+The decoder validates the raw `:sections` slot rather than defaulting nil/false to `[]`. Missing sections fail the marker-body gate; invalid present sections fail section validation; explicit `[]` is the valid no-change diff.
 
 > **Note** root-path patches: an `[[] :assoc <full>]` patch replaces `base` outright (whole-DB replacement, e.g. `replace-app-db!`); an `[[] :dissoc]` is a no-op by convention.
 
@@ -130,5 +130,3 @@ The conformance harness at `tools/mcp-conformance/` drives epoch-shaped tool res
 - [`section-grouping.md`](section-grouping.md) — the path-headed cluster grouping (`:sections` projection) this ns consumes.
 - [`../../../spec/Tool-Pair.md`](../../../spec/Tool-Pair.md) — the pair-tool runtime contract this ns is downstream of (the time-travel slice that produces `:rf/epoch-record`s).
 - [`vocab.md`](vocab.md) — the `:rf.mcp/diff-from` marker key.
-- rf2-1wdzp — the bead that landed this encoding.
-- rf2-qeous — the path-headed cluster projection (`:sections`) that replaced the flat `:patches` shape.

--- a/tools/mcp-base/spec/egress.md
+++ b/tools/mcp-base/spec/egress.md
@@ -7,10 +7,10 @@ This doc is one of thirteen per-namespace contracts indexed from [`README.md`](R
 
 ## The problem it solves
 
-EP-0015 graduates the named-egress model: an off-box surface chooses *which boundary is this?* — a named `:rf.egress/*` profile — not *which combination of `:rf.size/*` booleans did I remember?*. The framework owns the authoritative table in `re-frame.projection/profile-size-opts` (`implementation/core`), but that namespace transitively requires the framework runtime graph (`re-frame.elision` → `re-frame.frame` → substrate adapter, …). The MCP servers must NOT pull that graph into their wire-egress decision:
+EP-0015 graduates the named-egress model: an off-box surface chooses *which boundary is this?* — a named `:rf.egress/*` profile — not *which combination of `:rf.size/*` booleans did I remember?*. The framework owns the authoritative table in `re-frame.projection/profile-size-opts` (`implementation/core`), but that namespace transitively requires the framework runtime graph. The shared base must remain independent of that graph:
 
-- **re-frame2-pair-mcp** ships as a self-contained Node `server.js` bundle; requiring the runtime graph would bloat it and trip bundle-isolation.
-- The profile→opts resolution is a *server-side* decision (it renders the resolved `:rf.size/*` map into the eval form before it crosses the wire), so it cannot defer to the live app's `project-egress`.
+- **re-frame2-pair-mcp** renders the resolved opts into an nREPL eval form without adding the framework graph to its Node server bundle.
+- **story-mcp** applies the same opts in-process. The pure mirror keeps these two host paths aligned.
 
 This namespace is the pure-data, framework-runtime-free mirror of the six-member closed profile enum and its `:rf.size/*` floor. It is pure data over the keys [`vocab`](vocab.md) already owns (`:rf.size/include-sensitive?` / `:rf.size/include-large?` / `:rf.size/include-digests?`). No transport, no runtime, no framework dep — it loads identically into the JVM (story-mcp) and CLJS (re-frame2-pair-mcp).
 
@@ -24,8 +24,8 @@ This namespace is the pure-data, framework-runtime-free mirror of the six-member
 
 `egress` does NOT own:
 
-- **The authoritative table.** `re-frame.projection/profile-size-opts` (`implementation/core`) is the single source of truth; this is a MIRROR pinned byte-identical to it by the conformance gate (below).
-- **Applying the floor.** Walking a value against the resolved `:rf.size/*` opt-set is the framework's `project-egress` job; this namespace only RESOLVES the named profile to the opt-set the server splices into its eval form.
+- **The authoritative table.** `re-frame.projection/profile-size-opts` (`implementation/core`) is the single source of truth; this is a MIRROR pinned value-for-value to it by the conformance gate (below).
+- **Applying the floor.** This namespace only resolves a profile. Consumers pass the result to the appropriate framework boundary (`project-egress` or `elide-wire-value`), either in-process or through pair-mcp's eval form.
 
 ## The six profiles (EP-0015 §10, CLOSED enum)
 
@@ -51,7 +51,7 @@ The opt-set keys are `vocab/include-sensitive-opt` / `vocab/include-large-opt` /
 | `profile->size-opts` | (def) | `{profile → {:rf.size/include-*? bool}}` table |
 | `profile-size-opts` | `[profile]` | the `:rf.size/*` floor map, or `nil` for an unknown / absent profile |
 
-`profile-size-opts` returns `nil` (not a permissive default) for an unknown or `nil` profile — the closed enum means a caller never silently gets a permissive walk from a typo'd profile name.
+`profile-size-opts` returns `nil` (not a permissive default) for an unknown or absent profile. Callers choose profiles from the closed `profiles` set; this resolver does not validate or throw for them.
 
 ## Determinism + drift protection
 
@@ -62,5 +62,5 @@ The opt-set keys are `vocab/include-sensitive-opt` / `vocab/include-large-opt` /
 
 - [`README.md`](README.md) — the per-namespace index this doc is part of.
 - [`vocab.md`](vocab.md) — the `:rf.size/*` opt keys this table's values are keyed by.
-- [`tools/mcp-conformance/wire-vocab/`](../../mcp-conformance/wire-vocab/) — the JVM-side gate that pins this mirror byte-identical to the framework table.
+- [`tools/mcp-conformance/wire-vocab/`](../../mcp-conformance/wire-vocab/) — the JVM-side gate that pins this mirror equal to the framework table.
 - [`/spec/015-Data-Classification.md`](../../../spec/015-Data-Classification.md) — EP-0015, the named-egress model this namespace mirrors for the MCP wire.

--- a/tools/mcp-base/spec/elision.md
+++ b/tools/mcp-base/spec/elision.md
@@ -43,19 +43,17 @@ Definition (effectively):
 
 The counter is non-negative integer; 0 means nothing was elided. The slot itself rides the response envelope (per [`vocab.md` §Envelope counter slots](vocab.md#envelope-counter-slots)).
 
-**Records are NOT walked.** The walker descends through the explicit collection-type triad (`vector?` / `set?` / `seq?`) plus `map?`, not the broader `coll?` predicate. On CLJS, defrecord instances satisfy `coll?` but neither `map?` nor any of the three sequential predicates, so a record-shaped slot carrying an elision marker is treated as a leaf. This is OK in practice because the wire egress path stamps payloads through `pr-str` / `read-string` so record types are stripped to plain maps before the walker sees them — but JVM-side decoders walking pre-egress data should not rely on record descent.
+The walker descends through maps (including record values that satisfy `map?`), vectors, sets, and seqs. Other values are leaves.
 
 ## Cousin to `sensitive`
 
-`sensitive/strip-sensitive` returns `[kept dropped-count]` for the `:dropped-sensitive` slot; `count-elided-markers` returns the integer for `:elided-large`. Both indicators ride the response envelope together per the cross-MCP indicator-field parity rule.
-
-**Parity is MUST-level.** Indicator-field parity is the round-2 audit fix the conformance gate at `tools/mcp-conformance/wire-vocab/` enforces — one without the other is a wire-protocol break.
+`sensitive/strip-sensitive` returns `[kept dropped-count]` for `:dropped-sensitive`; `count-elided-markers` returns the count for `:elided-large`. Tree-payload emitters compute both, and omit each zero count independently.
 
 ## Cross-platform
 
 Pure-data tree walk; loads identically into JVM (story-mcp) and CLJS (re-frame2-pair-mcp). No transport, no runtime, no framework dep. The walker uses only:
 
-- `map?` / `coll?` host predicates.
+- `map?` / `vector?` / `set?` / `seq?` host predicates.
 - `contains?` membership.
 - `reduce` / `map` recursion.
 
@@ -63,11 +61,11 @@ All available in both CLJ and CLJS without `.cljc` reader-conditional branches.
 
 ## Conformance posture
 
-The conformance harness at `tools/mcp-conformance/` drives every tool with a payload that contains a `{:rf.size/large-elided {…}}` substitution and asserts:
+Base and consumer conformance fixtures assert:
 
 1. The response envelope's `:elided-large` slot is a non-zero integer.
-2. The slot is present **alongside** the `:dropped-sensitive` slot — indicator-field parity.
-3. The counter value equals the visible marker count in the response body (no double-counting; no under-counting).
+2. A zero count omits the slot independently of `:dropped-sensitive`.
+3. The count equals the visible marker count in the response body.
 
 ## See also
 
@@ -75,4 +73,4 @@ The conformance harness at `tools/mcp-conformance/` drives every tool with a pay
 - [`../../../spec/009-Instrumentation.md` §Size elision in traces](../../../spec/009-Instrumentation.md) — the framework primitive this ns counts the output of.
 - [`vocab.md` §Envelope counter slots](vocab.md#envelope-counter-slots) — the `:elided-large` slot definition.
 - [`sensitive.md`](sensitive.md) — the cousin walker; both indicators ride the response envelope.
-- [`../../../spec/Conventions.md` §Cross-MCP indicator-field vocabulary](../../../spec/Conventions.md) — the MUST-level parity between `:dropped-sensitive` and `:elided-large`.
+- [`../../../spec/Conventions.md` §Cross-MCP indicator-field vocabulary](../../../spec/Conventions.md) — the shared indicator rules.

--- a/tools/mcp-base/spec/envelope.md
+++ b/tools/mcp-base/spec/envelope.md
@@ -1,4 +1,4 @@
-# `envelope` — cross-MCP response-envelope helpers (rf2-ee38b.19)
+# `envelope` — cross-MCP response-envelope helpers
 
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > Owns the SHAPE of the indicator-field splice (`with-indicators`) enforcing the MUST-level "omit when zero" rule, plus the wire-bounded `:rf.mcp/*` marker detection used by the cache + cap boundary steps. The indicator KEYS themselves live in [`vocab.md`](vocab.md); this ns owns the splice + detection logic.
@@ -25,11 +25,11 @@ This doc is one of thirteen per-namespace contracts indexed from [`README.md`](R
 
 Splice the cross-MCP indicator-field slots onto a tool's envelope map, enforcing the MUST-level "omit when zero" rule from Conventions §Cross-MCP indicator-field vocabulary and Spec 009 §Indicator field on tool responses.
 
-Every tool that walks a tree-typed payload (`snapshot`, `get-path`, `trace-window`, `watch-epochs`, `subscribe`, …) routes its envelope-tail through here so the rule lives in one place — drift across emit sites can no longer silently violate the MUST.
+Tree-payload emitters route their envelope through this helper so the indicator-key and omit-when-zero rules stay consistent.
 
 `counts`:
 
-- `:dropped` — count of `:sensitive? true` leaves dropped at the wire boundary (from `sensitive/strip-sensitive`). Emitted under `vocab/dropped-sensitive-key` when positive.
+- `:dropped` — count of records classified as sensitive and dropped at the wire boundary, including fail-closed malformed stamps. Emitted under `vocab/dropped-sensitive-key` when positive.
 - `:elided` — count of leaves replaced with the `:rf.size/large-elided` marker (from `elision/count-elided-markers`). Emitted under `vocab/elided-large-key` when positive.
 
 A zero / nil / absent count omits its slot entirely (the "omit when zero" MUST). Returns `envelope` unchanged when both counts are zero — identity-preserving on the common path.
@@ -48,9 +48,9 @@ Matches the EXACT marker key, not merely a prefix of it (see §Exact-key match b
 
 Nil-safe: a nil / non-string `text` is not a marker.
 
-## Why wire-bounded markers matter (rf2-gktyn, rf2-3z0zi)
+## Why wire-bounded markers matter
 
-The `:rf.mcp/cache-hit` and `:rf.mcp/overflow` envelopes are replacement results the cache + cap boundary steps emit themselves. By construction they are sub-cap size — re-walking either is wasted work, and a cache check on a hit-marker would hash the marker, not the original payload. `marker-text?` is the cheap detector every boundary step uses to short-circuit when it sees an earlier step's marker.
+The `:rf.mcp/cache-hit` and `:rf.mcp/overflow` envelopes are replacement results emitted by cache and cap steps. By construction they are sub-cap size; pair-mcp uses `marker-text?` to avoid re-walking them. Consumers that do not chain such boundary steps need not call the detector.
 
 ## Print-form parity
 
@@ -61,11 +61,11 @@ Leading-token match on the rendered text is the cheap detector — the marker ma
 
 Matching both keeps the detector host- and print-setting-agnostic.
 
-## Exact-key match (rf2-3xd9i9)
+## Exact-key match
 
 The detector matches the marker key EXACTLY — not merely as a prefix. After the leading marker-key text matches, the very next character must be an EDN token TERMINATOR (whitespace, `,`, or a map/vector/list/string delimiter) — proving the marker key ended exactly there and was not merely a prefix of a longer key. EDN keyword/symbol constituents (alphanumerics plus `* + ! - _ ' ? < > = . / : # & %`) immediately after the prefix mean the leading key is a LOOKALIKE, not the marker.
 
-This closes a correctness hole a bare `starts-with?` left open: a lookalike leading key whose name begins with a marker key — e.g. `:rf.mcp/overflowed` or `:rf.mcp/cache-hit-extra` — was wrongly classified as an already-bounded marker, so an over-budget payload whose first key merely started with `:rf.mcp/overflow` would bypass cap enforcement. The two real markers always carry a non-empty map value, so the terminator (the space `pr-str` writes before the value) is always present — the exact-match check preserves their short-circuit while rejecting the lookalikes.
+A bare prefix match would also accept lookalike keys such as `:rf.mcp/overflowed`, allowing an ordinary payload to bypass cap enforcement. Requiring a token terminator preserves the real markers' short-circuit while rejecting lookalikes.
 
 ## Indicator-field parity
 
@@ -84,5 +84,3 @@ Every server that emits an envelope with one of these slots routes through `with
 - [`elision.md`](elision.md) — the producer of `:elided` counts.
 - `spec/Conventions.md` §Cross-MCP indicator-field vocabulary — the MUST-level parity rule.
 - `spec/009-Instrumentation.md` §Indicator field on tool responses — the framework-level surface.
-- rf2-ee38b.19 — the bead that landed this ns.
-- rf2-gktyn / rf2-3z0zi — the beads that landed the wire-bounded marker detection.

--- a/tools/mcp-base/spec/handler-arity.md
+++ b/tools/mcp-base/spec/handler-arity.md
@@ -1,7 +1,5 @@
 # Handler-arity divergence across the MCP pair
 
-Source: rf2-63s4e (rf2-h1izl follow-on C7).
-
 The two shipped MCP servers in the re-frame2 pair use **different
 registry-handler arities**:
 
@@ -24,15 +22,11 @@ The two source-of-truth declarations:
   cap dispatcher (`re-frame.story-mcp.tools.wire-pipeline/invoke-tool`) calls
   `(handler arguments)` and returns the EDN result map.
 
-## Consequence
+## Ownership
 
-Cross-MCP-aware tooling under `tools/mcp-base/` cannot abstract the
-handler invocation shape — each server's dispatcher is a distinct
-implementation. A future third MCP-server author who consults both
-servers as examples sees two patterns rather than one. This is the
-**deliberate gap** acknowledged here; the originally-anticipated
-third instance (`xray-mcp`) was dropped per rf2-hvl1g, so unification
-will wait until a fresh third server crystallises the canonical shape.
+Handler invocation stays consumer-side. mcp-base shares the pure wire
+primitives used around invocation, but it does not define a common
+handler protocol or adapt one server's registry to the other.
 
 ## Why the divergence stayed
 
@@ -40,44 +34,13 @@ Both shapes are correct for their respective servers. Forcing pair-mcp's
 handlers to drop `conn` / `extra` would push the streaming
 `subscribe` plumbing into a side-channel (or force `extra` through a
 dynamic var); forcing story-mcp's handlers to accept dead slots adds
-boilerplate without buying anything. The honest answer is "two
-correct shapes, not yet unified" — that's what this doc records.
-
-## Phase-2 unification (deferred — separate bead)
-
-The unification is **not** part of this bead. A separate follow-on
-will factor an explicit `ExecutionContext` type (likely a record /
-map with optional `:conn` / `:progress-callback` / `:request-meta`
-slots) into `tools/mcp-base/` and refit both servers to a uniform
-`(fn [ctx args])` handler shape. That bead waits for a third server
-instance to land — the originally-anticipated `xray-mcp` was dropped
-per rf2-hvl1g, so there's no reliable third instance to validate the
-shape against today.
-
-When it lands, the unification should:
-
-1. Add a `re-frame.mcp-base.execution-context` namespace pinning the
-   ctx record/map shape + accessor fns.
-2. Refit `re-frame2-pair-mcp.tools.registry` to wrap every per-tool fn
-   into the new `(fn [ctx args])` shape (the `ignoring-extra`
-   adapter becomes `ctx->conn-args-extra` or similar; subscribe's
-   handler reads `:conn` / `:progress-callback` off the ctx
-   instead).
-3. Refit `re-frame.story-mcp.tools.wire-pipeline` / category descriptors to
-   call handlers with `(handler ctx args)`; the JVM-side
-   `:conn` / `:progress-callback` slots are nil and ignored.
-4. The new third server adopts the unified shape from day one.
-
-Until that bead lands, the divergence is the documented state.
+boilerplate without buying anything. The divergence follows the two
+dispatchers' current requirements.
 
 ## See also
 
 - [README.md](README.md) §"What deliberately does NOT live here"
-  — the existing list of tool-shaped surfaces that stay consumer-side
-  (wire transport, cursor base64 codec, tool registries). Handler-arity
-  belongs on that list in spirit but is broken out into its own doc
-  because the divergence is structural — a future third server
-  WILL need to pick one shape, and this doc gives them the context.
+  — the existing list of tool-shaped surfaces that stay consumer-side.
 - [`tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/registry.cljs`](../../re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/registry.cljs)
   — pair-mcp's 3-arity registry; ns docstring §"Handler arity
   convention" cross-references this doc.

--- a/tools/mcp-base/spec/overflow.md
+++ b/tools/mcp-base/spec/overflow.md
@@ -1,4 +1,4 @@
-# `overflow` — overflow-marker shape builder (rf2-rvyzy)
+# `overflow` — overflow-marker shape builder
 
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > Owns the SHAPE of the overflow marker (the `{:rf.mcp/overflow {:limit :reached :token-count … :cap-tokens … :tool … :hint …}}` map). The cap-enforcement glue (counting tokens, replacing the payload) lives in [`cap.md`](cap.md).
@@ -34,7 +34,7 @@ The convention's documented cap. Sized for a typical 5K-token MCP response envel
 
 Cheap character→token approximation aligned with Anthropic's rule-of-thumb for English / EDN. Not exact; the goal is a **bounded** wire payload, not a precise meter.
 
-The estimate is intentionally simple — running a tokeniser per response would re-introduce the perf cost the cap is supposed to prevent. The 4-chars-per-token approximation overshoots and undershoots in roughly equal measure across realistic EDN payloads.
+The estimate is intentionally simple; it is a cheap heuristic, not a tokenizer. `cap` also tracks an absolute character sum across measured slots.
 
 ### `overflow-hint-fallback` — generic fallback
 
@@ -81,7 +81,7 @@ Example consumer registration:
 
 The MCP transport carries text payloads to the agent host (Claude, GPT, etc.). Agents have **context budgets** measured in tokens; an MCP tool that responds with 50K tokens of payload would consume the agent's working context, leaving no room for the agent's reasoning. The cap is the agent-ergonomics counterpart to the framework's `:rf.size/threshold-bytes` (which caps per-leaf byte size); both close the "response too big for the consumer to use" failure mode.
 
-The cap is a **soft** constraint at the algorithm level — the consumer can override via `:max-tokens`. It is a **hard** constraint at the wire level — every server's cap pipeline runs the same algorithm, and the cross-MCP conformance gate asserts the marker shape is identical across consumers.
+The default is enforced at the wire boundary by the shared cap algorithm. Callers may choose a different cap or explicitly disable it with `:max-tokens 0`.
 
 ## Conformance posture
 
@@ -98,7 +98,7 @@ The cross-MCP conformance gate at `tools/mcp-conformance/wire-vocab/` pins the c
    [:hint        [:or :string :keyword]]]]]
 ```
 
-Both servers emit this marker via the shared `cap/apply-cap` → `overflow-payload`, so the body is byte-identical; the gate carries a per-server cap-trigger fixture (`:re-frame2-pair-mcp` and `:story-mcp`) and asserts each validates against this one schema.
+Both servers emit this marker via the shared `cap/apply-cap` → `overflow-payload`, so they share one data shape. Per-server fixtures validate against this schema.
 
 Live cap-trigger coverage today:
 
@@ -112,4 +112,3 @@ The marker SHAPE builder (`overflow-payload`) is additionally driven live JVM-si
 - [`README.md`](README.md) — the per-namespace index this doc is part of.
 - [`cap.md`](cap.md) — the cap-enforcement algorithm that drives this marker into a result.
 - [`vocab.md` §Marker catalogue (`:rf.mcp/*`)](vocab.md#marker-catalogue-rfmcp) — the `:rf.mcp/overflow` key.
-- rf2-rvyzy — the bead that landed this marker shape.

--- a/tools/mcp-base/spec/section-grouping.md
+++ b/tools/mcp-base/spec/section-grouping.md
@@ -1,7 +1,7 @@
-# `section-grouping` — patch-list → path-headed cluster sections (rf2-qeous)
+# `section-grouping` — patch-list → path-headed cluster sections
 
 > **Type:** Reference (`tools/mcp-base/spec/`)
-> Projects a flat diff patch-list into path-headed cluster **sections** — the same sections-per-cluster decomposition Xray's panel renderer ships (rf2-gfxmk Phase 1 of rf2-abts7), but computed from the patch list rather than the annotated tree. [`diff-encode.md`](diff-encode.md) consumes this to shape the `:db-after` marker's `:sections` slot.
+> Projects a flat diff patch-list into path-headed cluster **sections**, matching Xray's section decomposition but computed from patches rather than an annotated tree. [`diff-encode.md`](diff-encode.md) consumes it for the `:db-after` marker's `:sections` slot.
 
 This doc is one of thirteen per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`egress.md`](egress.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`dedup.md`](dedup.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
 
@@ -12,7 +12,7 @@ This doc is one of thirteen per-namespace contracts indexed from [`README.md`](R
 - `group-patches-into-sections` — the flat-patch-list → sections projection.
 - `sections->patches` — the lossless inverse (flatten sections back to a replayable patch list).
 - `default-opts` (`{:max-coalesce-depth 3}`) — the tunable cluster-coalescence knob, mirroring Xray's defaults.
-- `group-patches-into-sections` `opts` also accepts `:db-before` — the pre-change value the patches diff from. When supplied, a `:section-kind :added` is claimed only for an all-`:assoc` direct-child cluster whose container was ABSENT in `:db-before` (rf2-ykv9a0); when absent, the classifier conservatively emits `:modified`.
+- `group-patches-into-sections` `opts` also accepts `:db-before`. When supplied, `:section-kind :added` requires an all-`:assoc` direct-child cluster whose container was absent before; without it, the classifier conservatively emits `:modified`.
 
 `section-grouping` does NOT own:
 
@@ -61,7 +61,7 @@ Mirrors the Xray pass (`section_grouping.cljc` §3.1.1), recast over patches:
    - all `:assoc` AND every patch is exactly one segment deeper than `:section-path` AND the container was ABSENT in `:db-before` → `:added`.
    - otherwise → `:modified` (the conservative default; a mix of inserts / changes / deletes, or an existing container whose direct children changed).
 
-   **Why `:added` needs `:db-before` (rf2-ykv9a0).** The patch grammar uses `:assoc` for BOTH inserted and changed leaves, so patch SHAPE alone cannot distinguish a newly-added container from an existing one whose direct children changed. `{:user {:name "bob"}}` → `{:user {:name "ada" :email "…"}}` emits the SAME all-`:assoc` direct-child cluster under `[:user]` as a genuinely new `[:user]` subtree — a patch-only classifier mislabels the FIRST (a modification) as `:added`, a false skim signal to the agent. So `:added` is claimed only when `:db-before` (threaded through `opts`, supplied by the `diff-encode-db-after` caller) proves the section-path container did not previously exist. When `:db-before` is absent (the standalone projection used by tests / advanced consumers diffing arbitrary structures), the classifier cannot prove addition and conservatively emits `:modified` for every all-`:assoc` cluster. The cosmetic `:section-kind` never affects round-trip — concatenating `:patches` replays losslessly regardless.
+   **Why `:added` needs `:db-before`.** `:assoc` represents both insertion and change, so patch shape alone cannot distinguish a new container from changed children in an existing one. `:added` therefore requires proof that the section path was absent; without `:db-before`, all-`:assoc` clusters remain `:modified`. The label does not affect replay.
 
    > Note: over the `collect-patches` pipeline a genuinely-new multi-key container is emitted as a single whole-subtree `[[:k] :assoc {...}]` patch (collect-patches doesn't recurse into an absent key), which heads as a singleton → `:modified`. The all-`:assoc` direct-child `:added` shape therefore arises only from an advanced consumer supplying a synthetic patch list whose `:db-before` proves the container absent.
 
@@ -84,5 +84,3 @@ All passes are linear in patch count — negligible vs the walk that produced th
 
 - [`README.md`](README.md) — the per-namespace index this doc is part of.
 - [`diff-encode.md`](diff-encode.md) — the diff transform that produces the patch list this ns groups, and the `section-schema` Malli gate that pins the section shape at the wire boundary.
-- rf2-qeous — the bead that landed the path-headed cluster projection.
-- rf2-gfxmk / rf2-abts7 — Xray's panel `sections-per-cluster` decomposition this projection mirrors.

--- a/tools/mcp-base/spec/sensitive.md
+++ b/tools/mcp-base/spec/sensitive.md
@@ -1,7 +1,7 @@
 # `sensitive` — Spec 009 §Privacy default-suppress filter
 
 > **Type:** Reference (`tools/mcp-base/spec/`)
-> The cross-MCP privacy filter. Framework-published forwarders — Sentry / Honeybadger, re-frame2-pair server, Story-MCP (xray-mcp was dropped in rf2-bu21t; xray now ships as a Clojars-only library, not an MCP server) — MUST default-drop trace events whose registration declared `:sensitive? true`. The runtime stamps the flag at the top level of every emitted trace event inside such a registration's handler scope; the forwarder's job is to gate egress on it before any data crosses the trust boundary.
+> The cross-MCP privacy filter. Off-box forwarders must default-drop trace events whose registration declared `:sensitive? true`. The runtime stamps that classification on emitted trace events; forwarders gate egress before data crosses the trust boundary.
 
 This doc is one of thirteen per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`egress.md`](egress.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`dedup.md`](dedup.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
 
@@ -12,7 +12,7 @@ This doc is one of thirteen per-namespace contracts indexed from [`README.md`](R
 - The cross-MCP fail-closed `sensitive-event?` predicate over a trace-event map.
 - The `strip-sensitive` walker (returns `[kept dropped-count]`).
 - The `scrub-snapshot` walker that strips `:traces` / `:epochs` slices from each per-frame snapshot map.
-- The fail-closed malformed-stamp counter (`malformed-count` / `reset-malformed-count!`) — operator-surface observability for the rf2-ih7g4 fail-closed posture; bumped exactly **once per dropped malformed event** (a non-boolean truthy `:sensitive?` stamp). `strip-sensitive` / `scrub-snapshot` classify each event exactly once (single-pass — rf2-el9sw), so the count is a faithful per-event metric rather than a scan-strategy-dependent over-count.
+- The fail-closed malformed-stamp counter (`malformed-count` / `reset-malformed-count!`), bumped exactly once per dropped malformed event. The walkers classify each event once, so the count is a per-event metric.
 - The fixed cross-server arg-vocabulary name (`:include-sensitive`) every MCP tool surfacing trace-like data MUST accept.
 
 `sensitive` does NOT own:
@@ -25,9 +25,9 @@ This doc is one of thirteen per-namespace contracts indexed from [`README.md`](R
 
 ### `sensitive-event?` — predicate
 
-Predicate over a trace-event map. **Fail-closed** (rf2-ih7g4): the literal `true` value drops (the documented spec/009 path), AND any other *truthy non-boolean* stamp also drops — with a stderr / `console.warn` contract-drift warning and a bump of the malformed counter. Only an explicit `false` / `nil` / absent stamp passes. The `:rf/trace-event` schema types `:sensitive?` as a boolean (Spec 009 + Spec-Schemas); a non-boolean stamp is a serialisation-bug *contract violation* that we surface (warn + drop) rather than silently treat as non-sensitive.
+Predicate over a trace-event map. **Fail-closed**: literal `true` drops, and any other truthy non-boolean stamp drops with a value-free warning and malformed-counter increment. Only `false`, nil, or an absent stamp passes.
 
-**The contract-drift warning is value-free (rf2-el9sw).** Logs are an egress boundary on this privacy surface; a malformed stamp is wire-adjacent, untrusted data, and a serialisation bug could put a secret-bearing string / map / vector in `:sensitive?`. The warning therefore carries ONLY a value-free type tag (`type=String`, `type=Keyword`, …) and a fixed `value=:rf/redacted` sentinel — it MUST NOT `pr-str` the raw stamp. The `malformed-count` counter is the quantitative observability hook; the type tag is the qualitative one; neither carries the payload.
+**The contract-drift warning is value-free.** Logs are an egress boundary, so the warning carries only a type tag and fixed `value=:rf/redacted` sentinel, never the raw malformed stamp.
 
 Definition (effectively):
 
@@ -44,7 +44,7 @@ Definition (effectively):
                               true)))))            ; fail-closed drop + warn
 ```
 
-The earlier `true?`-only predicate was fail-**open** on contract drift: an upstream serialisation bug coercing the boolean into a string (`"true"`) would silently leak every sensitive event past the filter. The fail-closed posture closes that leak. The same predicate applies whether the trace event is a top-level emission or a nested fragment inside a snapshot.
+A literal-`true`-only predicate would fail open if serialization changed the stamp's type. The same fail-closed classifier applies to top-level trace batches and snapshot trace slices.
 
 ### `strip-sensitive` — coll → `[kept dropped-count]`
 
@@ -56,9 +56,9 @@ The count feeds the indicator-field slot the agent reads to know the payload was
 
 Walks a snapshot map keyed by frame and, for each per-frame map, applies the strip-fn to the `:traces` and `:epochs` slices only. Returns `[scrubbed-snapshot total-dropped]`. Non-map slices and non-snapshot inputs pass through unchanged.
 
-`scrub-snapshot` is a **trace/epoch sensitivity filter only — NOT the complete snapshot privacy boundary.** The walk is **shallow by design** (per rf2-zq0n1 / rf2-3cted): it strips sensitive trace events from `:traces` / `:epochs` but **leaves `:app-db`, `:sub-cache`, and `:machines` untouched** — it does NOT descend into arbitrary sub-trees and does NOT redact app-db values. Its OUTPUT is therefore **not** already-projected full-snapshot output.
+`scrub-snapshot` is a **trace/epoch sensitivity filter only, not the complete snapshot privacy boundary.** It strips the `:traces` and `:epochs` slices but leaves `:app-db`, `:sub-cache`, and `:machines` untouched. Its output is not a fully projected snapshot.
 
-Per [EP-0015](../../../docs/EP/EP-0015-frame-owned-egress-policy.md), the public privacy model is registration-owned `:sensitive` / `:large` classification plus centralized `project-egress` (under a named `:rf.egress/*` profile) at the egress boundary; the write-time `redact-interceptor` that earlier owned app-db payload redaction has been **removed**. So the **caller's egress pipeline** must run `project-egress` over the non-trace slices with the frame's known policy **before** the snapshot crosses an MCP/tool boundary. A consumer must NOT treat `scrub-snapshot` output as sufficient, and must NOT look for a write-time interceptor to have handled app-db redaction — it does not happen here, and there is no longer a write-time interceptor that does it.
+Per [EP-0015](../../../docs/EP/EP-0015-frame-owned-egress-policy.md), non-trace slices are projected at egress under a named `:rf.egress/*` profile. The caller must apply that projection before a snapshot crosses the MCP boundary; `scrub-snapshot` alone is insufficient.
 
 Two arities:
 
@@ -69,7 +69,7 @@ Two arities:
 
 The opt-in arg every MCP tool surfacing trace-like data MUST accept. The semantics are fixed — accept the arg, default it to `false`, feed it to `strip-sensitive` (and any analogous walker that recurses through snapshot slices) — and the **wire-key spelling is now uniform** across every server:
 
-- **story-mcp** (rf2-y710n) and **re-frame2-pair-mcp** (rf2-ihq4d) both ship the unqualified `:include-sensitive` (no trailing `?` — the Anthropic tool-input-schema regex `^[a-zA-Z0-9_.-]{1,64}$` rejects `?`).
+- Both servers ship the unqualified `:include-sensitive` wire key (no trailing `?`).
 - The walker option key inside the framework (`vocab/include-sensitive-opt`) is the namespaced `:rf.size/include-sensitive?` — internal, not a wire-key, so the predicate `?` is retained.
 
 The cross-server wire-key is a fixed literal-spelling pin: every server accepts `:include-sensitive` (the per-server tool catalogue documents the same literal).
@@ -78,15 +78,15 @@ The default-OFF posture aligns with the framework's privacy-by-default stance (p
 
 ## Zero-dep rationale
 
-re-frame2-pair-mcp is a CLJS Node bundle (no `re-frame.trace` on its classpath); story-mcp is JVM-side and DOES have the framework primitive available. The predicate here matches the spirit of `re-frame.privacy/sensitive?` but adds the fail-closed posture (rf2-ih7g4): the runtime always stamps the literal boolean, but if a transport bug delivers any other truthy value, the filter drops the event AND logs so the contract drift surfaces in operator output rather than leaking the event.
+re-frame2-pair-mcp is a CLJS Node bundle without `re-frame.trace` on its classpath; story-mcp is JVM-side. This zero-framework-dependency predicate gives both hosts the same fail-closed classification.
 
 Consumers reach the predicate two ways: re-frame2-pair-mcp keeps a thin local alias ns (`tools/sensitive.cljs`) that delegates here, for code-review locality; story-mcp requires `re-frame.mcp-base.sensitive` directly (no local alias ns). Either way the fail-closed predicate itself lives here.
 
 ## Conformance posture
 
-The `:dropped-sensitive` envelope slot rides alongside `:elided-large` per the indicator-field parity rule (per [`vocab.md` §Envelope counter slots](vocab.md#envelope-counter-slots)). Both slots are MUST-level — the conformance gate at `tools/mcp-conformance/wire-vocab/` asserts parity.
+Tree-payload emitters compute both `:dropped-sensitive` and `:elided-large` indicators; each zero count is omitted independently (see [`vocab.md` §Envelope counter slots](vocab.md#envelope-counter-slots)).
 
-The privacy default — `:include-sensitive` defaults `false` — is enforced via the per-tool argument schema in each consumer; the conformance harness drives every tool with a payload that includes a `:sensitive? true` event and asserts the response envelope's `:dropped-sensitive` counter is non-zero, with the sensitive event absent from the response body.
+Consumer and conformance fixtures cover the default-off posture, the dropped count, and absence of sensitive events from emitted bodies.
 
 ## See also
 

--- a/tools/mcp-base/spec/vocab.md
+++ b/tools/mcp-base/spec/vocab.md
@@ -12,7 +12,7 @@ This doc is one of thirteen per-namespace contracts indexed from [`README.md`](R
 - The `:rf.mcp/*` marker keyword catalogue.
 - The `:rf.size/*` marker keyword catalogue (shared with the framework's `rf/elide-wire-value` walker).
 - The unqualified envelope counter slots (`:dropped-sensitive`, `:elided-large`).
-- The JSON-RPC 2.0 §5.1 error codes used by every server in the pair.
+- The JSON-RPC 2.0 §5.1 error-code constants used by direct JSON-RPC consumers.
 
 `vocab` does NOT own:
 
@@ -26,42 +26,42 @@ This doc is one of thirteen per-namespace contracts indexed from [`README.md`](R
 
 `:rf.size/*` — size-elision markers. Owned jointly with the framework's `rf/elide-wire-value` walker (per [`../../../spec/Conventions.md` §Reserved namespaces](../../../spec/Conventions.md#reserved-namespaces-framework-owned); [`../../../spec/009-Instrumentation.md` §Size elision in traces](../../../spec/009-Instrumentation.md)).
 
-Unqualified envelope slots — `:dropped-sensitive`, `:elided-large` — are per-call scalar counters summarising the walker's suppression count (per [`../../../spec/Conventions.md` §Cross-MCP indicator-field vocabulary](../../../spec/Conventions.md); [`../../../spec/009-Instrumentation.md` §Size elision in traces](../../../spec/009-Instrumentation.md) — Indicator field on tool responses, MUST-level per rf2-2499j).
+Unqualified envelope slots — `:dropped-sensitive`, `:elided-large` — are per-call scalar counters summarising suppression and elision (per [`../../../spec/Conventions.md` §Cross-MCP indicator-field vocabulary](../../../spec/Conventions.md) and [`../../../spec/009-Instrumentation.md` §Size elision in traces](../../../spec/009-Instrumentation.md)).
 
 ## Marker catalogue (`:rf.mcp/*`)
 
-| Var | Key | Shape | Source bead |
-|---|---|---|---|
-| `overflow-key` | `:rf.mcp/overflow` | `{:limit :reached :token-count N :cap-tokens M :tool "…" :hint "…"}` | rf2-rvyzy |
-| `dedup-table-key` | `:rf.mcp/dedup-table` | `{<cache-map>}` (de-dupe library) | rf2-obpa9 |
-| `diff-from-key` | `:rf.mcp/diff-from` | Slot pointer keyword (`:db-before`) | rf2-1wdzp |
-| `cursor-stale-reason` | `:rf.mcp/cursor-stale` | Error-result `:reason` value | rf2-kbqq3 |
-| `cache-hit-key` | `:rf.mcp/cache-hit` | `{:tool … :digest … :hint …}` (content-free; agent host correlates by cache key) | rf2-3rt1f / rf2-36xod |
-| `summary-key` | `:rf.mcp/summary` | `{<tree-summary>}` (lazy-summary projection) | rf2-tygdv / rf2-u2029 |
-| `invalid-arg-key` | `:rf.mcp/invalid-arg` | `{:arg <kw> :value <supplied> :hint <str>}` — top-level wrapper carried as the payload of an `isError: true` result rejecting a malformed per-call arg. First emitter: `cap/max-tokens` on a negative `:max-tokens` (see [`cap.md` §Out-of-domain `:max-tokens` is rejected](cap.md#out-of-domain-max-tokens-is-rejected-rf2-5rdit--rf2-li6y22--rf2-ykv9a0)). | rf2-5rdit |
-| `result-key` | `:rf.mcp/result` | `{:rf.mcp/result <tag> …}` — top-level discriminator for a wire-**fidelity** typed result envelope. `<tag>` ∈ `:value` (`:value <v>`), `:nil` (no extra slots), `:eval-error` (`:reason :ex :message :ex-data`), `:unserializable` (`:type :preview`). TYPES an evaluation's outcome so a genuine `nil`, a thrown eval-error, and an unserializable value (`#object`/`#js`/Function) stop collapsing to a bare `null`. Emitted by re-frame2-pair-mcp's `tools/result_envelope.cljs` for `eval-cljs` / `handler-meta`; the server projects each tag onto the tool's `:ok?` vocabulary. Composes with — never bypasses — the size machinery: the codec tags the outcome; the elision walker still runs over the `:value` payload. Per [Tool-Pair §Wire fidelity](../../../spec/Tool-Pair.md). Cross-gated by the `wire-vocab` conformance corpus (`ResultEnvelope` schema + per-tag fixtures, rf2-ihf8v). | rf2-qobqy |
+| Var | Key | Shape |
+|---|---|---|
+| `overflow-key` | `:rf.mcp/overflow` | `{:limit :reached :token-count N :cap-tokens M :tool "…" :hint "…"}` |
+| `dedup-table-key` | `:rf.mcp/dedup-table` | `{<cache-map>}` (de-dupe library) |
+| `diff-from-key` | `:rf.mcp/diff-from` | Slot pointer keyword (`:db-before`) |
+| `cursor-stale-reason` | `:rf.mcp/cursor-stale` | Error-result `:reason` value for an invalid continuation position |
+| `cache-hit-key` | `:rf.mcp/cache-hit` | `{:tool … :digest … :hint …}` (content-free; agent host correlates by cache key) |
+| `summary-key` | `:rf.mcp/summary` | `{<tree-summary>}` (lazy-summary projection) |
+| `invalid-arg-key` | `:rf.mcp/invalid-arg` | `{:arg <kw> :value <supplied> :hint <str>}` — payload of an `isError: true` result rejecting a malformed per-call arg. See [`cap.md` §Out-of-domain `:max-tokens` is rejected](cap.md#out-of-domain-max-tokens-is-rejected). |
+| `result-key` | `:rf.mcp/result` | `{:rf.mcp/result <tag> …}` — typed evaluation outcome (`:value`, `:nil`, `:eval-error`, or `:unserializable`). See [Tool-Pair §Wire fidelity](../../../spec/Tool-Pair.md). |
 
 ## Marker catalogue (`:rf.size/*`)
 
 | Var | Key | Role | Source |
 |---|---|---|---|
 | `large-elided-key` | `:rf.size/large-elided` | Substituted for an over-threshold leaf (or declared-large slot). | Spec 009 §Size elision |
-| `redacted-sentinel` | `:rf/redacted` | In-place **scalar sentinel** (bare keyword, no body) substituted for a `:sensitive?` leaf by `rf/elide-wire-value` / `redact-interceptor`. Unlike `:rf.size/large-elided`, there is no `:handle` / `:bytes` slot — the value is gone and MUST NOT be re-fetched. Reserved under the `:rf/*` single-root scheme (Conventions §Reserved namespaces). | Spec 009 §Privacy / `tools/mcp-base/src/re_frame/mcp_base/vocab.cljc` `redacted-sentinel` |
-| `elision-handle-key` | First slot in the elision handle vector | Vector-shaped handle for follow-up `get-path` calls. | rf2-9fz64 |
+| `redacted-sentinel` | `:rf/redacted` | In-place **scalar sentinel** substituted by the egress projection/walker for a sensitive value. Unlike `:rf.size/large-elided`, it has no handle: the value must not be re-fetched. | Spec 009 §Privacy |
+| `elision-handle-key` | First slot in the elision handle vector | Vector-shaped handle for follow-up `get-path` calls. | Spec 009 §Size elision |
 | `include-large-opt` / `include-sensitive-opt` / `include-digests-opt` / `threshold-bytes-opt` | (framework-side opts) | Knobs `rf/elide-wire-value` honours when the consumer relays a wire request to the walker. | Spec 009 §Size elision |
 
 ## Envelope counter slots
 
 | Var | Slot | Counts |
 |---|---|---|
-| `dropped-sensitive-key` | `:dropped-sensitive` | `:sensitive? true` leaves dropped this call. |
+| `dropped-sensitive-key` | `:dropped-sensitive` | Sensitive records dropped this call, including fail-closed malformed stamps. |
 | `elided-large-key` | `:elided-large` | Leaves replaced with the `:rf.size/large-elided` marker. |
 
-Both slots ride the response envelope alongside the tool's unqualified slots. **Indicator-field parity** is MUST-level: if one slot is emitted, the other must be too (the round-2 audit fix the conformance gate enforces).
+Tree-payload emitters compute both indicators under the same convention. Each zero count is omitted independently; a positive count emits its own slot.
 
 ## JSON-RPC error codes (per JSON-RPC 2.0 §5.1)
 
-The same numeric codes apply across both servers. Owned constants:
+The constants follow JSON-RPC 2.0:
 
 - `code-parse-error` (-32700)
 - `code-invalid-request` (-32600)
@@ -69,14 +69,14 @@ The same numeric codes apply across both servers. Owned constants:
 - `code-invalid-params` (-32602)
 - `code-internal-error` (-32603)
 
-Story-mcp emits them via Cheshire; re-frame2-pair-mcp emits via the npm MCP SDK's `isError: true` tool-result shape, but the codes still pin the cross-consumer protocol surface.
+Story-mcp uses these constants in its direct JSON-RPC envelopes. re-frame2-pair-mcp delegates protocol-level errors to the npm MCP SDK; `isError: true` is a tool-result failure shape, not a JSON-RPC error code.
 
 ## Conformance posture
 
 The marker keys + envelope slots + JSON-RPC codes are a **wire-protocol contract**. A rename here breaks every connected agent. Two layers of protection:
 
 1. **The cross-MCP conformance gate** at `tools/mcp-conformance/wire-vocab/` pins the canonical Malli schema for every reserved `:rf.mcp/*` / `:rf.size/large-elided` / `:rf.elision/at` marker and asserts that fixtures + source text from every emitting server conform. Any rename or shape drift fails the JVM test corpus.
-2. **The marker-key vars in `vocab.cljc`** are the single reference point — every server reads them via `(:require ...)` rather than re-typing the keyword literal. A grep for `:rf.mcp/overflow` shows exactly one defining occurrence; everywhere else is a `vocab/overflow-key` reference.
+2. **The marker-key vars in `vocab.cljc`** are the shared reference point for executable consumers rather than consumer-local constant definitions.
 
 ## See also
 

--- a/tools/mcp-base/src/re_frame/mcp_base/args.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/args.cljc
@@ -7,17 +7,17 @@
 
   ## Cross-server convention
 
-  Argument names and default postures are a cross-MCP convention. An
-  agent that learns `:dedup` defaults true on re-frame2-pair-mcp must see the
-  same default everywhere. These parsers encode the defaults so they
-  can't drift across consumers."
+  Argument names and default postures are a cross-MCP convention. These
+  parsers share coercion semantics; consumers supply the documented
+  default at each call site."
   (:refer-clojure :exclude [parse-boolean])
   (:require [clojure.string :as str]))
 
 (defn parse-boolean
   "Normalise a possibly-string MCP arg into a boolean. Accepts
   booleans (passthrough), strings (`\"true\"`/`\"false\"`/`\"1\"`/
-  `\"0\"`/`\"yes\"`/`\"no\"`, case-insensitive), keywords
+  `\"0\"`/`\"yes\"`/`\"no\"`/`\"y\"`/`\"n\"`/`\"on\"`/`\"off\"`,
+  case-insensitive), keywords
   (`:true`/`:false`), or nil. Unrecognised values fall back to
   `default`.
 
@@ -39,7 +39,7 @@
 (def ^:private int-string-re
   "Strict integer-string grammar: optional sign + one-or-more digits,
   nothing else. Trailing garbage (`\"12abc\"`) is rejected so the
-  string arm parses byte-identically across hosts —
+  string arm produces the same result across hosts —
   `Long/parseLong` (JVM) already rejects trailing garbage; raw
   `js/parseInt` (CLJS) parses a numeric PREFIX (`\"12abc\"` ⇒ 12),
   which would diverge from the JVM default-fallback. Guarding both
@@ -49,9 +49,9 @@
 ;; ---------------------------------------------------------------------------
 ;; Cross-runtime finite/range guard.
 ;;
-;; `(long raw)` is UNSAFE on out-of-domain numerics: on the JVM `##Inf`,
-;; `##NaN`, and finite values past the long range (`1.0E20`) THROW
-;; `IllegalArgumentException`, while `##NaN` quietly truncates to `0` — a
+;; `(long raw)` is UNSAFE on out-of-domain numerics: on the JVM `##Inf`
+;; and finite values past the long range (`1.0E20`) throw, while `##NaN`
+;; quietly truncates to `0` — a
 ;; real, non-sentinel cap that locks the agent out. The string arm has
 ;; the same hazard: a digit string above the JS safe-integer ceiling
 ;; parses on the JVM (`Long/parseLong "9007199254740992"`) but defaults
@@ -72,7 +72,7 @@
 
 (def ^:private max-safe-integer
   "The JS safe-integer ceiling, `2^53 − 1` (9 007 199 254 740 991). The
-  cross-runtime domain boundary: a value strictly inside `[-max, max]`
+  cross-runtime domain boundary: a value within `[-max, max]`
   round-trips losslessly through both a JS `number` and a JVM `long`."
   9007199254740991)
 
@@ -146,12 +146,12 @@
 
 (defn parse-positive-int
   "Normalise a possibly-string MCP arg into a positive integer. Accepts
-  ints (passed through, clamped to ≥1), strings (parsed; non-numeric
-  falls back to `default`), or nil (returns `default`). Non-positive
-  numeric inputs clamp to 1.
+  finite in-range numbers (floored toward zero, then clamped to ≥1),
+  integer strings, or nil. Invalid and out-of-range values return
+  `default`; non-positive numeric inputs clamp to 1.
 
-  The `default` is the convention's documented cap (e.g. 50 for cursor
-  pagination, 5000 for token caps)."
+  The caller supplies the documented default (for example, a cursor
+  pagination limit)."
   [raw default]
   (parse-int* raw default 1))
 
@@ -184,13 +184,9 @@
 ;;
 ;;   - `fresh-keyword` — the policy-gated intern. INTERNS by design (the
 ;;                       call site is allocating a new identifier, not
-;;                       resolving an existing one). Only callable when
-;;                       the surrounding context has already bounded the
-;;                       allocation cost — typically an operator-gated
-;;                       write path (`--allow-writes`) whose registrar
-;;                       enforces a grammar over the input. The
-;;                       fresh-id posture is carried on the name itself
-;;                       rather than in a warning-laden docstring.
+;;                       resolving an existing one). Reserve it for an
+;;                       operator-gated write path; prefer
+;;                       `fresh-keyword-checked` when the id has a grammar.
 ;;
 ;; `parse-mode` routes through `safe-keyword` — every caller passes a
 ;; finite `recognised` set, so the bounded gate fits cleanly.
@@ -272,10 +268,8 @@
 
 (defn fresh-keyword
   "Coerce an agent-supplied id into a keyword, INTERNING it. The
-  primitive for paths whose allocation cost is **bounded by some
-  other gate** — either an operator-gated write path that allocates a
-  fresh identifier, or a read path whose universe of acceptable
-  identifiers is constrained by a runtime registry. Strips a leading
+  primitive for operator-gated write paths that deliberately allocate
+  a fresh identifier. Strips a leading
   `:` if present (some agents may serialise EDN-ish). Returns nil for
   nil / blank input.
 
@@ -285,25 +279,17 @@
 
   JVM keywords are interned in a never-shrinking global table. Every
   `fresh-keyword` call permanently grows that table by one slot for a
-  hitherto-unseen input. The policy is **bounded-cost allocation** —
-  reserve this primitive for sites where some other gate caps the
-  number of fresh keywords an attacker can mint:
+  hitherto-unseen input. Reserve this primitive for sites where the
+  write policy accepts the allocation:
 
     - **Operator-gated write paths** that allocate a NEW identifier —
       story-mcp's `--allow-writes` flag plus `:story.<path>/<name>`
       grammar bound; `register-variant`'s `:variant-id`,
       `record-as-variant`'s `:new-variant-id`.
-    - **Runtime-bounded read paths** that resolve against a FINITE
-      registry — re-frame2-pair-mcp's frame-id coercion. The registry's
-      live size caps the allocation; an agent passing arbitrary
-      strings can mint at most one new keyword per registered frame.
-    - **Grammar-bounded registrars** (e.g. `:story.<path>/<name>` in
-      `assert-id!`) — the grammar constrains the per-id allocation
-      cost regardless of read/write direction.
-
-  For finite option sets (mode keywords, slice keywords), use
-  `safe-keyword` against a finite allowlist; `fresh-keyword` is the
-  wrong primitive there — it would intern every typo the agent sent."
+  Grammar validation alone does not bound the number of valid names.
+  For registry lookups, finite option sets, mode keywords, and slice
+  keywords, use `safe-keyword` against the live finite allowlist;
+  `fresh-keyword` would intern every rejected spelling before lookup."
   [v]
   (cond
     (keyword? v) v
@@ -340,9 +326,10 @@
   constructed. `shape-ok?` receives `[ns-part name-part]` (either may be
   `nil` for a bare name) and returns truthy iff the id is admissible.
 
-  `:max-len` (default 512) caps the combined `ns`+`name` length — a
-  defence against a single enormous-id intern even when the grammar
-  itself is permissive.
+  For string inputs, `:max-len` (default 512) caps the combined
+  `ns`+`name` length — a defence against a single enormous-id intern
+  even when the grammar itself is permissive. Keyword inputs are
+  already interned, so they are shape-checked but not length-checked.
 
   On CLJS keywords are not interned in the JVM-table sense, so the
   growth concern does not apply; the same shape gate runs for behavioural

--- a/tools/mcp-base/src/re_frame/mcp_base/cap.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/cap.cljc
@@ -53,13 +53,10 @@
   per-tool next-step prose is domain-specific. The cap value, token
   rule, and marker shape are cross-MCP conventions and stay here.
 
-  ## Single strategy today: truncate-with-marker
+  ## Overflow strategy
 
-  The only strategy wired is drop-the-payload-and-emit-the-overflow-
-  marker. Future strategies (path-slicing, lazy summary, diff encoding)
-  would add a pluggable hook here. For the single strategy `apply-cap`
-  calls `build-overflow-result` directly — no `case` dispatcher
-  pretending there's more than one branch (pre-alpha YAGNI).
+  Over-budget results are replaced with the overflow marker through
+  `build-overflow-result`; strategy selection is not part of this API.
 
   ## Cross-platform
 
@@ -265,11 +262,10 @@
   "Sum the character count across every wire payload string the
   consumer's `wire-payload-strings` surfaces for `result` (every
   serialized payload-bearing slot, not only `:text`), accessed via `io`.
-  Used by the secondary byte cap — the primary
-  `sum-payload-tokens` divides by 4 (Anthropic's English-rule-of-thumb),
-  which materially undercounts CJK, emoji, base64, and dense code. A
-  char-count secondary gate catches payloads that escape the quotient
-  heuristic.
+  Used by the secondary character ceiling. The primary token estimate
+  floors each payload string independently; an absolute character sum
+  prevents many sub-four-character slots from disappearing into those
+  per-string quotients.
 
   Returns the cumulative `(count s)` across the payload strings. The
   caller decides the multiplier (`cap * 8` in `apply-cap` — generous
@@ -279,21 +275,17 @@
   (sum-payload-by io result count))
 
 (def ^:const byte-cap-multiplier
-  "Secondary byte-cap multiplier. `cap * multiplier` is the
-  hard char-count ceiling — a defence-in-depth gate against payloads
-  that escape the primary `(quot count 4)` token heuristic (CJK,
-  emoji, base64, dense code). Set high enough that an English / EDN
-  payload at the token cap passes (1 char ≈ 4 tokens ⇒ 4×); set low
-  enough that a payload doubled by undercount trips (≥2×). 8× is the
-  compromise — generous to the common path, conservative on the
-  pathological one."
+  "Multiplier for the secondary character ceiling. English/EDN is
+  roughly four characters per token, so `8 * cap` leaves 2× headroom
+  over the primary estimate while bounding multi-slot quotient loss.
+  The public name is retained because it is already the cap constant."
   8)
 
 ;; ---------------------------------------------------------------------------
 ;; Over-budget decision — extracted from `apply-cap`'s inline `let` so the
 ;; two-stage gate is unit-trippable in isolation.
 ;;
-;; ## Why the secondary char gate is load-bearing today
+;; ## Why the secondary char gate is reachable
 ;;
 ;; `apply-cap` derives BOTH sums from the SAME `wire-payload-strings` seq:
 ;; `tokens = Σ (token-estimate s)`, `chars = Σ (count s)`. A NAIVE reading
@@ -315,14 +307,9 @@
 ;; `chars = 9000`. At `cap = 1` the token gate is QUIET (`0 > 1` is false)
 ;; yet the char gate FIRES (`9000 > 8`) — `apply-cap` correctly replaces
 ;; the over-budget payload with the overflow marker. The secondary char
-;; gate is therefore reachable through the LIVE `apply-cap` path today,
-;; not merely a future-proofing branch. (`watch-epochs` / `trace-window`
-;; slices are exactly this shape: a long vector of small per-record text
-;; slots, each well under 4 chars of net token contribution per fragment.)
-;;
-;; The branch is doubly justified: load-bearing now AND defence-in-depth
-;; against a FUTURE `token-estimate` refinement (one recognising base64 /
-;; CJK at a lower per-char cost) that would decouple the two sums further.
+;; gate is therefore reachable for a ResultIO exposing many short wire
+;; slots. The shipping dual-coded envelopes normally expose only a small
+;; number of strings; the protocol nevertheless permits multipart results.
 ;; The decision is extracted as a pure predicate over already-summed
 ;; `tokens`/`chars` so BOTH disjuncts and the `reported` selector are
 ;; exercised directly in `cap_test.clj` (decoupled sums, isolation) AND
@@ -334,10 +321,8 @@
   "Two-stage over-budget predicate. True when EITHER the
   token sum exceeds `cap` OR the char sum exceeds `cap *
   byte-cap-multiplier`. Pure over already-summed counts so the
-  secondary char gate is unit-trippable in isolation (see the comment
-  block above for why the per-string floor in `token-estimate` makes
-  this gate load-bearing through the live `apply-cap` path today —
-  not merely a future-proofing branch)."
+  secondary char gate is unit-trippable in isolation. See the comment
+  block above for the multi-slot quotient-loss case."
   [tokens chars cap]
   (or (> tokens cap)
       (> chars (* cap byte-cap-multiplier))))

--- a/tools/mcp-base/src/re_frame/mcp_base/cursor.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/cursor.cljc
@@ -12,11 +12,11 @@
 
   Both servers need the SAME machinery:
 
-    - story-mcp     — offset/total/sig over append-mostly registries
+    - story-mcp     — version/offset/total/sig over registries
     - re-frame2-pair-mcp — after-id/ms over the bounded epoch ring
 
   The cursor PAYLOAD differs by domain — story carries
-  `{:offset :total :sig}`, pair carries `{:after-id :ms :until-ms
+  `{:v :offset :total :sig}`, pair carries `{:after-id :ms :until-ms
   :frame}` — but the base64 codec, the EDN read with ALL-tagged-literal
   rejection (built-in `#inst`/`#uuid` included) + size guard, the
   `::malformed` recovery contract, the `:limit` clamp, and the
@@ -93,7 +93,7 @@
   string/number coercion + default posture, then applies the ceiling.
 
   Each server bakes its own `default` (story 25, pair 50) and `max`
-  (story's 200; pair's wire-cap is the implicit ceiling) — the
+  (story 200, pair 1000) — the
   convention is the CLAMP behaviour, not the numbers."
   [raw default max]
   (min max (args/parse-positive-int raw default)))
@@ -237,9 +237,10 @@
                       treat `::malformed` exactly like a STALE cursor —
                       drop it and restart.
 
-  `valid?` is the consumer's payload-shape predicate (e.g.
-  `#(and (map? %) (integer? (:offset %)) (string? (:sig %)))` for
-  story; `#(and (map? %) (string? (:after-id %)))` for pair). The
+  `valid?` is the consumer's payload-shape predicate. Story validates
+  `:v`, natural `:offset`/`:total`, and a string `:sig`; pair requires
+  a present, non-nil `:after-id` of any EDN-printable type because the
+  epoch-id contract is opaque. The
   codec, the size cap, and the tagged-literal rejection are shared; the
   shape check is the consumer's.
 

--- a/tools/mcp-base/src/re_frame/mcp_base/dedup.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/dedup.cljc
@@ -11,12 +11,12 @@
   The library guarantees round-trip exactness via the companion `expand`
   function; the agent host can decode locally.
 
-  Both MCP servers ship the same kinds of duplicate-rich payloads:
+  Both MCP servers ship duplicate-rich payloads:
   re-frame2-pair-mcp's `:epochs` slice (`:db-before` + path-keyed
   `:db-after` diff), subscribe progress `:events`; story-mcp's
   `run-variant` results (`:app-db` + `:snapshot` + `:rendered-hiccup`),
   assertion vectors, recorder replay tuples. The encode step is
-  byte-identical across both servers, so it lives here once.
+  the same data transform on both hosts, so it lives here once.
 
   ## Why `de-dupe-eq` (equality), not `de-dupe` (identity)
 
@@ -33,7 +33,7 @@
   `{:rf.mcp/dedup-table <cache-map>}` (`vocab/dedup-table-key`). Agents
   reconstruct by calling `de-dupe.core/expand` on the cache-map value —
   a cross-MCP key by construction, so an agent that learned the slot on
-  one server sees the byte-identical slot on the other.
+  one server sees the same slot key on the other.
 
   ## Idempotence on no-dedup-opportunity
 
@@ -52,12 +52,12 @@
 
   ## What does NOT live here — the inverse (`dedup-expand`)
 
-  The forward direction is byte-identical, so it is shared here. The
+  The forward transform and marker shape are shared here. The
   INVERSE (`dedup-expand`) is NOT — neither MCP server calls it at
   runtime (the
   wire contract is that the agent host calls `de-dupe.core/expand`
   directly), so it is test-only. Each consumer keeps its own inverse
-  in ITS TEST corpus, signalled \"test-only\" by location (rf2-ywkiss):
+  in its test corpus, signalled \"test-only\" by location:
 
   - re-frame2-pair-mcp keeps it in `re-frame2-pair-mcp.test-utils`
     (its CLJS test corpus's shared test-helper ns).
@@ -99,8 +99,8 @@
   Checked on the cache SHAPE (single entry keyed by `cache-0`), not by
   re-walking the value: any repeated subtree would have added a second
   `cache-N` entry, so `(= 1 (count cache))` already implies root-only —
-  the explicit key check guards against a future `de-dupe` change that
-  keyed the root differently."
+  the explicit key check also verifies the root slot expected by this
+  pinned dependency version."
   [cache]
   (and (map? cache)
        (= 1 (count cache))

--- a/tools/mcp-base/src/re_frame/mcp_base/descriptor_manifest.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/descriptor_manifest.cljc
@@ -410,23 +410,8 @@
          :changed changed}))))
 
 ;; ---------------------------------------------------------------------------
-;; Drift-report formatting — PURE, platform-neutral report lines.
-;;
-;; The two server generators previously each carried a byte-identical
-;; `row-slot-deltas` (with a copy of the governed-slot vector) and an
-;; identical added / removed / changed / malformed traversal over a
-;; `check` result — the diagnostic body the maintainer reads when a
-;; drift-check trips. That duplication drifts: a governed slot added to
-;; `descriptor->row` had to be mirrored into two report vectors, and any
-;; wording tweak had to be applied twice or the two servers would report
-;; the same drift differently. This section centralises the shared
-;; diagnostic: the governed-slot vector, the per-row slot-delta helper,
-;; and a pure formatter that turns a `check` result + the consumer's
-;; wording into the report lines. It adds NO I/O — no file lookup, no
-;; output channel, no process exit. Each server keeps its own file
-;; lookup, stdout/stderr binding, OK-path wording, and exit codes, and
-;; supplies the two strings that legitimately differ per server (the
-;; regenerate command + the missing-file header).
+;; Drift-report formatting — pure, platform-neutral report lines.
+;; Consumers retain file I/O, output routing, commands, and exit codes.
 ;; ---------------------------------------------------------------------------
 
 (def governed-slots
@@ -436,7 +421,7 @@
   present in BOTH the committed and regenerated manifests but differing
   in any of these is a `:changed` row; `row-slot-deltas` names which of
   them moved. Shared so the two server generators report the SAME
-  governed surface (they previously duplicated this vector)."
+  governed surface."
   [:description :input-keys :gated-input-keys :required :output? :annotations :typicalTokens])
 
 (defn row-slot-deltas

--- a/tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc
@@ -524,7 +524,7 @@
   segment about to be `assoc`ed into it. Assumes the caller
   (`assoc-in-safe`'s `ok?` walk) has already proven every segment along
   `path` is safe to descend — in particular that an integer segment
-  meeting a `nil` node is exactly `0` (see rf2-x2vapx below), so the
+  meeting a `nil` node is exactly `0`, so the
   freshly-vivified `[]` here never `assoc`s an out-of-range index."
   [node path v]
   (if (empty? path)
@@ -544,18 +544,11 @@
   non-associative, or when a `nil` parent is reached by an
   out-of-range vector index.
 
-  The spec contract for `[<path> :assoc v]` is 'set the value at
-  `path`, creating the slot if it didn't exist'. The naive `assoc-in`
-  honours the create-if-absent half, but always vivifies a MAP for a
-  missing intermediate regardless of the segment's type — including
-  an INTEGER segment (`(assoc-in {} [:items 0 :qty] 2)` ⇒
-  `{:items {0 {:qty 2}}}`, an int-keyed MAP), which is a shape NEITHER
-  encoder side ever emits (`collect-vector-patches-into` only reaches
-  an index path via an actual vector). `vivify-assoc-in` (above) fixes
-  this: a `nil` node reached by an integer segment vivifies a VECTOR
-  instead (`⇒ {:items [{:qty 2}]}`, rf2-x2vapx) — the shape a real
-  diff would have produced — while every non-integer segment still
-  vivifies a map exactly as before.
+  The `[<path> :assoc v]` contract creates missing slots while
+  preserving path shape. `vivify-assoc-in` creates a vector for an
+  integer segment (`{} + [[:items 0 :qty] :assoc 2]` ⇒
+  `{:items [{:qty 2}]}`) and a map for any other segment; an int-keyed
+  map is not a shape the encoder emits.
 
   A freshly-vivified vector starts empty, so — mirroring the existing
   PRESENT-vector tail-growth rule below — only index `0` is a valid

--- a/tools/mcp-base/src/re_frame/mcp_base/egress.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/egress.cljc
@@ -8,24 +8,21 @@
   *which boundary is this?* — a named `:rf.egress/*` profile — not *which
   combination of `:rf.size/*` booleans did I remember?*. The framework
   owns the authoritative table in `re-frame.projection/profile-size-opts`
-  (`implementation/core`), but that ns transitively requires the
+  (`implementation/core`), but that namespace transitively requires the
   framework runtime graph (`re-frame.elision` → `re-frame.frame` →
-  substrate adapter, …). The MCP servers must NOT pull that graph into
-  their wire-egress decision:
+  substrate adapter, …). The shared base must not depend on that graph:
 
-  - **re-frame2-pair-mcp** ships as a self-contained Node `server.js`
-    bundle; requiring the runtime graph would bloat it and trip
-    bundle-isolation.
-  - the profile→opts resolution is a *server-side* decision (it renders
-    the resolved `:rf.size/*` map into the eval form before it crosses
-    the wire), so it cannot defer to the live app's `project-egress`.
+  - re-frame2-pair-mcp renders the resolved opts into an nREPL eval form
+    without adding the framework graph to its Node server bundle.
+  - story-mcp applies the same opts in-process. Sharing the pure table
+    keeps the two server paths aligned despite their different hosts.
 
   This ns is the cross-MCP, framework-runtime-free mirror of the six-
   member closed profile enum and its `:rf.size/*` floor. It is pure data
   over the keys `re-frame.mcp-base.vocab` already owns
   (`:rf.size/include-sensitive?` / `:rf.size/include-large?` /
   `:rf.size/include-digests?`). The mcp-conformance wire-vocab gate pins
-  this table byte-identical to the framework enum so the two cannot
+  this table value-for-value equal to the framework enum so the two cannot
   drift (a profile rename / opt-set change in the framework that does not
   land here fails the gate).
 
@@ -47,7 +44,7 @@
 
 (def profiles
   "The closed six-member `:rf.egress/profile` vocabulary (EP-0015 §10).
-  Mirror of `re-frame.projection/profiles` — pinned byte-identical by the
+  Mirror of `re-frame.projection/profiles` — pinned value-for-value by the
   mcp-conformance wire-vocab gate."
   #{:rf.egress/off-box-observability
     :rf.egress/off-box-tool

--- a/tools/mcp-base/src/re_frame/mcp_base/elision.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/elision.cljc
@@ -22,10 +22,8 @@
 
   `sensitive/strip-sensitive` returns `[kept dropped-count]` for the
   `:dropped-sensitive` envelope slot; `count-elided-markers` returns
-  the integer for the `:elided-large` slot. Both indicators ride the
-  response envelope together per the cross-MCP indicator-field
-  parity — emitting one without the other is the failure the
-  conformance gate catches.
+  the integer for the `:elided-large` slot. Tree-payload emitters compute
+  both indicators; each zero count is omitted independently.
 
   ## Cross-platform
 

--- a/tools/mcp-base/src/re_frame/mcp_base/envelope.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/envelope.cljc
@@ -1,9 +1,7 @@
 (ns re-frame.mcp-base.envelope
   "Cross-MCP response-envelope helpers.
 
-  The MCP servers decorate their tool-response envelopes with two
-  cross-cutting concerns that are pure data and identical across the
-  pair:
+  These helpers operate on wire vocabulary shared by the MCP pair:
 
     1. The indicator-field counters (`:dropped-sensitive` /
        `:elided-large`) — the MUST-level 'omit when zero' parity rule
@@ -42,14 +40,13 @@
   Conventions §Cross-MCP indicator-field vocabulary and Spec 009
   §Indicator field on tool responses.
 
-  Every tool that walks a tree-typed payload (`snapshot`, `get-path`,
-  `trace-window`, `watch-epochs`, `subscribe`, …) routes its
-  envelope-tail through here so the rule lives in one place — drift
-  across emit sites can no longer silently violate the MUST.
+  Tree-payload emitters route their envelope through this helper so the
+  indicator-key and omit-when-zero rules stay consistent.
 
   `counts`:
-    :dropped — count of `:sensitive? true` leaves dropped at the wire
-               boundary (from `sensitive/strip-sensitive`). Emitted
+    :dropped — count of records classified as sensitive and dropped at
+               the wire boundary (including fail-closed malformed
+               stamps). Emitted
                under `vocab/dropped-sensitive-key` when positive.
     :elided  — count of leaves replaced with the
                `:rf.size/large-elided` marker (from
@@ -119,7 +116,7 @@
   above) so the detector works regardless of host or
   `*print-namespace-maps*`. A response whose leading token IS one of
   these keys (not merely starts-with — see `marker-text?`) is a
-  boundary-step marker that later boundary steps must NOT re-walk."
+  boundary-step marker that a consumer can skip re-walking."
   (into [] (mapcat marker-key-prefixes) [vocab/cache-hit-key vocab/overflow-key]))
 
 ;; An EDN keyword/symbol constituent: alphanumerics plus the punctuation

--- a/tools/mcp-base/src/re_frame/mcp_base/sensitive.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/sensitive.cljc
@@ -341,7 +341,7 @@
                        [frame-map acc]))
 
                    ;; Any other non-sequential shape (nil, scalar, string)
-                   ;; is not a batch — pass it through byte-identically per
+                   ;; is not a batch — pass it through unchanged per
                    ;; the helper contract.
                    :else
                    [frame-map acc]))))

--- a/tools/mcp-base/src/re_frame/mcp_base/vocab.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/vocab.cljc
@@ -36,12 +36,9 @@
 
   ## JSON-RPC error codes
 
-  Per JSON-RPC 2.0 §5.1 and MCP's reuse of them — the same numeric
-  codes apply across both servers. Story-mcp emits them via Cheshire;
-  re-frame2-pair-mcp would emit them via the npm MCP SDK if it surfaced
-  JSON-RPC-level errors directly (today it uses the SDK's
-  `isError: true` tool-result shape, but the codes still pin the
-  cross-consumer protocol if a future bead lifts them).")
+  The constants follow JSON-RPC 2.0 §5.1. story-mcp uses them in its
+  direct JSON-RPC envelopes; re-frame2-pair-mcp delegates protocol-level
+  errors to the npm MCP SDK and uses `isError: true` for tool failures.")
 
 ;; ---------------------------------------------------------------------------
 ;; :rf.mcp/* — per-tool wire mechanism markers
@@ -75,10 +72,12 @@
 
 (def cursor-stale-reason
   "Structured error-result `:reason` value indicating the cursor's
-  epoch-id is no longer in the runtime ring.
+  continuation position is no longer valid. This covers an epoch id
+  aged out of pair-mcp's ring and a story-mcp registry fingerprint that
+  changed between pages.
 
-  Agents pattern-match on this `:reason` to either drop the cursor
-  and restart, or widen the window to recover."
+  Agents recover by dropping the cursor and restarting. Pair-specific
+  callers may also widen their time window to recover aged-out records."
   :rf.mcp/cursor-stale)
 
 (def cache-hit-key
@@ -107,11 +106,10 @@
   payload of an `isError: true` tool-result — an honest, recoverable
   rejection the agent reads and corrects, not a server fault.
 
-  First emitter: `cap/max-tokens` rejects a NEGATIVE
-  `:max-tokens` arg here rather than resolving it to a negative cap
-  (which would over-trip `apply-cap` and lock the agent out of every
-  response). The cross-MCP `:rf.mcp/*` namespace reserves the key for
-  any future per-call arg-validation rejection."
+  `cap/max-tokens` uses this for negative, sub-one fractional,
+  non-finite, and out-of-range numeric values. The cross-MCP
+  `:rf.mcp/*` namespace reserves the key for per-call argument
+  rejections."
   :rf.mcp/invalid-arg)
 
 (def result-key
@@ -215,14 +213,15 @@
 ;; `{:db {...} :elided-large 2}`). Mixing namespaced and unqualified
 ;; envelope keys would split the response shape across two conventions
 ;; and burn agent-host pattern-match budget for no information gain.
-;; The wire markers at the leaf-substitution site stay namespaced —
-;; they are addressable values the agent re-fetches; these counts are
-;; scalar summaries on the envelope.
+;; The substitution markers stay namespaced; `:rf.size/large-elided`
+;; may carry a follow-up handle, while `:rf/redacted` deliberately does
+;; not. These unqualified counts are scalar envelope summaries.
 ;; ---------------------------------------------------------------------------
 
 (def dropped-sensitive-key
-  "Envelope-slot key for the count of `:sensitive? true` leaves dropped
-  at the wire boundary. Unqualified per Conventions §Cross-MCP
+  "Envelope-slot key for the count of sensitive records dropped at the
+  wire boundary, including fail-closed malformed stamps. Unqualified
+  per Conventions §Cross-MCP
   indicator-field vocabulary. Omit the slot when the count is zero.
   Mirror of `[● REDACTED N]` on on-box dev-tool surfaces."
   :dropped-sensitive)

--- a/tools/mcp-base/test/re_frame/mcp_base/cljs_branches_cljs_test.cljs
+++ b/tools/mcp-base/test/re_frame/mcp_base/cljs_branches_cljs_test.cljs
@@ -267,7 +267,7 @@
         "exactly the ceiling still parses on both hosts")))
 
 (deftest max-tokens-finite-range-guard-cljs
-  ;; rf2-ykv9a0 — non-finite / out-of-range `:max-tokens` rejects with an
+  ;; Non-finite and out-of-range `:max-tokens` rejects with an
   ;; {:rf.mcp/invalid-arg} marker on CLJS too, never a crash / real 0-cap.
   (doseq [raw [js/Infinity js/NaN 1e20 (- 1e20)]]
     (let [out (cap/max-tokens raw)]
@@ -278,7 +278,7 @@
   (is (= 5000 (cap/max-tokens 5000)) "in-range cap passes through"))
 
 ;; ---------------------------------------------------------------------------
-;; 5c. Cursor rejects trailing forms on CLJS too (rf2-ykv9a0). A cursor is
+;; 5c. Cursor rejects trailing forms on CLJS too. A cursor is
 ;;     ONE opaque payload map; decoded text with a trailing form (tagged
 ;;     literal, ordinary EDN, scalar) ⇒ ::malformed. The wrap-in-[...]
 ;;     one-form check runs identically on cljs.reader.
@@ -299,7 +299,7 @@
              (cursor/decode-cursor
                (cursor/b64-encode "{:v 1 :after-id 1} 42")
                pair?))))
-    ;; rf2-rtg9t1 — `]`-injection runs identically on cljs.reader. The
+    ;; `]`-injection runs identically on cljs.reader. The
     ;; injected `]` closes the wrap-in-`[…]` early; the EOF-sentinel
     ;; exhaustion check rejects because the truncated read no longer ends
     ;; with the appended sentinel.
@@ -322,7 +322,7 @@
 
 ;; ---------------------------------------------------------------------------
 ;; 5d. apply-patches nested :dissoc no-op + section-kind :db-before
-;;     classification run under CLJS too (rf2-ykv9a0).
+;;     classification run under CLJS too.
 ;; ---------------------------------------------------------------------------
 
 (deftest apply-patches-nested-dissoc-noop-cljs
@@ -335,7 +335,7 @@
     (is (= {:a 1} (de/apply-patches {:a 1 :b 2} [[[:b] :dissoc]])))))
 
 (deftest apply-patches-nested-assoc-scalar-parent-structured-error-cljs
-  ;; rf2-glybzz — the `:assoc` peer of the dissoc guard, on CLJS.
+  ;; The `:assoc` peer of the dissoc guard, on CLJS.
   ;; CRUCIAL: this build runs WITHOUT Malli on the classpath, so the
   ;; grammar gate (`validate-patches!`) SOFT-PASSES — yet the replay
   ;; guard still fires. The guard is a pure structural walk during
@@ -382,7 +382,7 @@
         "absent container + direct-child assocs ⇒ :added")))
 
 ;; ---------------------------------------------------------------------------
-;; 6. Shared cursor codec round-trips under CLJS (rf2-ee38b.19). The base64
+;; 6. Shared cursor codec round-trips under CLJS. The base64
 ;;    codec is reader-conditional (`js/Buffer` on CLJS); pin the encode →
 ;;    decode round-trip and the malformed/oversize sentinels on the
 ;;    Node runtime the pair-mcp server actually runs on.
@@ -410,7 +410,7 @@
     (let [evil (cursor/b64-encode "#js {:a 1}")]
       (is (= :re-frame.mcp-base.cursor/malformed
              (cursor/decode-cursor evil any?)))))
-  (testing "built-in #inst / #uuid tags in a valid map are rejected on CLJS too (rf2-13wbe)"
+  (testing "built-in #inst / #uuid tags in a valid map are rejected on CLJS too"
     ;; `cljs.reader` resolves built-in `inst` / `uuid` from its tag-table
     ;; and BYPASSES `:default` — without the `:readers` override these
     ;; decode to a host `js/Date` / `cljs.core/UUID` and smuggle a host
@@ -430,7 +430,7 @@
                                    permissive?))))))
 
 ;; ---------------------------------------------------------------------------
-;; 7. Shared with-indicators envelope helper under CLJS (rf2-ee38b.19).
+;; 7. Shared with-indicators envelope helper under CLJS.
 ;;    The MUST-level "omit when zero" parity rule runs identically on
 ;;    both hosts; pin the CLJS half.
 ;; ---------------------------------------------------------------------------
@@ -445,7 +445,7 @@
          (envelope/with-indicators {:trace [1]} {:dropped 3 :elided 2}))))
 
 ;; ---------------------------------------------------------------------------
-;; 8. `sensitive.cljc` CLJS reader-conditional arms (rf2-k76ohl — SECURITY).
+;; 8. `sensitive.cljc` CLJS reader-conditional arms.
 ;;
 ;;    `re-frame.mcp-base.sensitive` is the spec/009 §Privacy default-suppress
 ;;    filter every MCP forwarder routes trace-like data through. Its `:cljs`

--- a/tools/mcp-base/test/re_frame/mcp_base/dedup_test.cljc
+++ b/tools/mcp-base/test/re_frame/mcp_base/dedup_test.cljc
@@ -66,12 +66,8 @@
     (is (false? (boolean (dedup/no-substitutions? {}))))))
 
 (deftest dedup-value-no-repeats-non-empty-returns-input-verbatim
-  ;; The headline fix (rf2-fwaolt): a NON-EMPTY collection with no
-  ;; repeated subtrees must stay RAW on the wire — `de-dupe-eq` yields a
-  ;; one-entry root-only cache whose wrapped shape is strictly larger than
-  ;; the input, violating the documented no-repeat-payloads-stay-raw
-  ;; contract. `empty-payload?` does NOT catch these (they're non-empty),
-  ;; so before the fix they wrapped and grew.
+  ;; A non-empty collection with no repeated subtrees produces only the
+  ;; root cache entry; wrapping it would grow the wire value.
   (testing "a flat no-repeat map is returned identical, NOT wrapped"
     (let [v {:a 1 :b 2 :c 3}
           out (dedup/dedup-value v true)]

--- a/tools/mcp-base/test/re_frame/mcp_base/descriptor_manifest_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/descriptor_manifest_test.clj
@@ -357,12 +357,8 @@
       (is (true? (:ok? res)) "LF-normalised comparison ignores line-ending style"))))
 
 ;; ---------------------------------------------------------------------------
-;; Drift-report formatting — the shared, pure diagnostic body both server
-;; generators print when a drift-check trips (rf2-cbgc40). Previously each
-;; generator carried a byte-identical copy of the governed-slot vector +
-;; the added / removed / changed / malformed traversal; centralising it
-;; here pins the ONE report surface both servers share, with the two
-;; per-server strings (regenerate command + missing-file header) injected.
+;; Drift-report formatting — the shared, pure diagnostic body. The two
+;; server-specific strings are injected by each generator.
 ;; ---------------------------------------------------------------------------
 
 (def ^:private wording

--- a/tools/mcp-base/test/re_frame/mcp_base/diff_encode_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/diff_encode_test.clj
@@ -39,7 +39,7 @@
 
 ;; ---------------------------------------------------------------------------
 ;; collect-patches — added-key detection is by KEY PRESENCE, not a
-;; sentinel VALUE (rf2-znjqja).
+;; sentinel value.
 ;;
 ;; The added-key arm keys off `find` (presence), never a marker value. An
 ;; app-db leaf can be ANY runtime value — including the private
@@ -261,7 +261,7 @@
           (is (= :rf.error/bad-diff-replay (:rf.error/id d))
               "carries the reserved :rf.error/* code")
           (is (= 'mcp-base/apply-patches (:where d))
-              "decode-side boundary (rf2-4ypau)")
+              "decode-side boundary")
           (is (= :no-recovery (:recovery d)))
           (is (= [:a :b] (:patch-path d)) "reports the offending patch path")
           (is (= [:a] (:at d)) "reports the prefix where traversal hit the non-associative node")
@@ -301,7 +301,7 @@
     (is (= {:y 9} (de/apply-patches {:x 1} [[[] :assoc {:y 9}]])))))
 
 (deftest apply-patches-vector-index-vs-absent-parent-vivifies-vector
-  ;; rf2-x2vapx: the missing-parent auto-vivification cases pinned above
+  ;; The missing-parent auto-vivification cases pinned above
   ;; ("MISSING / nil intermediate parent still auto-vivifies") only cover
   ;; MAP-KEY paths (`[:a :b]` ⇒ `{:a {:b 2}}`). A path whose NEXT segment
   ;; is an INTEGER (a vector index) reaching an ABSENT parent used to fall
@@ -359,7 +359,7 @@
       (catch clojure.lang.ExceptionInfo e
         (is (= :rf.error/bad-diff-replay (:rf.error/id (ex-data e))))
         (is (= 'mcp-base/decode-db-after (:where (ex-data e)))
-            "boundary attributes the section decoder, not apply-patches (rf2-4ypau)"))))
+            "boundary attributes the section decoder, not apply-patches"))))
   (testing "a well-formed diff against a matching base still round-trips"
     (let [encoded (de/diff-encode-db-after {:db-before {:a {:x 1}}
                                             :db-after  {:a {:x 1 :y 2}}})]
@@ -614,7 +614,7 @@
           (is (= :rf.error/bad-diff-patches
                  (:rf.error/id (ex-data e)))
               "ex-info carries the reserved :rf.error/* code")))))
-  (testing "the threaded `where` symbol propagates to ex-info :where (rf2-4ypau)"
+  (testing "the threaded `where` symbol propagates to ex-info :where"
     (let [bad [[[:a] :replace 1]]]
       (try
         (#'de/validate-patches! bad 'mcp-base/diff-encode-db-after)
@@ -750,7 +750,7 @@
                (:rf.error/id (ex-data e))))
         (is (= 'mcp-base/apply-patches
                (:where (ex-data e)))
-            "ex-info names the DECODE-side boundary, not the encoder (rf2-4ypau)")))))
+            "ex-info names the decode-side boundary, not the encoder")))))
 
 (deftest apply-patches-well-formed-input-passes-validation
   ;; Soft contract: well-formed patches pass the gate silently and
@@ -821,7 +821,7 @@
               "ex-info carries the reserved :rf.error/* code")
           (is (= 'mcp-base/decode-db-after
                  (:where (ex-data e)))
-              "ex-info names the DECODE-side boundary, not the encoder (rf2-4ypau)"))))))
+              "ex-info names the decode-side boundary, not the encoder"))))))
 
 (deftest decode-db-after-rejects-malformed-sections-slot
   ;; A diff marker whose `:sections` slot is `nil` or `false` must not

--- a/tools/mcp-base/test/re_frame/mcp_base/section_grouping_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/section_grouping_test.clj
@@ -62,7 +62,7 @@
     (let [s (first sections)]
       (is (= [:cart :items 0] (:section-path s)))
       (is (= :modified (:section-kind s))
-          "all-:assoc direct children WITHOUT :db-before context → :modified (rf2-ykv9a0): patch shape can't prove the container is new")
+          "without :db-before, patch shape cannot prove the container is new")
       (is (= 2 (count (:patches s)))))))
 
 (deftest unrelated-root-keys-stand-as-separate-sections
@@ -266,7 +266,7 @@
         "input order doesn't alter section order — the sort makes it stable")))
 
 (deftest sections-are-sorted-ascending-by-final-section-path
-  ;; rf2-8y5pen: the initial sort keys patches by their FULL path, but
+  ;; The initial sort keys patches by their full path, but
   ;; coalescing (`group-by-ancestor`) and singleton-promotion both
   ;; NARROW a cluster's prefix to a shorter common-ancestor path —
   ;; changing its sort key. `pr-str` of a vector closes with `]` (char


### PR DESCRIPTION
## Summary

- align argument, cursor, cap, egress, envelope, dedup, descriptor, and wire-vocabulary explanations with current consumer contracts
- remove historical bead narration, speculative plans, and duplicated configuration commentary
- keep executable behavior unchanged

## Verification

- `clojure -M:test` in `tools/mcp-base` (266 tests, 877 assertions)
- `npm run test:cljs` in `tools/mcp-base` (28 tests, 181 assertions)
- `clj-kondo --parallel --fail-level error --lint tools/mcp-base` (0 errors; 1 existing warning)
- `clojure -M:splint --fail-on-errors ../tools/mcp-base` from `implementation` (0 errors; 35 existing style warnings)
