### PR TITLE
docs(examples): correct pattern explanations (rf2-c5x02i)

### DIFF
--- a/examples/patterns/boot/boot.cljs
+++ b/examples/patterns/boot/boot.cljs
@@ -185,7 +185,7 @@
                :action (fn [{data :data [_ _ reply] :event}]
                          {:data (assoc data :payload (:value reply))})}
               {:target :failed
-               ;; rf2-ibksxg — the classified failure map rides under :error.
+               ;; Managed HTTP puts the classified failure map under :error.
                :action (fn [{data :data [_ _ reply] :event}]
                          {:data (assoc data :error (:error reply))})}]}}
 
@@ -242,9 +242,9 @@
     ;; place it's allowed to reach the machine's own snapshot: mirroring it
     ;; into `:data` here — from inside the machine's own action — is what
     ;; Spec 005 §Where snapshots live means by "the machine sets its own
-    ;; :data." An ordinary handler writing straight into
-    ;; `[:rf.runtime/machines ...]` (which `:boot/apply-hydration` used to
-    ;; do) is the thing this action replaces.
+    ;; :data." An ordinary handler must not write straight into
+    ;; `[:rf.runtime/machines ...]`; the machine action is the ownership
+    ;; boundary for snapshot data.
     (fn [{data :data [_ staged] :event}]
       {:data (merge data staged)})}
 

--- a/examples/patterns/boot/schema.cljs
+++ b/examples/patterns/boot/schema.cljs
@@ -25,10 +25,11 @@
             ;; Schemas ship in their own artefact; this require registers
             ;; `rf/reg-app-schema`.
             [re-frame.schemas]
-            ;; This one turns Malli validation on. The Malli adapter ns
-            ;; publishes the default validator, and requiring it is the CLJS
-            ;; opt-in — skip it and the validator soft-passes, so a malformed
-            ;; slice slides through with no failure trace.
+            ;; The schemas facade above loads this Malli adapter and publishes
+            ;; the default validator. Naming the adapter explicitly here makes
+            ;; the concrete validator behind these Malli forms visible at the
+            ;; declaration site; activation does not depend on this second
+            ;; require.
             [re-frame.schemas.malli]))
 
 ;; ============================================================================

--- a/examples/patterns/boot/views.cljs
+++ b/examples/patterns/boot/views.cljs
@@ -11,8 +11,8 @@
 
    2. **Ready** — once the boot reaches `:ready`, we swap in `[main-app]`.
       It reads `:config`, `:flags`, `:user`, and `:routes` straight from
-      app-db with no defensiveness, because by now they're all there and
-      not going anywhere.
+      app-db without per-slice loading branches, because by now they're all
+      present.
 
    3. **Failed** — `[boot-failed]` shows the error and a retry button.
       Retry dispatches `[:app/boot [:boot/restart]]` to run the boot

--- a/examples/patterns/long_running_work/core.cljs
+++ b/examples/patterns/long_running_work/core.cljs
@@ -15,11 +15,11 @@
      of who's finished; the runtime owns the join state, so the
      parent's `:data` stays clean.
    - **Cancellation that always lands** — whenever the parent leaves
-     `:working` (you hit Cancel, the job finishes, the frame is
-     destroyed, a timeout fires), one `:rf.machine/destroy` fx tears
-     down every child still standing. Their in-flight timers and HTTP
-     requests go down with them, so nothing keeps ticking after the
-     curtain falls.
+     `:working` (you hit Cancel or the job finishes), one
+     `:rf.machine/destroy` fx tears down every child still standing.
+     Destroying the owning frame tears down the machine tree too. The
+     children's in-flight timers and HTTP requests go down with them, so
+     nothing keeps ticking after the curtain falls.
    - **Live progress** — each child fires a `:progress` event at the
      parent after every chunk. The parent stashes it in
      `:data :progress`, the `:work/progress-fraction` sub recomputes,

--- a/examples/patterns/nine_states/README.md
+++ b/examples/patterns/nine_states/README.md
@@ -141,13 +141,6 @@ beats which, you edit one table, not ten views.
   transitions stay inline, as plain `event → target` entries. The
   machine declaration is meant to be read.
 
