### PR TITLE
docs(xray): clarify runtime and host contracts (rf2-6g9zhg)

### DIFF
--- a/tools/xray/README.md
+++ b/tools/xray/README.md
@@ -26,11 +26,10 @@ two modes: a **9-tab Dynamic detail panel** (event-coupled) and a
 **5-tab Static mode** (registry browse). The tabs are *presentation* of
 an already-structured runtime.
 
-AI agent access to Xray's surfaces flows through
-`tools/re-frame2-pair-mcp/` against the framework-published Xray
-runtime API at `day8.re-frame2-xray.runtime` — per rf2-hvl1g a
-dedicated xray-mcp jar is unnecessary; agents read the same trace bus
-+ epoch history + registrar Xray itself reads.
+AI agent access uses `tools/re-frame2-pair-mcp/` and the browser-side
+accessors in `day8.re-frame2-xray.runtime`. There is no separate Xray
+MCP artefact: agents and the human-facing panel read the same trace,
+epoch, and registrar data.
 
 ## Headline experiences
 
@@ -41,7 +40,7 @@ Selecting an event in the L2 event list moves a single spine sub
 event*. Time-travel is the spine itself — the events-ribbon nav cluster
 plus the event list are the scrubber; there is no bottom rail. Issues are
 not a tab — they surface inline in the Epoch panel, the L2 event-row
-pink-wash, and the always-on issues ribbon signal (per rf2-gbz39).
+pink-wash, and the always-on issues ribbon signal.
 
 ### Dynamic mode — the 9 tabs (lenses on the focused event)
 
@@ -230,11 +229,9 @@ force-disable in dev.
 
 ### MCP (Xray as an agent surface)
 
