### PR TITLE
docs(examples): clarify shared asset ownership (rf2-1kbde6)

### DIFF
--- a/examples/_shared/README.md
+++ b/examples/_shared/README.md
@@ -1,87 +1,57 @@
-# `examples/_shared/` — shared examples design system
+# `examples/_shared/` - shared example assets
 
-This directory holds the assets every example shares: one stylesheet,
-one favicon, one social card. Every example `index.html` links the same
-three, on every substrate (Reagent, Reagent Slim, UIx, Helix). The one
-exception is TodoMVC, which keeps the official TodoMVC stylesheets but
-still carries the shared favicon and social card.
+This directory is the canonical source for the example catalogue's visual
+assets. All example pages reference the shared favicon and PNG social card;
+all except TodoMVC also load the shared stylesheet. TodoMVC keeps its official
+stylesheets and declares that single exception in
+`examples/scripts/examples-asset-manifest.cjs`.
 
-Keeping them here means there's only one copy. Change the palette in this
-directory and the whole catalogue re-skins — no per-example copy drifts
-out of sync.
+## Ownership
 
-Examples build into many different output folders, yet share one asset
-directory. The trick: every page references its assets at the *same
-relative path* — `_shared/css/style.css`, never an absolute URL. So
-whatever stages an example just drops a copy of this tree next to the
-staged page.
+- This directory owns the shared CSS, favicon, and social-card source art.
+- `examples/scripts/examples-asset-manifest.cjs` owns per-page asset exceptions
+  and any extra assets that a page needs.
+- `examples/scripts/examples-staging.cjs` copies this tree beside each staged
+  `index.html`.
+- `examples/scripts/check-examples-assets.cjs` enforces page references, the
+  manifest exceptions, shared-tree integrity, and the CSS accessibility and
+  responsive contracts.
+
+Pages use stable relative URLs such as `_shared/css/style.css`. Staging can
+therefore place the same `_shared` tree beside every output page regardless of
+that example's source or build directory.
 
 ## Visual identity
 
-Every page wears the same skin: one typography stack, one palette, one
-stylesheet. This is deliberate. The obvious alternative — give each
-substrate its own colours, so you can tell a Reagent page from a UIx page
-at a glance — is a trap. We want you to notice the *code*, not the
-styling.
+The catalogue deliberately uses one substrate-neutral identity. Substrate
+differences belong in the selector and example code, not in competing palettes.
 
-Substrate gets announced where it belongs: in the substrate selector, and
-in the substrate-specific examples themselves. The look stays neutral. So
-when two examples look identical, that's the point — their UIs really are
-the same, give or take the rendering layer.
+| Role | Choice |
+| --- | --- |
+| Typography | Inter/system UI for text; JetBrains Mono/system mono for code |
+| Palette | paper `#F7F3EC`, ink `#1A1814`, amber `#C8741A` |
+| Atmosphere | subtle radial highlights fixed to the viewport |
 
-| Mood              | Editorial Warm — established, refined, magazine-leaning  |
-| ----------------- | -------------------------------------------------------- |
-| Typography pair   | Inter (UI + body) + JetBrains Mono (code, mono labels)   |
-| Palette           | warm paper bg #F7F3EC / deep ink #1A1814 / amber #C8741A |
-| Atmosphere        | paper-grain radial gradients fixed to the viewport       |
-
-The fonts echo the rest of the project: Xray uses Inter + JBM, and Story
-and the docs use IBM Plex. So an example, a dev tool, and the docs open
-side by side read as one family, not three unrelated apps.
-
-**No remote fonts.** The stylesheet *names* Inter and JetBrains Mono as
-its first-preference families, but it loads **no** web fonts to back them
-up — no `@import` of Google Fonts or any other host. The font stacks fall
-through to their declared system fallbacks: `system-ui` / `-apple-system` /
-`Segoe UI` for the UI, `ui-monospace` / `SF Mono` / `Menlo` for the
-mono.
-
-So a staged example makes **zero** third-party network requests just to
-style itself. That matters beyond tidiness. Offline runs, firewalled CI,
-and privacy-sensitive local demos all render the same. And a screenshot
-taken today matches one taken next year, because nothing is fetched from
-a server that might have changed.
+The font names are preferences only. The stylesheet loads no remote fonts and
+falls back to local system families, so examples do not make third-party font
+requests and remain usable offline.
 
 ## Files
 
