### PR TITLE
fix(epoch): serialize Tool-Pair writes under the frame drain lock — no TOCTOU with event transitions (rf2-3fc89f.4)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -346,24 +346,41 @@
   remaining teardown race: nil means the frame disappeared before the write
   landed, while any non-nil changed-key set, including empty, is a successful
   live-frame write. Failure is reported before telemetry, listener fan-out, or
-  a synthetic epoch can claim success."
+  a synthetic epoch can claim success.
+
+  The coherent read (`fs-before`), the physical write, and the synthetic-epoch
+  bookkeeping run under the frame's `:drain-lock` (`serialize-tool-write!`), so
+  no event transition can interleave between the `fs-before` read and the
+  write's own re-read. `fs-after` is therefore the EXACT value installed — the
+  synthetic `:frame-state-before` / `:frame-state-after` describe the physical
+  transition, and a concurrent event's update to an omitted partition is never
+  lost or silently reverted (rf2-3fc89f.4). A replace invoked reentrantly from
+  the active drainer refuses with `:rf.epoch/replace-during-drain`."
   [frame-id fs-after-fn write-fn]
-  (let [{:keys [outcome op tags]} (tool-pair/live-container-or-fail frame-id)]
-    (if (= :fail outcome)
-      (do (tool-pair/emit-precondition-failure! op tags)
-          false)
-      (let [;; Record the same coherent whole-frame value the write installs.
-            ;; Nil means teardown won the post-liveness race; an empty set is
-            ;; still a successful no-op write against a live frame.
-            fs-before (frame/frame-state-value frame-id)
-            fs-after  (fs-after-fn fs-before)
-            changed   (write-fn)]
-        (if (nil? changed)
-          (do (tool-pair/emit-precondition-failure! :rf.error/no-such-handler
-                                                    {:kind :frame :frame frame-id})
+  (tool-pair/serialize-tool-write!
+    frame-id
+    :rf.epoch/replace-during-drain
+    {:frame frame-id}
+    (fn []
+      (let [{:keys [outcome op tags]} (tool-pair/live-container-or-fail frame-id)]
+        (if (= :fail outcome)
+          (do (tool-pair/emit-precondition-failure! op tags)
               false)
-          (do (record-synthetic-replace-epoch! frame-id fs-before fs-after)
-              true))))))
+          (let [;; Record the same coherent whole-frame value the write installs.
+                ;; Read under the drain lock so the write's own re-read (which
+                ;; preserves omitted partitions) sees this same state — fs-after
+                ;; then equals the installed value. Nil means teardown won the
+                ;; post-liveness race; an empty set is still a successful no-op
+                ;; write against a live frame.
+                fs-before (frame/frame-state-value frame-id)
+                fs-after  (fs-after-fn fs-before)
+                changed   (write-fn)]
+            (if (nil? changed)
+              (do (tool-pair/emit-precondition-failure! :rf.error/no-such-handler
+                                                        {:kind :frame :frame frame-id})
+                  false)
+              (do (record-synthetic-replace-epoch! frame-id fs-before fs-after)
+                  true))))))))
 
 (defn- perform-replace-frame-state!
   "Carry out the partial frame-state patch once preconditions have passed.

--- a/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
+++ b/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
@@ -499,6 +499,64 @@
      :tags    {:kind  :frame
                :frame frame-id}}))
 
+;; ---- drain serialization for tool writes ----------------------------------
+;;
+;; The precondition validators (`check-restore-preconditions!` /
+;; `check-replace-frame-state-preconditions!`) read the router's `:in-drain?` /
+;; `:in-sync-drain?` flags, but that read and the subsequent coherent
+;; read → optional reconcile → physical write → success bookkeeping are a
+;; TOCTOU pair: a drain that STARTS on another thread after validation and
+;; before the write can interleave between a handler's `db` read and its
+;; commit. The tool write then splices into the middle of an event transition —
+;; a non-linearizable result — while still returning `true` and emitting
+;; success telemetry (rf2-3fc89f.4). For a partial `replace-frame-state!` the
+;; same window also lets the recorded synthetic `:frame-state-before` /
+;; `:frame-state-after` (computed from a pre-interleave read) diverge from the
+;; value the write actually installed.
+;;
+;; The fix routes the WHOLE state-sensitive operation — not just the final
+;; container call — through the core single-drainer `:drain-lock` via
+;; `frame/call-serialized-with-drain!` (Spec 002 §Single drainer per frame; the
+;; SAME primitive the flows lifecycle ops use). Under that lock no event
+;; transition can run concurrently, so the tool write holds ONE serial position
+;; relative to any drain: its coherent read and its physical write see the same
+;; frame-state, and the recorded synthetic epoch describes exactly the
+;; transition installed.
+;;
+;; REENTRANCY. A restore/replace invoked from the frame's ACTIVE drainer (a
+;; tool write issued mid-cascade from an event handler) must NOT run: it would
+;; either self-deadlock re-taking `:drain-lock` or, worse, splice a
+;; non-linearizable write into the in-flight transition (`call-serialized-with-
+;; drain!`'s reentrant branch runs the thunk DIRECTLY — correct for the flows
+;; ops, wrong for a tool write). So we refuse the reentrant case up front with
+;; the documented during-drain op, returning `false` and recording nothing.
+;; `frame/in-drain?` is the same `:in-drain?` thread marker the pre-lock
+;; precondition `drain-in-flight?` reads, so this also closes the gap between
+;; the (separate) precondition call and this write. On CLJS — single-threaded —
+;; a mid-drain call is likewise refused here (no deadlock); a top-level call
+;; takes the uncontended lock and runs.
+
+(defn serialize-tool-write!
+  "Run `op` — the coherent liveness-check → read → (reconcile) → physical
+  write → success-bookkeeping thunk of a Tool-Pair state write — serialized
+  against `frame-id`'s event drain through the core `:drain-lock`
+  (`frame/call-serialized-with-drain!`), so the whole operation is mutually
+  exclusive with any event transition (no validate-then-write TOCTOU).
+
+  `op` is `(fn [] <boolean>)` returning the operation's own result (it still
+  owns the destroyed-frame liveness recheck and its `false` returns).
+
+  A call from the frame's ACTIVE drainer (a reentrant mid-cascade tool write)
+  is REFUSED here — `during-drain-op` is emitted with `during-drain-tags` and
+  `false` is returned, `op` never runs — mirroring the pre-lock
+  `drain-in-flight?` precondition and avoiding both self-deadlock and a
+  non-linearizable mid-transition splice."
+  [frame-id during-drain-op during-drain-tags op]
+  (if (frame/in-drain? frame-id)
+    (do (emit-precondition-failure! during-drain-op during-drain-tags)
+        false)
+    (frame/call-serialized-with-drain! frame-id op)))
+
 ;; ---- runtime-db subsystem reconcile on restore ----------------------------
 ;;
 ;; Epoch restore installs the captured frame-state WHOLESALE — it does not run
