### PR TITLE
docs(examples): correct capability explanations

### DIFF
--- a/examples/capabilities/resources/linearlite/core.cljs
+++ b/examples/capabilities/resources/linearlite/core.cljs
@@ -11,7 +11,7 @@
    the write fails. You write only the forward step.
 
    See the guide: [Optimistic writes commit, roll back, or
-   reconcile](../../../docs/resources/concepts.md#optimistic-writes-commit-roll-back-or-reconcile).
+   reconcile](../../../../docs/resources/concepts.md#optimistic-writes-commit-roll-back-or-reconcile).
 
    Four ideas, and they're the whole example:
 
@@ -70,7 +70,7 @@
             ;; Managed HTTP — the one transport every resource and mutation
             ;; lowers its read/write onto. Loading the ns registers the
             ;; `:rf.http/managed` fx. Guide:
-            ;; ../../../docs/resources/glossary.md#managed-http
+            ;; ../../../../docs/resources/glossary.md#managed-http
             [re-frame.http.managed]
             ;; The framework's canned-reply fx. Our demo stub delegates to it
             ;; instead of hitting a network — the deliberate opt-in for an app
@@ -125,7 +125,7 @@
    ;; This board is the same for every viewer, so we make the global claim
    ;; explicit — there's no implicit default to fall back on. A per-team board
    ;; would carry a scope resolver here instead. Guide:
-   ;; ../../../docs/resources/glossary.md#scope
+   ;; ../../../../docs/resources/glossary.md#scope
    :scope          :rf.scope/global
 
    :stale-after-ms 60000
@@ -135,7 +135,7 @@
    ;; invalidate the whole thing by tag. The optimistic writes below patch the
    ;; entry directly and re-seed via `:populates` on commit, so they never need
    ;; this coarser hammer. Guide:
-   ;; ../../../docs/resources/glossary.md#cache-tag
+   ;; ../../../../docs/resources/glossary.md#cache-tag
    :tags           (fn [_params _data] #{[:board]})}
   (fn [_params _ctx]
     {:request {:method :get :url "/api/board"}
@@ -601,7 +601,7 @@
 ;; override pointing at our canned stub so the whole thing runs standalone. On
 ;; hot reload it finds that same frame and keeps its app-db. Every dispatch and
 ;; subscribe inside the tree resolves against that id. Guide:
-;; ../../../docs/routing/glossary.md#url-bound
+;; ../../../../docs/routing/glossary.md#url-bound
 ;;
 ;; Notice there are no `:initial-events`. The board isn't seeded at boot — it's
 ;; seeded by entering the route. The `:linearlite.app/board` route's `:resources`

--- a/examples/capabilities/resources/resources/core.cljs
+++ b/examples/capabilities/resources/resources/core.cljs
@@ -1,7 +1,7 @@
 (ns resources.core
   "A worked example of resources — named, cached server-state reads. See the
-   [resources guide](../../../docs/resources/concepts.md) and its
-   [glossary](../../../docs/resources/glossary.md).
+   [resources guide](../../../../docs/resources/concepts.md) and its
+   [glossary](../../../../docs/resources/glossary.md).
 
    The app is a small articles list plus an article detail. Nothing exotic —
    it's ordinary re-frame2: app-db, events, subs, passive views. The one habit
@@ -23,14 +23,14 @@
    Owner and cause are the two ideas to keep straight: an owner keeps a cached
    entry alive, a cause just records why a fetch happened. Owner = lifetime,
    cause = explanation. See
-   [owner & cause](../../../docs/resources/glossary.md#owner--cause).
+   [owner & cause](../../../../docs/resources/glossary.md#owner--cause).
 
    Every resource declares `:scope :rf.scope/global` — this data is public and
    the same for everyone. Scope is a required, fail-closed leak boundary, so
    one user's data can't leak into another's cache; a per-user read would carry
    a scope resolver instead. There's no default on purpose — forgetting it is
    an error, not a silent global. See
-   [scope](../../../docs/resources/glossary.md#scope).
+   [scope](../../../../docs/resources/glossary.md#scope).
 
    There's no real backend here. Instead the example overrides the
    `:rf.http/managed` effect with a per-URL stub that returns canned articles —
@@ -43,14 +43,14 @@
 
    This example is reads only. The other half of the story — writes, and how a
    mutation invalidates reads by tag — lives in the
-   [resources guide](../../../docs/resources/concepts.md)."
+   [resources guide](../../../../docs/resources/concepts.md)."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.registrar :as registrar]
             ;; Managed HTTP is the transport a resource fetch rides on.
             ;; Requiring it registers the `:rf.http/managed` effect that every
             ;; ensure ultimately runs onto. See the managed-HTTP glossary entry:
-            ;; ../../../docs/resources/glossary.md#managed-http
+            ;; ../../../../docs/resources/glossary.md#managed-http
             [re-frame.http.managed]
             ;; Canned-reply test effects. With no real server, the stub further
             ;; down stands in for one — and it delegates to the
@@ -77,7 +77,7 @@
 ;; function at the bottom. `:scope :rf.scope/global` is us promising this read
 ;; is the same for every user. Scope has no default; leave it off and you get an
 ;; error at registration, not a quietly-global cache.
-;; See ../../../docs/resources/glossary.md#scope
+;; See ../../../../docs/resources/glossary.md#scope
 
 (rf/reg-resource :articles/list
   {:doc            "The recent-articles list (public, same for everyone)."
@@ -86,7 +86,7 @@
    :stale-after-ms 60000
    :gc-after-ms    (* 5 60 1000)
    ;; Tags are how a future write says "this list is now stale" without naming
-   ;; the list directly. See ../../../docs/resources/glossary.md#cache-tag
+   ;; the list directly. See ../../../../docs/resources/glossary.md#cache-tag
    :tags           (fn [_params _data] #{[:article-list]})}
   (fn [_params _ctx]
     {:request {:method :get :url "/api/articles"}
@@ -172,7 +172,7 @@
 ;; the route and the runtime ensures each one, owned by the route itself. Leave,
 ;; and it releases that ownership and quietly drops any reply still in flight.
 ;; The view does nothing but read — the route does the causing.
-;; See ../../../docs/routing/glossary.md#route
+;; See ../../../../docs/routing/glossary.md#route
 
 (rf/reg-route :resources.app/home
   {:doc  "Landing page."} "/")
@@ -206,7 +206,7 @@
 ;; ownership comes responsibility: whatever mints a lease must also, somewhere,
 ;; fire a matching `:rf.resource/release-owner`. Forget that, and the lease pins
 ;; the entry alive forever — the cache equivalent of a memory leak.
-;; See ../../../docs/resources/glossary.md#owner--cause
+;; See ../../../../docs/resources/glossary.md#owner--cause
 
 (rf/reg-event :resources.app/preview-opened
   {:doc "Open a lightweight article preview from the list — ensure the
@@ -252,7 +252,7 @@
 ;; mechanics underneath. What follows is about the smallest such machine you
 ;; could write: a reader that ensures the one article it's reading, and lets go
 ;; of it when it stops. See the machines glossary:
-;; ../../../docs/machines/glossary.md#machine
+;; ../../../../docs/machines/glossary.md#machine
 
 ;; Starting the reader takes two steps, and the split is on purpose. First we
 ;; birth the actor with a bare `[:rf.machine/start]` marker; then we dispatch a
@@ -297,7 +297,7 @@
    ;; action has to ride inside an `{:action …}` map. Write the tempting shorthand
    ;; `{:reader/load :ensure-article}` and the machine reads `:ensure-article` as
    ;; the name of a target *state*, then fails to find one.
-   ;; See ../../../docs/machines/glossary.md#transition
+   ;; See ../../../../docs/machines/glossary.md#transition
    {:reading {:on {:reader/load {:action :ensure-article}}}}})
 
 ;; These two events are the UI's start and stop buttons for the reader. Start
@@ -335,7 +335,7 @@
 ;; The input-fn is a pure `(fn [query-v])` returning a vector of query vectors
 ;; (never a deref'd subscribe), and the compute fn then gets the resolved inputs
 ;; back positionally: `[[articles] _]`.
-;; See ../../../docs/core/glossary.md#subscription
+;; See ../../../../docs/core/glossary.md#subscription
 (rf/reg-sub :resources.app/first-slug
   (fn [_query-v]
     [[:rf.resource/data {:resource :articles/list :params {}}]])
@@ -515,7 +515,7 @@
 ;; `:url-bound? true` is also what syncs the initial URL and wires up the
 ;; browser back/forward buttons — the frame's creation installs the listener
 ;; automatically. See the frame glossary entry:
-;; ../../../docs/core/glossary.md#frame
+;; ../../../../docs/core/glossary.md#frame
 
 (defonce react-root (atom nil))
 

--- a/examples/capabilities/routing/routing/README.md
+++ b/examples/capabilities/routing/routing/README.md
@@ -45,10 +45,11 @@ three-page site. It's the worked companion to
   to that owner — no separate install call. It's the right surface for the
   job: a hand-rolled, frameless `:rf.route/handle-url-change` dispatch has no
   frame to land in and raises `:rf.error/no-frame-context`.
-- **The same routing runs on the server** — the routing artefact is
-  `.cljc`, so this exact `reg-route` table works on a JVM server too.
-  Nothing in the table is browser-only (this demo's file is `.cljs` only
-  because the mount beside it is browser code). The
+- **Route declarations are platform-neutral** — the routing artefact is
+  `.cljc`, so the `reg-route` table has the same shape on a JVM server.
+  Nothing in the table is browser-only. This demo remains client-only: its
+  file is `.cljs` because the browser mount lives beside the declarations.
+  In a shared `.cljc` application, the
   `:rf.route/handle-url-change` handler
   that popstate and the initial load drive on the client is the same one
   a server render uses — the server just feeds it the request URL

--- a/examples/capabilities/routing/routing/core.cljs
+++ b/examples/capabilities/routing/routing/core.cljs
@@ -1,6 +1,6 @@
 (ns routing.core
   "A small three-page routing app: home, an articles list, and an article
-   detail page. See the [routing guide](../../../docs/routing/concepts.md).
+   detail page. See the [routing guide](../../../../docs/routing/concepts.md).
 
    Here's the one idea worth taking away: the URL is just application state,
    and you read it through a subscription. Navigation, then, is just an event.
@@ -98,7 +98,7 @@
 ;; attrs you pass (here `:data-testid`) ride along onto the `<a>`.
 ;;
 ;; See the routing guide, "Linking from views":
-;; ../../../docs/routing/concepts.md#linking-from-views
+;; ../../../../docs/routing/concepts.md#linking-from-views
 
 (rf/reg-view home-page []
   [:div
@@ -175,7 +175,7 @@
 ;; app's provider flips that on. That's what connects the address bar to *this*
 ;; frame's route state. See the routing guide, "The browser is just another
 ;; event source":
-;; ../../../docs/routing/concepts.md#the-browser-is-just-another-event-source
+;; ../../../../docs/routing/concepts.md#the-browser-is-just-another-event-source
 (def app-frame :rf/default)
 
 ;; DOM setup lives in `mount!`, tagged `^:dev/after-load` so shadow-cljs re-runs

--- a/examples/capabilities/ssr/resources_ssr/core.cljc
+++ b/examples/capabilities/ssr/resources_ssr/core.cljc
@@ -51,8 +51,8 @@
    `rf/resource-state` introspection read — see `await-resource-loaded!`
    below.
 
-   For the full picture see [Resources: SSR and hydration](../../../docs/resources/concepts.md#ssr-and-hydration)
-   and [Server-side rendering](../../../docs/ssr/concepts.md).
+   For the full picture see [Resources: SSR and hydration](../../../../docs/resources/concepts.md#ssr-and-hydration)
+   and [Server-side rendering](../../../../docs/ssr/concepts.md).
 
    The sibling `examples/capabilities/ssr/ssr/` is the simpler cousin: it bakes a
    fetched list into app-db and hands that frozen value across. Here the data

--- a/examples/capabilities/ssr/ssr/core.cljc
+++ b/examples/capabilities/ssr/ssr/core.cljc
@@ -3,7 +3,7 @@
    HTML so the first paint arrives ready-made; the client then hydrates that
    same HTML and takes over, fully interactive. The trick is that both runs
    are the *same code* — the SSR guide tells the longer story:
-   ../../../docs/ssr/concepts.md.
+   ../../../../docs/ssr/concepts.md.
 
    That's why this file is .cljc and not .cljs. The events, subscriptions,
    and views are written once and shared. The `#?(:clj …)` / `#?(:cljs …)`
@@ -31,7 +31,7 @@
    - A structural render hash that catches the classic SSR bug. The client
      hashes its own first render and compares it to the server's; if they
      disagree, the runtime emits :rf.ssr/hydration-mismatch. See
-     ../../../docs/ssr/glossary.md#hydration-mismatch.
+     ../../../../docs/ssr/glossary.md#hydration-mismatch.
 
    Want to see it live? The hand-written `index.html` beside this file is a
    runnable stand-in for what `handle-request` below would emit if a real
@@ -95,7 +95,7 @@
 ;; hydration lands. A bare `[:vector …]` would call that intermediate nil a
 ;; violation and roll the commit back — so we tell the schema, up front, that
 ;; nil is a fine place to pass through. See
-;; ../../../docs/core/glossary.md#schema.
+;; ../../../../docs/core/glossary.md#schema.
 (def ArticlesSchema
   [:maybe [:vector [:map
                     [:id    :string]
@@ -129,7 +129,7 @@
   {:doc       "Per-request server-side boot. Reads the incoming request through
                the :rf.server/request coeffect and starts the work the page
                needs. Server only. See
-               ../../../docs/ssr/concepts.md#reading-the-request."
+               ../../../../docs/ssr/concepts.md#reading-the-request."
    :platforms #{:server}
    :rf.cofx/requires [:rf.server/request]}
   (fn handler-rf-server-init [{:keys [db rf.server/request]} _]
@@ -166,7 +166,7 @@
 ;; slice) becomes the serializable runtime-db projection. Whatever the client
 ;; had pre-seeded is overwritten, no negotiation. On hydration the server is
 ;; the authority, full stop. (Why replace rather than merge is worth the read:
-;; ../../../docs/ssr/concepts.md#the-client-side-hydrate-then-verify.)
+;; ../../../../docs/ssr/concepts.md#the-client-side-hydrate-then-verify.)
 ;;
 ;; It's also paranoid in the good way — it fails closed. A payload that isn't a
 ;; map, or a slice (`:rf/app-db` / `:rf/runtime-db`) that's present but not a
@@ -219,7 +219,7 @@
 ;; the current value and returns. On the client, the very same deref registers
 ;; a reaction, so the view re-renders whenever app-db changes underneath it.
 ;; Same code, two behaviours, picked up from the context. See
-;; ../../../docs/core/glossary.md#view.
+;; ../../../../docs/core/glossary.md#view.
 (rf/reg-view ^{:rf/id :pages/articles} articles-page []
   (let [arts         @(subscribe [:articles/slice])
         show-bodies? @(subscribe [:articles/show-bodies?])]
@@ -245,7 +245,7 @@
 ;; ============================================================================
 ;;
 ;; Here's the whole server-side dance, one request from end to end
-;; (../../../docs/ssr/concepts.md#a-request-start-to-finish):
+;; (../../../../docs/ssr/concepts.md#a-request-start-to-finish):
 ;;   1. A request arrives.
 ;;   2. set-request! drops it into the per-frame slot that the
 ;;      :rf.server/request coeffect will read back out.
@@ -356,12 +356,13 @@
 ;; image of the server render. It rolls three steps into one, and the order is
 ;; the point:
 ;;   1. READ    — pull the embedded `__rf_payload` `<script>` by its pinned id.
-;;                A malformed payload fails closed (nothing replaces app-db); a
-;;                missing one just means "nobody server-rendered this" — a plain
-;;                first load.
+;;                A malformed payload fails closed (nothing replaces the frame
+;;                state); a missing one just means "nobody server-rendered
+;;                this" — a plain first load.
 ;;   2. HYDRATE — dispatch-sync `[:rf/hydrate payload]`, before the first
-;;                render. The framework handler swaps in the server's slice and
-;;                sets the server's render hash aside for step 3.
+;;                render. The framework handler swaps in the server's
+;;                serialisable frame state and sets the server's render hash
+;;                aside for step 3.
 ;;   3. VERIFY  — once that first render is on screen, hash the `:render-tree-fn`
 ;;                result and hold it up against the server's hash. Disagree and
 ;;                you get :rf.ssr/hydration-mismatch.
@@ -370,7 +371,7 @@
 ;; sniff the DOM. The reason to route through the helper rather than wire these
 ;; up yourself: it keeps the fail-closed check, the hash stash, and the verify
 ;; locked together in the one correct order. See
-;; ../../../docs/ssr/concepts.md#the-client-side-hydrate-then-verify.
+;; ../../../../docs/ssr/concepts.md#the-client-side-hydrate-then-verify.
 
 ;; A quick naming note. App events live under a namespace you pick; the reserved
 ;; `:rf/*` root is the framework's. `:rf/hydrate` is framework-owned, and

--- a/examples/capabilities/ssr/ssr/index.html
+++ b/examples/capabilities/ssr/ssr/index.html
@@ -21,9 +21,9 @@
     in for what `handle-request` (in core.cljc, :clj branch) would emit if a
     real Clojure server were sitting in front. The corresponding
     `<script id="__rf_payload">` block immediately below carries the
-    serialised app-db; the client `run` reads it, dispatches `:rf/hydrate`
-    (replace-app-db semantics, Spec 011), and renders against the now-seeded
-    state.
+    serialised frame state; the client `run` reads it, dispatches
+    `:rf/hydrate` (replace-frame-state semantics, Spec 011), and renders
+    against the now-seeded state.
 
     The data-rf-render-hash attribute would normally be emitted by
     render-to-string with :emit-hash? true, and the matching :rf/render-hash

--- a/examples/capabilities/ssr/ssr_streaming/README.md
+++ b/examples/capabilities/ssr/ssr_streaming/README.md
@@ -1,12 +1,13 @@
 # A dashboard that streams in, card by card
 
-This example is a dashboard with three slow cards (revenue, signups,
-latency), plus a fourth that fails on purpose. The page shell and header
-render and flush *immediately* on the server. Then each card streams in
-as its own chunk, the moment its data resolves. Picture three slow
-microservices behind those cards: the browser paints a usable skeleton
-within ~50ms, and the real numbers trickle in over ~300ms each — instead
-of the whole page sitting blank until the slowest service answers.
+This example models a dashboard with three slow cards (revenue, signups,
+latency), plus a fourth that fails on purpose. With a live streaming host,
+the page shell and header flush first and each card follows as its own chunk
+when its data resolves. Picture three slow microservices behind those cards:
+the browser can paint a usable skeleton before the real numbers arrive,
+instead of holding the whole page until the slowest service answers. The
+offline demo below preserves that wire shape, but does not simulate those
+timings.
 
 That's *streaming SSR*: the page stops waiting on its slowest part. It's
 the React-18 / Next.js `loading.js` move — ship the shell first, fill the

--- a/examples/capabilities/ssr/ssr_streaming/core.cljc
+++ b/examples/capabilities/ssr/ssr_streaming/core.cljc
@@ -1,12 +1,12 @@
 (ns ssr-streaming.core
   "Streaming SSR — a dashboard that refuses to wait on its slowest part.
 
-  The page is four cards. The shell and header render instantly on the
-  server, then each card streams in the moment its own data resolves.
-  Picture three slow microservices behind those cards: the browser paints
-  a usable skeleton in ~50ms, and the real numbers trickle in over ~300ms
-  each, instead of the whole page sitting blank until the slowest one
-  answers.
+  The page is four cards. With a live streaming host, the shell and header
+  flush first, then each card follows when its own data resolves. Picture
+  three slow microservices behind those cards: the browser can paint a usable
+  skeleton before the real numbers arrive instead of holding the whole page
+  until the slowest one answers. This offline example preserves that wire
+  shape as collected data; it does not simulate network timings.
 
   Five ideas earn their keep here:
    - `:rf/suspense-boundary` — one hiccup marker that says \"this region
@@ -25,7 +25,7 @@
   server calls per request, the `:cljs` branch is what the page boots once
   the chunks land.
 
-  See the [SSR guide — Streaming](../../../docs/ssr/concepts.md#streaming-rfsuspense-boundary)."
+  See the [SSR guide — Streaming](../../../../docs/ssr/concepts.md#streaming-rfsuspense-boundary)."
   (:require [re-frame.core :as rf]
             [re-frame.schemas]
             [re-frame.ssr :as ssr]
@@ -48,7 +48,7 @@
 ;; seeds it (`:rf/server-init`) or the client hydrates it. A bare
 ;; `[:map-of …]` would reject that perfectly legal nil and roll the commit
 ;; back on you.
-;; See the [schemas guide](../../../docs/core/how-to/validate-with-schemas.md).
+;; See the [schemas guide](../../../../docs/core/how-to/validate-with-schemas.md).
 (def CardsSchema
   [:maybe [:map-of :keyword [:map [:title :string] [:value [:maybe :int]]]]])
 
@@ -96,7 +96,7 @@
   ;; with no hydrate delta. The other three cards stream on as if nothing
   ;; happened. A thrown render takes down exactly one boundary, never the
   ;; page. See the
-  ;; [SSR guide — Streaming](../../../docs/ssr/concepts.md#streaming-rfsuspense-boundary).
+  ;; [SSR guide — Streaming](../../../../docs/ssr/concepts.md#streaming-rfsuspense-boundary).
   (throw (ex-info "flaky third-party metric service" {})))
 
 (rf/reg-view ^{:rf/id :dashboard/root} root-view []
@@ -210,7 +210,7 @@
            ;; no frame-id and the client's explicit target simply stands. (If
            ;; you do want one on the wire, share a stable id both sides agree
            ;; on, not a gensym.) See the
-           ;; [SSR guide — hydrate, then verify](../../../docs/ssr/concepts.md#the-client-side-hydrate-then-verify).
+           ;; [SSR guide — hydrate, then verify](../../../../docs/ssr/concepts.md#the-client-side-hydrate-then-verify).
            final-payload (dissoc final-payload :rf/frame-id)
            _ (rf/destroy-frame! fid)]
        {:shell shell-html
@@ -249,8 +249,8 @@
 ;;     deltas got each card on screen early; this last step makes the whole
 ;;     thing correct.
 ;;
-;; See the [SSR guide — Streaming](../../../docs/ssr/concepts.md#streaming-rfsuspense-boundary)
-;; and [hydrate, then verify](../../../docs/ssr/concepts.md#the-client-side-hydrate-then-verify).
+;; See the [SSR guide — Streaming](../../../../docs/ssr/concepts.md#streaming-rfsuspense-boundary)
+;; and [hydrate, then verify](../../../../docs/ssr/concepts.md#the-client-side-hydrate-then-verify).
 ;;
 ;; One honest caveat: this example boots from a hand-written `index.html`
 ;; that plays the part of the streaming server, with the resolved chunks and
@@ -279,7 +279,7 @@
 ;; `:rf/frame-id`, and that's deliberate: the server rendered under a
 ;; per-request gensym, the client hydrates this fixed frame, so an absent
 ;; frame-id is exactly right — the explicit `:frame` says where to land. See
-;; [frames](../../../docs/core/glossary.md#frame-identity-is-carried-not-found).
+;; [frames](../../../../docs/core/glossary.md#frame-identity-is-carried-not-found).
 #?(:cljs (def app-frame :rf/default))
 
 ;; DOM setup lives in `mount!`, tagged `^:dev/after-load` so shadow-cljs re-runs


### PR DESCRIPTION
## Summary

- correct the static SSR host's hydration description from the retired app-db-only wording to replace-frame-state semantics
- distinguish the streaming SSR example's offline wire-shape replay from the timing behavior of a live streaming host
- clarify that the routing demo is client-only even though route declarations are platform-neutral
- repair guide references in the deeper capability source tree so they resolve from the files that contain them

## Why

These examples are teaching surfaces. Several explanations were individually plausible but misleading when read against the runnable code: one described an older hydration contract, one attributed live streaming timing to an offline demo, and one implied the routing example itself exercised the server path. The source guide references were also one directory short.

The patch changes comments, docstrings, README prose, and an HTML comment only. Runtime forms and behavior are unchanged.

## Verification

- `clojure -M:test -d core/test -n re-frame.examples-test` (14 tests, 65 assertions)
- `npx --no-install shadow-cljs compile examples/routing examples/resources examples/linearlite examples/ssr examples/resources-ssr examples/ssr-streaming` (six builds, zero warnings)
- `clj-kondo` on the six edited Clojure/CLJS sources (zero errors; four pre-existing warnings in untouched forms)
- `clojure -M:splint` on the six edited Clojure/CLJS sources (two pre-existing naming warnings for `ArticlesSchema` and `CardsSchema`)
- `git diff --check`
- relative-link target checks for every capability README and every edited source guide reference
