### PR TITLE
docs(examples): correct substrate explanations

### DIFF
--- a/examples/substrates/helix/counter/README.md
+++ b/examples/substrates/helix/counter/README.md
@@ -74,12 +74,11 @@ character for character, in all three counters. Below it is the only
 substrate-specific code in the example: the Helix `defnc` views and the
 mount.
 
-The duplicated model across three folders looks like copy-paste rot. It
-isn't — the duplication *is* the demonstration. Byte-identical events and a
-byte-identical sub, driving a Reagent `reg-view`, a UIx `defui`, and a Helix
-`defnc`, prove the adapter contract is the whole story: nothing leaks across
-the boundary. Hoist the model into a shared namespace and you lose that
-proof.
+The duplicated model across three folders is deliberate. Byte-identical events
+and a byte-identical sub, driving a Reagent `reg-view`, a UIx `defui`, and a
+Helix `defnc`, make the adapter boundary visible in a direct diff. A shared,
+substrate-agnostic namespace could still preserve bundle isolation, but it
+would hide this local comparison and make each example less self-contained.
 
 ## Files
 

--- a/examples/substrates/helix/counter/core.cljs
+++ b/examples/substrates/helix/counter/core.cljs
@@ -30,16 +30,16 @@
 ;; a pure function: hand it the coeffects (which carry the current app-db) and
 ;; the event vector, and it hands back an effect map. The `{:db …}` key means
 ;; "replace app-db with this value", and the runtime commits it atomically at
-;; the end of the pipeline run. Not a word about React in here — so this block is
-;; byte-for-byte the same as the Reagent and UIx counters. See
+;; the end of the pipeline run. Not a word about React in here — so these four
+;; registrations are byte-for-byte the same as the Reagent and UIx counters. See
 ;; `docs/core/glossary.md#event-handler`.
 ;;
 ;; You might wonder why the three counters retype these handlers instead of
-;; sharing one namespace. It's deliberate. Each example is its own self-
-;; contained build, and a bundle-isolation test checks that a Helix bundle
-;; ships zero Reagent or UIx code (and vice versa). A shared namespace dragged
-;; into all three builds would quietly break that guarantee. The seam worth
-;; learning is the substrate boundary below — one dataflow, three view layers.
+;; sharing one namespace. Keeping them local is a teaching choice, not a bundle-
+;; isolation requirement: a shared substrate-agnostic namespace could still be
+;; renderer-free. Local copies make each example self-contained and turn the
+;; substrate boundary below into a direct, readable diff — one dataflow, three
+;; view layers.
 
 (rf/reg-event :counter/initialise
   (fn [{:keys [db]} _event] {:db {:counter/value 5}}))

--- a/examples/substrates/helix/login/README.md
+++ b/examples/substrates/helix/login/README.md
@@ -74,16 +74,15 @@ Helix sits downstream. *Below* the line is the **only** substrate-specific code
 in the file: the Helix `defnc` views and the mount.
 
 That artefact layer is **duplicated** across all three login examples. The
-duplication is **deliberate**, not copy-paste drift — it is the intended v2
-style. The shared ids *are* the demonstration: the same machine, schemas, and
-HTTP stub driving Reagent `reg-view`, UIx `defui`, and Helix `defnc` is what
-proves the [Spec 005 machine](../../../../spec/005-StateMachines.md),
+shared ids make the demonstration readable in place: the same machine, schemas,
+and HTTP stub drive Reagent `reg-view`, UIx `defui`, and Helix `defnc`. That is
+the comparison which shows the [Spec 005 machine](../../../../spec/005-StateMachines.md),
 [Spec 010 schemas](../../../../spec/010-Schemas.md), and
 [Spec 014 managed-HTTP](../../../../spec/014-HTTPRequests.md) surfaces are
-substrate-agnostic. Each substrate login is a self-contained `:browser` build
-carrying no other substrate's code. Hoisting the shared model into one namespace
-would look tidier but would quietly destroy the claim — the parity demonstration
-needs the three to stand alone.
+substrate-agnostic. A shared substrate-neutral namespace could preserve renderer
+isolation, but keeping the model local makes each `:browser` build readable on
+its own and preserves the direct three-way comparison. The bundle-isolation
+gate scans the smaller counter builds; the login builds are compile-gated.
 
 ## Files
 

--- a/examples/substrates/helix/login/core.cljs
+++ b/examples/substrates/helix/login/core.cljs
@@ -51,11 +51,12 @@
 ;; care which view library draws it.
 ;;
 ;; You might expect this shared half to live in one file the three examples
