### PR TITLE
docs(examples): clarify script contracts (rf2-1ixa0n)

### DIFF
--- a/examples/scripts/check-examples-assets.cjs
+++ b/examples/scripts/check-examples-assets.cjs
@@ -27,7 +27,7 @@
  *
  * What this gate does (STATIC — no browser, no Playwright)
  * -------------------------------------------------------
- * It walks every tracked example index.html and, for each:
+ * It walks every example host page present under examples/ and, for each:
  *
  *   1. RESOLVES every local asset reference (link href, script src,
  *      img/source/video src, each `srcset`/`imagesrcset` candidate, a
@@ -99,7 +99,7 @@
  *      asset (see ALLOWLIST, the page-opt-out projection of the shared
  *      examples asset/exception manifest). The TodoMVC stylesheet opt-out is
  *      encoded in that manifest: it is exempt from style.css (it links the
- *      vendored TodoMVC base.css + index.css) but STILL required to carry the
+ *      npm-staged TodoMVC base.css + index.css) but STILL required to carry the
  *      shared favicon + OG card.
  *
  *   3. Asserts the social-preview (og:image) target is a RASTER, never an SVG:
@@ -117,9 +117,10 @@
  *      (a) EXISTENCE: the required _shared files are present on disk (incl. the
  *          og.png raster + its og.svg source art) and structure.css remains
  *          reachable from style.css's @import.
- *      (b) OG RASTER BYTES: og.png actually decodes as a PNG (signature + IHDR)
- *          at the documented 1200x630 dimensions — a renamed SVG/text file or a
- *          wrong-size export fails, not just a missing file (rf2-mon7tz).
+ *      (b) OG RASTER HEADER: og.png has the PNG signature and an IHDR declaring
+ *          the documented 1200x630 dimensions — a renamed SVG/text file or a
+ *          wrong-size export fails, not just a missing file (rf2-mon7tz). This
+ *          is a header check, not a full pixel decode or CRC validation.
  *      (c) OG SOURCE-ART PALETTE: og.svg carries no retired / sub-AA colour
  *          literal as a live paint value, so the re-exported card cannot drift
  *          back below the shared palette's accessibility decisions (rf2-y82dk9).
@@ -680,11 +681,12 @@ const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0
 const OG_PNG_WIDTH = 1200;
 const OG_PNG_HEIGHT = 630;
 
-// Validate that `data` is a decodable PNG whose IHDR declares the expected
+// Validate that `data` has a PNG signature and an IHDR declaring the expected
 // dimensions. Returns { ok, width, height, reason }. A spec-conformant PNG
 // always opens with the 8-byte signature immediately followed by the IHDR
 // chunk (length=13, type='IHDR', then width:uint32be, height:uint32be), so
