### PR TITLE
docs(testbed-support): focus explanations on current contracts

### DIFF
--- a/tools/testbed-support/README.md
+++ b/tools/testbed-support/README.md
@@ -1,209 +1,109 @@
 # tools/testbed-support/
 
-A small **dev-only** support library shared by the Xray and Story
-browser testbeds. Three namespaces:
+Dev-only support shared by the Xray and Story browser testbeds. It is not a
+published library and no production namespace depends on it.
 
-- `re-frame.testbed.config` — derives the on-disk source root those
-  testbeds hand to their "open in editor" source-coord resolvers (a
-  build-env-seeded **checkout root** plus the caller's tool subdir),
-  cross-platform and with no hardcoded checkout path.
-- `re-frame.testbed.story-host` — the live-app ↔ Story-shell hash-toggle
-  host harness the Story showcase testbeds share.
-- `re-frame.testbed.open-in-editor-server` — a JVM-only (`.clj`)
-  shadow-cljs `:dev-http` handler that answers the
-  `POST /__rf-open-in-editor` endpoint, resolving a
-  classpath-relative source `:file` against the dev JVM's source-paths at
-  runtime and launching the editor via the `launch-editor` npm package
-  (the re-frame2 equivalent of Vite's `/__open-in-editor`). Because it
-  launches the editor on a local file, it is POST-only and loopback-guarded
-  (the request must be addressed to a loopback `Host` and, when present,
-  carry a loopback `Origin`; CORS reflects that origin, never `*`) — the
-  drive-by class the historic Vite / react-dev-utils CVEs hit. It runs on
-  the shadow-cljs SERVER JVM and is never part of any browser/CLJS build.
+The surface contains three namespaces:
 
-## What it is
+- `re-frame.testbed.config` resolves an on-disk source root for source
+  coordinates.
+- `re-frame.testbed.story-host` switches one `#app` node between a live app and
+  the Story shell.
+- `re-frame.testbed.open-in-editor-server` provides the JVM-side
+  `POST /__rf-open-in-editor` handler used by shadow-cljs dev servers.
 
-Xray and Story turn a source-coord (`standard_epochs/core.cljs:42`) into
-an editor URI by prepending a project-root. Shipped code reads that root
-from host config; the *testbeds* that drive Xray / Story have to pass one
-in, and they previously each hardcoded the author's absolute Windows
-checkout — six copies of one machine-specific string that broke on every
-other clone and every Mac/Linux maintainer (rf2-5dphw).
+## Source-root configuration
 
-`re-frame.testbed.config` replaces that with a single shared helper:
+`resolve-source-root` appends a caller-supplied source subdirectory, such as
+`tools/xray/testbeds`, to the checkout root. The checkout root comes from one of
+two places, in precedence order:
 
-- **`checkout-root`** — a `goog-define`d string (default `""`). Seeded per
-  build via `#shadow/env` from the `RF2_TESTBED_PROJECT_ROOT` env var,
-  which the dev launcher (`implementation/scripts/dev-testbed.cjs`,
-  wired as the `dev` npm script) resolves from its own location using
-  node's `path` module — identical on Windows, macOS, and Linux.
-- **`resolve-source-root`** — joins a **checkout root** input with the
-  tool-relative testbed subdir the caller passes (e.g.
-  `"tools/xray/testbeds"`) to produce the **source root** output. A
-  `?checkout-root=<checkout>` query string wins over the build-time
-  `checkout-root` define as a per-session escape hatch (CI, a reader on
-  another machine, a copied bundle). Both input tiers name a checkout
-  root and have the subdir appended the same way, so the composed editor
-  URI reaches `<checkout>/tools/xray/testbeds` where the classpath-relative
-  source coords resolve (rf2-w4yw9q). Paste the checkout root unencoded,
-  including a literal `+` (e.g. `?checkout-root=/home/dev/re-frame2+wip`);
-  the parser decodes percent-escapes but preserves `+` rather than
-  mapping it to a space (rf2-xdsat.1). Both tiers and the subdir are
-  normalised to a canonical forward-slash form (`\` → `/`, trailing /
-  leading slash stripped), so a Windows override
-  (`?checkout-root=C:\Users\me\code\re-frame2\`, raw or `%5C`-encoded)
-  resolves to a clean single-separator path rather than a `\/` boundary —
-  matching the launcher's build-env normalisation and the
-  separator-agnostic editor-URI composer (rf2-d01s6s). When neither tier
-  is present it returns `nil`, and the testbed configures no root —
-  "open in editor" degrades to a graceful no-op rather than a broken link.
+1. `?checkout-root=<path>` in the browser URL, for a per-session override.
+2. The `re-frame.testbed.config/checkout-root` goog-define, seeded from
+   `RF2_TESTBED_PROJECT_ROOT` by `implementation/shadow-cljs.edn`.
 
-## The Story host harness (`story-host`)
+The result uses forward slashes and one separator at each join. Both raw and
+percent-encoded Windows separators are accepted. Query parsing preserves a
+literal `+`, because checkout directory names may contain one. When neither
+root is available, the resolver returns `nil` and open-in-editor remains a
+no-op.
 
-Every Story showcase entry point hosts two surfaces on the same `#app`
-node, one React root at a time — `#/` the live app, `#/stories` the Story
-shell. The plumbing that switches between them (a `defonce` React-root
-handle, the tear-down-one-before-mounting-the-other dance, and the
-`hashchange` listener) is pure React-DOM-root juggling — identical across
-every testbed but for the live-app root view. That root view is not a bare
-React tree: it is a **frame-scoped subtree** — a frame, supplied by the
-consuming testbed via `frame-provider`, resolving its handlers against a
-loaded image (EP-0023 §Views). This harness sits strictly ABOVE that
-frame/image boundary — it owns the React-root + hashchange mechanics and
-treats the testbed's root view as an opaque frame subtree; it neither
-creates frames nor loads images (that is the consuming testbed's job, via
-`reg-frame` / `with-frame` / `rf/init!`). It was copy-pasted across
-six hosts (`counter_with_stories`, `login_form`, the `login` and
-`nine_states` examples, the Xray `panel_gallery` testbed, plus the template
-scaffolding), already drifting in the per-testbed boot specifics they each add.
+## Story host
 
-`re-frame.testbed.story-host/mount-with-hash-routing!` owns that harness:
-the testbed does its own boot (Xray config, `rf/init!`, `:fx-overrides`,
-seed dispatches, CI hooks) and calls the helper LAST with its live-app root
-view. Five of the six hosts now call it (the four Story showcases above plus
-`panel_gallery`, which previously installed a bare per-`run` `hashchange`
-listener — rf2-x31vn); the **template copy stays standalone by design** — it
-is `resources/` scaffolding emitted into a fresh consumer project whose
-classpath has no access to this dev-repo-internal helper.
+`mount-with-hash-routing!` selects the surface from the current hash:
 
-### The open-in-editor project-root is a host responsibility (rf2-77wqzi)
+- `#/stories...` mounts the Story shell.
+- Any other hash mounts the supplied live-app root view.
 
-Story stamps each registered source-coord with a **classpath-relative**
-`:file` slot (e.g. `login/stories.cljs`); the 'open in editor' chip prepends
-an on-disk project-root to build a real editor URI. That config used to be
-left inline in every consuming `run` (`story/configure! {:rf.story/project-root …}`),
-and the two `examples/reagent` showcases silently forgot it — they mounted
-the shell fine but their Story source links resolved against a nil root, so
-OS editor handlers could not open the file (a false green).
+The consumer must create its frame, load its image, and complete its own boot
+before calling the host. The host owns only the React-root handoff and the
+`hashchange` listener. It unmounts the current root before the other surface
+claims `#app`.
 
-The optional second arg to `mount-with-hash-routing!` closes that gap: a
-consumer declares its tool-relative source subdir via `:source-subdir` (e.g.
-`{:source-subdir "examples/reagent"}`) and the host resolves the on-disk root
-through `resolve-source-root` (build-env define or `?checkout-root=` override,
-cross-platform) and calls `story/configure!` itself — which also bridges the
-root into Xray's slot. Omit the opt (or use the 1-arity call) when the
-consumer drives `story/configure!` itself. A blank subdir, or a checkout with
-no resolvable root, configures nothing (graceful no-op). Declaring the subdir
-means a Story-host consumer can no longer mount the shell while silently
-forgetting the project-root config.
+The listener handle is stored in a `defonce` atom and explicitly removed before
+each install. This matters during hot reload: recompiling a top-level CLJS
+function changes its JavaScript identity, so `addEventListener` cannot dedupe a
+listener from the previous compile.
 
-## Layout
+Pass `{:source-subdir "..."}` when the host should also configure Story's
+open-in-editor project root:
 
-```
-tools/testbed-support/
-├── README.md                                 ; this file
-├── deps.edn                                  ; JVM :test classpath for the open-in-editor server (test-only, not a published jar)
-├── src/re_frame/testbed/
-│   ├── config.cljs                           ; resolve-source-root + the checkout-root goog-define
-│   ├── story_host.cljs                       ; mount-with-hash-routing! (live-app↔shell host)
-│   └── open_in_editor_server.clj             ; JVM-only :dev-http open-in-editor endpoint handler
-└── test/re_frame/testbed/
-    ├── config_cljs_test.cljs                 ; CLJS unit tests for the resolver
-    ├── story_host_cljs_test.cljs             ; CLJS unit tests for the host harness (node)
-    ├── story_host_dom_cljs_test.cljs         ; browser-level live↔shell root-handoff test
-    └── open_in_editor_server_test.clj        ; JVM unit tests for the endpoint's :file resolution
+```clojure
+(mount-with-hash-routing!
+  live-app
+  {:source-subdir "tools/story/testbeds"})
 ```
 
-## How it's wired
+Omit the option when the consumer manages `story/configure!` itself.
 
-This library is **not a published jar** — it carries no Clojars coord.
-The CLJS halves are consumed purely as an extra source path: the testbed
-builds add `../tools/testbed-support/src` to their source paths
-in [`implementation/shadow-cljs.edn`](../../implementation/shadow-cljs.edn),
-and seed `re-frame.testbed.config/checkout-root` via that file's
-`:closure-defines`. The sibling `../tools/testbed-support/test` path is
-also listed so the always-on `:node-test` build discovers the unit
-suites (see below). Bundle-isolation holds: nothing under
-`implementation/` `:require`s it.
+## Open-in-editor server
 
-There **is** a `deps.edn`, but it is a **test-only** harness, not a
-packaging surface: the open-in-editor endpoint is a JVM-only `.clj` that
-no CLJS build compiles, so its `:file`-resolution logic can only be
-exercised by a JVM `clojure -M:test` gate (see below). The `deps.edn`
-exists solely to give that `.clj` a JVM test classpath; it declares no
-Clojars coord and the testbeds keep consuming `src/` as a source path.
+The JVM namespace is a shadow-cljs `:dev-http` fallback handler. It resolves a
+classpath-relative `file` query parameter against the dev JVM's source paths,
+falls back to the process working directory, and invokes the `launch-editor`
+npm package through Node.
 
-## How to test
+Because this endpoint can open a local file, it accepts launches only when all
+of these conditions hold:
 
-Four suites under `test/` — three CLJS, one JVM:
+- The request method is `POST`.
+- The `Host` header names a loopback host.
+- When present, `Origin` also names a loopback host.
 
-- `config_cljs_test.cljs` — the resolver: param parsing, cross-platform
-  path joining (Windows / POSIX, including the lone-`/` filesystem-root
-  edge), and the build-time-vs-`?checkout-root=` tier precedence.
-- `story_host_cljs_test.cljs` — the host harness's `hashchange`-listener
-  lifecycle / hot-reload idempotence and the project-root config contract,
-  with the mount switch stubbed to count-only no-ops (listener-identity
-  focus, runs under `:node-test`).
-- `story_host_dom_cljs_test.cljs` — a **browser-level** handoff test
-  that drives the host through `#/` → `#/stories` → `#/`
-  (plus a hot-reload re-run) on a real `#app` node with **real React
-  roots**, asserting the live ↔ shell root handoff leaks no root and emits
-  no `createRoot`-reuse warning. ns ends in `-dom-cljs-test`, so the
-  `:browser-test` build runs the real-DOM assertions; under `:node-test`
-  its body gates on `(browser?)` and no-ops.
-- `open_in_editor_server_test.clj` — a **JVM** suite for the
-  open-in-editor endpoint's `:file` resolution: that `resolve-file` /
-  `file-url->path` decode a classpath `file:` URL with a literal `+` in
-  the path verbatim (the `URLDecoder`-maps-`+`-to-space corruption guard),
-  decode `%20` / `%2B` correctly, and strip the Windows drive-letter
-  leading slash. The endpoint is JVM-only `.clj` that no CLJS build
-  compiles, so it rides the `clojure -M:test` gate below rather than the
-  node suites.
+CORS reflects only a validated loopback origin; it never emits `*`. Missing
+files return 422 before Node is spawned so the browser client can fall back to
+its `editor://` URI. The handler lives in a `.clj` file and is never compiled
+into a browser bundle.
 
-### The always-on gate
+## Wiring
 
-`npm run test:cljs` from `implementation/` compiles the `:node-test` build,
-whose `:ns-regexp "cljs-test$"` discovers all three namespaces through this
-slice's wired `../tools/testbed-support/test` source path; `npm run
-test:browser` runs the DOM suite's real-React assertions. The slice rides
-both on every PR.
+The testbed builds add `tools/testbed-support/src` to their shadow-cljs source
+paths. Test builds also add `tools/testbed-support/test`. The local `deps.edn`
+exists only for the JVM endpoint tests; it is not a packaging surface.
 
-### The focused CLJS gate
+## Tests
 
-Workers no longer need the full ~3500-test consolidated build to
-verify the CLJS halves of this slice. `npm run test:testbed-support` from
-`implementation/` compiles a dedicated `:node-test-testbed-support` build
-whose `:ns-regexp "^re-frame\.testbed\..+-cljs-test$"` matches ONLY the
-`re-frame.testbed.*` test namespaces, then runs it on Node — a cheap,
-named, slice-scoped gate. (It still needs the shared shadow-cljs binary
-`npm install` provides; it does not depend on the rest of the node suite
-compiling.) The DOM suite's real-React-root assertions still require the
-`:browser-test` runner — the focused node build exercises only the
-node-runnable bodies. The suites live under a dedicated `test/` root — the
-same src/test split every other tool/artefact uses.
+From `implementation/`:
 
-### The JVM gate (open-in-editor endpoint)
+```bash
+npm run test:testbed-support
+npm run test:browser
+```
 
-The open-in-editor endpoint is a JVM-only `.clj`, so its
-`:file`-resolution logic is gated by a JVM test rather than the node
-suites. Run `clojure -M:test` from `tools/testbed-support/` — it uses the
-same `test/` root and the silent-on-success quiet runner every other
-per-artefact `:test` alias uses, and exercises
-`open_in_editor_server_test.clj` against the real classpath-resolution
-path (including a throwaway classpath root whose directory name carries a
-literal `+`).
+The focused Node suite covers config parsing and Story-host listener lifecycle.
+The browser suite covers the real React-root handoff on a DOM node.
+
+From `tools/testbed-support/`:
+
+```bash
+clojure -M:test
+```
+
+The JVM suite covers file resolution, query parsing, launch argument handling,
+JSON responses, and the method/loopback/origin guard.
 
 ## See also
 
-- [`tools/README.md`](../README.md) — the per-tool layout and bundle-isolation contract.
-- [`tools/xray/`](../xray/) and [`tools/story/`](../story/) — the testbeds that consume this helper.
+- [`tools/README.md`](../README.md)
+- [`tools/xray/`](../xray/)
+- [`tools/story/`](../story/)

--- a/tools/testbed-support/deps.edn
+++ b/tools/testbed-support/deps.edn
@@ -1,31 +1,13 @@
-;; tools/testbed-support — JVM test classpath for the dev-only
-;; open-in-editor server (`re-frame.testbed.open-in-editor-server`).
-;;
-;; testbed-support is NOT a published jar and is consumed by the testbeds
-;; purely as an extra shadow-cljs source path (see README.md "How it's
-;; wired"). The CLJS halves (`config.cljs` / `story_host.cljs`) are tested
-;; by the always-on `:node-test` build and the focused
-;; `:node-test-testbed-support` build (`npm run test:testbed-support`).
-;;
-;; The open-in-editor endpoint, however, is a JVM-only `.clj` that runs on
-;; the shadow-cljs SERVER JVM and is never compiled by any CLJS build, so
-;; its `resolve-file` path-decoding logic cannot be exercised by the node
-;; suites. This deps.edn exists solely to give that `.clj` a JVM
-;; `clojure -M:test` gate — the same src/test + test-quiet-runner shape
-;; every other tool/artefact uses. It is a TEST harness, not a packaging
-;; surface (still no Clojars coord; the testbeds keep consuming `src/` as a
-;; source path).
+;; JVM test harness for the dev-only open-in-editor server. The browser
+;; testbeds consume this tool through shadow-cljs source paths, not as a jar.
 {:paths ["src"]
  :deps  {org.clojure/clojure {:mvn/version "1.12.0"}
-         ;; The server `:require`s `re-frame.source-coords.editor-uri`
-         ;; (`absolute-path?`); pull implementation/core for it.
+         ;; Supplies the source-coordinate resolver used by the server.
          day8/re-frame2      {:local/root "../../implementation/core"}}
 
  :aliases
  {:test {:extra-paths ["test"]
-         :extra-deps  {;; The silent-on-success reporter — the same quiet
-                       ;; runner every per-artefact :test alias uses.
-                       day8/re-frame2-test-quiet {:local/root "../../implementation/test-quiet"}
+         :extra-deps  {day8/re-frame2-test-quiet {:local/root "../../implementation/test-quiet"}
                        io.github.cognitect-labs/test-runner
                        {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
          :main-opts   ["-m" "re-frame.test-quiet.runner"]}}}

--- a/tools/testbed-support/src/re_frame/testbed/config.cljs
+++ b/tools/testbed-support/src/re_frame/testbed/config.cljs
@@ -1,112 +1,31 @@
 (ns re-frame.testbed.config
-  "Shared testbed-config helper — derives the on-disk source-root the
-  Xray / Story testbeds hand to their 'open in editor' resolvers.
+  "Resolves the on-disk source root used by testbed open-in-editor links.
 
-  ## Two roots, named for what they are
-
-  Two concepts ride this helper, and they are deliberately named apart:
-
-  - a **checkout root** — the absolute path to a clone of this repo
-    (`<checkout>`). This is the *input*: the build-env-seeded
-    `checkout-root` goog-define and the `?checkout-root=` query override
-    both name one.
-  - a **source root** — the checkout root with the caller's tool-relative
-    testbed subdir appended (`<checkout>/tools/xray/testbeds`). This is
-    the *output* `resolve-source-root` returns — the root the editor-URI
-    composer prepends to a classpath-relative `:file` slot.
-
-  Keeping the two names distinct keeps input and output from both being
-  spelled 'root', which would overload the reader.
-
-  ## Why this exists
-
-  Xray and Story turn a source-coord (`standard_epochs/core.cljs:42`) into an
-  editor URI by prepending an on-disk *source root*. Shipped code reads
-  that root from host config (`xray-config/configure!` /
-  `story/configure!`); there is no baked default. The dev testbeds that
-  drive Xray / Story have to PASS a root to `configure!`, and that root
-  cannot be a hardcoded absolute checkout (e.g.
-  `C:/Users/me/code/my-app/tools/xray/testbeds`): on any other clone, any
-  other directory, and every Mac/Linux maintainer, such a literal resolves
-  'open in editor' to a path that does not exist. This helper derives the
-  root cross-platform from the build environment instead.
-
-  ## How the root is derived (cross-platform, build-env derived)
-
-  `checkout-root` is a `goog-define`d string, default `\"\"`. The dev launcher
-  (`implementation/scripts/dev-testbed.cjs`, wired as the `dev` npm
-  script) resolves the checkout root from its OWN location via node's
-  `path` module — which works identically on Windows, macOS, and Linux —
-  exports it as the `RF2_TESTBED_PROJECT_ROOT` env var, and spawns
-  `shadow-cljs`. Every testbed build in `implementation/shadow-cljs.edn`
-  (the Xray testbeds plus the Story testbeds + static build) seeds the
-  define from that env var via `#shadow/env`, so the absolute root is the
-  ACTUAL checkout root of whatever clone did the build — never a literal.
-
-  `resolve-source-root` then joins that checkout root with the
-  tool-relative testbed subdir (`\"tools/xray/testbeds\"` /  `\"tools/story/testbeds\"`)
-  the caller passes. A `?checkout-root=<checkout>` query string wins
-  as the per-session escape hatch (CI, a reader on a different machine, a
-  testbed served from a copied bundle) — it names the same thing as the
-  build-time root (a CHECKOUT root) and has the subdir appended the same
-  way, so the composed editor URI reaches the tool source root
-  (`<checkout>/tools/xray/testbeds`) the classpath-relative source coords
-  resolve against. When neither the override nor the
-  build-time root is present, this returns `nil` and the testbed simply
-  configures no root — 'open in editor' degrades to a no-op rather than a
-  broken link, exactly the graceful-absence behaviour
-  `set-project-root!` already encodes for blank input.
-
-  ## Why a goog-define and not a literal
-
-  The checkout root cannot be known when the source is authored (it differs
-  per clone), so it must be supplied at build time. A goog-define seeded
-  from the build environment is the smallest cross-platform-correct
-  mechanism: one define + one shared helper, no per-file string, no
-  OS-specific path assumptions."
+  The input is a checkout root, supplied by `?checkout-root=` or the
+  build-seeded `checkout-root` define. `resolve-source-root` appends the
+  caller's tool-relative source subdirectory. Paths are normalized to forward
+  slashes; query decoding preserves literal `+` characters. Missing roots
+  resolve to nil so open-in-editor can remain a no-op."
   (:require [clojure.string :as str]))
 
-;; ---- the compile-time, build-env-derived checkout root -------------------
-;;
 ;; @define {string}
-;; Defaults to "" (no root known). Seeded per build from the
-;; RF2_TESTBED_PROJECT_ROOT env var via `#shadow/env` in
-;; implementation/shadow-cljs.edn :closure-defines. The `dev` npm script
-;; (implementation/scripts/dev-testbed.cjs) exports that env var with the
-;; node-resolved checkout root before spawning shadow-cljs.
+;; Seeded from RF2_TESTBED_PROJECT_ROOT by implementation/shadow-cljs.edn.
 (goog-define checkout-root "")
 
 (defn- non-blank
-  "Return `s` when it is a non-blank string, else nil."
   [s]
   (when (and (string? s) (seq (str/trim s))) s))
 
 (defn- decode-component
-  "`decodeURIComponent` the value, returning the raw value unchanged if it
-  carries a malformed percent-escape (which would otherwise throw)."
+  "Decode percent escapes, leaving malformed input unchanged."
   [v]
   (try
     (js/decodeURIComponent v)
     (catch :default _ v)))
 
 (defn- query-param-from-search
-  "Pure parser for the per-session override knob: given a URL query string
-  `search` (the `?a=b&c=d` form, as produced by `location.search`) and a
-  `param-name`, return that param's value URL-decoded, trimmed, and
-  non-blank — or nil when the param is absent, blank, or the search string
-  itself is blank/nil.
-
-  Decoding semantics: a literal `+` in the value is preserved
-  VERBATIM, NOT decoded to a space. The override names an on-disk checkout
-  root, so a checkout at e.g. `/home/dev/re-frame2+wip` must round-trip
-  through `?checkout-root=/home/dev/re-frame2+wip` with the `+` intact. We
-  therefore split the query string manually and decode each component with
-  `js/decodeURIComponent` (which does NOT map `+` → space) rather than
-  `js/URLSearchParams` (form-urlencoded: `+` → space, silent path
-  corruption). Percent-escapes still decode (`%2F` → `/`, `%20` → space,
-  `%2B` → `+`). This fn carries no `js/window` dependency and is fully
-  exercisable off-browser; the only genuinely browser-bound step — reading
-  `location.search` off the live document — is isolated in `query-param`."
+  "Return a decoded, trimmed query value or nil. Parsing is deliberately not
+  form-urlencoded: a literal `+` in a checkout path must remain `+`."
   [search param-name]
   (when-let [s (non-blank search)]
     (let [s (cond-> s (str/starts-with? s "?") (subs 1))]
@@ -120,64 +39,27 @@
             (str/split s #"&")))))
 
 (defn- query-param
-  "Return the named URL query param as a trimmed non-blank string, or nil
-  when absent / blank / running outside a browser. The per-session
-  override knob — not a Xray/Story-API surface, so kept private.
-
-  Thin browser-only adapter: reads `location.search` off the live document
-  when a `js/window` exists, then delegates the parse/decode/trim/non-blank
-  contract to the pure `query-param-from-search`. Outside a browser (e.g.
-  `:node-test`) there is no `js/window`, so this returns nil and the
-  build-time `checkout-root` tier governs (the intended non-browser degradation)."
+  "Read a query value from the browser, or nil outside a browser."
   [param-name]
   (when (exists? js/window)
     (query-param-from-search (-> js/window .-location .-search) param-name)))
 
 (defn- to-forward-slashes
-  "Canonicalise every path separator in `s` to a forward slash. A Windows
-  checkout root (`C:\\Users\\me\\code\\re-frame2`) and a POSIX one
-  (`/home/dev/re-frame2`) thus reduce to the SAME `/`-separated form, the
-  canonical shape this helper emits — matching the launcher's build-env
-  normalisation (`implementation/scripts/dev-testbed.cjs`) and the
-  separator-agnostic editor-URI composer (`source_coords/editor_uri.cljc`,
-  which accepts both `/` and `\\` on input and joins with `/`)."
+  "Canonicalize Windows and POSIX separators to `/`."
   [s]
   (str/replace s #"\\" "/"))
 
 (defn- strip-trailing-slash
-  "Return `s` without a single trailing forward slash, leaving a lone
-  `\"/\"` intact. Callers canonicalise backslashes to `/` first
-  (`to-forward-slashes`), so this only needs to consider forward slashes."
+  "Strip one trailing slash, but preserve the POSIX root `/`."
   [s]
   (if (and (> (count s) 1) (str/ends-with? s "/"))
     (subs s 0 (dec (count s)))
     s))
 
 (defn- join-root+subdir
-  "Join a checkout `root` with the tool-relative testbed `subdir`,
-  normalising both sides so the result carries exactly one separator and
-  uses the canonical forward-slash form on every platform.
-
-  Both sides are first canonicalised so any `\\` separator (a raw or
-  `%5C`-decoded Windows override root, e.g.
-  `C:\\Users\\me\\code\\re-frame2\\`) becomes `/` — so a Windows
-  `?checkout-root=` value joins exactly like a POSIX one rather than
-  yielding a `\\/` boundary (`C:\\...\\/tools/xray/testbeds`) that would
-  depend on downstream tolerant path normalisation. `root` then has any
-  single trailing slash stripped (so `/repo/` + `sub` never yields `/repo//sub`);
-  `subdir` is trimmed and any leading slash(es) removed (so callers may
-  pass it with or without a leading slash). A blank / nil / slash-only
-  `subdir` collapses to the normalised root verbatim.
-
-  The one root that survives normalisation WITH a trailing slash is the
-  lone POSIX filesystem root `\"/\"`: `strip-trailing-slash` preserves it
-  (a lone separator is meaningful — destroying it would make the root a
-  blank relative path), so it is the only case where `normalized-root`
-  ends in `/`. We therefore add the boundary separator only when the
-  root does not already supply one, so `\"/\"` + `\"tools/xray/testbeds\"`
-  yields `/tools/xray/testbeds` (exactly one separator) rather than
-  `//tools/xray/testbeds` — honouring the single-separator contract for
-  every root, POSIX filesystem-root included."
+  "Join a checkout root and source subdirectory using forward slashes and a
+  single boundary separator. A blank subdirectory returns the normalized
+  root. The POSIX root `/` remains significant."
   [root subdir]
   (let [normalized-root   (-> root str/trim to-forward-slashes strip-trailing-slash)
         normalized-subdir (-> (or subdir "")
@@ -185,48 +67,18 @@
                               to-forward-slashes
                               (str/replace #"^/+" ""))]
     (if (seq normalized-subdir)
-      ;; Add the boundary "/" only when the root does not already end in
-      ;; one — the lone-"/" filesystem root is the sole normalised root
-      ;; that keeps a trailing slash, so this is what stops `//tools/...`.
+      ;; `/` is the only normalized root that already supplies the boundary.
       (if (str/ends-with? normalized-root "/")
         (str normalized-root normalized-subdir)
         (str normalized-root "/" normalized-subdir))
       normalized-root)))
 
 (defn resolve-source-root
-  "Resolve the on-disk source root a testbed should hand to its
-  open-in-editor resolver, for the given tool-relative testbed subdir
-  (e.g. `\"tools/xray/testbeds\"` or `\"tools/story/testbeds\"`).
+  "Resolve a testbed source root for tool-relative `subdir`.
 
-  Both input tiers name a *checkout root* and have the caller's `subdir`
-  appended to yield the *source root*, because the editor URI is built by
-  prepending the resolved source root to a *classpath-relative* source
-  coord (the form-meta `:file` slot, e.g. `\"standard_epochs/core.cljs\"`,
-  relative to the testbed source root `<checkout>/tools/xray/testbeds`).
-  The result must therefore reach down to that source root, or the composed
-  editor URI misses the tool source-root segment and points at a nonexistent
-  file. The override and the build-time define mean the
-  same thing — a checkout root — so they share one join.
-
-  Resolution order:
-
-    1. `?checkout-root=<checkout>` query string — the per-session escape
-       hatch (CI, a reader on a different machine, a copied bundle served
-       elsewhere). Wins over the build-time tier. Paste the checkout root
-       unencoded, a literal `+` included (it is preserved, NOT decoded to
-       a space; see `query-param-from-search`); a Windows root may use
-       `\\` separators (raw or `%5C`-encoded) and is canonicalised to `/`
-       (see `join-root+subdir`); `subdir` is appended just like tier 2.
-    2. The build-time `checkout-root` goog-define — the default for a normal
-       `npm run dev ...` launch; `subdir` is appended.
-    3. `nil` — neither checkout root is available. The caller configures no
-       root and open-in-editor is a graceful no-op (matching
-       `set-project-root!`'s blank-input contract).
-
-  Both input tiers and `subdir` are normalised to the canonical
-  forward-slash form (`\\` → `/`, trim, trailing/leading-slash strip) so
-  callers may pass either separator style with or without a leading
-  slash, and the result carries exactly one separator at every boundary."
+  A non-blank `?checkout-root=` override wins over the build-time
+  `checkout-root` define. Both values name the checkout root and receive the
+  same normalized subdirectory join. Returns nil when neither is available."
   [subdir]
   (when-let [root (non-blank (or (query-param "checkout-root") checkout-root))]
     (join-root+subdir root subdir)))

--- a/tools/testbed-support/src/re_frame/testbed/open_in_editor_server.clj
+++ b/tools/testbed-support/src/re_frame/testbed/open_in_editor_server.clj
@@ -1,69 +1,10 @@
 (ns re-frame.testbed.open-in-editor-server
-  "Dev-server 'open in editor' endpoint (Option B).
+  "Dev-only Ring endpoint for opening source coordinates in an editor.
 
-  The JS-ecosystem standard for jump-to-source is a dev-server endpoint:
-  Vite's `/__open-in-editor`, react-dev-utils' `launchEditorEndpoint`,
-  Next.js' launch-editor middleware. This namespace is the re-frame2
-  equivalent — a shadow-cljs `:dev-http` Ring `:handler` (a not-found
-  fallback) that answers `POST /__rf-open-in-editor?file=<…>&line=<n>
-  &column=<c>` by resolving the (classpath-relative) `:file` against the
-  dev JVM's source-paths AT RUNTIME and launching the editor via the
-  `launch-editor` npm package.
-
-  ## Why it is POST-only + loopback-guarded
-
-  The endpoint LAUNCHES the developer's editor on a local file path, so
-  left open it is a drive-by vector in the historic Vite / react-dev-utils
-  CVE class — any page the developer is visiting could fire a request at
-  `http://localhost:<dev-port>` and open an attacker-chosen file. The
-  handler therefore acts only on a POST that is addressed to a loopback
-  `Host` and (when one is present) carries a loopback `Origin`; CORS is
-  reflected to that validated loopback origin, never `*`. A simple GET/HEAD
-  drive-by, a request reaching a non-loopback hostname, or a POST from a
-  remote page's Origin is rejected before any path resolution. The default
-  client (`re-frame.source-coords.open-endpoint`) already POSTs from the
-  same/cross-PORT dev origin, so the dev DX is unchanged.
-
-  ## Why server-side beats the editor:// URI scheme
-
-  The editor:// open-in-editor path (kept as the fallback — see
-  `day8.re-frame2-xray.open-in-editor` / `re-frame.story.ui.open-in-editor`)
-  builds an `editor://file/<abs-path>:<line>:<column>` URI and hands it to
-  `window.location`. That works zero-config for the common local-build
-  case (`absolutise-file` bakes the absolute path in at macro-expansion
-  time), but it has two residual gaps Option B closes:
-
-    1. `absolutise-file` can only absolutise coords whose
-       sources are classpath `file:` resources — sources consumed as JARs
-       / in-jar / unusual classpaths leave a RELATIVE `:file` that needs a
-       manual `:project-root`. This endpoint resolves the relative file
-       against the live source-paths on the dev machine, so jump-to-source
-       is zero-config for EVERYONE including the JAR/relative-coord case.
-    2. `absolutise-file` bakes the BUILDER's absolute home path into the
-       dev bundle (DCE-d in prod, so not a shipped leak, but it puts the
-       dev username/path into the dev JS). This endpoint resolves the path
-       at runtime on the server — nothing baked into the bundle.
-
-  ## Bundle isolation
-
-  This is a `.clj` file (JVM-only) that runs on the shadow-cljs SERVER
-  JVM — it is NEVER part of any browser/CLJS build (shadow ignores `.clj`
-  sources for CLJS compilation), so it cannot leak into a production
-  bundle. It is wired into the testbed `:dev-http` ports in
-  `implementation/shadow-cljs.edn`; the `:dev-http` block itself is honoured
-  only by `shadow-cljs watch`/`compile`, never by `release`.
-
-  ## Editor launch
-
-  `launch-editor` (the Vite/CRA/Next package) is a Node-only library with
-  no CLI, so we shell out to `node` running a one-liner that requires it
-  and passes the resolved `<abs-path>:<line>:<column>` string plus an
-  optional editor-command hint. `launch-editor` parses the `:line:column`
-  suffix itself and builds the per-editor argument shape (it handles every
-  OS + editor, so no per-editor `editor://` scheme table is needed). The
-  editor hint maps the configured editor keyword (`:vscode`/`:cursor`/…)
-  to the editor's launch command; when no hint is given launch-editor
-  auto-detects the running editor (and honours `$LAUNCH_EDITOR`)."
+  The JVM handler resolves classpath-relative files at request time and invokes
+  the Node `launch-editor` package. Launches require POST, a loopback Host, and
+  a loopback Origin when one is present. This `.clj` namespace runs only in the
+  shadow-cljs server and is never part of a browser bundle."
   (:require [clojure.string :as str]
             [re-frame.source-coords :as source-coords]
             [re-frame.source-coords.editor-uri :as editor-uri])
@@ -73,25 +14,13 @@
 (set! *warn-on-reflection* true)
 
 (def endpoint-path
-  "The request path this handler answers. Mirrors Vite's
-  `/__open-in-editor`, namespaced under the `__rf-` dev-affordance prefix
-  so it cannot collide with an app route."
+  "The dev-server path handled by this namespace."
   "/__rf-open-in-editor")
 
-;; ---- editor-keyword → launch-editor command hint -------------------------
-;;
-;; `launch-editor`'s optional 2nd arg is an editor *command* (a bin name,
-;; e.g. "code"), NOT the editor:// keyword our config carries. Map the
-;; configured keyword to the conventional launch command so a host that
-;; has already set `:rf.xray/editor :cursor` / `:rf.story/editor :idea`
-;; gets the same editor server-side. Unknown / `{:custom …}` shapes return
-;; nil → launch-editor falls back to running-process detection + the
-;; `$LAUNCH_EDITOR` env override (the same auto-detection Vite relies on).
+;; launch-editor expects a binary name, not the editor keyword in host config.
 
 (def editor-command-by-keyword
-  "Map of the open-in-editor keyword vocabulary → the editor's launch
-  command for `launch-editor`. `:custom` templates and unknown keywords
-  resolve to nil (auto-detect)."
+  "Open-in-editor keyword strings mapped to launch-editor binary names."
   {"vscode"          "code"
    "vscode-insiders" "code-insiders"
    "cursor"          "cursor"
@@ -100,64 +29,28 @@
    "idea"            "idea"})
 
 (defn editor-hint
-  "Resolve the launch-editor command hint from an `editor` query value
-  (the editor keyword as a bare string, e.g. \"cursor\"). Returns nil for
-  blank / unknown values so launch-editor auto-detects."
+  "Resolve an editor query value to a command hint, or nil for auto-detect."
   [editor]
   (when (and (string? editor) (not (str/blank? editor)))
     (get editor-command-by-keyword (str/lower-case (str/trim editor)))))
 
-;; ---- runtime :file resolution (delegates to core absolutise-file) --------
-;;
-;; The server runs on the dev JVM with the full shadow-cljs classpath, so
-;; a classpath-relative `:file` (the common macro-captured shape — e.g.
-;; "day8/re_frame2_xray/views/edn_inspector.cljs") resolves to its on-disk
-;; absolute path via the context class-loader exactly like the JVM-side
-;; `re-frame.source-coords/absolutise-file` does at macro-expansion time —
-;; but here at RUNTIME, so it works even when the build-time bake didn't
-;; (JARs, odd classpaths, relative coords that fell through).
-;;
-;; That classpath stage — context-class-loader lookup, `file:` URL decode
-;; (`URI.getPath`, preserving a literal `+`), and Windows drive-letter
-;; normalization — is exactly what `re-frame.source-coords/absolutise-file`
-;; already owns canonically (rf2-wvsxg / rf2-st3ax4). `resolve-file` delegates
-;; to it rather than re-implementing the same decode dance a second time
-;; (rf2-hf0vqa). `absolutise-file` is JVM-private in core; it is reached here
-;; via its var (`#'source-coords/absolutise-file`) so the runtime twin stays a
-;; single source of truth without widening core's public surface. The
-;; endpoint-owned cwd fallback + existence/raw-path policy stay here — they are
-;; the runtime-only gap Option B exists to close, which the macro-time
-;; `absolutise-file` has no notion of.
+;; Core owns classpath URL decoding; this endpoint adds runtime cwd fallback.
 
 (defn resolve-file
-  "Resolve a (possibly classpath-relative) `path` to its absolute on-disk
-  path. Returns the input unchanged when it is already absolute (per
-  `editor-uri/absolute-path?`). Otherwise the classpath stage is delegated to
-  `re-frame.source-coords/absolutise-file` (the canonical context-class-loader
-  `getResource`-then-`URI.getPath`-decode resolver, which preserves a literal
-  `+` and normalizes a Windows drive path). When the classpath stage cannot
-  resolve the file — `absolutise-file` then returns the input UNCHANGED (not on
-  classpath, non-`file:` URL, or a probe error) — this falls back to resolving
-  it against the JVM's working directory (the dev process cwd is the consumer's
-  project root under shadow-cljs); if that file does not exist either, the input
-  is returned unchanged so launch-editor at least gets the raw path. Returns nil
-  for nil/blank input."
+  "Resolve `path` through core's classpath resolver, then the dev-process cwd.
+  Absolute paths pass through, unresolved paths remain unchanged, and blank
+  input returns nil."
   [path]
   (cond
     (or (nil? path) (str/blank? path)) nil
     (editor-uri/absolute-path? path)   path
     :else
-    ;; 1. Classpath stage — delegate to core's canonical resolver. It returns
-    ;;    the absolute on-disk path when the file resolves on the classpath,
-    ;;    else the input UNCHANGED. A resolved path is always absolute (≠ the
-    ;;    relative input), so an unchanged result is the "did not resolve"
-    ;;    signal that falls through to the endpoint-owned fallbacks below.
+    ;; An unchanged result signals that the classpath lookup did not resolve.
     (let [absolutised (#'source-coords/absolutise-file path)]
       (if (not= absolutised path)
         absolutised
         (or
-          ;; 2. Relative to the dev process cwd (JAR / in-jar / off-classpath
-          ;;    coords getResource cannot reach — the gap Option B closes).
+          ;; Off-classpath coordinates may still be relative to the dev cwd.
           (try
             (let [f     (File. ^String path)
                   cwd-f (File. ^String (System/getProperty "user.dir") ^String path)]
@@ -166,38 +59,21 @@
                 (.exists cwd-f) (.getAbsolutePath cwd-f)
                 :else           nil))
             (catch Throwable _ nil))
-          ;; 3. Unresolvable — hand the raw path back; the existence gate in
-          ;;    `launch!` then rejects it rather than launching blind.
+          ;; launch! applies the final existence check.
           path)))))
 
 (defn ^:private file-exists?
-  "True when `path` names an existing filesystem entry. Mirrors
-  `launch-editor`'s OWN `fs.existsSync(fileName)` gate: `launch-editor`
-  silently no-ops on a missing file — it returns WITHOUT invoking its
-  error callback, so the `node` process exits 0 and `launch!` would report
-  a false `{:ok true}`. Checking the resolved path here (before the spawn)
-  turns that silent no-op into an explicit failure the endpoint answers as
-  a 422, so the client falls back to the `editor://` URI instead of
-  believing the file opened. Never throws — a nil/blank path or any IO /
-  security-manager error is treated as 'does not exist'."
+  "Return whether `path` exists, treating invalid input and IO errors as false."
   [path]
   (boolean
     (when-not (str/blank? path)
       (try (.exists (File. ^String path)) (catch Throwable _ false)))))
 
-;; ---- the launch shim -----------------------------------------------------
-;;
 ;; launch-editor has no CLI, so we run `node -e` requiring it. The file
-;; spec carries the :line:column suffix launch-editor parses itself; the
-;; editor command (if any) is the optional 2nd argv. Resolved relative to
-;; the dev JVM's working directory so `node`'s require finds the package in
-;; the consumer's node_modules.
+;; spec and optional editor binary are passed as separate argv tokens.
 
 (def ^:private launch-shim
-  ;; Single-line Node program: require launch-editor and invoke it with
-  ;; argv[1]=<file:line:col> argv[2]=<editor-or-empty>. On the error
-  ;; callback, write the message to stderr and exit non-zero so the JVM
-  ;; side sees the failure in the shell exit code.
+  ;; Exit nonzero from launch-editor's callback so the JVM sees failures.
   (str "var l=require('launch-editor');"
        "var f=process.argv[1];var e=process.argv[2]||undefined;"
        "l(f,e,function(file,msg){"
@@ -205,22 +81,8 @@
        "process.exit(1);});"))
 
 (defn ^:private build-file-spec
-  "Build the `<abs-path>[:<line>][:<column>]` argv token `launch-editor`
-  parses itself.
-
-  A request carrying `column` with NO `line` is normalized to line 1
-  first. `launch-editor`'s `file:line:column` grammar takes the FIRST
-  number as the line, so a bare `path:<column>` would be misread as a line
-  jump and the column intent lost. Emitting `path:1:<column>` preserves
-  the column and aligns with the `editor://` URI fallback, which likewise
-  defaults a missing line to 1 whenever a column is present
-  (`editor-uri/coord-line` — `(or (:line coord) 1)`).
-
-  With a `line` present the column is appended after it (`path:line:col`),
-  and with neither the token stays a bare path. This keeps the client
-  contract (`open-endpoint/build-url` sends `&line=`/`&column=` via
-  independent `cond->` clauses) while never handing `launch-editor` a
-  column masquerading as a line."
+  "Build launch-editor's `path[:line][:column]` token. A column without a
+  line uses line 1 so the column is not parsed as a line number."
   [abs-path line column]
   (let [line (if (and column (nil? line)) 1 line)]
     (cond-> abs-path
@@ -228,23 +90,11 @@
       column (str ":" column))))
 
 (defn launch!
-  "Shell out to node + launch-editor for `abs-path` at `line`/`column`,
-  with an optional launch-editor `command` hint. Returns a map
-  `{:ok bool :message string?}`. Runs from the dev JVM cwd so node resolves
-  the launch-editor package in the consumer's node_modules.
+  "Invoke launch-editor from the dev JVM cwd and return `{:ok ...}`.
 
-  Rejects a missing file BEFORE spawning node. `launch-editor` silently
-  no-ops on a nonexistent file (`if (!fs.existsSync(fileName)) return` —
-  it never calls its error callback, so the node process exits 0), which
-  would report a false `{:ok true}` and make the endpoint answer 200 for an
-  unresolved / nonexistent `:file`, suppressing the client's `editor://`
-  fallback. A file that does not exist short-circuits to
-  `{:ok false :message \"file-not-found\"}` (no node spawn) so the endpoint
-  answers 422 and the client falls back.
-
-  Never throws — any other failure (node missing, package absent, launch
-  error) likewise degrades to `{:ok false :message …}` so the endpoint can
-  answer cleanly and the client falls back to the editor:// URI."
+  Missing files are rejected before spawning Node because launch-editor
+  otherwise exits successfully without opening anything. Other failures are
+  returned as messages instead of escaping the Ring boundary."
   [abs-path line column command]
   (if-not (file-exists? abs-path)
     {:ok false :message "file-not-found"}
@@ -256,9 +106,7 @@
                    (.redirectErrorStream false))
               _  (.directory pb (File. (System/getProperty "user.dir")))
               proc (.start pb)
-              ;; launch-editor returns ~immediately (it spawns the editor
-              ;; detached); bound the wait so a hung node never wedges the
-              ;; dev server's request thread.
+              ;; Bound the wait so Node cannot wedge a dev-server thread.
               done? (.waitFor proc 10 java.util.concurrent.TimeUnit/SECONDS)
               exit  (when done? (.exitValue proc))
               err   (when done?
@@ -276,34 +124,15 @@
 ;; ---- query parsing -------------------------------------------------------
 
 (defn ^:private decode-component
-  "Percent-decode one query key/value with `decodeURIComponent` semantics:
-  `%XX` escapes decode as UTF-8, a literal `+` is preserved as `+`.
-
-  Decodes via `java.net.URI` (the fragment component) rather than
-  `URLDecoder/decode`. `URLDecoder` is an `application/x-www-form-urlencoded`
-  decoder that maps a literal `+` to a SPACE — which would silently corrupt a
-  checkout path carrying a literal `+` (`C:/code/re-frame2+wip` →
-  `re-frame2 wip`), re-introducing exactly the bug `re-frame.source-coords/
-  absolutise-file` avoids for `file:` URLs (via `URI.getPath` — the classpath
-  resolver `resolve-file` delegates to) and the client's `js/decodeURIComponent`
-  avoids in `config.cljs` (rf2-62hu6k). Routing the component through `URI`'s
-  fragment decode leaves a literal `+` intact while still decoding `%20`/`%2B`,
-  matching that grammar.
-
-  A malformed percent-escape (a lone `%`, or `%` not followed by two hex
-  digits) makes `URI/create` throw `IllegalArgumentException`, which the
-  endpoint catches as the same clean 400 malformed-query response
-  `URLDecoder/decode` already triggered."
+  "Percent-decode with URI semantics, preserving a literal `+`. Malformed
+  escapes throw `IllegalArgumentException` for the handler to map to 400."
   [^String s]
   (if (.isEmpty s)
     s
     (.getFragment (URI/create (str "#" s)))))
 
 (defn ^:private parse-query
-  "Parse a URL query string into a `{name value}` map (last value wins).
-  Keys/values are percent-decoded via `decode-component` (decodeURIComponent
-  semantics — a literal `+` is PRESERVED, never mapped to a space). Returns
-  `{}` for nil/blank."
+  "Parse a query string into a decoded map; the last value wins."
   [qs]
   (if (str/blank? qs)
     {}
@@ -326,51 +155,22 @@
   (when (and (string? s) (re-matches #"\d+" s))
     (try (Long/parseLong s) (catch Throwable _ nil))))
 
-;; ---- localhost / origin guard --------------------------------------------
-;;
-;; This endpoint LAUNCHES the developer's editor on an arbitrary local file
-;; path. Left open it is a drive-by vector in the historic Vite /
-;; react-dev-utils CVE class: any web page the developer happens to be
-;; visiting could fire a request at `http://localhost:<dev-port>` and open
-;; an attacker-chosen file in the editor. The guard pins the endpoint to the
-;; local machine and to local browsing contexts:
-;;
-;;   1. request-method must be POST (the launch path). A simple GET/HEAD —
-;;      the only thing an `<img>`/`<form>`/`<link>` drive-by or a `no-cors`
-;;      simple request can issue — never reaches `launch!`.
-;;   2. the `Host` header must name a loopback address: the request must
-;;      have been addressed to localhost / 127.0.0.1 / [::1]. This rejects a
-;;      request that reached the dev JVM via a non-loopback hostname (a
-;;      DNS-rebinding / public-binding attempt).
-;;   3. when an `Origin` header is present it must itself be a loopback
-;;      origin. A page served from `https://evil.example` carries that
-;;      Origin on its cross-origin POST and is rejected; a legitimate
-;;      cross-PORT dev request (Story shell on :8042 → app on :8031) carries
-;;      a `http://localhost:8042` Origin and passes. (A same-origin POST may
-;;      omit Origin entirely, which is allowed once 1 + 2 hold.)
-;;
-;; CORS is then reflected to the validated loopback Origin only — never a
-;; `*` wildcard.
+;; Launches must be addressed to loopback and, when supplied, originate there.
+;; The handler separately enforces POST and reflects only validated origins.
 
 (defn ^:private loopback-host?
-  "True when `host` (a `Host`-header value, optionally `name:port`, or the
-  host portion of an Origin/URL) names a loopback address: `localhost`,
-  `127.0.0.0/8`, or the IPv6 `[::1]`/`::1`. Case-insensitive; nil/blank is
-  not loopback."
+  "Recognize localhost, 127.0.0.0/8, and IPv6 loopback host values."
   [host]
   (boolean
     (when (and (string? host) (not (str/blank? host)))
       (let [h    (str/lower-case (str/trim host))
-            ;; Drop a trailing :port. For a bracketed IPv6 literal
-            ;; (`[::1]:8080`) split on `]:`; otherwise on the last `:` only
-            ;; when there is exactly one (an unbracketed IPv6 has many and
-            ;; carries no port in a Host header).
+            ;; A single colon separates a port; multiple colons are IPv6.
             bare (cond
                    (str/starts-with? h "[")
                    (let [close (str/index-of h "]")]
                      (if close (subs h 1 close) h))
 
-                   (and (str/includes? h ":")
+                 (and (str/includes? h ":")
                         (= 1 (count (filter #(= % \:) h))))
                    (subs h 0 (str/index-of h ":"))
 
@@ -382,11 +182,7 @@
                  (re-matches #"127\.\d{1,3}\.\d{1,3}\.\d{1,3}" bare)))))))
 
 (defn ^:private origin-host
-  "Extract the host portion of an `Origin` header value (a serialized
-  origin, e.g. `http://localhost:8042`). Returns nil when it cannot be
-  parsed. The literal string `\"null\"` (an opaque origin — sandboxed
-  iframe, `file:`, some redirects) yields nil so it never passes the
-  loopback check."
+  "Extract an Origin host, rejecting blank, malformed, and opaque origins."
   [origin]
   (when (and (string? origin)
              (not (str/blank? origin))
@@ -396,8 +192,7 @@
       (catch Throwable _ nil))))
 
 (defn ^:private get-header
-  "Read a request header case-insensitively from the Ring `:headers` map
-  (shadow-cljs dev-http lowercases header names, but read defensively)."
+  "Read a Ring request header case-insensitively."
   [headers nm]
   (when (map? headers)
     (or (get headers nm)
@@ -407,10 +202,7 @@
               headers))))
 
 (defn ^:private local-request?
-  "Guard predicate: true when the request is safe to act on — addressed to a
-  loopback `Host` AND, if it carries an `Origin`, that Origin is itself a
-  loopback origin. A same-origin request that omits Origin passes on the
-  Host check alone. See the `loopback-host?` comment for the threat model."
+  "Require a loopback Host and, when present, a loopback Origin."
   [{:keys [headers]}]
   (let [host   (get-header headers "host")
         origin (get-header headers "origin")]
@@ -420,10 +212,7 @@
              (loopback-host? (origin-host origin))))))
 
 (defn ^:private allow-origin
-  "The `access-control-allow-origin` value to reflect: the request's own
-  Origin when it is a validated loopback origin (so a legitimate cross-PORT
-  dev request gets a usable CORS header), else `\"null\"` (deny). Never a
-  `*` wildcard."
+  "Reflect a validated loopback Origin; otherwise deny with `null`."
   [{:keys [headers]}]
   (let [origin (get-header headers "origin")]
     (if (and origin (loopback-host? (origin-host origin)))
@@ -431,19 +220,7 @@
       "null")))
 
 (defn ^:private escape-json-string
-  "Escape `s` for embedding in a JSON string literal: backslash and
-  double-quote, plus `\\n`/`\\r`/`\\t` and every other C0 control
-  character (`U+0000`-`U+001F`) as `\\uXXXX`. Single-pass (each char
-  handled once) so there is no double-escaping ordering hazard between
-  the backslash/quote rules.
-
-  Load-bearing: the 200 response echoes the url-decoded `:file` verbatim
-  and the 422 response echoes trimmed `node` stderr (which can be a
-  multi-line stack trace), so a `file=...%0A...` request or a multi-line
-  launch failure message can carry a raw control character. Escaping only
-  backslash/doublequote (the prior behaviour) let such a value emit a
-  literal newline/tab/CR into the body — syntactically INVALID JSON
-  despite the `application/json` header."
+  "Escape a JSON string in one pass, including every C0 control character."
   [^String s]
   (let [sb (StringBuilder. (.length s))]
     (doseq [c s]
@@ -462,10 +239,7 @@
   [status allow-origin-val m]
   {:status  status
    :headers {"content-type"                "application/json"
-             ;; CORS reflected to the validated loopback Origin only —
-             ;; never `*`. A legitimate cross-PORT dev request (Story shell
-             ;; on :8042 reaching an app on :8031) gets its own origin back;
-             ;; everything else gets `null` (deny).
+             ;; A cross-port local testbed receives its own validated origin.
              "access-control-allow-origin" allow-origin-val
              "vary"                        "origin"
              "cache-control"               "no-store"}
@@ -483,46 +257,16 @@
 ;; ---- the Ring handler ----------------------------------------------------
 
 (defn handle
-  "Core request handler for the open-in-editor endpoint. Pure-ish: takes a
-  standard Ring request map, returns a Ring response map (or nil to fall
-  through). Answers only the `endpoint-path`; returns nil for every other
-  path so the caller can defer to the next handler / push-state default.
+  "Handle the open-in-editor path or return nil for another path.
 
-  Query/form params:
-    `file`   — required; the source-coord `:file` (classpath-relative or
-               absolute). Resolved against source-paths at runtime.
-    `line`   — optional; integer.
-    `column` — optional; integer.
-    `editor` — optional; the editor keyword as a bare string (e.g.
-               \"cursor\"); maps to a launch-editor command hint.
-
-  Security: only a POST addressed to a loopback `Host` (with a loopback
-  `Origin` when one is present) reaches `launch!` — see `local-request?`.
-  A non-loopback / cross-origin request is rejected 403 before any path
-  resolution or editor launch; a non-POST (e.g. a drive-by GET) gets 405.
-
-  Responses:
-    200 `{\"ok\":true,\"file\":\"<abs>\"}`        — editor launched.
-    400 `{\"ok\":false,\"error\":\"missing-file\"}` — no `file` param.
-    400 `{\"ok\":false,\"error\":\"malformed-query\"}` — undecodable percent-escape
-        in the query string (e.g. a lone `%` or `%` not followed by two hex
-        digits — `decode-component`'s `URI/create` throws
-        `IllegalArgumentException` on these; caught here so a malformed query
-        answers cleanly instead of throwing into the shadow-cljs `:dev-http`
-        Ring plumbing).
-    403 `{\"ok\":false,\"error\":\"forbidden\"}`    — non-loopback / cross-origin.
-    405 `{\"ok\":false,\"error\":\"method-not-allowed\"}` — not POST.
-    422 `{\"ok\":false,\"error\":\"file-not-found\"}` — the resolved `:file`
-        does not exist on disk (`launch-editor` would silently no-op and the
-        endpoint would otherwise answer a false 200; see `launch!`). Non-2xx
-        so the client falls back to the `editor://` URI.
-    422 `{\"ok\":false,\"error\":\"<msg>\"}`       — launch failed."
+  Query keys are `file` (required), `line`, `column`, and `editor`. Only a
+  local POST reaches `launch!`. Invalid input produces JSON 400/403/405
+  responses; missing files and launch failures produce 422."
   [{:keys [uri request-method query-string] :as req}]
   (when (= uri endpoint-path)
     (let [ao (allow-origin req)]
       (cond
-        ;; CORS preflight for the cross-PORT dev POST. Reflect the validated
-        ;; loopback origin (or deny via `null`); only POST is offered.
+        ;; Cross-port local testbeds require an OPTIONS response.
         (= request-method :options)
         {:status 204
          :headers {"access-control-allow-origin"  ao
@@ -530,24 +274,16 @@
                    "access-control-allow-headers" "content-type"
                    "vary"                          "origin"}}
 
-        ;; Origin / host guard: reject anything not driven from the local
-        ;; machine + a local browsing context BEFORE touching the launch path.
+        ;; Apply the network boundary before resolving a path.
         (not (local-request? req))
         (json-resp 403 ao {:ok false :error "forbidden"})
 
-        ;; The launch path is POST-only — a simple GET/HEAD drive-by
-        ;; (`<img>`/`<form>`/`no-cors` fetch) can never trigger an editor launch.
+        ;; A simple GET/HEAD request must never trigger an editor launch.
         (not= request-method :post)
         (json-resp 405 ao {:ok false :error "method-not-allowed"})
 
         :else
-        ;; `parse-query` percent-decodes every key/value (via `decode-component`,
-        ;; preserving a literal `+`); a malformed percent-escape (a lone `%`, or
-        ;; `%` not followed by two hex digits) makes its `URI/create` throw
-        ;; `IllegalArgumentException`. Every other error path on this endpoint
-        ;; answers a clean JSON response — this one must too, so the decode is
-        ;; caught here rather than left to propagate uncaught into the Ring
-        ;; boundary.
+        ;; Convert URI decoding failures into the endpoint's JSON error shape.
         (try
           (let [q      (parse-query query-string)
                 file   (get q "file")
@@ -565,12 +301,7 @@
             (json-resp 400 ao {:ok false :error "malformed-query"})))))))
 
 (defn handler
-  "The shadow-cljs `:dev-http` `:handler` entry-point. A not-found
-  fallback: shadow tries the static file roots first, then calls this for
-  anything unmatched. We answer only `endpoint-path` and otherwise return a
-  404 (this is the last link in shadow's chain — returning nil here yields
-  an empty response rather than deferring, so a plain 404 is the honest
-  answer for paths we don't own)."
+  "shadow-cljs `:dev-http` fallback entry point."
   [req]
   (or (handle req)
       {:status 404

--- a/tools/testbed-support/src/re_frame/testbed/story_host.cljs
+++ b/tools/testbed-support/src/re_frame/testbed/story_host.cljs
@@ -1,112 +1,25 @@
 (ns re-frame.testbed.story-host
-  "Shared Story-host helper — the live-app ↔ Story-shell hash-toggle host
-  harness the Story showcase testbeds share.
+  "Hosts a live app and the Story shell on one `#app` node.
 
-  ## Why this exists
-
-  Every Story showcase entry point hosts TWO surfaces on the same `#app`
-  DOM node, one React root at a time:
-
-  - `#/`        → the live app (the testbed's own root view).
-  - `#/stories` → the Story shell mounted via `re-frame.story/mount-shell!`.
-
-  The live-app root view is not a bare React tree: it is a FRAME-SCOPED
-  SUBTREE — a frame, supplied by the consuming testbed via `frame-provider`,
-  resolving its handlers against a loaded IMAGE (EP-0023 §Views). This host
-  sits strictly ABOVE that frame/image boundary: it treats the root view as
-  an opaque frame subtree and never creates a frame or loads an image (the
-  consuming testbed does, via `reg-frame` / `with-frame` / `rf/init!`).
-
-  The plumbing that switches between them — a private `app-root` atom,
-  `ensure-app-root!` / `tear-down-app-root!` / `mount-app!` /
-  `mount-stories!`, and the `hashchange` listener — is pure React-DOM-root
-  juggling, identical across every testbed but for the live-app root view
-  (the frame subtree above). Centralising it here keeps each testbed's `run`
-  free to carry only its own boot specifics (CI hooks, elision listener,
-  `:fx-overrides`) without re-stating the host block.
-
-  ## What it owns
-
-  This namespace owns the React-root handle and the hash router ONLY — the
-  documented mount-handle exception to the app-db+events+subs rule. Both the
-  React-root atom and the installed-`hashchange`-listener
-  handle are `defonce` atoms here, so a testbed's hot-reload re-`run` reuses
-  the one root and replaces the one listener rather than leaking a fresh root
-  or STACKING a duplicate listener per reload (the explicit store/remove
-  discipline below). Everything else (Xray config, `rf/init!`,
-  `story/configure!`, per-frame `:fx-overrides`, seed dispatches, CI hooks)
-  stays inline in each testbed's `run` — those are the genuinely per-testbed
-  boot specifics, not host boilerplate.
-
-  ## How it's wired
-
-  Co-located with `re-frame.testbed.config` under `tools/testbed-support/
-  src`, which is already on every testbed build's shadow-cljs source path —
-  so consuming testbeds need no build-wiring change. Bundle-isolation holds:
-  nothing under `implementation/` `:require`s it (it lives under tools/).
-
-  ## The open-in-editor project-root
-
-  Story stamps each registered source-coord with a CLASSPATH-RELATIVE
-  `:file` slot (e.g. `login/stories.cljs`); the 'open in editor' chip
-  prepends an on-disk *project-root* to turn it into a real editor URI
-  (`re-frame.story.config/set-project-root!`). That root is per-build
-  (it differs per clone), so it cannot be baked in — the host must hand
-  it to `story/configure!` at boot. Carrying that call inline in every
-  consuming `run` makes it easy to mount the shell while silently
-  forgetting the root: the shell loads and the chip shows, but the source
-  links resolve against a nil root and OS editor handlers cannot open the
-  file (a false green — the link is dead).
-
-  To make that impossible to forget, the project-root config is a
-  HOST responsibility: a consumer declares its tool-relative source
-  subdir via the `:source-subdir` opt and `mount-with-hash-routing!`
-  resolves the root (through the shared `re-frame.testbed.config`
-  cross-platform mechanism — build-env define or `?checkout-root=`
-  override) and calls `story/configure!` itself. `story/configure!`
-  with `:rf.story/project-root` also bridges the root into Xray's slot
-  (`xray-preset/propagate-project-root!`), so the Xray-as-RHS chips
-  resolve too. When no subdir is declared (or no root is resolvable),
-  the host configures nothing and open-in-editor degrades to a graceful
-  no-op — the same blank-input contract `set-project-root!` already
-  encodes."
+  The consumer owns frame/image boot and supplies the live root view. This
+  namespace owns only the React-root handoff, hash routing, and optional Story
+  source-root configuration. `defonce` handles keep those resources stable
+  across hot reload."
   (:require [clojure.string :as str]
             [reagent.dom.client :as rdc]
             [re-frame.story :as story]
             [re-frame.testbed.config :as testbed-config]))
 
-;; -- The live-app React root ----------------------------------------------
-;;
 ;; The live app and the Story shell each own their own React root on the
-;; same `#app` DOM node, one at a time. The live app's root lives in
-;; `app-root` here; the Story shell allocates and owns its own root
-;; internally via `rdc/create-root` inside `mount-shell!`. We tear one down
-;; before mounting the other so React owns the target node exclusively.
-;;
-;; `defonce` so a testbed's hot-reload re-`run` reuses the same root rather
-;; than leaking a fresh one per reload.
+;; same node, one at a time. Each mount path tears down the other owner first.
 
 (defonce ^:private app-root (atom nil))
 
-;; The live-app root view in play, set by `mount-with-hash-routing!`. Held
-;; in an atom so the `hashchange` listener (below) reads the current view
-;; rather than closing over a per-`run` value — a re-`run` after hot-reload
-;; just `reset!`s the new view and the already-installed listener picks it up.
+;; The listener reads the current view instead of closing over a pre-reload one.
 (defonce ^:private root-view* (atom nil))
 
-;; The currently-installed `hashchange` listener handle, or nil when none is
-;; installed. A `defonce` atom so its value SURVIVES hot-reload — exactly the
-;; same explicit store/remove discipline `app-root` / `tear-down-app-root!`
-;; use for the React root. We need the *handle*, not just the fn, because
-;; `removeEventListener` deduplicates by reference identity, and a plain
-;; top-level `defn` listener does NOT keep that identity across a CLJS
-;; hot-reload: re-compiling the namespace rebinds the `defn` to a FRESH
-;; function object. Relying on the browser to no-op a repeat `addEventListener`
-;; of "the same fn" is therefore unsound — the post-reload re-`run` would pass
-;; a different reference and STACK a second listener (each later hash change
-;; then running the mount switch twice, churning the React root on `#app`).
-;; Storing the exact handle we installed lets us remove THAT one before
-;; installing the next, so at most one listener is ever active.
+;; Hot reload changes a top-level function's JavaScript identity. Retain the
+;; exact installed handle so the next run can remove it before adding another.
 (defonce ^:private hash-listener* (atom nil))
 
 (defn- app-node []
@@ -136,90 +49,31 @@
       (mount-stories!)
       (mount-app!))))
 
-;; -- Open-in-editor project-root -------------------------------------------
-;;
-;; A consumer declares its tool-relative source subdir (e.g.
-;; `"examples/reagent"` or `"tools/story/testbeds"`) and the host resolves
-;; the on-disk root through the shared cross-platform mechanism and hands it
-;; to `story/configure!`. Centralising it here means a Story-host consumer
-;; can no longer mount the shell while silently forgetting the project-root
-;; config. A blank subdir, or a checkout where neither the build-time
-;; define nor a `?checkout-root=` override is present, resolves to nil and
-;; configures no root (graceful no-op, matching `set-project-root!`).
-
 (defn- configure-story-source-root!
-  "Resolve the open-in-editor source root for the given tool-relative
-  `source-subdir` and hand it to `story/configure!`. `story/configure!`
-  with `:rf.story/project-root` also bridges the root into Xray's slot, so
-  Xray-as-RHS source-coord chips resolve against the same root. A nil /
-  blank `source-subdir` skips configuration entirely; a resolved nil root
-  (no build-time define, no `?checkout-root=` override) is passed through
-  and `set-project-root!` clears it — open-in-editor degrades to a no-op."
+  "Configure Story's project root when the consumer declares a source subdir."
   [source-subdir]
   (when (and (string? source-subdir) (not (str/blank? source-subdir)))
     (story/configure!
      {:rf.story/project-root (testbed-config/resolve-source-root source-subdir)})))
 
-;; -- The hash router -------------------------------------------------------
-
 (defn- mount-router!
-  "Install (remove-then-add) the single `hashchange` listener for
-  `root-view` and render the surface the current hash selects. The
-  remove-then-add discipline keeps exactly one listener active across
-  hot-reload re-`run`s (see the `mount-with-hash-routing!` docstring)."
+  "Replace the hash listener and render the surface selected by the URL."
   [root-view]
   (reset! root-view* root-view)
-  ;; Remove the listener we installed last time (if any) before installing
-  ;; the new one, so a hot-reload re-`run` never stacks a duplicate.
+  ;; The previous function may have a different pre-reload identity.
   (when-let [prev @hash-listener*]
     (.removeEventListener js/window "hashchange" prev))
   (.addEventListener js/window "hashchange" on-hash-change!)
   (reset! hash-listener* on-hash-change!)
   (on-hash-change!))
 
-;; -- The public host entry -------------------------------------------------
-
 (defn mount-with-hash-routing!
-  "Wire the live-app ↔ Story-shell hash router for `root-view` (a 0-arg
-  Reagent component — pass the live-app root view, e.g. `counter-app`).
-  `root-view` is the testbed's FRAME-SCOPED subtree: a frame the consuming
-  testbed has wired (typically via `frame-provider`) that resolves its
-  handlers against a loaded IMAGE (EP-0023 §Views). This host renders it as
-  an opaque component and stays above the frame/image boundary — it neither
-  creates the frame nor loads the image.
+  "Mount `root-view` for normal hashes and the Story shell for `#/stories...`.
 
-  Installs the `hashchange` listener and renders the surface the current
-  URL hash selects: `#/stories…` mounts the Story shell, anything else
-  mounts `root-view` as the live app. Call this at the END of a testbed's
-  `run`, after the testbed has done its own boot specifics (Xray config,
-  `rf/init!`, `:fx-overrides`, seed dispatches, …).
-
-  ## opts
-
-  The optional second arg is a map. Recognised key:
-
-  - `:source-subdir` — the tool-relative source subdir whose
-    classpath-relative Story coords need an on-disk root prepended for
-    'open in editor' (e.g. `\"examples/reagent\"`,
-    `\"tools/story/testbeds\"`). When supplied, the host resolves the root
-    via `re-frame.testbed.config/resolve-source-root` (build-env define or
-    `?checkout-root=` override, cross-platform) and calls `story/configure!`
-    with `:rf.story/project-root` — which also bridges the root into Xray's
-    slot. This is the ONE host-owned contract for Story-host project-root
-    config: declare the subdir and the host wires the rest, so
-    a consumer can no longer mount the shell while silently forgetting it.
-    Omit the opt (or pass a 1-arity call) when the consumer configures
-    `story/configure!` itself.
-
-  Idempotent across hot-reload: the React root is a `defonce` here, and the
-  `hashchange` listener installed on the *previous* `run` is explicitly
-  REMOVED (by the handle stashed in the `defonce` `hash-listener*`) before the
-  new one is installed. We do NOT rely on `addEventListener` to dedupe a
-  repeat add of \"the same fn\": a CLJS hot-reload rebinds the top-level
-  `on-hash-change!` `defn` to a fresh function object, so the post-reload
-  re-`run` would otherwise pass a different reference and STACK a second
-  listener. Remove-then-add keeps exactly one listener active across any
-  number of re-`run`s, however the listener fn's identity churns."
+  Call after the consumer has completed frame/image boot. An optional
+  `:source-subdir` configures the open-in-editor root through
+  `re-frame.testbed.config`; omit it when the consumer owns Story config.
+  Repeated calls replace the listener and are safe across hot reload."
   ([root-view] (mount-with-hash-routing! root-view nil))
   ([root-view {:keys [source-subdir]}]
    (configure-story-source-root! source-subdir)

--- a/tools/testbed-support/test/re_frame/testbed/config_cljs_test.cljs
+++ b/tools/testbed-support/test/re_frame/testbed/config_cljs_test.cljs
@@ -1,97 +1,17 @@
 (ns re-frame.testbed.config-cljs-test
-  "Focused unit tests for `re-frame.testbed.config`.
+  "Cross-platform tests for testbed source-root resolution.
 
-  ## What this pins
-
-  `config.cljs` is a tiny but cross-platform-load-bearing helper: it
-  turns a build-env-derived repo root + a tool-relative testbed subdir
-  into the on-disk checkout-root the Xray / Story testbeds hand to their
-  `configure!` open-in-editor resolvers. The whole point of the file is
-  correct *path joining* across Windows / macOS / Linux clones, so the
-  branches that matter are:
-
-    1. The build-time `checkout-root` goog-define joined with `subdir`
-       (the normal `npm run dev ...` launch).
-    2. Root trailing-slash normalisation (so `/repo/` + `sub` never
-       yields `/repo//sub`).
-    3. Subdir leading-slash normalisation (so callers may pass the
-       subdir with or without a leading slash).
-    4. Blank / nil subdir → the root verbatim.
-    5. Blank `checkout-root` → `nil` (the graceful-no-op contract that
-       `set-project-root!` already encodes for blank input).
-
-  The consuming testbeds compile through `config.cljs` under `npm run
-  test:xray-feature-gate`, but each calls `resolve-source-root` with
-  ONE fixed subdir and no query override, so those checks never assert the
-  normalisation branches above. A behaviour-preserving refactor of the
-  join/strip logic could silently regress cross-platform path
-  construction, so this suite pins each branch directly.
-
-  ## Where this lives
-
-  Like every other tool, `testbed-support` wires a dedicated
-  `tools/testbed-support/test` source-path into the top-level
-  `implementation/shadow-cljs.edn`, so `:node-test` (`npm run test:cljs`,
-  `:ns-regexp \"cljs-test$\"`) discovers this suite there. The runtime
-  helper source path (`tools/testbed-support/src`) carries the helper
-  namespaces only, keeping the same source/test separation the rest of
-  the repo uses. Nothing under `src/` `:require`s this test,
-  so it is on the classpath only for the `:node-test` build that finds it
-  by the `cljs-test$` ns regexp and never reaches a release bundle.
-
-  ## How the `?checkout-root=` override (tier 1) is pinned here
-
-  Tier 1 of the resolution order — the `?checkout-root=<path>` query
-  string winning over everything — is browser-bound: the override reads
-  `js/window.location.search` directly, and there is no `js/window` under
-  `:node-test`, so a naive test would silently degrade to nil and the
-  cross-machine escape hatch could regress unnoticed.
-
-  `config.cljs` isolates the single genuinely browser-bound step —
-  reading `location.search` off the live document — behind the thin
-  `query-param` adapter, and delegates the actual parse/decode/trim/
-  non-blank contract to the PURE `query-param-from-search`, which takes a
-  query string verbatim. That pure parser deliberately splits the query
-  string manually and decodes each component with `js/decodeURIComponent`
-  (NOT `js/URLSearchParams`, whose form-urlencoded semantics would corrupt a
-  literal `+` → space — see `config.cljs` and the preserves-literal-plus
-  test below); both `str/split` and `js/decodeURIComponent` are present in
-  Node too, so that parser runs identically off-browser. That lets us
-  pin, with no `js/window` faking:
-
-    a. the override-parsing contract — param selection, URL-decoding
-       (`%2F` → `/`), trimming, and the blank-falls-through rule — by
-       driving `query-param-from-search` with literal search strings; and
-    b. tier-1 PRECEDENCE — the override winning over a present `checkout-root`,
-       a blank override falling through to the `checkout-root` tier — by
-       `with-redefs`-ing the private `query-param` (the same technique the
-       join/normalisation tests use for `checkout-root`).
-
-  The node degradation (no window → adapter returns nil → checkout-root tier)
-  is still asserted in `resolve-source-root-nil-when-root-blank` below."
+  The pure query parser is exercised directly under Node; precedence tests
+  redefine the browser adapter. This keeps URL decoding, literal-plus
+  preservation, and Windows/POSIX joining covered without a fake DOM."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [clojure.string :as str]
             [re-frame.testbed.config :as config]))
 
-;; ---- shared test helper: composed-editor-path --------------------------
-;;
-;; The whole point of the resolved root is that the open-in-editor resolver
-;; prepends it to a CLASSPATH-RELATIVE source coord (the form-meta `:file`
-;; slot, e.g. `standard_epochs/core.cljs`). The downstream prepend is
-;; `(str root "/" file)`; this helper reproduces that single join so the
-;; slice's unit suite can pin the end-to-end composed path (no `//`, the
-;; tool source-root segment present) without reaching into the Xray
-;; editor-uri resolver. Defined here at the top so every composition test
-;; below — the override form, the Windows form, and the lone-`"/"`-root
-;; edge — can use it.
-
 (defn- composed-editor-path
-  "Mirror the open-in-editor prepend: resolved-root + \"/\" + the
-  classpath-relative source-coord `:file`."
+  "Compose a resolved root with a classpath-relative source file."
   [root file]
   (str root "/" file))
-
-;; ---- private helper: non-blank -----------------------------------------
 
 (deftest non-blank-only-passes-real-strings
   (testing "non-blank returns the string for non-blank strings and nil
@@ -107,8 +27,6 @@
     (is (nil? (#'config/non-blank nil)))
     (is (nil? (#'config/non-blank 42))
         "non-string input is rejected")))
-
-;; ---- private helper: strip-trailing-slash ------------------------------
 
 (deftest strip-trailing-slash-removes-single-trailing-slash
   (testing "a single trailing slash is removed"
@@ -131,13 +49,6 @@
             normal callers never pass `//`)"
     (is (= "/repo/" (#'config/strip-trailing-slash "/repo//")))))
 
-;; ---- private helper: to-forward-slashes --------------------------------
-;;
-;; The canonicalisation step: a Windows path with `\`
-;; separators reduces to the same `/`-separated form a POSIX path already
-;; has, matching the launcher's build-env normalisation and the
-;; separator-agnostic editor-URI composer.
-
 (deftest to-forward-slashes-canonicalises-backslashes
   (testing "every backslash becomes a forward slash; a path that is
             already forward-slashed is unchanged; a literal + survives"
@@ -154,15 +65,12 @@
            (#'config/to-forward-slashes "C:\\code\\app+1"))
         "a literal + is preserved through canonicalisation")))
 
-;; ---- resolve-source-root: blank-root tier (default goog-define) -------
-
 (deftest resolve-source-root-nil-when-root-blank
   (testing "with the default (blank) checkout-root goog-define and no
             browser query override (no js/window under node), every
             tier is absent → nil, so the testbed configures no root and
             open-in-editor degrades to a graceful no-op"
-    ;; `config/checkout-root` defaults to "" under :node-test (no #shadow/env
-    ;; seed in this build), and there is no js/window for the query tier.
+    ;; Node has neither a seeded define nor a browser query override.
     (is (= "" config/checkout-root)
         "node-test build carries the unseeded default define")
     (is (nil? (config/resolve-source-root "tools/xray/testbeds")))
@@ -171,12 +79,7 @@
     (is (nil? (config/resolve-source-root nil))
         "nil subdir with a blank root is still nil")))
 
-;; ---- resolve-source-root: checkout-root tier (join + normalisation) -------
-;;
-;; goog-define expands to a plain `def`, so `with-redefs` can stand in a
-;; concrete root to exercise the join/normalisation branches that the
-;; consuming testbeds never reach (they always pass a fixed subdir with a
-;; root present and no trailing slash).
+;; goog-define expands to a def, so tests can supply checkout roots directly.
 
 (deftest resolve-source-root-joins-root-and-subdir
   (testing "the build-time root is joined to the tool-relative subdir
@@ -233,24 +136,10 @@
     (with-redefs [config/checkout-root "   "]
       (is (nil? (config/resolve-source-root "tools/xray/testbeds"))))))
 
-;; ---- resolve-source-root: the lone POSIX filesystem root "/" ------------
-;;
-;; `strip-trailing-slash` DELIBERATELY preserves a lone `"/"` (the count > 1
-;; guard) so a Unix filesystem root is not destroyed into a blank relative
-;; path. That is the one normalised root that still ends in a separator — so
-;; the join must NOT then prepend a SECOND `/`: an unconditional
-;; `(str normalized-root "/" subdir)` would yield
-;; `//tools/xray/testbeds` for `root = "/"`, breaking the docstring's
-;; single-separator promise. These tests pin the edge through the FULL
-;; `resolve-source-root` surface for BOTH root tiers (build-time define and
-;; `?checkout-root=` override), and confirm the blank/slash-only-subdir
-;; collapse still returns the lone root verbatim.
+;; `/` is the only normalized root that already supplies a join separator.
 
 (deftest resolve-source-root-lone-root-slash-build-time-tier
-  (testing "rf2-fzgcii: a build-time `checkout-root` of the lone POSIX
-            filesystem root `\"/\"` joins a nonblank subdir with EXACTLY
-            ONE separator — `/tools/xray/testbeds`, not the pre-fix
-            `//tools/xray/testbeds`"
+  (testing "a POSIX filesystem root joins a subdir with one separator"
     (with-redefs [config/checkout-root "/"]
       (let [resolved (config/resolve-source-root "tools/xray/testbeds")]
         (is (= "/tools/xray/testbeds" resolved)
@@ -265,9 +154,7 @@
           "a leading slash on the subdir is still normalised away (no ///)"))))
 
 (deftest resolve-source-root-lone-root-slash-override-tier
-  (testing "rf2-fzgcii: the SAME lone-root edge through the
-            `?checkout-root=` override tier — both tiers share one join, so
-            an override of `\"/\"` must also yield a single-separator path"
+  (testing "the override tier handles a POSIX filesystem root identically"
     (with-redefs [config/query-param (fn [param]
                                        (when (= param "checkout-root") "/"))
                   config/checkout-root ""]
@@ -278,9 +165,7 @@
             "no // boundary duplication via the override tier")))))
 
 (deftest resolve-source-root-lone-root-slash-blank-subdir-yields-root
-  (testing "rf2-fzgcii: with the lone `\"/\"` root a blank / nil / slash-only
-            subdir still collapses to the lone root verbatim (the
-            graceful-no-subdir contract is unaffected by the join fix)"
+  (testing "blank subdirs preserve a POSIX filesystem root"
     (with-redefs [config/checkout-root "/"]
       (is (= "/" (config/resolve-source-root ""))
           "blank subdir → lone root preserved")
@@ -292,11 +177,7 @@
           "slash-only subdir normalises to empty → lone root preserved"))))
 
 (deftest resolve-source-root-lone-root-composes-to-intended-on-disk-file
-  (testing "rf2-fzgcii: the lone-root case composes with a representative
-            classpath-relative source coord to a clean on-disk path —
-            `/tools/xray/testbeds/standard_epochs/core.cljs`, the tool
-            source-root segment present and no `//` anywhere (the exact
-            downstream prepend the open-in-editor resolver performs)"
+  (testing "the POSIX root composes with a classpath-relative coordinate"
     (with-redefs [config/checkout-root "/"]
       (let [root     (config/resolve-source-root "tools/xray/testbeds")
             composed (composed-editor-path root "standard_epochs/core.cljs")]
@@ -307,15 +188,7 @@
         (is (not (str/includes? composed "//"))
             "no // boundary duplication in the composed path")))))
 
-;; ---- query-param-from-search: the pure override parser (tier 1) --------
-;;
-;; The override knob's parse/decode/trim/non-blank contract, exercised
-;; off-browser by handing the pure parser literal `location.search`
-;; strings — the same code path the browser adapter runs, no `js/window`
-;; fakery. The parser splits the query string manually and decodes with
-;; `js/decodeURIComponent` so a LITERAL `+` survives verbatim
-;; rather than being form-urlencoded-decoded to a space (the silent
-;; path-corruption seam `js/URLSearchParams` would introduce).
+;; The parser intentionally has URI, not form-urlencoded, plus semantics.
 
 (deftest query-param-from-search-reads-the-named-param
   (testing "the named param's value is returned, trimmed + non-blank"
@@ -340,12 +213,7 @@
         "a Windows drive path with an encoded space round-trips")))
 
 (deftest query-param-from-search-preserves-literal-plus
-  (testing "rf2-xdsat.1: a LITERAL `+` in the override path survives
-            verbatim — it is NOT form-urlencoded-decoded to a space. A
-            checkout at `/home/dev/re-frame2+wip` (or `C:/code/app+1`)
-            must round-trip through `?checkout-root=` unencoded, or every
-            open-in-editor link points at a nonexistent dir (the exact
-            cross-machine-portability failure the override exists to fix)."
+  (testing "literal plus characters are not form-urlencoded to spaces"
     (is (= "/home/dev/re-frame2+wip"
            (#'config/query-param-from-search
             "?checkout-root=/home/dev/re-frame2+wip" "checkout-root"))
@@ -388,20 +256,11 @@
     (is (nil? (#'config/query-param-from-search nil "checkout-root"))
         "nil search string → nil")))
 
-;; ---- resolve-source-root: tier-1 override PRECEDENCE -------------------
-;;
-;; `query-param` is the private browser-only adapter (no window under
-;; node → nil). Redefining it stands in a deterministic override value
-;; so the precedence rule — tier 1 over tier 2 — is asserted without a
-;; browser, mirroring how the join tests redefine `checkout-root`.
+;; Redefine the browser adapter to cover override precedence under Node.
 
 (deftest resolve-source-root-override-wins-over-checkout-root
   (testing "a present `?checkout-root=` override beats the build-time
-            checkout-root tier, AND — like that tier — names a CHECKOUT root
-            to which the caller's subdir is appended (rf2-w4yw9q). Both
-            tiers mean the same thing, so the composed editor URI reaches
-            the tool source-path root the classpath-relative source coords
-            resolve against."
+            checkout-root tier and receives the caller's subdir"
     (with-redefs [config/query-param (fn [param]
                                        (when (= param "checkout-root")
                                          "/override/checkout"))
@@ -414,7 +273,7 @@
           "the appended subdir tracks the caller, the root tracks the override"))))
 
 (deftest resolve-source-root-override-checkout-normalises-like-checkout-root
-  (testing "the override goes through the SAME join as the build-time tier:
+  (testing "the override uses the same join as the build-time tier:
             a trailing slash on the override checkout never doubles the
             separator, and the subdir's leading slash is normalised away"
     (with-redefs [config/query-param (fn [param]
@@ -450,30 +309,10 @@
       (is (nil? (config/resolve-source-root "tools/xray/testbeds"))
           "no override AND no checkout-root → nil (graceful no-op)"))))
 
-;; ---- composed editor path: the documented override form ----------------
-;;
-;; The whole point of the resolved root is that the open-in-editor
-;; resolver prepends it to a CLASSPATH-RELATIVE source coord (the
-;; form-meta `:file` slot, e.g. `standard_epochs/core.cljs`, relative to
-;; the testbed source-path root `<checkout>/tools/xray/testbeds`). These
-;; tests pin that the documented override form — pasting a CHECKOUT root
-;; into `?checkout-root=` — composes with a representative source coord to
-;; the intended on-disk file, the exact cross-machine portability path the
-;; override exists to provide. (The downstream prepend is `(str root "/"
-;; file)`; we reproduce that single join here so the slice's unit suite
-;; pins the end-to-end contract without reaching into the Xray editor-uri
-;; resolver. (`composed-editor-path` itself is defined near the top of this
-;; file so the lone-root and Windows composition tests can use it too.)
+;; Confirm that resolved roots compose with classpath-relative source coords.
 
 (deftest documented-override-composes-to-intended-on-disk-file
-  (testing "rf2-w4yw9q: pasting a CHECKOUT root into `?checkout-root=` (the
-            documented `?checkout-root=/home/dev/re-frame2+wip` form) and
-            resolving for the xray testbed subdir composes with a
-            representative source coord to the real on-disk file —
-            `<checkout>/tools/xray/testbeds/standard_epochs/core.cljs` —
-            NOT the tool-source-root-missing
-            `<checkout>/standard_epochs/core.cljs` that the pre-fix
-            verbatim semantics produced"
+  (testing "a checkout override composes to a file beneath the tool source root"
     (with-redefs [config/query-param (fn [param]
                                        (when (= param "checkout-root")
                                          "/home/dev/re-frame2+wip"))
@@ -486,11 +325,7 @@
             "the composed editor path reaches the actual on-disk source file")))))
 
 (deftest documented-override-and-build-time-tier-compose-identically
-  (testing "rf2-w4yw9q: the override and the build-time `checkout-root` tier
-            produce the SAME composed editor path for the same checkout —
-            the contract is one meaning (a checkout root) across both
-            tiers, so a reader's `?checkout-root=` override behaves exactly
-            like a local `npm run dev` launch from that checkout"
+  (testing "override and build-time tiers compose the same checkout path"
     (let [coord "standard_epochs/core.cljs"
           subdir "tools/xray/testbeds"
           via-override (with-redefs [config/query-param
@@ -509,15 +344,7 @@
       (is (= "/home/dev/re-frame2+wip/tools/xray/testbeds/standard_epochs/core.cljs"
              via-override)))))
 
-;; ---- Windows override normalisation ------------------------------------
-;;
-;; A Windows reader pasting `?checkout-root=C:\Users\me\code\re-frame2\`
-;; (raw `\` separators, with or without a trailing `\`) — or its
-;; %5C-encoded transport form — must resolve to a CLEAN, single-separator,
-;; forward-slash path, NOT the `C:\...\/tools/xray/testbeds` boundary
-;; duplication that would rely on downstream tolerant path normalisation. Both
-;; root tiers go through the SAME canonicalising join, so this holds for
-;; the build-time `checkout-root` tier as well as the query override.
+;; Raw and percent-encoded Windows roots share the same normalized join.
 
 (deftest query-param-from-search-decodes-encoded-backslash
   (testing "a %5C-encoded backslash in the override transport form decodes
@@ -563,8 +390,7 @@
     (with-redefs [config/query-param
                   (fn [param]
                     (when (= param "checkout-root")
-                      ;; mirrors the decode-component output for
-                      ;; ?checkout-root=C%3A%5CUsers%5Cme%5Ccode%5Cre-frame2%5C
+                      ;; The decoded form of a percent-encoded Windows root.
                       (#'config/query-param-from-search
                        "?checkout-root=C%3A%5CUsers%5Cme%5Ccode%5Cre-frame2%5C"
                        "checkout-root")))
@@ -583,12 +409,7 @@
              (config/resolve-source-root "tools/story/testbeds"))))))
 
 (deftest windows-override-composes-to-intended-on-disk-file
-  (testing "rf2-d01s6s + rf2-w4yw9q: a Windows `?checkout-root=` override
-            composes with a representative classpath-relative source coord
-            to the intended on-disk file with the tool-source-root segment
-            present and exactly one separator everywhere — proving no
-            missing `tools/<tool>/testbeds` segment and no `\\/` / `//`
-            duplication in the path Xray/Story actually prefix"
+  (testing "a Windows override composes beneath the tool source root"
     (with-redefs [config/query-param (fn [param]
                                        (when (= param "checkout-root")
                                          "C:\\Users\\me\\code\\re-frame2\\"))
@@ -609,7 +430,7 @@
 (deftest windows-override-preserves-literal-plus-in-checkout
   (testing "a Windows checkout with a `+` in the path (e.g.
             `C:\\code\\re-frame2+wip`) round-trips: `\\` → `/` but the
-            literal `+` is preserved (the existing rf2-xdsat.1 semantics)"
+            literal `+` is preserved"
     (with-redefs [config/query-param (fn [param]
                                        (when (= param "checkout-root")
                                          "C:\\code\\re-frame2+wip"))
@@ -618,11 +439,7 @@
              (config/resolve-source-root "tools/xray/testbeds"))
           "+ survives canonicalisation; \\ → /"))))
 
-;; ---- public-surface stability sentinel ---------------------------------
-
 (deftest public-config-surface-stable
-  (testing "the public surface rf2-ynjts.23 must keep stable is intact:
-            the `re-frame.testbed.config` ns exposes `resolve-source-root`
-            (a fn) and the `checkout-root` goog-define (a string)"
+  (testing "the namespace exposes the resolver and checkout-root define"
     (is (fn? config/resolve-source-root))
     (is (string? config/checkout-root))))

--- a/tools/testbed-support/test/re_frame/testbed/open_in_editor_server_test.clj
+++ b/tools/testbed-support/test/re_frame/testbed/open_in_editor_server_test.clj
@@ -1,20 +1,9 @@
 (ns re-frame.testbed.open-in-editor-server-test
-  "JVM regression tests for the dev-only open-in-editor endpoint's
-  `:file` resolution path.
+  "JVM tests for the dev-only open-in-editor endpoint.
 
-  The endpoint is a JVM-only `.clj` (it runs on the shadow-cljs SERVER
-  JVM), so it cannot be exercised by the node CLJS suites — this is its
-  `clojure -M:test` gate.
-
-  The classpath stage of `resolve-file` — context-class-loader lookup,
-  `file:` URL decode, and Windows drive-letter normalization — is delegated
-  to `re-frame.source-coords/absolutise-file`, the canonical resolver that
-  owns and separately tests that decode contract (literal-`+` preservation,
-  `%20`/`%2B` escapes, Windows drive shape — see `source_coords_test.clj`).
-  These tests therefore do NOT re-unit-test the decoder; they assert the
-  DELEGATION (resolve-file's classpath output IS core's) plus the
-  endpoint-owned policy the runtime twin adds on top: the cwd fallback,
-  the raw-path fall-through, and the nil/blank/absolute pass-through."
+  Core owns classpath URL decoding. This suite verifies that the endpoint
+  delegates there, adds cwd fallback, guards the launch boundary, and emits
+  valid responses."
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.java.io :as io]
             [clojure.string :as str]
@@ -23,26 +12,14 @@
   (:import [java.net URL URLClassLoader]
            [java.io File]))
 
-;; ---- resolve-file: the classpath stage delegates to core (rf2-hf0vqa) -----
-;;
-;; `resolve-file` no longer re-implements the context-class-loader
-;; `getResource` + `file:`-URL decode + Windows-drive normalization dance —
-;; it delegates that classpath stage to `re-frame.source-coords/absolutise-file`,
-;; which owns it canonically (rf2-wvsxg / rf2-st3ax4) and carries its own decode
-;; unit tests. This single integration test proves the delegation end-to-end:
-;; over a real `+`-bearing classpath root (the load-bearing regression — a
-;; literal `+` must survive, never form-decode to a space), `resolve-file`
-;; returns EXACTLY what `absolutise-file` returns, so the decode contract is
-;; sourced from core, not duplicated here.
+;; A `+`-bearing classpath root confirms that delegation preserves URI semantics.
 
 (deftest resolve-file-delegates-classpath-stage-to-core
   (testing "resolve-file's classpath stage IS core's absolutise-file: a
             classpath-relative `:file` resolves to exactly the absolute
             on-disk path core produces — verbatim, `+` preserved, never a
             space-corrupted sibling"
-    ;; Build a throwaway classpath root dir whose name carries a `+`, drop
-    ;; a fake source file under it, push a class-loader rooted there onto
-    ;; the context, and confirm resolve-file's result equals absolutise-file's.
+    ;; Install a throwaway source root on the thread context classloader.
     (let [tmp       (File. (System/getProperty "java.io.tmpdir")
                            (str "oies+test-" (System/nanoTime)))
           rel-path  "fake_ns/core.cljs"
@@ -59,7 +36,7 @@
             (let [resolved (oies/resolve-file rel-path)]
               (is (some? resolved) "the classpath resource resolved")
               (is (= (#'source-coords/absolutise-file rel-path) resolved)
-                  "resolve-file returns EXACTLY core's absolutise-file result —
+                  "resolve-file returns core's absolutise-file result;
                    the classpath stage is delegated, not re-implemented")
               (is (.contains ^String resolved "+")
                   "the literal + in the classpath root survived (core owns the
@@ -71,12 +48,10 @@
             (finally
               (.setContextClassLoader (Thread/currentThread) prev))))
         (finally
-          ;; Best-effort cleanup of the throwaway tree.
+          ;; Best-effort cleanup.
           (when (.exists src-file) (.delete src-file))
           (.delete (io/file tmp "fake_ns"))
           (.delete tmp))))))
-
-;; ---- absolute / blank pass-through contract ------------------------------
 
 (deftest resolve-file-passes-absolute-and-blank-through
   (testing "an already-absolute path is returned unchanged (incl. a + in it)"
@@ -87,21 +62,10 @@
     (is (nil? (oies/resolve-file "")))
     (is (nil? (oies/resolve-file "   ")))))
 
-;; ---- security: the loopback / origin / method guard ----------------------
-;;
-;; The endpoint launches the editor on a local file path, so it must NOT be
-;; drivable by a drive-by GET or a cross-origin POST from a remote page. The
-;; guard pins it to a POST addressed to a loopback Host with (when present)
-;; a loopback Origin. These tests redirect `launch!` to a recording stub so
-;; no real editor is spawned, and assert: the one valid local POST reaches
-;; the launch path and answers 200, while every unauthenticated / wrong-
-;; method / cross-origin / non-loopback variant is rejected (403/405) BEFORE
-;; `launch!` is ever called.
+;; Launch is stubbed while the method, Host, Origin, and CORS guards are tested.
 
 (defn ^:private req
-  "Build a minimal Ring request map for the endpoint. An explicit nil `host`
-  / `origin` omits that header (an explicit nil is respected over the :or
-  default, which only fills an ABSENT key)."
+  "Build a minimal endpoint request; nil host/origin values omit the header."
   [{:keys [method host origin file]
     :or   {method :post host "localhost:8031"}}]
   {:uri            oies/endpoint-path
@@ -112,8 +76,7 @@
                      origin (assoc "origin" origin))})
 
 (defmacro ^:private with-launch-spy
-  "Run `body` with `launch!` redirected to a stub that records each call in
-  `calls` (an atom holding a vector) and returns `{:ok true}`."
+  "Record launch calls without opening an editor."
   [calls & body]
   `(with-redefs [oies/launch! (fn [& args#]
                                 (swap! ~calls conj (vec args#))
@@ -159,7 +122,7 @@
                            :origin "https://evil.example"
                            :file   "/etc/passwd"}))]
           (is (= 403 (:status resp)) "cross-origin POST is forbidden")
-          (is (zero? (count @calls)) "launch! was NEVER called")
+          (is (zero? (count @calls)) "launch! was not called")
           (is (not= "*" (get-in resp [:headers "access-control-allow-origin"]))
               "no wildcard CORS — the remote origin is not reflected"))))))
 
@@ -195,7 +158,7 @@
                            :origin nil
                            :file   "/etc/passwd"}))]
           (is (= 405 (:status resp)) "GET is method-not-allowed")
-          (is (zero? (count @calls)) "launch! was NEVER called"))))))
+          (is (zero? (count @calls)) "launch! was not called"))))))
 
 (deftest guard-options-preflight-reflects-loopback-origin
   (testing "an OPTIONS preflight from a loopback origin reflects that origin
@@ -214,23 +177,10 @@
               "GET is no longer an allowed method")
           (is (zero? (count @calls))))))))
 
-;; ---- security negatives: the load-bearing rejection branches (rf2-jwdi4r) --
-;;
-;; The two adversarial paths the existing guard suite did NOT drive
-;; end-to-end. Both are safety branches — a false negative here re-opens the
-;; drive-by editor-launch vector — so each asserts the request is rejected
-;; AND `launch!` is never reached.
+;; Safety negatives assert both the response and absence of a launch call.
 
 (deftest guard-rejects-opaque-null-origin-post
-  (testing "rf2-jwdi4r: a POST carrying the opaque `Origin: null` (a
-            sandboxed iframe / `file:` page drive-by — the very context
-            `origin-host` documents as yielding nil) is rejected 403 and
-            NEVER reaches launch!. The Host is loopback, so this isolates the
-            ORIGIN gate: `origin-host` maps \"null\" → nil, which is not a
-            loopback origin, so `local-request?` fails and the launch path is
-            never touched. (origin-host-extracts-and-rejects-opaque only
-            proves the \"null\" → nil unit step; this proves the POST is
-            actually refused end-to-end.)"
+  (testing "an opaque Origin is rejected before launch"
     (let [calls (atom [])]
       (with-launch-spy calls
         (let [resp (oies/handle
@@ -240,20 +190,13 @@
                            :file   "/etc/passwd"}))]
           (is (= 403 (:status resp)) "opaque-origin POST is forbidden")
           (is (re-find #"\"error\":\"forbidden\"" (:body resp)))
-          (is (zero? (count @calls)) "launch! was NEVER called")
+          (is (zero? (count @calls)) "launch! was not called")
           (is (= "null" (get-in resp [:headers "access-control-allow-origin"]))
               "CORS denies via `null` — never reflects the opaque origin, never `*`")
           (is (not= "*" (get-in resp [:headers "access-control-allow-origin"]))))))))
 
 (deftest guard-options-preflight-denies-remote-origin
-  (testing "rf2-jwdi4r: an OPTIONS preflight is answered BEFORE the
-            `local-request?` guard (it is the first `cond` branch in
-            `handle`), so `allow-origin` is the SOLE gate on preflight CORS.
-            A preflight from a REMOTE origin must therefore get
-            `access-control-allow-origin: null` (deny) — never `*` and never
-            the reflected remote origin — so the browser blocks the follow-up
-            cross-origin POST. launch! is never touched. (The existing
-            preflight test only covers the loopback-origin ALLOW case.)"
+  (testing "a remote preflight receives no usable CORS origin"
     (let [calls (atom [])]
       (with-launch-spy calls
         (let [resp (oies/handle
@@ -268,11 +211,8 @@
           (is (not= "https://evil.example"
                     (get-in resp [:headers "access-control-allow-origin"]))
               "the remote origin is never reflected back")
-          (is (zero? (count @calls)) "launch! was NEVER called")))))
-  (testing "rf2-jwdi4r: an OPTIONS preflight from a non-loopback Host with no
-            Origin likewise denies (ao=null) — the allow-origin gate never
-            emits a usable CORS header for anything but a validated loopback
-            origin"
+          (is (zero? (count @calls)) "launch! was not called")))))
+  (testing "a preflight without a validated loopback Origin is denied"
     (let [calls (atom [])]
       (with-launch-spy calls
         (let [resp (oies/handle
@@ -289,14 +229,7 @@
                             :request-method :post
                             :headers {"host" "localhost:8031"}})))))
 
-;; ---- malformed query string: clean 400, never an uncaught throw ----------
-;;
-;; `parse-query` URL-decodes every key/value; a malformed percent-escape (a
-;; lone `%`, or `%` not followed by two hex digits) makes `decode-component`'s
-;; `URI/create` throw `IllegalArgumentException`. Every other error path on this endpoint
-;; (missing file, forbidden, method-not-allowed, launch failure) answers a
-;; clean JSON response — a malformed query must too, rather than propagating
-;; uncaught into the shadow-cljs `:dev-http` Ring plumbing (rf2-bhejni).
+;; URI decoding failures must become JSON 400 responses at the Ring boundary.
 
 (deftest malformed-query-returns-clean-400
   (testing "a lone `%` in the query string (an incomplete percent-escape)
@@ -325,20 +258,10 @@
           (is (re-find #"\"error\":\"malformed-query\"" (:body resp)))
           (is (zero? (count @calls))))))))
 
-;; ---- parse-query: literal `+` survives (rf2-62hu6k) ----------------------
-;;
-;; `parse-query` decodes with decodeURIComponent semantics (via
-;; `decode-component`'s `URI` fragment decode), NOT `URLDecoder/decode`'s
-;; application/x-www-form-urlencoded semantics that map a literal `+` to a
-;; space. This is the SAME contract `re-frame.source-coords/absolutise-file`
-;; upholds for `file:` URLs (the classpath resolver `resolve-file` delegates
-;; to) and `config.cljs`'s `js/decodeURIComponent` upholds on the client — so a
-;; checkout path carrying a literal `+` (`C:/code/re-frame2+wip`) survives
-;; verbatim through the query rather than being corrupted to `re-frame2 wip`.
+;; Query parsing uses URI semantics so a literal `+` in a path stays intact.
 
 (deftest parse-query-preserves-literal-plus
-  (testing "a literal `+` in a value is preserved, NOT form-decoded to a space
-            (the URLDecoder bug — rf2-62hu6k)"
+  (testing "a literal `+` is not form-decoded to a space"
     (is (= "C:/code/re-frame2+wip/core.cljs"
            (get (#'oies/parse-query
                  "file=C:/code/re-frame2+wip/core.cljs&line=10")
@@ -355,7 +278,7 @@
 
 (deftest endpoint-preserves-literal-plus-through-to-launch
   (testing "a POST whose `file` carries a literal `+` hands launch! the path
-            with the `+` intact (never corrupted to a space — rf2-62hu6k)"
+            with the `+` intact"
     (let [calls (atom [])]
       (with-launch-spy calls
         (let [resp (oies/handle
@@ -369,8 +292,6 @@
               "the literal + survived parse-query into the abs-path launch! got")
           (is (not (str/includes? (first (first @calls)) "re-frame2 wip"))
               "the + was NOT form-decoded to a space"))))))
-
-;; ---- header / origin parsing helpers -------------------------------------
 
 (deftest loopback-host?-classifies-correctly
   (testing "loopback hosts (with/without port, IPv4, IPv6, case)"
@@ -387,7 +308,7 @@
     (is (not (#'oies/loopback-host? "app.evil.example:8031")))
     (is (not (#'oies/loopback-host? "10.0.0.5")))
     (is (not (#'oies/loopback-host? "0.0.0.0")))
-    ;; not in 127.0.0.0/8 despite the `127` prefix textually
+    ;; A textual 127 prefix is not an IPv4 loopback address.
     (is (not (#'oies/loopback-host? "127malicious.example")))
     (is (not (#'oies/loopback-host? nil)))
     (is (not (#'oies/loopback-host? "")))))
@@ -401,23 +322,10 @@
     (is (nil? (#'oies/origin-host nil)))
     (is (nil? (#'oies/origin-host "")))))
 
-;; ---- json-resp: control-char escaping (rf2-2loouf finding 5) -------------
-;;
-;; The hand-rolled encoder previously escaped only `\` and `"`. Both the
-;; 200 response (echoes the url-decoded `:file` verbatim) and the 422
-;; response (echoes trimmed `node` stderr, which can be a multi-line stack
-;; trace) can carry a raw control character — a `file=...%0A...` request or
-;; a multi-line launch-failure message. A real JSON reader (`clojure.edn`
-;; cannot parse JSON, so this test hand-rolls a minimal JSON-string reader
-;; over the escaped body) must round-trip the exact original value.
+;; File values and launch stderr may contain controls, so verify JSON round trips.
 
 (defn ^:private read-json-string-literal
-  "Minimal JSON-string-literal reader: given `s` positioned so `s`'s first
-  char is the opening `\"`, decode the escaped literal and return
-  `[decoded-value chars-consumed]`. Only used to independently verify
-  `json-resp`'s output is valid JSON (no reliance on the encoder under
-  test, or on a JSON library dependency this JVM-only tool artefact does
-  not otherwise carry)."
+  "Decode one JSON string literal without depending on the encoder under test."
   [^String s]
   (let [n (.length s)]
     (loop [i (inc 0) sb (StringBuilder.)]
@@ -440,11 +348,7 @@
           :else (recur (inc i) (.append sb c)))))))
 
 (defn ^:private json-body->file-value
-  "Pull the decoded `\"file\"` string value out of a `json-resp` body by
-  locating the `\"file\":\"` key and decoding the quoted literal that
-  follows with `read-json-string-literal`. Throws if the body around it is
-  not well-formed JSON (a bare unescaped control char inside the literal
-  makes this parse fail exactly as a real JSON.parse would)."
+  "Decode a named string value from the small JSON response shape."
   [^String body key-prefix]
   (let [idx (.indexOf body ^String key-prefix)]
     (when (neg? idx)
@@ -493,23 +397,12 @@
     (is (= "\"plain/path.cljs\""
            (str "\"" (#'oies/escape-json-string "plain/path.cljs") "\"")))))
 
-;; ---- build-file-spec: column-only normalization (rf2-bj02en) --------------
-;;
-;; `build-file-spec` is the pure argv-token builder `launch!` delegates to
-;; before shelling out to `node`. History: `column` was once nested inside
-;; `(when line ...)`, which silently dropped a column-without-line request
-;; (rf2-2loouf finding 6). The independent `cond->` fix stopped the drop but
-;; encoded a column-only request as `path:<column>` — and `launch-editor`'s
-;; `file:line:column` grammar reads that lone number as the LINE, so the
-;; column was misread as a line jump (rf2-bj02en). `build-file-spec` now
-;; NORMALIZES a column-only request to line 1, emitting `path:1:<column>` —
-;; matching the `editor://` URI fallback (`editor-uri/coord-line` defaults a
-;; missing line to 1) so both open paths land on the same file:line:column.
+;; launch-editor parses the first numeric suffix as a line, so column-only
+;; coordinates must be encoded as `path:1:column`.
 
 (deftest build-file-spec-normalizes-column-only-to-line-1
   (testing "column with no line is normalized to line 1, NOT encoded as a
-            bare `path:<column>` that launch-editor would misread as a line
-            (the rf2-bj02en regression)"
+            bare `path:<column>` that launch-editor would misread as a line"
     (is (= "/abs/core.cljs:1:7" (#'oies/build-file-spec "/abs/core.cljs" nil 7))
         "column-only → line 1 + column, matching the editor:// URI fallback"))
   (testing "line with no column is unaffected (baseline — no phantom column)"
@@ -540,19 +433,9 @@
             (is (nil? line) "no line param was sent")
             (is (= 7 column) "column parsed through, not dropped upstream")
             (is (= (str abs-path ":1:7") (#'oies/build-file-spec abs-path line column))
-                "build-file-spec normalizes column-only to line 1 —
-                 the rf2-bj02en regression, now fixed")))))))
+                "build-file-spec normalizes column-only to line 1")))))))
 
-;; ---- missing-file guard: no false 200 (rf2-i877cj) -----------------------
-;;
-;; `launch-editor` SILENTLY no-ops on a nonexistent file — its internal
-;; `if (!fs.existsSync(fileName)) return` returns WITHOUT calling the error
-;; callback, so the node process exits 0 and `launch!` would report a false
-;; `{:ok true}`, making the endpoint answer HTTP 200 for an unresolved /
-;; nonexistent `:file`. That suppresses the client's `editor://` fallback
-;; (the client only falls back on a non-2xx). `launch!` now checks the
-;; resolved path's existence BEFORE spawning node and short-circuits to
-;; `{:ok false :message "file-not-found"}`, which the endpoint answers 422.
+;; launch-editor silently ignores missing files, so the JVM must reject them.
 
 (deftest file-exists?-detects-real-and-missing-paths
   (testing "an existing file is detected"
@@ -599,16 +482,10 @@
       (is (re-find #"\"error\":\"file-not-found\"" (:body resp))
           "the client-visible error names the missing file, not launch-failed"))))
 
-;; ---- missing-file 400: the blank/absent `file` param branch (rf2-bnv3cu) --
-;;
-;; `handle` returns 400 `{:ok false :error "missing-file"}` when the `file`
-;; query param is blank or absent (before any resolution / launch). The
-;; suite covered malformed-query 400 and file-not-found 422 but never this
-;; distinct earlier branch.
+;; A missing query parameter is a 400; a resolved but absent file is a 422.
 
 (deftest endpoint-missing-file-param-returns-400
-  (testing "rf2-bnv3cu: a valid local POST with a blank / absent `file`
-            param answers a clean 400 missing-file and never reaches launch!"
+  (testing "a blank or absent file parameter returns 400 before launch"
     (let [calls (atom [])]
       (with-launch-spy calls
         (testing "no `file` param in the query string"
@@ -639,17 +516,10 @@
         (is (zero? (count @calls))
             "launch! was never called on any missing-file path")))))
 
-;; ---- editor hint: keyword -> launch-editor command (rf2-bnv3cu) -----------
-;;
-;; `editor-hint` + `editor-command-by-keyword` are PUBLIC and were 100%
-;; untested. The `editor` query param maps through `editor-hint` to
-;; `launch!`'s 4th-arg command hint; an untested map means a regression
-;; could silently drop a configured editor (`:rf.xray/editor :cursor`) back
-;; to launch-editor's auto-detect.
+;; The query vocabulary maps to launch-editor binary names.
 
 (deftest editor-hint-maps-keyword-to-launch-command
-  (testing "rf2-bnv3cu: a known editor keyword (bare string) resolves to
-            launch-editor's launch command"
+  (testing "a known editor keyword resolves to its launch command"
     (is (= "code"          (oies/editor-hint "vscode")))
     (is (= "code-insiders" (oies/editor-hint "vscode-insiders")))
     (is (= "cursor"        (oies/editor-hint "cursor")))
@@ -669,9 +539,7 @@
     (is (nil? (oies/editor-hint 42)) "a non-string is rejected")))
 
 (deftest editor-command-by-keyword-is-the-launch-command-vocabulary
-  (testing "rf2-bnv3cu: the public keyword→command map maps the open-in-editor
-            keyword vocabulary to launch-editor bin names (a public-surface
-            sentinel — a new editor is a deliberate, reviewed addition)"
+  (testing "the public map defines the supported launch-command vocabulary"
     (is (= {"vscode"          "code"
             "vscode-insiders" "code-insiders"
             "cursor"          "cursor"
@@ -681,9 +549,7 @@
            oies/editor-command-by-keyword))))
 
 (deftest endpoint-passes-editor-hint-through-to-launch
-  (testing "rf2-bnv3cu: the `editor` query param maps through editor-hint to
-            launch!'s 4th-arg command hint — a request for a configured editor
-            reaches launch! with the resolved command, not auto-detect"
+  (testing "the editor query value reaches launch! as a command hint"
     (let [calls (atom [])]
       (with-launch-spy calls
         (let [resp (oies/handle
@@ -718,17 +584,10 @@
         (is (nil? (nth (first @calls) 3))
             "no editor param → nil hint")))))
 
-;; ---- escape-json-string: backslash + doublequote (rf2-bnv3cu) -------------
-;;
-;; The control-char round-trip test covered \n/\t/\r + C0 + plain ASCII but
-;; never a value carrying a literal `\` or `"`. On Windows the resolved
-;; abs-path echoed in the 200 `:file` field is `C:\Users\...`, so the
-;; backslash rule is Windows-load-bearing: unescaped, the JSON body is
-;; invalid despite the `application/json` header.
+;; Windows paths exercise the JSON backslash and quote rules.
 
 (deftest escape-json-string-escapes-backslash-and-doublequote
-  (testing "rf2-bnv3cu: a lone backslash and a double-quote are escaped
-            directly"
+  (testing "backslashes and double-quotes are escaped"
     (is (= "a\\\\b" (#'oies/escape-json-string "a\\b"))
         "one backslash → two")
     (is (= "say \\\"hi\\\"" (#'oies/escape-json-string "say \"hi\""))
@@ -738,12 +597,7 @@
         "a Windows abs-path's backslashes are all doubled")))
 
 (deftest json-resp-escapes-windows-backslash-path
-  (testing "rf2-bnv3cu: a 200 response whose resolved `:file` is a Windows
-            abs-path (literal `\\` separators) plus a stray `\"` is escaped so
-            the `application/json` body is valid and round-trips to the exact
-            path through a real JSON-string decode — the Windows-relevant path
-            the prior backslash/quote-only encoder would still have handled,
-            but never had a regression test"
+  (testing "a Windows path with a quote round-trips through the JSON response"
     (let [calls (atom [])
           file  "C:\\Users\\me\\code\\re-frame2\\src\\a\"b.cljs"]
       (with-launch-spy calls
@@ -761,19 +615,10 @@
             (is (= file (json-body->file-value (:body resp) "\"file\":\""))
                 "the escaped Windows path round-trips to the exact original")))))))
 
-;; ---- resolve-file: the cwd-relative branch (rf2-bnv3cu) -------------------
-;;
-;; resolve-file's branch 2 (relative to the dev process cwd) is the
-;; JAR / off-classpath case Option B exists to close — a relative coord that
-;; getResource cannot reach on the classpath still resolves against the dev
-;; JVM's working directory. Branch 1 (classpath) is covered by
-;; resolve-file-resolves-classpath-path-with-plus; this pins branch 2's
-;; SUCCESS path directly.
+;; Off-classpath relative coordinates fall back to the dev process cwd.
 
 (deftest resolve-file-resolves-cwd-relative-off-classpath
-  (testing "rf2-bnv3cu: a relative `:file` that is NOT on the classpath
-            resolves against the working directory (`user.dir`) to its real
-            on-disk absolute path — the off-classpath branch"
+  (testing "an off-classpath relative file resolves against user.dir"
     (let [tmp      (File. (System/getProperty "java.io.tmpdir")
                           (str "oies-cwd-" (System/nanoTime)))
           sub      (str "off_classpath_" (System/nanoTime))
@@ -783,8 +628,7 @@
       (try
         (io/make-parents src-file)
         (spit src-file ";; fixture\n")
-        ;; Point the JVM working dir at the throwaway tree; the explicit
-        ;; cwd branch reads `user.dir` live, so resolution finds the fixture.
+        ;; resolve-file reads user.dir at request time.
         (System/setProperty "user.dir" (.getAbsolutePath tmp))
         (let [resolved (oies/resolve-file rel-path)]
           (is (some? resolved)

--- a/tools/testbed-support/test/re_frame/testbed/story_host_cljs_test.cljs
+++ b/tools/testbed-support/test/re_frame/testbed/story_host_cljs_test.cljs
@@ -1,66 +1,19 @@
 (ns re-frame.testbed.story-host-cljs-test
-  "Focused unit tests for `re-frame.testbed.story-host`.
+  "Node tests for Story-host routing and source-root configuration.
 
-  ## What this pins
-
-  `mount-with-hash-routing!` is the shared live-app ↔ Story-shell host:
-  every Story showcase testbed calls it LAST in its `run` to install one
-  `hashchange` listener that swaps the surface mounted on `#app`. The whole
-  point of the helper is to be HOT-RELOAD IDEMPOTENT — a testbed dev edits a
-  file, shadow recompiles + re-runs `run`, and `mount-with-hash-routing!`
-  fires again. It must NOT accumulate a second listener on that second (and
-  third, …) call, or each later hash change runs the mount switch N times,
-  repeatedly tearing down/remounting the Story shell on the same `#app` node
-  (lost shell state, leaked shell listeners/polls, React `createRoot` churn).
-
-  ## The unsound pattern these tests lock out
-
-  Installing the top-level `on-hash-change!` `defn` as the listener and
-  relying on the browser to no-op a *repeat* `addEventListener` of the same
-  fn reference is unsound: a CLJS hot-reload recompiles the namespace,
-  rebinding the `on-hash-change!` `defn` to a FRESH function object. So the
-  post-reload re-`run` passes a DIFFERENT reference — the browser does not
-  dedupe, and a second listener stacks, making the \"idempotent across
-  hot-reload\" contract false for every Story showcase that consumes the
-  helper.
-
-  The host instead mirrors the adjacent React-root store/remove discipline
-  (`app-root` / `tear-down-app-root!`): the installed listener handle is
-  stashed in the `defonce` `hash-listener*` atom and explicitly REMOVED
-  before the next one is installed.
-
-  ## How the hot-reload identity churn is simulated off-browser
-
-  The genuine hazard is `on-hash-change!`'s identity changing across a
-  recompile. We reproduce exactly that by `with-redefs`-ing the private
-  `story-host/on-hash-change!` to a fresh fn for the second `run` — the
-  same technique `config_cljs_test.cljs` uses to redefine private vars. A
-  controllable fake `js/window` records every `addEventListener` /
-  `removeEventListener` call into a real registry, so we can assert the
-  number of ACTIVE `hashchange` listeners directly. `mount-app!` /
-  `mount-stories!` are redefined to count-only no-ops so the test never
-  touches React-DOM (there is no `#app` node, and no `js/document`, under
-  `:node-test`)."
+  A fake window records listener identity while mount functions are stubbed.
+  Rebinding `on-hash-change!` simulates CLJS hot reload and verifies that the
+  previous listener is removed rather than stacked."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [clojure.string :as str]
             [re-frame.story.config :as story-config]
             [re-frame.testbed.config :as testbed-config]
             [re-frame.testbed.story-host :as host]))
 
-;; ---------------------------------------------------------------------------
-;; A controllable fake `js/window`.
-;;
-;; Holds a `hashchange`-listener registry (a JS Set of installed fns) plus a
-;; mutable `location.hash`. `addEventListener` / `removeEventListener` mutate
-;; that set with reference identity — the exact semantics the browser uses and
-;; the exact thing the remove-then-add discipline depends on. We count ACTIVE
-;; listeners by the set's size, so a stacked duplicate shows up as size 2.
-;; ---------------------------------------------------------------------------
+;; A JS Set gives the fake window browser-like listener identity semantics.
 
 (defn- make-fake-window
-  "Build a fake window whose add/removeEventListener maintain a real
-  reference-identity registry. Returns a map of the window object plus a
-  0-arg `hashchange-count` reader for the test to assert on."
+  "Build a fake window with an observable hashchange listener registry."
   ([] (make-fake-window "#/"))
   ([initial-hash]
    (let [registry (js/Set.)
@@ -78,14 +31,8 @@
       :registry        registry
       :hashchange-count (fn [] (.-size registry))})))
 
-;; Install / clear the fake on `goog.global` directly (the Closure global
-;; object `js/window` references resolve against). We write
-;; `goog.global.window` rather than bare `js/window`: under shadow's
-;; `:node-test` target a bare-`window` `set!` is a strict-mode write to an
-;; undeclared global and throws `ReferenceError`, whereas `goog.global` is a
-;; real object we may add a property to — the same `goog.global` slot the
-;; xray keybinding tests stub `js/document` through. Reads of
-;; `js/window` inside `story-host` then see the fake.
+;; js/window resolves through Closure's global object under the Node target;
+;; assigning a bare window name would violate strict mode.
 (def ^:private real-window (when (exists? js/window) js/window))
 
 (defn- install-window! [w]
@@ -97,9 +44,7 @@
     (js-delete js/goog.global "window")))
 
 (defn- reset-host-handles!
-  "Reset the helper's `defonce` private atoms to a clean baseline. They are
-  `defonce` (they survive across calls by design), so a test that wants a
-  pristine starting point must reset them explicitly."
+  "Reset host state that intentionally survives reloads."
   []
   (reset! @#'host/hash-listener* nil)
   (reset! @#'host/root-view* nil))
@@ -107,22 +52,16 @@
 (use-fixtures :each
   {:before (fn []
              (reset-host-handles!)
-             ;; The project-root tests below configure Story's project-root
-             ;; through the host; clear it before/after so neither leaks.
+             ;; Source-root tests mutate Story's global config.
              (story-config/set-project-root! nil))
    :after  (fn []
-             ;; Remove the fake so it never leaks into another namespace's
-             ;; tests; restore the node-test baseline (no `window`).
+             ;; Restore the Node baseline for subsequent namespaces.
              (clear-window!)
              (reset-host-handles!)
              (story-config/set-project-root! nil))})
 
-;; A trivial 0-arg root view stand-in (never rendered — mount-* are no-ops).
+;; Mount functions are stubbed, so this view is never rendered.
 (defn- dummy-view [] [:div "dummy"])
-
-;; ---------------------------------------------------------------------------
-;; Tests
-;; ---------------------------------------------------------------------------
 
 (deftest single-run-installs-exactly-one-listener
   (testing "one `mount-with-hash-routing!` call installs exactly one active
@@ -142,23 +81,16 @@
           "the initial `on-hash-change!` ran the mount switch exactly once"))))
 
 (deftest re-run-with-changed-handler-identity-does-not-stack
-  (testing "rf2-liive: a second `mount-with-hash-routing!` run AFTER a
-            simulated hot-reload — where `on-hash-change!` has been
-            recompiled to a FRESH function object — removes the prior
-            listener and installs the new one, leaving exactly ONE active
-            hashchange listener (not two). This is the regression the old
-            browser-dedupe assumption failed to provide."
+  (testing "a re-run with a fresh handler identity replaces the prior listener"
     (let [{:keys [window hashchange-count]} (make-fake-window "#/")]
       (install-window! window)
       (with-redefs [host/mount-app!     (constantly nil)
                     host/mount-stories! (constantly nil)]
-        ;; Run #1 — installs the real `on-hash-change!` (identity #1).
+        ;; First install the current function identity.
         (host/mount-with-hash-routing! dummy-view)
         (is (= 1 (hashchange-count)) "one listener after the first run")
         (let [handle-1 @@#'host/hash-listener*]
-          ;; Run #2 — simulate a hot-reload by rebinding `on-hash-change!`
-          ;; to a DIFFERENT function object (what a CLJS recompile does to a
-          ;; top-level `defn`), then re-`run`.
+          ;; A fresh function identity simulates a recompile.
           (with-redefs [host/on-hash-change! (fn [] nil)]
             (host/mount-with-hash-routing! dummy-view))
           (is (= 1 (hashchange-count))
@@ -178,63 +110,33 @@
     (let [{:keys [window registry hashchange-count]} (make-fake-window "#/")
           switches (atom 0)]
       (install-window! window)
-      ;; First run installs the genuine `on-hash-change!`.
+      ;; First run installs the current handler.
       (with-redefs [host/mount-app!     (fn [] (swap! switches inc))
                     host/mount-stories! (fn [] (swap! switches inc))]
         (host/mount-with-hash-routing! dummy-view))
-      ;; Then five more re-runs, each simulating a recompile (a fresh
-      ;; `on-hash-change!` identity) that still routes through the same
-      ;; count-only mount switch.
+      ;; Each subsequent run uses a new handler identity.
       (dotimes [_ 5]
         (with-redefs [host/on-hash-change! (fn [] (swap! switches inc))]
           (host/mount-with-hash-routing! dummy-view)))
       (is (= 1 (hashchange-count))
           "six runs total → still exactly one active listener (no leak)")
-      ;; Fire ONE hash change by invoking every listener the registry holds
-      ;; (the real browser would call each registered listener once). With a
-      ;; single active listener the switch must run exactly once; the old
-      ;; stacking bug would have run it six times.
+      ;; A browser invokes every registered listener for one hash change.
       (reset! switches 0)
       (.forEach registry (fn [listener] (listener)))
       (is (= 1 @switches)
           "one hash change runs the mount switch exactly once — proving a
            single active listener, not an N-deep stack"))))
 
-;; ---------------------------------------------------------------------------
-;; The host owns Story-host open-in-editor project-root config.
-;;
-;; Story stamps each registered source-coord with a CLASSPATH-RELATIVE
-;; `:file` slot (e.g. `login/stories.cljs`); the open-in-editor chip
-;; prepends an on-disk project-root to build a real editor URI. A consumer
-;; that mounts the shell without configuring a root leaves its Story source
-;; links resolving against a nil root, so OS editor handlers cannot open the
-;; file (a false green).
-;;
-;; The host owns project-root config: a consumer declares its
-;; tool-relative source subdir via the `:source-subdir` opt and
-;; `mount-with-hash-routing!` resolves the on-disk root (through the shared
-;; `re-frame.testbed.config` build-env / `?checkout-root=` mechanism) and
-;; calls `story/configure!` itself. These tests pin that contract directly:
-;; the consumer can no longer mount the shell while silently forgetting the
-;; root. We exercise the private `configure-story-source-root!` (it carries
-;; no React-DOM / `js/window` dependency, so it runs under `:node-test`) and
-;; read Story's configured root back via `re-frame.story.config`.
-;; ---------------------------------------------------------------------------
+;; Source-subdir options configure Story without requiring a DOM.
 
 (deftest source-subdir-configures-absolute-project-root
-  (testing "rf2-77wqzi: declaring `:source-subdir` resolves the build-time
-            checkout-root joined with that subdir and configures it as Story's
-            project-root — so a classpath-relative Story coord composes to an
-            ABSOLUTE on-disk path, not a nil-root relative one. Covers the
-            `examples/core` subdir the login Story showcase uses."
+  (testing "a source subdir configures an absolute Story project root"
     (with-redefs [testbed-config/checkout-root "/home/dev/re-frame2"]
       (#'host/configure-story-source-root! "examples/core")
       (is (= "/home/dev/re-frame2/examples/core"
              (story-config/get-project-root))
           "Story's project-root is the absolute checkout/subdir join")
-      ;; The open-in-editor prepend is `(str root "/" file)`; reproduce that
-      ;; single join to prove a representative example Story coord reaches
-      ;; the intended on-disk file (under <checkout>/examples/core/...).
+      ;; Compose a representative classpath-relative coordinate.
       (let [composed (str (story-config/get-project-root) "/" "login/stories.cljs")]
         (is (= "/home/dev/re-frame2/examples/core/login/stories.cljs"
                composed)
@@ -243,15 +145,7 @@
             "the example source-root segment is present (not missing)")))))
 
 (deftest example-story-builds-resolve-absolute-source-coords
-  (testing "rf2-77wqzi: the two example Story dev builds named in the bead —
-            `:examples/login-with-stories` and
-            `:examples/nine-states-with-stories` — host their Story sources
-            under `examples/core` and `examples/patterns` respectively, so the
-            host-owned config resolves each build's representative Story coord
-            to an ABSOLUTE on-disk path under `<checkout>/<subdir>/...`. This
-            enumerates the affected builds explicitly so a future regression
-            (dropping the `:source-subdir` opt or the build-env define) trips
-            here. Each entry is `[build-id story-coord source-subdir expected-on-disk]`."
+  (testing "example Story builds resolve coordinates beneath their source subdir"
     (with-redefs [testbed-config/checkout-root "/home/dev/re-frame2"]
       (doseq [[build coord subdir expected]
               [[:examples/login-with-stories
@@ -274,37 +168,26 @@
               (str build " keeps the example source-root segment")))))))
 
 (deftest source-subdir-omitted-configures-no-root
-  (testing "rf2-77wqzi: a 1-arity call (no opts) and an explicitly nil/blank
-            `:source-subdir` configure NO project-root — the host leaves
-            Story's root untouched so a consumer that drives `story/configure!`
-            itself is not overridden, and the graceful-no-op contract holds"
+  (testing "nil and blank source subdirs do not change Story config"
     (with-redefs [testbed-config/checkout-root "/home/dev/re-frame2"]
-      ;; nil subdir → skip
+      ;; nil subdir skips configuration
       (#'host/configure-story-source-root! nil)
       (is (nil? (story-config/get-project-root))
           "nil subdir configures nothing")
-      ;; blank subdir → skip
+      ;; blank subdir also skips configuration
       (#'host/configure-story-source-root! "   ")
       (is (nil? (story-config/get-project-root))
           "blank subdir configures nothing"))))
 
 (deftest source-subdir-with-no-resolvable-root-degrades-to-no-op
-  (testing "rf2-77wqzi: when a subdir is declared but NEITHER the build-time
-            define NOR a `?checkout-root=` override is present (the default
-            `:node-test` shape: blank checkout-root, no js/window), the host
-            configures a nil root and open-in-editor degrades to a graceful
-            no-op rather than a broken relative link"
+  (testing "a declared subdir with no checkout root configures no project root"
     (with-redefs [testbed-config/checkout-root ""]
       (#'host/configure-story-source-root! "examples/reagent")
       (is (nil? (story-config/get-project-root))
           "no resolvable root → Story's root stays nil (no broken prefix)"))))
 
 (deftest mount-with-hash-routing-arity-2-configures-project-root
-  (testing "rf2-77wqzi: the public 2-arity entry threads `:source-subdir`
-            into the project-root config before wiring the router — the
-            exact call shape the two example Story hosts now use. We stub
-            the mount switch + a fake window so the router wiring is inert
-            and assert only that the project-root landed."
+  (testing "the public two-arity entry configures the declared source subdir"
     (let [{:keys [window]} (make-fake-window "#/")]
       (install-window! window)
       (with-redefs [testbed-config/checkout-root "/home/dev/re-frame2"
@@ -316,10 +199,7 @@
           "the 2-arity call configured the resolved absolute root"))))
 
 (deftest mount-with-hash-routing-arity-1-leaves-root-untouched
-  (testing "rf2-77wqzi: the 1-arity entry (no opts) does NOT touch Story's
-            project-root — a consumer that calls `story/configure!` itself
-            keeps full control. We pre-set a root and confirm the host
-            leaves it intact."
+  (testing "the one-arity entry leaves consumer-owned Story config untouched"
     (let [{:keys [window]} (make-fake-window "#/")]
       (install-window! window)
       (story-config/set-project-root! "/preset/by/consumer")

--- a/tools/testbed-support/test/re_frame/testbed/story_host_dom_cljs_test.cljs
+++ b/tools/testbed-support/test/re_frame/testbed/story_host_dom_cljs_test.cljs
@@ -1,61 +1,9 @@
 (ns re-frame.testbed.story-host-dom-cljs-test
-  "Browser-level handoff test for `re-frame.testbed.story-host`.
+  "Browser tests for the Story-host React-root handoff.
 
-  ## Why this exists (the gap the node suite cannot close)
-
-  The sibling node suite (`story_host_cljs_test.cljs`) pins the
-  `hashchange`-listener lifecycle — exactly one active listener across
-  hot-reload re-`run`s — but it does so with `mount-app!` / `mount-stories!`
-  redefined to count-only NO-OPS and a fake `js/window`. That is the right
-  shape for proving listener identity, but by stubbing the mount switch it
-  CANNOT catch a regression in the real React-DOM-root choreography the host
-  performs on the live `#app` node:
-
-    - `mount-app!`     → `story/unmount-shell!` then `ensure-app-root!`
-                         (`rdc/create-root`) then `rdc/render` the live view.
-    - `mount-stories!` → `tear-down-app-root!` (`rdc/unmount` the live root)
-                         then `story/mount-shell!` (a fresh `rdc/create-root`
-                         on the SAME node).
-
-  The load-bearing invariant is that whichever surface currently owns the
-  `#app` node MUST release its React root before the other surface calls
-  `rdc/create-root` on that same node — otherwise React 19 emits the
-  \"You are calling ReactDOMClient.createRoot() on a container that has
-  already been passed to createRoot() before\" warning, and roots leak.
-  A subtle way to violate it is passing the DOM node, not the root handle,
-  to `unmount` — a silent no-op that leaves the shell root alive.
-  Only a test that drives the REAL handoff on a REAL node can lock it out.
-
-  ## What this test does
-
-  It mounts on a real `#app` div and drives the REAL `on-hash-change!`
-  listener through the full `#/` -> `#/stories` -> `#/` cycle, plus a
-  hot-reload-style re-`run`, asserting:
-
-    1. exactly one `hashchange` listener is ever active (across the re-run);
-    2. the surfaces hand off the `#app` node cleanly — the live view's text
-       and the (stand-in) shell's text alternate correctly, proving each
-       side's root was torn down before the other created one;
-    3. React emits NO createRoot-reuse / handoff warning across the whole
-       cycle (captured off `console.error` / `console.warn`).
-
-  ## Why the shell side is a REAL minimal root, not the full Story shell
-
-  We redefine `story/mount-shell!` / `story/unmount-shell!` to perform the
-  GENUINE React-root lifecycle (`rdc/create-root` + `rdc/render` +
-  `rdc/unmount`) on the passed node, rendering a tiny marker view rather
-  than the full Story shell tree (sidebar + embedded Xray inspector +
-  recorder + command palette …). That keeps the slice test free of the
-  heavyweight Story+Xray render surface and its registry/app-state
-  preconditions, while still exercising the EXACT root-handoff contract the
-  bead names — the host's `tear-down-app-root!` must release the live root
-  before this real `create-root` runs on the same node, or React warns.
-  This is a non-stubbed handoff (real roots, real unmount), not the
-  count-only no-op the node suite uses.
-
-  ns ends in `-dom-cljs-test` so shadow's `:browser-test` discovers it; the
-  `:node-test` runner also loads it, where the body gates on `(browser?)`
-  and no-ops cleanly (no DOM)."
+  The Node suite covers listener identity with mount stubs. This suite uses a
+  real DOM node and minimal real React roots to verify that each surface
+  unmounts before the other claims `#app`. Its bodies no-op under Node."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [clojure.string :as str]
             [reagent.dom.client :as rdc]
@@ -67,10 +15,7 @@
   (and (exists? js/document)
        (some? (.-createElement js/document))))
 
-;; ---- the real `#app` node ------------------------------------------------
-;;
-;; `story_host` reads the node via `(js/document.getElementById "app")`, so
-;; the test must install a real element with that id on the live document.
+;; story-host finds the target by id, so install it on the live document.
 
 (defn- ensure-app-node! []
   (when (browser?)
@@ -84,16 +29,11 @@
   (when-let [el (and (browser?) (js/document.getElementById "app"))]
     (.remove el)))
 
-;; ---- a real-but-minimal Story-shell stand-in -----------------------------
-;;
-;; A holder for the shell's own React root so our `mount-shell!` /
-;; `unmount-shell!` stand-ins perform the genuine create-root / unmount
-;; lifecycle on the `#app` node — the real handoff the host must coordinate.
+;; A minimal shell root exercises the real create/render/unmount lifecycle.
 (defonce ^:private shell-root* (atom nil))
 
 (defn- shell-mount! [node]
-  ;; Mirror the real `story/mount-shell!` contract: tear down any prior
-  ;; shell root, then create + render a fresh root on the node.
+  ;; Match mount-shell!: release any prior root before creating the next one.
   (when-let [prev @shell-root*]
     (try (rdc/unmount prev) (catch :default _ nil)))
   (let [root (rdc/create-root node)]
@@ -101,10 +41,7 @@
     (reset! shell-root* root)
     {:root root :node node}))
 
-;; Mirror the real `story/unmount-shell!` arities ([] / [handle]) so the
-;; `(story/unmount-shell!)` arity-0 call site inside `mount-app!` resolves
-;; against the redefinition (a variadic-only stand-in does not expose the
-;; arity-0 invoke slot the compiled call site dispatches through).
+;; Preserve both real arities so compiled arity-0 calls reach the redefinition.
 (defn- shell-unmount!
   ([] (shell-unmount! nil))
   ([_handle]
@@ -112,8 +49,6 @@
      (try (rdc/unmount root) (catch :default _ nil))
      (reset! shell-root* nil)
      nil)))
-
-;; ---- console capture (createRoot-reuse warnings land on error/warn) ------
 
 (defn- with-captured-console [thunk]
   (let [calls         (atom [])
@@ -135,8 +70,6 @@
         (str/includes? m "already been passed")
         (str/includes? m "already mounted"))))
 
-;; ---- reset the host's defonce handles between tests ----------------------
-
 (defn- reset-host-handles! []
   (reset! @#'host/hash-listener* nil)
   (reset! @#'host/root-view* nil)
@@ -147,11 +80,8 @@
              (reset-host-handles!)
              (reset! shell-root* nil))
    :after  (fn []
-             ;; Tear down anything still mounted so a leaked root never
-             ;; bleeds into another namespace's tests. Unmount the held
-             ;; roots directly (do NOT re-enter `mount-app!`, which would
-             ;; call the REAL `story/unmount-shell!` outside the test's
-             ;; `with-redefs` and create a root on a possibly-removed node).
+             ;; Unmount held roots directly; the Story redefinitions are no
+             ;; longer active during fixture teardown.
              (when-let [r @@#'host/app-root]
                (try (rdc/unmount r) (catch :default _ nil)))
              (when-let [r @shell-root*]
@@ -159,8 +89,6 @@
              (reset-host-handles!)
              (reset! shell-root* nil)
              (remove-app-node!))})
-
-;; ---- a trivial live-app root view ----------------------------------------
 
 (defn- live-view [] [:div {:id "live-marker"} "LIVE"])
 
@@ -171,16 +99,9 @@
   (when-let [el (js/document.getElementById id)]
     (.-textContent el)))
 
-;; ---------------------------------------------------------------------------
-;; The handoff test
-;; ---------------------------------------------------------------------------
-
 (deftest live-stories-live-handoff-no-listener-or-root-leak
-  (testing "rf2-fzgcii: driving the REAL host through #/ -> #/stories -> #/
-            (plus a hot-reload re-run) hands the #app node off between the
-            live view and the (real-root) Story shell with NO duplicate
-            hashchange listener, NO leaked React root, and NO createRoot
-            handoff warning"
+  (testing "a live -> stories -> live cycle and re-run release each React root
+            before the next surface claims #app"
     (if-not (browser?)
       (is true ":node-test: no DOM — :browser-test runner exercises the assertion")
       (let [app-node (ensure-app-node!)
@@ -189,38 +110,27 @@
               (fn []
                 (with-redefs [story/mount-shell!   shell-mount!
                               story/unmount-shell! shell-unmount!]
-                  ;; Start on the live app (#/). mount-with-hash-routing!
-                  ;; installs the listener and renders the current hash's
-                  ;; surface.
+                  ;; Start with the live app.
                   (set-hash! "#/")
                   (react-dom/flushSync
                    (fn [] (host/mount-with-hash-routing! live-view)))
-                  ;; -> #/stories : tear down the live root, mount the shell
-                  ;; root on the SAME node.
+                  ;; Hand the same node to the shell.
                   (set-hash! "#/stories")
                   (react-dom/flushSync (fn [] (#'host/on-hash-change!)))
-                  ;; -> #/ : tear down the shell, re-create the live root on
-                  ;; the same node.
+                  ;; Hand the node back to the live app.
                   (set-hash! "#/")
                   (react-dom/flushSync (fn [] (#'host/on-hash-change!)))
-                  ;; Hot-reload re-run: a fresh `run` re-installs the
-                  ;; listener (must REMOVE the prior one, not stack) and
-                  ;; re-renders the current surface on the same node.
+                  ;; Re-run the host as hot reload would.
                   (react-dom/flushSync
                    (fn [] (host/mount-with-hash-routing! live-view)))
-                  ;; One more #/stories -> #/ cycle AFTER the re-run, to
-                  ;; prove the post-reload listener still drives a clean
-                  ;; handoff.
+                  ;; Repeat the handoff after the re-run.
                   (set-hash! "#/stories")
                   (react-dom/flushSync (fn [] (#'host/on-hash-change!)))
                   (set-hash! "#/")
                   (react-dom/flushSync (fn [] (#'host/on-hash-change!))))))]
-        ;; -- exactly one active listener (no stacking across the re-run) --
-        ;; The host stores the single installed handle; a stacked duplicate
-        ;; would mean a different handle was added without removing the old.
+        ;; The host retains the currently installed listener handle.
         (is (some? @@#'host/hash-listener*)
             "the single installed hashchange handle is recorded")
-        ;; -- the node ends on the LIVE surface, cleanly handed back --------
         (is (= "LIVE" (marker-text "live-marker"))
             "after the final #/ the live view owns #app")
         (is (nil? (marker-text "shell-marker"))
@@ -229,18 +139,14 @@
             "the shell root handle was released (no leaked shell root)")
         (is (= app-node (js/document.getElementById "app"))
             "the same #app node was reused throughout (one node, one owner)")
-        ;; -- NO React createRoot-reuse / handoff warning -------------------
         (let [bad (filterv handoff-warning? warnings)]
           (is (empty? bad)
               (str "no createRoot-reuse / handoff warning across the full "
                    "#/ <-> #/stories cycle and re-run; saw: " (pr-str bad))))))))
 
 (deftest hot-reload-rerun-does-not-stack-listener-on-real-node
-  (testing "rf2-fzgcii: a hot-reload re-run where on-hash-change! is rebound
-            to a fresh fn (the CLJS recompile churn) still leaves the stored
-            listener handle advanced to the NEW fn — the remove-then-add
-            discipline holds on a real node, not just the fake-window node
-            suite"
+  (testing "a re-run with a fresh listener identity advances the stored handle
+            on a real DOM node"
     (if-not (browser?)
       (is true ":node-test: no DOM — :browser-test runner exercises the assertion")
       (do
@@ -252,7 +158,7 @@
            (fn [] (host/mount-with-hash-routing! live-view)))
           (let [handle-1 @@#'host/hash-listener*]
             (is (some? handle-1) "first run records a listener handle")
-            ;; Simulate a recompile: on-hash-change! becomes a fresh fn.
+            ;; A new function identity simulates a recompile.
             (with-redefs [host/on-hash-change! (fn [] nil)]
               (react-dom/flushSync
                (fn [] (host/mount-with-hash-routing! live-view))))


### PR DESCRIPTION
## Summary
- rewrite the testbed-support README around the current source-root, Story-host, and JVM endpoint contracts
- consolidate repeated namespace/function commentary at the boundary that owns each invariant
- remove historical bead narration and shouted regression prose from fixtures while retaining the load-bearing explanations
- keep executable forms and behavior unchanged

## Review coverage
Reviewed all 9 files under `tools/testbed-support`: README and dependency harness, all three source namespaces, and all four test namespaces.

The retained explanations focus on:
- literal-plus URI decoding and cross-platform source-root normalization
- listener identity across CLJS hot reload
- exclusive React-root ownership during live/Story handoff
- POST plus loopback Host/Origin protection for local editor launch
- missing-file detection so the browser fallback remains available

## Verification
- `clojure -M:test` from `tools/testbed-support` (28 tests, 141 assertions)
- `npm run test:testbed-support` from `implementation` (46 tests, 109 assertions; 0 compiler warnings)
- `clj-kondo --lint tools/testbed-support/src tools/testbed-support/test` (0 errors, 0 warnings)
- `git diff --check`

`clojure -M:splint ../tools/testbed-support/src ../tools/testbed-support/test` continues to report the surface's 77 existing executable-code style warnings. This change does not alter those forms.

Tracking: rf2-bqtndo