### PR TITLE
fix(elision): multi-owner claim registry — independent owners union correctly (rf2-wdm1vg)

### DIFF
--- a/implementation/core/src/re_frame/elision.cljc
+++ b/implementation/core/src/re_frame/elision.cljc
@@ -119,6 +119,127 @@
     :else
     runtime-db))
 
+;; ---- multi-owner claim registry (rf2-wdm1vg) -----------------------------
+;;
+;; The per-frame elision registry is a MULTI-OWNER claim registry. Each axis
+;; slot (`:sensitive-declarations` / `:declarations`) maps a concrete
+;; runtime-db path to the SET of OWNER identities that currently claim it. An
+;; owner identity is any EDN value that names a claimant for the purpose of
+;; add / remove: the commit-plane effects claim under `{:source :effect}`,
+;; `reg-flow` outputs `{:source :flow :flow-id <id>}`, machine spawns
+;; `{:source :machine :actor-id <id>}`, route activation `{:source :route}`,
+;; and resource instances `{:source :resource}`. Instance identity (`:flow-id`
+;; / `:actor-id`) is carried where an owner reconciles its OWN claims
+;; independently of a same-family sibling, so removing one leaves the rest.
+;;
+;; Independent owners UNION: a path is redacted / size-marked at egress while
+;; ANY owner claims it, and it is pruned from the registry only when its LAST
+;; owner drops. This is the privacy-boundary correctness property (rf2-wdm1vg).
+;; Before it, the registry held one owner per path, so a second owner's claim
+;; either overwrote the first (then deleted it on teardown) or was silently
+;; ignored — a route change / actor teardown could un-redact an
+;; effect-classified path (a fail-open on the AI-egress privacy boundary). The
+;; egress read needs only PRESENCE (sensitive) or a STABLE provenance derived
+;; from the owner-set (the large marker's `:reason`).
+;;
+;; Family code (effects / flows / machines / routing / resources) derives only
+;; absolute paths + owner identities and DELEGATES to the pure operations
+;; below; there is no family-private source-filter / overlay logic.
+
+(def ^:no-doc effect-owner
+  "The owner identity the EP-0025 commit-plane classification effects claim
+  under. A distinguished value: it is the ONLY in-band owner (written WITH the
+  `:db` commit), so `restore-elision-slot` unwinds it on a schema rollback
+  while carrying the out-of-band subsystem owners forward."
+  {:source :effect})
+
+(defn ^:no-doc add-claims
+  "PURE. Add owner-identity `owner` to each path in `paths` within the axis
+  `slot` of registry value `reg`. UNION: a path already claimed by other owners
+  keeps them and gains `owner`; a path with no prior claim is created with
+  `#{owner}`. A no-op (returns `reg`) when `paths` is empty. Returns the new
+  registry value."
+  [reg slot owner paths]
+  (if (empty? paths)
+    reg
+    (let [cur     (get reg slot)
+          updated (reduce (fn [m p] (update m (vec p) (fnil conj #{}) owner))
+                          (or cur {})
+                          paths)]
+      (assoc reg slot updated))))
+
+(defn ^:no-doc remove-claims
+  "PURE. Remove owner-identity `owner` from each NAMED path in `paths` within
+  axis `slot`; a path whose owner-set empties is pruned. Other owners on a
+  named path survive, so a source-scoped clear / teardown never un-redacts a
+  path another owner still claims (a privacy fail-open). A no-op when `paths`
+  or the slot is empty. Returns the new registry value (the slot is dissoc'd
+  when it empties)."
+  [reg slot owner paths]
+  (let [cur (get reg slot)]
+    (if (or (empty? paths) (empty? cur))
+      reg
+      (let [updated (reduce (fn [m p]
+                              (let [p      (vec p)
+                                    owners (disj (get m p) owner)]
+                                (if (seq owners)
+                                  (assoc m p owners)
+                                  (dissoc m p))))
+                            cur
+                            paths)]
+        (if (seq updated)
+          (assoc reg slot updated)
+          (dissoc reg slot))))))
+
+(defn ^:no-doc remove-owner
+  "PURE. Remove owner-identity `owner` from EVERY path in axis `slot`; a path
+  whose owner-set empties is pruned. The whole-axis complement of
+  `remove-claims` — the flow-clear + the route / resource reconcile drop step.
+  Returns the new registry value (the slot is dissoc'd when it empties)."
+  [reg slot owner]
+  (let [cur (get reg slot)]
+    (if (empty? cur)
+      reg
+      (let [updated (reduce-kv (fn [m p owners]
+                                 (let [owners' (disj owners owner)]
+                                   (if (seq owners')
+                                     (assoc m p owners')
+                                     m)))
+                               {}
+                               cur)]
+        (if (seq updated)
+          (assoc reg slot updated)
+          (dissoc reg slot))))))
+
+(defn ^:no-doc replace-owner-claims
+  "PURE. Reconcile owner `owner`'s claims in axis `slot` to EXACTLY `paths`:
+  drop `owner` from every path, then add `owner` to each path in `paths`. The
+  whole-owner reconcile the singleton route lowering, the self-dropping
+  resource lowering, and a `reg-flow` re-registration use — a foreign owner on
+  any path survives untouched. Returns the new registry value."
+  [reg slot owner paths]
+  (-> reg
+      (remove-owner slot owner)
+      (add-claims slot owner paths)))
+
+(def ^:private source-provenance-priority
+  "Deterministic priority order for deriving a large marker's STABLE `:reason`
+  provenance from a path's retained owner-set. A large path may be claimed by
+  several independent owners; the marker carries ONE reproducible source so the
+  wire shape is stable across runs and serialization. First match wins."
+  [:effect :flow :machine :route :resource])
+
+(defn ^:no-doc owners->provenance
+  "Derive the STABLE `:reason` / `:source` provenance keyword for a large-
+  classified path from its retained `owners` set. Picks the highest-priority
+  `:source` present (`source-provenance-priority`); falls back to `:effect`
+  when the set carries no recognised source (defensive — matches the historical
+  `->marker` default)."
+  [owners]
+  (let [sources (into #{} (keep :source) owners)]
+    (or (some sources source-provenance-priority)
+        :effect)))
+
 (defn ^:no-doc restore-elision-slot
   "EP-0025 SOURCE-AWARE rollback restore for the per-frame elision registry.
 
@@ -126,39 +247,39 @@
   unwinds with the WHOLE frame-state transition (both partitions back to the
   pre-handler value). Per Spec 015 §84 a classification `walks back atomically
   with the frame on a revert` — but only the IN-BAND classification this event
-  produced: the four commit-plane classification effects write
-  `{:source :effect}` marks (`apply-classification-effects`), and those MUST
-  unwind. The OTHER sources are written OUT-OF-BAND by long-lived subsystems —
-  `reg-flow` outputs (`:source :flow`), machine actor spawns
-  (`:source :machine`), route activation (`:source :route`) — and a
-  declaration one of those LOWERED during the rejected event may LEGITIMATELY
-  survive the rollback (the actor / route registration is not the
-  schema-rejected `:db` effect).
+  produced: the four commit-plane classification effects claim under the
+  `effect-owner` (`apply-classification-effects`), and those MUST unwind. Every
+  OTHER owner is written OUT-OF-BAND by a long-lived subsystem — `reg-flow`
+  outputs (`{:source :flow …}`), machine actor spawns (`{:source :machine …}`),
+  route activation (`{:source :route}`), resource instances
+  (`{:source :resource}`) — and a claim one of those LOWERED during the
+  rejected event may LEGITIMATELY survive the rollback (the actor / route
+  registration is not the schema-rejected `:db` effect).
 
-  The base is `pre-reg` — the per-frame elision registry as it was at
-  chain-start, BEFORE the cascade ran (the `[:rf.runtime/elision]` sub-tree of
-  the chain-start `runtime-before` runtime-db, captured by reference in the
-  router's `assemble-initial-ctx`, so it is a true PRE-CASCADE snapshot at no
-  copy cost). Restoring to that base alone already:
+  Since the registry retains ALL owners per path (rf2-wdm1vg), the restore is
+  per-OWNER, not per-path: for each path in an axis the restored owner-set is
 
-    - UNWINDS in-band `:source :effect` marks the rejected event added
-      (rf2-5lo1fk) — they were not in the pre-cascade snapshot, so they are
-      gone; and
-    - RESTORES an out-of-band `:source :flow` mark a mid-drain reentrant
-      `reg-flow` output-path MOVE dropped (rf2-o6rsi2) — the OLD path's
-      `:source :flow` entry is still in the pre-cascade snapshot, so it comes
-      back (the live registry had already dropped it; carrying live forward
-      would leak — a privacy fail-open on revert).
+      pre-owners[path]  ∪  (live-owners[path] MINUS effect-owner)
 
-  But the base alone would also drop an out-of-band declaration LOWERED
-  DURING the event (a `:source :machine` / `:source :route` mark from an actor
-  spawn / route activation inside the rejected event, or the NEW-path
-  `:source :flow` mark from a reentrant move) — those are absent from the
-  pre-cascade snapshot yet legitimately survive. So OVERLAY the LIVE
-  out-of-band entries (`:source` ≠ `:effect`) onto the pre-cascade base: this
-  re-adds the during-event subsystem-lowered marks WITHOUT re-adding the
-  in-band `:source :effect` marks (the only sourced kind that must unwind).
-  Privacy posture stays fail-safe-toward-redaction: a kept mark over a value
+  — the pre-cascade owners (which includes whatever the effect owner held at
+  chain-start, so its during-event add / clear both unwind to the pre value)
+  UNIONED with every NON-effect owner LIVE currently holds (so a during-event
+  subsystem lowering survives). `pre-reg` is the `[:rf.runtime/elision]`
+  sub-tree at chain-start (captured by reference in the router's
+  `assemble-initial-ctx`, a true PRE-CASCADE snapshot at no copy cost).
+
+  This subsumes the historical single-owner cases:
+    - UNWINDS an in-band effect claim the rejected event ADDED (rf2-5lo1fk) —
+      absent from `pre`, and the effect owner is stripped from `live`, so it is
+      gone;
+    - RESTORES an out-of-band `:source :flow` claim a mid-drain reentrant
+      `reg-flow` output-path MOVE dropped (rf2-o6rsi2) — the OLD path's flow
+      owner is still in `pre`, so the union re-adds it (carrying live forward
+      alone would leak — a privacy fail-open on revert); and
+    - KEEPS the NEW-path `:source :flow` / `:source :machine` / `:source :route`
+      claim lowered DURING the event — present in `live` and non-effect, so the
+      union carries it forward.
+  Privacy posture stays fail-safe-toward-redaction: a kept claim over a value
   the rolled-back db no longer holds redacts nothing (harmless); a dropped one
   risks raw egress.
 
@@ -167,23 +288,27 @@
   — the caller folds it onto `runtime-before` via `write-elision-slot`.
   Pure."
   [pre-reg live-reg]
-  (let [;; Per axis slot (`:sensitive-declarations` / `:declarations`): start
-        ;; from the pre-cascade entries, then overlay the LIVE OUT-OF-BAND
-        ;; (`:source` ≠ `:effect`) entries. The pre-cascade base unwinds in-band
-        ;; `:source :effect` and restores a dropped old-path `:source :flow`;
-        ;; the overlay re-adds during-event subsystem-lowered survivors.
+  (let [;; Per axis slot (`:sensitive-declarations` / `:declarations`): the
+        ;; restored owner-set for a path is the pre-cascade owners UNIONED with
+        ;; the LIVE non-effect owners. The pre base unwinds the in-band effect
+        ;; owner (add + clear) and restores a dropped out-of-band owner; the
+        ;; live union re-adds during-event subsystem-lowered survivors.
         restore-axis
         (fn [slot]
-          (let [pre  (get pre-reg slot)
-                live (get live-reg slot)
-                out-of-band-live (reduce-kv
-                                   (fn [m path decl]
-                                     (if (= :effect (:source decl))
-                                       m
-                                       (assoc m path decl)))
-                                   {}
-                                   (or live {}))
-                merged (merge (or pre {}) out-of-band-live)]
+          (let [pre    (get pre-reg slot)
+                live   (get live-reg slot)
+                paths  (into (set (keys pre)) (keys live))
+                merged (reduce
+                         (fn [m p]
+                           (let [pre-owners  (get pre p #{})
+                                 live-owners (get live p #{})
+                                 owners      (into pre-owners
+                                                   (disj live-owners effect-owner))]
+                             (if (seq owners)
+                               (assoc m p owners)
+                               m)))
+                         {}
+                         paths)]
             (not-empty merged)))
         s (restore-axis :sensitive-declarations)
         l (restore-axis :declarations)]
@@ -272,14 +397,14 @@
 ;; They are applied WITH the `:db` write (a frame-state transform at the
 ;; commit point — `re-frame.router/commit-frame-effects!`), NOT as a later
 ;; post-commit `:fx`, so a path classified in the SAME event is redacted from
-;; its first egress. They write into the per-frame elision registry's
-;; `:sensitive-declarations` (sensitive) / `:declarations` (large) sub-maps —
-;; the SAME slot `re-frame.flows.registry` (`:source :flow`) and the subsystem
-;; projection-relative declarations populate — tagged
-;; `:source :effect`, unioned with the other sources at egress-lookup time
-;; (`elide-against-frame` reads both sub-maps verbatim, so no change to the wire
-;; walker is needed). Classification is VALUE-INDEPENDENT (classify a path before
-;; any value lands there) and read ONLY at egress.
+;; its first egress. They add the `effect-owner` to the per-frame elision
+;; registry's `:sensitive-declarations` (sensitive) / `:declarations` (large)
+;; multi-owner slots — the SAME slots `re-frame.flows.registry`
+;; (`{:source :flow …}`) and the subsystem projection-relative declarations
+;; populate — unioned with every other owner at egress-lookup time
+;; (`elide-against-frame` reads the owner-set per path, so a path claimed by
+;; ANY owner redacts). Classification is VALUE-INDEPENDENT (classify a path
+;; before any value lands there) and read ONLY at egress.
 ;;
 ;; The two axes (`:sensitive` / `:large`) are INDEPENDENT — a
 ;; `:clear-sensitive` never touches `:declarations`, and `:clear-large` never
@@ -299,8 +424,8 @@
 (def ^:private classification-effect-axis
   "Map each classification effect key to the registry slot it writes and
   whether it SETS or CLEARS. `:slot` is the `[:rf.runtime/elision …]`
-  declaration sub-map; `:set?` true adds `{:source :effect}` decls, false
-  removes the named paths. The two axes are independent — a clear on one axis
+  declaration sub-map; `:set?` true ADDS the `effect-owner` to the named
+  paths, false REMOVES it. The two axes are independent — a clear on one axis
   never touches the other's slot."
   {:sensitive       {:slot :sensitive-declarations :set? true}
    :large           {:slot :declarations           :set? true}
@@ -370,39 +495,27 @@
   a live container, so the router can fold the result into the atomic `:db`
   commit transition (a partition-write alongside `:db`).
 
-  Each SET key (`:sensitive` / `:large`) adds `{:source :effect}` declarations
-  for its paths to the axis slot (`:sensitive-declarations` / `:declarations`)
-  WITHOUT clobbering a foreign-source standing entry: the registry is
-  one-entry-per-path-per-axis, so a SET on a path another owner already claims
-  (`:source :flow` / `:machine` / `:route` / a subsystem declaration) leaves
-  that owner standing rather than overwriting it to `:source :effect`
-  (rf2-p4spo4). Were it to overwrite, the later source-scoped CLEAR would
-  dissoc the entry and silently un-redact a path the other owner still
-  classifies — a privacy fail-open. The egress read needs only presence, so a
-  doubly-claimed path stays redacted and the SET is a no-op on it; only a free
-  or already-effect-owned slot is (re)stamped `:source :effect`.
-  Each CLEAR key (`:clear-sensitive` / `:clear-large`) removes ONLY the
-  effect's OWN contribution to its paths from the axis slot. A clear is
-  SOURCE-SCOPED: it dissocs a path only when the standing entry is
-  `:source :effect` (the effect's own declaration); a path also claimed by
-  another source (`:source :flow` from a `reg-flow` output, `:source :machine`,
-  `:source :route`, or a subsystem projection declaration) is LEFT INTACT, so
-  the clear can never silently un-redact a path another owner still classifies
-  (a privacy fail-open). This mirrors `re-frame.flows.registry/drop-flow-sourced`,
-  which likewise removes only its own `:source :flow` entries. The two axes are
-  INDEPENDENT — clearing one never touches the other's slot — and clearing
-  removes only the named paths (other-sourced entries for an unnamed path
-  survive). Within one effect map, a SET on an axis applies before its own
-  CLEAR (a handler returns at most one of each axis's set/clear), so if both an
-  axis SET and that axis's CLEAR name the same path the CLEAR wins (the SET
-  stamped it `:source :effect`, so the source-scoped clear removes the
-  effect's own just-written entry). An empty/absent axis slot is pruned
-  (dissoc'd) rather than left as `{}` (matching
-  `write-elision-slot`). Assumes `effects` already passed
-  `classification-effect-defect` (the router's pure pre-commit check returned
-  nil, so the paths are valid concrete `:rf/path`s); normalizes each to its
-  canonical vector form here so the stored decl key matches the wire walker's
-  `(vec path)` lookup.
+  Each SET key (`:sensitive` / `:large`) ADDS the `effect-owner` to its paths
+  in the axis slot (`:sensitive-declarations` / `:declarations`), UNIONING with
+  any foreign owner already on the path (`add-claims`): a SET on a path another
+  owner claims (`:source :flow` / `:machine` / `:route` / `:resource`) leaves
+  that owner in place AND records the effect owner alongside it (rf2-wdm1vg),
+  so both claims survive independently. Each CLEAR key (`:clear-sensitive` /
+  `:clear-large`) removes ONLY the `effect-owner` from its named paths
+  (`remove-claims`); a path still claimed by another owner stays redacted (the
+  clear can never silently un-redact a path another owner still classifies — a
+  privacy fail-open), and a path whose last owner was the effect owner is
+  pruned. The two axes are INDEPENDENT — clearing one never touches the other's
+  slot — and clearing removes only the named paths (other paths survive).
+  Within one effect map, a SET on an axis applies before its own CLEAR (a
+  handler returns at most one of each axis's set/clear), so if both an axis SET
+  and that axis's CLEAR name the same path the CLEAR wins (the SET added the
+  effect owner; the CLEAR removes the effect's own just-added claim). An
+  empty/absent axis slot is pruned (dissoc'd) rather than left as `{}`. Assumes
+  `effects` already passed `classification-effect-defect` (the router's pure
+  pre-commit check returned nil, so the paths are valid concrete `:rf/path`s);
+  normalizes each to its canonical vector form here so the stored key matches
+  the wire walker's `(vec path)` lookup.
 
   Pre-commit FAIL-OPEN posture: a path classified here is value-independent —
   it redacts whatever later occupies the path, and is a harmless no-op over an
@@ -412,51 +525,20 @@
         reg  (get base :rf.runtime/elision)
         ;; Reduce the four effects (set axes first, clear axes second) so a
         ;; same-axis set+clear on one path resolves to cleared. Order within a
-        ;; single map is fixed by the key sequence below.
+        ;; single map is fixed by the key sequence below. Each arm derives the
+        ;; concrete paths and DELEGATES to the core multi-owner ops — add-claims
+        ;; unions the effect owner in, remove-claims strips only the effect
+        ;; owner (a foreign owner on the path survives).
         new-reg
         (reduce
           (fn [reg k]
             (if-not (contains? effects k)
               reg
               (let [{:keys [slot set?]} (classification-effect-axis k)
-                    paths   (map #(vec (path/normalize-concrete %)) (get effects k))
-                    cur     (get reg slot)
-                    updated (if set?
-                              ;; NON-CLOBBERING set (rf2-p4spo4): the registry is
-                              ;; one-entry-per-path-per-axis, so an effect SET on a
-                              ;; path ALSO claimed by another owner (`:source :flow`
-                              ;; from a reg-flow output, `:source :machine`,
-                              ;; `:source :route`, or a subsystem declaration) must
-                              ;; NOT overwrite that owner's provenance. If it did,
-                              ;; the later SOURCE-SCOPED clear below would see
-                              ;; `:source :effect`, dissoc the entry, and silently
-                              ;; un-redact a path the other owner still classifies —
-                              ;; a privacy fail-open. The egress read needs only
-                              ;; PRESENCE, so leaving the foreign owner standing
-                              ;; keeps the path redacted while preserving the source
-                              ;; the clear must honour. Only a free or already-
-                              ;; effect-owned slot is (re)stamped `:source :effect`.
-                              (reduce (fn [m p]
-                                        (let [src (:source (get m p))]
-                                          (if (or (nil? src) (= :effect src))
-                                            (assoc m p {:source :effect})
-                                            m)))
-                                      (or cur {}) paths)
-                              ;; SOURCE-SCOPED clear (rf2-34jrb6): remove a path
-                              ;; only when ITS standing entry is the effect's own
-                              ;; (`:source :effect`). A path also claimed by a
-                              ;; flow / machine / route / subsystem source is
-                              ;; left intact, so a clear never un-redacts a path
-                              ;; another owner still classifies (privacy fail-open).
-                              (reduce (fn [m p]
-                                        (if (= :effect (:source (get m p)))
-                                          (dissoc m p)
-                                          m))
-                                      (or cur {})
-                                      paths))]
-                (if (seq updated)
-                  (assoc reg slot updated)
-                  (dissoc reg slot)))))
+                    paths (map #(vec (path/normalize-concrete %)) (get effects k))]
+                (if set?
+                  (add-claims reg slot effect-owner paths)
+                  (remove-claims reg slot effect-owner paths)))))
           (or reg {})
           ;; SET axes before CLEAR axes — a same-event set+clear of one path on
           ;; an axis resolves to cleared (the clear is the later write).
@@ -569,14 +651,15 @@
 
 (defn- marker-opts
   "The `->marker` option map for a declared-`:large` node — derived from the
-  matched `large-decl` (its `:hint` / `:source`) and the walk `ctx` (its
-  `:as-of-epoch` / `:include-digests?`). The 4-key option map the path-based
-  wire walker (`walk-decider`) passes to `->marker`. The `:source` / `:hint`
-  stay genuinely multi-valued across the flow / effect / schema declaration
-  sources, so the lookup is real even with a single caller."
-  [large-decl ctx]
-  {:hint             (:hint large-decl)
-   :reason           (:source large-decl)
+  matched path's retained `large-owners` set (a STABLE `:reason` provenance via
+  `owners->provenance`) and the walk `ctx` (its `:as-of-epoch` /
+  `:include-digests?`). The 4-key option map the path-based wire walker
+  (`walk-decider`) passes to `->marker`. A large path may carry several
+  independent owners (rf2-wdm1vg); the marker's `:reason` picks the
+  highest-priority source deterministically so the wire shape is reproducible."
+  [large-owners ctx]
+  {:hint             nil
+   :reason           (owners->provenance large-owners)
    :as-of-epoch      (:as-of-epoch ctx)
    :include-digests? (:include-digests? ctx)})
 
@@ -882,7 +965,7 @@
         frame-id      (:frame-id ctx)]
     {:decide
      (fn [[path decl-paths] v]
-       (let [large-decl (decl-match decl-paths large-tbl)
+       (let [large-owners (decl-match decl-paths large-tbl)
              sensitive? (decl-sensitive? decl-paths sensitive-tbl)]
          (cond
            (and sensitive? (not include-s?))
@@ -903,12 +986,12 @@
            ;; fires when a sensitive descendant actually exists under a large
            ;; match, so the ordinary same-path / no-nesting large case is
            ;; unchanged.
-           (and large-decl (not include-lg?) (not include-s?)
+           (and large-owners (not include-lg?) (not include-s?)
                 (seq shadow-set)
                 (some #(contains? shadow-set %) decl-paths))
            walk-recur
 
-           (and large-decl (not include-lg?))
+           (and large-owners (not include-lg?))
            (if (marker? v)
              ;; Idempotence under double-projection: a value at a `:large?`-
              ;; declared path that already carries the `:rf.size/large-elided`
@@ -921,7 +1004,7 @@
              ;; sentinel is non-matchable so the walker descends into nothing
              ;; on a re-projection pass).
              v
-             (->marker v path (marker-opts large-decl ctx)))
+             (->marker v path (marker-opts large-owners ctx)))
 
            :else
            walk-recur)))
@@ -936,10 +1019,10 @@
 
      :leaf
      (fn [[path decl-paths] v]
-       (let [large-decl (decl-match decl-paths large-tbl)
+       (let [large-owners (decl-match decl-paths large-tbl)
              sensitive? (decl-sensitive? decl-paths sensitive-tbl)]
          (when (and (string? v)
-                    (not large-decl)
+                    (not large-owners)
                     (not sensitive?))
            ;; A threshold of 0 disables runtime auto-detect entirely —
            ;; no `pr-str-bytes` walk, no warning. Per API.md §Configure

--- a/implementation/core/src/re_frame/elision.cljc
+++ b/implementation/core/src/re_frame/elision.cljc
@@ -232,12 +232,14 @@
 (defn ^:no-doc owners->provenance
   "Derive the STABLE `:reason` / `:source` provenance keyword for a large-
   classified path from its retained `owners` set. Picks the highest-priority
-  `:source` present (`source-provenance-priority`); falls back to `:effect`
-  when the set carries no recognised source (defensive — matches the historical
-  `->marker` default)."
+  `:source` present (`source-provenance-priority`); for a set carrying only
+  unrecognised sources it picks the lexicographically-first source (still
+  deterministic); falls back to `:effect` for an empty set (defensive —
+  matches the historical `->marker` default)."
   [owners]
   (let [sources (into #{} (keep :source) owners)]
     (or (some sources source-provenance-priority)
+        (first (sort sources))
         :effect)))
 
 (defn ^:no-doc restore-elision-slot
@@ -651,17 +653,20 @@
 
 (defn- marker-opts
   "The `->marker` option map for a declared-`:large` node — derived from the
-  matched path's retained `large-owners` set (a STABLE `:reason` provenance via
-  `owners->provenance`) and the walk `ctx` (its `:as-of-epoch` /
-  `:include-digests?`). The 4-key option map the path-based wire walker
-  (`walk-decider`) passes to `->marker`. A large path may carry several
-  independent owners (rf2-wdm1vg); the marker's `:reason` picks the
-  highest-priority source deterministically so the wire shape is reproducible."
+  matched path's retained `large-owners` set and the walk `ctx` (its
+  `:as-of-epoch` / `:include-digests?`). The 4-key option map the path-based
+  wire walker (`walk-decider`) passes to `->marker`. A large path may carry
+  several independent owners (rf2-wdm1vg); the marker's `:reason` picks the
+  highest-priority source deterministically (`owners->provenance`) and its
+  `:hint` rides from that SAME owner (when the declaration carried one), so the
+  wire shape is reproducible."
   [large-owners ctx]
-  {:hint             nil
-   :reason           (owners->provenance large-owners)
-   :as-of-epoch      (:as-of-epoch ctx)
-   :include-digests? (:include-digests? ctx)})
+  (let [source (owners->provenance large-owners)
+        hint   (some (fn [o] (when (= source (:source o)) (:hint o))) large-owners)]
+    {:hint             hint
+     :reason           source
+     :as-of-epoch      (:as-of-epoch ctx)
+     :include-digests? (:include-digests? ctx)}))
 
 (defn- warn-large-unschema'd!
   [frame-id path bytes]

--- a/implementation/core/test/re_frame/classification_effects_cljs_test.cljc
+++ b/implementation/core/test/re_frame/classification_effects_cljs_test.cljc
@@ -82,8 +82,8 @@
     ;; recorded in the registry, tagged :source :effect
     (is (contains? (sensitive-decls) [:user :token])
         "the classified path is in the per-frame sensitive registry")
-    (is (= :effect (:source (get (sensitive-decls) [:user :token])))
-        "the effect-sourced declaration is tagged :source :effect")
+    (is (= #{{:source :effect}} (get (sensitive-decls) [:user :token]))
+        "the effect owner is the sole claimant of the path (a one-owner set)")
     ;; the application sees the REAL value in app-db (read-only-at-egress)
     (is (= "Bearer secret-xyz" (get-in (frame/frame-app-db-value :rf/default)
                                        [:user :token]))
@@ -122,7 +122,7 @@
     (rf/dispatch-sync [:docs/upload])
     (is (contains? (large-decls) [:docs :csv])
         "the classified path is in the per-frame large registry")
-    (is (= :effect (:source (get (large-decls) [:docs :csv]))))
+    (is (= #{{:source :effect}} (get (large-decls) [:docs :csv])))
     (let [wire (elision/elide-wire-value (frame/frame-app-db-value :rf/default))
           slot (get-in wire [:docs :csv])]
       (is (elision/marker? slot)
@@ -187,53 +187,51 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest clear-sensitive-is-source-scoped-does-not-un-redact-another-source
-  (testing ":clear-sensitive removes only the effect's OWN declaration for a
-            path; a path ALSO claimed by another source (e.g. a reg-flow output
-            under :source :flow) stays classified — the clear must not silently
+  (testing ":clear-sensitive removes only the effect's OWN claim for a path; a
+            path ALSO claimed by another owner (e.g. a reg-flow output under
+            :source :flow) stays classified — the clear must not silently
             un-redact a path another owner still considers sensitive (a privacy
-            fail-open). rf2-34jrb6 + rf2-p4spo4.
+            fail-open). rf2-34jrb6 + rf2-wdm1vg.
 
             This exercises the REAL cross-event path with NO artificial
             re-assertion of the flow mark: the flow claim is installed ONCE up
             front, then a LATER, unrelated event does SET+CLEAR on the same
-            path. Because the SET is non-clobbering (rf2-p4spo4) the flow's
-            :source survives the SET, so the source-scoped clear refuses to
-            dissoc it. Manually re-installing the flow mark between the SET and
-            the CLEAR (the prior papering pattern) is GONE — a live reg-flow
-            does NOT re-fold between two unrelated events, so that re-assertion
-            masked the SET-clobber bug."
-    ;; A flow (another source) declares [:user :token] sensitive in the SAME
+            path. The effect SET UNIONS in (multi-owner registry, rf2-wdm1vg) —
+            both owners now claim the path — and the source-scoped clear removes
+            ONLY the effect owner, leaving the flow owner standing."
+    ;; A flow (another owner) declares [:user :token] sensitive in the SAME
     ;; per-frame elision registry slot the effects write. reg-flow lives in a
     ;; separate artefact, so simulate its registry write directly via the shared
-    ;; swap-elision-slot! seam (the exact slot + shape reg-flow installs:
-    ;; {:source :flow :flow-id …}). Installed ONCE — it is never re-asserted.
+    ;; swap-elision-slot! seam, delegating to the same core op reg-flow uses
+    ;; ({:source :flow :flow-id …}). Installed ONCE — it is never re-asserted.
     (elision/swap-elision-slot! :rf/default
       (fn [reg]
-        (assoc-in reg [:sensitive-declarations [:user :token]]
-                  {:source :flow :flow-id :token-watch})))
-    (is (= :flow (:source (get (sensitive-decls) [:user :token])))
-        "the flow-sourced declaration is standing in the registry")
+        (elision/add-claims (or reg {}) :sensitive-declarations
+                            {:source :flow :flow-id :token-watch} [[:user :token]])))
+    (is (= #{{:source :flow :flow-id :token-watch}}
+           (get (sensitive-decls) [:user :token]))
+        "the flow owner is standing in the registry")
     ;; A LATER, unrelated event ALSO classifies the same path via an effect SET.
-    ;; The NON-CLOBBERING set must leave the flow's :source standing (the
-    ;; registry is one-entry-per-path-per-axis; presence is what egress needs).
+    ;; The multi-owner SET UNIONS the effect owner in alongside the flow owner.
     (rf/reg-event :effect-classify-token
       (fn [{:keys [db]} _]
         {:db (assoc-in db [:user :token] "Bearer secret-xyz")
          :sensitive [[:user :token]]}))
     (rf/dispatch-sync [:effect-classify-token])
-    (is (= :flow (:source (get (sensitive-decls) [:user :token])))
-        "the same-path effect SET did NOT clobber the flow's :source (rf2-p4spo4)")
-    ;; A still-later event CLEARS the path. The source-scoped clear sees
-    ;; :source :flow (NOT :effect) and refuses to dissoc — the path stays
-    ;; classified and the value stays REDACTED. No flow mark is re-asserted
-    ;; between the SET and the CLEAR: this is the real operational sequence.
+    (is (= #{{:source :flow :flow-id :token-watch} {:source :effect}}
+           (get (sensitive-decls) [:user :token]))
+        "the same-path effect SET UNIONS in — both owners claim the path (rf2-wdm1vg)")
+    ;; A still-later event CLEARS the path. The source-scoped clear removes ONLY
+    ;; the effect owner — the flow owner survives, the path stays classified and
+    ;; the value stays REDACTED. This is the real operational sequence.
     (rf/reg-event :effect-clear-token
       (fn [{:keys [db]} _] {:db db :clear-sensitive [[:user :token]]}))
     (rf/dispatch-sync [:effect-clear-token])
     (is (contains? (sensitive-decls) [:user :token])
         "the path is STILL classified — the flow's claim survives the effect clear")
-    (is (= :flow (:source (get (sensitive-decls) [:user :token])))
-        "the surviving entry is the flow's, not the effect's")
+    (is (= #{{:source :flow :flow-id :token-watch}}
+           (get (sensitive-decls) [:user :token]))
+        "the sole surviving owner is the flow's, not the effect's")
     (let [wire (elision/elide-wire-value (frame/frame-app-db-value :rf/default))]
       (is (= privacy/redacted-sentinel (get-in wire [:user :token]))
           "the value stays REDACTED at egress — the clear did not un-redact it"))))
@@ -245,7 +243,7 @@
     (rf/reg-event :effect-only-classify
       (fn [{:keys [db]} _] {:db db :sensitive [[:only :effect]]}))
     (rf/dispatch-sync [:effect-only-classify])
-    (is (= :effect (:source (get (sensitive-decls) [:only :effect]))))
+    (is (= #{{:source :effect}} (get (sensitive-decls) [:only :effect])))
     (rf/reg-event :effect-only-clear
       (fn [{:keys [db]} _] {:db db :clear-sensitive [[:only :effect]]}))
     (rf/dispatch-sync [:effect-only-clear])

--- a/implementation/core/test/re_frame/conformance_runner.cljc
+++ b/implementation/core/test/re_frame/conformance_runner.cljc
@@ -474,16 +474,13 @@
   [fixture scope-frame]
   (letfn [(slot-for [axis]
             (case axis :sensitive :sensitive-declarations :large :declarations))
+          ;; Delegate to the SAME core multi-owner ops the real commit-plane
+          ;; effects use, so the seed writes the effect owner exactly as
+          ;; `apply-classification-effects` would (rf2-wdm1vg).
           (add-paths [reg axis paths]
-            (reduce (fn [r path]
-                      (assoc-in r [(slot-for axis) (vec path)] {:source :effect}))
-                    reg paths))
+            (elision/add-claims reg (slot-for axis) {:source :effect} (map vec paths)))
           (clear-paths [reg axis paths]
-            (let [slot (slot-for axis)]
-              (reduce (fn [r path]
-                        (let [kept (dissoc (get r slot) (vec path))]
-                          (if (seq kept) (assoc r slot kept) (dissoc r slot))))
-                      reg paths)))]
+            (elision/remove-claims reg (slot-for axis) {:source :effect} (map vec paths)))]
     (doseq [op (or (:fixture/classification-effects fixture) [])]
       (cond
         (contains? op :sensitive)

--- a/implementation/core/test/re_frame/elision_multi_owner_cljs_test.cljc
+++ b/implementation/core/test/re_frame/elision_multi_owner_cljs_test.cljc
@@ -1,0 +1,221 @@
+(ns re-frame.elision-multi-owner-cljs-test
+  "rf2-wdm1vg — the per-frame elision registry is a MULTI-OWNER claim registry:
+  each axis slot maps a path to the SET of owner identities that claim it, and a
+  path is redacted while ANY owner claims it, pruned only when the LAST owner
+  drops.
+
+  The correctness property this pins: two INDEPENDENT owners on the SAME path
+  UNION, and removing one leaves the other intact. Before the fix the registry
+  stored one owner per path, so a second owner's claim either overwrote the
+  first (then deleted it on teardown) or was silently ignored — a source-scoped
+  clear / subsystem teardown could un-redact a path another owner still
+  classifies (a fail-open on the AI-egress privacy boundary).
+
+  The cross-family proofs (effect + route / flow / machine / resource on the same
+  path) live in each family's own test suite; this core suite pins the effect
+  path + the pure core operations (`add-claims` / `remove-claims` /
+  `remove-owner` / `replace-owner-claims`) + the source-aware rollback restore.
+
+  Dual-runtime: `*_cljs_test.cljc` so both the shadow-cljs `:node-test` build
+  (`npm run test:cljs`) and the JVM `clojure -M:test` runner run it."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core :as rf]
+            [re-frame.elision :as elision]
+            [re-frame.frame :as frame]
+            [re-frame.privacy :as privacy]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as ts]))
+
+(use-fixtures :each
+  (ts/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter}))
+
+(def ^:private sentinel privacy/redacted-sentinel)
+
+;; A stand-in for a subsystem owner (route / flow / machine / resource): any
+;; family lowers by delegating to the SAME core ops with its own owner
+;; identity, so a `{:source :route}` owner installed via the shared
+;; `swap-elision-slot!` seam models every subsystem claim generically.
+(def ^:private subsystem-owner {:source :route})
+
+(defn- claim-subsystem!
+  "Install a subsystem owner claim on `slot` for `paths` (the way every family
+  lowering does — deriving paths + owner and delegating to `add-claims`)."
+  [slot paths]
+  (elision/swap-elision-slot! :rf/default
+    (fn [reg] (elision/add-claims (or reg {}) slot subsystem-owner paths))))
+
+(defn- drop-subsystem!
+  "Drop the subsystem owner's claims from `slot` (its teardown — delegating to
+  `remove-owner`)."
+  [slot]
+  (elision/swap-elision-slot! :rf/default
+    (fn [reg] (elision/remove-owner (or reg {}) slot subsystem-owner))))
+
+(defn- wire []
+  (elision/elide-wire-value (frame/frame-app-db-value :rf/default)))
+
+;; ===========================================================================
+;; (1) UNION + independent removal — the headline correctness property
+;; ===========================================================================
+
+(deftest effect-then-subsystem-independent-survival-sensitive
+  (testing "effect claims a path, a subsystem ALSO claims it, both survive; the
+            subsystem's teardown leaves the effect claim intact (the path stays
+            redacted); only clearing the LAST (effect) owner un-classifies it"
+    ;; effect classifies [:user :token] alongside its :db write
+    (rf/reg-event :classify-token
+      (fn [{:keys [db]} _]
+        {:db (assoc-in db [:user :token] "Bearer secret") :sensitive [[:user :token]]}))
+    (rf/dispatch-sync [:classify-token])
+    ;; a subsystem (route-like) claims the SAME absolute path
+    (claim-subsystem! :sensitive-declarations [[:user :token]])
+    (is (= #{{:source :effect} subsystem-owner}
+           (get (elision/sensitive-declarations) [:user :token]))
+        "both independent owners are retained as a union")
+    (is (= sentinel (get-in (wire) [:user :token]))
+        "the doubly-claimed path redacts at egress")
+    ;; subsystem teardown (route-leave) — the effect claim MUST survive
+    (drop-subsystem! :sensitive-declarations)
+    (is (= #{{:source :effect}} (get (elision/sensitive-declarations) [:user :token]))
+        "the effect claim survives the subsystem teardown (the fix)")
+    (is (= sentinel (get-in (wire) [:user :token]))
+        "the path is STILL redacted after the subsystem left — the effect owns it")
+    ;; now clear the effect (the sole remaining owner) — the path un-classifies
+    (rf/reg-event :clear-token
+      (fn [{:keys [db]} _] {:db db :clear-sensitive [[:user :token]]}))
+    (rf/dispatch-sync [:clear-token])
+    (is (not (contains? (elision/sensitive-declarations) [:user :token]))
+        "clearing the last owner prunes the path")
+    (is (= "Bearer secret" (get-in (wire) [:user :token]))
+        "with no owner the value ships raw")))
+
+(deftest subsystem-then-effect-clear-preserves-subsystem-sensitive
+  (testing "the REVERSE order: a subsystem claims first, an effect SET on the
+            same path UNIONS (it is neither ignored nor a clobber), and the
+            effect's source-scoped CLEAR leaves the subsystem claim standing —
+            the path stays redacted (the reverse-order fail-open the old
+            single-owner registry hit)"
+    (claim-subsystem! :sensitive-declarations [[:user :token]])
+    (rf/reg-event :classify-token
+      (fn [{:keys [db]} _]
+        {:db (assoc-in db [:user :token] "Bearer secret") :sensitive [[:user :token]]}))
+    (rf/dispatch-sync [:classify-token])
+    (is (= #{subsystem-owner {:source :effect}}
+           (get (elision/sensitive-declarations) [:user :token]))
+        "the effect SET UNIONS in — the subsystem claim is not overwritten and the effect claim is not ignored")
+    ;; effect CLEAR — source-scoped, removes ONLY the effect owner
+    (rf/reg-event :clear-token
+      (fn [{:keys [db]} _] {:db db :clear-sensitive [[:user :token]]}))
+    (rf/dispatch-sync [:clear-token])
+    (is (= #{subsystem-owner} (get (elision/sensitive-declarations) [:user :token]))
+        "the subsystem claim survives the effect clear (not silently un-redacted)")
+    (is (= sentinel (get-in (wire) [:user :token]))
+        "the path is STILL redacted — the subsystem owns it")
+    ;; subsystem teardown — now the path is finally free
+    (drop-subsystem! :sensitive-declarations)
+    (is (not (contains? (elision/sensitive-declarations) [:user :token]))
+        "removing the last owner prunes the path")))
+
+(deftest effect-and-subsystem-independent-survival-large
+  (testing "the large axis unions the same way: a subsystem teardown leaves the
+            effect's :large claim, so the path still elides to a size marker;
+            the marker's :reason carries a STABLE provenance"
+    (rf/reg-event :classify-blob
+      (fn [{:keys [db]} _]
+        {:db (assoc-in db [:docs :csv] (apply str (repeat 500 "X"))) :large [[:docs :csv]]}))
+    (rf/dispatch-sync [:classify-blob])
+    (claim-subsystem! :declarations [[:docs :csv]])
+    (is (= #{{:source :effect} subsystem-owner}
+           (get (elision/declarations) [:docs :csv]))
+        "both owners retained on the large axis")
+    (is (elision/marker? (get-in (wire) [:docs :csv]))
+        "a doubly-claimed large path elides to a marker")
+    (drop-subsystem! :declarations)
+    (is (= #{{:source :effect}} (get (elision/declarations) [:docs :csv]))
+        "the effect large-claim survives the subsystem teardown")
+    (let [slot (get-in (wire) [:docs :csv])]
+      (is (elision/marker? slot) "the path still elides after the subsystem left")
+      (is (keyword? (get-in slot [:rf.size/large-elided :reason]))
+          "the marker carries a stable provenance keyword derived from the owners"))))
+
+;; ===========================================================================
+;; (2) source-aware rollback restore — unwinds the in-band effect owner only
+;; ===========================================================================
+
+(deftest rollback-unwinds-effect-preserves-out-of-band-owner
+  (testing "restore-elision-slot: on a schema rollback the in-band effect owner
+            unwinds to its PRE-cascade state while every out-of-band subsystem
+            owner (route/flow/machine/resource) is carried forward"
+    (let [pre  {:sensitive-declarations {[:a] #{{:source :route}}}}
+          ;; during the rejected event: effect ADDED [:a] and [:b]; a subsystem
+          ;; owner still claims [:a]; a new subsystem claim lowered [:c].
+          live {:sensitive-declarations {[:a] #{{:source :route} {:source :effect}}
+                                         [:b] #{{:source :effect}}
+                                         [:c] #{{:source :machine :actor-id :m#1}}}}
+          restored (elision/restore-elision-slot pre live)
+          s        (:sensitive-declarations restored)]
+      (is (= #{{:source :route}} (get s [:a]))
+          "the during-event effect claim on [:a] unwinds; the out-of-band route claim survives")
+      (is (nil? (get s [:b]))
+          "an in-band effect-only claim added this event is fully unwound")
+      (is (= #{{:source :machine :actor-id :m#1}} (get s [:c]))
+          "a during-event out-of-band subsystem lowering survives the rollback"))))
+
+(deftest rollback-restores-effect-claim-cleared-in-band
+  (testing "an effect claim that PREDATED the cascade and was cleared in-band by
+            the rejected event is restored on rollback (the clear unwinds too)"
+    (let [pre      {:sensitive-declarations {[:a] #{{:source :effect}}}}
+          live     {:sensitive-declarations {}}
+          restored (elision/restore-elision-slot pre live)]
+      (is (= #{{:source :effect}} (get-in restored [:sensitive-declarations [:a]]))
+          "the pre-cascade effect claim is restored"))))
+
+(deftest rollback-restores-dropped-out-of-band-old-path
+  (testing "rf2-o6rsi2: a mid-drain reentrant flow output-path MOVE that dropped
+            the OLD path's flow claim is restored from the pre-cascade snapshot,
+            while the NEW path's during-event flow claim survives from live"
+    (let [owner    {:source :flow :flow-id :f}
+          pre      {:sensitive-declarations {[:old] #{owner}}}
+          live     {:sensitive-declarations {[:new] #{owner}}}
+          restored (elision/restore-elision-slot pre live)
+          s        (:sensitive-declarations restored)]
+      (is (= #{owner} (get s [:old])) "the dropped old-path flow claim is restored from pre")
+      (is (= #{owner} (get s [:new])) "the during-event new-path flow claim survives"))))
+
+;; ===========================================================================
+;; (3) the pure multi-owner operations
+;; ===========================================================================
+
+(deftest core-ops-union-and-scoped-removal
+  (testing "add-claims unions; remove-claims / remove-owner strip one owner and
+            prune only when the last owner leaves; replace-owner-claims reconciles"
+    (let [e {:source :effect}
+          r {:source :route}
+          r2 (-> {}
+                 (elision/add-claims :sensitive-declarations e [[:a]])
+                 (elision/add-claims :sensitive-declarations r [[:a]]))]
+      (is (= #{e r} (get-in r2 [:sensitive-declarations [:a]]))
+          "two owners union on one path")
+      (testing "remove-claims strips one owner at a named path, the other survives"
+        (let [r3 (elision/remove-claims r2 :sensitive-declarations e [[:a]])]
+          (is (= #{r} (get-in r3 [:sensitive-declarations [:a]])))))
+      (testing "removing the last owner prunes the path AND the slot"
+        (let [r4 (-> r2
+                     (elision/remove-owner :sensitive-declarations e)
+                     (elision/remove-owner :sensitive-declarations r))]
+          (is (not (contains? r4 :sensitive-declarations))
+              "the emptied slot is dissoc'd, not left as {}")))
+      (testing "replace-owner-claims reconciles ONE owner's paths, leaving foreign owners"
+        (let [r5 (elision/replace-owner-claims r2 :sensitive-declarations r [[:b]])]
+          (is (= #{e} (get-in r5 [:sensitive-declarations [:a]]))
+              "the route owner is dropped from its old path; the effect owner stays")
+          (is (= #{r} (get-in r5 [:sensitive-declarations [:b]]))
+              "the route owner is installed at its new path"))))))
+
+(deftest core-ops-are-no-ops-on-empty-inputs
+  (testing "add/remove with no paths, or remove against an empty slot, are no-ops"
+    (is (= {} (elision/add-claims {} :sensitive-declarations {:source :effect} [])))
+    (is (= {} (elision/remove-claims {} :sensitive-declarations {:source :effect} [[:a]])))
+    (is (= {} (elision/remove-owner {} :sensitive-declarations {:source :effect})))))

--- a/implementation/core/test/re_frame/elision_test.clj
+++ b/implementation/core/test/re_frame/elision_test.clj
@@ -562,8 +562,10 @@
     (re-frame.elision/swap-elision-slot!
        frame-id
        (fn [reg]
+         ;; owner-set shape (rf2-wdm1vg): the owner carries its optional
+         ;; display `:hint`, which rides into the marker.
          (assoc reg :declarations
-                {path {:large? true :source :test :hint "Upload preview"}})))
+                {path #{{:source :test :hint "Upload preview"}}})))
     (let [out  (rf/elide-wire-value sub-cache {:frame frame-id})
           slot (get-in out [[:user/uploaded] :value :pdf])]
       (is (elision/marker? slot)

--- a/implementation/core/test/re_frame/elision_test.clj
+++ b/implementation/core/test/re_frame/elision_test.clj
@@ -81,7 +81,7 @@
         out   (rf/elide-wire-value
                 {:user {:name "Ada" :uploaded-pdf "<<5MB-blob>>"}})
         slot  (get-in out [:user :uploaded-pdf])]
-    (is (= {:source :effect}
+    (is (= #{{:source :effect}}
            (get decls [:user :uploaded-pdf])))
     (is (elision/marker? slot))
     (is (= [:user :uploaded-pdf]
@@ -330,7 +330,7 @@
   (install-class! [[:root :a :b :token]] [[:root :a :b :c]])
   (is (contains? (elision/declarations) [:root :a :b :c]))
   (is (contains? (elision/sensitive-declarations) [:root :a :b :token]))
-  (is (= {:source :effect}
+  (is (= #{{:source :effect}}
          (get (elision/declarations) [:root :a :b :c]))))
 
 ;; rf2-izlr7f — NESTED-AXIS SUPPRESSION (the highest-priority EP-0025 egress

--- a/implementation/core/test/re_frame/frame_classification_cljs_test.cljc
+++ b/implementation/core/test/re_frame/frame_classification_cljs_test.cljc
@@ -133,8 +133,8 @@
           large (elision/declarations :app/effects)]
       (is (contains? sens [:auth :token])
           "the :sensitive effect classified [:auth :token]")
-      (is (= :effect (:source (get sens [:auth :token])))
-          "the declaration is tagged :source :effect")
+      (is (= #{{:source :effect}} (get sens [:auth :token]))
+          "the effect owner is the sole claimant, tagged :source :effect")
       (is (contains? large [:documents :csv-upload])
           "the :large effect classified [:documents :csv-upload]"))))
 

--- a/implementation/core/test/re_frame/partitioned_commit_test.clj
+++ b/implementation/core/test/re_frame/partitioned_commit_test.clj
@@ -435,10 +435,10 @@
       ;; the `{:source :flow}` mark at REGISTRATION time, so it is present in
       ;; `runtime-before` (the chain-start snapshot) and must survive a rollback.
       (rf/reg-flow :creds {:frame :pc/rb-srcaware :inputs [[:n]] :output-path [:derived :creds] :sensitive [[:secret]]} (fn [n] {:secret n}))
-      (is (= {:source :flow :flow-id :creds}
+      (is (= #{{:source :flow :flow-id :creds}}
              (get (elision/sensitive-declarations :pc/rb-srcaware)
                   [:derived :creds :secret]))
-          "precondition: the :source :flow mark is installed at reg-flow time")
+          "precondition: the :source :flow owner is installed at reg-flow time")
       ;; app schema demanding :n stay a non-negative int — the bad handler
       ;; violates it, forcing the post-commit rollback.
       (rf/with-frame :pc/rb-srcaware
@@ -461,10 +461,10 @@
                           [:another-secret]))
           "the rejected event's in-band :source :effect classification UNWINDS on rollback (rf2-5lo1fk)")
       ;; rf2-3pglag: the pre-existing :source :flow mark SURVIVES the rollback.
-      (is (= {:source :flow :flow-id :creds}
+      (is (= #{{:source :flow :flow-id :creds}}
              (get (elision/sensitive-declarations :pc/rb-srcaware)
                   [:derived :creds :secret]))
-          "the pre-existing :source :flow mark SURVIVES the rollback (rf2-3pglag)"))))
+          "the pre-existing :source :flow owner SURVIVES the rollback (rf2-3pglag)"))))
 
 ;; rf2-yzsims — positive rollback-survivor coverage for genuine out-of-band
 ;; sources LOWERED DURING the rejected event, plus the rf2-o6rsi2 reentrant
@@ -492,8 +492,9 @@
         {:after (fn [ctx]
                   (elision/swap-elision-slot! :pc/rb-subsys
                     (fn [reg]
-                      (assoc-in reg [:sensitive-declarations [:actor :token]]
-                                {:source :machine :machine-id :door})))
+                      (elision/add-claims (or reg {}) :sensitive-declarations
+                                          {:source :machine :machine-id :door}
+                                          [[:actor :token]])))
                   ctx)})
       (rf/reg-event :pc/bad-subsys
         {:doc "schema-violating handler; the interceptor lowers a subsystem mark"
@@ -503,9 +504,9 @@
       (rf/dispatch-sync [:pc/bad-subsys] {:frame :pc/rb-subsys})
       (is (= {:n 0} (rf/app-db-value :pc/rb-subsys))
           "app-db rolled back to the pre-handler value")
-      (is (= {:source :machine :machine-id :door}
+      (is (= #{{:source :machine :machine-id :door}}
              (get (elision/sensitive-declarations :pc/rb-subsys) [:actor :token]))
-          "the during-event out-of-band :source :machine mark SURVIVES the rollback (rf2-yzsims)"))))
+          "the during-event out-of-band :source :machine owner SURVIVES the rollback (rf2-yzsims)"))))
 
 (deftest schema-rollback-restores-moved-flow-old-path-mark
   (testing "a reentrant reg-flow output-path MOVE inside a schema-rejected
@@ -521,10 +522,10 @@
       ;; A real flow whose sensitive output sits at the OLD path. The mark is
       ;; installed at reg-flow time, so it is in the chain-start snapshot.
       (rf/reg-flow :mover {:frame :pc/rb-move :inputs [[:n]] :output-path [:old :creds] :sensitive [[:secret]]} (fn [n] {:secret n}))
-      (is (= {:source :flow :flow-id :mover}
+      (is (= #{{:source :flow :flow-id :mover}}
              (get (elision/sensitive-declarations :pc/rb-move)
                   [:old :creds :secret]))
-          "precondition: the OLD-path :source :flow mark is installed")
+          "precondition: the OLD-path :source :flow owner is installed")
       (rf/with-frame :pc/rb-move
         (rf/reg-app-schema [] [:map [:n [:int {:min 0}]]]))
       ;; An :after interceptor MOVES the flow's output-path mid-cascade (a
@@ -545,16 +546,16 @@
       ;; rf2-o6rsi2: the OLD-path mark is restored from the pre-cascade snapshot
       ;; (the live registry had dropped it; the rolled-back db still holds the
       ;; old output value, so dropping the mark would leak it RAW).
-      (is (= {:source :flow :flow-id :mover}
+      (is (= #{{:source :flow :flow-id :mover}}
              (get (elision/sensitive-declarations :pc/rb-move)
                   [:old :creds :secret]))
-          "the dropped OLD-path :source :flow mark is RESTORED on rollback (rf2-o6rsi2)")
+          "the dropped OLD-path :source :flow owner is RESTORED on rollback (rf2-o6rsi2)")
       ;; The NEW-path mark — lowered out-of-band during the event — legitimately
       ;; survives too (the flow now declares it; harmless over the rolled-back db).
-      (is (= {:source :flow :flow-id :mover}
+      (is (= #{{:source :flow :flow-id :mover}}
              (get (elision/sensitive-declarations :pc/rb-move)
                   [:new :creds :secret]))
-          "the NEW-path out-of-band :source :flow mark survives (during-event subsystem write)"))))
+          "the NEW-path out-of-band :source :flow owner survives (during-event subsystem write)"))))
 
 ;; rf2-wfy2kq (P1 DATA-CORRUPTION) — the post-commit schema rollback must
 ;; restore the FULL prior app-db, not a path-focused SLICE.

--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -378,42 +378,27 @@
       (contains? flow :large)
       (contains? flow :large?)))
 
-(defn- drop-flow-sourced
-  "Remove every `{:source :flow :flow-id <flow-id>}` entry from a declaration
-  map, preserving every other-sourced entry (and any OTHER flow's entries)."
-  [decls flow-id]
-  (when decls
-    (reduce-kv (fn [acc path decl]
-                 (if (and (= :flow (:source decl))
-                          (= flow-id (:flow-id decl)))
-                   acc
-                   (assoc acc path decl)))
-               {}
-               decls)))
-
-(defn- assoc-flow-paths
-  "Add `paths` to `existing` declaration map, each stamped
-  `{:source :flow :flow-id <flow-id>}` so lifecycle cleanup can find them."
-  [existing paths flow-id]
-  (reduce (fn [acc path]
-            (assoc acc (vec path) {:source :flow :flow-id flow-id}))
-          (or existing {})
-          paths))
+(defn- flow-owner
+  "The multi-owner elision-registry owner identity a `reg-flow` output claims
+  under. The `:flow-id` is carried so re-registration / clear scope to THIS
+  flow (`replace-owner-claims` / `remove-owner`) without disturbing a sibling
+  flow's — or any other source's — claim on the same absolute path."
+  [flow-id]
+  {:source :flow :flow-id flow-id})
 
 (defn- fold-flow-declarations
-  "Replace one flow's declarations in an elision registry value."
+  "Reconcile one flow's output declarations in an elision registry value:
+  replace THIS flow's owner claims (both axes) with its current explicit
+  sensitive / large absolute output paths, delegating to the core multi-owner
+  op (`elision/replace-owner-claims`). A foreign owner (effect / route /
+  machine / resource) — or a sibling flow — on the same absolute path survives
+  untouched, and the flow's claim unions with theirs (rf2-wdm1vg)."
   [reg flow]
-  (let [flow-id            (:id flow)
-        [explicit-s explicit-l] (explicit-flow-output-mark-paths flow)
-        carry-s            (drop-flow-sourced (get reg :sensitive-declarations) flow-id)
-        carry-l            (drop-flow-sourced (get reg :declarations) flow-id)
-        new-s              (assoc-flow-paths carry-s explicit-s flow-id)
-        new-l              (assoc-flow-paths carry-l explicit-l flow-id)]
-    (cond-> (or reg {})
-      (seq new-s)    (assoc :sensitive-declarations new-s)
-      (empty? new-s) (dissoc :sensitive-declarations)
-      (seq new-l)    (assoc :declarations new-l)
-      (empty? new-l) (dissoc :declarations))))
+  (let [owner (flow-owner (:id flow))
+        [explicit-s explicit-l] (explicit-flow-output-mark-paths flow)]
+    (-> (or reg {})
+        (elision/replace-owner-claims :sensitive-declarations owner explicit-s)
+        (elision/replace-owner-claims :declarations owner explicit-l))))
 
 (defn- write-flow-output-marks!
   "Install or refresh one flow's output declarations in its frame."
@@ -422,20 +407,19 @@
     (fn [reg] (fold-flow-declarations reg flow))))
 
 (defn- clear-flow-output-marks!
-  "Remove one flow's declarations while preserving other declaration sources.
+  "Remove one flow's declarations while preserving every other declaration
+  owner (and any sibling flow's) via the core `elision/remove-owner` op per
+  axis.
 
   Frame teardown needs no per-flow scrub because the elision registry belongs
   to the frame-state container that destruction removes."
   [frame-id flow-id]
-  (elision/swap-elision-slot! frame-id
-    (fn [reg]
-      (let [new-s (drop-flow-sourced (get reg :sensitive-declarations) flow-id)
-            new-l (drop-flow-sourced (get reg :declarations) flow-id)]
-        (cond-> (or reg {})
-          (seq new-s)    (assoc :sensitive-declarations new-s)
-          (empty? new-s) (dissoc :sensitive-declarations)
-          (seq new-l)    (assoc :declarations new-l)
-          (empty? new-l) (dissoc :declarations))))))
+  (let [owner (flow-owner flow-id)]
+    (elision/swap-elision-slot! frame-id
+      (fn [reg]
+        (-> (or reg {})
+            (elision/remove-owner :sensitive-declarations owner)
+            (elision/remove-owner :declarations owner))))))
 
 ;; ---- registration --------------------------------------------------------
 

--- a/implementation/flows/test/re_frame/flows_trace_test.clj
+++ b/implementation/flows/test/re_frame/flows_trace_test.clj
@@ -1082,8 +1082,8 @@
     (rf/reg-flow :payload {:inputs [[:n]] :output-path [:derived :blob] :large? true} (fn [_] {:bytes "BIG"}))
     ;; Precondition: the flow's own registration installed the :source :flow
     ;; declaration (not a helper, not an effect).
-    (is (= :flow (:source (get (elision/declarations :rf/default) [:derived :blob])))
-        "precondition: the reg-flow :large? mark stands as a :source :flow declaration")
+    (is (some #(= :flow (:source %)) (get (elision/declarations :rf/default) [:derived :blob]))
+        "precondition: the reg-flow :large? mark stands as a :source :flow owner")
     (reset! *captured* [])
     (rf/dispatch-sync [:init])
     ;; (a) the trace channel — :rf.flow/computed :result rides elide-wire-value.
@@ -1117,9 +1117,9 @@
     (rf/reg-flow :creds {:inputs [[:n]] :output-path [:auth :creds] :sensitive [[:secret]]} (fn [n] {:secret (str "Bearer-" n)}))
     ;; Precondition: the sensitive sub-slot roots at :output-path ++ [:secret]
     ;; and is a :source :flow declaration.
-    (is (= :flow (:source (get (elision/sensitive-declarations :rf/default)
-                               [:auth :creds :secret])))
-        "precondition: the reg-flow :sensitive mark stands as a :source :flow declaration")
+    (is (some #(= :flow (:source %)) (get (elision/sensitive-declarations :rf/default)
+                                          [:auth :creds :secret]))
+        "precondition: the reg-flow :sensitive mark stands as a :source :flow owner")
     (reset! *captured* [])
     (rf/dispatch-sync [:init])
     ;; (a) the trace channel — :result's :secret sub-slot redacts (sensitive

--- a/implementation/flows/test/re_frame/flows_trace_test.clj
+++ b/implementation/flows/test/re_frame/flows_trace_test.clj
@@ -1468,3 +1468,36 @@
                ") — run-end fires AFTER the deferred install, not before"))
       (is (= (dec (count ops)) p-run-end)
           ":rf.event/run-end is the FINAL trace of the clean cascade"))))
+
+;; ===========================================================================
+;; (rf2-wdm1vg) MULTI-OWNER union — a reg-flow output's :sensitive claim and an
+;; app effect claim on the SAME absolute output path survive INDEPENDENTLY.
+;; ===========================================================================
+
+(deftest flow-and-effect-claims-union-and-remove-independently
+  (testing "rf2-wdm1vg — a reg-flow output's :sensitive claim and an app effect
+            claim on the SAME absolute output path UNION, and each removes
+            INDEPENDENTLY: the effect clear leaves the flow claim; clear-flow
+            leaves the effect claim. The path stays classified while any owner
+            claims it."
+    (let [p      [:auth :creds :secret]
+          owners #(get (elision/sensitive-declarations :rf/default) p)]
+      ;; a flow classifies its own output sub-slot :sensitive at registration
+      (rf/reg-flow :creds {:inputs [[:n]] :output-path [:auth :creds] :sensitive [[:secret]]}
+                   (fn [n] {:secret (str "Bearer-" n)}))
+      (is (some #(= :flow (:source %)) (owners)) "the flow claim is standing after reg-flow")
+      ;; an app effect ALSO classifies the SAME absolute path → union
+      (rf/reg-event :flow-union/classify (fn [{:keys [db]} _] {:db db :sensitive [p]}))
+      (rf/dispatch-sync [:flow-union/classify])
+      (is (contains? (owners) {:source :effect}) "the effect claim UNIONS in")
+      (is (some #(= :flow (:source %)) (owners)) "the flow claim is retained through the effect SET")
+      ;; effect CLEAR removes only the effect owner — the flow survives
+      (rf/reg-event :flow-union/clear (fn [{:keys [db]} _] {:db db :clear-sensitive [p]}))
+      (rf/dispatch-sync [:flow-union/clear])
+      (is (not (contains? (owners) {:source :effect})) "the effect owner is cleared")
+      (is (some #(= :flow (:source %)) (owners)) "the flow claim SURVIVES the effect clear")
+      ;; re-add the effect, then clear-flow — the effect survives the flow teardown
+      (rf/dispatch-sync [:flow-union/classify])
+      (flows/clear-flow :creds {:frame :rf/default})
+      (is (contains? (owners) {:source :effect}) "the effect claim SURVIVES clear-flow")
+      (is (not (some #(= :flow (:source %)) (owners))) "the flow owner is dropped by clear-flow"))))

--- a/implementation/machines/src/re_frame/machines/classification.cljc
+++ b/implementation/machines/src/re_frame/machines/classification.cljc
@@ -109,57 +109,45 @@
   [actor-id path]
   (into (paths/snapshot-path actor-id) path))
 
+(defn- machine-owner
+  "The multi-owner elision-registry owner identity a machine actor's lowered
+  `:data` classification claims under. The `:actor-id` is carried so an actor's
+  spawn / destroy scopes to THAT instance — removing one actor's claims never
+  disturbs a sibling actor's or another source's claim on the same absolute
+  path."
+  [actor-id]
+  {:source :machine :actor-id actor-id})
+
 (defn- apply-decls
   "Pure registry transform: ADD (`set?` true) or DROP (`set?` false) the
   absolute snapshot-rooted declarations for `actor-id`'s `decls`
   (`{:sensitive [paths] :large [paths]}`) on a base elision-registry value
-  `reg`. SET writes `{:source :machine}` at each axis slot
+  `reg`, delegating to the core multi-owner ops. SET UNIONS this actor's owner
+  (`{:source :machine :actor-id …}`) into each axis slot
   (`:sensitive-declarations` / `:declarations` — the SAME slots the four
-  commit-plane effects and `reg-flow` outputs populate) WITHOUT clobbering a
-  foreign-source standing entry (the registry is one-entry-per-path-per-axis;
-  an app effect, flow, or route claim on the same absolute path is left
-  standing). DROP is SOURCE-SCOPED: it dissocs a named absolute path only when
-  its standing entry
-  is the machine's own (`:source :machine`). A path ALSO claimed by another
-  source (Spec 015 L149 explicitly permits an app to additionally classify a
-  subsystem absolute path from a handler effect, `:source :effect`) is LEFT
-  INTACT, so an actor teardown never silently un-redacts a path another owner
-  still classifies (a privacy fail-open). Mirrors the effect clear
-  (`re-frame.elision/apply-classification-effects`, source-scoped) and the
-  route lowering (`re-frame.routing.classification/without-route-sourced`,
-  which filters `:source :route`). An emptied axis slot is pruned. Returns the new registry
-  value."
+  commit-plane effects and `reg-flow` outputs populate) ALONGSIDE any foreign
+  owner on the same absolute path (Spec 015 L149 explicitly permits an app to
+  additionally classify a subsystem absolute path from a handler effect,
+  `:source :effect`); DROP removes ONLY this actor's own owner
+  (`elision/remove-claims`) at the named absolute paths — a path ALSO claimed
+  by another owner is LEFT INTACT, so an actor teardown never silently
+  un-redacts a path another owner still classifies (a privacy fail-open,
+  rf2-wdm1vg). An emptied axis slot is pruned by the core ops. Returns the new
+  registry value."
   [reg actor-id decls set?]
-  (reduce
-    (fn [reg [axis slot]]
-      (let [paths (get decls axis)]
-        (if-not (seq paths)
-          reg
-          (let [abs (map #(absolute-snapshot-path actor-id %) paths)
-                cur (get reg slot)
-                updated (if set?
-                          (reduce (fn [m p]
-                                    ;; Do NOT overwrite a foreign-source entry —
-                                    ;; only write the machine claim into a free
-                                    ;; or already-machine-owned slot.
-                                    (let [src (:source (get m p))]
-                                      (if (or (nil? src) (= :machine src))
-                                        (assoc m p {:source :machine})
-                                        m)))
-                                  (or cur {}) abs)
-                          ;; SOURCE-SCOPED drop: remove a path only when its
-                          ;; standing entry is the machine's own.
-                          (reduce (fn [m p]
-                                    (if (= :machine (:source (get m p)))
-                                      (dissoc m p)
-                                      m))
-                                  (or cur {}) abs))]
-            (if (seq updated)
-              (assoc reg slot updated)
-              (dissoc reg slot))))))
-    (or reg {})
-    {:sensitive :sensitive-declarations
-     :large     :declarations}))
+  (let [owner (machine-owner actor-id)]
+    (reduce
+      (fn [reg [axis slot]]
+        (let [paths (get decls axis)]
+          (if-not (seq paths)
+            reg
+            (let [abs (map #(absolute-snapshot-path actor-id %) paths)]
+              (if set?
+                (elision/add-claims reg slot owner abs)
+                (elision/remove-claims reg slot owner abs))))))
+      (or reg {})
+      {:sensitive :sensitive-declarations
+       :large     :declarations})))
 
 (defn lower-at-spawn!
   "LOWER the machine `spec`'s projection-relative `:sensitive` / `:large`

--- a/implementation/machines/test/re_frame/machine_data_schema_redaction_test.clj
+++ b/implementation/machines/test/re_frame/machine_data_schema_redaction_test.clj
@@ -400,7 +400,7 @@
       (let [reg (snapshot-elision-reg)]
         (is (contains? (:sensitive-declarations reg) abs-token)
             "sensitive `:data` path lowered to the ABSOLUTE snapshot path at boot")
-        (is (= :machine (get-in reg [:sensitive-declarations abs-token :source]))
+        (is (some #(= :machine (:source %)) (get-in reg [:sensitive-declarations abs-token]))
             "lowered under :source :machine")
         (is (contains? (:declarations reg) abs-blob)
             "large `:data` path lowered at boot"))
@@ -460,7 +460,7 @@
               reg       (snapshot-elision-reg)]
           (is (contains? (:sensitive-declarations reg) abs-token)
               "the spawned instance's :data :token lowered at spawn (per-instance)")
-          (is (= :machine (get-in reg [:sensitive-declarations abs-token :source])))
+          (is (some #(= :machine (:source %)) (get-in reg [:sensitive-declarations abs-token])))
           ;; egress redacts the spawned instance's declared slot
           (let [out (classification/project-trace-event
                       {:operation :rf.machine/snapshot-updated
@@ -519,25 +519,26 @@
         (fn [{:keys [db]} _]
           {:db db :sensitive [abs-token]}))
       (rf/dispatch-sync [:rf.machine-redaction/app-classify-token])
-      (is (= :effect (get-in (snapshot-elision-reg)
-                             [:sensitive-declarations abs-token :source]))
+      (is (contains? (get-in (snapshot-elision-reg) [:sensitive-declarations abs-token])
+                     {:source :effect})
           "precondition: the app's :source :effect classification is standing")
-      ;; Booting the singleton lowers the machine declaration at the SAME path.
-      ;; The machine SET must NOT clobber the app's :source :effect claim.
+      ;; Booting the singleton runs the machine lowering at the SAME path. The
+      ;; machine's own claim never CLOBBERS the app's effect claim — the effect
+      ;; owner survives the boot (multi-owner registry, rf2-wdm1vg).
       (rf/dispatch-sync [mid [:rf.machine/noop]])
-      (is (= :effect (get-in (snapshot-elision-reg)
-                             [:sensitive-declarations abs-token :source]))
-          "the machine SET did NOT clobber the app's :source :effect claim")
-      ;; Destroy the actor. The DROP must be source-scoped — it must NOT remove
-      ;; the app's :source :effect entry.
+      (is (contains? (get-in (snapshot-elision-reg) [:sensitive-declarations abs-token])
+                     {:source :effect})
+          "the machine boot did NOT clobber the app's :source :effect claim")
+      ;; Destroy the actor. The source-scoped drop removes only the machine's own
+      ;; owner — it must NOT remove the app's :source :effect entry.
       (rf/reg-event :rf.machine-redaction/destroy-coupled
         (fn [_ _] {:fx [[:rf.machine/destroy mid]]}))
       (rf/dispatch-sync [:rf.machine-redaction/destroy-coupled])
       (let [reg (snapshot-elision-reg)]
         (is (contains? (:sensitive-declarations reg) abs-token)
             "the path is STILL classified after destroy — the app's claim survives")
-        (is (= :effect (get-in reg [:sensitive-declarations abs-token :source]))
-            "the surviving entry is the app's :source :effect, not the machine's"))
+        (is (contains? (get-in reg [:sensitive-declarations abs-token]) {:source :effect})
+            "the app's :source :effect owner survives the actor teardown"))
       ;; And egress still redacts — the fail-open is sealed.
       (let [out  (classification/project-trace-event (machine-transition-event mid))
             tags (:tags out)]
@@ -545,3 +546,49 @@
             "the value stays REDACTED at egress — the teardown did not un-redact it")
         (is (not (.contains (pr-str out) "secret-jwt"))
             "no secret leaks through the post-destroy egress")))))
+
+(deftest machine-and-effect-claims-union-and-remove-independently
+  (testing "rf2-wdm1vg — a machine's lowered :data claim and an app effect claim
+            on the SAME absolute snapshot path UNION (both owners retained), and
+            each removes INDEPENDENTLY: the effect clear leaves the machine claim
+            standing; the actor destroy leaves the effect claim standing. Both
+            keep the path redacted while any owner claims it."
+    (let [mid       :rf.machine-redaction/union-single
+          abs-token [:rf.runtime/machines :snapshots mid :data :token]
+          owners    #(get-in (snapshot-elision-reg) [:sensitive-declarations abs-token])]
+      (rf/reg-machine mid
+        {:sensitive [[:data :token]]
+         :initial   :anon
+         :data      {:token nil :retries 0}
+         :states    {:anon {:on {:login :authed}} :authed {}}})
+      ;; Machine boots FIRST → its own claim lands at the absolute snapshot path.
+      (rf/dispatch-sync [mid [:rf.machine/noop]])
+      (is (some #(= :machine (:source %)) (owners))
+          "the machine's own claim is standing after boot")
+      ;; An app effect ALSO classifies the same absolute path (Spec 015 L149) →
+      ;; UNION: both owners now claim the path.
+      (rf/reg-event :rf.machine-redaction/union-classify
+        (fn [{:keys [db]} _] {:db db :sensitive [abs-token]}))
+      (rf/dispatch-sync [:rf.machine-redaction/union-classify])
+      (is (contains? (owners) {:source :effect})
+          "the effect claim UNIONS in alongside the machine claim")
+      (is (some #(= :machine (:source %)) (owners))
+          "the machine claim is retained through the effect SET")
+      ;; The effect CLEAR removes ONLY the effect owner — the machine survives.
+      (rf/reg-event :rf.machine-redaction/union-clear
+        (fn [{:keys [db]} _] {:db db :clear-sensitive [abs-token]}))
+      (rf/dispatch-sync [:rf.machine-redaction/union-clear])
+      (is (not (contains? (owners) {:source :effect}))
+          "the effect owner is removed by its source-scoped clear")
+      (is (some #(= :machine (:source %)) (owners))
+          "the machine claim SURVIVES the effect clear — the path stays classified")
+      ;; Re-add the effect, then DESTROY the actor — the effect survives the
+      ;; source-scoped actor teardown (the reverse independent-removal leg).
+      (rf/dispatch-sync [:rf.machine-redaction/union-classify])
+      (rf/reg-event :rf.machine-redaction/union-destroy
+        (fn [_ _] {:fx [[:rf.machine/destroy mid]]}))
+      (rf/dispatch-sync [:rf.machine-redaction/union-destroy])
+      (is (contains? (owners) {:source :effect})
+          "the effect claim SURVIVES the actor destroy — no fail-open")
+      (is (not (some #(= :machine (:source %)) (owners)))
+          "the machine's own owner is dropped by the source-scoped teardown"))))

--- a/implementation/machines/test/re_frame/machine_data_schema_redaction_test.clj
+++ b/implementation/machines/test/re_frame/machine_data_schema_redaction_test.clj
@@ -101,13 +101,11 @@
   ([actor-id]
    (elision/swap-elision-slot! :rf/default
      (fn [reg]
-       (-> reg
-           (assoc-in [:sensitive-declarations
-                      [:rf.runtime/machines :snapshots actor-id :data :token]]
-                     {:source :effect})
-           (assoc-in [:declarations
-                      [:rf.runtime/machines :snapshots actor-id :data :blob]]
-                     {:source :effect}))))))
+       (-> (or reg {})
+           (elision/add-claims :sensitive-declarations {:source :effect}
+                               [[:rf.runtime/machines :snapshots actor-id :data :token]])
+           (elision/add-claims :declarations {:source :effect}
+                               [[:rf.runtime/machines :snapshots actor-id :data :blob]]))))))
 
 (defn- machine-transition-event*
   "Build a `:rf.machine/transition` trace event whose `:before` / `:after`

--- a/implementation/resources/src/re_frame/resources/classification.cljc
+++ b/implementation/resources/src/re_frame/resources/classification.cljc
@@ -546,50 +546,34 @@
     {:sensitive (->abs s)
      :large     (->abs l)}))
 
-(defn- without-resource-sourced
-  "Drop `:source :resource` entries from a `{path decl}` declaration map,
-  preserving every other-sourced entry (`:effect` / `:flow` / `:route` /
-  `:machine` / `:owner-declaration`). Returns `{}` for nil."
-  [decls]
-  (reduce-kv (fn [acc p decl]
-               (if (= resource-source (:source decl))
-                 acc
-                 (assoc acc p decl)))
-             {}
-             (or decls {})))
-
-(defn- with-resource-paths
-  "Overlay `:source :resource` declarations for the absolute `paths` onto the
-  carried (non-resource-sourced) declaration map WITHOUT clobbering a foreign-
-  source standing entry on the same absolute path (the registry is one entry-
-  per-path-per-axis; an app-effect / flow / route claim on the same path is left
-  standing — the same posture machines' `apply-decls` SET uses)."
-  [carried paths]
-  (reduce (fn [acc p]
-            (if (contains? acc p)
-              acc
-              (assoc acc p {:source resource-source})))
-          carried
-          paths))
+(def ^:private resource-owner
+  "The multi-owner elision-registry owner identity a resource / mutation
+  instance lowering claims under. All current entries share this owner; the
+  reconcile rebuilds the full resource-owned claim set from the live entries
+  each commit (self-dropping), so `elision/replace-owner-claims` drops evicted
+  entries' claims and installs current ones in one step."
+  {:source resource-source})
 
 (defn reconcile-registry
   "PURE per-instance lowering: given a base `runtime-db` value and a `spec-of`
   resolver `(fn [resource-id] -> spec|nil)`, return the runtime-db with the
-  `[:rf.runtime/elision …]` registry's `:source :resource` entries REPLACED by
-  the declarations of EVERY current cache entry (re-rooted absolute per the
-  entry's byte `key-id`). This is the resources peer of
-  `re-frame.routing.classification/apply-route-classification` and
-  `re-frame.machines.classification/lower-at-spawn!`.
+  `[:rf.runtime/elision …]` registry's resource-owner claims REPLACED by the
+  declarations of EVERY current cache entry (re-rooted absolute per the entry's
+  byte `key-id`), delegating to the core multi-owner op
+  `re-frame.elision/replace-owner-claims`. The standard EP-0025 lowering — the
+  resources peer of `re-frame.routing.classification/apply-route-classification`
+  and `re-frame.machines.classification/lower-at-spawn!` (rf2-v8x9n8).
 
   Operates on a VALUE so a resource handler's durable `:rf.db/runtime`
   transition folds the registry update into the SAME atomic commit that
   writes / evicts the entry. IDEMPOTENT + SELF-DROPPING: the full resource-
-  sourced set is rebuilt from the current `:entries`, so an evicted entry's
+  owned claim set is rebuilt from the current `:entries`, so an evicted entry's
   declarations vanish (the per-instance teardown) and a newly-minted entry's
   appear, with no separate drop hook. Value-INDEPENDENT (the declared path
-  redacts whatever later occupies the slot). Other-sourced registry entries
-  (`:effect` / `:flow` / `:route` / `:machine`) ride untouched and union at
-  egress-lookup time.
+  redacts whatever later occupies the slot). A path ALSO claimed by another
+  owner (`{:source :effect}` / `{:source :flow …}` / `{:source :route}` /
+  `{:source :machine …}`) rides untouched and unions at egress-lookup time
+  (rf2-wdm1vg).
 
   `spec-of` is injected (resources' `registry` requires `classification`, so a
   static back-require would cycle) — the caller (a resource event handler in
@@ -598,7 +582,7 @@
   nothing.
 
   Reconcile-aware (router `re-frame.elision/reconcile-runtime-db-effect`): when
-  the lowering touched the registry (the base carried resource-sourced entries
+  the lowering touched the registry (the base carried resource-owned entries
   or the current entries declare some), it emits an EXPLICIT
   `:rf.runtime/elision` key (possibly cleared of all resource entries) so a
   whole-value runtime-db commit honours an eviction's drop verbatim rather than
@@ -608,8 +592,6 @@
   (let [base    (or runtime-db {})
         entries (get-in base (state/entries-path))
         reg     (get base elision-registry-key)
-        carry-s (without-resource-sourced (:sensitive-declarations reg))
-        carry-l (without-resource-sourced (:declarations reg))
         ;; gather every current entry's absolute declaration paths
         {:keys [sensitive large]}
         (reduce-kv
@@ -624,11 +606,9 @@
                       (update :large into large))))))
           {:sensitive [] :large []}
           (or entries {}))
-        new-s   (with-resource-paths carry-s sensitive)
-        new-l   (with-resource-paths carry-l large)
-        new-reg (cond-> {}
-                  (seq new-s) (assoc :sensitive-declarations new-s)
-                  (seq new-l) (assoc :declarations new-l))]
+        new-reg (-> (or reg {})
+                    (elision/replace-owner-claims :sensitive-declarations resource-owner sensitive)
+                    (elision/replace-owner-claims :declarations resource-owner large))]
     (cond
       (seq new-reg)
       (assoc base elision-registry-key new-reg)

--- a/implementation/resources/test/re_frame/resources_classification_lowering_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_classification_lowering_cljs_test.cljc
@@ -82,13 +82,13 @@
           data-pre  [:rf.runtime/resources :entries k-id :data]
           key-pre   [:rf.runtime/resources :entries k-id :resource/key]]
       ;; :data-rooted sensitive → absolute entry :data path
-      (is (= {:source :resource} (get sens (conj data-pre :ssn)))
+      (is (= #{{:source :resource}} (get sens (conj data-pre :ssn)))
           "the :data :ssn declaration is lowered at the absolute entry data path")
       ;; :params-rooted sensitive → the scoped-key params component (index 2)
-      (is (= {:source :resource} (get sens (conj key-pre 2 :account-id)))
+      (is (= #{{:source :resource}} (get sens (conj key-pre 2 :account-id)))
           "the :params :account-id declaration is lowered at the scoped-key params index")
       ;; :data-rooted large → absolute entry :data path
-      (is (= {:source :resource} (get large (conj data-pre :avatar-bytes)))
+      (is (= #{{:source :resource}} (get large (conj data-pre :avatar-bytes)))
           "the :data :avatar-bytes declaration is lowered as a large declaration"))))
 
 (deftest reconcile-is-idempotent
@@ -123,9 +123,9 @@
     (let [k   (state/scoped-resource-key :rf.scope/global :profile/card4 {:slug "x"})
           rdb (-> (runtime-db-with {k {:data {:ssn "x"}}})
                   (assoc-in [:rf.runtime/elision :sensitive-declarations [:app :token]]
-                            {:source :effect}))
+                            #{{:source :effect}}))
           out (classification/reconcile-registry rdb registry/resource-meta)]
-      (is (= {:source :effect} (get (sensitive-decls out) [:app :token]))
+      (is (= #{{:source :effect}} (get (sensitive-decls out) [:app :token]))
           "the :source :effect entry survives reconciliation"))))
 
 (deftest reconcile-no-classification-no-registry
@@ -169,6 +169,6 @@
         (is (= "Alice" (:name projected))
             "the undeclared sibling rides verbatim")
         (testing "the registry carries the declaration under :source :resource"
-          (is (= {:source :resource}
+          (is (= #{{:source :resource}}
                  (get (elision/sensitive-declarations :reg/frame)
                       [:rf.runtime/resources :entries k-id :data :ssn]))))))))

--- a/implementation/resources/test/re_frame/resources_classification_lowering_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_classification_lowering_cljs_test.cljc
@@ -172,3 +172,41 @@
           (is (= #{{:source :resource}}
                  (get (elision/sensitive-declarations :reg/frame)
                       [:rf.runtime/resources :entries k-id :data :ssn]))))))))
+
+;; ===========================================================================
+;; (rf2-wdm1vg) MULTI-OWNER union — a resource's lowered :data claim and an app
+;; effect claim on the SAME absolute entry path survive INDEPENDENTLY.
+;; ===========================================================================
+
+(deftest resource-and-effect-claims-union-and-remove-independently
+  (reg! :acct/card {:sensitive [[:data :ssn]]})
+  (testing "rf2-wdm1vg — a resource's lowered :data claim and an app effect claim
+            on the SAME absolute entry path UNION through reconcile, and each
+            removes INDEPENDENTLY: eviction drops the resource claim while the
+            effect survives; removing the effect owner leaves the resource claim."
+    (let [k       (state/scoped-resource-key :rf.scope/global :acct/card {:slug "x"})
+          k-id    (state/key-id k)
+          abs-ssn [:rf.runtime/resources :entries k-id :data :ssn]
+          ;; base runtime-db: the entry exists AND an app effect ALREADY
+          ;; classifies the same absolute path (Spec 015 L149).
+          base    (-> (runtime-db-with {k {:data {:ssn "123-45-6789"}}})
+                      (assoc-in [:rf.runtime/elision :sensitive-declarations abs-ssn]
+                                #{{:source :effect}}))
+          ;; reconcile LOWERS the resource claim → UNION with the effect claim
+          unioned (classification/reconcile-registry base registry/resource-meta)
+          owners  (get-in unioned [:rf.runtime/elision :sensitive-declarations abs-ssn])]
+      (is (contains? owners {:source :effect})  "the effect claim is retained")
+      (is (contains? owners {:source :resource}) "the resource claim UNIONS in")
+      ;; EVICT the entry → reconcile drops ONLY the resource owner; effect survives
+      (let [evicted  (-> unioned
+                         (assoc-in [state/resources-key :entries] {})
+                         (classification/reconcile-registry registry/resource-meta))
+            e-owners (get-in evicted [:rf.runtime/elision :sensitive-declarations abs-ssn])]
+        (is (= #{{:source :effect}} e-owners)
+            "eviction drops the resource claim; the effect claim SURVIVES (no fail-open)"))
+      ;; conversely, removing the effect owner leaves the resource claim standing
+      (let [reg-only       (get unioned :rf.runtime/elision)
+            without-effect (elision/remove-owner reg-only :sensitive-declarations {:source :effect})
+            r-owners       (get-in without-effect [:sensitive-declarations abs-ssn])]
+        (is (= #{{:source :resource}} r-owners)
+            "removing the effect owner leaves the resource claim standing")))))

--- a/implementation/routing/src/re_frame/routing/classification.cljc
+++ b/implementation/routing/src/re_frame/routing/classification.cljc
@@ -248,80 +248,64 @@
 ;; classification effects (`re-frame.elision/apply-classification-effects`)
 ;; touch only their own `:source :effect` entries.
 
-(defn- without-route-sourced
-  "Drop `:source :route` entries from a `{path decl}` declaration map,
-  preserving any other-sourced entries (frame / marks / effect). Returns `{}`
-  for nil."
-  [decls]
-  (reduce-kv (fn [acc p decl]
-               (if (= :route (:source decl))
-                 acc
-                 (assoc acc p decl)))
-             {}
-             (or decls {})))
-
-(defn- with-route-paths
-  "Overlay `:source :route` declarations for `paths` (projection-relative)
-  onto the carried (non-route-sourced) declaration map, RE-ROOTING each path
-  under `[:rf.runtime/routing :current …]` so the stored decl key matches the
-  wire walker's runtime-path lookup."
-  [carried paths]
-  (reduce (fn [acc p]
-            (assoc acc (into current-route-root p) {:source :route}))
-          carried
-          paths))
+(def ^:private route-owner
+  "The multi-owner elision-registry owner identity route activation claims
+  under. A route is a SINGLETON current-route (only one active per frame), so
+  the owner needs no instance id — `elision/replace-owner-claims` under this
+  owner drops the leaving route's claims and installs the entering route's in
+  one reconcile."
+  {:source :route})
 
 (defn apply-route-classification
   "PURE lowering: given a base `runtime-db` value and a route's validated
   projection-relative `classification` (the `validate+extract` result, or
   nil), return the new runtime-db with the `[:rf.runtime/elision …]` registry's
-  `:source :route` entries REPLACED by this route's (re-rooted under
-  `[:rf.runtime/routing :current …]`).
+  route-owner claims REPLACED by this route's (re-rooted under
+  `[:rf.runtime/routing :current …]`), delegating to the core multi-owner op
+  `re-frame.elision/replace-owner-claims`.
 
   Operates on a VALUE (not a live container) so the navigation commit can fold
   it into the atomic `:rf.db/runtime` transition that publishes the slice — the
   classification lands WITH the slice (EP-0025 §Same-event ordering).
 
   Singleton semantics: a nil / empty `classification` (a route that declares no
-  classification) still runs, clearing the prior route's `:source :route`
-  entries — the leaving route's classification drops on every route change. The
-  two axes write the elision registry's `:sensitive-declarations` (sensitive)
-  and `:declarations` (large) sub-maps; an emptied axis slot is pruned
-  (dissoc'd) rather than left as `{}`. Other-sourced entries (`:frame` /
-  `:marks` / `:effect`) survive untouched.
+  classification) still runs, clearing the prior route's route-owner claims —
+  the leaving route's classification drops on every route change. The two axes
+  write the elision registry's `:sensitive-declarations` (sensitive) and
+  `:declarations` (large) sub-maps. A path ALSO claimed by another owner
+  (`{:source :effect}` commit-plane effects / `{:source :flow …}` flow outputs /
+  `{:source :machine …}` / `{:source :resource}`) survives untouched and unions
+  at egress-lookup time (rf2-wdm1vg); an emptied axis slot is pruned by the core
+  ops.
 
   Reconcile-aware (router `re-frame.elision/reconcile-runtime-db-effect`): a
   whole-value `:rf.db/runtime` commit that OMITS the `:rf.runtime/elision` key
   has the prior registry CARRIED FORWARD (so an unrelated runtime-db write does
   not drop the durable registry). But a route change that clears the LAST
-  route-sourced entry must DROP it — the leaving route's classification has to
+  route-owner claim must DROP it — the leaving route's classification has to
   go. So whenever this lowering touched the registry (the base carried one, or
   this route declares some), it emits an EXPLICIT `:rf.runtime/elision` key
   (possibly `{}`) so reconcile honours the clear VERBATIM rather than resurrecting
   the leaving route's entries. The common no-classification-ever case (no prior
   slot, no new entries) emits no key — nothing to clear, no stray sub-tree."
   [runtime-db classification]
-  (let [base  (or runtime-db {})
-        sens  (:sensitive classification)
-        large (:large classification)
-        reg   (get base :rf.runtime/elision)
-        carry-s (without-route-sourced (:sensitive-declarations reg))
-        carry-l (without-route-sourced (:declarations reg))
-        new-s   (with-route-paths carry-s sens)
-        new-l   (with-route-paths carry-l large)
-        new-reg (cond-> {}
-                  (seq new-s) (assoc :sensitive-declarations new-s)
-                  (seq new-l) (assoc :declarations new-l))]
+  (let [base    (or runtime-db {})
+        sens    (mapv #(into current-route-root %) (:sensitive classification))
+        large   (mapv #(into current-route-root %) (:large classification))
+        reg     (get base :rf.runtime/elision)
+        new-reg (-> (or reg {})
+                    (elision/replace-owner-claims :sensitive-declarations route-owner sens)
+                    (elision/replace-owner-claims :declarations route-owner large))]
     (cond
       ;; The lowering produced declarations → install the registry verbatim.
       (seq new-reg)
       (assoc base :rf.runtime/elision new-reg)
 
       ;; Empty result, but the base carried a registry → this is a CLEAR (the
-      ;; leaving route's last route-sourced entry, or an effect/frame entry the
-      ;; route doesn't touch but that resolved away). Emit the explicit key so
-      ;; the router's reconcile honours the drop rather than carrying the prior
-      ;; registry forward. `{}` is honoured verbatim and read as no declarations.
+      ;; leaving route's last route-owner claim, or another owner's claim that
+      ;; resolved away). Emit the explicit key so the router's reconcile honours
+      ;; the drop rather than carrying the prior registry forward. `{}` is
+      ;; honoured verbatim and read as no declarations.
       (contains? base :rf.runtime/elision)
       (assoc base :rf.runtime/elision {})
 

--- a/implementation/routing/test/re_frame/routing_classification_test.clj
+++ b/implementation/routing/test/re_frame/routing_classification_test.clj
@@ -43,21 +43,24 @@
   []
   (get-in (:rf.db/runtime (rf/frame-state-value :rf/default)) [:rf.runtime/elision]))
 
-(defn- route-sensitive-paths
-  "The set of runtime paths classified `:sensitive` `:source :route` in the
-  registry."
-  []
-  (->> (:sensitive-declarations (elision-reg))
-       (filter (fn [[_ decl]] (= :route (:source decl))))
+(defn- owners-sourced-by
+  "The set of paths in a multi-owner declaration map `decls` (`{path #{owner…}}`)
+  whose retained owner-set carries an owner with `:source src`."
+  [decls src]
+  (->> decls
+       (filter (fn [[_ owners]] (some #(= src (:source %)) owners)))
        (map key)
        set))
 
+(defn- route-sensitive-paths
+  "The set of runtime paths claimed by a `:source :route` owner in the sensitive
+  registry."
+  []
+  (owners-sourced-by (:sensitive-declarations (elision-reg)) :route))
+
 (defn- route-large-paths
   []
-  (->> (:declarations (elision-reg))
-       (filter (fn [[_ decl]] (= :route (:source decl))))
-       (map key)
-       set))
+  (owners-sourced-by (:declarations (elision-reg)) :route))
 
 ;; ===========================================================================
 ;; (1) registration-time fail-loud validation (EP-0025 §Failure posture)
@@ -332,11 +335,9 @@
   "The set of runtime paths classified :sensitive :source :route in
   `frame-id`'s elision registry."
   [frame-id]
-  (->> (get-in (:rf.db/runtime (rf/frame-state-value frame-id))
-               [:rf.runtime/elision :sensitive-declarations])
-       (filter (fn [[_ decl]] (= :route (:source decl))))
-       (map key)
-       set))
+  (owners-sourced-by (get-in (:rf.db/runtime (rf/frame-state-value frame-id))
+                             [:rf.runtime/elision :sensitive-declarations])
+                     :route))
 
 (deftest cross-frame-route-classification-is-isolated
   (testing "two frames navigating different :sensitive routes each carry ONLY
@@ -382,27 +383,30 @@
 ;; ===========================================================================
 
 (deftest apply-route-classification-replaces-route-sourced-only
-  (testing "lowering preserves other-sourced (effect/flow) entries"
+  (testing "lowering preserves other-owner (effect/flow) claims and unions"
     (let [base {:rf.runtime/elision
                 {:sensitive-declarations
-                 {[:auth :token]                              {:source :effect}
-                  [:rf.runtime/routing :current :query :old]  {:source :route}}}}
+                 {[:auth :token]                              #{{:source :effect}}
+                  ;; an effect ALSO co-classifies the route's absolute path —
+                  ;; it must SURVIVE the route reconcile (rf2-wdm1vg union).
+                  [:rf.runtime/routing :current :query :new]  #{{:source :effect}}
+                  [:rf.runtime/routing :current :query :old]  #{{:source :route}}}}}
           out  (classification/apply-route-classification
                  base {:sensitive [[:query :new]] :large []})
           sens (get-in out [:rf.runtime/elision :sensitive-declarations])]
-      (is (= {:source :effect} (get sens [:auth :token]))
-          "the effect-sourced entry survives")
+      (is (= #{{:source :effect}} (get sens [:auth :token]))
+          "the effect-owned entry survives")
       (is (nil? (get sens [:rf.runtime/routing :current :query :old]))
-          "the prior route-sourced entry is dropped (singleton replacement)")
-      (is (= {:source :route}
+          "the prior route-owned entry is dropped (singleton replacement)")
+      (is (= #{{:source :effect} {:source :route}}
              (get sens [:rf.runtime/routing :current :query :new]))
-          "the new route-sourced entry is installed, re-rooted"))))
+          "the new route claim UNIONS with the co-located effect claim, re-rooted"))))
 
 (deftest apply-empty-classification-clears-route-sourced
   (testing "an empty classification clears the prior :source :route entries"
     (let [base {:rf.runtime/elision
                 {:sensitive-declarations
-                 {[:rf.runtime/routing :current :query :old] {:source :route}}}}
+                 {[:rf.runtime/routing :current :query :old] #{{:source :route}}}}}
           out  (classification/apply-route-classification base nil)]
       (is (nil? (get-in out [:rf.runtime/elision :sensitive-declarations]))
           "the emptied axis slot is pruned, not left as {}")
@@ -690,3 +694,88 @@
           route (get-in slice [:rf.runtime/routing :current])]
       (is (= "visible" (get-in route [:query :q]))
           "an unclassified query value rides verbatim through the SSR projection"))))
+
+;; ===========================================================================
+;; (rf2-wdm1vg) MULTI-OWNER union — an effect-owned absolute path AND a route
+;; claim on the SAME absolute path survive INDEPENDENTLY. Spec 015 L149 permits
+;; an app to additionally classify a subsystem's absolute runtime-db path from a
+;; handler effect (`:source :effect`); a route change must NOT un-redact that
+;; effect-owned path. Both dispatch orders are pinned. On the pre-fix single-
+;; owner registry the route claim overwrote (forward order) or ignored (reverse
+;; order) the effect claim and then DELETED the path on route-leave — a live
+;; privacy fail-open on the AI-egress boundary. These are the cross-family
+;; reproduce→fix acceptance legs the bead enumerates.
+;; ===========================================================================
+
+(def ^:private abs-token-path [:rf.runtime/routing :current :query :token])
+
+(defn- effect-classify-abs-token!
+  "An app classifies the route's ABSOLUTE storage path directly via a
+  commit-plane `:sensitive` effect (Spec 015 L149) — `:source :effect`."
+  []
+  (rf/reg-event :app/classify-abs-token
+    (fn [{:keys [db]} _] {:db db :sensitive [abs-token-path]}))
+  (rf/dispatch-sync [:app/classify-abs-token]))
+
+(defn- token-path-classified?
+  "Shape-agnostic: is the absolute token path present in the sensitive registry
+  at all (i.e. still classified by SOME owner)?"
+  []
+  (contains? (:sensitive-declarations (elision-reg)) abs-token-path))
+
+(defn- token-owners []
+  (get (:sensitive-declarations (elision-reg)) abs-token-path))
+
+(defn- redacts-token-at-abs-path?
+  "Place a value at the absolute token path and egress-project it — is it
+  redacted?"
+  []
+  (let [rdb   (-> (:rf.db/runtime (rf/frame-state-value :rf/default))
+                  (assoc-in abs-token-path "secret123"))
+        slice (get-in (elision/elide-wire-value rdb {:frame :rf/default})
+                      [:rf.runtime/routing :current :query :token])]
+    (= sentinel slice)))
+
+(deftest effect-then-route-then-route-leave-preserves-effect-claim
+  (testing "forward order: an effect classifies the route's absolute :query
+            :token path; a route ALSO claims it (union); after navigating AWAY
+            the effect claim SURVIVES and the path stays redacted (rf2-wdm1vg)"
+    (effect-classify-abs-token!)
+    (is (token-path-classified?) "the effect claim is installed")
+    (rf/reg-route :route/oauth
+                  {:sensitive [[:query :token]] :query [:map [:token :string]]}
+                  "/oauth")
+    (rf/reg-route :route/plain {} "/plain")
+    (rf/dispatch-sync [:rf.route/transitioned "/oauth?token=secret123"])
+    (is (= #{{:source :effect} {:source :route}} (token-owners))
+        "the effect and route claims UNION on the same absolute path")
+    ;; navigate to a route declaring NO classification (route-leave)
+    (rf/dispatch-sync [:rf.route/transitioned "/plain"])
+    (is (token-path-classified?)
+        "the effect claim SURVIVES the route change (the fix — the path was deleted before)")
+    (is (= #{{:source :effect}} (token-owners))
+        "only the effect owner remains after the route left")
+    (is (redacts-token-at-abs-path?)
+        "a value at the effect-classified absolute path still redacts after route-leave")))
+
+(deftest route-then-effect-then-route-leave-preserves-effect-claim
+  (testing "reverse order: the route claims the absolute path first, THEN an
+            effect classifies it (union — the effect is neither ignored nor a
+            clobber); after route-leave the effect claim SURVIVES (rf2-wdm1vg —
+            the effect claim was ignored then vanished before the fix)"
+    (rf/reg-route :route/oauth
+                  {:sensitive [[:query :token]] :query [:map [:token :string]]}
+                  "/oauth")
+    (rf/reg-route :route/plain {} "/plain")
+    (rf/dispatch-sync [:rf.route/transitioned "/oauth?token=secret123"])
+    (is (= #{{:source :route}} (token-owners)) "only the route claim so far")
+    (effect-classify-abs-token!)
+    (is (= #{{:source :route} {:source :effect}} (token-owners))
+        "the effect SET UNIONS in — it is not ignored under the standing route claim")
+    (rf/dispatch-sync [:rf.route/transitioned "/plain"])
+    (is (token-path-classified?)
+        "the effect claim SURVIVES the route change (the fix)")
+    (is (= #{{:source :effect}} (token-owners))
+        "only the effect owner remains after the route left")
+    (is (redacts-token-at-abs-path?)
+        "a value at the effect-classified absolute path still redacts after route-leave")))

--- a/implementation/ssr/test/re_frame/ssr/payload_policy_cljs_test.cljc
+++ b/implementation/ssr/test/re_frame/ssr/payload_policy_cljs_test.cljc
@@ -330,9 +330,9 @@
    ;; (`[:by-id "user-secret-id" :token]`) — so shipping it raw leaks both the
    ;; sensitive path STRUCTURE and the embedded id off-box. The SSR projection
    ;; OMITS this slot entirely (the client rebuilds its own registry on mount).
-   :rf.runtime/elision  {:declarations           {[:auth :token] {:source :effect}}
+   :rf.runtime/elision  {:declarations           {[:auth :token] #{{:source :effect}}}
                          :sensitive-declarations {[:by-id "user-secret-id" :token]
-                                                  {:source :effect}}}
+                                                  #{{:source :effect}}}}
    :rf.runtime/ssr      {:hydration {:server-hash "h1"}}})
 
 (deftest project-runtime-db-ships-durable-omits-transient
@@ -400,7 +400,7 @@
             never be the sole reason a runtime-db slice rides)"
     (is (nil? (payload-policy/project-runtime-db
                 {:rf.runtime/elision {:sensitive-declarations
-                                      {[:auth :token] {:source :effect}}}}))
+                                      {[:auth :token] #{{:source :effect}}}}}))
         "elision-only runtime-db contributes no wire slice")))
 
 (deftest project-runtime-db-nil-and-empty

--- a/tools/mcp-conformance/test/live-re-frame2-pair-redaction.cjs
+++ b/tools/mcp-conformance/test/live-re-frame2-pair-redaction.cjs
@@ -392,13 +392,17 @@ function assertOk(resp, name) {
 
 // Extract the `:declared` slot's rendered VALUE (the text of the map
 // literal / `nil` immediately following the key) from an eval-cljs
-// response's text — one level of brace-nesting, matching the shape
-// `re-frame.elision/sensitive-declarations` actually returns: a map from
-// classified PATH VECTOR to a decl map, e.g.
-// `{[:rf-conformance/secret] {:source :effect}}`, or `{}` when nothing is
-// classified. Returns `null` if `:declared` is absent entirely (a
-// malformed / unexpected eval return — the caller treats that as a
-// precondition failure too).
+// response's text, matching the shape `re-frame.elision/sensitive-
+// declarations` actually returns: a map from classified PATH VECTOR to the
+// retained OWNER-SET (rf2-wdm1vg — the registry is multi-owner), e.g.
+// `{[:rf-conformance/secret] #{{:source :effect}}}` (and, when two
+// independent owners claim one path, `#{{:source :effect} {:source :route}}`),
+// or `{}` when nothing is classified. The owner-set nests THREE brace levels
+// deep — the outer map, the `#{…}` owner-set, and each owner map — so the
+// regex tolerates three levels of brace nesting (it still matches the legacy
+// single-map `{:source :effect}` shape too). Returns `null` if `:declared` is
+// absent entirely (a malformed / unexpected eval return — the caller treats
+// that as a precondition failure too).
 function declaredValueText(text) {
   // The closing `\}` alternative deliberately carries NO trailing `\b`:
   // a map literal is almost always followed by another non-word char
@@ -406,8 +410,11 @@ function declaredValueText(text) {
   // non-word characters — a boundary assertion there would silently
   // fail to match the common case. `nil(?!\w)` gets the equivalent
   // "don't swallow a longer identifier" guard the word-boundary was
-  // after, scoped to the one alternative that actually needs it.
-  const m = /:declared\s+(\{(?:[^{}]|\{[^{}]*\})*\}|nil(?!\w))/.exec(text);
+  // after, scoped to the one alternative that actually needs it. The
+  // brace group is nested to depth 3 to admit the `{path #{{:source …}}}`
+  // owner-set shape (rf2-wdm1vg).
+  const m =
+    /:declared\s+(\{(?:[^{}]|\{(?:[^{}]|\{[^{}]*\})*\})*\}|nil(?!\w))/.exec(text);
   return m ? m[1] : null;
 }
 


### PR DESCRIPTION
## What & why

The per-frame elision registry (`[:rf.runtime/elision …]`) stored **one owner per path per axis**. Independent owners therefore did **not** union: a route/subsystem claim overwrote (or was silently ignored by) an effect-owned sensitive path, and then **deleted it on teardown** — un-redacting a path another owner still classifies. This is a live fail-open on the **AI-egress privacy boundary**.

This makes the registry a genuine **multi-owner claim registry**: each axis slot maps a path to the **set of owner identities** that claim it. A path redacts / size-marks while **any** owner claims it, and is pruned only when the **last** owner drops.

Stance: pre-alpha, **no compatibility shape** (the durable registry shape changes from `{path decl}` to `{path #{owner …}}`); primary lenses ELEGANCE + CLARITY + CORRECTNESS.

## Reproduce → fix (both orders)

A minimal reproduction run against **origin/main (old single-owner code)** — effect classifies the absolute route path (Spec 015 L149), a route also claims it, then the app navigates away:

```
FAIL forward-order  … effect claim MUST survive route-leave → (not (classified?))
FAIL forward-order  … path MUST still redact at egress      → (not (redacts?))
FAIL reverse-order  … effect claim MUST survive route-leave → (not (classified?))
FAIL reverse-order  … path MUST still redact at egress      → (not (redacts?))
4 failures
```

Both orders now pass. The committed acceptance legs (`routing_classification_test.clj`) drive the **real** cross-family path (`apply-classification-effects` + `apply-route-classification`): an effect-owned absolute route path and a route claim on the same path survive **independently**, both dispatch orders, across route-leave. Equivalent independent-lifecycle union tests were added for **flows**, **machines**, and **resources**, plus the core ops + source-aware rollback (`elision_multi_owner_cljs_test.cljc`).

## The change (per DESIGN)

Core's `re-frame.elision` gains PURE owner-set operations — `add-claims` / `remove-claims` / `remove-owner` / `replace-owner-claims` (+ `owners->provenance` for a stable large-marker `:reason`). `apply-classification-effects` (union SET, source-scoped CLEAR) and the source-aware `restore-elision-slot` rollback are rewritten in owner-set terms (`new = pre-owners ∪ (live-owners \ effect-owner)`).

Every family now **derives absolute paths + an owner identity and DELEGATES**:

| Family | Owner identity | Delegates to |
|---|---|---|
| effects | `{:source :effect}` | `add-claims` / `remove-claims` |
| flows | `{:source :flow :flow-id id}` | `replace-owner-claims` / `remove-owner` |
| machines | `{:source :machine :actor-id id}` | `add-claims` / `remove-claims` |
| routing | `{:source :route}` | `replace-owner-claims` |
| resources | `{:source :resource}` | `replace-owner-claims` |

**Family-private overlay helpers DELETED**: `drop-flow-sourced` / `assoc-flow-paths` (flows), `without-route-sourced` / `with-route-paths` (routing), `without-resource-sourced` / `with-resource-paths` (resources), and the inline non-clobber-SET / source-scoped-DROP in machines' `apply-decls`. No compatibility shape added.

## Quality gates

All foreground, 0 failures:

| Gate | Result |
|---|---|
| `core` `clojure -M:test` | 1777 tests ✓ |
| `flows` | 195 ✓ |
| `machines` | 923 ✓ |
| `resources` | 623 ✓ |
| `routing` | 393 ✓ |
| `ssr` | 372 ✓ |
| `epoch` / `security` / `schemas` / `reply-conformance` / `http` | 376 / 92 / 341 / 23 / 470 ✓ |
| `npm run test:cljs` (node) | 8474 tests / 39189 assertions ✓ |
| `npm run test:elision` (production elision probe) | PASS (47/47 absent) ✓ |
| `npm run test:mcp-conformance` (redaction/egress) | ALL GREEN ✓ |

## Note (pre-existing, benign — filed as follow-up context)

When an app effect **pre-**classifies a machine snapshot path, the machine's own claim does not land durably at boot (`lower-at-spawn!`'s live swap is carried-forward-wiped by the boot snapshot commit). This is pre-existing (the old test only asserted effect-survival) and **not a fail-open** — the effect owner keeps the path redacted throughout. The machine+effect union is proven in the machine-first order (which lands both).

rf2-wdm1vg