@@ -654,47 +712,60 @@
   closes the remaining teardown race: nil means no write, while a non-nil set,
   including empty, is success. Only the success branch emits restore telemetry,
   re-anchors post-settle attribution, commits deferred subsystem traces, and
-  cancels host-transient work from the abandoned timeline."
+  cancels host-transient work from the abandoned timeline.
+
+  The whole liveness-check → reconcile → write → bookkeeping runs under the
+  frame's `:drain-lock` (`serialize-tool-write!`), so no event transition can
+  interleave between the reconcile's read and the physical install — the
+  restore holds one serial position relative to any drain (rf2-3fc89f.4). A
+  restore invoked reentrantly from the active drainer refuses with
+  `:rf.epoch/restore-during-drain` rather than deadlocking or splicing."
   [frame-id epoch]
-  (let [{:keys [outcome op tags]} (live-container-or-fail frame-id)]
-    (if (= :fail outcome)
-      (do (emit-precondition-failure! op tags)
-          false)
-      (let [;; Whole `:frame-state-after` is the only restore source.
-            frame-state-target (:frame-state-after epoch)
-            ;; Reconcile runtime subsystems before the atomic install,
-            ;; the same way SSR hydration reconciles its installed slice — so a
-            ;; mid-flight captured snapshot does not install stranded
-            ;; `:loading` / `:fetching` entries pointing at vanished attempts,
-            ;; and a pre-restore reply cannot write stale data into a restored
-            ;; entry.
-            ;; Thread the restored epoch's causal time
-            ;; (`:committed-at` = the committing token's `:rf.cofx`
-            ;; `:rf/time-ms`) so the reconcile stamps a dangled-on-restore
-            ;; mutation instance's durable `:settled-at` from a replay-stable
-            ;; causal input, not the live install clock (EP-0010 §Restore/Replay).
-            frame-state-target (reconcile-runtime-db-on-restore
-                                 frame-id frame-state-target (:committed-at epoch))
-            ;; Write both partitions through the one physical frame container.
-            ;; Nil means the frame was destroyed after the liveness check; a
-            ;; non-nil changed-key-set (even empty) means the write landed.
-            changed (frame/replace-frame-state! frame-id frame-state-target)]
-        (if (nil? changed)
-          (do (emit-precondition-failure! :rf.error/no-such-handler
-                                          {:kind :frame :frame frame-id})
+  (serialize-tool-write!
+    frame-id
+    :rf.epoch/restore-during-drain
+    {:frame frame-id :rf.epoch/id (:epoch-id epoch)}
+    (fn []
+      (let [{:keys [outcome op tags]} (live-container-or-fail frame-id)]
+        (if (= :fail outcome)
+          (do (emit-precondition-failure! op tags)
               false)
-          (do (trace/emit! :rf.epoch :rf.epoch/restored
-                           {:frame       frame-id
-                            :rf.epoch/id (:epoch-id epoch)})
-              ;; Restore triggers no ordinary event, so explicitly anchor its
-              ;; repaint/subscription/unmount back-fill to the restored epoch.
-              (state/set-last-settled-epoch! frame-id (:epoch-id epoch))
-              ;; Deferred subsystem success traces are valid only after install.
-              (commit-resources-restore-traces! frame-state-target)
-              ;; Host timers and HTTP handles are not frame state; cancel the
-              ;; abandoned timeline only after the new state is installed.
-              (quiesce-orphaned-async-host-work! frame-id)
-              true))))))
+          (let [;; Whole `:frame-state-after` is the only restore source.
+                frame-state-target (:frame-state-after epoch)
+                ;; Reconcile runtime subsystems before the atomic install,
+                ;; the same way SSR hydration reconciles its installed slice — so a
+                ;; mid-flight captured snapshot does not install stranded
+                ;; `:loading` / `:fetching` entries pointing at vanished attempts,
+                ;; and a pre-restore reply cannot write stale data into a restored
+                ;; entry.
+                ;; Thread the restored epoch's causal time
+                ;; (`:committed-at` = the committing token's `:rf.cofx`
+                ;; `:rf/time-ms`) so the reconcile stamps a dangled-on-restore
+                ;; mutation instance's durable `:settled-at` from a replay-stable
+                ;; causal input, not the live install clock (EP-0010 §Restore/Replay).
+                frame-state-target (reconcile-runtime-db-on-restore
+                                     frame-id frame-state-target (:committed-at epoch))
+                ;; Write both partitions through the one physical frame container.
+                ;; Under the drain lock the container's re-read matches the value
+                ;; installed. Nil means the frame was destroyed after the liveness
+                ;; check; a non-nil changed-key-set (even empty) means it landed.
+                changed (frame/replace-frame-state! frame-id frame-state-target)]
+            (if (nil? changed)
+              (do (emit-precondition-failure! :rf.error/no-such-handler
+                                              {:kind :frame :frame frame-id})
+                  false)
+              (do (trace/emit! :rf.epoch :rf.epoch/restored
+                               {:frame       frame-id
+                                :rf.epoch/id (:epoch-id epoch)})
+                  ;; Restore triggers no ordinary event, so explicitly anchor its
+                  ;; repaint/subscription/unmount back-fill to the restored epoch.
+                  (state/set-last-settled-epoch! frame-id (:epoch-id epoch))
+                  ;; Deferred subsystem success traces are valid only after install.
+                  (commit-resources-restore-traces! frame-state-target)
+                  ;; Host timers and HTTP handles are not frame state; cancel the
+                  ;; abandoned timeline only after the new state is installed.
+                  (quiesce-orphaned-async-host-work! frame-id)
+                  true))))))))
 
 ;; ---- replace-frame-state! preconditions ------------------------------------
 ;;