-Five asset files. Most are plain; only the social card needs explaining.
+- `css/style.css` defines the shared `--ex-*` tokens and visual rules. Pages
+  link this file; it imports `structure.css`.
+- `css/structure.css` defines reusable geometry and the responsive inline-Xray
+  shell. It is not linked directly.
+- `img/favicon.svg` is the shared `r2` favicon and ships as SVG.
+- `img/og.png` is the 1200x630 social-preview asset referenced by every page.
+- `img/og.svg` is the editable source for `og.png`, not a page asset. Re-export
+  the PNG at exactly 1200x630 after changing the source art. Its colour literals
+  intentionally mirror the `--ex-*` tokens in `style.css`.
 
-- `css/style.css` — the shared design system itself, linked by every
-  `index.html` except TodoMVC's. Imports `structure.css`.
-- `css/structure.css` — the substrate-agnostic structural baseline:
-  form geometry, grid layout, the max-widths. This is about *shape*, not
-  brand — that's why it's split out from `style.css`.
-- `img/favicon.svg` — the shared favicon (an `r2` monogram on a deep-ink
-  tile with an amber accent). Browsers render SVG favicons fine, so it
-  ships as-is, with no raster step.
-- `img/og.png` — the shared Open Graph preview card, a 1200×630 raster.
-  Every `index.html` references this one. It has to be a raster because
-  link-preview scrapers (Facebook / X / LinkedIn / Slack / Discord) won't
-  render an SVG `og:image` — so the social card must be a PNG/JPG to show
-  up at all.
-- `img/og.svg` — the editable SOURCE ART behind that card; no page
-  references it. When the design changes, re-export `og.png` from this at
-  *exactly* 1200×630. Its colour literals mirror the `--ex-*` tokens in
-  `style.css`, so the source and the stylesheet stay in sync — the social
-  card inherits the same palette, and the same accessibility decisions,
-  as the rest of the catalogue.
+## Inline Xray shell
 
-## Responsive Xray-host shell
-
-Two examples (`counter`, `flows`) run Xray *inline*, side by side with the
-app. That raises a layout problem, and it's worth solving once in the
-shared CSS instead of separately in each example. Both wrap their app +
-Xray panel in a `.rf2-testbed-shell`:
+The `counter` and `flows` examples mount Xray beside the app with the same DOM
+contract:
 
 ```html
 <div class="rf2-testbed-shell">
@@ -90,21 +60,8 @@ Xray panel in a `.rf2-testbed-shell`:
 </div>
 ```
 
-On a desktop this is a two-column flex — app on the left, the inline
-Xray host on the right at `--rf-xray-inline-width` (560px by default).
-That breaks on a phone. The host is `flex-shrink: 0` with a 320px
-`min-width`, so it won't give up space; together with a usable app column,
-the layout needs roughly 624px before any app content can appear. Below
-that, the pages declare a responsive viewport but the layout still runs
-off the side of the screen.
-
-So `structure.css` **stacks** the shell below a 900px breakpoint. The two
-columns become two rows — app on top, Xray host underneath. The host
-drops its fixed width and min-width and goes full-bleed, and its height is
-capped (`max-height: 60vh` with internal scroll) so the panel can't grow
-tall enough to push the app off-screen.
-
-None of this touches the host/app DOM contract. The shape Xray looks for
-(`.rf2-testbed-shell > #app` plus `[data-rf-xray-host]`) is **unchanged**,
-so auto-mounting and both examples keep working at every width — only the
-CSS rearranges.
+`structure.css` lays this out as two columns on wider viewports, with the host
+width controlled by `--rf-xray-inline-width` (560px by default). At 900px and
+below it stacks the host beneath the app, removes the host's fixed minimum
+width, and caps its height so the panel scrolls internally. These rules only
+change layout; Xray's host selector and mount contract remain unchanged.

