### PR TITLE
docs(mcp-conformance): clarify current contracts (rf2-0idv89)

### DIFF
--- a/tools/mcp-conformance/NAMING.md
+++ b/tools/mcp-conformance/NAMING.md
@@ -1,351 +1,130 @@
-# Cross-MCP tool-naming convention
+# Cross-MCP tool naming
 
-Source: rf2-mzf1r.
+`re-frame2-pair-mcp` and `story-mcp` share a bounded tool-name
+vocabulary. A tool's leading verb should tell a client whether it reads,
+enumerates, executes, mutates, waits, or streams without requiring
+server-specific guesswork.
 
-The re-frame2 MCP pair — `tools/re-frame2-pair-mcp/` and
-`tools/story-mcp/` — exposes a deliberately bounded surface, catalogued
-per-server at
-[`tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md`](../re-frame2-pair-mcp/spec/003-Tool-Catalogue.md)
-and
-[`tools/story-mcp/spec/002-Tool-Registry.md`](../story-mcp/spec/002-Tool-Registry.md).
-Per the §"Single source of truth for tool counts" rule below, every count
-sits in one place: the catalogue. An agent host with both servers
-attached at once sees the union as one surface.
-**The verb a tool uses is the first signal the agent parses**; verb
-drift across siblings makes that signal lossy (snapshot in re-frame2-pair ≠
-snapshot-identity in story) and pushes the agent towards trial-and-error
-rather than pattern-match.
+Each server's canonical `tool-names.json` fixture owns its complete
+catalogue. The JVM `verb_vocab_test.clj` gate reads those fixtures and
+checks every name against the vocabulary below. This document does not
+repeat either full catalogue.
 
-(Historical: a third server `xray-mcp` was envisaged; it was dropped
-per rf2-hvl1g — AI agent access to Xray state already flows via
-`re-frame2-pair-mcp` against the framework-published Xray runtime API,
-so a dedicated xray-mcp is unnecessary.)
+## Verb vocabulary
 
