### PR TITLE
docs(examples): clarify RealWorld implementation notes

### DIFF
--- a/examples/real-apps/realworld_http/article_editor.cljs
+++ b/examples/real-apps/realworld_http/article_editor.cljs
@@ -99,9 +99,9 @@
 ;; lighter `:editor/reset` (slice wipe only), so no fresh flow registration
 ;; leaks on each visit.
 
-;; The 3-slot triple `[flow-id metadata derive-fn]` (rf2-bqstzr) — the exact
-;; shape both `reg-flow` and `:rf.fx/reg-flow` take, so `[:rf.fx/reg-flow
-;; can-submit-flow]` splats it straight through.
+;; This value uses the canonical `[flow-id metadata derive-fn]` triple shared by
+;; `reg-flow` and `:rf.fx/reg-flow`, so `[:rf.fx/reg-flow can-submit-flow]`
+;; passes the complete registration through unchanged.
 (def can-submit-flow
   [:editor/can-submit?
    {:doc    "True when the editor draft is both valid AND dirty (it differs from
@@ -555,12 +555,11 @@
 
 ;; ---- per-render-state subviews ----
 ;;
-;; Right now every render-mode just delegates to `editor-form`, and the form's
-;; own tag queries (`:editor/busy`, `:editor/can-delete`) sort out the
-;; in-form differences. So why four wrappers that all do the same thing? They
-;; give you one cheap, obvious hook per mode for the day you want
-;; mode-specific scaffolding — a full-page spinner, a bespoke load-error layout
-;; — without having to crack open the `case` branch to do it.
+;; Every render mode delegates to `editor-form`; its tag queries
+;; (`:editor/busy`, `:editor/can-delete`) handle the current in-form differences.
+;; The wrappers deliberately preserve one named extension point per mode for
+;; page-level scaffolding such as a full-page loader or a dedicated load-error
+;; layout, while keeping the root `case` stable.
 
 (reg-view ^{:doc "Lifecycle :idle / :submitting — the form being a form
                    (interactive, or busy mid-save)."}

--- a/examples/real-apps/realworld_http/auth.cljs
+++ b/examples/real-apps/realworld_http/auth.cljs
@@ -37,8 +37,9 @@
 ;;
 ;; One detail that isn't ours to choose: the official RealWorld E2E suite reads
 ;; the session straight out of `localStorage["jwtToken"]`, so we use that exact
-;; key, un-namespaced, verbatim. Conformance is checked against standalone
-;; serving (one app per origin), so there's no collision to worry about.
+;; key, un-namespaced, verbatim. The contract assumes one app per origin. The
+;; repo's dev orchestrator serves both RealWorld variants from one origin, so
+;; they share this key there; standalone serving gives each app its own origin.
 
 (rf/reg-fx :auth.session/persist
   {:doc       "Save or clear the JWT in localStorage, under the contract key
@@ -60,7 +61,7 @@
 ;; supplier reads localStorage; that supplier runs once, its value is recorded
 ;; onto the causal token, and from then on replay hands back the captured token
 ;; verbatim. See the coeffects guide on the two grades:
-;; ../../../docs/core/concepts/effects-and-coeffects.md#two-grades-ambient-and-recordable
+;; ../../../docs/core/coeffects.md#two-grades-ambient-and-recordable
 ;;
 ;; It's also why `ssr.cljc` can happily redact [:auth :token] from the
 ;; hydration payload: the client doesn't need the server to ship it the token,

--- a/examples/real-apps/realworld_http/comments.cljs
+++ b/examples/real-apps/realworld_http/comments.cljs
@@ -52,7 +52,7 @@
 ;; the very same string. `:comment-form/submit` asks for it via
 ;; `:rf.cofx/requires` and reads it flat, staying pure and replayable. See the
 ;; coeffects guide:
-;; ../../../docs/core/concepts/effects-and-coeffects.md#two-grades-ambient-and-recordable
+;; ../../../docs/core/coeffects.md#two-grades-ambient-and-recordable
 (rf/reg-cofx :realworld/temp-comment-id
   {:recordable? true
    :doc "A replay-safe temp-id for an optimistically-posted comment."}

--- a/examples/real-apps/realworld_http/core.cljs
+++ b/examples/real-apps/realworld_http/core.cljs
@@ -576,13 +576,12 @@
     ;;     `:app/initialise` so the token is sitting in app-db before the
     ;;     bearer-auth interceptor needs to send anything authenticated.
     ;;   - `:app/initialise` — fans out to all the per-feature initialisers.
-    ;; There is no explicit `:rf.route/handle-url-change` step any more — the
-    ;; `:url-bound? true` frame lifecycle (rf2-g8pbwg) does the first
-    ;; URL→slice sync itself, automatically, AFTER every `:initial-events`
-    ;; step above has run — which is exactly the ordering this app needs: by
-    ;; then the session is restored, so when a deep link to a
-    ;; `:requires-auth` route runs its `:can-enter` gate, it's judging a
-    ;; logged-in user correctly rather than bouncing them by mistake.
+    ;; `:url-bound? true` performs the initial URL→slice sync after every
+    ;; `:initial-events` step above. That ordering is load-bearing: session
+    ;; restore completes before a deep link to a `:requires-auth` route runs its
+    ;; `:can-enter` gate, so the gate judges the restored user rather than an
+    ;; uninitialised auth slice. No explicit `:rf.route/handle-url-change`
+    ;; initial event is needed.
     (rdc/render @react-root
                 [rf/frame-provider {:id              :rf/default
                                     :doc             "Realworld demo frame."

--- a/examples/real-apps/realworld_http/http.cljs
+++ b/examples/real-apps/realworld_http/http.cljs
@@ -229,7 +229,7 @@
 ;; In tests and replay fixtures you can pin an exact instant through the
 ;; dispatch opts (`{:rf.cofx {:rf/time-ms 1781078400123}}`); live code just
 ;; lets the router stamp the real time. See the coeffects guide:
-;; ../../../docs/core/concepts/effects-and-coeffects.md#two-grades-ambient-and-recordable
+;; ../../../docs/core/coeffects.md#two-grades-ambient-and-recordable
 
 ;; ============================================================================
 ;; FAILURE PROJECTION

--- a/examples/real-apps/realworld_http/routing.cljs
+++ b/examples/real-apps/realworld_http/routing.cljs
@@ -136,12 +136,10 @@
 ;; Back/Forward — with zero per-door plumbing. See the routing guide on guards:
 ;; ../../../docs/routing/concepts.md#blocking-a-navigation
 ;;
-;; This is the whole reason `:can-enter` shipped: the auth gate used to be a
-;; hand-rolled interceptor that flattened all three nav events down to one
-;; `{:id :params}` target, skipped the protected handler, and stashed a bespoke
-;; `[:auth :return-to]` resume crumb — ~100 lines re-implementing what
-;; `:rf/pending-navigation` + `:rf.route/continue` already do. Now it's a guard
-;; sub plus one `:rf.route/entry-blocked` handler.
+;; The guard and `:rf.route/entry-blocked` handler share the framework's single
+;; pending-navigation path. That keeps target capture, cancellation, and resume
+;; semantics in routing rather than duplicating them for each navigation entry
+;; point.
 
 ;; The guard sub. `true` → OK to enter. It reads the durable `[:auth :user]`
 ;; presence (not the machine's `:authed` state), so a deep-link that arrives
@@ -160,8 +158,8 @@
 ;; handler turns that into a login redirect and stashes the target for the
 ;; post-login bounce-back. The auth machine's `:store-session` action
 ;; (auth.cljs) reads `[:auth :return-to]` on a successful login and navigates
-;; there — the SAME resume path the interceptor version used, minus the
-;; hand-rolled three-door flattening.
+;; there. Both the rejection and the eventual resume therefore remain ordinary,
+;; traceable routing events.
 ;;
 ;; The pending-nav slot carries `:rejecting-route` (the target route-id) and
 ;; `:requested-url`; we resolve the params off the URL so a deep-link like
@@ -180,7 +178,7 @@
 
 ;; This example might be served from a sub-path — a host staging lots of demos
 ;; side by side could mount it at /realworld/ — even though on its own it'd
-;; live at /. `with-base-path` (rf2-g8pbwg) is a STRATEGY COMBINATOR: it wraps
+;; live at /. `with-base-path` is a strategy combinator: it wraps
 ;; the default history strategy so the base path is stripped off every
 ;; inbound URL and re-added to every outbound one, at the framework's four
 ;; egress/ingress consult points (Spec 012 §URL strategies) — so the whole
@@ -188,8 +186,7 @@
 ;; owned `/`. Declared as this app's `:url-strategy` on the URL-owning frame
 ;; in core.cljs; the frame's `:url-bound? true` creation installs the
 ;; base-path-aware popstate listener AND does the first-load URL→state sync
-;; automatically — there is no hand-rolled listener or explicit install call
-;; here any more.
+;; automatically, so this namespace needs no separate listener or install call.
 (def url-strategy
   (routing/with-base-path routing/history-url-strategy "/realworld"))
 

--- a/examples/real-apps/realworld_resources/article_editor.cljs
+++ b/examples/real-apps/realworld_resources/article_editor.cljs
@@ -39,8 +39,8 @@
    and feed and the instance settled, and the continuation branches save-vs-delete
    on the reply value (save and delete share one instance, so they share one
    continuation). The seed-on-load continuation is the `:realworld/article`
-   ensure's `:reply-to [:editor/article-loaded]` (rf2-p1yri7 — a resource read now
-   gets the same causal completion continuation a mutation does): a cache-hit
+   ensure's `:reply-to [:editor/article-loaded]`, the resource-read counterpart
+   of a mutation completion continuation: a cache-hit
    fires it immediately, a fetch fires it on settle, and a stale/superseded reply
    never fires it. Both are declarative, replayable causal events, not Form-3
    `reagent.ratom/run!` reactions watching a settle. The render bodies, as
@@ -126,9 +126,9 @@
 ;; drain; a fresh editor starts invalid and clean anyway, so that one-event lag
 ;; never carries a stale value.
 
-;; The 3-slot triple `[flow-id metadata derive-fn]` (rf2-bqstzr) — the exact
-;; shape both `reg-flow` and `:rf.fx/reg-flow` take, so `[:rf.fx/reg-flow
-;; can-submit-flow]` splats it straight through.
+;; This value uses the canonical `[flow-id metadata derive-fn]` triple shared by
+;; `reg-flow` and `:rf.fx/reg-flow`, so `[:rf.fx/reg-flow can-submit-flow]`
+;; passes the complete registration through unchanged.
 (def can-submit-flow
   [:editor/can-submit?
    {:doc    "True when the editor draft is both valid AND dirty (differs from the
@@ -526,8 +526,8 @@
    ONE lifecycle concern left is releasing the article read's lease when the
    editor leaves the screen. There is no off-render reaction: the seed-on-load is
    the `:realworld/article` ensure's `:reply-to [:editor/article-loaded]`
-   continuation (a declarative causal event — a resource read now gets the same
-   reply-side continuation a mutation does, rf2-p1yri7), and the same-component
+   continuation (a declarative causal event, and the read-side counterpart of a
+   mutation's reply continuation), and the same-component
    `/editor/A` -> `/editor/B` slug-change lease release rides
    `:editor/load-article` (navigation is causal). So the only thing that
    genuinely needs a component hook is leaving the editor entirely — the unmount.

--- a/examples/real-apps/realworld_resources/auth.cljs
+++ b/examples/real-apps/realworld_resources/auth.cljs
@@ -317,8 +317,8 @@
               [:dispatch [:auth/ensure-session-feed]]]}))
 
     :record-error
-    ;; rf2-ibksxg — the appended HTTP reply is the canonical envelope; the
-    ;; classified `:rf.http/*` failure map rides under `:error` (was `:failure`).
+    ;; The appended HTTP reply is the canonical envelope; the classified
+    ;; `:rf.http/*` failure map rides under its `:error` key.
     (fn [{[_ {:keys [error]}] :event}]
       {:data {:error (rh/failure->message error)}})
 

--- a/examples/real-apps/realworld_resources/core.cljs
+++ b/examples/real-apps/realworld_resources/core.cljs
@@ -269,7 +269,7 @@
     ;;
     ;; `:url-strategy routing/url-strategy` is what makes this work under the
     ;; dev orchestrator's `/realworld-resources/` mount point: it wraps the
-    ;; default history strategy with `with-base-path` (rf2-g8pbwg) so that
+    ;; default history strategy with `with-base-path` so that
     ;; prefix is stripped before the matcher ever sees the URL, and re-added on
     ;; the way out. `:url-bound? true` frame creation then automatically
     ;; installs the base-path-aware popstate listener AND does the first

--- a/examples/real-apps/realworld_resources/resources.cljs
+++ b/examples/real-apps/realworld_resources/resources.cljs
@@ -254,7 +254,7 @@
 ;;   - logged out, the reference resolves to nil, fail-closed: the sub becomes a
 ;;     loud 'scope unresolved' signal, never a quiet read of someone else's cache.
 ;; See the named resolver in scope.cljs and
-;; ../../../docs/resources/how-to/add-auth.md.
+;; ../../../docs/core/how-to/add-auth.md.
 
 (rf/reg-resource :realworld/feed
   {:doc            "The authenticated user's feed (`/articles/feed`). Session-

--- a/examples/real-apps/realworld_resources/routing.cljs
+++ b/examples/real-apps/realworld_resources/routing.cljs
@@ -255,8 +255,8 @@
 ;; ============================================================================
 ;;
 ;; The dev orchestrator serves this example under `/realworld-resources/`, but
-;; the routes above are written as if it owned `/`. `with-base-path`
-;; (rf2-g8pbwg) wraps the default history strategy so that prefix is
+;; the routes above are written as if it owned `/`. `with-base-path` wraps the
+;; default history strategy so that prefix is
 ;; stripped/re-added automatically at the framework's four egress/ingress
 ;; consult points (Spec 012 §URL strategies). Declared as this app's
 ;; `:url-strategy` on the URL-owning frame in core.cljs; the frame's

--- a/examples/real-apps/realworld_resources/scope.cljs
+++ b/examples/real-apps/realworld_resources/scope.cljs
@@ -2,7 +2,7 @@
   "The resource cache SCOPE for this app — the fail-closed leak boundary,
    written as a named resource-scope resolver (`reg-resource-scope`). See scope:
    ../../../docs/resources/glossary.md#scope, and the worked walkthrough in
-   ../../../docs/resources/how-to/add-auth.md.
+   ../../../docs/core/how-to/add-auth.md.
 
    Scope is the cache's tenant / user / permission boundary, and the cardinal
    rule is that it fails closed: a resource never silently falls back to a shared

--- a/examples/real-apps/realworld_shared/markdown.cljs
+++ b/examples/real-apps/realworld_shared/markdown.cljs
@@ -83,10 +83,9 @@
   ;; chars) from a URL before resolving its scheme, so a payload like
   ;; "java<TAB>script:alert(1)" fires as javascript: on click. Detect the
   ;; scheme against a copy with every ASCII control + space char removed, then
-  ;; run it through the allowlist — an unknown or obfuscated scheme is
-  ;; default-DENIED, never waved through the `:else` branch as if it were a
-  ;; relative URL (the bug the old `:else true` had: a non-matching scheme run
-  ;; fell through and was KEPT, contradicting this fn's own contract).
+  ;; run it through the allowlist. An unknown or obfuscated scheme must be
+  ;; default-DENIED rather than treated as a relative URL; only a URL with no
+  ;; scheme at all reaches the relative-reference branch below.
   (let [u (str/replace (or url "") #"[\x00-\x20\x7f]" "")]
     (if (str/blank? u)
       false


### PR DESCRIPTION
## Summary

- review all 32 files under `examples/real-apps` for comment, docstring, and explanatory accuracy
- replace five links to documentation pages that moved during the core/docs navigation rewrite
- remove historical bead IDs and migration narration from the example source, keeping explanations focused on the live flow, routing, reply, and URL-strategy contracts
- document the shared-origin `localStorage["jwtToken"]` caveat consistently across both RealWorld variants
- clarify the current extension points around editor render modes, resource reply continuations, and URL-bound frame startup

## Impact

This is a behavior-neutral documentation change. It makes the two flagship RealWorld examples usable as current architecture references without exposing internal tracker history or sending readers to missing pages. No event, request, schema, resource, mutation, or view form changed.

## Verification

- `npx shadow-cljs compile examples/realworld examples/realworld-resources` (317 and 313 files; 0 warnings)
- `npm run test:cljs` (8,465 tests; 39,156 assertions; 0 failures, 0 errors)
- `clj-kondo --lint examples/real-apps` (0 errors; 2 pre-existing unused-require warnings)
- `git diff --check`
- source-link audit: every relative `docs/*.md` target referenced from `examples/real-apps` resolves
- tracker audit: no `rf2-*` IDs remain under `examples/real-apps`

Tracking: rf2-745mpk