--- a/examples/_shared/css/structure.css
+++ b/examples/_shared/css/structure.css
@@ -1,10 +1,10 @@
 /* ============================================================================
- * Structural baseline — class shapes the example views actually emit.
+ * Structural baseline for the reusable class names emitted by example views.
  *
- * The classes here are layout-only (display/flex/grid, padding,
- * max-widths, grid-template-columns); typography + palette + atmosphere
- * live in style.css (one shared identity across every example substrate)
- * which @imports this file.
+ * This file owns geometry and low-level component shape. The shared palette,
+ * typography, and page atmosphere live in style.css, which imports this file.
+ * The inline-Xray section also publishes the host integration variables next
+ * to the layout that consumes them.
  * ========================================================================== */
 
 /* -- Forms (login, signup, settings) ------------------------------------- */
@@ -202,22 +202,13 @@ hr {
   box-sizing: border-box;
 }
 
-/* -- Xray-host shell (counter testbed pattern) -------------------------- */
+/* -- Inline-Xray host shell (counter and flows) ------------------------- */
 /*
- * Responsive contract (rf2-y82dk9). The desktop layout is a two-column flex:
- * the app on the left, the inline Xray host fixed at --rf-xray-inline-width
- * (default 560px) on the right. With `flex-shrink:0` + a 320px host min-width
- * that desktop shell needs ~624px before any app content shows, so on a phone
- * it would overflow horizontally even though the pages declare a responsive
- * viewport. Below a 900px breakpoint (the narrowest the side-by-side layout can
- * be without overflow is ~624px; 900px keeps a comfortable app column before
- * stacking) we STACK: the columns become rows (app on top, Xray host below),
- * the host drops its
- * fixed width / min-width and goes full-bleed, and its height is capped so the
- * panel never crowds the app off-screen. The host/app DOM contract
- * (`.rf2-testbed-shell > #app` + `[data-rf-xray-host]`) is untouched, so Xray
- * auto-mounting and the counter/flows examples keep working at every width.
- * See examples/_shared/README.md §Responsive Xray-host shell.
+ * Wide viewports place the app beside a host whose flex basis follows Xray's
+ * --rf-xray-inline-width setting. At 900px and below the layout stacks, removes
+ * the host minimum width, and caps its height for internal scrolling. Selectors
+ * preserve the `.rf2-testbed-shell > #app` plus `[data-rf-xray-host]` mount
+ * contract described in examples/_shared/README.md.
  */
 
 :root {
@@ -241,8 +232,7 @@ hr {
   padding: 2em;
 }
 
-/* Narrow viewports: stack the inline-Xray host below the app rather than
-   overflowing the side-by-side desktop shell (rf2-y82dk9). */
+/* Narrow viewports stack the host below the app. */
 @media (max-width: 900px) {
   .rf2-testbed-shell {
     flex-direction: column;

--- a/examples/_shared/css/style.css
+++ b/examples/_shared/css/style.css
@@ -1,39 +1,14 @@
 /* ============================================================================
- * Shared examples design system — one identity across every example
- * substrate (Reagent, Reagent Slim, UIx, Helix). Substrate variety is
- * communicated by the
- * substrate selector + the per-substrate examples themselves — NOT via
- * visual identity.
+ * Shared, substrate-neutral visual rules for the example catalogue.
  *
- * Mood              : Editorial Warm — established, refined, magazine.
- * Typography pairing: Inter (UI + body) + JetBrains Mono (code, mono labels).
- *                     Matches the project-wide family used by Xray, so the
- *                     examples and the dev tools sit naturally next to one
- *                     another.
- * Palette           : warm paper bg #F7F3EC / deep ink #1A1814 / amber
- *                     accent #C8741A. A cohesive light-mode identity that
- *                     echoes Xray/Story's warm-slate-amber pairing.
- * Atmosphere        : subtle paper-grain radial gradients fixed to the
- *                     viewport + soft warm-toned shadows. No heavy textures.
+ * The canonical token vocabulary is --ex-*. Bright accent tokens are for
+ * decoration; their -deep variants are the contrast-safe choices for text and
+ * text-bearing controls. Font names are preferences backed only by local system
+ * fallbacks: this stylesheet does not load remote fonts.
  *
- * Token convention  : the canonical (and only) names are --ex-*. The shared
- *                     design system exposes one substrate-agnostic token
- *                     vocabulary; every example — including the design-led
- *                     notebook and process-monitor — consumes --ex-* directly.
- *                     Note the bright/deep accent split below: the bright
- *                     --ex-accent paints large decorative fills, the --ex-*-deep
- *                     siblings carry any text or button a human reads (AA-safe).
- *
- * @imports structure.css for layout-only class shapes
- *          (forms, banners, pills, boot, navbar, cards, cells grid,
- *          testbed shell). Stays substrate-agnostic.
- *
- * No remote fonts. The Inter / JetBrains Mono families below are stated as
- * the first preference but resolve entirely through the declared system
- * fallbacks (system-ui / Segoe UI / -apple-system; ui-monospace / SF Mono /
- * Menlo). A staged example therefore makes ZERO third-party network
- * requests for styling — offline, firewalled, and privacy-sensitive local
- * runs render identically and screenshots stay reproducible. (rf2-byf7y)
+ * Imports structure.css, which owns reusable geometry and the inline-Xray
+ * layout. Pages link this file only; the import makes the structural rules
+ * reachable from the same stable entry point.
  * ========================================================================== */
 
 @import url('structure.css');
@@ -50,29 +25,16 @@
   /* ink — warm neutrals, not pure black */
   --ex-ink:         #1A1814;
   --ex-ink-muted:   #5C5448;
-  /* --ex-ink-faint darkened from #8A8270 (≤3.81:1, sub-AA) to #6E6654 so muted
-     /skeleton text clears WCAG AA 4.5:1 on every shipped surface: 5.14:1 on
-     paper, 5.69:1 on white, 4.61:1 on sunken (rf2-febmqu). */
+  /* Muted/skeleton text still clears WCAG AA on every shared surface. */
   --ex-ink-faint:   #6E6654;
   --ex-rule:        #DCD3BF;
   --ex-rule-strong: #B8AC93;
 
-  /* accents.
-     --ex-accent (#C8741A) is a DECORATIVE/large-fill amber only: as normal-text
-     foreground or as a white-text filled background it is ≤3.52:1 (sub-AA). Use
-     --ex-accent-deep (#9C4F0E) for text links, white-text filled buttons, and
-     text-bearing status pills — it clears AA at ≥5.37:1 on paper/white and
-     5.94:1 white-on-deep (rf2-febmqu). */
+  /* Bright accents decorate; deep variants carry text and control borders. */
   --ex-accent:      #C8741A;  /* amber-sienna — decorative fill / focus accent */
   --ex-accent-deep: #9C4F0E;  /* AA-safe text / filled-button background */
   --ex-accent-soft: #E5A23D;  /* warm gold — secondary highlight */
   --ex-success:     #4A7340;  /* forest green for connected/ok states */
-  /* --ex-warn (#C49419) is a DECORATIVE/large-fill amber only: as normal-text
-     foreground on the shared light surfaces it is ≤2.76:1 (sub-AA — 2.50:1 on
-     paper, 2.24:1 on sunken). Use --ex-warn-deep (#7E5F10) for warning TEXT and
-     for warning UI-component borders — it clears AA at ≥4.82:1 on every shipped
-     surface (5.38:1 paper, 4.82:1 sunken, 5.95:1 white) and the 3:1 non-text bar
-     (rf2-ihruwa). */
   --ex-warn:        #C49419;  /* warm amber — decorative fill / accent only */
   --ex-warn-deep:   #7E5F10;  /* AA-safe warning text / border */
   --ex-error:       #B23A2E;  /* warm oxblood for errors */
@@ -98,8 +60,7 @@ html, body {
   -moz-osx-font-smoothing: grayscale;
 }
 
-/* Paper-grain ambience — three radial gradients fixed to the viewport.
-   Low-cost, pure CSS, no <img>. */
+/* Subtle radial ambience, rendered locally without an image asset. */
 body::before {
   content: '';
   position: fixed;
@@ -141,8 +102,7 @@ code {
 }
 
 a, .nav-link {
-  /* --ex-accent-deep (≥5.37:1 on paper/white), not --ex-accent (≤3.52:1,
-     sub-AA), so link text clears WCAG AA (rf2-febmqu). */
+  /* Text uses the deep accent; the bright accent is decorative only. */
   color: var(--ex-accent-deep);
   text-decoration-color: var(--ex-accent-soft);
   text-underline-offset: 3px;
@@ -163,14 +123,8 @@ input, textarea, select {
   transition: border-color 120ms ease, box-shadow 120ms ease;
 }
 
-/* Keyboard focus indicator (rf2-mon7tz).
-   The old rule set `outline: none` and replaced it with a low-alpha amber ring
-   (≈1.5:1 against the light surfaces) — keyboard users effectively lost the
-   focus indicator. We now keep a visible, solid ring built from
-   --ex-accent-deep (#9C4F0E), which clears the WCAG 1.4.11 non-text/focus
-   3:1 bar on every shipped surface: 5.37:1 on paper, 5.94:1 on white, 4.81:1
-   on sunken. A 2px transparent outline carries the indicator in forced-colors
-   / high-contrast mode where box-shadow is dropped. */
+/* The solid ring clears the non-text contrast threshold. The transparent
+   outline preserves a focus indicator when forced-colors drops box shadows. */
 input:focus-visible, textarea:focus-visible, select:focus-visible {
   outline: 2px solid transparent; /* forced-colors fallback */
   outline-offset: 2px;
@@ -202,18 +156,14 @@ button {
 }
 
 button:hover:not([disabled]) {
-  /* --ex-accent-deep, not --ex-accent: the button text is white, and white on
-     --ex-accent is only 3.52:1 (sub-AA); white on --ex-accent-deep is 5.94:1
-     (rf2-febmqu). */
+  /* White labels require the deep accent background. */
   background: var(--ex-accent-deep);
   border-color: var(--ex-accent-deep);
 }
 
 button:active:not([disabled]) { transform: translateY(1px); }
 
-/* Form-bound submit gets the accent fill — using --ex-accent-deep so the
-   white label clears AA (white-on-deep 5.94:1; white-on-accent was 3.52:1,
-   sub-AA). rf2-febmqu. */
+/* Form submit uses the text-safe accent because its label is white. */
 .login-form button[type="submit"] {
   background: var(--ex-accent-deep);
   border-color: var(--ex-accent-deep);
@@ -242,15 +192,8 @@ button:active:not([disabled]) { transform: translateY(1px); }
   color: var(--ex-ink);
 }
 
-/* Pills carry white text by default (structure.css). Backgrounds are chosen so
-   white-on-fill clears WCAG AA 4.5:1, or the pill overrides to ink text where
-   the fill is too light (rf2-febmqu):
-   - disconnected  : --ex-ink-muted #5C5448 → white 7.46:1 (was #8A8270, 3.81:1)
-   - authenticating: --ex-accent-deep #9C4F0E → white 5.94:1 (was --ex-accent, 3.52:1)
-   - connected     : --ex-success #4A7340 → white 5.50:1
-   - failed        : --ex-error #B23A2E → white 5.94:1
-   - connecting / reconnecting: --ex-accent-soft is light, so they use ink text
-     (8.08:1). */
+/* Pills default to white text in structure.css. The two light fills override
+   that default with ink; the remaining fills are dark enough for white. */
 .pill.disconnected   { background: var(--ex-ink-muted); }
 .pill.connecting     { background: var(--ex-accent-soft); color: var(--ex-ink); }
 .pill.authenticating { background: var(--ex-accent-deep); }
@@ -326,6 +269,6 @@ body > div > #app {
   box-sizing: border-box;
 }
 
-/* The .rf2-testbed-shell wrapper supplies its own grid; undo the
-   inherited #app padding under that wrapper. */
+/* The testbed wrapper supplies its own flex layout, so remove the standalone
+   app container's width and centering constraints. */
 .rf2-testbed-shell > #app { max-width: none; margin: 0; }

--- a/examples/_shared/img/favicon.svg
+++ b/examples/_shared/img/favicon.svg
@@ -1,13 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  re-frame2 examples favicon.
-
-  A 32x32 monogram: stylised "r2" glyph on a dark surface, with an amber
-  accent stroke under the descender. One favicon shared across every
-  example substrate (Reagent, Reagent Slim, UIx, Helix) — substrate
-  variety is not communicated via visual identity.
-
-  Accent: #C8741A (matches --ex-accent in examples/_shared/css/style.css).
+  Shared 32x32 example favicon. Its paper, ink, and decorative amber literals
+  mirror the --ex-* palette in examples/_shared/css/style.css.
 -->
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
   <rect width="32" height="32" rx="6" fill="#1A1814"/>
@@ -15,6 +9,6 @@
   <path d="M9 22 V12 H11 V13.6 C12 12.3 13.4 11.8 14.6 12 V14.2 C13.3 14 11.5 14.6 11 16 V22 Z" fill="#F7F3EC"/>
   <!-- "2" subscript -->
   <path d="M16 22 V20.5 C16 19 17 18 18.5 18 H20 C20.6 18 21 17.6 21 17 C21 16.4 20.6 16 20 16 H17 V14.5 H20.4 C22 14.5 23 15.5 23 17 C23 18.5 22 19.5 20.4 19.5 H18.5 C18 19.5 17.8 19.8 17.8 20.2 V20.5 H23 V22 Z" fill="#F7F3EC"/>
-  <!-- amber accent underline — shared across all substrates -->
+  <!-- Decorative amber underline. -->
   <rect x="6" y="26" width="20" height="2" rx="1" fill="#C8741A"/>
 </svg>

--- a/examples/_shared/img/og.svg
+++ b/examples/_shared/img/og.svg
@@ -1,21 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Open Graph card — SOURCE ART, not the shipped social-preview asset.
-     Link-preview scrapers (Facebook / X / LinkedIn / Slack / Discord) do not
-     render an SVG og:image, so the rasterised examples/_shared/img/og.png is
-     what every example references and what the asset gate requires. Keep this
-     SVG as the editable master; re-export og.png from it when the design
-     changes.
-     1200x630 — standard social-card aspect ratio.
+<!-- Editable source for the shared social card. Pages reference the rasterised
+     examples/_shared/img/og.png, not this SVG. Re-export that file at 1200x630
+     after changing this source.
      Matches the shared 'Editorial Warm' identity in examples/_shared/css/style.css:
        paper bg     #F7F3EC  (--ex-bg)
        deep ink     #1A1814  (--ex-ink)        — display text + monogram
        muted ink    #5C5448  (--ex-ink-muted)  — strapline
-       faint ink    #6E6654  (--ex-ink-faint)  — mono label (AA-safe; the old
-                    #8A8270 was sub-AA on paper at 3.45:1, darkened to 6E6654
-                    at 5.14:1 — keep this mirrored to the CSS token, rf2-febmqu)
-       amber accent #C8741A  (--ex-accent)     — decorative rule + monogram bar
-     Source-art palette literals intentionally mirror the --ex-* tokens; the
-     asset gate rejects re-introducing the retired #8A8270 here (rf2-y82dk9). -->
+        faint ink    #6E6654  (--ex-ink-faint)  — mono label
+        amber accent #C8741A  (--ex-accent)     — decorative rule + monogram bar
+     Keep these literals aligned with the CSS tokens; the shared-asset gate
+     checks the source-art palette. -->
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
   <defs>
     <radialGradient id="grain" cx="20%" cy="30%" r="60%">


### PR DESCRIPTION
## Summary

- document the ownership split between shared asset sources, the page manifest, staging, and the asset scanner
- replace duplicated historical rationale with current palette, accessibility, and inline-Xray contracts
- correct comment drift that described the flex-based Xray shell as a grid
- align the SVG source comments with the contracts enforced by the shared-asset gate

## Review coverage

Reviewed all six files under `examples/_shared`: the README, both stylesheets, both SVG sources, and the PNG social card. The PNG was inspected directly and remains unchanged; the other five files receive explanation-only edits.

## Verification

- `node scripts/check-examples-assets.test.cjs` from `implementation/` (all checks passed)
- `node ../examples/scripts/check-examples-assets.cjs` from `implementation/` (35 host pages plus the shared tree passed)
- `git diff --check`

## Risk

Documentation and comments only. No CSS declarations, SVG elements, or binary assets changed.