-## Legacy variant
-
-This example is the canonical implementation of Pattern-NineStates. The
-older variant — nine boolean discriminator subs plus a priority `cond` —
-still works and is supported, but it's the shape this example exists to
-retire. Reach for the machine.
-
 ## File layout
 
 ```

--- a/examples/patterns/nine_states/core.cljs
+++ b/examples/patterns/nine_states/core.cljs
@@ -159,8 +159,8 @@
 ;; equivalent of an app-schema, but for runtime-db-resident snapshot data.
 ;; Three fields, one per axis's needs: `:items` (the list the `:data`
 ;; region's cardinality guards count), `:error` (the failure the `:error`
-;; branch records), and `:archived-at` (the stamp the `:mode` region writes
-;; on `:archive`).
+;; branch records), and `:archived-at` (the caller-supplied `:now` value the
+;; `:mode` region writes on `:archive`, or `0` when the event omits it).
 (def NineStatesData
   [:map
    [:items       [:vector Todo]]
@@ -302,6 +302,8 @@
       {:data (assoc data :error failure)})
 
     :stamp-archived
+    ;; The demo buttons omit `:now`, so their deterministic sentinel is 0.
+    ;; A host that needs a real archive time supplies it on the event.
     (fn action-stamp-archived [{data :data [_ {:keys [now]}] :event}]
       {:data (assoc data :archived-at (or now 0))})}
 
@@ -460,8 +462,8 @@
 (rf/reg-event :nine-states.demo/load-failed
   {:doc "The fetch fell over. Pass the failure category along to the
          machine, which routes the :data region to :error."}
-  ;; rf2-ibksxg — the classified :rf.http/* failure map rides under :error on
-  ;; the canonical reply; we forward it as the machine's own :failure domain slot.
+  ;; The canonical reply carries the classified :rf.http/* failure map under
+  ;; :error; we forward it as the machine's own :failure domain slot.
   (fn handler-demo-load-failed [_ [_ {:keys [error]}]]
     {:fx [[:dispatch [:ui/nine-states [:fetch-failed {:failure error}]]]]}))
 

--- a/examples/patterns/nine_states/stories_host.cljs
+++ b/examples/patterns/nine_states/stories_host.cljs
@@ -28,11 +28,11 @@
 
    ## One adapter
 
-   This host installs the full Reagent adapter (`re-frame.adapter.reagent`)
-   — the substrate the Story shell itself renders on — and runs everything
-   on it: live app, shell, and every variant canvas. (The example's own
-   `core.cljs` mounts on the stock Reagent adapter for its standalone
-   `:examples/nine-states` build; this showcase is a separate entry point.)
+   This host installs the Reagent adapter (`re-frame.adapter.reagent`) — the
+   substrate the Story shell itself renders on — and runs everything on it:
+   live app, shell, and every variant canvas. The standalone
+   `:examples/nine-states` build installs the same adapter from `core.cljs`;
+   this showcase is simply a separate entry point.
    It all works because `nine-states.core/root-view` is a
    substrate-agnostic `reg-view` — it renders identically either way.
 

--- a/examples/patterns/websocket/connection.cljs
+++ b/examples/patterns/websocket/connection.cljs
@@ -249,9 +249,9 @@
       ;; inbound event (`[:ws/send …]` or `[:ws/request …]`), not just its
       ;; body. `:flush-queue` (above) re-dispatches each verbatim on the next
       ;; `:connected` entry, so a queued request rejoins `:register-request`
-      ;; and gets correlated. (Buffering a bare body instead put a request's
-      ;; whole envelope onto the wire as if it were the payload —
-      ;; uncorrelated, never answered.)
+      ;; and gets correlated. Keeping the event preserves whether the queued
+      ;; item was a send or a request; a bare body would lose that routing
+      ;; intent.
       (fn action-enqueue-message [{data :data event :event}]
         {:data (update data :queue conj event)})
 
@@ -447,8 +447,9 @@
 ;; ============================================================================
 
 ;; `reg-machine` marks this registration `:rf/machine? true` — the flag a
-;; declarative `:spawn` looks for when resolving its target. Forget it and
-;; the spawn quietly does nothing, which is a fun afternoon to debug.
+;; declarative `:spawn` looks for when resolving its target. An unregistered
+;; target is rejected with `:rf.error/machine-spawn-unregistered-type`; no
+;; child snapshot is created.
 (rf/reg-machine :ws/connection connection-machine)
 
 ;; --- subs -------------------------------------------------------------

--- a/examples/patterns/websocket/schema.cljs
+++ b/examples/patterns/websocket/schema.cljs
@@ -85,9 +85,9 @@
    [:draft    :string]
    ;; The inbox log, newest-first, so the view just renders top-down.
    [:received [:vector Message]]
-   ;; The most recent correlated reply (set by :ws.app/request-reply, or by
-   ;; :ws/handle-message for server pushes) — handy for the round-trip view
-   ;; and a convenient thing for a test to assert on.
+   ;; The most recent correlated reply. :ws/handle-message updates this only
+   ;; when the body has a :request-id, and :ws.app/request-reply records the
+   ;; same body for the registered callback. Server pushes stay in :received.
    [:last-reply [:maybe :any]]
    ;; The ticking source for each message's :rx-seq stamp.
    [:rx-count :int]])

--- a/examples/patterns/websocket/views.cljs
+++ b/examples/patterns/websocket/views.cljs
@@ -12,14 +12,15 @@
       `:websocket/connecting`, `:websocket/authenticating`,
       `:websocket/connected`, `:websocket/reconnecting`,
       `:websocket/failed` — through this example's per-tag subs
-      (`:ws/connected?` and friends in `connection.cljs`, each a
-      `contains?` over the snapshot's `:tags` union). It doesn't care which
-      leaf carries the `:connected` intent, only that the tag is there.
+      (`:ws/connected?` and friends in `connection.cljs`, each chaining off
+      the framework's `:rf.machine/has-tag?` sub). It doesn't care which leaf
+      carries the `:connected` intent, only that the tag is there.
       Ask, don't tell. See docs/machines/glossary.md#state-tag.
 
-   2. The send form disables itself off the `:ws/connected?` sub, not a
-      `cond` picking apart the raw `:state` vector. Same answer, far nicer
-      to read."
+   2. The send form uses the `:ws/connected?` sub to label its action
+      **Send** or **Queue**. It remains usable while disconnected because
+      the connection machine owns the offline queue; the view never picks
+      apart the raw `:state` vector."
   (:require [re-frame.core :as rf]
             [websocket.messages]
             [websocket.connection]))


### PR DESCRIPTION
## Summary

- review all 25 files under `examples/patterns` across boot, long-running work, nine states, and websocket
- correct explanations that had drifted from current schema activation, spawn failure, offline queue, reply, and adapter behavior
- remove internal tracker references and obsolete implementation-history prose
- keep the patch behavior-neutral: comments, docstrings, and README text only

## Notable corrections

- schema activation now reflects that `re-frame.schemas` loads the Malli adapter
- unregistered spawn targets are documented as failing closed with `:rf.error/machine-spawn-unregistered-type`
- the websocket send form is documented as queueing while offline, rather than disabling
- server pushes are distinguished from correlated replies in `:last-reply`
- the long-running-work overview no longer claims this example has a timeout exit path

## Verification

- worker worktree guard passed
- no open pull request touched `examples/patterns` at review start or before publish
- `git diff --check`
- `npx shadow-cljs compile examples/boot examples/long-running-work examples/nine-states examples/nine-states-with-stories examples/websocket` (all five builds passed with 0 warnings)
- `npm run test:cljs` (8,465 tests, 39,156 assertions, 0 failures, 0 errors; 3 pre-existing compiler warnings outside this patch)
- `clj-kondo --parallel --fail-level error --lint examples/patterns` (0 errors; 2 pre-existing warnings in unchanged files)

Tracking: `rf2-c5x02i`