--- a/implementation/epoch/test/re_frame/epoch_cljs_test.cljs
+++ b/implementation/epoch/test/re_frame/epoch_cljs_test.cljs
@@ -175,6 +175,52 @@
       (is (= {:n 1} (rf/app-db-value :rf/default))
           "app-db now matches the named epoch's :db-after"))))
 
+;; ---- 2b. rf2-3fc89f.4 — reentrant tool writes refuse mid-drain -------------
+;;
+;; The drain-serialization fix routes tool writes through the frame's
+;; `:drain-lock` (`re-frame.frame/call-serialized-with-drain!`). A restore /
+;; replace issued reentrantly from inside an event handler (i.e. from the
+;; active drainer) must REFUSE with the documented during-drain op rather than
+;; run — otherwise it would re-take the lock. CLJS cannot thread-preempt, so it
+;; never hits the cross-thread TOCTOU, but it MUST still take the same reentrant
+;; mid-drain refusal WITHOUT deadlocking (the pre-lock `drain-in-flight?`
+;; precondition, unchanged by the fix, is what fires here on `:in-drain? true`).
+
+(deftest reentrant-tool-writes-refuse-mid-drain-cljs
+  (testing "restore-epoch! / replace-frame-state! called from inside a drain
+            return false, emit :rf.epoch/restore-during-drain /
+            :rf.epoch/replace-during-drain, record NO synthetic epoch, and do
+            not deadlock (the drain settles cleanly)"
+    (rf/reg-event :n/init (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/dispatch-sync [:n/init])
+    (let [target-id  (:epoch-id (last (rf/epoch-history :rf/default)))
+          restore-r  (atom ::unset)
+          replace-r  (atom ::unset)
+          ops        (atom #{})]
+      (trace-tooling/register-listener! ::rec
+                                        (fn [ev] (swap! ops conj (:operation ev))))
+      (rf/reg-event :n/try-writes
+        (fn [{:keys [db]} _]
+          (reset! restore-r (rf/restore-epoch! :rf/default target-id))
+          (reset! replace-r (rf/replace-frame-state! :rf/default {:rf.db/app {:n 99}}))
+          {:db (assoc db :phase :done)}))
+      ;; If either reentrant call deadlocked re-taking the lock, this
+      ;; dispatch-sync would never return.
+      (rf/dispatch-sync [:n/try-writes])
+      (trace-tooling/unregister-listener! ::rec)
+
+      (is (false? @restore-r) "reentrant restore-epoch! returned false")
+      (is (false? @replace-r) "reentrant replace-frame-state! returned false")
+      (is (contains? @ops :rf.epoch/restore-during-drain)
+          ":rf.epoch/restore-during-drain fired")
+      (is (contains? @ops :rf.epoch/replace-during-drain)
+          ":rf.epoch/replace-during-drain fired")
+      (is (nil? (some #(when (= :rf.epoch/db-replaced (:event-id %)) %)
+                      (rf/epoch-history :rf/default)))
+          "no synthetic :rf.epoch/db-replaced record was created by the refused replace")
+      (is (= :done (:phase (rf/app-db-value :rf/default)))
+          "the drain settled cleanly (no deadlock); app-db carries the handler's own commit"))))
+
 ;; ---- 3. Ring depth cap -----------------------------------------------------
 
 (deftest ring-depth-evicts-oldest-cljs

--- a/implementation/epoch/test/re_frame/epoch_concurrency_stress_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_concurrency_stress_test.clj
@@ -104,6 +104,10 @@
             ;; exercise directly — NOT for fixture config reset (that now
             ;; flows through `configure!`).
             [re-frame.epoch.state :as state]
+            ;; `tool-pair` is `with-redefs`'d in Scenario 6 to open the
+            ;; validate-then-write TOCTOU window deterministically (the
+            ;; barriered precondition check).
+            [re-frame.epoch.tool-pair :as tool-pair]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
             ;; rf2-v6z0: machines is a separate artefact whose late-bind
@@ -736,3 +740,117 @@
                  " splices (a positive count means the race window was "
                  "actually exercised; some attempts return nil when the "
                  "target evicted before the splice)."))))))