-;; require. It deliberately doesn't. Each example is its own self-contained
-;; `:browser` build, and the bundle-isolation gate proves a Helix bundle
-;; carries no Reagent or UIx code — a shared file pulled into all three would
-;; blow that apart. So the lesson here is "one dataflow, three view layers,"
-;; not "factor out the common bit." The duplication is on purpose.
+;; require. Keeping it local is deliberate, but not required for renderer
+;; isolation: a substrate-agnostic namespace could remain renderer-free. The
+;; local copies keep each example self-contained and make "one dataflow, three
+;; view layers" visible in a direct diff. The bundle-isolation gate establishes
+;; the renderer boundary on the smaller counter builds; login builds are
+;; compile-gated rather than scanned by that gate.
 
 ;; ============================================================================
 ;; SCHEMAS
@@ -63,11 +64,12 @@
 
 ;; What a login submit carries: an email and a password.
 ;;
-;; Notice where the password is allowed to go. It rides this event-arg schema
-;; and the HTTP body, and that's it — it never lands in app-db. So there's no
-;; app-db path to tag `:sensitive`; the only thing to scrub is the request on
-;; the wire, which the HTTP call below handles with `:sensitive? true`. See
-;; docs/core/how-to/keep-secrets-out-of-traces.md.
+;; This schema validates shape; it does not classify or redact the password.
+;; While the user types, the password lives in the form draft in app-db and in
+;; `:auth.login/edit-field` events. A valid submit clears the durable draft;
+;; `:sensitive? true` below separately redacts the managed-HTTP request. A
+;; production form must classify every other observation surface explicitly;
+;; see docs/core/how-to/keep-secrets-out-of-traces.md.
 (def Credentials
   [:map
    [:email    [:re #".+@.+"]]
@@ -206,7 +208,7 @@
               :on-failure [:auth.login/flow [:auth.login/failure]]}]]})
 
     :record-error
