### PR TITLE
docs(core): connect destructuring to app-db

### DIFF
--- a/docs/cljs/index.md
+++ b/docs/cljs/index.md
@@ -1216,54 +1216,60 @@ One last bit of reader shorthand you'll meet often.
 
 ## Destructuring
 
-Destructuring is a way to bind local names to values inside a collection, without writing lookup code by hand. The original collection is not changed.
+Destructuring binds local names to values inside a collection, without writing lookup code by hand. Read a binding from right to left: the value is on the right, and the pattern on the left names the pieces you want. The original collection is not changed.
 
 ### With `let`
 
-Here is a map. Without destructuring you might write:
+Without destructuring, you might pull values from a map one at a time:
 
 ```cljs
 (let [a-map {:db {:value 0} :event [:inc]}
-      db    (get a-map :db)]  ;; <- get is used to reach into the map and obtain a value
-  db)
+      db    (get a-map :db)
+      event (get a-map :event)]
+  [db event])
 ```
 
-evaluates to `{:value 0}`. Now the same thing with destructuring — still using `a-map`:
+Now the same lookup with a map pattern:
 
 ```cljs
-(let [a-map         {:db {:value 0} :event [:inc]}
-      {:keys [db]}  a-map]  ;; <-- destructuring is used to obtain the :db value from the map
-  db)
+(let [a-map {:db {:value 0} :event [:inc]}
+      {:keys [db event]} a-map]
+  [db event])
 ```
 
-Again `{:value 0}`. The pattern `{:keys [db]}` means: look up `:db` in the map, and bind that value to a local called `db` — no separate `get`.
+Both evaluate to `[{:value 0} [:inc]]`. The pattern `{:keys [db event]}` means: look up `:db` and `:event`, then bind their values to locals with the same names.
 
-Vectors work by position:
+Vector patterns bind by position:
 
 ```cljs
-(let [[a b] [1 2]]
-  b)
+(let [[event-id payload] [:step-size/set {:step-size 10}]]
+  [event-id payload])
 ```
 
-evaluates to `2` — first element is `a`, second is `b`.
+This evaluates to `[:step-size/set {:step-size 10}]`: the first element is bound to `event-id`, and the second to `payload`.
+
+When a position is not used, Clojure programmers conventionally give it a name beginning with `_`:
+
+```cljs
+(let [[_ payload] [:step-size/set {:step-size 10}]]
+  payload)
+```
+
+`_` is still an ordinary local name; it signals to the reader that this code intentionally ignores the event id.
 
 ### In function parameters
 
-Here is destructuring used in the arguments of a `defn`:
+Function parameters use the same binding patterns. A re-frame2 event handler often combines map and vector destructuring:
 
 ```cljs
-(defn my-fn 
-  [{:keys [db]}]
-  db)
+(fn [{:keys [db]} [_ {:keys [step-size]}]]
+  {:db (assoc db :step-size step-size)})
 ```
 
-Now call the function with a map argument containing the key `:db`:
-```cljs
-(my-fn  {:db {:value 0 :other 1}})
-```
+- The first argument is a map. `{:keys [db]}` binds its `:db` value to `db`.
+- The second argument is an event vector. `_` receives the ignored event id; the second position is a map whose `:step-size` value is bound to `step-size`.
 
-which evaluates to `{:value 0 :other 1}` — the value at `:db`, bound to the local `db`.
-
+The pattern mirrors the shape of the incoming data while naming only the values the function needs. You will meet this exact handler shape on the Core pages.
 
 ## Summary
 

--- a/docs/core/app-db.md
+++ b/docs/core/app-db.md
@@ -1,6 +1,6 @@
-# app-db: the one place
+# app-db: one map, one write path
 
-The [introduction](introduction.md) showed how re-frame2 **computes**. This page is where the data in that loop lives.
+The [introduction](introduction.md) showed how re-frame2 **computes**. This page follows the application data through that loop: where it lives and how it changes through events.
 
 **[app-db](glossary.md#app-db)** is the application state for one [frame](glossary.md#frame): one immutable Clojure map. Handlers return a *description* of the next map; the [event pipeline](glossary.md#event-pipeline) is what actually writes.
 
@@ -54,19 +54,28 @@ This page makes the initial value **explicit** through an `:initialise` event, t
  [stepping-counter]]
 ```
 
-No second store. After `:initialise`, the shape already holds both facts:
+The handler parameters use [destructuring](../cljs/index.md#destructuring). `{:keys [db]}` takes app-db from the world map. `[_ {:keys [step-size]}]` ignores the event id and takes `:step-size` from the event's payload map.
+
+No second store. The events produce a sequence of complete map values:
 
 ```clojure
