### PR TITLE
docs(examples): clarify demonstrated core contracts (rf2-ollt50)

### DIFF
--- a/examples/core/login/core.cljs
+++ b/examples/core/login/core.cljs
@@ -289,7 +289,7 @@
       :record-error
       ;; Remember what went wrong (for the UI) and tick the attempt
       ;; counter up by one (for the retry guard).
-      ;; rf2-ibksxg — the classified failure map rides under :error.
+      ;; The classified failure map rides under :error.
       (fn [{data :data [_ {:keys [error]}] :event}]
         {:data (-> data
                    (update :attempts inc)

--- a/examples/core/managed_http_counter/README.md
+++ b/examples/core/managed_http_counter/README.md
@@ -2,9 +2,12 @@
 
 The buttons on this counter don't add anything locally. You click **+1**, and instead of bumping a number in the page, the click asks the server what the new count should be. The answer comes back as an ordinary [event](../../../docs/core/glossary.md#event) — and that event is what moves the count.
 
-Five buttons — **+1 / Fail / Retry-recover / Start long / Cancel** — walk the full managed-HTTP surface: a success, a real failure, a retry that recovers, and a real cancel of a request that is really in flight. Small enough to hold in your head; complete enough to hit every code path.
+Five buttons — **+1 / Fail / Retry-recover / Start long / Cancel** — cover a
+successful Fetch, a failing Fetch, a canned success reply, and the managed-abort
+registry path. The last two are controlled seams rather than live transport:
+this example does not run a retry policy or cancel a network request.
 
-Underneath, all of them lean on one idea. This is the smallest honest demo of [managed HTTP](../../../docs/resources/glossary.md#managed-http): the [`:rf.http/managed`](../../../spec/014-HTTPRequests.md) [effect](../../../docs/core/glossary.md#effect). You describe a request as data, and the framework owns its whole lifecycle. Your code never touches `js/fetch`.
+The live request paths lean on one idea: [managed HTTP](../../../docs/resources/glossary.md#managed-http), exposed through the [`:rf.http/managed`](../../../spec/014-HTTPRequests.md) [effect](../../../docs/core/glossary.md#effect). You describe a request as data, and the framework owns its lifecycle. The canned-reply and abort buttons isolate adjacent contracts without reaching for `js/fetch` in application code.
 
 The [event handler](../../../docs/core/glossary.md#event-handler) stays a pure function. It returns a `:db` and an `:fx` that describes the request, and then it's done. There is no promise to chain and no callback to thread back. The reply comes home as a dispatched event, and the same handler that sent the request handles the answer.
 
@@ -14,9 +17,9 @@ The [event handler](../../../docs/core/glossary.md#event-handler) stays a pure f
 
 - **The reply comes back as an event — to the handler that sent it.** This is [the uniform reply](../../../docs/core/glossary.md#the-uniform-reply) at work. Each request sets `:reply-to [:http-counter/+1]` — the **unified reply spelling**: one target for both the success and the failure reply, and the app branches on the envelope's `:status`. So `:http-counter/+1` runs a second time, now carrying the canonical envelope as its last argument (`[:http-counter/+1 {:status :ok :value {:delta 1} …}]`). A `cond` inside the handler branches on the reply's `:status` — increment on `:ok`, record the error (which rides under `:error`) on `:error`, or (no reply yet) issue the request. One handler, three branches. You [subscribe](../../../docs/core/glossary.md#subscription) to the plain `:http-counter/count` / `:http-counter/status` / `:http-counter/error` slices the handler keeps; the [view](../../../docs/core/glossary.md#view) never knows an HTTP call happened.
 
-- **Mixed real and stubbed traffic.** Some contracts are awkward to drive live, so this example mixes the two. **+1** and **Fail** do a *real* round-trip: Fetch hits a static asset (`api/inc.json`) or 404s against a path that isn't there. **Retry-recover** is harder — you'd need an endpoint that 503s once then 200s — so it uses a canned stub instead (`:rf.http/managed-canned-success`), which returns a canonical `{:status :ok :value {:delta 5} …}` reply. The call site still spells out the `:request` and `:decode`, so it reads just like the real thing; the stub only short-circuits the trip over the network.
+- **Mixed real and stubbed traffic.** Some contracts are awkward to drive live, so this example mixes the two. **+1** and **Fail** do a *real* round-trip: Fetch hits a static asset (`api/inc.json`) or 404s against a path that isn't there. **Retry-recover** uses `:rf.http/managed-canned-success` to return a canonical `{:status :ok :value {:delta 5} …}` reply. Its name describes the outcome it stands in for; the canned effect does not execute retry scheduling or attempts. It demonstrates that the handler consumes the same reply envelope regardless of which transport or test seam produced it.
 
-- **`:rf.http/managed-abort` — a real cancel of a request that is really in flight.** This one is subtle, so the example demonstrates the *actual* contract, not a look-alike. A static dev server resolves instantly, so a real Fetch leaves nothing in flight to cancel. Instead, **Start long** seeds a real request-id-keyed handle straight into the framework's in-flight registry — the same atom the live transport's `run-attempt!` writes into. Its `:abort-fn` clears the slot and dispatches the canonical `:rf.http/aborted` reply. **Cancel** then fires the *live* `:rf.http/managed-abort` fx. It looks up that handle by `:request-id`, fires its `:abort-fn`, and exercises the real abort path, registry cleanup, and aborted classification end-to-end (all visible in [Xray](../../../docs/core/glossary.md#xray) and traces).
+- **`:rf.http/managed-abort` over a seeded registry handle.** A static dev server resolves too quickly to leave a Fetch available for cancellation. **Start long** therefore inserts a request-id-keyed handle into the framework's in-flight registry, using the same registry API as the live transport. **Cancel** runs the production `:rf.http/managed-abort` effect, which resolves the handle, invokes its `:abort-fn`, clears the slot, and dispatches a canonical `:rf.http/aborted` reply. This covers the framework's lookup, cleanup, and reply contract, but not `AbortController` or network cancellation.
 
 - **Substrate** — stock Reagent (`re-frame.adapter.reagent`), like the rest of the `examples/core/` catalogue.
 
@@ -24,7 +27,7 @@ The [event handler](../../../docs/core/glossary.md#event-handler) stays a pure f
 
 Managed HTTP is a feature where the *contract* is everything — the failure taxonomy, the classification order, the retry-then-recover semantics, the abort path. A browseable demo is a poor place to assert all of that rigorously, so this one doesn't try.
 
-Its job is the part the contract tests *can't* show: the cross-substrate sanity check. The same fx and the same reply shape, end-to-end through Reagent and Fetch, in something you can click. The takeaway is the `cond`-per-handler structure — the request-issuing branch and the reply-handling branches sit side by side. The split between "real round-trip" and "stubbed seam" makes plain which parts of the contract need a server and which don't.
+Its job is the part the contract tests *can't* show: a clickable, Reagent-based sanity check. The Fetch branches exercise the managed effect end to end; the controlled branches isolate reply handling and registry-based abort. The takeaway is the `cond`-per-handler structure — the request-issuing branch and the reply-handling branches sit side by side. The split between live transport and controlled seams makes clear which behavior this browser-only example actually exercises.
 
 ## Files
 

--- a/examples/core/managed_http_counter/core.cljs
+++ b/examples/core/managed_http_counter/core.cljs
@@ -1,8 +1,7 @@
 (ns managed-http-counter.core
-  "A counter whose buttons don't add anything locally — each click asks
-  the server what the new count should be.
+  "A counter whose +1 action asks the server what the new count should be.
 
-  That's the whole idea, and it's built on one effect: `:rf.http/managed`.
+  The live request path is built on one effect: `:rf.http/managed`.
   You describe a request as data; the runtime owns the rest of its life —
   encode, send, decode, sort the failures, retry, abort. When the answer
   comes home it arrives as an ordinary event: you address the reply with
@@ -12,34 +11,29 @@
   function — you never go near js/fetch. The HTTP guide has the full
   contract: docs/async/http.md.
 
-  Five buttons walk the whole surface:
+  Five buttons cover the live and controlled paths used by this example:
 
     +1             GET api/inc.json — a real, successful round-trip.
     Fail           GET api/does-not-exist — a real 404 (:rf.http/http-4xx).
-    Retry-recover  the recovery-after-retry path, driven by a canned stub.
-    Start long     a request that genuinely stays in flight.
-    Cancel         aborts that request by :request-id.
+    Retry-recover  a canonical success reply, driven by a canned stub.
+    Start long     a request handle seeded into the in-flight registry.
+    Cancel         aborts that handle by :request-id.
 
-  +1 and Fail are honest Fetches: the request goes out, the body is decoded
-  (only on a 2xx), and the reply lands back in app-db. Retry-recover would
-  need an endpoint that fails once then succeeds, which is a nuisance to
-  stand up — so it uses a canned-success stub that synthesises the reply
-  the live fx would have produced.
+  +1 and Fail use Fetch: the request goes out, the body is decoded (only on a
+  2xx), and the reply lands back in app-db. Retry-recover uses a
+  canned-success stub. It demonstrates the canonical reply envelope, not the
+  retry scheduler or a sequence of transport attempts.
 
-  Start long / Cancel are the interesting pair: a real abort of a request
-  that is really in flight. There's a catch, though. This app serves only
-  static assets, so a real GET resolves instantly and never lingers long
-  enough to cancel. The fix is honest: \"Start long\" seeds a request-id-keyed
-  handle straight into the framework's in-flight registry — the very atom
-  the live transport writes into — so we have a deterministically pending
-  request. \"Cancel\" then fires the live `:rf.http/managed-abort` fx at it:
-  the abort resolves the handle, fires its `:abort-fn`, and a
-  `:rf.http/aborted` reply comes home to the issuing handler. Only the
-  transport is stood in for. The registry entry, the abort fx, and the
-  aborted classification are all real — and all visible in Xray and traces.
+  Start long / Cancel exercise the managed-abort registry contract without a
+  network request. A static GET resolves too quickly to cancel reliably, so
+  \"Start long\" seeds a request-id-keyed handle through the same registry API
+  used by the live transport. \"Cancel\" then fires the production
+  `:rf.http/managed-abort` fx: it resolves the handle, invokes its `:abort-fn`,
+  clears the slot, and dispatches a canonical `:rf.http/aborted` reply. This
+  covers the framework path, but not `AbortController` or network cancellation.
 
-  Put plainly: this is the runnable cross-substrate sanity check. The same
-  fx and the same reply shape, end to end, through Reagent and Fetch."
+  The Fetch branches exercise managed HTTP end to end through Reagent; the
+  controlled branches isolate canonical reply handling and registry abort."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             ;; Managed HTTP ships in its own artefact (day8/re-frame2-http).
@@ -47,9 +41,8 @@
             ;; and its family — skip it and the first fx dispatch fails loud
             ;; with a friendly "HTTP artefact missing" error.
             [re-frame.http.managed]
-            ;; Home of the canned-success stub the Retry-recover button leans
-            ;; on (`:rf.http/managed-canned-success`). It lives here, in the
-            ;; test-support ns, rather than in re-frame.http.managed proper.
+            ;; Home of the canned-success reply seam used by Retry-recover.
+            ;; It emits a canonical reply but does not execute retry attempts.
             [re-frame.http.test-support]
             ;; "Start long" seeds a pending handle straight into the registry.
             ;; The write seam (`record-in-flight!`) isn't on the public facade,
@@ -160,14 +153,11 @@
 ;; Retry-recover  —  canned-stub at app level
 ;; ============================================================================
 ;;
-;; The "it failed, retried, and recovered" path — without needing a flaky
-;; endpoint to make it happen on cue. The handler issues
-;; :rf.http/managed-canned-success, which synthesises a canonical
-;; {:status :ok :value {:delta 5} …} reply: the exact shape the live fx
-;; would deliver if its retry policy hit a real endpoint that 503s once and
-;; then 200s. The stub lets you exercise the contract without owning a
-;; server, and — the part that matters — the handler can't tell the
-;; difference. It reads the reply the same way either way.
+;; This path synthesises the success envelope a recovered request would
+;; eventually deliver: {:status :ok :value {:delta 5} …}. It deliberately does
+;; not exercise retry policy, attempt counting, or backoff. The point here is
+;; narrower: the handler consumes the same canonical reply whether it came from
+;; the live transport or a controlled test seam.
 
 (rf/reg-event :http-counter/retry-recover
   (fn [{:keys [db]} [_ reply]]
@@ -190,7 +180,7 @@
               :reply-to [:http-counter/retry-recover]}]]})))
 
 ;; ============================================================================
-;; Start long / Cancel  —  a REAL abort of a REAL in-flight request
+;; Start long / Cancel  —  managed-abort over a seeded registry handle
 ;; ============================================================================
 ;;
 ;; The abort contract is simple to state: you cancel an in-flight
@@ -200,17 +190,12 @@
 ;; to the handler that issued the request. The abort section of
 ;; docs/async/http.md has the details.
 ;;
-;; Here's the catch worth being honest about: this app serves only static
-;; assets, so a real GET resolves in a blink and nothing ever lingers
-;; in-flight long enough to cancel. Demoing a cancel against a request that's
-;; already finished would be theatre. So instead, "Start long" seeds a
-;; request-id-keyed handle straight into the registry — the very atom the
-;; live transport writes into — which gives us a request that is genuinely,
-;; deterministically pending. "Cancel" then fires the *live*
-;; `:rf.http/managed-abort` fx at that handle. Only the transport is stood
-;; in for. The registry entry, the abort fx, and the `:rf.http/aborted`
-;; classification are all the real thing — and you can watch them in Xray
-;; and the trace stream.
+;; This app serves only static assets, so a GET resolves too quickly to cancel
+;; reliably. "Start long" instead seeds a request-id-keyed handle through the
+;; same registry API used by the live transport. "Cancel" fires the production
+;; `:rf.http/managed-abort` fx at that handle. The demo therefore covers handle
+;; lookup, registry cleanup, and the `:rf.http/aborted` reply, while explicitly
+;; leaving network transport and `AbortController` out of scope.
 
 (def long-request-id :http-counter/long)
 
@@ -221,12 +206,12 @@
 (def long-pending-url "api/long")
 
 (rf/reg-fx :http-counter/seed-long-request
-  {:doc       "Demo-only fx that fakes a request stuck in flight. It records a
-               request-id-keyed handle in the framework registry whose
+  {:doc       "Demo-only fx that seeds a request handle in the in-flight
+               registry. It records a request-id-keyed handle whose
                :abort-fn clears the slot and dispatches the :rf.http/aborted
                reply back to :http-counter/start-long. That's the whole trick: it
-               lets the live :rf.http/managed-abort fx resolve a real handle
-               end-to-end, with no real request behind it."
+               lets :rf.http/managed-abort exercise its production lookup,
+               cleanup, and reply path, with no network request behind it."
    :platforms #{:client}}
   (fn fx-seed-long-request [frame-ctx {:keys [request-id]}]
     ;; A small but important wrinkle. The :abort-fn doesn't run now — it runs
@@ -250,8 +235,8 @@
          ;; so we mirror that: the canonical envelope is the appended last arg.
          :abort-fn (fn [reason]
                      (http-registry/clear-in-flight! request-id)
-                     ;; rf2-ibksxg — the canonical abort reply: an abort is
-                     ;; `:status :cancelled`, the `:rf.http/aborted` map under
+                     ;; The canonical abort reply uses `:status :cancelled`,
+                     ;; with the `:rf.http/aborted` map under
                      ;; `:error` (mirrors the live transport's abort path).
                      (rf/dispatch [:http-counter/start-long
                                    {:status        :cancelled

--- a/examples/core/notebook/core.cljs
+++ b/examples/core/notebook/core.cljs
@@ -165,7 +165,7 @@
   ;; clicked. We must therefore detect the scheme against a copy with every
   ;; ASCII control + space char removed; otherwise a control-char-broken
   ;; scheme fails the anchored regex, is misclassified as scheme-LESS, and is
-  ;; waved through as a live `<a href>` — the allowlist bypass rf2-9tllom.
+  ;; incorrectly allowed as a live `<a href>`.
   ;; Stripping [\x00-\x20\x7f] is a *superset* of what the browser drops, so
   ;; we can never under-detect a scheme the browser would go on to resolve;
   ;; the anchored regex + `:else nil` then default-DENY anything not

--- a/examples/core/notebook/index.html
+++ b/examples/core/notebook/index.html
@@ -119,8 +119,8 @@
       font-family: var(--ex-mono);
     }
 
-    /* Narrow viewport: collapse to single column with tabs (skipped here
-       to keep the example small; smoke test runs at desktop width). */
+    /* This focused example intentionally omits a mobile layout; its visual
+       smoke coverage uses the desktop three-pane composition. */
   </style>
 </head>
 <body>

--- a/examples/core/seven_guis/temperature/core.cljs
+++ b/examples/core/seven_guis/temperature/core.cljs
@@ -8,8 +8,8 @@
    to show a stale value.
 
    re-frame2 sidesteps the whole thing. Keep *one* canonical temperature in
-   app-db and *one* event that writes it. Both inputs read from that single
-   value through subscriptions and write back through that single event. The
+   app-db. Both inputs read from that value through subscriptions, and each
+   field has one edit event that converts its input into the canonical unit. The
    fields never speak to each other, so they can't fight. The trap simply
    never opens.
 

--- a/examples/core/seven_guis/timer/core.cljs
+++ b/examples/core/seven_guis/timer/core.cljs
@@ -38,9 +38,9 @@
 ;; SCHEMA
 ;; ============================================================================
 
-;; The whole timer is four numbers. That's it — no objects, no timer handle,
-;; nothing hiding outside app-db. This schema spells them out, and the runtime
-;; checks every commit against it.
+;; Four app-db values determine the timer: elapsed time, target duration, an
+;; active flag, and a generation token. Scheduled callbacks remain runtime-owned;
+;; app-db stores no timer handle. The runtime checks this slice on every commit.
 (def TimerState
   [:map
    [:elapsed-ms :int]                  ;; milliseconds counted since the last reset
@@ -65,13 +65,11 @@
 ;; handle to cancel a tick once it's in the air. So how do we ever *stop* a
 ;; tick, or start a clean one over the top of it?
 ;;
-;; The answer is a generation token, `:tick-gen`. Think of it as a wristband at
-;; a club: every tick is stamped with the generation it was scheduled under,
-;; and when it finally fires it checks whether its stamp still matches the one
-;; in app-db. Want to retire whatever's in flight? Bump `:tick-gen`. The old
-;; tick still goes off — we can't stop that — but its wristband is now stale,
-;; so it quietly does nothing. Then we schedule a fresh tick under the new
-;; generation. Net result: exactly one live chain, ever.
+;; The answer is a generation token, `:tick-gen`. Every scheduled tick carries
+;; the generation under which it was created and checks that value against
+;; app-db when it runs. Bumping `:tick-gen` retires previously scheduled ticks:
+;; they still fire, but return no effects when their generation is stale. A new
+;; tick is then scheduled under the current generation, leaving one active chain.
 ;;
 ;; Two handlers lean on this:
 ;;   - Reset bumps the generation so a tick scheduled a moment earlier can't
@@ -96,7 +94,7 @@
   (fn handler-timer-tick [{:keys [db]} [_ gen]]
     (let [{:keys [elapsed-ms duration-ms tick-active? tick-gen]} (:timer db)]
       (if (not= gen tick-gen)
-        ;; Wrong wristband — this tick belongs to a retired generation. Ignore it.
+        ;; This tick belongs to a retired generation; ignore it.
         {}
         (let [next-elapsed (min (+ elapsed-ms tick-ms) duration-ms)
               done?        (>= next-elapsed duration-ms)]


### PR DESCRIPTION
## Summary

- review all 39 files under `examples/core` for stale, misleading, duplicate, or insufficient explanations
- distinguish the managed HTTP example's live Fetch paths from its canned-reply and seeded-registry seams
- correct smaller educational inaccuracies in the temperature and timer examples
- remove internal bead references from user-facing source comments and clarify the notebook's desktop-only layout boundary

## Why

The managed HTTP prose described a canned success as an exercised retry and a seeded registry handle as a network request in flight. Readers could therefore infer that this example validates retry scheduling, backoff, or `AbortController`, none of which runs here. The revised explanation names the exact contract each button covers without changing behavior.

The rest of the changes keep the examples internally consistent: temperature has one edit event per field, the timer stores four mixed values rather than four numbers, and issue-tracker identifiers no longer leak into educational comments.

## Impact

Documentation and comments only. No events, effects, subscriptions, views, styles, or runtime behavior changed.

## Verification

- `npx shadow-cljs compile examples/managed-http-counter examples/temperature examples/timer examples/login examples/notebook` (all five builds, 0 warnings)
- `npm run test:cljs` (8,465 tests, 39,156 assertions, 0 failures, 0 errors)
- `clj-kondo` over the five changed CLJS namespaces (0 errors; 2 pre-existing unused-binding warnings)
- `git diff --check`

Tracking: `rf2-ollt50`