-Per rf2-hvl1g there is no dedicated `xray-mcp` jar. AI agents reach
-Xray's surfaces through `tools/re-frame2-pair-mcp/`, which can read
-the framework-published Xray runtime API on
-`day8.re-frame2-xray.runtime` (the same trace bus + epoch history +
-registrar Xray's chrome reads).
+AI agents reach Xray through `tools/re-frame2-pair-mcp/`, which evaluates
+the browser-side accessors in `day8.re-frame2-xray.runtime`. See
+[`spec/API.md`](./spec/API.md) for the accessor contract.
 
 ## Spec
 
@@ -336,81 +333,13 @@ Required GitHub secrets (configured at the repository level):
 
 ## Status
 
-Pre-alpha. Running shell with the full two-mode chrome (9-tab Dynamic
-detail panel + 5-tab Static mode), one wired keybinding
-(`Ctrl+Shift+C` toggle), default true-inline mount under
-`[data-rf-xray-host]`, programmatic pop-out via `(xray/popout!)`,
-and a frame-isolated `:rf/xray` registrar.
-Spec corpus landed via rf2-1lls (2026-05-12). The test coverage matrix
-at [`spec/017-Test-Coverage-Matrix.md`](./spec/017-Test-Coverage-Matrix.md)
-tracks per-surface status: most rows are `covered` (unit/helper/view
-tier plus a browser-level path), while several newer rows are `partial`
-— some unit/helper/view or smoke coverage exists, but the deterministic
-browser feature path or failure path is still missing (see the matrix
-for the live per-row status). The 20-event/load re-check is **not
-default CI**; it is an occasional pre-commit / explicit pre-PR gate for
-Xray-heavy work.
+Pre-alpha. The full 9-tab Dynamic shell, 5-tab Static catalogue,
+true-inline and overlay launch modes, same-origin pop-out, command palette,
+global shortcuts, and frame-isolated `:rf/xray` state are implemented.
 
-Browser testbeds live under `tools/xray/testbeds/` —
-`two_frame_isolation`, `standard_epochs`, `routes_epochs`, `machine_epochs`,
-`edn_inspector`, `feature_matrix`, `panel_gallery` — covering the canonical
-multi-frame isolation surface
-(`two_frame_isolation`: one app · two frames · Counter / Machine
-(websocket) / Routing / Async&errors tabs navigated as routes ·
-per-frame trace / events / issues / cascades · Xray target-frame
-round-trip; built from the shared `testdeck/` modules), the
-deliberately-simple single-frame driving surface (`standard_epochs`,
-rf2-gsr6z: one frame · a tall column of numbered buttons, each bumping
-a shared baseline counter + exercising exactly one more feature, so
-clicking top-to-bottom completely exercises any one Xray panel —
-Epoch / App-db / Views / Trace + the inline issue surfacing (Epoch
-issue blocks · L2 event-row wash · issues ribbon signal; the standalone
-Issues tab was removed per rf2-gbz39); no tabs, no routing, no
-machines/SSR; supersedes the old `step_deck`. App-db coverage here is
-the scalar bump + a flow-derived slot; the rich App-db DIFF shapes
-— added / removed-to-empty / changed (diff-mode-3) — moved to the
-`edn_inspector` deck per rf2-jmcjm, where they drive the App-db panel
-directly), the routing sibling
-(`routes_epochs`, rf2-5crg4: the same numbered-button shape — one frame ·
-baseline-bump per press · one more ROUTING feature per rung — aimed
-squarely at the Routing panel, so clicking top-to-bottom completely
-exercises its Current route · Navigation this epoch · Route table
-sections; served on port 8032), the state-machine sibling
-(`machine_epochs`, rf2-w06op: the same numbered-button shape — one frame ·
-baseline-bump per press · one more MACHINE feature per rung (start ·
-transition · entry/exit actions · guard allowed/blocked · transition-
-with-effect · ignored event · parallel regions · transition history ·
-multiple machines) — aimed squarely at the Machine Inspector
-(`rf-xray-machine-inspector`), so clicking top-to-bottom completely
-exercises its topology highlight · focused-transition lens · guards /
-actions · snapshot drill-in · transition history · parallel-region
-surfaces; owns its own `:door/main` + `:traffic/light` machines and does
-NOT touch the `deep_machine` gate substrate; served on port 8033), the
-edn-inspector sibling (`edn_inspector`, rf2-74u2s → rf2-1niob: the same
-numbered-button shape — one frame · baseline-bump per press — where each
-button DISPATCHES a real app-db change at a meaningful path, and the Xray
-sidecar mounted INLINE on the right shows it via the EPOCH (db-before /
-after) + APP-DB (the diff) panels, both of which render their CLJS values
-through the edn-inspector
-(`day8.re-frame2-xray.views.edn-inspector`) — so the inspector is
-demonstrated through its PRIMARY use case, the panels, not a standalone
-widget. An 8-rung ladder, each rung writing one inspector-stressing shape:
-large collection → elision · deeply nested → path render/collapse · the
-three App-db diff ops (added / removed-to-empty per rf2-8pfkk / changed
-diff-mode-3) · :rf/redacted sentinel · :rf.size/large-elided sentinel
-(Spec 015) · mixed types + #uuid/#inst tagged literals. The inline shell
-mounts from the deck's `run` via the public
-`day8.re-frame2-xray.core/init!` + `open!` (the manual alternative to the
-`:preloads` wiring) so no shadow-cljs.edn edit is needed; served on port
-8034), the deterministic
-feature-matrix sweep across panels + shell + launch modes + redaction
-+ 20-event load, the Panel-view gallery, and the performance probe.
-
-Agent access to Xray's surfaces flows through
-`tools/re-frame2-pair-mcp/` against the framework-published Xray
-runtime API on `day8.re-frame2-xray.runtime` (per rf2-hvl1g — no
-dedicated xray-mcp jar).
-
-Next: alpha cut once the browser feature gate from
 [`spec/017-Test-Coverage-Matrix.md`](./spec/017-Test-Coverage-Matrix.md)
-lands as default CI and the `0.0.1.alpha` Clojars publish is wired.
+is the live source for per-surface coverage. Browser fixtures under
+`testbeds/` exercise multi-frame isolation, epoch/routing/machine ladders,
+the EDN inspector, panel gallery, feature matrix, and performance probes.
+The matrix, rather than this README, records which paths are covered,
+partial, deferred, or intentionally run outside default CI.

--- a/tools/xray/deps.edn
+++ b/tools/xray/deps.edn
@@ -1,228 +1,66 @@
-;; day8/re-frame2-xray — Xray, the re-frame2 devtools panel (Phase 1
-;; foundation, rf2-n6x4q; parent epic rf2-5aw5v).
+;; day8/re-frame2-xray — Xray, the re-frame2 devtools panel.
 ;;
-;; Per tools/README.md the artefact is a downstream consumer of
-;; implementation/core/ + an adapter (Reagent, UIx, or Helix). Xray
-;; does NOT register any new framework primitives; every surface it
-;; exposes is built on the Spec 009 trace bus, the Spec 002 frame
-;; primitive, and the Spec 006 substrate adapter API. The bundle-
-;; isolation contract holds: nothing in implementation/ may
-;; :require from here.
+;; Xray is a downstream, dev-only consumer of core, feature artefacts,
+;; and the substrate adapter API. It does not define framework
+;; primitives, and implementation/ must never depend on it.
 ;;
 ;; ## Pin lockstep with implementation/core
 ;;
 ;; Xray rides the core artefact at :local/root during development;
 ;; the release workflow rewrites :local/root → :mvn/version pinned to
-;; the same VERSION file the core artefact reads (mirrors the pattern
-;; in tools/story/deps.edn). Xray's published version equals the
-;; framework's published version at every release — same lockstep
-;; convention used by implementation/adapters/* (rf2-w05l) so apps
-;; never mix incompatible core + tools versions.
-;;
-;; ## Phase 1 scope (this commit)
-;;
-;; Foundation only: preload, Ctrl+Shift+C, frame-provider :rf/xray
-;; isolation, empty-shell layout, trace bus subscription. Panels
-;; (Epoch hero, app-db diff, etc.) ship as separate beads under
-;; rf2-5aw5v. (Pre rf2-5gl5r the hero was the now-retired Event/
-;; Handler panel; the Epoch panel is the canonical replacement.)
+;; the repository VERSION. Published Xray and framework artefacts
+;; therefore use the same version.
 ;;
 ;; ## MCP surface
 ;;
 ;; AI agent access to Xray state flows via `tools/re-frame2-pair-mcp/`
-;; (which can read the framework-published Xray runtime API on
-;; `day8.re-frame2-xray.runtime`); per rf2-hvl1g there is no dedicated
-;; xray-mcp jar. Nothing in this deps.edn references an MCP server.
+;; and `day8.re-frame2-xray.runtime`. Xray has no MCP-server dependency.
 {:paths ["src"]
  :deps  {day8/re-frame2 {:local/root "../../implementation/core"}
 
-         ;; Per rf2-5so8f — `day8/re-frame2-epoch` is a hard dep of Xray,
-         ;; not an optional add-on. The Xray preload `:require`s
-         ;; `re-frame.epoch` (see preload.cljs §rf2-1barg) so the Time
-         ;; Travel scrubber has an epoch-history seed table to read from
-         ;; `rf/epoch-history` / `rf/register-epoch-listener!`.
-         ;; Without the artefact on the classpath the preload fails to
-         ;; compile in any downstream consumer build that doesn't
-         ;; coincidentally already declare `day8/re-frame2-epoch` — a
-         ;; silent footgun for migration authors following the skill doc.
-         ;;
-         ;; Spec C-000.27 forbids only *core* from transitively requiring
-         ;; per-feature namespaces; a downstream tool artefact pulling a
-         ;; per-feature artefact is allowed. Pay-as-you-go still holds at
-         ;; the level the user cares about: production builds never see
-         ;; Xray (per the `:devtools/preloads` gate + the
-         ;; `interop/debug-enabled?` elision in `re-frame.epoch`), and
-         ;; apps that don't install Xray don't get epoch unless they ask.
+         ;; Time travel reads epoch history and registers an epoch
+         ;; listener, so epoch is part of Xray's compile-time contract.
          day8/re-frame2-epoch {:local/root "../../implementation/epoch"}
 
-         ;; Per rf2-lq0ef — `day8/re-frame2-routing` is a hard dep of
-         ;; Xray. The Routes lens uses `re-frame.routing.match` directly
-         ;; for the Simulate-URL surface: paste a URL, the lens runs
-         ;; `match-against` on every registered route's compiled pattern
-         ;; and ranks the matching candidates by `:rf.route/rank`. The
-         ;; helper ns (`day8.re-frame2-xray.panels.routing-helpers`)
-         ;; `:require`s `re-frame.routing.match` at load time so a host
-         ;; without the routing artefact on its classpath would crash
-         ;; Xray's preload. Most real hosts already pull routing, but
-         ;; the Routes lens must work even for hosts that haven't
-         ;; registered any routes yet — same posture as the
-         ;; re-frame2-epoch dep above.
+         ;; The Routes lens compiles and ranks candidates through
+         ;; `re-frame.routing.match`, including when the host registry is empty.
          day8/re-frame2-routing {:local/root "../../implementation/routing"}
 
-         ;; Per rf2-uhsqb — `day8/re-frame2-flows` is a hard dep of
-         ;; Xray. The Static Flows sub-tab reads the public
-         ;; `re-frame.flows/flows-snapshot` introspection surface (and
-         ;; the Epoch panel's flow-step source link reads
-         ;; `re-frame.flows/flow-meta-at`) to project the registered-flows
-         ;; catalogue — the per-frame flows atom is the sole store after
-         ;; rf2-en00bk (the registrar `:flow` slot is reserved-but-empty),
-         ;; repointed off it by rf2-20359j. Same posture as the routing
-         ;; dep above: most real hosts already pull the flows artefact, but
-         ;; the Static Flows sub-tab must work (rendering an empty
-         ;; catalogue when no flows are registered) even for hosts that
-         ;; haven't registered any flows yet.
+         ;; The Static Flows catalogue and Epoch source links use the
+         ;; flows artefact's public introspection functions.
          day8/re-frame2-flows {:local/root "../../implementation/flows"}
 
-         ;; Per rf2-o5f5f.4 — `day8/re-frame2-schemas` is a hard dep
-         ;; of Xray. The Static Schemas sub-tab reads
-         ;; `re-frame.schemas.storage/schemas-by-frame` at view-render
-         ;; time to project the registered-schemas catalogue. Same
-         ;; posture as the flows + routing deps above: the Static
-         ;; Schemas sub-tab must work (rendering an empty catalogue
-         ;; when no schemas are registered) even for hosts that
-         ;; haven't registered any schemas yet.
+         ;; The Static Schemas catalogue reads the schema registry directly.
          day8/re-frame2-schemas {:local/root "../../implementation/schemas"}
 
-         ;; Per rf2-1fc459 — `day8/re-frame2-resources` is a hard dep of
-         ;; Xray. The Derivation-Graph tab (025) is EP-0014's NAMED FIRST
-         ;; CONSUMER and its spec promises a single graph across ALL FIVE
-         ;; algebra-view families — subscriptions, flows, resources, route
-         ;; facts, and machine processes + selectors. The composer
-         ;; (`re-frame.derivation.graph`) reaches each optional family
-         ;; through the `{family contributor}` map the consuming tool
-         ;; supplies from the tooling siblings it statically `:require`s; on
-         ;; CLJS that means Xray must pull the resources artefact so it can
-         ;; `:require re-frame.resources.tooling` (the
-         ;; `resource-algebra-view` / `resource-cache-algebra-view`
-         ;; projections) and feed the `:resources` contributor. Same posture
-         ;; as the flows / routing / schemas deps above: the resources
-         ;; artefact depends only on core, and the tooling sibling's body is
-         ;; gated by `interop/debug-enabled?` + is DCE'd / bundle-isolated
-         ;; from production (Xray is dev-only via `:devtools/preloads`). The
-         ;; Resources PANEL (024) still reads the runtime-db slice decoupled;
-         ;; the Derivation-Graph tab is a SEPARATE surface that needs the
-         ;; algebra-view projection, not the raw slice.
+         ;; The Derivation Graph composes the resource and cache algebra
+         ;; projections. The Resources panel separately reads runtime data.
          day8/re-frame2-resources {:local/root "../../implementation/resources"}
 
-         ;; Per rf2-1fc459 — `day8/re-frame2-machines` is a hard dep of Xray
-         ;; for the same reason as the resources dep above: the
-         ;; Derivation-Graph tab's `:machines` contributor needs
-         ;; `re-frame.machines.tooling` (the `machine-algebra-view` /
-         ;; `machine-instance-algebra-view` projections + the
-         ;; `machine-selector-targets` extractor that draws precise
-         ;; `:selector` edges). Without this dep the named first consumer
-         ;; cannot show machine process nodes or machine-selector edges even
-         ;; when the host app registers machines. Xray ALREADY pulls
-         ;; `day8/re-frame2-machines-viz` (the MachineChart), but that
-         ;; artefact depends only on core — it carries the chart, NOT the
-         ;; machines runtime / tooling sibling. The machines artefact
-         ;; depends only on core; its tooling body is dev-gated + DCE'd /
-         ;; bundle-isolated from production. The Machine Inspector (003)
-         ;; still reads the runtime-db slice decoupled; the Derivation-Graph
-         ;; tab needs the algebra-view projection.
+         ;; The Derivation Graph consumes machine algebra and selector
+         ;; projections; the Machine Inspector reads the runtime slice.
          day8/re-frame2-machines {:local/root "../../implementation/machines"}
 
-         ;; Per rf2-o9arp — the MachineChart implementation lives in
-         ;; day8/re-frame2-machines-viz. Xray's panels require the
-         ;; canonical machines-viz chart surface directly
-         ;; (`day8.re-frame2-machines-viz.chart.layout`, the chart
-         ;; primitives, etc.); the old `day8.re-frame2-xray.chart.*`
-         ;; re-export shims were removed (rf2-blli8). This makes the
-         ;; chart embeddable in non-Xray hosts (Story, the read-only
-         ;; viewer page, direct user-app embeds) without dragging
-         ;; Xray's full panel chrome along.
+         ;; Machine charts are owned by machines-viz and embedded here;
+         ;; Xray does not maintain a second chart implementation.
          day8/re-frame2-machines-viz {:local/root "../machines-viz"}
 
-         ;; Per rf2-wl5pa — Xray targets day8/reagent-slim (the rewrite)
-         ;; rather than stock Reagent. Xray has zero direct `reagent.*`
-         ;; requires under tools/xray/src/ (the dep is purely the
-         ;; substrate the host installs and that mount.cljs reaches via
-         ;; re-frame.substrate.adapter/render). Switching from stock
-         ;; Reagent to slim means:
-         ;;
-         ;;   1. UIx-only / Helix-only / plain-atom users get Xray
-         ;;      without dragging stock Reagent into their transitive
-         ;;      deps — Xray picks the lighter substrate regardless
-         ;;      of the host's adapter choice.
-         ;;
-         ;;   2. The smaller dev bundle (3954 bytes smaller on the
-         ;;      counter example per the rf2-tba5e smoke test) shaves
-         ;;      hot-reload latency — Xray overhead is felt most
-         ;;      acutely in the watch loop where the dev bundle dominates.
-         ;;
-         ;;   3. The framework's own devtools dogfood the framework's
-         ;;      Reagent rewrite at the load profile that matters.
-         ;;
-         ;; Note on the adapter ns: the in-tree slim adapter ns is
-         ;; `re-frame.adapter.reagent-slim`; at artefact-publication
-         ;; time the slim artefact ships its own `re-frame.adapter.reagent`
-         ;; ns (per implementation/adapters/reagent-slim/IMPL-SPEC.md §1.8).
-         ;; Either way, Xray never directly :requires the adapter ns —
-         ;; mount.cljs reaches the substrate via
-         ;; re-frame.substrate.adapter/render so the host's installed
-         ;; adapter governs the render path; the slim dep here is purely
-         ;; transitive-classpath assembly so Xray's published artefact
-         ;; carries an adapter on the consumer side.
+         ;; Reagent Slim supplies the default transitive adapter. Xray
+         ;; renders through `re-frame.substrate.adapter`, so the adapter
+         ;; installed by the host still governs the runtime path.
          day8/reagent-slim {:local/root "../../implementation/adapters/reagent-slim"}
 
-         ;; rf2-oqa60 phase 1 — binaryage/devtools dep dropped. The
-         ;; first-class `views/edn-inspector` widget replaces the
-         ;; cljs-devtools-backed renderer with a roll-your-own CLJS
-         ;; tree walker. The impedance-mismatch bug class (rf2-dw8n7,
-         ;; rf2-oswhk) goes away with the dep. The bundle-isolation
-         ;; gate's `cljs-devtools` checks still run as defence-in-depth
-         ;; (a stray re-introduction would re-fail the gate).
-
-         ;; Editscript — canonical diff engine for Xray (rf2-n2jig).
-         ;; A* algorithm producing optimally-small edit scripts as pure
-         ;; EDN — `[[[path] :+ value] [[path] :- ] [[path] :r value]]`.
-         ;; Replaces the home-grown classifier at
-         ;; `views/edn_inspector.cljs:533-664` (10 fns; pre-alpha clean
-         ;; delete, no shim). Vector shift-detection comes free from
-         ;; A*'s Myers underpinnings — an insert in a 30-element vector
-         ;; renders as 1 `:+` op + N-1 shifted-but-equal rows rather
-         ;; than N spurious modifications. Pure-data output aligns
-         ;; with re-frame2's spec-is-data ethos; the same edit script
-         ;; feeds Xray's renderer, the legacy flat-diff line view, and
-         ;; (future) Story's snapshot lens + MCP wire surfaces — one
-         ;; diff representation, many consumers. Bundle-isolated: Xray
-         ;; is dev-only via `:devtools/preloads`; the bundle-isolation
-         ;; gate verifies `editscript.*` does not reach production
-         ;; bundles.
+         ;; Editscript is the shared pure-data diff representation for
+         ;; the tree inspector, flat diff view, and runtime accessor.
          juji/editscript {:mvn/version "0.6.5"}
 
-         ;; zprint — canonical pretty-printer for the EDN widget's
-         ;; `code-block` rendering of handler-source strings. The Event
-         ;; panel's HANDLER section reads `:rf.handler/source` off the
-         ;; registry meta and renders it under a syntax-highlighted
-         ;; `<pre>`; zprint pre-formats the source to canonical
-         ;; line-breaks + indentation before the in-bundle tokenizer
-         ;; runs, so a poorly-formatted source registration still reads
-         ;; cleanly in the panel. Used in `:parse {:interpose true}` mode
-         ;; via `zprint.core/zprint-file-str` so existing comments and
-         ;; blank lines survive the round-trip.
-         ;;
-         ;; Xray is dev-only (gated by `:devtools/preloads` in
-         ;; shadow-cljs) so zprint does NOT land in production bundles.
-         ;; The bundle-isolation gate verifies via the `zprint.core`
-         ;; sentinel that the formatter body is absent from the counter
-         ;; example's :advanced release bundle.
+         ;; Handler source is formatted before Xray tokenises and renders
+         ;; it. The dependency remains confined to the dev-only artefact.
          zprint/zprint {:mvn/version "1.3.0"}}
 
  :aliases
  {:test {:extra-paths ["test"]
-         :extra-deps  {;; rf2-try1x — silent-on-success reporter.
-                       day8/re-frame2-test-quiet {:local/root "../../implementation/test-quiet"}
+         :extra-deps  {day8/re-frame2-test-quiet {:local/root "../../implementation/test-quiet"}
                        io.github.cognitect-labs/test-runner
                        {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
          :main-opts   ["-m" "re-frame.test-quiet.runner"]}

--- a/tools/xray/src/day8/re_frame2_xray/core.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/core.cljs
@@ -29,16 +29,6 @@
   `registry`, ...) remaining as the *internal* seams Xray's own code
   reads. Hosts never need to know which file holds which fn.
 
-  ## Pre-alpha posture
-
-  Every surface this facade exposes is wired end-to-end — no
-  TBD-impl stubs, no documented-warning-emit placeholders. `init!`,
-  `load-theme`, the mount/config re-exports, and the frame picker
-  all route through their respective backing surfaces (the persisted
-  Settings shape, the theme module's CSS-swap site, the mount
-  layer's singleton guards). Future opt-keys that don't yet have a
-  backing surface land here only after their machinery does.
-
   ## What this namespace deliberately does NOT expose
 
   Per `spec/API.md` §What this doesn't expose, the facade carries no
@@ -54,15 +44,8 @@
   (:require [re-frame.core :as rf]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.focus :as focus]
-            ;; Require the INERT install-helper ns, NOT the
-            ;; side-effecting `day8.re-frame2-xray.preload`. Loading
-            ;; `preload` runs its top-level boot block (settings load,
-            ;; handler/collector registration, browser globals,
-            ;; keybinding attach, auto-open); requiring this facade to
-            ;; reach the MANUAL `init!`/`configure!` API must NOT fire
-            ;; full preload behaviour before the host's `configure!`
-            ;; can win. `install` is load-inert; the side-effects fire
-            ;; only when `init!` (below) calls them.
+            ;; Manual startup must remain inert until `init!`, allowing
+            ;; the host to call `configure!` first.
             [day8.re-frame2-xray.install :as install]
             [day8.re-frame2-xray.keybinding :as keybinding]
             [day8.re-frame2-xray.mount :as mount]
@@ -132,7 +115,7 @@
        :density      :compact           ;; / :cosy   (settings persist)
        :buffer-depths {:epoch 50}}      ;; per-frame ring depth
 
-  EP-0002 — the inspected-host opt is `:target-frame`, distinct from
+  The inspected-host opt is `:target-frame`, distinct from
   Xray's OWN frame (`:own-frame`, the `:rf/xray` shell frame where the
   chrome's app-db lives — a fixed singleton, not a per-call opt).
   Omitting `:target-frame` leaves the inspected target UNSELECTED — the
@@ -171,20 +154,12 @@
    (registry/register-xray-handlers!)
    (install/register-trace-collector!)
    (install/register-epoch-collector!)
-   ;; Install the browser-API exports on
-   ;; `window.day8.re_frame2_xray.*` (same call the preload's boot
-   ;; block makes). The palette pop-out fx + the Settings panel-position
-   ;; effect late-bind their mount calls through these exports to break
-   ;; the `mount → shell → palette/settings → mount` require cycle (see
-   ;; palette/events §mount-popout! + settings/effects §late-bind). The
-   ;; manual `init!` path must install the exports so those late-bound
-   ;; actions (palette Ctrl+Enter pop-out, Settings panel-position →
-   ;; fullscreen / back-to-inline, fullscreen, right-rail) fire under it
-   ;; just as they do under the preload path. Idempotent: re-exports
-   ;; the same fn values.
+   ;; The palette and Settings effects resolve mount operations through
+   ;; these globals to avoid a mount/shell require cycle. Manual and
+   ;; preload startup therefore install the same exports.
    (install/install-browser-api-exports!)
    (keybinding/attach!)
-   ;; EP-0002 — select the explicit inspected TARGET frame in
+   ;; Select the explicit inspected target frame in
    ;; Xray's OWN (`:rf/xray`) frame. Absent → leave unselected (the picker
    ;; / mount discovery policy chooses); never a `:rf/default` fallback.
    (when target-frame
@@ -209,7 +184,7 @@
   scrubber / app-db / machine-inspector panels are observing — or
   **`nil` when UNSELECTED**.
 
-  EP-0002 — the inspected target starts UNSELECTED and is
+  The inspected target starts unselected and is
   selected by host config (`init! {:target-frame …}` / `set-target-
   frame!`), the frame picker, or the mount-time discovery policy. It is
   NOT defaulted to `:rf/default`: `:rf/default` is an ordinary id, never
@@ -232,7 +207,7 @@
   `:rf.xray/target-frame` sub and every dependent panel re-fire on the
   standard reactive path.
 
-  EP-0002 — `nil` resets the target to UNSELECTED (the panels render
+  `nil` resets the target to unselected (the panels render
   their no-frame-selected state and the picker prompts a choice). The
   inspected target is never absence-repaired to the ordinary
   `:rf/default` id (Spec 002 §Frame target resolution).
@@ -296,20 +271,13 @@
 ;; sessions that want to flip one knob without writing the full map.
 
 (def configure!
-  "Top-level Xray configuration. Every key lives under the
-  `:rf.xray/*` reserved namespace (the `:rf.<tool>/*` convention for
-  re-frame2 tools' boot-time config). The on-box reveal grain is
-  per-tool (EP-0015 issue 7): there is NO single cross-tool toggle.
-
-    `{:rf.xray/editor <kw>}`                — 'Open in editor' preference.
-    `{:rf.xray/layout-host-selector <css>}` — true-inline layout host selector.
-    `{:rf.xray/auto-open? <bool>}`          — default true-inline auto-open.
-    `{:rf.xray/egress-profile <kw>}`        — on-box dev-UI egress profile
-       (`:rf.egress/local-redacted` default / `:rf.egress/local-raw`
-       trusted-local reveal opt-in — EP-0015 per-(tool,frame) grain).
-
-  Future phases extend with theme / buffer keys. Hosts typically call
-  once at boot, before Xray auto-opens. Returns nothing."
+  "Top-level Xray boot configuration. Keys live under the `:rf.xray/*`
+  reserved namespace and cover editor integration, layout and launch,
+  keybindings, egress, persisted settings defaults, filters, render
+  policy, trace sampling, and logging. See
+  `day8.re-frame2-xray.config/configure!` for the complete key inventory
+  and precedence rules. Hosts normally call this once before Xray
+  auto-opens. Returns nothing."
   config/configure!)
 
 (def set-auto-open!

--- a/tools/xray/src/day8/re_frame2_xray/drop_in.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/drop_in.cljc
@@ -1,5 +1,5 @@
 (ns day8.re-frame2-xray.drop-in
-  "Drop-in mode for non-re-frame2 hosts (v1.1).
+  "Trace-source adapter for hosts that do not emit re-frame2 traces.
 
   Xray's primary integration is as a dev-tool inside a re-frame2 app:
   the host's `re-frame.trace/emit!` calls fan trace events out to
@@ -14,7 +14,7 @@
   state-machine harness — anything that can produce events shaped
   per [`spec/Spec-Schemas.md` §`:rf/trace-event`](../../../../spec/Spec-Schemas.md#rftrace-event)
   — can plug into Xray by attaching its trace source here. The
-  panels (Event detail, Trace, App-db diff, machine inspector, …)
+  panels (Epoch, Trace, App-db diff, Machine, ...)
   light up against the host's events exactly as they would against a
   native re-frame2 event-bundle.
 
@@ -76,7 +76,7 @@
   - It does NOT change Xray's ingest filters: the privacy gate
     still suppresses `:sensitive? true` events unless the host has
     opted in via `(xray-config/configure! {:rf.xray/egress-profile
-    :rf.egress/local-raw})` — the EP-0015 trusted-local reveal grain.
+    :rf.egress/local-raw})`.
   - It does NOT mutate the host's state. The host owns its event
     source; the drop-in is a one-way pump from there into Xray's
     buffer.

--- a/tools/xray/src/day8/re_frame2_xray/focus.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/focus.cljc
@@ -1,28 +1,10 @@
 (ns day8.re-frame2-xray.focus
-  "Host-facing focus API for an embedded Xray surface (rf2-crtmq).
+  "Host-facing focus API for an already-mounted Xray surface.
 
-  ## What this owns
-
-  A small, **data-shaped focus command** a host (Story) sends to focus
-  an already-embedded Xray surface onto a specific panel + epoch +
-  event-bundle + app-db path — driven from a narrative beat, a failed
-  assertion, a canvas inspect command, or a docs/test link.
-
-  This is the channel the StoryUI decision register
-  (`ai/findings/StoryUI/06-open-decisions.md` §D3 \"Story-To-Xray Focus
-  API\") settled on: a small one-way focus command, NOT a broad two-way
-  embedding protocol.
-
-  ## The ownership boundary (load-bearing)
-
-  - **Story owns the narrative / action** — it constructs the command
-    (which panel, which epoch, which path) and the `:source` provenance
-    (which variant / assertion / beat triggered it), then calls
-    `focus!`.
-  - **Xray owns the diagnostic state + panel semantics** — it receives
-    the command and routes it to the canonical `:rf.xray/*` spine / tab
-    / path / frame events. Xray decides what \"focus the app-db panel on
-    epoch 42 at path [:checkout :state]\" *means*.
+  A host supplies a small data command naming an observed frame, panel,
+  epoch or event bundle, app-db path, and optional opaque provenance.
+  The host owns the intent; Xray owns how that intent maps onto its frame,
+  spine, tab, and path events.
 
   No second Xray runtime model is introduced. Every field in the
   command maps to an EXISTING canonical write surface:
@@ -35,20 +17,13 @@
   | `:dispatch-id` | `:rf.xray/focus-event <id> <frame>` | `spine.cljs` |
   | `:path`        | `:rf.xray/focus-slice-path <path>` | `app_db_diff_events.cljs` |
 
-  This namespace is a thin composer over those events — it adds no new
-  app-db slots, no new spine model, no new panel state. It mirrors the
-  posture of `day8.re-frame2-xray.runtime` (the MCP read/mutate seam):
-  a clean, host-agnostic, data-in / data-out façade over surfaces that
-  already exist.
+  This namespace only composes those events. It adds no app-db slots,
+  spine model, or panel state.
 
   ## Separate from open-full-Xray
 
-  Mounting / opening / popping-out the whole Xray shell stays in
-  `mount.cljs` (`open!` / `open-overlay!` / `popout!`). This namespace
-  is purely *focus-a-panel-on-a-beat* — it assumes the Xray surface is
-  already embedded (Story mounts it via the locked render-shell
-  contract). Per §D3 rule: \"opening/pop-out of the full Xray shell is
-  current; focusing a panel/beat/path is [the new surface].\"
+  Mounting, opening, and popping out the shell remain in `mount.cljs`.
+  This API assumes a host has already mounted Xray.
 
   ## Command shape (the contract)
 
@@ -70,7 +45,7 @@
   a beat that only cares about \"show me the trace\" sends
   `{:panel :trace}`.
 
-  The `:source` map is host-agnostic provenance. §D3's worked shape:
+  The `:source` map is host-agnostic provenance. For example:
 
       {:kind        :story/assertion
        :variant/id  :story.checkout/form/submitted
@@ -81,16 +56,12 @@
   it likes there. This is what makes the command host-agnostic: the
   channel carries Story's intent without Xray knowing it's Story.
 
-  ## Pure core + thin CLJS shell
-
   `focus-command->dispatches` is a pure, `.cljc`, JVM-runnable
   translation from a command map to the ordered vector of event
   vectors. The CLJS `focus!` fn (below, reader-conditional) resolves
   the Xray frame and fires them via `re-frame.core/dispatch`. The pure
   core is what the test corpus drives; the CLJS shell is the runtime
   glue.
-
-  ## Why ordered dispatches
 
   The events are dispatched in a fixed order — `:frame` FIRST (so the
   per-frame epoch ring is re-seeded before any epoch / event-bundle pin
@@ -118,7 +89,7 @@
 ;; rejects a typo'd panel with a useful diagnostic rather than silently
 ;; selecting a tab that renders the unknown-tab stub.
 ;;
-;; ## Single source of truth: the live L4 tab registry (rf2-1sddi6 / rf2-7ed9ms)
+;; ## Single source of truth: the live L4 tab registry
 ;;
 ;; `valid-panels` below MIRRORS the live Dynamic L4 tab registry
 ;; (`panel-registry/tab-ids-for-mode :dynamic`) — the SAME inventory the
@@ -149,20 +120,13 @@
   label is. Host callers who prefer the display-noun spelling can pass
   `:routes` (normalised to `:routing` via `panel-aliases`).
 
-  History: the Issues tab was removed per rf2-gbz39 (Option (c) —
-  issues surface inline in the Epoch + the L2 event-row pink-wash + the
-  always-on issues ribbon signal), so `:issues` is no longer a
-  focusable panel. `:derivation-graph` (EP-0014 prop-3, rf2-9ett2d) and
-  `:module-view` (EP-0013, rf2-wtg9z4) are the runtime-structure tabs.
-
   This set MIRRORS `panel-registry/tab-ids-for-mode :dynamic` (the live
-  registry) — see the ns comment above; a cross-check test fails the
-  build if they drift (rf2-1sddi6 / rf2-7ed9ms)."
+  registry); a cross-check test fails the build if they drift."
   #{:epoch :app-db :views :trace :machines :routing
     :resources :derivation-graph :module-view})
 
 ;; ---------------------------------------------------------------------------
-;; Host-friendly panel aliases (rf2-7ed9ms finding 1)
+;; Host-friendly panel aliases
 ;; ---------------------------------------------------------------------------
 ;;
 ;; A host (Story beat, docs link, assertion) naturally reaches for the
@@ -199,7 +163,7 @@
   `:rf.xray/*` event vectors. JVM-runnable; no re-frame runtime,
   no app-db. The CLJS `focus!` fn fires these in order.
 
-  `command` is the §D3 shape (every field optional):
+  Every command field is optional:
 
       {:frame :checkout
        :panel :app-db

--- a/tools/xray/src/day8/re_frame2_xray/host_registry.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/host_registry.cljs
@@ -1,10 +1,9 @@
 (ns day8.re-frame2-xray.host-registry
-  "Host-app registry reads that survive Xray running in its OWN image-loaded
-  frame (EP-0023 §Xray Beside The Target).
+  "Host-app registry reads for Xray's image-loaded frame.
 
   ## Why this exists
 
-  Xray seats in its OWN image-loaded `:rf/xray` frame
+  Xray runs in its own image-loaded `:rf/xray` frame
   (`image_view_reads/seat-xray-frame!` → `rf/make-frame {:id :rf/xray :images
   [(xray-image)]}`). When a `:rf.xray/*` subscription RECOMPUTES, the framework
   binds the registrar resolution to that frame's sealed image generation for the
@@ -12,21 +11,21 @@
   `re-frame.live-frame/call-with-frame-resolution` around every subscribe build
   targeting an image-loaded frame). So a bare `(rf/registrations :route)` /
   `(rf/handler-meta :event id)` call INSIDE a sub computation resolves through
-  Xray's OWN image resolver — which selects ONLY Xray's `:rf.xray/*` namespaces
+  Xray's image resolver — which selects only Xray's `:rf.xray/*` namespaces
   (`xray-image`'s `:select-ns :include`), NOT the host app's registrations. The
-  inspector would then see only its OWN handlers / routes / resources, never the
-  HOST app's — the Routing panel renders an empty route table, the palette lists
+  inspector would then see only its own handlers, routes, and resources, never the
+  host app's — the Routing panel renders an empty route table, the palette lists
   only Xray's own handlers, the Resources panel loses the host's resource
   registry.
 
   This is correct framework behaviour (a frame resolves its own image), and
   exactly the wrong thing for an INSPECTOR: Xray reads the registry of the
-  INSPECTED app — the process-global registrar — not its own image's resolver.
+  inspected app — the process-global registrar — not its own image's resolver.
 
   ## The mechanism
 
   The process-global registrar atom (`re-frame.registrar/kind->id->metadata`) is
-  read DIRECTLY, BYPASSING any bound `*generation*`. A TOOL reads the owning
+  read directly, bypassing any bound `*generation*`. A tool reads the owning
   `re-frame.registrar` namespace directly, just as it already reads
   `re-frame.frame` / `re-frame.live-frame` (bundle isolation forbids
   `implementation/` requiring from `tools/`, not the reverse). The process-global

--- a/tools/xray/src/day8/re_frame2_xray/install.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/install.cljs
@@ -1,59 +1,19 @@
 (ns day8.re-frame2-xray.install
-  "Side-effect-free Xray install helpers (rf2-5w06uu).
+  "Load-inert install primitives shared by manual and preload startup.
 
-  This namespace holds the *callable* install primitives Xray's two
-  install paths share — the trace/epoch collector registrations and
-  the browser-API export installer — WITHOUT performing any work at
-  namespace-load time. Loading this ns is inert; the side-effects fire
-  only when a caller invokes one of the helpers below.
+  Requiring this namespace performs no installation. `core/init!` calls
+  these functions explicitly; `preload` calls them from its dev-only boot
+  block. This separation lets a manual host require and configure Xray
+  before any listeners, browser globals, keybindings, or mounts exist.
 
-  ## Why this split exists
-
-  Before rf2-5w06uu the foundation registrations lived in
-  `day8.re-frame2-xray.preload`, whose top-level
-  `(when interop/debug-enabled? …)` boot block runs them on load. But
-  the user-facing facade `day8.re-frame2-xray.core` requires `preload`
-  to reach `init!`'s registration helpers — so a host that chose the
-  *manual* `require core → configure! → init!` path got the full
-  preload behaviour (settings load, handler/collector registration,
-  browser globals, keybinding attach, auto-open) merely by requiring
-  `core`, defeating `configure!`-before-auto-open ordering and boot
-  flags like `:rf.xray/auto-open? false`.
-
-  Splitting the inert helpers here lets:
-
-  - `core` require *this* ns (load-inert) instead of `preload`, so
-    requiring the manual facade no longer fires preload side-effects.
-  - `preload` require this ns and call these helpers from its
-    side-effecting boot block — the zero-config `:devtools/preloads`
-    path keeps auto-installing exactly as before.
-
-  ## Production posture
-
-  As with the preload, the registration/install work is no-op-safe in
-  production: the trace surface elides via `interop/debug-enabled?`,
-  the browser-API export guards on `js/window`, and the framework's
-  epoch listener registration is itself a no-op when the epoch artefact
-  is absent. But the right answer is still to keep Xray out of
-  production builds via shadow-cljs's `:dev`-only `:devtools` block."
+  The helpers register the trace and epoch collectors and expose the
+  browser launch API. Each operation is idempotent; the browser export is
+  a no-op without `js/window`, and the preload owns the debug-build gate."
   (:require [goog.object :as gobj]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            ;; rf2-qwm0a / rf2-rfid2x — the public-tooling listener
-            ;; surface (`register-listener!` etc.) lives in the
-            ;; per-stream HOME namespaces for production-DCE reasons.
-            ;; Per the Tool-Pair §"Facade vs home-namespace verb — the
-            ;; DCE tier rule": canonical devtools attach via the home
-            ;; verbs, NOT the `re-frame.core` facade, because a tool
-            ;; preload MUST NOT require `re-frame.core` into a
-            ;; production build. Xray's trace-collector targets
-            ;; `re-frame.trace.tooling/register-listener!` and its
-            ;; epoch-collector targets
-            ;; `re-frame.epoch/register-epoch-listener!` directly. The
-            ;; two consumers of this ns (preload + core) are both
-            ;; dev-only, so these requires are excluded from production
-            ;; bundles. `re-frame.epoch` is a hard Xray dep (deps.edn),
-            ;; so the artefact is always present in an Xray build.
+            ;; Listener registration uses each stream's home namespace so
+            ;; the dev-only tooling surface remains independently elidable.
             [re-frame.trace.tooling :as trace-tooling]
             [re-frame.epoch :as epoch]
             [day8.re-frame2-xray.mount :as mount]
@@ -70,11 +30,7 @@
   (atom false))
 
 (defonce ^:private epoch-cb-registered?
-  ;; Idempotency sentinel for the epoch-callback registration. Same
-  ;; rationale as `trace-cb-registered?`. Phase 3 (rf2-t53ze) — the
-  ;; Time Travel panel needs a per-settle pump from
-  ;; `re-frame.epoch/register-epoch-listener!` into Xray's app-db so the
-  ;; scrubber's subscriptions re-fire when the framework appends an epoch.
+  ;; The Time Travel panel needs one per-settle pump into Xray's app-db.
   (atom false))
 
 (defn register-trace-collector!
@@ -100,27 +56,10 @@
   `:rf.xray/epoch-history` sub then re-fires off the standard
   app-db-write reactive path.
 
-  ## Pre-mount guard (rf2-1barg)
-
-  The preload runs at app boot but `:rf/xray` is lazy-registered by
-  `mount.cljs/open!` on the first Ctrl+Shift+C keypress. Host
-  dispatches that fire BEFORE the user opens Xray would otherwise
-  flow through this cb and dispatch into a frame that doesn't yet
-  exist — the runtime would emit `:rf.error/frame-destroyed` and the
-  record would be lost. The `frame/frame :rf/xray` guard makes
-  pre-mount cbs a silent no-op; `ensure-xray-frame!` seeds the
-  panel's `:epoch-history` slot with the framework's current
-  `(rf/epoch-history target)` snapshot at first open, so the
-  pre-mount window's records still surface.
-
-  Idempotent via the `epoch-cb-registered?` sentinel. Registers via the
-  epoch home verb `re-frame.epoch/register-epoch-listener!` (canonical
-  devtools attach via the home-namespace verbs, per [Tool-Pair §Facade
-  vs home-namespace verb — the DCE tier rule]; the `re-frame.core`
-  facade is not required into this dev-only namespace). `re-frame.epoch`
-  is a hard Xray dependency, so the artefact is always on the classpath
-  in an Xray build; the whole foundation block is `debug-enabled?`-gated
-  so the registration is elided in production regardless."
+  Before the `:rf/xray` frame is mounted, the callback deliberately does
+  nothing. First mount seeds history from the framework ring, so records
+  produced during that window are still visible. Idempotent via the
+  `epoch-cb-registered?` sentinel."
   []
   (when (compare-and-set! epoch-cb-registered? false true)
     (epoch/register-epoch-listener! :rf.xray/epoch-collector

--- a/tools/xray/src/day8/re_frame2_xray/mount.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/mount.cljs
@@ -1,22 +1,20 @@
 (ns day8.re-frame2-xray.mount
-  "DOM-side mount machinery for the Xray shell. Per rf2-tijr Option C +
-  spec/007-UX-IA.md §The default landing view:
+  "DOM-side lifecycle for Xray's inline, overlay, and pop-out shells.
 
   - The preload auto-opens the shell into the app-provided
     `[data-rf-xray-host]` layout host once the substrate adapter is
     ready. This is true inline layout: Xray participates in normal
     flex/grid flow on the right, and the app stays visible/clickable to
     the left.
-  - Subsequent presses toggle the container's `display` between
-    `block` and `none` (a CSS-only show/hide; per the spec a re-mount
-    would discard internal state and miss the <80ms toggle target).
+  - Subsequent toggles change CSS visibility without remounting, so
+    panel state and focus survive hide/show cycles.
   - All state is `defonce`-guarded so shadow-cljs `:after-load` does
     not re-attach listeners or re-mount the shell.
 
   ## Why we use the substrate adapter's render fn
 
-  Per rf2-tijr Xray is substrate-agnostic: the host may be running
-  Reagent, UIx, or Helix. The substrate adapter's `:render` slot is
+  Xray is substrate-agnostic: the host may be running Reagent, UIx, or
+  Helix. The substrate adapter's `:render` slot is
   the canonical mount path (`rf/render render-tree mount-point opts`);
   every adapter's impl produces an unmount fn on first call. Xray
   calls that path so the shell mounts via the adapter the host
@@ -29,21 +27,15 @@
   contains no production-elision logic of its own — the call-site
   gate is sufficient.
 
-  ## Lazy `:rf/xray` frame registration (rf2-in6l2)
+  ## Lazy `:rf/xray` frame registration
 
   The Xray shell wraps every panel in `[rf/frame-provider {:frame
   :rf/xray} …]` and every panel is `reg-view`-wrapped so subscribes
   resolve through the React-context tier to the named frame. For that
-  routing to land in the *registered* `:rf/xray` frame (not chain-
-  resolve to `:rf/default`), the frame must exist — and the preload
-  can't register it because the preload runs before the host's
-  `rf/init!` has installed a substrate adapter, and `reg-frame` writes
-  trace events that need a running adapter to be reactive (per rf2-e9s81
-  the preload-time `reg-frame :rf/xray` path is the one that produced
-  the iw5ym regression). The first Ctrl+Shift+C keypress fires AFTER
-  `rf/init!`, so `open!` is the canonical place to call `reg-frame` —
-  the call is idempotent (surgical update on re-register) so subsequent
-  toggles are no-ops on this axis."
+  routing to land in the registered `:rf/xray` frame, the frame must
+  exist. The preload runs before the host installs a substrate adapter,
+  so first mount performs registration and seeding after adapter
+  readiness. The operation is idempotent."
   (:require [re-frame.core :as rf]
             [re-frame.substrate.adapter :as substrate-adapter]
             [day8.re-frame2-xray.config :as config]
@@ -70,13 +62,8 @@
   ;;    :unmount   (fn [] ...)         ; substrate adapter unmount fn
   ;;    :visible?  <boolean>
   ;;    :mode      <:inline|:overlay>}
-  ;; Per rf2-zkfiz Q1-8 the `:mode` enumeration is exactly the two
-  ;; values written by `open!` (`:inline`) and `open-overlay!`
-  ;; (`:overlay`). The popout shell lives in `popout-state` below
-  ;; with `:mode :popout` — the two singletons do NOT share a `:mode`
-  ;; vocabulary. Earlier shapes carried a `:docked` variant (the
-  ;; body-padding dock surface); that mode was removed under
-  ;; rf2-sbfb7 together with the `dock!` / `undock!` API.
+  ;; The in-page singleton uses `:inline` or `:overlay`. Pop-out state is
+  ;; tracked separately and always uses `:popout`.
   ;; Nil before first mount; never re-allocated across reloads thanks
   ;; to defonce.
   (atom nil))
@@ -84,10 +71,7 @@
 (defonce ^:private popout-state
   ;; Optional second-window mount. Shape mirrors mount-state plus
   ;; `:window`, `:ok?`, `:overlay-node`, and `:watchdog-id`. The
-  ;; opener runtime remains the source of truth. Per rf2-zkfiz Q1-8
-  ;; the `:mode` slot is always `:popout` — the popout never
-  ;; participates in the `mount-state` `:inline`/`:overlay`
-  ;; enumeration above. Per rf2-h3ekl the `:overlay-node` slot holds
+  ;; opener runtime remains the source of truth. The `:overlay-node` slot holds
   ;; the opener-gone overlay element (sibling to the shell root) and
   ;; `:watchdog-id` holds the setInterval token that polls
   ;; `window.opener.closed`.
@@ -100,8 +84,7 @@
   (atom {:started? false :attempts 0}))
 
 (declare ensure-xray-frame!)
-;; rf2-czcg5 — `install-fx!` (below) registers `:rf.xray.fx/popout-shell`
-;; whose handler calls `popout!`, which is defined later in this ns.
+;; `install-fx!` registers a handler that calls this later definition.
 (declare popout!)
 
 (defn mounted?
@@ -131,11 +114,11 @@
 
 (defn- remove-stale-root!
   "Defensive cleanup before a fresh mount allocates `#rf-xray-root`.
-  The singleton `mount-state` precludes coexistence today (both
+  The singleton `mount-state` precludes coexistence (both
   `open!` and `open-overlay!` short-circuit when the singleton is
   populated), but the DOM id remains a single shared name across
-  `:inline` and `:overlay` modes. Per rf2-zkfiz Q1-4 the create fns
-  evict any orphaned node first so a stale `#rf-xray-root` left
+  `:inline` and `:overlay` modes. Create functions evict any orphaned
+  node first so a stale `#rf-xray-root` left
   behind by a partially-failed teardown cannot survive into a fresh
   mount cycle. No-op when the document has no such node."
   []
@@ -188,7 +171,7 @@
   (reset! diagnostic-state {:ok? true :reason :auto-open-disabled})
   nil)
 
-;; ---- layout-host display snapshot (rf2-4itwg) ----------------------------
+;; ---- layout-host display snapshot ---------------------------------------
 ;;
 ;; Toggle-off must collapse the layout host's flex/grid slot too, not just
 ;; hide the mount root. The previous `display:none` on `#rf-xray-root`

--- a/tools/xray/src/day8/re_frame2_xray/panels.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels.cljs
@@ -2,14 +2,11 @@
   "Per-panel mount surface. **Internal-but-stable**, NOT a v1.0
   host-facing embed contract.
 
-  Every Xray panel is independently mountable: a host can mount one
-  panel in isolation without the surrounding 4-layer shell, without
-  sibling panels, and without any shell-owned chrome state. This
-  surface is the load-bearing seam the 4-layer shell composes through
-  and that the test suite mounts panels through; it also lets Xray be
-  embedded inside Story, inside the Scittle playground (option-c
-  progressive disclosure), inside custom debugging configurations, and
-  inside the docs / guide / examples surface.
+  Each facade enumerated by `panel-enum` can be mounted without the
+  surrounding 4-layer shell or sibling panels. The shell and tests use
+  this seam, and development hosts may use it for focused embeds. Graph
+  and Modules are L4-only tabs and are not part of the standalone mount
+  inventory.
 
   **Status: internal-but-stable, not a host-facing v1.0 embed
   contract.** The mount fns are stable (the shell + tests depend on
@@ -25,8 +22,7 @@
 
   ## The surface
 
-  Per `tools/xray/spec/008-Embedding-Contract.md` every panel exposes
-  a mount fn:
+  The standalone facade inventory is:
 
       (mount-epoch-panel!      mount-point opts) → unmount-fn
       (mount-app-db-diff!      mount-point opts) → unmount-fn
@@ -76,12 +72,12 @@
 
   1. Calls `(registry/register-xray-handlers!)` — idempotent, registers
      every panel's subs + events + fxs under `:rf.xray/*`.
-  2. Calls `(rf/reg-frame :rf/xray {})` — idempotent, ensures the
-     state-isolation frame exists.
-  3. Wraps the panel's `Panel` (or equivalent) view in
-     `[rf/frame-provider {:frame :rf/xray} [<Panel>]]` so descendant
-     subscribes / dispatches re-anchor to `:rf/xray` regardless of
-     the host's React-context.
+  2. Calls `mount/ensure-xray-frame!` so the state-isolation frame exists
+     and first-mount seed hooks have run.
+  3. Wraps the panel's `Panel` (or equivalent) view in a
+     `rf/frame-provider` for `opts :frame` (default `:rf/xray`) so
+     descendant subscribes and dispatches do not inherit the host's
+     ambient React context accidentally.
   4. Delegates to `substrate-adapter/render` with the wrapped tree +
      the supplied mount-point. The substrate adapter is the host's
      (installed via `rf/init!`); the panels are substrate-agnostic
@@ -183,11 +179,8 @@
   populated, and the user sees blank inputs even though the host has
   been dispatching events.
 
-  `ensure-xray-frame!` is idempotent (a `seeded-frame-ids` run-once
-  guard on the hook fan-out per rf2-n4p5it + reg-frame's surgical-
-  update-on-re-register semantics per Spec 002 §reg-frame) so multiple
-  panel mounts collapse to one seed pass + zero re-registrations
-  across shadow-cljs reloads."
+  `ensure-xray-frame!` is idempotent, so multiple panel mounts and
+  shadow-cljs reloads collapse to one seed pass."
   []
   (registry/register-xray-handlers!)
   (mount/ensure-xray-frame!))

--- a/tools/xray/src/day8/re_frame2_xray/preload.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/preload.cljs
@@ -18,7 +18,7 @@
      `console.error` and the inspectable Xray status API; startup is
      not blocked.
 
-  All three are idempotent: re-loading the namespace (shadow-cljs
+  All four are idempotent: re-loading the namespace (shadow-cljs
   `:after-load`) re-runs the side-effects but each step
   `defonce`-guards its own state. The net effect is no double-
   registration, no double-listener, no shell re-mount.
@@ -38,52 +38,23 @@
   Xray is dev-tier per tools/README.md's bundle-isolation contract.
   But if it does happen, the trace-callback registration is a no-op
   in production (the framework's trace surface elides via
-  `interop/debug-enabled?`), the keybinding listener attaches but
-  finds an empty `current-adapter` when the user hits Ctrl+Shift+C,
-  and the mount fails silently. The fallback is graceful, not
-  catastrophic — but the right answer is to keep the preload out of
-  production builds via shadow-cljs's `:dev`-only `:devtools` block."
+  `interop/debug-enabled?`). The right contract is to keep this preload
+  in shadow-cljs's dev-only `:devtools` block; the remaining guards make
+  an accidental production load inert rather than useful."
   (:require [re-frame.interop :as interop]
-            ;; Pull `re-frame.epoch` into the dev classpath via the
-            ;; Xray preload. The Xray Time Travel panel
-            ;; reads epoch records via `rf/epoch-history` and its
-            ;; epoch-collector attaches via the epoch home verb
-            ;; `re-frame.epoch/register-epoch-listener!` (per the Tool-Pair
-            ;; DCE tier rule; see install.cljs). When the host example
-            ;; omits the artefact (the counter example does, by
-            ;; design — it's the smallest reference app), the wrappers
-            ;; degrade silently to `[]` / no-op and the panel sits
-            ;; empty even though the user has just opened Xray
-            ;; specifically to look at epoch history. Loading the
-            ;; epoch artefact as part of Xray's preload anchors the
-            ;; integration: every Xray-enabled build has working
-            ;; time-travel without the host having to add a separate
-            ;; dependency. Bundle-isolation still holds — Xray's
-            ;; preload is dev-only and is excluded from production
-            ;; bundles by the `:devtools/preloads` shadow-cljs gate.
+            ;; Time Travel requires the epoch listener and history API;
+            ;; deps.edn makes the artefact part of every Xray build.
             [re-frame.epoch]
             [day8.re-frame2-xray.config :as config]
-            ;; The inert, callable install helpers (trace/epoch
-            ;; collector registration + browser-API exports) live in
-            ;; `day8.re-frame2-xray.install`, a namespace whose LOAD
-            ;; performs no side-effects. The preload's side-effecting
-            ;; boot block below calls them; the manual facade (`core`)
-            ;; requires `install` directly, so requiring the facade
-            ;; does not drag in this preload's load-time side-effects.
+            ;; Shared installation functions are load-inert; only this
+            ;; preload's boot block and explicit `core/init!` invoke them.
             [day8.re-frame2-xray.install :as install]
             [day8.re-frame2-xray.keybinding :as keybinding]
             [day8.re-frame2-xray.mount :as mount]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.settings.effects :as settings-effects]
-            ;; Pull the Xray-runtime accessor namespace into the
-            ;; preload classpath. The `:require` is the
-            ;; load: `day8.re-frame2-xray.runtime` installs its
-            ;; `js/globalThis.__day8_re_frame2_xray_runtime` sentinel as
-            ;; a top-level side effect (gated on `interop/debug-enabled?`).
-            ;; Any attached MCP server (re-frame2-pair-mcp today) reads
-            ;; that sentinel as its preload probe; the runtime rides
-            ;; Xray-the-panel's preload, so no separate `:preloads`
-            ;; entry is required on the consumer side.
+            ;; Loading the runtime installs its debug-gated session
+            ;; sentinel for agent discovery; no second preload is needed.
             [day8.re-frame2-xray.runtime]))
 
 ;; ---- install-helper re-exports -------------------------------------------
@@ -113,18 +84,13 @@
 
 ;; ---- side-effecting boot -------------------------------------------------
 
-;; Loading this namespace runs the foundation's three side effects.
-;; Idempotency: each side-effect is self-guarded (see keybinding/
-;; attach!, registry/register-xray-handlers!, the trace-cb sentinel
-;; above), so the load order is `:after-load`-safe.
+;; Loading this namespace runs the installation sequence. Each operation
+;; is self-guarded, so reloads do not duplicate listeners or mounts.
 ;;
 ;; The whole block is gated on `interop/debug-enabled?` so production
 ;; bundles compiled with `(set! goog.DEBUG false)` strip the entire
 ;; preload's side-effects via Closure DCE. The keybinding listener,
-;; the trace-callback registration, and the Xray registry all elide
-;; together — production builds carry zero Xray runtime cost beyond
-;; the unused require chain (which itself is candidates for further
-;; tree-shaking).
+;; collectors, registry, settings effects, and auto-open all elide together.
 
 (when interop/debug-enabled?
   ;; Settings persistence — load BEFORE registry install

--- a/tools/xray/src/day8/re_frame2_xray/runtime.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/runtime.cljs
@@ -1,117 +1,56 @@
 (ns day8.re-frame2-xray.runtime
-  "Injected-runtime namespace exposing Xray's read/mutate accessors
-  to AI agents (rf2-8xzoe.4 / F-4, rf2-crhr8).
+  "Browser-side read and mutation accessors for agent integrations.
 
-  Lives on the browser side of the stdio JSON-RPC pipe. Rides
-  Xray-the-panel's `:devtools/preloads` (see `preload.cljs`'s require
-  list) so a consumer app that already loads Xray-the-panel
-  automatically carries the runtime — no separate preload entry.
+  The Xray preload installs this namespace in the application tab.
+  `tools/re-frame2-pair-mcp/` invokes its public functions through
+  shadow-cljs evaluation; the runtime itself has no dependency on an MCP
+  server or transport. The accessor contract is documented in
+  [`API.md` §Xray runtime API](../../spec/API.md).
 
-  Per rf2-hvl1g (closure 2026-05-19) there is no dedicated `xray-mcp`
-  jar; AI agents reach this runtime via `tools/re-frame2-pair-mcp/`
-  (which can read this ns via `eval-cljs`). The accessors below are
-  the framework-published Xray runtime API.
-
-  ## What this namespace is
-
-  Tool-shaped accessors (see [`API.md` §Xray runtime API](../../spec/API.md))
-  rendered as EDN forms addressed at
-  `day8.re-frame2-xray.runtime/<accessor>`; an MCP server (today
-  `tools/re-frame2-pair-mcp/`) renders the form against the nREPL
-  socket, shadow-cljs evaluates each form in the browser tab, and the
-  return value comes back over the bencode-framed channel.
-
-  Plus three load-bearing supports:
+  Three values support the cross-process contract:
 
   - `session-id` — random UUID per preload load. The MCP-server-side
     preload probe reads either this CLJS var or its
-    `js/globalThis.__day8_re_frame2_xray_runtime` mirror to confirm
-    the runtime landed. A full page refresh wipes both — the next
-    `discover-app` tool call reports `:reason :runtime-not-preloaded`
-    with a setup hint.
+    `js/globalThis.__day8_re_frame2_xray_runtime` mirror to confirm that
+    the preload is present. A full refresh creates a new session.
   - `*current-origin*` — `^:dynamic` var holding the dispatch `:origin`
     opt the runtime stamps onto every mutation it performs (surfacing on
-    the trace bus as the `:rf.event/origin` tag);
-    `current-origin` (no earmuffs) is the plain read accessor that
-    returns it. The default `:xray-mcp` is grandfathered from the
-    original xray-mcp design; revising the default to a more accurate
-    tag (e.g. `:xray-runtime`) is tracked separately as a follow-on.
-    The MCP server is expected to rebind `*current-origin*` for the
-    synchronous extent of an eval'd form to its own `:origin`
-    identifier.
+    the trace bus as `:rf.event/origin`. A caller may rebind it for the
+    synchronous extent of an evaluated mutation.
   - `health` — one-call summary used by `discover-app`. Side-effect-free
     here; the runtime registers no listeners on its own.
 
-  ## What this namespace is NOT
-
-  - Not a new framework registry. Every accessor below routes through
-    an existing `re-frame.core/*` surface. We add no new dispatch
-    types, no new effect substrates, no new component substrates.
-  - Not a re-frame2-pair-mcp port. The accessor surface is shaped to
-    the Xray-specific surfaces (trace buffer, epoch history,
-    app-db-diff, machine-state) rather than to re-frame2-pair-mcp's
-    own tool shapes.
-  - Not a streaming substrate. The runtime exposes
-    `register-listener!` / `register-epoch-listener!` indirection via
-    re-frame.core, plus a thin `current-subscriptions` accessor for
-    the diagnostic; per-tick queue / overflow bookkeeping lives on
-    the MCP-server side.
+  Every accessor delegates to existing framework or Xray projection
+  surfaces. This namespace owns no registry, queue, transport, or parallel
+  state model; streaming and backpressure belong to the caller.
 
   ## Why the install side-effect block is gated on `debug-enabled?`
 
-  Per Xray-the-panel's preload, the framework's trace surface elides
-  in production builds (`re-frame.interop/debug-enabled?` false). The
-  runtime's sentinel installation is gated the same way so a stray
-  production load (which is a configuration mistake but should fail
-  gracefully) is a no-op rather than a `js/globalThis` pollution.
-
-  ## Cross-side coupling is one-way
-
-  The MCP server depends on the accessor signatures below (the
-  contract); the runtime is independent of any server. Xray-the-panel
-  loads this ns without an MCP server running, and any MCP consumer
-  (re-frame2-pair-mcp today) can attach later without the runtime
-  needing to know."
+  The framework trace surface and the global session sentinel are both
+  gated by `re-frame.interop/debug-enabled?`, so an accidental production
+  load is inert."
   (:require [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.machines :as machines]
-            ;; rf2-qwm0a: trace-buffer (and the rest of the listener +
-            ;; ring-buffer surface) lives in re-frame.trace.tooling, not
-            ;; re-frame.trace. CLJS deliberately omits `rf/<name>` aliases
-            ;; for these so production counter bundles DCE the tooling
-            ;; sibling wholesale; Xray's runtime is dev-only (rides the
-            ;; panel's :devtools/preloads), so requiring the tooling ns
-            ;; directly here is bundle-isolation-safe.
+            ;; Ring-buffer inspection is a tooling-tier dependency; the
+            ;; event/frame vocabulary remains on the trace contract ns.
             [re-frame.trace.tooling :as trace-tooling]
-            ;; rf2-7737vq: the canonical RAW trace-event frame reader
-            ;; (`re-frame.trace/trace-event-frame`). A plain public defn on
-            ;; the trace contract ns (NOT a facade export); requiring it
-            ;; here is the bundle-isolation-safe dev-tier dependency the
-            ;; trace tooling sibling above already establishes.
             [re-frame.trace :as trace]
             [re-frame.interop :as interop]
-            ;; rf2-uv2q2: the canonical Editscript-A* diff engine. Used by
-            ;; get-app-db-diff to project the changed-paths slice diff its
-            ;; docstring promises ({:added :removed :changed}) instead of
-            ;; egressing two whole app-db snapshots.
+            ;; Runtime diff reads return the same changed-path projection
+            ;; as the human-facing App-DB panel.
             [day8.re-frame2-xray.diff.engine :as diff-engine]
             ;; Spec 016 §Xray and AI tooling — the resource-accessor
             ;; projection algebra (registry rows, instance/work-ledger
             ;; rows, lifecycle timeline, invalidation graph, and the
             ;; filter axes). Pure-data + JVM-portable; carries the
             ;; in-panel privacy summaries. The off-box egress here adds
-            ;; the framework `egress-value` walker on top. Decoupled from
-            ;; the optional resources artefact (reads via the registrar +
-            ;; runtime-db slice; Xray never :requires re-frame.resources).
+            ;; the framework `egress-value` walker on top. This accessor
+            ;; reads the registrar and runtime-db slice rather than calling
+            ;; resource implementation namespaces directly.
             [day8.re-frame2-xray.panels.resources-helpers :as resources-helpers]
-            ;; rf2-ku6j74: `get-handlers`' unnarrowed sweep must walk the
-            ;; framework's own closed kind-set, not a hand-maintained
-            ;; shadow list that drifted from it. `re-frame.registrar` is the
-            ;; same core artefact `re-frame.core` already pulls in, so
-            ;; requiring it directly here (rather than duplicating its
-            ;; kinds) is bundle-isolation-safe — mirrors the established
-            ;; `tools/story` pattern of reading `re-frame.registrar/kinds`
-            ;; straight off the framework.
+            ;; Handler enumeration reads the framework-owned kind set rather
+            ;; than maintaining an Xray copy.
             [re-frame.registrar :as registrar]))
 
 ;; ---------------------------------------------------------------------------
@@ -208,9 +147,9 @@
   Returns nil when no frame is registered or more than one is registered
   without an explicit pick — callers tag the result accordingly.
 
-  NOTE this does NOT validate an explicit id against the registry — a
+  This does not validate an explicit id against the registry: a
   caller-supplied id is returned verbatim. Accessors guard the
-  explicit-but-unregistered case via `frame-failure` (rf2-xxo3zz) so a
+  explicit-but-unregistered case via `frame-failure` so a
   typo / stale frame id fails with a distinct `:no-such-frame` rather
   than reporting success against a nonexistent frame."
   [explicit]
@@ -221,8 +160,8 @@
                          (first fids)))))
 
 (defn- frame-failure
-  "rf2-xxo3zz — the single frame-resolution guard every read / dispatch /
-  mutation accessor consults before touching a frame. Given the caller's
+  "The single frame-resolution guard every read, dispatch, and mutation
+  accessor consults before touching a frame. Given the caller's
   `explicit` `:frame` arg and the `fid` that `resolve-frame` returned,
   returns a consistent failure map when the frame cannot be operated on,
   or nil when the accessor may proceed:

--- a/tools/xray/src/day8/re_frame2_xray/spine.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/spine.cljs
@@ -1,19 +1,10 @@
 (ns day8.re-frame2-xray.spine
-  "The single-axis spine substrate (rf2-adve5).
+  "The single focus axis shared by Xray's event list and Dynamic panels.
 
-  ## rf2-r9lyy — `:ungrouped` opt-in surface
-
-  By default the spine strips the `:ungrouped` pseudo-event-bundle bucket
-  from every walk (`focusable-event-bundles`) so the bucket is never a
-  focus target — pinning to it degrades the L4 panels into an
-  aggregate look (rf2-fzbrw). Mike's 2026-05-19 closure of rf2-q60yf
-  flipped this from a hard contract to an opt-in: the new
-  `:settings/show-ungrouped?` knob (defaults `false`) reveals the
-  bucket in L2 and lets the user click it to focus. When the flag
-  is `true`, the spine's helpers/reducers include `:ungrouped` in
-  their walks; when `false`, the existing strict behaviour is
-  preserved. Every public arity that previously walked
-  `focusable-event-bundles` gains an additive arity that takes the flag.
+  By default the spine omits the `:ungrouped` pseudo-event-bundle because
+  it has no event vector for event-coupled panels to inspect. Enabling
+  `:settings/show-ungrouped?` includes that bucket in list, focus, and
+  stepping operations for registry-time, REPL, and frameless diagnostics.
 
   Per `tools/xray/spec/018-Event-Spine.md` §6 Spine binding the spine
   sub `:rf.xray/focus` is the one axis every dependent surface reads
@@ -45,14 +36,9 @@
   no mirror slots: the App-DB-diff / Views panels follow the focused
   epoch through `[:focus :epoch-id]` (surfaced by `:rf.xray/focus` →
   `:rf.xray/focus-epoch-id` → `app_db_diff_subs`), and the cross-panel
-  `:rf.xray/focused-event-bundle-detail` composite (relocated to `registry.cljs`
-  post rf2-5gl5r — the retired Event/Handler panel originally owned it;
-  renamed off the retired-panel name per rf2-7ed9ms)
-  reads focus directly off the spine. The former `:selected-dispatch-id`
-  / `:selected-dispatch` / `:selected-epoch-id` mirror slots are all
-  gone (the last, `:selected-epoch-id`, was retired by rf2-uy7nz once
-  every production consumer had migrated to the spine focus epoch via
-  rf2-70tkv) — there is no longer any dual-write."
+  `:rf.xray/focused-event-bundle-detail` composite reads focus directly
+  from the spine. Panels must not introduce mirror selection slots or
+  dual-write focus state."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.defaults :as defaults]
@@ -63,13 +49,9 @@
 ;; ---- pure helpers --------------------------------------------------------
 
 (defn focusable-event-bundles
-  "Per rf2-fzbrw — the spine's invariant is 'one focused event at a
-  time'. The `:ungrouped` bucket produced by `projection/group-by-event`
-  for registry-time emits / frame lifecycle outside a drain / REPL
-  evals carries no event vector and is therefore NOT a valid focus
-  target BY DEFAULT: pinning to it leaves every epoch / app-db /
-  views panel with no event-bundle to render, which degrades into the
-  unwanted 'all subs / all handlers' aggregate look.
+  "Return the event bundles the spine may focus. The `:ungrouped` bucket
+  produced for frameless events is excluded by default because it has no
+  event vector for event-coupled panels to render.
 
   Strip the bucket before any spine walk so:
     - the head/tail boundary predicates align with what the user sees
@@ -79,14 +61,8 @@
     - `compose-focus` cannot resolve an effective dispatch-id to
       `:ungrouped` for a stored slot that was already pointing there.
 
-  ## rf2-r9lyy — opt-in inclusion
-
-  Mike 2026-05-19 closure of rf2-q60yf: pass `show-ungrouped? true`
-  (the 2-arity) to KEEP the bucket. Users debugging SSR / REPL /
-  registry-time flows opt in via Settings → General → Power user
-  → 'Show :ungrouped pseudo-event-bundle events in L2'. When the flag
-  is on, the bucket appears as a focusable target so clicking it
-  populates the downstream panels with its trace events.
+  Pass `show-ungrouped? true` to include the bucket for SSR, REPL, or
+  registry-time diagnostics.
 
   Pure data; JVM-runnable; idempotent (re-filtering a cleaned vector
   is a no-op)."
@@ -116,14 +92,13 @@
   row the user actually sees in the L2 event list. Returns nil when
   no focusable event-bundles exist.
 
-  Used for click-on-head detection (rf2-xzzih): clicking the visible
+  Used for click-on-head detection: clicking the visible
   head event should stay LIVE; the raw `head-dispatch-id` would treat
   an `:ungrouped` bucket as the head if it sorted last, which the
   user never sees as a focusable row.
 
-  rf2-r9lyy — the 2-arity threads `show-ungrouped?` through
-  `focusable-event-bundles` so the head-detection also lights up the
-  bucket when the user has opted in."
+  The 2-arity threads `show-ungrouped?` through
+  `focusable-event-bundles`."
   ([event-bundles]
    (focusable-head-id event-bundles false))
   ([event-bundles show-ungrouped?]
@@ -135,7 +110,7 @@
   focusable event-bundle exists (cold start; buffer-cleared; only the
   `:ungrouped` bucket present).
 
-  Used at first-mount seeding time (rf2-boyc2): `compose-focus` derives
+  Used at first-mount seeding time: `compose-focus` derives
   the panel-observed frame from this same head event-bundle, so seeding the
   Xray app-db's `:target-frame` + `:epoch-history` from the same axis
   closes the initial-mount race where the App-DB panel renders the
@@ -155,9 +130,9 @@
   "Find an event-bundle in `event-bundles` by its `:dispatch-id`. Returns nil when
   no match (id refers to an evicted event-bundle, or a fresh session).
 
-  The 3-arity prefers an event-bundle matching `:frame` when supplied —
-  multiple event-bundles can share a dispatch-id across frames (Spec 002
-  §Frame isolation + rf2-g6ih4: dispatch-id uniqueness is per-frame,
+  The 3-arity prefers an event-bundle matching `:frame` when supplied.
+  Multiple event-bundles can share a dispatch-id across frames (Spec 002
+  §Frame isolation: dispatch-id uniqueness is per-frame,
   not process-global). When no frame-matching event-bundle exists the
   lookup falls back to a dispatch-id-only match so a stale stored
   frame (e.g. a user-frame the event-bundle was re-emitted from) doesn't
@@ -186,14 +161,14 @@
   in that frame carries the focused dispatch-id, the result is nil
   rather than a same-id event-bundle from a foreign frame.
 
-  Dispatch ids are unique only WITHIN a frame (Spec 002 §Frame
-  isolation + rf2-g6ih4); the framework's trace projection groups
+  Dispatch ids are unique only within a frame (Spec 002 §Frame
+  isolation); the framework's trace projection groups
   event-bundles by `[frame dispatch-id]` and intentionally emits two
   event-bundle records when the same id occurs in two frames (see
   `re-frame.trace.projection/grouped-event-bundles`). Panel reads that key
   by dispatch-id alone can surface records/overlays/status from the
   first matching frame while focus is actually on another — this
-  helper is the frame-strict path those reads use (rf2-bz7flo).
+  helper is the frame-strict path those reads use.
 
   When `focus` has no `:frame` (single-frame / pre-frame-set focus),
   the lookup degrades to a plain dispatch-id match."

--- a/tools/xray/src/day8/re_frame2_xray/trace_collector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/trace_collector.cljs
@@ -3,47 +3,28 @@
   bridges the framework's per-frame trace rings into Xray's reactive
   app-db.
 
-  ## What this ns owns (post rf2-43koh)
+  `collect-trace!` drops Xray self-noise, applies the local egress
+  profile, retains otherwise-unaddressable frameless events, and requests
+  a coalesced mirror refresh. One refresh per microtask snapshots every
+  registered frame ring plus the bounded frameless ring into
+  `[:trace-buffer]` in Xray's app-db.
 
-  - The `:rf.xray/trace-collector` listener body (`collect-trace!`):
-    self-noise drop → privacy gate → frameless secondary ring push →
-    coalesced mirror sync request.
-  - A small 100-event secondary ring at the listener boundary for
-    FRAMELESS events (per the rf2-3g9nw D2=a ruling). The framework's
-    per-frame rings skip frameless emits per the B3 ruling (rf2-g1b2m)
-    so those events would never surface in Xray without a Xray-side
-    capture; the secondary ring backs the `:show-ungrouped?` UX
-    (rf2-r9lyy).
-  - The microtask-coalesced `refresh-trace-rings!` helper that
-    snapshots every registered frame's ring + the frameless secondary
-    ring into Xray's app-db's `:trace-buffer` slot. Production hosts
-    drive this via the listener's request-mirror-sync path (one
-    dispatch per JS tick regardless of trace volume); tests can call
-    `refresh-trace-rings!` synchronously to deterministically snap the
-    app-db against the rings.
-  - Retroactive scrub of every per-frame ring + the secondary ring +
-    Xray's app-db slot when the local-render egress profile narrows from
-    `:rf.egress/local-raw` back to the redacting default
-    (`:rf.egress/local-redacted`) (per Spec 009 §Privacy
-    §Retroactive-scrub; EP-0015 per-(tool,frame) reveal grain).
+  Frameless events have no frame or dispatch id, so the framework's
+  per-frame rings cannot retain them. The secondary ring exists only to
+  support the opt-in `:show-ungrouped?` view. All addressed events remain
+  owned by the framework rings; Xray does not maintain a duplicate global
+  trace store.
 
-  ## What this ns no longer owns
-
-  The pre-rf2-43koh `trace_bus.cljc` carried a separate 1000-event
-  process-global ring. The framework's per-frame event-keyed rings
-  + B4 dedup (rf2-g1b2m + rf2-8uwce) supersede that surface — Xray's
-  separate ring was redundant. The event-bundle list, the L2 event list,
-  the spine, every panel-side consumer now reads via the per-frame
-  ring snapshot in app-db.
+  Narrowing the egress profile also scrubs the framework rings, frameless
+  ring, and app-db mirror before another read can expose old raw values.
 
   ## Production posture
 
   Every entry point is gated on `re-frame.interop/debug-enabled?` so
   Closure DCE drops the whole namespace in `:advanced` + `goog.DEBUG
-  false` builds. The listener registration itself lives in
-  `preload.cljs` under the same gate.
-
-  Per rf2-43koh + spec/013-Trace-Consumer.md."
+  false` builds. Listener registration lives in `install.cljs` and is
+  invoked by the preload under the same gate. See
+  `spec/013-Trace-Consumer.md`."
   (:require [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
@@ -52,17 +33,14 @@
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.self-noise :as self-noise]))
 
-;; ---- frameless secondary ring (rf2-43koh / rf2-3g9nw D2=a) -------------
+;; ---- frameless secondary ring -------------------------------------------
 ;;
 ;; Frameless trace events — registry-time emits, REPL evals, frame
 ;; lifecycle outside a drain, SSR hydration mismatches that fire before
-;; any `:dispatch-id` is in scope — carry no `:rf.trace/dispatch-id` /
-;; no `:frame`. The framework's per-frame rings skip these per the B3
-;; ruling (rf2-g1b2m); they stream to listeners only.
-;;
-;; Mike's rf2-3g9nw D2=a ruling preserves the `:show-ungrouped?` UX
-;; (per rf2-r9lyy) by keeping a small, capped Xray-side ring for
-;; frameless events at the listener boundary. The depth is bounded
+;; any `:dispatch-id` is in scope — carry no `:rf.trace/dispatch-id` or
+;; `:frame`. The framework's per-frame rings skip them; listeners still
+;; receive them. Xray keeps a small, capped ring at that boundary so the
+;; opt-in `:show-ungrouped?` view can surface them. The depth is bounded
 ;; (default 100 events; framework's per-frame default is 50 event-bundles)
 ;; because frameless events are rare in a healthy app — most happen at
 ;; boot or during a REPL session. A bigger buffer would buy little
@@ -70,8 +48,8 @@
 
 (def default-frameless-ring-depth
   "Default capacity of the frameless secondary ring (in events). Capped
-  small because frameless emits are rare; the user-facing surface is
-  the `:show-ungrouped?` opt-in. Per the rf2-3g9nw D2=a ruling."
+  small because frameless emits are rare and hidden unless
+  `:show-ungrouped?` is enabled."
   100)
 
 (defonce ^:private frameless-ring-depth


### PR DESCRIPTION
## Summary

- replace Phase-1 and issue-history narration in Xray's entry points with current ownership and lifecycle contracts
- clarify the host/runtime, trace capture, focus, embedding, MCP accessor, and dependency boundaries
- fix stale explanation contradictions around preload steps, panel frame seeding, keybindings, configuration inventory, and testbed status
- keep all runtime forms and dependencies unchanged

## Review coverage

Reviewed the complete immediate `tools/xray` surface: 403 files / 197,891 lines across source, tests, testbeds, specs, configuration, and design references. The broad inventory and stale-contract sweeps found 8,418 tracker-history lines across 338 files; this focused pass removes 94 such lines from the 13 contract-bearing entry files and replaces the useful rationale with durable explanations.

No open PR touched `tools/xray` when the review started. This change deliberately avoids topology implementation and test fixture/scaffolding files because those areas have separately owned open beads.

## Verification

- `cd tools/xray && clojure -M:test` - 1,233 tests / 5,729 assertions, 0 failures, 0 errors
- `cd implementation && npm run test:cljs` - 8,465 tests / 39,156 assertions, 0 failures, 0 errors
- `clj-kondo --lint tools/xray/src tools/xray/test` - 0 errors, 118 existing surface warnings
- `git diff --check`

## Risk

Documentation, comments, and docstrings only. No executable form, dependency coordinate, fixture, or test assertion changes.