-    ;; rf2-ibksxg — the classified failure map rides under :error.
+    ;; The classified failure map rides under :error.
     (fn [{data :data [_ {:keys [error]}] :event}]
       {:data (-> data
                  (update :attempts inc)
@@ -295,9 +297,9 @@
 ;; `:on-change` dispatches `:auth.login/edit-field`. See
 ;; docs/core/how-to/build-a-form.md.
 ;;
-;; Like the machine above, this whole block — the defaults, the events, and the
-;; draft/slice subs further down — is shared verbatim across the three login
-;; examples. Only the view syntax changes.
+;; Like the machine above, the three login examples carry equivalent defaults,
+;; event registrations, and draft/slice subscriptions. Only the view syntax
+;; changes.
 
 ;; The empty draft a fresh form starts from. Its value shape is `Credentials`
 ;; (email regex, 8-char-minimum password) — the very schema the machine's
@@ -351,8 +353,9 @@
 ;; On a clean draft this is the hand-off: it flips `:status` to `:submitting`,
 ;; clears any stale field errors, and dispatches the draft INTO the machine.
 ;; That dispatch is the one and only place the draft crosses over. From here on
-;; the machine owns the real status (in-flight / authed / error / locked); the
-;; slice's `:status` just shadows it.
+;; the machine owns the real status (in-flight / authed / error / locked). The
+;; slice's `:status` records only that the form handed off a valid submit; views
+;; use machine tags for the authoritative lifecycle.
 ;;
 ;; On an INVALID draft we stop here: the field errors land in `:errors`
 ;; (rendered under each input) and nothing is dispatched. Handing a bad draft to
@@ -364,10 +367,11 @@
 ;; Watch how the password is handled. On the clean branch the handler lifts it
 ;; off the draft, sends it to the machine, and CLEARS `[:draft :password]` in
 ;; the very same commit. The moment the request is on its way the secret has
-;; done its one job, so we don't leave it lounging in app-db where the next
-;; snapshot or recording could scoop it up. Its only trip off the box is inside
-;; the HTTP body (scrubbed by `:sensitive? true`); it never touches `:submitted`
-;; or the machine's `:data`. See docs/core/how-to/keep-secrets-out-of-traces.md.
+;; done its one job, so we don't leave it in app-db for later snapshots. This
+;; cleanup does not retroactively redact the edit/submit events or earlier
+;; snapshots; `:sensitive? true` covers only the HTTP request. It never touches
+;; `:submitted` or the machine's `:data`. See
+;; docs/core/how-to/keep-secrets-out-of-traces.md.
 (rf/reg-event :auth.login/submit-form
   {:doc "Submit the login form: validate the draft against Credentials. If
          clean, dispatch it into the :auth.login/flow machine's :submit
@@ -452,9 +456,10 @@
 ;; ============================================================================
 ;;
 ;; Below this line is the only substrate-specific code in this example: the
-;; Helix views + the mount. The Reagent and UIx login examples share every
-;; line ABOVE this divider and differ only in what sits BELOW it (Reagent
-;; `reg-view`, UIx `defui` + `use-subscribe`, Helix `defnc` + `use-subscribe`).
+;; Helix views + the mount. The Reagent and UIx login examples carry the same
+;; registration ids and behavior above this divider, then use their own view
+;; idioms below it (Reagent `reg-view`, UIx `defui` + `use-subscribe`, Helix
+;; `defnc` + `use-subscribe`).
 
 ;; ============================================================================
 ;; VIEWS  (Helix — defnc + use-subscribe)

--- a/examples/substrates/helix/process_monitor/core.cljs
+++ b/examples/substrates/helix/process_monitor/core.cljs
@@ -58,10 +58,10 @@
 ;; EVENTS
 ;; ============================================================================
 ;;
-;; The tick is a `:dispatch-later` that reschedules itself — a loop with no
-;; off switch, because that effect has no cancel API. Left alone, a hot reload
-;; or a re-mount would just spawn a second chain alongside the first, and now
-;; two loops append lines forever. Not ideal.
+;; The tick is a `:dispatch-later` that reschedules itself. The effect returns no
+;; cancellation handle, so the application needs another way to retire a chain.
+;; Left alone, a re-mount would spawn a second chain alongside the first, and
+;; two loops would append lines forever.
 ;;
 ;; The fix is a generation guard, and it's pleasingly small. A counter,
 ;; `:process-monitor/tick-gen`, records which "arming" each chain belongs to:
@@ -304,9 +304,9 @@
   ;; retires it. We capture `(:dispatch (rf/capture-frame))` here in the `let`,
   ;; at render-time, while the frame is still in scope. By the time the effect
   ;; and its cleanup actually run — after commit — that scope is gone, so a
-  ;; dispatch fetched in there would have no frame to land in. Grab it now,
-  ;; close over it, and you're safe. The Helix adapter README §use-effect has
-  ;; the long version.
+  ;; dispatch fetched in there would have no frame to land in. Grab it now so
+  ;; the closure carries the intended frame. The Helix adapter README
+  ;; §use-effect has the long version.
   (let [dispatch (:dispatch (rf/capture-frame))]
     (helix-hooks/use-effect
       ;; Empty deps ⇒ run once on mount, clean up once on unmount.

--- a/examples/substrates/helix/process_monitor/index.html
+++ b/examples/substrates/helix/process_monitor/index.html
@@ -63,7 +63,7 @@
     .pm-tile-warn { border-left: 3px solid var(--ex-warn); }
     /* Warning value is TEXT on the light --ex-bg-sunken tile — use the AA-safe
        deep amber (--ex-warn-deep), not decorative --ex-warn (sub-AA as text).
-       The left border above stays decorative amber. (rf2-ihruwa) */
+       The left border above stays decorative amber. */
     .pm-tile-warn .pm-tile-value { color: var(--ex-warn-deep); }
     .pm-tile-bad  { border-left: 3px solid var(--ex-error); }
     .pm-tile-bad  .pm-tile-value { color: var(--ex-error); }
@@ -123,7 +123,7 @@
     .pm-chip-info.is-on  { color: var(--ex-info);    border-color: var(--ex-info); }
     /* Active warn chip carries label TEXT + a state border on the light
        --ex-bg-sunken pane-head — use AA-safe --ex-warn-deep so both the text
-       (≥4.5:1) and the UI-component border (≥3:1) clear WCAG. (rf2-ihruwa) */
+       (≥4.5:1) and the UI-component border (≥3:1) clear WCAG. */
     .pm-chip-warn.is-on  { color: var(--ex-warn-deep); border-color: var(--ex-warn-deep); }
     .pm-chip-error.is-on { color: var(--ex-error);     border-color: var(--ex-error); }
 
@@ -191,7 +191,7 @@
       letter-spacing: 0.06em;
     }
     .pm-log-level-info  { color: var(--ex-info); }
-    .pm-log-level-warn  { color: var(--ex-warn-deep); }  /* warn log level is TEXT on paper — AA-safe deep amber (rf2-ihruwa) */
+    .pm-log-level-warn  { color: var(--ex-warn-deep); }  /* warn log level is text on paper: use AA-safe deep amber */
     .pm-log-level-error { color: var(--ex-error); }
     .pm-log-msg { color: var(--ex-ink); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 

--- a/examples/substrates/uix/counter/core.cljs
+++ b/examples/substrates/uix/counter/core.cljs
@@ -31,7 +31,7 @@
 ;; and the event vector, and it hands back an effect map. The `{:db …}` key
 ;; means "replace app-db with this value", and the runtime commits it
 ;; atomically at the end of the pipeline run. Not a word about React in here — so
-;; this block is byte-for-byte the same on every substrate. See
+;; these four registrations are byte-for-byte the same on every substrate. See
 ;; `docs/core/glossary.md#event-handler`.
 
 (rf/reg-event :counter/initialise

--- a/examples/substrates/uix/dashboard/core.cljs
+++ b/examples/substrates/uix/dashboard/core.cljs
@@ -23,7 +23,7 @@
 
    The derivation graph is the concept worth slowing down for; the
    guide glossary has the full picture
-   (../../../docs/core/glossary.md#the-derivation-graph).
+   (docs/core/glossary.md#the-derivation-graph).
 
    The shared visual identity comes from examples/_shared/css/style.css."
   (:require [uix.core :refer [$ defui]]
@@ -140,9 +140,9 @@
   "Turn a series of numbers into an SVG <path> `d` string, scaled to fit a
    100×30 viewBox. Pure in, pure out; `sparkline` below draws it.
 
-   Why a <path> and not a <polyline>: at this tiny size with a hair-thin
-   stroke, one `M…L…L…` path renders noticeably crisper. The renderer
-   isn't anti-aliasing every vertex twice, and your eye can tell."
+   A polyline would render the same segments. This example uses a path because
+   the helper can emit one compact `d` string without building an intermediate
+   collection of point attributes."
   [series]
   (let [n     (count series)
         lo    (apply min series)

--- a/examples/substrates/uix/login/README.md
+++ b/examples/substrates/uix/login/README.md
@@ -85,11 +85,12 @@ siblings — [`examples/core/login/`](../../../core/login/) is the reference,
 schemas, the machine, the subs, and the HTTP stub are the same in all three; the
 view layer is the only thing that differs. Three renderers, one model.
 
-The model is *duplicated* across the three logins on purpose, not by copy-paste
-drift. Each substrate login is a self-contained build. The bundle-isolation gate
-proves the point on the counter twins — a UIx-only `main.js` carries no Reagent
-code — and a shared model required into all three logins would defeat exactly
-the isolation the parity claim rests on.
+The model is duplicated across the three logins on purpose so each example is
+self-contained and the parity comparison remains local. The bundle-isolation
+gate proves the renderer boundary on the smaller counter builds — a UIx-only
+counter `main.js` carries no Reagent code — while the login builds are
+compile-gated. A shared substrate-neutral model could preserve isolation, but it
+would hide the direct comparison this example is meant to teach.
 
 One mechanical note: the namespace here is `uix.login.core`, not `login.core` —
 the `substrates/uix/` folder becomes the namespace prefix, so this example

--- a/examples/substrates/uix/login/core.cljs
+++ b/examples/substrates/uix/login/core.cljs
@@ -43,11 +43,12 @@
 ;; ============================================================================
 
 ;; What valid credentials look like: an email and a password of at least 8
-;; characters. The password is a careful little traveller — it rides only this
-;; schema and the HTTP body, and is never written to app-db. The request body
-;; that carries it gets scrubbed from traces by `:sensitive? true` on the
-;; managed-HTTP request below (docs/core/how-to/keep-secrets-out-of-traces.md).
-;; The same schema guards reagent/login and helix.
+;; characters. This schema validates shape; it does not classify or redact the
+;; password. While the user types, the password lives in the form draft in
+;; app-db and in `:auth.login/edit-field` events. A valid submit clears the
+;; durable draft; `:sensitive? true` below separately redacts the managed-HTTP
+;; request. See docs/core/how-to/keep-secrets-out-of-traces.md for the
+;; classification required on every other observation surface.
 (def Credentials
   [:map
    [:email    [:re #".+@.+"]]
@@ -175,8 +176,8 @@
       {:fx [[:rf.http/managed
              ;; `:sensitive? true` is the per-request wire scrub: it redacts
              ;; this request body — which is carrying the `:password` — from
-             ;; every `:rf.http/*` trace event, so the secret never lands in the
-             ;; tape. See docs/core/how-to/keep-secrets-out-of-traces.md.
+             ;; every `:rf.http/*` trace event, so the HTTP surface does not add
+             ;; it to the tape. See docs/core/how-to/keep-secrets-out-of-traces.md.
              {:request    {:method :post
                            :url    "/api/login"
                            :body   creds
@@ -187,7 +188,7 @@
               :on-failure [:auth.login/flow [:auth.login/failure]]}]]})
 
     :record-error
-    ;; rf2-ibksxg — the classified failure map rides under :error.
+    ;; The classified failure map rides under :error.
     (fn [{data :data [_ {:keys [error]}] :event}]
       {:data (-> data
                  (update :attempts inc)
@@ -342,7 +343,8 @@
 ;; clear any stale field errors, and dispatch the draft into the machine. That
 ;; hand-off is the single place the draft ever crosses into the machine. From
 ;; there the machine — not the slice — owns the real story: in flight, authed,
-;; errored, locked. The slice's `:status` is just a mirror.
+;; errored, locked. The slice's `:status` records only the valid-submit handoff;
+;; views use machine tags for the authoritative lifecycle.
 ;;
 ;; On an *invalid* draft we stop here: the field errors land in `:errors`
 ;; (rendered under each input) and nothing is dispatched. Handing a bad draft
@@ -354,10 +356,10 @@
 ;; And a word on the password. On the clean branch we read it off the draft,
 ;; give it to the machine, then clear `[:draft :password]` in the very same
 ;; commit. Once the request is on its way the secret has done its job, and
-;; there's no reason to leave it sitting in app-db where the next snapshot or
-;; recording would scoop it up. Its only trip off the box is inside the HTTP
-;; request body (scrubbed by that `:sensitive? true` flag), and it's never
-;; written to `:submitted` or the machine's `:data`. See
+;; there's no reason to leave it sitting in app-db for later snapshots. This
+;; cleanup does not retroactively redact the edit/submit events or earlier
+;; snapshots; `:sensitive? true` covers only the HTTP request. The password is
+;; never copied to `:submitted` or the machine's `:data`. See
 ;; docs/core/how-to/keep-secrets-out-of-traces.md.
 (rf/reg-event :auth.login/submit-form
   {:doc "Submit the login form: validate the draft against Credentials. If
@@ -416,7 +418,7 @@
 ;; what makes them controlled. The per-field-error sub follows the form
 ;; pattern's rule for when an error is allowed to show: once the field is
 ;; touched, or once the user has tried to submit. Like the events above, these
-;; subs are shared verbatim across the three substrate examples.
+;; subs have equivalent registrations across the three substrate examples.
 
 (rf/reg-sub :auth.login/form-slice
   {:doc "The whole login-form slice at [:auth :login-form] — the root the other
@@ -440,6 +442,13 @@
     (when (or (:submit-attempted? slice)
               (contains? (:touched slice) field))
       (first (get-in slice [:errors field])))))
+
+;; ============================================================================
+;; --------------------------  SUBSTRATE BOUNDARY  ---------------------------
+;; ============================================================================
+;;
+;; Everything above this divider is the substrate-agnostic artefact layer.
+;; Everything below it is UIx-specific: `defui` views, hooks, and the mount.
 
 ;; ============================================================================
 ;; VIEWS  (UIx — defui + use-subscribe)


### PR DESCRIPTION
## Summary

- reviews all 23 files under `examples/substrates` and updates the 10 files with actionable explanation drift
- corrects Helix/UIx login comments that overstated password redaction and app-db handling
- narrows bundle-isolation claims to the counter builds the gate actually scans
- makes the UIx login substrate boundary explicit and scopes byte-identity claims to the registrations that are actually identical
- replaces an unsupported sparkline rendering claim and removes stale bead references from teaching comments

## Why

These examples are the comparison surface for Reagent, UIx, Helix, and Reagent Slim. Several comments had drifted beyond the code: the login draft and edit events still carry the password even though the managed-HTTP request is redacted, the slice `:status` is not a live mirror of machine state, and the bundle-isolation gate does not scan the login builds. The revised text states those boundaries directly without changing runtime behavior.

## Impact

Documentation, docstrings, and comments only. No executable forms or example behavior changed.

Tracking bead: `rf2-4ojf79`.

## Verification

- `npx shadow-cljs compile examples/counter-uix examples/counter-helix examples/login-uix examples/dashboard-uix examples/login-helix examples/process-monitor-helix examples/counter-slim-and-fast` (all seven builds, 0 warnings)
- `clj-kondo --lint examples/substrates` (0 errors; 4 existing unused-binding warnings)
- `clojure -M:splint ../examples/substrates` (7 existing warnings on unchanged executable forms)
- `git diff --check`