### PR TITLE
docs(template): focus explanations on current contracts (rf2-6miw3k)

### DIFF
--- a/tools/template/README.md
+++ b/tools/template/README.md
@@ -1,17 +1,16 @@
 # re-frame2-template
 
-> `day8/re-frame2-template` — scaffolding tool for new re-frame2 apps
-> (rf2-lrtc; rf2-dolpf). The v2 equivalent of v1's
+> `day8/re-frame2-template` is the scaffolding tool for new re-frame2 apps
+> and the v2 equivalent of v1's
 > [`day8/re-frame-template`](https://github.com/day8/re-frame-template).
 >
-> **Spec:** [`spec/`](./spec/) — the tool's normative contract per the
-> per-tool [spec/ folder convention (rf2-bfax)](../README.md#per-tool-spec-folder-convention-rf2-bfax).
+> **Spec:** [`spec/`](./spec/) contains the current contract, design
+> rationale, and migration records.
 >
 > **Implementation shape:** [deps-new](https://github.com/seancorfield/deps-new)
-> template with programmatic body. Distribution: git-coord (tag-based),
-> not Clojars (rf2-dolpf §2.5 — `day8/clj-template.re-frame2` on Clojars
-> is now frozen at its last clj-new release; older versions remain
-> resolvable for legacy users).
+> template with a programmatic body. Distribution is tag-based git-coord,
+> not Clojars. The old `day8/clj-template.re-frame2` Clojars artefact is
+> frozen at its last clj-new release.
 >
 > **Release pipeline:**
 > [`.github/workflows/template-release.yml`](../../.github/workflows/template-release.yml)
@@ -20,8 +19,8 @@
 > (independent of the framework-wide repo-root `VERSION`).
 >
 > **Repo home:** the template currently lives in-tree at
-> [`tools/template/`](./) in the re-frame2 monorepo while the rebuild
-> settles (rf2-dolpf §4). Its planned permanent home is the external
+> [`tools/template/`](./) in the re-frame2 monorepo. Its planned permanent
+> home is the external
 > repo `github.com/day8/re-frame2-template`; the split out to that
 > external repo is a Mike-operator handoff. The deps-new coord shifts from
 > `day8/re-frame2-template` (current `:local/root` shape, monorepo) to
@@ -39,7 +38,7 @@ wired against the alpha-channel `day8/re-frame2-*` coords, ready to
 > **Pre-split status (current):** the dedicated
 > `github.com/day8/re-frame2-template` repo does not exist yet — the
 > template still lives in-tree under `tools/template/` in the
-> re-frame2 monorepo (rf2-dolpf §4 / rf2-7jgkv). Until the split
+> re-frame2 monorepo. Until the split
 > lands, the only working invocation is the `:local/root` route
 > against a checkout of this repo. The published
 > `io.github.day8/re-frame2-template` git-coord form is **not yet a
@@ -91,7 +90,7 @@ because the `io.github.*` prefix would trigger deps-new's
 auto-git-clone before classpath lookup — bypassing the local-root
 checkout (and, pre-split, cloning a repo that doesn't exist yet).
 
-`:include-story? true` is **Reagent-only in v1** — combining it with
+`:include-story? true` is currently **Reagent-only**. Combining it with
 `:substrate :uix` or `:substrate :helix` throws
 `:rf.error/template-include-story-reagent-only`. UIx + Helix Story
 variants follow once those adapters' Story coverage matches Reagent's.
@@ -128,7 +127,7 @@ status and the error table.
 ### Post-split (future)
 
 Once the template is split out to its dedicated
-`github.com/day8/re-frame2-template` repo (rf2-dolpf §4 / rf2-7jgkv),
+`github.com/day8/re-frame2-template` repo,
 the steady-state invocation becomes the published git-coord form —
 deps-new's `auto-git-url` mechanism clones the external repo at the
 requested tag and runs the template hooks (the tagged commit IS the
@@ -177,9 +176,9 @@ The normative contract lives under [`spec/`](./spec/):
 | [`spec/000-Vision.md`](./spec/000-Vision.md) | What the tool is for; lineage from v1; goals; non-goals. |
 | [`spec/001-Substrate-Variants.md`](./spec/001-Substrate-Variants.md) | Reagent / UIx / Helix variants; the top-level k/v invocation form; substrate coercion. |
 | [`spec/002-Generated-Shape.md`](./spec/002-Generated-Shape.md) | The file tree emitted; the resource tree; substitution variables. |
-| [`spec/003-DepsNew-Rebuild-Plan.md`](./spec/003-DepsNew-Rebuild-Plan.md) | Migration plan from clj-new + Clojars to deps-new + git-coord (rf2-dolpf). |
-| [`spec/004-SSR-Validation-Report.md`](./spec/004-SSR-Validation-Report.md) | SSR reference-impl validation report (rf2-0m5ea); gates the `:include-ssr?` flag work. |
-| [`spec/005-Repo-Split.md`](./spec/005-Repo-Split.md) | Migration procedure for the monorepo → external repo split (rf2-dolpf §4 / rf2-7jgkv). |
+| [`spec/003-DepsNew-Rebuild-Plan.md`](./spec/003-DepsNew-Rebuild-Plan.md) | Completed migration record from clj-new and Clojars to deps-new and git-coord. |
+| [`spec/004-SSR-Validation-Report.md`](./spec/004-SSR-Validation-Report.md) | Completed validation record for the shipped SSR variant. |
+| [`spec/005-Repo-Split.md`](./spec/005-Repo-Split.md) | Procedure for the remaining monorepo-to-external-repo split. |
 | [`spec/Principles.md`](./spec/Principles.md) | The design principles (build-time only, counter as canonical example, substrate-agnostic shell, top-level k/v selection). |
 | [`spec/API.md`](./spec/API.md) | The consolidated public invocation surface. |
 | [`spec/DESIGN-RATIONALE.md`](./spec/DESIGN-RATIONALE.md) | WHY each major decision (deps-new + git-coord over clj-new + Clojars, top-level k/v plumbing, three substrates in v1, counter as example, no-Story-yet, pin lockstep). |

--- a/tools/template/deps.edn
+++ b/tools/template/deps.edn
@@ -1,84 +1,22 @@
-;; day8/re-frame2-template — scaffolding tool for new re-frame2 apps
-;; (rf2-lrtc). The v2 equivalent of v1's day8/re-frame-template.
-;;
-;; Per tools/README.md the artefact is a downstream build-time tool —
-;; it generates fresh re-frame2 apps, it does not run inside them. The
-;; bundle-isolation contract is satisfied trivially: this jar is never
-;; on a consumer's runtime classpath; consumers invoke it via deps-new
-;; (`clojure -Tnew create :template io.github.day8/re-frame2-template
-;; :name acme/my-app`) and what lands in their project is the
-;; generated source tree, not this jar.
-;;
-;; Implementation shape: deps-new template (rf2-dolpf — switched from
-;; clj-new + Clojars to deps-new + git-coord distribution per the
-;; template walkthrough Q2 lock, 2026-05-12). Rationale documented in
-;; spec/003-DepsNew-Rebuild-Plan.md and spec/DESIGN-RATIONALE.md.
-;;
-;; The template ships three substrate variants — Reagent (default), UIx,
-;; and Helix — selected at scaffold time via the `:substrate` arg. The
-;; generated app depends on:
-;;   - day8/re-frame2          (core)
-;;   - day8/re-frame2-<subst>  (Reagent / UIx / Helix adapter)
-;; at the alpha-channel coord (see VERSION at the repo root: 0.0.1.alpha).
-;;
-;; This deps.edn is the contract; the template logic lives under
-;; src/day8/re_frame2_template/hooks.clj (the `:data-fn` /
-;; `:template-fn` / `:post-process-fn` hooks) and its resource tree
-;; under resources/day8/re_frame2_template/ (`template.edn` + `root/`
-;; + per-substrate `_reagent/` / `_uix/` / `_helix/` + `_shared/`).
-;; deps-new's renderer discovers both via the classpath
-;; (`day8/re_frame2_template/template.edn` for the template body;
-;; `day8.re-frame2-template.hooks` for the hooks ns).
-;;
-;; `:paths` exposes both the hooks ns (`src/`) and the template body
-;; (`resources/`):
-;;
-;;   - `src` puts `day8.re-frame2-template.hooks` on the classpath so
-;;     deps-new's `requiring-resolve` can find it via `template.edn`.
-;;   - `resources` puts the deps-new template body
-;;     (`day8/re_frame2_template/template.edn` + `root/`) on the
-;;     classpath so `org.corfield.new.impl/find-root` resolves the
-;;     `:template day8/re-frame2-template` argument via classpath
-;;     lookup. §3 of the rebuild plan moves it to the
-;;     `io/github/day8/...` path inside a dedicated repo for
-;;     production-canonical resolution.
-;;
-;; Local-root consumers (a downstream `:local/root "tools/template"`
-;; dep) inherit both `:paths`, so they pick up both the hooks ns and
-;; the template body.
-;;
-;; Per spec/003-DepsNew-Rebuild-Plan.md §2.5 (rf2-40vmd) this artefact
-;; no longer publishes to Clojars. The existing
-;; `day8/clj-template.re-frame2` Clojars artefact stays in place
-;; (older versions remain resolvable for legacy users); we just stop
-;; pushing new versions. §3 of the plan replaces Clojars with a
-;; tag-on-release git-coord pipeline.
+;; deps-new needs both paths: `src` contains the hook namespace and
+;; `resources` contains the template body resolved from the template symbol.
+;; Generated projects depend on re-frame2 and the selected React adapter;
+;; this build-time tool does not remain on their runtime classpath.
 {:paths ["src" "resources"]
  :deps  {org.clojure/clojure {:mvn/version "1.12.0"}}
 
  :aliases
  {:test {:extra-paths ["test"]
-         :extra-deps  {;; rf2-try1x — silent-on-success reporter.
-                       day8/re-frame2-test-quiet {:local/root "../../implementation/test-quiet"}
+         :extra-deps  {day8/re-frame2-test-quiet {:local/root "../../implementation/test-quiet"}
                        io.github.cognitect-labs/test-runner
                        {:git/tag "v0.5.1" :git/sha "dfb30dd"}
-                       ;; deps-new is pulled in under :test so the
-                       ;; template_test.clj suite can drive
-                       ;; `org.corfield.new/create` in-process (the
-                       ;; full pipeline runs through `data-fn` /
-                       ;; `template-fn` / `post-process-fn` exactly as
-                       ;; a `clojure -Tnew create` invocation would
-                       ;; — without the per-substrate process-spawn
-                       ;; cost). The hooks ns + the template body are
-                       ;; both already on the classpath via this jar's
-                       ;; :paths.
+                       ;; Tests drive the same in-process create pipeline as
+                       ;; the command-line tool.
                        io.github.seancorfield/deps-new
                        {:git/tag "v0.12.1" :git/sha "883e82c"}}
          :main-opts   ["-m" "re-frame.test-quiet.runner"]}
 
-  ;; deps-new bridge for in-repo smoke testing.
-  ;;
-  ;; Usage (from a fresh empty directory):
+  ;; deps-new bridge for in-repo smoke testing. From an empty directory:
   ;;
   ;;     mkdir -p /tmp/spike-out && cd /tmp/spike-out
   ;;     clojure -Sdeps '{:deps {day8/re-frame2-template
@@ -86,20 +24,9 @@
   ;;             -Tnew create :template day8/re-frame2-template \
   ;;                          :name acme/my-app
   ;;
-  ;; The `:local/root` dep is what puts the template's `src/` AND
-  ;; `resources/` on the classpath so deps-new can `requiring-resolve`
-  ;; the `day8.re-frame2-template.hooks` ns AND `find-root` the
-  ;; template body. End users will eventually invoke deps-new via
-  ;; the official tool install or a global `:new` alias in
-  ;; ~/.clojure/deps.edn — §3 of the rebuild plan ports this into a
-  ;; proper tag-on-release pipeline.
-  ;;
-  ;; Note: we use `day8/re-frame2-template` (not
-  ;; `io.github.day8/re-frame2-template`) as the template name in the
-  ;; local-dev smoke to bypass `auto-git-url` — the `io.github.*`
-  ;; prefix triggers an automatic git-clone of the published repo,
-  ;; which doesn't exist yet. §3 publishes the repo + flips the
-  ;; on-disk path to `io/github/day8/re_frame2_template/`.
+  ;; The local symbol deliberately lacks the `io.github.*` prefix, which
+  ;; would make deps-new clone a remote repository instead of resolving this
+  ;; checkout from the classpath.
   :new {:replace-deps {io.github.seancorfield/deps-new
                        {:git/tag "v0.12.1" :git/sha "883e82c"}}
         :ns-default org.corfield.new}}}

--- a/tools/template/resources/day8/re_frame2_template/_css_tailwind/index.html
+++ b/tools/template/resources/day8/re_frame2_template/_css_tailwind/index.html
@@ -43,8 +43,8 @@
     <meta http-equiv="Content-Security-Policy"
           content="default-src 'self'; script-src 'self' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' ws: wss:; object-src 'none'; base-uri 'none'">
     <title>{{name}} — re-frame2</title>
-    <!-- Tailwind v4, dev-only CDN compiler (@tailwindcss/browser@4,
-         Q6 lock / rf2-gthro). Compiles the utilities used on the page at
+    <!-- Tailwind v4, dev-only CDN compiler (@tailwindcss/browser@4). It
+         compiles the utilities used on the page at
          runtime — zero build step. Swap for a compiled stylesheet from
          `@tailwindcss/cli` before shipping (README "Production
          hardening"). -->

--- a/tools/template/resources/day8/re_frame2_template/_helix/core.cljs
+++ b/tools/template/resources/day8/re_frame2_template/_helix/core.cljs
@@ -7,8 +7,6 @@
             [re-frame.adapter.helix :as helix-adapter]
             [{{namespace}}.events]
             [{{namespace}}.subs]
-            ;; Frame-local schema registration — called from `init` under the
-            ;; app's frame scope (see register-schema! below).
             [{{namespace}}.schema   :as schema]
             [{{namespace}}.views    :as views]))
 
@@ -18,32 +16,19 @@
 (defn ^:export init
   "Called by shadow-cljs. Idempotent — re-invoked on each hot reload."
   []
-  ;; Pass the adapter spec map directly — no registry.
   (rf/init! helix-adapter/adapter)
-  ;; EP-0002 carried-frame invariant (Spec 002 §Frame target resolution):
-  ;; the runtime never synthesises a frame from absence. `init!` installs the
-  ;; adapter only; this app registers `:rf/default` as its app frame, then
-  ;; runs its frame-local boot work (schema attach + seed dispatch) inside a
-  ;; `with-frame :rf/default` scope, and wraps the render in the Helix
-  ;; `frame-provider` so the `use-subscribe` / `capture-frame` reads inside the
-  ;; view tree resolve to `:rf/default`.
+  ;; `init!` installs the adapter but does not create a frame. Register the
+  ;; app frame before frame-local boot work and provide it to the view tree.
   ;;
-  ;; EGRESS CLASSIFICATION (Spec 015 §The three-layer model): app-db SCHEMAS
-  ;; validate shape; they do NOT classify durable app-db egress. Once your
-  ;; app-db carries sensitive paths (an `[:auth]` token) or large blobs,
-  ;; classify them from the event that writes them — return the `:sensitive` /
-  ;; `:large` commit-plane effects alongside `:db` (EP-0025) so the framework
-  ;; redacts/elides at every observation boundary (Xray, Story, error sink,
-  ;; off-box export):
+  ;; Schemas validate shape; they do not classify durable app-db egress.
+  ;; Classify a path from the event that writes it by returning `:sensitive`
+  ;; or `:large` alongside `:db`:
   ;;   (rf/reg-event :auth/init
   ;;     (fn [{:keys [db]} _]
   ;;       {:db        (assoc db :auth {})
   ;;        :sensitive [[:auth :token]]
   ;;        :large     [[:documents :upload]]}))
-  ;; HTTP carrier names ride the `:rf.http/managed` reg-fx registration's
-  ;; `:carriers` block (`(rf/reg-fx :rf.http/managed {:carriers {:headers ["X-My-Auth"]}} h)`).
-  ;; See README §Privacy / egress classification. HTTP response BODIES are
-  ;; classified on the request's `:decode` schema instead — see events.cljs.
+  ;; See the README's privacy section for HTTP carriers and response bodies.
   (rf/reg-frame :rf/default {})
   (rf/with-frame :rf/default
     (schema/register-schema!)

--- a/tools/template/resources/day8/re_frame2_template/_reagent/core.cljs
+++ b/tools/template/resources/day8/re_frame2_template/_reagent/core.cljs
@@ -9,11 +9,9 @@
   (:require [reagent.dom.client       :as rdc]
             [re-frame.core            :as rf]
             [re-frame.adapter.reagent :as reagent-adapter]
-            ;; Side-effecting requires — register the events and subs.
+            ;; Requiring these namespaces installs their registrations.
             [{{namespace}}.events]
             [{{namespace}}.subs]
-            ;; Frame-local schema registration — called from `init` under the
-            ;; app's frame scope (see register-schema! below).
             [{{namespace}}.schema    :as schema]
             [{{namespace}}.views     :as views]))
 
@@ -24,37 +22,23 @@
   "Called by shadow-cljs (see :init-fn in shadow-cljs.edn). Idempotent —
    shadow's hot-reload pipeline re-invokes it on each rebuild."
   []
-  ;; `rf/init!` takes the adapter spec map directly — pass the adapter
-  ;; var explicitly (there is no default-adapter registry).
   (rf/init! reagent-adapter/adapter)
-  ;; EP-0002 carried-frame invariant (Spec 002 §Frame target resolution):
-  ;; the runtime never synthesises a frame from absence. `init!` installs the
-  ;; adapter only; this app registers `:rf/default` as its app frame, then
-  ;; runs its frame-local boot work (schema attach + seed dispatch) inside a
-  ;; `with-frame :rf/default` scope, and wraps the render in a `frame-provider`
-  ;; so every in-tree dispatch/subscribe resolves to `:rf/default`.
+  ;; `init!` installs the adapter but does not create a frame. Register the
+  ;; app frame before running frame-local boot work, and provide that same
+  ;; frame to the rendered tree below.
   ;;
-  ;; The empty `{}` config is also where frame-owned EGRESS CLASSIFICATION
-  ;; lives (Spec 015 §The three-layer model). app-db SCHEMAS validate shape;
-  ;; they do NOT classify durable app-db egress. Once your app-db carries
-  ;; sensitive paths (an `[:auth]` token) or large blobs, classify them from
-  ;; the event that writes them — return the `:sensitive` / `:large`
-  ;; commit-plane effects alongside `:db` (EP-0025) so the framework
-  ;; redacts/elides at every observation boundary (Xray, Story, error sink,
-  ;; off-box export):
+  ;; Schemas validate shape; they do not classify durable app-db egress.
+  ;; Classify a path from the event that writes it by returning `:sensitive`
+  ;; or `:large` alongside `:db`:
   ;;   (rf/reg-event :auth/init
   ;;     (fn [{:keys [db]} _]
   ;;       {:db        (assoc db :auth {})
   ;;        :sensitive [[:auth :token]]
   ;;        :large     [[:documents :upload]]}))
-  ;; HTTP carrier names ride the `:rf.http/managed` reg-fx registration's
-  ;; `:carriers` block (`(rf/reg-fx :rf.http/managed {:carriers {:headers ["X-My-Auth"]}} h)`).
-  ;; See README §Privacy / egress classification. HTTP response BODIES are
-  ;; classified on the request's `:decode` schema instead — see events.cljs.
+  ;; See the README's privacy section for HTTP carriers and response bodies.
   (rf/reg-frame :rf/default {})
   (rf/with-frame :rf/default
-    ;; Frame-local schema attach — must run under a live frame scope (it
-    ;; cannot register at ns-load; see {{namespace}}.schema/register-schema!).
+    ;; Schema attachment is frame-local and must run after reg-frame.
     (schema/register-schema!)
     ;; dispatch-sync so the initial render sees the seeded app-db rather
     ;; than a transient empty frame.

--- a/tools/template/resources/day8/re_frame2_template/_reagent/core_with_ssr.cljc
+++ b/tools/template/resources/day8/re_frame2_template/_reagent/core_with_ssr.cljc
@@ -1,48 +1,13 @@
 (ns {{namespace}}.core
-  "One app that runs twice — server-side render + client-side hydration.
+  "Shared server-render and client-hydration entry point.
 
-   The server renders the counter to HTML so the first paint arrives
-   ready-made; the client then hydrates that same HTML and takes over,
-   fully interactive. Both runs are the *same code* — which is why this
-   file is `.cljc` and not `.cljs`. The events, subscription, schema, and
-   view are written once and shared. The `#?(:clj …)` / `#?(:cljs …)`
-   reader conditionals carve out the few spots that genuinely differ: the
-   JVM render path on one side, the browser mount on the other.
-
-   Emitted by `day8/re-frame2-template` under `:include-ssr? true`
-   (Reagent-only in v1). The canonical worked example this mirrors is
-   `examples/capabilities/ssr/ssr/core.cljc` in the re-frame2 repo, and
-   the full story lives in Spec 011 — SSR & Hydration.
-
-   The tour, top to bottom:
-   - The whole-app-db schema, kept as a plain value so it can be
-     registered against whichever frame the entry point stands up (the
-     throwaway per-request server frame, or the fixed client frame).
-   - `:counter/initialise` / `:counter/increment` — the shared events.
-   - `:counter/value` — the shared subscription.
-   - `counter-app` — the shared root view (`reg-view`).
-   - SERVER ENTRY: `register-schema!` / `:ssr/register-schema` /
-     `server-init-events` / `root-view` — the per-request schema-attach
-     step and the vectors the Ring host-adapter (see server.clj) hands
-     to `ssr-handler`.
-   - CLIENT ENTRY: `run`, which boots through `ssr/hydrate!` — READ the
-     embedded payload, HYDRATE (dispatch the framework-owned `:rf/hydrate`
-     event), VERIFY the render hash — then mounts on top of the seeded
-     state. No flash, no re-fetch."
+   Events, subscriptions, schema, and view run on both platforms. The Ring
+   host creates a short-lived frame per request; the browser creates a
+   client frame, applies the embedded payload with `ssr/hydrate!`, verifies
+   the render hash, and mounts the same view."
   (:require [re-frame.core :as rf]
-            ;; Schema hooks — required as a side-effecting load so the
-            ;; `reg-app-schema` calls below have a live validator to resolve
-            ;; to. Requiring `re-frame.schemas` makes the default Malli
-            ;; validator live: the artefact `:require`s its Malli adapter
-            ;; itself at ns-load (on both platforms), so a registered schema
-            ;; validates rather than soft-passing — "schema implies
-            ;; validation" (rf2-v96fh). Mirrors the canonical SSR example
-            ;; (examples/capabilities/ssr/ssr/core.cljc).
+            ;; Installs the default Malli validator before schema attachment.
             [re-frame.schemas]
-            ;; The SSR machinery: the framework-owned `:rf/hydrate` event, the
-            ;; render/hash hooks, and (JVM-side) the pure hiccup -> HTML
-            ;; emitter. Required on both platforms so `:rf/hydrate` is
-            ;; auto-registered for the client hydrate path.
             [re-frame.ssr :as ssr]
             #?(:cljs [reagent.dom.client :as rdc])
             #?(:cljs [re-frame.adapter.reagent :as reagent-adapter])))
@@ -51,11 +16,7 @@
 ;; SCHEMA
 ;; ============================================================================
 ;;
-;; A plain value, registered per-frame by whichever entry point brings a
-;; frame up. Parking it in a `def` means namespace-load never reaches for
-;; an ambient frame that isn't there yet (reg-app-schema is frame-local,
-;; EP-0002). See ../../../examples/capabilities/ssr/ssr/core.cljc for the
-;; longer discussion.
+;; Keep the schema as data and attach it after each platform creates a frame.
 
 (def CounterDb
   [:map {:closed true}
@@ -65,24 +26,19 @@
 ;; EVENTS
 ;; ============================================================================
 
-;; Per-request server boot. Seeds the counter so the server render has a
-;; value to show. Server-only (`:platforms #{:server}`); the client never
-;; dispatches it — it hydrates the server's finished state instead.
+;; The client hydrates this server-seeded state instead of running this event.
 (rf/reg-event :rf/server-init
   {:doc       "Per-request server-side boot — seeds the counter."
    :platforms #{:server}}
   (fn [_cofx _event]
     {:db {:counter/value 0}}))
 
-;; Client-side bootstrap for a plain first load (no server render). Fires
-;; only when `ssr/hydrate!` finds no payload — see `run` below.
+;; Used only for a plain client load with no hydration payload.
 (rf/reg-event :counter/initialise
   {:doc "Client-side seed for a plain (non-server-rendered) first load."}
   (fn [_cofx _event]
     {:db {:counter/value 0}}))
 
-;; The button dispatches this. Same handler on both platforms — but only
-;; the client ever renders the button, so in practice it runs client-side.
 (rf/reg-event :counter/increment
   (fn [{:keys [db]} _event]
     {:db (update db :counter/value inc)}))
@@ -99,15 +55,7 @@
 ;; VIEW
 ;; ============================================================================
 ;;
-;; `reg-view` auto-`def`s the symbol, registers it under `(keyword *ns*
-;; sym)`, and injects a frame-bound `subscribe` / `dispatch` resolved at
-;; render time. That single detail is what lets one view run twice: on the
-;; JVM render path a deref just reads the current value; on the client the
-;; same deref registers a reaction so the view re-renders on change. Same
-;; code, two behaviours, picked up from the context.
-;;
-;; The `^{:rf/id :app/root}` metadata pins the id the server + client both
-;; name (server.clj's `:root-view [:app/root]`, and `run`'s render below).
+;; Pin the view id so the server and browser resolve the same registration.
 
 (rf/reg-view ^{:rf/id :app/root} counter-app []
   [:div
@@ -123,46 +71,14 @@
 ;; SERVER ENTRY POINT
 ;; ============================================================================
 ;;
-;; server.clj wires `server-init-events` + `root-view` into
-;; `re-frame.ssr.ring/ssr-handler`, which owns the per-request lifecycle
-;; (frame create -> drain -> response read -> render -> frame destroy) —
-;; and gensyms the per-request frame id INTERNALLY. server.clj (and this
-;; namespace) never see that id, so the schema can't be attached with an
-;; explicit `{:frame frame-id}` call the way the CLIENT does below (where
-;; `app-frame` is a known symbol).
-;;
-;; Instead `:ssr/register-schema` rides as the FIRST `:initial-events`
-;; step (see `server-init-events`): its handler body runs with
-;; `frame/*current-frame*` bound to the very frame `ssr-handler` is
-;; constructing for THIS request — the binding covers "the duration of
-;; the handler chain" per Spec 002 §Dispatch resolution chain — so a
-;; no-`:frame`-override `register-schema!` call resolves that ambient
-;; frame. This is the scope path `schemas.cljc`'s `resolve-frame` names
-;; as valid ("a frame `:initial-events` step"). It runs BEFORE
-;; `:rf/server-init` so the counter seed commit that follows has a
-;; schema to validate against.
-
-;; A JVM-side helper attaching the whole-app-db schema. Two forms:
-;;   (register-schema!)          — the AMBIENT frame (a carried-invariant
-;;                                 scope). `:ssr/register-schema` below
-;;                                 uses this form — the server never sees
-;;                                 its own per-request frame id.
-;;   (register-schema! frame-id) — an EXPLICIT frame. The CLIENT's `init`
-;;                                 (below) uses this form, since
-;;                                 `app-frame` IS a known symbol.
-;; reg-app-schema is frame-local, so either form must run under a live
-;; frame scope — never at ns-load.
+;; ssr-handler owns the per-request frame id. Its initial events run inside
+;; that frame, so the zero-arity helper attaches to the ambient request frame.
+;; The browser knows its frame id and uses the explicit arity.
 (defn register-schema!
   ([] (rf/reg-app-schema [] CounterDb))
   ([frame-id] (rf/reg-app-schema [] {:frame frame-id} CounterDb)))
 
-;; The schema-attach step — dispatched FIRST by `server-init-events`
-;; (below), never by the client (`:platforms #{:server}`; the client
-;; calls `register-schema!` directly from `init` instead). Returns `{}`
-;; — no `:db` effect — so THIS step's own commit is never itself subject
-;; to app-db schema validation (app-db schemas validate only when a
-;; `:db` effect lands, Mike ruling #11); it exists purely to attach the
-;; schema before the step that actually seeds the counter.
+;; Attach the schema before the following seed event returns its :db effect.
 (rf/reg-event :ssr/register-schema
   {:doc       "Per-request schema attach — registers the whole-app-db
                 schema against the frame ssr-handler is constructing for
@@ -174,10 +90,7 @@
 
 (def server-init-events
   "The `:initial-events` vector the Ring SSR handler dispatches into each
-   per-request server frame. `:ssr/register-schema` runs FIRST so the
-   whole-app-db schema is live before `:rf/server-init`'s seed commits —
-   see the comment above for why the schema can't be attached any other
-   way on this path."
+   request frame. Schema attachment must precede the seed commit."
   [[:ssr/register-schema]
    [:rf/server-init]])
 
@@ -189,27 +102,12 @@
 ;; CLIENT ENTRY POINT
 ;; ============================================================================
 ;;
-;; On the client the whole boot is `ssr/hydrate!` — the mirror of the
-;; server render. It rolls three steps into one, and the order is the
-;; point:
-;;   1. READ    — pull the embedded `__rf_payload` <script> by its id. A
-;;                malformed payload fails closed (nothing replaces app-db);
-;;                a missing one just means "nobody server-rendered this" — a
-;;                plain first load.
-;;   2. HYDRATE — dispatch-sync `[:rf/hydrate payload]` BEFORE the first
-;;                render. The framework handler swaps in the server's slice
-;;                and stashes the server's render hash for step 3.
-;;   3. VERIFY  — once the first render is on screen, hash the render tree
-;;                and compare it to the server's. Disagree and the runtime
-;;                raises `:rf.ssr/hydration-mismatch`.
+;; hydrate! reads and applies the embedded payload before the first render,
+;; then compares the client render-tree hash with the server marker.
 
 #?(:cljs (defonce ^:private react-root (atom nil)))
 
-;; The client's app-frame id. Threaded through `ssr/hydrate!` (where the
-;; server's state gets seeded) and the root `frame-provider` (where every
-;; dispatch / subscribe in the tree resolves). It must be a `:client`
-;; frame — the `:rf/hydrate` handler fires compatibility-check effects a
-;; `:server` frame would skip.
+;; Hydration and the view tree must target the same client frame.
 (def app-frame :rf/default)
 
 #?(:cljs
@@ -217,36 +115,21 @@
      "Called by shadow-cljs (see :init-fn in shadow-cljs.edn). Idempotent —
       shadow's hot-reload pipeline re-invokes it on each rebuild."
      []
-     ;; Point the runtime at the Reagent substrate (idempotent — installs
-     ;; the adapter on the first call, no-op after).
      (rf/init! reagent-adapter/adapter)
-     ;; Stand up the client app-frame before hydrating into it.
-     ;; Re-registering an existing frame is a no-op, so hot-reload shrugs.
+     ;; Create the frame before attaching its schema or hydrating state.
      (rf/reg-frame app-frame {:doc      "{{name}} SSR client app-frame"
                               :platform :client})
-     ;; Register the schema against the client frame — the mirror of the
-     ;; server's `:ssr/register-schema` step, using the explicit-frame
-     ;; arity since `app-frame` (unlike the server's per-request id) is a
-     ;; known symbol.
      (register-schema! app-frame)
-     ;; One call, all three steps — READ, HYDRATE, VERIFY — against the
-     ;; same `app-frame` the mount below uses. `:render-tree-fn` must hash
-     ;; the EXACT tree the server hashed: the server hashed
-     ;; `((rf/view :app/root))` (the view fn CALLED), so we call it the
-     ;; same way here — not the `[(rf/view :app/root)]` vector form Reagent
-     ;; mounts. `hydrate!` returns the payload it applied, or nil on a
-     ;; plain client load.
+     ;; Hash the realised view value, matching the server render input.
      (let [payload (ssr/hydrate! {:frame          app-frame
                                   :render-tree-fn (fn [] ((rf/view :app/root)))})]
        (when-not payload
-         ;; No payload — a plain first load (dev `watch app` with no server
-         ;; in front). Seed the counter so the page isn't a blank frame.
+         ;; A plain client load has no server state to apply.
          (rf/dispatch-sync [:counter/initialise] {:frame app-frame})))
      (when (exists? js/document)
        (when-not @react-root
          (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-       ;; Mount inside the app-frame's `frame-provider` so every dispatch /
-       ;; subscribe in the tree resolves to the frame we just hydrated.
+       ;; Resolve view registrations and dispatches against the hydrated frame.
        (rdc/render @react-root
                    [rf/frame-provider {:frame app-frame}
                     [(rf/view :app/root)]]))))

--- a/tools/template/resources/day8/re_frame2_template/_reagent/core_with_stories.cljs
+++ b/tools/template/resources/day8/re_frame2_template/_reagent/core_with_stories.cljs
@@ -12,38 +12,23 @@
    below; the Story shell allocates and owns its own root internally
    via `rdc/create-root` inside `mount-shell!`.
 
-   Per IMPL-SPEC §6.5 / Stage 8: under `:advanced` with
-   `:closure-defines {re-frame.story.config/enabled? false}`, every
-   `reg-*` form in `{{namespace}}.stories` elides to `nil` and
-   `mount-shell!` short-circuits — the production bundle carries no
-   Story body code.
-
-   IMPORTANT — elision is OPT-IN, not automatic. `re-frame.story.config/
-   enabled?` defaults to `true`, and `shadow-cljs.edn` does NOT set the
-   closure-define for you. So a plain `npx shadow-cljs release app` SHIPS
-   the Story shell, the `#/stories` route, and every registration to
-   production. To elide Story from the release bundle, add the
-   `:release` compiler-options block to `shadow-cljs.edn`'s `:app`
-   build:
+   Story elision is opt-in. To remove the shell and registrations from an
+   advanced release build, add this to the `:app` build in shadow-cljs.edn:
 
      :release {:compiler-options
                {:closure-defines {re-frame.story.config/enabled? false}}}
 
-   (Leave it OUT — keep `enabled?` true in release — only when you want
-   a release-flavoured Story build for visual-regression.)"
+   Leave the define unset when Story is intentionally part of the release."
   (:require [reagent.dom.client       :as rdc]
             [re-frame.core            :as rf]
             [re-frame.story           :as story]
             [re-frame.adapter.reagent :as reagent-adapter]
-            ;; Side-effecting requires — register events / subs and
-            ;; pull the views ns in so its `reg-view` forms register.
+            ;; Requiring these namespaces installs their registrations.
             [{{namespace}}.events]
             [{{namespace}}.subs]
-            ;; Frame-local schema registration — called from `init` under the
-            ;; app's frame scope (see register-schema! below).
             [{{namespace}}.schema     :as schema]
             [{{namespace}}.views      :as views]
-            ;; Loading the stories ns fires the Story `reg-*` calls.
+            ;; Loading the stories namespace installs Story registrations.
             [{{namespace}}.stories]))
 
 ;; -- Live-app root --------------------------------------------------------
@@ -62,9 +47,7 @@
 (defn- mount-app! []
   (story/unmount-shell!)
   (ensure-app-root!)
-  ;; EP-0002 carried-frame invariant: wrap the live-app render in a
-  ;; `frame-provider` so the in-tree dispatch/subscribe in `counter-app`
-  ;; resolve to the app's `:rf/default` frame (registered in `init`).
+  ;; Use the same frame that init seeds.
   (rdc/render @app-root [rf/frame-provider {:frame :rf/default} [views/counter-app]]))
 
 (defn- mount-stories! []
@@ -79,15 +62,8 @@
 
 ;; -- hashchange listener (hot-reload-safe) --------------------------------
 ;;
-;; `init` runs on first boot AND on every shadow hot-reload. The closure
-;; identity of `on-hash-change!` changes on each rebuild, so a naive
-;; `(.addEventListener … on-hash-change!)` in `init` would accumulate one
-;; stale listener per rebuild — every subsequent route change would then
-;; fire the mount switch N times (repeated React root teardown/recreate,
-;; flicker, a growing listener leak). We hold the *installed* listener in
-;; a `defonce` atom that survives reloads, and remove the previous one
-;; before adding the new one — so exactly one hashchange listener is ever
-;; wired, pointing at the current code.
+;; Hot reload creates a new callback identity. Keep the installed callback in
+;; a defonce atom so it can be removed before its replacement is registered.
 (defonce ^:private hash-listener (atom nil))
 
 (defn- install-hash-listener! []
@@ -101,27 +77,13 @@
    shadow's hot-reload pipeline re-invokes it on each rebuild."
   []
   (rf/init! reagent-adapter/adapter)
-  ;; EP-0002 carried-frame invariant (Spec 002 §Frame target resolution):
-  ;; `init!` installs the adapter only — the runtime never synthesises a
-  ;; frame from absence. Register `:rf/default` as the app frame, then run
-  ;; frame-local boot work (schema attach + seed dispatch) inside its scope.
-  ;; The live-app render wraps `counter-app` in a `frame-provider` (see
-  ;; mount-app!).
+  ;; init! installs the adapter but does not create the app frame.
   (rf/reg-frame :rf/default {})
-  ;; The canonical Story vocabulary auto-installs on the first `reg-*`
-  ;; call in `{{namespace}}.stories` (loaded via the :require above)
-  ;; — no explicit `(story/install-canonical-vocabulary!)`
-  ;; call needed. The hook is idempotent and survives a `clear-all!`
-  ;; during dev experiments.
-  ;; Seed app-db before the first render so the live-app branch sees a
-  ;; populated frame.
+  ;; stories.cljs installs the canonical Story vocabulary on its first
+  ;; registration. Seed app-db before mounting the live-app branch.
   (rf/with-frame :rf/default
     (schema/register-schema!)
     (rf/dispatch-sync [:counter/initialise]))
-  ;; Wire hash-change so reloading `#/stories` lands on the shell
-  ;; without a manual click-through. `install-hash-listener!` removes any
-  ;; listener a previous hot-reload installed before adding this one, so
-  ;; reloads never accumulate stale listeners (defonce atom holds the
-  ;; current one).
+  ;; Install the reload-safe route listener before applying the current hash.
   (install-hash-listener!)
   (on-hash-change!))

--- a/tools/template/resources/day8/re_frame2_template/_shared/README_with_ssr.md
+++ b/tools/template/resources/day8/re_frame2_template/_shared/README_with_ssr.md
@@ -52,7 +52,7 @@ Rebuild the client on save with the watcher above; to pick up a change to the
 - **`CounterDb`** — the whole-app-db Malli schema, kept as a plain value so it
   can be registered against whichever frame the entry point stands up (the
   throwaway per-request server frame, or the fixed client frame). `reg-app-schema`
-  is frame-local (EP-0002), so it is attached under a live frame scope, never at
+  is frame-local, so it is attached under a live frame scope, never at
   namespace load.
 - **`:counter/initialise` / `:counter/increment`** — the shared events.
 - **`:counter/value`** — the shared subscription.
@@ -219,8 +219,8 @@ error event.
 `core.cljc` registers a **whole-app-db schema** (`CounterDb`) at the empty path
 `[]`. The runtime validates every write against the registered schemas; a
 non-conforming write rolls back the `:db` effect and emits
-`:rf.error/schema-validation-failure`. App-db schemas are **frame-local**
-(EP-0002): the scaffold attaches the schema under a live frame scope
+`:rf.error/schema-validation-failure`. App-db schemas are **frame-local**:
+the scaffold attaches the schema under a live frame scope
 (`register-schema!` — the server via the `:ssr/register-schema` initial-event, the
 client via the explicit-frame arity), never at namespace load. Closed maps
 (`{:closed true}`) catch typos; schema validation elides automatically under
@@ -230,15 +230,15 @@ For multi-feature apps, register **per-feature schemas at their prefix path**
 rather than one giant root schema. Full detail:
 [Spec 010 §`app-db` schemas — path-based](https://github.com/day8/re-frame2/blob/main/spec/010-Schemas.md#app-db-schemas--path-based).
 
-### Privacy / egress classification — declare it on the frame
+### Privacy / egress classification — declare it where data is written
 
 re-frame2 makes runtime state highly observable (Xray, the trace stream, off-box
 monitors) — a productivity feature **and** a privacy surface. **App-db schemas
 validate shape; they do NOT classify egress.** Egress classification for durable
-app-db paths is owned by the **frame** (declared on `reg-frame`), never
-re-attached to a schema. As soon as you add auth/API data to app-db, classify it
-from the event that writes it — return the `:sensitive` / `:large` commit-plane
-effects alongside `:db` (EP-0025). On SSR the `:payload` allowlist on
+app-db paths is recorded per frame, but authored by the event that writes the
+data rather than on `reg-frame` or a schema. As soon as you add auth/API data
+to app-db, return the `:sensitive` / `:large` commit-plane effects alongside
+`:db`. On SSR the `:payload` allowlist on
 `ssr-handler` is a second privacy gate: ship only the slices the client needs in
 the hydration payload (this scaffold ships `[:counter/value]`), so server-only
 secrets never cross to the wire. Full model:

--- a/tools/template/resources/day8/re_frame2_template/_shared/events_test.cljs
+++ b/tools/template/resources/day8/re_frame2_template/_shared/events_test.cljs
@@ -14,51 +14,35 @@
             [re-frame.core                 :as rf]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support         :as ts]
-            ;; Side-effecting requires — load the user's handlers / subs
-            ;; into the registrar so the tests can dispatch / compute
-            ;; against them.
+            ;; Requiring these namespaces installs their registrations.
             [{{namespace}}.events]
             [{{namespace}}.subs]))
 
 ;; --- Fixture ---------------------------------------------------------------
 ;;
-;; `make-reset-runtime-fixture` snapshot/restores the registrar around each
-;; test, resets every frame's app-db to `{}`, and reinstalls the
-;; plain-atom adapter. Per-test `reg-*` calls roll back on exit;
-;; framework registrations (and the app's own ns-load registrations
-;; above) survive.
+;; The fixture restores registrations and app-db between tests and installs a
+;; DOM-free adapter.
 ;;
-;; STRICT cofx mint policy (EP-0017). The fixture's `:init-fn` re-registers
-;; `:rf/default` with `{:preset :test}`, which sets
-;; `:rf.cofx/mint-policy :strict`. Under strict, a handler that DECLARES a
-;; generator-backed recordable coeffect via `:rf.cofx/requires` but is NOT
-;; supplied the fact FAILS as `:rf.error/missing-required-cofx` rather than
-;; silently minting a fresh per-run value (a random uuid, the wall clock, …).
-;; That is EP-0017's *supply-data-don't-stub* testing posture: a test makes
-;; the durable fact explicit instead of letting a nondeterministic live read
-;; leak in. Supply required facts FLAT under `:rf.cofx` in the dispatch opts:
+;; The test preset uses strict coeffect minting. Handlers that require a
+;; generated fact must receive it under `:rf.cofx` instead of reading a live,
+;; nondeterministic value:
 ;;
 ;;     (rf/dispatch-sync [:order/place]
 ;;                       {:rf.cofx {:order/id #uuid "..."
 ;;                                  :rf/time-ms 1700000000000}})
 ;;
-;; A test that INTENTIONALLY accepts nondeterministic generation opts back
-;; into the live policy per-call with `:rf.cofx/mint-policy :explicit-live`:
+;; A test that intentionally exercises live generation can opt in per call:
 ;;
 ;;     (rf/dispatch-sync [:order/place] {:rf.cofx/mint-policy :explicit-live})
 ;;
-;; The plain counter events below declare no recordable coeffects, so they
-;; run identically under strict — the policy guards future handlers that add
-;; one, so the scaffold never regresses to live minting by default.
+;; The counter does not require generated coeffects; this default protects
+;; future tests as handlers grow.
 
 (use-fixtures :each
   (ts/make-reset-runtime-fixture
     {:adapter plain-atom/adapter
      :init-fn (fn []
-                ;; `:preset :test` ⇒ `:rf.cofx/mint-policy :strict` (EP-0017).
-                ;; Re-registering `:rf/default` is last-write-wins; it runs
-                ;; AFTER the fixture's `ensure-default-frame!`, so this is the
-                ;; effective default-frame config the tests dispatch into.
+                ;; The init hook overrides the fixture's default frame config.
                 (rf/reg-frame :rf/default {:preset :test}))}))
 
 ;; --- Tests -----------------------------------------------------------------

--- a/tools/template/resources/day8/re_frame2_template/_shared/schema.cljs
+++ b/tools/template/resources/day8/re_frame2_template/_shared/schema.cljs
@@ -1,64 +1,43 @@
 (ns {{namespace}}.schema
-  "App-db schema — typed-at-boundaries posture (Spec 010).
+  "App-db schema for validation at state-change boundaries.
 
    re-frame2 attaches schemas at paths. The framework validates writes
-   against every registered path-schema after each handler completes a
-   state mutation. A non-conforming write rolls back the `:db` effect
-   and emits a structured `:rf.error/schema-validation-failure` trace —
-   the runtime treats it as a failed dispatch (flows don't evaluate,
-   `:fx` doesn't walk), but the queue continues to drain.
+   against registered path schemas after a handler returns a `:db` effect.
+   A non-conforming write is rolled back and reported as
+   `:rf.error/schema-validation-failure`.
 
    The starter app registers ONE schema at the empty path `[]` — the
-   whole-app-db form (`get-in`/`assoc-in` semantics: `[]` means \"the
-   whole map\"). For multi-feature apps, split per-feature schemas at
-   their prefix paths (`[:cart]`, `[:auth]`, ...) per
+   whole-app-db form (`[]` means the whole map). For multi-feature apps,
+   split schemas across feature prefix paths such as `[:cart]` and `[:auth]`.
+   See
    [Spec 010 §`app-db` schemas — path-based](https://github.com/day8/re-frame2/blob/main/spec/010-Schemas.md#app-db-schemas--path-based)
    and the [Feature-modularity prefix
    convention](https://github.com/day8/re-frame2/blob/main/spec/Conventions.md#feature-modularity-prefix-convention).
 
-   The schemas artefact (`day8/re-frame2-schemas`) is loaded as a
-   side-effect in events.cljs. Requiring `re-frame.schemas` makes the
-   default Malli validator live — the artefact `:require`s its Malli
-   adapter (`re-frame.schemas.malli`) itself at ns-load, publishing
-   Malli's `validate` and `explain` into the framework's late-bind hook
-   table before any `reg-app-schema` call runs. \"Schema implies
-   validation\" (rf2-v96fh): there is no registered-but-silently-inert
-   state.
+   Requiring `re-frame.schemas` from events.cljs installs the default Malli
+   validator before this schema is registered.
 
    Schemas validate **in dev** (and on JVM unless production-hardened);
    the validation check elides automatically under `:advanced`
    `goog.DEBUG=false` builds — schema attachments stay in source but
    cost nothing in production hot paths.
 
-   A schema validates **shape**; it does NOT classify durable app-db
-   egress. Whether an app-db path is sensitive or large — and therefore
-   redacted/elided at observation boundaries (Xray, Story, traces,
-   off-box export) — is FRAME-owned policy declared on `reg-frame`, not
-   re-attached here (Spec 015 §Schemas describe shape, not durable app-db
-   egress policy: one owner, one route). See `core.cljs` (where the frame
-   is registered) and README §Privacy / egress classification."
+   A schema validates shape; it does NOT classify durable app-db egress.
+   The event that writes a sensitive or large path declares that fact via
+   commit-plane effects. See core.cljs and the README privacy section."
   (:require [re-frame.core :as rf]))
 
 ;; --- Whole-app-db schema ---------------------------------------------------
 ;;
-;; A closed map: a typo like `:countr/value` (one missing `e`) is caught
-;; at the boundary instead of producing a silent `nil` downstream. Open
-;; vs closed is a team decision — open admits new keys mid-development;
-;; closed catches typos. Best practice for a starter scaffold: closed.
+;; A closed map catches misspelled keys at the boundary. Choose open schemas
+;; deliberately when a feature needs to admit keys outside this contract.
 
 (def CounterDb
   [:map {:closed true}
    [:counter/value :int]])
 
-;; EP-0002 (carried-frame invariant, Spec 002 §Frame target resolution):
-;; app-db schemas are FRAME-LOCAL — `reg-app-schema` targets a frame and the
-;; runtime never synthesises one from absence. At namespace-load time no
-;; frame is established, so this registration MUST NOT run as a load-time
-;; side-effect (it would raise `:rf.error/no-frame-context`). Instead it is a
-;; boot step: `core/init` calls `register-schema!` AFTER `reg-frame` makes the
-;; app's `:rf/default` frame live, inside a `with-frame :rf/default` scope.
-;; (Contrast events/subs above, which are frame-agnostic global registrations
-;; and are fine at ns-load.)
+;; App-db schemas are frame-local, so core/init calls this after reg-frame
+;; instead of registering it as a namespace-load side effect.
 (defn register-schema!
   "Attach the whole-app-db schema to the app's frame. Call once at boot,
    under the app's frame scope (see core/init)."

--- a/tools/template/resources/day8/re_frame2_template/_shared/ssr_test.clj
+++ b/tools/template/resources/day8/re_frame2_template/_shared/ssr_test.clj
@@ -1,95 +1,48 @@
 (ns {{namespace}}.ssr-test
   "Headless JVM SSR test for the emitted {{name}} SSR scaffold.
 
-   Mirrors the canonical worked-example gate in the re-frame2 repo
-   (`re-frame.examples-test/ssr-example-runs-end-to-end`,
-   `examples/capabilities/ssr/ssr`): boots the SSR adapter, stands up a
-   per-request `:server` frame that drains `:rf/server-init`, renders the
-   `:app/root` view to a string with `render-to-string`, and asserts the
-   HTML content + the structural render-hash marker. No React / JSDOM — it
-   runs end-to-end on the JVM.
+   The direct render test exercises frame setup, rendering, and the hydration
+   hash. The handler tests compile and drive server.clj's production path,
+   including schema attachment to the frame that ssr-handler creates.
 
-   This is the gate shape a template-emitted SSR scaffold should ship (Spec
-   011 §Hydration-mismatch detection): it proves the server render path
-   compiles and produces hydration-ready HTML with the
-   `data-rf-render-hash` tripwire the client compares against.
-
-   `ssr-render-produces-hydration-ready-html` (above) hand-rolls
-   `reg-frame` + `register-schema!` directly, which is a DIFFERENT code
-   path from the one `server.clj` actually serves — `server.clj` never
-   sees its own per-request frame id (`ssr-ring/ssr-handler` gensyms it
-   internally), so a test that supplies the frame id itself cannot catch a
-   regression in how the schema attaches to THAT path (rf2-hbobni). The
-   two tests below exercise the REAL server path — the happy path drives
-   `server.clj`'s own `make-handler` (not a hand-rolled copy) and renders
-   normally, and a deliberately schema-violating commit is REJECTED,
-   proving `:ssr/register-schema` attaches the whole-app-db schema to the
-   exact frame `ssr-handler` constructs for the request, not a
-   different/default one.
-
-   Requiring `{{namespace}}.server` here is load-bearing beyond the one
-   test that calls it: it is the ONLY thing that compiles the Ring host
-   under `clojure -M:test` (the SSR scaffold's sole automated gate). Before
-   this require nothing loaded `server.clj`, so a framework rename on the
-   host surface (`ssr-ring/ssr-handler`, `ssr/adapter`) shipped
-   broken-but-green and first broke on `clojure -X:server` (rf2-e0xspa).
-
-   Run it with `clojure -M:test` (the `:test` alias picks it up alongside
-   the CLJS node-test build)."
+   Run with `clojure -M:test`."
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.string :as string]
             [re-frame.core :as rf]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.ring :as ssr-ring]
             [{{namespace}}.core :as app]
-            ;; The Ring host. Requiring it compiles server.clj under
-            ;; `clojure -M:test`, so a rename on its framework surface fails
-            ;; the build here instead of on first `clojure -X:server`
-            ;; (rf2-e0xspa). The happy-path test below drives its real
-            ;; `make-handler`.
+            ;; Requiring the host keeps its API surface in the test build.
             [{{namespace}}.server :as server]))
 
 (deftest ssr-render-produces-hydration-ready-html
   (testing "the SSR server flow renders the counter to HTML with a render hash"
-    ;; Boot the runtime (idempotent) — installs the SSR adapter. re-frame.ssr
-    ;; exports its own JVM-side `adapter` var (the counterpart of the
-    ;; reagent/uix/helix adapters); pass it explicitly.
     (rf/init! ssr/adapter)
     (let [fid      (keyword "rf.frame" (str (gensym "")))
-          ;; Populate the per-request request slot before the frame's
-          ;; :initial-events drain (the `:rf.server/request` cofx reads it).
+          ;; Initial events read the request coeffect from this slot.
           _        (ssr/set-request! fid {:uri "/"})
-          ;; Register the whole-app-db schema against this per-request frame
-          ;; BEFORE reg-frame drains :rf/server-init — otherwise the seed
-          ;; commit has nothing to validate against.
+          ;; Attach the schema before reg-frame drains initial events.
           _        (app/register-schema! fid)
           f        (rf/reg-frame fid
                      {:doc            "{{name}} SSR test frame"
                       :platform       :server
                       :initial-events app/server-init-events})
           final-db (rf/app-db-value f)]
-      ;; The root view derefs (rf/subscribe [:counter/value]), so it MUST
-      ;; be realised INSIDE the frame scope — `with-frame` binds
-      ;; *current-frame* across the render so the sub reads from f, not
-      ;; :rf/default (and not "no frame context"). We call the view fn,
-      ;; render, and hash all inside the one scope.
+      ;; Realise and hash the view inside the request frame so subscriptions
+      ;; read the state seeded above.
       (rf/with-frame f
         (let [hiccup      ((rf/view :app/root))
               html        (rf/render-to-string hiccup {:emit-hash? true})
               render-hash (rf/render-tree-hash hiccup)]
-          ;; :rf/server-init seeded the counter.
           (is (= 0 (:counter/value final-db))
               ":rf/server-init seeded :counter/value")
-          ;; The rendered HTML carries the counter view.
           (is (string/includes? html "<h1>")
               "render-to-string round-trips the root view without React/JSDOM")
           (is (string/includes? html "{{name}}")
               "the rendered HTML carries the app title")
           (is (string/includes? html "0")
               "the seeded counter value is rendered")
-          ;; The render hash is a structural marker (lowercase-hex FNV-1a
-          ;; per Spec 011); the client recomputes it and the runtime emits
-          ;; :rf.ssr/hydration-mismatch on disagreement.
+          ;; The client compares this marker during hydration.
           (is (re-matches #"[0-9a-f]{8}" render-hash)
               "render-tree-hash is an 8-char lowercase-hex FNV-1a digest")
           (is (string/includes? html "data-rf-render-hash")
@@ -100,12 +53,9 @@
   (testing "server.clj's OWN make-handler (the composite Ring handler
             `clojure -X:server` serves) renders normally end-to-end —
             :ssr/register-schema doesn't disturb the happy path, and
-            requiring the host ns compiles server.clj (rf2-e0xspa)"
+            requiring the host ns compiles server.clj"
     (rf/init! ssr/adapter)
-    ;; Build the actual production handler from server.clj — not a
-    ;; hand-rolled `ssr-ring/ssr-handler` copy. `static-root` only matters
-    ;; for the `/main.js` route; the SSR render path below (`:uri \"/\"`)
-    ;; never touches it, so any path serves.
+    ;; static-root is unused by the SSR route exercised here.
     (let [handler (server/make-handler "resources/public/js")
           resp    (handler {:uri "/" :request-method :get})]
       (is (= 200 (:status resp))
@@ -115,15 +65,10 @@
 
 (deftest ssr-handler-rejects-a-schema-violating-commit-on-the-real-path
   (testing "the REAL ssr-ring/ssr-handler path — the one server.clj actually
-            serves — enforces the whole-app-db schema (rf2-hbobni)"
+            serves — enforces the whole-app-db schema"
     (rf/init! ssr/adapter)
-    ;; A test-only step appended AFTER the app's own `server-init-events`,
-    ;; committing a key CounterDb's `{:closed true}` map forbids. If
-    ;; `:ssr/register-schema` failed to attach the schema to THIS
-    ;; per-request frame (the bug rf2-hbobni describes — the schema landing
-    ;; on a different/default frame the server never renders against), this
-    ;; commit would sail through uncaught and the assertion below would
-    ;; fail, catching the regression.
+    ;; Append a commit forbidden by CounterDb. A 500 proves the schema is
+    ;; attached to this request frame rather than another frame.
     (rf/reg-event :ssr-test/corrupt-commit
       {:doc "Test-only — forces a schema-violating app-db commit to prove
              server-side validation is live on the production ssr-handler
@@ -140,5 +85,4 @@
           (str "expected the schema-violating commit to be REJECTED by the "
                "production ssr-handler path (proving server-side app-db "
                "validation is live), but got status " (:status resp)
-               " — this is exactly the silently-inert-validation bug "
-               "rf2-hbobni describes if it regresses")))))
+               " — validation may not be attached to the request frame")))))

--- a/tools/template/resources/day8/re_frame2_template/_shared/stories.cljs
+++ b/tools/template/resources/day8/re_frame2_template/_shared/stories.cljs
@@ -1,11 +1,7 @@
 (ns {{namespace}}.stories
   "Story playground registrations for the scaffolded counter.
 
-   Emitted by `day8/re-frame2-template` when scaffolded with
-   `:include-story? true`. Mirrors the canonical shape at
-   `tools/story/testbeds/counter_with_stories/stories.cljs` in the
-   re-frame2 repo — kept small here so the scaffold reads at a glance
-   rather than overwhelming a first-time Story user.
+   Emitted when the project is scaffolded with `:include-story? true`.
 
    The four shipped `reg-*` macros each appear once:
 
@@ -14,18 +10,11 @@
    - `reg-tag`         — `:{{main}}/canonical` (project-scoped tag).
    - `reg-workspace`   — `:Workspace.counter/all` (auto-grid layout).
 
-   Per spec/017-Testing-Story.md §Public vocabulary every variant body
-   is plain data — no fn-slots; the public authoring keys are `:setup`
-   (preconditions) + `:script` (behaviour-under-test). The view at the
-   centre of each variant is referenced by
-   id (`:{{namespace}}.views/counter-app`); the events the variant
-   dispatches reference event-ids. Add more `reg-variant` / `reg-tag`
-   / `reg-decorator` / `reg-mode` calls below as your app grows."
+   Variant bodies are data: `:setup` establishes preconditions and `:script`
+   describes behaviour and assertions. Components and events are referenced
+   by registration id."
   (:require [re-frame.story :as story]
-            ;; Source the events / subs / views by requiring their
-            ;; namespaces — registrations fire as a side effect of
-            ;; loading the ns. The variant bodies reference those
-            ;; registrations by keyword id.
+            ;; Variant ids resolve against these registrations.
             [{{namespace}}.events]
             [{{namespace}}.subs]
             [{{namespace}}.views]))
@@ -34,10 +23,7 @@
   "Register the scaffolded Story artefacts. Idempotent — the trailing
    top-level call fires this at namespace load; tests / hot-reload may
    call it again after a `clear-all!`. The canonical Story vocabulary
-   (`:dev :docs :test :screenshot :experimental :internal :agent` tags,
-   the lifecycle machine, the `:rf.assert/*` handlers, the layout-debug
-   decorator set, and the v1 panel set) auto-installs on the first
-   `reg-*` call below — no explicit boot step required."
+   and assertion handlers auto-installs on the first `reg-*` call below."
   []
   ;; -- reg-tag — a project-scoped tag for the canonical screenshot ---------
   (story/reg-tag :{{main}}/canonical
@@ -53,14 +39,8 @@
 
   ;; -- reg-variant — empty (zero) + incremented (three clicks) -------------
   ;;
-  ;; The authoring surface is `:setup` (preconditions, dispatched before
-  ;; the play runs) + `:script` (the ordered behaviour-under-test). Per
-  ;; spec/017-Testing-Story.md §Public vocabulary `:setup` / `:script`
-  ;; are the public keys. A `:script` step is a tagged vector; an
-  ;; `:rf.assert/*` checkpoint rides the `[:assert [...]]` step tag, and a
-  ;; bare event vector lifts to `[:dispatch ...]`. This is what makes a
-  ;; Story double as a test — the `:rf.assert/*` checkpoints are the
-  ;; assertions, run by the CI play-runner.
+  ;; Setup runs before the play. Script steps drive behaviour and carry the
+  ;; assertions used by the play runner.
   (story/reg-variant :story.counter/empty
     {:doc    "Fresh counter at zero."
      :setup  [[:counter/initialise]]

--- a/tools/template/resources/day8/re_frame2_template/_uix/core.cljs
+++ b/tools/template/resources/day8/re_frame2_template/_uix/core.cljs
@@ -7,8 +7,6 @@
             [re-frame.adapter.uix :as uix-adapter]
             [{{namespace}}.events]
             [{{namespace}}.subs]
-            ;; Frame-local schema registration — called from `init` under the
-            ;; app's frame scope (see register-schema! below).
             [{{namespace}}.schema :as schema]
             [{{namespace}}.views  :as views]))
 
@@ -18,32 +16,19 @@
 (defn ^:export init
   "Called by shadow-cljs. Idempotent — re-invoked on each hot reload."
   []
-  ;; Pass the adapter spec map directly — no registry.
   (rf/init! uix-adapter/adapter)
-  ;; EP-0002 carried-frame invariant (Spec 002 §Frame target resolution):
-  ;; the runtime never synthesises a frame from absence. `init!` installs the
-  ;; adapter only; this app registers `:rf/default` as its app frame, then
-  ;; runs its frame-local boot work (schema attach + seed dispatch) inside a
-  ;; `with-frame :rf/default` scope, and wraps the render in the UIx
-  ;; `frame-provider` so the `use-subscribe` / `capture-frame` reads inside the
-  ;; view tree resolve to `:rf/default`.
+  ;; `init!` installs the adapter but does not create a frame. Register the
+  ;; app frame before frame-local boot work and provide it to the view tree.
   ;;
-  ;; EGRESS CLASSIFICATION (Spec 015 §The three-layer model): app-db SCHEMAS
-  ;; validate shape; they do NOT classify durable app-db egress. Once your
-  ;; app-db carries sensitive paths (an `[:auth]` token) or large blobs,
-  ;; classify them from the event that writes them — return the `:sensitive` /
-  ;; `:large` commit-plane effects alongside `:db` (EP-0025) so the framework
-  ;; redacts/elides at every observation boundary (Xray, Story, error sink,
-  ;; off-box export):
+  ;; Schemas validate shape; they do not classify durable app-db egress.
+  ;; Classify a path from the event that writes it by returning `:sensitive`
+  ;; or `:large` alongside `:db`:
   ;;   (rf/reg-event :auth/init
   ;;     (fn [{:keys [db]} _]
   ;;       {:db        (assoc db :auth {})
   ;;        :sensitive [[:auth :token]]
   ;;        :large     [[:documents :upload]]}))
-  ;; HTTP carrier names ride the `:rf.http/managed` reg-fx registration's
-  ;; `:carriers` block (`(rf/reg-fx :rf.http/managed {:carriers {:headers ["X-My-Auth"]}} h)`).
-  ;; See README §Privacy / egress classification. HTTP response BODIES are
-  ;; classified on the request's `:decode` schema instead — see events.cljs.
+  ;; See the README's privacy section for HTTP carriers and response bodies.
   (rf/reg-frame :rf/default {})
   (rf/with-frame :rf/default
     (schema/register-schema!)

--- a/tools/template/resources/day8/re_frame2_template/root/dev/scratch.cljs
+++ b/tools/template/resources/day8/re_frame2_template/root/dev/scratch.cljs
@@ -5,8 +5,8 @@
    nREPL after `npx shadow-cljs watch app`, then evaluate the
    `(comment …)` forms below.
 
-   EP-0002 (Spec 002 §Frame target resolution): the runtime never
-   synthesises a frame from absence — there is NO `:rf/default` floor.
+   The runtime never synthesises a frame from absence; there is no implicit
+   `:rf/default` floor.
    A bare `rf/dispatch` / `rf/subscribe` evaluated at the REPL with no
    established scope raises `:rf.error/no-frame-context`. So every
    example below names a frame explicitly: the live-app forms pin
@@ -44,12 +44,10 @@
   ;;
   ;; `with-new-frame` is the eval-bind-run-destroy form: it evaluates the
   ;; expr (here `make-frame`), binds the new frame to the symbol, runs the
-  ;; body under that frame's scope, then destroys the frame on exit (success
-  ;; or exception) — the live `:rf/default` frame is untouched. `rf/make-frame`
-  ;; returns the live frame OBJECT (EP-0023); `:initial-events` seeds the fresh
-  ;; frame's app-db before the body runs (EP-0027 — seeding is itself an event).
-  ;; (Use `with-frame <keyword>` to PIN an EXISTING frame, as above; use
-  ;; `with-new-frame [sym expr]` to CREATE one — see Spec 002 §with-frame.)
+  ;; body under that frame's scope, then destroys the frame on exit. The live
+  ;; `:rf/default` frame is untouched. `:initial-events` seeds the new frame
+  ;; before the body runs. Use `with-frame` for an existing frame and
+  ;; `with-new-frame` to create a temporary one.
   (rf/with-new-frame [f (rf/make-frame {:initial-events [[:rf/set-db {:counter/value 0}]]})]
     (rf/dispatch-sync [:counter/increment])
     @(rf/subscribe [:counter/value]))

--- a/tools/template/resources/day8/re_frame2_template/template.edn
+++ b/tools/template/resources/day8/re_frame2_template/template.edn
@@ -1,55 +1,9 @@
-;; deps-new template config for day8/re-frame2-template
-;; (rf2-dolpf §2.2-2.4, rf2-c2770).
+;; deps-new template config for day8/re-frame2-template.
 ;;
-;; Scope: the full three-substrate matrix (Reagent / UIx / Helix), with
-;; an optional Story playground on Reagent. The matrix is built at run
-;; time by `template-fn` (see the `:transform` note below); this EDN only
-;; declares the hook fns. See tools/template/spec/003-DepsNew-Rebuild-Plan.md
-;; for the migration plan and §-by-§ status.
-;;
-;; deps-new resolution mechanics:
-;;
-;;   - Symbol-to-path:
-;;     deps-new (`org.corfield.new.impl/find-root`) translates the
-;;     `:template` symbol to a filesystem path: dots → slashes,
-;;     dashes → underscores. So `day8/re-frame2-template` →
-;;     `day8/re_frame2_template/template.edn`. This file lives at
-;;     that path under `tools/template/resources/`.
-;;
-;;   - Current (pre-§3-split) local-dev / smoke:
-;;     `clojure -Sdeps '{:deps {day8/re-frame2-template
-;;                              {:local/root "./tools/template"}}}'
-;;       -Tnew create :template day8/re-frame2-template
-;;             :name acme/my-app`
-;;     The local-root coord exposes `tools/template/resources/` on
-;;     the classpath (via tools/template/deps.edn's `:paths`), so
-;;     `find-root`'s classpath lookup resolves to this file.
-;;     The non-`io.github.*` qualifier (`day8`) bypasses deps-new's
-;;     auto-git-clone behaviour — exactly what we want during
-;;     in-repo development.
-;;
-;;   - §3 steady-state — published / git-coord:
-;;     `clojure -Tnew create :template io.github.day8/re-frame2-template
-;;             :name acme/my-app`
-;;     deps-new sees the `io.github.*` prefix, auto-derives the URL
-;;     `https://github.com/day8/re-frame2-template.git`, clones via
-;;     `gitlibs/procure`, then runs `find-root` against the clone
-;;     using the resolved symbol (path
-;;     `io/github/day8/re_frame2_template/template.edn`). The repo
-;;     split (spec/005-Repo-Split.md §2.1) retargets the resources to
-;;     the `io/github/day8/...` path inside the extracted
-;;     `day8/re-frame2-template` repo so the steady-state invocation
-;;     works against the published artefact. The current monorepo tree
-;;     ships the `day8/...` path only — the retarget is mechanical (a
-;;     `git mv`) once the split lands, and the local-dev smoke then
-;;     resolves that single canonical body via the
-;;     `day8/re-frame2-template%%io.github.day8/re-frame2-template`
-;;     override coord (no second on-disk copy; see 005 §2.1 + §3.4.1).
-;;
-;; The static `:transform` is intentionally absent — `template-fn`
-;; (in `src/day8/re_frame2_template/hooks.clj`) builds the transform
-;; vector at run time from the chosen substrate + opt-in flags. The
-;; programmatic body owns the decisions.
+;; deps-new maps the template symbol to this resource and resolves these
+;; functions from the classpath. `template-fn` builds `:transform` at run
+;; time because the selected substrate and optional features change the
+;; emitted file set.
 {:description     "Scaffold a new re-frame2 application (Reagent / UIx / Helix; optional Story playground via :include-story? true on Reagent)."
  :data-fn         day8.re-frame2-template.hooks/data-fn
  :template-fn     day8.re-frame2-template.hooks/template-fn

--- a/tools/template/spec/000-Vision.md
+++ b/tools/template/spec/000-Vision.md
@@ -89,9 +89,9 @@ and recognises the shape. That continuity is deliberate.
 
 ## Non-goals
 
-- **Branching feature toggles** beyond the locked v1 set. The
+- **Branching feature toggles** beyond the current set. The
   template ships **three flags total**: `:include-story?`, `:css`,
-  and `:include-ssr?`. Branching is reserved for the day choices
+  and `:include-ssr?`. Branching is reserved for the day when choices
   materially exceed deps-new's substitution capability
   ([DESIGN-RATIONALE](DESIGN-RATIONALE.md) §deps-new vs CLI).
 
@@ -99,18 +99,17 @@ and recognises the shape. That continuity is deliberate.
   *optional shared scaffolding* whose absence would force the user
   into hand-wiring known idioms:
 
-  - `:include-story?` (rf2-t009p, shipped today) — emits a
+  - `:include-story?` — emits a
     `counter_with_stories`-shaped story scaffold alongside the
-    live app. Reagent-only in v1.
-  - `:css :tailwind` (rf2-gthro verification; wiring rf2-nxqcov,
-    shipped) — Tailwind v4 in place of the default plain-CSS
+    live app. Currently Reagent-only.
+  - `:css :tailwind` — Tailwind v4 in place of the default plain-CSS
     `app.css`: a CSS-first `@import "tailwindcss";` stylesheet (no
     `tailwind.config.js`) plus an `index.html` that loads the
     `@tailwindcss/browser@4` dev CDN compiler. Substrate-invariant.
-  - `:include-ssr?` (rf2-675qdb, shipped) — SSR scaffolding per
+  - `:include-ssr?` — SSR scaffolding per
     Spec 011: a shared `core.cljc` (JVM render + CLJS hydration),
     a `server.clj` Ring host, and a headless `ssr_test.clj`.
-    Reagent-only in v1; mutually exclusive with `:include-story?`.
+    Currently Reagent-only; mutually exclusive with `:include-story?`.
 
   Resist further proliferation — every additional flag requires
   explicit DESIGN-RATIONALE justification.
@@ -126,9 +125,9 @@ and recognises the shape. That continuity is deliberate.
   Guide chapter 06 to add more.
 - **Server-side hosting on the default path.** The default scaffold is a
   pure CLJS SPA — no backend. SSR scaffolding (Spec 011) is the opt-in
-  exception: `:include-ssr? true` (rf2-675qdb, shipped) emits a shared
+  exception: `:include-ssr? true` emits a shared
   `core.cljc` + a Ring/Jetty `server.clj` host + a headless `ssr_test.clj`
-  (Reagent-only in v1). See 004-SSR-Validation-Report and
+  (currently Reagent-only). See 004-SSR-Validation-Report and
   001-Substrate-Variants §Variants.
 
 ## Distribution
@@ -150,8 +149,8 @@ a GitHub Release per `template-v<VERSION>` tag push; that's the
 publication moment from the consumer's perspective.
 
 Initial home is `tools/template/` inside the `day8/re-frame2`
-monorepo. Final home is a dedicated `day8/re-frame2-template` repo;
-the split is rf2-7jgkv (rf2-dolpf §4).
+monorepo. Final home is a dedicated `day8/re-frame2-template` repo; see
+005-Repo-Split for the remaining procedure.
 
 ## Cross-references
 

--- a/tools/template/spec/001-Substrate-Variants.md
+++ b/tools/template/spec/001-Substrate-Variants.md
@@ -61,8 +61,7 @@ message naming the valid set:
 
 Anything not in `#{:reagent :uix :helix}` (or anything not a keyword)
 throws an `ex-info` with the offending value and the set of valid
-substrates in `ex-data`. This tightening (rf2-h0imw) replaces the
-earlier kw/string/symbol forgiving-input posture; see
+substrates in `ex-data`. See
 [DESIGN-RATIONALE.md §8](DESIGN-RATIONALE.md) for the rationale.
 
 ## What each variant emits
@@ -126,11 +125,8 @@ io.github.day8/re-frame2-template ...` and then reads Guide chapter
 
 ## SSR variant (`:include-ssr? true`, Reagent-only)
 
-Both gating conditions for the SSR variant have cleared —
-`implementation/ssr/` + `implementation/ssr-ring/` carry the full Spec 011
-reference impl, and rf2-0m5ea (SSR validation) closed — so
-`:include-ssr?` is a **live Reagent-only flag** (rf2-675qdb; the
-close-out of 004-SSR-Validation-Report §6).
+`:include-ssr?` is a live Reagent-only flag. The validation record is in
+004-SSR-Validation-Report.
 
 Under `:include-ssr? true` the Reagent counter is emitted as a shared
 `core.cljc` (the same code runs the JVM render path and the CLJS

--- a/tools/template/spec/002-Generated-Shape.md
+++ b/tools/template/spec/002-Generated-Shape.md
@@ -56,7 +56,7 @@ the emitted test file up out of the box, and `dev/scratch.cljs` +
 `(user/refresh)` entry) are reachable from `clojure -M:shadow` and
 shadow's nREPL without further classpath plumbing.
 
-**`dev/scratch.cljs` runs under a frame (EP-0002).** The runtime has no
+**`dev/scratch.cljs` runs under a frame.** The runtime has no
 implicit `:rf/default` floor — a bare `rf/dispatch` / `rf/subscribe`
 evaluated at the REPL with no established scope raises
 `:rf.error/no-frame-context` (Spec 002 §Frame target resolution). Every
@@ -132,7 +132,7 @@ identically across all three substrates:
 Xray is default-on because the scaffold's headline promise is
 "save and see it live" — the dispatch log, app-db diff, causality
 graph, and time-travel scrubber are the on-ramp's primary feedback
-surface. See [DESIGN-RATIONALE §9](DESIGN-RATIONALE.md#9--xray-on-by-default-rf2-y9zqc)
+surface. See [DESIGN-RATIONALE §9](DESIGN-RATIONALE.md)
 for the WHY and the release-elision guarantee. The generated
 `README.md` documents the runtime experience (the
 `Ctrl+Shift+C` toggle, what each panel shows).
@@ -156,7 +156,7 @@ tools/template/
     ├── root/                             ; bulk-copied, default placement
     │   ├── README.md
     │   ├── lefthook.yml
-    │   ├── .github/workflows/ci.yml      ; baseline CI workflow (rf2-k2z79)
+    │   ├── .github/workflows/ci.yml      ; baseline CI workflow
     │   ├── dev/{user.clj, scratch.cljs}
     │   └── resources/public/{index.html, css/app.css}
     ├── _shared/                          ; substrate-agnostic; renamed / flag-switched at emit

--- a/tools/template/spec/API.md
+++ b/tools/template/spec/API.md
@@ -39,7 +39,7 @@ Where:
 - `:substrate <kw>` is one of `:reagent` `:uix` `:helix`. Optional.
   Defaults to `:reagent`.
 - `:include-story? <bool>` and `:include-ssr? <bool>` are `true` /
-  `false` (default `false`). Both are **Reagent-only in v1** and
+  `false` (default `false`). Both are currently **Reagent-only** and
   **mutually exclusive** — pass at most one.
 - `:css <kw>` is `:tailwind` (the Tailwind v4 scaffold) or omitted
   (the plain-CSS default). Substrate-invariant.
@@ -108,15 +108,14 @@ clojure -Tnew create \
 | Arg | Required | Meaning | Default |
 |---|---|---|---|
 | `:substrate` | no | One of `:reagent` `:uix` `:helix`. | `:reagent` |
-| `:include-story?` | no | When `true`, scaffolds the Story playground alongside the live app — adds the `day8/re-frame2-story` coord, emits `src/.../stories.cljs`, and swaps the entry `core.cljs` for the hash-routing `core_with_stories.cljs` variant. **Reagent only in v1** — non-Reagent substrates throw a clear error (UIx + Helix follow once those variants' app-shells catch up to Reagent's). Mutually exclusive with `:include-ssr?`. | `false` |
-| `:include-ssr?` | no | When `true`, scaffolds a server-side-rendered app (JVM render + client hydration). The registration root becomes a single shared `src/.../core.cljc` (folding in the events / subs / schema / view), a Ring/Jetty `server.clj` host is added (run with `clojure -X:server`), and a headless JVM `test/.../ssr_test.clj` gate replaces the CLJS `events_test.cljs`. An SSR-flavoured `README.md` overlays the default SPA one. The per-slice CLJS sources (`events.cljs` / `subs.cljs` / `schema.cljs` / `views.cljs`) are **not** emitted — they live in `core.cljc`. **Reagent-only in v1** (non-Reagent substrates throw a clear error) and **mutually exclusive with `:include-story?`**. | `false` |
+| `:include-story?` | no | When `true`, scaffolds the Story playground alongside the live app — adds the `day8/re-frame2-story` coord, emits `src/.../stories.cljs`, and swaps the entry `core.cljs` for the hash-routing `core_with_stories.cljs` variant. **Currently Reagent-only**; non-Reagent substrates throw a clear error. Mutually exclusive with `:include-ssr?`. | `false` |
+| `:include-ssr?` | no | When `true`, scaffolds a server-side-rendered app (JVM render + client hydration). The registration root becomes a single shared `src/.../core.cljc` (folding in the events / subs / schema / view), a Ring/Jetty `server.clj` host is added (run with `clojure -X:server`), and a headless JVM `test/.../ssr_test.clj` gate replaces the CLJS `events_test.cljs`. An SSR-flavoured `README.md` overlays the default SPA one. The per-slice CLJS sources (`events.cljs` / `subs.cljs` / `schema.cljs` / `views.cljs`) are **not** emitted — they live in `core.cljc`. **Currently Reagent-only** and **mutually exclusive with `:include-story?`**. | `false` |
 | `:css` | no | `:tailwind` swaps the plain-CSS scaffold for a Tailwind v4 one — an `@import "tailwindcss";` `app.css` (v4 is CSS-first; no `tailwind.config.js`) and an `index.html` that loads the `@tailwindcss/browser@4` dev CDN compiler (zero build step). Omit (or pass `nil`) for the plain-CSS default. **Substrate-invariant** — identical across Reagent / UIx / Helix — and composes with `:include-story?` / `:include-ssr?`. | `nil` (plain CSS) |
 
 `:substrate` accepts only a keyword (or omission, which defaults
 to `:reagent`). Anything else — string, symbol, number, … — throws
 with a clear message naming the valid set. See
-[DESIGN-RATIONALE.md §8](DESIGN-RATIONALE.md) for why the earlier
-forgiving-input posture was tightened (rf2-h0imw).
+[DESIGN-RATIONALE.md §8](DESIGN-RATIONALE.md) for why inputs fail closed.
 
 `:include-story?` accepts `true` / `false` / `nil`; anything else
 throws. The branching exception is justified in
@@ -127,7 +126,7 @@ absence would force the user into hand-wiring known idioms.
 
 `:include-ssr?` likewise accepts `true` / `false` / `nil`; anything
 else throws `:rf.error/template-bad-include-ssr-flag`. It is
-**Reagent-only in v1** (a non-Reagent substrate throws
+currently **Reagent-only** (a non-Reagent substrate throws
 `:rf.error/template-include-ssr-reagent-only`) and **mutually
 exclusive with `:include-story?`** — passing both throws
 `:rf.error/ssr-and-story-mutually-exclusive`, because the
@@ -141,16 +140,13 @@ keyword — fails closed with `:rf.error/template-bad-css-flag`. The
 flag is orthogonal to `:substrate` / `:include-story?` /
 `:include-ssr?` and composes with all of them.
 
-The v1 set is locked at three flags total (`:include-story?`,
-`:include-ssr?`, `:css`) — all now live (`:css` under rf2-gthro
-verification + rf2-nxqcov wiring; `:include-ssr?` under rf2-0m5ea
-validation + rf2-675qdb wiring). Their accepted values and
-constraints are documented per-flag above.
+The current set has three live flags: `:include-story?`, `:include-ssr?`,
+and `:css`. Their accepted values and constraints are documented above.
 There are no reserved-but-unimplemented flags today; the fail-closed
 `reserved-flag-gates` list (empty) stays as the home for any future
 one — passing a reserved flag would throw
-`:rf.error/template-unsupported-flag` (the flag and its gating bead
-named in the message). Any other unrecognised template key,
+`:rf.error/template-unsupported-flag` (the flag and gate are named in the
+message). Any other unrecognised template key,
 including a typo of a live flag (e.g. `:include-story` for
 `:include-story?`), fails closed with
 `:rf.error/template-unknown-flag`. The gate distinguishes template
@@ -172,8 +168,8 @@ reads the args directly off the `data` map deps-new hands it.
 
 ## Local-development invocation
 
-Until the dedicated `day8/re-frame2-template` repo is published
-(rf2-dolpf §4 — repo split), use the `:local/root` route to exercise
+Until the dedicated `day8/re-frame2-template` repo is published, use the
+`:local/root` route to exercise
 the template from a checkout of this repo:
 
 ```bash

--- a/tools/template/spec/DESIGN-RATIONALE.md
+++ b/tools/template/spec/DESIGN-RATIONALE.md
@@ -88,7 +88,7 @@ branching choices ("include Story? include 10x?") but:
   include-story? + the two deferred flags). deps-new's programmatic
   template-fn is more than adequate.
 
-Option C remains reserved for the day branching choices materially
+Option C remains reserved for the day when branching choices materially
 exceed deps-new's substitution capability.
 
 ## §2 — Three substrates in v1 (Reagent / UIx / Helix)

--- a/tools/template/spec/Principles.md
+++ b/tools/template/spec/Principles.md
@@ -109,8 +109,8 @@ reads `:substrate` off the map and threads the coerced keyword
 through to `template-fn`'s per-substrate `case`.
 
 The v1 clj-new template plumbed `:substrate` through `:edn-args`
-to work around clj-new's top-level-arg stripping; the deps-new
-migration (rf2-dolpf) removed the workaround. See
+to work around clj-new's top-level-arg stripping; deps-new removed the
+workaround. See
 [DESIGN-RATIONALE.md §Retired §`:edn-args`-not-top-level](DESIGN-RATIONALE.md#retired--edn-args-not-top-level)
 for the historical record.
 
@@ -139,10 +139,7 @@ The substrate **value** is also strict: anything not in
 valid set. No silent fallback to default, no "did you mean...?"
 fuzz. The user sees the typo and fixes it.
 
-(History: this principle tightened from "forgiving on input shape,
-strict on substrate set" to "strict on both" in rf2-h0imw, on the
-back of the rf2-c8tmc first-principles audit. See
-[DESIGN-RATIONALE.md §8](DESIGN-RATIONALE.md) for the rationale.)
+See [DESIGN-RATIONALE.md §8](DESIGN-RATIONALE.md) for the rationale.
 
 ## P7 — Tested end-to-end, per substrate
 

--- a/tools/template/spec/README.md
+++ b/tools/template/spec/README.md
@@ -5,14 +5,14 @@
 - **[000-Vision.md](000-Vision.md)** — The v2 equivalent of v1's `day8/re-frame-template`: front-door scaffolding tool for new re-frame2 apps via deps-new + git-coord distribution.
 - **[001-Substrate-Variants.md](001-Substrate-Variants.md)** — The three substrate variants (`:reagent` default, `:uix`, `:helix`); top-level k/v invocation form; substrate coercion.
 - **[002-Generated-Shape.md](002-Generated-Shape.md)** — File layout the template emits; deps-new resource tree (`root/` + `_shared/` + per-substrate); substitution variables.
-- **[003-DepsNew-Rebuild-Plan.md](003-DepsNew-Rebuild-Plan.md)** — Normative migration plan for the deps-new rebuild (rf2-dolpf): final shape, Stage 2-4 decomposition, cross-references to the v1 emit-spec locks.
-- **[004-SSR-Validation-Report.md](004-SSR-Validation-Report.md)** — SSR reference-impl validation report (rf2-0m5ea); gates the `:include-ssr?` flag work.
-- **[005-Repo-Split.md](005-Repo-Split.md)** — Migration procedure for splitting `tools/template/` out of the monorepo into `github.com/day8/re-frame2-template` (rf2-dolpf §4 / rf2-7jgkv).
+- **[003-DepsNew-Rebuild-Plan.md](003-DepsNew-Rebuild-Plan.md)** — Completed migration record for the deps-new rebuild; historical, not the current API contract.
+- **[004-SSR-Validation-Report.md](004-SSR-Validation-Report.md)** — Completed validation record for the shipped SSR variant.
+- **[005-Repo-Split.md](005-Repo-Split.md)** — Procedure for the remaining split into `github.com/day8/re-frame2-template`.
 - **[API.md](API.md)** — Consolidated public surface: every invocation form, every argument, every supported flag.
 - **[Principles.md](Principles.md)** — Template-specific design principles (build-time only, never on consumer classpath); WHY for the major decisions lives in DESIGN-RATIONALE.
-- **[DESIGN-RATIONALE.md](DESIGN-RATIONALE.md)** — WHY behind 000 / 001 / 002 / Principles / API; deps-new over clj-new + git-coord over Clojars; beads referenced as rf2-xxxx.
+- **[DESIGN-RATIONALE.md](DESIGN-RATIONALE.md)** — Reasons behind the current design and its superseded alternatives.
 - **[findings/](findings/)** — Exploratory working substrate; audit lineage, not normative.
 
 ## How to use
 
-This folder is complete enough to one-shot the tool. Read [`000-Vision.md`](000-Vision.md) first to anchor scope (deps-new template, build-time-only, alpha-channel `day8/re-frame2-*` coords, git-coord distribution); the capability docs (001–002) are normative — they own the substrate-variants matrix and the generated file shape. [`Principles.md`](Principles.md) and [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md) capture the locks. [`API.md`](API.md) is the consolidated invocation reference. [`003-DepsNew-Rebuild-Plan.md`](003-DepsNew-Rebuild-Plan.md) is the migration record (§2-3 landed; §4 docs-sweep + scaffolding landed at rf2-7jgkv; §4 repo-split is operator-handoff per [`005-Repo-Split.md`](005-Repo-Split.md)). `findings/` preserves the audit lineage and is never normative.
+Start with [`API.md`](API.md) for invocation and argument details. The current normative design is in 000–002 and [`Principles.md`](Principles.md); [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md) explains the choices. Files 003–004 are completed migration/validation records, while 005 owns the pending repository split. `findings/` preserves audit lineage and is never normative.

--- a/tools/template/src/day8/re_frame2_template/hooks.clj
+++ b/tools/template/src/day8/re_frame2_template/hooks.clj
@@ -1,73 +1,26 @@
 (ns day8.re-frame2-template.hooks
   "deps-new hooks for day8/re-frame2-template.
 
-   `template.edn` declares this ns's `data-fn`, `template-fn`, and
-   `post-process-fn`. deps-new invokes them in that order:
+   `template.edn` declares three hooks, invoked in this order:
 
-     1. `data-fn`   — augment the substitution data map.
-     2. `template-fn` — return a modified template-edn whose `:transform`
-                       drives file emission.
-     3. `post-process-fn` — final fix-ups after files have been emitted
-                            (e.g. dotfile renames deps-new can't do
-                            natively).
+     1. `data-fn` validates arguments and derives substitution values.
+     2. `template-fn` selects the files for the requested variant.
+     3. `post-process-fn` prints the generated project's next steps.
 
-   Current scope (003-DepsNew-Rebuild-Plan.md §2.2-2.4):
+   The supported matrix is Reagent, UIx, and Helix; Story and SSR are
+   mutually exclusive Reagent-only options; Tailwind is available on every
+   substrate. Unknown keys and unsupported combinations fail closed.
 
-     - Substrates: Reagent / UIx / Helix (full matrix).
-     - Flags: `:include-story?` + `:include-ssr?` (both Reagent-only in
-       v1; UIx + Helix variants follow once each feature's adapter
-       coverage matches Reagent's). `:include-story?` and `:include-ssr?`
-       are **mutually exclusive** in v1 — passing both throws
-       `:rf.error/ssr-and-story-mutually-exclusive` (the file-naming
-       convention would blow up combinatorially on `_with_X_and_Y`
-       sources; see 004-SSR-Validation-Report §2.1).
-     - `:css` — `:tailwind` swaps the plain-CSS scaffold for a Tailwind
-       v4 one (Q6 lock / rf2-gthro verification; wiring rf2-nxqcov).
-       Omitted / nil ⇒ the plain-CSS default. Substrate-invariant.
-     - No pending (reserved-but-unimplemented) flags today.
-       `reserved-flag-gates` (empty) stays as the fail-closed home for any
-       future one — passing a reserved flag throws
-       `:rf.error/template-unsupported-flag` (see `gate-arg-keys!`).
-
-   ## Substitution engine note
-
-   deps-new uses **simple `{{key}}` substitution** (see
-   `org.corfield.new.impl/->subst-map` + `substitute`). There is **no**
-   Mustache-style conditional syntax (`{{#flag}}…{{/flag}}`) — `tools.build`'s
-   `copy-dir :replace` does a flat string replace.
-
-   This forces the `:include-story?` branch to be implemented as
-   **separate template-source files** rather than conditional blocks
-   inside one file: `_reagent/deps.edn` (default) vs
-   `_reagent/deps_with_story.edn` (with-story). `template-fn` picks the
-   right source per the flag; the output filename is the same
-   (`deps.edn`) regardless of which source ran.
-
-   `package.json` is the exception. Its per-flag deltas — the
-   `description` parenthetical naming the Story playground
-   (`{{story-tag}}`) and the `test` npm script (`{{test-script}}`: the
-   CLJS node-test bundle on the default / Story paths vs `clojure -M:test`
-   for the SSR scaffold's JVM `ssr_test.clj` gate) — are each small enough
-   to carry as a subst var, so a single `_shared/package.json` source
-   serves every path. No `package_with_story.json` / `package_with_ssr.json`
-   source exists.
-
-   The steady-state shape (see tools/template/spec/003-DepsNew-Rebuild-Plan.md
-   §1) is the same matrix; the v1 flag set (`:include-story?`,
-   `:include-ssr?`, `:css`) is fully wired — further flags slot in here
-   once justified in DESIGN-RATIONALE."
+   deps-new performs flat `{{key}}` substitution, not conditional template
+   syntax. Variants with structural differences therefore use separate
+   source files; small `package.json` differences use the `{{story-tag}}`
+   and `{{test-script}}` substitution values."
   (:require [clojure.set :as set]
             [clojure.string :as string]))
 
 ;; -- substrate registry -----------------------------------------------------
 ;;
-;; Single source of truth for the per-substrate facts. Each substrate's
-;; display label and shields.io badge URL live in one row, so adding a
-;; substrate is a one-row edit (the valid-set, the data-fn label/badge
-;; lookups, and `template-fn`'s `case` all key off this same set). Keeping
-;; these as one data table — rather than three parallel `case` forms keyed
-;; on the same `:reagent/:uix/:helix` set — is the data-driven idiom and
-;; removes the drift risk of the keys diverging across sites.
+;; Labels and badges share the same key set used for substrate validation.
 
 (def ^:private substrate-registry
   {:reagent {:label "Reagent"
@@ -89,7 +42,7 @@
   message naming the valid set.
 
   The contract is keyword-only: string and symbol inputs are rejected
-  rather than coerced, matching the SOTA pre-alpha fail-closed posture."
+  rather than coerced, preserving the fail-closed argument contract."
   [raw]
   (let [substrate-kw (cond
                        (nil? raw)     :reagent
@@ -121,30 +74,10 @@
 
 ;; -- argument-key gate -------------------------------------------------------
 ;;
-;; deps-new hands `data-fn` a single map that merges its own harness keys
-;; (the project-name derivations + run metadata) with whatever top-level
-;; k/v args the caller passed. We accept exactly four template-specific
-;; flags today (`:substrate`, `:include-story?`, `:include-ssr?`, `:css`).
-;; `reserved-flag-gates` is the fail-closed home for any future
-;; reserved-but-unimplemented flag (empty today — `:css` shipped under
-;; rf2-nxqcov once its rf2-gthro gate closed).
-;;
-;; The substrate posture already fails closed on bad values; this gate
-;; extends that strictness to the *key set* so a flag typo
-;; (`:include-story`) can't fail open into a misleading vanilla scaffold.
-;;
-;; HOW WE DISTINGUISH HARNESS KEYS FROM TEMPLATE KEYS: deps-new's
-;; `preprocess-options` (org.corfield.new.impl) populates a fixed, known
-;; set of harness keys before `data-fn` runs. We pin the deps-new coord in
-;; this template's deps.edn (and the §3 release install), so that set is
-;; deterministic — we allowlist it and reject anything outside it. If the
-;; pinned deps-new version is bumped and adds a harness key, this list must
-;; grow in lockstep (the gate would otherwise false-reject the new key);
-;; `harness-keys-not-rejected-test` exercises a representative harness key
-;; (`:overwrite`) to confirm the allowlist doesn't false-reject it, and
-;; `misspelled-story-flag-rejected-test` / `pluralised-story-flag-rejected-test`
-;; pin the negative direction (unknown keys ARE rejected) — together they
-;; keep that coupling honest.
+;; deps-new merges caller arguments with keys produced by
+;; `preprocess-options`. Keep this allowlist aligned with the pinned deps-new
+;; version; otherwise a newly introduced harness key will be rejected as an
+;; unknown template flag.
 
 (def ^:private deps-new-harness-keys
   "The keys deps-new injects into the `data` map before `data-fn` runs
@@ -163,14 +96,8 @@
   #{:substrate :include-story? :include-ssr? :css})
 
 (def ^:private reserved-flag-gates
-  "Reserved-but-unimplemented flags → the gating bead that must clear
-   before they go live. Passing one today fails closed rather than
-   scaffolding a vanilla app that silently lacks the feature.
-
-   Empty today: the last reserved flag (`:css`, gated on rf2-gthro)
-   shipped once the Tailwind-major verification closed (rf2-nxqcov).
-   Kept as the fail-closed home for any future reserved-but-unimplemented
-   flag."
+  "Reserved-but-unimplemented flags and the condition that enables them.
+   Passing one fails closed rather than silently emitting the default app."
   {})
 
 (defn- gate-arg-keys!
@@ -178,7 +105,7 @@
 
    - A reserved flag (see `reserved-flag-gates`; empty today) throws
      `:rf.error/template-unsupported-flag`, naming the flag and its
-     gating bead — it is not silently dropped.
+     gate — it is not silently dropped.
    - Any key that is neither a deps-new harness key nor a live
      template flag throws `:rf.error/template-unknown-flag` (catches
      typos like `:include-story` / `:include-stories?`)."
@@ -216,7 +143,7 @@
 (defn- coerce-include-story?
   "Coerce the `:include-story?` arg to a boolean. The only accepted
    values are literal `true` / `false` / `nil` (nil ⇒ false); anything
-   else throws with a clear message. The flag is Reagent-only in v1 —
+   else throws with a clear message. The flag is Reagent-only —
    caller-level guard checks the substrate."
   [raw]
   (if (contains? #{nil true false} raw)
@@ -234,7 +161,7 @@
 (defn- coerce-include-ssr?
   "Coerce the `:include-ssr?` arg to a boolean. The only accepted values
    are literal `true` / `false` / `nil` (nil ⇒ false); anything else
-   throws with a clear message. The flag is Reagent-only in v1 and
+   throws with a clear message. The flag is Reagent-only and
    mutually exclusive with `:include-story?` — caller-level guards check
    both (see data-fn)."
   [raw]
@@ -252,8 +179,7 @@
 
 (def ^:private valid-css
   "Accepted `:css` values. `nil` ⇒ the plain-CSS default; `:tailwind`
-   swaps in the Tailwind v4 scaffold (Q6 lock / rf2-gthro; wiring
-   rf2-nxqcov). Additional CSS opt-ins would grow this set."
+   swaps in the Tailwind v4 scaffold."
   #{:tailwind})
 
 (defn- coerce-css
@@ -308,77 +234,23 @@
 ;; -- data-fn ----------------------------------------------------------------
 
 (defn data-fn
-  "Augment deps-new's substitution data with re-frame2 template fields.
+  "Validate template arguments and derive values used during substitution.
 
-   deps-new auto-derives the project-name keys (from
-   `preprocess-options` + `->subst-map`):
-
-     {{name}}         — the qualified raw symbol (e.g. `acme/my-app`)
-     {{top}}          — group portion (e.g. `acme`)
-     {{main}}         — artifact portion (e.g. `my-app`)
-     {{top/ns}}       — namespace-safe top (`acme`)       ; ←
-     {{main/ns}}      — namespace-safe main (`my-app`)    ; ← computed by ->subst-map
-     {{top/file}}     — file-safe top (`acme`)            ; ←
-     {{main/file}}    — file-safe main (`my_app`)         ; ←
-
-   On top of those we add:
-
-     {{namespace}}    — derived `{{top/ns}}.{{main/ns}}` (matches the
-                        clj-new template's user-facing var; downstream
-                        Selmer-substituted files key off this).
-     {{nested-dirs}}  — derived `{{top/file}}/{{main/file}}` (file-path
-                        component, e.g. `acme/my_app` — used in
-                        `src/<nested-dirs>/core.cljs` rename targets).
-     {{substrate}}    — the chosen substrate name, lower-case
-                        (`reagent` / `uix` / `helix`).
-     {{substrate-label}} — the chosen substrate's display name, proper-
-                        case (`Reagent` / `UIx` / `Helix`); used in the
-                        substrate-invariant shadow-cljs.edn header comment
-                        and the package.json `description`, both emitted
-                        once from `_shared/`.
-     {{story-tag}}    — the package.json `description` suffix that varies
-                        by `:include-story?`: `\"\"` on the default path,
-                        `\", with Story playground\"` under
-                        `:include-story? true`. Lets the single
-                        `_shared/package.json` source carry both variants
-                        (the only per-flag delta was this one parenthetical).
-     {{test-script}}  — the package.json `test` npm script, which varies
-                        by `:include-ssr?`: the CLJS node-test bundle
-                        (`shadow-cljs compile test && node out/node-test.js`)
-                        on the default / Story paths, or `clojure -M:test`
-                        (the headless JVM `ssr_test.clj` gate) on the SSR
-                        path. A second `_shared/package.json` subst delta
-                        alongside `{{story-tag}}` — the SSR scaffold ships
-                        no cljs.test suite, so its `npm test` must run the
-                        JVM gate, not an empty node-test bundle.
-     {{substrate-badge-url}} — shields.io badge URL keyed by substrate.
-     {{rf2-version}}  — runtime coord version (kept in lockstep with
-                        the repo-root VERSION file via the §3 release
-                        pipeline; pinned manually for now).
-     {{shadow-version}} — shadow-cljs npm pin.
-     {{react-version}}  — react / react-dom npm pin.
-
-   Substrate + include-story? are also stored under `:substrate-kw` and
-   `:include-story?` for `template-fn`'s switch (`->subst-map` would
-   otherwise coerce the keyword to a string). `:css-kw` (nil or
-   `:tailwind`) is likewise stored for `template-fn`'s CSS overlay
-   branch (rf2-nxqcov)."
+   deps-new supplies `:name`, `:top`, and `:main`. This hook adds the
+   namespace/file forms, selected substrate metadata, package description
+   and test-script variants, and dependency version pins. Keyword copies of
+   selector values are retained for `template-fn`, because deps-new coerces
+   substitution values to strings."
   [data]
-  ;; Fail closed on reserved + unknown arguments BEFORE any coercion, so a
-  ;; flag typo or a documented-future flag never produces a misleading
-  ;; vanilla scaffold.
+  ;; Validate the key set before coercing values so a typo cannot silently
+  ;; emit the default scaffold.
   (gate-arg-keys! data)
   (let [substrate       (coerce-substrate (:substrate data))
         include-story?  (coerce-include-story? (:include-story? data))
         include-ssr?    (coerce-include-ssr? (:include-ssr? data))
         css             (coerce-css (:css data))]
-    ;; Guards — all hoisted above the name-derivation `let` so the data
-    ;; map build below has no side-effecting binding.
-
-    ;; Mutual exclusion (004-SSR-Validation-Report §2.1): the file-naming
-    ;; convention would blow up combinatorially on `_with_story_and_ssr`
-    ;; sources, and every additive combination needs its own template test.
-    ;; v1 locks the two feature flags mutually exclusive.
+    ;; Story and SSR have separate complete source variants; there is no
+    ;; combined variant.
     (when (and include-story? include-ssr?)
       (throw (ex-info
                ":rf.error/ssr-and-story-mutually-exclusive"
@@ -393,7 +265,7 @@
                 :include-story? include-story?
                 :include-ssr?   include-ssr?})))
 
-    ;; :include-story? is Reagent-only in v1.
+    ;; Story and SSR currently have Reagent implementations only.
     (when (and include-story? (not= substrate :reagent))
       (throw (ex-info
                ":rf.error/template-include-story-reagent-only"
@@ -408,9 +280,6 @@
                 :substrate substrate
                 :include-story? include-story?})))
 
-    ;; :include-ssr? is Reagent-only in v1 — the SSR worked example, the
-    ;; ssr-ring test corpus, and the emitted scaffold are all Reagent-
-    ;; driven (004-SSR-Validation-Report §Recommended decision / §7).
     (when (and include-ssr? (not= substrate :reagent))
       (throw (ex-info
                ":rf.error/template-include-ssr-reagent-only"
@@ -436,37 +305,19 @@
        :substrate-label     label
        :include-story?      include-story?
        :include-ssr?        include-ssr?
-       ;; nil (plain-CSS default) or :tailwind (Tailwind v4 scaffold).
-       ;; `template-fn` reads this to overlay the Tailwind app.css +
-       ;; index.html over the plain defaults emitted from `root/`.
+       ;; Keep selectors as keywords for `template-fn`; substitution values
+       ;; are stringified by deps-new.
        :css-kw              css
-       ;; package.json `description` suffix — the single per-flag delta
-       ;; between the default and with-Story descriptions. Emitting it as
-       ;; a subst var lets one `_shared/package.json` source serve both
-       ;; paths from a single file.
        :story-tag           (if include-story? ", with Story playground" "")
-       ;; package.json `test` script — the second per-flag delta the single
-       ;; `_shared/package.json` source carries via a subst var (alongside
-       ;; `{{story-tag}}`). The default + Story scaffolds ship a CLJS
-       ;; `events_test.cljs` run by the `:test` shadow node-test build; the
-       ;; SSR scaffold ships NO cljs.test suite — its only test is the
-       ;; headless JVM `ssr_test.clj`, run by the emitted deps.edn `:test`
-       ;; alias — so `npm test` (and the generated CI's `npm test` step)
-       ;; must invoke `clojure -M:test` there instead of the empty
-       ;; node-test bundle (which would false-green on zero tests).
+       ;; SSR emits a JVM test instead of the shared CLJS test.
        :test-script         (if include-ssr?
                               "clojure -M:test"
                               "shadow-cljs compile test && node out/node-test.js")
        :namespace           (str top-ns "." main-ns)
        :nested-dirs         (str top-file "/" main-file)
        :substrate-badge-url badge-url
-       ;; -- DO NOT EDIT — managed by version_lockstep_test --
-       ;; The three version pins below are checked against the repo-root
-       ;; sources of truth (the VERSION file, implementation/package.json's
-       ;; shadow-cljs / react pins) by
-       ;; `test/day8/re_frame2_template/version_lockstep_test.clj`. Bumping
-       ;; them here in isolation will fail that test. The §3 release pipeline
-       ;; updates all four in lockstep.
+       ;; Checked against the repository sources of truth by
+       ;; version_lockstep_test.clj; update the pins together.
        :rf2-version         "0.0.1.alpha"
        :shadow-version      "3.4.10"
        :react-version       "19.2.0"})))
@@ -475,125 +326,29 @@
 ;;
 ;; deps-new's file-emission contract:
 ;;
-;;   1. Bulk copy `<template-dir>/root/` → `<target-dir>/` (the project
-;;      root). Substitution applies; no renames.
-;;   2. For each entry in the `:transform` vector, run a second copy
-;;      with the file-map's rename rules applied.
+;;   1. Copy `root/` into the project root.
+;;   2. Apply each `[src-dir target-dir file-map :only]` transform.
 ;;
-;; Each transform entry is:
-;;
-;;     [src-dir target-dir file-map delimiters & flags]
-;;
-;; - `src-dir` is relative to the template-dir (the directory
-;;   containing `template.edn`), NOT relative to `root/`.
-;; - `target-dir` is relative to the project root; supports `{{var}}`
-;;   substitution.
-;; - `file-map` renames files inside the transform (substitution
-;;   applies to both keys and values).
-;; - Flags: `:only` (copy ONLY files in file-map; skip the implicit
-;;   bulk-copy of `src-dir`), `:raw` (no substitution).
-;;
-;; Layout (under `<template-dir>` =
-;; `resources/day8/re_frame2_template/`):
-;;
-;;     ├── root/        — bulk-copied content with default placement
-;;     │   ├── README.md  · lefthook.yml
-;;     │   ├── dev/{user.clj, scratch.cljs}
-;;     │   └── resources/public/{index.html, css/app.css}
-;;     ├── _shared/     — substrate-agnostic content that needs renames
-;;     │                  or a flag switch (dotfile rename + namespace-
-;;     │                   path rename for src/test files; the
-;;     │                   substrate-invariant build configs
-;;     │                   shadow-cljs.edn + package.json [the latter's
-;;     │                   with-Story `description` delta rides the
-;;     │                   {{story-tag}} subst var, not a second file];
-;;     │                   stories.cljs, which only emits under
-;;     │                   :include-story? true)
-;;     ├── _reagent/    — Reagent-specific content (core.cljs / views.cljs
-;;     │                  / deps.edn); includes the with-story core +
-;;     │                  deps variants
-;;     ├── _uix/        — UIx-specific content (core.cljs / views.cljs /
-;;     │                  deps.edn)
-;;     └── _helix/      — Helix-specific content (core.cljs / views.cljs
-;;                        / deps.edn)
-;;
-;; The underscore-prefix convention signals "not bulk-copied — picked
-;; up by a transform with :only". Per-substrate sub-trees emit only
-;; for the chosen substrate; the only files that genuinely vary by
-;; substrate are core.cljs (mount/adapter wiring), views.cljs (the
-;; view macros), and deps.edn (the adapter coord + npm libs).
+;; Underscore-prefixed directories are never bulk-copied. Their explicit
+;; file maps select shared, substrate-specific, and optional sources.
 
 (defn template-fn
-  "Build the `:transform` vector and merge it into the template EDN.
+  "Attach the explicit file transforms for the selected project variant.
 
-   Transform groups:
-
-     - Shared (from `_shared/`): dotfile rename (e.g. `gitignore` →
-       `.gitignore`) + namespace-path rename for src/test source files
-       + the substrate-invariant build configs (`shadow-cljs.edn`,
-       `package.json`).
-     - Per-substrate (from `_<substrate>/`): the files that genuinely
-       differ by substrate — the entry-point `core.cljs`, the view
-       module `views.cljs`, and `deps.edn` (adapter coord + npm libs).
-     - Story scaffolding (Reagent-only, under `:include-story? true`):
-       picks `core_with_stories.cljs` instead of `core.cljs`, picks
-       `deps_with_story.edn` instead of the default `deps.edn`, and emits
-       `stories.cljs` from `_shared/`. (The shared `package.json` source
-       is unchanged — its with-Story `description` delta rides the
-       `{{story-tag}}` subst var, not a second file.)
-     - SSR scaffolding (Reagent-only, under `:include-ssr? true`, mutually
-       exclusive with `:include-story?`): the app's registration root is a
-       single shared `core.cljc` (JVM render + CLJS hydration), so the
-       per-substrate branch picks `core_with_ssr.cljc` → `core.cljc`,
-       `deps_with_ssr.edn` → `deps.edn`, and adds a `server.clj` (the Ring
-       host). Because the SSR `core.cljc` folds in its own events / subs /
-       schema / view, the shared per-slice CLJS sources
-       (`events.cljs` / `subs.cljs` / `schema.cljs` / `events_test.cljs` /
-       `views.cljs`) are NOT emitted; the shared file-map instead emits a
-       headless JVM `ssr_test.clj` AND overlays an SSR-flavoured
-       `README_with_ssr.md` → `README.md` (rf2-6ikgyr) over the default SPA
-       README the `root/` bulk-copy laid down — the default one describes the
-       static dev-server workflow + per-slice file names the SSR branch does
-       not emit. See 004-SSR-Validation-Report §3 / §188.
-     - CSS overlay (substrate-invariant, under `:css :tailwind`; Q6 lock /
-       rf2-gthro, wiring rf2-nxqcov): overwrites the plain-CSS `app.css` +
-       `index.html` (emitted by the `root/` bulk-copy) with the Tailwind v4
-       variants from `_css_tailwind/` — an `@import \"tailwindcss\";`
-       stylesheet (v4 is CSS-first; no `tailwind.config.js`) and an
-       `index.html` that loads the `@tailwindcss/browser@4` dev CDN
-       compiler. Runs last so it lands on top of the root copy.
-
-   All groups use `:only` so only files explicitly listed in the
-   file-map emit (the implicit bulk-copy of `<src-dir>/*` is skipped).
-   The default placement files (README.md, lefthook.yml, dev/*,
-   resources/public/*) are handled by deps-new's `:root` bulk-copy
-   from `root/` — they don't need an entry here.
-
-   Dotfile sources live without the leading dot in the source tree;
-   the file-map attaches the dot on the output side (same defensive
-   pattern the clj-new template used)."
+   Shared files provide build config, dotfiles, and the default CLJS slices.
+   A substrate transform adds its adapter entry point, views, and deps. Story
+   replaces the Reagent entry point and deps and adds `stories.cljs`; SSR
+   replaces the CLJS slices with `core.cljc`, `server.clj`, a JVM test, and an
+   SSR-specific README. The optional Tailwind transform runs last so it can
+   replace the default stylesheet and HTML."
   [edn data]
   (let [nested         (:nested-dirs data)
         substrate      (:substrate data)
         include-story? (:include-story? data)
         include-ssr?   (:include-ssr? data)
         css            (:css-kw data)
-        ;; The build configs are substrate-invariant — the React
-        ;; substrate is chosen in deps.edn + core.cljs, never here — so
-        ;; they live in `_shared/` and emit once. package.json's only
-        ;; per-flag variation is its `description` parenthetical, carried
-        ;; by the `{{story-tag}}` subst var (see data-fn), so a single
-        ;; `_shared/package.json` source serves both the default and the
-        ;; with-Story path.
-        ;; Shared transforms — renames only. `:only` skips the bulk
-        ;; copy of `_shared/*`, so source files that don't appear in
-        ;; the file-map below DO NOT emit. Add explicit entries if
-        ;; you need them.
-        ;; The dotfiles + substrate-invariant build configs emit on every
-        ;; path. The per-slice CLJS sources (events / subs / schema /
-        ;; events_test / — and, per-substrate, views) are the DEFAULT and
-        ;; STORY shape; the SSR path folds those into `core.cljc` instead,
-        ;; so they are omitted there in favour of a headless `ssr_test.clj`.
+        ;; Every shared source must be named here because `:only` disables
+        ;; implicit copying.
         shared-common  {"gitignore"            ".gitignore"
                         "editorconfig"         ".editorconfig"
                         "cljfmt.edn"           ".cljfmt.edn"
@@ -602,57 +357,30 @@
                         "shadow-cljs.edn"      "shadow-cljs.edn"
                         "package.json"         "package.json"}
         shared-files   (cond-> shared-common
-                         ;; Default + Story shape: the per-slice CLJS
-                         ;; sources, re-homed under the user's namespace
-                         ;; path.
+                         ;; SSR folds these slices into core.cljc.
                          (not include-ssr?)
                          (assoc "events.cljs"      (str "src/" nested "/events.cljs")
                                 "subs.cljs"        (str "src/" nested "/subs.cljs")
                                 "schema.cljs"      (str "src/" nested "/schema.cljs")
                                 "events_test.cljs" (str "test/" nested "/events_test.cljs"))
-                         ;; Story scaffolding lands under
-                         ;; `src/<nested>/stories.cljs` when the flag
-                         ;; is on. Same file-map entry; the source
-                         ;; lives in _shared/ alongside the other
-                         ;; substrate-agnostic files.
                          include-story?
                          (assoc "stories.cljs"
                                 (str "src/" nested "/stories.cljs"))
-                         ;; SSR shape: the events / subs / schema / view all
-                         ;; live in `core.cljc` (see the per-substrate
-                         ;; branch), so the only shared source is the
-                         ;; headless JVM SSR gate. The SSR path also swaps in
-                         ;; an SSR-flavoured README (rf2-6ikgyr): the default
-                         ;; `root/README.md` (bulk-copied first) describes the
-                         ;; static-SPA dev-server workflow + the per-slice
-                         ;; file names this branch does NOT emit, so
-                         ;; `README_with_ssr.md` overwrites it with the SSR
-                         ;; quick-start (JVM render server + client watcher),
-                         ;; the core.cljc / server.clj / ssr_test.clj shape,
-                         ;; and the error-projector surface. Since all
-                         ;; transforms run AFTER the `root/` bulk-copy (and
-                         ;; tools.build's copy-dir overwrites), the SSR README
-                         ;; wins — the same overlay mechanism the Tailwind CSS
-                         ;; variant uses (004-SSR-Validation-Report §188).
+                         ;; Transforms run after the root copy, so this README
+                         ;; replaces the SPA README.
                          include-ssr?
                          (assoc "ssr_test.clj"
                                 (str "test/" nested "/ssr_test.clj")
                                 "README_with_ssr.md" "README.md"))
         shared         [["_shared" "." shared-files :only]]
 
-        ;; Per-substrate transforms. `:only` keeps each substrate
-        ;; transform self-documenting (any new file under
-        ;; `_<substrate>/` must be opted in here).
+        ;; Any new substrate source must be opted into its map.
         per-substrate
         (case substrate
           "reagent"
           (cond
-            ;; SSR path: the registration root is a single `core.cljc`
-            ;; (JVM render + CLJS hydration) that folds in the events /
-            ;; subs / schema / view, so `views.cljs` is NOT emitted; a
-            ;; `server.clj` (the Ring host) is. `:include-ssr?` is mutually
-            ;; exclusive with `:include-story?` (data-fn guard), so the two
-            ;; `_with_*` shapes never combine.
+            ;; SSR's core.cljc contains both platform entry points and all
+            ;; shared registrations.
             include-ssr?
             [["_reagent" "."
               {"deps_with_ssr.edn"    "deps.edn"
@@ -687,19 +415,8 @@
              "views.cljs"      (str "src/" nested "/views.cljs")}
             :only]])
 
-        ;; CSS overlay (Q6 lock / rf2-gthro; wiring rf2-nxqcov). The
-        ;; default plain-CSS `app.css` + `index.html` are emitted by the
-        ;; `root/` bulk-copy above. When `:css :tailwind` is passed, this
-        ;; transform runs AFTER the root copy and overwrites those two
-        ;; files with the Tailwind v4 variants from `_css_tailwind/`: an
-        ;; `app.css` whose entry is `@import "tailwindcss";` (v4 is
-        ;; CSS-first — no `tailwind.config.js`) and an `index.html` that
-        ;; loads the `@tailwindcss/browser@4` dev CDN compiler (zero build
-        ;; step) with a CSP tuned to admit it. deps-new runs the `:root`
-        ;; copy first, then each `:transform` entry in order (see
-        ;; org.corfield.new/create), and tools.build's `copy-dir`
-        ;; overwrites, so the overlay is deterministic. Substrate-invariant
-        ;; — the CSS scaffold is the same across Reagent / UIx / Helix.
+        ;; This transform runs after the root copy and replaces the plain-CSS
+        ;; files on every substrate.
         css-overlay
         (when (= css :tailwind)
           [["_css_tailwind" "."

--- a/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
+++ b/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
@@ -452,47 +452,17 @@
                                 "around events.cljs's register-listener! "
                                 "is gone — a dev-only console listener "
                                 "closure is leaking into the production "
-                                "bundle (rf2-ek857f F2)."))))))))))
+                                "bundle."))))))))))
        (finally
          (delete-recursively tmp))))))
 
 (defn- run-ssr-emitted-test!
-  "The SSR variant of the emitted-test-run tier. The SSR scaffold has TWO
-  runtime halves, and this tier now covers both:
+  "Compile both halves of an emitted SSR project.
 
-    1. SERVER — the headless JVM gate (`ssr_test.clj`). No cljs.test suite,
-       no `:node-test` bundle, so it runs via the emitted deps.edn `:test`
-       alias (`clojure -M:test`), NOT `shadow compile test` + node. That is
-       the exact path `npm test` and the generated CI invoke (package.json
-       `test` = `clojure -M:test` on the SSR path, per hooks.clj's
-       `{{test-script}}`); before this wiring nothing ran the emitted
-       ssr_test.clj, so an SSR-scaffold regression shipped uncaught
-       (rf2-97eebb).
-
-    2. CLIENT — `clojure -M:shadow compile app`. `ssr_test.clj` loads only
-       the `#?(:clj)` render half of `core.cljc`, so the `#?(:cljs)`
-       HYDRATION branch (`reagent.dom.client/create-root` + `.render`
-       interop, `ssr/hydrate!`, `rf/frame-provider`, `rf/view`, the
-       `^:export init` entry point) was compile-UNTESTED — the sibling
-       static-parse (template_emission_test.clj) only checks re-frame.*
-       symbol EXISTENCE, missing reagent.dom.client interop / arity /
-       macro-expansion breaks. The other four CLJS-emitting variants all
-       get a real `shadow compile app`; the SSR client branch now does too
-       (rf2-ue5ev3). Compile-only — no `node` run — because the SSR
-       scaffold ships no client cljs.test bundle.
-
-  Generate the SSR scaffold (`:include-ssr? true`), rewrite the framework
-  coords — including day8/re-frame2-ssr + day8/re-frame2-ssr-ring — to
-  :local/root, link node_modules, `shadow compile app` (the client branch),
-  then `clojure -M:test` (the server gate) asserting exit 0 plus the
-  cljs.test summary lines so a silent zero-test run can't false-green.
-
-  Needs `clojure` on PATH plus a project-local `node_modules`: the added
-  `:app` (`:browser`) compile resolves React (via reagent) at compile time
-  and — like the CLJS variants — searches ONLY the project-local
-  node_modules (it ignores NODE_PATH). No `node` RUNTIME is needed, though:
-  the browser compile is JVM/Closure-driven, and the JVM SSR render is a
-  pure hiccup -> HTML emitter (no React / JSDOM)."
+   The browser build compiles core.cljc's hydration branch. `clojure -M:test`
+   runs the JVM render and Ring-handler tests, which are also what the emitted
+   npm test script and CI invoke. The browser compile needs project-local
+   node_modules; the tests themselves need no Node runtime or DOM."
   []
   (let [root (repo-root)
         tmp  (tmp-dir "rf2-template-run-reagent-ssr-")]
@@ -545,8 +515,7 @@
               ;; the cognitect runner) doesn't false-green.
               (is (re-find #"Ran \d+ tests? containing \d+ assertions" out)
                   (str "expected 'Ran N tests' summary line — a silent "
-                       "zero-test run (the very false-green rf2-97eebb "
-                       "guards) would otherwise pass. Got:\n" out))
+                       "zero-test run would otherwise pass. Got:\n" out))
               (is (re-find #"0 failures, 0 errors" out)
                   (str "expected '0 failures, 0 errors' line in output. "
                        "Got:\n" out))))))
@@ -609,7 +578,7 @@
 (deftest reagent-with-story-emitted-tests-run-test
   ;; The only tier that actually shadow-compiles +
   ;; node-runs the `:include-story? true` scaffold. Reagent-only because
-  ;; with-story is Reagent-only in v1 (hooks.clj data-fn guard). Same
+  ;; with-story is currently Reagent-only (hooks.clj data-fn guard). Same
   ;; events_test.cljs as the default path runs; the value here is that
   ;; the with-story core (`core_with_stories.cljs` requiring
   ;; re-frame.story + the stories ns), `deps_with_story.edn`, and
@@ -642,20 +611,17 @@
 
 (deftest reagent-ssr-emitted-tests-run-test
   ;; The SSR scaffold's TWO halves: the client `:cljs` hydration branch via
-  ;; `clojure -M:shadow compile app` (rf2-ue5ev3 — core.cljc's #?(:cljs)
+  ;; `clojure -M:shadow compile app` (core.cljc's #?(:cljs)
   ;; reagent.dom.client interop + ssr/hydrate! + ^:export init, which the
   ;; JVM `ssr_test.clj` :clj-only load never compiles), and the server
   ;; render via the headless JVM gate (`ssr_test.clj`) run through the
   ;; emitted deps.edn `:test` alias (`clojure -M:test`) — the exact path
   ;; `npm test` and the generated CI invoke on the SSR scaffold.
-  ;; Reagent-only because `:include-ssr?` is Reagent-only in v1. Needs
+  ;; Reagent-only because `:include-ssr?` currently supports Reagent. Needs
   ;; `clojure` on PATH plus a project-local node_modules for the `:app`
   ;; compile (React via reagent; no `node` RUNTIME — the browser compile is
   ;; JVM/Closure-driven and the JVM SSR render is a pure hiccup -> HTML
   ;; emitter), and rides the same RF2_TEMPLATE_RUN_EMITTED_TESTS gate.
-  ;; Before this tier nothing ran the emitted ssr_test.clj — the empty CLJS
-  ;; node-test bundle the SSR package.json used to run false-greened on zero
-  ;; tests (rf2-97eebb); and the client branch shipped compile-untested.
   (testing "the emitted SSR Reagent app's client :cljs branch compiles
             (`shadow compile app`) + its ssr_test.clj runs green via
             `clojure -M:test` (the JVM gate npm/CI now invoke)"
@@ -711,7 +677,7 @@
        (throw (ex-info (str "setup-skill fixture: found no ```" lang
                             " fenced block " where
                             " — the skill snippet anchors moved; update the "
-                            "fixture extractor (rf2-ae98go).")
+                            "fixture extractor.")
                        {:lang lang :where where})))
      (first blocks))))
 
@@ -838,11 +804,11 @@
                        "`:devtools {:preloads [day8.re-frame2-xray.preload]}`. "
                        "Xray is a day-one dep and index.html ships the host "
                        "column — the canonical block must wire the preload that "
-                       "fills it (rf2-ae98go)."))
+                       "fills it."))
               (is (string/includes? html-text "data-rf-xray-host")
                   (str "the skill's index.html block (references/shadow-cljs.md) "
                        "no longer carries the `[data-rf-xray-host]` Xray layout "
-                       "host column (rf2-ae98go)."))))
+                       "host column."))))
 
           ;; --- compile the :app build -------------------------------------
           (testing "setup-skill scaffold — clojure -M:shadow compile app"
@@ -857,7 +823,7 @@
                        "re-frame2 source — its boot ceremony (`:app/main` + "
                        "`:initial-events` + bare `frame-provider` + `reg-view`) "
                        "diverges from the generator template, so the template "
-                       "variants above can't catch this (rf2-ae98go). Output:\n"
+                       "variants above can't catch this. Output:\n"
                        out))
               ;; A zero-exit with no emitted bundle would false-green.
               (let [bundle (io/file proj "resources/public/js/main.js")]

--- a/tools/template/test/day8/re_frame2_template/template_emission_test.clj
+++ b/tools/template/test/day8/re_frame2_template/template_emission_test.clj
@@ -161,8 +161,7 @@
   "Map a re-frame.X namespace symbol to its source-of-truth file under
   `implementation/` or `tools/`. Returns the `java.io.File`, or nil if
   we don't know about this ns (we only audit framework namespaces —
-  the user's own `<app>.events` / `.subs` aren't audited here; the
-  bead is about drift against the framework surface).
+  the user's own `<app>.events` / `.subs` aren't audited here).
 
   Search order:
 
@@ -185,7 +184,7 @@
        The `:include-ssr?` scaffold's `core.cljc` requires `re-frame.ssr`
        and its `server.clj` requires `re-frame.ssr.ring`; the audit needs
        to resolve both. `re-frame.ssr.ring` is JVM-only, so a `.clj`
-       candidate is included (rf2-e0xspa)."
+       candidate is included."
   [root ns-sym]
   (let [name- (name ns-sym)]
     (cond
@@ -345,20 +344,11 @@
                      substrate ") uses alias " alias-sym
                      " but no matching :as is declared in the ns form"))))))))
 
-;; --- Strict EP-0017 cofx mint policy guard ---------------------------------
+;; --- Strict cofx mint policy guard -----------------------------------------
 ;;
-;; EP-0017's strict-test posture: a generated app that later adds a
-;; generator-backed recordable coeffect must not be able to write a green
-;; test that forgot to supply the fact (the default live policy would
-;; silently mint a fresh per-run value — the opposite of
-;; supply-data-don't-stub). The emitted `events_test.cljs` fixture therefore
-;; establishes a STRICT mint policy by default — via `{:preset :test}` (which
-;; sets `:rf.cofx/mint-policy :strict`) or an explicit
-;; `:rf.cofx/mint-policy :strict`. This guard reads the emitted file and
-;; fails if the strict posture is dropped, or if the supply-data /
-;; explicit-live testing idiom is not documented for the user. It also
-;; locks out non-EP-0017/EP-0018 vocabulary (`:rf.world/inputs`,
-;; grouped/nested cofx, `inject-cofx`).
+;; Generated tests must supply generator-backed recordable coeffects instead
+;; of silently minting live values. The fixture therefore establishes strict
+;; minting and documents both explicit data supply and the per-call live opt-in.
 
 (defn- assert-events-test-strict-mint-policy!
   [substrate ^java.io.File root]
@@ -373,17 +363,16 @@
         (is (or (re-find #":preset\s+:test" text)
                 (re-find #":rf\.cofx/mint-policy\s+:strict" text))
             (str "events_test.cljs (" substrate ") must run under a STRICT "
-                 "EP-0017 cofx mint policy by default — register the test "
+                 "cofx mint policy by default — register the test "
                  "frame with `{:preset :test}` or set "
                  "`:rf.cofx/mint-policy :strict`. Without it a generated app "
                  "that adds a generator-backed recordable coeffect can ship a "
                  "green test that forgot to supply the fact (the live policy "
-                 "silently mints a fresh per-run value — the opposite of "
-                 "EP-0017's supply-data-don't-stub posture)."))
+                 "silently mints a fresh per-run value)."))
         ;; (2) The supply-data idiom is documented for recordable coeffects:
         ;; supply facts FLAT under `:rf.cofx`.
         (is (re-find #":rf\.cofx\b" text)
-            (str "events_test.cljs (" substrate ") must document the EP-0017 "
+            (str "events_test.cljs (" substrate ") must document the "
                  "supply-data idiom — supply required recordable facts FLAT "
                  "under `:rf.cofx` in the dispatch opts."))
         ;; (3) The intentional-nondeterminism escape hatch is documented.
@@ -392,13 +381,13 @@
                  "`:rf.cofx/mint-policy :explicit-live` opt-out — the per-call "
                  "escape a test uses when it INTENTIONALLY accepts "
                  "nondeterministic generation."))
-        ;; (4) No non-EP-0017/EP-0018 vocabulary leaks into the scaffold.
+        ;; (4) No retired coeffect vocabulary leaks into the scaffold.
         (doseq [[re what]
                 [[#":rf\.world/inputs" ":rf.world/inputs (retired — declare :rf.cofx/requires)"]
                  [#"inject-cofx"        "inject-cofx (removed — declare :rf.cofx/requires)"]]]
           (is (not (re-find re text))
               (str "events_test.cljs (" substrate ") must not use legacy "
-                   "EP-0017/EP-0018 vocabulary: " what ".")))))))
+                   "coeffect vocabulary: " what ".")))))))
 
 ;; --- Generic ns-surface drift check (events / subs / views / events_test)
 ;; ----------------------------------------------------------------------------
@@ -442,8 +431,7 @@
 
   `features` selects the reader-conditional view: the 3-arg arity reads
   under `:cljs` (the browser branch of a `.cljc` / a `.cljs` file); the
-  SSR host audit passes `#{:clj}` to read `server.clj` under the JVM
-  branch (rf2-e0xspa)."
+  SSR host audit passes `#{:clj}` to read `server.clj` under the JVM branch."
   ([substrate ^java.io.File file root]
    (audit-framework-surface! substrate file root #{:cljs}))
   ([substrate ^java.io.File file root features]
@@ -567,7 +555,7 @@
           (is (valid-with-frame-first-arg? first-arg)
               (str "scratch.cljs (" substrate ") (with-frame "
                    (pr-str first-arg) " …) — first arg must be a "
-                   "keyword or symbol (pin form). Per rf2-twoc5, a "
+                   "keyword or symbol (pin form). A "
                    "vector argument is a compile-time error; use "
                    "`with-new-frame` for eval-bind-run-destroy."))))
       (doseq [call new-frame-calls]
@@ -575,13 +563,13 @@
           (is (valid-with-new-frame-first-arg? first-arg)
               (str "scratch.cljs (" substrate ") (with-new-frame "
                    (pr-str first-arg) " …) — first arg must be a "
-                   "2-element [sym expr] vector. Per rf2-twoc5, a "
+                   "2-element [sym expr] vector. A "
                    "keyword argument is a compile-time error; use "
                    "`with-frame` to pin to an existing frame-id.")))))))
 
 ;; --- scratch.cljs frame-context audit --------------------------------------
 ;;
-;; EP-0002 removed the implicit `:rf/default` floor: a frame-scoped call
+;; There is no implicit `:rf/default` floor: a frame-scoped call
 ;; (`dispatch` / `dispatch-sync` / `subscribe`) evaluated with no
 ;; established scope raises `:rf.error/no-frame-context`
 ;; (implementation/core/src/re_frame/core.cljc §current-frame-id). The
@@ -599,12 +587,11 @@
 ;;       trailing opts map, e.g. `(rf/dispatch [:e] {:frame :rf/default})`
 ;;       / `(rf/subscribe [query] {:frame :rf/default})` — the ONE
 ;;       frame-targeting shape for `dispatch` / `dispatch-sync` /
-;;       `subscribe` alike (API-shrink #1, rf2-csbbwu deleted the
-;;       frame-first positional form).
+;;       `subscribe` alike.
 
 (def ^:private frame-scoped-call-names
   "Bare names (alias-stripped) of the frame-scoped REPL ops scratch.cljs
-  may use. Each requires a resolvable frame at eval time (EP-0002)."
+  may use. Each requires a resolvable frame at eval time."
   #{"dispatch" "dispatch-sync" "subscribe"})
 
 (defn- frame-scope-form?
@@ -635,8 +622,7 @@
   "Does this frame-scoped call name its frame inline (so it does not need a
   surrounding `with-frame` / `with-new-frame` scope)? `dispatch` /
   `dispatch-sync` / `subscribe` all share the ONE shape: a `:frame` key in
-  the trailing opts map (API-shrink #1, rf2-csbbwu deleted the frame-first
-  positional form)."
+  the trailing opts map."
   [form]
   (case (name (first form))
     ("dispatch" "dispatch-sync" "subscribe") (dispatch-has-explicit-frame? form)
@@ -694,8 +680,8 @@
       (is (empty? frameless)
           (str "scratch.cljs (" substrate ") has frame-scoped REPL "
                "call(s) with no resolvable frame: "
-               (pr-str (mapv #(take 2 %) frameless)) ". EP-0002 removed "
-               "the :rf/default floor — such a call throws "
+               (pr-str (mapv #(take 2 %) frameless)) ". There is no "
+               "implicit :rf/default floor, so such a call throws "
                ":rf.error/no-frame-context on first eval. Put it inside a "
                "(with-frame :rf/default …) / (with-new-frame [f …] …) body, "
                "or give it an explicit frame: {:frame :rf/default} opts for "
@@ -774,8 +760,8 @@
         ;; The 560px default fallback matches Xray's recommended default.
         (is (re-find #"var\(--rf-xray-inline-width,\s*560px\)" css)
             (str "app.css (" substrate
-                 ") Xray host flex-basis fallback must be 560px (Xray's "
-                 "recommended default, rf2-9ovfb)."))
+                 ") Xray host flex-basis fallback must be Xray's "
+                 "recommended 560px default."))
         ;; box-sizing + border-left so the separator lives inside the
         ;; documented width.
         (is (re-find #"(?s)\.rf2-xray-host\s*\{[^}]*box-sizing:\s*border-box" css)
@@ -906,13 +892,13 @@
                      "`flex: 0 0 var(--rf-xray-inline-width, 560px)` (pinned by "
                      "assert-xray-host-contract! above) — a literal 420px width "
                      "ignores the host-owned resize knob. Remove the stale "
-                     "420px claim (rf2-7s8ou3 / tools/xray/spec/011-Launch-Modes.md)."))
+                     "420px claim (tools/xray/spec/011-Launch-Modes.md)."))
             (is (not (re-find #"(?i)left[- ]?(layout )?column" section))
                 (str "002-Generated-Shape.md §Xray devtools still describes the "
                      "Xray host as a left column. The emitted index.html orders "
                      "`<main id=\"app\">` BEFORE `<aside data-rf-xray-host>`, so "
                      "the host is a RIGHT-side layout host. Match the emitted "
-                     "layout + the Xray spec (rf2-7s8ou3)."))
+                     "layout and the Xray spec."))
             ;; --- the current contract must be stated --------------------
             ;; Positive assertions so the negatives can't pass vacuously by
             ;; deleting/emptying the section.
@@ -973,50 +959,25 @@
 
 ;; --- :include-ssr? -------------------------------------------------------
 ;;
-;; The SSR scaffold is the template's LEAST-covered variant (rf2-e0xspa):
-;; its emitted-run tier (`emitted_test_run_test.clj`) executes only
-;; `clojure -M:test`, which loads `core.cljc`'s `:clj` branch (via
-;; `ssr_test.clj`'s `[…core :as app]` require) and — since rf2-e0xspa —
-;; `server.clj` (via `ssr_test.clj`'s new `[…server :as server]` require).
-;; But NO gate compiles `core.cljc`'s `:cljs` CLIENT branch (the hydration
-;; path: `ssr/hydrate!`, `rf/view`, `rf/frame-provider`, the reagent
-;; adapter, `reagent.dom.client`), and that emitted-run tier is opt-in
-;; (`RF2_TEMPLATE_RUN_EMITTED_TESTS`). So a framework rename on the SSR
-;; client/host surface used to ship broken-but-green.
-;;
-;; This audit closes that gap CHEAPLY on every PR (no node, no shadow, no
-;; env gate): it reads the emitted `core.cljc` under the `:cljs`
-;; reader-conditional view — the exact CLIENT branch no compile touches —
-;; and `server.clj` under the `:clj` view, and asserts every referenced
-;; `re-frame.*` / `re-frame.ssr(.ring)` symbol is actually defined in the
-;; framework source. A rename (e.g. `ssr/hydrate!` → `ssr/hydrate`,
-;; `ssr-ring/ssr-handler` → `…/handler`, `rf/frame-provider` → `…/provider`)
-;; trips this JVM check. `framework-ns-file` above resolves the SSR coords
-;; (implementation/ssr/ + implementation/ssr-ring/).
+;; The opt-in emitted-run tier compiles the client and runs the JVM SSR tests.
+;; This cheaper static audit runs even when that tier is disabled: it reads the
+;; client and server branches and verifies that their re-frame symbols still
+;; exist in the corresponding source artefacts.
 
 (deftest reagent-ssr-emission-static-parse-test
   (testing ":include-ssr? true emits a core.cljc whose :cljs CLIENT branch
             + a server.clj Ring host that reference only defined re-frame.*
-            + re-frame.ssr(.ring) symbols (rf2-e0xspa)"
+            + re-frame.ssr(.ring) symbols"
     (let [tmp  (tmp-dir "rf2-emission-ssr-")
           root (repo-root)]
       (try
         (let [proj (run-template-opts! tmp "acme/my-app"
                                        {:substrate :reagent :include-ssr? true})]
-          ;; The CLIENT (:cljs) branch of the shared core.cljc — compiled
-          ;; by no gate. Read under `:features #{:cljs}` so the audit sees
-          ;; exactly the browser-side requires (`reagent.dom.client`, the
-          ;; reagent adapter) + hydration calls (`ssr/hydrate!`, `rf/view`,
-          ;; `rf/frame-provider`).
+          ;; Read the browser branch even when the opt-in compile gate is off.
           (audit-framework-surface! :reagent
                                     (io/file proj "src/acme/my_app/core.cljc")
                                     root #{:cljs})
-          ;; The Ring host — a JVM-only `.clj`. Read under `:features
-          ;; #{:clj}`. Its framework surface (`ssr-ring/ssr-handler`,
-          ;; `ssr/adapter`, `rf/init!`) is now ALSO compiled for real by the
-          ;; emitted `ssr_test.clj`'s `[…server :as server]` require under
-          ;; `clojure -M:test`; this ungated static check is the fast-loop
-          ;; net that catches a rename without the opt-in emitted-run tier.
+          ;; Read the JVM-only Ring host under its platform feature set.
           (audit-framework-surface! :reagent
                                     (io/file proj "src/acme/my_app/server.clj")
                                     root #{:clj}))
@@ -1026,7 +987,7 @@
 ;; --- :css :tailwind --------------------------------------------------------
 ;;
 ;; The Tailwind overlay overwrites the plain-CSS `app.css` + `index.html`
-;; with the `_css_tailwind/` variants (rf2-nxqcov). The Xray-host layout
+;; with the `_css_tailwind/` variants. The Xray-host layout
 ;; contract MUST survive that swap: the emitted index.html/app.css still
 ;; have to satisfy `assert-xray-host-contract!` (right-side host DOM order,
 ;; resizable flex-basis, :empty collapse) and `assert-no-stale-xray-wording!`


### PR DESCRIPTION
## Summary

- replace duplicated migration and issue-history narration in the deps-new hooks, template config, and current contract docs with concise operational explanations
- make generated Reagent, UIx, Helix, Story, and SSR starter files explain the frame, schema, classification, hydration, and test contracts at the point where they matter
- correct the SSR README's durable app-db classification owner: writing events declare `:sensitive` / `:large` commit-plane effects; schemas validate shape and `reg-frame` does not own those declarations
- update template-test commentary to describe the gates that exist today, including the SSR client compile tier

This is an explanation-only change. Template selection, emitted forms, dependency coordinates, and runtime behavior are unchanged.

## Coverage and ownership

Reviewed all 55 files under `tools/template`.

Open PR #5481 already owns `_shared/events.cljs` and `template_test.clj`, so this branch does not touch them. The separate root-README HTTP follow-up also owns that section; this branch leaves it unchanged.

## Verification

- `cd tools/template && clojure -M:test` (47 tests, 641 assertions, 0 failures, 0 errors)
- `clj-kondo --lint tools/template/src tools/template/test` (0 errors, 1 pre-existing warning; identical to `origin/main`)
- `cd implementation && clojure -M:splint ../tools/template/src ../tools/template/test` (269 pre-existing style warnings; identical to `origin/main`)
- `git diff --check`

Tracking: `rf2-6miw3k`
