### PR TITLE
fix(ssr): project-runtime-db honors the explicit frame — no classified-state leak (rf2-3fc89f.15)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/payload_policy.cljc
+++ b/implementation/ssr/src/re_frame/ssr/payload_policy.cljc
@@ -491,11 +491,42 @@
   per-frame registry, never the wire copy. The classified app-db / route /
   machine slices above were ALREADY projected against this registry server-side,
   so their redaction is baked into the wire value and does not need the
-  declarations to re-derive it."
-  [runtime-db]
-  (when (map? runtime-db)
+  declarations to re-derive it.
+
+  ## The projection frame is the EXPLICIT carried target (rf2-3fc89f.15)
+
+  The two-arity `[runtime-db frame-id]` is the canonical form: it projects
+  every runtime-db slice under the EXPLICIT `frame-id` the caller carries — the
+  same target the payload is stamped `:rf/frame-id`, and the same target
+  `build-final-payload` / the non-streaming builder already thread to the app-db
+  projection. A hydration payload therefore projects BOTH partitions under ONE
+  frame, regardless of ambient scope.
+
+  This matters because the runtime-db projectors fail in OPPOSITE directions on
+  a missing frame: `project-routing-egress` fails OPEN (no frame ⇒ the
+  classified route `:current` slice rides RAW) while the machines projector
+  skips `:data` redaction. Resolving the frame AMBIENTLY (the pre-3fc89f.15
+  one-arity behaviour) meant a builder called outside `rf/with-frame`, or under
+  a DIFFERENT ambient frame, serialized classified route / machine / resource
+  state under nil or the WRONG frame's policy — a serialization privacy leak.
+
+  The one-arity `[runtime-db]` is a convenience that projects under the ambient
+  scope frame — sound ONLY at a call site already inside the MATCHING
+  `rf/with-frame` (ambient == target). The security-critical builders MUST pass
+  the explicit target.
+
+  The late-bound `:ssr/extend-runtime-db-projection` hook (resources) resolves
+  its OWN frame ambiently; the two-arity binds the explicit target as the
+  ambient scope around that call so the extension projects under the SAME frame
+  as every other slice — never a borrowed / mismatched ambient scope."
+  ([runtime-db]
+   ;; Convenience: project under the AMBIENT scope frame. Correct only when the
+   ;; call site is inside the frame's own `with-frame` (ambient == the target).
+   ;; The security-critical builders pass the explicit target (rf2-3fc89f.15).
+   (project-runtime-db runtime-db (frame/resolve-current-frame)))
+  ([runtime-db frame-id]
+   (when (map? runtime-db)
     (let [project-machines (late-bind/get-fn :machines/project-ssr-runtime-db)
-          frame-id         (frame/resolve-current-frame)
           machines-slice   (when (contains? runtime-db :rf.runtime/machines)
                              (if project-machines
                                (project-machines runtime-db frame-id)
@@ -538,9 +569,14 @@
           ;; `:tag-index` / `:owner-index` are recomputable-from-entries
           ;; and need not ride the wire — Spec 016 §Restore and replay).
           slice (if-let [extend-fn (late-bind/get-fn :ssr/extend-runtime-db-projection)]
-                  (merge slice (extend-fn runtime-db))
+                  ;; The extension hook (resources) resolves its OWN frame
+                  ;; ambiently — bind the EXPLICIT target as the ambient scope so
+                  ;; it projects under the same frame as every other slice, never
+                  ;; a borrowed / mismatched ambient one (rf2-3fc89f.15).
+                  (merge slice (binding [frame/*current-frame* frame-id]
+                                 (extend-fn runtime-db)))
                   slice)]
-      (when (seq slice) slice))))
+      (when (seq slice) slice)))))
 
 ;; ---- version resolution + payload assembly -------------------------------
 ;;

--- a/implementation/ssr/src/re_frame/ssr/streaming.cljc
+++ b/implementation/ssr/src/re_frame/ssr/streaming.cljc
@@ -657,7 +657,12 @@
       (payload-policy/apply-policy app-db policy-opts)
       frame-id)
      render-hash
-     (assoc policy-opts :runtime-db (payload-policy/project-runtime-db runtime-db)))))
+     ;; rf2-3fc89f.15 — project the runtime-db under the EXPLICIT carried
+     ;; `frame-id` (the same target the app-db projection above uses), NOT an
+     ;; ambient one. A streaming build called outside `with-frame`, or under a
+     ;; different ambient frame, otherwise serialized classified route / machine
+     ;; / resource runtime state under nil / the wrong frame's policy.
+     (assoc policy-opts :runtime-db (payload-policy/project-runtime-db runtime-db frame-id)))))
 
 ;; ---- late-bind hook registration -----------------------------------------
 ;;

--- a/implementation/ssr/test/re_frame/ssr_runtime_db_explicit_frame_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_runtime_db_explicit_frame_test.clj
@@ -1,0 +1,236 @@
+(ns re-frame.ssr-runtime-db-explicit-frame-test
+  "rf2-3fc89f.15 — the SSR runtime-db hydration projection must honour the
+  EXPLICIT carried frame, never an ambient one.
+
+  `re-frame.ssr.streaming/build-final-payload` carries an explicit `frame-id`
+  and reads BOTH partitions of the frame-state container by it. Its app-db
+  projection (`project-app-db-egress`) is seeded at that explicit target — but
+  the prior `project-runtime-db` (one-arity) discarded the carried target and
+  bound the projection frame ambiently via `frame/resolve-current-frame`.
+
+  So a payload stamped `:rf/frame-id A` projected its app-db under A while its
+  runtime-db (route / machine / resource-extension slices) projected under
+  whatever frame happened to be ambient:
+
+    - OUTSIDE any `rf/with-frame` the ambient is nil → `project-routing-egress`
+      fails OPEN (no frame ⇒ no walk) and the classified `:current` route
+      `:query` / `:params` ride the hydration blob RAW; the machines projector
+      gets nil (no `:data` redaction); the resource extension hook resolves no
+      frame.
+    - Under a DIFFERENT ambient frame B the runtime-db projects under B's
+      (wrong / absent) declarations while app-db projects under A — an
+      internally inconsistent payload that can also apply another frame's
+      classifications (cross-frame non-determinism).
+
+  A P1 security boundary: the durable route query/params, machine snapshot
+  `:data`, and resource-extension state are exactly the classified runtime
+  facts EP-0025 / Spec 011 §Off-box redaction forbid shipping raw.
+
+  These regressions drive the ACTUAL public streaming builder
+  (`streaming/build-final-payload`) with an explicit non-default server frame,
+  once with NO ambient scope and once under a MISMATCHED ambient frame, and
+  prove the explicit target's classifications win for every runtime-db slice.
+  The pre-existing route / machine regressions
+  (`ssr_route_slice_projection_test`, `ssr_machine_snapshot_projection_test`)
+  miss this because their fixtures classify + project under the SAME frame that
+  is ambient, so ambient == explicit and the bug is invisible."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.elision :as elision]
+            [re-frame.frame :as frame]
+            [re-frame.late-bind :as late-bind]
+            ;; Loading routing / machines publishes the route classification
+            ;; machinery and the `:machines/project-ssr-runtime-db` hook; the
+            ;; reset fixture reloads both.
+            [re-frame.machines]
+            [re-frame.routing]
+            [re-frame.routing.classification :as route-class]
+            [re-frame.schemas]
+            [re-frame.schemas.malli]
+            [re-frame.ssr.payload-policy :as payload-policy]
+            [re-frame.ssr.streaming :as streaming]
+            [re-frame.ssr.test-fixture :as tf]))
+
+(use-fixtures :each tf/reset-runtime)
+
+;; ---- the target frame + its classified runtime state ----------------------
+;;
+;; `server-frame` (frame A) is the EXPLICIT SSR target. The fixture pins
+;; `:rf/default` (frame B) as the ambient scope, so A is NEVER the ambient
+;; frame inside a test body — precisely the seam the bug lives in.
+
+(def ^:private server-frame :review/ssr-target)
+(def ^:private route-id      :route/oauth-callback)
+(def ^:private machine-id    :review.ssr/auth)
+
+(def ^:private route-classification
+  "OAuth-callback-shaped: `:query :token` is a live secret (SENSITIVE → redact),
+  `:params :payload` a large blob (LARGE → elide), `:query :return-to` a plain
+  breadcrumb (unclassified → verbatim). Projection-relative, per Spec 012."
+  {:sensitive [[:query :token]]
+   :large     [[:params :payload]]})
+
+(defn- frame-a-runtime-db
+  "The runtime-db value seeded into frame A's container. Carries:
+
+    - the per-frame elision registry with (a) the route's re-rooted
+      `:source :route` `:current` decls, and (b) `:source :effect` decls for a
+      machine-snapshot `:data` path and an app-db `[:secret]` path;
+    - the durable `:current` route slice (secret token + large blob);
+    - one durable machine snapshot whose `:data` holds a secret + large blob.
+
+  Every classified path is declared ONLY in frame A's registry — frame B
+  (`:rf/default`) declares nothing, so a projection run under B leaks."
+  []
+  (-> (route-class/apply-route-classification
+        {} (route-class/validate+extract route-id route-classification))
+      (elision/apply-classification-effects
+        {:sensitive [[:secret]
+                     [:rf.runtime/machines :snapshots machine-id :data :token]]
+         :large     [[:rf.runtime/machines :snapshots machine-id :data :blob]]})
+      (assoc :rf.runtime/routing
+             {:current            {:route-id  route-id
+                                   :query     {:token     "secret-oauth-token"
+                                               :return-to "/dashboard"}
+                                   :params    {:payload "huge-callback-blob-value"}}
+              :pending-navigation {:id "pn-1" :reason :can-leave}})
+      (assoc :rf.runtime/machines
+             {:snapshots  {machine-id {:state :authed
+                                       :data  {:retries 2
+                                               :token   "secret-jwt-snapshot"
+                                               :blob    "huge-blob-value"}}}
+              :system-ids {}
+              :spawned    {}})))
+
+(def ^:private auth-schema
+  [:map [:retries :int] [:token [:maybe :string]] [:blob [:maybe :string]]])
+
+(defn- setup-frame-a!
+  "Register frame A as a server frame with a seeded app-db (a `[:secret]` slot
+  classified in A's registry), register the machine so the machines hook has a
+  live definition, then seed A's runtime-db with the classified slices."
+  []
+  (rf/reg-event :review.ssr/seed-db (fn [_ [_ db]] {:db db}))
+  (rf/reg-frame server-frame
+    {:doc            "explicit-frame SSR-target regression frame"
+     :platform       :server
+     :initial-events [[:review.ssr/seed-db {:public "ok" :secret "app-db-secret"}]]})
+  (rf/reg-machine machine-id
+    {:initial :anon
+     :data    {:retries 0 :token nil :blob nil}
+     :schemas {:data auth-schema}
+     :states  {:anon {:on {:login :authed}} :authed {}}})
+  (frame/swap-runtime-db! server-frame (constantly (frame-a-runtime-db))))
+
+;; ---- AC#1: leak with NO ambient scope -------------------------------------
+
+(deftest build-final-payload-honours-explicit-frame-outside-with-frame
+  (testing "streaming/build-final-payload called OUTSIDE any rf/with-frame
+            projects the runtime-db under the EXPLICIT frame A — the classified
+            route :query / :params redact/elide, no raw secret survives"
+    (setup-frame-a!)
+    ;; Escape the fixture's `(with-frame :rf/default …)` scope: no ambient frame
+    ;; at all. On the buggy one-arity projector `resolve-current-frame` → nil,
+    ;; `project-routing-egress` fails OPEN, and the raw token rides the wire.
+    (let [payload (binding [frame/*current-frame* nil]
+                    (streaming/build-final-payload
+                      server-frame "hash"
+                      {:payload :rf.ssr.payload/whole-app-db}))
+          current (get-in payload [:rf/runtime-db :rf.runtime/routing :current])
+          snap    (get-in payload [:rf/runtime-db :rf.runtime/machines
+                                   :snapshots machine-id])]
+      (is (= server-frame (:rf/frame-id payload))
+          "payload names frame A as its target")
+      (is (= :rf/redacted (get-in current [:query :token]))
+          "route-declared sensitive :query :token redacted under frame A")
+      (is (contains? (get-in current [:params :payload]) :rf.size/large-elided)
+          "route-declared large :params :payload elided under frame A")
+      (is (= "/dashboard" (get-in current [:query :return-to]))
+          "the unclassified route sibling rides verbatim")
+      (is (= :rf/redacted (get-in snap [:data :token]))
+          "machine snapshot :data :token redacted under frame A")
+      (is (contains? (get-in snap [:data :blob]) :rf.size/large-elided)
+          "machine snapshot :data :blob elided under frame A")
+      (is (not (.contains (pr-str payload) "secret-oauth-token"))
+          "no raw route token survives anywhere in the payload")
+      (is (not (.contains (pr-str payload) "huge-callback-blob-value"))
+          "no raw route blob survives")
+      (is (not (.contains (pr-str payload) "secret-jwt-snapshot"))
+          "no raw machine token survives")
+      (is (not (.contains (pr-str payload) "huge-blob-value"))
+          "no raw machine blob survives"))))
+
+;; ---- AC#2: explicit frame A wins over a MISMATCHED ambient frame B ---------
+
+(deftest build-final-payload-explicit-frame-wins-over-ambient
+  (testing "with frame B (:rf/default) ambient and frame A passed explicitly,
+            frame A's classifications win for app-db, route runtime state,
+            machine snapshot :data, AND the resource-extension hook — the whole
+            payload projects under ONE frame (A), never the ambient B"
+    (setup-frame-a!)
+    (let [captured-hook-frame (atom :unset)
+          orig-hook (late-bind/get-fn :ssr/extend-runtime-db-projection)]
+      (try
+        ;; A stub resource-extension hook records the frame it resolves
+        ;; ambiently — proving the projector reconciles the ambient scope to the
+        ;; explicit target A before invoking a hook that resolves its own frame
+        ;; (resources isn't on this artefact's classpath, so we stub its seam).
+        (late-bind/set-fn! :ssr/extend-runtime-db-projection
+                           (fn [_runtime-db]
+                             (reset! captured-hook-frame (frame/resolve-current-frame))
+                             {}))
+        ;; Ambient is frame B (the fixture's `:rf/default` scope); we pass A.
+        (is (= :rf/default (frame/resolve-current-frame))
+            "sanity: the ambient frame is B (:rf/default), NOT A")
+        (let [payload (streaming/build-final-payload
+                        server-frame "hash"
+                        {:payload :rf.ssr.payload/whole-app-db})
+              current (get-in payload [:rf/runtime-db :rf.runtime/routing :current])
+              snap    (get-in payload [:rf/runtime-db :rf.runtime/machines
+                                       :snapshots machine-id])]
+          (is (= server-frame @captured-hook-frame)
+              "the resource-extension hook resolves the EXPLICIT target A, not ambient B")
+          (is (= :rf/redacted (get-in payload [:rf/app-db :secret]))
+              "app-db :secret redacted under frame A's declaration")
+          (is (= "ok" (get-in payload [:rf/app-db :public]))
+              "app-db unclassified sibling rides verbatim")
+          (is (= :rf/redacted (get-in current [:query :token]))
+              "route :query :token redacted under frame A, not leaked under B")
+          (is (contains? (get-in current [:params :payload]) :rf.size/large-elided)
+              "route :params :payload elided under frame A")
+          (is (= :rf/redacted (get-in snap [:data :token]))
+              "machine snapshot :data :token redacted under frame A")
+          (is (contains? (get-in snap [:data :blob]) :rf.size/large-elided)
+              "machine snapshot :data :blob elided under frame A")
+          (is (not (.contains (pr-str payload) "secret-oauth-token")))
+          (is (not (.contains (pr-str payload) "huge-callback-blob-value")))
+          (is (not (.contains (pr-str payload) "secret-jwt-snapshot")))
+          (is (not (.contains (pr-str payload) "huge-blob-value")))
+          (is (not (.contains (pr-str payload) "app-db-secret"))
+              "no raw app-db secret survives"))
+        (finally
+          (late-bind/set-fn! :ssr/extend-runtime-db-projection orig-hook))))))
+
+;; ---- AC#4 (unit): explicit precedence at the projector seam ---------------
+
+(deftest project-runtime-db-explicit-target-beats-ambient
+  (testing "the two-arity project-runtime-db projects under its EXPLICIT
+            frame-id argument even under a mismatched ambient frame; the
+            one-arity falls back to ambient only when no target is carried"
+    (setup-frame-a!)
+    (let [rt (frame/frame-runtime-db-value server-frame)]
+      ;; Ambient is B (:rf/default, no route decls). Explicit A ⇒ redacted.
+      (let [slice   (payload-policy/project-runtime-db rt server-frame)
+            current (get-in slice [:rf.runtime/routing :current])]
+        (is (= :rf/redacted (get-in current [:query :token]))
+            "explicit A wins: route token redacted despite ambient B")
+        (is (not (.contains (pr-str slice) "secret-oauth-token"))))
+      ;; One-arity resolves ambient B (no decls) ⇒ the route slice fails open.
+      ;; This documents the sanctioned ambient-fallback path (a caller inside a
+      ;; MATCHING with-frame gets correct behaviour); the security-critical
+      ;; builders always pass the explicit target.
+      (let [slice   (payload-policy/project-runtime-db rt)
+            current (get-in slice [:rf.runtime/routing :current])]
+        (is (= "secret-oauth-token" (get-in current [:query :token]))
+            "one-arity under ambient B applies B's (absent) policy — the
+             documented fallback; explicit target is required for correctness")))))


### PR DESCRIPTION
## Summary

P1 security/serialization-privacy fix. `re-frame.ssr.streaming/build-final-payload` carries an explicit `frame-id` and reads both frame-state partitions by it, but the one-arity `re-frame.ssr.payload-policy/project-runtime-db` **discarded that carried target** and resolved the projection frame ambiently via `frame/resolve-current-frame`. So a payload stamped `:rf/frame-id A` projected its app-db under A while its runtime-db (route / machine / resource-extension slices) projected under whatever frame happened to be ambient.

The two runtime-db projectors fail in **opposite** directions on a missing frame, which is what makes this a leak rather than a fail-closed error:
- **Outside** `rf/with-frame` → ambient nil → `project-routing-egress` fails **OPEN** and the classified `:current` route `:query` / `:params` ride the hydration blob RAW; the machines projector gets nil (no `:data` redaction); the resource extension hook resolves no frame.
- Under a **different** ambient frame B → runtime-db projects under B's wrong/absent declarations while app-db projects under A — an internally inconsistent payload that can also apply another frame's classifications.

## Reproduce → fix (evidence)

- `payload_policy.cljc` (pre-fix): `project-runtime-db` bound `frame-id (frame/resolve-current-frame)` and passed that to `project-routing-egress` / the machines projector; the resource hook (`extend-fn runtime-db`) resolved its own frame ambiently too.
- `streaming.cljc` `build-final-payload:660`: passed only `runtime-db` (one-arity) despite carrying `frame-id` and already threading it to the app-db projection.
- New regression `ssr_runtime_db_explicit_frame_test.clj` drives the **actual public streaming builder** with an explicit non-default server frame (a) with **no ambient scope** and (b) under a **mismatched ambient frame** (`:rf/default`), with classified route + machine snapshot slices and a stub `:ssr/extend-runtime-db-projection` hook. On `main` it FAILED — the raw `secret-oauth-token` / route blob / `secret-jwt-snapshot` / machine blob all survived in the payload (13 failures + the large-value assertions erroring on the raw string). After the fix it passes.

## The fix

- `project-runtime-db` is now two-arity `[runtime-db frame-id]` — the canonical form projects **every** slice under the EXPLICIT target (route, machines, resource-extension hook), exactly as the app-db projection already does.
- The one-arity `[runtime-db]` remains an **ambient-fallback convenience** (sound only at a call site inside the MATCHING `with-frame`; ambient == target). Sanctioned per the fix brief — falling back to ambient is acceptable only when no explicit target was carried.
- `build-final-payload` now passes its carried `frame-id`.
- The late-bound `:ssr/extend-runtime-db-projection` hook (resources) resolves its own frame ambiently, so the two-arity **binds the explicit target as the ambient scope** around that call — the extension projects under the same frame as every other slice without a signature change.

## Scope

Touched only `implementation/ssr/{payload_policy.cljc, streaming.cljc}` + a new ssr test, per the fix brief (deliberately narrower than the bead's full clean-break design). The non-streaming `ssr-ring/payload.clj` and the resources hook keep the one-arity call — both currently run inside a matching ambient `with-frame` (closed `rf2-p026f5` / `rf2-tbr67x` host-scope fixes), so they remain correct; passing the explicit target there and re-signaturing the hook (bead AC#3/AC#4 clean-break) is a follow-up left to the mayor.

## Stance

Pre-alpha; redaction/classification is an AI-egress + serialization privacy boundary — the fix is airtight for the streaming builder path. Primary lenses: ELEGANCE + CLARITY + CORRECTNESS.

## Quality gates (foreground, all 0 failures)

| Gate | Result |
| --- | --- |
| `ssr` JVM (`clojure -M:test`) | 375 tests / 1561 assertions, 0 failures |
| `routing` JVM (1-arity caller) | 391 / 1748, 0 failures |
| `ssr-ring` JVM (non-streaming caller) | 172 / 839, 0 failures |
| `npm run test:cljs` | 8465 / 39156, 0 failures |
| `npm run test:security` (redaction/egress conformance) | 93 / 673, 0 failures |

Negative assertion proven: no raw classified route / machine / resource state survives in the serialized hydration payload under nil or a mismatched ambient frame.

Closes rf2-3fc89f.15.