-// reading the dimensions needs no full decoder — just the first 24 bytes.
+// reading the dimensions needs no full decoder — just the first 24 bytes. This
+// intentionally does not validate later chunks, CRCs, or decoded pixel data.
 // Accepts a Buffer or coerces a string fixture to one (latin1 preserves bytes).
 function validatePng(data, expectedWidth = OG_PNG_WIDTH, expectedHeight = OG_PNG_HEIGHT) {
   const buf = Buffer.isBuffer(data) ? data : Buffer.from(String(data), 'latin1');
@@ -1110,7 +1112,10 @@ function scanPage(io, indexAbsPath, opts = {}) {
   //    og:image and render no large preview card — a failure mode invisible to
   //    a pure "the referenced file exists" check. (rf2-lr4am3)
   for (const og of extractOgImageRefs(html)) {
-    if (isExternalRef(og)) continue; // a hosted absolute URL is the page's call
+    // Remote targets are governed separately by the direct-HTML network
+    // allowlist. Their URL suffix is not reliable evidence of the response
+    // media type, so this source-file extension check applies only to local refs.
+    if (isExternalRef(og)) continue;
     const ext = path.extname(og).toLowerCase();
     if (!SOCIAL_PREVIEW_RASTER_EXTS.has(ext)) {
       errors.push(

--- a/examples/scripts/check-reagent-slim-boundary.cjs
+++ b/examples/scripts/check-reagent-slim-boundary.cjs
@@ -24,7 +24,7 @@
  *
  * What this gate does (STATIC — no browser, no Playwright, no compile)
  * -------------------------------------------------------------------
- * It walks every tracked Clojure(Script) source in the stock-Reagent buckets and
+ * It walks every Clojure(Script) source present in the stock-Reagent buckets and
  * FAILS if any of them requires a slim-substrate namespace:
  *
  *   - `reagent2.*`                    (the slim substrate's user-facing import)

--- a/examples/scripts/examples-port.cjs
+++ b/examples/scripts/examples-port.cjs
@@ -1,6 +1,7 @@
 /*
- * Port resolver for the adapter-smoke orchestrator
- * (serve-and-run-adapter-smokes.cjs).
+ * Port resolver shared by the adapter-smoke orchestrator
+ * (`implementation/adapters/scripts/serve-and-run-adapter-smokes.cjs`) and
+ * the standalone-example development server (`serve-example.cjs`).
  *
  * Why this exists (rf2-0u6ce). The orchestrator used to hard-bind
  * 0.0.0.0:8030. But 8030 is ALSO claimed by the top-level :dev-http map

--- a/examples/scripts/examples-staging.cjs
+++ b/examples/scripts/examples-staging.cjs
@@ -12,6 +12,10 @@
  * staging rather than re-implementing an ad hoc copy. One source of truth for
  * "what lands in an example's output dir".
  *
+ * The Story feature-load and play-script runners also consume the path-guarded
+ * cleanStageDirs helper, but stage their testbed-specific HTML themselves; they
+ * do not use the standalone-example asset manifest.
+ *
  * This module ALSO derives the standalone-example manifest (build id ->
  * output dir + source folder + index.html) directly from shadow-cljs.edn, so
  * the dev runner has no hardcoded build->folder table that could drift. The
@@ -36,7 +40,7 @@ const SHARED_SRC = path.join(EXAMPLES_ROOT, '_shared');
 // ---------------------------------------------------------------------------
 
 // Minimal recursive copy. Each file overwrites the destination
-// unconditionally so repeat runs pick up re-compiled bundles.
+// unconditionally so repeat runs pick up current shared assets.
 function copyDirRecursive(src, dest) {
   fs.mkdirSync(dest, { recursive: true });
   for (const entry of fs.readdirSync(src, { withFileTypes: true })) {

--- a/examples/scripts/port-resolver.cjs
+++ b/examples/scripts/port-resolver.cjs
@@ -1,11 +1,12 @@
 /*
  * Shared port-resolution mechanism for the example/Story orchestrators.
  *
- * Two sibling orchestrators each need to pick a free TCP port and serve
- * `implementation/out/examples` on it:
+ * Two resolver policies serve the runners that host
+ * `implementation/out/examples` on a free TCP port:
  *
- *   - examples-port.cjs            — the adapter-smoke orchestrator.
- *   - story-feature-load-port.cjs  — the Story feature-load + play-script
+ *   - examples-port.cjs            — the adapter-smoke orchestrator and the
+ *                                    standalone-example development server.
+ *   - story-feature-load-port.cjs  — the Story feature-load and play-script
  *                                    gates.
  *
  * Both want IDENTICAL contention handling — a loopback bind-and-release
@@ -56,8 +57,9 @@ function makeParseExplicitPort(envVarName, { actionable = false } = {}) {
 }
 
 // Bind-and-release probe on 127.0.0.1 (by default). Resolves true when
-// the port is free, false when it is taken (any bind error —
-// EADDRINUSE on Mac/Linux, EACCES for a dual-stack listener on Windows).
+// the port is free and false when it cannot be bound. The latter includes
+// EADDRINUSE on Mac/Linux and EACCES for a dual-stack listener on Windows;
+// callers intentionally treat every bind failure as "unavailable".
 function canListen(port, host = '127.0.0.1') {
   return new Promise((resolve) => {
     const server = net.createServer();

--- a/examples/scripts/run-story-feature-load-tests.cjs
+++ b/examples/scripts/run-story-feature-load-tests.cjs
@@ -6,6 +6,12 @@
  * buffered browser diagnostics plus Story-specific context: feature,
  * phase, URL, active variant, active mode, and browser console/page
  * errors. See docs/quiet-tests.md.
+ *
+ * The serving orchestrator injects STORY_FEATURE_LOAD_BASE_URL. A direct run
+ * defaults to 127.0.0.1:8031; STORY_FEATURE_LOAD_TIMEOUT_MS controls each
+ * navigation/spec timeout, and STORY_FEATURE_LOAD_SPEC filters spec basenames.
+ * Every selected module must export a string `url` and a `run(page)` function
+ * (`name` and `context(page)` are optional diagnostic metadata).
  */
 
 const path = require('path');

--- a/examples/scripts/serve-and-run-story-play-scripts.cjs
+++ b/examples/scripts/serve-and-run-story-play-scripts.cjs
@@ -7,8 +7,9 @@
  * whose body carries a non-empty `:play-script` or `:plays` slot (via
  * the `window.__rf2_story_ci` global installed by
  * `re-frame.story.play.ci-runner/install-ci-hooks!`), navigates the
- * shell to each variant, waits for each play's terminal status
- * (`:pass` / `:fail`), and prints a per-play report.
+ * shell to each variant, waits for each play's terminal status (`:pass`,
+ * `:fail`, or `:cannot-run`), and prints a per-play report. `:cannot-run` is
+ * terminal but never expected, so it produces a failed row without a timeout.
  *
  * Multi-play
  * ----------
@@ -30,7 +31,7 @@
  *     is treated as expected-fail; the runner asserts `:fail`
  *   - everything else asserts `:pass`
  *
- * The seeded fixtures in the testbed:
+ * Representative seeded fixtures in the testbed:
  *   :story.counter-play-script/passing            → expects :pass
  *   :story.counter-play-script/failing            → expects :fail
  *
@@ -206,13 +207,9 @@ function variantIdToParam(idStr) {
 }
 
 /**
- * Navigate the Story shell to `variantId` using the same hash route
- * the human shell uses (`#/stories?variant=story.foo/bar`). The
- * search params are placed AFTER the hash because the shell parses
- * them out of `window.location.hash`.
- *
- * Falls back to the share-link affordance (`select-variant` event)
- * if the URL parse path is unreachable.
+ * Navigate the Story shell to `variantId` using the human shell's share-link
+ * shape (`?variant=story.foo/bar#/stories`). The query is placed BEFORE the
+ * hash route because shell hydration reads `window.location.search`.
  */
 async function navigateToVariant(page, baseUrl, variantId) {
   const variantStr = variantIdToParam(variantId);
@@ -466,10 +463,11 @@ function writeFailureReport(failures, allResults, browserMessages, pageErrors = 
  * That contradicted the pageerror discipline the adjacent example and
  * Story feature-load runners already keep. Any pageerror is now fatal.
  *
- * Console errors are intentionally NOT fatal: they are captured (under
- * RF2_VERBOSE_TESTS) for diagnostics only, matching the adjacent
- * runners, which likewise gate on crashes/`pageerror` and not on
- * console noise. Pure inputs → exit code, so it is unit-testable.
+ * Console errors are intentionally NOT fatal in this runner: play status and
+ * uncaught page errors own its verdict, while console messages are captured
+ * under RF2_VERBOSE_TESTS for diagnostics. This differs from the broader Story
+ * feature-load runner, which treats console errors as failures. Pure inputs ->
+ * exit code, so this helper is unit-testable.
  */
 function computeExitCode({ failures, pageErrors }) {
   const unexpectedOutcomes = (failures && failures.length) || 0;

--- a/examples/scripts/spec-helpers.cjs
+++ b/examples/scripts/spec-helpers.cjs
@@ -11,8 +11,9 @@
  *
  * Those specs drive raw `playwright` (not `@playwright/test`), so we don't
  * get the `expect()` matcher API for free. These helpers fill the gap with
- * just the matchers we need: text equality, attribute checks, value
- * checks. Each polls until success or timeout.
+ * just the matchers we need: text, attribute, input-value, visibility, and
+ * count checks, plus generic wait helpers. Condition-based helpers poll until
+ * success or timeout; expectVisible delegates to Playwright's own wait.
  */
 
 async function expectTextEquals(locator, expected, timeoutMs = 5000) {
@@ -115,9 +116,10 @@ async function waitForValue(readFn, predicate, options = {}) {
  * wait for a value to *settle* (e.g. animated progress counters that have
  * already advanced past zero and now must stop).
  *
- * readFn is an async function returning the current value (anything that
- * survives a strict `===` check between two reads — strings, numbers, or
- * primitive-equal objects via JSON-stringify if you need it).
+ * readFn is an async function returning the current value. Stability uses
+ * strict `===`, so primitives compare by value and objects only compare when
+ * readFn returns the same reference. For structural object equality, have
+ * readFn return a stable primitive representation such as JSON.stringify(...).
  *
  * Options:
  *   intervalMs (default 100) — gap between reads.

--- a/examples/scripts/story-feature-load-port.cjs
+++ b/examples/scripts/story-feature-load-port.cjs
@@ -1,7 +1,8 @@
 /*
- * Worktree-aware port resolver for the Story feature-load gate. The
- * deterministic hash of the worktree path derives a stable port offset
- * so parallel worktrees (rf2-* worker checkouts) never collide on 8031.
+ * Worktree-aware port resolver for the Story feature-load and play-script
+ * gates. The deterministic hash of the worktree path derives a stable port
+ * preference so parallel worktrees (rf2-* worker checkouts) normally start
+ * from different ports instead of all contending for 8031.
  * Honours STORY_FEATURE_LOAD_PORT if set; otherwise scans forward from
  * the derived preference until an unused port is found.
  *


### PR DESCRIPTION
## Summary
- clarify which example and Story runners own the shared port and staging helpers
- correct Story play-runner docs for query-before-hash navigation, `cannot-run`, and console-error policy
- make static-gate explanations match actual filesystem enumeration and PNG header validation
- document strict-equality behavior and direct Story feature-load runner inputs

## Review coverage
Reviewed all 12 files under `examples/scripts` (about 4,300 lines). Changes are explanation-only across 9 files; executable behavior is unchanged. No changed file overlaps an existing open PR. The open `rf2-78th1g` bead concerns changed-surface CI routing for the asset manifest, not this explanation pass.

## Verification
- `npm run test:script-policy` (pass)
- `node --check` on all 9 changed `.cjs` files (pass)
- `git diff --check` (pass)

Tracking: `rf2-1ixa0n`