+
+;; ---- Scenario 6 (rf2-3fc89f.4) --------------------------------------------
+;;
+;; RESTORE-vs-EVENT-DRAIN LINEARIZABILITY under the validate-then-write TOCTOU.
+;; Scenario 3 above races restores against dispatches but accepts an arbitrary
+;; true/false mix and asserts only exceptions / ring count / trigger order — it
+;; never asserts that a SUCCESSFUL restore stayed OUTSIDE an event's
+;; read-to-commit window. This scenario adds that STATE-linearizability
+;; invariant, deterministically, over many iterations.
+;;
+;; Each iteration forces the TOCTOU window open with a barrier wrapped around
+;; the precondition check: the restore validates its preconditions with NO
+;; drain in flight (so validation passes), THEN a concurrent `dispatch-sync`
+;; starts a drain whose handler reads db and blocks mid-transition (holding the
+;; frame's `:drain-lock`), THEN the restore is released to attempt its write. On
+;; the pre-fix code the restore's write splices into the blocked transition and
+;; is overwritten by the handler's commit, so the frame ends at `{:n 3}` even
+;; though the restore returned `true` — a result no serial schedule can
+;; produce. With the fix the restore blocks on `:drain-lock` and serializes
+;; AFTER the drain, so the outcome is the linearizable `{:n 1}`.
+;;
+;; The invariant, asserted every iteration: the racing event read the
+;; pre-restore db `{:n 2}` (so the event linearized BEFORE the restore), the
+;; restore reported success, therefore the restore committed LAST and its
+;; installed value MUST be the durable final state `{:n 1}`. `{:n 3}` (the
+;; restore's write erased by the event commit) is the non-linearizable failure.
+;;
+;; CLJS is single-threaded; the interleaving cannot manifest there — JVM-only.
+
+(def ^:private lin-iters
+  (or (some-> (System/getenv "RF2_3FC89F4_LIN_ITERS") Long/parseLong)
+      120))
+
+(deftest restore-linearizable-against-blocked-drain-stress
+  (testing (str lin-iters " iterations of restore-vs-blocked-drain under the "
+                "validate-then-write TOCTOU — every successful restore is "
+                "serialized against the event drain, so the outcome is the "
+                "linearizable {:n 1}, never the mid-transition-splice {:n 3}")
+    (let [frame-id       :3fc89f4.lin/main
+          ;; Per-iteration barrier state, read by the shared redef / handler.
+          barrier        (atom nil) ;; {:passed promise :release latch :armed? atom}
+          cur-hread      (atom nil) ;; per-iter promise: handler published db
+          cur-hrelease   (atom nil) ;; per-iter latch: release the blocked handler
+          orig-check     tool-pair/check-restore-preconditions!]
+      (rf/reg-frame frame-id {:doc "restore linearizability stress frame"})
+      (rf/reg-event :set (fn [{:keys [db]} [_ v]] {:db {:n v}}))
+      ;; The racing event: read db, publish it, block mid-transition holding
+      ;; :drain-lock until released, then commit n+1.
+      (rf/reg-event :blocked-inc
+        (fn [{:keys [db]} _]
+          (deliver @cur-hread db)
+          (.await ^CountDownLatch @cur-hrelease (long join-timeout-ms) TimeUnit/MILLISECONDS)
+          {:db {:n (inc (:n db))}}))
+
+      (with-redefs
+        [tool-pair/check-restore-preconditions!
+         (fn [f e]
+           (let [result (orig-check f e)
+                 b      @barrier]
+             ;; Fire the barrier exactly once per iteration: publish the (:ok)
+             ;; result computed with NO drain in flight, then park until the
+             ;; concurrent drain is blocked mid-transition.
+             (when (and b (compare-and-set! (:armed? b) true false))
+               (deliver (:passed b) result)
+               (.await ^CountDownLatch (:release b) (long join-timeout-ms) TimeUnit/MILLISECONDS))
+             result))]
+
+        (dotimes [_ lin-iters]
+          (let [passed          (promise)
+                release-precond (CountDownLatch. 1)
+                armed?          (atom true)
+                handler-read    (promise)
+                release-handler (CountDownLatch. 1)]
+            (reset! barrier {:passed passed :release release-precond :armed? armed?})
+            (reset! cur-hread handler-read)
+            (reset! cur-hrelease release-handler)
+
+            ;; Seed a fresh {:n 1} epoch (target), then move current db to {:n 2}.
+            ;; The leading :set 7 guarantees a real transition INTO {:n 1}.
+            (rf/dispatch-sync [:set 7] {:frame frame-id})
+            (rf/dispatch-sync [:set 1] {:frame frame-id})
+            (rf/dispatch-sync [:set 2] {:frame frame-id})
+            (let [eid-1 (some (fn [r] (when (= {:n 1} (:db-after r)) (:epoch-id r)))
+                              (reverse (rf/epoch-history frame-id)))]
+              (is (some? eid-1) "seeded a fresh {:n 1} epoch to restore to")
+
+              (let [restore-fut (future (rf/restore-epoch! frame-id eid-1))]
+                ;; 1. Preconditions resolve with no drain in flight.
+                (is (= :ok (:outcome (deref passed join-timeout-ms ::timeout)))
+                    "restore preconditions passed before any drain")
+                ;; 2. Start the racing drain; wait until it is blocked mid-transition.
+                (let [drain-fut (future (rf/dispatch-sync [:blocked-inc] {:frame frame-id}))]
+                  (is (= {:n 2} (deref handler-read join-timeout-ms ::timeout))
+                      "the racing event read the pre-restore db {:n 2}")
+                  ;; 3. Release the restore to attempt its write (blocks on the
+                  ;;    lock under the fix; splices under the bug).
+                  (.countDown release-precond)
+                  ;; A short bias toward the bug's interleave (regression aid).
+                  (Thread/sleep 2)
+                  ;; 4. Let the blocked handler commit {:n 3} and settle.
+                  (.countDown release-handler)
+
+                  (let [rr (await-future restore-fut)
+                        dr (await-future drain-fut)]
+                    (is (not= ::timeout rr) "restore completed (no deadlock)")
+                    (is (not= ::timeout dr) "drain completed (no deadlock)")
+                    (is (true? rr) "restore reported success")
+                    ;; The linearizability invariant.
+                    (is (= {:n 1} (rf/app-db-value frame-id))
+                        (str "successful restore must be durable and serialized "
+                             "after the event that read {:n 2}; final db was "
+                             (pr-str (rf/app-db-value frame-id))
+                             " ({:n 3} = the restore's write spliced into and "
+                             "erased by the blocked transition — non-linearizable)"))))))))))))

--- a/implementation/epoch/test/re_frame/epoch_drain_serialization_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_drain_serialization_test.clj
@@ -1,0 +1,293 @@
+(ns re-frame.epoch-drain-serialization-test
+  "Deterministic JVM regression for rf2-3fc89f.4 — Tool-Pair state writes
+  (`restore-epoch!` / `replace-frame-state!`) MUST be serialized against the
+  frame's event drain via the core single-drainer `:drain-lock`, so a tool
+  write holds ONE serial position relative to any event transition.
+
+  The defect (pre-fix): the precondition validators read the router's
+  `:in-drain?` / `:in-sync-drain?` flags, but the coherent read / reconcile /
+  physical write / success bookkeeping ran OUTSIDE the frame's `:drain-lock`.
+  A drain that started AFTER validation and BEFORE the write could interleave
+  between a handler's `db` read and its commit, so the tool write spliced into
+  the middle of an event transition — a non-linearizable result — while the
+  tool op still returned `true` and emitted success telemetry.
+
+  These tests force that TOCTOU window open with a barrier wrapped around the
+  precondition validator: the restore/replace validates its preconditions with
+  NO drain in flight (so validation passes), THEN a concurrent `dispatch-sync`
+  starts a drain and blocks its handler mid-transition (holding `:drain-lock`),
+  THEN the tool write is released. On the buggy code the write splices in and
+  is overwritten; with the fix the write blocks on `:drain-lock` and serializes
+  AFTER the drain, producing a linearizable transition whose installed value
+  matches the recorded synthetic epoch.
+
+  CLJS cannot thread-preempt, so this interleaving is JVM-only; the reentrant
+  mid-drain refusal (which CLJS DOES need) is covered on both runtimes by the
+  during-drain precondition tests. Per Spec 002 §Single drainer per frame and
+  the frame `:drain-lock` discipline (`re-frame.frame/call-serialized-with-drain!`)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.epoch :as epoch]
+            [re-frame.epoch.state :as state]
+            [re-frame.epoch.tool-pair :as tool-pair]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            ;; machines is pulled in for parity with the rest of the epoch
+            ;; suite so the ns-load registrar snapshot the fixture restores is
+            ;; the same shape (the reconcile hooks stay nil-safe here).
+            [re-frame.machines])
+  (:import [java.util.concurrent CountDownLatch TimeUnit]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter}))
+
+;; ---- orchestration helpers -------------------------------------------------
+
+(def ^:private join-timeout-ms 20000)
+
+(defn- await-future [f]
+  (deref f join-timeout-ms ::timeout))
+
+(defn- await-latch [^CountDownLatch latch]
+  (.await latch (long join-timeout-ms) TimeUnit/MILLISECONDS))
+
+(defn- await-promise [p]
+  (deref p join-timeout-ms ::timeout))
+
+(defn- target-epoch-id
+  "The epoch-id of the recorded epoch whose app-db projection equals `db`."
+  [frame-id db]
+  (some (fn [r] (when (= db (:db-after r)) (:epoch-id r)))
+        (rf/epoch-history frame-id)))
+
+;; ---- Acceptance criterion 1 — restore-epoch! linearizability ---------------
+
+(deftest restore-epoch!-serialized-against-concurrent-drain
+  (testing "A restore whose preconditions pass with no drain in flight, then
+            races a concurrent event that reads db before the restore lands,
+            must NOT splice a mid-transition write: the outcome is a
+            linearizable schedule (the restore serializes after the event and
+            its installed value is durable), not a success that was silently
+            overwritten by the event commit."
+    (let [frame-id :drainlin/restore]
+      (rf/reg-frame frame-id {:doc "restore drain-serialization frame"})
+      (rf/reg-event :set (fn [{:keys [db]} [_ v]] {:db {:n v}}))
+
+      ;; Barrier plumbing.
+      (let [precond-passed (promise)         ;; R -> main: check computed (:ok?)
+            handler-read   (promise)         ;; D -> main: handler read db
+            release-precond (CountDownLatch. 1) ;; main -> R: return from check
+            release-handler (CountDownLatch. 1) ;; main -> D: finish handler
+            barrier-armed?  (atom true)
+            handler-read-db (atom nil)]
+
+        ;; The racing event: reads db, publishes it, then blocks mid-transition
+        ;; holding the frame's :drain-lock until released, then commits n+1.
+        (rf/reg-event :blocked-inc
+          (fn [{:keys [db]} _]
+            (reset! handler-read-db db)
+            (deliver handler-read db)
+            (await-latch release-handler)
+            {:db {:n (inc (:n db))}}))
+
+        ;; Seed: record an epoch at {:n 1}; move current state to {:n 2}.
+        (rf/dispatch-sync [:set 1] {:frame frame-id})
+        (rf/dispatch-sync [:set 2] {:frame frame-id})
+        (let [eid-1 (target-epoch-id frame-id {:n 1})
+              orig-check tool-pair/check-restore-preconditions!]
+          (is (some? eid-1) "seeded an epoch whose db-after is {:n 1}")
+          (is (= {:n 2} (rf/app-db-value frame-id)) "current db is {:n 2}")
+
+          (with-redefs
+            [tool-pair/check-restore-preconditions!
+             (fn [f e]
+               (let [result (orig-check f e)]
+                 (when (compare-and-set! barrier-armed? true false)
+                   ;; Preconditions were resolved with NO drain in flight.
+                   (deliver precond-passed result)
+                   ;; Park until the concurrent drain is mid-transition.
+                   (await-latch release-precond))
+                 result))]
+
+            (let [restore-fut (future (rf/restore-epoch! frame-id eid-1))]
+              ;; 1. Restore validates preconditions (drain not yet in flight).
+              (let [pc (await-promise precond-passed)]
+                (is (= :ok (:outcome pc))
+                    "restore preconditions passed BEFORE any drain — the TOCTOU window is real"))
+              ;; 2. Start the racing drain; wait until it has read db and is
+              ;;    blocked mid-transition holding :drain-lock.
+              (let [drain-fut (future (rf/dispatch-sync [:blocked-inc] {:frame frame-id}))]
+                (is (= {:n 2} (await-promise handler-read))
+                    "the racing event read the pre-restore db {:n 2}")
+                ;; 3. Release the restore to attempt its write. On the buggy
+                ;;    code it writes {:n 1} immediately (no lock); with the fix
+                ;;    it blocks on :drain-lock.
+                (.countDown release-precond)
+                ;; Give the restore a beat to either finish (buggy) or park on
+                ;; the lock (fixed).
+                (Thread/sleep 100)
+                ;; 4. Let the blocked handler commit {:n 3} and settle.
+                (.countDown release-handler)
+
+                (let [restore-result (await-future restore-fut)
+                      drain-result   (await-future drain-fut)]
+                  (is (not= ::timeout restore-result) "restore future completed (no deadlock)")
+                  (is (not= ::timeout drain-result) "drain future completed (no deadlock)")
+
+                  (is (true? restore-result) "restore reported success")
+                  ;; The event read the pre-restore state {:n 2}, so a
+                  ;; linearizable schedule places the event BEFORE the restore;
+                  ;; therefore the restore committed LAST and its value must be
+                  ;; the durable final state. The bug produces {:n 3} — the
+                  ;; restore's write erased by the event commit despite the true
+                  ;; return — which no serial order can produce.
+                  (is (= {:n 1} (rf/app-db-value frame-id))
+                      (str "restore reported success but its installed value must be "
+                           "durable; final db was "
+                           (pr-str (rf/app-db-value frame-id))
+                           " (a mid-transition splice overwritten by the event "
+                           "commit is non-linearizable)")))))))))))
+
+;; ---- Acceptance criterion 2 — replace-frame-state! partition coherence -----
+
+(deftest replace-frame-state!-serialized-preserves-omitted-partition
+  (testing "A partial replace-frame-state! that patches ONLY app-db, racing a
+            concurrent event that changes the OMITTED runtime-db partition,
+            must install the coherent whole frame-state AND record a synthetic
+            epoch whose :frame-state-after equals the installed value — no
+            partition update lost, no synthetic anchor describing a state that
+            was never a serial frame state."
+    (let [frame-id :drainlin/replace]
+      (rf/reg-frame frame-id {:doc "replace drain-serialization frame"})
+      (rf/reg-event :seed
+        (fn [_ _]
+          {:db            {:app :v0}
+           :rf.db/runtime {:rf.runtime/marker :r0}}))
+
+      (let [precond-passed  (promise)
+            runtime-read    (promise)
+            release-precond (CountDownLatch. 1)
+            release-handler (CountDownLatch. 1)
+            barrier-armed?  (atom true)]
+
+        ;; Racing event: changes ONLY the runtime-db partition (the partition
+        ;; the tool patch omits), blocking mid-transition holding :drain-lock.
+        (rf/reg-event :bump-runtime
+          (fn [{rt :rf.db/runtime} _]
+            (deliver runtime-read rt)
+            (await-latch release-handler)
+            {:rf.db/runtime {:rf.runtime/marker :r1}}))
+
+        (rf/dispatch-sync [:seed] {:frame frame-id})
+        (is (= :r0 (:rf.runtime/marker (:rf.db/runtime (rf/frame-state-value frame-id))))
+            "seeded runtime-db marker :r0")
+
+        (let [orig-check tool-pair/check-replace-frame-state-preconditions!
+              history-before (count (rf/epoch-history frame-id))]
+          (with-redefs
+            [tool-pair/check-replace-frame-state-preconditions!
+             (fn [f fs]
+               (let [result (orig-check f fs)]
+                 (when (compare-and-set! barrier-armed? true false)
+                   (deliver precond-passed result)
+                   (await-latch release-precond))
+                 result))]
+
+            ;; The tool patch touches ONLY app-db; runtime-db is omitted and
+            ;; must be carried forward from whatever the frame holds at write
+            ;; time (which — after serialization — is the event's :r1).
+            (let [replace-fut (future (rf/replace-frame-state! frame-id {:rf.db/app {:app :patched}}))]
+              (let [pc (await-promise precond-passed)]
+                (is (= :ok (:outcome pc))
+                    "replace preconditions passed BEFORE any drain"))
+              (let [drain-fut (future (rf/dispatch-sync [:bump-runtime] {:frame frame-id}))]
+                (is (= :r0 (:rf.runtime/marker (await-promise runtime-read)))
+                    "the racing event read the pre-replace runtime-db :r0")
+                (.countDown release-precond)
+                (Thread/sleep 100)
+                (.countDown release-handler)
+
+                (let [replace-result (await-future replace-fut)
+                      drain-result   (await-future drain-fut)]
+                  (is (not= ::timeout replace-result) "replace future completed (no deadlock)")
+                  (is (not= ::timeout drain-result) "drain future completed (no deadlock)")
+                  (is (true? replace-result) "replace reported success")
+
+                  (let [installed  (rf/frame-state-value frame-id)
+                        history    (rf/epoch-history frame-id)
+                        synthetics (filter #(= :rf.epoch/db-replaced (:event-id %)) history)
+                        synthetic  (first synthetics)]
+                    ;; The event's runtime update must NOT be lost: the omitted
+                    ;; partition carries forward the serialized-before event's :r1.
+                    (is (= :r1 (:rf.runtime/marker (:rf.db/runtime installed)))
+                        (str "the concurrent event's runtime-db update must survive the "
+                             "omitted-partition carry-forward; installed runtime-db was "
+                             (pr-str (:rf.db/runtime installed))))
+                    (is (= {:app :patched} (:rf.db/app installed))
+                        "the app-db partition holds the tool patch")
+                    (is (= 1 (count synthetics))
+                        "exactly one synthetic :rf.epoch/db-replaced record was appended")
+                    ;; The synthetic undo-anchor must describe the EXACT installed
+                    ;; transition — its :frame-state-after equals the installed
+                    ;; whole frame-state. The bug records runtime :r0 here
+                    ;; (computed from a stale pre-event read) while the frame holds
+                    ;; :r1, so restoring the anchor would silently revert the
+                    ;; event's runtime update.
+                    (is (= installed (:frame-state-after synthetic))
+                        (str "the synthetic epoch's :frame-state-after must equal the "
+                             "installed whole frame-state; synthetic recorded "
+                             (pr-str (:frame-state-after synthetic))
+                             " vs installed " (pr-str installed)))
+                    ;; history-before was counted after the seed; the race adds
+                    ;; exactly the drain's :bump-runtime epoch + the one synthetic.
+                    (is (= (+ history-before 2) (count history))
+                        "history grew by exactly the drain epoch + the synthetic replace epoch")))))))))))
+
+;; ---- Acceptance criterion 3 — reentrant mid-drain refusal, no deadlock -----
+
+(deftest reentrant-tool-writes-refuse-mid-drain-without-deadlock
+  (testing "A restore/replace invoked reentrantly from the active drainer (i.e.
+            issued from inside an event handler) must return false, emit the
+            documented :rf.epoch/restore-during-drain / :rf.epoch/replace-during-drain
+            trace, create NO synthetic record, and NOT deadlock re-taking the
+            drain lock. This is the same-thread reentrancy contract the fix must
+            preserve on CLJ (and, single-threaded, CLJS)."
+    (let [frame-id :drainlin/reentrant]
+      (rf/reg-frame frame-id {:doc "reentrant refusal frame"})
+      (rf/reg-event :seed (fn [_ _] {:db {:n 0}}))
+      (rf/dispatch-sync [:seed] {:frame frame-id})
+      (let [target-eid (:epoch-id (last (rf/epoch-history frame-id)))
+            restore-r  (atom ::unset)
+            replace-r  (atom ::unset)
+            recorded   (atom [])
+            hist-before (count (rf/epoch-history frame-id))]
+        (rf/register-listener! :trace ::rec (fn [ev] (swap! recorded conj ev)))
+        ;; A handler that, mid-transition, attempts BOTH tool writes.
+        (rf/reg-event :try-writes
+          (fn [{:keys [db]} _]
+            (reset! restore-r (rf/restore-epoch! frame-id target-eid))
+            (reset! replace-r (rf/replace-frame-state! frame-id {:rf.db/app {:n 99}}))
+            {:db (assoc db :phase :done)}))
+        ;; If either reentrant call self-deadlocked on :drain-lock this
+        ;; dispatch-sync would never return (the suite's global test timeout
+        ;; would surface it); a clean settle is itself part of the assertion.
+        (rf/dispatch-sync [:try-writes] {:frame frame-id})
+
+        (is (false? @restore-r) "reentrant restore-epoch! returned false")
+        (is (false? @replace-r) "reentrant replace-frame-state! returned false")
+        (rf/unregister-listener! :trace ::rec)
+        (let [ops (set (map :operation @recorded))]
+          (is (contains? ops :rf.epoch/restore-during-drain)
+              ":rf.epoch/restore-during-drain fired")
+          (is (contains? ops :rf.epoch/replace-during-drain)
+              ":rf.epoch/replace-during-drain fired"))
+        ;; The reentrant writes created NO synthetic epoch — only the
+        ;; :try-writes cascade's own settle record should have landed.
+        (is (nil? (some (fn [r] (when (= :rf.epoch/db-replaced (:event-id r)) r))
+                        (rf/epoch-history frame-id)))
+            "no synthetic :rf.epoch/db-replaced record was created by the refused replace")
+        (is (= (inc hist-before) (count (rf/epoch-history frame-id)))
+            "exactly one record (the :try-writes settle) was appended — no tool-write record")
+        (is (= :done (:phase (rf/app-db-value frame-id)))
+            "the drain settled cleanly (no deadlock); app-db carries the handler's own commit")))))


### PR DESCRIPTION
## Summary

`restore-epoch!` and `replace-frame-state!` validated the no-drain precondition (`:in-drain?` / `:in-sync-drain?`) but then ran their coherent read → optional reconcile → physical write → success bookkeeping **outside** the frame's `:drain-lock`. A drain starting on another thread after validation and before the write could interleave between a handler's `db` read and its commit — splicing the tool write into the middle of an event transition (non-linearizable) while still returning `true` and emitting success telemetry. For a partial replace, the recorded synthetic `:frame-state-before`/`:frame-state-after` (computed from a pre-interleave read) could also diverge from the value actually installed, so restoring the undo anchor would silently revert a concurrent event's update to the omitted partition.

## The fix

Route the **whole** state-sensitive operation — not just the final container call — through the core single-drainer `:drain-lock` via `frame/call-serialized-with-drain!` (the same primitive the flows lifecycle ops use). A new `serialize-tool-write!` helper wraps both `perform-restore!` and `perform-replace!`, so the coherent read, the physical write, and the synthetic-epoch bookkeeping hold **one serial position** relative to any drain:

- Under the lock no event transition can run concurrently, so the write's own re-read matches the value installed and the synthetic epoch describes the exact transition (`fs-after == installed`).
- A tool write invoked **reentrantly from the active drainer** is refused up front (`frame/in-drain?`) with the documented during-drain op, avoiding both self-deadlock and a mid-transition splice — on CLJ and CLJS.
- The pre-lock `drain-in-flight?` precondition is retained as a diagnostic fast-fail; correctness now comes from validation-and-mutation sharing the lock window.

Applied to **both** paths. Operation bodies are unchanged — only wrapped.

Note: the tool-write listener fan-out now runs under the lock, which is **consistent** with the normal-event path — `settle!` (the router's per-event epoch commit) already fans out inside the drain window.

## Reproduce → fix evidence

A deterministic barrier test opens the TOCTOU window: the restore validates its preconditions with no drain in flight, a concurrent `dispatch-sync` then blocks its handler mid-transition holding `:drain-lock`, then the tool write is released.

- **Pre-fix (reproduced on origin/main):** the racing event reads `{:n 2}`, the restore returns `true` and writes `{:n 1}`, but the blocked handler's commit lands last → final db `{:n 3}` — a result no serial schedule can produce (matches the bead's reported symptom).
- **Post-fix:** the restore blocks on `:drain-lock` and serializes **after** the drain → linearizable `{:n 1}`.

## Stance

Pre-alpha; the single-drainer / drain-lock contract is a load-bearing linearizability invariant. The fix makes tool writes mutually exclusive with event transitions using the **existing** core primitive — ELEGANCE + CLARITY + CORRECTNESS. No new lock machinery, no core changes; touches only the epoch artefact.

## New / changed coverage

- `epoch/test/re_frame/epoch_drain_serialization_test.clj` (new) — AC1 restore linearizability, AC2 replace omitted-partition coherence (installed == synthetic `:frame-state-after`), AC3 reentrant refusal (false + during-drain trace + no synthetic record + no deadlock).
- `epoch/test/re_frame/epoch_concurrency_stress_test.clj` — Scenario 6: looped controlled-race restore linearizability, tightening AC4 (the prior stress accepted an unconstrained true/false mix).
- `epoch/test/re_frame/epoch_cljs_test.cljs` — reentrant mid-drain refusal on CLJS (AC3, no deadlock).
- AC5 (validate-then-destroy: nil write → `:rf.error/no-such-handler` false, no success trace/synthetic) preserved — the nil-liveness branches stay inside the serialized thunk; existing destroyed-frame regressions green.

## Quality gates (foreground)

- `implementation/epoch` `clojure -M:test` — **380 tests / 2371 assertions, 0 failures, 0 errors**.
- `implementation` `npm run test:cljs` — **8466 tests / 39162 assertions, 0 failures, 0 errors**.
- Pre-fix reproduction confirmed failing (`{:n 3}`) before applying the fix.

Closes rf2-3fc89f.4.