-This doc locks the verb vocabulary the pair picks from. New tools
-land against an existing verb; novel verbs require a Lock entry in
-the relevant server's `DESIGN-RATIONALE.md` and a return-trip here
-to extend the table. The conformance harness in
-[`wire-vocab/`](./wire-vocab/) covers the wire payloads; this doc
-covers the catalogue surface.
-
-## The verb table
-
-| Verb shape | Semantics | Examples | Notes |
-|---|---|---|---|
-| **`get-<thing>`** | Single-entity read by id / key / addressed path. Returns ONE record or value. | `get-app-db`, `get-path`, `get-story`, `get-variant`, `get-trace-buffer`, `get-epoch-history`, `get-machine-state`, `get-machine-list`, `get-issues`, `get-handlers`, `get-source-coord`, `get-story-instructions` | The most common verb. The agent supplies an id / path / filter; the server returns the addressed slice. `get-` is a pure read — no side-effects, no recompute. `get-trace-buffer` and `get-epoch-history` are `get-` rather than `list-` because they return slices addressed by filter, not full enumerations. |
-| **`list-<things>`** | Collection enumeration — no id, returns vector / set. | `list-stories`, `list-substrates`, `list-tags`, `list-modes`, `list-assertions` | Closed-set or registrar-derived enumeration. The returned shape is a vector of records (or ids); no filter axis collapses it to one entity. re-frame2-pair-mcp doesn't ship any `list-*` today (its catalogue is small enough that the per-frame snapshot covers the discovery workflow). New tools that match the pure-enumeration shape use `list-`. |
-| **`read-<thing>`** | Diagnostic re-read of last-computed state. Same shape as `get-`, but reserved for the **no-recompute** read path against a previously-executed artefact. | `read-failures`, `read-a11y-violations` | Distinguished from `get-` so the agent recognises "the run already happened; this is a cheap reflection" — not "fetch the live state". The difference matters when the value is expensive to recompute (story-mcp's `read-failures` reads the variant's accumulated `:rf.story/assertions` rather than re-running the play sequence; `read-a11y-violations` reads the in-browser a11y panel's accumulated axe-core violations rather than executing axe — the name says read, not run, precisely because calling it neither runs a fresh check nor proves the variant accessible). |
-| **`discover-<surface>`** | Session-bootstrap health probe. Returns `{:ok? ... :debug-enabled? ... :frames [...] :build-id ...}` or a structured `:reason` keyword. | `discover-app` | Run first every session. Used by re-frame2-pair-mcp; story-mcp doesn't ship `discover-app` because its runtime model is JVM-side (no nREPL handshake). |
-| **`dispatch`** | Fire a re-frame2 event. Bare verb, used by re-frame2-pair-mcp. Always tagged with `:origin :<server-name>` on the trace bus. | `dispatch` | Story-mcp does NOT ship `dispatch` — its mutations go through `register-variant` / `unregister-variant` instead. The bare verb is reserved for the framework's primary mutation primitive. |
-| **`eval-cljs`** | The escape hatch — evaluate an arbitrary CLJS form in the connected runtime. Bare verb, used by re-frame2-pair-mcp. Any side-effect the form triggers inherits the server's `:origin` tag. | `eval-cljs` | Story-mcp does NOT ship `eval-cljs` because its server runs JVM-side and there's no browser runtime to eval into. |
-| **`restore-<thing>`** | Time-travel state restore. Mirrors a user-confirmed in-panel affordance. | `restore-epoch` | Mutating; tagged `:origin :<server-name>`. Shipped by re-frame2-pair-mcp behind `--allow-writes` (rf2-ee38b.18). |
-| **`replace-<thing>`** | Replace a named state partition with a caller-supplied value, bypassing the normal cascade. Mirrors a "try anyway" / state-injection affordance. | `replace-app-db` | Mutating; tagged `:origin :<server-name>`. `replace-app-db` (re-frame2-pair-mcp) is gated behind `--allow-writes` (rf2-ee38b.18); it wraps the framework's `replace-frame-state!` Tool-Pair write primitive as an app-only partial map (`{:rf.db/app v}`) — the ONE frame-state write surface (a db-shaped key never silently replaces runtime-db). |
-| **`reset-<thing>`** | Reset a named state / session partition to its empty / default value, bypassing the normal cascade. | `reset-operating-frame` | Mutating where it touches app-db; tagged `:origin :<server-name>`. `reset-operating-frame` (rf2-zomfq) clears the SESSION operating-frame pin — not an app-db write, so ungated. (The former `reset-frame-db` state-injection tool was renamed to `replace-app-db` under EP-0001.) |
-| **`set-<thing>`** | Pin / declare ONE named **session setting** — not a generic mutation surface. Narrowly catalogued for the operating-frame contract only. | `set-operating-frame` | Added by rf2-zomfq (re-frame2-pair). The Tool-Pair §Tool-surface obligations contract mandates a set/reset/get trio for the operating frame and states the stable names are "typically `set-operating-frame` / `reset-operating-frame` / `get-operating-frame`"; the spec-mandated name wins for cross-server mental-model transfer. This is the deliberate carve-out from the `set-` rejection in §"What's NOT a locked verb" below — admissible ONLY because it pins a single named session setting (the operating frame), not arbitrary state. A future generic `set-<arbitrary>` is still rejected. Lock entry: re-frame2-pair-mcp `DESIGN-RATIONALE.md` §Subsequent evolution (rf2-zomfq). |
-| **`register-<thing>` / `unregister-<thing>`** | Registry add / remove, symmetric pair. Both gated behind the server's write-allow flag where applicable. | `register-variant`, `unregister-variant` | Story-mcp only today. If a future tool surfaces "register a handler at the framework level via MCP" it adopts this verb. |
-| **`run-<thing>`** | Execute a definition and report **pass / fail** results. Implies a play sequence, an assertion vocabulary, or some explicit success criterion. | `run-variant` | Distinguished from `preview-` (no pass/fail) and `dispatch` (one event, not a sequence). Story-mcp only today. `run-` is reserved for tools that actually execute a runner — the a11y violation surface is a `read-` (no-recompute) tool, `read-a11y-violations`, because it only reflects the in-browser panel's already-accumulated state and does NOT execute axe. |
-| **`preview-<thing>`** | Execute and report **rendered / resolved state**, but no pass/fail. The "show me what this would look like" call. | `preview-variant` | The symmetric pair of `run-` for the same registry. Story-mcp only today. |
-| **`explain-<thing>`** | Pure read of the **derivation / resolution reasoning** for a definition — "why did this resolve the way it did". No run, no live state. Mirrors a human "explain" panel. | `explain-variant` | Distinguished from `get-` (which returns the stored body) and `preview-` (which executes): `explain-` returns the plan compiler's source/merge/lowering reasoning. Story-mcp's `explain-variant` mirrors the human Explain panel over `re-frame.story/explain` (rf2-ba86n.17). Story-mcp only today. |
-| **`describe-<thing>`** | Read the **composed / derived behaviour** an addressed runtime context runs PLUS where each piece resolved from — "what behaviour does THIS context run, and which source won each resolution". A pure read; no run, no mutation. | `describe-image` | Added by rf2-srobm0 (re-frame2-pair). Distinguished from `get-` (returns ONE stored record/value), `read-` (no-recompute reflection of an already-executed artefact), and `list-` (flat enumeration): `describe-` reports a per-context COMPOSITION — the selected universe a frame actually runs, with optional per-registration provenance. `describe-image` is the EP-0023 Use-Case 7 read over a frame's running image generation (images / kinds / capability requires / per-kind counts / optional per-registration coordinate). Lock #11 in re-frame2-pair-mcp `DESIGN-RATIONALE.md`. |
-| **`record-as-<thing>`** | Capture user / agent activity for a bounded duration; emit as an artefact (variant snippet, etc.). | `record-as-variant` | The bridge between live dispatches and the persisted registry. Story-mcp only today. |
-| **`subscribe` / `unsubscribe`** | Streaming pair. Bare verbs, used by re-frame2-pair-mcp. `subscribe` returns one `notifications/progress` per matching batch; `unsubscribe` closes out-of-band. | `subscribe`, `unsubscribe` | Topic vocabulary is per-server (re-frame2-pair ships `:trace` / `:epoch` / `:fx` / `:error`). Story-mcp does not ship streaming. |
-| **`tail-<thing>`** | Wait for an external state change to land. Polls until a probe condition flips or `wait-ms` expires. | `tail-build` | Today only `tail-build` exists (await hot-reload). Future variants (`tail-test`, `tail-deploy`) take the same shape: integer wait, probe form, structured timeout. |
-| **`watch-<thing>`** | Block until a predicate over a live signal holds, or time out. Distinct from `tail-` (which awaits an EXTERNAL state change via a probe-value delta) — `watch-` blocks on a PREDICATE over an in-runtime signal-set (app-db / sub / DOM / focus). | `watch-until` | Added by rf2-zo4b9 (re-frame2-pair). `watch-epochs` predates the prefix and stays on the bare-verb list (its semantics are pull-mode pagination, not blocking-until). The server-side poll cadence mirrors `tail-build`. |
-| **Mega-op bare verbs** | Reserved for derived projections / multi-registry reads that don't fit `get-<thing>`. Bare names, no prefix. | `snapshot`, `trace-window`, `watch-epochs`, `record`, `orient` | These are re-frame2-pair-mcp's coarse-grained reads / recorders that span multiple registry kinds (`snapshot` covers app-db + sub-cache + machines + epochs + traces in one round-trip; `trace-window` and `watch-epochs` page over the trace bus; `record` (rf2-zo4b9) installs a read-only change-log observer over a heterogeneous signal-set — app-db / sub / DOM / focus; `orient` (rf2-3bu3d.8) is the first-contact app-shape summary — liveness + frames + per-frame app-db top-keys + registry counts/ids + machines in one round-trip, composing the existing introspection surfaces). Adding a new bare verb requires a Lock entry in the relevant server's `DESIGN-RATIONALE.md`. NOTE the contrast with the `record-as-<thing>` PREFIX (story-mcp's `record-as-variant`, capture-as-artefact): bare `record` is the live recorder, `record-as-` persists a captured artefact. |
-
-## What's NOT a locked verb
-
-These prefixes are **deliberately rejected** for new tools — call them
-out in PR review and pick from the table above instead.
-
-- **`fetch-`, `query-`, `find-`, `lookup-`** — verb-soup synonyms for
-  `get-`. Pick `get-`.
-- **`update-`** — implies a generic mutation surface. Pick a
-  named verb (`dispatch`, `register-`, `restore-`, `reset-`) so the
-  agent sees the registry / surface, not the verb tense.
-- **`set-`** — generally rejected for the same generic-mutation-surface
-  reason: pick a named verb. The **sole catalogued exception** is
-  `set-operating-frame` (rf2-zomfq), admitted because it pins ONE named
-  session setting the Tool-Pair contract mandates under that exact name
-  (§The verb table `set-<thing>` row). A generic `set-<arbitrary-slot>`
-  remains rejected.
-- **`enumerate-`, `all-<things>`, `<things>-list`** — verb-soup
-  synonyms for `list-`. Pick `list-`.
-- **`call-`, `invoke-`, `run-fn`** — `eval-cljs` is the catalogued
-  escape hatch; bare-name dispatch is the catalogued event-fire. Don't
-  bypass them.
-- **`stream-`, `observe-`, `tail-trace`** — `subscribe` / `unsubscribe`
-  is the catalogued streaming pair. `tail-` is reserved for external-
-  state-change-await semantics (one-shot, returns when a probe-value
-  delta trips); `watch-` (rf2-zo4b9) is reserved for blocking on a
-  PREDICATE over an in-runtime signal-set. Continuous change-logging of
-  a signal-set is `record` (rf2-zo4b9), not `observe-`.
-
-## Server alignment today
-
-The pair is **fully aligned** with this convention today
-(post-rf2-4y595). The table below is the audit; the table reflects
-the post-rename state — pair-mcp's two former deviations
-(`subscription-info`, `registry-list`) were renamed to
-`list-subscriptions` / `list-handlers` per rf2-4y595 (rf2-h1izl
-follow-on C5). The convention is the lock for **any future extension**
-to re-frame2-pair-mcp / story-mcp.
-
-### re-frame2-pair-mcp
-
-(Live tool count: see
-[`tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md`](../re-frame2-pair-mcp/spec/003-Tool-Catalogue.md)
-— the canonical count site per §"Single source of truth for tool
-counts" below.)
-
-| Tool | Verb shape | Notes |
+| Shape | Meaning | Examples |
 |---|---|---|
-| `discover-app` | `discover-` | Conformant. |
-| `eval-cljs` | bare (universal) | Conformant. |
-| `dispatch` | bare (universal) | Conformant. |
-| `tail-build` | `tail-` | Conformant. |
-| `snapshot` | bare (mega-op) | Conformant — multi-slice projection. |
-| `trace-window` | bare (mega-op) | Conformant — paginated projection over trace bus. |
-| `watch-epochs` | bare (mega-op) | Conformant — paginated projection. (Borderline: arguably a `list-` candidate, but the cursor / filter shape leans mega-op.) |
-| `get-path` | `get-` | Conformant. |
-| `subscribe` / `unsubscribe` | bare (universal pair) | Conformant. |
-| `list-subscriptions` | `list-` | Conformant — renamed from `subscription-info` per rf2-4y595 (NAMING.md follow-on). No back-compat shim; the old name hard-errors with `:unknown-tool`. |
-| `handler-meta` | bare-noun read | Conformant exception — bare-noun read of a single-record metadata map. Accepted under the bare-noun-exception clause when the return value is a structured metadata blob the agent reads as one record (same shape as story-mcp's `snapshot-identity`). Added by rf2-cibp8. |
-| `list-handlers` | `list-` | Conformant — renamed from `registry-list` per rf2-4y595 (NAMING.md follow-on). The `<noun>-list` suffix was flagged as rejected in §"What's NOT a locked verb" above; `list-<things>` prefix is the catalogued shape. The runtime's `(rf/registry-list kind)` accessor keeps its name (separate naming surface). Added by rf2-pctf8. |
-| `get-re-frame2-pair-instructions` | `get-` | Conformant — single-record read of the agent-onboarding instructions blob (rf2-fnpqg). Mirrors story-mcp's `get-story-instructions`. |
-| `restore-epoch` | `restore-` | Conformant — time-travel state restore. Gated behind `--allow-writes` (default OFF). Added by rf2-ee38b.18. |
-| `replace-app-db` | `replace-` | Conformant — state injection, bypassing the normal cascade. Gated behind `--allow-writes` (default OFF). Added by rf2-ee38b.18; renamed from `reset-frame-db` under EP-0001 (rf2-tfepxu / rf2-0acvdb); tracks the framework's `replace-frame-state!` write primitive as an app-only partial map (rf2-t3lftq — API-shrink #3 consolidated the former `replace-app-db!` into this). |
-| `read-dom` | `read-` | Conformant — diagnostic re-read of rendered DOM content (no recompute; the render already happened). Added by rf2-nfjil. |
-| `record` | bare (mega-op) | Conformant — bare-verb signal recorder spanning app-db / sub / DOM / focus. Lock entry in `DESIGN-RATIONALE.md`. Distinct from the `record-as-` prefix (capture-as-artefact). Added by rf2-zo4b9. |
-| `read-recording` | `read-` | Conformant — diagnostic re-read of a recording's change-log (paired with `record`). Added by rf2-zo4b9. |
-| `watch-until` | `watch-` | Conformant — blocks until a predicate over a signal holds. New `watch-` prefix; Lock entry in `DESIGN-RATIONALE.md`. Added by rf2-zo4b9. |
-| `set-operating-frame` | `set-` (carve-out) | Conformant — pins the session operating frame (the tier-2 escape from `:ambiguous-frame`). The one catalogued `set-` exception; the Tool-Pair contract mandates this stable name. Lock entry in `DESIGN-RATIONALE.md`. Added by rf2-zomfq. |
-| `reset-operating-frame` | `reset-` | Conformant — clears the session operating-frame pin. Ungated (session-state, not app-db). Added by rf2-zomfq. |
-| `get-operating-frame` | `get-` | Conformant — single-record read of the `{:frames :selected :operating}` operating-frame triple (Tool-Pair §Tool-surface obligations). Added by rf2-zomfq. |
-| `read-sub` | `read-` | Conformant — diagnostic re-read of a single subscription's current value via the validated read path (no recompute beyond the reactive cache resolve). Added by rf2-3bu3d.7. |
-| `orient` | bare (mega-op) | Conformant — first-contact app-shape summary spanning liveness + frames + per-frame app-db top-keys + registry counts/ids + machines in one round-trip. Lock #9 in `DESIGN-RATIONALE.md`. Added by rf2-3bu3d.8. |
-| `describe-image` | `describe-` | Conformant — new `describe-<thing>` prefix. Per-frame read of the composed image generation a frame runs (images / kinds / capability requires / per-kind counts / optional per-registration provenance). Distinct from `get-` / `read-` / `list-` — see §The verb table. Lock #11 in `DESIGN-RATIONALE.md`. Added by rf2-srobm0. |
+| `get-<thing>` | Read one addressed record or value. | `get-path`, `get-story`, `get-operating-frame` |
+| `list-<things>` | Enumerate a collection. | `list-handlers`, `list-stories`, `list-streams` |
+| `read-<thing>` | Re-read already computed or rendered diagnostic state; do not imply a fresh run. | `read-sub`, `read-dom`, `read-failures` |
+| `discover-<surface>` | Bootstrap health and connection discovery. | `discover-app` |
+| `restore-<thing>` | Restore a prior state. | `restore-epoch` |
+| `replace-<thing>` | Replace a named state partition outside the normal cascade. | `replace-app-db` |
+| `reset-<thing>` | Clear a named state or session partition. | `reset-operating-frame` |
+| `set-<thing>` | Pin one named session setting. This prefix is reserved for the operating-frame contract. | `set-operating-frame` |
+| `register-<thing>` / `unregister-<thing>` | Add or remove a registry entry. | `register-variant`, `unregister-variant` |
+| `run-<thing>` | Execute a definition and report pass/fail results. | `run-variant` |
+| `preview-<thing>` | Execute and report rendered or resolved state without a pass/fail claim. | `preview-variant` |
+| `explain-<thing>` | Read derivation or resolution reasoning without executing. | `explain-variant` |
+| `describe-<thing>` | Read composed behaviour and its provenance for an addressed runtime context. | `describe-image` |
+| `record-as-<thing>` | Capture activity and return it as an artefact. | `record-as-variant` |
+| `tail-<thing>` | Wait for an external state change or timeout. | `tail-build` |
+| `watch-<thing>` | Wait until a predicate over live signals holds or times out. | `watch-until` |
 
-### Story-mcp
+The following names are intentionally bare:
 
-(Live tool count: see
-[`tools/story-mcp/spec/002-Tool-Registry.md`](../story-mcp/spec/002-Tool-Registry.md)
-— the canonical count site per §"Single source of truth for tool
-counts" below.)
+- `dispatch` and `dispatch-dry-run`: the framework event primitives.
+- `eval-cljs`: the browser-runtime evaluation primitive.
+- `subscribe` and `unsubscribe`: the streaming pair.
+- `snapshot`, `trace-window`, `watch-epochs`, `orient`, and `record`:
+  coarse projections or recorders that span several registry kinds.
 
-| Tool | Verb shape | Notes |
+Three catalogue names are explicit exceptions:
+
+- `handler-meta`: a single metadata record.
+- `variant->edn`: a Clojure-idiomatic canonical-form projection.
+- `snapshot-identity`: a single identity digest.
+
+The exception allowlist is executable in `verb_vocab_test.clj`; adding a
+name there requires the matching rationale here.
+
+## Rejected synonyms
+
+Do not introduce alternate verbs for an existing semantic:
+
+- use `get-`, not `fetch-`, `query-`, `find-`, or `lookup-`;
+- use `list-`, not `enumerate-`, `all-`, or a `<things>-list` suffix;
+- use a named mutation such as `dispatch`, `register-`, `restore-`, or
+  `replace-`, not generic `update-`;
+- reserve `set-` for `set-operating-frame`, rather than generic state
+  mutation;
+- use `eval-cljs` or `dispatch`, not `call-`, `invoke-`, or `run-fn`;
+- use `subscribe`/`unsubscribe` for streams, `tail-` for one external
+  change, `watch-` for a predicate, and `record` for a bounded live
+  change log.
+
+## Catalogue and count ownership
+
+The complete tool lists and counts live in the server catalogues:
+
+- [`re-frame2-pair-mcp/spec/003-Tool-Catalogue.md`](../re-frame2-pair-mcp/spec/003-Tool-Catalogue.md)
+- [`story-mcp/spec/002-Tool-Registry.md`](../story-mcp/spec/002-Tool-Registry.md)
+
+Other documents should link to those catalogues instead of copying a
+count or inventory. The executable conformance harness loads these
+canonical fixtures directly:
+
+- `tools/re-frame2-pair-mcp/test/fixtures/tool-names.json`
+- `tools/story-mcp/test/fixtures/tool-names.json`
+
+Adding or removing a tool updates the owning server catalogue and
+fixture. The Node call-coverage ratchet then requires the advertised
+tool to be called or explicitly excluded, while the JVM verb linter
+requires its name to conform.
+
+## Operator flags
+
+Equivalent authority gates use the same launch-flag spelling across
+servers:
+
+| Flag | Default | Contract |
 |---|---|---|
-| `get-story-instructions` | `get-` | Conformant — single-record read of the instruction blob. |
-| `preview-variant` | `preview-` | Conformant. |
-| `list-substrates` | `list-` | Conformant. |
-| `list-stories` | `list-` | Conformant. |
-| `get-story` | `get-` | Conformant. |
-| `get-variant` | `get-` | Conformant. |
-| `list-tags` | `list-` | Conformant. |
-| `list-modes` | `list-` | Conformant. |
-| `list-decorators` | `list-` | Conformant — read-only `(story/registrations :decorator)` enumeration (rf2-mqp1u). |
-| `list-assertions` | `list-` | Conformant. |
-| `get-docs-markdown` | `get-` | Conformant — single-record read of a story's GFM-projected documentation (rf2-i0kyy). Sibling shape to `get-story`. |
-| `variant->edn` | bare (Clojure idiom) | **Deviation** — `->edn` is a Clojure-idiomatic projection name (mirrors `into`, `seq->vec` etc.). The convention catalogues this as an accepted exception: when the operation is a **canonical-form serialiser** of a known artefact, `<thing>->edn` is preferable to `get-<thing>-edn` because the arrow signals the projection direction. Story-mcp ships exactly one of these; if a sibling appears (`variant->json`, etc.) it follows the same shape. |
-| `run-variant` | `run-` | Conformant. |
-| `snapshot-identity` | bare (Clojure idiom) | **Deviation** — bare-noun read of a content-hash. The convention catalogues this as an accepted bare-noun exception when the return value is a single primitive (a hash, a count, a digest) and the call is read-only. An alternative future shape `get-variant-identity` would also be conformant; the current name is grandfathered. |
-| `read-failures` | `read-` | Conformant — diagnostic re-read of last-computed state. |
-| `read-a11y-violations` | `read-` | Conformant — diagnostic re-read of the in-browser a11y panel's accumulated axe-core violations; does NOT execute axe (the `read-` no-recompute path, sibling of `read-failures`). |
-| `register-variant` | `register-` | Conformant. |
-| `unregister-variant` | `unregister-` | Conformant. |
-| `record-as-variant` | `record-as-` | Conformant. |
+| `--no-eval` | eval enabled | Pair-only opt-out for `eval-cljs`; disabled calls return `:rf.error/eval-cljs-disabled` before nREPL. |
+| `--allow-sensitive-reads` | closed | Allows per-call sensitive/raw opt-ins that are otherwise forced to the safe projection. |
+| `--allow-writes` | closed | Enables named state or registry writes. It does not make an eval-enabled pair server read-only; compose with `--no-eval` for that posture. |
 
-## Single source of truth for tool counts
+Rules:
 
-Each per-server spec carries its catalogue count in prose ("the 19 tools",
-"the fourteen tools"). Past drift episodes (story-mcp shipped both "16 tools"
-and "17 tools" across five docs after `list-subscriptions` was added; the
-audit that surfaced it had to grep across `tools/story-mcp/` to find every
-mention) trace to one root cause: **the count is repeated, not extracted**.
-Every doc that recites the number ages independently when a tool lands or
-gets retired.
+- describe the operator-visible authority, not an implementation detail;
+- reject removed spellings instead of maintaining aliases;
+- keep the gate at `tools/call`, so descriptors remain discoverable;
+- return a structured refusal without contacting the runtime when the
+  launch gate is closed.
 
-The convention for per-server tool-catalogue docs:
+`test/end-to-end-flag-gates.cjs` owns the SDK-level story write-gate
+checks. The live pair suite owns the pair configurations that require a
+runtime, including the `--no-eval` result envelope. Server unit tests own
+argument parsing and removed-flag diagnostics.
 
-- **One canonical count site per server.** Pin the integer in exactly one
-  place — the catalogue file's `# <Server> — Tool Registry` heading or its
-  introductory paragraph (`tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md`,
-  `tools/story-mcp/spec/002-Tool-Registry.md`). Every other doc that
-  needs to cite the count **links to the catalogue** rather than
-  repeating the integer:
-  ```md
-  See [`002-Tool-Registry.md`](002-Tool-Registry.md) for the full tool list.
-  ```
-  rather than
-  ```md
-  See [`002-Tool-Registry.md`](002-Tool-Registry.md) — the 17 tools.
-  ```
-- **PR-review rule.** A PR that adds or removes a tool MUST update the
-  canonical count site in the catalogue heading. Any other doc that still
-  reads "the N tools" after the catalogue update is a stale citation — fix
-  it or convert it to a count-free link. The cross-MCP audit walks both
-  servers once per release looking for the pattern; until that audit is
-  automated, the discipline lives here.
-- **`Server alignment today` (above) carries no integer counts in its
-  headings.** Per-server subsections link to the catalogue for the live
-  count rather than pinning an integer that would silently age past the
-  next add/remove. The audit table itself enumerates the verb-conformance
-  judgement for each tool by name — a tool added after this doc's last
-  audit pass simply isn't in the table yet, which is the correct signal
-  ("re-audit needed") rather than a contradicted count.
+## JSON-RPC versus tool errors
 
-This is the same single-source-of-truth principle that governs the verb
-table above — the table is the lock, the per-server catalogues are the
-projections.
+Protocol failures use JSON-RPC numeric codes. The canonical constants
+live in `tools/mcp-base/src/re_frame/mcp_base/vocab.cljc`; the SDK
+conformance harness pins `MethodNotFound` and accepts the SDK-observed
+`InvalidParams`/`InternalError` union for malformed `tools/call` input.
 
-## Error-vocabulary alignment
+Tool execution failures remain MCP tool results: `isError: true` plus a
+structured reason. Cross-server reason and marker vocabulary belongs to
+[`wire-vocab/README.md`](wire-vocab/README.md), not the tool-name table.
 
-The `:reason` keyword on `{:ok? false ...}` returns follows the same
-cross-server discipline. Three reserved namespaces:
+## Extending the vocabulary
 
-- **`:rf.error/*`** — framework runtime errors (handler exceptions,
-  schema-validation failures, dispatch-cycle limits). Owned by the
-  framework, surfaced verbatim by every server.
-- **`:rf.epoch/*`** — epoch-machinery errors (`:rf.epoch/cursor-stale`,
-  `:rf.epoch/id-aged-out`). Owned by `spec/Tool-Pair.md`, surfaced
-  verbatim by every server that ships epoch slices.
-- **`:<server-name>.error/*`** — server-specific failures
-  (`:rf.story-mcp.error/write-gate-closed`,
-  `:rf.re-frame2-pair-mcp.error/runtime-not-preloaded`). Owned by the
-  server.
+A genuinely new verb shape requires:
 
-Additional cross-server reserved keywords cover the wire-vocabulary
-markers (`:rf.mcp/overflow`, `:rf.mcp/summary`, `:rf.mcp/dedup-table`,
-`:rf.mcp/diff-from`, `:rf.mcp/cache-hit`, `:rf.size/large-elided`,
-`:rf.elision/at`) — see [`wire-vocab/README.md`](./wire-vocab/README.md)
-for the shape contract and the conformance gate.
+1. a rationale in the owning server's `spec/DESIGN-RATIONALE.md`;
+2. a row in this table;
+3. a corresponding update to `verb-prefixes`, `bare-verbs`, or the
+   exception allowlist in `verb_vocab_test.clj`; and
+4. wire-vocabulary coverage if the tool emits a shared marker.
 
-### JSON-RPC error codes
-
-Underneath the `:reason` keyword layer above sits the **JSON-RPC 2.0
-numeric error-code** layer — the codes the SDK / framework return
-when a request is malformed at the protocol level rather than failing
-in tool-result space. Per JSON-RPC §5.1 and MCP's reuse, the same
-numeric codes apply across both servers; the canonical home for every
-code constant is
-[`tools/mcp-base/src/re_frame/mcp_base/vocab.cljc`](../mcp-base/src/re_frame/mcp_base/vocab.cljc)
-(see the `code-*` defs).
-
-The conformance contract pins:
-
-- **`-32601 MethodNotFound`** — the canonical code for an unknown
-  JSON-RPC method. Pinned by `mcp-base/vocab.cljc/code-method-not-found`.
-  Every server in the pair MUST yield this code for an unrecognised
-  method name; the conformance harness asserts the exact value (see
-  `tools/mcp-conformance/test/_runner.cjs/assertJsonRpcErrorCodes`).
-- **`-32602 InvalidParams` / `-32603 InternalError`** — both are
-  conformant today for a malformed `tools/call` request (e.g. one
-  missing the `:name` slot). JSON-RPC §5.1's plain reading says
-  `-32602`; the npm MCP SDK in practice wraps the underlying zod
-  parse failure as `-32603`. Both are pinned by `mcp-base/vocab.cljc`
-  (`code-invalid-params` / `code-internal-error`). The conformance
-  gate accepts the **union** — either code passes
-  `assertJsonRpcErrorCodes` — so an SDK tightening that flips the
-  emit from one to the other does not break the contract. A future
-  bead may collapse to a single code if upstream converges; until
-  then the union is the locked surface.
-
-Note the relationship to MCP tool-result errors: tool-execution
-failures (a `dispatch` that throws, a `run-variant` that asserts) do
-NOT use these JSON-RPC codes. They surface via the MCP tool-result
-shape (`isError: true` plus the `:reason` keyword vocabulary above)
-so the agent host can present the failure to the LLM without
-aborting the conversation. JSON-RPC codes are reserved for
-protocol-level failures the SDK detects before (or instead of)
-dispatching a tool.
-
-## Operator-opt-in CLI flag vocabulary
-
-Boot-time CLI flags that gate authority surfaces share a canonical
-name across both servers. Same operator semantic ⇒
-same flag spelling. Sourced from rf2-2x3ql: story-mcp originally
-shipped `--allow-sensitive-reads` (rf2-uaymx / rf2-g9fje); pair-mcp
-shipped `--allow-raw-state` for the same concept. Both servers now
-expose the gate as `--allow-sensitive-reads` — the operator-facing
-name avoids implementation leak ("raw-state" was specific to
-pair-mcp's data shape) and reads at the operator semantic level.
-
-| Flag                      | Meaning                                                                                                                                                        | Servers that ship it             | Rationale anchor |
-|---------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------|------------------|
-| `--no-eval`               | Opt OUT of the arbitrary-CLJS-form evaluator tool (`eval-cljs`). Default is eval-cljs ENABLED (rf2-a0z0h; inverts the prior rf2-cxx5s default-OFF posture — eval is the REPL primitive of a pair-debug session, and the gate did not add a protection separable from `--allow-writes` because eval can express the same writes). With this flag, `eval-cljs` calls return `{:ok? false :reason :rf.error/eval-cljs-disabled}` without touching nREPL. | re-frame2-pair-mcp               | rf2-a0z0h (current); rf2-zyoj2 / rf2-cxx5s (prior default-OFF posture) |
-| `--allow-sensitive-reads` | Honour caller-supplied `:include-sensitive true` (and pair-mcp's `:elision false`) on direct-read tools. Default OFF; sensitive slots return `:rf/redacted` and large slots elide regardless of the per-call arg when the flag is absent. | re-frame2-pair-mcp, story-mcp    | rf2-2x3ql (alignment), rf2-c2dtu (pair-mcp impl), rf2-uaymx / rf2-g9fje (story-mcp impl) |
-| `--allow-writes`          | Enable the server's state-mutating write surface. story-mcp: the registry write tools (`register-variant` / `unregister-variant`). pair-mcp: the state-mutation tools (`restore-epoch` / `replace-app-db`). Default OFF; gated calls return `isError: true` — story-mcp surfaces `structuredContent {:gated true :tool "<name>"}`, pair-mcp surfaces `{:ok? false :reason :rf.error/writes-disabled :tool "<name>"}` — when the flag is absent. Note: this gate protects the named-write audit trail; it does NOT defend against eval-driven writes (the eval surface can express the same writes when enabled), so it composes with `--no-eval` for a true read-only posture. | re-frame2-pair-mcp, story-mcp    | story-mcp IMPL-SPEC §7.3 (003-Write-Surface-Gating.md); pair-mcp rf2-ee38b.18 (writes.cljs) |
-
-### Rules
-
-- **Same semantic ⇒ same flag name across servers.** A new operator
-  opt-in that already has a counterpart on a sibling server reuses the
-  counterpart's CLI flag spelling.
-- **Operator-facing semantic, not implementation leak.** Flag names
-  describe what the operator is opting into (`--allow-sensitive-reads`)
-  rather than the impl detail (`--allow-raw-state`).
-- **Hard rename, no aliases.** Per re-frame2's pre-alpha posture, when a
-  flag is realigned both spellings are NOT accepted. The legacy
-  spelling stops being recognised at the parser; tests pin the
-  rejection so a regression can't reintroduce ambiguity. (See
-  `tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/raw_state_test.cljs`
-  `parse-launch-flags-old-name-rejected`.)
-- **Internal Clojure identifiers may keep legacy names.** The CLI flag
-  is the operator-facing surface; per-server impl-side identifiers
-  (predicate / namespace / keyword names) are separate refactor
-  surfaces that don't require cross-server lockstep. pair-mcp retains
-  `raw-state-allowed?` / `:allow-raw-state?` internally even though the
-  CLI flag aligned on `--allow-sensitive-reads`.
-
-### Wire-level conformance (rf2-ee38b.20)
-
-The flag table's default-OFF posture and the hard-rename rule are pinned
-end-to-end (over the real MCP wire) by the conformance harness:
-
-- **story-mcp `--allow-writes`** — `test/end-to-end-flag-gates.cjs`
-  boots story-mcp without / with / with-a-legacy spelling and asserts the
-  gate stays closed by default (`structuredContent.gated`), opens only on
-  the canonical spelling, and is NOT re-opened by an unrecognised flag
-  (the no-alias rule). Runs on CI in the `mcp-conformance-story` job.
-- **re-frame2-pair-mcp `--no-eval`** — `test/live-re-frame2-pair-subscribe.cjs`
-  (which boots a non-degraded server WITH `--no-eval`) asserts the
-  `:rf.error/eval-cljs-disabled` envelope crosses the wire. Post-rf2-a0z0h
-  the eval gate flipped to default-ON, so the disabled envelope is now
-  reachable only via the explicit opt-out. This is the one boot
-  configuration where pair-mcp's eval gate is observable: in degraded
-  mode (no nREPL) every tool short-circuits to `:nrepl-port-not-found`
-  before the gate runs, so the wire check needs a live runtime (the
-  hermetic orchestrator provides one on CI). The pair-mcp parser
-  rename-rejection (legacy `--allow-raw-state` ⇒ gate stays closed; legacy
-  `--allow-eval` ⇒ silent no-op, gate stays at default-ON) is pinned
-  unit-side by `raw_state_test.cljs`
-  (`parse-launch-flags-old-name-rejected` + `parse-launch-flags-legacy-allow-eval-is-noop`).
-
-## How to extend this table
-
-A new tool that **doesn't fit** an existing verb shape needs:
-
-1. A Lock entry in the relevant server's `spec/DESIGN-RATIONALE.md`
-   recording the verb pick (question / options / pick / why / date).
-2. A row in the table above with one-line semantics + an example.
-3. A row in the "What's NOT a locked verb" list IF the new verb shape
-   subsumes a previously-tempting prefix.
-4. A test fixture in `wire-vocab/` if the new tool emits any of the
-   cross-server wire markers.
-
-Don't extend silently — agents learn the verb table by example, and
-silent additions to the table erode the "one signal, one meaning"
-property the table exists to enforce.
-
-## See also
-
-- [`wire-vocab/README.md`](./wire-vocab/README.md) — cross-MCP
-  wire-vocabulary conformance (the `:rf.mcp/*` namespace).
-- [`tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md`](../re-frame2-pair-mcp/spec/003-Tool-Catalogue.md)
-  — re-frame2-pair-mcp's tool catalogue (verbs annotated in
-  `spec/Principles.md`).
-- [`tools/story-mcp/spec/002-Tool-Registry.md`](../story-mcp/spec/002-Tool-Registry.md)
-  — story-mcp's tool catalogue.
-- [`spec/Conventions.md`](../../spec/Conventions.md) §"Reserved
-  namespaces (framework-owned)" — the `:rf.*` keyword discipline this
-  doc inherits.
+Prefer an existing shape whenever its semantics fit.

--- a/tools/mcp-conformance/README.md
+++ b/tools/mcp-conformance/README.md
@@ -1,630 +1,172 @@
-# tools/mcp-conformance
+# MCP conformance
 
-End-to-end **MCP-client** conformance harness for the re-frame2 MCP
-servers — `re-frame2-pair-mcp` and `story-mcp`. Source: rf2-cum40.
+Client-side conformance for the `re-frame2-pair-mcp` and `story-mcp`
+servers. The Node harnesses use the official
+`@modelcontextprotocol/sdk` client, so the SDK validates the initialize,
+`tools/list`, and `tools/call` envelopes that a real MCP host receives.
 
-(Historical: a third server `xray-mcp` was envisaged; it was dropped
-per rf2-hvl1g — AI agent access to Xray state flows via
-`re-frame2-pair-mcp` against the framework-published Xray runtime API.)
+This artefact owns four cross-server concerns:
 
-This artefact has four surfaces:
+1. SDK-driven end-to-end workflows in `test/end-to-end-*.cjs`.
+2. Live re-frame2-pair workflows in `test/live-re-frame2-pair-*.cjs`,
+   with a hermetic shadow-cljs and Chromium orchestrator.
+3. JVM vocabulary gates in [`wire-vocab/`](wire-vocab/).
+4. The shared naming and token-budget conventions in
+   [`NAMING.md`](NAMING.md) and [`TOKEN-BUDGETS.md`](TOKEN-BUDGETS.md).
 
-1. **`test/end-to-end-*.cjs`** — Node-side end-to-end conformance.
-   Drives each server through the official `@modelcontextprotocol/sdk`
-   client to validate JSON-RPC handshake + tool catalogue + one
-   canonical workflow per server. Source: rf2-cum40.
-2. **`wire-vocab/`** — JVM-side cross-server wire-vocabulary
-   conformance. Pins the canonical Malli schema for every
-   reserved `:rf.mcp/*` / `:rf.size/large-elided` / `:rf.elision/at`
-   marker and asserts that fixtures + source text from every
-   emitting server conform. Source: rf2-j2z7o. See
-   [`wire-vocab/README.md`](wire-vocab/README.md).
-3. **[`NAMING.md`](NAMING.md)** — the cross-MCP tool-naming
-   convention: which verbs the catalogues pick from
-   (`get-` / `list-` / `read-` / `discover-` / `restore-` / `reset-`
-   / `register-` / `unregister-` / `run-` / `preview-` / `record-as-`
-   / `tail-` / `dispatch` / `eval-cljs` / `subscribe` / `unsubscribe`
-   / mega-op bare verbs), with one-line semantics and the per-server
-   audit table. Source: rf2-mzf1r.
-4. **[`TOKEN-BUDGETS.md`](TOKEN-BUDGETS.md)** — the cross-MCP
-   token-budget posture: the 5,000-token default cap, the
-   `max-tokens` per-call override, the `:rf.mcp/overflow` retry
-   marker, per-server mechanism inventory, chained-budget rules
-   when an agent attaches both servers in one session, and the
-   deliberate divergences between server implementations.
-   Source: rf2-ll0yq.
+Server unit tests still own tool implementation details. This artefact
+owns the client-observable protocol, shared vocabulary, and the seams
+between the servers.
 
-## What this is
+## Conformance layers
 
-Every existing test surface for these servers is **server-side**:
+### Degraded end to end
 
-- per-tool unit tests (under each server artefact's `test/`)
-- `stdio-roundtrip.js` — a hand-rolled JSON-RPC wire-format probe
-- `live-nrepl.js` — workflow tests against a running runtime
+`test/end-to-end-re-frame2-pair.cjs` starts the pair server without a
+live nREPL. It checks the SDK handshake, the canonical tool catalogue,
+descriptor metadata, every advertised tool's `callTool()` envelope, the
+pre-connection write refusals, and JSON-RPC error codes.
 
-None of these drive a server from the **client** side of MCP — they all
-either hand-roll JSON-RPC framing or skip the protocol layer entirely.
-That leaves a gap: when a real MCP-aware consumer (Claude Code,
-Continue, etc.) talks to one of these servers, it goes through the
-official `@modelcontextprotocol/sdk` `Client`, which validates **every**
-response against the spec's Zod schemas (`InitializeResultSchema`,
-`ListToolsResultSchema`, `CallToolResultSchema`, …). A server response
-that's "close enough" to the spec to fool a hand-rolled probe can still
-fail the SDK's parse step, and that bug ships unobserved until a real
-consumer attaches.
+`test/end-to-end-story.cjs` starts story-mcp with writes enabled. It
+checks the catalogue and descriptors, then drives the closed-world reads
+and the complete register, inspect, preview, run, record, and unregister
+workflow.
 
-This harness closes that gap. It spawns each server through the SDK's
-`StdioClientTransport`, completes the full `Client.connect()`
-handshake, walks one canonical workflow per server using `listTools()`
-and `callTool()`, and tears the transport down cleanly. Any spec drift
-on the server side surfaces as an SDK parse-error.
+`test/end-to-end-flag-gates.cjs` owns the cross-server launch-flag
+contract that can be exercised without a browser runtime. In particular,
+it checks story-mcp's default-closed `--allow-writes` surface, opt-in
+behaviour, and removed-flag rejection.
 
-### callTool() coverage ratchet (rf2-ke5n56)
+These tests prove MCP and result-envelope behaviour. They do not prove
+live runtime semantics that the pair server short-circuits when nREPL is
+absent.
 
-`listTools()` + `assertDescriptorShape` + `assertClassificationRatchet`
-pin every advertised tool's *descriptor metadata*. But descriptor
-metadata is not the wire envelope: a tool that is only LISTED (never
-driven through `callTool()`) can regress its result envelope,
-`outputSchema` / `structuredContent` shape, or argument handling and
-still ship green. A senior review found several advertised Story + Pair
-tools were exactly this — descriptor-only in conformance.
+### Live pair conformance
 
-`assertCallCoverageRatchet` (in [`test/_runner.cjs`](test/_runner.cjs))
-closes it. Each end-to-end harness records every tool it drives through
-`callTool()` and asserts at the end that EVERY advertised tool was
-either SDK-called or listed in a reviewed exclusion table with a
-non-empty rationale naming where its coverage lives (a live-only gate, a
-hermetic harness, a unit/fixture pin). A new advertised tool the
-workflow forgets to probe trips RED; a stale, blank, or contradictory
-exclusion row also trips RED, so the table cannot rot into a rubber
-stamp. The ratchet's own teeth are unit-tested in
-[`test/call-coverage-ratchet.test.cjs`](test/call-coverage-ratchet.test.cjs).
-Today both servers' exclusion tables are EMPTY — every advertised tool
-is SDK-called (Story reads + write-loop; Pair degraded `:nrepl-port-not-
-found` envelopes for the read/session/streaming-shaped surface +
-`:rf.error/writes-disabled` pre-connection refusals for the two gated
-writes).
+The live tests exercise behaviour that requires a connected browser
+runtime: overflow, progress notifications, sensitive-value projection,
+the universal `isError`/`:ok?` relationship, recordable coeffects, and
+event metadata.
 
-### Coverage boundary — keyword-intern bounds (rf2-fphr3)
+[`scripts/live-test-inventory.cjs`](scripts/live-test-inventory.cjs) is
+the single owner of the live-test roster. Both `npm test` and the
+hermetic runner derive their rows from it. The disk-completeness test
+fails if a `live-re-frame2-pair-*.cjs` file is not registered.
 
-The charter's threat model asks whether the corpus has teeth on the
-**keyword-intern bounds** — the DoS surface where a server keywordizes
-an unbounded stream of agent-supplied strings (event ids, sub ids,
-frame ids, mode/slice args) into the JVM's never-shrinking global
-keyword table. **This is NOT a cross-server WIRE contract** (the
-conformance gate's natural remit — egress redaction, overflow markers,
-flag gating, descriptor shape); it is a per-server **input-sanitisation**
-property, and it is **covered, by construction, at the `mcp-base` unit
-layer** — the shared coercion ns every server routes agent-supplied ids
-through (the conformance gate covers the wire; intern bounding is
-covered by `mcp-base`'s `args` tests):
+Each live test skips cleanly when `SHADOW_CLJS_NREPL_PORT` is absent.
+[`scripts/run-re-frame2-pair-live-hermetic-suite.cjs`](scripts/run-re-frame2-pair-live-hermetic-suite.cjs)
+boots the fixture, supplies the port, launches Chromium, and runs the
+entire roster. It grades a test only after the child closes and requires
+both a zero exit code and that test's success sentinel. A skipped inner
+test therefore cannot pass the hermetic suite.
 
-- **`re-frame.mcp-base.args/safe-keyword`** — the bounded-allowlist
-  resolver. Membership-checks BEFORE constructing the keyword (via JVM
-  `find-keyword`, which never interns), so a caller-supplied string
-  outside the finite set never mints a fresh keyword. Pinned by
-  `tools/mcp-base/test/re_frame/mcp_base/args_test.clj`
-  (`safe-keyword-disallowed-string-returns-nil-and-does-not-intern`
-  for the bare-name arm, plus
-  `safe-keyword-disallowed-NAMESPACED-string-returns-nil-and-does-not-intern`
-  — rf2-ynjts.17 — for the namespaced arm the registry-backed frame-id
-  / `:rf.assert/*` coercions actually hit). Both assert via a
-  `find-keyword` probe that the rejected novel name is absent from the
-  table both before and after the call: a literal no-intern-on-rejection
-  proof.
-- **`re-frame.mcp-base.args/parse-mode`** — routes every finite-set arm
-  through `safe-keyword` so the membership check precedes any intern
-  (rf2-ih7g4 flipped the historical intern-then-check order). Pinned by
-  `parse-mode-unknown-string-does-not-intern`.
-- **`re-frame.mcp-base.args/fresh-keyword`** — the deliberately-interning
-  primitive, reserved (per its docstring policy) for **bounded-cost**
-  sites only: operator-gated write paths (story-mcp's `--allow-writes`
-  + the `:story.<path>/<name>` grammar bound), runtime-registry-bounded
-  read paths (re-frame2-pair-mcp's frame-id coercion, where the live
-  registry size caps allocation), and grammar-bounded registrars.
-  Pinned by `fresh-keyword-interns-on-fresh-input` (rf2-xxtrz).
+The runner owns cleanup for Chromium and shadow-cljs. Cleanup is
+idempotent, bounded, and awaited on normal completion; watchdog and
+signal paths allow a short cleanup window before forcing exit.
 
-On the wire-validated paths the conformance corpus DOES drive
-(`dispatch` event ids, `read-sub` sub ids), the server additionally
-VALIDATES the id against the live registrar and refuses unknowns with
-`:reason :unknown-id` + `:nearest` matches (rf2-3bu3d.3) — bounding the
-accepted set to the registered universe before any intern. So the
-intern surface is doubly bounded: the `mcp-base` allowlist/registry gate
-upstream, and the registrar validation at the tool body.
+### Wire vocabulary
 
-This note records the seam so a reviewer does not read the conformance
-gate's silence on intern bounds as "uncovered". If a future open-world
-intern path emerges that is bounded by NEITHER a `mcp-base` allowlist nor
-a runtime registry (e.g. an arbitrary-topic-string surface that
-keywordizes without a finite gate), that is a server-side bug to file
-against `mcp-base` / the owning server — not a hole in this cross-server
-wire gate.
+[`wire-vocab/README.md`](wire-vocab/README.md) describes the JVM suite.
+It pins canonical schemas, representative fixtures, live builders where
+they are available on the JVM, source literals, and rejected near-miss
+spellings. It also owns the executable tool-verb linter against each
+server's canonical `tool-names.json` fixture.
 
-### Coverage boundary — EP-0017 cofx + EP-0018 event metadata (rf2-jyxmtq / rf2-z0owya)
+## Shared ratchets
 
-The EP-0017 recordable-coeffects (`cofx`) surface and the EP-0018 unified
-event-registration metadata are exercised across THREE layers; a future
-MCP change to either should land in the layer matching what it touches:
+The end-to-end workflows use helpers from `test/_runner.cjs`:
 
-- **SDK conformance harness (this artefact)** — the cross-MCP WIRE
-  contract. EP-0017: a `cofx` arg is accepted into the `dispatch` request
-  envelope (degraded `end-to-end-re-frame2-pair.cjs`); the supplied
-  `:rf/time-ms` reaches the resulting state, the malformed-`cofx`
-  structured refusals, and the `cofx`-kind `list-handlers`/`handler-meta`
-  visibility + authored `:rf.cofx/requires` (live
-  `live-re-frame2-pair-cofx.cjs`). EP-0018: the live event-metadata wire
-  reflects the unified shape and carries none of the retired markers (live
-  `live-re-frame2-pair-event-meta.cjs`). The degraded handler short-circuits
-  every live-runtime tool to `:nrepl-port-not-found` BEFORE the tool body —
-  so the cofx shape-check and the live event metadata are reachable ONLY
-  through the hermetic live gates, NOT the degraded harness (which proves
-  descriptor / arg-shape / CallToolResult wiring). The two live gates use
-  the fixture event `:counter/stamp` (EP-0017 `:rf.cofx/requires`) and
-  `:counter/inc` (EP-0018 plain `reg-event`) at
-  `skills/re-frame2-pair/tests/fixture/src/counter/core.cljs`.
-- **pair-MCP unit tests** — the server-side `cofx` parsing / threading
-  under `:rf.cofx`, owner-qualified facts, omitted-key behaviour, and the
-  malformed-input reasons in isolation
-  (`tools/re-frame2-pair-mcp/test/.../dispatch_test.cljs`); event
-  `handler-meta` projection shape
-  (`.../handler_meta_test.cljs`). These pin the projection / parse logic
-  without a live runtime or the SDK boundary.
-- **core tests** — the EP-0017 / EP-0018 semantics themselves: the router
-  preserving a supplied `:rf.cofx` verbatim, `:rf.cofx/requires` parse /
-  satisfaction, the one `:rf/event-handler` wrapper, the removed
-  `:event/kind`, and the retired-name hard errors
-  (`implementation/core/.../events.cljc` + its tests). These own the
-  behaviour the wire gates merely OBSERVE crossing the MCP boundary.
+- `assertDescriptorShape` checks the common descriptor envelope.
+- `assertClassificationRatchet` compares every live descriptor with the
+  server classification fixture. The fixture key set must exactly match
+  the advertised catalogue.
+- `trackCallCoverage` and `assertCallCoverageRatchet` require every
+  advertised tool to be SDK-called or named in a reviewed exclusion map
+  with a non-empty alternative-coverage rationale. Stale, contradictory,
+  and blank exclusions fail.
+- `assertIsErrorMatchesOk` requires structured `:ok? false` results to
+  set `isError`, and structured `:ok? true` results not to set it.
+- `structured` expands `:rf.mcp/dedup-table` before semantic assertions,
+  matching the payload a decoding client consumes.
 
-Keep this surface free of the legacy `world-inputs` / `:rf.world/inputs`
-vocabulary as a LIVE assertion — EP-0017 replaced it with `cofx` /
-`:rf.cofx` / `:rf/time-ms`; any historical mention must name the
-replacement.
+The canonical tool-name fixtures remain server-owned:
 
-## Files
+- `tools/re-frame2-pair-mcp/test/fixtures/tool-names.json`
+- `tools/story-mcp/test/fixtures/tool-names.json`
 
-- `package.json` — depends on `@modelcontextprotocol/sdk` only
-- `test/end-to-end-re-frame2-pair.cjs` — re-frame2-pair-mcp conformance (degraded mode,
-  no nREPL needed — same shape as re-frame2-pair-mcp's stdio-roundtrip)
-- `test/live-re-frame2-pair-overflow.cjs` — re-frame2-pair-mcp **live**-runtime variant
-  (rf2-ynaoc) that exercises the wire-cap `:rf.mcp/overflow` marker
-  under a real over-budget eval. **Gated on `$SHADOW_CLJS_NREPL_PORT`**:
-  unset = clean SKIP (degraded mode can't trip the cap naturally),
-  set = full live-runtime cap-trigger conformance against the
-  canonical `ReFrame2PairOverflowBody` schema pinned by `wire-vocab/`.
-- `test/live-re-frame2-pair-subscribe.cjs` — re-frame2-pair-mcp **live**-runtime variant
-  (rf2-zb5z6) that exercises the `notifications/progress` streaming
-  wire surface. Subscribes to `:trace`, dispatches a known event,
-  collects every progress frame the server emits, and validates each
-  against the canonical `ReFrame2PairProgressNotificationParams` schema
-  pinned by `wire-vocab/`. Gated on `$SHADOW_CLJS_NREPL_PORT` (same
-  posture as the overflow variant).
-- `test/live-re-frame2-pair-redaction.cjs` — re-frame2-pair-mcp **live**-runtime variant
-  (rf2-q4o83) that exercises egress redaction of a classified
-  `:sensitive` app-db slot through the pull-mode epoch tools
-  (`trace-window` + `watch-epochs`). Classifies the sensitive slot app-side
-  through the PUBLIC EP-0025 route (an event returns the commit-plane
-  `:sensitive [[…]]` effect alongside `:db` — rf2-2h7153; NOT a hand-seeded
-  elision registry and NOT schema-attached / importer-driven classification,
-  all of which EP-0015/EP-0025 removed), dispatches a recognisable
-  sentinel into it, then asserts the sentinel is ABSENT in the egress
-  payload with the `--allow-sensitive-reads` gate OFF (default) — the whole
-  sensitive epoch is DROPPED (`:dropped-sensitive` >= 1) — and SHIPS with
-  the gate ON + `:include-sensitive true`. A third arm classifies the path
-  through the commit-plane effect AFTER the epoch is recorded, so the
-  inner `projected-record` value-redaction is the sole protection (sentinel
-  ABSENT + `:rf/redacted` PRESENT + `:dropped-sensitive 0`). Pins BOTH gate
-  directions so the gate can't silently invert, and proves the commit-plane
-  classification effect reaches the epoch rollup AND the projected-record
-  egress. This is the regression net for rf2-6wvh5 (the leak the gate let
-  ship green) and rf2-2h7153 (the classification route bypass). Gated on
-  `$SHADOW_CLJS_NREPL_PORT` (same posture as the other live variants). Has
-  a standalone `npm run test:re-frame2-pair-live-redaction` script
-  (rf2-ybiz0) for local runnability + parity with the overflow / subscribe
-  variants — without a live port it SKIPs, with one (e.g. an
-  externally-attached shadow-cljs) it runs the full gate.
-- `test/live-re-frame2-pair-cofx.cjs` — re-frame2-pair-mcp **live**-runtime variant
-  (rf2-jyxmtq) pinning the EP-0017 recordable-coeffects (`cofx`) paths on
-  the SDK boundary. Dispatches the fixture's `[:counter/stamp]` (a
-  `reg-event` declaring `:rf.cofx/requires [:rf/time-ms]` that folds the
-  recorded wall-clock fact into app-db under `:stamped-at`) with a scripted
-  `cofx "{:rf/time-ms <N>}"` — TWICE with two distinct pinned-past times —
-  and asserts each lands verbatim in `:stamped-at` (reproducible-dispatch
-  determinism; a server stamping a live clock could never match two pinned
-  pasts). Then proves the malformed-`cofx` refusals the degraded handler
-  hides (non-map / unreadable / non-integer `:rf/time-ms` ⇒
-  `:invalid-cofx` / `:invalid-cofx-time-ms`, no state mutation), and the
-  EP-0017 tooling visibility: `list-handlers {kind "cofx"}` discovers
-  `:rf/time-ms`, `handler-meta {kind "cofx" id ":rf/time-ms"}` surfaces the
-  recordable grade (`:recordable? true :provided? true`), and the event
-  fixture's `handler-meta` exposes the authored `:rf.cofx/requires`. Gated
-  on `$SHADOW_CLJS_NREPL_PORT` (same posture as the other live variants).
-- `test/live-re-frame2-pair-event-meta.cjs` — re-frame2-pair-mcp **live**-runtime
-  variant (rf2-z0owya) pinning the EP-0018 unified event-registration
-  metadata on the SDK boundary. `list-handlers {kind "event"}` discovers
-  the fixture `rf/reg-event` id `:counter/inc`; `handler-meta {kind "event"
-  id ":counter/inc"}` asserts `:ok? true` / `:kind :event` / `:id` AND
-  rejects EP-0018 drift on the same wire response — NO `:event/kind`
-  sub-tag, NO `:rf/db-handler` / `:rf/fx-handler` / `:rf/ctx-handler`
-  retired wrapper id, and the unified `:rf/event-handler` wrapper visible in
-  the effective interceptor chain. Closes the gap the degraded-only
-  `handler-meta` / `list-handlers` coverage left (degraded short-circuits to
-  the same `:nrepl-port-not-found` envelope for every live-runtime tool, so
-  the live event-metadata wire was never inspected). Gated on
-  `$SHADOW_CLJS_NREPL_PORT`.
-- `scripts/run-re-frame2-pair-live-hermetic-suite.cjs` — hermetic
-  live-suite orchestrator (rf2-uw6d6) that boots shadow-cljs against the re-frame2-pair
-  fixture (`skills/re-frame2-pair/tests/fixture/`), launches headless
-  Chromium so the runtime preload lands, then runs every live inner test
-  (`live-re-frame2-pair-overflow.cjs`, `live-re-frame2-pair-subscribe.cjs`,
-  `live-re-frame2-pair-redaction.cjs`, `live-re-frame2-pair-iserror.cjs`,
-  `live-re-frame2-pair-cofx.cjs`, `live-re-frame2-pair-event-meta.cjs`)
-  against the spawned
-  `SHADOW_CLJS_NREPL_PORT`. Closes the CI-coverage gap the SKIP path
-  leaves on each. **Observable-SKIP guard (rf2-ybiz0):** after each inner
-  test exits 0 the orchestrator asserts it printed its `... CONFORMANCE
-  GREEN` sentinel AND did NOT print a `SKIP ` banner — so a setup-path
-  regression that left a load-bearing live gate SKIPping (exit 0, never
-  exercised) turns the hermetic job RED (exit 2, orchestration failure)
-  instead of riding green on the other inner tests.
-- `test/end-to-end-story.cjs` — story-mcp conformance (full write-loop
-  with `--allow-writes` enabled) + closed-world read-path success
-  envelopes
-- `lib/dedup-envelope.cjs` — Node-side mirror of `de-dupe.core/expand`
-  for the `:rf.mcp/dedup-table` wire envelope (rf2-90eft). story-mcp +
-  pair-mcp wrap selected tools' `:structuredContent` in
-  `{:rf.mcp/dedup-table <cache>}`; a real MCP client decodes by
-  calling `de-dupe.core/expand` before user code sees the payload.
-  `decodeDedupEnvelope` is the Node-side mirror: idempotent on
-  unwrapped payloads, so harnesses can route every
-  `:structuredContent` slot read through it and talk to the SEMANTIC
-  contract (e.g. `:lifecycle` reachable) rather than the wire shape.
-- `test/end-to-end-flag-gates.cjs` — cross-MCP operator-opt-in CLI
-  flag-vocabulary conformance (rf2-ee38b.20). Boots story-mcp without /
-  with / with-a-legacy `--allow-writes` spelling and asserts the
-  default-OFF write gate (`structuredContent.gated` + `.tool`) + the
-  hard-rename-rejection rule (an unrecognised flag must NOT open the
-  gate) over the MCP wire — the NAMING.md §"Operator-opt-in CLI flag
-  vocabulary" contract. rf2-ke5n56 extended the default-OFF coverage from
-  `register-variant`-only to ALL the gated write tools: `register-variant`
-  + `unregister-variant` (gate-first refusal, `:tool` slot pinned) +
-  `record-as-variant` write-back (both gate states — see the VERIFIED
-  gate-ordering note below), plus the intentionally UNGATED
-  snippet-only `record-as-variant` path. Needs `clojure` (the JVM
-  story-mcp server). The
-  pair-mcp eval-cljs gate flipped to default-ON in rf2-a0z0h; its
-  disabled-envelope wire counterpart now rides the live
-  `live-re-frame2-pair-subscribe.cjs` path (the one boot config where
-  the gate is observable — non-degraded, WITH `--no-eval`).
+Do not copy those inventories into this artefact. The workflows load the
+fixtures directly, and the coverage ratchet compares calls against the
+loaded names.
 
-### VERIFIED: `record-as-variant` write-back gate ORDERING asymmetry (rf2-ke5n56, flagged)
+## Running the gates
 
-While wiring the rf2-ke5n56 default-OFF gated-refusal coverage for
-`record-as-variant` write-back, the harness author verified a server-side
-gate-ordering asymmetry worth flagging to the story-mcp owner:
-
-- `register-variant` / `unregister-variant`
-  (`tools/story-mcp/.../tools/write.cljc`) check `assert-writes-allowed`
-  as their FIRST expression — BEFORE any variant resolution — so a
-  gate-OFF boot refuses with `structuredContent.gated === true`
-  regardless of whether the target variant exists.
-- `record-as-variant`
-  (`tools/story-mcp/.../tools/recorder.cljc` `tool-record-as-variant`)
-  wraps the whole body in `(targs/with-variant arguments (fn [vk body] …))`,
-  which resolves `:variant-id` against the live registered-variant set
-  FIRST; the `(when write-back? (write/assert-writes-allowed …))` gate is
-  NESTED inside that callback.
-
-The canonical-vocabulary boot registers NO variants, and a gate-OFF boot
-cannot register one through the MCP surface, so a gate-OFF
-`record-as-variant` write-back:true call short-circuits to `Variant not
-found` BEFORE the gate is consulted — the `gated:true` envelope is
-**unreachable default-off**. The literal default-OFF `gated:true` probe the
-acceptance criterion describes is therefore impossible via the MCP surface
-without either (a) reordering the gate ahead of variant resolution
-(consistent with the two siblings), or (b) a registered fixture under a
-closed gate (no single boot provides both).
-
-`end-to-end-flag-gates.cjs` `assertRecordAsVariantWriteBackGate` pins what
-IS reachable on both gate states — gate-OFF write-back:true ⇒ `Variant not
-found` (regression-locking the current ordering), gate-ON write-back:true
-⇒ success + `:written-back? true` (the positive control) — and its
-gate-OFF assertion is written so that if the server is later reordered
-gate-first, it flips RED with a message telling the maintainer to update
-it to expect `gated:true` + `tool:"record-as-variant"`. The
-intentionally-ungated snippet-only path (`record-as-variant` without
-`:write-back`) is pinned by `assertSnippetOnlyRecordIsUngated`. Whether to
-reorder the gate is a server-owner decision (filed as a follow-up); the
-conformance harness does NOT modify server source.
-
-## How to run
-
-From this directory:
+Install this artefact's Node dependencies first:
 
 ```bash
-# REQUIRED in a fresh worktree — these gates drive the servers through
-# the official @modelcontextprotocol/sdk `Client`, which is NOT vendored.
-# Without this, `npm run test:story` / `test:re-frame2-pair` fail at
-# `require('@modelcontextprotocol/sdk/client/index.js')`. (Worktrees that
-# junction node_modules from the mayor checkout already have it; a clean
-# `git worktree add` does not.)
 npm install
-
-# re-frame2-pair-mcp: requires the server bundle on disk at
-# ../re-frame2-pair-mcp/out/server.js. Build it first with:
-#   cd ../re-frame2-pair-mcp && npx shadow-cljs compile server
-npm run test:re-frame2-pair
-
-# story-mcp: requires `clojure` on PATH (override via
-# $STORY_MCP_CMD if non-default). No pre-build step — the server is
-# launched via `clojure -M -m re-frame.story-mcp.server`.
-npm run test:story
-
-# Both (re-frame2-pair must be pre-built):
-npm test
 ```
 
-## What each test covers
+The focused, server-free Node gate is:
 
-### `end-to-end-re-frame2-pair.cjs`
+```bash
+npm run test:unit
+```
 
-1. Connect — full SDK handshake against the freshly spawned bundle
-2. `tools/list` — confirm the advertised tools match the pinned
-   catalogue (sourced from re-frame2-pair-mcp's `tool-names.json`
-   fixture — the single source of truth)
-3. Spot-check every descriptor carries an `inputSchema`
-4. Walk degraded-mode `callTool()` for EVERY advertised tool (rf2-ke5n56)
-   — the read / session / streaming-shaped surface returns the shared
-   `:nrepl-port-not-found` envelope; the two gated writes
-   (`restore-epoch` / `replace-app-db`) return the
-   `:rf.error/writes-disabled` PRE-connection refusal (default-OFF write
-   gate). Each call routes through the SDK's `CallToolResultSchema` parse
-   step. The `callTool` coverage ratchet then asserts no advertised tool
-   was left descriptor-only.
-5. Clean `Client.close()`
+The pair end-to-end test needs the server bundle:
 
-Runs without an nREPL on `$SHADOW_CLJS_NREPL_PORT`, so it's
-self-contained and reproducible.
+```bash
+cd ../re-frame2-pair-mcp
+npx shadow-cljs compile server
+cd ../mcp-conformance
+npm run test:re-frame2-pair
+```
 
-### `live-re-frame2-pair-overflow.cjs`  (rf2-ynaoc)
+Story gates need `clojure` on `PATH`:
 
-Live-runtime variant — fills the gap left by the degraded-mode
-sibling above. Gated on `$SHADOW_CLJS_NREPL_PORT`; unset = clean
-SKIP. When attached:
+```bash
+npm run test:story
+npm run test:flag-gates
+```
 
-1. Connect — full SDK handshake.
-2. `tools/call eval-cljs` with `(apply str (repeat 25000 "x"))` —
-   25,000-char return ⇒ ~6,250 token-estimate ⇒ over the 5,000-token
-   default cap.
-3. SDK's `CallToolResultSchema` accepts the envelope; `isError` is
-   `false` (overflow is a signal, not an error).
-4. Response text carries `:rf.mcp/overflow`.
-5. Marker body validates against canonical `ReFrame2PairOverflowBody`
-   schema pinned by `wire-vocab/`: `:limit :reached`, integer `:cap-tokens`
-   and `:token-count` with `:token-count > :cap-tokens`, string
-   `:tool` and `:hint`.
-6. Pin per-tool facts: `:cap-tokens = 5000` (default), `:tool =
-   "eval-cljs"`, `:hint` contains "Slice" (per-tool entry from
-   re-frame2-pair-mcp's `overflow-hints` table).
-7. Recursion-safety: the marker itself fits under the cap.
-8. Clean `Client.close()`.
+The hermetic live suite also needs the pair bundle and Playwright. It
+installs the fixture's own Node dependencies when its `node_modules`
+directory is absent:
 
-Catches: cap-trigger threshold drift; marker shape regressions that
-only fire on real payloads; client-side parse failures on cap-marker
-shapes the SDK's strict `CallToolResultSchema` doesn't yet
-recognise; keyword renames (`:cap-tokens` → `:cap_tokens`,
-`:rf.mcp/overflow` → `:rf.mcp/overflows`) at the live emission site.
+```bash
+npm run test:re-frame2-pair-live-hermetic-suite
+```
 
-### `scripts/run-re-frame2-pair-live-hermetic-suite.cjs`  (rf2-uw6d6)
+Run the JVM vocabulary suite separately:
 
-Hermetic live-SUITE orchestrator that makes the live path above run on CI
-without any external nREPL. It runs the WHOLE `INNER_TESTS` inventory
-(overflow plus subscribe/progress, redaction, isError, cofx, and
-event-metadata), not just the overflow gate.
+```bash
+cd wire-vocab
+clojure -M:test
+```
 
-1. Wipes any stale `target/shadow-cljs/nrepl.port` under the re-frame2-pair
-   fixture (`skills/re-frame2-pair/tests/fixture/`).
-2. `npm install` in the fixture (idempotent — skipped if
-   `node_modules/` already exists).
-3. Spawns `shadow-cljs watch app` against the fixture (a minimal
-   counter with `re-frame2-pair.runtime` already wired as a
-   `:devtools :preloads` entry).
-4. Polls for the nREPL port file, then the nREPL TCP listener, then
-   the dev-http on `:8030`.
-5. Launches headless Chromium (Playwright, resolved from
-   `tools/mcp-conformance` or `implementation/`), navigates to the
-   fixture URL, waits for `window.__re_frame2_pair_runtime` to land
-   so re-frame2-pair-mcp's `ensure-runtime!` will pass.
-6. Runs `test/live-re-frame2-pair-overflow.cjs` with
-   `SHADOW_CLJS_NREPL_PORT` set to the spawned port.
-7. Tears down browser + shadow-cljs in `finally` (and on SIGINT /
-   SIGTERM / SIGHUP). The teardown is an idempotent **async** operation
-   (rf2-7ckmwx): it `await`s Playwright's promise-returning
-   `browser.close()` (bounded so a wedged close can't hang), then
-   SIGTERMs shadow-cljs and `await`s its `exit` (or a short grace),
-   escalating to SIGKILL and awaiting the final exit. The normal
-   `finally` path awaits it before reporting success / exiting; the
-   signal and watchdog paths race it against a hard cap so an
-   interrupted run still exits promptly but does not fire-and-forget
-   exit before the children have had a real chance to be reaped. The
-   `makeCleanup` factory is exported and unit-tested by
-   `test/runner-cleanup.test.cjs`.
+`npm test` runs the authoritative Node inventory sequentially and fails
+fast. Live rows report `SKIP` unless a port is supplied; the hermetic
+command above is the gate that requires them to execute.
 
-Exit codes: `0` = green; `1` = conformance failure (forwarded from
-the inner test); `2` = orchestration failure (shadow-cljs didn't
-boot, runtime didn't preload, watchdog elapsed).
+## Inventory ownership
 
-Watchdog: 360s for the whole hermetic run. The re-frame2-pair-mcp server
-bundle must already be compiled — the script bails with a structured
-error if `tools/re-frame2-pair-mcp/out/server.js` is missing.
+- `scripts/test-all.cjs` owns the overall Node inventory.
+- `scripts/test-unit.cjs` derives all `node --test` rows from that
+  inventory and runs them in one process.
+- `scripts/live-test-inventory.cjs` owns the live pair inventory.
+- Each server's `tool-names.json` owns its advertised tool names.
+- `test/fixtures/*-classifications.json` owns the expected descriptor
+  classification partition.
+- `wire-vocab/test/re_frame/mcp_conformance/wire_vocab/schemas.clj`
+  owns shared wrapper-marker schemas.
 
-#### Fixture dependency install — supported pattern (rf2-o0tpo)
+When adding a test, update its owning inventory rather than another
+runner. When adding a tool, update the server's canonical name fixture;
+the conformance and vocabulary gates consume it directly.
 
-The hermetic orchestrator's step 2 (`npm install` inside the re-frame2-pair
-fixture at `skills/re-frame2-pair/tests/fixture/`) is the **supported
-pattern** for this artefact, confirmed by rf2-o0tpo (pragmatic stance,
-2026-05-14). Rationale:
+## Contract ownership
 
-- The fixture is a self-contained Node project with its own
-  `package.json`; nested `npm install` is how Node projects compose.
-- The dev runs the orchestrator deliberately; this isn't a hidden side
-  effect of a generic test invocation.
-- The install is idempotent (skips when `node_modules/` already exists)
-  so the second run is hot.
-- Moving the install to an explicit bootstrap script would add a
-  separate setup step every dev / CI runner has to remember and gate.
-  The current shape — invoke the orchestrator, it ensures its own
-  dependencies — is simpler and the failure mode is loud (the install
-  fails or shadow-cljs fails to boot; nothing silent).
-
-If you adopt this orchestrator's pattern for a new conformance fixture,
-follow the same shape: nest the fixture's `package.json`, gate the
-install behind an existence check on `node_modules/`, and document the
-fixture's location and entry script in the orchestrator's preamble.
-
-### `end-to-end-story.cjs`
-
-The single SDK-driven agent-loop harness for story-mcp's write surface.
-It absorbed the four smokes that `tools/story-mcp/test/live-server.js`
-used to add on top of a hand-rolled copy of this same loop (rf2-2mx0q),
-so CI runs one JVM boot here instead of two near-identical ones.
-
-1. Connect — `clojure -M -m re-frame.story-mcp.server --allow-writes`
-2. `tools/list` — confirm the advertised catalogue per story-mcp's
-   `tool-names.json` fixture (count-free per NAMING.md §"Single source
-   of truth for tool counts")
-3. `assertDescriptorShape` — every descriptor: `inputSchema`
-   (type=object + `max-tokens`) + `outputSchema` + an `annotations`
-   classification hint
-4. Closed-world reads (`get-story-instructions` / `list-substrates` /
-   `list-modes` / `list-tags` / `list-stories` / `list-assertions` /
-   `list-decorators`) → success envelopes; `get-story` /
-   `get-docs-markdown` default-off refusal probes (rf2-ke5n56) →
-   `Story not found`
-5. `register-variant` → `get-variant` (body `:doc` round-trips through
-   EDN text) → `variant->edn` (the rf2-vyacl outputSchema-defect twin) +
-   `read-a11y-violations` (JVM-standalone empty read) → `preview-variant`
-   (`:lifecycle` surfaces) → `run-variant` (vacuous pass) →
-   `read-failures` (total=0) → `snapshot-identity` (stable content-hash
-   twice) → `record-as-variant` (recorder bridge wired, rf2-luhdu) →
-   `unregister-variant` + not-found verify
-6. `assertJsonRpcErrorCodes` — MethodNotFound + (InvalidParams|InternalError)
-7. `callTool` coverage ratchet (rf2-ke5n56) — every advertised tool
-   SDK-called or reviewed-excluded
-8. Clean `Client.close()`
-
-Watchdog: 90s (cold JVM boot is ~10–30s on a CI runner).
-
-## CI
-
-`.github/workflows/test.yml` runs each of the conformance scripts in
-its own `mcp-conformance-{re-frame2-pair,story}` job, parallel to the
-existing `node-test-tools-{re-frame2-pair,story}-mcp` jobs. Same
-Node 24 + JDK 21 setup as those jobs.
-
-The `mcp-conformance-re-frame2-pair` job runs four steps in sequence:
-
-0. **`test:unit`** (rf2-md05gp) — the FULL pure-Node unit-regression
-   cluster: every `node --test` row from the authoritative inventory in
-   `scripts/test-all.cjs` (exec-safety, runner-watchdog, runner-cleanup,
-   hermetic-setup-timeout, port-file-escape, dedup-envelope,
-   call-coverage-ratchet, classification-ratchet). These are the harness's
-   own regression nets — watchdog teardown of hung clients, awaited
-   hermetic cleanup, bounded setup commands, symlink-safe port-file reads,
-   dedup-envelope decoding, and the call/classification ratchets. It runs
-   FIRST so a cheap unit regression fails before the heavier server boots,
-   and is the natural home for the unit set (Node-only, no `clojure`).
-   `test:unit` DERIVES its set from `test-all.cjs` rather than re-listing,
-   so a new `node --test` row is picked up automatically. Pre-rf2-md05gp
-   only `exec-safety` ran in CI; the other seven gates were in the local
-   inventory but dead in CI, so a regression they guard could ship green.
-1. **`test:re-frame2-pair`** — degraded-mode conformance against the SDK's
-   strict schemas.
-2. **`test:re-frame2-pair-live-overflow`** — the gated live variant. Runs
-   without `$SHADOW_CLJS_NREPL_PORT` so the SKIP path is exercised
-   on every CI run (a regression that broke SKIP would surface here).
-3. **`test:re-frame2-pair-live-hermetic-suite`** (rf2-uw6d6) — boots
-   shadow-cljs against the re-frame2-pair fixture and runs the WHOLE live
-   inner-test suite (overflow is one member). The overflow path runs a
-   real over-budget eval; this is the path that catches cap-trigger
-   threshold drift, marker shape regressions on real payloads, and SDK
-   strict-schema rejection of cap-marker shapes under CI's clean
-   ephemeral runtime — not just on Mike's machine. The
-   hermetic suite also runs `live-re-frame2-pair-subscribe.cjs`, which
-   (booting non-degraded WITH `--no-eval`) pins pair-mcp's eval-cljs
-   opt-out wire envelope (`:rf.error/eval-cljs-disabled`) post-rf2-a0z0h;
-   `live-re-frame2-pair-iserror.cjs` (the read-family genuine-error
-   isError contract); `live-re-frame2-pair-cofx.cjs` (rf2-jyxmtq — EP-0017
-   reproducible-dispatch + cofx tooling visibility); and
-   `live-re-frame2-pair-event-meta.cjs` (rf2-z0owya — EP-0018 unified
-   event-metadata wire shape + retired-marker rejection). Each inner test
-   carries a success sentinel the orchestrator asserts (rf2-ybiz0), so a
-   silent in-hermetic SKIP turns the job RED.
-
-The `mcp-conformance-story` job runs two steps: **`test:story`** (the
-write-loop + read-path conformance + the rf2-ke5n56 callTool coverage
-ratchet) and **`test:flag-gates`** (the cross-MCP CLI flag-vocabulary
-conformance — story-mcp `--allow-writes` default-OFF for all three gated
-write tools + the ungated snippet-only path + opt-in + hard-rename
-rejection). Both need `clojure`. The `callTool` coverage ratchet's own
-unit tests (`test:call-coverage-ratchet`) run in PR CI as part of the
-`test:unit` cluster in the `mcp-conformance-re-frame2-pair` job (above) —
-the Node unit set is server-agnostic, so it runs once there rather than
-being duplicated in this `clojure`-only job. Locally the full inventory
-(unit + e2e + live + story) runs via `npm test` (`scripts/test-all.cjs`).
-
-## Why a separate artefact?
-
-The harness only depends on `@modelcontextprotocol/sdk` and Node's
-stdlib. Putting it under each server's `test/` would duplicate the
-dependency and tie the client-side fixture to each server's
-build/dependency graph. A standalone artefact keeps the conformance
-contract in one place and makes "add an MCP server, add a conformance
-script" a one-file change.
-
-The artefact is bundle-isolated from production builds by construction
-(it's pure Node-side test fixtures; no CLJS sources).
-
-## Spec posture (rf2-uzouv)
-
-`tools/mcp-conformance/` deliberately has **no local `spec/` folder**.
-This is a documented exemption from the per-tool spec convention
-(`tools/README.md` §Per-tool `spec/` folder convention), not a gap.
-
-Rationale: the per-tool `spec/` convention exists so each artefact's
-contract — what it does, why, the locks behind major calls — survives
-across sessions in committed form. For `mcp-conformance` that contract
-already lives, by construction, in three other places:
-
-1. **The test corpus itself.** Each `test/end-to-end-<server>.cjs`
-   pins exactly one server's wire surface (advertised tool catalogue,
-   tool descriptor presence, the canonical workflow), and the
-   `wire-vocab/` JVM test corpus pins the canonical Malli schema for
-   every reserved `:rf.mcp/*` / `:rf.size/large-elided` /
-   `:rf.elision/at` marker. The tests are the normative contract a
-   server must satisfy; they're machine-checked.
-
-2. **The three cross-MCP docs at this artefact's root** —
-   [`NAMING.md`](NAMING.md) (cross-MCP tool-naming convention,
-   rf2-mzf1r), [`TOKEN-BUDGETS.md`](TOKEN-BUDGETS.md) (cross-MCP
-   token-budget posture, rf2-ll0yq), and
-   [`wire-vocab/README.md`](wire-vocab/README.md) (cross-MCP
-   wire-vocabulary pinning, rf2-j2z7o). These are the
-   non-test-corpus normative content, sitting where their reach is
-   widest (all three MCP servers consume them).
-
-3. **The servers being verified.** Per-tool input / output / error
-   contracts are owned by each server's own `spec/`
-   ([`tools/re-frame2-pair-mcp/spec/`](../re-frame2-pair-mcp/spec/) and
-   [`tools/story-mcp/spec/`](../story-mcp/spec/)). Duplicating that
-   here would create a second source of truth on a wire that already
-   has one canonical home per server.
-
-A `spec/` folder containing only pointers to those three places would
-add navigation tax for no informational gain. The exemption is the
-straight read.
-
-If `mcp-conformance` ever gains contract surface that does not belong
-to a specific server or to one of the three cross-MCP docs — e.g. a
-new conformance-only protocol the harness defines on its own behalf —
-the exemption is revisited at that point.
+This artefact deliberately has no local `spec/` directory. Per-tool
+input, output, and error contracts live in each server's `spec/`
+directory. Cross-server contracts live in `NAMING.md`,
+`TOKEN-BUDGETS.md`, and `wire-vocab/README.md`; executable constraints
+live in this test corpus. A local spec would duplicate those owners.

--- a/tools/mcp-conformance/TOKEN-BUDGETS.md
+++ b/tools/mcp-conformance/TOKEN-BUDGETS.md
@@ -1,346 +1,104 @@
 # Cross-MCP token-budget posture
 
-Source: rf2-ll0yq.
+`re-frame2-pair-mcp` and `story-mcp` share one response-budget contract:
 
-The re-frame2 MCP pair — `tools/re-frame2-pair-mcp/` and
-`tools/story-mcp/` — shares a normative **token-budget posture**: a
-5,000-token-per-response cap, a single per-call override slot
-(`max-tokens`), and a single cross-server overflow marker
-(`:rf.mcp/overflow`). An agent host that attaches both sees one
-disciplined surface, not two dialects of "I'm too big".
+- a 5,000-token default cap;
+- a `max-tokens` per-call argument on every tool;
+- `max-tokens 0` as the explicit cap-disable sentinel; and
+- `:rf.mcp/overflow` as the structured retry signal.
 
-(Historical: a third server `xray-mcp` was envisaged in this contract;
-it was dropped per rf2-hvl1g. AI agent access to Xray state already
-flows via `re-frame2-pair-mcp` against the framework-published Xray
-runtime API, so a dedicated xray-mcp is unnecessary.)
+The shared implementation lives in `tools/mcp-base`. Server specs own
+their domain-specific slicing, pagination, summary, and hint details.
 
-This doc is the canonical pin. Each server's `Principles.md` carries
-the per-server expansion (mechanism inventory, pipeline order,
-implementation notes); this doc carries the **cross-server contract**
-— what is shared verbatim, where deliberate divergence lives today,
-and how the budget interacts when an agent chains multiple servers in
-one session.
+## Measurement
 
-The peer cross-server docs are:
+The cap is enforced at each server's `tools/call` wire boundary through
+`re-frame.mcp-base.cap/apply-cap`.
 
-- [`NAMING.md`](./NAMING.md) — verb vocabulary (catalogue surface).
-- [`wire-vocab/README.md`](./wire-vocab/README.md) — the `:rf.mcp/*` /
-  `:rf.size/*` keyword namespaces (wire payload surface).
-- **This doc** — the budget posture (response-size discipline).
+Each server's `ResultIO` implementation exposes every serialized,
+payload-bearing string that will ride the wire. This includes the text
+content and any duplicated `structuredContent` projection. The cap must
+not measure only one encoding of a payload that is transmitted twice.
 
-## Why a cap exists
+The primary estimate is `(quot (count text) 4)` for each payload string.
+The pipeline also applies a `cap * 8` aggregate character ceiling. The
+second bound covers many short strings whose per-string quotient rounds
+to zero and gives a conservative backstop for data unlike English prose.
+The objective is bounded egress, not tokenizer-precise billing.
 
-Microsoft's April 2026 recommendation — **Playwright CLI over
-Playwright MCP for coding agents** — was driven by MCP responses being
-~4× larger in tokens than the equivalent CLI output. Anthropic's own
-router-SKILL guidance lands at the same ~5k ceiling. An agent host
-with a 200k-token context window absorbs a handful of 20k tool returns
-fine, but the realistic working session fires dozens of tool calls. A
-single oversized response burns the budget the agent needs for the
-next ten ops.
+## `max-tokens`
 
-The pair's exposed surfaces are exactly the SOTA-flagged shapes:
+The common resolver has these results:
 
-| Server | Exposed surfaces | Why exposed |
-|---|---|---|
-| `re-frame2-pair-mcp` | `snapshot`, `subscribe`, `watch-epochs`, `trace-window` | Mega-op spans 5 registries; subscribe batches scale with traffic; epochs carry full app-db pairs. |
-| `story-mcp` | `run-variant`, `list-stories` on populous libraries | Variant output carries assertions + rendered hiccup + snapshot; list-* size is a function of registry size. |
+| Input | Result |
+|---|---|
+| absent or non-numeric | use the 5,000 default |
+| `0` | disable the cap for this call |
+| integer `>= 1` | use that cap |
+| negative, fractional in `(0,1)`, non-finite, or out of range | return `:rf.mcp/invalid-arg` as an error result |
 
-Cap-first design pushes each server to **bound its egress by
-construction** (path-slicing, lazy summary, cursor pagination,
-diff-encoding, structural dedup, size elision) rather than relying on
-the cap as a backstop. The cap is the safety net; the per-tool
-mechanisms are the load-bearing budget posture.
+Every advertised descriptor includes the `max-tokens` property and
+non-empty budget guidance. The descriptor and classification ratchets in
+the Node conformance suite enforce that inventory-wide.
 
-## The shared contract
+## Overflow
 
-These slots are **identical across both servers**. An agent that
-learns them once recognises them everywhere.
-
-### Default cap
-
-**5,000 tokens per response.** Every tool that returns to the agent
-MUST measure its rendered payload against this cap before egress.
-"Token" here is the Anthropic rule-of-thumb estimate: `(quot (count
-serialised-text) 4)` — a cheap character→token approximation, not a
-precise per-token meter. The goal is a bounded wire payload, not
-exact metering.
-
-The cap applies to the sum of every `:text` slot in the assembled MCP
-`{:content [{:type "text" :text ...} ...]}` result. Multi-part
-responses share one cumulative budget rather than per-key.
-
-### Per-call override slot
-
-**Argument name**: `max-tokens` (integer).
-
-- Absent or non-numeric ⇒ server defaults to 5,000.
-- `0` ⇒ cap disabled. Escape hatch for callers that have already
-  paginated, applied filters, or genuinely need the full payload (e.g.
-  a debug session inspecting an elided slot itself, or a session
-  running with a large-context model).
-- Positive integer ⇒ that cap applies for this call.
-
-The slot surfaces in `tools/list` on every tool descriptor so clients
-discover it automatically. Story-mcp uses the same `:max-tokens`
-keyword and the same defaults — the wire shape is identical, both
-servers resolving the cap through the shared
-`re-frame.mcp-base.cap/max-tokens`.
-
-### Overflow marker (cross-server reserved key)
-
-A tool that would exceed the cap MUST NOT silently truncate. The
-payload is replaced with a structured marker the agent host
-recognises as a retry signal:
+An over-budget result is replaced, never silently truncated:
 
 ```clojure
-{:rf.mcp/overflow {... slot vocabulary varies (see "Divergence" below) ...}}
+{:rf.mcp/overflow
+ {:limit       :reached
+  :token-count <integer>
+  :cap-tokens  <integer>
+  :tool        <string>
+  :hint        <string>}}
 ```
 
-The reserved keyword `:rf.mcp/overflow` is pinned in
-[`spec/Conventions.md` §Reserved namespaces (framework-owned)](../../spec/Conventions.md)
-and gated by the conformance test in
-[`wire-vocab/`](./wire-vocab/). Cross-server reserved-keyword
-absence ≠ free divergence — every server's overflow shape MUST
-validate against the canonical Malli schema pinned in
-`wire-vocab/wire_vocab_test.clj`.
+Both servers build this body through
+`re-frame.mcp-base.overflow/overflow-payload`. The per-tool hint is
+server-authored; the key and body shape are cross-server vocabulary.
+The JVM vocabulary suite and the live pair overflow test pin the shape.
 
-**The agent-host contract**: a result whose first key is
-`:rf.mcp/overflow` is a structured retry signal, not an error. The
-agent narrows args (drop slices, pass a tighter `:path`, tighter
-`:filter`, smaller `:limit`) or passes `max-tokens 0` if the full
-payload is genuinely needed. `:isError` stays `false` on overflow —
-the call succeeded; the response is a budget signal.
+Overflow is a successful budget signal, so `isError` remains false. A
+client should narrow the request using paths, filters, limits, cursors,
+or summary modes. Use `max-tokens 0` only when the full payload is
+deliberately required.
 
-### Cap-aware planning slots in tool descriptors
+## Pipeline invariants
 
-Every catalogue entry (per re-frame2-pair-mcp's
-[`003-Tool-Catalogue.md`](../re-frame2-pair-mcp/spec/003-Tool-Catalogue.md)
-and story-mcp's
-[`002-Tool-Registry.md`](../story-mcp/spec/002-Tool-Registry.md))
-carries:
+Budget-reduction transforms run before the final cap. In particular,
+structural dedup must be reflected in the payload that `apply-cap`
+measures. The cap then either returns the result unchanged or replaces
+the payload with the fixed-shape overflow marker.
 
-- A **typical-token** hint (`~1.2k`, `~3k under :sample`,
-  `~0.8k`) — surfaces in `list-tools` so the agent plans before
-  calling.
-- A **cap-reached** behaviour note — usually the overflow-marker hint
-  string the wrapper emits, optionally tool-specific (re-frame2-pair-mcp's
-  `snapshot` recommends path-slicing; `subscribe` recommends tighter
-  filter; etc.).
+The pair server additionally bounds streaming queues by event count and
+bytes. That upstream resource control is distinct from the per-response
+wire cap. Story-mcp has no streaming surface.
 
-The hints are part of the descriptor, not a separate registry — an
-agent's `tools/list` walk pulls them automatically.
+The detailed mechanism order belongs to the server specs:
 
-## Per-server posture today
+- [`re-frame2-pair-mcp/spec/Principles.md`](../re-frame2-pair-mcp/spec/Principles.md)
+- [`story-mcp/spec/Principles.md`](../story-mcp/spec/Principles.md)
 
-### re-frame2-pair-mcp — enforced, 8 mechanisms
+## Multi-server sessions
 
-The cap is **enforced at the wire boundary** in
-`tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools.cljs` (`apply-cap` at
-the `invoke` boundary, rf2-rvyzy). Per-tool functions emit the same
-shapes they always did; the cap is a property of egress, not of each
-tool's internals.
+The cap is per response, not per server process or host session. Servers
+do not coordinate budgets. A host attached to both servers is
+responsible for the sum of their responses and should:
 
-The discipline rests on **eight mechanisms**, running in pipeline
-order:
+1. start with default summaries or samples;
+2. drill into a path or use a tighter filter;
+3. paginate unbounded collections; and
+4. disable the cap only for an intentional full read.
 
-1. **Size elision** — `:rf.size/large-elided` substitution at
-   declared-large slots, BEFORE everything else (rf2-urjnc).
-2. **Diff-encoded `:db-after`** — `:rf.mcp/diff-from` path-headed
-   cluster sections in epoch slices (rf2-1wdzp + rf2-qeous; each
-   `:section-path`-headed cluster bundles the relevant patches).
-3. **Structural dedup** — `:rf.mcp/dedup-table` cross-record
-   substitution table (rf2-obpa9).
-4. **Path slicing** — `:path` arg defaults to tree-summary on rich
-   slices (rf2-tygdv).
-5. **Lazy summary** — `:rf.mcp/summary` mode for rich payloads
-   (rf2-u2029).
-6. **Cursor pagination** — `:cursor` + `:limit` on unbounded
-   surfaces.
-7. **Streaming budget** — runtime-side OR-combined event-count +
-   byte caps on `subscribe` queue (rf2-ho4ve).
-8. **Wire-boundary cap** — final 5,000-token check, swap with
-   overflow marker if over (rf2-rvyzy).
+`max-tokens` applies independently to each call.
 
-Per-session response cache (`:rf.mcp/cache-hit`, rf2-3rt1f) layers on
-top: byte-identical second reads collapse to a sub-100-byte marker.
+## Changing the contract
 
-Full per-mechanism documentation:
-[`tools/re-frame2-pair-mcp/spec/Principles.md` §"Tight token budget per response"](../re-frame2-pair-mcp/spec/Principles.md#tight-token-budget-per-response).
+Changes to the default, argument name, disable sentinel, overflow key,
+or overflow body must be made atomically across `mcp-base`, both server
+adapters and descriptors, this document, and the conformance fixtures.
+Marker-shape changes also require the JVM wire-vocabulary gate to change.
 
-### story-mcp — enforced at the wire boundary
-
-The cap is **enforced at the wire boundary** in
-`tools/story-mcp/src/re_frame/story_mcp/tools/wire_pipeline.cljc`
-(`invoke-tool` → `re-frame.mcp-base.cap/apply-cap`, rf2-90eft) — the
-SAME shared `mcp-base` algorithm re-frame2-pair-mcp runs, reified over
-story-mcp's `{:content [...] :structuredContent ...}` CLJ-map result
-shape. Per-tool functions emit the shapes they always did; the cap is a
-property of egress. When a response exceeds the per-call cap the payload
-is replaced with the canonical `{:rf.mcp/overflow {...}}` marker carrying
-the tool-specific next-step hint — a structured retry signal, never a
-silent truncation. The `:max-tokens` per-call override and `0`-disables
-sentinel ride the same way they do on re-frame2-pair-mcp.
-
-Two transforms compose at story-mcp's wire boundary, in pipeline order
-(mirroring re-frame2-pair-mcp's invariant — dedup is always the last
-transform before the cap check):
-
-1. **Structural dedup** (`:rf.mcp/dedup-table`, rf2-90eft) — opt-in via
-   `:dedup-eligible?` on `preview-variant` / `run-variant` /
-   `record-as-variant`, the surfaces where repeated subtrees (the same
-   `:app-db` slice reappearing in `:rendered-hiccup` and `:snapshot`)
-   dominate the wire cost.
-2. **Wire-boundary token-cap** (`:rf.mcp/overflow`, rf2-90eft via the
-   shared `mcp-base.cap/apply-cap`) — sizes the post-dedup payload and
-   swaps the overflow marker when over.
-
-Cap-first design still pushes each tool to bound its egress by
-construction, so the cap is the safety net rather than the primary
-mechanism for the common case:
-
-- **Pagination / cursor** on `list-variants`, `list-modes`,
-  `list-assertions`, `list-stories`, `list-substrates`, `list-tags`.
-- **Summarisation modes** (`:count` / `:sample` / `:full`) on
-  `run-variant`, `snapshot-identity`, `variant->edn`, with `:sample`
-  as the default for rich payloads.
-
-The self-healing loop (run → read-failures → fix) naturally biases
-towards failure-only payloads — `:sample` mode under a failure filter
-keeps the typical workflow well inside the cap.
-
-Full posture text:
-[`tools/story-mcp/spec/Principles.md` §"Tight token budget per response"](../story-mcp/spec/Principles.md#tight-token-budget-per-response).
-
-## Chained budgets — when agents attach multiple servers
-
-The realistic agent host attaches **both servers in one session**
-(re-frame2-pair-mcp dispatching events + inspecting trace causality,
-story-mcp running variants). The 5,000-token cap is **per response**,
-not per session — the agent host's total context budget absorbs the
-sum.
-
-The pair's design assumes the agent meters consumption:
-
-- **Each server's responses are bounded.** No server can blow the
-  session on its own.
-- **No cross-server budget coordination.** Servers don't know about
-  each other's outputs; the agent host is the metering authority.
-- **Per-server `max-tokens` overrides compose additively.** An agent
-  that needs a full re-frame2-pair-mcp `snapshot` payload AND a full
-  story-mcp `run-variant` payload passes `max-tokens 0` to both —
-  total cost is the sum.
-
-The agent-host workflow Mike's skills assume:
-
-1. **Start with summaries.** Default `:summary` / `:sample` modes
-   keep the first read cheap (~1-3k tokens).
-2. **Drill down with `:path`.** Subsequent reads target the addressed
-   subtree — the cap stays a backstop, not the primary mechanism for
-   the common case.
-3. **Paginate when summarising won't help.** Trace bursts, epoch
-   history, populous list-* surfaces all carry `:cursor` + `:limit`.
-4. **Override only when you have to.** `max-tokens 0` is the escape
-   hatch; the convention is to narrow args first.
-
-## Divergence — what differs cross-server today
-
-The contract above is shared. These differences exist today and are
-deliberate or pending alignment.
-
-### Overflow-marker slot vocabulary — converged
-
-Both servers now emit the **identical** overflow marker body, built by
-the shared `mcp-base.cap/apply-cap` → `overflow/overflow-payload`:
-
-| Server | Slot shape |
-|---|---|
-| `re-frame2-pair-mcp` | `{:rf.mcp/overflow {:limit :reached :token-count <int> :cap-tokens <int> :tool <str> :hint <str>}}` |
-| `story-mcp` | `{:rf.mcp/overflow {:limit :reached :token-count <int> :cap-tokens <int> :tool <str> :hint <str>}}` (same builder; the marker rides story-mcp's `:structuredContent` slot, the `:hint` text is story-mcp's per-tool table) |
-
-The **reserved keyword** (`:rf.mcp/overflow`), the **marker body
-shape**, and the **retry-signal contract** are all identical — the
-former `:reason :budget-exceeded` legacy path is gone (it never
-shipped; the wire-boundary check converged story-mcp onto the shared
-shape per rf2-90eft). Only the per-tool `:hint` prose is
-server-authored, which the cross-MCP contract leaves to the consumer
-by design.
-
-### Streaming-overflow surface
-
-re-frame2-pair-mcp ships an **upstream-queue budget**
-(`:max-buffered-events` + `:max-buffered-bytes`, OR-combined) per
-subscription, with `:overflow-reason` reported per drain. story-mcp
-doesn't ship streaming.
-
-### Enforcement surface — both runtime-enforced
-
-| Server | Enforcement | Note |
-|---|---|---|
-| `re-frame2-pair-mcp` | Runtime — `apply-cap` at the `invoke` boundary | Live in `tools.cljs` via the shared `mcp-base.cap/apply-cap`. |
-| `story-mcp` | Runtime — `apply-cap` at the `invoke-tool` wire boundary | Live in `wire_pipeline.cljc` via the same shared `mcp-base.cap/apply-cap` (rf2-90eft). |
-
-Both servers run the **same** `mcp-base.cap/apply-cap` algorithm,
-reified over their respective result shapes (`#js {...}` for
-re-frame2-pair-mcp, CLJ maps for story-mcp). The shared **default cap
-(5,000)**, the **shared override slot name (`max-tokens`)**, and the
-**shared overflow keyword (`:rf.mcp/overflow`)** are pinned cross-server
-AND enforced at both wire boundaries.
-
-## Recommended client-side override convention
-
-Agent hosts and skills that drive both servers follow one
-override-pattern convention:
-
-1. **First call: defaults.** No `max-tokens` arg. The server's default
-   (5,000) applies. The agent learns the rough size from the
-   typical-token hint in `tools/list`.
-2. **Cap tripped: narrow first.** On `:rf.mcp/overflow`, the agent
-   narrows args (`:path`, `:filter`, `:limit`, `:mode :sample`)
-   before raising the cap.
-3. **Cap raised: deliberate.** When the agent genuinely needs the
-   full payload, it passes `max-tokens 0` (disable) — not `100000`
-   (raise). The disable-form signals "I am taking responsibility for
-   the budget" rather than "I am guessing at a bigger number".
-4. **Per-server, not per-session.** Each call carries its own
-   `max-tokens` slot. Servers don't coordinate; the agent host meters
-   consumption across the session.
-
-The skill catalogue
-([`skills/re-frame-pair/`](../../skills/re-frame-pair/) and
-[`skills/re-frame-story/`](../../skills/re-frame-story/)) encodes this
-pattern; agents attaching ad-hoc are encouraged to follow it.
-
-## When this convention changes
-
-The 5,000-token default, the `max-tokens` override slot name, the
-`:rf.mcp/overflow` reserved keyword, and the agent-host retry
-contract are **stable cross-server pins**. Changing any of them
-requires:
-
-1. A Lock entry in the relevant server's `DESIGN-RATIONALE.md`
-   recording the question / options / pick / why / date.
-2. A return-trip to this doc to revise the cross-server contract.
-3. A conformance-test update in [`wire-vocab/`](./wire-vocab/) if the
-   change touches the marker shape.
-4. Cross-server alignment — a default-cap change in one server
-   without the others creates a per-server-budget surprise the agent
-   has to special-case.
-
-Don't change silently. Agents pattern-match on the slot shapes the
-table above pins; silent divergence forces per-server
-special-casing and erodes the "one signal, one meaning" property the
-cross-server contract exists to enforce.
-
-## See also
-
-- [`NAMING.md`](./NAMING.md) — cross-MCP verb vocabulary.
-- [`wire-vocab/README.md`](./wire-vocab/README.md) — `:rf.mcp/*` /
-  `:rf.size/*` keyword conformance.
-- [`tools/re-frame2-pair-mcp/spec/Principles.md` §"Tight token budget per response"](../re-frame2-pair-mcp/spec/Principles.md#tight-token-budget-per-response)
-  — re-frame2-pair-mcp's eight mechanisms, in pipeline order.
-- [`tools/story-mcp/spec/Principles.md` §"Tight token budget per response"](../story-mcp/spec/Principles.md#tight-token-budget-per-response)
-  — story-mcp's three-axis discipline.
-- [`spec/Conventions.md` §"Reserved namespaces (framework-owned)"](../../spec/Conventions.md)
-  — the `:rf.mcp/*` / `:rf.size/*` keyword discipline this contract
-  inherits.
+See also [`NAMING.md`](NAMING.md) and
+[`wire-vocab/README.md`](wire-vocab/README.md).

--- a/tools/mcp-conformance/scripts/live-test-inventory.cjs
+++ b/tools/mcp-conformance/scripts/live-test-inventory.cjs
@@ -1,34 +1,6 @@
-// Single source of truth for the re-frame2-pair LIVE conformance gates.
-//
-// The live gates live in `test/live-re-frame2-pair-*.cjs`. Each is named in
-// TWO runners that used to declare the roster independently:
-//
-//   1. `scripts/run-re-frame2-pair-live-hermetic-suite.cjs` — the ONLY place
-//      the live path actually FIRES (boots shadow-cljs, sets
-//      `$SHADOW_CLJS_NREPL_PORT`, spawns each entry, asserts the sentinel).
-//   2. `scripts/test-all.cjs` — spawned by `npm test`, where they
-//      SKIP-by-default (no `$SHADOW_CLJS_NREPL_PORT`) and ride green.
-//
-// Two hand-maintained lists could drift from each other and from disk; the
-// old `live-list-completeness.test.cjs` existed mainly to ratchet the two
-// lists back into agreement. This module makes the roster a SINGLE owner:
-// each gate's basename, display name, and success sentinel are declared here
-// ONCE. Both runners DERIVE their rows from this array (the hermetic runner
-// resolves each `basename` to an absolute path; `test-all.cjs` derives a
-// SKIP-by-default live row), so they can no longer drift from each other —
-// the only remaining anti-drift check is disk-versus-this-inventory
-// (`test/live-list-completeness.test.cjs`).
-//
-// Side-effect-free: requiring this module boots nothing (no shadow-cljs, no
-// Chromium, no MCP server) — it is pure data, safe to import from the
-// completeness gate and both runners.
-//
-// Each entry's `sentinel` is the `... CONFORMANCE GREEN` line the gate prints
-// ONLY on a real (non-skipped) pass. The hermetic env guarantees
-// `$SHADOW_CLJS_NREPL_PORT` is set, so the gate's SKIP path MUST NOT fire
-// there — yet a SKIP still exits 0. The hermetic runner asserts the sentinel
-// (and the absence of a `SKIP ` banner) so a silent in-hermetic SKIP turns
-// the gate RED rather than riding green via the OTHER gates.
+// Single, side-effect-free roster for both live runners. The completeness
+// test compares it with disk. A sentinel distinguishes a real pass from the
+// live tests' exit-0 SKIP path inside the hermetic runner.
 'use strict';
 
 const LIVE_TESTS = [
@@ -38,58 +10,30 @@ const LIVE_TESTS = [
     sentinel: 'RE-FRAME2-PAIR-MCP LIVE OVERFLOW CONFORMANCE GREEN',
   },
   {
-    // Pins the `notifications/progress` streaming wire surface.
     basename: 'live-re-frame2-pair-subscribe.cjs',
     name: 'live subscribe / notifications/progress conformance',
     sentinel: 'RE-FRAME2-PAIR-MCP LIVE SUBSCRIBE CONFORMANCE GREEN',
   },
   {
-    // Egress-protection regression net for the pull-mode epoch tools
-    // (trace-window / watch-epochs). Drives a declared-sensitive app-db
-    // slot through both tools across the MCP wire and asserts the
-    // sensitive epoch is WHOLE-DROPPED gate-OFF (the default) and shipped
-    // gate-ON. This is the gate that pins the whole-drop behaviour.
+    // Pull-mode epoch projection with sensitive reads closed and open.
     basename: 'live-re-frame2-pair-redaction.cjs',
     name: 'live egress-protection conformance (pull-mode epoch tools)',
     sentinel: 'RE-FRAME2-PAIR-MCP LIVE EGRESS-PROTECTION CONFORMANCE GREEN',
   },
   {
-    // Pin the universal `:ok? false ⇒ isError:true` contract on the
-    // read-family GENUINE error envelopes (read-dom/read-ui bad-selector).
-    // Drives a malformed CSS selector against the live runtime so
-    // `querySelectorAll` throws and the runtime fn returns a structured
-    // `{:ok? false :reason :rf.error/...-bad-selector}` — then asserts the
-    // SDK response is isError. This is the live SDK-boundary gate for the
-    // error path; the degraded walk only exercises the
-    // :nrepl-port-not-found shape, so the live runtime is required here.
+    // Genuine read-dom/read-ui error envelopes, unavailable in degraded mode.
     basename: 'live-re-frame2-pair-iserror.cjs',
     name: 'live isError-on-:ok?-false conformance (read-dom/read-ui bad selector)',
     sentinel: 'RE-FRAME2-PAIR-MCP LIVE ISERROR-ON-OK-FALSE CONFORMANCE GREEN',
   },
   {
-    // EP-0017 recordable-coeffects (`cofx`) over the live MCP wire.
-    // Dispatches the fixture's [:counter/stamp] (a reg-event declaring
-    // `:rf.cofx/requires [:rf/time-ms]`) with a scripted
-    // `cofx "{:rf/time-ms <N>}"` and proves the supplied fact reaches the
-    // resulting app-db state (reproducible-dispatch determinism), the
-    // malformed-cofx refusals the degraded handler hides, and the EP-0017
-    // tooling visibility (`list-handlers`/`handler-meta` for the `cofx`
-    // kind + authored `:rf.cofx/requires` on the event). The degraded
-    // end-to-end only proves the `cofx` arg is ACCEPTED — this is the
-    // behaviour gate.
+    // Recordable coeffects: dispatch semantics, refusals, and metadata.
     basename: 'live-re-frame2-pair-cofx.cjs',
     name: 'live EP-0017 cofx conformance (reproducible dispatch + cofx tooling)',
     sentinel: 'RE-FRAME2-PAIR-MCP LIVE COFX CONFORMANCE GREEN',
   },
   {
-    // EP-0018 unified event-registration metadata over the live MCP wire.
-    // Inspects a fixture `rf/reg-event` id (`:counter/inc`) via
-    // `list-handlers`/`handler-meta {kind "event"}` and pins the unified
-    // shape (`:ok? true`, `:kind :event`, `:id`, the `:rf/event-handler`
-    // wrapper) AND the absence of any of the markers that must not appear
-    // (`:event/kind`, `:rf/db-handler`/`:rf/fx-handler`/`:rf/ctx-handler`).
-    // The degraded gate only proves the descriptor/CallToolResult wiring —
-    // this proves the live event-metadata wire reflects EP-0018.
+    // Unified event-registration metadata over the live wire.
     basename: 'live-re-frame2-pair-event-meta.cjs',
     name: 'live EP-0018 event-metadata conformance (unified reg-event shape)',
     sentinel: 'RE-FRAME2-PAIR-MCP LIVE EVENT-METADATA CONFORMANCE GREEN',

--- a/tools/mcp-conformance/scripts/run-re-frame2-pair-live-hermetic-suite.cjs
+++ b/tools/mcp-conformance/scripts/run-re-frame2-pair-live-hermetic-suite.cjs
@@ -1,74 +1,15 @@
 #!/usr/bin/env node
-/*
- * Hermetic orchestrator for the re-frame2-pair LIVE conformance SUITE.
+/* Hermetic live-suite orchestrator.
  *
- * This is the CI entry point for the WHOLE hermetic live suite — it runs
- * EVERY live inner test in the shared inventory
- * (`scripts/live-test-inventory.cjs`), not just the overflow gate.
- * Overflow is one member of that inventory alongside subscribe/progress,
- * redaction, isError, EP-0017 cofx, and EP-0018 event-metadata. The runner
- * is named for the suite, not for the overflow gate, so test selection / CI
- * triage / future conformance work find a suite-shaped name.
+ * Boots the pair fixture, waits for the nREPL socket, compiled JS, browser
+ * preload, and an addressable shadow runtime, then runs every entry in
+ * live-test-inventory.cjs with SHADOW_CLJS_NREPL_PORT set. A child passes
+ * only after close when it exits zero, prints its success sentinel, and
+ * does not print SKIP.
  *
- * Each live inner test (e.g. `test/live-re-frame2-pair-overflow.cjs`) is
- * gated on $SHADOW_CLJS_NREPL_PORT. Without that env var it exits 0 with
- * a SKIP marker because the re-frame2-pair-mcp server runs degraded — no
- * real eval, no cap-trigger, no overflow marker.
- *
- * This script makes the live path *actually* fire on CI by:
- *
- *   1. Spawning `shadow-cljs watch app` against the re-frame2-pair fixture at
- *      `skills/re-frame2-pair/tests/fixture/` — a tiny re-frame2 counter
- *      with `re-frame2-pair.runtime` already wired as a `:devtools
- *      :preloads` entry. The shadow-cljs build also serves an
- *      http-server on :8030.
- *   2. Waiting for the nREPL port file to land (shadow-cljs 3.x writes
- *      to `.shadow-cljs/nrepl.port`; we also probe the legacy
- *      `target/shadow-cljs/nrepl.port` and `.nrepl-port` fallbacks).
- *   3. Waiting for the `:app` bundle to actually compile (not just the
- *      nREPL port to bind — dev-http serves a SPA-style fallback HTML
- *      for `/out/main.js` 200 BEFORE the first compile completes; we
- *      gate on the Content-Type being JS).
- *   4. Launching headless Chromium (Playwright) at
- *      http://localhost:8030 so the bundle loads and the runtime
- *      preload sets `window.__re_frame2_pair_runtime`.
- *   5. Waiting for the runtime sentinel to be present in the browser
- *      AND for shadow-cljs's `:app` runtime to be addressable via
- *      `cljs-eval` over nREPL (so re-frame2-pair-mcp's `ensure-runtime!` probe
- *      sees the runtime — that probe `.catch`es shadow's
- *      "no-runtime-connected" error to `false`, surfacing as a false
- *      `:runtime-not-preloaded`).
- *   6. Setting SHADOW_CLJS_NREPL_PORT=<port> and spawning
- *      `node test/live-re-frame2-pair-overflow.cjs`.
- *   7. Tearing down browser + shadow-cljs cleanly on success, failure,
- *      or signal.
- *
- * All six boot gates (port file at the right path, TCP listener, fixture
- * HTTP, bundle compile, browser sentinel, shadow-runtime addressable) are
- * required: each one closes a window in which the live path would fire
- * before the runtime is genuinely ready, which would surface as a long CI
- * timeout rather than a clean conformance result.
- *
- * Exit codes:
- *   0  hermetic conformance passed
- *   1  conformance failure (overflow marker / SDK / etc.)
- *   2  orchestration failure (shadow-cljs didn't boot, port file
- *      missing, runtime preload didn't land, watchdog elapsed)
- *
- * Hard time-cap of HERMETIC_TIMEOUT_MS guards against runaway compiles
- * on a cold CI runner. The shadow-cljs `watch` child + Playwright
- * browser are killed in the `finally`; SIGINT/SIGTERM also wire to the
- * same cleanup.
- *
- * The fixture `npm install` setup runs under an ASYNC spawn with its own
- * `SETUP_COMMAND_TIMEOUT_MS` cap (see `runTrusted`). A synchronous
- * `crossSpawn.sync` there would block the event loop for the install's
- * whole lifetime — during which the HERMETIC_TIMEOUT_MS watchdog (and
- * signal handlers) physically cannot fire — so a hung `npm install` would
- * wedge the run past the outer CI job timeout. The async spawn keeps the
- * loop live so BOTH the per-command timeout AND the whole-run watchdog
- * stay armed across setup.
- */
+ * Exit codes: 0 conformance passed; 1 inner conformance failed; 2 setup,
+ * grading, or watchdog failure. Setup commands and the whole run are
+ * asynchronously bounded so watchdogs and signal cleanup remain active. */
 'use strict';
 
 const fs = require('node:fs');
@@ -84,17 +25,8 @@ const {
 } = require('../lib/exec-safety.cjs');
 const { LIVE_TESTS } = require('./live-test-inventory.cjs');
 
-// We use `cross-spawn` instead of Node's `child_process.spawn` for the
-// two Windows-toolchain spawn sites (`npm` install + `npx shadow-cljs
-// watch`) because Node's spawn refuses to execute `.cmd` / `.bat` with
-// `shell: false` since the CVE-2024-27980 fix (EINVAL). cross-spawn
-// dispatches to cmd.exe under the hood when the resolved target ends
-// in `.cmd`, escapes arguments correctly, and — load-bearing for the
-// command-hijack accident-gating — does NOT do a cwd-prefixed PATH walk
-// when the command argument is an absolute path (see `which`'s
-// `cmd.match(/\//)` short-circuit). The accident-gating contract is
-// preserved by passing an absolute path resolved via the host's
-// PATH-only scan (see `lib/exec-safety.cjs`).
+// cross-spawn executes Windows .cmd shims without enabling shell parsing.
+// Executables are still resolved to absolute, PATH-only locations first.
 
 const HERE = __dirname;
 const MCP_CONFORMANCE_ROOT = path.resolve(HERE, '..');
@@ -120,23 +52,11 @@ const {
 const VERBOSE_TESTS = isVerboseTests();
 const DIAGNOSTICS = createDiagnosticBuffer();
 
-// Module-scope handle to the in-flight teardown closure.
-// `main()` assigns this once it has spawned shadow-cljs / Chromium so
-// the hard watchdog below can tear those children down BEFORE
-// `process.exit` — without it, a watchdog-elapse would orphan the
-// shadow-cljs JVM (and a launched Chromium), and those orphans can keep
-// the CI step's inherited log pipes open past the node exit. Stays null
-// until the children exist; the watchdog null-guards it.
+// Published as soon as children exist so watchdog and signal paths can reap
+// the same resources as the normal finally path.
 let activeCleanup = null;
 
-// Shadow-cljs writes its nREPL port file under whichever cache-root
-// the build is configured for. Default in 3.x is `.shadow-cljs/`; older
-// configs used `target/shadow-cljs/`; nrepl itself drops `.nrepl-port`.
-// re-frame2-pair-mcp's runtime probe (`re_frame2_pair_mcp/nrepl.cljs`
-// `port-file-candidates`) walks the same list — keep them in lockstep.
-// The orchestrator watches every candidate path so it binds to whichever
-// one the active shadow-cljs version writes (shadow-cljs 3.x defaults to
-// `.shadow-cljs/nrepl.port`), rather than gambling on a single location.
+// Keep this list aligned with pair-mcp's `port-file-candidates`.
 const NREPL_PORT_FILE_CANDIDATES = [
   path.join(FIXTURE_DIR, '.shadow-cljs', 'nrepl.port'),
   path.join(FIXTURE_DIR, 'target', 'shadow-cljs', 'nrepl.port'),
@@ -147,65 +67,25 @@ const FIXTURE_HTTP_PORT = 8030; // hard-coded in fixture's shadow-cljs.edn
 const FIXTURE_URL = `http://127.0.0.1:${FIXTURE_HTTP_PORT}/`;
 const FIXTURE_BUNDLE_PATH = path.join(FIXTURE_DIR, 'public', 'out', 'main.js');
 
-// Wall-clock caps. shadow-cljs cold-start with a warm Maven cache is
-// typically 30-60s on GHA; warm restart is much faster. We give the
-// boot 360s so the first cold-cache run of the day (no `~/.m2`
-// restore hit at all) still has headroom while Maven resolves the
-// fixture's :local/root deps (core + reagent + epoch + schemas +
-// machines + Reagent/Malli trees). The CI workflow's
-// `mcp-conformance-re-frame2-pair` job hashes those
-// inputs into its actions/cache key, so this headroom only
-// kicks in on the truly cold path; warm-cache runs still bind the
-// nREPL port in <60s.
+// Cold shadow-cljs dependency resolution needs substantially more headroom
+// than a warm fixture boot.
 const SHADOW_BOOT_TIMEOUT_MS = 360_000;
 const RUNTIME_PRELOAD_TIMEOUT_MS = 60_000;
 const HERMETIC_TIMEOUT_MS = 540_000;
-// Bounded waits for the async teardown. `cleanup`
-// awaits Playwright's promise-returning `browser.close()` (capped so a
-// wedged browser-close can't hang the teardown) and SIGTERM→exit of the
-// shadow-cljs child (escalating to SIGKILL after the grace, then observing
-// the final exit). `$HERMETIC_CLEANUP_*_MS` shrink these caps for the
-// teardown regression harness only (`runner-cleanup.test.cjs`); production
-// CI never sets them.
+// Tests override these values to exercise bounded close and kill escalation.
 const CLEANUP_BROWSER_CLOSE_TIMEOUT_MS =
   Number(process.env.HERMETIC_CLEANUP_BROWSER_MS) || 15_000;
 const CLEANUP_SHADOW_SIGTERM_GRACE_MS =
   Number(process.env.HERMETIC_CLEANUP_SHADOW_GRACE_MS) || 5_000;
 const CLEANUP_SHADOW_SIGKILL_GRACE_MS =
   Number(process.env.HERMETIC_CLEANUP_SHADOW_KILL_MS) || 5_000;
-// Hard cap the signal/watchdog paths race the async cleanup against, so an
-// interrupted run still exits promptly even if a child refuses to die. The
-// cleanup is awaited up to this bound, then the process exits regardless.
+// Signal/watchdog paths race cleanup against this final bound.
 const CLEANUP_HARD_CAP_MS =
   Number(process.env.HERMETIC_CLEANUP_HARD_CAP_MS) || 30_000;
-// Poll cadence for the four sequential boot gates (port file, TCP
-// listener, fixture HTTP, bundle compile, runtime sentinel, shadow
-// runtime addressable). Each gate latches as soon as it flips, so the
-// poll interval is pure resolution latency on the critical path: a warm
-// cache boot is gated by `~6 * POLL_MS` of cumulative wait. A tight 100ms
-// cadence keeps warm-cache CI runs fast (the gates check cheap
-// filesystem/TCP probes, so the high poll rate doesn't meaningfully raise
-// cold-cache load).
+// Sequential readiness probes latch once true; this is their resolution.
 const POLL_MS = 100;
 
-// Inner tests the orchestrator boots shadow-cljs for, DERIVED from the
-// shared live-test inventory (`scripts/live-test-inventory.cjs` — the
-// single owner of each gate's basename / display name / sentinel). Each
-// runs with the spawned `SHADOW_CLJS_NREPL_PORT` set so its SKIP gate flips
-// off and the live path fires; they run sequentially against the same
-// booted runtime so the cold-boot cost amortises across every test.
-//
-// The orchestrator's name keeps `overflow` to match the workflow YAML's
-// script reference; the inventory (not this derived list) is the
-// authoritative roster — `test-all.cjs` derives its SKIP-by-default live
-// rows from the same array, and `test/live-list-completeness.test.cjs`
-// cross-checks the inventory against the `test/live-re-frame2-pair-*.cjs`
-// files on disk.
-//
-// The inventory carries each gate's success `sentinel` (see its header for
-// why the sentinel assertion below is load-bearing against a silent
-// in-hermetic SKIP that would otherwise ride green via the OTHER gates).
-// Here we resolve each `basename` to the absolute path the spawn needs.
+// Run the shared roster sequentially against one booted fixture.
 const INNER_TESTS = LIVE_TESTS.map((t) => ({
   name: t.name,
   path: path.join(MCP_CONFORMANCE_ROOT, 'test', t.basename),

--- a/tools/mcp-conformance/scripts/test-all.cjs
+++ b/tools/mcp-conformance/scripts/test-all.cjs
@@ -1,22 +1,6 @@
 #!/usr/bin/env node
-/*
- * Sequential orchestrator for the mcp-conformance test suite. Spawns each
- * conformance test in sequence with structured per-test exit-code
- * reporting; it is the implementation behind the `npm test` script.
- *
- * Why an orchestrator: it runs each test in sequence, records its exit
- * status, and prints a structured summary at the end. It bails on the
- * first failure (so CI fails fast), and the summary makes failure
- * attribution one-glance instead of one-grep — each test's pass/fail and
- * exit code is listed by name rather than buried in a chained exit code.
- *
- * Exit codes:
- *   0  every test passed (some may have SKIPped — they still exit 0)
- *   N  the exit code of the first test that failed (forwarded verbatim
- *      so a downstream failure that itself uses a non-1 exit code —
- *      e.g. the runner's watchdog `process.exit(2)` — surfaces
- *      faithfully to the parent shell).
- */
+/* Sequential, fail-fast `npm test` orchestrator. It forwards the first
+ * failing exit code and distinguishes an exit-0 SKIP banner from a pass. */
 'use strict';
 
 const path = require('node:path');
@@ -26,97 +10,73 @@ const { LIVE_TESTS } = require('./live-test-inventory.cjs');
 const HERE = __dirname;
 const ROOT = path.resolve(HERE, '..');
 
-// The live re-frame2-pair gates, DERIVED from the shared inventory
-// (`scripts/live-test-inventory.cjs`) — the single owner of the roster — so
-// this file and the hermetic runner (`run-re-frame2-pair-live-hermetic-suite.cjs`)
-// can never declare a different set. Under `npm test` (no
-// `$SHADOW_CLJS_NREPL_PORT`) each SKIPs and rides green; the hermetic CI job
-// is the only place the live path fires. Spliced into `TESTS` below AFTER the
-// degraded end-to-end and BEFORE story-mcp so a green run reads as "real
-// conformance passed, the live gates gracefully skipped".
+// Both this runner and the hermetic runner derive the live roster here.
+// Without SHADOW_CLJS_NREPL_PORT these rows report SKIP.
 const LIVE_ROWS = LIVE_TESTS.map((t) => ({
   name: `re-frame2-pair-mcp ${t.name} (SKIPs without $SHADOW_CLJS_NREPL_PORT)`,
   argv: [`test/${t.basename}`],
 }));
 
-// One row per conformance test. Order matters: cheap unit tests first
-// so a typo in the exec-safety helpers fails before we spawn an MCP
-// server. SKIP-by-default tests (live-re-frame2-pair-overflow) live near
-// the end so a green run reads as "real conformance passed, one
-// gracefully skipped".
-//
-// This array is the SINGLE SOURCE OF TRUTH for the conformance
-// inventory. It is exported (see the bottom of this file) so derived
-// runners can select a subset without re-listing — notably
-// `scripts/test-unit.cjs`, which runs the pure-Node unit cluster
-// (every row whose `argv[0] === '--test'`) in one `node --test`
-// invocation for the PR CI Node-regression gate. Because
-// that runner DERIVES its set from this array, a new `--test` row added
-// here is automatically picked up by PR CI — no second list to keep in
-// sync.
-//
-// The LIVE re-frame2-pair rows are themselves DERIVED from the shared
-// live-test inventory (`LIVE_ROWS`, above) rather than re-listed here, so
-// they cannot drift from the hermetic runner's roster.
+// Authoritative Node inventory. Keep cheap `node --test` rows first;
+// test-unit.cjs derives that subset from argv[0] rather than re-listing it.
 const TESTS = [
   {
     name: 'exec-safety unit tests',
     argv: ['--test', 'test/exec-safety.test.cjs'],
   },
   {
-    name: 'runner watchdog connect-hang teardown (rf2-2js41 finding 2 + rf2-wqi4n4 finding 1)',
+    name: 'runner watchdog connect-hang teardown',
     argv: ['--test', 'test/runner-watchdog.test.cjs'],
   },
   {
-    name: 'hermetic async cleanup awaited teardown (rf2-7ckmwx finding 1)',
+    name: 'hermetic async cleanup awaited teardown',
     argv: ['--test', 'test/runner-cleanup.test.cjs'],
   },
   {
-    name: 'hermetic setup-command timeout (rf2-wqi4n4 finding 2)',
+    name: 'hermetic setup-command timeout',
     argv: ['--test', 'test/hermetic-setup-timeout.test.cjs'],
   },
   {
-    name: 'hermetic INNER_TESTS grading on close, not exit (rf2-6girz0)',
+    name: 'hermetic inner-test grading on close, not exit',
     argv: ['--test', 'test/inner-test-close-grading.test.cjs'],
   },
   {
-    name: 'live-gate list completeness — disk ⇄ shared live-test inventory (rf2-79qmsw / rf2-phveub)',
+    name: 'live-gate disk and shared-inventory completeness',
     argv: ['--test', 'test/live-list-completeness.test.cjs'],
   },
   {
-    name: 'hermetic port-file escape refusal (rf2-khav7l)',
+    name: 'hermetic port-file escape refusal',
     argv: ['--test', 'test/port-file-escape.test.cjs'],
   },
   {
-    name: 'hermetic stale port-file wipe fails loud on a surviving stale file (rf2-6i2yi4)',
+    name: 'hermetic stale port-file wipe fails on a surviving stale file',
     argv: ['--test', 'test/stale-port-file-trust.test.cjs'],
   },
   {
-    name: 'dedup-envelope decoder — cyclic-cache throws + acyclic happy path (rf2-87h71e)',
+    name: 'dedup-envelope decoder rejects cycles and expands acyclic caches',
     argv: ['--test', 'test/dedup-envelope.test.cjs'],
   },
   {
-    name: 'exact-token match — anchors :invalid-cofx vs :invalid-cofx-time-ms (rf2-6i2yi4)',
+    name: 'exact-token matching distinguishes overlapping reason names',
     argv: ['--test', 'test/token-match.test.cjs'],
   },
   {
-    name: 'universal isError <-> :ok? cross-check reads through the dedup decoder (rf2-6i2yi4)',
+    name: 'universal isError and :ok? cross-check after dedup decoding',
     argv: ['--test', 'test/is-error-matches-ok.test.cjs'],
   },
   {
-    name: 'callTool coverage ratchet unit tests (rf2-ke5n56)',
+    name: 'callTool coverage ratchet unit tests',
     argv: ['--test', 'test/call-coverage-ratchet.test.cjs'],
   },
   {
-    name: 'classification ratchet unit tests — read/destructive + open-world partition (rf2-yi451 / rf2-ppk6hy)',
+    name: 'descriptor classification and open-world partition ratchet',
     argv: ['--test', 'test/classification-ratchet.test.cjs'],
   },
   {
     name: 're-frame2-pair-mcp end-to-end',
     argv: ['test/end-to-end-re-frame2-pair.cjs'],
   },
-  // Live re-frame2-pair gates, derived from the shared inventory (see
-  // `LIVE_ROWS` above). SKIP-by-default under `npm test`.
+  // Derived live rows; SKIP by default under `npm test`.
   ...LIVE_ROWS,
   {
     name: 'story-mcp end-to-end',
@@ -133,14 +93,7 @@ function banner(line) {
   process.stdout.write('\n' + sep + '\n' + line + '\n' + sep + '\n');
 }
 
-// The shared pre-flight skip helper (`_runner.cjs` `runWithWatchdog.skip`)
-// prints a `SKIP <reason>` line and exits 0 BEFORE running any real
-// assertions. That exit-0 is indistinguishable from a real pass by
-// status code alone — the six live-re-frame2-pair-* rows all SKIP this
-// way when `$SHADOW_CLJS_NREPL_PORT` is unset, which is the normal state
-// of a local `npm test` run. Detect the banner in the child's captured
-// stdout so the summary can tell "skipped" apart from "actually ran and
-// passed" instead of collapsing both into a bare exit-0 OK.
+// Skip is an exit-0 outcome, so grade the shared banner as well as status.
 const SKIP_BANNER = /^SKIP /m;
 
 function main() {
@@ -149,13 +102,7 @@ function main() {
 
   for (const test of TESTS) {
     banner('▶ ' + test.name + '\n  ' + test.argv.join(' '));
-    // `process.execPath` is always absolute. stdout is piped (not
-    // inherited) so we can inspect it for the SKIP banner; it is written
-    // to our own stdout immediately after the child exits, so nothing is
-    // lost — only the live-interleaving with stderr is (stderr stays
-    // `inherit`, unaffected). `shell: false` keeps the accident-gating
-    // from the lib/exec-safety.cjs preamble: no shell-interpolation of
-    // test names.
+    // Capture stdout for SKIP grading, then replay it. stderr remains live.
     const child = spawnSync(process.execPath, test.argv, {
       cwd: ROOT,
       stdio: ['inherit', 'pipe', 'inherit'],
@@ -186,8 +133,7 @@ function main() {
         (firstFailure.signal ? ' (signal ' + firstFailure.signal + ')' : '') +
         '\n',
     );
-    // Forward the inner exit code verbatim. `null` (signal-terminated)
-    // becomes 1 so the parent shell still sees a non-zero exit.
+    // A signal has no numeric status but must remain a failing outcome.
     process.exit(firstFailure.status === null ? 1 : firstFailure.status);
   }
 
@@ -203,12 +149,7 @@ function main() {
   process.exit(0);
 }
 
-// Export the authoritative inventory so derived runners (e.g.
-// `scripts/test-unit.cjs`) can select a subset without re-listing.
-// `ROOT` rides along so a derived runner resolves test paths against the
-// same artefact root. The orchestrator only auto-runs when invoked
-// directly (`node scripts/test-all.cjs` / `npm test`), not when required
-// as a module — so importing this file has no side effects.
+// Importing the inventory is side-effect free.
 module.exports = { TESTS, ROOT };
 
 if (require.main === module) {

--- a/tools/mcp-conformance/scripts/test-unit.cjs
+++ b/tools/mcp-conformance/scripts/test-unit.cjs
@@ -1,37 +1,6 @@
 #!/usr/bin/env node
-/*
- * PR-CI Node-regression gate.
- *
- * Runs the pure-Node UNIT cluster of the conformance inventory — every
- * row in `scripts/test-all.cjs`'s authoritative `TESTS` array whose
- * `argv[0] === '--test'` (i.e. invoked via `node --test`). These are the
- * harness's own regression nets: the runner watchdog teardown, the
- * awaited hermetic cleanup, the bounded setup-command timeout, the
- * symlink-safe port-file read, the dedup-envelope decoder, and the
- * call-coverage / classification ratchets. They boot no MCP server, need
- * no nREPL / clojure / Chromium, and finish in a couple of seconds.
- *
- * ## Why this script exists
- *
- * `test-all.cjs` is the single source of truth for the conformance
- * inventory, but it spawns EVERY test — including the end-to-end (server
- * bundle), live (nREPL), story (JVM `clojure`), and hermetic
- * (shadow-cljs + Chromium) gates. Those are run by dedicated CI jobs
- * (`mcp-conformance-{re-frame2-pair,story}`) with their own toolchains
- * and caches. This gate runs the full set of `node --test` unit gates in
- * PR CI, so a regression any of them guards is caught before merge.
- *
- * This runner DERIVES its set from `test-all.cjs` rather than
- * re-listing, so it cannot drift: add a new `node --test` row to the
- * authoritative array and PR CI picks it up automatically. It runs the
- * whole cluster in ONE `node --test` invocation (Node's test runner
- * aggregates results across files and exits non-zero if any file fails),
- * which is faster than spawning each file separately and gives one
- * combined summary.
- *
- * Exit codes: 0 = every unit gate green; non-zero = at least one failed
- * (forwarded from the `node --test` child).
- */
+/* Node-only CI gate. Derives every `node --test` row from test-all.cjs
+ * and runs the files together without booting either MCP server. */
 'use strict';
 
 const path = require('node:path');
@@ -39,10 +8,7 @@ const { spawnSync } = require('node:child_process');
 
 const { TESTS, ROOT } = require('./test-all.cjs');
 
-// The unit cluster is exactly the rows invoked through `node --test`.
-// The end-to-end / live / story / flag-gates rows are plain
-// `node <script>` (no `--test`) and are excluded — they belong to the
-// dedicated server jobs, not this Node-only unit gate.
+// Plain `node <script>` rows are integration tests and stay excluded.
 const UNIT_FILES = TESTS.filter((t) => t.argv[0] === '--test').map(
   (t) => t.argv[t.argv.length - 1],
 );
@@ -59,18 +25,14 @@ const sep = '─'.repeat(72);
 process.stdout.write(
   '\n' +
     sep +
-    '\n▶ mcp-conformance Node unit cluster (rf2-md05gp)\n  node --test ' +
+    '\n▶ mcp-conformance Node unit cluster\n  node --test ' +
     UNIT_FILES.join(' ') +
     '\n' +
     sep +
     '\n',
 );
 
-// One `node --test` invocation across every unit file: the runner
-// aggregates and exits non-zero on any failure. `cwd: ROOT` so the
-// relative `test/...` paths resolve against the artefact root regardless
-// of the caller's cwd. `shell: false` (spawnSync default) — no
-// shell-interpolation of file paths.
+// ROOT keeps the inventory's relative paths independent of caller cwd.
 const child = spawnSync(process.execPath, ['--test', ...UNIT_FILES], {
   cwd: ROOT,
   stdio: 'inherit',

--- a/tools/mcp-conformance/test/_runner.cjs
+++ b/tools/mcp-conformance/test/_runner.cjs
@@ -1,72 +1,7 @@
-// Shared Node-side test runner for MCP-conformance harnesses.
-//
-// Every `tools/mcp-conformance/test/end-to-end-*.cjs` (and the
-// sibling `live-re-frame2-pair-overflow.cjs`) repeats the same ceremony:
-//
-//   - construct a `StdioClientTransport` with `stderr: 'pipe'`
-//   - pipe the child's stderr to ours with a `[server]` prefix
-//   - construct an SDK `Client` with a `mcp-conformance-*` identity
-//   - install a watchdog `setTimeout` so a hung child can't wedge CI
-//   - on success: tear down the transport, clear the watchdog,
-//     `process.exit(0)`
-//   - on error: best-effort `client.close()`, clear the watchdog,
-//     print the failure, `process.exit(1)`
-//   - on watchdog: print the timeout, TEAR THE SPAWNED CHILD DOWN
-//     (`client.close()` closes its transport, killing the stdio child),
-//     then `process.exit(2)` — a hard-exit fallback fires after a short
-//     grace window so a hung close can't keep the process alive. Tearing
-//     the child down on the timeout keeps it from being orphaned (the
-//     hermetic orchestrator guards the same class).
-//
-// Centralising the framing here shrinks each test body to the workflow
-// steps that actually differ — the framing is otherwise a near-identical
-// ~40-LoC block of pure ceremony per test. Adding another Node-side
-// conformance test (a third re-frame2-pair variant) becomes ~30 LoC
-// instead of ~110.
-//
-// ## Contract
-//
-// `runWithWatchdog({ watchdogMs, transportSpec, clientName }, body)`
-//
-//   - `watchdogMs`     — ms before the hard-cap `process.exit(2)` fires.
-//   - `transportSpec`  — `{ command, args, cwd, env }` forwarded to
-//                        `StdioClientTransport` (with `stderr: 'pipe'`
-//                        spliced in automatically).
-//   - `clientName`     — the SDK `Client` `name` slot. Every conformance
-//                        test uses a `mcp-conformance-<server>` identity.
-//   - `body`           — `async (client, transport) => void`. Throws on
-//                        any assertion failure; the runner reports the
-//                        message + stack and exits 1.
-//
-// The SDK `Client.version` slot is pinned at `'0.1.0'` for every
-// conformance harness — none of the callers override it and the
-// server's `initialize` handler treats client version as informational.
-// Promoting it to a parameter would be slot-soup.
-//
-// `runWithWatchdog` performs the SDK connect handshake itself (so each
-// body starts already connected) and passes the connected `client` +
-// `transport` to `body`. Tests that want to
-// skip (no-op exit 0) call `runWithWatchdog.skip(reason)` BEFORE
-// invoking this function — that prints a uniform `SKIP <reason>`
-// banner and exits 0 without spawning a child or installing a
-// watchdog.
-//
-// The runner returns nothing; it always terminates the process via
-// `process.exit`. Callers that pre-flight skip MUST exit themselves
-// (via `runWithWatchdog.skip`).
-//
-// ## Bare spawn (no watchdog / no exit) — `connectServer` + `closeQuietly`
-//
-// `runWithWatchdog` is the single-boot-per-process form. Two gates need
-// a SECOND in-process server boot it can't serve (it `process.exit`s on
-// every path): `end-to-end-flag-gates.cjs` (three fresh JVMs, one per
-// gate-posture probe) and `live-re-frame2-pair-redaction.cjs` (a second
-// server with `--allow-sensitive-reads` for the gate-ON arm). Both call
-// the shared `connectServer({ transportSpec, clientName, stderrPrefix })`
-// primitive — the exact spawn+stderr-pipe+Client+connect ceremony this
-// header describes — and tear down with `closeQuietly(client)`.
-// `runWithWatchdog` is itself just `connectServer` wrapped in the
-// watchdog + exit-code framing, so the framing has one home.
+// Shared SDK transport, watchdog, catalogue-ratchet, and envelope helpers.
+// `runWithWatchdog` owns a single primary server and exits 0/1/2 for pass,
+// assertion failure, or timeout. Tests that need secondary servers use
+// `connectServer` and register each client so the same watchdog can reap it.
 
 const { Client } = require('@modelcontextprotocol/sdk/client/index.js');
 const { StdioClientTransport } = require('@modelcontextprotocol/sdk/client/stdio.js');
@@ -75,70 +10,16 @@ const { decodeDedupEnvelope } = require('../lib/dedup-envelope.cjs');
 
 const CLIENT_VERSION = '0.1.0';
 
-// ---------------------------------------------------------------------
-// Shared SDK-spawn primitive.
-//
-// Spawn one MCP server over a `StdioClientTransport`, pipe its stderr
-// to ours, construct an SDK `Client` with the pinned conformance
-// identity, and run the `initialize` handshake. Returns the connected
-// `{ client, transport }` for the caller to drive + tear down.
-//
-// `runWithWatchdog` below is the watchdog-wrapped, single-boot-per-
-// process form (it `process.exit`s on every path). But two gates need
-// a SECOND, in-process server boot the watchdog form can't provide:
-//
-//   - `end-to-end-flag-gates.cjs` boots three fresh JVMs in one process
-//     (the gate is a boot-time atom — flipping it needs a new server).
-//   - `live-re-frame2-pair-redaction.cjs` boots a second server with
-//     `--allow-sensitive-reads` to pin the gate-ON direction.
-//
-// Centralising the transport+client+stderr-pipe+connect ceremony here
-// means the framing the runner's header documents has ONE home; a caller
-// that needs a bare boot calls `connectServer` + `closeQuietly`, and
-// `runWithWatchdog` itself is just `connectServer` wrapped in the
-// watchdog + exit-code framing.
-//
-//   - `transportSpec`  — `{ command, args, cwd, env }` forwarded to
-//                        `StdioClientTransport` (`stderr: 'pipe'` is
-//                        spliced in here — non-negotiable so CI logs
-//                        surface server stderr on a failing step).
-//   - `clientName`     — the SDK `Client` `name` slot.
-//   - `stderrPrefix`   — bracketed tag prepended to each piped stderr
-//                        line. Defaults to `[server]`; the redaction
-//                        gate-ON arm passes `[server:gate-on]` to keep
-//                        the two concurrent servers' logs distinguishable.
-//   - `onClient`       — OPTIONAL `(client) => void` callback, invoked
-//                        with the constructed client BEFORE the
-//                        `await client.connect()` handshake. The
-//                        watchdog form (`runWithWatchdog`) uses it to
-//                        capture a teardown handle the moment the child
-//                        is spawned — so a server that spawns and then
-//                        HANGS during the initialize handshake (connect
-//                        never resolving, never throwing) is still torn
-//                        down by the timeout path instead of orphaning
-//                        the child. The connect try/catch below only
-//                        covers a connect that THROWS — a connect that
-//                        hangs never reaches it.
-// ---------------------------------------------------------------------
+// `onClient` runs before connect awaits, making a hung initialize handshake
+// reachable by the caller's watchdog.
 async function connectServer({ transportSpec, clientName, stderrPrefix = '[server]', onClient }) {
   const transport = new StdioClientTransport({ ...transportSpec, stderr: 'pipe' });
   const client = new Client({ name: clientName, version: CLIENT_VERSION }, { capabilities: {} });
-  // Hand the caller a teardown handle the moment the client exists —
-  // BEFORE the connect handshake. The child has already been spawned by
-  // the transport construction above, so a connect that hangs (server
-  // boots but never finishes `initialize`) would otherwise leave the
-  // watchdog with no client to close. `onClient` closes that window: the
-  // watchdog captures `client` here, not after `connect` resolves.
+  // Publish the teardown handle before the initialize await.
   if (onClient) onClient(client);
-  // Pipe the child's stderr to ours with the (prefixed) tag. The closure
-  // captures the transport reference cleanly.
+  // Prefix stderr so concurrent secondary servers remain distinguishable.
   transport.stderr?.on('data', (d) => process.stderr.write(stderrPrefix + ' ' + d.toString()));
-  // Initialize handshake. SDK validates the result against
-  // InitializeResultSchema; a malformed envelope throws here. On a
-  // connect-throw, tear the half-open transport down before re-throwing
-  // so the spawned child can't leak — `client.close()` closes its
-  // transport, so callers need no transport handle to clean up a failed
-  // boot.
+  // SDK validation happens during connect; close a half-open child on throw.
   try {
     await client.connect(transport);
   } catch (connectErr) {
@@ -148,11 +29,7 @@ async function connectServer({ transportSpec, clientName, stderrPrefix = '[serve
   return { client, transport };
 }
 
-// Best-effort `client.close()` that never throws. A close-error is
-// purely cosmetic — it's independent of whatever outcome the caller
-// already recorded — so we log it and swallow it. Shared by every
-// teardown path (the runner's `finally`, the flag-gate per-boot
-// `finally`, the redaction gate-ON arm's `finally`).
+// Teardown must not mask the conformance outcome already recorded.
 async function closeQuietly(client) {
   try {
     await client.close();
@@ -161,75 +38,30 @@ async function closeQuietly(client) {
   }
 }
 
-// Module-scope set of SECONDARY MCP clients the watchdog must ALSO tear
-// down on a timeout. `runWithWatchdog` owns at most ONE primary client
-// (`activeClient`); but two gates boot ADDITIONAL in-process servers via
-// bare `connectServer` INSIDE the body
-// (`live-re-frame2-pair-redaction.cjs`'s inner-projection + gate-ON arms),
-// which the outer watchdog cannot reach through `activeClient` alone — a
-// hang in a secondary boot or a later secondary tool call would orphan
-// that child despite the harness reporting a watchdog timeout. A body
-// registers each secondary client here (via `registerAuxClient`, fired
-// the instant the client is constructed) and deregisters it on teardown;
-// the watchdog drains every surviving member so EVERY spawned child the
-// conformance process owns is reachable by the timeout path from the
-// moment it can exist until teardown.
+// Secondary servers must remain reachable by the process-level watchdog.
 const AUX_CLIENTS = new Set();
 
-// Register a secondary client so the active watchdog reaps it on a timeout.
-// Call it from a bare `connectServer`'s `onClient` (BEFORE connect awaits)
-// so a hung secondary boot is reachable from the moment its child exists.
-// Returns the client unchanged for fluent use.
+// Register from `onClient`, before connect awaits.
 function registerAuxClient(client) {
   if (client) AUX_CLIENTS.add(client);
   return client;
 }
 
-// Drop a secondary client from the watchdog set once its arm has torn it
-// down (or is about to). Idempotent; safe to call in a `finally`.
+// Idempotent removal after secondary teardown.
 function unregisterAuxClient(client) {
   if (client) AUX_CLIENTS.delete(client);
 }
 
 async function runWithWatchdog({ watchdogMs, transportSpec, clientName }, body) {
-  // The watchdog must OWN the active client so a timeout tears the
-  // spawned child down instead of orphaning it. `activeClient` is the
-  // closure handle the watchdog reads; it is assigned via
-  // `connectServer`'s `onClient` callback the moment the client is
-  // constructed — BEFORE the `await client.connect()` handshake — so a
-  // hang ANYWHERE after spawn (during `initialize`, inside `body`,
-  // inside a slow tool call) is cleaned up. Assigning at construction
-  // time (not after connect resolves) keeps a server that spawns and
-  // then hangs mid-handshake (connect never resolving, never throwing)
-  // reachable by the timeout path — the exact orphan class this watchdog
-  // exists to prevent.
-  //
-  // On a timeout the watchdog tears the spawned MCP server (Node bundle
-  // or JVM) down rather than letting it keep the CI step's log pipes /
-  // ports held past the node exit (the same orphan class the hermetic
-  // orchestrator guards). `client.close()` closes its transport, which
-  // kills the stdio child (the same teardown `closeQuietly` performs on
-  // the normal paths). We hold the exit a short grace window so the
-  // close lands, then exit with code 2 regardless (a wedged child must
-  // not keep us alive).
+  // The timeout owns every spawned client from construction through close.
   let activeClient;
-  // Install the watchdog FIRST so even a hang inside transport
-  // construction (rare but possible: bad cwd, env corruption) gets
-  // killed. The `finally` below clears the timer on every exit path —
-  // including the case where `client.close()` itself throws. Keeping the
-  // teardown out of the `try` means a throw on the success-path teardown
-  // does not invert the log to a FAIL and lose the body's success state.
+  // Install before connect; clear only after normal teardown.
   const watchdog = setTimeout(() => {
     console.error('FAIL: watchdog timeout (' + watchdogMs + 'ms)');
-    // Tear the spawned child down before exiting. `closeQuietly` never
-    // throws; the `.then`/`.catch` both arm the hard-exit fallback so a
-    // hung close can't keep the process alive.
+    // The fallback bounds a close that never settles.
     const hardExit = setTimeout(() => process.exit(2), 2000);
     hardExit.unref();
-    // Close the primary AND every registered secondary client so a hang
-    // in ANY in-process MCP child the body spawned is reaped, not just
-    // the runner-managed primary. `closeQuietly` never throws; wait for
-    // all closes to settle before the exit.
+    // Close primary and secondary clients before the timeout exit.
     const toClose = [];
     if (activeClient) toClose.push(activeClient);
     for (const aux of AUX_CLIENTS) toClose.push(aux);
@@ -242,20 +74,13 @@ async function runWithWatchdog({ watchdogMs, transportSpec, clientName }, body) 
     }
   }, watchdogMs);
 
-  // Spawn + connect via the shared primitive. A throw here (bad cwd, a
-  // malformed initialize envelope) is caught below and surfaces as
-  // exit 1.
+  // Transport and SDK initialization failures are conformance failures.
   let client;
   let exitCode;
   let bodyError;
   try {
     let transport;
-    // Capture the teardown handle via `onClient` — fired the instant the
-    // client is constructed, BEFORE connect awaits — so a hang during the
-    // initialize handshake is still reachable by the watchdog. The
-    // post-resolve `activeClient = client` below is redundant on the
-    // happy path but kept as a belt-and-braces guarantee (and to leave
-    // `client` bound for the `finally` teardown).
+    // Capture before connect; retain the resolved binding for finally.
     ({ client, transport } = await connectServer({
       transportSpec,
       clientName,
@@ -268,12 +93,7 @@ async function runWithWatchdog({ watchdogMs, transportSpec, clientName }, body) 
     exitCode = 1;
     bodyError = err;
   } finally {
-    // Best-effort teardown. A throw here is independent of the body
-    // outcome: if `client.close()` raises on a green body, we still
-    // exit 0 (the conformance assertions passed). If it raises on a
-    // failed body, the original `bodyError` is still the load-bearing
-    // signal and the close-error is purely cosmetic. `client` may be
-    // undefined if `connectServer` threw before constructing it.
+    // Preserve the body outcome if close itself reports an error.
     if (client) await closeQuietly(client);
     clearTimeout(watchdog);
     if (bodyError) {
@@ -404,35 +224,11 @@ async function assertJsonRpcErrorCodes(client) {
   }
 }
 
-// ---------------------------------------------------------------------
-// Tool-descriptor shape gate.
-//
-// Both `end-to-end-re-frame2-pair.cjs` and `end-to-end-story.cjs` walk the
-// catalogue with this shared gate, pinning cross-MCP-convention
-// invariants the SDK's ListToolsResultSchema does NOT model:
-//
-//   1. inputSchema.type === 'object'        (NAMING.md catalogue surface)
-//   2. inputSchema.properties has max-tokens (TOKEN-BUDGETS.md MUST)
-//   3. an :outputSchema map is declared
-//   4. an :annotations map with at least one classification hint set
-//
-// The two servers differ in EXACTLY one place: the annotations
-// classification set — whether `openWorldHint` counts as a classifier.
-// Both pass `allowOpenWorld: true`: re-frame2-pair-mcp's eval-cljs /
-// dispatch tools touch an open world, and story-mcp's `run-variant` /
-// `preview-variant` run the variant author's lifecycle events/fx which
-// can reach external systems unless stubbed (so story-mcp is not wholly
-// closed-world). The PER-TOOL open-world VALUES are pinned exactly by
-// `assertClassificationRatchet`'s `closed-world` list, so `allowOpenWorld`
-// only sets the "at-least-one-classifier" floor; it does not let a
-// closed-world tool flip open undetected. Sharing the loop here keeps the
-// gate single-maintained; a new invariant is added once, not twice.
-//
-// Throws on the first violation with a descriptive, server-agnostic
-// message (the tool name + the failed invariant). Returns nothing.
-// ---------------------------------------------------------------------
+// Descriptor floor not covered by the SDK schema: object input with the
+// shared budget arg, output schema, and at least one annotation hint. Exact
+// per-tool annotation values belong to assertClassificationRatchet.
 function assertDescriptorShape(tools, { allowOpenWorld } = {}) {
-  // 1 + 2. inputSchema is a map with type=object and a max-tokens slot.
+  // Object input and the universal budget argument.
   for (const t of tools) {
     if (!t.inputSchema || typeof t.inputSchema !== 'object') {
       throw new Error('tool ' + t.name + ' has no inputSchema');
@@ -454,7 +250,7 @@ function assertDescriptorShape(tools, { allowOpenWorld } = {}) {
     }
   }
 
-  // 3. outputSchema declared.
+  // Structured result schema.
   for (const t of tools) {
     if (!t.outputSchema || typeof t.outputSchema !== 'object') {
       throw new Error(
@@ -464,9 +260,7 @@ function assertDescriptorShape(tools, { allowOpenWorld } = {}) {
     }
   }
 
-  // 4. annotations map with at least one classification hint.
-  // openWorldHint counts as a classifier only when `allowOpenWorld` is
-  // set — the single per-server difference between the two harnesses.
+  // At least one host-visible classification hint.
   for (const t of tools) {
     if (!t.annotations || typeof t.annotations !== 'object') {
       throw new Error(
@@ -491,70 +285,17 @@ function assertDescriptorShape(tools, { allowOpenWorld } = {}) {
   }
 }
 
-// ---------------------------------------------------------------------
-// Per-descriptor CONTENT ratchet.
-//
-// `assertDescriptorShape` (above) pins that EVERY descriptor carries
-// SOME classification hint and a `max-tokens` PROP — but never WHICH
-// classifier, nor that the budget hint carries prose. The `tools/list`
-// name ratchet (`tool-names.json`, compared in each end-to-end-*.cjs)
-// pins WHICH tools exist. NEITHER pins per-tool CONTENT, so for an
-// UNCHANGED tool-set:
-//
-//   - a destructive write tool (restore-epoch, replace-app-db,
-//     register-variant, …) silently re-classified `readOnlyHint:true`
-//     / `destructiveHint` dropped still passes — `readOnlyHint` alone
-//     satisfies the "≥1 set" check. annotations are the TRUST SIGNAL an
-//     agent host uses to auto-approve a call, so a destructive tool
-//     re-labelled read-only is a real (if narrow) safety regression;
-//   - a tool that dropped its `max-tokens` budget-hint PROSE ships green
-//     — only the PROP presence is pinned, not the description text.
-//
-// This ratchet closes both gaps. `expected` is a per-server fixture
-// (`test/fixtures/<server>-classifications.json`):
-//
-//   - `classifications` — tool-name -> posture, one of:
-//       `read-only`   readOnlyHint===true  AND destructiveHint!==true
-//       `destructive` destructiveHint===true AND readOnlyHint!==true
-//       `neither`     readOnlyHint!==true  AND destructiveHint!==true
-//                     (session-pin / streaming tools — classified via
-//                      openWorldHint; pinning `neither` catches a
-//                      side-effecting tool that wrongly gained
-//                      readOnlyHint, masking its effect)
-//   - `closed-world`  — the EXHAUSTIVE open-world partition:
-//                       tools listed here MUST carry `openWorldHint:false`
-//                       (inline / no-runtime-reach tools, e.g.
-//                       get-re-frame2-pair-instructions); EVERY tool NOT
-//                       listed MUST carry `openWorldHint:true` (it reaches
-//                       the live browser / nREPL — an external process).
-//                       Both sides are pinned. Asserting only the `false`
-//                       side left a hole: a read-only/destructive tool that
-//                       reaches the runtime could drop `openWorldHint:true`
-//                       (or set it false) and still ship green, mislabelling
-//                       a live-reaching tool as contained and weakening the
-//                       MCP client trust/confirmation boundary. Pinning the
-//                       complement turns that regression RED.
-//
-// Also pins, per descriptor, that the `max-tokens` property carries a
-// NON-EMPTY `description` (the budget-hint prose — TOKEN-BUDGETS.md
-// §"Per-call override slot").
-//
-// The fixture's `classifications` key-set MUST match the live tool-set
-// EXACTLY (every tool pinned, no stale rows) — a tool present on the
-// wire but absent from the fixture (or vice-versa) trips, so a NEW tool
-// can't slip past unclassified and a REMOVED tool can't leave a dangling
-// row. Throws on the first violation with a server-agnostic message.
-// ---------------------------------------------------------------------
+// Exact descriptor-content ratchet. `classifications` maps every advertised
+// tool to read-only, destructive, or neither. `closed-world` is the false
+// side of an exhaustive openWorldHint partition; all other tools must set
+// openWorldHint true. Every max-tokens property also needs useful prose.
 function assertClassificationRatchet(tools, expected) {
   const table = (expected && expected.classifications) || {};
   const closedWorld = new Set((expected && expected['closed-world']) || []);
   const liveNames = tools.map((t) => t.name).sort();
   const pinnedNames = Object.keys(table).sort();
 
-  // 0. The fixture must pin EXACTLY the live tool-set — no unclassified
-  // new tool, no stale removed row. (The name ratchet already pins the
-  // live set against tool-names.json; this keeps the classification
-  // fixture in lockstep so a new tool can't ship unclassified.)
+  // Classification rows and the live catalogue must have identical keys.
   if (JSON.stringify(liveNames) !== JSON.stringify(pinnedNames)) {
     const missing = liveNames.filter((n) => !table[n]);
     const stale = pinnedNames.filter((n) => !tools.some((t) => t.name === n));
@@ -567,12 +308,7 @@ function assertClassificationRatchet(tools, expected) {
     );
   }
 
-  // 0b. `closed-world` entries must be a subset of `classifications` (now
-  // known exact-equal to the live tool-set per check 0 above). Unlike a
-  // stale `classifications` row, a dangling `closed-world` entry naming a
-  // renamed/removed tool is NEVER visited by the per-tool loop below (it
-  // only iterates live `tools`), so without this check it survives a
-  // rename undetected — silently tolerated instead of tripping RED.
+  // The partition cannot name a tool outside that exact catalogue.
   const staleClosedWorld = Array.from(closedWorld).filter(
     (n) => !Object.prototype.hasOwnProperty.call(table, n),
   );
@@ -591,8 +327,7 @@ function assertClassificationRatchet(tools, expected) {
     const ro = a.readOnlyHint === true;
     const de = a.destructiveHint === true;
 
-    // 1. The load-bearing classification: the EXACT readOnly/destructive
-    // posture. A flipped or dropped hint trips here.
+    // Exact readOnly/destructive posture.
     if (posture === 'read-only') {
       if (!ro || de) {
         throw new Error(
@@ -638,19 +373,9 @@ function assertClassificationRatchet(tools, expected) {
       );
     }
 
-    // 2. openWorld posture — BOTH sides of the partition. The fixture's
-    // `closed-world` list IS the exhaustive partition: a tool is
-    // closed-world (no runtime reach) OR open-world (reaches the live
-    // browser/nREPL — an external process). Pinning only the `false` side
-    // would leave a hole — a read-only/destructive tool that reaches the
-    // runtime could DROP `openWorldHint:true` (or set it false) and still
-    // ship GREEN, mislabelling a live-reaching tool as contained and
-    // weakening the MCP client trust/confirmation boundary. Pinning both
-    // sides means the complement can't regress.
+    // Both sides of the exhaustive open-world partition.
     if (closedWorld.has(t.name)) {
-      // 2a. Closed-world (inline / no runtime reach) — these ship static /
-      // inline / server-local content; openWorldHint MUST be false so a
-      // host doesn't treat them as reaching an external world.
+      // Inline or server-local content.
       if (a.openWorldHint !== false) {
         throw new Error(
           'tool ' + t.name + ' is pinned closed-world (inline / no runtime ' +
@@ -659,11 +384,7 @@ function assertClassificationRatchet(tools, expected) {
         );
       }
     } else {
-      // 2b. Open-world (every NON-closed tool reaches the live browser /
-      // nREPL — an external process) — openWorldHint MUST be true so a
-      // host applies the appropriate confirmation ceremony instead of
-      // treating the call as contained on-box. A missing or false hint on
-      // a live-reaching tool is the exact false-green this side closes.
+      // Every non-closed tool reaches an external runtime.
       if (a.openWorldHint !== true) {
         throw new Error(
           'tool ' + t.name + ' is open-world (reaches the live browser / ' +
@@ -677,10 +398,7 @@ function assertClassificationRatchet(tools, expected) {
       }
     }
 
-    // 3. Budget-hint PROSE — the `max-tokens` property must carry a
-    // non-empty description (TOKEN-BUDGETS.md §"Per-call override slot").
-    // `assertDescriptorShape` pins the PROP presence; this pins that the
-    // hint text wasn't dropped/emptied.
+    // The universal budget slot must explain its use.
     const props = (t.inputSchema && t.inputSchema.properties) || {};
     const mt = props['max-tokens'];
     if (!mt || typeof mt.description !== 'string' || mt.description.trim().length === 0) {
@@ -694,55 +412,14 @@ function assertClassificationRatchet(tools, expected) {
   }
 }
 
-// ---------------------------------------------------------------------
-// SDK callTool() coverage ratchet.
-//
-// The name ratchet (`tool-names.json`) pins WHICH tools the catalogue
-// advertises; `assertDescriptorShape` / `assertClassificationRatchet`
-// pin the descriptor METADATA of every advertised tool. NEITHER pins
-// that a tool was ever actually INVOKED through `Client.callTool()` —
-// so a regression in a tool's callTool envelope, outputSchema /
-// structuredContent shape, or argument handling ships GREEN for any
-// advertised tool the conformance workflow only LISTS but never CALLS.
-// That is the false-green class this ratchet exists to catch: an
-// advertised Story or Pair tool that is descriptor-only in conformance.
-//
-// The harness records every tool name it
-// drove through `callTool()` (in a `Set`), then calls this gate with:
-//
-//   - `advertised`  — the live `tools/list` names (sourced from the
-//                     server's own `tool-names.json` fixture, the same
-//                     single-source the name ratchet compares against).
-//   - `called`      — the Set of names the workflow SDK-invoked.
-//   - `exclusions`  — a REVIEWED table: `{ "<tool>": "<rationale>" }`.
-//                     Each row names a tool that is intentionally NOT
-//                     SDK-call-covered HERE and states WHERE its
-//                     alternative coverage lives (a live-only gate, a
-//                     hermetic harness, a lower-layer unit/fixture pin).
-//                     A bare-string rationale is mandatory and must be
-//                     non-empty — an empty exclusion is a silent hole.
-//
-// The gate fails when a tool is NEITHER called NOR excluded-with-
-// rationale, AND when the exclusion table carries a stale row (a name
-// that is excluded but was also called, or that the catalogue no longer
-// advertises) — so the table cannot rot into a rubber stamp. A NEW
-// advertised tool that the author forgets to probe trips RED with a
-// message naming it and pointing at the two ways to green it (add a
-// probe, or add a reviewed exclusion row).
-//
-// Throws on the first violation with a descriptive, server-agnostic
-// message. Returns nothing.
-// ---------------------------------------------------------------------
+// Every advertised tool must be SDK-called or carry a non-empty rationale
+// naming its alternative coverage. Stale and contradictory exclusions fail.
 function assertCallCoverageRatchet({ advertised, called, exclusions = {} }) {
   const advertisedSet = new Set(advertised);
   const calledSet = called instanceof Set ? called : new Set(called);
   const excludedNames = Object.keys(exclusions);
 
-  // 0. The exclusion table must not carry stale rows. A row whose tool
-  // is not advertised is a dangling rationale (the tool was renamed /
-  // removed); a row whose tool WAS called is a contradiction (it claims
-  // "not covered here" but the workflow drove it) — both mean the table
-  // drifted from reality and must be corrected, not silently tolerated.
+  // Exclusions must be current and genuinely uncalled.
   const staleNotAdvertised = excludedNames.filter((n) => !advertisedSet.has(n));
   const staleAlsoCalled = excludedNames.filter((n) => calledSet.has(n));
   if (staleNotAdvertised.length > 0 || staleAlsoCalled.length > 0) {
@@ -756,8 +433,7 @@ function assertCallCoverageRatchet({ advertised, called, exclusions = {} }) {
     );
   }
 
-  // 1. Every excluded row MUST carry a non-empty string rationale. An
-  // empty / non-string rationale is a silent hole dressed as a decision.
+  // Alternative coverage must be reviewable.
   const blankRationale = excludedNames.filter(
     (n) => typeof exclusions[n] !== 'string' || exclusions[n].trim().length === 0,
   );
@@ -771,10 +447,7 @@ function assertCallCoverageRatchet({ advertised, called, exclusions = {} }) {
     );
   }
 
-  // 2. The load-bearing check: every advertised tool is either driven
-  // through callTool() or carries a reviewed exclusion. An advertised
-  // tool that is neither trips RED — the descriptor-only false-green
-  // this ratchet exists to catch.
+  // Descriptors alone do not satisfy call-envelope coverage.
   const excludedSet = new Set(excludedNames);
   const uncovered = advertised.filter(
     (n) => !calledSet.has(n) && !excludedSet.has(n),
@@ -798,19 +471,7 @@ function assertCallCoverageRatchet({ advertised, called, exclusions = {} }) {
   }
 }
 
-// ---------------------------------------------------------------------
-// Envelope readers / coverage tracker.
-//
-// Three SDK-envelope-shape helpers shared by every conformance body.
-// None pins a per-test contract — they are pure mechanics feeding the
-// shared ratchets above, so they live here once.
-// ---------------------------------------------------------------------
-
-// Concatenate the `.text` of every content block from an SDK callTool
-// response into one newline-joined string. Tolerates a missing / non-
-// array `content` (returns '') so a malformed envelope reads as empty
-// rather than throwing — callers grep the whole string for sentinels /
-// EDN, so a no-text block must contribute nothing, not crash the search.
+// Concatenate text blocks; non-text or absent content contributes nothing.
 function responseText(resp) {
   if (!resp || !Array.isArray(resp.content)) return '';
   return resp.content
@@ -818,15 +479,7 @@ function responseText(resp) {
     .join('\n');
 }
 
-// SDK callTool() coverage tracker. Wrap the raw SDK client
-// in a Proxy that records the tool name on each `callTool({name,…})` into
-// a fresh `called` Set and transparently delegates every other client
-// member (listTools, getServerVersion, request, close, …) to the real
-// client — so existing call sites read unchanged. Returns
-// `{ client, called }`: drive the workflow through `client`, then feed
-// `called` to `assertCallCoverageRatchet`. A callTool that bypasses the
-// proxy can't quietly erode coverage — the tool simply goes unrecorded
-// and the ratchet catches it as uncovered.
+// Transparent client proxy that records each callTool name.
 function track(rawClient) {
   const called = new Set();
   const client = new Proxy(rawClient, {
@@ -844,37 +497,13 @@ function track(rawClient) {
   return { client, called };
 }
 
-// Read a callTool response's `structuredContent` through
-// `decodeDedupEnvelope`. A dedup-eligible tool ships its structured
-// payload wrapped in a `{:rf.mcp/dedup-table …}` envelope that a real MCP
-// client expands via `de-dupe.core/expand` before reading semantic slots;
-// this mirrors that. Idempotent on payloads without the marker, so it is
-// safe to route EVERY structuredContent read through it — a tool gaining
-// or losing dedup-eligibility doesn't break the suite (the slot is
-// reachable either way).
+// Decode optional structural dedup before reading semantic slots.
 function structured(resp) {
   return decodeDedupEnvelope((resp && resp.structuredContent) || {});
 }
 
-// Universal isError <-> :ok? cross-check. The spec contract
-// (spec/003-Tool-Catalogue.md §381) is universal: EVERY `:ok? false`
-// structuredContent MUST carry `isError === true`, and every `:ok? true`
-// MUST carry a falsy isError. This cross-check pins the contract for an
-// ARBITRARY structured envelope at the SDK boundary — a single gate
-// covering every tool, rather than tool-specific + outcome-specific
-// checks — catching any tool that decouples its isError flag from its
-// `:ok?` slot (the class the pair-mcp read-dom/read-ui envelope
-// belonged to, rf2-87h71e / rf2-q7cavs).
-//
-// Reads `:ok?` through `structured()` — the shared dedup-decoder —
-// rather than the raw wire `resp.structuredContent`. A dedup-eligible
-// tool ships its structured payload wrapped in
-// `{:rf.mcp/dedup-table {...}}`; reading the raw field finds no
-// top-level `:ok?` slot at all, so this cross-check would silently no-op
-// on exactly the envelopes a real MCP client (which always expands the
-// dedup table before reading semantic slots) would grade (rf2-6i2yi4
-// finding 1). Tolerates an envelope with no `:ok?` slot (a non-`:ok?`-
-// shaped result is out of scope — there is nothing to cross-check).
+// Universal SDK-boundary cross-check after dedup decoding. Results without
+// an :ok? slot are outside this relation.
 function assertIsErrorMatchesOk(label, resp) {
   const sc = structured(resp);
   if (sc === undefined || sc === null || typeof sc !== 'object') return;

--- a/tools/mcp-conformance/wire-vocab/README.md
+++ b/tools/mcp-conformance/wire-vocab/README.md
@@ -1,215 +1,130 @@
-# tools/mcp-conformance/wire-vocab
+# Cross-MCP wire vocabulary
 
-**Cross-MCP wire-vocabulary conformance test.** Source: rf2-j2z7o.
+This JVM suite checks the shared vocabulary consumed across the
+re-frame2 MCP servers and their framework-facing projections. It is
+complementary to the Node SDK tests: Node owns protocol envelopes and
+workflows; this suite owns EDN value shapes, canonical names, and source
+alignment.
 
-## What this is
-
-The MCP servers under `tools/` — `re-frame2-pair-mcp` and `story-mcp` —
-share a reserved cross-server **wire vocabulary**: namespaced map keys
-that an agent recognises identically across every server it talks to.
-
-(Historical: a third server `xray-mcp` was envisaged in the vocabulary;
-it was dropped per rf2-hvl1g — AI agent access to Xray state flows via
-`re-frame2-pair-mcp` against the framework-published Xray runtime API.
-A prior false-start drop was tracked under rf2-bu21t; rf2-hvl1g is the
-final close-out.)
-
-There are **six top-level wire markers** (the `canonical-markers` table
-in `wire_vocab_test.clj` is the source of truth) plus one embedded
-fetch-handle tag (`:rf.elision/at`, pinned inside the
-`:rf.size/large-elided` body's `:handle` slot — not a standalone marker
-an agent encounters at the top level of a payload):
-
-```
-:rf.mcp/overflow       — token-budget overflow marker
-:rf.mcp/summary        — tree-summary lazy-mode marker
-:rf.mcp/dedup-table    — structural-dedup wrapper
-:rf.mcp/diff-from      — diff-encoded :db-after marker
-:rf.size/large-elided  — size-elision wire marker
-:rf.mcp/cache-hit      — per-session response-cache hit marker
-:rf.elision/at         — embedded fetch-handle tag inside the
-                         :rf.size/large-elided body's :handle slot
-                         (pinned via ElisionMarkerBody, not a
-                         standalone top-level marker)
-```
-
-Without conformance enforcement, two servers could each ship the
-"overflow" concept with slightly different shapes (`:cap-tokens` vs
-`:cap_tokens`; `:hint` as a string vs as a keyword vs absent) and an
-agent host would have to special-case per server. The cross-server
-value proposition collapses if every server invents its own dialect.
-
-This test is the conformance gate. It asserts:
-
-1. **One canonical Malli schema per marker.** The schemas live in
-   `wire_vocab/schemas.clj` (the cross-family ones) or co-located with
-   their focused test namespace (the marker-family-local ones), derived from
-   [`spec/Spec-Schemas.md` §`:rf/elision-marker`](../../../spec/Spec-Schemas.md)
-   and [`tools/re-frame2-pair-mcp/src/.../tools.cljs`](../../re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools.cljs)
-   (re-frame2-pair-mcp's `overflow-payload`, `tree-summary`, `dedup-value`,
-   `diff-encode-db-after`).
-2. **Per-server fixtures all conform.** Each marker has a fixture
-   representing each server's actual / spec'd emission shape. They
-   MUST validate against the same schema.
-3. **Source-text vocabulary pin.** A grep against each server's source
-   (`re-frame2-pair-mcp/src/`) asserts the canonical literal appears,
-   and asserts that no near-miss spelling (snake_case, pluralised,
-   namespace-with-underscores) appears.
-4. **story-mcp uncontracted-marker tripwire.** story-mcp emits two
-   cross-MCP markers today — `:rf.mcp/dedup-table` (rf2-90eft, mirror
-   of pair-mcp's rf2-obpa9 wire-boundary structural dedup) and
-   `:rf.mcp/overflow` (rf2-yxgcsz, its wire-boundary token-cap, sharing
-   pair-mcp's `mcp-base.cap/apply-cap` builder) — and otherwise uses its
-   own `:rf.story/*` / `:rf.assert/*` / `:rf.error/*` vocabularies. A
-   test asserts that NO UNCONTRACTED cross-MCP marker leaks into
-   story-mcp source, so the day it adopts another marker the test fails
-   loud and forces the reviewer to register a fixture and a source file
-   (rather than diverge silently).
-
-## Files
-
-- `deps.edn` — pure JVM Clojure, one dep: `metosin/malli`.
-- `test/re_frame/mcp_conformance/wire_vocab/schemas.clj` — the canonical
-  cross-MCP marker schemas + the `canonical-markers` catalogue (the
-  contract data shared across test namespaces). Split out by rf2-7ckmwx.
-- `test/re_frame/mcp_conformance/wire_vocab/source_pins.clj` — the shared
-  source-text pin inventories (`emit-source-files` / `doc-source-files` /
-  `all-source-files`) + the `marker-key->literal` / `near-miss-variants`
-  helpers. Split out by rf2-7ckmwx.
-- `test/re_frame/mcp_conformance/fixtures.clj` — classpath-walk + slurp
-  ceremony + the filesystem-derived story-mcp source inventory + the
-  `strip-comments-and-strings` documentation-vs-emission discriminator.
-- `test/re_frame/mcp_conformance/wire_vocab_test.clj` — the CORE
-  wrapper-marker contract: fixture-conformance over `canonical-markers`,
-  the per-marker negative/live-emission gates, the marker-literal source
-  pins, the JS cross-encoding pin, server-coverage, the story-mcp
-  inventory tripwires, and the envelope indicator-field slots.
-- Focused per-family test namespaces (the NON-wrapper markers, split out
-  by rf2-7ckmwx): `cursor_stale_test.clj`, `result_envelope_test.clj`,
-  `redacted_sentinel_test.clj`, `progress_notification_test.clj`,
-  `event_bundle_test.clj`. Each requires the shared `schemas` +
-  `source-pins` support nses; a marker-family-LOCAL schema
-  (`ResultEnvelope`, `EventBundle`) stays co-located with its tests.
-- `indicator_field_test.clj`, `slot_name_test.clj`, `verb_vocab_test.clj`
-  — independent cross-MCP vocabulary surfaces (pre-existing).
-- `reply_envelope_test.clj` — the EP-0011 reply-envelope TRACE-egress
-  vocabulary gate (rf2-mrfvg2). See §EP-0011 coverage boundary below.
-
-## EP-0011 reply-envelope coverage boundary (rf2-mrfvg2)
-
-`reply_envelope_test.clj` pins the additive `:rf.reply/*` trace vocabulary
-an MCP consumer reads off a `trace-window` / event-bundle `:trace-events`
-reply-envelope row — the EP-0011 uniform reply envelope is named among
-Tool-Pair's record-shaped off-box egress
-([`spec/Tool-Pair.md`](../../re-frame2-pair-mcp/spec) §`project-egress`),
-and Managed-Effects property 9 requires managed-async families to emit trace
-rows FROM reply-envelope facts. Before this gate, `tools/mcp-conformance`
-validated only the MCP wrapper / event-bundle envelope + a counter dispatch — no
-managed-async reply-envelope trace CONTENT.
-
-It pins, in the same schema + fixture + source-pin + near-miss shape as the
-wrapper markers above:
-
-- a canonical Malli schema (`ReplyEnvelopeTraceRow`) for the MCP-visible
-  reply-envelope trace row: the additive `:rf.reply/status` /
-  `:rf.reply/work-id` / `:rf.reply/work-status` keys, the canonical bare
-  `:work/id` join key (which MUST equal `:rf.reply/work-id`), and the
-  carried/current stale-suppression correlation gate;
-- fixtures matching the REAL production emissions (HTTP
-  `:rf.http/stale-suppressed`, resource `:rf.resource/stale-suppressed`,
-  machine), so a tag-map drift trips the gate;
-- a SOURCE-text pin that the additive `:rf.reply/*` keys appear as DATA in
-  the production emit sites (HTTP transport, resources events, machine
-  transition, routing nav-token) — so a substrate / family rename trips the
-  gate even though the literals live in `implementation/`, not in
-  re-frame2-pair-mcp;
-- a near-miss anti-pin so a snake_case / pluralised / predicate spelling
-  fails;
-- schema fail-closed checks for a scalar (non-tuple) work-id, an
-  off-vocabulary status / work-status, and a dropped required reply key.
-
-**What it does NOT cover (complementarity, not duplication):** it does not
-re-validate the whole managed-effect suite. Family-internal correctness +
-the runtime trace emission live in the per-family `*-reply-lowering-*` suites
-and the resources / machines runtime tests; the cross-family reply
-VOCABULARY consistency lives in `implementation/reply-conformance`; the
-EP-0015 reply egress projection lives there too; Xray's consumer-side reply
-panel is `tools/xray`. This gate is narrowly the MCP-egress-visible contract
-that those `:rf.reply/*` keys reach a `trace-window` / `subscribe` consumer
-un-renamed. The live `subscribe` end-to-end path
-(`test/live-re-frame2-pair-subscribe.cjs`) is the runtime counterpart; this
-JVM gate is the cheap, hermetic vocabulary pin.
-
-## Adding a new cross-MCP marker — which files to touch
-
-For a **wrapper-shaped** marker (`{<key> <body>}` — the agent walks the
-body):
-
-1. Add the canonical Malli schema to `wire_vocab/schemas.clj`.
-2. Add a `canonical-markers` entry there: `:key` + `:schema` +
-   per-server `:fixtures` + `:servers`.
-3. If the literal's source-of-truth home or doc-source differs from the
-   existing markers, extend the inventories in `wire_vocab/source_pins.clj`.
-
-The generic fixture-conformance + source-pin + near-miss sweeps in
-`wire_vocab_test.clj` then cover it automatically.
-
-For a **non-wrapper** marker (a `:reason` value like `:rf.mcp/cursor-stale`,
-a bare scalar like `:rf/redacted`, a tagged-union like `:rf.mcp/result`,
-or a streaming-notification shape):
-
-1. Create a focused `<marker>_test.clj` namespace (use the existing
-   `cursor_stale_test.clj` / `result_envelope_test.clj` /
-   `redacted_sentinel_test.clj` / `progress_notification_test.clj` /
-   `event_bundle_test.clj` as templates), requiring the shared
-   `wire_vocab.schemas` + `wire_vocab.source-pins` support nses.
-2. Keep the schema co-located in that test namespace when it is
-   referenced only by that family; promote it to `schemas.clj` only if a
-   second namespace needs it.
-3. Cover all five conformance layers the family templates show: schema +
-   fixture, live-emission gate (when a JVM-reachable builder exists),
-   source-text emit/doc pin, JS cross-encoding pin (when a live `.cjs`
-   harness re-encodes the shape), and the near-miss anti-pin.
-
-New `*_test.clj` namespaces are auto-discovered by the cognitect
-test-runner — no registration needed.
-
-## How to run
-
-From this directory:
+Run it from this directory:
 
 ```bash
 clojure -M:test
 ```
 
-The test:
+## What is pinned
 
-- Resolves the repo root from `*file*` so it works from any CWD.
-- Reads each server's source/spec via `slurp`.
-- Validates each fixture against its canonical schema via
-  `malli.core/validate`.
-- Greps for canonical and near-miss spellings.
+`wire_vocab/schemas.clj` owns the generic wrapper-marker catalogue:
 
-Total run time on a cold JVM: ~3-5 seconds.
+```text
+:rf.mcp/overflow
+:rf.mcp/summary
+:rf.mcp/dedup-table
+:rf.mcp/diff-from
+:rf.size/large-elided
+:rf.mcp/cache-hit
+```
 
-## Why JVM (not Node SDK)
+Focused namespaces own shapes that are not generic one-key wrappers,
+including:
 
-The sibling `tools/mcp-conformance/test/end-to-end-*.cjs` files drive
-each server through the official MCP SDK client (handshake +
-`tools/list` + `tools/call` against a live process). That's *protocol*
-conformance.
+- `:rf.mcp/cursor-stale` result reasons;
+- `:rf.mcp/result` tagged results;
+- `:rf/redacted`;
+- progress notifications and event bundles;
+- reply-envelope trace rows;
+- suppression indicator fields and shared input slots;
+- operating-frame addresses and egress profiles;
+- tool-name verbs, infinite-trace operations, and trace-catalogue
+  duplicate-key linting.
 
-This test is *vocabulary* conformance — the shapes of EDN values a
-server emits as response payloads. It does NOT need a live server: the
-schemas are normative, the fixtures are authored from each server's
-spec/source, and the grep step pins those authored fixtures to the
-actual source/spec text. Two complementary gates; one wire.
+The focused schema stays beside its tests unless more than one namespace
+needs it. Shared wrapper schemas and their fixture catalogue stay in
+`wire_vocab/schemas.clj`.
 
-## When this test fails
+## Evidence layers
 
-| Failing assertion | Likely cause | Fix |
-|---|---|---|
-| Fixture doesn't validate against schema | Server (or spec) changed the marker body shape | Update both the schema AND the relevant fixture; the divergence is the bug |
-| Literal missing from server source | Marker was renamed in one server | Pick the canonical form, rename the other server, update the schema |
-| Near-miss variant present | Vocabulary drift (snake_case spelling crept in) | Rename back to the canonical form |
-| story-mcp uncontracted-marker tripwire fires | story-mcp now emits a NEW cross-MCP marker | Add story-mcp to the marker's `:servers` set, add a fixture, extend `server-source-files` |
+Not every vocabulary family has a reachable builder on the JVM, so the
+suite composes several independent checks:
+
+1. **Schema and fixtures.** Representative emissions must validate
+   against one canonical Malli shape.
+2. **Live builder calls.** When the canonical encoder or builder is on
+   the JVM classpath, the test drives it and validates the emitted value.
+3. **Emission-source pins.** Canonical literals must occur as data at the
+   contracted emit sites.
+4. **Documentation pins.** Where a public server contract owns a literal,
+   its source must describe the canonical spelling.
+5. **Near-miss rejection.** Snake-case, pluralized, or otherwise
+   confusing spellings are rejected in the relevant source inventory.
+6. **Cross-encoding pins.** When a Node live test re-encodes a body, the
+   JVM suite checks that its assertion names every required field.
+
+Fixtures are evidence, not production owners. A source pin alone proves
+only that a literal exists, so builder tests are preferred whenever the
+real emitter can be invoked hermetically.
+
+## Inventory ownership
+
+- `wire_vocab/schemas.clj`: shared wrapper schemas and
+  `canonical-markers`.
+- `wire_vocab/source_pins.clj`: contracted emit/doc source inventories
+  and near-miss helpers.
+- `fixtures.clj`: repository path resolution, filesystem inventories,
+  and comment/string stripping for source scans.
+- `wire_vocab_test.clj`: generic wrapper-marker checks and story-mcp's
+  uncontracted-marker tripwire.
+- focused `*_test.clj` namespaces: non-wrapper vocabulary families.
+- each server's `test/fixtures/tool-names.json`: advertised tool names;
+  `verb_vocab_test.clj` consumes those files directly.
+
+Do not add a second hand-maintained tool or source inventory to a runner.
+Extend the owner above and derive from it.
+
+## Cross-server marker adoption
+
+story-mcp currently emits the shared dedup and overflow wrappers. The
+uncontracted-marker tripwire scans its tool sources for other `:rf.mcp/*`
+or `:rf.size/*` literals. When story-mcp adopts another shared marker,
+the change must register that server in the canonical marker entry and
+provide a conforming fixture and source pin. The failure is an adoption
+prompt, not evidence that the new marker spelling is acceptable.
+
+## Reply-envelope boundary
+
+`reply_envelope_test.clj` checks the MCP-visible reply facts carried in
+trace rows: `:rf.reply/status`, `:rf.reply/work-id`,
+`:rf.reply/work-status`, the canonical `:work/id` tuple, and stale
+suppression correlation. It validates cross-family fixtures and pins the
+production emit sites.
+
+Managed-effect behaviour remains owned by each implementation family and
+`implementation/reply-conformance`. This suite checks only that the
+shared reply vocabulary reaches MCP trace consumers without renaming or
+shape drift.
+
+## Adding vocabulary
+
+For a generic wrapper marker:
+
+1. add its schema and `canonical-markers` entry to
+   `wire_vocab/schemas.clj`;
+2. include a fixture for every contracted server;
+3. extend the emit/doc source inventories when the existing sets do not
+   cover its owners; and
+4. add a live-builder assertion when the canonical builder is available.
+
+The generic fixture, source, server-coverage, and near-miss sweeps then
+apply automatically.
+
+For a non-wrapper family:
+
+1. add a focused `<family>_test.clj` namespace;
+2. keep a single-family schema local;
+3. cover the applicable evidence layers above; and
+4. rely on test-runner discovery rather than registering the namespace
+   in another list.
+
+When a gate fails, reconcile the production owner and the canonical
+schema together. Updating only a fixture hides the divergence instead of
+resolving it.

--- a/tools/mcp-conformance/wire-vocab/deps.edn
+++ b/tools/mcp-conformance/wire-vocab/deps.edn
@@ -1,10 +1,5 @@
-;; tools/mcp-conformance/wire-vocab — cross-MCP wire-vocabulary
-;; conformance test (rf2-j2z7o).
-;;
-;; A pure-JVM Clojure test that pins the **cross-server wire-marker
-;; vocabulary** shared by re-frame2-pair-mcp and story-mcp (the
-;; `canonical-markers` table in wire_vocab_test.clj is the source of
-;; truth — six top-level wrapper markers):
+;; Pure-JVM cross-MCP vocabulary conformance. `canonical-markers` in
+;; wire_vocab/schemas.clj owns these six generic wrapper markers:
 ;;
 ;;   :rf.mcp/overflow      — token-budget overflow (mechanism 1)
 ;;   :rf.mcp/summary       — tree-summary lazy mode (mechanism 4)
@@ -12,122 +7,38 @@
 ;;   :rf.mcp/diff-from     — diff-encoded epochs
 ;;   :rf.size/large-elided — size-elision wire marker
 ;;   :rf.mcp/cache-hit     — per-session response-cache hit marker
-;;   :rf.elision/at        — size-elision fetch handle
-;;
-;; The test asserts a single canonical schema per marker, validates
-;; fixtures representing each server's observed emission shape against
-;; the canonical schema, and grep-pins the source/spec files so a
-;; per-server vocabulary drift trips this gate. See README.md.
-;;
-;; Why a separate JVM artefact inside tools/mcp-conformance/?
-;; The sibling end-to-end-*.js tests drive each server through the MCP
-;; SDK client — they are Node-side. This wire-vocab test is pure data:
-;; a Malli-style schema validated against authored fixtures, plus a
-;; grep against source files. JVM Clojure is the cheaper substrate for
-;; that shape (no SDK install, no server boot, ~100ms test run).
-;;
-;; Bundle isolation: the artefact is test-only and never on a consumer's
-;; runtime classpath.
+;; Other vocabulary families, including :rf.elision/at, use focused test
+;; namespaces. See README.md for the ownership and evidence layers. This
+;; artefact is test-only and never enters a consumer runtime classpath.
 {:paths []
 
  :deps  {org.clojure/clojure  {:mvn/version "1.12.0"}
-         ;; Malli for schema validation. Already on the implementation's
-         ;; classpath (used by tools/story-mcp); pinning the same version
-         ;; here so the schema syntax matches.
+         ;; Canonical schema validation.
          metosin/malli        {:mvn/version "0.16.4"}
-         ;; data.json for the verb-vocab linter (rf2-vkx7m) — reads each
-         ;; server's canonical `tool-names.json` fixture to lint against
-         ;; the NAMING.md verb catalogue.
+         ;; Reads each server's canonical tool-name fixture for verb linting.
          org.clojure/data.json {:mvn/version "2.5.0"}}
 
  :aliases
- ;; All fixtures are inlined in `wire_vocab_test.clj` (as the `:fixtures`
- ;; slot on `canonical-markers`) and in the sibling test files —
- ;; no `fixtures/` directory exists. A standalone fixture-tree would
- ;; be more work than the inline form is currently worth: the fixtures
- ;; live next to their schemas and the test files are small enough
- ;; (rf2-ikjrr).
  {:test {:extra-paths ["test"]
-         :extra-deps  {;; rf2-try1x — silent-on-success reporter.
-                       day8/re-frame2-test-quiet
+         :extra-deps  {day8/re-frame2-test-quiet
                        {:local/root "../../../implementation/test-quiet"}
                        io.github.cognitect-labs/test-runner
                        {:git/tag "v0.5.1" :git/sha "dfb30dd"}
-                       ;; rf2-80y2h — the canonical `:rf.mcp/diff-from`
-                       ;; encoder so the wire-vocab gate can assert LIVE
-                       ;; emission (the real encoder actually producing
-                       ;; the marker), not only fixture+grep coverage.
-                       ;; The grep pin only checks the literal exists in
-                       ;; `mcp-base/vocab.cljc`; without a live-emission
-                       ;; gate a tool that stopped diff-encoding
-                       ;; `:db-after` would pass every conformance check.
+                       ;; Canonical diff and overflow builders.
                        day8/re-frame2-mcp-base
                        {:local/root "../../mcp-base"}
-                       ;; rf2-x0pr0 — the canonical structural-dedup
-                       ;; encoder so the `:rf.mcp/dedup-table` gate can
-                       ;; drive the REAL `de-dupe.core/de-dupe-eq` and
-                       ;; assert (a) its output validates against the
-                       ;; tightened `DedupTable` schema and (b) the
-                       ;; emitted root cache-id agrees byte-for-byte with
-                       ;; the Node decoder's `ROOT_CACHE_ID`
-                       ;; (`lib/dedup-envelope.cjs`). Lockstep on the same
-                       ;; tag pair-mcp + story-mcp pin so the gate sees
-                       ;; the same algorithm the servers emit.
+                       ;; Canonical structural-dedup encoder.
                        day8/de-dupe
                        {:git/url "https://github.com/day8/de-dupe.git"
                         :git/tag "v0.3.0"
                         :git/sha "367de784faf13c710a895bed867f36a36e594a2a"}
-                       ;; rf2-2js41 finding 1 — `:rf.mcp/cursor-stale` is
-                       ;; a MULTI-server reason value: pair-mcp emits it
-                       ;; on epoch-ring rotation, story-mcp emits the SAME
-                       ;; reason when a Docs `list-*` registry changes
-                       ;; between cursor pages. Both delegate to the
-                       ;; shared `mcp-base/cursor.cljc/cursor-stale-result`.
-                       ;; This dep puts story-mcp's own
-                       ;; `re-frame.story-mcp.tools.cursor/cursor-stale-result`
-                       ;; on the classpath so the gate can drive the
-                       ;; SECOND server's builder LIVE (mirroring the
-                       ;; pair-mcp + diff-encode + de-dupe live-emission
-                       ;; gates) — closing the false-green hole where a
-                       ;; story-mcp cursor-stale drift was caught only by
-                       ;; story-mcp's local unit tests, not by the
-                       ;; cross-MCP vocabulary surface. `:local/root` (not
-                       ;; an `:extra-paths` to story-mcp's `src`) is the
-                       ;; idiomatic, deprecation-warning-free form; the
-                       ;; transitive story/implementation tree it pulls is
-                       ;; the cost of validating the real builder.
+                       ;; Story's cursor-stale builder.
                        day8/re-frame2-story-mcp
                        {:local/root "../../story-mcp"}
-                       ;; rf2-hvn83u — the canonical wire-elision walker
-                       ;; (`re-frame.elision/elide-wire-value`) so the
-                       ;; `:rf.size/large-elided` gate can drive the REAL
-                       ;; emitter LIVE over a frame-declared `:large` slot
-                       ;; and validate the emitted marker against the
-                       ;; `ElisionMarker` schema. Without this gate the
-                       ;; marker was FIXTURE+grep only — exactly why the
-                       ;; pre-EP-0015 `:reason :schema` pin sat stale and
-                       ;; VACUOUS (the canonical schema validated only the
-                       ;; impossible `:schema` shape while the runtime
-                       ;; emitted `:frame`/`:marks`). `:local/root` to core
-                       ;; (not the transitive story-mcp pull) makes the
-                       ;; classpath dependency intentional, mirroring the
-                       ;; diff-encode + de-dupe live-emission gates.
+                       ;; Framework elision walker.
                        day8/re-frame2
                        {:local/root "../../../implementation/core"}
-                       ;; rf2-9wvwpa — the SECOND framework emitter of the
-                       ;; `:rf.size/large-elided` marker:
-                       ;; `re-frame.schemas.validate/validate-event!`'s
-                       ;; validation-failure size-safety arm (Spec 010
-                       ;; §`:large?`). hvn83u's live gate drove only the
-                       ;; `re-frame.elision/elide-wire-value` walker; the
-                       ;; schemas-artefact emitter sat fixture-free — exactly
-                       ;; the blind spot that let `validate.cljc` ship a
-                       ;; non-conformant `:reason :schema` / no-`:hint`
-                       ;; marker. `:local/root` to the schemas artefact puts
-                       ;; `re-frame.schemas` on the JVM classpath so the gate
-                       ;; below can drive the REAL validation-failure emitter
-                       ;; LIVE and validate its marker against the same
-                       ;; canonical `ElisionMarker` schema.
+                       ;; Schema validation-failure elision emitter.
                        day8/re-frame2-schemas
                        {:local/root "../../../implementation/schemas"}}
          :main-opts   ["-m" "re-frame.test-quiet.runner"]}}}

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/event_bundle_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/event_bundle_test.clj
@@ -196,17 +196,3 @@
                     (assoc re-frame2-pair-event-bundle-fixture
                            :dispatch-id :cart/checkout))
         "a keyword dispatch id (not :ungrouped) is application-shaped and accepted")))
-
-;; rf2-hvn83u (LOW): the former "event-bundle topics ship under
-;; :event-bundles; frameless under :events" testing block was DROPPED — it
-;; asserted `vector?` / `not contains?` over locally hand-built literal
-;; maps (`cascade-tick` / `frameless-tick`), which is tautological: the
-;; values were constructed as vectors / without the key the assertion
-;; checked for, so the block could never fail and observed no real
-;; emitter. The genuine event-vs-frameless distinction is pinned by the
-;; two schema-rejection `testing` blocks above (`:ungrouped` rejected on an
-;; EventBundle and inside an EventBundleVector via the `not-ungrouped?`
-;; predicate). Tying the dropped tautology to a real progress-notification
-;; subscribe-emit projection would require the heavyweight live emitter
-;; and is out of scope for the fixture-drift fix; the schema gates carry
-;; the contract.

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/fixtures.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/fixtures.clj
@@ -1,55 +1,13 @@
 (ns re-frame.mcp-conformance.fixtures
-  "Shared fixtures + helpers for the three conformance test namespaces
-  in this artefact (`wire_vocab_test`, `indicator_field_test`,
-  `slot_name_test`).
+  "Repository and source-inventory helpers shared by vocabulary tests.
 
-  All three tests share the same surface posture: grep source files at
-  the repo root for canonical literal strings, validate authored
-  fixtures against Malli schemas, and pin per-server presence /
-  absence invariants. The classpath-derived `repo-root`, the
-  `read-source` slurp helper, and the `known-servers` set are
-  centralised here so each test namespace pulls them in via one
-  `:require` rather than re-deriving the classpath-walk + slurp
-  ceremony.
-
-  ## What this ns owns
-
-  - **`repo-root`** — absolute path to the repo root, derived from the
-    classpath URL of this file. Walks seven `.getParentFile` levels
-    (mcp_conformance → re_frame → test → wire-vocab → mcp-conformance
-    → tools → repo-root).
-  - **`read-source`** — slurp a file at a repo-relative path. Fails
-    loudly via `slurp`'s IOException if the path doesn't resolve;
-    that's the right signal — a moved/removed file under conformance
-    needs the test to surface it.
-  - **`known-servers`** — the canonical `#{:re-frame2-pair-mcp :story-mcp}`
-    pair. A typo in any test's `:servers` set surfaces against this.
-    (xray ships as a Clojars-only library, not an MCP server.)
-
-  ## What this ns does NOT own
-
-  Per-marker schemas + the `canonical-markers` catalogue live in
-  `wire_vocab/schemas.clj`; the shared source-text pin inventories +
-  near-miss helpers live in `wire_vocab/source_pins.clj`.
-  Marker-family-LOCAL schemas +
-  fixtures (`ResultEnvelope`, `EventBundle`, and the per-family fixture
-  maps) stay co-located with their tests in the focused `*_test.clj`
-  namespaces — they ARE the contract for that family, not boilerplate.
-  Same posture for `canonical-slots` (`slot_name_test.clj`) and
-  `envelope-indicator-slots` (`wire_vocab_test.clj`). The split is:
-  data-tables that ARE a single family's contract live next to their
-  assertions; the cross-family schema/pin data lives in the `wire_vocab/`
-  support nses; classpath-walk + slurp ceremony lives here."
+  This namespace owns CWD-independent repo resolution, memoized source
+  reads, the conformed server set, and filesystem-derived story tool
+  sources. Schemas and marker source pins live under `wire_vocab/`; a
+  focused family's fixtures remain beside its tests."
   (:require [clojure.java.io :as io]))
 
-;; ---------------------------------------------------------------------------
-;; Repo-root resolution. This file lives at
-;; `tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/fixtures.clj`
-;; relative to the repo root. We resolve THIS file's classpath URL and
-;; walk seven parents up to reach the repo root (one `.getParentFile`
-;; per path segment). `io/resource` returns the absolute classpath URL
-;; whose first parent is the `mcp_conformance/` leaf directly.
-;; ---------------------------------------------------------------------------
+;; Resolve from the classpath resource rather than the invoking CWD.
 
 (def repo-root
   "Absolute path to the repo root, derived from this file's classpath
@@ -74,62 +32,20 @@
   doesn't resolve — that's the right signal: a source file under
   conformance was moved or removed.
 
-  ## Memoisation (rf2-re2tv)
-
-  Callers iterate `doseq` over the same files dozens of times across
-  the three conformance test namespaces (`wire-vocab-test`,
-  `slot-name-test`, `indicator-field-test`); the wire-vocab suite was
-  ~4356ms wall-clock and almost entirely I/O-bound on a cold disk
-  cache. Wrapping in `memoize` keyed on the rel-path drops the
-  re-slurp cost to zero for every repeated access. Source files do
-  not change mid-test-run, so cache invalidation is a non-concern.
-
-  The bound name stays `read-source` (no underscore prefix or
-  `read-source*` indirection) so the call sites read identically to
-  the un-memoised form."
+  Reads are memoized because many vocabulary families scan the same
+  immutable source files during one test process."
   (memoize
     (fn read-source* [rel-path]
       (slurp (io/file repo-root rel-path)))))
 
-;; ---------------------------------------------------------------------------
-;; Cross-server registry. The MCP servers under conformance. A typo in
-;; any test's `:servers` set surfaces here against this canonical set.
-;; ---------------------------------------------------------------------------
-
 (def known-servers
   "The canonical set of MCP servers under conformance. Adding a new
   server means extending this set AND adding per-server source/spec
-  coverage to every relevant test catalogue.
-
-  xray-mcp was dropped in rf2-bu21t — `tools/xray-mcp/` is no longer
-  in the repo; xray now ships as a Clojars-only library."
+  coverage to every relevant test catalogue."
   #{:re-frame2-pair-mcp :story-mcp})
 
-;; ---------------------------------------------------------------------------
-;; story-mcp source-file inventory — single source of truth (rf2-ee38b.20).
-;;
-;; Several absence-tripwires across the three conformance test namespaces
-;; grep the same canonical set of story-mcp source files (the day story-mcp
-;; adopts a cross-MCP marker / envelope slot / near-miss slot name, the
-;; tripwire flips RED). The list was duplicated verbatim across
-;; `wire_vocab_test.clj` (two deftests) and `slot_name_test.clj` — exactly
-;; the drift the gates exist to prevent, reproduced inside the gate: a new
-;; story-mcp tool file added to one tripwire's list silently escaped the
-;; others. Centralised here so "the files story-mcp ships" has one home.
-;; ---------------------------------------------------------------------------
-
-;; rf2-ribu5a — filesystem-derived, NOT hand-maintained. The previous
-;; hand list ran through `recorder.cljc` but silently omitted
-;; `cursor.cljc` (routes the cross-MCP `:rf.mcp/cursor-stale` marker)
-;; and the since-removed `dedup.cljc` (rf2-ywkiss folded the dedup
-;; encode step into a direct `re-frame.mcp-base.dedup` require) —
-;; exactly the drift these absence-tripwires exist to prevent,
-;; reproduced inside the gate. A dropped/added tool file could escape
-;; the generic near-miss / uncontracted-marker sweeps because the
-;; inventory was edited by hand and fell behind the directory. Deriving
-;; the set from the directory listing makes "the files story-mcp ships"
-;; literally the files on disk: a new tool file is swept the moment it
-;; lands, with zero list maintenance.
+;; Derive the story tool surface from disk so a new source file enters every
+;; marker/slot absence tripwire automatically.
 (def story-mcp-tools-dir
   "Repo-relative path to story-mcp's `tools/` source directory — the
   single home of the per-category tool handlers plus the shared
@@ -140,8 +56,8 @@
 
 (def story-mcp-tool-source-files
   "The story-mcp `tools/*.cljc` source files — derived from a
-  filesystem listing of `story-mcp-tools-dir`, NOT a hand-maintained
-  list (rf2-ribu5a). This is the surface the slot-name and indicator
+  filesystem listing of `story-mcp-tools-dir`, not a hand-maintained
+  list. This is the surface the slot-name and indicator
   near-miss tripwires grep (the slots live in the tool bodies, not the
   wire framing). Sorted for deterministic iteration order. Fails loudly
   if the directory is missing or empty — a story-mcp source-tree move

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/indicator_field_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/indicator_field_test.clj
@@ -257,9 +257,8 @@
 ;; Cross-server posture pin — story-mcp.
 ;;
 ;; The sibling `wire_vocab_test.clj` pins:
-;; - story-mcp emits ZERO UNCONTRACTED cross-MCP markers (it is
-;;   contracted for `:rf.mcp/dedup-table` only)
-;; - story-mcp NOW emits both envelope indicators (rf2-koq5m): its
+;; - story-mcp emits no uncontracted cross-MCP markers;
+;; - story-mcp emits both envelope indicators: its
 ;;   `run-variant` / `preview-variant` / `read-failures` payload
 ;;   builders drop `:sensitive? true` assertion records and elide
 ;;   over-threshold `:app-db` leaves, surfacing the counts via the
@@ -275,13 +274,4 @@
 ;; `re-frame2-pair-mcp-source-files` walker above (CLJS-only) does not
 ;; cover them; the story-mcp routing pin lives in `wire_vocab_test.clj`
 ;; against the `.cljc` helper + tool sources.
-;;
-;; The xray-mcp T-Insp cluster (historic rf2-8xzoe.14..22) was
-;; reverted in rf2-bu21t — `tools/xray-mcp/` is now absent. Xray
-;; ships as a Clojars-only library; there is no xray-mcp wire
-;; surface to pin here. If a future MCP server reintroduces a
-;; tree-walking surface, extend `tree-walking-tool-sources` and
-;; `inline-emit-whitelist` above (or add a parallel pair) to cover
-;; it; the re-frame2-pair-mcp gates + the mcp-base helper unit tests are
-;; the live reference.
 ;; ---------------------------------------------------------------------------

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/redacted_sentinel_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/redacted_sentinel_test.clj
@@ -1,6 +1,5 @@
 (ns re-frame.mcp-conformance.redacted-sentinel-test
-  "`:rf/redacted` scalar-sentinel gate (rf2-xm1fv). Split out of
-  `wire_vocab_test.clj` by rf2-7ckmwx.
+  "`:rf/redacted` scalar-sentinel vocabulary gate.
 
   Unlike the wrapper-shaped markers in `schemas/canonical-markers`,
   `:rf/redacted` rides the wire as a **bare keyword scalar** — a literal
@@ -17,8 +16,7 @@
   keyword scalar has no body to schema-validate — but it IS a wire-
   protocol contract: every agent reading sensitive-leaf data pattern-
   matches on the literal `:rf/redacted`. A rename in `vocab.cljc`
-  (e.g. `:rf.size/redacted` — the historical doc-drift in
-  rf2-pv7we) or a near-miss spelling that escapes the canonical-marker
+  (e.g. `:rf.size/redacted`) or a near-miss spelling that escapes the canonical-marker
   gate would slip past silently because the existing near-miss anti-
   pin only checks `:rf.mcp/*` / `:rf.size/*` marker keys (the namespace
   pattern fixed in `pins/near-miss-variants`).
@@ -49,13 +47,12 @@
     multi-segment name.
   - pluralised (`:rf/redacteds`).
   - predicate `?` suffix (`:rf/redacted?`).
-  - the historical wrong-namespace forms — the rf2-pv7we doc-drift
-    targeted exactly these.
+  - wrong-namespace forms.
   - capitalised name (`:rf/Redacted`) — caught here even though
     canonical Clojure idiom is all-lowercase."
   #{":rf/redacteds"
     ":rf/redacted?"
-    ":rf.size/redacted"        ;; the rf2-pv7we historical doc-drift
+    ":rf.size/redacted"
     ":rf.mcp/redacted"
     ":rf.privacy/redacted"
     ":rf/Redacted"})

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/reply_envelope_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/reply_envelope_test.clj
@@ -1,5 +1,5 @@
 (ns re-frame.mcp-conformance.reply-envelope-test
-  "EP-0011 reply-envelope TRACE-EGRESS wire-vocabulary gate (rf2-mrfvg2).
+  "Reply-envelope trace-egress wire-vocabulary gate.
 
   ## Why this gate
 

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/slot_name_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/slot_name_test.clj
@@ -402,15 +402,7 @@
                  "the literal or update this test."))))))
 
 ;; ---------------------------------------------------------------------------
-;; Gate 6 — no xray-mcp wire surface.
-;;
-;; There is no `tools/xray-mcp/` directory: xray ships as a Clojars-only
-;; library, not an MCP server, so there is no xray-mcp tool surface to
-;; pin a structural-floor assertion against.
-;; ---------------------------------------------------------------------------
-
-;; ---------------------------------------------------------------------------
-;; Gate 7 — server-coverage sanity. Every server referenced in
+;; Gate 6 — server-coverage sanity. Every server referenced in
 ;; `canonical-slots` is one of the known servers. Typos surface here.
 ;; ---------------------------------------------------------------------------
 
@@ -422,7 +414,7 @@
                (remove fx/known-servers servers))))))
 
 ;; ---------------------------------------------------------------------------
-;; Gate 8 — slot uniqueness. No two `canonical-slots` rows share the
+;; Gate 7 — slot uniqueness. No two `canonical-slots` rows share the
 ;; same `:slot` keyword. A duplicate row is a definition error.
 ;; ---------------------------------------------------------------------------
 

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/trace_catalogue_lint_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/trace_catalogue_lint_test.clj
@@ -1,26 +1,11 @@
 (ns re-frame.mcp-conformance.trace-catalogue-lint-test
-  "Trace-catalogue one-name-per-fact lint (rf2-o6c2jr).
+  "Trace-catalogue one-name-per-fact lint.
 
-  ## Why this gate
-
-  `spec/Conventions.md` §The naming rules (one name per fact) forbids a
-  subsystem carrying the same fact under two keys. Managed-Effects property 9
-  requires managed async families to emit trace rows FROM reply-envelope facts,
-  and the async-completion / stale-suppression trace rows historically stamped
-  the SAME fact twice — the work identity under BOTH bare `:work/id` AND the
-  namespaced `:rf.reply/work-id`, and the completion time under BOTH bare
-  `:completed-at` AND `:rf.reply/completed-at`. rf2-o6c2jr dropped the bare
-  duplicates and made the namespaced spelling canonical.
-
-  This lint keeps the drop honest. It reads the production emitter sources,
-  reads each file as data (`:read-cond :allow` so a `.cljc` reader-conditional
-  parses), walks EVERY map literal, and asserts no single map carries a fact
-  under both its namespaced reply-envelope spelling AND its bare duplicate:
+  Reads production emitters as data and rejects a map that carries a reply
+  fact under both its namespaced spelling and its bare duplicate:
 
     - a map carrying `:rf.reply/work-id`      MUST NOT also carry `:work/id`
     - a map carrying `:rf.reply/completed-at` MUST NOT also carry `:completed-at`
-
-  ## Scope — reply-envelope rows, not the durable identity
 
   The bare `:work/id` is still legitimate on its own: it is the durable
   work-ledger identity key ON THE REPLY MAP and on non-reply resource-lifecycle
@@ -32,11 +17,8 @@
   correlation payload like `:rf.reply/carried {:work/id … :generation …}` is
   fine (that inner map carries no `:rf.reply/work-id`).
 
-  ## Teeth
-
   `sanity-a-planted-duplicate-is-caught` plants a map carrying both spellings
-  and asserts the detector flags it — so a future emitter re-introducing the
-  bare duplicate FAILS here, not silently."
+  and asserts that the detector remains live."
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
             [clojure.walk :as walk]

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/verb_vocab_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/verb_vocab_test.clj
@@ -1,56 +1,14 @@
 (ns re-frame.mcp-conformance.verb-vocab-test
-  "Cross-MCP verb-vocabulary conformance (rf2-vkx7m).
+  "Executable tool-name vocabulary for both MCP servers.
 
-  Pins the cross-server **tool-name verb vocabulary** catalogued in
-  `tools/mcp-conformance/NAMING.md` §The verb table. Every tool the
-  pair (re-frame2-pair-mcp, story-mcp) advertises MUST start with one
-  of the catalogued verb prefixes — or appear on the bare-verb /
-  bare-noun exception list — so an agent that learned the verb table
-  once recognises the surface across servers.
-
-  Sibling to:
-
-  - [`wire_vocab_test.clj`](wire_vocab_test.clj)     — wire MARKER
-    vocabulary (`:rf.mcp/*` / `:rf.size/*` namespaced payload shapes).
-  - [`indicator_field_test.clj`](indicator_field_test.clj) —
-    envelope SLOT vocabulary for suppression counters.
-  - [`slot_name_test.clj`](slot_name_test.clj)       — `tools/call`
-    INPUT-arg slot vocabulary.
-  - **This file**                                    — tool-NAME verb
-    vocabulary.
-
-  ## What this test guards
-
-  Each server ships a canonical `tool-names.json` fixture used by the
-  per-server unit tests (story-mcp's `tools_test.clj`,
-  re-frame2-pair-mcp's stdio roundtrip). This linter reads each
-  fixture and asserts every tool name starts with a catalogued verb,
-  is a catalogued bare-verb, or appears on the bare-noun-exception
-  allowlist (Clojure-idiomatic projections like `variant->edn`, single-
-  primitive reads like `snapshot-identity`).
-
-  A new tool with an off-convention verb (`fetch-foo`, `update-bar`,
-  …) lands today without anything tripping — the convention is doc-
-  only. This gate makes the convention executable.
-
-  ## Adding a new verb
-
-  Extending the catalogue requires a Lock entry in the relevant
-  server's `spec/DESIGN-RATIONALE.md` AND a row in NAMING.md §The
-  verb table. THEN extend `verb-prefixes` / `bare-verbs` /
-  `bare-noun-exceptions` below. The friction is intentional — every
-  added verb is a new surface an agent must learn."
+  Reads each server's canonical `tool-names.json` fixture and requires
+  every advertised name to use a prefix, bare verb, or explicit exception
+  documented in `tools/mcp-conformance/NAMING.md`. A new verb requires the
+  owning server rationale, a NAMING.md row, and an update here."
   (:require [clojure.data.json :as json]
             [clojure.string    :as str]
             [clojure.test      :refer [deftest is testing]]
             [re-frame.mcp-conformance.fixtures :as fx]))
-
-;; ---------------------------------------------------------------------------
-;; Catalogued verb prefixes — every entry mirrors a row in NAMING.md
-;; §The verb table. Order is non-significant; matching is "first prefix
-;; that matches", so register-/unregister- precede register precedes
-;; nothing — we test by prefix-with-trailing-dash so no ordering hazard.
-;; ---------------------------------------------------------------------------
 
 (def ^:private verb-prefixes
   "Catalogued prefix verbs from NAMING.md §The verb table. Each entry
@@ -61,47 +19,17 @@
     "discover"
     "restore"
     "reset"
-    "replace"     ; rf2-0acvdb (EP-0001 rf2-tfepxu) — `replace-<thing>`
-                  ; whole-value state injection, bypassing the normal
-                  ; cascade. `replace-app-db` (re-frame2-pair) is gated
-                  ; behind `--allow-writes`; it wraps the framework's
-                  ; `replace-frame-state!` Tool-Pair write primitive as an
-                  ; app-only partial map (rf2-t3lftq — API-shrink #3
-                  ; consolidated the former `replace-app-db!` into this —
-                  ; a db-shaped key must never silently replace
-                  ; runtime-db). Mirrors NAMING.md §The verb table
-                  ; `replace-<thing>` row.
-    "set"         ; rf2-zomfq — the SOLE catalogued `set-` carve-out:
-                  ; `set-operating-frame` (re-frame2-pair) pins ONE named
-                  ; session setting the Tool-Pair contract mandates under
-                  ; that exact name. NAMING.md §"What's NOT a locked verb"
-                  ; still rejects generic `set-<arbitrary-slot>`; this
-                  ; prefix entry is admissible because the only `set-` tool
-                  ; that exists is the spec-mandated operating-frame pin.
+    "replace"
+    ;; Reserved for the one operating-frame session pin.
+    "set"
     "register"
     "unregister"
     "run"
-    "describe"    ; rf2-srobm0 — `describe-<thing>` reads the COMPOSED /
-                  ; derived behaviour a frame runs PLUS where each piece
-                  ; resolved from. `describe-image` (re-frame2-pair) is the
-                  ; EP-0023 Use-Case 7 read over a frame's running image
-                  ; generation (images / kinds / capability requires /
-                  ; per-kind counts / optional per-registration provenance).
-                  ; Distinct from `get-` (stored body), `read-` (no-recompute
-                  ; reflection of an already-run artefact) and `list-`
-                  ; (enumeration): `describe-` answers "what behaviour does
-                  ; THIS frame run, and which source won each resolution".
-                  ; Lock #11 in pair-mcp DESIGN-RATIONALE.md; NAMING.md §The
-                  ; verb table `describe-<thing>` row.
+    "describe"
     "preview"
-    "explain"     ; rf2-ba86n.17 — `explain-variant` (story-mcp; the agent
-                  ; mirror of the human Explain panel over `story/explain`)
+    "explain"
     "record-as"
-    "watch"       ; rf2-zo4b9 — `watch-<until>` blocking watch family
-                  ; (re-frame2-pair; block until a predicate over a signal
-                  ; holds). Generalises the `watch-epochs` bare verb into a
-                  ; prefix; `watch-epochs` stays on the bare-verb allowlist
-                  ; below to avoid churn.
+    "watch"
     "tail"})
 
 (def ^:private bare-verbs
@@ -110,29 +38,18 @@
   mega-op bare verbs (`snapshot`, `trace-window`, `watch-epochs`,
   `record`)."
   #{"dispatch"
-    "dispatch-dry-run"  ; sibling of `dispatch` (rf2-ee38b.18 dry-run gate)
+    "dispatch-dry-run"
     "eval-cljs"
     "subscribe"
     "unsubscribe"
     "snapshot"
     "trace-window"
     "watch-epochs"
-    "orient"            ; rf2-3bu3d.8 — bare-verb mega-op app-shape summary
-                        ; (re-frame2-pair; spans liveness / frames /
-                        ; app-db-top-keys / registry counts+ids / machines in
-                        ; one round-trip). First-contact orientation on an
-                        ; unfamiliar app; composes the existing introspection
-                        ; surfaces. Lock #9 in pair-mcp DESIGN-RATIONALE.md.
-    "record"})          ; rf2-zo4b9 — bare-verb mega-op signal recorder
-                        ; (re-frame2-pair; spans app-db / sub / DOM / focus
-                        ; signals). Distinct from the `record-as-` prefix
-                        ; (capture-as-artefact); `record` installs a live
-                        ; change-log observer.
+    "orient"
+    "record"})
 
 (def ^:private bare-noun-exceptions
-  "Bare-noun reads catalogued in NAMING.md §Server alignment today as
-  'Deviation — accepted exception'. Each entry needs a row in the
-  alignment table explaining the exception:
+  "Bare-noun reads catalogued as explicit exceptions in NAMING.md:
 
   - `handler-meta` — bare-noun read of a single-record metadata map
     (re-frame2-pair-mcp; accepted under the bare-noun-exception clause

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab/schemas.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab/schemas.clj
@@ -1,27 +1,11 @@
 (ns re-frame.mcp-conformance.wire-vocab.schemas
-  "Canonical cross-MCP wire-marker schemas + the `canonical-markers`
-  catalogue.
+  "Canonical shared wrapper-marker schemas and fixture catalogue.
 
-  This is the **contract data**, not boilerplate: a single Malli schema
-  per cross-server wire marker, plus the ordered `canonical-markers`
-  index binding each marker key to its schema, description, and
-  per-server fixtures. The several focused test namespaces that share
-  these schemas (`wire_vocab_test`, `cursor_stale_test`,
-  `progress_notification_test`, …) each `:require` ONE support ns rather
-  than re-deriving the shapes. The marker-family-LOCAL schemas
-  (`ResultEnvelope`, `EventBundle`) stay co-located with their tests —
-  only the shapes referenced across families live here.
-
-  See `wire_vocab_test.clj`'s ns docstring for the full cross-MCP
-  vocabulary rationale (six top-level wrapper markers + the
-  `:rf.elision/at` fetch-handle tag, the per-server presence/absence
-  contract, the source-text pins). This ns is the schemas only.
-
-  Each schema is the cross-MCP-server contract for one wire marker. The
-  marker is **always a single-key map** keyed by the reserved keyword;
-  the value is a body conforming to the per-marker schema below. Agents
-  pattern-match on the top-level reserved key — that rule is what makes
-  the vocabulary cross-server."
+  `canonical-markers` binds each reserved key to one Malli schema,
+  contracted servers, and representative fixtures. Family-local schemas
+  such as result envelopes and event bundles stay beside their focused
+  tests. Wrapper maps are closed and single-keyed; marker bodies remain
+  open where additive fields are part of the contract."
   (:require [malli.core :as m]))
 
 ;; ---------------------------------------------------------------------------
@@ -29,21 +13,8 @@
 ;; ---------------------------------------------------------------------------
 
 (def ReFrame2PairOverflowBody
-  "The canonical `:rf.mcp/overflow` body shape (per
-  `mcp-base/overflow.cljc/overflow-payload`). Every emit carries
-  `:cap-tokens` + `:token-count` + `:tool` + `:hint` plus the `:limit
-  :reached` sentinel. Required-not-optional — an emit missing any of
-  these is a contract break, not a degenerate but tolerated marker.
-
-  Multi-emitter: BOTH re-frame2-pair-mcp and story-mcp emit this marker
-  via the shared `mcp-base.cap/apply-cap` → `overflow-payload` builder,
-  so the body is byte-identical across both — there is exactly one
-  shape, not a per-server variant. (story-mcp's wire-boundary cap is
-  `tools/story-mcp/.../tools/wire_pipeline.cljc`, which calls
-  `base-cap/apply-cap`. The name keeps the `ReFrame2Pair` prefix as the
-  shape-author; the SHAPE is the cross-MCP contract.) Cap renames
-  (`cap-tokens` vs `cap_tokens`), field renames (`hint` vs `next-step`),
-  or empty bodies all trip the schema."
+  "Canonical `:rf.mcp/overflow` body emitted by the shared mcp-base
+  builder. Both servers must carry every required field."
   [:map
    {:closed false}
    [:limit       [:enum :reached]]
@@ -53,16 +24,7 @@
    [:hint        [:or :string :keyword]]])
 
 (def Overflow
-  "`{:rf.mcp/overflow ReFrame2PairOverflowBody}` — the wrapper shape.
-
-  CLOSED single-key map: a wire marker is ALWAYS a
-  single reserved wrapper key (see the header — agents pattern-match on
-  exactly one top-level key). A payload carrying the marker plus an
-  unrelated sibling top-level key is a mixed-envelope emission a uniform
-  cross-server client can't pattern-match; the `{:closed true}` arm
-  rejects it so the conformance gate pins the single-key contract the
-  contract documents. (The marker BODY stays open — additive body slots
-  compose; it's the top-level envelope that is single-key.)"
+  "Closed, single-key overflow wrapper. The body remains additive."
   [:map {:closed true} [:rf.mcp/overflow ReFrame2PairOverflowBody]])
 
 (defn summary-has-count-or-counts?

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab/source_pins.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab/source_pins.clj
@@ -1,35 +1,10 @@
 (ns re-frame.mcp-conformance.wire-vocab.source-pins
-  "Shared source-text pin inventories + near-miss helpers.
+  "Shared emit/doc source inventories and near-miss generators.
 
-  The wire-vocab conformance corpus pins each canonical marker literal
-  against the server source/spec files where it MUST (emit-sources) or
-  SHOULD (doc-sources) appear, and an anti-pin that forbids near-miss
-  spellings anywhere in the conformance-tracked tree. The per-server
-  file inventories and the near-miss generator are shared by several
-  focused test namespaces (`wire_vocab_test`, `cursor_stale_test`,
-  `result_envelope_test`, `progress_notification_test`,
-  `redacted_sentinel_test`) — they live here so a new marker family adds
-  ONE `:require` rather than re-deriving the inventories.
-
-  ## The two-tier pin
-
-  - **emit-sources** — source files where the literal MUST appear as
-    actual data (not in a comment or docstring). Stripped via
-    `fx/strip-comments-and-strings` before the grep. A rename in any of
-    these files MUST trip the test even if a docstring elsewhere still
-    carries the old form.
-  - **doc-sources** — spec docs and prose-y descriptors where the
-    literal SHOULD appear for human readers. Looser — a `str/includes?`
-    against raw text suffices; documentation reorganisation may move
-    the mention around without tripping the gate.
-
-  The emit-side pin is the load-bearing one: a `some`-over-doc-sources
-  check would pass merely because the spec docs prose-reference every
-  marker, even though four of five literals never appear in
-  re-frame2-pair-mcp source code at all (they are imported via
-  `re-frame.mcp-base.vocab/<key>`), so a rename inside
-  `mcp-base/vocab.cljc` (the canonical home of every literal) would not
-  trip a doc-only gate. The emit-side pin closes that hole."
+  Emit pins scan comment/string-stripped source so documentation cannot
+  satisfy a data-emission assertion. Doc pins scan raw contract text.
+  Focused vocabulary tests reuse these inventories instead of defining
+  partial source sets."
   (:require [clojure.string :as str]))
 
 (def emit-source-files
@@ -47,12 +22,8 @@
   is the right invariant; emit-sites that import from vocab.cljc
   cannot drift independently of the canonical declaration.
 
-  story-mcp also consumes from `mcp-base/vocab.cljc` (the
-  `dedup-table-key` symbol — `tools/story-mcp/src/re_frame/
-  story_mcp/tools/wire_pipeline.cljc` reaches it transitively via its
-  `re-frame.mcp-base.dedup` require; rf2-ywkiss removed the intermediate
-  `tools/dedup.cljc`). Same single-source-of-truth posture as pair-mcp;
-  the canonical literal home is `mcp-base/vocab.cljc`."
+  story-mcp also consumes these names from `mcp-base/vocab.cljc`, so both
+  server entries intentionally pin the same production owner."
   {:re-frame2-pair-mcp ["tools/mcp-base/src/re_frame/mcp_base/vocab.cljc"]
    :story-mcp ["tools/mcp-base/src/re_frame/mcp_base/vocab.cljc"]})
 

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
@@ -1,11 +1,8 @@
 (ns re-frame.mcp-conformance.wire-vocab-test
-  "Cross-MCP wire-vocabulary conformance (rf2-j2z7o).
+  "Generic wrapper-marker conformance for the cross-MCP vocabulary.
 
-  Two MCP servers ship under `tools/`: re-frame2-pair-mcp and story-mcp.
-  re-frame2-pair-mcp owns the reserved cross-server **wire vocabulary** —
-  namespaced map keys an agent recognises identically across every
-  server that adopts it. (xray-mcp was dropped in rf2-bu21t — xray
-  now ships as a Clojars-only library, not an MCP server.)
+  `wire-vocab.schemas/canonical-markers` owns the wrapper keys, schemas,
+  contracted servers, and representative fixtures.
 
   Six top-level wrapper markers (the `canonical-markers` table below is
   the source of truth — see it rather than re-counting this list),
@@ -94,38 +91,23 @@
             [de-dupe.core    :as dd]
             [malli.core      :as m]
             [malli.error     :as me]
-            ;; rf2-hvn83u — the canonical framework wire-elision walker +
-            ;; the EP-0025 commit-plane `:large` classification effect, so the
-            ;; `:rf.size/large-elided` gate drives the REAL emitter LIVE over a
-            ;; classified `:large` slot (not a fixture).
+            ;; Canonical framework elision builder and classification effect.
             [re-frame.core   :as rf]
             [re-frame.elision :as elision]
             [re-frame.frame  :as frame]
-            ;; rf2-9wvwpa — the SECOND framework emitter of the
-            ;; `:rf.size/large-elided` marker: the schemas-artefact
-            ;; validation-failure size-safety arm (Spec 010 §`:large?`).
-            ;; Required so the gate below can drive `validate-event!`
-            ;; LIVE over a `:large?`-flagged schema and validate the
-            ;; emitted failure-trace marker against `ElisionMarker`.
+            ;; Schema-validation failure is an independent elision emitter.
             [re-frame.schemas :as schemas]
             [re-frame.schemas.malli]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.mcp-base.diff-encode :as de]
             [re-frame.mcp-base.overflow :as mcp-overflow]
             [re-frame.mcp-conformance.fixtures :as fx]
-            ;; rf2-7ckmwx — the canonical schemas + `canonical-markers`
-            ;; catalogue moved to a shared support ns so the focused
-            ;; marker-family test namespaces each :require ONE place. See
-            ;; `schemas.clj` for the full schema set; the contract-bearing
-            ;; data lives there, the assertions live here.
+            ;; Shared wrapper contract data.
             [re-frame.mcp-conformance.wire-vocab.schemas
              :refer [Overflow Summary DedupTable DiffFromBody
                      ElisionMarker CacheHit DroppedSensitive ElidedLarge
                      canonical-markers]]
-            ;; rf2-7ckmwx — shared source-text pin inventories + near-miss
-            ;; helpers (`emit-source-files` / `doc-source-files` /
-            ;; `all-source-files` / `marker-key->literal` /
-            ;; `near-miss-variants`).
+            ;; Shared source inventories and near-miss helpers.
             [re-frame.mcp-conformance.wire-vocab.source-pins :as pins]))
 
 ;; ---------------------------------------------------------------------------
@@ -188,10 +170,8 @@
                (me/humanize (m/explain schema fixture-value)))))))
 
 (deftest every-canonical-marker-has-required-fixture-count
-  ;; Every marker MUST carry >=1 fixture; multi-server markers MUST
-  ;; carry >=2. Single-server today (all markers are re-frame2-pair-mcp-only
-  ;; post rf2-bu21t), so the >=1 floor applies; the >=2 path stays
-  ;; live for any future MCP server adoption.
+  ;; Single-server markers need evidence; multi-server markers need at least
+  ;; two fixtures before distinct-server coverage is checked below.
   (doseq [{:keys [key fixtures servers]} canonical-markers]
     (testing (str "marker " key " — fixture count")
       (let [n (count fixtures)]
@@ -204,18 +184,7 @@
                    ") so >=2 fixtures required, got " n)))))))
 
 (deftest every-multi-server-marker-fixtures-cover-each-server
-  ;; rf2-87h71e LOW — the per-server fixture-coverage claim in the header
-  ;; (guard #2) was NOT enforced. `every-canonical-marker-has-required-
-  ;; fixture-count` asserts only `(count fixtures) >= 2` for a multi-server
-  ;; marker — never that the fixtures cover DISTINCT servers. So
-  ;; `:rf.mcp/overflow` (3 fixtures: 2 re-frame2-pair variants + 1
-  ;; story-mcp) would still pass with the `:story-mcp` fixture dropped
-  ;; (leaving 2 pair fixtures), silently losing the cross-server emission
-  ;; pin. This gate asserts that for EVERY server in `:servers`, at least
-  ;; one fixture is tagged for it — keyed by the catalogue's fixture-key
-  ;; naming convention: every fixture key starts with its server's name
-  ;; (`:re-frame2-pair-mcp...`, `:story-mcp...`). A dropped per-server
-  ;; fixture now trips RED directly.
+  ;; Fixture count alone cannot prove that every contracted server is covered.
   (let [;; The servers the catalogue knows about, longest-first so a
         ;; prefix match resolves the most specific server (no overlap
         ;; today, but order-stable regardless).


### PR DESCRIPTION
## Summary

- replace historical mcp-conformance narratives with current client, live, vocabulary, inventory, and ownership contracts
- remove the incomplete copied tool audit and point naming/call coverage at each server's canonical tool-name fixture
- document the actual shared token-cap algorithm, including duplicated payload slots, invalid cap handling, and the secondary character ceiling
- tighten runner and JVM conformance comments while preserving independent grading, cleanup, fixture, source-pin, and cross-server invariants

## Notable corrections

- `canonical-markers` owns six generic wrappers; `:rf.elision/at` is a focused embedded vocabulary concern rather than a seventh wrapper
- story-mcp and pair-mcp share the mcp-base overflow/dedup builders where contracted
- multi-server fixture coverage is current and distinct from the minimum fixture-count check
- live tests are derived from `live-test-inventory.cjs`; Node unit tests are derived from `test-all.cjs`
- per-tool specifications and complete catalogue inventories remain server-owned rather than copied here

The changes are explanation-only. Conformance logic and production behaviour are unchanged.

## Gates

- `npm run test:unit` (88 tests; 79 passed, 9 platform skips, 0 failed)
- `clojure -M:test` in `tools/mcp-conformance/wire-vocab` (100 tests, 1056 assertions, 0 failures/errors)

Bead: `rf2-0idv89`