-{:value 0 :step-size 1}
+[:initialise]
+;; => {:value 0 :step-size 1}
+
+[:step-size/set {:step-size 10}]
+;; => {:value 0 :step-size 10}
+
+[:inc]
+;; => {:value 10 :step-size 10}
 ```
 
-— not a lone `{:value 0}` that later grows a second key by accident. You put both in the seed map (or add keys in later events the same way).
+The seed is not a lone `{:value 0}` that later grows a second key by accident. Both facts begin in the initial map; later events return replacements for that whole value.
 
 That is a **complete live counter**: [registrations](glossary.md#register), a [frame-provider](glossary.md#frame-provider) that creates and scopes the frame and runs the seed, and a view. (The playground mounts the trailing hiccup; a real app still needs boot wiring — [counter example](../../examples/core/counter) or [Boot and mount an app](how-to/boot-and-mount-an-app.md).) The rest of the guide grows this same counter one concept at a time.
 
 ## One map, one write path
 
-Everything your app knows sits in one map — ordinary nested data, no imposed schema:
+Everything your app owns as state between events sits in one map — ordinary nested data, with no framework-imposed shape:
 
 ```clojure
 {:user {:id 42 :name "Mike"}
@@ -106,7 +115,7 @@ A handler may return no `:db` key (only `:fx`, say) and leave app-db alone, or r
 
 ## Initial state is an event
 
-A frame starts with `app-db = {}`. There is no `:db` config slot to seed it. Seeding is itself an event — the same pipeline as every later change — listed as `:initial-events` on the frame (or `frame-provider`).
+A frame's event fold starts with `app-db = {}`. There is no `:db` config slot to seed it. Seeding is itself an event — the same pipeline as every later change — listed as `:initial-events` on the frame (or `frame-provider`).
 
 The counter already did this with `:initialise`. A larger app is the same idea: a domain handler that returns the first map, then any follow-ups you need:
 
@@ -122,7 +131,7 @@ The counter already did this with `:initialise`. A larger app is the same idea: 
  [root-view]]
 ```
 
-Steps run synchronously, in order, each to completion before the next. By the time setup finishes, app-db is whatever those handlers produced — no side channel. Prefer a named map payload when an initialise event carries options: `[:initialise {:user-id 42}]` with `[_ {:keys [user-id]}]`. [Frames](frames.md) covers the rest of the registration grammar.
+Each initial event's pipeline runs synchronously, in order, through its immediate commit before the next begins. If a handler starts asynchronous work, its reply arrives later through another event; setup does not wait for the host operation. By the time setup finishes, app-db includes the immediate `:db` commits from the initial events — no seeding side channel. Prefer a named map payload when an initialise event carries options: `[:initialise {:user-id 42}]` with `[_ {:keys [user-id]}]`. [Frames](frames.md) covers the rest of the registration grammar.
 
 ??? info "From re-frame v1"
 
@@ -155,4 +164,4 @@ Poor:
 
 ## Yours, and the framework's next door
 
-For everything you write, app-db is the state that matters. A running frame also holds [**runtime-db**](glossary.md#runtime-db) — framework bookkeeping (machine snapshots, route, resource cache, …) under reserved `:rf.runtime/*` keys. [Two partitions](glossary.md#the-two-partitions): app-db is yours; runtime-db is the framework's (read it via its subscriptions; influence it by dispatching its events — never forge it by hand in app-db). An ordinary `:db` effect cannot wipe a machine snapshot. [Frames](frames.md) goes deeper.
+For state your application owns between events, app-db is the write target. A running frame also holds [**runtime-db**](glossary.md#runtime-db) — framework bookkeeping (machine snapshots, route, resource cache, …) under reserved `:rf.runtime/*` keys. [Two partitions](glossary.md#the-two-partitions): app-db is yours; runtime-db is the framework's (read it via its subscriptions; influence it by dispatching its events — never forge it by hand in app-db). An ordinary `:db` effect cannot wipe a machine snapshot. [Frames](frames.md) goes deeper.


### PR DESCRIPTION
## Summary
- teach destructuring as a reusable binding pattern, including the exact world/event parameter shape used by re-frame2 handlers
- make the app-db counter show concrete event-to-map transitions and link back to the syntax lesson
- narrow app-db ownership claims and distinguish synchronous initial commits from asynchronous replies

## Verification
- `python scripts/check_readme_links.py --ci`
- `python scripts/check_ep_status_sync.py --self-test`
- `python scripts/check_ep_status_sync.py`
- `python scripts/check_runtime_subsystem_grading.py --self-test`
- `python scripts/check_runtime_subsystem_grading.py`
- `python -m mkdocs build --strict`
- `git diff --check origin/main...HEAD`

## Baseline note
`python scripts/check_doc_slugs.py` passed before rebase. Current origin/main now has an unrelated broken anchor at `spec/Conventions.md:95` into a removed `tools/mcp-conformance/NAMING.md#error-vocabulary-alignment` heading. Follow-up bead: rf2-7hqqub.
